### PR TITLE
fix: Reset parallelism configs to default after initial import

### DIFF
--- a/nemo_rl/models/megatron/community_import.py
+++ b/nemo_rl/models/megatron/community_import.py
@@ -41,8 +41,12 @@ def import_model_from_hf_name(
     orig_pipeline_model_parallel_size = model_provider.pipeline_model_parallel_size
     orig_expert_model_parallel_size = model_provider.expert_model_parallel_size
     orig_expert_tensor_parallel_size = model_provider.expert_tensor_parallel_size
-    orig_num_layers_in_first_pipeline_stage = model_provider.num_layers_in_first_pipeline_stage
-    orig_num_layers_in_last_pipeline_stage = model_provider.num_layers_in_last_pipeline_stage
+    orig_num_layers_in_first_pipeline_stage = (
+        model_provider.num_layers_in_first_pipeline_stage
+    )
+    orig_num_layers_in_last_pipeline_stage = (
+        model_provider.num_layers_in_last_pipeline_stage
+    )
     orig_pipeline_dtype = model_provider.pipeline_dtype
 
     if megatron_config is not None:
@@ -71,13 +75,14 @@ def import_model_from_hf_name(
     # The above parallelism settings are used to load the model in a distributed manner.
     # However, we do not want to save the parallelism settings to the checkpoint config
     # because they may result in validation errors when loading the checkpoint.
-    megatron_model[0].config.tensor_model_parallel_size = orig_tensor_model_parallel_size
-    megatron_model[0].config.pipeline_model_parallel_size = orig_pipeline_model_parallel_size
-    megatron_model[0].config.expert_model_parallel_size = orig_expert_model_parallel_size
-    megatron_model[0].config.expert_tensor_parallel_size = orig_expert_tensor_parallel_size
-    megatron_model[0].config.num_layers_in_first_pipeline_stage = orig_num_layers_in_first_pipeline_stage
-    megatron_model[0].config.num_layers_in_last_pipeline_stage = orig_num_layers_in_last_pipeline_stage
-    megatron_model[0].config.pipeline_dtype = orig_pipeline_dtype
+    config = megatron_model[0].config
+    config.tensor_model_parallel_size = orig_tensor_model_parallel_size
+    config.pipeline_model_parallel_size = orig_pipeline_model_parallel_size
+    config.expert_model_parallel_size = orig_expert_model_parallel_size
+    config.expert_tensor_parallel_size = orig_expert_tensor_parallel_size
+    config.num_layers_in_first_pipeline_stage = orig_num_layers_in_first_pipeline_stage
+    config.num_layers_in_last_pipeline_stage = orig_num_layers_in_last_pipeline_stage
+    config.pipeline_dtype = orig_pipeline_dtype
 
     bridge.save_megatron_model(megatron_model, output_path)
 
@@ -85,7 +90,6 @@ def import_model_from_hf_name(
     import megatron.core.rerun_state_machine
 
     megatron.core.rerun_state_machine.destroy_rerun_state_machine()
-
 
 
 def export_model_from_megatron(

--- a/nemo_rl/models/megatron/community_import.py
+++ b/nemo_rl/models/megatron/community_import.py
@@ -36,6 +36,15 @@ def import_model_from_hf_name(
 
     model_provider = bridge.to_megatron_provider(load_weights=True)
 
+    # Keep track of defaults so can restore them to the config after loading the model
+    orig_tensor_model_parallel_size = model_provider.tensor_model_parallel_size
+    orig_pipeline_model_parallel_size = model_provider.pipeline_model_parallel_size
+    orig_expert_model_parallel_size = model_provider.expert_model_parallel_size
+    orig_expert_tensor_parallel_size = model_provider.expert_tensor_parallel_size
+    orig_num_layers_in_first_pipeline_stage = model_provider.num_layers_in_first_pipeline_stage
+    orig_num_layers_in_last_pipeline_stage = model_provider.num_layers_in_last_pipeline_stage
+    orig_pipeline_dtype = model_provider.pipeline_dtype
+
     if megatron_config is not None:
         model_provider.tensor_model_parallel_size = megatron_config[
             "tensor_model_parallel_size"
@@ -59,12 +68,24 @@ def import_model_from_hf_name(
     model_provider.initialize_model_parallel(seed=0)
     megatron_model = model_provider.provide_distributed_model(wrap_with_ddp=False)
 
+    # The above parallelism settings are used to load the model in a distributed manner.
+    # However, we do not want to save the parallelism settings to the checkpoint config
+    # because they may result in validation errors when loading the checkpoint.
+    megatron_model[0].config.tensor_model_parallel_size = orig_tensor_model_parallel_size
+    megatron_model[0].config.pipeline_model_parallel_size = orig_pipeline_model_parallel_size
+    megatron_model[0].config.expert_model_parallel_size = orig_expert_model_parallel_size
+    megatron_model[0].config.expert_tensor_parallel_size = orig_expert_tensor_parallel_size
+    megatron_model[0].config.num_layers_in_first_pipeline_stage = orig_num_layers_in_first_pipeline_stage
+    megatron_model[0].config.num_layers_in_last_pipeline_stage = orig_num_layers_in_last_pipeline_stage
+    megatron_model[0].config.pipeline_dtype = orig_pipeline_dtype
+
     bridge.save_megatron_model(megatron_model, output_path)
 
     # resetting mcore state
     import megatron.core.rerun_state_machine
 
     megatron.core.rerun_state_machine.destroy_rerun_state_machine()
+
 
 
 def export_model_from_megatron(


### PR DESCRIPTION
# What does this PR do ?

This prevents validation errors when loading the checkpoint after the initial import. The problem is that the parallelism settings we use for importing may not pass validation when loading the model for training. For example, if we set EP > 1 and TP > 1, Megatron expects sequence_parallel to be True. sequence_parallel is not needed for importing the model, so we do not set it. In this PR, we fix the issue by resetting the config to the default values (which should not have any validation errors) after loading the model so the defaults get saved to the run_config.yaml.

Closes https://github.com/NVIDIA-NeMo/RL/issues/1060

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
