### PR TITLE
ci: Fix build and test publish wheel

### DIFF
--- a/.github/workflows/build-test-publish-wheel.yml
+++ b/.github/workflows/build-test-publish-wheel.yml
@@ -36,6 +36,7 @@ jobs:
       python-package: nemo_rl
       packaging: uv
       submodules: recursive
+      no-publish: ${{ github.event_name == 'pull_request' }}
     secrets:
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
       TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/build-test-publish-wheel.yml
+++ b/.github/workflows/build-test-publish-wheel.yml
@@ -16,6 +16,13 @@ name: Build, test, and publish a PyPi wheel (to testpypi).
 
 on:
   push:
+    branches:
+      - main
+      - "r**"
+  pull_request:
+    branches:
+      - main
+      - r**
 
 defaults:
   run:
@@ -23,7 +30,7 @@ defaults:
 
 jobs:
   build-test-publish-wheel:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@8f0565506c82de5fb5a3254dd8b64f110e424dd2
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@9fd09e86e5d34d3095afc7b334bd2bfbafc3f607
     with:
       dry-run: true
       python-package: nemo_rl

--- a/.github/workflows/build-test-publish-wheel.yml
+++ b/.github/workflows/build-test-publish-wheel.yml
@@ -30,7 +30,7 @@ defaults:
 
 jobs:
   build-test-publish-wheel:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@9fd09e86e5d34d3095afc7b334bd2bfbafc3f607
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@v0.55.0
     with:
       dry-run: true
       python-package: nemo_rl

--- a/.github/workflows/build-test-publish-wheel.yml
+++ b/.github/workflows/build-test-publish-wheel.yml
@@ -16,9 +16,6 @@ name: Build, test, and publish a PyPi wheel (to testpypi).
 
 on:
   push:
-    branches:
-      - main
-      - "r**"
 
 defaults:
   run:
@@ -26,11 +23,12 @@ defaults:
 
 jobs:
   build-test-publish-wheel:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@v0.33.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@8f0565506c82de5fb5a3254dd8b64f110e424dd2
     with:
       dry-run: true
       python-package: nemo_rl
       packaging: uv
+      submodules: recursive
     secrets:
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
       TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ automodel = [
 ]
 vllm = [
     "cuda-python",
-    "deep_gemm",
     "vllm==0.10.0",
     "num2words>=0.5.14",
     # Remove this once https://github.com/NVIDIA-NeMo/RL/issues/501 resolved
@@ -130,6 +129,9 @@ test = [
     "pytest-timeout",
     "pytest-cov",
     "pytest-asyncio",
+]
+vllm = [
+    "deep_gemm"
 ]
 
 [tool.uv.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ automodel = [
 ]
 vllm = [
     "cuda-python",
-    "deep_gemm @ git+https://github.com/deepseek-ai/DeepGEMM.git@7b6b5563b9d4c1ae07ffbce7f78ad3ac9204827c",
+    "deep_gemm",
     "vllm==0.10.0",
     "num2words>=0.5.14",
     # Remove this once https://github.com/NVIDIA-NeMo/RL/issues/501 resolved
@@ -150,6 +150,7 @@ triton = [
 ]
 causal-conv1d = { git = "https://github.com/Dao-AILab/causal-conv1d", tag = "v1.5.0.post8" }
 mamba-ssm = { git = "https://github.com/state-spaces/mamba.git", rev = "2e16fc3062cdcd4ebef27a9aa4442676e1c7edf4" }
+deep_gemm = { git = "https://github.com/deepseek-ai/DeepGEMM.git", rev = "7b6b5563b9d4c1ae07ffbce7f78ad3ac9204827c" }
 
 [tool.uv.workspace]
 members = [

--- a/uv.lock
+++ b/uv.lock
@@ -3057,7 +3057,6 @@ mcore = [
 vllm = [
     { name = "causal-conv1d" },
     { name = "cuda-python" },
-    { name = "deep-gemm" },
     { name = "flash-attn" },
     { name = "mamba-ssm" },
     { name = "num2words" },
@@ -3095,6 +3094,9 @@ test = [
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
 ]
+vllm = [
+    { name = "deep-gemm" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -3106,7 +3108,6 @@ requires-dist = [
     { name = "cuda-python", marker = "extra == 'vllm'" },
     { name = "datasets", specifier = ">=4.0.0" },
     { name = "debugpy" },
-    { name = "deep-gemm", marker = "extra == 'vllm'", git = "https://github.com/deepseek-ai/DeepGEMM.git?rev=7b6b5563b9d4c1ae07ffbce7f78ad3ac9204827c" },
     { name = "flash-attn", marker = "extra == 'automodel'", specifier = "==2.7.4.post1" },
     { name = "flash-attn", marker = "extra == 'mcore'", specifier = "==2.7.4.post1" },
     { name = "flash-attn", marker = "extra == 'vllm'", specifier = "==2.7.4.post1" },
@@ -3178,6 +3179,7 @@ test = [
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
 ]
+vllm = [{ name = "deep-gemm", git = "https://github.com/deepseek-ai/DeepGEMM.git?rev=7b6b5563b9d4c1ae07ffbce7f78ad3ac9204827c" }]
 
 [[package]]
 name = "nemo-run"


### PR DESCRIPTION
# What does this PR do ?

Fix build and test publish wheel test.

* The Automodel submodule needed to be checked out when building the wheel. So we update the build-test-wheel template to allow that. 
* Also, deep_gemm cannot be referenced as a git repo to have this be uploaded as a pypi package. So, this moves that to a uv dependency group instead
* Lastly, add the build-test wheel test to be on PRs as well

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
