### PR TITLE
fix: fix nccl P2P initialization error for non-colocated

### DIFF
--- a/nemo_rl/models/generation/vllm.py
+++ b/nemo_rl/models/generation/vllm.py
@@ -1328,6 +1328,7 @@ class VllmGeneration(GenerationInterface):
             "nemo_rl.models.generation.vllm.VllmGenerationWorker", config
         )
 
+        # It's necessary to set env_vars here to ensure that vllm non-leader workers also have these env_vars
         # Explicitly set NCCL_CUMEM_ENABLE to 1 to avoid the P2P initialization error for PyNCCLCommunicator.
         # See https://github.com/NVIDIA-NeMo/RL/issues/564 for more details.
         env_vars = {}

--- a/nemo_rl/models/generation/vllm.py
+++ b/nemo_rl/models/generation/vllm.py
@@ -1328,12 +1328,11 @@ class VllmGeneration(GenerationInterface):
             "nemo_rl.models.generation.vllm.VllmGenerationWorker", config
         )
 
-        # It's necessary to set env_vars here to ensure that vllm non-leader workers also have these env_vars
-        # Disable NCCL SHM if training and generation are not co-located: https://github.com/NVIDIA-NeMo/RL/issues/564
+        # Explicitly set NCCL_CUMEM_ENABLE to 1 to avoid the P2P initialization error for PyNCCLCommunicator.
+        # See https://github.com/NVIDIA-NeMo/RL/issues/564 for more details.
         env_vars = {}
         if not self.cfg["colocated"]["enabled"]:
-            env_vars["NCCL_SHM_DISABLE"] = "1"
-            env_vars["NCCL_P2P_DISABLE"] = "1"
+            os.environ["NCCL_CUMEM_ENABLE"] = "1"
 
         # Check if we need parallelism-aware worker group creation
         if self.model_parallel_size > 1:

--- a/nemo_rl/models/generation/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm_backend.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Any
+import os
 
 import torch
 
@@ -35,6 +36,10 @@ class VllmInternalWorkerExtension:
 
         local_rank = torch.distributed.get_rank()
         rank = rank_prefix + local_rank + 1  # 1 is the head node of the train cluster
+
+        # Temporary fix for vllm==0.9.0 which overrides the NCCL_CUMEM_ENABLE to 0 and causes
+        # https://github.com/NVIDIA-NeMo/RL/issues/564. This can be removed after it is upgraded to vllm>=0.9.1rc1.
+        os.environ["NCCL_CUMEM_ENABLE"] = "1"
 
         pg = StatelessProcessGroup.create(
             host=ip, port=port, rank=rank, world_size=world_size

--- a/nemo_rl/models/generation/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm_backend.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any
 import os
+from typing import Any
 
 import torch
 

--- a/nemo_rl/models/policy/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker.py
@@ -136,14 +136,14 @@ class DTensorPolicyWorker:
         init_reference_model: bool = True,
         **kwargs: Any,
     ):
-        # Disable NCCL SHM if training and generation are not co-located: https://github.com/NVIDIA-NeMo/RL/issues/564
+        # Explicitly set NCCL_CUMEM_ENABLE to 1 to avoid the P2P initialization error for PyNCCLCommunicator.
+        # See https://github.com/NVIDIA-NeMo/RL/issues/564 for more details.
         if (
             "generation" in config
             and config["generation"] is not None
             and not config["generation"]["colocated"]["enabled"]
         ):
-            os.environ["NCCL_SHM_DISABLE"] = "1"
-            os.environ["NCCL_P2P_DISABLE"] = "1"
+            os.environ["NCCL_CUMEM_ENABLE"] = "1"
 
         self.cfg = config
         # torch distributed init. Envars for rank, world_size, and master_addr and master_port are set from the ray remote call
@@ -385,11 +385,6 @@ class DTensorPolicyWorker:
         """Initialize the collective communication."""
         from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
         from vllm.distributed.utils import StatelessProcessGroup
-
-        # keep the same behavior as vllm
-        # see https://github.com/vllm-project/vllm/blob/v0.9.0/vllm/env_override.py#L25
-        if not os.path.exists("/dev/nvidia-caps-imex-channels"):
-            os.environ["NCCL_CUMEM_ENABLE"] = "0"
 
         if self.rank == 0:
             pg = StatelessProcessGroup.create(


### PR DESCRIPTION
# What does this PR do ?

Adds explicit `NCCL_CUMEM_ENABLE=1` environment variable setting to resolve P2P initialization failures in distributed training with vLLM.

Please see detailed analysis in https://github.com/NVIDIA-NeMo/RL/issues/564#issuecomment-3050323063.

# Issues

Closes #564.

This PR can also be helpful to #613. Maybe @yuki-666 could take a look. The only change you may need to make it to delete the `os.environ["NCCL_CUMEM_ENABLE"] = "0"` in function `init_collective` for `nemo_rl/models/policy/megatron_policy_worker.py`.

# Test results

I have tested the settings @yuki-666 provided: 8b model grpo on 5 nodes:

![image](https://github.com/user-attachments/assets/aa547f9b-6a9c-4fb7-9d95-2e5f9dab82a0)

Where

- Purple line: `exp1_5n_non_colocated_p2p_disabled`: before the fix, running with `NCCL_P2P_DISABLE=1`.
- Pink line: `exp2_5n_non_colocated_fix`: after this pr's fix.

We can see that:

- The training reward mostly aligns.
- The training speed is back to normal.

# Usage

The fix automatically applies when using distributed training with vLLM generation workers. No user action required.

# Additional Information

This PR works for both the current `vllm==0.9.0` and also new versions like `vllm>=0.9.1rc1`.
If we upgrade our version, we can remove the additional environment variable setting in `nemo_rl/models/generation/vllm_backend.py`.