### PR TITLE
fix: optional clear cache between microbatch iterations

### DIFF
--- a/examples/configs/dpo.yaml
+++ b/examples/configs/dpo.yaml
@@ -54,6 +54,7 @@ policy:
     tensor_parallel_size: 1
     context_parallel_size: 1
     custom_parallel_plan: null
+    clear_cache_every_n_steps: null
 
   dynamic_batching:
     enabled: false

--- a/examples/configs/recipes/llm/dpo-mistral-nemo-instruct-2407-1n8g-fsdp2tp8-actckpt-long.yaml
+++ b/examples/configs/recipes/llm/dpo-mistral-nemo-instruct-2407-1n8g-fsdp2tp8-actckpt-long.yaml
@@ -49,6 +49,7 @@ policy:
     tensor_parallel_size: 8
     context_parallel_size: 1
     custom_parallel_plan: null
+    clear_cache_every_n_steps: 1
     env_vars:
       PYTORCH_CUDA_ALLOC_CONF: "max_split_size_mb:64"
 

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -27,6 +27,7 @@ class DTensorConfig(TypedDict):
     tensor_parallel_size: NotRequired[int]
     context_parallel_size: NotRequired[int]
     custom_parallel_plan: NotRequired[str]
+    clear_cache_every_n_steps: NotRequired[int]
 
 
 class SequencePackingConfig(TypedDict):

--- a/nemo_rl/models/policy/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker.py
@@ -630,9 +630,13 @@ class DTensorPolicyWorker:
                     mb_iterator = batch.make_microbatch_iterator(mbs)
                     iterator_len = batch.size // mbs
 
-                empty_cache_steps = self.cfg.get("dtensor_cfg", {}).get("empty_cache_every_n_steps")
+                empty_cache_steps = self.cfg.get("dtensor_cfg", {}).get(
+                    "empty_cache_every_n_steps"
+                )
                 if empty_cache_steps:
-                    warnings.warn(f"Emptying cache every {empty_cache_steps} microbatches, doing so unnnecessarily would incur a large performance overhead.")
+                    warnings.warn(
+                        f"Emptying cache every {empty_cache_steps} microbatches, doing so unnnecessarily would incur a large performance overhead."
+                    )
 
                 for mb_idx, mb in enumerate(
                     itertools.chain(mb_iterator, dummy_iterator)

--- a/nemo_rl/models/policy/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker.py
@@ -16,6 +16,7 @@ import contextlib
 import gc
 import itertools
 import os
+import warnings
 from collections import defaultdict
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from typing import Any, Generator, Iterable, Optional, Set, Union, cast
@@ -629,10 +630,16 @@ class DTensorPolicyWorker:
                     mb_iterator = batch.make_microbatch_iterator(mbs)
                     iterator_len = batch.size // mbs
 
+                empty_cache_steps = self.cfg.get("dtensor_cfg", {}).get("empty_cache_every_n_steps")
+                if empty_cache_steps:
+                    warnings.warn(f"Emptying cache every {empty_cache_steps} microbatches, doing so unnnecessarily would incur a large performance overhead.")
+
                 for mb_idx, mb in enumerate(
                     itertools.chain(mb_iterator, dummy_iterator)
                 ):
-                    torch.cuda.empty_cache()
+                    # Conditioanlly empty cache when sensitive to fragmentation
+                    if empty_cache_steps and mb_idx % empty_cache_steps == 0:
+                        torch.cuda.empty_cache()
 
                     with torch.autocast(device_type="cuda", dtype=self.dtype):
                         if self.enable_seq_packing:

--- a/nemo_rl/models/policy/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker_v2.py
@@ -558,14 +558,17 @@ class DTensorPolicyWorkerV2:
                     mb_iterator = batch.make_microbatch_iterator(mbs)
                     iterator_len = batch.size // mbs
 
-                empty_cache_steps = self.cfg.get("dtensor_cfg", {}).get("empty_cache_every_n_steps")
+                empty_cache_steps = self.cfg.get("dtensor_cfg", {}).get(
+                    "empty_cache_every_n_steps"
+                )
                 if empty_cache_steps:
-                    warnings.warn(f"Emptying cache every {empty_cache_steps} microbatches, doing so unnnecessarily would incur a large performance overhead.")
+                    warnings.warn(
+                        f"Emptying cache every {empty_cache_steps} microbatches, doing so unnnecessarily would incur a large performance overhead."
+                    )
 
                 for mb_idx, mb in enumerate(
                     itertools.chain(mb_iterator, dummy_iterator)
                 ):
-
                     # Conditioanlly empty cache when sensitive to fragmentation
                     if empty_cache_steps and mb_idx % empty_cache_steps == 0:
                         torch.cuda.empty_cache()

--- a/nemo_rl/models/policy/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker_v2.py
@@ -15,6 +15,7 @@
 import gc
 import itertools
 import os
+import warnings
 from collections import defaultdict
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from typing import Any, Generator, Iterable, Optional, cast
@@ -557,10 +558,17 @@ class DTensorPolicyWorkerV2:
                     mb_iterator = batch.make_microbatch_iterator(mbs)
                     iterator_len = batch.size // mbs
 
+                empty_cache_steps = self.cfg.get("dtensor_cfg", {}).get("empty_cache_every_n_steps")
+                if empty_cache_steps:
+                    warnings.warn(f"Emptying cache every {empty_cache_steps} microbatches, doing so unnnecessarily would incur a large performance overhead.")
+
                 for mb_idx, mb in enumerate(
                     itertools.chain(mb_iterator, dummy_iterator)
                 ):
-                    torch.cuda.empty_cache()
+
+                    # Conditioanlly empty cache when sensitive to fragmentation
+                    if empty_cache_steps and mb_idx % empty_cache_steps == 0:
+                        torch.cuda.empty_cache()
 
                     with torch.autocast(device_type="cuda", dtype=self.dtype):
                         if self.enable_seq_packing:


### PR DESCRIPTION
# What does this PR do ?

Help mitigate the performance overheads from clearing cache which is introduced in #926 by making clear cache behaviour optional. 

# Issues

This PR resolves #1036. 

# Usage

This PR introduces an additional option for `dtensor_config`. To clear cache between microbatch iterations, add:
```yaml
policy:
    dtensor_cfg:
        # .....
        clear_cache_every_n_steps: 1
```

A warning will be displayed before a training iteration indicating that clear cache has been turned on and its potential performance overheads. 

```
(DTensorPolicyWorker[rank=0] pid=3016383) /lustre/fs1/portfolios/coreai/users/yubog/RL/nemo_rl/models/policy/dtensor_policy_worker.py:635: UserWarning: Emptying cache every 1 microbatches
, doing so unnnecessarily would incur a large performance overhead.
(DTensorPolicyWorker[rank=0] pid=3016383)   warnings.warn(f"Emptying cache every {empty_cache_steps} microbatches, doing so unnnecessarily would incur a large performance overhead.")
```

Below is the speed comparison of the default SFT experiment with clear cache every 1 microbatch vs. no clear cache:
<img width="754" height="315" alt="image" src="https://github.com/user-attachments/assets/15958a74-c61e-40f9-b3fb-6d496d9b5d11" />


# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
