### PR TITLE
feat: Add support for IPO and RPO

### DIFF
--- a/docs/guides/dpo.md
+++ b/docs/guides/dpo.md
@@ -141,8 +141,8 @@ The DPO implementation in NeMo RL supports several key parameters that can be ad
 - `dpo.sft_loss_weight`: Weight for the auxiliary SFT loss
 - `dpo.preference_average_log_probs`: Whether to average log probabilities over tokens in the preference loss term
 - `dpo.sft_average_log_probs`: Whether to average log probabilities over tokens in the SFT loss term
-- `dpo.preference_loss`: Preference-based objective to use (choose from dpo, ipo, rpo_sq, rpo_fwd_kl, rpo_bwd_kl; default dpo)
-- `dpo.gt_reward_scale`: Reward scale for ground-truth rewards, only used in RPO (default 1.0)
+- `dpo.preference_loss`: Preference-based objective to use (choose from dpo, ipo, rpo_sq, rpo_fwd_kl, rpo_bwd_kl)
+- `dpo.gt_reward_scale`: Reward scale for ground-truth rewards, only used in RPO
 
 These parameters can be adjusted in the config file or via command-line overrides to optimize training for your specific use case.
 

--- a/docs/guides/dpo.md
+++ b/docs/guides/dpo.md
@@ -4,6 +4,11 @@
 to increase the probability of the chosen response and decrease the probability of the rejected response relative to a frozen reference model. The actor is initialized using the reference model. For more details, refer to the
 [DPO paper](https://arxiv.org/pdf/2305.18290).
 
+## Other Objectives
+
+- [Identity Preference Optimization (IPO)](https://arxiv.org/pdf/2310.12036)
+- [Reward-Aware Preference Optimization (RPO) with backward KL divergence](https://arxiv.org/pdf/2406.11704), [forward KL divergence, and squared distance](https://arxiv.org/pdf/2502.00203)
+
 ## Launch a DPO Run
 
 The script [examples/run_dpo.py](../../examples/run_dpo.py) can be used to launch a DPO experiment. This script can either be launched locally or via Slurm. For details on how to set up Ray and launch a job using Slurm, refer to the [cluster documentation](../cluster.md).
@@ -40,11 +45,13 @@ Each DPO dataset class is expected to have the following attributes:
   "completions": [ // list of dicts — The list of completions
     {
       "rank": 0, // int — The rank of the completion (lower rank is preferred)
-      "completion": [] // list of dicts — The completion message(s)
+      "completion": [], // list of dicts — The completion message(s)
+      "reward": 10.0, // Optional, float - The ground truth reward of the completion (required for rpo)
     },
     {
       "rank": 1, // int — The rank of the completion (lower rank is preferred)
-      "completion": [] // list of dicts — The completion message(s)
+      "completion": [], // list of dicts — The completion message(s)
+      "reward": 0.0, // Optional, float - The ground truth reward of the completion (required for rpo)
     }
   ]
 }
@@ -76,7 +83,8 @@ DPO training supports only two completions (where the lowest rank is preferred a
                     "role": "assistant",
                     "content": "The capital of Germany is Berlin."
                 }
-            ]
+            ],
+            "reward": 10.0 // required for rpo
         },
         {
             "rank": 1,
@@ -85,7 +93,8 @@ DPO training supports only two completions (where the lowest rank is preferred a
                     "role": "assistant",
                     "content": "The capital of Germany is Munich."
                 }
-            ]
+            ],
+            "reward": 0.0 // required for rpo
         }
     ]
 }
@@ -132,6 +141,8 @@ The DPO implementation in NeMo RL supports several key parameters that can be ad
 - `dpo.sft_loss_weight`: Weight for the auxiliary SFT loss
 - `dpo.preference_average_log_probs`: Whether to average log probabilities over tokens in the preference loss term
 - `dpo.sft_average_log_probs`: Whether to average log probabilities over tokens in the SFT loss term
+- `dpo.preference_loss`: Preference-based objective to use (choose from dpo, ipo, rpo_sq, rpo_fwd_kl, rpo_bwd_kl; default dpo)
+- `dpo.gt_reward_scale`: Reward scale for ground-truth rewards, only used in RPO (default 1.0)
 
 These parameters can be adjusted in the config file or via command-line overrides to optimize training for your specific use case.
 

--- a/docs/guides/rm.md
+++ b/docs/guides/rm.md
@@ -130,7 +130,7 @@ The reward model training implementation in NeMo RL supports key parameters that
 
 - `rm.preference_loss`: Preference-based objective to use (choose from dpo, ipo, rpo_sq, rpo_fwd_kl, rpo_bwd_kl)
 - `rm.reference_policy_kl_penalty`: Strength of the kl penalty term
-- `dpo.gt_reward_scale`: Reward scale for ground-truth rewards, only used in RPO
+- `rm.gt_reward_scale`: Reward scale for ground-truth rewards, only used in RPO
 
 ## Using Reward Models as Environments
 

--- a/docs/guides/rm.md
+++ b/docs/guides/rm.md
@@ -128,9 +128,9 @@ Please note:
 
 The reward model training implementation in NeMo RL supports key parameters that can be adjusted:
 
-- `dpo.preference_loss`: Preference-based objective to use (choose from dpo, ipo, rpo_sq, rpo_fwd_kl, rpo_bwd_kl)
-- `dpo.beta`: Scaling parameter (ex: `reference_policy_kl_penalty` in DPO)
-- `dpo.eta`: Reward scale for ground-truth rewards, only used in RPO
+- `rm.preference_loss`: Preference-based objective to use (choose from dpo, ipo, rpo_sq, rpo_fwd_kl, rpo_bwd_kl)
+- `rm.reference_policy_kl_penalty`: Strength of the kl penalty term
+- `dpo.gt_reward_scale`: Reward scale for ground-truth rewards, only used in RPO
 
 ## Using Reward Models as Environments
 

--- a/examples/configs/dpo.yaml
+++ b/examples/configs/dpo.yaml
@@ -13,7 +13,6 @@ dpo:
   preference_average_log_probs: False # whether normalizing log probs according to the sequence length in preference_loss
   sft_average_log_probs: ${.preference_average_log_probs} # whether normalizing log probs according to the sequence length in sft_loss
 
-  ## TODO(@ashors) support other loss functions
   preference_loss: dpo # the preference loss, we support dpo, ipo, rpo_sq, rpo_bwd_kl, rpo_fwd_kl
   gt_reward_scale: 1. # the scale of the rewards in RPO
   preference_loss_weight: 1 # the coefficient of the preference loss

--- a/examples/configs/dpo.yaml
+++ b/examples/configs/dpo.yaml
@@ -14,8 +14,8 @@ dpo:
   sft_average_log_probs: ${.preference_average_log_probs} # whether normalizing log probs according to the sequence length in sft_loss
 
   ## TODO(@ashors) support other loss functions
-  #preference_loss: dpo # the preference loss, we support dpo, ipo, rpo_sq, rpo_bwd_kl, rpo_fwd_kl
-  #gt_reward_scale: 1. # the scale of the rewards in RPO
+  preference_loss: dpo # the preference loss, we support dpo, ipo, rpo_sq, rpo_bwd_kl, rpo_fwd_kl
+  gt_reward_scale: 1. # the scale of the rewards in RPO
   preference_loss_weight: 1 # the coefficient of the preference loss
   sft_loss_weight: 0 # the coefficient of the SFT loss
 

--- a/examples/configs/rm.yaml
+++ b/examples/configs/rm.yaml
@@ -12,9 +12,9 @@ rm:
   val_at_start: false
   seed: 42
 
-  preference_loss: dpo
-  beta: 1.
-  eta: 1.
+  preference_loss: dpo # the preference loss type, we support dpo, ipo, rpo_sq, rpo_bwd_kl, rpo_fwd_kl
+  gt_reward_scale: 1. # the scale of the rewards in RPO
+  reference_policy_kl_penalty: 0.05 # the strength of the kl penalty term
 
 checkpointing:
   enabled: true

--- a/examples/configs/rm.yaml
+++ b/examples/configs/rm.yaml
@@ -12,6 +12,10 @@ rm:
   val_at_start: false
   seed: 42
 
+  preference_loss: dpo
+  beta: 1.
+  eta: 1.
+
 checkpointing:
   enabled: true
   checkpoint_dir: "results/rm"

--- a/examples/run_dpo.py
+++ b/examples/run_dpo.py
@@ -160,6 +160,11 @@ def dpo_preprocessor(
         "loss_multiplier": loss_multiplier,
         "idx": idx,
     }
+
+    if "reward" in chosen_completion and "reward" in rejected_completion:
+        output["reward_chosen"] = chosen_completion["score"]
+        output["reward_rejected"] = rejected_completion["score"]
+
     return output
 
 

--- a/examples/run_dpo.py
+++ b/examples/run_dpo.py
@@ -162,8 +162,8 @@ def dpo_preprocessor(
     }
 
     if "reward" in chosen_completion and "reward" in rejected_completion:
-        output["reward_chosen"] = chosen_completion["score"]
-        output["reward_rejected"] = rejected_completion["score"]
+        output["reward_chosen"] = chosen_completion["reward"]
+        output["reward_rejected"] = rejected_completion["reward"]
 
     return output
 

--- a/examples/run_rm.py
+++ b/examples/run_rm.py
@@ -116,6 +116,11 @@ def rm_preprocessor(
         "loss_multiplier": loss_multiplier,
         "idx": idx,
     }
+
+    if "reward" in chosen_completion and "reward" in rejected_completion:
+        output["reward_chosen"] = chosen_completion["reward"]
+        output["reward_rejected"] = rejected_completion["reward"]
+
     return output
 
 

--- a/nemo_rl/algorithms/dpo.py
+++ b/nemo_rl/algorithms/dpo.py
@@ -73,8 +73,8 @@ class DPOConfig(TypedDict):
     sft_average_log_probs: bool
     ## TODO(@ashors) support other loss functions
     ## https://github.com/NVIDIA-NeMo/RL/issues/193
-    # preference_loss: str
-    # gt_reward_scale: float
+    preference_loss: str
+    gt_reward_scale: float
     preference_loss_weight: float
     sft_loss_weight: float
 

--- a/nemo_rl/algorithms/dpo.py
+++ b/nemo_rl/algorithms/dpo.py
@@ -71,8 +71,6 @@ class DPOConfig(TypedDict):
     reference_policy_kl_penalty: float
     preference_average_log_probs: bool
     sft_average_log_probs: bool
-    ## TODO(@ashors) support other loss functions
-    ## https://github.com/NVIDIA-NeMo/RL/issues/193
     preference_loss: str
     gt_reward_scale: float
     preference_loss_weight: float

--- a/nemo_rl/algorithms/loss_functions.py
+++ b/nemo_rl/algorithms/loss_functions.py
@@ -771,7 +771,7 @@ class DPOLossFn(LossFunction):
         vocab_parallel_rank: Optional[int] = None,
         vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
         context_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
-    ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
         ## TODO(@ashors): there's some duplicate code here with the NLLLoss function. We should refactor
         token_mask = data["token_mask"][:, 1:]
         seq_index = data.get("seq_index", None)

--- a/nemo_rl/algorithms/loss_functions.py
+++ b/nemo_rl/algorithms/loss_functions.py
@@ -548,6 +548,8 @@ class DPOLossConfig(TypedDict):
     sft_loss_weight: float
     preference_average_log_probs: bool
     sft_average_log_probs: bool
+    preference_loss: NotRequired[str]
+    gt_reward_scale: NotRequired[float]
 
 
 class DPOLossDataDict(TypedDict):
@@ -557,14 +559,25 @@ class DPOLossDataDict(TypedDict):
     reference_policy_logprobs: torch.Tensor
     token_mask: torch.Tensor
     sample_mask: torch.Tensor
+    rewards: NotRequired[torch.Tensor]
 
 
-class DPOLossFn(PreferenceLoss):
+class DPOLossFn(LossFunction):
     """Direct Preference Optimization (DPO) loss function.
 
-    This loss function implements the DPO algorithm as described in:
+    This loss function implements:
+    - the DPO algorithm as described in:
     "Direct Preference Optimization: Your Language Model is Secretly a Reward Model"
     (https://arxiv.org/abs/2305.18290)
+    - the IPO algorithm as described in:
+    "A General Theoretical Paradigm to Understand Learning from Human Preferences"
+    (https://arxiv.org/abs/2310.12036)
+    - the RPO algorithm (with squared distance and forward/backward KL divergence) as described in:
+    "Nemotron-4 340B Technical Report"
+    (https://arxiv.org/abs/2406.11704)
+    "Reward-aware Preference Optimization: A Unified Mathematical Framework for Model Alignment"
+    (https://arxiv.org/abs/2502.00203)
+
 
     The loss combines two main components:
     1. Preference Loss: Optimizes the model to prefer chosen responses over rejected ones
@@ -579,15 +592,31 @@ class DPOLossFn(PreferenceLoss):
     - L_pref(θ) is the preference loss term
     - L_sft(θ) is the supervised fine-tuning loss term
 
-    The preference loss term is computed as:
-    L_pref(θ) = -E[log(σ(β * (r_chosen - r_rejected)))]
+    For DPO, the preference loss term is computed as:
+    L_pref(θ) = -E[log(σ(β * Δ_r))]
+
+    For IPO, the preference loss term is computed as:
+    L_pref(θ) = E[(Δ_r - (1/(2β))) ^ 2]
+
+    For RPO with squared distance, the preference loss term is computed as:
+    L_pref(θ) = E[(Δ_r - Δ_gtr) ^ 2]
+
+    For RPO with forward KL divergence, the preference loss term is computed as:
+    L_pref(θ) = E[σ(β * Δ_r) * log(σ(β * Δ_r)/σ(Δ_gtr)) + σ(-β * Δ_r) * log(σ(-β * Δ_r)/σ(Δ_gtr))]
+
+    For RPO with backward KL divergence, the preference loss term is computed as:
+    L_pref(θ) = E[σ(Δ_gtr) * log(σ(Δ_gtr)/σ(β * Δ_r)) + σ(-Δ_gtr) * log(σ(-Δ_gtr)/σ(-β * Δ_r))]
 
     where:
     - σ is the sigmoid function
     - β is the reference_policy_kl_penalty
     - r_chosen and r_rejected are the rewards for chosen and rejected responses
+    - Δ_r is the difference in rewards (r_chosen - r_rejected)
     - The rewards are computed as the sum of log probability differences between
       the current policy and reference policy
+    - gt_r_chosen and gt_r_rejected are the ground truth rewards for chosen and rejected responses
+    - η is the ground truth rewards scale
+    - Δ_gtr is the scaled difference in ground truth rewards (η * gt_r_chosen - η * gt_r_rejected)
 
     If preference_average_log_probs is True, the rewards are averaged over tokens:
     r = (1/n) * Σ_t (log π_θ(a_t|s_t) - log π_ref(a_t|s_t))
@@ -604,6 +633,8 @@ class DPOLossFn(PreferenceLoss):
             - sft_loss_weight (float): Weight for the SFT loss term (w_s)
             - preference_average_log_probs (bool): Whether to average log probs across tokens in preference loss
             - sft_average_log_probs (bool): Whether to average log probs across tokens in SFT loss
+            - preference_loss (Optional, str): Type of preference loss to use, default dpo
+            - gt_reward_scale (Optional, float): Scale of the ground truth rewards (η), default 1
 
     Returns:
         tuple[torch.Tensor, dict]: A tuple containing:
@@ -621,9 +652,15 @@ class DPOLossFn(PreferenceLoss):
         self.sft_loss_weight = cfg["sft_loss_weight"]
         self.preference_average_log_probs = cfg["preference_average_log_probs"]
         self.sft_average_log_probs = cfg["sft_average_log_probs"]
+        self.preference_loss = cfg.get("preference_loss", "dpo")
+        self.gt_reward_scale = cfg.get("gt_reward_scale", 1.0)
         self.sft_loss = NLLLoss()
 
         self.loss_type = LossType.SEQUENCE_LEVEL
+
+    def split_output_tensor(self, tensor: Tensor) -> tuple[Tensor, Tensor]:
+        # tensor is of shape (2*micro_batch_size,)
+        return tensor[::2], tensor[1::2]
 
     def _dpo_loss(
         self,
@@ -677,8 +714,92 @@ class DPOLossFn(PreferenceLoss):
         if self.preference_average_log_probs:
             rewards = rewards / token_mask.sum(-1).clamp(min=1)
 
-        return self._preference_loss(
-            rewards, sample_mask, global_valid_seqs, self.reference_policy_kl_penalty
+        rewards_chosen, rewards_rejected = self.split_output_tensor(rewards)
+        rewards_delta = rewards_chosen - rewards_rejected
+
+        if self.preference_loss == "dpo":
+            per_sample_loss = (
+                -torch.nn.functional.logsigmoid(
+                    self.reference_policy_kl_penalty * rewards_delta
+                )
+                * sample_mask[::2]
+            )  ## zero out invalid samples
+        elif self.preference_loss == "ipo":
+            assert self.reference_policy_kl_penalty != 0, (
+                "IPO requires a non-zero reference_policy_kl_penalty"
+            )
+            per_sample_loss = (
+                torch.square(
+                    rewards_delta - 1.0 / (2.0 * self.reference_policy_kl_penalty)
+                )
+                * sample_mask[::2]
+            )
+        elif self.preference_loss in ["rpo_fwd_kl", "rpo_bwd_kl", "rpo_sq"]:
+            assert "rewards" in data, "RPO requires rewards"
+            gt_rewards_chosen, gt_rewards_rejected = self.split_output_tensor(
+                data["rewards"]
+            )
+            gt_rewards_delta = self.gt_reward_scale * (
+                gt_rewards_chosen - gt_rewards_rejected
+            )
+
+            if "kl" in self.preference_loss:
+                logbeta_hat_chosen = torch.nn.functional.logsigmoid(
+                    self.reference_policy_kl_penalty * rewards_delta
+                )
+                logbeta_hat_rejected = torch.nn.functional.logsigmoid(
+                    -self.reference_policy_kl_penalty * rewards_delta
+                )
+                logalpha_hat_chosen = torch.nn.functional.logsigmoid(gt_rewards_delta)
+                logalpha_hat_rejected = torch.nn.functional.logsigmoid(
+                    -gt_rewards_delta
+                )
+
+                if "fwd" in self.preference_loss:
+                    per_sample_loss = (
+                        torch.exp(logbeta_hat_chosen)
+                        * (logbeta_hat_chosen - logalpha_hat_chosen)
+                        + torch.exp(logbeta_hat_rejected)
+                        * (logbeta_hat_rejected - logalpha_hat_rejected)
+                    ) * sample_mask[::2]
+                elif "bwd" in self.preference_loss:
+                    per_sample_loss = (
+                        torch.exp(logalpha_hat_chosen)
+                        * (logalpha_hat_chosen - logbeta_hat_chosen)
+                        + torch.exp(logalpha_hat_rejected)
+                        * (logalpha_hat_rejected - logbeta_hat_rejected)
+                    ) * sample_mask[::2]
+            elif self.preference_loss == "rpo_sq":
+                per_sample_loss = (
+                    torch.square(rewards_delta - gt_rewards_delta) * sample_mask[::2]
+                )
+        else:
+            raise NotImplementedError(
+                f"preference loss {self.preference_loss} is not implemented"
+            )
+
+        ## divide by 2 because each preference example corresponds to 2 samples (chosen, rejected)
+        return (
+            masked_mean(
+                per_sample_loss,
+                sample_mask[::2],
+                global_normalization_factor=global_valid_seqs / 2,
+            ),
+            masked_mean(
+                rewards_chosen > rewards_rejected,
+                sample_mask[::2],
+                global_normalization_factor=global_valid_seqs / 2,
+            ),
+            masked_mean(
+                rewards_chosen,
+                sample_mask[::2],
+                global_normalization_factor=global_valid_seqs / 2,
+            ),
+            masked_mean(
+                rewards_rejected,
+                sample_mask[1::2],
+                global_normalization_factor=global_valid_seqs / 2,
+            ),
         )
 
     # TODO a cleaner typing fix would be required (probably that DPOLossFn should not inherit from PreferenceLoss)

--- a/nemo_rl/algorithms/loss_functions.py
+++ b/nemo_rl/algorithms/loss_functions.py
@@ -548,8 +548,8 @@ class DPOLossConfig(TypedDict):
     sft_loss_weight: float
     preference_average_log_probs: bool
     sft_average_log_probs: bool
-    preference_loss: NotRequired[str]
-    gt_reward_scale: NotRequired[float]
+    preference_loss: str
+    gt_reward_scale: float
 
 
 class DPOLossDataDict(TypedDict):
@@ -633,8 +633,8 @@ class DPOLossFn(LossFunction):
             - sft_loss_weight (float): Weight for the SFT loss term (w_s)
             - preference_average_log_probs (bool): Whether to average log probs across tokens in preference loss
             - sft_average_log_probs (bool): Whether to average log probs across tokens in SFT loss
-            - preference_loss (Optional, str): Type of preference loss to use, default dpo
-            - gt_reward_scale (Optional, float): Scale of the ground truth rewards (η), default 1
+            - preference_loss (str): Type of preference loss to use, default dpo
+            - gt_reward_scale (float): Scale of the ground truth rewards (η), default 1
 
     Returns:
         tuple[torch.Tensor, dict]: A tuple containing:
@@ -652,8 +652,8 @@ class DPOLossFn(LossFunction):
         self.sft_loss_weight = cfg["sft_loss_weight"]
         self.preference_average_log_probs = cfg["preference_average_log_probs"]
         self.sft_average_log_probs = cfg["sft_average_log_probs"]
-        self.preference_loss = cfg.get("preference_loss", "dpo")
-        self.gt_reward_scale = cfg.get("gt_reward_scale", 1.0)
+        self.preference_loss = cfg["preference_loss"]
+        self.gt_reward_scale = cfg["gt_reward_scale"]
         self.sft_loss = NLLLoss()
 
         self.loss_type = LossType.SEQUENCE_LEVEL

--- a/nemo_rl/algorithms/loss_functions.py
+++ b/nemo_rl/algorithms/loss_functions.py
@@ -633,8 +633,8 @@ class DPOLossFn(LossFunction):
             - sft_loss_weight (float): Weight for the SFT loss term (w_s)
             - preference_average_log_probs (bool): Whether to average log probs across tokens in preference loss
             - sft_average_log_probs (bool): Whether to average log probs across tokens in SFT loss
-            - preference_loss (str): Type of preference loss to use, default dpo
-            - gt_reward_scale (float): Scale of the ground truth rewards (η), default 1
+            - preference_loss (str): Type of preference loss to use
+            - gt_reward_scale (float): Scale of the ground truth rewards (η)
 
     Returns:
         tuple[torch.Tensor, dict]: A tuple containing:
@@ -771,7 +771,11 @@ class DPOLossFn(LossFunction):
                     ) * sample_mask[::2]
             elif self.preference_loss == "rpo_sq":
                 per_sample_loss = (
-                    torch.square(rewards_delta - gt_rewards_delta) * sample_mask[::2]
+                    torch.square(
+                        self.reference_policy_kl_penalty * rewards_delta
+                        - gt_rewards_delta
+                    )
+                    * sample_mask[::2]
                 )
         else:
             raise NotImplementedError(

--- a/nemo_rl/algorithms/rm.py
+++ b/nemo_rl/algorithms/rm.py
@@ -222,7 +222,7 @@ def setup(
         init_optimizer=True,
         init_reference_model=False,
     )
-    loss_fn = PreferenceLoss()
+    loss_fn = PreferenceLoss(rm_config)
     print("  ✓ Model initialized")
 
     print("\n" + "=" * 60)

--- a/nemo_rl/data/collate_fn.py
+++ b/nemo_rl/data/collate_fn.py
@@ -202,6 +202,6 @@ def preference_collate_fn(
     if add_loss_mask:
         data["token_mask"] = cat_and_padded["token_loss_mask"]
     if rewards:
-        data["rewards"] = rewards
+        data["rewards"] = torch.Tensor(rewards)
 
     return data

--- a/nemo_rl/data/collate_fn.py
+++ b/nemo_rl/data/collate_fn.py
@@ -149,6 +149,7 @@ def preference_collate_fn(
     loss_multiplier = []
     idx = []
     task_names = []
+    rewards = []
     for datum_spec in data_batch:
         ## interleave chosen and rejected examples
         message_log.append(datum_spec["message_log_chosen"])
@@ -158,6 +159,13 @@ def preference_collate_fn(
         loss_multiplier.extend([datum_spec["loss_multiplier"]] * 2)
         idx.extend([datum_spec["idx"]] * 2)
         task_names.extend([datum_spec.get("task_name", None)] * 2)
+        if "reward_chosen" in datum_spec and "reward_rejected" in datum_spec:
+            rewards.append(datum_spec["reward_chosen"])
+            rewards.append(datum_spec["reward_rejected"])
+    if rewards:
+        assert len(rewards) == len(message_log), (
+            f"rewards length ({len(rewards)}) and message_log length ({len(message_log)}) mismatch"
+        )
     length_batch: torch.Tensor = torch.tensor(length)
     loss_multiplier_batch: torch.Tensor = torch.tensor(loss_multiplier)
 
@@ -193,5 +201,7 @@ def preference_collate_fn(
     )
     if add_loss_mask:
         data["token_mask"] = cat_and_padded["token_loss_mask"]
+    if rewards:
+        data["rewards"] = rewards
 
     return data

--- a/nemo_rl/data/datasets/preference_datasets/helpsteer3.py
+++ b/nemo_rl/data/datasets/preference_datasets/helpsteer3.py
@@ -48,8 +48,16 @@ def to_preference_data_format(
         if isinstance(data["context"], str)
         else data["context"],
         "completions": [
-            {"rank": 0, "completion": [{"role": "assistant", "content": chosen}]},
-            {"rank": 1, "completion": [{"role": "assistant", "content": rejected}]},
+            {
+                "rank": 0,
+                "completion": [{"role": "assistant", "content": chosen}],
+                "reward": abs(overall_preference),
+            },
+            {
+                "rank": 1,
+                "completion": [{"role": "assistant", "content": rejected}],
+                "reward": 0,
+            },
         ],
     }
 

--- a/nemo_rl/data/datasets/preference_datasets/preference_dataset.py
+++ b/nemo_rl/data/datasets/preference_datasets/preference_dataset.py
@@ -28,6 +28,7 @@ class PreferenceDataset:
             {
                 "rank": int, # The rank of the completion (lower rank is preferred)
                 "completion": list of dicts, # The completion message(s)
+                "reward": Optional, float, # The ground trutch reward for the completion (required for rpo)
             }
     }
 

--- a/nemo_rl/data/datasets/preference_datasets/preference_dataset.py
+++ b/nemo_rl/data/datasets/preference_datasets/preference_dataset.py
@@ -28,7 +28,7 @@ class PreferenceDataset:
             {
                 "rank": int, # The rank of the completion (lower rank is preferred)
                 "completion": list of dicts, # The completion message(s)
-                "reward": Optional, float, # The ground trutch reward for the completion (required for rpo)
+                "reward": float, # Optional; The ground trutch reward for the completion (required for RPO)
             }
     }
 

--- a/nemo_rl/data/interfaces.py
+++ b/nemo_rl/data/interfaces.py
@@ -47,6 +47,8 @@ class DPODatumSpec(TypedDict):
     length_rejected: int
     loss_multiplier: float
     idx: int
+    reward_chosen: NotRequired[float]
+    reward_rejected: NotRequired[float]
 
 
 @dataclass

--- a/tests/unit/algorithms/test_dpo.py
+++ b/tests/unit/algorithms/test_dpo.py
@@ -169,7 +169,7 @@ def mock_dpo_components():
     tokenizer = MagicMock()
     tokenizer.pad_token_id = 0
 
-    loss_fn = PreferenceLoss()
+    loss_fn = PreferenceLoss(cfg={"preference_loss": "dpo", "beta": 1.0, "eta": 1.0})
     logger = MagicMock()
     checkpointer = MagicMock()
 

--- a/tests/unit/algorithms/test_dpo.py
+++ b/tests/unit/algorithms/test_dpo.py
@@ -169,7 +169,13 @@ def mock_dpo_components():
     tokenizer = MagicMock()
     tokenizer.pad_token_id = 0
 
-    loss_fn = PreferenceLoss(cfg={"preference_loss": "dpo", "beta": 1.0, "eta": 1.0})
+    loss_fn = PreferenceLoss(
+        cfg={
+            "preference_loss": "dpo",
+            "reference_policy_kl_penalty": 1.0,
+            "gt_reward_scale": 1.0,
+        }
+    )
     logger = MagicMock()
     checkpointer = MagicMock()
 

--- a/tests/unit/algorithms/test_loss_functions.py
+++ b/tests/unit/algorithms/test_loss_functions.py
@@ -407,8 +407,7 @@ def test_ipo_loss():
 
     # Hand Calculation
     expected_loss = (
-        expected_rewards_delta
-        - torch.tensor(1 / (2 * loss_fn.reference_policy_kl_penalty))
+        expected_rewards_delta - torch.tensor(1 / (2 * loss_fn.preference_loss.beta))
     ) ** 2
     # (2.23 - (1 / (2 * 1))^2 = (2.23 - 0.5)^2 = 1.73^2 = 3 (approx)
     assert torch.isclose(expected_loss, torch.tensor(3.0), rtol=1e-3)

--- a/tests/unit/algorithms/test_loss_functions.py
+++ b/tests/unit/algorithms/test_loss_functions.py
@@ -129,6 +129,8 @@ def test_dpo_loss():
             "sft_loss_weight": 0.0,
             "preference_average_log_probs": False,
             "sft_average_log_probs": False,
+            "preference_loss": "dpo",
+            "gt_reward_scale": 1.0,
         }
     )
 
@@ -151,6 +153,8 @@ def test_dpo_loss():
             "sft_loss_weight": 0.5,
             "preference_average_log_probs": False,
             "sft_average_log_probs": False,
+            "preference_loss": "dpo",
+            "gt_reward_scale": 1.0,
         }
     )
 
@@ -190,6 +194,8 @@ def test_dpo_loss_varying_sequence_lengths():
             "sft_loss_weight": 0.5,
             "preference_average_log_probs": False,
             "sft_average_log_probs": False,
+            "preference_loss": "dpo",
+            "gt_reward_scale": 1.0,
         }
     )
     dpo_loss_fn_avg = DPOLossFn(
@@ -199,6 +205,8 @@ def test_dpo_loss_varying_sequence_lengths():
             "sft_loss_weight": 0.5,
             "preference_average_log_probs": True,
             "sft_average_log_probs": True,
+            "preference_loss": "dpo",
+            "gt_reward_scale": 1.0,
         }
     )
 
@@ -320,6 +328,8 @@ def test_dpo_sft_matches_nll_loss():
             "sft_loss_weight": 1.0,  # Only use SFT loss
             "preference_average_log_probs": False,
             "sft_average_log_probs": False,
+            "preference_loss": "dpo",
+            "gt_reward_scale": 1.0,
         }
     )
     dpo_loss, dpo_metrics = dpo_loss_fn(
@@ -363,6 +373,7 @@ def test_ipo_loss():
             "preference_average_log_probs": False,
             "sft_average_log_probs": False,
             "preference_loss": "ipo",
+            "gt_reward_scale": 1.0,
         }
     )
 
@@ -398,6 +409,7 @@ def test_rpo_sq_loss():
             "preference_average_log_probs": False,
             "sft_average_log_probs": False,
             "preference_loss": "rpo_sq",
+            "gt_reward_scale": 1.0,
         }
     )
 
@@ -434,6 +446,7 @@ def test_rpo_fwd_kl_loss():
             "preference_average_log_probs": False,
             "sft_average_log_probs": False,
             "preference_loss": "rpo_fwd_kl",
+            "gt_reward_scale": 1.0,
         }
     )
 
@@ -470,6 +483,7 @@ def test_rpo_bwd_kl_loss():
             "preference_average_log_probs": False,
             "sft_average_log_probs": False,
             "preference_loss": "rpo_bwd_kl",
+            "gt_reward_scale": 1.0,
         }
     )
 

--- a/tests/unit/algorithms/test_rm.py
+++ b/tests/unit/algorithms/test_rm.py
@@ -75,7 +75,7 @@ def mock_components():
     tokenizer = MagicMock()
     tokenizer.pad_token_id = 0
 
-    loss_fn = PreferenceLoss()
+    loss_fn = PreferenceLoss(cfg={"preference_loss": "dpo", "beta": 1.0, "eta": 1.0})
     logger = MagicMock()
     checkpointer = MagicMock()
     rm_task_spec = MagicMock()

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -1282,6 +1282,8 @@ def test_megatron_dpo_training(tiny_llama_model_path):
             "sft_loss_weight": 0.5,
             "preference_average_log_probs": False,
             "sft_average_log_probs": False,
+            "preference_loss": "dpo",
+            "gt_reward_scale": 1.0,
         }
     )
 


### PR DESCRIPTION
# What does this PR do ?

Add support for IPO and RPO (with forward and backward KL distance, and squared distance)

# Issues
[Issue #193](https://github.com/NVIDIA-NeMo/RL/issues/193):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for multiple DPO preference loss objectives: IPO and RPO variants (forward KL, backward KL, squared distance).
  * Introduced configurable ground-truth reward scaling for preference optimization.
  * Extended training dataset schemas to support optional reward values per completion.

* **Documentation**
  * Updated DPO guides with new preference loss options and configuration examples.

* **Tests**
  * Added test coverage for new preference loss modes and reward handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->