### PR TITLE
feat: add set_learning_rate RPC to DTensorPolicyWorkerV2

### DIFF
--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -1054,6 +1054,12 @@ class DTensorPolicyWorkerV2Impl(AbstractPolicyWorker, ColocatablePolicyInterface
             f"GPU Memory after optimizer offload: {allocated:.2f}GB allocated, {reserved:.2f}GB reserved"
         )
 
+    def set_learning_rate(self, learning_rate: float) -> None:
+        """Set the learning rate on the optimizer's param groups."""
+        if self.optimizer is not None:
+            for pg in self.optimizer.param_groups:
+                pg["lr"] = learning_rate
+
     def move_optimizer_to_device(self, device: str | torch.device) -> None:
         for state in self.optimizer.state.values():
             for k, v in state.items():


### PR DESCRIPTION


# What does this PR do ?

Enables external orchestrators (service built on nemo RL) to dynamically set the optimizer learning rate on DTensor policy workers via run_all_workers_single_data("set_learning_rate", learning_rate=1e-5).

# Issues
 Without this, the LR is fixed at Policy init time and cannot be overridden per training step. Training frameworks that pass LR via optimizer step params (like Tinker's adam_params.learning_rate) had no way to propagate it to NeMo RL workers.

# Usage
* **You can potentially add a usage example below**

```python
       futures = policy.worker_group.run_all_workers_single_data(
           "set_learning_rate",
            learning_rate=learning_rate,
         )

       ray.get(futures)
       logger.info("Set learning rate to %s", learning_rate)
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ x ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to dynamically update the optimizer's learning rate during training.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->