### PR TITLE
feat: add cpu_serialize transport fallback for weight streaming

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1154,8 +1154,12 @@ def refit_policy_generation(
                 update_success = True
             else:
                 # Original ZMQ IPC path for vLLM
+                model_update_transport = os.getenv(
+                    "NRL_MODEL_UPDATE_TRANSPORT", "cuda_ipc"
+                )
                 futures_train = policy.stream_weights_via_ipc_zmq(
-                    buffer_size_bytes=buffer_size_bytes
+                    buffer_size_bytes=buffer_size_bytes,
+                    model_update_transport=model_update_transport,
                 )
                 futures_inference = policy_generation.update_weights_via_ipc_zmq()
                 # wait for all futures to complete

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -190,8 +190,23 @@ class VllmInternalWorkerExtension:
                     self.zmq_socket.send(IPCProtocol.ACK.value.encode())
                     break
 
-                ipc_handle, list_keys, used_bytes = payload
-                buffer = rebuild_cuda_tensor_from_ipc(ipc_handle, self.device.index)
+                ipc_handle_or_bytes, list_keys, used_bytes = payload
+
+                if isinstance(ipc_handle_or_bytes, bytes):
+                    # cpu_serialize path: deserialize CPU tensor, DMA to GPU
+                    import io
+
+                    bucket_data = torch.load(
+                        io.BytesIO(ipc_handle_or_bytes), weights_only=True
+                    )
+                    buffer = bucket_data["bucket"].contiguous().pin_memory()
+                    buffer = buffer.to(device=self.device, non_blocking=True)
+                    torch.cuda.current_stream().synchronize()
+                else:
+                    # Existing CUDA IPC path
+                    buffer = rebuild_cuda_tensor_from_ipc(
+                        ipc_handle_or_bytes, self.device.index
+                    )
 
                 weights = []
                 offset = 0

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -883,13 +883,17 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
         return free_memory_bytes
 
     def stream_weights_via_ipc_zmq(
-        self, buffer_size_bytes: int, kv_scales: Optional[dict[str, float]] = None
+        self,
+        buffer_size_bytes: int,
+        kv_scales: Optional[dict[str, float]] = None,
+        model_update_transport: str = "cuda_ipc",
     ) -> list[ray.ObjectRef]:
         """Send the weights for IPC handles via ZMQ socket."""
         futures = self.worker_group.run_all_workers_single_data(
             "stream_weights_via_ipc_zmq",
             buffer_size_bytes=buffer_size_bytes,
             kv_scales=kv_scales,
+            model_update_transport=model_update_transport,
         )
         return futures
 

--- a/nemo_rl/models/policy/utils.py
+++ b/nemo_rl/models/policy/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import gc
+import io
 import os
 import traceback
 from enum import Enum
@@ -248,7 +249,12 @@ def calculate_aligned_size(size_bytes: int, alignment: int = 512) -> int:
 
 
 def stream_weights_via_ipc_zmq_impl(
-    params_generator, buffer_size_bytes: int, zmq_socket, rank: int, worker_name: str
+    params_generator,
+    buffer_size_bytes: int,
+    zmq_socket,
+    rank: int,
+    worker_name: str,
+    model_update_transport: str = "cuda_ipc",
 ) -> None:
     """Shared implementation for streaming weights via IPC ZMQ with improved memory management.
 
@@ -261,21 +267,42 @@ def stream_weights_via_ipc_zmq_impl(
         zmq_socket: ZMQ socket for communication
         rank: Worker rank for logging
         worker_name: Name of the worker for logging
+        model_update_transport: Serialization format for weight transfer. Either ``"cuda_ipc"``
+            (default, requires ``CAP_SYS_PTRACE``/``--ipc=host``) or ``"cpu_serialize"``
+            (pinned-memory DMA + ``torch.save``/``torch.load``, works without special container
+            capabilities).
     """
+    if model_update_transport not in ("cuda_ipc", "cpu_serialize"):
+        raise ValueError(
+            f"Unsupported model_update_transport: {model_update_transport!r}. "
+            f"Expected 'cuda_ipc' or 'cpu_serialize'."
+        )
     # Divide total buffer size by 2 because we use two individual buffers (ping-pong) for overlapping communication.
     buffer_size_bytes = buffer_size_bytes // 2
 
     def send_buffer_group_overlap(buffer, param_names, used_bytes, await_recv) -> bool:
         """Send a group of parameters and return new pending_recv state."""
-        # Synchronize before getting IPC handle to ensure data is ready
-        torch.cuda.current_stream().synchronize()
-        cuda_ipc_handle = get_handle_from_tensor(buffer)
+        if model_update_transport == "cpu_serialize":
+            # Bucket-level pinned DMA: ~10x faster than per-tensor pageable .cpu()
+            # (270ms vs 2.7s at 3.4GB on PCIe 4.0, per ROLL benchmarks).
+            torch.cuda.current_stream().synchronize()
+            bucket = buffer[:used_bytes].contiguous()
+            pinned = torch.empty_like(bucket, device="cpu").pin_memory()
+            pinned.copy_(bucket, non_blocking=True)
+            torch.cuda.current_stream().synchronize()
+            buf = io.BytesIO()
+            torch.save({"bucket": pinned}, buf)
+            serialized = buf.getvalue()  # bytes object
+        else:
+            # Existing CUDA IPC path
+            torch.cuda.current_stream().synchronize()
+            serialized = get_handle_from_tensor(buffer)  # tuple
 
         if await_recv:
             zmq_socket.recv()
 
-        # Payload tuple: (cuda_ipc_handle, param_names, used_bytes)
-        payload = (cuda_ipc_handle, param_names, used_bytes)
+        # Payload tuple: (serialized, param_names, used_bytes)
+        payload = (serialized, param_names, used_bytes)
         zmq_socket.send_pyobj(payload)
         return True  # pending_recv = True
 

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -1804,6 +1804,7 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
         self,
         buffer_size_bytes: int = 0,
         kv_scales: Optional[dict[str, float]] = None,
+        model_update_transport: str = "cuda_ipc",
     ) -> None:
         """Stream model weights to peer process via ZMQ IPC socket."""
         if kv_scales is not None:
@@ -1840,6 +1841,7 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
             zmq_socket=self.zmq_socket,
             rank=self.rank,
             worker_name=str(self),
+            model_update_transport=model_update_transport,
         )
 
     @torch.no_grad()

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -884,6 +884,7 @@ class DTensorPolicyWorkerV2Impl(AbstractPolicyWorker, ColocatablePolicyInterface
         self,
         buffer_size_bytes: int = 0,
         kv_scales: Optional[dict[str, float]] = None,
+        model_update_transport: str = "cuda_ipc",
     ) -> None:
         """Stream model weights to peer process via ZMQ IPC socket."""
         if kv_scales is not None:
@@ -905,6 +906,7 @@ class DTensorPolicyWorkerV2Impl(AbstractPolicyWorker, ColocatablePolicyInterface
             zmq_socket=self.zmq_socket,
             rank=self.rank,
             worker_name=str(self),
+            model_update_transport=model_update_transport,
         )
 
     @torch.no_grad()

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -1078,7 +1078,10 @@ class MegatronPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface)
     @torch.no_grad()
     @wrap_with_nvtx_name("megatron_policy_worker/stream_weights_via_ipc_zmq")
     def stream_weights_via_ipc_zmq(
-        self, buffer_size_bytes: int = 0, kv_scales: Optional[dict[str, float]] = None
+        self,
+        buffer_size_bytes: int = 0,
+        kv_scales: Optional[dict[str, float]] = None,
+        model_update_transport: str = "cuda_ipc",
     ) -> None:
         """Stream model weights to peer process via ZMQ IPC socket."""
         self.maybe_init_zmq()
@@ -1094,6 +1097,7 @@ class MegatronPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface)
             zmq_socket=self.zmq_socket,
             rank=self.rank,
             worker_name=str(self),
+            model_update_transport=model_update_transport,
         )
 
     @torch.no_grad()

--- a/tests/unit/models/policy/test_utils.py
+++ b/tests/unit/models/policy/test_utils.py
@@ -125,6 +125,7 @@ def server_process(
     known_tensors: list[tuple[str, torch.Tensor]],
     buffer_size_bytes: int,
     ready_queue: multiprocessing.Queue,
+    model_update_transport: str = "cuda_ipc",
 ) -> None:
     """Server process that streams tensors via IPC ZMQ."""
     try:
@@ -144,6 +145,7 @@ def server_process(
             socket,
             rank=0,
             worker_name="test_server",
+            model_update_transport=model_update_transport,
         )
     except Exception as e:
         import sys
@@ -189,8 +191,19 @@ def client_process(
                 socket.send(IPCProtocol.ACK.value.encode())
                 break
 
-            ipc_handle, list_keys, used_bytes = payload
-            buffer = rebuild_cuda_tensor_from_ipc(ipc_handle, device.index)
+            ipc_handle_or_bytes, list_keys, used_bytes = payload
+
+            if isinstance(ipc_handle_or_bytes, bytes):
+                import io
+
+                bucket_data = torch.load(
+                    io.BytesIO(ipc_handle_or_bytes), weights_only=True
+                )
+                buffer = bucket_data["bucket"].contiguous().pin_memory()
+                buffer = buffer.to(device=device, non_blocking=True)
+                torch.cuda.current_stream().synchronize()
+            else:
+                buffer = rebuild_cuda_tensor_from_ipc(ipc_handle_or_bytes, device.index)
 
             offset = 0
             for key in list_keys:
@@ -343,3 +356,73 @@ class TestStreamWeightsViaIPC:
 
             if os.path.exists(socket_path):
                 os.unlink(socket_path)
+
+    def test_stream_weights_cpu_serialize(self):
+        """Test cpu_serialize round-trip: sender serializes via torch.save, receiver auto-detects bytes payload."""
+        tensor_specs = [
+            ("weight_a", (32, 64), torch.float32),
+            ("weight_b", (16, 16), torch.bfloat16),
+            ("weight_c", (128,), torch.float16),
+        ]
+        known_tensors = [
+            (name, torch.randn(*shape, dtype=dtype))
+            for name, shape, dtype in tensor_specs
+        ]
+        known_tensors_data = [
+            (name, list(t.shape), t.dtype, t) for name, t in known_tensors
+        ]
+
+        socket_path = f"/tmp/test_ipc_zmq_cpu_serialize_{os.getpid()}_{time.time()}"
+        zmq_addr = f"ipc://{socket_path}"
+        buffer_size_bytes = 100 * 1024  # 100 KB
+
+        mp_context = multiprocessing.get_context("spawn")
+        ready_queue = mp_context.Queue()
+        result_queue = mp_context.Queue()
+
+        server_proc = mp_context.Process(
+            target=server_process,
+            args=(zmq_addr, known_tensors, buffer_size_bytes, ready_queue, "cpu_serialize"),
+        )
+        server_proc.start()
+
+        status, msg = ready_queue.get(timeout=self.TIMEOUT)
+        assert status == "ready", f"Server failed: {msg}"
+
+        client_proc = mp_context.Process(
+            target=client_process,
+            args=(zmq_addr, known_tensors_data, result_queue),
+        )
+        client_proc.start()
+
+        try:
+            server_proc.join(timeout=self.TIMEOUT)
+            client_proc.join(timeout=self.TIMEOUT)
+
+            check_process_error(client_proc, result_queue, "Client")
+            check_process_error(server_proc, ready_queue, "Server")
+
+            status, msg = result_queue.get(timeout=self.TIMEOUT)
+            assert status == "success", f"Validation failed: {msg}"
+        finally:
+            for proc in [server_proc, client_proc]:
+                if proc and proc.is_alive():
+                    proc.terminate()
+                    proc.join(timeout=self.TIMEOUT)
+                    if proc.is_alive():
+                        proc.kill()
+
+            if os.path.exists(socket_path):
+                os.unlink(socket_path)
+
+    def test_stream_weights_invalid_transport(self):
+        """Validation fires before any ZMQ I/O for an unrecognised transport name."""
+        with pytest.raises(ValueError, match="Unsupported model_update_transport"):
+            stream_weights_via_ipc_zmq_impl(
+                params_generator=iter([]),
+                buffer_size_bytes=1024,
+                zmq_socket=None,
+                rank=0,
+                worker_name="test",
+                model_update_transport="typo",
+            )


### PR DESCRIPTION
### Problem
In certain restricted environments (like vast.ai or shared HPC clusters), containers lack `CAP_SYS_PTRACE` privileges, which causes CUDA IPC weight transfer to fail.

### Solution
Implemented an alternative `cpu_serialize` path that uses bucket-level pinned DMA and `torch.save/load` over ZMQ. 

- **Sender**: Added `cpu_serialize` branch in `stream_weights_via_ipc_zmq_impl` using pinned memory for ~10x faster transfer than pageable CPU copies.
- **Receiver**: Added auto-detection logic in `vllm_backend.py` to handle both `bytes` (CPU) and `tuple` (CUDA IPC) payloads.
- **Plumbing**: Threaded `model_update_transport` parameter from `grpo.py` (via env var) down to the workers.

### Verification
- **Unit Tests**: Passed `tests/unit/models/policy/test_utils.py` in a non-privileged container.
