### PR TITLE
Add ray-interactive.sub and interactive mode guide

### DIFF
--- a/docs/guides/ray-interactive.md
+++ b/docs/guides/ray-interactive.md
@@ -1,0 +1,186 @@
+# Interactive Ray Cluster on Slurm
+
+> [!TIP]
+> A key advantage of running interactively is the ability to execute **multiple multi-node jobs without re-queuing** in the Slurm job queue. During a debugging session you can submit, cancel, and re-submit NeMo RL jobs directly from the head-node shell — paying the queue wait time only once.
+
+`ray-interactive.sub` starts a Ray cluster on your Slurm allocation, waits until all workers have connected, then prints connection instructions and **idles indefinitely**. You attach to the head node at any time and submit jobs manually.
+
+This is the recommended approach when:
+
+- Iterating quickly on configs or debugging failures
+- Running a series of ablations back-to-back without re-queuing
+- Exploring the cluster interactively with `ray status` or custom scripts
+
+---
+
+## 1. Submit the Job
+
+```sh
+# Run from the root of the NeMo RL repo
+NUM_NODES=2   # Total nodes (head + workers share the allocation)
+
+CONTAINER=YOUR_CONTAINER \
+MOUNTS="$PWD:$PWD" \
+sbatch \
+    --nodes=${NUM_NODES} \
+    --account=YOUR_ACCOUNT \
+    --job-name=YOUR_JOBNAME \
+    --partition=YOUR_PARTITION \
+    --time=4:0:0 \
+    --gres=gpu:8 \
+    ray-interactive.sub
+```
+
+> [!TIP]
+> Depending on your Slurm cluster configuration, you may or may not need to include `--gres=gpu:8`. For GB200 systems with 4 GPUs per node, use `--gres=gpu:4`.
+
+> [!NOTE]
+> All environment variables supported by `ray.sub` (e.g. `GPUS_PER_NODE`, `SETUP_COMMAND`, `UV_CACHE_DIR_OVERRIDE`, `RAY_LOG_SYNC_FREQUENCY`, `SANDBOX_CONTAINER`) are also supported by `ray-interactive.sub`. See the [cluster documentation](../cluster.md#slurm-environment-variables) for the full list.
+
+Upon successful submission, Slurm will print the job ID:
+
+```text
+Submitted batch job 1980204
+```
+
+---
+
+## 2. Wait for the Cluster to Come Up
+
+The SLURM job stdout (`slurm-<JOB_ID>.out` by default) streams startup progress. Watch it with:
+
+```sh
+tail -f slurm-1980204.out
+```
+
+The head-node Ray log is also useful if you want to see `ray start` output in detail:
+
+```sh
+tail -f 1980204-logs/ray-head.log
+```
+
+Once all worker nodes have connected you will see the ready banner in the job stdout:
+
+```text
+============================================================
+ Ray cluster is READY (job 1980204)
+ Head node : gpu-node-001 (10.0.0.1)
+ Ray address: 10.0.0.1:9900
+ Dashboard  : http://10.0.0.1:8265
+ Logs       : /path/to/submit/dir/1980204-logs
+============================================================
+
+Attach to the head node with:
+  bash /path/to/submit/dir/1980204-attach.sh
+
+Or run a one-shot command on the head node:
+  COMMAND='python my_script.py' bash /path/to/submit/dir/1980204-attach.sh
+
+Attach to worker N (1-indexed):
+  bash /path/to/submit/dir/1980204-attach.sh <N>
+```
+
+---
+
+## 3. Attach to the Head Node
+
+Once the banner appears, an attach script is written to your submission directory. Run it from any login node:
+
+```sh
+bash 1980204-attach.sh
+```
+
+This opens an **interactive PTY shell** inside the container running on the Ray head node. From there you can submit jobs, inspect the cluster, or run debugging commands.
+
+---
+
+## 4. Submit Jobs from the Interactive Shell
+
+Inside the head-node shell, submit jobs exactly as you would via `COMMAND=` in a batched run:
+
+```sh
+# Verify the cluster is healthy first
+ray status
+
+# Run a NeMo RL training job
+uv run ./examples/run_grpo.py --config examples/configs/grpo_math_1B.yaml
+
+# Run another job after the first finishes — no re-queuing needed
+uv run ./examples/run_grpo.py --config examples/configs/grpo_math_1B_run2.yaml
+```
+
+> [!TIP]
+> Because the Ray cluster stays alive between runs, subsequent jobs skip the cluster startup overhead (typically 2–3 minutes) and begin nearly instantly.
+
+---
+
+## 5. Attach Script Usage Reference
+
+The generated `<JOB_ID>-attach.sh` supports several modes, all run from **outside** the container (on a login node):
+
+| Command | Effect |
+|---|---|
+| `bash <JOB_ID>-attach.sh` | Interactive shell on the **head node** |
+| `bash <JOB_ID>-attach.sh <N>` | Interactive shell on **worker N** (1-indexed) |
+| `COMMAND='...' bash <JOB_ID>-attach.sh` | Run a one-shot command on the head node (non-interactive) |
+| `COMMAND='...' bash <JOB_ID>-attach.sh <N>` | Run a one-shot command on worker N (non-interactive) |
+
+Examples:
+
+```sh
+# Verify cluster health non-interactively
+COMMAND="ray status" bash 1980204-attach.sh
+
+# Inspect GPU usage on worker 1
+COMMAND="nvidia-smi" bash 1980204-attach.sh 1
+
+# Open an interactive shell on worker 2
+bash 1980204-attach.sh 2
+```
+
+---
+
+## 6. Graceful Shutdown
+
+The cluster runs until the Slurm time limit expires. To terminate it early:
+
+```sh
+touch 1980204-logs/ENDED
+```
+
+All node sidecars detect this file within ~60 seconds and terminate cleanly. The Slurm job will then exit.
+
+Alternatively, cancel the job via Slurm:
+
+```sh
+scancel 1980204
+```
+
+---
+
+## 7. Smoke Test Checklist
+
+Use this checklist to confirm the cluster is working correctly before submitting a real training run:
+
+- [ ] Job transitions to `RUNNING` state: `squeue -j 1980204`
+- [ ] Head log shows `ray start --head` completing: `tail -f 1980204-logs/ray-head.log`
+- [ ] Worker logs show `ray start --address` completing: `tail -f 1980204-logs/ray-worker-1.log`
+- [ ] Job stdout shows the "Ray cluster is READY" banner: `tail -f slurm-1980204.out`
+- [ ] Attach script is present: `ls 1980204-attach.sh`
+- [ ] Attach script opens a shell: `bash 1980204-attach.sh`
+- [ ] `ray status` inside the shell shows all nodes and correct `worker_units` count
+- [ ] A minimal Ray task runs successfully:
+
+```python
+import ray
+ray.init(address="auto")
+
+@ray.remote
+def hello():
+    return "hello from Ray"
+
+print(ray.get(hello.remote()))
+ray.shutdown()
+```
+
+- [ ] `touch 1980204-logs/ENDED` terminates the job cleanly

--- a/docs/index.md
+++ b/docs/index.md
@@ -190,6 +190,7 @@ about/tips-and-tricks
 
 local-workstation.md
 cluster.md
+guides/ray-interactive.md
 
 ```
 

--- a/ray-interactive.sub
+++ b/ray-interactive.sub
@@ -1,0 +1,606 @@
+#!/bin/bash
+#SBATCH --nodes=2
+#SBATCH --exclusive
+#SBATCH --account=ACCOUNT
+#SBATCH --job-name=JOB_NAME
+#SBATCH --partition=PARTITION
+#SBATCH --time=1:0:0
+#SBATCH --dependency=singleton
+
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Interactive mode: starts a Ray cluster and waits indefinitely.
+# Once the cluster is ready, attach to the head node using the generated
+# attach script and submit jobs manually.
+
+
+set -eoux pipefail
+
+########################################################
+# Function to detect if SLURM cluster uses GRES
+########################################################
+maybe_gres_arg() {
+  # Check if any nodes in the partition have GRES configured
+  # Assumes a homogeneous allocation (not a heterogeneous job)
+  if sinfo -p $SLURM_JOB_PARTITION -h -o "%G" | grep -q "gpu:"; then
+    # Do a quick assert here that gpus:8 == gpus:$GPUS_PER_NODE. It is probably a user error if someone isn't using GPUS_PER_NODE=8 on our clusters if it supports --gres=gpu:8 or gpu:a100:8
+    # Note: cut -d'(' -f1 removes the socket spec like "(S:0-3)" that some clusters append
+    if [[ $GPUS_PER_NODE -ne $(sinfo -p $SLURM_JOB_PARTITION -h -o "%G" | grep "gpu:" | cut -d'(' -f1 | awk -F: '{print $NF}') ]]; then
+      echo "Error: GPUS_PER_NODE=$GPUS_PER_NODE but GRES detected is $(sinfo -p $SLURM_JOB_PARTITION -h -o "%G" | grep "gpu:") meaning GPUS_PER_NODE is not set to fully claim the GPUs on the nodes." >&2
+      exit 1
+    fi
+    echo "--gres=gpu:${GPUS_PER_NODE}"
+    return
+  fi
+  
+  # No GRES support detected
+  echo ""
+}
+
+########################################################
+# User defined variables
+########################################################
+export OMP_NUM_THREADS=16
+CONTAINER=$CONTAINER
+MOUNTS=$MOUNTS
+SETUP_COMMAND=${SETUP_COMMAND:-}  # Setup commands to run on all nodes before starting Ray
+########################################################
+# Ports for all nodes (should be odd numbers since we place head/worker[0] on the same node) so all workers get the odd ports, but the head will get +1 the ports
+NODE_MANAGER_PORT=${NODE_MANAGER_PORT:-53001}
+OBJECT_MANAGER_PORT=${OBJECT_MANAGER_PORT:-53003}
+RUNTIME_ENV_AGENT_PORT=${RUNTIME_ENV_AGENT_PORT:-53005}
+DASHBOARD_AGENT_GRPC_PORT=${DASHBOARD_AGENT_GRPC_PORT:-53007}
+METRICS_EXPORT_PORT=${METRICS_EXPORT_PORT:-53009}
+
+# Ports for the head node
+# GCS head port and client server port -- kept below ephemeral range (32768-60999).
+PORT=${PORT:-9900}
+RAY_CLIENT_SERVER_PORT=${RAY_CLIENT_SERVER_PORT:-9901}
+#REDIT_SHARD_PORTS=${REDIT_SHARD_PORTS:-"random"} ??
+DASHBOARD_PORT=${DASHBOARD_PORT:-8265}  # Also used by debugger
+DASHBOARD_AGENT_LISTEN_PORT=${DASHBOARD_AGENT_LISTEN_PORT:-52365}
+RAY_DEBUGGER_ARGS=
+if [ "${RAY_DEBUG:-}" = "legacy" ]; then
+  RAY_DEBUGGER_ARGS="--ray-debugger-external"
+fi
+
+# After ray>=2.47, this feature is enabled by default which creates uv venvs for any py_executable starting with `uv run`.
+# There is severe contention and performance issues with this enabled considering our dependencies are so large and occasionally
+# need to be compiled, so NeMo RL has an implementation in nemo_rl/utils/venv.py that does it once per node as opposed to once per task.
+export RAY_ENABLE_UV_RUN_RUNTIME_ENV=0
+
+# Setting ulimit is recommended by ray best practices page
+# @ https://docs.ray.io/en/latest/cluster/vms/user-guides/large-cluster-best-practices.html
+# It's session based and won't affect the system outside the script
+# Ensure that the soft limit isn't above the hard limit
+if [[ $(ulimit -Hn) == "unlimited" ]] || [[ 65535 -lt $(ulimit -Hn) ]]; then
+  ulimit -Sn 65535
+elif [[ $(ulimit -Hn) != "unlimited" ]] && [[ $(ulimit -Hn) -lt 65535 ]]; then
+  echo "[WARNING]: Cannot increase ulimit on file descriptors to 65535 according ray recommendation: https://docs.ray.io/en/latest/cluster/vms/user-guides/large-cluster-best-practices.html. Speak to cluster admins to increase, otherwise ray may crash unexpectedly."
+fi
+
+# Worker port range must NOT overlap with the OS ephemeral range (32768-60999)
+# to prevent TOCTOU collisions.  Ray's Raylet uses a probe-and-release pattern
+# (CheckPortFree) that can leave a window where the port is unguarded.
+# If the range overlaps with the ephemeral range, the kernel can assign the same
+# port as an ephemeral source port for outgoing TCP traffic during that window,
+# causing EADDRINUSE when the worker tries to bind.
+#
+# Port layout (all below ephemeral range):
+#   10002-11000  Ray worker gRPC (this setting)
+#   11001-15000  NeMo RL HTTP servers / TCPStore (policy.generation.port_range_low/high)
+#   15001-20000  NeMo Gym HTTP servers (Gym global config port_range_low/high)
+MIN_WORKER_PORT=${MIN_WORKER_PORT:-10002}
+MAX_WORKER_PORT=${MAX_WORKER_PORT:-11000}
+########################################################
+# Number seconds to sync logs from /tmp/ray/session_*/logs to $LOG_DIR/ray/
+RAY_LOG_SYNC_FREQUENCY=${RAY_LOG_SYNC_FREQUENCY:-}
+########################################################
+
+# Unset UV_CACHE_DIR to avoid local cache directory interferring with the container cache
+unset UV_CACHE_DIR
+
+if [[ -n "${UV_CACHE_DIR_OVERRIDE:-}" ]]; then
+  mkdir -p "$UV_CACHE_DIR_OVERRIDE"
+  if [[ -n $MOUNTS ]]; then
+    MOUNTS+=",$UV_CACHE_DIR_OVERRIDE:/root/.cache/uv"
+  else
+    MOUNTS="$UV_CACHE_DIR_OVERRIDE:/root/.cache/uv"
+  fi
+fi
+
+# Create logs directory
+BASE_LOG_DIR=${BASE_LOG_DIR:-$SLURM_SUBMIT_DIR}
+LOG_DIR="$BASE_LOG_DIR/$SLURM_JOB_ID-logs"
+mkdir -p $LOG_DIR
+
+# Write SETUP_COMMAND to a file to avoid heredoc escaping issues
+SETUP_COMMAND_FILE=""
+if [[ -n "$SETUP_COMMAND" ]]; then
+  SETUP_COMMAND_FILE="$LOG_DIR/setup_command.sh"
+  echo "$SETUP_COMMAND" > "$SETUP_COMMAND_FILE"
+  chmod +x "$SETUP_COMMAND_FILE"
+fi
+
+# Number of GPUs per worker node
+GPUS_PER_NODE=${GPUS_PER_NODE:-8}
+
+# Detect GRES support and set GRES_ARG
+GRES_ARG=$(maybe_gres_arg)
+if [[ -n "$GRES_ARG" ]]; then
+  echo "[INFO] GRES support detected. Using: $GRES_ARG"
+else
+  echo "[INFO] No GRES support detected. Running without --gres flag."
+fi
+
+COMMON_SRUN_ARGS="$GRES_ARG"
+COMMON_SRUN_ARGS+=" --no-container-mount-home"
+COMMON_SRUN_ARGS+=" --mpi=pmix"
+COMMON_SRUN_ARGS+=" --container-mounts=$MOUNTS"
+COMMON_SRUN_ARGS+=" --container-image=$CONTAINER"
+COMMON_SRUN_ARGS+=" --container-workdir=$SLURM_SUBMIT_DIR"
+# TODO: delete these (just for debugging)
+COMMON_SRUN_ARGS+=" -p $SLURM_JOB_PARTITION"
+COMMON_SRUN_ARGS+=" -A $SLURM_JOB_ACCOUNT"
+# Number of CPUs per worker node
+CPUS_PER_WORKER=${CPUS_PER_WORKER:-112}
+
+num_retries=3
+
+# Track backgrounded srun client PIDs for head and workers
+declare -A SRUN_PIDS
+
+# Verify all backgrounded srun client processes are still alive; exit fast if any died
+check_srun_processes() {
+  for name in "${!SRUN_PIDS[@]}"; do
+    pid="${SRUN_PIDS[$name]}"
+    # Check if the process is still running
+    if ! kill -0 "$pid" 2>/dev/null; then
+      echo "[ERROR] Background srun '$name' died (pid=$pid). Could be a failure in startup or an issue with the node preventing the srun to start. Attempting to exit." >&2
+      # Signal sidecars inside containers to terminate ASAP
+      touch "$LOG_DIR/ENDED"
+      exit 1
+    fi
+  done
+}
+
+# Getting the node names and IP addresses in the SLURM allocation
+nodes=$(scontrol show hostnames "$SLURM_JOB_NODELIST")
+nodes_array=($nodes)
+ip_addresses_array=()
+
+for node in $nodes; do
+    # Try multiple methods to get IP address - ENHANCED VERSION v2.0
+    echo "[DEBUG] Resolving hostname: $node using enhanced resolution methods"
+    ip_address=""
+    
+    # Method 1: Try host command
+    echo "[DEBUG] Method 1: host command"
+    ip_address=$(host $node 2>/dev/null | awk '/has address/ { print $4 }' | head -1 || true)
+    echo "[DEBUG] host result: '$ip_address'"
+    
+    # Method 2: If host fails, try getent
+    if [[ -z "$ip_address" ]]; then
+        echo "[DEBUG] Method 2: getent hosts"
+        ip_address=$(getent hosts $node 2>/dev/null | awk '{ print $1 }' | head -1 || true)
+        echo "[DEBUG] getent result: '$ip_address'"
+    fi
+    
+    # Method 3: If getent fails, try nslookup
+    if [[ -z "$ip_address" ]]; then
+        echo "[DEBUG] Method 3: nslookup"
+        ip_address=$(nslookup $node 2>/dev/null | awk '/^Address: / { print $2 }' | head -1 || true)
+        echo "[DEBUG] nslookup result: '$ip_address'"
+    fi
+    
+    # Method 4: If all DNS methods fail, try ping to extract IP
+    if [[ -z "$ip_address" ]]; then
+        echo "[DEBUG] Method 4: ping"
+        ip_address=$(ping -c 1 $node 2>/dev/null | grep "PING" | sed 's/.*(\([^)]*\)).*/\1/' || true)
+        echo "[DEBUG] ping result: '$ip_address'"
+    fi
+    
+    # If still no IP, use the hostname itself (might work if it's already an IP or resolvable)
+    if [[ -z "$ip_address" ]]; then
+        echo "[WARNING] Could not resolve IP for $node, using hostname as fallback"
+        ip_address=$node
+    fi
+    
+    echo "[INFO] Node: $node -> IP: $ip_address"
+    # Add the IP address to the array
+    ip_addresses_array+=("$ip_address")
+done
+
+head_node=${nodes_array[0]}
+head_node_ip=${ip_addresses_array[0]}
+
+ip_head=$head_node_ip:$PORT
+
+# First we start the head of the ray cluster on one of the physical nodes
+# Give the head node actual resources to make it schedulable
+
+head_cmd=$(cat <<EOF
+# Touch a file to indicate that the head node has started
+# Overlapping srun commands will check this file to determine if we can overlap a container command
+touch $LOG_DIR/STARTED_RAY_HEAD
+env
+
+exit-dramatically() {
+    # Use SIGTERM to forcefully terminate the srun process
+    pkill -P $$ || true
+    kill -TERM 0 || true
+    # As a last resort, exit with a non-zero code
+    exit 1
+}
+export -f exit-dramatically
+
+# Background process to check for ENDED file
+monitor-sidecar() {
+  set +x
+  while true; do
+    sleep 60
+    if [[ -f "$LOG_DIR/ENDED" ]]; then
+      echo "Detected ENDED file, terminating..."
+      exit-dramatically
+    fi
+  done
+}
+monitor-sidecar &
+
+# Background process to sync ray logs every $RAY_LOG_SYNC_FREQUENCY seconds
+log-sync-sidecar() {
+  set +x
+  if [[ -z "$RAY_LOG_SYNC_FREQUENCY" ]]; then
+    echo "RAY_LOG_SYNC_FREQUENCY is not set, skipping log sync sidecar"
+    return
+  fi
+  mkdir -p $LOG_DIR/ray
+  while true; do
+    sleep $RAY_LOG_SYNC_FREQUENCY
+    if ls /tmp/ray/session_[0-9]* > /dev/null 2>&1; then
+      for session_dir in /tmp/ray/session_[0-9]*/; do
+        if [[ -d "\$session_dir/logs" ]]; then
+          session_name=\$(basename "\$session_dir")
+          mkdir -p "$LOG_DIR/ray/\$session_name"
+          if command -v rsync > /dev/null 2>&1; then
+            rsync -ahP "\$session_dir/logs/" "$LOG_DIR/ray/\$session_name/logs/" 2>/dev/null || true
+          else
+            cp -r "\$session_dir/logs" "$LOG_DIR/ray/\$session_name/"
+          fi
+        fi
+      done
+    fi
+    if [[ -f "$LOG_DIR/ENDED" ]]; then
+      echo "Log sync sidecar terminating..."
+      break
+    fi
+  done
+}
+log-sync-sidecar &
+
+# Patch nsight.py before starting Ray head
+sed -i 's/context\.py_executable = " "\.join(self\.nsight_cmd) + " python"/context.py_executable = " ".join(self.nsight_cmd) + f" {context.py_executable}"/g' /opt/nemo_rl_venv/lib64/python*/site-packages/ray/_private/runtime_env/nsight.py
+
+cat <<EOFINNER | tee /launch-head.sh
+ray start --head \
+    --disable-usage-stats \
+    --resources="{\"worker_units\": $GPUS_PER_NODE, \"slurm_managed_ray_cluster\": 1}" \
+    --node-ip-address="$head_node_ip" \
+    --port=${PORT} \
+    --ray-client-server-port=${RAY_CLIENT_SERVER_PORT} \
+    --dashboard-port=${DASHBOARD_PORT} \
+    --dashboard-host="$head_node_ip" \
+    --include-dashboard=True \
+    \
+    --node-manager-port=$((${NODE_MANAGER_PORT} + 1)) \
+    --object-manager-port=$((${OBJECT_MANAGER_PORT} + 1)) \
+    --runtime-env-agent-port=$((${RUNTIME_ENV_AGENT_PORT} + 1)) \
+    --dashboard-agent-grpc-port=$((${DASHBOARD_AGENT_GRPC_PORT} + 1)) \
+    --dashboard-agent-listen-port=$((${DASHBOARD_AGENT_LISTEN_PORT} + 1)) \
+    --metrics-export-port=$((${METRICS_EXPORT_PORT} + 1)) \
+    $RAY_DEBUGGER_ARGS \
+    \
+    --block 
+EOFINNER
+chmod +x /launch-head.sh
+
+count=0
+while [[ \$count -lt $num_retries ]]; do
+  if [[ -n "$SETUP_COMMAND_FILE" ]] && [[ -f "$SETUP_COMMAND_FILE" ]]; then
+    echo "[INFO] Running setup command from $SETUP_COMMAND_FILE..."
+    bash "$SETUP_COMMAND_FILE"
+  fi
+  bash /launch-head.sh
+  count=\$((count+1))
+  echo "Head node failed \$count/$num_retries times, restarting in 5 seconds..."
+  sleep 5
+done
+touch $LOG_DIR/ENDED
+exit 1
+EOF
+)
+srun $COMMON_SRUN_ARGS --nodes=1 --ntasks=1 --cpus-per-task=$CPUS_PER_WORKER -w "$head_node" -o $LOG_DIR/ray-head.log bash -x -c "$head_cmd" &
+SRUN_PIDS["ray-head"]=$!
+
+sleep 120s
+NUM_ACTORS=$((GPUS_PER_NODE * SLURM_JOB_NUM_NODES))
+
+# Start Ray worker nodes
+# We want 1 Ray worker node per physical node (excluding the head node)
+# Worker nodes are started with ray start but without the --head flag
+# Start from node 1 since node 0 is running the head
+for ((i = 1; i < SLURM_JOB_NUM_NODES; i++)); do
+  node_i=${nodes_array[$i]}
+    
+  worker_cmd=$(cat <<EOF
+env
+
+exit-dramatically() {
+    # Use SIGTERM to forcefully terminate the srun process
+    pkill -P $$ || true
+    kill -TERM 0 || true
+    # As a last resort, exit with a non-zero code
+    exit 1
+}
+
+# Background process to check for ENDED file
+monitor-sidecar() {
+  set +x
+  while true; do
+    sleep 60
+    if [[ -f "$LOG_DIR/ENDED" ]]; then
+      echo "Detected ENDED file, terminating..."
+      exit-dramatically
+    fi
+  done
+}
+monitor-sidecar &
+
+# Background process to sync ray logs every $RAY_LOG_SYNC_FREQUENCY seconds
+log-sync-sidecar() {
+  set +x
+  if [[ -z "$RAY_LOG_SYNC_FREQUENCY" ]]; then
+    echo "RAY_LOG_SYNC_FREQUENCY is not set, skipping log sync sidecar"
+    return
+  fi
+  mkdir -p $LOG_DIR/ray/$node_i
+  while true; do
+    sleep $RAY_LOG_SYNC_FREQUENCY
+    if ls /tmp/ray/session_[0-9]* > /dev/null 2>&1; then
+      for session_dir in /tmp/ray/session_[0-9]*/; do
+        if [[ -d "\$session_dir/logs" ]]; then
+          session_name=\$(basename "\$session_dir")
+          mkdir -p "$LOG_DIR/ray/$node_i/\$session_name"
+          if command -v rsync > /dev/null 2>&1; then
+            rsync -ahP "\$session_dir/logs/" $LOG_DIR/ray/$node_i/\$session_name/logs/ 2>/dev/null || true
+          else
+            cp -r "\$session_dir/logs" $LOG_DIR/ray/$node_i/\$session_name/
+          fi
+        fi
+      done
+    fi
+    if [[ -f "$LOG_DIR/ENDED" ]]; then
+      echo "Log sync sidecar terminating..."
+      break
+    fi
+  done
+}
+log-sync-sidecar &
+
+# Patch nsight.py before starting Ray worker
+sed -i 's/context\.py_executable = " "\.join(self\.nsight_cmd) + " python"/context.py_executable = " ".join(self.nsight_cmd) + f" {context.py_executable}"/g' /opt/nemo_rl_venv/lib64/python*/site-packages/ray/_private/runtime_env/nsight.py
+
+cat <<EOFINNER | tee /launch-worker.sh
+ray start --address "$ip_head" \
+          --disable-usage-stats \
+          --resources="{\"worker_units\": $GPUS_PER_NODE, \"slurm_managed_ray_cluster\": 1}" \
+          --min-worker-port=${MIN_WORKER_PORT} \
+          --max-worker-port=${MAX_WORKER_PORT} \
+          \
+          --node-manager-port=${NODE_MANAGER_PORT} \
+          --object-manager-port=${OBJECT_MANAGER_PORT} \
+          --runtime-env-agent-port=${RUNTIME_ENV_AGENT_PORT} \
+          --dashboard-agent-grpc-port=${DASHBOARD_AGENT_GRPC_PORT} \
+          --dashboard-agent-listen-port=${DASHBOARD_AGENT_LISTEN_PORT} \
+          --metrics-export-port=${METRICS_EXPORT_PORT} \
+          $RAY_DEBUGGER_ARGS \
+          \
+          --block 
+EOFINNER
+
+count=0
+while [[ \$count -lt $num_retries ]]; do
+  if [[ -n "$SETUP_COMMAND_FILE" ]] && [[ -f "$SETUP_COMMAND_FILE" ]]; then
+    echo "[INFO] Running setup command from $SETUP_COMMAND_FILE..."
+    bash "$SETUP_COMMAND_FILE"
+  fi
+  bash /launch-worker.sh
+  count=\$((count+1))
+  echo "Worker failed \$count/$num_retries times, restarting in 5 seconds..."
+  sleep 5
+done
+touch $LOG_DIR/ENDED
+exit 1
+EOF
+)
+  srun $COMMON_SRUN_ARGS --exact --nodes=1 --ntasks=1 --cpus-per-task=$CPUS_PER_WORKER -w "$node_i" -o $LOG_DIR/ray-worker-$i.log bash -x -c "$worker_cmd" &
+  SRUN_PIDS["ray-worker-$i"]=$!
+  sleep 3
+done
+
+# Then we wait here for the file to be created by the head node container
+while check_srun_processes && ! srun --overlap --nodes=1 --ntasks=1 -w $head_node test -f $LOG_DIR/STARTED_RAY_HEAD; do
+  echo "[INFO][$(date)] Waiting for head node container to start..."
+  sleep 2
+done
+
+########################################################
+# Run sandbox in parallel on the head node (overlap)
+########################################################
+export SLURM_MASTER_NODE=$(scontrol show hostnames $SLURM_JOB_NODELIST | head -n1)
+
+# Check if SANDBOX_CONTAINER and SANDBOX_COMMAND are defined
+if [[ -n "${SANDBOX_CONTAINER:-}" ]] && [[ -n "${SANDBOX_COMMAND:-}" ]]; then
+  SANDBOX_PORTS_DIR="$LOG_DIR/sandbox"
+  mkdir -p "$SANDBOX_PORTS_DIR"
+  echo "[INFO] Starting sandbox on head node in parallel (ports_dir=$SANDBOX_PORTS_DIR)..."
+  srun --output "$LOG_DIR/sandbox.log" \
+    --error "$LOG_DIR/sandbox.log" \
+    --container-image="$SANDBOX_CONTAINER" \
+    --container-mounts="$SANDBOX_PORTS_DIR:$SANDBOX_PORTS_DIR" \
+    --no-container-mount-home \
+    --mpi=pmix \
+    -A "$SLURM_JOB_ACCOUNT" \
+    -p "$SLURM_JOB_PARTITION" \
+    --wait=60 \
+    --kill-on-bad-exit=1 \
+    --overlap \
+    --nodes="$SLURM_JOB_NUM_NODES" \
+    --ntasks-per-node=1 \
+    -w "$head_node" \
+    --export=ALL,SANDBOX_PORTS_DIR=$SANDBOX_PORTS_DIR \
+    bash -c "$SANDBOX_COMMAND" &
+  SRUN_PIDS["sandbox"]=$!
+  echo "[INFO] Sandbox started in background (PID: ${SRUN_PIDS["sandbox"]})"
+else
+  echo "[INFO] SANDBOX_CONTAINER or SANDBOX_COMMAND not defined, skipping sandbox startup"
+fi
+
+# At this stage the Ray cluster bringup has started on the physical nodes in the allocation
+# Before we launch a job on this cluster we need to make sure that the bringup is complete
+# We do so by querying the number of worker_units in the ray cluster and asserting = NUM_ACTORS
+
+# Helper function to get container PID using enroot
+# Since we use -w to target specific nodes and only run one container per node,
+# we can just grab the first (and only) container PID on that node
+get_container_pid() {
+  local node=$1
+  srun --overlap --nodes=1 -w "$node" bash -c "enroot list -f | awk 'NR>1 && \$2 ~ /^[0-9]+\$/ {print \$2; exit}'"
+}
+
+extract_worker_units() {
+  # Get the container PID for ray-head
+  head_container_pid=$(get_container_pid "$head_node")
+  if [[ -z "$head_container_pid" ]]; then
+    echo 0
+    return
+  fi
+  
+  # Execute ray status inside the container using enroot exec
+  status_output=$(srun --overlap --nodes=1 -w "$head_node" enroot exec "$head_container_pid" ray status)
+  if echo "$status_output" | grep -q "worker_units"; then
+    worker_units=$(echo "$status_output" | grep "worker_units" | awk -F'[/. ]' '{print $4}')
+    echo $worker_units
+  else
+    echo 0
+  fi
+}
+
+# Poll to make sure that all Ray worker nodes have connected to the head.
+# All workers have connected when number of GPUs in ray cluster
+# is equal to NUM_ACTORS. We use the utility function above
+# to check how many GPUs have come online in the ray cluster
+while true; do
+  worker_units=$(extract_worker_units)
+  echo "[INFO] Number of actors online: $worker_units/$NUM_ACTORS"
+  if [[ "$worker_units" -eq "$NUM_ACTORS" ]]; then
+    break
+  fi
+  check_srun_processes
+  sleep 2
+done
+
+echo "All workers connected!"
+
+########################################################
+# Interactive mode: generate attach script and wait
+########################################################
+
+CONTAINER_CWD=$(scontrol show job $SLURM_JOB_ID | grep -oP 'WorkDir=\K[^ ]+' | head -1)
+
+cat <<EOF >$SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh
+# Attach script for interactive Ray cluster (job $SLURM_JOB_ID)
+#
+# Usage:
+#   bash ${SLURM_JOB_ID}-attach.sh           # open interactive shell on the head node
+#   bash ${SLURM_JOB_ID}-attach.sh 1         # open interactive shell on worker 1
+#   COMMAND='...' bash ${SLURM_JOB_ID}-attach.sh     # run a non-interactive command on head node
+#   COMMAND='...' bash ${SLURM_JOB_ID}-attach.sh 1   # run a non-interactive command on worker 1
+#
+# To submit a Ray job from inside the head-node shell:
+#   python my_script.py --config my_config.yaml
+
+# Helper to get container PID
+get_container_pid() {
+  local node=\$1
+  srun --overlap --nodes=1 -w "\$node" --jobid $SLURM_JOB_ID bash -c "enroot list -f | awk 'NR>1 && \\\$2 ~ /^[0-9]+\\\$/ {print \\\$2; exit}'"
+}
+
+WORKER_NUM=\${1:-}
+if [[ -z "\$WORKER_NUM" ]]; then
+  # Attach to the head node
+  HEAD_PID=\$(get_container_pid "$head_node")
+  if [[ -n "\${COMMAND:-}" ]]; then
+    srun $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --nodes=1 -w "$head_node" --jobid $SLURM_JOB_ID enroot exec "\$HEAD_PID" bash -c "cd $CONTAINER_CWD && \$COMMAND"
+  else
+    srun $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --nodes=1 -w "$head_node" --jobid $SLURM_JOB_ID --pty enroot exec "\$HEAD_PID" bash -c "cd $CONTAINER_CWD && exec bash"
+  fi
+else
+  # Attach to a specific worker node (1-indexed)
+  if [[ \$WORKER_NUM -lt 1 || \$WORKER_NUM -ge $SLURM_JOB_NUM_NODES ]]; then
+    echo "Error: WORKER_NUM must be between 1 and $((SLURM_JOB_NUM_NODES-1))"
+    exit 1
+  fi
+  nodes_array=($nodes)
+  node="\${nodes_array[\$WORKER_NUM]}"
+  WORKER_PID=\$(get_container_pid "\$node")
+  if [[ -n "\${COMMAND:-}" ]]; then
+    srun $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --nodes=1 -w "\$node" --jobid $SLURM_JOB_ID enroot exec "\$WORKER_PID" bash -c "cd $CONTAINER_CWD && \$COMMAND"
+  else
+    srun $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --nodes=1 -w "\$node" --jobid $SLURM_JOB_ID --pty enroot exec "\$WORKER_PID" bash -c "cd $CONTAINER_CWD && exec bash"
+  fi
+fi
+EOF
+chmod +x $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh
+
+echo ""
+echo "============================================================"
+echo " Ray cluster is READY (job $SLURM_JOB_ID)"
+echo " Head node : $head_node ($head_node_ip)"
+echo " Ray address: $ip_head"
+echo " Dashboard  : http://$head_node_ip:$DASHBOARD_PORT"
+echo " Logs       : $LOG_DIR"
+echo "============================================================"
+echo ""
+echo "Attach to the head node with:"
+echo "  bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh"
+echo ""
+echo "Or run a one-shot command on the head node:"
+echo "  COMMAND='python my_script.py' bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh"
+echo ""
+echo "Attach to worker N (1-indexed):"
+echo "  bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh <N>"
+echo ""
+echo "The cluster will remain alive until the SLURM time limit or until"
+echo "  touch $LOG_DIR/ENDED"
+echo "is executed to gracefully shut it down."
+echo ""
+
+# Wait-loop: keep the job alive and periodically verify all Ray processes are healthy.
+# Users can ssh to $head_node and run the attach script to submit jobs.
+while true; do
+  check_srun_processes
+  sleep 60
+done


### PR DESCRIPTION
# What does this PR do ?

**Adds `ray-interactive.sub`, a Slurm submission script that starts a Ray cluster and idles it for interactive use, along with a usage guide.**

# Issues

N/A

# Usage

Submit the job without a `COMMAND` to bring up a Ray cluster that stays alive for interactive use:

```sh
CONTAINER=YOUR_CONTAINER \
MOUNTS="$PWD:$PWD" \
sbatch \
    --nodes=2 \
    --account=YOUR_ACCOUNT \
    --job-name=YOUR_JOBNAME \
    --partition=YOUR_PARTITION \
    --time=4:0:0 \
    --gres=gpu:8 \
    ray-interactive.sub
```

Once all workers have connected, an attach script is written to the submission directory. Use it to open an interactive shell on the head node and submit jobs directly:

```sh
# Attach to head node (interactive shell)
bash 1980204-attach.sh

# Inside the container — run jobs without re-queuing
ray status
uv run ./examples/run_grpo.py --config examples/configs/grpo_math_1B.yaml

# Or run a one-shot command non-interactively
COMMAND="ray status" bash 1980204-attach.sh

# Attach to worker N
bash 1980204-attach.sh 1
```

Gracefully shut down the cluster early:

```sh
touch 1980204-logs/ENDED
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

* `ray-interactive.sub` is identical to `ray.sub` up through cluster bringup (GRES detection, head/worker startup, sandbox sidecar, worker-unit polling). The only difference is that it always enters interactive/wait mode — there is no `COMMAND` variable.
* The main wait loop calls `check_srun_processes` every 60 s so the job exits cleanly if any Ray head or worker srun dies unexpectedly, rather than hanging silently until the time limit.
* The generated `<JOB_ID>-attach.sh` supports interactive PTY shells and one-shot non-interactive commands on any node in the allocation (head or worker N).
* Documentation added at `docs/guides/ray-interactive.md` and linked from the "Environment Start" section of `docs/index.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new comprehensive guide for launching and interacting with Ray clusters on SLURM-based HPC environments, covering job submission, cluster startup, attaching to nodes, submitting jobs, monitoring logs, and graceful shutdown.
  * Updated documentation navigation to include the new interactive Ray cluster guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->