### PR TITLE
fix: allow zero grad norm in dtensor policies for consistency with Megatron

### DIFF
--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -192,7 +192,7 @@ class DTensorPolicyWorker(AbstractPolicyWorker, ColocatablePolicyInterface):
         self.offload_optimizer_for_logprob = self.cfg["offload_optimizer_for_logprob"]
         self.max_grad_norm = self.cfg["max_grad_norm"]
         # allow zero grad norm for consistency with megatron
-        if self.max_grad_norm == 0.0: 
+        if self.max_grad_norm == 0.0:
             self.max_grad_norm = None
 
         if self.cfg["precision"] == "float32":

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -236,7 +236,7 @@ class DTensorPolicyWorkerV2(AbstractPolicyWorker, ColocatablePolicyInterface):
         self.offload_optimizer_for_logprob = self.cfg["offload_optimizer_for_logprob"]
         self.max_grad_norm = self.cfg["max_grad_norm"]
         # allow zero grad norm for consistency with megatron
-        if self.max_grad_norm == 0.0: 
+        if self.max_grad_norm == 0.0:
             self.max_grad_norm = None
 
         try:


### PR DESCRIPTION
# What does this PR do ?

Currently Megatron only accepts float/int for grad norm. To disable grad norm, Dtensor needs None while megatron needs zero. Adding zero to dtensor as well to allow for a consistent grad norm clipping usage.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gradient clipping validation to correctly handle edge cases when the maximum gradient norm is configured to zero or negative values, preventing unintended clipping behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->