### PR TITLE
fix: fix async vllm nccl fail on dsv3 tp16pp2 and non-colocated on single node

### DIFF
--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -202,9 +202,14 @@ class BaseVllmGenerationWorker:
             logger.info("Successfully patched vllm.utils._maybe_force_spawn.")
 
             def _patch_vllm_init_workers_ray():
-                # Patch the vLLM ray_distributed_executor.py file to pass custom runtime_env in _init_workers_ray call.
-                # This allows passing custom env_vars and py_executable to worker initialization.
+                """Patch the vLLM ray_distributed_executor.py file.
 
+                1. Pass custom runtime_env in _init_workers_ray call.
+                    - This allows passing custom py_executable to worker initialization.
+                2. Add NCCL_CUMEM_ENABLE and NCCL_NVLS_ENABLE to vLLM ADDITIONAL_ENV_VARS.
+                    - This is a workaround to fix async vllm in some scenarios.
+                    - See https://github.com/NVIDIA-NeMo/RL/pull/898 for more details.
+                """
                 try:
                     import vllm.executor.ray_distributed_executor as ray_executor_module
 


### PR DESCRIPTION
# What does this PR do ?
The workers under async vllm engine are unable to get os.environ correctly in some scenarios.

This PR fix the following error in these two scenarios by adding the env vars to vllm's `ADDITIONAL_ENV_VARS`.
1. set `NCCL_NVLS_ENABLE` for async vllm fail on dsv3 tp16pp2.
2. set `NCCL_CUMEM_ENABLE` for async vllm fail with non-colocated on single node.

**Error**:
```bash
transport/nvls.cc:598 NCCL WARN Cuda failure 1 'invalid argument'

raise RuntimeError(f"NCCL error: {error_str}")
RuntimeError: NCCL error: unhandled cuda error (run with NCCL_DEBUG=INFO for details)
```

# Issues
Related https://github.com/NVIDIA-NeMo/RL/issues/908.