### PR TITLE
fix: fix sft-openmathinstruct2

### DIFF
--- a/docs/guides/sft-openmathinstruct2.md
+++ b/docs/guides/sft-openmathinstruct2.md
@@ -4,7 +4,7 @@ This guide explains how to use NeMo RL to run SFT on the [nvidia/OpenMathInstruc
 
 
 ## Train the Model
-To train the model using NeMo RL, use the `examples/configs/recipes/tutorials/sft/sft_openmathinstruct2.yaml` config file. This file closely matches the experiment settings in the [original OpenMathInstruct-2 paper](https://arxiv.org/abs/2410.01560).
+To train the model using NeMo RL, use the `examples/configs/sft_openmathinstruct2.yaml` config file. This file closely matches the experiment settings in the [original OpenMathInstruct-2 paper](https://arxiv.org/abs/2410.01560).
 
 ```
 uv run examples/run_sft.py --config=examples/configs/sft_openmathinstruct2.yaml

--- a/examples/configs/sft_openmathinstruct2.yaml
+++ b/examples/configs/sft_openmathinstruct2.yaml
@@ -1,114 +1,49 @@
-# SFT Algorithm Configuration
+defaults: sft.yaml
 sft:
-  max_num_epochs: 1
   max_num_steps: 1000000
   val_period: 500
   val_batches: 4
   val_global_batch_size: 128
   val_micro_batch_size: 2
-  val_at_start: true
-  val_at_end: false
-  seed: 42
-
 checkpointing:
-  enabled: true
-  checkpoint_dir: "results/sft_openmathinstruct2"
-  metric_name: "val:val_loss" # one of "val:" or "train:" followed by the metric name
-  higher_is_better: false
+  checkpoint_dir: results/sft_openmathinstruct2
   keep_top_k: 100
   save_period: 500
-  checkpoint_must_save_by: null
-
 policy:
-  model_name: "meta-llama/Llama-3.1-8B"
+  model_name: meta-llama/Llama-3.1-8B
   tokenizer:
-    name: meta-llama/Llama-3.1-8B-Instruct ## specify if you'd like to use a tokenizer different from the model's default
+    name: meta-llama/Llama-3.1-8B-Instruct
   train_global_batch_size: 512
   train_micro_batch_size: 2
   max_total_sequence_length: 4096
-  precision: "bfloat16"
-
-  offload_optimizer_for_logprob: false
-
   dtensor_cfg:
-    enabled: true
-    cpu_offload: False
-    sequence_parallel: false
-    activation_checkpointing: false
     tensor_parallel_size: 4
-    context_parallel_size: 1
-    custom_parallel_plan: null
-
-  megatron_cfg:
-    enabled: false
-
-  dynamic_batching:
-    enabled: false
-
-  sequence_packing:
-    enabled: false
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    algorithm: "modified_first_fit_decreasing"
-    sequence_length_round: 64
-
-  # makes the training sequence length divisible by the tensor parallel size
-  # this is useful for sequence parallel training
-  make_sequence_length_divisible_by: ${policy.dtensor_cfg.tensor_parallel_size}
   max_grad_norm: null
-
   optimizer:
-    name: "torch.optim.AdamW"
     kwargs:
-      lr: 2e-5
+      lr: 2.0e-05
       weight_decay: 0.01
-      betas: [0.9, 0.98]
-      eps: 1e-8
-      # when using Dtensor, we need to set foreach
-      # and fused to False
-      foreach: False
-      fused: False
-
+      eps: 1.0e-08
 data:
-  max_input_seq_length: ${policy.max_total_sequence_length}
-  add_bos: true
-  add_eos: true
   add_generation_prompt: true
-  shuffle: true
-
-  # dataset
   train:
     dataset_name: OpenMathInstruct-2
     output_key: generated_solution
     split: train_1M
-    split_validation_size: 0.05 # use 5% of the training data as validation data
-    seed: ${sft.seed} # seed for train/validation split when split_validation_size > 0
+    split_validation_size: 0.05
+    seed: ${sft.seed}
   validation: null
-  # default settings for all datasets
   default:
     prompt_file: examples/prompts/math.txt
-
 logger:
-  log_dir: "logs"  # Base directory for all logs
-  wandb_enabled: true # Make sure you do a ``wandb login [Your API key]'' before running
-  tensorboard_enabled: true
-  mlflow_enabled: false
-  swanlab_enabled: false # Disable SwanLab logging
-  monitor_gpus: false  # If true, will monitor GPU usage and log to wandb and/or tensorboard
+  monitor_gpus: false
   wandb:
-    project: "sft-dev"
-    name: "openmathinstruct-nemorl-1M_train"
+    name: openmathinstruct-nemorl-1M_train
   swanlab:
-    project: "sft-dev"
-    name: "openmathinstruct-nemorl-1M_train"
+    name: openmathinstruct-nemorl-1M_train
   tensorboard:
-    log_dir: "tb_logs-openmathinstruct-nemorl-1M_train"
+    log_dir: tb_logs-openmathinstruct-nemorl-1M_train
   mlflow:
-    experiment_name: "sft-dev"
-    run_name: "openmathinstruct-nemorl-1M_train"
-  gpu_monitoring:
-    collection_interval: 10  # How often to collect GPU usage metrics (in seconds)
-    flush_interval: 10  # How often to flush GPU usage metrics to the loggers (in seconds)
-
+    run_name: openmathinstruct-nemorl-1M_train
 cluster:
   gpus_per_node: 8
-  num_nodes: 1

--- a/examples/configs/sft_openmathinstruct2_megatron.yaml
+++ b/examples/configs/sft_openmathinstruct2_megatron.yaml
@@ -1,164 +1,44 @@
-# SFT Algorithm Configuration
 defaults: sft_openmathinstruct2.yaml
-
 sft:
-  max_num_epochs: 1
-  max_num_steps: 1000000
-  val_period: 500
-  val_batches: 4
-  val_global_batch_size: 128
   val_micro_batch_size: 1
-  val_at_start: true
-  val_at_end: false
-  seed: 42
-
-checkpointing:
-  enabled: true
-  checkpoint_dir: "results/sft_openmathinstruct2"
-  metric_name: "val:val_loss" # one of "val:" or "train:" followed by the metric name
-  higher_is_better: false
-  keep_top_k: 100
-  save_period: 500
-
 policy:
-  model_name: "meta-llama/Llama-3.1-8B"
-  tokenizer:
-    name: meta-llama/Llama-3.1-8B-Instruct
-  train_global_batch_size: 512
   train_micro_batch_size: 1
-  max_total_sequence_length: 4096
-  precision: "bfloat16"
-
   dtensor_cfg:
     enabled: false
-
   megatron_cfg:
-    activation_checkpointing: false
-    context_parallel_size: 1
     distributed_data_parallel_config:
-      data_parallel_sharding_strategy: optim_grads_params
       grad_reduce_in_fp32: true
-      overlap_grad_reduce: true
-      overlap_param_gather: true
-      use_custom_fsdp: false
-    empty_unused_memory_level: 1
     enabled: true
-    expert_tensor_parallel_size: 1
-    expert_model_parallel_size: 1
-    num_layers_in_first_pipeline_stage: null
-    num_layers_in_last_pipeline_stage: null
     optimizer:
-      adam_beta1: 0.9
-      adam_beta2: 0.98
-      adam_eps: 1.0e-8
-      bf16: true
+      adam_eps: 1.0e-08
       clip_grad: 0
-      fp16: false
-      lr: 0.00002
-      min_lr: 0.00002
-      optimizer: adam
+      lr: 2.0e-05
+      min_lr: 2.0e-05
       params_dtype: bfloat16
-      sgd_momentum: 0.9
-      use_distributed_optimizer: true
-      use_precision_aware_optimizer: false #true ## TODO: precision aware optim not working with fp8. Is this expected?
+      use_precision_aware_optimizer: false
       weight_decay: 0.01
-
-      # optimizer cpu offload
-      optimizer_cpu_offload: false
-      optimizer_offload_fraction: 0.0
-
-      ## recently introduced, our current mcore commit doesn't have this
-      #fp8_recipe: delayed
-
     pipeline_dtype: bfloat16
-    pipeline_model_parallel_size: 1
     scheduler:
       end_weight_decay: 0.01
-      lr_decay_iters: 1000
-      lr_decay_style: constant
-      lr_warmup_init: 0.00001999999
+      lr_warmup_init: 1.999999e-05
       lr_warmup_iters: 1
       start_weight_decay: 0.01
-      weight_decay_incr_style: constant
-    sequence_parallel: false
-    tensor_model_parallel_size: 4 ## TODO: should not need this large TP size
-
+    tensor_model_parallel_size: 4
     freeze_moe_router: true
-    moe_router_dtype: "fp64"
-    moe_router_load_balancing_type: "none" # "seq_aux_loss" causes logprob error divergence for grpo
-    moe_router_bias_update_rate: 0.0 # by default, disable bias updates for grpo
-    moe_permute_fusion: false
-    #gives ~20% training perf speedup with sequence packing
-    apply_rope_fusion: True
-    # gives ~25% training perf speedup with sequence packing and apply_rope_fusion
-    bias_activation_fusion: True
-    moe_per_layer_logging: False
-    moe_enable_deepep: false
-    moe_token_dispatcher_type: "alltoall"
-    moe_shared_expert_overlap: false
+    moe_router_dtype: fp64
+    moe_router_load_balancing_type: none
+    moe_router_bias_update_rate: 0.0
     peft:
-      enabled: false
-      target_modules: []
-      exclude_modules: []
-      dim: 8
-      alpha: 32
-      dropout: 0.0
-      dropout_position: "post"
-      lora_A_init_method: "xavier"
-      lora_B_init_method: "zero"
-      a2a_experimental: false
       lora_dtype: null
-
     env_vars:
-      PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:False"
-
-    fp8_cfg:
-      enabled: false
-      fp8: "e4m3"
-      fp8_recipe: "blockwise"
-      fp8_param: false
-
-  dynamic_batching:
-    enabled: false
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    sequence_length_round: 64
-
-
+      PYTORCH_CUDA_ALLOC_CONF: expandable_segments:False
   sequence_packing:
-    enabled: True
-    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
-    algorithm: "modified_first_fit_decreasing"
-    sequence_length_round: 64
-
-  # makes the training sequence length divisible by the tensor parallel size
-  # this is useful for sequence parallel training
+    enabled: true
   make_sequence_length_divisible_by: ${mul:16, ${policy.megatron_cfg.tensor_model_parallel_size}}
-  max_grad_norm: null
-
   optimizer: null
-
-data:
-  num_workers: 1
-
 logger:
-  log_dir: "logs"  # Base directory for all logs
-  wandb_enabled: true # Make sure you do a ``wandb login [Your API key]'' before running
-  tensorboard_enabled: true
-  mlflow_enabled: false
-  monitor_gpus: false  # If true, will monitor GPU usage and log to wandb and/or tensorboard
   wandb:
-    project: "sft-openmathinstruct-megatron"
-    name: "llama8b"
-  tensorboard:
-    log_dir: "tb_logs-openmathinstruct-nemorl-1M_train"
-  mlflow:
-    experiment_name: "sft-dev"
-    run_name: "openmathinstruct-nemorl-1M_train"
-  gpu_monitoring:
-    collection_interval: 10  # How often to collect GPU usage metrics (in seconds)
-    flush_interval: 10  # How often to flush GPU usage metrics to the loggers (in seconds)
-
+    project: sft-openmathinstruct-megatron
+    name: llama8b
 cluster:
-  gpus_per_node: 8
   num_nodes: 2
-                                                  


### PR DESCRIPTION
Fix `examples/configs/sft_openmathinstruct2.yaml` and `examples/configs/sft_openmathinstruct2_megatron.yaml` using incorrect data_processor by inheriting from `sft.yaml`.

Closes https://github.com/NVIDIA-NeMo/RL/issues/2074.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated training configuration documentation path reference.

* **Chores**
  * Simplified and reorganized supervised fine-tuning configuration examples to streamline training setup options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->