### PR TITLE
feat: topology-aware autoscaling validation (RL-414)

### DIFF
--- a/k8s/rl-414-topology-autoscale-test.yaml
+++ b/k8s/rl-414-topology-autoscale-test.yaml
@@ -1,23 +1,48 @@
 # RL-414: Validate kai-scheduler + kuberay autoscaling with topology constraints
 #
-# Tests whether kuberay's autoscaler can dynamically scale worker groups that
-# have kai-scheduler topology constraints (gb300-topology at nvidia.com/gpu.clique).
+# Extended test: 2 initial cliques + 12 add-on cliques (6 full + 6 partial)
+#   initial-a, initial-b: replicas=4 (pre-existing workers)
+#   addon-1..6: replicas=0 (autoscale 0->4 with full 4-node PGs)
+#   addon-7..12: replicas=0 (autoscale 0->2->4 with half-clique 2-node PGs)
 #
-# Test design:
-#   clique-a: 4 workers (replicas=4, minReplicas=0) — starts full, tests scale DOWN
-#   clique-b: 4 workers (replicas=4, minReplicas=0) — baseline
-#   clique-c: 0 workers (replicas=0, minReplicas=0) — tests scale UP (0->4)
-#
-# The kai-scheduler ray-grouper EXCLUDES PodGroup subgroups where both
-# minReplicas=0 AND replicas=0 (clique-c). This test validates whether new pods
-# created by the autoscaler still get topology-aware scheduling.
+# Test phases:
+#   1. Verify initial-a/b placement in separate topology cliques
+#   2a. Autoscale 6 full-clique groups (4-node PGs) - confirms topology is not a fluke
+#   2b. Autoscale 6 partial-clique groups (2-node PGs) - tests partial allocation
+#   3. Scale down: remove initial-a PG, verify workers drain
 #
 # Usage:
 #   kubectl apply -f k8s/rl-414-topology-autoscale-test.yaml --context aws-cmh
 #   kubectl logs -f -l ray.io/node-type=head -c ray-head --context aws-cmh
-#   # Clean up:
-#   kubectl delete rayjob rl-414-autoscale-topology-test --context aws-cmh
-#   kubectl delete configmap rl-414-driver-script --context aws-cmh
+#   # Clean up (including RBAC):
+#   kubectl delete -f k8s/rl-414-topology-autoscale-test.yaml --context aws-cmh
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rl-414-node-reader
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rl-414-node-reader
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rl-414-node-reader
+subjects:
+- kind: ServiceAccount
+  name: rl-414-node-reader
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: rl-414-node-reader
+  apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -30,12 +55,35 @@ data:
     import os
     import json
     import socket
+    import ssl
     import sys
+    import urllib.request
     from ray.util.placement_group import placement_group, remove_placement_group
 
 
     def log(msg):
         print(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] {msg}", flush=True)
+
+
+    def get_node_clique(node_name):
+        try:
+            with open("/var/run/secrets/kubernetes.io/serviceaccount/token") as f:
+                token = f.read().strip()
+            ctx = ssl.create_default_context(
+                cafile="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+            )
+            req = urllib.request.Request(
+                f"https://kubernetes.default.svc/api/v1/nodes/{node_name}",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            with urllib.request.urlopen(req, context=ctx) as resp:
+                data = json.loads(resp.read())
+                return data["metadata"]["labels"].get(
+                    "nvidia.com/gpu.clique", "unknown"
+                )
+        except Exception as e:
+            log(f"  WARNING: Could not query node {node_name}: {e}")
+            return "error"
 
 
     @ray.remote(num_cpus=0)
@@ -59,8 +107,22 @@ data:
         nodes = ray.get(tasks, timeout=120)
         log(f"{label} nodes:")
         for i, n in enumerate(nodes):
-            log(f"  bundle[{i}]: node={n['node_name']}, host={n['hostname']}, ip={n['node_ip']}")
+            n["clique"] = get_node_clique(n["node_name"])
+            log(f"  bundle[{i}]: node={n['node_name']}, clique={n['clique']}")
         return nodes
+
+
+    def verify_same_clique(nodes, label):
+        cliques = {n["clique"] for n in nodes if n["clique"] not in ("error", "unknown")}
+        if len(cliques) == 1:
+            log(f"  PASS: {label} -> clique {next(iter(cliques))}")
+            return True
+        elif len(cliques) == 0:
+            log(f"  WARN: Could not determine clique for {label}")
+            return False
+        else:
+            log(f"  FAIL: {label} spans cliques: {cliques}")
+            return False
 
 
     def wait_for_pg(pg, label, timeout=600):
@@ -78,138 +140,189 @@ data:
             avail = ray.available_resources()
             log(
                 f"{label} pending ({elapsed}s)"
-                f" | cluster GPU={res.get('GPU', 0)}"
-                f" avail GPU={avail.get('GPU', 0)}"
+                f" | GPU={res.get('GPU', 0)} avail={avail.get('GPU', 0)}"
             )
+
+
+    def create_pg(name, resource_key, num_bundles):
+        bundles = [{"GPU": 4, resource_key: 0.001} for _ in range(num_bundles)]
+        return placement_group(bundles, strategy="STRICT_SPREAD", name=name)
 
 
     def main():
         ray.init()
         results = {}
+        all_pgs = {}
+        all_nodes = {}
 
         log("=" * 70)
         log("RL-414: Topology-Aware Autoscaling Validation")
+        log("  2 initial + 6 full-clique + 6 partial-clique add-ons")
         log("=" * 70)
-        log(f"Cluster resources: {json.dumps(dict(ray.cluster_resources()), indent=2)}")
+        log(f"Resources: {json.dumps(dict(ray.cluster_resources()), indent=2)}")
 
-        # ── PHASE 1: Verify initial topology placement ──
+        # Phase 1: Initial topology placement
         log("\n" + "=" * 70)
-        log("PHASE 1: Verify initial topology placement")
+        log("PHASE 1: Initial placement (2 x 4-node PGs)")
         log("=" * 70)
 
-        log("Creating PG1 (clique-a): 4 bundles x 4 GPUs")
-        pg1 = placement_group(
-            [{"GPU": 4, "clique_a": 0.001} for _ in range(4)],
-            strategy="STRICT_SPREAD",
-            name="pg-clique-a",
-        )
-        if not wait_for_pg(pg1, "PG1", timeout=300):
-            log("FAIL: PG1 timed out")
-            sys.exit(1)
+        for name, res_key in [("initial-a", "initial_a"), ("initial-b", "initial_b")]:
+            pg = create_pg(f"pg-{name}", res_key, 4)
+            all_pgs[name] = pg
 
-        log("Creating PG2 (clique-b): 4 bundles x 4 GPUs")
-        pg2 = placement_group(
-            [{"GPU": 4, "clique_b": 0.001} for _ in range(4)],
-            strategy="STRICT_SPREAD",
-            name="pg-clique-b",
-        )
-        if not wait_for_pg(pg2, "PG2", timeout=300):
-            log("FAIL: PG2 timed out")
-            sys.exit(1)
+        for name in ["initial-a", "initial-b"]:
+            pg = all_pgs[name]
+            if not wait_for_pg(pg, name, timeout=300):
+                log(f"FAIL: {name} timed out")
+                sys.exit(1)
+            nodes = collect_pg_nodes(pg, 4, name)
+            all_nodes[name] = nodes
+            results[f"p1_{name}"] = "PASS" if verify_same_clique(nodes, name) else "FAIL"
 
-        pg1_nodes = collect_pg_nodes(pg1, 4, "PG1 (clique-a)")
-        pg2_nodes = collect_pg_nodes(pg2, 4, "PG2 (clique-b)")
-
-        pg1_names = {n["node_name"] for n in pg1_nodes}
-        pg2_names = {n["node_name"] for n in pg2_nodes}
-        if pg1_names & pg2_names:
-            log(f"WARNING: PG1/PG2 share nodes: {pg1_names & pg2_names}")
-            results["phase1"] = "WARN"
+        a_set = {n["node_name"] for n in all_nodes["initial-a"]}
+        b_set = {n["node_name"] for n in all_nodes["initial-b"]}
+        if a_set & b_set:
+            log(f"WARNING: initial-a/b share nodes: {a_set & b_set}")
+            results["p1_disjoint"] = "WARN"
         else:
-            log("PASS: PG1 and PG2 on disjoint nodes")
-            results["phase1"] = "PASS"
+            log("PASS: initial-a and initial-b on disjoint nodes")
+            results["p1_disjoint"] = "PASS"
 
-        # ── PHASE 2: Autoscale UP (clique-c: 0 -> 4) ──
+        # Phase 2a: Full-clique autoscaling (6 x 4-node PGs)
         log("\n" + "=" * 70)
-        log("PHASE 2: Autoscale UP (clique-c: 0 -> 4 workers)")
-        log("=" * 70)
-        log("clique-c has replicas=0/minReplicas=0 => NOT in PodGroup subgroups")
-
-        log("Creating PG3 (clique-c): 4 bundles x 4 GPUs")
-        pg3 = placement_group(
-            [{"GPU": 4, "clique_c": 0.001} for _ in range(4)],
-            strategy="STRICT_SPREAD",
-            name="pg-clique-c",
-        )
-
-        pg3_ready = wait_for_pg(pg3, "PG3", timeout=600)
-        pg3_nodes = None
-        if not pg3_ready:
-            log("FAIL: PG3 timed out")
-            log("Autoscaling with topology likely does not work for 0-replica groups")
-            results["phase2"] = "FAIL"
-        else:
-            pg3_nodes = collect_pg_nodes(pg3, 4, "PG3 (clique-c)")
-            pg3_names = {n["node_name"] for n in pg3_nodes}
-            if pg3_names & pg1_names or pg3_names & pg2_names:
-                log("WARNING: PG3 shares nodes with other PGs")
-                results["phase2"] = "WARN"
-            else:
-                log("PASS: Autoscale UP succeeded, PG3 on disjoint nodes")
-                results["phase2"] = "PASS"
-
-        # ── PHASE 3: Autoscale DOWN (remove PG1, clique-a: 4 -> 0) ──
-        log("\n" + "=" * 70)
-        log("PHASE 3: Autoscale DOWN (clique-a: 4 -> 0 after removing PG1)")
+        log("PHASE 2a: Full-clique autoscale (6 PGs x 4 nodes)")
+        log("Verifies topology placement is not a fluke")
         log("=" * 70)
 
-        remove_placement_group(pg1)
-        log("PG1 removed. Monitoring clique-a scale-down...")
+        for i in range(1, 7):
+            name = f"addon-{i}"
+            all_pgs[name] = create_pg(f"pg-{name}", f"addon_{i}", 4)
 
-        initial_ca = ray.cluster_resources().get("clique_a", 0)
+        for i in range(1, 7):
+            name = f"addon-{i}"
+            if not wait_for_pg(all_pgs[name], name, timeout=600):
+                log(f"FAIL: {name} timed out")
+                results[f"p2a_{name}"] = "FAIL"
+                continue
+            nodes = collect_pg_nodes(all_pgs[name], 4, name)
+            all_nodes[name] = nodes
+            results[f"p2a_{name}"] = (
+                "PASS" if verify_same_clique(nodes, name) else "FAIL"
+            )
+
+        # Phase 2b: Partial-clique autoscaling (12 x 2-node PGs)
+        log("\n" + "=" * 70)
+        log("PHASE 2b: Partial-clique autoscale (12 PGs x 2 nodes)")
+        log("Tests whether 2/4 nodes still get same-clique placement")
+        log("=" * 70)
+
+        # Batch 1: triggers scale 0->2 for addon-7 through addon-12
+        log("Batch 1: 6 PGs x 2 nodes (scale 0->2)...")
+        for i in range(7, 13):
+            name = f"addon-{i}-a"
+            all_pgs[name] = create_pg(f"pg-{name}", f"addon_{i}", 2)
+
+        for i in range(7, 13):
+            name = f"addon-{i}-a"
+            if not wait_for_pg(all_pgs[name], name, timeout=600):
+                log(f"FAIL: {name} timed out")
+                results[f"p2b_{name}"] = "FAIL"
+                continue
+            nodes = collect_pg_nodes(all_pgs[name], 2, name)
+            all_nodes[name] = nodes
+            results[f"p2b_{name}"] = (
+                "PASS" if verify_same_clique(nodes, name) else "FAIL"
+            )
+
+        # Batch 2: triggers scale 2->4 for addon-7 through addon-12
+        log("Batch 2: 6 PGs x 2 nodes (scale 2->4)...")
+        for i in range(7, 13):
+            name = f"addon-{i}-b"
+            all_pgs[name] = create_pg(f"pg-{name}", f"addon_{i}", 2)
+
+        for i in range(7, 13):
+            name = f"addon-{i}-b"
+            if not wait_for_pg(all_pgs[name], name, timeout=600):
+                log(f"FAIL: {name} timed out")
+                results[f"p2b_{name}"] = "FAIL"
+                continue
+            nodes = collect_pg_nodes(all_pgs[name], 2, name)
+            all_nodes[name] = nodes
+            results[f"p2b_{name}"] = (
+                "PASS" if verify_same_clique(nodes, name) else "FAIL"
+            )
+
+        # Cross-check: both halves in same clique
+        for i in range(7, 13):
+            a_key = f"addon-{i}-a"
+            b_key = f"addon-{i}-b"
+            if a_key in all_nodes and b_key in all_nodes:
+                combined = all_nodes[a_key] + all_nodes[b_key]
+                label = f"addon-{i} combined"
+                results[f"p2b_addon{i}_combined"] = (
+                    "PASS" if verify_same_clique(combined, label) else "FAIL"
+                )
+
+        # Phase 3: Scale down
+        log("\n" + "=" * 70)
+        log("PHASE 3: Scale DOWN (remove pg-initial-a)")
+        log("=" * 70)
+
+        remove_placement_group(all_pgs["initial-a"])
+        del all_pgs["initial-a"]
+        log("pg-initial-a removed. Monitoring scale-down...")
+
+        init_val = ray.cluster_resources().get("initial_a", 0)
         scaled_down = False
-        for i in range(10):
+        for tick in range(10):
             time.sleep(30)
-            elapsed = (i + 1) * 30
+            elapsed = (tick + 1) * 30
             res = ray.cluster_resources()
-            ca = res.get("clique_a", 0)
-            log(f"[{elapsed}s] clique_a={ca}, GPU={res.get('GPU', 0)}")
-            if ca < initial_ca:
+            cur = res.get("initial_a", 0)
+            log(f"[{elapsed}s] initial_a={cur}, GPU={res.get('GPU', 0)}")
+            if cur < init_val:
                 scaled_down = True
-            if ca == 0:
-                log(f"PASS: clique-a fully scaled down after {elapsed}s")
+            if cur == 0:
+                log(f"PASS: initial-a scaled down after {elapsed}s")
                 break
 
-        results["phase3"] = "PASS" if scaled_down else "FAIL"
+        results["p3_scale_down"] = "PASS" if scaled_down else "FAIL"
         if not scaled_down:
-            log("clique-a did not scale down within 5 minutes")
+            log("initial-a did not scale down within 5 min")
 
-        # ── SUMMARY ──
+        # Summary
         log("\n" + "=" * 70)
         log("SUMMARY")
         log("=" * 70)
-        for phase, result in sorted(results.items()):
-            log(f"  {phase}: {result}")
-        log(f"\nPG1 nodes: {json.dumps([n['node_name'] for n in pg1_nodes])}")
-        log(f"PG2 nodes: {json.dumps([n['node_name'] for n in pg2_nodes])}")
-        if pg3_nodes:
-            log(f"PG3 nodes: {json.dumps([n['node_name'] for n in pg3_nodes])}")
 
-        log("\nVerify topology externally:")
-        log(
-            "  kubectl get nodes -l nvidia.com/gpu.clique"
-            " -o custom-columns="
-            "\"NAME:.metadata.name,CLIQUE:.metadata.labels.nvidia\\\\.com/gpu\\\\.clique\""
-        )
+        passes = sum(1 for v in results.values() if v == "PASS")
+        fails = sum(1 for v in results.values() if v == "FAIL")
+        warns = sum(1 for v in results.values() if v == "WARN")
 
-        # Cleanup
-        log("\nCleaning up...")
-        remove_placement_group(pg2)
-        if pg3_ready:
-            remove_placement_group(pg3)
-        log("Done")
+        for key in sorted(results):
+            log(f"  {key}: {results[key]}")
+        log(f"\nTotal: {passes} PASS, {fails} FAIL, {warns} WARN")
 
-        if any(v == "FAIL" for v in results.values()):
+        log("\nClique mapping:")
+        clique_map = {}
+        for pg_name, nodes in all_nodes.items():
+            for n in nodes:
+                c = n.get("clique", "?")
+                clique_map.setdefault(c, set()).add(pg_name)
+        for c in sorted(clique_map):
+            log(f"  {c}: {sorted(clique_map[c])}")
+
+        log("\nCleaning up placement groups...")
+        for name, pg in list(all_pgs.items()):
+            try:
+                remove_placement_group(pg)
+            except Exception:
+                pass
+
+        log("Done.")
+        log("Clean up: kubectl delete -f k8s/rl-414-topology-autoscale-test.yaml")
+
+        if fails > 0:
             sys.exit(1)
 
 
@@ -245,7 +358,7 @@ spec:
         block: 'true'
       template:
         spec:
-          # Adjust nodeSelector if your cluster uses different labels for CPU nodes
+          serviceAccountName: rl-414-node-reader
           nodeSelector:
             nodeGroup: customer-cpu
           schedulerName: kai-scheduler
@@ -270,14 +383,15 @@ spec:
             configMap:
               name: rl-414-driver-script
     workerGroupSpecs:
-    - groupName: clique-a
+    # ── Initial cliques (replicas=4, pre-existing workers) ──
+    - groupName: initial-a
       replicas: 4
       minReplicas: 0
       maxReplicas: 4
       rayStartParams:
         block: 'true'
         num-gpus: "4"
-        resources: '{"clique_a": 1}'
+        resources: '{"initial_a": 1}'
       template:
         metadata:
           annotations:
@@ -306,14 +420,14 @@ spec:
                   fieldPath: spec.nodeName
             - name: RAY_memory_monitor_refresh_ms
               value: "0"
-    - groupName: clique-b
+    - groupName: initial-b
       replicas: 4
       minReplicas: 0
       maxReplicas: 4
       rayStartParams:
         block: 'true'
         num-gpus: "4"
-        resources: '{"clique_b": 1}'
+        resources: '{"initial_b": 1}'
       template:
         metadata:
           annotations:
@@ -342,16 +456,412 @@ spec:
                   fieldPath: spec.nodeName
             - name: RAY_memory_monitor_refresh_ms
               value: "0"
-    # This group is EXCLUDED from the PodGroup (replicas=0 AND minReplicas=0).
-    # Testing whether autoscaler-created pods still get topology constraints.
-    - groupName: clique-c
+    # ── Full-clique add-ons (replicas=0, autoscale 0->4) ──
+    - groupName: addon-1
       replicas: 0
       minReplicas: 0
       maxReplicas: 4
       rayStartParams:
         block: 'true'
         num-gpus: "4"
-        resources: '{"clique_c": 1}'
+        resources: '{"addon_1": 1}'
+      template:
+        metadata:
+          annotations:
+            kai.scheduler/topology: gb300-topology
+            kai.scheduler/topology-required-placement: nvidia.com/gpu.clique
+        spec:
+          schedulerName: kai-scheduler
+          tolerations:
+          - operator: Exists
+          containers:
+          - name: ray-worker
+            image: rayproject/ray:2.54.0
+            resources:
+              requests:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+              limits:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: RAY_memory_monitor_refresh_ms
+              value: "0"
+    - groupName: addon-2
+      replicas: 0
+      minReplicas: 0
+      maxReplicas: 4
+      rayStartParams:
+        block: 'true'
+        num-gpus: "4"
+        resources: '{"addon_2": 1}'
+      template:
+        metadata:
+          annotations:
+            kai.scheduler/topology: gb300-topology
+            kai.scheduler/topology-required-placement: nvidia.com/gpu.clique
+        spec:
+          schedulerName: kai-scheduler
+          tolerations:
+          - operator: Exists
+          containers:
+          - name: ray-worker
+            image: rayproject/ray:2.54.0
+            resources:
+              requests:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+              limits:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: RAY_memory_monitor_refresh_ms
+              value: "0"
+    - groupName: addon-3
+      replicas: 0
+      minReplicas: 0
+      maxReplicas: 4
+      rayStartParams:
+        block: 'true'
+        num-gpus: "4"
+        resources: '{"addon_3": 1}'
+      template:
+        metadata:
+          annotations:
+            kai.scheduler/topology: gb300-topology
+            kai.scheduler/topology-required-placement: nvidia.com/gpu.clique
+        spec:
+          schedulerName: kai-scheduler
+          tolerations:
+          - operator: Exists
+          containers:
+          - name: ray-worker
+            image: rayproject/ray:2.54.0
+            resources:
+              requests:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+              limits:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: RAY_memory_monitor_refresh_ms
+              value: "0"
+    - groupName: addon-4
+      replicas: 0
+      minReplicas: 0
+      maxReplicas: 4
+      rayStartParams:
+        block: 'true'
+        num-gpus: "4"
+        resources: '{"addon_4": 1}'
+      template:
+        metadata:
+          annotations:
+            kai.scheduler/topology: gb300-topology
+            kai.scheduler/topology-required-placement: nvidia.com/gpu.clique
+        spec:
+          schedulerName: kai-scheduler
+          tolerations:
+          - operator: Exists
+          containers:
+          - name: ray-worker
+            image: rayproject/ray:2.54.0
+            resources:
+              requests:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+              limits:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: RAY_memory_monitor_refresh_ms
+              value: "0"
+    - groupName: addon-5
+      replicas: 0
+      minReplicas: 0
+      maxReplicas: 4
+      rayStartParams:
+        block: 'true'
+        num-gpus: "4"
+        resources: '{"addon_5": 1}'
+      template:
+        metadata:
+          annotations:
+            kai.scheduler/topology: gb300-topology
+            kai.scheduler/topology-required-placement: nvidia.com/gpu.clique
+        spec:
+          schedulerName: kai-scheduler
+          tolerations:
+          - operator: Exists
+          containers:
+          - name: ray-worker
+            image: rayproject/ray:2.54.0
+            resources:
+              requests:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+              limits:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: RAY_memory_monitor_refresh_ms
+              value: "0"
+    - groupName: addon-6
+      replicas: 0
+      minReplicas: 0
+      maxReplicas: 4
+      rayStartParams:
+        block: 'true'
+        num-gpus: "4"
+        resources: '{"addon_6": 1}'
+      template:
+        metadata:
+          annotations:
+            kai.scheduler/topology: gb300-topology
+            kai.scheduler/topology-required-placement: nvidia.com/gpu.clique
+        spec:
+          schedulerName: kai-scheduler
+          tolerations:
+          - operator: Exists
+          containers:
+          - name: ray-worker
+            image: rayproject/ray:2.54.0
+            resources:
+              requests:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+              limits:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: RAY_memory_monitor_refresh_ms
+              value: "0"
+    # ── Partial-clique add-ons (replicas=0, autoscale 0->2->4) ──
+    - groupName: addon-7
+      replicas: 0
+      minReplicas: 0
+      maxReplicas: 4
+      rayStartParams:
+        block: 'true'
+        num-gpus: "4"
+        resources: '{"addon_7": 1}'
+      template:
+        metadata:
+          annotations:
+            kai.scheduler/topology: gb300-topology
+            kai.scheduler/topology-required-placement: nvidia.com/gpu.clique
+        spec:
+          schedulerName: kai-scheduler
+          tolerations:
+          - operator: Exists
+          containers:
+          - name: ray-worker
+            image: rayproject/ray:2.54.0
+            resources:
+              requests:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+              limits:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: RAY_memory_monitor_refresh_ms
+              value: "0"
+    - groupName: addon-8
+      replicas: 0
+      minReplicas: 0
+      maxReplicas: 4
+      rayStartParams:
+        block: 'true'
+        num-gpus: "4"
+        resources: '{"addon_8": 1}'
+      template:
+        metadata:
+          annotations:
+            kai.scheduler/topology: gb300-topology
+            kai.scheduler/topology-required-placement: nvidia.com/gpu.clique
+        spec:
+          schedulerName: kai-scheduler
+          tolerations:
+          - operator: Exists
+          containers:
+          - name: ray-worker
+            image: rayproject/ray:2.54.0
+            resources:
+              requests:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+              limits:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: RAY_memory_monitor_refresh_ms
+              value: "0"
+    - groupName: addon-9
+      replicas: 0
+      minReplicas: 0
+      maxReplicas: 4
+      rayStartParams:
+        block: 'true'
+        num-gpus: "4"
+        resources: '{"addon_9": 1}'
+      template:
+        metadata:
+          annotations:
+            kai.scheduler/topology: gb300-topology
+            kai.scheduler/topology-required-placement: nvidia.com/gpu.clique
+        spec:
+          schedulerName: kai-scheduler
+          tolerations:
+          - operator: Exists
+          containers:
+          - name: ray-worker
+            image: rayproject/ray:2.54.0
+            resources:
+              requests:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+              limits:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: RAY_memory_monitor_refresh_ms
+              value: "0"
+    - groupName: addon-10
+      replicas: 0
+      minReplicas: 0
+      maxReplicas: 4
+      rayStartParams:
+        block: 'true'
+        num-gpus: "4"
+        resources: '{"addon_10": 1}'
+      template:
+        metadata:
+          annotations:
+            kai.scheduler/topology: gb300-topology
+            kai.scheduler/topology-required-placement: nvidia.com/gpu.clique
+        spec:
+          schedulerName: kai-scheduler
+          tolerations:
+          - operator: Exists
+          containers:
+          - name: ray-worker
+            image: rayproject/ray:2.54.0
+            resources:
+              requests:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+              limits:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: RAY_memory_monitor_refresh_ms
+              value: "0"
+    - groupName: addon-11
+      replicas: 0
+      minReplicas: 0
+      maxReplicas: 4
+      rayStartParams:
+        block: 'true'
+        num-gpus: "4"
+        resources: '{"addon_11": 1}'
+      template:
+        metadata:
+          annotations:
+            kai.scheduler/topology: gb300-topology
+            kai.scheduler/topology-required-placement: nvidia.com/gpu.clique
+        spec:
+          schedulerName: kai-scheduler
+          tolerations:
+          - operator: Exists
+          containers:
+          - name: ray-worker
+            image: rayproject/ray:2.54.0
+            resources:
+              requests:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+              limits:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: RAY_memory_monitor_refresh_ms
+              value: "0"
+    - groupName: addon-12
+      replicas: 0
+      minReplicas: 0
+      maxReplicas: 4
+      rayStartParams:
+        block: 'true'
+        num-gpus: "4"
+        resources: '{"addon_12": 1}'
       template:
         metadata:
           annotations:

--- a/k8s/rl-414-topology-autoscale-test.yaml
+++ b/k8s/rl-414-topology-autoscale-test.yaml
@@ -1,0 +1,382 @@
+# RL-414: Validate kai-scheduler + kuberay autoscaling with topology constraints
+#
+# Tests whether kuberay's autoscaler can dynamically scale worker groups that
+# have kai-scheduler topology constraints (gb300-topology at nvidia.com/gpu.clique).
+#
+# Test design:
+#   clique-a: 4 workers (replicas=4, minReplicas=0) — starts full, tests scale DOWN
+#   clique-b: 4 workers (replicas=4, minReplicas=0) — baseline
+#   clique-c: 0 workers (replicas=0, minReplicas=0) — tests scale UP (0->4)
+#
+# The kai-scheduler ray-grouper EXCLUDES PodGroup subgroups where both
+# minReplicas=0 AND replicas=0 (clique-c). This test validates whether new pods
+# created by the autoscaler still get topology-aware scheduling.
+#
+# Usage:
+#   kubectl apply -f k8s/rl-414-topology-autoscale-test.yaml --context aws-cmh
+#   kubectl logs -f -l ray.io/node-type=head -c ray-head --context aws-cmh
+#   # Clean up:
+#   kubectl delete rayjob rl-414-autoscale-topology-test --context aws-cmh
+#   kubectl delete configmap rl-414-driver-script --context aws-cmh
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rl-414-driver-script
+data:
+  driver.py: |
+    import ray
+    import time
+    import os
+    import json
+    import socket
+    import sys
+    from ray.util.placement_group import placement_group, remove_placement_group
+
+
+    def log(msg):
+        print(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] {msg}", flush=True)
+
+
+    @ray.remote(num_cpus=0)
+    def get_node_info():
+        return {
+            "hostname": socket.gethostname(),
+            "node_name": os.environ.get("NODE_NAME", "unknown"),
+            "node_ip": ray.util.get_node_ip_address(),
+        }
+
+
+    def collect_pg_nodes(pg, num_bundles, label):
+        tasks = [
+            get_node_info.options(
+                placement_group=pg,
+                placement_group_bundle_index=i,
+                num_gpus=4,
+            ).remote()
+            for i in range(num_bundles)
+        ]
+        nodes = ray.get(tasks, timeout=120)
+        log(f"{label} nodes:")
+        for i, n in enumerate(nodes):
+            log(f"  bundle[{i}]: node={n['node_name']}, host={n['hostname']}, ip={n['node_ip']}")
+        return nodes
+
+
+    def wait_for_pg(pg, label, timeout=600):
+        start = time.time()
+        while True:
+            remaining = timeout - (time.time() - start)
+            if remaining <= 0:
+                return False
+            ready = pg.wait(timeout_seconds=min(30, remaining))
+            if ready:
+                log(f"{label} ready ({int(time.time() - start)}s)")
+                return True
+            elapsed = int(time.time() - start)
+            res = ray.cluster_resources()
+            avail = ray.available_resources()
+            log(
+                f"{label} pending ({elapsed}s)"
+                f" | cluster GPU={res.get('GPU', 0)}"
+                f" avail GPU={avail.get('GPU', 0)}"
+            )
+
+
+    def main():
+        ray.init()
+        results = {}
+
+        log("=" * 70)
+        log("RL-414: Topology-Aware Autoscaling Validation")
+        log("=" * 70)
+        log(f"Cluster resources: {json.dumps(dict(ray.cluster_resources()), indent=2)}")
+
+        # ── PHASE 1: Verify initial topology placement ──
+        log("\n" + "=" * 70)
+        log("PHASE 1: Verify initial topology placement")
+        log("=" * 70)
+
+        log("Creating PG1 (clique-a): 4 bundles x 4 GPUs")
+        pg1 = placement_group(
+            [{"GPU": 4, "clique_a": 0.001} for _ in range(4)],
+            strategy="STRICT_SPREAD",
+            name="pg-clique-a",
+        )
+        if not wait_for_pg(pg1, "PG1", timeout=300):
+            log("FAIL: PG1 timed out")
+            sys.exit(1)
+
+        log("Creating PG2 (clique-b): 4 bundles x 4 GPUs")
+        pg2 = placement_group(
+            [{"GPU": 4, "clique_b": 0.001} for _ in range(4)],
+            strategy="STRICT_SPREAD",
+            name="pg-clique-b",
+        )
+        if not wait_for_pg(pg2, "PG2", timeout=300):
+            log("FAIL: PG2 timed out")
+            sys.exit(1)
+
+        pg1_nodes = collect_pg_nodes(pg1, 4, "PG1 (clique-a)")
+        pg2_nodes = collect_pg_nodes(pg2, 4, "PG2 (clique-b)")
+
+        pg1_names = {n["node_name"] for n in pg1_nodes}
+        pg2_names = {n["node_name"] for n in pg2_nodes}
+        if pg1_names & pg2_names:
+            log(f"WARNING: PG1/PG2 share nodes: {pg1_names & pg2_names}")
+            results["phase1"] = "WARN"
+        else:
+            log("PASS: PG1 and PG2 on disjoint nodes")
+            results["phase1"] = "PASS"
+
+        # ── PHASE 2: Autoscale UP (clique-c: 0 -> 4) ──
+        log("\n" + "=" * 70)
+        log("PHASE 2: Autoscale UP (clique-c: 0 -> 4 workers)")
+        log("=" * 70)
+        log("clique-c has replicas=0/minReplicas=0 => NOT in PodGroup subgroups")
+
+        log("Creating PG3 (clique-c): 4 bundles x 4 GPUs")
+        pg3 = placement_group(
+            [{"GPU": 4, "clique_c": 0.001} for _ in range(4)],
+            strategy="STRICT_SPREAD",
+            name="pg-clique-c",
+        )
+
+        pg3_ready = wait_for_pg(pg3, "PG3", timeout=600)
+        pg3_nodes = None
+        if not pg3_ready:
+            log("FAIL: PG3 timed out")
+            log("Autoscaling with topology likely does not work for 0-replica groups")
+            results["phase2"] = "FAIL"
+        else:
+            pg3_nodes = collect_pg_nodes(pg3, 4, "PG3 (clique-c)")
+            pg3_names = {n["node_name"] for n in pg3_nodes}
+            if pg3_names & pg1_names or pg3_names & pg2_names:
+                log("WARNING: PG3 shares nodes with other PGs")
+                results["phase2"] = "WARN"
+            else:
+                log("PASS: Autoscale UP succeeded, PG3 on disjoint nodes")
+                results["phase2"] = "PASS"
+
+        # ── PHASE 3: Autoscale DOWN (remove PG1, clique-a: 4 -> 0) ──
+        log("\n" + "=" * 70)
+        log("PHASE 3: Autoscale DOWN (clique-a: 4 -> 0 after removing PG1)")
+        log("=" * 70)
+
+        remove_placement_group(pg1)
+        log("PG1 removed. Monitoring clique-a scale-down...")
+
+        initial_ca = ray.cluster_resources().get("clique_a", 0)
+        scaled_down = False
+        for i in range(10):
+            time.sleep(30)
+            elapsed = (i + 1) * 30
+            res = ray.cluster_resources()
+            ca = res.get("clique_a", 0)
+            log(f"[{elapsed}s] clique_a={ca}, GPU={res.get('GPU', 0)}")
+            if ca < initial_ca:
+                scaled_down = True
+            if ca == 0:
+                log(f"PASS: clique-a fully scaled down after {elapsed}s")
+                break
+
+        results["phase3"] = "PASS" if scaled_down else "FAIL"
+        if not scaled_down:
+            log("clique-a did not scale down within 5 minutes")
+
+        # ── SUMMARY ──
+        log("\n" + "=" * 70)
+        log("SUMMARY")
+        log("=" * 70)
+        for phase, result in sorted(results.items()):
+            log(f"  {phase}: {result}")
+        log(f"\nPG1 nodes: {json.dumps([n['node_name'] for n in pg1_nodes])}")
+        log(f"PG2 nodes: {json.dumps([n['node_name'] for n in pg2_nodes])}")
+        if pg3_nodes:
+            log(f"PG3 nodes: {json.dumps([n['node_name'] for n in pg3_nodes])}")
+
+        log("\nVerify topology externally:")
+        log(
+            "  kubectl get nodes -l nvidia.com/gpu.clique"
+            " -o custom-columns="
+            "\"NAME:.metadata.name,CLIQUE:.metadata.labels.nvidia\\\\.com/gpu\\\\.clique\""
+        )
+
+        # Cleanup
+        log("\nCleaning up...")
+        remove_placement_group(pg2)
+        if pg3_ready:
+            remove_placement_group(pg3)
+        log("Done")
+
+        if any(v == "FAIL" for v in results.values()):
+            sys.exit(1)
+
+
+    if __name__ == "__main__":
+        main()
+---
+apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: rl-414-autoscale-topology-test
+  labels:
+    kai.scheduler/queue: default-queue
+spec:
+  entrypoint: python /opt/driver/driver.py
+  shutdownAfterJobFinishes: true
+  ttlSecondsAfterFinished: 3600
+  rayClusterSpec:
+    rayVersion: '2.54.0'
+    enableInTreeAutoscaling: true
+    autoscalerOptions:
+      upscalingMode: Default
+      idleTimeoutSeconds: 60
+      resources:
+        requests:
+          cpu: "500m"
+          memory: "512Mi"
+        limits:
+          cpu: "1"
+          memory: "1Gi"
+    headGroupSpec:
+      rayStartParams:
+        dashboard-host: '0.0.0.0'
+        block: 'true'
+      template:
+        spec:
+          # Adjust nodeSelector if your cluster uses different labels for CPU nodes
+          nodeSelector:
+            nodeGroup: customer-cpu
+          schedulerName: kai-scheduler
+          containers:
+          - name: ray-head
+            image: rayproject/ray:2.54.0
+            resources:
+              requests:
+                cpu: "2"
+                memory: "4Gi"
+              limits:
+                cpu: "4"
+                memory: "8Gi"
+            env:
+            - name: RAY_memory_monitor_refresh_ms
+              value: "0"
+            volumeMounts:
+            - name: driver-script
+              mountPath: /opt/driver
+          volumes:
+          - name: driver-script
+            configMap:
+              name: rl-414-driver-script
+    workerGroupSpecs:
+    - groupName: clique-a
+      replicas: 4
+      minReplicas: 0
+      maxReplicas: 4
+      rayStartParams:
+        block: 'true'
+        num-gpus: "4"
+        resources: '{"clique_a": 1}'
+      template:
+        metadata:
+          annotations:
+            kai.scheduler/topology: gb300-topology
+            kai.scheduler/topology-required-placement: nvidia.com/gpu.clique
+        spec:
+          schedulerName: kai-scheduler
+          tolerations:
+          - operator: Exists
+          containers:
+          - name: ray-worker
+            image: rayproject/ray:2.54.0
+            resources:
+              requests:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+              limits:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: RAY_memory_monitor_refresh_ms
+              value: "0"
+    - groupName: clique-b
+      replicas: 4
+      minReplicas: 0
+      maxReplicas: 4
+      rayStartParams:
+        block: 'true'
+        num-gpus: "4"
+        resources: '{"clique_b": 1}'
+      template:
+        metadata:
+          annotations:
+            kai.scheduler/topology: gb300-topology
+            kai.scheduler/topology-required-placement: nvidia.com/gpu.clique
+        spec:
+          schedulerName: kai-scheduler
+          tolerations:
+          - operator: Exists
+          containers:
+          - name: ray-worker
+            image: rayproject/ray:2.54.0
+            resources:
+              requests:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+              limits:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: RAY_memory_monitor_refresh_ms
+              value: "0"
+    # This group is EXCLUDED from the PodGroup (replicas=0 AND minReplicas=0).
+    # Testing whether autoscaler-created pods still get topology constraints.
+    - groupName: clique-c
+      replicas: 0
+      minReplicas: 0
+      maxReplicas: 4
+      rayStartParams:
+        block: 'true'
+        num-gpus: "4"
+        resources: '{"clique_c": 1}'
+      template:
+        metadata:
+          annotations:
+            kai.scheduler/topology: gb300-topology
+            kai.scheduler/topology-required-placement: nvidia.com/gpu.clique
+        spec:
+          schedulerName: kai-scheduler
+          tolerations:
+          - operator: Exists
+          containers:
+          - name: ray-worker
+            image: rayproject/ray:2.54.0
+            resources:
+              requests:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+              limits:
+                nvidia.com/gpu: 4
+                cpu: "4"
+                memory: "16Gi"
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: RAY_memory_monitor_refresh_ms
+              value: "0"

--- a/k8s/rl-414-topology-autoscale-test.yaml
+++ b/k8s/rl-414-topology-autoscale-test.yaml
@@ -1,20 +1,18 @@
 # RL-414: Validate kai-scheduler + kuberay autoscaling with topology constraints
 #
-# Extended test: 2 initial cliques + 12 add-on cliques (6 full + 6 partial)
-#   initial-a, initial-b: replicas=4 (pre-existing workers)
-#   addon-1..6: replicas=0 (autoscale 0->4 with full 4-node PGs)
-#   addon-7..12: replicas=0 (autoscale 0->2->4 with half-clique 2-node PGs)
+# Segment test: 5 worker groups, each with 8 pods (4 GPUs per pod = 32 GPUs/group)
+# Total: 5 x 32 = 160 GPUs at peak (of 288 available)
 #
-# Test phases:
-#   1. Verify initial-a/b placement in separate topology cliques
-#   2a. Autoscale 6 full-clique groups (4-node PGs) - confirms topology is not a fluke
-#   2b. Autoscale 6 partial-clique groups (2-node PGs) - tests partial allocation
-#   3. Scale down: remove initial-a PG, verify workers drain
+# Groups:
+#   group-1 (8,0,8) — Steps 1 & 6 (create PG, then scale down)
+#   group-2 (8,0,8) — Step 2 (create PG)
+#   group-3 (0,0,8) — Step 3 (autoscale up)
+#   group-4 (0,0,8) — Step 4 (autoscale up)
+#   group-5 (0,0,8) — Step 5 (autoscale up)
 #
 # Usage:
 #   kubectl apply -f k8s/rl-414-topology-autoscale-test.yaml --context aws-cmh
 #   kubectl logs -f -l ray.io/node-type=head -c ray-head --context aws-cmh
-#   # Clean up (including RBAC):
 #   kubectl delete -f k8s/rl-414-topology-autoscale-test.yaml --context aws-cmh
 ---
 apiVersion: v1
@@ -28,7 +26,7 @@ metadata:
   name: rl-414-node-reader
 rules:
 - apiGroups: [""]
-  resources: ["nodes"]
+  resources: ["nodes", "pods"]
   verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -58,6 +56,7 @@ data:
     import ssl
     import sys
     import urllib.request
+    from collections import defaultdict
     from ray.util.placement_group import placement_group, remove_placement_group
 
 
@@ -65,25 +64,92 @@ data:
         print(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] {msg}", flush=True)
 
 
+    def k8s_api_get(path):
+        with open("/var/run/secrets/kubernetes.io/serviceaccount/token") as f:
+            token = f.read().strip()
+        ctx = ssl.create_default_context(
+            cafile="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+        )
+        req = urllib.request.Request(
+            f"https://kubernetes.default.svc{path}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        with urllib.request.urlopen(req, context=ctx) as resp:
+            return json.loads(resp.read())
+
+
     def get_node_clique(node_name):
         try:
-            with open("/var/run/secrets/kubernetes.io/serviceaccount/token") as f:
-                token = f.read().strip()
-            ctx = ssl.create_default_context(
-                cafile="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+            data = k8s_api_get(f"/api/v1/nodes/{node_name}")
+            return data["metadata"]["labels"].get(
+                "nvidia.com/gpu.clique", "unknown"
             )
-            req = urllib.request.Request(
-                f"https://kubernetes.default.svc/api/v1/nodes/{node_name}",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-            with urllib.request.urlopen(req, context=ctx) as resp:
-                data = json.loads(resp.read())
-                return data["metadata"]["labels"].get(
-                    "nvidia.com/gpu.clique", "unknown"
-                )
         except Exception as e:
             log(f"  WARNING: Could not query node {node_name}: {e}")
             return "error"
+
+
+    def get_worker_pods():
+        """Query k8s API for all worker pods in this RayCluster."""
+        try:
+            data = k8s_api_get(
+                "/api/v1/namespaces/default/pods"
+                "?labelSelector=ray.io/cluster=rl-414-autoscale-topology-test"
+                ",ray.io/node-type=worker"
+            )
+            pods = []
+            for item in data.get("items", []):
+                meta = item["metadata"]
+                spec = item["spec"]
+                status = item.get("status", {})
+                phase = status.get("phase", "Unknown")
+                if phase != "Running":
+                    continue
+                pod_name = meta["name"]
+                group = meta.get("labels", {}).get("ray.io/group", "unknown")
+                node_name = spec.get("nodeName", "unknown")
+                clique = get_node_clique(node_name) if node_name != "unknown" else "unknown"
+                pods.append({
+                    "pod": pod_name,
+                    "group": group,
+                    "node": node_name,
+                    "clique": clique,
+                })
+            return pods
+        except Exception as e:
+            log(f"WARNING: Could not list worker pods: {e}")
+            return []
+
+
+    def verify_groups(pods):
+        """Check per-group topology: all pods in each group should share a clique."""
+        groups = defaultdict(list)
+        for p in pods:
+            groups[p["group"]].append(p)
+
+        results = {}
+        clique_map = {}
+        for group_name in sorted(groups):
+            group_pods = groups[group_name]
+            cliques = {p["clique"] for p in group_pods if p["clique"] not in ("error", "unknown")}
+            nodes = sorted({p["node"] for p in group_pods})
+
+            if len(cliques) == 1:
+                clique_id = next(iter(cliques))
+                log(f"  PASS: {group_name} ({len(group_pods)} pods) -> clique {clique_id}")
+                log(f"         nodes: {nodes}")
+                results[group_name] = "PASS"
+                clique_map[group_name] = clique_id
+            elif len(cliques) == 0:
+                log(f"  WARN: {group_name} ({len(group_pods)} pods) -> could not determine clique")
+                results[group_name] = "WARN"
+            else:
+                log(f"  FAIL: {group_name} ({len(group_pods)} pods) -> spans cliques: {sorted(cliques)}")
+                log(f"         nodes: {nodes}")
+                for p in group_pods:
+                    log(f"           {p['node']} -> {p['clique']}")
+                results[group_name] = "FAIL"
+        return results, clique_map
 
 
     @ray.remote(num_cpus=0)
@@ -95,7 +161,8 @@ data:
         }
 
 
-    def collect_pg_nodes(pg, num_bundles, label):
+    def collect_pg_node_info(pg, num_bundles, label):
+        """Run a task on each PG bundle to identify nodes from Ray's perspective."""
         tasks = [
             get_node_info.options(
                 placement_group=pg,
@@ -104,25 +171,25 @@ data:
             ).remote()
             for i in range(num_bundles)
         ]
-        nodes = ray.get(tasks, timeout=120)
-        log(f"{label} nodes:")
-        for i, n in enumerate(nodes):
-            n["clique"] = get_node_clique(n["node_name"])
-            log(f"  bundle[{i}]: node={n['node_name']}, clique={n['clique']}")
+        nodes = ray.get(tasks, timeout=180)
+        unique_nodes = sorted({n["node_name"] for n in nodes})
+        log(f"  {label}: {len(unique_nodes)} unique nodes: {unique_nodes}")
         return nodes
 
 
-    def verify_same_clique(nodes, label):
-        cliques = {n["clique"] for n in nodes if n["clique"] not in ("error", "unknown")}
-        if len(cliques) == 1:
-            log(f"  PASS: {label} -> clique {next(iter(cliques))}")
-            return True
-        elif len(cliques) == 0:
-            log(f"  WARN: Could not determine clique for {label}")
-            return False
-        else:
-            log(f"  FAIL: {label} spans cliques: {cliques}")
-            return False
+    def wait_for_gpus(target, timeout=600):
+        """Wait until at least `target` GPUs are available in the cluster."""
+        start = time.time()
+        while time.time() - start < timeout:
+            total = ray.cluster_resources().get("GPU", 0)
+            if total >= target:
+                log(f"  {int(total)} GPUs available (target: {target})")
+                return True
+            elapsed = int(time.time() - start)
+            log(f"  Waiting for GPUs: {int(total)}/{target} ({elapsed}s)")
+            time.sleep(15)
+        log(f"  TIMEOUT waiting for {target} GPUs")
+        return False
 
 
     def wait_for_pg(pg, label, timeout=600):
@@ -130,197 +197,225 @@ data:
         while True:
             remaining = timeout - (time.time() - start)
             if remaining <= 0:
+                log(f"  TIMEOUT: {label} not ready after {timeout}s")
                 return False
             ready = pg.wait(timeout_seconds=min(30, remaining))
             if ready:
-                log(f"{label} ready ({int(time.time() - start)}s)")
+                log(f"  {label} ready ({int(time.time() - start)}s)")
                 return True
             elapsed = int(time.time() - start)
             res = ray.cluster_resources()
             avail = ray.available_resources()
             log(
-                f"{label} pending ({elapsed}s)"
-                f" | GPU={res.get('GPU', 0)} avail={avail.get('GPU', 0)}"
+                f"  {label} pending ({elapsed}s)"
+                f" | total_GPU={int(res.get('GPU', 0))}"
+                f" avail_GPU={int(avail.get('GPU', 0))}"
             )
 
 
-    def create_pg(name, resource_key, num_bundles):
-        bundles = [{"GPU": 4, resource_key: 0.001} for _ in range(num_bundles)]
-        return placement_group(bundles, strategy="STRICT_SPREAD", name=name)
+    def wait_for_pods(expected_groups, expected_per_group, timeout=600):
+        """Wait until k8s shows expected number of Running worker pods per group."""
+        start = time.time()
+        while time.time() - start < timeout:
+            pods = get_worker_pods()
+            groups = defaultdict(int)
+            for p in pods:
+                groups[p["group"]] += 1
+            ready = all(groups.get(g, 0) >= expected_per_group for g in expected_groups)
+            elapsed = int(time.time() - start)
+            status = ", ".join(f"{g}={groups.get(g, 0)}" for g in sorted(expected_groups))
+            if ready:
+                log(f"  All groups ready ({elapsed}s): {status}")
+                return True
+            log(f"  Waiting for pods ({elapsed}s): {status}")
+            time.sleep(15)
+        log(f"  TIMEOUT waiting for pods")
+        return False
 
 
     def main():
         ray.init()
         results = {}
-        all_pgs = {}
-        all_nodes = {}
 
         log("=" * 70)
-        log("RL-414: Topology-Aware Autoscaling Validation")
-        log("  2 initial + 6 full-clique + 6 partial-clique add-ons")
+        log("RL-414: Topology-Aware Autoscaling — Segment Test")
+        log("  5 groups x 8 pods x 4 GPUs = 160 GPUs at peak")
+        log("  group-1/2: replicas=8 (pre-provisioned)")
+        log("  group-3/4/5: replicas=0 (autoscale targets)")
         log("=" * 70)
-        log(f"Resources: {json.dumps(dict(ray.cluster_resources()), indent=2)}")
 
-        # Phase 1: Initial topology placement
+        initial_res = dict(ray.cluster_resources())
+        log(f"Initial cluster resources: GPU={int(initial_res.get('GPU', 0))}")
+
+        # ── STEP 1: Create PG on group-1 capacity ──
         log("\n" + "=" * 70)
-        log("PHASE 1: Initial placement (2 x 4-node PGs)")
+        log("STEP 1: Verify initial groups & create PG-1 (32 GPUs)")
         log("=" * 70)
 
-        for name, res_key in [("initial-a", "initial_a"), ("initial-b", "initial_b")]:
-            pg = create_pg(f"pg-{name}", res_key, 4)
-            all_pgs[name] = pg
+        log("Waiting for initial workers (64 GPUs from group-1 + group-2)...")
+        if not wait_for_gpus(64, timeout=600):
+            log("FATAL: Initial workers did not come up")
+            sys.exit(1)
 
-        for name in ["initial-a", "initial-b"]:
-            pg = all_pgs[name]
-            if not wait_for_pg(pg, name, timeout=300):
-                log(f"FAIL: {name} timed out")
-                sys.exit(1)
-            nodes = collect_pg_nodes(pg, 4, name)
-            all_nodes[name] = nodes
-            results[f"p1_{name}"] = "PASS" if verify_same_clique(nodes, name) else "FAIL"
+        log("Checking initial per-group topology via k8s API...")
+        pods = get_worker_pods()
+        init_results, init_cliques = verify_groups(pods)
+        for g, r in init_results.items():
+            results[f"step1_{g}"] = r
 
-        a_set = {n["node_name"] for n in all_nodes["initial-a"]}
-        b_set = {n["node_name"] for n in all_nodes["initial-b"]}
-        if a_set & b_set:
-            log(f"WARNING: initial-a/b share nodes: {a_set & b_set}")
-            results["p1_disjoint"] = "WARN"
+        log("Creating PG-1 (8 bundles x 4 GPUs = 32 GPUs)...")
+        pg1 = placement_group(
+            [{"GPU": 4}] * 8, strategy="STRICT_SPREAD", name="pg-step1"
+        )
+        if not wait_for_pg(pg1, "PG-1", timeout=300):
+            log("FATAL: PG-1 timed out")
+            sys.exit(1)
+        pg1_nodes = collect_pg_node_info(pg1, 8, "PG-1")
+
+        # ── STEP 2: Create PG on group-2 capacity ──
+        log("\n" + "=" * 70)
+        log("STEP 2: Create PG-2 (32 GPUs)")
+        log("=" * 70)
+
+        pg2 = placement_group(
+            [{"GPU": 4}] * 8, strategy="STRICT_SPREAD", name="pg-step2"
+        )
+        if not wait_for_pg(pg2, "PG-2", timeout=300):
+            log("FATAL: PG-2 timed out")
+            sys.exit(1)
+        pg2_nodes = collect_pg_node_info(pg2, 8, "PG-2")
+
+        log("All 64 initial GPUs now claimed by PG-1 + PG-2")
+
+        # ── STEP 3: Autoscale group-3 ──
+        log("\n" + "=" * 70)
+        log("STEP 3: Create PG-3 (32 GPUs) — should trigger autoscale")
+        log("=" * 70)
+
+        pg3 = placement_group(
+            [{"GPU": 4}] * 8, strategy="STRICT_SPREAD", name="pg-step3"
+        )
+        if not wait_for_pg(pg3, "PG-3", timeout=600):
+            log("FAIL: PG-3 timed out — autoscaling may not work")
+            results["step3_autoscale"] = "FAIL"
         else:
-            log("PASS: initial-a and initial-b on disjoint nodes")
-            results["p1_disjoint"] = "PASS"
+            results["step3_autoscale"] = "PASS"
+            pg3_nodes = collect_pg_node_info(pg3, 8, "PG-3")
 
-        # Phase 2a: Full-clique autoscaling (6 x 4-node PGs)
+        # ── STEP 4: Autoscale group-4 ──
         log("\n" + "=" * 70)
-        log("PHASE 2a: Full-clique autoscale (6 PGs x 4 nodes)")
-        log("Verifies topology placement is not a fluke")
+        log("STEP 4: Create PG-4 (32 GPUs) — should trigger autoscale")
         log("=" * 70)
 
-        for i in range(1, 7):
-            name = f"addon-{i}"
-            all_pgs[name] = create_pg(f"pg-{name}", f"addon_{i}", 4)
+        pg4 = placement_group(
+            [{"GPU": 4}] * 8, strategy="STRICT_SPREAD", name="pg-step4"
+        )
+        if not wait_for_pg(pg4, "PG-4", timeout=600):
+            log("FAIL: PG-4 timed out — autoscaling may not work")
+            results["step4_autoscale"] = "FAIL"
+        else:
+            results["step4_autoscale"] = "PASS"
+            pg4_nodes = collect_pg_node_info(pg4, 8, "PG-4")
 
-        for i in range(1, 7):
-            name = f"addon-{i}"
-            if not wait_for_pg(all_pgs[name], name, timeout=600):
-                log(f"FAIL: {name} timed out")
-                results[f"p2a_{name}"] = "FAIL"
-                continue
-            nodes = collect_pg_nodes(all_pgs[name], 4, name)
-            all_nodes[name] = nodes
-            results[f"p2a_{name}"] = (
-                "PASS" if verify_same_clique(nodes, name) else "FAIL"
-            )
-
-        # Phase 2b: Partial-clique autoscaling (12 x 2-node PGs)
+        # ── STEP 5: Autoscale group-5 ──
         log("\n" + "=" * 70)
-        log("PHASE 2b: Partial-clique autoscale (12 PGs x 2 nodes)")
-        log("Tests whether 2/4 nodes still get same-clique placement")
+        log("STEP 5: Create PG-5 (32 GPUs) — should trigger autoscale")
         log("=" * 70)
 
-        # Batch 1: triggers scale 0->2 for addon-7 through addon-12
-        log("Batch 1: 6 PGs x 2 nodes (scale 0->2)...")
-        for i in range(7, 13):
-            name = f"addon-{i}-a"
-            all_pgs[name] = create_pg(f"pg-{name}", f"addon_{i}", 2)
+        pg5 = placement_group(
+            [{"GPU": 4}] * 8, strategy="STRICT_SPREAD", name="pg-step5"
+        )
+        if not wait_for_pg(pg5, "PG-5", timeout=600):
+            log("FAIL: PG-5 timed out — autoscaling may not work")
+            results["step5_autoscale"] = "FAIL"
+        else:
+            results["step5_autoscale"] = "PASS"
+            pg5_nodes = collect_pg_node_info(pg5, 8, "PG-5")
 
-        for i in range(7, 13):
-            name = f"addon-{i}-a"
-            if not wait_for_pg(all_pgs[name], name, timeout=600):
-                log(f"FAIL: {name} timed out")
-                results[f"p2b_{name}"] = "FAIL"
-                continue
-            nodes = collect_pg_nodes(all_pgs[name], 2, name)
-            all_nodes[name] = nodes
-            results[f"p2b_{name}"] = (
-                "PASS" if verify_same_clique(nodes, name) else "FAIL"
-            )
-
-        # Batch 2: triggers scale 2->4 for addon-7 through addon-12
-        log("Batch 2: 6 PGs x 2 nodes (scale 2->4)...")
-        for i in range(7, 13):
-            name = f"addon-{i}-b"
-            all_pgs[name] = create_pg(f"pg-{name}", f"addon_{i}", 2)
-
-        for i in range(7, 13):
-            name = f"addon-{i}-b"
-            if not wait_for_pg(all_pgs[name], name, timeout=600):
-                log(f"FAIL: {name} timed out")
-                results[f"p2b_{name}"] = "FAIL"
-                continue
-            nodes = collect_pg_nodes(all_pgs[name], 2, name)
-            all_nodes[name] = nodes
-            results[f"p2b_{name}"] = (
-                "PASS" if verify_same_clique(nodes, name) else "FAIL"
-            )
-
-        # Cross-check: both halves in same clique
-        for i in range(7, 13):
-            a_key = f"addon-{i}-a"
-            b_key = f"addon-{i}-b"
-            if a_key in all_nodes and b_key in all_nodes:
-                combined = all_nodes[a_key] + all_nodes[b_key]
-                label = f"addon-{i} combined"
-                results[f"p2b_addon{i}_combined"] = (
-                    "PASS" if verify_same_clique(combined, label) else "FAIL"
-                )
-
-        # Phase 3: Scale down
+        # ── Verify all groups after autoscaling ──
         log("\n" + "=" * 70)
-        log("PHASE 3: Scale DOWN (remove pg-initial-a)")
+        log("POST-AUTOSCALE: Verify per-group topology for all 5 groups")
         log("=" * 70)
 
-        remove_placement_group(all_pgs["initial-a"])
-        del all_pgs["initial-a"]
-        log("pg-initial-a removed. Monitoring scale-down...")
+        time.sleep(10)
+        pods = get_worker_pods()
+        all_results, all_cliques = verify_groups(pods)
+        for g, r in all_results.items():
+            results[f"topology_{g}"] = r
 
-        init_val = ray.cluster_resources().get("initial_a", 0)
+        # Check that we used multiple cliques (proves it's not a fluke)
+        unique_cliques = set(all_cliques.values())
+        if len(unique_cliques) >= 2:
+            log(f"  PASS: Groups span {len(unique_cliques)} distinct cliques: {sorted(unique_cliques)}")
+            results["multi_clique"] = "PASS"
+        else:
+            clique_str = sorted(unique_cliques) if unique_cliques else "none"
+            log(f"  NOTE: All groups in {len(unique_cliques)} clique(s): {clique_str}")
+            log(f"    (With 40 nodes across 4 cliques of 18, we expect 3+ cliques)")
+            results["multi_clique"] = "NOTE"
+
+        # ── STEP 6: Scale down group-1 ──
+        log("\n" + "=" * 70)
+        log("STEP 6: Remove PG-1 — monitor group-1 scale-down")
+        log("=" * 70)
+
+        remove_placement_group(pg1)
+        log("PG-1 removed. Monitoring scale-down (idleTimeout=60s)...")
+
         scaled_down = False
-        for tick in range(10):
-            time.sleep(30)
-            elapsed = (tick + 1) * 30
-            res = ray.cluster_resources()
-            cur = res.get("initial_a", 0)
-            log(f"[{elapsed}s] initial_a={cur}, GPU={res.get('GPU', 0)}")
-            if cur < init_val:
+        initial_group1_count = sum(1 for p in pods if p["group"] == "group-1")
+        for tick in range(15):
+            time.sleep(20)
+            elapsed = (tick + 1) * 20
+            current_pods = get_worker_pods()
+            group1_count = sum(1 for p in current_pods if p["group"] == "group-1")
+            total_gpus = int(ray.cluster_resources().get("GPU", 0))
+            log(f"  [{elapsed}s] group-1 pods: {group1_count}/{initial_group1_count}, total_GPU={total_gpus}")
+            if group1_count < initial_group1_count:
                 scaled_down = True
-            if cur == 0:
-                log(f"PASS: initial-a scaled down after {elapsed}s")
+            if group1_count == 0:
+                log(f"  PASS: group-1 fully scaled down after {elapsed}s")
                 break
 
-        results["p3_scale_down"] = "PASS" if scaled_down else "FAIL"
-        if not scaled_down:
-            log("initial-a did not scale down within 5 min")
+        if scaled_down:
+            results["step6_scale_down"] = "PASS"
+        else:
+            log("  FAIL: group-1 did not scale down within 5 min")
+            results["step6_scale_down"] = "FAIL"
 
-        # Summary
+        # ── SUMMARY ──
         log("\n" + "=" * 70)
         log("SUMMARY")
         log("=" * 70)
 
         passes = sum(1 for v in results.values() if v == "PASS")
         fails = sum(1 for v in results.values() if v == "FAIL")
-        warns = sum(1 for v in results.values() if v == "WARN")
+        warns = sum(1 for v in results.values() if v in ("WARN", "NOTE"))
 
         for key in sorted(results):
             log(f"  {key}: {results[key]}")
-        log(f"\nTotal: {passes} PASS, {fails} FAIL, {warns} WARN")
+        log(f"\nTotal: {passes} PASS, {fails} FAIL, {warns} WARN/NOTE")
 
-        log("\nClique mapping:")
-        clique_map = {}
-        for pg_name, nodes in all_nodes.items():
-            for n in nodes:
-                c = n.get("clique", "?")
-                clique_map.setdefault(c, set()).add(pg_name)
-        for c in sorted(clique_map):
-            log(f"  {c}: {sorted(clique_map[c])}")
+        log("\nClique assignment:")
+        for group_name in sorted(all_cliques):
+            log(f"  {group_name} -> {all_cliques[group_name]}")
 
+        log("\nNode detail:")
+        pods = get_worker_pods()
+        for p in sorted(pods, key=lambda x: (x["group"], x["node"])):
+            log(f"  {p['group']:12s} | {p['node']:40s} | clique={p['clique']}")
+
+        # Clean up remaining PGs
         log("\nCleaning up placement groups...")
-        for name, pg in list(all_pgs.items()):
+        for name, pg in [("pg-step2", pg2), ("pg-step3", pg3), ("pg-step4", pg4), ("pg-step5", pg5)]:
             try:
                 remove_placement_group(pg)
+                log(f"  Removed {name}")
             except Exception:
                 pass
 
-        log("Done.")
-        log("Clean up: kubectl delete -f k8s/rl-414-topology-autoscale-test.yaml")
+        log("\nDone. Clean up k8s resources:")
+        log("  kubectl delete -f k8s/rl-414-topology-autoscale-test.yaml --context aws-cmh")
 
         if fails > 0:
             sys.exit(1)
@@ -337,6 +432,7 @@ metadata:
     kai.scheduler/queue: default-queue
 spec:
   entrypoint: python /opt/driver/driver.py
+  submissionMode: HTTPMode
   shutdownAfterJobFinishes: true
   ttlSecondsAfterFinished: 3600
   rayClusterSpec:
@@ -383,15 +479,14 @@ spec:
             configMap:
               name: rl-414-driver-script
     workerGroupSpecs:
-    # ── Initial cliques (replicas=4, pre-existing workers) ──
-    - groupName: initial-a
-      replicas: 4
+    # ── group-1 (8,0,8) — pre-provisioned, Step 1 PG + Step 6 scale-down ──
+    - groupName: group-1
+      replicas: 8
       minReplicas: 0
-      maxReplicas: 4
+      maxReplicas: 8
       rayStartParams:
         block: 'true'
         num-gpus: "4"
-        resources: '{"initial_a": 1}'
       template:
         metadata:
           annotations:
@@ -420,14 +515,14 @@ spec:
                   fieldPath: spec.nodeName
             - name: RAY_memory_monitor_refresh_ms
               value: "0"
-    - groupName: initial-b
-      replicas: 4
+    # ── group-2 (8,0,8) — pre-provisioned, Step 2 PG ──
+    - groupName: group-2
+      replicas: 8
       minReplicas: 0
-      maxReplicas: 4
+      maxReplicas: 8
       rayStartParams:
         block: 'true'
         num-gpus: "4"
-        resources: '{"initial_b": 1}'
       template:
         metadata:
           annotations:
@@ -456,15 +551,14 @@ spec:
                   fieldPath: spec.nodeName
             - name: RAY_memory_monitor_refresh_ms
               value: "0"
-    # ── Full-clique add-ons (replicas=0, autoscale 0->4) ──
-    - groupName: addon-1
+    # ── group-3 (0,0,8) — autoscale target, Step 3 ──
+    - groupName: group-3
       replicas: 0
       minReplicas: 0
-      maxReplicas: 4
+      maxReplicas: 8
       rayStartParams:
         block: 'true'
         num-gpus: "4"
-        resources: '{"addon_1": 1}'
       template:
         metadata:
           annotations:
@@ -493,14 +587,14 @@ spec:
                   fieldPath: spec.nodeName
             - name: RAY_memory_monitor_refresh_ms
               value: "0"
-    - groupName: addon-2
+    # ── group-4 (0,0,8) — autoscale target, Step 4 ──
+    - groupName: group-4
       replicas: 0
       minReplicas: 0
-      maxReplicas: 4
+      maxReplicas: 8
       rayStartParams:
         block: 'true'
         num-gpus: "4"
-        resources: '{"addon_2": 1}'
       template:
         metadata:
           annotations:
@@ -529,339 +623,14 @@ spec:
                   fieldPath: spec.nodeName
             - name: RAY_memory_monitor_refresh_ms
               value: "0"
-    - groupName: addon-3
+    # ── group-5 (0,0,8) — autoscale target, Step 5 ──
+    - groupName: group-5
       replicas: 0
       minReplicas: 0
-      maxReplicas: 4
+      maxReplicas: 8
       rayStartParams:
         block: 'true'
         num-gpus: "4"
-        resources: '{"addon_3": 1}'
-      template:
-        metadata:
-          annotations:
-            kai.scheduler/topology: gb300-topology
-            kai.scheduler/topology-required-placement: nvidia.com/gpu.clique
-        spec:
-          schedulerName: kai-scheduler
-          tolerations:
-          - operator: Exists
-          containers:
-          - name: ray-worker
-            image: rayproject/ray:2.54.0
-            resources:
-              requests:
-                nvidia.com/gpu: 4
-                cpu: "4"
-                memory: "16Gi"
-              limits:
-                nvidia.com/gpu: 4
-                cpu: "4"
-                memory: "16Gi"
-            env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: RAY_memory_monitor_refresh_ms
-              value: "0"
-    - groupName: addon-4
-      replicas: 0
-      minReplicas: 0
-      maxReplicas: 4
-      rayStartParams:
-        block: 'true'
-        num-gpus: "4"
-        resources: '{"addon_4": 1}'
-      template:
-        metadata:
-          annotations:
-            kai.scheduler/topology: gb300-topology
-            kai.scheduler/topology-required-placement: nvidia.com/gpu.clique
-        spec:
-          schedulerName: kai-scheduler
-          tolerations:
-          - operator: Exists
-          containers:
-          - name: ray-worker
-            image: rayproject/ray:2.54.0
-            resources:
-              requests:
-                nvidia.com/gpu: 4
-                cpu: "4"
-                memory: "16Gi"
-              limits:
-                nvidia.com/gpu: 4
-                cpu: "4"
-                memory: "16Gi"
-            env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: RAY_memory_monitor_refresh_ms
-              value: "0"
-    - groupName: addon-5
-      replicas: 0
-      minReplicas: 0
-      maxReplicas: 4
-      rayStartParams:
-        block: 'true'
-        num-gpus: "4"
-        resources: '{"addon_5": 1}'
-      template:
-        metadata:
-          annotations:
-            kai.scheduler/topology: gb300-topology
-            kai.scheduler/topology-required-placement: nvidia.com/gpu.clique
-        spec:
-          schedulerName: kai-scheduler
-          tolerations:
-          - operator: Exists
-          containers:
-          - name: ray-worker
-            image: rayproject/ray:2.54.0
-            resources:
-              requests:
-                nvidia.com/gpu: 4
-                cpu: "4"
-                memory: "16Gi"
-              limits:
-                nvidia.com/gpu: 4
-                cpu: "4"
-                memory: "16Gi"
-            env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: RAY_memory_monitor_refresh_ms
-              value: "0"
-    - groupName: addon-6
-      replicas: 0
-      minReplicas: 0
-      maxReplicas: 4
-      rayStartParams:
-        block: 'true'
-        num-gpus: "4"
-        resources: '{"addon_6": 1}'
-      template:
-        metadata:
-          annotations:
-            kai.scheduler/topology: gb300-topology
-            kai.scheduler/topology-required-placement: nvidia.com/gpu.clique
-        spec:
-          schedulerName: kai-scheduler
-          tolerations:
-          - operator: Exists
-          containers:
-          - name: ray-worker
-            image: rayproject/ray:2.54.0
-            resources:
-              requests:
-                nvidia.com/gpu: 4
-                cpu: "4"
-                memory: "16Gi"
-              limits:
-                nvidia.com/gpu: 4
-                cpu: "4"
-                memory: "16Gi"
-            env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: RAY_memory_monitor_refresh_ms
-              value: "0"
-    # ── Partial-clique add-ons (replicas=0, autoscale 0->2->4) ──
-    - groupName: addon-7
-      replicas: 0
-      minReplicas: 0
-      maxReplicas: 4
-      rayStartParams:
-        block: 'true'
-        num-gpus: "4"
-        resources: '{"addon_7": 1}'
-      template:
-        metadata:
-          annotations:
-            kai.scheduler/topology: gb300-topology
-            kai.scheduler/topology-required-placement: nvidia.com/gpu.clique
-        spec:
-          schedulerName: kai-scheduler
-          tolerations:
-          - operator: Exists
-          containers:
-          - name: ray-worker
-            image: rayproject/ray:2.54.0
-            resources:
-              requests:
-                nvidia.com/gpu: 4
-                cpu: "4"
-                memory: "16Gi"
-              limits:
-                nvidia.com/gpu: 4
-                cpu: "4"
-                memory: "16Gi"
-            env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: RAY_memory_monitor_refresh_ms
-              value: "0"
-    - groupName: addon-8
-      replicas: 0
-      minReplicas: 0
-      maxReplicas: 4
-      rayStartParams:
-        block: 'true'
-        num-gpus: "4"
-        resources: '{"addon_8": 1}'
-      template:
-        metadata:
-          annotations:
-            kai.scheduler/topology: gb300-topology
-            kai.scheduler/topology-required-placement: nvidia.com/gpu.clique
-        spec:
-          schedulerName: kai-scheduler
-          tolerations:
-          - operator: Exists
-          containers:
-          - name: ray-worker
-            image: rayproject/ray:2.54.0
-            resources:
-              requests:
-                nvidia.com/gpu: 4
-                cpu: "4"
-                memory: "16Gi"
-              limits:
-                nvidia.com/gpu: 4
-                cpu: "4"
-                memory: "16Gi"
-            env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: RAY_memory_monitor_refresh_ms
-              value: "0"
-    - groupName: addon-9
-      replicas: 0
-      minReplicas: 0
-      maxReplicas: 4
-      rayStartParams:
-        block: 'true'
-        num-gpus: "4"
-        resources: '{"addon_9": 1}'
-      template:
-        metadata:
-          annotations:
-            kai.scheduler/topology: gb300-topology
-            kai.scheduler/topology-required-placement: nvidia.com/gpu.clique
-        spec:
-          schedulerName: kai-scheduler
-          tolerations:
-          - operator: Exists
-          containers:
-          - name: ray-worker
-            image: rayproject/ray:2.54.0
-            resources:
-              requests:
-                nvidia.com/gpu: 4
-                cpu: "4"
-                memory: "16Gi"
-              limits:
-                nvidia.com/gpu: 4
-                cpu: "4"
-                memory: "16Gi"
-            env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: RAY_memory_monitor_refresh_ms
-              value: "0"
-    - groupName: addon-10
-      replicas: 0
-      minReplicas: 0
-      maxReplicas: 4
-      rayStartParams:
-        block: 'true'
-        num-gpus: "4"
-        resources: '{"addon_10": 1}'
-      template:
-        metadata:
-          annotations:
-            kai.scheduler/topology: gb300-topology
-            kai.scheduler/topology-required-placement: nvidia.com/gpu.clique
-        spec:
-          schedulerName: kai-scheduler
-          tolerations:
-          - operator: Exists
-          containers:
-          - name: ray-worker
-            image: rayproject/ray:2.54.0
-            resources:
-              requests:
-                nvidia.com/gpu: 4
-                cpu: "4"
-                memory: "16Gi"
-              limits:
-                nvidia.com/gpu: 4
-                cpu: "4"
-                memory: "16Gi"
-            env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: RAY_memory_monitor_refresh_ms
-              value: "0"
-    - groupName: addon-11
-      replicas: 0
-      minReplicas: 0
-      maxReplicas: 4
-      rayStartParams:
-        block: 'true'
-        num-gpus: "4"
-        resources: '{"addon_11": 1}'
-      template:
-        metadata:
-          annotations:
-            kai.scheduler/topology: gb300-topology
-            kai.scheduler/topology-required-placement: nvidia.com/gpu.clique
-        spec:
-          schedulerName: kai-scheduler
-          tolerations:
-          - operator: Exists
-          containers:
-          - name: ray-worker
-            image: rayproject/ray:2.54.0
-            resources:
-              requests:
-                nvidia.com/gpu: 4
-                cpu: "4"
-                memory: "16Gi"
-              limits:
-                nvidia.com/gpu: 4
-                cpu: "4"
-                memory: "16Gi"
-            env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: RAY_memory_monitor_refresh_ms
-              value: "0"
-    - groupName: addon-12
-      replicas: 0
-      minReplicas: 0
-      maxReplicas: 4
-      rayStartParams:
-        block: 'true'
-        num-gpus: "4"
-        resources: '{"addon_12": 1}'
       template:
         metadata:
           annotations:


### PR DESCRIPTION
## Summary

RayJob manifest + driver script to validate kai-scheduler + kuberay topology-aware autoscaling across multiple NVL72 cliques on the aws-cmh cluster.

### Segment Test Design: 5 Worker Groups

| Group | replicas | min | max | Purpose |
|-------|----------|-----|-----|---------|
| group-1 | 8 | 0 | 8 | Pre-provisioned. Step 1 PG + Step 6 scale-down |
| group-2 | 8 | 0 | 8 | Pre-provisioned. Step 2 PG |
| group-3 | 0 | 0 | 8 | Autoscale target (Step 3) |
| group-4 | 0 | 0 | 8 | Autoscale target (Step 4) |
| group-5 | 0 | 0 | 8 | Autoscale target (Step 5) |

**Total GPU usage at peak**: 5 groups x 8 pods x 4 GPUs = 160 GPUs (of 288 available, 40 of 72 nodes)

With 40 nodes spread across 4 cliques of 18, we expect 3+ cliques to be used — proving topology placement is not a fluke.

### Test Steps

| Step | Action | Expected |
|------|--------|----------|
| 1 | Create PG-1 (32 GPUs), verify group-1/2 topology | Both groups in same clique per-group |
| 2 | Create PG-2 (32 GPUs) — claims all initial capacity | All 64 initial GPUs consumed |
| 3 | Create PG-3 (32 GPUs) — triggers autoscale | group-3 scales 0→8, topology verified |
| 4 | Create PG-4 (32 GPUs) — triggers autoscale | group-4 scales 0→8, topology verified |
| 5 | Create PG-5 (32 GPUs) — triggers autoscale | group-5 scales 0→8, topology verified |
| 6 | Remove PG-1 — monitor scale-down | group-1 drains to 0 after idle timeout |

### Key features

- **Per-group topology verification via k8s API**: RBAC enables driver to query pod labels (`ray.io/group`) and node labels (`nvidia.com/gpu.clique`) to verify all nodes in each worker group share the same clique
- **Multi-clique validation**: With 40 nodes, groups must span multiple cliques — confirms topology constraint is enforced, not just coincidental
- **No custom resources**: Avoids kuberay shell quoting bug with `rayStartParams.resources`
- **Hermetic**: Single YAML with ConfigMap-embedded driver; `kubectl delete -f` cleans up everything including RBAC

### Usage

```bash
kubectl apply -f k8s/rl-414-topology-autoscale-test.yaml --context aws-cmh
kubectl logs -f -l ray.io/node-type=head -c ray-head --context aws-cmh
# Clean up:
kubectl delete -f k8s/rl-414-topology-autoscale-test.yaml --context aws-cmh
```

Linear: RL-414