### PR TITLE
chore: output safetensors + remove logger before backend is ready

### DIFF
--- a/examples/converters/convert_dcp_to_hf.py
+++ b/examples/converters/convert_dcp_to_hf.py
@@ -13,10 +13,13 @@
 # limitations under the License.
 
 import argparse
-
+import glob
+import os
 import yaml
 
 from nemo_rl.utils.native_checkpoint import convert_dcp_to_hf
+
+from transformers import AutoModel
 
 
 def parse_args():
@@ -25,13 +28,10 @@ def parse_args():
         description="Convert Torch DCP checkpoint to HF checkpoint"
     )
     parser.add_argument(
-        "--config",
+        "--checkpoint-path",
         type=str,
         default=None,
-        help="Path to config.yaml file in the checkpoint directory",
-    )
-    parser.add_argument(
-        "--dcp-ckpt-path", type=str, default=None, help="Path to DCP checkpoint"
+        help="Path to the checkpoint directory with config.yaml in it",
     )
     parser.add_argument(
         "--hf-ckpt-path", type=str, default=None, help="Path to save HF checkpoint"
@@ -46,24 +46,34 @@ def main():
     """Main entry point."""
     args = parse_args()
 
-    with open(args.config, "r") as f:
+    config = f"{args.checkpoint_path}/config.json"
+
+    with open(config, "r") as f:
         config = yaml.safe_load(f)
 
     model_name_or_path = config["policy"]["model_name"]
-    # TODO: After the following PR gets merged:
-    # https://github.com/NVIDIA-NeMo/RL/pull/148/files
-    # tokenizer should be copied from policy/tokenizer/* instead of relying on the model name
-    # We can expose a arg at the top level --tokenizer_path to plumb that through.
-    # This is more stable than relying on the current NeMo-RL get_tokenizer() which can
-    # change release to release.
-    tokenizer_name_or_path = config["policy"]["model_name"]
+    tokenizer_name_or_path = f"{args.checkpoint_path}/policy/tokenizer"
 
     hf_ckpt = convert_dcp_to_hf(
-        dcp_ckpt_path=args.dcp_ckpt_path,
+        dcp_ckpt_path=f"{args.checkpoint_path}/policy/weights",
         hf_ckpt_path=args.hf_ckpt_path,
         model_name_or_path=model_name_or_path,
         tokenizer_name_or_path=tokenizer_name_or_path,
+        overwrite=True,
     )
+
+    model = AutoModel.from_pretrained(args.hf_ckpt_path)
+    model.save_pretrained(
+        args.hf_ckpt_path,
+        safe_serialization=True,
+        max_shard_size="4GB",
+    )
+
+    for f in glob.glob(os.path.join(args.hf_ckpt_path, "*.bin")) + glob.glob(
+        os.path.join(args.hf_ckpt_path, "*.bin.index.json")
+    ):
+        os.remove(f)
+
     print(f"Saved HF checkpoint to: {hf_ckpt}")
 
 

--- a/examples/run_dpo.py
+++ b/examples/run_dpo.py
@@ -251,6 +251,7 @@ def main():
         dpo_save_state,
         master_config,
     ) = setup(config, tokenizer, train_dataset, val_dataset)
+    logger.log_hyperparams(master_config)
     dpo_train(
         policy,
         train_dataloader,

--- a/nemo_rl/algorithms/dpo.py
+++ b/nemo_rl/algorithms/dpo.py
@@ -134,7 +134,6 @@ def setup(
     #         Logger
     # ==========================
     logger = Logger(logger_config)
-    logger.log_hyperparams(master_config)
 
     # ==========================
     #      Checkpointing


### PR DESCRIPTION
# What does this PR do ?

- This PR adds the changes from these 3 PRs that are merged in [integration/nemo-customizer](https://github.com/NVIDIA-NeMo/RL/tree/integration/nemo-customizer)  branch but are not already included in main.
- PRs merged -  [843](https://github.com/NVIDIA-NeMo/RL/pull/843/files), [845](https://github.com/NVIDIA-NeMo/RL/pull/845), [850](https://github.com/NVIDIA-NeMo/RL/pull/850)

**List of changes in above PRs, and what is present in this PR:**
- Convert the model weights from PyTorch’s .bin to safetensors as it is more secure and an ask from security. - added in this PR
- Get the path to config.jsonl from checkpoint dir - added in this PR
- Enable tool calling in alignment datasets - covered by https://github.com/NVIDIA-NeMo/RL/pull/778
- Fixes the response Tuple returned during setup and initialization in dpo.py - already updated [here](https://github.com/NVIDIA-NeMo/RL/blob/main/nemo_rl/algorithms/dpo.py#L104-L106)
- Remove log_hyperparams because it logs information before the backend is ready / initialized which causes crashes - added in this PR


# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
