### PR TITLE
fix: removed sliding_window_overwrite

### DIFF
--- a/nemo_rl/models/policy/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker.py
@@ -76,7 +76,6 @@ from nemo_rl.models.policy.utils import (
     get_runtime_env_for_policy_worker,
     import_class_from_path,
     resolve_model_class,
-    sliding_window_overwrite,
 )
 from nemo_rl.utils.native_checkpoint import (
     load_checkpoint,
@@ -218,9 +217,6 @@ class DTensorPolicyWorker:
             # Keeping the master weights in lower precision has shown to cause issues with convergence.
             torch_dtype=torch.float32,
             trust_remote_code=True,
-            **sliding_window_overwrite(
-                model_name
-            ),  # due to https://github.com/huggingface/transformers/issues/38002
             attn_implementation="flash_attention_2"
             if self.enable_seq_packing
             else None,

--- a/nemo_rl/models/policy/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker_v2.py
@@ -27,9 +27,6 @@ from accelerate import init_empty_weights
 from nemo_automodel import (
     NeMoAutoModelForSequenceClassification,
 )
-from nemo_automodel.components._transformers.utils import (
-    sliding_window_overwrite,
-)
 from nemo_automodel.components.distributed.cp_utils import (
     create_context_parallel_ctx,
     get_train_context,
@@ -181,9 +178,6 @@ class DTensorPolicyWorkerV2:
             # Keeping the master weights in lower precision has shown to cause issues with convergence.
             torch_dtype=torch.float32,
             trust_remote_code=True,
-            **sliding_window_overwrite(
-                model_name
-            ),  # due to https://github.com/huggingface/transformers/issues/38002
             attn_implementation="flash_attention_2"
             if self.enable_seq_packing
             else None,

--- a/nemo_rl/models/policy/utils.py
+++ b/nemo_rl/models/policy/utils.py
@@ -23,7 +23,6 @@ import torch
 import zmq
 from torch.multiprocessing.reductions import rebuild_cuda_tensor
 from transformers import (
-    AutoConfig,
     AutoModelForCausalLM,
     AutoModelForImageTextToText,
     AutoModelForTextToWaveform,
@@ -272,35 +271,6 @@ def get_gpu_info(model: torch.nn.Module) -> dict[str, Any]:
             if k.startswith("CUDA") or k in ["LOCAL_RANK", "RANK", "WORLD_SIZE"]
         },
     }
-
-
-def sliding_window_overwrite(model_name: str) -> dict[str, Any]:
-    """Returns configuration overrides to handle sliding window settings based on model rules.
-
-    Args:
-        model_name: The HuggingFace model name or path to load configuration from
-
-    Returns:
-        dict: Dictionary with overwrite values, or empty dict if no overwrites needed
-    """
-    hf_config = AutoConfig.from_pretrained(model_name, trust_remote_code=True)
-    overwrite_dict = {}
-
-    # Override sliding_window setting to address a HF mismatch relevant to use_sliding_window
-    # TODO(@zhiyul): remove this once the bug is fixed https://github.com/huggingface/transformers/issues/38002
-    if (
-        hasattr(hf_config, "use_sliding_window")
-        and hf_config.use_sliding_window == False
-    ):
-        assert hasattr(hf_config, "sliding_window")
-        overwrite_dict = {
-            "sliding_window": None,
-        }
-        print(
-            f"use_sliding_window=False in config - overriding sliding_window parameter to None: {overwrite_dict}"
-        )
-
-    return overwrite_dict
 
 
 def configure_dynamo_cache() -> None:

--- a/nemo_rl/utils/flops_tracker.py
+++ b/nemo_rl/utils/flops_tracker.py
@@ -24,7 +24,6 @@ from transformers.models.qwen2.configuration_qwen2 import Qwen2Config
 from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
 from transformers.models.qwen3_moe.configuration_qwen3_moe import Qwen3MoeConfig
 
-from nemo_rl.models.policy.utils import sliding_window_overwrite
 from nemo_rl.utils.flops_formulas import FLOPSConfig, deepseekv3, llama, qwen2, qwen3
 
 
@@ -38,7 +37,6 @@ def get_default_hf_config(model_name: str) -> PretrainedConfig:
         model_name,
         torch_dtype=torch.float32,
         trust_remote_code=True,
-        **sliding_window_overwrite(model_name),
     )
 
 


### PR DESCRIPTION
# What does this PR do ?

Removes sliding_window_overwrite after https://github.com/huggingface/transformers/issues/38002 is fixed

To validate the change, I ran:
```bash
uv run --extra mcore --extra vllm python examples/run_grpo_math.py \
    --config=examples/configs/recipes/llm/grpo-deepscaler-1.5b-8K.yaml \
    logger.wandb_enabled=true
```


<img width="3792" height="1992" alt="W B Chart 20_11_2025, 21_39_19" src="https://github.com/user-attachments/assets/54dbd715-b5f5-4d1f-ae16-b17e47b6dfe3" />
<img width="3792" height="1992" alt="W B Chart 20_11_2025, 21_39_00" src="https://github.com/user-attachments/assets/6e27bc5d-20c4-4de9-97fd-3aa0202e979f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified model configuration loading by removing sliding window override logic from policy worker initialization.
  * Streamlined Hugging Face transformer model configuration across policy worker and FLOPS tracking components.
  * Updated model initialization to rely on standard configuration parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->