### PR TITLE
fix: assert no duplicate starting bos

### DIFF
--- a/examples/run_grpo_math.py
+++ b/examples/run_grpo_math.py
@@ -89,15 +89,11 @@ def hf_data_processor(
         add_generation_prompt=True,
         add_special_tokens=False,
     )
-    # add bos token if not in chat template
-    bos_token_in_chat_template = tokenizer.chat_template.startswith(
-        "{{- bos_token }}"
-    ) or tokenizer.chat_template.startswith("{{ bos_token }}")
 
     user_message["token_ids"] = tokenizer(
         message,
         return_tensors="pt",
-        add_special_tokens=not bos_token_in_chat_template,
+        add_special_tokens=False,
     )["input_ids"][0]
     user_message["content"] = message
     message_log.append(user_message)

--- a/tests/unit/data/test_data_processor.py
+++ b/tests/unit/data/test_data_processor.py
@@ -73,6 +73,8 @@ def test_math_data_processor():
         "Qwen/Qwen2.5-1.5B-Instruct",  # no bos token
         "google/gemma-3-1b-it",
         "Qwen/Qwen3-0.6B",  # no bos token
+        "deepseek-ai/DeepSeek-V3",
+        "moonshotai/Moonlight-16B-A3B-Instruct",
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this PR do ?

This is to fix the previous PR https://github.com/NVIDIA-NeMo/RL/pull/747, which fails on tokenizers `deepseek-ai/DeepSeek-V3` and `moonshotai/Moonlight-16B-A3B-Instruct`. 

Thank you @yfw for reporting the issue.

* got duplicated bos in `deepseek-ai/DeepSeek-V3`: the following is not a good way to track added `bos_token` in template as `bos_token` may not always appear at the beginning
```
bos_token_in_chat_template = tokenizer.chat_template.startswith(
        "{{- bos_token }}"
    ) or tokenizer.chat_template.startswith("{{ bos_token }}")
```

* got missing bos in `moonshotai/Moonlight-16B-A3B-Instruct`: it is because `TikTokenTokenizer` follows a different logic no bos token added even with `add_special_tokens=True`, which is different to the other tokenizer like Llama, qwen, etc. In summary, `add_special_tokens=True` doesn't guarantee adding beginning bos token. 

To resolve these inconsistencies, set `add_special_tokens=True` as false all the time and let `chat_template` handle `bos` token. Remove starting `bos_token` check, since it may not hold in `moonshotai/Moonlight-16B-A3B-Instruct`. Only error out when there's 2 duplicated bos token detected at the beginning.


# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
