### PR TITLE
build: Add vllm arm precompiled wheel env variable

### DIFF
--- a/tools/build-custom-vllm.sh
+++ b/tools/build-custom-vllm.sh
@@ -24,7 +24,9 @@ GIT_URL=${1:-https://github.com/vllm-project/vllm.git}
 GIT_REF=${2:-cc99baf14dacc2497d0c5ed84e076ef2c37f6a4d}
 # NOTE: VLLM_USE_PRECOMPILED=1 didn't always seem to work since the wheels were sometimes built against an incompatible torch/cuda combo.
 # This commit was chosen as one close to the v0.10 release: git merge-base --fork-point origin/main tags/v0.10.0
-if [[ "$(uname -m)" == "aarch64" ]]; then
+if [[ -n "${3:-}" ]]; then
+  VLLM_PRECOMPILED_WHEEL_LOCATION="$3"
+elif [[ "$(uname -m)" == "aarch64" ]]; then
   VLLM_PRECOMPILED_WHEEL_LOCATION="https://github.com/vllm-project/vllm/releases/download/v0.13.0/vllm-0.13.0-cp38-abi3-manylinux_2_31_aarch64.whl"
 else
   VLLM_PRECOMPILED_WHEEL_LOCATION="https://github.com/vllm-project/vllm/releases/download/v0.13.0/vllm-0.13.0-cp38-abi3-manylinux_2_31_x86_64.whl"


### PR DESCRIPTION
# What does this PR do ?

Adding vllm arm precompiled wheel environment variable to build on ARM machines

# Issues
Fixes https://github.com/NVIDIA-NeMo/RL/issues/1952

# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build configuration to automatically detect and use the appropriate precompiled wheels based on system architecture, improving compatibility across different platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->