### PR TITLE
build: Remove torch extra build dependency for NGC Pytorch build

### DIFF
--- a/docker/Dockerfile.ngc_pytorch
+++ b/docker/Dockerfile.ngc_pytorch
@@ -96,6 +96,8 @@ COPY --from=nemo-rl --link 3rdparty/ ./3rdparty/
 
 
 RUN --mount=type=bind,from=build_vllm,source=/opt/,target=/tmp/build_vllm/ <<"EOF" bash -exu
+# Remove torch requirements from extra-build-dependencies for build with NGC PyTorch base image
+sed -i 's/= \[{ requirement = "torch", match-runtime = true }\]/= []/g' pyproject.toml
 
 # uv sync has a more reliable resolver than simple uv pip install which can fail
 # The venv is symlinked to avoid bloating the layer size


### PR DESCRIPTION
# What does this PR do ?

Remove torch extra build dependency for NGC Pytorch build

This is not necessary and breaks the build in the NGC pytorch container with:
```
13.47 error: `torch` was declared as an extra build dependency with `match-runtime = true`, but was not found in the resolution
```

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build process for NGC PyTorch environments by adjusting build-time dependency resolution, improving compatibility and build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->