### PR TITLE
perf: [Perf recipe] Change TP 16->32 for deepseek GB200 sync benchmark

### DIFF
--- a/examples/configs/recipes/llm/performance/grpo-deepseek-v3-32n4g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-deepseek-v3-32n4g.yaml
@@ -11,7 +11,7 @@ policy:
     num_layers_in_last_pipeline_stage: 6
   generation:
     vllm_cfg:
-      tensor_parallel_size: 16
+      tensor_parallel_size: 32
 logger:
   log_dir: logs/grpo-deepseek-v3-32n4g
   wandb:


### PR DESCRIPTION
# What does this PR do ?

There seems to be issues with optimizer offloading on GB200, so in the deepseek colocated benchmark, OOM happens in refit unexpectedly; I had to tune up the vLLM TP size to avoid OOM.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated performance optimization configuration to enhance parallel processing efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->