### PR TITLE
Remove do_not_average_loss; undo Megatron loss averaging in RL code

### DIFF
--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -392,6 +392,7 @@ class MegatronPolicyWorker(AbstractPolicyWorker, ColocatablePolicyInterface):
                             global_valid_toks,
                             pack_sequences=self.cfg["sequence_packing"]["enabled"],
                             defer_fp32_logits=self.defer_fp32_logits,
+                            num_microbatches=num_microbatches,
                         ),
                         data_iterator=data_iterator,
                         model=self.model,
@@ -400,7 +401,6 @@ class MegatronPolicyWorker(AbstractPolicyWorker, ColocatablePolicyInterface):
                         micro_batch_size=mbs,
                         decoder_seq_length=padded_seq_length,
                         forward_only=eval_mode,
-                        do_not_average_loss=True,
                     )
 
                 # Empty unused memory.

--- a/tests/unit/algorithms/test_sequence_packing_gradients.py
+++ b/tests/unit/algorithms/test_sequence_packing_gradients.py
@@ -351,7 +351,7 @@ class SequencePackingGradientTestActor:
             model=MockModel(),
             loss_fn=base_loss_fn,
             pack_sequences=True,
-            cp_normalize=True,
+            num_microbatches=1,
         )
         loss, metrics = wrapped_loss_fn(output_tensor)
 


### PR DESCRIPTION
## Summary

Instead of passing `do_not_average_loss=True` to Megatron's `forward_backward_func`, we now let Megatron apply its default loss averaging (`output_tensor *= cp_group_size; output_tensor /= num_microbatches`) and undo it in `forward_step_arbitrary_loss` by applying the inverse (`loss *= num_microbatches / cp_size`).

This removes our dependency on the upstream `do_not_average_loss` option in Megatron-LM (ref: PR 2951).

## Changes

- **`nemo_rl/models/megatron/common.py`**: Rename `cp_normalize` → `undo_megatron_loss_averaging`, add `num_microbatches` param, replace `_div_by_cp_size` wrapper with `_undo_megatron_loss_averaging` that applies `loss * num_microbatches / cp_size`
- **`nemo_rl/models/policy/workers/megatron_policy_worker.py`**: Remove `do_not_average_loss=True` from `forward_backward_func` call, pass `num_microbatches` to `forward_step` partial
- **`tests/unit/algorithms/test_sequence_packing_gradients.py`**: Update call to `forward_step_arbitrary_loss` to use new parameter names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Changed loss computation parameter from a boolean normalization flag to an explicit microbatch count, improving clarity in training configuration and microbatch handling during loss computation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->