### PR TITLE
fix: add Gym submodule to git safe.directory in CI

### DIFF
--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -140,6 +140,7 @@ runs:
           --volume ${{ inputs.test_data_path }}/nemo-rl/hf_datasets_cache:/home/TestData/nemo-rl/hf_datasets_cache \
           ${{ inputs.registry }}/${{ inputs.image }}:${{ inputs.image-tag || github.run_id }} bash -eux -o pipefail -c '\
             git config --global --add safe.directory /opt/nemo-rl
+            git config --global --add safe.directory /opt/nemo-rl/3rdparty/Gym-workspace/Gym
             # This is needed since we create virtualenvs in the workspace, so this allows it to be cleaned up if necessary
             umask 000
             # When reusing a pre-built container (FAST=1), prefetch venvs and regenerate the


### PR DESCRIPTION
## Summary

Fixes git ownership issue when building `nemo-gym` in CI containers for external contributors.

## Problem

Since January 2026 (PR #1773), the Gym submodule uses `setuptools-scm` which requires git access during package builds. In CI Docker containers:
- Container runs as root
- Repository files are mounted with different ownership
- Git 2.35.2+ blocks access to repos with ownership mismatch (security feature)
- Build fails: `fatal: detected dubious ownership in repository at '/opt/nemo-rl/3rdparty/Gym-workspace/Gym'`

## Solution

Add the Gym submodule directory to git's `safe.directory` config, consistent with the existing pattern for the main repo (line 142).

## Risk Assessment

**Low Risk:**
- CI runs in isolated, ephemeral Docker containers
- Submodule updates go through PR review process
- Consistent with existing pattern for main repo
- Only affects read-only git operations for versioning

## Testing

- [x] Fixes test failures: https://github.com/NVIDIA-NeMo/RL/actions/runs/23744949284/job/69171205398?pr=2137
https://github.com/NVIDIA-NeMo/RL/actions/runs/23680116283/job/68994254946 
- [x] Consistent with existing `safe.directory` pattern
- [x] No security regression (submodule updates still require review)

## Related Issues

Resolves build failures in functional tests that use nemo-gym.

🤖 Generated with [Claude Code](https://claude.com/claude-code)