### PR TITLE
fix: checkpoint saving with distributed optimizer + overlap param gather

### DIFF
--- a/nemo_rl/models/policy/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/megatron_policy_worker.py
@@ -1770,6 +1770,8 @@ class MegatronPolicyWorker:
             if not is_training:
                 self.model.eval()
 
+            if self.should_disable_forward_pre_hook:
+                self.disable_forward_pre_hook()
             save_checkpoint(
                 state=self.mcore_state,
                 model=[self.model],
@@ -1784,6 +1786,8 @@ class MegatronPolicyWorker:
                 blocking=True,
                 terminate=True,
             )
+            if self.should_disable_forward_pre_hook:
+                self.enable_forward_pre_hook()
 
             if not is_training:  # Restore training state if it was changed
                 self.model.train()


### PR DESCRIPTION
# What does this PR do ?
Fixes checkpoint saving when distributed optimizer + overlap param gather are used together. We need to disable/re-enable the pre-forward hooks around checkpoint saving as done here: https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/742aaf84d9a3c4108b675968cc5b5ed59e4e4921/src/megatron/bridge/training/train.py#L787-L805

Currently state: the loss spikes on resume without this:
<img width="461" height="327" alt="Screenshot 2025-08-20 at 1 54 41 AM" src="https://github.com/user-attachments/assets/3c76a51b-41ff-4b28-a329-50c6b2ac5344" />

With this PR:
<img width="453" height="318" alt="Screenshot 2025-08-20 at 2 31 35 AM" src="https://github.com/user-attachments/assets/f8030955-7542-47e0-9f25-a1a8c5de0375" />


+ testing with https://github.com/NVIDIA-NeMo/RL/pull/905:

<img width="460" height="324" alt="Screenshot 2025-08-20 at 1 54 30 AM" src="https://github.com/user-attachments/assets/d9476354-08ce-4181-9467-5f9309e832df" />



# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
