### PR TITLE
ci: retry apt-get installs to handle mirror sync failures

### DIFF
--- a/.claude/skills/contributing/SKILL.md
+++ b/.claude/skills/contributing/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: contributing
+description: Contribution conventions for NeMo-RL. Covers PR title format, commit sign-off, and CI triggering. Auto-invoked during code review.
+---
+
+# Contributing Conventions
+
+## PR Title Format
+
+PR titles **must** follow the [Conventional Commits](https://www.conventionalcommits.org/) spec. This is enforced by the `semantic-pull-request` CI check.
+
+```
+<type>[optional scope]: <description>
+```
+
+Allowed types:
+
+| Type | When to use |
+|------|-------------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `ci` | CI/CD changes |
+| `docs` | Documentation only |
+| `refactor` | Code restructuring without behaviour change |
+| `test` | Adding or fixing tests |
+| `chore` | Maintenance (deps, configs, tooling) |
+| `perf` | Performance improvement |
+| `build` | Build system changes |
+| `revert` | Reverts a previous commit |
+
+**Do:**
+```
+ci: retry apt-get installs to handle mirror sync failures
+feat(grpo): add dataclass config defaults infrastructure
+fix: preserve RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES
+```
+
+**Don't:**
+```
+[ci] fix: retry apt-get installs   ← area tags are not part of this convention
+Update stuff
+Fix bug
+```
+
+## Commit Sign-off
+
+All commits must be signed off with `-s`:
+
+```bash
+git commit -s -m "fix: correct reward normalization"
+```
+
+## CI Triggering
+
+After pushing, trigger CI with:
+
+```
+/ok to test <full-commit-sha>
+```
+
+Use `git rev-parse HEAD` (not the short form) to get the full SHA.

--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -87,8 +87,11 @@ runs:
       shell: bash -x -e -u -o pipefail {0}
       if: ${{ contains(inputs.runner, 'gcp') }}
       run: |
-        apt-get update
-        apt-get install -y uuid-runtime
+        for i in 1 2 3; do
+          apt-get update && apt-get install -y uuid-runtime && break
+          echo "Attempt $i failed, retrying in 10s..."
+          sleep 10
+        done
 
     - name: Docker system cleanup
       shell: bash

--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -81,7 +81,11 @@ runs:
       if: ${{ inputs.has-azure-credentials == 'true' }}
       shell: bash
       run: |
-        curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+        for i in 1 2 3; do
+          curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash && break
+          echo "Attempt $i failed, retrying in 10s..."
+          sleep 10
+        done
 
     - name: Install uuidgen
       shell: bash -x -e -u -o pipefail {0}


### PR DESCRIPTION
## Summary

- Wraps all `apt-get update && apt-get install` calls in a 3-attempt retry loop with a 10s back-off
- Wraps the Azure CLI install script (`InstallAzureCLIDeb`) in the same retry loop — the script runs its own `apt-get update` internally and is subject to the same mirror sync failures
- Adds a `contributing` skill documenting the Conventional Commits PR title format enforced by the `semantic-pull-request` CI check

## Affected files

- `.github/actions/test-template/action.yml` — Install uuidgen + Install Azure CLI
- `.claude/skills/contributing/SKILL.md` — new skill: PR title format, commit sign-off, CI triggering

## Test plan

- [ ] CI passes on the next run without manual retries
- [ ] `semantic-pull-request` check passes on this PR