### PR TITLE
fix: loosen sft-llama3.2-1b-1n8g-fsdp2tp1.v3.sh step time/loss check

### DIFF
--- a/tests/test_suites/llm/sft-llama3.2-1b-1n8g-fsdp2tp1.v3.sh
+++ b/tests/test_suites/llm/sft-llama3.2-1b-1n8g-fsdp2tp1.v3.sh
@@ -35,8 +35,9 @@ uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
 if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
     uv run tests/check_metrics.py $JSON_METRICS \
         'data["train/loss"]["1"] < 0.82' \
-        'data["train/loss"]["250"] < 0.5' \
+        'mean(data["train/loss"],-10,-1) < 0.58' \
         'max(data["ray/node.0.gpu.0.mem_gb"]) < 25' \
         'mean(data["timing/train/total_step_time"], -6, -1) < 0.7'
+    # mean(data["train/loss"],-10,-1) observed to be 0.5557474825117323
     # timing/train/total_step_time observed 0.6-0.64
 fi


### PR DESCRIPTION
# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

Step time threshold is a little too strict on this test:

<img width="693" height="982" alt="image" src="https://github.com/user-attachments/assets/d178be32-5416-4738-9350-9a8eb191fc61" />

https://wandb.ai/nvidia/nemo-rl/panel/z7zystoxj?nw=5kdn9ueaulf

Even on the first commit that introduced this test, the timing check can fail

----
The loss issue was bisected in #1223. tldr; the `num_workers` change affected the dataloading very slightly that caused the strict loss check to fail


<img width="1125" height="523" alt="image" src="https://github.com/user-attachments/assets/6516e91b-97c6-4328-b71c-37a04d17e23a" />


https://wandb.ai/nvidia/nemo-rl?nw=fnhia71y43d

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Relaxed the performance threshold for LLM training step-time checks to better match observed timing variability, reducing flaky failures and improving CI reliability.
  * Maintains performance monitoring while minimizing false negatives across environments.
  * No impact on product functionality; end-user features and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->