### PR TITLE
chore: fix grpo functional test metric

### DIFF
--- a/tests/functional/grpo.sh
+++ b/tests/functional/grpo.sh
@@ -38,5 +38,5 @@ uv run coverage run -a --data-file=$PROJECT_ROOT/tests/.coverage --source=$PROJE
 uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
 
 uv run tests/check_metrics.py $JSON_METRICS \
-    'max(data["train/gen_kl_error"]) < 1.05'
+    'max(data["train/gen_kl_error"]) < 0.001'
 


### PR DESCRIPTION
# What does this PR do ?

Reduce the functional test acceptance threshold for train/gen_kl_error from 1.05 to 0.001 to catch subtle regressions in generation logprob/KL alignment early.

## Related Context
Link: https://github.com/NVIDIA-NeMo/RL/pull/1506#discussion_r2601326402
gen_kl_error should actually be pretty low, usually we set it to be <1e-3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated validation thresholds for training metrics to enforce stricter quality standards during testing procedures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->