### PR TITLE
fix: stabilize uv lock after experimental changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,15 @@ explicit = true
 
 [tool.uv]
 preview = true  # Enable preview features like extra-build-dependencies
-no-build-isolation-package = ["transformer-engine-torch", "transformer-engine", "flash-attn", "mamba-ssm", "causal-conv1d", "deep_gemm", "deep_ep"]
+no-build-isolation-package = [
+    "transformer-engine-torch",
+    "transformer-engine",
+    "flash-attn",
+    "mamba-ssm",
+    "causal-conv1d",
+    "deep_gemm",
+    "deep_ep"
+]
 # Always apply the build group since dependencies like TE/mcore/nemo-run require build dependencies
 # and this lets us assume they are implicitly installed with a simply `uv sync`. Ideally, we'd
 # avoid including these in the default dependency set, but for now it's required.
@@ -219,18 +227,26 @@ requires-dist = ["torch", "einops", "setuptools", "psutil", "ninja"]
 
 [[tool.uv.dependency-metadata]]
 name = "causal-conv1d"
+# This version has to match the version in the commit/rev/tag used
+version = "1.5.0.post8"
 requires-dist = ["torch", "packaging", "ninja"]
 
 [[tool.uv.dependency-metadata]]
 name = "mamba-ssm"
+# This version has to match the version in the commit/rev/tag used
+version = "2.2.4"
 requires-dist = ["torch", "packaging", "ninja", "causal-conv1d"]
 
 [[tool.uv.dependency-metadata]]
 name = "deep_ep"
+# This version has to match the version in the commit/rev/tag used
+version = "v1.1.0+e3908bf"
 requires-dist = ["torch", "packaging", "ninja"]
 
 [[tool.uv.dependency-metadata]]
 name = "deep_gemm"
+# This version has to match the version in the commit/rev/tag used
+version = "v2.0.0+7b6b556"
 requires-dist = ["torch", "packaging", "ninja"]
 
 [tool.black]

--- a/uv.lock
+++ b/uv.lock
@@ -28,14 +28,17 @@ overrides = [{ name = "transformer-engine", extras = ["pytorch"], specifier = "=
 
 [[manifest.dependency-metadata]]
 name = "causal-conv1d"
+version = "1.5.0.post8"
 requires-dist = ["torch", "packaging", "ninja"]
 
 [[manifest.dependency-metadata]]
 name = "deep-ep"
+version = "1.1.0+e3908bf"
 requires-dist = ["torch", "packaging", "ninja"]
 
 [[manifest.dependency-metadata]]
 name = "deep-gemm"
+version = "2.0.0+7b6b556"
 requires-dist = ["torch", "packaging", "ninja"]
 
 [[manifest.dependency-metadata]]
@@ -44,6 +47,7 @@ requires-dist = ["torch", "einops", "setuptools", "psutil", "ninja"]
 
 [[manifest.dependency-metadata]]
 name = "mamba-ssm"
+version = "2.2.4"
 requires-dist = ["torch", "packaging", "ninja", "causal-conv1d"]
 
 [[package]]
@@ -1097,11 +1101,23 @@ wheels = [
 name = "deep-ep"
 version = "1.1.0+e3908bf"
 source = { git = "https://github.com/deepseek-ai/DeepEP.git?rev=e3908bf5bd0cc6265bcb225d15cd8c996d4759ef#e3908bf5bd0cc6265bcb225d15cd8c996d4759ef" }
+dependencies = [
+    { name = "ninja" },
+    { name = "packaging" },
+    { name = "torch", version = "2.8.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.8.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "sys_platform != 'darwin'" },
+]
 
 [[package]]
 name = "deep-gemm"
 version = "2.0.0+7b6b556"
 source = { git = "https://github.com/deepseek-ai/DeepGEMM.git?rev=7b6b5563b9d4c1ae07ffbce7f78ad3ac9204827c#7b6b5563b9d4c1ae07ffbce7f78ad3ac9204827c" }
+dependencies = [
+    { name = "ninja" },
+    { name = "packaging" },
+    { name = "torch", version = "2.8.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.8.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "sys_platform != 'darwin'" },
+]
 
 [[package]]
 name = "defusedxml"
@@ -2367,15 +2383,11 @@ name = "mamba-ssm"
 version = "2.2.4"
 source = { git = "https://github.com/state-spaces/mamba.git?rev=2e16fc3062cdcd4ebef27a9aa4442676e1c7edf4#2e16fc3062cdcd4ebef27a9aa4442676e1c7edf4" }
 dependencies = [
-    { name = "einops" },
+    { name = "causal-conv1d" },
     { name = "ninja" },
     { name = "packaging" },
-    { name = "setuptools" },
     { name = "torch", version = "2.8.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
     { name = "torch", version = "2.8.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "sys_platform != 'darwin'" },
-    { name = "transformers" },
-    { name = "triton", version = "3.4.0", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "sys_platform != 'darwin'" },
-    { name = "triton", version = "3.4.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
 ]
 
 [[package]]


### PR DESCRIPTION
# What does this PR do ?

Address instability introduced by this PR https://github.com/NVIDIA-NeMo/RL/pull/1334

Errors users saw before this:

```
× Failed to download and build `deep-ep @
  │ git+https://github.com/deepseek-ai/DeepEP.git`
  ╰─▶ Extra build requirement `torch` was declared with `match-runtime
      = true`, but `deep-ep` does not declare static metadata, making
      runtime-matching impossible
```

when changing unrelated delepdencies

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version specifications for causal-conv1d, mamba-ssm, deep_ep, and deep_gemm to ensure consistent version pinning across configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->