### PR TITLE
Task 1 shard preemption retry

### DIFF
--- a/docs/vastai-setup.md
+++ b/docs/vastai-setup.md
@@ -1,0 +1,201 @@
+# Vast.ai Development Environment Setup
+
+This guide walks through setting up a NeMo RL development environment on Vast.ai for running unit and integration tests. This is particularly useful for testing the `cpu_serialize` weight transfer path, which was designed for containers that lack `CAP_SYS_PTRACE` / `--ipc=host` (the default on Vast.ai).
+
+## Machine Selection
+
+### Template Configuration
+
+- **Docker Image**: `nvcr.io/nvidia/nemo-rl:v0.5.0`
+- **Container Disk**: 120 GB minimum (60 GB will cause `No space left on device` during dependency builds)
+
+### GPU Requirements
+
+Different tests have different VRAM requirements:
+
+| Test Type | Minimum GPU | Notes |
+|-----------|-------------|-------|
+| Unit tests (`test_utils.py`) | 1x GPU, any VRAM | Basic transport protocol tests |
+| `cpu_serialize` integration tests | 2x RTX 4090 (24 GB) | Sufficient for `cpu_serialize` path |
+| `cuda_ipc` integration tests | 2x GPU with ≥40 GB VRAM (L40, A40, A100) | `cuda_ipc` requires `--ipc=host` which Vast.ai does not provide; these tests will fail on Vast.ai regardless of VRAM |
+
+> **Note**: Vast.ai containers do not have `CAP_SYS_PTRACE` / `--ipc=host`, so `cuda_ipc` weight transfer will not work. This is the reason the `cpu_serialize` fallback path exists. The `cuda_ipc` regression tests can still be run if the underlying ZMQ transport works, but CUDA IPC handle sharing across processes may fail depending on the container configuration.
+
+## Initial Setup
+
+### 1. SSH into the Machine
+
+Vast.ai provides SSH connection details on the instance page. Typically:
+
+```bash
+ssh -p <port> root@<host> -L 8080:localhost:8080
+```
+
+### 2. Clone the Repository
+
+```bash
+cd /workspace
+git clone https://github.com/<your-fork>/RL.git
+cd RL
+git checkout <your-branch>
+```
+
+### 3. Fix Python Version Constraint
+
+The NeMo RL container ships Python 3.12, but `pyproject.toml` may require a newer version. Fix this:
+
+```bash
+# Check current Python version
+python3 --version
+
+# If pyproject.toml requires a version higher than what's installed:
+sed -i 's/requires-python = ">=3\.[0-9]*\.[0-9]*"/requires-python = ">=3.12"/' pyproject.toml
+sed -i 's/requires-python = ">=3\.[0-9]*\.[0-9]*"/requires-python = ">=3.12"/' 3rdparty/Megatron-LM-workspace/Megatron-LM/megatron/core/distributed/fsdp/pyproject.toml
+```
+
+> **Note**: Do not commit these changes. They are local workarounds for the Vast.ai container environment.
+
+### 4. Set Up HuggingFace Token
+
+Some tests download gated models. Set your HF token:
+
+```bash
+export HF_TOKEN=<your-token>
+# Or persist it:
+huggingface-cli login
+```
+
+### 5. Install Dependencies
+
+```bash
+pip install -e ".[dev,test]" --break-system-packages
+```
+
+## Running Tests
+
+### Key Flags
+
+Every test command should include these flags:
+
+- `-o "addopts="` — Overrides `pyproject.toml` default addopts (which includes `--testmon`, not available in the container)
+- `--timeout=0` — Disables timeout (first run compiles flash-attn, mamba-ssm, etc. in Ray worker venvs, which can take 10+ minutes)
+- `-v -s` — Verbose output with stdout
+
+Always stop Ray before each test to avoid stale process issues:
+
+```bash
+ray stop --force
+```
+
+### Full Test Command Template
+
+```bash
+ray stop --force && pytest <test_path> -v -s -o "addopts=" --timeout=0
+```
+
+### Unit Tests (Transport Protocol)
+
+```bash
+ray stop --force && pytest tests/unit/models/policy/test_utils.py -k "stream_weights" -v -s -o "addopts=" --timeout=0
+```
+
+### Integration Tests (cpu_serialize)
+
+```bash
+# Async refit (production path) — most important test
+ray stop --force && pytest tests/unit/models/generation/test_vllm_generation.py::test_vllm_async_refit_cpu_serialize -v -s -o "addopts=" --timeout=0
+
+# Direct ZMQ weight update
+ray stop --force && pytest tests/unit/models/generation/test_vllm_generation.py::test_vllm_direct_zmq_weight_update_cpu_serialize -v -s -o "addopts=" --timeout=0
+```
+
+### Regression Tests (cuda_ipc)
+
+```bash
+ray stop --force && pytest tests/unit/models/generation/test_vllm_generation.py::test_vllm_weight_update_and_prefix_cache_reset -v -s -o "addopts=" --timeout=0
+```
+
+> **Note**: On GPUs with ≤24 GB VRAM, this test may fail with a buffer sizing assertion (`Parameter model.embed_tokens.weight too large for buffer`). This is a pre-existing limitation of the `0.3 * free_memory` buffer calculation on small-VRAM GPUs, not a regression.
+
+## Troubleshooting
+
+### Ray Worker Venv Issues
+
+Ray creates isolated virtual environments for workers at `/opt/ray_venvs/`. These can become stale or have version mismatches.
+
+**Symptom**: `ModuleNotFoundError: No module named 'megatron'` in Ray workers, or `ValueError: runtime_env_agent_port must be an integer between 1024 and 65535`.
+
+**Fix**: Delete stale venvs and force rebuild:
+
+```bash
+rm -rf /opt/ray_venvs/*
+NRL_FORCE_REBUILD_VENVS=true pytest <your_test> -v -s -o "addopts=" --timeout=0
+```
+
+If Megatron is still not found after rebuild, add `.pth` files to the worker venvs:
+
+```bash
+# Find the site-packages directories in worker venvs
+find /opt/ray_venvs/ -name "site-packages" -type d
+
+# For each one, add a .pth file pointing to the main venv's packages
+echo "/opt/nemo_rl_venv/lib/python3.12/site-packages" > /opt/ray_venvs/<worker_venv>/lib/python3.12/site-packages/nemo_rl_main.pth
+```
+
+### Stale Ray Processes
+
+**Symptom**: `ConnectionError: GCS connection timed out` or tests hang at startup.
+
+**Fix**:
+
+```bash
+ray stop --force
+# If that doesn't work:
+pkill -9 -f ray
+```
+
+### Disk Space
+
+**Symptom**: `No space left on device` during pip install or venv builds.
+
+**Fix**: Clear caches:
+
+```bash
+rm -rf /root/.cache/pip /root/.cache/huggingface
+du -sh /root/.cache/*  # Check what's using space
+```
+
+> **Important**: Be careful not to delete packages that pip depends on (like `pluggy` or `urllib3`). If pip breaks, reinstall them:
+> ```bash
+> python3 -m ensurepip --upgrade
+> pip install --no-cache-dir pip setuptools wheel --break-system-packages
+> ```
+
+### Worker Venv Build Timeout
+
+**Symptom**: Test appears to hang during first run (compiling flash-attn, mamba-ssm, causal-conv1d).
+
+**Fix**: This is normal on first run. Use `--timeout=0` and wait 10-15 minutes. Subsequent runs reuse the compiled venvs.
+
+## Test Results
+
+Test results are saved to `tests/unit/unit_results/` with timestamps:
+
+```bash
+# List all test results
+ls -lt tests/unit/unit_results/
+
+# View a specific result
+cat tests/unit/unit_results/<timestamp>.json
+
+# Check exit status (0 = passed)
+jq '.exit_status' tests/unit/unit_results/<timestamp>.json
+```
+
+## Known Limitations
+
+1. **No CUDA IPC on Vast.ai**: Vast.ai containers lack `CAP_SYS_PTRACE` / `--ipc=host`, so `cuda_ipc` transport will not work. Use `NRL_MODEL_UPDATE_TRANSPORT=cpu_serialize` instead.
+
+2. **Buffer Sizing on Small GPUs**: The default buffer calculation (`free_memory * 0.3`) may produce buffers too small for the largest model parameters on GPUs with ≤24 GB VRAM. This affects both `cuda_ipc` and `cpu_serialize` paths equally and is a pre-existing framework limitation.
+
+3. **First-Run Compilation**: Ray worker venvs compile native extensions (flash-attn, mamba-ssm) on first use. Always use `--timeout=0` for the first run on a new machine.

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1154,8 +1154,12 @@ def refit_policy_generation(
                 update_success = True
             else:
                 # Original ZMQ IPC path for vLLM
+                model_update_transport = os.environ.get(
+                    "NRL_MODEL_UPDATE_TRANSPORT", "cuda_ipc"
+                )
                 futures_train = policy.stream_weights_via_ipc_zmq(
-                    buffer_size_bytes=buffer_size_bytes
+                    buffer_size_bytes=buffer_size_bytes,
+                    model_update_transport=model_update_transport,
                 )
                 futures_inference = policy_generation.update_weights_via_ipc_zmq()
                 # wait for all futures to complete

--- a/nemo_rl/models/generation/vllm/config.py
+++ b/nemo_rl/models/generation/vllm/config.py
@@ -26,6 +26,7 @@ class VllmSpecificArgs(TypedDict):
     # Additional arguments for vLLM inserted by nemo rl based on the context of when vllm is used
     skip_tokenizer_init: bool
     async_engine: bool
+    sleep_level: NotRequired[int]
     load_format: NotRequired[str]
     precision: NotRequired[str]
     kv_cache_dtype: Literal["auto", "fp8", "fp8_e4m3"]

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import gc
 import io
+import pickle
 import traceback
 from typing import Any
 
@@ -177,37 +178,39 @@ class VllmInternalWorkerExtension:
             self.maybe_init_zmq()
             while True:
                 # Blocking receive with timeout (this is the main operation)
-                payload = self.zmq_socket.recv_pyobj()
+                frames = self.zmq_socket.recv_multipart(copy=False)
 
-                if payload == IPCProtocol.COMPLETE:
-                    # means the update is done
-                    from vllm.model_executor.model_loader.utils import (
-                        process_weights_after_loading,
+                if len(frames) == 1:
+                    payload = pickle.loads(frames[0].buffer)
+                    if payload == IPCProtocol.COMPLETE:
+                        # means the update is done
+                        from vllm.model_executor.model_loader.utils import (
+                            process_weights_after_loading,
+                        )
+
+                        process_weights_after_loading(
+                            self.model_runner.model, self.model_config, self.device
+                        )
+                        self.zmq_socket.send(IPCProtocol.ACK.value.encode())
+                        break
+
+                    ipc_handle_or_bytes, list_keys, used_bytes = payload
+                    buffer = rebuild_cuda_tensor_from_ipc(
+                        ipc_handle_or_bytes, self.device.index
                     )
-
-                    process_weights_after_loading(
-                        self.model_runner.model, self.model_config, self.device
-                    )
-                    self.zmq_socket.send(IPCProtocol.ACK.value.encode())
-                    break
-
-                ipc_handle_or_bytes, list_keys, used_bytes = payload
-                if isinstance(ipc_handle_or_bytes, bytes):
-                    # cpu_serialize path: deserialize CPU tensor, DMA to GPU
+                elif len(frames) == 3 and bytes(frames[0].buffer) == b"cpu_serialize":
+                    list_keys, used_bytes = pickle.loads(frames[1].buffer)
                     bucket_data = torch.load(
-                        io.BytesIO(ipc_handle_or_bytes), weights_only=True
+                        io.BytesIO(frames[2].buffer), weights_only=True
                     )
                     buffer = bucket_data["bucket"]
                     if not buffer.is_pinned():
                         buffer = buffer.pin_memory()
-                    buffer = buffer.to(
-                        device=self.device, non_blocking=True
-                    )
+                    buffer = buffer.to(device=self.device, non_blocking=True)
                     torch.cuda.current_stream().synchronize()
                 else:
-                    # cuda_ipc path (existing)
-                    buffer = rebuild_cuda_tensor_from_ipc(
-                        ipc_handle_or_bytes, self.device.index
+                    raise RuntimeError(
+                        f"Unexpected ZMQ frame format in update_weights_via_ipc_zmq: {len(frames)} frame(s)"
                     )
 
                 weights = []

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import gc
+import io
 import traceback
 from typing import Any
 
@@ -190,8 +191,24 @@ class VllmInternalWorkerExtension:
                     self.zmq_socket.send(IPCProtocol.ACK.value.encode())
                     break
 
-                ipc_handle, list_keys, used_bytes = payload
-                buffer = rebuild_cuda_tensor_from_ipc(ipc_handle, self.device.index)
+                ipc_handle_or_bytes, list_keys, used_bytes = payload
+                if isinstance(ipc_handle_or_bytes, bytes):
+                    # cpu_serialize path: deserialize CPU tensor, DMA to GPU
+                    bucket_data = torch.load(
+                        io.BytesIO(ipc_handle_or_bytes), weights_only=True
+                    )
+                    buffer = bucket_data["bucket"]
+                    if not buffer.is_pinned():
+                        buffer = buffer.pin_memory()
+                    buffer = buffer.to(
+                        device=self.device, non_blocking=True
+                    )
+                    torch.cuda.current_stream().synchronize()
+                else:
+                    # cuda_ipc path (existing)
+                    buffer = rebuild_cuda_tensor_from_ipc(
+                        ipc_handle_or_bytes, self.device.index
+                    )
 
                 weights = []
                 offset = 0

--- a/nemo_rl/models/generation/vllm/vllm_generation.py
+++ b/nemo_rl/models/generation/vllm/vllm_generation.py
@@ -44,6 +44,12 @@ from nemo_rl.models.generation.vllm.utils import (
 )
 
 
+class ShardPreemptedError(RuntimeError):
+    def __init__(self, dp_rank: int):
+        super().__init__(f"Generation shard {dp_rank} was preempted")
+        self.dp_rank = dp_rank
+
+
 class VllmGeneration(GenerationInterface):
     def __init__(
         self,
@@ -207,6 +213,8 @@ class VllmGeneration(GenerationInterface):
         self.current_generate_dp_shard_idx = 0
         self._active_dp_ranks = set(range(self.worker_group.dp_size))
         self._active_dp_ranks_lock = threading.Lock()
+        self._preempted_dp_ranks: set[int] = set()
+        self._preempted_dp_ranks_lock = threading.Lock()
 
         # Save the device uuids for the workers
         self.device_uuids = self._report_device_id()
@@ -590,102 +598,121 @@ class VllmGeneration(GenerationInterface):
         if not data_validation_fn(data):
             return
 
-        selected_dp_shard_idx = self._select_next_active_dp_rank()
-        while selected_dp_shard_idx is None:
-            await self._wait_for_active_dp_ranks()
+        max_shard_redispatch_attempts = max(1, min(3, self.worker_group.dp_size))
+
+        for attempt in range(max_shard_redispatch_attempts):
             selected_dp_shard_idx = self._select_next_active_dp_rank()
+            while selected_dp_shard_idx is None:
+                await self._wait_for_active_dp_ranks()
+                selected_dp_shard_idx = self._select_next_active_dp_rank()
 
-        leader_worker_idx = self.worker_group.get_dp_leader_worker_idx(
-            selected_dp_shard_idx
-        )
+            leader_worker_idx = self.worker_group.get_dp_leader_worker_idx(
+                selected_dp_shard_idx
+            )
 
-        # Run the async method on the selected leader worker
-        worker_gen_proxy = self.worker_group.run_single_worker_single_data(
-            method_name=method_name,
-            worker_idx=leader_worker_idx,
-            data=data,
-            greedy=greedy,
-        )
+            # Run the async method on the selected leader worker
+            worker_gen_proxy = self.worker_group.run_single_worker_single_data(
+                method_name=method_name,
+                worker_idx=leader_worker_idx,
+                data=data,
+                greedy=greedy,
+            )
 
-        # Create a queue to collect sample results from the worker as they complete
-        result_queue = asyncio.Queue()
-        finished = False
+            # Create a queue to collect sample results from the worker as they complete
+            result_queue = asyncio.Queue()
+            finished = False
+            yielded_sample = False
+            preempted_error: ShardPreemptedError | None = None
 
-        async def consume_worker_generator(worker_idx, worker_gen):
-            """Consume a single worker generator and put sample results in the queue."""
-            nonlocal finished
-            worker_name = f"Worker-{worker_idx}"
-            try:
-                async for sample_result_ref in worker_gen:
-                    sample_result = await sample_result_ref
-                    # sample_result is a tuple: (original_idx, BatchedDataDict)
-                    # Tag the result with worker index for downstream attribution
-                    original_idx, result_batch = sample_result
-                    # Use a length-one list so BatchedDataDict.from_batches can merge without shape errors
-                    result_batch["gen_leader_worker_idx"] = [int(worker_idx)]
-                    sample_result = (original_idx, result_batch)
-                    await result_queue.put(("sample", sample_result))
-            except Exception as e:
-                # Log the error before putting it in the queue for better debugging
-                import traceback
+            async def consume_worker_generator(worker_idx, worker_gen):
+                """Consume a single worker generator and put sample results in the queue."""
+                nonlocal finished
+                worker_name = f"Worker-{worker_idx}"
+                try:
+                    async for sample_result_ref in worker_gen:
+                        sample_result = await sample_result_ref
+                        # sample_result is a tuple: (original_idx, BatchedDataDict)
+                        # Tag the result with worker index for downstream attribution
+                        original_idx, result_batch = sample_result
+                        # Use a length-one list so BatchedDataDict.from_batches can merge without shape errors
+                        result_batch["gen_leader_worker_idx"] = [int(worker_idx)]
+                        sample_result = (original_idx, result_batch)
+                        await result_queue.put(("sample", sample_result))
+                except Exception as e:
+                    # Log the error before putting it in the queue for better debugging
+                    import traceback
 
-                print(f"Exception in worker {worker_name}")
-                traceback.print_exc()
-                await result_queue.put(("error", e))
-            finally:
-                finished = True
-                await result_queue.put(("worker_done", None))
+                    print(f"Exception in worker {worker_name}")
+                    traceback.print_exc()
+                    await result_queue.put(("error", e))
+                finally:
+                    finished = True
+                    await result_queue.put(("worker_done", None))
 
-        # Start the task to consume the worker generator
-        worker_task = asyncio.create_task(
-            consume_worker_generator(leader_worker_idx, worker_gen_proxy)
-        )
+            # Start the task to consume the worker generator
+            worker_task = asyncio.create_task(
+                consume_worker_generator(leader_worker_idx, worker_gen_proxy)
+            )
 
-        # Yield sample results as they become available from the worker
-        timeout_seconds = float(
-            os.environ.get("NRL_VLLM_ASYNC_TIMEOUT_SECONDS", "600")
-        )  # Default 10 minutes
+            # Yield sample results as they become available from the worker
+            timeout_seconds = float(
+                os.environ.get("NRL_VLLM_ASYNC_TIMEOUT_SECONDS", "600")
+            )  # Default 10 minutes
 
-        while not finished:
-            try:
-                msg_type, item = await asyncio.wait_for(
-                    result_queue.get(), timeout=timeout_seconds
-                )
-            except asyncio.TimeoutError:
-                print(
-                    f"Timeout waiting for results after {timeout_seconds}s. Worker has not finished."
-                )
-                print(
-                    f"For longer sequences, increase the timeout by setting: export NRL_VLLM_ASYNC_TIMEOUT_SECONDS={int(timeout_seconds * 2)}"
-                )
-                # Cancel the task
-                if not worker_task.done():
-                    worker_task.cancel()
-                await asyncio.gather(worker_task, return_exceptions=True)
-                raise RuntimeError(
-                    f"Timeout waiting for worker results after {timeout_seconds}s. "
-                    f"For longer sequences, increase timeout by setting: export NRL_VLLM_ASYNC_TIMEOUT_SECONDS={int(timeout_seconds * 2)}"
-                )
+            while not finished:
+                try:
+                    msg_type, item = await asyncio.wait_for(
+                        result_queue.get(), timeout=timeout_seconds
+                    )
+                except asyncio.TimeoutError:
+                    print(
+                        f"Timeout waiting for results after {timeout_seconds}s. Worker has not finished."
+                    )
+                    print(
+                        f"For longer sequences, increase the timeout by setting: export NRL_VLLM_ASYNC_TIMEOUT_SECONDS={int(timeout_seconds * 2)}"
+                    )
+                    # Cancel the task
+                    if not worker_task.done():
+                        worker_task.cancel()
+                    await asyncio.gather(worker_task, return_exceptions=True)
+                    raise RuntimeError(
+                        f"Timeout waiting for worker results after {timeout_seconds}s. "
+                        f"For longer sequences, increase timeout by setting: export NRL_VLLM_ASYNC_TIMEOUT_SECONDS={int(timeout_seconds * 2)}"
+                    )
 
-            if msg_type == "sample":
-                # Yield individual sample result immediately
-                yield item
-            elif msg_type == "error":
-                # Cancel the task and propagate error
-                if not worker_task.done():
-                    worker_task.cancel()
-                await asyncio.gather(worker_task, return_exceptions=True)
-                raise item
-            elif msg_type == "worker_done":
-                # Worker finished, just continue the loop
-                pass
-            else:
-                raise RuntimeError(f"Unexpected message type: {msg_type}")
+                if msg_type == "sample":
+                    # Yield individual sample result immediately
+                    yielded_sample = True
+                    yield item
+                elif msg_type == "error":
+                    # Cancel the task and classify the error
+                    if not worker_task.done():
+                        worker_task.cancel()
+                    await asyncio.gather(worker_task, return_exceptions=True)
 
-        # Verify the task is actually done
-        assert worker_task.done(), (
-            f"Worker task {leader_worker_idx} should be done but isn't"
-        )
+                    if yielded_sample or not self._is_dp_rank_preempted(
+                        selected_dp_shard_idx
+                    ):
+                        raise item
+
+                    preempted_error = ShardPreemptedError(selected_dp_shard_idx)
+                    break
+                elif msg_type == "worker_done":
+                    # Worker finished, just continue the loop
+                    pass
+                else:
+                    raise RuntimeError(f"Unexpected message type: {msg_type}")
+
+            # Verify the task is actually done
+            assert worker_task.done(), (
+                f"Worker task {leader_worker_idx} should be done but isn't"
+            )
+
+            if preempted_error is None:
+                return
+
+            if attempt == max_shard_redispatch_attempts - 1:
+                raise preempted_error
 
     def _normalize_dp_ranks(self, dp_ranks: list[int]) -> list[int]:
         """Validate and normalize data parallel shard indices."""
@@ -742,7 +769,21 @@ class VllmGeneration(GenerationInterface):
                     return
             await asyncio.sleep(0.05)
 
-    def sleep_partial(self, dp_ranks: list[int], level: int | None = None) -> bool:
+    def _mark_preempted_dp_ranks(self, dp_ranks: list[int]) -> None:
+        with self._preempted_dp_ranks_lock:
+            self._preempted_dp_ranks.update(dp_ranks)
+
+    def _clear_preempted_dp_ranks(self, dp_ranks: list[int]) -> None:
+        with self._preempted_dp_ranks_lock:
+            self._preempted_dp_ranks.difference_update(dp_ranks)
+
+    def _is_dp_rank_preempted(self, dp_rank: int) -> bool:
+        with self._preempted_dp_ranks_lock:
+            return dp_rank in self._preempted_dp_ranks
+
+    def sleep_partial(
+        self, dp_ranks: list[int], level: int | None = None, mode: str = "wait"
+    ) -> bool:
         """Drain and sleep a subset of DP shards without stopping all inference."""
         if self.cfg["colocated"]["enabled"]:
             raise RuntimeError(
@@ -753,6 +794,8 @@ class VllmGeneration(GenerationInterface):
         if not target_dp_ranks:
             return True
 
+        mark_preempted = mode == "abort"
+
         with self._active_dp_ranks_lock:
             inactive_dp_ranks = sorted(
                 set(target_dp_ranks).difference(self._active_dp_ranks)
@@ -761,7 +804,17 @@ class VllmGeneration(GenerationInterface):
                 raise ValueError(
                     f"Cannot sleep inactive DP shards: {inactive_dp_ranks}"
                 )
+
+            remaining_active_dp_ranks = self._active_dp_ranks.difference(
+                target_dp_ranks
+            )
+            if not remaining_active_dp_ranks:
+                return False
+
             self._active_dp_ranks.difference_update(target_dp_ranks)
+
+        if mark_preempted:
+            self._mark_preempted_dp_ranks(target_dp_ranks)
 
         method_name = (
             "sleep_async" if self.cfg["vllm_cfg"]["async_engine"] else "sleep"
@@ -772,12 +825,14 @@ class VllmGeneration(GenerationInterface):
                 method_name,
                 target_dp_ranks,
                 level=level,
-                mode="wait",
+                mode=mode,
             )
         except Exception as e:
             print(f"Error dispatching partial sleep: {e}")
             with self._active_dp_ranks_lock:
                 self._active_dp_ranks.update(target_dp_ranks)
+            if mark_preempted:
+                self._clear_preempted_dp_ranks(target_dp_ranks)
             return False
 
         all_success = True
@@ -798,6 +853,8 @@ class VllmGeneration(GenerationInterface):
         if failed_dp_ranks:
             with self._active_dp_ranks_lock:
                 self._active_dp_ranks.update(failed_dp_ranks)
+            if mark_preempted:
+                self._clear_preempted_dp_ranks(failed_dp_ranks)
 
         return all_success
 
@@ -854,6 +911,7 @@ class VllmGeneration(GenerationInterface):
         if successful_dp_ranks:
             with self._active_dp_ranks_lock:
                 self._active_dp_ranks.update(successful_dp_ranks)
+            self._clear_preempted_dp_ranks(successful_dp_ranks)
 
         return all_success
 

--- a/nemo_rl/models/generation/vllm/vllm_generation.py
+++ b/nemo_rl/models/generation/vllm/vllm_generation.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import os
+import threading
 import warnings
 from collections import defaultdict
 from typing import (
@@ -204,6 +205,8 @@ class VllmGeneration(GenerationInterface):
 
         # Used to track the round-robin selection of worker groups for generate_async
         self.current_generate_dp_shard_idx = 0
+        self._active_dp_ranks = set(range(self.worker_group.dp_size))
+        self._active_dp_ranks_lock = threading.Lock()
 
         # Save the device uuids for the workers
         self.device_uuids = self._report_device_id()
@@ -587,9 +590,13 @@ class VllmGeneration(GenerationInterface):
         if not data_validation_fn(data):
             return
 
-        # Determine the leader worker for the current data parallel shard
+        selected_dp_shard_idx = self._select_next_active_dp_rank()
+        while selected_dp_shard_idx is None:
+            await self._wait_for_active_dp_ranks()
+            selected_dp_shard_idx = self._select_next_active_dp_rank()
+
         leader_worker_idx = self.worker_group.get_dp_leader_worker_idx(
-            self.current_generate_dp_shard_idx
+            selected_dp_shard_idx
         )
 
         # Run the async method on the selected leader worker
@@ -599,10 +606,6 @@ class VllmGeneration(GenerationInterface):
             data=data,
             greedy=greedy,
         )
-
-        # Increment the round-robin worker group index
-        self.current_generate_dp_shard_idx += 1
-        self.current_generate_dp_shard_idx %= self.worker_group.dp_size
 
         # Create a queue to collect sample results from the worker as they complete
         result_queue = asyncio.Queue()
@@ -683,6 +686,176 @@ class VllmGeneration(GenerationInterface):
         assert worker_task.done(), (
             f"Worker task {leader_worker_idx} should be done but isn't"
         )
+
+    def _normalize_dp_ranks(self, dp_ranks: list[int]) -> list[int]:
+        """Validate and normalize data parallel shard indices."""
+        normalized_dp_ranks = sorted(set(dp_ranks))
+        invalid_dp_ranks = [
+            dp_rank
+            for dp_rank in normalized_dp_ranks
+            if dp_rank < 0 or dp_rank >= self.worker_group.dp_size
+        ]
+        if invalid_dp_ranks:
+            raise ValueError(
+                f"Invalid data parallel shard indices: {invalid_dp_ranks}. "
+                f"Valid range is [0, {self.worker_group.dp_size})."
+            )
+        return normalized_dp_ranks
+
+    def _run_on_dp_shard_leaders(
+        self, method_name: str, dp_ranks: list[int], **kwargs: Any
+    ) -> list[ray.ObjectRef]:
+        """Run a method on the leader worker of each requested DP shard."""
+        futures: list[ray.ObjectRef] = []
+        for dp_rank in self._normalize_dp_ranks(dp_ranks):
+            worker_idx = self.worker_group.get_dp_leader_worker_idx(dp_rank)
+            futures.append(
+                self.worker_group.run_single_worker_single_data(
+                    method_name=method_name,
+                    worker_idx=worker_idx,
+                    **kwargs,
+                )
+            )
+        return futures
+
+    def _select_next_active_dp_rank(self) -> int | None:
+        """Return the next routable DP shard using round-robin selection."""
+        with self._active_dp_ranks_lock:
+            if not self._active_dp_ranks:
+                return None
+
+            for _ in range(self.worker_group.dp_size):
+                candidate_dp_rank = self.current_generate_dp_shard_idx
+                self.current_generate_dp_shard_idx = (
+                    self.current_generate_dp_shard_idx + 1
+                ) % self.worker_group.dp_size
+                if candidate_dp_rank in self._active_dp_ranks:
+                    return candidate_dp_rank
+
+        return None
+
+    async def _wait_for_active_dp_ranks(self) -> None:
+        """Block until at least one DP shard is active again."""
+        while True:
+            with self._active_dp_ranks_lock:
+                if self._active_dp_ranks:
+                    return
+            await asyncio.sleep(0.05)
+
+    def sleep_partial(self, dp_ranks: list[int], level: int | None = None) -> bool:
+        """Drain and sleep a subset of DP shards without stopping all inference."""
+        if self.cfg["colocated"]["enabled"]:
+            raise RuntimeError(
+                "Partial shard sleep is only supported for non-colocated inference."
+            )
+
+        target_dp_ranks = self._normalize_dp_ranks(dp_ranks)
+        if not target_dp_ranks:
+            return True
+
+        with self._active_dp_ranks_lock:
+            inactive_dp_ranks = sorted(
+                set(target_dp_ranks).difference(self._active_dp_ranks)
+            )
+            if inactive_dp_ranks:
+                raise ValueError(
+                    f"Cannot sleep inactive DP shards: {inactive_dp_ranks}"
+                )
+            self._active_dp_ranks.difference_update(target_dp_ranks)
+
+        method_name = (
+            "sleep_async" if self.cfg["vllm_cfg"]["async_engine"] else "sleep"
+        )
+
+        try:
+            futures = self._run_on_dp_shard_leaders(
+                method_name,
+                target_dp_ranks,
+                level=level,
+                mode="wait",
+            )
+        except Exception as e:
+            print(f"Error dispatching partial sleep: {e}")
+            with self._active_dp_ranks_lock:
+                self._active_dp_ranks.update(target_dp_ranks)
+            return False
+
+        all_success = True
+        failed_dp_ranks: list[int] = []
+        for dp_rank, future in zip(target_dp_ranks, futures):
+            try:
+                result = ray.get(future)
+            except Exception as e:
+                print(f"Error during partial sleep for DP shard {dp_rank}: {e}")
+                failed_dp_ranks.append(dp_rank)
+                all_success = False
+                continue
+
+            if result is not None and not result:
+                failed_dp_ranks.append(dp_rank)
+                all_success = False
+
+        if failed_dp_ranks:
+            with self._active_dp_ranks_lock:
+                self._active_dp_ranks.update(failed_dp_ranks)
+
+        return all_success
+
+    def wake_up_partial(
+        self, dp_ranks: list[int], tags: list[str] | None = None
+    ) -> bool:
+        """Wake a subset of previously slept DP shards and restore routing."""
+        if self.cfg["colocated"]["enabled"]:
+            raise RuntimeError(
+                "Partial shard wake-up is only supported for non-colocated inference."
+            )
+
+        target_dp_ranks = self._normalize_dp_ranks(dp_ranks)
+        if not target_dp_ranks:
+            return True
+
+        with self._active_dp_ranks_lock:
+            already_active_dp_ranks = sorted(
+                self._active_dp_ranks.intersection(target_dp_ranks)
+            )
+            if already_active_dp_ranks:
+                raise ValueError(
+                    f"Cannot wake already-active DP shards: {already_active_dp_ranks}"
+                )
+
+        method_name = (
+            "wake_up_async" if self.cfg["vllm_cfg"]["async_engine"] else "wake_up"
+        )
+        wake_up_kwargs: dict[str, Any] = {}
+        if tags is not None:
+            wake_up_kwargs["tags"] = tags
+
+        futures = self._run_on_dp_shard_leaders(
+            method_name,
+            target_dp_ranks,
+            **wake_up_kwargs,
+        )
+
+        all_success = True
+        successful_dp_ranks: list[int] = []
+        for dp_rank, future in zip(target_dp_ranks, futures):
+            try:
+                result = ray.get(future)
+            except Exception as e:
+                print(f"Error during partial wake-up for DP shard {dp_rank}: {e}")
+                all_success = False
+                continue
+
+            if result is None or result:
+                successful_dp_ranks.append(dp_rank)
+            else:
+                all_success = False
+
+        if successful_dp_ranks:
+            with self._active_dp_ranks_lock:
+                self._active_dp_ranks.update(successful_dp_ranks)
+
+        return all_success
 
     async def generate_text_async(
         self, data: BatchedDataDict[GenerationDatumSpec], greedy: bool = False

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -983,7 +983,7 @@ class VllmGenerationWorker(BaseVllmGenerationWorker):
         gc.collect()
         torch.cuda.empty_cache()
 
-    def sleep(self):
+    def sleep(self, level: int | None = None, mode: str = "abort"):
         """Put the vLLM engine to sleep."""
         assert self.llm is not None, (
             "Attempting to sleep with either an uninitialized vLLM or non-model-owner"
@@ -993,6 +993,10 @@ class VllmGenerationWorker(BaseVllmGenerationWorker):
             raise RuntimeError(
                 "sleep cannot be used with async_engine=True. Use sleep_async instead."
             )
+
+        resolved_level = self.cfg["vllm_cfg"].get("sleep_level", 1)
+        if level is not None:
+            resolved_level = level
 
         # Reset the prefix cache to ensure that prefix cache is not reused after weights are updated
         self.llm.llm_engine.reset_prefix_cache()
@@ -1006,7 +1010,7 @@ class VllmGenerationWorker(BaseVllmGenerationWorker):
             self.llm.renderer, "clear_mm_cache"
         ):
             self.llm.renderer.clear_mm_cache()
-        self.llm.sleep(level=1)
+        self.llm.sleep(level=resolved_level, mode=mode)
 
         gc.collect()
         torch.cuda.empty_cache()

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -1132,7 +1132,7 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
         gc.collect()
         torch.cuda.empty_cache()
 
-    async def sleep_async(self):
+    async def sleep_async(self, level: int | None = None, mode: str = "abort"):
         """Async version of sleep."""
         assert self.llm is not None, (
             "Attempting to sleep with either an uninitialized vLLM or non-model-owner"
@@ -1143,6 +1143,10 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
                 "sleep_async can only be used with async_engine=True. Use sleep instead."
             )
 
+        resolved_level = self.cfg["vllm_cfg"].get("sleep_level", 1)
+        if level is not None:
+            resolved_level = level
+
         # Reset the prefix cache to ensure that prefix cache is not reused after weights are updated
         await self.llm.reset_prefix_cache()
         # Reset the multimodal processor cache (sender side) so it stays in
@@ -1151,7 +1155,7 @@ class VllmAsyncGenerationWorker(BaseVllmGenerationWorker):
         # the receiver and sends data=None, causing an assertion error.
         if hasattr(self.llm, "reset_mm_cache"):
             await self.llm.reset_mm_cache()
-        await self.llm.sleep(level=1)
+        await self.llm.sleep(level=resolved_level, mode=mode)
 
         gc.collect()
         torch.cuda.empty_cache()

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -883,13 +883,17 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
         return free_memory_bytes
 
     def stream_weights_via_ipc_zmq(
-        self, buffer_size_bytes: int, kv_scales: Optional[dict[str, float]] = None
+        self,
+        buffer_size_bytes: int,
+        kv_scales: Optional[dict[str, float]] = None,
+        model_update_transport: str = "cuda_ipc",
     ) -> list[ray.ObjectRef]:
         """Send the weights for IPC handles via ZMQ socket."""
         futures = self.worker_group.run_all_workers_single_data(
             "stream_weights_via_ipc_zmq",
             buffer_size_bytes=buffer_size_bytes,
             kv_scales=kv_scales,
+            model_update_transport=model_update_transport,
         )
         return futures
 

--- a/nemo_rl/models/policy/utils.py
+++ b/nemo_rl/models/policy/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import gc
+import io
 import os
 import traceback
 from enum import Enum
@@ -248,7 +249,12 @@ def calculate_aligned_size(size_bytes: int, alignment: int = 512) -> int:
 
 
 def stream_weights_via_ipc_zmq_impl(
-    params_generator, buffer_size_bytes: int, zmq_socket, rank: int, worker_name: str
+    params_generator,
+    buffer_size_bytes: int,
+    zmq_socket,
+    rank: int,
+    worker_name: str,
+    model_update_transport: str = "cuda_ipc",
 ) -> None:
     """Shared implementation for streaming weights via IPC ZMQ with improved memory management.
 
@@ -261,21 +267,44 @@ def stream_weights_via_ipc_zmq_impl(
         zmq_socket: ZMQ socket for communication
         rank: Worker rank for logging
         worker_name: Name of the worker for logging
+        model_update_transport: Transport method for weight transfer.
+            "cuda_ipc" (default) uses CUDA IPC handles via ZMQ.
+            "cpu_serialize" uses torch.save/load over CPU pinned memory,
+            which does not require CAP_SYS_PTRACE / --ipc=host.
     """
+    if model_update_transport not in ("cuda_ipc", "cpu_serialize"):
+        raise ValueError(
+            f"Unsupported model_update_transport: {model_update_transport!r}. "
+            f"Expected 'cuda_ipc' or 'cpu_serialize'."
+        )
+
     # Divide total buffer size by 2 because we use two individual buffers (ping-pong) for overlapping communication.
     buffer_size_bytes = buffer_size_bytes // 2
 
     def send_buffer_group_overlap(buffer, param_names, used_bytes, await_recv) -> bool:
         """Send a group of parameters and return new pending_recv state."""
-        # Synchronize before getting IPC handle to ensure data is ready
-        torch.cuda.current_stream().synchronize()
-        cuda_ipc_handle = get_handle_from_tensor(buffer)
+        if model_update_transport == "cpu_serialize":
+            # Bucket-level pinned DMA: ~10x faster than per-tensor pageable .cpu()
+            # (270ms vs 2.7s at 3.4GB on PCIe 4.0, per ROLL benchmarks).
+            torch.cuda.current_stream().synchronize()
+            bucket = buffer[:used_bytes].contiguous()
+            pinned = torch.empty_like(bucket, device="cpu").pin_memory()
+            pinned.copy_(bucket, non_blocking=True)
+            torch.cuda.current_stream().synchronize()
+            buf = io.BytesIO()
+            torch.save({"bucket": pinned}, buf)
+            serialized = buf.getvalue()  # bytes object
+        else:  # cuda_ipc
+            # Synchronize before getting IPC handle to ensure data is ready
+            torch.cuda.current_stream().synchronize()
+            serialized = get_handle_from_tensor(buffer)  # tuple
 
         if await_recv:
             zmq_socket.recv()
 
-        # Payload tuple: (cuda_ipc_handle, param_names, used_bytes)
-        payload = (cuda_ipc_handle, param_names, used_bytes)
+        # Payload tuple: (serialized, param_names, used_bytes)
+        # Receiver auto-detects format by isinstance(serialized, bytes)
+        payload = (serialized, param_names, used_bytes)
         zmq_socket.send_pyobj(payload)
         return True  # pending_recv = True
 

--- a/nemo_rl/models/policy/utils.py
+++ b/nemo_rl/models/policy/utils.py
@@ -15,6 +15,7 @@
 import gc
 import io
 import os
+import pickle
 import traceback
 from enum import Enum
 from typing import Any, Dict, Optional, cast
@@ -302,10 +303,16 @@ def stream_weights_via_ipc_zmq_impl(
         if await_recv:
             zmq_socket.recv()
 
-        # Payload tuple: (serialized, param_names, used_bytes)
-        # Receiver auto-detects format by isinstance(serialized, bytes)
-        payload = (serialized, param_names, used_bytes)
-        zmq_socket.send_pyobj(payload)
+        if model_update_transport == "cpu_serialize":
+            metadata = pickle.dumps(
+                (param_names, used_bytes), protocol=pickle.HIGHEST_PROTOCOL
+            )
+            zmq_socket.send_multipart(
+                [b"cpu_serialize", metadata, memoryview(serialized)], copy=False
+            )
+        else:
+            payload = (serialized, param_names, used_bytes)
+            zmq_socket.send_pyobj(payload)
         return True  # pending_recv = True
 
     def allocate_buffer(device):

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -1804,6 +1804,7 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
         self,
         buffer_size_bytes: int = 0,
         kv_scales: Optional[dict[str, float]] = None,
+        model_update_transport: str = "cuda_ipc",
     ) -> None:
         """Stream model weights to peer process via ZMQ IPC socket."""
         if kv_scales is not None:
@@ -1840,6 +1841,7 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
             zmq_socket=self.zmq_socket,
             rank=self.rank,
             worker_name=str(self),
+            model_update_transport=model_update_transport,
         )
 
     @torch.no_grad()

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -884,6 +884,7 @@ class DTensorPolicyWorkerV2Impl(AbstractPolicyWorker, ColocatablePolicyInterface
         self,
         buffer_size_bytes: int = 0,
         kv_scales: Optional[dict[str, float]] = None,
+        model_update_transport: str = "cuda_ipc",
     ) -> None:
         """Stream model weights to peer process via ZMQ IPC socket."""
         if kv_scales is not None:
@@ -905,6 +906,7 @@ class DTensorPolicyWorkerV2Impl(AbstractPolicyWorker, ColocatablePolicyInterface
             zmq_socket=self.zmq_socket,
             rank=self.rank,
             worker_name=str(self),
+            model_update_transport=model_update_transport,
         )
 
     @torch.no_grad()

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -1078,7 +1078,10 @@ class MegatronPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface)
     @torch.no_grad()
     @wrap_with_nvtx_name("megatron_policy_worker/stream_weights_via_ipc_zmq")
     def stream_weights_via_ipc_zmq(
-        self, buffer_size_bytes: int = 0, kv_scales: Optional[dict[str, float]] = None
+        self,
+        buffer_size_bytes: int = 0,
+        kv_scales: Optional[dict[str, float]] = None,
+        model_update_transport: str = "cuda_ipc",
     ) -> None:
         """Stream model weights to peer process via ZMQ IPC socket."""
         self.maybe_init_zmq()
@@ -1094,6 +1097,7 @@ class MegatronPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface)
             zmq_socket=self.zmq_socket,
             rank=self.rank,
             worker_name=str(self),
+            model_update_transport=model_update_transport,
         )
 
     @torch.no_grad()

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -260,7 +260,12 @@ async def _collect_async_generate_outputs(policy, data):
 
 
 def _extract_gen_leader_worker_indices(outputs: BatchedDataDict) -> set[int]:
-    return {int(idx) for idx in outputs["gen_leader_worker_idx"].reshape(-1).tolist()}
+    worker_indices = outputs["gen_leader_worker_idx"]
+    if hasattr(worker_indices, "reshape"):
+        worker_indices = worker_indices.reshape(-1).tolist()
+    elif not isinstance(worker_indices, list):
+        worker_indices = [worker_indices]
+    return {int(idx) for idx in worker_indices}
 
 
 def test_vllm_generation_worker_sleep_passes_configured_level_and_mode():

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -207,7 +207,7 @@ def _make_partial_overlap_policy(async_engine: bool = True, dp_size: int = 4):
 
 
 def test_vllm_generation_worker_sleep_passes_configured_level_and_mode():
-    worker = object.__new__(VllmGenerationWorker)
+    worker = object.__new__(VllmGenerationWorker.__ray_metadata__.modified_class)
     worker.cfg = {"vllm_cfg": {"async_engine": False, "sleep_level": 2}}
     worker.llm = MagicMock()
     worker.llm.renderer = MagicMock()
@@ -220,7 +220,7 @@ def test_vllm_generation_worker_sleep_passes_configured_level_and_mode():
 
 
 def test_vllm_generation_worker_sleep_explicit_level_overrides_config():
-    worker = object.__new__(VllmGenerationWorker)
+    worker = object.__new__(VllmGenerationWorker.__ray_metadata__.modified_class)
     worker.cfg = {"vllm_cfg": {"async_engine": False, "sleep_level": 2}}
     worker.llm = MagicMock()
     worker.llm.renderer = MagicMock()
@@ -232,7 +232,7 @@ def test_vllm_generation_worker_sleep_explicit_level_overrides_config():
 
 @pytest.mark.asyncio
 async def test_vllm_async_generation_worker_sleep_passes_configured_level_and_mode():
-    worker = object.__new__(VllmAsyncGenerationWorker)
+    worker = object.__new__(VllmAsyncGenerationWorker.__ray_metadata__.modified_class)
     worker.cfg = {"vllm_cfg": {"async_engine": True, "sleep_level": 2}}
     worker.llm = MagicMock()
     worker.llm.reset_prefix_cache = AsyncMock()

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -34,6 +34,7 @@ from nemo_rl.models.generation.interfaces import (
     GenerationDatumSpec,
 )
 from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration
+from nemo_rl.models.generation.vllm.vllm_generation import ShardPreemptedError
 from nemo_rl.models.generation.vllm.vllm_worker import VllmGenerationWorker
 from nemo_rl.models.generation.vllm.vllm_worker_async import (
     VllmAsyncGenerationWorker,
@@ -203,7 +204,63 @@ def _make_partial_overlap_policy(async_engine: bool = True, dp_size: int = 4):
     policy.current_generate_dp_shard_idx = 0
     policy._active_dp_ranks = set(range(dp_size))
     policy._active_dp_ranks_lock = threading.Lock()
+    policy._preempted_dp_ranks = set()
+    policy._preempted_dp_ranks_lock = threading.Lock()
     return policy
+
+
+def _make_generation_input() -> BatchedDataDict[GenerationDatumSpec]:
+    return BatchedDataDict(
+        {
+            "input_ids": torch.tensor([[1, 2, 3]], dtype=torch.long),
+            "input_lengths": torch.tensor([3], dtype=torch.int32),
+        }
+    )
+
+
+def _make_generation_output(original_idx: int = 0) -> BatchedDataDict:
+    return BatchedDataDict(
+        {
+            "output_ids": torch.tensor([[4, 5]], dtype=torch.long),
+            "logprobs": torch.tensor([[0.0, 0.0]], dtype=torch.float32),
+            "generation_lengths": torch.tensor([2], dtype=torch.int32),
+            "unpadded_sequence_lengths": torch.tensor([2], dtype=torch.int32),
+        }
+    )
+
+
+def _make_successful_async_worker_proxy(original_idx: int = 0):
+    async def sample_result_ref():
+        return original_idx, _make_generation_output(original_idx)
+
+    async def worker_gen():
+        yield sample_result_ref()
+
+    return worker_gen()
+
+
+def _make_failing_async_worker_proxy(exc: Exception):
+    async def worker_gen():
+        if False:
+            yield None
+        raise exc
+
+    return worker_gen()
+
+
+async def _collect_async_generate_outputs(policy, data):
+    outputs = []
+    async for item in policy._async_generate_base(
+        data,
+        "generate_async",
+        lambda batched_data: bool(len(batched_data["input_ids"])),
+    ):
+        outputs.append(item)
+    return outputs
+
+
+def _extract_gen_leader_worker_indices(outputs: BatchedDataDict) -> set[int]:
+    return {int(idx) for idx in outputs["gen_leader_worker_idx"].reshape(-1).tolist()}
 
 
 def test_vllm_generation_worker_sleep_passes_configured_level_and_mode():
@@ -289,6 +346,87 @@ def test_vllm_generation_sleep_partial_restores_failed_shards(monkeypatch):
     assert not policy.sleep_partial([1, 3], level=2)
     assert policy._active_dp_ranks == {0, 2, 3}
 
+
+def test_vllm_generation_wait_mode_does_not_mark_preempted(monkeypatch):
+    policy = _make_partial_overlap_policy(async_engine=True, dp_size=4)
+    monkeypatch.setattr(ray, "get", lambda _future: True)
+
+    assert policy.sleep_partial([1], level=2, mode="wait")
+    assert policy._preempted_dp_ranks == set()
+
+
+def test_vllm_generation_abort_mode_marks_preempted(monkeypatch):
+    policy = _make_partial_overlap_policy(async_engine=True, dp_size=4)
+    monkeypatch.setattr(ray, "get", lambda _future: True)
+
+    assert policy.sleep_partial([1], level=2, mode="abort")
+    assert policy._preempted_dp_ranks == {1}
+
+
+def test_vllm_generation_rejects_sleeping_last_active_shard():
+    policy = _make_partial_overlap_policy(async_engine=True, dp_size=1)
+
+    assert not policy.sleep_partial([0], level=2, mode="wait")
+    assert policy._active_dp_ranks == {0}
+
+
+@pytest.mark.asyncio
+async def test_vllm_generation_retries_preempted_shard():
+    policy = _make_partial_overlap_policy(async_engine=True, dp_size=2)
+    data = _make_generation_input()
+    policy._preempted_dp_ranks = {0}
+    policy.worker_group.run_single_worker_single_data.side_effect = [
+        _make_failing_async_worker_proxy(RuntimeError("preempted")),
+        _make_successful_async_worker_proxy(),
+    ]
+
+    outputs = await _collect_async_generate_outputs(policy, data)
+
+    assert len(outputs) == 1
+    assert outputs[0][0] == 0
+    assert outputs[0][1]["gen_leader_worker_idx"] == [101]
+    assert policy.worker_group.run_single_worker_single_data.call_args_list == [
+        call(
+            method_name="generate_async",
+            worker_idx=100,
+            data=data,
+            greedy=False,
+        ),
+        call(
+            method_name="generate_async",
+            worker_idx=101,
+            data=data,
+            greedy=False,
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_vllm_generation_raises_shard_preempted_after_retry_exhaustion():
+    policy = _make_partial_overlap_policy(async_engine=True, dp_size=2)
+    data = _make_generation_input()
+    policy._preempted_dp_ranks = {0, 1}
+    policy.worker_group.run_single_worker_single_data.side_effect = [
+        _make_failing_async_worker_proxy(RuntimeError("preempted-0")),
+        _make_failing_async_worker_proxy(RuntimeError("preempted-1")),
+    ]
+
+    with pytest.raises(ShardPreemptedError) as excinfo:
+        await _collect_async_generate_outputs(policy, data)
+
+    assert excinfo.value.dp_rank == 1
+
+
+@pytest.mark.asyncio
+async def test_vllm_generation_does_not_retry_non_preempt_error():
+    policy = _make_partial_overlap_policy(async_engine=True, dp_size=2)
+    data = _make_generation_input()
+    policy.worker_group.run_single_worker_single_data.return_value = (
+        _make_failing_async_worker_proxy(RuntimeError("boom"))
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await _collect_async_generate_outputs(policy, data)
 
 
 def test_vllm_generation_wake_partial_only_restores_successful_shards(monkeypatch):
@@ -607,6 +745,97 @@ async def _generate_async(vllm_policy, tokenizer, test_input_data, greedy=False)
         pad_value_dict={"output_ids": pad_token_id, "logprobs": 0.0},
     )
     return outputs
+
+
+@pytest.mark.timeout(600)
+@pytest.mark.asyncio
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Test requires at least 2 GPUs.")
+async def test_vllm_async_partial_sleep_wake_runtime_smoke(tokenizer, test_input_data):
+    generation_cluster_separate = get_generation_cluster_separate(2)
+    vllm_generation = None
+
+    try:
+        vllm_config = deepcopy(basic_vllm_test_config)
+        vllm_config = configure_generation_config(vllm_config, tokenizer, is_eval=True)
+        vllm_config["vllm_cfg"]["async_engine"] = True
+        vllm_config["vllm_cfg"]["tensor_parallel_size"] = 1
+        vllm_config["colocated"]["enabled"] = False
+
+        vllm_generation = VllmGeneration(generation_cluster_separate, vllm_config)
+
+        leader_0 = vllm_generation.worker_group.get_dp_leader_worker_idx(0)
+        leader_1 = vllm_generation.worker_group.get_dp_leader_worker_idx(1)
+
+        outputs1 = await _generate_async(
+            vllm_generation, tokenizer, test_input_data, greedy=True
+        )
+        assert _extract_gen_leader_worker_indices(outputs1) == {leader_0, leader_1}
+
+        assert vllm_generation.sleep_partial([0], level=2, mode="wait")
+        assert vllm_generation._active_dp_ranks == {1}
+
+        outputs2 = await _generate_async(
+            vllm_generation, tokenizer, test_input_data, greedy=True
+        )
+        assert _extract_gen_leader_worker_indices(outputs2) == {leader_1}
+
+        assert vllm_generation.wake_up_partial([0])
+        assert vllm_generation._active_dp_ranks == {0, 1}
+
+        outputs3 = await _generate_async(
+            vllm_generation, tokenizer, test_input_data, greedy=True
+        )
+        assert _extract_gen_leader_worker_indices(outputs3) == {leader_0, leader_1}
+
+    finally:
+        if vllm_generation:
+            vllm_generation.shutdown()
+        try:
+            generation_cluster_separate.shutdown()
+        except Exception:
+            pass
+
+
+@pytest.mark.timeout(600)
+@pytest.mark.asyncio
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Test requires at least 2 GPUs.")
+async def test_vllm_partial_sleep_rejects_last_active_shard_tp2(
+    tokenizer, test_input_data
+):
+    generation_cluster_separate = get_generation_cluster_separate(2)
+    vllm_generation = None
+
+    try:
+        vllm_config = deepcopy(basic_vllm_test_config)
+        vllm_config = configure_generation_config(vllm_config, tokenizer, is_eval=True)
+        vllm_config["vllm_cfg"]["async_engine"] = True
+        vllm_config["vllm_cfg"]["tensor_parallel_size"] = 2
+        vllm_config["colocated"]["enabled"] = False
+
+        vllm_generation = VllmGeneration(generation_cluster_separate, vllm_config)
+
+        leader_0 = vllm_generation.worker_group.get_dp_leader_worker_idx(0)
+
+        outputs1 = await _generate_async(
+            vllm_generation, tokenizer, test_input_data, greedy=True
+        )
+        assert _extract_gen_leader_worker_indices(outputs1) == {leader_0}
+
+        assert not vllm_generation.sleep_partial([0], level=2, mode="wait")
+        assert vllm_generation._active_dp_ranks == {0}
+
+        outputs2 = await _generate_async(
+            vllm_generation, tokenizer, test_input_data, greedy=True
+        )
+        assert _extract_gen_leader_worker_indices(outputs2) == {leader_0}
+
+    finally:
+        if vllm_generation:
+            vllm_generation.shutdown()
+        try:
+            generation_cluster_separate.shutdown()
+        except Exception:
+            pass
 
 
 @pytest.mark.asyncio

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -2681,8 +2681,11 @@ def test_vllm_direct_zmq_weight_update_cpu_serialize(
             ]
         )
 
-        # Direct ZMQ weight update with cpu_serialize transport
-        buffer_size_bytes = int(lm_policy.get_free_memory_bytes() * 0.3)
+        vllm_policy.finish_generation()
+        lm_policy.offload_before_refit()
+        vllm_policy.prepare_for_generation(tags=["weights"])
+
+        buffer_size_bytes = int(1.5 * (1024**3))
         futures_train = lm_policy.stream_weights_via_ipc_zmq(
             buffer_size_bytes=buffer_size_bytes,
             model_update_transport="cpu_serialize",
@@ -2695,6 +2698,7 @@ def test_vllm_direct_zmq_weight_update_cpu_serialize(
         ), "cpu_serialize weight update should succeed"
 
         print("Running Generation 2 (Weights Updated)...")
+        vllm_policy.prepare_for_generation()
         outputs2 = vllm_policy.generate(test_input_data, greedy=True)
         logprob2 = outputs2["logprobs"][0, input_lengths[0]].item()
         assert logprob2 != logprob1, (
@@ -2730,6 +2734,7 @@ async def test_vllm_async_refit_cpu_serialize(
     dtensor_config = basic_dtensor_test_config
 
     lm_policy = None
+    updated_policy = None
     async_policy = None
     try:
         async_policy = VllmGeneration(cluster, vllm_config)
@@ -2756,17 +2761,26 @@ async def test_vllm_async_refit_cpu_serialize(
         input_lengths = test_input_data["input_lengths"]
         logprob1 = outputs1["logprobs"][0, input_lengths[0]].item()
 
+        async_policy.finish_generation()
+
+        lm_policy.shutdown()
+        lm_policy = None
+
+        updated_policy = Policy(cluster, dtensor_config, tokenizer)
+        state_dict_info = updated_policy.prepare_refit_info()
+        async_policy.prepare_refit_info(state_dict_info)
+
         print("Adding noise to weights in HF policy...")
         ray.get(
             [
                 worker._add_noise_to_weights.remote()
-                for worker in lm_policy.worker_group.workers
+                for worker in updated_policy.worker_group.workers
             ]
         )
 
         print("Running cpu_serialize refit after weight change...")
         refit_policy_generation(
-            lm_policy,
+            updated_policy,
             async_policy,
             vllm_config["colocated"]["enabled"],
         )
@@ -2789,6 +2803,11 @@ async def test_vllm_async_refit_cpu_serialize(
         if lm_policy:
             try:
                 lm_policy.shutdown()
+            except Exception:
+                pass
+        if updated_policy:
+            try:
+                updated_policy.shutdown()
             except Exception:
                 pass
         import gc

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -2640,3 +2640,158 @@ def test_vllm_megatron_weight_update_with_packing(cluster, test_input_data):
             megatron_policy.shutdown()
         if vllm_generation:
             vllm_generation.shutdown()
+
+
+@pytest.mark.timeout(600)
+def test_vllm_direct_zmq_weight_update_cpu_serialize(
+    cluster, tokenizer, test_input_data
+):
+    """Test direct ZMQ weight update using cpu_serialize transport.
+
+    This exercises the lm_policy.stream_weights_via_ipc_zmq() → vllm_backend
+    path with explicit model_update_transport="cpu_serialize", bypassing the
+    env-var reading in refit_policy_generation.
+    """
+    from nemo_rl.models.policy.lm_policy import Policy
+
+    vllm_config = deepcopy(basic_vllm_test_config)
+    vllm_config = configure_generation_config(vllm_config, tokenizer, is_eval=True)
+    dtensor_config = basic_dtensor_test_config
+
+    vllm_policy = None
+    lm_policy = None
+    try:
+        lm_policy = Policy(cluster, dtensor_config, tokenizer)
+        vllm_policy = VllmGeneration(cluster, vllm_config)
+
+        state_dict_info = lm_policy.prepare_refit_info()
+        vllm_policy.prepare_refit_info(state_dict_info)
+
+        print("Running Generation 1 (Initial)...")
+        vllm_policy.prepare_for_generation()
+        outputs1 = vllm_policy.generate(test_input_data, greedy=True)
+        input_lengths = test_input_data["input_lengths"]
+        logprob1 = outputs1["logprobs"][0, input_lengths[0]].item()
+
+        print("Adding noise to weights in HF policy...")
+        ray.get(
+            [
+                worker._add_noise_to_weights.remote()
+                for worker in lm_policy.worker_group.workers
+            ]
+        )
+
+        # Direct ZMQ weight update with cpu_serialize transport
+        buffer_size_bytes = int(lm_policy.get_free_memory_bytes() * 0.3)
+        futures_train = lm_policy.stream_weights_via_ipc_zmq(
+            buffer_size_bytes=buffer_size_bytes,
+            model_update_transport="cpu_serialize",
+        )
+        futures_inference = vllm_policy.update_weights_via_ipc_zmq()
+        ray.get(futures_train)
+        results = ray.get(futures_inference)
+        assert all(
+            result for result in results if result is not None
+        ), "cpu_serialize weight update should succeed"
+
+        print("Running Generation 2 (Weights Updated)...")
+        outputs2 = vllm_policy.generate(test_input_data, greedy=True)
+        logprob2 = outputs2["logprobs"][0, input_lengths[0]].item()
+        assert logprob2 != logprob1, (
+            "Logprobs should change after cpu_serialize direct weight update."
+        )
+
+    finally:
+        if vllm_policy:
+            vllm_policy.shutdown()
+        if lm_policy:
+            lm_policy.shutdown()
+        import gc
+
+        gc.collect()
+        torch.cuda.empty_cache()
+
+
+@pytest.mark.timeout(600)
+@pytest.mark.asyncio
+async def test_vllm_async_refit_cpu_serialize(
+    cluster, test_input_data, tokenizer, monkeypatch
+):
+    """Test async refit path using cpu_serialize transport via env var.
+
+    This exercises the refit_policy_generation() → env-var → sender →
+    receiver path with NRL_MODEL_UPDATE_TRANSPORT=cpu_serialize.
+    """
+    from nemo_rl.models.policy.lm_policy import Policy
+
+    vllm_config = deepcopy(basic_vllm_test_config)
+    vllm_config = configure_generation_config(vllm_config, tokenizer)
+    vllm_config["vllm_cfg"]["async_engine"] = True
+    dtensor_config = basic_dtensor_test_config
+
+    lm_policy = None
+    async_policy = None
+    try:
+        async_policy = VllmGeneration(cluster, vllm_config)
+        async_policy.finish_generation()
+
+        lm_policy = Policy(cluster, dtensor_config, tokenizer)
+
+        state_dict_info = lm_policy.prepare_refit_info()
+        async_policy.prepare_refit_info(state_dict_info)
+
+        monkeypatch.setenv("NRL_MODEL_UPDATE_TRANSPORT", "cpu_serialize")
+
+        print("Running initial cpu_serialize refit...")
+        refit_policy_generation(
+            lm_policy,
+            async_policy,
+            vllm_config["colocated"]["enabled"],
+        )
+
+        print("Running Generation 1 (Initial)...")
+        outputs1 = await _generate_async(
+            async_policy, tokenizer, test_input_data, greedy=True
+        )
+        input_lengths = test_input_data["input_lengths"]
+        logprob1 = outputs1["logprobs"][0, input_lengths[0]].item()
+
+        print("Adding noise to weights in HF policy...")
+        ray.get(
+            [
+                worker._add_noise_to_weights.remote()
+                for worker in lm_policy.worker_group.workers
+            ]
+        )
+
+        print("Running cpu_serialize refit after weight change...")
+        refit_policy_generation(
+            lm_policy,
+            async_policy,
+            vllm_config["colocated"]["enabled"],
+        )
+
+        print("Running Generation 2 (Weights Updated)...")
+        outputs2 = await _generate_async(
+            async_policy, tokenizer, test_input_data, greedy=True
+        )
+        logprob2 = outputs2["logprobs"][0, input_lengths[0]].item()
+        assert logprob2 != logprob1, (
+            "Logprobs should change after cpu_serialize async refit."
+        )
+
+    finally:
+        if async_policy:
+            try:
+                async_policy.shutdown()
+            except Exception:
+                pass
+        if lm_policy:
+            try:
+                lm_policy.shutdown()
+            except Exception:
+                pass
+        import gc
+
+        gc.collect()
+        torch.cuda.empty_cache()

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -14,9 +14,10 @@
 
 import json
 import os
+import threading
 from copy import deepcopy
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 import ray
@@ -33,7 +34,9 @@ from nemo_rl.models.generation.interfaces import (
     GenerationDatumSpec,
 )
 from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration
+from nemo_rl.models.generation.vllm.vllm_worker import VllmGenerationWorker
 from nemo_rl.models.generation.vllm.vllm_worker_async import (
+    VllmAsyncGenerationWorker,
     _replace_prefix_tokens,
 )
 from nemo_rl.models.policy import LoRAConfig, PolicyConfig
@@ -187,6 +190,121 @@ def test_configure_generation_config_keeps_dummy_startup_weights_with_draft_refi
     )
 
     assert configured["vllm_cfg"]["load_format"] == "dummy"
+
+
+def _make_partial_overlap_policy(async_engine: bool = True, dp_size: int = 4):
+    policy = object.__new__(VllmGeneration)
+    policy.cfg = {"vllm_cfg": {"async_engine": async_engine}, "colocated": {"enabled": False}}
+    policy.worker_group = MagicMock()
+    policy.worker_group.dp_size = dp_size
+    policy.worker_group.get_dp_leader_worker_idx.side_effect = (
+        lambda dp_rank: dp_rank + 100
+    )
+    policy.current_generate_dp_shard_idx = 0
+    policy._active_dp_ranks = set(range(dp_size))
+    policy._active_dp_ranks_lock = threading.Lock()
+    return policy
+
+
+def test_vllm_generation_worker_sleep_passes_configured_level_and_mode():
+    worker = object.__new__(VllmGenerationWorker)
+    worker.cfg = {"vllm_cfg": {"async_engine": False, "sleep_level": 2}}
+    worker.llm = MagicMock()
+    worker.llm.renderer = MagicMock()
+
+    worker.sleep(mode="wait")
+
+    worker.llm.llm_engine.reset_prefix_cache.assert_called_once_with()
+    worker.llm.renderer.clear_mm_cache.assert_called_once_with()
+    worker.llm.sleep.assert_called_once_with(level=2, mode="wait")
+
+
+def test_vllm_generation_worker_sleep_explicit_level_overrides_config():
+    worker = object.__new__(VllmGenerationWorker)
+    worker.cfg = {"vllm_cfg": {"async_engine": False, "sleep_level": 2}}
+    worker.llm = MagicMock()
+    worker.llm.renderer = MagicMock()
+
+    worker.sleep(level=1, mode="wait")
+
+    worker.llm.sleep.assert_called_once_with(level=1, mode="wait")
+
+
+@pytest.mark.asyncio
+async def test_vllm_async_generation_worker_sleep_passes_configured_level_and_mode():
+    worker = object.__new__(VllmAsyncGenerationWorker)
+    worker.cfg = {"vllm_cfg": {"async_engine": True, "sleep_level": 2}}
+    worker.llm = MagicMock()
+    worker.llm.reset_prefix_cache = AsyncMock()
+    worker.llm.reset_mm_cache = AsyncMock()
+    worker.llm.sleep = AsyncMock()
+
+    await worker.sleep_async(mode="wait")
+
+    worker.llm.reset_prefix_cache.assert_awaited_once_with()
+    worker.llm.reset_mm_cache.assert_awaited_once_with()
+    worker.llm.sleep.assert_awaited_once_with(level=2, mode="wait")
+
+
+def test_vllm_generation_partial_overlap_helpers_update_active_ranks(monkeypatch):
+    policy = _make_partial_overlap_policy(async_engine=True, dp_size=4)
+    monkeypatch.setattr(ray, "get", lambda _future: True)
+
+    assert policy.sleep_partial([1, 3], level=2)
+    assert policy._active_dp_ranks == {0, 2}
+    assert policy.worker_group.run_single_worker_single_data.call_args_list == [
+        call(method_name="sleep_async", worker_idx=101, level=2, mode="wait"),
+        call(method_name="sleep_async", worker_idx=103, level=2, mode="wait"),
+    ]
+
+    policy.worker_group.run_single_worker_single_data.reset_mock()
+
+    assert policy.wake_up_partial([3], tags=["weights"])
+    assert policy._active_dp_ranks == {0, 2, 3}
+    policy.worker_group.run_single_worker_single_data.assert_called_once_with(
+        method_name="wake_up_async", worker_idx=103, tags=["weights"]
+    )
+
+
+def test_vllm_generation_selects_only_active_dp_ranks():
+    policy = _make_partial_overlap_policy(async_engine=True, dp_size=4)
+    policy._active_dp_ranks = {1, 3}
+
+    assert policy._select_next_active_dp_rank() == 1
+    assert policy._select_next_active_dp_rank() == 3
+    assert policy._select_next_active_dp_rank() == 1
+
+
+def test_vllm_generation_sleep_partial_restores_failed_shards(monkeypatch):
+    policy = _make_partial_overlap_policy(async_engine=True, dp_size=4)
+    policy.worker_group.run_single_worker_single_data.side_effect = ["sleep-1", "sleep-3"]
+
+    def fake_ray_get(future):
+        if future == "sleep-1":
+            return True
+        raise RuntimeError("sleep failed")
+
+    monkeypatch.setattr(ray, "get", fake_ray_get)
+
+    assert not policy.sleep_partial([1, 3], level=2)
+    assert policy._active_dp_ranks == {0, 2, 3}
+
+
+
+def test_vllm_generation_wake_partial_only_restores_successful_shards(monkeypatch):
+    policy = _make_partial_overlap_policy(async_engine=True, dp_size=4)
+    policy._active_dp_ranks = {0, 2}
+    policy.worker_group.run_single_worker_single_data.side_effect = ["wake-1", "wake-3"]
+
+    def fake_ray_get(future):
+        if future == "wake-1":
+            return True
+        raise RuntimeError("wake failed")
+
+    monkeypatch.setattr(ray, "get", fake_ray_get)
+
+    assert not policy.wake_up_partial([1, 3], tags=["weights"])
+    assert policy._active_dp_ranks == {0, 1, 2}
 
 
 def get_basic_megatron_test_config(

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -2697,8 +2697,9 @@ def test_vllm_direct_zmq_weight_update_cpu_serialize(
             result for result in results if result is not None
         ), "cpu_serialize weight update should succeed"
 
+        lm_policy.offload_after_refit()
+        vllm_policy.prepare_for_generation(tags=["kv_cache"])
         print("Running Generation 2 (Weights Updated)...")
-        vllm_policy.prepare_for_generation()
         outputs2 = vllm_policy.generate(test_input_data, greedy=True)
         logprob2 = outputs2["logprobs"][0, input_lengths[0]].item()
         assert logprob2 != logprob1, (

--- a/tests/unit/models/policy/test_utils.py
+++ b/tests/unit/models/policy/test_utils.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import multiprocessing
 import os
+import pickle
 import sys
 import time
 import traceback
@@ -186,18 +188,21 @@ def client_process(
 
         # Receive and validate loop
         while True:
-            payload = socket.recv_pyobj()
-            if payload == IPCProtocol.COMPLETE:
-                socket.send(IPCProtocol.ACK.value.encode())
-                break
+            frames = socket.recv_multipart(copy=False)
+            if len(frames) == 1:
+                payload = pickle.loads(frames[0].buffer)
+                if payload == IPCProtocol.COMPLETE:
+                    socket.send(IPCProtocol.ACK.value.encode())
+                    break
 
-            ipc_handle_or_bytes, list_keys, used_bytes = payload
-            if isinstance(ipc_handle_or_bytes, bytes):
-                # cpu_serialize path: deserialize CPU tensor, DMA to GPU
-                import io
-
+                ipc_handle_or_bytes, list_keys, used_bytes = payload
+                buffer = rebuild_cuda_tensor_from_ipc(
+                    ipc_handle_or_bytes, device.index
+                )
+            elif len(frames) == 3 and bytes(frames[0].buffer) == b"cpu_serialize":
+                list_keys, used_bytes = pickle.loads(frames[1].buffer)
                 bucket_data = torch.load(
-                    io.BytesIO(ipc_handle_or_bytes), weights_only=True
+                    io.BytesIO(frames[2].buffer), weights_only=True
                 )
                 buffer = bucket_data["bucket"]
                 if not buffer.is_pinned():
@@ -205,9 +210,8 @@ def client_process(
                 buffer = buffer.to(device=device, non_blocking=True)
                 torch.cuda.current_stream().synchronize()
             else:
-                # cuda_ipc path (existing)
-                buffer = rebuild_cuda_tensor_from_ipc(
-                    ipc_handle_or_bytes, device.index
+                raise RuntimeError(
+                    f"Unexpected ZMQ frame format in client_process: {len(frames)} frame(s)"
                 )
 
             offset = 0

--- a/tests/unit/models/policy/test_utils.py
+++ b/tests/unit/models/policy/test_utils.py
@@ -125,6 +125,7 @@ def server_process(
     known_tensors: list[tuple[str, torch.Tensor]],
     buffer_size_bytes: int,
     ready_queue: multiprocessing.Queue,
+    model_update_transport: str = "cuda_ipc",
 ) -> None:
     """Server process that streams tensors via IPC ZMQ."""
     try:
@@ -144,6 +145,7 @@ def server_process(
             socket,
             rank=0,
             worker_name="test_server",
+            model_update_transport=model_update_transport,
         )
     except Exception as e:
         import sys
@@ -189,8 +191,24 @@ def client_process(
                 socket.send(IPCProtocol.ACK.value.encode())
                 break
 
-            ipc_handle, list_keys, used_bytes = payload
-            buffer = rebuild_cuda_tensor_from_ipc(ipc_handle, device.index)
+            ipc_handle_or_bytes, list_keys, used_bytes = payload
+            if isinstance(ipc_handle_or_bytes, bytes):
+                # cpu_serialize path: deserialize CPU tensor, DMA to GPU
+                import io
+
+                bucket_data = torch.load(
+                    io.BytesIO(ipc_handle_or_bytes), weights_only=True
+                )
+                buffer = bucket_data["bucket"]
+                if not buffer.is_pinned():
+                    buffer = buffer.pin_memory()
+                buffer = buffer.to(device=device, non_blocking=True)
+                torch.cuda.current_stream().synchronize()
+            else:
+                # cuda_ipc path (existing)
+                buffer = rebuild_cuda_tensor_from_ipc(
+                    ipc_handle_or_bytes, device.index
+                )
 
             offset = 0
             for key in list_keys:
@@ -256,6 +274,7 @@ class TestStreamWeightsViaIPC:
 
     TIMEOUT = 30  # 30 second timeout for additional overhead when running with coverage
 
+    @pytest.mark.parametrize("model_update_transport", ["cuda_ipc", "cpu_serialize"])
     @pytest.mark.parametrize(
         "test_case,tensor_specs,buffer_size_bytes,test_description",
         [
@@ -285,7 +304,12 @@ class TestStreamWeightsViaIPC:
         ],
     )
     def test_stream_weights_via_ipc_zmq_impl(
-        self, test_case, tensor_specs, buffer_size_bytes, test_description
+        self,
+        test_case,
+        tensor_specs,
+        buffer_size_bytes,
+        test_description,
+        model_update_transport,
     ):
         """Test streaming weights via IPC ZMQ between server and client processes."""
         # Generate test tensors
@@ -298,7 +322,7 @@ class TestStreamWeightsViaIPC:
         ]
 
         # Create unique socket path and queues
-        socket_path = f"/tmp/test_ipc_zmq_{test_case}_{os.getpid()}_{time.time()}"
+        socket_path = f"/tmp/test_ipc_zmq_{test_case}_{model_update_transport}_{os.getpid()}_{time.time()}"
         zmq_addr = f"ipc://{socket_path}"
 
         mp_context = multiprocessing.get_context("spawn")
@@ -308,7 +332,7 @@ class TestStreamWeightsViaIPC:
         # Start server and client
         server_proc = mp_context.Process(
             target=server_process,
-            args=(zmq_addr, known_tensors, buffer_size_bytes, ready_queue),
+            args=(zmq_addr, known_tensors, buffer_size_bytes, ready_queue, model_update_transport),
         )
         server_proc.start()
 
@@ -343,3 +367,30 @@ class TestStreamWeightsViaIPC:
 
             if os.path.exists(socket_path):
                 os.unlink(socket_path)
+
+    def test_stream_weights_invalid_transport(self):
+        """Invalid model_update_transport should raise ValueError before any ZMQ I/O."""
+
+        class _DummySocket:
+            def send_pyobj(self, *a, **k):
+                raise AssertionError("should not reach ZMQ send")
+
+            def recv(self, *a, **k):
+                raise AssertionError("should not reach ZMQ recv")
+
+            def getsockopt(self, *a, **k):
+                return 0
+
+        def _empty_gen():
+            if False:
+                yield None  # pragma: no cover
+
+        with pytest.raises(ValueError, match="Unsupported model_update_transport"):
+            stream_weights_via_ipc_zmq_impl(
+                params_generator=_empty_gen(),
+                buffer_size_bytes=1024,
+                zmq_socket=_DummySocket(),
+                rank=0,
+                worker_name="test",
+                model_update_transport="not_a_real_transport",
+            )


### PR DESCRIPTION
# What does this PR do ?

adds partial DP-shard sleep/wake for vLLM inference, so overlapping inference shards can release GPUs for training while non-overlapping shards keep serving, then wake back up afterward. Includes targeted re-dispatch for shard-preempted async requests, last-active-shard protection, and 15 passing tests, including 2 real 2-GPU runtime integration tests.

Configurable vLLM sleep level (was hardcoded to 1)
Partial DP shard sleep/wake with active set and preemption tracking
Async routing skip for sleeping shards + ShardPreemptedError + bounded retry

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
