### PR TITLE
ci(action): surface launch info and pass/fail banner; fix exit_code capture

### DIFF
--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -127,7 +127,7 @@ runs:
         echo -e "\033[1;34m│  runner    : ${{ inputs.runner }}\033[0m"
         echo -e "\033[1;34m│  container : ${{ inputs.registry }}/${{ inputs.image }}:${{ inputs.image-tag || github.run_id }}\033[0m"
         echo -e "\033[1;34m└──────────────────────────────────────────────────────────────────────────┘\033[0m"
-
+        echo "::group::Logs"
         docker run --rm -u root --runtime=nvidia --gpus all \
           --shm-size=64g \
           --env TRANSFORMERS_OFFLINE=0 \
@@ -158,6 +158,7 @@ runs:
             fi
             bash tests/${{ inputs.is_doc_test == 'true' && 'docs' || (inputs.is_unit_test == 'true' && 'unit' || 'functional') }}/${{ inputs.script }}.sh && \
             echo "Finished successfully." || echo "Did not finish."' 2>&1 | tee err.log
+        echo "::endgroup::"
 
     - name: Check result
       id: check

--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -122,6 +122,12 @@ runs:
         COVERAGE_PREFIX=$([[ "${{ inputs.is_doc_test }}" == "true" ]] && echo "doc-test" || ([[ "${{ inputs.is_unit_test }}" == "true" ]] && echo "unit-test" || echo "e2e"))
         echo "coverage-prefix=$COVERAGE_PREFIX" | tee -a "$GITHUB_OUTPUT"
 
+        echo -e "\033[1;34m┌─ launching test ─────────────────────────────────────────────────────────┐\033[0m"
+        echo -e "\033[1;34m│  script    : ${{ inputs.script }}\033[0m"
+        echo -e "\033[1;34m│  runner    : ${{ inputs.runner }}\033[0m"
+        echo -e "\033[1;34m│  container : ${{ inputs.registry }}/${{ inputs.image }}:${{ inputs.image-tag || github.run_id }}\033[0m"
+        echo -e "\033[1;34m└──────────────────────────────────────────────────────────────────────────┘\033[0m"
+
         docker run --rm -u root --runtime=nvidia --gpus all \
           --shm-size=64g \
           --env TRANSFORMERS_OFFLINE=0 \
@@ -155,24 +161,38 @@ runs:
 
     - name: Check result
       id: check
-      shell: bash
+      shell: bash -e -u -o pipefail {0}
+      if: always()
       run: |
         coverage_report=coverage-${{ steps.test.outputs.coverage-prefix }}-${{ github.run_id }}-$(uuidgen)
-        echo "coverage_report=$coverage_report" >> "$GITHUB_OUTPUT"
+        echo "coverage_report=$coverage_report" | tee -a "$GITHUB_OUTPUT"
 
         IS_SUCCESS=$(tail -n 1 err.log | grep -q "Finished successfully." && echo "true" || echo "false")
 
-        if [[ "$IS_SUCCESS" == "false" && "{% raw %}${{ inputs.is_optional }}" == "true" ]]; then
-          echo "::warning:: Test failed, but displayed as successful because it is marked as optional."
+        if [[ "$IS_SUCCESS" == "false" && "${{ inputs.is_optional }}" == "true" ]]; then
+          echo "::warning::Test failed but is marked optional — treating as success."
           IS_SUCCESS=true
         fi
 
-        if [[ "$IS_SUCCESS" == "false" ]]; then
-          echo Test did not finish successfully.
+        if [[ "$IS_SUCCESS" == "true" ]]; then
+          echo -e "\033[1;32m╔══════════════════════════════════════════════════════════════════════════╗\033[0m"
+          echo -e "\033[1;32m║                                                                          ║\033[0m"
+          echo -e "\033[1;32m║   ✅  PASSED                                                             ║\033[0m"
+          echo -e "\033[1;32m║   ${{ inputs.script }}\033[0m"
+          echo -e "\033[1;32m║                                                                          ║\033[0m"
+          echo -e "\033[1;32m╚══════════════════════════════════════════════════════════════════════════╝\033[0m"
+          echo "::notice title=Result::✅ ${{ inputs.script }} — PASSED"
+          exit 0
+        else
+          echo -e "\033[1;31m╔══════════════════════════════════════════════════════════════════════════╗\033[0m"
+          echo -e "\033[1;31m║                                                                          ║\033[0m"
+          echo -e "\033[1;31m║   ❌  FAILED                                                             ║\033[0m"
+          echo -e "\033[1;31m║   ${{ inputs.script }}\033[0m"
+          echo -e "\033[1;31m║                                                                          ║\033[0m"
+          echo -e "\033[1;31m╚══════════════════════════════════════════════════════════════════════════╝\033[0m"
+          echo "::error title=Result::❌ ${{ inputs.script }} — FAILED"
           exit 1
         fi
-
-        exit $EXIT_CODE
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Summary

Ports improvements from Megatron-Bridge [925c88f](https://github.com/NVIDIA-NeMo/Megatron-Bridge/commit/925c88f5a73a46bb42283d53da43999094ee94ae) to RL:

- **Launch banner**: prints script name, runner, and container image at the start of "Run tests"
- **`::group::Logs`**: wraps the entire `docker run` output (previously ~44k lines of flat text per run) in a collapsible section
- **Pass/fail banner**: "Check result" now prints a colored ✅ PASSED / ❌ FAILED box at the end of every run
- **`if: always()`** on "Check result" so the banner is shown even on failure
- **`shell: bash -e -u -o pipefail {0}`** on "Check result" for strict error handling
- **`tee -a`** instead of `>>` when writing to `$GITHUB_OUTPUT`
- **Fixed `{% raw %}` template artifact** in the optional-test condition (was preventing optional tests from ever being treated as success)
- **Fixed optional warning message** formatting
- **Removed broken `exit $EXIT_CODE`** where `EXIT_CODE` was never defined

## Example output

**Launch banner:**
```
┌─ launching test ─────────────────────────────────────────────────────────┐
│  script    : L0_Unit_Tests_Policy                                         │
│  runner    : nemo-ci-gcp-gpu-x2                                           │
│  container : us-east4-docker.pkg.dev/.../rl:12345                         │
└──────────────────────────────────────────────────────────────────────────┘
▶ Logs   (collapsed — click to expand)
```

**Result banner:**
```
╔══════════════════════════════════════════════════════════════════════════╗
║                                                                          ║
║   ✅  PASSED                                                             ║
║   L0_Unit_Tests_Policy                                                   ║
║                                                                          ║
╚══════════════════════════════════════════════════════════════════════════╝
```

## Test plan

- [ ] Verify launch banner appears at the start of a test run
- [ ] Verify docker run output is collapsed under "Logs" group
- [ ] Verify ✅ PASSED banner appears on success
- [ ] Verify ❌ FAILED banner appears on failure
- [ ] Verify optional tests are now correctly treated as success when `is_optional=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)