### PR TITLE
fix: align sequence_length_pad_multiple in lm_policy

### DIFF
--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -278,9 +278,7 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
 
         if config["sequence_packing"]["enabled"]:
             self.use_sequence_packing = True
-            sequence_length_pad_multiple = (
-                cp_size * 2 * tp_size if cp_size > 1 else tp_size
-            )
+            sequence_length_pad_multiple = config["make_sequence_length_divisible_by"]
             self.sequence_packing_args: SequencePackingArgs = {
                 "algorithm": config["sequence_packing"]["algorithm"],
                 "input_key": "input_ids",


### PR DESCRIPTION
## Summary
Fix a crash in Megatron sequence packing when `sequence_length_pad_multiple != make_sequence_length_divisible_by`.

## Problem
`sequence_length_pad_multiple` was computed as `tp_size` when `cp_size=1`, but `pack_sequences` actually pads each sequence to `make_sequence_length_divisible_by = tp_size*2` which is defined in the config.
This mismatch causes the actual packed total to exceed `pad_packed_seq_to`, resulting in a crash at unpack time:
```
RuntimeError: The expanded size of the tensor (517) must match the existing size (502)
```

## Fix
Replace `cp_size * 2 * tp_size if cp_size > 1 else tp_size` with `config["make_sequence_length_divisible_by"]` so both sides use the same padding factor. Safe for DTensor: when `cp=1` bins become slightly more conservative but DTensor does not apply per-sequence alignment padding during packing.

## Test plan
- [x] `distillation-qwen3-32b-to-1.7b-base-1n4g-megatron-tp1pp2cp2-pack` — previously crashed, now completes successfully.