### PR TITLE
ci: run doc tests for Lfast label

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -313,7 +313,7 @@ jobs:
       ${{
         (
           always() &&
-          contains('docs L0 L1 L2', needs.pre-flight.outputs.test_level) &&
+          contains('docs Lfast L0 L1 L2', needs.pre-flight.outputs.test_level) &&
           needs.pre-flight.result == 'success' &&
           (needs.build-container.result == 'success' || needs.build-container.result == 'skipped')
         ) && !cancelled()


### PR DESCRIPTION
## Summary
- Add `Lfast` to the `cicd-doc-tests` job condition so doc tests also run when the `CI:Lfast` label is used
- This reuses the `main` container image (same as the existing Lfast fast path for unit/functional tests)

## Test plan
- [ ] Apply `CI:Lfast` label to a PR and verify doc tests run alongside unit and fast functional tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)