### PR TITLE
ci: Add DCO placeholder check for merge queue

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -182,3 +182,10 @@ jobs:
           echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY
 
           test "$ALL_SUCCESS" = "true" || test "$CI_SKIP" = "true"
+
+  DCO_merge_group:
+    name: DCO
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "The actual DCO check happens on PRs only. This is a placeholder for the merge queue to keep the DCO check as a required status check."


### PR DESCRIPTION
# What does this PR do ?

Add DCO placeholder check for merge queue

We require the DCO status check on PRs to main. However, this does not work by default with merge queues because the DCO check happens on PRs only. And merge queues operate on temporary branches, so the merge queue will never succeed without the required DCO check.

So, we create a placeholder DCO check that does nothing but satisfy the required status check in merge queues. The real check will still happen on PRs.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA/reinforcer/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA/reinforcer/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA/reinforcer/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
