### PR TITLE
fix: use seq_length instead of padded_seq_length for topk output padding

### DIFF
--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -939,7 +939,7 @@ class MegatronPolicyWorker(AbstractPolicyWorker, ColocatablePolicyInterface):
             for out in list_of_outputs:
                 tk = out["topk_logits"]
                 ti = out["topk_indices"]
-                pad_len = padded_seq_length - tk.shape[1]
+                pad_len = seq_length - tk.shape[1]
                 if pad_len > 0:
                     tk = torch.nn.functional.pad(tk, (0, 0, 0, pad_len), value=0.0)
                     ti = torch.nn.functional.pad(ti, (0, 0, 0, pad_len), value=0)


### PR DESCRIPTION

# What does this PR do ?

Fix distillation training assertion failure by using `seq_length` instead of `padded_seq_length` when padding topk outputs in `get_topk_logits`, consistent with how `get_logprobs` handles the same padding.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage


Nightly test `tests/test_suites/llm/distillation-qwen3-32b-to-1.7b-base-1n8g-megatron-tp2pp2cp2-pack.sh` fails with:
                                                                                                                                                                                   
```python
AssertionError: Dim 1 must be the sequence dim, expected dim 1=4200 but got shape torch.Size([32, 8156, 64]) for key teacher_topk_indices                                                                                                                                       
```
In `get_topk_logits` (megatron_policy_worker.py:942), topk outputs were padded to `padded_seq_length` (used only for PP communication) instead of `seq_length` (the actual input sequence length). This caused `teacher_topk_indices` to have a larger sequence dimension than `input_ids`, triggering an assertion in `get_and_validate_seqlen` during student training.

The fix is a one-line change aligning with the existing pattern in get_logprobs (line 656):
```
# Before (bug)
pad_len = padded_seq_length - tk.shape[1]

# After (fix)
pad_len = seq_length - tk.shape[1]
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected padding calculation for top-k results to ensure proper alignment when processing multiple microbatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->