### PR TITLE
ci: Ensure mcore and automodel are installed before checking if tests exist

### DIFF
--- a/tests/unit/L0_Unit_Tests_Generation.sh
+++ b/tests/unit/L0_Unit_Tests_Generation.sh
@@ -21,7 +21,7 @@ cd /opt/nemo-rl
 uv run --no-sync bash -x ./tests/run_unit.sh unit/models/generation/ --cov=nemo_rl --cov-report=term-missing --cov-report=json --hf-gated
 
 # Check and run mcore tests
-exit_code=$(pytest tests/unit/models/generation/ --collect-only --hf-gated --mcore-only -q >/dev/null 2>&1; echo $?)
+exit_code=$(uv run --extra mcore pytest tests/unit/models/generation/ --collect-only --hf-gated --mcore-only -q >/dev/null 2>&1; echo $?)
 if [[ $exit_code -eq 5 ]]; then
     echo "No mcore tests to run"
 else
@@ -29,7 +29,7 @@ else
 fi
 
 # Check and run automodel tests
-exit_code=$(pytest tests/unit/models/generation/ --collect-only --hf-gated --automodel-only -q >/dev/null 2>&1; echo $?)
+exit_code=$(uv run --extra automodel pytest tests/unit/models/generation/ --collect-only --hf-gated --automodel-only -q >/dev/null 2>&1; echo $?)
 if [[ $exit_code -eq 5 ]]; then
     echo "No automodel tests to run"
 else

--- a/tests/unit/L0_Unit_Tests_Other.sh
+++ b/tests/unit/L0_Unit_Tests_Other.sh
@@ -21,7 +21,7 @@ cd /opt/nemo-rl
 uv run --no-sync bash -x ./tests/run_unit.sh unit/ --ignore=unit/models/generation/ --ignore=unit/models/policy/ --cov=nemo_rl --cov-report=term-missing --cov-report=json --hf-gated
 
 # Check and run mcore tests
-exit_code=$(pytest tests/unit/ --ignore=unit/models/generation/ --ignore=unit/models/policy/ --collect-only --hf-gated --mcore-only -q >/dev/null 2>&1; echo $?)
+exit_code=$(uv run --extra mcore pytest tests/unit/ --ignore=unit/models/generation/ --ignore=unit/models/policy/ --collect-only --hf-gated --mcore-only -q >/dev/null 2>&1; echo $?)
 if [[ $exit_code -eq 5 ]]; then
     echo "No mcore tests to run"
 else
@@ -29,7 +29,7 @@ else
 fi
 
 # Check and run automodel tests
-exit_code=$(pytest tests/unit/ --ignore=unit/models/generation/ --ignore=unit/models/policy/ --collect-only --hf-gated --automodel-only -q >/dev/null 2>&1; echo $?)
+exit_code=$(uv run --extra automodel pytest tests/unit/ --ignore=unit/models/generation/ --ignore=unit/models/policy/ --collect-only --hf-gated --automodel-only -q >/dev/null 2>&1; echo $?)
 if [[ $exit_code -eq 5 ]]; then
     echo "No automodel tests to run"
 else

--- a/tests/unit/L0_Unit_Tests_Policy.sh
+++ b/tests/unit/L0_Unit_Tests_Policy.sh
@@ -21,7 +21,7 @@ cd /opt/nemo-rl
 uv run --no-sync bash -x ./tests/run_unit.sh unit/models/policy/ --cov=nemo_rl --cov-report=term-missing --cov-report=json --hf-gated
 
 # Check and run mcore tests
-exit_code=$(pytest tests/unit/models/policy/ --collect-only --hf-gated --mcore-only -q >/dev/null 2>&1; echo $?)
+exit_code=$(uv run --extra mcore pytest tests/unit/models/policy/ --collect-only --hf-gated --mcore-only -q >/dev/null 2>&1; echo $?)
 if [[ $exit_code -eq 5 ]]; then
     echo "No mcore tests to run"
 else
@@ -29,7 +29,7 @@ else
 fi
 
 # Check and run automodel tests
-exit_code=$(pytest tests/unit/models/policy/ --collect-only --hf-gated --automodel-only -q >/dev/null 2>&1; echo $?)
+exit_code=$(uv run --extra automodel pytest tests/unit/models/policy/ --collect-only --hf-gated --automodel-only -q >/dev/null 2>&1; echo $?)
 if [[ $exit_code -eq 5 ]]; then
     echo "No automodel tests to run"
 else


### PR DESCRIPTION
# What does this PR do ?

Ensure mcore and automodel are installed before checking if tests exist

Previously, it seemed that some automodel tests are skipped because nemo-automodel was not installed.  And a import guard exists in one of the test suites.

https://github.com/NVIDIA-NeMo/RL/blob/cfaf5a84b4c654e65a122ec713d0c9982d454eb8/tests/unit/utils/test_automodel_checkpoint.py#L27

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
