### PR TITLE
chore: update version and references for r0.6.0 release (#2261)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,10 +4,10 @@
 #     docker buildx build -f docker/Dockerfile --tag <registry>/nemo-rl:latest --push .
 #
 #   Self-contained build (specific git ref):
-#     docker buildx build -f docker/Dockerfile --build-arg NRL_GIT_REF=r0.3.0 --tag <registry>/nemo-rl:r0.3.0 --push .
+#     docker buildx build -f docker/Dockerfile --build-arg NRL_GIT_REF=r0.6.0 --tag <registry>/nemo-rl:r0.6.0 --push .
 #
 #   Self-contained build (remote NeMo RL source; no need for a local clone of NeMo RL):
-#     docker buildx build -f docker/Dockerfile --build-arg NRL_GIT_REF=r0.3.0 --tag <registry>/nemo-rl:r0.3.0 --push https://github.com/NVIDIA-NeMo/RL.git
+#     docker buildx build -f docker/Dockerfile --build-arg NRL_GIT_REF=r0.6.0 --tag <registry>/nemo-rl:r0.6.0 --push https://github.com/NVIDIA-NeMo/RL.git
 #
 #   Local NeMo RL source override:
 #     docker buildx build --build-context nemo-rl=. -f docker/Dockerfile --tag <registry>/nemo-rl:latest --push .

--- a/docker/Dockerfile.ngc_pytorch
+++ b/docker/Dockerfile.ngc_pytorch
@@ -3,8 +3,8 @@
 #
 # Usage:
 # Self-contained build (default: builds from main): docker buildx build -f docker/Dockerfile.ngc_pytorch --tag <registry>/nemo-rl:latest --push .
-# Self-contained build (specific git ref): docker buildx build -f docker/Dockerfile.ngc_pytorch --build-arg NRL_GIT_REF=r0.3.0 --tag <registry>/nemo-rl:r0.3.0 --push .
-# Self-contained build (remote NeMo RL source; no need for a local clone of NeMo RL): docker buildx build -f docker/Dockerfile.ngc_pytorch --build-arg NRL_GIT_REF=r0.3.0 --tag <registry>/nemo-rl:r0.3.0 --push https://github.com/NVIDIA-NeMo/RL.git
+# Self-contained build (specific git ref): docker buildx build -f docker/Dockerfile.ngc_pytorch --build-arg NRL_GIT_REF=r0.6.0 --tag <registry>/nemo-rl:r0.6.0 --push .
+# Self-contained build (remote NeMo RL source; no need for a local clone of NeMo RL): docker buildx build -f docker/Dockerfile.ngc_pytorch --build-arg NRL_GIT_REF=r0.6.0 --tag <registry>/nemo-rl:r0.6.0 --push https://github.com/NVIDIA-NeMo/RL.git
 # Local NeMo RL source override: docker buildx build --build-context nemo-rl=. -f docker/Dockerfile.ngc_pytorch --tag <registry>/nemo-rl:latest --push .
 #
 # If installing new dependencies in the container, then use "uv pip install new-dependency"

--- a/docs/about/performance-summary.md
+++ b/docs/about/performance-summary.md
@@ -3,7 +3,7 @@
 
 As part of the NVIDIA NeMo Framework, NeMo RL, provides optimal performance for reinforcement learning on generative AI models by incorporating the latest optimizations - such as refit optimizations, mixed-precision training, and off-policy training.
 
-This page provides performance benchmarks for LLMs and VLMs using NeMo RL across different GPU systems and configurations. The recipes to reproduce these runs, in yaml file form, can be found under [this folder](https://github.com/NVIDIA-NeMo/RL/tree/r0.5.0/examples/configs/recipes/llm/performance).
+This page provides performance benchmarks for LLMs and VLMs using NeMo RL across different GPU systems and configurations. The recipes to reproduce these runs, in yaml file form, can be found under [this folder](https://github.com/NVIDIA-NeMo/RL/tree/r0.6.0/examples/configs/recipes/llm/performance).
 
 ## Nomenclature
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -14,14 +14,14 @@ docker buildx build -f docker/Dockerfile \
 
 # Self-contained build (specific git ref):
 docker buildx build -f docker/Dockerfile \
-    --build-arg NRL_GIT_REF=r0.3.0 \
-    --tag <registry>/nemo-rl:r0.3.0 \
+    --build-arg NRL_GIT_REF=r0.6.0 \
+    --tag <registry>/nemo-rl:r0.6.0 \
     --push .
 
 # Self-contained build (remote NeMo RL source; no need for a local clone of NeMo RL):
 docker buildx build -f docker/Dockerfile \
-    --build-arg NRL_GIT_REF=r0.3.0 \
-    --tag <registry>/nemo-rl:r0.3.0 \
+    --build-arg NRL_GIT_REF=r0.6.0 \
+    --tag <registry>/nemo-rl:r0.6.0 \
     --push https://github.com/NVIDIA-NeMo/RL.git
 
 # Local NeMo RL source override:

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -4,10 +4,14 @@
         "url": "https://docs.nvidia.com/nemo/rl/nightly/"
     },
     {
-        "name": "0.5.0 (latest)",
-        "version": "0.5.0",
+        "name": "0.6.0 (latest)",
+        "version": "0.6.0",
         "url": "https://docs.nvidia.com/nemo/rl/latest/",
         "preferred": true
+    },
+    {
+        "version": "0.5.0",
+        "url": "https://docs.nvidia.com/nemo/rl/0.5.0/"
     },
     {
         "version": "0.4.0",

--- a/nemo_rl/package_info.py
+++ b/nemo_rl/package_info.py
@@ -14,7 +14,7 @@
 
 
 MAJOR = 0
-MINOR = 5
+MINOR = 6
 PATCH = 0
 PRE_RELEASE = "rc0"
 


### PR DESCRIPTION
## Summary
- Bump package version from 0.5.0 to 0.6.0
- Update Docker build examples and docs to reference `r0.6.0` instead of `r0.3.0`/`r0.5.0`
- Update performance summary link to point to `r0.6.0` branch
