### PR TITLE
fix: make sft dynamic batch step time check more stable

### DIFF
--- a/tests/test_suites/llm/sft-llama3.1-8b-1n8g-fsdp2tp1-dynamicbatch.sh
+++ b/tests/test_suites/llm/sft-llama3.1-8b-1n8g-fsdp2tp1-dynamicbatch.sh
@@ -38,5 +38,5 @@ if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | ma
 	    'data["train/loss"]["1"] < 0.6' \
         'data["train/loss"]["250"] < 0.36' \
         'max(data["ray/node.0.gpu.0.mem_gb"]) < 70' \
-        'mean(data["timing/train/total_step_time"], 2) < 10'
+        'mean(data["timing/train/total_step_time"], -6, -1) < 10'
 fi


### PR DESCRIPTION
Failure seems to have been there since the beginning, usually the threshold is barely crossed

```
                                 Metric Checks                                  
┏━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Status ┃ Check                  ┃ Value              ┃ Message               ┃
┡━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━┩
│ PASS   │ data["train/loss"]["1… │ 0.5874428153038025 │                       │
│        │ < 0.6                  │                    │                       │
│ PASS   │ data["train/loss"]["2… │ 0.3165355920791626 │                       │
│        │ < 0.36                 │                    │                       │
│ PASS   │ max(data["ray/node.0.… │ 68.64453125        │                       │
│        │ < 70                   │                    │                       │
│ FAIL   │ mean(data["timing/tra… │ 10.07073718764217  │ mean(data["timing/tr… │
│        │ 2) < 10                │                    │ 2) < 10 (condition    │
│        │                        │                    │ evaluated to False)   │
└────────┴────────────────────────┴────────────────────┴───────────────────────┘
```

It's biased a little high because it also includes the checkpointing https://wandb.ai/nvidia/nemo-rl/panel/z7zystoxj?nw=rv5zmj1j76g&yAxisMax=13

<img width="1019" height="901" alt="image" src="https://github.com/user-attachments/assets/7699a2ba-d07a-4f95-a612-2617a8b3e2e9" />

The performance seems to be pretty high variance between commits, even the initial commit had a step time pretty close to 10

```
                                 Metric Checks                             
┏━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓┃ Status ┃ Check                                 ┃ Value             ┃ Message ┃┡━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
│ PASS   │ mean(data["timing/train/total_step_t… │ 9.983369773650265 │         │   │        │ 2) < 10                               │                   │         │   └────────┴───────────────────────────────────────┴───────────────────┴─────────┘
```

Averaging just the last steps seems to give a larger gap and fewer false positives