### PR TITLE
fix: Remove obsolete MoE aux loss validation assertion

### DIFF
--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -527,15 +527,6 @@ def _validate_training_config(config: PolicyConfig, model_cfg: Any) -> None:
     model_cfg.calculate_per_token_loss = True
     model_cfg.perform_initialization = True
 
-    # MoE aux loss validation
-    assert (
-        "aux_loss" not in model_cfg.moe_router_load_balancing_type
-        or model_cfg.moe_aux_loss_coeff == 0
-    ), (
-        "MoE aux loss is currently not supported due to a known bug in Megatron-LM. "
-        "See https://github.com/NVIDIA/Megatron-LM/issues/1984 for more details."
-    )
-
 
 def _validate_dtype_config(
     dtype: torch.dtype, model_cfg: Any, optimizer_cfg: Any


### PR DESCRIPTION
# What does this PR do?

Removes the assertion for MoE aux loss validation that was blocking usage due to a known bug in Megatron-LM. The upstream issue has been resolved ([NVIDIA/Megatron-LM#1984](https://github.com/NVIDIA/Megatron-LM/issues/1984)), so this assertion is no longer necessary.

# Issues

N/A — This is a cleanup PR removing an outdated workaround.

# Usage

No usage changes. MoE aux loss can now be used without triggering the assertion error.
```python
# MoE aux loss is now supported
model_cfg.moe_router_load_balancing_type = "aux_loss"
model_cfg.moe_aux_loss_coeff = 0.01  # Previously would fail assertion
```

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

- Upstream fix: https://github.com/NVIDIA/Megatron-LM/issues/1984
- This removes 9 lines of assertion code that is no longer needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed overly restrictive validation that prevented certain Mixture of Experts (MoE) configuration combinations during model setup, allowing previously blocked auxiliary loss settings to be used.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->