### PR TITLE
fix: Handle missing prompts in math HF data processor and add regression test

### DIFF
--- a/nemo_rl/data/processors.py
+++ b/nemo_rl/data/processors.py
@@ -108,9 +108,12 @@ def math_hf_data_processor(
     extra_env_info = {"ground_truth": user_message[1]["content"]}
 
     message_log: LLMMessageLogType = []
+    formatted_content = (
+        task_data_spec.prompt.format(problem) if task_data_spec.prompt else problem
+    )
     user_message = {
         "role": "user",
-        "content": task_data_spec.prompt.format(problem),
+        "content": formatted_content,
     }
     message: list[str] = tokenizer.apply_chat_template(  # type: ignore
         [user_message],


### PR DESCRIPTION
# What does this PR do ?

Fixes math HF data processor to handle missing prompts and adds regression coverage.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
