### PR TITLE
fix: fp8 rollout nightly fix check from step 100 to 40

### DIFF
--- a/tests/test_suites/llm/grpo-llama3.1-8b-instruct-1n8g-megatron-fp8-rollouts.v2.sh
+++ b/tests/test_suites/llm/grpo-llama3.1-8b-instruct-1n8g-megatron-fp8-rollouts.v2.sh
@@ -35,5 +35,5 @@ uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
 if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
     uv run tests/check_metrics.py $JSON_METRICS \
         'mean(data["train/token_mult_prob_error"]) < 1.1' \
-        'data["train/token_mult_prob_error"]["100"] < 1.1'
+        'data["train/token_mult_prob_error"]["40"] < 1.1'
 fi


### PR DESCRIPTION
A fix missed in my earlier commit: https://github.com/NVIDIA-NeMo/RL/pull/1231

tested locally and passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted validation to check token probability error thresholds at step 40 (previously 100) for LLM rollouts. Maintains existing gating on maximum step completion while improving CI reliability and reducing test flakiness. No impact on model behavior or user features.
* **Chores**
  * Operational test tuning only; no user-facing functionality, performance, or UI changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->