### PR TITLE
cp: `feat: Overlap param iteration and broadcast in non-colocated refit (1379)` into `r0.4.0`

### DIFF
--- a/nemo_rl/utils/packed_tensor.py
+++ b/nemo_rl/utils/packed_tensor.py
@@ -22,13 +22,18 @@ import torch
 
 @lru_cache(maxsize=1)
 def get_target_packed_tensor_size():
-    memory_ratio = os.getenv("NRL_REFIT_BUFFER_MEMORY_RATIO", "0.01")
+    memory_ratio = os.getenv("NRL_REFIT_BUFFER_MEMORY_RATIO", "0.02")
     device = torch.device("cuda")
     props = torch.cuda.get_device_properties(device)
     total_memory_bytes = props.total_memory
     # max size is 5GB
     target_size = min(int(total_memory_bytes * float(memory_ratio)), 5 * 1024**3)
     return target_size
+
+
+@lru_cache(maxsize=1)
+def get_num_buffers():
+    return int(os.getenv("NRL_REFIT_NUM_BUFFERS", "2"))
 
 
 def packed_broadcast_producer(iterator, group, src, post_iter_func):
@@ -46,27 +51,48 @@ def packed_broadcast_producer(iterator, group, src, post_iter_func):
     """
     target_packed_tensor_size = get_target_packed_tensor_size()
 
+    num_buffers = get_num_buffers()
+    streams = [torch.cuda.Stream() for _ in range(num_buffers)]
+    buffer_idx = 0
+
+    packing_tensor_list = [[] for _ in range(num_buffers)]
+    packing_tensor_sizes = [0 for _ in range(num_buffers)]
+    packed_tensors = [
+        torch.empty(0, dtype=torch.uint8, device="cuda") for _ in range(num_buffers)
+    ]
+
     while True:
-        # Form a packed tensor
-        packing_tensor_list = []
-        packing_tensor_sizes = 0
-        try:
-            while True:
-                # Apply backend specific post processing and then convert to linearized uint8 tensor
-                tensor = post_iter_func(next(iterator)).view(torch.uint8).view(-1)
-                packing_tensor_list.append(tensor)
-                packing_tensor_sizes += tensor.view(torch.uint8).numel()
-                if packing_tensor_sizes > target_packed_tensor_size:
-                    break
-            # Pack the tensors and call broadcast collective
-            packed_tensor = torch.cat(packing_tensor_list, dim=0)
-            group.broadcast(packed_tensor, src=src)
-        except StopIteration:
-            # do the last broadcast if there are remaining tensors
-            if len(packing_tensor_list) > 0:
-                packed_tensor = torch.cat(packing_tensor_list, dim=0)
-                group.broadcast(packed_tensor, src=src)
-            break
+        # Move to the next buffer
+        buffer_idx = (buffer_idx + 1) % num_buffers
+        # Synchronize the current stream
+        streams[buffer_idx].synchronize()
+        # Start tasks for the new buffer in a new stream
+        with torch.cuda.stream(streams[buffer_idx]):  # type: ignore[arg-type]
+            try:
+                # Initialize the packing tensor list and sizes
+                packing_tensor_list[buffer_idx] = []
+                packing_tensor_sizes[buffer_idx] = 0
+                # Pack the tensors
+                while True:
+                    # Apply backend specific post processing and then convert to linearized uint8 tensor
+                    tensor = post_iter_func(next(iterator)).view(torch.uint8).view(-1)
+                    packing_tensor_list[buffer_idx].append(tensor)
+                    packing_tensor_sizes[buffer_idx] += tensor.view(torch.uint8).numel()
+                    if packing_tensor_sizes[buffer_idx] > target_packed_tensor_size:
+                        break
+                # Pack the tensors and call broadcast collective
+                packed_tensors[buffer_idx] = torch.cat(
+                    packing_tensor_list[buffer_idx], dim=0
+                )
+                group.broadcast(packed_tensors[buffer_idx], src=src)
+            except StopIteration:
+                # do the last broadcast if there are remaining tensors
+                if len(packing_tensor_list[buffer_idx]) > 0:
+                    packed_tensors[buffer_idx] = torch.cat(
+                        packing_tensor_list[buffer_idx], dim=0
+                    )
+                    group.broadcast(packed_tensors[buffer_idx], src=src)
+                break
 
 
 def packed_broadcast_consumer(iterator, group, src, post_unpack_func):
@@ -113,38 +139,65 @@ def packed_broadcast_consumer(iterator, group, src, post_unpack_func):
 
     target_packed_tensor_size = get_target_packed_tensor_size()
 
+    num_buffers = get_num_buffers()
+    streams = [torch.cuda.Stream() for _ in range(num_buffers)]
+    buffer_idx = 0
+
+    packing_tensor_meta_data = [[] for _ in range(num_buffers)]
+    packing_tensor_sizes = [0 for _ in range(num_buffers)]
+    offsets = [0 for _ in range(num_buffers)]
+    packed_tensors = [
+        torch.empty(0, dtype=torch.uint8, device="cuda") for _ in range(num_buffers)
+    ]
+
     while True:
-        # Form a packed tensor
-        packing_tensor_meta_data = []
-        packing_tensor_sizes = 0
-        offset = 0
-        try:
-            while True:
+        # Move to the next buffer
+        buffer_idx = (buffer_idx + 1) % num_buffers
+        # Synchronize the current stream
+        streams[buffer_idx].synchronize()
+        with torch.cuda.stream(streams[buffer_idx]):  # type: ignore[arg-type]
+            # Initialize the packing tensor meta data
+            packing_tensor_meta_data[buffer_idx] = []
+            packing_tensor_sizes[buffer_idx] = 0
+            offsets[buffer_idx] = 0
+            try:
                 # Form a packed tensor
-                name, (shape, dtype) = next(iterator)
-                tensor_size = math.prod(shape) * dtype.itemsize
-                packing_tensor_meta_data.append(
-                    (name, shape, dtype, offset, tensor_size)
-                )
-                packing_tensor_sizes += tensor_size
-                offset += tensor_size
-                if packing_tensor_sizes > target_packed_tensor_size:
-                    break
-            # Create a packed tensor and broadcast it
-            packed_tensor = torch.empty(
-                packing_tensor_sizes, dtype=torch.uint8, device="cuda"
-            )
-            group.broadcast(packed_tensor, src=src)
-            # Load the packed tensor into the model
-            post_unpack_func(unpack_tensor(packed_tensor, packing_tensor_meta_data))
-        except StopIteration:
-            # do the last broadcast if there are remaining tensors
-            if len(packing_tensor_meta_data) > 0:
+                while True:
+                    name, (shape, dtype) = next(iterator)
+                    tensor_size = math.prod(shape) * dtype.itemsize
+                    packing_tensor_meta_data[buffer_idx].append(
+                        (name, shape, dtype, offsets[buffer_idx], tensor_size)
+                    )
+                    packing_tensor_sizes[buffer_idx] += tensor_size
+                    offsets[buffer_idx] += tensor_size
+                    if packing_tensor_sizes[buffer_idx] > target_packed_tensor_size:
+                        break
                 # Create a packed tensor and broadcast it
-                packed_tensor = torch.empty(
-                    packing_tensor_sizes, dtype=torch.uint8, device="cuda"
+                packed_tensors[buffer_idx] = torch.empty(
+                    packing_tensor_sizes[buffer_idx], dtype=torch.uint8, device="cuda"
                 )
-                group.broadcast(packed_tensor, src=src)
+                group.broadcast(packed_tensors[buffer_idx], src=src)
                 # Load the packed tensor into the model
-                post_unpack_func(unpack_tensor(packed_tensor, packing_tensor_meta_data))
-            break
+                post_unpack_func(
+                    unpack_tensor(
+                        packed_tensors[buffer_idx], packing_tensor_meta_data[buffer_idx]
+                    )
+                )
+            except StopIteration:
+                # do the last broadcast if there are remaining tensors
+                if len(packing_tensor_meta_data[buffer_idx]) > 0:
+                    # Create a packed tensor and broadcast it
+                    packed_tensors[buffer_idx] = torch.empty(
+                        packing_tensor_sizes[buffer_idx],
+                        dtype=torch.uint8,
+                        device="cuda",
+                    )
+                    group.broadcast(packed_tensors[buffer_idx], src=src)
+                    # Load the packed tensor into the model
+                    post_unpack_func(
+                        unpack_tensor(
+                            packed_tensors[buffer_idx],
+                            packing_tensor_meta_data[buffer_idx],
+                        )
+                    )
+                break


### PR DESCRIPTION
beep boop [🤖]: Hi @youngeunkwon0405 👋,

    we've cherry picked #1379 into  for you! 🚀

    Please review and approve this cherry pick by your convenience!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `NRL_REFIT_NUM_BUFFERS` environment variable for configurable buffer management (defaults to 2)
  * Added `get_num_buffers()` function to query buffer configuration

* **Improvements**
  * Enhanced memory efficiency by increasing device memory allocation ratio to 0.02
  * Optimized data processing pipeline with independent per-buffer handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->