### PR TITLE
fix: Fix non-colocated refit when vLLM model parallel size is larger than 8

### DIFF
--- a/nemo_rl/models/generation/vllm/vllm_generation.py
+++ b/nemo_rl/models/generation/vllm/vllm_generation.py
@@ -162,15 +162,16 @@ class VllmGeneration(GenerationInterface):
         # See https://github.com/NVIDIA-NeMo/RL/issues/564 for more details.
         if not self.cfg["colocated"]["enabled"]:
             env_vars["NCCL_CUMEM_ENABLE"] = "1"
-            if needs_cross_node_parallelism:
-                # When using cross-node model parallelism with non-colocated inference,
-                # we are disabling NCCL_NVLS_ENABLE to avoid the NCCL error.
-                # See https://github.com/NVIDIA-NeMo/RL/issues/1352 for more details.
-                env_vars["NCCL_NVLS_ENABLE"] = "0"
-                print(
-                    "[INFO] NCCL_NVLS_ENABLE is set to 0 for non-colocated inference with cross-node model parallelism."
-                    "See https://github.com/NVIDIA-NeMo/RL/issues/1352 for more details."
-                )
+
+        if needs_cross_node_parallelism:
+            # When using cross-node model parallelism with non-colocated inference,
+            # we are disabling NCCL_NVLS_ENABLE to avoid the NCCL error.
+            # See https://github.com/NVIDIA-NeMo/RL/issues/1352 for more details.
+            env_vars["NCCL_NVLS_ENABLE"] = "0"
+            print(
+                "[INFO] NCCL_NVLS_ENABLE is set to 0 for non-colocated inference with cross-node model parallelism."
+                "See https://github.com/NVIDIA-NeMo/RL/issues/1352 for more details."
+            )
         # We should use vLLM DP if ep_size > tp_size since EP_SIZE = DP_SIZE * TP_SIZE in vLLM.
         # See details in https://github.com/vllm-project/vllm/blob/main/examples/offline_inference/data_parallel.py
         if self.ep_size > self.tp_size:


### PR DESCRIPTION
# What does this PR do ?

See #1352 for the details.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

Closes #1352

# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improves reliability of multi-node inference when running non-colocated with cross-node model parallelism by automatically adjusting communication settings.
  - Adds an informational log to clarify when this configuration is applied.
  - Applies the adjustment only in relevant scenarios to avoid affecting colocated runs or other setups.
  - No changes to public interfaces; behavior is transparent and aims to prevent communication issues during distributed generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->