### PR TITLE
added save_to_parquet feature to eval

### DIFF
--- a/examples/configs/evals/eval.yaml
+++ b/examples/configs/evals/eval.yaml
@@ -4,6 +4,8 @@ eval:
   num_tests_per_prompt: 1 # every prompt will be tested num_tests_per_prompt times and use the average score as the final score
   seed: 42
   pass_k_value: 1
+  save_path: null # Path to save evaluation results as parquet file. Set to null to disable saving.
+                  # Example: "results/eval_output.parquet" or "/path/to/evaluation_results.parquet"
 
 generation:
   backend: "vllm" # only vllm is supported for evaluation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,9 @@ dependencies = [
     "nvtx",
     "matplotlib",
     "plotly",
-    "mlflow",
+    "mlflow",,
+    "pandas",
+    "pyarrow"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# What does this PR do ?

It adds functionality to save the eval results in a parquet file when running `run_eval.py` in the examples.

# Issues

None.

# Usage

Change the `save_path: null` to your specified parquet save path to store the results. The save_path defaults to None in the code so the code still works with old config files.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
None.
