### PR TITLE
feat: add support for COMMAND= in ray.sub *-attach.sh scripts

### DIFF
--- a/ray.sub
+++ b/ray.sub
@@ -443,10 +443,15 @@ else
   cat <<EOF >$SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh
 # No args launches on the head node (node 0)
 # Args 1-N launch on worker nodes (nodes 1 through N-1)
+# Optional: set COMMAND='...' to run non-interactively instead of opening an interactive shell
 WORKER_NUM=\${1:-}
 if [[ -z "\$WORKER_NUM" ]]; then
   # Empty means we are on the head node
-  srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "$head_node" --jobid $SLURM_JOB_ID --pty bash
+  if [[ -n "\${COMMAND:-}" ]]; then
+    srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "$head_node" --jobid $SLURM_JOB_ID bash -c "\$COMMAND"
+  else
+    srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "$head_node" --jobid $SLURM_JOB_ID --pty bash
+  fi
 else
   # Worker numbers 1 through N-1 correspond to ray-worker-1 through ray-worker-(N-1)
   # and use nodes_array[1] through nodes_array[N-1]
@@ -455,10 +460,15 @@ else
     exit 1
   fi
   nodes_array=($nodes)
-  srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-worker-\$WORKER_NUM --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "\${nodes_array[\$WORKER_NUM]}" --jobid $SLURM_JOB_ID --pty bash
+  if [[ -n "\${COMMAND:-}" ]]; then
+    srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-worker-\$WORKER_NUM --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "\${nodes_array[\$WORKER_NUM]}" --jobid $SLURM_JOB_ID bash -c "\$COMMAND"
+  else
+    srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-worker-\$WORKER_NUM --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "\${nodes_array[\$WORKER_NUM]}" --jobid $SLURM_JOB_ID --pty bash
+  fi
 fi
 EOF
   chmod +x $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh
+  echo "     COMMAND='echo hello' bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh    # run a non-interactive command on head node"
   echo "     bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh    # to attach to head node (i.e., 'worker 0')"
   echo "     bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh 1  # to attach to worker 1"
   echo "     bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh 2  # to attach to worker 2, etc."


### PR DESCRIPTION
This should help with using cursor agent mode from a login node. As long as you set up a rule to execute through this pattern. Here's an example file you can drop into `.cursor/rules/slurm_attach.mdc` and cursor will run stuff so long as you have an interactive slurm allocation running.

``````markdown
---
description: Always run shell commands inside the latest *-attach.sh using COMMAND=\"...\"
globs: ["**/*"]
alwaysApply: true
---

When proposing or running any shell command for this project, do not execute it directly on the SLURM login node. Instead, run it inside the most recent attach script emitted by `ray.sub`.

Use this exact wrapper:

```bash
COMMAND="<the command to run>" bash $(ls -tr *-attach.sh | tail -n1)
```

Guidelines:

- If the command contains quotes, prefer double quotes around COMMAND and escape inner double quotes.
- Keep the entire intended shell line inside COMMAND so it runs within the SLURM allocation.
- If no `*-attach.sh` exists, do not run the command; instruct the user to launch `ray.sub` first so the attach script is created.

Examples:

```bash
COMMAND="uv run script.py --arg value" bash $(ls -tr *-attach.sh | tail -n1)
```
``````


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Optional non-interactive execution via a COMMAND environment variable. When set, attach flows run the specified command on head and worker nodes; when unset, they open interactive shells as before.

- Documentation
  - Attach script now includes a comment explaining the COMMAND option and an example showing how to run a non-interactive command on the head node.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->