### PR TITLE
fix: reference model swap for Megatron policy worker with FP8 / _extra_state

### DIFF
--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -519,6 +519,56 @@ class MegatronPolicyWorker(AbstractPolicyWorker, ColocatablePolicyInterface):
         no_grad.__exit__(None, None, None)
         return BatchedDataDict[LogprobOutputSpec](logprobs=logprobs).to("cpu")
 
+    def _apply_state_dict_to_model(
+        self,
+        source_state_dict: dict,
+        *,
+        raise_if_key_missing: bool = False,
+    ) -> None:
+        """Apply a state dict to self.model in-place.
+
+        - Tensors with matching shape: in-place copy (parameters / buffers).
+        - _extra_state keys (e.g. FP8 scale/amax) with shape mismatch or non-Tensor value:
+          resolve the submodule and call set_extra_state(); supports DDP and Float16Module unwrap.
+
+        Args:
+            source_state_dict: State dict to apply (e.g. reference_state_dict or saved model_state_dict).
+            raise_if_key_missing: If True, raise when a key in self.model.state_dict() is missing
+                from source_state_dict; if False, skip such keys.
+        """
+        for state_dict_key, param_or_buf in self.model.state_dict().items():
+            if not isinstance(param_or_buf, torch.Tensor):
+                continue
+            if state_dict_key not in source_state_dict:
+                if raise_if_key_missing:
+                    raise ValueError(
+                        f"Key '{state_dict_key}' not in source state_dict."
+                    )
+                continue
+            source_value = source_state_dict[state_dict_key]
+
+            # Case 1: Same shape → in-place copy (parameters / buffers)
+            if (
+                isinstance(source_value, torch.Tensor)
+                and param_or_buf.shape == source_value.shape
+            ):
+                param_or_buf.copy_(source_value)
+                continue
+
+            # Case 2: _extra_state (shape mismatch or non-Tensor) → set_extra_state()
+            assert "extra_state" in state_dict_key, (
+                f"the {state_dict_key} is not an extra_state, but the param_or_buf is mismatched with the reference_state_dict {source_value.shape} != {param_or_buf.shape}."
+            )
+
+            submodule_path = state_dict_key.rsplit("._extra_state", 1)[0]
+            base_module = getattr(self.model, "module", self.model)
+            # Unwrap Float16Module/MoEFloat16Module: state_dict keys are relative to inner .module
+            top_level_name = submodule_path.split(".", 1)[0]
+            if not hasattr(base_module, top_level_name):
+                base_module = getattr(base_module, "module", base_module)
+            target_module = base_module.get_submodule(submodule_path)
+            target_module.set_extra_state(source_value)
+
     @contextmanager
     def use_reference_model(self):
         """Context manager that temporarily swaps the reference model and active model.
@@ -541,10 +591,11 @@ class MegatronPolicyWorker(AbstractPolicyWorker, ColocatablePolicyInterface):
                         )
                     model_state_dict[name] = item
 
-                # Swap reference model state_dict to self.model
-                for k, v in self.model.state_dict().items():
-                    if isinstance(v, torch.Tensor):
-                        v.copy_(self.reference_state_dict[k])
+                # Swap reference model state_dict into self.model (reference weights + optional FP8 extra_state)
+                self._apply_state_dict_to_model(
+                    self.reference_state_dict,
+                    raise_if_key_missing=True,
+                )
 
                 if self.cfg["megatron_cfg"]["empty_unused_memory_level"] >= 1:
                     gc.collect()
@@ -555,10 +606,11 @@ class MegatronPolicyWorker(AbstractPolicyWorker, ColocatablePolicyInterface):
                 yield
 
             finally:
-                # Restore original references and device placement
-                for k, v in self.model.state_dict().items():
-                    if isinstance(v, torch.Tensor):
-                        v.copy_(model_state_dict[k])
+                # Restore original policy state (weights + FP8 extra_state) from saved model_state_dict
+                self._apply_state_dict_to_model(
+                    model_state_dict,
+                    raise_if_key_missing=True,
+                )
 
                 if self.cfg["megatron_cfg"]["empty_unused_memory_level"] >= 1:
                     gc.collect()


### PR DESCRIPTION
## Summary

Fix `MegatronPolicyWorker.use_reference_model()` when the policy model uses FP8 and has `_extra_state` (e.g. TransformerEngine attention scale/amax). Previously, swapping reference state into the model could raise a shape mismatch error (e.g. 546 vs 0) or fail on wrapped models (DDP, Float16Module/MoEFloat16Module). This PR corrects state application and restores policy state on exit, and extracts the shared logic into a reusable helper.

## Problem

1. **Shape mismatch on `_extra_state`**  
   When copying `reference_state_dict` into `self.model` with a simple loop `v.copy_(self.reference_state_dict[k])`, keys like `decoder.layers.0.self_attention.core_attention._extra_state` can have different shapes:
   - Policy (FP8 enabled): non-empty tensor (e.g. shape `(546,)` for scale/amax).
   - Reference (from checkpoint, no FP8): empty tensor (e.g. shape `(0,)`) or missing.
   - `copy_()` then raises: `The size of tensor a (546) must match the size of tensor b (0) at non-singleton dimension 0`.

2. **Wrong module for `get_submodule`**  
   - `self.model` may be wrapped in `DistributedDataParallel`; the real module is `self.model.module`.
   - Under DDP, the inner module may be `MoEFloat16Module` / `Float16Module`, and the actual model with `decoder` is in `.module`. Calling `get_submodule("decoder.layers.0...")` on the wrapper raises `AttributeError: MoEFloat16Module has no attribute 'decoder'`.

3. **Restore not handling `_extra_state`**  
   In the `finally` block, restoring policy state used the same `copy_`-only logic, so `_extra_state` with shape mismatch was not restored, leaving FP8 metadata inconsistent after exiting the context.

## Solution

- **Two cases in state application**
  - **Case 1**: Tensor with matching shape → in-place `copy_` (parameters / buffers).
  - **Case 2**: Key contains `_extra_state` and shape differs or value is non-Tensor → resolve the owning submodule and call `set_extra_state(source_value)` instead of `copy_`. This supports reference overwriting (e.g. empty tensor) and avoids shape errors.

- **Correct module for `_extra_state`**
  - Use `getattr(self.model, "module", self.model)` so DDP is unwrapped.
  - If the resulting module does not have the first path component (e.g. `decoder`), unwrap again via `getattr(base_module, "module", base_module)` so Float16Module/MoEFloat16Module is skipped and `get_submodule` runs on the real model.

- **Restore uses the same logic**  
  In `finally`, apply the saved `model_state_dict` with the same two-case logic so that `_extra_state` is restored via `set_extra_state(saved_value)` and policy FP8 state is consistent after exit.

- **Shared helper**  
  Extract the common logic into `_apply_state_dict_to_model(source_state_dict, *, raise_if_key_missing=False)` and call it:
  - On entry: `_apply_state_dict_to_model(self.reference_state_dict, raise_if_key_missing=True)`.
  - On exit: `_apply_state_dict_to_model(model_state_dict, raise_if_key_missing=...)` (False recommended so missing keys are skipped).

## Changes

**File: `nemo_rl/models/policy/workers/megatron_policy_worker.py`**

1. **New method `_apply_state_dict_to_model(self, source_state_dict, *, raise_if_key_missing=False)`**
   - Applies `source_state_dict` to `self.model` in-place.
   - Case 1: same-shape tensors → `copy_`.
   - Case 2: `_extra_state` keys → resolve submodule (with DDP and Float16Module unwrap) and `set_extra_state(source_value)`.
   - Missing keys: raise if `raise_if_key_missing` else skip.
   - Docstring and inline comments describe behavior and arguments.

2. **`use_reference_model()`**
   - **Try block**: Replaces the previous per-key loop with `self._apply_state_dict_to_model(self.reference_state_dict, raise_if_key_missing=True)`.
   - **Finally block**: Replaces the previous restore loop with `self._apply_state_dict_to_model(model_state_dict, raise_if_key_missing=...)` so policy state (including `_extra_state`) is restored consistently.

3. **Save of full state for restore**  
   Unchanged: `model_state_dict` is still built from `self.model.state_dict()` (including non-Tensor values and `_extra_state`) so that restore has the full policy state.

## Testing

- Run GRPO with Megatron + FP8 (e.g. `grpo-llama3.1-8b-instruct-2n8g-megatron-fp8-e2e.sh`).
- Confirm `get_reference_policy_logprobs` no longer raises:
  - tensor size mismatch on `_extra_state`, or
  - `AttributeError` from DDP / MoEFloat16Module when resolving submodule.
- Run GRPO with Megatron + Lora (e.g. `grpo-qwen3-8b-base-1n8g-megatron-lora.sh`)
  - We update params by key instead of use `load_state_dict` directly is because of lora will introduce `to_wrap` key. We need to validate this change won't destroy lora.