### PR TITLE
feat: LLaDA Model Support

### DIFF
--- a/nemo_rl/models/dtensor/parallelize.py
+++ b/nemo_rl/models/dtensor/parallelize.py
@@ -405,6 +405,11 @@ def _parallelize_model(
         layers: torch.nn.ModuleList = model.language_model.layers  # type: ignore
         num_attention_heads = model.config.text_config.num_attention_heads
         num_key_value_heads = model.config.text_config.num_key_value_heads
+    elif "GSAI-ML.LLaDA" in str(model_cls):
+        # Adding this for LlaDA compatibility which uses a different naming convention compared to GPT Llama style models
+        layers: torch.nn.ModuleList = model.model.transformer.blocks
+        num_attention_heads = model.model.config.n_heads
+        num_key_value_heads = model.model.config.n_kv_heads
     else:
         layers: torch.nn.ModuleList = model.model.layers  # type: ignore
         num_attention_heads = model.config.num_attention_heads


### PR DESCRIPTION
# What does this PR do ?

Adds support for the LLaDA class of diffusion LM models on HuggingFace

# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [X] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

Currently, trying to do diffusion SFT with one of the LLaDA models on HuggingFace results in various crashes, as the DTensor logic has been written to only parallelise and work with GPT-style LLama models and their architecture and attributes. This PR allows LLada models to be successfully loaded and parallelised, and paves the way for future PRs to implement things such as diffusion SFT and generation