### PR TITLE
fix: Make `prepare_for_generation` metric names compatible with MLFlow

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -611,7 +611,7 @@ def grpo_train(
                     f"▶ Generating responses for batch of size {repeated_batch.size}...",
                     flush=True,
                 )
-                with timer.time("prepare_for_generation"):
+                with timer.time("prepare_for_generation/total"):
                     if NEED_REFIT and POLICY_GENERATION_STALE:
                         refit_policy_generation(
                             policy, policy_generation, colocated_inference, timer=timer


### PR DESCRIPTION
# What does this PR do ?

Renames timing metrics to remove metric names which are prefixes of others to ensure compatibility with MLFlow logging.

# Issues
Fixes https://github.com/NVIDIA-NeMo/RL/issues/1068

# Additional Information
* MLFlow masks this issue by only erroring on the server-side. The user gets repeated 500s after exponential backoff, then an opaque error. It may be worth following up by changing the Logger to throw an error if an incompatible name arrives. I decided against including in this PR since it bloats the logger, and the fix for now is very minimal.