### PR TITLE
Fix async multiturn

### DIFF
--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -509,7 +509,8 @@ def run_multi_turn_rollout(
         "truncation_rate": float(sample_truncated.float().mean().item()),
         "max_turns_reached_rate": float(sample_max_turns_reached.float().mean().item()),
         # Token usage metrics
-        "mean_gen_tokens_per_sample": float(sample_token_counts.float().mean().item()),
+        "mean_total_tokens_per_sample": float(sample_token_counts.float().mean().item()),
+        "mean_gen_tokens_per_sample": float(sample_assistant_token_counts.float().mean().item()),
         "mean_env_tokens_per_sample": float(
             sample_env_token_counts.float().mean().item()
         ),
@@ -878,7 +879,7 @@ async def run_async_multi_turn_rollout(
             m["total_tokens"] for m in all_sample_metrics
         )
         / batch_size,
-        "mean_assistant_tokens_per_sample": sum(
+        "mean_gen_tokens_per_sample": sum(
             m["assistant_tokens"] for m in all_sample_metrics
         )
         / batch_size,

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -509,8 +509,12 @@ def run_multi_turn_rollout(
         "truncation_rate": float(sample_truncated.float().mean().item()),
         "max_turns_reached_rate": float(sample_max_turns_reached.float().mean().item()),
         # Token usage metrics
-        "mean_total_tokens_per_sample": float(sample_token_counts.float().mean().item()),
-        "mean_gen_tokens_per_sample": float(sample_assistant_token_counts.float().mean().item()),
+        "mean_total_tokens_per_sample": float(
+            sample_token_counts.float().mean().item()
+        ),
+        "mean_gen_tokens_per_sample": float(
+            sample_assistant_token_counts.float().mean().item()
+        ),
         "mean_env_tokens_per_sample": float(
             sample_env_token_counts.float().mean().item()
         ),
@@ -700,9 +704,7 @@ async def run_sample_multi_turn_rollout(
                     >= max_seq_len
                 ):
                     # Truncate environment observation
-                    max_env_tokens = (
-                        max_seq_len - input_lengths - len(generated_tokens)
-                    )
+                    max_env_tokens = max_seq_len - input_lengths - len(generated_tokens)
                     if max_env_tokens > 0:
                         tokenized_obs = tokenized_obs[:max_env_tokens]
                     else:


### PR DESCRIPTION
# What does this PR do ?

Fix incorrect seq len and statistic name.
e2e async run works fine after this.

test script:
```
uv run python examples/run_grpo_sliding_puzzle.py \
    policy.generation.vllm_cfg.async_engine=true \
    policy.train_global_batch_size=32 \
    policy.train_micro_batch_size=2 \
    checkpointing.enabled=false
```

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA/NeMo-RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA/NeMo-RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA/NeMo-RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
