### PR TITLE
feat: more granular time trace for prepare_for_generation/transfer_and_update_weights

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import os
 import warnings
-from contextlib import nullcontext
 from pathlib import Path
 from typing import Any, NotRequired, Optional, TypedDict, TypeVar, cast
 
@@ -66,7 +65,7 @@ from nemo_rl.utils.logger import (
     print_message_log_samples,
 )
 from nemo_rl.utils.nsys import maybe_gpu_profile_step
-from nemo_rl.utils.timer import TimeoutChecker, Timer
+from nemo_rl.utils.timer import NullTimer, TimeoutChecker, Timer
 
 # ===============================================================================
 # Configuration
@@ -440,13 +439,9 @@ def refit_policy_generation(
         policy.offload_before_refit()
         policy_generation.prepare_for_generation(tags=["weights"])
 
-    # Create a context manager that does nothing when timer is None
-    timer_context = (
-        timer.time("prepare_for_generation/transfer_and_update_weights")
-        if timer is not None
-        else nullcontext()
-    )
-    with timer_context:
+    timer = timer if timer is not None else NullTimer()
+
+    with timer.time("prepare_for_generation/transfer_and_update_weights"):
         # update weights
         update_success = False
         if colocated_inference:
@@ -461,10 +456,16 @@ def refit_policy_generation(
             )
             # do update
             for keys in grouped_param_keys:
-                ipc_handles = policy.get_weights_ipc_handles(keys)
-                update_success = policy_generation.update_weights_from_ipc_handles(
-                    ipc_handles
-                )
+                with timer.time(
+                    "prepare_for_generation/transfer_and_update_weights/get_weights_ipc_handles"
+                ):
+                    ipc_handles = policy.get_weights_ipc_handles(keys)
+                with timer.time(
+                    "prepare_for_generation/transfer_and_update_weights/update_weights_from_ipc_handles"
+                ):
+                    update_success = policy_generation.update_weights_from_ipc_handles(
+                        ipc_handles
+                    )
                 if not update_success:
                     break
         else:

--- a/nemo_rl/utils/timer.py
+++ b/nemo_rl/utils/timer.py
@@ -19,6 +19,14 @@ from typing import Callable, Generator, Optional, Sequence, Union
 import numpy as np
 
 
+class NullTimer:
+    """A null timer that does nothing but provides the same interface as Timer."""
+
+    @contextmanager
+    def time(self, label: str) -> Generator[None, None, None]:
+        yield
+
+
 class Timer:
     """A utility for timing code execution.
 


### PR DESCRIPTION
…d_update_weights

# What does this PR do ?

As titled add more info about refit time:
```
  • prepare_for_generation/transfer_and_update_weights: 0.08s (0.1%)
  • prepare_for_generation/transfer_and_update_weights/get_weights_ipc_handles: 0.05s (0.1%)
  ...
  • prepare_for_generation/transfer_and_update_weights/update_weights_from_ipc_handles: 0.02s (0.0%)
```
# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
