### PR TITLE
fix: skip HelpSteer3 unit test if downloading failed

### DIFF
--- a/tests/unit/data/hf_datasets/test_helpsteer.py
+++ b/tests/unit/data/hf_datasets/test_helpsteer.py
@@ -13,10 +13,22 @@
 # limitations under the License.
 
 
+import pytest
+
 from nemo_rl.data.hf_datasets.helpsteer3 import (
     HelpSteer3Dataset,
     format_helpsteer3,
 )
+
+
+@pytest.fixture(scope="module")
+def helpsteer3_dataset():
+    try:
+        dataset = HelpSteer3Dataset()
+        yield dataset
+    except Exception as e:
+        print(f"Error during loading HelpSteer3Dataset: {e}")
+        yield
 
 
 def test_format_helpsteer3():
@@ -60,19 +72,23 @@ def test_format_helpsteer3():
     assert result3["rejected_response"] == "It's sunny today."
 
 
-def test_helpsteer3_dataset_initialization():
+def test_helpsteer3_dataset_initialization(helpsteer3_dataset):
     """Test that HelpSteer3Dataset initializes correctly."""
 
-    dataset = HelpSteer3Dataset()
+    dataset = helpsteer3_dataset
+    if dataset is None:
+        pytest.skip("dataset download is flaky")
 
     # Verify dataset initialization
     assert dataset.task_spec.task_name == "HelpSteer3"
 
 
-def test_helpsteer3_dataset_data_format():
+def test_helpsteer3_dataset_data_format(helpsteer3_dataset):
     """Test that HelpSteer3Dataset correctly formats the data."""
 
-    dataset = HelpSteer3Dataset()
+    dataset = helpsteer3_dataset
+    if dataset is None:
+        pytest.skip("dataset download is flaky")
 
     assert isinstance(dataset.formatted_ds, dict)
     assert "train" in dataset.formatted_ds


### PR DESCRIPTION
`test_helpsteer3_dataset_initialization` flaky failed in CI.
This PR will skip it when downloading failed.