### PR TITLE
fix: fix Ray typing to not use internal package

### DIFF
--- a/nemo_rl/distributed/worker_groups.py
+++ b/nemo_rl/distributed/worker_groups.py
@@ -56,7 +56,7 @@ class MultiWorkerFuture:
         Returns:
             List of results, deduplicated by tied workers if respect_tied_workers is True
         """
-        from ray._raylet import ObjectRef, ObjectRefGenerator
+        from ray import ObjectRef, ObjectRefGenerator
 
         # Flatten futures into a list of ObjectRefs
         object_refs: list[ObjectRef] = []


### PR DESCRIPTION
# What does this PR do ?

Small fix to not use types from the private `ray._raylet` package and instead use them from the public `ray` package.

I also made fix upstream in Ray so the repr of the type show the correct `ray.ObjectRef` instead of the private version `ray._raylet.ObjectRef` (https://github.com/ray-project/ray/pull/54011)

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA/NeMo-RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA/NeMo-RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA/NeMo-RL/blob/main/docs/documentation.md) for how to write, build and test the docs.
