### PR TITLE
fix: Adding mean total tokens per sample to the output log

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1977,6 +1977,7 @@ def async_grpo_train(
                         "reward",
                         "global_valid_seqs",
                         "global_valid_toks",
+                        "mean_prompt_length",
                     }:
                         metrics[k] = np.mean(v).item()
                     else:

--- a/nemo_rl/algorithms/utils.py
+++ b/nemo_rl/algorithms/utils.py
@@ -401,6 +401,11 @@ def print_performance_metrics(
             average_token_imbalance = visualize_per_worker_load(per_worker_token_counts)
             performance_metrics["average_token_imbalance"] = average_token_imbalance
 
+    if "mean_total_tokens_per_sample" in metrics:
+        print(
+            f"  • Mean Total Tokens per Sample: {metrics['mean_total_tokens_per_sample']:.2f}"
+        )
+
     # =====================================================
     # Throughputs
     # =====================================================


### PR DESCRIPTION
# What does this PR do ?

1. Fix a wrong number in wandb log

2. Print avg seq length directly to the output log
<img width="669" height="910" alt="image" src="https://github.com/user-attachments/assets/04c3a194-a940-4531-a815-1cc8b4d36193" />


# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected metric calculation to properly average prompt length metrics alongside other metrics.
  * Enhanced performance metrics reporting to display mean total tokens per sample.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->