### PR TITLE
cp: `perf: [Perf recipe] Change TP 16->32 for deepseek GB200 sync benchmark (1715)` into `r0.5.0`

### DIFF
--- a/examples/configs/recipes/llm/performance/grpo-deepseek-v3-32n4g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-deepseek-v3-32n4g.yaml
@@ -11,7 +11,7 @@ policy:
     num_layers_in_last_pipeline_stage: 6
   generation:
     vllm_cfg:
-      tensor_parallel_size: 16
+      tensor_parallel_size: 32
 logger:
   log_dir: logs/grpo-deepseek-v3-32n4g
   wandb:


### PR DESCRIPTION
beep boop [🤖]: Hi @guyueh1 👋,

    we've cherry picked #1715 into  for you! 🚀

    Please review and approve this cherry pick by your convenience!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated tensor parallelism configuration in the example LLM performance recipe. The tensor parallel size setting has been increased from 16 to 32 for improved distributed computation capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->