### PR TITLE
fix: Fix indent in dtensor policy

### DIFF
--- a/nemo_reinforcer/models/policy/dtensor_policy_worker.py
+++ b/nemo_reinforcer/models/policy/dtensor_policy_worker.py
@@ -351,11 +351,11 @@ class DTensorPolicyWorker:
                                 dtype=torch.float32,
                             )
 
-                        # Update parameters
-                        self.optimizer.step()
-                        self.scheduler.step()
+                    # Update parameters
+                    self.optimizer.step()
+                    self.scheduler.step()
 
-                    losses.append(torch.tensor(mb_losses).sum().item())
+                losses.append(torch.tensor(mb_losses).sum().item())
 
             # Compute global loss across all ranks
             with torch.no_grad():


### PR DESCRIPTION
# What does this PR do ?

Fixes an indentation bug found by @yfw. The bug surfaces when running SFT validation because the list of `losses` ends up being empty when we expect it to be populated with losses per microbatch.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA/reinforcer/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA/reinforcer/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA/reinforcer/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
