### PR TITLE
fix: crash when sequence packing is enabled for gemma 1b.

### DIFF
--- a/nemo_rl/models/policy/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker.py
@@ -672,7 +672,7 @@ class DTensorPolicyWorker:
 
                             attention_mask = torch.ones(
                                 (batch_size, seq_len),
-                                dtype=torch.long,
+                                dtype=torch.bool,
                                 device=input_ids.device,
                             )
                             position_ids = torch.arange(
@@ -982,7 +982,7 @@ class DTensorPolicyWorker:
                 else:
                     # Create post_attention_mask for right-padded data for masking token after forwarding.
                     post_attention_mask = torch.zeros(
-                        (batch_size, seq_len), dtype=torch.long, device=input_ids.device
+                        (batch_size, seq_len), dtype=torch.bool, device=input_ids.device
                     )
                     for i, length in enumerate(input_lengths):
                         # For right-padded sequence, set 1s at the beginning of the sequence
@@ -995,16 +995,15 @@ class DTensorPolicyWorker:
                     ).repeat(batch_size, 1)
                     flash_attn_kwargs = {}
 
-                    with torch.autocast(device_type="cuda", dtype=self.dtype):
-                        # DTensor requires the casual attention kernel to hit,
-                        # yet our attention mask above is not always all 1s
-                        # this is fine because we mask with the actual attention mask
-                        # later, but for input it has to be all 1s
-                        attention_mask = torch.ones(
-                            (batch_size, seq_len),
-                            dtype=torch.long,
-                            device=input_ids.device,
-                        )
+                    # DTensor requires the casual attention kernel to hit,
+                    # yet our attention mask above is not always all 1s
+                    # this is fine because we mask with the actual attention mask
+                    # later, but for input it has to be all 1s
+                    attention_mask = torch.ones(
+                        (batch_size, seq_len),
+                        dtype=torch.bool,
+                        device=input_ids.device,
+                    )
 
                 # if there are multimodal kwargs, we don't need to add position_ids (computed internally)
                 if len(vlm_kwargs) > 0:

--- a/nemo_rl/models/policy/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker_v2.py
@@ -616,7 +616,7 @@ class DTensorPolicyWorkerV2:
 
                             attention_mask = torch.ones(
                                 (batch_size, seq_len),
-                                dtype=torch.long,
+                                dtype=torch.bool,
                                 device=input_ids.device,
                             )
                             position_ids = torch.arange(
@@ -926,7 +926,7 @@ class DTensorPolicyWorkerV2:
                 else:
                     # Create post_attention_mask for right-padded data for masking token after forwarding.
                     post_attention_mask = torch.zeros(
-                        (batch_size, seq_len), dtype=torch.long, device=input_ids.device
+                        (batch_size, seq_len), dtype=torch.bool, device=input_ids.device
                     )
                     for i, length in enumerate(input_lengths):
                         # For right-padded sequence, set 1s at the beginning of the sequence
@@ -939,16 +939,15 @@ class DTensorPolicyWorkerV2:
                     ).repeat(batch_size, 1)
                     flash_attn_kwargs = {}
 
-                    with torch.autocast(device_type="cuda", dtype=self.dtype):
-                        # DTensor requires the casual attention kernel to hit,
-                        # yet our attention mask above is not always all 1s
-                        # this is fine because we mask with the actual attention mask
-                        # later, but for input it has to be all 1s
-                        attention_mask = torch.ones(
-                            (batch_size, seq_len),
-                            dtype=torch.long,
-                            device=input_ids.device,
-                        )
+                    # DTensor requires the casual attention kernel to hit,
+                    # yet our attention mask above is not always all 1s
+                    # this is fine because we mask with the actual attention mask
+                    # later, but for input it has to be all 1s
+                    attention_mask = torch.ones(
+                        (batch_size, seq_len),
+                        dtype=torch.bool,
+                        device=input_ids.device,
+                    )
 
                 # if there are multimodal kwargs, we don't need to add position_ids (computed internally)
                 if len(vlm_kwargs) > 0:


### PR DESCRIPTION
# What does this PR do ?

Fix crash when get_logprobs for dtensor with gemma model...
The reason why we don't have this bug on other models like llama or qwen is because we passed all ones attention mask and inside modeling script will change attention mask to pass to following on operators to None.
But for model like gemma won't take such approach. And attention mask shape mismatch with input_ids results in crash (Only in flash attention2 now).

# Issues
sequence_packing does not work for gemma models. closes #790

# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
Verify with command to compare with dynamic_batching enabled case (pink):
```
NRL_FORCE_REBUILD_VENVS=1 uv run python examples/run_grpo_math.py  \
    --config examples/configs/recipes/llm/grpo-gemma3-1b-it-1n8g-fsdp2tp1.yaml \
    cluster.gpus_per_node=2 \
    grpo.max_num_steps=25 \
    policy.dynamic_batching.enabled=False \
    policy.sequence_packing.enabled=True \
    ++policy.dtensor_cfg._v2=0 \
    ++policy.sequence_packing.train_mb_tokens=2048 \
    ++policy.sequence_packing.logprob_mb_tokens=2048 \
    ++policy.sequence_packing.algorithm="first_fit_decreasing" \
    ++policy.sequence_packing.sequence_length_round=64 \
    ++policy.megatron_cfg.enabled=false \
    logger.wandb_enabled=1 \
    ++logger.wandb.project=${WANDB_PROJECT} \
    ++logger.wandb.entity=${WANDB_ENTITY} \
    grpo.num_prompts_per_step=8 policy.train_global_batch_size=128 policy.train_micro_batch_size=16

```
Graph with commit c2ebb8c7886fcbcd2f91df2ad994f372b7ace49c.
<img width="1338" height="681" alt="image" src="https://github.com/user-attachments/assets/2b7ba287-5883-4887-a7ce-1303ceab985d" />

<img width="1351" height="712" alt="image" src="https://github.com/user-attachments/assets/1d07635b-8dc1-4ff6-89dc-1ebaa71bcbfc" />

<img width="1342" height="642" alt="image" src="https://github.com/user-attachments/assets/bcd651cd-01e0-43e6-96d5-0659ead77fd7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect handling of padding for right‑padded (non-packed) inputs so padded tokens no longer affect token log probability calculations.
  * Sequence‑packing behavior remains unchanged.

* **Refactor**
  * Mask handling unified to boolean and split into forward‑pass vs post‑processing masks for more consistent, reliable behavior.
  * No changes to public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->