### PR TITLE
feat: separately wakeup vllm to reduce peak memory in refitting

### DIFF
--- a/nemo_reinforcer/algorithms/grpo.py
+++ b/nemo_reinforcer/algorithms/grpo.py
@@ -277,9 +277,10 @@ def refit_policy_generation(
     """Refit the policy generation interface with the latest policy weights."""
     policy.offload_before_refit()
     ipc_handles = policy.get_weights_ipc_handles()
-    policy_generation.prepare_for_generation()
+    policy_generation.prepare_for_generation(tags=["weights"])
     policy_generation.update_weights(ipc_handles)
     policy.offload_after_refit()
+    policy_generation.prepare_for_generation(tags=["kv_cache"])
 
 
 def generate_responses(

--- a/nemo_reinforcer/models/generation/vllm.py
+++ b/nemo_reinforcer/models/generation/vllm.py
@@ -410,8 +410,12 @@ class VllmGenerationWorker:
         gc.collect()
         torch.cuda.empty_cache()
 
-    def wake_up(self):
-        self.llm.wake_up()
+    def wake_up(self, **kwargs):
+        # tags like ["weights", "kv_cache"]
+        if "tags" in kwargs:
+            self.llm.wake_up(tags=kwargs["tags"])
+        else:
+            self.llm.wake_up()
 
 
 class VllmGeneration(GenerationInterface):
@@ -580,7 +584,7 @@ class VllmGeneration(GenerationInterface):
         try:
             # Use run_all_workers_single_data for methods that don't need data
             futures = self.worker_group.run_all_workers_single_data(
-                "wake_up", respect_tied_workers=True
+                "wake_up", respect_tied_workers=True, **kwargs
             )
             # Wait for all futures to complete
             results = ray.get(futures)


### PR DESCRIPTION
During experiments, I encountered OOM (Out of Memory) issues when waking up VLLM. Additionally, I noticed that in the latest VLLM version 0.8.3, they updated the wakeup API by adding a 'tags' parameter.

# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

 As shown in the figure below, we can first load only the weights, then update the parameters, and finally load the KV cache to reduce peak memory usage during the refit_policy_generation phase. This logic has also been implemented in veRL.

![wakeup](https://private-user-images.githubusercontent.com/46737979/425212360-37033bed-67a6-4578-9355-7111aaf719ec.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDQ3MDU0MDUsIm5iZiI6MTc0NDcwNTEwNSwicGF0aCI6Ii80NjczNzk3OS80MjUyMTIzNjAtMzcwMzNiZWQtNjdhNi00NTc4LTkzNTUtNzExMWFhZjcxOWVjLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA0MTUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwNDE1VDA4MTgyNVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWNmNDJkMDc1NzU0ZWUyZjJjYzY0YWIwNjBkMzI5Mzk4Mzc1ZWFlOTQ5ODQxMDA0ODFlYTgwYzYwYTNhMmFiMDAmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.ZO546BkngMnWh8DsVOMrNGj7H_Hf2s5F33B1pDcq4TA)

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- #170 upgrade vllm


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x ] Make sure you read and followed [Contributor guidelines](/NVIDIA/reinforcer/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA/reinforcer/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA/reinforcer/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
