### PR TITLE
fix(grpo): add GDPO rollout guardrails and env stop-string defaults

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -58,6 +58,7 @@ from nemo_rl.data.llm_message_utils import (
     get_keys_from_message_log,
 )
 from nemo_rl.data.utils import extract_necessary_env_names
+from nemo_rl.data.utils import get_default_stop_strings_from_env_config
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.ray_actor_environment_registry import get_actor_python_env
 from nemo_rl.distributed.virtual_cluster import ClusterConfig, RayVirtualCluster
@@ -208,9 +209,163 @@ class MasterConfig(TypedDict):
     checkpointing: CheckpointingConfig
 
 
+ROLLOUT_BUDGET_WARNING_TOKEN_THRESHOLD = 131_072
+
+
 # ===============================================================================
 # Setup & Initialization
 # ===============================================================================
+
+
+def _iter_dataset_configs(section_config: Any) -> list[dict[str, Any]]:
+    """Normalize a data-config section into a list of dataset configs."""
+    if section_config is None:
+        return []
+    if isinstance(section_config, dict):
+        return [section_config]
+    if isinstance(section_config, list):
+        return [cfg for cfg in section_config if isinstance(cfg, dict)]
+    return []
+
+
+def _resolved_train_dataset_configs(data_config: DataConfig) -> list[dict[str, Any]]:
+    """Return train dataset configs with `data.default` applied."""
+    default_cfg = data_config.get("default") or {}
+    resolved_configs = []
+    for cfg in _iter_dataset_configs(data_config["train"]):
+        resolved_cfg = dict(default_cfg)
+        resolved_cfg.update(cfg)
+        resolved_configs.append(resolved_cfg)
+    return resolved_configs
+
+
+def _has_obvious_first_turn_stop_strings(master_config: MasterConfig) -> bool:
+    """Best-effort check for clearly configured first-turn stop strings."""
+    generation_config = master_config["policy"]["generation"]
+    assert generation_config is not None, "GRPO requires a generation config"
+
+    if generation_config.get("stop_strings"):
+        return True
+
+    env_configs = master_config.get("env", {})
+    for cfg in _resolved_train_dataset_configs(master_config["data"]):
+        env_name = cfg.get("env_name")
+        if env_name is None:
+            continue
+        if get_default_stop_strings_from_env_config(env_configs.get(env_name)):
+            return True
+
+    return False
+
+
+def _compute_rollout_budget_summary(master_config: MasterConfig) -> dict[str, Any]:
+    """Compute a small rollout-budget summary for setup logging and warnings."""
+    generation_config = master_config["policy"]["generation"]
+    assert generation_config is not None, "GRPO requires a generation config"
+
+    grpo_config = master_config["grpo"]
+    effective_num_prompts = grpo_config["num_prompts_per_step"]
+    if grpo_config["use_dynamic_sampling"]:
+        effective_num_prompts = int(
+            effective_num_prompts * grpo_config.get("batch_multiplier", 1)
+        )
+
+    num_generations_per_prompt = grpo_config["num_generations_per_prompt"]
+    samples_per_step = effective_num_prompts * num_generations_per_prompt
+
+    colocated_cfg = generation_config.get("colocated", {})
+    colocated_enabled = bool(colocated_cfg.get("enabled", True))
+    generation_resources = colocated_cfg.get("resources") or {}
+
+    return {
+        "effective_num_prompts_per_step": effective_num_prompts,
+        "num_generations_per_prompt": num_generations_per_prompt,
+        "samples_per_step": samples_per_step,
+        "configured_max_new_tokens": generation_config["max_new_tokens"],
+        "theoretical_max_generated_tokens_per_step": (
+            samples_per_step * generation_config["max_new_tokens"]
+        ),
+        "generation_backend": generation_config["backend"],
+        "async_generation_enabled": bool(
+            generation_config.get("vllm_cfg", {}).get("async_engine", False)
+        ),
+        "colocated_generation_enabled": colocated_enabled,
+        "generation_gpus_per_node": generation_resources.get("gpus_per_node"),
+        "generation_num_nodes": generation_resources.get("num_nodes"),
+    }
+
+
+def _get_rollout_budget_warnings(master_config: MasterConfig) -> list[str]:
+    """Return advisory rollout-budget warnings for likely slow configs."""
+    summary = _compute_rollout_budget_summary(master_config)
+    warning_messages: list[str] = []
+
+    if (
+        summary["theoretical_max_generated_tokens_per_step"]
+        >= ROLLOUT_BUDGET_WARNING_TOKEN_THRESHOLD
+    ):
+        warning_messages.append(
+            "This GRPO/GDPO config requests a very large theoretical rollout budget "
+            f"({summary['theoretical_max_generated_tokens_per_step']:,} max generated tokens per step). "
+            "If training is slow, reduce policy.generation.max_new_tokens and/or "
+            "grpo.num_generations_per_prompt before tuning training-side settings."
+        )
+
+    if summary[
+        "configured_max_new_tokens"
+    ] >= 1024 and not _has_obvious_first_turn_stop_strings(master_config):
+        warning_messages.append(
+            "This GRPO/GDPO config uses a large max_new_tokens setting without any obvious first-turn "
+            "stop strings from policy.generation.stop_strings or env defaults. "
+            "Long unconstrained generations can dominate step time."
+        )
+
+    return warning_messages
+
+
+def _log_rollout_budget_summary(master_config: MasterConfig) -> None:
+    """Print a concise rollout-budget summary during setup."""
+    summary = _compute_rollout_budget_summary(master_config)
+    print("\n📦 Rollout Budget Summary:")
+    print(
+        f"  • Effective prompts per step: {summary['effective_num_prompts_per_step']}",
+        flush=True,
+    )
+    print(
+        f"  • Generations per prompt: {summary['num_generations_per_prompt']}",
+        flush=True,
+    )
+    print(f"  • Samples per step: {summary['samples_per_step']}", flush=True)
+    print(
+        f"  • Max new tokens per sample: {summary['configured_max_new_tokens']}",
+        flush=True,
+    )
+    print(
+        "  • Theoretical max generated tokens per step: "
+        f"{summary['theoretical_max_generated_tokens_per_step']:,}",
+        flush=True,
+    )
+    print(f"  • Generation backend: {summary['generation_backend']}", flush=True)
+    print(
+        f"  • Async generation enabled: {summary['async_generation_enabled']}",
+        flush=True,
+    )
+    print(
+        f"  • Colocated generation enabled: {summary['colocated_generation_enabled']}",
+        flush=True,
+    )
+    if not summary["colocated_generation_enabled"]:
+        print(
+            "  • Generation resources (gpus_per_node, num_nodes): "
+            f"({summary['generation_gpus_per_node']}, {summary['generation_num_nodes']})",
+            flush=True,
+        )
+
+
+def _warn_on_rollout_budget(master_config: MasterConfig) -> None:
+    """Emit advisory warnings for potentially expensive rollout configs."""
+    for warning_message in _get_rollout_budget_warnings(master_config):
+        warnings.warn(warning_message, stacklevel=2)
 
 
 def setup(
@@ -301,6 +456,9 @@ def setup(
             "Please check the configuration of num_prompts_per_step and num_prompts_per_dataloader. "
             "If use_dynamic_sampling is enabled and batch_multiplier is used, please also check the configuration of batch_multiplier."
         )
+
+    _log_rollout_budget_summary(master_config)
+    _warn_on_rollout_budget(master_config)
 
     # Load train dataset
     def init_train_dataloader(dataset, suffix: str = ""):
@@ -1576,6 +1734,15 @@ def grpo_train(
                     metrics_logging_data["mean_gen_tokens_per_sample"] = (
                         rollout_metrics["mean_gen_tokens_per_sample"]
                     )
+                    metrics_logging_data["max_gen_tokens_per_sample"] = rollout_metrics[
+                        "max_gen_tokens_per_sample"
+                    ]
+                    metrics_logging_data["truncation_rate"] = rollout_metrics[
+                        "truncation_rate"
+                    ]
+                    metrics_logging_data["mean_total_tokens_per_sample"] = (
+                        rollout_metrics["mean_total_tokens_per_sample"]
+                    )
                     logger.log_metrics(rollout_metrics, total_steps + 1, prefix="train")
 
                 repeated_batch = scale_rewards(
@@ -2130,6 +2297,19 @@ def grpo_train(
                 print(f"  • Avg Reward: {np.mean(rewards.numpy()):.4f}")
             print(
                 f"  • Mean Generation Length: {metrics_logging_data['mean_gen_tokens_per_sample']:.4f}",
+                flush=True,
+            )
+            print(
+                f"  • Max Generation Length: {metrics_logging_data['max_gen_tokens_per_sample']:.4f}",
+                flush=True,
+            )
+            print(
+                f"  • Truncation Rate: {metrics_logging_data['truncation_rate']:.4f}",
+                flush=True,
+            )
+            print(
+                "  • Mean Total Tokens Per Sample: "
+                f"{metrics_logging_data['mean_total_tokens_per_sample']:.4f}",
                 flush=True,
             )
 

--- a/nemo_rl/data/datasets/processed_dataset.py
+++ b/nemo_rl/data/datasets/processed_dataset.py
@@ -129,6 +129,14 @@ class AllTaskProcessedDataset:
             entry, task_data_spec, self.tokenizer, self.max_seq_length, idx
         )
 
+        # Preserve explicit processor-authored stop strings. Otherwise fill in
+        # task-local defaults derived from the bound environment config.
+        if (
+            "stop_strings" not in datum_spec
+            and task_data_spec.default_stop_strings is not None
+        ):
+            datum_spec["stop_strings"] = list(task_data_spec.default_stop_strings)
+
         # Check the first processed item for BOS token assertion
         if (
             not self._bos_checked

--- a/nemo_rl/data/datasets/utils.py
+++ b/nemo_rl/data/datasets/utils.py
@@ -136,12 +136,17 @@ def extract_necessary_env_names(data_config: dict) -> list[str]:
     necessary_env_names = set()
     keys = ["train", "validation", "default"]
     for key in keys:
-        if (
-            key in data_config
-            and data_config[key] is not None
-            and "env_name" in data_config[key]
-        ):
-            necessary_env_names.add(data_config[key]["env_name"])
+        if key not in data_config or data_config[key] is None:
+            continue
+
+        section_config = data_config[key]
+        if isinstance(section_config, dict):
+            if "env_name" in section_config:
+                necessary_env_names.add(section_config["env_name"])
+        elif isinstance(section_config, list):
+            for cfg in section_config:
+                if isinstance(cfg, dict) and "env_name" in cfg:
+                    necessary_env_names.add(cfg["env_name"])
     return list(necessary_env_names)
 
 

--- a/nemo_rl/data/interfaces.py
+++ b/nemo_rl/data/interfaces.py
@@ -59,6 +59,9 @@ class TaskDataSpec:
     prompt_file: Optional[PathLike] = None
 
     system_prompt_file: Optional[PathLike] = None
+    # Optional task-local default stop strings used when a processor does not
+    # emit per-datum stop strings explicitly.
+    default_stop_strings: Optional[list[str]] = None
 
     def __post_init__(self) -> None:
         def load_prompt_file(
@@ -82,6 +85,11 @@ class TaskDataSpec:
         default_attrs = {
             "system_prompt": from_spec.system_prompt,
             "prompt": from_spec.prompt,
+            "default_stop_strings": (
+                list(from_spec.default_stop_strings)
+                if from_spec.default_stop_strings is not None
+                else None
+            ),
         }
 
         for attr_name, default_value in default_attrs.items():

--- a/nemo_rl/data/utils.py
+++ b/nemo_rl/data/utils.py
@@ -30,6 +30,32 @@ from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.environments.utils import create_env
 
 
+def get_default_stop_strings_from_env_config(
+    env_config: Optional[dict[str, Any]],
+) -> Optional[list[str]]:
+    """Extract task-local default stop strings from an environment config.
+
+    Supports both built-in env shapes like:
+        env.<name>.stop_strings
+
+    and custom env shapes like:
+        env.<name>.config.stop_strings
+    """
+    if not isinstance(env_config, dict):
+        return None
+
+    candidate_values = [env_config.get("stop_strings")]
+    nested_config = env_config.get("config")
+    if isinstance(nested_config, dict):
+        candidate_values.append(nested_config.get("stop_strings"))
+
+    for candidate in candidate_values:
+        if isinstance(candidate, list) and len(candidate) > 0:
+            return list(candidate)
+
+    return None
+
+
 # TODO: @yukih: unify to setup_data after dataset refactored
 def setup_response_data(
     tokenizer: AutoProcessor | AutoTokenizer,
@@ -109,6 +135,11 @@ def setup_response_data(
         )
         # bind task_name to task_data_processors and task_to_env
         task_name = data.task_name
+        if has_envs:
+            default_stop_strings = get_default_stop_strings_from_env_config(
+                env_configs.get(cfg["env_name"])
+            )
+            data.task_spec.default_stop_strings = default_stop_strings
         task_data_processors[task_name] = (data.task_spec, data.processor)
         if hasattr(data, "preprocessor") and data.preprocessor is not None:
             task_data_preprocessors[task_name] = data.preprocessor
@@ -187,6 +218,11 @@ def setup_response_data(
             )
             # bind task_name to task_data_processors and task_to_env
             task_name = val_data.task_name
+            if has_envs:
+                default_stop_strings = get_default_stop_strings_from_env_config(
+                    env_configs.get(cfg["env_name"])
+                )
+                val_data.task_spec.default_stop_strings = default_stop_strings
             val_task_data_processors[task_name] = (
                 val_data.task_spec,
                 val_data.processor,

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -25,7 +25,10 @@ from nemo_rl.algorithms.advantage_estimator import (
     ReinforcePlusPlusAdvantageEstimator,
 )
 from nemo_rl.algorithms.grpo import (
+    ROLLOUT_BUDGET_WARNING_TOKEN_THRESHOLD,
     _default_grpo_save_state,
+    _compute_rollout_budget_summary,
+    _get_rollout_budget_warnings,
     async_grpo_train,
     compute_and_apply_seq_logprob_error_masking,
     dynamic_sampling,
@@ -48,6 +51,90 @@ from tests.unit.algorithms.utils import (
 # ============================================================================
 # Stub classes for async GRPO testing (non-Ray versions for easy mocking)
 # ============================================================================
+
+
+def _make_rollout_budget_config(
+    *,
+    num_prompts_per_step=32,
+    num_generations_per_prompt=16,
+    max_new_tokens=1024,
+    generation_stop_strings=None,
+    env_stop_strings=None,
+    nested_env_stop_strings=None,
+    colocated_enabled=False,
+):
+    env_config = {"num_workers": 1}
+    if env_stop_strings is not None:
+        env_config["stop_strings"] = env_stop_strings
+    if nested_env_stop_strings is not None:
+        env_config["config"] = {"stop_strings": nested_env_stop_strings}
+
+    return {
+        "policy": {
+            "generation": {
+                "backend": "vllm",
+                "max_new_tokens": max_new_tokens,
+                "stop_strings": generation_stop_strings,
+                "vllm_cfg": {"async_engine": True},
+                "colocated": {
+                    "enabled": colocated_enabled,
+                    "resources": {"gpus_per_node": 4, "num_nodes": 1},
+                },
+            }
+        },
+        "grpo": {
+            "num_prompts_per_step": num_prompts_per_step,
+            "num_generations_per_prompt": num_generations_per_prompt,
+            "use_dynamic_sampling": False,
+            "batch_multiplier": 1,
+        },
+        "data": {
+            "train": {"env_name": "thai_reward_env"},
+            "default": None,
+        },
+        "env": {"thai_reward_env": env_config},
+        "cluster": {"num_nodes": 1, "gpus_per_node": 8},
+    }
+
+
+def test_compute_rollout_budget_summary_uses_effective_step_shape():
+    config = _make_rollout_budget_config()
+
+    summary = _compute_rollout_budget_summary(config)
+
+    assert summary["effective_num_prompts_per_step"] == 32
+    assert summary["num_generations_per_prompt"] == 16
+    assert summary["samples_per_step"] == 512
+    assert summary["configured_max_new_tokens"] == 1024
+    assert (
+        summary["theoretical_max_generated_tokens_per_step"]
+        == ROLLOUT_BUDGET_WARNING_TOKEN_THRESHOLD * 4
+    )
+    assert summary["async_generation_enabled"] is True
+    assert summary["colocated_generation_enabled"] is False
+
+
+def test_rollout_budget_warnings_flag_large_budget_without_stop_strings():
+    config = _make_rollout_budget_config()
+
+    warning_messages = _get_rollout_budget_warnings(config)
+
+    assert len(warning_messages) == 2
+    assert any(
+        "very large theoretical rollout budget" in msg for msg in warning_messages
+    )
+    assert any(
+        "without any obvious first-turn stop strings" in msg for msg in warning_messages
+    )
+
+
+def test_rollout_budget_warnings_accept_nested_env_stop_strings():
+    config = _make_rollout_budget_config(nested_env_stop_strings=["</s>"])
+
+    warning_messages = _get_rollout_budget_warnings(config)
+
+    assert len(warning_messages) == 1
+    assert "very large theoretical rollout budget" in warning_messages[0]
 
 
 class StubReplayBuffer:

--- a/tests/unit/data/test_data_processor.py
+++ b/tests/unit/data/test_data_processor.py
@@ -26,6 +26,7 @@ sys.path.append("/".join(abspath.split("/")[:-4]))
 
 from nemo_rl.algorithms.utils import get_tokenizer
 from nemo_rl.data.datasets import AllTaskProcessedDataset
+from nemo_rl.data.datasets.utils import extract_necessary_env_names
 from nemo_rl.data.datasets.eval_datasets import (
     AIMEDataset,
     GPQADataset,
@@ -42,10 +43,14 @@ from nemo_rl.data.processors import (
     math_data_processor,
     math_hf_data_processor,
 )
+from nemo_rl.data.utils import get_default_stop_strings_from_env_config
 from nemo_rl.models.policy import TokenizerConfig
 
 
 class DummyTokenizer:
+    bos_token_id = None
+    name_or_path = "dummy-tokenizer"
+
     def apply_chat_template(
         self,
         messages,
@@ -67,6 +72,133 @@ class DummyTokenizer:
         if return_tensors == "pt":
             return {"input_ids": torch.tensor([encoded], dtype=torch.long)}
         return {"input_ids": encoded}
+
+    def text_to_ids(self, text):
+        return list(range(len(text)))
+
+
+def _processor_without_stop_strings(
+    datum_dict, task_data_spec, tokenizer, max_seq_length, idx
+):
+    message_log = []
+    for message in datum_dict["message_log"]:
+        message_log.append(
+            {
+                "role": message["role"],
+                "content": message["content"],
+                "token_ids": torch.tensor(message["token_ids"], dtype=torch.long),
+            }
+        )
+    return {
+        "message_log": message_log,
+        "length": len(message_log[0]["token_ids"]),
+        "extra_env_info": None,
+        "loss_multiplier": 1.0,
+        "idx": idx,
+        "task_name": datum_dict["task_name"],
+    }
+
+
+def _processor_with_explicit_stop_strings(
+    datum_dict, task_data_spec, tokenizer, max_seq_length, idx
+):
+    output = _processor_without_stop_strings(
+        datum_dict, task_data_spec, tokenizer, max_seq_length, idx
+    )
+    output["stop_strings"] = ["<explicit-stop>"]
+    return output
+
+
+def test_get_default_stop_strings_from_env_config_supports_direct_and_nested_keys():
+    assert get_default_stop_strings_from_env_config(
+        {"stop_strings": ["</s>", "<|end|>"]}
+    ) == ["</s>", "<|end|>"]
+    assert get_default_stop_strings_from_env_config(
+        {"config": {"stop_strings": ["<nested-stop>"]}}
+    ) == ["<nested-stop>"]
+    assert get_default_stop_strings_from_env_config({"config": {}}) is None
+    assert get_default_stop_strings_from_env_config(None) is None
+
+
+def test_extract_necessary_env_names_supports_list_configs():
+    data_config = {
+        "train": [
+            {"env_name": "env_a"},
+            {"env_name": "env_b"},
+        ],
+        "validation": [
+            {"env_name": "env_b"},
+            {"env_name": "env_c"},
+        ],
+        "default": {"env_name": "env_default"},
+    }
+
+    assert set(extract_necessary_env_names(data_config)) == {
+        "env_a",
+        "env_b",
+        "env_c",
+        "env_default",
+    }
+
+
+def test_processed_dataset_injects_task_default_stop_strings():
+    raw_dataset = Dataset.from_list(
+        [
+            {
+                "task_name": "thai_reward_env",
+                "message_log": [
+                    {
+                        "role": "user",
+                        "content": "Hi",
+                        "token_ids": torch.tensor([1, 2, 3], dtype=torch.long),
+                    }
+                ],
+            }
+        ]
+    )
+    task_spec = TaskDataSpec(
+        task_name="thai_reward_env",
+        default_stop_strings=["</s>", "<|end|>"],
+    )
+    dataset = AllTaskProcessedDataset(
+        dataset=raw_dataset,
+        tokenizer=DummyTokenizer(),
+        default_task_data_spec=task_spec,
+        task_data_processors=_processor_without_stop_strings,
+        max_seq_length=128,
+    )
+
+    assert dataset[0]["stop_strings"] == ["</s>", "<|end|>"]
+
+
+def test_processed_dataset_preserves_processor_stop_strings_over_task_defaults():
+    raw_dataset = Dataset.from_list(
+        [
+            {
+                "task_name": "thai_reward_env",
+                "message_log": [
+                    {
+                        "role": "user",
+                        "content": "Hi",
+                        "token_ids": torch.tensor([1, 2, 3], dtype=torch.long),
+                    }
+                ],
+            }
+        ]
+    )
+    task_spec = TaskDataSpec(
+        task_name="thai_reward_env",
+        default_stop_strings=["</s>", "<|end|>"],
+    )
+    dataset = AllTaskProcessedDataset(
+        dataset=raw_dataset,
+        tokenizer=DummyTokenizer(),
+        default_task_data_spec=task_spec,
+        task_data_processors=_processor_with_explicit_stop_strings,
+        max_seq_length=128,
+    )
+
+    assert dataset[0]["stop_strings"] == ["<explicit-stop>"]
 
 
 def test_math_data_processor():


### PR DESCRIPTION
## Summary

This PR adds targeted guardrails and task-local stop-string defaulting to address the training-speed and rollout-behavior problems discussed in #2153.

Addresses #2153.

## Root cause

The issue report points to a GDPO run that is overwhelmingly generation-bound, with a very large effective rollout budget per optimization step and weak first-turn stopping signals. In practice, that means the run spends most of its wall-clock time in rollout generation rather than reward computation or GDPO-specific math.

A smaller but important product gap is that environment-level default stop strings were not being propagated into the first-turn `DatumSpec` unless the data processor set them explicitly, which makes it easy for long generations to continue until `max_new_tokens`.

## What changed

- add startup rollout-budget summaries and warning-only guardrails in GRPO setup so obviously expensive configurations are visible immediately
- warn when the theoretical rollout token budget is very large and when long first-turn generations appear to be missing obvious stop strings
- plumb task-local default stop strings from env config into `TaskDataSpec`, supporting both `env.<name>.stop_strings` and `env.<name>.config.stop_strings`
- inject those defaults into `DatumSpec` only when the processor did not already provide explicit stop strings
- expand rollout logging with truncation rate plus max and mean token visibility for easier runtime diagnosis
- fix `extract_necessary_env_names()` so list-shaped dataset configs still register env usage correctly
- add focused unit coverage for rollout-budget warnings, nested env stop strings, default stop-string injection, explicit stop-string preservation, and list-based env extraction

## Why this design

The implementation stays intentionally narrow:

- it preserves processor-authored stop strings instead of overwriting them
- it avoids mutating the global generation config from env-specific defaults
- it improves observability and setup-time feedback without introducing a heavier validation or scheduling subsystem
- it fixes the first-turn stop-string gap at the task-data boundary, where the information is already available and correctly scoped

## Validation

Passed locally:

- `ruff check` on all touched files
- `compileall` on all touched files
- focused smoke validation for env stop-string extraction, task-default injection, explicit-stop preservation, list-based env extraction, rollout-budget summary calculation, and warning behavior

Blocked in this environment:

- targeted pytest slices are blocked here by the repo's autouse Ray fixture hitting a macOS sandbox permission error
- direct import coverage for `grpo.py` is also limited in this local environment by missing optional Megatron packages

## User impact

This should make issue-like GDPO misconfigurations much easier to spot at startup, improve first-turn stopping behavior when env defaults are configured, and provide better runtime signals for diagnosing rollout-bound training runs.
