### PR TITLE
fix: Fix crash when using cp in dtensor path

### DIFF
--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -277,10 +277,24 @@ class DTensorPolicyWorkerV2(AbstractPolicyWorker, ColocatablePolicyInterface):
         # All ranks initialize model on meta device, so FSDP can shard it.
         # The actual weights will be broadcast from rank 0.
 
+        cp_size = self.cfg["dtensor_cfg"]["context_parallel_size"]
         with init_empty_weights():
             # NeMoAutoModelForCausalLM uses flash_attention_2 by default
             # so we need to set it to None if sequence packing is disabled
             # https://github.com/NVIDIA-NeMo/Automodel/blob/7e748be260651349307862426c0c168cebdeeec3/nemo_automodel/components/_transformers/auto_model.py#L180
+            if cp_size > 1:
+                # Match Automodel's `get_train_context` in `cp_utils.py` where only
+                # flash and efficient backends are supported
+                # Ref: https://github.com/NVIDIA-NeMo/Automodel/blob/81788d6f4848f5f066c4a6a2bece4689a6a83687/nemo_automodel/components/distributed/cp_utils.py#L57
+                from torch.nn.attention import SDPBackend
+
+                sdpa_method = [
+                    SDPBackend.FLASH_ATTENTION,
+                    SDPBackend.EFFICIENT_ATTENTION,
+                ]
+            else:
+                sdpa_method = None
+
             self.model = model_class.from_config(
                 model_config,
                 attn_implementation="flash_attention_2"
@@ -289,6 +303,7 @@ class DTensorPolicyWorkerV2(AbstractPolicyWorker, ColocatablePolicyInterface):
                 use_liger_kernel=False,
                 trust_remote_code=True,
                 torch_dtype=str(model_config.torch_dtype),
+                sdpa_method=sdpa_method,
             )
             if self.lora_enabled:
                 apply_lora_to_linear_modules(self.model, self.peft_config)
@@ -297,7 +312,6 @@ class DTensorPolicyWorkerV2(AbstractPolicyWorker, ColocatablePolicyInterface):
             self.model.config.pad_token_id = tokenizer.pad_token_id
 
         tp_size = self.cfg["dtensor_cfg"]["tensor_parallel_size"]
-        cp_size = self.cfg["dtensor_cfg"]["context_parallel_size"]
         if cp_size > 1 and self.enable_seq_packing:
             raise ValueError(
                 "Context parallel is not supported for sequence packing. Refer to https://github.com/NVIDIA/NeMo-RL/blob/main/docs/model-quirks.md#context-parallel-with-fsdp2 for more details."


### PR DESCRIPTION
# What does this PR do ?

Fixes a crash when cp > 1 in dtensor path that was introduced in https://github.com/NVIDIA-NeMo/RL/commit/5bf56a9971afb055d72db0d578b711ee4cc901d6.

After this version bump, we found that the cudnn sdpa backend was getting selected even when `cp > 1` on certain machines (we noticed this for h100, but not a100), which was causing a crash due to this bug: https://github.com/pytorch/pytorch/issues/162743. This is unexpected because we restrict to `SDPBackend.FLASH_ATTENTION` and `SDPBackend.EFFICIENT_ATTENTION` when `cp > 1`: https://github.com/NVIDIA-NeMo/Automodel/blob/81788d6f4848f5f066c4a6a2bece4689a6a83687/nemo_automodel/components/distributed/cp_utils.py#L57.

The issue is that we patch the attention with all possible backends here: https://github.com/NVIDIA-NeMo/Automodel/blob/81788d6f4848f5f066c4a6a2bece4689a6a83687/nemo_automodel/components/_transformers/auto_model.py#L65-L71 which overrides the previous restriction. To fix this issue, we pass in only `SDPBackend.FLASH_ATTENTION` and `SDPBackend.EFFICIENT_ATTENTION` when `cp > 1` when calling `from_config` to restrict to only these backends, as is expected when `cp > 1`. 

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context-parallel optimization support with automatic attention backend selection for distributed training scenarios.

* **Refactor**
  * Improved model initialization efficiency by consolidating configuration setup and removing redundant definitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->