### PR TITLE
feat: Add TP to embed_tokens and lm_head for Gemma models

### DIFF
--- a/nemo_rl/models/dtensor/parallelize.py
+++ b/nemo_rl/models/dtensor/parallelize.py
@@ -31,8 +31,6 @@ from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.parallel import (
     ColwiseParallel,
     ParallelStyle,
-    PrepareModuleInput,
-    PrepareModuleOutput,
     RowwiseParallel,
     SequenceParallel,
     parallelize_module,
@@ -93,18 +91,14 @@ def _parallelize_gemma3(
     model: Union[Gemma3ForCausalLM, Gemma3ForConditionalGeneration],
     sequence_parallel: bool = False,
 ) -> dict[str, ParallelStyle]:
-    """Parallelizes a Gemma3ForCausalLM model across data parallel dimensions.
-
-    Tensor parallelism is not supported for Gemma3 models because of tied word embeddings.
-    """
+    """Parallelizes a Gemma3ForCausalLM model across data and tensor parallel dimensions."""
     if isinstance(model, Gemma3ForConditionalGeneration):
         model_prefix = "model.language_model"
     else:
         model_prefix = "model"
 
-    # For gemma3 models, we don't include the model.embed_tokens and lm_head in the
-    # parallelization plans because they have tied weights.
     base_model_tp_plan: dict[str, ParallelStyle] = {
+        f"{model_prefix}.embed_tokens": RowwiseParallel(input_layouts=Replicate()),
         f"{model_prefix}.layers.*.self_attn.q_proj": ColwiseParallel(),
         f"{model_prefix}.layers.*.self_attn.k_proj": ColwiseParallel(),
         f"{model_prefix}.layers.*.self_attn.v_proj": ColwiseParallel(),
@@ -112,13 +106,12 @@ def _parallelize_gemma3(
         f"{model_prefix}.layers.*.mlp.up_proj": ColwiseParallel(),
         f"{model_prefix}.layers.*.mlp.gate_proj": ColwiseParallel(),
         f"{model_prefix}.layers.*.mlp.down_proj": RowwiseParallel(),
+        "lm_head": ColwiseParallel(output_layouts=Shard(-1), use_local_output=False),
     }
 
     base_model_sp_plan = {
-        f"{model_prefix}.embed_tokens": PrepareModuleOutput(
-            output_layouts=Replicate(),
-            desired_output_layouts=Shard(1),
-            use_local_output=False,
+        f"{model_prefix}.embed_tokens": RowwiseParallel(
+            input_layouts=Replicate(), output_layouts=Shard(1)
         ),
         f"{model_prefix}.rotary_emb": RotaryEmbedParallel(use_local_output=True),
         f"{model_prefix}.rotary_emb_local": RotaryEmbedParallel(use_local_output=True),
@@ -133,10 +126,8 @@ def _parallelize_gemma3(
         ),
         f"{model_prefix}.layers.*.post_feedforward_layernorm": SequenceParallel(),
         f"{model_prefix}.norm": SequenceParallel(),
-        "lm_head": PrepareModuleInput(
-            input_layouts=(Shard(1),),
-            desired_input_layouts=(Replicate(),),
-            use_local_output=True,
+        "lm_head": ColwiseParallel(
+            input_layouts=Shard(1), output_layouts=Shard(-1), use_local_output=False
         ),
     }
 


### PR DESCRIPTION
# What does this PR do ?

This PR enables tensor parallelism (TP) for Gemma3 models by adding support for parallelizing the embed_tokens and lm_head layers. Previously, these layers were excluded from TP due to tied word embeddings constraints, but with the removal of TP plan restrictions, Gemma3 models can now fully leverage tensor parallelism.

## Changes Made
- Modified _parallelize_gemma3() function in nemo_rl/models/dtensor/parallelize.py:
    - Added embed_tokens to tensor parallel plan using ColwiseParallel()
    - Added lm_head to tensor parallel plan using RowwiseParallel()
    - Updated sequence parallel plan to include proper configurations for both layers
    - Removed the previous workaround using PrepareModuleOutput and PrepareModuleInput

# Issues
List issues that this PR closes : #812 


# Testing
Command:
```bash
NRL_FORCE_REBUILD_VENVS=true uv run python examples/run_grpo_math.py --config examples/configs/grpo_math_1B.yaml \
		grpo.max_num_steps=100 \
		policy.model_name='google/gemma-3-4b-it' \
		policy.generation.temperature=1.0 \
		policy.dynamic_batching.enabled=True \
		policy.sequence_packing.enabled=False \
		policy.max_total_sequence_length=2048 \
		policy.dtensor_cfg.tensor_parallel_size=2 \
		checkpointing.checkpoint_dir='results/gemma-3-4b-it-tp2' \
		checkpointing.save_period=50 \
		logger.wandb_enabled=true \
		logger.wandb.project='add_tp_for_gemma-496d61fc4ea2d70972e3b82b24363dfbe294d904' \
		logger.wandb.name='gemma-3-4b-it-tp2' \
		cluster.gpus_per_node=8"
```

<img width="726" height="954" alt="image" src="https://github.com/user-attachments/assets/094fe23f-83a4-4a81-8ba9-f87f28189ea2" />

