### PR TITLE
fix: correct version and use setuptools.dynamic metadata for version/readme

### DIFF
--- a/nemo_reinforcer/package_info.py
+++ b/nemo_reinforcer/package_info.py
@@ -14,9 +14,9 @@
 
 
 MAJOR = 0
-MINOR = 1
+MINOR = 2
 PATCH = 0
-PRE_RELEASE = ""
+PRE_RELEASE = "dev"
 
 # Use the following formatting: (major, minor, patch, pre-release)
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nemo-reinforcer"
-version = "0.0.1"
+dynamic = [
+    "version",
+    "readme",
+]
 description = "Nemo-Reinforcer: A Scalable and Efficient Post-Training Library for Models Ranging from 1 GPU to 1000s, and from Tiny to >100B Parameters"
-readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "Apache 2.0"}
 dependencies = [
@@ -28,6 +30,10 @@ dependencies = [
 
 [tool.setuptools]
 packages = ["nemo_reinforcer"]
+
+[tool.setuptools.dynamic]
+version = {attr = "nemo_reinforcer.__version__"}  # any module attribute compatible with ast.literal_eval
+readme = {file = "README.md", content-type = "text/markdown"}
 
 [project.optional-dependencies]
 build = [


### PR DESCRIPTION
We now only need to specify the version in package_info.py and it will be read in automatically.