### PR TITLE
fix: Ensure code coverage report is uploaded

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -551,14 +551,6 @@ jobs:
           pattern: coverage-${{ matrix.flag }}-*
           path: coverage-downloads
 
-      - name: Debug download layout
-        run: |
-          echo "Working directory: $(pwd)"
-          echo "--- coverage-downloads ---"
-          ls -laR coverage-downloads 2>/dev/null || echo "coverage-downloads/ does not exist"
-          echo "--- top-level coverage-* ---"
-          ls -la coverage-* 2>/dev/null || echo "No coverage-* entries in workspace"
-
       - name: Check if artifacts were downloaded
         id: check-artifacts
         run: |

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -549,12 +549,21 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           pattern: coverage-${{ matrix.flag }}-*
+          path: coverage-downloads
+
+      - name: Debug download layout
+        run: |
+          echo "Working directory: $(pwd)"
+          echo "--- coverage-downloads ---"
+          ls -laR coverage-downloads 2>/dev/null || echo "coverage-downloads/ does not exist"
+          echo "--- top-level coverage-* ---"
+          ls -la coverage-* 2>/dev/null || echo "No coverage-* entries in workspace"
 
       - name: Check if artifacts were downloaded
         id: check-artifacts
         run: |
-          # Check if any coverage directories were downloaded
-          if ls coverage-* 1> /dev/null 2>&1; then
+          # Check if any .coverage files were downloaded
+          if find coverage-downloads -name ".coverage" -type f 2>/dev/null | grep -q .; then
             echo "artifacts-found=true" >> $GITHUB_OUTPUT
             echo "Found coverage artifacts for ${{ matrix.flag }}"
           else
@@ -568,12 +577,10 @@ jobs:
         run: |
           pip install coverage
 
-          ls -al .
-          ls -al coverage-*/
-          coverage combine --keep $(ls coverage-*/.coverage)
+          find coverage-downloads -name ".coverage" -type f
+          coverage combine --keep $(find coverage-downloads -name ".coverage" -type f)
           coverage report -i --show-missing
-          rm -rf coverage-*
-          ls -al
+          rm -rf coverage-downloads
 
       - name: Skip coverage processing
         if: ${{ steps.check-artifacts.outputs.artifacts-found == 'false' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -542,8 +542,7 @@ exclude = '''
 '''
 
 [tool.pytest.ini_options]
-addopts = "--testmon --durations=100 -s -rA -x"
-#addopts = "--durations=100 -s -rA -x"
+addopts = "--durations=100 -s -rA -x"
 testpaths = ["tests"]
 python_files = "test_*.py"
 markers = [


### PR DESCRIPTION
# What does this PR do ?

Fix code coverage report

For some reason, the code coverage report was not being found correctly since late March. Our coverage dropped from ~70% to now ~25%. This increases it to ~50%. Some other event happened to affect coverage that we need to investigate in a follow-up. 

Codecov is now ~70%.  Still a little lower than before.  But better than 25%.
https://app.codecov.io/gh/NVIDIA-NeMo/RL/pull/2339

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
