### PR TITLE
docs: add missing async_grpo.enabled flag to configuration

### DIFF
--- a/docs/guides/async-grpo.md
+++ b/docs/guides/async-grpo.md
@@ -39,6 +39,7 @@ policy:
 ```yaml
 grpo:
   async_grpo:
+    enabled: true
     max_trajectory_age_steps: 1  # Maximum age, in training steps, for trajectories
 ```
 
@@ -62,6 +63,7 @@ grpo:
   num_prompts_per_step: 32
   num_generations_per_prompt: 4
   async_grpo:
+    enabled: true
     max_trajectory_age_steps: 1
 
 cluster:


### PR DESCRIPTION
# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Async GRPO guide to include clear instructions for enabling the feature via configuration.
  * Added examples demonstrating how to turn on Async GRPO in both relevant configuration sections.
  * Clarified enablement behavior and expectations without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->