### PR TITLE
fix: unit test error when coverage wasn't specified

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -51,7 +51,7 @@ class UnitTestData(TypedDict):
     start_time: str
     metrics: dict
     gpu_types: list[str]
-    coverage: dict
+    coverage: str
 
 
 def pytest_sessionstart(session):
@@ -83,7 +83,7 @@ def pytest_sessionstart(session):
         start_time=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         metrics={},
         gpu_types=[],
-        coverage={},
+        coverage="[n/a] run with --cov=nemo_reinforcer",
     )
 
 
@@ -122,10 +122,16 @@ def session_data(request, init_ray_cluster):
     ############################################################
     # We directly access the coverage controller from the plugin manager
     # so we can access the coverage total before the pytest session finishes.
+    cov_controller = None
     if request.config.pluginmanager.hasplugin("_cov"):
         plugin = request.config.pluginmanager.getplugin("_cov")
         if plugin.cov_controller:
             cov_controller = plugin.cov_controller
+
+    if not cov_controller:
+        # Means the user didn't run with --cov=...
+        return
+
     # We currently don't use the cov_report since we can always access the coverage.json later, but
     # in the future if we want to report the coverage more granularly as part of the session finish,
     # we can access it here.


### PR DESCRIPTION
# What does this PR do ?

@yuki-666 reported pytest failing when not using `tests/run_unit.sh` and bare `pytest`

```
ERROR tests/unit/models/generation/test_vllm_generation.py::test_vllm_generate_text - UnboundLocalError: cannot access local variable 'cov_controller' where it is not associated with a value
```

This just fixes it so it doesn't error and leaves a message to turn it on in the unit_results.json

```json
{
  "exit_status": 0,
  "git_commit": "084d6facd38f5a14c54adff11e32031be28451db",
  "start_time": "2025-03-26 09:24:12",
  "metrics": {},
  "gpu_types": [
    "NVIDIA H100 80GB HBM3"
  ],
  "coverage": "[n/a] run with --cov=nemo_reinforcer"
}
```

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA/reinforcer/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA/reinforcer/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA/reinforcer/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
