### PR TITLE
fix: Pass sequence_parallel in import_model_from_hf_name

### DIFF
--- a/nemo_rl/models/megatron/community_import.py
+++ b/nemo_rl/models/megatron/community_import.py
@@ -55,6 +55,7 @@ def import_model_from_hf_name(
         model_provider.num_layers_in_last_pipeline_stage = megatron_config[
             "num_layers_in_last_pipeline_stage"
         ]
+        model_provider.sequence_parallel = megatron_config["sequence_parallel"]
         model_provider.pipeline_dtype = megatron_config["pipeline_dtype"]
     model_provider.initialize_model_parallel(seed=0)
     megatron_model = model_provider.provide_distributed_model(wrap_with_ddp=False)


### PR DESCRIPTION
# What does this PR do ?

Fixes https://github.com/NVIDIA-NeMo/RL/issues/1060 by directly passing `sequence_parallel` - without it, the default `false` can break validation based on the parallelisation setting. 

# Issues
Closes https://github.com/NVIDIA-NeMo/RL/issues/1060

# Additional Information
This fixes the specific issue following the current pattern (a. below), but there may be a more comprehensive pattern (e.g. b. or c. below). I have not followed through with these as I don't know the implications of potentially continuing a previous checkpoint with a different cluster/distributed setup. 

a. add `sequence_parallel` override to [import_model_from_hf_name](https://github.com/NVIDIA-NeMo/RL/blob/13b4ca5a9b396dc5a8c82eee9c0c1c7df6c81736/nemo_rl/models/megatron/community_import.py#L57)
b. add more complex merge logic to the above to automatically merge the user's megatron config
c. in [MegatronPolicyWorker](https://github.com/NVIDIA-NeMo/RL/blob/13b4ca5a9b396dc5a8c82eee9c0c1c7df6c81736/nemo_rl/models/policy/megatron_policy_worker.py#L523), load `pretrained_run_config` as a dict first, then pass through all manual updates, then validate in strict mode using `from_dict` rather than `from_yaml`.