### PR TITLE
fix: set moe_permute_fusion default to true for deterministic MoE forward

### DIFF
--- a/examples/configs/distillation_math.yaml
+++ b/examples/configs/distillation_math.yaml
@@ -104,7 +104,7 @@ policy: &POLICY_BASE
         moe_router_dtype: "fp64"
         moe_router_load_balancing_type: "none" # "seq_aux_loss" causes logprob error divergence for grpo
         moe_router_bias_update_rate: 0.0 # by default, disable bias updates for grpo
-        moe_permute_fusion: false
+        moe_permute_fusion: true
         #gives ~20% training perf speedup with sequence packing 
         apply_rope_fusion: True
         bias_activation_fusion: True

--- a/examples/configs/distillation_math_megatron.yaml
+++ b/examples/configs/distillation_math_megatron.yaml
@@ -53,7 +53,7 @@ policy: &POLICY_BASE
         moe_router_dtype: "fp64"
         moe_router_load_balancing_type: "none" # "seq_aux_loss" causes logprob error divergence for grpo
         moe_router_bias_update_rate: 0.0 # by default, disable bias updates for grpo
-        moe_permute_fusion: false
+        moe_permute_fusion: true
         #gives ~20% training perf speedup with sequence packing 
         apply_rope_fusion: True
         bias_activation_fusion: True

--- a/examples/configs/dpo.yaml
+++ b/examples/configs/dpo.yaml
@@ -137,7 +137,7 @@ policy:
     moe_router_dtype: "fp64"
     moe_router_load_balancing_type: "aux_loss"
     moe_router_bias_update_rate: 1e-3
-    moe_permute_fusion: false
+    moe_permute_fusion: true
     #gives ~20% training perf speedup with sequence packing 
     apply_rope_fusion: True
     # gives ~25% training perf speedup with sequence packing and apply_rope_fusion

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -145,7 +145,7 @@ policy:
     moe_router_dtype: "fp64"
     moe_router_load_balancing_type: "none" # "seq_aux_loss" causes logprob error divergence for grpo
     moe_router_bias_update_rate: 0.0 # by default, disable bias updates for grpo
-    moe_permute_fusion: false
+    moe_permute_fusion: true
     # gives ~20% training perf speedup with sequence packing
     apply_rope_fusion: True
     # gives ~25% training perf speedup with sequence packing and apply_rope_fusion

--- a/examples/configs/grpo_math_1B_megatron.yaml
+++ b/examples/configs/grpo_math_1B_megatron.yaml
@@ -95,7 +95,7 @@ policy:
     moe_router_dtype: "fp64"
     moe_router_load_balancing_type: "none" # "seq_aux_loss" causes logprob error divergence for grpo
     moe_router_bias_update_rate: 0.0 # by default, disable bias updates for grpo
-    moe_permute_fusion: false
+    moe_permute_fusion: true
     moe_enable_deepep: false
     moe_token_dispatcher_type: "alltoall"
     moe_shared_expert_overlap: false

--- a/examples/configs/recipes/llm/dpo-qwen2.5-math7b-1n8g-megatron_chunked_linear_ce_loss.yaml
+++ b/examples/configs/recipes/llm/dpo-qwen2.5-math7b-1n8g-megatron_chunked_linear_ce_loss.yaml
@@ -21,7 +21,6 @@ policy:
     attention_backend: unfused
     freeze_moe_router: true
     moe_router_bias_update_rate: 0.0
-    moe_permute_fusion: true
     optimizer:
       lr: 1.0e-06
       min_lr: 1.0e-06

--- a/examples/configs/recipes/llm/grpo-dapomath17k-dsv3-megatron.yaml
+++ b/examples/configs/recipes/llm/grpo-dapomath17k-dsv3-megatron.yaml
@@ -28,7 +28,6 @@ policy:
     num_layers_in_last_pipeline_stage: 6
     context_parallel_size: 4
     sequence_parallel: true
-    moe_permute_fusion: true
     apply_rope_fusion: false
     moe_enable_deepep: true
     moe_token_dispatcher_type: flex

--- a/examples/configs/recipes/llm/grpo-gptoss-20b-8n8g-megatron.yaml
+++ b/examples/configs/recipes/llm/grpo-gptoss-20b-8n8g-megatron.yaml
@@ -13,7 +13,6 @@ policy:
     expert_model_parallel_size: 8
     tensor_model_parallel_size: 4
     sequence_parallel: true
-    moe_permute_fusion: true
   make_sequence_length_divisible_by: 4
   dtensor_cfg:
     enabled: false

--- a/examples/configs/recipes/llm/performance/dapo-deepseek-v3-64n8g.yaml
+++ b/examples/configs/recipes/llm/performance/dapo-deepseek-v3-64n8g.yaml
@@ -51,7 +51,6 @@ policy:
     num_layers_in_last_pipeline_stage: 6
     context_parallel_size: 4
     sequence_parallel: true
-    moe_permute_fusion: true
     apply_rope_fusion: false
     # MTP — disabled
     mtp_num_layers: 0

--- a/examples/configs/recipes/llm/performance/grpo-deepseek-v3-32n8g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-deepseek-v3-32n8g.yaml
@@ -27,7 +27,6 @@ policy:
     num_layers_in_first_pipeline_stage: 3
     num_layers_in_last_pipeline_stage: 2
     apply_rope_fusion: false
-    moe_permute_fusion: true
     defer_fp32_logits: true
     # MTP — disabled
     mtp_num_layers: 0

--- a/examples/configs/recipes/llm/performance/grpo-qwen3-235b-16n8g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-qwen3-235b-16n8g.yaml
@@ -31,7 +31,6 @@ policy:
     activation_checkpointing: true
     num_layers_in_first_pipeline_stage: 11
     num_layers_in_last_pipeline_stage: 11
-    moe_permute_fusion: true
     defer_fp32_logits: true
     optimizer:
       lr: 5.0e-07

--- a/examples/configs/recipes/llm/sft-qwen2.5-math7b-1n8g-megatron_chunked_linear_ce_loss.yaml
+++ b/examples/configs/recipes/llm/sft-qwen2.5-math7b-1n8g-megatron_chunked_linear_ce_loss.yaml
@@ -20,7 +20,6 @@ policy:
     freeze_moe_router: true
     moe_router_dtype: fp64
     moe_router_bias_update_rate: 0.0
-    moe_permute_fusion: true
     optimizer:
       lr: 1.0e-06
       min_lr: 1.0e-06

--- a/examples/configs/recipes/llm/sft-qwen2.5-math7b-2n8g-megatron.yaml
+++ b/examples/configs/recipes/llm/sft-qwen2.5-math7b-2n8g-megatron.yaml
@@ -17,7 +17,6 @@ policy:
     freeze_moe_router: true
     moe_router_dtype: fp64
     moe_router_bias_update_rate: 0.0
-    moe_permute_fusion: true
     # overlap_param_gather requires use_distributed_optimizer=true in mcore.
     # Without it, start_param_sync tries to use layerwise params that were never set.
     distributed_data_parallel_config:

--- a/examples/configs/sft.yaml
+++ b/examples/configs/sft.yaml
@@ -118,7 +118,7 @@ policy:
     moe_router_dtype: null
     moe_router_load_balancing_type: "aux_loss"
     moe_router_bias_update_rate: 1e-3
-    moe_permute_fusion: false
+    moe_permute_fusion: true
     #gives ~20% training perf speedup with sequence packing 
     apply_rope_fusion: True
     # gives ~25% training perf speedup with sequence packing and apply_rope_fusion

--- a/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
+++ b/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
@@ -117,7 +117,7 @@ policy:
     #gives ~20% training perf speedup with sequence packing
     apply_rope_fusion: True
     defer_fp32_logits: false
-    moe_permute_fusion: false
+    moe_permute_fusion: true
     moe_enable_deepep: false
     moe_token_dispatcher_type: "alltoall"
     moe_shared_expert_overlap: false

--- a/research/template_project/configs/grpo_math_1B.yaml
+++ b/research/template_project/configs/grpo_math_1B.yaml
@@ -92,7 +92,7 @@ policy:
     moe_router_dtype: "fp64"
     moe_router_load_balancing_type: "none" # "seq_aux_loss" causes logprob error divergence for grpo
     moe_router_bias_update_rate: 0.0 # by default, disable bias updates for grpo
-    moe_permute_fusion: false
+    moe_permute_fusion: true
     #gives ~20% training perf speedup with sequence packing
     apply_rope_fusion: True
     defer_fp32_logits: null


### PR DESCRIPTION


# What does this PR do ?

With moe_permute_fusion=false, MoE models produce non-deterministic forward pass results due to scatter_add_ in the unpermute operation, causing train/probs_ratio to deviate from 1.0 in on-policy GRPO.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):
Fixes #2255

# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
