### PR TITLE
feat: support DTensor CP in DPO and SFT

### DIFF
--- a/nemo_rl/algorithms/loss_functions.py
+++ b/nemo_rl/algorithms/loss_functions.py
@@ -325,6 +325,7 @@ class NLLLoss(LossFunction):
         token_mask = data["token_mask"][:, 1:]
         sample_mask = data["sample_mask"]
         mask = token_mask * sample_mask.unsqueeze(-1)
+        seq_index = data.get("seq_index", None)
 
         next_token_logits = next_token_logits.to(torch.float32)
 
@@ -346,7 +347,7 @@ class NLLLoss(LossFunction):
             token_logprobs = token_logprobs[:, : data["input_ids"].shape[1] - 1]
         elif isinstance(next_token_logits, torch.distributed.tensor.DTensor):
             token_logprobs = get_logprobs_from_vocab_parallel_logits(
-                next_token_logits, data["input_ids"]
+                next_token_logits, data["input_ids"], seq_index=seq_index
             )
         else:
             next_tokens = data["input_ids"][:, 1:].cuda()  # Skip first token
@@ -580,6 +581,7 @@ class DPOLossFn(PreferenceLoss):
         ## TODO(@ashors): there's some duplicate code here with the NLLLoss function. We should refactor
         token_mask = data["token_mask"][:, 1:]
         sample_mask = data["sample_mask"]
+        seq_index = data.get("seq_index", None)
 
         next_token_logits = next_token_logits.to(torch.float32)
         if vocab_parallel_group is not None:
@@ -599,7 +601,7 @@ class DPOLossFn(PreferenceLoss):
             token_logprobs = token_logprobs[:, : data["input_ids"].shape[1] - 1]
         elif isinstance(next_token_logits, torch.distributed.tensor.DTensor):
             token_logprobs = get_logprobs_from_vocab_parallel_logits(
-                next_token_logits, data["input_ids"]
+                next_token_logits, data["input_ids"], seq_index=seq_index
             )
         else:
             next_tokens = data["input_ids"][:, 1:].cuda()  # Skip first token

--- a/nemo_rl/algorithms/loss_functions.py
+++ b/nemo_rl/algorithms/loss_functions.py
@@ -155,22 +155,8 @@ class ClippedPGLossFn(LossFunction):
             # slice off to the correct length to remove potential CP padding
             curr_logprobs = curr_logprobs[:, : data["input_ids"].shape[1] - 1]
         elif isinstance(next_token_logits, torch.distributed.tensor.DTensor):
-            target = data["input_ids"]
-
-            cp_size = 1
-            if (
-                target.device_mesh.mesh_dim_names is not None
-                and "cp" in target.device_mesh.mesh_dim_names
-            ):
-                cp_dim_index = target.device_mesh.mesh_dim_names.index("cp")
-                cp_size = target.device_mesh.shape[cp_dim_index]
-            if cp_size > 1:
-                assert seq_index is not None, (
-                    "seq_index must be provided when CP is enabled"
-                )
-
             curr_logprobs = get_logprobs_from_vocab_parallel_logits(
-                next_token_logits, target, seq_index=seq_index
+                next_token_logits, data["input_ids"], seq_index=seq_index
             )
         else:
             next_token_logits_wo_last = next_token_logits[
@@ -360,21 +346,8 @@ class NLLLoss(LossFunction):
             # slice off to the correct length to remove potential CP padding
             token_logprobs = token_logprobs[:, : data["input_ids"].shape[1] - 1]
         elif isinstance(next_token_logits, torch.distributed.tensor.DTensor):
-            target = data["input_ids"]
-
-            cp_size = 1
-            if (
-                target.device_mesh.mesh_dim_names is not None
-                and "cp" in target.device_mesh.mesh_dim_names
-            ):
-                cp_dim_index = target.device_mesh.mesh_dim_names.index("cp")
-                cp_size = target.device_mesh.shape[cp_dim_index]
-            if cp_size > 1:
-                assert seq_index is not None, (
-                    "seq_index must be provided when CP is enabled"
-                )
             token_logprobs = get_logprobs_from_vocab_parallel_logits(
-                next_token_logits, target, seq_index=seq_index
+                next_token_logits, data["input_ids"], seq_index=seq_index
             )
         else:
             next_tokens = data["input_ids"][:, 1:].cuda()  # Skip first token
@@ -627,21 +600,8 @@ class DPOLossFn(PreferenceLoss):
             # slice off to the correct length to remove potential CP padding
             token_logprobs = token_logprobs[:, : data["input_ids"].shape[1] - 1]
         elif isinstance(next_token_logits, torch.distributed.tensor.DTensor):
-            target = data["input_ids"]
-
-            cp_size = 1
-            if (
-                target.device_mesh.mesh_dim_names is not None
-                and "cp" in target.device_mesh.mesh_dim_names
-            ):
-                cp_dim_index = target.device_mesh.mesh_dim_names.index("cp")
-                cp_size = target.device_mesh.shape[cp_dim_index]
-            if cp_size > 1:
-                assert seq_index is not None, (
-                    "seq_index must be provided when CP is enabled"
-                )
             token_logprobs = get_logprobs_from_vocab_parallel_logits(
-                next_token_logits, target, seq_index=seq_index
+                next_token_logits, data["input_ids"], seq_index=seq_index
             )
         else:
             next_tokens = data["input_ids"][:, 1:].cuda()  # Skip first token


### PR DESCRIPTION
# What does this PR do ?
Enables CP with DTensor for DPO and SFT

DPO loss: 
<img src="https://github.com/user-attachments/assets/6adb791d-32fd-4ec2-8d47-d4342e4f738e" alt="dpo_cp" width="350"/>

SFT loss:
<img src="https://github.com/user-attachments/assets/12ed21ee-fbe5-4da1-aee4-683878cef6fb" alt="sft_cp" width="350"/>

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
