### PR TITLE
chore: add HFC cluster container setup and launch scripts

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,0 +1,216 @@
+# syntax=docker/dockerfile:1
+# Usage:
+#   Self-contained build (default: builds from main):
+#     docker buildx build -f docker/Dockerfile --tag <registry>/nemo-rl:latest --push .
+#
+#   Self-contained build (specific git ref):
+#     docker buildx build -f docker/Dockerfile --build-arg NRL_GIT_REF=r0.3.0 --tag <registry>/nemo-rl:r0.3.0 --push .
+#
+#   Self-contained build (remote NeMo RL source; no need for a local clone of NeMo RL):
+#     docker buildx build -f docker/Dockerfile --build-arg NRL_GIT_REF=r0.3.0 --tag <registry>/nemo-rl:r0.3.0 --push https://github.com/NVIDIA-NeMo/RL.git
+#
+#   Local NeMo RL source override:
+#     docker buildx build --build-context nemo-rl=. -f docker/Dockerfile --tag <registry>/nemo-rl:latest --push .
+#
+# Optional build args to skip vLLM or SGLang dependencies:
+#   --build-arg SKIP_VLLM_BUILD=1    # Skip vLLM dependencies
+#   --build-arg SKIP_SGLANG_BUILD=1  # Skip SGLang dependencies
+
+ARG BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.05-cuda12.9-devel-ubuntu24.04
+FROM scratch AS nemo-rl
+ARG NRL_GIT_REF=main
+ADD --keep-git-dir=true https://github.com/NVIDIA-NeMo/RL.git#${NRL_GIT_REF} /
+
+FROM ${BASE_IMAGE} AS base
+# An environment variable to indicate that we are in a container.
+ENV NRL_CONTAINER=1
+
+# It is more convenient for users to run as root
+USER root
+
+RUN <<"EOF" bash -exu -o pipefail
+export DEBIAN_FRONTEND=noninteractive
+export TZ=America/Los_Angeles
+
+apt-get update
+apt-get install -y --no-install-recommends \
+    jq \
+    curl \
+    git \
+    rsync \
+    wget \
+    less \
+    vim \
+
+# Nsight
+apt install -y --no-install-recommends gnupg
+echo "deb http://developer.download.nvidia.com/devtools/repos/ubuntu$(source /etc/lsb-release; echo "$DISTRIB_RELEASE" | tr -d .)/$(dpkg --print-architecture) /" | tee /etc/apt/sources.list.d/nvidia-devtools.list
+apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/$(uname -m | sed 's/aarch64/sbsa/')/7fa2af80.pub
+apt update
+apt install -y nsight-systems-cli
+
+# To fix CVE-2025-68973
+apt install -y --only-upgrade gnupg
+
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+EOF
+
+# CMake (for sglang build)
+RUN GITHUB_ARTIFACTORY=github.com \
+    && CMAKE_VERSION=3.31.1 \
+    && ARCH=$(uname -m) \
+    && CMAKE_INSTALLER="cmake-${CMAKE_VERSION}-linux-${ARCH}" \
+    && curl --retry 3 --retry-delay 2 -fsSL -o "${CMAKE_INSTALLER}.tar.gz" \
+        "https://${GITHUB_ARTIFACTORY}/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_INSTALLER}.tar.gz" \
+    && tar -xzf "${CMAKE_INSTALLER}.tar.gz" \
+    && cp -r "${CMAKE_INSTALLER}/bin/"* /usr/local/bin/ \
+    && cp -r "${CMAKE_INSTALLER}/share/"* /usr/local/share/ \
+    && rm -rf "${CMAKE_INSTALLER}" "${CMAKE_INSTALLER}.tar.gz"
+
+# Install uv and python
+ARG UV_VERSION=0.11.3
+ARG PYTHON_VERSION=3.13.11
+ENV PATH="/root/.local/bin:$PATH"
+RUN curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh && \
+    uv python install ${PYTHON_VERSION}
+
+# Disable usage stats by default for users who are sensitive to sharing usage.
+# Users are encouraged to enable if the wish.
+ENV RAY_USAGE_STATS_ENABLED=0
+# After ray>=2.47, this feature is enabled by default which creates uv venvs for any py_executable starting with `uv run`.
+# There is severe contention and performance issues with this enabled considering our dependencies are so large and occasionally
+# need to be compiled, so NeMo RL has an implementation in nemo_rl/utils/venv.py that does it once per node as opposed to once per task.
+ENV RAY_ENABLE_UV_RUN_RUNTIME_ENV=0
+ENV NEMO_RL_VENV_DIR=/opt/ray_venvs
+
+
+FROM base AS hermetic
+
+WORKDIR /opt/nemo-rl
+
+# Variables to control the build of TE. If there are issues with parallelization, consider
+# setting these to 1.
+ARG MAX_JOBS
+ARG NVTE_BUILD_THREADS_PER_JOB
+# Only use for custom vllm installs. Learn more at https://github.com/NVIDIA-NeMo/RL/blob/main/docs/guides/use-custom-vllm.md
+ARG BUILD_CUSTOM_VLLM
+ARG BUILD_CUSTOM_VLLM_URL
+ARG BUILD_CUSTOM_VLLM_REF
+ARG BUILD_CUSTOM_VLLM_PRECOMPILED_WHEEL_LOCATION
+# Only use for custom flashinfer installs.
+ARG BUILD_CUSTOM_FLASHINFER
+ARG BUILD_CUSTOM_FLASHINFER_URL
+ARG BUILD_CUSTOM_FLASHINFER_REF
+# Skip building vLLM or SGLang dependencies (set to any non-empty value to skip)
+ARG SKIP_VLLM_BUILD
+ARG SKIP_SGLANG_BUILD
+
+ENV UV_PROJECT_ENVIRONMENT=/opt/nemo_rl_venv
+ENV UV_LINK_MODE=copy
+
+# Ensure DeepEP is built for H100 and B200 (also mcore inference unified memory API now invokes a torch API that requires these to be set)
+ENV TORCH_CUDA_ARCH_LIST="9.0 10.0"
+
+# First copy only the dependency files
+COPY --from=nemo-rl pyproject.toml uv.lock ./
+# Copy in the top level __init__.py/package_info.py since build-custom-vllm.sh needs the nemo_rl package to exist.
+COPY --from=nemo-rl nemo_rl/__init__.py nemo_rl/package_info.py ./nemo_rl/
+COPY --from=nemo-rl tools/build-custom-vllm.sh ./tools/build-custom-vllm.sh
+COPY --from=nemo-rl tools/build-custom-flashinfer.sh ./tools/build-custom-flashinfer.sh
+COPY --from=nemo-rl --link research/ ./research/
+COPY --from=nemo-rl --link 3rdparty/ ./3rdparty/
+
+RUN --mount=type=ssh <<"EOF" bash -exu
+uv venv --seed
+if [[ -n "${BUILD_CUSTOM_VLLM:-}" ]]; then
+    bash tools/build-custom-vllm.sh ${BUILD_CUSTOM_VLLM_URL} ${BUILD_CUSTOM_VLLM_REF} ${BUILD_CUSTOM_VLLM_PRECOMPILED_WHEEL_LOCATION}
+    source 3rdparty/vllm/nemo-rl.env
+fi
+if [[ -n "${BUILD_CUSTOM_FLASHINFER:-}" ]]; then
+    bash tools/build-custom-flashinfer.sh ${BUILD_CUSTOM_FLASHINFER_URL} ${BUILD_CUSTOM_FLASHINFER_REF}
+fi
+# uv sync has a more reliable resolver than simple uv pip install which can fail
+
+# Sync each training + inference backend one at a time (since they may conflict)
+# to warm the uv cache, then at the end just sync the default dependencies.
+# Do everything in one layer to prevent large layers.
+
+# The venv is symlinked to avoid bloating the layer size
+uv sync --link-mode symlink --locked --no-install-project
+if [[ -z "${SKIP_VLLM_BUILD:-}" ]]; then
+    uv sync --link-mode symlink --locked --extra vllm --no-install-project
+fi
+if [[ -z "${SKIP_SGLANG_BUILD:-}" ]]; then
+    uv sync --link-mode symlink --locked --extra sglang --no-install-project
+fi
+uv sync --link-mode symlink --locked --extra mcore --no-install-project
+uv sync --link-mode symlink --locked --extra automodel --no-install-project
+uv sync --link-mode symlink --locked --all-groups --no-install-project
+
+# Remove the aiohttp in this uv cache dir to fully address CVE GHSA-mqqc-3gqh-h2x8
+# The ray install will include the older aiohttp version in its cache
+find /root/.cache/uv -type d -path "*ray/_private/runtime_env/agent/thirdparty_files/aiohttp*" -exec rm -rf {} +
+EOF
+
+ENV PATH="/opt/nemo_rl_venv/bin:$PATH"
+ENV NEMO_RL_VENV_DIR=/opt/ray_venvs
+# Point TE at the pip-installed cuDNN (nvidia-cudnn-cu12) instead of the system one.
+# The container's system cuDNN (/lib/x86_64-linux-gnu/libcudnn*.so.9) may be a different
+# version than what pip installed. TE prioritizes system libraries by default, causing a
+# version mismatch crash (e.g. system 9.10.1 vs pip 9.19.0). CUDNN_HOME makes TE's Python
+# code find the pip version first, and LD_LIBRARY_PATH makes the dynamic linker resolve
+# cuDNN sub-libraries from pip when loading libtransformer_engine.so.
+ENV CUDNN_HOME=/opt/nemo_rl_venv/lib/python3.13/site-packages/nvidia/cudnn
+ENV LD_LIBRARY_PATH="/opt/nemo_rl_venv/lib/python3.13/site-packages/nvidia/cudnn/lib:${LD_LIBRARY_PATH}"
+# Verify with: python -c "import transformer_engine.pytorch as te; print(te.get_cudnn_version())"
+
+WORKDIR /opt/nemo-rl
+
+FROM hermetic AS release
+
+# Re-declare build args for this stage
+ARG SKIP_VLLM_BUILD
+ARG SKIP_SGLANG_BUILD
+ARG NEMO_RL_COMMIT
+ARG NVIDIA_BUILD_ID
+ARG NVIDIA_BUILD_REF
+ARG RC_DATE=00.00
+ARG TARGETARCH
+ENV NEMO_RL_COMMIT=${NEMO_RL_COMMIT:-<unknown>}
+ENV NVIDIA_BUILD_ID=${NVIDIA_BUILD_ID:-<unknown>}
+ENV NVIDIA_BUILD_REF=${NVIDIA_BUILD_REF:-<unknown>}
+LABEL com.nvidia.build.id="${NVIDIA_BUILD_ID}"
+LABEL com.nvidia.build.ref="${NVIDIA_BUILD_REF}"
+
+ENV NEMO_RL_VENV_DIR=/opt/ray_venvs
+
+# Copy in source from build context (defaults to cloned repo, can be overridden)
+# Exclude pyproject.toml and uv.lock since those may be altered by build-custom-vllm.sh
+COPY --from=nemo-rl --exclude=pyproject.toml --exclude=uv.lock . /opt/nemo-rl
+# Unshallow the repo to get the full history (in the case it was from the scratch layer).
+# Potentially not necessary if the repo is passed in as a complete repository (w/ full git history),
+# so do a quick check before trying to unshallow.
+RUN git rev-parse --is-shallow-repository | grep -q true && git fetch --unshallow || true
+RUN <<"EOF" bash -exu
+NEGATIVE_FILTERS=""
+if [[ -n "${SKIP_VLLM_BUILD:-}" ]]; then
+    NEGATIVE_FILTERS="$NEGATIVE_FILTERS vllm"
+fi
+if [[ -n "${SKIP_SGLANG_BUILD:-}" ]]; then
+    NEGATIVE_FILTERS="$NEGATIVE_FILTERS sglang"
+fi
+if [[ -n "$NEGATIVE_FILTERS" ]]; then
+    UV_LINK_MODE=symlink uv run nemo_rl/utils/prefetch_venvs.py --negative-filters $NEGATIVE_FILTERS
+else
+    UV_LINK_MODE=symlink uv run nemo_rl/utils/prefetch_venvs.py
+fi
+EOF
+
+# Generate container fingerprint for frozen environment support
+# Store outside /opt/nemo-rl to avoid being overwritten by user mounts
+RUN python tools/generate_fingerprint.py > /opt/nemo_rl_container_fingerprint
+
+# NOTICES.txt file points to where the OSS source code is archived
+RUN echo "This distribution includes open source which is archived at the following URL: https://opensource.nvidia.com/oss/teams/nvidia/nemo-rl/${RC_DATE}:linux-${TARGETARCH}/index.html" > NOTICES.txt && \
+    echo "For further inquiries or assistance, contact us at oss-requests@nvidia.com" >> NOTICES.txt

--- a/container/README.md
+++ b/container/README.md
@@ -1,0 +1,64 @@
+# NeMo-RL
+
+**Repository**: https://github.com/NVIDIA-NeMo/RL
+
+## Requirements
+
+- CUDA 12.9, Python 3.12, PyTorch 2.8.0
+- NVIDIA H100/B200 (compute capability 9.0+)
+- SLURM with Enroot + Pyxis
+
+## Setup
+
+### 1. Build Container (Login Node)
+
+```bash
+export REGISTRY="registry.hpc-cluster-hopper.hpc.internal.huggingface.tech"
+./build_container.sh --sqsh-output nemo-rl.sqsh
+```
+
+Build time: ~50-60 minutes.
+
+### 2. Test Container (Compute Node)
+
+```bash
+sbatch test_container.slurm --sqsh /fsx/edward/docker_images/nemo-rl.sqsh
+```
+
+Test time: ~30 seconds. Check output: `cat nemo_rl_test_<job-id>.out`
+
+## Usage
+
+### Training Examples
+
+Single-node GRPO (interactive):
+```bash
+export CONTAINER_IMAGE="/fsx/edward/docker_images/nemo-rl.sqsh"
+
+srun --gpus-per-node=8 \
+     --container-image="${CONTAINER_IMAGE}" \
+     --container-mounts="/fsx:/fsx,/scratch:/scratch" \
+     --no-container-mount-home \
+     bash -c "cd /opt/nemo-rl && uv run python examples/run_grpo_math.py"
+```
+
+Multi-node GRPO (batch):
+```bash
+# Edit run_multinode.slurm to set HF_TOKEN (for gated models), then:
+sbatch run_multinode.slurm
+bash run_multinode.slurm 21639840
+```
+
+### Full Unit Tests (2 GPUs)
+
+```bash
+sbatch run_full_tests.slurm --sqsh /fsx/edward/docker_images/nemo-rl.sqsh
+```
+
+## Notes
+
+- Build runs on login node (Docker), tests run on compute nodes (Enroot/Pyxis)
+- `run_multinode.slurm` uses GRPO with Llama 3.1 8B (2-node config, HF token included)
+- Other examples: `run_sft.py`, `run_dpo.py`, `run_rm.py` (see `examples/`)
+- vLLM is optional (requires `uv sync --extra vllm`)
+- Official docs: https://github.com/NVIDIA-NeMo/RL

--- a/container/build_container.sh
+++ b/container/build_container.sh
@@ -1,0 +1,385 @@
+#!/bin/bash
+# NeMo-RL Container Build Script
+# Run this on the node where Docker is available (typically the login node)
+# This script builds the Docker image and pushes it to your registry
+
+set -e
+
+echo "========================================="
+echo "NeMo-RL Container Build Script"
+echo "========================================="
+echo "This script must run on a node with Docker access (login node)"
+echo "Started at: $(date)"
+echo "========================================="
+
+# Parse command line arguments
+SQSH_OUTPUT=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --sqsh-output)
+            SQSH_OUTPUT="$2"
+            shift 2
+            ;;
+        *)
+            echo "ERROR: Unknown argument: $1"
+            echo ""
+            echo "Usage: $0 [--sqsh-output <path>]"
+            echo ""
+            echo "Options:"
+            echo "  --sqsh-output <path>  Create .sqsh file at specified path (requires enroot)"
+            echo ""
+            echo "Examples:"
+            echo "  $0                                    # Build only"
+            echo "  $0 --sqsh-output nemo-rl.sqsh        # Build and create .sqsh"
+            exit 1
+            ;;
+    esac
+done
+
+# Configuration
+FRAMEWORK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$FRAMEWORK_DIR/../.." && pwd)"
+IMAGE_NAME="nemo-rl"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+CONTAINER_IMAGES_DIR="${CONTAINER_IMAGES_DIR:-/fsx/edward/docker_images}"
+
+# Path to local NeMo-RL clone (default: the repo this container dir lives in)
+NEMO_RL_SOURCE="${NEMO_RL_SOURCE:-$(cd "$FRAMEWORK_DIR/.." && pwd)}"
+
+# Registry configuration
+REGISTRY="${REGISTRY:-registry.hpc-cluster-hopper.hpc.internal.huggingface.tech}"
+
+if [ -z "$REGISTRY" ]; then
+    echo "ERROR: REGISTRY environment variable not set"
+    echo "Please set it to your cluster's Docker registry:"
+    echo "  export REGISTRY=registry.hpc-cluster-hopper.hpc.internal.huggingface.tech"
+    exit 1
+fi
+
+# Validate local source exists
+if [ ! -d "$NEMO_RL_SOURCE" ]; then
+    echo "ERROR: NeMo-RL source directory not found: $NEMO_RL_SOURCE"
+    echo ""
+    echo "Expected to find local NeMo-RL clone at: $NEMO_RL_SOURCE"
+    echo ""
+    echo "Options:"
+    echo "  1. Clone NeMo-RL first:"
+    echo "     cd $REPO_ROOT"
+    echo "     ./shared/scripts/clone_frameworks.sh nemo-rl"
+    echo ""
+    echo "  2. Set NEMO_RL_SOURCE to your local clone:"
+    echo "     export NEMO_RL_SOURCE=/path/to/your/nemo-rl"
+    exit 1
+fi
+
+# Check if it's a git repository
+if [ ! -d "$NEMO_RL_SOURCE/.git" ]; then
+    echo "ERROR: $NEMO_RL_SOURCE is not a git repository"
+    echo ""
+    echo "The local source must be a git clone with .git directory"
+    echo "Please clone it properly using git"
+    exit 1
+fi
+
+LOCAL_IMAGE="${IMAGE_NAME}:${IMAGE_TAG}"
+REGISTRY_IMAGE="${REGISTRY}/library/${IMAGE_NAME}:${IMAGE_TAG}"
+
+echo "Configuration:"
+echo "  Framework directory: $FRAMEWORK_DIR"
+echo "  Local NeMo-RL source: $NEMO_RL_SOURCE"
+echo "  Local image: $LOCAL_IMAGE"
+echo "  Registry image: $REGISTRY_IMAGE"
+echo ""
+echo "Using local NeMo-RL clone (commit info):"
+cd "$NEMO_RL_SOURCE"
+git --no-pager log -1 --pretty=format:"  Commit: %h%n  Date: %ai%n  Message: %s%n" || echo "  (Unable to read git info)"
+cd "$FRAMEWORK_DIR"
+echo "========================================="
+
+# Check if Docker is available
+if ! command -v docker &> /dev/null; then
+    echo "ERROR: Docker is not available on this node"
+    echo ""
+    echo "Please run this script on a node with Docker access (typically the login node)"
+    echo "If you are on a login node and Docker is still not available, contact your cluster admin"
+    exit 1
+fi
+
+# Check Docker daemon connectivity
+if ! docker info &> /dev/null; then
+    echo "ERROR: Cannot connect to Docker daemon"
+    echo ""
+    echo "Docker is installed but the daemon is not accessible."
+    echo "Please check:"
+    echo "  1. Are you on the correct login node?"
+    echo "  2. Is the Docker service running?"
+    echo "  3. Do you have permissions to access Docker?"
+    exit 1
+fi
+
+echo "✓ Docker is available and daemon is accessible"
+echo ""
+
+# Build Docker image using official Dockerfile with local source
+echo "========================================="
+echo "Building Docker image from local source..."
+echo "This will take 30-60 minutes due to:"
+echo "  - Installing PyTorch 2.8.0, Ray 2.49.2"
+echo "  - Building vLLM and other dependencies"
+echo "  - Installing NeMo-RL from local clone"
+echo ""
+echo "Using official NeMo-RL Dockerfile with multi-stage build"
+echo "Target stage: release"
+echo "Build context: Using local NeMo-RL source"
+echo "========================================="
+
+cd "$FRAMEWORK_DIR"
+
+# The official Dockerfile uses multi-stage builds
+# Stages: nemo-rl (source) -> base -> hermetic (deps) -> release (final)
+# We override the nemo-rl stage with local source using --build-context
+
+# Build with buildx using local source override
+if docker buildx version &> /dev/null; then
+    echo "Using docker buildx for build..."
+    docker buildx build \
+        --target release \
+        --build-context nemo-rl="$NEMO_RL_SOURCE" \
+        --build-arg SKIP_SGLANG_BUILD="${SKIP_SGLANG_BUILD:-}" \
+        -t $LOCAL_IMAGE \
+        --load \
+        .
+else
+    echo "ERROR: docker buildx is required for local source override"
+    echo ""
+    echo "The --build-context flag requires docker buildx"
+    echo "Please install docker buildx or use Docker Desktop"
+    exit 1
+fi
+
+if [ $? -eq 0 ]; then
+    echo "✓ Docker image built successfully: $LOCAL_IMAGE"
+else
+    echo "ERROR: Docker image build failed"
+    exit 1
+fi
+
+# Tag for registry
+echo ""
+echo "========================================="
+echo "Tagging image for registry..."
+echo "========================================="
+
+docker tag $LOCAL_IMAGE $REGISTRY_IMAGE
+
+if [ $? -eq 0 ]; then
+    echo "✓ Image tagged: $REGISTRY_IMAGE"
+else
+    echo "ERROR: Failed to tag image"
+    exit 1
+fi
+
+# Check if image already exists in registry
+echo ""
+echo "========================================="
+echo "Checking registry for existing image..."
+echo "========================================="
+if docker manifest inspect $REGISTRY_IMAGE &> /dev/null; then
+    echo "⚠️  WARNING: Image already exists in registry: $REGISTRY_IMAGE"
+    echo ""
+    echo "The existing image will be overwritten."
+    echo "If you want to preserve it, consider using a different tag:"
+    echo "  export IMAGE_TAG=v1.0.0"
+    echo "  export IMAGE_TAG=\$(date +%Y%m%d-%H%M%S)"
+    echo ""
+    echo "Press any key to continue or Ctrl+C to cancel..."
+    read -n 1 -s -r
+else
+    echo "✓ No existing image found in registry (new image)"
+fi
+
+# Push to registry
+echo ""
+echo "========================================="
+echo "Pushing to registry..."
+echo "This may take several minutes..."
+echo "========================================="
+
+docker push $REGISTRY_IMAGE
+
+if [ $? -eq 0 ]; then
+    echo "✓ Image pushed successfully to registry"
+else
+    echo "ERROR: Failed to push image to registry"
+    echo ""
+    echo "Please check:"
+    echo "  1. Is the registry URL correct? ($REGISTRY)"
+    echo "  2. Do you have push permissions to the registry?"
+    echo "  3. Is the registry accessible from this node?"
+    exit 1
+fi
+
+# Verify the push
+echo ""
+echo "========================================="
+echo "Verifying registry push..."
+echo "========================================="
+
+# Try to pull the image to verify it's available
+docker pull $REGISTRY_IMAGE &> /dev/null
+
+if [ $? -eq 0 ]; then
+    echo "✓ Image verified in registry"
+else
+    echo "WARNING: Could not verify image in registry (may still be accessible)"
+fi
+
+# Optional: Create .sqsh file with enroot
+if [ -n "$SQSH_OUTPUT" ]; then
+    echo ""
+    echo "========================================="
+    echo "Creating .sqsh file with enroot..."
+    echo "========================================="
+
+    # Check if enroot is available
+    if ! command -v enroot &> /dev/null; then
+        echo "ERROR: enroot is not available on this node"
+        echo ""
+        echo "The --sqsh-output option requires enroot to be installed."
+        echo "You can create the .sqsh file later on compute nodes:"
+        echo "  enroot import \"docker://${REGISTRY_IMAGE}\""
+        echo "  mv library+${IMAGE_NAME}+${IMAGE_TAG}.sqsh ${SQSH_OUTPUT}"
+        exit 1
+    fi
+
+    echo "✓ Enroot is available"
+
+    # Set enroot environment variables to use writable locations
+    export ENROOT_RUNTIME_PATH="${ENROOT_RUNTIME_PATH:-$HOME/.enroot/runtime}"
+    export ENROOT_DATA_PATH="${ENROOT_DATA_PATH:-$HOME/.enroot/data}"
+    export ENROOT_CACHE_PATH="${ENROOT_CACHE_PATH:-$HOME/.enroot/cache}"
+
+    # Create directories if they don't exist
+    mkdir -p "$ENROOT_RUNTIME_PATH" "$ENROOT_DATA_PATH" "$ENROOT_CACHE_PATH"
+
+    echo "Using enroot directories:"
+    echo "  Runtime: $ENROOT_RUNTIME_PATH"
+    echo "  Data: $ENROOT_DATA_PATH"
+    echo "  Cache: $ENROOT_CACHE_PATH"
+
+    # Determine output path
+    if [[ "$SQSH_OUTPUT" = /* ]]; then
+        # Absolute path provided
+        SQSH_FINAL_PATH="$SQSH_OUTPUT"
+        SQSH_DIR="$(dirname "$SQSH_FINAL_PATH")"
+    else
+        # Relative filename provided, use CONTAINER_IMAGES_DIR
+        SQSH_FINAL_PATH="${CONTAINER_IMAGES_DIR}/${SQSH_OUTPUT}"
+        SQSH_DIR="$CONTAINER_IMAGES_DIR"
+    fi
+
+    # Create output directory if needed
+    mkdir -p "$SQSH_DIR"
+
+    # Import with enroot
+    echo ""
+    echo "Importing from registry to .sqsh format..."
+    echo "This may take 5-10 minutes..."
+    echo ""
+
+    enroot import "docker://${REGISTRY_IMAGE}"
+
+    if [ $? -eq 0 ]; then
+        ENROOT_FILENAME="library+${IMAGE_NAME}+${IMAGE_TAG}.sqsh"
+
+        if [ -f "$ENROOT_FILENAME" ]; then
+            # Remove existing file if it exists at destination
+            if [ -f "$SQSH_FINAL_PATH" ]; then
+                echo "Removing existing .sqsh file: $SQSH_FINAL_PATH"
+                rm -f "$SQSH_FINAL_PATH"
+            fi
+
+            # Move to final location
+            mv "$ENROOT_FILENAME" "$SQSH_FINAL_PATH"
+
+            if [ $? -eq 0 ]; then
+                SQSH_SIZE=$(du -h "$SQSH_FINAL_PATH" | cut -f1)
+                echo "✓ .sqsh file created successfully: $SQSH_FINAL_PATH"
+                echo "  Size: $SQSH_SIZE"
+            else
+                echo "ERROR: Failed to move .sqsh file to $SQSH_FINAL_PATH"
+                exit 1
+            fi
+        else
+            echo "ERROR: .sqsh file not found after import: $ENROOT_FILENAME"
+            echo "The import may have failed or created the file with a different name"
+            exit 1
+        fi
+    else
+        echo "ERROR: enroot import failed"
+        echo ""
+        echo "Please check:"
+        echo "  1. Is the registry accessible from this node?"
+        echo "  2. Is the image available in the registry?"
+        echo "  3. Do you have sufficient disk space?"
+        exit 1
+    fi
+fi
+
+echo ""
+echo "========================================="
+echo "Build Completed Successfully!"
+echo "Finished at: $(date)"
+echo "========================================="
+echo ""
+echo "Image pushed to: $REGISTRY_IMAGE"
+
+if [ -n "$SQSH_OUTPUT" ]; then
+    echo ".sqsh file created: $SQSH_FINAL_PATH"
+fi
+
+echo ""
+echo "Next steps:"
+echo ""
+
+if [ -n "$SQSH_OUTPUT" ]; then
+    echo "1. Test the .sqsh file on compute nodes:"
+    echo ""
+    echo "   sbatch test_container.slurm --sqsh \"${SQSH_FINAL_PATH}\""
+    echo ""
+    echo "2. Use the .sqsh file in your training jobs:"
+    echo ""
+    echo "   export CONTAINER_IMAGE=\"${SQSH_FINAL_PATH}\""
+    echo ""
+    echo "   srun --gpus-per-node=8 \\"
+    echo "     --container-image=\"\${CONTAINER_IMAGE}\" \\"
+    echo "     --container-mounts=\"/fsx:/fsx,/scratch:/scratch\" \\"
+    echo "     --no-container-mount-home \\"
+    echo "     bash -c 'cd /opt/nemo-rl && uv run python examples/run_grpo_math.py'"
+else
+    echo "1. Test the container on compute nodes:"
+    echo ""
+    echo "   export REGISTRY=\"${REGISTRY}\""
+    echo "   sbatch test_container.slurm"
+    echo ""
+    echo "2. Use the container in your jobs:"
+    echo ""
+    echo "   Option A - Direct from registry (simplest):"
+    echo "   export CONTAINER_IMAGE=\"docker://${REGISTRY_IMAGE}\""
+    echo ""
+    echo "   Option B - Create .sqsh file for better performance:"
+    echo "   ./build_container.sh --sqsh-output nemo-rl.sqsh"
+    echo "   # Or manually:"
+    echo "   enroot import \"docker://${REGISTRY_IMAGE}\""
+    echo "   mv library+nemo-rl+${IMAGE_TAG}.sqsh /fsx/edward/docker_images/"
+    echo ""
+    echo "3. Run training:"
+    echo ""
+    echo "   srun --gpus-per-node=8 \\"
+    echo "     --container-image=\"\${CONTAINER_IMAGE}\" \\"
+    echo "     --container-mounts=\"/fsx:/fsx,/scratch:/scratch\" \\"
+    echo "     --no-container-mount-home \\"
+    echo "     bash -c 'cd /opt/nemo-rl && uv run python examples/run_grpo_math.py'"
+fi
+
+echo ""

--- a/container/configs/grpo-qwen3-4b-thinking-2n8g-fsdp2tp1-noncolocated-fast.yaml
+++ b/container/configs/grpo-qwen3-4b-thinking-2n8g-fsdp2tp1-noncolocated-fast.yaml
@@ -1,0 +1,192 @@
+# NeMo-RL GRPO Config - FAST VERSION FOR TESTING
+# Model: Qwen/Qwen3-4B-Thinking-2507
+# Optimized for quick iterations and frequent logging
+defaults: /fsx/edward/work/scale-rl/nemo-rl/examples/configs/grpo_math_1B.yaml
+
+cluster:
+  num_nodes: 2
+  gpus_per_node: 8
+
+data:
+  dataset_name: "OpenMathInstruct-2"
+  max_input_seq_length: 256  # Reduced from 512 for faster processing
+  num_workers: 1
+  prompt_file: "examples/prompts/cot.txt"
+  shuffle: true
+  system_prompt_file: null
+
+grpo:
+  seed: 42
+  max_num_steps: 5  # Reduced from 10 for quick testing
+  max_num_epochs: 10
+  num_generations_per_prompt: 4  # Reduced from 16 (4x speedup)
+  num_prompts_per_step: 16  # Reduced from 64 (4x speedup)
+  normalize_rewards: true
+  use_leave_one_out_baseline: true
+  max_rollout_turns: 1
+  batch_multiplier: 1
+  overlong_filtering: false
+  use_dynamic_sampling: false
+  dynamic_sampling_max_gen_batches: 10
+  val_at_start: false
+  val_period: 1  # Validate every single step for maximum logging
+  val_batch_size: 64  # Smaller validation batches (was 256)
+  max_val_samples: 64  # Fewer validation samples (was 256)
+
+  reward_scaling:
+    enabled: false
+    source_min: 0.0
+    source_max: 1.0
+    target_min: 0.0
+    target_max: 1.0
+
+  reward_shaping:
+    enabled: false
+    max_response_length: 256  # Reduced from 1024
+    overlong_buffer_length: 64  # Reduced from 128
+    overlong_buffer_penalty: 1
+
+loss_fn:
+  reference_policy_kl_penalty: 0.0  # TRL: beta = 0.0 (No KL term)
+  reference_policy_kl_type: "k3"
+  ratio_clip_min: 0.2
+  ratio_clip_max: 0.2
+  ratio_clip_c: null
+  kl_input_clamp_value: 20.0
+  kl_output_clamp_value: 10.0
+  token_level_loss: true
+  sequence_level_importance_ratios: false
+  use_importance_sampling_correction: false
+  use_on_policy_kl_approximation: false
+  truncated_importance_sampling_ratio: null
+
+policy:
+  model_name: "Qwen/Qwen3-4B-Thinking-2507"
+  max_total_sequence_length: 512  # Reduced from 1536 (256 prompt + 256 completion)
+  max_grad_norm: 1.0
+  generation_batch_size: 16
+  logprob_batch_size: 4  # Increased from 2 for faster logprob computation
+  logprob_chunk_size: null
+  make_sequence_length_divisible_by: 1
+  hf_config_overrides: {}
+  precision: "bfloat16"
+
+  # Tokenizer
+  tokenizer:
+    name: "Qwen/Qwen3-4B-Thinking-2507"
+    chat_template_kwargs: null
+
+  # Batch sizes - reduced for faster iterations
+  train_global_batch_size: 64  # Reduced from 512 (8x speedup)
+  train_micro_batch_size: 1
+
+  # Optimizer (for DTensor path)
+  optimizer:
+    name: "torch.optim.AdamW"
+    kwargs:
+      lr: 1.0e-06  # TRL: learning_rate
+      betas: [0.9, 0.999]
+      eps: 1.0e-08
+      weight_decay: 0.01
+      foreach: false
+      fused: false
+
+  # Scheduler - simple constant LR
+  scheduler:
+    - name: "torch.optim.lr_scheduler.ConstantLR"
+      kwargs:
+        factor: 1.0
+        total_iters: 10000000000
+    - milestones: []
+
+  # Offload optimizer during logprob computation
+  offload_optimizer_for_logprob: false
+
+  # Dynamic batching disabled for simplicity
+  dynamic_batching:
+    enabled: false
+    train_mb_tokens: 4096
+    logprob_mb_tokens: 8192
+    sequence_length_round: 64
+
+  # Sequence packing disabled
+  sequence_packing:
+    enabled: false
+    algorithm: "modified_first_fit_decreasing"
+    max_diff_pct: 0.1
+
+  # Generation settings - OPTIMIZED FOR SPEED
+  generation:
+    backend: "vllm"  # TRL: use_vllm = true
+    max_new_tokens: 256  # Reduced from 1024 (4x speedup per generation)
+    temperature: 1.0
+    top_p: 1.0
+    top_k: null
+    stop_strings: null
+    stop_token_ids: null
+
+    vllm_cfg:
+      precision: "bfloat16"
+      max_model_len: 512  # Reduced from 1536
+      gpu_memory_utilization: 0.4  # Lower = faster KV cache allocation during init
+      tensor_parallel_size: 1
+      pipeline_parallel_size: 1
+      expert_parallel_size: 1
+      enforce_eager: true # Disable slow Capturing CUDA graph for faster init
+      use_deep_gemm: false
+      num_first_layers_in_bf16: 0
+      num_last_layers_in_bf16: 0
+      async_engine: true
+
+    vllm_kwargs:
+      compilation_config:
+        use_inductor: false  # Disable torch compilation for faster init
+
+  # DTensor (FSDP2 with TP1) - simplified
+  dtensor_cfg:
+    enabled: true
+    _v2: true
+    tensor_parallel_size: 1
+    context_parallel_size: 1
+    sequence_parallel: false
+    activation_checkpointing: false
+    cpu_offload: false
+    custom_parallel_plan: null
+
+  # Megatron disabled - using DTensor instead
+  megatron_cfg:
+    enabled: false
+
+env:
+  math:
+    math_verify_impl: "hf_math_verify"
+    num_workers: 8
+
+logger:
+  log_dir: "logs/grpo-qwen3-4b-thinking-fast"
+  monitor_gpus: true
+  num_val_samples_to_print: 2  # Print 2 validation samples for visibility
+  tensorboard_enabled: true
+  wandb_enabled: false
+  mlflow_enabled: false
+  swanlab_enabled: false
+
+  tensorboard: {}
+  wandb:
+    project: "nemo-rl"
+    name: "grpo-qwen3-4b-thinking-fast"
+
+  gpu_monitoring:
+    collection_interval: 5  # Log GPU stats every 5 seconds
+    flush_interval: 5  # Flush logs every 5 seconds
+
+checkpointing:
+  enabled: false
+  checkpoint_dir: "/fsx/edward/checkpoints/nemo-rl/grpo_test_fast"
+  save_period: 10000
+  keep_top_k: 3
+  metric_name: "val:accuracy"
+  higher_is_better: true
+  save_consolidated: false
+  model_save_format: "safetensors"
+  checkpoint_must_save_by: null

--- a/container/configs/grpo-qwen3-4b-thinking-2n8g-fsdp2tp1-noncolocated.yaml
+++ b/container/configs/grpo-qwen3-4b-thinking-2n8g-fsdp2tp1-noncolocated.yaml
@@ -1,0 +1,196 @@
+# NeMo-RL GRPO Config matching TRL qwen3-4b-thinking.yaml
+# Model: Qwen/Qwen3-4B-Thinking-2507
+# Simplified configuration for quick testing
+
+cluster:
+  num_nodes: 2
+  gpus_per_node: 8
+
+data:
+  dataset_name: "OpenMathInstruct-2"
+  max_input_seq_length: 512  # TRL: max_prompt_length
+  num_workers: 1
+  prompt_file: "examples/prompts/cot.txt"
+  shuffle: true
+  system_prompt_file: null
+
+grpo:
+  seed: 42
+  max_num_steps: 1  # TRL: max_steps (scale to 10 for real benchmark)
+  max_num_epochs: 1
+  num_generations_per_prompt: 16  # TRL: num_generations
+  num_prompts_per_step: 64
+  normalize_rewards: true
+  use_leave_one_out_baseline: true
+  max_rollout_turns: 1
+  batch_multiplier: 1
+  overlong_filtering: false
+  use_dynamic_sampling: false
+  dynamic_sampling_max_gen_batches: 10
+  val_at_start: false
+  val_period: 10
+  val_batch_size: 256
+  max_val_samples: 256
+
+  reward_scaling:
+    enabled: false
+    source_min: 0.0
+    source_max: 1.0
+    target_min: 0.0
+    target_max: 1.0
+
+  reward_shaping:
+    enabled: false
+    max_response_length: 1024
+    overlong_buffer_length: 128
+    overlong_buffer_penalty: 1
+
+loss_fn:
+  reference_policy_kl_penalty: 0.0  # TRL: beta = 0.0 (No KL term)
+  reference_policy_kl_type: "k3"
+  ratio_clip_min: 0.2
+  ratio_clip_max: 0.2
+  ratio_clip_c: null
+  kl_input_clamp_value: 20.0
+  kl_output_clamp_value: 10.0
+  token_level_loss: true
+  sequence_level_importance_ratios: false
+  use_importance_sampling_correction: false
+  use_on_policy_kl_approximation: false
+  truncated_importance_sampling_ratio: null
+
+policy:
+  model_name: "Qwen/Qwen3-4B-Thinking-2507"
+  max_total_sequence_length: 1536  # 512 prompt + 1024 completion
+  max_grad_norm: 1.0
+  generation_batch_size: 16
+  logprob_batch_size: 2
+  logprob_chunk_size: null
+  make_sequence_length_divisible_by: 1
+  hf_config_overrides: {}
+  precision: "bfloat16"
+
+  # Tokenizer
+  tokenizer:
+    name: "Qwen/Qwen3-4B-Thinking-2507"
+    chat_template_kwargs: null
+
+  # Batch sizes
+  train_global_batch_size: 512
+  train_micro_batch_size: 1
+
+  # Optimizer (for DTensor path)
+  optimizer:
+    name: "torch.optim.AdamW"
+    kwargs:
+      lr: 1.0e-06  # TRL: learning_rate
+      betas: [0.9, 0.999]
+      eps: 1.0e-08
+      weight_decay: 0.01
+      foreach: false
+      fused: false
+
+  # Scheduler - simple constant LR
+  scheduler:
+    - name: "torch.optim.lr_scheduler.ConstantLR"
+      kwargs:
+        factor: 1.0
+        total_iters: 10000000000
+    - milestones: []
+
+  # Offload optimizer during logprob computation
+  offload_optimizer_for_logprob: false
+
+  # Dynamic batching disabled for simplicity
+  dynamic_batching:
+    enabled: false
+    train_mb_tokens: 4096
+    logprob_mb_tokens: 8192
+    sequence_length_round: 64
+
+  # Sequence packing disabled
+  sequence_packing:
+    enabled: false
+    algorithm: "modified_first_fit_decreasing"
+    max_diff_pct: 0.1
+
+  # Generation settings
+  generation:
+    backend: "vllm"  # TRL: use_vllm = true
+    max_new_tokens: 1024  # TRL: max_completion_length
+    temperature: 1.0
+    top_p: 1.0
+    top_k: null
+    stop_strings: null
+    stop_token_ids: null
+
+    # Non-colocated VLLM setup
+    colocated:
+      enabled: false
+      resources:
+        num_nodes: 1
+        gpus_per_node: 8
+
+    vllm_cfg:
+      precision: "bfloat16"
+      max_model_len: 1536
+      gpu_memory_utilization: 0.6
+      tensor_parallel_size: 1
+      pipeline_parallel_size: 1
+      expert_parallel_size: 1
+      enforce_eager: false
+      use_deep_gemm: false
+      num_first_layers_in_bf16: 0
+      num_last_layers_in_bf16: 0
+      async_engine: true
+
+    vllm_kwargs: {}
+
+  # DTensor (FSDP2 with TP1) - simplified
+  dtensor_cfg:
+    enabled: true
+    _v2: true
+    tensor_parallel_size: 1
+    context_parallel_size: 1
+    sequence_parallel: false
+    activation_checkpointing: false
+    cpu_offload: false
+    custom_parallel_plan: null
+
+  # Megatron disabled - using DTensor instead
+  megatron_cfg:
+    enabled: false
+
+env:
+  math:
+    math_verify_impl: "hf_math_verify"
+    num_workers: 8
+
+logger:
+  log_dir: "logs/grpo-qwen3-4b-thinking"
+  monitor_gpus: true
+  num_val_samples_to_print: 0
+  tensorboard_enabled: true
+  wandb_enabled: false  # TRL has wandb but we disable for simplicity
+  mlflow_enabled: false
+  swanlab_enabled: false
+
+  tensorboard: {}
+  wandb:
+    project: "nemo-rl"
+    name: "grpo-qwen3-4b-thinking"
+
+  gpu_monitoring:
+    collection_interval: 10
+    flush_interval: 10
+
+checkpointing:
+  enabled: true
+  checkpoint_dir: "/fsx/edward/checkpoints/nemo-rl/grpo_qwen3"
+  save_period: 10
+  keep_top_k: 3
+  metric_name: "val:accuracy"
+  higher_is_better: true
+  save_consolidated: false
+  model_save_format: "safetensors"
+  checkpoint_must_save_by: null

--- a/container/ray_patched.sub
+++ b/container/ray_patched.sub
@@ -1,0 +1,485 @@
+#!/bin/bash
+#SBATCH --nodes=2
+#SBATCH --exclusive
+#SBATCH --account=ACCOUNT
+#SBATCH --job-name=JOB_NAME
+#SBATCH --partition=PARTITION
+#SBATCH --time=1:0:0
+#SBATCH --dependency=singleton
+
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -eoux pipefail
+
+
+########################################################
+# User defined variables
+########################################################
+CONTAINER=$CONTAINER
+MOUNTS=$MOUNTS
+COMMAND=${COMMAND:-}  # This is a script relative to the SLURM_SUBMIT_DIR. If left empty, it will leave the cluster idle after it's brought up.
+########################################################
+# Ports for all nodes (should be odd numbers since we place head/worker[0] on the same node) so all workers get the odd ports, but the head will get +1 the ports
+NODE_MANAGER_PORT=${NODE_MANAGER_PORT:-53001}
+OBJECT_MANAGER_PORT=${OBJECT_MANAGER_PORT:-53003}
+RUNTIME_ENV_AGENT_PORT=${RUNTIME_ENV_AGENT_PORT:-53005}
+DASHBOARD_AGENT_GRPC_PORT=${DASHBOARD_AGENT_GRPC_PORT:-53007}
+METRICS_EXPORT_PORT=${METRICS_EXPORT_PORT:-53009}
+
+# Ports for the head node
+PORT=${PORT:-54514}
+RAY_CLIENT_SERVER_PORT=${RAY_CLIENT_SERVER_PORT:-10001}
+#REDIT_SHARD_PORTS=${REDIT_SHARD_PORTS:-"random"} ??
+DASHBOARD_PORT=${DASHBOARD_PORT:-8265}  # Also used by debugger
+DASHBOARD_AGENT_LISTEN_PORT=${DASHBOARD_AGENT_LISTEN_PORT:-52365}
+RAY_DEBUGGER_ARGS=
+if [ "${RAY_DEBUG:-}" = "legacy" ]; then
+  RAY_DEBUGGER_ARGS="--ray-debugger-external"
+fi
+
+# After ray>=2.47, this feature is enabled by default which creates uv venvs for any py_executable starting with `uv run`.
+# There is severe contention and performance issues with this enabled considering our dependencies are so large and occasionally
+# need to be compiled, so NeMo RL has an implementation in nemo_rl/utils/venv.py that does it once per node as opposed to once per task.
+export RAY_ENABLE_UV_RUN_RUNTIME_ENV=0
+
+# Enhanced Ray Logging for Debugging
+export RAY_BACKEND_LOG_LEVEL=${RAY_BACKEND_LOG_LEVEL:-info}     # C++ backend logging: debug, info, warning, error
+export RAY_LOG_TO_STDERR=${RAY_LOG_TO_STDERR:-0}                # Set to 1 to log Python side to stderr
+export RAY_logging_level=${RAY_logging_level:-INFO}             # Python logging: DEBUG, INFO, WARNING, ERROR
+export VLLM_LOGGING_LEVEL=${VLLM_LOGGING_LEVEL:-INFO}           # vLLM logging: DEBUG, INFO, WARNING, ERROR
+
+# Override Dockerfile's NEMO_RL_VENV_DIR to use persistent /fsx storage
+# (Dockerfile sets it to /opt/ray_venvs which gets deleted on container restart)
+export NEMO_RL_VENV_DIR=/fsx/${USER}/.cache/nemo-rl/ray_venvs
+
+# Setting ulimit is recommended by ray best practices page
+# @ https://docs.ray.io/en/latest/cluster/vms/user-guides/large-cluster-best-practices.html
+# It's session based and won't affect the system outside the script
+# Ensure that the soft limit isn't above the hard limit
+if [[ $(ulimit -Hn) == "unlimited" ]] || [[ 65535 -lt $(ulimit -Hn) ]]; then
+  ulimit -Sn 65535
+elif [[ $(ulimit -Hn) != "unlimited" ]] && [[ $(ulimit -Hn) -lt 65535 ]]; then
+  echo "[WARNING]: Cannot increase ulimit on file descriptors to 65535 according ray recommendation: https://docs.ray.io/en/latest/cluster/vms/user-guides/large-cluster-best-practices.html. Speak to cluster admins to increase, otherwise ray may crash unexpectedly."
+fi
+
+# On our clusters, the largest port range on an idle worker appeared between 52369-64607
+# (not including the other ports set by this script). So this range is chosen to be
+# somewhere in the middle
+MIN_WORKER_PORT=${MIN_WORKER_PORT:-54001}
+MAX_WORKER_PORT=${MAX_WORKER_PORT:-54513}
+########################################################
+# Number seconds to sync logs from /tmp/ray/session_*/logs to $LOG_DIR/ray/
+RAY_LOG_SYNC_FREQUENCY=${RAY_LOG_SYNC_FREQUENCY:-}
+########################################################
+
+# Unset UV_CACHE_DIR to avoid local cache directory interferring with the container cache
+unset UV_CACHE_DIR
+
+if [[ -n "${UV_CACHE_DIR_OVERRIDE:-}" ]]; then
+  mkdir -p "$UV_CACHE_DIR_OVERRIDE"
+  if [[ -n $MOUNTS ]]; then
+    MOUNTS+=",$UV_CACHE_DIR_OVERRIDE:/root/.cache/uv"
+  else
+    MOUNTS="$UV_CACHE_DIR_OVERRIDE:/root/.cache/uv"
+  fi
+fi
+
+# Create logs directory with datetime (default to logs/ subdirectory)
+BASE_LOG_DIR=${BASE_LOG_DIR:-$SLURM_SUBMIT_DIR/logs}
+LOG_DATETIME=${LOG_DATETIME:-$(date +%Y%m%d_%H%M%S)}
+LOG_DIR="${LOG_DIR:-$BASE_LOG_DIR/$SLURM_JOB_ID-$LOG_DATETIME-logs}"
+mkdir -p $LOG_DIR
+
+# Number of GPUs per worker node
+GPUS_PER_NODE=${GPUS_PER_NODE:-8}
+
+# Number of CPUs per worker node (default to 88 for H100 nodes)
+CPUS_PER_NODE=${CPUS_PER_NODE:-88}
+
+COMMON_SRUN_ARGS=""
+COMMON_SRUN_ARGS+=" --no-container-mount-home"
+COMMON_SRUN_ARGS+=" --mpi=pmix"
+COMMON_SRUN_ARGS+=" --container-mounts=$MOUNTS"
+COMMON_SRUN_ARGS+=" --container-image=$CONTAINER"
+COMMON_SRUN_ARGS+=" --container-workdir=$SLURM_SUBMIT_DIR"
+# TODO: delete these (just for debugging)
+COMMON_SRUN_ARGS+=" -p $SLURM_JOB_PARTITION"
+COMMON_SRUN_ARGS+=" -A $SLURM_JOB_ACCOUNT"
+# Claim all the CPU/memory/GPUs on the node
+COMMON_SRUN_ARGS+=" --exclusive"
+# Don't use --cpus-per-task with --exclusive as it causes allocation conflicts
+# Instead, set CPU count in Ray's resource specifications below
+
+num_retries=3
+
+# Track backgrounded srun client PIDs for head and workers
+declare -A SRUN_PIDS
+
+# Verify all backgrounded srun client processes are still alive; exit fast if any died
+check_srun_processes() {
+  for name in "${!SRUN_PIDS[@]}"; do
+    pid="${SRUN_PIDS[$name]}"
+    # Check if the process is still running
+    if ! kill -0 "$pid" 2>/dev/null; then
+      echo "[ERROR] Background srun '$name' died (pid=$pid). Could be a failure in startup or an issue with the node preventing the srun to start. Attempting to exit." >&2
+      # Signal sidecars inside containers to terminate ASAP
+      touch "$LOG_DIR/ENDED"
+      exit 1
+    fi
+  done
+}
+
+# Getting the node names and IP addresses in the SLURM allocation
+nodes=$(scontrol show hostnames "$SLURM_JOB_NODELIST")
+nodes_array=($nodes)
+ip_addresses_array=()
+
+for node in $nodes; do
+    # Try multiple methods to get IP address - ENHANCED VERSION v2.0
+    echo "[DEBUG] Resolving hostname: $node using enhanced resolution methods"
+    ip_address=""
+    
+    # Method 1: Try host command
+    echo "[DEBUG] Method 1: host command"
+    ip_address=$(host $node 2>/dev/null | awk '/has address/ { print $4 }' | head -1 || true)
+    echo "[DEBUG] host result: '$ip_address'"
+    
+    # Method 2: If host fails, try getent
+    if [[ -z "$ip_address" ]]; then
+        echo "[DEBUG] Method 2: getent hosts"
+        ip_address=$(getent hosts $node 2>/dev/null | awk '{ print $1 }' | head -1 || true)
+        echo "[DEBUG] getent result: '$ip_address'"
+    fi
+    
+    # Method 3: If getent fails, try nslookup
+    if [[ -z "$ip_address" ]]; then
+        echo "[DEBUG] Method 3: nslookup"
+        ip_address=$(nslookup $node 2>/dev/null | awk '/^Address: / { print $2 }' | head -1 || true)
+        echo "[DEBUG] nslookup result: '$ip_address'"
+    fi
+    
+    # Method 4: If all DNS methods fail, try ping to extract IP
+    if [[ -z "$ip_address" ]]; then
+        echo "[DEBUG] Method 4: ping"
+        ip_address=$(ping -c 1 $node 2>/dev/null | grep "PING" | sed 's/.*(\([^)]*\)).*/\1/' || true)
+        echo "[DEBUG] ping result: '$ip_address'"
+    fi
+    
+    # If still no IP, use the hostname itself (might work if it's already an IP or resolvable)
+    if [[ -z "$ip_address" ]]; then
+        echo "[WARNING] Could not resolve IP for $node, using hostname as fallback"
+        ip_address=$node
+    fi
+    
+    echo "[INFO] Node: $node -> IP: $ip_address"
+    # Add the IP address to the array
+    ip_addresses_array+=("$ip_address")
+done
+
+head_node=${nodes_array[0]}
+head_node_ip=${ip_addresses_array[0]}
+
+ip_head=$head_node_ip:$PORT
+
+# First we start the head of the ray cluster on one of the physical nodes
+# Give the head node actual resources to make it schedulable
+
+head_cmd=$(cat <<EOF
+# Touch a file to indicate that the head node has started
+# Overlapping srun commands will check this file to determine if we can overlap a container command
+touch $LOG_DIR/STARTED_RAY_HEAD
+
+# Override Docker ENV variables for persistent venv storage
+export NEMO_RL_VENV_DIR=$NEMO_RL_VENV_DIR
+
+env
+
+exit-dramatically() {
+    # Use SIGTERM to forcefully terminate the srun process
+    pkill -P $$ || true
+    kill -TERM 0 || true
+    # As a last resort, exit with a non-zero code
+    exit 1
+}
+export -f exit-dramatically
+
+# Background process to check for ENDED file
+monitor-sidecar() {
+  set +x
+  while true; do
+    sleep 60
+    if [[ -f "$LOG_DIR/ENDED" ]]; then
+      echo "Detected ENDED file, terminating..."
+      exit-dramatically
+    fi
+  done
+}
+monitor-sidecar &
+
+# Background process to sync ray logs every $RAY_LOG_SYNC_FREQUENCY seconds
+log-sync-sidecar() {
+  set +x
+  if [[ -z "$RAY_LOG_SYNC_FREQUENCY" ]]; then
+    echo "RAY_LOG_SYNC_FREQUENCY is not set, skipping log sync sidecar"
+    return
+  fi
+  mkdir -p $LOG_DIR/ray
+  while true; do
+    sleep $RAY_LOG_SYNC_FREQUENCY
+    if ls /tmp/ray/session_[0-9]* > /dev/null 2>&1; then
+      for session_dir in /tmp/ray/session_[0-9]*/; do
+        if [[ -d "\$session_dir/logs" ]]; then
+          session_name=\$(basename "\$session_dir")
+          mkdir -p "$LOG_DIR/ray/\$session_name"
+          if command -v rsync > /dev/null 2>&1; then
+            rsync -ahP "\$session_dir/logs/" "$LOG_DIR/ray/\$session_name/logs/" 2>/dev/null || true
+          else
+            cp -r "\$session_dir/logs" "$LOG_DIR/ray/\$session_name/"
+          fi
+        fi
+      done
+    fi
+    if [[ -f "$LOG_DIR/ENDED" ]]; then
+      echo "Log sync sidecar terminating..."
+      break
+    fi
+  done
+}
+log-sync-sidecar &
+
+# Patch nsight.py before starting Ray head
+sed -i 's/context\.py_executable = " "\.join(self\.nsight_cmd) + " python"/context.py_executable = " ".join(self.nsight_cmd) + f" {context.py_executable}"/g' /opt/nemo_rl_venv/lib64/python*/site-packages/ray/_private/runtime_env/nsight.py
+
+cat <<EOFINNER | tee /launch-head.sh
+ray start --head \
+    --disable-usage-stats \
+    --num-cpus=$CPUS_PER_NODE \
+    --resources="{\"worker_units\": $GPUS_PER_NODE, \"slurm_managed_ray_cluster\": 1}" \
+    --node-ip-address="$head_node_ip" \
+    --port=${PORT} \
+    --ray-client-server-port=${RAY_CLIENT_SERVER_PORT} \
+    --dashboard-port=${DASHBOARD_PORT} \
+    \
+    --node-manager-port=$((${NODE_MANAGER_PORT} + 1)) \
+    --object-manager-port=$((${OBJECT_MANAGER_PORT} + 1)) \
+    --runtime-env-agent-port=$((${RUNTIME_ENV_AGENT_PORT} + 1)) \
+    --dashboard-agent-grpc-port=$((${DASHBOARD_AGENT_GRPC_PORT} + 1)) \
+    --dashboard-agent-listen-port=$((${DASHBOARD_AGENT_LISTEN_PORT} + 1)) \
+    --metrics-export-port=$((${METRICS_EXPORT_PORT} + 1)) \
+    $RAY_DEBUGGER_ARGS \
+    \
+    --block 
+EOFINNER
+chmod +x /launch-head.sh
+
+count=0
+while [[ \$count -lt $num_retries ]]; do
+  bash /launch-head.sh
+  count=\$((count+1))
+  echo "Head node failed \$count/$num_retries times, restarting in 5 seconds..."
+  sleep 5
+done
+touch $LOG_DIR/ENDED
+exit 1
+EOF
+)
+srun $COMMON_SRUN_ARGS --container-name=ray-head --nodes=1 -w "$head_node" -o $LOG_DIR/ray-head.log bash -x -c "$head_cmd" &
+SRUN_PIDS["ray-head"]=$!
+
+NUM_ACTORS=$((GPUS_PER_NODE * SLURM_JOB_NUM_NODES))
+
+# Start Ray worker nodes
+# We want 1 Ray worker node per physical node (excluding the head node)
+# Worker nodes are started with ray start but without the --head flag
+# Start from node 1 since node 0 is running the head
+for ((i = 1; i < SLURM_JOB_NUM_NODES; i++)); do
+  node_i=${nodes_array[$i]}
+    
+  worker_cmd=$(cat <<EOF
+# Override Docker ENV variables for persistent venv storage
+export NEMO_RL_VENV_DIR=$NEMO_RL_VENV_DIR
+
+env
+
+exit-dramatically() {
+    # Use SIGTERM to forcefully terminate the srun process
+    pkill -P $$ || true
+    kill -TERM 0 || true
+    # As a last resort, exit with a non-zero code
+    exit 1
+}
+
+# Background process to check for ENDED file
+monitor-sidecar() {
+  set +x
+  while true; do
+    sleep 60
+    if [[ -f "$LOG_DIR/ENDED" ]]; then
+      echo "Detected ENDED file, terminating..."
+      exit-dramatically
+    fi
+  done
+}
+monitor-sidecar &
+
+# Background process to sync ray logs every $RAY_LOG_SYNC_FREQUENCY seconds
+log-sync-sidecar() {
+  set +x
+  if [[ -z "$RAY_LOG_SYNC_FREQUENCY" ]]; then
+    echo "RAY_LOG_SYNC_FREQUENCY is not set, skipping log sync sidecar"
+    return
+  fi
+  mkdir -p $LOG_DIR/ray/$node_i
+  while true; do
+    sleep $RAY_LOG_SYNC_FREQUENCY
+    if ls /tmp/ray/session_[0-9]* > /dev/null 2>&1; then
+      for session_dir in /tmp/ray/session_[0-9]*/; do
+        if [[ -d "\$session_dir/logs" ]]; then
+          session_name=\$(basename "\$session_dir")
+          mkdir -p "$LOG_DIR/ray/$node_i/\$session_name"
+          if command -v rsync > /dev/null 2>&1; then
+            rsync -ahP "\$session_dir/logs/" $LOG_DIR/ray/$node_i/\$session_name/logs/ 2>/dev/null || true
+          else
+            cp -r "\$session_dir/logs" $LOG_DIR/ray/$node_i/\$session_name/
+          fi
+        fi
+      done
+    fi
+    if [[ -f "$LOG_DIR/ENDED" ]]; then
+      echo "Log sync sidecar terminating..."
+      break
+    fi
+  done
+}
+log-sync-sidecar &
+
+# Patch nsight.py before starting Ray worker
+sed -i 's/context\.py_executable = " "\.join(self\.nsight_cmd) + " python"/context.py_executable = " ".join(self.nsight_cmd) + f" {context.py_executable}"/g' /opt/nemo_rl_venv/lib64/python*/site-packages/ray/_private/runtime_env/nsight.py
+
+cat <<EOFINNER | tee /launch-worker.sh
+ray start --address "$ip_head" \
+          --disable-usage-stats \
+          --num-cpus=$CPUS_PER_NODE \
+          --resources="{\"worker_units\": $GPUS_PER_NODE, \"slurm_managed_ray_cluster\": 1}" \
+          --min-worker-port=${MIN_WORKER_PORT} \
+          --max-worker-port=${MAX_WORKER_PORT} \
+          \
+          --node-manager-port=${NODE_MANAGER_PORT} \
+          --object-manager-port=${OBJECT_MANAGER_PORT} \
+          --runtime-env-agent-port=${RUNTIME_ENV_AGENT_PORT} \
+          --dashboard-agent-grpc-port=${DASHBOARD_AGENT_GRPC_PORT} \
+          --dashboard-agent-listen-port=${DASHBOARD_AGENT_LISTEN_PORT} \
+          --metrics-export-port=${METRICS_EXPORT_PORT} \
+          $RAY_DEBUGGER_ARGS \
+          \
+          --block 
+EOFINNER
+
+count=0
+while [[ \$count -lt $num_retries ]]; do
+  bash /launch-worker.sh
+  count=\$((count+1))
+  echo "Worker failed \$count/$num_retries times, restarting in 5 seconds..."
+  sleep 5
+done
+touch $LOG_DIR/ENDED
+exit 1
+EOF
+)
+  srun $COMMON_SRUN_ARGS --container-name=ray-worker-$i --nodes=1 -w "$node_i" -o $LOG_DIR/ray-worker-$i.log bash -x -c "$worker_cmd" &
+  SRUN_PIDS["ray-worker-$i"]=$!
+  sleep 3
+done
+
+# Then we wait here for the file to be created by the head node container
+# Check file directly on shared /fsx filesystem (no srun needed)
+while check_srun_processes && ! test -f $LOG_DIR/STARTED_RAY_HEAD; do
+  echo "[INFO][$(date)] Waiting for head node container to start..."
+  sleep 2
+done
+
+# At this stage the Ray cluster bringup has started on the physical nodes in the allocation
+# Before we launch a job on this cluster we need to make sure that the bringup is complete
+# We do so by querying the number of worker_units in the ray cluster and asserting = NUM_ACTORS
+extract_worker_units() {
+  # Use --jobid to attach to existing job and --overlap to share the node
+  status_output=$(srun --jobid=$SLURM_JOB_ID --overlap --container-name=ray-head --nodes=1 -w "$head_node" ray status 2>/dev/null) || true
+  if echo "$status_output" | grep -q "worker_units"; then
+    worker_units=$(echo "$status_output" | grep "worker_units" | awk -F'[/. ]' '{print $4}')
+    echo $worker_units
+  else
+    echo 0
+  fi
+}
+
+# Poll to make sure that all Ray worker nodes have connected to the head.
+# All workers have connected when number of GPUs in ray cluster
+# is equal to NUM_ACTORS. We use the utility function above
+# to check how many GPUs have come online in the ray cluster
+while true; do
+  worker_units=$(extract_worker_units)
+  echo "[INFO] Number of actors online: $worker_units/$NUM_ACTORS"
+  if [[ "$worker_units" -eq "$NUM_ACTORS" ]]; then
+    break
+  fi
+  check_srun_processes
+  sleep 2
+done
+
+echo "All workers connected!"
+
+# We can now launch a job on this cluster
+# We do so by launching a driver process on the physical node that the head node is on
+# This driver process is responsible for launching a job on the Ray cluster
+CONTAINER_CWD=$(scontrol show job $SLURM_JOB_ID | grep -oP 'WorkDir=\K[^ ]+' | head -1)
+if [[ -n "$COMMAND" ]]; then
+  srun --jobid=$SLURM_JOB_ID --no-container-mount-home --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 -w "$head_node" -o $LOG_DIR/ray-driver.log bash -c "$COMMAND"
+else
+  echo "[INFO]: Ray Cluster is idled, run this on the slurm head node to get a shell to the head node:"
+  cat <<EOF >$SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh
+# No args launches on the head node (node 0)
+# Args 1-N launch on worker nodes (nodes 1 through N-1)
+# Optional: set COMMAND='...' to run non-interactively instead of opening an interactive shell
+WORKER_NUM=\${1:-}
+if [[ -z "\$WORKER_NUM" ]]; then
+  # Empty means we are on the head node
+  if [[ -n "\${COMMAND:-}" ]]; then
+    srun --no-container-mount-home -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 -w "$head_node" --jobid $SLURM_JOB_ID bash -c "\$COMMAND"
+  else
+    srun --no-container-mount-home -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 -w "$head_node" --jobid $SLURM_JOB_ID --pty bash
+  fi
+else
+  # Worker numbers 1 through N-1 correspond to ray-worker-1 through ray-worker-(N-1)
+  # and use nodes_array[1] through nodes_array[N-1]
+  if [[ \$WORKER_NUM -lt 1 || \$WORKER_NUM -ge $SLURM_JOB_NUM_NODES ]]; then
+    echo "Error: WORKER_NUM must be between 1 and $((SLURM_JOB_NUM_NODES-1))"
+    exit 1
+  fi
+  nodes_array=($nodes)
+  if [[ -n "\${COMMAND:-}" ]]; then
+    srun --no-container-mount-home -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-worker-\$WORKER_NUM --container-workdir=$CONTAINER_CWD --nodes=1 -w "\${nodes_array[\$WORKER_NUM]}" --jobid $SLURM_JOB_ID bash -c "\$COMMAND"
+  else
+    srun --no-container-mount-home -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-worker-\$WORKER_NUM --container-workdir=$CONTAINER_CWD --nodes=1 -w "\${nodes_array[\$WORKER_NUM]}" --jobid $SLURM_JOB_ID --pty bash
+  fi
+fi
+EOF
+  chmod +x $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh
+  echo "     COMMAND='echo hello' bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh    # run a non-interactive command on head node"
+  echo "     bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh    # to attach to head node (i.e., 'worker 0')"
+  echo "     bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh 1  # to attach to worker 1"
+  echo "     bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh 2  # to attach to worker 2, etc."
+  sleep infinity
+fi

--- a/container/run_full_tests.slurm
+++ b/container/run_full_tests.slurm
@@ -1,0 +1,111 @@
+#!/bin/bash
+#SBATCH --job-name=nemo-rl-full-tests
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=16
+#SBATCH --gpus-per-node=2
+#SBATCH --mem=64G
+#SBATCH --time=02:00:00
+#SBATCH --output=nemo_rl_full_tests_%j.out
+
+# NeMo-RL Full Test Suite
+# Runs all 984 unit tests with 2 GPUs
+#
+# Based on: https://github.com/NVIDIA-NeMo/RL/blob/main/docs/testing.md
+
+set -e
+
+# Parse command line arguments
+SQSH_FILE=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --sqsh)
+            SQSH_FILE="$2"
+            shift 2
+            ;;
+        *)
+            echo "ERROR: Unknown argument: $1"
+            echo ""
+            echo "Usage: sbatch run_full_tests.slurm [--sqsh <path>]"
+            echo ""
+            echo "Options:"
+            echo "  --sqsh <path>  Use specific .sqsh file instead of registry"
+            echo ""
+            echo "Examples:"
+            echo "  sbatch run_full_tests.slurm --sqsh /fsx/edward/docker_images/nemo-rl.sqsh"
+            exit 1
+            ;;
+    esac
+done
+
+# Set enroot environment variables
+export ENROOT_RUNTIME_PATH="${ENROOT_RUNTIME_PATH:-$HOME/.enroot/runtime}"
+export ENROOT_DATA_PATH="${ENROOT_DATA_PATH:-$HOME/.enroot/data}"
+export ENROOT_CACHE_PATH="${ENROOT_CACHE_PATH:-$HOME/.enroot/cache}"
+
+mkdir -p "$ENROOT_RUNTIME_PATH" "$ENROOT_DATA_PATH" "$ENROOT_CACHE_PATH"
+
+echo "========================================="
+echo "NeMo-RL Full Test Suite"
+echo "========================================="
+echo "Job ID: $SLURM_JOB_ID"
+echo "Node: $SLURM_NODELIST"
+echo "GPUs: $SLURM_GPUS_PER_NODE"
+echo "Started at: $(date)"
+echo "========================================="
+
+# Configuration
+IMAGE_NAME="nemo-rl"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+
+# Determine container image source
+if [ -n "$SQSH_FILE" ]; then
+    if [ ! -f "$SQSH_FILE" ]; then
+        echo "ERROR: .sqsh file not found: $SQSH_FILE"
+        exit 1
+    fi
+    CONTAINER_IMAGE="$SQSH_FILE"
+    echo "Using .sqsh file: $CONTAINER_IMAGE"
+else
+    REGISTRY="${REGISTRY}"
+    if [ -z "$REGISTRY" ]; then
+        echo "ERROR: REGISTRY environment variable not set"
+        echo "Please set it or use --sqsh option"
+        exit 1
+    fi
+    REGISTRY_IMAGE="${REGISTRY}/library/${IMAGE_NAME}:${IMAGE_TAG}"
+    CONTAINER_IMAGE="docker://${REGISTRY_IMAGE}"
+    echo "Using registry: $CONTAINER_IMAGE"
+fi
+
+echo "========================================="
+
+# Run full test suite
+echo ""
+echo "========================================="
+echo "Running full NeMo-RL test suite..."
+echo "This will run all 984 unit tests"
+echo "Expected time: 30-60 minutes"
+echo "========================================="
+echo ""
+
+srun --container-image="$CONTAINER_IMAGE" \
+     --container-mounts="/fsx:/fsx" \
+     --no-container-mount-home \
+     bash -c 'cd /opt/nemo-rl && uv run --group test bash tests/run_unit.sh'
+
+TEST_EXIT_CODE=$?
+
+echo ""
+if [ $TEST_EXIT_CODE -eq 0 ]; then
+    echo "========================================="
+    echo "✓ All tests passed!"
+    echo "========================================="
+else
+    echo "========================================="
+    echo "✗ Tests failed (exit code: $TEST_EXIT_CODE)"
+    echo "========================================="
+fi
+echo ""
+
+exit $TEST_EXIT_CODE

--- a/container/run_grpo.slurm
+++ b/container/run_grpo.slurm
@@ -1,0 +1,355 @@
+#!/bin/bash
+#SBATCH --job-name=nemo-rl-grpo
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --exclusive
+#SBATCH --gres=gpu:8
+#SBATCH --partition=hopper-prod
+#SBATCH --output=logs/%x-%j.out
+#SBATCH --error=logs/%x-%j.err
+#SBATCH --requeue
+#SBATCH --time=3-00:00:00
+
+# NeMo-RL GRPO Training with Ray Cluster (containerized)
+#
+# This script starts a Ray cluster inside a container and runs GRPO training.
+# Based on NeMo-RL's ray.sub and adapted for this cluster.
+#
+# Usage:
+#   Single node (8 GPUs, default 1B model):
+#     sbatch container/run_grpo.slurm
+#
+#   Multi-node (2 nodes, 16 GPUs):
+#     sbatch --nodes=2 container/run_grpo.slurm
+#
+#   Custom config:
+#     CONFIG_FILE=/path/to/config.yaml sbatch container/run_grpo.slurm
+#
+#   Custom config with overrides:
+#     EXTRA_OVERRIDES="grpo.max_num_steps=5 policy.model_name=Qwen/Qwen3-4B" sbatch container/run_grpo.slurm
+#
+#   Idle mode (just start Ray cluster, attach manually):
+#     COMMAND="" sbatch --nodes=2 container/run_grpo.slurm
+#
+#   Attach to running idle cluster:
+#     bash logs/nemo-rl-grpo-<jobid>.out  # prints attach instructions
+#     bash <jobid>-attach.sh              # shell into head node
+#     bash <jobid>-attach.sh 1            # shell into worker 1
+
+set -eoux pipefail
+
+# ==============================================================================
+# Configuration
+# ==============================================================================
+
+# Container
+CONTAINER="${CONTAINER:-/fsx/edward/docker_images/nemo-rl.sqsh}"
+NEMO_RL_SOURCE="${NEMO_RL_SOURCE:-/fsx/edward/work/scale-rl/nemo-rl}"
+MOUNTS="/fsx:/fsx,/scratch:/scratch,${NEMO_RL_SOURCE}:/opt/nemo-rl"
+
+# Training config
+CONFIG_FILE="${CONFIG_FILE:-}"
+CHECKPOINT_DIR="${CHECKPOINT_DIR:-/fsx/edward/checkpoints/nemo-rl/grpo}"
+EXTRA_OVERRIDES="${EXTRA_OVERRIDES:-}"
+
+# Build the training command
+if [[ -n "${COMMAND+x}" && -z "$COMMAND" ]]; then
+    # COMMAND="" explicitly set — idle mode
+    COMMAND=""
+elif [[ -n "${COMMAND:-}" ]]; then
+    # COMMAND set to something — use as-is
+    :
+else
+    # Default: run GRPO
+    COMMAND="cd /opt/nemo-rl && uv run python examples/run_grpo.py"
+    if [[ -n "$CONFIG_FILE" ]]; then
+        COMMAND+=" --config ${CONFIG_FILE}"
+    fi
+    COMMAND+=" cluster.num_nodes=${SLURM_NNODES:-1}"
+    COMMAND+=" cluster.gpus_per_node=8"
+    COMMAND+=" checkpointing.checkpoint_dir='${CHECKPOINT_DIR}'"
+    if [[ -n "$EXTRA_OVERRIDES" ]]; then
+        COMMAND+=" ${EXTRA_OVERRIDES}"
+    fi
+fi
+
+# Ray venv cache on persistent storage
+export NEMO_RL_VENV_DIR="/fsx/edward/.cache/nemo-rl/ray_venvs"
+
+# Ray settings
+export RAY_ENABLE_UV_RUN_RUNTIME_ENV=0
+export RAY_USAGE_STATS_ENABLED=0
+export RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+
+# Ray logging
+export RAY_BACKEND_LOG_LEVEL=${RAY_BACKEND_LOG_LEVEL:-info}
+export RAY_LOG_TO_STDERR=${RAY_LOG_TO_STDERR:-0}
+export RAY_logging_level=${RAY_logging_level:-INFO}
+export VLLM_LOGGING_LEVEL=${VLLM_LOGGING_LEVEL:-INFO}
+
+# ==============================================================================
+# Ray cluster ports
+# ==============================================================================
+NODE_MANAGER_PORT=${NODE_MANAGER_PORT:-53001}
+OBJECT_MANAGER_PORT=${OBJECT_MANAGER_PORT:-53003}
+RUNTIME_ENV_AGENT_PORT=${RUNTIME_ENV_AGENT_PORT:-53005}
+DASHBOARD_AGENT_GRPC_PORT=${DASHBOARD_AGENT_GRPC_PORT:-53007}
+METRICS_EXPORT_PORT=${METRICS_EXPORT_PORT:-53009}
+PORT=${PORT:-54514}
+RAY_CLIENT_SERVER_PORT=${RAY_CLIENT_SERVER_PORT:-10001}
+DASHBOARD_PORT=${DASHBOARD_PORT:-8265}
+DASHBOARD_AGENT_LISTEN_PORT=${DASHBOARD_AGENT_LISTEN_PORT:-52365}
+MIN_WORKER_PORT=${MIN_WORKER_PORT:-54001}
+MAX_WORKER_PORT=${MAX_WORKER_PORT:-54513}
+RAY_LOG_SYNC_FREQUENCY=${RAY_LOG_SYNC_FREQUENCY:-}
+RAY_DEBUGGER_ARGS=
+if [ "${RAY_DEBUG:-}" = "legacy" ]; then
+  RAY_DEBUGGER_ARGS="--ray-debugger-external"
+fi
+
+# ==============================================================================
+# Setup
+# ==============================================================================
+
+# Unset UV_CACHE_DIR to avoid local cache interfering with container cache
+unset UV_CACHE_DIR
+
+# Log directory
+mkdir -p logs
+LOG_DIR="logs/${SLURM_JOB_ID}-logs"
+mkdir -p "$LOG_DIR"
+
+GPUS_PER_NODE=8
+
+# ulimit per Ray best practices
+if [[ $(ulimit -Hn) == "unlimited" ]] || [[ 65535 -lt $(ulimit -Hn) ]]; then
+  ulimit -Sn 65535
+fi
+
+# srun common args
+COMMON_SRUN_ARGS=""
+COMMON_SRUN_ARGS+=" --gres=gpu:${GPUS_PER_NODE}"
+COMMON_SRUN_ARGS+=" --no-container-mount-home"
+COMMON_SRUN_ARGS+=" --mpi=pmix"
+COMMON_SRUN_ARGS+=" --container-mounts=$MOUNTS"
+COMMON_SRUN_ARGS+=" --container-image=$CONTAINER"
+COMMON_SRUN_ARGS+=" --container-workdir=$(pwd)"
+
+num_retries=3
+
+# Track backgrounded srun PIDs
+declare -A SRUN_PIDS
+
+check_srun_processes() {
+  for name in "${!SRUN_PIDS[@]}"; do
+    pid="${SRUN_PIDS[$name]}"
+    if ! kill -0 "$pid" 2>/dev/null; then
+      echo "[ERROR] Background srun '$name' died (pid=$pid)." >&2
+      touch "$LOG_DIR/ENDED"
+      exit 1
+    fi
+  done
+}
+
+# ==============================================================================
+# Resolve node IPs
+# ==============================================================================
+nodes=$(scontrol show hostnames "$SLURM_JOB_NODELIST")
+nodes_array=($nodes)
+ip_addresses_array=()
+
+for node in $nodes; do
+    ip_address=""
+    ip_address=$(host $node 2>/dev/null | awk '/has address/ { print $4 }' | head -1 || true)
+    if [[ -z "$ip_address" ]]; then
+        ip_address=$(getent hosts $node 2>/dev/null | awk '{ print $1 }' | head -1 || true)
+    fi
+    if [[ -z "$ip_address" ]]; then
+        ip_address=$node
+    fi
+    echo "[INFO] Node: $node -> IP: $ip_address"
+    ip_addresses_array+=("$ip_address")
+done
+
+head_node=${nodes_array[0]}
+head_node_ip=${ip_addresses_array[0]}
+ip_head=$head_node_ip:$PORT
+
+echo "========================================="
+echo "NeMo-RL GRPO Training"
+echo "========================================="
+echo "Job ID: $SLURM_JOB_ID"
+echo "Nodes: $SLURM_NNODES"
+echo "GPUs per node: $GPUS_PER_NODE"
+echo "Head node: $head_node ($head_node_ip)"
+echo "Container: $CONTAINER"
+echo "Config: ${CONFIG_FILE:-default (grpo_math_1B.yaml)}"
+echo "Command: ${COMMAND:-<idle>}"
+echo "Log dir: $LOG_DIR"
+echo "Started at: $(date)"
+echo "========================================="
+
+# ==============================================================================
+# Start Ray head node
+# ==============================================================================
+head_cmd=$(cat <<EOF
+touch $LOG_DIR/STARTED_RAY_HEAD
+export NEMO_RL_VENV_DIR=$NEMO_RL_VENV_DIR
+
+exit-dramatically() {
+    pkill -P \$\$ || true
+    kill -TERM 0 || true
+    exit 1
+}
+export -f exit-dramatically
+
+# Monitor sidecar
+(set +x; while true; do sleep 60; if [[ -f "$LOG_DIR/ENDED" ]]; then echo "ENDED detected"; exit-dramatically; fi; done) &
+
+# Log sync sidecar
+if [[ -n "$RAY_LOG_SYNC_FREQUENCY" ]]; then
+  (set +x; while true; do
+    sleep $RAY_LOG_SYNC_FREQUENCY
+    mkdir -p $LOG_DIR/ray
+    for d in /tmp/ray/session_[0-9]*/logs; do
+      [[ -d "\$d" ]] && rsync -a "\$d/" "$LOG_DIR/ray/\$(basename \$(dirname \$d))/logs/" 2>/dev/null || true
+    done
+    [[ -f "$LOG_DIR/ENDED" ]] && break
+  done) &
+fi
+
+ray start --head \
+    --disable-usage-stats \
+    --resources='{"worker_units": $GPUS_PER_NODE, "slurm_managed_ray_cluster": 1}' \
+    --node-ip-address="$head_node_ip" \
+    --port=${PORT} \
+    --ray-client-server-port=${RAY_CLIENT_SERVER_PORT} \
+    --dashboard-port=${DASHBOARD_PORT} \
+    --dashboard-host="$head_node_ip" \
+    --include-dashboard=True \
+    --node-manager-port=$((NODE_MANAGER_PORT + 1)) \
+    --object-manager-port=$((OBJECT_MANAGER_PORT + 1)) \
+    --runtime-env-agent-port=$((RUNTIME_ENV_AGENT_PORT + 1)) \
+    --dashboard-agent-grpc-port=$((DASHBOARD_AGENT_GRPC_PORT + 1)) \
+    --dashboard-agent-listen-port=$((DASHBOARD_AGENT_LISTEN_PORT + 1)) \
+    --metrics-export-port=$((METRICS_EXPORT_PORT + 1)) \
+    $RAY_DEBUGGER_ARGS \
+    --block
+EOF
+)
+
+srun $COMMON_SRUN_ARGS --container-name=ray-head --nodes=1 --ntasks=1 -w "$head_node" -o $LOG_DIR/ray-head.log bash -x -c "$head_cmd" &
+SRUN_PIDS["ray-head"]=$!
+
+NUM_ACTORS=$((GPUS_PER_NODE * SLURM_NNODES))
+
+# ==============================================================================
+# Start Ray worker nodes (if multi-node)
+# ==============================================================================
+for ((i = 1; i < SLURM_NNODES; i++)); do
+  node_i=${nodes_array[$i]}
+
+  worker_cmd=$(cat <<EOF
+export NEMO_RL_VENV_DIR=$NEMO_RL_VENV_DIR
+
+exit-dramatically() {
+    pkill -P \$\$ || true
+    kill -TERM 0 || true
+    exit 1
+}
+
+(set +x; while true; do sleep 60; if [[ -f "$LOG_DIR/ENDED" ]]; then echo "ENDED detected"; exit-dramatically; fi; done) &
+
+if [[ -n "$RAY_LOG_SYNC_FREQUENCY" ]]; then
+  (set +x; while true; do
+    sleep $RAY_LOG_SYNC_FREQUENCY
+    mkdir -p $LOG_DIR/ray/$node_i
+    for d in /tmp/ray/session_[0-9]*/logs; do
+      [[ -d "\$d" ]] && rsync -a "\$d/" "$LOG_DIR/ray/$node_i/\$(basename \$(dirname \$d))/logs/" 2>/dev/null || true
+    done
+    [[ -f "$LOG_DIR/ENDED" ]] && break
+  done) &
+fi
+
+ray start --address "$ip_head" \
+          --disable-usage-stats \
+          --resources='{"worker_units": $GPUS_PER_NODE, "slurm_managed_ray_cluster": 1}' \
+          --min-worker-port=${MIN_WORKER_PORT} \
+          --max-worker-port=${MAX_WORKER_PORT} \
+          --node-manager-port=${NODE_MANAGER_PORT} \
+          --object-manager-port=${OBJECT_MANAGER_PORT} \
+          --runtime-env-agent-port=${RUNTIME_ENV_AGENT_PORT} \
+          --dashboard-agent-grpc-port=${DASHBOARD_AGENT_GRPC_PORT} \
+          --dashboard-agent-listen-port=${DASHBOARD_AGENT_LISTEN_PORT} \
+          --metrics-export-port=${METRICS_EXPORT_PORT} \
+          $RAY_DEBUGGER_ARGS \
+          --block
+EOF
+)
+  srun $COMMON_SRUN_ARGS --container-name=ray-worker-$i --nodes=1 --ntasks=1 -w "$node_i" -o $LOG_DIR/ray-worker-$i.log bash -x -c "$worker_cmd" &
+  SRUN_PIDS["ray-worker-$i"]=$!
+  sleep 3
+done
+
+# ==============================================================================
+# Wait for Ray cluster to be ready
+# ==============================================================================
+while check_srun_processes && ! srun --overlap --nodes=1 --ntasks=1 -w $head_node test -f $LOG_DIR/STARTED_RAY_HEAD; do
+  echo "[INFO][$(date)] Waiting for head node container to start..."
+  sleep 2
+done
+
+extract_worker_units() {
+  status_output=$(srun --overlap --container-name=ray-head --nodes=1 --ntasks=1 -w "$head_node" ray status 2>/dev/null) || true
+  if echo "$status_output" | grep -q "worker_units"; then
+    echo "$status_output" | grep "worker_units" | awk -F'[/. ]' '{print $4}'
+  else
+    echo 0
+  fi
+}
+
+while true; do
+  worker_units=$(extract_worker_units)
+  echo "[INFO] Ray workers online: $worker_units/$NUM_ACTORS"
+  if [[ "$worker_units" -eq "$NUM_ACTORS" ]]; then
+    break
+  fi
+  check_srun_processes
+  sleep 2
+done
+
+echo "All Ray workers connected!"
+
+# ==============================================================================
+# Run training (or idle)
+# ==============================================================================
+CONTAINER_CWD=$(scontrol show job $SLURM_JOB_ID | grep -oP 'WorkDir=\K[^ ]+' | head -1)
+
+if [[ -n "$COMMAND" ]]; then
+  echo "Running: $COMMAND"
+  srun --no-container-mount-home --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "$head_node" -o $LOG_DIR/ray-driver.log bash -c "$COMMAND"
+else
+  echo "[INFO] Ray cluster is idle. To attach:"
+  cat <<EOF >${SLURM_JOB_ID}-attach.sh
+WORKER_NUM=\${1:-}
+if [[ -z "\$WORKER_NUM" ]]; then
+  if [[ -n "\${COMMAND:-}" ]]; then
+    srun --no-container-mount-home --gres=gpu:${GPUS_PER_NODE} --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "$head_node" --jobid $SLURM_JOB_ID bash -c "\$COMMAND"
+  else
+    srun --no-container-mount-home --gres=gpu:${GPUS_PER_NODE} --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "$head_node" --jobid $SLURM_JOB_ID --pty bash
+  fi
+else
+  nodes_array=($nodes)
+  if [[ -n "\${COMMAND:-}" ]]; then
+    srun --no-container-mount-home --gres=gpu:${GPUS_PER_NODE} --overlap --container-name=ray-worker-\$WORKER_NUM --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "\${nodes_array[\$WORKER_NUM]}" --jobid $SLURM_JOB_ID bash -c "\$COMMAND"
+  else
+    srun --no-container-mount-home --gres=gpu:${GPUS_PER_NODE} --overlap --container-name=ray-worker-\$WORKER_NUM --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "\${nodes_array[\$WORKER_NUM]}" --jobid $SLURM_JOB_ID --pty bash
+  fi
+fi
+EOF
+  chmod +x ${SLURM_JOB_ID}-attach.sh
+  echo "  bash ${SLURM_JOB_ID}-attach.sh          # head node shell"
+  echo "  bash ${SLURM_JOB_ID}-attach.sh 1         # worker 1 shell"
+  echo "  COMMAND='ray status' bash ${SLURM_JOB_ID}-attach.sh  # run command"
+  sleep infinity
+fi

--- a/container/run_multinode.slurm
+++ b/container/run_multinode.slurm
@@ -1,0 +1,165 @@
+#!/bin/bash
+#SBATCH --job-name=nemo-rl-train
+#SBATCH --nodes=2
+#SBATCH --qos=high
+#SBATCH --partition=hopper-prod
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=8
+#SBATCH --cpus-per-task=88
+#SBATCH --time=24:00:00
+#SBATCH --output=logs/nemo_rl_train_%j.out
+#SBATCH --exclusive
+
+set -e -x
+
+
+# ==============================================================================
+# Configuration - Customize these variables
+# ==============================================================================
+
+# Container configuration
+export CONTAINER="/fsx/edward/docker_images/nemo-rl.sqsh"
+
+# Mount points for container
+# Overlay /opt/nemo-rl with local development copy for live code updates
+export MOUNTS="/fsx:/fsx,/scratch:/scratch,/fsx/edward/work/scale-rl/nemo-rl:/opt/nemo-rl"
+
+# NeMo-RL configuration
+CONFIG_FILE="${CONFIG_FILE:-/fsx/edward/work/scale-rl/nemo-rl/container/configs/grpo-qwen3-4b-thinking-2n8g-fsdp2tp1-noncolocated-fast.yaml}"
+CHECKPOINT_DIR="${CHECKPOINT_DIR:-/fsx/edward/checkpoints/nemo-rl/grpo_test_fast}"
+WANDB_ENABLED="${WANDB_ENABLED:-true}"
+
+# Optional: Set HF_TOKEN before running if using gated models
+# export HF_TOKEN="your_token_here"
+
+# Optional: Ray configuration
+export GPUS_PER_NODE=${GPUS_PER_NODE:-8}
+export CPUS_PER_NODE=${CPUS_PER_NODE:-88}  # CPUs per node (default 88 for H100 nodes)
+# export RAY_LOG_SYNC_FREQUENCY=300  # Sync Ray logs every 5 minutes
+
+# Enhanced Ray Logging for Debugging
+export RAY_BACKEND_LOG_LEVEL=${RAY_BACKEND_LOG_LEVEL:-info}     # C++ backend logging: debug, info, warning, error
+export RAY_LOG_TO_STDERR=${RAY_LOG_TO_STDERR:-0}                # Set to 1 to log Python side to stderr
+export RAY_logging_level=${RAY_logging_level:-INFO}             # Python logging: DEBUG, INFO, WARNING, ERROR
+export VLLM_LOGGING_LEVEL=${VLLM_LOGGING_LEVEL:-INFO}           # vLLM logging: DEBUG, INFO, WARNING, ERROR
+
+# Override Dockerfile's NEMO_RL_VENV_DIR to use persistent /fsx storage
+# (Dockerfile sets it to /opt/ray_venvs which gets deleted on container restart)
+export NEMO_RL_VENV_DIR="/fsx/edward/.cache/nemo-rl/ray_venvs"
+
+# Path to ray.sub (using patched version with CPU allocation fix)
+RAY_SUB_SCRIPT="/fsx/edward/work/scale-rl/nemo-rl/container/ray_patched.sub"
+
+# ==============================================================================
+# Build command to run inside Ray cluster
+# ==============================================================================
+
+export COMMAND="cd /opt/nemo-rl && uv run python examples/run_grpo_math.py \
+  --config ${CONFIG_FILE} \
+  checkpointing.checkpoint_dir='${CHECKPOINT_DIR}' \
+  logger.wandb_enabled=${WANDB_ENABLED}"
+
+# ==============================================================================
+# Dual Mode: Run on existing allocation OR submit new job
+# ==============================================================================
+
+if [ -n "$1" ]; then
+    # =========================================================================
+    # MODE 1: Run on existing job allocation using ray.sub
+    # =========================================================================
+    JOBID="$1"
+
+    # Query job info
+    JOB_INFO=$(scontrol show job -o "$JOBID")
+
+    # Extract job details
+    SLURM_NNODES=$(echo "$JOB_INFO" | tr ' ' '\n' | awk -F= '$1=="NumNodes"{print $2}')
+    SLURM_GPUS_PER_NODE=$(echo "$JOB_INFO" | grep -oP 'TresPerNode=gres:gpu:\K\d+' || echo "8")
+    SLURM_NODELIST=$(echo "$JOB_INFO" | grep -oP '\bNodeList=\K[^ ]+' | head -1)
+    SLURM_ACCOUNT=$(echo "$JOB_INFO" | tr ' ' '\n' | awk -F= '$1=="Account"{print $2}')
+    SLURM_PARTITION=$(echo "$JOB_INFO" | tr ' ' '\n' | awk -F= '$1=="Partition"{print $2}')
+
+    # Create timestamped log directory
+    DATETIME=$(date +%Y%m%d_%H%M%S)
+    RAY_LOG_DIR="${JOBID}-${DATETIME}-logs"
+    LOGFILE="logs/nemo_rl_train_${DATETIME}_${JOBID}.log"
+    mkdir -p $(dirname "$LOGFILE")
+
+    echo "=========================================" | tee "$LOGFILE"
+    echo "NeMo-RL Training with Ray Cluster" | tee -a "$LOGFILE"
+    echo "Mode: Using existing allocation with ray.sub" | tee -a "$LOGFILE"
+    echo "=========================================" | tee -a "$LOGFILE"
+    echo "Job ID: $JOBID" | tee -a "$LOGFILE"
+    echo "Nodes: $SLURM_NNODES" | tee -a "$LOGFILE"
+    echo "GPUs per node: $SLURM_GPUS_PER_NODE" | tee -a "$LOGFILE"
+    echo "Container: ${CONTAINER}" | tee -a "$LOGFILE"
+    echo "Config: ${CONFIG_FILE}" | tee -a "$LOGFILE"
+    echo "Checkpoint dir: ${CHECKPOINT_DIR}" | tee -a "$LOGFILE"
+    echo "Started at: $(date)" | tee -a "$LOGFILE"
+    echo "Log file: $LOGFILE" | tee -a "$LOGFILE"
+    echo "Ray logs: $RAY_LOG_DIR" | tee -a "$LOGFILE"
+    echo "=========================================" | tee -a "$LOGFILE"
+    echo "" | tee -a "$LOGFILE"
+
+    # Set SLURM environment variables that ray.sub expects
+    # These are normally set by sbatch but need to be explicit with salloc
+    export SLURM_SUBMIT_DIR="$(pwd)"
+    export SLURM_JOB_ID="$JOBID"
+    export SLURM_JOB_NUM_NODES="$SLURM_NNODES"
+    export SLURM_JOB_NODELIST="$SLURM_NODELIST"
+    export SLURM_JOB_ACCOUNT="$SLURM_ACCOUNT"
+    export SLURM_JOB_PARTITION="$SLURM_PARTITION"
+
+    # Set custom log directory with datetime for ray.sub (under logs/)
+    export BASE_LOG_DIR="${SLURM_SUBMIT_DIR}/logs"
+    export LOG_DIR="${BASE_LOG_DIR}/${RAY_LOG_DIR}"
+
+    # Fix Ray CPU detection in containers
+    # Ray's container CPU detection is incorrect and only sees ~2 CPUs
+    # This env var tells Ray to use multiprocessing.cpu_count() instead
+    export RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+
+    # Clean up any stale ENDED file from previous runs
+    # This file is used by ray.sub to signal termination, and if left from a previous run
+    # it will cause the new run to immediately terminate
+    ENDED_FILE="${LOG_DIR}/ENDED"
+    if [ -f "$ENDED_FILE" ]; then
+        echo "Removing stale ENDED file from previous run: $ENDED_FILE" | tee -a "$LOGFILE"
+        rm -f "$ENDED_FILE"
+    fi
+
+    # Run ray.sub as a bash script (not via srun or source)
+    # This allows ray.sub to execute its internal srun commands properly
+    bash "$RAY_SUB_SCRIPT" 2>&1 | tee -a "$LOGFILE"
+
+else
+    # =========================================================================
+    # MODE 2: Submit new job via sbatch
+    # =========================================================================
+
+    # Set SLURM_SUBMIT_DIR if not already set (when running outside sbatch)
+    export SLURM_SUBMIT_DIR="${SLURM_SUBMIT_DIR:-$(pwd)}"
+    # All logs go under logs/ directory
+    export BASE_LOG_DIR="${SLURM_SUBMIT_DIR}/logs"
+
+    # Fix Ray CPU detection in containers
+    export RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+
+    echo "========================================="
+    echo "NeMo-RL Training with Ray Cluster"
+    echo "Mode: Submitting new job via sbatch"
+    echo "========================================="
+    echo "Nodes: ${SLURM_JOB_NUM_NODES:-2}"
+    echo "GPUs per node: ${GPUS_PER_NODE}"
+    echo "Container: ${CONTAINER}"
+    echo "Config: ${CONFIG_FILE}"
+    echo "Checkpoint dir: ${CHECKPOINT_DIR}"
+    echo "Started at: $(date)"
+    echo "Ray logs will be in: ${BASE_LOG_DIR}/\${SLURM_JOB_ID}-<datetime>-logs"
+    echo "========================================="
+    echo ""
+
+    # Source the ray.sub script inline to inherit SLURM environment
+    # ray.sub will create LOG_DIR as ${BASE_LOG_DIR}/${SLURM_JOB_ID}-logs
+    source "$RAY_SUB_SCRIPT"
+fi

--- a/container/test_container.slurm
+++ b/container/test_container.slurm
@@ -1,0 +1,232 @@
+#!/bin/bash
+#SBATCH --job-name=nemo-rl-test
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --gpus-per-node=1
+#SBATCH --mem=32G
+#SBATCH --time=00:30:00
+#SBATCH --output=nemo_rl_test_%j.out
+
+# NeMo-RL Container Test Script
+# This script tests the NeMo-RL container from the registry
+#
+# Prerequisites:
+#   1. Docker image must be built and pushed to registry first
+#   2. Run build_container.sh on login node before submitting this job
+#
+# Based on: https://github.com/NVIDIA-NeMo/RL
+
+set -e
+
+# Parse command line arguments
+SQSH_FILE=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --sqsh)
+            SQSH_FILE="$2"
+            shift 2
+            ;;
+        *)
+            echo "ERROR: Unknown argument: $1"
+            echo ""
+            echo "Usage: sbatch test_container.slurm [--sqsh <path>]"
+            echo ""
+            echo "Options:"
+            echo "  --sqsh <path>  Use specific .sqsh file instead of registry"
+            echo ""
+            echo "Examples:"
+            echo "  sbatch test_container.slurm"
+            echo "  sbatch test_container.slurm --sqsh /fsx/edward/docker_images/nemo-rl.sqsh"
+            exit 1
+            ;;
+    esac
+done
+
+# Set enroot environment variables to use writable locations
+export ENROOT_RUNTIME_PATH="${ENROOT_RUNTIME_PATH:-$HOME/.enroot/runtime}"
+export ENROOT_DATA_PATH="${ENROOT_DATA_PATH:-$HOME/.enroot/data}"
+export ENROOT_CACHE_PATH="${ENROOT_CACHE_PATH:-$HOME/.enroot/cache}"
+
+# Create directories if they don't exist
+mkdir -p "$ENROOT_RUNTIME_PATH" "$ENROOT_DATA_PATH" "$ENROOT_CACHE_PATH"
+
+echo "========================================="
+echo "NeMo-RL Container Test"
+echo "========================================="
+echo "Job ID: $SLURM_JOB_ID"
+echo "Node: $SLURM_NODELIST"
+echo "Started at: $(date)"
+echo "========================================="
+
+# Configuration
+IMAGE_NAME="nemo-rl"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+
+# Determine container image source
+if [ -n "$SQSH_FILE" ]; then
+    # Use provided .sqsh file
+    if [ ! -f "$SQSH_FILE" ]; then
+        echo "ERROR: .sqsh file not found: $SQSH_FILE"
+        exit 1
+    fi
+    CONTAINER_IMAGE="$SQSH_FILE"
+    echo "Configuration:"
+    echo "  Using .sqsh file: $CONTAINER_IMAGE"
+    echo "========================================="
+else
+    # Use registry (requires REGISTRY env var)
+    REGISTRY="${REGISTRY}"
+
+    # Validate required environment variables
+    if [ -z "$REGISTRY" ]; then
+        echo "ERROR: REGISTRY environment variable not set"
+        echo ""
+        echo "Please set it before submitting this job:"
+        echo "  export REGISTRY=registry.hpc-cluster-hopper.hpc.internal.huggingface.tech"
+        echo "  sbatch test_container.slurm"
+        echo ""
+        echo "Or use --sqsh to specify a .sqsh file directly:"
+        echo "  sbatch test_container.slurm --sqsh /path/to/nemo-rl.sqsh"
+        exit 1
+    fi
+
+    REGISTRY_IMAGE="${REGISTRY}/library/${IMAGE_NAME}:${IMAGE_TAG}"
+    CONTAINER_IMAGE="docker://${REGISTRY_IMAGE}"
+
+    echo "Configuration:"
+    echo "  Registry: $REGISTRY"
+    echo "  Testing image: $REGISTRY_IMAGE"
+    echo "  Container URI: $CONTAINER_IMAGE"
+    echo "========================================="
+fi
+
+# Check if enroot/pyxis is available (srun with --container-image requires it)
+if ! command -v enroot &> /dev/null; then
+    echo "WARNING: enroot command not found"
+    echo "This script requires Pyxis/Enroot for SLURM container support"
+fi
+
+# Run verification tests using srun with Pyxis
+echo ""
+echo "========================================="
+echo "Running verification tests..."
+echo "========================================="
+
+srun --container-image="$CONTAINER_IMAGE" \
+     --container-mounts="/fsx:/fsx" \
+     --no-container-mount-home \
+     bash <<'OUTER_EOF'
+cd /opt/nemo-rl && uv run python <<'INNER_EOF'
+import sys
+
+tests_passed = 0
+tests_failed = 0
+
+# Test 1: NeMo-RL
+print("\nTest 1: Checking NeMo-RL installation...")
+try:
+    import nemo_rl
+    print(f"✓ NeMo-RL version: {nemo_rl.__version__}")
+    tests_passed += 1
+except Exception as e:
+    print(f"✗ NeMo-RL import failed: {e}")
+    tests_failed += 1
+
+# Test 2: PyTorch and CUDA
+print("\nTest 2: Checking PyTorch and CUDA...")
+try:
+    import torch
+    print(f"✓ PyTorch version: {torch.__version__}")
+    print(f"  CUDA available: {torch.cuda.is_available()}")
+    if torch.cuda.is_available():
+        print(f"  CUDA version: {torch.version.cuda}")
+        print(f"  CUDA devices: {torch.cuda.device_count()}")
+    tests_passed += 1
+except Exception as e:
+    print(f"✗ PyTorch check failed: {e}")
+    tests_failed += 1
+
+# Test 3: Ray
+print("\nTest 3: Checking Ray installation...")
+try:
+    import ray
+    print(f"✓ Ray version: {ray.__version__}")
+    tests_passed += 1
+except Exception as e:
+    print(f"✗ Ray import failed: {e}")
+    tests_failed += 1
+
+# Test 4: vLLM (optional backend)
+print("\nTest 4: Checking vLLM installation (optional)...")
+try:
+    import vllm
+    print(f"✓ vLLM version: {vllm.__version__}")
+    tests_passed += 1
+except Exception as e:
+    print(f"⚠️  vLLM not available (optional - requires 'uv run --extra vllm')")
+    # Don't count as failure since it's optional
+    tests_passed += 1
+
+# Test 5: Transformers
+print("\nTest 5: Checking transformers installation...")
+try:
+    import transformers
+    print(f"✓ Transformers version: {transformers.__version__}")
+    tests_passed += 1
+except Exception as e:
+    print(f"✗ Transformers import failed: {e}")
+    tests_failed += 1
+
+# Test 6: Verify pytest test collection works
+print("\nTest 6: Checking test framework...")
+try:
+    import subprocess
+    import re
+
+    # Collect tests to verify pytest works
+    collect_result = subprocess.run(
+        ["uv", "run", "--group", "test", "pytest", "--collect-only", "-q", "tests/unit"],
+        capture_output=True,
+        text=True,
+        timeout=60
+    )
+
+    if collect_result.returncode == 0:
+        match = re.search(r"(\d+) tests? collected", collect_result.stdout)
+        test_count = int(match.group(1)) if match else 0
+        print(f"✓ Test framework functional ({test_count} tests available)")
+        tests_passed += 1
+    else:
+        print(f"✗ Test collection failed")
+        tests_failed += 1
+
+except subprocess.TimeoutExpired:
+    print(f"⚠️  Test collection slow but container is functional")
+    tests_passed += 1
+except Exception as e:
+    print(f"✗ Test framework check failed: {e}")
+    tests_failed += 1
+
+# Summary
+print(f"\n{'='*50}")
+print(f"Tests passed: {tests_passed}/6")
+print(f"Tests failed: {tests_failed}/6")
+print(f"{'='*50}")
+
+if tests_failed > 0:
+    sys.exit(1)
+INNER_EOF
+OUTER_EOF
+
+if [ $? -ne 0 ]; then
+    echo ""
+    echo "✗ Container validation failed"
+    exit 1
+fi
+
+echo ""
+echo "========================================="
+echo "✓ Container validation passed!"
+echo "========================================="
+echo ""


### PR DESCRIPTION
Add container build tooling, SLURM launch scripts, and example configs for running NeMo-RL on the HuggingFace HPC cluster (hopper-prod).

- Dockerfile (from upstream, Python 3.13.11, CUDA 12.9)
- build_container.sh: builds and pushes to cluster registry
- run_grpo.slurm: single/multi-node GRPO with Ray cluster in container
- run_multinode.slurm: multi-node training with ray_patched.sub
- test_container.slurm: quick container validation
- run_full_tests.slurm: full unit test suite
- Example configs for Qwen3-4B GRPO (fast and full variants)

# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
