### PR TITLE
fix: address double bos in eval task

### DIFF
--- a/nemo_rl/data/processors.py
+++ b/nemo_rl/data/processors.py
@@ -51,7 +51,9 @@ def math_data_processor(
             add_generation_prompt=False,
             add_special_tokens=False,
         )
-        sys_prompt["token_ids"] = tokenizer(sys, return_tensors="pt")["input_ids"][0]
+        sys_prompt["token_ids"] = tokenizer(
+            sys, return_tensors="pt", add_special_tokens=False
+        )["input_ids"][0]
         message_log.append(sys_prompt)
 
     # user prompt
@@ -138,7 +140,9 @@ def multichoice_qa_processor(
             add_generation_prompt=False,
             add_special_tokens=False,
         )
-        sys_prompt["token_ids"] = tokenizer(sys, return_tensors="pt")["input_ids"][0]
+        sys_prompt["token_ids"] = tokenizer(
+            sys, return_tensors="pt", add_special_tokens=False
+        )["input_ids"][0]
         message_log.append(sys_prompt)
 
     # user prompt
@@ -153,7 +157,9 @@ def multichoice_qa_processor(
         add_generation_prompt=True,
         add_special_tokens=False,
     )
-    user_message["token_ids"] = tokenizer(message, return_tensors="pt")["input_ids"][0]
+    user_message["token_ids"] = tokenizer(
+        message, return_tensors="pt", add_special_tokens=False
+    )["input_ids"][0]
     user_message["content"] = message
     message_log.append(user_message)
 

--- a/tests/unit/data/test_data_processor.py
+++ b/tests/unit/data/test_data_processor.py
@@ -14,6 +14,7 @@
 
 import os
 import sys
+import tempfile
 from collections import defaultdict
 
 import pytest
@@ -25,6 +26,11 @@ sys.path.append("/".join(abspath.split("/")[:-4]))
 from examples.run_grpo_math import hf_data_processor
 from nemo_rl.algorithms.utils import get_tokenizer
 from nemo_rl.data.datasets import AllTaskProcessedDataset
+from nemo_rl.data.eval_datasets.aime2024 import AIME2024Dataset
+from nemo_rl.data.eval_datasets.aime2025 import AIME2025Dataset
+from nemo_rl.data.eval_datasets.gpqa import GPQADataset
+from nemo_rl.data.eval_datasets.math import MathDataset
+from nemo_rl.data.eval_datasets.mmlu import MMLUDataset
 from nemo_rl.data.hf_datasets.deepscaler import DeepScalerDataset
 from nemo_rl.data.hf_datasets.openmathinstruct2 import OpenMathInstruct2Dataset
 from nemo_rl.data.interfaces import TaskDataProcessFnCallable, TaskDataSpec
@@ -78,18 +84,15 @@ def test_math_data_processor():
     ],
 )
 @pytest.mark.parametrize(
-    "dataset_name",
+    "dataset_cls",
     [
-        "openmathinstruct2",
-        "deepscaler",
+        OpenMathInstruct2Dataset,
+        DeepScalerDataset,
     ],
 )
-def test_math_hf_data_processor(tokenizer_name, dataset_name):
+def test_math_hf_data_processor(tokenizer_name, dataset_cls):
     # Initialize dataset
-    if dataset_name == "openmathinstruct2":
-        data = OpenMathInstruct2Dataset()
-    elif dataset_name == "deepscaler":
-        data = DeepScalerDataset()
+    data = dataset_cls()
 
     # Setup tokenizer
     tokenizer = get_tokenizer(
@@ -116,6 +119,73 @@ def test_math_hf_data_processor(tokenizer_name, dataset_name):
         tokenizer=tokenizer,
         default_task_data_spec=math_task_spec,
         task_data_processors=task_data_processors,
+        max_seq_length=128,
+    )
+
+    # Test that the first item can be retrieved when the BOS token assertion passes
+    first_item = dataset[0]
+    assert first_item is not None
+    assert "message_log" in first_item
+    assert len(first_item["message_log"]) > 0
+
+
+@pytest.fixture
+def system_prompt_file(request):
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as file:
+        file.write("You are a helpful assistant.\n{}")
+
+    return file.name
+
+
+@pytest.mark.hf_gated
+@pytest.mark.parametrize(
+    "tokenizer_name",
+    [
+        "meta-llama/Llama-3.2-1B-Instruct",
+        "Qwen/Qwen2.5-1.5B-Instruct",  # no bos token
+        "google/gemma-3-1b-it",
+        "Qwen/Qwen3-0.6B",  # no bos token
+        "deepseek-ai/DeepSeek-V3",
+        "moonshotai/Moonlight-16B-A3B-Instruct",
+    ],
+)
+@pytest.mark.parametrize(
+    "dataset_cls",
+    [
+        MMLUDataset,
+        GPQADataset,
+        MathDataset,
+        AIME2024Dataset,
+        AIME2025Dataset,
+    ],
+)
+@pytest.mark.parametrize(
+    "system_prompt_file", [system_prompt_file, None], indirect=True
+)
+def test_eval_math_hf_data_processor(tokenizer_name, dataset_cls, system_prompt_file):
+    # Initialize dataset
+    data = dataset_cls()
+
+    # Setup tokenizer
+    tokenizer = get_tokenizer(
+        TokenizerConfig(
+            name=tokenizer_name,
+            chat_template="default",
+        )
+    )
+
+    # Configure task specification
+    math_task_spec = TaskDataSpec(
+        task_name="math",
+        prompt_file=f"{os.path.dirname(abspath)}/../../../examples/prompts/cot.txt",
+        system_prompt_file=system_prompt_file,
+    )
+
+    dataset = AllTaskProcessedDataset(
+        dataset=data.rekeyed_ds,
+        tokenizer=tokenizer,
+        default_task_data_spec=math_task_spec,
+        task_data_processors=data.processor,
         max_seq_length=128,
     )
 


### PR DESCRIPTION
# What does this PR do ?

As titled, address double bos issue all over the repo. The missing part is mainly in eval.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
