### PR TITLE
Use llm export for refit

### DIFF
--- a/nemo_rl/models/megatron/converters/__init__.py
+++ b/nemo_rl/models/megatron/converters/__init__.py
@@ -20,27 +20,10 @@ from .common import (
     get_global_layer_num,
     get_local_layer_num,
 )
-from .llama import mcore_te_to_hf_llama
-from .qwen2 import mcore_te_to_hf_qwen2
-
-
-class ModelType(Enum):
-    LLAMA = "LlamaForCausalLM"
-    QWEN2 = "Qwen2ForCausalLM"
-
-
-REGISTRY = {
-    ModelType.LLAMA: mcore_te_to_hf_llama,
-    ModelType.QWEN2: mcore_te_to_hf_qwen2,
-}
-# Allow indexing by string name
-for key in list(REGISTRY.keys()):
-    REGISTRY[key.value] = REGISTRY[key]
 
 __all__ = [
     "get_all_rank_ids_in_group",
     "get_local_layer_num",
     "get_global_layer_num",
-    "REGISTRY",
     "SafeDict",
 ]

--- a/nemo_rl/models/megatron/converters/__init__.py
+++ b/nemo_rl/models/megatron/converters/__init__.py
@@ -15,7 +15,6 @@
 from enum import Enum
 
 from .common import (
-    SafeDict,
     get_all_rank_ids_in_group,
     get_global_layer_num,
     get_local_layer_num,
@@ -25,5 +24,4 @@ __all__ = [
     "get_all_rank_ids_in_group",
     "get_local_layer_num",
     "get_global_layer_num",
-    "SafeDict",
 ]

--- a/nemo_rl/models/megatron/converters/llama.py
+++ b/nemo_rl/models/megatron/converters/llama.py
@@ -12,102 +12,61 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import einops
-import torch
-
-_GROUP_TO_RANKS_CACHE = {}
+from nemo.lightning import io
+from nemo.lightning.io.state import TransformFns
 
 
-def split_qkv_llama(gathered_mcore_qkv_layer, cfg):
-    hidden_size = cfg.hidden_size
-    head_num = cfg.num_attention_heads
-    num_query_groups = (
-        cfg.num_query_groups or head_num
-    )  # different num_query_groups for 70B
-
-    head_size = cfg.kv_channels or (
-        hidden_size // head_num
-    )  # equivalent to hf's head_dim
-    heads_per_group = head_num // num_query_groups
-    qkv_total_dim = head_num + 2 * num_query_groups
-
-    qkv_weights = gathered_mcore_qkv_layer
-    qkv_weights = qkv_weights.reshape([qkv_total_dim, head_size, hidden_size])
-
-    q_slice = torch.cat(
-        [
-            torch.arange(
-                (heads_per_group + 2) * i, (heads_per_group + 2) * i + heads_per_group
-            )
-            for i in range(num_query_groups)
-        ]
-    )
-    k_slice = torch.arange(heads_per_group, qkv_total_dim, (heads_per_group + 2))
-    v_slice = torch.arange(heads_per_group + 1, qkv_total_dim, (heads_per_group + 2))
-    ## Example of slices
-    ## 7b: num_query_groups = head_num = 32,
-    ## q_slice = [0, 3, 6, 9 , ... 90, 93]
-    ## k_slice = [1, 4, 7, 10, ... 91, 94]
-    ## v_slice = [2, 5, 8, 11, ... 92, 95]
-    ## 70b (with GQA): num_query_groups = 8, head_num = 64
-    ## q_slice = [0, 1, .. 6, 7, 10, 11, .. 16, 17, 20, 21, .. 67, 70, ... 76, 77]
-    ## k_slice = [8, 18, 28, ... 68, 78]
-    ## v_slice = [9, 19, 29, ... 69, 79]
-
-    q_name = "model.layers.{gl}.self_attn.q_proj.weight"
-    k_name = "model.layers.{gl}.self_attn.k_proj.weight"
-    v_name = "model.layers.{gl}.self_attn.v_proj.weight"
-    q = qkv_weights[q_slice].reshape(-1, hidden_size)
-    k = qkv_weights[k_slice].reshape(-1, hidden_size)
-    v = qkv_weights[v_slice].reshape(-1, hidden_size)
-
-    return {q_name: q, k_name: k, v_name: v}
-
-
-def split_fc1_gate_down_llama(gathered_mcore_fc1, cfg):
-    # gate proj and up proj are mixed right now, and we need to reshape them
-    # [ gate_tp0 ]     [ gate_tp0 ]
-    # [  up_tp0  ] --\ [ gate_tp1 ] --\ (split gate)
-    # [ gate_tp1 ] --/ [  up_tp0  ] --/ (split  up)
-    # [  up_tp1  ]     [  up_tp1  ]
-    tp = cfg.tensor_model_parallel_size
-    gathered_mcore_fc1 = einops.rearrange(
-        gathered_mcore_fc1, "(t c d) a1 ->  c (t d) a1", c=2, t=tp
-    )
-    mlp_gate_proj_weight = gathered_mcore_fc1[0]
-    mlp_up_proj_weight = gathered_mcore_fc1[1]
-    mlp_gate_proj_base_name = "model.layers.{gl}.mlp.gate_proj.weight"
-    mlp_up_proj_base_name = "model.layers.{gl}.mlp.up_proj.weight"
-    return {
-        mlp_up_proj_base_name: mlp_up_proj_weight,
-        mlp_gate_proj_base_name: mlp_gate_proj_weight,
+def get_export_mapping():
+    mapping = {
+        "decoder.layers.*.self_attention.linear_proj.weight": "model.layers.*.self_attn.o_proj.weight",
+        "decoder.layers.*.mlp.linear_fc2.weight": "model.layers.*.mlp.down_proj.weight",
+        "decoder.layers.*.self_attention.linear_qkv.layer_norm_weight": "model.layers.*.input_layernorm.weight",
+        "decoder.layers.*.mlp.linear_fc1.layer_norm_weight": "model.layers.*.post_attention_layernorm.weight",
+        "decoder.final_layernorm.weight": "model.norm.weight",
     }
+    return mapping
 
 
-mcore_te_to_hf_llama = {
-    "embedding.word_embeddings.weight": {"tp": 0, "hf": "model.embed_tokens.weight"},
-    "decoder.final_layernorm.weight": {"hf": "model.norm.weight"},
-    "output_layer.weight": {"tp": 0, "hf": "lm_head.weight"},
-    "decoder.layers.{l}.self_attention.linear_proj.weight": {
-        "tp": 1,
-        "hf": "model.layers.{gl}.self_attn.o_proj.weight",
-    },
-    "decoder.layers.{l}.self_attention.linear_qkv.weight": {
-        "tp": 0,
-        "hf_func": split_qkv_llama,
-    },
-    "decoder.layers.{l}.self_attention.linear_qkv.layer_norm_weight": {
-        "hf": "model.layers.{gl}.input_layernorm.weight"
-    },
-    "decoder.layers.{l}.mlp.linear_fc1.weight": {
-        "tp": 0,
-        "hf_func": split_fc1_gate_down_llama,
-    },
-    "decoder.layers.{l}.mlp.linear_fc1.layer_norm_weight": {
-        "hf": "model.layers.{gl}.post_attention_layernorm.weight"
-    },
-    "decoder.layers.{l}.mlp.linear_fc2.weight": {
-        "tp": 1,
-        "hf": "model.layers.{gl}.mlp.down_proj.weight",
-    },
-}
+def get_export_transforms(hf_config):
+    transforms = [
+        io.state_transform(
+            source_key="decoder.layers.*.self_attention.linear_qkv.weight",
+            target_key=(
+                "model.layers.*.self_attn.q_proj.weight",
+                "model.layers.*.self_attn.k_proj.weight",
+                "model.layers.*.self_attn.v_proj.weight",
+            ),
+            fn=TransformFns.split_qkv,
+        ),
+        io.state_transform(
+            source_key="decoder.layers.*.mlp.linear_fc1.weight",
+            target_key=(
+                "model.layers.*.mlp.gate_proj.weight",
+                "model.layers.*.mlp.up_proj.weight",
+            ),
+            fn=TransformFns.split_fc1,
+        ),
+        io.state_transform(
+            source_key="embedding.word_embeddings.weight",
+            target_key="model.embed_tokens.weight",
+            fn=TransformFns.prune_padding,
+        ),
+    ]
+
+    # TODO(yifu): don't think want to skip this for vllm export?
+    # if not hf_config.tie_word_embeddings:
+    #     transforms.append(
+    #         io.state_transform(
+    #             source_key="output_layer.weight",
+    #             target_key="lm_head.weight",
+    #             fn=TransformFns.prune_padding,
+    #         )
+    #     )
+    transforms.append(
+        io.state_transform(
+            source_key="output_layer.weight",
+            target_key="lm_head.weight",
+            fn=TransformFns.prune_padding,
+        )
+    )
+    return transforms

--- a/nemo_rl/models/megatron/converters/qwen2.py
+++ b/nemo_rl/models/megatron/converters/qwen2.py
@@ -12,79 +12,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import torch
+from nemo.lightning import io
+from nemo.lightning.io.state import TransformFns
 
-from nemo_rl.models.megatron.converters.llama import (
-    split_fc1_gate_down_llama,
-    split_qkv_llama,
-)
+def get_export_mapping():
+    mapping = {
+        "decoder.layers.*.self_attention.linear_proj.weight": "model.layers.*.self_attn.o_proj.weight",
+        "decoder.layers.*.mlp.linear_fc2.weight": "model.layers.*.mlp.down_proj.weight",
+        "decoder.layers.*.self_attention.linear_qkv.layer_norm_weight": "model.layers.*.input_layernorm.weight",
+        "decoder.layers.*.mlp.linear_fc1.layer_norm_weight": "model.layers.*.post_attention_layernorm.weight",
+        "decoder.final_layernorm.weight": "model.norm.weight",
+    }
+    return mapping
 
+def get_export_transforms():
+    transforms = [
+        io.state_transform(
+            source_key="decoder.layers.*.self_attention.linear_qkv.weight",
+            target_key=(
+                "model.layers.*.self_attn.q_proj.weight",
+                "model.layers.*.self_attn.k_proj.weight",
+                "model.layers.*.self_attn.v_proj.weight",
+            ),
+            fn=TransformFns.split_qkv,
+        ),
+        io.state_transform(
+            source_key="decoder.layers.*.self_attention.linear_qkv.bias",
+            target_key=(
+                "model.layers.*.self_attn.q_proj.bias",
+                "model.layers.*.self_attn.k_proj.bias",
+                "model.layers.*.self_attn.v_proj.bias",
+            ),
+            fn=TransformFns.split_qkv_bias,
+        ),
+        io.state_transform(
+            source_key="decoder.layers.*.mlp.linear_fc1.weight",
+            target_key=("model.layers.*.mlp.gate_proj.weight", "model.layers.*.mlp.up_proj.weight"),
+            fn=TransformFns.split_fc1,
+        ),
+        io.state_transform(
+            source_key="embedding.word_embeddings.weight",
+            target_key="model.embed_tokens.weight",
+            fn=TransformFns.prune_padding,
+        ),
+        io.state_transform(
+            source_key="output_layer.weight",
+            target_key="lm_head.weight",
+            fn=TransformFns.prune_padding,
+        ),
+    ]
 
-def split_qkv_bias_qwen(gathered_mcore_qkv_layer, cfg):
-    hidden_size = cfg.hidden_size
-    head_num = cfg.num_attention_heads
-    num_query_groups = (
-        cfg.num_query_groups or head_num
-    )  # different num_query_groups for GQA
-
-    head_size = cfg.kv_channels or (
-        hidden_size // head_num
-    )  # equivalent to hf's head_dim
-    heads_per_group = head_num // num_query_groups
-    qkv_total_dim = head_num + 2 * num_query_groups
-
-    qkv_bias = gathered_mcore_qkv_layer
-    qkv_bias = qkv_bias.reshape([qkv_total_dim, head_size])
-
-    q_slice = torch.cat(
-        [
-            torch.arange(
-                (heads_per_group + 2) * i, (heads_per_group + 2) * i + heads_per_group
-            )
-            for i in range(num_query_groups)
-        ]
-    )
-    k_slice = torch.arange(heads_per_group, qkv_total_dim, (heads_per_group + 2))
-    v_slice = torch.arange(heads_per_group + 1, qkv_total_dim, (heads_per_group + 2))
-
-    q_name = "model.layers.{gl}.self_attn.q_proj.bias"
-    k_name = "model.layers.{gl}.self_attn.k_proj.bias"
-    v_name = "model.layers.{gl}.self_attn.v_proj.bias"
-    q = qkv_bias[q_slice].reshape(-1)
-    k = qkv_bias[k_slice].reshape(-1)
-    v = qkv_bias[v_slice].reshape(-1)
-
-    return {q_name: q, k_name: k, v_name: v}
-
-
-mcore_te_to_hf_qwen2 = {
-    "embedding.word_embeddings.weight": {"tp": 0, "hf": "model.embed_tokens.weight"},
-    "decoder.final_layernorm.weight": {"hf": "model.norm.weight"},
-    "output_layer.weight": {"tp": 0, "hf": "lm_head.weight"},
-    "decoder.layers.{l}.self_attention.linear_proj.weight": {
-        "tp": 1,
-        "hf": "model.layers.{gl}.self_attn.o_proj.weight",
-    },
-    "decoder.layers.{l}.self_attention.linear_qkv.weight": {
-        "tp": 0,
-        "hf_func": split_qkv_llama,
-    },
-    "decoder.layers.{l}.self_attention.linear_qkv.bias": {
-        "tp": 0,
-        "hf_func": split_qkv_bias_qwen,
-    },
-    "decoder.layers.{l}.self_attention.linear_qkv.layer_norm_weight": {
-        "hf": "model.layers.{gl}.input_layernorm.weight"
-    },
-    "decoder.layers.{l}.mlp.linear_fc1.weight": {
-        "tp": 0,
-        "hf_func": split_fc1_gate_down_llama,
-    },
-    "decoder.layers.{l}.mlp.linear_fc1.layer_norm_weight": {
-        "hf": "model.layers.{gl}.post_attention_layernorm.weight"
-    },
-    "decoder.layers.{l}.mlp.linear_fc2.weight": {
-        "tp": 1,
-        "hf": "model.layers.{gl}.mlp.down_proj.weight",
-    },
-}
+    return transforms

--- a/nemo_rl/models/megatron/refit_utils.py
+++ b/nemo_rl/models/megatron/refit_utils.py
@@ -19,25 +19,7 @@ from megatron.core import parallel_state
 from nemo.collections.llm.gpt.model.base import GPTConfig
 
 import nemo_rl.models.megatron.converters as model_converters
-
-
-def get_param_conversion_recipe_dict(
-    name, converter_type: model_converters.ModelType, model_cfg: GPTConfig
-):
-    converter_dict = model_converters.REGISTRY[converter_type]
-
-    local_layer = model_converters.get_local_layer_num(name)
-    global_layer = (
-        model_converters.get_global_layer_num(name, model_cfg)
-        if local_layer is not None
-        else None
-    )
-    format_dict = model_converters.SafeDict(l=local_layer, gl=global_layer)
-
-    formatted_mapping = {
-        k.format_map(format_dict): rec for k, rec in converter_dict.items()
-    }
-    return formatted_mapping, format_dict
+from nemo_rl.models.megatron.converters.common import get_tp_dim
 
 
 @torch.no_grad()
@@ -49,7 +31,7 @@ def get_global_param_key_to_local_key_map(
     Args:
         model: The model to get the mapping for.
         model_cfg: The model configuration.
-        keys: The keys to get the mapping for. Tuple of (local_key, global_hf_key)
+        keys: The local_keys to get the mapping for.
 
     Returns:
         A dictionary mapping global parameter keys to a tuple of (rank, local parameter key).
@@ -63,7 +45,7 @@ def get_global_param_key_to_local_key_map(
     # The global key is computed by replacing the local layer number (after "layers.")
     # with its corresponding global layer number (if applicable).
     local_map = {}
-    for local_key, _ in keys:
+    for local_key in keys:
         if local_key not in model.state_dict():
             continue
         local_layer = model_converters.get_local_layer_num(local_key)
@@ -100,16 +82,16 @@ def get_global_param_key_to_local_key_map(
 
 
 @torch.no_grad()
-def gather_and_convert_params(
+def gather_params(
     model,
-    converter_type: model_converters.ModelType,
-    model_cfg: GPTConfig,
     param_name_to_rank_and_key,
 ):
     import time
+
     st = time.time()
     # Process each parameter (by its unique global key) one at a time.
     gathered_params = {}
+    named_modules_dict = dict(model.named_modules())
     for gk in sorted(param_name_to_rank_and_key.keys()):
         owner_pp_global_rank, owner_raw_key = param_name_to_rank_and_key[gk]
 
@@ -117,51 +99,30 @@ def gather_and_convert_params(
         if torch.distributed.get_rank() == owner_pp_global_rank:
             param = model.state_dict()[owner_raw_key]
 
-            # Use the conversion dict to get the appropriate recipe for this parameter.
-            recipe_dict, format_dict = get_param_conversion_recipe_dict(
-                owner_raw_key, converter_type, model_cfg
-            )
-            recipe = recipe_dict.get(owner_raw_key, None)
-            if recipe is None and "_extra_state" not in owner_raw_key:
-                print(
-                    f"WARNING: {owner_raw_key} has no recipe mapping for conversion",
-                    flush=True,
-                )
-                hf_mapping = {"None": None}
+            # Check if param is TP-sharded
+            tp_dim = get_tp_dim(model, owner_raw_key, named_modules_dict)
+
+            # If the parameter is TP-sharded, gather its slices on GPU.
+            if tp_dim is not None:
+                tp_group = parallel_state.get_tensor_model_parallel_group()
+                tp_world_size = torch.distributed.get_world_size(tp_group)
+                gathered_slices = [
+                    torch.empty_like(param) for _ in range(tp_world_size)
+                ]
+                torch.distributed.all_gather(gathered_slices, param, group=tp_group)
+                full_param = torch.cat(gathered_slices, dim=tp_dim).to(torch.bfloat16)
             else:
-                # If the parameter is TP-sharded, gather its slices on GPU.
-                if recipe.get("tp", None) is not None:
-                    tp_group = parallel_state.get_tensor_model_parallel_group()
-                    tp_world_size = torch.distributed.get_world_size(tp_group)
-                    gathered_slices = [
-                        torch.empty_like(param) for _ in range(tp_world_size)
-                    ]
-                    torch.distributed.all_gather(gathered_slices, param, group=tp_group)
-                    full_param = torch.cat(gathered_slices, dim=recipe["tp"]).to(
-                        torch.bfloat16
-                    )
-                else:
-                    full_param = torch.clone(param).to(torch.bfloat16)
+                full_param = torch.clone(param).to(torch.bfloat16)
 
-                # Convert the parameter using the provided function or mapping.
-                if recipe.get("hf_func", None) is not None:
-                    hf_mapping = recipe["hf_func"](full_param, model_cfg)
-                    hf_mapping = {
-                        k.format_map(format_dict): v for k, v in hf_mapping.items()
-                    }
-                elif recipe.get("hf", None) is not None:
-                    hf_mapping = {recipe["hf"].format_map(format_dict): full_param}
-                else:
-                    raise NotImplementedError(
-                        f"No conversion recipe found for {owner_raw_key}"
-                    )
+            # Use the original parameter key without conversion
+            param_mapping = {gk: full_param}
         else:
-            hf_mapping = None  # Non-owner ranks will receive the converted tensors.
+            param_mapping = None  # Non-owner ranks will receive the tensors.
 
-        # Broadcast the list of target HF parameter keys from the owner.
+        # Broadcast the list of target parameter keys from the owner.
         pp_group = parallel_state.get_pipeline_model_parallel_group()
         if torch.distributed.get_rank() == owner_pp_global_rank:
-            target_keys = [list(hf_mapping.keys())]
+            target_keys = [list(param_mapping.keys())]
         else:
             target_keys = [None]  # Placeholder to be filled by broadcast.
 
@@ -171,10 +132,10 @@ def gather_and_convert_params(
         if "None" in target_keys[0]:
             continue
 
-        # For each converted tensor (could be more than one per original parameter), broadcast it individually.
+        # For each tensor, broadcast it individually.
         for target_key in target_keys[0]:
             if torch.distributed.get_rank() == owner_pp_global_rank:
-                tensor_to_send = hf_mapping[target_key]
+                tensor_to_send = param_mapping[target_key]
             else:
                 tensor_to_send = None
             # Broadcast tensor metadata (shape and dtype) to allocate GPU buffer on receiving ranks.
@@ -197,5 +158,5 @@ def gather_and_convert_params(
 
     torch.cuda.empty_cache()
     torch.cuda.synchronize()
-    print(f'Time taken to gather and convert params: {time.time() - st}')
+    print(f"Time taken to gather params: {time.time() - st}")
     return gathered_params

--- a/nemo_rl/models/policy/megatron_policy.py
+++ b/nemo_rl/models/policy/megatron_policy.py
@@ -166,7 +166,9 @@ class MegatronPolicy(PolicyInterface, GenerationInterface):
         # Aggregate the results
         aggregated_results = {}
         aggregated_results["loss"] = results[0]["global_loss"]
-        aggregated_results["grad_norm"] = torch.tensor(results[0]["grad_norm"], device="cpu")
+        aggregated_results["grad_norm"] = torch.tensor(
+            results[0]["grad_norm"], device="cpu"
+        )
         # aggregated_results["sums"] = results[0]["sums"]
 
         # Aggregate metrics across all workers

--- a/nemo_rl/models/policy/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/megatron_policy_worker.py
@@ -90,14 +90,15 @@ from nemo_rl.models.generation.interfaces import (
     GenerationOutputSpec,
     verify_right_padding,
 )
+from nemo_rl.models.megatron.converters.common import MegatronToHFConverter
 from nemo_rl.models.megatron.common import (
     broadcast_tensor,
     forward_step_arbitrary_loss,
 )
+from nemo_rl.models.megatron.converters.common import get_tp_dim
 from nemo_rl.models.megatron.refit_utils import (
-    gather_and_convert_params,
+    gather_params,
     get_global_param_key_to_local_key_map,
-    get_param_conversion_recipe_dict,
 )
 from nemo_rl.models.policy import PolicyConfig
 from nemo_rl.models.policy.utils import get_gpu_info
@@ -249,6 +250,8 @@ class MegatronPolicyWorker:
         pt_checkpoint_exists = os.path.exists(output_path) and os.path.exists(
             os.path.join(output_path, "iter_0000000")
         )
+
+        self.converter = MegatronToHFConverter(hf_model_name)
 
         if get_rank_safe() == 0:
             if pt_checkpoint_exists:
@@ -443,14 +446,14 @@ class MegatronPolicyWorker:
         """Train the policy on a batch of data with a given loss function."""
         torch.cuda.empty_cache()
         self.model.zero_grad_buffer()
-        if hasattr(self.model, 'inference_params'):
+        if hasattr(self.model, "inference_params"):
             self.model.inference_params = None
 
         # Reset any cached attention states
         for module in self.model.modules():
-            if hasattr(module, 'reset_inference_cache'):
+            if hasattr(module, "reset_inference_cache"):
                 module.reset_inference_cache()
-            if hasattr(module, '_inference_key_value_memory'):
+            if hasattr(module, "_inference_key_value_memory"):
                 module._inference_key_value_memory = None
 
         if gbs is None:
@@ -514,7 +517,9 @@ class MegatronPolicyWorker:
                 )
                 # grad_norm and num_zeros_in_grad will be None on ranks without trainable params,
                 # so we must gather across mp ranks
-                grad_norm: float = reduce_max_stat_across_model_parallel_group(grad_norm)
+                grad_norm: float = reduce_max_stat_across_model_parallel_group(
+                    grad_norm
+                )
                 num_zeros_in_grad: float = reduce_max_stat_across_model_parallel_group(
                     num_zeros_in_grad
                 )
@@ -590,7 +595,9 @@ class MegatronPolicyWorker:
             "global_loss": loss.cpu(),
             "rank": torch.distributed.get_rank(),
             "all_mb_metrics": dict(mb_metrics),
-            "grad_norm": mb_metrics["grad_norm"][-1], # TODO @sahilj: return an average or something later
+            "grad_norm": mb_metrics["grad_norm"][
+                -1
+            ],  # TODO @sahilj: return an average or something later
         }
         return metrics
 
@@ -891,21 +898,20 @@ class MegatronPolicyWorker:
         # Collect parameter info
         param_info = []
 
+        # Dictionary of modules we can quickly look up to check if a module has TP
+        named_modules_dict = dict(self.model.named_modules())
+
         # Process each parameter in the model
         for name, param in self.model.state_dict().items():
             # Skip _extra_state entries (these are metadata, not actual weights)
             if "_extra_state" in name:
                 continue
 
-            # Use the conversion dict to get the appropriate recipe for this parameter.
-            recipe_dict, _ = get_param_conversion_recipe_dict(
-                name, self.converter_type, self.megatron_cfg.model_config
-            )
-            tp = 1
-            if name in recipe_dict:
-                recipe = recipe_dict[name]
-                if "tp" in recipe and recipe["tp"] is not None:
-                    tp = tp_world_size
+            tp_dim = get_tp_dim(self.model, name, named_modules_dict)
+            if tp_dim is not None:
+                tp = tp_world_size
+            else:
+                tp = 1
 
             # Calculate size for this parameter
             prec_to_bytes = {
@@ -915,7 +921,7 @@ class MegatronPolicyWorker:
             }
             scale = prec_to_bytes[self.dtype] / prec_to_bytes[param.dtype]
             size_in_bytes = param.element_size() * param.numel() * tp * scale
-            param_info.append(((name, recipe.get("hf", None)), size_in_bytes))
+            param_info.append((name, size_in_bytes))
 
         # Include buffers (non-parameter tensors)
         for name, buffer in self.model.named_buffers():
@@ -966,12 +972,14 @@ class MegatronPolicyWorker:
         param_name_to_rank_and_key = get_global_param_key_to_local_key_map(
             self.model, self.megatron_cfg.model_config, keys
         )
-        gathered_params = gather_and_convert_params(
+        gathered_megatron_params = gather_params(
             self.model,
-            self.converter_type,
-            self.megatron_cfg.model_config,
             param_name_to_rank_and_key,
         )
+        gathered_hf_params = self.converter.convert(
+            gathered_megatron_params, self.model.config
+        )
+
         gc.collect()
         torch.cuda.empty_cache()
 
@@ -981,14 +989,14 @@ class MegatronPolicyWorker:
 
         # Create IPC handles for each parameter
         all_handles = []
-        for key, tensor in gathered_params.items():
+        for key, tensor in gathered_hf_params.items():
             handle = reduce_tensor(tensor.detach())
             all_handles.append((key, handle))
 
         # Store references to avoid premature garbage collection
-        self._held_gather_buffer = gathered_params
+        self._held_gather_buffer = gathered_hf_params
         shapes = {}
-        for key, tensor in gathered_params.items():
+        for key, tensor in gathered_hf_params.items():
             shapes[key] = tensor.shape
 
         return {device_uuid: all_handles}
@@ -1106,7 +1114,7 @@ class MegatronPolicyWorker:
                     optimizer_to_save = self.optimizer
                 if self.scheduler is not None:
                     scheduler_to_save = self.scheduler
-            
+
             # Ensure model is in eval mode for consistent saving, unless actively training
             # This is a common practice, though NeMo's save might handle this.
             # For safety, if not in training loop, setting to eval.
@@ -1124,7 +1132,7 @@ class MegatronPolicyWorker:
             )
             print(f"Saved checkpoint to {weights_path}")
 
-            if not is_training: # Restore training state if it was changed
+            if not is_training:  # Restore training state if it was changed
                 self.model.train()
 
         except Exception as e:
@@ -1170,13 +1178,17 @@ class MegatronPolicyWorker:
                     optimizer_to_load = self.optimizer
                 else:
                     if get_rank_safe() == 0:
-                        print("Warning: Optimizer state loading requested, but self.optimizer is None. Optimizer state will not be loaded.")
+                        print(
+                            "Warning: Optimizer state loading requested, but self.optimizer is None. Optimizer state will not be loaded."
+                        )
                 if self.scheduler is not None:
                     scheduler_to_load = self.scheduler
                 else:
-                     if get_rank_safe() == 0:
-                        print("Warning: Scheduler state loading requested, but self.scheduler is None. Scheduler state will not be loaded.")
-            
+                    if get_rank_safe() == 0:
+                        print(
+                            "Warning: Scheduler state loading requested, but self.scheduler is None. Scheduler state will not be loaded."
+                        )
+
             # Model should be on device before loading. load_checkpoint expects this.
             # self.model.to('cuda') # Already handled by setup and prepare_for_training/inference
 


### PR DESCRIPTION
# What does this PR do ?

This allows us to use NeMo's llm export mapping and transforms when converting megatron params to HF params for refit. The mapping and transforms in nemo_rl/models/megatron/converters/qwen2.py is currently copied from https://github.com/NVIDIA/NeMo/blob/c882b4885349b5a750147d242338ebcbc7058ef6/nemo/collections/llm/gpt/model/qwen2.py#L316-L358

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA/NeMo-RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA/NeMo-RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA/NeMo-RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
