### PR TITLE
fix: fix mcore train_iters in grpo

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -420,7 +420,10 @@ def setup(
 
     if policy_config.get("megatron_cfg", {}).get("enabled", False):
         ## NOTE: this is equal to the total number of scheduler steps
-        total_train_iters = min(grpo_config["max_num_steps"], len(dataloader))
+        total_train_iters = min(
+            grpo_config["max_num_steps"],
+            grpo_config["max_num_epochs"] * len(dataloader),
+        )
         policy_config["megatron_cfg"]["train_iters"] = total_train_iters
 
     policy = Policy(


### PR DESCRIPTION
Previously we forgot to multiple the dataloader length with `max_num_epochs` when calculating `train_iters`.
This PR will fix it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the calculation of total training iterations to provide more granular control over training duration through epoch-based configuration, allowing better flexibility in managing training sessions and step limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->