### PR TITLE
[2/2] Top-k and Top-p support for dtensor worker with vLLM V0 when `TP>1`

### DIFF
--- a/nemo_rl/models/dtensor/parallelize.py
+++ b/nemo_rl/models/dtensor/parallelize.py
@@ -620,6 +620,8 @@ def get_logprobs_from_vocab_parallel_logits(
     vocab_parallel_logits: DTensor,
     input_ids: torch.Tensor | DTensor,
     seq_index: Optional[torch.Tensor] = None,
+    top_k: Optional[int] = None,
+    top_p: Optional[float] = None,
 ):
     """Computes log probabilities from vocabulary-parallel logits.
 
@@ -633,6 +635,10 @@ def get_logprobs_from_vocab_parallel_logits(
             with shape [batch_size, seq_len].
         seq_index (Optional[torch.Tensor]): Sequence index for the input IDs,
             with shape [sequence_length].
+        top_k (Optional[int]): Top-k sampling parameter. If provided, only the top-k tokens
+            with highest probabilities are considered.
+        top_p (Optional[float]): Top-p (nucleus) sampling parameter. If provided, only tokens
+            with cumulative probability up to p are considered.
 
     Returns:
         torch.Tensor: Log probabilities for the given input IDs.
@@ -660,4 +666,6 @@ def get_logprobs_from_vocab_parallel_logits(
         tp_group,
         inference_only=not torch.is_grad_enabled(),
         seq_index=seq_index,
+        top_k=top_k,
+        top_p=top_p,
     )


### PR DESCRIPTION
# What does this PR do ?

tldr: Support top-k and top-p for dtensor worker with vLLM v0. This pr supports `tp>1` on top of #773. 

Instead of using `_compute_distributed_log_softmax`, we implement `_compute_distributed_log_softmax_with_sampling` to support Top-k and Top-p when TP is enabled.

**Note**: This change depends on #773 and should be merged after it. We should also decide if we want to merge this implementation or, alternatively, add a warning to users about a potential mismatch between this inference logic and the logic used in policy training for vLLM engine V0 and dtensor with TP>1.

Tests for distributed functionalities and docs will be added after we make the decision.

# Issues

Related Issue: https://github.com/NVIDIA-NeMo/RL/issues/69

# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.
