### PR TITLE
fix: remove tie weight check

### DIFF
--- a/docs/model-quirks.md
+++ b/docs/model-quirks.md
@@ -9,7 +9,6 @@ This document outlines special cases and model-specific behaviors that require c
 For Gemma-3, all model sizes have weight-tying enabled, including the larger models which require tensor parallelism. To support training of these models, we specially handle the Gemma-3 models by allowing training using the DTensor policy with TP > 1.
 
 **Special Handling:**
-- We skip the tied weights check for all Gemma-3 models when using the DTensor policy, allowing training using TP > 1.
 - We exclude `model.embed_tokens` and `lm_head` from the DTensor tensor parallel plan to maintain weight tying correctly.
 
 ### vLLM Initialization

--- a/docs/model-quirks.md
+++ b/docs/model-quirks.md
@@ -4,13 +4,6 @@ This document outlines special cases and model-specific behaviors that require c
 
 ## Gemma-3
 
-### Tied Weights
-
-For Gemma-3, all model sizes have weight-tying enabled, including the larger models which require tensor parallelism. To support training of these models, we specially handle the Gemma-3 models by allowing training using the DTensor policy with TP > 1.
-
-**Special Handling:**
-- We exclude `model.embed_tokens` and `lm_head` from the DTensor tensor parallel plan to maintain weight tying correctly.
-
 ### vLLM Initialization
 
 Gemma-3 models have a specific issue with vLLM dummy weight initialization due to a vLLM bug where [a `normalizer` buffer is created](https://github.com/vllm-project/vllm/blob/964472b9667508b1d4a7ed92068ff81740ae0036/vllm/model_executor/models/gemma3.py#L372) that is not present in the Hugging Face model. This causes the `normalizer` buffer to be set to dummy weights at initialization and then never updated with the correct values during model refit. As a workaround for this issue, we do not use dummy weight initialization for vLLM with Gemma-3 models and instead use the `load_format="auto"` setting to load the full weights at initialization.

--- a/docs/model-quirks.md
+++ b/docs/model-quirks.md
@@ -6,7 +6,7 @@ This document outlines special cases and model-specific behaviors that require c
 
 ### Tied Weights
 
-Weight tying between the embedding layer (`model.embed_tokens`) and output layer (`lm_head`) is currently not respected when using the DTensor policy when TP > 1 (See [this issue](https://github.com/NVIDIA-NeMo/RL/issues/227)). To avoid errors when training these models, we only allow training models with tied weights using the DTensor policy with TP=1. For Llama-3 and Qwen2.5 models, weight-tying is only enabled for the smaller models (< 2B), which can typically be trained without tensor parallelism. For Gemma-3, all model sizes have weight-tying enabled, including the larger models which require tensor parallelism. To support training of these models, we specially handle the Gemma-3 models by allowing training using the DTensor policy with TP > 1.
+For Gemma-3, all model sizes have weight-tying enabled, including the larger models which require tensor parallelism. To support training of these models, we specially handle the Gemma-3 models by allowing training using the DTensor policy with TP > 1.
 
 **Special Handling:**
 - We skip the tied weights check for all Gemma-3 models when using the DTensor policy, allowing training using TP > 1.

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -32,7 +32,6 @@ checkpointing:
   checkpoint_must_save_by: null
 
 policy:
-  # Qwen/Qwen2.5-1.5B has tied weights which are only supported with dtensor policy with tp size 1 (https://github.com/NVIDIA-NeMo/RL/issues/227)
   model_name: "Qwen/Qwen2.5-1.5B"
   tokenizer:
     name: ${policy.model_name} ## specify if you'd like to use a tokenizer different from the model's default

--- a/examples/configs/recipes/llm/grpo-deepscaler-1.5b-8K.yaml
+++ b/examples/configs/recipes/llm/grpo-deepscaler-1.5b-8K.yaml
@@ -32,7 +32,6 @@ checkpointing:
   checkpoint_must_save_by: null
 
 policy:
-  # Qwen/Qwen2.5-1.5B has tied weights which are only supported with dtensor policy with tp size 1 (https://github.com/NVIDIA-NeMo/RL/issues/227)
   model_name: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
   tokenizer:
     name: ${policy.model_name} ## specify if you'd like to use a tokenizer different from the model's default

--- a/nemo_rl/models/dtensor/parallelize.py
+++ b/nemo_rl/models/dtensor/parallelize.py
@@ -342,19 +342,12 @@ def get_hf_tp_plan(model: PreTrainedModel):
     )
 
     # hf tp plan not contain embed_tokens, we add it and set to rowwise_rep
-    if (
-        f"{model_prefix}.embed_tokens" not in hf_tp_plan
-        and not model.config.tie_word_embeddings
-    ):
+    if f"{model_prefix}.embed_tokens" not in hf_tp_plan:
         hf_tp_plan[f"{model_prefix}.embed_tokens"] = "rowwise_rep"
 
     for k, v in hf_tp_plan.items():
         # speed up the tp plan for lm_head
-        if (
-            k == "lm_head"
-            and v == "colwise_rep"
-            and not model.config.tie_word_embeddings
-        ):
+        if k == "lm_head" and v == "colwise_rep":
             hf_tp_plan[k] = ColwiseParallel(
                 output_layouts=Shard(-1), use_local_output=False
             )

--- a/nemo_rl/models/huggingface/common.py
+++ b/nemo_rl/models/huggingface/common.py
@@ -39,21 +39,16 @@ class ModelFlag(Enum):
     configuration in different parts of the NeMo RL codebase.
 
     Flags:
-        SKIP_DTENSOR_TIED_WEIGHTS_CHECK: Models that should skip the tied weights check
-                                 for the DTensor Policy.
         VLLM_LOAD_FORMAT_AUTO: Models that should use the "auto" load format when initializing
                                VLLM.
 
     Each flag has a `matches` method that determines if the flag applies to a given model_name.
     """
 
-    SKIP_DTENSOR_TIED_WEIGHTS_CHECK = auto()
     VLLM_LOAD_FORMAT_AUTO = auto()
 
     def matches(self, model_name: str) -> bool:
         match self:
-            case ModelFlag.SKIP_DTENSOR_TIED_WEIGHTS_CHECK:
-                return is_gemma_model(model_name)
             case ModelFlag.VLLM_LOAD_FORMAT_AUTO:
                 return is_gemma_model(model_name)
             case _:

--- a/nemo_rl/models/huggingface/common.py
+++ b/nemo_rl/models/huggingface/common.py
@@ -40,8 +40,7 @@ class ModelFlag(Enum):
 
     Flags:
         SKIP_DTENSOR_TIED_WEIGHTS_CHECK: Models that should skip the tied weights check
-                                 for the DTensor Policy even without setting the
-                                 NRL_SKIP_TIED_WEIGHT_CHECK flag.
+                                 for the DTensor Policy.
         VLLM_LOAD_FORMAT_AUTO: Models that should use the "auto" load format when initializing
                                VLLM.
 

--- a/nemo_rl/models/policy/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker.py
@@ -266,7 +266,6 @@ class DTensorPolicyWorker:
             self.model.config.pad_token_id = tokenizer.pad_token_id
 
         # caching since this property is not always preserved after FSDP
-        self.num_tied_weights = len(find_tied_parameters(self.model))
         self.tokenizer = tokenizer
 
         # ------------------------------------------------

--- a/nemo_rl/models/policy/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker.py
@@ -56,7 +56,6 @@ from nemo_rl.models.dtensor.parallelize import (
     to_local_if_dtensor,
 )
 from nemo_rl.models.huggingface.common import (
-    ModelFlag,
     get_flash_attention_kwargs,
     pack_sequences,
 )
@@ -268,11 +267,8 @@ class DTensorPolicyWorker:
 
         # caching since this property is not always preserved after FSDP
         self.num_tied_weights = len(find_tied_parameters(self.model))
-        self.skip_tie_check = os.environ.get(
-            "NRL_SKIP_TIED_WEIGHT_CHECK"
-        ) or ModelFlag.SKIP_DTENSOR_TIED_WEIGHTS_CHECK.matches(model_name)
-
         self.tokenizer = tokenizer
+
         # ------------------------------------------------
         # 3) Move to GPU + Composable FSDP
         #    (Initialize device mesh, shard submodules, then shard entire model)
@@ -528,15 +524,6 @@ class DTensorPolicyWorker:
         mbs: Optional[int] = None,
     ) -> dict[str, Any]:
         """Train the policy on a batch of data with a given loss function."""
-        # Check if the model has tied weights
-        if (
-            self.num_tied_weights != 0
-            and self.cfg["dtensor_cfg"]["tensor_parallel_size"] > 1
-            and not self.skip_tie_check
-        ):
-            raise ValueError(
-                f"Using dtensor policy with tp size {self.cfg['dtensor_cfg']['tensor_parallel_size']} for model ({self.cfg['model_name']}) that has tied weights (num_tied_weights={self.num_tied_weights}) is not supported (https://github.com/NVIDIA-NeMo/RL/issues/227). Please use dtensor policy with tensor parallel == 1 instead."
-            )
         if gbs is None:
             gbs = self.cfg["train_global_batch_size"]
         if mbs is None:

--- a/nemo_rl/models/policy/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker.py
@@ -42,7 +42,6 @@ from transformers import (
     AutoModelForSequenceClassification,
     AutoTokenizer,
 )
-from transformers.integrations.accelerate import find_tied_parameters
 from transformers.models.gemma3.modeling_gemma3 import Gemma3ForCausalLM
 
 from nemo_rl.algorithms.interfaces import LossFunction, LossType

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -302,17 +302,6 @@ def test_input_data(tokenizer):
     )
 
 
-@pytest.fixture(scope="module", autouse=True)
-def skip_tied_weight_check_for_all():
-    """Automatically skip tied weight check for all tests in this module."""
-    os.environ["NRL_SKIP_TIED_WEIGHT_CHECK"] = "1"
-
-    yield
-
-    # Restore the original value
-    os.environ.pop("NRL_SKIP_TIED_WEIGHT_CHECK", None)
-
-
 def test_vllm_missing_required_config_key(cluster):
     """Test that an assertion error is raised when a required config key is missing."""
     # Create a config missing a required key by removing 'model_name'

--- a/tests/unit/models/generation/test_vllm_large_model.py
+++ b/tests/unit/models/generation/test_vllm_large_model.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from copy import deepcopy
 
 import pytest
@@ -61,14 +60,6 @@ large_model_vllm_config: VllmConfig = {
     },
     "vllm_kwargs": {},
 }
-
-
-@pytest.fixture(scope="module", autouse=True)
-def skip_tied_weight_check():
-    """Automatically skip tied weight check for all tests in this module."""
-    os.environ["NRL_SKIP_TIED_WEIGHT_CHECK"] = "1"
-    yield
-    os.environ.pop("NRL_SKIP_TIED_WEIGHT_CHECK", None)
 
 
 @pytest.fixture(scope="function")

--- a/tests/unit/models/huggingface/test_common.py
+++ b/tests/unit/models/huggingface/test_common.py
@@ -39,7 +39,6 @@ from nemo_rl.models.huggingface.common import ModelFlag, is_gemma_model
 )
 def test_gemma_models(model_name):
     assert is_gemma_model(model_name)
-    assert ModelFlag.SKIP_DTENSOR_TIED_WEIGHTS_CHECK.matches(model_name)
     assert ModelFlag.VLLM_LOAD_FORMAT_AUTO.matches(model_name)
 
 
@@ -54,5 +53,4 @@ def test_gemma_models(model_name):
 )
 def test_non_gemma_models(model_name):
     assert not is_gemma_model(model_name)
-    assert not ModelFlag.SKIP_DTENSOR_TIED_WEIGHTS_CHECK.matches(model_name)
     assert not ModelFlag.VLLM_LOAD_FORMAT_AUTO.matches(model_name)

--- a/tests/unit/models/policy/test_dtensor_worker.py
+++ b/tests/unit/models/policy/test_dtensor_worker.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import pprint
 
 import pytest
@@ -105,17 +104,6 @@ def create_test_config(
         },
         "max_grad_norm": 1.0,
     }
-
-
-@pytest.fixture(scope="module", autouse=True)
-def skip_tied_weight_check_for_all():
-    """Automatically skip tied weight check for all tests in this module."""
-    os.environ["NRL_SKIP_TIED_WEIGHT_CHECK"] = "1"
-
-    yield
-
-    # Restore the original value
-    os.environ.pop("NRL_SKIP_TIED_WEIGHT_CHECK", None)
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -133,14 +133,6 @@ def create_megatron_test_config(
     }
 
 
-@pytest.fixture(scope="module", autouse=True)
-def skip_tied_weight_check_for_all():
-    """Automatically skip tied weight check for all tests in this module."""
-    os.environ["NRL_SKIP_TIED_WEIGHT_CHECK"] = "1"
-    yield
-    os.environ.pop("NRL_SKIP_TIED_WEIGHT_CHECK", None)
-
-
 @pytest.fixture(scope="function")
 def gc_collect():
     """Helper function to force garbage collection after a test"""

--- a/tests/unit/utils/test_native_checkpoint.py
+++ b/tests/unit/utils/test_native_checkpoint.py
@@ -130,17 +130,6 @@ def policy(cluster, tokenizer):
     policy.worker_group.shutdown()
 
 
-@pytest.fixture(scope="module", autouse=True)
-def skip_tied_weight_check_for_all():
-    """Automatically skip tied weight check for all tests in this module."""
-    os.environ["NRL_SKIP_TIED_WEIGHT_CHECK"] = "1"
-
-    yield
-
-    # Restore the original value
-    os.environ.pop("NRL_SKIP_TIED_WEIGHT_CHECK", None)
-
-
 def get_dummy_state_dict(state_dict, dummy_dict={}):
     """Recursively get the dummy state dict
     by replacing tensors with random ones of the same shape.


### PR DESCRIPTION
# What does this PR do ?
This pull request removes the tie weight check in the DTensor Worker, addressing a previous limitation with training models that utilize tie_word_embeddings when tensor parallel size (tp_size) > 1.

# Issues
closes #684 

# Test Result

## For remove `NRL_SKIP_TIED_WEIGHT_CHECK` env variable

Experiments were run with meta-llama/Llama-3.2-1B, Qwen/Qwen2.5-1.5B-Instruct and google/gemma-2-2b-it. With the truncate rate set within a reasonable range, both tp_size=1 and tp_size=2 produced comparable reward results, indicating that training proceeds as expected. This demonstrates consistency in model behavior across different tensor parallel configurations, confirming correct handling of tied word embeddings during training.

Main setup:
- policy.generation.temperature=1.0
- policy.max_total_sequence_length=2048 
- cluster.gpus_per_node=8

### Llama-3.2-1B
<p align="center">
  <img src="https://github.com/user-attachments/assets/6456172a-e58f-42f3-939b-c22c151e2c0b" width="75%" />
  <img src="https://github.com/user-attachments/assets/71b913c4-79f2-45ae-9f37-79dea9c46971" width="75%" />
  <img src="https://github.com/user-attachments/assets/47e60d7a-fa4b-40a1-86af-0c505207a433" width="75%" />

</p>

### Qwen2.5-1.5B-Instruct
<p align="center">
  <img src="https://github.com/user-attachments/assets/68abb91d-764f-4bee-84ef-b80f85ca354b" width="75%" />
  <img src="https://github.com/user-attachments/assets/9c6c8ebb-3634-4e17-893d-8afa0788711e" width="75%" />
  <img src="https://github.com/user-attachments/assets/948bc8da-7686-4a84-89d0-c2fccd31c21a" width="75%" />
</p>

### google/gemma-2-2b-it
Test with:
- policy.dynamic_batching.enabled=true 
- policy.sequence_packing.enabled=false 
- policy.train_global_batch_size=128
<p align="center">
<img width="50%"  alt="gemma_reward_40" src="https://github.com/user-attachments/assets/91714396-94b6-4a29-9d1b-40305be31c01" />
<img width="50%"  alt="gemma_trancate_rate_40" src="https://github.com/user-attachments/assets/228e4867-6e67-43b1-9b68-9ae3ac6e9eb5" />
<img width="50%"  alt="gemma_token_mult_prob_error_40" src="https://github.com/user-attachments/assets/ed6aca0c-5457-4f1f-ade3-27e6fe374e11" />

</p>


## For remove `model.config.tie_word_embeddings` in `nemo_rl/models/dtensor/parallelize.py`
Experiments were conducted using both the Qwen/Qwen2.5-1.5B-Instruct and Qwen/Qwen2.5-7B-Instruct models, representing the original tied and untied weight configurations, respectively. I disabled Qwen's optimized parallel plan in PARALLIZE_FUNCTIONS, forcing both models to utilize the HP plan for testing.
- The results indicate that, after removing the model.config.tie_word_embeddings check, the HP plan and the optimized plan produce identical outcomes.


### Qwen/Qwen2.5-1.5B-Instruct
- This model uses tied word embeddings by default.
- Current results are from a short test of 10 steps.

<p align="center">
<img width="630" height="958" alt="image" src="https://github.com/user-attachments/assets/45bf28d7-9646-4435-b99d-acc4d8a92566" />
</p>


### Qwen/Qwen2.5-7B-Instruct
- This model uses untied word embeddings by default.
- Current results are from a short test of 10 steps.
<p align="center">
<img width="443" height="711" alt="image" src="https://github.com/user-attachments/assets/195f96e4-d1ea-45a7-8913-7fd4a36ee097" />
</p>


### More Custom Test
Some additional tests were also conducted here. 
**For models like Qwen/Qwen2.5-1.5B-Instruct, which by default use tied word embeddings, we forcibly disabled the tie_word_embedding setting.** The results showed significant anomalies in both the token_mult_prob_error and the reward. We suspect this may be because vLLM still keeps the embeddings tied on its side, so when you call update_weights, there might be some issues (in practice, vLLM may be using either the embed or the lm_head weight, rather than truly untying them as in training). This causes the token_mult_prob_error to behave abnormally.
<p align="center">
<img  width="45%" alt="qwen_1 5b_reward" src="https://github.com/user-attachments/assets/ddcfce02-8b56-4960-995d-8945de0c63a2" />
<img width="45%" alt="qwen_1 5b_token_mult_prob_error" src="https://github.com/user-attachments/assets/90f1c936-3aad-473f-8295-fb6e8240793d" />
</p>



**For models like Qwen/Qwen2.5-7B-Instruct, which by default do not use tied embeddings, we forcibly enabled tie_word_embedding.** The results showed large differences in reward, but the token_mult_prob_error remained stable. This might be because, originally, the embed and lm_head weights were different due to being untied; forcing a tie essentially removes the original lm_head weights. When we call update_weights to vLLM, its lm_head is also overwritten with the embed weights, so the token_mult_prob_error remains normal. However, since we forcibly replaced the original weights, the reward becomes abnormal.

<p align="center">
<img width="45%" alt="qwen_7b_reward" src="https://github.com/user-attachments/assets/8575201e-e9ae-4708-adaf-15dcb6fb91b4" />
<img width="45%" alt="qwen_7b_token_mult_prob_error" src="https://github.com/user-attachments/assets/60d1d394-f91b-425a-a9b5-fcc92ed62eca" />

</p>


## Additional Notes on Gemma Model Testing

- gemma-3-1b-it: This model sets kv_head=1, which is currently not compatible with tensor parallelism (TP=2). As a result, it could not be tested in a TP=2 configuration.




