### PR TITLE
fix: fix make_sequence_length_divisible_by in config

### DIFF
--- a/examples/configs/recipes/llm/grpo-dapomath17k-dsv3-32n4g-megatron.yaml
+++ b/examples/configs/recipes/llm/grpo-dapomath17k-dsv3-32n4g-megatron.yaml
@@ -7,7 +7,7 @@ policy:
     context_parallel_size: 2
     num_layers_in_first_pipeline_stage: 15
     num_layers_in_last_pipeline_stage: 14
-  make_sequence_length_divisible_by: 4
+  make_sequence_length_divisible_by: 16
   generation:
     vllm_cfg:
       tensor_parallel_size: 16

--- a/examples/configs/recipes/llm/grpo-dapomath17k-dsv3-megatron.yaml
+++ b/examples/configs/recipes/llm/grpo-dapomath17k-dsv3-megatron.yaml
@@ -15,7 +15,8 @@ policy:
   max_total_sequence_length: 16384
   dtensor_cfg:
     enabled: false
-  make_sequence_length_divisible_by: ${policy.megatron_cfg.tensor_model_parallel_size}
+  make_sequence_length_divisible_by: ${mul:${policy.megatron_cfg.tensor_model_parallel_size},
+    ${mul:2, ${policy.megatron_cfg.context_parallel_size}}}
   optimizer: null
   megatron_cfg:
     enabled: true

--- a/examples/configs/recipes/llm/grpo-gptoss-20b-8n4g-megatron.yaml
+++ b/examples/configs/recipes/llm/grpo-gptoss-20b-8n4g-megatron.yaml
@@ -3,6 +3,7 @@ policy:
   megatron_cfg:
     expert_model_parallel_size: 4
     tensor_model_parallel_size: 2
+  make_sequence_length_divisible_by: 2
   generation:
     vllm_cfg:
       tensor_parallel_size: 1

--- a/examples/configs/recipes/llm/grpo-gptoss-20b-8n8g-megatron.yaml
+++ b/examples/configs/recipes/llm/grpo-gptoss-20b-8n8g-megatron.yaml
@@ -14,6 +14,7 @@ policy:
     tensor_model_parallel_size: 4
     sequence_parallel: true
     moe_permute_fusion: true
+  make_sequence_length_divisible_by: 4
   dtensor_cfg:
     enabled: false
   sequence_packing:

--- a/examples/configs/recipes/llm/grpo-nano-v2-12b-1n8g-megatron.yaml
+++ b/examples/configs/recipes/llm/grpo-nano-v2-12b-1n8g-megatron.yaml
@@ -14,7 +14,7 @@ policy:
     tensor_model_parallel_size: 8
   dtensor_cfg:
     enabled: false
-  make_sequence_length_divisible_by: 1
+  make_sequence_length_divisible_by: 8
   generation:
     max_new_tokens: 512
     vllm_cfg:

--- a/examples/configs/recipes/llm/performance/dapo-deepseek-v3-64n8g.yaml
+++ b/examples/configs/recipes/llm/performance/dapo-deepseek-v3-64n8g.yaml
@@ -38,8 +38,8 @@ policy:
   max_total_sequence_length: 1536
   dtensor_cfg:
     enabled: false
-  make_sequence_length_divisible_by: ${mul:${policy.dtensor_cfg.tensor_parallel_size},
-    ${mul:2, ${policy.dtensor_cfg.context_parallel_size}}}
+  make_sequence_length_divisible_by: ${mul:${policy.megatron_cfg.tensor_model_parallel_size},
+    ${mul:2, ${policy.megatron_cfg.context_parallel_size}}}
   megatron_cfg:
     empty_unused_memory_level: 2
     enabled: true

--- a/examples/configs/recipes/llm/performance/grpo-qwen3-235b-16n8g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-qwen3-235b-16n8g.yaml
@@ -16,7 +16,7 @@ policy:
   train_micro_batch_size: 1
   logprob_batch_size: 1
   max_total_sequence_length: 8192
-  make_sequence_length_divisible_by: 1
+  make_sequence_length_divisible_by: 8
   dtensor_cfg:
     enabled: false
   megatron_cfg:

--- a/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n8g-40K.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n8g-40K.yaml
@@ -13,7 +13,8 @@ policy:
     enabled: false
   optimizer: null
   scheduler: null
-  make_sequence_length_divisible_by: ${policy.megatron_cfg.tensor_model_parallel_size}
+  make_sequence_length_divisible_by: ${mul:${policy.megatron_cfg.tensor_model_parallel_size},
+    ${mul:2, ${policy.megatron_cfg.context_parallel_size}}}
   megatron_cfg:
     enabled: true
     empty_unused_memory_level: 1


### PR DESCRIPTION
https://github.com/NVIDIA-NeMo/RL/pull/2053 makes megatron respect to `policy.make_sequence_length_divisible_by`, but some configs are missing to update this param. This PR fixes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Updated sequence length alignment configurations in multiple training recipe files to optimize model training performance across different hardware configurations and parallelization strategies. Changes include increased alignment divisor values in several configurations and new dynamic calculation expressions that incorporate tensor and context parallelization factors to ensure proper sequence handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->