### PR TITLE
fix: store mm_token_type_ids as plain tensor in get_formatted_message_log

### DIFF
--- a/nemo_rl/data/llm_message_utils.py
+++ b/nemo_rl/data/llm_message_utils.py
@@ -623,10 +623,17 @@ def get_formatted_message_log(
             # add all vlm keys to the message
             for key in multimodal_keys:
                 if key in processed_chunk:
-                    new_message[key] = PackedTensor(
-                        processed_chunk[key],
-                        dim_to_pack=get_dim_to_pack_along(tokenizer, key),
-                    )
+                    # token_type_ids and mm_token_type_ids are sequence-length tensors
+                    # (one label per token), not visual patch tensors. They must be
+                    # stored as plain tensors and padded like input_ids rather than
+                    # packed as multimodal data. This mirrors processors.py behavior.
+                    if key in ("token_type_ids", "mm_token_type_ids"):
+                        new_message[key] = processed_chunk[key][0]
+                    else:
+                        new_message[key] = PackedTensor(
+                            processed_chunk[key],
+                            dim_to_pack=get_dim_to_pack_along(tokenizer, key),
+                        )
 
         if len(new_message["token_ids"]) == 0:
             # if there is an empty message, the empty `token_ids` tensor ends up being in fp32,


### PR DESCRIPTION
# What does this PR do ?

fix: store mm_token_type_ids as plain tensor in get_formatted_message_log

This is a Fix from Claude Code.

This fixes an error introduced from this PR: https://github.com/NVIDIA-NeMo/RL/pull/2073
Potentially due to this change:
https://github.com/NVIDIA-NeMo/RL/pull/2073/changes#diff-ace3aad9850c0390e28b2bebf63ce50dd1ecba7c558abcf8066aaafdd48256e6R217

token_type_ids and mm_token_type_ids are per-token sequence labels, not visual patch tensors. Storing them as PackedTensor(dim_to_pack=0) causes torch.cat to fail when batching samples with different sequence lengths, because the variable seq_len dimension does not match across samples.

Store them as plain 1D tensors instead so they get padded via pad_sequence in batched_message_log_to_flat_message, matching how processors.py already handles them in the VLM environment processor.


**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
