### PR TITLE
cp: `docs: Hardcode docs github url (1328)` into `r0.4.0`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -191,7 +191,9 @@ class _GitHubLinkTransform(Transform):
     def apply(self, **kwargs: Any) -> None:  # type: ignore[bad-override]
         try:
             local_repo = git.Repo(search_parent_directories=True)
-            remote_repo_url = self._get_github_source_url(local_repo)
+            # Hardcode github url for now due to errors when building in a different environment
+            # remote_repo_url = self._get_github_source_url(local_repo)
+            remote_repo_url = "https://github.com/NVIDIA-NeMo/RL"
         except Exception:
             # Cannot figure out which source url it should be; leave links as-is.
             return


### PR DESCRIPTION
beep boop [🤖]: Hi @chtruong814 👋,

    we've cherry picked #1328 into  for you! 🚀

    Please review and approve this cherry pick by your convenience!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Standardized documentation source links to consistently point to the correct GitHub repository.
  - Improves reliability of “View source”/“Edit on GitHub” links across the docs.
  - Reduces risk of broken or mismatched links; graceful fallback remains unchanged if link generation fails.
  - No impact on application behavior; change only affects documentation link generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->