### PR TITLE
feat: support `chat_template_kwargs` in tokenizer config

### DIFF
--- a/docs/guides/eval.md
+++ b/docs/guides/eval.md
@@ -48,6 +48,16 @@ uv run python examples/run_eval.py
 # Run evaluation script with converted model
 uv run python examples/run_eval.py generation.model_name=$PWD/results/grpo/hf
 
+# Run evaluation script with Qwen3 model under thinking mode
+uv run python examples/run_eval.py \
+    generation.model_name=Qwen/Qwen3-8B \
+    generation.temperature=0.6 \
+    generation.top_p=0.95 \
+    generation.top_k=20 \
+    generation.vllm_cfg.max_model_len=38912 \
+    tokenizer.chat_template_kwargs.enable_thinking=true \
+    data.prompt_file=examples/prompts/cot.txt
+
 # Run evaluation script with custom config file
 uv run python examples/run_eval.py --config path/to/custom_config.yaml
 

--- a/docs/guides/grpo.md
+++ b/docs/guides/grpo.md
@@ -82,6 +82,7 @@ Then, you can set the data up as follows:
 ```python
 base_dataset = load_dataset("json", data_files=data_config["dataset_name"])["train"]
 tokenizer = AutoTokenizer.from_pretrained(policy_config["model_name"])
+chat_template_kwargs = {}
 
 task_data_processors = defaultdict(lambda: (math_task_spec, math_data_processor))
 task_data_processors["math"] = (math_task_spec, math_data_processor)
@@ -91,6 +92,7 @@ math_env = MathEnvironment.remote(env_configs["math"]) # ray remote actor
 dataset = AllTaskProcessedDataset(
     base_dataset,
     tokenizer,
+    chat_template_kwargs,
     math_task_spec,
     task_data_processors,
     max_seq_length=data_config["max_input_seq_length"],

--- a/examples/configs/evals/eval.yaml
+++ b/examples/configs/evals/eval.yaml
@@ -37,6 +37,8 @@ generation:
 tokenizer:
   name: ${generation.model_name} ## specify if you'd like to use a tokenizer different from the model's default
   chat_template: "default"
+  chat_template_kwargs:
+    enable_thinking: false
 
 data:
   max_input_seq_length: ${generation.vllm_cfg.max_model_len} # useless since we directly use prompts in evaluation

--- a/examples/configs/evals/gpqa_eval.yaml
+++ b/examples/configs/evals/gpqa_eval.yaml
@@ -12,4 +12,4 @@ data:
 
 env:
   math:
-    verifier_type: "multichoice"
+    verifier_type: "english_multichoice"

--- a/examples/configs/evals/mmlu.yaml
+++ b/examples/configs/evals/mmlu.yaml
@@ -10,4 +10,4 @@ data:
 
 env:
   math:
-    verifier_type: "multichoice"
+    verifier_type: "english_multichoice"

--- a/examples/configs/evals/mmlu_zh_cn.yaml
+++ b/examples/configs/evals/mmlu_zh_cn.yaml
@@ -4,3 +4,6 @@ defaults: "mmlu.yaml"
 data:
   dataset_name: "mmlu_ZH-CN"
 
+env:
+  math:
+    verifier_type: "multilingual_multichoice"

--- a/examples/run_dpo.py
+++ b/examples/run_dpo.py
@@ -52,6 +52,7 @@ def dpo_preprocessor(
     datum_dict: dict[str, Any],
     task_data_spec: TaskDataSpec,
     tokenizer,
+    chat_template_kwargs: dict[str, Any],
     max_seq_length: int,
     idx: int,
 ) -> DatumSpec:
@@ -134,10 +135,10 @@ def dpo_preprocessor(
     )
 
     message_log_chosen = get_formatted_message_log(
-        messages_chosen, tokenizer, task_data_spec
+        messages_chosen, tokenizer, chat_template_kwargs, task_data_spec
     )
     message_log_rejected = get_formatted_message_log(
-        messages_rejected, tokenizer, task_data_spec
+        messages_rejected, tokenizer, chat_template_kwargs, task_data_spec
     )
 
     length_chosen = sum(len(m["token_ids"]) for m in message_log_chosen)
@@ -186,10 +187,12 @@ def setup_data(data_config: DataConfig, policy_config: PolicyConfig):
 
     dpo_task_spec = data.task_spec
 
-    tokenizer = get_tokenizer(policy_config["tokenizer"])
+    tokenizer_config = policy_config["tokenizer"]
+    tokenizer = get_tokenizer(tokenizer_config)
     train_dataset = AllTaskProcessedDataset(
         train_dataset,
         tokenizer,
+        tokenizer_config.get("chat_template_kwargs", {}),
         dpo_task_spec,
         dpo_preprocessor,
         max_seq_length=data_config["max_input_seq_length"],
@@ -198,6 +201,7 @@ def setup_data(data_config: DataConfig, policy_config: PolicyConfig):
     val_dataset = AllTaskProcessedDataset(
         val_dataset,
         tokenizer,
+        tokenizer_config.get("chat_template_kwargs", {}),
         dpo_task_spec,
         dpo_preprocessor,
         max_seq_length=data_config["max_input_seq_length"],

--- a/examples/run_eval.py
+++ b/examples/run_eval.py
@@ -32,6 +32,7 @@ from nemo_rl.distributed.virtual_cluster import init_ray
 from nemo_rl.environments.math_environment import MathEnvironment
 from nemo_rl.evals.eval import MasterConfig, run_env_eval, setup
 from nemo_rl.models.generation import configure_generation_config
+from nemo_rl.models.policy import TokenizerConfig
 from nemo_rl.utils.config import load_config
 
 TokenizerType = PreTrainedTokenizerBase
@@ -53,7 +54,12 @@ def parse_args():
     return args, overrides
 
 
-def setup_data(tokenizer: AutoTokenizer, data_config, env_configs):
+def setup_data(
+    tokenizer: AutoTokenizer,
+    tokenizer_config: TokenizerConfig,
+    data_config,
+    env_configs,
+):
     print("Setting up data...")
 
     # load dataset
@@ -71,6 +77,7 @@ def setup_data(tokenizer: AutoTokenizer, data_config, env_configs):
     dataset = AllTaskProcessedDataset(
         dataset=rekeyed_ds,
         tokenizer=tokenizer,
+        chat_template_kwargs=tokenizer_config.get("chat_template_kwargs", {}),
         default_task_data_spec=base_dataset.task_spec,
         task_data_processors=base_dataset.processor,
         max_seq_length=data_config["max_input_seq_length"],
@@ -118,7 +125,7 @@ def main():
         dataset,
         env,
         tokenizer,
-    ) = setup_data(tokenizer, config["data"], config["env"])
+    ) = setup_data(tokenizer, config["tokenizer"], config["data"], config["env"])
 
     # Setup
     (

--- a/examples/run_grpo_math.py
+++ b/examples/run_grpo_math.py
@@ -40,6 +40,7 @@ from nemo_rl.distributed.virtual_cluster import init_ray
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.environments.math_environment import MathEnvironment
 from nemo_rl.models.generation import configure_generation_config
+from nemo_rl.models.policy import TokenizerConfig
 from nemo_rl.utils.config import load_config, parse_hydra_overrides
 from nemo_rl.utils.logger import get_next_experiment_dir
 
@@ -70,6 +71,7 @@ def hf_data_processor(
     datum_dict: dict[str, Any],
     task_data_spec: TaskDataSpec,
     tokenizer: TokenizerType,
+    chat_template_kwargs: dict[str, Any],
     max_seq_length: int,
     idx: int,
 ) -> DatumSpec:
@@ -88,6 +90,7 @@ def hf_data_processor(
         tokenize=False,
         add_generation_prompt=True,
         add_special_tokens=False,
+        **chat_template_kwargs,
     )
     user_message["token_ids"] = tokenizer(message, return_tensors="pt")["input_ids"][0]
     user_message["content"] = message[0]
@@ -117,6 +120,7 @@ def hf_data_processor(
 
 def setup_data(
     tokenizer: TokenizerType,
+    tokenizer_config: TokenizerConfig,
     data_config: DataConfig,
     env_configs: dict[str, Any],
 ) -> tuple[
@@ -160,6 +164,7 @@ def setup_data(
     dataset = AllTaskProcessedDataset(
         data.formatted_ds["train"],
         tokenizer,
+        tokenizer_config.get("chat_template_kwargs", {}),
         math_task_spec,
         task_data_processors,
         max_seq_length=data_config["max_input_seq_length"],
@@ -170,6 +175,7 @@ def setup_data(
         val_dataset = AllTaskProcessedDataset(
             data.formatted_ds["validation"],
             tokenizer,
+            tokenizer_config.get("chat_template_kwargs", {}),
             math_task_spec,
             task_data_processors,
             max_seq_length=data_config["max_input_seq_length"],
@@ -217,7 +223,8 @@ def main() -> None:
     init_ray()
 
     # setup tokenizer
-    tokenizer = get_tokenizer(config["policy"]["tokenizer"])
+    tokenizer_config = config["policy"]["tokenizer"]
+    tokenizer = get_tokenizer(tokenizer_config)
     assert config["policy"]["generation"] is not None, (
         "A generation config is required for GRPO"
     )
@@ -231,7 +238,7 @@ def main() -> None:
         val_dataset,
         task_to_env,
         val_task_to_env,
-    ) = setup_data(tokenizer, config["data"], config["env"])
+    ) = setup_data(tokenizer, tokenizer_config, config["data"], config["env"])
 
     (
         policy,

--- a/examples/run_grpo_sliding_puzzle.py
+++ b/examples/run_grpo_sliding_puzzle.py
@@ -34,6 +34,7 @@ from nemo_rl.environments.games.sliding_puzzle import (
     SlidingPuzzleMetadata,
 )
 from nemo_rl.models.generation import configure_generation_config
+from nemo_rl.models.policy import TokenizerConfig
 from nemo_rl.utils.config import load_config, parse_hydra_overrides
 from nemo_rl.utils.logger import get_next_experiment_dir
 
@@ -57,6 +58,7 @@ def generate_puzzle_datum(
     task_name: str,
     idx: int,
     add_system_prompt: bool,
+    chat_template_kwargs: dict[str, Any],
 ) -> DatumSpec:
     """Generates a single sliding puzzle datum (prompt and metadata)."""
 
@@ -91,6 +93,7 @@ def generate_puzzle_datum(
         add_system_prompt=add_system_prompt,
         add_generation_prompt=True,
         add_special_tokens=False,
+        **chat_template_kwargs,
     ).strip()
     tokenized_prompt = tokenizer(
         initial_prompt_content, return_tensors="pt", add_special_tokens=False
@@ -121,10 +124,18 @@ class IterablePuzzleDataset(IterableDataset):
     """An IterableDataset that generates sliding puzzle data indefinitely."""
 
     def __init__(
-        self, tokenizer, game_config, max_moves, task_name, add_system_prompt, length
+        self,
+        tokenizer,
+        chat_template_kwargs,
+        game_config,
+        max_moves,
+        task_name,
+        add_system_prompt,
+        length,
     ):
         super().__init__()
         self.tokenizer = tokenizer
+        self.chat_template_kwargs = chat_template_kwargs
         self.game_config = game_config
         self.max_moves = max_moves
         self.task_name = task_name
@@ -142,6 +153,7 @@ class IterablePuzzleDataset(IterableDataset):
                 task_name=self.task_name,
                 idx=i,
                 add_system_prompt=self.add_system_prompt,
+                chat_template_kwargs=self.chat_template_kwargs,
             )
 
     def __len__(self):
@@ -150,6 +162,7 @@ class IterablePuzzleDataset(IterableDataset):
 
 def setup_puzzle_data(
     tokenizer: AutoTokenizer,
+    tokenizer_config: TokenizerConfig,
     env_cfg: dict[str, Any],
     task_name: str,
     length: int,
@@ -168,6 +181,7 @@ def setup_puzzle_data(
     print("Creating Sliding Puzzle dataset...")
     training_dataset = IterablePuzzleDataset(
         tokenizer=tokenizer,
+        chat_template_kwargs=tokenizer_config.get("chat_template_kwargs", {}),
         game_config=dict(env_config["cfg"]["game_config"]),
         max_moves=env_config["cfg"]["max_moves"],
         task_name=task_name,
@@ -178,6 +192,7 @@ def setup_puzzle_data(
 
     validation_dataset = IterablePuzzleDataset(
         tokenizer=tokenizer,
+        chat_template_kwargs=tokenizer_config.get("chat_template_kwargs", {}),
         game_config=dict(env_config["cfg"]["game_config"]),
         max_moves=env_config["cfg"]["max_moves"],
         task_name=task_name,
@@ -224,7 +239,8 @@ def main():
     init_ray()
 
     # setup tokenizer
-    tokenizer = get_tokenizer(config["policy"]["tokenizer"])
+    tokenizer_config = config["policy"]["tokenizer"]
+    tokenizer = get_tokenizer(tokenizer_config)
     config["policy"]["generation"] = configure_generation_config(
         config["policy"]["generation"], tokenizer
     )
@@ -237,6 +253,7 @@ def main():
     )
     dataset, val_dataset, task_to_env, val_task_to_env = setup_puzzle_data(
         tokenizer=tokenizer,
+        tokenizer_config=tokenizer_config,
         env_cfg=config["env"],
         task_name="sliding_puzzle_game",
         length=ds_length,

--- a/examples/run_sft.py
+++ b/examples/run_sft.py
@@ -28,6 +28,7 @@ from nemo_rl.data.datasets import AllTaskProcessedDataset
 from nemo_rl.data.interfaces import DatumSpec, TaskDataSpec
 from nemo_rl.data.llm_message_utils import get_formatted_message_log
 from nemo_rl.distributed.virtual_cluster import init_ray
+from nemo_rl.models.policy import TokenizerConfig
 from nemo_rl.utils.config import load_config, parse_hydra_overrides
 from nemo_rl.utils.logger import get_next_experiment_dir
 
@@ -54,6 +55,7 @@ def sft_preprocessor(
     datum_dict: dict[str, Any],
     task_data_spec: TaskDataSpec,
     tokenizer,
+    chat_template_kwargs: dict[str, Any],
     max_seq_length: int,
     idx: int,
     add_bos: bool = True,
@@ -64,6 +66,7 @@ def sft_preprocessor(
     message_log = get_formatted_message_log(
         datum_dict["messages"],
         tokenizer,
+        chat_template_kwargs,
         task_data_spec,
         add_bos_token=add_bos,
         add_eos_token=add_eos,
@@ -91,7 +94,9 @@ def sft_preprocessor(
     return output
 
 
-def setup_data(tokenizer: AutoTokenizer, data_config: DataConfig):
+def setup_data(
+    tokenizer: AutoTokenizer, tokenizer_config: TokenizerConfig, data_config: DataConfig
+):
     print("\n▶ Setting up data...")
     data_cls = data_config["dataset_name"]
     if data_cls == "open_assistant":
@@ -132,6 +137,7 @@ def setup_data(tokenizer: AutoTokenizer, data_config: DataConfig):
     train_dataset = AllTaskProcessedDataset(
         train_dataset,
         tokenizer,
+        tokenizer_config.get("chat_template_kwargs", {}),
         sft_task_spec,
         partial(
             sft_preprocessor,
@@ -145,6 +151,7 @@ def setup_data(tokenizer: AutoTokenizer, data_config: DataConfig):
     val_dataset = AllTaskProcessedDataset(
         val_dataset,
         tokenizer,
+        tokenizer_config.get("chat_template_kwargs", {}),
         sft_task_spec,
         partial(
             sft_preprocessor,
@@ -190,14 +197,15 @@ def main():
     init_ray()
 
     # setup tokenizer
-    tokenizer = get_tokenizer(config["policy"]["tokenizer"])
+    tokenizer_config = config["policy"]["tokenizer"]
+    tokenizer = get_tokenizer(tokenizer_config)
 
     # setup data
     (
         dataset,
         val_dataset,
         sft_task_spec,
-    ) = setup_data(tokenizer, config["data"])
+    ) = setup_data(tokenizer, tokenizer_config, config["data"])
 
     (
         policy,

--- a/nemo_rl/data/datasets.py
+++ b/nemo_rl/data/datasets.py
@@ -51,6 +51,7 @@ class AllTaskProcessedDataset:
         self,
         dataset: Dataset | Any,
         tokenizer: TokenizerType,
+        chat_template_kwargs: dict[str, Any],
         default_task_data_spec: TaskDataSpec,
         task_data_processors: (
             dict[str, tuple[TaskDataSpec, TaskDataProcessFnCallable]]
@@ -60,6 +61,7 @@ class AllTaskProcessedDataset:
     ):
         self.dataset = dataset
         self.tokenizer = tokenizer
+        self.chat_template_kwargs = chat_template_kwargs
         self.default_task_data_spec = default_task_data_spec
         self.task_data_processors = task_data_processors
         self.max_seq_length = max_seq_length
@@ -109,7 +111,12 @@ class AllTaskProcessedDataset:
             task_data_processor = self.task_data_processors
 
         datum_spec = task_data_processor(
-            entry, task_data_spec, self.tokenizer, self.max_seq_length, idx
+            entry,
+            task_data_spec,
+            self.tokenizer,
+            self.chat_template_kwargs,
+            self.max_seq_length,
+            idx,
         )
         return datum_spec
 

--- a/nemo_rl/data/interfaces.py
+++ b/nemo_rl/data/interfaces.py
@@ -94,6 +94,7 @@ class TaskDataProcessFnCallable(Protocol):
         datum_dict: dict[str, Any],
         task_data_spec: TaskDataSpec,
         tokenizer: TokenizerType,
+        chat_template_kwargs: dict[str, Any],
         max_seq_length: int | None,
         idx: int,
     ) -> DatumSpec:

--- a/nemo_rl/data/llm_message_utils.py
+++ b/nemo_rl/data/llm_message_utils.py
@@ -375,6 +375,7 @@ def get_first_index_that_differs(str1: str, str2: str) -> int:
 def get_formatted_message_log(
     message_log: LLMMessageLogType,
     tokenizer: TokenizerType,
+    chat_template_kwargs: dict[str, Any],
     task_data_spec: TaskDataSpec,
     add_bos_token: bool = True,
     add_eos_token: bool = True,
@@ -385,6 +386,7 @@ def get_formatted_message_log(
     Args:
         message_log: List of message dicts with 'role' and 'content' keys
         tokenizer: Tokenizer for converting text to token IDs
+        chat_template_kwargs: chat template keyword arguments.
         task_data_spec: Task spec for this dataset.
         add_bos_token: Whether to add bos token to first message if it is not already present. Default: True
         add_eos_token: Whether to add eos token to last message if it is not already present. Default: True
@@ -415,6 +417,7 @@ def get_formatted_message_log(
             add_generation_prompt=add_generation_prompt and message["role"] == "user",
             tokenize=False,
             add_special_tokens=False,
+            **chat_template_kwargs,
         )
 
         ## get the length of the previous message, excluding the eos token (if present)

--- a/nemo_rl/data/processors.py
+++ b/nemo_rl/data/processors.py
@@ -29,6 +29,7 @@ def math_data_processor(
     datum_dict: dict[str, Any],
     task_data_spec: TaskDataSpec,
     tokenizer: TokenizerType,
+    chat_template_kwargs: dict[str, Any],
     max_seq_length: int,
     idx: int,
 ) -> DatumSpec:
@@ -63,6 +64,7 @@ def math_data_processor(
         tokenize=False,
         add_generation_prompt=True,
         add_special_tokens=False,
+        **chat_template_kwargs,
     )
     user_message["token_ids"] = tokenizer(message, return_tensors="pt")["input_ids"][0]
     user_message["content"] = message
@@ -111,6 +113,7 @@ def multichoice_qa_processor(
     datum_dict: dict[str, Any],
     task_data_spec: TaskDataSpec,
     tokenizer: TokenizerType,
+    chat_template_kwargs: dict[str, Any],
     max_seq_length: int,
     idx: int,
 ) -> DatumSpec:
@@ -150,6 +153,7 @@ def multichoice_qa_processor(
         tokenize=False,
         add_generation_prompt=True,
         add_special_tokens=False,
+        **chat_template_kwargs,
     )
     user_message["token_ids"] = tokenizer(message, return_tensors="pt")["input_ids"][0]
     user_message["content"] = message

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -102,6 +102,7 @@ class MegatronConfig(TypedDict):
 class TokenizerConfig(TypedDict):
     name: str
     chat_template: NotRequired[str]
+    chat_template_kwargs: NotRequired[dict[str, Any]]
 
 
 class PytorchOptimizerConfig(TypedDict):

--- a/tests/unit/data/test_data_processor.py
+++ b/tests/unit/data/test_data_processor.py
@@ -51,6 +51,7 @@ def test_math_data_processor():
     dataset = AllTaskProcessedDataset(
         dataset=raw_dataset,
         tokenizer=tokenizer,
+        chat_template_kwargs={},
         default_task_data_spec=math_task_spec,
         task_data_processors=math_data_processor,
         max_seq_length=128,


### PR DESCRIPTION
# What does this PR do ?

**Support additional arg `chat_template_kwargs` inside tokenizer config**

This is useful for models that have both `thinking` and `non-thinking` modes.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)): N/A


# Usage
* **Run evaluation using Qwen3 under thinking mode**

```python
uv run python examples/run_eval.py --config examples/configs/evals/qwen3_thinking.yaml
```
* **Run evaluation using Qwen3 under non-thinking mode**

```python
uv run python examples/run_eval.py --config examples/configs/evals/qwen3_non_thinking.yaml
```
Also, verified that the metric is much higher using `thinking` mode. Made sure that `run_sft.py`, `run_dpo.py`, `run_grpo_math.py` are working.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
