### PR TITLE
fix: skip_reference_policy_logprobs_calculation=true crashes training

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1769,6 +1769,10 @@ def grpo_train(
                                 timer=timer,
                             )["reference_logprobs"]
                         )
+                    else:
+                        train_data["reference_policy_logprobs"] = torch.zeros_like(
+                            train_data["prev_logprobs"]
+                        )
 
                     del logprob_data
                     del extra_multimodal_data
@@ -2799,12 +2803,18 @@ def async_grpo_train(
                         train_data,
                         timer=timer,
                     )["logprobs"]
-                    reference_logprobs = policy.get_reference_policy_logprobs(
-                        train_data,
-                        timer=timer,
-                    )["reference_logprobs"]
                     train_data["prev_logprobs"] = fprop_logprobs
-                    train_data["reference_policy_logprobs"] = reference_logprobs
+
+                    if not master_config["grpo"].get(
+                        "skip_reference_policy_logprobs_calculation"
+                    ):
+                        reference_logprobs = policy.get_reference_policy_logprobs(
+                            train_data,
+                            timer=timer,
+                        )["reference_logprobs"]
+                        train_data["reference_policy_logprobs"] = reference_logprobs
+                    else:
+                        train_data["reference_policy_logprobs"] = torch.zeros_like(fprop_logprobs)
 
                     (
                         max_seq_mult_prob_error,

--- a/nemo_rl/models/policy/workers/base_policy_worker.py
+++ b/nemo_rl/models/policy/workers/base_policy_worker.py
@@ -139,6 +139,15 @@ class AbstractPolicyWorker:
           We use the convention that the logprob of the first token is 0 so that the sequence length is maintained.
           The logprob of input token i is specified at position i in the output logprobs tensor.
         """
+        # When reference model was never initialized (e.g.,
+        # skip_reference_policy_logprobs_calculation=true), return zeros
+        # matching the expected shape to avoid crashes downstream.
+        if not self._has_reference_model():
+            logprobs = self.get_logprobs(data=data, micro_batch_size=micro_batch_size)
+            return_data = BatchedDataDict[ReferenceLogprobOutputSpec]()
+            return_data["reference_logprobs"] = torch.zeros_like(logprobs["logprobs"]).cpu()
+            return return_data
+
         with self.use_reference_model():
             reference_logprobs = self.get_logprobs(
                 data=data, micro_batch_size=micro_batch_size
@@ -147,6 +156,15 @@ class AbstractPolicyWorker:
         return_data = BatchedDataDict[ReferenceLogprobOutputSpec]()
         return_data["reference_logprobs"] = reference_logprobs["logprobs"].cpu()
         return return_data
+
+    def _has_reference_model(self) -> bool:
+        """Check if a reference model has been initialized."""
+        # DTensor v2 uses reference_model_state_dict, others use reference_state_dict
+        for attr in ("reference_model_state_dict", "reference_state_dict"):
+            val = getattr(self, attr, None)
+            if val is not None:
+                return True
+        return False
 
     def finish_training(self, *args: Any, **kwargs: Any) -> None:
         # Placeholder implementation

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -1667,6 +1667,11 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
                   is different from the current policy, making filtered logprobs incompatible.
         On exit: Restores original references and re-flips cuda/cpu, restores sampling_params.
         """
+        # If reference model was never initialized, yield without swapping
+        if not hasattr(self, "reference_model_state_dict") or self.reference_model_state_dict is None:
+            yield
+            return
+
         with torch.no_grad():
             # Save train model state_dict
             curr_state_dict = get_cpu_state_dict(

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -785,6 +785,11 @@ class DTensorPolicyWorkerV2Impl(AbstractPolicyWorker, ColocatablePolicyInterface
                   is different from the current policy, making filtered logprobs incompatible.
         On exit: Restores original references and re-flips cuda/cpu, restores sampling_params.
         """
+        # If reference model was never initialized, yield without swapping
+        if not hasattr(self, "reference_model_state_dict") or self.reference_model_state_dict is None:
+            yield
+            return
+
         with torch.no_grad():
             # Save train model state_dict
             curr_state_dict = get_cpu_state_dict(

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -534,6 +534,11 @@ class MegatronPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface)
                   is different from the current policy, making filtered logprobs incompatible.
         On exit: Restores original references and re-flips cuda/cpu, restores sampling_params.
         """
+        # If reference model was never initialized, yield without swapping
+        if not hasattr(self, "reference_state_dict") or self.reference_state_dict is None:
+            yield
+            return
+
         ## disable overlap param gather when swapping weights
         if self.should_disable_forward_pre_hook:
             self.disable_forward_pre_hook()


### PR DESCRIPTION
# What does this PR do ?

## Summary

Setting `skip_reference_policy_logprobs_calculation=true` in GRPO config crashes because:
1. `reference_policy_logprobs` is never assigned to `train_data` when skipped
2. `use_reference_model()` context manager crashes when no reference state dict exists

Fixes NVIDIA-NeMo/RL#1968

## Root Cause

Three code paths needed fixes:
1. **`grpo.py` sync path**: missing `train_data["reference_policy_logprobs"]` assignment
2. **`grpo.py` async path**: same
3. **Policy workers**: `use_reference_model()` tries to swap non-existent state dicts

## Fix

1. When skip is enabled, assign `torch.zeros_like(prev_logprobs)` to `reference_policy_logprobs`
2. Added `_has_reference_model()` base method
3. In `get_reference_policy_logprobs()`: return zeros if no reference model
4. In all three worker `use_reference_model()` context managers: yield without swapping if no reference state dict

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):
https://github.com/NVIDIA-NeMo/RL/issues/1968

# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
