### PR TITLE
fix: quote \$0 in basename call

### DIFF
--- a/tests/functional/grpo_megatron_lora_async.sh
+++ b/tests/functional/grpo_megatron_lora_async.sh
@@ -6,7 +6,7 @@ git config --global --add safe.directory $PROJECT_ROOT
 
 set -eou pipefail
 
-EXP_NAME=$(basename $0 .sh)
+EXP_NAME=$(basename "$0" .sh)
 EXP_DIR=$SCRIPT_DIR/$EXP_NAME
 LOG_DIR=$EXP_DIR/logs
 JSON_METRICS=$EXP_DIR/metrics.json


### PR DESCRIPTION
Quote $0 in the basename call to avoid potential word splitting if the script path contains spaces. This change does not alter behavior but makes the script more robust.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test script reliability with improved handling of file paths containing spaces to ensure consistent behavior across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->