### PR TITLE
perf(model_utils.py): avoiding softmax deepcopy

### DIFF
--- a/nemo_rl/distributed/model_utils.py
+++ b/nemo_rl/distributed/model_utils.py
@@ -103,6 +103,9 @@ class DistributedLogprob(torch.autograd.Function):
         ctx: Any,
         *grad_outputs: torch.Tensor,
     ) -> tuple[torch.Tensor, None, None, None, None, None, None]:
+        grad_output = grad_outputs[0]
+        softmax, target_mask, masked_target = ctx.saved_tensors
+
         if softmax.ndim == 3:
             B, S, V = softmax.shape
 


### PR DESCRIPTION
# What does this PR do ?

During `backward`, there is a deepcopy in `torch.nn.functional.one_hot` for softmax, which caused OOM.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

https://github.com/NVIDIA-NeMo/RL/issues/662

# Test result

- Precision check with `torch.all_close` passed
- Speed and memory-cost comparision:

  <img width="984" height="418" alt="image" src="https://github.com/user-attachments/assets/45e287b5-4eb1-4a09-9c2e-45a84ef22944" />


## Here is my training log

So far so good:

  <img width="848" height="386" alt="image" src="https://github.com/user-attachments/assets/b403d996-77e5-498d-875c-958b07154e48" />


## All my test code

Please run it with `python3 -m pytest -s backward_test.py`

  ```python
  # backward_test.py
  import time
  import torch
  import pytest
  
  # ---------- baseline ----------
  def baseline_backward(ctx, *grad_outputs):
      grad_output = grad_outputs[0]
      softmax, target_mask, masked_target = ctx.saved_tensors
      V = softmax.size(-1)
      is_chosen = (~target_mask).unsqueeze(-1) * torch.nn.functional.one_hot(
          masked_target, num_classes=V
      )
      grad_input = is_chosen.float().sub_(softmax)
      grad_input.mul_(grad_output.unsqueeze(-1))
      return grad_input, None, None, None, None, None, None
  
  def v2_sparse_backward(ctx, *grad_outputs):
      grad_output = grad_outputs[0]
      softmax, target_mask, masked_target = ctx.saved_tensors
  
      if softmax.ndim == 3:
          B, S, V = softmax.shape
  
          # skip `torch.nn.functional.one_hot`
          row = torch.arange(B, device=softmax.device).view(-1, 1).expand(-1, S).reshape(-1)
          col = torch.arange(S, device=softmax.device).expand(B, -1).reshape(-1)
          flat_idx = (row * S + col) * V
  
          flat_chosen = flat_idx.masked_select(~target_mask.reshape(-1)) + \
                      masked_target.masked_select(~target_mask)
  
          # `neg` is zero-copy 
          grad_input = softmax.neg()
          grad_input = grad_input.mul_(grad_output.unsqueeze(-1))
  
          grad_output_selected = grad_output.masked_select(~target_mask)
          grad_input.view(-1).scatter_add_(0, flat_chosen, grad_output_selected)
      else:
          V = softmax.size(-1)
          is_chosen = (~target_mask).unsqueeze(-1) * torch.nn.functional.one_hot(
              masked_target, num_classes=V
          )
          grad_input = is_chosen.float().sub_(softmax)
          grad_input.mul_(grad_output.unsqueeze(-1))
      return grad_input, None, None, None, None, None, None
  
  # ---------- 统一的 autograd.Function ----------
  class FuncBase(torch.autograd.Function):
      backward_fn = None  # 占位，运行期再覆盖
  
      @staticmethod
      def forward(ctx, logits, target_mask, masked_target):
          softmax = torch.softmax(logits, dim=-1)
          ctx.save_for_backward(softmax, target_mask, masked_target)
          return softmax.sum()
  
      @staticmethod
      def backward(ctx, *g):
          return FuncBase.backward_fn(ctx, *g)
  
  class BaseFunc(torch.autograd.Function):
      backward_fn = None
  
      @staticmethod
      def forward(ctx, logits, target_mask, masked_target):
          softmax = torch.softmax(logits, dim=-1)
          ctx.save_for_backward(softmax.detach(), target_mask, masked_target)
          return logits.sum() * 0.0 + softmax.sum()
  
      @staticmethod
      def backward(ctx, *g):
          return BaseFunc.backward_fn(ctx, *g)
  
  # ---------- pytest ----------
  @pytest.mark.parametrize("device", ["cuda"])
  @pytest.mark.parametrize("bsz,seqlen,vocab", [(2, 1265, 151_936)])
  @pytest.mark.parametrize("niters", [5])
  def test_compare(device, bsz, seqlen, vocab, niters):
      torch.cuda.reset_peak_memory_stats(device)
      torch.manual_seed(42)
  
      logits = torch.randn(bsz, seqlen, vocab, device=device, requires_grad=True)
      target_mask = torch.randint(0, 2, (bsz, seqlen), dtype=torch.bool, device=device)
      masked_target = torch.randint(0, vocab, (bsz, seqlen), device=device)
      grads = []
      for fn in [baseline_backward, v2_sparse_backward]:
          logits.grad = None
          logits_ = logits.clone().detach().requires_grad_(True)
  
          BaseFunc.backward_fn = staticmethod(fn)
          loss = BaseFunc.apply(logits_, target_mask, masked_target)
  
          # 使用 grad 而不是 backward
          grad_input = torch.autograd.grad(loss, logits_, retain_graph=False)[0]
          grads.append(grad_input)
  
      atol=1e-5
      rtol=1e-5
      assert torch.allclose(grads[0],grads[1], atol=atol, rtol=rtol)
      print("✅ precision check passed")
  
      torch.cuda.reset_peak_memory_stats(device)
      torch.cuda.empty_cache()
  
      for name, fn in [("baseline", baseline_backward),
                      ("v2",       v2_sparse_backward)]:
          BaseFunc.backward_fn = staticmethod(fn)
  
          # 1. 先重置峰值计数器
          torch.cuda.reset_peak_memory_stats(device)
  
          # 2. 预热（不计时）
          loss = BaseFunc.apply(logits, target_mask, masked_target)
          loss.backward()
          logits.grad = None
          torch.cuda.synchronize()
  
          # 3. 正式计时
          start = time.perf_counter()
          for _ in range(niters):
              loss = BaseFunc.apply(logits, target_mask, masked_target)
              loss.backward()
              logits.grad = None
              torch.cuda.synchronize()
          elapsed = time.perf_counter() - start
  
          # 4. 读取本轮峰值
          max_mem = torch.cuda.max_memory_allocated(device) / 1024 ** 3
  
          # 5. 清空缓存（可选，不影响已记录的峰值）
          torch.cuda.empty_cache()
  
          print(f"\n[{name}] niters={niters}, avg_time={elapsed/niters*1000:.2f} ms, "
              f"peak_mem={max_mem:.2f} GB")
  
  ```