### PR TITLE
fix: Release gradient memory after policy training

### DIFF
--- a/nemo_rl/models/policy/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker.py
@@ -861,6 +861,8 @@ class DTensorPolicyWorker:
 
                 losses.append(torch.tensor(mb_losses).sum().item())
 
+            # release gradient memory before rollouts
+            self.optimizer.zero_grad()
             # increment scheduler after all batches in rollout are processed
             if not eval_mode:
                 self.scheduler.step()

--- a/nemo_rl/models/policy/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker_v2.py
@@ -837,6 +837,8 @@ class DTensorPolicyWorkerV2:
 
                 losses.append(torch.tensor(mb_losses).sum().item())
 
+            # release gradient memory before rollouts
+            self.optimizer.zero_grad()
             # increment scheduler after all batches in rollout are processed
             if not eval_mode:
                 self.scheduler.step()


### PR DESCRIPTION
# What does this PR do ?

Release gradient memory after policy training to avoid OOM during rollouts.

# Issues
Currently the training is likely to OOM at the beginning of 2nd step rollouts because gradient memory is not freed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced GPU memory usage during multi-rollout training by resetting gradients between rollouts, preventing unintended accumulation.
  * Lowers risk of out-of-memory errors and improves stability on long training runs for dtensor policy workers (v1 and v2).
  * Slight performance improvement from earlier memory release; training behavior and results remain unchanged.
  * No changes to user-facing APIs or configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->