### PR TITLE
fix: Fix crash when using activation_checkpointing

### DIFF
--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -282,10 +282,14 @@ class DTensorPolicyWorkerV2(AbstractPolicyWorker, ColocatablePolicyInterface):
             # NeMoAutoModelForCausalLM uses flash_attention_2 by default
             # so we need to set it to None if sequence packing is disabled
             # https://github.com/NVIDIA-NeMo/Automodel/blob/7e748be260651349307862426c0c168cebdeeec3/nemo_automodel/components/_transformers/auto_model.py#L180
-            if cp_size > 1:
-                # Match Automodel's `get_train_context` in `cp_utils.py` where only
+            if cp_size > 1 or self.cfg["dtensor_cfg"]["activation_checkpointing"]:
+                # For cp, match Automodel's `get_train_context` in `cp_utils.py` where only
                 # flash and efficient backends are supported
                 # Ref: https://github.com/NVIDIA-NeMo/Automodel/blob/81788d6f4848f5f066c4a6a2bece4689a6a83687/nemo_automodel/components/distributed/cp_utils.py#L57
+
+                # For activation_checkpointing, CUDNN_ATTENTION must be excluded
+                # since it results in an error:
+                # "Recomputed values for the following tensors have different metadata than during the forward pass."
                 from torch.nn.attention import SDPBackend
 
                 sdpa_method = [


### PR DESCRIPTION
# What does this PR do ?

Fixes a crash that occasionally occurs when enabling activation_checkpointing in dtensor path.

Previously, we were seeing the following error:

```
torch.utils.checkpoint.CheckpointError: torch.utils.checkpoint: Recomputed values for the following tensors have different metadata than during the forward pass.
tensor at position 25:
saved metadata: {'shape': torch.Size([16, 4, 448, 1]), 'dtype': torch.float32, 'device': device(type='cuda', index=0)}
recomputed metadata: {'shape': torch.Size([16, 4, 448]), 'dtype': torch.float32, 'device': device(type='cuda', index=0)}
tensor at position 27:
saved metadata: {'shape': torch.Size([]), 'dtype': torch.int64, 'device': device(type='cuda', index=0)}
recomputed metadata: {'shape': torch.Size([2]), 'dtype': torch.uint64, 'device': device(type='cuda', index=0)}
tensor at position 28:
saved metadata: {'shape': torch.Size([]), 'dtype': torch.int64, 'device': device(type='cuda', index=0)}
recomputed metadata: {'shape': torch.Size([]), 'dtype': torch.uint64, 'device': device(type='cuda', index=0)}
```

This seemed to be happening with the CUDNN_ATTENTION sdpa implementation was being selected and activation_checkpointing was enabled. As a workaround, we do not allow CUDNN_ATTENTION when activation_checkpointing is enabled in the dtensor path.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced backend selection logic for attention computation to support additional configuration scenarios, improving stability and performance in more use cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->