### PR TITLE
feat: adding wandb table log feature, showing concrete test samples

### DIFF
--- a/docs/design-docs/logger.md
+++ b/docs/design-docs/logger.md
@@ -151,6 +151,30 @@ When enabled, the pretty logging will generate formatted text similar to:
 
 ![Validation Pretty Logging Example](../assets/val-log.png)
 
+## Validation Table Logging (WandB)
+
+When WandB is enabled, validation input/output samples can be logged as WandB tables for manual inspection in the WandB UI. This is controlled by the `num_val_samples_to_log` configuration parameter.
+
+```python
+logger:
+  wandb_enabled: true
+  wandb:
+    project: "my-project"
+    name: "my-run"
+  num_val_samples_to_log: 16  # 0 to disable
+```
+
+When `num_val_samples_to_log` is greater than 0, the logger uploads a table at each validation step with columns **input**, **output**, and **reward**. Samples are chosen to include a mix of high- and low-reward examples for easier quality inspection. The tables appear in WandB as `val/generations` and `val/generations_step_{step}`.
+
+This is useful for:
+
+1. Inspecting model generations directly in the WandB run without opening logs or artifacts.
+2. Comparing prompts, responses, and rewards across validation steps.
+3. Sharing or reviewing specific samples with collaborators via the WandB UI.
+
+> [!NOTE]
+> This feature only has effect when `wandb_enabled` is true. If WandB is disabled or `num_val_samples_to_log` is 0, no validation tables are logged.
+
 ## GPU Metric Logging
 
 NeMo RL monitors GPU memory and utilization through [system metrics](https://docs.ray.io/en/latest/ray-observability/reference/system-metrics.html#system-metrics) exposed by Ray nodes. While Ray makes these metrics available for tools like Prometheus, NeMo RL directly polls GPU memory and utilization data and logs them to TensorBoard, WandB, MLflow and/or SwanLab.

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -329,7 +329,8 @@ env:
 
 logger:
   log_dir: "logs"  # Base directory for all logs
-  num_val_samples_to_print: 0 # Number of validation samples to pretty print on terminal
+  num_val_samples_to_print: 16 # Number of validation samples to pretty print on terminal
+  num_val_samples_to_log: 16 # Number of validation samples to log to wandb table
   wandb_enabled: false
   tensorboard_enabled: false
   mlflow_enabled: false  # Disable MLflow logging
@@ -350,5 +351,5 @@ logger:
     flush_interval: 10  # How often to flush GPU usage metrics to the loggers (in seconds)
 
 cluster:
-  gpus_per_node: 1
-  num_nodes: 1
+  gpus_per_node: 8
+  num_nodes: 2

--- a/nemo_rl/utils/logger.py
+++ b/nemo_rl/utils/logger.py
@@ -87,6 +87,7 @@ class LoggerConfig(TypedDict):
     monitor_gpus: bool
     gpu_monitoring: GPUMonitoringConfig
     num_val_samples_to_print: NotRequired[int]
+    num_val_samples_to_log: NotRequired[int]
 
 
 class LoggerInterface(ABC):


### PR DESCRIPTION
# What does this PR do?

VERL has this useful feature, where at each validation step, a number of input/output samples are included in Wandb for easy manual inspection:
<img width="1787" height="891" alt="image" src="https://github.com/user-attachments/assets/bbbf3878-0f4b-4753-873d-c79a293784b4" />

This PR add a similar functionality to NemoRL:
<img width="798" height="1391" alt="image" src="https://github.com/user-attachments/assets/f9bef9bd-c8e6-4e99-bd43-1fdd0419c453" />

Add optional logging of validation input/output samples to WandB as tables so runs can be inspected manually in the WandB UI (prompt, response, reward per sample).

# Issues
<!-- Add issue links here if applicable, e.g. Closes #123 -->

# Usage

Enable WandB and set `num_val_samples_to_log` in the logger config. At each validation step, a subset of samples (mix of high- and low-reward) is logged as a WandB table with columns **input**, **output**, and **reward**.

```
# In your recipe or config (e.g. under logger:)
logger:
  wandb_enabled: true
  wandb:
    project: "my-project"
    name: "my-run"
  num_val_samples_to_log: 16   # 0 to disable; number of val samples to log to wandb table
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
Files changed: nemo_rl/algorithms/grpo.py (wandb Table logging and helpers), nemo_rl/utils/logger.py (num_val_samples_to_log in LoggerConfig), examples/configs/grpo_math_1B.yaml (config option), docs/design-docs/logger.md (Validation Table Logging section).
No tables are logged when wandb_enabled is false or num_val_samples_to_log is 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added WandB table logging for validation samples, displaying input, output, and reward data to monitor validation performance in real-time.

**Documentation**
* Added comprehensive guide for configuring and using validation table logging in WandB, including configuration examples and sample selection details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->