### PR TITLE
fix: Fix crash for logprob error plot

### DIFF
--- a/nemo_rl/utils/logger.py
+++ b/nemo_rl/utils/logger.py
@@ -757,6 +757,12 @@ class Logger(LoggerInterface):
             data["full_lengths"][sample_idx] - 1,
         )
 
+        if generation_start_idx >= generation_end_idx:
+            print(
+                f"Skipping token_mult_prob_error plot because generation_start_idx ({generation_start_idx}) >= generation_end_idx ({generation_end_idx})"
+            )
+            return
+
         generation_logprob = generation_logprobs[
             sample_idx, generation_start_idx:generation_end_idx
         ]


### PR DESCRIPTION
# What does this PR do ?

Fixes below crash. I believe this is happening when the prompt length exceeds max sequence length

```
Traceback (most recent call last):
  File "/lustre/fs1/portfolios/coreai/users/yifuw/code/tmp/real_ep_merge/RL/examples/run_grpo_math.py", line 335, in <module>
    main()
  File "/lustre/fs1/portfolios/coreai/users/yifuw/code/tmp/real_ep_merge/RL/examples/run_grpo_math.py", line 318, in main
    grpo_train(
  File "/lustre/fs1/portfolios/coreai/users/yifuw/code/tmp/real_ep_merge/RL/nemo_rl/algorithms/grpo.py", line 777, in grpo_train
    logger.log_plot_token_mult_prob_error(
  File "/lustre/fs1/portfolios/coreai/users/yifuw/code/tmp/real_ep_merge/RL/nemo_rl/utils/logger.py", line 770, in log_plot_token_mult_prob_error
    max_abs_error_idx = torch.argmax(diff_i).item()
                        ^^^^^^^^^^^^^^^^^^^^
IndexError: argmax(): Expected reduction dim to be specified for input.numel() == 0.
```

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
Reproduced crash by hardcoding logprob error threshold to 1.0 and setting policy.max_total_sequence_length=64: https://wandb.ai/nvidia/grpo-dev-yifu/runs/tcv42xq1/logs

With fix: https://wandb.ai/nvidia/grpo-dev-yifu/runs/i1krxjes/logs
