### PR TITLE
fix: nightlies using v1 can't use model_save_format=safetensors

### DIFF
--- a/examples/configs/recipes/llm/grpo-deepscaler-1.5b-8K.yaml
+++ b/examples/configs/recipes/llm/grpo-deepscaler-1.5b-8K.yaml
@@ -8,6 +8,7 @@ loss_fn:
   reference_policy_kl_penalty: 0.0
 checkpointing:
   keep_top_k: 10
+  model_save_format: null
 policy:
   model_name: deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
   train_global_batch_size: 64

--- a/examples/configs/recipes/llm/grpo-gemma3-27b-it-8n8g-fsdp2tp8-actckpt-long.yaml
+++ b/examples/configs/recipes/llm/grpo-gemma3-27b-it-8n8g-fsdp2tp8-actckpt-long.yaml
@@ -5,6 +5,7 @@ grpo:
   max_num_steps: 20
 checkpointing:
   checkpoint_dir: results/grpo-gemma3-27b-it-8n8g-fsdp2tp8sp-actckpt-long
+  model_save_format: null
 policy:
   model_name: google/gemma-3-27b-it
   tokenizer:

--- a/examples/configs/recipes/llm/grpo-gspo-deepscaler-1.5b-8K.yaml
+++ b/examples/configs/recipes/llm/grpo-gspo-deepscaler-1.5b-8K.yaml
@@ -10,6 +10,7 @@ loss_fn:
   token_level_loss: false
 checkpointing:
   keep_top_k: 10
+  model_save_format: null
 policy:
   model_name: deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
   train_global_batch_size: 64


### PR DESCRIPTION
As title describes.

Previously the error encountered was:

```
Saving checkpoint for step 10...
Traceback (most recent call last):
  File "/opt/nemo-rl/examples/run_grpo_math.py", line 235, in <module>
    main()
  File "/opt/nemo-rl/examples/run_grpo_math.py", line 218, in main
    grpo_train(
  File "/opt/nemo-rl/nemo_rl/algorithms/grpo.py", line 889, in grpo_train
    policy.save_checkpoint(
  File "/opt/nemo-rl/nemo_rl/models/policy/lm_policy.py", line 697, in save_checkpoint
    raise ValueError(
ValueError: safetensors is only supported with DTensorPolicyWorkerV2 (_v2=true).
Traceback (most recent call last):
  File "/opt/nemo-rl/examples/run_grpo_math.py", line 235, in <module>
    main()
  File "/opt/nemo-rl/examples/run_grpo_math.py", line 218, in main
    grpo_train(
  File "/opt/nemo-rl/nemo_rl/algorithms/grpo.py", line 889, in grpo_train
    policy.save_checkpoint(
  File "/opt/nemo-rl/nemo_rl/models/policy/lm_policy.py", line 697, in save_checkpoint
    raise ValueError(
ValueError: safetensors is only supported with DTensorPolicyWorkerV2 (_v2=true).
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional checkpointing setting to specify the model save format in LLM training recipes. Defaults to current behavior (no format specified) and has no impact unless configured.

* **Chores**
  * Updated example recipes to include a placeholder for model save format, improving discoverability of the option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->