### PR TITLE
docs: update `grpo.md`

### DIFF
--- a/docs/guides/grpo.md
+++ b/docs/guides/grpo.md
@@ -252,6 +252,7 @@ We roughly approximate the entropy of the LLM's distribution throughout training
 $$
 E_{s \sim \pi_{\text{inference}}(x)}[-\frac{\pi_{\text{training}}(x)}{\pi_{\text{inference}}(x)}log(\pi_{\text{training}}(x))]
 $$
+
 using the rollouts in each training global batch as Monte-Carlo samples. The ratio of $\pi$ is in the formula to importance-correct for the mismatch between the policy over the course of training in a singular GRPO step and the inference framework.
 
 We use this to track if our models are entropy-collapsing too quickly during training (as is quite common). This is a pretty rough monte-carlo approximation, so we wouldn't recommend using this directly for an entropy bonus or otherwise backpropagating through this. You can take a look at NeMo-Aligner's [implementation](https://github.com/NVIDIA/NeMo-Aligner/blob/main/nemo_aligner/utils/distributed.py#L351) of a full entropy calculation if you're interested (WIP efficient calculation in NeMo-RL).


### PR DESCRIPTION
# What does this PR do ?

**Update grpo markdown.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)): N/A


# Usage
The equation was not render correctly without the newline.
For example,
before the change
<img width="1040" height="170" alt="Screenshot 2025-09-09 at 2 22 46 PM" src="https://github.com/user-attachments/assets/c655f7e6-86bf-4370-8c0d-11b9caa075ae" />

after the change
<img width="1016" height="218" alt="Screenshot 2025-09-09 at 2 18 31 PM" src="https://github.com/user-attachments/assets/10cd78be-0e31-4226-acc6-6195a15afa57" />



# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified entropy calculation in the GRPO guide: rollouts in each training global batch are treated as Monte Carlo samples.
  * Explained the role of the pi-ratio term as an importance-correction for the mismatch between the training policy and the inference framework.
  * No changes to formulas, functionality, or behavior; explanatory text only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->