### PR TITLE
fix: ci uses umask

### DIFF
--- a/.github/workflows/_run_test.yml
+++ b/.github/workflows/_run_test.yml
@@ -70,21 +70,6 @@ jobs:
           run: |
             docker pull nemoci.azurecr.io/nemo_reinforcer_container:${{ github.run_id }}
 
-        # NOTE: under certain circumstances, the checkout action cannot clean up the workspace properly, so
-        # this workaround is needed to ensure that the workspace is clean by removing all files created by root.
-        #
-        # The error observed looked like this from the checkout action:
-        #      Run actions/checkout@v4
-        #      ...
-        #      Deleting the contents of '/home/azureuser/actions-runner/_work/reinforcer/reinforcer'
-        #      Error: File was unable to be removed Error: EACCES: permission denied, rmdir '/home/azureuser/actions-runner/_work/reinforcer/reinforcer/docs/_build/doctest'
-        - name: Forcefully clean up the repository
-          run: |
-            docker run --rm -u root \
-              -v /home/azureuser/actions-runner/_work/reinforcer/reinforcer:/home/azureuser/actions-runner/_work/reinforcer/reinforcer \
-              nemoci.azurecr.io/nemo_reinforcer_container:${{ github.run_id }} \
-              bash -x -c "ls -lah /home/azureuser/actions-runner/_work/reinforcer/reinforcer && shopt -s dotglob && rm -rf /home/azureuser/actions-runner/_work/reinforcer/reinforcer/*"
-
         - name: Checkout repository
           uses: actions/checkout@v4
 


### PR DESCRIPTION
# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA/reinforcer/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA/reinforcer/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA/reinforcer/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
