### PR TITLE
fix: include scalar float/int in metric aggregation

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1929,7 +1929,7 @@ def grpo_train(
                         "mean_prompt_length",
                     }:
                         metrics[k] = np.mean(v).item()
-                    elif isinstance(v, (np.ndarray, list)):
+                    elif isinstance(v, (np.ndarray, list, float, int)):
                         metrics[k] = np.sum(v).item()
                     else:
                         print(f"Skipping aggregation for {k} ({type(v)})")


### PR DESCRIPTION
# What does this PR do ?

Fix metric aggregation to include Python `float` and `int` scalars, restoring logging for 12 silently dropped metrics.

# Issues

Regression introduced in #1773 (`2311de49`).

# Usage

No usage change — metrics that were silently skipped now appear in WandB/TensorBoard as expected.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests? — No new tests needed: 1-line type fix restoring pre-existing behavior.
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? — No documentation change needed.

# Additional Information

The `isinstance` guard added in #1773 (`2311de49`) changed the `else` fallback to only accept `np.ndarray` and `list`, inadvertently excluding plain `float`/`int` scalars produced by `.item()` calls. This silently drops 12 metrics with `Skipping aggregation for <key> (<class 'float'>)`:

- `baseline_reward/pct_0`, `pct_1`, `pct_mixed`
- `advantages/mean`, `min`, `max`, `sum`
- `vllm/spec_acceptance_length`, `spec_acceptance_rate`, `spec_num_accepted_tokens`, `spec_num_drafts`, `spec_num_draft_tokens`

Adding `float, int` to the `isinstance` check restores them while still guarding against non-numeric types (dicts, strings, etc.) that motivated the original change.