### PR TITLE
feat: add experiment launchers

### DIFF
--- a/xp/eval_launcher.py
+++ b/xp/eval_launcher.py
@@ -1,0 +1,573 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import hashlib
+import itertools
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Tuple, Optional
+
+import yaml
+
+
+# Environment variables
+LOG_DIR = os.environ.get("LOG", "/tmp") + "/nemo-rl"
+ACCOUNT = os.environ.get("ACCOUNT", "default")
+CONTAINER = os.environ.get("CON", "/containers") + "/nemo_rl_base.sqsh"
+MOUNTS = "/lustre:/lustre"
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Launch Slurm evaluation experiments with parameter sweeps")
+    
+    # Evaluation specific arguments
+    parser.add_argument("--config", type=str, help="Path to the evaluation config YAML file")
+    parser.add_argument("--sweep", type=str, help="Path to the sweep config YAML file")
+    
+    # Checkpoint conversion arguments
+    parser.add_argument("--dcp-ckpt-path", type=str, help="Path to DCP checkpoint to convert")
+    parser.add_argument("--dcp-config", type=str, help="Path to config file for DCP checkpoint")
+    parser.add_argument("--hf-ckpt-path", type=str, help="Path to save converted HF checkpoint (optional)")
+    parser.add_argument("--skip-conversion", action="store_true", help="Skip checkpoint conversion")
+    parser.add_argument("--force-conversion", action="store_true", help="Force re-conversion even if cached version exists")
+    
+    # SLURM arguments
+    parser.add_argument("--nodes", type=int, default=None, help="Number of nodes to use")
+    parser.add_argument("--gpus", type=int, default=None, help="Number of GPUs per node")
+    parser.add_argument("--time", type=str, default="2:0:0", help="Time limit for the job")
+    parser.add_argument("--account", type=str, default=ACCOUNT, help="Slurm account to use")
+    parser.add_argument("--partition", type=str, default="batch", help="Slurm partition to use")
+    parser.add_argument("--container", type=str, default=CONTAINER, help="Container to use")
+    parser.add_argument("--mounts", type=str, default=MOUNTS, help="Mounts to use")
+    parser.add_argument("--jobname", type=str, default=None, help="Base name for the job")
+    parser.add_argument("--dry", action="store_true", help="Print commands without executing them")
+    
+    args, extra_args = parser.parse_known_args()
+    return args, extra_args
+
+
+def load_yaml(file_path: str) -> Dict[str, Any]:
+    """Load a YAML file."""
+    try:
+        with open(file_path, "r") as f:
+            return yaml.safe_load(f)
+    except FileNotFoundError:
+        print(f"Warning: Config file not found at {file_path}.")
+        return {}
+    except yaml.YAMLError as e:
+        print(f"Warning: Error parsing YAML file {file_path}: {e}.")
+        return {}
+
+
+def get_num_nodes(config_path: Optional[str], cli_nodes: Optional[int]) -> int:
+    """
+    Determine the number of nodes to use.
+    Reads from the config file (cluster.num_nodes) as default,
+    overrides with CLI argument if provided.
+    """
+    if cli_nodes is not None:
+        return cli_nodes
+    
+    config_nodes = None
+    if config_path:
+        config_data = load_yaml(config_path)
+        config_nodes = config_data.get("cluster", {}).get("num_nodes")
+
+    if isinstance(config_nodes, int) and config_nodes > 0:
+        return config_nodes
+        
+    print("Warning: Number of nodes not specified in CLI or config, defaulting to 1.")
+    return 1
+
+
+def get_num_gpus(config_path: Optional[str], cli_gpus: Optional[int]) -> int:
+    """
+    Determine the number of GPUs per node to use.
+    Reads from the config file (cluster.gpus_per_node) as default,
+    overrides with CLI argument if provided.
+    """
+    if cli_gpus is not None:
+        return cli_gpus
+    
+    config_gpus = None
+    if config_path:
+        config_data = load_yaml(config_path)
+        config_gpus = config_data.get("cluster", {}).get("gpus_per_node")
+
+    if isinstance(config_gpus, int) and config_gpus > 0:
+        return config_gpus
+        
+    print("Warning: Number of GPUs per node not specified in CLI or config, defaulting to 8.")
+    return 8
+
+
+def get_checkpoint_hash(dcp_ckpt_path: str, dcp_config: str) -> str:
+    """
+    Generate a consistent hash based on the DCP checkpoint path and config.
+    
+    Returns:
+        str: A hash string that uniquely identifies this checkpoint
+    """
+    # Normalize paths to ensure consistency
+    normalized_ckpt = os.path.abspath(dcp_ckpt_path)
+    normalized_config = os.path.abspath(dcp_config)
+    
+    # Create a unique identifier from both paths
+    identifier = f"{normalized_ckpt}:{normalized_config}"
+    
+    # Generate a hash
+    hash_obj = hashlib.md5(identifier.encode())
+    return hash_obj.hexdigest()[:16]  # Use first 16 chars for readability
+
+
+def get_hf_checkpoint_path(dcp_ckpt_path: str, dcp_config: str, log_dir: str) -> str:
+    """
+    Get the path where the HF checkpoint should be stored.
+    
+    Returns:
+        str: Path to the HF checkpoint directory
+    """
+    checkpoint_hash = get_checkpoint_hash(dcp_ckpt_path, dcp_config)
+    hf_checkpoints_dir = os.path.join(log_dir, "hf_eval_checkpoints")
+    
+    # Extract model name from path for readability
+    path_parts = dcp_ckpt_path.strip('/').split('/')
+    model_identifier = ""
+    for part in reversed(path_parts):
+        if part and part != "weights" and part != "policy" and part != "actor":
+            model_identifier = part
+            break
+    
+    # Create a descriptive directory name with hash
+    checkpoint_name = f"{model_identifier}_{checkpoint_hash}" if model_identifier else checkpoint_hash
+    return os.path.join(hf_checkpoints_dir, checkpoint_name)
+
+
+def create_conversion_command(
+    dcp_ckpt_path: str,
+    dcp_config: str,
+    hf_ckpt_path: str,
+    force_conversion: bool = False
+) -> str:
+    """
+    Create the command to convert DCP to HF format, with caching logic.
+    
+    Returns:
+        str: Shell command to execute for conversion
+    """
+    # Create a lock file path based on the checkpoint hash
+    lock_file = f"{hf_ckpt_path}.lock"
+    
+    if force_conversion:
+        # Force conversion case - delete existing and always convert with locking
+        conversion_cmd = (
+            f"mkdir -p $(dirname '{hf_ckpt_path}') && "
+            f"exec 200>'{lock_file}' && "
+            f"if flock -n 200; then "
+            f"echo 'Force conversion enabled, removing existing checkpoint if present...' && "
+            f"rm -rf '{hf_ckpt_path}' && "
+            f"echo 'Converting DCP to HF format (forced)...' && "
+            f"uv run python examples/convert_dcp_to_hf.py "
+            f"--config {dcp_config} "
+            f"--dcp-ckpt-path {dcp_ckpt_path} "
+            f"--hf-ckpt-path {hf_ckpt_path} && "
+            f"echo 'Successfully converted checkpoint to: {hf_ckpt_path}'; "
+            f"flock -u 200; "
+            f"else "
+            f"echo 'Another process is force converting, waiting for completion...' && "
+            f"flock 200 && "
+            f"echo 'Force conversion completed by another process'; "
+            f"fi; "
+            f"exec 200>&-"  # Close the file descriptor
+        )
+    else:
+        # Normal case - check cache first with lock file for race condition handling
+        conversion_cmd = (
+            # First check if conversion is already complete
+            f"if [ -d '{hf_ckpt_path}' ] && [ -f '{hf_ckpt_path}/config.json' ]; then "
+            f"echo 'Found cached HF checkpoint at: {hf_ckpt_path}' && "
+            f"echo 'Using cached checkpoint, skipping conversion'; "
+            f"else "
+            # Try to acquire lock for conversion
+            f"mkdir -p $(dirname '{hf_ckpt_path}') && "
+            f"exec 200>'{lock_file}' && "
+            f"if flock -n 200; then "
+            # We got the lock, check again if someone else completed it while we were waiting
+            f"if [ -d '{hf_ckpt_path}' ] && [ -f '{hf_ckpt_path}/config.json' ]; then "
+            f"echo 'Another process completed conversion, using cached checkpoint'; "
+            f"else "
+            # Proceed with conversion
+            f"echo 'Acquired lock, converting DCP to HF format...' && "
+            f"uv run python examples/convert_dcp_to_hf.py "
+            f"--config {dcp_config} "
+            f"--dcp-ckpt-path {dcp_ckpt_path} "
+            f"--hf-ckpt-path {hf_ckpt_path} && "
+            f"echo 'Successfully converted checkpoint to: {hf_ckpt_path}'; "
+            f"fi; "
+            f"flock -u 200; "
+            f"else "
+            # Could not get lock, wait for the other process
+            f"echo 'Another process is converting, waiting for completion...' && "
+            f"flock 200 && "
+            f"echo 'Conversion completed by another process'; "
+            f"fi; "
+            f"exec 200>&-; "  # Close the file descriptor
+            f"fi"
+        )
+    
+    return conversion_cmd
+
+
+def verify_with_sweep(sweep_config: Dict[str, Any], config_path: Optional[str]) -> Optional[str]:
+    """
+    Verify the sweep config and determine the final config path.
+
+    Args:
+        sweep_config: The loaded sweep configuration
+        config_path: Config path from command line (if any)
+
+    Returns:
+        str: The determined config path (can be None)
+    
+    Raises:
+        AssertionError: If inconsistencies are found between CLI and sweep config.
+    """
+    sweep_config_path = sweep_config.get("config_path")
+
+    # Determine config path
+    if config_path is None:
+        # Use config path from sweep if available
+        final_config_path = sweep_config_path 
+    else:
+        final_config_path = config_path
+        if sweep_config_path and final_config_path != sweep_config_path:
+            raise AssertionError(
+                f"Command line config '{final_config_path}' does not match "
+                f"sweep config config_path '{sweep_config_path}'. Please ensure consistency."
+            )
+    
+    return final_config_path
+
+
+def generate_parameter_combinations(sweep_config: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Generate all combinations of parameters from the sweep config."""
+    # Remove config_path from the parameters to sweep over (similar to script_path in original launcher)
+    sweep_params = {k: v for k, v in sweep_config.items() if k not in ["config_path"]}
+    
+    # Extract parameter names and their values
+    param_names = list(sweep_params.keys())
+    param_values = [sweep_params[name] for name in param_names]
+    
+    # Generate all combinations
+    combinations = []
+    for values in itertools.product(*param_values):
+        param_dict = dict(zip(param_names, values))
+        combinations.append(param_dict)
+    
+    return combinations
+
+
+def parse_extra_args(extra_args: List[str]) -> Dict[str, Any]:
+    """Parse extra arguments into a dictionary of parameter overrides."""
+    if not extra_args:
+        return {}
+    
+    # Filter out the '--' separator
+    filtered_args = [arg for arg in extra_args if arg != '--']
+    if not filtered_args:
+        return {}
+    
+    # Parse arguments into a dictionary
+    overrides = {}
+    for arg in filtered_args:
+        if '=' in arg:
+            key, value = arg.split('=', 1)
+            # Remove leading dashes if present
+            key = key.lstrip('-')
+            # Try to convert value to appropriate type
+            try:
+                if value.lower() == 'true':
+                    value = True
+                elif value.lower() == 'false':
+                    value = False
+                elif value.isdigit():
+                    value = int(value)
+                elif value.replace('.', '', 1).isdigit() and value.count('.') == 1:
+                    value = float(value)
+            except ValueError:
+                pass
+            overrides[key] = value
+        else:
+            # Handle boolean flags
+            key = arg.lstrip('-')
+            overrides[key] = True
+    
+    return overrides
+
+
+def format_parameter_override(param_dict: Dict[str, Any]) -> str:
+    """Format parameter dictionary into command line override string."""
+    overrides = []
+    for key, value in param_dict.items():
+        if isinstance(value, str):
+            overrides.append(f"{key}='{value}'")
+        else:
+            overrides.append(f"{key}={value}")
+    return " ".join(overrides)
+
+
+def launch_eval_experiment(
+    config: Optional[str],
+    model_path: str,
+    param_overrides: str,
+    nodes: int,
+    gpus_per_node: int,
+    time: str,
+    account: str,
+    partition: str,
+    container: str,
+    mounts: str,
+    job_name: str,
+    conversion_cmd: Optional[str] = None,
+    hf_checkpoint_path: Optional[str] = None,
+    dry_run: bool = False,
+    extra_args: List[str] = None,
+) -> Tuple[str, Optional[str]]:
+    """Launch a single evaluation experiment using Slurm."""
+    # Construct the evaluation command
+    eval_command = f"uv run examples/run_eval.py"
+    if config:
+        eval_command += f" --config {config}"
+    
+    log_dir = os.path.join(LOG_DIR, job_name)
+    
+    # Parse extra arguments into overrides
+    all_args = list(extra_args) if extra_args else []
+    
+    # If we have a conversion command, use the HF checkpoint path directly
+    if conversion_cmd and hf_checkpoint_path:
+        model_path_arg = f"generation.model_name={hf_checkpoint_path}"
+    else:
+        model_path_arg = f"generation.model_name={model_path}"
+    
+    default_args = [
+        model_path_arg,
+        f"cluster.num_nodes={nodes}",
+        f"cluster.gpus_per_node={gpus_per_node}",
+    ]
+    all_args.extend(default_args)
+    extra_overrides = parse_extra_args(all_args)
+    
+    # If we have parameter overrides, parse them and merge with extra overrides
+    if param_overrides:
+        # Split the param_overrides string into key-value pairs
+        param_dict = {}
+        for param in param_overrides.split():
+            if '=' in param:
+                key, value = param.split('=', 1)
+                # Remove quotes if present
+                value = value.strip("'")
+                param_dict[key] = value
+        
+        # Update with extra overrides (they take precedence)
+        param_dict.update(extra_overrides)
+        eval_command += " " + format_parameter_override(param_dict)
+    elif extra_overrides:
+        # If no param_overrides but we have extra_overrides, use those
+        eval_command += " " + format_parameter_override(extra_overrides)
+    
+    # Combine conversion and evaluation commands
+    if conversion_cmd:
+        # The conversion command sets HF_MODEL_PATH, so we need to ensure it's available for the eval command
+        full_command = f"{conversion_cmd} && {eval_command}"
+    else:
+        full_command = eval_command
+    
+    # Construct the sbatch command
+    sbatch_cmd = [
+        f"BASE_LOG_DIR={log_dir}",
+        f"NUM_ACTOR_NODES={nodes}",
+        f"CONTAINER=\"{container}\"",
+        f"MOUNTS=\"{mounts}\"",
+        f"COMMAND=\"{full_command}\"",
+        "sbatch",
+        f"--nodes={nodes}",
+        f"--account={account}",
+        f"--job-name={job_name}",
+        f"--partition={partition}",
+        f"--time={time}",
+        f"--gres=gpu:{gpus_per_node}",
+        "ray.sub",
+    ]
+    
+    # Join the command
+    full_cmd = " \\\n".join(sbatch_cmd)
+    
+    if dry_run:
+        # For dry run, show the command that will be executed
+        if conversion_cmd:
+            print("\n--- Command that will be executed ---")
+            print(full_command)
+            print("--- End of command ---\n")
+        return full_cmd, None
+    else:
+        result = subprocess.run(full_cmd, shell=True, capture_output=True, text=True)
+        if result.returncode != 0:
+            print(f"Error submitting job: {result.stderr}")
+            return full_cmd, None
+        job_id = result.stdout.strip() if result.stdout else None
+        return full_cmd, job_id
+
+
+def print_experiment_info(
+    job_name: str,
+    params: Dict[str, Any],
+    cmd: str,
+    job_id: Optional[str] = None,
+    dry_run: bool = False,
+) -> None:
+    """Print information about an experiment in a consistent format."""
+    print(f"\n[{job_name}]")
+    print("Parameters:")
+    for key, value in params.items():
+        print(f"  {key}: {value}")
+    print("\nCommand:")
+    print(cmd)
+    if not dry_run and job_id:
+        print(f"\nSubmitted batch job {job_id}")
+    print("\n" + "="*80 + "\n")
+
+
+def main():
+    """Main entry point."""
+    args, extra_args = parse_args()
+    
+    # Handle sweep config and verify consistency
+    config_path = args.config
+    param_combinations = [{}]  # Default to no parameters
+    
+    if args.sweep:
+        sweep_config = load_yaml(args.sweep)
+        config_path = verify_with_sweep(sweep_config, args.config)
+        param_combinations = generate_parameter_combinations(sweep_config)
+    
+    # Handle checkpoint paths
+    model_path = None
+    conversion_cmd = None
+    hf_checkpoint_path = None
+    
+    if args.dcp_ckpt_path and not args.skip_conversion:
+        if not args.dcp_config:
+            raise ValueError("--dcp-config must be provided when converting DCP checkpoint")
+        
+        # Get the HF checkpoint path (either specified or auto-generated)
+        if args.hf_ckpt_path:
+            hf_checkpoint_path = args.hf_ckpt_path
+        else:
+            # Use the smart caching system
+            hf_checkpoint_path = get_hf_checkpoint_path(
+                args.dcp_ckpt_path, 
+                args.dcp_config,
+                LOG_DIR
+            )
+        
+        print(f"\n=== DCP to HF Conversion Setup ===")
+        print(f"DCP checkpoint: {args.dcp_ckpt_path}")
+        print(f"HF checkpoint will be at: {hf_checkpoint_path}")
+        
+        # Create the conversion command
+        conversion_cmd = create_conversion_command(
+            args.dcp_ckpt_path,
+            args.dcp_config,
+            hf_checkpoint_path,
+            args.force_conversion
+        )
+        
+        # Model path will be set to the HF checkpoint path
+        model_path = hf_checkpoint_path
+        
+    elif args.skip_conversion and args.hf_ckpt_path:
+        model_path = args.hf_ckpt_path
+    else:
+        # Check if model path is provided in extra args
+        for arg in extra_args:
+            if arg.startswith("generation.model_name="):
+                model_path = arg.split("=", 1)[1].strip("'\"")
+                break
+    
+    if not model_path:
+        raise ValueError("Model path must be provided either through checkpoint conversion or generation.model_name parameter")
+    
+    # Determine the number of nodes and GPUs using the verified config path
+    num_nodes = get_num_nodes(config_path, args.nodes)
+    num_gpus = get_num_gpus(config_path, args.gpus)
+    
+    # Print header
+    mode = "DRY RUN" if args.dry else "SUBMITTING"
+    print(f"\n=== {mode} - Evaluation Experiments ===\n")
+    if config_path:
+        print(f"Config: {config_path}")
+    if conversion_cmd:
+        print(f"Model: Will be converted from DCP checkpoint")
+        print(f"Target HF path: {hf_checkpoint_path}")
+    else:
+        print(f"Model: {model_path}")
+    print(f"Nodes: {num_nodes}")
+    print(f"GPUs per node: {num_gpus}")
+    
+    # Launch experiments
+    for i, params in enumerate(param_combinations):
+        # Format parameter overrides
+        param_overrides = format_parameter_override(params)
+        
+        # Generate job name if not provided
+        job_name = args.jobname or "eval"
+        if len(param_combinations) > 1:
+            job_name = f"{job_name}_sweep_{i+1}"
+        
+        # Launch experiment
+        cmd, job_id = launch_eval_experiment(
+            config=config_path,
+            model_path=model_path,
+            param_overrides=param_overrides,
+            nodes=num_nodes,
+            gpus_per_node=num_gpus,
+            time=args.time,
+            account=args.account,
+            partition=args.partition,
+            container=args.container,
+            mounts=args.mounts,
+            job_name=job_name,
+            conversion_cmd=conversion_cmd,
+            hf_checkpoint_path=hf_checkpoint_path,
+            dry_run=args.dry,
+            extra_args=extra_args,
+        )
+        
+        # Print experiment info
+        print_experiment_info(
+            job_name=job_name,
+            params=params,
+            cmd=cmd,
+            job_id=job_id,
+            dry_run=args.dry,
+        )
+
+
+if __name__ == "__main__":
+    main() 

--- a/xp/eval_launcher_README.md
+++ b/xp/eval_launcher_README.md
@@ -1,0 +1,289 @@
+# Evaluation Launcher for NeMo RL
+
+The `eval_launcher.py` script provides a convenient way to launch evaluation experiments on SLURM clusters with automatic DCP to HuggingFace checkpoint conversion and parameter sweeps.
+
+## Features
+
+- **Smart Checkpoint Caching**: Automatically caches converted HF checkpoints to avoid redundant conversions
+- **Race Condition Protection**: Uses file locking to prevent multiple jobs from converting the same checkpoint simultaneously
+- **Force Re-conversion**: Option to delete and re-convert existing checkpoints
+- **In-Job Conversion**: DCP to HF conversion happens inside the SLURM job, not on the login node
+- **SLURM Resource Management**: Handles job submission with configurable resources
+- **Parameter Sweeps**: Support for sweeping over multiple evaluation parameters
+- **Dry Run Mode**: Preview commands before execution
+
+## How It Works
+
+### Smart Caching System
+
+When converting DCP checkpoints:
+1. The script generates a unique hash based on the DCP checkpoint path and config file
+2. Converted checkpoints are stored in `$LOG/nemo-rl/hf_eval_checkpoints/` with descriptive names
+3. Before conversion, the script checks if a cached version already exists
+4. If found, it uses the cached checkpoint; otherwise, it performs the conversion
+5. All conversion happens inside the SLURM job to utilize compute resources
+
+### Race Condition Handling
+
+When multiple jobs try to convert the same checkpoint:
+1. The script uses file locking (`flock`) to ensure only one job performs the conversion
+2. Other jobs wait for the conversion to complete and then use the converted checkpoint
+3. This prevents duplicate work and potential file corruption from concurrent writes
+
+### Force Conversion
+
+When `--force-conversion` is used:
+1. Any existing converted checkpoint is deleted first
+2. A fresh conversion is performed regardless of cache status
+3. This is useful when you suspect the cached version is corrupted or outdated
+
+## Usage
+
+### Basic Evaluation
+
+Evaluate a HuggingFace model:
+```bash
+python xp/eval_launcher.py generation.model_name=meta-llama/Llama-3.2-1B-Instruct
+```
+
+### Evaluate with DCP Checkpoint Conversion
+
+Convert a DCP checkpoint and evaluate (with automatic caching):
+```bash
+python xp/eval_launcher.py \
+    --dcp-ckpt-path results/grpo/step_170/policy/weights/ \
+    --dcp-config results/grpo/step_170/config.yaml
+```
+
+The converted checkpoint will be cached at:
+`$LOG/nemo-rl/hf_eval_checkpoints/step_170_<hash>/`
+
+### Force Re-conversion
+
+To delete existing cache and force re-conversion:
+```bash
+python xp/eval_launcher.py \
+    --dcp-ckpt-path results/grpo/step_170/policy/weights/ \
+    --dcp-config results/grpo/step_170/config.yaml \
+    --force-conversion
+```
+
+### Specify Custom HF Path
+
+To save the converted checkpoint at a specific location:
+```bash
+python xp/eval_launcher.py \
+    --dcp-ckpt-path results/grpo/step_170/policy/weights/ \
+    --dcp-config results/grpo/step_170/config.yaml \
+    --hf-ckpt-path /custom/path/to/hf_checkpoint
+```
+
+### Multi-node Evaluation
+
+Run evaluation on multiple nodes:
+```bash
+python xp/eval_launcher.py \
+    --nodes 2 \
+    --gpus 8 \
+    generation.model_name=Qwen/Qwen2.5-32B \
+    generation.vllm_cfg.tensor_parallel_size=4
+```
+
+### Parameter Sweeps
+
+Create a sweep configuration file (e.g., `eval_sweep.yaml`):
+```yaml
+# Optional: Specify the config file to use for all experiments
+config_path: examples/configs/eval.yaml
+
+# Parameters to sweep over
+generation.temperature: [0.6, 0.8, 1.0]
+generation.top_p: [0.9, 0.95]
+eval.num_tests_per_prompt: [8, 16]
+data.dataset_name: ["HuggingFaceH4/MATH-500", "openai/gsm8k"]
+```
+
+Run the sweep:
+```bash
+python xp/eval_launcher.py \
+    --sweep eval_sweep.yaml \
+    --dcp-ckpt-path results/grpo/step_170/policy/weights/ \
+    --dcp-config results/grpo/step_170/config.yaml
+```
+
+**Config Path Handling:**
+- If `config_path` is specified in the sweep file, it will be used for all experiments
+- If both `--config` CLI argument and `config_path` in sweep file are provided, they must match
+- If neither is provided, the script will use its default config handling
+
+When using sweeps with the same checkpoint, the conversion only happens once due to the caching system. Multiple jobs will coordinate through file locking to avoid race conditions.
+
+### Custom Evaluation Config
+
+Use a custom evaluation configuration:
+```bash
+python xp/eval_launcher.py \
+    --config examples/configs/eval_custom.yaml \
+    generation.model_name=agentica-org/DeepScaleR-1.5B-Preview
+```
+
+## Command Line Arguments
+
+### Evaluation Arguments
+- `--config`: Path to evaluation config YAML file (default: examples/configs/eval.yaml)
+- `--sweep`: Path to sweep config YAML file for parameter sweeps
+
+### Checkpoint Conversion Arguments
+- `--dcp-ckpt-path`: Path to DCP checkpoint to convert
+- `--dcp-config`: Path to config file for DCP checkpoint (required with --dcp-ckpt-path)
+- `--hf-ckpt-path`: Path to save converted HF checkpoint (optional, auto-generated with caching if not provided)
+- `--skip-conversion`: Skip checkpoint conversion (use with pre-converted checkpoints)
+- `--force-conversion`: Force re-conversion even if cached version exists (deletes existing cache first)
+
+### SLURM Arguments
+- `--nodes`: Number of nodes to use (default: from config or 1)
+- `--gpus`: Number of GPUs per node (default: 8)
+- `--time`: Time limit for the job (default: "2:0:0")
+- `--account`: SLURM account to use
+- `--partition`: SLURM partition to use (default: "batch")
+- `--container`: Container to use
+- `--mounts`: Mount points (default: "/lustre:/lustre")
+- `--jobname`: Base name for the job (default: "eval")
+- `--dry`: Print commands without executing (dry run mode)
+
+### Additional Parameters
+Any additional parameters can be passed directly and will be forwarded to the evaluation script:
+```bash
+python xp/eval_launcher.py \
+    generation.model_name=model_path \
+    data.dataset_name=HuggingFaceH4/MATH-500 \
+    eval.num_tests_per_prompt=16
+```
+
+## Examples
+
+### Example 1: Evaluate DeepScaleR on MATH-500
+```bash
+python xp/eval_launcher.py \
+    --nodes 1 \
+    --gpus 8 \
+    --time "4:0:0" \
+    generation.model_name=agentica-org/DeepScaleR-1.5B-Preview \
+    generation.temperature=0.6 \
+    generation.top_p=0.95 \
+    generation.vllm_cfg.max_model_len=32768 \
+    data.dataset_name=HuggingFaceH4/MATH-500 \
+    data.dataset_key=test \
+    eval.num_tests_per_prompt=16
+```
+
+### Example 2: Convert and Evaluate GRPO Checkpoint (with caching)
+```bash
+python xp/eval_launcher.py \
+    --dcp-ckpt-path /path/to/grpo/checkpoint/weights/ \
+    --dcp-config /path/to/grpo/checkpoint/config.yaml \
+    --nodes 2 \
+    --jobname grpo_eval \
+    data.dataset_name=openai/gsm8k
+```
+
+### Example 3: Dry Run with Sweep
+```bash
+python xp/eval_launcher.py \
+    --dry \
+    --sweep xp/eval_sweep_example.yaml \
+    --dcp-ckpt-path results/checkpoint/weights/ \
+    --dcp-config results/checkpoint/config.yaml
+```
+
+### Example 4: View What Commands Will Be Run
+Use dry run to see the full command that will be executed inside the SLURM job:
+```bash
+python xp/eval_launcher.py \
+    --dry \
+    --dcp-ckpt-path results/grpo/step_170/policy/weights/ \
+    --dcp-config results/grpo/step_170/config.yaml
+```
+
+### Example 5: Force Re-conversion for Updated Checkpoint
+```bash
+python xp/eval_launcher.py \
+    --dcp-ckpt-path results/grpo/final/policy/weights/ \
+    --dcp-config results/grpo/final/config.yaml \
+    --force-conversion \
+    --jobname grpo_final_fresh
+```
+
+## Environment Variables
+
+The script uses the following environment variables with defaults:
+- `LOG`: Base log directory (default: "/tmp")
+- `ACCOUNT`: SLURM account (default: "default")
+- `CON`: Container directory (default: "/containers")
+
+## Notes
+
+1. **Caching System**: The script uses MD5 hashing of the checkpoint paths to create unique identifiers for cached checkpoints
+2. **Race Condition Protection**: File locking ensures that only one job performs the conversion when multiple jobs are launched simultaneously
+3. **Force Conversion**: The `--force-conversion` flag deletes any existing converted checkpoint before re-converting
+4. **In-Job Conversion**: All DCP to HF conversion happens inside the SLURM job, utilizing compute resources efficiently
+5. **Automatic Path Detection**: The script extracts meaningful identifiers from checkpoint paths for readable cache directory names
+6. **Error Handling**: If conversion fails, the job will exit with an error message
+
+## Cache Directory Structure
+
+Converted checkpoints are stored as:
+```
+$LOG/nemo-rl/hf_eval_checkpoints/
+├── step_170_a1b2c3d4e5f6g7h8/
+│   ├── config.json
+│   ├── model.safetensors
+│   └── ...
+├── step_170_a1b2c3d4e5f6g7h8.lock  (temporary during conversion)
+├── checkpoint_final_9i8j7k6l5m4n3o2/
+│   └── ...
+└── ...
+```
+
+Where the directory name format is: `<checkpoint_identifier>_<hash>`
+
+## Troubleshooting
+
+### Multiple Jobs Converting Same Checkpoint
+If you launch multiple evaluation jobs with the same DCP checkpoint:
+- The first job to acquire the lock will perform the conversion
+- Other jobs will wait and use the converted checkpoint once ready
+- You'll see messages like "Another process is converting, waiting for completion..."
+
+### Corrupted or Outdated Cache
+If you suspect the cached checkpoint is corrupted or outdated:
+- Use `--force-conversion` to delete and re-convert
+- Check the conversion logs for any errors
+- Verify the checkpoint files exist and are readable
+
+### Config Path Conflicts
+If you get an assertion error about config path mismatch:
+- Either remove `--config` from command line and let sweep file specify it
+- Or remove `config_path` from sweep file and use `--config` CLI argument
+- Or ensure both specify the exact same path
+
+Example error and solutions:
+```
+AssertionError: Command line config 'configs/eval_custom.yaml' does not match sweep config config_path 'configs/eval.yaml'
+```
+
+**Solution 1:** Use sweep file config
+```bash
+python xp/eval_launcher.py --sweep my_sweep.yaml  # Remove --config
+```
+
+**Solution 2:** Use CLI config
+```yaml
+# Remove config_path from sweep file
+generation.temperature: [0.6, 0.8]
+```
+
+**Solution 3:** Make them match
+```bash
+python xp/eval_launcher.py --config configs/eval.yaml --sweep my_sweep.yaml
+``` 

--- a/xp/launcher.py
+++ b/xp/launcher.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import itertools
+import os
+import subprocess
+from typing import Any, Dict, List, Tuple, Optional
+import time
+import yaml
+import sys # Added for countdown timer
+
+
+# Environment variables
+LOG_DIR = os.environ["LOG"] + "/nemo-rl"
+ACCOUNT = os.environ["ACCOUNT"]
+CONTAINER = os.environ["CON"] + "/nemo_rl_base.sqsh"
+MOUNTS = "/lustre:/lustre"
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Launch Slurm experiments with parameter sweeps")
+    parser.add_argument("--script", type=str, default=None, help="Path to the Python script to run")
+    parser.add_argument("--config", type=str, default=None, help="Path to the base YAML config file")
+    parser.add_argument("--sweep", type=str, default=None, help="Path to the sweep config YAML file")
+    parser.add_argument("--nodes", type=int, default=None, help="Number of nodes to use")
+    parser.add_argument("--time", type=str, default="4:0:0", help="Time limit for the job")
+    parser.add_argument("--account", type=str, default=ACCOUNT, help="Slurm account to use")
+    parser.add_argument("--partition", type=str, default="batch", help="Slurm partition to use")
+    parser.add_argument("--container", type=str, default=CONTAINER, help="Container to use")
+    parser.add_argument("--mounts", type=str, default=MOUNTS, help="Mounts to use")
+    parser.add_argument("--jobname", type=str, default=None, help="Base name for the job")
+    parser.add_argument("--dry", action="store_true", help="Print commands without executing them")
+    parser.add_argument("--sleep", type=int, default=0, help="Sleep time in seconds between jobs")
+    args, extra_args = parser.parse_known_args()
+    return args, extra_args
+
+
+def load_yaml(file_path: str) -> Dict[str, Any]:
+    """Load a YAML file."""
+    try:
+        with open(file_path, "r") as f:
+            return yaml.safe_load(f)
+    except FileNotFoundError:
+        print(f"Warning: Config file not found at {file_path}. Using default node count.")
+        return {}
+    except yaml.YAMLError as e:
+        print(f"Warning: Error parsing YAML file {file_path}: {e}. Using default node count.")
+        return {}
+
+
+def get_num_nodes(config_path: Optional[str], cli_nodes: Optional[int]) -> int:
+    """
+    Determine the number of nodes to use.
+    Reads from the config file (cluster.num_nodes) as default,
+    overrides with CLI argument if provided.
+    """
+    # Prioritize CLI argument
+    if cli_nodes is not None:
+        return cli_nodes
+    
+    config_nodes = None
+    if config_path:
+        config_data = load_yaml(config_path)
+        config_nodes = config_data.get("cluster", {}).get("num_nodes")
+
+    # Use config value if valid
+    if isinstance(config_nodes, int) and config_nodes > 0:
+        return config_nodes
+        
+    # Default to 1 node if not specified or invalid
+    print("Warning: Number of nodes not specified in CLI or config, defaulting to 1.")
+    return 1
+
+
+def verify_with_sweep(sweep_config: Dict[str, Any], script_path: Optional[str], config_path: Optional[str]) -> Tuple[str, str]:
+    """
+    Verify the sweep config and determine the final script and config paths.
+
+    Returns:
+        Tuple[str, str]: The determined script path and config path.
+    Raises:
+        AssertionError: If inconsistencies are found or required paths are missing.
+    """
+    sweep_script_path = sweep_config.get("script_path")
+    sweep_config_path = sweep_config.get("config_path")
+
+    # Determine script path
+    if script_path is None:
+        final_script_path = sweep_script_path
+    else:
+        final_script_path = script_path
+        if sweep_script_path and final_script_path != sweep_script_path:
+            raise AssertionError(
+               f"Command line script '{os.path.basename(final_script_path)}' does not match "
+               f"sweep config script_name '{sweep_script_path}'. Please ensure consistency."
+            )
+
+    # Determine config path
+    if config_path is None:
+        # config_path can be None if not provided by CLI or sweep
+        final_config_path = sweep_config_path 
+    else:
+        final_config_path = config_path
+        if sweep_config_path and final_config_path != sweep_config_path:
+            raise AssertionError(
+                f"Command line config '{final_config_path}' does not match "
+                f"sweep config config_path '{sweep_config_path}'. Please ensure consistency."
+            )
+    
+    if final_script_path is None:
+        raise AssertionError(
+            "Script path must be provided either via --script in command line or 'script_path' in the sweep config."
+        )
+
+    return final_script_path, final_config_path
+
+
+def generate_parameter_combinations(sweep_config: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Generate all combinations of parameters from the sweep config."""
+    # Remove script_name from the parameters to sweep over
+    sweep_params = {k: v for k, v in sweep_config.items() if k not in ["script_path", "config_path"]}
+    
+    # Extract parameter names and their values
+    param_names = list(sweep_params.keys())
+    param_values = [sweep_params[name] for name in param_names]
+    
+    # Generate all combinations
+    combinations = []
+    for values in itertools.product(*param_values):
+        param_dict = dict(zip(param_names, values))
+        combinations.append(param_dict)
+    
+    return combinations
+
+
+def parse_extra_args(extra_args: List[str]) -> Dict[str, Any]:
+    """Parse extra arguments into a dictionary of parameter overrides."""
+    if not extra_args:
+        return {}
+    
+    # Filter out the '--' separator
+    filtered_args = [arg for arg in extra_args if arg != '--']
+    if not filtered_args:
+        return {}
+    
+    # Parse arguments into a dictionary
+    overrides = {}
+    for arg in filtered_args:
+        if '=' in arg:
+            key, value = arg.split('=', 1)
+            # Remove leading dashes if present
+            key = key.lstrip('-')
+            # Try to convert value to appropriate type
+            try:
+                if value.lower() == 'true':
+                    value = True
+                elif value.lower() == 'false':
+                    value = False
+                elif value.isdigit():
+                    value = int(value)
+                elif value.replace('.', '', 1).isdigit() and value.count('.') == 1:
+                    value = float(value)
+            except ValueError:
+                pass
+            overrides[key] = value
+        else:
+            # Handle boolean flags
+            key = arg.lstrip('-')
+            overrides[key] = True
+    
+    return overrides
+
+
+def format_parameter_override(param_dict: Dict[str, Any]) -> str:
+    """Format parameter dictionary into command line override string."""
+    overrides = []
+    for key, value in param_dict.items():
+        if isinstance(value, str):
+            overrides.append(f"{key}='{value}'")
+        else:
+            overrides.append(f"{key}={value}")
+    return " ".join(overrides)
+
+
+def launch_experiment(
+    script: str,
+    config: Optional[str],
+    param_overrides: str,
+    nodes: int,
+    time: str,
+    account: str,
+    partition: str,
+    container: str,
+    mounts: str,
+    job_name: str,
+    dry_run: bool = False,
+    extra_args: List[str] = None,
+) -> Tuple[str, Optional[str]]:
+    """Launch a single experiment using Slurm."""
+    # Construct the command
+    command = f"uv run {script}"
+    if config:
+        command += f" --config {config}"
+    
+    log_dir = os.path.join(LOG_DIR, job_name)
+    checkpoint_dir = os.path.join(log_dir, "checkpoints")
+    
+    # Parse extra arguments into overrides
+    # Add default args before parsing extra args
+    all_args = list(extra_args) if extra_args else []
+    default_args = [
+        f"logger.log_dir={log_dir}",
+        "logger.wandb_enabled=True",
+        f"logger.wandb.name={job_name}",
+        f"checkpointing.checkpoint_dir={checkpoint_dir}",
+        f"cluster.num_nodes={nodes}"
+    ]
+    all_args.extend(default_args)
+    extra_overrides = parse_extra_args(all_args)
+    
+    # If we have parameter overrides, parse them and merge with extra overrides
+    if param_overrides:
+        # Split the param_overrides string into key-value pairs
+        param_dict = {}
+        for param in param_overrides.split():
+            if '=' in param:
+                key, value = param.split('=', 1)
+                # Remove quotes if present
+                value = value.strip("'")
+                param_dict[key] = value
+        
+        # Update with extra overrides (they take precedence)
+        param_dict.update(extra_overrides)
+        command += " " + format_parameter_override(param_dict)
+    elif extra_overrides:
+        # If no param_overrides but we have extra_overrides, use those
+        command += " " + format_parameter_override(extra_overrides)
+    
+    # Construct the sbatch command
+    sbatch_cmd = [
+        f"BASE_LOG_DIR={log_dir}",
+        f"NUM_ACTOR_NODES={nodes}",
+        f"CONTAINER=\"{container}\"",
+        f"MOUNTS=\"{mounts}\"",
+        f"COMMAND=\"{command}\"",
+        "sbatch",
+        f"--nodes={nodes}",
+        f"--account={account}",
+        f"--job-name={job_name}",
+        f"--partition={partition}",
+        f"--time={time}",
+        "--gres=gpu:8",
+        "ray.sub",
+    ]
+    
+    # Join the command
+    full_cmd = " \\\n".join(sbatch_cmd)
+    
+    if dry_run:
+        return full_cmd, None
+    else:
+        result = subprocess.run(full_cmd, shell=True, capture_output=True, text=True)
+        job_id = result.stdout.strip() if result.stdout else None
+        return full_cmd, job_id
+
+
+def print_experiment_info(
+    job_name: str,
+    params: Dict[str, Any],
+    cmd: str,
+    job_id: Optional[str] = None,
+    dry_run: bool = False,
+) -> None:
+    """Print information about an experiment in a consistent format."""
+    print(f"\n[{job_name}]")
+    print("Parameters:")
+    for key, value in params.items():
+        print(f"  {key}: {value}")
+    print("\nCommand:")
+    print(cmd)
+    if not dry_run and job_id:
+        print(f"\nSubmitted batch job {job_id}")
+    print("\n" + "="*80 + "\n")
+
+
+def main():
+    """Main entry point."""
+    args, extra_args = parse_args()
+
+    script_path, config_path = args.script, args.config
+    
+    # Load sweep config if provided
+    param_combinations = [{}]  # Default to no parameters
+    if args.sweep:
+        sweep_config = load_yaml(args.sweep)
+        script_path, config_path = verify_with_sweep(sweep_config, script_path, config_path)
+        param_combinations = generate_parameter_combinations(sweep_config)
+    elif not script_path:
+         raise ValueError("Script path must be provided via --script or sweep config")
+
+    # Determine the number of nodes after potentially getting config_path from sweep
+    num_nodes = get_num_nodes(config_path, args.nodes)
+    
+    # Print header
+    mode = "DRY RUN" if args.dry else "SUBMITTING"
+    print(f"\n=== {mode} - Experiments ===\n")
+    
+    # Launch experiments
+    for i, params in enumerate(param_combinations):
+        # Format parameter overrides
+        param_overrides = format_parameter_override(params)
+        
+        # Generate job name if not provided
+        job_name = args.jobname or (
+            os.path.splitext(os.path.basename(args.sweep))[0] if args.sweep 
+            else os.path.splitext(os.path.basename(script_path))[0]
+        )
+        if len(param_combinations) > 1:
+            job_name = f"{job_name}_{i+1}"
+        
+        # Launch experiment
+        cmd, job_id = launch_experiment(
+            script=script_path,
+            config=config_path,
+            param_overrides=param_overrides,
+            nodes=num_nodes,
+            time=args.time,
+            account=args.account,
+            partition=args.partition,
+            container=args.container,
+            mounts=args.mounts,
+            job_name=job_name,
+            dry_run=args.dry,
+            extra_args=extra_args,
+        )
+        
+        # Print experiment info
+        print_experiment_info(
+            job_name=job_name,
+            params=params,
+            cmd=cmd,
+            job_id=job_id,
+            dry_run=args.dry,
+        )
+
+        if args.sleep and i < len(param_combinations) - 1: # Don't sleep after the last job
+            print(f"Sumbitted {i+1} of {len(param_combinations)} jobs")
+            print(f"Sleeping for {args.sleep} seconds before the next job...")
+            for remaining in range(args.sleep, 0, -1):
+                sys.stdout.write(f"\rTime remaining: {remaining:2d} seconds")
+                sys.stdout.flush()
+                time.sleep(1)
+            sys.stdout.write("\rDone sleeping.                           \n") # Clear the countdown line
+            sys.stdout.flush()
+        
+        print(f"All {len(param_combinations)} jobs submitted")
+
+
+if __name__ == "__main__":
+    main()

--- a/xp/launcher_README.md
+++ b/xp/launcher_README.md
@@ -1,0 +1,331 @@
+# Experiment Launcher for NeMo RL
+
+The `launcher.py` script provides a convenient way to launch training and experiment jobs on SLURM clusters with automatic resource management and parameter sweeps.
+
+## Features
+
+- **SLURM Job Management**: Handles job submission with configurable resources
+- **Parameter Sweeps**: Support for sweeping over multiple training parameters
+- **Flexible Script Execution**: Run any Python script with configurable arguments
+- **Resource Auto-detection**: Automatically reads cluster configuration from config files
+- **Dry Run Mode**: Preview commands before execution
+- **Automatic Logging Setup**: Sets up logging directories and wandb integration
+
+## How It Works
+
+### Script Execution
+
+The launcher executes Python scripts using `uv run` with:
+1. Configurable base configuration files
+2. Parameter overrides from sweep configs or command line
+3. Automatic logging and checkpoint directory setup
+4. SLURM resource allocation
+
+### Parameter Sweeps
+
+When using parameter sweeps:
+1. Load sweep configuration from YAML file
+2. Generate all combinations of specified parameters
+3. Launch separate SLURM jobs for each parameter combination
+4. Each job gets a unique name and logging directory
+
+### Resource Management
+
+The script automatically:
+1. Reads cluster configuration from config files (`cluster.num_nodes`)
+2. Allows CLI overrides for nodes and other SLURM parameters
+3. Sets up appropriate logging and checkpoint directories
+4. Configures wandb logging with unique job names
+
+## Usage
+
+### Basic Script Execution
+
+Run a training script with default configuration:
+```bash
+python xp/launcher.py \
+    --script examples/train_grpo.py \
+    --config examples/configs/grpo.yaml
+```
+
+### Multi-node Training
+
+Run training on multiple nodes:
+```bash
+python xp/launcher.py \
+    --script examples/train_grpo.py \
+    --config examples/configs/grpo.yaml \
+    --nodes 4 \
+    --time "8:0:0"
+```
+
+### Parameter Sweeps
+
+Create a sweep configuration file (e.g., `grpo_sweep.yaml`):
+```yaml
+# Required: Specify the script to run
+script_path: examples/train_grpo.py
+
+# Optional: Specify the config file to use for all experiments
+config_path: examples/configs/grpo.yaml
+
+# Parameters to sweep over
+grpo.kl_penalty: [0.01, 0.02, 0.05]
+grpo.learning_rate: [1e-6, 5e-6, 1e-5]
+optim.lr: [1e-6, 5e-6, 1e-5]
+model.model_name: ["meta-llama/Llama-3.2-1B", "meta-llama/Llama-3.2-3B"]
+```
+
+Run the sweep:
+```bash
+python xp/launcher.py --sweep grpo_sweep.yaml
+```
+
+**Config Path Handling:**
+- If `config_path` is specified in the sweep file, it will be used for all experiments
+- If both `--config` CLI argument and `config_path` in sweep file are provided, they must match
+- If neither is provided, scripts will run without a base config file
+
+### Custom Parameters
+
+Add custom parameters that will be passed to the script:
+```bash
+python xp/launcher.py \
+    --script examples/train_grpo.py \
+    --config examples/configs/grpo.yaml \
+    model.model_name=meta-llama/Llama-3.2-7B \
+    grpo.kl_penalty=0.02 \
+    optim.lr=5e-6
+```
+
+## Command Line Arguments
+
+### Core Arguments
+- `--script`: Path to the Python script to run (required unless specified in sweep).
+- `--config`: Path to base YAML config file (optional).
+- `--sweep`: Path to sweep config YAML file for parameter sweeps.
+
+### Launcher Control
+- `--jobname`: Base name for the job and logging directories. If not provided, it's inferred from the sweep or script file name.
+- `--dry`: Print commands without executing them (dry run mode).
+- `--sleep`: Time in seconds to sleep between submitting jobs in a sweep (default: 0). A countdown timer will be displayed.
+
+### SLURM Configuration
+- `--nodes`: Number of nodes to use (default: from config or 1).
+- `--time`: Time limit for the job (default: "4:0:0").
+- `--account`: SLURM account to use (defaults to `$ACCOUNT` environment variable).
+- `--partition`: SLURM partition to use (default: "batch").
+- `--container`: Container to use (defaults to `$CON/nemo_rl_base.sqsh`).
+- `--mounts`: Mount points (default: "/lustre:/lustre").
+
+### Additional Parameters
+Any additional parameters can be passed directly and will be forwarded to the script:
+```bash
+python xp/launcher.py \
+    --script examples/train_grpo.py \
+    model.model_name=custom_model \
+    grpo.num_episodes=1000 \
+    logger.wandb.project=my_project
+```
+
+## Examples
+
+### Example 1: Basic GRPO Training
+```bash
+python xp/launcher.py \
+    --script examples/train_grpo.py \
+    --config examples/configs/grpo.yaml \
+    --nodes 2 \
+    --time "6:0:0" \
+    --jobname grpo_llama_7b \
+    model.model_name=meta-llama/Llama-3.2-7B
+```
+
+### Example 2: Parameter Sweep for Learning Rate
+```bash
+# Create sweep_lr.yaml
+cat > sweep_lr.yaml << EOF
+script_path: examples/train_grpo.py
+config_path: examples/configs/grpo.yaml
+optim.lr: [1e-6, 5e-6, 1e-5, 2e-5]
+grpo.kl_penalty: [0.01, 0.02]
+EOF
+
+python xp/launcher.py --sweep sweep_lr.yaml --nodes 2
+```
+
+### Example 3: Multi-Model Comparison
+```bash
+# Create sweep_models.yaml
+cat > sweep_models.yaml << EOF
+script_path: examples/train_grpo.py
+config_path: examples/configs/grpo.yaml
+model.model_name: 
+  - "meta-llama/Llama-3.2-1B"
+  - "meta-llama/Llama-3.2-3B"
+  - "microsoft/DialoGPT-medium"
+grpo.learning_rate: [1e-6, 5e-6]
+EOF
+
+python xp/launcher.py \
+    --sweep sweep_models.yaml \
+    --time "12:0:0" \
+    --jobname model_comparison
+```
+
+### Example 4: Dry Run to Preview Commands
+```bash
+python xp/launcher.py \
+    --dry \
+    --script examples/train_grpo.py \
+    --config examples/configs/grpo.yaml \
+    model.model_name=meta-llama/Llama-3.2-7B
+```
+
+### Example 5: PPO Training with Custom Settings
+```bash
+python xp/launcher.py \
+    --script examples/train_ppo.py \
+    --config examples/configs/ppo.yaml \
+    --nodes 4 \
+    --time "10:0:0" \
+    --jobname ppo_large_model \
+    model.model_name=meta-llama/Llama-3.2-8B \
+    ppo.epochs=4 \
+    ppo.learning_rate=3e-6 \
+    logger.wandb.project=ppo_experiments
+```
+
+### Example 6: Training with Custom Logging
+```bash
+python xp/launcher.py \
+    --script examples/train_grpo.py \
+    --jobname custom_experiment \
+    logger.wandb.project=my_research \
+    logger.wandb.group=grpo_experiments \
+    logger.wandb.tags='["experiment1", "baseline"]'
+```
+
+## Environment Variables
+
+The script uses the following environment variables:
+- `LOG`: Base log directory (required)
+- `ACCOUNT`: SLURM account (required)
+- `CON`: Container directory (required)
+
+These must be set in your environment before running the launcher.
+
+## Automatic Setup
+
+The launcher automatically configures:
+
+1. **Logging Directories**: `$LOG/nemo-rl/{job_name}/`
+2. **Checkpoint Directories**: `$LOG/nemo-rl/{job_name}/checkpoints/`
+3. **Wandb Integration**: Enabled by default with job name as run name
+4. **Cluster Configuration**: Reads from config file or uses CLI overrides
+
+## Sweep Configuration Format
+
+Sweep YAML files support:
+```yaml
+# Required if not provided via CLI
+script_path: path/to/script.py
+
+# Optional base config
+config_path: path/to/config.yaml
+
+# Parameters to sweep - each will be combined with all others
+parameter_name: [value1, value2, value3]
+nested.parameter: [val1, val2]
+boolean_param: [true, false]
+```
+
+The launcher generates all combinations of parameters using itertools.product().
+
+## Job Naming
+
+The base name for a job is determined with the following precedence:
+1. The `--jobname` argument, if provided.
+2. The basename of the sweep file, if `--sweep` is used (e.g., `grpo_sweep` from `grpo_sweep.yaml`).
+3. The basename of the script file (e.g., `train_grpo` from `train_grpo.py`).
+
+For sweeps that generate multiple jobs, a numeric index is appended to the base name for each job (e.g., `{base_name}_1`, `{base_name}_2`, etc.).
+
+## Resource Configuration
+
+### From Config File
+```yaml
+cluster:
+  num_nodes: 2
+  gpus_per_node: 8  # Currently fixed at 8 in sbatch command
+```
+
+### CLI Override
+```bash
+python xp/launcher.py --nodes 4  # Overrides config file
+```
+
+## Notes
+
+1. **Fixed GPU Count**: Currently fixed at 8 GPUs per node in the sbatch command
+2. **Wandb Integration**: Automatically enabled with job name as run name
+3. **Parameter Precedence**: CLI extra args override sweep parameters
+4. **Directory Structure**: Automatically creates organized logging directories
+5. **Error Handling**: Validates configuration consistency between CLI and sweep files
+
+## Troubleshooting
+
+### Script Path Requirements
+If you get an error about missing script path:
+- Provide `--script` on command line, or
+- Add `script_path` to your sweep configuration
+
+### Config Path Conflicts
+If you get an assertion error about config path mismatch:
+```
+AssertionError: Command line config 'configs/custom.yaml' does not match sweep config config_path 'configs/base.yaml'
+```
+
+**Solutions:**
+1. Remove `--config` and let sweep file specify it
+2. Remove `config_path` from sweep file
+3. Ensure both specify the same path
+
+### Environment Variables Not Set
+```bash
+# Set required environment variables
+export LOG="/path/to/logs"
+export ACCOUNT="your_slurm_account" 
+export CON="/path/to/containers"
+```
+
+### Job Submission Failures
+- Check SLURM account permissions
+- Verify partition availability
+- Ensure container path exists
+- Check node availability for requested resources
+
+### Parameter Override Issues
+- Use quotes for string values: `param="string value"`
+- Boolean values: `param=true` or `param=false`
+- Nested parameters: `section.param=value`
+
+## Directory Structure
+
+Each job creates:
+```
+$LOG/nemo-rl/{job_name}/
+├── checkpoints/          # Model checkpoints
+├── logs/                 # Training logs
+├── wandb/               # Wandb run data
+└── ...                  # Other training artifacts
+```
+
+For sweeps, the structure will be based on the indexed job names:
+```
+$LOG/nemo-rl/
+├── {base_name}_1/
+├── {base_name}_2/
+├── {base_name}_3/
+└── ...
+```

--- a/xp/sweep_configs/deepscaler_sweep.yaml
+++ b/xp/sweep_configs/deepscaler_sweep.yaml
@@ -1,0 +1,21 @@
+# Sample sweep configuration for deepscaler experiments
+# Each parameter can have a list of values to sweep over
+# The launcher will generate all possible combinations
+
+# Required parameter that must match the target script name
+script_path: "examples/run_grpo_math.py"
+
+# Optional: Path to the base YAML config file
+# Can be overridden by the --config command-line argument
+# If null and --config is not provided, no base config will be used
+config_path: "examples/configs/grpo-deepscaler-1.5b-8K.yaml" 
+
+
+# ------------------------------------------------------------
+# hyperparameters
+# ------------------------------------------------------------
+policy.model_name: ["deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"]
+
+grpo.num_generations_per_prompt: [8, 16, 32]
+
+# ------------------------------------------------------------

--- a/xp/sweep_configs/eval_qwen2.5-math_small_sweep.yaml
+++ b/xp/sweep_configs/eval_qwen2.5-math_small_sweep.yaml
@@ -1,0 +1,13 @@
+# Example sweep configuration for evaluation experiments
+# This file demonstrates how to sweep over different evaluation parameters
+
+# Optional: Specify the config file to use for all experiments in this sweep
+# If not specified here, must be provided via --config command line argument
+config_path: examples/configs/eval.yaml
+
+generation.model_name: ["Qwen/Qwen2.5-Math-7B"]
+tokenizer.chat_template: ["examples/prompts/quack/qwen2.5-math.jinja"]
+data.prompt_file: ["examples/prompts/quack/math.txt"]
+
+# Different datasets to evaluate on
+data.dataset_name: ["HuggingFaceH4/aime_2024", "HuggingFaceH4/MATH-500"] 

--- a/xp/sweep_configs/grpo_math_sweep.yaml
+++ b/xp/sweep_configs/grpo_math_sweep.yaml
@@ -1,0 +1,18 @@
+# Sample sweep configuration for GRPO math experiments
+# Each parameter can have a list of values to sweep over
+# The launcher will generate all possible combinations
+
+# Required parameter that must match the target script name
+script_path: "examples/run_grpo_math.py"
+
+# Optional: Path to the base YAML config file
+# Can be overridden by the --config command-line argument
+# If null and --config is not provided, no base config will be used
+config_path: "examples/configs/grpo_math_1B.yaml" 
+
+
+# Model configuration
+policy.model_name: ["Qwen/Qwen3-1.7B", "Qwen/Qwen3-4B"]
+
+# Generation configuration
+policy.generation.temperature: [1.0, 0.7]


### PR DESCRIPTION
# What does this PR do ?

The launcher.py and eval_launcher.py scripts introduce a powerful and unified system for managing SLURM jobs. The training launcher simplifies running experiments and hyperparameter sweeps by automatically generating and submitting jobs from a simple configuration file. The evaluation launcher builds on this by adding a sophisticated, race-condition-safe caching system that automatically converts distributed checkpoints into a HuggingFace format on-the-fly, streamlining the evaluation process and saving significant compute resources.

**what this PR aims to accomplish**
It adds launchers for train and eval jobs. The scripts lock resources on SLURM and launch experiments, e.g. sweeps specified by sweep yaml files, in parallel or sequentially. The experiment and resource parameters are highly configurable.

# Usage
* **You can potentially add a usage example below**

```bash
    # This example demonstrates how to use the training launcher for a parameter sweep.
    
    # 1. Create a sweep configuration file. This file specifies the script to run
    #    and the hyperparameters to sweep over.
    cat > grpo_sweep_example.yaml << EOF
    script_path: examples/train_grpo.py
    config_path: examples/configs/grpo.yaml
    optim.lr: [1e-6, 5e-6, 1e-5]
    grpo.kl_penalty: [0.01, 0.02]
    EOF
    
    # 2. Run the launcher with the sweep file.
    #    This command will launch a separate SLURM job for each of the 6 (3x2)
    #    parameter combinations on a 2-node allocation.
    #    Use --dry to print the sbatch commands without submitting them.
    python xp/launcher.py \
        --sweep grpo_sweep_example.yaml \
        --nodes 2 \
        --jobname grpo_sweep_example \
        --dry
```

```bash
    # This example shows how to evaluate a NeMo-RL distributed checkpoint (DCP).
    # The launcher automatically handles the conversion to HuggingFace format
    # and caches the result for future runs.
    
    # Run the evaluation, pointing to the DCP checkpoint and its config file.
    # The conversion happens automatically inside the SLURM job.
    python xp/eval_launcher.py \
        --dcp-ckpt-path /path/to/your/nemo_checkpoint/weights/ \
        --dcp-config /path/to/your/nemo_checkpoint/config.yaml \
        --nodes 1 \
        --jobname my_model_evaluation \
        data.dataset_name=openai/gsm8k
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA/NeMo-RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA/NeMo-RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA/NeMo-RL/blob/main/docs/documentation.md) for how to write, build and test the docs.
