### PR TITLE
feat: add nsys profiling for for dtensor and vllm workers 

### DIFF
--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -25,9 +25,9 @@ sbatch \
     ray.sub
 ```
 
-```{tip}
+:::{tip}
 Depending on your Slurm cluster configuration, you may or may not need to include the `--gres=gpu:8` option in the `sbatch` command.
-```
+:::
 
 Upon successful submission, Slurm will print the `SLURM_JOB_ID`:
 ```text

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,21 +1,20 @@
-# Debugging in NeMo RL
+# Debug NeMo RL Applications
 
 This guide explains how to debug NeMo RL applications, covering two scenarios. It first outlines the procedure for debugging distributed Ray worker/actor processes using the Ray Distributed Debugger within a SLURM environment, and then details debugging the main driver script.
 
-## Debugging in the Worker/Actors (on SLURM)
+## Debug Worker/Actors on SLURM
 
-Since Ray programs can spawn many workers/actors, we need to use the Ray Distributed Debugger
-to properly jump to the breakpoint on each worker.
+Since Ray programs can spawn multiple workers and actors, using the Ray Distributed Debugger is essential to accurately jump to breakpoints on each worker.
 
 ### Prerequisites
 
-* Install [Ray Debugger VS Code/Cursor extension](https://docs.ray.io/en/latest/ray-observability/ray-distributed-debugger.html).
+* Install the [Ray Debugger VS Code/Cursor extension](https://docs.ray.io/en/latest/ray-observability/ray-distributed-debugger.html).
 * Launch the [interactive cluster](./cluster.md#interactive-launching) with `ray.sub`.
 * Launch VS Code/Cursor on the SLURM login node (where `squeue`/`sbatch` is available).
 * Add `breakpoint()` in your code under actors & tasks (i.e. classes or functions decorated with `@ray.remote`).
 * **Ensure** `RAY_DEBUG=legacy` is not set since this debugging requires the default distributed debugger.
 
-### Port-forwarding from the Head Node
+### Forward a Port from the Head Node
 
 From the SLURM login node, query the nodes used by the interactive `ray.sub` job as follows:
 
@@ -38,7 +37,7 @@ ssh -L $LOCAL_PORT:localhost:$DASHBOARD_PORT -N node-12
 ssh -L 52640:localhost:8265 -N node-12
 ```
 
-Example output from the port-forwarding with `ssh` may print logs like this, where the warning is expected:
+The example output from the port-forwarding with `ssh` may print logs like this, where the warning is expected.
 
 ```text
 Warning: Permanently added 'node-12' (ED25519) to the list of known hosts.
@@ -47,7 +46,7 @@ bind [::1]:52640: Cannot assign requested address
 
 ### Open the Ray Debugger Extension
 
-In VS Code/Cursor, open the Ray Debugger extension by clicking on the Ray icon in the activity bar or by searching for "View: Show Ray Debugger" in the command palette (Ctrl+Shift+P or Cmd+Shift+P).
+In VS Code or Cursor, open the Ray Debugger extension by clicking the Ray icon in the activity bar or searching for "View: Show Ray Debugger" in the Command Palette (Ctrl+Shift+P or Cmd+Shift+P).
 
 ![Ray Debugger Extension Step 1](./assets/ray-debug-step1.png)
 
@@ -63,90 +62,16 @@ Enter the address and port you set up in the port forwarding step. If you follow
 
 ### Add a Breakpoint and Run Your Program
 
-All breakpoints that are reached while the program is running will be visible in the Ray Debugger Panel dropdown for the cluster `127.0.0.1:52640`. Click
-`Start Debugging` to jump to one worker's breakpoint.
+The Ray Debugger Panel for cluster `127.0.0.1:52640` lists all active breakpoints. To begin debugging, select a breakpoint from the dropdown and click `Start Debugging` to jump to that worker.
 
 Note that you can jump between breakpoints across all workers with this process.
 
 ![Ray Debugger Extension Step 4](./assets/ray-debug-step4.png)
 
-## Debugging in the Driver Script
+## Debug the Driver Script
 
 By default, setting breakpoints in the driver script (outside of  `@ray.remote`) will not pause program execution when using Ray. To enable pausing at these breakpoints, set the environment variable to `RAY_DEBUG=legacy`:
 
 ```sh
 RAY_DEBUG=legacy uv run ....
 ```
-
-## Nsight Profiling (nsys)
-
-NeMo RL supports nsight profiling for Ray workers through environment variable pattern matching. This allows you to selectively profile specific worker types without modifying code or affecting performance of workers that don't need profiling.
-
-**Note**: To prevent profile files from becoming too large, consider running for a small number of steps (e.g., 10 steps) when profiling.
-
-### Prerequisites
-
-* Install NVIDIA Nsight Systems (`nsys`) on the compute nodes where workers will run. For Ubuntu installation instructions, see the [NVIDIA Nsight Systems Installation Guide](https://docs.nvidia.com/nsight-systems/InstallationGuide/index.html#:~:text=Ubuntu%20(minimal%20setup%20for%20containers)). **Note: If you're using NeMo RL containers, `nsys` is already installed.**
-* Ensure the workers you want to profile have GPU access
-
-### Environment Variable Configuration
-
-Set the `NRL_NSYS_WORKER_PATTERNS` environment variable with a comma-separated list of patterns to match worker names:
-
-```bash
-export NRL_NSYS_WORKER_PATTERNS="*policy*,*vllm*"
-```
-
-#### Pattern Format
-
-- Use shell-style wildcards (`*`, `?`, `[seq]`, `[!seq]`)
-- Patterns are matched against worker names using `fnmatch`
-- Multiple patterns are separated by commas
-- Whitespace around patterns is automatically stripped
-- Empty patterns are ignored
-
-#### Supported Workers
-
-Currently supported worker types:
-- **DTensorPolicyWorker**: Pattern matched against `"dtensor_policy_worker"`
-- **VllmGenerationWorker**: Pattern matched against `"vllm_generation_worker"`
-
-### Example Usage
-
-#### Profile Only Policy Workers
-```bash
-NRL_NSYS_WORKER_PATTERNS="*policy*" uv run examples/run_grpo_math.py grpo.max_num_steps=10
-```
-
-#### Profile Multiple Worker Types
-```bash
-NRL_NSYS_WORKER_PATTERNS="*policy*,*vllm*" uv run examples/run_grpo_math.py grpo.max_num_steps=10
-```
-
-#### Profile Workers with Exact Names
-```bash
-NRL_NSYS_WORKER_PATTERNS="dtensor_policy_worker,vllm_generation_worker" uv run examples/run_grpo_math.py grpo.max_num_steps=10
-```
-
-### Profile Output
-
-When profiling is enabled:
-
-1. **Logging**: You'll see log messages indicating which workers have profiling enabled:
-   ```
-   Nsight profiling enabled for worker 'dtensor_policy_worker' (matched pattern '*policy*')
-   ```
-
-2. **Profile Files**: Each profiled worker generates a `.nsys-rep` file with naming pattern:
-   ```
-   dtensor_policy_worker_<PID>.nsys-rep
-   vllm_generation_worker_<PID>.nsys-rep
-   ```
-
-3. **File Location**: Profile files are saved in `/tmp/ray/session*/logs/nsight/` directory on each worker node.
-
-**Note for SLURM users with `ray.sub`**: When using `ray.sub` on SLURM, set `RAY_LOG_SYNC_FREQUENCY=$NUM_SEC` (e.g., `RAY_LOG_SYNC_FREQUENCY=30`) to ensure that the nsight profile files get copied from the container's ephemeral filesystem (`/tmp/ray`) to the persistent `$SLURM_JOB_ID-logs/ray` directory.
-
-### Analyzing Profiles
-
-To analyze the generated profile files, load the `.nsys-rep` files into the NVIDIA Nsight Systems desktop application, which you can download from the [NVIDIA Nsight Systems Get Started page](https://developer.nvidia.com/nsight-systems/get-started).

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -77,3 +77,76 @@ By default, setting breakpoints in the driver script (outside of  `@ray.remote`)
 ```sh
 RAY_DEBUG=legacy uv run ....
 ```
+
+## Nsight Profiling (nsys)
+
+NeMo RL supports nsight profiling for Ray workers through environment variable pattern matching. This allows you to selectively profile specific worker types without modifying code or affecting performance of workers that don't need profiling.
+
+**Note**: To prevent profile files from becoming too large, consider running for a small number of steps (e.g., 10 steps) when profiling.
+
+### Prerequisites
+
+* Install NVIDIA Nsight Systems (`nsys`) on the compute nodes where workers will run. For Ubuntu installation instructions, see the [NVIDIA Nsight Systems Installation Guide](https://docs.nvidia.com/nsight-systems/InstallationGuide/index.html#:~:text=Ubuntu%20(minimal%20setup%20for%20containers)). **Note: If you're using NeMo RL containers, `nsys` is already installed.**
+* Ensure the workers you want to profile have GPU access
+
+### Environment Variable Configuration
+
+Set the `NRL_NSYS_WORKER_PATTERNS` environment variable with a comma-separated list of patterns to match worker names:
+
+```bash
+export NRL_NSYS_WORKER_PATTERNS="*policy*,*vllm*"
+```
+
+#### Pattern Format
+
+- Use shell-style wildcards (`*`, `?`, `[seq]`, `[!seq]`)
+- Patterns are matched against worker names using `fnmatch`
+- Multiple patterns are separated by commas
+- Whitespace around patterns is automatically stripped
+- Empty patterns are ignored
+
+#### Supported Workers
+
+Currently supported worker types:
+- **DTensorPolicyWorker**: Pattern matched against `"dtensor_policy_worker"`
+- **VllmGenerationWorker**: Pattern matched against `"vllm_generation_worker"`
+
+### Example Usage
+
+#### Profile Only Policy Workers
+```bash
+NRL_NSYS_WORKER_PATTERNS="*policy*" uv run examples/run_grpo_math.py grpo.max_num_steps=10
+```
+
+#### Profile Multiple Worker Types
+```bash
+NRL_NSYS_WORKER_PATTERNS="*policy*,*vllm*" uv run examples/run_grpo_math.py grpo.max_num_steps=10
+```
+
+#### Profile Workers with Exact Names
+```bash
+NRL_NSYS_WORKER_PATTERNS="dtensor_policy_worker,vllm_generation_worker" uv run examples/run_grpo_math.py grpo.max_num_steps=10
+```
+
+### Profile Output
+
+When profiling is enabled:
+
+1. **Logging**: You'll see log messages indicating which workers have profiling enabled:
+   ```
+   Nsight profiling enabled for worker 'dtensor_policy_worker' (matched pattern '*policy*')
+   ```
+
+2. **Profile Files**: Each profiled worker generates a `.nsys-rep` file with naming pattern:
+   ```
+   dtensor_policy_worker_<PID>.nsys-rep
+   vllm_generation_worker_<PID>.nsys-rep
+   ```
+
+3. **File Location**: Profile files are saved in `/tmp/ray/session*/logs/nsight/` directory on each worker node.
+
+**Note for SLURM users with `ray.sub`**: When using `ray.sub` on SLURM, set `RAY_LOG_SYNC_FREQUENCY=$NUM_SEC` (e.g., `RAY_LOG_SYNC_FREQUENCY=30`) to ensure that the nsight profile files get copied from the container's ephemeral filesystem (`/tmp/ray`) to the persistent `$SLURM_JOB_ID-logs/ray` directory.
+
+### Analyzing Profiles
+
+To analyze the generated profile files, load the `.nsys-rep` files into the NVIDIA Nsight Systems desktop application, which you can download from the [NVIDIA Nsight Systems Get Started page](https://developer.nvidia.com/nsight-systems/get-started).

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ docker.md
 testing.md
 documentation.md
 debugging.md
+nsys-profiling.md
 apidocs/index.rst
 ```
 

--- a/docs/nsys-profiling.md
+++ b/docs/nsys-profiling.md
@@ -1,0 +1,123 @@
+# Profile GPU with Nsys
+
+NeMo RL supports Nsight profiling for Ray workers through environment variable pattern matching. This allows you to selectively profile specific worker types without modifying code or affecting the performance of workers that don't need profiling.
+
+**Note**: To prevent profile files from becoming too large, consider limiting profiling to a smaller number of steps (e.g., 10 steps).
+
+## Prerequisites
+
+* Install NVIDIA Nsight Systems (`nsys`) on the compute nodes where workers will run. For Ubuntu installation instructions, see the [NVIDIA Nsight Systems Installation Guide](https://docs.nvidia.com/nsight-systems/InstallationGuide/index.html#:~:text=Ubuntu%20(minimal%20setup%20for%20containers)).
+
+**Note: If you're using NeMo RL containers, `nsys` is already installed.**
+* Ensure the workers you want to profile have GPU access
+
+## Configure the Environment Variables
+
+Set the `NRL_NSYS_WORKER_PATTERNS` environment variable with a comma-separated list of patterns to match worker names:
+
+```bash
+export NRL_NSYS_WORKER_PATTERNS="*policy*,*vllm*"
+```
+
+Set the `NRL_NSYS_PROFILE_STEP_RANGE` environment variable to control which training steps the profiler captures. Its
+format is colon separated integers representing `start:stop`, where `start` is inclusive and `stop` is exclusive
+(same as slice syntax `arr[start:stop]`). Note that the `start` is 1-index, so `NRL_NSYS_PROFILE_STEP_RANGE=0:10` would error.
+
+```bash
+export NRL_NSYS_PROFILE_STEP_RANGE=3:5
+```
+
+### Pattern Format
+
+- Use shell-style wildcards (`*`, `?`, `[seq]`, `[!seq]`)
+- Patterns are matched against worker names using `fnmatch`
+- Multiple patterns are separated by commas
+- Whitespace around patterns is automatically stripped
+- Empty patterns are ignored
+
+### Supported Workers
+
+The supported worker types are:
+- **DTensorPolicyWorker**: Pattern matched against `"dtensor_policy_worker"`
+- **VllmGenerationWorker**: Pattern matched against `"vllm_generation_worker"`
+
+## Example Usage
+
+### Profile Only Policy Workers
+```bash
+NRL_NSYS_PROFILE_STEP_RANGE=2:3 NRL_NSYS_WORKER_PATTERNS="*policy*" uv run examples/run_grpo_math.py grpo.max_num_steps=5
+```
+
+### Profile Multiple Worker Types
+```bash
+NRL_NSYS_PROFILE_STEP_RANGE=1:2 NRL_NSYS_WORKER_PATTERNS="*policy*,*vllm*" uv run examples/run_grpo_math.py grpo.max_num_steps=5
+```
+
+### Profile Workers with Exact Names
+```bash
+NRL_NSYS_PROFILE_STEP_RANGE=3:10 NRL_NSYS_WORKER_PATTERNS="dtensor_policy_worker,vllm_generation_worker" uv run examples/run_grpo_math.py grpo.max_num_steps=5
+```
+
+## Profile Output
+
+When profiling is enabled, it generates the following logs and files:
+
+1. **Logging**: You'll see log messages indicating which workers have profiling enabled:
+   ```
+   Nsight profiling enabled for worker 'dtensor_policy_worker' (matched pattern '*policy*')
+   ```
+
+2. **Profile Files**: Each profiled worker generates a `.nsys-rep` file with naming pattern:
+   ```
+   dtensor_policy_worker_<NRL_NSYS_PROFILE_STEP_RANGE>_<PID>.nsys-rep
+   vllm_generation_worker_<NRL_NSYS_PROFILE_STEP_RANGE>_<PID>.nsys-rep
+   ```
+
+3. **File Location**: Profile files are saved in `/tmp/ray/session*/logs/nsight/` directory on each worker node.
+
+**Note for SLURM users with `ray.sub`**: When using `ray.sub` on SLURM, set `RAY_LOG_SYNC_FREQUENCY=$NUM_SEC` (e.g., `RAY_LOG_SYNC_FREQUENCY=30`) to ensure that the nsight profile files get copied from the container's ephemeral filesystem (`/tmp/ray`) to the persistent `$SLURM_JOB_ID-logs/ray` directory.
+
+## Analyze Profile Files
+
+To analyze the generated profile files, load the `.nsys-rep` files into the NVIDIA Nsight Systems desktop application, which you can download from the [NVIDIA Nsight Systems Get Started page](https://developer.nvidia.com/nsight-systems/get-started).
+
+## How We Patched Nsight Support in Ray
+
+Ray's Nsight profiling support had a bug where it hardcoded the Python executable path instead of using the actual Python executable from the runtime environment. This caused issues when using virtual environments or custom Python installations (`py_executables`).
+
+### The Problem
+
+In Ray's `nsight.py` file, the original code was:
+
+```python
+context.py_executable = " ".join(self.nsight_cmd) + " python"
+```
+
+This hardcoded `" python"` instead of correctly preserving the intended Python executable path.
+
+### The Fix
+
+To fix this problem, we patched the following line to preserve the original `context.py_executable`:
+
+```python
+context.py_executable = " ".join(self.nsight_cmd) + f" {context.py_executable}"
+```
+
+### Where We Applied the Patch
+
+We applied this patch in two locations to cover different deployment scenarios:
+
+1. **In `ray.sub` (SLURM clusters)**: The patch is applied before Ray's control plane starts up on both head and worker nodes:
+   ```bash
+   sed -i 's/context\.py_executable = " "\.join(self\.nsight_cmd) + " python"/context.py_executable = " ".join(self.nsight_cmd) + f" {context.py_executable}"/g' /opt/nemo_rl_venv/lib64/python*/site-packages/ray/_private/runtime_env/nsight.py
+   ```
+
+2. **In `nemo_rl/__init__.py` (Local clusters)**: The patch is applied automatically when NeMo RL is imported, making it work seamlessly for local development and testing environments.
+
+### Why We Needed Both Locations
+
+- **`ray.sub`**: Required for SLURM-managed clusters where Ray processes start in containers before Python imports happen. The patch must be applied at the filesystem level before Ray's control plane initializes.
+
+- **`__init__.py`**: Required for local clusters and development environments where users start Ray clusters directly. The patch is applied when `nemo_rl` is imported, ensuring the fix is in place before any Ray processes are spawned.
+
+This dual approach ensures that Nsight profiling works correctly regardless of how the Ray cluster is deployed.

--- a/docs/nsys-profiling.md
+++ b/docs/nsys-profiling.md
@@ -69,7 +69,7 @@ To profile a Megatron worker, you should set `LD_LIBRARY_PATH` as follows, other
 
 ```bash
 LD_LIBRARY_PATH="/usr/local/cuda/targets/x86_64-linux/lib:/usr/local/cuda/lib64:/usr/local/cuda/lib:/usr/local/nvidia/lib64:/usr/local/nvidia/lib:/usr/lib/x86_64-linux-gnu" \
-NRL_NSYS_PROFILE_STEP_RANGE=3:5 NRL_NSYS_WORKER_PATTERNS="dtensor_policy_worker,vllm_generation_worker" uv run --config examples/configs/grpo_math_1B_megatron.yaml examples/run_grpo_math.py grpo.max_num_steps=5
+NRL_NSYS_PROFILE_STEP_RANGE=2:3 NRL_NSYS_WORKER_PATTERNS="dtensor_policy_worker,vllm_generation_worker" uv run --config examples/configs/grpo_math_1B_megatron.yaml examples/run_grpo_math.py grpo.max_num_steps=5
 ```
 
 ## Profile Output

--- a/docs/nsys-profiling.md
+++ b/docs/nsys-profiling.md
@@ -50,13 +50,26 @@ NRL_NSYS_PROFILE_STEP_RANGE=2:3 NRL_NSYS_WORKER_PATTERNS="*policy*" uv run examp
 ```
 
 ### Profile Multiple Worker Types
+
 ```bash
 NRL_NSYS_PROFILE_STEP_RANGE=1:2 NRL_NSYS_WORKER_PATTERNS="*policy*,*vllm*" uv run examples/run_grpo_math.py grpo.max_num_steps=5
 ```
 
 ### Profile Workers with Exact Names
+
 ```bash
 NRL_NSYS_PROFILE_STEP_RANGE=3:10 NRL_NSYS_WORKER_PATTERNS="dtensor_policy_worker,vllm_generation_worker" uv run examples/run_grpo_math.py grpo.max_num_steps=5
+```
+
+### Profile Megatron Workers
+
+:::{important}
+To profile a Megatron worker, you should set `LD_LIBRARY_PATH` as follows, otherwise you will get errors when loading `libtransformer_engine.so`.
+:::
+
+```bash
+LD_LIBRARY_PATH="/usr/local/cuda/targets/x86_64-linux/lib:/usr/local/cuda/lib64:/usr/local/cuda/lib:/usr/local/nvidia/lib64:/usr/local/nvidia/lib:/usr/lib/x86_64-linux-gnu" \
+NRL_NSYS_PROFILE_STEP_RANGE=3:5 NRL_NSYS_WORKER_PATTERNS="dtensor_policy_worker,vllm_generation_worker" uv run --config examples/configs/grpo_math_1B_megatron.yaml examples/run_grpo_math.py grpo.max_num_steps=5
 ```
 
 ## Profile Output

--- a/docs/nsys-profiling.md
+++ b/docs/nsys-profiling.md
@@ -9,6 +9,7 @@ NeMo RL supports Nsight profiling for Ray workers through environment variable p
 * Install NVIDIA Nsight Systems (`nsys`) on the compute nodes where workers will run. For Ubuntu installation instructions, see the [NVIDIA Nsight Systems Installation Guide](https://docs.nvidia.com/nsight-systems/InstallationGuide/index.html#:~:text=Ubuntu%20(minimal%20setup%20for%20containers)).
 
 **Note: If you're using NeMo RL containers, `nsys` is already installed.**
+
 * Ensure the workers you want to profile have GPU access
 
 ## Configure the Environment Variables

--- a/nemo_rl/__init__.py
+++ b/nemo_rl/__init__.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 import os
 import sys
 from pathlib import Path
@@ -45,3 +46,67 @@ from nemo_rl.package_info import (
 )
 
 os.environ["RAY_USAGE_STATS_ENABLED"] = "0"
+
+
+def _patch_nsight_file():
+    """Patch the nsight.py file to fix the context.py_executable assignment.
+
+    Until this fix is upstreamed, we will maintain this patch here. This patching
+    logic is only applied if the user intends to use nsys profiling which they enable with
+    NRL_NSYS_WORKER_PATTERNS.
+
+    If enabled, will effectively apply the following patch in an idempotent manner:
+
+    https://github.com/ray-project/ray/compare/master...terrykong:ray:tk/nsight-py-exeutable-fix?expand=1
+
+    This hack works b/c the nsight plugin is not called from the main driver process, so
+    as soon as nemo_rl is imported, the patch is applied and the source of the nsight.py module
+    is up to date before the nsight.py is actually needed.
+    """
+    # Only apply patch if user intends to use nsys profiling
+    if not os.environ.get("NRL_NSYS_WORKER_PATTERNS"):
+        return
+
+    try:
+        from ray._private.runtime_env import nsight
+
+        file_to_patch = nsight.__file__
+
+        # Read the current file content
+        with open(file_to_patch, "r") as f:
+            content = f.read()
+
+        # The line we want to replace
+        old_line = 'context.py_executable = " ".join(self.nsight_cmd) + " python"'
+        new_line = 'context.py_executable = " ".join(self.nsight_cmd) + f" {context.py_executable}"'
+
+        # Check if patch has already been applied (idempotent check)
+        if new_line in content:
+            # Already patched
+            logging.info(f"Ray nsight plugin already patched at {file_to_patch}")
+            return
+
+        # Check if the old line exists to patch
+        if old_line not in content:
+            # Nothing to patch or file structure has changed
+            logging.warning(
+                f"Expected line not found in {file_to_patch} - Ray version may have changed"
+            )
+            return
+
+        # Apply the patch
+        patched_content = content.replace(old_line, new_line)
+
+        # Write back the patched content
+        with open(file_to_patch, "w") as f:
+            f.write(patched_content)
+
+        logging.info(f"Successfully patched Ray nsight plugin at {file_to_patch}")
+
+    except (ImportError, FileNotFoundError, PermissionError) as e:
+        # Allow failures gracefully - Ray might not be installed or file might be read-only
+        pass
+
+
+# Apply the patch
+_patch_nsight_file()

--- a/nemo_rl/__init__.py
+++ b/nemo_rl/__init__.py
@@ -64,6 +64,9 @@ def _patch_nsight_file():
     is up to date before the nsight.py is actually needed.
     """
     # Only apply patch if user intends to use nsys profiling
+
+    # Don't rely on nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS since nemo_rl may not be available
+    # on the node that imports nemo_rl.
     if not os.environ.get("NRL_NSYS_WORKER_PATTERNS"):
         return
 

--- a/nemo_rl/algorithms/dpo.py
+++ b/nemo_rl/algorithms/dpo.py
@@ -36,6 +36,7 @@ from nemo_rl.models.policy.interfaces import PolicyInterface
 from nemo_rl.models.policy.lm_policy import Policy
 from nemo_rl.utils.checkpoint import CheckpointingConfig, CheckpointManager
 from nemo_rl.utils.logger import Logger, LoggerConfig
+from nemo_rl.utils.nsys import maybe_gpu_profile_step
 from nemo_rl.utils.timer import Timer
 
 
@@ -412,6 +413,7 @@ def dpo_train(
             print(
                 f"\n{'=' * 25} Step {current_step + 1}/{min(len(train_dataloader), master_config['dpo']['max_num_steps'])} {'=' * 25}"
             )
+            maybe_gpu_profile_step(policy, total_steps + 1)
             val_metrics, validation_timings = None, None
 
             with timer.time("total_step_time"):

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -59,6 +59,7 @@ from nemo_rl.utils.logger import (
     LoggerConfig,
     print_message_log_samples,
 )
+from nemo_rl.utils.nsys import maybe_gpu_profile_step
 from nemo_rl.utils.timer import Timer
 
 # ===============================================================================
@@ -502,6 +503,9 @@ def grpo_train(
         print(
             f"\n{'=' * 25} Step {step + 1}/{min(len(dataloader), master_config['grpo']['max_num_steps'])} {'=' * 25}"
         )
+        maybe_gpu_profile_step(policy, step + 1)
+        if policy != policy_generation:
+            maybe_gpu_profile_step(policy_generation, step + 1)
         val_metrics, validation_timings = None, None
 
         with timer.time("total_step_time"):

--- a/nemo_rl/algorithms/sft.py
+++ b/nemo_rl/algorithms/sft.py
@@ -39,6 +39,7 @@ from nemo_rl.models.policy.interfaces import PolicyInterface
 from nemo_rl.models.policy.lm_policy import Policy
 from nemo_rl.utils.checkpoint import CheckpointingConfig, CheckpointManager
 from nemo_rl.utils.logger import Logger, LoggerConfig
+from nemo_rl.utils.nsys import maybe_gpu_profile_step
 from nemo_rl.utils.timer import Timer
 
 
@@ -385,6 +386,7 @@ def sft_train(
             print(
                 f"\n{'=' * 25} Step {current_step + 1}/{min(len(train_dataloader), master_config['sft']['max_num_steps'])} {'=' * 25}"
             )
+            maybe_gpu_profile_step(policy, total_steps + 1)
             val_metrics, validation_timings = None, None
 
             with timer.time("total_step_time"):

--- a/nemo_rl/distributed/worker_group_utils.py
+++ b/nemo_rl/distributed/worker_group_utils.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import fnmatch
+import logging
+from copy import deepcopy
+from typing import Any
+
+from nemo_rl.utils.nsys import NRL_NSYS_PROFILE_STEP_RANGE, NRL_NSYS_WORKER_PATTERNS
+
+
+def get_nsight_config_if_pattern_matches(worker_name: str) -> dict[str, Any]:
+    """Check if worker name matches patterns in NRL_NSYS_WORKER_PATTERNS and return nsight config.
+
+    Args:
+        worker_name: Name of the worker to check against patterns
+
+    Returns:
+        Dictionary containing {"nsight": config} if pattern matches, empty dict otherwise
+    """
+    assert not (bool(NRL_NSYS_WORKER_PATTERNS) ^ bool(NRL_NSYS_PROFILE_STEP_RANGE)), (
+        "Either both NRL_NSYS_WORKER_PATTERNS and NRL_NSYS_PROFILE_STEP_RANGE must be set, or neither. See https://github.com/NVIDIA/NeMo-RL/tree/main/docs/nsys-profiling.md for more details."
+    )
+
+    patterns_env = NRL_NSYS_WORKER_PATTERNS
+    if not patterns_env:
+        return {}
+
+    # Parse CSV patterns
+    patterns = [
+        pattern.strip() for pattern in patterns_env.split(",") if pattern.strip()
+    ]
+
+    # Check if worker name matches any pattern
+    for pattern in patterns:
+        if fnmatch.fnmatch(worker_name, pattern):
+            logging.info(
+                f"Nsight profiling enabled for worker '{worker_name}' (matched pattern '{pattern}')"
+            )
+            return {
+                "nsight": {
+                    "t": "cuda,cudnn,cublas,nvtx",
+                    "o": f"'{worker_name}_{NRL_NSYS_PROFILE_STEP_RANGE}_%p'",
+                    "stop-on-exit": "true",
+                    # Capture range is required to control the scope of the profile
+                    # Profile will only start/stop when torch.cuda.profiler.start()/stop() is called
+                    "capture-range": "cudaProfilerApi",
+                    "capture-range-end": "stop",
+                }
+            }
+
+    return {}
+
+
+def recursive_merge_options(
+    default_options: dict[str, Any], extra_options: dict[str, Any]
+) -> dict[str, Any]:
+    """Recursively merge extra options into default options using OmegaConf.
+
+    Args:
+        default_options: Default options dictionary (lower precedence)
+        extra_options: Extra options provided by the caller (higher precedence)
+
+    Returns:
+        Merged options dictionary with extra_options taking precedence over default_options
+    """
+    # Convert to OmegaConf DictConfig for robust merging
+    default_conf = deepcopy(default_options)
+    extra_conf = deepcopy(extra_options)
+
+    def recursive_merge_dict(base, incoming):
+        """Recursively merge incoming dict into base dict, with incoming taking precedence."""
+        if isinstance(incoming, dict):
+            for k, v in incoming.items():
+                if k in base and isinstance(base[k], dict) and isinstance(v, dict):
+                    # Both are dicts, recurse
+                    recursive_merge_dict(base[k], v)
+                else:
+                    # Incoming takes precedence (overwrites base) - handles all cases:
+                    # - scalar replacing dict, dict replacing scalar, scalar replacing scalar
+                    base[k] = deepcopy(v)
+
+    # Handle special nsight configuration transformation (_nsight -> nsight) early
+    # so that extra_options can properly override the transformed default
+    # https://github.com/ray-project/ray/blob/3c4a5b65dd492503a707c0c6296820228147189c/python/ray/runtime_env/runtime_env.py#L345
+    if "runtime_env" in default_conf and isinstance(default_conf["runtime_env"], dict):
+        runtime_env = default_conf["runtime_env"]
+        if "_nsight" in runtime_env and "nsight" not in runtime_env:
+            runtime_env["nsight"] = runtime_env["_nsight"]
+            del runtime_env["_nsight"]
+
+    # Merge in place
+    recursive_merge_dict(base=default_conf, incoming=extra_conf)
+
+    return default_conf

--- a/nemo_rl/distributed/worker_groups.py
+++ b/nemo_rl/distributed/worker_groups.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import fnmatch
 import importlib
 import os
 from copy import deepcopy
@@ -28,6 +29,86 @@ from nemo_rl.distributed.ray_actor_environment_registry import (
 )
 from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
 from nemo_rl.utils.venvs import create_local_venv_on_each_node
+
+
+def get_nsight_config_if_pattern_matches(worker_name: str) -> dict[str, Any]:
+    """Check if worker name matches patterns in NRL_NSYS_WORKER_PATTERNS and return nsight config.
+
+    Args:
+        worker_name: Name of the worker to check against patterns
+
+    Returns:
+        Dictionary containing {"nsight": config} if pattern matches, empty dict otherwise
+    """
+    import logging
+
+    patterns_env = os.environ.get("NRL_NSYS_WORKER_PATTERNS")
+    if not patterns_env:
+        return {}
+
+    # Parse CSV patterns
+    patterns = [
+        pattern.strip() for pattern in patterns_env.split(",") if pattern.strip()
+    ]
+
+    # Check if worker name matches any pattern
+    for pattern in patterns:
+        if fnmatch.fnmatch(worker_name, pattern):
+            logging.info(
+                f"Nsight profiling enabled for worker '{worker_name}' (matched pattern '{pattern}')"
+            )
+            return {
+                "nsight": {
+                    "t": "cuda,cudnn,cublas,nvtx",
+                    "o": f"'{worker_name}_%p'",
+                    "stop-on-exit": "true",
+                }
+            }
+
+    return {}
+
+
+def recursive_merge_options(
+    default_options: dict[str, Any], extra_options: dict[str, Any]
+) -> dict[str, Any]:
+    """Recursively merge extra options into default options using OmegaConf.
+
+    Args:
+        default_options: Default options dictionary (lower precedence)
+        extra_options: Extra options provided by the caller (higher precedence)
+
+    Returns:
+        Merged options dictionary with extra_options taking precedence over default_options
+    """
+    # Convert to OmegaConf DictConfig for robust merging
+    default_conf = deepcopy(default_options)
+    extra_conf = deepcopy(extra_options)
+
+    def recursive_merge_dict(base, incoming):
+        """Recursively merge incoming dict into base dict, with incoming taking precedence."""
+        if isinstance(incoming, dict):
+            for k, v in incoming.items():
+                if k in base and isinstance(base[k], dict) and isinstance(v, dict):
+                    # Both are dicts, recurse
+                    recursive_merge_dict(base[k], v)
+                else:
+                    # Incoming takes precedence (overwrites base) - handles all cases:
+                    # - scalar replacing dict, dict replacing scalar, scalar replacing scalar
+                    base[k] = deepcopy(v)
+
+    # Handle special nsight configuration transformation (_nsight -> nsight) early
+    # so that extra_options can properly override the transformed default
+    # https://github.com/ray-project/ray/blob/3c4a5b65dd492503a707c0c6296820228147189c/python/ray/runtime_env/runtime_env.py#L345
+    if "runtime_env" in default_conf and isinstance(default_conf["runtime_env"], dict):
+        runtime_env = default_conf["runtime_env"]
+        if "_nsight" in runtime_env and "nsight" not in runtime_env:
+            runtime_env["nsight"] = runtime_env["_nsight"]
+            del runtime_env["_nsight"]
+
+    # Merge in place
+    recursive_merge_dict(base=default_conf, incoming=extra_conf)
+
+    return default_conf
 
 
 @dataclass
@@ -142,7 +223,8 @@ class RayWorkerBuilder:
             module = importlib.import_module(module_name)
             worker_class = getattr(module, class_name)
             worker_kwargs = dict(self.init_kwargs)
-            options: dict[str, Any] = deepcopy(extra_options)
+            default_options = getattr(worker_class, "_default_options", {})
+            options = recursive_merge_options(default_options, extra_options)
 
             # Use the worker's configuration interface if available
             if hasattr(worker_class, "configure_worker"):

--- a/nemo_rl/distributed/worker_groups.py
+++ b/nemo_rl/distributed/worker_groups.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import fnmatch
 import importlib
 import os
 from copy import deepcopy
@@ -29,86 +28,7 @@ from nemo_rl.distributed.ray_actor_environment_registry import (
 )
 from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
 from nemo_rl.utils.venvs import create_local_venv_on_each_node
-
-
-def get_nsight_config_if_pattern_matches(worker_name: str) -> dict[str, Any]:
-    """Check if worker name matches patterns in NRL_NSYS_WORKER_PATTERNS and return nsight config.
-
-    Args:
-        worker_name: Name of the worker to check against patterns
-
-    Returns:
-        Dictionary containing {"nsight": config} if pattern matches, empty dict otherwise
-    """
-    import logging
-
-    patterns_env = os.environ.get("NRL_NSYS_WORKER_PATTERNS")
-    if not patterns_env:
-        return {}
-
-    # Parse CSV patterns
-    patterns = [
-        pattern.strip() for pattern in patterns_env.split(",") if pattern.strip()
-    ]
-
-    # Check if worker name matches any pattern
-    for pattern in patterns:
-        if fnmatch.fnmatch(worker_name, pattern):
-            logging.info(
-                f"Nsight profiling enabled for worker '{worker_name}' (matched pattern '{pattern}')"
-            )
-            return {
-                "nsight": {
-                    "t": "cuda,cudnn,cublas,nvtx",
-                    "o": f"'{worker_name}_%p'",
-                    "stop-on-exit": "true",
-                }
-            }
-
-    return {}
-
-
-def recursive_merge_options(
-    default_options: dict[str, Any], extra_options: dict[str, Any]
-) -> dict[str, Any]:
-    """Recursively merge extra options into default options using OmegaConf.
-
-    Args:
-        default_options: Default options dictionary (lower precedence)
-        extra_options: Extra options provided by the caller (higher precedence)
-
-    Returns:
-        Merged options dictionary with extra_options taking precedence over default_options
-    """
-    # Convert to OmegaConf DictConfig for robust merging
-    default_conf = deepcopy(default_options)
-    extra_conf = deepcopy(extra_options)
-
-    def recursive_merge_dict(base, incoming):
-        """Recursively merge incoming dict into base dict, with incoming taking precedence."""
-        if isinstance(incoming, dict):
-            for k, v in incoming.items():
-                if k in base and isinstance(base[k], dict) and isinstance(v, dict):
-                    # Both are dicts, recurse
-                    recursive_merge_dict(base[k], v)
-                else:
-                    # Incoming takes precedence (overwrites base) - handles all cases:
-                    # - scalar replacing dict, dict replacing scalar, scalar replacing scalar
-                    base[k] = deepcopy(v)
-
-    # Handle special nsight configuration transformation (_nsight -> nsight) early
-    # so that extra_options can properly override the transformed default
-    # https://github.com/ray-project/ray/blob/3c4a5b65dd492503a707c0c6296820228147189c/python/ray/runtime_env/runtime_env.py#L345
-    if "runtime_env" in default_conf and isinstance(default_conf["runtime_env"], dict):
-        runtime_env = default_conf["runtime_env"]
-        if "_nsight" in runtime_env and "nsight" not in runtime_env:
-            runtime_env["nsight"] = runtime_env["_nsight"]
-            del runtime_env["_nsight"]
-
-    # Merge in place
-    recursive_merge_dict(base=default_conf, incoming=extra_conf)
-
-    return default_conf
+from nemo_rl.distributed.worker_group_utils import recursive_merge_options
 
 
 @dataclass

--- a/nemo_rl/distributed/worker_groups.py
+++ b/nemo_rl/distributed/worker_groups.py
@@ -27,8 +27,8 @@ from nemo_rl.distributed.ray_actor_environment_registry import (
     get_actor_python_env,
 )
 from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
-from nemo_rl.utils.venvs import create_local_venv_on_each_node
 from nemo_rl.distributed.worker_group_utils import recursive_merge_options
+from nemo_rl.utils.venvs import create_local_venv_on_each_node
 
 
 @dataclass

--- a/nemo_rl/models/generation/vllm.py
+++ b/nemo_rl/models/generation/vllm.py
@@ -42,7 +42,11 @@ from nemo_rl.distributed.named_sharding import NamedSharding
 from nemo_rl.distributed.virtual_cluster import (
     RayVirtualCluster,
 )
-from nemo_rl.distributed.worker_groups import RayWorkerBuilder, RayWorkerGroup
+from nemo_rl.distributed.worker_groups import (
+    RayWorkerBuilder,
+    RayWorkerGroup,
+    get_nsight_config_if_pattern_matches,
+)
 from nemo_rl.models.generation.interfaces import (
     GenerationConfig,
     GenerationDatumSpec,
@@ -70,7 +74,9 @@ class VllmConfig(GenerationConfig):
     vllm_kwargs: NotRequired[dict[str, Any]]
 
 
-@ray.remote
+@ray.remote(
+    runtime_env={**get_nsight_config_if_pattern_matches("vllm_generation_worker")}
+)
 class VllmGenerationWorker:
     def __repr__(self) -> str:
         """Customizes the actor's prefix in the Ray logs.

--- a/nemo_rl/models/generation/vllm.py
+++ b/nemo_rl/models/generation/vllm.py
@@ -42,10 +42,10 @@ from nemo_rl.distributed.named_sharding import NamedSharding
 from nemo_rl.distributed.virtual_cluster import (
     RayVirtualCluster,
 )
+from nemo_rl.distributed.worker_group_utils import get_nsight_config_if_pattern_matches
 from nemo_rl.distributed.worker_groups import (
     RayWorkerBuilder,
     RayWorkerGroup,
-    get_nsight_config_if_pattern_matches,
 )
 from nemo_rl.models.generation.interfaces import (
     GenerationConfig,
@@ -1050,6 +1050,14 @@ class VllmGenerationWorker:
 
         await self.llm.wake_up(**wake_up_args)
 
+    def start_gpu_profiling(self) -> None:
+        """Start GPU profiling."""
+        torch.cuda.profiler.start()
+
+    def stop_gpu_profiling(self) -> None:
+        """Stop GPU profiling."""
+        torch.cuda.profiler.stop()
+
 
 class VllmGeneration(GenerationInterface):
     def __init__(
@@ -1538,6 +1546,16 @@ class VllmGeneration(GenerationInterface):
 
         # this function should co-work with lm_policy, so we should wait for all futures to complete outside
         return futures
+
+    def start_gpu_profiling(self) -> None:
+        """Start GPU profiling."""
+        futures = self.worker_group.run_all_workers_single_data("start_gpu_profiling")
+        ray.get(futures)
+
+    def stop_gpu_profiling(self) -> None:
+        """Stop GPU profiling."""
+        futures = self.worker_group.run_all_workers_single_data("stop_gpu_profiling")
+        ray.get(futures)
 
     def __del__(self) -> None:
         """Shuts down the worker groups when the object is deleted or is garbage collected.

--- a/nemo_rl/models/policy/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker.py
@@ -36,7 +36,7 @@ from transformers.models.gemma3.modeling_gemma3 import Gemma3ForCausalLM
 
 from nemo_rl.algorithms.interfaces import LossFunction, LossType
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
-from nemo_rl.distributed.worker_groups import get_nsight_config_if_pattern_matches
+from nemo_rl.distributed.worker_group_utils import get_nsight_config_if_pattern_matches
 from nemo_rl.models.dtensor.parallelize import (
     _parallelize_model,
     clip_grad_by_total_norm_,
@@ -1071,3 +1071,11 @@ class DTensorPolicyWorker:
 
     def shutdown(self) -> None:
         """Shutdown the policy."""
+
+    def start_gpu_profiling(self) -> None:
+        """Start GPU profiling."""
+        torch.cuda.profiler.start()
+
+    def stop_gpu_profiling(self) -> None:
+        """Stop GPU profiling."""
+        torch.cuda.profiler.stop()

--- a/nemo_rl/models/policy/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker.py
@@ -36,6 +36,7 @@ from transformers.models.gemma3.modeling_gemma3 import Gemma3ForCausalLM
 
 from nemo_rl.algorithms.interfaces import LossFunction, LossType
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.distributed.worker_groups import get_nsight_config_if_pattern_matches
 from nemo_rl.models.dtensor.parallelize import (
     _parallelize_model,
     clip_grad_by_total_norm_,
@@ -109,7 +110,10 @@ def get_cpu_state_dict(
 
 
 @ray.remote(
-    runtime_env={"env_vars": {"PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"}}
+    runtime_env={
+        "env_vars": {"PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"},
+        **get_nsight_config_if_pattern_matches("dtensor_policy_worker"),
+    }
 )
 class DTensorPolicyWorker:
     def __repr__(self) -> str:

--- a/nemo_rl/models/policy/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker.py
@@ -111,7 +111,8 @@ def get_cpu_state_dict(
 
 @ray.remote(
     runtime_env={
-        "env_vars": {"PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"},
+        # TODO: This option causes a crash on Ampere. It's okay to enable on Hopper.
+        # "env_vars": {"PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"},
         **get_nsight_config_if_pattern_matches("dtensor_policy_worker"),
     }
 )

--- a/nemo_rl/models/policy/fsdp1_policy_worker.py
+++ b/nemo_rl/models/policy/fsdp1_policy_worker.py
@@ -1058,4 +1058,12 @@ class FSDP1PolicyWorker:
 
     def shutdown(self) -> None:
         """Shutdown the policy."""
-        #
+        pass
+
+    def start_gpu_profiling(self) -> None:
+        """Start GPU profiling."""
+        torch.cuda.profiler.start()
+
+    def stop_gpu_profiling(self) -> None:
+        """Stop GPU profiling."""
+        torch.cuda.profiler.stop()

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -542,3 +542,13 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
         user calls worker_group.shutdown().
         """
         self.worker_group.shutdown()
+
+    def start_gpu_profiling(self) -> None:
+        """Start GPU profiling."""
+        futures = self.worker_group.run_all_workers_single_data("start_gpu_profiling")
+        ray.get(futures)
+
+    def stop_gpu_profiling(self) -> None:
+        """Stop GPU profiling."""
+        futures = self.worker_group.run_all_workers_single_data("stop_gpu_profiling")
+        ray.get(futures)

--- a/nemo_rl/models/policy/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/megatron_policy_worker.py
@@ -89,6 +89,7 @@ from nemo_rl.algorithms.interfaces import LossFunction, LossType
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.model_utils import from_parallel_logits_to_logprobs
 from nemo_rl.distributed.named_sharding import NamedSharding
+from nemo_rl.distributed.worker_group_utils import get_nsight_config_if_pattern_matches
 from nemo_rl.models.generation.interfaces import (
     GenerationDatumSpec,
     GenerationOutputSpec,
@@ -108,7 +109,6 @@ from nemo_rl.models.megatron.refit_utils import (
 )
 from nemo_rl.models.policy import PolicyConfig
 from nemo_rl.models.policy.utils import get_gpu_info
-from nemo_rl.distributed.worker_group_utils import get_nsight_config_if_pattern_matches
 
 
 def setup_megatron_model(

--- a/nemo_rl/models/policy/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/megatron_policy_worker.py
@@ -108,6 +108,7 @@ from nemo_rl.models.megatron.refit_utils import (
 )
 from nemo_rl.models.policy import PolicyConfig
 from nemo_rl.models.policy.utils import get_gpu_info
+from nemo_rl.distributed.worker_group_utils import get_nsight_config_if_pattern_matches
 
 
 def setup_megatron_model(
@@ -315,7 +316,11 @@ def destroy_parallel_state():
         pass
 
 
-@ray.remote
+@ray.remote(
+    runtime_env={
+        **get_nsight_config_if_pattern_matches("megatron_policy_worker"),
+    }
+)
 class MegatronPolicyWorker:
     def __repr__(self):
         """Customizes the actor's prefix in the Ray logs.

--- a/nemo_rl/models/policy/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/megatron_policy_worker.py
@@ -1529,5 +1529,12 @@ class MegatronPolicyWorker:
 
     def shutdown(self):
         """Shutdown the policy."""
-        #
         pass
+
+    def start_gpu_profiling(self) -> None:
+        """Start GPU profiling."""
+        torch.cuda.profiler.start()
+
+    def stop_gpu_profiling(self) -> None:
+        """Stop GPU profiling."""
+        torch.cuda.profiler.stop()

--- a/nemo_rl/utils/nsys.py
+++ b/nemo_rl/utils/nsys.py
@@ -1,0 +1,65 @@
+import atexit
+import os
+from typing import Protocol
+
+import rich
+
+NRL_NSYS_WORKER_PATTERNS = os.environ.get("NRL_NSYS_WORKER_PATTERNS", "")
+NRL_NSYS_PROFILE_STEP_RANGE = os.environ.get("NRL_NSYS_PROFILE_STEP_RANGE", "")
+
+
+class ProfilablePolicy(Protocol):
+    def start_gpu_profiling(self) -> None: ...
+
+    def stop_gpu_profiling(self) -> None: ...
+
+
+def maybe_gpu_profile_step(policy: ProfilablePolicy, step: int):
+    assert not (bool(NRL_NSYS_WORKER_PATTERNS) ^ bool(NRL_NSYS_PROFILE_STEP_RANGE)), (
+        "Either both NRL_NSYS_WORKER_PATTERNS and NRL_NSYS_PROFILE_STEP_RANGE must be set, or neither. See https://github.com/NVIDIA/NeMo-RL/tree/main/docs/nsys-profiling.md for more details."
+    )
+
+    if not NRL_NSYS_WORKER_PATTERNS:
+        return
+
+    NSYS_START_STEP, NSYS_STOP_STEP = NRL_NSYS_PROFILE_STEP_RANGE.split(":")
+    try:
+        NSYS_START_STEP = int(NSYS_START_STEP)
+        NSYS_STOP_STEP = int(NSYS_STOP_STEP)
+    except ValueError as e:
+        raise ValueError(
+            f"Error parsing NRL_NSYS_PROFILE_STEP_RANGE: {str(e)}. "
+            "Please ensure the format is 'start:stop' where both values are integers. "
+            "See https://github.com/NVIDIA/NeMo-RL/tree/main/docs/nsys-profiling.md for more details."
+        ) from e
+
+    assert NSYS_START_STEP < NSYS_STOP_STEP, (
+        f"{NRL_NSYS_PROFILE_STEP_RANGE=} must be a non-empty range"
+    )
+    assert NSYS_START_STEP >= 1, (
+        f"The start step in {NRL_NSYS_PROFILE_STEP_RANGE=} must be >= 1"
+    )
+
+    # Use slice syntax of left inclusive and right exclusive
+    if NSYS_START_STEP <= step < NSYS_STOP_STEP:
+        if not getattr(policy, "__NRL_PROFILE_STARTED", False):
+            rich.print(
+                f"[bold red]Starting GPU profiling for {policy} for step {step}[/bold red]"
+            )
+            policy.start_gpu_profiling()
+            policy.__NRL_PROFILE_STARTED = True
+
+            def stop_profiler_on_exit():
+                rich.print(
+                    f"[bold red]Stopping GPU profiling on exit for {policy} for step {step}[/bold red]"
+                )
+                policy.stop_gpu_profiling()
+
+            atexit.register(stop_profiler_on_exit)
+    else:
+        if getattr(policy, "__NRL_PROFILE_STARTED", False):
+            rich.print(
+                f"[bold red]Stopping GPU profiling for {policy} for step {step}[/bold red]"
+            )
+            policy.stop_gpu_profiling()
+            policy.__NRL_PROFILE_STARTED = False

--- a/nemo_rl/utils/nsys.py
+++ b/nemo_rl/utils/nsys.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import atexit
 import os
 from typing import Protocol

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "tiktoken",
     "blobfile",
     "debugpy",
+    "nvtx",
     "matplotlib",
     "plotly"
 ]

--- a/ray.sub
+++ b/ray.sub
@@ -53,6 +53,9 @@ DASHBOARD_AGENT_LISTEN_PORT=${DASHBOARD_AGENT_LISTEN_PORT:-52365}
 MIN_WORKER_PORT=${MIN_WORKER_PORT:-54001}
 MAX_WORKER_PORT=${MAX_WORKER_PORT:-54257}
 ########################################################
+# Number seconds to sync logs from /tmp/ray/session_*/logs to $LOG_DIR/ray/
+RAY_LOG_SYNC_FREQUENCY=${RAY_LOG_SYNC_FREQUENCY:-}
+########################################################
 
 # Unset UV_CACHE_DIR to avoid local cache directory interferring with the container cache
 unset UV_CACHE_DIR
@@ -106,7 +109,7 @@ head_node_ip=${ip_addresses_array[0]}
 ip_head=$head_node_ip:$PORT
 
 # First we start the head of the ray cluster on one of the physical nodes
-# Give the head node actual resources to make it schedulable
+# Set GPU/CPU resources to 0 to avoid scheduling on the head node
 
 head_cmd=$(cat <<EOF
 # Touch a file to indicate that the head node has started
@@ -136,10 +139,42 @@ monitor-sidecar() {
 }
 monitor-sidecar &
 
+# Background process to sync ray logs every $RAY_LOG_SYNC_FREQUENCY seconds
+log-sync-sidecar() {
+  set +x
+  if [[ -z "$RAY_LOG_SYNC_FREQUENCY" ]]; then
+    echo "RAY_LOG_SYNC_FREQUENCY is not set, skipping log sync sidecar"
+    return
+  fi
+  mkdir -p $LOG_DIR/ray
+  while true; do
+    sleep $RAY_LOG_SYNC_FREQUENCY
+    if ls /tmp/ray/session_[0-9]* > /dev/null 2>&1; then
+      for session_dir in /tmp/ray/session_[0-9]*/; do
+        if [[ -d "\$session_dir/logs" ]]; then
+          session_name=\$(basename "\$session_dir")
+          mkdir -p "$LOG_DIR/ray/\$session_name"
+          if command -v rsync > /dev/null 2>&1; then
+            rsync -ahP "\$session_dir/logs/" "$LOG_DIR/ray/\$session_name/logs/" 2>/dev/null || true
+          else
+            cp -r "\$session_dir/logs" "$LOG_DIR/ray/\$session_name/"
+          fi
+        fi
+      done
+    fi
+    if [[ -f "$LOG_DIR/ENDED" ]]; then
+      echo "Log sync sidecar terminating..."
+      break
+    fi
+  done
+}
+log-sync-sidecar &
+
 cat <<EOFINNER | tee /launch-head.sh
 ray start --head \
     --disable-usage-stats \
-    --resources="{\"worker_units\": $GPUS_PER_NODE, \"slurm_managed_ray_cluster\": 1}" \
+    --num-cpus=0 \
+    --num-gpus=0 \
     --node-ip-address="$head_node_ip" \
     --port=${PORT} \
     --ray-client-server-port=${RAY_CLIENT_SERVER_PORT} \
@@ -168,15 +203,14 @@ touch $LOG_DIR/ENDED
 exit 1
 EOF
 )
-srun $COMMON_SRUN_ARGS --container-name=ray-head --nodes=1 --ntasks=1 --cpus-per-task=$CPUS_PER_WORKER -w "$head_node" -o $LOG_DIR/ray-head.log bash -x -c "$head_cmd" &
+srun $COMMON_SRUN_ARGS --container-name=ray-head --nodes=1 --ntasks=1 -w "$head_node" -o $LOG_DIR/ray-head.log bash -x -c "$head_cmd" &
 
 NUM_ACTORS=$((GPUS_PER_NODE * SLURM_JOB_NUM_NODES))
 
 # Start Ray worker nodes
-# We want 1 Ray worker node per physical node (excluding the head node)
+# We want 1 Ray worker node per physical node
 # Worker nodes are started with ray start but without the --head flag
-# Start from node 1 since node 0 is running the head
-for ((i = 1; i < SLURM_JOB_NUM_NODES; i++)); do
+for ((i = 0; i < SLURM_JOB_NUM_NODES; i++)); do
   node_i=${nodes_array[$i]}
     
   worker_cmd=$(cat <<EOF
@@ -231,7 +265,10 @@ touch $LOG_DIR/ENDED
 exit 1
 EOF
 )
-  srun $COMMON_SRUN_ARGS --container-name=ray-worker-$i --exact --nodes=1 --ntasks=1 --cpus-per-task=$CPUS_PER_WORKER -w "$node_i" -o $LOG_DIR/ray-worker-$i.log bash -x -c "$worker_cmd" &
+  if [[ $i -eq 0 ]]; then
+    OVERLAP_HEAD_AND_WORKER_ARG="--overlap"
+  fi
+  srun $COMMON_SRUN_ARGS ${OVERLAP_HEAD_AND_WORKER_ARG:-} --container-name=ray-worker-$i --exact --nodes=1 --ntasks=1 --cpus-per-task=$CPUS_PER_WORKER -w "$node_i" -o $LOG_DIR/ray-worker-$i.log bash -x -c "$worker_cmd" &
   sleep 3
 done
 
@@ -274,30 +311,21 @@ echo "All workers connected!"
 # This driver process is responsible for launching a job on the Ray cluster
 CONTAINER_CWD=$(scontrol show job $SLURM_JOB_ID --json | jq -r '.jobs[].current_working_directory')
 if [[ -n "$COMMAND" ]]; then
-  srun --no-container-mount-home --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "$head_node" -o $LOG_DIR/ray-driver.log bash -c "$COMMAND"
+  srun --no-container-mount-home --gpus=0 --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "$head_node" -o $LOG_DIR/ray-driver.log bash -c "$COMMAND"
 else
   echo "[INFO]: Ray Cluster is idled, run this on the slurm head node to get a shell to the head node:"
   cat <<EOF >$SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh
-# No args launches on the head node (node 0)
-# Args 1-N launch on worker nodes (nodes 1 through N-1)
+# No args launches on the head node
 WORKER_NUM=\${1:-}
 if [[ -z "\$WORKER_NUM" ]]; then
   # Empty means we are on the head node
-  srun --no-container-mount-home --gres=gpu:8 -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "$head_node" --jobid $SLURM_JOB_ID --pty bash
+  srun --no-container-mount-home --gpus=0 -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "$head_node" --jobid $SLURM_JOB_ID --pty bash
 else
-  # Worker numbers 1 through N-1 correspond to ray-worker-1 through ray-worker-(N-1)
-  # and use nodes_array[1] through nodes_array[N-1]
-  if [[ \$WORKER_NUM -lt 1 || \$WORKER_NUM -ge $SLURM_JOB_NUM_NODES ]]; then
-    echo "Error: WORKER_NUM must be between 1 and $((SLURM_JOB_NUM_NODES-1))"
-    exit 1
-  fi
   nodes_array=($nodes)
   srun --no-container-mount-home --gres=gpu:8 -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-worker-\$WORKER_NUM --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "\${nodes_array[\$WORKER_NUM]}" --jobid $SLURM_JOB_ID --pty bash
 fi
 EOF
   chmod +x $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh
-  echo "     bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh    # to attach to head node (i.e., 'worker 0')"
-  echo "     bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh 1  # to attach to worker 1"
-  echo "     bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh 2  # to attach to worker 2, etc."
+  echo "     bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh"
   sleep infinity
 fi

--- a/ray.sub
+++ b/ray.sub
@@ -109,7 +109,7 @@ head_node_ip=${ip_addresses_array[0]}
 ip_head=$head_node_ip:$PORT
 
 # First we start the head of the ray cluster on one of the physical nodes
-# Set GPU/CPU resources to 0 to avoid scheduling on the head node
+# Give the head node actual resources to make it schedulable
 
 head_cmd=$(cat <<EOF
 # Touch a file to indicate that the head node has started
@@ -170,11 +170,13 @@ log-sync-sidecar() {
 }
 log-sync-sidecar &
 
+# Patch nsight.py before starting Ray head
+sed -i 's/context\.py_executable = " "\.join(self\.nsight_cmd) + " python"/context.py_executable = " ".join(self.nsight_cmd) + f" {context.py_executable}"/g' /opt/nemo_rl_venv/lib64/python*/site-packages/ray/_private/runtime_env/nsight.py
+
 cat <<EOFINNER | tee /launch-head.sh
 ray start --head \
     --disable-usage-stats \
-    --num-cpus=0 \
-    --num-gpus=0 \
+    --resources="{\"worker_units\": $GPUS_PER_NODE, \"slurm_managed_ray_cluster\": 1}" \
     --node-ip-address="$head_node_ip" \
     --port=${PORT} \
     --ray-client-server-port=${RAY_CLIENT_SERVER_PORT} \
@@ -203,14 +205,15 @@ touch $LOG_DIR/ENDED
 exit 1
 EOF
 )
-srun $COMMON_SRUN_ARGS --container-name=ray-head --nodes=1 --ntasks=1 -w "$head_node" -o $LOG_DIR/ray-head.log bash -x -c "$head_cmd" &
+srun $COMMON_SRUN_ARGS --container-name=ray-head --nodes=1 --ntasks=1 --cpus-per-task=$CPUS_PER_WORKER -w "$head_node" -o $LOG_DIR/ray-head.log bash -x -c "$head_cmd" &
 
 NUM_ACTORS=$((GPUS_PER_NODE * SLURM_JOB_NUM_NODES))
 
 # Start Ray worker nodes
-# We want 1 Ray worker node per physical node
+# We want 1 Ray worker node per physical node (excluding the head node)
 # Worker nodes are started with ray start but without the --head flag
-for ((i = 0; i < SLURM_JOB_NUM_NODES; i++)); do
+# Start from node 1 since node 0 is running the head
+for ((i = 1; i < SLURM_JOB_NUM_NODES; i++)); do
   node_i=${nodes_array[$i]}
     
   worker_cmd=$(cat <<EOF
@@ -236,6 +239,9 @@ monitor-sidecar() {
   done
 }
 monitor-sidecar &
+
+# Patch nsight.py before starting Ray worker
+sed -i 's/context\.py_executable = " "\.join(self\.nsight_cmd) + " python"/context.py_executable = " ".join(self.nsight_cmd) + f" {context.py_executable}"/g' /opt/nemo_rl_venv/lib64/python*/site-packages/ray/_private/runtime_env/nsight.py
 
 cat <<EOFINNER | tee /launch-worker.sh
 ray start --address "$ip_head" \
@@ -265,10 +271,7 @@ touch $LOG_DIR/ENDED
 exit 1
 EOF
 )
-  if [[ $i -eq 0 ]]; then
-    OVERLAP_HEAD_AND_WORKER_ARG="--overlap"
-  fi
-  srun $COMMON_SRUN_ARGS ${OVERLAP_HEAD_AND_WORKER_ARG:-} --container-name=ray-worker-$i --exact --nodes=1 --ntasks=1 --cpus-per-task=$CPUS_PER_WORKER -w "$node_i" -o $LOG_DIR/ray-worker-$i.log bash -x -c "$worker_cmd" &
+  srun $COMMON_SRUN_ARGS --container-name=ray-worker-$i --exact --nodes=1 --ntasks=1 --cpus-per-task=$CPUS_PER_WORKER -w "$node_i" -o $LOG_DIR/ray-worker-$i.log bash -x -c "$worker_cmd" &
   sleep 3
 done
 
@@ -311,21 +314,30 @@ echo "All workers connected!"
 # This driver process is responsible for launching a job on the Ray cluster
 CONTAINER_CWD=$(scontrol show job $SLURM_JOB_ID --json | jq -r '.jobs[].current_working_directory')
 if [[ -n "$COMMAND" ]]; then
-  srun --no-container-mount-home --gpus=0 --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "$head_node" -o $LOG_DIR/ray-driver.log bash -c "$COMMAND"
+  srun --no-container-mount-home --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "$head_node" -o $LOG_DIR/ray-driver.log bash -c "$COMMAND"
 else
   echo "[INFO]: Ray Cluster is idled, run this on the slurm head node to get a shell to the head node:"
   cat <<EOF >$SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh
-# No args launches on the head node
+# No args launches on the head node (node 0)
+# Args 1-N launch on worker nodes (nodes 1 through N-1)
 WORKER_NUM=\${1:-}
 if [[ -z "\$WORKER_NUM" ]]; then
   # Empty means we are on the head node
-  srun --no-container-mount-home --gpus=0 -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "$head_node" --jobid $SLURM_JOB_ID --pty bash
+  srun --no-container-mount-home --gres=gpu:8 -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "$head_node" --jobid $SLURM_JOB_ID --pty bash
 else
+  # Worker numbers 1 through N-1 correspond to ray-worker-1 through ray-worker-(N-1)
+  # and use nodes_array[1] through nodes_array[N-1]
+  if [[ \$WORKER_NUM -lt 1 || \$WORKER_NUM -ge $SLURM_JOB_NUM_NODES ]]; then
+    echo "Error: WORKER_NUM must be between 1 and $((SLURM_JOB_NUM_NODES-1))"
+    exit 1
+  fi
   nodes_array=($nodes)
   srun --no-container-mount-home --gres=gpu:8 -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-worker-\$WORKER_NUM --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "\${nodes_array[\$WORKER_NUM]}" --jobid $SLURM_JOB_ID --pty bash
 fi
 EOF
   chmod +x $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh
-  echo "     bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh"
+  echo "     bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh    # to attach to head node (i.e., 'worker 0')"
+  echo "     bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh 1  # to attach to worker 1"
+  echo "     bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh 2  # to attach to worker 2, etc."
   sleep infinity
 fi

--- a/tests/unit/distributed/test_worker_groups.py
+++ b/tests/unit/distributed/test_worker_groups.py
@@ -107,6 +107,33 @@ class MyTestActor:
 MY_TEST_ACTOR_FQN = f"{MyTestActor.__module__}.MyTestActor"
 
 
+@ray.remote(
+    num_gpus=1,
+    runtime_env={"nsight": {"t": "cuda,cudnn,cublas", "cuda-memory-usage": "true"}},
+)
+class NsightDummyActor:
+    def __init__(self):
+        self.initialized = True
+        # Store environment info that we can check later
+        self.env_vars = dict(os.environ)
+
+    def get_status(self):
+        return "ready"
+
+    def get_env_var(self, var_name):
+        return self.env_vars.get(var_name)
+
+    def check_nsight_config(self):
+        """Check if nsight profiling environment is properly configured."""
+        # Check if we're running under nsys (which would be the case if nsight was applied)
+        # The nsight configuration should result in the process being run with nsys profiler
+        return {
+            "has_nsight_env": "NSYS_RECIPE_ENABLED" in self.env_vars,
+            "nsys_recipe": self.env_vars.get("NSYS_RECIPE_ENABLED", ""),
+            "all_env_keys": list(self.env_vars.keys()),
+        }
+
+
 @pytest.fixture
 def register_test_actor(request):
     # Default to PY_EXECUTABLES.SYSTEM if no param is given
@@ -660,3 +687,165 @@ def test_run_all_workers_sharded_data_2d_output_replicated(worker_group_2d_shard
     # Assuming MultiWorkerFuture.get_results returns in order of return_from_workers
     assert "my_rank: 0" in results[0]  # from worker 0
     assert "my_rank: 2" in results[1]  # from worker 2
+
+
+def test_nsight_configuration_forwarding(register_test_actor, virtual_cluster):
+    """Test that nsight configuration in @ray.remote decorator is properly forwarded through RayWorkerGroup."""
+
+    # Check if nsys is installed, skip test if not available
+    import shutil
+
+    if shutil.which("nsys") is None:
+        pytest.skip("nsys (NVIDIA Nsight Systems) is not installed")
+
+    # Register the NsightDummyActor for use in the test
+    nsight_actor_fqn = f"{NsightDummyActor.__module__}.NsightDummyActor"
+    original_registry_value = ACTOR_ENVIRONMENT_REGISTRY.get(nsight_actor_fqn)
+    ACTOR_ENVIRONMENT_REGISTRY[nsight_actor_fqn] = PY_EXECUTABLES.SYSTEM
+
+    try:
+        # Create a RayWorkerBuilder with the nsight-configured actor
+        builder = RayWorkerBuilder(nsight_actor_fqn)
+
+        # Verify the worker has the expected default options from the @ray.remote decorator
+        # We can check this directly by ensuring the actor class has the nsight config
+        assert hasattr(NsightDummyActor, "_default_options")
+        options = getattr(NsightDummyActor, "_default_options", {})
+
+        # Verify the nsight configuration is in the runtime_env
+        assert "runtime_env" in options
+        assert (
+            "_nsight" in options["runtime_env"]
+        )  # Ray stores it with underscore prefix
+        assert options["runtime_env"]["_nsight"]["t"] == "cuda,cudnn,cublas"
+        assert options["runtime_env"]["_nsight"]["cuda-memory-usage"] == "true"
+        assert options.get("num_gpus") == 1
+
+        # Create worker group - nsight should be applied successfully
+        worker_group = RayWorkerGroup(
+            cluster=virtual_cluster, remote_worker_builder=builder, workers_per_node=1
+        )
+
+        assert len(worker_group.workers) == 1
+        worker = worker_group.workers[0]
+
+        # Verify the actor can be created and responds
+        status = ray.get(worker.get_status.remote())
+        assert status == "ready"
+
+        # Check if nsight configuration was applied
+        nsight_info = ray.get(worker.check_nsight_config.remote())
+
+        # The exact environment variables set by nsight profiling may vary,
+        # but we can verify that the worker was created successfully
+        # and the runtime_env with nsight was processed
+        assert isinstance(nsight_info, dict)
+        assert "all_env_keys" in nsight_info
+
+        worker_group.shutdown(force=True)
+
+    finally:
+        # Clean up registry
+        if nsight_actor_fqn in ACTOR_ENVIRONMENT_REGISTRY:
+            if original_registry_value is None:
+                del ACTOR_ENVIRONMENT_REGISTRY[nsight_actor_fqn]
+            else:
+                ACTOR_ENVIRONMENT_REGISTRY[nsight_actor_fqn] = original_registry_value
+
+
+def test_get_nsight_config_if_pattern_matches():
+    """Test the get_nsight_config_if_pattern_matches utility function."""
+    from nemo_rl.distributed.worker_groups import get_nsight_config_if_pattern_matches
+
+    # Test 1: No environment variable set
+    if "NRL_NSYS_WORKER_PATTERNS" in os.environ:
+        del os.environ["NRL_NSYS_WORKER_PATTERNS"]
+
+    result = get_nsight_config_if_pattern_matches("test_worker")
+    assert result == {}
+
+    # Test 2: Environment variable set but no pattern matches
+    os.environ["NRL_NSYS_WORKER_PATTERNS"] = "*critic*,*inference*"
+    result = get_nsight_config_if_pattern_matches("dtensor_policy_worker")
+    assert result == {}
+
+    # Test 3: Pattern matches with wildcard
+    os.environ["NRL_NSYS_WORKER_PATTERNS"] = "*policy*,*critic*"
+    result = get_nsight_config_if_pattern_matches("dtensor_policy_worker")
+    assert "nsight" in result
+    assert result["nsight"]["t"] == "cuda,cudnn,cublas,nvtx"
+    assert result["nsight"]["o"] == "'dtensor_policy_worker_%p'"
+    assert result["nsight"]["stop-on-exit"] == "true"
+
+    # Test 4: Exact name match
+    os.environ["NRL_NSYS_WORKER_PATTERNS"] = "exact-worker,another-worker"
+    result = get_nsight_config_if_pattern_matches("exact-worker")
+    assert "nsight" in result
+    assert result["nsight"]["o"] == "'exact-worker_%p'"
+
+    # Test 5: Multiple patterns, first one matches
+    os.environ["NRL_NSYS_WORKER_PATTERNS"] = "*vllm*,*policy*,*critic*"
+    result = get_nsight_config_if_pattern_matches("vllm_inference_worker")
+    assert "nsight" in result
+    assert result["nsight"]["o"] == "'vllm_inference_worker_%p'"
+
+    # Test 6: CSV parsing with whitespace
+    os.environ["NRL_NSYS_WORKER_PATTERNS"] = "  *train*  ,  exact-name  ,  *test*  "
+    result = get_nsight_config_if_pattern_matches("training_worker")
+    assert "nsight" in result
+
+    result = get_nsight_config_if_pattern_matches("exact-name")
+    assert "nsight" in result
+
+    result = get_nsight_config_if_pattern_matches("some_test_worker")
+    assert "nsight" in result
+
+    result = get_nsight_config_if_pattern_matches("no_match")
+    assert result == {}
+
+    # Test 7: Empty patterns in CSV
+    os.environ["NRL_NSYS_WORKER_PATTERNS"] = "*policy*,,*critic*,"
+    result = get_nsight_config_if_pattern_matches("policy_worker")
+    assert "nsight" in result
+
+    result = get_nsight_config_if_pattern_matches("critic_worker")
+    assert "nsight" in result
+
+    result = get_nsight_config_if_pattern_matches("other_worker")
+    assert result == {}
+
+    # Clean up
+    if "NRL_NSYS_WORKER_PATTERNS" in os.environ:
+        del os.environ["NRL_NSYS_WORKER_PATTERNS"]
+
+
+def test_get_nsight_config_output_format():
+    """Test that the nsight config output can be directly unpacked into runtime_env."""
+    from nemo_rl.distributed.worker_groups import get_nsight_config_if_pattern_matches
+
+    os.environ["NRL_NSYS_WORKER_PATTERNS"] = "*test*"
+
+    # Test the unpacking behavior
+    base_runtime_env = {"env_vars": {"SOME_VAR": "value"}, "py_executable": "python"}
+
+    nsight_config = get_nsight_config_if_pattern_matches("test_worker")
+
+    # This should work without errors
+    combined_runtime_env = {**base_runtime_env, **nsight_config}
+
+    assert "env_vars" in combined_runtime_env
+    assert "py_executable" in combined_runtime_env
+    assert "nsight" in combined_runtime_env
+    assert combined_runtime_env["nsight"]["t"] == "cuda,cudnn,cublas,nvtx"
+
+    # Test with no match
+    no_match_config = get_nsight_config_if_pattern_matches("no_match_worker")
+    combined_runtime_env_no_match = {**base_runtime_env, **no_match_config}
+
+    assert "env_vars" in combined_runtime_env_no_match
+    assert "py_executable" in combined_runtime_env_no_match
+    assert "nsight" not in combined_runtime_env_no_match
+
+    # Clean up
+    if "NRL_NSYS_WORKER_PATTERNS" in os.environ:
+        del os.environ["NRL_NSYS_WORKER_PATTERNS"]

--- a/tests/unit/distributed/test_worker_groups_utils.py
+++ b/tests/unit/distributed/test_worker_groups_utils.py
@@ -1,0 +1,305 @@
+"""Tests for worker groups utility functions."""
+
+from copy import deepcopy
+
+from nemo_rl.distributed.worker_groups import recursive_merge_options
+
+
+class TestRecursiveMergeOptions:
+    """Test cases for the recursive_merge_options function."""
+
+    def test_simple_merge(self):
+        """Test simple merging of two dictionaries."""
+        default_options = {"a": 1, "b": 2}
+        extra_options = {"c": 3, "d": 4}
+
+        result = recursive_merge_options(default_options, extra_options)
+
+        expected = {"a": 1, "b": 2, "c": 3, "d": 4}
+
+        assert result == expected
+
+    def test_override_values(self):
+        """Test that extra_options override default_options."""
+        default_options = {"a": 1, "b": 2}
+        extra_options = {
+            "a": 10,  # Override
+            "c": 3,
+        }
+
+        result = recursive_merge_options(default_options, extra_options)
+
+        expected = {
+            "a": 10,  # Overridden value
+            "b": 2,
+            "c": 3,
+        }
+
+        assert result == expected
+
+    def test_nested_merge(self):
+        """Test recursive merging of nested dictionaries."""
+        default_options = {"level1": {"a": 1, "b": 2, "nested": {"x": 10, "y": 20}}}
+        extra_options = {
+            "level1": {
+                "b": 20,  # Override
+                "c": 3,  # New key
+                "nested": {
+                    "y": 200,  # Override nested
+                    "z": 30,  # New nested key
+                },
+            }
+        }
+
+        result = recursive_merge_options(default_options, extra_options)
+
+        expected = {
+            "level1": {
+                "a": 1,
+                "b": 20,  # Overridden
+                "c": 3,  # Added
+                "nested": {
+                    "x": 10,
+                    "y": 200,  # Overridden
+                    "z": 30,  # Added
+                },
+            }
+        }
+
+        assert result == expected
+
+    def test_scalar_replaces_dict(self):
+        """Test that scalar values can replace dictionary values."""
+        default_options = {"config": {"nested": {"key": "value"}}}
+        extra_options = {
+            "config": "simple_string"  # Scalar replaces entire dict
+        }
+
+        result = recursive_merge_options(default_options, extra_options)
+
+        expected = {"config": "simple_string"}
+
+        assert result == expected
+
+    def test_dict_replaces_scalar(self):
+        """Test that dictionary values can replace scalar values."""
+        default_options = {"config": "simple_string"}
+        extra_options = {
+            "config": {  # Dict replaces scalar
+                "nested": {"key": "value"}
+            }
+        }
+
+        result = recursive_merge_options(default_options, extra_options)
+
+        expected = {"config": {"nested": {"key": "value"}}}
+
+        assert result == expected
+
+    def test_nsight_transformation(self):
+        """Test the special _nsight -> nsight transformation."""
+        default_options = {
+            "runtime_env": {
+                "_nsight": {"profile": True, "output": "profile.nsys-rep"},
+                "env_vars": {"CUDA_VISIBLE_DEVICES": "0"},
+            }
+        }
+        extra_options = {"runtime_env": {"env_vars": {"PYTHONPATH": "/custom/path"}}}
+
+        result = recursive_merge_options(default_options, extra_options)
+
+        expected = {
+            "runtime_env": {
+                "nsight": {  # _nsight transformed to nsight
+                    "profile": True,
+                    "output": "profile.nsys-rep",
+                },
+                "env_vars": {"CUDA_VISIBLE_DEVICES": "0", "PYTHONPATH": "/custom/path"},
+            }
+        }
+
+        assert result == expected
+        # Ensure _nsight is removed
+        assert "_nsight" not in result["runtime_env"]
+
+    def test_nsight_transformation_with_override(self):
+        """Test that extra_options can override transformed nsight config."""
+        default_options = {
+            "runtime_env": {"_nsight": {"profile": True, "output": "default.nsys-rep"}}
+        }
+        extra_options = {
+            "runtime_env": {
+                "nsight": {  # Should override the transformed _nsight
+                    "profile": True,
+                    "output": "custom.nsys-rep",
+                    "extra_flag": "--custom",
+                }
+            }
+        }
+
+        result = recursive_merge_options(default_options, extra_options)
+
+        expected = {
+            "runtime_env": {
+                "nsight": {
+                    "profile": True,
+                    "output": "custom.nsys-rep",  # Overridden
+                    "extra_flag": "--custom",  # Added
+                }
+            }
+        }
+
+        assert result == expected
+
+    def test_no_nsight_transformation_when_nsight_exists(self):
+        """Test that _nsight is not transformed when nsight already exists."""
+        default_options = {
+            "runtime_env": {
+                "_nsight": {"profile": True},
+                "nsight": {  # Already exists
+                    "output": "existing.nsys-rep"
+                },
+            }
+        }
+        extra_options = {}
+
+        result = recursive_merge_options(default_options, extra_options)
+
+        expected = {
+            "runtime_env": {
+                "_nsight": {  # Should remain as _nsight
+                    "profile": True
+                },
+                "nsight": {"output": "existing.nsys-rep"},
+            }
+        }
+
+        assert result == expected
+
+    def test_empty_dictionaries(self):
+        """Test merging with empty dictionaries."""
+        default_options = {}
+        extra_options = {"key": "value"}
+
+        result = recursive_merge_options(default_options, extra_options)
+        assert result == {"key": "value"}
+
+        default_options = {"key": "value"}
+        extra_options = {}
+
+        result = recursive_merge_options(default_options, extra_options)
+        assert result == {"key": "value"}
+
+    def test_deep_copy_behavior(self):
+        """Test that the function doesn't modify original dictionaries."""
+        default_options = {"nested": {"key": "original"}}
+        extra_options = {"nested": {"key": "modified"}}
+
+        original_default = deepcopy(default_options)
+        original_extra = deepcopy(extra_options)
+
+        result = recursive_merge_options(default_options, extra_options)
+
+        # Original dictionaries should be unchanged
+        assert default_options == original_default
+        assert extra_options == original_extra
+
+        # Result should have the merged values
+        assert result["nested"]["key"] == "modified"
+
+    def test_list_handling(self):
+        """Test that lists are replaced entirely, not merged."""
+        default_options = {"list_key": [1, 2, 3]}
+        extra_options = {"list_key": [4, 5]}
+
+        result = recursive_merge_options(default_options, extra_options)
+
+        expected = {
+            "list_key": [4, 5]  # Completely replaced
+        }
+
+        assert result == expected
+
+    def test_complex_nested_structure(self):
+        """Test merging of complex nested structures."""
+        default_options = {
+            "worker_config": {
+                "resources": {"num_cpus": 4, "num_gpus": 1},
+                "runtime_env": {
+                    "_nsight": {"profile": False},
+                    "env_vars": {"CUDA_VISIBLE_DEVICES": "0,1"},
+                },
+            },
+            "other_config": {"timeout": 300},
+        }
+
+        extra_options = {
+            "worker_config": {
+                "resources": {
+                    "num_gpus": 2,  # Override
+                    "memory": "16GB",  # Add
+                },
+                "runtime_env": {
+                    "env_vars": {
+                        "CUDA_VISIBLE_DEVICES": "2,3",  # Override
+                        "PYTHONPATH": "/custom",  # Add
+                    }
+                },
+            },
+            "new_config": {"enabled": True},
+        }
+
+        result = recursive_merge_options(default_options, extra_options)
+
+        expected = {
+            "worker_config": {
+                "resources": {
+                    "num_cpus": 4,
+                    "num_gpus": 2,  # Overridden
+                    "memory": "16GB",  # Added
+                },
+                "runtime_env": {
+                    "_nsight": {  # _nsight stays as _nsight in nested structure
+                        "profile": False
+                    },
+                    "env_vars": {
+                        "CUDA_VISIBLE_DEVICES": "2,3",  # Overridden
+                        "PYTHONPATH": "/custom",  # Added
+                    },
+                },
+            },
+            "other_config": {"timeout": 300},
+            "new_config": {  # Added
+                "enabled": True
+            },
+        }
+
+        assert result == expected
+
+    def test_top_level_runtime_env_nsight_transformation(self):
+        """Test _nsight transformation when runtime_env is at the top level."""
+        default_options = {
+            "runtime_env": {
+                "_nsight": {"profile": True, "output": "profile.nsys-rep"},
+                "env_vars": {"CUDA_VISIBLE_DEVICES": "0"},
+            },
+            "other_key": "value",
+        }
+        extra_options = {"runtime_env": {"env_vars": {"PYTHONPATH": "/custom/path"}}}
+
+        result = recursive_merge_options(default_options, extra_options)
+
+        expected = {
+            "runtime_env": {
+                "nsight": {  # _nsight transformed to nsight at top level
+                    "profile": True,
+                    "output": "profile.nsys-rep",
+                },
+                "env_vars": {"CUDA_VISIBLE_DEVICES": "0", "PYTHONPATH": "/custom/path"},
+            },
+            "other_key": "value",
+        }
+
+        assert result == expected
+        # Ensure _nsight is removed
+        assert "_nsight" not in result["runtime_env"]

--- a/tests/unit/distributed/test_worker_groups_utils.py
+++ b/tests/unit/distributed/test_worker_groups_utils.py
@@ -2,7 +2,7 @@
 
 from copy import deepcopy
 
-from nemo_rl.distributed.worker_groups import recursive_merge_options
+from nemo_rl.distributed.worker_group_utils import recursive_merge_options
 
 
 class TestRecursiveMergeOptions:

--- a/tests/unit/distributed/test_worker_groups_utils.py
+++ b/tests/unit/distributed/test_worker_groups_utils.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Tests for worker groups utility functions."""
 
 from copy import deepcopy

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -1197,7 +1197,7 @@ def test_vllm_refit_non_collocated_handles_update(
     lm_policy.shutdown()
 
 
-@pytest.mark.timeout(180)
+@pytest.mark.timeout(210)
 @pytest.mark.parametrize("tensor_parallel_size", [1, 2])
 def test_vllm_generation_with_megatron_training(
     cluster, tokenizer, tensor_parallel_size

--- a/tests/unit/test_nsight_patching.py
+++ b/tests/unit/test_nsight_patching.py
@@ -1,0 +1,206 @@
+"""Tests for the nsight file patching functionality."""
+
+import os
+from unittest.mock import Mock, mock_open, patch
+
+from nemo_rl import _patch_nsight_file
+
+
+class TestNsightPatching:
+    """Test cases for the _patch_nsight_file function."""
+
+    def test_no_patching_when_env_var_not_set(self):
+        """Test that patching is skipped when NRL_NSYS_WORKER_PATTERNS is not set."""
+        # Ensure env var is not set
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("nemo_rl.logging") as mock_logging:
+                _patch_nsight_file()
+                # Should not log anything since function returns early
+                mock_logging.info.assert_not_called()
+                mock_logging.warning.assert_not_called()
+
+    def test_patching_when_env_var_set(self):
+        """Test that patching proceeds when NRL_NSYS_WORKER_PATTERNS is set."""
+        with patch.dict(os.environ, {"NRL_NSYS_WORKER_PATTERNS": "test_pattern"}):
+            with patch("nemo_rl.logging") as mock_logging:
+                # Mock the ray import inside the function
+                mock_nsight = Mock()
+                mock_nsight.__file__ = "/fake/path/nsight.py"
+
+                original_content = (
+                    'context.py_executable = " ".join(self.nsight_cmd) + " python"'
+                )
+
+                # Use patch with create=True to mock the import
+                with patch("ray._private.runtime_env.nsight", mock_nsight, create=True):
+                    with patch("builtins.open", mock_open(read_data=original_content)):
+                        _patch_nsight_file()
+
+                        # Should have attempted to log success
+                        mock_logging.info.assert_called()
+
+    def test_successful_patching(self):
+        """Test successful patching of a file."""
+        with patch.dict(os.environ, {"NRL_NSYS_WORKER_PATTERNS": "test_pattern"}):
+            with patch("nemo_rl.logging") as mock_logging:
+                # Mock the ray import
+                mock_nsight = Mock()
+                mock_nsight.__file__ = "/fake/path/nsight.py"
+
+                original_content = (
+                    'context.py_executable = " ".join(self.nsight_cmd) + " python"'
+                )
+                expected_content = 'context.py_executable = " ".join(self.nsight_cmd) + f" {context.py_executable}"'
+
+                # Mock file operations
+                mock_file = mock_open(read_data=original_content)
+
+                # Use patch with create=True to mock the import
+                with patch("ray._private.runtime_env.nsight", mock_nsight, create=True):
+                    with patch("builtins.open", mock_file):
+                        _patch_nsight_file()
+
+                        # Verify file was read and written
+                        mock_file.assert_any_call("/fake/path/nsight.py", "r")
+                        mock_file.assert_any_call("/fake/path/nsight.py", "w")
+
+                        # Verify patched content was written
+                        handle = mock_file()
+                        handle.write.assert_called_with(expected_content)
+
+                        mock_logging.info.assert_called_with(
+                            "Successfully patched Ray nsight plugin at /fake/path/nsight.py"
+                        )
+
+    def test_already_patched_file(self):
+        """Test that already patched files are detected and skipped."""
+        with patch.dict(os.environ, {"NRL_NSYS_WORKER_PATTERNS": "test_pattern"}):
+            with patch("nemo_rl.logging") as mock_logging:
+                mock_nsight = Mock()
+                mock_nsight.__file__ = "/fake/path/nsight.py"
+
+                # Content already contains the patched line
+                already_patched_content = 'context.py_executable = " ".join(self.nsight_cmd) + f" {context.py_executable}"'
+
+                mock_file = mock_open(read_data=already_patched_content)
+
+                # Use patch with create=True to mock the import
+                with patch("ray._private.runtime_env.nsight", mock_nsight, create=True):
+                    with patch("builtins.open", mock_file):
+                        _patch_nsight_file()
+
+                        # Should only read, not write
+                        mock_file.assert_called_once_with("/fake/path/nsight.py", "r")
+                        handle = mock_file()
+                        handle.write.assert_not_called()
+
+                        mock_logging.info.assert_called_with(
+                            "Ray nsight plugin already patched at /fake/path/nsight.py"
+                        )
+
+    def test_expected_line_not_found(self):
+        """Test handling when expected line is not found in file."""
+        with patch.dict(os.environ, {"NRL_NSYS_WORKER_PATTERNS": "test_pattern"}):
+            with patch("nemo_rl.logging") as mock_logging:
+                mock_nsight = Mock()
+                mock_nsight.__file__ = "/fake/path/nsight.py"
+
+                # Content doesn't contain expected line
+                different_content = "some other content"
+
+                mock_file = mock_open(read_data=different_content)
+
+                # Use patch with create=True to mock the import
+                with patch("ray._private.runtime_env.nsight", mock_nsight, create=True):
+                    with patch("builtins.open", mock_file):
+                        _patch_nsight_file()
+
+                        # Should only read, not write
+                        mock_file.assert_called_once_with("/fake/path/nsight.py", "r")
+                        handle = mock_file()
+                        handle.write.assert_not_called()
+
+                        mock_logging.warning.assert_called_with(
+                            "Expected line not found in /fake/path/nsight.py - Ray version may have changed"
+                        )
+
+    def test_import_error_handling(self):
+        """Test graceful handling of ImportError."""
+        with patch.dict(os.environ, {"NRL_NSYS_WORKER_PATTERNS": "test_pattern"}):
+            with patch("nemo_rl.logging") as mock_logging:
+                # Mock the import to raise ImportError
+                with patch(
+                    "builtins.__import__", side_effect=ImportError("Ray not found")
+                ):
+                    _patch_nsight_file()
+
+                    # Should not crash and should not log anything (silent failure)
+                    mock_logging.info.assert_not_called()
+                    mock_logging.warning.assert_not_called()
+
+    def test_file_not_found_error_handling(self):
+        """Test graceful handling of FileNotFoundError."""
+        with patch.dict(os.environ, {"NRL_NSYS_WORKER_PATTERNS": "test_pattern"}):
+            with patch("nemo_rl.logging") as mock_logging:
+                mock_nsight = Mock()
+                mock_nsight.__file__ = "/nonexistent/path/nsight.py"
+
+                # Use patch with create=True to mock the import
+                with patch("ray._private.runtime_env.nsight", mock_nsight, create=True):
+                    with patch(
+                        "builtins.open", side_effect=FileNotFoundError("File not found")
+                    ):
+                        _patch_nsight_file()
+
+                        # Should not crash and should not log anything (silent failure)
+                        mock_logging.info.assert_not_called()
+                        mock_logging.warning.assert_not_called()
+
+    def test_permission_error_handling(self):
+        """Test graceful handling of PermissionError."""
+        with patch.dict(os.environ, {"NRL_NSYS_WORKER_PATTERNS": "test_pattern"}):
+            with patch("nemo_rl.logging") as mock_logging:
+                mock_nsight = Mock()
+                mock_nsight.__file__ = "/fake/path/nsight.py"
+
+                # Use patch with create=True to mock the import
+                with patch("ray._private.runtime_env.nsight", mock_nsight, create=True):
+                    with patch(
+                        "builtins.open",
+                        side_effect=PermissionError("Permission denied"),
+                    ):
+                        _patch_nsight_file()
+
+                        # Should not crash and should not log anything (silent failure)
+                        mock_logging.info.assert_not_called()
+                        mock_logging.warning.assert_not_called()
+
+    def test_line_replacement_accuracy(self):
+        """Test that the exact line replacement is accurate."""
+        with patch.dict(os.environ, {"NRL_NSYS_WORKER_PATTERNS": "test_pattern"}):
+            with patch("nemo_rl.logging"):
+                mock_nsight = Mock()
+                mock_nsight.__file__ = "/fake/path/nsight.py"
+
+                # Content with the target line embedded in other code
+                original_content = """
+def some_function():
+    context.py_executable = " ".join(self.nsight_cmd) + " python"
+    return context
+"""
+
+                expected_content = """
+def some_function():
+    context.py_executable = " ".join(self.nsight_cmd) + f" {context.py_executable}"
+    return context
+"""
+
+                mock_file = mock_open(read_data=original_content)
+
+                # Use patch with create=True to mock the import
+                with patch("ray._private.runtime_env.nsight", mock_nsight, create=True):
+                    with patch("builtins.open", mock_file):
+                        _patch_nsight_file()
+
+                        handle = mock_file()
+                        handle.write.assert_called_with(expected_content)

--- a/tests/unit/test_nsight_patching.py
+++ b/tests/unit/test_nsight_patching.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Tests for the nsight file patching functionality."""
 
 import os

--- a/tests/unit/utils/test_nsys.py
+++ b/tests/unit/utils/test_nsys.py
@@ -1,0 +1,526 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest.mock import Mock, patch
+
+import pytest
+
+from nemo_rl.utils.nsys import maybe_gpu_profile_step
+
+
+class MockPolicy:
+    """Mock implementation of ProfilablePolicy for testing."""
+
+    def __init__(self):
+        self.start_gpu_profiling = Mock()
+        self.stop_gpu_profiling = Mock()
+
+    def __repr__(self):
+        return "MockPolicy"
+
+
+class TestMaybeGpuProfileStep:
+    """Test cases for the maybe_gpu_profile_step function."""
+
+    def test_no_environment_variables_set(self):
+        """Test that function returns early when no environment variables are set."""
+        policy = MockPolicy()
+
+        with (
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", ""),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", ""),
+        ):
+            maybe_gpu_profile_step(policy, 5)
+
+        # Should not call any profiling methods
+        policy.start_gpu_profiling.assert_not_called()
+        policy.stop_gpu_profiling.assert_not_called()
+
+    def test_only_worker_patterns_set_raises_assertion_error(self):
+        """Test that setting only NRL_NSYS_WORKER_PATTERNS raises AssertionError."""
+        policy = MockPolicy()
+
+        with (
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", ""),
+        ):
+            with pytest.raises(
+                AssertionError,
+                match="Either both NRL_NSYS_WORKER_PATTERNS and NRL_NSYS_PROFILE_STEP_RANGE must be set",
+            ):
+                maybe_gpu_profile_step(policy, 5)
+
+    def test_only_step_range_set_raises_assertion_error(self):
+        """Test that setting only NRL_NSYS_PROFILE_STEP_RANGE raises AssertionError."""
+        policy = MockPolicy()
+
+        with (
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", ""),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "1:10"),
+        ):
+            with pytest.raises(
+                AssertionError,
+                match="Either both NRL_NSYS_WORKER_PATTERNS and NRL_NSYS_PROFILE_STEP_RANGE must be set",
+            ):
+                maybe_gpu_profile_step(policy, 5)
+
+    def test_invalid_step_range_format_missing_colon(self):
+        """Test that invalid step range format raises ValueError."""
+        policy = MockPolicy()
+
+        with (
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "1-10"),
+        ):
+            with pytest.raises(ValueError, match="not enough values to unpack"):
+                maybe_gpu_profile_step(policy, 5)
+
+    def test_invalid_step_range_format_non_integer_start(self):
+        """Test that non-integer start value raises ValueError."""
+        policy = MockPolicy()
+
+        with (
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "abc:10"),
+        ):
+            with pytest.raises(
+                ValueError, match="Error parsing NRL_NSYS_PROFILE_STEP_RANGE"
+            ):
+                maybe_gpu_profile_step(policy, 5)
+
+    def test_invalid_step_range_format_non_integer_stop(self):
+        """Test that non-integer stop value raises ValueError."""
+        policy = MockPolicy()
+
+        with (
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "1:xyz"),
+        ):
+            with pytest.raises(
+                ValueError, match="Error parsing NRL_NSYS_PROFILE_STEP_RANGE"
+            ):
+                maybe_gpu_profile_step(policy, 5)
+
+    def test_start_step_greater_than_stop_step(self):
+        """Test that start >= stop raises AssertionError."""
+        policy = MockPolicy()
+
+        with (
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "10:5"),
+        ):
+            with pytest.raises(AssertionError, match="must be a non-empty range"):
+                maybe_gpu_profile_step(policy, 7)
+
+    def test_start_step_equal_to_stop_step(self):
+        """Test that start == stop raises AssertionError."""
+        policy = MockPolicy()
+
+        with (
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "5:5"),
+        ):
+            with pytest.raises(AssertionError, match="must be a non-empty range"):
+                maybe_gpu_profile_step(policy, 5)
+
+    def test_start_step_less_than_one(self):
+        """Test that start < 1 raises AssertionError."""
+        policy = MockPolicy()
+
+        with (
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "0:10"),
+        ):
+            with pytest.raises(AssertionError, match="must be >= 1"):
+                maybe_gpu_profile_step(policy, 5)
+
+    def test_negative_start_step(self):
+        """Test that negative start raises AssertionError."""
+        policy = MockPolicy()
+
+        with (
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "-5:10"),
+        ):
+            with pytest.raises(AssertionError, match="must be >= 1"):
+                maybe_gpu_profile_step(policy, 5)
+
+    @patch("nemo_rl.utils.nsys.rich.print")
+    @patch("nemo_rl.utils.nsys.atexit.register")
+    def test_start_profiling_in_range(self, mock_atexit_register, mock_rich_print):
+        """Test that profiling starts when step is in range."""
+        policy = MockPolicy()
+
+        with (
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "5:10"),
+        ):
+            maybe_gpu_profile_step(policy, 5)
+
+        # Should start profiling
+        policy.start_gpu_profiling.assert_called_once()
+        policy.stop_gpu_profiling.assert_not_called()
+
+        # Should set the flag
+        assert hasattr(policy, "__NRL_PROFILE_STARTED")
+        assert getattr(policy, "__NRL_PROFILE_STARTED") is True
+
+        # Should print status message
+        mock_rich_print.assert_called_once()
+        assert "Starting GPU profiling" in str(mock_rich_print.call_args)
+
+        # Should register exit handler
+        mock_atexit_register.assert_called_once()
+
+    @patch("nemo_rl.utils.nsys.rich.print")
+    @patch("nemo_rl.utils.nsys.atexit.register")
+    def test_start_profiling_at_start_boundary(
+        self, mock_atexit_register, mock_rich_print
+    ):
+        """Test profiling starts at the exact start step."""
+        policy = MockPolicy()
+
+        with (
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "3:8"),
+        ):
+            maybe_gpu_profile_step(policy, 3)
+
+        policy.start_gpu_profiling.assert_called_once()
+        assert getattr(policy, "__NRL_PROFILE_STARTED") is True
+
+    @patch("nemo_rl.utils.nsys.rich.print")
+    def test_continue_profiling_when_already_started(self, mock_rich_print):
+        """Test that profiling doesn't restart when already started."""
+        policy = MockPolicy()
+        setattr(policy, "__NRL_PROFILE_STARTED", True)
+
+        with (
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "5:10"),
+        ):
+            maybe_gpu_profile_step(policy, 6)
+
+        # Should not call start again
+        policy.start_gpu_profiling.assert_not_called()
+        policy.stop_gpu_profiling.assert_not_called()
+
+        # Should not print anything
+        mock_rich_print.assert_not_called()
+
+    @patch("nemo_rl.utils.nsys.rich.print")
+    def test_stop_profiling_after_range(self, mock_rich_print):
+        """Test that profiling stops when step goes beyond range."""
+        policy = MockPolicy()
+        setattr(policy, "__NRL_PROFILE_STARTED", True)
+
+        with (
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "5:10"),
+        ):
+            maybe_gpu_profile_step(policy, 10)  # Exclusive upper bound
+
+        # Should stop profiling
+        policy.start_gpu_profiling.assert_not_called()
+        policy.stop_gpu_profiling.assert_called_once()
+
+        # Should clear the flag
+        assert getattr(policy, "__NRL_PROFILE_STARTED") is False
+
+        # Should print status message
+        mock_rich_print.assert_called_once()
+        assert "Stopping GPU profiling" in str(mock_rich_print.call_args)
+
+    @patch("nemo_rl.utils.nsys.rich.print")
+    def test_stop_profiling_at_stop_boundary(self, mock_rich_print):
+        """Test profiling stops at the exact stop step (exclusive)."""
+        policy = MockPolicy()
+        setattr(policy, "__NRL_PROFILE_STARTED", True)
+
+        with (
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "3:8"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+        ):
+            maybe_gpu_profile_step(policy, 8)  # Should stop at step 8 (exclusive)
+
+        policy.stop_gpu_profiling.assert_called_once()
+        assert getattr(policy, "__NRL_PROFILE_STARTED") is False
+
+    def test_no_action_when_step_before_range(self):
+        """Test that no action is taken when step is before range."""
+        policy = MockPolicy()
+
+        with (
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "5:10"),
+        ):
+            maybe_gpu_profile_step(policy, 3)
+
+        policy.start_gpu_profiling.assert_not_called()
+        policy.stop_gpu_profiling.assert_not_called()
+        assert not hasattr(policy, "__NRL_PROFILE_STARTED")
+
+    def test_no_action_when_step_after_range_and_not_started(self):
+        """Test that no action is taken when step is after range and profiling wasn't started."""
+        policy = MockPolicy()
+
+        with (
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "5:10"),
+        ):
+            maybe_gpu_profile_step(policy, 15)
+
+        policy.start_gpu_profiling.assert_not_called()
+        policy.stop_gpu_profiling.assert_not_called()
+
+    @patch("nemo_rl.utils.nsys.rich.print")
+    @patch("nemo_rl.utils.nsys.atexit.register")
+    def test_atexit_handler_calls_stop_profiling(
+        self, mock_atexit_register, mock_rich_print
+    ):
+        """Test that the registered atexit handler calls stop_gpu_profiling."""
+        policy = MockPolicy()
+
+        with (
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "5:10"),
+        ):
+            maybe_gpu_profile_step(policy, 5)
+
+        # Verify atexit handler was registered
+        mock_atexit_register.assert_called_once()
+
+        # Get the registered function and call it
+        registered_function = mock_atexit_register.call_args[0][0]
+        registered_function()
+
+        # The atexit handler should print and call stop_gpu_profiling
+        # Note: We called start once during the main call, and stop once in the exit handler
+        assert policy.stop_gpu_profiling.call_count == 1
+
+        # Should have printed twice: once for start, once for exit
+        assert mock_rich_print.call_count == 2
+        assert "Stopping GPU profiling on exit" in str(
+            mock_rich_print.call_args_list[1]
+        )
+
+    @patch("nemo_rl.utils.nsys.atexit.register")
+    def test_single_step_range(self, mock_atexit_register):
+        """Test profiling with a single-step range."""
+        policy = MockPolicy()
+
+        # Step 5 should start profiling
+        with (
+            patch("nemo_rl.utils.nsys.rich.print"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "5:6"),
+        ):
+            maybe_gpu_profile_step(policy, 5)
+        assert getattr(policy, "__NRL_PROFILE_STARTED") is True
+        policy.start_gpu_profiling.assert_called_once()
+
+        # Step 6 should stop profiling
+        with (
+            patch("nemo_rl.utils.nsys.rich.print"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "5:6"),
+        ):
+            maybe_gpu_profile_step(policy, 6)
+        assert getattr(policy, "__NRL_PROFILE_STARTED") is False
+        policy.stop_gpu_profiling.assert_called_once()
+
+    @patch("nemo_rl.utils.nsys.atexit.register")
+    def test_profiling_sequence_full_lifecycle(self, mock_atexit_register):
+        """Test a complete profiling lifecycle from start to stop."""
+        policy = MockPolicy()
+
+        with (
+            patch("nemo_rl.utils.nsys.rich.print"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "3:7"),
+        ):
+            # Before range - no action
+            maybe_gpu_profile_step(policy, 1)
+            assert not hasattr(policy, "__NRL_PROFILE_STARTED")
+
+            maybe_gpu_profile_step(policy, 2)
+            assert not hasattr(policy, "__NRL_PROFILE_STARTED")
+
+            # Start of range - start profiling
+            maybe_gpu_profile_step(policy, 3)
+            assert getattr(policy, "__NRL_PROFILE_STARTED") is True
+            policy.start_gpu_profiling.assert_called_once()
+
+            # Within range - continue profiling (no additional calls)
+            maybe_gpu_profile_step(policy, 4)
+            maybe_gpu_profile_step(policy, 5)
+            maybe_gpu_profile_step(policy, 6)
+            policy.start_gpu_profiling.assert_called_once()  # Still only called once
+
+            # End of range - stop profiling
+            maybe_gpu_profile_step(policy, 7)
+            assert getattr(policy, "__NRL_PROFILE_STARTED") is False
+            policy.stop_gpu_profiling.assert_called_once()
+
+            # After range - no additional action
+            maybe_gpu_profile_step(policy, 8)
+            policy.stop_gpu_profiling.assert_called_once()  # Still only called once
+
+    @patch("nemo_rl.utils.nsys.atexit.register")
+    def test_large_step_numbers(self, mock_atexit_register):
+        """Test profiling with large step numbers."""
+        policy = MockPolicy()
+
+        with (
+            patch("nemo_rl.utils.nsys.rich.print"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "1000000:1000002"),
+        ):
+            maybe_gpu_profile_step(policy, 1000000)
+
+        assert getattr(policy, "__NRL_PROFILE_STARTED") is True
+        policy.start_gpu_profiling.assert_called_once()
+
+    @patch("nemo_rl.utils.nsys.atexit.register")
+    def test_whitespace_in_environment_variables(self, mock_atexit_register):
+        """Test that whitespace in environment variables is handled correctly."""
+        policy = MockPolicy()
+
+        # This should work despite whitespace
+        with (
+            patch("nemo_rl.utils.nsys.rich.print"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", " worker* "),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", " 5:10 "),
+        ):
+            maybe_gpu_profile_step(policy, 5)
+
+        policy.start_gpu_profiling.assert_called_once()
+
+    def test_policy_without_profiling_methods_fails(self):
+        """Test that a policy without required methods raises AttributeError."""
+
+        class InvalidPolicy:
+            pass
+
+        policy = InvalidPolicy()
+
+        with (
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "5:10"),
+        ):
+            with pytest.raises(AttributeError):
+                maybe_gpu_profile_step(policy, 5)
+
+
+class TestProfilablePolicy:
+    """Test cases for the ProfilablePolicy protocol."""
+
+    def test_mock_policy_implements_protocol(self):
+        """Test that our MockPolicy correctly implements the ProfilablePolicy protocol."""
+        policy = MockPolicy()
+
+        # Should have the required methods
+        assert hasattr(policy, "start_gpu_profiling")
+        assert hasattr(policy, "stop_gpu_profiling")
+        assert callable(policy.start_gpu_profiling)
+        assert callable(policy.stop_gpu_profiling)
+
+    def test_protocol_methods_can_be_called(self):
+        """Test that protocol methods can be called."""
+        policy = MockPolicy()
+
+        # Should be able to call methods without errors
+        policy.start_gpu_profiling()
+        policy.stop_gpu_profiling()
+
+        # Verify calls were made
+        policy.start_gpu_profiling.assert_called_once()
+        policy.stop_gpu_profiling.assert_called_once()
+
+
+class TestEdgeCases:
+    """Test edge cases and error conditions."""
+
+    @patch("nemo_rl.utils.nsys.atexit.register")
+    def test_exception_in_start_profiling_propagates(self, mock_atexit_register):
+        """Test that exceptions in start_gpu_profiling propagate correctly."""
+        policy = MockPolicy()
+        policy.start_gpu_profiling.side_effect = RuntimeError("GPU not available")
+
+        with (
+            patch("nemo_rl.utils.nsys.rich.print"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "5:10"),
+        ):
+            with pytest.raises(RuntimeError, match="GPU not available"):
+                maybe_gpu_profile_step(policy, 5)
+
+    def test_exception_in_stop_profiling_propagates(self):
+        """Test that exceptions in stop_gpu_profiling propagate correctly."""
+        policy = MockPolicy()
+        setattr(policy, "__NRL_PROFILE_STARTED", True)
+        policy.stop_gpu_profiling.side_effect = RuntimeError("Profiler error")
+
+        with (
+            patch("nemo_rl.utils.nsys.rich.print"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "5:10"),
+        ):
+            with pytest.raises(RuntimeError, match="Profiler error"):
+                maybe_gpu_profile_step(policy, 10)
+
+    @patch("nemo_rl.utils.nsys.atexit.register")
+    def test_multiple_calls_to_same_step(self, mock_atexit_register):
+        """Test calling maybe_gpu_profile_step multiple times with the same step."""
+        policy = MockPolicy()
+
+        with (
+            patch("nemo_rl.utils.nsys.rich.print"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "5:10"),
+        ):
+            # First call should start profiling
+            maybe_gpu_profile_step(policy, 5)
+            policy.start_gpu_profiling.assert_called_once()
+
+            # Second call to same step should not call start again
+            maybe_gpu_profile_step(policy, 5)
+            policy.start_gpu_profiling.assert_called_once()  # Still only called once
+
+    def test_step_zero_handling(self):
+        """Test handling of step 0."""
+        policy = MockPolicy()
+
+        with (
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "1:5"),
+        ):
+            # Step 0 should not trigger profiling
+            maybe_gpu_profile_step(policy, 0)
+
+        policy.start_gpu_profiling.assert_not_called()
+        policy.stop_gpu_profiling.assert_not_called()
+
+    def test_negative_step_handling(self):
+        """Test handling of negative steps."""
+        policy = MockPolicy()
+
+        with (
+            patch("nemo_rl.utils.nsys.NRL_NSYS_WORKER_PATTERNS", "worker*"),
+            patch("nemo_rl.utils.nsys.NRL_NSYS_PROFILE_STEP_RANGE", "1:5"),
+        ):
+            # Negative step should not trigger profiling
+            maybe_gpu_profile_step(policy, -5)
+
+        policy.start_gpu_profiling.assert_not_called()
+        policy.stop_gpu_profiling.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -2301,6 +2301,7 @@ dependencies = [
     { name = "matplotlib" },
     { name = "numpy" },
     { name = "nvidia-ml-py" },
+    { name = "nvtx" },
     { name = "omegaconf" },
     { name = "plotly" },
     { name = "ray", extra = ["default"] },
@@ -2369,6 +2370,7 @@ requires-dist = [
     { name = "nemo-tron", marker = "extra == 'mcore'", editable = "3rdparty/NeMo-workspace" },
     { name = "numpy" },
     { name = "nvidia-ml-py" },
+    { name = "nvtx" },
     { name = "omegaconf" },
     { name = "plotly" },
     { name = "ray", extras = ["default"], specifier = "==2.46.0" },
@@ -2816,6 +2818,20 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/74/996dbc314da8ed670cd5e040d0b4b5be79ff1fc3db3fe25e63134deebe9a/nvidia_sphinx_theme-0.0.8-py3-none-any.whl", hash = "sha256:18f117aa154a3a156251a75647279c541464f3e75f7df2ae283e720cc7d0bc2c", size = 140678, upload-time = "2025-03-24T21:56:25.621Z" },
+]
+
+[[package]]
+name = "nvtx"
+version = "0.2.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/05/160dc24b6cd1e21e5b00d55a46abac5802ed7c15c675e6ce25febad2b0d7/nvtx-0.2.12.tar.gz", hash = "sha256:b871fae9b80b004e624b5755291799794287016fa6a0c8fd0fb3255393ae3bc8", size = 110848, upload-time = "2025-05-26T10:32:33.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/e4/944e63039a0d652c843ecffb42700e2b4f596b745ac9ac6ebed937f1bce5/nvtx-0.2.12-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9ea22a86eca22fd52e3c2905654182da1fcebea6f0107e87d7dc4ec6871604ca", size = 539647, upload-time = "2025-05-25T08:52:12.911Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/7b/6e25716c92039a3ecc2f6f4e1380b5492b0d23af78ea862cb84e8ffe0d7b/nvtx-0.2.12-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a279d880c27ec8c72632a0685456c170e7b12da2839c861ee461c121692aea6", size = 543614, upload-time = "2025-05-25T08:44:44.678Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/96/eb1078d7509b72e3e4b6dd7ff12a698951e81dcc5f20a3ad7f35d7455700/nvtx-0.2.12-cp312-cp312-win_amd64.whl", hash = "sha256:2f93e07add2544a85c202b3c710945b54b3abb6660a6a7e447395cb024938b35", size = 98894, upload-time = "2025-05-25T08:42:59.068Z" },
+    { url = "https://files.pythonhosted.org/packages/55/78/88563935649f9202735ac5686fc451d3fa9f34e6592787ba224244c3570a/nvtx-0.2.12-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:871e54f95929a6c7c39b85d4111bf6af8ab43325bbc36c97a179270443896ef7", size = 520074, upload-time = "2025-05-25T08:52:50.144Z" },
+    { url = "https://files.pythonhosted.org/packages/86/0c/62b1f76c84a8bed267421d11114953b5da631daeb0ec7894a91252f79b5d/nvtx-0.2.12-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b82ad84ac8d5408851947d1d2cef3e8e627627cc2290e5150c8af0dda1e3f63", size = 524516, upload-time = "2025-05-25T08:45:06.598Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/41/e74ec826e1585ad6d31f41de96f6faae8ffc712a45c2b880baca4ae87a64/nvtx-0.2.12-cp313-cp313-win_amd64.whl", hash = "sha256:a37e063c3c745a4c6b561993a2dae2f67fcc26f2a2c2653f24eeae5810a2180d", size = 97070, upload-time = "2025-05-25T08:43:41.323Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #216 

Potentially solves #383 

To allow nsys profiling had to fix how the default options were propagated from `@ray.remote(...)` get propagated in the `RayWorkerGroup`.

Also there's a bug in upstream ray for nsight + py_executable that I'll submit a fix for, but in order to use nsys today, this PR includes patches in `__init__.py` and `ray.sub`.