### PR TITLE
fix: Fix megatron checkpoint loading during sft

### DIFF
--- a/examples/configs/sft.yaml
+++ b/examples/configs/sft.yaml
@@ -64,7 +64,7 @@ policy:
       # and fused to False
       foreach: False
       fused: False
-    
+
   ## ignored since enabled=false, but needed for testing purposes
   megatron_cfg:
     enabled: false
@@ -83,15 +83,15 @@ policy:
     moe_router_dtype: null
     moe_router_load_balancing_type: "aux_loss"
     moe_router_bias_update_rate: 1e-3
-    #gives ~20% training perf speedup with sequence packing 
-    apply_rope_fusion: True   
+    #gives ~20% training perf speedup with sequence packing
+    apply_rope_fusion: True
 
     optimizer:
       optimizer: "adam"
       lr: 5.0e-6
       min_lr: 4.9999e-6
       weight_decay: 0.1
-      bf16: false
+      bf16: true
       fp16: false
       params_dtype: "float32"
 


### PR DESCRIPTION
# What does this PR do ?

This is to prevent the following error when enabling megatron and loading a previously saved checkpoint for sft:

```
 File "/opt/NeMo-RL/3rdparty/Megatron-LM-workspace/Megatron-LM/megatron/core/optimizer/distrib_optimizer.py", line 1120, in sharded_state_dict
  self.load_state_dict(self.state_dict())
 File "/opt/NeMo-RL/3rdparty/Megatron-LM-workspace/Megatron-LM/megatron/core/optimizer/distrib_optimizer.py", line 774, in load_state_dict
  self.optimizer.load_state_dict(
 File "/opt/ray_venvs/nemo_rl.models.policy.megatron_policy_worker.MegatronPolicyWorker/lib/python3.12/site-packages/transformer_engine/pytorch/optimizers/fused_adam.py", line 470, in load_state_dict
  self.set_scaled_state(param, name, v[name])
 File "/opt/ray_venvs/nemo_rl.models.policy.megatron_policy_worker.MegatronPolicyWorker/lib/python3.12/site-packages/transformer_engine/pytorch/optimizers/fused_adam.py", line 347, in set_scaled_state
  assert unscaled_state.dtype == torch.int16
```

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
