### PR TITLE
chore: better logging when insufficient resources

### DIFF
--- a/nemo_reinforcer/distributed/virtual_cluster.py
+++ b/nemo_reinforcer/distributed/virtual_cluster.py
@@ -160,7 +160,8 @@ class RayVirtualCluster:
                 self._init_placement_groups(placement_group_strategy)
                 # Reaching here means we were successful
                 break
-            except ResourceInsufficientError:
+            except ResourceInsufficientError as e:
+                print(e)
                 print(
                     f"Retrying placement group creation... {i + 1}/{max_retries}. Next retry in {2**i} seconds."
                 )


### PR DESCRIPTION
Example:
```
▶ Setting up compute cluster...
Not enough GPUs available. Requested 16 GPUs, but only 8 are available in the cluster.
Retrying placement group creation... 1/6. Next retry in 1 seconds.
Not enough GPUs available. Requested 16 GPUs, but only 8 are available in the cluster.
Retrying placement group creation... 2/6. Next retry in 2 seconds.
Not enough GPUs available. Requested 16 GPUs, but only 8 are available in the cluster.
Retrying placement group creation... 3/6. Next retry in 4 seconds.
Not enough GPUs available. Requested 16 GPUs, but only 8 are available in the cluster.
Retrying placement group creation... 4/6. Next retry in 8 seconds.
Not enough GPUs available. Requested 16 GPUs, but only 8 are available in the cluster.
Retrying placement group creation... 5/6. Next retry in 16 seconds.
```

# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA/reinforcer/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA/reinforcer/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA/reinforcer/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
