### PR TITLE
cp: `chore: add chat_template_kwargs in default train configs (1353)` into `r0.4.0`

### DIFF
--- a/examples/configs/distillation_math.yaml
+++ b/examples/configs/distillation_math.yaml
@@ -31,6 +31,7 @@ policy: &POLICY_BASE
     model_name: "Qwen/Qwen3-1.7B-Base"
     tokenizer:
         name: ${..model_name} ## specify if you'd like to use a tokenizer different from the model's default
+        chat_template_kwargs: null # can be used to pass kwargs to the chat template, e.g., enable_thinking=true
     train_global_batch_size: 64
     train_micro_batch_size: 1
     generation_batch_size: 64

--- a/examples/configs/dpo.yaml
+++ b/examples/configs/dpo.yaml
@@ -32,6 +32,7 @@ policy:
   model_name: "meta-llama/Llama-3.2-1B-Instruct"
   tokenizer:
     name: "meta-llama/Llama-3.2-1B-Instruct"
+    chat_template_kwargs: null # can be used to pass kwargs to the chat template, e.g., enable_thinking=true
 
   # number of preference samples per batch
   # each preference sample corresponds to a pair of chosen and rejected responses

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -46,6 +46,7 @@ policy:
   model_name: "Qwen/Qwen2.5-1.5B"
   tokenizer:
     name: ${policy.model_name} ## specify if you'd like to use a tokenizer different from the model's default
+    chat_template_kwargs: null # can be used to pass kwargs to the chat template, e.g., enable_thinking=true
   train_global_batch_size: 512
   train_micro_batch_size: 4
   generation_batch_size: 32 # Only used when generating using HF backend

--- a/examples/configs/grpo_math_1B_megatron.yaml
+++ b/examples/configs/grpo_math_1B_megatron.yaml
@@ -39,6 +39,7 @@ policy:
   model_name: "Qwen/Qwen2.5-1.5B"
   tokenizer:
     name: ${policy.model_name} ## specify if you'd like to use a tokenizer different from the model's default
+    chat_template_kwargs: null # can be used to pass kwargs to the chat template, e.g., enable_thinking=true
   train_global_batch_size: 512
   train_micro_batch_size: 4
   generation_batch_size: 64 # Only used when generating using megatron backend

--- a/examples/configs/rm.yaml
+++ b/examples/configs/rm.yaml
@@ -28,6 +28,7 @@ policy:
     # We don't use the "default" chat template because the Llama tokenizer inserts the current
     # date in the system prompt, which could make the reward model's output date-dependent.
     chat_template: "{{- bos_token }}\n\n{#- This block extracts the system message, so we can slot it into the right place. #}\n{%- if messages[0]['role'] == 'system' %}\n    {%- set system_message = messages[0]['content']|trim %}\n    {%- set messages = messages[1:] %}\n{%- else %}\n    {%- set system_message = '' %}\n{%- endif %}\n\n{#- System message #}\n{{- '<|start_header_id|>system<|end_header_id|>\n\n' }}\n{{- system_message }}\n{{- '<|eot_id|>' }}\n\n{%- for message in messages %}\n    {{- '<|start_header_id|>' + message['role'] + '<|end_header_id|>\n\n' + message['content'] | trim + '<|eot_id|>' }}\n{%- endfor %}\n{%- if add_generation_prompt %}\n    {{- '<|start_header_id|>assistant<|end_header_id>\n\n' }}\n{%- endif %}"
+    chat_template_kwargs: null # can be used to pass kwargs to the chat template, e.g., enable_thinking=true
   train_global_batch_size: 128
   train_micro_batch_size: 1
   max_total_sequence_length: 8192

--- a/examples/configs/sft.yaml
+++ b/examples/configs/sft.yaml
@@ -27,6 +27,7 @@ policy:
     name: ${policy.model_name} ## specify if you'd like to use a tokenizer different from the model's default
     # chat_template can be a Jinja template string or path to a .jinja file
     chat_template: "{% for message in messages %}{%- if message['role'] == 'system'  %}{{'Context: ' + message['content'].strip()}}{%- elif message['role'] == 'user'  %}{{' Question: ' + message['content'].strip() + ' Answer:'}}{%- elif message['role'] == 'assistant'  %}{{' ' + message['content'].strip()}}{%- endif %}{% endfor %}"
+    chat_template_kwargs: null # can be used to pass kwargs to the chat template, e.g., enable_thinking=true
   train_global_batch_size: 32
   train_micro_batch_size: 1
   max_total_sequence_length: 1024


### PR DESCRIPTION
beep boop [🤖]: Hi @yuki-97 👋,

    we've cherry picked #1353 into  for you! 🚀

    Please review and approve this cherry pick by your convenience!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional chat_template_kwargs field under policy.tokenizer in configuration examples, enabling users to pass extra arguments to chat templates (e.g., enable_thinking). Defaults to null and is backward-compatible.

* **Documentation**
  * Updated example configs to illustrate how to supply chat template keyword arguments, clarifying usage without altering existing behavior when unset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->