### PR TITLE
feat: Add pinned memory optimizer offload for Megatron policy worker

### DIFF
--- a/docs/broken_links_needing_review.json
+++ b/docs/broken_links_needing_review.json
@@ -1,0 +1,2 @@
+{"uri": "https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-alloc-conf"}
+{"uri": "https://docs.pytorch.org/docs/stable/notes/cuda.html#reduced-precision-reduction-in-bf16-gemms"}

--- a/docs/broken_links_needing_review.json
+++ b/docs/broken_links_needing_review.json
@@ -1,2 +1,0 @@
-{"uri": "https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-alloc-conf"}
-{"uri": "https://docs.pytorch.org/docs/stable/notes/cuda.html#reduced-precision-reduction-in-bf16-gemms"}

--- a/examples/configs/distillation_math.yaml
+++ b/examples/configs/distillation_math.yaml
@@ -44,6 +44,7 @@ policy: &POLICY_BASE
     logprob_chunk_size: null
 
     offload_optimizer_for_logprob: false
+    use_pinned_optimizer_offload: false # Use pinned memory for optimizer D2H/H2D transfers
 
     dtensor_cfg: &DTENSOR_BASE
         enabled: true

--- a/examples/configs/distillation_math.yaml
+++ b/examples/configs/distillation_math.yaml
@@ -44,7 +44,8 @@ policy: &POLICY_BASE
     logprob_chunk_size: null
 
     offload_optimizer_for_logprob: false
-    use_pinned_optimizer_offload: false # Use pinned memory for optimizer D2H/H2D transfers
+    use_pinned_optimizer_offload: false # Use pinned memory for optimizer D2H/H2D transfers (per-tensor pinning)
+    use_coalesced_optimizer_offload: false # Coalesce all optimizer state into a single pinned buffer; requires use_pinned_optimizer_offload=true. Faster but may OOM on very large models.
 
     dtensor_cfg: &DTENSOR_BASE
         enabled: true

--- a/examples/configs/dpo.yaml
+++ b/examples/configs/dpo.yaml
@@ -53,6 +53,7 @@ policy:
   precision: "bfloat16"
 
   offload_optimizer_for_logprob: false
+  use_pinned_optimizer_offload: false # Use pinned memory for optimizer D2H/H2D transfers
 
   dtensor_cfg:
     env_vars:

--- a/examples/configs/dpo.yaml
+++ b/examples/configs/dpo.yaml
@@ -53,7 +53,8 @@ policy:
   precision: "bfloat16"
 
   offload_optimizer_for_logprob: false
-  use_pinned_optimizer_offload: false # Use pinned memory for optimizer D2H/H2D transfers
+  use_pinned_optimizer_offload: false # Use pinned memory for optimizer D2H/H2D transfers (per-tensor pinning)
+  use_coalesced_optimizer_offload: false # Coalesce all optimizer state into a single pinned buffer; requires use_pinned_optimizer_offload=true. Faster but may OOM on very large models.
 
   dtensor_cfg:
     env_vars:

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -95,6 +95,7 @@ policy:
   precision: "bfloat16"
   logprob_chunk_size: null
   offload_optimizer_for_logprob: false # Only useful for non-colocated generation since colocated generation will always offload optimizer to cuda before refit
+  use_pinned_optimizer_offload: false # Use pinned memory for optimizer D2H/H2D transfers
 
   dtensor_cfg:
     _v2: true

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -124,7 +124,8 @@ policy:
   precision: "bfloat16"
   logprob_chunk_size: null
   offload_optimizer_for_logprob: false # Only useful for non-colocated generation since colocated generation will always offload optimizer to cuda before refit
-  use_pinned_optimizer_offload: false # Use pinned memory for optimizer D2H/H2D transfers
+  use_pinned_optimizer_offload: false # Use pinned memory for optimizer D2H/H2D transfers (per-tensor pinning)
+  use_coalesced_optimizer_offload: false # Coalesce all optimizer state into a single pinned buffer; requires use_pinned_optimizer_offload=true. Faster but may OOM on very large models.
 
   dtensor_cfg:
     _v2: true

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -124,8 +124,8 @@ policy:
   precision: "bfloat16"
   logprob_chunk_size: null
   offload_optimizer_for_logprob: false # Only useful for non-colocated generation since colocated generation will always offload optimizer to cuda before refit
-  use_pinned_optimizer_offload: false # Use pinned memory for optimizer D2H/H2D transfers (per-tensor pinning)
-  use_coalesced_optimizer_offload: false # Coalesce all optimizer state into a single pinned buffer; requires use_pinned_optimizer_offload=true. Faster but may OOM on very large models.
+  use_pinned_optimizer_offload: false # Pin optimizer state in CPU memory for non-blocking D2H/H2D transfers; most useful in colocated/syncRL runs that offload the optimizer every step
+  use_coalesced_optimizer_offload: false # Pack all optimizer state into one pinned buffer (faster, fewer cudaHostAlloc calls); requires use_pinned_optimizer_offload=true; may OOM on very large models
 
   dtensor_cfg:
     _v2: true

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -124,6 +124,7 @@ policy:
   precision: "bfloat16"
   logprob_chunk_size: null
   offload_optimizer_for_logprob: false # Only useful for non-colocated generation since colocated generation will always offload optimizer to cuda before refit
+  use_pinned_optimizer_offload: false # Use pinned memory for optimizer D2H/H2D transfers
 
   dtensor_cfg:
     _v2: true

--- a/examples/configs/ppo_math_1B.yaml
+++ b/examples/configs/ppo_math_1B.yaml
@@ -99,6 +99,8 @@ policy:
   precision: "bfloat16"
   logprob_chunk_size: null
   offload_optimizer_for_logprob: false
+  use_pinned_optimizer_offload: false
+  use_coalesced_optimizer_offload: false
 
   dtensor_cfg:
     _v2: true

--- a/examples/configs/rm.yaml
+++ b/examples/configs/rm.yaml
@@ -38,6 +38,7 @@ policy:
   activation_checkpointing_enabled: false
 
   offload_optimizer_for_logprob: false
+  use_pinned_optimizer_offload: false # Use pinned memory for optimizer D2H/H2D transfers
 
   reward_model_cfg:
     enabled: true  # loads model as a Reward Model (do not change)

--- a/examples/configs/rm.yaml
+++ b/examples/configs/rm.yaml
@@ -38,7 +38,8 @@ policy:
   activation_checkpointing_enabled: false
 
   offload_optimizer_for_logprob: false
-  use_pinned_optimizer_offload: false # Use pinned memory for optimizer D2H/H2D transfers
+  use_pinned_optimizer_offload: false # Use pinned memory for optimizer D2H/H2D transfers (per-tensor pinning)
+  use_coalesced_optimizer_offload: false # Coalesce all optimizer state into a single pinned buffer; requires use_pinned_optimizer_offload=true. Faster but may OOM on very large models.
 
   reward_model_cfg:
     enabled: true  # loads model as a Reward Model (do not change)

--- a/examples/configs/sft.yaml
+++ b/examples/configs/sft.yaml
@@ -42,7 +42,8 @@ policy:
   precision: "bfloat16"
 
   offload_optimizer_for_logprob: false
-  use_pinned_optimizer_offload: false # Use pinned memory for optimizer D2H/H2D transfers
+  use_pinned_optimizer_offload: false # Use pinned memory for optimizer D2H/H2D transfers (per-tensor pinning)
+  use_coalesced_optimizer_offload: false # Coalesce all optimizer state into a single pinned buffer; requires use_pinned_optimizer_offload=true. Faster but may OOM on very large models.
 
   dtensor_cfg:
     _v2: true

--- a/examples/configs/sft.yaml
+++ b/examples/configs/sft.yaml
@@ -42,6 +42,7 @@ policy:
   precision: "bfloat16"
 
   offload_optimizer_for_logprob: false
+  use_pinned_optimizer_offload: false # Use pinned memory for optimizer D2H/H2D transfers
 
   dtensor_cfg:
     _v2: true

--- a/examples/nemo_gym/grpo_nanov3.yaml
+++ b/examples/nemo_gym/grpo_nanov3.yaml
@@ -193,6 +193,8 @@ policy:
   scheduler: null
 
   offload_optimizer_for_logprob: False
+  use_pinned_optimizer_offload: false # Use pinned memory for optimizer D2H/H2D transfers (per-tensor pinning)
+  use_coalesced_optimizer_offload: false # Coalesce all optimizer state into a single pinned buffer; requires use_pinned_optimizer_offload=true. Faster but may OOM on very large models.
 
   generation:
     # Port range for vLLM HTTP servers, kept below the OS ephemeral range.

--- a/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
+++ b/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
@@ -205,6 +205,8 @@ policy:
   make_sequence_length_divisible_by: 1
   max_grad_norm: 1.0
   offload_optimizer_for_logprob: false # Only useful for non-colocated generation since colocated generation will always offload optimizer to cuda before refit
+  use_pinned_optimizer_offload: false # Use pinned memory for optimizer D2H/H2D transfers (per-tensor pinning)
+  use_coalesced_optimizer_offload: false # Coalesce all optimizer state into a single pinned buffer; requires use_pinned_optimizer_offload=true. Faster but may OOM on very large models.
 
   optimizer: null
 

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -539,6 +539,7 @@ class PolicyConfig(TypedDict):
     max_total_sequence_length: int
     offload_optimizer_for_logprob: bool
     use_pinned_optimizer_offload: bool
+    use_coalesced_optimizer_offload: bool
     # This sets the clipping norm for the DTensorPolicyWorkers (Megatron's is called clip_grad)
     max_grad_norm: NotRequired[float | int | None]
     refit_buffer_size_gb: NotRequired[float]

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -538,7 +538,14 @@ class PolicyConfig(TypedDict):
     make_sequence_length_divisible_by: int
     max_total_sequence_length: int
     offload_optimizer_for_logprob: bool
+    # Pin optimizer state tensors in CPU memory during D2H/H2D transfers so
+    # DMA can overlap with other work. Beneficial for colocated/syncRL runs
+    # that offload the optimizer every step. Adds per-tensor pinned allocations.
     use_pinned_optimizer_offload: bool
+    # Pack all optimizer state into one pre-allocated pinned CPU buffer to
+    # eliminate per-tensor cudaHostAlloc overhead. Requires
+    # use_pinned_optimizer_offload=True. Faster than per-tensor pinning but
+    # allocates a single contiguous region that may OOM on very large models.
     use_coalesced_optimizer_offload: bool
     # This sets the clipping norm for the DTensorPolicyWorkers (Megatron's is called clip_grad)
     max_grad_norm: NotRequired[float | int | None]

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -537,6 +537,8 @@ class PolicyConfig(TypedDict):
     sequence_packing: NotRequired[SequencePackingConfig | SequencePackingConfigDisabled]
     make_sequence_length_divisible_by: int
     max_total_sequence_length: int
+    offload_optimizer_for_logprob: bool
+    use_pinned_optimizer_offload: bool
     # This sets the clipping norm for the DTensorPolicyWorkers (Megatron's is called clip_grad)
     max_grad_norm: NotRequired[float | int | None]
     refit_buffer_size_gb: NotRequired[float]

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -1255,22 +1255,92 @@ class MegatronPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface)
             optimizer_state = self.optimizer.state
         else:
             optimizer_state = self.optimizer._get_state()
+
+        use_pinned = self.cfg.get("use_pinned_optimizer_offload", False)
+
+        if device == "cpu":
+            if use_pinned:
+                self._coalesced_optimizer_to_cpu(optimizer_state)
+            else:
+                self._optimizer_to_cpu(optimizer_state)
+        elif device == "cuda":
+            if use_pinned:
+                self._coalesced_optimizer_to_cuda(optimizer_state)
+            else:
+                self._optimizer_to_cuda(optimizer_state)
+        else:
+            raise ValueError(
+                f"Invalid device: {device}. Only strings 'cpu' and 'cuda' are supported."
+            )
+
+    def _optimizer_to_cpu(self, optimizer_state):
+        """Offload optimizer state tensors to CPU using default pageable memory."""
         for _, state in optimizer_state.items():
-            # Iterate through the state items (e.g., momentum, variance) for a parameter
             for k, v in state.items():
-                # Check if the item is a tensor
-                if torch.is_tensor(v):
-                    # Move the tensor to device and update the state dictionary
-                    if device == "cpu":
-                        if v.is_cuda:
-                            state[k] = v.to("cpu")
-                    elif device == "cuda":
-                        if not v.is_cuda:
-                            state[k] = v.to("cuda")
-                    else:
-                        raise ValueError(
-                            f"Invalid device: {device}. Only strings 'cpu' and 'cuda' are supported."
-                        )
+                if torch.is_tensor(v) and v.is_cuda:
+                    state[k] = v.to("cpu")
+
+    def _optimizer_to_cuda(self, optimizer_state):
+        """Reload optimizer state tensors to CUDA."""
+        for _, state in optimizer_state.items():
+            for k, v in state.items():
+                if torch.is_tensor(v) and not v.is_cuda:
+                    state[k] = v.to("cuda")
+
+    def _get_or_alloc_pinned_buf(
+        self, attr_name: str, total_bytes: int
+    ) -> torch.Tensor:
+        """Return a cached pinned CPU buffer, allocating only on first use or resize."""
+        buf = getattr(self, attr_name, None)
+        if buf is None or buf.numel() < total_bytes:
+            buf = torch.empty(
+                total_bytes, device="cpu", dtype=torch.uint8, pin_memory=True
+            )
+            setattr(self, attr_name, buf)
+        return buf
+
+    def _coalesced_optimizer_to_cpu(self, optimizer_state):
+        """Offload all optimizer state tensors to CPU via a cached pinned buffer.
+
+        Packs all CUDA tensors into a single pre-allocated pinned CPU buffer,
+        eliminating per-tensor cudaHostAlloc overhead. The pinned buffer is
+        allocated once on first call and reused across iterations.
+        """
+        ALIGN = 512
+        entries = []
+        total_bytes = 0
+
+        for _, state in optimizer_state.items():
+            for k, v in state.items():
+                if not torch.is_tensor(v) or not v.is_cuda:
+                    continue
+                if v.dim() == 0:
+                    state[k] = v.cpu()
+                    continue
+                offset = (total_bytes + ALIGN - 1) // ALIGN * ALIGN
+                nbytes = v.numel() * v.element_size()
+                entries.append((state, k, v, offset, nbytes))
+                total_bytes = offset + nbytes
+
+        if not entries:
+            return
+
+        cpu_buf = self._get_or_alloc_pinned_buf("_optimizer_pinned_buf", total_bytes)
+
+        for state, k, v, offset, nbytes in entries:
+            dst = cpu_buf[offset : offset + nbytes].view(v.dtype).reshape(v.shape)
+            dst.copy_(v, non_blocking=True)
+            state[k] = dst
+
+        torch.cuda.synchronize()
+
+    def _coalesced_optimizer_to_cuda(self, optimizer_state):
+        """Reload all optimizer state tensors back to CUDA."""
+        for _, state in optimizer_state.items():
+            for k, v in state.items():
+                if torch.is_tensor(v) and not v.is_cuda:
+                    state[k] = v.to("cuda", non_blocking=True)
+        torch.cuda.synchronize()
 
     def save_checkpoint(
         self,

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -2158,15 +2158,24 @@ class MegatronPolicyWorkerImpl(
             optimizer_state = self.optimizer._get_state()
 
         use_pinned = self.cfg["use_pinned_optimizer_offload"]
+        use_coalesced = self.cfg["use_coalesced_optimizer_offload"]
+        if use_coalesced and not use_pinned:
+            raise ValueError(
+                "use_coalesced_optimizer_offload requires use_pinned_optimizer_offload=True."
+            )
 
         if device == "cpu":
-            if use_pinned:
+            if use_coalesced:
                 self._coalesced_optimizer_to_cpu(optimizer_state)
+            elif use_pinned:
+                self._pinned_optimizer_to_cpu(optimizer_state)
             else:
                 self._optimizer_to_cpu(optimizer_state)
         elif device == "cuda":
-            if use_pinned:
+            if use_coalesced:
                 self._coalesced_optimizer_to_cuda(optimizer_state)
+            elif use_pinned:
+                self._pinned_optimizer_to_cuda(optimizer_state)
             else:
                 self._optimizer_to_cuda(optimizer_state)
         else:
@@ -2188,6 +2197,33 @@ class MegatronPolicyWorkerImpl(
                 if torch.is_tensor(v) and not v.is_cuda:
                     state[k] = v.to("cuda")
 
+    def _pinned_optimizer_to_cpu(self, optimizer_state):
+        """Offload optimizer state tensors to CPU using per-tensor pinned memory.
+
+        Each tensor gets its own pinned CPU allocation. Avoids the single large
+        contiguous pinned buffer used by the coalesced path, at the cost of more
+        host allocations.
+        """
+        for _, state in optimizer_state.items():
+            for k, v in state.items():
+                if not torch.is_tensor(v) or not v.is_cuda:
+                    continue
+                if v.dim() == 0:
+                    state[k] = v.cpu()
+                    continue
+                dst = torch.empty(v.shape, dtype=v.dtype, device="cpu", pin_memory=True)
+                dst.copy_(v, non_blocking=True)
+                state[k] = dst
+        torch.cuda.synchronize()
+
+    def _pinned_optimizer_to_cuda(self, optimizer_state):
+        """Reload optimizer state tensors from per-tensor pinned CPU memory to CUDA."""
+        for _, state in optimizer_state.items():
+            for k, v in state.items():
+                if torch.is_tensor(v) and not v.is_cuda:
+                    state[k] = v.to("cuda", non_blocking=True)
+        torch.cuda.synchronize()
+
     def _get_or_alloc_pinned_buf(
         self, attr_name: str, total_bytes: int
     ) -> torch.Tensor:
@@ -2199,11 +2235,6 @@ class MegatronPolicyWorkerImpl(
             )
             setattr(self, attr_name, buf)
         return buf
-
-    def _delete_pinned_buf(self, attr_name: str) -> None:
-        """Free a cached pinned CPU buffer allocated by _get_or_alloc_pinned_buf."""
-        if hasattr(self, attr_name):
-            delattr(self, attr_name)
 
     def _coalesced_optimizer_to_cpu(self, optimizer_state):
         """Offload all optimizer state tensors to CPU via a cached pinned buffer.

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -2091,8 +2091,20 @@ class MegatronPolicyWorkerImpl(
         no_grad.__enter__()
         self.model = self.move_model(self.model, "cpu")
         self.model.eval()
+        # Offload grad buffers (params already on CPU from the move above).
+        self.model = self.move_model(
+            self.model, "cpu", move_params=False, move_grads=True
+        )
         torch.randn(1).cuda()  # wake up torch allocator
-        self.offload_before_refit()  # rerun the old offload function
+        if (
+            hasattr(self, "optimizer")
+            and self.optimizer is not None
+            and not self.optimizer_cpu_offload
+        ):
+            self.move_optimizer("cpu")
+
+        gc.collect()
+        torch.cuda.empty_cache()
 
         allocated = torch.cuda.memory_allocated() / (1024**3)  # Convert to GB
         reserved = torch.cuda.memory_reserved() / (1024**3)  # Convert to GB

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -2156,22 +2156,92 @@ class MegatronPolicyWorkerImpl(
             optimizer_state = self.optimizer.state
         else:
             optimizer_state = self.optimizer._get_state()
+
+        use_pinned = self.cfg.get("use_pinned_optimizer_offload", False)
+
+        if device == "cpu":
+            if use_pinned:
+                self._coalesced_optimizer_to_cpu(optimizer_state)
+            else:
+                self._optimizer_to_cpu(optimizer_state)
+        elif device == "cuda":
+            if use_pinned:
+                self._coalesced_optimizer_to_cuda(optimizer_state)
+            else:
+                self._optimizer_to_cuda(optimizer_state)
+        else:
+            raise ValueError(
+                f"Invalid device: {device}. Only strings 'cpu' and 'cuda' are supported."
+            )
+
+    def _optimizer_to_cpu(self, optimizer_state):
+        """Offload optimizer state tensors to CPU using default pageable memory."""
         for _, state in optimizer_state.items():
-            # Iterate through the state items (e.g., momentum, variance) for a parameter
             for k, v in state.items():
-                # Check if the item is a tensor
-                if torch.is_tensor(v):
-                    # Move the tensor to device and update the state dictionary
-                    if device == "cpu":
-                        if v.is_cuda:
-                            state[k] = v.to("cpu")
-                    elif device == "cuda":
-                        if not v.is_cuda:
-                            state[k] = v.to("cuda")
-                    else:
-                        raise ValueError(
-                            f"Invalid device: {device}. Only strings 'cpu' and 'cuda' are supported."
-                        )
+                if torch.is_tensor(v) and v.is_cuda:
+                    state[k] = v.to("cpu")
+
+    def _optimizer_to_cuda(self, optimizer_state):
+        """Reload optimizer state tensors to CUDA."""
+        for _, state in optimizer_state.items():
+            for k, v in state.items():
+                if torch.is_tensor(v) and not v.is_cuda:
+                    state[k] = v.to("cuda")
+
+    def _get_or_alloc_pinned_buf(
+        self, attr_name: str, total_bytes: int
+    ) -> torch.Tensor:
+        """Return a cached pinned CPU buffer, allocating only on first use or resize."""
+        buf = getattr(self, attr_name, None)
+        if buf is None or buf.numel() < total_bytes:
+            buf = torch.empty(
+                total_bytes, device="cpu", dtype=torch.uint8, pin_memory=True
+            )
+            setattr(self, attr_name, buf)
+        return buf
+
+    def _coalesced_optimizer_to_cpu(self, optimizer_state):
+        """Offload all optimizer state tensors to CPU via a cached pinned buffer.
+
+        Packs all CUDA tensors into a single pre-allocated pinned CPU buffer,
+        eliminating per-tensor cudaHostAlloc overhead. The pinned buffer is
+        allocated once on first call and reused across iterations.
+        """
+        ALIGN = 512
+        entries = []
+        total_bytes = 0
+
+        for _, state in optimizer_state.items():
+            for k, v in state.items():
+                if not torch.is_tensor(v) or not v.is_cuda:
+                    continue
+                if v.dim() == 0:
+                    state[k] = v.cpu()
+                    continue
+                offset = (total_bytes + ALIGN - 1) // ALIGN * ALIGN
+                nbytes = v.numel() * v.element_size()
+                entries.append((state, k, v, offset, nbytes))
+                total_bytes = offset + nbytes
+
+        if not entries:
+            return
+
+        cpu_buf = self._get_or_alloc_pinned_buf("_optimizer_pinned_buf", total_bytes)
+
+        for state, k, v, offset, nbytes in entries:
+            dst = cpu_buf[offset : offset + nbytes].view(v.dtype).reshape(v.shape)
+            dst.copy_(v, non_blocking=True)
+            state[k] = dst
+
+        torch.cuda.synchronize()
+
+    def _coalesced_optimizer_to_cuda(self, optimizer_state):
+        """Reload all optimizer state tensors back to CUDA."""
+        for _, state in optimizer_state.items():
+            for k, v in state.items():
+                if torch.is_tensor(v) and not v.is_cuda:
+                    state[k] = v.to("cuda", non_blocking=True)
+        torch.cuda.synchronize()
 
     def save_checkpoint(
         self,

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -2157,7 +2157,7 @@ class MegatronPolicyWorkerImpl(
         else:
             optimizer_state = self.optimizer._get_state()
 
-        use_pinned = self.cfg.get("use_pinned_optimizer_offload", False)
+        use_pinned = self.cfg["use_pinned_optimizer_offload"]
 
         if device == "cpu":
             if use_pinned:
@@ -2199,6 +2199,11 @@ class MegatronPolicyWorkerImpl(
             )
             setattr(self, attr_name, buf)
         return buf
+
+    def _delete_pinned_buf(self, attr_name: str) -> None:
+        """Free a cached pinned CPU buffer allocated by _get_or_alloc_pinned_buf."""
+        if hasattr(self, attr_name):
+            delattr(self, attr_name)
 
     def _coalesced_optimizer_to_cpu(self, optimizer_state):
         """Offload all optimizer state tensors to CPU via a cached pinned buffer.

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -290,6 +290,13 @@ class MegatronPolicyWorkerImpl(
         self.cfg = config
         self._router_replay_enabled = router_replay_enabled(config)
 
+        if config.get("use_coalesced_optimizer_offload") and not config.get(
+            "use_pinned_optimizer_offload"
+        ):
+            raise ValueError(
+                "use_coalesced_optimizer_offload requires use_pinned_optimizer_offload=True."
+            )
+
         # Set rank for non-collocated to check which ranks to broadcast from
         self.rank = get_rank_safe()
         self.timer = Timer(context={"worker": "megatron_policy", "rank": self.rank})
@@ -1993,23 +2000,14 @@ class MegatronPolicyWorkerImpl(
             f"[_clear_fp8_caches] Cleared {workspace_count} workspace modules on rank {self.rank}"
         )
 
-    @wrap_with_nvtx_name("megatron_policy_worker/offload_before_refit")
-    def offload_before_refit(self):
-        """Offload the optimizer and buffers to the CPU."""
-        no_grad = torch.no_grad()
-        no_grad.__enter__()
-        allocated = torch.cuda.memory_allocated() / (1024**3)  # Convert to GB
-        reserved = torch.cuda.memory_reserved() / (1024**3)  # Convert to GB
-        print(
-            f"GPU Memory before optimizer offload: {allocated:.2f}GB allocated, {reserved:.2f}GB reserved"
-        )
-        self.model = self.move_model(
-            self.model, "cpu", move_params=False, move_grads=True
-        )  # get rid of grad buffers
+    def _clear_refit_memory_caches(self):
+        """Clear optional GPU memory caches that can cause creep for fp8/MoE models.
 
+        Called by both offload_before_refit and offload_after_refit so neither
+        diverges from the other on cache-cleanup behaviour.
+        """
         # When True, clear Transformer Engine's per-module _fp8_workspaces scratch
-        # buffers in offload_before_refit (before weight transfer to the inference
-        # engine).
+        # buffers before weight transfer to the inference engine.
         if self.fp8_cfg and self.fp8_cfg.get("force_clear_fp8_caches", False):
             self._clear_fp8_caches()
 
@@ -2065,6 +2063,22 @@ class MegatronPolicyWorkerImpl(
             except Exception:
                 pass
 
+    @wrap_with_nvtx_name("megatron_policy_worker/offload_before_refit")
+    def offload_before_refit(self):
+        """Offload the optimizer and buffers to the CPU."""
+        no_grad = torch.no_grad()
+        no_grad.__enter__()
+        allocated = torch.cuda.memory_allocated() / (1024**3)  # Convert to GB
+        reserved = torch.cuda.memory_reserved() / (1024**3)  # Convert to GB
+        print(
+            f"GPU Memory before optimizer offload: {allocated:.2f}GB allocated, {reserved:.2f}GB reserved"
+        )
+        self.model = self.move_model(
+            self.model, "cpu", move_params=False, move_grads=True
+        )  # get rid of grad buffers
+
+        self._clear_refit_memory_caches()
+
         torch.randn(1).cuda()  # wake up torch allocator
         if (
             hasattr(self, "optimizer")
@@ -2091,10 +2105,9 @@ class MegatronPolicyWorkerImpl(
         no_grad.__enter__()
         self.model = self.move_model(self.model, "cpu")
         self.model.eval()
-        # Offload grad buffers (params already on CPU from the move above).
-        self.model = self.move_model(
-            self.model, "cpu", move_params=False, move_grads=True
-        )
+
+        self._clear_refit_memory_caches()
+
         torch.randn(1).cuda()  # wake up torch allocator
         if (
             hasattr(self, "optimizer")

--- a/research/template_project/configs/grpo_math_1B.yaml
+++ b/research/template_project/configs/grpo_math_1B.yaml
@@ -63,6 +63,7 @@ policy:
   precision: "bfloat16"
   logprob_chunk_size: null
   offload_optimizer_for_logprob: false # Only useful for non-colocated generation since colocated generation will always offload optimizer to cuda before refit
+  use_pinned_optimizer_offload: false # Use pinned memory for optimizer D2H/H2D transfers
 
   dtensor_cfg:
     _v2: true

--- a/research/template_project/configs/grpo_math_1B.yaml
+++ b/research/template_project/configs/grpo_math_1B.yaml
@@ -98,6 +98,7 @@ policy:
   precision: "bfloat16"
   logprob_chunk_size: null
   offload_optimizer_for_logprob: false # Only useful for non-colocated generation since colocated generation will always offload optimizer to cuda before refit
+  use_pinned_optimizer_offload: false # Use pinned memory for optimizer D2H/H2D transfers
 
   dtensor_cfg:
     _v2: true

--- a/research/template_project/configs/grpo_math_1B.yaml
+++ b/research/template_project/configs/grpo_math_1B.yaml
@@ -98,7 +98,8 @@ policy:
   precision: "bfloat16"
   logprob_chunk_size: null
   offload_optimizer_for_logprob: false # Only useful for non-colocated generation since colocated generation will always offload optimizer to cuda before refit
-  use_pinned_optimizer_offload: false # Use pinned memory for optimizer D2H/H2D transfers
+  use_pinned_optimizer_offload: false # Use pinned memory for optimizer D2H/H2D transfers (per-tensor pinning)
+  use_coalesced_optimizer_offload: false # Coalesce all optimizer state into a single pinned buffer; requires use_pinned_optimizer_offload=true. Faster but may OOM on very large models.
 
   dtensor_cfg:
     _v2: true

--- a/tests/functional/test_converter_roundtrip.py
+++ b/tests/functional/test_converter_roundtrip.py
@@ -87,6 +87,7 @@ def create_test_config() -> Dict[str, Any]:
             "max_total_sequence_length": 128,
             "precision": "bfloat16",
             "offload_optimizer_for_logprob": False,
+            "use_pinned_optimizer_offload": False,
             "dtensor_cfg": {
                 "_v2": False,
                 "enabled": True,

--- a/tests/functional/test_converter_roundtrip.py
+++ b/tests/functional/test_converter_roundtrip.py
@@ -88,6 +88,7 @@ def create_test_config() -> Dict[str, Any]:
             "precision": "bfloat16",
             "offload_optimizer_for_logprob": False,
             "use_pinned_optimizer_offload": False,
+            "use_coalesced_optimizer_offload": False,
             "dtensor_cfg": {
                 "_v2": False,
                 "enabled": True,

--- a/tests/unit/data_plane/conftest.py
+++ b/tests/unit/data_plane/conftest.py
@@ -30,6 +30,8 @@ smoke / smoke-backend / smoke-1d / obj-backend / mix-e2e today).
 from __future__ import annotations
 
 import pytest
+import torch
+from tensordict import TensorDict
 
 from nemo_rl.data_plane import build_data_plane_client
 
@@ -68,6 +70,27 @@ def _session_tq_client_mooncake_cpu():
             "(set NEMO_RL_REQUIRE_MOONCAKE=1 to fail loud)"
         )
     client = build_data_plane_client(_make_tq_cfg("mooncake_cpu"))
+
+    # Probe that the mooncake store actually works at runtime.
+    # Installed-but-broken mooncake (e.g. no RDMA / SHM init failure)
+    # returns non-zero error codes from batch_upsert_from; skip rather
+    # than fail the test suite in that environment.
+    try:
+        _probe_id = "__mooncake_probe__"
+        client.register_partition(_probe_id, ["_x"], 1, ["_probe"])
+        client.put_samples(
+            ["_a"],
+            _probe_id,
+            TensorDict({"_x": torch.zeros(1, dtype=torch.float32)}, batch_size=[1]),
+        )
+        client.clear_samples(sample_ids=None, partition_id=_probe_id)
+    except RuntimeError as e:
+        client.close()
+        pytest.skip(
+            f"mooncake installed but not functional ({e}) — "
+            "skipping mooncake_cpu backend"
+        )
+
     yield client
     client.close()
 

--- a/tests/unit/environments/test_reward_model_environment.py
+++ b/tests/unit/environments/test_reward_model_environment.py
@@ -37,6 +37,7 @@ basic_env_config: RewardModelEnvironmentConfig = {
     "precision": "bfloat16",
     "offload_optimizer_for_logprob": False,
     "use_pinned_optimizer_offload": False,
+    "use_coalesced_optimizer_offload": False,
     "batch_size": 32,
     "checkpoint_path": None,
     "max_model_len": MAX_MODEL_LEN,

--- a/tests/unit/environments/test_reward_model_environment.py
+++ b/tests/unit/environments/test_reward_model_environment.py
@@ -36,6 +36,7 @@ basic_env_config: RewardModelEnvironmentConfig = {
     "tokenizer": {"name": REWARD_MODEL_NAME},
     "precision": "bfloat16",
     "offload_optimizer_for_logprob": False,
+    "use_pinned_optimizer_offload": False,
     "batch_size": 32,
     "checkpoint_path": None,
     "max_model_len": MAX_MODEL_LEN,

--- a/tests/unit/models/automodel/test_automodel_setup.py
+++ b/tests/unit/models/automodel/test_automodel_setup.py
@@ -53,6 +53,7 @@ def mock_config():
         "precision": "bfloat16",
         "max_grad_norm": 1.0,
         "offload_optimizer_for_logprob": False,
+        "use_pinned_optimizer_offload": False,
         "sequence_packing": {"enabled": False},
         "dtensor_cfg": {
             "cpu_offload": False,

--- a/tests/unit/models/automodel/test_automodel_setup.py
+++ b/tests/unit/models/automodel/test_automodel_setup.py
@@ -54,6 +54,7 @@ def mock_config():
         "max_grad_norm": 1.0,
         "offload_optimizer_for_logprob": False,
         "use_pinned_optimizer_offload": False,
+        "use_coalesced_optimizer_offload": False,
         "sequence_packing": {"enabled": False},
         "dtensor_cfg": {
             "cpu_offload": False,

--- a/tests/unit/models/generation/test_megatron_generation.py
+++ b/tests/unit/models/generation/test_megatron_generation.py
@@ -40,6 +40,8 @@ basic_megatron_test_config: PolicyConfig = {
     # The dynamic inference engine requires fp16/bf16
     "precision": "bfloat16",
     "offload_optimizer_for_logprob": False,
+    "use_pinned_optimizer_offload": False,
+    "use_coalesced_optimizer_offload": False,
     "dtensor_cfg": {"enabled": False},
     "dynamic_batching": {"enabled": False},
     "sequence_packing": {"enabled": False},

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -105,6 +105,7 @@ basic_dtensor_test_config: PolicyConfig = {
     "precision": "float32",
     "offload_optimizer_for_logprob": False,
     "use_pinned_optimizer_offload": False,
+    "use_coalesced_optimizer_offload": False,
     "optimizer": {
         "name": "torch.optim.AdamW",
         "kwargs": {
@@ -520,6 +521,7 @@ def get_basic_megatron_test_config(
         "precision": precision,
         "offload_optimizer_for_logprob": False,
         "use_pinned_optimizer_offload": False,
+        "use_coalesced_optimizer_offload": False,
         "dtensor_cfg": {
             "enabled": False,  # Disabled for Megatron tests
         },

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -104,6 +104,7 @@ basic_dtensor_test_config: PolicyConfig = {
     "do_sample": False,
     "precision": "float32",
     "offload_optimizer_for_logprob": False,
+    "use_pinned_optimizer_offload": False,
     "optimizer": {
         "name": "torch.optim.AdamW",
         "kwargs": {
@@ -518,6 +519,7 @@ def get_basic_megatron_test_config(
         "logprob_batch_size": 2,
         "precision": precision,
         "offload_optimizer_for_logprob": False,
+        "use_pinned_optimizer_offload": False,
         "dtensor_cfg": {
             "enabled": False,  # Disabled for Megatron tests
         },

--- a/tests/unit/models/megatron/test_megatron_setup.py
+++ b/tests/unit/models/megatron/test_megatron_setup.py
@@ -1664,6 +1664,7 @@ class TestValidateAndSetConfig:
             },
             "offload_optimizer_for_logprob": False,
             "use_pinned_optimizer_offload": False,
+            "use_coalesced_optimizer_offload": False,
         }
 
         with pytest.raises(NotImplementedError) as exc_info:
@@ -1700,6 +1701,7 @@ class TestValidateAndSetConfig:
             },
             "offload_optimizer_for_logprob": False,
             "use_pinned_optimizer_offload": False,
+            "use_coalesced_optimizer_offload": False,
         }
 
         # The function would fail on setup_model_config, but we test the initial parsing

--- a/tests/unit/models/megatron/test_megatron_setup.py
+++ b/tests/unit/models/megatron/test_megatron_setup.py
@@ -1663,6 +1663,7 @@ class TestValidateAndSetConfig:
                 },
             },
             "offload_optimizer_for_logprob": False,
+            "use_pinned_optimizer_offload": False,
         }
 
         with pytest.raises(NotImplementedError) as exc_info:
@@ -1698,6 +1699,7 @@ class TestValidateAndSetConfig:
                 "tensor_model_parallel_size": 2,
             },
             "offload_optimizer_for_logprob": False,
+            "use_pinned_optimizer_offload": False,
         }
 
         # The function would fail on setup_model_config, but we test the initial parsing

--- a/tests/unit/models/policy/test_dtensor_worker.py
+++ b/tests/unit/models/policy/test_dtensor_worker.py
@@ -85,6 +85,7 @@ def create_test_config(
         "precision": "float32",
         "offload_optimizer_for_logprob": False,
         "use_pinned_optimizer_offload": False,
+        "use_coalesced_optimizer_offload": False,
         "generation": {
             "backend": "hf",
             "temperature": 1.0,

--- a/tests/unit/models/policy/test_dtensor_worker.py
+++ b/tests/unit/models/policy/test_dtensor_worker.py
@@ -84,6 +84,7 @@ def create_test_config(
         "logprob_batch_size": 1,
         "precision": "float32",
         "offload_optimizer_for_logprob": False,
+        "use_pinned_optimizer_offload": False,
         "generation": {
             "backend": "hf",
             "temperature": 1.0,

--- a/tests/unit/models/policy/test_dtensor_worker_v2.py
+++ b/tests/unit/models/policy/test_dtensor_worker_v2.py
@@ -124,6 +124,7 @@ def create_test_config(
         "precision": precision,
         "offload_optimizer_for_logprob": False,
         "use_pinned_optimizer_offload": False,
+        "use_coalesced_optimizer_offload": False,
         "generation": {
             "backend": "hf",
             "temperature": 1.0,

--- a/tests/unit/models/policy/test_dtensor_worker_v2.py
+++ b/tests/unit/models/policy/test_dtensor_worker_v2.py
@@ -123,6 +123,7 @@ def create_test_config(
         "logprob_batch_size": 1,
         "precision": precision,
         "offload_optimizer_for_logprob": False,
+        "use_pinned_optimizer_offload": False,
         "generation": {
             "backend": "hf",
             "temperature": 1.0,

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -2847,3 +2847,179 @@ def test_megatron_policy_flops_range_check(tiny_llama_model_path):
     finally:
         policy.shutdown()
         cluster.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Pinned optimizer offload tests
+# ---------------------------------------------------------------------------
+
+
+def _make_optimizer_state(shapes, dtype=torch.float32, include_scalar=False):
+    """Build a fake optimizer_state dict mimicking Adam (exp_avg, exp_avg_sq)."""
+    state = {}
+    for i, shape in enumerate(shapes):
+        param_state = {
+            "exp_avg": torch.randn(shape, device="cuda", dtype=dtype),
+            "exp_avg_sq": torch.randn(shape, device="cuda", dtype=dtype).abs(),
+        }
+        if include_scalar:
+            param_state["step"] = torch.tensor(10.0, device="cuda", dtype=dtype)
+        state[i] = param_state
+    return state
+
+
+class _FakeOptimizer:
+    """Minimal optimizer stub that exposes state via _get_state()."""
+
+    def __init__(self, state):
+        self._state = state
+
+    def _get_state(self):
+        return self._state
+
+
+def _make_pinned_test_worker(use_pinned, optimizer_state):
+    """Build a stub worker with only the attributes needed for optimizer offload."""
+    from nemo_rl.models.policy.workers.megatron_policy_worker import (
+        MegatronPolicyWorkerImpl,
+    )
+
+    worker = object.__new__(MegatronPolicyWorkerImpl)
+    worker.cfg = {"use_pinned_optimizer_offload": use_pinned}
+    worker.optimizer = _FakeOptimizer(optimizer_state)
+    return worker
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+class TestOptimizerOffloadRoundtrip:
+    """Verify optimizer state survives a GPU -> CPU -> GPU round-trip."""
+
+    @pytest.mark.parametrize("use_pinned", [False, True], ids=["pageable", "pinned"])
+    def test_values_preserved(self, use_pinned):
+        shapes = [(64, 128), (32,), (256, 256)]
+        state = _make_optimizer_state(shapes, include_scalar=True)
+        worker = _make_pinned_test_worker(use_pinned, state)
+
+        originals = {}
+        for pid, param_state in state.items():
+            originals[pid] = {k: v.clone() for k, v in param_state.items()}
+
+        worker.move_optimizer("cpu")
+        for param_state in state.values():
+            for v in param_state.values():
+                assert not v.is_cuda, "tensor should be on CPU after offload"
+
+        worker.move_optimizer("cuda")
+        for pid, param_state in state.items():
+            for k, v in param_state.items():
+                assert v.is_cuda, f"tensor {k} should be back on CUDA"
+                torch.testing.assert_close(
+                    v, originals[pid][k], msg=lambda m: f"param {pid}/{k}: {m}"
+                )
+
+    @pytest.mark.parametrize("use_pinned", [False, True], ids=["pageable", "pinned"])
+    def test_multiple_dtypes(self, use_pinned):
+        for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+            state = _make_optimizer_state([(128,)], dtype=dtype)
+            worker = _make_pinned_test_worker(use_pinned, state)
+            original = state[0]["exp_avg"].clone()
+
+            worker.move_optimizer("cpu")
+            worker.move_optimizer("cuda")
+
+            torch.testing.assert_close(state[0]["exp_avg"], original)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+class TestPinnedBufferCaching:
+    """Verify the pinned path allocates the buffer once and reuses it."""
+
+    def test_buffer_reused_across_calls(self):
+        state = _make_optimizer_state([(64, 128)])
+        worker = _make_pinned_test_worker(True, state)
+
+        worker.move_optimizer("cpu")
+        buf1 = worker._optimizer_pinned_buf
+
+        worker.move_optimizer("cuda")
+        worker.move_optimizer("cpu")
+        buf2 = worker._optimizer_pinned_buf
+
+        assert buf1.data_ptr() == buf2.data_ptr(), "pinned buffer should be reused"
+
+    def test_no_pinned_buf_when_disabled(self):
+        state = _make_optimizer_state([(64, 128)])
+        worker = _make_pinned_test_worker(False, state)
+
+        worker.move_optimizer("cpu")
+        assert not hasattr(worker, "_optimizer_pinned_buf")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+class TestPinnedMemoryProperties:
+    """Verify CPU tensors from the pinned path are actually pinned."""
+
+    def test_cpu_tensors_are_pinned(self):
+        state = _make_optimizer_state([(64, 128), (256,)])
+        worker = _make_pinned_test_worker(True, state)
+
+        worker.move_optimizer("cpu")
+        for param_state in state.values():
+            for k, v in param_state.items():
+                if v.dim() > 0:
+                    assert v.is_pinned(), f"{k} should be in pinned memory"
+
+    def test_cpu_tensors_not_pinned_when_disabled(self):
+        state = _make_optimizer_state([(64, 128)])
+        worker = _make_pinned_test_worker(False, state)
+
+        worker.move_optimizer("cpu")
+        for param_state in state.values():
+            for v in param_state.values():
+                assert not v.is_pinned(), (
+                    "pageable path should not produce pinned tensors"
+                )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+class TestPinnedOptimizerEdgeCases:
+    """Edge cases: empty state, scalars only, invalid device."""
+
+    @pytest.mark.parametrize("use_pinned", [False, True], ids=["pageable", "pinned"])
+    def test_empty_optimizer_state(self, use_pinned):
+        state = {}
+        worker = _make_pinned_test_worker(use_pinned, state)
+        worker.move_optimizer("cpu")
+        worker.move_optimizer("cuda")
+
+    @pytest.mark.parametrize("use_pinned", [False, True], ids=["pageable", "pinned"])
+    def test_scalars_only(self, use_pinned):
+        state = {0: {"step": torch.tensor(5.0, device="cuda")}}
+        worker = _make_pinned_test_worker(use_pinned, state)
+
+        worker.move_optimizer("cpu")
+        assert not state[0]["step"].is_cuda
+
+        worker.move_optimizer("cuda")
+        assert state[0]["step"].is_cuda
+
+    @pytest.mark.parametrize("use_pinned", [False, True], ids=["pageable", "pinned"])
+    def test_invalid_device_raises(self, use_pinned):
+        state = _make_optimizer_state([(8,)])
+        worker = _make_pinned_test_worker(use_pinned, state)
+        with pytest.raises(ValueError, match="Invalid device"):
+            worker.move_optimizer("tpu")
+
+    def test_pinned_buffer_grows_if_needed(self):
+        state_small = _make_optimizer_state([(16,)])
+        worker = _make_pinned_test_worker(True, state_small)
+        worker.move_optimizer("cpu")
+        small_size = worker._optimizer_pinned_buf.numel()
+
+        state_large = _make_optimizer_state([(16,), (1024, 1024)])
+        worker.optimizer = _FakeOptimizer(state_large)
+        worker.move_optimizer("cuda")
+        worker.move_optimizer("cpu")
+        large_size = worker._optimizer_pinned_buf.numel()
+
+        assert large_size > small_size, "buffer should grow for larger state"

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -236,6 +236,7 @@ def create_megatron_test_config(
         "logprob_chunk_size": logprob_chunk_size,
         "precision": precision,
         "offload_optimizer_for_logprob": False,
+        "use_pinned_optimizer_offload": False,
         "generation": {
             "backend": generation_backend,
             "temperature": 1.0,

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -3097,3 +3097,179 @@ def test_megatron_policy_flops_range_check(tiny_llama_model_path):
     finally:
         policy.shutdown()
         cluster.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Pinned optimizer offload tests
+# ---------------------------------------------------------------------------
+
+
+def _make_optimizer_state(shapes, dtype=torch.float32, include_scalar=False):
+    """Build a fake optimizer_state dict mimicking Adam (exp_avg, exp_avg_sq)."""
+    state = {}
+    for i, shape in enumerate(shapes):
+        param_state = {
+            "exp_avg": torch.randn(shape, device="cuda", dtype=dtype),
+            "exp_avg_sq": torch.randn(shape, device="cuda", dtype=dtype).abs(),
+        }
+        if include_scalar:
+            param_state["step"] = torch.tensor(10.0, device="cuda", dtype=dtype)
+        state[i] = param_state
+    return state
+
+
+class _FakeOptimizer:
+    """Minimal optimizer stub that exposes state via _get_state()."""
+
+    def __init__(self, state):
+        self._state = state
+
+    def _get_state(self):
+        return self._state
+
+
+def _make_pinned_test_worker(use_pinned, optimizer_state):
+    """Build a stub worker with only the attributes needed for optimizer offload."""
+    from nemo_rl.models.policy.workers.megatron_policy_worker import (
+        MegatronPolicyWorkerImpl,
+    )
+
+    worker = object.__new__(MegatronPolicyWorkerImpl)
+    worker.cfg = {"use_pinned_optimizer_offload": use_pinned}
+    worker.optimizer = _FakeOptimizer(optimizer_state)
+    return worker
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+class TestOptimizerOffloadRoundtrip:
+    """Verify optimizer state survives a GPU -> CPU -> GPU round-trip."""
+
+    @pytest.mark.parametrize("use_pinned", [False, True], ids=["pageable", "pinned"])
+    def test_values_preserved(self, use_pinned):
+        shapes = [(64, 128), (32,), (256, 256)]
+        state = _make_optimizer_state(shapes, include_scalar=True)
+        worker = _make_pinned_test_worker(use_pinned, state)
+
+        originals = {}
+        for pid, param_state in state.items():
+            originals[pid] = {k: v.clone() for k, v in param_state.items()}
+
+        worker.move_optimizer("cpu")
+        for param_state in state.values():
+            for v in param_state.values():
+                assert not v.is_cuda, "tensor should be on CPU after offload"
+
+        worker.move_optimizer("cuda")
+        for pid, param_state in state.items():
+            for k, v in param_state.items():
+                assert v.is_cuda, f"tensor {k} should be back on CUDA"
+                torch.testing.assert_close(
+                    v, originals[pid][k], msg=lambda m: f"param {pid}/{k}: {m}"
+                )
+
+    @pytest.mark.parametrize("use_pinned", [False, True], ids=["pageable", "pinned"])
+    def test_multiple_dtypes(self, use_pinned):
+        for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+            state = _make_optimizer_state([(128,)], dtype=dtype)
+            worker = _make_pinned_test_worker(use_pinned, state)
+            original = state[0]["exp_avg"].clone()
+
+            worker.move_optimizer("cpu")
+            worker.move_optimizer("cuda")
+
+            torch.testing.assert_close(state[0]["exp_avg"], original)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+class TestPinnedBufferCaching:
+    """Verify the pinned path allocates the buffer once and reuses it."""
+
+    def test_buffer_reused_across_calls(self):
+        state = _make_optimizer_state([(64, 128)])
+        worker = _make_pinned_test_worker(True, state)
+
+        worker.move_optimizer("cpu")
+        buf1 = worker._optimizer_pinned_buf
+
+        worker.move_optimizer("cuda")
+        worker.move_optimizer("cpu")
+        buf2 = worker._optimizer_pinned_buf
+
+        assert buf1.data_ptr() == buf2.data_ptr(), "pinned buffer should be reused"
+
+    def test_no_pinned_buf_when_disabled(self):
+        state = _make_optimizer_state([(64, 128)])
+        worker = _make_pinned_test_worker(False, state)
+
+        worker.move_optimizer("cpu")
+        assert not hasattr(worker, "_optimizer_pinned_buf")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+class TestPinnedMemoryProperties:
+    """Verify CPU tensors from the pinned path are actually pinned."""
+
+    def test_cpu_tensors_are_pinned(self):
+        state = _make_optimizer_state([(64, 128), (256,)])
+        worker = _make_pinned_test_worker(True, state)
+
+        worker.move_optimizer("cpu")
+        for param_state in state.values():
+            for k, v in param_state.items():
+                if v.dim() > 0:
+                    assert v.is_pinned(), f"{k} should be in pinned memory"
+
+    def test_cpu_tensors_not_pinned_when_disabled(self):
+        state = _make_optimizer_state([(64, 128)])
+        worker = _make_pinned_test_worker(False, state)
+
+        worker.move_optimizer("cpu")
+        for param_state in state.values():
+            for v in param_state.values():
+                assert not v.is_pinned(), (
+                    "pageable path should not produce pinned tensors"
+                )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+class TestPinnedOptimizerEdgeCases:
+    """Edge cases: empty state, scalars only, invalid device."""
+
+    @pytest.mark.parametrize("use_pinned", [False, True], ids=["pageable", "pinned"])
+    def test_empty_optimizer_state(self, use_pinned):
+        state = {}
+        worker = _make_pinned_test_worker(use_pinned, state)
+        worker.move_optimizer("cpu")
+        worker.move_optimizer("cuda")
+
+    @pytest.mark.parametrize("use_pinned", [False, True], ids=["pageable", "pinned"])
+    def test_scalars_only(self, use_pinned):
+        state = {0: {"step": torch.tensor(5.0, device="cuda")}}
+        worker = _make_pinned_test_worker(use_pinned, state)
+
+        worker.move_optimizer("cpu")
+        assert not state[0]["step"].is_cuda
+
+        worker.move_optimizer("cuda")
+        assert state[0]["step"].is_cuda
+
+    @pytest.mark.parametrize("use_pinned", [False, True], ids=["pageable", "pinned"])
+    def test_invalid_device_raises(self, use_pinned):
+        state = _make_optimizer_state([(8,)])
+        worker = _make_pinned_test_worker(use_pinned, state)
+        with pytest.raises(ValueError, match="Invalid device"):
+            worker.move_optimizer("tpu")
+
+    def test_pinned_buffer_grows_if_needed(self):
+        state_small = _make_optimizer_state([(16,)])
+        worker = _make_pinned_test_worker(True, state_small)
+        worker.move_optimizer("cpu")
+        small_size = worker._optimizer_pinned_buf.numel()
+
+        state_large = _make_optimizer_state([(16,), (1024, 1024)])
+        worker.optimizer = _FakeOptimizer(state_large)
+        worker.move_optimizer("cuda")
+        worker.move_optimizer("cpu")
+        large_size = worker._optimizer_pinned_buf.numel()
+
+        assert large_size > small_size, "buffer should grow for larger state"

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -237,6 +237,7 @@ def create_megatron_test_config(
         "precision": precision,
         "offload_optimizer_for_logprob": False,
         "use_pinned_optimizer_offload": False,
+        "use_coalesced_optimizer_offload": False,
         "generation": {
             "backend": generation_backend,
             "temperature": 1.0,
@@ -3129,14 +3130,24 @@ class _FakeOptimizer:
         return self._state
 
 
-def _make_pinned_test_worker(use_pinned, optimizer_state):
+_MODES = [
+    pytest.param(False, False, id="pageable"),
+    pytest.param(True, False, id="pinned"),
+    pytest.param(True, True, id="coalesced"),
+]
+
+
+def _make_pinned_test_worker(use_pinned, optimizer_state, use_coalesced=False):
     """Build a stub worker with only the attributes needed for optimizer offload."""
     from nemo_rl.models.policy.workers.megatron_policy_worker import (
         MegatronPolicyWorkerImpl,
     )
 
     worker = object.__new__(MegatronPolicyWorkerImpl)
-    worker.cfg = {"use_pinned_optimizer_offload": use_pinned}
+    worker.cfg = {
+        "use_pinned_optimizer_offload": use_pinned,
+        "use_coalesced_optimizer_offload": use_coalesced,
+    }
     worker.optimizer = _FakeOptimizer(optimizer_state)
     return worker
 
@@ -3145,11 +3156,11 @@ def _make_pinned_test_worker(use_pinned, optimizer_state):
 class TestOptimizerOffloadRoundtrip:
     """Verify optimizer state survives a GPU -> CPU -> GPU round-trip."""
 
-    @pytest.mark.parametrize("use_pinned", [False, True], ids=["pageable", "pinned"])
-    def test_values_preserved(self, use_pinned):
+    @pytest.mark.parametrize("use_pinned,use_coalesced", _MODES)
+    def test_values_preserved(self, use_pinned, use_coalesced):
         shapes = [(64, 128), (32,), (256, 256)]
         state = _make_optimizer_state(shapes, include_scalar=True)
-        worker = _make_pinned_test_worker(use_pinned, state)
+        worker = _make_pinned_test_worker(use_pinned, state, use_coalesced)
 
         originals = {}
         for pid, param_state in state.items():
@@ -3168,11 +3179,11 @@ class TestOptimizerOffloadRoundtrip:
                     v, originals[pid][k], msg=lambda m: f"param {pid}/{k}: {m}"
                 )
 
-    @pytest.mark.parametrize("use_pinned", [False, True], ids=["pageable", "pinned"])
-    def test_multiple_dtypes(self, use_pinned):
+    @pytest.mark.parametrize("use_pinned,use_coalesced", _MODES)
+    def test_multiple_dtypes(self, use_pinned, use_coalesced):
         for dtype in [torch.float32, torch.float16, torch.bfloat16]:
             state = _make_optimizer_state([(128,)], dtype=dtype)
-            worker = _make_pinned_test_worker(use_pinned, state)
+            worker = _make_pinned_test_worker(use_pinned, state, use_coalesced)
             original = state[0]["exp_avg"].clone()
 
             worker.move_optimizer("cpu")
@@ -3182,12 +3193,12 @@ class TestOptimizerOffloadRoundtrip:
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-class TestPinnedBufferCaching:
-    """Verify the pinned path allocates the buffer once and reuses it."""
+class TestCoalescedBufferCaching:
+    """Verify the coalesced path allocates the buffer once and reuses it."""
 
     def test_buffer_reused_across_calls(self):
         state = _make_optimizer_state([(64, 128)])
-        worker = _make_pinned_test_worker(True, state)
+        worker = _make_pinned_test_worker(True, state, use_coalesced=True)
 
         worker.move_optimizer("cpu")
         buf1 = worker._optimizer_pinned_buf
@@ -3198,21 +3209,33 @@ class TestPinnedBufferCaching:
 
         assert buf1.data_ptr() == buf2.data_ptr(), "pinned buffer should be reused"
 
-    def test_no_pinned_buf_when_disabled(self):
+    def test_no_pinned_buf_when_pageable(self):
         state = _make_optimizer_state([(64, 128)])
         worker = _make_pinned_test_worker(False, state)
 
         worker.move_optimizer("cpu")
         assert not hasattr(worker, "_optimizer_pinned_buf")
 
+    def test_no_pinned_buf_when_pinned_per_tensor(self):
+        state = _make_optimizer_state([(64, 128)])
+        worker = _make_pinned_test_worker(True, state, use_coalesced=False)
+
+        worker.move_optimizer("cpu")
+        assert not hasattr(worker, "_optimizer_pinned_buf"), (
+            "per-tensor pinned path must not allocate the coalesced buffer"
+        )
+
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 class TestPinnedMemoryProperties:
-    """Verify CPU tensors from the pinned path are actually pinned."""
+    """Verify CPU tensors from the pinned paths are actually pinned."""
 
-    def test_cpu_tensors_are_pinned(self):
+    @pytest.mark.parametrize(
+        "use_coalesced", [False, True], ids=["per-tensor", "coalesced"]
+    )
+    def test_cpu_tensors_are_pinned(self, use_coalesced):
         state = _make_optimizer_state([(64, 128), (256,)])
-        worker = _make_pinned_test_worker(True, state)
+        worker = _make_pinned_test_worker(True, state, use_coalesced)
 
         worker.move_optimizer("cpu")
         for param_state in state.values():
@@ -3236,17 +3259,17 @@ class TestPinnedMemoryProperties:
 class TestPinnedOptimizerEdgeCases:
     """Edge cases: empty state, scalars only, invalid device."""
 
-    @pytest.mark.parametrize("use_pinned", [False, True], ids=["pageable", "pinned"])
-    def test_empty_optimizer_state(self, use_pinned):
+    @pytest.mark.parametrize("use_pinned,use_coalesced", _MODES)
+    def test_empty_optimizer_state(self, use_pinned, use_coalesced):
         state = {}
-        worker = _make_pinned_test_worker(use_pinned, state)
+        worker = _make_pinned_test_worker(use_pinned, state, use_coalesced)
         worker.move_optimizer("cpu")
         worker.move_optimizer("cuda")
 
-    @pytest.mark.parametrize("use_pinned", [False, True], ids=["pageable", "pinned"])
-    def test_scalars_only(self, use_pinned):
+    @pytest.mark.parametrize("use_pinned,use_coalesced", _MODES)
+    def test_scalars_only(self, use_pinned, use_coalesced):
         state = {0: {"step": torch.tensor(5.0, device="cuda")}}
-        worker = _make_pinned_test_worker(use_pinned, state)
+        worker = _make_pinned_test_worker(use_pinned, state, use_coalesced)
 
         worker.move_optimizer("cpu")
         assert not state[0]["step"].is_cuda
@@ -3254,16 +3277,24 @@ class TestPinnedOptimizerEdgeCases:
         worker.move_optimizer("cuda")
         assert state[0]["step"].is_cuda
 
-    @pytest.mark.parametrize("use_pinned", [False, True], ids=["pageable", "pinned"])
-    def test_invalid_device_raises(self, use_pinned):
+    @pytest.mark.parametrize("use_pinned,use_coalesced", _MODES)
+    def test_invalid_device_raises(self, use_pinned, use_coalesced):
         state = _make_optimizer_state([(8,)])
-        worker = _make_pinned_test_worker(use_pinned, state)
+        worker = _make_pinned_test_worker(use_pinned, state, use_coalesced)
         with pytest.raises(ValueError, match="Invalid device"):
             worker.move_optimizer("tpu")
 
+    def test_coalesced_without_pinned_raises(self):
+        state = _make_optimizer_state([(8,)])
+        worker = _make_pinned_test_worker(False, state, use_coalesced=True)
+        with pytest.raises(
+            ValueError, match="use_coalesced_optimizer_offload requires"
+        ):
+            worker.move_optimizer("cpu")
+
     def test_pinned_buffer_grows_if_needed(self):
         state_small = _make_optimizer_state([(16,)])
-        worker = _make_pinned_test_worker(True, state_small)
+        worker = _make_pinned_test_worker(True, state_small, use_coalesced=True)
         worker.move_optimizer("cpu")
         small_size = worker._optimizer_pinned_buf.numel()
 

--- a/tests/unit/models/policy/test_policy_validation.py
+++ b/tests/unit/models/policy/test_policy_validation.py
@@ -68,6 +68,7 @@ def create_dtensor_config(
         "logprob_batch_size": 1,
         "precision": "float32",
         "offload_optimizer_for_logprob": False,
+        "use_pinned_optimizer_offload": False,
         "generation": {
             "backend": "hf",
             "temperature": 1.0,
@@ -124,6 +125,7 @@ def create_megatron_config(
         "logprob_batch_size": 1,
         "precision": "float32",
         "offload_optimizer_for_logprob": False,
+        "use_pinned_optimizer_offload": False,
         "generation": {
             "backend": "hf",
             "temperature": 1.0,

--- a/tests/unit/models/policy/test_policy_validation.py
+++ b/tests/unit/models/policy/test_policy_validation.py
@@ -69,6 +69,7 @@ def create_dtensor_config(
         "precision": "float32",
         "offload_optimizer_for_logprob": False,
         "use_pinned_optimizer_offload": False,
+        "use_coalesced_optimizer_offload": False,
         "generation": {
             "backend": "hf",
             "temperature": 1.0,
@@ -126,6 +127,7 @@ def create_megatron_config(
         "precision": "float32",
         "offload_optimizer_for_logprob": False,
         "use_pinned_optimizer_offload": False,
+        "use_coalesced_optimizer_offload": False,
         "generation": {
             "backend": "hf",
             "temperature": 1.0,

--- a/tests/unit/reference_configs/distillation_math.yaml
+++ b/tests/unit/reference_configs/distillation_math.yaml
@@ -44,6 +44,8 @@ policy: &POLICY_BASE
     logprob_chunk_size: null
 
     offload_optimizer_for_logprob: false
+    use_pinned_optimizer_offload: false
+    use_coalesced_optimizer_offload: false
 
     dtensor_cfg: &DTENSOR_BASE
         enabled: true

--- a/tests/unit/reference_configs/dpo.yaml
+++ b/tests/unit/reference_configs/dpo.yaml
@@ -48,6 +48,8 @@ policy:
   precision: "bfloat16"
 
   offload_optimizer_for_logprob: false
+  use_pinned_optimizer_offload: false
+  use_coalesced_optimizer_offload: false
 
   dtensor_cfg:
     env_vars:

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -124,6 +124,8 @@ policy:
   precision: "bfloat16"
   logprob_chunk_size: null
   offload_optimizer_for_logprob: false # Only useful for non-colocated generation since colocated generation will always offload optimizer to cuda before refit
+  use_pinned_optimizer_offload: false
+  use_coalesced_optimizer_offload: false
 
   dtensor_cfg:
     _v2: true

--- a/tests/unit/reference_configs/ppo_math_1B_megatron.yaml
+++ b/tests/unit/reference_configs/ppo_math_1B_megatron.yaml
@@ -100,6 +100,8 @@ policy:
   precision: "bfloat16"
   logprob_chunk_size: null
   offload_optimizer_for_logprob: false
+  use_pinned_optimizer_offload: false
+  use_coalesced_optimizer_offload: false
 
   dtensor_cfg:
     _v2: true

--- a/tests/unit/reference_configs/rm.yaml
+++ b/tests/unit/reference_configs/rm.yaml
@@ -38,6 +38,8 @@ policy:
   activation_checkpointing_enabled: false
 
   offload_optimizer_for_logprob: false
+  use_pinned_optimizer_offload: false
+  use_coalesced_optimizer_offload: false
 
   reward_model_cfg:
     enabled: true  # loads model as a Reward Model (do not change)

--- a/tests/unit/reference_configs/sft.yaml
+++ b/tests/unit/reference_configs/sft.yaml
@@ -37,6 +37,8 @@ policy:
   precision: "bfloat16"
 
   offload_optimizer_for_logprob: false
+  use_pinned_optimizer_offload: false
+  use_coalesced_optimizer_offload: false
 
   dtensor_cfg:
     _v2: true

--- a/tests/unit/utils/test_native_checkpoint.py
+++ b/tests/unit/utils/test_native_checkpoint.py
@@ -44,6 +44,7 @@ simple_policy_config = {
     "precision": "float32",
     "offload_optimizer_for_logprob": False,
     "use_pinned_optimizer_offload": False,
+    "use_coalesced_optimizer_offload": False,
     "optimizer": {
         "name": "torch.optim.AdamW",
         "kwargs": {

--- a/tests/unit/utils/test_native_checkpoint.py
+++ b/tests/unit/utils/test_native_checkpoint.py
@@ -43,6 +43,7 @@ simple_policy_config = {
     "max_total_sequence_length": 1024,
     "precision": "float32",
     "offload_optimizer_for_logprob": False,
+    "use_pinned_optimizer_offload": False,
     "optimizer": {
         "name": "torch.optim.AdamW",
         "kwargs": {


### PR DESCRIPTION
This significantly improves performance for the optimizer_offload_before_refit pass which is quite expensive in co-located/syncRL cases. 

Enabled/disabled using the `use_pinned_optimizer_offload` setting (default=disabled). It has been set to `false` in a couple of grpo_math* yaml configs as an example. Added test cases for this feature in `test_megatron_worker.py`

# What does this PR do ?

Optimizer D2H/H2D transfers used per-tensor pageable allocations, causing expensive cudaHostAlloc calls and synchronous memcpy on every step. This adds an opt-in mode (use_pinned_optimizer_offload) that coalesces all optimizer state into a single cached pinned buffer, eliminating cudaHostAlloc from the hot path and enabling non-blocking DMA transfers.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
