### PR TITLE
fix: fix log step

### DIFF
--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -834,7 +834,7 @@ def distillation_train(
             log_data = {"content": flat_messages["content"]}
             log_data["input_lengths"] = input_lengths.tolist()
             logger.log_batched_dict_as_jsonl(
-                log_data, f"train_data_step{total_steps}.jsonl"
+                log_data, f"train_data_step{total_steps + 1}.jsonl"
             )
 
             timing_metrics: dict[str, float] = timer.get_timing_metrics(

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1234,7 +1234,7 @@ def grpo_train(
             log_data["prev_logprobs"] = train_data["prev_logprobs"].tolist()
             log_data["input_lengths"] = input_lengths.tolist()
             logger.log_batched_dict_as_jsonl(
-                log_data, f"train_data_step{total_steps}.jsonl"
+                log_data, f"train_data_step{total_steps + 1}.jsonl"
             )
 
             timing_metrics: dict[str, float] = timer.get_timing_metrics(
@@ -2058,7 +2058,9 @@ def async_grpo_train(
             log_data["generation_logprobs"] = train_data["generation_logprobs"].tolist()
             log_data["prev_logprobs"] = train_data["prev_logprobs"].tolist()
             log_data["input_lengths"] = input_lengths.tolist()
-            logger.log_batched_dict_as_jsonl(log_data, f"train_data_step{step}.jsonl")
+            logger.log_batched_dict_as_jsonl(
+                log_data, f"train_data_step{step + 1}.jsonl"
+            )
 
             timing_metrics: dict[str, float] = timer.get_timing_metrics(
                 reduction_op="sum"


### PR DESCRIPTION
Previously we have one step mismatch when saving log in grpo and distillation, this PR will fix it.

Before this PR:
```
Logged data to logs/exp_014/train_data_step307.jsonl
Logged data to logs/exp_014/train_data_step308.jsonl

▶ Starting validation at step 310...
Saving checkpoint for step 310...

Logged data to logs/exp_014/train_data_step309.jsonl
Logged data to logs/exp_014/train_data_step310.jsonl
Logged data to logs/exp_014/train_data_step311.jsonl
```

After this PR:
```
Logged data to logs/exp_014/train_data_step308.jsonl
Logged data to logs/exp_014/train_data_step309.jsonl

▶ Starting validation at step 310...
Saving checkpoint for step 310...

Logged data to logs/exp_014/train_data_step310.jsonl
Logged data to logs/exp_014/train_data_step311.jsonl
Logged data to logs/exp_014/train_data_step312.jsonl
```