### PR TITLE
ci: Fix copy-pr-bot config

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,3 +1,3 @@
 enabled: true
 auto_sync_draft: false
-auto_sync_ready: true
+auto_sync_ready: false


### PR DESCRIPTION
# What does this PR do ?

ci: Fix copy-pr-bot config

We're working on enabling copy-pr-bot for kicking-off CI for the RL repo. This is used by other repos already as the mechanism to verify whether CI should run, especially for external contributors.  However, the original copy-pr-bot config we have has the extension `.yml`, and it should be `.yaml`.  Also, update the config to not automatically run and require an explicit `/ok to test` comment. This will be more in line with how RL team currently launches CI jobs with different labels.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automatic pull request readiness synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->