### PR TITLE
save checking point before timeout to deal with 4 hour limit

### DIFF
--- a/nemo_rl/utils/timer.py
+++ b/nemo_rl/utils/timer.py
@@ -14,7 +14,7 @@
 import time
 from contextlib import contextmanager
 from typing import Callable, Generator, Optional, Sequence, Union
-
+import sys
 import numpy as np
 
 
@@ -245,3 +245,65 @@ class Timer:
         else:
             self._timers = {}
             self._start_times = {}
+
+
+
+
+
+
+
+def convert_to_seconds(time_string):
+    # Split the string into components
+    days, hours, minutes, seconds = map(int, time_string.split(':'))
+
+    # Calculate total seconds
+    total_seconds = days * 86400 + hours * 3600 + minutes * 60 + seconds
+
+    return total_seconds
+
+
+class TimeoutChecker:
+    def __init__(self, timeout: str = '00:03:45:00', fit_last_save_time=False):
+        super().__init__()
+        self.last_save_time = convert_to_seconds(timeout)
+        self.start_time = time.time()
+        self.last_saved = False
+        self.iteration_times = []
+        self.previous_iteration_time = None
+        self.fit_last_save_time = fit_last_save_time
+
+    def check_save(self):
+        # Flush
+        sys.stdout.flush()
+        sys.stderr.flush()
+
+        # Already saved after timeout
+        if self.last_saved:
+            return False
+
+        current_time = time.time()
+        elapsed_time = current_time - self.start_time
+
+        if self.fit_last_save_time:
+            average_iteration_time = sum(self.iteration_times) / len(self.iteration_times)
+            if elapsed_time + average_iteration_time >= self.last_save_time:
+                self.last_saved = True
+                return True
+
+        if elapsed_time >= self.last_save_time:
+            self.last_saved = True
+            return True
+
+        return False
+
+    def start_iterations(self):
+        self.previous_iteration_time = time.time()
+
+    def mark_iteration(self):
+        sys.stdout.flush()
+        sys.stderr.flush()
+
+        current_time = time.time()
+        elapsed_time = current_time - self.previous_iteration_time
+        self.previous_iteration_time = current_time
+        self.iteration_times.append(elapsed_time)


### PR DESCRIPTION
…g time lmit

# What does this PR do ?
Since the server automatically stops after 4 hours, it's recommended to save a checkpoint beforehand. For example, set the timeout to 3 hours and 45 minutes to ensure check point saved is saved in time

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
