### PR TITLE
feat: Generation sampling params

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1041,6 +1041,17 @@ def validate(
         print("  ⚠️ No validation dataloader provided, skipping validation", flush=True)
         return {}, {}
 
+    val_sampling_params = {}
+    val_temperature = master_config["grpo"].get("val_temperature", None)
+    if val_temperature is not None:
+        val_sampling_params["temperature"] = val_temperature
+    val_top_p = master_config["grpo"].get("val_top_p", None)
+    if val_top_p is not None:
+        val_sampling_params["top_p"] = val_top_p
+    val_top_k = master_config["grpo"].get("val_top_k", None)
+    if val_top_k is not None:
+        val_sampling_params["top_k"] = val_top_k
+
     timer = Timer()
     with timer.time("total_validation_time"):
         print(f"▶ Starting validation at step {step}...", flush=True)
@@ -1068,6 +1079,7 @@ def validate(
                     max_seq_len=master_config["policy"]["max_total_sequence_length"],
                     max_rollout_turns=master_config["grpo"]["max_rollout_turns"],
                     greedy=False,
+                    sampling_params=val_sampling_params,
                 )
             else:
                 val_batch, gen_metrics = run_multi_turn_rollout(
@@ -1078,6 +1090,7 @@ def validate(
                     max_seq_len=master_config["policy"]["max_total_sequence_length"],
                     max_rollout_turns=master_config["grpo"]["max_rollout_turns"],
                     greedy=False,
+                    sampling_params=val_sampling_params,
                 )
             rewards = val_batch["total_reward"]
 

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -409,12 +409,16 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
         self,
         data: BatchedDataDict[GenerationDatumSpec],
         greedy: bool = False,
+        sampling_params: Optional[dict] = None,
     ) -> AsyncGenerator[tuple[int, BatchedDataDict[GenerationOutputSpec]], None]:
         """Generate a batch of data using vLLM's AsyncLLMEngine, yielding results as they are ready.
 
         Args:
             data: BatchedDataDict with input_ids and input_lengths
             greedy: Whether to use greedy decoding instead of sampling
+            sampling_params: (Optional) Generation sampling parameters.
+                Note that setting `greedy` will override these parameters.
+                Currently supports: temperature, top_p, top_k.
 
         Yields:
             Tuple of (original_index, BatchedDataDict conforming to GenerationOutputSpec for the single sequence)
@@ -444,8 +448,11 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
             "stop_strings", [[] for _ in range(batch_size)]
         )
 
+        if sampling_params is None:
+            sampling_params = {}
+
         # Create tasks for each sample in the batch
-        async def process_single_sample(sample_idx):
+        async def process_single_sample(sample_idx, sampling_params):
             """Process a single sample and return the result."""
             current_input_actual_length = input_lengths_batch[sample_idx].item()
             prompt = format_prompt_for_vllm_generation(data, sample_idx)
@@ -506,6 +513,7 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
                 greedy=greedy,
                 stop_strings=final_stop_strings_for_sample,
                 max_new_tokens=allowed_new_tokens,
+                **sampling_params
             )
 
             request_id = str(uuid.uuid4())
@@ -609,7 +617,8 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
 
         # Create tasks for all samples and yield results as they complete
         sample_tasks = [
-            asyncio.create_task(process_single_sample(i)) for i in range(batch_size)
+            asyncio.create_task(process_single_sample(i, sampling_params))
+            for i in range(batch_size)
         ]
 
         # Yield results as they become available
@@ -626,13 +635,19 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
                 raise e
 
     async def generate_text_async(
-        self, data: BatchedDataDict[GenerationDatumSpec], greedy: bool = False
+        self,
+        data: BatchedDataDict[GenerationDatumSpec],
+        greedy: bool = False,
+        sampling_params: Optional[dict] = None,
     ) -> AsyncGenerator[tuple[int, BatchedDataDict[GenerationOutputSpec]], None]:
         """Generate text responses asynchronously, yielding results as they are ready.
 
         Args:
             data: BatchedDataDict containing prompts with text strings
             greedy: Whether to use greedy decoding instead of sampling
+            sampling_params: (Optional) Generation sampling parameters.
+                Note that setting `greedy` will override these parameters.
+                Currently supports: temperature, top_p, top_k.
 
         Yields:
             Tuple of (original_index, BatchedDataDict containing single text response)
@@ -654,8 +669,11 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
             "stop_strings", [self.cfg.get("stop_strings")] * batch_size
         )
 
+        if sampling_params is None:
+            sampling_params = {}
+
         # Create tasks for each prompt
-        async def process_single_prompt(prompt_idx):
+        async def process_single_prompt(prompt_idx, sampling_params: dict):
             """Process a single prompt and return the result."""
             prompt = prompts[prompt_idx]
 
@@ -670,15 +688,10 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
             )
 
             # Create sampling parameters
-            top_k = self.cfg["top_k"] if self.cfg["top_k"] is not None else -1
-            sampling_params = self.SamplingParams(
-                temperature=self.cfg["temperature"] if not greedy else 0,
-                top_p=self.cfg["top_p"],
-                top_k=top_k if not greedy else 1,
-                max_tokens=self.cfg["max_new_tokens"],
-                stop_token_ids=self.cfg["stop_token_ids"],
-                stop=final_stop_strings,
-                include_stop_str_in_output=True,  # returning stop strings like hf
+            sampling_params = self._build_sampling_params(
+                greedy=greedy,
+                stop_strings=final_stop_strings,
+                **sampling_params
             )
 
             request_id = str(uuid.uuid4())
@@ -710,7 +723,8 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
 
         # Create tasks for all prompts and yield results as they complete
         prompt_tasks = [
-            asyncio.create_task(process_single_prompt(i)) for i in range(batch_size)
+            asyncio.create_task(process_single_prompt(i, sampling_params))
+            for i in range(batch_size)
         ]
 
         # Yield results as they become available


### PR DESCRIPTION
# What does this PR do ?

Generation-related functionality accepts optional sampling params which overrides the default sampling params in the generation config. This may be useful e.g. for using different sampling params during validation than during training.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
