### PR TITLE
feat: Support top-p and top-k

### DIFF
--- a/examples/configs/recipes/llm/grpo-llama3.2-1b-instruct-1n8g-megatron-sampling.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.2-1b-instruct-1n8g-megatron-sampling.yaml
@@ -1,0 +1,37 @@
+defaults: ../../grpo_math_1B.yaml
+grpo:
+  max_num_steps: 500
+checkpointing:
+  enabled: false
+  checkpoint_dir: results/grpo-llama3.2-1b-instruct-1n8g-megatron
+  save_period: 100
+policy:
+  model_name: meta-llama/Llama-3.2-1B-Instruct
+  tokenizer:
+    name: meta-llama/Llama-3.2-1B-Instruct
+  optimizer: null
+  megatron_cfg:
+    enabled: true
+    scheduler:
+      lr_warmup_iters: 50
+  dtensor_cfg:
+    enabled: false
+  make_sequence_length_divisible_by: 1
+  generation:
+    max_new_tokens: 512
+    vllm_cfg:
+      max_model_len: 512
+    temperature: 0.8
+    top_p: 0.9
+    top_k: 50
+data:
+  max_input_seq_length: 512
+logger:
+  log_dir: logs/grpo-llama3.2-1b-instruct-1n8g-megatron
+  wandb_enabled: true
+  tensorboard_enabled: true
+  wandb:
+    project: nemo-rl
+    name: grpo-llama3.2-1b-instruct-1n8g-megatron
+cluster:
+  gpus_per_node: 8

--- a/examples/configs/recipes/llm/grpo-llama3.2-1b-instruct-1n8g-megatron-temp0.6.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.2-1b-instruct-1n8g-megatron-temp0.6.yaml
@@ -1,0 +1,35 @@
+defaults: ../../grpo_math_1B.yaml
+grpo:
+  max_num_steps: 500
+checkpointing:
+  enabled: false
+  checkpoint_dir: results/grpo-llama3.2-1b-instruct-1n8g-megatron
+  save_period: 100
+policy:
+  model_name: meta-llama/Llama-3.2-1B-Instruct
+  tokenizer:
+    name: meta-llama/Llama-3.2-1B-Instruct
+  optimizer: null
+  megatron_cfg:
+    enabled: true
+    scheduler:
+      lr_warmup_iters: 50
+  dtensor_cfg:
+    enabled: false
+  make_sequence_length_divisible_by: 1
+  generation:
+    max_new_tokens: 512
+    vllm_cfg:
+      max_model_len: 512
+    temperature: 0.6
+data:
+  max_input_seq_length: 512
+logger:
+  log_dir: logs/grpo-llama3.2-1b-instruct-1n8g-megatron
+  wandb_enabled: true
+  tensorboard_enabled: true
+  wandb:
+    project: nemo-rl
+    name: grpo-llama3.2-1b-instruct-1n8g-megatron
+cluster:
+  gpus_per_node: 8

--- a/nemo_rl/algorithms/loss_functions.py
+++ b/nemo_rl/algorithms/loss_functions.py
@@ -24,9 +24,15 @@ from nemo_rl.distributed.model_utils import (
     ChunkedDistributedGatherLogprob,
     _get_tokens_on_this_cp_rank,
     allgather_cp_sharded_tensor,
+    apply_top_k_top_p,
     from_parallel_logits_to_logprobs,
     gather_logits_at_global_indices,
     get_logprobs_from_vocab_parallel_logits,
+)
+from nemo_rl.models.policy.utils import (
+    TrainingSamplingParams,
+    need_top_k_filtering,
+    need_top_p_filtering,
 )
 
 Tensor = TypeVar("Tensor", bound=torch.Tensor)
@@ -150,6 +156,7 @@ class ClippedPGLossFn(LossFunction):
         vocab_parallel_rank: Optional[int] = None,
         vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
         context_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
+        sampling_params: TrainingSamplingParams | None = None,
     ) -> tuple[torch.Tensor, dict]:
         """Clipped Policy Gradient RL loss function."""
         token_mask = data["token_mask"][:, 1:]
@@ -240,17 +247,27 @@ class ClippedPGLossFn(LossFunction):
                 tp_group=vocab_parallel_group,
                 inference_only=False,
                 cp_group=context_parallel_group,
+                sampling_params=sampling_params,
             )
             # slice off to the correct length to remove potential CP padding
             curr_logprobs = curr_logprobs[:, : data["input_ids"].shape[1] - 1]
         elif isinstance(next_token_logits, torch.distributed.tensor.DTensor):
             curr_logprobs = get_logprobs_from_vocab_parallel_logits(
-                next_token_logits, data["input_ids"], seq_index=seq_index
+                next_token_logits,
+                data["input_ids"],
+                seq_index=seq_index,
+                sampling_params=sampling_params,
             )
         else:
             next_token_logits_wo_last = next_token_logits[
                 :, :-1
             ]  # Remove last position's logits
+            # Apply top-k and top-p filtering
+            next_token_logits_wo_last, _ = apply_top_k_top_p(
+                next_token_logits_wo_last,
+                top_k=sampling_params.top_k if sampling_params is not None else None,
+                top_p=sampling_params.top_p if sampling_params is not None else None,
+            )
             next_token_logprobs = torch.nn.functional.log_softmax(
                 next_token_logits_wo_last, dim=-1
             )
@@ -258,6 +275,11 @@ class ClippedPGLossFn(LossFunction):
             curr_logprobs = next_token_logprobs.gather(
                 dim=-1, index=next_tokens.unsqueeze(-1)
             ).squeeze(-1)
+
+        # Apply masking to avoid NaN in KL/Ratios when logprobs are -inf at masked positions
+        # This happens when top-k/p filtering removes the padding token
+        # This avoids -inf * 0 = NaN when doing calculations similar to the masked_mean
+        curr_logprobs = torch.where(mask.bool(), curr_logprobs, 0.0)
 
         # Calculate KL regularization.
         if self.reference_policy_kl_penalty != 0:
@@ -456,6 +478,7 @@ class NLLLoss(LossFunction):
         context_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
         dpo_loss: bool = False,
         dpo_average_log_probs: bool = False,
+        sampling_params: TrainingSamplingParams | None = None,
     ) -> tuple[torch.Tensor, dict[str, Any]]:
         # logits shape: [batch_size, seq_len, vocab_size]
         # Get the next token logits for each position
@@ -479,15 +502,25 @@ class NLLLoss(LossFunction):
                 tp_group=vocab_parallel_group,
                 inference_only=False,
                 cp_group=context_parallel_group,
+                sampling_params=sampling_params,
             )
             # slice off to the correct length to remove potential CP padding
             token_logprobs = token_logprobs[:, : data["input_ids"].shape[1] - 1]
         elif isinstance(next_token_logits, torch.distributed.tensor.DTensor):
             token_logprobs = get_logprobs_from_vocab_parallel_logits(
-                next_token_logits, data["input_ids"], seq_index=seq_index
+                next_token_logits,
+                data["input_ids"],
+                seq_index=seq_index,
+                sampling_params=sampling_params,
             )
         else:
             next_tokens = data["input_ids"][:, 1:].cuda()  # Skip first token
+            # Apply top-k and top-p filtering
+            next_token_logits, _ = apply_top_k_top_p(
+                next_token_logits,
+                top_k=sampling_params.top_k if sampling_params is not None else None,
+                top_p=sampling_params.top_p if sampling_params is not None else None,
+            )
             next_token_logprobs = torch.nn.functional.log_softmax(
                 next_token_logits, dim=-1
             )
@@ -495,6 +528,9 @@ class NLLLoss(LossFunction):
             token_logprobs = logprobs.gather(
                 dim=-1, index=next_tokens.unsqueeze(-1)
             ).squeeze(-1)
+
+        # Apply masking to avoid NaN when logprobs are -inf at masked positions
+        token_logprobs = torch.where(mask.bool(), token_logprobs, 0.0)
 
         if dpo_loss:
             ## shape: [batch_size]
@@ -714,6 +750,7 @@ class DPOLossFn(PreferenceLoss):
         vocab_parallel_rank: Optional[int] = None,
         vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
         context_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
+        sampling_params: TrainingSamplingParams | None = None,
     ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
         ## TODO(@ashors): there's some duplicate code here with the NLLLoss function. We should refactor
         token_mask = data["token_mask"][:, 1:]
@@ -733,15 +770,25 @@ class DPOLossFn(PreferenceLoss):
                 tp_group=vocab_parallel_group,
                 inference_only=False,
                 cp_group=context_parallel_group,
+                sampling_params=sampling_params,
             )
             # slice off to the correct length to remove potential CP padding
             token_logprobs = token_logprobs[:, : data["input_ids"].shape[1] - 1]
         elif isinstance(next_token_logits, torch.distributed.tensor.DTensor):
             token_logprobs = get_logprobs_from_vocab_parallel_logits(
-                next_token_logits, data["input_ids"], seq_index=seq_index
+                next_token_logits,
+                data["input_ids"],
+                seq_index=seq_index,
+                sampling_params=sampling_params,
             )
         else:
             next_tokens = data["input_ids"][:, 1:].cuda()  # Skip first token
+            # Apply top-k and top-p filtering
+            next_token_logits, _ = apply_top_k_top_p(
+                next_token_logits,
+                top_k=sampling_params.top_k if sampling_params is not None else None,
+                top_p=sampling_params.top_p if sampling_params is not None else None,
+            )
             next_token_logprobs = torch.nn.functional.log_softmax(
                 next_token_logits, dim=-1
             )
@@ -749,6 +796,9 @@ class DPOLossFn(PreferenceLoss):
             token_logprobs = logprobs.gather(
                 dim=-1, index=next_tokens.unsqueeze(-1)
             ).squeeze(-1)
+
+        # Apply masking to avoid NaN when logprobs are -inf at masked positions
+        token_logprobs = torch.where(token_mask.bool(), token_logprobs, 0.0)
 
         ref_logprobs = data["reference_policy_logprobs"][:, :-1]
 
@@ -772,6 +822,7 @@ class DPOLossFn(PreferenceLoss):
         vocab_parallel_rank: Optional[int] = None,
         vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
         context_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
+        sampling_params: TrainingSamplingParams | None = None,
     ) -> tuple[torch.Tensor, dict[str, Any]]:
         sft_loss_chosen = torch.tensor(0.0)
         if self.sft_loss_weight > 0:
@@ -788,6 +839,7 @@ class DPOLossFn(PreferenceLoss):
                 context_parallel_group=context_parallel_group,
                 dpo_loss=True,
                 dpo_average_log_probs=self.sft_average_log_probs,
+                sampling_params=sampling_params,
             )
             sft_loss_chosen, sft_loss_rejected = self.split_output_tensor(sft_loss)
             sft_loss_chosen = masked_mean(
@@ -808,6 +860,7 @@ class DPOLossFn(PreferenceLoss):
             vocab_parallel_rank=vocab_parallel_rank,
             vocab_parallel_group=vocab_parallel_group,
             context_parallel_group=context_parallel_group,
+            sampling_params=sampling_params,
         )
 
         dpo_loss = (
@@ -849,6 +902,7 @@ class SequencePackingLossWrapper:
         vocab_parallel_rank: Optional[int] = None,
         vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
         context_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
+        sampling_params: TrainingSamplingParams | None = None,
     ) -> tuple[Tensor, dict[str, Any]]:
         """Wraps a loss function to handle sequence packing by doing one sequence at a time to avoid excessive padding."""
         unpadded_cu_seqlens = self.cu_seqlens_q
@@ -899,6 +953,7 @@ class SequencePackingLossWrapper:
                 vocab_parallel_rank=vocab_parallel_rank,
                 vocab_parallel_group=vocab_parallel_group,
                 context_parallel_group=context_parallel_group,
+                sampling_params=sampling_params,
             )
             loss_accum += loss
             for k, v in metrics.items():
@@ -948,8 +1003,18 @@ class DistillationLossFn(LossFunction):
         vocab_parallel_rank: Optional[int] = None,
         vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
         context_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
+        sampling_params: TrainingSamplingParams | None = None,
     ) -> tuple[torch.Tensor, dict[str, Any]]:
         """Compute distillation loss between teacher and student logits."""
+        # The generation sampling params top-k and top-p are supported yet for distillation loss
+        if sampling_params is not None and (
+            need_top_k_filtering(sampling_params.top_k)
+            or need_top_p_filtering(sampling_params.top_p)
+        ):
+            raise ValueError(
+                "Generation sampling params top-k and top-p are supported yet for distillation loss"
+            )
+
         # Basic shapes
         input_ids = data["input_ids"]
         batch_size = input_ids.shape[0]

--- a/nemo_rl/algorithms/loss_functions.py
+++ b/nemo_rl/algorithms/loss_functions.py
@@ -266,7 +266,7 @@ class ClippedPGLossFn(LossFunction):
             next_token_logits_wo_last, _ = apply_top_k_top_p(
                 next_token_logits_wo_last,
                 top_k=sampling_params.top_k if sampling_params is not None else None,
-                top_p=sampling_params.top_p if sampling_params is not None else None,
+                top_p=sampling_params.top_p if sampling_params is not None else 1.0,
             )
             next_token_logprobs = torch.nn.functional.log_softmax(
                 next_token_logits_wo_last, dim=-1
@@ -519,7 +519,7 @@ class NLLLoss(LossFunction):
             next_token_logits, _ = apply_top_k_top_p(
                 next_token_logits,
                 top_k=sampling_params.top_k if sampling_params is not None else None,
-                top_p=sampling_params.top_p if sampling_params is not None else None,
+                top_p=sampling_params.top_p if sampling_params is not None else 1.0,
             )
             next_token_logprobs = torch.nn.functional.log_softmax(
                 next_token_logits, dim=-1
@@ -787,7 +787,7 @@ class DPOLossFn(PreferenceLoss):
             next_token_logits, _ = apply_top_k_top_p(
                 next_token_logits,
                 top_k=sampling_params.top_k if sampling_params is not None else None,
-                top_p=sampling_params.top_p if sampling_params is not None else None,
+                top_p=sampling_params.top_p if sampling_params is not None else 1.0,
             )
             next_token_logprobs = torch.nn.functional.log_softmax(
                 next_token_logits, dim=-1
@@ -1006,13 +1006,13 @@ class DistillationLossFn(LossFunction):
         sampling_params: TrainingSamplingParams | None = None,
     ) -> tuple[torch.Tensor, dict[str, Any]]:
         """Compute distillation loss between teacher and student logits."""
-        # The generation sampling params top-k and top-p are supported yet for distillation loss
+        # The generation sampling params top-k and top-p are not supported yet for distillation loss
         if sampling_params is not None and (
             need_top_k_filtering(sampling_params.top_k)
             or need_top_p_filtering(sampling_params.top_p)
         ):
             raise ValueError(
-                "Generation sampling params top-k and top-p are supported yet for distillation loss"
+                "Generation sampling params top-k and top-p are not supported yet for distillation loss"
             )
 
         # Basic shapes

--- a/nemo_rl/models/generation/vllm/vllm_generation.py
+++ b/nemo_rl/models/generation/vllm/vllm_generation.py
@@ -84,13 +84,13 @@ class VllmGeneration(GenerationInterface):
         top_k: int | None = self.cfg.get("top_k", None)
         if top_k is not None and top_k != -1 and top_k < 1:
             raise ValueError(
-                "top_k valid values: i) None or -1: no filtering. ii) >= 1: top-k filtering. Got top_k={top_k}."
+                f"top_k valid values: i) None or -1: no filtering. ii) >= 1: top-k filtering. Got top_k={top_k}."
             )
 
         top_p: float = self.cfg.get("top_p", 1.0)
         if top_p <= 0:
             raise ValueError(
-                "top_p valid values: i) 1.0: no filtering. ii) (0, 1]: top-p filtering. Got top_p={top_p}."
+                f"top_p valid values: i) 1.0: no filtering. ii) (0, 1]: top-p filtering. Got top_p={top_p}."
             )
 
         # Ensure all required VllmConfig fields are present

--- a/nemo_rl/models/generation/vllm/vllm_generation.py
+++ b/nemo_rl/models/generation/vllm/vllm_generation.py
@@ -40,8 +40,8 @@ from nemo_rl.models.generation.vllm.config import VllmConfig
 # Global thresholds for top_k and top_p validation.
 # While top-k/p are not supported, these values allow for token filtering while the logprobs should be compatible.
 # See https://github.com/NVIDIA-NeMo/RL/issues/69 and https://github.com/NVIDIA-NeMo/RL/issues/237 for more details.
-TOP_K_THRESHOLD = 8000  # Allow top_k >= 8000 (effectively no filtering)
-TOP_P_THRESHOLD = 0.99  # Allow top_p >= 0.99 (close to 1.0)
+TOP_K_THRESHOLD = 1  # Allow top_k >= 8000 (effectively no filtering)
+TOP_P_THRESHOLD = 0.1  # Allow top_p >= 0.99 (close to 1.0)
 
 
 class VllmGeneration(GenerationInterface):

--- a/nemo_rl/models/generation/vllm/vllm_generation.py
+++ b/nemo_rl/models/generation/vllm/vllm_generation.py
@@ -37,12 +37,6 @@ from nemo_rl.models.generation.interfaces import (
 )
 from nemo_rl.models.generation.vllm.config import VllmConfig
 
-# Global thresholds for top_k and top_p validation.
-# While top-k/p are not supported, these values allow for token filtering while the logprobs should be compatible.
-# See https://github.com/NVIDIA-NeMo/RL/issues/69 and https://github.com/NVIDIA-NeMo/RL/issues/237 for more details.
-TOP_K_THRESHOLD = 1  # Allow top_k >= 8000 (effectively no filtering)
-TOP_P_THRESHOLD = 0.1  # Allow top_p >= 0.99 (close to 1.0)
-
 
 class VllmGeneration(GenerationInterface):
     def __init__(
@@ -87,30 +81,16 @@ class VllmGeneration(GenerationInterface):
                 )
 
         # Validate sampling parameters early to avoid resource allocation with unsupported configs.
-        # The vLLM sampler patch only supports temperature scaling and does not handle top_p/top_k correctly.
-        # However, we allow values above certain thresholds for token filtering purposes.
-        top_k = self.cfg["top_k"]
-        if top_k is not None and top_k != -1 and top_k < TOP_K_THRESHOLD:
+        top_k: int | None = self.cfg.get("top_k", None)
+        if top_k is not None and top_k != -1 and top_k < 1:
             raise ValueError(
-                (
-                    f"top_k sampling with values < {TOP_K_THRESHOLD} is not supported because the vLLM V1 engine "
-                    "does not return logprobs after top_k filtering. Values >= {TOP_K_THRESHOLD} are allowed "
-                    "for token filtering purposes. If you understand the implications and still want to use "
-                    f"a lower top_k value, please manually comment out this check. Got top_k={top_k}. "
-                    "See https://github.com/NVIDIA-NeMo/RL/issues/69 for more details."
-                )
+                "top_k valid values: i) None or -1: no filtering. ii) >= 1: top-k filtering. Got top_k={top_k}."
             )
 
         top_p: float = self.cfg.get("top_p", 1.0)
-        if top_p < TOP_P_THRESHOLD:
+        if top_p <= 0:
             raise ValueError(
-                (
-                    f"top_p sampling with values < {TOP_P_THRESHOLD} is not supported because the vLLM V1 engine "
-                    "does not return logprobs after top_p filtering. Values >= {TOP_P_THRESHOLD} are allowed "
-                    "for token filtering purposes. If you understand the implications and still want to use "
-                    f"a lower top_p value, please manually comment out this check. Got top_p={top_p}. "
-                    "See https://github.com/NVIDIA-NeMo/RL/issues/69 for more details."
-                )
+                "top_p valid values: i) 1.0: no filtering. ii) (0, 1]: top-p filtering. Got top_p={top_p}."
             )
 
         # Ensure all required VllmConfig fields are present

--- a/nemo_rl/models/policy/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker.py
@@ -1688,8 +1688,16 @@ class DTensorPolicyWorker:
                 # The reference policy has different weights, so its top-k/top-p set is
                 # inherently different from the current policy. Using filtered logprobs
                 # would cause -inf mismatches that cannot be resolved by masking.
+                # Note: We keep temperature scaling since it was applied to prev_logprobs.
                 saved_sampling_params = self.sampling_params
-                self.sampling_params = None
+                if saved_sampling_params is not None:
+                    self.sampling_params = TrainingSamplingParams(
+                        top_k=None,  # Disable top-k
+                        top_p=1.0,  # Disable top-p
+                        temperature=saved_sampling_params.temperature,  # Keep temperature
+                    )
+                else:
+                    self.sampling_params = None
 
                 # - self.model is the original reference_model, now on CUDA
                 # - curr_state_dict is the train model, now on CPU

--- a/nemo_rl/models/policy/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker_v2.py
@@ -1651,8 +1651,16 @@ class DTensorPolicyWorkerV2:
                 # The reference policy has different weights, so its top-k/top-p set is
                 # inherently different from the current policy. Using filtered logprobs
                 # would cause -inf mismatches that cannot be resolved by masking.
+                # Note: We keep temperature scaling since it was applied to prev_logprobs.
                 saved_sampling_params = self.sampling_params
-                self.sampling_params = None
+                if saved_sampling_params is not None:
+                    self.sampling_params = TrainingSamplingParams(
+                        top_k=None,  # Disable top-k
+                        top_p=1.0,  # Disable top-p
+                        temperature=saved_sampling_params.temperature,  # Keep temperature
+                    )
+                else:
+                    self.sampling_params = None
 
                 # - self.model is the original reference_model, now on CUDA
                 # - curr_state_dict is the train model, now on CPU

--- a/nemo_rl/models/policy/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/megatron_policy_worker.py
@@ -125,6 +125,7 @@ from nemo_rl.models.policy.interfaces import (
     ReferenceLogprobOutputSpec,
 )
 from nemo_rl.models.policy.utils import (
+    TrainingSamplingParams,
     configure_dynamo_cache,
     get_gpu_info,
     get_megatron_checkpoint_dir,
@@ -473,6 +474,16 @@ class MegatronPolicyWorker:
             "optimizer_cpu_offload"
         ]
         self.offload_optimizer_for_logprob = self.cfg["offload_optimizer_for_logprob"]
+
+        if "generation" in self.cfg and self.cfg["generation"] is not None:
+            generation_cfg = self.cfg["generation"]
+            self.sampling_params = TrainingSamplingParams(
+                top_k=generation_cfg.get("top_k", None),
+                top_p=generation_cfg.get("top_p", 1.0),
+                temperature=generation_cfg.get("temperature", 1.0),
+            )
+        else:
+            self.sampling_params = None
 
         # Reward models are not yet supported with Megatron.
         if "reward_model_cfg" in self.cfg and self.cfg["reward_model_cfg"]["enabled"]:
@@ -980,7 +991,9 @@ class MegatronPolicyWorker:
                     )
 
             forward_step = partial(
-                forward_step_arbitrary_loss, loss_fn=loss_fn, policy_cfg=self.cfg
+                forward_step_arbitrary_loss,
+                loss_fn=loss_fn,
+                sampling_params=self.sampling_params,
             )
             all_mb_metrics = []
             losses = []
@@ -1300,8 +1313,11 @@ class MegatronPolicyWorker:
 
             # Apply temperature scaling to logits for training
             # This matches the dtensor worker's _apply_temperature_scaling in the train method
-            if "generation" in self.cfg and self.cfg["generation"] is not None:
-                output_tensor.div_(self.cfg["generation"]["temperature"])
+            if (
+                self.sampling_params is not None
+                and self.sampling_params.temperature != 1.0
+            ):
+                output_tensor.div_(self.sampling_params.temperature)
 
             def collection_fn(output_tensor):
                 stc = time.time()
@@ -1320,6 +1336,7 @@ class MegatronPolicyWorker:
                         inference_only=True,
                         cp_group=get_context_parallel_group(),
                         chunk_size=logprob_chunk_size,
+                        sampling_params=self.sampling_params,
                     )
                 else:
                     token_logprobs = from_parallel_logits_to_logprobs(
@@ -1330,6 +1347,7 @@ class MegatronPolicyWorker:
                         tp_group=tp_grp,
                         inference_only=True,
                         chunk_size=logprob_chunk_size,
+                        sampling_params=self.sampling_params,
                     )
 
                 # Prepend 0 logprob for first token to maintain same sequence length as input
@@ -1581,8 +1599,12 @@ class MegatronPolicyWorker:
                 **multimodal_data,
             )
 
-            if "generation" in self.cfg and self.cfg["generation"] is not None:
-                output_tensor.div_(self.cfg["generation"]["temperature"])
+            # Apply temperature scaling
+            if (
+                self.sampling_params is not None
+                and self.sampling_params.temperature != 1.0
+            ):
+                output_tensor.div_(self.sampling_params.temperature)
 
             def collection_fn(_):
                 # Only the last PP stage produces final logits/top-k; earlier stages return empty

--- a/nemo_rl/models/policy/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/megatron_policy_worker.py
@@ -1445,8 +1445,16 @@ class MegatronPolicyWorker:
                 # The reference policy has different weights, so its top-k/top-p set is
                 # inherently different from the current policy. Using filtered logprobs
                 # would cause -inf mismatches that cannot be resolved by masking.
+                # Note: We keep temperature scaling since it was applied to prev_logprobs.
                 saved_sampling_params = self.sampling_params
-                self.sampling_params = None
+                if saved_sampling_params is not None:
+                    self.sampling_params = TrainingSamplingParams(
+                        top_k=None,  # Disable top-k
+                        top_p=1.0,  # Disable top-p
+                        temperature=saved_sampling_params.temperature,  # Keep temperature
+                    )
+                else:
+                    self.sampling_params = None
 
                 # - self.model is the original reference_model, now on CUDA
                 # - self.reference_model is the original model, now on CPU

--- a/nemo_rl/models/policy/utils.py
+++ b/nemo_rl/models/policy/utils.py
@@ -16,6 +16,7 @@ import gc
 import importlib
 import os
 import traceback
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Optional
 
@@ -81,68 +82,39 @@ class IPCProtocol(Enum):
     ACK = "ack"
 
 
-def apply_top_k_top_p(
-    logits: torch.Tensor,
-    top_k: Optional[int] = None,
-    top_p: Optional[float] = None,
-) -> torch.Tensor:
-    """Apply top-k and top-p masks to the logits.
+def need_top_k_filtering(top_k: int | None) -> bool:
+    """Check if top-k filtering is needed."""
+    return top_k is not None and top_k != -1
 
-    Simplified version of VLLM's implementation for scalar parameters.
 
-    Based on VLLM's implementation:
-    https://github.com/vllm-project/vllm/blob/34a20c49b3f81f64133428b3a0d62309db1256f9/vllm/v1/sample/ops/topk_topp_sampler.py
-    SPDX-License-Identifier: Apache-2.0
-    Copyright contributors to the vLLM project
+def need_top_p_filtering(top_p: float | None) -> bool:
+    """Check if top-p filtering is needed."""
+    return top_p is not None and top_p != 1.0
 
-    Args:
-        logits: Input logits tensor of shape [batch_size, seq_len, vocab_size]
-        top_k: Top-k sampling parameter. Set to -1 to consider all tokens.
-        top_p: Top-p (nucleus) sampling parameter. Must be in (0, 1]. Set to 1 to consider all tokens.
 
-    Returns:
-        Filtered logits with sampling parameters applied
+@dataclass
+class TrainingSamplingParams:
+    """Training-specific sampling parameters to match generation parameters.
+
+    Used to ensure consistency between training and inference by applying the same sampling strategy during
+    logprob computation. Not directly using vLLM's SamplingParams class to avoid dependency on vLLM in this env.
+
+    Attributes:
+        top_k: Top-k filtering parameter (None or -1 to disable)
+        top_p: Top-p filtering parameter (1.0 to disable)
+        temperature: Temperature for scaling logits (default: 1.0)
     """
-    if top_p is None or top_p == 1.0:
-        if top_k is None or top_k == -1:
-            return logits
-        # Avoid sorting vocab for top-k only case
-        return apply_top_k_only(logits, top_k)
 
-    # Apply top-p (requires sorting)
-    logits_sort, logits_idx = logits.sort(dim=-1, descending=False)
-
-    if top_k is not None and top_k != -1:
-        # Apply top-k first
-        top_k_index = logits_sort.size(-1) - top_k
-        # Get all the top_k values - need to broadcast the index across all dimensions
-        index_tensor = torch.full(
-            logits_sort.shape[:-1],
-            top_k_index,
-            device=logits_sort.device,
-            dtype=torch.long,
-        )
-        top_k_threshold = logits_sort.gather(-1, index_tensor.unsqueeze(-1))
-        top_k_mask = logits_sort < top_k_threshold
-        logits_sort.masked_fill_(top_k_mask, -float("inf"))
-
-    # Apply top-p
-    probs_sort = logits_sort.softmax(dim=-1)
-    probs_sum = torch.cumsum(probs_sort, dim=-1)
-    top_p_mask = probs_sum <= 1 - top_p
-    # at least one
-    top_p_mask[..., -1] = False
-    logits_sort.masked_fill_(top_p_mask, -float("inf"))
-
-    # Re-sort the probabilities
-    logits = logits_sort.scatter(dim=-1, index=logits_idx, src=logits_sort)
-    return logits
+    top_k: int | None = None
+    top_p: float = 1.0
+    temperature: float = 1.0
 
 
-def apply_top_k_only(
+@torch.no_grad()
+def _apply_top_k_only_fn(
     logits: torch.Tensor,
-    top_k: int,
-) -> torch.Tensor:
+    top_k: int | None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Apply top-k mask to the logits.
 
     Simplified version of VLLM's implementation for scalar parameters.
@@ -158,23 +130,155 @@ def apply_top_k_only(
         top_k: Top-k sampling parameter.
 
     Returns:
-        Filtered logits with top-k applied
+        filtered_logits: Filtered logits tensor of shape [batch_size, seq_len, vocab_size].
+        keep_mask: Mask tensor of shape [batch_size, seq_len, vocab_size], where 1 (True) indicates tokens to be
+            kept, 0 (False) indicates tokens to be masked. None if top-k filtering is not needed.
     """
-    if top_k >= logits.shape[-1] or top_k == -1:
-        return logits
+    if not need_top_k_filtering(top_k):
+        return logits, None
 
     # Get top-k values and create mask
+    assert top_k is not None  # Type narrowing
     top_k_values, _ = torch.topk(logits, top_k, dim=-1)
     threshold = top_k_values[..., -1:].expand_as(logits)
-    mask = logits >= threshold
+    keep_mask = logits >= threshold
 
     # Apply mask: keep top-k values, set others to -inf
     logits = torch.where(
-        mask,
+        keep_mask,
         logits,
         torch.tensor(-float("inf"), device=logits.device, dtype=logits.dtype),
     )
-    return logits
+    return logits, keep_mask
+
+
+@torch.no_grad()
+def _apply_top_k_top_p_fn(
+    logits: torch.Tensor,
+    top_k: int | None,
+    top_p: float,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Apply top-k and top-p masks to the logits (internal function).
+
+    Simplified version of VLLM's implementation for scalar parameters.
+
+    Based on VLLM's implementation:
+    https://github.com/vllm-project/vllm/blob/34a20c49b3f81f64133428b3a0d62309db1256f9/vllm/v1/sample/ops/topk_topp_sampler.py
+    SPDX-License-Identifier: Apache-2.0
+    Copyright contributors to the vLLM project
+
+    Args:
+        logits: Input logits tensor of shape [batch_size, seq_len, vocab_size]
+        top_k: Top-k sampling parameter. Set to -1 to consider all tokens.
+        top_p: Top-p (nucleus) sampling parameter. Must be in (0, 1]. Set to 1 to consider all tokens.
+
+    Returns:
+        filtered_logits: Filtered logits tensor of shape [batch_size, seq_len, vocab_size].
+        keep_mask: Mask tensor of shape [batch_size, seq_len, vocab_size], where 1 (True) indicates
+            tokens to be kept, 0 (False) indicates tokens to be masked.
+    """
+    if not need_top_p_filtering(top_p):
+        if not need_top_k_filtering(top_k):
+            return logits, None
+        # Avoid sorting vocab for top-k only case
+        filtered_logits, top_k_keep_mask = _apply_top_k_only_fn(logits, top_k)
+        return filtered_logits, top_k_keep_mask
+
+    # Apply top-p (requires sorting)
+    logits_sort, logits_idx = logits.sort(dim=-1, descending=False)
+    top_k_keep_mask = None
+
+    if need_top_k_filtering(top_k):
+        assert top_k is not None  # Type narrowing
+        # Apply top-k first
+        top_k_index = logits_sort.size(-1) - top_k
+        # Get all the top_k values - need to broadcast the index across all dimensions
+        index_tensor = torch.full(
+            logits_sort.shape[:-1],
+            top_k_index,
+            device=logits_sort.device,
+            dtype=torch.long,
+        )
+        top_k_threshold = logits_sort.gather(-1, index_tensor.unsqueeze(-1))
+        top_k_keep_mask = logits_sort >= top_k_threshold
+        logits_sort.masked_fill_(~top_k_keep_mask, -float("inf"))
+
+    # Apply top-p
+    probs_sort = logits_sort.softmax(dim=-1)
+    probs_sum = torch.cumsum(probs_sort, dim=-1)
+    top_p_keep_mask = probs_sum > 1 - top_p
+    # at least one
+    top_p_keep_mask[..., -1] = True
+    logits_sort.masked_fill_(~top_p_keep_mask, -float("inf"))
+
+    # Re-sort the probabilities
+    logits = logits_sort.scatter(dim=-1, index=logits_idx, src=logits_sort)
+    if top_k_keep_mask is not None:
+        keep_mask = torch.logical_and(top_k_keep_mask, top_p_keep_mask)
+    else:
+        keep_mask = top_p_keep_mask
+
+    return logits, keep_mask
+
+
+class ApplyTopKTopP(torch.autograd.Function):
+    """Autograd function for top-k and top-p filtering with proper gradient handling."""
+
+    @staticmethod
+    def forward(  # pyrefly: ignore[bad-override]  Always ignore torch.autograd.Function.forward's type since it's always more specific than the base class
+        ctx,
+        logits: torch.Tensor,
+        top_k: Optional[int],
+        top_p: float,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Apply top-k/top-p filtering and save masks for backward."""
+        filtered_logits, keep_mask = _apply_top_k_top_p_fn(logits, top_k, top_p)
+
+        # Save masks for backward pass
+        ctx.save_for_backward(keep_mask)
+
+        return filtered_logits, keep_mask
+
+    @staticmethod
+    def backward(ctx, *grad_outputs: torch.Tensor):
+        """Backward pass: mask out gradients for filtered tokens."""
+        grad_filtered_logits = grad_outputs[0]
+        (keep_mask,) = ctx.saved_tensors
+
+        # Apply masks to gradients - masked out tokens should not receive gradients
+        if keep_mask is not None:
+            grad_filtered_logits = grad_filtered_logits.masked_fill(~keep_mask, 0.0)
+
+        return grad_filtered_logits, None, None
+
+
+def apply_top_k_top_p(
+    logits: torch.Tensor,
+    top_k: int | None,
+    top_p: float,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Apply top-k and top-p masks to the logits with proper gradient handling.
+
+    Simplified version of VLLM's implementation for scalar parameters.
+
+    Based on VLLM's implementation:
+    https://github.com/vllm-project/vllm/blob/34a20c49b3f81f64133428b3a0d62309db1256f9/vllm/v1/sample/ops/topk_topp_sampler.py
+    SPDX-License-Identifier: Apache-2.0
+    Copyright contributors to the vLLM project
+
+    Args:
+        logits: Input logits tensor of shape [batch_size, seq_len, vocab_size]
+        top_k: Top-k sampling parameter. Set to -1 to consider all tokens.
+        top_p: Top-p (nucleus) sampling parameter. Must be in (0, 1]. Set to 1 to consider all tokens.
+
+    Returns:
+        filtered_logits: Filtered logits tensor of shape [batch_size, seq_len, vocab_size].
+        keep_mask: Mask tensor of shape [batch_size, seq_len, vocab_size], where 1 (True) indicates tokens to be
+            kept, 0 (False) indicates tokens to be masked.
+    """
+    if not need_top_k_filtering(top_k) and not need_top_p_filtering(top_p):
+        return logits, None
+    return ApplyTopKTopP.apply(logits, top_k, top_p)
 
 
 def resolve_model_class(model_name: str) -> Any:

--- a/nemo_rl/models/policy/utils.py
+++ b/nemo_rl/models/policy/utils.py
@@ -74,6 +74,14 @@ if NEMO_AUTOMODEL_AVAILABLE:
         "llama4": NeMoAutoModelForImageTextToText,
     }
 
+# Default chunk size for top-k/top-p filtering.
+# The sort operation in top-p filtering is memory intensive because it creates
+# intermediate tensors of shape [bsz, seq_len, vocab_size] for both sorted values
+# and indices. For large vocab sizes (e.g., 152K) and long sequences (e.g., 32K),
+# this can cause OOM. Chunking along the sequence dimension reduces peak memory.
+# Different chunk sizes have minor performance differences.
+TOP_K_TOP_P_CHUNK_SIZE: int = 256
+
 
 class IPCProtocol(Enum):
     """IPC protocol constants for ZMQ weight streaming."""
@@ -90,6 +98,11 @@ def need_top_k_filtering(top_k: int | None) -> bool:
 def need_top_p_filtering(top_p: float | None) -> bool:
     """Check if top-p filtering is needed."""
     return top_p is not None and top_p != 1.0
+
+
+def need_top_k_or_top_p_filtering(top_k: int | None, top_p: float | None) -> bool:
+    """Check if top-k or top-p filtering is needed."""
+    return need_top_k_filtering(top_k) or need_top_p_filtering(top_p)
 
 
 @dataclass
@@ -126,12 +139,12 @@ def _apply_top_k_only_fn(
     Copyright contributors to the vLLM project
 
     Args:
-        logits: Input logits tensor of shape [batch_size, seq_len, vocab_size]
+        logits: Input logits tensor of shape [*, vocab_size].
         top_k: Top-k sampling parameter.
 
     Returns:
-        filtered_logits: Filtered logits tensor of shape [batch_size, seq_len, vocab_size].
-        keep_mask: Mask tensor of shape [batch_size, seq_len, vocab_size], where 1 (True) indicates tokens to be
+        filtered_logits: Filtered logits tensor with the same shape as input logits.
+        keep_mask: Mask tensor with the same shape as input logits, where 1 (True) indicates tokens to be
             kept, 0 (False) indicates tokens to be masked. None if top-k filtering is not needed.
     """
     if not need_top_k_filtering(top_k):
@@ -157,10 +170,15 @@ def _apply_top_k_top_p_fn(
     logits: torch.Tensor,
     top_k: int | None,
     top_p: float,
+    chunk_size: int | None = TOP_K_TOP_P_CHUNK_SIZE,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
-    """Apply top-k and top-p masks to the logits (internal function).
+    """Apply top-k and top-p masks to the logits with chunking for memory efficiency.
 
-    Simplified version of VLLM's implementation for scalar parameters.
+    The sort operation in top-p filtering is memory intensive because it creates
+    intermediate tensors of shape [num_tokens, vocab_size] for both sorted values
+    and indices. For large vocab sizes (e.g., 152K) and many tokens, this can cause OOM.
+    This function flattens the input to 2D and processes in chunks along the token
+    dimension (controlled by chunk_size) to reduce peak memory.
 
     Based on VLLM's implementation:
     https://github.com/vllm-project/vllm/blob/34a20c49b3f81f64133428b3a0d62309db1256f9/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -168,13 +186,15 @@ def _apply_top_k_top_p_fn(
     Copyright contributors to the vLLM project
 
     Args:
-        logits: Input logits tensor of shape [batch_size, seq_len, vocab_size]
-        top_k: Top-k sampling parameter. Set to -1 to consider all tokens.
-        top_p: Top-p (nucleus) sampling parameter. Must be in (0, 1]. Set to 1 to consider all tokens.
+        logits: Input logits tensor of shape [*, vocab_size] (e.g., [batch_size, seq_len, vocab_size]
+            or [batch_size, vocab_size]). Internally flattened to [num_tokens, vocab_size] for processing.
+        top_k: Top-k sampling parameter. Set to -1 or None to consider all tokens.
+        top_p: Top-p (nucleus) sampling parameter. Must be in (0, 1]. Set to 1 to consider all tokens
+        chunk_size: Number of tokens to process per chunk for memory efficiency. Defaults to TOP_K_TOP_P_CHUNK_SIZE.
 
     Returns:
-        filtered_logits: Filtered logits tensor of shape [batch_size, seq_len, vocab_size].
-        keep_mask: Mask tensor of shape [batch_size, seq_len, vocab_size], where 1 (True) indicates
+        filtered_logits: Filtered logits tensor with the same shape as input logits.
+        keep_mask: Mask tensor with the same shape as input logits, where 1 (True) indicates
             tokens to be kept, 0 (False) indicates tokens to be masked.
     """
     if not need_top_p_filtering(top_p):
@@ -184,44 +204,67 @@ def _apply_top_k_top_p_fn(
         filtered_logits, top_k_keep_mask = _apply_top_k_only_fn(logits, top_k)
         return filtered_logits, top_k_keep_mask
 
-    # Apply top-p (requires sorting)
-    logits_sort, logits_idx = logits.sort(dim=-1, descending=False)
-    top_k_keep_mask = None
+    # Save original shape and flatten to 2D for consistent chunking
+    original_shape = logits.shape
+    vocab_size = logits.shape[-1]
+    logits = logits.view(-1, vocab_size)  # [*, vocab_size] -> [num_tokens, vocab_size]
+    num_tokens = logits.shape[0]
 
-    if need_top_k_filtering(top_k):
-        assert top_k is not None  # Type narrowing
-        # Apply top-k first
-        top_k_index = logits_sort.size(-1) - top_k
-        # Get all the top_k values - need to broadcast the index across all dimensions
-        index_tensor = torch.full(
-            logits_sort.shape[:-1],
-            top_k_index,
-            device=logits_sort.device,
-            dtype=torch.long,
-        )
-        top_k_threshold = logits_sort.gather(-1, index_tensor.unsqueeze(-1))
-        top_k_keep_mask = logits_sort >= top_k_threshold
-        logits_sort.masked_fill_(~top_k_keep_mask, -float("inf"))
+    chunk_size = chunk_size if chunk_size is not None else num_tokens
 
-    # Apply top-p
-    probs_sort = logits_sort.softmax(dim=-1)
-    probs_sum = torch.cumsum(probs_sort, dim=-1)
-    top_p_keep_mask = probs_sum > 1 - top_p
-    # at least one
-    top_p_keep_mask[..., -1] = True
-    logits_sort.masked_fill_(~top_p_keep_mask, -float("inf"))
+    # Pre-allocate output tensors
+    filtered_logits = torch.empty_like(logits)
+    keep_mask = torch.empty(
+        num_tokens, vocab_size, dtype=torch.bool, device=logits.device
+    )
 
-    # Scatter the logits back to the original order
-    logits = logits_sort.scatter(dim=-1, index=logits_idx, src=logits_sort)
-    if top_k_keep_mask is not None:
-        keep_mask = torch.logical_and(top_k_keep_mask, top_p_keep_mask)
-    else:
-        keep_mask = top_p_keep_mask
+    for start_idx in range(0, num_tokens, chunk_size):
+        end_idx = min(start_idx + chunk_size, num_tokens)
+        chunk_logits = logits[start_idx:end_idx, :]
 
-    # Scatter the keep_mask back to the original order to match logits
-    keep_mask = keep_mask.scatter(dim=-1, index=logits_idx, src=keep_mask)
+        # Sort this chunk
+        logits_sort, logits_idx = chunk_logits.sort(dim=-1, descending=False)
+        top_k_keep_mask_chunk = None
 
-    return logits, keep_mask
+        if need_top_k_filtering(top_k):
+            assert top_k is not None  # Type narrowing
+            # Apply top-k first
+            top_k_index = logits_sort.size(-1) - top_k
+            index_tensor = torch.full(
+                logits_sort.shape[:-1],
+                top_k_index,
+                device=logits_sort.device,
+                dtype=torch.long,
+            )
+            top_k_threshold = logits_sort.gather(-1, index_tensor.unsqueeze(-1))
+            top_k_keep_mask_chunk = logits_sort >= top_k_threshold
+            logits_sort.masked_fill_(~top_k_keep_mask_chunk, -float("inf"))
+
+        # Apply top-p
+        probs_sort = logits_sort.softmax(dim=-1)
+        probs_sum = torch.cumsum(probs_sort, dim=-1)
+        top_p_keep_mask_chunk = probs_sum > 1 - top_p
+        # at least one
+        top_p_keep_mask_chunk[..., -1] = True
+        logits_sort.masked_fill_(~top_p_keep_mask_chunk, -float("inf"))
+
+        # Scatter back to original order
+        chunk_filtered = logits_sort.scatter(dim=-1, index=logits_idx, src=logits_sort)
+        if top_k_keep_mask_chunk is not None:
+            chunk_mask = torch.logical_and(top_k_keep_mask_chunk, top_p_keep_mask_chunk)
+        else:
+            chunk_mask = top_p_keep_mask_chunk
+        chunk_mask = chunk_mask.scatter(dim=-1, index=logits_idx, src=chunk_mask)
+
+        # Store results
+        filtered_logits[start_idx:end_idx, :] = chunk_filtered
+        keep_mask[start_idx:end_idx, :] = chunk_mask
+
+    # Restore original shape
+    filtered_logits = filtered_logits.view(original_shape)
+    keep_mask = keep_mask.view(original_shape)
+
+    return filtered_logits, keep_mask
 
 
 class ApplyTopKTopP(torch.autograd.Function):
@@ -233,9 +276,19 @@ class ApplyTopKTopP(torch.autograd.Function):
         logits: torch.Tensor,
         top_k: Optional[int],
         top_p: float,
+        chunk_size: int | None = TOP_K_TOP_P_CHUNK_SIZE,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        """Apply top-k/top-p filtering and save masks for backward."""
-        filtered_logits, keep_mask = _apply_top_k_top_p_fn(logits, top_k, top_p)
+        """Apply top-k/top-p filtering and save masks for backward.
+
+        Args:
+            logits: Input logits tensor of shape [*, vocab_size].
+            top_k: Top-k sampling parameter. Set to -1 or None to consider all tokens.
+            top_p: Top-p sampling parameter. Must be in (0, 1]. Set to 1 to consider all tokens.
+            chunk_size: Number of tokens to process per chunk. Defaults to TOP_K_TOP_P_CHUNK_SIZE.
+        """
+        filtered_logits, keep_mask = _apply_top_k_top_p_fn(
+            logits, top_k, top_p, chunk_size
+        )
 
         # Save masks for backward pass
         ctx.save_for_backward(keep_mask)
@@ -252,17 +305,21 @@ class ApplyTopKTopP(torch.autograd.Function):
         if keep_mask is not None:
             grad_filtered_logits = grad_filtered_logits.masked_fill(~keep_mask, 0.0)
 
-        return grad_filtered_logits, None, None
+        return grad_filtered_logits, None, None, None
 
 
 def apply_top_k_top_p(
     logits: torch.Tensor,
     top_k: int | None,
     top_p: float,
+    chunk_size: int | None = TOP_K_TOP_P_CHUNK_SIZE,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Apply top-k and top-p masks to the logits with proper gradient handling.
 
     Simplified version of VLLM's implementation for scalar parameters.
+
+    When top_p < 1.0, sorting is required which is memory intensive for large vocab sizes.
+    Processing is done in chunks (controlled by chunk_size) to reduce peak memory.
 
     Based on VLLM's implementation:
     https://github.com/vllm-project/vllm/blob/34a20c49b3f81f64133428b3a0d62309db1256f9/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -270,18 +327,19 @@ def apply_top_k_top_p(
     Copyright contributors to the vLLM project
 
     Args:
-        logits: Input logits tensor of shape [batch_size, seq_len, vocab_size]
+        logits: Input logits tensor of shape [*, vocab_size].
         top_k: Top-k sampling parameter. Set to -1 to consider all tokens.
         top_p: Top-p (nucleus) sampling parameter. Must be in (0, 1]. Set to 1 to consider all tokens.
+        chunk_size: Number of tokens to process per chunk. Defaults to TOP_K_TOP_P_CHUNK_SIZE.
 
     Returns:
-        filtered_logits: Filtered logits tensor of shape [batch_size, seq_len, vocab_size].
-        keep_mask: Mask tensor of shape [batch_size, seq_len, vocab_size], where 1 (True) indicates tokens to be
+        filtered_logits: Filtered logits tensor with the same shape as input logits.
+        keep_mask: Mask tensor with the same shape as input logits, where 1 (True) indicates tokens to be
             kept, 0 (False) indicates tokens to be masked.
     """
-    if not need_top_k_filtering(top_k) and not need_top_p_filtering(top_p):
+    if not need_top_k_or_top_p_filtering(top_k, top_p):
         return logits, None
-    return ApplyTopKTopP.apply(logits, top_k, top_p)
+    return ApplyTopKTopP.apply(logits, top_k, top_p, chunk_size)
 
 
 def resolve_model_class(model_name: str) -> Any:

--- a/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-megatron-sampling.sh
+++ b/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-megatron-sampling.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $SCRIPT_DIR/common.env
+
+# ===== BEGIN CONFIG =====
+NUM_NODES=1
+STEPS_PER_RUN=500
+MAX_STEPS=500
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=180
+# ===== END CONFIG =====
+
+exit_if_max_steps_reached
+
+# Run the experiment
+cd $PROJECT_ROOT
+uv run examples/run_grpo_math.py \
+    --config $CONFIG_PATH \
+    grpo.max_num_steps=$MAX_STEPS \
+    logger.log_dir=$LOG_DIR \
+    logger.wandb_enabled=True \
+    logger.wandb.project=nemo-rl \
+    logger.wandb.name=$EXP_NAME \
+    logger.monitor_gpus=True \
+    logger.tensorboard_enabled=True \
+    checkpointing.enabled=True \
+    checkpointing.checkpoint_dir=$CKPT_DIR \
+    $@ \
+    2>&1 | tee $RUN_LOG
+
+# Convert tensorboard logs to json
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+
+# Only run metrics if the target step is reached
+if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
+    uv run tests/check_metrics.py $JSON_METRICS \
+        'mean(data["train/token_mult_prob_error"], ignore_top_p=0.01) < 1.05' \
+        'data["train/token_mult_prob_error"]["500"] < 1.1' \
+        'data["train/reward"]["500"] > 0.1' \
+        'mean(data["timing/train/total_step_time"], -6, -1) < 12.5'
+fi

--- a/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-megatron-temp0.6.sh
+++ b/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-megatron-temp0.6.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $SCRIPT_DIR/common.env
+
+# ===== BEGIN CONFIG =====
+NUM_NODES=1
+STEPS_PER_RUN=500
+MAX_STEPS=500
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=180
+# ===== END CONFIG =====
+
+exit_if_max_steps_reached
+
+# Run the experiment
+cd $PROJECT_ROOT
+uv run examples/run_grpo_math.py \
+    --config $CONFIG_PATH \
+    grpo.max_num_steps=$MAX_STEPS \
+    logger.log_dir=$LOG_DIR \
+    logger.wandb_enabled=True \
+    logger.wandb.project=nemo-rl \
+    logger.wandb.name=$EXP_NAME \
+    logger.monitor_gpus=True \
+    logger.tensorboard_enabled=True \
+    checkpointing.enabled=True \
+    checkpointing.checkpoint_dir=$CKPT_DIR \
+    $@ \
+    2>&1 | tee $RUN_LOG
+
+# Convert tensorboard logs to json
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+
+# Only run metrics if the target step is reached
+if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
+    uv run tests/check_metrics.py $JSON_METRICS \
+        'mean(data["train/token_mult_prob_error"], ignore_top_p=0.01) < 1.05' \
+        'data["train/token_mult_prob_error"]["500"] < 1.1' \
+        'data["train/reward"]["500"] > 0.1' \
+        'mean(data["timing/train/total_step_time"], -6, -1) < 10.5'
+fi

--- a/tests/test_suites/nightly.txt
+++ b/tests/test_suites/nightly.txt
@@ -26,6 +26,10 @@ tests/test_suites/vlm/vlm_grpo-qwen2.5-vl-3b-instruct-clevr-1n2g-megatrontp2.v1.
 # Removing this until this issue is resolved: https://github.com/huggingface/transformers/issues/41190
 # tests/test_suites/vlm/vlm_grpo-smolvlm2-2.2b-instruct-clevr-1n2g-dtensor2tp1.v2.sh
 
+# Sampling
+tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-megatron-temp0.6.sh
+tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-megatron-sampling.sh
+
 # Deepscaler (short tests)
 tests/test_suites/llm/grpo-deepscaler-1.5b-16K.sh
 tests/test_suites/llm/grpo-deepscaler-1.5b-24K.sh

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -2501,3 +2501,309 @@ def test_vllm_megatron_weight_update_with_packing(cluster, test_input_data):
             megatron_policy.shutdown()
         if vllm_generation:
             vllm_generation.shutdown()
+
+
+@pytest.mark.timeout(600)
+@pytest.mark.parametrize(
+    "temperature,top_p,top_k",
+    [
+        # Test with temperature scaling only
+        (0.6, 1.0, None),
+        # Test with top-p sampling only
+        (1.0, 0.5, None),
+        # Test with top-k sampling only
+        (1.0, 1.0, 50),
+        # Test with combined sampling
+        (0.6, 0.5, 50),
+    ],
+)
+@pytest.mark.parametrize("tensor_parallel_size", [1, 2])
+@pytest.mark.parametrize("policy_type", ["dtensor", "megatron"])
+def test_vllm_policy_logprob_agreement_with_sampling(
+    cluster, tokenizer, temperature, top_p, top_k, tensor_parallel_size, policy_type
+):
+    """Test that policy worker logprobs match vLLM with sampling parameters.
+
+    This test validates that when using the same sampling parameters (temperature, top_k, top_p),
+    the policy workers produce logprobs that closely match vLLM's processed_logprobs.
+
+    We test both:
+    1. get_logprobs() - forward pass for logprob computation
+    2. train() with loss functions - ensures loss computation uses same logprobs
+
+    Args:
+        cluster: Ray virtual cluster fixture
+        tokenizer: Tokenizer fixture
+        temperature: Temperature for scaling logits
+        top_p: Top-p (nucleus) sampling parameter
+        top_k: Top-k sampling parameter
+        policy_type: Type of policy worker to test ("dtensor" or "megatron")
+    """
+    from nemo_rl.algorithms.loss_functions import ClippedPGLossFn
+
+    # Use 2 prompts to match batch size configuration
+    prompts = [
+        "Hello, how are you?",
+        "The capital of France is",
+        "Write a short story about",
+        "Explain quantum physics in simple terms:",
+    ]
+
+    # Tokenize the prompts
+    tokenized = tokenizer(
+        prompts,
+        padding=True,
+        truncation=True,
+        max_length=32,
+        return_tensors="pt",
+        padding_side="right",
+    )
+    # Calculate input lengths from attention mask
+    input_lengths = tokenized["attention_mask"].sum(dim=1).to(torch.int32)
+
+    test_input_data = BatchedDataDict(
+        {
+            "input_ids": tokenized["input_ids"],
+            "input_lengths": input_lengths,
+        }
+    )
+
+    # Create configurations with specified sampling parameters
+    vllm_config = deepcopy(basic_vllm_test_config)
+    vllm_config["temperature"] = temperature
+    vllm_config["top_p"] = top_p
+    vllm_config["top_k"] = top_k
+    vllm_config["dtype"] = "float32"
+    vllm_config["vllm_cfg"]["precision"] = "float32"
+    vllm_config["vllm_cfg"]["enforce_eager"] = True
+    vllm_config = configure_generation_config(vllm_config, tokenizer)
+
+    if policy_type == "dtensor":
+        policy_config = deepcopy(basic_dtensor_test_config)
+        policy_config["dtensor_cfg"]["tensor_parallel_size"] = tensor_parallel_size
+        policy_config["model_name"] = vllm_config["model_name"]
+        policy_config["tokenizer"]["name"] = vllm_config["tokenizer"]["name"]
+        policy_config["precision"] = "float32"
+        policy_config["logprob_batch_size"] = 2
+        policy_config["train_global_batch_size"] = 4
+        policy_config["train_micro_batch_size"] = 2
+        policy_config["dynamic_batching"]["enabled"] = False
+        policy_config["generation"] = deepcopy(vllm_config)
+    elif policy_type == "megatron":
+        policy_config = get_basic_megatron_test_config(
+            tp=tensor_parallel_size, pp=1, precision="float32"
+        )
+        policy_config["model_name"] = vllm_config["model_name"]
+        policy_config["tokenizer"]["name"] = vllm_config["tokenizer"]["name"]
+        policy_config["logprob_batch_size"] = 2
+        policy_config["train_global_batch_size"] = 4
+        policy_config["train_micro_batch_size"] = 2
+        policy_config["generation"] = deepcopy(vllm_config)
+    else:
+        raise ValueError(f"Unknown policy_type: {policy_type}")
+
+    print(f"\n{'=' * 80}")
+    print(f"Testing {policy_type} policy with:")
+    print(f"  temperature={temperature}, top_p={top_p}, top_k={top_k}")
+    print(f"{'=' * 80}\n")
+
+    # Create vLLM generation policy
+    print("Creating vLLM generation policy...")
+    vllm_policy = VllmGeneration(cluster, vllm_config)
+
+    # Put vLLM to sleep and create training policy
+    print("Preparing for training policy creation...")
+    vllm_policy.finish_generation()
+
+    print(f"Creating {policy_type} policy...")
+    lm_policy = Policy(cluster, policy_config, tokenizer)
+
+    # Prepare refit info and refit vLLM with policy weights
+    print("Preparing refit info...")
+    state_dict_info = lm_policy.prepare_refit_info()
+    vllm_policy.prepare_refit_info(state_dict_info)
+
+    print("Refitting vLLM policy with training policy weights...")
+    refit_policy_generation(lm_policy, vllm_policy, vllm_config["colocated"]["enabled"])
+
+    # Generate with vLLM to get logprobs
+    print("Generating with vLLM...")
+    vllm_policy.prepare_for_generation()
+    generation_results = vllm_policy.generate(test_input_data, greedy=False)
+
+    assert "output_ids" in generation_results, (
+        "output_ids not found in vLLM generation output"
+    )
+    assert "logprobs" in generation_results, (
+        "logprobs not found in vLLM generation output"
+    )
+
+    print(f"vLLM output shape: {generation_results['output_ids'].shape}")
+    print(f"vLLM logprobs shape: {generation_results['logprobs'].shape}")
+
+    # ========================================================================
+    # Part 1: Test get_logprobs() function
+    # ========================================================================
+    print(f"\n{'=' * 80}")
+    print("Part 1: Testing get_logprobs() function")
+    print(f"{'=' * 80}\n")
+
+    print(f"Computing logprobs with {policy_type} policy...")
+
+    fprop_logprob_data = BatchedDataDict(
+        {
+            "input_ids": generation_results["output_ids"],
+            "input_lengths": generation_results["unpadded_sequence_lengths"],
+        }
+    )
+
+    lm_policy.prepare_for_lp_inference()
+    fprop_results = lm_policy.get_logprobs(fprop_logprob_data)
+    policy_logprobs = fprop_results["logprobs"]
+    print(f"Policy logprobs shape: {policy_logprobs.shape}")
+
+    # Create mask for generated tokens only (exclude prompt tokens and padding)
+    padding_mask = torch.zeros_like(generation_results["logprobs"], dtype=torch.bool)
+    for i, (input_len, total_valid_len) in enumerate(
+        zip(
+            test_input_data.get("input_lengths"),
+            generation_results["unpadded_sequence_lengths"],
+        )
+    ):
+        # Only compare logprobs for generated tokens
+        padding_mask[i, input_len:total_valid_len] = True
+
+    # Compute absolute difference
+    abs_diff = torch.abs(generation_results["logprobs"] - policy_logprobs)
+    masked_abs_diff = abs_diff.masked_select(padding_mask)
+
+    # Compute metrics
+    max_abs_diff = masked_abs_diff.max().item() if masked_abs_diff.numel() > 0 else 0.0
+    mean_abs_diff = (
+        masked_abs_diff.mean().item() if masked_abs_diff.numel() > 0 else 0.0
+    )
+    avg_prob_mult_error = (
+        torch.mean(torch.exp(masked_abs_diff)).item()
+        if masked_abs_diff.numel() > 0
+        else 1.0
+    )
+
+    print("\nget_logprobs() Agreement Metrics:")
+    print(f"  Max absolute difference: {max_abs_diff:.6f}")
+    print(f"  Mean absolute difference: {mean_abs_diff:.6f}")
+    print(f"  Average probability multiplicative error: {avg_prob_mult_error:.6f}")
+    print(f"  Number of compared tokens: {masked_abs_diff.numel()}")
+
+    # Validate closeness for get_logprobs
+    assert avg_prob_mult_error <= 1.01, (
+        f"get_logprobs: Average probability multiplicative error ({avg_prob_mult_error:.6f}) exceeds threshold (1.01). "
+        f"vLLM and {policy_type} policy logprobs should closely match with same sampling parameters."
+    )
+
+    assert max_abs_diff <= 0.05, (
+        f"get_logprobs: Max absolute difference ({max_abs_diff:.6f}) exceeds threshold (0.05). "
+        f"vLLM and {policy_type} policy logprobs should closely match with same sampling parameters."
+    )
+
+    print("\n✓ Part 1 passed: get_logprobs() produces matching logprobs!")
+
+    # ========================================================================
+    # Part 2: Test train() function and loss functions
+    # ========================================================================
+    print(f"\n{'=' * 80}")
+    print("Part 2: Testing train() function and loss computation")
+    print(f"{'=' * 80}\n")
+
+    # Prepare training data using the generated sequences
+    max_seq_len = min(40, generation_results["output_ids"].shape[1])
+
+    generation_results["unpadded_sequence_lengths"] = torch.clamp(
+        generation_results["unpadded_sequence_lengths"], max=max_seq_len
+    )
+
+    train_input_ids = generation_results["output_ids"][:, :max_seq_len]
+    token_loss_mask = torch.ones_like(train_input_ids)
+
+    # Mask out prompt tokens and padding
+    for idx, (input_len, total_len) in enumerate(
+        zip(
+            test_input_data.get("input_lengths"),
+            generation_results["unpadded_sequence_lengths"],
+        )
+    ):
+        token_loss_mask[idx, :input_len] = 0  # Mask prompt
+        token_loss_mask[idx, total_len:] = 0  # Mask padding
+
+    # Create loss function with KL penalty=1.0 to test logprob matching
+    # If logprobs from train match vLLM, KL should be near zero
+    loss_config = {
+        "ratio_clip_min": 0.2,
+        "ratio_clip_max": 0.2,
+        "ratio_clip_c": None,
+        "reference_policy_kl_penalty": 1.0,  # Use KL to validate logprob matching
+        "reference_policy_kl_type": "k3",
+        "kl_input_clamp_value": None,
+        "kl_output_clamp_value": None,
+        "use_on_policy_kl_approximation": False,
+        "use_importance_sampling_correction": False,
+        "truncated_importance_sampling_ratio": None,
+        "token_level_loss": True,
+    }
+    loss_fn = ClippedPGLossFn(loss_config)
+
+    train_data = BatchedDataDict(
+        {
+            "input_ids": train_input_ids,
+            "input_lengths": generation_results["unpadded_sequence_lengths"],
+            "token_mask": token_loss_mask,
+            "sample_mask": torch.ones(train_input_ids.shape[0]),
+            "advantages": torch.ones_like(
+                train_input_ids, dtype=torch.float32
+            ),  # Dummy advantages
+            "prev_logprobs": generation_results["logprobs"][
+                :, :max_seq_len
+            ],  # From generation
+            "generation_logprobs": generation_results["logprobs"][
+                :, :max_seq_len
+            ],  # Same as prev
+            "reference_policy_logprobs": generation_results["logprobs"][
+                :, :max_seq_len
+            ],  # Same for KL test
+        }
+    )
+
+    print("Training with loss function (single step to compute KL)...")
+    lm_policy.prepare_for_training()
+    results = lm_policy.train(train_data, loss_fn)
+
+    kl_penalty = results["all_mb_metrics"].get("kl_penalty", None)
+    print("\nTrain + Loss Function Metrics:")
+    print(f"  KL penalty (should be near 0 if logprobs match): {kl_penalty}")
+    print(
+        f"  Token mult prob error: {results['all_mb_metrics'].get('token_mult_prob_error', 'N/A')}"
+    )
+
+    # If the train() path computes logprobs correctly with sampling params,
+    # the KL between curr_logprobs (from train) and reference_policy_logprobs
+    # (from vLLM generation) should be very small
+    assert kl_penalty is not None and isinstance(kl_penalty, list), (
+        "KL penalty should be a list and should be computed"
+    )
+    # Check all values in the kl_penalty list
+    for idx, kl in enumerate(kl_penalty):
+        assert kl <= 1e-4, (
+            f"train() + loss: KL penalty at index {idx} ({kl:.6f}) exceeds threshold (1e-4). "
+            f"This indicates that curr_logprobs from train() don't match vLLM generation logprobs. "
+            f"The train path should apply the same sampling parameters (temp={temperature}, top_p={top_p}, top_k={top_k})."
+        )
+
+    print("\n✓ Part 2 passed: train() and loss functions produce matching logprobs!")
+
+    print(f"\n{'=' * 80}")
+    print(f"✓✓✓ All tests passed for {policy_type} policy with sampling parameters!")
+    print(f"{'=' * 80}\n")
+
+    # Cleanup
+    lm_policy.finish_training()
+    vllm_policy.shutdown()
+    lm_policy.shutdown()

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -363,43 +363,6 @@ def test_vllm_missing_required_config_key(cluster):
     print(f"Successfully caught missing config key with error: {error_message}")
 
 
-def test_vllm_top_p_top_k_validation(cluster):
-    """Test that top_p and top_k validation works correctly with threshold-based logic."""
-    # Test that values above thresholds are allowed
-    config_above_thresholds = deepcopy(basic_vllm_test_config)
-    config_above_thresholds["top_p"] = 0.99  # Above TOP_P_THRESHOLD
-    config_above_thresholds["top_k"] = 8000  # Above TOP_K_THRESHOLD
-
-    # Should not raise an error
-    try:
-        VllmGeneration(cluster, config_above_thresholds)
-        print("Successfully initialized with top_p=0.99 and top_k=8000")
-    except Exception as e:
-        pytest.fail(f"Should not raise error with values above thresholds: {e}")
-
-    # Test that values below thresholds are rejected
-    config_below_thresholds = deepcopy(basic_vllm_test_config)
-    config_below_thresholds["top_p"] = 0.9  # Below TOP_P_THRESHOLD
-
-    with pytest.raises(ValueError) as excinfo:
-        VllmGeneration(cluster, config_below_thresholds)
-
-    error_message = str(excinfo.value)
-    assert "top_p sampling with values < 0.99 is not supported" in error_message
-    print(f"Successfully caught low top_p value with error: {error_message}")
-
-    # Test that low top_k values are rejected
-    config_low_top_k = deepcopy(basic_vllm_test_config)
-    config_low_top_k["top_k"] = 7999  # Below TOP_K_THRESHOLD
-
-    with pytest.raises(ValueError) as excinfo:
-        VllmGeneration(cluster, config_low_top_k)
-
-    error_message = str(excinfo.value)
-    assert "top_k sampling with values < 8000 is not supported" in error_message
-    print(f"Successfully caught low top_k value with error: {error_message}")
-
-
 def test_vllm_policy_generation(policy, test_input_data, tokenizer):
     """Test vLLM policy generation capabilities."""
     # Test generation

--- a/tests/unit/models/generation/test_vllm_logprobs_mode.py
+++ b/tests/unit/models/generation/test_vllm_logprobs_mode.py
@@ -255,7 +255,7 @@ def test_apply_top_k_top_p_matches_vllm_upstream(top_k, top_p, test_name):
     print(f"Testing: {test_name}")
 
     # Our implementation: expects [batch, seq, vocab], takes scalar k/p
-    our_result = apply_top_k_top_p(logits_3d.clone(), top_k=top_k, top_p=top_p)
+    our_result, _ = apply_top_k_top_p(logits_3d.clone(), top_k=top_k, top_p=top_p)
 
     # vLLM upstream: expects [batch, vocab], takes tensor k/p with shape [batch]
     # Process each sequence position separately (vLLM doesn't batch over seq_len)

--- a/tests/unit/models/generation/test_vllm_logprobs_mode.py
+++ b/tests/unit/models/generation/test_vllm_logprobs_mode.py
@@ -167,7 +167,7 @@ def test_processed_logprobs_matches_manual_computation():
         scaled_logits_batched = scaled_logits.unsqueeze(0).unsqueeze(
             0
         )  # [1, 1, vocab_size]
-        filtered_logits_batched = apply_top_k_top_p(
+        filtered_logits_batched, _ = apply_top_k_top_p(
             scaled_logits_batched, top_k=top_k, top_p=top_p
         )
         filtered_logits = filtered_logits_batched.squeeze(0).squeeze(0)  # [vocab_size]

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -17,6 +17,7 @@ import torch
 
 from nemo_rl.algorithms.interfaces import LossType
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.models.policy.utils import TrainingSamplingParams
 
 
 class SimpleLoss:
@@ -31,6 +32,7 @@ class SimpleLoss:
         vocab_parallel_rank: Optional[int] = None,
         vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
         context_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
+        sampling_params: Optional[TrainingSamplingParams] = None,
     ) -> tuple[torch.Tensor, dict[str, Any]]:
         # Just return mean of logprobs as the loss for testing
         loss = next_token_logits.mean()
@@ -55,6 +57,7 @@ class SimpleNLLLoss:
         vocab_parallel_rank: Optional[int] = None,
         vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
         context_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
+        sampling_params: Optional[TrainingSamplingParams] = None,
     ) -> tuple[torch.Tensor, dict[str, Any]]:
         # logits shape: [batch_size, seq_len, vocab_size]
         # Get the next token logits for each position


### PR DESCRIPTION
# What does this PR do ?

This PR implements top-k and top-p sampling in training to to ensure consistency between training and inference with sampling parameters.

1. **Why top-p and top-k are a bit tricky?** In TP, the vocab is sharded across GPUs (vocab parallel). However, top-p and top-k require the entire probabilities across the full vocabulary, not individual shards. This means applying all-gather to get the full logits, which leads to communication overhead and the large memory consumption.
2. **Solution**: We convert from vocab-parallel to batch-sequence-parallel layout via `all-to-all` communication, apply filtering on the full vocabulary, then convert back. 

### Detailed Changes

1. In `nemo_rl/model/policy/utils.py`: added the `TrainingSamplingParams` and implemented `apply_top_k_top_p` with proper autograd support.
2. In `nemo_rl/distributed/model_utils.py`: implemented `DistributedLogprobWithSampling` and `ChunkedDistributedLogprobWithSampling`, and integrated into all logprob computation paths (TP, CP, DTensor, packed sequences).
3. Loss Functions and policy workers: updated `ClippedPGLossFn`, `NLLLoss`, and `DPOLossFn` to accept `sampling_params`; changed the policy workers call the functions with `sampling_params`.

### Tests

- `test_top_k_top_p_filtering_forward_backward`: Tests top_k and top_p functionalities. Test gradient masking correctness.
- `test_distributed_logprob_with_sampling`: Tests TP distributed implementation.
- `test_vllm_policy_logprob_agreement_with_sampling`: Test that policy worker logprobs match vLLM with sampling parameters.

We have also tested that with `temperature != 1`, the logprobs match. See `test_vllm_policy_logprob_agreement_with_sampling`.


# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced generation with top-k/top-p filtering support for improved sampling control
  * Improved temperature scaling during model generation
  * Better distributed sampling computation paths

* **Bug Fixes**
  * Fixed NaN issues in gradient computations during sampling operations
  * Adjusted sampling parameter validation thresholds for better compatibility

* **Tests**
  * Added comprehensive tests for sampling functionality and distributed computation paths

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->