### PR TITLE
ci: Run tests only in merge queue or when labeled

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -117,6 +117,7 @@ jobs:
           pre-commit run --all-files --show-diff-on-failure --color=always
 
   sphinx-build:
+    if: ${{ needs.pre-flight.outputs.test_level != 'none' }}
     name: Sphinx build
     needs: [pre-flight]
     runs-on: ubuntu-latest
@@ -214,11 +215,13 @@ jobs:
           ALL_SUCCESS: >-
             ${{
               needs.lint-check.result == 'success' &&
-              needs.sphinx-build.result == 'success' &&
               (
                 needs.pre-flight.outputs.test_level == 'none' ||
-                (needs.pre-flight.outputs.test_level != 'none' &&
-                 needs.tests.result == 'success')
+                (
+                  needs.pre-flight.outputs.test_level != 'none' &&
+                  needs.sphinx-build.result == 'success' &&
+                  needs.tests.result == 'success'
+                )
               )
             }}
           CI_SKIP: ${{ github.event.label.name == 'Skip CICD' }}


### PR DESCRIPTION
# What does this PR do ?

Run tests only in merge queue or when labeled with:
* `CI:docs` - run doctests
* `CI:L0` - run doctests plus unit tests
* `CI:L1` - run doctests, unit tests, and functional tests
* `CI:L2` - run doctests, unit tests, functional tests, and convergence tests

Always do the lint check

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA/reinforcer/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA/reinforcer/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA/reinforcer/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
