### PR TITLE
fix: preserve matched filenames in `no-underscore-md` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@ repos:
       - id: no-underscore-md
         name: "Disallow '_' in Markdown filenames"
         language: system
+        # With `bash -c`, the first extra arg becomes `$0`, so `--` keeps matched filenames in `"$@"`.
         entry: |
           bash -c '
             # Report the offending files
@@ -35,7 +36,7 @@ repos:
               echo "  - $file (use hyphens instead)" >&2
             done
             exit 1
-          '
+          ' --
         files: '.*\/[^\/]*_[^\/]*\.md$'
         exclude: '^\.github/'
         types: [file]


### PR DESCRIPTION
# What does this PR do ?

Without `--`, the first matched filename is treated as `$0` by `bash -c`, which means the hook can fail without reporting every offending Markdown file.

- pass `--` to `bash -c` in the `no-underscore-md` local pre-commit hook
- add an inline comment explaining why the separator is required

```bash
bash -c 'echo "Hi! $@"' "foo" "bar"
# Hi! bar

bash -c 'echo "Hi! $@"' -- "foo" "bar"
# Hi! foo bar
```

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
