### PR TITLE
fix: fix pytest -k test usage

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -118,6 +118,21 @@ def session_data(request, init_ray_cluster):
     ############################################################
     # 1. Gather all the unit test data #
     ############################################################
+
+    # Check if _unit_test_data exists, if not, create it
+    if not hasattr(request.config, "_unit_test_data"):
+        print(
+            "Warning: _unit_test_data not found in session_data fixture, creating minimal data"
+        )
+        request.config._unit_test_data = UnitTestData(
+            exit_status="was not set",
+            git_commit="unknown",
+            start_time=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            metrics={},
+            gpu_types=[],
+            coverage="[n/a] run with --cov=nemo_rl",
+        )
+
     unit_test_data: UnitTestData = request.config._unit_test_data
     yield unit_test_data
 


### PR DESCRIPTION

# What does this PR do ?

`pytest -k testname` was broken earlier with the below error message:
```
conftest.py", line 222, in pytest_sessionfinish
    data = session.config._unit_test_data
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Config' object has no attribute '_unit_test_data'
```


**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA/NeMo-RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA/NeMo-RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA/NeMo-RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
