### PR TITLE
feat: add nvidia-resiliency-ext as nvrx optional extra

### DIFF
--- a/docs/guides/ft-launcher-guide.md
+++ b/docs/guides/ft-launcher-guide.md
@@ -1,6 +1,6 @@
 # Fault Tolerance Launcher Guide
 
-The `ft_launcher` is provided by `nvidia-resiliency-ext` (included in NeMo RL dependencies) and enables automatic fault tolerance and recovery for distributed training runs.
+The `ft_launcher` is provided by `nvidia-resiliency-ext` (available via the `nvrx` optional extra, e.g. `uv run --extra nvrx ft_launcher ...`) and enables automatic fault tolerance and recovery for distributed training runs.
 
 ## Key Arguments
 
@@ -14,7 +14,7 @@ The `ft_launcher` is provided by `nvidia-resiliency-ext` (included in NeMo RL de
 ## Basic Usage
 
 ```bash
-uv run ft_launcher \
+uv run --extra nvrx ft_launcher \
     --ft-cfg-path examples/ft_launcher/ft_config.yaml \
     --ft-rank-heartbeat-timeout 450 \
     --ft-initial-rank-heartbeat-timeout 1200 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,9 @@ mcore = [
   "emerging-optimizers==0.2.0",
   "deep_ep @ git+https://github.com/deepseek-ai/DeepEP.git@bfded34800dfec415b71503f8205181de90b2480",
 ]
-nvrx = ["nvidia-resiliency-ext"]  # for ft_launcher (fault-tolerant training launcher)
+nvrx = [
+  "nvidia-resiliency-ext",
+] # for ft_launcher (fault-tolerant training launcher)
 nemo_gym = ["nemo_gym"]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ dependencies = [
   "cuda-bindings",                                                                                                    # for non-colocated refit
   "pybase64",                                                                                                         # for sglang refit
   "nvidia-cudnn-cu12==9.19.0.56",                                                                                     # for transformer-engine no build isolation
-  # nvidia-resiliency-ext removed: no Python 3.13 wheels available (v0.5.0 only has cp310-cp312)
 ]
 
 [project.optional-dependencies]
@@ -109,6 +108,7 @@ mcore = [
   "emerging-optimizers==0.2.0",
   "deep_ep @ git+https://github.com/deepseek-ai/DeepEP.git@bfded34800dfec415b71503f8205181de90b2480",
 ]
+nvrx = ["nvidia-resiliency-ext"]  # for ft_launcher (fault-tolerant training launcher)
 nemo_gym = ["nemo_gym"]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -4205,6 +4205,9 @@ mcore = [
 nemo-gym = [
     { name = "nemo-gym" },
 ]
+nvrx = [
+    { name = "nvidia-resiliency-ext" },
+]
 sglang = [
     { name = "sglang" },
     { name = "sglang-kernel" },
@@ -4302,6 +4305,7 @@ requires-dist = [
     { name = "nvidia-cutlass-dsl", marker = "extra == 'vllm'", specifier = ">=4.4.0.dev1" },
     { name = "nvidia-ml-py" },
     { name = "nvidia-nvshmem-cu12", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-resiliency-ext", marker = "extra == 'nvrx'" },
     { name = "nvtx" },
     { name = "omegaconf" },
     { name = "pillow", specifier = ">=12.1.1" },
@@ -4331,7 +4335,7 @@ requires-dist = [
     { name = "vllm", marker = "extra == 'vllm'", specifier = "==0.17.1" },
     { name = "wandb", specifier = ">=0.25.1" },
 ]
-provides-extras = ["fsdp", "automodel", "vllm", "sglang", "mcore", "nemo-gym"]
+provides-extras = ["fsdp", "automodel", "vllm", "sglang", "mcore", "nvrx", "nemo-gym"]
 
 [package.metadata.requires-dev]
 build = [


### PR DESCRIPTION
## Summary
- Follow-up to #2228, which added `nvidia-resiliency-ext` to default dependencies but was reverted because the PyPI wheels for v0.5.0 did not publish Python 3.13 wheels
- Adds `nvidia-resiliency-ext` as an optional extra called `nvrx` instead, so users can opt in with `uv run --extra nvrx ft_launcher ...`
- Updates ft-launcher docs to reflect the new `--extra nvrx` usage

## Test plan
- [x] `uv lock` resolves successfully
- [x] `uv run --extra nvrx ft_launcher --help` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)