### PR TITLE
feat: support loading jinja templates from file

### DIFF
--- a/docs/guides/sft.md
+++ b/docs/guides/sft.md
@@ -68,7 +68,14 @@ NeMo RL SFT uses Hugging Face chat templates to format the individual examples. 
 
     ```yaml
     tokenizer:
-    custom_template: "{% for message in messages %}{%- if message['role'] == 'system'  %}{{'Context: ' + message['content'].strip()}}{%- elif message['role'] == 'user'  %}{{' Question: ' + message['content'].strip() + ' Answer: '}}{%- elif message['role'] == 'assistant'  %}{{message['content'].strip()}}{%- endif %}{% endfor %}"
+      chat_template: "{% for message in messages %}{%- if message['role'] == 'system'  %}{{'Context: ' + message['content'].strip()}}{%- elif message['role'] == 'user'  %}{{' Question: ' + message['content'].strip() + ' Answer: '}}{%- elif message['role'] == 'assistant'  %}{{message['content'].strip()}}{%- endif %}{% endfor %}"
+    ```
+
+    Alternatively, use a path to a local jinja template and load directly from file:
+
+    ```yaml
+    tokenizer:
+      chat_template: /path/to/template.jinja
     ```
 
 

--- a/nemo_rl/algorithms/utils.py
+++ b/nemo_rl/algorithms/utils.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 import random
 import warnings
 from functools import wraps
@@ -214,8 +215,14 @@ def get_tokenizer(tokenizer_config: TokenizerConfig) -> PreTrainedTokenizerBase:
         elif tokenizer_config["chat_template"].lower() == "default":
             print("Using tokenizer's default chat template")
         else:
-            print("Using custom chat template")
-            tokenizer.chat_template = tokenizer_config["chat_template"]
+            jinja_template = tokenizer_config["chat_template"]
+            if os.path.exists(jinja_template) and os.path.isfile(jinja_template):
+                print(f"Using custom chat template from file: {jinja_template}")
+                with open(jinja_template, "r", encoding="utf-8") as file:
+                    tokenizer.chat_template = file.read()
+            else:
+                print("Using custom chat template")
+                tokenizer.chat_template = jinja_template
     else:
         print("No chat template provided, using tokenizer's default")
 

--- a/tests/unit/algorithms/test_utils.py
+++ b/tests/unit/algorithms/test_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import tempfile
 from datetime import datetime
 
 import pytest
@@ -123,6 +124,30 @@ def test_get_tokenizer_custom_jinja_template(conversation_messages):
     config = {
         "name": "meta-llama/Llama-3.2-1B-Instruct",
         "chat_template": custom_template,
+    }
+    tokenizer = get_tokenizer(config)
+
+    # Verify that the custom template is used
+    formatted = tokenizer.apply_chat_template(conversation_messages, tokenize=False)
+    expected = get_format_with_simple_role_header(conversation_messages)
+    assert formatted == expected
+
+
+@pytest.mark.hf_gated
+def test_get_tokenizer_custom_jinja_template_from_file(conversation_messages):
+    """Test get_tokenizer when a custom jinja template is specified as a file path"""
+    custom_template = COMMON_CHAT_TEMPLATES.simple_role_header
+
+    # Create a temporary file with the template
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".jinja", delete=False
+    ) as temp_file:
+        temp_file.write(custom_template)
+        temp_file_path = temp_file.name
+
+    config = {
+        "name": "meta-llama/Llama-3.2-1B-Instruct",
+        "chat_template": temp_file_path,
     }
     tokenizer = get_tokenizer(config)
 


### PR DESCRIPTION
# What does this PR do ?

Support loading custom chat templates from jinja files

# Issues
N/A

# Usage
    ```yaml
    tokenizer:
      chat_template: /path/to/template.jinja
    ```

# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [X] Did you write any new necessary tests?
- [X] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [X] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
There was also a typo in the sft guide, changed `custom_template` -> `chat_template`
