### PR TITLE
fix: improve local eval config and doc

### DIFF
--- a/docs/guides/eval.md
+++ b/docs/guides/eval.md
@@ -64,8 +64,12 @@ uv run python examples/run_eval.py --config path/to/custom_config.yaml
 # Run evaluation script on one of the supported benchmarks (e.g., GPQA)
 uv run python examples/run_eval.py --config examples/configs/evals/gpqa_eval.yaml
 
-# Run evaluation script with a local dataset that is prefetched as a csv file.
-uv run python examples/run_eval.py --config examples/configs/evals/local_eval.yaml
+# Run evaluation script with a local dataset where the problem and solution keys are "Question" and "Answer" respectively.
+uv run python examples/run_eval.py \
+    --config examples/configs/evals/local_eval.yaml \
+    data.dataset_name=/path/to/local/dataset \
+    data.problem_key=Question \
+    data.solution_key=Answer
 
 # Override specific config values via command line
 # Example: Evaluation of DeepScaleR-1.5B-Preview on MATH-500 using 8 GPUs

--- a/examples/configs/evals/local_eval.yaml
+++ b/examples/configs/evals/local_eval.yaml
@@ -1,11 +1,17 @@
 # Evaluation Configuration from local files.
+# Other settings (e.g., eval metrics, vLLM, cluster, etc.) are inherited from examples/configs/evals/eval.yaml.
 defaults: "eval.yaml"
 
 generation:
   model_name: "Qwen/Qwen2.5-7B-Instruct"
+  vllm_cfg:
+    max_model_len: 2048
 
 data:
   prompt_file: "examples/prompts/cot.txt"
+  system_prompt_file: null
+  # You can also use custom datasets from a local dataset or HuggingFace.
+  # e.g., /path/to/local/dataset or hf_org/hf_dataset_name (HuggingFace)
   dataset_name: "https://openaipublic.blob.core.windows.net/simple-evals/math_500_test.csv"
   problem_key: "Question"
   solution_key: "Answer"


### PR DESCRIPTION
1. Add some importance settings to `examples/configs/evals/local_eval.yaml` directly instead of inherited from `examples/configs/evals/eval.yaml` for easy use.
2. Update local eval dataset usage in doc.

Closes https://github.com/NVIDIA-NeMo/RL/issues/1512.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local dataset evaluation guide with instructions for configuring custom dataset keys (e.g., "Question" and "Answer") in CLI commands.

* **Chores**
  * Enhanced evaluation configuration template with additional setup options including system prompt file configuration and dataset format specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->