### PR TITLE
cp: `fix: gemma3 27b must now have skip_tokenizer_init=False in vllm (1721)` into `r0.5.0`

### DIFF
--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -388,6 +388,14 @@ class BaseVllmGenerationWorker:
                 )
                 # disable quantization
                 vllm_kwargs["hf_overrides"]["quantization_config"] = {}
+        elif "Gemma3ForConditionalGeneration" in getattr(
+            hf_config, "architectures", []
+        ):
+            if self.cfg["vllm_cfg"]["skip_tokenizer_init"]:
+                print(
+                    "Gemma3ForConditionalGeneration models may crash when skip_tokenizer_init is True. NeMo-RL is forcing it to False for this architecture. See https://github.com/NVIDIA-NeMo/RL/issues/1681 for more details."
+                )
+            self.cfg["vllm_cfg"]["skip_tokenizer_init"] = False
 
         llm_kwargs = dict(
             model=self.model_name,


### PR DESCRIPTION
beep boop [🤖]: Hi @terrykong 👋,

    we've cherry picked #1721 into  for you! 🚀

    Please review and approve this cherry pick by your convenience!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced support for Gemma3 models with improved tokenizer initialization handling.
  * Added warning messages to alert users when tokenizer configuration requires adjustment for Gemma3 architectures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->