### PR TITLE
fix: add theoretical TFlops for H200 GPU

### DIFF
--- a/nemo_rl/utils/flops_tracker.py
+++ b/nemo_rl/utils/flops_tracker.py
@@ -115,6 +115,8 @@ THEORETICAL_TFLOPS = {
     ("NVIDIA A100 80GB PCIe", torch.float32): 312 / 2 if is_using_tf32() else 19.5,
     ("NVIDIA H100 80GB HBM3", torch.bfloat16): 1979 / 2,
     ("NVIDIA H100 80GB HBM3", torch.float32): 989 / 2 if is_using_tf32() else 67.0,
+    ("NVIDIA H200", torch.bfloat16): 1979 / 2,
+    ("NVIDIA H200", torch.float32): 989 / 2 if is_using_tf32() else 67.0,
     ("NVIDIA B200", torch.bfloat16): 4500 / 2,
     ("NVIDIA B200", torch.float32): 2200 / 2 if is_using_tf32() else 80.0,
     ("NVIDIA B300", torch.bfloat16): 4500 / 2,


### PR DESCRIPTION
# What does this PR do ?

Added the theoretical TFlops for H200 GPUs to measure the process efficiency.

# Issues
N/A

# Usage
N/A

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* Confirmed the format of the GPU output on a cluster with H200s:
```bash
$ python3 -c 'import torch; print(torch.cuda.get_device_name())'
NVIDIA H200
```
* Confirmed theoretical TFlops in the H200 [data sheet](https://www.nvidia.com/en-us/data-center/h200/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended GPU performance tracking support to include NVIDIA H200 with bfloat16 and float32 precision types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->