### PR TITLE
ci: skip container build for CI:docs level

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -32,7 +32,7 @@ on:
           - L0
           - L1
           - L2
-        description: Test level to run. docs = doc tests only, Lfast = fast subset (reuses main container), L0 = unit/docs/lint, L1 = L0 + functional, L2 = L1 + convergence
+        description: Test level to run. docs = doc tests only (reuses main container), Lfast = fast subset (reuses main container), L0 = unit/docs/lint, L1 = L0 + functional, L2 = L1 + convergence
       image_tag:
         description: "Override container image tag (e.g. 'main'). Skips container build."
         required: false
@@ -163,9 +163,9 @@ jobs:
 
           echo "test_level=$TEST_LEVEL" | tee -a "$GITHUB_OUTPUT"
 
-          # Determine image tag: Lfast uses main, workflow_dispatch can override
+          # Determine image tag: Lfast and docs reuse the main container, workflow_dispatch can override
           IMAGE_TAG=""
-          if [[ "$TEST_LEVEL" == "Lfast" ]]; then
+          if [[ "$TEST_LEVEL" == "Lfast" || "$TEST_LEVEL" == "docs" ]]; then
             IMAGE_TAG="main"
           fi
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.image_tag }}" ]]; then
@@ -308,7 +308,15 @@ jobs:
           - script: Docs_Tests
             runner: ${{ needs.org-member-pre-flight.outputs.runner_prefix }}-gpu-x2
     needs: [pre-flight, build-container, org-member-pre-flight]
-    if: ${{ contains('docs L0 L1 L2', needs.pre-flight.outputs.test_level) }}
+    if: >-
+      ${{
+        (
+          always() &&
+          contains('docs L0 L1 L2', needs.pre-flight.outputs.test_level) &&
+          needs.pre-flight.result == 'success' &&
+          (needs.build-container.result == 'success' || needs.build-container.result == 'skipped')
+        ) && !cancelled()
+      }}
     runs-on: ${{ matrix.runner }}
     name: ${{ matrix.is_optional && 'PLEASEFIXME_' || '' }}${{ matrix.script }}
     environment: nemo-ci
@@ -321,6 +329,7 @@ jobs:
           runner: ${{ runner.name }}
           registry: ${{ needs.org-member-pre-flight.outputs.registry }}
           image: ${{ vars.CI_CONTAINER_NAME }}
+          image-tag: ${{ needs.pre-flight.outputs.image_tag }}
           test_data_path: ${{ needs.org-member-pre-flight.outputs.test_data_path }}
           script: ${{ matrix.script }}
           is_doc_test: "true"


### PR DESCRIPTION
## Summary
- **CI:docs** now reuses the latest main container instead of building a new one, matching **CI:Lfast** behavior
- This avoids the slow container build (especially due to sglang) for doc-only test runs
- The cicd-doc-tests job now passes image-tag to the test template, which triggers FAST=1 mode (prefetches venvs + regenerates fingerprint upfront)

## What changed
1. IMAGE_TAG is set to "main" when TEST_LEVEL is "docs", causing build-container to be skipped
2. cicd-doc-tests job if-condition updated to handle build-container being skipped (using always() pattern like cicd-unit-tests)
3. cicd-doc-tests now passes image-tag to the test template

## Test plan
- [ ] Apply CI:docs label to this PR and verify container build is skipped
- [ ] Verify doc tests still run successfully using the main container
- [ ] Verify CI:L0/CI:L1 still builds the container and runs doc tests as before

Closes RL-7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to enhance test reliability and optimize container resource reuse across documentation tests. Improved image tag resolution and job gating conditions to ensure dependencies are properly met before test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->