### PR TITLE
feat: dynamically detect --gres=gpu:8 arg to work on clusters that don't need it

### DIFF
--- a/ray.sub
+++ b/ray.sub
@@ -31,13 +31,9 @@ maybe_gres_arg() {
   # Check if any nodes in the partition have GRES configured
   # Assumes a homogeneous allocation (not a heterogeneous job)
   if sinfo -p $SLURM_JOB_PARTITION -h -o "%G" | grep -q "gpu:"; then
-    # Do a quick assert here that gpus:8 == gpus:$GPUS_PER_NODE. It is probably a user error if someone isn't using GPUS_PER_NODE=8 on our clusters.
-    echo SLURM_JOB_PARTITION=$SLURM_JOB_PARTITION >&2
-    echo sinfo -p $SLURM_JOB_PARTITION >&2
-    echo sinfo -p $SLURM_JOB_PARTITION -h -o "%G" >&2
-    echo GRES_ARG=$(sinfo -p $SLURM_JOB_PARTITION -h -o "%G" | grep -q "gpu:") >&2
-    if [[ $GPUS_PER_NODE -ne $(sinfo -p $SLURM_JOB_PARTITION -h -o "%G" | grep -q "gpu:" | cut -d: -f2) ]]; then
-      echo "Error: GPUS_PER_NODE=$GPUS_PER_NODE but GRES detected is $(sinfo -p $SLURM_JOB_PARTITION -h -o "%G" | grep -q "gpu:") meaning GPUS_PER_NODE is not set to fully claim the GPUs on the nodes." >&2
+    # Do a quick assert here that gpus:8 == gpus:$GPUS_PER_NODE. It is probably a user error if someone isn't using GPUS_PER_NODE=8 on our clusters if it supports --gres=gpu:8.
+    if [[ $GPUS_PER_NODE -ne $(sinfo -p $SLURM_JOB_PARTITION -h -o "%G" | grep "gpu:" | cut -d: -f2) ]]; then
+      echo "Error: GPUS_PER_NODE=$GPUS_PER_NODE but GRES detected is $(sinfo -p $SLURM_JOB_PARTITION -h -o "%G" | grep "gpu:") meaning GPUS_PER_NODE is not set to fully claim the GPUs on the nodes." >&2
       exit 1
     fi
     echo "--gres=gpu:${GPUS_PER_NODE}"


### PR DESCRIPTION
tested on Eos (doesn't need --gres) and other internal clusters (that do need)