### PR TITLE
Remove policy offload for async grpo dtensor

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -2510,7 +2510,6 @@ def async_grpo_train(
                             os.path.join(checkpoint_path, "train_dataloader.pt"),
                         )
                         checkpointer.finalize_checkpoint(checkpoint_path)
-                    policy.offload_after_refit()
 
             log_data = {"content": flat_messages["content"]}
             log_data["rewards"] = rewards.tolist()


### PR DESCRIPTION
# What does this PR do ?

The async GRPO does not need to offload the policy after checkpointing since the training and inference are not colocated. Currently this leads to exception after checkpointing since some tensors are not moved back to cuda.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined resource handling during checkpoint finalization in GRPO async training by removing an unnecessary cleanup step. This change improves efficiency without affecting training behavior or output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->