### PR TITLE
ci: Update to include public/ folder for pages deployment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,8 @@ pages:
   needs: ["build-docs"]
   script:
     - echo "Publishing HTML to GitLab Pages"
+    - rm -rf public
+    - mkdir public
     - cp -r docs/_build/html/* public/
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH


### PR DESCRIPTION
# What does this PR do ?

Creates a public/ folder for external CI to resolve a deployment error.

# Issues

#66 

