### PR TITLE
chore: test FW-CI-templates ko3n1g/fix/linkcheck-retry-backoff

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -80,7 +80,7 @@ on:
 
 jobs:
   build-docs:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@ko3n1g/fix/linkcheck-retry-backoff
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@v0.80.2
     with:
       ref: ${{ inputs.github-ref }}
 


### PR DESCRIPTION
## Summary
- Bumps \`NVIDIA-NeMo/FW-CI-templates\` reference in docs workflow from previous version to \`ko3n1g/fix/linkcheck-retry-backoff\`
- This branch includes retry with exponential backoff for Sphinx linkcheck to handle transient failures

## Test plan
- [ ] Verify the \`build-docs\` workflow triggers and passes after this bump

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation build workflow configuration to use an updated template version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->