### PR TITLE
feat: Loss memory optimization (1/2) Fuse float16_to_float32 into loss and use recompute

### DIFF
--- a/nemo_rl/models/megatron/common.py
+++ b/nemo_rl/models/megatron/common.py
@@ -348,6 +348,7 @@ def forward_step_arbitrary_loss(
             position_ids,
             attention_mask,
             packed_seq_params=packed_seq_params,
+            fp32_output=False,
         )
 
         # Apply temperature scaling to logits for training


### PR DESCRIPTION
# What does this PR do ?

This is first of the two features to reduce loss memory usage. This PR puts the bf16-to-fp32 cast of output logits into the loss function and use recompute to get rid of the saved activations during loss. 

# Issues
related to #990 

# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Optional FP32 output mode for GPT models to improve numerical stability during training and inference.
- Bug Fixes
  - Increased reliability of distributed training by ensuring correct context is preserved across forward and backward passes.
- Refactor
  - Reduced memory footprint during training by recomputing softmax values in backward instead of storing them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->