### PR TITLE
ci: add step summary when CI quality gate fails due to missing label

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -480,6 +480,24 @@ jobs:
           SUMMARY=$(echo $JOB_RESULTS | jq 'to_entries[] | .key + ": " + .value.result' | tr -d '"')
           echo '🤖: CICD Result for test level: ${{ needs.pre-flight.outputs.test_level }}' >> $GITHUB_STEP_SUMMARY
           echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY
+
+          if [[ "$TEST_LEVEL" == "none" ]]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "---" >> $GITHUB_STEP_SUMMARY
+            echo "⚠️ **No tests were run.** This PR does not have a CI label." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "To trigger tests, add one of the following labels to your PR:" >> $GITHUB_STEP_SUMMARY
+            echo "| Label | What it runs |" >> $GITHUB_STEP_SUMMARY
+            echo "|-------|-------------|" >> $GITHUB_STEP_SUMMARY
+            echo "| \`CI:docs\` | Doc tests only |" >> $GITHUB_STEP_SUMMARY
+            echo "| \`CI:Lfast\` | Fast subset (reuses main container) |" >> $GITHUB_STEP_SUMMARY
+            echo "| \`CI:L0\` | Unit tests + docs + lint |" >> $GITHUB_STEP_SUMMARY
+            echo "| \`CI:L1\` | L0 + functional tests |" >> $GITHUB_STEP_SUMMARY
+            echo "| \`CI:L2\` | L1 + convergence tests |" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "This check will remain failed until a CI label is added." >> $GITHUB_STEP_SUMMARY
+          fi
+
           test "$ALL_SUCCESS" = "true" || test "$CI_SKIP" = "true"
 
   notify-nightly-failure:


### PR DESCRIPTION
## Summary

- When a PR has no `CI:*` label, `test_level` is `none` and the `CI_QA_Gate` check fails — but there's no indication **why** it failed
- This adds a GitHub Actions step summary that clearly explains the failure and lists all available CI labels with what they run

## What it looks like

When the gate fails due to missing label, the step summary will show:

> ⚠️ **No tests were run.** This PR does not have a CI label.
>
> | Label | What it runs |
> |-------|-------------|
> | `CI:docs` | Doc tests only |
> | `CI:Lfast` | Fast subset (reuses main container) |
> | `CI:L0` | Unit tests + docs + lint |
> | `CI:L1` | L0 + functional tests |
> | `CI:L2` | L1 + convergence tests |
>
> This check will remain failed until a CI label is added.

## Context

Discussed with @ko3n1g — the current behavior (gate failing without CI label) is deliberate, but contributors get stuck not knowing why. This keeps the gate behavior unchanged and just adds visibility.

## Test plan

- [ ] Push a PR without a CI label and verify the step summary renders in the `CI_QA_Gate` job


🤖 Generated with [Claude Code](https://claude.com/claude-code)