### PR TITLE
chore: 0.4.0.rc0 -> 0.4.0

### DIFF
--- a/nemo_rl/package_info.py
+++ b/nemo_rl/package_info.py
@@ -16,7 +16,7 @@
 MAJOR = 0
 MINOR = 4
 PATCH = 0
-PRE_RELEASE = "rc0"
+PRE_RELEASE = ""
 
 # Use the following formatting: (major, minor, patch, pre-release)
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)


### PR DESCRIPTION
# What does this PR do ?

chore: 0.4.0.rc0 -> 0.4.0

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Promoted package from release candidate to stable release. The version string no longer includes the “rc” suffix (e.g., 1.x.y instead of 1.x.yrc0).
  - Users will see the updated version in package metadata, CLI/version outputs, and logs.
  - Improves compatibility with tooling expecting final releases and may affect dependency resolution and PyPI packaging tags.
  - No functional changes to features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->