### PR TITLE
ci: pass quality gate when test_level is none (lint-only PRs)

### DIFF
--- a/.claude/skills/contributing/SKILL.md
+++ b/.claude/skills/contributing/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: contributing
+description: Contribution conventions for NeMo-RL. Covers PR title format, commit sign-off, and CI triggering. Auto-invoked during code review.
+---
+
+# Contributing Conventions
+
+## PR Title Format
+
+PR titles **must** follow the [Conventional Commits](https://www.conventionalcommits.org/) spec. This is enforced by the `semantic-pull-request` CI check.
+
+```
+<type>[optional scope]: <description>
+```
+
+Allowed types:
+
+| Type | When to use |
+|------|-------------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `ci` | CI/CD changes |
+| `docs` | Documentation only |
+| `refactor` | Code restructuring without behaviour change |
+| `test` | Adding or fixing tests |
+| `chore` | Maintenance (deps, configs, tooling) |
+| `perf` | Performance improvement |
+| `build` | Build system changes |
+| `revert` | Reverts a previous commit |
+
+**Do:**
+```
+ci: retry apt-get installs to handle mirror sync failures
+feat(grpo): add dataclass config defaults infrastructure
+fix: preserve RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES
+```
+
+**Don't:**
+```
+[ci] fix: retry apt-get installs   ← area tags are not part of this convention
+Update stuff
+Fix bug
+```
+
+## Commit Sign-off
+
+All commits must be signed off with `-s`:
+
+```bash
+git commit -s -m "fix: correct reward normalization"
+```
+
+## CI Triggering
+
+After pushing, trigger CI with:
+
+```
+/ok to test <full-commit-sha>
+```
+
+Use `git rev-parse HEAD` (not the short form) to get the full SHA.

--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -87,8 +87,11 @@ runs:
       shell: bash -x -e -u -o pipefail {0}
       if: ${{ contains(inputs.runner, 'gcp') }}
       run: |
-        apt-get update
-        apt-get install -y uuid-runtime
+        for i in 1 2 3; do
+          apt-get update && apt-get install -y uuid-runtime && break
+          echo "Attempt $i failed, retrying in 10s..."
+          sleep 10
+        done
 
     - name: Docker system cleanup
       shell: bash

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -459,10 +459,10 @@ jobs:
               needs.lint-check.result == 'success' &&
               (needs.pr-branch-up-to-date-check.result == 'success' || needs.pr-branch-up-to-date-check.result == 'skipped') &&
               (
-                needs.pre-flight.outputs.test_level != 'none' &&
-                needs.sphinx-build.result == 'success' &&
-                (needs.build-container.result == 'success' || needs.build-container.result == 'skipped') &&
+                needs.pre-flight.outputs.test_level == 'none' ||
                 (
+                  needs.sphinx-build.result == 'success' &&
+                  (needs.build-container.result == 'success' || needs.build-container.result == 'skipped') &&
                   (
                     (needs.cicd-doc-tests.result == 'success' || needs.cicd-doc-tests.result == 'skipped') &&
                     (needs.cicd-unit-tests.result == 'skipped' || needs.cicd-unit-tests.result == 'success') &&


### PR DESCRIPTION
## Summary

Fixes the `CI_QA_Gate` always failing for PRs that have no CI label (e.g. docs-only or workflow-only changes).

## Root cause

`ALL_SUCCESS` required `test_level != 'none'` as part of a conjunction, so when no tests were scheduled the entire condition evaluated to `false` — even if lint passed cleanly. The comment above the expression already said *"Job is considered successful if nothing was run"*, but the logic didn't implement that.

## Fix

Replace `test_level != 'none' && <all jobs passed>` with `test_level == 'none' || <all jobs passed>`, which correctly short-circuits to `true` when no tests were scheduled.

## Before / After

```diff
-              needs.pre-flight.outputs.test_level != 'none' &&
-              needs.sphinx-build.result == 'success' &&
+              needs.pre-flight.outputs.test_level == 'none' ||
+              (
+                needs.sphinx-build.result == 'success' &&
               ...
+              )
```

## Unblocks

- NVIDIA-NeMo/RL#2265

## Test plan

- [ ] This PR itself should pass the quality gate with `test_level = none`