### PR TITLE
fix: Mxfp8 training fix sequence padding

### DIFF
--- a/examples/configs/distillation_math.yaml
+++ b/examples/configs/distillation_math.yaml
@@ -155,6 +155,12 @@ policy: &POLICY_BASE
             use_custom_fsdp: false
             data_parallel_sharding_strategy: "optim_grads_params"
 
+        fp8_cfg:
+            enabled: false
+            fp8: "e4m3"
+            fp8_recipe: "blockwise"
+            fp8_param: false
+
     scheduler:
         - name: "torch.optim.lr_scheduler.LinearLR"
           kwargs:

--- a/examples/configs/distillation_math_megatron.yaml
+++ b/examples/configs/distillation_math_megatron.yaml
@@ -106,6 +106,12 @@ policy: &POLICY_BASE
             use_custom_fsdp: false
             data_parallel_sharding_strategy: "optim_grads_params"
 
+        fp8_cfg:
+            enabled: false
+            fp8: "e4m3"
+            fp8_recipe: "blockwise"
+            fp8_param: false
+
     generation:
         backend: "vllm"
         max_new_tokens: ${..max_total_sequence_length} # refer to local policy/teacher config

--- a/examples/configs/dpo.yaml
+++ b/examples/configs/dpo.yaml
@@ -177,7 +177,13 @@ policy:
       overlap_param_gather: true
       data_parallel_sharding_strategy: "optim_grads_params"
       use_custom_fsdp: false
-    
+
+    fp8_cfg:
+      enabled: false
+      fp8: "e4m3"
+      fp8_recipe: "blockwise"
+      fp8_param: false
+
 data:
   max_input_seq_length: ${policy.max_total_sequence_length}
   shuffle: true

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -189,7 +189,11 @@ policy:
       use_custom_fsdp: false
       data_parallel_sharding_strategy: "optim_grads_params"
 
-    fp8_cfg: null
+    fp8_cfg: 
+      enabled: false
+      fp8: "e4m3"
+      fp8_recipe: "blockwise"
+      fp8_param: false
 
     env_vars: null
 

--- a/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-2n8g-megatron-fp8-e2e.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-2n8g-megatron-fp8-e2e.yaml
@@ -33,9 +33,6 @@ policy:
       lr_warmup_init: 5.0e-08
     fp8_cfg:
       enabled: true
-      fp8: e4m3
-      fp8_recipe: blockwise
-      fp8_param: false
     env_vars:
       NVTE_FP8_BLOCK_SCALING_FP32_SCALES: '1'
   generation:

--- a/examples/configs/recipes/llm/grpo-moonlight-16ba3b-4n8g-megatron-fp8-e2e.yaml
+++ b/examples/configs/recipes/llm/grpo-moonlight-16ba3b-4n8g-megatron-fp8-e2e.yaml
@@ -28,9 +28,6 @@ policy:
     apply_rope_fusion: false
     fp8_cfg:
       enabled: true
-      fp8: e4m3
-      fp8_recipe: blockwise
-      fp8_param: false
     optimizer:
       lr: 1.0e-06
       use_precision_aware_optimizer: false
@@ -43,10 +40,9 @@ policy:
       precision: fp8
       use_deep_gemm: true
       gpu_memory_utilization: 0.5
-      quantization_ignored_layer_kws: [
-        a_proj,
-        b_proj
-      ]
+      quantization_ignored_layer_kws:
+      - a_proj
+      - b_proj
 logger:
   monitor_gpus: false
   wandb:

--- a/examples/configs/recipes/llm/performance/grpo-llama3.1-8b-instruct-2n8g-fp8-async-1off.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-llama3.1-8b-instruct-2n8g-fp8-async-1off.yaml
@@ -5,9 +5,6 @@ policy:
   megatron_cfg:
     fp8_cfg:
       enabled: true
-      fp8: "e4m3"
-      fp8_recipe: "blockwise"
-      fp8_param: false
     env_vars:
       NVTE_FP8_BLOCK_SCALING_FP32_SCALES: "1"
   generation:

--- a/examples/configs/rm.yaml
+++ b/examples/configs/rm.yaml
@@ -128,6 +128,11 @@ policy:
       overlap_param_gather: false
       data_parallel_sharding_strategy: "optim_grads_params"
 
+    fp8_cfg:
+      enabled: false
+      fp8: "e4m3"
+      fp8_recipe: "blockwise"
+      fp8_param: false
     
 data:
   max_input_seq_length: ${policy.max_total_sequence_length}

--- a/examples/configs/sft.yaml
+++ b/examples/configs/sft.yaml
@@ -175,6 +175,12 @@ policy:
       data_parallel_sharding_strategy: "optim_grads_params"
       use_custom_fsdp: false
 
+    fp8_cfg:
+      enabled: false
+      fp8: "e4m3"
+      fp8_recipe: "blockwise"
+      fp8_param: false
+
 data:
   max_input_seq_length: ${policy.max_total_sequence_length}
   add_bos: true

--- a/examples/configs/sft_openmathinstruct2_megatron.yaml
+++ b/examples/configs/sft_openmathinstruct2_megatron.yaml
@@ -100,14 +100,11 @@ policy:
     env_vars:
       PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:False"
 
-    ## fp8 training currently not supported
-    #fp8_cfg:
-    #  enabled: true
-    #  fp8: hybrid
-    #  fp8_recipe: delayed
-    #  fp8_param: true # false gives the following error: "RuntimeError: /TransformerEngine/transformer_engine/common/gemm/cublaslt_gemm.cu:116 in function CanonicalizeGemmInput: Assertion failed: !is_fp8_dtype(ret.Atype). Input A is missing column-wise usage"
-    #  fp8_dot_product_attention: false #true
-    #  fp8_multi_head_attention: false #true
+    fp8_cfg:
+      enabled: false
+      fp8: "e4m3"
+      fp8_recipe: "blockwise"
+      fp8_param: false
 
   dynamic_batching:
     enabled: false

--- a/examples/configs/vlm_grpo_3B.yaml
+++ b/examples/configs/vlm_grpo_3B.yaml
@@ -159,6 +159,12 @@ policy:
       use_custom_fsdp: false
       data_parallel_sharding_strategy: "optim_grads_params"
 
+    fp8_cfg:
+      enabled: false
+      fp8: "e4m3"
+      fp8_recipe: "blockwise"
+      fp8_param: false
+
 
   # dynamic_batching improves performance by ensuring logprob and training microbatches
   # have a sufficent number of tokens to maximize GPU utilization. Specifically, variable length

--- a/examples/configs/vlm_grpo_3B_megatron.yaml
+++ b/examples/configs/vlm_grpo_3B_megatron.yaml
@@ -189,6 +189,11 @@ policy:
       overlap_param_gather: true
       use_custom_fsdp: false
       data_parallel_sharding_strategy: optim_grads_params
+    fp8_cfg:
+      enabled: false
+      fp8: "e4m3"
+      fp8_recipe: "blockwise"
+      fp8_param: false
 data:
   max_input_seq_length: ${policy.max_total_sequence_length}
   shuffle: true

--- a/nemo_rl/models/megatron/data.py
+++ b/nemo_rl/models/megatron/data.py
@@ -558,9 +558,9 @@ def _get_pack_sequence_parameters_for_megatron(
     # packed sequence length, after splitted to TP and CP domains, needs to be divisible by 128 if using blockwise FP8, and divisible by 16 if using other FP8 recipes.
     if use_fp8:
         divisor = 16
-        if fp8_cfg.get("fp8_recipe", None) == "blockwise":
+        if fp8_cfg["fp8_recipe"] == "blockwise":
             divisor = 128
-        elif fp8_cfg.get("fp8_recipe", None) == "mxfp8":
+        elif fp8_cfg["fp8_recipe"] == "mxfp8":
             divisor = 32
         pad_packed_seq_to_multiple_of = divisor
         if cp_size > 1:

--- a/research/template_project/configs/grpo_math_1B.yaml
+++ b/research/template_project/configs/grpo_math_1B.yaml
@@ -136,7 +136,11 @@ policy:
       use_custom_fsdp: false
       data_parallel_sharding_strategy: "optim_grads_params"
 
-    fp8_cfg: null
+    fp8_cfg:
+      enabled: false
+      fp8: "e4m3"
+      fp8_recipe: "blockwise"
+      fp8_param: false
 
     env_vars: null
 

--- a/tests/unit/models/megatron/test_megatron_data.py
+++ b/tests/unit/models/megatron/test_megatron_data.py
@@ -1443,7 +1443,12 @@ class GetPackSequenceParametersTestActor:
             "sequence_parallel": False,
             "pipeline_model_parallel_size": 1,
             "context_parallel_size": 1,
-            "fp8_cfg": {"enabled": True},
+            "fp8_cfg": {
+                "enabled": True,
+                "fp8": "hybrid",
+                "fp8_recipe": "tensorwise",
+                "fp8_param": False,
+            },
         }
 
         pad_individual, pad_packed, pad_to = _get_pack_sequence_parameters_for_megatron(
@@ -1462,7 +1467,12 @@ class GetPackSequenceParametersTestActor:
             "sequence_parallel": False,
             "pipeline_model_parallel_size": 1,
             "context_parallel_size": 1,
-            "fp8_cfg": {"enabled": True, "fp8_recipe": "blockwise"},
+            "fp8_cfg": {
+                "enabled": True,
+                "fp8": "e4m3",
+                "fp8_recipe": "blockwise",
+                "fp8_param": False,
+            },
         }
 
         pad_individual, pad_packed, pad_to = _get_pack_sequence_parameters_for_megatron(
@@ -1481,7 +1491,12 @@ class GetPackSequenceParametersTestActor:
             "sequence_parallel": True,
             "pipeline_model_parallel_size": 1,
             "context_parallel_size": 4,
-            "fp8_cfg": {"enabled": True, "fp8_recipe": "blockwise"},
+            "fp8_cfg": {
+                "enabled": True,
+                "fp8": "e4m3",
+                "fp8_recipe": "blockwise",
+                "fp8_param": False,
+            },
         }
 
         pad_individual, pad_packed, pad_to = _get_pack_sequence_parameters_for_megatron(
@@ -1506,7 +1521,12 @@ class GetPackSequenceParametersTestActor:
             "sequence_parallel": True,
             "pipeline_model_parallel_size": 4,
             "context_parallel_size": 2,
-            "fp8_cfg": {"enabled": True, "fp8_recipe": "other"},
+            "fp8_cfg": {
+                "enabled": True,
+                "fp8": "hybrid",
+                "fp8_recipe": "tensorwise",
+                "fp8_param": False,
+            },
         }
 
         pad_individual, pad_packed, pad_to = _get_pack_sequence_parameters_for_megatron(
@@ -1535,7 +1555,12 @@ class GetPackSequenceParametersTestActor:
             "sequence_parallel": False,
             "pipeline_model_parallel_size": 1,
             "context_parallel_size": 1,
-            "fp8_cfg": {"enabled": False},
+            "fp8_cfg": {
+                "enabled": False,
+                "fp8": "e4m3",
+                "fp8_recipe": "blockwise",
+                "fp8_param": False,
+            },
         }
 
         pad_individual, pad_packed, pad_to = _get_pack_sequence_parameters_for_megatron(
@@ -1573,7 +1598,12 @@ class GetPackSequenceParametersTestActor:
             "sequence_parallel": True,
             "pipeline_model_parallel_size": 1,
             "context_parallel_size": 8,
-            "fp8_cfg": {"enabled": True, "fp8_recipe": "blockwise"},
+            "fp8_cfg": {
+                "enabled": True,
+                "fp8": "e4m3",
+                "fp8_recipe": "blockwise",
+                "fp8_param": False,
+            },
         }
 
         pad_individual, pad_packed, pad_to = _get_pack_sequence_parameters_for_megatron(
@@ -1617,7 +1647,12 @@ class GetPackSequenceParametersTestActor:
             "sequence_parallel": False,
             "pipeline_model_parallel_size": 1,
             "context_parallel_size": 1,
-            "fp8_cfg": {"enabled": True, "fp8_recipe": "mxfp8"},
+            "fp8_cfg": {
+                "enabled": True,
+                "fp8": "e4m3",
+                "fp8_recipe": "mxfp8",
+                "fp8_param": False,
+            },
         }
 
         pad_individual, pad_packed, pad_to = _get_pack_sequence_parameters_for_megatron(
@@ -1636,7 +1671,12 @@ class GetPackSequenceParametersTestActor:
             "sequence_parallel": True,
             "pipeline_model_parallel_size": 1,
             "context_parallel_size": 4,
-            "fp8_cfg": {"enabled": True, "fp8_recipe": "mxfp8"},
+            "fp8_cfg": {
+                "enabled": True,
+                "fp8": "e4m3",
+                "fp8_recipe": "mxfp8",
+                "fp8_param": False,
+            },
         }
 
         pad_individual, pad_packed, pad_to = _get_pack_sequence_parameters_for_megatron(
@@ -1662,7 +1702,12 @@ class GetPackSequenceParametersTestActor:
             "sequence_parallel": True,
             "pipeline_model_parallel_size": 4,
             "context_parallel_size": 4,
-            "fp8_cfg": {"enabled": True, "fp8_recipe": "mxfp8"},
+            "fp8_cfg": {
+                "enabled": True,
+                "fp8": "e4m3",
+                "fp8_recipe": "mxfp8",
+                "fp8_param": False,
+            },
         }
 
         pad_individual, pad_packed, pad_to = _get_pack_sequence_parameters_for_megatron(


### PR DESCRIPTION
# What does this PR do ?

In sequence packing case, the full sequence needs to be packed to multiple of X, where for BF16 X is 1, for FP8 it is: delayed or tensorwise recipe: 16; blockwise recipe: 128; mxfp8 recipe: 32. 

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FP8 quantization handling for sequence packing. The padding strategy now automatically adjusts based on the selected FP8 recipe type (blockwise or mxfp8), optimizing memory usage and numerical precision for different quantization configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->