### PR TITLE
feat(sft): make only_unmask_final configurable in SFTConfig

### DIFF
--- a/examples/configs/sft.yaml
+++ b/examples/configs/sft.yaml
@@ -12,6 +12,7 @@ sft:
   val_at_start: true
   val_at_end: false
   seed: 42
+  only_unmask_final: false
 
 checkpointing:
   enabled: true

--- a/nemo_rl/algorithms/sft.py
+++ b/nemo_rl/algorithms/sft.py
@@ -71,6 +71,7 @@ class SFTConfig(TypedDict):
     # final checkpoint has validation metrics, which is required for get_best_checkpoint_path().
     val_at_end: bool
     seed: int
+    only_unmask_final: bool
 
 
 class MasterConfig(TypedDict):
@@ -267,6 +268,7 @@ def validate(
             add_loss_mask_to_message_log(
                 val_batch["message_log"],
                 roles_to_train_on=["assistant"],
+                only_unmask_final=master_config["sft"]["only_unmask_final"],
             )
 
             cat_and_padded, input_lengths = batched_message_log_to_flat_message(
@@ -430,6 +432,7 @@ def sft_train(
                     add_loss_mask_to_message_log(
                         batch["message_log"],
                         roles_to_train_on=["assistant"],
+                        only_unmask_final=master_config["sft"]["only_unmask_final"],
                     )
 
                     cat_and_padded, input_lengths = batched_message_log_to_flat_message(


### PR DESCRIPTION
## Context

While working on a multi-turn SFT setup, I noticed that `add_loss_mask_to_message_log` already supports an `only_unmask_final` parameter (which masks all messages except the last one), but there was no way to set it through the SFT configuration — it was hardcoded to `False` at both call sites in `sft.py`.

This came up when trying to train on only the final assistant response in a multi-turn conversation, which is a common pattern for instruction-following tasks where prior turns serve as context.

## Changes

- Added `only_unmask_final: bool` field to `SFTConfig` TypedDict
- Wired the config value through to `add_loss_mask_to_message_log` in both `validate()` and `sft_train()`
- Added `only_unmask_final: false` to the base `sft.yaml` config (other configs inherit this default)

The default is `false`, so existing behavior is unchanged. Setting it to `true` causes only the final message in each conversation to be unmasked for loss computation, regardless of role.

Closes #2219