### PR TITLE
fix: simplified megatron to hf conversion script

### DIFF
--- a/nemo_rl/models/megatron/community_import.py
+++ b/nemo_rl/models/megatron/community_import.py
@@ -105,10 +105,6 @@ def export_model_from_megatron(
         )
 
     bridge = AutoBridge.from_hf_pretrained(hf_model_name, trust_remote_code=True)
-    megatron_model = bridge.load_megatron_model(input_path)
-    bridge.save_hf_pretrained(megatron_model, output_path)
-
-    # resetting mcore state
-    import megatron.core.rerun_state_machine
-
-    megatron.core.rerun_state_machine.destroy_rerun_state_machine()
+    bridge.export_ckpt(
+        megatron_path=input_path, hf_path=output_path, show_progress=True
+    )


### PR DESCRIPTION
# What does this PR do ?

The PR is primary to fix This should also fix https://github.com/NVIDIA-NeMo/RL/issues/1102, but in addition to that:

1. Added an option to use `--hf-model` for model name instead of a full config file
2. simplified the script a little bit

# Issues
https://github.com/NVIDIA-NeMo/RL/issues/1102


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added --hf-model CLI option for direct Hugging Face model conversion.
  - Supports two entry paths: provide a config file or an HF model name/path (mutually exclusive).
  - Automatically infers the tokenizer when using --hf-model.

- Refactor
  - Streamlined export into a single-step operation with a progress indicator.
  - Strengthened argument validation (exactly one of --config or --hf-model required).
  - Preserves existing input/output behavior with no changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->