### PR TITLE
fix: permit conflicting metrics in nightly tests + config code_snapshot dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ docker/*
 wandb/
 checkpoints/
 results/
-code_snapshots/
+code_snapshots*/
 
 # Runtime env
 *runtime_env.yaml

--- a/tests/test_suites/llm/grpo-deepscaler-1.5b-16K.sh
+++ b/tests/test_suites/llm/grpo-deepscaler-1.5b-16K.sh
@@ -36,7 +36,7 @@ uv run examples/run_grpo_math.py \
     2>&1 | tee $RUN_LOG
 
 # Convert tensorboard logs to json
-uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS --allow-conflicts
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
 
 # Only run metrics if the target step is reached
 if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then

--- a/tests/test_suites/llm/grpo-deepscaler-1.5b-24K.sh
+++ b/tests/test_suites/llm/grpo-deepscaler-1.5b-24K.sh
@@ -36,7 +36,7 @@ uv run examples/run_grpo_math.py \
     2>&1 | tee $RUN_LOG
 
 # Convert tensorboard logs to json
-uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS --allow-conflicts
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
 
 # Only run metrics if the target step is reached
 if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then

--- a/tests/test_suites/llm/grpo-deepscaler-1.5b-8K.sh
+++ b/tests/test_suites/llm/grpo-deepscaler-1.5b-8K.sh
@@ -29,7 +29,7 @@ uv run examples/run_grpo_math.py \
     2>&1 | tee $RUN_LOG
 
 # Convert tensorboard logs to json
-uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS --allow-conflicts
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
 
 # Only run metrics if the target step is reached
 if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then

--- a/tools/code_snapshot.sh
+++ b/tools/code_snapshot.sh
@@ -16,12 +16,14 @@ if [[ ! -e "$PROJECT_ROOT/.git" ]]; then
 elif [[ $# -lt 1 ]]; then
   echo2 "[Error]: This script requires one argument: the name of the experiment to be used as the snapshot directory name"
   echo2 "Usage: bash tools/code_snapshot.sh <experiment_name>"
+  echo2 "Usage: CODE_SNAPSHOT_DIRNAME=code_snapshots_dbg bash tools/code_snapshot.sh <experiment_name>"
   exit 1
 fi
 
 EXP_NAME=$1
+CODE_SNAPSHOT_DIRNAME=${CODE_SNAPSHOT_DIRNAME:-code_snapshots}
 
-SNAPSHOT_DIR="$PROJECT_ROOT/code_snapshots/${EXP_NAME}"
+SNAPSHOT_DIR="$PROJECT_ROOT/${CODE_SNAPSHOT_DIRNAME}/${EXP_NAME}"
 if [[ ! -d "$SNAPSHOT_DIR" ]]; then
   echo2 "Creating new code snapshot in $SNAPSHOT_DIR"
   mkdir -p $SNAPSHOT_DIR


### PR DESCRIPTION
Sometimes the metric calculation can error if there is data for the same step in multiple sets of TB logs. This permits this since the usual reason this happens is one stage is pre-empted, so the following stage needs to go back to the last checkpoint so its value is repeated in both the pre-empted TB logs and the new one.

This change also configures the code_snapshot dir which is helpful for versioning runs