### PR TITLE
ci: Set HF_HUB_OFFLINE=1 during tests when PR is from a fork

### DIFF
--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -54,6 +54,10 @@ inputs:
     description: "Has Azure credentials"
     required: false
     default: "false"
+  is_fork_pr:
+    description: "Whether this is a pull request from a fork"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -171,6 +175,7 @@ runs:
           --env HF_DATASETS_CACHE=/home/TestData/nemo-rl/hf_datasets_cache \
           --env NEMO_RL_REPO_DIR=/opt/nemo-rl \
           --env HF_TOKEN \
+          ${{ inputs.is_fork_pr == 'true' && '--env HF_HUB_OFFLINE=1' || '' }} \
           --volume $(pwd)/${{ github.run_id }}/${{steps.uuid.outputs.id }}/nemo-rl:/opt/nemo-rl \
           --volume $GITHUB_ACTION_DIR:$GITHUB_ACTION_DIR \
           --volume /mnt/datadrive/TestData/nemo-rl/datasets:/opt/nemo-rl/datasets:ro \

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -225,6 +225,7 @@ jobs:
           runner: ${{ runner.name }}
           script: ${{ matrix.script }}
           is_doc_test: "true"
+          is_fork_pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}
 
   cicd-unit-tests:
     strategy:
@@ -253,6 +254,7 @@ jobs:
           script: ${{ matrix.script }}
           is_unit_test: "true"
           cpu-only: ${{ matrix.cpu-only || false }}
+          is_fork_pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}
 
   cicd-functional-tests:
     strategy:
@@ -276,6 +278,7 @@ jobs:
         with:
           runner: ${{ runner.name }}
           script: ${{ matrix.script }}
+          is_fork_pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}
 
   CI_QA_Gate:
     name: CI quality check


### PR DESCRIPTION
# What does this PR do ?

Set HF_HUB_OFFLINE=1 during tests when PR is from a fork

Pull requests from forks do not have access to secrets like HF_TOKEN, so their CI tests will fail when downloading HF models.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Tests
  - For forked pull requests, tests now run in offline mode; behavior is unchanged for non-fork runs.

- Chores
  - CI now detects forked pull requests via a new parameter and propagates it to test jobs across documentation, unit, and functional pipelines for consistent handling.

- Impact
  - No user-facing changes; improves CI robustness for external contributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->