### PR TITLE
add qwen3 to megatron conversion

### DIFF
--- a/nemo_rl/models/megatron/community_import.py
+++ b/nemo_rl/models/megatron/community_import.py
@@ -85,9 +85,14 @@ def export_model_from_megatron(
         from nemo.tron.converter.qwen import HFQwen2Exporter
 
         exporter_cls = HFQwen2Exporter
+
+    elif hf_config.model_type == "qwen3":
+        from nemo.tron.converter.qwen import HFQwen3Exporter
+
+        exporter_cls = HFQwen3Exporter
     else:
         raise ValueError(
-            f"Unknown model: {hf_model_name}. Currently, only Qwen2 and Llama are supported. "
+            f"Unknown model: {hf_model_name}. Currently, only Qwen2, Qwen3 and Llama are supported. "
             "If you'd like to run with a different model, please raise an issue or consider adding your own converter."
         )
     print(f"Exporting model {hf_model_name} to {output_path}...")


### PR DESCRIPTION
IMPORTANT:
The NeMo submodule should be updated as in this PR: https://github.com/NVIDIA/NeMo/pull/14378

# What does this PR do ?

This PR allow to export  qwen3 model type from megatron format to HF

# Test
Tested locally via run the megatron conversion script on Qwen3-1.7B.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
