### PR TITLE
fix: use swap_tensors

### DIFF
--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -1839,7 +1839,7 @@ class DTensorPolicyWorker(AbstractPolicyWorker, ColocatablePolicyInterface):
     ) -> nn.Module:
         # FSDP modules do not move buffers to the device automatically
         for v in model.buffers():
-            v = v.to(device)
+            torch.utils.swap_tensors(v, v.to(device))
 
         return model
 

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -1878,7 +1878,7 @@ class DTensorPolicyWorkerV2(AbstractPolicyWorker, ColocatablePolicyInterface):
     ) -> nn.Module:
         # FSDP modules do not move buffers to the device automatically
         for v in model.buffers():
-            v = v.to(device)
+            torch.utils.swap_tensors(v, v.to(device))
 
         return model
 


### PR DESCRIPTION
1. `v.data = v.data.to(device)` will cause the below error for gemma3. https://github.com/NVIDIA-NeMo/RL/pull/1563/changes#r2626166513
    > RuntimeError: Attempted to set the storage of a tensor on device "cuda:0" to a storage on different device "cpu".  This is no longer allowed; the devices must match.
2. `v = v.to(device)` can't update the reference of `v`, so the old tensor on GPU isn't released, this will cause the below error. https://github.com/NVIDIA-NeMo/RL/actions/runs/20744518055/job/59648725289?pr=1726
    > assert current_allocated == 0.0, "Memory should be 0 after refit completed"

`torch.utils.swap_tensors(v, v.to(device))` could solve both error above.
<img width="2424" height="1478" alt="image" src="https://github.com/user-attachments/assets/20ce0f08-9475-4038-a261-5131bb1ba316" />
<img width="2432" height="624" alt="image" src="https://github.com/user-attachments/assets/28b5d0ac-16cd-4fa8-a6f5-ac4655b589d7" />