### PR TITLE
feat: add throughput/prompt_length/total_num_tokens metrics

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -761,7 +761,14 @@ def grpo_train(
         }
         metrics.update(train_results["all_mb_metrics"])
         for k, v in metrics.items():
-            if k in {"lr", "wd", "reward", "global_valid_seqs", "global_valid_toks", "mean_prompt_length"}:
+            if k in {
+                "lr",
+                "wd",
+                "reward",
+                "global_valid_seqs",
+                "global_valid_toks",
+                "mean_prompt_length",
+            }:
                 metrics[k] = np.mean(v).item()
             else:
                 metrics[k] = np.sum(v).item()
@@ -795,8 +802,17 @@ def grpo_train(
         # Display total time first, separately
         total_time = timing_metrics.get("total_step_time", 0)
 
-        total_num_gpus = master_config["cluster"]["num_nodes"] * master_config["cluster"]["gpus_per_node"]
-        metrics.update({"throughput_per_gpu": metrics["total_num_tokens"] / total_time / total_num_gpus})
+        total_num_gpus = (
+            master_config["cluster"]["num_nodes"]
+            * master_config["cluster"]["gpus_per_node"]
+        )
+        metrics.update(
+            {
+                "throughput_per_gpu": metrics["total_num_tokens"]
+                / total_time
+                / total_num_gpus
+            }
+        )
 
         print(f"  • Total step time: {total_time:.2f}s")
 

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -756,10 +756,12 @@ def grpo_train(
             "loss": train_results["loss"].numpy(),
             "reward": rewards.numpy(),
             "grad_norm": train_results["grad_norm"].numpy(),
+            "mean_prompt_length": repeated_batch["length"].numpy(),
+            "total_num_tokens": input_lengths.numpy(),
         }
         metrics.update(train_results["all_mb_metrics"])
         for k, v in metrics.items():
-            if k in {"lr", "wd", "reward", "global_valid_seqs", "global_valid_toks"}:
+            if k in {"lr", "wd", "reward", "global_valid_seqs", "global_valid_toks", "mean_prompt_length"}:
                 metrics[k] = np.mean(v).item()
             else:
                 metrics[k] = np.sum(v).item()
@@ -792,6 +794,10 @@ def grpo_train(
         print("\n⏱️  Timing:")
         # Display total time first, separately
         total_time = timing_metrics.get("total_step_time", 0)
+
+        total_num_gpus = master_config["cluster"]["num_nodes"] * master_config["cluster"]["gpus_per_node"]
+        metrics.update({"throughput_per_gpu": metrics["total_num_tokens"] / total_time / total_num_gpus})
+
         print(f"  • Total step time: {total_time:.2f}s")
 
         # Display all other timing metrics

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -808,7 +808,7 @@ def grpo_train(
         )
         metrics.update(
             {
-                "throughput_per_gpu": metrics["total_num_tokens"]
+                "tokens_per_sec_per_gpu": metrics["total_num_tokens"]
                 / total_time
                 / total_num_gpus
             }


### PR DESCRIPTION
# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**
As attached. Add the following metrics:

* train/mean_prompt_length: mean token length of prompt
* train/total_num_tokens: total num of tokens (including prompt and generation tokens)
* train/throughput_per_gpu: num of tokens per second (including prompt and generation tokens)

https://wandb.ai/nvidia/grpo-dev/runs/33pb40kk?nw=nwuserzhiyul

As a quick verification/test:

* train/total_num_tokens =  num_prompts_per_step x num_generations_per_prompt x (train/mean_prompt_length + train/mean_total_tokens_per_sample)
   - actual: 2869598 vs calculated 2869596.16 (numerical difference)
*  train/throughput = train/total_num_tokens / step time / total_num_gpus
   - actual: 1199 vs  1199

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
