### PR TITLE
feat: start nemo gym and other environments with cached venvs

### DIFF
--- a/nemo_rl/environments/utils.py
+++ b/nemo_rl/environments/utils.py
@@ -18,6 +18,7 @@ from hydra.utils import get_object
 
 from nemo_rl.distributed.ray_actor_environment_registry import get_actor_python_env
 from nemo_rl.environments.interfaces import EnvironmentInterface
+from nemo_rl.utils.venvs import create_local_venv_on_each_node
 
 
 # Environment registry entry schema.
@@ -105,10 +106,21 @@ def create_env(env_name: str, env_config: dict) -> EnvironmentInterface:
     )
     actor_class_fqn = ENV_REGISTRY[env_name]["actor_class_fqn"]
     actor_class = get_object(actor_class_fqn)
+    actor_py_exec = get_actor_python_env(actor_class_fqn)
+    extra_env_vars = {}
+    if actor_py_exec.startswith("uv"):
+        actor_py_exec = create_local_venv_on_each_node(
+            actor_py_exec,
+            actor_class_fqn,
+        )
+        extra_env_vars = {
+            "VIRTUAL_ENV": actor_py_exec,
+            "UV_PROJECT_ENVIRONMENT": actor_py_exec,
+        }
     env = actor_class.options(  # type: ignore # it's wrapped with ray.remote
         runtime_env={
-            "py_executable": get_actor_python_env(actor_class_fqn),
-            "env_vars": dict(os.environ),
+            "py_executable": actor_py_exec,
+            "env_vars": {**dict(os.environ), **extra_env_vars},
         }
     ).remote(env_config)
     return env


### PR DESCRIPTION
This avoids issues like seeing (raylet) Installing ... which can lead to failures in high node count settings

# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):
closes #1925

# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced environment variable propagation in distributed setups.
  * Added automatic virtual environment initialization on compute nodes when using uv-based Python environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->