### PR TITLE
fix: Fix gradient clipping of non-float32 params

### DIFF
--- a/nemo_rl/models/dtensor/parallelize.py
+++ b/nemo_rl/models/dtensor/parallelize.py
@@ -719,7 +719,6 @@ def clip_grad_by_total_norm_(
     parameters: Union[list[Union[torch.Tensor, DTensor]], Union[torch.Tensor, DTensor]],
     max_grad_norm: Union[int, float],
     total_norm: float,
-    dtype: torch.dtype = torch.float32,
 ):
     """Clips gradient of an iterable of parameters by total norm.
 
@@ -737,17 +736,17 @@ def clip_grad_by_total_norm_(
     if isinstance(parameters, (torch.Tensor, DTensor)):
         parameters = [parameters]
 
-    # Grads.
-    grads = [
-        to_local_if_dtensor(p.grad.detach()).to(dtype)
-        for p in parameters
-        if p.grad is not None
-    ]
-
     # Scale.
     clip_coeff = max_grad_norm / (total_norm + 1.0e-6)
 
     if clip_coeff < 1.0:
+        # Grads.
+        grads = [
+            to_local_if_dtensor(p.grad.detach())
+            for p in parameters
+            if p.grad is not None
+        ]
+
         for g in grads:
             g.mul_(clip_coeff)
 

--- a/nemo_rl/models/policy/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker.py
@@ -852,7 +852,6 @@ class DTensorPolicyWorker:
                                 self.model.parameters(),
                                 max_grad_norm=self.max_grad_norm,
                                 total_norm=grad_norm,
-                                dtype=torch.float32,
                             )
                         grad_norm = torch.tensor([grad_norm])
 

--- a/nemo_rl/models/policy/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker_v2.py
@@ -828,7 +828,6 @@ class DTensorPolicyWorkerV2:
                                 self.model.parameters(),
                                 max_grad_norm=self.max_grad_norm,
                                 total_norm=grad_norm,
-                                dtype=torch.float32,
                             )
                         grad_norm = torch.tensor([grad_norm])
 


### PR DESCRIPTION
# What does this PR do ?

Fix gradient clipping for mixed precision training. Currently gradient clipping does nothing when parameters are not in float32 precision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified gradient clipping to avoid unnecessary dtype casts and compute gradients only when clipping is required.
  - Removed the dtype parameter from the gradient clipping function signature.
- Chores
  - Updated training workflows to call the revised gradient clipping and grad-norm utilities without an explicit dtype.
- Impact
  - Potentially faster training steps with reduced overhead.
  - Minor API change: callers must no longer pass a dtype to the gradient clipping function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->