### PR TITLE
fix: dpo mistral nightly needs more time

### DIFF
--- a/tests/test_suites/llm/dpo-mistral-nemo-instruct-2407-1n8g-fsdp2tp8-actckpt-long.sh
+++ b/tests/test_suites/llm/dpo-mistral-nemo-instruct-2407-1n8g-fsdp2tp8-actckpt-long.sh
@@ -7,7 +7,7 @@ NUM_NODES=1
 STEPS_PER_RUN=100
 MAX_STEPS=100
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
-NUM_MINUTES=45
+NUM_MINUTES=60
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached


### PR DESCRIPTION
There seems to be a jump in the total step time according to our CI

<img width="711" height="1018" alt="image" src="https://github.com/user-attachments/assets/e9d60c5a-e5f0-4e86-bbeb-e9788f255693" />

https://wandb.ai/nvidia/nemo-rl/panel/z7zystoxj?nw=sorg4p7b5x

But upon inspecting the commit range there weren't any suspicious PRs
<img width="1337" height="446" alt="image" src="https://github.com/user-attachments/assets/6dcc2c88-bd83-4009-b6a3-396a20367695" />

This perf jump may just be infra related since i don't see it with other runs
<img width="709" height="974" alt="image" src="https://github.com/user-attachments/assets/28bf7750-a022-4a1b-859c-deeafa1fc07b" />

https://wandb.ai/nvidia/nemo-rl/panel/z7zystoxj?nw=np5jodktgg

For now, just give this test slightly more time so it can run till completion since 100 steps has been taking 45min exactly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Standardized tips/notes/important blocks to GitHub-style admonitions for consistent look and readability.
  - Cleaned up text wrapping and code fences; aligned examples and line breaks.
  - Clarified GPU recommendation tip presentation without changing guidance.
  - Merged environment variable assignment and command into a single profiling example for easier copy-paste.
- Refactor
  - Improved docs build to convert admonitions during content processing, ensuring consistent formatting across sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->