### PR TITLE
chore: enable tool calling and output safetensors in distributed checkpoint

### DIFF
--- a/examples/converters/convert_dcp_to_hf.py
+++ b/examples/converters/convert_dcp_to_hf.py
@@ -13,10 +13,14 @@
 # limitations under the License.
 
 import argparse
+import glob
+import os
 
 import yaml
 
 from nemo_rl.utils.native_checkpoint import convert_dcp_to_hf
+
+from transformers import AutoModel
 
 
 def parse_args():
@@ -25,13 +29,10 @@ def parse_args():
         description="Convert Torch DCP checkpoint to HF checkpoint"
     )
     parser.add_argument(
-        "--config",
+        "--checkpoint-path",
         type=str,
         default=None,
-        help="Path to config.yaml file in the checkpoint directory",
-    )
-    parser.add_argument(
-        "--dcp-ckpt-path", type=str, default=None, help="Path to DCP checkpoint"
+        help="Path to the checkpoint directory with config.yaml in it",
     )
     parser.add_argument(
         "--hf-ckpt-path", type=str, default=None, help="Path to save HF checkpoint"
@@ -46,17 +47,13 @@ def main():
     """Main entry point."""
     args = parse_args()
 
-    with open(args.config, "r") as f:
+    config = f"{args.checkpoint_path}/config.json"
+
+    with open(config, "r") as f:
         config = yaml.safe_load(f)
 
     model_name_or_path = config["policy"]["model_name"]
-    # TODO: After the following PR gets merged:
-    # https://github.com/NVIDIA-NeMo/RL/pull/148/files
-    # tokenizer should be copied from policy/tokenizer/* instead of relying on the model name
-    # We can expose a arg at the top level --tokenizer_path to plumb that through.
-    # This is more stable than relying on the current NeMo-RL get_tokenizer() which can
-    # change release to release.
-    tokenizer_name_or_path = config["policy"]["model_name"]
+    tokenizer_name_or_path = f"{args.checkpoint_path}/policy/tokenizer"
 
     hf_ckpt = convert_dcp_to_hf(
         dcp_ckpt_path=args.dcp_ckpt_path,
@@ -64,6 +61,19 @@ def main():
         model_name_or_path=model_name_or_path,
         tokenizer_name_or_path=tokenizer_name_or_path,
     )
+
+    model = AutoModel.from_pretrained(args.hf_ckpt_path)
+    model.save_pretrained(
+        args.hf_ckpt_path,
+        safe_serialization=True,
+        max_shard_size="4GB",
+    )
+
+    for f in glob.glob(os.path.join(args.hf_ckpt_path, "*.bin")) + glob.glob(
+        os.path.join(args.hf_ckpt_path, "*.bin.index.json")
+    ):
+        os.remove(f)
+
     print(f"Saved HF checkpoint to: {hf_ckpt}")
 
 

--- a/examples/run_dpo.py
+++ b/examples/run_dpo.py
@@ -134,10 +134,10 @@ def dpo_preprocessor(
     )
 
     message_log_chosen = get_formatted_message_log(
-        messages_chosen, tokenizer, task_data_spec
+        messages_chosen, tokenizer, task_data_spec, tools=datum_dict.get("tools")
     )
     message_log_rejected = get_formatted_message_log(
-        messages_rejected, tokenizer, task_data_spec
+        messages_rejected, tokenizer, task_data_spec, tools=datum_dict.get("tools")
     )
 
     length_chosen = sum(len(m["token_ids"]) for m in message_log_chosen)

--- a/nemo_rl/data/llm_message_utils.py
+++ b/nemo_rl/data/llm_message_utils.py
@@ -379,6 +379,7 @@ def get_formatted_message_log(
     add_bos_token: bool = True,
     add_eos_token: bool = True,
     add_generation_prompt: bool = False,
+    tools: Optional[dict] = None,
 ) -> LLMMessageLogType:
     """Format and tokenize chat messages using the specified template.
 
@@ -415,6 +416,7 @@ def get_formatted_message_log(
             add_generation_prompt=add_generation_prompt and message["role"] == "user",
             tokenize=False,
             add_special_tokens=False,
+            tools=tools,
         )
 
         ## get the length of the previous message, excluding the eos token (if present)


### PR DESCRIPTION
# What does this PR do ?

- Convert the model weights from PyTorch’s .bin to safetensors as it is more secure and an ask from security.
- Get the path to `config.jsonl` from checkpoint dir
- Enable tool calling in alignment datasets

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
