### PR TITLE
ci: Temp disable megatron lora grpo tests

### DIFF
--- a/tests/functional/L1_Functional_Tests_GPU.sh
+++ b/tests/functional/L1_Functional_Tests_GPU.sh
@@ -52,8 +52,8 @@ run_test      uv run --no-sync bash ./tests/functional/grpo_automodel_lora_async
 run_test      uv run --no-sync bash ./tests/functional/grpo_automodel_lora_non_colocated.sh
 run_test      uv run --no-sync bash ./tests/functional/grpo_megatron.sh
 run_test      uv run --no-sync bash ./tests/functional/grpo_megatron_generation.sh
-run_test      uv run --no-sync bash ./tests/functional/grpo_megatron_lora.sh
-run_test      uv run --no-sync bash ./tests/functional/grpo_megatron_lora_async.sh
+# run_test      uv run --no-sync bash ./tests/functional/grpo_megatron_lora.sh
+# run_test      uv run --no-sync bash ./tests/functional/grpo_megatron_lora_async.sh
 run_test      uv run --no-sync bash ./tests/functional/grpo_multiple_dataloaders.sh
 run_test      uv run --no-sync bash ./tests/functional/grpo_multiturn.sh
 run_test      uv run --no-sync bash ./tests/functional/grpo_non_colocated.sh


### PR DESCRIPTION
# What does this PR do ?

Temp disable megatron lora grpo tests

These tests were failing and a fix is being worked on.  In the mean time, let's skip the tests.
https://github.com/NVIDIA-NeMo/RL/pull/1889

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Disabled GPU functional tests for grpo_megatron_lora and grpo_megatron_lora_async configurations in the L1 functional test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->