### PR TITLE
fix: fix async grpo offload

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -2817,6 +2817,7 @@ def async_grpo_train(
                             "seq_logprob_error_threshold"
                         ],
                     )
+
                 # Compute advantages with adv_estimator using correct mask and logprobs
                 with timer.time("advantage_calculation"):
                     print("▶ Computing advantages...", flush=True)
@@ -3012,8 +3013,6 @@ def async_grpo_train(
                 if master_config["checkpointing"]["enabled"] and (
                     should_save_by_step or should_save_by_timeout
                 ):
-                    policy.prepare_for_training()
-
                     grpo_save_state["current_step"] = step + 1
                     grpo_save_state["total_valid_tokens"] = total_valid_tokens
                     if val_metrics is not None:
@@ -3077,7 +3076,6 @@ def async_grpo_train(
                             os.path.join(checkpoint_path, "train_dataloader.pt"),
                         )
                         checkpointer.finalize_checkpoint(checkpoint_path)
-                    policy.offload_after_refit()
 
             # Logging
             # Log training data (match sync GRPO logging payload for parity)

--- a/tests/functional/grpo_async_gym.sh
+++ b/tests/functional/grpo_async_gym.sh
@@ -19,6 +19,9 @@ export PYTHONPATH=${PROJECT_ROOT}:${PYTHONPATH:-}
 rm -rf $EXP_DIR $LOG_DIR
 mkdir -p $EXP_DIR $LOG_DIR $CHECKPOINT_DIR $DATA_DIR
 
+# clean up checkpoint directory on exit
+trap "rm -rf $CHECKPOINT_DIR" EXIT
+
 cd $PROJECT_ROOT
 
 # Follow nemo-gym instructions here to get this data:
@@ -72,6 +75,7 @@ uv run coverage run -a --data-file=$PROJECT_ROOT/tests/.coverage --source=$PROJE
     grpo.num_prompts_per_step=4 \
     grpo.num_generations_per_prompt=2 \
     grpo.max_num_steps=10 \
+    grpo.val_period=5 \
     grpo.async_grpo.enabled=true \
     grpo.async_grpo.max_trajectory_age_steps=1 \
     grpo.async_grpo.in_flight_weight_updates=true \
@@ -83,7 +87,8 @@ uv run coverage run -a --data-file=$PROJECT_ROOT/tests/.coverage --source=$PROJE
     logger.log_dir=$LOG_DIR \
     logger.wandb_enabled=false \
     logger.monitor_gpus=true \
-    checkpointing.enabled=false \
+    checkpointing.enabled=true \
+    checkpointing.save_period=5 \
     checkpointing.checkpoint_dir=$CHECKPOINT_DIR \
     data.train.data_path=$TRAIN_PATH \
     data.validation.data_path=$VALIDATION_PATH \
@@ -94,4 +99,5 @@ uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
 
 # Observed to be between 0.8-1.3
 uv run tests/check_metrics.py $JSON_METRICS \
-    'median(data["train/gen_kl_error"]) < 1.3'
+    'median(data["train/gen_kl_error"]) < 1.3' \
+    'data["validation/accuracy"]["10"] > 0.1'


### PR DESCRIPTION
If checkpointing is enabled and offload_optimizer_for_logprob is set to False, async grpo will get error like below after saving checkpoint.
Related: https://github.com/NVIDIA-NeMo/RL/pull/2118

This PR fixes this by removing on-load/off-load before and after saving checkpoint.

For async grpo case:
1. It always uses non-colocated.
2. Only setting `offload_optimizer_for_logprob=true` will offload optimizer before calculating logprobs and on-load after calculating logprobs (before train), on-load/offload is not needed in other places.
3. Model params and optimizers should be at GPU before saving ckpt, so `prepare_for_training` before saving ckpt isn't needed.

```
# in megatron
torch.AcceleratorError: CUDA error: an illegal memory access was encountered

# in dtensor
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

cc @nbasyl @binhu-nv 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes / Optimizations**
  * Streamlined async GRPO training flow by removing unnecessary pre-checkpoint preparation and post-refit weight transfer operations.

* **Tests**
  * Enhanced async GRPO training tests with periodic validation checks and improved metrics verification during training execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->