### PR TITLE
fix: fix Tuple response + move log_hyperparam responsibility to caller

### DIFF
--- a/examples/run_dpo.py
+++ b/examples/run_dpo.py
@@ -251,6 +251,7 @@ def main():
         dpo_save_state,
         master_config,
     ) = setup(config, tokenizer, train_dataset, val_dataset)
+    logger.log_hyperparams(master_config)
     dpo_train(
         policy,
         train_dataloader,

--- a/nemo_rl/algorithms/dpo.py
+++ b/nemo_rl/algorithms/dpo.py
@@ -101,10 +101,11 @@ def setup(
     StatefulDataLoader,
     StatefulDataLoader,
     DPOLossFn,
-    MasterConfig,
     Logger,
+    CheckpointManager,
     TaskDataSpec,
     DPOSaveState,
+    MasterConfig,
 ]:
     """Main entry point for running DPO algorithm.
 
@@ -135,7 +136,6 @@ def setup(
     #         Logger
     # ==========================
     logger = Logger(logger_config)
-    logger.log_hyperparams(master_config)
 
     # ==========================
     #      Checkpointing


### PR DESCRIPTION
# What does this PR do ?

- Fixes the response Tuple returned during setup and initialization in `dpo.py`
- Remove `log_hyperparams` because it logs information before the backend is ready / initialized which causes crashes


# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
