### PR TITLE
fix: restore qwen3 support for FLOPs accounting

### DIFF
--- a/nemo_rl/utils/flops_tracker.py
+++ b/nemo_rl/utils/flops_tracker.py
@@ -20,6 +20,7 @@ from transformers import AutoConfig
 from transformers.configuration_utils import PretrainedConfig
 from transformers.models.llama.configuration_llama import LlamaConfig
 from transformers.models.qwen2.configuration_qwen2 import Qwen2Config
+from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
 from transformers.models.qwen3_moe.configuration_qwen3_moe import Qwen3MoeConfig
 
 from nemo_rl.models.policy.utils import sliding_window_overwrite
@@ -52,7 +53,7 @@ def convert_config_to_flops_config(
             ffn_hs=config.intermediate_size,
             vocab_size=config.vocab_size,
         ), qwen2
-    elif isinstance(config, Qwen3MoeConfig):
+    elif isinstance(config, (Qwen3Config, Qwen3MoeConfig)):
         return FLOPSConfig(
             gbs=0,
             hs=config.hidden_size,


### PR DESCRIPTION
# What does this PR do ?

The FLOPs accountant should now match both regular and moe versions of Qwen3. 

# Issues

N/A

# Usage
N/A

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FLOPS tracking support for Qwen3 and Qwen3-MoE models.
* **Refactor**
  * Simplified configuration handling by unifying Qwen3 model detection into a single path.
* **Chores**
  * Removed legacy references to older Qwen versions to streamline model support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->