### PR TITLE
chore: exclude ray.remote from coverage

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -210,7 +210,7 @@ jobs:
       UNIT_TEST_SCRIPT: |
         cd /opt/nemo-rl
         if [[ "${{ needs.pre-flight.outputs.test_level }}" =~ ^(L0|L1|L2)$ ]]; then
-          uv run --no-sync bash -x ./tests/run_unit.sh --cov=nemo_rl --cov-report=term --cov-report=json
+          uv run --no-sync bash -x ./tests/run_unit.sh --cov=nemo_rl --cov-report=term-missing --cov-report=json
         else
           echo Skipping unit tests for docs-only level
         fi

--- a/nemo_rl/distributed/virtual_cluster.py
+++ b/nemo_rl/distributed/virtual_cluster.py
@@ -55,7 +55,7 @@ class PY_EXECUTABLES:
     MCORE = "uv run --reinstall --extra mcore"
 
 
-@ray.remote
+@ray.remote  # pragma: no cover
 def _get_node_ip_and_free_port() -> tuple[str, int]:
     import socket
 

--- a/nemo_rl/environments/games/sliding_puzzle.py
+++ b/nemo_rl/environments/games/sliding_puzzle.py
@@ -338,7 +338,7 @@ class SlidingPuzzleRunner:
         )
 
 
-@ray.remote
+@ray.remote  # pragma: no cover
 class SlidingPuzzleEnv(EnvironmentInterface):
     """Sliding Puzzle environment (Ray Actor)."""
 

--- a/nemo_rl/environments/math_environment.py
+++ b/nemo_rl/environments/math_environment.py
@@ -52,7 +52,7 @@ def _mute_output():
         yield
 
 
-@ray.remote
+@ray.remote  # pragma: no cover
 class HFVerifyWorker:
     def __init__(self) -> None:
         logging.getLogger("math_verify").setLevel(logging.CRITICAL)
@@ -100,7 +100,7 @@ class HFVerifyWorker:
         return results
 
 
-@ray.remote
+@ray.remote  # pragma: no cover
 class MultilingualMultichoiceVerifyWorker:
     def verify(
         self, pred_responses: list[str], ground_truths: list[str]
@@ -133,7 +133,7 @@ class MultilingualMultichoiceVerifyWorker:
         return results
 
 
-@ray.remote
+@ray.remote  # pragma: no cover
 class EnglishMultichoiceVerifyWorker:
     def verify(
         self, pred_responses: list[str], ground_truths: list[str]
@@ -166,7 +166,7 @@ class MathEnvironmentMetadata(TypedDict):
     ground_truth: str
 
 
-@ray.remote(max_restarts=-1, max_task_retries=-1)
+@ray.remote(max_restarts=-1, max_task_retries=-1)  # pragma: no cover
 class MathEnvironment(EnvironmentInterface):
     def __init__(self, cfg: MathEnvConfig):
         self.cfg = cfg

--- a/nemo_rl/models/generation/vllm.py
+++ b/nemo_rl/models/generation/vllm.py
@@ -76,7 +76,7 @@ class VllmConfig(GenerationConfig):
 
 @ray.remote(
     runtime_env={**get_nsight_config_if_pattern_matches("vllm_generation_worker")}
-    )  # pragma: no cover
+)  # pragma: no cover
 class VllmGenerationWorker:
     def __repr__(self) -> str:
         """Customizes the actor's prefix in the Ray logs.

--- a/nemo_rl/models/generation/vllm.py
+++ b/nemo_rl/models/generation/vllm.py
@@ -76,7 +76,7 @@ class VllmConfig(GenerationConfig):
 
 @ray.remote(
     runtime_env={**get_nsight_config_if_pattern_matches("vllm_generation_worker")}
-)
+    )  # pragma: no cover
 class VllmGenerationWorker:
     def __repr__(self) -> str:
         """Customizes the actor's prefix in the Ray logs.

--- a/nemo_rl/models/policy/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker.py
@@ -114,7 +114,7 @@ def get_cpu_state_dict(
     return new_state_dict
 
 
-@ray.remote(runtime_env=get_runtime_env_for_policy_worker("dtensor_policy_worker"))
+@ray.remote(runtime_env=get_runtime_env_for_policy_worker("dtensor_policy_worker"))  # pragma: no cover
 class DTensorPolicyWorker:
     def __repr__(self) -> str:
         """Customizes the actor's prefix in the Ray logs.

--- a/nemo_rl/models/policy/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker.py
@@ -114,7 +114,9 @@ def get_cpu_state_dict(
     return new_state_dict
 
 
-@ray.remote(runtime_env=get_runtime_env_for_policy_worker("dtensor_policy_worker"))  # pragma: no cover
+@ray.remote(
+    runtime_env=get_runtime_env_for_policy_worker("dtensor_policy_worker")
+)  # pragma: no cover
 class DTensorPolicyWorker:
     def __repr__(self) -> str:
         """Customizes the actor's prefix in the Ray logs.

--- a/nemo_rl/models/policy/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/megatron_policy_worker.py
@@ -327,7 +327,9 @@ def destroy_parallel_state():
         pass
 
 
-@ray.remote(runtime_env=get_runtime_env_for_policy_worker("megatron_policy_worker"))  # pragma: no cover
+@ray.remote(
+    runtime_env=get_runtime_env_for_policy_worker("megatron_policy_worker")
+)  # pragma: no cover
 class MegatronPolicyWorker:
     def __repr__(self):
         """Customizes the actor's prefix in the Ray logs.

--- a/nemo_rl/models/policy/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/megatron_policy_worker.py
@@ -327,7 +327,7 @@ def destroy_parallel_state():
         pass
 
 
-@ray.remote(runtime_env=get_runtime_env_for_policy_worker("megatron_policy_worker"))
+@ray.remote(runtime_env=get_runtime_env_for_policy_worker("megatron_policy_worker"))  # pragma: no cover
 class MegatronPolicyWorker:
     def __repr__(self):
         """Customizes the actor's prefix in the Ray logs.

--- a/nemo_rl/utils/venvs.py
+++ b/nemo_rl/utils/venvs.py
@@ -104,7 +104,7 @@ def create_local_venv(
 
 
 # Ray-based helper to create a virtual environment on each Ray node
-@ray.remote(num_cpus=1)
+@ray.remote(num_cpus=1)  # pragma: no cover
 def _env_builder(
     py_executable: str, venv_name: str, node_idx: int, force_rebuild: bool = False
 ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,14 +180,6 @@ omit = ["/tmp/*"]
 [tool.coverage.paths]
 source = ["nemo_rl/", "/opt/nemo-rl/nemo_rl/"]
 
-[tool.coverage.report]
-# At the moment there's no way to easily get line coverage across the ray.remote boundary.
-# We disable coverage so we can have an accurate number of non-remote logic.
-# https://github.com/NVIDIA/NeMo-RL/issues/329
-exclude_also = [
-    "@ray.remote",
-]
-
 [tool.ruff.lint]
 # Enable all `pydocstyle` rules, limiting to those that adhere to the
 # Google convention via `convention = "google"`, below.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,14 @@ omit = ["/tmp/*"]
 [tool.coverage.paths]
 source = ["nemo_rl/", "/opt/nemo-rl/nemo_rl/"]
 
+[tool.coverage.report]
+# At the moment there's no way to easily get line coverage across the ray.remote boundary.
+# We disable coverage so we can have an accurate number of non-remote logic.
+# https://github.com/NVIDIA/NeMo-RL/issues/329
+exclude_also = [
+    "@ray.remote",
+]
+
 [tool.ruff.lint]
 # Enable all `pydocstyle` rules, limiting to those that adhere to the
 # Google convention via `convention = "google"`, below.


### PR DESCRIPTION
Change excludes ray.remotes from coverage. Brings coverage from 45 -> 58% (still a large gap)

also print the missing lines