### PR TITLE
feat: Add safe_serialization option to the dcp checkpoint conversion script

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ If you have trained a model and saved the checkpoint in the Pytorch DCP format, 
 
 ```sh
 # Example for a GRPO checkpoint at step 170
-uv run python examples/convert_dcp_to_hf.py \
+uv run python examples/converters/convert_dcp_to_hf.py \
     --config results/grpo/step_170/config.yaml \
     --dcp-ckpt-path results/grpo/step_170/policy/weights/ \
     --hf-ckpt-path results/grpo/hf

--- a/docs/design-docs/checkpointing.md
+++ b/docs/design-docs/checkpointing.md
@@ -5,8 +5,13 @@ NeMo RL provides two checkpoint formats for Hugging Face models: Torch distribut
 A checkpoint converter is provided to convert a Torch distributed checkpoint checkpoint to Hugging Face format after training:
 
 ```sh
-uv run examples/converters/convert_dcp_to_hf.py --config=<YAML CONFIG USED DURING TRAINING> <ANY CONFIG OVERRIDES USED DURING TRAINING> --dcp-ckpt-path=<PATH TO DIST CHECKPOINT TO CONVERT> --hf-ckpt-path=<WHERE TO SAVE HF CHECKPOINT>
+uv run examples/converters/convert_dcp_to_hf.py --config=<YAML CONFIG USED DURING TRAINING> <ANY CONFIG OVERRIDES USED DURING TRAINING> --dcp-ckpt-path=<PATH TO DIST CHECKPOINT TO CONVERT> --hf-ckpt-path=<WHERE TO SAVE HF CHECKPOINT> --safe-serialization=false
 ```
+
+The --safe-serialization flag controls the output format:
+
+--safe-serialization=false (default): Saves weights as PyTorch .bin files
+--safe-serialization=true: Saves weights as .safetensors files for enhanced security and faster loading
 
 Usually Hugging Face checkpoints keep the weights and tokenizer together (which we also recommend for provenance). You can copy it afterwards. Here's an end-to-end example:
 
@@ -14,6 +19,6 @@ Usually Hugging Face checkpoints keep the weights and tokenizer together (which 
 # Change to your appropriate checkpoint directory
 CKPT_DIR=results/sft/step_10
 
-uv run examples/converters/convert_dcp_to_hf.py --config=$CKPT_DIR/config.yaml --dcp-ckpt-path=$CKPT_DIR/policy/weights --hf-ckpt-path=${CKPT_DIR}-hf
+uv run examples/converters/convert_dcp_to_hf.py --config=$CKPT_DIR/config.yaml --dcp-ckpt-path=$CKPT_DIR/policy/weights --hf-ckpt-path=${CKPT_DIR}-hf --safe-serialization=false
 rsync -ahP $CKPT_DIR/policy/tokenizer ${CKPT_DIR}-hf/
 ```

--- a/examples/converters/convert_dcp_to_hf.py
+++ b/examples/converters/convert_dcp_to_hf.py
@@ -36,6 +36,9 @@ def parse_args():
     parser.add_argument(
         "--hf-ckpt-path", type=str, default=None, help="Path to save HF checkpoint"
     )
+    parser.add_argument(
+        "--safe-serialization", type=bool, default=False, help="Save huggingface model as .safetensors"
+    )
     # Parse known args for the script
     args = parser.parse_args()
 
@@ -63,6 +66,7 @@ def main():
         hf_ckpt_path=args.hf_ckpt_path,
         model_name_or_path=model_name_or_path,
         tokenizer_name_or_path=tokenizer_name_or_path,
+        safe_serialization=args.safe_serialization,
     )
     print(f"Saved HF checkpoint to: {hf_ckpt}")
 

--- a/nemo_rl/utils/native_checkpoint.py
+++ b/nemo_rl/utils/native_checkpoint.py
@@ -14,6 +14,7 @@
 
 """Checkpoint management utilities for HF models."""
 
+import io
 import os
 from typing import Any, Optional
 
@@ -207,6 +208,7 @@ def convert_dcp_to_hf(
     hf_ckpt_path: str,
     model_name_or_path: str,
     tokenizer_name_or_path: str,
+    safe_serialization: bool = False,
     overwrite: bool = False,
 ) -> str:
     """Convert a Torch DCP checkpoint to a Hugging Face checkpoint.
@@ -220,6 +222,7 @@ def convert_dcp_to_hf(
         model_name_or_path (str): Model name or path for config
         tokenizer_name_or_path (str, optional): Tokenizer name or path.
                                                Defaults to model_name_or_path if None.
+        safe_serialization (bool, optional): Whether to save the checkpoint as .safetensors. Defaults to False.
         overwrite (bool, optional): Whether to overwrite existing checkpoint. Defaults to False.
 
     Returns:
@@ -234,15 +237,51 @@ def convert_dcp_to_hf(
         )
 
     os.makedirs(hf_ckpt_path, exist_ok=True)
-    weights_path = os.path.join(hf_ckpt_path, "pytorch_model.bin")
-    dcp_to_torch_save(dcp_ckpt_path, weights_path)
 
-    # Need to reload and save b/c the state dict is scoped inside the model key {"model": actual_state_dict}
-    state_dict = torch.load(weights_path)
-    assert set(state_dict.keys()) == {"model"}, (
-        f"We expect that the state dict only has the top level model key, but found: {state_dict.keys()}"
-    )
-    torch.save(state_dict["model"], weights_path)
+    if safe_serialization:
+        from safetensors.torch import save_file as save_safetensors
+        
+        buffer = io.BytesIO()
+        
+        original_torch_save = torch.save
+
+        def save_to_buffer(obj, f, **kwargs):
+            original_torch_save(obj, buffer, **kwargs)
+
+        try:
+            torch.save = save_to_buffer
+            
+            # This will save to buffer instead of disk
+            dcp_to_torch_save(dcp_ckpt_path, "memory_buffer")
+
+            torch.save = original_torch_save
+            buffer.seek(0)
+            state_dict = torch.load(buffer, map_location="cpu")
+
+        finally:
+            # Ensure we restore torch.save even if an error occurs
+            torch.save = original_torch_save
+            buffer.close()
+
+        weights_path = os.path.join(hf_ckpt_path, "model.safetensors")
+
+        assert set(state_dict.keys()) == {"model"}, (
+            f"We expect that the state dict only has the top level model key, but found: {state_dict.keys()}"
+        )
+        save_safetensors(state_dict["model"], weights_path)
+
+    else:
+        weights_path = os.path.join(hf_ckpt_path, "pytorch_model.bin")
+        dcp_to_torch_save(dcp_ckpt_path, weights_path)
+
+        # Need to reload and save b/c the state dict is scoped inside the model key {"model": actual_state_dict}
+        state_dict = torch.load(weights_path)
+    
+        assert set(state_dict.keys()) == {"model"}, (
+            f"We expect that the state dict only has the top level model key, but found: {state_dict.keys()}"
+        )
+        torch.save(state_dict["model"], weights_path)
+
 
     config = AutoConfig.from_pretrained(model_name_or_path)
     config.save_pretrained(hf_ckpt_path)


### PR DESCRIPTION
# What does this PR do ?

Currently, the script converts dcp checkpoints to `.bin` for the HF checkpoint. This PR allows users to also convert checkpoints to `.safetensors`.

# Issues
Closes #491 

# Usage
* **You can potentially add a usage example below**

```sh
uv run python examples/converters/convert_dcp_to_hf.py \
    --config results/grpo/step_170/config.yaml \
    --dcp-ckpt-path results/grpo/step_170/policy/weights/ \
    --hf-ckpt-path results/grpo/hf \
    --safe-serialization true
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA/NeMo-RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA/NeMo-RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA/NeMo-RL/blob/main/docs/documentation.md) for how to write, build and test the docs.
