### PR TITLE
feat: enable toggling between `thinking` and `non-thinking` for evaluation.

### DIFF
--- a/docs/guides/eval.md
+++ b/docs/guides/eval.md
@@ -45,6 +45,9 @@ Note that the evaluation script only supports the Hugging Face format model. If 
 # Run evaluation script with default config (examples/configs/evals/eval.yaml)
 uv run python examples/run_eval.py
 
+# Run evaluation script with default config and enable thinking (examples/configs/evals/eval_enable_thinking.yaml)
+uv run python examples/run_eval.py --config=examples/configs/evals/eval_enable_thinking.yaml
+
 # Run evaluation script with converted model
 uv run python examples/run_eval.py generation.model_name=$PWD/results/grpo/hf
 

--- a/examples/configs/evals/eval_enable_thinking.yaml
+++ b/examples/configs/evals/eval_enable_thinking.yaml
@@ -1,0 +1,12 @@
+# Math evaluation Configuration
+defaults: "eval.yaml"
+
+generation:
+  model_name: "Qwen/Qwen3-14B"
+  enable_thinking: true
+  temperature: 0.6
+  top_p: 0.95
+  top_k: 20
+  vllm_cfg:
+    max_model_len: 32768
+

--- a/examples/configs/evals/gpqa_eval.yaml
+++ b/examples/configs/evals/gpqa_eval.yaml
@@ -12,4 +12,4 @@ data:
 
 env:
   math:
-    verifier_type: "multichoice"
+    verifier_type: "english_multichoice"

--- a/examples/configs/evals/mmlu.yaml
+++ b/examples/configs/evals/mmlu.yaml
@@ -10,4 +10,4 @@ data:
 
 env:
   math:
-    verifier_type: "multichoice"
+    verifier_type: "multilingual_multichoice"

--- a/examples/run_eval.py
+++ b/examples/run_eval.py
@@ -53,7 +53,7 @@ def parse_args():
     return args, overrides
 
 
-def setup_data(tokenizer: AutoTokenizer, data_config, env_configs):
+def setup_data(tokenizer: AutoTokenizer, data_config, env_configs, enable_thinking):
     print("Setting up data...")
 
     # load dataset
@@ -68,6 +68,7 @@ def setup_data(tokenizer: AutoTokenizer, data_config, env_configs):
         }
     ).remote(env_configs["math"])
 
+    base_dataset.task_spec.enable_thinking = enable_thinking
     dataset = AllTaskProcessedDataset(
         dataset=rekeyed_ds,
         tokenizer=tokenizer,
@@ -109,6 +110,7 @@ def main():
 
     # Setup tokenizer
     tokenizer = get_tokenizer(config["tokenizer"])
+    enable_thinking = config["generation"].get("enable_thinking", False)
     config["generation"] = configure_generation_config(
         config["generation"], tokenizer, is_eval=True
     )
@@ -118,7 +120,7 @@ def main():
         dataset,
         env,
         tokenizer,
-    ) = setup_data(tokenizer, config["data"], config["env"])
+    ) = setup_data(tokenizer, config["data"], config["env"], enable_thinking)
 
     # Setup
     (

--- a/nemo_rl/data/interfaces.py
+++ b/nemo_rl/data/interfaces.py
@@ -57,6 +57,8 @@ class TaskDataSpec:
 
     system_prompt_file: Optional[PathLike] = None
 
+    enable_thinking: bool = False
+
     def __post_init__(self) -> None:
         def load_prompt_file(
             prompt_file: Optional[PathLike],
@@ -79,6 +81,7 @@ class TaskDataSpec:
         default_attrs = {
             "system_prompt": from_spec.system_prompt,
             "prompt": from_spec.prompt,
+            "enable_thinking": from_spec.enable_thinking,
         }
 
         for attr_name, default_value in default_attrs.items():

--- a/nemo_rl/data/processors.py
+++ b/nemo_rl/data/processors.py
@@ -63,6 +63,7 @@ def math_data_processor(
         tokenize=False,
         add_generation_prompt=True,
         add_special_tokens=False,
+        enable_thinking=task_data_spec.enable_thinking,
     )
     user_message["token_ids"] = tokenizer(message, return_tensors="pt")["input_ids"][0]
     user_message["content"] = message
@@ -150,6 +151,7 @@ def multichoice_qa_processor(
         tokenize=False,
         add_generation_prompt=True,
         add_special_tokens=False,
+        enable_thinking=task_data_spec.enable_thinking,
     )
     user_message["token_ids"] = tokenizer(message, return_tensors="pt")["input_ids"][0]
     user_message["content"] = message


### PR DESCRIPTION
# What does this PR do ?

**enable toggling between `thinking` and `non-thinking` for evaluation.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):
N/A

# Usage
* **Run AIME2024 evaluation under `thinking` mode using the Qwen3 14B model:**

```python
uv run examples/run_eval.py --config examples/configs/evals/eval_enable_thinking.yaml cluster.gpus_per_node=8
```

Under `thinking` mode, the model scores 80% while under `non-thinking` mode the model scores 30%.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
