### PR TITLE
refactor: update TypedDict to BaseModel (MasterConfig & ClippedPGLossConfig)

### DIFF
--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -61,9 +61,12 @@ loss_fn:
   # Async GRPO requires importance sampling correction enabled
   # Set to true when async_grpo.enabled is true
   use_importance_sampling_correction: false
+  # "tis"          – clamp IS weights to max
+  # "icepop"       – zero out tokens with IS weight outside [min, max]
+  # "seq-mask-tis" – zero out sequences by geometric-mean IS ratio, non-truncated token IS correction
+  truncated_importance_sampling_type: null
   truncated_importance_sampling_ratio: null
   truncated_importance_sampling_ratio_min: null  # Lower bound for ICE-POP
-  truncated_importance_sampling_type: tis  # "tis" (clamp to max) or "icepop" (filter outside [min, max])
   sequence_level_importance_ratios: false
   token_level_loss: true
   force_on_policy_ratio: false  # Set to true to force ratio=1.0 (requires train_global_batch_size == num_prompts_per_step * num_generations_per_prompt)

--- a/examples/nemo_gym/run_grpo_nemo_gym.py
+++ b/examples/nemo_gym/run_grpo_nemo_gym.py
@@ -81,13 +81,13 @@ def collect_trajectories(
 ) -> None:
     """Run trajectory collection."""
     # common config/state items
-    colocated_inference = master_config["policy"]["generation"]["colocated"]["enabled"]
+    colocated_inference = master_config.policy["generation"]["colocated"]["enabled"]
     refit_policy_generation(policy, policy_generation, colocated_inference)
 
     log_filename = "trajectory_collection.jsonl"
 
     print("\n🔍 Running trajectory collection...", flush=True)
-    generation_config = master_config["policy"]["generation"]
+    generation_config = master_config.policy["generation"]
     for val_batch in val_dataloader:
         nemo_gym_rollout_result = run_async_nemo_gym_rollout(
             policy_generation=policy_generation,
@@ -136,24 +136,25 @@ def main() -> None:
         print(f"Overrides: {overrides}")
         config = parse_hydra_overrides(config, overrides)
 
-    config: MasterConfig = OmegaConf.to_container(config, resolve=True)
+    config = OmegaConf.to_container(config, resolve=True)
+    config = MasterConfig(**config)
     print("Applied CLI overrides")
 
     # Get the next experiment directory with incremented ID
-    config["logger"]["log_dir"] = get_next_experiment_dir(config["logger"]["log_dir"])
-    print(f"📊 Using log directory: {config['logger']['log_dir']}")
-    if config["checkpointing"]["enabled"]:
+    config.logger["log_dir"] = get_next_experiment_dir(config.logger["log_dir"])
+    print(f"📊 Using log directory: {config.logger['log_dir']}")
+    if config.checkpointing["enabled"]:
         print(
-            f"📊 Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}"
+            f"📊 Using checkpoint directory: {config.checkpointing['checkpoint_dir']}"
         )
 
     # setup tokenizer
-    tokenizer = get_tokenizer(config["policy"]["tokenizer"])
-    assert config["policy"]["generation"] is not None, (
+    tokenizer = get_tokenizer(config.policy["tokenizer"])
+    assert config.policy["generation"] is not None, (
         "A generation config is required for GRPO"
     )
-    config["policy"]["generation"] = configure_generation_config(
-        config["policy"]["generation"], tokenizer
+    config.policy["generation"] = configure_generation_config(
+        config.policy["generation"], tokenizer
     )
 
     # NeMo-Gym specific config setup.
@@ -165,11 +166,11 @@ def main() -> None:
     # NeMo-Gym environment needs to get dp_openai_server_base_urls from policy_generation, so we don't setup env here.
     print("\n▶ Setting up data...")
     train_dataset, val_dataset = setup_response_data(
-        tokenizer, config["data"], env_configs=None
+        tokenizer, config.data, env_configs=None
     )
 
     # Validation dataset config setup.
-    if config["grpo"]["max_val_samples"] is not None:
+    if config.grpo["max_val_samples"] is not None:
         raise ValueError(
             """A non-null `grpo.max_val_samples` parameter is not supported.
 
@@ -182,8 +183,8 @@ The validation set you pass in will directly be used for validation with no addi
         print(
             f"Setting `grpo.max_val_samples` and `grpo.val_batch_size` to the length of the validation dataset, which is {len(val_dataset)}"
         )
-        config["grpo"]["max_val_samples"] = len(val_dataset)
-        config["grpo"]["val_batch_size"] = config["grpo"]["max_val_samples"]
+        config.grpo["max_val_samples"] = len(val_dataset)
+        config.grpo["val_batch_size"] = config.grpo["max_val_samples"]
 
     # Print config
     print("Final config:")
@@ -205,12 +206,12 @@ The validation set you pass in will directly be used for validation with no addi
     ) = setup(config, tokenizer, train_dataset, val_dataset)
 
     is_trajectory_collection = (
-        config["env"]["nemo_gym"].pop("is_trajectory_collection", False) or False
+        config.env["nemo_gym"].pop("is_trajectory_collection", False) or False
     )
     nemo_gym_config = NemoGymConfig(
         model_name=policy_generation.cfg["model_name"],
         base_urls=policy_generation.dp_openai_server_base_urls,
-        initial_global_config_dict=config["env"]["nemo_gym"],
+        initial_global_config_dict=config.env["nemo_gym"],
     )
     nemo_gym = create_env(env_name="nemo_gym", env_config=nemo_gym_config)
     # Blocking wait for NeMo-Gym to spin up
@@ -232,7 +233,7 @@ The validation set you pass in will directly be used for validation with no addi
             master_config=master_config,
         )
     # Check if async mode is enabled
-    elif "async_grpo" in config["grpo"] and config["grpo"]["async_grpo"]["enabled"]:
+    elif "async_grpo" in config.grpo and config.grpo["async_grpo"]["enabled"]:
         # Async GRPO does not support dynamic sampling, reward scaling, or reward shaping (DAPO features)
         unsupported_features = [
             "use_dynamic_sampling",
@@ -241,22 +242,22 @@ The validation set you pass in will directly be used for validation with no addi
         ]
 
         for feature in unsupported_features:
-            if feature not in config["grpo"]:
+            if feature not in config.grpo:
                 continue
 
             if feature == "use_dynamic_sampling":
-                if config["grpo"][feature]:
+                if config.grpo[feature]:
                     raise NotImplementedError(
                         f"{feature} is not supported with async GRPO"
                     )
             else:
-                if config["grpo"][feature]["enabled"]:
+                if config.grpo[feature]["enabled"]:
                     raise NotImplementedError(
                         f"{feature} is not supported with async GRPO"
                     )
 
         # Async GRPO does not support multiple dataloaders
-        if config["data"]["use_multiple_dataloader"]:
+        if config.data["use_multiple_dataloader"]:
             raise NotImplementedError(
                 "use_multiple_dataloader is not supported with async GRPO"
             )
@@ -265,7 +266,7 @@ The validation set you pass in will directly be used for validation with no addi
 
         print("🚀 Running async GRPO training")
 
-        async_config = config["grpo"]["async_grpo"]
+        async_config = config.grpo["async_grpo"]
         # Run async GRPO training
         async_grpo_train(
             policy=policy,

--- a/examples/nemo_gym/run_grpo_nemo_gym.py
+++ b/examples/nemo_gym/run_grpo_nemo_gym.py
@@ -94,7 +94,7 @@ def collect_trajectories(
             input_batch=val_batch,
             tokenizer=tokenizer,
             task_to_env=val_task_to_env,
-            max_seq_len=master_config["policy"]["max_total_sequence_length"],
+            max_seq_len=master_config.policy["max_total_sequence_length"],
             generation_config=generation_config,
             max_rollout_turns=None,
             greedy=False,

--- a/examples/run_distillation.py
+++ b/examples/run_distillation.py
@@ -60,18 +60,20 @@ def main() -> None:
     if overrides:
         config = parse_hydra_overrides(config, overrides)
 
-    config: MasterConfig = OmegaConf.to_container(config, resolve=True)
+    config = OmegaConf.to_container(config, resolve=True)
+    config = MasterConfig(**config)
+    print("Applied CLI overrides")
 
     # Get the next experiment directory with incremented ID
-    config["logger"]["log_dir"] = get_next_experiment_dir(config["logger"]["log_dir"])
+    config.logger["log_dir"] = get_next_experiment_dir(config.logger["log_dir"])
 
     init_ray()
 
-    tokenizer = get_tokenizer(config["policy"]["tokenizer"])
+    tokenizer = get_tokenizer(config.policy["tokenizer"])
 
-    if config["policy"]["generation"] is not None:
-        config["policy"]["generation"] = configure_generation_config(
-            config["policy"]["generation"], tokenizer
+    if config.policy["generation"] is not None:
+        config.policy["generation"] = configure_generation_config(
+            config.policy["generation"], tokenizer
         )
     else:
         print("  ⚠️ No generation config found, this may cause issues")
@@ -82,7 +84,7 @@ def main() -> None:
         val_dataset,
         task_to_env,
         val_task_to_env,
-    ) = setup_response_data(tokenizer, config["data"], config["env"])
+    ) = setup_response_data(tokenizer, config.data, config.env)
 
     (
         student_policy,

--- a/examples/run_dpo.py
+++ b/examples/run_dpo.py
@@ -53,27 +53,28 @@ def main():
         print(f"Overrides: {overrides}")
         config = parse_hydra_overrides(config, overrides)
 
-    config: MasterConfig = OmegaConf.to_container(config, resolve=True)
+    config = OmegaConf.to_container(config, resolve=True)
+    config = MasterConfig(**config)
     print("Applied CLI overrides")
 
     # Print config
     print("Final config:")
     pprint.pprint(config)
 
-    config["logger"]["log_dir"] = get_next_experiment_dir(config["logger"]["log_dir"])
-    print(f"📊 Using log directory: {config['logger']['log_dir']}")
-    if config["checkpointing"]["enabled"]:
+    config.logger["log_dir"] = get_next_experiment_dir(config.logger["log_dir"])
+    print(f"📊 Using log directory: {config.logger['log_dir']}")
+    if config.checkpointing["enabled"]:
         print(
-            f"📊 Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}"
+            f"📊 Using checkpoint directory: {config.checkpointing['checkpoint_dir']}"
         )
 
     init_ray()
 
     # setup tokenizer
-    tokenizer = get_tokenizer(config["policy"]["tokenizer"])
+    tokenizer = get_tokenizer(config.policy["tokenizer"])
 
     # setup data
-    dataset, val_dataset = setup_preference_data(tokenizer, config["data"])
+    dataset, val_dataset = setup_preference_data(tokenizer, config.data)
 
     (
         policy,

--- a/examples/run_eval.py
+++ b/examples/run_eval.py
@@ -90,7 +90,8 @@ def main():
         print(f"Overrides: {override_conf}")
         config = OmegaConf.merge(config, override_conf)
 
-    config: MasterConfig = OmegaConf.to_container(config, resolve=True)
+    config = OmegaConf.to_container(config, resolve=True)
+    config = MasterConfig(**config)
     print("Applied CLI overrides")
 
     # Print config
@@ -101,7 +102,7 @@ def main():
     init_ray()
 
     # Setup tokenizer — get_tokenizer handles both text-only and multimodal
-    is_multimodal = _is_multimodal_dataset(config["data"]["dataset_name"])
+    is_multimodal = _is_multimodal_dataset(config.data["dataset_name"])
     tokenizer = get_tokenizer(config["tokenizer"], get_processor=is_multimodal)
     config["generation"] = configure_generation_config(
         config["generation"], tokenizer, is_eval=True
@@ -112,7 +113,7 @@ def main():
         dataset,
         env,
         tokenizer,
-    ) = setup_data(tokenizer, config["data"], config["env"])
+    ) = setup_data(tokenizer, config.data, config.env)
 
     # Setup
     (

--- a/examples/run_eval.py
+++ b/examples/run_eval.py
@@ -103,9 +103,9 @@ def main():
 
     # Setup tokenizer — get_tokenizer handles both text-only and multimodal
     is_multimodal = _is_multimodal_dataset(config.data["dataset_name"])
-    tokenizer = get_tokenizer(config["tokenizer"], get_processor=is_multimodal)
-    config["generation"] = configure_generation_config(
-        config["generation"], tokenizer, is_eval=True
+    tokenizer = get_tokenizer(config.tokenizer, get_processor=is_multimodal)
+    config.generation = configure_generation_config(
+        config.generation, tokenizer, is_eval=True
     )
 
     # Setup data

--- a/examples/run_grpo.py
+++ b/examples/run_grpo.py
@@ -62,7 +62,8 @@ def main() -> None:
         print(f"Overrides: {overrides}")
         config = parse_hydra_overrides(config, overrides)
 
-    config: MasterConfig = OmegaConf.to_container(config, resolve=True)
+    config = OmegaConf.to_container(config, resolve=True)
+    config = MasterConfig(**config)
     print("Applied CLI overrides")
 
     # Print config
@@ -70,23 +71,23 @@ def main() -> None:
     pprint.pprint(config)
 
     # Get the next experiment directory with incremented ID
-    config["logger"]["log_dir"] = get_next_experiment_dir(config["logger"]["log_dir"])
-    print(f"📊 Using log directory: {config['logger']['log_dir']}")
-    if config["checkpointing"]["enabled"]:
+    config.logger["log_dir"] = get_next_experiment_dir(config.logger["log_dir"])
+    print(f"📊 Using log directory: {config.logger['log_dir']}")
+    if config.checkpointing["enabled"]:
         print(
-            f"📊 Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}"
+            f"📊 Using checkpoint directory: {config.checkpointing['checkpoint_dir']}"
         )
 
     init_ray()
 
     # setup tokenizer
-    tokenizer = get_tokenizer(config["policy"]["tokenizer"])
-    assert config["policy"]["generation"] is not None, (
+    tokenizer = get_tokenizer(config.policy["tokenizer"])
+    assert config.policy["generation"] is not None, (
         "A generation config is required for GRPO"
     )
-    has_refit_draft_weights = bool(config["policy"]["draft"]["enabled"])
-    config["policy"]["generation"] = configure_generation_config(
-        config["policy"]["generation"],
+    has_refit_draft_weights = bool(config.policy["draft"]["enabled"])
+    config.policy["generation"] = configure_generation_config(
+        config.policy["generation"],
         tokenizer,
         has_refit_draft_weights=has_refit_draft_weights,
     )
@@ -97,7 +98,7 @@ def main() -> None:
         val_dataset,
         task_to_env,
         val_task_to_env,
-    ) = setup_response_data(tokenizer, config["data"], config["env"])
+    ) = setup_response_data(tokenizer, config.data, config.env)
 
     (
         policy,
@@ -113,7 +114,7 @@ def main() -> None:
     ) = setup(config, tokenizer, dataset, val_dataset)
 
     # Check if async mode is enabled
-    if "async_grpo" in config["grpo"] and config["grpo"]["async_grpo"]["enabled"]:
+    if "async_grpo" in config.grpo and config.grpo["async_grpo"]["enabled"]:
         # Async GRPO does not support dynamic sampling, reward scaling, or reward shaping (DAPO features)
         unsupported_features = [
             "use_dynamic_sampling",
@@ -122,22 +123,22 @@ def main() -> None:
         ]
 
         for feature in unsupported_features:
-            if feature not in config["grpo"]:
+            if feature not in config.grpo:
                 continue
 
             if feature == "use_dynamic_sampling":
-                if config["grpo"][feature]:
+                if config.grpo[feature]:
                     raise NotImplementedError(
                         f"{feature} is not supported with async GRPO"
                     )
             else:
-                if config["grpo"][feature]["enabled"]:
+                if config.grpo[feature]["enabled"]:
                     raise NotImplementedError(
                         f"{feature} is not supported with async GRPO"
                     )
 
         # Async GRPO does not support multiple dataloaders
-        if config["data"]["use_multiple_dataloader"]:
+        if config.data["use_multiple_dataloader"]:
             raise NotImplementedError(
                 "use_multiple_dataloader is not supported with async GRPO"
             )
@@ -146,7 +147,7 @@ def main() -> None:
 
         print("🚀 Running async GRPO training")
 
-        async_config = config["grpo"]["async_grpo"]
+        async_config = config.grpo["async_grpo"]
         # Run async GRPO training
         async_grpo_train(
             policy=policy,

--- a/examples/run_grpo_sliding_puzzle.py
+++ b/examples/run_grpo_sliding_puzzle.py
@@ -209,7 +209,8 @@ def main():
         print(f"Overrides: {overrides}")
         config = parse_hydra_overrides(config, overrides)
 
-    config: MasterConfig = OmegaConf.to_container(config, resolve=True)
+    config = OmegaConf.to_container(config, resolve=True)
+    config = MasterConfig(**config)
     print("Applied CLI overrides")
 
     # Print config
@@ -217,36 +218,36 @@ def main():
     pprint.pprint(config)
 
     # Get the next experiment directory with incremented ID
-    config["logger"]["log_dir"] = get_next_experiment_dir(config["logger"]["log_dir"])
-    print(f"📊 Using log directory: {config['logger']['log_dir']}")
-    if config["checkpointing"]["enabled"]:
+    config.logger["log_dir"] = get_next_experiment_dir(config.logger["log_dir"])
+    print(f"📊 Using log directory: {config.logger['log_dir']}")
+    if config.checkpointing["enabled"]:
         print(
-            f"📊 Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}"
+            f"📊 Using checkpoint directory: {config.checkpointing['checkpoint_dir']}"
         )
 
     init_ray()
 
-    set_seed(config["grpo"]["seed"])
+    set_seed(config.grpo["seed"])
 
     # setup tokenizer
-    tokenizer = get_tokenizer(config["policy"]["tokenizer"])
-    config["policy"]["generation"] = configure_generation_config(
-        config["policy"]["generation"], tokenizer
+    tokenizer = get_tokenizer(config.policy["tokenizer"])
+    config.policy["generation"] = configure_generation_config(
+        config.policy["generation"], tokenizer
     )
 
     # setup data & env map
     ds_length = (
-        config["grpo"]["num_prompts_per_step"]
-        * config["grpo"]["num_generations_per_prompt"]
-        * config["grpo"]["max_num_steps"]
+        config.grpo["num_prompts_per_step"]
+        * config.grpo["num_generations_per_prompt"]
+        * config.grpo["max_num_steps"]
     )
     dataset, val_dataset, task_to_env, val_task_to_env = setup_puzzle_data(
         tokenizer=tokenizer,
-        env_cfg=config["env"],
+        env_cfg=config.env,
         task_name="sliding_puzzle_game",
         length=ds_length,
-        val_length=config["grpo"]["max_val_samples"],
-        add_system_prompt=config["data"]["add_system_prompt"],
+        val_length=config.grpo["max_val_samples"],
+        add_system_prompt=config.data["add_system_prompt"],
     )
 
     (

--- a/examples/run_rm.py
+++ b/examples/run_rm.py
@@ -54,29 +54,30 @@ def main():
         print(f"Overrides: {overrides}")
         config = parse_hydra_overrides(config, overrides)
 
-    config: MasterConfig = OmegaConf.to_container(config, resolve=True)
+    config = OmegaConf.to_container(config, resolve=True)
+    config = MasterConfig(**config)
     print("Applied CLI overrides")
 
     # Print config
     print("Final config:")
     pprint.pprint(config)
 
-    assert config["policy"]["reward_model_cfg"]["enabled"]
+    assert config.policy["reward_model_cfg"]["enabled"]
 
-    config["logger"]["log_dir"] = get_next_experiment_dir(config["logger"]["log_dir"])
-    print(f"📊 Using log directory: {config['logger']['log_dir']}")
-    if config["checkpointing"]["enabled"]:
+    config.logger["log_dir"] = get_next_experiment_dir(config.logger["log_dir"])
+    print(f"📊 Using log directory: {config.logger['log_dir']}")
+    if config.checkpointing["enabled"]:
         print(
-            f"📊 Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}"
+            f"📊 Using checkpoint directory: {config.checkpointing['checkpoint_dir']}"
         )
 
     init_ray()
 
     # setup tokenizer
-    tokenizer = get_tokenizer(config["policy"]["tokenizer"])
+    tokenizer = get_tokenizer(config.policy["tokenizer"])
 
     # setup data
-    dataset, val_dataset = setup_preference_data(tokenizer, config["data"])
+    dataset, val_dataset = setup_preference_data(tokenizer, config.data)
 
     (
         policy,

--- a/examples/run_sft.py
+++ b/examples/run_sft.py
@@ -174,27 +174,28 @@ def main(is_vlm: bool = False):
         print(f"Overrides: {overrides}")
         config = parse_hydra_overrides(config, overrides)
 
-    config: MasterConfig = OmegaConf.to_container(config, resolve=True)
+    config = OmegaConf.to_container(config, resolve=True)
+    config = MasterConfig(**config)
     print("Applied CLI overrides")
 
     # Print config
     print("Final config:")
     pprint.pprint(config)
 
-    config["logger"]["log_dir"] = get_next_experiment_dir(config["logger"]["log_dir"])
-    print(f"📊 Using log directory: {config['logger']['log_dir']}")
-    if config["checkpointing"]["enabled"]:
+    config.logger["log_dir"] = get_next_experiment_dir(config.logger["log_dir"])
+    print(f"📊 Using log directory: {config.logger['log_dir']}")
+    if config.checkpointing["enabled"]:
         print(
-            f"📊 Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}"
+            f"📊 Using checkpoint directory: {config.checkpointing['checkpoint_dir']}"
         )
 
     init_ray()
 
     # setup tokenizer (or processor)
-    tokenizer = get_tokenizer(config["policy"]["tokenizer"], get_processor=is_vlm)
+    tokenizer = get_tokenizer(config.policy["tokenizer"], get_processor=is_vlm)
 
     # setup data
-    dataset, val_dataset = setup_data(tokenizer, config["data"])
+    dataset, val_dataset = setup_data(tokenizer, config.data)
 
     (
         policy,

--- a/examples/run_vlm_grpo.py
+++ b/examples/run_vlm_grpo.py
@@ -60,7 +60,8 @@ def main() -> None:
         print(f"Overrides: {overrides}")
         config = parse_hydra_overrides(config, overrides)
 
-    config: MasterConfig = OmegaConf.to_container(config, resolve=True)
+    config = OmegaConf.to_container(config, resolve=True)
+    config = MasterConfig(**config)
     print("Applied CLI overrides")
 
     # Print config
@@ -68,28 +69,28 @@ def main() -> None:
     pprint.pprint(config)
 
     # Get the next experiment directory with incremented ID
-    config["logger"]["log_dir"] = get_next_experiment_dir(config["logger"]["log_dir"])
-    print(f"📊 Using log directory: {config['logger']['log_dir']}")
-    if config["checkpointing"]["enabled"]:
+    config.logger["log_dir"] = get_next_experiment_dir(config.logger["log_dir"])
+    print(f"📊 Using log directory: {config.logger['log_dir']}")
+    if config.checkpointing["enabled"]:
         print(
-            f"📊 Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}"
+            f"📊 Using checkpoint directory: {config.checkpointing['checkpoint_dir']}"
         )
 
     init_ray()
 
     # init processor
-    processor = get_tokenizer(config["policy"]["tokenizer"], get_processor=True)
+    processor = get_tokenizer(config.policy["tokenizer"], get_processor=True)
     tokenizer = processor.tokenizer
 
-    assert config["policy"]["generation"] is not None, (
+    assert config.policy["generation"] is not None, (
         "A generation config is required for GRPO"
     )
-    config["policy"]["generation"] = configure_generation_config(
-        config["policy"]["generation"], processor.tokenizer
+    config.policy["generation"] = configure_generation_config(
+        config.policy["generation"], processor.tokenizer
     )
-    if "vllm_cfg" in config["policy"]["generation"]:
+    if "vllm_cfg" in config.policy["generation"]:
         assert (
-            config["policy"]["generation"]["vllm_cfg"]["skip_tokenizer_init"] == False
+            config.policy["generation"]["vllm_cfg"]["skip_tokenizer_init"] == False
         ), (
             "VLMs require tokenizer to be initialized before generation, so skip_tokenizer_init must be set to False."
         )
@@ -101,7 +102,7 @@ def main() -> None:
         val_dataset,
         task_to_env,
         val_task_to_env,
-    ) = setup_response_data(processor, config["data"], config["env"], is_vlm=True)
+    ) = setup_response_data(processor, config.data, config.env, is_vlm=True)
 
     (
         policy,

--- a/nemo_rl/algorithms/advantage_estimator.py
+++ b/nemo_rl/algorithms/advantage_estimator.py
@@ -25,6 +25,7 @@ Reference papers:
 
 import torch
 
+from nemo_rl.algorithms.loss import ClippedPGLossConfig
 from nemo_rl.algorithms.utils import (
     calculate_baseline_and_std_per_prompt,
     calculate_kl,
@@ -155,11 +156,11 @@ class ReinforcePlusPlusAdvantageEstimator:
         use_kl_in_reward: If True, add KL penalty to reward instead of loss.
     """
 
-    def __init__(self, estimator_config: dict, loss_config: dict):
+    def __init__(self, estimator_config: dict, loss_config: ClippedPGLossConfig):
         self.minus_baseline = estimator_config["minus_baseline"]
-        self.use_kl_in_reward = loss_config["use_kl_in_reward"]
-        self.kl_coef = loss_config["reference_policy_kl_penalty"]
-        self.kl_type = loss_config["reference_policy_kl_type"]
+        self.use_kl_in_reward = loss_config.use_kl_in_reward
+        self.kl_coef = loss_config.reference_policy_kl_penalty
+        self.kl_type = loss_config.reference_policy_kl_type
 
     def compute_advantage(
         self,

--- a/nemo_rl/algorithms/advantage_estimator.py
+++ b/nemo_rl/algorithms/advantage_estimator.py
@@ -39,7 +39,7 @@ class GRPOAdvantageEstimator:
     Note: GRPO computes advantages over all responses for each prompt.
     """
 
-    def __init__(self, estimator_config: dict, loss_config: dict):
+    def __init__(self, estimator_config: dict, loss_config: ClippedPGLossConfig):
         self.use_leave_one_out_baseline = estimator_config["use_leave_one_out_baseline"]
         self.normalize_rewards = estimator_config["normalize_rewards"]
 
@@ -81,7 +81,7 @@ class GDPOAdvantageEstimator:
     Note: GDPO computes advantages for each reward separately over all responses for each prompt.
     """
 
-    def __init__(self, estimator_config: dict, loss_config: dict):
+    def __init__(self, estimator_config: dict, loss_config: ClippedPGLossConfig):
         self.use_leave_one_out_baseline = estimator_config["use_leave_one_out_baseline"]
         self.normalize_rewards = estimator_config["normalize_rewards"]
 

--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -104,7 +104,7 @@ class AsyncTrajectoryCollector:
             [11, 12, 13, 14]  # Meaning this generation server can create trajectories for training step 11, 12, 13, 14
         """
         # Read async config strictly from grpo.async_grpo
-        async_cfg = self.master_config.get("grpo", {}).get("async_grpo", {})
+        async_cfg = self.master_config.grpo.get("async_grpo", {})
         max_trajectory_age = async_cfg["max_trajectory_age_steps"]
         if generation_weight_version == self.initial_weight_version:
             return [
@@ -207,9 +207,7 @@ class AsyncTrajectoryCollector:
                 if self._should_pause_for_generation_limits() and self.running:
                     # Only log warning once per weight version
                     if self._last_limit_warning_version != self.current_weight_version:
-                        async_cfg = self.master_config.get("grpo", {}).get(
-                            "async_grpo", {}
-                        )
+                        async_cfg = self.master_config.grpo.get("async_grpo", {})
                         max_trajectory_age = async_cfg["max_trajectory_age_steps"]
                         target_weights = [
                             self.current_weight_version + i
@@ -340,16 +338,10 @@ class AsyncTrajectoryCollector:
         print("⏸️ New generation starts paused")
 
         # Check if we're using vLLM async engine
-        vllm_cfg = (
-            self.master_config.get("policy", {})
-            .get("generation", {})
-            .get("vllm_cfg", {})
-        )
+        vllm_cfg = self.master_config.policy.get("generation", {}).get("vllm_cfg", {})
         is_async_engine = vllm_cfg.get("async_engine", False)
-        in_flight_weight_updates = (
-            self.master_config.get("grpo", {})
-            .get("async_grpo", {})
-            .get("in_flight_weight_updates", False)
+        in_flight_weight_updates = self.master_config.grpo.get("async_grpo", {}).get(
+            "in_flight_weight_updates", False
         )
 
         if is_async_engine and in_flight_weight_updates:
@@ -379,7 +371,7 @@ class AsyncTrajectoryCollector:
         # Invalidate&recompute vLLM caches after the in-flight weight updates if
         # recompute_kv_cache_after_weight_updates is True (AREAL-style implementation).
         # Otherwise, keep using the stale KV caches (Magistral-style implementation).
-        async_cfg = self.master_config.get("grpo", {}).get("async_grpo", {})
+        async_cfg = self.master_config.grpo.get("async_grpo", {})
         if async_cfg.get("in_flight_weight_updates", False) and async_cfg.get(
             "recompute_kv_cache_after_weight_updates", False
         ):
@@ -448,7 +440,6 @@ class AsyncTrajectoryCollector:
             # Check if we should use nemo_gym (similar to synchronous GRPO)
             if _should_use_nemo_gym(self.master_config):
                 generation_config = self.master_config.policy["generation"]
-                env_cfg = self.master_config.get("env") or {}
                 nemo_gym_rollout_result = run_async_nemo_gym_rollout(
                     policy_generation=self.policy_generation,
                     input_batch=repeated_batch,

--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -78,8 +78,8 @@ class AsyncTrajectoryCollector:
         # Limit in-flight generator requests to num_prompts_per_step * max_trajectory_age_steps
         # This value limits the parallelism of the generation requests.
         max_inflight = (
-            int(self.master_config["grpo"]["num_prompts_per_step"])
-            * int(self.master_config["grpo"]["async_grpo"]["max_trajectory_age_steps"])
+            int(self.master_config.grpo["num_prompts_per_step"])
+            * int(self.master_config.grpo["async_grpo"]["max_trajectory_age_steps"])
         ) or 1
         self._inflight_sema = _threading.Semaphore(max_inflight)
 
@@ -249,7 +249,7 @@ class AsyncTrajectoryCollector:
         """Process a single batch and generate for one target weight."""
         try:
             generation_weight_version = self.current_weight_version
-            num_generations = self.master_config["grpo"]["num_generations_per_prompt"]
+            num_generations = self.master_config.grpo["num_generations_per_prompt"]
             num_prompts = batch.size
 
             # Get the next target weight that needs generation
@@ -447,7 +447,7 @@ class AsyncTrajectoryCollector:
             # Async engine supports concurrent generation; avoid locking
             # Check if we should use nemo_gym (similar to synchronous GRPO)
             if _should_use_nemo_gym(self.master_config):
-                generation_config = self.master_config["policy"]["generation"]
+                generation_config = self.master_config.policy["generation"]
                 env_cfg = self.master_config.get("env") or {}
                 nemo_gym_rollout_result = run_async_nemo_gym_rollout(
                     policy_generation=self.policy_generation,
@@ -469,10 +469,8 @@ class AsyncTrajectoryCollector:
                     input_batch=repeated_batch,
                     tokenizer=self.tokenizer,
                     task_to_env=self.task_to_env,
-                    max_seq_len=self.master_config["policy"][
-                        "max_total_sequence_length"
-                    ],
-                    max_rollout_turns=self.master_config["grpo"]["max_rollout_turns"],
+                    max_seq_len=self.master_config.policy["max_total_sequence_length"],
+                    max_rollout_turns=self.master_config.grpo["max_rollout_turns"],
                     greedy=False,
                 )
 

--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -445,9 +445,7 @@ class AsyncTrajectoryCollector:
                     input_batch=repeated_batch,
                     tokenizer=self.tokenizer,
                     task_to_env=self.task_to_env,
-                    max_seq_len=self.master_config["policy"][
-                        "max_total_sequence_length"
-                    ],
+                    max_seq_len=self.master_config.policy["max_total_sequence_length"],
                     generation_config=generation_config,
                     max_rollout_turns=None,
                     greedy=False,

--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -227,7 +227,7 @@ def setup(
     #         Logger
     # ==========================
     logger = Logger(logger_config)
-    logger.log_hyperparams(master_config)
+    logger.log_hyperparams(master_config.model_dump())
 
     # ==========================
     #      Checkpointing

--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -18,6 +18,7 @@ from typing import Any, NotRequired, Optional, TypedDict, TypeVar, cast
 import numpy as np
 import ray
 import torch
+from pydantic import BaseModel
 from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import AutoConfig, AutoTokenizer
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
@@ -109,7 +110,7 @@ def _default_distillation_save_state() -> DistillationSaveState:
     }
 
 
-class MasterConfig(TypedDict):
+class MasterConfig(BaseModel, extra="allow"):
     """Main configuration structure."""
 
     policy: PolicyConfig  # Student model configuration
@@ -179,19 +180,19 @@ def setup(
         loss_fn, logger, checkpointer, distillation_save_state, master_config
     """
     # Extract configuration
-    policy_config = master_config["policy"]
-    checkpointing_pretrained = master_config.get("checkpointing", {}).get(
-        "pretrained_checkpoint"
-    )
+    policy_config = master_config.policy
+    generation_config = policy_config["generation"]
+    teacher_config = master_config.teacher
+    loss_config = master_config.loss_fn
+    data_config = master_config.data
+    distillation_config = master_config.distillation
+    logger_config = master_config.logger
+    cluster_config = master_config.cluster
+    checkpointing_config = master_config.checkpointing
+
+    checkpointing_pretrained = checkpointing_config.get("pretrained_checkpoint")
     if checkpointing_pretrained is not None:
         policy_config["pretrained_checkpoint"] = checkpointing_pretrained
-    teacher_config = master_config["teacher"]
-    generation_config = master_config["policy"]["generation"]
-    loss_config = master_config["loss_fn"]
-    distillation_config = master_config["distillation"]
-    data_config = master_config["data"]
-    logger_config = master_config["logger"]
-    cluster_config = master_config["cluster"]
 
     assert generation_config is not None, (
         "A generation config in the PolicyConfig is required for distillation"
@@ -231,7 +232,7 @@ def setup(
     # ==========================
     #      Checkpointing
     # ==========================
-    checkpointer = CheckpointManager(master_config["checkpointing"])
+    checkpointer = CheckpointManager(checkpointing_config)
     last_checkpoint_path = checkpointer.get_latest_checkpoint_path()
     distillation_save_state: Optional[DistillationSaveState] = cast(
         Optional[DistillationSaveState],
@@ -520,7 +521,7 @@ def distillation_train(
     """Run Distillation training algorithm."""
     timer = Timer()
     timeout = TimeoutChecker(
-        timeout=master_config["checkpointing"]["checkpoint_must_save_by"],
+        timeout=master_config.checkpointing["checkpoint_must_save_by"],
         fit_last_save_time=True,
     )
     timeout.start_iterations()
@@ -543,14 +544,14 @@ def distillation_train(
     ]  # total number of steps across all epochs
     consumed_samples = distillation_save_state["consumed_samples"]
     total_valid_tokens = distillation_save_state["total_valid_tokens"]
-    val_period = master_config["distillation"]["val_period"]
-    val_at_start = master_config["distillation"]["val_at_start"]
-    val_at_end = master_config["distillation"]["val_at_end"]
-    colocated_inference = master_config["policy"]["generation"]["colocated"]["enabled"]
-    max_epochs = master_config["distillation"][
+    val_period = master_config.distillation["val_period"]
+    val_at_start = master_config.distillation["val_at_start"]
+    val_at_end = master_config.distillation["val_at_end"]
+    colocated_inference = master_config.policy["generation"]["colocated"]["enabled"]
+    max_epochs = master_config.distillation[
         "max_num_epochs"
     ]  # max number of epochs to train for
-    max_steps = master_config["distillation"][
+    max_steps = master_config.distillation[
         "max_num_steps"
     ]  # max number of steps to train for
 
@@ -602,7 +603,7 @@ def distillation_train(
                     # Repeat batch items
                     repeated_batch: BatchedDataDict[DatumSpec] = (
                         batch.repeat_interleave(
-                            master_config["distillation"]["num_generations_per_prompt"]
+                            master_config.distillation["num_generations_per_prompt"]
                         )
                     )
 
@@ -634,10 +635,10 @@ def distillation_train(
                             input_batch=repeated_batch,
                             tokenizer=tokenizer,
                             task_to_env=task_to_env,
-                            max_seq_len=master_config["policy"][
+                            max_seq_len=master_config.policy[
                                 "max_total_sequence_length"
                             ],
-                            max_rollout_turns=master_config["distillation"][
+                            max_rollout_turns=master_config.distillation[
                                 "max_rollout_turns"
                             ],
                             greedy=False,
@@ -648,10 +649,10 @@ def distillation_train(
                             input_batch=repeated_batch,
                             tokenizer=tokenizer,
                             task_to_env=task_to_env,
-                            max_seq_len=master_config["policy"][
+                            max_seq_len=master_config.policy[
                                 "max_total_sequence_length"
                             ],
-                            max_rollout_turns=master_config["distillation"][
+                            max_rollout_turns=master_config.distillation[
                                 "max_rollout_turns"
                             ],
                             greedy=False,
@@ -675,7 +676,7 @@ def distillation_train(
                     flat_messages, input_lengths = batched_message_log_to_flat_message(
                         repeated_batch["message_log"],
                         pad_value_dict={"token_ids": tokenizer.pad_token_id},
-                        make_sequence_length_divisible_by=master_config["policy"][
+                        make_sequence_length_divisible_by=master_config.policy[
                             "make_sequence_length_divisible_by"
                         ],
                     )
@@ -703,7 +704,7 @@ def distillation_train(
                 with timer.time("teacher_logprob_inference"):
                     teacher_topk = teacher_policy.get_topk_logits(
                         train_data,
-                        k=master_config["distillation"]["topk_logits_k"],
+                        k=master_config.distillation["topk_logits_k"],
                         timer=timer,
                     )
                     train_data["teacher_topk_logits"] = teacher_topk["topk_logits"]
@@ -777,21 +778,19 @@ def distillation_train(
                 total_valid_tokens += metrics["global_valid_toks"]
 
                 ## Checkpointing
-                consumed_samples += master_config["distillation"][
-                    "num_prompts_per_step"
-                ]
+                consumed_samples += master_config.distillation["num_prompts_per_step"]
                 timeout.mark_iteration()
 
                 should_save_by_step = (
                     is_last_step
-                    or (total_steps + 1) % master_config["checkpointing"]["save_period"]
+                    or (total_steps + 1) % master_config.checkpointing["save_period"]
                     == 0
                 )
                 # +1 because total_steps is 0-indexed
                 # Check if timeout-based checkpointing is enabled in config.
                 should_save_by_timeout = timeout.check_save()
 
-                if master_config["checkpointing"]["enabled"] and (
+                if master_config.checkpointing["enabled"] and (
                     should_save_by_step or should_save_by_timeout
                 ):
                     student_policy.prepare_for_training()
@@ -806,7 +805,7 @@ def distillation_train(
                         del distillation_save_state["val_reward"]
                     distillation_save_state["consumed_samples"] = consumed_samples
 
-                    full_metric_name = master_config["checkpointing"]["metric_name"]
+                    full_metric_name = master_config.checkpointing["metric_name"]
                     if full_metric_name is not None:
                         assert full_metric_name.startswith(
                             "train:"
@@ -855,7 +854,7 @@ def distillation_train(
                             tokenizer_path=os.path.join(
                                 checkpoint_path, "policy", "tokenizer"
                             ),
-                            checkpointing_cfg=master_config["checkpointing"],
+                            checkpointing_cfg=master_config.checkpointing,
                         )
                         torch.save(
                             dataloader.state_dict(),
@@ -905,8 +904,8 @@ def distillation_train(
             total_time = timing_metrics.get("total_step_time", 0)
 
             total_num_gpus = (
-                master_config["cluster"]["num_nodes"]
-                * master_config["cluster"]["gpus_per_node"]
+                master_config.cluster["num_nodes"]
+                * master_config.cluster["gpus_per_node"]
             )
             metrics.update(
                 {
@@ -979,10 +978,10 @@ def validate(
         all_message_logs = []  # Collect all message logs
 
         max_batches = (
-            master_config["distillation"]["max_val_samples"]
-            + master_config["distillation"]["val_batch_size"]
+            master_config.distillation["max_val_samples"]
+            + master_config.distillation["val_batch_size"]
             - 1
-        ) // master_config["distillation"]["val_batch_size"]
+        ) // master_config.distillation["val_batch_size"]
         for batch_idx, val_batch in enumerate(val_dataloader):
             if batch_idx >= max_batches:
                 break
@@ -995,10 +994,8 @@ def validate(
                     val_batch,
                     tokenizer,
                     val_task_to_env,
-                    max_seq_len=master_config["policy"]["max_total_sequence_length"],
-                    max_rollout_turns=master_config["distillation"][
-                        "max_rollout_turns"
-                    ],
+                    max_seq_len=master_config.policy["max_total_sequence_length"],
+                    max_rollout_turns=master_config.distillation["max_rollout_turns"],
                     greedy=False,
                 )
             else:
@@ -1007,10 +1004,8 @@ def validate(
                     val_batch,
                     tokenizer,
                     val_task_to_env,
-                    max_seq_len=master_config["policy"]["max_total_sequence_length"],
-                    max_rollout_turns=master_config["distillation"][
-                        "max_rollout_turns"
-                    ],
+                    max_seq_len=master_config.policy["max_total_sequence_length"],
+                    max_rollout_turns=master_config.distillation["max_rollout_turns"],
                     greedy=False,
                 )
             rewards = val_batch["total_reward"]
@@ -1047,7 +1042,7 @@ def validate(
                 all_message_logs,
                 total_rewards,
                 num_samples=min(
-                    master_config["logger"]["num_val_samples_to_print"],
+                    master_config.logger["num_val_samples_to_print"],
                     len(all_message_logs),
                 ),
                 step=step,

--- a/nemo_rl/algorithms/dpo.py
+++ b/nemo_rl/algorithms/dpo.py
@@ -19,6 +19,7 @@ from typing import Optional, TypedDict, cast
 
 import numpy as np
 import torch
+from pydantic import BaseModel
 from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import AutoTokenizer
 
@@ -79,7 +80,7 @@ class DPOConfig(TypedDict):
     sft_loss_weight: float
 
 
-class MasterConfig(TypedDict):
+class MasterConfig(BaseModel, extra="allow"):
     policy: PolicyConfig
     data: DataConfig
     dpo: DPOConfig
@@ -124,23 +125,31 @@ def setup(
     Returns:
         Tuple of policy, cluster, dataloader, tokenizer, loss_fn, math_env, master_config, logger
     """
+    set_seed(master_config.dpo["seed"])
+
+    # Extract individual configs for easier access
+    policy_config = master_config.policy
+    data_config = master_config.data
+    dpo_config = master_config.dpo
+    logger_config = master_config.logger
+    cluster_config = master_config.cluster
+    checkpointing_config = master_config.checkpointing
+
+    checkpointing_pretrained = checkpointing_config.get("pretrained_checkpoint")
+    if checkpointing_pretrained is not None:
+        policy_config["pretrained_checkpoint"] = checkpointing_pretrained
+
     # Make sure we are not using dynamic batching or sequence packing.
     # Anything that changes the order of data within a batch is currently incompatible with DPO.
-    assert not master_config["policy"]["dynamic_batching"]["enabled"], (
+    assert not policy_config["dynamic_batching"]["enabled"], (
         "Dynamic batching is currently not supported with DPO. "
         "See https://github.com/NVIDIA-NeMo/RL/issues/719"
     )
-    assert not master_config["policy"]["sequence_packing"]["enabled"], (
+    assert not policy_config["sequence_packing"]["enabled"], (
         "Sequence packing is currently not supported with DPO. "
         "See https://github.com/NVIDIA-NeMo/RL/issues/719"
     )
 
-    policy_config = master_config["policy"]
-    checkpointing_pretrained = master_config.get("checkpointing", {}).get(
-        "pretrained_checkpoint"
-    )
-    if checkpointing_pretrained is not None:
-        policy_config["pretrained_checkpoint"] = checkpointing_pretrained
     # Add a guardrail for linear CE fusion loss: if sequence packing is enabled for DPO in the future,
     # we need to validate the fusion path with cu_seqlens-based logprob aggregation first and then remove this guardrail.
     if policy_config["sequence_packing"]["enabled"]:
@@ -152,14 +161,6 @@ def setup(
             "The fusion path has not been validated with cu_seqlens-based logprob aggregation."
         )
 
-    set_seed(master_config["dpo"]["seed"])
-
-    # Extract individual configs for easier access
-    data_config = master_config["data"]
-    logger_config = master_config["logger"]
-    cluster_config = master_config["cluster"]
-    dpo_config = master_config["dpo"]
-
     # ==========================
     #         Logger
     # ==========================
@@ -169,7 +170,7 @@ def setup(
     # ==========================
     #      Checkpointing
     # ==========================
-    checkpointer = CheckpointManager(master_config["checkpointing"])
+    checkpointer = CheckpointManager(checkpointing_config)
     last_checkpoint_path = checkpointer.get_latest_checkpoint_path()
     dpo_save_state: Optional[DPOSaveState] = cast(
         Optional[DPOSaveState], checkpointer.load_training_info(last_checkpoint_path)
@@ -266,7 +267,7 @@ def setup(
     policy.print_node_ip_and_gpu_id()
 
     loss_fn = DPOLossFn(
-        master_config["dpo"],
+        master_config.dpo,
         use_linear_ce_fusion=policy_config["megatron_cfg"]["enabled"]
         and policy_config["megatron_cfg"]["use_linear_ce_fusion_loss"],
     )
@@ -296,9 +297,9 @@ def add_ref_logprobs_to_data(dataloader, policy, master_config, is_val=False):
             batch = next(dataloader_iter)
 
             micro_batch_size = (
-                master_config["dpo"]["val_micro_batch_size"] * 2
+                master_config.dpo["val_micro_batch_size"] * 2
                 if is_val
-                else master_config["policy"]["train_micro_batch_size"] * 2
+                else master_config.policy["train_micro_batch_size"] * 2
             )
 
             # when running validation with drop_last=False, we might end up with a partial batch.
@@ -389,7 +390,7 @@ def validate_one_dataset(
 ):
     """Run validation on one validation dataset."""
     if val_dataloader is None:
-        assert val_dataloader is not None or master_config["dpo"]["val_period"] == 0, (
+        assert val_dataloader is not None or master_config.dpo["val_period"] == 0, (
             "val_dataloader is None, so dpo.val_period must be 0"
         )
         print("  ⚠️ No validation dataloader provided, skipping validation")
@@ -520,7 +521,7 @@ def dpo_train(
     # Run dpo training
     timer = Timer()
     timeout = TimeoutChecker(
-        timeout=master_config["checkpointing"]["checkpoint_must_save_by"],
+        timeout=master_config.checkpointing["checkpoint_must_save_by"],
         fit_last_save_time=True,
     )
     timeout.start_iterations()
@@ -539,7 +540,7 @@ def dpo_train(
             "total_valid_tokens", 0
         )  # Default to 0 for backward compatibility with older checkpoints
 
-    dpo_config = master_config["dpo"]
+    dpo_config = master_config.dpo
     # Validation configuration
     val_period = dpo_config["val_period"]
     val_at_start = dpo_config["val_at_start"]
@@ -570,13 +571,13 @@ def dpo_train(
 
     while (
         current_epoch < max_num_epochs
-        and total_steps < master_config["dpo"]["max_num_steps"]
+        and total_steps < master_config.dpo["max_num_steps"]
     ):
         print(f"\n{'=' * 25} Epoch {current_epoch + 1}/{max_num_epochs} {'=' * 25}")
 
         for batch in add_ref_logprobs_to_data(train_dataloader, policy, master_config):
             print(
-                f"\n{'=' * 25} Step {current_step + 1}/{min(len(train_dataloader), master_config['dpo']['max_num_steps'])} {'=' * 25}"
+                f"\n{'=' * 25} Step {current_step + 1}/{min(len(train_dataloader), master_config.dpo['max_num_steps'])} {'=' * 25}"
             )
             maybe_gpu_profile_step(policy, total_steps + 1)
             val_metrics, validation_timings = None, None
@@ -590,12 +591,12 @@ def dpo_train(
                         eval_mode=False,
                         ## NOTE: we double the batch size here because each preference example corresponds to a pair of
                         ## examples, chosen and rejected, and the pair needs to be processed as part of the same microbatch.
-                        gbs=master_config["policy"]["train_global_batch_size"] * 2,
-                        mbs=master_config["policy"]["train_micro_batch_size"] * 2,
+                        gbs=master_config.policy["train_global_batch_size"] * 2,
+                        mbs=master_config.policy["train_micro_batch_size"] * 2,
                         timer=timer,
                     )
 
-                is_last_step = total_steps + 1 >= master_config["dpo"][
+                is_last_step = total_steps + 1 >= master_config.dpo[
                     "max_num_steps"
                 ] or (
                     current_epoch + 1 == max_num_epochs
@@ -639,21 +640,21 @@ def dpo_train(
                 total_valid_tokens += metrics["global_valid_toks"]
 
                 ## Checkpointing
-                dpo_save_state["consumed_samples"] += master_config["policy"][
+                dpo_save_state["consumed_samples"] += master_config.policy[
                     "train_global_batch_size"
                 ]
                 timeout.mark_iteration()
 
                 should_save_by_step = (
                     is_last_step
-                    or (total_steps + 1) % master_config["checkpointing"]["save_period"]
+                    or (total_steps + 1) % master_config.checkpointing["save_period"]
                     == 0
                 )
                 # +1 because step is 0-indexed
                 # Check if timeout-based checkpointing is enabled in config.
                 should_save_by_timeout = timeout.check_save()
 
-                if master_config["checkpointing"]["enabled"] and (
+                if master_config.checkpointing["enabled"] and (
                     should_save_by_step or should_save_by_timeout
                 ):
                     dpo_save_state["step"] = (current_step + 1) % len(train_dataloader)
@@ -677,7 +678,7 @@ def dpo_train(
                     if val_metrics is not None:
                         dpo_save_state.update(val_metrics)
 
-                    full_metric_name = master_config["checkpointing"]["metric_name"]
+                    full_metric_name = master_config.checkpointing["metric_name"]
                     if full_metric_name is not None:
                         assert full_metric_name.startswith(
                             "train:"
@@ -723,7 +724,7 @@ def dpo_train(
                             tokenizer_path=os.path.join(
                                 checkpoint_path, "policy", "tokenizer"
                             ),
-                            checkpointing_cfg=master_config["checkpointing"],
+                            checkpointing_cfg=master_config.checkpointing,
                         )
                         torch.save(
                             train_dataloader.state_dict(),
@@ -766,8 +767,8 @@ def dpo_train(
                     print(f"  • {k}: {v:.2f}s ({percent:.1f}%)")
 
             total_num_gpus = (
-                master_config["cluster"]["num_nodes"]
-                * master_config["cluster"]["gpus_per_node"]
+                master_config.cluster["num_nodes"]
+                * master_config.cluster["gpus_per_node"]
             )
             timing_metrics["valid_tokens_per_sec_per_gpu"] = (
                 metrics["global_valid_toks"] / total_time / total_num_gpus
@@ -782,7 +783,7 @@ def dpo_train(
             if should_save_by_timeout:
                 print("Timeout has been reached, stopping training early", flush=True)
                 return
-            if total_steps >= master_config["dpo"]["max_num_steps"]:
+            if total_steps >= master_config.dpo["max_num_steps"]:
                 print(
                     "Max number of steps has been reached, stopping training early",
                     flush=True,

--- a/nemo_rl/algorithms/dpo.py
+++ b/nemo_rl/algorithms/dpo.py
@@ -165,7 +165,7 @@ def setup(
     #         Logger
     # ==========================
     logger = Logger(logger_config)
-    logger.log_hyperparams(master_config)
+    logger.log_hyperparams(master_config.model_dump())
 
     # ==========================
     #      Checkpointing

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -22,6 +22,7 @@ from typing import Any, NotRequired, Optional, TypedDict, TypeVar, cast
 import numpy as np
 import ray
 import torch
+from pydantic import BaseModel
 from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import AutoProcessor
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
@@ -197,7 +198,7 @@ class GRPOLoggerConfig(LoggerConfig):
     num_val_samples_to_print: int  # number of val samples to print to stdout
 
 
-class MasterConfig(TypedDict):
+class MasterConfig(BaseModel, extra="allow"):
     policy: PolicyConfig
     loss_fn: ClippedPGLossConfig
     env: dict[str, Any]
@@ -240,19 +241,19 @@ def setup(
     setup_start_time = time.perf_counter()
 
     # Extract individual configs for easier access
-    policy_config = master_config["policy"]
-    checkpointing_pretrained = master_config.get("checkpointing", {}).get(
-        "pretrained_checkpoint"
-    )
+    policy_config = master_config.policy
+    generation_config = policy_config["generation"]
+    loss_config = master_config.loss_fn
+    env_configs = master_config.env
+    data_config = master_config.data
+    grpo_config = master_config.grpo
+    logger_config = master_config.logger
+    cluster_config = master_config.cluster
+    checkpointing_config = master_config.checkpointing
+
+    checkpointing_pretrained = checkpointing_config.get("pretrained_checkpoint")
     if checkpointing_pretrained is not None:
         policy_config["pretrained_checkpoint"] = checkpointing_pretrained
-    generation_config = master_config["policy"]["generation"]
-    env_configs = master_config["env"]
-    loss_config = master_config["loss_fn"]
-    grpo_config = master_config["grpo"]
-    data_config = master_config["data"]
-    logger_config = master_config["logger"]
-    cluster_config = master_config["cluster"]
 
     assert generation_config is not None, (
         "A generation config in the PolicyConfig is required for GRPO"
@@ -270,7 +271,7 @@ def setup(
     # ==========================
     #      Checkpointing
     # ==========================
-    checkpointer = CheckpointManager(master_config["checkpointing"])
+    checkpointer = CheckpointManager(checkpointing_config)
     last_checkpoint_path = checkpointer.get_latest_checkpoint_path()
     grpo_save_state: Optional[GRPOSaveState] = cast(
         Optional[GRPOSaveState], checkpointer.load_training_info(last_checkpoint_path)
@@ -569,13 +570,13 @@ def setup(
         policy_config["megatron_cfg"]["train_iters"] = total_train_iters
 
     # Define initialization functions that will be used in all paths
-    init_reference_model = master_config["loss_fn"]["reference_policy_kl_penalty"] > 0
+    init_reference_model = loss_config["reference_policy_kl_penalty"] > 0
 
     # Auto-enable skip_reference_policy_logprobs_calculation when the reference model is not loaded.
-    if not init_reference_model and not master_config["grpo"].get(
+    if not init_reference_model and not grpo_config.get(
         "skip_reference_policy_logprobs_calculation"
     ):
-        master_config["grpo"]["skip_reference_policy_logprobs_calculation"] = True
+        grpo_config["skip_reference_policy_logprobs_calculation"] = True
         print(
             "Auto-enabling `grpo.skip_reference_policy_logprobs_calculation=True` "
             "because `loss_fn.reference_policy_kl_penalty == 0` "
@@ -869,8 +870,8 @@ def dynamic_sampling(
 
     # Required batch size for training
     train_prompts_size = (
-        master_config["grpo"]["num_prompts_per_step"]
-        * master_config["grpo"]["num_generations_per_prompt"]
+        master_config.grpo["num_prompts_per_step"]
+        * master_config.grpo["num_generations_per_prompt"]
     )
     # Store the baseline, std and total_reward for the current unfiltered batch.
     repeated_batch["baseline"] = baseline
@@ -881,7 +882,7 @@ def dynamic_sampling(
     # Dynamic sampling algorithm (used in DAPO algorithm)
     # This block implements dynamic sampling by selecting prompt groups with non-zero std.
     # If sampled prompts (with non-zero std) are fewer than num_prompts_per_step * num_generations_per_prompt, continue sampling until dynamic_sampling_max_gen_batches is reached.
-    if master_config["grpo"]["use_dynamic_sampling"]:
+    if master_config.grpo["use_dynamic_sampling"]:
         with timer.time("dynamic_sampling"):
             # Get the prompt indices with non-zero std
             non_zero_std_mask = std != 0.0
@@ -924,7 +925,7 @@ def dynamic_sampling(
 
             # If the generation samples size is smaller than a fixed threshold (train_prompts_size), keep generating by processing the next batch
             if filtered_prompts_size < train_prompts_size:
-                dynamic_sampling_max_gen_batches = master_config["grpo"][
+                dynamic_sampling_max_gen_batches = master_config.grpo[
                     "dynamic_sampling_max_gen_batches"
                 ]
                 assert dynamic_sampling_max_gen_batches > 0, (
@@ -952,7 +953,7 @@ def dynamic_sampling(
 
     batch_to_return = (
         filtered_repeated_batch
-        if master_config["grpo"]["use_dynamic_sampling"]
+        if master_config.grpo["use_dynamic_sampling"]
         else repeated_batch
     )
     return batch_to_return, is_batch_complete, batch_cache, dynamic_sampling_metrics
@@ -1009,7 +1010,7 @@ def _should_use_async_rollouts(master_config: MasterConfig) -> bool:
 
     Returns True if vLLM backend is used with async_engine enabled.
     """
-    generation_config = master_config["policy"]["generation"]
+    generation_config = master_config.policy["generation"]
     if generation_config is None:
         return False
 
@@ -1023,7 +1024,7 @@ def _should_use_async_rollouts(master_config: MasterConfig) -> bool:
 
 def _should_use_nemo_gym(master_config: MasterConfig) -> bool:
     """Determine if NeMo-Gym should be used for rollouts and validation based on the configuration."""
-    env_config = master_config.get("env") or dict()
+    env_config = master_config.env
     should_use_nemo_gym = bool(env_config.get("should_use_nemo_gym"))
     if not should_use_nemo_gym:
         return should_use_nemo_gym
@@ -1033,9 +1034,8 @@ def _should_use_nemo_gym(master_config: MasterConfig) -> bool:
         "❌ Error: In order to use NeMo-Gym, you must use vllm generation backend with `async_engine: true`!"
     )
 
-    generation_config = master_config["policy"]["generation"]
-
     # We piggyback off of `_should_use_async_rollouts` to guarantee the existence of these configs.
+    generation_config = master_config.policy["generation"]
     should_expose_http_server = generation_config["vllm_cfg"].get("expose_http_server")
     assert should_expose_http_server, (
         "In order to use NeMo-Gym, you must expose the vllm server via `expose_http_server: true`!"
@@ -1045,7 +1045,7 @@ def _should_use_nemo_gym(master_config: MasterConfig) -> bool:
 
 
 def _should_log_nemo_gym_responses(master_config: MasterConfig) -> bool:
-    env_config = master_config.get("env") or dict()
+    env_config = master_config.env
     should_log_nemo_gym_responses = bool(
         env_config.get("should_log_nemo_gym_responses")
     )
@@ -1065,8 +1065,8 @@ def _create_advantage_estimator(master_config: MasterConfig):
     Raises:
         ValueError: If the advantage estimator name is not recognized.
     """
-    grpo_config = master_config["grpo"]
-    loss_config = master_config["loss_fn"]
+    grpo_config = master_config.grpo
+    loss_config = master_config.loss_fn
 
     # Provide backward-compatible defaults when adv_estimator is not in config.
     # Fall back to top-level grpo.normalize_rewards / grpo.use_leave_one_out_baseline
@@ -1349,7 +1349,7 @@ def grpo_train(
     """Run GRPO training algorithm."""
     timer = Timer()
     timeout = TimeoutChecker(
-        timeout=master_config["checkpointing"]["checkpoint_must_save_by"],
+        timeout=master_config.checkpointing["checkpoint_must_save_by"],
         fit_last_save_time=True,
     )
     timeout.start_iterations()
@@ -1372,11 +1372,11 @@ def grpo_train(
     # common config/state times
     current_step = grpo_save_state["current_step"]  # current step within an epoch
     total_steps = grpo_save_state["total_steps"]  # total steps across all epochs
-    max_num_steps = master_config["grpo"][
+    max_num_steps = master_config.grpo[
         "max_num_steps"
     ]  # max number of steps to train for
     current_epoch = grpo_save_state["current_epoch"]  # current epoch
-    max_num_epochs = master_config["grpo"][
+    max_num_epochs = master_config.grpo[
         "max_num_epochs"
     ]  # max number of epochs to train for
     consumed_samples = grpo_save_state[
@@ -1385,10 +1385,10 @@ def grpo_train(
     total_valid_tokens = grpo_save_state.get(
         "total_valid_tokens", 0
     )  # total valid tokens processed across all epochs; default to 0 for backward compatibility with older checkpoints
-    val_at_start = master_config["grpo"]["val_at_start"]
-    val_at_end = master_config["grpo"]["val_at_end"]
-    val_period = master_config["grpo"]["val_period"]
-    colocated_inference = master_config["policy"]["generation"]["colocated"]["enabled"]
+    val_at_start = master_config.grpo["val_at_start"]
+    val_at_end = master_config.grpo["val_at_end"]
+    val_period = master_config.grpo["val_period"]
+    colocated_inference = master_config.policy["generation"]["colocated"]["enabled"]
 
     # Initialize advantage estimator
     adv_estimator = _create_advantage_estimator(master_config)
@@ -1417,7 +1417,7 @@ def grpo_train(
         logger.log_metrics(val_metrics, current_step, prefix="validation")
         logger.log_metrics(validation_timings, current_step, prefix="timing/validation")
 
-    if master_config["data"]["use_multiple_dataloader"]:
+    if master_config.data["use_multiple_dataloader"]:
         warnings.warn(
             "When using multiple dataloaders, MultipleDataloaderWrapper operates as an infinite iterator. "
             "As a result, grpo.max_num_epochs will be ignored, and only grpo.max_num_steps will be used. "
@@ -1438,7 +1438,7 @@ def grpo_train(
             metrics_logging_data = dict()
             metrics = dict()
 
-            if master_config["data"]["use_multiple_dataloader"]:
+            if master_config.data["use_multiple_dataloader"]:
                 print(
                     f"\n{'=' * 25} Step {current_step + 1}/{max_num_steps} {'=' * 25}",
                     flush=True,
@@ -1461,7 +1461,7 @@ def grpo_train(
                     # Repeat batch items
                     repeated_batch: BatchedDataDict[DatumSpec] = (
                         batch.repeat_interleave(
-                            master_config["grpo"]["num_generations_per_prompt"]
+                            master_config.grpo["num_generations_per_prompt"]
                         )
                     )
                     # Convert LLMMessageLogType to FlatMessagesType for generation
@@ -1490,9 +1490,9 @@ def grpo_train(
                                     pad_value_dict={
                                         "token_ids": tokenizer.pad_token_id
                                     },
-                                    make_sequence_length_divisible_by=master_config[
-                                        "policy"
-                                    ]["make_sequence_length_divisible_by"],
+                                    make_sequence_length_divisible_by=master_config.policy[
+                                        "make_sequence_length_divisible_by"
+                                    ],
                                 )
                             )
                             # Create calibration data from flattened messages
@@ -1534,7 +1534,7 @@ def grpo_train(
                         policy_generation.clear_logger_metrics()
                     # Use NeMo-Gym rollouts if enabled. We cascade NeMo-Gym first since NeMo-Gym requires async rollouts.
                     if _should_use_nemo_gym(master_config):
-                        generation_config = master_config["policy"]["generation"]
+                        generation_config = master_config.policy["generation"]
                         nemo_gym_rollout_result = run_async_nemo_gym_rollout(
                             policy_generation=policy_generation,
                             input_batch=repeated_batch,
@@ -1568,12 +1568,10 @@ def grpo_train(
                             input_batch=repeated_batch,
                             tokenizer=tokenizer,
                             task_to_env=task_to_env,
-                            max_seq_len=master_config["policy"][
+                            max_seq_len=master_config.policy[
                                 "max_total_sequence_length"
                             ],
-                            max_rollout_turns=master_config["grpo"][
-                                "max_rollout_turns"
-                            ],
+                            max_rollout_turns=master_config.grpo["max_rollout_turns"],
                             greedy=False,
                         )
                     else:
@@ -1582,12 +1580,10 @@ def grpo_train(
                             input_batch=repeated_batch,
                             tokenizer=tokenizer,
                             task_to_env=task_to_env,
-                            max_seq_len=master_config["policy"][
+                            max_seq_len=master_config.policy[
                                 "max_total_sequence_length"
                             ],
-                            max_rollout_turns=master_config["grpo"][
-                                "max_rollout_turns"
-                            ],
+                            max_rollout_turns=master_config.grpo["max_rollout_turns"],
                             greedy=False,
                         )
                     policy_generation.finish_generation()
@@ -1604,12 +1600,12 @@ def grpo_train(
                     logger.log_metrics(rollout_metrics, total_steps + 1, prefix="train")
 
                 repeated_batch = scale_rewards(
-                    repeated_batch, master_config["grpo"]["reward_scaling"]
+                    repeated_batch, master_config.grpo["reward_scaling"]
                 )
                 # Process rewards with custom reward function
-                if master_config["grpo"]["reward_shaping"]["enabled"]:
+                if master_config.grpo["reward_shaping"]["enabled"]:
                     repeated_batch = apply_reward_shaping(
-                        repeated_batch, master_config["grpo"]["reward_shaping"]
+                        repeated_batch, master_config.grpo["reward_shaping"]
                     )
 
                 # Calculate rewards & advantages
@@ -1620,7 +1616,7 @@ def grpo_train(
                     rewards = repeated_batch["total_reward"]
 
                     print("▶ Computing advantages...", flush=True)
-                    if master_config["grpo"].get("calculate_advantages_on_gpu"):
+                    if master_config.grpo.get("calculate_advantages_on_gpu"):
                         print("Computing advantages on GPU!")
                         # Just fix the device id for now
                         device_id = 0
@@ -1628,7 +1624,7 @@ def grpo_train(
                             input_ids.cuda(device_id),
                             rewards.cuda(device_id),
                             torch.ones_like(rewards).cuda(device_id),
-                            leave_one_out_baseline=master_config["grpo"][
+                            leave_one_out_baseline=master_config.grpo[
                                 "use_leave_one_out_baseline"
                             ],
                         )
@@ -1639,7 +1635,7 @@ def grpo_train(
                             input_ids,
                             rewards,
                             torch.ones_like(rewards),
-                            leave_one_out_baseline=master_config["grpo"][
+                            leave_one_out_baseline=master_config.grpo[
                                 "use_leave_one_out_baseline"
                             ],
                         )
@@ -1663,7 +1659,7 @@ def grpo_train(
                     # Get the updated rewards and baselines. For DAPO, these rewards and baselines only correspond to the prompts with non-zero std.
                     rewards = (
                         repeated_batch["total_reward"]
-                        if not master_config["grpo"]["use_dynamic_sampling"]
+                        if not master_config.grpo["use_dynamic_sampling"]
                         else repeated_batch["filtered_reward"]
                     )
                     baseline = repeated_batch["baseline"]
@@ -1696,7 +1692,7 @@ def grpo_train(
                     del std
 
                 with timer.time("data_processing"):
-                    use_overlong_filtering = master_config["grpo"]["overlong_filtering"]
+                    use_overlong_filtering = master_config.grpo["overlong_filtering"]
                     if use_overlong_filtering:
                         loss_multiplier = repeated_batch["loss_multiplier"].clone()
                         truncated = repeated_batch["truncated"]
@@ -1726,7 +1722,7 @@ def grpo_train(
                     flat_messages, input_lengths = batched_message_log_to_flat_message(
                         repeated_batch["message_log"],
                         pad_value_dict={"token_ids": tokenizer.pad_token_id},
-                        make_sequence_length_divisible_by=master_config["policy"][
+                        make_sequence_length_divisible_by=master_config.policy[
                             "make_sequence_length_divisible_by"
                         ],
                     )
@@ -1788,7 +1784,7 @@ def grpo_train(
                             train_data["generation_logprobs"]
                         )
 
-                    if not master_config["grpo"].get(
+                    if not master_config.grpo.get(
                         "skip_reference_policy_logprobs_calculation"
                     ):
                         train_data["reference_policy_logprobs"] = (
@@ -1806,7 +1802,7 @@ def grpo_train(
                     del extra_multimodal_data
 
                 # Seq-level logprob error metrics/masking require real prev_logprobs
-                seq_logprob_error_threshold = master_config["grpo"].get(
+                seq_logprob_error_threshold = master_config.grpo.get(
                     "seq_logprob_error_threshold", None
                 )
                 if skip_prev_logprobs:
@@ -1885,7 +1881,7 @@ def grpo_train(
                         POLICY_GENERATION_STALE = True
 
                 is_last_step = total_steps + 1 >= max_num_steps
-                if not master_config["data"]["use_multiple_dataloader"]:
+                if not master_config.data["use_multiple_dataloader"]:
                     is_last_step = is_last_step or (
                         (current_epoch + 1 == max_num_epochs)
                         and (current_step + 1 == len(wrapped_dataloader))
@@ -1958,7 +1954,7 @@ def grpo_train(
                     metrics.update(
                         {f"moe/{k}": v for k, v in train_results["moe_metrics"].items()}
                     )
-                if master_config["grpo"]["use_dynamic_sampling"]:
+                if master_config.grpo["use_dynamic_sampling"]:
                     metrics["filtered_reward"] = rewards.numpy()
                     metrics["reward"] = repeated_batch["total_reward"].numpy()
 
@@ -2000,12 +1996,12 @@ def grpo_train(
                 metrics["masked_correct_pct"] = masked_correct_pct
 
                 ## Checkpointing
-                consumed_samples += master_config["grpo"]["num_prompts_per_step"]
+                consumed_samples += master_config.grpo["num_prompts_per_step"]
                 timeout.mark_iteration()
 
                 should_save_by_step = (
                     is_last_step
-                    or (total_steps + 1) % master_config["checkpointing"]["save_period"]
+                    or (total_steps + 1) % master_config.checkpointing["save_period"]
                     == 0
                 )
                 # +1 because step is 0-indexed
@@ -2013,7 +2009,7 @@ def grpo_train(
                 should_save_by_timeout = timeout.check_save()
 
                 memory_tracker.snapshot_start_of_stage("Checkpointing", dir())
-                if master_config["checkpointing"]["enabled"] and (
+                if master_config.checkpointing["enabled"] and (
                     should_save_by_step or should_save_by_timeout
                 ):
                     policy.prepare_for_training()
@@ -2029,7 +2025,7 @@ def grpo_train(
                         del grpo_save_state["val_reward"]
                     grpo_save_state["consumed_samples"] = consumed_samples
 
-                    full_metric_name = master_config["checkpointing"]["metric_name"]
+                    full_metric_name = master_config.checkpointing["metric_name"]
                     if full_metric_name is not None:
                         assert full_metric_name.startswith(
                             "train:"
@@ -2078,9 +2074,9 @@ def grpo_train(
                             tokenizer_path=os.path.join(
                                 checkpoint_path, "policy", "tokenizer"
                             ),
-                            checkpointing_cfg=master_config["checkpointing"],
+                            checkpointing_cfg=master_config.checkpointing,
                         )
-                        if master_config["data"]["use_multiple_dataloader"]:
+                        if master_config.data["use_multiple_dataloader"]:
                             for (
                                 task_name,
                                 task_dataloader,
@@ -2108,7 +2104,7 @@ def grpo_train(
                     log_data["agent_ref"] = repeated_batch["agent_ref"]
                 log_data["content"] = flat_messages["content"]
                 log_data["rewards"] = rewards.tolist()
-                if master_config["grpo"]["use_dynamic_sampling"]:
+                if master_config.grpo["use_dynamic_sampling"]:
                     log_data["filtered_rewards"] = rewards.tolist()
                     log_data["rewards"] = repeated_batch["total_reward"].tolist()
                 log_data["input_lengths"] = input_lengths.tolist()
@@ -2145,13 +2141,16 @@ def grpo_train(
                     name="train/token_mult_prob_error_plot_sample",
                 )
             del train_data
-            if master_config["policy"]["generation"].get("vllm_cfg", {}).get(
-                "enable_vllm_metrics_logger", False
-            ) and master_config.get("logger", {}).get("wandb_enabled", False):
+            if (
+                master_config.policy["generation"]
+                .get("vllm_cfg", {})
+                .get("enable_vllm_metrics_logger", False)
+                and master_config.logger["wandb_enabled"]
+            ):
                 log_generation_metrics_to_wandb(
                     generation_logger_metrics,
                     total_steps + 1,
-                    master_config["policy"]["generation"]["vllm_cfg"][
+                    master_config.policy["generation"]["vllm_cfg"][
                         "vllm_metrics_logger_interval"
                     ],
                     logger,
@@ -2159,7 +2158,7 @@ def grpo_train(
 
             # Plot ISL/OSL/ISL+OSL histograms to wandb
             if (
-                master_config["policy"]["generation"]
+                master_config.policy["generation"]
                 .get("vllm_cfg", {})
                 .get("async_engine", False)
             ):
@@ -2177,7 +2176,7 @@ def grpo_train(
             if "draft_loss" in metrics:
                 print(f"  • Draft Loss: {metrics['draft_loss']:.4f}")
             print(f"  • Generation KL Error: {metrics['gen_kl_error']:.4f}")
-            if master_config["grpo"]["use_dynamic_sampling"]:
+            if master_config.grpo["use_dynamic_sampling"]:
                 print(f"  • Avg Filtered Reward: {np.mean(rewards.numpy()):.4f}")
                 print(
                     f"  • Avg Total Reward: {np.mean(repeated_batch['total_reward'].numpy()):.4f}"
@@ -2194,12 +2193,12 @@ def grpo_train(
             total_time = timing_metrics.get("total_step_time", 0)
 
             number_of_samples_per_step = (
-                master_config["grpo"]["num_prompts_per_step"]
-                * master_config["grpo"]["num_generations_per_prompt"]
+                master_config.grpo["num_prompts_per_step"]
+                * master_config.grpo["num_generations_per_prompt"]
             )
             total_num_gpus = (
-                master_config["cluster"]["num_nodes"]
-                * master_config["cluster"]["gpus_per_node"]
+                master_config.cluster["num_nodes"]
+                * master_config.cluster["gpus_per_node"]
             )
 
             print(f"  • Total step time: {total_time:.2f}s", flush=True)
@@ -2277,7 +2276,7 @@ def validate(
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     """Run validation on the validation dataset."""
     if val_dataloader is None:
-        assert val_dataloader is not None or master_config["dpo"]["val_period"] == 0, (
+        assert val_dataloader is not None or master_config.dpo["val_period"] == 0, (
             "val_dataloader is None, so dpo.val_period must be 0"
         )
         print("  ⚠️ No validation dataloader provided, skipping validation", flush=True)
@@ -2292,8 +2291,8 @@ def validate(
         all_message_logs = []  # Collect all message logs
 
         max_batches = (
-            master_config["grpo"]["max_val_samples"]
-            // master_config["grpo"]["val_batch_size"]
+            master_config.grpo["max_val_samples"]
+            // master_config.grpo["val_batch_size"]
         )
         for batch_idx, val_batch in enumerate(val_dataloader):
             if batch_idx >= max_batches:
@@ -2304,7 +2303,7 @@ def validate(
             # Use async rollouts if vLLM async engine is enabled
             # We cascade NeMo-Gym first since NeMo-Gym also uses async rollouts.
             if _should_use_nemo_gym(master_config):
-                generation_config = master_config["policy"]["generation"]
+                generation_config = master_config.policy["generation"]
                 nemo_gym_rollout_result = run_async_nemo_gym_rollout(
                     policy_generation=policy_generation,
                     input_batch=val_batch,
@@ -2324,8 +2323,8 @@ def validate(
                     val_batch,
                     tokenizer,
                     val_task_to_env,
-                    max_seq_len=master_config["policy"]["max_total_sequence_length"],
-                    max_rollout_turns=master_config["grpo"]["max_rollout_turns"],
+                    max_seq_len=master_config.policy["max_total_sequence_length"],
+                    max_rollout_turns=master_config.grpo["max_rollout_turns"],
                     greedy=False,
                 )
             else:
@@ -2334,8 +2333,8 @@ def validate(
                     val_batch,
                     tokenizer,
                     val_task_to_env,
-                    max_seq_len=master_config["policy"]["max_total_sequence_length"],
-                    max_rollout_turns=master_config["grpo"]["max_rollout_turns"],
+                    max_seq_len=master_config.policy["max_total_sequence_length"],
+                    max_rollout_turns=master_config.grpo["max_rollout_turns"],
                     greedy=False,
                 )
 
@@ -2376,7 +2375,7 @@ def validate(
                 all_message_logs,
                 total_rewards,
                 num_samples=min(
-                    master_config["logger"]["num_val_samples_to_print"],
+                    master_config.logger["num_val_samples_to_print"],
                     len(all_message_logs),
                 ),
                 step=step,
@@ -2455,14 +2454,12 @@ def async_grpo_train(
         "Async GRPO requires vLLM backend with vllm_cfg.async_engine=True. "
         "Set policy.generation.vllm_cfg.async_engine to true in your config."
     )
-    assert master_config["loss_fn"]["use_importance_sampling_correction"] is True, (
+    assert master_config.loss_fn["use_importance_sampling_correction"] is True, (
         "Importance sampling correction must be enabled for async GRPO for good convergence due to off-policy samples!"
     )
 
-    if master_config["grpo"]["async_grpo"]["max_trajectory_age_steps"] > 1:
-        if not master_config["grpo"]["async_grpo"].get(
-            "in_flight_weight_updates", False
-        ):
+    if master_config.grpo["async_grpo"]["max_trajectory_age_steps"] > 1:
+        if not master_config.grpo["async_grpo"].get("in_flight_weight_updates", False):
             print(
                 "⚠️ WARNING: In-flight weight updates must be enabled for async GRPO with max_trajectory_age_steps > 1. "
                 "Without in-flight weight updates, having more max_trajectory_age_steps will not give any performance benefit."
@@ -2473,7 +2470,7 @@ def async_grpo_train(
 
     timer = Timer()
     timeout = TimeoutChecker(
-        timeout=master_config["checkpointing"]["checkpoint_must_save_by"],
+        timeout=master_config.checkpointing["checkpoint_must_save_by"],
         fit_last_save_time=True,
     )
     timeout.start_iterations()
@@ -2493,10 +2490,10 @@ def async_grpo_train(
     total_valid_tokens = grpo_save_state.get(
         "total_valid_tokens", 0
     )  # Default to 0 for backward compatibility with older checkpoints
-    val_period = master_config["grpo"]["val_period"]
-    val_at_start = master_config["grpo"]["val_at_start"]
-    val_at_end = master_config["grpo"]["val_at_end"]
-    colocated_inference = master_config["policy"]["generation"]["colocated"]["enabled"]
+    val_period = master_config.grpo["val_period"]
+    val_at_start = master_config.grpo["val_at_start"]
+    val_at_end = master_config.grpo["val_at_end"]
+    colocated_inference = master_config.policy["generation"]["colocated"]["enabled"]
 
     # Initialize advantage estimator
     adv_estimator = _create_advantage_estimator(master_config)
@@ -2507,9 +2504,9 @@ def async_grpo_train(
 
     # Calculate minimum buffer size from training requirements
     # In per-prompt buffer mode, one buffer entry is 1 prompt * num_generations_per_prompt
-    num_prompts_per_step = master_config["grpo"]["num_prompts_per_step"]
-    samples_per_prompt_group = master_config["grpo"]["num_generations_per_prompt"]
-    train_gbs = master_config["policy"]["train_global_batch_size"]
+    num_prompts_per_step = master_config.grpo["num_prompts_per_step"]
+    samples_per_prompt_group = master_config.grpo["num_generations_per_prompt"]
+    train_gbs = master_config.policy["train_global_batch_size"]
 
     # Ensure the buffer has at least one step worth of prompt-groups before training
     min_trajectories_needed = num_prompts_per_step
@@ -2547,7 +2544,7 @@ def async_grpo_train(
     # Calculate optimal buffer size based on generation limits to prevent length bias
     # Each weight version generates exactly num_prompts_per_step trajectories
     # With max_age_steps, we keep trajectories from multiple weight versions
-    num_prompts_per_step = master_config["grpo"]["num_prompts_per_step"]
+    num_prompts_per_step = master_config.grpo["num_prompts_per_step"]
     late_arrival_slack = 2
     optimal_buffer_size = (
         num_prompts_per_step * max_trajectory_age_steps * late_arrival_slack
@@ -2686,9 +2683,9 @@ def async_grpo_train(
 
     # Main training loop
     try:
-        while step < master_config["grpo"]["max_num_steps"]:
+        while step < master_config.grpo["max_num_steps"]:
             print(
-                f"\n{'=' * 25} Step {step + 1}/{master_config['grpo']['max_num_steps']} {'=' * 25}"
+                f"\n{'=' * 25} Step {step + 1}/{master_config.grpo['max_num_steps']} {'=' * 25}"
             )
             maybe_gpu_profile_step(policy, step + 1)
             if policy != policy_generation:
@@ -2704,7 +2701,7 @@ def async_grpo_train(
                     )
 
                     # Sample the required number of per-prompt groups.
-                    num_prompt_groups_needed = master_config["grpo"][
+                    num_prompt_groups_needed = master_config.grpo[
                         "num_prompts_per_step"
                     ]
                     sample_result = ray.get(
@@ -2765,8 +2762,8 @@ def async_grpo_train(
 
                 # Enforce fixed training batch: num_prompts_per_step * num_generations_per_prompt
                 expected_batch_size = (
-                    master_config["grpo"]["num_prompts_per_step"]
-                    * master_config["grpo"]["num_generations_per_prompt"]
+                    master_config.grpo["num_prompts_per_step"]
+                    * master_config.grpo["num_generations_per_prompt"]
                 )
                 if repeated_batch.size != expected_batch_size:
                     print(
@@ -2826,7 +2823,7 @@ def async_grpo_train(
                     flat_messages, input_lengths = batched_message_log_to_flat_message(
                         repeated_batch["message_log"],
                         pad_value_dict={"token_ids": tokenizer.pad_token_id},
-                        make_sequence_length_divisible_by=master_config["policy"][
+                        make_sequence_length_divisible_by=master_config.policy[
                             "make_sequence_length_divisible_by"
                         ],
                     )
@@ -2883,7 +2880,7 @@ def async_grpo_train(
                         )
 
                 # Seq-level logprob error metrics/masking require real prev_logprobs
-                seq_logprob_error_threshold = master_config["grpo"].get(
+                seq_logprob_error_threshold = master_config.grpo.get(
                     "seq_logprob_error_threshold", None
                 )
                 if skip_prev_logprobs:
@@ -2980,7 +2977,7 @@ def async_grpo_train(
 
                 # Validation
                 val_metrics, validation_timings = None, None
-                is_last_step = step + 1 == master_config["grpo"]["max_num_steps"]
+                is_last_step = step + 1 == master_config.grpo["max_num_steps"]
 
                 # Run validation if it's a validation step or last step with val_at_end
                 if (val_period > 0 and (step + 1) % val_period == 0) or (
@@ -3086,18 +3083,18 @@ def async_grpo_train(
                 metrics["masked_correct_pct"] = masked_correct_pct
 
                 # Checkpointing (same as sync version)
-                consumed_samples += master_config["grpo"]["num_prompts_per_step"]
+                consumed_samples += master_config.grpo["num_prompts_per_step"]
                 timeout.mark_iteration()
 
                 should_save_by_step = (
                     is_last_step
-                    or (step + 1) % master_config["checkpointing"]["save_period"] == 0
+                    or (step + 1) % master_config.checkpointing["save_period"] == 0
                 )
                 # +1 because step is 0-indexed
                 # Check if timeout-based checkpointing is enabled in config.
                 should_save_by_timeout = timeout.check_save()
 
-                if master_config["checkpointing"]["enabled"] and (
+                if master_config.checkpointing["enabled"] and (
                     should_save_by_step or should_save_by_timeout
                 ):
                     grpo_save_state["current_step"] = step + 1
@@ -3108,7 +3105,7 @@ def async_grpo_train(
                         del grpo_save_state["val_reward"]
                     grpo_save_state["consumed_samples"] = consumed_samples
 
-                    full_metric_name = master_config["checkpointing"]["metric_name"]
+                    full_metric_name = master_config.checkpointing["metric_name"]
                     if full_metric_name is not None:
                         assert full_metric_name.startswith(
                             "train:"
@@ -3154,7 +3151,7 @@ def async_grpo_train(
                             tokenizer_path=os.path.join(
                                 checkpoint_path, "policy", "tokenizer"
                             ),
-                            checkpointing_cfg=master_config["checkpointing"],
+                            checkpointing_cfg=master_config.checkpointing,
                         )
                         # Get dataloader state from trajectory collector
                         actual_dataloader_state = ray.get(
@@ -3173,7 +3170,7 @@ def async_grpo_train(
                 log_data["agent_ref"] = repeated_batch["agent_ref"]
             log_data["content"] = flat_messages_content
             log_data["rewards"] = rewards.tolist()
-            if master_config["grpo"]["use_dynamic_sampling"]:
+            if master_config.grpo["use_dynamic_sampling"]:
                 # In dynamic sampling, `rewards` corresponds to filtered rewards
                 log_data["filtered_rewards"] = rewards.tolist()
                 log_data["rewards"] = repeated_batch["total_reward"].tolist()
@@ -3199,13 +3196,16 @@ def async_grpo_train(
             metrics["buffer_size"] = buffer_size_current
             metrics["avg_trajectory_age"] = avg_trajectory_age
 
-            if master_config["policy"]["generation"].get("vllm_cfg", {}).get(
-                "enable_vllm_metrics_logger", False
-            ) and master_config.get("logger", {}).get("wandb_enabled", False):
+            if (
+                master_config.policy["generation"]
+                .get("vllm_cfg", {})
+                .get("enable_vllm_metrics_logger", False)
+                and master_config.logger["wandb_enabled"]
+            ):
                 log_generation_metrics_to_wandb(
                     generation_logger_metrics,
                     step + 1,
-                    master_config["policy"]["generation"]["vllm_cfg"][
+                    master_config.policy["generation"]["vllm_cfg"][
                         "vllm_metrics_logger_interval"
                     ],
                     logger,
@@ -3213,7 +3213,7 @@ def async_grpo_train(
 
             # Plot ISL/OSL/ISL+OSL histograms to wandb
             if (
-                master_config["policy"]["generation"]
+                master_config.policy["generation"]
                 .get("vllm_cfg", {})
                 .get("async_engine", False)
             ):
@@ -3245,8 +3245,8 @@ def async_grpo_train(
                     print(f"  • {k}: {v:.2f}s ({percent:.1f}%)")
 
             total_num_gpus = (
-                master_config["cluster"]["num_nodes"]
-                * master_config["cluster"]["gpus_per_node"]
+                master_config.cluster["num_nodes"]
+                * master_config.cluster["gpus_per_node"]
             )
             timing_metrics["valid_tokens_per_sec_per_gpu"] = (
                 metrics["global_valid_toks"] / total_time / total_num_gpus
@@ -3264,7 +3264,7 @@ def async_grpo_train(
             if should_save_by_timeout:
                 print("Timeout has been reached, stopping training early", flush=True)
                 return
-            if step >= master_config["grpo"]["max_num_steps"]:
+            if step >= master_config.grpo["max_num_steps"]:
                 print(
                     "Max number of steps has been reached, stopping training early",
                     flush=True,

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -2275,7 +2275,7 @@ def validate(
     """Run validation on the validation dataset."""
     if val_dataloader is None:
         assert val_dataloader is not None or master_config.grpo["val_period"] == 0, (
-            "val_dataloader is None, so dpo.val_period must be 0"
+            "val_dataloader is None, so grpo.val_period must be 0"
         )
         print("  ⚠️ No validation dataloader provided, skipping validation", flush=True)
         return {}, {}

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -243,7 +243,7 @@ def setup(
     # Extract individual configs for easier access
     policy_config = master_config.policy
     generation_config = policy_config["generation"]
-    loss_config = master_config.loss_fn
+    loss_config: ClippedPGLossConfig = master_config.loss_fn
     env_configs = master_config.env
     data_config = master_config.data
     grpo_config = master_config.grpo
@@ -384,7 +384,7 @@ def setup(
     loss_fn = ClippedPGLossFn(loss_config)
 
     # Validate force_on_policy_ratio
-    if loss_config.get("force_on_policy_ratio", False):
+    if loss_config.force_on_policy_ratio:
         assert (
             grpo_config["num_prompts_per_step"]
             * grpo_config["num_generations_per_prompt"]
@@ -689,7 +689,7 @@ def setup(
         # vLLM generation: setup config, then initialize with policy
         generation_config = cast(VllmConfig, generation_config)
         if generation_config["vllm_cfg"]["precision"] == "fp8":
-            assert loss_config["use_importance_sampling_correction"] is True, (
+            assert loss_config.use_importance_sampling_correction, (
                 "Importance sampling must be enabled for vLLM FP8 generation for good convergence!"
             )
         if generation_config["vllm_cfg"]["kv_cache_dtype"].startswith("fp8"):
@@ -1750,7 +1750,7 @@ def grpo_train(
 
                 memory_tracker.snapshot_start_of_stage("Computing logprobs", dir())
                 # Skip prev_logprobs computation when force_on_policy_ratio=True
-                skip_prev_logprobs = master_config["loss_fn"].get(
+                skip_prev_logprobs = master_config.loss_fn.get(
                     "force_on_policy_ratio", False
                 )
                 if skip_prev_logprobs:
@@ -2454,7 +2454,7 @@ def async_grpo_train(
         "Async GRPO requires vLLM backend with vllm_cfg.async_engine=True. "
         "Set policy.generation.vllm_cfg.async_engine to true in your config."
     )
-    assert master_config.loss_fn["use_importance_sampling_correction"] is True, (
+    assert master_config.loss_fn.use_importance_sampling_correction, (
         "Importance sampling correction must be enabled for async GRPO for good convergence due to off-policy samples!"
     )
 
@@ -2843,7 +2843,7 @@ def async_grpo_train(
 
                 # Training phase (same as sync version)
                 # Skip prev_logprobs computation when force_on_policy_ratio=True
-                skip_prev_logprobs = master_config["loss_fn"].get(
+                skip_prev_logprobs = master_config.loss_fn.get(
                     "force_on_policy_ratio", False
                 )
                 if skip_prev_logprobs:

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -266,7 +266,7 @@ def setup(
     #         Logger
     # ==========================
     logger = Logger(logger_config)
-    logger.log_hyperparams(master_config)
+    logger.log_hyperparams(master_config.model_dump())
 
     # ==========================
     #      Checkpointing

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -142,12 +142,12 @@ class GRPOConfig(TypedDict):
     normalize_rewards: bool
     use_leave_one_out_baseline: bool
     val_period: int
-    val_batch_size: int
+    val_batch_size: int | None  # None for NeMo-Gym compatibility
     val_at_start: bool
     # Whether to run validation on the last training step. Setting this to True ensures the
     # final checkpoint has validation metrics, which is required for get_best_checkpoint_path().
     val_at_end: bool
-    max_val_samples: int
+    max_val_samples: int | None  # None for NeMo-Gym compatibility
     skip_reference_policy_logprobs_calculation: NotRequired[bool]
     seed: int
     async_grpo: NotRequired[AsyncGRPOConfig]

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -2276,7 +2276,7 @@ def validate(
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     """Run validation on the validation dataset."""
     if val_dataloader is None:
-        assert val_dataloader is not None or master_config.dpo["val_period"] == 0, (
+        assert val_dataloader is not None or master_config.grpo["val_period"] == 0, (
             "val_dataloader is None, so dpo.val_period must be 0"
         )
         print("  ⚠️ No validation dataloader provided, skipping validation", flush=True)

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -397,7 +397,7 @@ def setup(
 
     # Validate skip_reference_policy_logprobs_calculation
     if grpo_config.get("skip_reference_policy_logprobs_calculation"):
-        assert loss_config["reference_policy_kl_penalty"] == 0, (
+        assert loss_config.reference_policy_kl_penalty == 0, (
             "grpo.skip_reference_policy_logprobs_calculation=True requires "
             "loss_fn.reference_policy_kl_penalty == 0"
         )
@@ -570,7 +570,7 @@ def setup(
         policy_config["megatron_cfg"]["train_iters"] = total_train_iters
 
     # Define initialization functions that will be used in all paths
-    init_reference_model = loss_config["reference_policy_kl_penalty"] > 0
+    init_reference_model = loss_config.reference_policy_kl_penalty > 0
 
     # Auto-enable skip_reference_policy_logprobs_calculation when the reference model is not loaded.
     if not init_reference_model and not grpo_config.get(
@@ -1750,9 +1750,7 @@ def grpo_train(
 
                 memory_tracker.snapshot_start_of_stage("Computing logprobs", dir())
                 # Skip prev_logprobs computation when force_on_policy_ratio=True
-                skip_prev_logprobs = master_config.loss_fn.get(
-                    "force_on_policy_ratio", False
-                )
+                skip_prev_logprobs = master_config.loss_fn.force_on_policy_ratio
                 if skip_prev_logprobs:
                     print(
                         "▶ Skipping prev_logprobs (force_on_policy_ratio=True)...",
@@ -2843,9 +2841,7 @@ def async_grpo_train(
 
                 # Training phase (same as sync version)
                 # Skip prev_logprobs computation when force_on_policy_ratio=True
-                skip_prev_logprobs = master_config.loss_fn.get(
-                    "force_on_policy_ratio", False
-                )
+                skip_prev_logprobs = master_config.loss_fn.force_on_policy_ratio
                 if skip_prev_logprobs:
                     print(
                         "▶ Skipping prev_logprobs (force_on_policy_ratio=True)...",

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1540,7 +1540,7 @@ def grpo_train(
                             input_batch=repeated_batch,
                             tokenizer=tokenizer,
                             task_to_env=task_to_env,
-                            max_seq_len=master_config["policy"][
+                            max_seq_len=master_config.policy[
                                 "max_total_sequence_length"
                             ],
                             generation_config=generation_config,
@@ -2307,7 +2307,7 @@ def validate(
                     input_batch=val_batch,
                     tokenizer=tokenizer,
                     task_to_env=val_task_to_env,
-                    max_seq_len=master_config["policy"]["max_total_sequence_length"],
+                    max_seq_len=master_config.policy["max_total_sequence_length"],
                     generation_config=generation_config,
                     max_rollout_turns=None,
                     greedy=False,
@@ -2862,7 +2862,7 @@ def async_grpo_train(
                         )["logprobs"]
                     train_data["prev_logprobs"] = fprop_logprobs
 
-                    if not master_config["grpo"].get(
+                    if not master_config.grpo.get(
                         "skip_reference_policy_logprobs_calculation"
                     ):
                         reference_logprobs = policy.get_reference_policy_logprobs(

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -15,6 +15,7 @@
 from typing import Any, NotRequired, Optional, TypedDict, TypeVar
 
 import torch
+from pydantic import BaseModel
 
 from nemo_rl.algorithms.loss.interfaces import LossFunction, LossInputType, LossType
 from nemo_rl.algorithms.utils import calculate_kl, masked_mean
@@ -79,39 +80,54 @@ class DraftCrossEntropyLossFn(LossFunction):
         )
 
 
-class ClippedPGLossConfig(TypedDict):
-    reference_policy_kl_penalty: float
-    reference_policy_kl_type: str
-    kl_input_clamp_value: float | None
-    kl_output_clamp_value: float | None
-    ratio_clip_min: float
-    ratio_clip_max: float
-    # Dual-clipping value (should be >1 if enabled; usually set to 3 empirically). None to disable.
-    ratio_clip_c: float | None
-    use_on_policy_kl_approximation: bool
-    use_importance_sampling_correction: bool
-    truncated_importance_sampling_ratio: float | None
-    # Type of truncated importance sampling:
-    #   "tis"          – clamp IS weights to max
-    #   "icepop"       – zero out tokens with IS weight outside [min, max]
-    #   "seq-mask-tis" – zero out sequences by geometric-mean IS ratio, non-truncated token IS correction
-    truncated_importance_sampling_type: NotRequired[str | None]
-    # Lower bound for ICE-POP / seq-mask-tis filtering
-    truncated_importance_sampling_ratio_min: NotRequired[float | None]
-    token_level_loss: bool
+class ClippedPGLossConfig(BaseModel, extra="allow"):
+    # --- Loss type ---
+    disable_ppo_ratio: bool = False
+    token_level_loss: bool = True
     # If True, apply the off-policy importance-sampling correction at the
     # sequence level (one weight per generated sample), as in GSPO.
     # If False (default), correction is applied at the token level as in the
     # original GRPO paper.
-    sequence_level_importance_ratios: NotRequired[bool]
-    disable_ppo_ratio: NotRequired[bool]
+    sequence_level_importance_ratios: bool = False
+
+    # --- Clipping ---
+    ratio_clip_min: float = 0.2
+    ratio_clip_max: float = 0.2
+    # Dual-clipping value (should be >1 if enabled; usually set to 3 empirically). None to disable.
+    ratio_clip_c: Optional[float] = None
+
+    # --- KL regularization ---
+    reference_policy_kl_penalty: float = 0.01
+    # Can be set to k1, k2, k3
+    # For more details, see http://joschu.net/blog/kl-approx.html
+    reference_policy_kl_type: str = "k3"
+    kl_input_clamp_value: Optional[float] = 20.0
+    kl_output_clamp_value: Optional[float] = 10.0
+    # If True, add KL penalty to reward instead of loss (used by Reinforce++)
+    use_kl_in_reward: bool = False
+
+    # --- Importance sampling correction ---
+    # Async GRPO requires importance sampling correction enabled
+    # Set to true when async_grpo.enabled is true
+    use_importance_sampling_correction: bool = False
+    # --- Truncated importance sampling ---
+    # Type of truncated importance sampling:
+    #   "tis"          – clamp IS weights to max
+    #   "icepop"       – zero out tokens with IS weight outside [min, max]
+    #   "seq-mask-tis" – zero out sequences by geometric-mean IS ratio, non-truncated token IS correction
+    truncated_importance_sampling_type: Optional[str] = "tis"
+    truncated_importance_sampling_ratio: Optional[float] = None
+    # Lower bound for ICE-POP / seq-mask-tis filtering
+    truncated_importance_sampling_ratio_min: Optional[float] = None
+
+    # --- On-policy ---
+    # (default off) loss formulation improvements (docs/guides/grpo.md#loss)
+    use_on_policy_kl_approximation: bool = False
     # If True, force the ratio to 1.0 for truly on-policy behavior,
     # eliminating any importance sampling effects.
     # NOTE: This should only be used when doing exactly one update per rollout
     # (i.e., num_prompts_per_step * num_generations_per_prompt == train_global_batch_size)
-    force_on_policy_ratio: NotRequired[bool]
-    # If True, add KL penalty to reward instead of loss (used by Reinforce++)
-    use_kl_in_reward: NotRequired[bool]
+    force_on_policy_ratio: bool = False
 
 
 class ClippedPGLossDataDict(TypedDict):
@@ -171,44 +187,37 @@ class ClippedPGLossFn(LossFunction):
     input_type = LossInputType.LOGPROB
 
     def __init__(self, cfg: ClippedPGLossConfig):
-        self.ratio_clip_min = cfg["ratio_clip_min"]
-        self.ratio_clip_max = cfg["ratio_clip_max"]
-        self.ratio_clip_c = cfg["ratio_clip_c"]  # set to None to disable dual-clipping
-        self.reference_policy_kl_penalty = cfg["reference_policy_kl_penalty"]
-        self.reference_policy_kl_type = cfg["reference_policy_kl_type"]
-        self.kl_input_clamp_value = cfg["kl_input_clamp_value"]
-        self.kl_output_clamp_value = cfg["kl_output_clamp_value"]
-        self.disable_ppo_ratio = cfg.get("disable_ppo_ratio", False)
-        self.force_on_policy_ratio = cfg.get(
-            "force_on_policy_ratio", False
-        )  # Force ratio to 1.0
-        self.use_on_policy_kl_approximation = cfg["use_on_policy_kl_approximation"]
-        self.use_importance_sampling_correction = cfg[
-            "use_importance_sampling_correction"
-        ]
-        self.truncated_importance_sampling_ratio = cfg[
-            "truncated_importance_sampling_ratio"
-        ]
+        self.disable_ppo_ratio = cfg.disable_ppo_ratio
+        self.ratio_clip_min = cfg.ratio_clip_min
+        self.ratio_clip_max = cfg.ratio_clip_max
+        self.ratio_clip_c = cfg.ratio_clip_c  # set to None to disable dual-clipping
+        self.reference_policy_kl_penalty = cfg.reference_policy_kl_penalty
+        self.reference_policy_kl_type = cfg.reference_policy_kl_type
+        self.kl_input_clamp_value = cfg.kl_input_clamp_value
+        self.kl_output_clamp_value = cfg.kl_output_clamp_value
+        self.use_importance_sampling_correction = cfg.use_importance_sampling_correction
         # Type of truncated importance sampling: "tis" | "icepop" | "seq-mask-tis"
-        self.truncated_importance_sampling_type = cfg.get(
-            "truncated_importance_sampling_type"
+        self.truncated_importance_sampling_type = cfg.truncated_importance_sampling_type
+        self.truncated_importance_sampling_ratio = (
+            cfg.truncated_importance_sampling_ratio
         )
         # Lower bound for ICE-POP / seq-mask-tis filtering
-        self.truncated_importance_sampling_ratio_min = cfg.get(
-            "truncated_importance_sampling_ratio_min"
+        self.truncated_importance_sampling_ratio_min = (
+            cfg.truncated_importance_sampling_ratio_min
         )
+        self.use_on_policy_kl_approximation = cfg.use_on_policy_kl_approximation
+        self.force_on_policy_ratio = cfg.force_on_policy_ratio  # Force ratio to 1.0
+
         # Whether to compute importance weights per-sequence instead of per-token.
-        self.sequence_level_importance_ratios = cfg.get(
-            "sequence_level_importance_ratios",
-            False,
-        )
+        self.sequence_level_importance_ratios = cfg.sequence_level_importance_ratios
         self.loss_type = (
-            LossType.TOKEN_LEVEL if cfg["token_level_loss"] else LossType.SEQUENCE_LEVEL
+            LossType.TOKEN_LEVEL if cfg.token_level_loss else LossType.SEQUENCE_LEVEL
         )
         if self.sequence_level_importance_ratios:
             assert self.loss_type == LossType.SEQUENCE_LEVEL, (
                 "sequence-level importance sampling (e.g. GSPO) is mutually exclusive with token-level loss"
             )
+
         if self.truncated_importance_sampling_ratio is not None:
             assert self.use_importance_sampling_correction, (
                 "truncated_importance_sampling_ratio is only supported when use_importance_sampling_correction is True"
@@ -232,9 +241,9 @@ class ClippedPGLossFn(LossFunction):
         else:
             # Warn user that TIS-related parameters are ignored when truncated_importance_sampling_ratio is not set
             ignored_params = []
-            if cfg.get("truncated_importance_sampling_type") is not None:
+            if self.truncated_importance_sampling_type is not None:
                 ignored_params.append("truncated_importance_sampling_type")
-            if cfg.get("truncated_importance_sampling_ratio_min") is not None:
+            if self.truncated_importance_sampling_ratio_min is not None:
                 ignored_params.append("truncated_importance_sampling_ratio_min")
             if ignored_params:
                 print(

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -115,7 +115,7 @@ class ClippedPGLossConfig(BaseModel, extra="allow"):
     #   "tis"          – clamp IS weights to max
     #   "icepop"       – zero out tokens with IS weight outside [min, max]
     #   "seq-mask-tis" – zero out sequences by geometric-mean IS ratio, non-truncated token IS correction
-    truncated_importance_sampling_type: Optional[str] = "tis"
+    truncated_importance_sampling_type: Optional[str] = None
     truncated_importance_sampling_ratio: Optional[float] = None
     # Lower bound for ICE-POP / seq-mask-tis filtering
     truncated_importance_sampling_ratio_min: Optional[float] = None
@@ -218,12 +218,9 @@ class ClippedPGLossFn(LossFunction):
                 "sequence-level importance sampling (e.g. GSPO) is mutually exclusive with token-level loss"
             )
 
-        if self.truncated_importance_sampling_ratio is not None:
+        if self.truncated_importance_sampling_type is not None:
             assert self.use_importance_sampling_correction, (
-                "truncated_importance_sampling_ratio is only supported when use_importance_sampling_correction is True"
-            )
-            assert self.truncated_importance_sampling_ratio > 0, (
-                "truncated_importance_sampling_ratio should be positive"
+                "truncated importance sampling is only supported when use_importance_sampling_correction is True"
             )
             assert self.truncated_importance_sampling_type in (
                 "tis",
@@ -233,24 +230,18 @@ class ClippedPGLossFn(LossFunction):
                 f"truncated_importance_sampling_type must be 'tis', 'icepop', or 'seq-mask-tis', "
                 f"got {self.truncated_importance_sampling_type}"
             )
+            assert (
+                self.truncated_importance_sampling_ratio is not None
+                and self.truncated_importance_sampling_ratio > 0
+            ), "truncated_importance_sampling_ratio should be positive"
+            if self.truncated_importance_sampling_type in ("icepop", "seq-mask-tis"):
+                assert self.truncated_importance_sampling_ratio_min is not None, (
+                    "truncated_importance_sampling_ratio_min should be set when truncated_importance_sampling_type is 'icepop' or 'seq-mask-tis'"
+                )
             if self.truncated_importance_sampling_type == "seq-mask-tis":
                 assert not self.sequence_level_importance_ratios, (
                     "seq-mask-tis uses token-level IS correction with sequence-level masking, "
                     "and is incompatible with sequence_level_importance_ratios=True"
-                )
-        else:
-            # Warn user that TIS-related parameters are ignored when truncated_importance_sampling_ratio is not set
-            ignored_params = []
-            if self.truncated_importance_sampling_type is not None:
-                ignored_params.append("truncated_importance_sampling_type")
-            if self.truncated_importance_sampling_ratio_min is not None:
-                ignored_params.append("truncated_importance_sampling_ratio_min")
-            if ignored_params:
-                print(
-                    f"[WARN] truncated_importance_sampling_ratio is not set, so the following "
-                    f"parameters are ignored: {', '.join(ignored_params)}. "
-                    f"Set truncated_importance_sampling_ratio to enable truncated importance sampling.",
-                    flush=True,
                 )
 
     def __call__(

--- a/nemo_rl/algorithms/rm.py
+++ b/nemo_rl/algorithms/rm.py
@@ -316,7 +316,7 @@ def validate_one_dataset(
     """Run validation on one validation dataset."""
     if val_dataloader is None:
         assert val_dataloader is not None or master_config.rm["val_period"] == 0, (
-            "val_dataloader is None, so dpo.val_period must be 0"
+            "val_dataloader is None, so rm.val_period must be 0"
         )
         print("  ⚠️ No validation dataloader provided, skipping validation")
         return

--- a/nemo_rl/algorithms/rm.py
+++ b/nemo_rl/algorithms/rm.py
@@ -315,7 +315,7 @@ def validate_one_dataset(
 ):
     """Run validation on one validation dataset."""
     if val_dataloader is None:
-        assert val_dataloader is not None or master_config.dpo["val_period"] == 0, (
+        assert val_dataloader is not None or master_config.rm["val_period"] == 0, (
             "val_dataloader is None, so dpo.val_period must be 0"
         )
         print("  ⚠️ No validation dataloader provided, skipping validation")

--- a/nemo_rl/algorithms/rm.py
+++ b/nemo_rl/algorithms/rm.py
@@ -130,7 +130,7 @@ def setup(
     #         Logger
     # ==========================
     logger = Logger(logger_config)
-    logger.log_hyperparams(master_config)
+    logger.log_hyperparams(master_config.model_dump())
 
     # ==========================
     #      Checkpointing

--- a/nemo_rl/algorithms/rm.py
+++ b/nemo_rl/algorithms/rm.py
@@ -19,6 +19,7 @@ from typing import Optional, TypedDict
 
 import numpy as np
 import torch
+from pydantic import BaseModel
 from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import AutoTokenizer
 
@@ -70,7 +71,7 @@ class RMConfig(TypedDict):
     seed: int
 
 
-class MasterConfig(TypedDict):
+class MasterConfig(BaseModel, extra="allow"):
     policy: PolicyConfig
     data: DataConfig
     rm: RMConfig
@@ -111,19 +112,19 @@ def setup(
     Returns:
         Tuple of policy, cluster, dataloader, tokenizer, loss_fn, math_env, master_config, logger
     """
-    set_seed(master_config["rm"]["seed"])
+    set_seed(master_config.rm["seed"])
 
     # Extract individual configs for easier access
-    policy_config = master_config["policy"]
-    checkpointing_pretrained = master_config.get("checkpointing", {}).get(
-        "pretrained_checkpoint"
-    )
+    policy_config = master_config.policy
+    data_config = master_config.data
+    rm_config = master_config.rm
+    logger_config = master_config.logger
+    cluster_config = master_config.cluster
+    checkpointing_config = master_config.checkpointing
+
+    checkpointing_pretrained = checkpointing_config.get("pretrained_checkpoint")
     if checkpointing_pretrained is not None:
         policy_config["pretrained_checkpoint"] = checkpointing_pretrained
-    data_config = master_config["data"]
-    logger_config = master_config["logger"]
-    cluster_config = master_config["cluster"]
-    rm_config = master_config["rm"]
 
     # ==========================
     #         Logger
@@ -134,7 +135,7 @@ def setup(
     # ==========================
     #      Checkpointing
     # ==========================
-    checkpointer = CheckpointManager(master_config["checkpointing"])
+    checkpointer = CheckpointManager(checkpointing_config)
     last_checkpoint_path = checkpointer.get_latest_checkpoint_path()
     rm_save_state: Optional[RMSaveState] = checkpointer.load_training_info(
         last_checkpoint_path
@@ -314,7 +315,7 @@ def validate_one_dataset(
 ):
     """Run validation on one validation dataset."""
     if val_dataloader is None:
-        assert val_dataloader is not None or master_config["dpo"]["val_period"] == 0, (
+        assert val_dataloader is not None or master_config.dpo["val_period"] == 0, (
             "val_dataloader is None, so dpo.val_period must be 0"
         )
         print("  ⚠️ No validation dataloader provided, skipping validation")
@@ -439,7 +440,7 @@ def rm_train(
     # Run basic rm training
     timer = Timer()
     timeout = TimeoutChecker(
-        timeout=master_config["checkpointing"]["checkpoint_must_save_by"],
+        timeout=master_config.checkpointing["checkpoint_must_save_by"],
         fit_last_save_time=True,
     )
     timeout.start_iterations()
@@ -457,7 +458,7 @@ def rm_train(
             "total_valid_tokens", 0
         )  # Default to 0 for backward compatibility with older checkpoints
 
-    rm_config = master_config["rm"]
+    rm_config = master_config.rm
     # Validation configuration
     val_period = rm_config["val_period"]
     val_at_start = rm_config["val_at_start"]
@@ -483,14 +484,14 @@ def rm_train(
     policy.prepare_for_training()
 
     while current_epoch < max_num_epochs and (
-        master_config["rm"]["max_num_steps"] == -1
-        or total_steps < master_config["rm"]["max_num_steps"]
+        master_config.rm["max_num_steps"] == -1
+        or total_steps < master_config.rm["max_num_steps"]
     ):
         print(f"\n{'=' * 25} Epoch {current_epoch + 1}/{max_num_epochs} {'=' * 25}")
 
         for batch in train_dataloader:
             print(
-                f"\n{'=' * 25} Step {current_step + 1}/{min(len(train_dataloader), master_config['rm']['max_num_steps'] if master_config['rm']['max_num_steps'] != -1 else len(train_dataloader))} {'=' * 25}"
+                f"\n{'=' * 25} Step {current_step + 1}/{min(len(train_dataloader), master_config.rm['max_num_steps'] if master_config.rm['max_num_steps'] != -1 else len(train_dataloader))} {'=' * 25}"
             )
             maybe_gpu_profile_step(policy, total_steps + 1)
             val_metrics, validation_timings = None, None
@@ -505,14 +506,14 @@ def rm_train(
                     eval_mode=False,
                     ## NOTE: we double the batch size here because each preference example corresponds to a pair of
                     ## examples, chosen and rejected, and the pair needs to be processed as part of the same microbatch.
-                    gbs=master_config["policy"]["train_global_batch_size"] * 2,
-                    mbs=master_config["policy"]["train_micro_batch_size"] * 2,
+                    gbs=master_config.policy["train_global_batch_size"] * 2,
+                    mbs=master_config.policy["train_micro_batch_size"] * 2,
                     timer=timer,
                 )
 
                 is_last_step = (
-                    master_config["rm"]["max_num_steps"] != -1
-                    and total_steps + 1 >= master_config["rm"]["max_num_steps"]
+                    master_config.rm["max_num_steps"] != -1
+                    and total_steps + 1 >= master_config.rm["max_num_steps"]
                 ) or (
                     current_epoch + 1 == max_num_epochs
                     and current_step + 1 == len(train_dataloader)
@@ -549,18 +550,18 @@ def rm_train(
                 ## Checkpointing
                 timeout.mark_iteration()
 
-                rm_save_state["consumed_samples"] += master_config["policy"][
+                rm_save_state["consumed_samples"] += master_config.policy[
                     "train_global_batch_size"
                 ]
 
                 should_save_by_step = (
                     is_last_step
-                    or (total_steps + 1) % master_config["checkpointing"]["save_period"]
+                    or (total_steps + 1) % master_config.checkpointing["save_period"]
                     == 0
                 )
                 should_save_by_timeout = timeout.check_save()
 
-                if master_config["checkpointing"]["enabled"] and (
+                if master_config.checkpointing["enabled"] and (
                     should_save_by_step or should_save_by_timeout
                 ):
                     ## +1 because step is 0-indexed
@@ -585,7 +586,7 @@ def rm_train(
                     if val_metrics is not None:
                         rm_save_state.update(val_metrics)
 
-                    full_metric_name = master_config["checkpointing"]["metric_name"]
+                    full_metric_name = master_config.checkpointing["metric_name"]
                     if full_metric_name is not None:
                         assert full_metric_name.startswith(
                             "train:"
@@ -631,7 +632,7 @@ def rm_train(
                             tokenizer_path=os.path.join(
                                 checkpoint_path, "policy", "tokenizer"
                             ),
-                            checkpointing_cfg=master_config["checkpointing"],
+                            checkpointing_cfg=master_config.checkpointing,
                         )
                         torch.save(
                             train_dataloader.state_dict(),
@@ -662,8 +663,8 @@ def rm_train(
                     print(f"  • {k}: {v:.2f}s ({percent:.1f}%)")
 
             total_num_gpus = (
-                master_config["cluster"]["num_nodes"]
-                * master_config["cluster"]["gpus_per_node"]
+                master_config.cluster["num_nodes"]
+                * master_config.cluster["gpus_per_node"]
             )
             timing_metrics["valid_tokens_per_sec_per_gpu"] = (
                 metrics["global_valid_toks"] / total_time / total_num_gpus
@@ -679,8 +680,8 @@ def rm_train(
                 print("Timeout has been reached, stopping training early", flush=True)
                 return
             if (
-                master_config["rm"]["max_num_steps"] != -1
-                and total_steps >= master_config["rm"]["max_num_steps"]
+                master_config.rm["max_num_steps"] != -1
+                and total_steps >= master_config.rm["max_num_steps"]
             ):
                 print(
                     "Max number of steps has been reached, stopping training early",

--- a/nemo_rl/algorithms/sft.py
+++ b/nemo_rl/algorithms/sft.py
@@ -125,7 +125,7 @@ def setup(
     #         Logger
     # ==========================
     logger = Logger(logger_config)
-    logger.log_hyperparams(master_config)
+    logger.log_hyperparams(master_config.model_dump())
 
     # ==========================
     #      Checkpointing

--- a/nemo_rl/algorithms/sft.py
+++ b/nemo_rl/algorithms/sft.py
@@ -17,6 +17,7 @@ from typing import NotRequired, Optional, TypedDict, cast
 
 import numpy as np
 import torch
+from pydantic import BaseModel
 from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
@@ -73,7 +74,7 @@ class SFTConfig(TypedDict):
     seed: int
 
 
-class MasterConfig(TypedDict):
+class MasterConfig(BaseModel, extra="allow"):
     policy: PolicyConfig
     data: DataConfig
     sft: SFTConfig
@@ -106,19 +107,19 @@ def setup(
     Returns:
         Tuple of policy, cluster, dataloader, tokenizer, loss_fn, math_env, master_config, logger
     """
-    set_seed(master_config["sft"]["seed"])
+    set_seed(master_config.sft["seed"])
 
     # Extract individual configs for easier access
-    policy_config = master_config["policy"]
-    checkpointing_pretrained = master_config.get("checkpointing", {}).get(
-        "pretrained_checkpoint"
-    )
+    policy_config = master_config.policy
+    data_config = master_config.data
+    sft_config = master_config.sft
+    logger_config = master_config.logger
+    cluster_config = master_config.cluster
+    checkpointing_config = master_config.checkpointing
+
+    checkpointing_pretrained = checkpointing_config.get("pretrained_checkpoint")
     if checkpointing_pretrained is not None:
         policy_config["pretrained_checkpoint"] = checkpointing_pretrained
-    data_config = master_config["data"]
-    logger_config = master_config["logger"]
-    cluster_config = master_config["cluster"]
-    sft_config = master_config["sft"]
 
     # ==========================
     #         Logger
@@ -129,7 +130,7 @@ def setup(
     # ==========================
     #      Checkpointing
     # ==========================
-    checkpointer = CheckpointManager(master_config["checkpointing"])
+    checkpointer = CheckpointManager(checkpointing_config)
     last_checkpoint_path = checkpointer.get_latest_checkpoint_path()
     sft_save_state: Optional[SFTSaveState] = cast(
         Optional[SFTSaveState], checkpointer.load_training_info(last_checkpoint_path)
@@ -249,7 +250,7 @@ def validate(
 ):
     """Run validation on the validation dataset."""
     if val_dataloader is None:
-        assert master_config["sft"]["val_period"] <= 0, (
+        assert master_config.sft["val_period"] <= 0, (
             "val_dataloader is None, so sft.val_period must be <= 0"
         )
         print("  ⚠️ No validation dataloader provided, skipping validation")
@@ -277,7 +278,7 @@ def validate(
             cat_and_padded, input_lengths = batched_message_log_to_flat_message(
                 val_batch["message_log"],
                 pad_value_dict={"token_ids": tokenizer.pad_token_id},
-                make_sequence_length_divisible_by=master_config["policy"][
+                make_sequence_length_divisible_by=master_config.policy[
                     "make_sequence_length_divisible_by"
                 ],
             )
@@ -368,7 +369,7 @@ def sft_train(
     # Run basic sft training
     timer = Timer()
     timeout = TimeoutChecker(
-        timeout=master_config["checkpointing"]["checkpoint_must_save_by"],
+        timeout=master_config.checkpointing["checkpoint_must_save_by"],
         fit_last_save_time=True,
     )
     timeout.start_iterations()
@@ -387,7 +388,7 @@ def sft_train(
             "total_valid_tokens", 0
         )  # Default to 0 for backward compatibility with older checkpoints
 
-    sft_config = master_config["sft"]
+    sft_config = master_config.sft
     # Validation configuration
     val_period = sft_config["val_period"]
     val_at_start = sft_config["val_at_start"]
@@ -416,13 +417,13 @@ def sft_train(
 
     while (
         current_epoch < max_num_epochs
-        and total_steps < master_config["sft"]["max_num_steps"]
+        and total_steps < master_config.sft["max_num_steps"]
     ):
         print(f"\n{'=' * 25} Epoch {current_epoch + 1}/{max_num_epochs} {'=' * 25}")
 
         for batch in train_dataloader:
             print(
-                f"\n{'=' * 25} Step {current_step + 1}/{min(len(train_dataloader), master_config['sft']['max_num_steps'])} {'=' * 25}"
+                f"\n{'=' * 25} Step {current_step + 1}/{min(len(train_dataloader), master_config.sft['max_num_steps'])} {'=' * 25}"
             )
             maybe_gpu_profile_step(policy, total_steps + 1)
             val_metrics, validation_timings = None, None
@@ -440,7 +441,7 @@ def sft_train(
                     cat_and_padded, input_lengths = batched_message_log_to_flat_message(
                         batch["message_log"],
                         pad_value_dict={"token_ids": tokenizer.pad_token_id},
-                        make_sequence_length_divisible_by=master_config["policy"][
+                        make_sequence_length_divisible_by=master_config.policy[
                             "make_sequence_length_divisible_by"
                         ],
                     )
@@ -465,7 +466,7 @@ def sft_train(
                         timer=timer,
                     )
 
-                is_last_step = total_steps + 1 >= master_config["sft"][
+                is_last_step = total_steps + 1 >= master_config.sft[
                     "max_num_steps"
                 ] or (
                     current_epoch + 1 == max_num_epochs
@@ -510,20 +511,20 @@ def sft_train(
                 total_valid_tokens += metrics.get("global_valid_toks", 0)
 
                 ## Checkpointing
-                sft_save_state["consumed_samples"] += master_config["policy"][
+                sft_save_state["consumed_samples"] += master_config.policy[
                     "train_global_batch_size"
                 ]
                 timeout.mark_iteration()
                 should_save_by_step = (
                     is_last_step
-                    or (total_steps + 1) % master_config["checkpointing"]["save_period"]
+                    or (total_steps + 1) % master_config.checkpointing["save_period"]
                     == 0
                 )
                 # +1 because step is 0-indexed
                 # Check if timeout-based checkpointing is enabled in config.
                 should_save_by_timeout = timeout.check_save()
 
-                if master_config["checkpointing"]["enabled"] and (
+                if master_config.checkpointing["enabled"] and (
                     should_save_by_step or should_save_by_timeout
                 ):
                     sft_save_state["step"] = (current_step + 1) % len(train_dataloader)
@@ -531,7 +532,7 @@ def sft_train(
                     sft_save_state["epoch"] = current_epoch
                     sft_save_state["total_valid_tokens"] = total_valid_tokens
 
-                    full_metric_name = master_config["checkpointing"]["metric_name"]
+                    full_metric_name = master_config.checkpointing["metric_name"]
                     if full_metric_name is not None:
                         assert full_metric_name.startswith(
                             "train:"
@@ -577,7 +578,7 @@ def sft_train(
                             tokenizer_path=os.path.join(
                                 checkpoint_path, "policy", "tokenizer"
                             ),
-                            checkpointing_cfg=master_config["checkpointing"],
+                            checkpointing_cfg=master_config.checkpointing,
                         )
                         torch.save(
                             train_dataloader.state_dict(),
@@ -619,8 +620,8 @@ def sft_train(
                     print(f"  • {k}: {v:.2f}s ({percent:.1f}%)")
 
             total_num_gpus = (
-                master_config["cluster"]["num_nodes"]
-                * master_config["cluster"]["gpus_per_node"]
+                master_config.cluster["num_nodes"]
+                * master_config.cluster["gpus_per_node"]
             )
             if total_time > 0:
                 timing_metrics["valid_tokens_per_sec_per_gpu"] = (
@@ -638,7 +639,7 @@ def sft_train(
             if should_save_by_timeout:
                 print("Timeout has been reached, stopping training early", flush=True)
                 return
-            if total_steps >= master_config["sft"]["max_num_steps"]:
+            if total_steps >= master_config.sft["max_num_steps"]:
                 print(
                     "Max number of steps has been reached, stopping training early",
                     flush=True,

--- a/nemo_rl/algorithms/utils.py
+++ b/nemo_rl/algorithms/utils.py
@@ -594,9 +594,9 @@ def print_performance_metrics(
             else:
                 print(f"    - Generation Worker {dp_idx:3.0f}: {''.join(timeline)}")
 
-    is_vllm_metrics_logger_enabled = master_config["policy"]["generation"].get(
+    is_vllm_metrics_logger_enabled = master_config.policy["generation"].get(
         "vllm_cfg", {}
-    ).get("enable_vllm_metrics_logger", False) and master_config["policy"][
+    ).get("enable_vllm_metrics_logger", False) and master_config.policy[
         "generation"
     ].get("vllm_cfg", {}).get("async_engine", False)
     generation_logger_metrics = metrics.get("generation_logger_metrics", {})
@@ -618,9 +618,9 @@ def print_performance_metrics(
             "num_pending_samples must be a dictionary"
         )
 
-        vllm_metrics_logger_interval = master_config["policy"]["generation"][
-            "vllm_cfg"
-        ]["vllm_metrics_logger_interval"]
+        vllm_metrics_logger_interval = master_config.policy["generation"]["vllm_cfg"][
+            "vllm_metrics_logger_interval"
+        ]
         print("  • vLLM Logger Metrics:")
         # Visualize the inflight batch sizes timeline
         if len(vllm_logger_metrics["inflight_batch_sizes"].values()) > 0:
@@ -666,14 +666,15 @@ def print_performance_metrics(
             + timing_metrics["policy_training"]
         )
 
-    num_nodes = master_config["cluster"]["num_nodes"]
-    gpus_per_node = master_config["cluster"]["gpus_per_node"]
+    num_nodes = master_config.cluster["num_nodes"]
+    gpus_per_node = master_config.cluster["gpus_per_node"]
     total_num_gpus = num_nodes * gpus_per_node
-    colocated_inference = master_config["policy"]["generation"]["colocated"]["enabled"]
+    colocated_inference = master_config.policy["generation"]["colocated"]["enabled"]
 
     # Idle Time from Training Worker (Async GRPO only)
+    grpo_config = master_config.grpo
     if (
-        "async_grpo" in master_config and master_config["async_grpo"]["enabled"]
+        "async_grpo" in grpo_config and grpo_config["async_grpo"]["enabled"]
     ) and not colocated_inference:
         # async grpo
         exposed_generation_time = timing_metrics["exposed_generation"]
@@ -696,8 +697,7 @@ def print_performance_metrics(
         )
 
     number_of_samples_per_step = (
-        master_config["grpo"]["num_prompts_per_step"]
-        * master_config["grpo"]["num_generations_per_prompt"]
+        grpo_config["num_prompts_per_step"] * grpo_config["num_generations_per_prompt"]
     )
 
     if colocated_inference:
@@ -705,11 +705,11 @@ def print_performance_metrics(
         generation_num_gpus = total_num_gpus
     else:
         generation_num_nodes = (
-            master_config["policy"]["generation"]["colocated"]["resources"]["num_nodes"]
+            master_config.policy["generation"]["colocated"]["resources"]["num_nodes"]
             or 1
         )
         generation_num_gpus = (
-            master_config["policy"]["generation"]["colocated"]["resources"][
+            master_config.policy["generation"]["colocated"]["resources"][
                 "gpus_per_node"
             ]
             * generation_num_nodes

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -274,7 +274,7 @@ Output prompt token IDs: {output_item_dict["prompt_token_ids"]}
 
 
 def setup_nemo_gym_config(config, tokenizer) -> None:
-    generation_config = config["policy"]["generation"]
+    generation_config = config.policy["generation"]
 
     # Enable the http server. Requires both async engine and the expose_http_server flag
     generation_config["vllm_cfg"]["async_engine"] = True

--- a/nemo_rl/evals/eval.py
+++ b/nemo_rl/evals/eval.py
@@ -21,6 +21,7 @@ from typing import NotRequired, TypedDict
 
 import ray
 import torch
+from pydantic import BaseModel
 from torch.utils.data import DataLoader
 from transformers import AutoTokenizer
 
@@ -56,7 +57,7 @@ class _PassThroughEnvConfig(TypedDict):
     mmau: NotRequired[VLMEnvConfig]
 
 
-class MasterConfig(TypedDict):
+class MasterConfig(BaseModel, extra="allow"):
     eval: EvalConfig
     generation: GenerationConfig  # Fixed: was 'generate'
     tokenizer: TokenizerConfig  # Added missing tokenizer key
@@ -91,9 +92,9 @@ def setup(
         VLLM model, data loader, and config.
     """
     # Extract individual configs for easier access
-    eval_config = master_config["eval"]
-    generation_config = master_config["generation"]
-    cluster_config = master_config["cluster"]
+    eval_config = master_config.eval
+    generation_config = master_config.generation
+    cluster_config = master_config.cluster
 
     # Set seed for reproducibility
     set_seed(eval_config["seed"])
@@ -288,7 +289,7 @@ def run_env_eval(vllm_generation, dataloader, env, master_config):
         master_config: Configuration settings.
     """
     # Check if async engine is enabled and run appropriate version
-    if master_config["generation"]["vllm_cfg"]["async_engine"]:
+    if master_config.generation["vllm_cfg"]["async_engine"]:
         asyncio.run(
             _run_env_eval_impl(
                 vllm_generation, dataloader, env, master_config, use_async=True
@@ -307,8 +308,8 @@ async def _run_env_eval_impl(
 ):
     """Unified implementation for both sync and async evaluation."""
     # Extract for easier access
-    generation_config = master_config["generation"]
-    eval_config = master_config["eval"]
+    generation_config = master_config.generation
+    eval_config = master_config.eval
     metric = eval_config["metric"]
     num_tests_per_prompt = eval_config["num_tests_per_prompt"]
     k_value = eval_config["k_value"]
@@ -464,14 +465,14 @@ def _save_evaluation_data_to_json(evaluation_data, master_config, save_path):
     """
     # Extract configuration information
     config_data = {
-        "model_name": master_config["generation"]["model_name"],
-        "dataset_name": master_config["data"]["dataset_name"],
-        "metric": master_config["eval"]["metric"],
-        "k_value": master_config["eval"]["k_value"],
-        "num_tests_per_prompt": master_config["eval"]["num_tests_per_prompt"],
-        "temperature": master_config["generation"]["temperature"],
-        "top_p": master_config["generation"]["top_p"],
-        "top_k": master_config["generation"]["top_k"],
+        "model_name": master_config.generation["model_name"],
+        "dataset_name": master_config.data["dataset_name"],
+        "metric": master_config.eval["metric"],
+        "k_value": master_config.eval["k_value"],
+        "num_tests_per_prompt": master_config.eval["num_tests_per_prompt"],
+        "temperature": master_config.generation["temperature"],
+        "top_p": master_config.generation["top_p"],
+        "top_k": master_config.generation["top_k"],
     }
 
     # Create directory if it doesn't exist
@@ -522,10 +523,10 @@ def _print_results(
     num_tests_per_prompt,
 ):
     """Print evaluation results."""
-    dataset_name = os.path.basename(master_config["data"]["dataset_name"])
+    dataset_name = os.path.basename(master_config.data["dataset_name"])
     model_name = os.path.basename(generation_config["model_name"])
     max_new_tokens = generation_config["vllm_cfg"]["max_model_len"]
-    seed = master_config["eval"]["seed"]
+    seed = master_config.eval["seed"]
     temperature = generation_config["temperature"]
     top_p = generation_config["top_p"]
     top_k = generation_config["top_k"]

--- a/nemo_rl/utils/checkpoint.py
+++ b/nemo_rl/utils/checkpoint.py
@@ -29,6 +29,7 @@ from typing import Any, Literal, Mapping, NotRequired, Optional, TypedDict, Unio
 import numpy as np
 import torch
 import yaml
+from pydantic import BaseModel
 
 PathLike = Union[str, "os.PathLike[Any]"]
 
@@ -190,7 +191,7 @@ class CheckpointManager:
         self,
         step: int,
         training_info: Mapping[str, Any],
-        run_config: Optional[Mapping[str, Any]] = None,
+        run_config: Optional[BaseModel] = None,
     ) -> PathLike:
         """Initialize a temporary checkpoint directory.
 
@@ -203,7 +204,7 @@ class CheckpointManager:
         Args:
             step (int): The training step number.
             training_info (dict[str, Any]): Dictionary containing training metrics and info.
-            run_config (Optional[dict[str, Any]]): Optional configuration for the training run.
+            run_config (Optional[BaseModel]): Optional configuration for the training run.
 
         Returns:
             PathLike: Path to the temporary checkpoint directory.
@@ -224,7 +225,7 @@ class CheckpointManager:
         # save config
         if run_config is not None:
             with open(save_dir / "config.yaml", "w") as f:
-                yaml.safe_dump(run_config, f)
+                yaml.safe_dump(run_config.model_dump(), f)
 
         return Path(os.path.abspath(save_dir))
 

--- a/research/template_project/configs/grpo_math_1B.yaml
+++ b/research/template_project/configs/grpo_math_1B.yaml
@@ -14,6 +14,16 @@ grpo:
   max_val_samples: 256
   val_batch_size: 256
   seed: 42
+  use_dynamic_sampling: false
+  dynamic_sampling_max_gen_batches: 10
+  batch_multiplier: 1
+  reward_shaping:
+    enabled: false
+    overlong_buffer_length: 128
+    overlong_buffer_penalty: 1
+    max_response_length: ${policy.max_total_sequence_length}
+    stop_properly_penalty_coef: null
+
   # Advantage Estimator Configuration
   # Options: "grpo" (default) or "reinforce_plus_plus"
   adv_estimator:
@@ -21,13 +31,28 @@ grpo:
     normalize_rewards: ${grpo.normalize_rewards}
     use_leave_one_out_baseline: ${grpo.use_leave_one_out_baseline}
     minus_baseline: true  # Reinforce++-baseline specific: subtract per-prompt mean baseline
+  reward_scaling:
+    enabled: false
+    source_min: 0.0
+    source_max: 1.0
+    target_min: 0.0
+    target_max: 1.0
+  seq_logprob_error_threshold: null
+
   async_grpo:
     enabled: false # Set to true to enable async training mode
     # Max age (in training steps) for trajectories used in training
     max_trajectory_age_steps: 1
+    in_flight_weight_updates: false # Set to true to enable in-flight weight updates
+    recompute_kv_cache_after_weight_updates: false # Set to true to recompute kv cache after in-flight-weight-updates
 
 loss_fn:
   reference_policy_kl_penalty: 0.01
+  # Can be set to k1, k2, k3
+  # For more details, see http://joschu.net/blog/kl-approx.html
+  reference_policy_kl_type: "k3"
+  kl_input_clamp_value: 20.0
+  kl_output_clamp_value: 10.0
   ratio_clip_min: 0.2
   ratio_clip_max: 0.2
   ratio_clip_c: null
@@ -36,13 +61,18 @@ loss_fn:
   # Async GRPO requires importance sampling correction enabled
   # Set to true when async_grpo.enabled is true
   use_importance_sampling_correction: false
+  truncated_importance_sampling_ratio: null
+  truncated_importance_sampling_ratio_min: null  # Lower bound for ICE-POP
+  truncated_importance_sampling_type: tis  # "tis" (clamp to max) or "icepop" (filter outside [min, max])
   sequence_level_importance_ratios: false
   token_level_loss: true
+  force_on_policy_ratio: false  # Set to true to force ratio=1.0 (requires train_global_batch_size == num_prompts_per_step * num_generations_per_prompt)
+  use_kl_in_reward: false  # Reinforce++: add KL penalty to reward instead of loss
 
 checkpointing:
   enabled: true
   checkpoint_dir: "results/grpo"
-  metric_name: "val_reward"
+  metric_name: "val:accuracy" # one of "val:" or "train:" followed by the metric name
   higher_is_better: true
   keep_top_k: 3
   save_period: 10
@@ -55,10 +85,12 @@ policy:
   model_name: "Qwen/Qwen2.5-1.5B"
   tokenizer:
     name: ${policy.model_name} ## specify if you'd like to use a tokenizer different from the model's default
+    chat_template_kwargs: null # can be used to pass kwargs to the chat template, e.g., enable_thinking=true
+  hf_config_overrides: {} 
   train_global_batch_size: 512
   train_micro_batch_size: 4
   generation_batch_size: 32 # Only used when generating using HF backend
-  logprob_batch_size: 4
+  logprob_batch_size: ${policy.train_micro_batch_size}
   max_total_sequence_length: 512
   precision: "bfloat16"
   logprob_chunk_size: null
@@ -73,10 +105,31 @@ policy:
     tensor_parallel_size: 1
     context_parallel_size: 1
     custom_parallel_plan: null
+
+    # Automodel kwargs passed to from_pretrained.
+    # Uncomment force_hf if the custom model's adapter doesn't support per-tensor
+    # weight conversion (e.g. Qwen2, Llama). Auto-detected if not set.
+    # See https://github.com/NVIDIA-NeMo/RL/issues/2072
+    automodel_kwargs: {}
+      # force_hf: true
+
+    # LoRA (Low-Rank Adaptation) Configuration
+    lora_cfg:
+      enabled: False  # Set to True to enable LoRA fine-tuning
+      target_modules: []  # List of module names to apply LoRA (empty list with match_all_linear=true applies to all linear layers)
+      exclude_modules: []  # List of module names to exclude from LoRA
+      match_all_linear: true  # If True, applies LoRA to all linear layers (overrides target_modules)
+      dim: 8  # LoRA rank (r): lower rank = fewer parameters but less capacity. Typical values: 4, 8, 16, 32, 64
+      alpha: 32  # LoRA scaling factor: effective learning rate multiplier = alpha/dim. Typical values: 16, 32, 64
+      dropout: 0.0  # Dropout probability applied to LoRA layers (0.0 = no dropout)
+      dropout_position: "post"  # Where to apply dropout: "pre" (before LoRA) or "post" (after LoRA)
+      lora_A_init: "xavier"  # Initialization method for LoRA A matrix: "xavier" or "uniform"
+      use_triton: true  # Use Triton-optimized kernels for LoRA (faster but requires flash-attn). Disable when tensor_parallel_size > 1
   
   megatron_cfg:
     enabled: false
-    empty_unused_memory_level: 0
+    force_reconvert_from_hf: False # Set to True to force reconvert of the model from Hugging Face
+    empty_unused_memory_level: 1  # 1 is the minimum recommendation for RL since we almost always need to offload before beginning generation. Setting to 0 is faster, but you are more likely to run out of GPU memory.
     activation_checkpointing: false
     converter_type: "Qwen2ForCausalLM"
     tensor_model_parallel_size: 1
@@ -93,10 +146,29 @@ policy:
     moe_router_load_balancing_type: "none" # "seq_aux_loss" causes logprob error divergence for grpo
     moe_router_bias_update_rate: 0.0 # by default, disable bias updates for grpo
     moe_permute_fusion: true
-    #gives ~20% training perf speedup with sequence packing
+    # gives ~20% training perf speedup with sequence packing
     apply_rope_fusion: True
-    defer_fp32_logits: null
+    # gives ~25% training perf speedup with sequence packing and apply_rope_fusion
+    bias_activation_fusion: True
+    defer_fp32_logits: False
+    moe_per_layer_logging: False
+    moe_enable_deepep: false
+    moe_token_dispatcher_type: "alltoall"
+    moe_shared_expert_overlap: false
     gradient_accumulation_fusion: false
+
+    peft:
+      enabled: false
+      target_modules: []
+      exclude_modules: []
+      dim: 8
+      alpha: 32
+      dropout: 0.0
+      dropout_position: "post"
+      lora_A_init_method: "xavier"
+      lora_B_init_method: "zero"
+      a2a_experimental: false
+      lora_dtype: None
 
     optimizer:
       optimizer: "adam"
@@ -121,6 +193,10 @@ policy:
 
       clip_grad: ${policy.max_grad_norm}
 
+      # optimizer cpu offload
+      optimizer_cpu_offload: false
+      optimizer_offload_fraction: 0.0
+
     scheduler:
       start_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
       end_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
@@ -134,17 +210,23 @@ policy:
       grad_reduce_in_fp32: false
       overlap_grad_reduce: true
       overlap_param_gather: true
-      average_in_collective: true
       use_custom_fsdp: false
       data_parallel_sharding_strategy: "optim_grads_params"
 
-    fp8_cfg:
+    fp8_cfg: 
       enabled: false
       fp8: "e4m3"
       fp8_recipe: "blockwise"
       fp8_param: false
 
     env_vars: null
+
+  draft:
+    enabled: false
+    model_name: null
+    loss_weight: 0.1
+    num_layers: null
+    aux_layer_indices: null
 
   # See docs/design-docs/sequence-packing-and-dynamic-batching.md 
   # for more details on dynamic batching and sequence packing.
@@ -198,9 +280,18 @@ policy:
     top_k: null
     stop_token_ids: null
     stop_strings: null
+    mcore_generation_config:
+      buffer_size_gb: 10  # Total buffer size is 2x this value (active requests + paused requests)
+      num_cuda_graphs: 4  # Number of CUDA graphs to pre-compile for different batch sizes
+      block_size_tokens: 256  # Size of each KV cache block in tokens (affects memory granularity)
+      use_cuda_graphs_for_non_decode_steps: true  # Enable CUDA graphs for prefill/context processing
+      enable_chunked_prefill: true  # Split long prefills into chunks for better memory management
+      unified_memory_level: 0  # Unified memory usage level (0=disabled, higher values enable more aggressive paging)
+      max_tokens: 16384 # Maximum number of tokens to use in a single step. Analogous to vllm's max_num_batched_tokens
     vllm_cfg:
       async_engine: false
       precision: ${policy.precision}
+      kv_cache_dtype: "auto"
       tensor_parallel_size: 1
       pipeline_parallel_size: 1
       expert_parallel_size: 1  # When EP > 1, EP must be a multiple of TP since vLLM's EP = DP * TP
@@ -213,6 +304,8 @@ policy:
       use_deep_gemm: False
       num_last_layers_in_bf16: 0
       num_first_layers_in_bf16: 0
+      enable_vllm_metrics_logger: true # Set to true to enable vLLM internal metrics logger, turn off for better performance
+      vllm_metrics_logger_interval: 0.5 # Interval in seconds to collect vLLM logger metrics
     vllm_kwargs: {}
     colocated:
       # true: generation shares training GPUs
@@ -225,25 +318,52 @@ policy:
 
 data:
   max_input_seq_length: ${policy.max_total_sequence_length} # upper bound, real truncation occurs at vllm.max_model_len
-  prompt_file: "examples/prompts/cot.txt"
-  system_prompt_file: null
   shuffle: true
+  num_workers: 1
 
-  dataset_name: "OpenMathInstruct-2"
+  # use multiple dataloader for train
+  # see https://github.com/NVIDIA-NeMo/RL/blob/main/docs/guides/grpo.md#multiple-dataloaders for more details.
+  use_multiple_dataloader: false
+
+  # dataset
+  train:
+    dataset_name: OpenMathInstruct-2
+    split_validation_size: 0.05 # use 5% of the training data as validation data
+    seed: ${grpo.seed} # seed for train/validation split when split_validation_size > 0
+  validation: null
+  # default settings for all datasets
+  default:
+    prompt_file: "examples/prompts/cot.txt"
+    system_prompt_file: null
+    processor: "math_hf_data_processor"
+    env_name: "math"
+
+  # You can also use multiple datasets by using a list of datasets.
+  # See `examples/configs/grpo_multiple_datasets.yaml` for a full configuration example.
+
   # You can use custom response datasets for training and validation. For example:
-  #   data:
-  #     dataset_name: ResponseDataset
-  #     train_data_path: <PathToTrainingDataset>  # e.g., /path/to/local/dataset.jsonl or hf_org/hf_dataset_name (HuggingFace)
-  #     val_data_path: <PathToValidationDataset>
-  #     input_key: <QuestionKey>, default is "input"
-  #     output_key: <AnswerKey>, default is "output"
-  #     train_split: <TrainSplit>, default is None  # used for HuggingFace datasets
-  #     val_split: <ValSplit>, default is None  # used for HuggingFace datasets
+  # train:
+  #   # this dataset will override input_key and use the default values for other vars
+  #   data_path: /path/to/local/train_dataset.jsonl
+  #   input_key: question
+  # validation:
+  #   # this dataset will use the default values for other vars except data_path
+  #   data_path: /path/to/local/val_dataset.jsonl
+  # default:
+  #   # will use below vars as default values if dataset doesn't specify it
+  #   dataset_name: ResponseDataset
+  #   input_key: input
+  #   output_key: output
+  #   prompt_file: null
+  #   system_prompt_file: null
+  #   processor: "math_hf_data_processor"
+  #   env_name: math
   # See https://github.com/NVIDIA-NeMo/RL/blob/main/docs/guides/grpo.md#datasets for more details.
 
 env:
   math:
     num_workers: 8
+    math_verify_impl: "hf_math_verify"
 
 logger:
   log_dir: "logs"  # Base directory for all logs
@@ -263,6 +383,7 @@ logger:
   mlflow:
     experiment_name: "grpo-dev"
     run_name: "grpo-dev-logger"
+    tracking_uri: "http://localhost:5000"
   gpu_monitoring:
     collection_interval: 10  # How often to collect GPU usage metrics (in seconds)
     flush_interval: 10  # How often to flush GPU usage metrics to the loggers (in seconds)

--- a/research/template_project/configs/grpo_math_1B.yaml
+++ b/research/template_project/configs/grpo_math_1B.yaml
@@ -61,9 +61,12 @@ loss_fn:
   # Async GRPO requires importance sampling correction enabled
   # Set to true when async_grpo.enabled is true
   use_importance_sampling_correction: false
+  # "tis"          – clamp IS weights to max
+  # "icepop"       – zero out tokens with IS weight outside [min, max]
+  # "seq-mask-tis" – zero out sequences by geometric-mean IS ratio, non-truncated token IS correction
+  truncated_importance_sampling_type: null
   truncated_importance_sampling_ratio: null
   truncated_importance_sampling_ratio_min: null  # Lower bound for ICE-POP
-  truncated_importance_sampling_type: tis  # "tis" (clamp to max) or "icepop" (filter outside [min, max])
   sequence_level_importance_ratios: false
   token_level_loss: true
   force_on_policy_ratio: false  # Set to true to force ratio=1.0 (requires train_global_batch_size == num_prompts_per_step * num_generations_per_prompt)

--- a/research/template_project/single_update.py
+++ b/research/template_project/single_update.py
@@ -63,7 +63,7 @@ ACTOR_ENVIRONMENT_REGISTRY[
 
 def main(config: MasterConfig) -> None:
     # 0) Config
-    policy_config = config["policy"]
+    policy_config = config.policy
     tokenizer = get_tokenizer(policy_config["tokenizer"])
     policy_config["generation"] = configure_generation_config(
         policy_config["generation"], tokenizer
@@ -124,7 +124,7 @@ def main(config: MasterConfig) -> None:
 
     # Create tiny numeric batch and train with NLLLossFn
     print("\n▶ Creating tiny numeric batch and training with NLLLossFn...")
-    train_sentences = ["a b c d e hello", "a d f world"] * config["policy"][
+    train_sentences = ["a b c d e hello", "a d f world"] * config.policy[
         "train_global_batch_size"
     ]
     generation_prompts = [

--- a/research/template_project/single_update.py
+++ b/research/template_project/single_update.py
@@ -32,6 +32,7 @@ import argparse
 import os
 
 from omegaconf import OmegaConf
+from rich.pretty import pprint
 from template_project.data_utils import create_batch_from
 
 from nemo_rl.algorithms.grpo import MasterConfig, refit_policy_generation
@@ -74,10 +75,10 @@ def main(config: MasterConfig) -> None:
     init_ray()
     cluster = RayVirtualCluster(
         name="single_update_cluster",
-        bundle_ct_per_node_list=[config["cluster"]["gpus_per_node"]]
-        * config["cluster"]["num_nodes"],
+        bundle_ct_per_node_list=[config.cluster["gpus_per_node"]]
+        * config.cluster["num_nodes"],
         use_gpus=True,
-        num_gpus_per_node=config["cluster"]["gpus_per_node"],
+        num_gpus_per_node=config.cluster["gpus_per_node"],
         max_colocated_worker_groups=1
         if policy_config["generation"]["backend"] == "megatron"
         else 2,
@@ -113,7 +114,7 @@ def main(config: MasterConfig) -> None:
 
     # 4.2) Run a method on all workers in parallel with different data
     print("\n▶ Running a method on all workers in parallel with different data...")
-    worker_nums = config["cluster"]["gpus_per_node"] * config["cluster"]["num_nodes"]
+    worker_nums = config.cluster["gpus_per_node"] * config.cluster["num_nodes"]
     input_list = [i for i in range(worker_nums)]
     results = policy.run_all_workers_multiple_data("return_input", input=input_list)
     print(f"  ✓ Results for return_input: {results}")
@@ -225,9 +226,9 @@ if __name__ == "__main__":
         print(f"Overrides: {overrides}")
         config = parse_hydra_overrides(config, overrides)
 
-    config: MasterConfig = OmegaConf.to_container(config, resolve=True)
+    config = OmegaConf.to_container(config, resolve=True)
+    config = MasterConfig(**config)
     print("Applied CLI overrides")
-    from rich.pretty import pprint
 
     pprint(config)
 

--- a/skills/config-conventions/SKILL.md
+++ b/skills/config-conventions/SKILL.md
@@ -54,7 +54,7 @@ When accessing a `NotRequired` field, use an `in` check or `.get(key)` / `.get(k
 stop_properly_penalty_coef = cfg.get("stop_properly_penalty_coef", None)
 
 # Truthiness check for optional booleans
-if master_config["grpo"].get("skip_reference_policy_logprobs_calculation"):
+if master_config.grpo.get("skip_reference_policy_logprobs_calculation"):
     ...
 
 # Nested NotRequired: check presence at each level explicitly

--- a/tests/unit/algorithms/sequence_packing_gradient_actor.py
+++ b/tests/unit/algorithms/sequence_packing_gradient_actor.py
@@ -23,7 +23,11 @@ from unittest.mock import MagicMock
 import ray
 import torch
 
-from nemo_rl.algorithms.loss import ClippedPGLossFn, SequencePackingLossWrapper
+from nemo_rl.algorithms.loss import (
+    ClippedPGLossConfig,
+    ClippedPGLossFn,
+    SequencePackingLossWrapper,
+)
 from nemo_rl.algorithms.loss.utils import prepare_loss_input
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 
@@ -125,21 +129,10 @@ class SequencePackingGradientTestActor:
             batch_size, max_seq_len, vocab_size, requires_grad=True, device="cuda"
         )
 
-        loss_config = {
-            "reference_policy_kl_penalty": 0.1,
-            "reference_policy_kl_type": "k3",
-            "kl_input_clamp_value": 20.0,
-            "kl_output_clamp_value": 10.0,
-            "ratio_clip_min": 0.2,
-            "ratio_clip_max": 0.2,
-            "ratio_clip_c": 3.0,
-            "use_on_policy_kl_approximation": False,
-            "use_importance_sampling_correction": False,
-            "truncated_importance_sampling_ratio": None,
-            "sequence_level_importance_ratios": False,
-            "token_level_loss": True,
-            "force_on_policy_ratio": False,
-        }
+        loss_config = ClippedPGLossConfig(
+            reference_policy_kl_penalty=0.1,
+            ratio_clip_c=3.0,
+        )
 
         base_loss_fn = ClippedPGLossFn(loss_config)
         data_dict = BatchedDataDict(original_data)

--- a/tests/unit/algorithms/test_async_utils.py
+++ b/tests/unit/algorithms/test_async_utils.py
@@ -355,7 +355,7 @@ class TestAsyncTrajectoryCollector:
 
     def create_mock_config(self) -> MasterConfig:
         """Create a mock master config for testing."""
-        return {
+        config = {
             "grpo": {
                 "num_prompts_per_step": 2,
                 "num_generations_per_prompt": 3,
@@ -364,6 +364,7 @@ class TestAsyncTrajectoryCollector:
             },
             "policy": {"max_total_sequence_length": 512},
         }
+        return MasterConfig.model_construct(**config)
 
     def create_mock_batch(self, size: int = 2) -> BatchedDataDict[DatumSpec]:
         """Create a mock batch for testing."""
@@ -547,7 +548,7 @@ class TestAsyncUtilsIntegration:
 
     def create_mock_config(self) -> MasterConfig:
         """Create a mock master config for testing."""
-        return {
+        config = {
             "grpo": {
                 "num_prompts_per_step": 2,
                 "num_generations_per_prompt": 2,
@@ -556,6 +557,7 @@ class TestAsyncUtilsIntegration:
             },
             "policy": {"max_total_sequence_length": 512},
         }
+        return MasterConfig.model_construct(**config)
 
     def create_mock_batch(self, size: int = 2) -> BatchedDataDict[DatumSpec]:
         """Create a mock batch for testing."""

--- a/tests/unit/algorithms/test_distillation.py
+++ b/tests/unit/algorithms/test_distillation.py
@@ -20,6 +20,7 @@ from torchdata.stateful_dataloader import StatefulDataLoader
 
 import nemo_rl.algorithms.distillation as distil_mod
 from nemo_rl.algorithms.distillation import (
+    MasterConfig,
     _default_distillation_save_state,
     check_vocab_equality,
     distillation_train,
@@ -121,59 +122,61 @@ def mock_components():
     val_task_to_env = {"math": MagicMock()}
 
     # Create mock master config
-    master_config = {
-        "distillation": {
-            "max_num_steps": 5,
-            "max_num_epochs": 10,
-            "val_period": 100,
-            "val_batch_size": 1,
-            "val_at_start": False,
-            "val_at_end": False,
-            "max_val_samples": 10,
-            "topk_logits_k": 64,
-            "num_prompts_per_step": 1,
-            "num_generations_per_prompt": 1,
-            "max_rollout_turns": 0,  # No environment interaction needed for distillation
-            "seed": 42,
-        },
-        "policy": {
-            "train_global_batch_size": 1,
-            "make_sequence_length_divisible_by": 8,
-            "max_total_sequence_length": 2048,
-            "generation": {
-                "temperature": 1.0,
-                "top_p": 1.0,
-                "top_k": None,
-                "colocated": {
-                    "enabled": False,
+    master_config = MasterConfig.model_construct(
+        **{
+            "distillation": {
+                "max_num_steps": 5,
+                "max_num_epochs": 10,
+                "val_period": 100,
+                "val_batch_size": 1,
+                "val_at_start": False,
+                "val_at_end": False,
+                "max_val_samples": 10,
+                "topk_logits_k": 64,
+                "num_prompts_per_step": 1,
+                "num_generations_per_prompt": 1,
+                "max_rollout_turns": 0,  # No environment interaction needed for distillation
+                "seed": 42,
+            },
+            "policy": {
+                "train_global_batch_size": 1,
+                "make_sequence_length_divisible_by": 8,
+                "max_total_sequence_length": 2048,
+                "generation": {
+                    "temperature": 1.0,
+                    "top_p": 1.0,
+                    "top_k": None,
+                    "colocated": {
+                        "enabled": False,
+                    },
                 },
             },
-        },
-        "teacher": {
-            "model_name": "test-teacher",
-        },
-        "loss_fn": {
-            "kl_type": "forward",
-            "mixed_kl_weight": 0.5,
-            "zero_outside_topk": False,
-        },
-        "data": {
-            "dataset_name": "test_dataset",
-        },
-        "logger": {
-            "num_val_samples_to_print": 5,
-        },
-        "cluster": {
-            "num_nodes": 1,
-            "gpus_per_node": 2,
-        },
-        "checkpointing": {
-            "enabled": False,
-            "checkpoint_must_save_by": None,
-            "save_period": 10,
-            "metric_name": None,
-        },
-    }
+            "teacher": {
+                "model_name": "test-teacher",
+            },
+            "loss_fn": {
+                "kl_type": "forward",
+                "mixed_kl_weight": 0.5,
+                "zero_outside_topk": False,
+            },
+            "data": {
+                "dataset_name": "test_dataset",
+            },
+            "logger": {
+                "num_val_samples_to_print": 5,
+            },
+            "cluster": {
+                "num_nodes": 1,
+                "gpus_per_node": 2,
+            },
+            "checkpointing": {
+                "enabled": False,
+                "checkpoint_must_save_by": None,
+                "save_period": 10,
+                "metric_name": None,
+            },
+        }
+    )
 
     return {
         "student_policy": student_policy,
@@ -193,7 +196,7 @@ def mock_components():
 
 def test_distillation_train_max_steps(mock_components):
     """Test that training terminates correctly when maximum steps are reached."""
-    mock_components["master_config"]["distillation"]["max_num_steps"] = 5
+    mock_components["master_config"].distillation["max_num_steps"] = 5
 
     distillation_save_state = _default_distillation_save_state()
 
@@ -220,7 +223,7 @@ def test_distillation_train_max_steps(mock_components):
 def test_exit_on_timeout(mock_components, capsys):
     """Test that training loop exits when timeout is reached"""
     # Set max steps to large number
-    mock_components["master_config"]["distillation"]["max_num_steps"] = 100
+    mock_components["master_config"].distillation["max_num_steps"] = 100
 
     distillation_save_state = _default_distillation_save_state()
 
@@ -420,47 +423,49 @@ def test_noncolocated_inference_requires_explicit_gpus_per_node_single_node():
     from nemo_rl.algorithms.distillation import setup
 
     # Create minimal config with non-colocated inference but gpus_per_node=None
-    master_config = {
-        "policy": {
-            "generation": {
-                "temperature": 1.0,
-                "top_p": 1.0,
-                "top_k": None,
-                "backend": "vllm",
-                "colocated": {
-                    "enabled": False,  # Non-colocated
-                    "resources": {
-                        "gpus_per_node": None,  # This should trigger error
-                        "num_nodes": None,
+    master_config = MasterConfig.model_construct(
+        **{
+            "policy": {
+                "generation": {
+                    "temperature": 1.0,
+                    "top_p": 1.0,
+                    "top_k": None,
+                    "backend": "vllm",
+                    "colocated": {
+                        "enabled": False,  # Non-colocated
+                        "resources": {
+                            "gpus_per_node": None,  # This should trigger error
+                            "num_nodes": None,
+                        },
                     },
                 },
+                "dtensor_cfg": {
+                    "enabled": False,
+                },
             },
-            "dtensor_cfg": {
-                "enabled": False,
+            "teacher": {
+                "dtensor_cfg": {
+                    "enabled": False,
+                },
             },
-        },
-        "teacher": {
-            "dtensor_cfg": {
-                "enabled": False,
+            "loss_fn": {},
+            "distillation": {
+                "seed": 42,
+                "topk_logits_k": 64,
+                "num_prompts_per_step": 1,  # Config extraction requires this key
+                "val_period": 0,  # Config extraction requires this key
+                "val_at_start": False,  # Config extraction requires this key
+                "val_at_end": False,  # Config extraction requires this key
             },
-        },
-        "loss_fn": {},
-        "distillation": {
-            "seed": 42,
-            "topk_logits_k": 64,
-            "num_prompts_per_step": 1,  # Config extraction requires this key
-            "val_period": 0,  # Config extraction requires this key
-            "val_at_start": False,  # Config extraction requires this key
-            "val_at_end": False,  # Config extraction requires this key
-        },
-        "data": {"shuffle": False},
-        "logger": {},  # Config extraction requires this key
-        "checkpointing": {},  # Config extraction requires this key
-        "cluster": {
-            "num_nodes": 1,  # Single node
-            "gpus_per_node": 8,
-        },
-    }
+            "data": {"shuffle": False},
+            "logger": {},  # Config extraction requires this key
+            "checkpointing": {},  # Config extraction requires this key
+            "cluster": {
+                "num_nodes": 1,  # Single node
+                "gpus_per_node": 8,
+            },
+        }
+    )
 
     tokenizer = MagicMock()
     dataset = MagicMock()
@@ -488,52 +493,54 @@ def test_distillation_setup_non_colocated_smoke(monkeypatch):
     import nemo_rl.algorithms.distillation as distil_mod
 
     # Single node cluster; inference uses a subset of GPUs on same node
-    master_config = {
-        "policy": {
-            "generation": {
-                "temperature": 1.0,
-                "top_p": 1.0,
-                "top_k": None,
-                "backend": "vllm",
-                "colocated": {
-                    "enabled": False,
-                    "resources": {
-                        "gpus_per_node": 8,  # inference on 8 GPU
-                        "num_nodes": 1,
+    master_config = MasterConfig.model_construct(
+        **{
+            "policy": {
+                "generation": {
+                    "temperature": 1.0,
+                    "top_p": 1.0,
+                    "top_k": None,
+                    "backend": "vllm",
+                    "colocated": {
+                        "enabled": False,
+                        "resources": {
+                            "gpus_per_node": 8,  # inference on 8 GPU
+                            "num_nodes": 1,
+                        },
                     },
                 },
+                "dtensor_cfg": {
+                    "enabled": False,
+                },
+                "model_name": "test-policy",
             },
-            "dtensor_cfg": {
-                "enabled": False,
+            "teacher": {
+                "model_name": "test-teacher",
+                "dtensor_cfg": {
+                    "enabled": False,
+                },
             },
-            "model_name": "test-policy",
-        },
-        "teacher": {
-            "model_name": "test-teacher",
-            "dtensor_cfg": {
-                "enabled": False,
+            "loss_fn": {
+                "kl_type": "forward",
+                "mixed_kl_weight": 0.5,
+                "zero_outside_topk": False,
             },
-        },
-        "loss_fn": {
-            "kl_type": "forward",
-            "mixed_kl_weight": 0.5,
-            "zero_outside_topk": False,
-        },
-        "distillation": {
-            "seed": 42,
-            "topk_logits_k": 64,
-            "num_prompts_per_step": 1,
-            "max_num_epochs": 10,
-            "max_num_steps": 100,
-            "val_period": 0,
-            "val_at_start": False,
-            "val_at_end": False,
-        },
-        "data": {"shuffle": False},
-        "logger": {},
-        "checkpointing": {},
-        "cluster": {"num_nodes": 2, "gpus_per_node": 8},
-    }
+            "distillation": {
+                "seed": 42,
+                "topk_logits_k": 64,
+                "num_prompts_per_step": 1,
+                "max_num_epochs": 10,
+                "max_num_steps": 100,
+                "val_period": 0,
+                "val_at_start": False,
+                "val_at_end": False,
+            },
+            "data": {"shuffle": False},
+            "logger": {},
+            "checkpointing": {},
+            "cluster": {"num_nodes": 2, "gpus_per_node": 8},
+        }
+    )
 
     tokenizer = MagicMock()
     dataset = MagicMock()
@@ -607,49 +614,51 @@ def test_noncolocated_inference_requires_explicit_gpus_per_node_multi_node():
     from nemo_rl.algorithms.distillation import setup
 
     # Create minimal config with non-colocated inference but gpus_per_node=None
-    master_config = {
-        "policy": {
-            "generation": {
-                "temperature": 1.0,
-                "top_p": 1.0,
-                "top_k": None,
-                "backend": "vllm",
-                "colocated": {
-                    "enabled": False,  # Non-colocated
-                    "resources": {
-                        "gpus_per_node": None,  # This should trigger error
-                        "num_nodes": 1,  # Use 1 node for inference
+    master_config = MasterConfig.model_construct(
+        **{
+            "policy": {
+                "generation": {
+                    "temperature": 1.0,
+                    "top_p": 1.0,
+                    "top_k": None,
+                    "backend": "vllm",
+                    "colocated": {
+                        "enabled": False,  # Non-colocated
+                        "resources": {
+                            "gpus_per_node": None,  # This should trigger error
+                            "num_nodes": 1,  # Use 1 node for inference
+                        },
                     },
                 },
+                "dtensor_cfg": {
+                    "enabled": False,
+                },
             },
-            "dtensor_cfg": {
-                "enabled": False,
+            "teacher": {
+                "dtensor_cfg": {
+                    "enabled": False,
+                },
             },
-        },
-        "teacher": {
-            "dtensor_cfg": {
-                "enabled": False,
+            "loss_fn": {},
+            "distillation": {
+                "seed": 42,
+                "topk_logits_k": 64,
+                "max_num_epochs": 10,
+                "max_num_steps": 100,
+                "num_prompts_per_step": 1,  # Config extraction requires this key
+                "val_period": 0,  # Config extraction requires this key
+                "val_at_start": False,  # Config extraction requires this key
+                "val_at_end": False,  # Config extraction requires this key
             },
-        },
-        "loss_fn": {},
-        "distillation": {
-            "seed": 42,
-            "topk_logits_k": 64,
-            "max_num_epochs": 10,
-            "max_num_steps": 100,
-            "num_prompts_per_step": 1,  # Config extraction requires this key
-            "val_period": 0,  # Config extraction requires this key
-            "val_at_start": False,  # Config extraction requires this key
-            "val_at_end": False,  # Config extraction requires this key
-        },
-        "data": {"shuffle": False},
-        "logger": {},  # Config extraction requires this key
-        "checkpointing": {},  # Config extraction requires this key
-        "cluster": {
-            "num_nodes": 2,  # Multi-node
-            "gpus_per_node": 8,
-        },
-    }
+            "data": {"shuffle": False},
+            "logger": {},  # Config extraction requires this key
+            "checkpointing": {},  # Config extraction requires this key
+            "cluster": {
+                "num_nodes": 2,  # Multi-node
+                "gpus_per_node": 8,
+            },
+        }
+    )
 
     tokenizer = MagicMock()
     dataset = MagicMock()

--- a/tests/unit/algorithms/test_dpo.py
+++ b/tests/unit/algorithms/test_dpo.py
@@ -20,6 +20,7 @@ import torch
 from torchdata.stateful_dataloader import StatefulDataLoader
 
 from nemo_rl.algorithms.dpo import (
+    MasterConfig,
     _default_dpo_save_state,
     add_ref_logprobs_to_data,
     dpo_train,
@@ -75,7 +76,9 @@ def test_add_logprobs_to_batch():
     mock_policy = MockPolicy(mock_logprobs)
 
     # Create a mock master config
-    mock_master_config = {"policy": {"train_micro_batch_size": 1}}
+    mock_master_config = MasterConfig.model_construct(
+        **{"policy": {"train_micro_batch_size": 1}}
+    )
 
     # Get the augmented batches
     augmented_batches = list(
@@ -174,36 +177,38 @@ def mock_dpo_components():
     checkpointer = MagicMock()
 
     # Create mock master config
-    master_config = {
-        "dpo": {
-            "max_num_steps": 5,
-            "max_num_epochs": 2,
-            "val_period": 100,
-            "val_batches": 1,
-            "val_global_batch_size": 1,
-            "val_micro_batch_size": 1,
-            "val_at_start": False,
-            "val_at_end": False,
-        },
-        "policy": {
-            "train_global_batch_size": 2,
-            "make_sequence_length_divisible_by": 1,
-            "reward_model_cfg": {
-                "enabled": True,
-                "reward_model_type": "bradley_terry",
+    master_config = MasterConfig.model_construct(
+        **{
+            "dpo": {
+                "max_num_steps": 5,
+                "max_num_epochs": 2,
+                "val_period": 100,
+                "val_batches": 1,
+                "val_global_batch_size": 1,
+                "val_micro_batch_size": 1,
+                "val_at_start": False,
+                "val_at_end": False,
             },
-            "train_micro_batch_size": 1,
-        },
-        "checkpointing": {
-            "enabled": False,
-            "checkpoint_must_save_by": None,
-            "save_period": 10,
-        },
-        "cluster": {
-            "num_nodes": 1,
-            "gpus_per_node": 1,
-        },
-    }
+            "policy": {
+                "train_global_batch_size": 2,
+                "make_sequence_length_divisible_by": 1,
+                "reward_model_cfg": {
+                    "enabled": True,
+                    "reward_model_type": "bradley_terry",
+                },
+                "train_micro_batch_size": 1,
+            },
+            "checkpointing": {
+                "enabled": False,
+                "checkpoint_must_save_by": None,
+                "save_period": 10,
+            },
+            "cluster": {
+                "num_nodes": 1,
+                "gpus_per_node": 1,
+            },
+        }
+    )
 
     return {
         "policy": policy,
@@ -220,7 +225,7 @@ def mock_dpo_components():
 def test_exit_on_max_steps(mock_dpo_components):
     """Test that training loop exits when max_num_steps is reached"""
     # Set max steps to 12, which is less than len(train_dataloader) * max_num_epochs
-    mock_dpo_components["master_config"]["dpo"]["max_num_steps"] = 12
+    mock_dpo_components["master_config"].dpo["max_num_steps"] = 12
 
     dpo_save_state = _default_dpo_save_state()
 
@@ -244,8 +249,8 @@ def test_exit_on_max_steps(mock_dpo_components):
 def test_exit_on_max_epochs(mock_dpo_components):
     """Test that training loop exits when max_num_epochs is reached"""
     # Set max epochs to 2 and max steps to a large number
-    mock_dpo_components["master_config"]["dpo"]["max_num_epochs"] = 2
-    mock_dpo_components["master_config"]["dpo"]["max_num_steps"] = 100
+    mock_dpo_components["master_config"].dpo["max_num_epochs"] = 2
+    mock_dpo_components["master_config"].dpo["max_num_steps"] = 100
 
     dpo_save_state = _default_dpo_save_state()
 
@@ -269,8 +274,8 @@ def test_exit_on_max_epochs(mock_dpo_components):
 def test_exit_on_timeout(mock_dpo_components, capsys):
     """Test that training loop exits when timeout is reached"""
     # Set max steps and epochs to large numbers
-    mock_dpo_components["master_config"]["dpo"]["max_num_steps"] = 100
-    mock_dpo_components["master_config"]["dpo"]["max_num_epochs"] = 10
+    mock_dpo_components["master_config"].dpo["max_num_steps"] = 100
+    mock_dpo_components["master_config"].dpo["max_num_epochs"] = 10
 
     dpo_save_state = _default_dpo_save_state()
 

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -1075,8 +1075,8 @@ def test_setup_sglang_sets_model_path_and_parallel_flag(
     grpo_mod.setup(master_config, tokenizer, dataset, None)
 
     assert (
-        master_config["policy"]["generation"]["sglang_cfg"]["model_path"]
-        == master_config["policy"]["model_name"]
+        master_config.policy["generation"]["sglang_cfg"]["model_path"]
+        == master_config.policy["model_name"]
     )
     assert logged["metrics"]["parallel_init_enabled"] == expected_parallel
 
@@ -1218,11 +1218,11 @@ def test_grpo_train_collects_generation_logger_metrics(
     )
 
     master_config = mock_grpo_components["master_config"]
-    master_config["grpo"]["max_num_steps"] = 1
-    master_config["grpo"]["max_num_epochs"] = 1
-    master_config["grpo"]["val_period"] = 0
-    master_config["grpo"]["val_at_start"] = False
-    master_config["grpo"]["use_dynamic_sampling"] = False
+    master_config.grpo["max_num_steps"] = 1
+    master_config.grpo["max_num_epochs"] = 1
+    master_config.grpo["val_period"] = 0
+    master_config.grpo["val_at_start"] = False
+    master_config.grpo["use_dynamic_sampling"] = False
 
     grpo_mod.grpo_train(
         mock_grpo_components["policy"],

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -783,24 +783,7 @@ def test_noncolocated_inference_requires_explicit_gpus_per_node_single_node():
                     },
                 },
             },
-            "loss_fn": ClippedPGLossConfig(
-                **{
-                    "ratio_clip_min": 0.2,
-                    "ratio_clip_max": 0.2,
-                    "ratio_clip_c": None,
-                    "disable_ppo_ratio": False,
-                    "reference_policy_kl_penalty": 0.0,
-                    "reference_policy_kl_type": "k3",
-                    "kl_input_clamp_value": 20.0,
-                    "kl_output_clamp_value": 10.0,
-                    "use_on_policy_kl_approximation": False,
-                    "use_importance_sampling_correction": False,
-                    "truncated_importance_sampling_ratio": None,
-                    "sequence_level_importance_ratios": False,
-                    "token_level_loss": True,
-                    "force_on_policy_ratio": False,
-                }
-            ),
+            "loss_fn": ClippedPGLossConfig(reference_policy_kl_penalty=0.0),
             "env": {},  # Config extraction requires this key
             "grpo": {
                 "seed": 42,
@@ -869,24 +852,7 @@ def test_noncolocated_inference_requires_explicit_gpus_per_node_multi_node():
                     },
                 },
             },
-            "loss_fn": ClippedPGLossConfig(
-                **{
-                    "ratio_clip_min": 0.2,
-                    "ratio_clip_max": 0.2,
-                    "ratio_clip_c": None,
-                    "disable_ppo_ratio": False,
-                    "reference_policy_kl_penalty": 0.0,
-                    "reference_policy_kl_type": "k3",
-                    "kl_input_clamp_value": 20.0,
-                    "kl_output_clamp_value": 10.0,
-                    "use_on_policy_kl_approximation": False,
-                    "use_importance_sampling_correction": False,
-                    "truncated_importance_sampling_ratio": None,
-                    "sequence_level_importance_ratios": False,
-                    "token_level_loss": True,
-                    "force_on_policy_ratio": False,
-                }
-            ),
+            "loss_fn": ClippedPGLossConfig(reference_policy_kl_penalty=0.0),
             "env": {},  # Config extraction requires this key
             "grpo": {
                 "seed": 42,
@@ -1050,11 +1016,7 @@ def test_setup_sglang_sets_model_path_and_parallel_flag(
                     },
                 },
             },
-            "loss_fn": {
-                "force_on_policy_ratio": False,
-                "use_importance_sampling_correction": False,
-                "reference_policy_kl_penalty": 0.0,
-            },
+            "loss_fn": ClippedPGLossConfig(reference_policy_kl_penalty=0.0),
             "env": {},
             "grpo": {
                 "seed": 1,
@@ -1515,25 +1477,10 @@ def mock_grpo_components():
     tokenizer = MagicMock()
     tokenizer.pad_token_id = 0
 
-    loss_fn = ClippedPGLossFn(
-        ClippedPGLossConfig(
-            **{
-                "reference_policy_kl_penalty": 0.01,
-                "reference_policy_kl_type": "k3",
-                "kl_input_clamp_value": 20.0,
-                "kl_output_clamp_value": 10.0,
-                "ratio_clip_min": 0.8,
-                "ratio_clip_max": 1.2,
-                "ratio_clip_c": 1.0,
-                "use_on_policy_kl_approximation": False,
-                "use_importance_sampling_correction": False,
-                "truncated_importance_sampling_ratio": None,
-                "sequence_level_importance_ratios": False,
-                "token_level_loss": True,
-                "force_on_policy_ratio": False,
-            }
-        ),
+    loss_config = ClippedPGLossConfig(
+        ratio_clip_min=0.8, ratio_clip_max=1.2, ratio_clip_c=1.0
     )
+    loss_fn = ClippedPGLossFn(loss_config)
     logger = MagicMock()
     checkpointer = MagicMock()
 

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -26,6 +26,7 @@ from nemo_rl.algorithms.advantage_estimator import (
     ReinforcePlusPlusAdvantageEstimator,
 )
 from nemo_rl.algorithms.grpo import (
+    MasterConfig,
     _default_grpo_save_state,
     async_grpo_train,
     compute_and_apply_seq_logprob_error_masking,
@@ -33,7 +34,7 @@ from nemo_rl.algorithms.grpo import (
     grpo_train,
     validate,
 )
-from nemo_rl.algorithms.loss import ClippedPGLossFn
+from nemo_rl.algorithms.loss import ClippedPGLossConfig, ClippedPGLossFn
 from nemo_rl.data.interfaces import DatumSpec, LLMMessageLogType
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.environments.interfaces import (
@@ -502,14 +503,16 @@ def test_dapo_dynamic_sampling_filters_nonzero_std():
     baseline = torch.tensor([0.67, 0.67, 0.67, 0.33, 0.33, 0.33])  # Mock baselines
 
     # Configuration for dynamic sampling
-    master_config = {
-        "grpo": {
-            "use_dynamic_sampling": True,
-            "num_prompts_per_step": 2,  # Want 2 prompts
-            "num_generations_per_prompt": 3,  # Each with 3 generations
-            "dynamic_sampling_max_gen_batches": 5,
+    master_config = MasterConfig.model_construct(
+        **{
+            "grpo": {
+                "use_dynamic_sampling": True,
+                "num_prompts_per_step": 2,  # Want 2 prompts
+                "num_generations_per_prompt": 3,  # Each with 3 generations
+                "dynamic_sampling_max_gen_batches": 5,
+            }
         }
-    }
+    )
 
     timer = Timer()
     dynamic_sampling_num_gen_batches = 1
@@ -568,14 +571,16 @@ def test_dapo_dynamic_sampling_filters_zero_std():
     )  # First prompt has zero std, second has non-zero
     baseline = torch.tensor([1.0, 1.0, 1.0, 0.33, 0.33, 0.33])
 
-    master_config = {
-        "grpo": {
-            "use_dynamic_sampling": True,
-            "num_prompts_per_step": 1,  # Want 1 prompt only
-            "num_generations_per_prompt": 3,
-            "dynamic_sampling_max_gen_batches": 5,
+    master_config = MasterConfig.model_construct(
+        **{
+            "grpo": {
+                "use_dynamic_sampling": True,
+                "num_prompts_per_step": 1,  # Want 1 prompt only
+                "num_generations_per_prompt": 3,
+                "dynamic_sampling_max_gen_batches": 5,
+            }
         }
-    }
+    )
 
     timer = Timer()
     dynamic_sampling_num_gen_batches = 1
@@ -642,14 +647,16 @@ def test_dapo_dynamic_sampling_batch_caching():
     std = torch.tensor([0.4, 0.4, 0.4])  # Only one prompt with non-zero std
     baseline = torch.tensor([0.5, 0.5, 0.5])
 
-    master_config = {
-        "grpo": {
-            "use_dynamic_sampling": True,
-            "num_prompts_per_step": 2,  # Need 2 prompts but only have 1
-            "num_generations_per_prompt": 3,
-            "dynamic_sampling_max_gen_batches": 5,
+    master_config = MasterConfig.model_construct(
+        **{
+            "grpo": {
+                "use_dynamic_sampling": True,
+                "num_prompts_per_step": 2,  # Need 2 prompts but only have 1
+                "num_generations_per_prompt": 3,
+                "dynamic_sampling_max_gen_batches": 5,
+            }
         }
-    }
+    )
 
     timer = Timer()
     dynamic_sampling_num_gen_batches = 1
@@ -722,14 +729,16 @@ def test_dapo_dynamic_sampling_disabled():
     baseline = torch.tensor([1.0, 1.0, 1.0, 0.33, 0.33, 0.33])
 
     # Disable dynamic sampling
-    master_config = {
-        "grpo": {
-            "use_dynamic_sampling": False,
-            "num_prompts_per_step": 2,
-            "num_generations_per_prompt": 3,
-            "dynamic_sampling_max_gen_batches": 5,
+    master_config = MasterConfig.model_construct(
+        **{
+            "grpo": {
+                "use_dynamic_sampling": False,
+                "num_prompts_per_step": 2,
+                "num_generations_per_prompt": 3,
+                "dynamic_sampling_max_gen_batches": 5,
+            }
         }
-    }
+    )
 
     timer = Timer()
     dynamic_sampling_num_gen_batches = 1
@@ -757,61 +766,65 @@ def test_noncolocated_inference_requires_explicit_gpus_per_node_single_node():
     from nemo_rl.algorithms.grpo import setup
 
     # Create minimal config - only what's needed before the validation we're testing
-    master_config = {
-        "policy": {
-            "generation": {
-                "temperature": 1.0,
-                "top_p": 1.0,
-                "top_k": None,
-                "backend": "vllm",
-                "colocated": {
-                    "enabled": False,  # Non-colocated
-                    "resources": {
-                        "gpus_per_node": None,  # This should trigger error
-                        "num_nodes": None,
+    master_config = MasterConfig.model_construct(
+        **{
+            "policy": {
+                "generation": {
+                    "temperature": 1.0,
+                    "top_p": 1.0,
+                    "top_k": None,
+                    "backend": "vllm",
+                    "colocated": {
+                        "enabled": False,  # Non-colocated
+                        "resources": {
+                            "gpus_per_node": None,  # This should trigger error
+                            "num_nodes": None,
+                        },
                     },
                 },
             },
-        },
-        "loss_fn": {
-            "ratio_clip_min": 0.2,
-            "ratio_clip_max": 0.2,
-            "ratio_clip_c": None,
-            "disable_ppo_ratio": False,
-            "reference_policy_kl_penalty": 0.0,
-            "reference_policy_kl_type": "k3",
-            "kl_input_clamp_value": 20.0,
-            "kl_output_clamp_value": 10.0,
-            "use_on_policy_kl_approximation": False,
-            "use_importance_sampling_correction": False,
-            "truncated_importance_sampling_ratio": None,
-            "sequence_level_importance_ratios": False,
-            "token_level_loss": True,
-            "force_on_policy_ratio": False,
-        },
-        "env": {},  # Config extraction requires this key
-        "grpo": {
-            "seed": 42,
-            "num_prompts_per_step": 1,
-            "val_period": 0,
-            "val_at_start": False,
-            "val_at_end": False,
-            "use_dynamic_sampling": False,
-            "batch_multiplier": 1,
-        },
-        "data": {
-            "shuffle": False,
-            "num_workers": 1,
-            "env_name": None,
-            "use_multiple_dataloader": False,
-        },
-        "logger": {},  # Config extraction requires this key
-        "checkpointing": {},  # Config extraction requires this key
-        "cluster": {
-            "num_nodes": 1,  # Single node, so policy_nodes=1
-            "gpus_per_node": 8,
-        },
-    }
+            "loss_fn": ClippedPGLossConfig(
+                **{
+                    "ratio_clip_min": 0.2,
+                    "ratio_clip_max": 0.2,
+                    "ratio_clip_c": None,
+                    "disable_ppo_ratio": False,
+                    "reference_policy_kl_penalty": 0.0,
+                    "reference_policy_kl_type": "k3",
+                    "kl_input_clamp_value": 20.0,
+                    "kl_output_clamp_value": 10.0,
+                    "use_on_policy_kl_approximation": False,
+                    "use_importance_sampling_correction": False,
+                    "truncated_importance_sampling_ratio": None,
+                    "sequence_level_importance_ratios": False,
+                    "token_level_loss": True,
+                    "force_on_policy_ratio": False,
+                }
+            ),
+            "env": {},  # Config extraction requires this key
+            "grpo": {
+                "seed": 42,
+                "num_prompts_per_step": 1,
+                "val_period": 0,
+                "val_at_start": False,
+                "val_at_end": False,
+                "use_dynamic_sampling": False,
+                "batch_multiplier": 1,
+            },
+            "data": {
+                "shuffle": False,
+                "num_workers": 1,
+                "env_name": None,
+                "use_multiple_dataloader": False,
+            },
+            "logger": {},  # Config extraction requires this key
+            "checkpointing": {},  # Config extraction requires this key
+            "cluster": {
+                "num_nodes": 1,  # Single node, so policy_nodes=1
+                "gpus_per_node": 8,
+            },
+        }
+    )
 
     tokenizer = MagicMock()
     dataset = MagicMock()
@@ -839,61 +852,65 @@ def test_noncolocated_inference_requires_explicit_gpus_per_node_multi_node():
     from nemo_rl.algorithms.grpo import setup
 
     # Create minimal config - only what's needed before the validation we're testing
-    master_config = {
-        "policy": {
-            "generation": {
-                "temperature": 1.0,
-                "top_p": 1.0,
-                "top_k": None,
-                "backend": "vllm",
-                "colocated": {
-                    "enabled": False,  # Non-colocated
-                    "resources": {
-                        "gpus_per_node": None,  # This should trigger error
-                        "num_nodes": 1,  # Use 1 node for inference
+    master_config = MasterConfig.model_construct(
+        **{
+            "policy": {
+                "generation": {
+                    "temperature": 1.0,
+                    "top_p": 1.0,
+                    "top_k": None,
+                    "backend": "vllm",
+                    "colocated": {
+                        "enabled": False,  # Non-colocated
+                        "resources": {
+                            "gpus_per_node": None,  # This should trigger error
+                            "num_nodes": 1,  # Use 1 node for inference
+                        },
                     },
                 },
             },
-        },
-        "loss_fn": {
-            "ratio_clip_min": 0.2,
-            "ratio_clip_max": 0.2,
-            "ratio_clip_c": None,
-            "disable_ppo_ratio": False,
-            "reference_policy_kl_penalty": 0.0,
-            "reference_policy_kl_type": "k3",
-            "kl_input_clamp_value": 20.0,
-            "kl_output_clamp_value": 10.0,
-            "use_on_policy_kl_approximation": False,
-            "use_importance_sampling_correction": False,
-            "truncated_importance_sampling_ratio": None,
-            "sequence_level_importance_ratios": False,
-            "token_level_loss": True,
-            "force_on_policy_ratio": False,
-        },
-        "env": {},  # Config extraction requires this key
-        "grpo": {
-            "seed": 42,
-            "num_prompts_per_step": 1,
-            "val_period": 0,
-            "val_at_start": False,
-            "val_at_end": False,
-            "use_dynamic_sampling": False,
-            "batch_multiplier": 1,
-        },
-        "data": {
-            "shuffle": False,
-            "num_workers": 1,
-            "env_name": None,
-            "use_multiple_dataloader": False,
-        },
-        "logger": {},  # Config extraction requires this key
-        "checkpointing": {},  # Config extraction requires this key
-        "cluster": {
-            "num_nodes": 2,  # Multi-node, so policy_nodes=1 after subtracting inference
-            "gpus_per_node": 8,
-        },
-    }
+            "loss_fn": ClippedPGLossConfig(
+                **{
+                    "ratio_clip_min": 0.2,
+                    "ratio_clip_max": 0.2,
+                    "ratio_clip_c": None,
+                    "disable_ppo_ratio": False,
+                    "reference_policy_kl_penalty": 0.0,
+                    "reference_policy_kl_type": "k3",
+                    "kl_input_clamp_value": 20.0,
+                    "kl_output_clamp_value": 10.0,
+                    "use_on_policy_kl_approximation": False,
+                    "use_importance_sampling_correction": False,
+                    "truncated_importance_sampling_ratio": None,
+                    "sequence_level_importance_ratios": False,
+                    "token_level_loss": True,
+                    "force_on_policy_ratio": False,
+                }
+            ),
+            "env": {},  # Config extraction requires this key
+            "grpo": {
+                "seed": 42,
+                "num_prompts_per_step": 1,
+                "val_period": 0,
+                "val_at_start": False,
+                "val_at_end": False,
+                "use_dynamic_sampling": False,
+                "batch_multiplier": 1,
+            },
+            "data": {
+                "shuffle": False,
+                "num_workers": 1,
+                "env_name": None,
+                "use_multiple_dataloader": False,
+            },
+            "logger": {},  # Config extraction requires this key
+            "checkpointing": {},  # Config extraction requires this key
+            "cluster": {
+                "num_nodes": 2,  # Multi-node, so policy_nodes=1 after subtracting inference
+                "gpus_per_node": 8,
+            },
+        }
+    )
 
     tokenizer = MagicMock()
     dataset = MagicMock()
@@ -1006,67 +1023,69 @@ def test_setup_sglang_sets_model_path_and_parallel_flag(
     if colocated_inference:
         generation_resources = {"gpus_per_node": None, "num_nodes": None}
 
-    master_config = {
-        "policy": {
-            "model_name": "fake-model",
-            "train_global_batch_size": 1,
-            "train_micro_batch_size": 1,
-            "max_total_sequence_length": 8,
-            "make_sequence_length_divisible_by": 1,
-            "dtensor_cfg": {"enabled": False},
-            "megatron_cfg": {"enabled": False, "pipeline_model_parallel_size": 1},
-            "generation": {
-                "temperature": 1.0,
-                "top_p": 1.0,
-                "top_k": None,
-                "backend": "sglang",
-                "colocated": {
-                    "enabled": colocated_inference,
-                    "resources": generation_resources,
-                },
-                "sglang_cfg": {
-                    "gpus_per_server": 1,
-                    "dp_size": 1,
-                    "pp_size": 1,
-                    "ep_size": 1,
+    master_config = MasterConfig.model_construct(
+        **{
+            "policy": {
+                "model_name": "fake-model",
+                "train_global_batch_size": 1,
+                "train_micro_batch_size": 1,
+                "max_total_sequence_length": 8,
+                "make_sequence_length_divisible_by": 1,
+                "dtensor_cfg": {"enabled": False},
+                "megatron_cfg": {"enabled": False, "pipeline_model_parallel_size": 1},
+                "generation": {
+                    "temperature": 1.0,
+                    "top_p": 1.0,
+                    "top_k": None,
+                    "backend": "sglang",
+                    "colocated": {
+                        "enabled": colocated_inference,
+                        "resources": generation_resources,
+                    },
+                    "sglang_cfg": {
+                        "gpus_per_server": 1,
+                        "dp_size": 1,
+                        "pp_size": 1,
+                        "ep_size": 1,
+                    },
                 },
             },
-        },
-        "loss_fn": {
-            "force_on_policy_ratio": False,
-            "use_importance_sampling_correction": False,
-            "reference_policy_kl_penalty": 0.0,
-        },
-        "env": {},
-        "grpo": {
-            "seed": 1,
-            "num_prompts_per_step": 1,
-            "num_generations_per_prompt": 1,
-            "max_num_steps": 1,
-            "max_num_epochs": 1,
-            "val_period": 0,
-            "val_batch_size": 1,
-            "val_at_start": False,
-            "val_at_end": False,
-            "max_val_samples": 1,
-            "use_dynamic_sampling": False,
-            "batch_multiplier": 1,
-            "normalize_rewards": False,
-            "use_leave_one_out_baseline": False,
-            "reward_scaling": {"enabled": False},
-            "reward_shaping": {"enabled": False},
-            "overlong_filtering": False,
-        },
-        "data": {
-            "shuffle": False,
-            "num_workers": 0,
-            "env_name": None,
-            "use_multiple_dataloader": False,
-        },
-        "logger": {"num_val_samples_to_print": 0},
-        "checkpointing": {"enabled": False},
-        "cluster": {"num_nodes": 1, "gpus_per_node": 4},
-    }
+            "loss_fn": {
+                "force_on_policy_ratio": False,
+                "use_importance_sampling_correction": False,
+                "reference_policy_kl_penalty": 0.0,
+            },
+            "env": {},
+            "grpo": {
+                "seed": 1,
+                "num_prompts_per_step": 1,
+                "num_generations_per_prompt": 1,
+                "max_num_steps": 1,
+                "max_num_epochs": 1,
+                "val_period": 0,
+                "val_batch_size": 1,
+                "val_at_start": False,
+                "val_at_end": False,
+                "max_val_samples": 1,
+                "use_dynamic_sampling": False,
+                "batch_multiplier": 1,
+                "normalize_rewards": False,
+                "use_leave_one_out_baseline": False,
+                "reward_scaling": {"enabled": False},
+                "reward_shaping": {"enabled": False},
+                "overlong_filtering": False,
+            },
+            "data": {
+                "shuffle": False,
+                "num_workers": 0,
+                "env_name": None,
+                "use_multiple_dataloader": False,
+            },
+            "logger": {"num_val_samples_to_print": 0},
+            "checkpointing": {"enabled": False},
+            "cluster": {"num_nodes": 1, "gpus_per_node": 4},
+        }
+    )
 
     tokenizer = MagicMock()
     dataset = MagicMock()
@@ -1497,21 +1516,23 @@ def mock_grpo_components():
     tokenizer.pad_token_id = 0
 
     loss_fn = ClippedPGLossFn(
-        {
-            "reference_policy_kl_penalty": 0.01,
-            "reference_policy_kl_type": "k3",
-            "kl_input_clamp_value": 20.0,
-            "kl_output_clamp_value": 10.0,
-            "ratio_clip_min": 0.8,
-            "ratio_clip_max": 1.2,
-            "ratio_clip_c": 1.0,
-            "use_on_policy_kl_approximation": False,
-            "use_importance_sampling_correction": False,
-            "truncated_importance_sampling_ratio": None,
-            "sequence_level_importance_ratios": False,
-            "token_level_loss": True,
-            "force_on_policy_ratio": False,
-        }
+        ClippedPGLossConfig(
+            **{
+                "reference_policy_kl_penalty": 0.01,
+                "reference_policy_kl_type": "k3",
+                "kl_input_clamp_value": 20.0,
+                "kl_output_clamp_value": 10.0,
+                "ratio_clip_min": 0.8,
+                "ratio_clip_max": 1.2,
+                "ratio_clip_c": 1.0,
+                "use_on_policy_kl_approximation": False,
+                "use_importance_sampling_correction": False,
+                "truncated_importance_sampling_ratio": None,
+                "sequence_level_importance_ratios": False,
+                "token_level_loss": True,
+                "force_on_policy_ratio": False,
+            }
+        ),
     )
     logger = MagicMock()
     checkpointer = MagicMock()
@@ -1533,70 +1554,73 @@ def mock_grpo_components():
         env.global_post_process_and_metrics.return_value = (mock_batch, {})
 
     # Create mock master config
-    master_config = {
-        "grpo": {
-            "max_num_steps": 5,
-            "max_num_epochs": 2,
-            "num_prompts_per_step": 1,
-            "num_generations_per_prompt": 1,
-            "max_rollout_turns": 1,
-            "val_period": 100,
-            "val_batch_size": 1,
-            "val_at_start": False,
-            "val_at_end": False,
-            "max_val_samples": 10,
-            "seed": 42,
-            "advantage_normalization": "global",
-            "use_leave_one_out_baseline": False,
-            "normalize_rewards": False,
-            "overlong_filtering": False,
-            "reward_scaling": {"enabled": False},
-            "reward_shaping": {"enabled": False},
-            "use_dynamic_sampling": False,
-            "async_grpo": {
-                "enabled": False,
-                "max_trajectory_age_steps": 1,
-            },
-            "seq_logprob_error_threshold": None,
-            "adv_estimator": {
-                "name": "grpo",
+    master_config = MasterConfig.model_construct(
+        **{
+            "grpo": {
+                "max_num_steps": 5,
+                "max_num_epochs": 2,
+                "num_prompts_per_step": 1,
+                "num_generations_per_prompt": 1,
+                "max_rollout_turns": 1,
+                "val_period": 100,
+                "val_batch_size": 1,
+                "val_at_start": False,
+                "val_at_end": False,
+                "max_val_samples": 10,
+                "seed": 42,
+                "advantage_normalization": "global",
                 "use_leave_one_out_baseline": False,
-                "normalize_rewards": True,
+                "normalize_rewards": False,
+                "overlong_filtering": False,
+                "reward_scaling": {"enabled": False},
+                "reward_shaping": {"enabled": False},
+                "use_dynamic_sampling": False,
+                "async_grpo": {
+                    "enabled": False,
+                    "max_trajectory_age_steps": 1,
+                },
+                "seq_logprob_error_threshold": None,
+                "adv_estimator": {
+                    "name": "grpo",
+                    "use_leave_one_out_baseline": False,
+                    "normalize_rewards": True,
+                },
             },
-        },
-        "policy": {
-            "train_global_batch_size": 1,
-            "train_micro_batch_size": 1,
-            "max_total_sequence_length": 2048,
-            "make_sequence_length_divisible_by": 1,
-            "generation": {
-                "temperature": 1.0,
-                "top_p": 1.0,
-                "top_k": None,
-                "backend": "vllm",
-                "colocated": {"enabled": True},
-                "vllm_cfg": {"async_engine": True},  # Support async mode
+            "policy": {
+                "train_global_batch_size": 1,
+                "train_micro_batch_size": 1,
+                "max_total_sequence_length": 2048,
+                "make_sequence_length_divisible_by": 1,
+                "generation": {
+                    "temperature": 1.0,
+                    "top_p": 1.0,
+                    "top_k": None,
+                    "backend": "vllm",
+                    "colocated": {"enabled": True},
+                    "vllm_cfg": {"async_engine": True},  # Support async mode
+                },
             },
-        },
-        "loss_fn": {
-            "use_importance_sampling_correction": True,  # Required for async mode
-        },
-        "checkpointing": {
-            "enabled": False,
-            "checkpoint_must_save_by": None,
-            "save_period": 10,
-        },
-        "cluster": {
-            "num_nodes": 1,
-            "gpus_per_node": 2,
-        },
-        "logger": {
-            "num_val_samples_to_print": 5,
-        },
-        "data": {
-            "use_multiple_dataloader": False,
-        },
-    }
+            "loss_fn": {
+                "use_importance_sampling_correction": True,  # Required for async mode
+            },
+            "checkpointing": {
+                "enabled": False,
+                "checkpoint_must_save_by": None,
+                "save_period": 10,
+            },
+            "cluster": {
+                "num_nodes": 1,
+                "gpus_per_node": 2,
+            },
+            "logger": {
+                "num_val_samples_to_print": 5,
+            },
+            "data": {
+                "use_multiple_dataloader": False,
+            },
+            "env": {},
+        }
+    )
 
     return {
         "policy": policy,
@@ -1616,12 +1640,12 @@ def mock_grpo_components():
 def test_grpo_exit_on_max_steps(mock_grpo_components, train_func):
     """Test that GRPO training loop exits when max_num_steps is reached"""
     # Set max steps to 12
-    mock_grpo_components["master_config"]["grpo"]["max_num_steps"] = 12
+    mock_grpo_components["master_config"].grpo["max_num_steps"] = 12
     grpo_save_state = _default_grpo_save_state()
 
     # Async GRPO requires non-colocated inference
     if train_func == async_grpo_train:
-        mock_grpo_components["master_config"]["policy"]["generation"]["colocated"][
+        mock_grpo_components["master_config"].policy["generation"]["colocated"][
             "enabled"
         ] = False
 
@@ -1689,8 +1713,8 @@ def test_grpo_exit_on_max_steps(mock_grpo_components, train_func):
 def test_grpo_exit_on_max_epochs(mock_grpo_components, train_func):
     """Test that GRPO training loop exits when max_num_epochs is reached"""
     # Set max epochs to 2 and max steps to a large number
-    mock_grpo_components["master_config"]["grpo"]["max_num_epochs"] = 2
-    mock_grpo_components["master_config"]["grpo"]["max_num_steps"] = 100
+    mock_grpo_components["master_config"].grpo["max_num_epochs"] = 2
+    mock_grpo_components["master_config"].grpo["max_num_steps"] = 100
 
     grpo_save_state = _default_grpo_save_state()
 
@@ -1740,13 +1764,13 @@ def test_grpo_exit_on_max_epochs(mock_grpo_components, train_func):
 def test_grpo_exit_on_timeout(mock_grpo_components, train_func, capsys):
     """Test that GRPO training loop exits when timeout is reached"""
     # Set max steps and epochs to large numbers
-    mock_grpo_components["master_config"]["grpo"]["max_num_steps"] = 100
-    mock_grpo_components["master_config"]["grpo"]["max_num_epochs"] = 10
+    mock_grpo_components["master_config"].grpo["max_num_steps"] = 100
+    mock_grpo_components["master_config"].grpo["max_num_epochs"] = 10
     grpo_save_state = _default_grpo_save_state()
 
     # Async GRPO requires non-colocated inference
     if train_func == async_grpo_train:
-        mock_grpo_components["master_config"]["policy"]["generation"]["colocated"][
+        mock_grpo_components["master_config"].policy["generation"]["colocated"][
             "enabled"
         ] = False
 
@@ -2201,27 +2225,29 @@ class TestValidateFunction:
         mock_logger.log_batched_dict_as_jsonl = MagicMock(side_effect=capture_log)
 
         # Mock config
-        mock_config = {
-            "grpo": {
-                "max_val_samples": 10,
-                "val_batch_size": 2,
-                "max_rollout_turns": 1,
-            },
-            "policy": {
-                "max_total_sequence_length": 2048,
-                "generation": {
-                    "temperature": 1.0,
-                    "top_p": 1.0,
-                    "top_k": None,
-                    "backend": "vllm",
-                    "colocated": {"enabled": True},
-                    "vllm_cfg": {"async_engine": False},
+        mock_config = MasterConfig.model_construct(
+            **{
+                "grpo": {
+                    "max_val_samples": 10,
+                    "val_batch_size": 2,
+                    "max_rollout_turns": 1,
                 },
-            },
-            "logger": {
-                "num_val_samples_to_print": 2,
-            },
-        }
+                "policy": {
+                    "max_total_sequence_length": 2048,
+                    "generation": {
+                        "temperature": 1.0,
+                        "top_p": 1.0,
+                        "top_k": None,
+                        "backend": "vllm",
+                        "colocated": {"enabled": True},
+                        "vllm_cfg": {"async_engine": False},
+                    },
+                },
+                "logger": {
+                    "num_val_samples_to_print": 2,
+                },
+            }
+        )
 
         mock_rollout_metrics = {"mean_gen_tokens_per_sample": 10.0}
 
@@ -2297,27 +2323,29 @@ class TestValidateFunction:
         mock_env.global_post_process_and_metrics.return_value = (mock_batch, {})
 
         # Mock config
-        mock_config = {
-            "grpo": {
-                "max_val_samples": 10,
-                "val_batch_size": 1,
-                "max_rollout_turns": 1,
-            },
-            "policy": {
-                "max_total_sequence_length": 2048,
-                "generation": {
-                    "temperature": 1.0,
-                    "top_p": 1.0,
-                    "top_k": None,
-                    "backend": "vllm",
-                    "colocated": {"enabled": True},
-                    "vllm_cfg": {"async_engine": False},
+        mock_config = MasterConfig.model_construct(
+            **{
+                "grpo": {
+                    "max_val_samples": 10,
+                    "val_batch_size": 1,
+                    "max_rollout_turns": 1,
                 },
-            },
-            "logger": {
-                "num_val_samples_to_print": 1,
-            },
-        }
+                "policy": {
+                    "max_total_sequence_length": 2048,
+                    "generation": {
+                        "temperature": 1.0,
+                        "top_p": 1.0,
+                        "top_k": None,
+                        "backend": "vllm",
+                        "colocated": {"enabled": True},
+                        "vllm_cfg": {"async_engine": False},
+                    },
+                },
+                "logger": {
+                    "num_val_samples_to_print": 1,
+                },
+            }
+        )
 
         mock_rollout_metrics = {"mean_gen_tokens_per_sample": 10.0}
 
@@ -2351,9 +2379,11 @@ class TestValidateFunction:
         mock_policy_gen = MagicMock()
         mock_tokenizer = MagicMock()
 
-        mock_config = {
-            "dpo": {"val_period": 0},  # Required for the assertion
-        }
+        mock_config = MasterConfig.model_construct(
+            **{
+                "dpo": {"val_period": 0},  # Required for the assertion
+            }
+        )
 
         val_metrics, timing = validate(
             mock_policy_gen,

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -1547,9 +1547,9 @@ def mock_grpo_components():
                     "vllm_cfg": {"async_engine": True},  # Support async mode
                 },
             },
-            "loss_fn": {
-                "use_importance_sampling_correction": True,  # Required for async mode
-            },
+            "loss_fn": ClippedPGLossConfig(
+                use_importance_sampling_correction=True  # Required for async mode
+            ),
             "checkpointing": {
                 "enabled": False,
                 "checkpoint_must_save_by": None,
@@ -1837,7 +1837,7 @@ def test_grpo_advantage_estimator_zero_std():
         "use_leave_one_out_baseline": False,
         "normalize_rewards": True,
     }
-    loss_config = {}
+    loss_config = ClippedPGLossConfig()
     estimator = GRPOAdvantageEstimator(estimator_config, loss_config)
 
     # prompt 0: all same rewards -> std=0; prompt 1: different rewards -> std>0
@@ -1876,7 +1876,7 @@ def test_grpo_advantage_estimator_tensor_shapes():
         "use_leave_one_out_baseline": False,
         "normalize_rewards": True,
     }
-    loss_config = {}
+    loss_config = ClippedPGLossConfig()
     estimator = GRPOAdvantageEstimator(estimator_config, loss_config)
 
     # Test with batch size 2
@@ -1923,7 +1923,7 @@ def test_grpo_advantage_estimator_negative_advantages():
         "use_leave_one_out_baseline": False,
         "normalize_rewards": True,
     }
-    loss_config = {}
+    loss_config = ClippedPGLossConfig()
     estimator = GRPOAdvantageEstimator(estimator_config, loss_config)
 
     # Rewards with values below and above mean
@@ -1957,7 +1957,7 @@ def test_grpo_advantage_estimator_zero_std_and_zero_advantage():
         "use_leave_one_out_baseline": False,
         "normalize_rewards": True,
     }
-    loss_config = {}
+    loss_config = ClippedPGLossConfig()
     estimator = GRPOAdvantageEstimator(estimator_config, loss_config)
 
     # All rewards identical -> std=0, all advantages=0
@@ -1986,7 +1986,7 @@ def test_grpo_advantage_estimator_small_nonzero_std():
         "use_leave_one_out_baseline": False,
         "normalize_rewards": True,
     }
-    loss_config = {}
+    loss_config = ClippedPGLossConfig()
     estimator = GRPOAdvantageEstimator(estimator_config, loss_config)
 
     # Small reward differences -> small std but non-zero
@@ -2022,7 +2022,7 @@ def test_gdpo_advantage_estimator_multiple_rewards():
         "use_leave_one_out_baseline": False,
         "normalize_rewards": True,
     }
-    loss_config = {}
+    loss_config = ClippedPGLossConfig()
     estimator = GDPOAdvantageEstimator(estimator_config, loss_config)
 
     prompt_ids = torch.tensor([[0], [0]])
@@ -2045,7 +2045,7 @@ def test_gdpo_advantage_estimator_single_reward():
         "use_leave_one_out_baseline": False,
         "normalize_rewards": True,
     }
-    loss_config = {}
+    loss_config = ClippedPGLossConfig()
     estimator = GDPOAdvantageEstimator(estimator_config, loss_config)
 
     prompt_ids = torch.tensor([[0], [0]])
@@ -2071,11 +2071,11 @@ def test_reinforce_plus_plus_global_normalization():
     estimator_config = {
         "minus_baseline": True,
     }
-    loss_config = {
-        "use_kl_in_reward": False,
-        "reference_policy_kl_penalty": 0.0001,
-        "reference_policy_kl_type": "k2",
-    }
+    loss_config = ClippedPGLossConfig(
+        use_kl_in_reward=False,
+        reference_policy_kl_penalty=0.0001,
+        reference_policy_kl_type="k2",
+    )
     estimator = ReinforcePlusPlusAdvantageEstimator(estimator_config, loss_config)
 
     prompt_ids = torch.tensor(

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -159,6 +159,183 @@ class StubAsyncTrajectoryCollector:
         return mock
 
 
+@pytest.fixture
+def mock_grpo_components():
+    # Create mock components
+    policy = MagicMock()
+    policy.train.return_value = {
+        "loss": torch.tensor(0.5),
+        "grad_norm": torch.tensor(1.0),
+        "all_mb_metrics": {
+            "loss": [0.5],
+            "policy_gradient_loss": [0.3],
+            "value_loss": [0.2],
+            "global_valid_toks": [10],
+            "token_mult_prob_error": [
+                1.0
+            ],  # Must be <= 1.05 to avoid logging extra plots
+            "gen_kl_error": [0.0001],
+        },
+    }
+    policy.generate.return_value = {
+        "output_ids": torch.randint(0, 100, (2, 20)),
+        "generation_lengths": torch.tensor([10, 15]),
+        "unpadded_sequence_lengths": torch.tensor([12, 18]),
+        "logprobs": torch.randn(2, 20),
+    }
+    policy.prepare_for_training.return_value = None
+    # Mock sharding annotations for async GRPO
+    policy.sharding_annotations.get_axis_size.return_value = 1  # data_parallel size
+
+    # Create mock batch with proper structure
+    mock_batch = BatchedDataDict[DatumSpec](
+        {
+            "message_log": [
+                [
+                    {
+                        "role": "user",
+                        "content": "test",
+                        "token_ids": torch.tensor([1, 2, 3]),
+                    },
+                ]
+            ],
+            "task_name": ["math"],
+            "extra_env_info": [{}],
+            "loss_multiplier": torch.tensor([1.0]),
+            "idx": torch.tensor([0]),
+            "length": torch.tensor([3]),  # Add length field for GRPO
+            "total_reward": torch.tensor(
+                [1.0]
+            ),  # Add total_reward for rollout processing
+        }
+    )
+
+    # Create mock dataloader with 10 batches
+    train_dataloader = MagicMock(spec=StatefulDataLoader)
+
+    def train_iter(self):
+        return iter([mock_batch] * 10)
+
+    train_dataloader.__iter__ = train_iter
+    train_dataloader.__len__ = MagicMock(return_value=10)
+
+    val_dataloader = MagicMock(spec=StatefulDataLoader)
+
+    def val_iter(self):
+        return iter([mock_batch] * 10)
+
+    val_dataloader.__iter__ = val_iter
+    val_dataloader.__len__ = MagicMock(return_value=10)
+
+    tokenizer = MagicMock()
+    tokenizer.pad_token_id = 0
+
+    loss_config = ClippedPGLossConfig(
+        ratio_clip_min=0.8, ratio_clip_max=1.2, ratio_clip_c=1.0
+    )
+    loss_fn = ClippedPGLossFn(loss_config)
+    logger = MagicMock()
+    checkpointer = MagicMock()
+
+    # Create mock environment
+    task_to_env = {"math": MagicMock()}
+    val_task_to_env = {"math": MagicMock()}
+
+    # Mock environment return values
+    for env in [task_to_env["math"], val_task_to_env["math"]]:
+        env.step.return_value = (
+            [{"role": "environment", "content": "correct"}],  # observations
+            [{}],  # metadata
+            [[]],  # next_stop_strings
+            [1.0],  # rewards
+            [True],  # terminateds
+            [None],  # answers
+        )
+        env.global_post_process_and_metrics.return_value = (mock_batch, {})
+
+    # Create mock master config
+    master_config = MasterConfig.model_construct(
+        **{
+            "grpo": {
+                "max_num_steps": 5,
+                "max_num_epochs": 2,
+                "num_prompts_per_step": 1,
+                "num_generations_per_prompt": 1,
+                "max_rollout_turns": 1,
+                "val_period": 100,
+                "val_batch_size": 1,
+                "val_at_start": False,
+                "val_at_end": False,
+                "max_val_samples": 10,
+                "seed": 42,
+                "advantage_normalization": "global",
+                "use_leave_one_out_baseline": False,
+                "normalize_rewards": False,
+                "overlong_filtering": False,
+                "reward_scaling": {"enabled": False},
+                "reward_shaping": {"enabled": False},
+                "use_dynamic_sampling": False,
+                "async_grpo": {
+                    "enabled": False,
+                    "max_trajectory_age_steps": 1,
+                },
+                "seq_logprob_error_threshold": None,
+                "adv_estimator": {
+                    "name": "grpo",
+                    "use_leave_one_out_baseline": False,
+                    "normalize_rewards": True,
+                },
+            },
+            "policy": {
+                "train_global_batch_size": 1,
+                "train_micro_batch_size": 1,
+                "max_total_sequence_length": 2048,
+                "make_sequence_length_divisible_by": 1,
+                "generation": {
+                    "temperature": 1.0,
+                    "top_p": 1.0,
+                    "top_k": None,
+                    "backend": "vllm",
+                    "colocated": {"enabled": True},
+                    "vllm_cfg": {"async_engine": True},  # Support async mode
+                },
+            },
+            "loss_fn": ClippedPGLossConfig(
+                use_importance_sampling_correction=True  # Required for async mode
+            ),
+            "checkpointing": {
+                "enabled": False,
+                "checkpoint_must_save_by": None,
+                "save_period": 10,
+            },
+            "cluster": {
+                "num_nodes": 1,
+                "gpus_per_node": 2,
+            },
+            "logger": {
+                "num_val_samples_to_print": 5,
+            },
+            "data": {
+                "use_multiple_dataloader": False,
+            },
+            "env": {},
+        }
+    )
+
+    return {
+        "policy": policy,
+        "train_dataloader": train_dataloader,
+        "val_dataloader": val_dataloader,
+        "tokenizer": tokenizer,
+        "loss_fn": loss_fn,
+        "logger": logger,
+        "checkpointer": checkpointer,
+        "task_to_env": task_to_env,
+        "val_task_to_env": val_task_to_env,
+        "master_config": master_config,
+    }
+
+
 def mock_async_grpo_infrastructure(mock_batch, mock_rollout_metrics):
     """
     Context manager that mocks all async GRPO infrastructure (Ray actors, venv, etc).
@@ -1241,16 +1418,16 @@ def test_grpo_train_skips_reference_policy_logprobs_when_configured(
     ``use_reference_model()`` because the reference model state was never loaded.
     """
     master_config = mock_grpo_components["master_config"]
-    master_config["grpo"]["skip_reference_policy_logprobs_calculation"] = True
-    master_config["loss_fn"]["reference_policy_kl_penalty"] = 0
-    master_config["grpo"]["max_num_steps"] = 1
-    master_config["grpo"]["max_num_epochs"] = 1
-    master_config["grpo"]["val_period"] = 0
-    master_config["grpo"]["val_at_start"] = False
-    master_config["grpo"]["use_dynamic_sampling"] = False
+    master_config.loss_fn.reference_policy_kl_penalty = 0
+    master_config.grpo["skip_reference_policy_logprobs_calculation"] = True
+    master_config.grpo["max_num_steps"] = 1
+    master_config.grpo["max_num_epochs"] = 1
+    master_config.grpo["val_period"] = 0
+    master_config.grpo["val_at_start"] = False
+    master_config.grpo["use_dynamic_sampling"] = False
 
     if train_func == async_grpo_train:
-        master_config["policy"]["generation"]["colocated"]["enabled"] = False
+        master_config.policy["generation"]["colocated"]["enabled"] = False
 
     grpo_save_state = _default_grpo_save_state()
     mock_rollout_metrics = {
@@ -1330,16 +1507,16 @@ def test_grpo_train_skips_prev_logprobs_when_force_on_policy_ratio(
     the prev-policy forward pass would be wasted compute.
     """
     master_config = mock_grpo_components["master_config"]
-    master_config["loss_fn"]["force_on_policy_ratio"] = True
-    master_config["grpo"]["seq_logprob_error_threshold"] = None
-    master_config["grpo"]["max_num_steps"] = 1
-    master_config["grpo"]["max_num_epochs"] = 1
-    master_config["grpo"]["val_period"] = 0
-    master_config["grpo"]["val_at_start"] = False
-    master_config["grpo"]["use_dynamic_sampling"] = False
+    master_config.loss_fn.force_on_policy_ratio = True
+    master_config.grpo["seq_logprob_error_threshold"] = None
+    master_config.grpo["max_num_steps"] = 1
+    master_config.grpo["max_num_epochs"] = 1
+    master_config.grpo["val_period"] = 0
+    master_config.grpo["val_at_start"] = False
+    master_config.grpo["use_dynamic_sampling"] = False
 
     if train_func == async_grpo_train:
-        master_config["policy"]["generation"]["colocated"]["enabled"] = False
+        master_config.policy["generation"]["colocated"]["enabled"] = False
 
     grpo_save_state = _default_grpo_save_state()
     mock_rollout_metrics = {
@@ -1406,195 +1583,18 @@ def test_grpo_train_skips_prev_logprobs_when_force_on_policy_ratio(
     )
 
 
-@pytest.fixture
-def mock_grpo_components():
-    # Create mock components
-    policy = MagicMock()
-    policy.train.return_value = {
-        "loss": torch.tensor(0.5),
-        "grad_norm": torch.tensor(1.0),
-        "all_mb_metrics": {
-            "loss": [0.5],
-            "policy_gradient_loss": [0.3],
-            "value_loss": [0.2],
-            "global_valid_toks": [10],
-            "token_mult_prob_error": [
-                1.0
-            ],  # Must be <= 1.05 to avoid logging extra plots
-            "gen_kl_error": [0.0001],
-        },
-    }
-    policy.generate.return_value = {
-        "output_ids": torch.randint(0, 100, (2, 20)),
-        "generation_lengths": torch.tensor([10, 15]),
-        "unpadded_sequence_lengths": torch.tensor([12, 18]),
-        "logprobs": torch.randn(2, 20),
-    }
-    policy.prepare_for_training.return_value = None
-    # Mock sharding annotations for async GRPO
-    policy.sharding_annotations.get_axis_size.return_value = 1  # data_parallel size
-
-    # Create mock batch with proper structure
-    mock_batch = BatchedDataDict[DatumSpec](
-        {
-            "message_log": [
-                [
-                    {
-                        "role": "user",
-                        "content": "test",
-                        "token_ids": torch.tensor([1, 2, 3]),
-                    },
-                ]
-            ],
-            "task_name": ["math"],
-            "extra_env_info": [{}],
-            "loss_multiplier": torch.tensor([1.0]),
-            "idx": torch.tensor([0]),
-            "length": torch.tensor([3]),  # Add length field for GRPO
-            "total_reward": torch.tensor(
-                [1.0]
-            ),  # Add total_reward for rollout processing
-        }
-    )
-
-    # Create mock dataloader with 10 batches
-    train_dataloader = MagicMock(spec=StatefulDataLoader)
-
-    def train_iter(self):
-        return iter([mock_batch] * 10)
-
-    train_dataloader.__iter__ = train_iter
-    train_dataloader.__len__ = MagicMock(return_value=10)
-
-    val_dataloader = MagicMock(spec=StatefulDataLoader)
-
-    def val_iter(self):
-        return iter([mock_batch] * 10)
-
-    val_dataloader.__iter__ = val_iter
-    val_dataloader.__len__ = MagicMock(return_value=10)
-
-    tokenizer = MagicMock()
-    tokenizer.pad_token_id = 0
-
-    loss_config = ClippedPGLossConfig(
-        ratio_clip_min=0.8, ratio_clip_max=1.2, ratio_clip_c=1.0
-    )
-    loss_fn = ClippedPGLossFn(loss_config)
-    logger = MagicMock()
-    checkpointer = MagicMock()
-
-    # Create mock environment
-    task_to_env = {"math": MagicMock()}
-    val_task_to_env = {"math": MagicMock()}
-
-    # Mock environment return values
-    for env in [task_to_env["math"], val_task_to_env["math"]]:
-        env.step.return_value = (
-            [{"role": "environment", "content": "correct"}],  # observations
-            [{}],  # metadata
-            [[]],  # next_stop_strings
-            [1.0],  # rewards
-            [True],  # terminateds
-            [None],  # answers
-        )
-        env.global_post_process_and_metrics.return_value = (mock_batch, {})
-
-    # Create mock master config
-    master_config = MasterConfig.model_construct(
-        **{
-            "grpo": {
-                "max_num_steps": 5,
-                "max_num_epochs": 2,
-                "num_prompts_per_step": 1,
-                "num_generations_per_prompt": 1,
-                "max_rollout_turns": 1,
-                "val_period": 100,
-                "val_batch_size": 1,
-                "val_at_start": False,
-                "val_at_end": False,
-                "max_val_samples": 10,
-                "seed": 42,
-                "advantage_normalization": "global",
-                "use_leave_one_out_baseline": False,
-                "normalize_rewards": False,
-                "overlong_filtering": False,
-                "reward_scaling": {"enabled": False},
-                "reward_shaping": {"enabled": False},
-                "use_dynamic_sampling": False,
-                "async_grpo": {
-                    "enabled": False,
-                    "max_trajectory_age_steps": 1,
-                },
-                "seq_logprob_error_threshold": None,
-                "adv_estimator": {
-                    "name": "grpo",
-                    "use_leave_one_out_baseline": False,
-                    "normalize_rewards": True,
-                },
-            },
-            "policy": {
-                "train_global_batch_size": 1,
-                "train_micro_batch_size": 1,
-                "max_total_sequence_length": 2048,
-                "make_sequence_length_divisible_by": 1,
-                "generation": {
-                    "temperature": 1.0,
-                    "top_p": 1.0,
-                    "top_k": None,
-                    "backend": "vllm",
-                    "colocated": {"enabled": True},
-                    "vllm_cfg": {"async_engine": True},  # Support async mode
-                },
-            },
-            "loss_fn": ClippedPGLossConfig(
-                use_importance_sampling_correction=True  # Required for async mode
-            ),
-            "checkpointing": {
-                "enabled": False,
-                "checkpoint_must_save_by": None,
-                "save_period": 10,
-            },
-            "cluster": {
-                "num_nodes": 1,
-                "gpus_per_node": 2,
-            },
-            "logger": {
-                "num_val_samples_to_print": 5,
-            },
-            "data": {
-                "use_multiple_dataloader": False,
-            },
-            "env": {},
-        }
-    )
-
-    return {
-        "policy": policy,
-        "train_dataloader": train_dataloader,
-        "val_dataloader": val_dataloader,
-        "tokenizer": tokenizer,
-        "loss_fn": loss_fn,
-        "logger": logger,
-        "checkpointer": checkpointer,
-        "task_to_env": task_to_env,
-        "val_task_to_env": val_task_to_env,
-        "master_config": master_config,
-    }
-
-
 @pytest.mark.parametrize("train_func", [grpo_train, async_grpo_train])
 def test_grpo_exit_on_max_steps(mock_grpo_components, train_func):
     """Test that GRPO training loop exits when max_num_steps is reached"""
     # Set max steps to 12
-    mock_grpo_components["master_config"].grpo["max_num_steps"] = 12
+    master_config = mock_grpo_components["master_config"]
+    master_config.grpo["max_num_steps"] = 12
+
     grpo_save_state = _default_grpo_save_state()
 
     # Async GRPO requires non-colocated inference
     if train_func == async_grpo_train:
-        mock_grpo_components["master_config"].policy["generation"]["colocated"][
-            "enabled"
-        ] = False
+        master_config.policy["generation"]["colocated"]["enabled"] = False
 
     # Prepare mock data
     mock_rollout_metrics = {
@@ -1619,7 +1619,7 @@ def test_grpo_exit_on_max_steps(mock_grpo_components, train_func):
                 mock_grpo_components["logger"],
                 mock_grpo_components["checkpointer"],
                 grpo_save_state,
-                mock_grpo_components["master_config"],
+                master_config,
             )
     else:
         # For sync grpo_train, just mock the rollout functions
@@ -1647,7 +1647,7 @@ def test_grpo_exit_on_max_steps(mock_grpo_components, train_func):
                         mock_grpo_components["logger"],
                         mock_grpo_components["checkpointer"],
                         grpo_save_state,
-                        mock_grpo_components["master_config"],
+                        master_config,
                     )
 
     # Verify we trained for exactly 12 steps
@@ -1660,8 +1660,9 @@ def test_grpo_exit_on_max_steps(mock_grpo_components, train_func):
 def test_grpo_exit_on_max_epochs(mock_grpo_components, train_func):
     """Test that GRPO training loop exits when max_num_epochs is reached"""
     # Set max epochs to 2 and max steps to a large number
-    mock_grpo_components["master_config"].grpo["max_num_epochs"] = 2
-    mock_grpo_components["master_config"].grpo["max_num_steps"] = 100
+    master_config = mock_grpo_components["master_config"]
+    master_config.grpo["max_num_epochs"] = 2
+    master_config.grpo["max_num_steps"] = 100
 
     grpo_save_state = _default_grpo_save_state()
 
@@ -1700,7 +1701,7 @@ def test_grpo_exit_on_max_epochs(mock_grpo_components, train_func):
                     mock_grpo_components["logger"],
                     mock_grpo_components["checkpointer"],
                     grpo_save_state,
-                    mock_grpo_components["master_config"],
+                    master_config,
                 )
 
     # Verify we trained for exactly two epochs (20 batches)
@@ -1711,15 +1712,15 @@ def test_grpo_exit_on_max_epochs(mock_grpo_components, train_func):
 def test_grpo_exit_on_timeout(mock_grpo_components, train_func, capsys):
     """Test that GRPO training loop exits when timeout is reached"""
     # Set max steps and epochs to large numbers
-    mock_grpo_components["master_config"].grpo["max_num_steps"] = 100
-    mock_grpo_components["master_config"].grpo["max_num_epochs"] = 10
+    master_config = mock_grpo_components["master_config"]
+    master_config.grpo["max_num_steps"] = 100
+    master_config.grpo["max_num_epochs"] = 10
+
     grpo_save_state = _default_grpo_save_state()
 
     # Async GRPO requires non-colocated inference
     if train_func == async_grpo_train:
-        mock_grpo_components["master_config"].policy["generation"]["colocated"][
-            "enabled"
-        ] = False
+        master_config.policy["generation"]["colocated"]["enabled"] = False
 
     # Prepare mock data
     mock_rollout_metrics = {
@@ -1751,7 +1752,7 @@ def test_grpo_exit_on_timeout(mock_grpo_components, train_func, capsys):
                     mock_grpo_components["logger"],
                     mock_grpo_components["checkpointer"],
                     grpo_save_state,
-                    mock_grpo_components["master_config"],
+                    master_config,
                 )
         else:
             with patch(
@@ -1778,7 +1779,7 @@ def test_grpo_exit_on_timeout(mock_grpo_components, train_func, capsys):
                             mock_grpo_components["logger"],
                             mock_grpo_components["checkpointer"],
                             grpo_save_state,
-                            mock_grpo_components["master_config"],
+                            master_config,
                         )
 
         # Verify training stopped at 8 steps (when check_save returned True)
@@ -2328,7 +2329,7 @@ class TestValidateFunction:
 
         mock_config = MasterConfig.model_construct(
             **{
-                "dpo": {"val_period": 0},  # Required for the assertion
+                "grpo": {"val_period": 0},  # Required for the assertion
             }
         )
 

--- a/tests/unit/algorithms/test_loss_functions.py
+++ b/tests/unit/algorithms/test_loss_functions.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import itertools
-from copy import deepcopy
 
 import pytest
 import torch
@@ -27,23 +26,6 @@ from nemo_rl.algorithms.loss import (
 )
 from nemo_rl.algorithms.utils import calculate_kl, masked_mean
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
-
-basic_pg_loss_test_config: ClippedPGLossConfig = {
-    "ratio_clip_min": 0.2,
-    "ratio_clip_max": 0.2,
-    "ratio_clip_c": None,
-    "disable_ppo_ratio": False,
-    "reference_policy_kl_penalty": 0.0,  # Disable KL
-    "reference_policy_kl_type": "k3",
-    "kl_input_clamp_value": 20.0,
-    "kl_output_clamp_value": 10.0,
-    "use_on_policy_kl_approximation": False,
-    "use_importance_sampling_correction": False,
-    "truncated_importance_sampling_ratio": None,  # Disable TIS
-    "sequence_level_importance_ratios": False,
-    "token_level_loss": True,
-    "force_on_policy_ratio": False,
-}
 
 
 def setup_dpo_loss_test_data(vocab_size=16, batch_size=1):
@@ -464,7 +446,7 @@ def test_clipped_pg_loss_ppo_clipping():
     device = "cuda"
     data, batch_size, seq_len, vocab_size = _setup_clipped_pg_test_data(device=device)
 
-    cfg = basic_pg_loss_test_config
+    cfg = ClippedPGLossConfig(reference_policy_kl_penalty=0.0)
     loss_fn = ClippedPGLossFn(cfg)
 
     adv_masked = torch.tensor([[1.0, -1.0, 2.0]], device=device)
@@ -488,7 +470,7 @@ def test_clipped_pg_loss_ppo_clipping():
     )
 
     ratios_clamped = torch.clamp(
-        ratios, 1.0 - cfg["ratio_clip_min"], 1.0 + cfg["ratio_clip_max"]
+        ratios, 1.0 - cfg.ratio_clip_min, 1.0 + cfg.ratio_clip_max
     )  # [0.8, 1.0, 1.2]
     assert torch.allclose(
         ratios_clamped, torch.tensor([[0.8, 1.0, 1.2]], device=device), rtol=1e-3
@@ -540,10 +522,12 @@ def test_clipped_pg_loss_reinforce_mode():
     device = "cuda"
     data, batch_size, seq_len, vocab_size = _setup_clipped_pg_test_data(device=device)
 
-    cfg = deepcopy(basic_pg_loss_test_config)
-    cfg["disable_ppo_ratio"] = True
-    cfg["ratio_clip_min"] = 0.0
-    cfg["ratio_clip_max"] = 0.0
+    cfg = ClippedPGLossConfig(
+        reference_policy_kl_penalty=0.0,
+        disable_ppo_ratio=True,
+        ratio_clip_min=0.0,
+        ratio_clip_max=0.0,
+    )
     loss_fn = ClippedPGLossFn(cfg)
 
     adv_masked = torch.tensor([[1.0, -1.0, 2.0]], device=device)
@@ -589,8 +573,9 @@ def test_clipped_pg_loss_force_on_policy_ratio():
     device = "cuda"
     data, batch_size, seq_len, vocab_size = _setup_clipped_pg_test_data(device=device)
 
-    cfg = deepcopy(basic_pg_loss_test_config)
-    cfg["force_on_policy_ratio"] = True
+    cfg = ClippedPGLossConfig(
+        reference_policy_kl_penalty=0.0, force_on_policy_ratio=True
+    )
     loss_fn = ClippedPGLossFn(cfg)
 
     # Use same logprob pattern as PPO clipping test to ensure
@@ -742,8 +727,7 @@ def test_clipped_pg_loss_kl_penalty():
     data, batch_size, seq_len, vocab_size = _setup_clipped_pg_test_data(device=device)
 
     # --- Test Setup ---
-    cfg = deepcopy(basic_pg_loss_test_config)
-    cfg["reference_policy_kl_penalty"] = 0.1
+    cfg = ClippedPGLossConfig(reference_policy_kl_penalty=0.1)
     loss_fn = ClippedPGLossFn(cfg)
 
     adv_masked = torch.tensor([[0.0, 0.0, 0.0]], device=device)
@@ -772,7 +756,7 @@ def test_clipped_pg_loss_kl_penalty():
         expected_kl_mean, torch.tensor(0.362, device=device), rtol=1e-3
     )
 
-    expected_loss = cfg["reference_policy_kl_penalty"] * expected_kl_mean  # 0.0362
+    expected_loss = cfg.reference_policy_kl_penalty * expected_kl_mean  # 0.0362
     assert torch.allclose(expected_loss, torch.tensor(0.0362, device=device), rtol=1e-3)
 
     input_ids = data["input_ids"]
@@ -817,8 +801,7 @@ def test_clipped_pg_loss_masking():
     # Make advantages non-zero
     data["advantages"] = torch.randn_like(data["advantages"]) + 1.0
 
-    cfg = deepcopy(basic_pg_loss_test_config)
-    cfg["reference_policy_kl_penalty"] = 0.1
+    cfg = ClippedPGLossConfig(reference_policy_kl_penalty=0.1)
     loss_fn = ClippedPGLossFn(cfg)  # Use original loss fn
     loss_input, data = prepare_loss_input(dummy_logits, data, loss_fn)
 
@@ -904,8 +887,7 @@ def test_clipped_pg_loss_zero_mask():
     # Need dummy logits
     dummy_logits = torch.randn(1, seq_len, vocab_size, device=device)
 
-    cfg = deepcopy(basic_pg_loss_test_config)
-    cfg["reference_policy_kl_penalty"] = 0.1
+    cfg = ClippedPGLossConfig(reference_policy_kl_penalty=0.1)
     loss_fn = ClippedPGLossFn(cfg)  # Use original loss fn
     loss_input, data = prepare_loss_input(dummy_logits, data, loss_fn)
 
@@ -933,9 +915,11 @@ def test_clipped_pg_loss_on_policy_kl_importance_sampling():
     device = "cuda"
     data, batch_size, seq_len, vocab_size = _setup_clipped_pg_test_data(device=device)
 
-    cfg = deepcopy(basic_pg_loss_test_config)
-    cfg["use_on_policy_kl_approximation"] = True
-    cfg["use_importance_sampling_correction"] = True
+    cfg = ClippedPGLossConfig(
+        reference_policy_kl_penalty=0.0,
+        use_on_policy_kl_approximation=True,
+        use_importance_sampling_correction=True,
+    )
     loss_fn = ClippedPGLossFn(cfg)
 
     adv_masked = torch.tensor([[1.0, -1.0, 2.0]], device=device)
@@ -972,7 +956,7 @@ def test_clipped_pg_loss_on_policy_kl_importance_sampling():
     )
 
     ratios_clamped = torch.clamp(
-        ratios, 1.0 - cfg["ratio_clip_min"], 1.0 + cfg["ratio_clip_max"]
+        ratios, 1.0 - cfg.ratio_clip_min, 1.0 + cfg.ratio_clip_max
     )  # [0.8, 1.0, 1.2]
     assert torch.allclose(
         ratios_clamped, torch.tensor([[0.8, 1.0, 1.2]], device=device), rtol=1e-3
@@ -1047,7 +1031,7 @@ def test_clipped_pg_loss_on_policy_kl_importance_sampling():
         importance_weighted_kl_term_per_token
     )  # mean([0.09308, 0.0, 0.08855]) = 0.060543
     expected_kl_loss = (
-        cfg["reference_policy_kl_penalty"] * expected_kl_mean
+        cfg.reference_policy_kl_penalty * expected_kl_mean
     )  # 0.1 * 0.060543 = 0.0060543
 
     expected_total_loss = (
@@ -1080,13 +1064,15 @@ def test_clipped_pg_loss_on_policy_truncated_importance_sampling(
     device = "cuda"
     data, batch_size, seq_len, vocab_size = _setup_clipped_pg_test_data(device=device)
 
-    cfg = deepcopy(basic_pg_loss_test_config)
-    cfg["use_importance_sampling_correction"] = True
-    cfg["truncated_importance_sampling_ratio"] = 0.8
-    cfg["truncated_importance_sampling_type"] = "tis"
+    cfg = ClippedPGLossConfig(
+        reference_policy_kl_penalty=0.0,
+        use_importance_sampling_correction=True,
+        truncated_importance_sampling_ratio=0.8,
+        truncated_importance_sampling_type="tis",
+    )
     if sequence_level_importance_ratios:
-        cfg["sequence_level_importance_ratios"] = True
-        cfg["token_level_loss"] = False
+        cfg.sequence_level_importance_ratios = True
+        cfg.token_level_loss = False
     loss_fn = ClippedPGLossFn(cfg)
 
     adv_masked = torch.tensor([[1.0, -1.0, 2.0]], device=device)
@@ -1116,8 +1102,8 @@ def test_clipped_pg_loss_on_policy_truncated_importance_sampling(
 
     # sequence-level: [[0.9086, 0.9086, 0.9086]]
     # token-level: [[0.8, 1.0, 1.2]]
-    clip_min = cfg["ratio_clip_min"]
-    clip_max = cfg["ratio_clip_max"]
+    clip_min = cfg.ratio_clip_min
+    clip_max = cfg.ratio_clip_max
     ratios_clamped = torch.clamp(ratios, 1.0 - clip_min, 1.0 + clip_max)
 
     # sequence-level: [[-0.9086, 0.9086, -1.8171]]
@@ -1156,7 +1142,7 @@ def test_clipped_pg_loss_on_policy_truncated_importance_sampling(
     # sequence-level: [[0.8000]]
     # token-level: [[0.6065, 0.8000, 0.8000]]
     truncated_actor_importance_weights = torch.clamp(
-        actor_importance_weights, max=cfg["truncated_importance_sampling_ratio"]
+        actor_importance_weights, max=cfg.truncated_importance_sampling_ratio
     )
 
     # sequence-level: [[-0.7268, 0.7268, -1.4537]]
@@ -1213,11 +1199,13 @@ def test_clipped_pg_loss_icepop_importance_sampling():
     device = "cuda"
     data, batch_size, seq_len, vocab_size = _setup_clipped_pg_test_data(device=device)
 
-    cfg = deepcopy(basic_pg_loss_test_config)
-    cfg["use_importance_sampling_correction"] = True
-    cfg["truncated_importance_sampling_ratio"] = 5.0  # max (ref)
-    cfg["truncated_importance_sampling_type"] = "icepop"
-    cfg["truncated_importance_sampling_ratio_min"] = 0.5  # min (ref)
+    cfg = ClippedPGLossConfig(
+        reference_policy_kl_penalty=0.0,
+        use_importance_sampling_correction=True,
+        truncated_importance_sampling_type="icepop",
+        truncated_importance_sampling_ratio=5.0,  # max (ref)
+        truncated_importance_sampling_ratio_min=0.5,  # min (ref)
+    )
     loss_fn = ClippedPGLossFn(cfg)
 
     # On-policy (curr = prev) → ratios = 1, clip_loss = -adv
@@ -1260,11 +1248,13 @@ def test_clipped_pg_loss_seq_mask_tis():
     device = "cuda"
     data, batch_size, seq_len, vocab_size = _setup_clipped_pg_test_data(device=device)
 
-    cfg = deepcopy(basic_pg_loss_test_config)
-    cfg["use_importance_sampling_correction"] = True
-    cfg["truncated_importance_sampling_ratio"] = 1.002  # max (ref)
-    cfg["truncated_importance_sampling_type"] = "seq-mask-tis"
-    cfg["truncated_importance_sampling_ratio_min"] = 0.999  # min (ref)
+    cfg = ClippedPGLossConfig(
+        reference_policy_kl_penalty=0.0,
+        use_importance_sampling_correction=True,
+        truncated_importance_sampling_type="seq-mask-tis",
+        truncated_importance_sampling_ratio=1.002,  # max (ref)
+        truncated_importance_sampling_ratio_min=0.999,  # min (ref)
+    )
     loss_fn = ClippedPGLossFn(cfg)
 
     # On-policy (curr = prev), gen very close to prev
@@ -1343,8 +1333,7 @@ def test_clipped_pg_loss_dual_clip():
     device = "cuda"
     data, batch_size, seq_len, vocab_size = _setup_clipped_pg_test_data(device=device)
 
-    cfg = deepcopy(basic_pg_loss_test_config)
-    cfg["ratio_clip_c"] = 3.0
+    cfg = ClippedPGLossConfig(reference_policy_kl_penalty=0.0, ratio_clip_c=3.0)
     loss_fn = ClippedPGLossFn(cfg)
 
     # Create test data with a mix of advantages: positive, slightly negative, strongly negative
@@ -1368,7 +1357,7 @@ def test_clipped_pg_loss_dual_clip():
     # --- Hand Calculation ---
     # Actor Loss Calculation
     ratios_clamped = torch.clamp(
-        ratios, 1.0 - cfg["ratio_clip_min"], 1.0 + cfg["ratio_clip_max"]
+        ratios, 1.0 - cfg.ratio_clip_min, 1.0 + cfg.ratio_clip_max
     )  # [0.8, 1.0, 1.2]
     assert torch.allclose(
         ratios_clamped, torch.tensor([[0.8, 1.0, 1.2]], device=device), rtol=1e-3
@@ -1392,7 +1381,7 @@ def test_clipped_pg_loss_dual_clip():
 
     # Dual clipping
     loss3 = (
-        -adv_masked * cfg["ratio_clip_c"]
+        -adv_masked * cfg.ratio_clip_c
     )  # -[1*3.0, -1*3.0, -4*3.0] = [-3.0, 3.0, 12.0]
     assert torch.allclose(
         loss3, torch.tensor([[-3.0, 3.0, 12.0]], device=device), rtol=1e-3
@@ -1436,7 +1425,7 @@ def test_clipped_pg_loss_entropy():
     device = "cuda"
     data, batch_size, seq_len, vocab_size = _setup_clipped_pg_test_data(device=device)
 
-    cfg = basic_pg_loss_test_config
+    cfg = ClippedPGLossConfig(reference_policy_kl_penalty=0.0)
     loss_fn = ClippedPGLossFn(cfg)
 
     # Log probs for 3 tokens (default token_mask is [0, 1, 1, 1], so 3 unmasked after slicing)
@@ -1490,9 +1479,11 @@ def test_clipped_pg_loss_gspo():
     device = "cuda"
     data, batch_size, seq_len, vocab_size = _setup_clipped_pg_test_data(device=device)
 
-    cfg = deepcopy(basic_pg_loss_test_config)
-    cfg["sequence_level_importance_ratios"] = True
-    cfg["token_level_loss"] = False
+    cfg = ClippedPGLossConfig(
+        reference_policy_kl_penalty=0.0,
+        sequence_level_importance_ratios=True,
+        token_level_loss=False,
+    )
     loss_fn = ClippedPGLossFn(cfg)
 
     adv_masked = torch.tensor([[1.0, -1.0, 2.0]], device=device)
@@ -1518,7 +1509,7 @@ def test_clipped_pg_loss_gspo():
     )
 
     ratios_clamped = torch.clamp(
-        ratios, 1.0 - cfg["ratio_clip_min"], 1.0 + cfg["ratio_clip_max"]
+        ratios, 1.0 - cfg.ratio_clip_min, 1.0 + cfg.ratio_clip_max
     )
     assert torch.allclose(
         ratios_clamped,
@@ -1571,9 +1562,11 @@ def test_clipped_pg_loss_gspo_batch_size_2():
         batch_size=2, device=device
     )
 
-    cfg = deepcopy(basic_pg_loss_test_config)
-    cfg["sequence_level_importance_ratios"] = True
-    cfg["token_level_loss"] = False
+    cfg = ClippedPGLossConfig(
+        reference_policy_kl_penalty=0.0,
+        sequence_level_importance_ratios=True,
+        token_level_loss=False,
+    )
     loss_fn = ClippedPGLossFn(cfg)
 
     adv_masked = torch.tensor([[1.0, -1.0, 2.0], [1.0, -1.0, 2.0]], device=device)
@@ -1605,7 +1598,7 @@ def test_clipped_pg_loss_gspo_batch_size_2():
     )
 
     ratios_clamped = torch.clamp(
-        ratios, 1.0 - cfg["ratio_clip_min"], 1.0 + cfg["ratio_clip_max"]
+        ratios, 1.0 - cfg.ratio_clip_min, 1.0 + cfg.ratio_clip_max
     )
     assert torch.allclose(
         ratios_clamped,
@@ -1670,10 +1663,12 @@ def test_clipped_pg_loss_gspo_importance_sampling_correction():
     device = "cuda"
     data, batch_size, seq_len, vocab_size = _setup_clipped_pg_test_data(device=device)
 
-    cfg = deepcopy(basic_pg_loss_test_config)
-    cfg["use_importance_sampling_correction"] = True
-    cfg["sequence_level_importance_ratios"] = True
-    cfg["token_level_loss"] = False
+    cfg = ClippedPGLossConfig(
+        reference_policy_kl_penalty=0.0,
+        use_importance_sampling_correction=True,
+        sequence_level_importance_ratios=True,
+        token_level_loss=False,
+    )
     loss_fn = ClippedPGLossFn(cfg)
 
     adv_masked = torch.tensor([[1.0, -1.0, 2.0]], device=device)
@@ -1712,7 +1707,7 @@ def test_clipped_pg_loss_gspo_importance_sampling_correction():
     )
 
     ratios_clamped = torch.clamp(
-        ratios, 1.0 - cfg["ratio_clip_min"], 1.0 + cfg["ratio_clip_max"]
+        ratios, 1.0 - cfg.ratio_clip_min, 1.0 + cfg.ratio_clip_max
     )
     assert torch.allclose(
         ratios_clamped,

--- a/tests/unit/algorithms/test_loss_functions.py
+++ b/tests/unit/algorithms/test_loss_functions.py
@@ -635,8 +635,10 @@ def test_clipped_pg_loss_force_on_policy_ratio_ignores_prev_logprobs():
     device = "cuda"
     data, batch_size, seq_len, vocab_size = _setup_clipped_pg_test_data(device=device)
 
-    cfg = deepcopy(basic_pg_loss_test_config)
-    cfg["force_on_policy_ratio"] = True
+    cfg = ClippedPGLossConfig(
+        reference_policy_kl_penalty=0.0,
+        force_on_policy_ratio=True,
+    )
     loss_fn = ClippedPGLossFn(cfg)
 
     curr_lp = torch.tensor([[-1.0, -1.0, -1.0]], device=device)

--- a/tests/unit/algorithms/test_rm.py
+++ b/tests/unit/algorithms/test_rm.py
@@ -19,7 +19,7 @@ import torch
 from torchdata.stateful_dataloader import StatefulDataLoader
 
 from nemo_rl.algorithms.loss import PreferenceLossFn
-from nemo_rl.algorithms.rm import _default_rm_save_state, rm_train
+from nemo_rl.algorithms.rm import MasterConfig, _default_rm_save_state, rm_train
 
 
 @pytest.fixture
@@ -80,36 +80,38 @@ def mock_components():
     checkpointer = MagicMock()
 
     # Create mock master config
-    master_config = {
-        "rm": {
-            "max_num_steps": 5,
-            "max_num_epochs": 2,
-            "val_period": 100,
-            "val_batches": 1,
-            "val_global_batch_size": 1,
-            "val_micro_batch_size": 1,
-            "val_at_start": False,
-            "val_at_end": False,
-        },
-        "policy": {
-            "train_global_batch_size": 1,
-            "make_sequence_length_divisible_by": 1,
-            "reward_model_cfg": {
-                "enabled": True,
-                "reward_model_type": "bradley_terry",
+    master_config = MasterConfig.model_construct(
+        **{
+            "rm": {
+                "max_num_steps": 5,
+                "max_num_epochs": 2,
+                "val_period": 100,
+                "val_batches": 1,
+                "val_global_batch_size": 1,
+                "val_micro_batch_size": 1,
+                "val_at_start": False,
+                "val_at_end": False,
             },
-            "train_micro_batch_size": 1,
-        },
-        "checkpointing": {
-            "enabled": False,
-            "checkpoint_must_save_by": None,
-            "save_period": 10,
-        },
-        "cluster": {
-            "num_nodes": 1,
-            "gpus_per_node": 2,
-        },
-    }
+            "policy": {
+                "train_global_batch_size": 1,
+                "make_sequence_length_divisible_by": 1,
+                "reward_model_cfg": {
+                    "enabled": True,
+                    "reward_model_type": "bradley_terry",
+                },
+                "train_micro_batch_size": 1,
+            },
+            "checkpointing": {
+                "enabled": False,
+                "checkpoint_must_save_by": None,
+                "save_period": 10,
+            },
+            "cluster": {
+                "num_nodes": 1,
+                "gpus_per_node": 2,
+            },
+        }
+    )
 
     return {
         "policy": policy,
@@ -126,7 +128,7 @@ def mock_components():
 def test_exit_on_max_steps(mock_components):
     """Test that training loop exits when max_num_steps is reached"""
     # Set max steps to 12, which is less than len(train_dataloader) * max_num_epochs
-    mock_components["master_config"]["rm"]["max_num_steps"] = 12
+    mock_components["master_config"].rm["max_num_steps"] = 12
 
     rm_save_state = _default_rm_save_state()
 
@@ -150,8 +152,8 @@ def test_exit_on_max_steps(mock_components):
 def test_exit_on_max_epochs(mock_components):
     """Test that training loop exits when max_num_epochs is reached"""
     # Set max epochs to 2 and max steps to a large number
-    mock_components["master_config"]["rm"]["max_num_epochs"] = 2
-    mock_components["master_config"]["rm"]["max_num_steps"] = 100
+    mock_components["master_config"].rm["max_num_epochs"] = 2
+    mock_components["master_config"].rm["max_num_steps"] = 100
 
     rm_save_state = _default_rm_save_state()
 
@@ -175,8 +177,8 @@ def test_exit_on_max_epochs(mock_components):
 def test_exit_on_timeout(mock_components, capsys):
     """Test that training loop exits when timeout is reached"""
     # Set max steps and epochs to large numbers
-    mock_components["master_config"]["rm"]["max_num_steps"] = 100
-    mock_components["master_config"]["rm"]["max_num_epochs"] = 10
+    mock_components["master_config"].rm["max_num_steps"] = 100
+    mock_components["master_config"].rm["max_num_epochs"] = 10
 
     rm_save_state = _default_rm_save_state()
 

--- a/tests/unit/algorithms/test_sequence_packing_fusion.py
+++ b/tests/unit/algorithms/test_sequence_packing_fusion.py
@@ -28,6 +28,7 @@ import torch
 
 from nemo_rl.algorithms.logits_sampling_utils import TrainingSamplingParams
 from nemo_rl.algorithms.loss import (
+    ClippedPGLossConfig,
     ClippedPGLossFn,
     SequencePackingFusionLossWrapper,
     SequencePackingLossWrapper,
@@ -171,28 +172,12 @@ def _build_test_case(cp_size, tp_size, my_tp_rank, cp_group):
 
         return logits_local, packed_logits
 
-    loss_cfg = {
-        "reference_policy_kl_penalty": 0.01,
-        "ratio_clip_min": 0.2,
-        "ratio_clip_max": 0.2,
-        "use_on_policy_kl_approximation": False,
-        "use_importance_sampling_correction": False,
-        "token_level_loss": True,
-        "ratio_clip_c": None,
-        "reference_policy_kl_type": "k3",
-        "kl_input_clamp_value": 20.0,
-        "kl_output_clamp_value": 10.0,
-        "truncated_importance_sampling_ratio": None,
-        "sequence_level_importance_ratios": False,
-        "force_on_policy_ratio": False,
-    }
-
     valid_toks = int(torch.clamp(seq_lengths - 1, min=0).sum().item())
     global_valid_toks = torch.tensor(valid_toks, dtype=torch.float32, device=device)
     global_valid_seqs = torch.tensor(batch_size, dtype=torch.float32, device=device)
 
     return {
-        "loss_cfg": loss_cfg,
+        "loss_cfg": ClippedPGLossConfig(),
         "cu_seqlens": cu_seqlens,
         "cu_seqlens_padded": cu_seqlens_padded,
         "data_dict": data_dict,

--- a/tests/unit/algorithms/test_sft.py
+++ b/tests/unit/algorithms/test_sft.py
@@ -19,7 +19,7 @@ import torch
 from torchdata.stateful_dataloader import StatefulDataLoader
 
 from nemo_rl.algorithms.loss import NLLLossFn
-from nemo_rl.algorithms.sft import _default_sft_save_state, sft_train
+from nemo_rl.algorithms.sft import MasterConfig, _default_sft_save_state, sft_train
 
 
 @pytest.fixture
@@ -63,31 +63,33 @@ def mock_components():
     checkpointer = MagicMock()
 
     # Create mock master config
-    master_config = {
-        "sft": {
-            "max_num_steps": 5,
-            "max_num_epochs": 2,
-            "val_period": 100,
-            "val_batches": 1,
-            "val_global_batch_size": 1,
-            "val_micro_batch_size": 1,
-            "val_at_start": False,
-            "val_at_end": False,
-        },
-        "policy": {
-            "train_global_batch_size": 1,
-            "make_sequence_length_divisible_by": 8,
-        },
-        "checkpointing": {
-            "enabled": False,
-            "checkpoint_must_save_by": None,
-            "save_period": 10,
-        },
-        "cluster": {
-            "num_nodes": 1,
-            "gpus_per_node": 2,
-        },
-    }
+    master_config = MasterConfig.model_construct(
+        **{
+            "sft": {
+                "max_num_steps": 5,
+                "max_num_epochs": 2,
+                "val_period": 100,
+                "val_batches": 1,
+                "val_global_batch_size": 1,
+                "val_micro_batch_size": 1,
+                "val_at_start": False,
+                "val_at_end": False,
+            },
+            "policy": {
+                "train_global_batch_size": 1,
+                "make_sequence_length_divisible_by": 8,
+            },
+            "checkpointing": {
+                "enabled": False,
+                "checkpoint_must_save_by": None,
+                "save_period": 10,
+            },
+            "cluster": {
+                "num_nodes": 1,
+                "gpus_per_node": 2,
+            },
+        }
+    )
 
     return {
         "policy": policy,
@@ -104,7 +106,7 @@ def mock_components():
 def test_exit_on_max_steps(mock_components):
     """Test that training loop exits when max_num_steps is reached"""
     # Set max steps to 12, which is less than len(train_dataloader) * max_num_epochs
-    mock_components["master_config"]["sft"]["max_num_steps"] = 12
+    mock_components["master_config"].sft["max_num_steps"] = 12
 
     sft_save_state = _default_sft_save_state()
 
@@ -128,8 +130,8 @@ def test_exit_on_max_steps(mock_components):
 def test_exit_on_max_epochs(mock_components):
     """Test that training loop exits when max_num_epochs is reached"""
     # Set max epochs to 2 and max steps to a large number
-    mock_components["master_config"]["sft"]["max_num_epochs"] = 2
-    mock_components["master_config"]["sft"]["max_num_steps"] = 100
+    mock_components["master_config"].sft["max_num_epochs"] = 2
+    mock_components["master_config"].sft["max_num_steps"] = 100
 
     sft_save_state = _default_sft_save_state()
 
@@ -153,8 +155,8 @@ def test_exit_on_max_epochs(mock_components):
 def test_exit_on_timeout(mock_components, capsys):
     """Test that training loop exits when timeout is reached"""
     # Set max steps and epochs to large numbers
-    mock_components["master_config"]["sft"]["max_num_steps"] = 100
-    mock_components["master_config"]["sft"]["max_num_epochs"] = 10
+    mock_components["master_config"].sft["max_num_steps"] = 100
+    mock_components["master_config"].sft["max_num_epochs"] = 10
 
     sft_save_state = _default_sft_save_state()
 
@@ -205,9 +207,9 @@ def test_exit_on_timeout(mock_components, capsys):
 
 def test_training_with_disabled_validation(mock_components):
     """Test that training works when validation is disabled (val_dataloader=None, val_period<=0)"""
-    mock_components["master_config"]["sft"]["val_period"] = 0
-    mock_components["master_config"]["sft"]["max_num_steps"] = 5
-    mock_components["master_config"]["sft"]["max_num_epochs"] = 1
+    mock_components["master_config"].sft["val_period"] = 0
+    mock_components["master_config"].sft["max_num_steps"] = 5
+    mock_components["master_config"].sft["max_num_epochs"] = 1
 
     sft_save_state = _default_sft_save_state()
 
@@ -228,9 +230,9 @@ def test_training_with_disabled_validation(mock_components):
 
 def test_training_with_negative_val_period(mock_components):
     """Test that training works when val_period is negative (validation disabled)"""
-    mock_components["master_config"]["sft"]["val_period"] = -1
-    mock_components["master_config"]["sft"]["max_num_steps"] = 3
-    mock_components["master_config"]["sft"]["max_num_epochs"] = 1
+    mock_components["master_config"].sft["val_period"] = -1
+    mock_components["master_config"].sft["max_num_steps"] = 3
+    mock_components["master_config"].sft["max_num_epochs"] = 1
 
     sft_save_state = _default_sft_save_state()
 

--- a/tests/unit/algorithms/test_sft.py
+++ b/tests/unit/algorithms/test_sft.py
@@ -64,31 +64,29 @@ def mock_components():
 
     # Create mock master config
     master_config = MasterConfig.model_construct(
-        **{
-            "sft": {
-                "max_num_steps": 5,
-                "max_num_epochs": 2,
-                "val_period": 100,
-                "val_batches": 1,
-                "val_global_batch_size": 1,
-                "val_micro_batch_size": 1,
-                "val_at_start": False,
-                "val_at_end": False,
-            },
-            "policy": {
-                "train_global_batch_size": 1,
-                "make_sequence_length_divisible_by": 8,
-            },
-            "checkpointing": {
-                "enabled": False,
-                "checkpoint_must_save_by": None,
-                "save_period": 10,
-            },
-            "cluster": {
-                "num_nodes": 1,
-                "gpus_per_node": 2,
-            },
-        }
+        sft={
+            "max_num_steps": 5,
+            "max_num_epochs": 2,
+            "val_period": 100,
+            "val_batches": 1,
+            "val_global_batch_size": 1,
+            "val_micro_batch_size": 1,
+            "val_at_start": False,
+            "val_at_end": False,
+        },
+        policy={
+            "train_global_batch_size": 1,
+            "make_sequence_length_divisible_by": 8,
+        },
+        checkpointing={
+            "enabled": False,
+            "checkpoint_must_save_by": None,
+            "save_period": 10,
+        },
+        cluster={
+            "num_nodes": 1,
+            "gpus_per_node": 2,
+        },
     )
 
     return {

--- a/tests/unit/algorithms/test_utils.py
+++ b/tests/unit/algorithms/test_utils.py
@@ -312,7 +312,7 @@ def test_sync_colocated_throughput_flops_and_imbalance(capsys):
 
 def test_async_non_colocated_idle_ratio_and_generation_time(capsys):
     master_config = _base_master_config(colocated=False)
-    master_config["async_grpo"] = {"enabled": True}
+    master_config.grpo["async_grpo"] = {"enabled": True}
 
     timing_metrics = {
         "policy_and_reference_logprobs": 2.0,

--- a/tests/unit/algorithms/test_utils.py
+++ b/tests/unit/algorithms/test_utils.py
@@ -18,6 +18,7 @@ from datetime import datetime
 import pytest
 import torch
 
+from nemo_rl.algorithms.grpo import MasterConfig
 from nemo_rl.algorithms.utils import (
     calculate_baseline_and_std_per_prompt,
     get_tokenizer,
@@ -224,9 +225,9 @@ def test_maybe_pad_last_batch():
 
 
 def _base_master_config(colocated: bool):
-    return {
-        "cluster": {"num_nodes": 2, "gpus_per_node": 8},
-        "policy": {
+    return MasterConfig.model_construct(
+        cluster={"num_nodes": 2, "gpus_per_node": 8},
+        policy={
             "generation": {
                 "temperature": 1.0,
                 "top_p": 1.0,
@@ -237,8 +238,8 @@ def _base_master_config(colocated: bool):
                 },
             }
         },
-        "grpo": {"num_prompts_per_step": 8, "num_generations_per_prompt": 10},
-    }
+        grpo={"num_prompts_per_step": 8, "num_generations_per_prompt": 10},
+    )
 
 
 def test_sync_colocated_throughput_flops_and_imbalance(capsys):

--- a/tests/unit/environments/test_nemo_gym.py
+++ b/tests/unit/environments/test_nemo_gym.py
@@ -21,6 +21,7 @@ import ray
 import torch
 from yaml import safe_load
 
+from nemo_rl.algorithms.grpo import MasterConfig
 from nemo_rl.distributed.ray_actor_environment_registry import (
     get_actor_python_env,
 )
@@ -49,11 +50,9 @@ def test_nemo_gym_stub_module():
 @pytest.fixture(scope="function")
 def nemo_gym_vllm_generation(cluster, nemo_gym_tokenizer):  # noqa: F811
     generation_config = deepcopy(basic_vllm_test_config)
-    master_config = {
-        "policy": {
-            "generation": generation_config,
-        },
-    }
+    master_config = MasterConfig.model_construct(
+        policy={"generation": generation_config}
+    )
     setup_nemo_gym_config(master_config, nemo_gym_tokenizer)
 
     generation_config["vllm_cfg"]["max_model_len"] = 16_384

--- a/tests/unit/models/policy/test_dtensor_worker.py
+++ b/tests/unit/models/policy/test_dtensor_worker.py
@@ -996,7 +996,7 @@ class TestTwoGPUCluster:
         # Test NLLLossFn and ClippedPGLossFn with mbs=1
         nll_loss_fn = NLLLossFn()
         pg_loss_fn = ClippedPGLossFn(
-            {
+            **{
                 "ratio_clip_min": 0.2,
                 "ratio_clip_max": 0.2,
                 "ratio_clip_c": None,

--- a/tests/unit/models/policy/test_dtensor_worker.py
+++ b/tests/unit/models/policy/test_dtensor_worker.py
@@ -19,7 +19,7 @@ import ray
 import torch
 from transformers import AutoModelForCausalLM
 
-from nemo_rl.algorithms.loss import ClippedPGLossFn, NLLLossFn
+from nemo_rl.algorithms.loss import ClippedPGLossConfig, ClippedPGLossFn, NLLLossFn
 from nemo_rl.algorithms.loss.interfaces import LossFunction
 from nemo_rl.algorithms.utils import get_tokenizer
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
@@ -996,22 +996,7 @@ class TestTwoGPUCluster:
         # Test NLLLossFn and ClippedPGLossFn with mbs=1
         nll_loss_fn = NLLLossFn()
         pg_loss_fn = ClippedPGLossFn(
-            **{
-                "ratio_clip_min": 0.2,
-                "ratio_clip_max": 0.2,
-                "ratio_clip_c": None,
-                "reference_policy_kl_penalty": 0.1,
-                "reference_policy_kl_type": "k3",
-                "kl_input_clamp_value": 20.0,
-                "kl_output_clamp_value": 10.0,
-                "disable_ppo_ratio": False,
-                "use_on_policy_kl_approximation": False,
-                "use_importance_sampling_correction": False,
-                "truncated_importance_sampling_ratio": None,
-                "sequence_level_importance_ratios": False,
-                "token_level_loss": True,
-                "force_on_policy_ratio": False,
-            }
+            ClippedPGLossConfig(reference_policy_kl_penalty=0.1)
         )
 
         policy_mbs1.prepare_for_training()

--- a/tests/unit/models/policy/test_dtensor_worker_v2.py
+++ b/tests/unit/models/policy/test_dtensor_worker_v2.py
@@ -126,7 +126,7 @@ def create_test_config(
     if automodel_kwargs is not None:
         config["dtensor_cfg"]["automodel_kwargs"] = automodel_kwargs
     if checkpointing is not None:
-        config["checkpointing"] = checkpointing
+        config.checkpointing = checkpointing
     return config
 
 

--- a/tests/unit/models/policy/test_dtensor_worker_v2.py
+++ b/tests/unit/models/policy/test_dtensor_worker_v2.py
@@ -126,7 +126,7 @@ def create_test_config(
     if automodel_kwargs is not None:
         config["dtensor_cfg"]["automodel_kwargs"] = automodel_kwargs
     if checkpointing is not None:
-        config.checkpointing = checkpointing
+        config["checkpointing"] = checkpointing
     return config
 
 

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -1277,7 +1277,7 @@ def test_megatron_checkpoint_save_kill_and_restore(
             restore_config = deepcopy(initial_config)
 
             # Check if the optimizer exists in the checkpoint
-            # checkpointer = CheckpointManager(restore_config["checkpointing"])
+            # checkpointer = CheckpointManager(restore_config.checkpointing)
             weights_path, optimizer_path = CheckpointManager.get_resume_paths(
                 checkpoint_dir
             )

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -39,22 +39,24 @@ from tests.unit.test_utils import SimpleLossFn
 
 pytestmark = pytest.mark.mcore
 
-basic_pg_loss_test_config: ClippedPGLossConfig = {
-    "ratio_clip_min": 0.2,
-    "ratio_clip_max": 0.2,
-    "ratio_clip_c": None,
-    "reference_policy_kl_penalty": 0.1,
-    "reference_policy_kl_type": "k3",
-    "kl_input_clamp_value": 20.0,
-    "kl_output_clamp_value": 10.0,
-    "disable_ppo_ratio": False,
-    "use_on_policy_kl_approximation": False,
-    "use_importance_sampling_correction": False,
-    "truncated_importance_sampling_ratio": None,
-    "sequence_level_importance_ratios": False,
-    "token_level_loss": True,
-    "force_on_policy_ratio": False,
-}
+basic_pg_loss_test_config = ClippedPGLossConfig(
+    **{
+        "ratio_clip_min": 0.2,
+        "ratio_clip_max": 0.2,
+        "ratio_clip_c": None,
+        "reference_policy_kl_penalty": 0.1,
+        "reference_policy_kl_type": "k3",
+        "kl_input_clamp_value": 20.0,
+        "kl_output_clamp_value": 10.0,
+        "disable_ppo_ratio": False,
+        "use_on_policy_kl_approximation": False,
+        "use_importance_sampling_correction": False,
+        "truncated_importance_sampling_ratio": None,
+        "sequence_level_importance_ratios": False,
+        "token_level_loss": True,
+        "force_on_policy_ratio": False,
+    }
+)
 
 
 def create_megatron_test_config(

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -39,25 +39,6 @@ from tests.unit.test_utils import SimpleLossFn
 
 pytestmark = pytest.mark.mcore
 
-basic_pg_loss_test_config = ClippedPGLossConfig(
-    **{
-        "ratio_clip_min": 0.2,
-        "ratio_clip_max": 0.2,
-        "ratio_clip_c": None,
-        "reference_policy_kl_penalty": 0.1,
-        "reference_policy_kl_type": "k3",
-        "kl_input_clamp_value": 20.0,
-        "kl_output_clamp_value": 10.0,
-        "disable_ppo_ratio": False,
-        "use_on_policy_kl_approximation": False,
-        "use_importance_sampling_correction": False,
-        "truncated_importance_sampling_ratio": None,
-        "sequence_level_importance_ratios": False,
-        "token_level_loss": True,
-        "force_on_policy_ratio": False,
-    }
-)
-
 
 def create_megatron_test_config(
     model_name: str,
@@ -849,7 +830,7 @@ def test_megatron_loss_independent_of_microbatch_size(tiny_llama_model_path):
 
     # Test loss functions
     nll_loss_fn = NLLLossFn()
-    pg_loss_fn = ClippedPGLossFn(basic_pg_loss_test_config)
+    pg_loss_fn = ClippedPGLossFn(ClippedPGLossConfig())
 
     policy1.prepare_for_training()
     mbs1_nll_results = policy1.train(data, nll_loss_fn)
@@ -2425,7 +2406,7 @@ def test_megatron_context_parallel_training_agreement(tiny_llama_model_path):
     )
 
     # Create ClippedPG loss function
-    loss_fn = ClippedPGLossFn(basic_pg_loss_test_config)
+    loss_fn = ClippedPGLossFn(ClippedPGLossConfig())
 
     # Train non-CP model
     policy_no_cp.prepare_for_training()

--- a/tests/unit/reference_configs/distillation_math.yaml
+++ b/tests/unit/reference_configs/distillation_math.yaml
@@ -1,0 +1,267 @@
+# Distillation Algorithm Configuration
+distillation:
+    num_prompts_per_step: 128
+    num_generations_per_prompt: 1
+    max_rollout_turns: 1 # for multi-turn rollouts. Math Environments just have 1 turn (answering the question)
+    max_num_steps: 1000
+    max_num_epochs: 10
+    val_batch_size: 64
+    val_period: 20
+    val_at_start: false
+    val_at_end: false
+    max_val_samples: 512
+    topk_logits_k: 64
+    seed: 42
+
+loss_fn:
+    kl_type: "mixed" # forward, reverse, mixed
+    mixed_kl_weight: 0.5 # when kl_type is "mixed", this is the weight of the forward KL
+    zero_outside_topk: false # zero out the teacher logits outside the top k when calculate forward KL loss
+
+checkpointing:
+    enabled: true
+    checkpoint_dir: "checkpoints/distillation-${policy.model_name}"
+    metric_name: "val:accuracy" # one of "val:" or "train:" followed by the metric name
+    higher_is_better: true
+    keep_top_k: 3
+    save_period: 10
+    checkpoint_must_save_by: null
+    model_save_format: "safetensors"
+    save_consolidated: false
+    save_optimizer: true
+
+policy: &POLICY_BASE
+    model_name: "Qwen/Qwen3-1.7B-Base"
+    tokenizer:
+        name: ${..model_name} ## specify if you'd like to use a tokenizer different from the model's default
+        chat_template_kwargs: null # can be used to pass kwargs to the chat template, e.g., enable_thinking=true
+    train_global_batch_size: 64
+    train_micro_batch_size: 1
+    generation_batch_size: 64
+    logprob_batch_size: 1
+    max_total_sequence_length: 8192
+    precision: "bfloat16"
+    logprob_chunk_size: null
+
+    offload_optimizer_for_logprob: false
+
+    dtensor_cfg: &DTENSOR_BASE
+        enabled: true
+        _v2: true
+        cpu_offload: False
+        sequence_parallel: false
+        activation_checkpointing: true
+        tensor_parallel_size: 2
+        context_parallel_size: 2
+        custom_parallel_plan: null
+
+    dynamic_batching:
+        enabled: true
+        train_mb_tokens: ${mul:${..max_total_sequence_length}, ${..train_micro_batch_size}}
+        logprob_mb_tokens: ${mul:${..max_total_sequence_length}, ${..logprob_batch_size}}
+        sequence_length_round: 64
+
+    sequence_packing:
+        enabled: false
+        train_mb_tokens: ${mul:${..max_total_sequence_length}, ${..train_micro_batch_size}}
+        logprob_mb_tokens: ${mul:${..max_total_sequence_length}, ${..logprob_batch_size}}
+        algorithm: "modified_first_fit_decreasing"
+        sequence_length_round: 64
+
+    max_grad_norm: 1.0
+    # makes the training sequence length divisible by the tensor parallel size
+    # this is useful for sequence parallel training
+    # must be divisible by 2*cp
+    make_sequence_length_divisible_by: ${mul:${mul:${.dtensor_cfg.tensor_parallel_size}, ${.dtensor_cfg.context_parallel_size}}, 2}
+    optimizer:
+        name: "torch.optim.AdamW"
+        kwargs:
+            lr: 2.0e-5
+            weight_decay: 0.01
+            betas: [0.9, 0.999]
+            eps: 1e-8
+            # when using Dtensor, we need to set foreach
+            # and fused to False
+            foreach: False
+            fused: False
+
+    megatron_cfg: &MEGATRON_BASE
+        enabled: false
+        force_reconvert_from_hf: False # Set to True to force reconvert of the model from Hugging Face
+        empty_unused_memory_level: 0
+        activation_checkpointing: false
+        converter_type: "Qwen3ForCausalLM"
+        tensor_model_parallel_size: 2
+        expert_tensor_parallel_size: 1
+        expert_model_parallel_size: 1
+        pipeline_model_parallel_size: 2
+        num_layers_in_first_pipeline_stage: null
+        num_layers_in_last_pipeline_stage: null
+        context_parallel_size: 2
+        pipeline_dtype: ${policy.precision}
+        sequence_parallel: false
+        freeze_moe_router: true
+        moe_router_dtype: "fp64"
+        moe_router_load_balancing_type: "none" # "seq_aux_loss" causes logprob error divergence for grpo
+        moe_router_bias_update_rate: 0.0 # by default, disable bias updates for grpo
+        moe_permute_fusion: true
+        #gives ~20% training perf speedup with sequence packing 
+        apply_rope_fusion: True
+        bias_activation_fusion: True
+        defer_fp32_logits: False
+        moe_per_layer_logging: False
+        moe_enable_deepep: false
+        moe_token_dispatcher_type: "alltoall"
+        moe_shared_expert_overlap: false
+        gradient_accumulation_fusion: false
+        
+        optimizer:
+            optimizer: "adam"
+            lr: 2.00001e-5
+            min_lr: 2.0e-5
+            weight_decay: 0.01
+            bf16: true
+            fp16: false
+            params_dtype: "float32"
+
+            #adam
+            adam_beta1: 0.9
+            adam_beta2: 0.999
+            adam_eps: 1e-8
+
+            #sgd
+            sgd_momentum: 0.9
+
+            #distributed optimizer
+            use_distributed_optimizer: true
+            use_precision_aware_optimizer: true
+
+            # optimizer cpu offload
+            optimizer_cpu_offload: false
+            optimizer_offload_fraction: 0.0
+
+            clip_grad: ${policy.max_grad_norm}
+
+        scheduler:
+            start_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
+            end_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
+            weight_decay_incr_style: "constant"
+            lr_decay_style: "constant"
+            lr_decay_iters: 1000
+            lr_warmup_iters: 10
+            lr_warmup_init: 2.0e-6
+
+        distributed_data_parallel_config:
+            grad_reduce_in_fp32: false
+            overlap_grad_reduce: true
+            overlap_param_gather: true
+            use_custom_fsdp: false
+            data_parallel_sharding_strategy: "optim_grads_params"
+
+        fp8_cfg:
+            enabled: false
+            fp8: "e4m3"
+            fp8_recipe: "blockwise"
+            fp8_param: false
+
+    scheduler:
+        - name: "torch.optim.lr_scheduler.LinearLR"
+          kwargs:
+              start_factor: 0.1
+              end_factor: 1.0
+              total_iters: 10
+        - name: "torch.optim.lr_scheduler.ConstantLR"
+          kwargs:
+              factor: 1.0
+              total_iters: 10000000000
+        - milestones: [10]
+
+    generation:
+        backend: "vllm"
+        max_new_tokens: ${..max_total_sequence_length} # refer to local policy/teacher config
+        temperature: 1.0
+        top_p: 1.0
+        top_k: null
+        stop_token_ids: null
+        stop_strings: null
+        vllm_cfg:
+            async_engine: false
+            precision: ${...precision}
+            kv_cache_dtype: "auto"
+            tensor_parallel_size: 1
+            pipeline_parallel_size: 1
+            expert_parallel_size: 1  # When EP > 1, EP must be a multiple of TP since vLLM's EP = DP * TP
+            gpu_memory_utilization: 0.6
+            max_model_len: ${...max_total_sequence_length} # refer to local policy/teacher config
+            enforce_eager: False
+            use_deep_gemm: False
+            num_last_layers_in_bf16: 0
+            num_first_layers_in_bf16: 0
+            distributed_executor_backend: null
+        vllm_kwargs: {}
+
+        colocated:
+            # true: generation shares training GPUs
+            # false: uses dedicated generation resources
+            enabled: true
+            # only relevant when enabled is false
+            resources:
+                gpus_per_node: null # Decides num gpus to be dedicated to generation when there is one node in the cluster i.e cluster.num_nodes == 1
+                num_nodes: null # Decides number of nodes to be dedicated to generation
+
+
+teacher:
+    <<: *POLICY_BASE
+    model_name: "Qwen/Qwen3-4B"
+    dtensor_cfg:
+        <<: *DTENSOR_BASE
+        context_parallel_size: 2 
+        tensor_parallel_size: 4
+
+data:
+    max_input_seq_length: ${policy.max_total_sequence_length} # upper bound, real truncation occurs at vllm.max_model_len
+    shuffle: true
+
+    # dataset
+    train:
+        dataset_name: DeepScaler
+    validation:
+        dataset_name: AIME2024
+        repeat: 16
+    # default settings for all datasets
+    default:
+        prompt_file: "examples/prompts/cot.txt"
+        system_prompt_file: null
+        env_name: "math"
+
+env:
+    math:
+        num_workers: 8
+
+logger:
+    log_dir: "logs/distillation"
+    num_val_samples_to_print: 5
+    wandb_enabled: true
+    tensorboard_enabled: true
+    mlflow_enabled: false
+    swanlab_enabled: false
+    monitor_gpus: true
+    wandb:
+        project: "nemo-distillation"
+        name: "distillation-${data.train.dataset_name}-${teacher.model_name}-${policy.model_name}-${loss_fn.kl_type}-${distillation.topk_logits_k}"
+    swanlab:
+        project: "nemo-distillation"
+        name: "distillation-${data.train.dataset_name}-${teacher.model_name}-${policy.model_name}-${loss_fn.kl_type}-${distillation.topk_logits_k}"
+    tensorboard:
+        log_dir: "tb_logs-distillation-${data.train.dataset_name}"
+    mlflow:
+        experiment_name: "distillation-dev"
+        run_name: "distillation-math-cl-logger"
+        tracking_uri: "http://localhost:5000"
+    gpu_monitoring:
+        collection_interval: 10
+        flush_interval: 10
+
+cluster:
+    gpus_per_node: 8
+    num_nodes: 1

--- a/tests/unit/reference_configs/dpo.yaml
+++ b/tests/unit/reference_configs/dpo.yaml
@@ -1,0 +1,297 @@
+# DPO Algorithm Configuration
+dpo:
+  max_num_epochs: 1
+  max_num_steps: 150
+  val_period: 25
+  val_batches: 8
+  val_global_batch_size: 8
+  val_micro_batch_size: 1
+  val_at_start: true
+  val_at_end: false
+  seed: 42
+
+  reference_policy_kl_penalty: 0.05
+  preference_average_log_probs: False # whether normalizing log probs according to the sequence length in preference_loss
+  sft_average_log_probs: ${.preference_average_log_probs} # whether normalizing log probs according to the sequence length in sft_loss
+
+  ## TODO(@ashors) support other loss functions
+  #preference_loss: dpo # the preference loss, we support dpo, ipo, rpo_sq, rpo_bwd_kl, rpo_fwd_kl
+  #gt_reward_scale: 1. # the scale of the rewards in RPO
+  preference_loss_weight: 1 # the coefficient of the preference loss
+  sft_loss_weight: 0 # the coefficient of the SFT loss
+
+checkpointing:
+  enabled: true
+  checkpoint_dir: "results/dpo"
+  metric_name: "val:validation-default_loss"
+  higher_is_better: false
+  keep_top_k: 3
+  save_period: 50
+  checkpoint_must_save_by: null
+  save_optimizer: true
+
+policy:
+  model_name: "meta-llama/Llama-3.2-1B-Instruct"
+  tokenizer:
+    name: "meta-llama/Llama-3.2-1B-Instruct"
+    chat_template_kwargs: null # can be used to pass kwargs to the chat template, e.g., enable_thinking=true
+
+  # number of preference samples per batch
+  # each preference sample corresponds to a pair of chosen and rejected responses
+  # so the actual batch size processed by the model is train_global_batch_size * 2
+  train_global_batch_size: 128
+  train_micro_batch_size: 2
+
+  ## TODO(@ashors) support
+  #logprob_batch_size: ${policy.train_micro_batch_size}
+  max_total_sequence_length: 1024
+  precision: "bfloat16"
+
+  offload_optimizer_for_logprob: false
+
+  dtensor_cfg:
+    env_vars:
+      PYTORCH_CUDA_ALLOC_CONF: ""  # Refers to https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-alloc-conf
+    enabled: true
+    cpu_offload: False
+    sequence_parallel: false
+    activation_checkpointing: false
+    tensor_parallel_size: 1
+    context_parallel_size: 1
+    custom_parallel_plan: null
+    clear_cache_every_n_steps: null
+
+    # Automodel kwargs passed to from_pretrained.
+    # Uncomment force_hf if the custom model's adapter doesn't support per-tensor
+    # weight conversion (e.g. Qwen2, Llama). Auto-detected if not set.
+    # See https://github.com/NVIDIA-NeMo/RL/issues/2072
+    automodel_kwargs: {}
+      # force_hf: true
+
+    # LoRA (Low-Rank Adaptation) Configuration
+    lora_cfg:
+      enabled: False  # Set to True to enable LoRA fine-tuning
+      target_modules: []  # List of module names to apply LoRA (empty list with match_all_linear=true applies to all linear layers)
+      exclude_modules: []  # List of module names to exclude from LoRA
+      match_all_linear: true  # If True, applies LoRA to all linear layers (overrides target_modules)
+      dim: 8  # LoRA rank (r): lower rank = fewer parameters but less capacity. Typical values: 4, 8, 16, 32, 64
+      alpha: 32  # LoRA scaling factor: effective learning rate multiplier = alpha/dim. Typical values: 16, 32, 64
+      dropout: 0.0  # Dropout probability applied to LoRA layers (0.0 = no dropout)
+      dropout_position: "post"  # Where to apply dropout: "pre" (before LoRA) or "post" (after LoRA)
+      lora_A_init: "xavier"  # Initialization method for LoRA A matrix: "xavier" or "uniform"
+      use_triton: true  # Use Triton-optimized kernels for LoRA (faster but requires flash-attn). Disable when tensor_parallel_size > 1
+
+  dynamic_batching:
+    enabled: false
+
+  sequence_packing:
+    enabled: false
+
+  # makes the training sequence length divisible by the tensor parallel size
+  # this is useful for sequence parallel training
+  make_sequence_length_divisible_by: ${policy.dtensor_cfg.tensor_parallel_size}
+  max_grad_norm: 1.0
+
+  optimizer:
+    name: "torch.optim.AdamW"
+    kwargs:
+      lr: 5.0e-6
+      weight_decay: 0.1
+      betas: [0.9, 0.98]
+      eps: 1e-5
+      # when using Dtensor, we need to set foreach
+      # and fused to False
+      foreach: False
+      fused: False
+    
+  scheduler:
+    - name: "torch.optim.lr_scheduler.LinearLR"
+      kwargs:
+        start_factor: 0.1
+        end_factor: 1.0
+        total_iters: 20
+    - name: "torch.optim.lr_scheduler.ConstantLR"
+      kwargs:
+        factor: 1.0
+        total_iters: 10000000000
+    - milestones: [20]
+    
+  ## ignored since enabled=false, but needed for testing purposes
+  megatron_cfg:
+    enabled: false
+    use_linear_ce_fusion_loss: false
+    linear_ce_fusion_chunk_size: 256
+    force_reconvert_from_hf: False # Set to True to force reconvert of the model from Hugging Face
+    empty_unused_memory_level: 1
+    activation_checkpointing: false
+    tensor_model_parallel_size: 2
+    expert_tensor_parallel_size: 1
+    expert_model_parallel_size: 1
+    pipeline_model_parallel_size: 1
+    context_parallel_size: 1
+    pipeline_dtype: ${policy.precision}
+    num_layers_in_first_pipeline_stage: null
+    num_layers_in_last_pipeline_stage: null
+    sequence_parallel: true
+    freeze_moe_router: false
+    moe_router_dtype: "fp64"
+    moe_router_load_balancing_type: "aux_loss"
+    moe_router_bias_update_rate: 1e-3
+    moe_permute_fusion: true
+    #gives ~20% training perf speedup with sequence packing 
+    apply_rope_fusion: True
+    # gives ~25% training perf speedup with sequence packing and apply_rope_fusion
+    bias_activation_fusion: True
+    defer_fp32_logits: False
+    moe_per_layer_logging: False
+    moe_enable_deepep: false
+    moe_token_dispatcher_type: "alltoall"
+    moe_shared_expert_overlap: false
+    gradient_accumulation_fusion: false
+
+    peft:
+      enabled: false
+      target_modules: []
+      exclude_modules: []
+      dim: 8
+      alpha: 32
+      dropout: 0.0
+      dropout_position: "post"
+      lora_A_init_method: "xavier"
+      lora_B_init_method: "zero"
+      a2a_experimental: false
+      lora_dtype: null
+
+    optimizer:
+      optimizer: "adam"
+      lr: 5.0e-6 #4.0e-5
+      min_lr: 5.0e-6 #4.0e-5
+      weight_decay: 0.1
+      bf16: true
+      fp16: false
+      params_dtype: "float32"
+
+      #adam
+      adam_beta1: 0.9
+      adam_beta2: 0.98
+      adam_eps: 1e-8
+
+      #sgd
+      sgd_momentum: 0.9
+
+      #distributed optimizer
+      use_distributed_optimizer: true
+      use_precision_aware_optimizer: true
+
+      clip_grad: ${policy.max_grad_norm}
+
+      # optimizer cpu offload
+      optimizer_cpu_offload: false
+      optimizer_offload_fraction: 0.0
+
+    scheduler:
+      start_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
+      end_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
+      weight_decay_incr_style: "constant"
+      lr_decay_style: "constant"
+      lr_warmup_iters: 1
+      lr_warmup_init: 0.00000001
+
+    distributed_data_parallel_config:
+      grad_reduce_in_fp32: false
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+      data_parallel_sharding_strategy: "optim_grads_params"
+      use_custom_fsdp: false
+
+    fp8_cfg:
+      enabled: false
+      fp8: "e4m3"
+      fp8_recipe: "blockwise"
+      fp8_param: false
+
+data:
+  max_input_seq_length: ${policy.max_total_sequence_length}
+  shuffle: true
+  num_workers: 1
+
+  # dataset
+  train:
+    dataset_name: HelpSteer3
+    split: train
+  validation:
+    dataset_name: HelpSteer3
+    split: validation
+  # You can use custom preference datasets for training and validation. For example:
+  # 1. PreferenceDataset
+  #   train:
+  #     # this dataset will override prompt_key and use the default values for other vars
+  #     data_path: /path/to/local/train_dataset.jsonl  # local file or hf_org/hf_dataset_name (HuggingFace)
+  #     subset: null  # used for HuggingFace datasets
+  #     split: train  # used for HuggingFace datasets
+  #   validation:
+  #     # this dataset will use the default values for other vars except data_path
+  #     data_path: /path/to/local/val_dataset.jsonl
+  #   default:
+  #     # will use below vars as default values if dataset doesn't specify it
+  #     dataset_name: PreferenceDataset
+  #     prompt_file: null
+  #     system_prompt_file: null
+  #   # multiple validation sets is supported by using val_data_paths
+  #   # this will be removed after refactor
+  #   val_data_paths:
+  #     <NameOfValidationDataset1>: /path/to/local/val_dataset_1.jsonl
+  #     <NameOfValidationDataset2>: /path/to/local/val_dataset_2.jsonl
+  # 2. BinaryPreferenceDataset
+  #   train:
+  #     # this dataset will override prompt_key and use the default values for other vars
+  #     data_path: /path/to/local/train_dataset.jsonl  # local file or hf_org/hf_dataset_name (HuggingFace)
+  #     prompt_key: context
+  #     subset: null  # used for HuggingFace datasets
+  #     split: train  # used for HuggingFace datasets
+  #   validation:
+  #     # this dataset will use the default values for other vars except data_path
+  #     data_path: /path/to/local/val_dataset.jsonl
+  #   default:
+  #     # will use below vars as default values if dataset doesn't specify it
+  #     dataset_name: BinaryPreferenceDataset
+  #     prompt_key: prompt
+  #     chosen_key: chosen
+  #     rejected_key: rejected
+  #     prompt_file: null
+  #     system_prompt_file: null
+  # See https://github.com/NVIDIA-NeMo/RL/blob/main/docs/guides/dpo.md#datasets for more details.
+
+  # If you are doing checkpointing, `metric_name` should reflect the metric and validation set to be tracked. For example:
+  #   checkpointing:
+  #     metric_name: "val:validation-<NameOfValidationDataset1>_loss"
+  #   ...
+
+logger:
+  log_dir: "logs"  # Base directory for all logs
+  wandb_enabled: false # Make sure you do a ``wandb login [Your API key]'' before running
+
+  tensorboard_enabled: false
+  mlflow_enabled: false  # Disable MLflow logging
+  swanlab_enabled: false # Disable SwanLab logging
+  monitor_gpus: true  # If true, will monitor GPU usage and log to wandb and/or tensorboard
+  num_val_samples_to_print: 0 # Number of validation samples to pretty print on terminal
+  wandb:
+    project: "dpo-dev"
+    name: "dpo"
+  swanlab:
+    project: "dpo-dev"
+    name: "dpo"
+  tensorboard:
+    log_dir: "tb_logs-dpo-dev"
+  mlflow:
+    experiment_name: "dpo-dev"
+    run_name: "dpo"
+    tracking_uri: "http://localhost:5000"
+  gpu_monitoring:
+    collection_interval: 10  # How often to collect GPU usage metrics (in seconds)
+    flush_interval: 10  # How often to flush GPU usage metrics to the loggers (in seconds)
+
+cluster:
+  gpus_per_node: 1
+  num_nodes: 1

--- a/tests/unit/reference_configs/eval.yaml
+++ b/tests/unit/reference_configs/eval.yaml
@@ -1,0 +1,55 @@
+# Evaluation Configuration
+eval:
+  metric: "pass@k" # pass@k and cons@k are supported
+  num_tests_per_prompt: 1 # every prompt will be tested num_tests_per_prompt times and use the average score as the final score
+  seed: 42
+  k_value: 1
+  save_path: null # Path to save evaluation results and configuration of the evaluation. Set to null to disable saving. Example: "results/eval_output" or "/path/to/evaluation_results"
+
+generation:
+  backend: "vllm" # only vllm is supported for evaluation
+  max_new_tokens: ${generation.vllm_cfg.max_model_len}
+  temperature: 0.0
+  top_p: 1.0
+  top_k: -1 # -1 means disable
+  num_prompts_per_step: -1 # -1 means pass all prompts at once
+  model_name: "Qwen/Qwen2.5-Math-1.5B-Instruct"
+  stop_token_ids: null
+  stop_strings: null
+  vllm_cfg:
+    async_engine: false
+    precision: "bfloat16"
+    tensor_parallel_size: 1
+    pipeline_parallel_size: 1
+    expert_parallel_size: 1
+    gpu_memory_utilization: 0.9
+    max_model_len: 2048
+    enforce_eager: False
+  colocated:
+    # true: generation shares training GPUs
+    # false: uses dedicated generation resources
+    enabled: true
+    # only relevant when enabled is false
+    resources:
+      gpus_per_node: null # Decides num gpus to be dedicated to generation when there is one node in the cluster i.e cluster.num_nodes == 1
+      num_nodes: null # Decides number of nodes to be dedicated to generation
+
+
+tokenizer:
+  name: ${generation.model_name} ## specify if you'd like to use a tokenizer different from the model's default
+  chat_template: "default"
+  chat_template_kwargs: null # can be used to pass kwargs to the chat template, e.g., enable_thinking=true
+
+data:
+  max_input_seq_length: ${generation.vllm_cfg.max_model_len} # useless since we directly use prompts in evaluation
+  prompt_file: null
+  system_prompt_file: null
+  dataset_name: "aime2024"
+
+env:
+  math:
+    num_workers: 8
+
+cluster:
+  gpus_per_node: 1
+  num_nodes: 1

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -1,0 +1,393 @@
+# GRPO Algorithm Configuration
+grpo:
+  num_prompts_per_step: 32
+  num_generations_per_prompt: 16
+  max_rollout_turns: 1 # for multi-turn rollouts. Math Environments just have 1 turn (answering the question)
+  max_num_epochs: 1
+  max_num_steps: 1000000
+  normalize_rewards: true
+  use_leave_one_out_baseline: true
+  val_period: 10
+  val_at_start: false
+  val_at_end: false
+  overlong_filtering: false
+  max_val_samples: 256
+  val_batch_size: 256
+  seed: 42
+  use_dynamic_sampling: false
+  dynamic_sampling_max_gen_batches: 10
+  batch_multiplier: 1
+  reward_shaping:
+    enabled: false
+    overlong_buffer_length: 128
+    overlong_buffer_penalty: 1
+    max_response_length: ${policy.max_total_sequence_length}
+    stop_properly_penalty_coef: null
+
+  # Advantage Estimator Configuration
+  # Options: "grpo" (default) or "reinforce_plus_plus"
+  adv_estimator:
+    name: "grpo"  # Use "reinforce_plus_plus" for Reinforce++ estimator
+    normalize_rewards: ${grpo.normalize_rewards}
+    use_leave_one_out_baseline: ${grpo.use_leave_one_out_baseline}
+    minus_baseline: true  # Reinforce++-baseline specific: subtract per-prompt mean baseline
+  reward_scaling:
+    enabled: false
+    source_min: 0.0
+    source_max: 1.0
+    target_min: 0.0
+    target_max: 1.0
+  seq_logprob_error_threshold: null
+
+  async_grpo:
+    enabled: false # Set to true to enable async training mode
+    # Max age (in training steps) for trajectories used in training
+    max_trajectory_age_steps: 1
+    in_flight_weight_updates: false # Set to true to enable in-flight weight updates
+    recompute_kv_cache_after_weight_updates: false # Set to true to recompute kv cache after in-flight-weight-updates
+
+loss_fn:
+  reference_policy_kl_penalty: 0.01
+  # Can be set to k1, k2, k3
+  # For more details, see http://joschu.net/blog/kl-approx.html
+  reference_policy_kl_type: "k3"
+  kl_input_clamp_value: 20.0
+  kl_output_clamp_value: 10.0
+  ratio_clip_min: 0.2
+  ratio_clip_max: 0.2
+  ratio_clip_c: null
+  # (default off) loss formulation improvements (docs/guides/grpo.md#loss)
+  use_on_policy_kl_approximation: false
+  # Async GRPO requires importance sampling correction enabled
+  # Set to true when async_grpo.enabled is true
+  use_importance_sampling_correction: false
+  truncated_importance_sampling_ratio: null
+  truncated_importance_sampling_ratio_min: null  # Lower bound for ICE-POP
+  truncated_importance_sampling_type: tis  # "tis" (clamp to max) or "icepop" (filter outside [min, max])
+  sequence_level_importance_ratios: false
+  token_level_loss: true
+  force_on_policy_ratio: false  # Set to true to force ratio=1.0 (requires train_global_batch_size == num_prompts_per_step * num_generations_per_prompt)
+  use_kl_in_reward: false  # Reinforce++: add KL penalty to reward instead of loss
+
+checkpointing:
+  enabled: true
+  checkpoint_dir: "results/grpo"
+  metric_name: "val:accuracy" # one of "val:" or "train:" followed by the metric name
+  higher_is_better: true
+  keep_top_k: 3
+  save_period: 10
+  checkpoint_must_save_by: null
+  model_save_format: "safetensors"
+  save_consolidated: false
+  save_optimizer: true
+
+policy:
+  model_name: "Qwen/Qwen2.5-1.5B"
+  tokenizer:
+    name: ${policy.model_name} ## specify if you'd like to use a tokenizer different from the model's default
+    chat_template_kwargs: null # can be used to pass kwargs to the chat template, e.g., enable_thinking=true
+  hf_config_overrides: {} 
+  train_global_batch_size: 512
+  train_micro_batch_size: 4
+  generation_batch_size: 32 # Only used when generating using HF backend
+  logprob_batch_size: ${policy.train_micro_batch_size}
+  max_total_sequence_length: 512
+  precision: "bfloat16"
+  logprob_chunk_size: null
+  offload_optimizer_for_logprob: false # Only useful for non-colocated generation since colocated generation will always offload optimizer to cuda before refit
+
+  dtensor_cfg:
+    _v2: true
+    enabled: true
+    cpu_offload: False
+    sequence_parallel: false
+    activation_checkpointing: false
+    tensor_parallel_size: 1
+    context_parallel_size: 1
+    custom_parallel_plan: null
+
+    # Automodel kwargs passed to from_pretrained.
+    # Uncomment force_hf if the custom model's adapter doesn't support per-tensor
+    # weight conversion (e.g. Qwen2, Llama). Auto-detected if not set.
+    # See https://github.com/NVIDIA-NeMo/RL/issues/2072
+    automodel_kwargs: {}
+      # force_hf: true
+
+    # LoRA (Low-Rank Adaptation) Configuration
+    lora_cfg:
+      enabled: False  # Set to True to enable LoRA fine-tuning
+      target_modules: []  # List of module names to apply LoRA (empty list with match_all_linear=true applies to all linear layers)
+      exclude_modules: []  # List of module names to exclude from LoRA
+      match_all_linear: true  # If True, applies LoRA to all linear layers (overrides target_modules)
+      dim: 8  # LoRA rank (r): lower rank = fewer parameters but less capacity. Typical values: 4, 8, 16, 32, 64
+      alpha: 32  # LoRA scaling factor: effective learning rate multiplier = alpha/dim. Typical values: 16, 32, 64
+      dropout: 0.0  # Dropout probability applied to LoRA layers (0.0 = no dropout)
+      dropout_position: "post"  # Where to apply dropout: "pre" (before LoRA) or "post" (after LoRA)
+      lora_A_init: "xavier"  # Initialization method for LoRA A matrix: "xavier" or "uniform"
+      use_triton: true  # Use Triton-optimized kernels for LoRA (faster but requires flash-attn). Disable when tensor_parallel_size > 1
+  
+  megatron_cfg:
+    enabled: false
+    force_reconvert_from_hf: False # Set to True to force reconvert of the model from Hugging Face
+    empty_unused_memory_level: 1  # 1 is the minimum recommendation for RL since we almost always need to offload before beginning generation. Setting to 0 is faster, but you are more likely to run out of GPU memory.
+    activation_checkpointing: false
+    converter_type: "Qwen2ForCausalLM"
+    tensor_model_parallel_size: 1
+    expert_tensor_parallel_size: 1
+    expert_model_parallel_size: 1
+    pipeline_model_parallel_size: 1
+    num_layers_in_first_pipeline_stage: null
+    num_layers_in_last_pipeline_stage: null
+    context_parallel_size: 1
+    pipeline_dtype: ${policy.precision}
+    sequence_parallel: false
+    freeze_moe_router: true
+    moe_router_dtype: "fp64"
+    moe_router_load_balancing_type: "none" # "seq_aux_loss" causes logprob error divergence for grpo
+    moe_router_bias_update_rate: 0.0 # by default, disable bias updates for grpo
+    moe_permute_fusion: true
+    # gives ~20% training perf speedup with sequence packing
+    apply_rope_fusion: True
+    # gives ~25% training perf speedup with sequence packing and apply_rope_fusion
+    bias_activation_fusion: True
+    defer_fp32_logits: False
+    moe_per_layer_logging: False
+    moe_enable_deepep: false
+    moe_token_dispatcher_type: "alltoall"
+    moe_shared_expert_overlap: false
+    gradient_accumulation_fusion: false
+
+    peft:
+      enabled: false
+      target_modules: []
+      exclude_modules: []
+      dim: 8
+      alpha: 32
+      dropout: 0.0
+      dropout_position: "post"
+      lora_A_init_method: "xavier"
+      lora_B_init_method: "zero"
+      a2a_experimental: false
+      lora_dtype: None
+
+    optimizer:
+      optimizer: "adam"
+      lr: 5.0e-6
+      min_lr: 5.0e-7
+      weight_decay: 0.01
+      bf16: true
+      fp16: false
+      params_dtype: "float32"
+
+      #adam
+      adam_beta1: 0.9
+      adam_beta2: 0.999
+      adam_eps: 1e-8
+
+      #sgd
+      sgd_momentum: 0.9
+
+      #distributed optimizer
+      use_distributed_optimizer: true
+      use_precision_aware_optimizer: true
+
+      clip_grad: ${policy.max_grad_norm}
+
+      # optimizer cpu offload
+      optimizer_cpu_offload: false
+      optimizer_offload_fraction: 0.0
+
+    scheduler:
+      start_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
+      end_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
+      weight_decay_incr_style: "constant"
+      lr_decay_style: "constant"
+      lr_decay_iters: 1000
+      lr_warmup_iters: 13
+      lr_warmup_init: 5.0e-7
+
+    distributed_data_parallel_config:
+      grad_reduce_in_fp32: false
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+      use_custom_fsdp: false
+      data_parallel_sharding_strategy: "optim_grads_params"
+
+    fp8_cfg: 
+      enabled: false
+      fp8: "e4m3"
+      fp8_recipe: "blockwise"
+      fp8_param: false
+
+    env_vars: null
+
+  draft:
+    enabled: false
+    model_name: null
+    loss_weight: 0.1
+    num_layers: null
+    aux_layer_indices: null
+
+  # See docs/design-docs/sequence-packing-and-dynamic-batching.md 
+  # for more details on dynamic batching and sequence packing.
+  dynamic_batching:
+    enabled: False
+    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
+    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
+    sequence_length_round: 64
+
+  sequence_packing:
+    enabled: True
+    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
+    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
+    algorithm: "modified_first_fit_decreasing"
+    sequence_length_round: 64
+
+  # makes the training sequence length divisible by the tensor parallel size
+  # this is useful for sequence parallel training
+  make_sequence_length_divisible_by: ${policy.dtensor_cfg.tensor_parallel_size}
+  max_grad_norm: 1.0
+
+  optimizer:
+    name: "torch.optim.AdamW"
+    kwargs:
+      lr: 5.0e-6
+      weight_decay: 0.01
+      betas: [0.9, 0.999]
+      eps: 1e-8
+      # when using Dtensor, we need to set foreach
+      # and fused to False
+      foreach: False
+      fused: False
+
+  scheduler:
+    - name: "torch.optim.lr_scheduler.LinearLR"
+      kwargs:
+        start_factor: 0.1
+        end_factor: 1.0
+        total_iters: 50
+    - name: "torch.optim.lr_scheduler.ConstantLR"
+      kwargs:
+        factor: 1.0
+        total_iters: 10000000000
+    - milestones: [50]
+
+  generation:
+    backend: "vllm"
+    max_new_tokens: ${policy.max_total_sequence_length}
+    temperature: 1.0
+    top_p: 1.0
+    top_k: null
+    stop_token_ids: null
+    stop_strings: null
+    mcore_generation_config:
+      buffer_size_gb: 10  # Total buffer size is 2x this value (active requests + paused requests)
+      num_cuda_graphs: 4  # Number of CUDA graphs to pre-compile for different batch sizes
+      block_size_tokens: 256  # Size of each KV cache block in tokens (affects memory granularity)
+      use_cuda_graphs_for_non_decode_steps: true  # Enable CUDA graphs for prefill/context processing
+      enable_chunked_prefill: true  # Split long prefills into chunks for better memory management
+      unified_memory_level: 0  # Unified memory usage level (0=disabled, higher values enable more aggressive paging)
+      max_tokens: 16384 # Maximum number of tokens to use in a single step. Analogous to vllm's max_num_batched_tokens
+    vllm_cfg:
+      async_engine: false
+      precision: ${policy.precision}
+      kv_cache_dtype: "auto"
+      tensor_parallel_size: 1
+      pipeline_parallel_size: 1
+      expert_parallel_size: 1  # When EP > 1, EP must be a multiple of TP since vLLM's EP = DP * TP
+      gpu_memory_utilization: 0.6
+      max_model_len: ${policy.max_total_sequence_length}
+      # when enforce_eager is False, it is optional to set ++policy.generation.vllm_kwargs.compilation_config.backend=eager for better accuracy,
+      # with the flag, vllm will use the custom CUDA kernels instead of the Triton kernels generated by torch.compile
+      # for more details, see convergence issue https://github.com/NVIDIA-NeMo/RL/issues/998
+      enforce_eager: False
+      use_deep_gemm: False
+      num_last_layers_in_bf16: 0
+      num_first_layers_in_bf16: 0
+      enable_vllm_metrics_logger: true # Set to true to enable vLLM internal metrics logger, turn off for better performance
+      vllm_metrics_logger_interval: 0.5 # Interval in seconds to collect vLLM logger metrics
+    vllm_kwargs: {}
+    colocated:
+      # true: generation shares training GPUs
+      # false: uses dedicated generation resources
+      enabled: true
+      # only relevant when enabled is false
+      resources:
+        gpus_per_node: null # Decides num gpus to be dedicated to generation when there is one node in the cluster i.e cluster.num_nodes == 1
+        num_nodes: null # Decides number of nodes to be dedicated to generation
+
+data:
+  max_input_seq_length: ${policy.max_total_sequence_length} # upper bound, real truncation occurs at vllm.max_model_len
+  shuffle: true
+  num_workers: 1
+
+  # use multiple dataloader for train
+  # see https://github.com/NVIDIA-NeMo/RL/blob/main/docs/guides/grpo.md#multiple-dataloaders for more details.
+  use_multiple_dataloader: false
+
+  # dataset
+  train:
+    dataset_name: OpenMathInstruct-2
+    split_validation_size: 0.05 # use 5% of the training data as validation data
+    seed: ${grpo.seed} # seed for train/validation split when split_validation_size > 0
+  validation: null
+  # default settings for all datasets
+  default:
+    prompt_file: "examples/prompts/cot.txt"
+    system_prompt_file: null
+    processor: "math_hf_data_processor"
+    env_name: "math"
+
+  # You can also use multiple datasets by using a list of datasets.
+  # See `examples/configs/grpo_multiple_datasets.yaml` for a full configuration example.
+
+  # You can use custom response datasets for training and validation. For example:
+  # train:
+  #   # this dataset will override input_key and use the default values for other vars
+  #   data_path: /path/to/local/train_dataset.jsonl
+  #   input_key: question
+  # validation:
+  #   # this dataset will use the default values for other vars except data_path
+  #   data_path: /path/to/local/val_dataset.jsonl
+  # default:
+  #   # will use below vars as default values if dataset doesn't specify it
+  #   dataset_name: ResponseDataset
+  #   input_key: input
+  #   output_key: output
+  #   prompt_file: null
+  #   system_prompt_file: null
+  #   processor: "math_hf_data_processor"
+  #   env_name: math
+  # See https://github.com/NVIDIA-NeMo/RL/blob/main/docs/guides/grpo.md#datasets for more details.
+
+env:
+  math:
+    num_workers: 8
+    math_verify_impl: "hf_math_verify"
+
+logger:
+  log_dir: "logs"  # Base directory for all logs
+  num_val_samples_to_print: 0 # Number of validation samples to pretty print on terminal
+  wandb_enabled: false
+  tensorboard_enabled: false
+  mlflow_enabled: false  # Disable MLflow logging
+  swanlab_enabled: false # Disable SwanLab logging
+  monitor_gpus: true  # If true, will monitor GPU usage and log to wandb and/or tensorboard
+  wandb:
+    project: "grpo-dev"
+    name: "grpo-dev-logger"
+  swanlab:
+    project: "grpo-dev"
+    name: "grpo-dev-logger"
+  tensorboard: {}
+  mlflow:
+    experiment_name: "grpo-dev"
+    run_name: "grpo-dev-logger"
+    tracking_uri: "http://localhost:5000"
+  gpu_monitoring:
+    collection_interval: 10  # How often to collect GPU usage metrics (in seconds)
+    flush_interval: 10  # How often to flush GPU usage metrics to the loggers (in seconds)
+
+cluster:
+  gpus_per_node: 1
+  num_nodes: 1

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -68,6 +68,7 @@ loss_fn:
   token_level_loss: true
   force_on_policy_ratio: false  # Set to true to force ratio=1.0 (requires train_global_batch_size == num_prompts_per_step * num_generations_per_prompt)
   use_kl_in_reward: false  # Reinforce++: add KL penalty to reward instead of loss
+  disable_ppo_ratio: false
 
 checkpointing:
   enabled: true

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -61,9 +61,12 @@ loss_fn:
   # Async GRPO requires importance sampling correction enabled
   # Set to true when async_grpo.enabled is true
   use_importance_sampling_correction: false
+  # "tis"          – clamp IS weights to max
+  # "icepop"       – zero out tokens with IS weight outside [min, max]
+  # "seq-mask-tis" – zero out sequences by geometric-mean IS ratio, non-truncated token IS correction
+  truncated_importance_sampling_type: null
   truncated_importance_sampling_ratio: null
   truncated_importance_sampling_ratio_min: null  # Lower bound for ICE-POP
-  truncated_importance_sampling_type: tis  # "tis" (clamp to max) or "icepop" (filter outside [min, max])
   sequence_level_importance_ratios: false
   token_level_loss: true
   force_on_policy_ratio: false  # Set to true to force ratio=1.0 (requires train_global_batch_size == num_prompts_per_step * num_generations_per_prompt)

--- a/tests/unit/reference_configs/rm.yaml
+++ b/tests/unit/reference_configs/rm.yaml
@@ -1,0 +1,222 @@
+# Bradley-Terry (BT) Reward Model Training Configuration
+rm:
+  ## total number of steps to train will equal
+  ## min((max_num_epochs * len(train_dataloader)), max_num_steps)
+  max_num_epochs: 1
+  max_num_steps: -1  # by default, train for 1 epoch
+
+  val_period: 16
+  val_batches: -1
+  val_global_batch_size: 32
+  val_micro_batch_size: 1
+  val_at_start: false
+  val_at_end: false
+  seed: 42
+
+checkpointing:
+  enabled: true
+  checkpoint_dir: "results/rm"
+  metric_name: "val:validation-default_loss" # one of "val:" or "train:" followed by the metric name
+  higher_is_better: false
+  keep_top_k: 3
+  save_period: ${rm.val_period}
+  checkpoint_must_save_by: null
+  save_optimizer: true
+
+policy:
+  model_name: "meta-llama/Llama-3.2-1B-Instruct"
+  tokenizer:
+    name: ${policy.model_name} ## specify if you'd like to use a tokenizer different from the model's default
+    # We don't use the "default" chat template because the Llama tokenizer inserts the current
+    # date in the system prompt, which could make the reward model's output date-dependent.
+    chat_template: "{{- bos_token }}\n\n{#- This block extracts the system message, so we can slot it into the right place. #}\n{%- if messages[0]['role'] == 'system' %}\n    {%- set system_message = messages[0]['content']|trim %}\n    {%- set messages = messages[1:] %}\n{%- else %}\n    {%- set system_message = '' %}\n{%- endif %}\n\n{#- System message #}\n{{- '<|start_header_id|>system<|end_header_id|>\n\n' }}\n{{- system_message }}\n{{- '<|eot_id|>' }}\n\n{%- for message in messages %}\n    {{- '<|start_header_id|>' + message['role'] + '<|end_header_id|>\n\n' + message['content'] | trim + '<|eot_id|>' }}\n{%- endfor %}\n{%- if add_generation_prompt %}\n    {{- '<|start_header_id|>assistant<|end_header_id>\n\n' }}\n{%- endif %}"
+    chat_template_kwargs: null # can be used to pass kwargs to the chat template, e.g., enable_thinking=true
+  train_global_batch_size: 128
+  train_micro_batch_size: 1
+  max_total_sequence_length: 8192
+  precision: "bfloat16"
+  activation_checkpointing_enabled: false
+
+  offload_optimizer_for_logprob: false
+
+  reward_model_cfg:
+    enabled: true  # loads model as a Reward Model (do not change)
+    reward_model_type: "bradley_terry"  # only "bradley_terry" is currently supported
+
+  dtensor_cfg:
+    enabled: true
+    cpu_offload: false
+    sequence_parallel: false
+    activation_checkpointing: false
+    tensor_parallel_size: 1
+    context_parallel_size: 1
+    custom_parallel_plan: null
+
+  dynamic_batching:
+    enabled: false
+
+  sequence_packing:
+    enabled: false
+
+  # makes the training sequence length divisible by the tensor parallel size
+  # this is useful for sequence parallel training
+  make_sequence_length_divisible_by: ${policy.dtensor_cfg.tensor_parallel_size}
+  max_grad_norm: 1.0
+
+  optimizer:
+    name: "torch.optim.AdamW"
+    kwargs:
+      lr: 2.0e-6
+      weight_decay: 0.1
+      betas: [0.9, 0.98]
+      eps: 1e-5
+      # when using Dtensor, we need to set `foreach` and `fused` to false
+      foreach: false
+      fused: false
+    
+  ## ignored since enabled=false, but needed for testing purposes
+  megatron_cfg:
+    enabled: false
+    force_reconvert_from_hf: False # Set to True to force reconvert of the model from Hugging Face
+    empty_unused_memory_level: 1
+    activation_checkpointing: false
+    tensor_model_parallel_size: 2
+    pipeline_model_parallel_size: 2
+    context_parallel_size: 1
+    pipeline_dtype: ${policy.precision}
+    num_layers_in_first_pipeline_stage: null
+    num_layers_in_last_pipeline_stage: null
+    sequence_parallel: false
+    gradient_accumulation_fusion: false
+
+    optimizer:
+      optimizer: "adam"
+      lr: 2.0e-6
+      min_lr: 1.9999e-6
+      weight_decay: 0.1
+      bf16: false
+      fp16: false
+      params_dtype: "float32"
+
+      #adam
+      adam_beta1: 0.9
+      adam_beta2: 0.98
+      adam_eps: 1e-5
+
+      #sgd
+      sgd_momentum: 0.9
+
+      #distributed optimizer
+      use_distributed_optimizer: true
+      use_precision_aware_optimizer: true
+
+      clip_grad: ${policy.max_grad_norm}
+
+      # optimizer cpu offload
+      optimizer_cpu_offload: false
+      optimizer_offload_fraction: 0.0
+
+    scheduler:
+      start_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
+      end_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
+      weight_decay_incr_style: "constant"
+      lr_decay_style: "constant"
+      lr_decay_iters: 1000
+      lr_warmup_iters: 50
+      lr_warmup_init: 1.9999e-6
+
+    distributed_data_parallel_config:
+      grad_reduce_in_fp32: false
+      overlap_grad_reduce: true
+      overlap_param_gather: false
+      data_parallel_sharding_strategy: "optim_grads_params"
+
+    fp8_cfg:
+      enabled: false
+      fp8: "e4m3"
+      fp8_recipe: "blockwise"
+      fp8_param: false
+    
+data:
+  max_input_seq_length: ${policy.max_total_sequence_length}
+  shuffle: true
+  num_workers: 1
+
+  # dataset
+  train:
+    dataset_name: HelpSteer3
+    split: train
+  validation:
+    dataset_name: HelpSteer3
+    split: validation
+  # You can use custom preference datasets for training and validation. For example:
+  # 1. PreferenceDataset
+  #   train:
+  #     # this dataset will override prompt_key and use the default values for other vars
+  #     data_path: /path/to/local/train_dataset.jsonl  # local file or hf_org/hf_dataset_name (HuggingFace)
+  #     subset: null  # used for HuggingFace datasets
+  #     split: train  # used for HuggingFace datasets
+  #   validation:
+  #     # this dataset will use the default values for other vars except data_path
+  #     data_path: /path/to/local/val_dataset.jsonl
+  #   default:
+  #     # will use below vars as default values if dataset doesn't specify it
+  #     dataset_name: PreferenceDataset
+  #     prompt_file: null
+  #     system_prompt_file: null
+  #   # multiple validation sets is supported by using val_data_paths
+  #   # this will be removed after refactor
+  #   val_data_paths:
+  #     <NameOfValidationDataset1>: /path/to/local/val_dataset_1.jsonl
+  #     <NameOfValidationDataset2>: /path/to/local/val_dataset_2.jsonl
+  # 2. BinaryPreferenceDataset
+  #   train:
+  #     # this dataset will override prompt_key and use the default values for other vars
+  #     data_path: /path/to/local/train_dataset.jsonl  # local file or hf_org/hf_dataset_name (HuggingFace)
+  #     prompt_key: context
+  #     subset: null  # used for HuggingFace datasets
+  #     split: train  # used for HuggingFace datasets
+  #   validation:
+  #     # this dataset will use the default values for other vars except data_path
+  #     data_path: /path/to/local/val_dataset.jsonl
+  #   default:
+  #     # will use below vars as default values if dataset doesn't specify it
+  #     dataset_name: BinaryPreferenceDataset
+  #     prompt_key: prompt
+  #     chosen_key: chosen
+  #     rejected_key: rejected
+  #     prompt_file: null
+  #     system_prompt_file: null
+  # See https://github.com/NVIDIA-NeMo/RL/blob/main/docs/guides/rm.md#datasets for more details.
+
+  # If you are doing checkpointing, `metric_name` should reflect the metric and validation set to be tracked. For example:
+  #   checkpointing:
+  #     metric_name: "validation-<NameOfValidationDataset1>_loss"
+  #   ...
+
+logger:
+  log_dir: "logs"  # Base directory for all logs
+  wandb_enabled: true # Make sure you do a ``wandb login [Your API key]'' before running
+  tensorboard_enabled: true
+  mlflow_enabled: false
+  swanlab_enabled: false # Disable SwanLab logging
+  monitor_gpus: true  # If true, will monitor GPU usage and log to wandb and/or tensorboard
+  wandb:
+    project: "rm-dev"
+    name: "rm-dev-${data.train.dataset_name}"
+  swanlab:
+    project: "rm-dev"
+    name: "rm-dev-${data.train.dataset_name}"
+  tensorboard:
+    log_dir: "tb_logs-rm-dev-${data.train.dataset_name}"
+  mlflow:
+    experiment_name: "rm-dev"
+    run_name: "rm-dev-${data.train.dataset_name}"
+    tracking_uri: "http://localhost:5000"
+  gpu_monitoring:
+    collection_interval: 10  # How often to collect GPU usage metrics (in seconds)
+    flush_interval: 10  # How often to flush GPU usage metrics to the loggers (in seconds)
+
+cluster:
+  gpus_per_node: 1
+  num_nodes: 1

--- a/tests/unit/reference_configs/sft.yaml
+++ b/tests/unit/reference_configs/sft.yaml
@@ -1,0 +1,272 @@
+# SFT Algorithm Configuration
+sft:
+  ## total number of steps to train will equal
+  ## min((max_num_epochs * len(train_dataloader)), max_num_steps)
+  max_num_epochs: 1
+  max_num_steps: 60
+
+  val_period: 10
+  val_batches: 8
+  val_global_batch_size: 32
+  val_micro_batch_size: 1
+  val_at_start: true
+  val_at_end: false
+  seed: 42
+
+checkpointing:
+  enabled: true
+  checkpoint_dir: "results/sft"
+  metric_name: "val:val_loss" # one of "val:" or "train:" followed by the metric name
+  higher_is_better: false
+  keep_top_k: 3
+  save_period: 10
+  checkpoint_must_save_by: null
+  save_optimizer: true
+
+policy:
+  model_name: "meta-llama/Llama-3.2-1B"
+  tokenizer:
+    name: ${policy.model_name} ## specify if you'd like to use a tokenizer different from the model's default
+    # chat_template can be a Jinja template string or path to a .jinja file
+    chat_template: "{% for message in messages %}{%- if message['role'] == 'system'  %}{{'Context: ' + message['content'].strip()}}{%- elif message['role'] == 'user'  %}{{' Question: ' + message['content'].strip() + ' Answer:'}}{%- elif message['role'] == 'assistant'  %}{{' ' + message['content'].strip()}}{%- endif %}{% endfor %}"
+    chat_template_kwargs: null # can be used to pass kwargs to the chat template, e.g., enable_thinking=true
+  train_global_batch_size: 32
+  train_micro_batch_size: 1
+  max_total_sequence_length: 1024
+  precision: "bfloat16"
+
+  offload_optimizer_for_logprob: false
+
+  dtensor_cfg:
+    _v2: true
+    enabled: true
+    env_vars: {}
+    cpu_offload: False
+    sequence_parallel: false
+    activation_checkpointing: false
+    tensor_parallel_size: 1
+    context_parallel_size: 1
+    custom_parallel_plan: null
+
+    # Automodel kwargs passed to from_pretrained.
+    # Uncomment force_hf if the custom model's adapter doesn't support per-tensor
+    # weight conversion (e.g. Qwen2, Llama). Auto-detected if not set.
+    # See https://github.com/NVIDIA-NeMo/RL/issues/2072
+    automodel_kwargs: {}
+      # force_hf: true
+
+    # LoRA (Low-Rank Adaptation) Configuration
+    lora_cfg:
+      enabled: False  # Set to True to enable LoRA fine-tuning
+      target_modules: []  # List of module names to apply LoRA (empty list with match_all_linear=true applies to all linear layers)
+      exclude_modules: []  # List of module names to exclude from LoRA
+      match_all_linear: true  # If True, applies LoRA to all linear layers (overrides target_modules)
+      dim: 8  # LoRA rank (r): lower rank = fewer parameters but less capacity. Typical values: 4, 8, 16, 32, 64
+      alpha: 32  # LoRA scaling factor: effective learning rate multiplier = alpha/dim. Typical values: 16, 32, 64
+      dropout: 0.0  # Dropout probability applied to LoRA layers (0.0 = no dropout)
+      dropout_position: "post"  # Where to apply dropout: "pre" (before LoRA) or "post" (after LoRA)
+      lora_A_init: "xavier"  # Initialization method for LoRA A matrix: "xavier" or "uniform"
+      use_triton: true  # Use Triton-optimized kernels for LoRA (faster but requires flash-attn). Disable when tensor_parallel_size > 1
+
+  dynamic_batching:
+    enabled: false
+    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
+    sequence_length_round: 64
+
+  sequence_packing:
+    enabled: False
+    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
+    algorithm: "modified_first_fit_decreasing"
+    sequence_length_round: 64
+
+  # makes the training sequence length divisible by the tensor parallel size
+  # this is useful for sequence parallel training
+  make_sequence_length_divisible_by: ${policy.dtensor_cfg.tensor_parallel_size}
+  max_grad_norm: 1.0
+
+  optimizer:
+    name: "torch.optim.AdamW"
+    kwargs:
+      lr: 5.0e-6
+      weight_decay: 0.1
+      betas: [0.9, 0.98]
+      eps: 1e-5
+      # when using Dtensor, we need to set foreach
+      # and fused to False
+      foreach: False
+      fused: False
+    
+  ## ignored since enabled=false, but needed for testing purposes
+  megatron_cfg:
+    enabled: false
+    use_linear_ce_fusion_loss: false
+    linear_ce_fusion_chunk_size: 256
+    force_reconvert_from_hf: False # Set to True to force reconvert of the model from Hugging Face
+    env_vars: {}
+    empty_unused_memory_level: 1
+    activation_checkpointing: false
+    tensor_model_parallel_size: 1
+    expert_tensor_parallel_size: 1
+    expert_model_parallel_size: 1
+    pipeline_model_parallel_size: 1
+    context_parallel_size: 1
+    pipeline_dtype: ${policy.precision}
+    num_layers_in_first_pipeline_stage: null
+    num_layers_in_last_pipeline_stage: null
+    sequence_parallel: false
+    freeze_moe_router: false
+    moe_router_dtype: null
+    moe_router_load_balancing_type: "aux_loss"
+    moe_router_bias_update_rate: 1e-3
+    moe_permute_fusion: true
+    #gives ~20% training perf speedup with sequence packing 
+    apply_rope_fusion: True
+    # gives ~25% training perf speedup with sequence packing and apply_rope_fusion
+    bias_activation_fusion: True
+    defer_fp32_logits: False
+    moe_per_layer_logging: False
+    moe_enable_deepep: false
+    moe_token_dispatcher_type: "alltoall"
+    moe_shared_expert_overlap: false
+    gradient_accumulation_fusion: false
+
+    peft:
+      enabled: false
+      target_modules: []
+      exclude_modules: []
+      dim: 8
+      alpha: 32
+      dropout: 0.0
+      dropout_position: "post"
+      lora_A_init_method: "xavier"
+      lora_B_init_method: "zero"
+      a2a_experimental: false
+      lora_dtype: None
+
+
+    optimizer:
+      optimizer: "adam" # When weight decay is set, it actually uses AdamW 
+      lr: 5.0e-6
+      min_lr: 4.9999e-6
+      weight_decay: 0.1 # When weight decay is set, it actually uses AdamW
+      bf16: true
+      fp16: false
+      params_dtype: "float32"
+
+      #adam
+      adam_beta1: 0.9
+      adam_beta2: 0.98
+      adam_eps: 1e-5
+
+      #sgd
+      sgd_momentum: 0.9
+
+      #distributed optimizer
+      use_distributed_optimizer: true
+      use_precision_aware_optimizer: true
+
+      clip_grad: ${policy.max_grad_norm}
+
+      # optimizer cpu offload
+      optimizer_cpu_offload: false
+      optimizer_offload_fraction: 0.0
+
+    scheduler:
+      start_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
+      end_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
+      weight_decay_incr_style: "constant"
+      lr_decay_style: "constant"
+      lr_decay_iters: 1000
+      lr_warmup_iters: 50
+      lr_warmup_init: 4.9999e-6
+
+    distributed_data_parallel_config:
+      grad_reduce_in_fp32: false
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+      data_parallel_sharding_strategy: "optim_grads_params"
+      use_custom_fsdp: false
+
+    fp8_cfg:
+      enabled: false
+      fp8: "e4m3"
+      fp8_recipe: "blockwise"
+      fp8_param: false
+
+data:
+  max_input_seq_length: ${policy.max_total_sequence_length}
+  add_bos: true
+  add_eos: true
+  add_generation_prompt: false
+  shuffle: true
+  num_workers: 1
+
+  # dataset
+  train:
+    dataset_name: "squad"
+    split: "train"
+  validation:
+    dataset_name: "squad"
+    split: "validation"
+  # default settings for all datasets
+  default:
+    prompt_file: null
+    system_prompt_file: null
+    processor: "sft_processor"
+
+  # You can also use multiple datasets by using a list of datasets.
+  # See `examples/configs/grpo_multiple_datasets.yaml` for a full configuration example.
+
+  # You can use custom response datasets for training and validation. For example:
+  # train:
+  #   # this dataset will override input_key and use the default values for other vars
+  #   data_path: /path/to/local/train_dataset.jsonl
+  #   input_key: question
+  # validation:
+  #   # this dataset will use the default values for other vars except data_path
+  #   data_path: /path/to/local/val_dataset.jsonl
+  # default:
+  #   # will use below vars as default values if dataset doesn't specify it
+  #   dataset_name: ResponseDataset
+  #   input_key: input
+  #   output_key: output
+  #   prompt_file: null
+  #   system_prompt_file: null
+  #   processor: "sft_processor"
+  # See https://github.com/NVIDIA-NeMo/RL/blob/main/docs/guides/sft.md#datasets for more details.
+
+  # OpenAI format specific configs
+  # train_data_path: "/path/to/train.jsonl"  # Path to training data
+  # val_data_path: "/path/to/val.jsonl"      # Path to validation data
+  # chat_key: "messages"                     # Key for messages in the data
+  # system_key: null                         # Key for system message (optional)
+  # system_prompt: null                      # Default system prompt (optional)
+  # tool_key: "tools"                        # Key for tools in the data
+  # use_preserving_dataset: false            # If true, uses PreservingDataset to preserve heterogeneous schemas (e.g., tool calls with varying argument structures)
+
+logger:
+  log_dir: "logs"  # Base directory for all logs
+  wandb_enabled: true # Make sure you do a ``wandb login [Your API key]'' before running
+  tensorboard_enabled: true
+  mlflow_enabled: false
+  swanlab_enabled: false # Disable SwanLab logging
+  monitor_gpus: true  # If true, will monitor GPU usage and log to wandb and/or tensorboard
+  wandb:
+    project: "sft-dev"
+    name: "sft-dev-${data.train.dataset_name}"
+  swanlab:
+    project: "sft-dev"
+    name: "sft-dev-${data.train.dataset_name}"
+  tensorboard:
+    log_dir: "tb_logs-sft-dev-${data.train.dataset_name}"
+  mlflow:
+    experiment_name: "sft-dev"
+    run_name: "sft-dev-${data.train.dataset_name}"
+    tracking_uri: "http://localhost:5000"
+  gpu_monitoring:
+    collection_interval: 10  # How often to collect GPU usage metrics (in seconds)
+    flush_interval: 10  # How often to flush GPU usage metrics to the loggers (in seconds)
+
+cluster:
+  gpus_per_node: 1
+  num_nodes: 1

--- a/tests/unit/test_config_v2.py
+++ b/tests/unit/test_config_v2.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/test_config_v2.py
+++ b/tests/unit/test_config_v2.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test config v1(typing.TypedDict) -> v2(pydantic.BaseModel) changes.
+
+This test verifies that the config v1(typing.TypedDict) -> v2(pydantic.BaseModel) changes won't introduce any new default values.
+This test file and `tests/unit/reference_configs` will be removed once we completely migrate from v1 to v2.
+"""
+
+import glob
+import os
+from pathlib import Path
+
+import pytest
+from omegaconf import OmegaConf
+
+from nemo_rl.algorithms.distillation import MasterConfig as DistillationMasterConfig
+from nemo_rl.algorithms.dpo import MasterConfig as DPOMasterConfig
+from nemo_rl.algorithms.grpo import MasterConfig as GRPOMasterConfig
+from nemo_rl.algorithms.rm import MasterConfig as RMMasterConfig
+from nemo_rl.algorithms.sft import MasterConfig as SFTMasterConfig
+from nemo_rl.evals.eval import MasterConfig as EvalMasterConfig
+from nemo_rl.utils.config import load_config, register_omegaconf_resolvers
+
+# # All tests in this module should run first
+# pytestmark = pytest.mark.run_first
+
+register_omegaconf_resolvers()
+
+
+absolute_dir = os.path.dirname(os.path.abspath(__file__))
+real_configs_dir = Path(os.path.join(absolute_dir, "../../examples/configs"))
+reference_configs_dir = Path(os.path.join(absolute_dir, "reference_configs"))
+reference_config_files = glob.glob(
+    str(reference_configs_dir / "*.yaml"), recursive=True
+)
+
+
+def _collect_mismatched_keys(real: dict, reference: dict, path: str = ""):
+    """Return keys present in real but absent in reference, and keys with differing values.
+
+    Returns:
+        missing: keys in real but not in reference.
+        different: keys in both but with different values (leaf nodes only).
+    """
+    missing = []
+    different = []
+    for key, value in real.items():
+        full_key = f"{path}.{key}" if path else key
+        if key not in reference:
+            missing.append(full_key)
+        elif isinstance(value, dict) and isinstance(reference[key], dict):
+            sub_missing, sub_different = _collect_mismatched_keys(
+                value, reference[key], full_key
+            )
+            missing.extend(sub_missing)
+            different.extend(sub_different)
+        elif value != reference[key]:
+            different.append(
+                f"{full_key}: real={value!r}, reference={reference[key]!r}"
+            )
+    return missing, different
+
+
+@pytest.mark.parametrize("reference_config_file", reference_config_files)
+def test_reference_configs_up_to_date(reference_config_file):
+    """Test that the reference config is up to date."""
+
+    print(f"\nValidating config file: {reference_config_file}")
+
+    if "/eval.yaml" in reference_config_file:
+        real_config_file = (
+            real_configs_dir / "evals" / os.path.basename(reference_config_file)
+        )
+    else:
+        real_config_file = real_configs_dir / os.path.basename(reference_config_file)
+
+    reference_config = load_config(reference_config_file)
+    reference_config_dict = OmegaConf.to_container(reference_config, resolve=True)
+    real_config = load_config(real_config_file)
+    real_config_dict = OmegaConf.to_container(real_config, resolve=True)
+
+    missing, different = _collect_mismatched_keys(
+        real_config_dict, reference_config_dict
+    )
+    assert len(missing) == 0, (
+        f"\nKeys present in real config {real_config_file} but missing from reference config {reference_config_file}:\n"
+        + "\n".join(f"  - {k}" for k in missing)
+        + f"\nPlease add the missing keys to {reference_config_file}.",
+    )
+    assert len(different) == 0, (
+        f"\nKeys present in both real config {real_config_file} and reference config {reference_config_file} but with different values:\n"
+        + "\n".join(f"  - {k}" for k in different)
+        + f"\nPlease update the values in {reference_config_file} to match the values in {real_config_file}.",
+    )
+
+
+@pytest.mark.parametrize("config_file", reference_config_files)
+def test_config_v2_same_as_v1(config_file):
+    """Test that the config v2's behavior is the same as the config v1."""
+
+    print(f"\nValidating config file: {config_file}")
+
+    config = load_config(config_file)
+    config_v1 = OmegaConf.to_container(config, resolve=True)
+
+    if "eval" in config_v1:
+        master_config_class = EvalMasterConfig
+    elif "distillation" in config_v1:
+        master_config_class = DistillationMasterConfig
+    elif "dpo" in config_v1:
+        master_config_class = DPOMasterConfig
+    elif "sft" in config_v1:
+        master_config_class = SFTMasterConfig
+    elif "grpo" in config_v1:
+        master_config_class = GRPOMasterConfig
+    elif "rm" in config_v1:
+        master_config_class = RMMasterConfig
+
+    config_v2 = master_config_class(**config_v1)
+    config_v2 = config_v2.model_dump()
+
+    # Check v1 keys missing from v2, and differing values
+    missing_in_v2, different = _collect_mismatched_keys(config_v1, config_v2)
+    # Check v2 keys missing from v1 (new defaults introduced by Pydantic model)
+    missing_in_v1, _ = _collect_mismatched_keys(config_v2, config_v1)
+
+    # Check new defaults introduced by Pydantic model
+    assert len(missing_in_v1) == 0, (
+        f"\nKeys present in v2 config but missing from v1 ({config_file}) — Pydantic introduced new defaults:\n"
+        + "\n".join(f"  - {k}" for k in missing_in_v1)
+        + f"\nPlease make sure the code behavior is not changed and add the missing keys to {config_file} to pass the test.",
+    )
+    # Theoretically, the two things below shouldn't happen, but let's check them anyway.
+    assert len(missing_in_v2) == 0, (
+        f"\nKeys present in v1 config but missing from v2 ({config_file}):\n"
+        + "\n".join(f"  - {k}" for k in missing_in_v2)
+    )
+    assert len(different) == 0, (
+        f"\nKeys present in both v1 and v2 but with different values ({config_file}):\n"
+        + "\n".join(f"  - {k}" for k in different)
+    )

--- a/tests/unit/test_config_v2.py
+++ b/tests/unit/test_config_v2.py
@@ -33,8 +33,8 @@ from nemo_rl.algorithms.sft import MasterConfig as SFTMasterConfig
 from nemo_rl.evals.eval import MasterConfig as EvalMasterConfig
 from nemo_rl.utils.config import load_config, register_omegaconf_resolvers
 
-# # All tests in this module should run first
-# pytestmark = pytest.mark.run_first
+# All tests in this module should run first
+pytestmark = pytest.mark.run_first
 
 register_omegaconf_resolvers()
 

--- a/tests/unit/utils/test_checkpoint.py
+++ b/tests/unit/utils/test_checkpoint.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import json
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
@@ -48,7 +49,8 @@ def test_init_tmp_checkpoint(checkpoint_manager, checkpoint_dir):
     # Test creating a new checkpoint
     step = 1
     training_info = {"loss": 0.5, "tensor": torch.tensor(0.5), "numpy": np.array(0.5)}
-    run_config = {"model": "test"}
+    run_config = MagicMock()
+    run_config.model_dump.return_value = {"model": "test"}
 
     save_dir = checkpoint_manager.init_tmp_checkpoint(step, training_info, run_config)
 
@@ -66,7 +68,7 @@ def test_init_tmp_checkpoint(checkpoint_manager, checkpoint_dir):
     # Check if config was saved
     with open(save_dir / "config.yaml", "r") as f:
         saved_config = yaml.safe_load(f)
-        assert saved_config == run_config
+        assert saved_config == run_config.model_dump()
 
 
 def test_finalize_checkpoint(checkpoint_manager, checkpoint_dir):


### PR DESCRIPTION
## Related issues
1. https://github.com/NVIDIA-NeMo/RL/issues/1675
2. https://github.com/NVIDIA-NeMo/RL/issues/2102

## Summary

This PR refactors `MasterConfig` (in all algorithm entry points: `grpo.py`, `sft.py`, `dpo.py`, `rm.py`, `distillation.py`, `eval.py`) and `ClippedPGLossConfig` from `TypedDict` to `pydantic.BaseModel`.

We can now get four abilities when overriding config fields via Hydra/OmegaConf:

1. **Default values** — Fields omitted from the YAML use their Python-defined defaults.
   ```python
   # disable_ppo_ratio is defined with `= False` in ClippedPGLossConfig
   # but absent from examples/configs/grpo_math_1B.yaml — resolves to False
   loss_config.disable_ppo_ratio  # False
   ```
2. **Custom/extra fields** — Ad-hoc fields can be injected from the command line without modifying the config class.
   ```bash
   uv run python examples/run_grpo.py ++loss_fn.custom=1
   # cfg.custom is now accessible inside ClippedPGLossFn.__init__
   ```
3. **Type validation** — Pydantic validates field types at runtime.
   ```bash
   uv run python examples/run_grpo.py ++loss_fn.disable_ppo_ratio=1.2
   # Will raise error: "Input should be a valid boolean [type=bool_type, input_value=1.2, input_type=float]"
   ```
4. **Go-to-definition** — IDE navigation works on attribute access. Clicking on `config.disable_ppo_ratio` jumps directly to the field definition in `ClippedPGLossConfig`, whereas the previous dict-style access (`config["disable_ppo_ratio"]`) was opaque to static analysis tools.

## Changes

- `MasterConfig` in `grpo.py`, `sft.py`, `dpo.py`, `rm.py`, `distillation.py`, `eval.py`: `TypedDict` → `BaseModel(extra="allow")`
- `ClippedPGLossConfig` in `loss_functions.py`: `TypedDict` → `BaseModel(extra="allow")`
- All dict-style access (`config["key"]`) on these two config types updated to attribute access (`config.key`)
- `skills/config-conventions/SKILL.md` updated to reflect the new `BaseModel` convention

## Results before / after the changes

<img width="2728" height="628" alt="image" src="https://github.com/user-attachments/assets/7ddd0c76-a390-4863-966b-14e17bcdebd3" />