### PR TITLE
fix: forward HF env vars to policy worker runtime_env

### DIFF
--- a/nemo_rl/models/policy/utils.py
+++ b/nemo_rl/models/policy/utils.py
@@ -187,15 +187,23 @@ def configure_dynamo_cache() -> None:
     torch._inductor.config.autotune_local_cache = False
 
 
+_HF_ENV_VARS = ("HF_TOKEN", "HUGGING_FACE_HUB_TOKEN", "HF_HOME")
+
+
 def get_runtime_env_for_policy_worker(policy_worker_name: str) -> dict[str, Any]:
     """Get runtime environment configuration for policy workers.
 
     Note: expandable_segments configuration is handled directly in the worker init methods
     to ensure proper GPU detection after CUDA initialization.
     """
+    env_vars = {k: os.environ[k] for k in _HF_ENV_VARS if k in os.environ}
+
     runtime_env = {
         **get_nsight_config_if_pattern_matches(policy_worker_name),
     }
+
+    if env_vars:
+        runtime_env["env_vars"] = env_vars
 
     return runtime_env
 


### PR DESCRIPTION
## Summary
- Forward `HF_TOKEN`, `HUGGING_FACE_HUB_TOKEN`, and `HF_HOME` from the parent process into the policy worker `runtime_env` via `get_runtime_env_for_policy_worker()`
- Fixes 429 rate limit errors during CI when multiple `DTensorPolicyWorkerV2` workers simultaneously initialize tokenizers against the HuggingFace API without credentials
- Matches the existing pattern used by vLLM workers (`vllm_worker.py` `ADDITIONAL_ENV_VARS`)

## Test plan
- [ ] Run existing nemo-ci nightly/release tests (e.g. `grpo-llama3.2-1b-instruct-1n4g-fsdp2tp1`) and verify no more 429 errors during tokenizer init
- [ ] Verify `HF_TOKEN` is accessible inside `DTensorPolicyWorkerV2.__init__()` via `os.environ`

🤖 Generated with [Claude Code](https://claude.com/claude-code)