### PR TITLE
fix: fix mcore sequence packing

### DIFF
--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -364,7 +364,7 @@ class MegatronPolicyWorker(AbstractPolicyWorker, ColocatablePolicyInterface):
                 (
                     data_iterator,
                     num_microbatches,
-                    micro_batch_size,
+                    mbs,
                     seq_length,
                     padded_seq_length,
                 ) = get_microbatch_iterator(


### PR DESCRIPTION
As title.

Fix nightly test `sft-llama3.1-8b-1n8g-megatron-seqpack`.

```python
if mbs is None:
    mbs = self.cfg["train_micro_batch_size"]

# before fix
# (
#     data_iterator,
#     num_microbatches,
#     micro_batch_size,
#     seq_length,
#     padded_seq_length,
# ) = get_microbatch_iterator(...)

# after fix
(
    data_iterator,
    num_microbatches,
    mbs,
    seq_length,
    padded_seq_length,
) = get_microbatch_iterator(...)

losses_reduced = forward_backward_func(
    ...
    micro_batch_size=mbs,
    ...
)
```