### PR TITLE
fix: Fix the logger error in non-colocated sync-grpo code path

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1777,9 +1777,6 @@ def async_grpo_train(
                 train_results, metrics, timing_metrics, master_config
             )
 
-            if "per_worker_token_counts" in metrics:
-                del metrics["per_worker_token_counts"]
-
             logger.log_metrics(performance_metrics, step + 1, prefix="performance")
             logger.log_metrics(metrics, step + 1, prefix="train")
             logger.log_metrics(timing_metrics, step + 1, prefix="timing/train")

--- a/nemo_rl/algorithms/utils.py
+++ b/nemo_rl/algorithms/utils.py
@@ -554,6 +554,15 @@ def print_performance_metrics(
             )
 
     # =====================================================
+    # Clean up metrics
+    # =====================================================
+
+    # Clean up metrics to avoid wandb logging errors
+    # Dict structures cannot be logged to wandb
+    if "per_worker_token_counts" in metrics:
+        del metrics["per_worker_token_counts"]
+
+    # =====================================================
     # Logging
     # =====================================================
 


### PR DESCRIPTION
# What does this PR do ?

There was a bug when using non-colocated but sync-grpo code path.
metric['per_worker_token_counts'] is a dict type which cannot be logged in wandb. 
The existing code was deleting this only for async-grpo training loop. 
This PR moves the deletion code to the perf metric function, which could affect all the use cases.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Expanded logged metrics to include per-worker token counts across training, performance, and timing views.
  * Improved clarity and completeness of reported metrics during runs.

* **Bug Fixes**
  * Prevented errors during metric visualization by automatically removing incompatible entries before rendering.
  * Increased robustness of logging with third-party integrations to reduce interruptions during runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->