### PR TITLE
feat: add config_tools.py and refactor configs 

### DIFF
--- a/examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp2-quick.v2.yaml
+++ b/examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp2-quick.v2.yaml
@@ -1,95 +1,44 @@
+defaults: ../../dpo.yaml
 dpo:
   max_num_epochs: 2
   max_num_steps: 20
   val_period: 50
   val_batches: 16
   val_global_batch_size: 32
-  val_micro_batch_size: 1
   val_at_start: false
-  seed: 42
-
-  reference_policy_kl_penalty: 0.05
-  preference_average_log_probs: False
-  sft_average_log_probs: ${.preference_average_log_probs}
-  preference_loss_weight: 1
   sft_loss_weight: 0.01
-
 checkpointing:
-  enabled: true
-  checkpoint_dir: "results/dpo"
-  metric_name: "val_loss"
-  higher_is_better: false
-  keep_top_k: 3
   save_period: 10000
-  checkpoint_must_save_by: null
-
 policy:
-  model_name: "meta-llama/Llama-3.1-8B-Instruct"
+  model_name: meta-llama/Llama-3.1-8B-Instruct
   tokenizer:
     name: ${policy.model_name}
   train_global_batch_size: 256
   train_micro_batch_size: 1
   max_total_sequence_length: 2048
-  precision: "bfloat16"
   dtensor_cfg:
-    enabled: true
-    cpu_offload: False
-    sequence_parallel: false
-    activation_checkpointing: false
     tensor_parallel_size: 2
-    context_parallel_size: 1
-    custom_parallel_plan: null
-  
-  dynamic_batching:
-    enabled: false
-
-  sequence_packing:
-    enabled: false
-
-  make_sequence_length_divisible_by: ${policy.dtensor_cfg.tensor_parallel_size}
-  max_grad_norm: 1.0
-
   optimizer:
-    name: "torch.optim.AdamW"
     kwargs:
-      lr: 5.0e-6
-      weight_decay: 0.1
-      betas: [0.9, 0.98]
-      eps: 1e-8
-      foreach: False
-      fused: False
-
+      eps: 1.0e-08
   scheduler:
-    - name: "torch.optim.lr_scheduler.LinearLR"
-      kwargs:
-        start_factor: 0.000000001
-        end_factor: 1.0
-        total_iters: 1
-    - name: "torch.optim.lr_scheduler.ConstantLR"
-      kwargs:
-        factor: 1.0
-        total_iters: 10000000000
-    - milestones: [1]
-
-data:
-  dataset_name: "HelpSteer3"
-  max_input_seq_length: ${policy.max_total_sequence_length}
-  shuffle: true
-
+  - name: torch.optim.lr_scheduler.LinearLR
+    kwargs:
+      start_factor: 1.0e-09
+      end_factor: 1.0
+      total_iters: 1
+  - name: torch.optim.lr_scheduler.ConstantLR
+    kwargs:
+      factor: 1.0
+      total_iters: 10000000000
+  - milestones:
+    - 1
 logger:
-  log_dir: "logs"
   wandb_enabled: true
   tensorboard_enabled: true
-  mlflow_enabled: false
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: dpo-llama3.1-8b-instruct-4n8g-fsdp2tp1
-  tensorboard: {}
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
-
 cluster:
   gpus_per_node: 8
   num_nodes: 4

--- a/examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp4.yaml
+++ b/examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp4.yaml
@@ -1,95 +1,40 @@
+defaults: ../../dpo.yaml
 dpo:
-  max_num_epochs: 1
-  max_num_steps: 150
   val_period: 50
   val_batches: 16
   val_global_batch_size: 32
-  val_micro_batch_size: 1
   val_at_start: false
-  seed: 42
-
-  reference_policy_kl_penalty: 0.05
-  preference_average_log_probs: False
-  sft_average_log_probs: ${.preference_average_log_probs}
-  preference_loss_weight: 1
   sft_loss_weight: 0.01
-
-checkpointing:
-  enabled: true
-  checkpoint_dir: "results/dpo"
-  metric_name: "val_loss"
-  higher_is_better: false
-  keep_top_k: 3
-  save_period: 50
-  checkpoint_must_save_by: null
-
 policy:
-  model_name: "meta-llama/Llama-3.1-8B-Instruct"
+  model_name: meta-llama/Llama-3.1-8B-Instruct
   tokenizer:
     name: ${policy.model_name}
   train_global_batch_size: 256
   train_micro_batch_size: 1
   max_total_sequence_length: 8192
-  precision: "bfloat16"
   dtensor_cfg:
-    enabled: true
-    cpu_offload: False
-    sequence_parallel: false
-    activation_checkpointing: false
     tensor_parallel_size: 4
-    context_parallel_size: 1
-    custom_parallel_plan: null
-
-  dynamic_batching:
-    enabled: false
-
-  sequence_packing:
-    enabled: false
-
-  make_sequence_length_divisible_by: ${policy.dtensor_cfg.tensor_parallel_size}
-  max_grad_norm: 1.0
-
   optimizer:
-    name: "torch.optim.AdamW"
     kwargs:
-      lr: 5.0e-6
-      weight_decay: 0.1
-      betas: [0.9, 0.98]
-      eps: 1e-8
-      foreach: False
-      fused: False
-
+      eps: 1.0e-08
   scheduler:
-    - name: "torch.optim.lr_scheduler.LinearLR"
-      kwargs:
-        start_factor: 0.000000001
-        end_factor: 1.0
-        total_iters: 1
-    - name: "torch.optim.lr_scheduler.ConstantLR"
-      kwargs:
-        factor: 1.0
-        total_iters: 10000000000
-    - milestones: [1]
-
-data:
-  dataset_name: "HelpSteer3"
-  max_input_seq_length: ${policy.max_total_sequence_length}
-  shuffle: true
-
+  - name: torch.optim.lr_scheduler.LinearLR
+    kwargs:
+      start_factor: 1.0e-09
+      end_factor: 1.0
+      total_iters: 1
+  - name: torch.optim.lr_scheduler.ConstantLR
+    kwargs:
+      factor: 1.0
+      total_iters: 10000000000
+  - milestones:
+    - 1
 logger:
-  log_dir: "logs"
   wandb_enabled: true
   tensorboard_enabled: true
-  mlflow_enabled: false
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: dpo-llama3.1-8b-instruct-4n8g-fsdp2tp4
-  tensorboard: {}
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
-
 cluster:
   gpus_per_node: 8
   num_nodes: 4

--- a/examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-megatron.v2.yaml
+++ b/examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-megatron.v2.yaml
@@ -1,128 +1,32 @@
+defaults: ../../dpo.yaml
 dpo:
-  max_num_epochs: 1
-  max_num_steps: 150
   val_period: 50
   val_batches: 16
   val_global_batch_size: 32
-  val_micro_batch_size: 1
   val_at_start: false
-  seed: 42
-
-  reference_policy_kl_penalty: 0.05
-  preference_average_log_probs: False
-  sft_average_log_probs: ${.preference_average_log_probs}
-  preference_loss_weight: 1
   sft_loss_weight: 0.01
-
 checkpointing:
-  enabled: false #true
-  checkpoint_dir: "results/dpo"
-  metric_name: "val_loss"
-  higher_is_better: false
-  keep_top_k: 3
-  save_period: 50
-  checkpoint_must_save_by: null
-
+  enabled: false
 policy:
-  model_name: "meta-llama/Llama-3.1-8B-Instruct"
+  model_name: meta-llama/Llama-3.1-8B-Instruct
   tokenizer:
     name: ${policy.model_name}
   train_global_batch_size: 256
   train_micro_batch_size: 1
   max_total_sequence_length: 8192
-  precision: "bfloat16"
   dtensor_cfg:
     enabled: false
-
-  dynamic_batching:
-    enabled: false
-
-  sequence_packing:
-    enabled: false
-
   make_sequence_length_divisible_by: ${policy.megatron_cfg.tensor_model_parallel_size}
-  max_grad_norm: 1.0
-
   optimizer: null
-
   megatron_cfg:
     enabled: true
-    empty_unused_memory_level: 1
-    activation_checkpointing: false
     tensor_model_parallel_size: 4
-    expert_tensor_parallel_size: 1
-    expert_model_parallel_size: 1
-    pipeline_model_parallel_size: 1
-    context_parallel_size: 1
-    pipeline_dtype: ${policy.precision}
-    num_layers_in_first_pipeline_stage: null
-    num_layers_in_last_pipeline_stage: null
-    sequence_parallel: true
-    freeze_moe_router: false
-    moe_router_dtype: "fp64"
-    moe_router_load_balancing_type: "aux_loss"
-    moe_router_bias_update_rate: 1e-3
-    #gives ~20% training perf speedup with sequence packing 
-    apply_rope_fusion: True
-    
-    optimizer:
-      optimizer: "adam"
-      lr: 5.0e-6 #4.0e-5
-      min_lr: 5.0e-6 #4.0e-5
-      weight_decay: 0.1
-      bf16: true
-      fp16: false
-      params_dtype: "float32"
-
-      #adam
-      adam_beta1: 0.9
-      adam_beta2: 0.98
-      adam_eps: 1e-8
-
-      #sgd
-      sgd_momentum: 0.9
-
-      #distributed optimizer
-      use_distributed_optimizer: true
-      use_precision_aware_optimizer: true
-
-      clip_grad: ${policy.max_grad_norm}
-
-    scheduler:
-      start_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
-      end_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
-      weight_decay_incr_style: "constant"
-      lr_decay_style: "linear"
-      lr_decay_iters: 1000000000
-      lr_warmup_iters: 2
-      lr_warmup_init: 0.00000001
-
-    distributed_data_parallel_config:
-      grad_reduce_in_fp32: false
-      overlap_grad_reduce: true
-      overlap_param_gather: true
-      average_in_collective: true
-      data_parallel_sharding_strategy: "optim_grads_params"
-
-data:
-  dataset_name: "HelpSteer3"
-  max_input_seq_length: ${policy.max_total_sequence_length}
-  shuffle: true
-
 logger:
-  log_dir: "logs"
   wandb_enabled: true
   tensorboard_enabled: true
-  mlflow_enabled: false
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: dpo-llama3.1-8b-instruct-4n8g-fsdp2tp1-megatron
-  tensorboard: {}
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
-
 cluster:
   gpus_per_node: 8
   num_nodes: 4

--- a/examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-megatrontp2pp2-quick.yaml
+++ b/examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-megatrontp2pp2-quick.yaml
@@ -1,128 +1,34 @@
+defaults: ../../dpo.yaml
 dpo:
-  max_num_epochs: 1
   max_num_steps: 20
   val_period: 50
   val_batches: 16
   val_global_batch_size: 32
-  val_micro_batch_size: 1
   val_at_start: false
-  seed: 42
-
-  reference_policy_kl_penalty: 0.05
-  preference_average_log_probs: False
-  sft_average_log_probs: ${.preference_average_log_probs}
-  preference_loss_weight: 1
   sft_loss_weight: 0.01
-
 checkpointing:
-  enabled: false #true
-  checkpoint_dir: "results/dpo"
-  metric_name: "val_loss"
-  higher_is_better: false
-  keep_top_k: 3
+  enabled: false
   save_period: 10000
-  checkpoint_must_save_by: null
-
 policy:
-  model_name: "meta-llama/Llama-3.1-8B-Instruct"
+  model_name: meta-llama/Llama-3.1-8B-Instruct
   tokenizer:
     name: ${policy.model_name}
   train_global_batch_size: 256
   train_micro_batch_size: 1
   max_total_sequence_length: 2048
-  precision: "bfloat16"
   dtensor_cfg:
     enabled: false
-
-  dynamic_batching:
-    enabled: false
-
-  sequence_packing:
-    enabled: false
-
   make_sequence_length_divisible_by: ${policy.megatron_cfg.tensor_model_parallel_size}
-  max_grad_norm: 1.0
-
   optimizer: null
-
   megatron_cfg:
     enabled: true
-    empty_unused_memory_level: 1
-    activation_checkpointing: false
-    tensor_model_parallel_size: 2
-    expert_tensor_parallel_size: 1
-    expert_model_parallel_size: 1
     pipeline_model_parallel_size: 2
-    context_parallel_size: 1
-    pipeline_dtype: ${policy.precision}
-    num_layers_in_first_pipeline_stage: null
-    num_layers_in_last_pipeline_stage: null
-    sequence_parallel: true
-    freeze_moe_router: false
-    moe_router_dtype: "fp64"
-    moe_router_load_balancing_type: "aux_loss"
-    moe_router_bias_update_rate: 1e-3
-    #gives ~20% training perf speedup with sequence packing 
-    apply_rope_fusion: True
-    
-    optimizer:
-      optimizer: "adam"
-      lr: 5.0e-6 #4.0e-5
-      min_lr: 5.0e-6 #4.0e-5
-      weight_decay: 0.1
-      bf16: true
-      fp16: false
-      params_dtype: "float32"
-
-      #adam
-      adam_beta1: 0.9
-      adam_beta2: 0.98
-      adam_eps: 1e-8
-
-      #sgd
-      sgd_momentum: 0.9
-
-      #distributed optimizer
-      use_distributed_optimizer: true
-      use_precision_aware_optimizer: true
-
-      clip_grad: ${policy.max_grad_norm}
-
-    scheduler:
-      start_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
-      end_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
-      weight_decay_incr_style: "constant"
-      lr_decay_style: "linear"
-      lr_decay_iters: 1000000000
-      lr_warmup_iters: 2
-      lr_warmup_init: 0.00000001
-
-    distributed_data_parallel_config:
-      grad_reduce_in_fp32: false
-      overlap_grad_reduce: true
-      overlap_param_gather: true
-      average_in_collective: true
-      data_parallel_sharding_strategy: "optim_grads_params"
-
-data:
-  dataset_name: "HelpSteer3"
-  max_input_seq_length: ${policy.max_total_sequence_length}
-  shuffle: true
-
 logger:
-  log_dir: "logs"
   wandb_enabled: true
   tensorboard_enabled: true
-  mlflow_enabled: false
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: dpo-llama3.1-8b-instruct-4n8g-fsdp2tp1
-  tensorboard: {}
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
-
 cluster:
   gpus_per_node: 8
   num_nodes: 4

--- a/examples/configs/recipes/llm/dpo-llama3.1-8b-tulu3-1n8g-fsdp2tp1.yaml
+++ b/examples/configs/recipes/llm/dpo-llama3.1-8b-tulu3-1n8g-fsdp2tp1.yaml
@@ -1,51 +1,43 @@
-defaults: "../../dpo.yaml"
-
+defaults: ../../dpo.yaml
 cluster:
-  num_nodes: 1
   gpus_per_node: 8
-
 policy:
-  model_name: "allenai/Llama-3.1-Tulu-3-8B-SFT"
+  model_name: allenai/Llama-3.1-Tulu-3-8B-SFT
   tokenizer:
-    name: "allenai/Llama-3.1-Tulu-3-8B-SFT"
+    name: allenai/Llama-3.1-Tulu-3-8B-SFT
   train_micro_batch_size: 1
-  train_global_batch_size: 128
   max_total_sequence_length: 2048
   optimizer:
-    name: "torch.optim.AdamW"
     kwargs:
-      lr: 5.0e-7
+      lr: 5.0e-07
       weight_decay: 0.0
   scheduler:
-    - name: "torch.optim.lr_scheduler.LinearLR"
-      kwargs:
-        start_factor: 1.0e-6
-        end_factor: 1.0
-        total_iters: 211
-    - name: "torch.optim.lr_scheduler.LinearLR"
-      kwargs:
-        start_factor: 1.0
-        end_factor: 0.0
-        total_iters: 1899
-    - milestones: [211]
-
+  - name: torch.optim.lr_scheduler.LinearLR
+    kwargs:
+      start_factor: 1.0e-06
+      end_factor: 1.0
+      total_iters: 211
+  - name: torch.optim.lr_scheduler.LinearLR
+    kwargs:
+      start_factor: 1.0
+      end_factor: 0.0
+      total_iters: 1899
+  - milestones:
+    - 211
 data:
-  dataset_name: "Tulu3Preference"
-
+  dataset_name: Tulu3Preference
 dpo:
   max_num_steps: 2110
   val_period: -1
   val_at_start: false
-  preference_average_log_probs: True
+  preference_average_log_probs: true
   reference_policy_kl_penalty: 5
   val_micro_batch_size: ${policy.train_micro_batch_size}
   val_global_batch_size: ${policy.train_global_batch_size}
-
 checkpointing:
   metric_name: null
   save_period: 250
-
 logger:
-  wandb_enabled: True
+  wandb_enabled: true
   wandb:
-    name: "dpo-tulu3-8b"
+    name: dpo-tulu3-8b

--- a/examples/configs/recipes/llm/dpo-llama3.2-1b-instruct-1n8g-fsdp2tp1.v2.yaml
+++ b/examples/configs/recipes/llm/dpo-llama3.2-1b-instruct-1n8g-fsdp2tp1.v2.yaml
@@ -1,96 +1,15 @@
+defaults: ../../dpo.yaml
 dpo:
-  max_num_epochs: 1
-  max_num_steps: 150
-  val_period: 25
-  val_batches: 8
   val_global_batch_size: 32
-  val_micro_batch_size: 1
   val_at_start: false
-  seed: 42
-
-  reference_policy_kl_penalty: 0.05
-  preference_average_log_probs: False
-  sft_average_log_probs: ${.preference_average_log_probs}
-  preference_loss_weight: 1
-  sft_loss_weight: 0
-
-checkpointing:
-  enabled: true
-  checkpoint_dir: "results/dpo"
-  metric_name: "val_loss"
-  higher_is_better: false
-  keep_top_k: 3
-  save_period: 50
-  checkpoint_must_save_by: null
-
 policy:
-  model_name: "meta-llama/Llama-3.2-1B-Instruct"
   tokenizer:
     name: ${policy.model_name}
-
-  train_global_batch_size: 128
-  train_micro_batch_size: 2
-  max_total_sequence_length: 1024
-  precision: "bfloat16"
-  dtensor_cfg:
-    enabled: true
-    cpu_offload: False
-    sequence_parallel: false
-    activation_checkpointing: false
-    tensor_parallel_size: 1
-    context_parallel_size: 1
-    custom_parallel_plan: null
-
-  dynamic_batching:
-    enabled: false
-
-  sequence_packing:
-    enabled: false
-
-  make_sequence_length_divisible_by: ${policy.dtensor_cfg.tensor_parallel_size}
-  max_grad_norm: 1.0
-
-  optimizer:
-    name: "torch.optim.AdamW"
-    kwargs:
-      lr: 5.0e-6
-      weight_decay: 0.1
-      betas: [0.9, 0.98]
-      eps: 1e-5
-      foreach: False
-      fused: False
-    
-  scheduler:
-    - name: "torch.optim.lr_scheduler.LinearLR"
-      kwargs:
-        start_factor: 0.1
-        end_factor: 1.0
-        total_iters: 20
-    - name: "torch.optim.lr_scheduler.ConstantLR"
-      kwargs:
-        factor: 1.0
-        total_iters: 10000000000
-    - milestones: [20]
-    
-data:
-  dataset_name: "HelpSteer3"
-  max_input_seq_length: ${policy.max_total_sequence_length}
-  shuffle: true
-
 logger:
-  log_dir: "logs"
   wandb_enabled: true
   tensorboard_enabled: true
-  mlflow_enabled: false
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: dpo-llama3.2-1b-instruct-1n8g-fsdp2tp1
-  tensorboard: {}
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
-
 cluster:
   gpus_per_node: 8
-  num_nodes: 1

--- a/examples/configs/recipes/llm/dpo-mistral-nemo-instruct-2407-1n8g-fsdp2tp8-actckpt-long.yaml
+++ b/examples/configs/recipes/llm/dpo-mistral-nemo-instruct-2407-1n8g-fsdp2tp8-actckpt-long.yaml
@@ -1,106 +1,45 @@
-# DPO Algorithm Configuration
+defaults: ../../dpo.yaml
 dpo:
-  max_num_epochs: 1
   max_num_steps: 100
   val_period: 10
   val_batches: 1
   val_global_batch_size: 16
-  val_micro_batch_size: 1
-  val_at_start: true
-  seed: 42
-
   reference_policy_kl_penalty: 0.1
-  preference_average_log_probs: False # whether normalizing log probs according to the sequence length in preference_loss
-  sft_average_log_probs: ${.preference_average_log_probs} # whether normalizing log probs according to the sequence length in sft_loss
-
-  preference_loss_weight: 1 # the coefficient of the preference loss
-  sft_loss_weight: 0 # the coefficient of the SFT loss
-
 checkpointing:
-  enabled: true
-  checkpoint_dir: "results/dpo-mistral-nemo-instruct-2407-1n8g-fsdp2tp8-actckpt-long"
-  metric_name: "val_loss"
-  higher_is_better: false
+  checkpoint_dir: results/dpo-mistral-nemo-instruct-2407-1n8g-fsdp2tp8-actckpt-long
   keep_top_k: null
-  save_period: 50
-  checkpoint_must_save_by: null
-
 policy:
-  model_name: "mistralai/Mistral-Nemo-Instruct-2407"
+  model_name: mistralai/Mistral-Nemo-Instruct-2407
   tokenizer:
     name: ${policy.model_name}
-
-  # number of preference samples per batch
-  # each preference sample corresponds to a pair of chosen and rejected responses
-  # so the actual batch size processed by the model is train_global_batch_size * 2
   train_global_batch_size: 8
   train_micro_batch_size: 1
-
-
-  #logprob_batch_size: ${policy.train_micro_batch_size}
   max_total_sequence_length: 12288
-  precision: "bfloat16"
-
   dtensor_cfg:
-    enabled: true
-    cpu_offload: false
-    sequence_parallel: false
     activation_checkpointing: true
     tensor_parallel_size: 8
-    context_parallel_size: 1
-    custom_parallel_plan: null
     env_vars:
-      PYTORCH_CUDA_ALLOC_CONF: "max_split_size_mb:64"
-
-  dynamic_batching:
-    enabled: false
-
-  sequence_packing:
-    enabled: false
-
-  # makes the training sequence length divisible by the tensor parallel size
-  # this is useful for sequence parallel training
-  make_sequence_length_divisible_by: ${policy.dtensor_cfg.tensor_parallel_size}
-  max_grad_norm: 1.0
-
+      PYTORCH_CUDA_ALLOC_CONF: max_split_size_mb:64
   optimizer:
-    name: "torch.optim.AdamW"
     kwargs:
-      lr: 1.0e-6
+      lr: 1.0e-06
       weight_decay: 0.01
-      betas: [0.9, 0.999]
-      eps: 1e-8
-      # when using Dtensor, we need to set foreach
-      # and fused to False
-      foreach: False
-      fused: False
-
+      betas:
+      - 0.9
+      - 0.999
+      eps: 1.0e-08
   scheduler:
-    - name: "torch.optim.lr_scheduler.ConstantLR"
-      kwargs:
-        factor: 1.0
-        total_iters: 10000000000
-    - milestones: []
-
+  - name: torch.optim.lr_scheduler.ConstantLR
+    kwargs:
+      factor: 1.0
+      total_iters: 10000000000
+  - milestones: []
 data:
-  dataset_name: "HelpSteer3"
-  shuffle: False
-  max_input_seq_length: ${policy.max_total_sequence_length}
-
+  shuffle: false
 logger:
-  log_dir: "logs/dpo-mistral-nemo-instruct-2407-1n8g-fsdp2tp8-actckpt-long"  # Base directory for all logs
-  wandb_enabled: false # Make sure you do a ``wandb login [Your API key]'' before running
-  tensorboard_enabled: false
-  mlflow_enabled: false
-  monitor_gpus: true  # If true, will monitor GPU usage and log to wandb and/or tensorboard
-  num_val_samples_to_print: 0 # Number of validation samples to pretty print on terminal
+  log_dir: logs/dpo-mistral-nemo-instruct-2407-1n8g-fsdp2tp8-actckpt-long
   wandb:
-    project: "nemo-rl"
-    name: "dpo-mistral-nemo-instruct-2407-1n8g-fsdp2tp8-actckpt-long"
-  gpu_monitoring:
-    collection_interval: 10  # How often to collect GPU usage metrics (in seconds)
-    flush_interval: 10  # How often to flush GPU usage metrics to the loggers (in seconds)
-
+    project: nemo-rl
+    name: dpo-mistral-nemo-instruct-2407-1n8g-fsdp2tp8-actckpt-long
 cluster:
   gpus_per_node: 8
-  num_nodes: 1

--- a/examples/configs/recipes/llm/grpo-deepscaler-1.5b-16K.yaml
+++ b/examples/configs/recipes/llm/grpo-deepscaler-1.5b-16K.yaml
@@ -1,23 +1,14 @@
-# GRPO Algorithm Configuration
-defaults: "grpo-deepscaler-1.5b-8K.yaml"
-
+defaults:
+- ../../grpo_math_1B.yaml
+- grpo-deepscaler-1.5b-8K.yaml
 loss_fn:
   reference_policy_kl_penalty: 0.001
   ratio_clip_max: 0.28
-
-
 policy:
   max_total_sequence_length: 16384
   logprob_batch_size: 2
-
   dtensor_cfg:
-    enabled: true
     cpu_offload: true
     sequence_parallel: true
     activation_checkpointing: true
     tensor_parallel_size: 2
-    context_parallel_size: 1
-    custom_parallel_plan: null
-
-  dynamic_batching:
-    enabled: False

--- a/examples/configs/recipes/llm/grpo-deepscaler-1.5b-24K.yaml
+++ b/examples/configs/recipes/llm/grpo-deepscaler-1.5b-24K.yaml
@@ -1,48 +1,23 @@
-# GRPO Algorithm Configuration
-defaults: "grpo-deepscaler-1.5b-8K.yaml"
-
+defaults:
+- ../../grpo_math_1B.yaml
+- grpo-deepscaler-1.5b-8K.yaml
 loss_fn:
   reference_policy_kl_penalty: 0.0001
-  ratio_clip_min: 0.2
   ratio_clip_max: 0.28
-
 policy:
   max_total_sequence_length: 24576
   logprob_batch_size: 2
-
   dtensor_cfg:
-    enabled: true
     cpu_offload: true
     sequence_parallel: true
     activation_checkpointing: true
     tensor_parallel_size: 2
-    context_parallel_size: 1
-    custom_parallel_plan: null
-
-  dynamic_batching:
-    enabled: False
-
   sequence_packing:
-    enabled: False
-
+    enabled: false
   optimizer:
-    name: "torch.optim.AdamW"
     kwargs:
-      lr: 5.0e-7
-
+      lr: 5.0e-07
   generation:
-    backend: "vllm"
-    max_new_tokens: ${policy.max_total_sequence_length}
-    temperature: 1.0
-    top_p: 1.0
-    top_k: null
-    stop_token_ids: null
-    stop_strings: null
     vllm_cfg:
-      precision: ${policy.precision}
-      tensor_parallel_size: 1
-      pipeline_parallel_size: 1
-      enable_expert_parallel: false
       gpu_memory_utilization: 0.8
-      enforce_eager: True
-      max_model_len: ${policy.max_total_sequence_length}
+      enforce_eager: true

--- a/examples/configs/recipes/llm/grpo-deepscaler-1.5b-8K.yaml
+++ b/examples/configs/recipes/llm/grpo-deepscaler-1.5b-8K.yaml
@@ -1,146 +1,36 @@
-# GRPO Algorithm Configuration
+defaults: ../../grpo_math_1B.yaml
 grpo:
   num_prompts_per_step: 128
   num_generations_per_prompt: 8
-  max_rollout_turns: 1 # for multi-turn rollouts. Math Environments just have 1 turn (answering the question)
-  max_num_steps: 1000000
-  normalize_rewards: true
-  use_leave_one_out_baseline: true
-  val_period: 10
-  val_at_start: false
   max_val_samples: 480
   val_batch_size: 32
-  seed: 42
-
 loss_fn:
   reference_policy_kl_penalty: 0.0
-  ratio_clip_min: 0.2
-  ratio_clip_max: 0.2
-  ratio_clip_c: null
-  # (default off) loss formulation improvements (docs/guides/grpo.md#loss)
-  use_on_policy_kl_approximation: false
-  use_importance_sampling_correction: false
-  token_level_loss: true
-
 checkpointing:
-  enabled: true
-  checkpoint_dir: "results/grpo"
-  metric_name: "val_reward"
-  higher_is_better: true
   keep_top_k: 10
-  save_period: 10
-  checkpoint_must_save_by: null
-
 policy:
-  model_name: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
-  tokenizer:
-    name: ${policy.model_name} ## specify if you'd like to use a tokenizer different from the model's default
+  model_name: deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
   train_global_batch_size: 64
   train_micro_batch_size: 1
-  generation_batch_size: 32 # Only used when generating using HF backend
-  logprob_batch_size: 4
   max_total_sequence_length: 8192
-  precision: "bfloat16"
-
   dtensor_cfg:
-    enabled: true
     cpu_offload: true
     sequence_parallel: true
     activation_checkpointing: true
-    tensor_parallel_size: 1
-    context_parallel_size: 1
-    custom_parallel_plan: null
-
-  dynamic_batching:
-    enabled: False
-
   sequence_packing:
-    enabled: False
-
-  # makes the training sequence length divisible by the tensor parallel size
-  # this is useful for sequence parallel training
-  make_sequence_length_divisible_by: ${policy.dtensor_cfg.tensor_parallel_size}
-  max_grad_norm: 1.0
-
+    enabled: false
   optimizer:
-    name: "torch.optim.AdamW"
     kwargs:
-      lr: 2.0e-6
-      weight_decay: 0.01
-      betas: [0.9, 0.999]
-      eps: 1e-8
-      # when using Dtensor, we need to set foreach
-      # and fused to False
-      foreach: False
-      fused: False
-
-  scheduler:
-    - name: "torch.optim.lr_scheduler.LinearLR"
-      kwargs:
-        start_factor: 0.1
-        end_factor: 1.0
-        total_iters: 50
-    - name: "torch.optim.lr_scheduler.ConstantLR"
-      kwargs:
-        factor: 1.0
-        total_iters: 10000000000
-    - milestones: [50]
-
+      lr: 2.0e-06
   generation:
-    backend: "vllm"
-    max_new_tokens: ${policy.max_total_sequence_length}
-    temperature: 1.0
-    top_p: 1.0
-    top_k: null
-    stop_token_ids: null
-    stop_strings: null
     vllm_cfg:
-      async_engine: false
-      precision: ${policy.precision}
-      tensor_parallel_size: 1
-      pipeline_parallel_size: 1
-      enable_expert_parallel: false
-      gpu_memory_utilization: 0.6
-      max_model_len: ${policy.max_total_sequence_length}
-      enforce_eager: True
-    colocated:
-      # true: generation shares training GPUs
-      # false: uses dedicated generation resources
-      enabled: true
-      # only relevant when enabled is false
-      resources:
-        gpus_per_node: null # Decides num gpus to be dedicated to generation when there is one node in the cluster i.e cluster.num_nodes == 1
-        num_nodes: null # Decides number of nodes to be dedicated to generation
-
+      enforce_eager: true
 data:
-  max_input_seq_length: ${policy.max_total_sequence_length} # upper bound, real truncation occurs at vllm.max_model_len
-  prompt_file: "examples/prompts/cot.txt"
-  system_prompt_file: null
-  dataset_name: "DeepScaler"
-  shuffle: true
-
+  dataset_name: DeepScaler
 env:
   math:
     num_workers: 16
-
 logger:
-  log_dir: "logs"  # Base directory for all logs
-  num_val_samples_to_print: 0 # Number of validation samples to pretty print on terminal
-  wandb_enabled: false
-  tensorboard_enabled: false
-  mlflow_enabled: false
-  monitor_gpus: false  # If true, will monitor GPU usage and log to wandb and/or tensorboard
-  wandb:
-    project: "grpo-dev"
-    name: "grpo-dev-logger"
-  tensorboard: {}
-  mlflow:
-    experiment_name: "grpo-dev"
-    run_name: "grpo-dev-logger"
-  gpu_monitoring:
-    collection_interval: 10  # How often to collect GPU usage metrics (in seconds)
-    flush_interval: 10  # How often to flush GPU usage metrics to the loggers (in seconds)
-
+  monitor_gpus: false
 cluster:
   gpus_per_node: 8
-  num_nodes: 1

--- a/examples/configs/recipes/llm/grpo-gemma3-1b-it-1n8g-fsdp2tp1.yaml
+++ b/examples/configs/recipes/llm/grpo-gemma3-1b-it-1n8g-fsdp2tp1.yaml
@@ -1,130 +1,29 @@
+defaults: ../../grpo_math_1B.yaml
 grpo:
-  num_prompts_per_step: 32
-  num_generations_per_prompt: 16
-  max_rollout_turns: 1
   max_num_steps: 500
-  normalize_rewards: true
-  use_leave_one_out_baseline: true
-  val_period: 10
-  val_at_start: false
-  max_val_samples: 256
-  val_batch_size: 256
-  seed: 42
-loss_fn:
-  reference_policy_kl_penalty: 0.01
-  ratio_clip_min: 0.2
-  ratio_clip_max: 0.2
-  ratio_clip_c: null
-  use_on_policy_kl_approximation: false
-  use_importance_sampling_correction: false
-  token_level_loss: true
 checkpointing:
-  enabled: true
   checkpoint_dir: results/grpo-gemma3-1b-it-1n8g-fsdp2tp1
-  metric_name: val_reward
-  higher_is_better: true
-  keep_top_k: 3
-  save_period: 10
-  checkpoint_must_save_by: null
 policy:
   model_name: google/gemma-3-1b-it
   tokenizer:
     name: google/gemma-3-1b-it
-  train_global_batch_size: 512
-  train_micro_batch_size: 4
-  generation_batch_size: 32
-  logprob_batch_size: 4
-  max_total_sequence_length: 512
-  precision: bfloat16
-  dtensor_cfg:
-    enabled: true
-    cpu_offload: false
-    sequence_parallel: false
-    activation_checkpointing: false
-    tensor_parallel_size: 1
-    context_parallel_size: 1
-    custom_parallel_plan: null
   dynamic_batching:
-    enabled: True
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
-    sequence_length_round: 64
+    enabled: true
   sequence_packing:
     enabled: false
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
-    algorithm: "modified_first_fit_decreasing"
-    sequence_length_round: 64
   make_sequence_length_divisible_by: 1
-  max_grad_norm: 1
-  optimizer:
-    name: torch.optim.AdamW
-    kwargs:
-      lr: 5e-06
-      weight_decay: 0.01
-      betas:
-        - 0.9
-        - 0.999
-      eps: 1e-08
-      foreach: false
-      fused: false
-  scheduler:
-    - name: torch.optim.lr_scheduler.LinearLR
-      kwargs:
-        start_factor: 0.1
-        end_factor: 1
-        total_iters: 50
-    - name: torch.optim.lr_scheduler.ConstantLR
-      kwargs:
-        factor: 1
-        total_iters: 10000000000
-    - milestones:
-        - 50
   generation:
-    backend: vllm
     max_new_tokens: 512
-    temperature: 1
-    top_p: 1
-    top_k: null
-    stop_token_ids: null
-    stop_strings: null
     vllm_cfg:
-      async_engine: false
-      precision: ${policy.precision}
-      tensor_parallel_size: 1
-      pipeline_parallel_size: 1
-      enable_expert_parallel: false
-      gpu_memory_utilization: 0.6
       max_model_len: 512
-      enforce_eager: False
-    colocated:
-      enabled: true
-      resources:
-        gpus_per_node: null
-        num_nodes: null
 data:
   max_input_seq_length: 512
-  prompt_file: examples/prompts/cot.txt
-  system_prompt_file: null
-  dataset_name: OpenMathInstruct-2
-  shuffle: true
-env:
-  math:
-    num_workers: 8
 logger:
   log_dir: logs/grpo-gemma3-1b-it-1n8g-fsdp2tp1
-  num_val_samples_to_print: 0
   wandb_enabled: true
   tensorboard_enabled: true
-  mlflow_enabled: false
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: grpo-gemma3-1b-it-1n8g-fsdp2tp1
-  tensorboard: {}
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
 cluster:
   gpus_per_node: 8
-  num_nodes: 1

--- a/examples/configs/recipes/llm/grpo-gemma3-27b-it-16n8g-fsdp2tp8sp-actckpt-long.yaml
+++ b/examples/configs/recipes/llm/grpo-gemma3-27b-it-16n8g-fsdp2tp8sp-actckpt-long.yaml
@@ -1,131 +1,41 @@
+defaults: ../../grpo_math_1B.yaml
 grpo:
   num_prompts_per_step: 64
   num_generations_per_prompt: 32
-  max_rollout_turns: 1
   max_num_steps: 20
-  normalize_rewards: true
-  use_leave_one_out_baseline: true
-  val_period: 10
-  val_at_start: false
-  max_val_samples: 256
-  val_batch_size: 256
-  seed: 42
-loss_fn:
-  reference_policy_kl_penalty: 0.01
-  ratio_clip_min: 0.2
-  ratio_clip_max: 0.2
-  ratio_clip_c: null
-  use_on_policy_kl_approximation: false
-  use_importance_sampling_correction: false
-  token_level_loss: true
 checkpointing:
-  enabled: true
   checkpoint_dir: results/grpo-gemma3-27b-it-16n8g-fsdp2tp8sp-actckpt-long
-  metric_name: val_reward
-  higher_is_better: true
-  keep_top_k: 3
-  save_period: 10
-  checkpoint_must_save_by: null
 policy:
   model_name: google/gemma-3-27b-it
   tokenizer:
     name: google/gemma-3-27b-it
-  train_global_batch_size: 512
   train_micro_batch_size: 1
-  generation_batch_size: 32
   logprob_batch_size: 2
   max_total_sequence_length: 16384
-  precision: bfloat16
   dtensor_cfg:
-    enabled: true
-    cpu_offload: false
     sequence_parallel: true
     activation_checkpointing: true
     tensor_parallel_size: 8
-    context_parallel_size: 1
-    custom_parallel_plan: null
-  dynamic_batching:
-    # TODO: OOMs if enabled https://github.com/NVIDIA-NeMo/RL/issues/383
-    enabled: False
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
-    sequence_length_round: 64
   sequence_packing:
     enabled: false
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
-    algorithm: "modified_first_fit_decreasing"
-    sequence_length_round: 64
   make_sequence_length_divisible_by: 8
-  max_grad_norm: 1
   optimizer:
-    name: torch.optim.AdamW
     kwargs:
-      lr: 3e-07
-      weight_decay: 0.01
-      betas:
-        - 0.9
-        - 0.999
-      eps: 1e-08
-      foreach: false
-      fused: false
-  scheduler:
-    - name: torch.optim.lr_scheduler.LinearLR
-      kwargs:
-        start_factor: 0.1
-        end_factor: 1
-        total_iters: 50
-    - name: torch.optim.lr_scheduler.ConstantLR
-      kwargs:
-        factor: 1
-        total_iters: 10000000000
-    - milestones:
-        - 50
+      lr: 3.0e-07
   generation:
-    backend: vllm
     max_new_tokens: 16384
-    temperature: 1
-    top_p: 1
-    top_k: null
-    stop_token_ids: null
-    stop_strings: null
     vllm_cfg:
-      async_engine: false
-      precision: ${policy.precision}
       tensor_parallel_size: 4
-      pipeline_parallel_size: 1
-      enable_expert_parallel: false
-      gpu_memory_utilization: 0.6
       max_model_len: 16384
-      enforce_eager: False
-    colocated:
-      enabled: true
-      resources:
-        gpus_per_node: null
-        num_nodes: null
 data:
   max_input_seq_length: 16384
-  prompt_file: examples/prompts/cot.txt
-  system_prompt_file: null
-  dataset_name: OpenMathInstruct-2
-  shuffle: true
-env:
-  math:
-    num_workers: 8
 logger:
   log_dir: logs/grpo-gemma3-27b-it-16n8g-fsdp2tp8sp-actckpt-long
-  num_val_samples_to_print: 0
   wandb_enabled: true
   tensorboard_enabled: true
-  mlflow_enabled: false
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: grpo-gemma3-27b-it-16n8g-fsdp2tp8sp-actckpt-long
-  tensorboard: {}
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
 cluster:
   gpus_per_node: 8
   num_nodes: 16

--- a/examples/configs/recipes/llm/grpo-gspo-deepscaler-1.5b-8K.yaml
+++ b/examples/configs/recipes/llm/grpo-gspo-deepscaler-1.5b-8K.yaml
@@ -1,147 +1,38 @@
-# GRPO Algorithm Configuration
+defaults: ../../grpo_math_1B.yaml
 grpo:
   num_prompts_per_step: 128
   num_generations_per_prompt: 8
-  max_rollout_turns: 1 # for multi-turn rollouts. Math Environments just have 1 turn (answering the question)
-  max_num_steps: 1000000
-  normalize_rewards: true
-  use_leave_one_out_baseline: true
-  val_period: 10
-  val_at_start: false
   max_val_samples: 480
   val_batch_size: 32
-  seed: 42
-
 loss_fn:
   reference_policy_kl_penalty: 0.0
-  ratio_clip_min: 0.2
-  ratio_clip_max: 0.2
-  ratio_clip_c: null
-  # (default off) loss formulation improvements (docs/guides/grpo.md#loss)
-  use_on_policy_kl_approximation: false
-  use_importance_sampling_correction: false
   sequence_level_importance_ratios: true
   token_level_loss: false
-
 checkpointing:
-  enabled: true
-  checkpoint_dir: "results/grpo"
-  metric_name: "val_reward"
-  higher_is_better: true
   keep_top_k: 10
-  save_period: 10
-  checkpoint_must_save_by: null
-
 policy:
-  model_name: "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
-  tokenizer:
-    name: ${policy.model_name} ## specify if you'd like to use a tokenizer different from the model's default
+  model_name: deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
   train_global_batch_size: 64
   train_micro_batch_size: 1
-  generation_batch_size: 32 # Only used when generating using HF backend
-  logprob_batch_size: 4
   max_total_sequence_length: 8192
-  precision: "bfloat16"
-
   dtensor_cfg:
-    enabled: true
     cpu_offload: true
     sequence_parallel: true
     activation_checkpointing: true
-    tensor_parallel_size: 1
-    context_parallel_size: 1
-    custom_parallel_plan: null
-
-  dynamic_batching:
-    enabled: False
-
   sequence_packing:
-    enabled: False
-
-  # makes the training sequence length divisible by the tensor parallel size
-  # this is useful for sequence parallel training
-  make_sequence_length_divisible_by: ${policy.dtensor_cfg.tensor_parallel_size}
-  max_grad_norm: 1.0
-
+    enabled: false
   optimizer:
-    name: "torch.optim.AdamW"
     kwargs:
-      lr: 2.0e-6
-      weight_decay: 0.01
-      betas: [0.9, 0.999]
-      eps: 1e-8
-      # when using Dtensor, we need to set foreach
-      # and fused to False
-      foreach: False
-      fused: False
-
-  scheduler:
-    - name: "torch.optim.lr_scheduler.LinearLR"
-      kwargs:
-        start_factor: 0.1
-        end_factor: 1.0
-        total_iters: 50
-    - name: "torch.optim.lr_scheduler.ConstantLR"
-      kwargs:
-        factor: 1.0
-        total_iters: 10000000000
-    - milestones: [50]
-
+      lr: 2.0e-06
   generation:
-    backend: "vllm"
-    max_new_tokens: ${policy.max_total_sequence_length}
-    temperature: 1.0
-    top_p: 1.0
-    top_k: null
-    stop_token_ids: null
-    stop_strings: null
     vllm_cfg:
-      async_engine: false
-      precision: ${policy.precision}
-      tensor_parallel_size: 1
-      pipeline_parallel_size: 1
-      enable_expert_parallel: false
-      gpu_memory_utilization: 0.6
-      max_model_len: ${policy.max_total_sequence_length}
-      enforce_eager: True
-    colocated:
-      # true: generation shares training GPUs
-      # false: uses dedicated generation resources
-      enabled: true
-      # only relevant when enabled is false
-      resources:
-        gpus_per_node: null # Decides num gpus to be dedicated to generation when there is one node in the cluster i.e cluster.num_nodes == 1
-        num_nodes: null # Decides number of nodes to be dedicated to generation
-
+      enforce_eager: true
 data:
-  max_input_seq_length: ${policy.max_total_sequence_length} # upper bound, real truncation occurs at vllm.max_model_len
-  prompt_file: "examples/prompts/cot.txt"
-  system_prompt_file: null
-  dataset_name: "DeepScaler"
-  shuffle: true
-
+  dataset_name: DeepScaler
 env:
   math:
     num_workers: 16
-
 logger:
-  log_dir: "logs"  # Base directory for all logs
-  num_val_samples_to_print: 0 # Number of validation samples to pretty print on terminal
-  wandb_enabled: false
-  tensorboard_enabled: false
-  mlflow_enabled: false
-  monitor_gpus: false  # If true, will monitor GPU usage and log to wandb and/or tensorboard
-  wandb:
-    project: "grpo-dev"
-    name: "grpo-dev-logger"
-  tensorboard: {}
-  mlflow:
-    experiment_name: "grpo-dev"
-    run_name: "grpo-dev-logger"
-  gpu_monitoring:
-    collection_interval: 10  # How often to collect GPU usage metrics (in seconds)
-    flush_interval: 10  # How often to flush GPU usage metrics to the loggers (in seconds)
-
+  monitor_gpus: false
 cluster:
   gpus_per_node: 8
-  num_nodes: 1

--- a/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-1n8g-megatron-fp8.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-1n8g-megatron-fp8.yaml
@@ -1,162 +1,53 @@
+defaults: ../../grpo_math_1B.yaml
 grpo:
   num_prompts_per_step: 64
   num_generations_per_prompt: 32
-  max_rollout_turns: 1
   max_num_steps: 500
-  normalize_rewards: true
-  use_leave_one_out_baseline: true
-  val_period: 10
-  val_at_start: false
-  max_val_samples: 256
-  val_batch_size: 256
-  seed: 42
 loss_fn:
-  reference_policy_kl_penalty: 0.01
-  ratio_clip_min: 0.2
-  ratio_clip_max: 0.2
-  ratio_clip_c: null
-  use_on_policy_kl_approximation: false
-  use_importance_sampling_correction: True
-  token_level_loss: true
+  use_importance_sampling_correction: true
 checkpointing:
-  enabled: true
   checkpoint_dir: results/grpo-llama3.1-8b-instruct-1n8g-megatron-fp8
-  metric_name: val_reward
-  higher_is_better: true
-  keep_top_k: 3
-  save_period: 10
-  checkpoint_must_save_by: null
 policy:
   model_name: meta-llama/Llama-3.1-8B-Instruct
   tokenizer:
     name: meta-llama/Llama-3.1-8B-Instruct
-  train_global_batch_size: 512
   train_micro_batch_size: 1
-  generation_batch_size: 32
   logprob_batch_size: 2
   max_total_sequence_length: 4096
-  precision: bfloat16
   make_sequence_length_divisible_by: 1
-  max_grad_norm: 1
-
   dtensor_cfg:
-    enabled: False
-
-  dynamic_batching:
-    enabled: False
-
-  sequence_packing:
-    enabled: True
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
-    algorithm: "modified_first_fit_decreasing"
-    sequence_length_round: 64
-
+    enabled: false
   megatron_cfg:
-    enabled: True
+    enabled: true
     empty_unused_memory_level: 1
-    converter_type: "LlamaForCausalLM"
-    tensor_model_parallel_size: 1
+    converter_type: LlamaForCausalLM
     pipeline_model_parallel_size: 2
-    context_parallel_size: 1
-    expert_tensor_parallel_size: 1
-    expert_model_parallel_size: 1
-    sequence_parallel: False
-    pipeline_dtype: ${policy.precision}
-    num_layers_in_first_pipeline_stage: null
-    num_layers_in_last_pipeline_stage: null
-    freeze_moe_router: True
-    moe_router_dtype: "fp64"
-    moe_router_load_balancing_type: "none" # "seq_aux_loss" causes logprob error divergence for grpo
-    moe_router_bias_update_rate: 0.0 # by default, disable bias updates for grpo
-    apply_rope_fusion: True
-    activation_checkpointing: True
-    defer_fp32_logits: True
-
+    activation_checkpointing: true
+    defer_fp32_logits: true
     optimizer:
-      optimizer: "adam"
-      lr: 5.0e-7
-      min_lr: 5.0e-8
+      lr: 5.0e-07
+      min_lr: 5.0e-08
       weight_decay: 0.0
-      bf16: True
-      fp16: False
-      params_dtype: "float32"
-
-      adam_beta1: 0.9
-      adam_beta2: 0.999
-      adam_eps: 1e-8
-
-      use_distributed_optimizer: True
-      use_precision_aware_optimizer: True
-
-      clip_grad: ${policy.max_grad_norm}
-
     scheduler:
-      start_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
-      end_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
-      weight_decay_incr_style: "constant"
-      lr_decay_style: "constant"
-      lr_decay_iters: null
       lr_warmup_iters: 2
-      lr_warmup_init: 5.0e-8
-
-    distributed_data_parallel_config:
-      grad_reduce_in_fp32: False
-      overlap_grad_reduce: True
-      overlap_param_gather: True
-      average_in_collective: True
-      use_custom_fsdp: False
-      data_parallel_sharding_strategy: "optim_grads_params"
-
+      lr_warmup_init: 5.0e-08
   generation:
-    backend: vllm
     max_new_tokens: 4096
-    temperature: 1
-    top_p: 1
-    top_k: null
     stop_token_ids:
-      - 128009
-    stop_strings: null
+    - 128009
     vllm_cfg:
-      async_engine: false
-      precision: 'fp8'
-      tensor_parallel_size: 1
-      pipeline_parallel_size: 1
-      enable_expert_parallel: false
-      gpu_memory_utilization: 0.6
+      precision: fp8
       max_model_len: 4096
-      enforce_eager: False
       use_deep_gemm: true
-      num_last_layers_in_bf16: 0
-      num_first_layers_in_bf16: 0
-    colocated:
-      enabled: true
-      resources:
-        gpus_per_node: null
-        num_nodes: null
 data:
   max_input_seq_length: 4096
-  prompt_file: examples/prompts/cot.txt
-  system_prompt_file: null
-  dataset_name: OpenMathInstruct-2
-  shuffle: true
-env:
-  math:
-    num_workers: 8
 logger:
   log_dir: logs/grpo-llama3.1-8b-instruct-1n8g-megatron-fp8
-  num_val_samples_to_print: 0
   wandb_enabled: true
   tensorboard_enabled: true
-  mlflow_enabled: false
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: grpo-llama3.1-8b-instruct-1n8g-megatron-fp8
-  tensorboard: {}
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
 cluster:
   gpus_per_node: 8
   num_nodes: 4

--- a/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-2n8g-fsdp2tp1-noncolocated.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-2n8g-fsdp2tp1-noncolocated.yaml
@@ -1,130 +1,57 @@
+defaults: ../../grpo_math_1B.yaml
 grpo:
   num_prompts_per_step: 64
   num_generations_per_prompt: 32
-  max_rollout_turns: 1
   max_num_steps: 500
-  normalize_rewards: true
-  use_leave_one_out_baseline: true
-  val_period: 10
-  val_at_start: false
-  max_val_samples: 256
-  val_batch_size: 256
-  seed: 42
-loss_fn:
-  reference_policy_kl_penalty: 0.01
-  ratio_clip_min: 0.2
-  ratio_clip_max: 0.2
-  ratio_clip_c: null
-  use_on_policy_kl_approximation: false
-  use_importance_sampling_correction: false
-  token_level_loss: true
 checkpointing:
-  enabled: true
   checkpoint_dir: results/grpo-llama3.1-8b-instruct-2n8g-fsdp2tp1-noncolocated
-  metric_name: val_reward
-  higher_is_better: true
-  keep_top_k: 3
-  save_period: 10
-  checkpoint_must_save_by: null
 policy:
   model_name: meta-llama/Llama-3.1-8B-Instruct
   tokenizer:
     name: meta-llama/Llama-3.1-8B-Instruct
-  train_global_batch_size: 512
   train_micro_batch_size: 1
-  generation_batch_size: 32
   logprob_batch_size: 2
   max_total_sequence_length: 4096
-  precision: bfloat16
-  dtensor_cfg:
-    enabled: true
-    cpu_offload: false
-    sequence_parallel: false
-    activation_checkpointing: false
-    tensor_parallel_size: 1
-    context_parallel_size: 1
-    custom_parallel_plan: null
   dynamic_batching:
-    enabled: True
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
-    sequence_length_round: 64
+    enabled: true
   sequence_packing:
     enabled: false
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
-    algorithm: "modified_first_fit_decreasing"
-    sequence_length_round: 64
   make_sequence_length_divisible_by: 1
-  max_grad_norm: 1
   optimizer:
-    name: torch.optim.AdamW
     kwargs:
-      lr: 3e-07
-      weight_decay: 0.01
-      betas:
-        - 0.9
-        - 0.999
-      eps: 1e-08
-      foreach: false
-      fused: false
+      lr: 3.0e-07
   scheduler:
-    - name: torch.optim.lr_scheduler.LinearLR
-      kwargs:
-        start_factor: 0.1
-        end_factor: 1
-        total_iters: 13
-    - name: torch.optim.lr_scheduler.ConstantLR
-      kwargs:
-        factor: 1
-        total_iters: 10000000000
-    - milestones:
-        - 13
+  - name: torch.optim.lr_scheduler.LinearLR
+    kwargs:
+      start_factor: 0.1
+      end_factor: 1
+      total_iters: 13
+  - name: torch.optim.lr_scheduler.ConstantLR
+    kwargs:
+      factor: 1
+      total_iters: 10000000000
+  - milestones:
+    - 13
   generation:
-    backend: vllm
     max_new_tokens: 4096
-    temperature: 1
-    top_p: 1
-    top_k: null
     stop_token_ids:
-      - 128009
-    stop_strings: null
+    - 128009
     vllm_cfg:
       async_engine: true
-      precision: ${policy.precision}
-      tensor_parallel_size: 1
-      pipeline_parallel_size: 1
-      gpu_memory_utilization: 0.6
       max_model_len: 4096
-      enforce_eager: False
     colocated:
       enabled: false
       resources:
-        gpus_per_node: null
         num_nodes: 1
 data:
   max_input_seq_length: 4096
-  prompt_file: examples/prompts/cot.txt
-  system_prompt_file: null
-  dataset_name: OpenMathInstruct-2
-  shuffle: true
-env:
-  math:
-    num_workers: 8
 logger:
   log_dir: logs/grpo-llama3.1-8b-instruct-2n8g-fsdp2tp1-noncolocated
-  num_val_samples_to_print: 0
   wandb_enabled: true
   tensorboard_enabled: true
-  mlflow_enabled: false
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: grpo-llama3.1-8b-instruct-2n8g-fsdp2tp1-noncolocated
-  tensorboard: {}
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
 cluster:
   gpus_per_node: 8
   num_nodes: 2

--- a/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-4n8g-fsdp2tp1-long.v3.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-4n8g-fsdp2tp1-long.v3.yaml
@@ -1,131 +1,52 @@
+defaults: ../../grpo_math_1B.yaml
 grpo:
   num_prompts_per_step: 64
   num_generations_per_prompt: 32
-  max_rollout_turns: 1
   max_num_steps: 500
-  normalize_rewards: true
-  use_leave_one_out_baseline: true
-  val_period: 10
-  val_at_start: false
-  max_val_samples: 256
-  val_batch_size: 256
-  seed: 42
-loss_fn:
-  reference_policy_kl_penalty: 0.01
-  ratio_clip_min: 0.2
-  ratio_clip_max: 0.2
-  ratio_clip_c: null
-  use_on_policy_kl_approximation: false
-  use_importance_sampling_correction: false
-  token_level_loss: true
 checkpointing:
-  enabled: true
   checkpoint_dir: results/grpo-llama3.1-8b-instruct-4n8g-fsdp2tp1-long
-  metric_name: val_reward
-  higher_is_better: true
-  keep_top_k: 3
-  save_period: 10
-  checkpoint_must_save_by: null
 policy:
   model_name: meta-llama/Llama-3.1-8B-Instruct
   tokenizer:
     name: meta-llama/Llama-3.1-8B-Instruct
-  train_global_batch_size: 512
   train_micro_batch_size: 1
-  generation_batch_size: 32
   logprob_batch_size: 2
   max_total_sequence_length: 4096
-  precision: bfloat16
-  dtensor_cfg:
-    enabled: true
-    cpu_offload: false
-    sequence_parallel: false
-    activation_checkpointing: false
-    tensor_parallel_size: 1
-    context_parallel_size: 1
-    custom_parallel_plan: null
   dynamic_batching:
-    enabled: True
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
-    sequence_length_round: 64
+    enabled: true
   sequence_packing:
     enabled: false
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
-    algorithm: "modified_first_fit_decreasing"
-    sequence_length_round: 64
   make_sequence_length_divisible_by: 1
-  max_grad_norm: 1
   optimizer:
-    name: torch.optim.AdamW
     kwargs:
-      lr: 3e-07
-      weight_decay: 0.01
-      betas:
-        - 0.9
-        - 0.999
-      eps: 1e-08
-      foreach: false
-      fused: false
+      lr: 3.0e-07
   scheduler:
-    - name: torch.optim.lr_scheduler.LinearLR
-      kwargs:
-        start_factor: 0.1
-        end_factor: 1
-        total_iters: 13
-    - name: torch.optim.lr_scheduler.ConstantLR
-      kwargs:
-        factor: 1
-        total_iters: 10000000000
-    - milestones:
-        - 13
+  - name: torch.optim.lr_scheduler.LinearLR
+    kwargs:
+      start_factor: 0.1
+      end_factor: 1
+      total_iters: 13
+  - name: torch.optim.lr_scheduler.ConstantLR
+    kwargs:
+      factor: 1
+      total_iters: 10000000000
+  - milestones:
+    - 13
   generation:
-    backend: vllm
     max_new_tokens: 4096
-    temperature: 1
-    top_p: 1
-    top_k: null
     stop_token_ids:
-      - 128009
-    stop_strings: null
+    - 128009
     vllm_cfg:
-      async_engine: false
-      precision: ${policy.precision}
-      tensor_parallel_size: 1
-      pipeline_parallel_size: 1
-      enable_expert_parallel: false
-      gpu_memory_utilization: 0.6
       max_model_len: 4096
-      enforce_eager: False
-    colocated:
-      enabled: true
-      resources:
-        gpus_per_node: null
-        num_nodes: null
 data:
   max_input_seq_length: 4096
-  prompt_file: examples/prompts/cot.txt
-  system_prompt_file: null
-  dataset_name: OpenMathInstruct-2
-  shuffle: true
-env:
-  math:
-    num_workers: 8
 logger:
   log_dir: logs/grpo-llama3.1-8b-instruct-4n8g-fsdp2tp1-long
-  num_val_samples_to_print: 0
   wandb_enabled: true
   tensorboard_enabled: true
-  mlflow_enabled: false
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: grpo-llama3.1-8b-instruct-4n8g-fsdp2tp1-long
-  tensorboard: {}
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
 cluster:
   gpus_per_node: 8
   num_nodes: 4

--- a/examples/configs/recipes/llm/grpo-llama3.2-1b-instruct-1n8g-fsdp2tp1.v3.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.2-1b-instruct-1n8g-fsdp2tp1.v3.yaml
@@ -1,131 +1,31 @@
+defaults: ../../grpo_math_1B.yaml
 grpo:
-  num_prompts_per_step: 32
-  num_generations_per_prompt: 16
-  max_rollout_turns: 1
   max_num_steps: 500
-  normalize_rewards: true
-  use_leave_one_out_baseline: true
-  val_period: 10
-  val_at_start: false
-  max_val_samples: 256
-  val_batch_size: 256
-  seed: 42
-loss_fn:
-  reference_policy_kl_penalty: 0.01
-  ratio_clip_min: 0.2
-  ratio_clip_max: 0.2
-  ratio_clip_c: null
-  use_on_policy_kl_approximation: false
-  use_importance_sampling_correction: false
-  token_level_loss: true
 checkpointing:
-  enabled: true
   checkpoint_dir: results/grpo-llama3.2-1b-instruct-1n8g-fsdp2tp1
-  metric_name: val_reward
-  higher_is_better: true
-  keep_top_k: 3
-  save_period: 10
-  checkpoint_must_save_by: null
 policy:
   model_name: meta-llama/Llama-3.2-1B-Instruct
   tokenizer:
     name: meta-llama/Llama-3.2-1B-Instruct
-  train_global_batch_size: 512
-  train_micro_batch_size: 4
-  generation_batch_size: 32
-  logprob_batch_size: 4
-  max_total_sequence_length: 512
-  precision: bfloat16
-  dtensor_cfg:
-    enabled: true
-    cpu_offload: false
-    sequence_parallel: false
-    activation_checkpointing: false
-    tensor_parallel_size: 1
-    context_parallel_size: 1
-    custom_parallel_plan: null
   dynamic_batching:
-    enabled: True
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
-    sequence_length_round: 64
+    enabled: true
   sequence_packing:
     enabled: false
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
-    algorithm: "modified_first_fit_decreasing"
-    sequence_length_round: 64
   make_sequence_length_divisible_by: 1
-  max_grad_norm: 1
-  optimizer:
-    name: torch.optim.AdamW
-    kwargs:
-      lr: 5e-06
-      weight_decay: 0.01
-      betas:
-        - 0.9
-        - 0.999
-      eps: 1e-08
-      foreach: false
-      fused: false
-  scheduler:
-    - name: torch.optim.lr_scheduler.LinearLR
-      kwargs:
-        start_factor: 0.1
-        end_factor: 1
-        total_iters: 50
-    - name: torch.optim.lr_scheduler.ConstantLR
-      kwargs:
-        factor: 1
-        total_iters: 10000000000
-    - milestones:
-        - 50
   generation:
-    backend: vllm
     max_new_tokens: 512
-    temperature: 1
-    top_p: 1
-    top_k: null
     stop_token_ids:
-      - 128009
-    stop_strings: null
+    - 128009
     vllm_cfg:
-      async_engine: false
-      precision: ${policy.precision}
-      tensor_parallel_size: 1
-      pipeline_parallel_size: 1
-      enable_expert_parallel: false
-      gpu_memory_utilization: 0.6
       max_model_len: 512
-      enforce_eager: False
-    colocated:
-      enabled: true
-      resources:
-        gpus_per_node: null
-        num_nodes: null
 data:
   max_input_seq_length: 512
-  prompt_file: examples/prompts/cot.txt
-  system_prompt_file: null
-  dataset_name: OpenMathInstruct-2
-  shuffle: true
-env:
-  math:
-    num_workers: 8
 logger:
   log_dir: logs/grpo-llama3.2-1b-instruct-1n8g-fsdp2tp1
-  num_val_samples_to_print: 0
   wandb_enabled: true
   tensorboard_enabled: true
-  mlflow_enabled: false
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: grpo-llama3.2-1b-instruct-1n8g-fsdp2tp1
-  tensorboard: {}
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
 cluster:
   gpus_per_node: 8
-  num_nodes: 1

--- a/examples/configs/recipes/llm/grpo-llama3.2-1b-instruct-1n8g-megatron.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.2-1b-instruct-1n8g-megatron.yaml
@@ -1,160 +1,36 @@
+defaults: ../../grpo_math_1B.yaml
 grpo:
-  num_prompts_per_step: 32
-  num_generations_per_prompt: 16
-  max_rollout_turns: 1
   max_num_steps: 500
-  normalize_rewards: true
-  use_leave_one_out_baseline: true
-  val_period: 10
-  val_at_start: false
-  max_val_samples: 256
-  val_batch_size: 256
-  seed: 42
-loss_fn:
-  reference_policy_kl_penalty: 0.01
-  ratio_clip_min: 0.2
-  ratio_clip_max: 0.2
-  ratio_clip_c: null
-  use_on_policy_kl_approximation: false
-  use_importance_sampling_correction: false
-  token_level_loss: true
 checkpointing:
   enabled: false
   checkpoint_dir: results/grpo-llama3.2-1b-instruct-1n8g-megatron
-  metric_name: val_reward
-  higher_is_better: true
-  keep_top_k: 3
   save_period: 100
-  checkpoint_must_save_by: null
 policy:
   model_name: meta-llama/Llama-3.2-1B-Instruct
   tokenizer:
     name: meta-llama/Llama-3.2-1B-Instruct
-  train_global_batch_size: 512
-  train_micro_batch_size: 4
-  generation_batch_size: 32
-  logprob_batch_size: 4
-  max_total_sequence_length: 512
-  precision: bfloat16
   optimizer: null
   megatron_cfg:
     enabled: true
-    empty_unused_memory_level: 0
-    activation_checkpointing: false
-    tensor_model_parallel_size: 1
-    expert_tensor_parallel_size: 1
-    expert_model_parallel_size: 1
-    pipeline_model_parallel_size: 1
-    num_layers_in_first_pipeline_stage: null
-    num_layers_in_last_pipeline_stage: null
-    context_parallel_size: 1
-    pipeline_dtype: ${policy.precision}
-    sequence_parallel: false
-    freeze_moe_router: true
-    moe_router_dtype: "fp64"
-    moe_router_load_balancing_type: "none" # "seq_aux_loss" causes logprob error divergence for grpo
-    moe_router_bias_update_rate: 0.0 # by default, disable bias updates for grpo
-    #gives ~20% training perf speedup with sequence packing 
-    apply_rope_fusion: True
-    
-    optimizer:
-      optimizer: "adam"
-      lr: 5.0e-6
-      min_lr: 5.0e-7
-      weight_decay: 0.01
-      bf16: true
-      fp16: false
-      params_dtype: "float32"
-
-      #adam
-      adam_beta1: 0.9
-      adam_beta2: 0.999
-      adam_eps: 1e-8
-
-      #sgd
-      sgd_momentum: 0.9
-
-      #distributed optimizer
-      use_distributed_optimizer: true
-      use_precision_aware_optimizer: true
-
-      clip_grad: ${policy.max_grad_norm}
-
     scheduler:
-      start_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
-      end_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
-      weight_decay_incr_style: "constant"
-      lr_decay_style: "constant"
-      lr_decay_iters: null
       lr_warmup_iters: 50
-      lr_warmup_init: 5.0e-7
-
-    distributed_data_parallel_config:
-      grad_reduce_in_fp32: false
-      overlap_grad_reduce: true
-      overlap_param_gather: true
-      average_in_collective: true
-      use_custom_fsdp: false
-      data_parallel_sharding_strategy: "optim_grads_params"
-
   dtensor_cfg:
     enabled: false
-  dynamic_batching:
-    enabled: False
-  sequence_packing:
-    enabled: True
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
-    algorithm: "modified_first_fit_decreasing"
-    sequence_length_round: 64
   make_sequence_length_divisible_by: 1
-  max_grad_norm: 1
   generation:
-    backend: vllm
     max_new_tokens: 512
-    temperature: 1
-    top_p: 1
-    top_k: null
     stop_token_ids:
-      - 128009
-    stop_strings: null
+    - 128009
     vllm_cfg:
-      async_engine: false
-      precision: ${policy.precision}
-      tensor_parallel_size: 1
-      pipeline_parallel_size: 1
-      enable_expert_parallel: false
-      gpu_memory_utilization: 0.6
       max_model_len: 512
-      enforce_eager: False
-    colocated:
-      enabled: true
-      resources:
-        gpus_per_node: null
-        num_nodes: null
 data:
   max_input_seq_length: 512
-  prompt_file: examples/prompts/cot.txt
-  system_prompt_file: null
-  dataset_name: OpenMathInstruct-2
-  shuffle: true
-env:
-  math:
-    num_workers: 8
 logger:
   log_dir: logs/grpo-llama3.2-1b-instruct-1n8g-megatron
-  num_val_samples_to_print: 0
   wandb_enabled: true
   tensorboard_enabled: true
-  mlflow_enabled: False
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: grpo-llama3.2-1b-instruct-1n8g-megatron
-  tensorboard: {}
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
 cluster:
   gpus_per_node: 8
-  num_nodes: 1

--- a/examples/configs/recipes/llm/grpo-math-qwen3-30ba3b-megatron-tp4-32k.yaml
+++ b/examples/configs/recipes/llm/grpo-math-qwen3-30ba3b-megatron-tp4-32k.yaml
@@ -1,169 +1,53 @@
+defaults: ../../grpo_math_1B.yaml
 checkpointing:
-  enabled: True
   checkpoint_dir: results/grpo-math-qwen3-30ba3b-megatron-tp4-32k
   save_period: 3
   keep_top_k: 1
-  metric_name: val_reward
-  higher_is_better: True
-  checkpoint_must_save_by: null
-
 grpo:
-  normalize_rewards: True
-  use_leave_one_out_baseline: True
   max_num_steps: 3
   num_prompts_per_step: 64
-  num_generations_per_prompt: 16
-  max_rollout_turns: 1
   val_period: 3
-  val_at_start: False
-  max_val_samples: 256
-  val_batch_size: 256
-  seed: 42
-
-loss_fn:
-  reference_policy_kl_penalty: 0.01
-  ratio_clip_min: 0.2
-  ratio_clip_max: 0.2
-  # (default off) loss formulation improvements (docs/guides/grpo.md#loss)
-  use_on_policy_kl_approximation: False
-  use_importance_sampling_correction: False
-  token_level_loss: True
-  ratio_clip_c: null
-
 policy:
-  model_name: "Qwen/Qwen3-30B-A3B"
-  tokenizer:
-    name: ${policy.model_name} ## specify if you'd like to use a tokenizer different from the model's default
-  train_global_batch_size: 512
+  model_name: Qwen/Qwen3-30B-A3B
   train_micro_batch_size: 1
-  generation_batch_size: 32 # Only used when generating using HF backend
   logprob_batch_size: 1
   max_total_sequence_length: 32768
-  precision: "bfloat16"
   logprob_chunk_size: 2048
-
   dtensor_cfg:
-    enabled: False
-
-  dynamic_batching:
-    enabled: False
-
+    enabled: false
   sequence_packing:
-    enabled: False
-
-  max_grad_norm: 1.0
+    enabled: false
   make_sequence_length_divisible_by: ${policy.megatron_cfg.tensor_model_parallel_size}
-
-  optimizer: null # remove default FSDP optimizer
-
-  scheduler: null # remove default FSDP scheduler
-
+  optimizer: null
+  scheduler: null
   megatron_cfg:
-    enabled: True
+    enabled: true
     empty_unused_memory_level: 1
-    converter_type: "LlamaForCausalLM"
+    converter_type: LlamaForCausalLM
     tensor_model_parallel_size: 4
-    pipeline_model_parallel_size: 1
-    context_parallel_size: 1
-    expert_tensor_parallel_size: 1
     expert_model_parallel_size: 8
-    sequence_parallel: True
-    pipeline_dtype: ${policy.precision}
-    num_layers_in_first_pipeline_stage: null
-    num_layers_in_last_pipeline_stage: null
-    freeze_moe_router: True
-    moe_router_dtype: "fp64"
-    moe_router_load_balancing_type: "none" # "seq_aux_loss" causes logprob error divergence for grpo
-    moe_router_bias_update_rate: 0.0 # by default, disable bias updates for grpo
-    apply_rope_fusion: True
-    activation_checkpointing: True
-    defer_fp32_logits: True
-
+    sequence_parallel: true
+    activation_checkpointing: true
+    defer_fp32_logits: true
     optimizer:
-      optimizer: "adam"
-      lr: 5.0e-7
-      min_lr: 5.0e-8
+      lr: 5.0e-07
+      min_lr: 5.0e-08
       weight_decay: 0.0
-      bf16: True
-      fp16: False
-      params_dtype: "float32"
-
-      adam_beta1: 0.9
-      adam_beta2: 0.999
-      adam_eps: 1e-8
-
-      use_distributed_optimizer: True
-      use_precision_aware_optimizer: True
-
-      clip_grad: ${policy.max_grad_norm}
-
     scheduler:
-      start_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
-      end_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
-      weight_decay_incr_style: "constant"
-      lr_decay_style: "constant"
-      lr_decay_iters: null
       lr_warmup_iters: 2
-      lr_warmup_init: 5.0e-8
-
-    distributed_data_parallel_config:
-      grad_reduce_in_fp32: False
-      overlap_grad_reduce: True
-      overlap_param_gather: True
-      average_in_collective: True
-      use_custom_fsdp: False
-      data_parallel_sharding_strategy: "optim_grads_params"
-    
+      lr_warmup_init: 5.0e-08
   generation:
-    backend: "vllm"
-    max_new_tokens: ${policy.max_total_sequence_length}
-    temperature: 1.0
-    top_p: 1.0
-    top_k: null
-    stop_token_ids: null
-    stop_strings: null
     vllm_cfg:
-      async_engine: False
-      precision: ${policy.precision}
       tensor_parallel_size: 4
-      pipeline_parallel_size: 1
-      enable_expert_parallel: false
-      gpu_memory_utilization: 0.6
-      max_model_len: ${policy.max_total_sequence_length}
-      # NB(pjin): https://github.com/NVIDIA-NeMo/RL/pull/857
-      enforce_eager: True
-    colocated:
-      enabled: true
-      resources:
-        gpus_per_node: null
-        num_nodes: null
-
-data:
-  dataset_name: "OpenMathInstruct-2"
-  shuffle: true
-  max_input_seq_length: ${policy.max_total_sequence_length} # upper bound, real truncation occurs at vllm.max_model_len
-  prompt_file: "examples/prompts/cot.txt"
-  system_prompt_file: null
-
-env:
-  math:
-    num_workers: 8
-
+      enforce_eager: true
 logger:
   log_dir: logs/grpo-math-qwen3-30ba3b-megatron-tp4-32k
-  num_val_samples_to_print: 0 # Number of validation samples to pretty print on terminal
-  wandb_enabled: True
-  tensorboard_enabled: True
-  mlflow_enabled: False  # Disable MLflow logging
-  monitor_gpus: False  # If true, will monitor GPU usage and log to wandb and/or tensorboard
+  wandb_enabled: true
+  tensorboard_enabled: true
+  monitor_gpus: false
   wandb:
     project: nemo-rl
-    name: "grpo-math-qwen3-30ba3b-megatron-tp4-32k"
-  tensorboard: {}
-  gpu_monitoring:
-    collection_interval: 10  # How often to collect GPU usage metrics (in seconds)
-    flush_interval: 10  # How often to flush GPU usage metrics to the loggers (in seconds)
-
+    name: grpo-math-qwen3-30ba3b-megatron-tp4-32k
 cluster:
   gpus_per_node: 8
   num_nodes: 4

--- a/examples/configs/recipes/llm/grpo-moonlight-16ba3b-4n8g-megatron.yaml
+++ b/examples/configs/recipes/llm/grpo-moonlight-16ba3b-4n8g-megatron.yaml
@@ -1,169 +1,40 @@
-# GRPO Algorithm Configuration
-defaults: "../../grpo_math_1B.yaml"
-
+defaults: ../../grpo_math_1B.yaml
 grpo:
-  num_prompts_per_step: 32
-  num_generations_per_prompt: 16
-  max_num_steps: 1000000
-  normalize_rewards: true
-  use_leave_one_out_baseline: true
   val_period: -1
-  val_at_start: false
-  max_val_samples: 256
-  val_batch_size: 256
-
 loss_fn:
   reference_policy_kl_penalty: 0.04
-  ratio_clip_min: 0.2
-  ratio_clip_max: 0.2
-  # (default off) loss formulation improvements (docs/guides/grpo.md#loss)
-  use_on_policy_kl_approximation: false
-  use_importance_sampling_correction: false
-  token_level_loss: true
-  ratio_clip_c: null
-
 checkpointing:
   enabled: false
-  checkpoint_dir: "results/grpo_megatron"
-  metric_name: "val_reward"
-  higher_is_better: true
-  keep_top_k: 3
+  checkpoint_dir: results/grpo_megatron
   save_period: 10000
-
 policy:
-  model_name: "moonshotai/Moonlight-16B-A3B-Instruct"
-  tokenizer:
-    name: ${policy.model_name} ## specify if you'd like to use a tokenizer different from the model's default
-  train_global_batch_size: 512
+  model_name: moonshotai/Moonlight-16B-A3B-Instruct
   train_micro_batch_size: 1
-  generation_batch_size: 64 # Only used when generating using megatron backend
+  generation_batch_size: 64
   logprob_batch_size: 1
   max_total_sequence_length: 8192
-  precision: "bfloat16"
-
   dtensor_cfg:
     enabled: false
-
-  # dynamic_batching improves performance by ensuring logprob and training microbatches
-  # have a sufficent number of tokens to maximize GPU utilization. Specifically, variable length
-  # responses are sorted by sequence length and bucketed into microbatches with a total
-  # amount of tokens is approximately close to 'train_mb_tokens' and 'logprob_mb_tokens' for the
-  # training and logprob stages respectively.
-  dynamic_batching:
-    enabled: False
-
   sequence_packing:
-    enabled: False # coming soon
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
-    algorithm: "modified_ffd"
-    sequence_length_round: 64
-
-  max_grad_norm: 1.0
-  # makes the training sequence length divisible by the tensor parallel size
-  # this is useful for sequence parallel training
+    enabled: false
+    algorithm: modified_ffd
   make_sequence_length_divisible_by: ${policy.megatron_cfg.tensor_model_parallel_size}
-
-  optimizer: null # remove default FSDP optimizer
-
+  optimizer: null
   megatron_cfg:
     enabled: true
-    empty_unused_memory_level: 0
-    activation_checkpointing: false
-    converter_type: "Qwen2ForCausalLM"
-    tensor_model_parallel_size: 1
-    expert_tensor_parallel_size: 1
     expert_model_parallel_size: 4
     pipeline_model_parallel_size: 4
     num_layers_in_first_pipeline_stage: 7
     num_layers_in_last_pipeline_stage: 6
-    context_parallel_size: 1
-    pipeline_dtype: ${policy.precision}
-    sequence_parallel: false
-    freeze_moe_router: true
-    moe_router_dtype: "fp64"
-    moe_router_load_balancing_type: "none" # "seq_aux_loss" causes logprob error divergence for grpo
-    moe_router_bias_update_rate: 0.0 # by default, disable bias updates for grpo
-    #gives ~20% training perf speedup with sequence packing 
-    # Causes logprob error divergence for moonlight
-    apply_rope_fusion: False
-    
+    apply_rope_fusion: false
     optimizer:
-      optimizer: "adam"
-      lr: 1.0e-6
-      min_lr: 5.0e-7
-      weight_decay: 0.01
-      bf16: true
-      fp16: false
-      params_dtype: "float32"
-
-      #adam
-      adam_beta1: 0.9
-      adam_beta2: 0.999
-      adam_eps: 1e-8
-
-      #sgd
-      sgd_momentum: 0.9
-
-      #distributed optimizer
-      use_distributed_optimizer: true
-      use_precision_aware_optimizer: true
-
-      clip_grad: ${policy.max_grad_norm}
-
+      lr: 1.0e-06
     scheduler:
-      start_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
-      end_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
-      weight_decay_incr_style: "constant"
-      lr_decay_style: "constant"
-      lr_decay_iters: null
       lr_warmup_iters: 50
-      lr_warmup_init: 5.0e-7
-
-    distributed_data_parallel_config:
-      grad_reduce_in_fp32: false
-      overlap_grad_reduce: true
-      overlap_param_gather: true
-      average_in_collective: true
-      use_custom_fsdp: false
-      data_parallel_sharding_strategy: "optim_grads_params"
-
-  generation:
-    backend: "vllm"
-    max_new_tokens: ${policy.max_total_sequence_length}
-    temperature: 1.0
-    top_p: 1.0
-    top_k: null
-    vllm_cfg:
-      tensor_parallel_size: 1
-      gpu_memory_utilization: 0.6
-      max_model_len: ${policy.max_total_sequence_length}
-
-data:
-  max_input_seq_length: ${policy.max_total_sequence_length} # upper bound, real truncation occurs at vllm.max_model_len
-  prompt_file: "examples/prompts/cot.txt"
-  system_prompt_file: null
-  dataset_name: "OpenMathInstruct-2"
-
-env:
-  math:
-    num_workers: 8
-
 logger:
-  log_dir: "logs"  # Base directory for all logs
-  num_val_samples_to_print: 0 # Number of validation samples to pretty print on terminal
-  wandb_enabled: false
-  tensorboard_enabled: false
-  mlflow_enabled: False
-  monitor_gpus: false  # If true, will monitor GPU usage and log to wandb and/or tensorboard
+  monitor_gpus: false
   wandb:
-    project: "grpo-dev"
-    name: "grpo-moonlight-16B-A3B-Instruct"
-  tensorboard: {}
-  gpu_monitoring:
-    collection_interval: 10  # How often to collect GPU usage metrics (in seconds)
-    flush_interval: 10  # How often to flush GPU usage metrics to the loggers (in seconds)
-
+    name: grpo-moonlight-16B-A3B-Instruct
 cluster:
   gpus_per_node: 8
   num_nodes: 4

--- a/examples/configs/recipes/llm/grpo-qwen2.5-32b-32n8g-fsdp2tp8sp-actckpt-long.v3.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen2.5-32b-32n8g-fsdp2tp8sp-actckpt-long.v3.yaml
@@ -1,131 +1,57 @@
+defaults: ../../grpo_math_1B.yaml
 grpo:
   num_prompts_per_step: 64
   num_generations_per_prompt: 32
-  max_rollout_turns: 1
   max_num_steps: 20
-  normalize_rewards: true
-  use_leave_one_out_baseline: true
-  val_period: 10
-  val_at_start: false
-  max_val_samples: 256
-  val_batch_size: 256
-  seed: 42
-loss_fn:
-  reference_policy_kl_penalty: 0.01
-  ratio_clip_min: 0.2
-  ratio_clip_max: 0.2
-  ratio_clip_c: null
-  use_on_policy_kl_approximation: false
-  use_importance_sampling_correction: false
-  token_level_loss: true
 checkpointing:
-  enabled: true
   checkpoint_dir: results/grpo-qwen2.5-32b-32n8g-fsdp2tp8sp-actckpt-long
-  metric_name: val_reward
-  higher_is_better: true
-  keep_top_k: 3
-  save_period: 10
-  checkpoint_must_save_by: null
 policy:
   model_name: Qwen/Qwen2.5-32B
   tokenizer:
     name: Qwen/Qwen2.5-32B
-  train_global_batch_size: 512
   train_micro_batch_size: 1
-  generation_batch_size: 32
   logprob_batch_size: 2
   max_total_sequence_length: 16384
-  precision: bfloat16
   dtensor_cfg:
-    enabled: true
-    cpu_offload: false
     sequence_parallel: true
     activation_checkpointing: true
     tensor_parallel_size: 8
-    context_parallel_size: 1
-    custom_parallel_plan: null
   dynamic_batching:
-    enabled: True
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
-    sequence_length_round: 64
+    enabled: true
   sequence_packing:
     enabled: false
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
-    algorithm: "modified_first_fit_decreasing"
-    sequence_length_round: 64
   make_sequence_length_divisible_by: 8
-  max_grad_norm: 1
   optimizer:
-    name: torch.optim.AdamW
     kwargs:
-      lr: 3e-07
-      weight_decay: 0.01
-      betas:
-        - 0.9
-        - 0.999
-      eps: 1e-08
-      foreach: false
-      fused: false
+      lr: 3.0e-07
   scheduler:
-    - name: torch.optim.lr_scheduler.LinearLR
-      kwargs:
-        start_factor: 0.1
-        end_factor: 1
-        total_iters: 13
-    - name: torch.optim.lr_scheduler.ConstantLR
-      kwargs:
-        factor: 1
-        total_iters: 10000000000
-    - milestones:
-        - 13
+  - name: torch.optim.lr_scheduler.LinearLR
+    kwargs:
+      start_factor: 0.1
+      end_factor: 1
+      total_iters: 13
+  - name: torch.optim.lr_scheduler.ConstantLR
+    kwargs:
+      factor: 1
+      total_iters: 10000000000
+  - milestones:
+    - 13
   generation:
-    backend: vllm
     max_new_tokens: 16384
-    temperature: 1
-    top_p: 1
-    top_k: null
     stop_token_ids:
-      - 151643
-    stop_strings: null
+    - 151643
     vllm_cfg:
-      async_engine: false
-      precision: ${policy.precision}
       tensor_parallel_size: 4
-      pipeline_parallel_size: 1
-      enable_expert_parallel: false
-      gpu_memory_utilization: 0.6
       max_model_len: 16384
-      enforce_eager: False
-    colocated:
-      enabled: true
-      resources:
-        gpus_per_node: null
-        num_nodes: null
 data:
   max_input_seq_length: 16384
-  prompt_file: examples/prompts/cot.txt
-  system_prompt_file: null
-  dataset_name: OpenMathInstruct-2
-  shuffle: true
-env:
-  math:
-    num_workers: 8
 logger:
   log_dir: logs/grpo-qwen2.5-32b-32n8g-fsdp2tp8sp-actckpt-long
-  num_val_samples_to_print: 0
   wandb_enabled: true
   tensorboard_enabled: true
-  mlflow_enabled: false
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: grpo-qwen2.5-32b-32n8g-fsdp2tp8sp-actckpt-long
-  tensorboard: {}
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
 cluster:
   gpus_per_node: 8
   num_nodes: 32

--- a/examples/configs/recipes/llm/grpo-qwen2.5-32b-32n8g-fsdp2tp8sp-actckpt.v3.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen2.5-32b-32n8g-fsdp2tp8sp-actckpt.v3.yaml
@@ -1,131 +1,57 @@
+defaults: ../../grpo_math_1B.yaml
 grpo:
   num_prompts_per_step: 64
   num_generations_per_prompt: 32
-  max_rollout_turns: 1
   max_num_steps: 2
-  normalize_rewards: true
-  use_leave_one_out_baseline: true
-  val_period: 10
-  val_at_start: false
-  max_val_samples: 256
-  val_batch_size: 256
-  seed: 42
-loss_fn:
-  reference_policy_kl_penalty: 0.01
-  ratio_clip_min: 0.2
-  ratio_clip_max: 0.2
-  ratio_clip_c: null
-  use_on_policy_kl_approximation: false
-  use_importance_sampling_correction: false
-  token_level_loss: true
 checkpointing:
-  enabled: true
   checkpoint_dir: results/grpo-qwen2.5-32b-32n8g-fsdp2tp8sp-actckpt
-  metric_name: val_reward
-  higher_is_better: true
-  keep_top_k: 3
-  save_period: 10
-  checkpoint_must_save_by: null
 policy:
   model_name: Qwen/Qwen2.5-32B
   tokenizer:
     name: Qwen/Qwen2.5-32B
-  train_global_batch_size: 512
   train_micro_batch_size: 1
-  generation_batch_size: 32
   logprob_batch_size: 2
   max_total_sequence_length: 16384
-  precision: bfloat16
   dtensor_cfg:
-    enabled: true
-    cpu_offload: false
     sequence_parallel: true
     activation_checkpointing: true
     tensor_parallel_size: 8
-    context_parallel_size: 1
-    custom_parallel_plan: null
   dynamic_batching:
-    enabled: True
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
-    sequence_length_round: 64
+    enabled: true
   sequence_packing:
     enabled: false
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
-    algorithm: "modified_first_fit_decreasing"
-    sequence_length_round: 64
   make_sequence_length_divisible_by: 8
-  max_grad_norm: 1
   optimizer:
-    name: torch.optim.AdamW
     kwargs:
-      lr: 3e-07
-      weight_decay: 0.01
-      betas:
-        - 0.9
-        - 0.999
-      eps: 1e-08
-      foreach: false
-      fused: false
+      lr: 3.0e-07
   scheduler:
-    - name: torch.optim.lr_scheduler.LinearLR
-      kwargs:
-        start_factor: 0.1
-        end_factor: 1
-        total_iters: 13
-    - name: torch.optim.lr_scheduler.ConstantLR
-      kwargs:
-        factor: 1
-        total_iters: 10000000000
-    - milestones:
-        - 13
+  - name: torch.optim.lr_scheduler.LinearLR
+    kwargs:
+      start_factor: 0.1
+      end_factor: 1
+      total_iters: 13
+  - name: torch.optim.lr_scheduler.ConstantLR
+    kwargs:
+      factor: 1
+      total_iters: 10000000000
+  - milestones:
+    - 13
   generation:
-    backend: vllm
     max_new_tokens: 16384
-    temperature: 1
-    top_p: 1
-    top_k: null
     stop_token_ids:
-      - 151643
-    stop_strings: null
+    - 151643
     vllm_cfg:
-      async_engine: false
-      precision: ${policy.precision}
       tensor_parallel_size: 4
-      pipeline_parallel_size: 1
-      enable_expert_parallel: false
-      gpu_memory_utilization: 0.6
       max_model_len: 16384
-      enforce_eager: False
-    colocated:
-      enabled: true
-      resources:
-        gpus_per_node: null
-        num_nodes: null
 data:
   max_input_seq_length: 16384
-  prompt_file: examples/prompts/cot.txt
-  system_prompt_file: null
-  dataset_name: OpenMathInstruct-2
-  shuffle: true
-env:
-  math:
-    num_workers: 8
 logger:
   log_dir: logs/grpo-qwen2.5-32b-32n8g-fsdp2tp8sp-actckpt
-  num_val_samples_to_print: 0
   wandb_enabled: true
   tensorboard_enabled: true
-  mlflow_enabled: false
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: grpo-qwen2.5-32b-32n8g-fsdp2tp8sp-actckpt
-  tensorboard: {}
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
 cluster:
   gpus_per_node: 8
   num_nodes: 32

--- a/examples/configs/recipes/llm/grpo-qwen2.5-7b-instruct-4n8g-fsdp2tp4sp.v3.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen2.5-7b-instruct-4n8g-fsdp2tp4sp.v3.yaml
@@ -1,131 +1,56 @@
+defaults: ../../grpo_math_1B.yaml
 grpo:
   num_prompts_per_step: 64
   num_generations_per_prompt: 32
-  max_rollout_turns: 1
   max_num_steps: 30
-  normalize_rewards: true
-  use_leave_one_out_baseline: true
-  val_period: 10
-  val_at_start: false
-  max_val_samples: 256
-  val_batch_size: 256
-  seed: 42
-loss_fn:
-  reference_policy_kl_penalty: 0.01
-  ratio_clip_min: 0.2
-  ratio_clip_max: 0.2
-  ratio_clip_c: null
-  use_on_policy_kl_approximation: false
-  use_importance_sampling_correction: false
-  token_level_loss: true
 checkpointing:
-  enabled: true
   checkpoint_dir: results/grpo-qwen2.5-7b-instruct-4n8g-fsdp2tp4sp
-  metric_name: val_reward
-  higher_is_better: true
-  keep_top_k: 3
-  save_period: 10
-  checkpoint_must_save_by: null
 policy:
   model_name: Qwen/Qwen2.5-7B-Instruct
   tokenizer:
     name: Qwen/Qwen2.5-7B-Instruct
-  train_global_batch_size: 512
   train_micro_batch_size: 1
-  generation_batch_size: 32
   logprob_batch_size: 2
   max_total_sequence_length: 4096
-  precision: bfloat16
   dtensor_cfg:
-    enabled: true
-    cpu_offload: false
     sequence_parallel: true
-    activation_checkpointing: false
     tensor_parallel_size: 4
-    context_parallel_size: 1
-    custom_parallel_plan: null
   dynamic_batching:
-    enabled: True
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
-    sequence_length_round: 64
+    enabled: true
   sequence_packing:
     enabled: false
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
-    algorithm: "modified_first_fit_decreasing"
-    sequence_length_round: 64
   make_sequence_length_divisible_by: 4
-  max_grad_norm: 1
   optimizer:
-    name: torch.optim.AdamW
     kwargs:
-      lr: 3e-07
-      weight_decay: 0.01
-      betas:
-        - 0.9
-        - 0.999
-      eps: 1e-08
-      foreach: false
-      fused: false
+      lr: 3.0e-07
   scheduler:
-    - name: torch.optim.lr_scheduler.LinearLR
-      kwargs:
-        start_factor: 0.1
-        end_factor: 1
-        total_iters: 13
-    - name: torch.optim.lr_scheduler.ConstantLR
-      kwargs:
-        factor: 1
-        total_iters: 10000000000
-    - milestones:
-        - 13
+  - name: torch.optim.lr_scheduler.LinearLR
+    kwargs:
+      start_factor: 0.1
+      end_factor: 1
+      total_iters: 13
+  - name: torch.optim.lr_scheduler.ConstantLR
+    kwargs:
+      factor: 1
+      total_iters: 10000000000
+  - milestones:
+    - 13
   generation:
-    backend: vllm
     max_new_tokens: 4096
-    temperature: 1
-    top_p: 1
-    top_k: null
     stop_token_ids:
-      - 151645
-    stop_strings: null
+    - 151645
     vllm_cfg:
-      async_engine: false
-      precision: ${policy.precision}
       tensor_parallel_size: 4
-      pipeline_parallel_size: 1
-      enable_expert_parallel: false
-      gpu_memory_utilization: 0.6
       max_model_len: 4096
-      enforce_eager: False
-    colocated:
-      enabled: true
-      resources:
-        gpus_per_node: null
-        num_nodes: null
 data:
   max_input_seq_length: 4096
-  prompt_file: examples/prompts/cot.txt
-  system_prompt_file: null
-  dataset_name: OpenMathInstruct-2
-  shuffle: true
-env:
-  math:
-    num_workers: 8
 logger:
   log_dir: logs/grpo-qwen2.5-7b-instruct-4n8g-fsdp2tp4sp
-  num_val_samples_to_print: 0
   wandb_enabled: true
   tensorboard_enabled: true
-  mlflow_enabled: false
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: grpo-qwen2.5-7b-instruct-4n8g-fsdp2tp4sp
-  tensorboard: {}
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
 cluster:
   gpus_per_node: 8
   num_nodes: 4

--- a/examples/configs/recipes/llm/grpo-qwen2.5-7b-instruct-4n8g-megatron.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen2.5-7b-instruct-4n8g-megatron.yaml
@@ -1,182 +1,56 @@
+defaults: ../../grpo_math_1B.yaml
 grpo:
   num_prompts_per_step: 64
   num_generations_per_prompt: 32
-  max_rollout_turns: 1
   max_num_steps: 30
-  normalize_rewards: true
-  use_leave_one_out_baseline: true
-  val_period: 10
-  val_at_start: false
-  max_val_samples: 256
-  val_batch_size: 256
-  seed: 42
-loss_fn:
-  reference_policy_kl_penalty: 0.01
-  ratio_clip_min: 0.2
-  ratio_clip_max: 0.2
-  ratio_clip_c: null
-  use_on_policy_kl_approximation: false
-  use_importance_sampling_correction: false
-  token_level_loss: true
 checkpointing:
   enabled: false
   checkpoint_dir: results/grpo-qwen2.5-7b-instruct-4n8g-megatron
-  metric_name: val_reward
-  higher_is_better: true
-  keep_top_k: 3
   save_period: 100
-  checkpoint_must_save_by: null
 policy:
   model_name: Qwen/Qwen2.5-7B-Instruct
-  tokenizer:
-    name: ${policy.model_name}
-  train_global_batch_size: 512
   train_micro_batch_size: 1
-  generation_batch_size: 32
   logprob_batch_size: 2
   max_total_sequence_length: 4096
-  precision: bfloat16
   dtensor_cfg:
     enabled: false
   megatron_cfg:
     enabled: true
-    empty_unused_memory_level: 0
-    activation_checkpointing: false
-    converter_type: "Qwen2ForCausalLM"
     tensor_model_parallel_size: 2
-    expert_tensor_parallel_size: 1
-    expert_model_parallel_size: 1
-    pipeline_model_parallel_size: 1
-    num_layers_in_first_pipeline_stage: null
-    num_layers_in_last_pipeline_stage: null
-    context_parallel_size: 1
-    pipeline_dtype: ${policy.precision}
-    sequence_parallel: false
-    freeze_moe_router: true
-    moe_router_dtype: "fp64"
-    moe_router_load_balancing_type: "none" # "seq_aux_loss" causes logprob error divergence for grpo
-    moe_router_bias_update_rate: 0.0 # by default, disable bias updates for grpo
-    #gives ~20% training perf speedup with sequence packing 
-    apply_rope_fusion: True
-    
-    optimizer:
-      optimizer: "adam"
-      lr: 5.0e-6
-      min_lr: 5.0e-7
-      weight_decay: 0.01
-      bf16: true
-      fp16: false
-      params_dtype: "float32"
-
-      #adam
-      adam_beta1: 0.9
-      adam_beta2: 0.999
-      adam_eps: 1e-8
-
-      #sgd
-      sgd_momentum: 0.9
-
-      #distributed optimizer
-      use_distributed_optimizer: true
-      use_precision_aware_optimizer: true
-
-      clip_grad: ${policy.max_grad_norm}
-
     scheduler:
-      start_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
-      end_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
-      weight_decay_incr_style: "constant"
-      lr_decay_style: "constant"
-      lr_decay_iters: null
       lr_warmup_iters: 50
-      lr_warmup_init: 5.0e-7
-
-    distributed_data_parallel_config:
-      grad_reduce_in_fp32: false
-      overlap_grad_reduce: true
-      overlap_param_gather: true
-      average_in_collective: true
-      use_custom_fsdp: false
-      data_parallel_sharding_strategy: "optim_grads_params"
-  dynamic_batching:
-    enabled: false
-  sequence_packing:
-    enabled: true
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
-    algorithm: "modified_first_fit_decreasing"
-    sequence_length_round: 64
   make_sequence_length_divisible_by: 4
-  max_grad_norm: 1
   optimizer:
-    name: torch.optim.AdamW
     kwargs:
-      lr: 3e-07
-      weight_decay: 0.01
-      betas:
-        - 0.9
-        - 0.999
-      eps: 1e-08
-      foreach: false
-      fused: false
+      lr: 3.0e-07
   scheduler:
-    - name: torch.optim.lr_scheduler.LinearLR
-      kwargs:
-        start_factor: 0.1
-        end_factor: 1
-        total_iters: 13
-    - name: torch.optim.lr_scheduler.ConstantLR
-      kwargs:
-        factor: 1
-        total_iters: 10000000000
-    - milestones:
-        - 13
+  - name: torch.optim.lr_scheduler.LinearLR
+    kwargs:
+      start_factor: 0.1
+      end_factor: 1
+      total_iters: 13
+  - name: torch.optim.lr_scheduler.ConstantLR
+    kwargs:
+      factor: 1
+      total_iters: 10000000000
+  - milestones:
+    - 13
   generation:
-    backend: vllm
     max_new_tokens: 4096
-    temperature: 1
-    top_p: 1
-    top_k: null
     stop_token_ids:
-      - 151645
-    stop_strings: null
+    - 151645
     vllm_cfg:
-      async_engine: false
-      precision: ${policy.precision}
       tensor_parallel_size: 4
-      pipeline_parallel_size: 1
-      enable_expert_parallel: false
-      gpu_memory_utilization: 0.6
       max_model_len: 4096
-      enforce_eager: False
-    colocated:
-      enabled: true
-      resources:
-        gpus_per_node: null
-        num_nodes: null
 data:
   max_input_seq_length: 4096
-  prompt_file: examples/prompts/cot.txt
-  system_prompt_file: null
-  dataset_name: OpenMathInstruct-2
-  shuffle: true
-env:
-  math:
-    num_workers: 8
 logger:
   log_dir: logs/grpo-qwen2.5-7b-instruct-4n8g-megatron
-  num_val_samples_to_print: 0
   wandb_enabled: true
   tensorboard_enabled: true
-  mlflow_enabled: False
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: grpo-qwen2.5-7b-instruct-4n8g-megatron
-  tensorboard: {}
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
 cluster:
   gpus_per_node: 8
   num_nodes: 4

--- a/examples/configs/recipes/llm/grpo-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1.v3.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1.v3.yaml
@@ -1,131 +1,31 @@
+defaults: ../../grpo_math_1B.yaml
 grpo:
-  num_prompts_per_step: 32
-  num_generations_per_prompt: 16
-  max_rollout_turns: 1
   max_num_steps: 450
-  normalize_rewards: true
-  use_leave_one_out_baseline: true
-  val_period: 10
-  val_at_start: false
-  max_val_samples: 256
-  val_batch_size: 256
-  seed: 42
-loss_fn:
-  reference_policy_kl_penalty: 0.01
-  ratio_clip_min: 0.2
-  ratio_clip_max: 0.2
-  ratio_clip_c: null
-  use_on_policy_kl_approximation: false
-  use_importance_sampling_correction: false
-  token_level_loss: true
 checkpointing:
-  enabled: true
   checkpoint_dir: results/grpo-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1
-  metric_name: val_reward
-  higher_is_better: true
-  keep_top_k: 3
-  save_period: 10
-  checkpoint_must_save_by: null
 policy:
   model_name: Qwen/Qwen2.5-Math-1.5B-Instruct
   tokenizer:
     name: Qwen/Qwen2.5-Math-1.5B-Instruct
-  train_global_batch_size: 512
-  train_micro_batch_size: 4
-  generation_batch_size: 32
-  logprob_batch_size: 4
-  max_total_sequence_length: 512
-  precision: bfloat16
-  dtensor_cfg:
-    enabled: true
-    cpu_offload: false
-    sequence_parallel: false
-    activation_checkpointing: false
-    tensor_parallel_size: 1
-    context_parallel_size: 1
-    custom_parallel_plan: null
   dynamic_batching:
-    enabled: True
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
-    sequence_length_round: 64
+    enabled: true
   sequence_packing:
     enabled: false
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
-    algorithm: "modified_first_fit_decreasing"
-    sequence_length_round: 64
   make_sequence_length_divisible_by: 1
-  max_grad_norm: 1
-  optimizer:
-    name: torch.optim.AdamW
-    kwargs:
-      lr: 5e-06
-      weight_decay: 0.01
-      betas:
-        - 0.9
-        - 0.999
-      eps: 1e-08
-      foreach: false
-      fused: false
-  scheduler:
-    - name: torch.optim.lr_scheduler.LinearLR
-      kwargs:
-        start_factor: 0.1
-        end_factor: 1
-        total_iters: 50
-    - name: torch.optim.lr_scheduler.ConstantLR
-      kwargs:
-        factor: 1
-        total_iters: 10000000000
-    - milestones:
-        - 50
   generation:
-    backend: vllm
     max_new_tokens: 512
-    temperature: 1
-    top_p: 1
-    top_k: null
     stop_token_ids:
-      - 151645
-    stop_strings: null
+    - 151645
     vllm_cfg:
-      async_engine: false
-      precision: ${policy.precision}
-      tensor_parallel_size: 1
-      pipeline_parallel_size: 1
-      enable_expert_parallel: false
-      gpu_memory_utilization: 0.6
       max_model_len: 512
-      enforce_eager: False
-    colocated:
-      enabled: true
-      resources:
-        gpus_per_node: null
-        num_nodes: null
 data:
   max_input_seq_length: 512
-  prompt_file: examples/prompts/cot.txt
-  system_prompt_file: null
-  dataset_name: OpenMathInstruct-2
-  shuffle: true
-env:
-  math:
-    num_workers: 8
 logger:
   log_dir: logs/grpo-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1
-  num_val_samples_to_print: 0
   wandb_enabled: true
   tensorboard_enabled: true
-  mlflow_enabled: false
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: grpo-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1
-  tensorboard: {}
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
 cluster:
   gpus_per_node: 8
-  num_nodes: 1

--- a/examples/configs/recipes/llm/grpo-qwen3-30ba3b-8n8g-megatron.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen3-30ba3b-8n8g-megatron.yaml
@@ -1,154 +1,48 @@
-# GRPO Algorithm Configuration
-defaults: "../../grpo_math_1B.yaml"
-
+defaults: ../../grpo_math_1B.yaml
 grpo:
   num_prompts_per_step: 64
   num_generations_per_prompt: 32
-  max_num_steps: 1000000
-  normalize_rewards: true
-  use_leave_one_out_baseline: true
-  val_period: 10
-  val_at_start: false
-  max_val_samples: 256
-  val_batch_size: 256
-loss_fn:
-  reference_policy_kl_penalty: 0.01
-  ratio_clip_min: 0.2
-  ratio_clip_max: 0.2
-  # (default off) loss formulation improvements (docs/guides/grpo.md#loss)
-  use_on_policy_kl_approximation: false
-  use_importance_sampling_correction: false
-  token_level_loss: true
-  ratio_clip_c: null
 checkpointing:
   enabled: false
   checkpoint_dir: results/grpo-qwen3-30ba3b-8n8g-megatron
-  metric_name: val_reward
-  higher_is_better: true
-  keep_top_k: 3
-  save_period: 10
-  checkpoint_must_save_by: null
 policy:
-  model_name: "Qwen/Qwen3-30B-A3B"
-  tokenizer:
-    name: ${policy.model_name} ## specify if you'd like to use a tokenizer different from the model's default
-  train_global_batch_size: 512
+  model_name: Qwen/Qwen3-30B-A3B
   train_micro_batch_size: 1
-  generation_batch_size: 32 # Only used when generating using HF backend
-  logprob_batch_size: 4
   max_total_sequence_length: 4096
-  precision: "bfloat16"
-
   dtensor_cfg:
     enabled: false
-
-  optimizer: null # remove default FSDP optimizer
-
-  scheduler: null # remove default FSDP scheduler
-
-  dynamic_batching:
-    enabled: False
+  optimizer: null
+  scheduler: null
   sequence_packing:
-    enabled: False # coming soon
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
-    algorithm: "modified_ffd"
-    sequence_length_round: 64
-  max_grad_norm: 1.0
+    enabled: false
+    algorithm: modified_ffd
   make_sequence_length_divisible_by: ${policy.megatron_cfg.tensor_model_parallel_size}
   megatron_cfg:
     enabled: true
     empty_unused_memory_level: 1
-    activation_checkpointing: false
     tensor_model_parallel_size: 4
     pipeline_model_parallel_size: 4
-    context_parallel_size: 1
-    expert_tensor_parallel_size: 1
     expert_model_parallel_size: 4
-    num_layers_in_first_pipeline_stage: null
-    num_layers_in_last_pipeline_stage: null
-    sequence_parallel: True
-    pipeline_dtype: ${policy.precision}
-    freeze_moe_router: true
-    moe_router_dtype: "fp64"
-    moe_router_load_balancing_type: "none" # "seq_aux_loss" causes logprob error divergence for grpo
-    moe_router_bias_update_rate: 0.0 # by default, disable bias updates for grpo
-    #gives ~20% training perf speedup with sequence packing 
-    apply_rope_fusion: True
-
+    sequence_parallel: true
     optimizer:
-      optimizer: "adam"
-      lr: 3.0e-7
-      min_lr: 3.0e-8
-      weight_decay: 0.01
-      bf16: true
-      fp16: false
-      params_dtype: "float32"
-      clip_grad: ${policy.max_grad_norm}
-      #adam
-      adam_beta1: 0.9
-      adam_beta2: 0.999
-      adam_eps: 1e-8
-      #sgd
-      sgd_momentum: 0.9
-      #distributed optimizer
-      use_distributed_optimizer: true
-      use_precision_aware_optimizer: true
-
+      lr: 3.0e-07
+      min_lr: 3.0e-08
     scheduler:
-      start_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
-      end_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
-      weight_decay_incr_style: "constant"
-      lr_decay_style: "constant"
-      lr_decay_iters: null
       lr_warmup_iters: 50
-      lr_warmup_init: 3.0e-8
-    
+      lr_warmup_init: 3.0e-08
     env_vars:
-      PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:False"
-    
-    distributed_data_parallel_config:
-      grad_reduce_in_fp32: false
-      overlap_grad_reduce: true
-      overlap_param_gather: true
-      average_in_collective: true
-      use_custom_fsdp: false
-      data_parallel_sharding_strategy: "optim_grads_params"
-
+      PYTORCH_CUDA_ALLOC_CONF: expandable_segments:False
   generation:
-    backend: "vllm"
-    max_new_tokens: ${policy.max_total_sequence_length}
-    temperature: 1.0
-    top_p: 1.0
-    top_k: null
-    stop_token_ids: null
-    stop_strings: null
     vllm_cfg:
       tensor_parallel_size: 4
       gpu_memory_utilization: 0.7
-      max_model_len: ${policy.max_total_sequence_length}
-data:
-  max_input_seq_length: ${policy.max_total_sequence_length} # upper bound, real truncation occurs at vllm.max_model_len
-  prompt_file: "examples/prompts/cot.txt"
-  system_prompt_file: null
-  dataset_name: "OpenMathInstruct-2"
-env:
-  math:
-    num_workers: 8
 logger:
   log_dir: logs/grpo-qwen3-30ba3b-8n8g-megatron
-  num_val_samples_to_print: 0
   wandb_enabled: true
   tensorboard_enabled: true
-  mlflow_enabled: False
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: grpo-qwen3-30ba3b-8n8g-megatron
-  tensorboard: {}
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
 cluster:
   gpus_per_node: 8
   num_nodes: 8

--- a/examples/configs/recipes/llm/sft-llama3.1-70b-8n8g-tp4pp2-long-megatron.yaml
+++ b/examples/configs/recipes/llm/sft-llama3.1-70b-8n8g-tp4pp2-long-megatron.yaml
@@ -1,133 +1,60 @@
+defaults: ../../sft.yaml
 sft:
-  max_num_epochs: 1
   max_num_steps: 1000000
   val_period: 500
   val_batches: 4
   val_global_batch_size: 128
-  val_micro_batch_size: 1
   val_at_start: false
-  seed: 42
 checkpointing:
-  enabled: true
   checkpoint_dir: results/sft-llama3.1-70b-8n8g-tp4pp2-long-megatron
-  metric_name: val_loss
-  higher_is_better: false
-  keep_top_k: 3
   save_period: 100
-  checkpoint_must_save_by: null
 policy:
-  model_name: "meta-llama/Llama-3.1-70B"
+  model_name: meta-llama/Llama-3.1-70B
   tokenizer:
-    name: meta-llama/Llama-3.1-8B-Instruct ## specify if you'd like to use a tokenizer different from the model's default
+    name: meta-llama/Llama-3.1-8B-Instruct
   train_global_batch_size: 512
-  train_micro_batch_size: 1
   max_total_sequence_length: 4096
-  precision: "bfloat16"
   dtensor_cfg:
     enabled: false
   megatron_cfg:
     enabled: true
-    empty_unused_memory_level: 1
-    activation_checkpointing: false
     tensor_model_parallel_size: 4
-    expert_tensor_parallel_size: 1
-    expert_model_parallel_size: 1
     pipeline_model_parallel_size: 2
-    num_layers_in_first_pipeline_stage: null
-    num_layers_in_last_pipeline_stage: null
-    context_parallel_size: 1
-    pipeline_dtype: ${policy.precision}
-    sequence_parallel: false
     freeze_moe_router: true
-    moe_router_dtype: "fp64"
-    moe_router_load_balancing_type: "none" # "seq_aux_loss" causes logprob error divergence for grpo
-    moe_router_bias_update_rate: 0.0 # by default, disable bias updates for grpo
-    #gives ~20% training perf speedup with sequence packing 
-    apply_rope_fusion: True
-    
+    moe_router_dtype: fp64
+    moe_router_load_balancing_type: none
+    moe_router_bias_update_rate: 0.0
     optimizer:
-      optimizer: "adam"
-      lr: 2e-5
-      min_lr: 2e-5
+      lr: 2.0e-05
+      min_lr: 2.0e-05
       weight_decay: 0.01
       bf16: true
-      fp16: false
-      params_dtype: "float32"
-
-      #adam
-      adam_beta1: 0.9
       adam_beta2: 0.999
-      adam_eps: 1e-8
-
-      #sgd
-      sgd_momentum: 0.9
-
-      #distributed optimizer
-      use_distributed_optimizer: true
-      use_precision_aware_optimizer: true
-
+      adam_eps: 1.0e-08
       clip_grad: 0.0
-
     scheduler:
-      start_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
-      end_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
-      weight_decay_incr_style: "constant"
-      lr_decay_style: "constant"
-      lr_decay_iters: null
       lr_warmup_iters: 1
-      lr_warmup_init: 2e-5
-
-    distributed_data_parallel_config:
-      grad_reduce_in_fp32: false
-      overlap_grad_reduce: true
-      overlap_param_gather: true
-      average_in_collective: true
-      use_custom_fsdp: false
-      data_parallel_sharding_strategy: "optim_grads_params"
-  dynamic_batching:
-    enabled: false
-  sequence_packing:
-    enabled: false
-  # makes the training sequence length divisible by the tensor parallel size
-  # this is useful for sequence parallel training
+      lr_warmup_init: 2.0e-05
   make_sequence_length_divisible_by: ${policy.megatron_cfg.tensor_model_parallel_size}
   max_grad_norm: null
   optimizer:
-    name: "torch.optim.AdamW"
     kwargs:
-      lr: 2e-5
+      lr: 2.0e-05
       weight_decay: 0.01
-      betas: [0.9, 0.98]
-      eps: 1e-8
-      # when using Dtensor, we need to set foreach
-      # and fused to False
-      foreach: False
-      fused: False
+      eps: 1.0e-08
 data:
-  max_input_seq_length: ${policy.max_total_sequence_length}
-  dataset_name: "openmathinstruct2"
+  dataset_name: openmathinstruct2
   prompt_file: examples/prompts/math.txt
-  split: "train_1M"
-  add_bos: true
-  add_eos: true
+  split: train_1M
   add_generation_prompt: true
-  output_key: 'generated_solution'
-  shuffle: true
+  output_key: generated_solution
   seed: 42
 logger:
-  log_dir: "logs"  # Base directory for all logs
-  wandb_enabled: true # Make sure you do a ``wandb login [Your API key]'' before running
-  tensorboard_enabled: true
-  mlflow_enabled: False
-  monitor_gpus: false  # If true, will monitor GPU usage and log to wandb and/or tensorboard
+  monitor_gpus: false
   wandb:
-    project: "sft-dev"
-    name: "openmathinstruct-nemorl-1M_train"
+    name: openmathinstruct-nemorl-1M_train
   tensorboard:
-    log_dir: "tb_logs-openmathinstruct-nemorl-1M_train"
-  gpu_monitoring:
-    collection_interval: 10  # How often to collect GPU usage metrics (in seconds)
-    flush_interval: 10  # How often to flush GPU usage metrics to the loggers (in seconds)
+    log_dir: tb_logs-openmathinstruct-nemorl-1M_train
 cluster:
   gpus_per_node: 8
   num_nodes: 8

--- a/examples/configs/recipes/llm/sft-llama3.1-8b-1n8g-fsdp2tp1-dynamicbatch.yaml
+++ b/examples/configs/recipes/llm/sft-llama3.1-8b-1n8g-fsdp2tp1-dynamicbatch.yaml
@@ -1,20 +1,14 @@
+defaults: ../../sft.yaml
 sft:
-  max_num_epochs: 1
   max_num_steps: 10000
   val_period: 500
   val_batches: 4
   val_global_batch_size: 128
   val_micro_batch_size: 2
   val_at_start: false
-  seed: 42
 checkpointing:
-  enabled: true
   checkpoint_dir: results/sft-llama3.1-8b-instruct-1n8g-fsdp2tp1-long
-  metric_name: val_loss
-  higher_is_better: false
-  keep_top_k: 3
   save_period: 50
-  checkpoint_must_save_by: null
 policy:
   model_name: meta-llama/Llama-3.1-8B
   tokenizer:
@@ -22,59 +16,29 @@ policy:
   train_global_batch_size: 512
   train_micro_batch_size: 2
   max_total_sequence_length: 4096
-  precision: bfloat16
   dtensor_cfg:
-    enabled: true
-    cpu_offload: false
-    sequence_parallel: false
-    activation_checkpointing: false
     tensor_parallel_size: 4
-    context_parallel_size: 1
-    custom_parallel_plan: null
   dynamic_batching:
     enabled: true
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    sequence_length_round: 64
-  sequence_packing:
-    enabled: false
   make_sequence_length_divisible_by: 1
-  max_grad_norm: 1
   optimizer:
-    name: torch.optim.AdamW
     kwargs:
-      lr: 2e-5
+      lr: 2.0e-05
       weight_decay: 0.01
-      betas:
-        - 0.9
-        - 0.98
-      eps: 1e-08
-      foreach: false
-      fused: false
+      eps: 1.0e-08
 data:
-  max_input_seq_length: ${policy.max_total_sequence_length}
-  dataset_name: "openmathinstruct2"
+  dataset_name: openmathinstruct2
   prompt_file: examples/prompts/math.txt
-  split: "train_1M"
-  add_bos: true
-  add_eos: true
+  split: train_1M
   add_generation_prompt: true
-  output_key: 'generated_solution'
+  output_key: generated_solution
   seed: 42
-  shuffle: true
 logger:
   log_dir: logs/sft-llama3.1-8b-instruct-1n8g-fsdp2tp1-long
-  wandb_enabled: true
-  tensorboard_enabled: true
-  mlflow_enabled: false
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: sft-llama3.1-8b-instruct-1n8g-fsdp2tp1-long
   tensorboard:
     log_dir: tb_logs-sft-dev-squad
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
 cluster:
   gpus_per_node: 8
-  num_nodes: 1

--- a/examples/configs/recipes/llm/sft-llama3.1-8b-1n8g-fsdp2tp1-long.yaml
+++ b/examples/configs/recipes/llm/sft-llama3.1-8b-1n8g-fsdp2tp1-long.yaml
@@ -1,20 +1,14 @@
+defaults: ../../sft.yaml
 sft:
-  max_num_epochs: 1
   max_num_steps: 10000
   val_period: 500
   val_batches: 4
   val_global_batch_size: 128
   val_micro_batch_size: 2
   val_at_start: false
-  seed: 42
 checkpointing:
-  enabled: true
   checkpoint_dir: results/sft-llama3.1-8b-instruct-1n8g-fsdp2tp1-long
-  metric_name: val_loss
-  higher_is_better: false
-  keep_top_k: 3
   save_period: 100
-  checkpoint_must_save_by: null
 policy:
   model_name: meta-llama/Llama-3.1-8B
   tokenizer:
@@ -22,63 +16,25 @@ policy:
   train_global_batch_size: 512
   train_micro_batch_size: 2
   max_total_sequence_length: 4096
-  precision: bfloat16
-  dtensor_cfg:
-    enabled: true
-    cpu_offload: false
-    sequence_parallel: false
-    activation_checkpointing: false
-    tensor_parallel_size: 1
-    context_parallel_size: 1
-    custom_parallel_plan: null
-  dynamic_batching:
-    enabled: false
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    sequence_length_round: 64
-  sequence_packing:
-    enabled: false
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    algorithm: "modified_first_fit_decreasing"
-    sequence_length_round: 64
   make_sequence_length_divisible_by: 1
-  max_grad_norm: 1
   optimizer:
-    name: torch.optim.AdamW
     kwargs:
-      lr: 2e-5
+      lr: 2.0e-05
       weight_decay: 0.01
-      betas:
-        - 0.9
-        - 0.98
-      eps: 1e-08
-      foreach: false
-      fused: false
+      eps: 1.0e-08
 data:
-  max_input_seq_length: ${policy.max_total_sequence_length}
-  dataset_name: "openmathinstruct2"
+  dataset_name: openmathinstruct2
   prompt_file: examples/prompts/math.txt
-  split: "train_1M"
-  add_bos: true
-  add_eos: true
+  split: train_1M
   add_generation_prompt: true
-  output_key: 'generated_solution'
-  shuffle: true
+  output_key: generated_solution
   seed: 42
 logger:
   log_dir: logs/sft-llama3.1-8b-instruct-1n8g-fsdp2tp1-long
-  wandb_enabled: true
-  tensorboard_enabled: true
-  mlflow_enabled: false
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: sft-llama3.1-8b-instruct-1n8g-fsdp2tp1-long
   tensorboard:
     log_dir: tb_logs-sft-dev-squad
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
 cluster:
   gpus_per_node: 8
-  num_nodes: 1
-

--- a/examples/configs/recipes/llm/sft-llama3.1-8b-1n8g-fsdp2tp2sp.yaml
+++ b/examples/configs/recipes/llm/sft-llama3.1-8b-1n8g-fsdp2tp2sp.yaml
@@ -1,20 +1,10 @@
+defaults: ../../sft.yaml
 sft:
-  max_num_epochs: 1
   max_num_steps: 350
   val_period: 500
-  val_batches: 8
-  val_global_batch_size: 32
-  val_micro_batch_size: 1
-  val_at_start: true
-  seed: 42
 checkpointing:
-  enabled: true
   checkpoint_dir: results/sft-llama3.1-8b-instruct-1n8g-fsdp2tp2sp
-  metric_name: val_loss
-  higher_is_better: false
-  keep_top_k: 3
   save_period: 20
-  checkpoint_must_save_by: null
 policy:
   model_name: meta-llama/Llama-3.1-8B
   tokenizer:
@@ -22,60 +12,28 @@ policy:
   train_global_batch_size: 512
   train_micro_batch_size: 2
   max_total_sequence_length: 4096
-  precision: bfloat16
   dtensor_cfg:
-    enabled: true
-    cpu_offload: false
     sequence_parallel: true
-    activation_checkpointing: false
     tensor_parallel_size: 2
-    context_parallel_size: 1
-    custom_parallel_plan: null
-  dynamic_batching:
-    enabled: false
-  sequence_packing:
-    enabled: false
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    algorithm: "modified_first_fit_decreasing"
-    sequence_length_round: 64
   make_sequence_length_divisible_by: 2
-  max_grad_norm: 1
   optimizer:
-    name: torch.optim.AdamW
     kwargs:
-      lr: 2e-5
+      lr: 2.0e-05
       weight_decay: 0.01
-      betas:
-        - 0.9
-        - 0.98
-      eps: 1e-08
-      foreach: false
-      fused: false
+      eps: 1.0e-08
 data:
-  max_input_seq_length: ${policy.max_total_sequence_length}
-  dataset_name: "openmathinstruct2"
+  dataset_name: openmathinstruct2
   prompt_file: examples/prompts/math.txt
-  split: "train_1M"
-  add_bos: true
-  add_eos: true
+  split: train_1M
   add_generation_prompt: true
-  output_key: 'generated_solution'
-  shuffle: true
+  output_key: generated_solution
   seed: 42
 logger:
   log_dir: logs/sft-llama3.1-8b-instruct-1n8g-fsdp2tp2sp
-  wandb_enabled: true
-  tensorboard_enabled: true
-  mlflow_enabled: false
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: sft-llama3.1-8b-instruct-1n8g-fsdp2tp2sp
   tensorboard:
     log_dir: tb_logs-sft-dev-openmathinstruct2
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
 cluster:
   gpus_per_node: 8
-  num_nodes: 1

--- a/examples/configs/recipes/llm/sft-llama3.1-8b-1n8g-megatron-seqpack.yaml
+++ b/examples/configs/recipes/llm/sft-llama3.1-8b-1n8g-megatron-seqpack.yaml
@@ -1,20 +1,10 @@
+defaults: ../../sft.yaml
 sft:
-  max_num_epochs: 1
   max_num_steps: 250
   val_period: 500
-  val_batches: 8
-  val_global_batch_size: 32
-  val_micro_batch_size: 1
-  val_at_start: true
-  seed: 42
 checkpointing:
-  enabled: true
   checkpoint_dir: results/sft-llama3.1-8b-instruct-1n8g-megatron
-  metric_name: val_loss
-  higher_is_better: false
-  keep_top_k: 3
   save_period: 50
-  checkpoint_must_save_by: null
 policy:
   model_name: meta-llama/Llama-3.1-8B
   tokenizer:
@@ -22,104 +12,36 @@ policy:
   train_global_batch_size: 512
   train_micro_batch_size: 2
   max_total_sequence_length: 4096
-  precision: bfloat16
   dtensor_cfg:
-    enabled: false
-  dynamic_batching:
     enabled: false
   sequence_packing:
     enabled: true
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    algorithm: "modified_first_fit_decreasing"
-    sequence_length_round: 64
   make_sequence_length_divisible_by: ${policy.megatron_cfg.tensor_model_parallel_size}
-  max_grad_norm: 1
   optimizer: null
   megatron_cfg:
     enabled: true
-    empty_unused_memory_level: 1
-    activation_checkpointing: false
     tensor_model_parallel_size: 2
-    expert_tensor_parallel_size: 1
-    expert_model_parallel_size: 1
     pipeline_model_parallel_size: 2
-    context_parallel_size: 1
-    pipeline_dtype: ${policy.precision}
-    num_layers_in_first_pipeline_stage: null
-    num_layers_in_last_pipeline_stage: null
-    sequence_parallel: false
-    freeze_moe_router: false
-    moe_router_dtype: null
-    moe_router_load_balancing_type: "aux_loss"
-    moe_router_bias_update_rate: 1e-3
-    #gives ~20% training perf speedup with sequence packing 
-    apply_rope_fusion: True
-    
     optimizer:
-      optimizer: "adam"
-      lr: 2.0e-5
-      min_lr: 1.99999e-5
+      lr: 2.0e-05
+      min_lr: 1.99999e-05
       weight_decay: 0.01
       bf16: true
-      fp16: false
-      params_dtype: "float32"
-
-      #adam
-      adam_beta1: 0.9
-      adam_beta2: 0.98
-      adam_eps: 1e-5
-
-      #sgd
-      sgd_momentum: 0.9
-
-      #distributed optimizer
-      use_distributed_optimizer: true
-      use_precision_aware_optimizer: true
-
-      clip_grad: ${policy.max_grad_norm}
-
     scheduler:
-      start_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
-      end_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
-      weight_decay_incr_style: "constant"
-      lr_decay_style: "constant"
-      lr_decay_iters: null
-      lr_warmup_iters: 50
       lr_warmup_init: 1.9999e-65
-
-    distributed_data_parallel_config:
-      grad_reduce_in_fp32: false
-      overlap_grad_reduce: true
-      overlap_param_gather: true
-      average_in_collective: true
-      data_parallel_sharding_strategy: "optim_grads_params"
-
-
 data:
-  max_input_seq_length: ${policy.max_total_sequence_length}
-  dataset_name: "openmathinstruct2"
+  dataset_name: openmathinstruct2
   prompt_file: examples/prompts/math.txt
-  split: "train_1M"
-  add_bos: true
-  add_eos: true
+  split: train_1M
   add_generation_prompt: true
-  output_key: 'generated_solution'
+  output_key: generated_solution
   seed: 42
-  shuffle: true
 logger:
   log_dir: logs/sft-llama3.1-8b-1n8g-megatron
-  wandb_enabled: true
-  tensorboard_enabled: true
-  mlflow_enabled: false
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: sft-llama3.1-8b-1n8g-megatron
   tensorboard:
     log_dir: tb_logs-sft-dev-openmathinstruct2
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
 cluster:
   gpus_per_node: 8
-  num_nodes: 1

--- a/examples/configs/recipes/llm/sft-llama3.1-8b-1n8g-megatron.yaml
+++ b/examples/configs/recipes/llm/sft-llama3.1-8b-1n8g-megatron.yaml
@@ -1,20 +1,10 @@
+defaults: ../../sft.yaml
 sft:
-  max_num_epochs: 1
   max_num_steps: 250
   val_period: 500
-  val_batches: 8
-  val_global_batch_size: 32
-  val_micro_batch_size: 1
-  val_at_start: true
-  seed: 42
 checkpointing:
-  enabled: true
   checkpoint_dir: results/sft-llama3.1-8b-instruct-1n8g-megatron
-  metric_name: val_loss
-  higher_is_better: false
-  keep_top_k: 3
   save_period: 100
-  checkpoint_must_save_by: null
 policy:
   model_name: meta-llama/Llama-3.1-8B
   tokenizer:
@@ -22,104 +12,34 @@ policy:
   train_global_batch_size: 512
   train_micro_batch_size: 2
   max_total_sequence_length: 4096
-  precision: bfloat16
   dtensor_cfg:
     enabled: false
-  dynamic_batching:
-    enabled: false
-  sequence_packing:
-    enabled: false
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    algorithm: "modified_first_fit_decreasing"
-    sequence_length_round: 64
   make_sequence_length_divisible_by: ${policy.megatron_cfg.tensor_model_parallel_size}
-  max_grad_norm: 1
   optimizer: null
   megatron_cfg:
     enabled: true
-    empty_unused_memory_level: 1
-    activation_checkpointing: false
     tensor_model_parallel_size: 2
-    expert_tensor_parallel_size: 1
-    expert_model_parallel_size: 1
     pipeline_model_parallel_size: 2
-    context_parallel_size: 1
-    pipeline_dtype: ${policy.precision}
-    num_layers_in_first_pipeline_stage: null
-    num_layers_in_last_pipeline_stage: null
-    sequence_parallel: false
-    freeze_moe_router: false
-    moe_router_dtype: null
-    moe_router_load_balancing_type: "aux_loss"
-    moe_router_bias_update_rate: 1e-3
-    #gives ~20% training perf speedup with sequence packing 
-    apply_rope_fusion: True
-    
     optimizer:
-      optimizer: "adam"
-      lr: 2.0e-5
-      min_lr: 1.99999e-5
+      lr: 2.0e-05
+      min_lr: 1.99999e-05
       weight_decay: 0.01
       bf16: true
-      fp16: false
-      params_dtype: "float32"
-
-      #adam
-      adam_beta1: 0.9
-      adam_beta2: 0.98
-      adam_eps: 1e-5
-
-      #sgd
-      sgd_momentum: 0.9
-
-      #distributed optimizer
-      use_distributed_optimizer: true
-      use_precision_aware_optimizer: true
-
-      clip_grad: ${policy.max_grad_norm}
-
     scheduler:
-      start_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
-      end_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
-      weight_decay_incr_style: "constant"
-      lr_decay_style: "constant"
-      lr_decay_iters: null
-      lr_warmup_iters: 50
       lr_warmup_init: 1.9999e-65
-
-    distributed_data_parallel_config:
-      grad_reduce_in_fp32: false
-      overlap_grad_reduce: true
-      overlap_param_gather: true
-      average_in_collective: true
-      data_parallel_sharding_strategy: "optim_grads_params"
-
-
 data:
-  max_input_seq_length: ${policy.max_total_sequence_length}
-  dataset_name: "openmathinstruct2"
+  dataset_name: openmathinstruct2
   prompt_file: examples/prompts/math.txt
-  split: "train_1M"
-  add_bos: true
-  add_eos: true
+  split: train_1M
   add_generation_prompt: true
-  output_key: 'generated_solution'
-  shuffle: true
+  output_key: generated_solution
   seed: 42
 logger:
   log_dir: logs/sft-llama3.1-8b-1n8g-megatron
-  wandb_enabled: true
-  tensorboard_enabled: true
-  mlflow_enabled: false
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: sft-llama3.1-8b-1n8g-megatron
   tensorboard:
     log_dir: tb_logs-sft-dev-openmathinstruct2
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
 cluster:
   gpus_per_node: 8
-  num_nodes: 1

--- a/examples/configs/recipes/llm/sft-llama3.2-1b-1n8g-fsdp2tp1.v3.yaml
+++ b/examples/configs/recipes/llm/sft-llama3.2-1b-1n8g-fsdp2tp1.v3.yaml
@@ -1,82 +1,26 @@
+defaults: ../../sft.yaml
 sft:
-  max_num_epochs: 1
   max_num_steps: 500
-  val_period: 10
-  val_batches: 8
-  val_global_batch_size: 32
-  val_micro_batch_size: 1
-  val_at_start: true
-  seed: 42
 checkpointing:
-  enabled: true
   checkpoint_dir: results/sft-llama3.2-1b-1n8g-fsdp2tp1
-  metric_name: val_loss
-  higher_is_better: false
-  keep_top_k: 3
   save_period: 100
-  checkpoint_must_save_by: null
 policy:
-  model_name: meta-llama/Llama-3.2-1B
   tokenizer:
     name: meta-llama/Llama-3.2-1B
-    chat_template: '{% for message in messages %}{%- if message[''role''] == ''system''  %}{{''Context: '' + message[''content''].strip()}}{%- elif message[''role''] == ''user''  %}{{'' Question: '' + message[''content''].strip() + '' Answer:''}}{%- elif message[''role''] == ''assistant''  %}{{'' '' + message[''content''].strip()}}{%- endif %}{% endfor %}'
-  train_global_batch_size: 32
-  train_micro_batch_size: 1
-  max_total_sequence_length: 1024
-  precision: bfloat16
-  dtensor_cfg:
-    enabled: true
-    cpu_offload: false
-    sequence_parallel: false
-    activation_checkpointing: false
-    tensor_parallel_size: 1
-    context_parallel_size: 1
-    custom_parallel_plan: null
-  dynamic_batching:
-    enabled: false
-  sequence_packing:
-    enabled: false
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    algorithm: "modified_first_fit_decreasing"
-    sequence_length_round: 64
   make_sequence_length_divisible_by: 1
-  max_grad_norm: 1
-  optimizer:
-    name: torch.optim.AdamW
-    kwargs:
-      lr: 5e-06
-      weight_decay: 0.1
-      betas:
-        - 0.9
-        - 0.98
-      eps: 1e-05
-      foreach: false
-      fused: false
 data:
-  max_input_seq_length: ${policy.max_total_sequence_length}
-  dataset_name: "openmathinstruct2"
+  dataset_name: openmathinstruct2
   prompt_file: examples/prompts/math.txt
-  split: "train_1M"
-  add_bos: true
-  add_eos: true
+  split: train_1M
   add_generation_prompt: true
-  output_key: 'generated_solution'
-  shuffle: true
+  output_key: generated_solution
   seed: 42
 logger:
   log_dir: logs/sft-llama3.2-1b-1n8g-fsdp2tp1
-  wandb_enabled: true
-  tensorboard_enabled: true
-  mlflow_enabled: false
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: sft-llama3.2-1b-1n8g-fsdp2tp1
   tensorboard:
     log_dir: tb_logs-sft-dev-openmathinstruct2
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
 cluster:
   gpus_per_node: 8
-  num_nodes: 1

--- a/examples/configs/recipes/llm/sft-qwen2.5-32b-4n8g-fsdp2tp8sp-actckpt.v3.yaml
+++ b/examples/configs/recipes/llm/sft-qwen2.5-32b-4n8g-fsdp2tp8sp-actckpt.v3.yaml
@@ -1,81 +1,32 @@
+defaults: ../../sft.yaml
 sft:
-  max_num_epochs: 1
   max_num_steps: 20
-  val_period: 10
-  val_batches: 8
-  val_global_batch_size: 32
-  val_micro_batch_size: 1
-  val_at_start: true
-  seed: 42
 checkpointing:
-  enabled: true
   checkpoint_dir: results/sft-qwen2.5-32b-4n8g-fsdp2tp8sp-actckpt
-  metric_name: val_loss
-  higher_is_better: false
-  keep_top_k: 3
   save_period: 100
-  checkpoint_must_save_by: null
 policy:
   model_name: Qwen/Qwen2.5-32B
   tokenizer:
     name: Qwen/Qwen2.5-32B
-    chat_template: '{% for message in messages %}{%- if message[''role''] == ''system''  %}{{''Context: '' + message[''content''].strip()}}{%- elif message[''role''] == ''user''  %}{{'' Question: '' + message[''content''].strip() + '' Answer:''}}{%- elif message[''role''] == ''assistant''  %}{{'' '' + message[''content''].strip()}}{%- endif %}{% endfor %}'
-  train_global_batch_size: 32
-  train_micro_batch_size: 1
   max_total_sequence_length: 16000
-  precision: bfloat16
   dtensor_cfg:
-    enabled: true
-    cpu_offload: false
     sequence_parallel: true
     activation_checkpointing: true
     tensor_parallel_size: 8
-    context_parallel_size: 1
-    custom_parallel_plan: null
-  dynamic_batching:
-    enabled: false
-  sequence_packing:
-    enabled: false
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    algorithm: "modified_first_fit_decreasing"
-    sequence_length_round: 64
   make_sequence_length_divisible_by: 8
-  max_grad_norm: 1
-  optimizer:
-    name: torch.optim.AdamW
-    kwargs:
-      lr: 5e-06
-      weight_decay: 0.1
-      betas:
-        - 0.9
-        - 0.98
-      eps: 1e-05
-      foreach: false
-      fused: false
 data:
-  max_input_seq_length: ${policy.max_total_sequence_length}
-  dataset_name: "openmathinstruct2"
+  dataset_name: openmathinstruct2
   prompt_file: examples/prompts/math.txt
-  split: "train_1M"
-  add_bos: true
-  add_eos: true
+  split: train_1M
   add_generation_prompt: true
-  output_key: 'generated_solution'
-  shuffle: true
+  output_key: generated_solution
 logger:
   log_dir: logs/sft-qwen2.5-32b-4n8g-fsdp2tp8sp-actckpt
-  wandb_enabled: true
-  tensorboard_enabled: true
-  mlflow_enabled: false
-  monitor_gpus: true
   wandb:
     project: nemo-rl
     name: sft-qwen2.5-32b-4n8g-fsdp2tp8sp-actckpt
   tensorboard:
     log_dir: tb_logs-sft-dev-openmathinstruct2
-  gpu_monitoring:
-    collection_interval: 10
-    flush_interval: 10
 cluster:
   gpus_per_node: 8
   num_nodes: 4

--- a/tools/config_tools.py
+++ b/tools/config_tools.py
@@ -9,10 +9,44 @@ Subcommands:
     the base config file.
 
 Both commands support printing to stdout or in-place editing of the config file.
+
+Example:
+  # Expand a config with a root level "defaults" key to see the full config; print to stdout
+  uv run tools/config_tools.py expand examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp2-quick.v2.yaml
+
+  # Expand a config with a root level "defaults" key to see the full config; edit the config in place
+  uv run tools/config_tools.py expand examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp2-quick.v2.yaml --in-place
+
+  # Minimize a config and remove all keys that are present in the base config; print to stdout
+  # uv run tools/config_tools.py minimize <config> <base_config>
+  uv run tools/config_tools.py minimize examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp2-quick.v2.yaml examples/configs/dpo.yaml
+
+  # Minimize a config and remove all keys that are present in the base config; edit the config in place
+  # uv run tools/config_tools.py minimize <config> <base_config>
+  uv run tools/config_tools.py minimize examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp2-quick.v2.yaml examples/configs/dpo.yaml --in-place
+
+  # Minimize all llm the configs:
+  for algo in grpo dpo sft; do
+    base_config=examples/configs/${algo}.yaml
+    if [[ ${algo} == grpo ]]; then
+      base_config=examples/configs/grpo_math_1B.yaml
+    fi
+    for recipe in examples/configs/recipes/llm/${algo}-*.yaml; do
+      uv run tools/config_tools.py minimize $recipe examples/configs/${algo}.yaml --in-place
+    done
+  done
+
+  # Compare two configs
+  uv run tools/config_tools.py compare examples/configs/grpo_math_1B.yaml examples/configs/grpo_math_8B.yaml
+
+  # Minimize a config and compare it to not minimzing (should be the same)
+  uv run tools/config_tools.py minimize examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp2-quick.v2.yaml examples/configs/dpo.yaml >examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp2-quick.v2.yaml.minimized
+  uv run tools/config_tools.py compare \
+    examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp2-quick.v2.yaml \
+    examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp2-quick.v2.yaml.minimized
 """
 
 import argparse
-import sys
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -117,7 +151,7 @@ def expand(args: argparse.Namespace) -> int:
     if args.in_place:
         Path(args.config).write_text(text)
     else:
-        sys.stdout.write(text + ("\n" if not text.endswith("\n") else ""))
+        print(text + ("\n" if not text.endswith("\n") else ""), end="")
 
 
 def minimize(args: argparse.Namespace) -> int:
@@ -160,7 +194,70 @@ def minimize(args: argparse.Namespace) -> int:
     if args.in_place:
         Path(args.config).write_text(text)
     else:
-        sys.stdout.write(text + ("\n" if not text.endswith("\n") else ""))
+        print(text + ("\n" if not text.endswith("\n") else ""), end="")
+
+
+def _flatten(d: Any, prefix: str = "") -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    if isinstance(d, dict):
+        for k, v in d.items():
+            key = f"{prefix}.{k}" if prefix else str(k)
+            out.update(_flatten(v, key))
+    elif isinstance(d, list):
+        for i, v in enumerate(d):
+            key = f"{prefix}[{i}]"
+            out.update(_flatten(v, key))
+    else:
+        out[prefix] = d
+    return out
+
+
+def compare(args: argparse.Namespace) -> int:
+    left_path = Path(args.left).resolve()
+    right_path = Path(args.right).resolve()
+
+    # Expand via repo loader, then convert to plain dict/list so _flatten works
+    left = OmegaConf.to_container(load_config(str(left_path)))  # type: ignore[assignment]
+    right = OmegaConf.to_container(load_config(str(right_path)))  # type: ignore[assignment]
+
+    lf = _flatten(left)
+    rf = _flatten(right)
+
+    left_keys = set(lf.keys())
+    right_keys = set(rf.keys())
+
+    added = sorted(right_keys - left_keys)
+    removed = sorted(left_keys - right_keys)
+    common = sorted(left_keys & right_keys)
+
+    changed: list[str] = []
+    for k in common:
+        if lf[k] != rf[k]:
+            changed.append(k)
+
+    if not added and not removed and not changed:
+        print("Configs are identical after expansion")
+        return 0
+
+    # Print concise report with explicit left/right context
+    print("Comparing configs after expansion:")
+    print(f"  Left : {left_path}")
+    print(f"  Right: {right_path}")
+
+    if added:
+        print("\nAdded in Right (missing in Left):")
+        for k in added:
+            print(f"  {k} = {rf[k]}")
+
+    if removed:
+        print("\nRemoved in Right (only in Left):")
+        for k in removed:
+            print(f"  {k} = {lf[k]}")
+
+    if changed:
+        print("\nChanged (Left -> Right):")
+        for k in changed:
+            print(f"  {k}: {lf[k]} -> {rf[k]}")
 
 
 if __name__ == "__main__":
@@ -190,6 +287,13 @@ if __name__ == "__main__":
         help="Edit file in place instead of printing",
     )
     p_min.set_defaults(func=minimize)
+
+    p_cmp = sub.add_parser(
+        "compare", help="Compare two configs after expanding their defaults"
+    )
+    p_cmp.add_argument("left", help="Left config path")
+    p_cmp.add_argument("right", help="Right config path")
+    p_cmp.set_defaults(func=compare)
 
     args = parser.parse_args()
     args.func(args)

--- a/tools/config_tools.py
+++ b/tools/config_tools.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env -S uv run -q
+"""Utilities for working with YAML configs in this repo.
+
+Subcommands:
+  - expand: Resolve a config with OmegaConf interpolation and inheritance.
+  - minimize: Given a config and a base config, remove keys in the config that
+    are equal to the base, and ensure a defaults entry pointing to the base
+    exists. The defaults path in the resulting config is written relative to
+    the base config file.
+
+Both commands support printing to stdout or in-place editing of the config file.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+from omegaconf import DictConfig, OmegaConf
+
+from nemo_rl.utils.config import load_config
+
+
+def _dict_like(obj: Any) -> bool:
+    return isinstance(obj, dict)
+
+
+def _list_like(obj: Any) -> bool:
+    return isinstance(obj, list)
+
+
+REMOVE = object()
+
+
+def _prune_equal(a: Any, b: Any) -> Any:
+    """Return a copy of `a` with entries equal to `b` removed.
+
+    - If both are dicts: recursively prune and drop keys whose subtree is empty
+      after pruning or equal.
+    - If both are lists of same length: recursively prune by index and drop list
+      if becomes entirely empty or equal.
+    - Else: if equal, return a sentinel indicating removal; otherwise return `a`.
+    """
+    if _dict_like(a) and _dict_like(b):
+        out: dict[str, Any] = {}
+        a_dict: dict[str, Any] = a  # type: ignore[assignment]
+        b_dict: dict[str, Any] = b  # type: ignore[assignment]
+        for key, a_val in a_dict.items():
+            if key in b_dict:
+                pruned = _prune_equal(a_val, b_dict[key])
+                if pruned is REMOVE:
+                    # equal, skip
+                    continue
+                # keep if subtree has content
+                if pruned != {} and pruned != []:
+                    out[key] = pruned
+            else:
+                out[key] = a_val
+        return out
+
+    if _list_like(a) and _list_like(b) and len(a) == len(b):
+        # Only remove if entire list equals base; avoid partial list pruning
+        # to prevent semantic changes in ordered config sections.
+        if a == b:
+            return REMOVE
+        return a
+
+    # Base types
+    if a == b:
+        return REMOVE
+    return a
+
+
+def _ensure_defaults_relative(
+    child_path: Path, base_path: Path, child_cfg: dict[str, Any]
+) -> None:
+    """Ensure `defaults:` points to the base, with a path relative to the base config file.
+
+    The path we store must be a string such that, when the resulting minimized
+    config sits at `child_path`, the `defaults` string references the base
+    config location. The instruction asks that the defaults path in the resulting
+    config is relative to the base config; we interpret this as "express `base`
+    relative to the directory of the base file", then make that path relative
+    to the child config so that hydra resolution works from the child file.
+    """
+    # Compute a relative reference from child dir to base file
+    import os
+
+    rel_from_child_to_base = os.path.relpath(
+        str(base_path), start=str(child_path.parent)
+    )
+
+    existing = child_cfg.get("defaults")
+    if existing is None:
+        child_cfg["defaults"] = str(rel_from_child_to_base)
+        return
+    # Normalize various forms: string, single list element, list
+    if isinstance(existing, str):
+        existing_list: list[Any] = [existing]
+    else:
+        existing_list = list(existing) if isinstance(existing, Iterable) else [existing]
+    # Put our base at the first position if not present
+    if str(rel_from_child_to_base) not in [str(x) for x in existing_list]:
+        existing_list.insert(0, str(rel_from_child_to_base))
+    # If it's a single element list, collapse to string for this repo's style
+    if len(existing_list) == 1:
+        child_cfg["defaults"] = existing_list[0]
+    else:
+        child_cfg["defaults"] = existing_list
+
+
+def expand(args: argparse.Namespace) -> int:
+    # Merge defaults/inheritance using repo loader; preserve ${...}
+    cfg = load_config(str(Path(args.config).resolve()))
+    # Preserve ${...} by not resolving
+    text = OmegaConf.to_yaml(cfg)
+    if args.in_place:
+        Path(args.config).write_text(text)
+    else:
+        sys.stdout.write(text + ("\n" if not text.endswith("\n") else ""))
+
+
+def minimize(args: argparse.Namespace) -> int:
+    child_path = Path(args.config).resolve()
+    base_path = Path(args.base).resolve()
+
+    child_cfg_raw = OmegaConf.load(child_path)
+    if not isinstance(child_cfg_raw, DictConfig):
+        raise TypeError(
+            f"Config at {child_path} must be a mapping (DictConfig), got {type(child_cfg_raw)}"
+        )
+    base_cfg_raw = OmegaConf.load(base_path)
+    if not isinstance(base_cfg_raw, DictConfig):
+        raise TypeError(
+            f"Config at {base_path} must be a mapping (DictConfig), got {type(base_cfg_raw)}"
+        )
+
+    # Resolve both before comparison
+    child_resolved = OmegaConf.to_container(child_cfg_raw)
+    base_resolved = OmegaConf.to_container(base_cfg_raw)
+
+    if not isinstance(child_resolved, dict) or not isinstance(base_resolved, dict):
+        raise TypeError("Both child and base configs must be mappings after resolution")
+
+    pruned = _prune_equal(child_resolved, base_resolved)
+
+    # Ensure mapping output
+    if pruned is None or not isinstance(pruned, dict):
+        pruned = {} if pruned is None else {"value": pruned}
+
+    # Ensure defaults reference base (relative path from child)
+    _ensure_defaults_relative(child_path, base_path, pruned)
+
+    # Ensure `defaults` appears first in the top-level mapping
+    if "defaults" in pruned:
+        pruned = {"defaults": pruned["defaults"], **pruned}
+
+    # Emit
+    text = OmegaConf.to_yaml(OmegaConf.create(pruned))
+    if args.in_place:
+        Path(args.config).write_text(text)
+    else:
+        sys.stdout.write(text + ("\n" if not text.endswith("\n") else ""))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Config tools (expand, minimize)")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_expand = sub.add_parser("expand", help="Resolve a config with OmegaConf")
+    p_expand.add_argument("config", help="Path to config YAML")
+    p_expand.add_argument(
+        "--in-place",
+        action="store_true",
+        dest="in_place",
+        help="Edit file in place instead of printing",
+    )
+    p_expand.set_defaults(func=expand)
+
+    p_min = sub.add_parser(
+        "minimize",
+        help="Remove keys equal to base and ensure defaults reference base",
+    )
+    p_min.add_argument("config", help="Child config path")
+    p_min.add_argument("base", help="Base config path")
+    p_min.add_argument(
+        "--in-place",
+        action="store_true",
+        dest="in_place",
+        help="Edit file in place instead of printing",
+    )
+    p_min.set_defaults(func=minimize)
+
+    args = parser.parse_args()
+    args.func(args)

--- a/tools/config_tools.py
+++ b/tools/config_tools.py
@@ -32,14 +32,14 @@ Example:
       base_config=examples/configs/grpo_math_1B.yaml
     fi
     for recipe in examples/configs/recipes/llm/${algo}-*.yaml; do
-      uv run tools/config_tools.py minimize $recipe examples/configs/${algo}.yaml --in-place
+      uv run tools/config_tools.py minimize $recipe $base_config --in-place
     done
   done
 
   # Compare two configs
   uv run tools/config_tools.py compare examples/configs/grpo_math_1B.yaml examples/configs/grpo_math_8B.yaml
 
-  # Minimize a config and compare it to not minimzing (should be the same)
+  # Minimize a config and compare it to not minimzing (may see config differences since you are effectively re-parenting the config)
   uv run tools/config_tools.py minimize examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp2-quick.v2.yaml examples/configs/dpo.yaml >examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp2-quick.v2.yaml.minimized
   uv run tools/config_tools.py compare \
     examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp2-quick.v2.yaml \


### PR DESCRIPTION
Given the recent friction of merging can sometimes come down to config conflicts, this PR introduces a tool to merge configs so you can commit the minimal config necessary for a recipe. There is now a new risk of config changes in the base config propagating to the recipes, especially if the config was not defined and the new default changes the behavior.

For this reason, we need to now keep in mind that if a flag like "enable_eager" was false and no other config overrode it, turning it on would turn it on for all recipes.

Example of how to use the tool:

```sh
  # Expand a config with a root level "defaults" key to see the full config; print to stdout
  uv run tools/config_tools.py expand examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp2-quick.v2.yaml
  # Expand a config with a root level "defaults" key to see the full config; edit the config in place
  uv run tools/config_tools.py expand examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp2-quick.v2.yaml --in-place
  # Minimize a config and remove all keys that are present in the base config; print to stdout
  # uv run tools/config_tools.py minimize <config> <base_config>
  uv run tools/config_tools.py minimize examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp2-quick.v2.yaml examples/configs/dpo.yaml
  # Minimize a config and remove all keys that are present in the base config; edit the config in place
  # uv run tools/config_tools.py minimize <config> <base_config>
  uv run tools/config_tools.py minimize examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp2-quick.v2.yaml examples/configs/dpo.yaml --in-place
  # Minimize all llm the configs:
  for algo in grpo dpo sft; do
    base_config=examples/configs/${algo}.yaml
    if [[ ${algo} == grpo ]]; then
      base_config=examples/configs/grpo_math_1B.yaml
    fi
    for recipe in examples/configs/recipes/llm/${algo}-*.yaml; do
      uv run tools/config_tools.py minimize $recipe $base_config --in-place
    done
  done
  # Compare two configs
  uv run tools/config_tools.py compare examples/configs/grpo_math_1B.yaml examples/configs/grpo_math_8B.yaml
  # Minimize a config and compare it to not minimzing (may see config differences since you are effectively re-parenting the config)
  uv run tools/config_tools.py minimize examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp2-quick.v2.yaml examples/configs/dpo.yaml >examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp2-quick.v2.yaml.minimized
  uv run tools/config_tools.py compare \
    examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp2-quick.v2.yaml \
    examples/configs/recipes/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp2-quick.v2.yaml.minimized
```

Related to #927 