### PR TITLE
fix: do not remove newlines after final eos_token in data processing

### DIFF
--- a/nemo_rl/data/llm_message_utils.py
+++ b/nemo_rl/data/llm_message_utils.py
@@ -444,7 +444,7 @@ def get_formatted_message_log(
             have <eos>\n we'll check for that case.
 
             This makes the logic slightly more robust to the model family's chat template
-            so users don't nede to know whether they need to add add_eos or not.
+            so users don't need to know whether they need to add add_eos or not.
             """
             stripped_message_chunk = message_chunk.rstrip("\n")
             if add_eos_token:

--- a/nemo_rl/data/llm_message_utils.py
+++ b/nemo_rl/data/llm_message_utils.py
@@ -436,8 +436,6 @@ def get_formatted_message_log(
                     message_chunk = tokenizer.bos_token + message_chunk
 
         if i == len(message_log_strs) - 1:
-            # do a loose check if the message ends with a ${eos_token}\n, which is the case for chat templates from qwen. Otherwise append eos_token
-            # This is an attempt to robustly append the eos token
             r"""
             This is an attempt to robustly append the eos token. The origin is Qwen
             chat templates always append <eos>\n and some models like gemma do not

--- a/tests/unit/data/test_llm_message_utils.py
+++ b/tests/unit/data/test_llm_message_utils.py
@@ -429,20 +429,22 @@ def test_get_formatted_message_log_qwen(
 
     ## get expected result
     ## result is equivalent to if we apply chat template to the full message log,
-    ## remove the trailing newline, and then partition by the delimiter
+    ## and then partition by the delimiter
     expected_text_string = tokenizer.apply_chat_template(
         [raw_chat_message_log],
         tokenize=False,
         add_generation_prompt=False,
         add_special_tokens=False,
-    )[0].rstrip("\n")  ## remove trailing newline
+    )[0]
 
     delimiter = "<|im_end|>\n"
     split_text = expected_text_string.split(delimiter)
     expected_text = []
     for i in range(len(split_text)):
-        if i == len(raw_chat_message_log) - 1:
-            expected_text.append(split_text[i])
+        if i == len(split_text) - 1:
+            assert split_text[i] == "", (
+                f"Splitting on <|im_end|>\\n means that the last message should be empty but found: {split_text[i]}"
+            )
         else:
             expected_text.append(split_text[i] + delimiter)
 
@@ -464,7 +466,7 @@ def test_get_formatted_message_log_add_generation_prompt_qwen(
 
     ## get expected result
     ## result is equivalent to if we apply chat template to the full message log,
-    ## remove the trailing newline, and then partition by the delimiter
+    ## and then partition by the delimiter
     ## Separately handle the last message because of the generation prompt
     expected_text_string = tokenizer.apply_chat_template(
         [raw_chat_message_log[:2]],
@@ -482,8 +484,9 @@ def test_get_formatted_message_log_add_generation_prompt_qwen(
         else:
             expected_text.append(split_text[i] + delimiter)
 
+    # This trailing <eos_token>\n is very specific to qwen
     formatted_assistant_message = (
-        raw_chat_message_log[2]["content"] + tokenizer.eos_token
+        raw_chat_message_log[2]["content"] + tokenizer.eos_token + "\n"
     )
     expected_text.append(formatted_assistant_message)
 


### PR DESCRIPTION
# What does this PR do ?

Currently the data processing will strip the final newline after an eos token which may nudge training to not produce a newline after eos token. The tokenizer that this could be an issue for is qwen which always append a newline after eos_token.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

closes #932 

# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
