### PR TITLE
cp: `perf: Improve deepseek perf` into `r0.6.0`

### DIFF
--- a/examples/configs/recipes/llm/performance/grpo-deepseek-v3-32n4g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-deepseek-v3-32n4g.yaml
@@ -2,8 +2,6 @@ defaults: ./grpo-deepseek-v3-32n8g.yaml
 checkpointing:
   checkpoint_dir: results/grpo-deepseek-v3-32n4g
 policy:
-  sequence_packing:
-    enabled: false
   megatron_cfg:
     pipeline_model_parallel_size: 8
     num_layers_in_first_pipeline_stage: 7

--- a/examples/configs/recipes/llm/performance/grpo-deepseek-v3-32n8g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-deepseek-v3-32n8g.yaml
@@ -15,6 +15,8 @@ policy:
   logprob_batch_size: 1
   max_total_sequence_length: 1536
   make_sequence_length_divisible_by: 1
+  sequence_packing:
+    fuse_loss: true
   dtensor_cfg:
     enabled: false
   megatron_cfg:

--- a/examples/configs/recipes/llm/performance/grpo-deepseek-v3-64n4g-async-1off.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-deepseek-v3-64n4g-async-1off.yaml
@@ -2,8 +2,6 @@ defaults: ./grpo-deepseek-v3-64n8g-async-1off.yaml
 checkpointing:
   checkpoint_dir: results/grpo-deepseek-v3-64n4g-async-1off
 policy:
-  sequence_packing:
-    enabled: false
   megatron_cfg:
     pipeline_model_parallel_size: 8
     num_layers_in_first_pipeline_stage: 7


### PR DESCRIPTION
## Summary
- Cherry-pick of e34430d338 (`Improve deepseek perf`) into `r0.6.0`
- Adjusts DeepSeek V3 performance recipe configs (32n4g, 32n8g, 64n4g-async-1off)

## Test plan
- [ ] Verify perf recipes run correctly on nemo-ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)