### PR TITLE
cp: `fix: remove dynamic batching from 8B llama dtensor config (#728)`

### DIFF
--- a/examples/configs/grpo_math_8B.yaml
+++ b/examples/configs/grpo_math_8B.yaml
@@ -21,9 +21,6 @@ policy:
   dtensor_cfg:
     enabled: True
 
-  dynamic_batching:
-    enabled: True
-
   optimizer:
     name: "torch.optim.AdamW"
     kwargs:


### PR DESCRIPTION
cherry-pick workflow missed this one since it didn't have `r0.3.0` label when it landed in main