### PR TITLE
fix: Add the sequence parallel override to fix moe model loading in mcore path

### DIFF
--- a/nemo_rl/models/megatron/community_import.py
+++ b/nemo_rl/models/megatron/community_import.py
@@ -43,6 +43,7 @@ def import_model_from_hf_name(
         model_provider.pipeline_model_parallel_size = megatron_config[
             "pipeline_model_parallel_size"
         ]
+        model_provider.sequence_parallel = megatron_config["sequence_parallel"]
         model_provider.expert_model_parallel_size = megatron_config[
             "expert_model_parallel_size"
         ]


### PR DESCRIPTION
# What does this PR do ?

This PR fixes the issue with both tensor parallelism and expert parallelism, MoE model loading through megatron.bridge does not work:

```
megatron.bridge.utils.instantiate_utils.InstantiationException: Error in call to target 'megatron.bridge.models.qwen.qwen_provider.Qwen3MoEModelProvider': [repeated 7x across cluster]
ValueError('When using expert parallelism and tensor parallelism, sequence parallelism must be used') [repeated 7x across cluster]
```

It is because `sequence_parallel` is not correctly set when the worker overrides tp/pp stuff. It happens for configurations like `examples/configs/grpo_math_qwen30ba3b_megatron.yaml`

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

The original error should look like this:
```bash
"nemo_rl/models/policy/megatron_policy_worker.py", line 520, in __init__
model_cfg.tensor_model_parallel_size = self.cfg["megatron_cfg"][
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'tensor_model_parallel_size'
WARNING:root:Error instantiating None for key .model. Using None instead in lenient mode.
```

Basically it means the model is not loaded successfully. And @yaoyu-33 suggested commenting out the try block here  to show the real error.

https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/92955f30e567212bccfc857bbcd2615bbb8bffcf/src/megatron/bridge/utils/instantiate_utils.py#L240

Thanks to @yaoyu-33 for help the with debugging.