### PR TITLE
fix: fix eval config

### DIFF
--- a/examples/configs/evals/gpqa_eval.yaml
+++ b/examples/configs/evals/gpqa_eval.yaml
@@ -12,4 +12,4 @@ data:
 
 env:
   math:
-    verifier_type: "multichoice"
+    verifier_type: "multilingual_multichoice"

--- a/examples/configs/evals/mmlu.yaml
+++ b/examples/configs/evals/mmlu.yaml
@@ -10,4 +10,4 @@ data:
 
 env:
   math:
-    verifier_type: "multichoice"
+    verifier_type: "multilingual_multichoice"

--- a/examples/configs/evals/mmlu_zh_cn.yaml
+++ b/examples/configs/evals/mmlu_zh_cn.yaml
@@ -3,4 +3,3 @@ defaults: "mmlu.yaml"
 
 data:
   dataset_name: "mmlu_ZH-CN"
-


### PR DESCRIPTION
split eval config fix from https://github.com/NVIDIA-NeMo/RL/pull/778.

fix error verifier_type while running with:
```bash
uv run python examples/run_eval.py --config examples/configs/evals/gpqa_eval.yaml
uv run python examples/run_eval.py --config examples/configs/evals/mmlu.yaml
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled a multilingual multiple-choice verifier for GPQA and MMLU evaluation configs, improving support and accuracy for multilingual math-related questions.

- Style
  - Removed a trailing blank line in the MMLU (zh-CN) config for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->