### PR TITLE
fix: remove label name from CI concurrency group

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -46,7 +46,7 @@ on:
   #    - 'main'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.label.name || 'main' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- The CI concurrency group included `github.event.label.name`, which meant re-labeling a PR (e.g. `CI:L0` → `CI:L1`) created a different concurrency group and the old run was never cancelled
- This made "Cancel workflow" via re-labeling ineffective since both runs had different concurrency keys
- Removed the label component so all CI runs for the same PR share one group and `cancel-in-progress: true` works as expected

## Test plan
- [ ] Re-label a PR (e.g. remove `CI:L0`, add `CI:L1`) and verify the previous run gets cancelled
- [ ] Verify manual "Cancel workflow" button works while a run is in progress

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to optimize how concurrent workflow runs are managed and coordinated during pull request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->