### PR TITLE
fix(ray): preserve RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES for NCCL

### DIFF
--- a/nemo_rl/distributed/worker_groups.py
+++ b/nemo_rl/distributed/worker_groups.py
@@ -497,8 +497,13 @@ class RayWorkerGroup:
                         "AVAILABLE_PORT_LIST": str(available_ports),
                     }
                 )
-                # Remove Ray-specific environment variables, let the worker itself set them.
-                worker_env_vars.pop("RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES", None)
+                # Preserve RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1 to prevent Ray
+                # from masking CUDA_VISIBLE_DEVICES per actor. GPU masking triggers NCCL
+                # bugs on NVSwitch topologies (H200/P5en, H100/P5) including cuMem import
+                # penalty (nccl#1749) and NVLS rank ordering corruption (nccl#1906).
+                # Workers use explicit torch.cuda.set_device(local_rank) instead.
+                # See: https://github.com/NVIDIA-NeMo/RL/issues/1963
+                worker_env_vars["RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES"] = "1"
                 worker_env_vars.pop("RAY_CLIENT_MODE", None)
                 worker_env_vars.pop("RAY_JOB_ID", None)
                 worker_env_vars.pop("RAY_LD_PRELOAD", None)

--- a/nemo_rl/distributed/worker_groups.py
+++ b/nemo_rl/distributed/worker_groups.py
@@ -501,9 +501,12 @@ class RayWorkerGroup:
                 # from masking CUDA_VISIBLE_DEVICES per actor. GPU masking triggers NCCL
                 # bugs on NVSwitch topologies (H200/P5en, H100/P5) including cuMem import
                 # penalty (nccl#1749) and NVLS rank ordering corruption (nccl#1906).
-                # Workers use explicit torch.cuda.set_device(local_rank) instead.
+                # Workers rely on LOCAL_RANK env var for device selection via
+                # init_device_mesh / Megatron internals.
                 # See: https://github.com/NVIDIA-NeMo/RL/issues/1963
-                worker_env_vars["RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES"] = "1"
+                worker_env_vars.setdefault(
+                    "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES", "1"
+                )
                 worker_env_vars.pop("RAY_CLIENT_MODE", None)
                 worker_env_vars.pop("RAY_JOB_ID", None)
                 worker_env_vars.pop("RAY_LD_PRELOAD", None)

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -317,16 +317,16 @@ class DTensorPolicyWorker(AbstractPolicyWorker, ColocatablePolicyInterface):
                 "Context parallel is yet not supported for VLM models. Please set cp_size = 1 to train VLM models."
             )
 
-        # torch==2.8 uses LOCAL_RANK to set the device here (https://github.com/pytorch/pytorch/blob/ba56102387ef21a3b04b357e5b183d48f0afefc7/torch/distributed/device_mesh.py#L500),
-        # but CUDA_VISIBLE_DEVICES is set to only 1 gpu, so we need to temporarily set LOCAL_RANK to 0.
-        # TODO: consider changing the default LOCAL_RANK set in worker_groups.py
-        prev_local_rank = os.environ["LOCAL_RANK"]
-        os.environ["LOCAL_RANK"] = "0"
-
+        # torch==2.8 uses LOCAL_RANK to set the device here
+        # (https://github.com/pytorch/pytorch/blob/ba56102387ef21a3b04b357e5b183d48f0afefc7/torch/distributed/device_mesh.py#L500).
+        # Previously, Ray masked CUDA_VISIBLE_DEVICES to a single GPU per actor and this
+        # code had to temporarily override LOCAL_RANK=0. With PR #2252 preserving
+        # RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1 in worker_groups.py, every worker
+        # sees all node-local GPUs and init_device_mesh correctly uses the real
+        # LOCAL_RANK=bundle_idx set by the worker group.
         device_mesh = torch.distributed.device_mesh.init_device_mesh(
             "cuda", (dp_size, cp_size, tp_size), mesh_dim_names=("dp", "cp", "tp")
         )
-        os.environ["LOCAL_RANK"] = prev_local_rank
 
         self.dp_cp_mesh = device_mesh[("dp", "cp")]._flatten(mesh_dim_name="dp_cp")
 


### PR DESCRIPTION
Fixes #1963. Related: #1961.

## Summary

`worker_groups.py` removes `RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES` from the worker environment (line 501), which forces Ray to set per-actor `CUDA_VISIBLE_DEVICES` masking (e.g., `CUDA_VISIBLE_DEVICES=3` for the 4th GPU). This triggers three confirmed NCCL bugs on NVSwitch topologies (H200 P5en, H100 P5):

1. **cuMem import penalty** ([NVIDIA/nccl#1749](https://github.com/NVIDIA/nccl/issues/1749)) — `p2pMap()` iterates over all devices when importing cuMem handles with non-overlapping `CUDA_VISIBLE_DEVICES`. Causes **3,660ms** first-operation penalty vs 1.5ms with torchrun.

2. **NVLS rank ordering corruption** ([NVIDIA/nccl#1906](https://github.com/NVIDIA/nccl/issues/1906)) — allgather in `nvls.cc` is missing a user rank table when GPU indices are permuted by `CUDA_VISIBLE_DEVICES`. Causes **hang or silent data corruption** on NVSwitch systems.

3. **Multi-channel P2P hang at >8M elements** — AllReduce hangs for tensors larger than ~32MB even with `NCCL_CUMEM_ENABLE=0` and `NCCL_NVLS_ENABLE=0`.

## Fix

Preserve `RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1` instead of removing it. This tells Ray not to mask `CUDA_VISIBLE_DEVICES`, so each worker sees all GPUs. Workers use explicit `torch.cuda.set_device(local_rank)` instead, which mirrors torchrun behavior and works correctly on both NVSwitch and NVLink topologies.

## Benchmarks (same hardware, same NCCL)

| Method | AllReduce 4KB | AllReduce 933MB |
|--------|--------------|-----------------|
| **torchrun** (no GPU masking) | 1.5ms | 1.5ms |
| **Ray** (GPU masking forced) | 3,660ms | HANGS forever |

Both tests: P5en.48xlarge (8x H200, NVSwitch), NCCL 2.27.5, EFA, same container.

## Test plan

- [x] Verified fix on 4x P5en.48xlarge (32x H200) — multi-node GRPO training completes successfully
- [x] Verified no regression on P5.48xlarge (H100, NVLink PXN) — works as before
- [x] `LOCAL_RANK` is already set in `worker_env_vars` (line 492), so workers can `torch.cuda.set_device()` correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved distributed training GPU configuration to prevent unintended CUDA device masking and properly preserve GPU device visibility settings across worker processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->