### PR TITLE
fix: NVML memory query fallback for DGX Spark

### DIFF
--- a/nemo_rl/utils/nvml.py
+++ b/nemo_rl/utils/nvml.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import contextlib
+import logging
 import os
 from typing import Generator
 
 import pynvml
+
+logger = logging.getLogger(__name__)
 
 
 @contextlib.contextmanager
@@ -78,13 +81,16 @@ def get_device_uuid(device_idx: int) -> str:
 
 
 def get_free_memory_bytes(device_idx: int) -> float:
-    """Get the free memory of a CUDA device in bytes using NVML."""
+    """Get the free memory of a CUDA device in bytes using NVML, with torch.cuda fallback."""
     global_device_idx = device_id_to_physical_device_id(device_idx)
     with nvml_context():
         try:
             handle = pynvml.nvmlDeviceGetHandleByIndex(global_device_idx)
             return pynvml.nvmlDeviceGetMemoryInfo(handle).free
         except pynvml.NVMLError as e:
-            raise RuntimeError(
-                f"Failed to get free memory for device {device_idx} (global index: {global_device_idx}): {e}"
-            )
+            logger.warning("NVML memory query failed for device %d: %s. Falling back to torch.cuda.mem_get_info.", device_idx, e)
+
+    import torch
+
+    free, _total = torch.cuda.mem_get_info(device_idx)
+    return free


### PR DESCRIPTION
## Problem

Running GRPO training on NVIDIA DGX Spark (`examples/run_grpo.py`) crashes during weight refit because `nvmlDeviceGetMemoryInfo` is not supported on GB10:

```
pynvml.NVMLError_NotSupported: Not Supported

RuntimeError: Failed to get free memory for device 0 (global index: 0): Not Supported
```

Tested with the latest `nvidia-ml-py==13.595.45` — same error.

## Fix

Fall back to `torch.cuda.mem_get_info()` when the NVML call fails. This API works on all CUDA devices including DGX Spark.

