### PR TITLE
build: drop rc0 pre-release tag and add dynamic git versioning (#2235)

### DIFF
--- a/.github/workflows/build-test-publish-wheel.yml
+++ b/.github/workflows/build-test-publish-wheel.yml
@@ -26,7 +26,7 @@ defaults:
 
 jobs:
   build-test-publish-wheel:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@v0.33.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@v0.88.1
     if: ${{ vars.BUILD_TEST_PUBLISH_WHEEL == 'true' }}
     with:
       dry-run: true

--- a/nemo_rl/package_info.py
+++ b/nemo_rl/package_info.py
@@ -16,13 +16,31 @@
 MAJOR = 0
 MINOR = 6
 PATCH = 0
-PRE_RELEASE = "rc0"
+PRE_RELEASE = ""
 
 # Use the following formatting: (major, minor, patch, pre-release)
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)
 
 __shortversion__ = ".".join(map(str, VERSION[:3]))
 __version__ = ".".join(map(str, VERSION[:3])) + "".join(VERSION[3:])
+
+import os as _os  # noqa: I001
+import subprocess as _subprocess
+
+
+if not int(_os.getenv("NO_VCS_VERSION", "0")):
+    try:
+        _git = _subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            cwd=_os.path.dirname(_os.path.abspath(__file__)),
+            check=True,
+            universal_newlines=True,
+        )
+    except (_subprocess.CalledProcessError, OSError):
+        pass
+    else:
+        __version__ += f"+{_git.stdout.strip()}"
 
 __package_name__ = "nemo_rl"
 __contact_names__ = "NVIDIA"


### PR DESCRIPTION
Cherrypicking commit from the PR: https://github.com/NVIDIA-NeMo/RL/pull/2235  

## Summary

- Drops the `rc0` pre-release tag — version is now `X.Y.Z` (clean semver)
- Appends `+<short-sha>` to `__version__` at import/build time via `git rev-parse --short HEAD`
- Gracefully falls back to the base version if git is unavailable or the code is not in a git repo
- Set `NO_VCS_VERSION=1` to opt out (e.g. for release builds)
- Pins `build-test-publish-wheel` to `FW-CI-templates@7a6fd6d` (sets `NO_VCS_VERSION=1` in the build step to prevent sdist/wheel version mismatch); will be replaced with a version tag once NVIDIA-NeMo/FW-CI-templates#443 is released

## Example

```python
>>> import nemo_rl; nemo_rl.__version__
'0.5.0+5142e790'

>>> NO_VCS_VERSION=1 python -c "import nemo_rl; print(nemo_rl.__version__)"
0.5.0
```