### PR TITLE
fix: moonlight CI test mem regression (increase cache flush)

### DIFF
--- a/examples/configs/recipes/llm/grpo-moonlight-16ba3b-4n8g-megatron.yaml
+++ b/examples/configs/recipes/llm/grpo-moonlight-16ba3b-4n8g-megatron.yaml
@@ -22,6 +22,7 @@ policy:
   optimizer: null
   megatron_cfg:
     enabled: true
+    empty_unused_memory_level: 1
     expert_model_parallel_size: 4
     pipeline_model_parallel_size: 4
     num_layers_in_first_pipeline_stage: 7


### PR DESCRIPTION
# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a configuration option to control how aggressively unused GPU memory is released for Megatron-based models (default: level 1). This can reduce peak memory usage and improve stability on constrained hardware. Existing setups continue to work without changes; behavior remains the same unless you adjust this setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->