### PR TITLE
fix: colocated.resources.gpus_per_node is now required for colocated setups

### DIFF
--- a/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-2n8g-fsdp2tp1-noncolocated.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-2n8g-fsdp2tp1-noncolocated.yaml
@@ -42,6 +42,7 @@ policy:
     colocated:
       enabled: false
       resources:
+        gpus_per_node: 8
         num_nodes: 1
 data:
   max_input_seq_length: 4096

--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -304,8 +304,8 @@ def setup(
 
         # validate and configure resources
         if cluster_config["num_nodes"] == 1:
-            assert inference_gpus_per_node > 0, (
-                "policy.generation.colocated.resources.gpus_per_node must be > 0 "
+            assert inference_gpus_per_node is not None and inference_gpus_per_node > 0, (
+                "policy.generation.colocated.resources.gpus_per_node must be explicitly set to a value > 0 "
                 "when cluster.num_nodes = 1 and inference is non-colocated, "
                 f"but got {inference_gpus_per_node}."
             )
@@ -322,15 +322,11 @@ def setup(
                 "when cluster.num_nodes > 1 and inference is non-colocated, "
                 f"but got {inference_nodes}."
             )
-            assert (
-                inference_gpus_per_node is None
-                or inference_gpus_per_node == cluster_config["gpus_per_node"]
-            ), (
-                "policy.generation.colocated.resources.gpus_per_node must be equal to cluster.gpus_per_node or set to null "
+            assert inference_gpus_per_node is not None and inference_gpus_per_node == cluster_config["gpus_per_node"], (
+                "policy.generation.colocated.resources.gpus_per_node must be explicitly set and equal to cluster.gpus_per_node "
                 "when cluster.num_nodes > 1 and inference is non-colocated, "
-                f"but got {inference_gpus_per_node}."
+                f"but got inference_gpus_per_node={inference_gpus_per_node}, cluster.gpus_per_node={cluster_config['gpus_per_node']}."
             )
-            inference_gpus_per_node = cluster_config["gpus_per_node"]
             train_nodes -= inference_nodes
 
         # create clusters

--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -304,7 +304,9 @@ def setup(
 
         # validate and configure resources
         if cluster_config["num_nodes"] == 1:
-            assert inference_gpus_per_node is not None and inference_gpus_per_node > 0, (
+            assert (
+                inference_gpus_per_node is not None and inference_gpus_per_node > 0
+            ), (
                 "policy.generation.colocated.resources.gpus_per_node must be explicitly set to a value > 0 "
                 "when cluster.num_nodes = 1 and inference is non-colocated, "
                 f"but got {inference_gpus_per_node}."
@@ -322,7 +324,10 @@ def setup(
                 "when cluster.num_nodes > 1 and inference is non-colocated, "
                 f"but got {inference_nodes}."
             )
-            assert inference_gpus_per_node is not None and inference_gpus_per_node == cluster_config["gpus_per_node"], (
+            assert (
+                inference_gpus_per_node is not None
+                and inference_gpus_per_node == cluster_config["gpus_per_node"]
+            ), (
                 "policy.generation.colocated.resources.gpus_per_node must be explicitly set and equal to cluster.gpus_per_node "
                 "when cluster.num_nodes > 1 and inference is non-colocated, "
                 f"but got inference_gpus_per_node={inference_gpus_per_node}, cluster.gpus_per_node={cluster_config['gpus_per_node']}."

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -305,8 +305,8 @@ def setup(
         # validate and configure resources
         if policy_nodes == 1:
             # When policy_nodes == 1, train and inference are on the same node
-            assert inference_gpus_per_node > 0, (
-                "policy.generation.colocated.resources.gpus_per_node must be > 0 "
+            assert inference_gpus_per_node is not None and inference_gpus_per_node > 0, (
+                "policy.generation.colocated.resources.gpus_per_node must be explicitly set to a value > 0 "
                 "when policy_nodes = 1 and inference is non-colocated, "
                 f"but got {inference_gpus_per_node}."
             )
@@ -338,15 +338,11 @@ def setup(
                 "when cluster.num_nodes > 1 and inference is non-colocated, "
                 f"but got {inference_nodes}."
             )
-            assert (
-                inference_gpus_per_node is None
-                or inference_gpus_per_node == cluster_config["gpus_per_node"]
-            ), (
-                "policy.generation.colocated.resources.gpus_per_node must be equal to cluster.gpus_per_node or set to null "
+            assert inference_gpus_per_node is not None and inference_gpus_per_node == cluster_config["gpus_per_node"], (
+                "policy.generation.colocated.resources.gpus_per_node must be explicitly set and equal to cluster.gpus_per_node "
                 "when cluster.num_nodes > 1 and inference is non-colocated, "
-                f"but got {inference_gpus_per_node}."
+                f"but got inference_gpus_per_node={inference_gpus_per_node}, cluster.gpus_per_node={cluster_config['gpus_per_node']}."
             )
-            inference_gpus_per_node = cluster_config["gpus_per_node"]
             train_nodes -= inference_nodes
 
         # initialize train cluster

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -305,7 +305,9 @@ def setup(
         # validate and configure resources
         if policy_nodes == 1:
             # When policy_nodes == 1, train and inference are on the same node
-            assert inference_gpus_per_node is not None and inference_gpus_per_node > 0, (
+            assert (
+                inference_gpus_per_node is not None and inference_gpus_per_node > 0
+            ), (
                 "policy.generation.colocated.resources.gpus_per_node must be explicitly set to a value > 0 "
                 "when policy_nodes = 1 and inference is non-colocated, "
                 f"but got {inference_gpus_per_node}."
@@ -338,7 +340,10 @@ def setup(
                 "when cluster.num_nodes > 1 and inference is non-colocated, "
                 f"but got {inference_nodes}."
             )
-            assert inference_gpus_per_node is not None and inference_gpus_per_node == cluster_config["gpus_per_node"], (
+            assert (
+                inference_gpus_per_node is not None
+                and inference_gpus_per_node == cluster_config["gpus_per_node"]
+            ), (
                 "policy.generation.colocated.resources.gpus_per_node must be explicitly set and equal to cluster.gpus_per_node "
                 "when cluster.num_nodes > 1 and inference is non-colocated, "
                 f"but got inference_gpus_per_node={inference_gpus_per_node}, cluster.gpus_per_node={cluster_config['gpus_per_node']}."

--- a/tests/unit/algorithms/test_distillation.py
+++ b/tests/unit/algorithms/test_distillation.py
@@ -353,12 +353,13 @@ def test_check_vocab_equality_config_vocab_size_mismatch_raises(monkeypatch):
 
 def test_noncolocated_inference_requires_explicit_gpus_per_node_single_node():
     """Test that non-colocated inference requires explicit gpus_per_node when cluster.num_nodes=1."""
+    from unittest.mock import MagicMock, patch
+
     from nemo_rl.algorithms.distillation import setup
 
     # Create minimal config with non-colocated inference but gpus_per_node=None
     master_config = {
         "policy": {
-            "model_name": "test-student-model",
             "generation": {
                 "backend": "vllm",
                 "colocated": {
@@ -369,50 +370,60 @@ def test_noncolocated_inference_requires_explicit_gpus_per_node_single_node():
                     },
                 },
             },
+            "dtensor_cfg": {
+                "enabled": False,
+            },
         },
         "teacher": {
-            "model_name": "test-teacher-model",
+            "dtensor_cfg": {
+                "enabled": False,
+            },
         },
-        "loss_fn": {
-            "kl_type": "forward",
-            "mixed_kl_weight": 0.5,
-            "zero_outside_topk": False,
-        },
+        "loss_fn": {},
         "distillation": {
             "seed": 42,
-            "num_prompts_per_step": 1,
-            "val_period": 0,
-            "val_at_start": False,
             "topk_logits_k": 64,
+            "num_prompts_per_step": 1,  # Config extraction requires this key
+            "val_period": 0,  # Config extraction requires this key
+            "val_at_start": False,  # Config extraction requires this key
         },
         "data": {"shuffle": False},
-        "logger": {},
+        "logger": {},  # Config extraction requires this key
+        "checkpointing": {},  # Config extraction requires this key
         "cluster": {
             "num_nodes": 1,  # Single node
             "gpus_per_node": 8,
         },
-        "checkpointing": {},
     }
 
     tokenizer = MagicMock()
     dataset = MagicMock()
     dataset.__len__ = MagicMock(return_value=10)
-    
-    with pytest.raises(
-        AssertionError,
-        match="policy.generation.colocated.resources.gpus_per_node must be explicitly set"
+
+    # Mock everything we don't need to test
+    with (
+        patch("nemo_rl.algorithms.distillation.Logger") as mock_logger,
+        patch("nemo_rl.algorithms.distillation.CheckpointManager") as mock_checkpointer,
+        patch("nemo_rl.algorithms.distillation.StatefulDataLoader"),
+        pytest.raises(
+            AssertionError,
+            match="policy.generation.colocated.resources.gpus_per_node must be explicitly set",
+        ),
     ):
+        # Configure mocks to skip checkpoint loading
+        mock_checkpointer.return_value.get_latest_checkpoint_path.return_value = None
         setup(master_config, tokenizer, dataset, None)
 
 
 def test_noncolocated_inference_requires_explicit_gpus_per_node_multi_node():
     """Test that non-colocated inference requires explicit gpus_per_node when cluster.num_nodes>1."""
+    from unittest.mock import MagicMock, patch
+
     from nemo_rl.algorithms.distillation import setup
 
     # Create minimal config with non-colocated inference but gpus_per_node=None
     master_config = {
         "policy": {
-            "model_name": "test-student-model",
             "generation": {
                 "backend": "vllm",
                 "colocated": {
@@ -423,37 +434,46 @@ def test_noncolocated_inference_requires_explicit_gpus_per_node_multi_node():
                     },
                 },
             },
+            "dtensor_cfg": {
+                "enabled": False,
+            },
         },
         "teacher": {
-            "model_name": "test-teacher-model",
+            "dtensor_cfg": {
+                "enabled": False,
+            },
         },
-        "loss_fn": {
-            "kl_type": "forward",
-            "mixed_kl_weight": 0.5,
-            "zero_outside_topk": False,
-        },
+        "loss_fn": {},
         "distillation": {
             "seed": 42,
-            "num_prompts_per_step": 1,
-            "val_period": 0,
-            "val_at_start": False,
             "topk_logits_k": 64,
+            "num_prompts_per_step": 1,  # Config extraction requires this key
+            "val_period": 0,  # Config extraction requires this key
+            "val_at_start": False,  # Config extraction requires this key
         },
         "data": {"shuffle": False},
-        "logger": {},
+        "logger": {},  # Config extraction requires this key
+        "checkpointing": {},  # Config extraction requires this key
         "cluster": {
             "num_nodes": 2,  # Multi-node
             "gpus_per_node": 8,
         },
-        "checkpointing": {},
     }
 
     tokenizer = MagicMock()
     dataset = MagicMock()
     dataset.__len__ = MagicMock(return_value=10)
-    
-    with pytest.raises(
-        AssertionError,
-        match="policy.generation.colocated.resources.gpus_per_node must be explicitly set"
+
+    # Mock everything we don't need to test
+    with (
+        patch("nemo_rl.algorithms.distillation.Logger") as mock_logger,
+        patch("nemo_rl.algorithms.distillation.CheckpointManager") as mock_checkpointer,
+        patch("nemo_rl.algorithms.distillation.StatefulDataLoader"),
+        pytest.raises(
+            AssertionError,
+            match="policy.generation.colocated.resources.gpus_per_node must be explicitly set",
+        ),
     ):
+        # Configure mocks to skip checkpoint loading
+        mock_checkpointer.return_value.get_latest_checkpoint_path.return_value = None
         setup(master_config, tokenizer, dataset, None)

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -214,13 +214,13 @@ def test_calculate_rewards_missing_environment():
 
 def test_noncolocated_inference_requires_explicit_gpus_per_node_single_node():
     """Test that non-colocated inference requires explicit gpus_per_node when policy_nodes=1."""
-    from unittest.mock import MagicMock
+    from unittest.mock import MagicMock, patch
+
     from nemo_rl.algorithms.grpo import setup
 
-    # Create minimal config with non-colocated inference but gpus_per_node=None
+    # Create minimal config - only what's needed before the validation we're testing
     master_config = {
         "policy": {
-            "model_name": "test-model",
             "generation": {
                 "backend": "vllm",
                 "colocated": {
@@ -232,38 +232,51 @@ def test_noncolocated_inference_requires_explicit_gpus_per_node_single_node():
                 },
             },
         },
-        "loss_fn": {},
-        "env": {},
-        "grpo": {"seed": 42, "num_prompts_per_step": 1, "val_period": 0, "val_at_start": False},
+        "loss_fn": {},  # Config extraction requires this key
+        "env": {},  # Config extraction requires this key
+        "grpo": {
+            "seed": 42,
+            "num_prompts_per_step": 1,
+            "val_period": 0,
+            "val_at_start": False,
+        },
         "data": {"shuffle": False},
-        "logger": {},
+        "logger": {},  # Config extraction requires this key
+        "checkpointing": {},  # Config extraction requires this key
         "cluster": {
             "num_nodes": 1,  # Single node, so policy_nodes=1
             "gpus_per_node": 8,
         },
-        "checkpointing": {},
     }
 
     tokenizer = MagicMock()
     dataset = MagicMock()
     dataset.__len__ = MagicMock(return_value=10)
-    
-    with pytest.raises(
-        AssertionError,
-        match="policy.generation.colocated.resources.gpus_per_node must be explicitly set"
+
+    # Mock everything we don't need to test
+    with (
+        patch("nemo_rl.algorithms.grpo.Logger") as mock_logger,
+        patch("nemo_rl.algorithms.grpo.CheckpointManager") as mock_checkpointer,
+        patch("nemo_rl.algorithms.grpo.StatefulDataLoader"),
+        pytest.raises(
+            AssertionError,
+            match="policy.generation.colocated.resources.gpus_per_node must be explicitly set",
+        ),
     ):
+        # Configure mocks to skip checkpoint loading
+        mock_checkpointer.return_value.get_latest_checkpoint_path.return_value = None
         setup(master_config, tokenizer, dataset, None)
 
 
 def test_noncolocated_inference_requires_explicit_gpus_per_node_multi_node():
     """Test that non-colocated inference requires explicit gpus_per_node when policy_nodes>1."""
-    from unittest.mock import MagicMock
+    from unittest.mock import MagicMock, patch
+
     from nemo_rl.algorithms.grpo import setup
 
-    # Create minimal config with non-colocated inference but gpus_per_node=None
+    # Create minimal config - only what's needed before the validation we're testing
     master_config = {
         "policy": {
-            "model_name": "test-model",
             "generation": {
                 "backend": "vllm",
                 "colocated": {
@@ -275,24 +288,37 @@ def test_noncolocated_inference_requires_explicit_gpus_per_node_multi_node():
                 },
             },
         },
-        "loss_fn": {},
-        "env": {},
-        "grpo": {"seed": 42, "num_prompts_per_step": 1, "val_period": 0, "val_at_start": False},
+        "loss_fn": {},  # Config extraction requires this key
+        "env": {},  # Config extraction requires this key
+        "grpo": {
+            "seed": 42,
+            "num_prompts_per_step": 1,
+            "val_period": 0,
+            "val_at_start": False,
+        },
         "data": {"shuffle": False},
-        "logger": {},
+        "logger": {},  # Config extraction requires this key
+        "checkpointing": {},  # Config extraction requires this key
         "cluster": {
             "num_nodes": 2,  # Multi-node, so policy_nodes=1 after subtracting inference
             "gpus_per_node": 8,
         },
-        "checkpointing": {},
     }
 
     tokenizer = MagicMock()
     dataset = MagicMock()
     dataset.__len__ = MagicMock(return_value=10)
-    
-    with pytest.raises(
-        AssertionError,
-        match="policy.generation.colocated.resources.gpus_per_node must be explicitly set"
+
+    # Mock everything we don't need to test
+    with (
+        patch("nemo_rl.algorithms.grpo.Logger") as mock_logger,
+        patch("nemo_rl.algorithms.grpo.CheckpointManager") as mock_checkpointer,
+        patch("nemo_rl.algorithms.grpo.StatefulDataLoader"),
+        pytest.raises(
+            AssertionError,
+            match="policy.generation.colocated.resources.gpus_per_node must be explicitly set",
+        ),
     ):
+        # Configure mocks to skip checkpoint loading
+        mock_checkpointer.return_value.get_latest_checkpoint_path.return_value = None
         setup(master_config, tokenizer, dataset, None)


### PR DESCRIPTION
Initially I set out to fix the failing config (`examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-2n8g-fsdp2tp1-noncolocated.yaml`) since it was now missing `colocated.resources.gpus_per_node`, which is now mandatory.

I also cleaned up the code to properly give an error for this improper configuration and added tests for it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Enforce explicit gpus_per_node for non-colocated inference. Single-node requires >0; multi-node must equal cluster gpus_per_node. Improved, clearer error messages on misconfiguration.

- Documentation
  - Updated example recipe to include gpus_per_node under colocated resources to clarify GPU allocation per node.

- Tests
  - Added unit tests for single- and multi-node scenarios verifying the explicit gpus_per_node requirement and corresponding error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->