### PR TITLE
feat: decouple IS correction level from GSPO policy ratio

### DIFF
--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -104,6 +104,15 @@ class ClippedPGLossConfig(TypedDict):
     # If False (default), correction is applied at the token level as in the
     # original GRPO paper.
     sequence_level_importance_ratios: NotRequired[bool]
+    # Override the IS correction granularity independently of the PPO ratio.
+    # When set, this takes precedence over sequence_level_importance_ratios for
+    # the IS correction weight computation only (PPO ratio is still controlled
+    # by sequence_level_importance_ratios).
+    #   "sequence"      – exp(sum(prev - gen))      (one weight per sequence)
+    #   "sequence_mean" – exp(mean(prev - gen))      (geometric mean, more stable for long seqs)
+    #   "token"         – exp(prev - gen) per token  (token-level correction)
+    # If None (default), derived from sequence_level_importance_ratios for backward compat.
+    is_correction_level: NotRequired[str | None]
     disable_ppo_ratio: NotRequired[bool]
     # If True, force the ratio to 1.0 for truly on-policy behavior,
     # eliminating any importance sampling effects.
@@ -202,6 +211,13 @@ class ClippedPGLossFn(LossFunction):
             "sequence_level_importance_ratios",
             False,
         )
+        # IS correction level override (decoupled from PPO ratio level).
+        self.is_correction_level = cfg.get("is_correction_level", None)
+        if self.is_correction_level is not None:
+            assert self.is_correction_level in ("sequence", "sequence_mean", "token"), (
+                f"is_correction_level must be 'sequence', 'sequence_mean', or 'token', "
+                f"got {self.is_correction_level!r}"
+            )
         self.loss_type = (
             LossType.TOKEN_LEVEL if cfg["token_level_loss"] else LossType.SEQUENCE_LEVEL
         )
@@ -225,9 +241,13 @@ class ClippedPGLossFn(LossFunction):
                 f"got {self.truncated_importance_sampling_type}"
             )
             if self.truncated_importance_sampling_type == "seq-mask-tis":
-                assert not self.sequence_level_importance_ratios, (
+                _effective_is = self.is_correction_level
+                if _effective_is is None:
+                    _effective_is = "sequence" if self.sequence_level_importance_ratios else "token"
+                assert _effective_is == "token", (
                     "seq-mask-tis uses token-level IS correction with sequence-level masking, "
-                    "and is incompatible with sequence_level_importance_ratios=True"
+                    "and is incompatible with sequence-level IS correction "
+                    f"(is_correction_level={_effective_is!r})"
                 )
         else:
             # Warn user that TIS-related parameters are ignored when truncated_importance_sampling_ratio is not set
@@ -425,7 +445,13 @@ class ClippedPGLossFn(LossFunction):
         # -------------------------------------------------------------
         _is_filter_metrics: dict = {}  # populated for icepop / seq-mask-tis
         # See: docs/guides/grpo.md#importance-sampling-correction
-        if self.sequence_level_importance_ratios:
+        # Determine effective IS correction level.
+        _is_level = self.is_correction_level
+        if _is_level is None:
+            # Backward compat: derive from sequence_level_importance_ratios
+            _is_level = "sequence" if self.sequence_level_importance_ratios else "token"
+
+        if _is_level == "sequence":
             # importance weight w_i = exp(Σ_t (log π_actor − log π_behaviour))
             seq_lp_diff = ((prev_logprobs - generation_logprobs) * mask).sum(dim=-1)
             actor_importance_weights = torch.exp(seq_lp_diff).detach()
@@ -434,7 +460,18 @@ class ClippedPGLossFn(LossFunction):
             )
             # Broadcast to token dimension so we can reuse existing reduction
             actor_importance_weights_expanded = actor_importance_weights.unsqueeze(-1)
-        else:
+        elif _is_level == "sequence_mean":
+            # importance weight w_i = exp(mean_t (log π_actor − log π_behaviour))
+            # Geometric mean — more stable than exp(sum) for long sequences.
+            seq_lp_diff = masked_mean(
+                prev_logprobs - generation_logprobs, token_mask, dim=-1
+            )
+            actor_importance_weights = torch.exp(seq_lp_diff).detach()
+            actor_importance_weights = torch.nan_to_num(
+                actor_importance_weights, nan=0.0, posinf=0.0, neginf=0.0
+            )
+            actor_importance_weights_expanded = actor_importance_weights.unsqueeze(-1)
+        else:  # "token"
             # Token-level correction
             actor_importance_weights_expanded = torch.exp(
                 prev_logprobs - generation_logprobs
@@ -549,7 +586,7 @@ class ClippedPGLossFn(LossFunction):
 
         # Metric: sampling importance ratio (mean over samples)
         # See: docs/guides/grpo.md#sampling-importance-ratio
-        if self.sequence_level_importance_ratios:
+        if _is_level in ("sequence", "sequence_mean"):
             sample_importance_ratio = masked_mean(
                 actor_importance_weights,
                 sample_mask,

--- a/tests/unit/algorithms/test_loss_functions.py
+++ b/tests/unit/algorithms/test_loss_functions.py
@@ -1708,6 +1708,82 @@ def test_clipped_pg_loss_gspo_importance_sampling_correction():
     torch.testing.assert_close(actual_loss, expected_actor_loss, atol=1e-4, rtol=1e-3)
 
 
+def test_clipped_pg_loss_gspo_is_correction_level_sequence_mean():
+    """Tests GSPO with is_correction_level='sequence_mean' uses exp(mean) instead of exp(sum)."""
+    if not torch.cuda.is_available():
+        pytest.skip("No GPU available")
+
+    device = "cuda"
+    data, batch_size, seq_len, vocab_size = _setup_clipped_pg_test_data(device=device)
+
+    cfg = deepcopy(basic_pg_loss_test_config)
+    cfg["use_importance_sampling_correction"] = True
+    cfg["sequence_level_importance_ratios"] = True
+    cfg["is_correction_level"] = "sequence_mean"
+    cfg["token_level_loss"] = False
+    loss_fn = ClippedPGLossFn(cfg)
+
+    adv_masked = torch.tensor([[1.0, -1.0, 2.0]], device=device)
+    prev_lp_masked = torch.tensor([[-1.0, -1.0, -1.0]], device=device)
+    curr_lp_masked = torch.tensor(
+        [[-1.69315, -1.0, -0.59453]], device=device
+    )
+    ref_lp_masked = torch.tensor([[-1.0, -1.0, -1.0]], device=device)
+    gen_lp_masked = torch.tensor([[-0.5, -1.5, -0.8]], device=device)
+
+    data["advantages"][0, 1:] = adv_masked
+    data["prev_logprobs"][0, 1:] = prev_lp_masked
+    data["generation_logprobs"][0, 1:] = gen_lp_masked
+    data["reference_policy_logprobs"][0, 1:] = ref_lp_masked
+
+    # --- Hand Calculation ---
+    # Key difference: IS weight = exp(MEAN(prev - gen)) instead of exp(SUM(prev - gen))
+    # prev - gen = [-0.5, 0.5, -0.2], mean = -0.0667, exp(-0.0667) = 0.9355
+    per_token_diff = prev_lp_masked - gen_lp_masked  # [-0.5, 0.5, -0.2]
+    actor_importance_weights = torch.exp(per_token_diff.mean(dim=-1).unsqueeze(-1))
+    assert torch.allclose(
+        actor_importance_weights,
+        torch.tensor([[0.9355]], device=device),
+        rtol=1e-3,
+    )
+
+    # Compare with exp(sum) version: exp(-0.2) = 0.8187 — sequence_mean is closer to 1.0
+    actor_importance_weights_sum = torch.exp(per_token_diff.sum(dim=-1).unsqueeze(-1))
+    assert torch.allclose(
+        actor_importance_weights_sum,
+        torch.tensor([[0.8187]], device=device),
+        rtol=1e-3,
+    )
+    # sequence_mean IS weight is closer to 1.0 than sum version
+    assert (actor_importance_weights - 1.0).abs() < (actor_importance_weights_sum - 1.0).abs()
+
+    # PPO ratio unchanged (still GSPO exp(mean) of log ratios)
+    log_ratios = curr_lp_masked - prev_lp_masked
+    seq_log_ratios_mean = torch.mean(log_ratios, dim=-1).unsqueeze(-1)
+    ratios = seq_log_ratios_mean.exp().repeat(1, 3)
+
+    ratios_clamped = torch.clamp(
+        ratios, 1.0 - cfg["ratio_clip_min"], 1.0 + cfg["ratio_clip_max"]
+    )
+    max_loss = torch.maximum(-adv_masked * ratios, -adv_masked * ratios_clamped)
+    importance_weighted_max_loss = actor_importance_weights * max_loss
+    expected_actor_loss = torch.mean(importance_weighted_max_loss)
+
+    input_ids = data["input_ids"]
+    dummy_logits = _create_exact_logits(
+        curr_lp_masked, input_ids, batch_size, seq_len, vocab_size, device
+    )
+    loss_input, data = prepare_loss_input(dummy_logits, data, loss_fn)
+
+    actual_loss, _ = loss_fn(
+        data=data,
+        global_valid_seqs=torch.sum(data["sample_mask"]),
+        global_valid_toks=torch.sum(data["sample_mask"] * data["token_mask"]),
+        **loss_input,
+    )
+    torch.testing.assert_close(actual_loss, expected_actor_loss, atol=1e-4, rtol=1e-3)
+
+
 def setup_distillation_test_data(batch_size=2, seq_len=4, vocab_size=8, topk=64):
     """Setup test data for distillation loss function tests."""
     if not torch.cuda.is_available():


### PR DESCRIPTION
# What does this PR do?

  Decouple IS correction granularity from the GSPO policy ratio so they can be     
  configured independently.
                                                                                   
  Currently `sequence_level_importance_ratios=True` bundles two behaviors into a   
  single flag:                           
  1. **GSPO policy ratio**: `exp(mean(log(π_curr/π_prev)))` — numerically stable   
  2. **IS correction weight**: `exp(sum(prev - gen))` — collapses for long       
  sequences                                                                        
   
  For long sequences (~9k+ tokens), even a small per-token logprob mismatch between
   training and inference backends (e.g., ~2% with vLLM + Megatron) accumulates via
   `exp(sum)` to near-zero IS weights, effectively reducing the learning rate by   
  10–50x with high variance across steps.                                        
                                         
  This PR adds a new `is_correction_level` config field to `ClippedPGLossConfig`   
  that controls IS correction weight computation independently of the PPO ratio
  (which remains controlled by `sequence_level_importance_ratios`).                
                                                                                 
  Supported values:                      
  - `"sequence"` — `exp(sum(prev - gen))`, one weight per sequence (current
  behavior)                                                                        
  - `"sequence_mean"` — `exp(mean(prev - gen))`, geometric mean, numerically stable
   for long sequences                                                              
  - `"token"` — `exp(prev - gen)` per token, token-level correction              
                                                                                   
  When unset (`None`), behavior is derived from `sequence_level_importance_ratios`
  for full backward compatibility.                                                 
                                                                                 
  # Issues                               

  None — discovered during GRPO training with Qwen3.5-35B-A3B (MoE, ~9k avg        
  response tokens) where `sampling_importance_ratio` showed mean ~0.4, std ~0.27,
  with some steps collapsing to 0.02.                                              
                                                                                 
  # Usage                                

  ```yaml
  loss_fn:
    # GSPO policy ratio (unchanged)                                                
    sequence_level_importance_ratios: true
    token_level_loss: false                                                        
    # IS correction now independently configurable                               
    is_correction_level: "sequence_mean"  # or "token", or "sequence" (default)    
    use_importance_sampling_correction: true                                       
    truncated_importance_sampling_ratio: 2                                         
    truncated_importance_sampling_type: tis                                        
 ```   
  Before your PR is "Ready for review"                                           
                                                                                   
  Pre checks:                                                                    
  - Make sure you read and followed /NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md
  - Did you write any new necessary tests?                                         
  - Did you run the unit tests and functional tests locally? Visit our
  /NVIDIA-NeMo/RL/blob/main/docs/testing.md for how to run tests                   
  - Did you add or update any necessary documentation? Visit our                   
  /NVIDIA-NeMo/RL/blob/main/docs/documentation.md for how to write, build and test
  the docs.                                                                        
                                                                                 
  Additional Information                                                           
                                                                                 
  - All 44 existing tests pass (backward compat verified)                          
  - New test test_clipped_pg_loss_gspo_is_correction_level_sequence_mean validates
  that exp(mean) produces IS weights closer to 1.0 than exp(sum) and that the loss 
  value matches hand-calculated expectations                                     
  - seq-mask-tis compatibility assertion updated to account for the new field 