### PR TITLE
feat: implement cons@k evaluation

### DIFF
--- a/docs/guides/eval.md
+++ b/docs/guides/eval.md
@@ -81,7 +81,7 @@ When you complete the evaluation, you will receive a summary similar to the foll
 model_name='Qwen2.5-Math-1.5B-Instruct' dataset_name='aime2024'
 max_new_tokens=2048 temperature=0.0 top_p=1.0 top_k=-1
 
-metric='pass@k' k_value=1 num_tests_per_prompt=1
+metric=pass@k@1 num_tests_per_prompt=1
 
 score=0.1000 (3.0/30)
 ============================================================

--- a/docs/guides/eval.md
+++ b/docs/guides/eval.md
@@ -81,7 +81,7 @@ When you complete the evaluation, you will receive a summary similar to the foll
 model_name='Qwen2.5-Math-1.5B-Instruct' dataset_name='aime2024'
 max_new_tokens=2048 temperature=0.0 top_p=1.0 top_k=-1
 
-metric=pass@k@1 num_tests_per_prompt=1
+metric=pass@1 num_tests_per_prompt=1
 
 score=0.1000 (3.0/30)
 ============================================================

--- a/docs/guides/eval.md
+++ b/docs/guides/eval.md
@@ -81,7 +81,7 @@ When you complete the evaluation, you will receive a summary similar to the foll
 model_name='Qwen2.5-Math-1.5B-Instruct' dataset_name='aime2024'
 max_new_tokens=2048 temperature=0.0 top_p=1.0 top_k=-1
 
-metric='pass@k' pass_k_value=1 num_tests_per_prompt=1
+metric='pass@k' k_value=1 num_tests_per_prompt=1
 
 score=0.1000 (3.0/30)
 ============================================================

--- a/examples/configs/evals/eval.yaml
+++ b/examples/configs/evals/eval.yaml
@@ -1,7 +1,7 @@
 # Evaluation Configuration
 eval:
-  metric: "pass@k"
-  num_tests_per_prompt: 1 # every prompt will be tested num_tests_per_prompt times and use the average score as the final score
+  metric: "cons@k"
+  num_tests_per_prompt: 5 # every prompt will be tested num_tests_per_prompt times and use the average score as the final score
   seed: 42
   k_value: 1
   save_path: null # Path to save evaluation results and configuration of the evaluation. Set to null to disable saving. Example: "results/eval_output" or "/path/to/evaluation_results"
@@ -9,7 +9,7 @@ eval:
 generation:
   backend: "vllm" # only vllm is supported for evaluation
   max_new_tokens: ${generation.vllm_cfg.max_model_len}
-  temperature: 0.0
+  temperature: 0.7
   top_p: 1.0
   top_k: -1 # -1 means disable
   num_prompts_per_step: -1 # -1 means pass all prompts at once

--- a/examples/configs/evals/eval.yaml
+++ b/examples/configs/evals/eval.yaml
@@ -3,7 +3,7 @@ eval:
   metric: "pass@k"
   num_tests_per_prompt: 1 # every prompt will be tested num_tests_per_prompt times and use the average score as the final score
   seed: 42
-  pass_k_value: 1
+  k_value: 1
   save_path: null # Path to save evaluation results and configuration of the evaluation. Set to null to disable saving. Example: "results/eval_output" or "/path/to/evaluation_results"
 
 generation:

--- a/examples/configs/evals/eval.yaml
+++ b/examples/configs/evals/eval.yaml
@@ -1,7 +1,7 @@
 # Evaluation Configuration
 eval:
-  metric: "cons@k"
-  num_tests_per_prompt: 5 # every prompt will be tested num_tests_per_prompt times and use the average score as the final score
+  metric: "pass@k" # pass@k and cons@k are supported
+  num_tests_per_prompt: 1 # every prompt will be tested num_tests_per_prompt times and use the average score as the final score
   seed: 42
   k_value: 1
   save_path: null # Path to save evaluation results and configuration of the evaluation. Set to null to disable saving. Example: "results/eval_output" or "/path/to/evaluation_results"
@@ -9,7 +9,7 @@ eval:
 generation:
   backend: "vllm" # only vllm is supported for evaluation
   max_new_tokens: ${generation.vllm_cfg.max_model_len}
-  temperature: 0.7
+  temperature: 0.0
   top_p: 1.0
   top_k: -1 # -1 means disable
   num_prompts_per_step: -1 # -1 means pass all prompts at once

--- a/nemo_rl/environments/code_environment.py
+++ b/nemo_rl/environments/code_environment.py
@@ -244,7 +244,7 @@ class CodeEnvironment(EnvironmentInterface):
         assert return_extracted_answer == False, (
             "return_extracted_answer is not supported in CodeEnvironment. Please set it to False."
         )
-        answers_tensor = None
+        extracted_answers = None
 
         return EnvironmentReturn(
             observations=observations,
@@ -252,7 +252,7 @@ class CodeEnvironment(EnvironmentInterface):
             next_stop_strings=next_stop_strings,
             rewards=rewards_tensor,
             terminateds=terminated_tensor,
-            answers=answers_tensor,
+            answers=extracted_answers,
         )
 
     def shutdown(self):

--- a/nemo_rl/environments/code_environment.py
+++ b/nemo_rl/environments/code_environment.py
@@ -241,7 +241,9 @@ class CodeEnvironment(EnvironmentInterface):
 
         next_stop_strings = [["</code>"]] * len(message_log_batch)
 
-        assert return_extracted_answer == False, "The 'return_extracted_answer' parameter is not supported in this environment implementation. Please set it to False or remove this parameter from your configuration."    
+        assert return_extracted_answer == False, (
+            "return_extracted_answer is not supported in CodeEnvironment. Please set it to False."
+        )
         answers_tensor = None
 
         return EnvironmentReturn(

--- a/nemo_rl/environments/code_environment.py
+++ b/nemo_rl/environments/code_environment.py
@@ -206,6 +206,7 @@ class CodeEnvironment(EnvironmentInterface):
         self,
         message_log_batch: List[LLMMessageLogType],
         metadata_batch: List[CodeEnvMetadata],
+        return_extracted_answer: bool = False,
     ) -> EnvironmentReturn:
         """Process a batch of code execution steps."""
         message_batch = [ml[-1]["content"] for ml in message_log_batch]
@@ -240,12 +241,16 @@ class CodeEnvironment(EnvironmentInterface):
 
         next_stop_strings = [["</code>"]] * len(message_log_batch)
 
+        assert return_extracted_answer == False, "The 'return_extracted_answer' parameter is not supported in this environment implementation. Please set it to False or remove this parameter from your configuration."    
+        answers_tensor = None
+
         return EnvironmentReturn(
             observations=observations,
             metadata=new_metadata_batch,
             next_stop_strings=next_stop_strings,
             rewards=rewards_tensor,
             terminateds=terminated_tensor,
+            answers=answers_tensor,
         )
 
     def shutdown(self):

--- a/nemo_rl/environments/games/sliding_puzzle.py
+++ b/nemo_rl/environments/games/sliding_puzzle.py
@@ -272,7 +272,7 @@ class SlidingPuzzleRunner:
         bool,
         Optional[list[str]],
         Optional[SlidingPuzzleMetadata],
-        Optional[dict[str, Any]],
+        Optional[list[str]],
     ]:
         """Processes a single turn for the sliding puzzle task."""
         game_state = metadata["game_state"]
@@ -330,15 +330,15 @@ class SlidingPuzzleRunner:
 
             if is_terminated:
                 next_metadata = None  # Clear metadata on termination
-        # info save the extracted answer, only assigned in the verify function
-        next_info = None
+        # answers save the extracted answer, only assigned in the verify function
+        next_answers = None
         return (
             {"role": "environment", "content": next_observation_content + "\n"},
             turn_reward,
             is_terminated,
             next_stop_strings,
             next_metadata,
-            next_info,
+            next_answers,
         )
 
 
@@ -369,15 +369,15 @@ class SlidingPuzzleEnv(EnvironmentInterface[SlidingPuzzleMetadata]):
         terminateds = []
         all_stop_strings = []
         all_next_metadata = []
-        all_info = []
+        all_answers = []
 
-        for obs, rew, term, stops, meta, info in results:
+        for obs, rew, term, stops, meta, answ in results:
             observations.append(obs)
             rewards.append(rew)
             terminateds.append(term)
             all_stop_strings.append(stops)
             all_next_metadata.append(meta)
-            all_info.append(info)
+            all_answers.append(answ)
 
         rewards_tensor = torch.tensor(rewards, dtype=torch.float32)
         terminated_tensor = torch.tensor(terminateds, dtype=torch.bool)
@@ -388,7 +388,7 @@ class SlidingPuzzleEnv(EnvironmentInterface[SlidingPuzzleMetadata]):
             next_stop_strings=all_stop_strings,
             rewards=rewards_tensor,
             terminateds=terminated_tensor,
-            info=all_info,
+            answers=all_answers,
         )
 
     def shutdown(self):

--- a/nemo_rl/environments/interfaces.py
+++ b/nemo_rl/environments/interfaces.py
@@ -46,7 +46,7 @@ class EnvironmentReturn(NamedTuple, Generic[MetadataT]):
     next_stop_strings: list[list[str] | None] | list[None]
     rewards: Tensor
     terminateds: Tensor
-    answers: list[Optional[str]]
+    answers: list[str | None] | None
 
 
 class EnvironmentInterface(abc.ABC, Generic[MetadataT]):

--- a/nemo_rl/environments/interfaces.py
+++ b/nemo_rl/environments/interfaces.py
@@ -45,7 +45,7 @@ class EnvironmentReturn(NamedTuple, Generic[MetadataT]):
     next_stop_strings: list[list[str] | None] | list[None]
     rewards: Tensor
     terminateds: Tensor
-    info: list[Optional[dict]] | None
+    info: list[Optional[dict]] | None = None
 
 
 class EnvironmentInterface(abc.ABC, Generic[MetadataT]):

--- a/nemo_rl/environments/interfaces.py
+++ b/nemo_rl/environments/interfaces.py
@@ -38,7 +38,7 @@ class EnvironmentReturn(NamedTuple, Generic[MetadataT]):
                        similar. This field lets you control this per turn.
     rewards: the rewards for this turn.
     terminateds: whether the episode ended this turn.
-    info: any additional information from the environment.
+    answers: the answers for this turn.
     """
 
     observations: list[dict[str, str]]
@@ -46,7 +46,7 @@ class EnvironmentReturn(NamedTuple, Generic[MetadataT]):
     next_stop_strings: list[list[str] | None] | list[None]
     rewards: Tensor
     terminateds: Tensor
-    info: list[Optional[dict]]
+    answers: list[Optional[str]]
 
 
 class EnvironmentInterface(abc.ABC, Generic[MetadataT]):

--- a/nemo_rl/environments/interfaces.py
+++ b/nemo_rl/environments/interfaces.py
@@ -44,6 +44,7 @@ class EnvironmentReturn(NamedTuple, Generic[MetadataT]):
     metadata: list[MetadataT]
     next_stop_strings: list[list[str] | None] | list[None]
     rewards: Tensor
+    extracted_answers: list[list[str] | None]
     terminateds: Tensor
 
 

--- a/nemo_rl/environments/interfaces.py
+++ b/nemo_rl/environments/interfaces.py
@@ -45,6 +45,7 @@ class EnvironmentReturn(NamedTuple, Generic[MetadataT]):
     next_stop_strings: list[list[str] | None] | list[None]
     rewards: Tensor
     terminateds: Tensor
+    info: list[Optional[dict]] | None
 
 
 class EnvironmentInterface(abc.ABC, Generic[MetadataT]):

--- a/nemo_rl/environments/interfaces.py
+++ b/nemo_rl/environments/interfaces.py
@@ -44,7 +44,7 @@ class EnvironmentReturn(NamedTuple, Generic[MetadataT]):
     metadata: list[MetadataT]
     next_stop_strings: list[list[str] | None] | list[None]
     rewards: Tensor
-    extracted_answers: list[list[str] | None]
+    extracted_answers: list[str | None]
     terminateds: Tensor
 
 

--- a/nemo_rl/environments/interfaces.py
+++ b/nemo_rl/environments/interfaces.py
@@ -38,6 +38,7 @@ class EnvironmentReturn(NamedTuple, Generic[MetadataT]):
                        similar. This field lets you control this per turn.
     rewards: the rewards for this turn.
     terminateds: whether the episode ended this turn.
+    info: any additional information from the environment.
     """
 
     observations: list[dict[str, str]]
@@ -45,7 +46,7 @@ class EnvironmentReturn(NamedTuple, Generic[MetadataT]):
     next_stop_strings: list[list[str] | None] | list[None]
     rewards: Tensor
     terminateds: Tensor
-    info: list[Optional[dict]] | None = None
+    info: list[Optional[dict] | None] | list[None]
 
 
 class EnvironmentInterface(abc.ABC, Generic[MetadataT]):

--- a/nemo_rl/environments/interfaces.py
+++ b/nemo_rl/environments/interfaces.py
@@ -46,7 +46,7 @@ class EnvironmentReturn(NamedTuple, Generic[MetadataT]):
     next_stop_strings: list[list[str] | None] | list[None]
     rewards: Tensor
     terminateds: Tensor
-    info: list[Optional[dict] | None] | list[None]
+    info: list[Optional[dict]]
 
 
 class EnvironmentInterface(abc.ABC, Generic[MetadataT]):

--- a/nemo_rl/environments/interfaces.py
+++ b/nemo_rl/environments/interfaces.py
@@ -44,7 +44,6 @@ class EnvironmentReturn(NamedTuple, Generic[MetadataT]):
     metadata: list[MetadataT]
     next_stop_strings: list[list[str] | None] | list[None]
     rewards: Tensor
-    extracted_answers: list[str | None]
     terminateds: Tensor
 
 

--- a/nemo_rl/environments/math_environment.py
+++ b/nemo_rl/environments/math_environment.py
@@ -15,7 +15,7 @@ import contextlib
 import io
 import logging
 import re
-from typing import Any, Optional, TypedDict, Union
+from typing import Any, Optional, TypedDict
 
 import ray
 import torch
@@ -72,8 +72,7 @@ class HFVerifyWorker:
         self,
         pred_responses: list[str],
         ground_truths: list[str],
-        return_extracted_answer: bool = False,
-    ) -> Union[list[float], tuple[list[float], list[str | None]]]:
+    ) -> tuple[list[float], list[str | None]]:
         """Verify the correctness of the predicted responses against the ground truth.
 
         Args:
@@ -81,9 +80,7 @@ class HFVerifyWorker:
             ground_truths: list[str]. The ground truth responses.
 
         Returns:
-            Union[list[float], tuple[list[float], list[str | None]]].
-            If return_extracted_answer is False, returns only the scores.
-            If return_extracted_answer is True, returns (scores, extracted_answers).
+            tuple[list[float], list[str | None]].
         """
         results = []
         extracted_answers: list[str | None] = []
@@ -101,25 +98,22 @@ class HFVerifyWorker:
                     # to catch it.
                     except (Exception, TimeoutException):
                         ret_score = 0.0
-                        extracted_answers = None
+                        extracted_answer = None
 
                 results.append(float(ret_score))
-                if return_extracted_answer:
-                    # Make sure the extracted answer is not None and is a list of two elements
-                    assert extracted_answer is not None
-                    assert len(extracted_answer) == 2
-                    # The extracted answer is a list of two elements. The first element is the gold answer.
-                    # The second element is the predicted answer. The predicted answer also includes two
-                    # elements which are parsed with different ExtractionConfig. (Not sure why there are two elements.)
-                    # We choose the first element as the predicted answer.
-                    extracted_answers.append(extracted_answer[1][0][0])
+                # Make sure the extracted answer is not None and is a list of two elements
+                assert extracted_answer is not None
+                assert len(extracted_answer) == 2
+                # The extracted answer is a list of two elements. The first element is the gold answer.
+                # The second element is the predicted answer. The predicted answer also includes two
+                # elements which are parsed with different ExtractionConfig. (Not sure why there are two elements.)
+                # We choose the first element as the predicted answer.
+                extracted_answers.append(extracted_answer[1][0][0])
             except Exception:
                 results.append(0.0)
                 extracted_answers.append(None)
-        if return_extracted_answer:
-            return results, extracted_answers
-        else:
-            return results
+
+        return results, extracted_answers
 
 
 @ray.remote  # pragma: no cover
@@ -128,19 +122,15 @@ class MultilingualMultichoiceVerifyWorker:
         self,
         pred_responses: list[str],
         ground_truths: list[str],
-        return_extracted_answer: bool = False,
-    ) -> Union[list[float], tuple[list[float], list[str | None]]]:
+    ) -> tuple[list[float], list[str | None]]:
         """Verify the correctness of the predicted responses against the ground truth.
 
         Args:
             pred_responses: list[str]. The predicted responses from the LLM.
             ground_truths: list[str]. The ground truth responses.
-            return_extracted_answer: bool. Whether to return extracted answers along with scores.
 
         Returns:
-            Union[list[float], tuple[list[float], list[str | None]]].
-            If return_extracted_answer is False, returns only the scores.
-            If return_extracted_answer is True, returns (scores, extracted_answers).
+            tuple[list[float], list[str | None]].
         """
         results = []
         extracted_answers: list[str | None] = []
@@ -162,31 +152,22 @@ class MultilingualMultichoiceVerifyWorker:
             results.append(score)
             extracted_answers.append(extracted_answer)
 
-        if return_extracted_answer:
-            return results, extracted_answers
-        else:
-            return results
+        return results, extracted_answers
 
 
 @ray.remote  # pragma: no cover
 class EnglishMultichoiceVerifyWorker:
     def verify(
-        self,
-        pred_responses: list[str],
-        ground_truths: list[str],
-        return_extracted_answer: bool = False,
-    ) -> Union[list[float], tuple[list[float], list[str | None]]]:
+        self, pred_responses: list[str], ground_truths: list[str]
+    ) -> tuple[list[float], list[str | None]]:
         """Verify the correctness of the predicted responses against the ground truth.
 
         Args:
             pred_responses: list[str]. The predicted responses from the LLM.
             ground_truths: list[str]. The ground truth responses.
-            return_extracted_answer: bool. Whether to return extracted answers along with scores.
 
         Returns:
-            Union[list[float], tuple[list[float], list[str | None]]].
-            If return_extracted_answer is False, returns only the scores.
-            If return_extracted_answer is True, returns (scores, extracted_answers).
+            tuple[list[float], list[str | None]].
         """
         results = []
         extracted_answers: list[str | None] = []
@@ -202,17 +183,14 @@ class EnglishMultichoiceVerifyWorker:
                 )
             score = 1.0 if extracted_answer == ground_truth else 0.0
             results.append(score)
-            if return_extracted_answer:
-                extracted_answers.append(extracted_answer)
+            extracted_answers.append(extracted_answer)
 
-        if return_extracted_answer:
-            return results, extracted_answers
-        else:
-            return results
+        return results, extracted_answers
 
 
 class MathEnvironmentMetadata(TypedDict):
     ground_truth: str
+    extracted_answer: str | None
 
 
 @ray.remote(max_restarts=-1, max_task_retries=-1)  # pragma: no cover
@@ -252,8 +230,7 @@ class MathEnvironment(EnvironmentInterface[MathEnvironmentMetadata]):
 
         Args:
             message_log: list[list[dict[str, str]]]. A batch of OpenAI-API-like message logs that represent interactions with the LLM.
-            metadata: list[MathEnvironmentMetadata]. The grader will use the 'ground_truth' key to evaluate correctness.
-            return_extracted_answer: bool. Whether to extract and return answers in metadata.
+            metadata: list[MathEnvironmentMetadata]. The grader will use the 'ground_truth' key to evaluate correctness. The extracted answer will be stored to caculate cons@k.
 
         Returns:
             EnvironmentReturn: A tuple containing:
@@ -283,9 +260,7 @@ class MathEnvironment(EnvironmentInterface[MathEnvironmentMetadata]):
 
         # Process each chunk in parallel
         futures = [
-            self.workers[i].verify.remote(
-                chunk, ground_truth_chunk, return_extracted_answer
-            )
+            self.workers[i].verify.remote(chunk, ground_truth_chunk)
             for i, (chunk, ground_truth_chunk) in enumerate(
                 zip(chunked_assistant_response_batch, chunked_ground_truths)
             )
@@ -298,12 +273,9 @@ class MathEnvironment(EnvironmentInterface[MathEnvironmentMetadata]):
         extracted_answers_list: list[str | None] = []
 
         for worker_result in worker_results:
-            if return_extracted_answer:
-                worker_scores, worker_answers = worker_result
-                results.extend(worker_scores)
-                extracted_answers_list.extend(worker_answers)
-            else:
-                results.extend(worker_result)
+            worker_scores, worker_answers = worker_result
+            results.extend(worker_scores)
+            extracted_answers_list.extend(worker_answers)
 
         observations = [
             {
@@ -318,15 +290,17 @@ class MathEnvironment(EnvironmentInterface[MathEnvironmentMetadata]):
         # create a tensor of rewards and done flags
         rewards = torch.tensor(results).cpu()
         done = torch.ones_like(rewards).cpu()
-        extracted_answers = extracted_answers_list if return_extracted_answer else None
         next_stop_strings = [None] * len(message_log_batch)
+        metadata = [
+            {**m, "extracted_answer": extracted_answers_list[i]}
+            for i, m in enumerate(metadata)
+        ]
 
         return EnvironmentReturn(
             observations=observations,
             metadata=metadata,
             next_stop_strings=next_stop_strings,
             rewards=rewards,
-            extracted_answers=extracted_answers,
             terminateds=done,
         )
 

--- a/nemo_rl/environments/math_environment.py
+++ b/nemo_rl/environments/math_environment.py
@@ -322,7 +322,7 @@ class MathEnvironment(EnvironmentInterface[MathEnvironmentMetadata]):
         info = (
             [{"extracted_answer": answer} for answer in extracted_answers_list]
             if extracted_answers_list
-            else None
+            else [None] * len(message_log_batch)
         )
 
         return EnvironmentReturn(

--- a/nemo_rl/environments/math_environment.py
+++ b/nemo_rl/environments/math_environment.py
@@ -74,7 +74,7 @@ class HFVerifyWorker:
         pred_responses: list[str],
         ground_truths: list[str],
         return_extracted_answer: bool = False,
-    ) -> Union[list[float], tuple[list[float], list[str | None] | None]]:
+    ) -> Union[list[float], tuple[list[float], list[str | None]]]:
         """Verify the correctness of the predicted responses against the ground truth.
 
         Args:
@@ -82,14 +82,12 @@ class HFVerifyWorker:
             ground_truths: list[str]. The ground truth responses.
 
         Returns:
-            Union[list[float], tuple[list[float], list[str | None]| None]].
+            Union[list[float], tuple[list[float], list[str | None]]].
             If return_extracted_answer is False, returns only the scores.
             If return_extracted_answer is True, returns (scores, extracted_answers).
         """
         results = []
-        extracted_answers: list[str | None] | None = (
-            [] if return_extracted_answer else None
-        )
+        extracted_answers: list[str | None] = []
 
         for response, ground_truth in zip(pred_responses, ground_truths):
             try:
@@ -135,7 +133,7 @@ class MultilingualMultichoiceVerifyWorker:
         pred_responses: list[str],
         ground_truths: list[str],
         return_extracted_answer: bool = False,
-    ) -> Union[list[float], tuple[list[float], list[str | None] | None]]:
+    ) -> Union[list[float], tuple[list[float], list[str | None]]]:
         """Verify the correctness of the predicted responses against the ground truth.
 
         Args:
@@ -143,14 +141,12 @@ class MultilingualMultichoiceVerifyWorker:
             ground_truths: list[str]. The ground truth responses.
 
         Returns:
-            Union[list[float], tuple[list[float], list[str | None]| None]].
+            Union[list[float], tuple[list[float], list[str | None]]].
             If return_extracted_answer is False, returns only the scores.
             If return_extracted_answer is True, returns (scores, extracted_answers).
         """
         results = []
-        extracted_answers: list[str | None] | None = (
-            [] if return_extracted_answer else None
-        )
+        extracted_answers: list[str | None] = []
 
         for response, ground_truth in zip(pred_responses, ground_truths):
             response = answer_parsing.normalize_response(response)
@@ -182,7 +178,7 @@ class EnglishMultichoiceVerifyWorker:
         pred_responses: list[str],
         ground_truths: list[str],
         return_extracted_answer: bool = False,
-    ) -> Union[list[float], tuple[list[float], list[str | None] | None]]:
+    ) -> Union[list[float], tuple[list[float], list[str | None]]]:
         """Verify the correctness of the predicted responses against the ground truth.
 
         Args:
@@ -190,14 +186,12 @@ class EnglishMultichoiceVerifyWorker:
             ground_truths: list[str]. The ground truth responses.
 
         Returns:
-            Union[list[float], tuple[list[float], list[str | None]| None]].
+            Union[list[float], tuple[list[float], list[str | None]]].
             If return_extracted_answer is False, returns only the scores.
             If return_extracted_answer is True, returns (scores, extracted_answers).
         """
         results = []
-        extracted_answers: list[str | None] | None = (
-            [] if return_extracted_answer else None
-        )
+        extracted_answers: list[str | None] = []
 
         for response, ground_truth in zip(pred_responses, ground_truths):
             ground_truth = answer_parsing.normalize_response(ground_truth)

--- a/nemo_rl/environments/math_environment.py
+++ b/nemo_rl/environments/math_environment.py
@@ -74,7 +74,7 @@ class HFVerifyWorker:
         pred_responses: list[str],
         ground_truths: list[str],
         return_extracted_answer: bool = False,
-    ) -> Union[list[float], tuple[list[float], list[str | None]]]:
+    ) -> Union[list[float], tuple[list[float], list[str | None] | None]]:
         """Verify the correctness of the predicted responses against the ground truth.
 
         Args:
@@ -82,12 +82,14 @@ class HFVerifyWorker:
             ground_truths: list[str]. The ground truth responses.
 
         Returns:
-            Union[list[float], tuple[list[float], list[str | None]]].
+            Union[list[float], tuple[list[float], list[str | None]| None]].
             If return_extracted_answer is False, returns only the scores.
             If return_extracted_answer is True, returns (scores, extracted_answers).
         """
         results = []
-        extracted_answers: list[str | None] = []
+        extracted_answers: list[str | None] | None = (
+            [] if return_extracted_answer else None
+        )
 
         for response, ground_truth in zip(pred_responses, ground_truths):
             try:
@@ -133,7 +135,7 @@ class MultilingualMultichoiceVerifyWorker:
         pred_responses: list[str],
         ground_truths: list[str],
         return_extracted_answer: bool = False,
-    ) -> Union[list[float], tuple[list[float], list[str | None]]]:
+    ) -> Union[list[float], tuple[list[float], list[str | None] | None]]:
         """Verify the correctness of the predicted responses against the ground truth.
 
         Args:
@@ -141,12 +143,14 @@ class MultilingualMultichoiceVerifyWorker:
             ground_truths: list[str]. The ground truth responses.
 
         Returns:
-            Union[list[float], tuple[list[float], list[str | None]]].
+            Union[list[float], tuple[list[float], list[str | None]| None]].
             If return_extracted_answer is False, returns only the scores.
             If return_extracted_answer is True, returns (scores, extracted_answers).
         """
         results = []
-        extracted_answers: list[str | None] = []
+        extracted_answers: list[str | None] | None = (
+            [] if return_extracted_answer else None
+        )
 
         for response, ground_truth in zip(pred_responses, ground_truths):
             response = answer_parsing.normalize_response(response)
@@ -178,7 +182,7 @@ class EnglishMultichoiceVerifyWorker:
         pred_responses: list[str],
         ground_truths: list[str],
         return_extracted_answer: bool = False,
-    ) -> Union[list[float], tuple[list[float], list[str | None]]]:
+    ) -> Union[list[float], tuple[list[float], list[str | None] | None]]:
         """Verify the correctness of the predicted responses against the ground truth.
 
         Args:
@@ -186,12 +190,14 @@ class EnglishMultichoiceVerifyWorker:
             ground_truths: list[str]. The ground truth responses.
 
         Returns:
-            Union[list[float], tuple[list[float], list[str | None]]].
+            Union[list[float], tuple[list[float], list[str | None]| None]].
             If return_extracted_answer is False, returns only the scores.
             If return_extracted_answer is True, returns (scores, extracted_answers).
         """
         results = []
-        extracted_answers: list[str | None] = []
+        extracted_answers: list[str | None] | None = (
+            [] if return_extracted_answer else None
+        )
 
         for response, ground_truth in zip(pred_responses, ground_truths):
             ground_truth = answer_parsing.normalize_response(ground_truth)
@@ -297,7 +303,9 @@ class MathEnvironment(EnvironmentInterface[MathEnvironmentMetadata]):
 
         # Flatten the results and extract both scores and answers
         results = []
-        extracted_answers: list[str | None] = [] if return_extracted_answer else None
+        extracted_answers: list[str | None] | None = (
+            [] if return_extracted_answer else None
+        )
 
         for worker_result in worker_results:
             if return_extracted_answer:

--- a/nemo_rl/environments/math_environment.py
+++ b/nemo_rl/environments/math_environment.py
@@ -297,13 +297,13 @@ class MathEnvironment(EnvironmentInterface[MathEnvironmentMetadata]):
 
         # Flatten the results and extract both scores and answers
         results = []
-        extracted_answers_list: list[str | None] = []
+        extracted_answers: list[str | None] = []
 
         for worker_result in worker_results:
             if return_extracted_answer:
                 worker_scores, worker_answers = worker_result
                 results.extend(worker_scores)
-                extracted_answers_list.extend(worker_answers)
+                extracted_answers.extend(worker_answers)
             else:
                 results.extend(worker_result)
 
@@ -322,19 +322,13 @@ class MathEnvironment(EnvironmentInterface[MathEnvironmentMetadata]):
         done = torch.ones_like(rewards).cpu()
         next_stop_strings = [None] * len(message_log_batch)
 
-        info = (
-            [{"extracted_answer": answer} for answer in extracted_answers_list]
-            if extracted_answers_list
-            else [None] * len(message_log_batch)
-        )
-
         return EnvironmentReturn(
             observations=observations,
             metadata=metadata,
             next_stop_strings=next_stop_strings,
             rewards=rewards,
             terminateds=done,
-            info=info,
+            answers=extracted_answers,
         )
 
     def global_post_process_and_metrics(

--- a/nemo_rl/environments/math_environment.py
+++ b/nemo_rl/environments/math_environment.py
@@ -297,7 +297,7 @@ class MathEnvironment(EnvironmentInterface[MathEnvironmentMetadata]):
 
         # Flatten the results and extract both scores and answers
         results = []
-        extracted_answers: list[str | None] = []
+        extracted_answers: list[str | None] = [] if return_extracted_answer else None
 
         for worker_result in worker_results:
             if return_extracted_answer:

--- a/nemo_rl/environments/tools/retriever.py
+++ b/nemo_rl/environments/tools/retriever.py
@@ -162,6 +162,7 @@ class RAGEnvironment(EnvironmentInterface):
         self,
         message_log_batch: List[LLMMessageLogType],
         metadata_batch: List[Dict[str, Any]],
+        return_extracted_answer: bool = False,
     ) -> EnvironmentReturn:
         """Process a batch of retrieval steps."""
         # Extract queries from the last message in each log
@@ -186,12 +187,18 @@ class RAGEnvironment(EnvironmentInterface):
         terminated_tensor = torch.ones(batch_size, dtype=torch.bool)
         next_stop_strings = [["</retrieve>"]] * batch_size
 
+        assert return_extracted_answer == False, (
+            "return_extracted_answer is not supported in RAGEnvironment. Please set it to False."
+        )
+        extracted_answers = None
+
         return EnvironmentReturn(
             observations=results,
             metadata=metadata_batch,
             next_stop_strings=next_stop_strings,
             rewards=rewards_tensor,
             terminateds=terminated_tensor,
+            answers=extracted_answers,
         )
 
     def shutdown(self):

--- a/nemo_rl/evals/eval.py
+++ b/nemo_rl/evals/eval.py
@@ -340,8 +340,8 @@ async def _run_env_eval_impl(
             get_keys_from_message_log(batch["message_log"][i], ["role", "content"])
             for i in range(len(batch["message_log"]))
         ]
-        # Set return_extracted_answer to True to get the extracted answers
-        env_return = ray.get(env.step.remote(to_env, batch["extra_env_info"], True))
+
+        env_return = ray.get(env.step.remote(to_env, batch["extra_env_info"]))
         rewards = env_return.rewards
 
         # Collect data for JSON file
@@ -365,7 +365,7 @@ async def _run_env_eval_impl(
                 }
             )
 
-        extracted_answers = env_return.extracted_answers
+        extracted_answers = [m["extracted_answer"] for m in env_return.metadata]
         # update stats
         if metric == "pass@k":
             score += eval_pass_k(rewards, num_tests_per_prompt, k_value)

--- a/nemo_rl/evals/eval.py
+++ b/nemo_rl/evals/eval.py
@@ -493,6 +493,6 @@ def _print_results(
     print("\n" + "=" * 60)
     print(f"{model_name=} {dataset_name=}")
     print(f"{max_new_tokens=} {temperature=} {top_p=} {top_k=}\n")
-    print(f"{metric=} {k_value=} {num_tests_per_prompt=}\n")
+    print(f"metric={metric}@{k_value} {num_tests_per_prompt=}\n")
     print(f"score={average_score:.4f} ({score}/{dataset_size})")
     print("=" * 60 + "\n")

--- a/nemo_rl/evals/eval.py
+++ b/nemo_rl/evals/eval.py
@@ -104,9 +104,9 @@ def setup(
             "temperature > 0 and top_k != 1 are required for multiple samples"
         )
 
-    assert k_value >= 1, "k_value must be greater than or equal to 1 for pass@k metric"
+    assert k_value >= 1, "k_value must be greater than or equal to 1"
     assert num_tests_per_prompt >= k_value, (
-        "num_tests_per_prompt must be greater than or equal to k_value for pass@k metric"
+        "num_tests_per_prompt must be greater than or equal to k_value "
     )
 
     # ==========================

--- a/nemo_rl/evals/eval.py
+++ b/nemo_rl/evals/eval.py
@@ -15,6 +15,8 @@
 import asyncio
 import json
 import os
+from collections import Counter
+from itertools import combinations
 from typing import TypedDict
 
 import ray
@@ -95,17 +97,14 @@ def setup(
     temperature = generation_config["temperature"]
     top_k = generation_config["top_k"]
 
-    # TODO @yukih: support cons@k
     # Validate metrics
-    assert metric in ["pass@k"], f"Invalid metric: {metric}"
+    assert metric in ["pass@k", "cons@k"], f"Invalid metric: {metric}"
     if num_tests_per_prompt > 1:
         assert temperature > 0 and top_k != 1, (
             "temperature > 0 and top_k != 1 are required for multiple samples"
         )
 
-    assert k_value >= 1, (
-        "k_value must be greater than or equal to 1 for pass@k metric"
-    )
+    assert k_value >= 1, "k_value must be greater than or equal to 1 for pass@k metric"
     assert num_tests_per_prompt >= k_value, (
         "num_tests_per_prompt must be greater than or equal to k_value for pass@k metric"
     )
@@ -194,20 +193,80 @@ def eval_pass_k(rewards: torch.Tensor, num_tests_per_prompt: int, k: int) -> flo
 
     return pass_k_score
 
-def eval_cons_k(rewards: torch.Tensor, num_tests_per_prompt: int, k: int, extracted_answers: list[list[str]| None]) -> float:
+
+def eval_cons_k(
+    rewards: torch.Tensor,
+    num_tests_per_prompt: int,
+    k: int,
+    extracted_answers: list[str | None],
+) -> float:
     """Evaluate cons@k score using an unbiased estimator.
-    
+
     Args:
         rewards: Tensor of shape (batch_size * num_tests_per_prompt)
         num_tests_per_prompt: int
         k: int
-        extracted_answers: list[list[str]| None]
+        extracted_answers: list[str| None]
 
     Returns:
         cons_k_score: float
     """
-    pass
-    
+
+    def majority_vote(answers: list[str | None]) -> str | None:
+        """Find the most common answer in the list of answers."""
+        if not answers:
+            return None
+        # To fix@rayentian: How to deal with the case that there are multiple most common answers? Now we just return the first one.
+        return Counter(answers).most_common(1)[0][0]
+
+    def eval_single_cons_k(
+        chunk_rewards: torch.Tensor, chunk_answers: list[str | None], n: int, k: int
+    ) -> float:
+        if chunk_answers is None or n == 0 or k > n:
+            return 0.0
+
+        total_subsets = 0
+        correct_subsets = 0
+        # For each subset of k answers, we vote for the most common answer.
+        # If the most common answer is the same as the gold answer, we consider the subset as correct.
+        for subset_indices in combinations(range(n), k):
+            subset_answers = [chunk_answers[i] for i in subset_indices]
+            majority_answer = majority_vote(subset_answers)
+            reward_idx = chunk_answers.index(majority_answer)
+            reward = chunk_rewards[reward_idx].item()
+            total_subsets += 1
+            if reward == 1.0:
+                correct_subsets += 1
+
+        return correct_subsets / total_subsets
+
+    assert len(extracted_answers) == len(rewards), (
+        "The number of extracted answers must be the same as the number of rewards"
+    )
+    # Split the rewards and extracted answers into groups of num_tests_per_prompt.
+    group_rewards = rewards.split(num_tests_per_prompt)
+    group_extracted_answers = [
+        extracted_answers[i : i + num_tests_per_prompt]
+        for i in range(0, len(extracted_answers), num_tests_per_prompt)
+    ]
+    assert len(group_rewards) == len(group_extracted_answers), (
+        "The number of rewards and extracted answers must be the same"
+    )
+    num_groups = len(group_rewards)
+    cons_k_score = 0.0
+    # For each group of num_tests_per_prompt rewards and extracted answers, we evaluate the cons@k score.
+    for i in range(num_groups):
+        chunk_rewards = group_rewards[i]
+        chunk_answers = group_extracted_answers[i]
+        assert len(chunk_rewards) == len(chunk_answers), (
+            "The number of rewards and extracted answers must be the same"
+        )
+        cons_k_score += eval_single_cons_k(
+            chunk_rewards, chunk_answers, len(chunk_answers), k
+        )
+
+    return cons_k_score
+
 
 def run_env_eval(vllm_generation, dataloader, env, master_config):
     """Main entry point for running evaluation using environment.
@@ -282,7 +341,7 @@ async def _run_env_eval_impl(
             for i in range(len(batch["message_log"]))
         ]
         # Set return_extracted_answer to True to get the extracted answers
-        env_return = ray.get(env.step.remote(to_env, batch["extra_env_info"],True))
+        env_return = ray.get(env.step.remote(to_env, batch["extra_env_info"], True))
         rewards = env_return.rewards
 
         # Collect data for JSON file
@@ -310,6 +369,10 @@ async def _run_env_eval_impl(
         # update stats
         if metric == "pass@k":
             score += eval_pass_k(rewards, num_tests_per_prompt, k_value)
+        elif metric == "cons@k":
+            score += eval_cons_k(
+                rewards, num_tests_per_prompt, k_value, extracted_answers
+            )
         else:
             raise ValueError(f"Invalid metric: {metric}")
 
@@ -329,7 +392,7 @@ async def _run_env_eval_impl(
         score,
         len(dataloader.dataset),
         metric,
-        pass_k_value,
+        k_value,
         num_tests_per_prompt,
     )
 
@@ -415,7 +478,7 @@ def _print_results(
     score,
     dataset_size,
     metric,
-    pass_k_value,
+    k_value,
     num_tests_per_prompt,
 ):
     """Print evaluation results."""

--- a/nemo_rl/evals/eval.py
+++ b/nemo_rl/evals/eval.py
@@ -493,6 +493,6 @@ def _print_results(
     print("\n" + "=" * 60)
     print(f"{model_name=} {dataset_name=}")
     print(f"{max_new_tokens=} {temperature=} {top_p=} {top_k=}\n")
-    print(f"metric={metric}@{k_value} {num_tests_per_prompt=}\n")
+    print(f"metric={metric[:-1]}{k_value} {num_tests_per_prompt=}\n")
     print(f"score={average_score:.4f} ({score}/{dataset_size})")
     print("=" * 60 + "\n")

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -264,15 +264,23 @@ def calculate_rewards(
     all_next_stop_strings = []
     all_metadata = []  # Store extracted metadata
     all_indices_order = []
+    all_info = []
 
     for future, result in zip(futures, results):
         indices = future_to_indices[future]
         # Environment step returns: EnvironmentReturn
-        env_observations, metadata, next_stop_strings, task_rewards, terminateds, _ = (
-            result
-        )
+        (
+            env_observations,
+            metadata,
+            next_stop_strings,
+            task_rewards,
+            terminateds,
+            info,
+        ) = result
         if next_stop_strings is None:
             next_stop_strings = [None] * len(task_rewards)
+        if info is None:
+            info = [None] * len(task_rewards)
 
         # Store results with their original indices
         for i, idx in enumerate(indices):
@@ -282,6 +290,7 @@ def calculate_rewards(
             all_terminateds.append(terminateds[i])
             all_next_stop_strings.append(next_stop_strings[i])
             all_metadata.append(metadata[i])
+            all_info.append(info[i])
 
     # Sort results by original index to maintain order
     sorted_indices = sorted(
@@ -292,6 +301,7 @@ def calculate_rewards(
     terminateds = torch.tensor([all_terminateds[i] for i in sorted_indices])
     next_stop_strings = [all_next_stop_strings[i] for i in sorted_indices]
     metadata = [all_metadata[i] for i in sorted_indices]  # Sort metadata
+    info = [all_info[i] for i in sorted_indices]
 
     return EnvironmentReturn(
         observations=env_observations,
@@ -299,6 +309,7 @@ def calculate_rewards(
         next_stop_strings=next_stop_strings,
         rewards=rewards,
         terminateds=terminateds,
+        info=info,
     )
 
 

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -264,7 +264,7 @@ def calculate_rewards(
     all_next_stop_strings = []
     all_metadata = []  # Store extracted metadata
     all_indices_order = []
-    all_info = []
+    all_answers = []
 
     for future, result in zip(futures, results):
         indices = future_to_indices[future]
@@ -275,12 +275,12 @@ def calculate_rewards(
             next_stop_strings,
             task_rewards,
             terminateds,
-            info,
+            answers,
         ) = result
         if next_stop_strings is None:
             next_stop_strings = [None] * len(task_rewards)
-        if info is None:
-            info = [None] * len(task_rewards)
+        if answers is None:
+            answers = [None] * len(task_rewards)
 
         # Store results with their original indices
         for i, idx in enumerate(indices):
@@ -290,7 +290,7 @@ def calculate_rewards(
             all_terminateds.append(terminateds[i])
             all_next_stop_strings.append(next_stop_strings[i])
             all_metadata.append(metadata[i])
-            all_info.append(info[i])
+            all_answers.append(answers[i])
 
     # Sort results by original index to maintain order
     sorted_indices = sorted(
@@ -301,7 +301,7 @@ def calculate_rewards(
     terminateds = torch.tensor([all_terminateds[i] for i in sorted_indices])
     next_stop_strings = [all_next_stop_strings[i] for i in sorted_indices]
     metadata = [all_metadata[i] for i in sorted_indices]  # Sort metadata
-    info = [all_info[i] for i in sorted_indices]
+    answers = [all_answers[i] for i in sorted_indices]
 
     return EnvironmentReturn(
         observations=env_observations,
@@ -309,7 +309,7 @@ def calculate_rewards(
         next_stop_strings=next_stop_strings,
         rewards=rewards,
         terminateds=terminateds,
-        info=info,
+        answers=answers,
     )
 
 

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -268,7 +268,7 @@ def calculate_rewards(
     for future, result in zip(futures, results):
         indices = future_to_indices[future]
         # Environment step returns: EnvironmentReturn
-        env_observations, metadata, next_stop_strings, task_rewards, terminateds = (
+        env_observations, metadata, next_stop_strings, task_rewards, terminateds, _ = (
             result
         )
         if next_stop_strings is None:

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -41,6 +41,7 @@ class MockEnvironment(EnvironmentInterface):
             [[]] * len(messages),
             self.rewards,
             [True] * len(messages),
+            [None] * len(messages),
         )
 
     def get_calls(self):
@@ -126,7 +127,7 @@ def test_calculate_rewards_single_task(mock_env):
     assert len(terminateds) == 2
     assert len(next_stop_strings) == 2
     assert len(metadata) == 2
-    assert info is None
+    assert len(info) == 2
     assert torch.allclose(rewards, torch.tensor([1.0, 2.0]))
     assert (
         ray.get(mock_env.get_calls.remote()) == 1
@@ -162,7 +163,7 @@ def test_calculate_rewards_multiple_tasks(mock_envs):
     assert len(terminateds) == 4
     assert len(next_stop_strings) == 4
     assert len(metadata) == 4
-    assert info is None
+    assert len(info) == 4
     assert torch.allclose(rewards, torch.tensor([1.0, 2.0, 3.0, 4.0]))
     assert (
         ray.get(mock_envs["math"].get_calls.remote()) == 1
@@ -190,7 +191,7 @@ def test_calculate_rewards_empty_batch(mock_env):
     assert len(terminateds) == 0
     assert len(next_stop_strings) == 0
     assert len(metadata) == 0
-    assert info is None
+    assert len(info) == 0
     assert (
         ray.get(mock_env.get_calls.remote()) == 0
     )  # Should not call environment for empty batch

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -117,7 +117,7 @@ def test_calculate_rewards_single_task(mock_env):
     batch = create_mock_batch(2, task_names, message_logs)
 
     # Calculate rewards
-    env_observations, metadata, next_stop_strings, rewards, terminateds, info = (
+    env_observations, metadata, next_stop_strings, rewards, terminateds, answers = (
         calculate_rewards(batch, task_to_env)
     )
 
@@ -127,7 +127,7 @@ def test_calculate_rewards_single_task(mock_env):
     assert len(terminateds) == 2
     assert len(next_stop_strings) == 2
     assert len(metadata) == 2
-    assert len(info) == 2
+    assert len(answers) == 2
     assert torch.allclose(rewards, torch.tensor([1.0, 2.0]))
     assert (
         ray.get(mock_env.get_calls.remote()) == 1
@@ -153,7 +153,7 @@ def test_calculate_rewards_multiple_tasks(mock_envs):
     batch = create_mock_batch(4, task_names, message_logs)
 
     # Calculate rewards
-    env_observations, metadata, next_stop_strings, rewards, terminateds, info = (
+    env_observations, metadata, next_stop_strings, rewards, terminateds, answers = (
         calculate_rewards(batch, mock_envs)
     )
 
@@ -163,7 +163,7 @@ def test_calculate_rewards_multiple_tasks(mock_envs):
     assert len(terminateds) == 4
     assert len(next_stop_strings) == 4
     assert len(metadata) == 4
-    assert len(info) == 4
+    assert len(answers) == 4
     assert torch.allclose(rewards, torch.tensor([1.0, 2.0, 3.0, 4.0]))
     assert (
         ray.get(mock_envs["math"].get_calls.remote()) == 1
@@ -181,7 +181,7 @@ def test_calculate_rewards_empty_batch(mock_env):
     batch = create_mock_batch(0, [], [])
 
     # Calculate rewards
-    env_observations, metadata, next_stop_strings, rewards, terminateds, info = (
+    env_observations, metadata, next_stop_strings, rewards, terminateds, answers = (
         calculate_rewards(batch, task_to_env)
     )
 
@@ -191,7 +191,7 @@ def test_calculate_rewards_empty_batch(mock_env):
     assert len(terminateds) == 0
     assert len(next_stop_strings) == 0
     assert len(metadata) == 0
-    assert len(info) == 0
+    assert len(answers) == 0
     assert (
         ray.get(mock_env.get_calls.remote()) == 0
     )  # Should not call environment for empty batch

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -116,7 +116,7 @@ def test_calculate_rewards_single_task(mock_env):
     batch = create_mock_batch(2, task_names, message_logs)
 
     # Calculate rewards
-    env_observations, metadata, next_stop_strings, rewards, terminateds = (
+    env_observations, metadata, next_stop_strings, rewards, terminateds, info = (
         calculate_rewards(batch, task_to_env)
     )
 
@@ -126,6 +126,7 @@ def test_calculate_rewards_single_task(mock_env):
     assert len(terminateds) == 2
     assert len(next_stop_strings) == 2
     assert len(metadata) == 2
+    assert info is None
     assert torch.allclose(rewards, torch.tensor([1.0, 2.0]))
     assert (
         ray.get(mock_env.get_calls.remote()) == 1
@@ -151,7 +152,7 @@ def test_calculate_rewards_multiple_tasks(mock_envs):
     batch = create_mock_batch(4, task_names, message_logs)
 
     # Calculate rewards
-    env_observations, metadata, next_stop_strings, rewards, terminateds = (
+    env_observations, metadata, next_stop_strings, rewards, terminateds, info = (
         calculate_rewards(batch, mock_envs)
     )
 
@@ -161,6 +162,7 @@ def test_calculate_rewards_multiple_tasks(mock_envs):
     assert len(terminateds) == 4
     assert len(next_stop_strings) == 4
     assert len(metadata) == 4
+    assert info is None
     assert torch.allclose(rewards, torch.tensor([1.0, 2.0, 3.0, 4.0]))
     assert (
         ray.get(mock_envs["math"].get_calls.remote()) == 1
@@ -178,7 +180,7 @@ def test_calculate_rewards_empty_batch(mock_env):
     batch = create_mock_batch(0, [], [])
 
     # Calculate rewards
-    env_observations, metadata, next_stop_strings, rewards, terminateds = (
+    env_observations, metadata, next_stop_strings, rewards, terminateds, info = (
         calculate_rewards(batch, task_to_env)
     )
 
@@ -188,6 +190,7 @@ def test_calculate_rewards_empty_batch(mock_env):
     assert len(terminateds) == 0
     assert len(next_stop_strings) == 0
     assert len(metadata) == 0
+    assert info is None
     assert (
         ray.get(mock_env.get_calls.remote()) == 0
     )  # Should not call environment for empty batch

--- a/tests/unit/evals/test_eval.py
+++ b/tests/unit/evals/test_eval.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+import torch
+
+from nemo_rl.evals.eval import (
+    eval_cons_k,
+    eval_pass_k,
+)
+
+
+def test_eval_pass_k_basic():
+    """Test basic pass@k evaluation."""
+    # Test case: 3 samples, 2 correct, k=1
+    rewards = torch.tensor([1.0, 0.0, 1.0])
+    result = eval_pass_k(rewards, num_tests_per_prompt=3, k=1)
+    expected = 2 / 3
+    assert isinstance(result, float)
+    assert result == pytest.approx(expected, rel=1e-6)
+
+
+def test_eval_pass_k_all_correct():
+    """Test pass@k when all samples are correct."""
+    rewards = torch.tensor([1.0, 1.0, 1.0])
+    result = eval_pass_k(rewards, num_tests_per_prompt=3, k=1)
+    expected = 1.0
+    assert isinstance(result, float)
+    assert result == pytest.approx(expected, rel=1e-6)
+
+
+def test_eval_pass_k_none_correct():
+    """Test pass@k when no samples are correct."""
+    rewards = torch.tensor([0.0, 0.0, 0.0])
+    result = eval_pass_k(rewards, num_tests_per_prompt=3, k=1)
+    expected = 0.0
+    assert isinstance(result, float)
+    assert result == pytest.approx(expected, rel=1e-6)
+
+
+def test_eval_pass_k_multiple_groups():
+    """Test pass@k with multiple groups."""
+    # Two groups: [1,0,1] and [0,1,0]
+    rewards = torch.tensor([1.0, 0.0, 1.0, 0.0, 1.0, 0.0])
+    result = eval_pass_k(rewards, num_tests_per_prompt=3, k=1)
+    expected = 1.0
+    assert isinstance(result, float)
+    assert result == pytest.approx(expected, rel=1e-6)
+
+
+def test_eval_pass_k_edge_cases():
+    """Test pass@k edge cases."""
+    # k > num_tests_per_prompt
+    rewards = torch.tensor([1.0, 0.0])
+    result = eval_pass_k(rewards, num_tests_per_prompt=2, k=3)
+    expected = 1.0
+    assert isinstance(result, float)
+    assert result == pytest.approx(expected, rel=1e-6)
+
+
+def test_eval_cons_k_basic():
+    """Test basic cons@k evaluation."""
+    rewards = torch.tensor([1.0, 0.0, 1.0])
+    extracted_answers = ["A", "B", "A"]
+    result = eval_cons_k(
+        rewards, num_tests_per_prompt=3, k=1, extracted_answers=extracted_answers
+    )
+    expected = 2 / 3
+    assert isinstance(result, float)
+    assert result == pytest.approx(expected, rel=1e-6)
+
+
+def test_eval_cons_k_multiple_groups():
+    """Test cons@k with multiple groups."""
+    rewards = torch.tensor([1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0])
+    extracted_answers = [
+        "Correct",
+        "Wrong1",
+        "Correct",
+        "Wrong2",
+        "Correct",
+        "Wrong3",
+        "Correct",
+        "Wrong4",
+        "Correct",
+        "Wrong4",
+    ]
+    result = eval_cons_k(
+        rewards, num_tests_per_prompt=5, k=3, extracted_answers=extracted_answers
+    )
+    expected = 11 / 10
+    assert isinstance(result, float)
+    assert result == pytest.approx(expected, rel=1e-6)

--- a/tests/unit/evals/test_eval.py
+++ b/tests/unit/evals/test_eval.py
@@ -26,28 +26,36 @@ def test_eval_pass_k_basic():
     """Test basic pass@k evaluation."""
     # Test case: 3 samples, 2 correct, k=1
     rewards = torch.tensor([1.0, 0.0, 1.0])
-    result = eval_pass_k(rewards, num_tests_per_prompt=3, k=1)
+    num_tests_per_prompt = 3
+    score = eval_pass_k(rewards, num_tests_per_prompt=num_tests_per_prompt, k=1)
+    group_size = len(rewards) / num_tests_per_prompt
+    average_score = score / group_size
     expected = 2 / 3
-    assert isinstance(result, float)
-    assert result == pytest.approx(expected, rel=1e-6)
+    assert isinstance(average_score, float)
+    assert average_score == pytest.approx(expected, rel=1e-6)
 
 
 def test_eval_pass_k_all_correct():
     """Test pass@k when all samples are correct."""
     rewards = torch.tensor([1.0, 1.0, 1.0])
-    result = eval_pass_k(rewards, num_tests_per_prompt=3, k=1)
+    num_tests_per_prompt = 3
+    score = eval_pass_k(rewards, num_tests_per_prompt=num_tests_per_prompt, k=1)
+    group_size = len(rewards) / num_tests_per_prompt
+    average_score = score / group_size
     expected = 1.0
-    assert isinstance(result, float)
-    assert result == pytest.approx(expected, rel=1e-6)
+    assert isinstance(average_score, float)
+    assert average_score == pytest.approx(expected, rel=1e-6)
 
 
 def test_eval_pass_k_none_correct():
     """Test pass@k when no samples are correct."""
     rewards = torch.tensor([0.0, 0.0, 0.0])
-    result = eval_pass_k(rewards, num_tests_per_prompt=3, k=1)
+    num_tests_per_prompt = 3
+    score = eval_pass_k(rewards, num_tests_per_prompt=num_tests_per_prompt, k=1)
+    average_score = score / (len(rewards) / num_tests_per_prompt)
     expected = 0.0
-    assert isinstance(result, float)
-    assert result == pytest.approx(expected, rel=1e-6)
+    assert isinstance(average_score, float)
+    assert average_score == pytest.approx(expected, rel=1e-6)
 
 
 def test_eval_pass_k_multiple_groups():
@@ -55,12 +63,11 @@ def test_eval_pass_k_multiple_groups():
     # Two groups: [1,0,1] and [0,1,0]
     rewards = torch.tensor([1.0, 0.0, 1.0, 0.0, 1.0, 0.0])
     num_tests_per_prompt = 3
-    result = eval_pass_k(rewards, num_tests_per_prompt=num_tests_per_prompt, k=1) / (
-        len(rewards) / num_tests_per_prompt
-    )
+    score = eval_pass_k(rewards, num_tests_per_prompt=num_tests_per_prompt, k=1)
+    average_score = score / (len(rewards) / num_tests_per_prompt)
     expected = 0.5
-    assert isinstance(result, float)
-    assert result == pytest.approx(expected, rel=1e-6)
+    assert isinstance(average_score, float)
+    assert average_score == pytest.approx(expected, rel=1e-6)
 
 
 def test_eval_cons_k_basic():
@@ -69,18 +76,16 @@ def test_eval_cons_k_basic():
     extracted_answers = ["A", "B", "A"]
     num_tests_per_prompt = 3
     group_size = len(rewards) / num_tests_per_prompt
-    result = (
-        eval_cons_k(
-            rewards,
-            num_tests_per_prompt=num_tests_per_prompt,
-            k=1,
-            extracted_answers=extracted_answers,
-        )
-        / group_size
+    score = eval_cons_k(
+        rewards,
+        num_tests_per_prompt=num_tests_per_prompt,
+        k=1,
+        extracted_answers=extracted_answers,
     )
+    average_score = score / group_size
     expected = 2 / 3
-    assert isinstance(result, float)
-    assert result == pytest.approx(expected, rel=1e-6)
+    assert isinstance(average_score, float)
+    assert average_score == pytest.approx(expected, rel=1e-6)
 
 
 def test_eval_cons_k_multiple_groups():
@@ -100,15 +105,14 @@ def test_eval_cons_k_multiple_groups():
         "Wrong4",
     ]
     group_size = len(rewards) / num_tests_per_prompt
-    result = (
-        eval_cons_k(
-            rewards,
-            num_tests_per_prompt=num_tests_per_prompt,
-            k=3,
-            extracted_answers=extracted_answers,
-        )
-        / group_size
+    score = eval_cons_k(
+        rewards,
+        num_tests_per_prompt=num_tests_per_prompt,
+        k=3,
+        extracted_answers=extracted_answers,
     )
+    average_score = score / group_size
+
     """
     For the first group, the extracted answers are [Correct, Wrong1, Correct, Wrong2, Correct]
     When calculating unbiased estimate of cons@3(k=3), we need to consider the majority vote of all Combination(5, 3) = 10 cases.
@@ -143,5 +147,5 @@ def test_eval_cons_k_multiple_groups():
     The final result is( 8/10 + 3/10 ) / 2 = 11/20 = 0.55
     """
     expected = 11 / 20
-    assert isinstance(result, float)
-    assert result == pytest.approx(expected, rel=1e-6)
+    assert isinstance(average_score, float)
+    assert average_score == pytest.approx(expected, rel=1e-6)

--- a/tests/unit/test_envs.py
+++ b/tests/unit/test_envs.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, TypedDict
+from typing import Optional, TypedDict
 
 import ray
 import torch
@@ -100,7 +100,7 @@ class _MultiStepCalculatorLogic:
         bool,
         Optional[list[str]],
         Optional[MultiStepCalcMetadata],
-        Optional[dict[str, Any]],
+        Optional[list[str]],
     ]:
         """Processes a single turn for the multi-step calculator task."""
         last_assistant_msg = ""
@@ -169,15 +169,15 @@ class _MultiStepCalculatorLogic:
                 next_metadata = None
 
         next_observation = {"role": "environment", "content": next_observation_content}
-        # info save the extracted answer, only assigned in the verify function
-        next_info = None
+        # next_answer only assigned in the verify function
+        next_answer = None
         return (
             next_observation,
             turn_reward,
             is_terminated,
             next_stop_strings,
             next_metadata,
-            next_info,
+            next_answer,
         )
 
 
@@ -206,15 +206,15 @@ class MultiStepCalculatorEnv(EnvironmentInterface):
         terminateds = []
         all_stop_strings = []  # List of Lists or Nones
         all_next_metadata = []
-        all_info = []
+        all_answers = []
 
-        for obs, rew, term, stops, meta, info in results:
+        for obs, rew, term, stops, meta, answ in results:
             observations.append(obs)  # obs is already dict[str, str]
             rewards.append(rew)
             terminateds.append(term)
             all_stop_strings.append(stops)
             all_next_metadata.append(meta)
-            all_info.append(info)
+            all_answers.append(answ)
 
         # Convert to tensors where needed
         rewards_tensor = torch.tensor(rewards, dtype=torch.float32)
@@ -228,7 +228,7 @@ class MultiStepCalculatorEnv(EnvironmentInterface):
             next_stop_strings=all_stop_strings,
             rewards=rewards_tensor,
             terminateds=done_tensor,
-            info=all_info,
+            answers=all_answers,
         )
 
     def shutdown(self):


### PR DESCRIPTION
# What does this PR do ?

Add support for cons@k metric in evaluation module to improve performance measurement.
To be more specific:
        1. Add extracted_answer to EnvironmentReturn.metadata.
        2. Implement the function of selecting the majority of answers among k_value answers.
        3. Enumerate all combinations in C(k, n) and calculate the corresponding scores, and finally get an unbiased estimate of cons@k.

# Issues
Closes #541 

# Test Result
When k_value is set to 1, the values of pass@k and cons@k should be equal. By adding some print statements and running the following command:
```bash
uv run python examples/run_eval.py eval.metric="cons@k"
```

the results are as follows:
```
pass@k: 0.1(3.0/30)
cons@k: 0.1(3.0/30)

============================================================
model_name='Qwen2.5-Math-1.5B-Instruct' dataset_name='aime2024'
max_new_tokens=2048 temperature=0.0 top_p=1.0 top_k=-1

metric='cons@k' k_value=1 num_tests_per_prompt=1

score=0.1000 (3.0/30)
============================================================
```

For k_value=3 and num_tests_per_prompt=5, we set temperature=0.7. By adding some print statements and running the command:
```bash
uv run python examples/run_eval.py \
    generation.temperature=0.7 \
    eval.metric="cons@k" \
    eval.k_value=3 \
    eval.num_tests_per_prompt=5 
```
we obtain the following results:
```
============================================================
model_name='Qwen2.5-Math-1.5B-Instruct' dataset_name='aime2024'
max_new_tokens=2048 temperature=0.7 top_p=1.0 top_k=-1

metric='cons@k' k_value=3 num_tests_per_prompt=5

score=0.0833 (2.5/30)
============================================================
```

More intermediate results are provided in the [test_3_5.log](https://github.com/user-attachments/files/21280947/test_3_5.log) file, where you can see the calculation process and verify its correctness.


# Usage
1. Modify `examples/configs/evals/eval.yaml` as you need. Note that the metric field need to be set to cons@k.
2. Start up the eval process.
```python
uv run python examples/run_eval.py generation.temperature=0.7 eval.metric="cons@k" eval.k_value=3 eval.nu
m_tests_per_prompt=5 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

1. The cons@k metric uses an answer voting method to select the final answer. However, how to handle tie votes remains an open question. Currently, we choose the first generated answer in case of ties, but whether this approach is reasonable requires further discussion.
2. The math_metric does not allow passing an empty function, so the current operation is to obtain the corresponding predict_answer according to the scoring logic of math_metric.
