### PR TITLE
fix: pytest_sessionfinish hook in case there is no _unit_test_data.

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -199,6 +199,9 @@ def tracker(request, session_data, ray_gpu_monitor):
 
 
 def pytest_sessionfinish(session, exitstatus):
+    if not hasattr(session.config, "_unit_test_data"):
+        return
+
     data = session.config._unit_test_data
     data["exit_status"] = exitstatus
     print(f"\nSaving unit test data to {UNIT_RESULTS_FILE}")


### PR DESCRIPTION
# What does this PR do ?

Fixes bug when running  pytest_sessionfinish hook in case there is no _unit_test_data 
`uv run --group test pytest --collect-only`

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
