### PR TITLE
feat: Update Theoretical TFLOPS

### DIFF
--- a/nemo_rl/utils/flops_tracker.py
+++ b/nemo_rl/utils/flops_tracker.py
@@ -16,6 +16,7 @@ from dataclasses import asdict
 from typing import Callable, Optional
 
 import torch
+from packaging.version import Version as PkgVersion
 from transformers import AutoConfig
 from transformers.configuration_utils import PretrainedConfig
 from transformers.models.llama.configuration_llama import LlamaConfig
@@ -80,19 +81,27 @@ def convert_config_to_flops_config(
         raise ValueError(f"Unsupported config type: {type(config)}")
 
 
+def is_using_tf32() -> bool:
+    """Check if the current device is using TF32."""
+    if PkgVersion(torch.__version__) < PkgVersion("2.9.0a0"):
+        return torch.backends.cuda.matmul.allow_tf32
+    else:
+        return torch.backends.cuda.matmul.fp32_precision == "tf32"
+
+
 THEORETICAL_TFLOPS = {
     ("NVIDIA A100 80GB PCIe", torch.bfloat16): 624 / 2,
-    ("NVIDIA A100 80GB PCIe", torch.float32): 19.5,
+    ("NVIDIA A100 80GB PCIe", torch.float32): 312 / 2 if is_using_tf32() else 19.5,
     ("NVIDIA H100 80GB HBM3", torch.bfloat16): 1979 / 2,
-    ("NVIDIA H100 80GB HBM3", torch.float32): 67.0,
-    ("NVIDIA B200", torch.float32): 80.0,
+    ("NVIDIA H100 80GB HBM3", torch.float32): 989 / 2 if is_using_tf32() else 67.0,
     ("NVIDIA B200", torch.bfloat16): 4500 / 2,
-    ("NVIDIA B300", torch.float32): 80.0,
+    ("NVIDIA B200", torch.float32): 2200 / 2 if is_using_tf32() else 80.0,
     ("NVIDIA B300", torch.bfloat16): 4500 / 2,
-    ("NVIDIA GB200", torch.float32): 80.0,
+    ("NVIDIA B300", torch.float32): 2200 / 2 if is_using_tf32() else 80.0,
     ("NVIDIA GB200", torch.bfloat16): 4900 / 2,
-    ("NVIDIA GB300", torch.float32): 80.0,
+    ("NVIDIA GB200", torch.float32): 2500 / 2 if is_using_tf32() else 80.0,
     ("NVIDIA GB300", torch.bfloat16): 4900 / 2,
+    ("NVIDIA GB300", torch.float32): 2500 / 2 if is_using_tf32() else 80.0,
 }
 
 


### PR DESCRIPTION
# What does this PR do ?

Update TFLOPS of other GPUs

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded FLOPS tracking to recognize newer NVIDIA GPUs: B200, B300, GB200, and GB300.
  * Automatically reports theoretical performance for both float32 and bfloat16 on these devices, consistent with existing A100/H100 support.
  * Improves accuracy and completeness of performance metrics when running on supported hardware.
  * No user action required—FLOPS estimates will be applied automatically based on detected device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->