### PR TITLE
fix: fixing the sequence parallel related issue in mcore path

### DIFF
--- a/nemo_rl/models/megatron/community_import.py
+++ b/nemo_rl/models/megatron/community_import.py
@@ -72,6 +72,7 @@ def import_model_from_hf_name(
             "num_layers_in_last_pipeline_stage"
         ]
         model_provider.pipeline_dtype = megatron_config["pipeline_dtype"]
+        model_provider.sequence_parallel = megatron_config["sequence_parallel"]
     model_provider.finalize()
     model_provider.initialize_model_parallel(seed=0)
     megatron_model = model_provider.provide_distributed_model(wrap_with_ddp=False)


### PR DESCRIPTION
# What does this PR do ?

When we are using TP and EP, we need to enable SP. 
Even if we do that, we are still facing error in 
`3rdparty/Megatron-LM-workspace/Megatron-LM/megatron/core/model_parallel_config.py::__post_init__`
[this line](https://github.com/terrykong/Megatron-LM/blob/76065f17e1e1e2850d1e9009ae5f601007aeeeb3/megatron/core/model_parallel_config.py#L390).
Moreover, since Megatron-LM hasn't fixed the import error for the `warnings` in there, it just crashes.

It used to work before, but now I am hitting the error described above in the recent main + recent container even if I correctly configure SP+TP+EP from NeMo-RL. 
I checked that this PR fixes the issue.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Megatron model import configuration to enable sequence parallel flag during HuggingFace model loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->