### PR TITLE
ci: Remove test comment from automodel integration check

### DIFF
--- a/.github/workflows/_automodel_integration_check.yml
+++ b/.github/workflows/_automodel_integration_check.yml
@@ -210,7 +210,6 @@ jobs:
 
           # Set outputs
           echo "needs_attention=$needs_attention" >> $GITHUB_OUTPUT
-          comment_body="This is a test comment"
           if [[ -n "$comment_body" ]]; then
             echo "comment_body<<EOF" >> $GITHUB_OUTPUT
             echo "$comment_body" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# What does this PR do ?

Remove test comment from automodel integration check. I accidentally left that in this PR https://github.com/NVIDIA-NeMo/RL/pull/1028/files

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated integration check workflow to stop pre-populating review comments. Comments and related artifacts are now generated only when issues are detected, reducing PR noise and avoiding empty artifacts.
  - No changes to the checks themselves or their messaging; behavior only affects when comments/artifacts appear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->