### PR TITLE
fix: remove noisy qwen2 vl nightly test loss check

### DIFF
--- a/tests/test_suites/vlm/vlm_grpo-qwen2.5-vl-3b-instruct-clevr-1n2g-dtensor2tp1.v1.sh
+++ b/tests/test_suites/vlm/vlm_grpo-qwen2.5-vl-3b-instruct-clevr-1n2g-dtensor2tp1.v1.sh
@@ -34,7 +34,6 @@ uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
 # Only run metrics if the target step is reached
 if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
     uv run tests/check_metrics.py $JSON_METRICS \
-        'data["train/loss"]["200"] < 0.1' \
         'data["train/reward"]["200"] > 0.9'
 fi
 


### PR DESCRIPTION
# What does this PR do ?

The loss check for this test does not follow any particular trend and just hovers. In general we shouldn't use train/loss in grpo nightlies:

<img width="1024" height="947" alt="image" src="https://github.com/user-attachments/assets/a75ddc54-f810-44ed-8ca6-d0b1ba499a54" />


https://wandb.ai/nvidia/nemo-rl/panel/952wk61kd?nw=u4eso5k9jwb

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified automated validation by removing the loss threshold check; success is now determined solely by meeting the reward metric at the target step.
  * Aligns test success criteria with observed training outcomes for more stable test behavior.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->