### PR TITLE
build: Ensure xgrammar==0.1.32 in vllm and gym venvs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -197,6 +197,11 @@ else
     UV_LINK_MODE=hardlink uv run nemo_rl/utils/prefetch_venvs.py
 fi
 
+# Address CVE GHSA-7rgv-gqhr-fxg3 by forcing xgrammar 0.1.32 in custom vllm and gym venvs
+# It is not possible to use uv overrides with how we install these venvs
+/opt/nemo-rl/3rdparty/vllm/.venv/bin/pip install xgrammar==0.1.32
+/opt/gym_venvs/responses_api_models/vllm_model/.venv/bin/pip install xgrammar==0.1.32
+
 # Prune unreachable cache entries
 uv cache clean
 EOF


### PR DESCRIPTION
# What does this PR do ?

build: Ensure xgrammar==0.1.32 in vllm and gym venvs

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
