### PR TITLE
chore: add deepep install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ sudo apt-get update
 sudo apt-get install cudnn-cuda-12
 ```
 
+If you encounter problems when installing vllm's dependency deep_ep on bare-metal (outside of a container), you may need to install libibverbs-dev as well. Here is how you can install it:
+```sh
+sudo apt-get update
+sudo apt-get install libibverbs-dev
+```
+
 For faster setup and environment isolation, we use [uv](https://docs.astral.sh/uv/).
 Follow [these instructions](https://docs.astral.sh/uv/getting-started/installation/) to install uv.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ automodel = [
 vllm = [
     "cuda-python",
     "deep_gemm @ git+https://github.com/deepseek-ai/DeepGEMM.git@7b6b5563b9d4c1ae07ffbce7f78ad3ac9204827c",
+    # deep_ep also needs libibverbs-dev
+    # sudo apt-get update
+    # sudo apt-get install libibverbs-dev
     "deep_ep @ git+https://github.com/deepseek-ai/DeepEP.git@e3908bf5bd0cc6265bcb225d15cd8c996d4759ef",
     "vllm==0.10.0",
     "num2words>=0.5.14",


### PR DESCRIPTION
As title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified bare-metal installation requirements for vLLM’s deep_ep dependency, noting that libibverbs-dev may be needed and providing example apt-get commands.
  * Added inline notes to the dependency configuration highlighting the libibverbs-dev requirement.
  * No functional changes, dependency updates, or build behavior modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->