### PR TITLE
fix: loosen memory threshold for sft-llama3.1-70b-8n4g-tp2pp2-long-megatron

### DIFF
--- a/tests/test_suites/llm/sft-llama3.1-70b-8n4g-tp2pp2-long-megatron.sh
+++ b/tests/test_suites/llm/sft-llama3.1-70b-8n4g-tp2pp2-long-megatron.sh
@@ -38,7 +38,7 @@ if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | ma
     uv run tests/check_metrics.py $JSON_METRICS \
         'data["train/loss"]["1"] < 0.55' \
         'data["train/loss"]["300"] < 0.285' \
-        'max(data["ray/node.0.gpu.0.mem_gb"]) < 140' \
+        'max(data["ray/node.0.gpu.0.mem_gb"]) < 160' \
         'mean(data["timing/train/total_step_time"], 2) < 20'
 
     # Clean up checkpoint directory after successful run to save space.


### PR DESCRIPTION
`'max(data["ray/node.0.gpu.0.mem_gb"]) < 140'` works for some cluster, but on another cluster it always ~150.
loosen this check to make `sft-llama3.1-70b-8n4g-tp2pp2-long-megatron` pass on both clusters.