### PR TITLE
ci: Add healthcheck for Github runners to run on a schedule

### DIFF
--- a/.github/workflows/_healthcheck_vm.yml
+++ b/.github/workflows/_healthcheck_vm.yml
@@ -76,7 +76,14 @@ jobs:
         run: |
           if [[ "${{ steps.status.outputs.reboot_needed }}" == "true" ]]; then
             echo "Rebooting VM..."
-            echo ${{ secrets.VM_KEY }} | sudo -S reboot -h now
+            # Add some debug info
+            if [[ -z "${{ secrets.VM_KEY }}" ]]; then
+              echo "ERROR: VM_KEY secret is empty"
+              exit 1
+            fi
+            echo "Scheduling reboot in 30 seconds to allow workflow to complete..."
+            echo '${{ secrets.VM_KEY }}' | sudo -S bash -c 'nohup bash -c "sleep 30 && reboot" > /dev/null 2>&1 &'
+            echo "Reboot scheduled, workflow will continue..."
           fi
 
       - name: Send Slack Alert & Stop Service for Persistent Issues
@@ -98,5 +105,4 @@ jobs:
           curl -X POST -H "Content-type: application/json" --data "$MESSAGE" ${{ secrets.SLACK_RELEASE_ENDPOINT }}
 
           echo "Recheck detected persistent issues - stopping runner service to take VM offline"
-          cd /home/azureuser/actions-runner
-          echo ${{ secrets.VM_KEY }} | sudo -S ./svc.sh stop
+          echo '${{ secrets.VM_KEY }}' | sudo -S bash -c 'cd /home/azureuser/actions-runner && ./svc.sh stop'

--- a/.github/workflows/_healthcheck_vm.yml
+++ b/.github/workflows/_healthcheck_vm.yml
@@ -70,6 +70,19 @@ jobs:
             echo "reboot_needed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Save reboot status to artifact
+        run: |
+          mkdir -p /tmp/healthcheck-results
+          echo "${{ steps.status.outputs.reboot_needed }}" > /tmp/healthcheck-results/${{ inputs.vm }}-reboot-needed.txt
+          echo "${{ steps.status.outputs.main }}" > /tmp/healthcheck-results/${{ inputs.vm }}-status.txt
+
+      - name: Upload healthcheck results
+        uses: actions/upload-artifact@v4
+        with:
+          name: healthcheck-${{ inputs.vm }}
+          path: /tmp/healthcheck-results/
+          retention-days: 1
+
       - name: Take Action on Issues
         if: ${{ (steps.status.outputs.main == 'degraded' || failure()) && inputs.is_recheck != true }}
         continue-on-error: true

--- a/.github/workflows/_healthcheck_vm.yml
+++ b/.github/workflows/_healthcheck_vm.yml
@@ -76,11 +76,8 @@ jobs:
         run: |
           if [[ "${{ steps.status.outputs.reboot_needed }}" == "true" ]]; then
             echo "Rebooting VM..."
-            # Add some debug info
-            if [[ -z "${{ secrets.VM_KEY }}" ]]; then
-              echo "ERROR: VM_KEY secret is empty"
-              exit 1
-            fi
+            echo "Disconnecting runner from GitHub Actions..."
+            echo '${{ secrets.VM_KEY }}' | sudo -S bash -c 'cd /home/azureuser/actions-runner && ./svc.sh stop'
             echo "Scheduling reboot in 30 seconds to allow workflow to complete..."
             echo '${{ secrets.VM_KEY }}' | sudo -S bash -c 'nohup bash -c "sleep 30 && reboot" > /dev/null 2>&1 &'
             echo "Reboot scheduled, workflow will continue..."

--- a/.github/workflows/_healthcheck_vm.yml
+++ b/.github/workflows/_healthcheck_vm.yml
@@ -66,8 +66,8 @@ jobs:
             echo "reboot_needed=true" >> "$GITHUB_OUTPUT"
           else
             echo "✅ VM ${{ inputs.vm }} is healthy - found $NUM_GPUS/${{ inputs.n_gpus }} GPUs"
-            echo "main=degraded" >> "$GITHUB_OUTPUT"
-            echo "reboot_needed=true" >> "$GITHUB_OUTPUT"
+            echo "main=healthy" >> "$GITHUB_OUTPUT"
+            echo "reboot_needed=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Save reboot status to artifact

--- a/.github/workflows/_healthcheck_vm.yml
+++ b/.github/workflows/_healthcheck_vm.yml
@@ -33,7 +33,7 @@ on:
       SLACK_WEBHOOK_ADMIN:
         description: Slack webhook admin identifier
         required: true
-      SLACK_RELEASE_ENDPOINT:
+      SLACK_GITHUB_CI_WEBHOOK:
         description: Slack webhook URL for notifications
         required: true
       VM_KEY:
@@ -71,14 +71,14 @@ jobs:
           fi
 
       - name: Save reboot status to artifact
-        if: ${{ always() }}
+        if: ${{ inputs.is_recheck != true }}
         run: |
           mkdir -p /tmp/healthcheck-results
           echo "${{ steps.status.outputs.reboot_needed }}" > /tmp/healthcheck-results/${{ inputs.vm }}-reboot-needed.txt
           echo "${{ steps.status.outputs.main }}" > /tmp/healthcheck-results/${{ inputs.vm }}-status.txt
 
       - name: Upload healthcheck results
-        if: ${{ always() }}
+        if: ${{ inputs.is_recheck != true }}
         uses: actions/upload-artifact@v4
         with:
           name: healthcheck-${{ inputs.vm }}
@@ -112,7 +112,7 @@ jobs:
             ]
           }'
 
-          curl -X POST -H "Content-type: application/json" --data "$MESSAGE" ${{ secrets.SLACK_RELEASE_ENDPOINT }}
+          curl -X POST -H "Content-type: application/json" --data "$MESSAGE" ${{ secrets.SLACK_GITHUB_CI_WEBHOOK }}
 
           echo "Recheck detected persistent issues - stopping runner service to take VM offline"
           echo '${{ secrets.VM_KEY }}' | sudo -S bash -c 'sleep 30 && cd /home/azureuser/actions-runner && ./svc.sh stop'

--- a/.github/workflows/_healthcheck_vm.yml
+++ b/.github/workflows/_healthcheck_vm.yml
@@ -71,12 +71,14 @@ jobs:
           fi
 
       - name: Save reboot status to artifact
+        if: ${{ always() }}
         run: |
           mkdir -p /tmp/healthcheck-results
           echo "${{ steps.status.outputs.reboot_needed }}" > /tmp/healthcheck-results/${{ inputs.vm }}-reboot-needed.txt
           echo "${{ steps.status.outputs.main }}" > /tmp/healthcheck-results/${{ inputs.vm }}-status.txt
 
       - name: Upload healthcheck results
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: healthcheck-${{ inputs.vm }}

--- a/.github/workflows/_healthcheck_vm.yml
+++ b/.github/workflows/_healthcheck_vm.yml
@@ -115,4 +115,4 @@ jobs:
           curl -X POST -H "Content-type: application/json" --data "$MESSAGE" ${{ secrets.SLACK_GITHUB_CI_WEBHOOK }}
 
           echo "Recheck detected persistent issues - stopping runner service to take VM offline"
-          echo '${{ secrets.VM_KEY }}' | sudo -S bash -c 'sleep 30 && cd /home/azureuser/actions-runner && ./svc.sh stop'
+          echo '${{ secrets.VM_KEY }}' | sudo -S bash -c 'nohup bash -c "sleep 30 && cd /home/azureuser/actions-runner && ./svc.sh stop" > /dev/null 2>&1 &'

--- a/.github/workflows/_healthcheck_vm.yml
+++ b/.github/workflows/_healthcheck_vm.yml
@@ -1,0 +1,102 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: ~monitor a single VM
+
+on:
+  workflow_call:
+    inputs:
+      vm:
+        type: string
+        description: Name of VM
+        required: true
+      n_gpus:
+        type: string
+        description: Number of GPUs this VM has
+        required: true
+      is_recheck:
+        type: boolean
+        description: Whether this is a recheck after reboot
+        required: false
+        default: false
+    secrets:
+      SLACK_WEBHOOK_ADMIN:
+        description: Slack webhook admin identifier
+        required: true
+      SLACK_RELEASE_ENDPOINT:
+        description: Slack webhook URL for notifications
+        required: true
+      VM_KEY:
+        description: VM user credentials
+        required: true
+      PAT:
+        description: GitHub Personal Access Token
+        required: true
+
+jobs:
+  check-status-and-maybe-shutdown:
+    environment: main
+    runs-on: ${{ inputs.vm }}
+    outputs:
+      status: ${{ steps.status.outputs.main }}
+      reboot_needed: ${{ steps.status.outputs.reboot_needed }}
+    steps:
+      - name: Check status
+        id: status
+        run: |
+          echo "🔍 Running health check on VM ${{ inputs.vm }}"
+
+          docker run --rm --runtime=nvidia --gpus ${{ inputs.n_gpus }} ubuntu nvidia-smi
+
+          NUM_GPUS=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
+
+          if [[ $NUM_GPUS -ne ${{ inputs.n_gpus }} ]]; then
+            echo "Issues with GPU detected"
+            echo "main=degraded" >> "$GITHUB_OUTPUT"
+            echo "reboot_needed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "✅ VM ${{ inputs.vm }} is healthy - found $NUM_GPUS/${{ inputs.n_gpus }} GPUs"
+            echo "main=healthy" >> "$GITHUB_OUTPUT"
+            echo "reboot_needed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Take Action on Issues
+        if: ${{ (steps.status.outputs.main == 'degraded' || failure()) && inputs.is_recheck != true }}
+        continue-on-error: true
+        run: |
+          if [[ "${{ steps.status.outputs.reboot_needed }}" == "true" ]]; then
+            echo "Rebooting VM..."
+            echo ${{ secrets.VM_KEY }} | sudo -S reboot -h now
+          fi
+
+      - name: Send Slack Alert & Stop Service for Persistent Issues
+        if: ${{ (steps.status.outputs.main == 'degraded' || failure()) && inputs.is_recheck == true }}
+        continue-on-error: true
+        run: |
+          MESSAGE='{
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": ":alert: VM bot 🤖: Hey <!subteam^${{ secrets.SLACK_WEBHOOK_ADMIN }}>: VM `${{ inputs.vm }}` still has issues after reboot - stopping service and needs manual intervention."
+                }
+              }
+            ]
+          }'
+
+          curl -X POST -H "Content-type: application/json" --data "$MESSAGE" ${{ secrets.SLACK_RELEASE_ENDPOINT }}
+
+          echo "Recheck detected persistent issues - stopping runner service to take VM offline"
+          cd /home/azureuser/actions-runner
+          echo ${{ secrets.VM_KEY }} | sudo -S ./svc.sh stop

--- a/.github/workflows/_healthcheck_vm.yml
+++ b/.github/workflows/_healthcheck_vm.yml
@@ -76,10 +76,8 @@ jobs:
         run: |
           if [[ "${{ steps.status.outputs.reboot_needed }}" == "true" ]]; then
             echo "Rebooting VM..."
-            echo "Disconnecting runner from GitHub Actions..."
-            echo '${{ secrets.VM_KEY }}' | sudo -S bash -c 'cd /home/azureuser/actions-runner && ./svc.sh stop'
             echo "Scheduling reboot in 30 seconds to allow workflow to complete..."
-            echo '${{ secrets.VM_KEY }}' | sudo -S bash -c 'nohup bash -c "sleep 30 && reboot" > /dev/null 2>&1 &'
+            echo '${{ secrets.VM_KEY }}' | sudo -S bash -c 'nohup bash -c "sleep 30 && cd /home/azureuser/actions-runner && ./svc.sh stop && reboot" > /dev/null 2>&1 &'
             echo "Reboot scheduled, workflow will continue..."
           fi
 

--- a/.github/workflows/_healthcheck_vm.yml
+++ b/.github/workflows/_healthcheck_vm.yml
@@ -77,7 +77,7 @@ jobs:
           if [[ "${{ steps.status.outputs.reboot_needed }}" == "true" ]]; then
             echo "Rebooting VM..."
             echo "Scheduling reboot in 30 seconds to allow workflow to complete..."
-            echo '${{ secrets.VM_KEY }}' | sudo -S bash -c 'nohup bash -c "sleep 30 && cd /home/azureuser/actions-runner && ./svc.sh stop && reboot" > /dev/null 2>&1 &'
+            echo '${{ secrets.VM_KEY }}' | sudo -S bash -c 'nohup bash -c "sleep 30 && cd /home/azureuser/actions-runner && ./svc.sh stop && sleep 30 && reboot" > /dev/null 2>&1 &'
             echo "Reboot scheduled, workflow will continue..."
           fi
 
@@ -100,4 +100,4 @@ jobs:
           curl -X POST -H "Content-type: application/json" --data "$MESSAGE" ${{ secrets.SLACK_RELEASE_ENDPOINT }}
 
           echo "Recheck detected persistent issues - stopping runner service to take VM offline"
-          echo '${{ secrets.VM_KEY }}' | sudo -S bash -c 'cd /home/azureuser/actions-runner && ./svc.sh stop'
+          echo '${{ secrets.VM_KEY }}' | sudo -S bash -c 'sleep 30 && cd /home/azureuser/actions-runner && ./svc.sh stop'

--- a/.github/workflows/_healthcheck_vm.yml
+++ b/.github/workflows/_healthcheck_vm.yml
@@ -66,8 +66,8 @@ jobs:
             echo "reboot_needed=true" >> "$GITHUB_OUTPUT"
           else
             echo "✅ VM ${{ inputs.vm }} is healthy - found $NUM_GPUS/${{ inputs.n_gpus }} GPUs"
-            echo "main=healthy" >> "$GITHUB_OUTPUT"
-            echo "reboot_needed=false" >> "$GITHUB_OUTPUT"
+            echo "main=degraded" >> "$GITHUB_OUTPUT"
+            echo "reboot_needed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Take Action on Issues

--- a/.github/workflows/healthcheck_vms.yml
+++ b/.github/workflows/healthcheck_vms.yml
@@ -40,6 +40,7 @@ jobs:
     needs: healthcheck
     if: ${{ always() }}
     runs-on: ubuntu-latest
+    environment: main
     outputs:
       has_offline: ${{ steps.check.outputs.has_offline }}
     steps:

--- a/.github/workflows/healthcheck_vms.yml
+++ b/.github/workflows/healthcheck_vms.yml
@@ -85,7 +85,7 @@ jobs:
     uses: ./.github/workflows/_healthcheck_vm.yml
     with:
       vm: ${{ matrix.vm }}
-      n_gpus: ${{ matrix.n_gpus }}
+      n_gpus: "2"
       is_recheck: true
     secrets:
       SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}

--- a/.github/workflows/healthcheck_vms.yml
+++ b/.github/workflows/healthcheck_vms.yml
@@ -1,7 +1,21 @@
-# Regularly updates the CI container
-name: Reboots VMs in a controlled way
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: VM Health Check and Reboot
 on:
-  push:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
 
 jobs:
   pre-flight:

--- a/.github/workflows/healthcheck_vms.yml
+++ b/.github/workflows/healthcheck_vms.yml
@@ -1,0 +1,112 @@
+# Regularly updates the CI container
+name: Reboots VMs in a controlled way
+on:
+  push:
+
+jobs:
+  pre-flight:
+    runs-on: ubuntu-latest
+    outputs:
+      list-of-vms: ${{ steps.main.outputs.main }}
+    environment: main
+    steps:
+      - name: Get list of VMs
+        id: main
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+        run: |
+          RUNNERS=$(curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            ${{ github.api_url }}/repos/${{ github.repository }}/actions/runners)
+
+          MATRIX=$(echo $RUNNERS \
+            | jq -c '[
+                .runners[]
+                | select(.status == "online")
+                | select(.name | contains("cpu") | not)
+                | {
+                  "vm": .name,
+                  "n_gpus": [
+                    .labels[]
+                    | select(.name | endswith("gpu")) | .name
+                  ][0][:1]
+                }
+              ]
+            '
+          )
+          echo main=$MATRIX | tee -a "$GITHUB_OUTPUT"
+
+  healthcheck:
+    needs: pre-flight
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.pre-flight.outputs.list-of-vms )}}
+    uses: ./.github/workflows/_healthcheck_vm.yml
+    with:
+      vm: ${{ matrix.vm }}
+      n_gpus: ${{ matrix.n_gpus }}
+    secrets:
+      SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}
+      SLACK_RELEASE_ENDPOINT: ${{ secrets.SLACK_RELEASE_ENDPOINT }}
+      VM_KEY: ${{ secrets.VM_KEY }}
+      PAT: ${{ secrets.PAT }}
+
+  check-offline-runners:
+    needs: healthcheck
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    outputs:
+      has_offline: ${{ steps.check.outputs.has_offline }}
+    steps:
+      - name: Check if any runners are offline
+        id: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+        run: |
+          RUNNERS=$(curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            ${{ github.api_url }}/repos/${{ github.repository }}/actions/runners)
+
+          OFFLINE_COUNT=$(echo $RUNNERS | jq '[.runners[] | select(.status == "offline")] | length')
+
+          if [[ $OFFLINE_COUNT -gt 0 ]]; then
+            echo "Found $OFFLINE_COUNT offline runners"
+            echo "has_offline=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "All runners are online"
+            echo "has_offline=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  wait-for-reboot:
+    needs: check-offline-runners
+    if: ${{ needs.check-offline-runners.outputs.has_offline == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for VMs to come back online
+        run: |
+          WAIT_MINUTES=5
+          echo "Waiting ${WAIT_MINUTES} minutes for rebooted VMs to come back online..."
+          sleep $((WAIT_MINUTES * 60))
+
+  recheck:
+    needs: wait-for-reboot
+    if: ${{ always() && needs.wait-for-reboot.result == 'success' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.pre-flight.outputs.list-of-vms )}}
+    uses: ./.github/workflows/_healthcheck_vm.yml
+    with:
+      vm: ${{ matrix.vm }}
+      n_gpus: ${{ matrix.n_gpus }}
+      is_recheck: true
+    secrets:
+      SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}
+      SLACK_RELEASE_ENDPOINT: ${{ secrets.SLACK_RELEASE_ENDPOINT }}
+      VM_KEY: ${{ secrets.VM_KEY }}
+      PAT: ${{ secrets.PAT }}

--- a/.github/workflows/healthcheck_vms.yml
+++ b/.github/workflows/healthcheck_vms.yml
@@ -79,7 +79,7 @@ jobs:
           sleep $((WAIT_MINUTES * 60))
 
   recheck:
-    needs: [preflight, wait-for-reboot]
+    needs: [pre-flight, wait-for-reboot]
     if: ${{ always() && needs.wait-for-reboot.result == 'success' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/healthcheck_vms.yml
+++ b/.github/workflows/healthcheck_vms.yml
@@ -79,7 +79,7 @@ jobs:
           sleep $((WAIT_MINUTES * 60))
 
   recheck:
-    needs: wait-for-reboot
+    needs: [preflight, wait-for-reboot]
     if: ${{ always() && needs.wait-for-reboot.result == 'success' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/healthcheck_vms.yml
+++ b/.github/workflows/healthcheck_vms.yml
@@ -36,45 +36,65 @@ jobs:
       VM_KEY: ${{ secrets.VM_KEY }}
       PAT: ${{ secrets.PAT }}
 
-  check-offline-runners:
-    needs: healthcheck
+  check-reboots-needed:
+    needs: [pre-flight, healthcheck]
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    environment: main
     outputs:
-      has_offline: ${{ steps.check.outputs.has_offline }}
+      has_reboots: ${{ steps.check-artifacts.outputs.has_reboots }}
     steps:
-      - name: Check if any runners are offline
-        id: check
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
-        run: |
-          echo "Waiting 60 seconds for runners to reboot if necessary..."
-          sleep 60
-          echo "Fetching runners from GitHub API..."
-          RUNNERS=$(curl -L \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $GITHUB_TOKEN" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            ${{ github.api_url }}/repos/${{ github.repository }}/actions/runners)
+      - name: Download all healthcheck artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: healthcheck-*
+          path: ./healthcheck-results/
+          merge-multiple: true
 
-          OFFLINE_COUNT=$(echo "$RUNNERS" | jq -r '[.runners[]? | select(.status == "offline")] | length')
-          if [[ $OFFLINE_COUNT -gt 0 ]]; then
-            echo "Found $OFFLINE_COUNT offline runners"
-            echo "has_offline=true" >> "$GITHUB_OUTPUT"
+      - name: Check if any VMs needed reboots
+        id: check-artifacts
+        env:
+          VM_LIST: ${{ needs.pre-flight.outputs.list-of-vms }}
+        run: |
+          echo "Checking healthcheck artifacts for reboot status..."
+          HAS_REBOOTS=false
+
+          # Create a list of VMs to check
+          VM_NAMES=$(echo "$VM_LIST" | jq -r '.[] | .vm')
+
+          # Check each VM's artifact
+          for VM in $VM_NAMES; do
+            echo "Checking reboot status for VM: $VM"
+
+            REBOOT_FILE="./healthcheck-results/${VM}-reboot-needed.txt"
+            if [[ -f "$REBOOT_FILE" ]]; then
+              REBOOT_NEEDED=$(cat "$REBOOT_FILE")
+              echo "VM $VM reboot needed: $REBOOT_NEEDED"
+
+              if [[ "$REBOOT_NEEDED" == "true" ]]; then
+                echo "VM $VM needs/needed a reboot"
+                HAS_REBOOTS=true
+              fi
+            else
+              echo "WARNING: No artifact found for VM $VM"
+            fi
+          done
+
+          if [[ "$HAS_REBOOTS" == "true" ]]; then
+            echo "At least one VM was rebooted"
+            echo "has_reboots=true" >> "$GITHUB_OUTPUT"
           else
-            echo "All runners are online (checked $OFFLINE_COUNT offline)"
-            echo "has_offline=false" >> "$GITHUB_OUTPUT"
+            echo "No VMs were rebooted"
+            echo "has_reboots=false" >> "$GITHUB_OUTPUT"
           fi
 
   wait-for-reboot:
-    needs: check-offline-runners
-    if: ${{ needs.check-offline-runners.outputs.has_offline == 'true' }}
+    needs: check-reboots-needed
+    if: ${{ needs.check-reboots-needed.outputs.has_reboots == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Wait for VMs to come back online
         run: |
-          WAIT_MINUTES=5
+          WAIT_MINUTES=3
           echo "Waiting ${WAIT_MINUTES} minutes for rebooted VMs to come back online..."
           sleep $((WAIT_MINUTES * 60))
 

--- a/.github/workflows/healthcheck_vms.yml
+++ b/.github/workflows/healthcheck_vms.yml
@@ -27,11 +27,7 @@ jobs:
                 | select(.status == "online")
                 | select(.name | contains("cpu") | not)
                 | {
-                  "vm": .name,
-                  "n_gpus": [
-                    .labels[]
-                    | select(.name | endswith("gpu")) | .name
-                  ][0][:1]
+                  "vm": .name
                 }
               ]
             '
@@ -47,7 +43,7 @@ jobs:
     uses: ./.github/workflows/_healthcheck_vm.yml
     with:
       vm: ${{ matrix.vm }}
-      n_gpus: ${{ matrix.n_gpus }}
+      n_gpus: "2"
     secrets:
       SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}
       SLACK_RELEASE_ENDPOINT: ${{ secrets.SLACK_RELEASE_ENDPOINT }}
@@ -94,7 +90,7 @@ jobs:
           sleep $((WAIT_MINUTES * 60))
 
   recheck:
-    needs: wait-for-reboot
+    needs: [pre-flight, wait-for-reboot]
     if: ${{ always() && needs.wait-for-reboot.result == 'success' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/healthcheck_vms.yml
+++ b/.github/workflows/healthcheck_vms.yml
@@ -49,8 +49,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
         run: |
-          echo "Waiting 30 seconds for runners to reboot if necessary..."
-          sleep 30
+          echo "Waiting 60 seconds for runners to reboot if necessary..."
+          sleep 60
           echo "Fetching runners from GitHub API..."
           RUNNERS=$(curl -L \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/healthcheck_vms.yml
+++ b/.github/workflows/healthcheck_vms.yml
@@ -15,9 +15,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
         run: |
-          # Hardcoded for testing purposes
-          MATRIX='[{"vm": "azure-gpu-vm-runner2"}]'
-          echo "Using hardcoded test runner: $MATRIX"
+          RUNNERS=$(curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            ${{ github.api_url }}/repos/${{ github.repository }}/actions/runners)
+
+          MATRIX=$(echo $RUNNERS \
+            | jq -c '[
+                .runners[]
+                | select(.status == "online")
+                | select(.name | contains("cpu") | not)
+                | {
+                  "vm": .name
+                }
+              ]
+            '
+          )
           echo main=$MATRIX | tee -a "$GITHUB_OUTPUT"
 
   healthcheck:

--- a/.github/workflows/healthcheck_vms.yml
+++ b/.github/workflows/healthcheck_vms.yml
@@ -49,6 +49,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
         run: |
+          echo "Waiting 30 seconds for runners to reboot if necessary..."
+          sleep 30
           echo "Fetching runners from GitHub API..."
           RUNNERS=$(curl -L \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/healthcheck_vms.yml
+++ b/.github/workflows/healthcheck_vms.yml
@@ -48,19 +48,39 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
         run: |
+          # Debug: Check if token is available
+          if [[ -z "$GITHUB_TOKEN" ]]; then
+            echo "ERROR: GITHUB_TOKEN is empty - PAT secret may not be configured"
+            exit 1
+          fi
+
+          echo "Fetching runners from GitHub API..."
           RUNNERS=$(curl -L \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             ${{ github.api_url }}/repos/${{ github.repository }}/actions/runners)
 
-          OFFLINE_COUNT=$(echo $RUNNERS | jq '[.runners[] | select(.status == "offline")] | length')
+          # Debug: Check API response
+          if [[ -z "$RUNNERS" || "$RUNNERS" == "null" ]]; then
+            echo "ERROR: API response is empty or null"
+            echo "Response: $RUNNERS"
+            exit 1
+          fi
+
+          echo "API response received, checking for offline runners..."
+          OFFLINE_COUNT=$(echo "$RUNNERS" | jq -r '[.runners[]? | select(.status == "offline")] | length')
+
+          if [[ "$OFFLINE_COUNT" == "null" || -z "$OFFLINE_COUNT" ]]; then
+            echo "WARNING: Could not parse offline count, assuming no offline runners"
+            OFFLINE_COUNT=0
+          fi
 
           if [[ $OFFLINE_COUNT -gt 0 ]]; then
             echo "Found $OFFLINE_COUNT offline runners"
             echo "has_offline=true" >> "$GITHUB_OUTPUT"
           else
-            echo "All runners are online"
+            echo "All runners are online (checked $OFFLINE_COUNT offline)"
             echo "has_offline=false" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/healthcheck_vms.yml
+++ b/.github/workflows/healthcheck_vms.yml
@@ -15,23 +15,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
         run: |
-          RUNNERS=$(curl -L \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $GITHUB_TOKEN" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            ${{ github.api_url }}/repos/${{ github.repository }}/actions/runners)
-
-          MATRIX=$(echo $RUNNERS \
-            | jq -c '[
-                .runners[]
-                | select(.status == "online")
-                | select(.name | contains("cpu") | not)
-                | {
-                  "vm": .name
-                }
-              ]
-            '
-          )
+          # Hardcoded for testing purposes
+          MATRIX='[{"vm": "azure-gpu-vm-runner2"}]'
+          echo "Using hardcoded test runner: $MATRIX"
           echo main=$MATRIX | tee -a "$GITHUB_OUTPUT"
 
   healthcheck:

--- a/.github/workflows/healthcheck_vms.yml
+++ b/.github/workflows/healthcheck_vms.yml
@@ -49,12 +49,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
         run: |
-          # Debug: Check if token is available
-          if [[ -z "$GITHUB_TOKEN" ]]; then
-            echo "ERROR: GITHUB_TOKEN is empty - PAT secret may not be configured"
-            exit 1
-          fi
-
           echo "Fetching runners from GitHub API..."
           RUNNERS=$(curl -L \
             -H "Accept: application/vnd.github+json" \
@@ -62,21 +56,7 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             ${{ github.api_url }}/repos/${{ github.repository }}/actions/runners)
 
-          # Debug: Check API response
-          if [[ -z "$RUNNERS" || "$RUNNERS" == "null" ]]; then
-            echo "ERROR: API response is empty or null"
-            echo "Response: $RUNNERS"
-            exit 1
-          fi
-
-          echo "API response received, checking for offline runners..."
           OFFLINE_COUNT=$(echo "$RUNNERS" | jq -r '[.runners[]? | select(.status == "offline")] | length')
-
-          if [[ "$OFFLINE_COUNT" == "null" || -z "$OFFLINE_COUNT" ]]; then
-            echo "WARNING: Could not parse offline count, assuming no offline runners"
-            OFFLINE_COUNT=0
-          fi
-
           if [[ $OFFLINE_COUNT -gt 0 ]]; then
             echo "Found $OFFLINE_COUNT offline runners"
             echo "has_offline=true" >> "$GITHUB_OUTPUT"
@@ -97,7 +77,7 @@ jobs:
           sleep $((WAIT_MINUTES * 60))
 
   recheck:
-    needs: [pre-flight, wait-for-reboot]
+    needs: wait-for-reboot
     if: ${{ always() && needs.wait-for-reboot.result == 'success' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/healthcheck_vms.yml
+++ b/.github/workflows/healthcheck_vms.yml
@@ -32,7 +32,7 @@ jobs:
       n_gpus: "2"
     secrets:
       SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}
-      SLACK_RELEASE_ENDPOINT: ${{ secrets.SLACK_RELEASE_ENDPOINT }}
+      SLACK_GITHUB_CI_WEBHOOK: ${{ secrets.SLACK_GITHUB_CI_WEBHOOK }}
       VM_KEY: ${{ secrets.VM_KEY }}
       PAT: ${{ secrets.PAT }}
 
@@ -112,6 +112,6 @@ jobs:
       is_recheck: true
     secrets:
       SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}
-      SLACK_RELEASE_ENDPOINT: ${{ secrets.SLACK_RELEASE_ENDPOINT }}
+      SLACK_GITHUB_CI_WEBHOOK: ${{ secrets.SLACK_GITHUB_CI_WEBHOOK }}
       VM_KEY: ${{ secrets.VM_KEY }}
       PAT: ${{ secrets.PAT }}


### PR DESCRIPTION
# What does this PR do ?

* Add healthcheck for Github runners to run on a schedule (7 a.m. UTC)
* Checks number of gpus and reboots if gpus less than expected
* Re-runs health check if rebooted

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
