### PR TITLE
ci: Add merge queue retry if CI_TIMEOUT

### DIFF
--- a/.github/workflows/merge-queue-retry.yml
+++ b/.github/workflows/merge-queue-retry.yml
@@ -15,10 +15,9 @@
 name: "Merge Queue Auto-Retry"
 
 on:
-  push:
-  # pull_request:
-  #   types:
-  #     - dequeued
+  pull_request:
+    types:
+      - dequeued
 
 jobs:
   requeue-pr:
@@ -31,56 +30,56 @@ jobs:
           app-id: ${{ vars.BOT_ID }}
           private-key: ${{ secrets.BOT_KEY }}
 
-      # - name: Check dequeue reason and retry count
-      #   id: check_retry
-      #   if: github.event.reason == 'CI_TIMEOUT'
-      #   env:
-      #     GH_TOKEN: ${{ steps.generate_token.outputs.token }}
-      #   run: |
-      #     PR_NUMBER=${{ github.event.pull_request.number }}
-
-      #     # Debug: Show all comments first
-      #     echo "=== All PR Comments ==="
-      #     gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-      #       --jq '.[] | {id: .id, created_at: .created_at, body: .body[:100]}'
-
-      #     echo "=== Filtering for retry comments ==="
-
-      #     # Get the current number of retry attempts from PR comments
-      #     RETRY_COUNT=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-      #       --jq '[.[] | select(.body | contains("Auto-retry attempt")) | .body] | length')
-
-      #     echo "Current retry count: $RETRY_COUNT"
-
-      #     MAX_RETRIES=3
-
-      #     if [ "$RETRY_COUNT" -lt "$MAX_RETRIES" ]; then
-      #       echo "should_retry=true" >> $GITHUB_OUTPUT
-      #       echo "retry_count=$((RETRY_COUNT + 1))" >> $GITHUB_OUTPUT
-      #       echo "✅ Will retry (attempt $((RETRY_COUNT + 1))/$MAX_RETRIES)"
-      #     else
-      #       echo "should_retry=false" >> $GITHUB_OUTPUT
-      #       echo "❌ Max retries ($MAX_RETRIES) reached for PR #${PR_NUMBER}"
-      #     fi
-
-      # - name: Add retry comment
-      #   if: steps.check_retry.outputs.should_retry == 'true'
-      #   env:
-      #     GH_TOKEN: ${{ steps.generate_token.outputs.token }}
-      #   run: |
-      #     PR_NUMBER=${{ github.event.pull_request.number }}
-      #     RETRY_COUNT=${{ steps.check_retry.outputs.retry_count }}
-
-      #     gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-      #       -f body="🔄 Auto-retry attempt ${RETRY_COUNT}: PR was removed from merge queue, automatically requeuing..."
-
-      - name: Requeue Pull Request
-        # if: steps.check_retry.outputs.should_retry == 'true'
+      - name: Check dequeue reason and retry count
+        id: check_retry
+        if: github.event.reason == 'CI_TIMEOUT'
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
-          PR_NUMBER="1111"
-          PR_NODE_ID="PR_kwDOOJjv8s6nvYsV"
+          PR_NUMBER=${{ github.event.pull_request.number }}
+
+          # Debug: Show all comments first
+          echo "=== All PR Comments ==="
+          gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | {id: .id, created_at: .created_at, body: .body[:100]}'
+
+          echo "=== Filtering for retry comments ==="
+
+          # Get the current number of retry attempts from PR comments
+          RETRY_COUNT=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq '[.[] | select(.body | contains("Auto-retry attempt")) | .body] | length')
+
+          echo "Current retry count: $RETRY_COUNT"
+
+          MAX_RETRIES=3
+
+          if [ "$RETRY_COUNT" -lt "$MAX_RETRIES" ]; then
+            echo "should_retry=true" >> $GITHUB_OUTPUT
+            echo "retry_count=$((RETRY_COUNT + 1))" >> $GITHUB_OUTPUT
+            echo "✅ Will retry (attempt $((RETRY_COUNT + 1))/$MAX_RETRIES)"
+          else
+            echo "should_retry=false" >> $GITHUB_OUTPUT
+            echo "❌ Max retries ($MAX_RETRIES) reached for PR #${PR_NUMBER}"
+          fi
+
+      - name: Add retry comment
+        if: steps.check_retry.outputs.should_retry == 'true'
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          RETRY_COUNT=${{ steps.check_retry.outputs.retry_count }}
+
+          gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            -f body="🔄 Auto-retry attempt ${RETRY_COUNT}: PR was removed from merge queue, automatically requeuing..."
+
+      - name: Requeue Pull Request
+        if: steps.check_retry.outputs.should_retry == 'true'
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          PR_NODE_ID="${{ github.event.pull_request.node_id }}"
 
           echo "Requeuing PR #${PR_NUMBER}..."
 
@@ -91,20 +90,22 @@ jobs:
             -d "{\"query\": \"mutation { enqueuePullRequest(input: {pullRequestId: \\\"${PR_NODE_ID}\\\"}) { clientMutationId } }\"}" \
             https://api.github.com/graphql)
 
-          echo "GRAPHQL_RESPONSE: $GRAPHQL_RESPONSE"
           if echo "$GRAPHQL_RESPONSE" | jq -e '.data.enqueuePullRequest' > /dev/null; then
             echo "PR #${PR_NUMBER} has been successfully requeued"
+          else
+            echo "❌ Failed to enqueue PR #${PR_NUMBER}. GraphQL response for debugging:"
+            echo "$GRAPHQL_RESPONSE"
           fi
 
-      # - name: Max retries reached comment
-      #   if: steps.check_retry.outputs.should_retry == 'false'
-      #   env:
-      #     GH_TOKEN: ${{ steps.generate_token.outputs.token }}
-      #   run: |
-      #     PR_NUMBER=${{ github.event.pull_request.number }}
+      - name: Max retries reached comment
+        if: steps.check_retry.outputs.should_retry == 'false'
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
 
-      #     gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-      #       -f body="⚠️ Maximum auto-retry attempts reached. PR was removed from merge queue multiple times. Please investigate the issue and manually requeue if needed."
+          gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            -f body="⚠️ Maximum auto-retry attempts reached. PR was removed from merge queue multiple times. Please investigate the issue and manually requeue if needed."
 
       - name: Notify on failure
         if: failure()

--- a/.github/workflows/merge-queue-retry.yml
+++ b/.github/workflows/merge-queue-retry.yml
@@ -79,8 +79,8 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
-          PR_NUMBER=${{ github.event.pull_request.number }}
-          PR_NODE_ID="${{ github.event.pull_request.node_id }}"
+          PR_NUMBER="1111"
+          PR_NODE_ID="PR_kwDOOJjv8s6nvYsV"
 
           echo "Requeuing PR #${PR_NUMBER}..."
 

--- a/.github/workflows/merge-queue-retry.yml
+++ b/.github/workflows/merge-queue-retry.yml
@@ -30,9 +30,6 @@ jobs:
           app-id: ${{ vars.BOT_ID }}
           private-key: ${{ secrets.BOT_KEY }}
 
-      - name: Checkout code
-        uses: actions/checkout@v4
-
       - name: Check dequeue reason and retry count
         id: check_retry
         if: github.event.reason == 'CI_TIMEOUT'

--- a/.github/workflows/merge-queue-retry.yml
+++ b/.github/workflows/merge-queue-retry.yml
@@ -15,9 +15,10 @@
 name: "Merge Queue Auto-Retry"
 
 on:
-  pull_request:
-    types:
-      - dequeued
+  push:
+  # pull_request:
+  #   types:
+  #     - dequeued
 
 jobs:
   requeue-pr:
@@ -30,51 +31,51 @@ jobs:
           app-id: ${{ vars.BOT_ID }}
           private-key: ${{ secrets.BOT_KEY }}
 
-      - name: Check dequeue reason and retry count
-        id: check_retry
-        if: github.event.reason == 'CI_TIMEOUT'
-        env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
-        run: |
-          PR_NUMBER=${{ github.event.pull_request.number }}
+      # - name: Check dequeue reason and retry count
+      #   id: check_retry
+      #   if: github.event.reason == 'CI_TIMEOUT'
+      #   env:
+      #     GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+      #   run: |
+      #     PR_NUMBER=${{ github.event.pull_request.number }}
 
-          # Debug: Show all comments first
-          echo "=== All PR Comments ==="
-          gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-            --jq '.[] | {id: .id, created_at: .created_at, body: .body[:100]}'
+      #     # Debug: Show all comments first
+      #     echo "=== All PR Comments ==="
+      #     gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+      #       --jq '.[] | {id: .id, created_at: .created_at, body: .body[:100]}'
 
-          echo "=== Filtering for retry comments ==="
+      #     echo "=== Filtering for retry comments ==="
 
-          # Get the current number of retry attempts from PR comments
-          RETRY_COUNT=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-            --jq '[.[] | select(.body | contains("Auto-retry attempt")) | .body] | length')
+      #     # Get the current number of retry attempts from PR comments
+      #     RETRY_COUNT=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+      #       --jq '[.[] | select(.body | contains("Auto-retry attempt")) | .body] | length')
 
-          echo "Current retry count: $RETRY_COUNT"
+      #     echo "Current retry count: $RETRY_COUNT"
 
-          MAX_RETRIES=3
+      #     MAX_RETRIES=3
 
-          if [ "$RETRY_COUNT" -lt "$MAX_RETRIES" ]; then
-            echo "should_retry=true" >> $GITHUB_OUTPUT
-            echo "retry_count=$((RETRY_COUNT + 1))" >> $GITHUB_OUTPUT
-            echo "✅ Will retry (attempt $((RETRY_COUNT + 1))/$MAX_RETRIES)"
-          else
-            echo "should_retry=false" >> $GITHUB_OUTPUT
-            echo "❌ Max retries ($MAX_RETRIES) reached for PR #${PR_NUMBER}"
-          fi
+      #     if [ "$RETRY_COUNT" -lt "$MAX_RETRIES" ]; then
+      #       echo "should_retry=true" >> $GITHUB_OUTPUT
+      #       echo "retry_count=$((RETRY_COUNT + 1))" >> $GITHUB_OUTPUT
+      #       echo "✅ Will retry (attempt $((RETRY_COUNT + 1))/$MAX_RETRIES)"
+      #     else
+      #       echo "should_retry=false" >> $GITHUB_OUTPUT
+      #       echo "❌ Max retries ($MAX_RETRIES) reached for PR #${PR_NUMBER}"
+      #     fi
 
-      - name: Add retry comment
-        if: steps.check_retry.outputs.should_retry == 'true'
-        env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
-        run: |
-          PR_NUMBER=${{ github.event.pull_request.number }}
-          RETRY_COUNT=${{ steps.check_retry.outputs.retry_count }}
+      # - name: Add retry comment
+      #   if: steps.check_retry.outputs.should_retry == 'true'
+      #   env:
+      #     GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+      #   run: |
+      #     PR_NUMBER=${{ github.event.pull_request.number }}
+      #     RETRY_COUNT=${{ steps.check_retry.outputs.retry_count }}
 
-          gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-            -f body="🔄 Auto-retry attempt ${RETRY_COUNT}: PR was removed from merge queue, automatically requeuing..."
+      #     gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+      #       -f body="🔄 Auto-retry attempt ${RETRY_COUNT}: PR was removed from merge queue, automatically requeuing..."
 
       - name: Requeue Pull Request
-        if: steps.check_retry.outputs.should_retry == 'true'
+        # if: steps.check_retry.outputs.should_retry == 'true'
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
@@ -90,19 +91,20 @@ jobs:
             -d "{\"query\": \"mutation { enqueuePullRequest(input: {pullRequestId: \\\"${PR_NODE_ID}\\\"}) { clientMutationId } }\"}" \
             https://api.github.com/graphql)
 
+          echo "GRAPHQL_RESPONSE: $GRAPHQL_RESPONSE"
           if echo "$GRAPHQL_RESPONSE" | jq -e '.data.enqueuePullRequest' > /dev/null; then
             echo "PR #${PR_NUMBER} has been successfully requeued"
           fi
 
-      - name: Max retries reached comment
-        if: steps.check_retry.outputs.should_retry == 'false'
-        env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
-        run: |
-          PR_NUMBER=${{ github.event.pull_request.number }}
+      # - name: Max retries reached comment
+      #   if: steps.check_retry.outputs.should_retry == 'false'
+      #   env:
+      #     GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+      #   run: |
+      #     PR_NUMBER=${{ github.event.pull_request.number }}
 
-          gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-            -f body="⚠️ Maximum auto-retry attempts reached. PR was removed from merge queue multiple times. Please investigate the issue and manually requeue if needed."
+      #     gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+      #       -f body="⚠️ Maximum auto-retry attempts reached. PR was removed from merge queue multiple times. Please investigate the issue and manually requeue if needed."
 
       - name: Notify on failure
         if: failure()

--- a/.github/workflows/merge-queue-retry.yml
+++ b/.github/workflows/merge-queue-retry.yml
@@ -95,6 +95,7 @@ jobs:
           else
             echo "❌ Failed to enqueue PR #${PR_NUMBER}. GraphQL response for debugging:"
             echo "$GRAPHQL_RESPONSE"
+            exit 1
           fi
 
       - name: Max retries reached comment

--- a/.github/workflows/merge-queue-retry.yml
+++ b/.github/workflows/merge-queue-retry.yml
@@ -1,0 +1,126 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Merge Queue Auto-Retry"
+
+on:
+  pull_request:
+    types:
+      - dequeued
+
+jobs:
+  requeue-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.BOT_ID }}
+          private-key: ${{ secrets.BOT_KEY }}
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check dequeue reason and retry count
+        id: check_retry
+        if: github.event.reason == 'CI_TIMEOUT'
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+
+          # Debug: Show all comments first
+          echo "=== All PR Comments ==="
+          gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | {id: .id, created_at: .created_at, body: .body[:100]}'
+
+          echo "=== Filtering for retry comments ==="
+
+          # Get the current number of retry attempts from PR comments
+          RETRY_COUNT=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq '[.[] | select(.body | contains("Auto-retry attempt")) | .body] | length')
+
+          echo "Current retry count: $RETRY_COUNT"
+
+          MAX_RETRIES=3
+
+          if [ "$RETRY_COUNT" -lt "$MAX_RETRIES" ]; then
+            echo "should_retry=true" >> $GITHUB_OUTPUT
+            echo "retry_count=$((RETRY_COUNT + 1))" >> $GITHUB_OUTPUT
+            echo "✅ Will retry (attempt $((RETRY_COUNT + 1))/$MAX_RETRIES)"
+          else
+            echo "should_retry=false" >> $GITHUB_OUTPUT
+            echo "❌ Max retries ($MAX_RETRIES) reached for PR #${PR_NUMBER}"
+          fi
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+      - name: Add retry comment
+        if: steps.check_retry.outputs.should_retry == 'true'
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          RETRY_COUNT=${{ steps.check_retry.outputs.retry_count }}
+
+          gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            -f body="🔄 Auto-retry attempt ${RETRY_COUNT}: PR was removed from merge queue, automatically requeuing..."
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+      - name: Requeue Pull Request
+        if: steps.check_retry.outputs.should_retry == 'true'
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          PR_NODE_ID="${{ github.event.pull_request.node_id }}"
+
+          echo "Requeuing PR #${PR_NUMBER}..."
+
+          # First, try using GraphQL API to enqueue the PR directly
+          GRAPHQL_RESPONSE=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ steps.generate_token.outputs.token }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\": \"mutation { enqueuePullRequest(input: {pullRequestId: \\\"${PR_NODE_ID}\\\"}) { clientMutationId } }\"}" \
+            https://api.github.com/graphql)
+
+          if echo "$GRAPHQL_RESPONSE" | jq -e '.data.enqueuePullRequest' > /dev/null; then
+            echo "PR #${PR_NUMBER} has been successfully requeued using GraphQL API"
+          else
+            echo "GraphQL enqueue failed, falling back to gh CLI method..."
+            echo "GraphQL response: $GRAPHQL_RESPONSE"
+
+            # Fallback: Enable auto-merge for the PR (this adds it back to merge queue)
+            gh pr merge $PR_NUMBER --auto --merge
+
+            echo "PR #${PR_NUMBER} has been requeued using gh CLI fallback"
+          fi
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+      - name: Max retries reached comment
+        if: steps.check_retry.outputs.should_retry == 'false'
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+
+          gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            -f body="⚠️ Maximum auto-retry attempts reached. PR was removed from merge queue multiple times. Please investigate the issue and manually requeue if needed."
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+      - name: Notify on failure
+        if: failure()
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+
+          gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            -f body="❌ Auto-retry failed due to an error in the workflow. Please manually requeue the PR."
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/merge-queue-retry.yml
+++ b/.github/workflows/merge-queue-retry.yml
@@ -36,6 +36,8 @@ jobs:
       - name: Check dequeue reason and retry count
         id: check_retry
         if: github.event.reason == 'CI_TIMEOUT'
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
 
@@ -62,22 +64,22 @@ jobs:
             echo "should_retry=false" >> $GITHUB_OUTPUT
             echo "❌ Max retries ($MAX_RETRIES) reached for PR #${PR_NUMBER}"
           fi
-        env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
       - name: Add retry comment
         if: steps.check_retry.outputs.should_retry == 'true'
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
           RETRY_COUNT=${{ steps.check_retry.outputs.retry_count }}
 
           gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
             -f body="🔄 Auto-retry attempt ${RETRY_COUNT}: PR was removed from merge queue, automatically requeuing..."
-        env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
       - name: Requeue Pull Request
         if: steps.check_retry.outputs.should_retry == 'true'
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
           PR_NODE_ID="${{ github.event.pull_request.node_id }}"
@@ -92,35 +94,25 @@ jobs:
             https://api.github.com/graphql)
 
           if echo "$GRAPHQL_RESPONSE" | jq -e '.data.enqueuePullRequest' > /dev/null; then
-            echo "PR #${PR_NUMBER} has been successfully requeued using GraphQL API"
-          else
-            echo "GraphQL enqueue failed, falling back to gh CLI method..."
-            echo "GraphQL response: $GRAPHQL_RESPONSE"
-
-            # Fallback: Enable auto-merge for the PR (this adds it back to merge queue)
-            gh pr merge $PR_NUMBER --auto --merge
-
-            echo "PR #${PR_NUMBER} has been requeued using gh CLI fallback"
+            echo "PR #${PR_NUMBER} has been successfully requeued"
           fi
-        env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
       - name: Max retries reached comment
         if: steps.check_retry.outputs.should_retry == 'false'
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
 
           gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
             -f body="⚠️ Maximum auto-retry attempts reached. PR was removed from merge queue multiple times. Please investigate the issue and manually requeue if needed."
-        env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
       - name: Notify on failure
         if: failure()
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
 
           gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
             -f body="❌ Auto-retry failed due to an error in the workflow. Please manually requeue the PR."
-        env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
# What does this PR do ?

Add merge queue retry if CI_TIMEOUT

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Adds an active Merge Queue Auto-Retry that automatically requeues pull requests removed for CI timeout, with up to 3 auto-retry attempts.
  - Posts clear PR comments for each auto-retry, when maximum retries are reached, and if the workflow fails.

- **Chores**
  - Added repository workflow to manage automated requeue attempts and notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->