### PR TITLE
fix: Reinitialize model parallel after import

### DIFF
--- a/nemo_rl/models/policy/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/megatron_policy_worker.py
@@ -507,6 +507,10 @@ class MegatronPolicyWorker:
                 hf_model_name, pretrained_path, self.cfg["megatron_cfg"]
             )
 
+            if parallel_state.model_parallel_is_initialized():
+                print("Reinitializing model parallel after loading model state.")
+                parallel_state.destroy_model_parallel()
+
         pretrained_run_config = os.path.join(
             pretrained_path, "iter_0000000/run_config.yaml"
         )


### PR DESCRIPTION
# What does this PR do ?

This PR re-initializes the model parallel state after parallel model loading. This resolves the issue where the parallelism used during model loading is different from that used in training. This materializes in the error in #1300. 

In particular, the error occurred because the distributed model import process (`import_model_from_hf_name()`) initializes the model parallel state with default values (CP=1), leading to incorrect data parallel size calculations. When training begins, the system finds the parallel state already initialized with the wrong configuration and skips reinitialization, resulting in a training job launched with an incorrect value for DP. 

The reinitialization results in a *one-time performance cost* when *initially* loading the model. Subsequent training runs that load from checkpoints don't encounter this and hence don't incur this cost. 

# Issues

This PR resolves #1300.

# Usage

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents reinitialization conflicts in model-parallel setups when loading models from Hugging Face by safely resetting any existing parallel state. This reduces crashes, hangs, and inconsistent behavior in distributed runs and provides clearer log messaging during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->