### PR TITLE
Add optional Trackio logging backend

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,0 +1,216 @@
+# syntax=docker/dockerfile:1
+# Usage:
+#   Self-contained build (default: builds from main):
+#     docker buildx build -f docker/Dockerfile --tag <registry>/nemo-rl:latest --push .
+#
+#   Self-contained build (specific git ref):
+#     docker buildx build -f docker/Dockerfile --build-arg NRL_GIT_REF=r0.3.0 --tag <registry>/nemo-rl:r0.3.0 --push .
+#
+#   Self-contained build (remote NeMo RL source; no need for a local clone of NeMo RL):
+#     docker buildx build -f docker/Dockerfile --build-arg NRL_GIT_REF=r0.3.0 --tag <registry>/nemo-rl:r0.3.0 --push https://github.com/NVIDIA-NeMo/RL.git
+#
+#   Local NeMo RL source override:
+#     docker buildx build --build-context nemo-rl=. -f docker/Dockerfile --tag <registry>/nemo-rl:latest --push .
+#
+# Optional build args to skip vLLM or SGLang dependencies:
+#   --build-arg SKIP_VLLM_BUILD=1    # Skip vLLM dependencies
+#   --build-arg SKIP_SGLANG_BUILD=1  # Skip SGLang dependencies
+
+ARG BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.05-cuda12.9-devel-ubuntu24.04
+FROM scratch AS nemo-rl
+ARG NRL_GIT_REF=main
+ADD --keep-git-dir=true https://github.com/NVIDIA-NeMo/RL.git#${NRL_GIT_REF} /
+
+FROM ${BASE_IMAGE} AS base
+# An environment variable to indicate that we are in a container.
+ENV NRL_CONTAINER=1
+
+# It is more convenient for users to run as root
+USER root
+
+RUN <<"EOF" bash -exu -o pipefail
+export DEBIAN_FRONTEND=noninteractive
+export TZ=America/Los_Angeles
+
+apt-get update
+apt-get install -y --no-install-recommends \
+    jq \
+    curl \
+    git \
+    rsync \
+    wget \
+    less \
+    vim \
+
+# Nsight
+apt install -y --no-install-recommends gnupg
+echo "deb http://developer.download.nvidia.com/devtools/repos/ubuntu$(source /etc/lsb-release; echo "$DISTRIB_RELEASE" | tr -d .)/$(dpkg --print-architecture) /" | tee /etc/apt/sources.list.d/nvidia-devtools.list
+apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/$(uname -m | sed 's/aarch64/sbsa/')/7fa2af80.pub
+apt update
+apt install -y nsight-systems-cli
+
+# To fix CVE-2025-68973
+apt install -y --only-upgrade gnupg
+
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+EOF
+
+# CMake (for sglang build)
+RUN GITHUB_ARTIFACTORY=github.com \
+    && CMAKE_VERSION=3.31.1 \
+    && ARCH=$(uname -m) \
+    && CMAKE_INSTALLER="cmake-${CMAKE_VERSION}-linux-${ARCH}" \
+    && curl --retry 3 --retry-delay 2 -fsSL -o "${CMAKE_INSTALLER}.tar.gz" \
+        "https://${GITHUB_ARTIFACTORY}/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_INSTALLER}.tar.gz" \
+    && tar -xzf "${CMAKE_INSTALLER}.tar.gz" \
+    && cp -r "${CMAKE_INSTALLER}/bin/"* /usr/local/bin/ \
+    && cp -r "${CMAKE_INSTALLER}/share/"* /usr/local/share/ \
+    && rm -rf "${CMAKE_INSTALLER}" "${CMAKE_INSTALLER}.tar.gz"
+
+# Install uv and python
+ARG UV_VERSION=0.11.3
+ARG PYTHON_VERSION=3.13.11
+ENV PATH="/root/.local/bin:$PATH"
+RUN curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh && \
+    uv python install ${PYTHON_VERSION}
+
+# Disable usage stats by default for users who are sensitive to sharing usage.
+# Users are encouraged to enable if the wish.
+ENV RAY_USAGE_STATS_ENABLED=0
+# After ray>=2.47, this feature is enabled by default which creates uv venvs for any py_executable starting with `uv run`.
+# There is severe contention and performance issues with this enabled considering our dependencies are so large and occasionally
+# need to be compiled, so NeMo RL has an implementation in nemo_rl/utils/venv.py that does it once per node as opposed to once per task.
+ENV RAY_ENABLE_UV_RUN_RUNTIME_ENV=0
+ENV NEMO_RL_VENV_DIR=/opt/ray_venvs
+
+
+FROM base AS hermetic
+
+WORKDIR /opt/nemo-rl
+
+# Variables to control the build of TE. If there are issues with parallelization, consider
+# setting these to 1.
+ARG MAX_JOBS
+ARG NVTE_BUILD_THREADS_PER_JOB
+# Only use for custom vllm installs. Learn more at https://github.com/NVIDIA-NeMo/RL/blob/main/docs/guides/use-custom-vllm.md
+ARG BUILD_CUSTOM_VLLM
+ARG BUILD_CUSTOM_VLLM_URL
+ARG BUILD_CUSTOM_VLLM_REF
+ARG BUILD_CUSTOM_VLLM_PRECOMPILED_WHEEL_LOCATION
+# Only use for custom flashinfer installs.
+ARG BUILD_CUSTOM_FLASHINFER
+ARG BUILD_CUSTOM_FLASHINFER_URL
+ARG BUILD_CUSTOM_FLASHINFER_REF
+# Skip building vLLM or SGLang dependencies (set to any non-empty value to skip)
+ARG SKIP_VLLM_BUILD
+ARG SKIP_SGLANG_BUILD
+
+ENV UV_PROJECT_ENVIRONMENT=/opt/nemo_rl_venv
+ENV UV_LINK_MODE=copy
+
+# Ensure DeepEP is built for H100 and B200 (also mcore inference unified memory API now invokes a torch API that requires these to be set)
+ENV TORCH_CUDA_ARCH_LIST="9.0 10.0"
+
+# First copy only the dependency files
+COPY --from=nemo-rl pyproject.toml uv.lock ./
+# Copy in the top level __init__.py/package_info.py since build-custom-vllm.sh needs the nemo_rl package to exist.
+COPY --from=nemo-rl nemo_rl/__init__.py nemo_rl/package_info.py ./nemo_rl/
+COPY --from=nemo-rl tools/build-custom-vllm.sh ./tools/build-custom-vllm.sh
+COPY --from=nemo-rl tools/build-custom-flashinfer.sh ./tools/build-custom-flashinfer.sh
+COPY --from=nemo-rl --link research/ ./research/
+COPY --from=nemo-rl --link 3rdparty/ ./3rdparty/
+
+RUN --mount=type=ssh <<"EOF" bash -exu
+uv venv --seed
+if [[ -n "${BUILD_CUSTOM_VLLM:-}" ]]; then
+    bash tools/build-custom-vllm.sh ${BUILD_CUSTOM_VLLM_URL} ${BUILD_CUSTOM_VLLM_REF} ${BUILD_CUSTOM_VLLM_PRECOMPILED_WHEEL_LOCATION}
+    source 3rdparty/vllm/nemo-rl.env
+fi
+if [[ -n "${BUILD_CUSTOM_FLASHINFER:-}" ]]; then
+    bash tools/build-custom-flashinfer.sh ${BUILD_CUSTOM_FLASHINFER_URL} ${BUILD_CUSTOM_FLASHINFER_REF}
+fi
+# uv sync has a more reliable resolver than simple uv pip install which can fail
+
+# Sync each training + inference backend one at a time (since they may conflict)
+# to warm the uv cache, then at the end just sync the default dependencies.
+# Do everything in one layer to prevent large layers.
+
+# The venv is symlinked to avoid bloating the layer size
+uv sync --link-mode symlink --locked --no-install-project
+if [[ -z "${SKIP_VLLM_BUILD:-}" ]]; then
+    uv sync --link-mode symlink --locked --extra vllm --no-install-project
+fi
+if [[ -z "${SKIP_SGLANG_BUILD:-}" ]]; then
+    uv sync --link-mode symlink --locked --extra sglang --no-install-project
+fi
+uv sync --link-mode symlink --locked --extra mcore --no-install-project
+uv sync --link-mode symlink --locked --extra automodel --no-install-project
+uv sync --link-mode symlink --locked --all-groups --no-install-project
+
+# Remove the aiohttp in this uv cache dir to fully address CVE GHSA-mqqc-3gqh-h2x8
+# The ray install will include the older aiohttp version in its cache
+find /root/.cache/uv -type d -path "*ray/_private/runtime_env/agent/thirdparty_files/aiohttp*" -exec rm -rf {} +
+EOF
+
+ENV PATH="/opt/nemo_rl_venv/bin:$PATH"
+ENV NEMO_RL_VENV_DIR=/opt/ray_venvs
+# Point TE at the pip-installed cuDNN (nvidia-cudnn-cu12) instead of the system one.
+# The container's system cuDNN (/lib/x86_64-linux-gnu/libcudnn*.so.9) may be a different
+# version than what pip installed. TE prioritizes system libraries by default, causing a
+# version mismatch crash (e.g. system 9.10.1 vs pip 9.19.0). CUDNN_HOME makes TE's Python
+# code find the pip version first, and LD_LIBRARY_PATH makes the dynamic linker resolve
+# cuDNN sub-libraries from pip when loading libtransformer_engine.so.
+ENV CUDNN_HOME=/opt/nemo_rl_venv/lib/python3.13/site-packages/nvidia/cudnn
+ENV LD_LIBRARY_PATH="/opt/nemo_rl_venv/lib/python3.13/site-packages/nvidia/cudnn/lib:${LD_LIBRARY_PATH}"
+# Verify with: python -c "import transformer_engine.pytorch as te; print(te.get_cudnn_version())"
+
+WORKDIR /opt/nemo-rl
+
+FROM hermetic AS release
+
+# Re-declare build args for this stage
+ARG SKIP_VLLM_BUILD
+ARG SKIP_SGLANG_BUILD
+ARG NEMO_RL_COMMIT
+ARG NVIDIA_BUILD_ID
+ARG NVIDIA_BUILD_REF
+ARG RC_DATE=00.00
+ARG TARGETARCH
+ENV NEMO_RL_COMMIT=${NEMO_RL_COMMIT:-<unknown>}
+ENV NVIDIA_BUILD_ID=${NVIDIA_BUILD_ID:-<unknown>}
+ENV NVIDIA_BUILD_REF=${NVIDIA_BUILD_REF:-<unknown>}
+LABEL com.nvidia.build.id="${NVIDIA_BUILD_ID}"
+LABEL com.nvidia.build.ref="${NVIDIA_BUILD_REF}"
+
+ENV NEMO_RL_VENV_DIR=/opt/ray_venvs
+
+# Copy in source from build context (defaults to cloned repo, can be overridden)
+# Exclude pyproject.toml and uv.lock since those may be altered by build-custom-vllm.sh
+COPY --from=nemo-rl --exclude=pyproject.toml --exclude=uv.lock . /opt/nemo-rl
+# Unshallow the repo to get the full history (in the case it was from the scratch layer).
+# Potentially not necessary if the repo is passed in as a complete repository (w/ full git history),
+# so do a quick check before trying to unshallow.
+RUN git rev-parse --is-shallow-repository | grep -q true && git fetch --unshallow || true
+RUN <<"EOF" bash -exu
+NEGATIVE_FILTERS=""
+if [[ -n "${SKIP_VLLM_BUILD:-}" ]]; then
+    NEGATIVE_FILTERS="$NEGATIVE_FILTERS vllm"
+fi
+if [[ -n "${SKIP_SGLANG_BUILD:-}" ]]; then
+    NEGATIVE_FILTERS="$NEGATIVE_FILTERS sglang"
+fi
+if [[ -n "$NEGATIVE_FILTERS" ]]; then
+    UV_LINK_MODE=symlink uv run nemo_rl/utils/prefetch_venvs.py --negative-filters $NEGATIVE_FILTERS
+else
+    UV_LINK_MODE=symlink uv run nemo_rl/utils/prefetch_venvs.py
+fi
+EOF
+
+# Generate container fingerprint for frozen environment support
+# Store outside /opt/nemo-rl to avoid being overwritten by user mounts
+RUN python tools/generate_fingerprint.py > /opt/nemo_rl_container_fingerprint
+
+# NOTICES.txt file points to where the OSS source code is archived
+RUN echo "This distribution includes open source which is archived at the following URL: https://opensource.nvidia.com/oss/teams/nvidia/nemo-rl/${RC_DATE}:linux-${TARGETARCH}/index.html" > NOTICES.txt && \
+    echo "For further inquiries or assistance, contact us at oss-requests@nvidia.com" >> NOTICES.txt

--- a/container/README.md
+++ b/container/README.md
@@ -1,64 +1,195 @@
-# NeMo-RL
+# NeMo-RL on HFC (HuggingFace Cluster)
 
-**Repository**: https://github.com/NVIDIA-NeMo/RL
+**Upstream**: https://github.com/NVIDIA-NeMo/RL
 
 ## Requirements
 
-- CUDA 12.9, Python 3.12, PyTorch 2.8.0
 - NVIDIA H100/B200 (compute capability 9.0+)
 - SLURM with Enroot + Pyxis
+- Docker access on login node (for building)
 
-## Setup
+## Container Details
 
-### 1. Build Container (Login Node)
+- Base: `nvcr.io/nvidia/cuda-dl-base:25.05-cuda12.9-devel-ubuntu24.04`
+- Python 3.13.11, PyTorch 2.10.0, CUDA 12.9
+- Backends: vLLM, Megatron-Core, AutoModel (sglang skipped)
+- Registry tag: `nemo-rl:edward-20260410`
+
+## Pre-built Image
+
+A pre-built `.sqsh` file is available on the shared filesystem:
 
 ```bash
+/fsx/edward/docker_images/nemo-rl.sqsh
+```
+
+Or pull from the cluster registry:
+
+```bash
+# Direct use (no local copy needed)
+srun --container-image="docker://registry.hpc-cluster-hopper.hpc.internal.huggingface.tech/library/nemo-rl:edward-20260410" ...
+
+# Create your own local .sqsh copy
+enroot import "docker://registry.hpc-cluster-hopper.hpc.internal.huggingface.tech/library/nemo-rl:edward-20260410"
+```
+
+## Building from Source
+
+Run on the login node (requires Docker):
+
+```bash
+cd container/
 export REGISTRY="registry.hpc-cluster-hopper.hpc.internal.huggingface.tech"
+
+# Build, push to registry, and create .sqsh file
 ./build_container.sh --sqsh-output nemo-rl.sqsh
+
+# Skip sglang to speed up the build (~30 min instead of ~2h)
+SKIP_SGLANG_BUILD=1 ./build_container.sh --sqsh-output nemo-rl.sqsh
 ```
 
-Build time: ~50-60 minutes.
-
-### 2. Test Container (Compute Node)
+## Testing the Container
 
 ```bash
-sbatch test_container.slurm --sqsh /fsx/edward/docker_images/nemo-rl.sqsh
+sbatch container/test_container.slurm --sqsh /fsx/edward/docker_images/nemo-rl.sqsh
+cat nemo_rl_test_<job-id>.out
 ```
-
-Test time: ~30 seconds. Check output: `cat nemo_rl_test_<job-id>.out`
 
 ## Usage
 
-### Training Examples
+### Quick Start: Single-Node GRPO (sbatch)
 
-Single-node GRPO (interactive):
 ```bash
-export CONTAINER_IMAGE="/fsx/edward/docker_images/nemo-rl.sqsh"
+# Default config (Qwen2.5-1.5B, 8 GPUs, OpenMathInstruct-2)
+sbatch container/run_grpo.slurm
+```
 
-srun --gpus-per-node=8 \
-     --container-image="${CONTAINER_IMAGE}" \
-     --container-mounts="/fsx:/fsx,/scratch:/scratch" \
+### Multi-Node GRPO
+
+```bash
+# 2 nodes, 16 GPUs
+sbatch --nodes=2 container/run_grpo.slurm
+
+# With custom config
+CONFIG_FILE=container/configs/grpo-qwen3-4b-thinking-2n8g-fsdp2tp1-noncolocated-fast.yaml \
+  sbatch --nodes=2 container/run_grpo.slurm
+```
+
+### Custom Config Overrides
+
+```bash
+# Override any config value via Hydra syntax
+EXTRA_OVERRIDES="grpo.max_num_steps=5 policy.model_name=Qwen/Qwen2.5-1.5B" \
+  sbatch container/run_grpo.slurm
+```
+
+### Interactive: Piggyback on Existing Allocation
+
+If you already have a SLURM allocation (e.g., from `salloc` or a dev node):
+
+```bash
+# Find your job ID
+squeue -u $USER
+
+# Run GRPO on your existing allocation
+srun --jobid=<JOBID> --overlap --gres=gpu:8 --nodes=1 --ntasks=1 \
+     --container-image="/fsx/edward/docker_images/nemo-rl.sqsh" \
+     --container-mounts="/fsx:/fsx,/scratch:/scratch,/fsx/edward/work/scale-rl/nemo-rl:/opt/nemo-rl" \
      --no-container-mount-home \
-     bash -c "cd /opt/nemo-rl && uv run python examples/run_grpo_math.py"
+     bash -c "cd /opt/nemo-rl && uv run python examples/run_grpo.py cluster.num_nodes=1 cluster.gpus_per_node=8"
 ```
 
-Multi-node GRPO (batch):
-```bash
-# Edit run_multinode.slurm to set HF_TOKEN (for gated models), then:
-sbatch run_multinode.slurm
-bash run_multinode.slurm 21639840
-```
-
-### Full Unit Tests (2 GPUs)
+### Interactive: Get a Shell Inside the Container
 
 ```bash
-sbatch run_full_tests.slurm --sqsh /fsx/edward/docker_images/nemo-rl.sqsh
+srun --jobid=<JOBID> --overlap --gres=gpu:8 --nodes=1 --ntasks=1 \
+     --container-image="/fsx/edward/docker_images/nemo-rl.sqsh" \
+     --container-mounts="/fsx:/fsx,/scratch:/scratch,/fsx/edward/work/scale-rl/nemo-rl:/opt/nemo-rl" \
+     --no-container-mount-home \
+     --pty bash
 ```
+
+Then inside the container:
+
+```bash
+cd /opt/nemo-rl
+
+# Run GRPO (default 1B model)
+uv run python examples/run_grpo.py cluster.num_nodes=1 cluster.gpus_per_node=8
+
+# Run SFT
+uv run python examples/run_sft.py
+
+# Run DPO
+uv run python examples/run_dpo.py
+
+# Run unit tests
+uv run --group test pytest tests/unit -x -q
+```
+
+### Idle Ray Cluster (Start Cluster, Attach Later)
+
+Useful for debugging or running multiple experiments on the same cluster:
+
+```bash
+# Start a 2-node Ray cluster, but don't run anything
+COMMAND="" sbatch --nodes=2 container/run_grpo.slurm
+
+# Check logs for attach instructions
+cat logs/nemo-rl-grpo-<JOBID>.out
+
+# Attach to the head node
+bash <JOBID>-attach.sh
+
+# Attach to worker 1
+bash <JOBID>-attach.sh 1
+
+# Run a command without a shell
+COMMAND="ray status" bash <JOBID>-attach.sh
+```
+
+### Multi-Node with ray_patched.sub
+
+For more control over the Ray cluster (custom ports, logging, etc.):
+
+```bash
+# Edit run_multinode.slurm to customize CONFIG_FILE, CHECKPOINT_DIR, etc.
+sbatch container/run_multinode.slurm
+
+# Or attach to an existing allocation
+bash container/run_multinode.slurm <JOBID>
+```
+
+### Full Unit Tests
+
+```bash
+sbatch container/run_full_tests.slurm --sqsh /fsx/edward/docker_images/nemo-rl.sqsh
+```
+
+## Available Configs
+
+| Config | Model | Nodes | Description |
+|--------|-------|-------|-------------|
+| (default) | Qwen2.5-1.5B | 1 | `examples/configs/grpo_math_1B.yaml` |
+| `grpo-qwen3-4b-...-fast.yaml` | Qwen3-4B | 2 | Fast test (small batches, 5 steps) |
+| `grpo-qwen3-4b-...-noncolocated.yaml` | Qwen3-4B | 2 | Full config (non-colocated vLLM) |
+
+See `examples/configs/` for all upstream configs (8B, 70B, Megatron, etc.).
+
+## Developing with the Container
+
+Mount your local source to iterate without rebuilding:
+
+```bash
+# The mount overlay makes /opt/nemo-rl point to your local clone
+--container-mounts="/fsx:/fsx,/scratch:/scratch,/fsx/edward/work/scale-rl/nemo-rl:/opt/nemo-rl"
+```
+
+Edit code locally, re-run inside the container -- changes are reflected immediately.
 
 ## Notes
 
-- Build runs on login node (Docker), tests run on compute nodes (Enroot/Pyxis)
-- `run_multinode.slurm` uses GRPO with Llama 3.1 8B (2-node config, HF token included)
-- Other examples: `run_sft.py`, `run_dpo.py`, `run_rm.py` (see `examples/`)
-- vLLM is optional (requires `uv sync --extra vllm`)
-- Official docs: https://github.com/NVIDIA-NeMo/RL
+- Build runs on login node (Docker); training runs on compute nodes (Enroot/Pyxis)
+- vLLM runs in a separate Ray worker venv (pre-built inside the container)
+- `NEMO_RL_VENV_DIR` is set to `/fsx/edward/.cache/nemo-rl/ray_venvs` for persistent caching
+- For gated models (Llama, etc.), set `HF_TOKEN` before submitting

--- a/container/README.md
+++ b/container/README.md
@@ -1,0 +1,64 @@
+# NeMo-RL
+
+**Repository**: https://github.com/NVIDIA-NeMo/RL
+
+## Requirements
+
+- CUDA 12.9, Python 3.12, PyTorch 2.8.0
+- NVIDIA H100/B200 (compute capability 9.0+)
+- SLURM with Enroot + Pyxis
+
+## Setup
+
+### 1. Build Container (Login Node)
+
+```bash
+export REGISTRY="registry.hpc-cluster-hopper.hpc.internal.huggingface.tech"
+./build_container.sh --sqsh-output nemo-rl.sqsh
+```
+
+Build time: ~50-60 minutes.
+
+### 2. Test Container (Compute Node)
+
+```bash
+sbatch test_container.slurm --sqsh /fsx/edward/docker_images/nemo-rl.sqsh
+```
+
+Test time: ~30 seconds. Check output: `cat nemo_rl_test_<job-id>.out`
+
+## Usage
+
+### Training Examples
+
+Single-node GRPO (interactive):
+```bash
+export CONTAINER_IMAGE="/fsx/edward/docker_images/nemo-rl.sqsh"
+
+srun --gpus-per-node=8 \
+     --container-image="${CONTAINER_IMAGE}" \
+     --container-mounts="/fsx:/fsx,/scratch:/scratch" \
+     --no-container-mount-home \
+     bash -c "cd /opt/nemo-rl && uv run python examples/run_grpo_math.py"
+```
+
+Multi-node GRPO (batch):
+```bash
+# Edit run_multinode.slurm to set HF_TOKEN (for gated models), then:
+sbatch run_multinode.slurm
+bash run_multinode.slurm 21639840
+```
+
+### Full Unit Tests (2 GPUs)
+
+```bash
+sbatch run_full_tests.slurm --sqsh /fsx/edward/docker_images/nemo-rl.sqsh
+```
+
+## Notes
+
+- Build runs on login node (Docker), tests run on compute nodes (Enroot/Pyxis)
+- `run_multinode.slurm` uses GRPO with Llama 3.1 8B (2-node config, HF token included)
+- Other examples: `run_sft.py`, `run_dpo.py`, `run_rm.py` (see `examples/`)
+- vLLM is optional (requires `uv sync --extra vllm`)
+- Official docs: https://github.com/NVIDIA-NeMo/RL

--- a/container/build_container.sh
+++ b/container/build_container.sh
@@ -1,0 +1,385 @@
+#!/bin/bash
+# NeMo-RL Container Build Script
+# Run this on the node where Docker is available (typically the login node)
+# This script builds the Docker image and pushes it to your registry
+
+set -e
+
+echo "========================================="
+echo "NeMo-RL Container Build Script"
+echo "========================================="
+echo "This script must run on a node with Docker access (login node)"
+echo "Started at: $(date)"
+echo "========================================="
+
+# Parse command line arguments
+SQSH_OUTPUT=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --sqsh-output)
+            SQSH_OUTPUT="$2"
+            shift 2
+            ;;
+        *)
+            echo "ERROR: Unknown argument: $1"
+            echo ""
+            echo "Usage: $0 [--sqsh-output <path>]"
+            echo ""
+            echo "Options:"
+            echo "  --sqsh-output <path>  Create .sqsh file at specified path (requires enroot)"
+            echo ""
+            echo "Examples:"
+            echo "  $0                                    # Build only"
+            echo "  $0 --sqsh-output nemo-rl.sqsh        # Build and create .sqsh"
+            exit 1
+            ;;
+    esac
+done
+
+# Configuration
+FRAMEWORK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$FRAMEWORK_DIR/../.." && pwd)"
+IMAGE_NAME="nemo-rl"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+CONTAINER_IMAGES_DIR="${CONTAINER_IMAGES_DIR:-/fsx/edward/docker_images}"
+
+# Path to local NeMo-RL clone (default: the repo this container dir lives in)
+NEMO_RL_SOURCE="${NEMO_RL_SOURCE:-$(cd "$FRAMEWORK_DIR/.." && pwd)}"
+
+# Registry configuration
+REGISTRY="${REGISTRY:-registry.hpc-cluster-hopper.hpc.internal.huggingface.tech}"
+
+if [ -z "$REGISTRY" ]; then
+    echo "ERROR: REGISTRY environment variable not set"
+    echo "Please set it to your cluster's Docker registry:"
+    echo "  export REGISTRY=registry.hpc-cluster-hopper.hpc.internal.huggingface.tech"
+    exit 1
+fi
+
+# Validate local source exists
+if [ ! -d "$NEMO_RL_SOURCE" ]; then
+    echo "ERROR: NeMo-RL source directory not found: $NEMO_RL_SOURCE"
+    echo ""
+    echo "Expected to find local NeMo-RL clone at: $NEMO_RL_SOURCE"
+    echo ""
+    echo "Options:"
+    echo "  1. Clone NeMo-RL first:"
+    echo "     cd $REPO_ROOT"
+    echo "     ./shared/scripts/clone_frameworks.sh nemo-rl"
+    echo ""
+    echo "  2. Set NEMO_RL_SOURCE to your local clone:"
+    echo "     export NEMO_RL_SOURCE=/path/to/your/nemo-rl"
+    exit 1
+fi
+
+# Check if it's a git repository
+if [ ! -d "$NEMO_RL_SOURCE/.git" ]; then
+    echo "ERROR: $NEMO_RL_SOURCE is not a git repository"
+    echo ""
+    echo "The local source must be a git clone with .git directory"
+    echo "Please clone it properly using git"
+    exit 1
+fi
+
+LOCAL_IMAGE="${IMAGE_NAME}:${IMAGE_TAG}"
+REGISTRY_IMAGE="${REGISTRY}/library/${IMAGE_NAME}:${IMAGE_TAG}"
+
+echo "Configuration:"
+echo "  Framework directory: $FRAMEWORK_DIR"
+echo "  Local NeMo-RL source: $NEMO_RL_SOURCE"
+echo "  Local image: $LOCAL_IMAGE"
+echo "  Registry image: $REGISTRY_IMAGE"
+echo ""
+echo "Using local NeMo-RL clone (commit info):"
+cd "$NEMO_RL_SOURCE"
+git --no-pager log -1 --pretty=format:"  Commit: %h%n  Date: %ai%n  Message: %s%n" || echo "  (Unable to read git info)"
+cd "$FRAMEWORK_DIR"
+echo "========================================="
+
+# Check if Docker is available
+if ! command -v docker &> /dev/null; then
+    echo "ERROR: Docker is not available on this node"
+    echo ""
+    echo "Please run this script on a node with Docker access (typically the login node)"
+    echo "If you are on a login node and Docker is still not available, contact your cluster admin"
+    exit 1
+fi
+
+# Check Docker daemon connectivity
+if ! docker info &> /dev/null; then
+    echo "ERROR: Cannot connect to Docker daemon"
+    echo ""
+    echo "Docker is installed but the daemon is not accessible."
+    echo "Please check:"
+    echo "  1. Are you on the correct login node?"
+    echo "  2. Is the Docker service running?"
+    echo "  3. Do you have permissions to access Docker?"
+    exit 1
+fi
+
+echo "✓ Docker is available and daemon is accessible"
+echo ""
+
+# Build Docker image using official Dockerfile with local source
+echo "========================================="
+echo "Building Docker image from local source..."
+echo "This will take 30-60 minutes due to:"
+echo "  - Installing PyTorch 2.8.0, Ray 2.49.2"
+echo "  - Building vLLM and other dependencies"
+echo "  - Installing NeMo-RL from local clone"
+echo ""
+echo "Using official NeMo-RL Dockerfile with multi-stage build"
+echo "Target stage: release"
+echo "Build context: Using local NeMo-RL source"
+echo "========================================="
+
+cd "$FRAMEWORK_DIR"
+
+# The official Dockerfile uses multi-stage builds
+# Stages: nemo-rl (source) -> base -> hermetic (deps) -> release (final)
+# We override the nemo-rl stage with local source using --build-context
+
+# Build with buildx using local source override
+if docker buildx version &> /dev/null; then
+    echo "Using docker buildx for build..."
+    docker buildx build \
+        --target release \
+        --build-context nemo-rl="$NEMO_RL_SOURCE" \
+        --build-arg SKIP_SGLANG_BUILD="${SKIP_SGLANG_BUILD:-}" \
+        -t $LOCAL_IMAGE \
+        --load \
+        .
+else
+    echo "ERROR: docker buildx is required for local source override"
+    echo ""
+    echo "The --build-context flag requires docker buildx"
+    echo "Please install docker buildx or use Docker Desktop"
+    exit 1
+fi
+
+if [ $? -eq 0 ]; then
+    echo "✓ Docker image built successfully: $LOCAL_IMAGE"
+else
+    echo "ERROR: Docker image build failed"
+    exit 1
+fi
+
+# Tag for registry
+echo ""
+echo "========================================="
+echo "Tagging image for registry..."
+echo "========================================="
+
+docker tag $LOCAL_IMAGE $REGISTRY_IMAGE
+
+if [ $? -eq 0 ]; then
+    echo "✓ Image tagged: $REGISTRY_IMAGE"
+else
+    echo "ERROR: Failed to tag image"
+    exit 1
+fi
+
+# Check if image already exists in registry
+echo ""
+echo "========================================="
+echo "Checking registry for existing image..."
+echo "========================================="
+if docker manifest inspect $REGISTRY_IMAGE &> /dev/null; then
+    echo "⚠️  WARNING: Image already exists in registry: $REGISTRY_IMAGE"
+    echo ""
+    echo "The existing image will be overwritten."
+    echo "If you want to preserve it, consider using a different tag:"
+    echo "  export IMAGE_TAG=v1.0.0"
+    echo "  export IMAGE_TAG=\$(date +%Y%m%d-%H%M%S)"
+    echo ""
+    echo "Press any key to continue or Ctrl+C to cancel..."
+    read -n 1 -s -r
+else
+    echo "✓ No existing image found in registry (new image)"
+fi
+
+# Push to registry
+echo ""
+echo "========================================="
+echo "Pushing to registry..."
+echo "This may take several minutes..."
+echo "========================================="
+
+docker push $REGISTRY_IMAGE
+
+if [ $? -eq 0 ]; then
+    echo "✓ Image pushed successfully to registry"
+else
+    echo "ERROR: Failed to push image to registry"
+    echo ""
+    echo "Please check:"
+    echo "  1. Is the registry URL correct? ($REGISTRY)"
+    echo "  2. Do you have push permissions to the registry?"
+    echo "  3. Is the registry accessible from this node?"
+    exit 1
+fi
+
+# Verify the push
+echo ""
+echo "========================================="
+echo "Verifying registry push..."
+echo "========================================="
+
+# Try to pull the image to verify it's available
+docker pull $REGISTRY_IMAGE &> /dev/null
+
+if [ $? -eq 0 ]; then
+    echo "✓ Image verified in registry"
+else
+    echo "WARNING: Could not verify image in registry (may still be accessible)"
+fi
+
+# Optional: Create .sqsh file with enroot
+if [ -n "$SQSH_OUTPUT" ]; then
+    echo ""
+    echo "========================================="
+    echo "Creating .sqsh file with enroot..."
+    echo "========================================="
+
+    # Check if enroot is available
+    if ! command -v enroot &> /dev/null; then
+        echo "ERROR: enroot is not available on this node"
+        echo ""
+        echo "The --sqsh-output option requires enroot to be installed."
+        echo "You can create the .sqsh file later on compute nodes:"
+        echo "  enroot import \"docker://${REGISTRY_IMAGE}\""
+        echo "  mv library+${IMAGE_NAME}+${IMAGE_TAG}.sqsh ${SQSH_OUTPUT}"
+        exit 1
+    fi
+
+    echo "✓ Enroot is available"
+
+    # Set enroot environment variables to use writable locations
+    export ENROOT_RUNTIME_PATH="${ENROOT_RUNTIME_PATH:-$HOME/.enroot/runtime}"
+    export ENROOT_DATA_PATH="${ENROOT_DATA_PATH:-$HOME/.enroot/data}"
+    export ENROOT_CACHE_PATH="${ENROOT_CACHE_PATH:-$HOME/.enroot/cache}"
+
+    # Create directories if they don't exist
+    mkdir -p "$ENROOT_RUNTIME_PATH" "$ENROOT_DATA_PATH" "$ENROOT_CACHE_PATH"
+
+    echo "Using enroot directories:"
+    echo "  Runtime: $ENROOT_RUNTIME_PATH"
+    echo "  Data: $ENROOT_DATA_PATH"
+    echo "  Cache: $ENROOT_CACHE_PATH"
+
+    # Determine output path
+    if [[ "$SQSH_OUTPUT" = /* ]]; then
+        # Absolute path provided
+        SQSH_FINAL_PATH="$SQSH_OUTPUT"
+        SQSH_DIR="$(dirname "$SQSH_FINAL_PATH")"
+    else
+        # Relative filename provided, use CONTAINER_IMAGES_DIR
+        SQSH_FINAL_PATH="${CONTAINER_IMAGES_DIR}/${SQSH_OUTPUT}"
+        SQSH_DIR="$CONTAINER_IMAGES_DIR"
+    fi
+
+    # Create output directory if needed
+    mkdir -p "$SQSH_DIR"
+
+    # Import with enroot
+    echo ""
+    echo "Importing from registry to .sqsh format..."
+    echo "This may take 5-10 minutes..."
+    echo ""
+
+    enroot import "docker://${REGISTRY_IMAGE}"
+
+    if [ $? -eq 0 ]; then
+        ENROOT_FILENAME="library+${IMAGE_NAME}+${IMAGE_TAG}.sqsh"
+
+        if [ -f "$ENROOT_FILENAME" ]; then
+            # Remove existing file if it exists at destination
+            if [ -f "$SQSH_FINAL_PATH" ]; then
+                echo "Removing existing .sqsh file: $SQSH_FINAL_PATH"
+                rm -f "$SQSH_FINAL_PATH"
+            fi
+
+            # Move to final location
+            mv "$ENROOT_FILENAME" "$SQSH_FINAL_PATH"
+
+            if [ $? -eq 0 ]; then
+                SQSH_SIZE=$(du -h "$SQSH_FINAL_PATH" | cut -f1)
+                echo "✓ .sqsh file created successfully: $SQSH_FINAL_PATH"
+                echo "  Size: $SQSH_SIZE"
+            else
+                echo "ERROR: Failed to move .sqsh file to $SQSH_FINAL_PATH"
+                exit 1
+            fi
+        else
+            echo "ERROR: .sqsh file not found after import: $ENROOT_FILENAME"
+            echo "The import may have failed or created the file with a different name"
+            exit 1
+        fi
+    else
+        echo "ERROR: enroot import failed"
+        echo ""
+        echo "Please check:"
+        echo "  1. Is the registry accessible from this node?"
+        echo "  2. Is the image available in the registry?"
+        echo "  3. Do you have sufficient disk space?"
+        exit 1
+    fi
+fi
+
+echo ""
+echo "========================================="
+echo "Build Completed Successfully!"
+echo "Finished at: $(date)"
+echo "========================================="
+echo ""
+echo "Image pushed to: $REGISTRY_IMAGE"
+
+if [ -n "$SQSH_OUTPUT" ]; then
+    echo ".sqsh file created: $SQSH_FINAL_PATH"
+fi
+
+echo ""
+echo "Next steps:"
+echo ""
+
+if [ -n "$SQSH_OUTPUT" ]; then
+    echo "1. Test the .sqsh file on compute nodes:"
+    echo ""
+    echo "   sbatch test_container.slurm --sqsh \"${SQSH_FINAL_PATH}\""
+    echo ""
+    echo "2. Use the .sqsh file in your training jobs:"
+    echo ""
+    echo "   export CONTAINER_IMAGE=\"${SQSH_FINAL_PATH}\""
+    echo ""
+    echo "   srun --gpus-per-node=8 \\"
+    echo "     --container-image=\"\${CONTAINER_IMAGE}\" \\"
+    echo "     --container-mounts=\"/fsx:/fsx,/scratch:/scratch\" \\"
+    echo "     --no-container-mount-home \\"
+    echo "     bash -c 'cd /opt/nemo-rl && uv run python examples/run_grpo_math.py'"
+else
+    echo "1. Test the container on compute nodes:"
+    echo ""
+    echo "   export REGISTRY=\"${REGISTRY}\""
+    echo "   sbatch test_container.slurm"
+    echo ""
+    echo "2. Use the container in your jobs:"
+    echo ""
+    echo "   Option A - Direct from registry (simplest):"
+    echo "   export CONTAINER_IMAGE=\"docker://${REGISTRY_IMAGE}\""
+    echo ""
+    echo "   Option B - Create .sqsh file for better performance:"
+    echo "   ./build_container.sh --sqsh-output nemo-rl.sqsh"
+    echo "   # Or manually:"
+    echo "   enroot import \"docker://${REGISTRY_IMAGE}\""
+    echo "   mv library+nemo-rl+${IMAGE_TAG}.sqsh /fsx/edward/docker_images/"
+    echo ""
+    echo "3. Run training:"
+    echo ""
+    echo "   srun --gpus-per-node=8 \\"
+    echo "     --container-image=\"\${CONTAINER_IMAGE}\" \\"
+    echo "     --container-mounts=\"/fsx:/fsx,/scratch:/scratch\" \\"
+    echo "     --no-container-mount-home \\"
+    echo "     bash -c 'cd /opt/nemo-rl && uv run python examples/run_grpo_math.py'"
+fi
+
+echo ""

--- a/container/configs/grpo-qwen3-4b-thinking-2n8g-fsdp2tp1-noncolocated-fast.yaml
+++ b/container/configs/grpo-qwen3-4b-thinking-2n8g-fsdp2tp1-noncolocated-fast.yaml
@@ -1,0 +1,192 @@
+# NeMo-RL GRPO Config - FAST VERSION FOR TESTING
+# Model: Qwen/Qwen3-4B-Thinking-2507
+# Optimized for quick iterations and frequent logging
+defaults: /fsx/edward/work/scale-rl/nemo-rl/examples/configs/grpo_math_1B.yaml
+
+cluster:
+  num_nodes: 2
+  gpus_per_node: 8
+
+data:
+  dataset_name: "OpenMathInstruct-2"
+  max_input_seq_length: 256  # Reduced from 512 for faster processing
+  num_workers: 1
+  prompt_file: "examples/prompts/cot.txt"
+  shuffle: true
+  system_prompt_file: null
+
+grpo:
+  seed: 42
+  max_num_steps: 5  # Reduced from 10 for quick testing
+  max_num_epochs: 10
+  num_generations_per_prompt: 4  # Reduced from 16 (4x speedup)
+  num_prompts_per_step: 16  # Reduced from 64 (4x speedup)
+  normalize_rewards: true
+  use_leave_one_out_baseline: true
+  max_rollout_turns: 1
+  batch_multiplier: 1
+  overlong_filtering: false
+  use_dynamic_sampling: false
+  dynamic_sampling_max_gen_batches: 10
+  val_at_start: false
+  val_period: 1  # Validate every single step for maximum logging
+  val_batch_size: 64  # Smaller validation batches (was 256)
+  max_val_samples: 64  # Fewer validation samples (was 256)
+
+  reward_scaling:
+    enabled: false
+    source_min: 0.0
+    source_max: 1.0
+    target_min: 0.0
+    target_max: 1.0
+
+  reward_shaping:
+    enabled: false
+    max_response_length: 256  # Reduced from 1024
+    overlong_buffer_length: 64  # Reduced from 128
+    overlong_buffer_penalty: 1
+
+loss_fn:
+  reference_policy_kl_penalty: 0.0  # TRL: beta = 0.0 (No KL term)
+  reference_policy_kl_type: "k3"
+  ratio_clip_min: 0.2
+  ratio_clip_max: 0.2
+  ratio_clip_c: null
+  kl_input_clamp_value: 20.0
+  kl_output_clamp_value: 10.0
+  token_level_loss: true
+  sequence_level_importance_ratios: false
+  use_importance_sampling_correction: false
+  use_on_policy_kl_approximation: false
+  truncated_importance_sampling_ratio: null
+
+policy:
+  model_name: "Qwen/Qwen3-4B-Thinking-2507"
+  max_total_sequence_length: 512  # Reduced from 1536 (256 prompt + 256 completion)
+  max_grad_norm: 1.0
+  generation_batch_size: 16
+  logprob_batch_size: 4  # Increased from 2 for faster logprob computation
+  logprob_chunk_size: null
+  make_sequence_length_divisible_by: 1
+  hf_config_overrides: {}
+  precision: "bfloat16"
+
+  # Tokenizer
+  tokenizer:
+    name: "Qwen/Qwen3-4B-Thinking-2507"
+    chat_template_kwargs: null
+
+  # Batch sizes - reduced for faster iterations
+  train_global_batch_size: 64  # Reduced from 512 (8x speedup)
+  train_micro_batch_size: 1
+
+  # Optimizer (for DTensor path)
+  optimizer:
+    name: "torch.optim.AdamW"
+    kwargs:
+      lr: 1.0e-06  # TRL: learning_rate
+      betas: [0.9, 0.999]
+      eps: 1.0e-08
+      weight_decay: 0.01
+      foreach: false
+      fused: false
+
+  # Scheduler - simple constant LR
+  scheduler:
+    - name: "torch.optim.lr_scheduler.ConstantLR"
+      kwargs:
+        factor: 1.0
+        total_iters: 10000000000
+    - milestones: []
+
+  # Offload optimizer during logprob computation
+  offload_optimizer_for_logprob: false
+
+  # Dynamic batching disabled for simplicity
+  dynamic_batching:
+    enabled: false
+    train_mb_tokens: 4096
+    logprob_mb_tokens: 8192
+    sequence_length_round: 64
+
+  # Sequence packing disabled
+  sequence_packing:
+    enabled: false
+    algorithm: "modified_first_fit_decreasing"
+    max_diff_pct: 0.1
+
+  # Generation settings - OPTIMIZED FOR SPEED
+  generation:
+    backend: "vllm"  # TRL: use_vllm = true
+    max_new_tokens: 256  # Reduced from 1024 (4x speedup per generation)
+    temperature: 1.0
+    top_p: 1.0
+    top_k: null
+    stop_strings: null
+    stop_token_ids: null
+
+    vllm_cfg:
+      precision: "bfloat16"
+      max_model_len: 512  # Reduced from 1536
+      gpu_memory_utilization: 0.4  # Lower = faster KV cache allocation during init
+      tensor_parallel_size: 1
+      pipeline_parallel_size: 1
+      expert_parallel_size: 1
+      enforce_eager: true # Disable slow Capturing CUDA graph for faster init
+      use_deep_gemm: false
+      num_first_layers_in_bf16: 0
+      num_last_layers_in_bf16: 0
+      async_engine: true
+
+    vllm_kwargs:
+      compilation_config:
+        use_inductor: false  # Disable torch compilation for faster init
+
+  # DTensor (FSDP2 with TP1) - simplified
+  dtensor_cfg:
+    enabled: true
+    _v2: true
+    tensor_parallel_size: 1
+    context_parallel_size: 1
+    sequence_parallel: false
+    activation_checkpointing: false
+    cpu_offload: false
+    custom_parallel_plan: null
+
+  # Megatron disabled - using DTensor instead
+  megatron_cfg:
+    enabled: false
+
+env:
+  math:
+    math_verify_impl: "hf_math_verify"
+    num_workers: 8
+
+logger:
+  log_dir: "logs/grpo-qwen3-4b-thinking-fast"
+  monitor_gpus: true
+  num_val_samples_to_print: 2  # Print 2 validation samples for visibility
+  tensorboard_enabled: true
+  wandb_enabled: false
+  mlflow_enabled: false
+  swanlab_enabled: false
+
+  tensorboard: {}
+  wandb:
+    project: "nemo-rl"
+    name: "grpo-qwen3-4b-thinking-fast"
+
+  gpu_monitoring:
+    collection_interval: 5  # Log GPU stats every 5 seconds
+    flush_interval: 5  # Flush logs every 5 seconds
+
+checkpointing:
+  enabled: false
+  checkpoint_dir: "/fsx/edward/checkpoints/nemo-rl/grpo_test_fast"
+  save_period: 10000
+  keep_top_k: 3
+  metric_name: "val:accuracy"
+  higher_is_better: true
+  save_consolidated: false
+  model_save_format: "safetensors"
+  checkpoint_must_save_by: null

--- a/container/configs/grpo-qwen3-4b-thinking-2n8g-fsdp2tp1-noncolocated.yaml
+++ b/container/configs/grpo-qwen3-4b-thinking-2n8g-fsdp2tp1-noncolocated.yaml
@@ -1,0 +1,196 @@
+# NeMo-RL GRPO Config matching TRL qwen3-4b-thinking.yaml
+# Model: Qwen/Qwen3-4B-Thinking-2507
+# Simplified configuration for quick testing
+
+cluster:
+  num_nodes: 2
+  gpus_per_node: 8
+
+data:
+  dataset_name: "OpenMathInstruct-2"
+  max_input_seq_length: 512  # TRL: max_prompt_length
+  num_workers: 1
+  prompt_file: "examples/prompts/cot.txt"
+  shuffle: true
+  system_prompt_file: null
+
+grpo:
+  seed: 42
+  max_num_steps: 1  # TRL: max_steps (scale to 10 for real benchmark)
+  max_num_epochs: 1
+  num_generations_per_prompt: 16  # TRL: num_generations
+  num_prompts_per_step: 64
+  normalize_rewards: true
+  use_leave_one_out_baseline: true
+  max_rollout_turns: 1
+  batch_multiplier: 1
+  overlong_filtering: false
+  use_dynamic_sampling: false
+  dynamic_sampling_max_gen_batches: 10
+  val_at_start: false
+  val_period: 10
+  val_batch_size: 256
+  max_val_samples: 256
+
+  reward_scaling:
+    enabled: false
+    source_min: 0.0
+    source_max: 1.0
+    target_min: 0.0
+    target_max: 1.0
+
+  reward_shaping:
+    enabled: false
+    max_response_length: 1024
+    overlong_buffer_length: 128
+    overlong_buffer_penalty: 1
+
+loss_fn:
+  reference_policy_kl_penalty: 0.0  # TRL: beta = 0.0 (No KL term)
+  reference_policy_kl_type: "k3"
+  ratio_clip_min: 0.2
+  ratio_clip_max: 0.2
+  ratio_clip_c: null
+  kl_input_clamp_value: 20.0
+  kl_output_clamp_value: 10.0
+  token_level_loss: true
+  sequence_level_importance_ratios: false
+  use_importance_sampling_correction: false
+  use_on_policy_kl_approximation: false
+  truncated_importance_sampling_ratio: null
+
+policy:
+  model_name: "Qwen/Qwen3-4B-Thinking-2507"
+  max_total_sequence_length: 1536  # 512 prompt + 1024 completion
+  max_grad_norm: 1.0
+  generation_batch_size: 16
+  logprob_batch_size: 2
+  logprob_chunk_size: null
+  make_sequence_length_divisible_by: 1
+  hf_config_overrides: {}
+  precision: "bfloat16"
+
+  # Tokenizer
+  tokenizer:
+    name: "Qwen/Qwen3-4B-Thinking-2507"
+    chat_template_kwargs: null
+
+  # Batch sizes
+  train_global_batch_size: 512
+  train_micro_batch_size: 1
+
+  # Optimizer (for DTensor path)
+  optimizer:
+    name: "torch.optim.AdamW"
+    kwargs:
+      lr: 1.0e-06  # TRL: learning_rate
+      betas: [0.9, 0.999]
+      eps: 1.0e-08
+      weight_decay: 0.01
+      foreach: false
+      fused: false
+
+  # Scheduler - simple constant LR
+  scheduler:
+    - name: "torch.optim.lr_scheduler.ConstantLR"
+      kwargs:
+        factor: 1.0
+        total_iters: 10000000000
+    - milestones: []
+
+  # Offload optimizer during logprob computation
+  offload_optimizer_for_logprob: false
+
+  # Dynamic batching disabled for simplicity
+  dynamic_batching:
+    enabled: false
+    train_mb_tokens: 4096
+    logprob_mb_tokens: 8192
+    sequence_length_round: 64
+
+  # Sequence packing disabled
+  sequence_packing:
+    enabled: false
+    algorithm: "modified_first_fit_decreasing"
+    max_diff_pct: 0.1
+
+  # Generation settings
+  generation:
+    backend: "vllm"  # TRL: use_vllm = true
+    max_new_tokens: 1024  # TRL: max_completion_length
+    temperature: 1.0
+    top_p: 1.0
+    top_k: null
+    stop_strings: null
+    stop_token_ids: null
+
+    # Non-colocated VLLM setup
+    colocated:
+      enabled: false
+      resources:
+        num_nodes: 1
+        gpus_per_node: 8
+
+    vllm_cfg:
+      precision: "bfloat16"
+      max_model_len: 1536
+      gpu_memory_utilization: 0.6
+      tensor_parallel_size: 1
+      pipeline_parallel_size: 1
+      expert_parallel_size: 1
+      enforce_eager: false
+      use_deep_gemm: false
+      num_first_layers_in_bf16: 0
+      num_last_layers_in_bf16: 0
+      async_engine: true
+
+    vllm_kwargs: {}
+
+  # DTensor (FSDP2 with TP1) - simplified
+  dtensor_cfg:
+    enabled: true
+    _v2: true
+    tensor_parallel_size: 1
+    context_parallel_size: 1
+    sequence_parallel: false
+    activation_checkpointing: false
+    cpu_offload: false
+    custom_parallel_plan: null
+
+  # Megatron disabled - using DTensor instead
+  megatron_cfg:
+    enabled: false
+
+env:
+  math:
+    math_verify_impl: "hf_math_verify"
+    num_workers: 8
+
+logger:
+  log_dir: "logs/grpo-qwen3-4b-thinking"
+  monitor_gpus: true
+  num_val_samples_to_print: 0
+  tensorboard_enabled: true
+  wandb_enabled: false  # TRL has wandb but we disable for simplicity
+  mlflow_enabled: false
+  swanlab_enabled: false
+
+  tensorboard: {}
+  wandb:
+    project: "nemo-rl"
+    name: "grpo-qwen3-4b-thinking"
+
+  gpu_monitoring:
+    collection_interval: 10
+    flush_interval: 10
+
+checkpointing:
+  enabled: true
+  checkpoint_dir: "/fsx/edward/checkpoints/nemo-rl/grpo_qwen3"
+  save_period: 10
+  keep_top_k: 3
+  metric_name: "val:accuracy"
+  higher_is_better: true
+  save_consolidated: false
+  model_save_format: "safetensors"
+  checkpoint_must_save_by: null

--- a/container/ray_patched.sub
+++ b/container/ray_patched.sub
@@ -1,0 +1,485 @@
+#!/bin/bash
+#SBATCH --nodes=2
+#SBATCH --exclusive
+#SBATCH --account=ACCOUNT
+#SBATCH --job-name=JOB_NAME
+#SBATCH --partition=PARTITION
+#SBATCH --time=1:0:0
+#SBATCH --dependency=singleton
+
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -eoux pipefail
+
+
+########################################################
+# User defined variables
+########################################################
+CONTAINER=$CONTAINER
+MOUNTS=$MOUNTS
+COMMAND=${COMMAND:-}  # This is a script relative to the SLURM_SUBMIT_DIR. If left empty, it will leave the cluster idle after it's brought up.
+########################################################
+# Ports for all nodes (should be odd numbers since we place head/worker[0] on the same node) so all workers get the odd ports, but the head will get +1 the ports
+NODE_MANAGER_PORT=${NODE_MANAGER_PORT:-53001}
+OBJECT_MANAGER_PORT=${OBJECT_MANAGER_PORT:-53003}
+RUNTIME_ENV_AGENT_PORT=${RUNTIME_ENV_AGENT_PORT:-53005}
+DASHBOARD_AGENT_GRPC_PORT=${DASHBOARD_AGENT_GRPC_PORT:-53007}
+METRICS_EXPORT_PORT=${METRICS_EXPORT_PORT:-53009}
+
+# Ports for the head node
+PORT=${PORT:-54514}
+RAY_CLIENT_SERVER_PORT=${RAY_CLIENT_SERVER_PORT:-10001}
+#REDIT_SHARD_PORTS=${REDIT_SHARD_PORTS:-"random"} ??
+DASHBOARD_PORT=${DASHBOARD_PORT:-8265}  # Also used by debugger
+DASHBOARD_AGENT_LISTEN_PORT=${DASHBOARD_AGENT_LISTEN_PORT:-52365}
+RAY_DEBUGGER_ARGS=
+if [ "${RAY_DEBUG:-}" = "legacy" ]; then
+  RAY_DEBUGGER_ARGS="--ray-debugger-external"
+fi
+
+# After ray>=2.47, this feature is enabled by default which creates uv venvs for any py_executable starting with `uv run`.
+# There is severe contention and performance issues with this enabled considering our dependencies are so large and occasionally
+# need to be compiled, so NeMo RL has an implementation in nemo_rl/utils/venv.py that does it once per node as opposed to once per task.
+export RAY_ENABLE_UV_RUN_RUNTIME_ENV=0
+
+# Enhanced Ray Logging for Debugging
+export RAY_BACKEND_LOG_LEVEL=${RAY_BACKEND_LOG_LEVEL:-info}     # C++ backend logging: debug, info, warning, error
+export RAY_LOG_TO_STDERR=${RAY_LOG_TO_STDERR:-0}                # Set to 1 to log Python side to stderr
+export RAY_logging_level=${RAY_logging_level:-INFO}             # Python logging: DEBUG, INFO, WARNING, ERROR
+export VLLM_LOGGING_LEVEL=${VLLM_LOGGING_LEVEL:-INFO}           # vLLM logging: DEBUG, INFO, WARNING, ERROR
+
+# Override Dockerfile's NEMO_RL_VENV_DIR to use persistent /fsx storage
+# (Dockerfile sets it to /opt/ray_venvs which gets deleted on container restart)
+export NEMO_RL_VENV_DIR=/fsx/${USER}/.cache/nemo-rl/ray_venvs
+
+# Setting ulimit is recommended by ray best practices page
+# @ https://docs.ray.io/en/latest/cluster/vms/user-guides/large-cluster-best-practices.html
+# It's session based and won't affect the system outside the script
+# Ensure that the soft limit isn't above the hard limit
+if [[ $(ulimit -Hn) == "unlimited" ]] || [[ 65535 -lt $(ulimit -Hn) ]]; then
+  ulimit -Sn 65535
+elif [[ $(ulimit -Hn) != "unlimited" ]] && [[ $(ulimit -Hn) -lt 65535 ]]; then
+  echo "[WARNING]: Cannot increase ulimit on file descriptors to 65535 according ray recommendation: https://docs.ray.io/en/latest/cluster/vms/user-guides/large-cluster-best-practices.html. Speak to cluster admins to increase, otherwise ray may crash unexpectedly."
+fi
+
+# On our clusters, the largest port range on an idle worker appeared between 52369-64607
+# (not including the other ports set by this script). So this range is chosen to be
+# somewhere in the middle
+MIN_WORKER_PORT=${MIN_WORKER_PORT:-54001}
+MAX_WORKER_PORT=${MAX_WORKER_PORT:-54513}
+########################################################
+# Number seconds to sync logs from /tmp/ray/session_*/logs to $LOG_DIR/ray/
+RAY_LOG_SYNC_FREQUENCY=${RAY_LOG_SYNC_FREQUENCY:-}
+########################################################
+
+# Unset UV_CACHE_DIR to avoid local cache directory interferring with the container cache
+unset UV_CACHE_DIR
+
+if [[ -n "${UV_CACHE_DIR_OVERRIDE:-}" ]]; then
+  mkdir -p "$UV_CACHE_DIR_OVERRIDE"
+  if [[ -n $MOUNTS ]]; then
+    MOUNTS+=",$UV_CACHE_DIR_OVERRIDE:/root/.cache/uv"
+  else
+    MOUNTS="$UV_CACHE_DIR_OVERRIDE:/root/.cache/uv"
+  fi
+fi
+
+# Create logs directory with datetime (default to logs/ subdirectory)
+BASE_LOG_DIR=${BASE_LOG_DIR:-$SLURM_SUBMIT_DIR/logs}
+LOG_DATETIME=${LOG_DATETIME:-$(date +%Y%m%d_%H%M%S)}
+LOG_DIR="${LOG_DIR:-$BASE_LOG_DIR/$SLURM_JOB_ID-$LOG_DATETIME-logs}"
+mkdir -p $LOG_DIR
+
+# Number of GPUs per worker node
+GPUS_PER_NODE=${GPUS_PER_NODE:-8}
+
+# Number of CPUs per worker node (default to 88 for H100 nodes)
+CPUS_PER_NODE=${CPUS_PER_NODE:-88}
+
+COMMON_SRUN_ARGS=""
+COMMON_SRUN_ARGS+=" --no-container-mount-home"
+COMMON_SRUN_ARGS+=" --mpi=pmix"
+COMMON_SRUN_ARGS+=" --container-mounts=$MOUNTS"
+COMMON_SRUN_ARGS+=" --container-image=$CONTAINER"
+COMMON_SRUN_ARGS+=" --container-workdir=$SLURM_SUBMIT_DIR"
+# TODO: delete these (just for debugging)
+COMMON_SRUN_ARGS+=" -p $SLURM_JOB_PARTITION"
+COMMON_SRUN_ARGS+=" -A $SLURM_JOB_ACCOUNT"
+# Claim all the CPU/memory/GPUs on the node
+COMMON_SRUN_ARGS+=" --exclusive"
+# Don't use --cpus-per-task with --exclusive as it causes allocation conflicts
+# Instead, set CPU count in Ray's resource specifications below
+
+num_retries=3
+
+# Track backgrounded srun client PIDs for head and workers
+declare -A SRUN_PIDS
+
+# Verify all backgrounded srun client processes are still alive; exit fast if any died
+check_srun_processes() {
+  for name in "${!SRUN_PIDS[@]}"; do
+    pid="${SRUN_PIDS[$name]}"
+    # Check if the process is still running
+    if ! kill -0 "$pid" 2>/dev/null; then
+      echo "[ERROR] Background srun '$name' died (pid=$pid). Could be a failure in startup or an issue with the node preventing the srun to start. Attempting to exit." >&2
+      # Signal sidecars inside containers to terminate ASAP
+      touch "$LOG_DIR/ENDED"
+      exit 1
+    fi
+  done
+}
+
+# Getting the node names and IP addresses in the SLURM allocation
+nodes=$(scontrol show hostnames "$SLURM_JOB_NODELIST")
+nodes_array=($nodes)
+ip_addresses_array=()
+
+for node in $nodes; do
+    # Try multiple methods to get IP address - ENHANCED VERSION v2.0
+    echo "[DEBUG] Resolving hostname: $node using enhanced resolution methods"
+    ip_address=""
+    
+    # Method 1: Try host command
+    echo "[DEBUG] Method 1: host command"
+    ip_address=$(host $node 2>/dev/null | awk '/has address/ { print $4 }' | head -1 || true)
+    echo "[DEBUG] host result: '$ip_address'"
+    
+    # Method 2: If host fails, try getent
+    if [[ -z "$ip_address" ]]; then
+        echo "[DEBUG] Method 2: getent hosts"
+        ip_address=$(getent hosts $node 2>/dev/null | awk '{ print $1 }' | head -1 || true)
+        echo "[DEBUG] getent result: '$ip_address'"
+    fi
+    
+    # Method 3: If getent fails, try nslookup
+    if [[ -z "$ip_address" ]]; then
+        echo "[DEBUG] Method 3: nslookup"
+        ip_address=$(nslookup $node 2>/dev/null | awk '/^Address: / { print $2 }' | head -1 || true)
+        echo "[DEBUG] nslookup result: '$ip_address'"
+    fi
+    
+    # Method 4: If all DNS methods fail, try ping to extract IP
+    if [[ -z "$ip_address" ]]; then
+        echo "[DEBUG] Method 4: ping"
+        ip_address=$(ping -c 1 $node 2>/dev/null | grep "PING" | sed 's/.*(\([^)]*\)).*/\1/' || true)
+        echo "[DEBUG] ping result: '$ip_address'"
+    fi
+    
+    # If still no IP, use the hostname itself (might work if it's already an IP or resolvable)
+    if [[ -z "$ip_address" ]]; then
+        echo "[WARNING] Could not resolve IP for $node, using hostname as fallback"
+        ip_address=$node
+    fi
+    
+    echo "[INFO] Node: $node -> IP: $ip_address"
+    # Add the IP address to the array
+    ip_addresses_array+=("$ip_address")
+done
+
+head_node=${nodes_array[0]}
+head_node_ip=${ip_addresses_array[0]}
+
+ip_head=$head_node_ip:$PORT
+
+# First we start the head of the ray cluster on one of the physical nodes
+# Give the head node actual resources to make it schedulable
+
+head_cmd=$(cat <<EOF
+# Touch a file to indicate that the head node has started
+# Overlapping srun commands will check this file to determine if we can overlap a container command
+touch $LOG_DIR/STARTED_RAY_HEAD
+
+# Override Docker ENV variables for persistent venv storage
+export NEMO_RL_VENV_DIR=$NEMO_RL_VENV_DIR
+
+env
+
+exit-dramatically() {
+    # Use SIGTERM to forcefully terminate the srun process
+    pkill -P $$ || true
+    kill -TERM 0 || true
+    # As a last resort, exit with a non-zero code
+    exit 1
+}
+export -f exit-dramatically
+
+# Background process to check for ENDED file
+monitor-sidecar() {
+  set +x
+  while true; do
+    sleep 60
+    if [[ -f "$LOG_DIR/ENDED" ]]; then
+      echo "Detected ENDED file, terminating..."
+      exit-dramatically
+    fi
+  done
+}
+monitor-sidecar &
+
+# Background process to sync ray logs every $RAY_LOG_SYNC_FREQUENCY seconds
+log-sync-sidecar() {
+  set +x
+  if [[ -z "$RAY_LOG_SYNC_FREQUENCY" ]]; then
+    echo "RAY_LOG_SYNC_FREQUENCY is not set, skipping log sync sidecar"
+    return
+  fi
+  mkdir -p $LOG_DIR/ray
+  while true; do
+    sleep $RAY_LOG_SYNC_FREQUENCY
+    if ls /tmp/ray/session_[0-9]* > /dev/null 2>&1; then
+      for session_dir in /tmp/ray/session_[0-9]*/; do
+        if [[ -d "\$session_dir/logs" ]]; then
+          session_name=\$(basename "\$session_dir")
+          mkdir -p "$LOG_DIR/ray/\$session_name"
+          if command -v rsync > /dev/null 2>&1; then
+            rsync -ahP "\$session_dir/logs/" "$LOG_DIR/ray/\$session_name/logs/" 2>/dev/null || true
+          else
+            cp -r "\$session_dir/logs" "$LOG_DIR/ray/\$session_name/"
+          fi
+        fi
+      done
+    fi
+    if [[ -f "$LOG_DIR/ENDED" ]]; then
+      echo "Log sync sidecar terminating..."
+      break
+    fi
+  done
+}
+log-sync-sidecar &
+
+# Patch nsight.py before starting Ray head
+sed -i 's/context\.py_executable = " "\.join(self\.nsight_cmd) + " python"/context.py_executable = " ".join(self.nsight_cmd) + f" {context.py_executable}"/g' /opt/nemo_rl_venv/lib64/python*/site-packages/ray/_private/runtime_env/nsight.py
+
+cat <<EOFINNER | tee /launch-head.sh
+ray start --head \
+    --disable-usage-stats \
+    --num-cpus=$CPUS_PER_NODE \
+    --resources="{\"worker_units\": $GPUS_PER_NODE, \"slurm_managed_ray_cluster\": 1}" \
+    --node-ip-address="$head_node_ip" \
+    --port=${PORT} \
+    --ray-client-server-port=${RAY_CLIENT_SERVER_PORT} \
+    --dashboard-port=${DASHBOARD_PORT} \
+    \
+    --node-manager-port=$((${NODE_MANAGER_PORT} + 1)) \
+    --object-manager-port=$((${OBJECT_MANAGER_PORT} + 1)) \
+    --runtime-env-agent-port=$((${RUNTIME_ENV_AGENT_PORT} + 1)) \
+    --dashboard-agent-grpc-port=$((${DASHBOARD_AGENT_GRPC_PORT} + 1)) \
+    --dashboard-agent-listen-port=$((${DASHBOARD_AGENT_LISTEN_PORT} + 1)) \
+    --metrics-export-port=$((${METRICS_EXPORT_PORT} + 1)) \
+    $RAY_DEBUGGER_ARGS \
+    \
+    --block 
+EOFINNER
+chmod +x /launch-head.sh
+
+count=0
+while [[ \$count -lt $num_retries ]]; do
+  bash /launch-head.sh
+  count=\$((count+1))
+  echo "Head node failed \$count/$num_retries times, restarting in 5 seconds..."
+  sleep 5
+done
+touch $LOG_DIR/ENDED
+exit 1
+EOF
+)
+srun $COMMON_SRUN_ARGS --container-name=ray-head --nodes=1 -w "$head_node" -o $LOG_DIR/ray-head.log bash -x -c "$head_cmd" &
+SRUN_PIDS["ray-head"]=$!
+
+NUM_ACTORS=$((GPUS_PER_NODE * SLURM_JOB_NUM_NODES))
+
+# Start Ray worker nodes
+# We want 1 Ray worker node per physical node (excluding the head node)
+# Worker nodes are started with ray start but without the --head flag
+# Start from node 1 since node 0 is running the head
+for ((i = 1; i < SLURM_JOB_NUM_NODES; i++)); do
+  node_i=${nodes_array[$i]}
+    
+  worker_cmd=$(cat <<EOF
+# Override Docker ENV variables for persistent venv storage
+export NEMO_RL_VENV_DIR=$NEMO_RL_VENV_DIR
+
+env
+
+exit-dramatically() {
+    # Use SIGTERM to forcefully terminate the srun process
+    pkill -P $$ || true
+    kill -TERM 0 || true
+    # As a last resort, exit with a non-zero code
+    exit 1
+}
+
+# Background process to check for ENDED file
+monitor-sidecar() {
+  set +x
+  while true; do
+    sleep 60
+    if [[ -f "$LOG_DIR/ENDED" ]]; then
+      echo "Detected ENDED file, terminating..."
+      exit-dramatically
+    fi
+  done
+}
+monitor-sidecar &
+
+# Background process to sync ray logs every $RAY_LOG_SYNC_FREQUENCY seconds
+log-sync-sidecar() {
+  set +x
+  if [[ -z "$RAY_LOG_SYNC_FREQUENCY" ]]; then
+    echo "RAY_LOG_SYNC_FREQUENCY is not set, skipping log sync sidecar"
+    return
+  fi
+  mkdir -p $LOG_DIR/ray/$node_i
+  while true; do
+    sleep $RAY_LOG_SYNC_FREQUENCY
+    if ls /tmp/ray/session_[0-9]* > /dev/null 2>&1; then
+      for session_dir in /tmp/ray/session_[0-9]*/; do
+        if [[ -d "\$session_dir/logs" ]]; then
+          session_name=\$(basename "\$session_dir")
+          mkdir -p "$LOG_DIR/ray/$node_i/\$session_name"
+          if command -v rsync > /dev/null 2>&1; then
+            rsync -ahP "\$session_dir/logs/" $LOG_DIR/ray/$node_i/\$session_name/logs/ 2>/dev/null || true
+          else
+            cp -r "\$session_dir/logs" $LOG_DIR/ray/$node_i/\$session_name/
+          fi
+        fi
+      done
+    fi
+    if [[ -f "$LOG_DIR/ENDED" ]]; then
+      echo "Log sync sidecar terminating..."
+      break
+    fi
+  done
+}
+log-sync-sidecar &
+
+# Patch nsight.py before starting Ray worker
+sed -i 's/context\.py_executable = " "\.join(self\.nsight_cmd) + " python"/context.py_executable = " ".join(self.nsight_cmd) + f" {context.py_executable}"/g' /opt/nemo_rl_venv/lib64/python*/site-packages/ray/_private/runtime_env/nsight.py
+
+cat <<EOFINNER | tee /launch-worker.sh
+ray start --address "$ip_head" \
+          --disable-usage-stats \
+          --num-cpus=$CPUS_PER_NODE \
+          --resources="{\"worker_units\": $GPUS_PER_NODE, \"slurm_managed_ray_cluster\": 1}" \
+          --min-worker-port=${MIN_WORKER_PORT} \
+          --max-worker-port=${MAX_WORKER_PORT} \
+          \
+          --node-manager-port=${NODE_MANAGER_PORT} \
+          --object-manager-port=${OBJECT_MANAGER_PORT} \
+          --runtime-env-agent-port=${RUNTIME_ENV_AGENT_PORT} \
+          --dashboard-agent-grpc-port=${DASHBOARD_AGENT_GRPC_PORT} \
+          --dashboard-agent-listen-port=${DASHBOARD_AGENT_LISTEN_PORT} \
+          --metrics-export-port=${METRICS_EXPORT_PORT} \
+          $RAY_DEBUGGER_ARGS \
+          \
+          --block 
+EOFINNER
+
+count=0
+while [[ \$count -lt $num_retries ]]; do
+  bash /launch-worker.sh
+  count=\$((count+1))
+  echo "Worker failed \$count/$num_retries times, restarting in 5 seconds..."
+  sleep 5
+done
+touch $LOG_DIR/ENDED
+exit 1
+EOF
+)
+  srun $COMMON_SRUN_ARGS --container-name=ray-worker-$i --nodes=1 -w "$node_i" -o $LOG_DIR/ray-worker-$i.log bash -x -c "$worker_cmd" &
+  SRUN_PIDS["ray-worker-$i"]=$!
+  sleep 3
+done
+
+# Then we wait here for the file to be created by the head node container
+# Check file directly on shared /fsx filesystem (no srun needed)
+while check_srun_processes && ! test -f $LOG_DIR/STARTED_RAY_HEAD; do
+  echo "[INFO][$(date)] Waiting for head node container to start..."
+  sleep 2
+done
+
+# At this stage the Ray cluster bringup has started on the physical nodes in the allocation
+# Before we launch a job on this cluster we need to make sure that the bringup is complete
+# We do so by querying the number of worker_units in the ray cluster and asserting = NUM_ACTORS
+extract_worker_units() {
+  # Use --jobid to attach to existing job and --overlap to share the node
+  status_output=$(srun --jobid=$SLURM_JOB_ID --overlap --container-name=ray-head --nodes=1 -w "$head_node" ray status 2>/dev/null) || true
+  if echo "$status_output" | grep -q "worker_units"; then
+    worker_units=$(echo "$status_output" | grep "worker_units" | awk -F'[/. ]' '{print $4}')
+    echo $worker_units
+  else
+    echo 0
+  fi
+}
+
+# Poll to make sure that all Ray worker nodes have connected to the head.
+# All workers have connected when number of GPUs in ray cluster
+# is equal to NUM_ACTORS. We use the utility function above
+# to check how many GPUs have come online in the ray cluster
+while true; do
+  worker_units=$(extract_worker_units)
+  echo "[INFO] Number of actors online: $worker_units/$NUM_ACTORS"
+  if [[ "$worker_units" -eq "$NUM_ACTORS" ]]; then
+    break
+  fi
+  check_srun_processes
+  sleep 2
+done
+
+echo "All workers connected!"
+
+# We can now launch a job on this cluster
+# We do so by launching a driver process on the physical node that the head node is on
+# This driver process is responsible for launching a job on the Ray cluster
+CONTAINER_CWD=$(scontrol show job $SLURM_JOB_ID | grep -oP 'WorkDir=\K[^ ]+' | head -1)
+if [[ -n "$COMMAND" ]]; then
+  srun --jobid=$SLURM_JOB_ID --no-container-mount-home --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 -w "$head_node" -o $LOG_DIR/ray-driver.log bash -c "$COMMAND"
+else
+  echo "[INFO]: Ray Cluster is idled, run this on the slurm head node to get a shell to the head node:"
+  cat <<EOF >$SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh
+# No args launches on the head node (node 0)
+# Args 1-N launch on worker nodes (nodes 1 through N-1)
+# Optional: set COMMAND='...' to run non-interactively instead of opening an interactive shell
+WORKER_NUM=\${1:-}
+if [[ -z "\$WORKER_NUM" ]]; then
+  # Empty means we are on the head node
+  if [[ -n "\${COMMAND:-}" ]]; then
+    srun --no-container-mount-home -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 -w "$head_node" --jobid $SLURM_JOB_ID bash -c "\$COMMAND"
+  else
+    srun --no-container-mount-home -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 -w "$head_node" --jobid $SLURM_JOB_ID --pty bash
+  fi
+else
+  # Worker numbers 1 through N-1 correspond to ray-worker-1 through ray-worker-(N-1)
+  # and use nodes_array[1] through nodes_array[N-1]
+  if [[ \$WORKER_NUM -lt 1 || \$WORKER_NUM -ge $SLURM_JOB_NUM_NODES ]]; then
+    echo "Error: WORKER_NUM must be between 1 and $((SLURM_JOB_NUM_NODES-1))"
+    exit 1
+  fi
+  nodes_array=($nodes)
+  if [[ -n "\${COMMAND:-}" ]]; then
+    srun --no-container-mount-home -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-worker-\$WORKER_NUM --container-workdir=$CONTAINER_CWD --nodes=1 -w "\${nodes_array[\$WORKER_NUM]}" --jobid $SLURM_JOB_ID bash -c "\$COMMAND"
+  else
+    srun --no-container-mount-home -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-worker-\$WORKER_NUM --container-workdir=$CONTAINER_CWD --nodes=1 -w "\${nodes_array[\$WORKER_NUM]}" --jobid $SLURM_JOB_ID --pty bash
+  fi
+fi
+EOF
+  chmod +x $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh
+  echo "     COMMAND='echo hello' bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh    # run a non-interactive command on head node"
+  echo "     bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh    # to attach to head node (i.e., 'worker 0')"
+  echo "     bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh 1  # to attach to worker 1"
+  echo "     bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh 2  # to attach to worker 2, etc."
+  sleep infinity
+fi

--- a/container/run_full_tests.slurm
+++ b/container/run_full_tests.slurm
@@ -1,0 +1,111 @@
+#!/bin/bash
+#SBATCH --job-name=nemo-rl-full-tests
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=16
+#SBATCH --gpus-per-node=2
+#SBATCH --mem=64G
+#SBATCH --time=02:00:00
+#SBATCH --output=nemo_rl_full_tests_%j.out
+
+# NeMo-RL Full Test Suite
+# Runs all 984 unit tests with 2 GPUs
+#
+# Based on: https://github.com/NVIDIA-NeMo/RL/blob/main/docs/testing.md
+
+set -e
+
+# Parse command line arguments
+SQSH_FILE=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --sqsh)
+            SQSH_FILE="$2"
+            shift 2
+            ;;
+        *)
+            echo "ERROR: Unknown argument: $1"
+            echo ""
+            echo "Usage: sbatch run_full_tests.slurm [--sqsh <path>]"
+            echo ""
+            echo "Options:"
+            echo "  --sqsh <path>  Use specific .sqsh file instead of registry"
+            echo ""
+            echo "Examples:"
+            echo "  sbatch run_full_tests.slurm --sqsh /fsx/edward/docker_images/nemo-rl.sqsh"
+            exit 1
+            ;;
+    esac
+done
+
+# Set enroot environment variables
+export ENROOT_RUNTIME_PATH="${ENROOT_RUNTIME_PATH:-$HOME/.enroot/runtime}"
+export ENROOT_DATA_PATH="${ENROOT_DATA_PATH:-$HOME/.enroot/data}"
+export ENROOT_CACHE_PATH="${ENROOT_CACHE_PATH:-$HOME/.enroot/cache}"
+
+mkdir -p "$ENROOT_RUNTIME_PATH" "$ENROOT_DATA_PATH" "$ENROOT_CACHE_PATH"
+
+echo "========================================="
+echo "NeMo-RL Full Test Suite"
+echo "========================================="
+echo "Job ID: $SLURM_JOB_ID"
+echo "Node: $SLURM_NODELIST"
+echo "GPUs: $SLURM_GPUS_PER_NODE"
+echo "Started at: $(date)"
+echo "========================================="
+
+# Configuration
+IMAGE_NAME="nemo-rl"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+
+# Determine container image source
+if [ -n "$SQSH_FILE" ]; then
+    if [ ! -f "$SQSH_FILE" ]; then
+        echo "ERROR: .sqsh file not found: $SQSH_FILE"
+        exit 1
+    fi
+    CONTAINER_IMAGE="$SQSH_FILE"
+    echo "Using .sqsh file: $CONTAINER_IMAGE"
+else
+    REGISTRY="${REGISTRY}"
+    if [ -z "$REGISTRY" ]; then
+        echo "ERROR: REGISTRY environment variable not set"
+        echo "Please set it or use --sqsh option"
+        exit 1
+    fi
+    REGISTRY_IMAGE="${REGISTRY}/library/${IMAGE_NAME}:${IMAGE_TAG}"
+    CONTAINER_IMAGE="docker://${REGISTRY_IMAGE}"
+    echo "Using registry: $CONTAINER_IMAGE"
+fi
+
+echo "========================================="
+
+# Run full test suite
+echo ""
+echo "========================================="
+echo "Running full NeMo-RL test suite..."
+echo "This will run all 984 unit tests"
+echo "Expected time: 30-60 minutes"
+echo "========================================="
+echo ""
+
+srun --container-image="$CONTAINER_IMAGE" \
+     --container-mounts="/fsx:/fsx" \
+     --no-container-mount-home \
+     bash -c 'cd /opt/nemo-rl && uv run --group test bash tests/run_unit.sh'
+
+TEST_EXIT_CODE=$?
+
+echo ""
+if [ $TEST_EXIT_CODE -eq 0 ]; then
+    echo "========================================="
+    echo "✓ All tests passed!"
+    echo "========================================="
+else
+    echo "========================================="
+    echo "✗ Tests failed (exit code: $TEST_EXIT_CODE)"
+    echo "========================================="
+fi
+echo ""
+
+exit $TEST_EXIT_CODE

--- a/container/run_grpo.slurm
+++ b/container/run_grpo.slurm
@@ -1,0 +1,355 @@
+#!/bin/bash
+#SBATCH --job-name=nemo-rl-grpo
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --exclusive
+#SBATCH --gres=gpu:8
+#SBATCH --partition=hopper-prod
+#SBATCH --output=logs/%x-%j.out
+#SBATCH --error=logs/%x-%j.err
+#SBATCH --requeue
+#SBATCH --time=3-00:00:00
+
+# NeMo-RL GRPO Training with Ray Cluster (containerized)
+#
+# This script starts a Ray cluster inside a container and runs GRPO training.
+# Based on NeMo-RL's ray.sub and adapted for this cluster.
+#
+# Usage:
+#   Single node (8 GPUs, default 1B model):
+#     sbatch container/run_grpo.slurm
+#
+#   Multi-node (2 nodes, 16 GPUs):
+#     sbatch --nodes=2 container/run_grpo.slurm
+#
+#   Custom config:
+#     CONFIG_FILE=/path/to/config.yaml sbatch container/run_grpo.slurm
+#
+#   Custom config with overrides:
+#     EXTRA_OVERRIDES="grpo.max_num_steps=5 policy.model_name=Qwen/Qwen3-4B" sbatch container/run_grpo.slurm
+#
+#   Idle mode (just start Ray cluster, attach manually):
+#     COMMAND="" sbatch --nodes=2 container/run_grpo.slurm
+#
+#   Attach to running idle cluster:
+#     bash logs/nemo-rl-grpo-<jobid>.out  # prints attach instructions
+#     bash <jobid>-attach.sh              # shell into head node
+#     bash <jobid>-attach.sh 1            # shell into worker 1
+
+set -eoux pipefail
+
+# ==============================================================================
+# Configuration
+# ==============================================================================
+
+# Container
+CONTAINER="${CONTAINER:-/fsx/edward/docker_images/nemo-rl.sqsh}"
+NEMO_RL_SOURCE="${NEMO_RL_SOURCE:-/fsx/edward/work/scale-rl/nemo-rl}"
+MOUNTS="/fsx:/fsx,/scratch:/scratch,${NEMO_RL_SOURCE}:/opt/nemo-rl"
+
+# Training config
+CONFIG_FILE="${CONFIG_FILE:-}"
+CHECKPOINT_DIR="${CHECKPOINT_DIR:-/fsx/edward/checkpoints/nemo-rl/grpo}"
+EXTRA_OVERRIDES="${EXTRA_OVERRIDES:-}"
+
+# Build the training command
+if [[ -n "${COMMAND+x}" && -z "$COMMAND" ]]; then
+    # COMMAND="" explicitly set — idle mode
+    COMMAND=""
+elif [[ -n "${COMMAND:-}" ]]; then
+    # COMMAND set to something — use as-is
+    :
+else
+    # Default: run GRPO
+    COMMAND="cd /opt/nemo-rl && uv run python examples/run_grpo.py"
+    if [[ -n "$CONFIG_FILE" ]]; then
+        COMMAND+=" --config ${CONFIG_FILE}"
+    fi
+    COMMAND+=" cluster.num_nodes=${SLURM_NNODES:-1}"
+    COMMAND+=" cluster.gpus_per_node=8"
+    COMMAND+=" checkpointing.checkpoint_dir='${CHECKPOINT_DIR}'"
+    if [[ -n "$EXTRA_OVERRIDES" ]]; then
+        COMMAND+=" ${EXTRA_OVERRIDES}"
+    fi
+fi
+
+# Ray venv cache on persistent storage
+export NEMO_RL_VENV_DIR="/fsx/edward/.cache/nemo-rl/ray_venvs"
+
+# Ray settings
+export RAY_ENABLE_UV_RUN_RUNTIME_ENV=0
+export RAY_USAGE_STATS_ENABLED=0
+export RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+
+# Ray logging
+export RAY_BACKEND_LOG_LEVEL=${RAY_BACKEND_LOG_LEVEL:-info}
+export RAY_LOG_TO_STDERR=${RAY_LOG_TO_STDERR:-0}
+export RAY_logging_level=${RAY_logging_level:-INFO}
+export VLLM_LOGGING_LEVEL=${VLLM_LOGGING_LEVEL:-INFO}
+
+# ==============================================================================
+# Ray cluster ports
+# ==============================================================================
+NODE_MANAGER_PORT=${NODE_MANAGER_PORT:-53001}
+OBJECT_MANAGER_PORT=${OBJECT_MANAGER_PORT:-53003}
+RUNTIME_ENV_AGENT_PORT=${RUNTIME_ENV_AGENT_PORT:-53005}
+DASHBOARD_AGENT_GRPC_PORT=${DASHBOARD_AGENT_GRPC_PORT:-53007}
+METRICS_EXPORT_PORT=${METRICS_EXPORT_PORT:-53009}
+PORT=${PORT:-54514}
+RAY_CLIENT_SERVER_PORT=${RAY_CLIENT_SERVER_PORT:-10001}
+DASHBOARD_PORT=${DASHBOARD_PORT:-8265}
+DASHBOARD_AGENT_LISTEN_PORT=${DASHBOARD_AGENT_LISTEN_PORT:-52365}
+MIN_WORKER_PORT=${MIN_WORKER_PORT:-54001}
+MAX_WORKER_PORT=${MAX_WORKER_PORT:-54513}
+RAY_LOG_SYNC_FREQUENCY=${RAY_LOG_SYNC_FREQUENCY:-}
+RAY_DEBUGGER_ARGS=
+if [ "${RAY_DEBUG:-}" = "legacy" ]; then
+  RAY_DEBUGGER_ARGS="--ray-debugger-external"
+fi
+
+# ==============================================================================
+# Setup
+# ==============================================================================
+
+# Unset UV_CACHE_DIR to avoid local cache interfering with container cache
+unset UV_CACHE_DIR
+
+# Log directory
+mkdir -p logs
+LOG_DIR="logs/${SLURM_JOB_ID}-logs"
+mkdir -p "$LOG_DIR"
+
+GPUS_PER_NODE=8
+
+# ulimit per Ray best practices
+if [[ $(ulimit -Hn) == "unlimited" ]] || [[ 65535 -lt $(ulimit -Hn) ]]; then
+  ulimit -Sn 65535
+fi
+
+# srun common args
+COMMON_SRUN_ARGS=""
+COMMON_SRUN_ARGS+=" --gres=gpu:${GPUS_PER_NODE}"
+COMMON_SRUN_ARGS+=" --no-container-mount-home"
+COMMON_SRUN_ARGS+=" --mpi=pmix"
+COMMON_SRUN_ARGS+=" --container-mounts=$MOUNTS"
+COMMON_SRUN_ARGS+=" --container-image=$CONTAINER"
+COMMON_SRUN_ARGS+=" --container-workdir=$(pwd)"
+
+num_retries=3
+
+# Track backgrounded srun PIDs
+declare -A SRUN_PIDS
+
+check_srun_processes() {
+  for name in "${!SRUN_PIDS[@]}"; do
+    pid="${SRUN_PIDS[$name]}"
+    if ! kill -0 "$pid" 2>/dev/null; then
+      echo "[ERROR] Background srun '$name' died (pid=$pid)." >&2
+      touch "$LOG_DIR/ENDED"
+      exit 1
+    fi
+  done
+}
+
+# ==============================================================================
+# Resolve node IPs
+# ==============================================================================
+nodes=$(scontrol show hostnames "$SLURM_JOB_NODELIST")
+nodes_array=($nodes)
+ip_addresses_array=()
+
+for node in $nodes; do
+    ip_address=""
+    ip_address=$(host $node 2>/dev/null | awk '/has address/ { print $4 }' | head -1 || true)
+    if [[ -z "$ip_address" ]]; then
+        ip_address=$(getent hosts $node 2>/dev/null | awk '{ print $1 }' | head -1 || true)
+    fi
+    if [[ -z "$ip_address" ]]; then
+        ip_address=$node
+    fi
+    echo "[INFO] Node: $node -> IP: $ip_address"
+    ip_addresses_array+=("$ip_address")
+done
+
+head_node=${nodes_array[0]}
+head_node_ip=${ip_addresses_array[0]}
+ip_head=$head_node_ip:$PORT
+
+echo "========================================="
+echo "NeMo-RL GRPO Training"
+echo "========================================="
+echo "Job ID: $SLURM_JOB_ID"
+echo "Nodes: $SLURM_NNODES"
+echo "GPUs per node: $GPUS_PER_NODE"
+echo "Head node: $head_node ($head_node_ip)"
+echo "Container: $CONTAINER"
+echo "Config: ${CONFIG_FILE:-default (grpo_math_1B.yaml)}"
+echo "Command: ${COMMAND:-<idle>}"
+echo "Log dir: $LOG_DIR"
+echo "Started at: $(date)"
+echo "========================================="
+
+# ==============================================================================
+# Start Ray head node
+# ==============================================================================
+head_cmd=$(cat <<EOF
+touch $LOG_DIR/STARTED_RAY_HEAD
+export NEMO_RL_VENV_DIR=$NEMO_RL_VENV_DIR
+
+exit-dramatically() {
+    pkill -P \$\$ || true
+    kill -TERM 0 || true
+    exit 1
+}
+export -f exit-dramatically
+
+# Monitor sidecar
+(set +x; while true; do sleep 60; if [[ -f "$LOG_DIR/ENDED" ]]; then echo "ENDED detected"; exit-dramatically; fi; done) &
+
+# Log sync sidecar
+if [[ -n "$RAY_LOG_SYNC_FREQUENCY" ]]; then
+  (set +x; while true; do
+    sleep $RAY_LOG_SYNC_FREQUENCY
+    mkdir -p $LOG_DIR/ray
+    for d in /tmp/ray/session_[0-9]*/logs; do
+      [[ -d "\$d" ]] && rsync -a "\$d/" "$LOG_DIR/ray/\$(basename \$(dirname \$d))/logs/" 2>/dev/null || true
+    done
+    [[ -f "$LOG_DIR/ENDED" ]] && break
+  done) &
+fi
+
+ray start --head \
+    --disable-usage-stats \
+    --resources='{"worker_units": $GPUS_PER_NODE, "slurm_managed_ray_cluster": 1}' \
+    --node-ip-address="$head_node_ip" \
+    --port=${PORT} \
+    --ray-client-server-port=${RAY_CLIENT_SERVER_PORT} \
+    --dashboard-port=${DASHBOARD_PORT} \
+    --dashboard-host="$head_node_ip" \
+    --include-dashboard=True \
+    --node-manager-port=$((NODE_MANAGER_PORT + 1)) \
+    --object-manager-port=$((OBJECT_MANAGER_PORT + 1)) \
+    --runtime-env-agent-port=$((RUNTIME_ENV_AGENT_PORT + 1)) \
+    --dashboard-agent-grpc-port=$((DASHBOARD_AGENT_GRPC_PORT + 1)) \
+    --dashboard-agent-listen-port=$((DASHBOARD_AGENT_LISTEN_PORT + 1)) \
+    --metrics-export-port=$((METRICS_EXPORT_PORT + 1)) \
+    $RAY_DEBUGGER_ARGS \
+    --block
+EOF
+)
+
+srun $COMMON_SRUN_ARGS --container-name=ray-head --nodes=1 --ntasks=1 -w "$head_node" -o $LOG_DIR/ray-head.log bash -x -c "$head_cmd" &
+SRUN_PIDS["ray-head"]=$!
+
+NUM_ACTORS=$((GPUS_PER_NODE * SLURM_NNODES))
+
+# ==============================================================================
+# Start Ray worker nodes (if multi-node)
+# ==============================================================================
+for ((i = 1; i < SLURM_NNODES; i++)); do
+  node_i=${nodes_array[$i]}
+
+  worker_cmd=$(cat <<EOF
+export NEMO_RL_VENV_DIR=$NEMO_RL_VENV_DIR
+
+exit-dramatically() {
+    pkill -P \$\$ || true
+    kill -TERM 0 || true
+    exit 1
+}
+
+(set +x; while true; do sleep 60; if [[ -f "$LOG_DIR/ENDED" ]]; then echo "ENDED detected"; exit-dramatically; fi; done) &
+
+if [[ -n "$RAY_LOG_SYNC_FREQUENCY" ]]; then
+  (set +x; while true; do
+    sleep $RAY_LOG_SYNC_FREQUENCY
+    mkdir -p $LOG_DIR/ray/$node_i
+    for d in /tmp/ray/session_[0-9]*/logs; do
+      [[ -d "\$d" ]] && rsync -a "\$d/" "$LOG_DIR/ray/$node_i/\$(basename \$(dirname \$d))/logs/" 2>/dev/null || true
+    done
+    [[ -f "$LOG_DIR/ENDED" ]] && break
+  done) &
+fi
+
+ray start --address "$ip_head" \
+          --disable-usage-stats \
+          --resources='{"worker_units": $GPUS_PER_NODE, "slurm_managed_ray_cluster": 1}' \
+          --min-worker-port=${MIN_WORKER_PORT} \
+          --max-worker-port=${MAX_WORKER_PORT} \
+          --node-manager-port=${NODE_MANAGER_PORT} \
+          --object-manager-port=${OBJECT_MANAGER_PORT} \
+          --runtime-env-agent-port=${RUNTIME_ENV_AGENT_PORT} \
+          --dashboard-agent-grpc-port=${DASHBOARD_AGENT_GRPC_PORT} \
+          --dashboard-agent-listen-port=${DASHBOARD_AGENT_LISTEN_PORT} \
+          --metrics-export-port=${METRICS_EXPORT_PORT} \
+          $RAY_DEBUGGER_ARGS \
+          --block
+EOF
+)
+  srun $COMMON_SRUN_ARGS --container-name=ray-worker-$i --nodes=1 --ntasks=1 -w "$node_i" -o $LOG_DIR/ray-worker-$i.log bash -x -c "$worker_cmd" &
+  SRUN_PIDS["ray-worker-$i"]=$!
+  sleep 3
+done
+
+# ==============================================================================
+# Wait for Ray cluster to be ready
+# ==============================================================================
+while check_srun_processes && ! srun --overlap --nodes=1 --ntasks=1 -w $head_node test -f $LOG_DIR/STARTED_RAY_HEAD; do
+  echo "[INFO][$(date)] Waiting for head node container to start..."
+  sleep 2
+done
+
+extract_worker_units() {
+  status_output=$(srun --overlap --container-name=ray-head --nodes=1 --ntasks=1 -w "$head_node" ray status 2>/dev/null) || true
+  if echo "$status_output" | grep -q "worker_units"; then
+    echo "$status_output" | grep "worker_units" | awk -F'[/. ]' '{print $4}'
+  else
+    echo 0
+  fi
+}
+
+while true; do
+  worker_units=$(extract_worker_units)
+  echo "[INFO] Ray workers online: $worker_units/$NUM_ACTORS"
+  if [[ "$worker_units" -eq "$NUM_ACTORS" ]]; then
+    break
+  fi
+  check_srun_processes
+  sleep 2
+done
+
+echo "All Ray workers connected!"
+
+# ==============================================================================
+# Run training (or idle)
+# ==============================================================================
+CONTAINER_CWD=$(scontrol show job $SLURM_JOB_ID | grep -oP 'WorkDir=\K[^ ]+' | head -1)
+
+if [[ -n "$COMMAND" ]]; then
+  echo "Running: $COMMAND"
+  srun --no-container-mount-home --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "$head_node" -o $LOG_DIR/ray-driver.log bash -c "$COMMAND"
+else
+  echo "[INFO] Ray cluster is idle. To attach:"
+  cat <<EOF >${SLURM_JOB_ID}-attach.sh
+WORKER_NUM=\${1:-}
+if [[ -z "\$WORKER_NUM" ]]; then
+  if [[ -n "\${COMMAND:-}" ]]; then
+    srun --no-container-mount-home --gres=gpu:${GPUS_PER_NODE} --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "$head_node" --jobid $SLURM_JOB_ID bash -c "\$COMMAND"
+  else
+    srun --no-container-mount-home --gres=gpu:${GPUS_PER_NODE} --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "$head_node" --jobid $SLURM_JOB_ID --pty bash
+  fi
+else
+  nodes_array=($nodes)
+  if [[ -n "\${COMMAND:-}" ]]; then
+    srun --no-container-mount-home --gres=gpu:${GPUS_PER_NODE} --overlap --container-name=ray-worker-\$WORKER_NUM --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "\${nodes_array[\$WORKER_NUM]}" --jobid $SLURM_JOB_ID bash -c "\$COMMAND"
+  else
+    srun --no-container-mount-home --gres=gpu:${GPUS_PER_NODE} --overlap --container-name=ray-worker-\$WORKER_NUM --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "\${nodes_array[\$WORKER_NUM]}" --jobid $SLURM_JOB_ID --pty bash
+  fi
+fi
+EOF
+  chmod +x ${SLURM_JOB_ID}-attach.sh
+  echo "  bash ${SLURM_JOB_ID}-attach.sh          # head node shell"
+  echo "  bash ${SLURM_JOB_ID}-attach.sh 1         # worker 1 shell"
+  echo "  COMMAND='ray status' bash ${SLURM_JOB_ID}-attach.sh  # run command"
+  sleep infinity
+fi

--- a/container/run_grpo.slurm
+++ b/container/run_grpo.slurm
@@ -133,7 +133,7 @@ COMMON_SRUN_ARGS+=" --no-container-mount-home"
 COMMON_SRUN_ARGS+=" --mpi=pmix"
 COMMON_SRUN_ARGS+=" --container-mounts=$MOUNTS"
 COMMON_SRUN_ARGS+=" --container-image=$CONTAINER"
-COMMON_SRUN_ARGS+=" --container-workdir=$(pwd)"
+COMMON_SRUN_ARGS+=" --container-workdir=/opt/nemo-rl"
 
 num_retries=3
 
@@ -323,7 +323,7 @@ echo "All Ray workers connected!"
 # ==============================================================================
 # Run training (or idle)
 # ==============================================================================
-CONTAINER_CWD=$(scontrol show job $SLURM_JOB_ID | grep -oP 'WorkDir=\K[^ ]+' | head -1)
+CONTAINER_CWD=/opt/nemo-rl
 
 if [[ -n "$COMMAND" ]]; then
   echo "Running: $COMMAND"

--- a/container/run_multinode.slurm
+++ b/container/run_multinode.slurm
@@ -1,0 +1,165 @@
+#!/bin/bash
+#SBATCH --job-name=nemo-rl-train
+#SBATCH --nodes=2
+#SBATCH --qos=high
+#SBATCH --partition=hopper-prod
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=8
+#SBATCH --cpus-per-task=88
+#SBATCH --time=24:00:00
+#SBATCH --output=logs/nemo_rl_train_%j.out
+#SBATCH --exclusive
+
+set -e -x
+
+
+# ==============================================================================
+# Configuration - Customize these variables
+# ==============================================================================
+
+# Container configuration
+export CONTAINER="/fsx/edward/docker_images/nemo-rl.sqsh"
+
+# Mount points for container
+# Overlay /opt/nemo-rl with local development copy for live code updates
+export MOUNTS="/fsx:/fsx,/scratch:/scratch,/fsx/edward/work/scale-rl/nemo-rl:/opt/nemo-rl"
+
+# NeMo-RL configuration
+CONFIG_FILE="${CONFIG_FILE:-/fsx/edward/work/scale-rl/nemo-rl/container/configs/grpo-qwen3-4b-thinking-2n8g-fsdp2tp1-noncolocated-fast.yaml}"
+CHECKPOINT_DIR="${CHECKPOINT_DIR:-/fsx/edward/checkpoints/nemo-rl/grpo_test_fast}"
+WANDB_ENABLED="${WANDB_ENABLED:-true}"
+
+# Optional: Set HF_TOKEN before running if using gated models
+# export HF_TOKEN="your_token_here"
+
+# Optional: Ray configuration
+export GPUS_PER_NODE=${GPUS_PER_NODE:-8}
+export CPUS_PER_NODE=${CPUS_PER_NODE:-88}  # CPUs per node (default 88 for H100 nodes)
+# export RAY_LOG_SYNC_FREQUENCY=300  # Sync Ray logs every 5 minutes
+
+# Enhanced Ray Logging for Debugging
+export RAY_BACKEND_LOG_LEVEL=${RAY_BACKEND_LOG_LEVEL:-info}     # C++ backend logging: debug, info, warning, error
+export RAY_LOG_TO_STDERR=${RAY_LOG_TO_STDERR:-0}                # Set to 1 to log Python side to stderr
+export RAY_logging_level=${RAY_logging_level:-INFO}             # Python logging: DEBUG, INFO, WARNING, ERROR
+export VLLM_LOGGING_LEVEL=${VLLM_LOGGING_LEVEL:-INFO}           # vLLM logging: DEBUG, INFO, WARNING, ERROR
+
+# Override Dockerfile's NEMO_RL_VENV_DIR to use persistent /fsx storage
+# (Dockerfile sets it to /opt/ray_venvs which gets deleted on container restart)
+export NEMO_RL_VENV_DIR="/fsx/edward/.cache/nemo-rl/ray_venvs"
+
+# Path to ray.sub (using patched version with CPU allocation fix)
+RAY_SUB_SCRIPT="/fsx/edward/work/scale-rl/nemo-rl/container/ray_patched.sub"
+
+# ==============================================================================
+# Build command to run inside Ray cluster
+# ==============================================================================
+
+export COMMAND="cd /opt/nemo-rl && uv run python examples/run_grpo_math.py \
+  --config ${CONFIG_FILE} \
+  checkpointing.checkpoint_dir='${CHECKPOINT_DIR}' \
+  logger.wandb_enabled=${WANDB_ENABLED}"
+
+# ==============================================================================
+# Dual Mode: Run on existing allocation OR submit new job
+# ==============================================================================
+
+if [ -n "$1" ]; then
+    # =========================================================================
+    # MODE 1: Run on existing job allocation using ray.sub
+    # =========================================================================
+    JOBID="$1"
+
+    # Query job info
+    JOB_INFO=$(scontrol show job -o "$JOBID")
+
+    # Extract job details
+    SLURM_NNODES=$(echo "$JOB_INFO" | tr ' ' '\n' | awk -F= '$1=="NumNodes"{print $2}')
+    SLURM_GPUS_PER_NODE=$(echo "$JOB_INFO" | grep -oP 'TresPerNode=gres:gpu:\K\d+' || echo "8")
+    SLURM_NODELIST=$(echo "$JOB_INFO" | grep -oP '\bNodeList=\K[^ ]+' | head -1)
+    SLURM_ACCOUNT=$(echo "$JOB_INFO" | tr ' ' '\n' | awk -F= '$1=="Account"{print $2}')
+    SLURM_PARTITION=$(echo "$JOB_INFO" | tr ' ' '\n' | awk -F= '$1=="Partition"{print $2}')
+
+    # Create timestamped log directory
+    DATETIME=$(date +%Y%m%d_%H%M%S)
+    RAY_LOG_DIR="${JOBID}-${DATETIME}-logs"
+    LOGFILE="logs/nemo_rl_train_${DATETIME}_${JOBID}.log"
+    mkdir -p $(dirname "$LOGFILE")
+
+    echo "=========================================" | tee "$LOGFILE"
+    echo "NeMo-RL Training with Ray Cluster" | tee -a "$LOGFILE"
+    echo "Mode: Using existing allocation with ray.sub" | tee -a "$LOGFILE"
+    echo "=========================================" | tee -a "$LOGFILE"
+    echo "Job ID: $JOBID" | tee -a "$LOGFILE"
+    echo "Nodes: $SLURM_NNODES" | tee -a "$LOGFILE"
+    echo "GPUs per node: $SLURM_GPUS_PER_NODE" | tee -a "$LOGFILE"
+    echo "Container: ${CONTAINER}" | tee -a "$LOGFILE"
+    echo "Config: ${CONFIG_FILE}" | tee -a "$LOGFILE"
+    echo "Checkpoint dir: ${CHECKPOINT_DIR}" | tee -a "$LOGFILE"
+    echo "Started at: $(date)" | tee -a "$LOGFILE"
+    echo "Log file: $LOGFILE" | tee -a "$LOGFILE"
+    echo "Ray logs: $RAY_LOG_DIR" | tee -a "$LOGFILE"
+    echo "=========================================" | tee -a "$LOGFILE"
+    echo "" | tee -a "$LOGFILE"
+
+    # Set SLURM environment variables that ray.sub expects
+    # These are normally set by sbatch but need to be explicit with salloc
+    export SLURM_SUBMIT_DIR="$(pwd)"
+    export SLURM_JOB_ID="$JOBID"
+    export SLURM_JOB_NUM_NODES="$SLURM_NNODES"
+    export SLURM_JOB_NODELIST="$SLURM_NODELIST"
+    export SLURM_JOB_ACCOUNT="$SLURM_ACCOUNT"
+    export SLURM_JOB_PARTITION="$SLURM_PARTITION"
+
+    # Set custom log directory with datetime for ray.sub (under logs/)
+    export BASE_LOG_DIR="${SLURM_SUBMIT_DIR}/logs"
+    export LOG_DIR="${BASE_LOG_DIR}/${RAY_LOG_DIR}"
+
+    # Fix Ray CPU detection in containers
+    # Ray's container CPU detection is incorrect and only sees ~2 CPUs
+    # This env var tells Ray to use multiprocessing.cpu_count() instead
+    export RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+
+    # Clean up any stale ENDED file from previous runs
+    # This file is used by ray.sub to signal termination, and if left from a previous run
+    # it will cause the new run to immediately terminate
+    ENDED_FILE="${LOG_DIR}/ENDED"
+    if [ -f "$ENDED_FILE" ]; then
+        echo "Removing stale ENDED file from previous run: $ENDED_FILE" | tee -a "$LOGFILE"
+        rm -f "$ENDED_FILE"
+    fi
+
+    # Run ray.sub as a bash script (not via srun or source)
+    # This allows ray.sub to execute its internal srun commands properly
+    bash "$RAY_SUB_SCRIPT" 2>&1 | tee -a "$LOGFILE"
+
+else
+    # =========================================================================
+    # MODE 2: Submit new job via sbatch
+    # =========================================================================
+
+    # Set SLURM_SUBMIT_DIR if not already set (when running outside sbatch)
+    export SLURM_SUBMIT_DIR="${SLURM_SUBMIT_DIR:-$(pwd)}"
+    # All logs go under logs/ directory
+    export BASE_LOG_DIR="${SLURM_SUBMIT_DIR}/logs"
+
+    # Fix Ray CPU detection in containers
+    export RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+
+    echo "========================================="
+    echo "NeMo-RL Training with Ray Cluster"
+    echo "Mode: Submitting new job via sbatch"
+    echo "========================================="
+    echo "Nodes: ${SLURM_JOB_NUM_NODES:-2}"
+    echo "GPUs per node: ${GPUS_PER_NODE}"
+    echo "Container: ${CONTAINER}"
+    echo "Config: ${CONFIG_FILE}"
+    echo "Checkpoint dir: ${CHECKPOINT_DIR}"
+    echo "Started at: $(date)"
+    echo "Ray logs will be in: ${BASE_LOG_DIR}/\${SLURM_JOB_ID}-<datetime>-logs"
+    echo "========================================="
+    echo ""
+
+    # Source the ray.sub script inline to inherit SLURM environment
+    # ray.sub will create LOG_DIR as ${BASE_LOG_DIR}/${SLURM_JOB_ID}-logs
+    source "$RAY_SUB_SCRIPT"
+fi

--- a/container/test_container.slurm
+++ b/container/test_container.slurm
@@ -1,0 +1,232 @@
+#!/bin/bash
+#SBATCH --job-name=nemo-rl-test
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --gpus-per-node=1
+#SBATCH --mem=32G
+#SBATCH --time=00:30:00
+#SBATCH --output=nemo_rl_test_%j.out
+
+# NeMo-RL Container Test Script
+# This script tests the NeMo-RL container from the registry
+#
+# Prerequisites:
+#   1. Docker image must be built and pushed to registry first
+#   2. Run build_container.sh on login node before submitting this job
+#
+# Based on: https://github.com/NVIDIA-NeMo/RL
+
+set -e
+
+# Parse command line arguments
+SQSH_FILE=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --sqsh)
+            SQSH_FILE="$2"
+            shift 2
+            ;;
+        *)
+            echo "ERROR: Unknown argument: $1"
+            echo ""
+            echo "Usage: sbatch test_container.slurm [--sqsh <path>]"
+            echo ""
+            echo "Options:"
+            echo "  --sqsh <path>  Use specific .sqsh file instead of registry"
+            echo ""
+            echo "Examples:"
+            echo "  sbatch test_container.slurm"
+            echo "  sbatch test_container.slurm --sqsh /fsx/edward/docker_images/nemo-rl.sqsh"
+            exit 1
+            ;;
+    esac
+done
+
+# Set enroot environment variables to use writable locations
+export ENROOT_RUNTIME_PATH="${ENROOT_RUNTIME_PATH:-$HOME/.enroot/runtime}"
+export ENROOT_DATA_PATH="${ENROOT_DATA_PATH:-$HOME/.enroot/data}"
+export ENROOT_CACHE_PATH="${ENROOT_CACHE_PATH:-$HOME/.enroot/cache}"
+
+# Create directories if they don't exist
+mkdir -p "$ENROOT_RUNTIME_PATH" "$ENROOT_DATA_PATH" "$ENROOT_CACHE_PATH"
+
+echo "========================================="
+echo "NeMo-RL Container Test"
+echo "========================================="
+echo "Job ID: $SLURM_JOB_ID"
+echo "Node: $SLURM_NODELIST"
+echo "Started at: $(date)"
+echo "========================================="
+
+# Configuration
+IMAGE_NAME="nemo-rl"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+
+# Determine container image source
+if [ -n "$SQSH_FILE" ]; then
+    # Use provided .sqsh file
+    if [ ! -f "$SQSH_FILE" ]; then
+        echo "ERROR: .sqsh file not found: $SQSH_FILE"
+        exit 1
+    fi
+    CONTAINER_IMAGE="$SQSH_FILE"
+    echo "Configuration:"
+    echo "  Using .sqsh file: $CONTAINER_IMAGE"
+    echo "========================================="
+else
+    # Use registry (requires REGISTRY env var)
+    REGISTRY="${REGISTRY}"
+
+    # Validate required environment variables
+    if [ -z "$REGISTRY" ]; then
+        echo "ERROR: REGISTRY environment variable not set"
+        echo ""
+        echo "Please set it before submitting this job:"
+        echo "  export REGISTRY=registry.hpc-cluster-hopper.hpc.internal.huggingface.tech"
+        echo "  sbatch test_container.slurm"
+        echo ""
+        echo "Or use --sqsh to specify a .sqsh file directly:"
+        echo "  sbatch test_container.slurm --sqsh /path/to/nemo-rl.sqsh"
+        exit 1
+    fi
+
+    REGISTRY_IMAGE="${REGISTRY}/library/${IMAGE_NAME}:${IMAGE_TAG}"
+    CONTAINER_IMAGE="docker://${REGISTRY_IMAGE}"
+
+    echo "Configuration:"
+    echo "  Registry: $REGISTRY"
+    echo "  Testing image: $REGISTRY_IMAGE"
+    echo "  Container URI: $CONTAINER_IMAGE"
+    echo "========================================="
+fi
+
+# Check if enroot/pyxis is available (srun with --container-image requires it)
+if ! command -v enroot &> /dev/null; then
+    echo "WARNING: enroot command not found"
+    echo "This script requires Pyxis/Enroot for SLURM container support"
+fi
+
+# Run verification tests using srun with Pyxis
+echo ""
+echo "========================================="
+echo "Running verification tests..."
+echo "========================================="
+
+srun --container-image="$CONTAINER_IMAGE" \
+     --container-mounts="/fsx:/fsx" \
+     --no-container-mount-home \
+     bash <<'OUTER_EOF'
+cd /opt/nemo-rl && uv run python <<'INNER_EOF'
+import sys
+
+tests_passed = 0
+tests_failed = 0
+
+# Test 1: NeMo-RL
+print("\nTest 1: Checking NeMo-RL installation...")
+try:
+    import nemo_rl
+    print(f"✓ NeMo-RL version: {nemo_rl.__version__}")
+    tests_passed += 1
+except Exception as e:
+    print(f"✗ NeMo-RL import failed: {e}")
+    tests_failed += 1
+
+# Test 2: PyTorch and CUDA
+print("\nTest 2: Checking PyTorch and CUDA...")
+try:
+    import torch
+    print(f"✓ PyTorch version: {torch.__version__}")
+    print(f"  CUDA available: {torch.cuda.is_available()}")
+    if torch.cuda.is_available():
+        print(f"  CUDA version: {torch.version.cuda}")
+        print(f"  CUDA devices: {torch.cuda.device_count()}")
+    tests_passed += 1
+except Exception as e:
+    print(f"✗ PyTorch check failed: {e}")
+    tests_failed += 1
+
+# Test 3: Ray
+print("\nTest 3: Checking Ray installation...")
+try:
+    import ray
+    print(f"✓ Ray version: {ray.__version__}")
+    tests_passed += 1
+except Exception as e:
+    print(f"✗ Ray import failed: {e}")
+    tests_failed += 1
+
+# Test 4: vLLM (optional backend)
+print("\nTest 4: Checking vLLM installation (optional)...")
+try:
+    import vllm
+    print(f"✓ vLLM version: {vllm.__version__}")
+    tests_passed += 1
+except Exception as e:
+    print(f"⚠️  vLLM not available (optional - requires 'uv run --extra vllm')")
+    # Don't count as failure since it's optional
+    tests_passed += 1
+
+# Test 5: Transformers
+print("\nTest 5: Checking transformers installation...")
+try:
+    import transformers
+    print(f"✓ Transformers version: {transformers.__version__}")
+    tests_passed += 1
+except Exception as e:
+    print(f"✗ Transformers import failed: {e}")
+    tests_failed += 1
+
+# Test 6: Verify pytest test collection works
+print("\nTest 6: Checking test framework...")
+try:
+    import subprocess
+    import re
+
+    # Collect tests to verify pytest works
+    collect_result = subprocess.run(
+        ["uv", "run", "--group", "test", "pytest", "--collect-only", "-q", "tests/unit"],
+        capture_output=True,
+        text=True,
+        timeout=60
+    )
+
+    if collect_result.returncode == 0:
+        match = re.search(r"(\d+) tests? collected", collect_result.stdout)
+        test_count = int(match.group(1)) if match else 0
+        print(f"✓ Test framework functional ({test_count} tests available)")
+        tests_passed += 1
+    else:
+        print(f"✗ Test collection failed")
+        tests_failed += 1
+
+except subprocess.TimeoutExpired:
+    print(f"⚠️  Test collection slow but container is functional")
+    tests_passed += 1
+except Exception as e:
+    print(f"✗ Test framework check failed: {e}")
+    tests_failed += 1
+
+# Summary
+print(f"\n{'='*50}")
+print(f"Tests passed: {tests_passed}/6")
+print(f"Tests failed: {tests_failed}/6")
+print(f"{'='*50}")
+
+if tests_failed > 0:
+    sys.exit(1)
+INNER_EOF
+OUTER_EOF
+
+if [ $? -ne 0 ]; then
+    echo ""
+    echo "✗ Container validation failed"
+    exit 1
+fi
+
+echo ""
+echo "========================================="
+echo "✓ Container validation passed!"
+echo "========================================="
+echo ""

--- a/docs/design-docs/logger.md
+++ b/docs/design-docs/logger.md
@@ -1,6 +1,6 @@
 # Logger
 
-The logger is designed to track key training metrics (including distributed metrics with reductions and timing), as well as providing integration with logging backends like WandB, Tensorboard, MLflow and Swanlab.
+The logger is designed to track key training metrics (including distributed metrics with reductions and timing), as well as providing integration with logging backends like WandB, Trackio, Tensorboard, MLflow and Swanlab.
 
 ## Requirements
 
@@ -8,6 +8,7 @@ The logger is designed to track key training metrics (including distributed metr
 * Tracking distributed timing with (usually) 'max' reduction across ranks
 * Logging:
    * WandB
+   * Trackio
    * Tensorboard
    * MLflow
    * Swanlab
@@ -16,7 +17,7 @@ The logger is designed to track key training metrics (including distributed metr
 
 Since there is a single controller, the single process running the main training loop will gather the metrics and do the logging.
 
-To handle multiple logger backends, we will have a {py:class}`LoggerInterface <nemo_rl.utils.logger.LoggerInterface>` interface that the {py:class}`TensorboardLogger <nemo_rl.utils.logger.TensorboardLogger>`, {py:class}`WandbLogger <nemo_rl.utils.logger.WandbLogger>`, {py:class}`MLflowLogger <nemo_rl.utils.logger.MLflowLogger>` and {py:class}`SwanlabLogger <nemo_rl.utils.logger.SwanlabLogger>` will implement:
+To handle multiple logger backends, we will have a {py:class}`LoggerInterface <nemo_rl.utils.logger.LoggerInterface>` interface that the {py:class}`TensorboardLogger <nemo_rl.utils.logger.TensorboardLogger>`, {py:class}`WandbLogger <nemo_rl.utils.logger.WandbLogger>`, {py:class}`TrackioLogger <nemo_rl.utils.logger.TrackioLogger>`, {py:class}`MLflowLogger <nemo_rl.utils.logger.MLflowLogger>` and {py:class}`SwanlabLogger <nemo_rl.utils.logger.SwanlabLogger>` will implement:
 
 ```python
 class LoggerInterface(ABC):
@@ -36,15 +37,27 @@ class LoggerInterface(ABC):
 A {py:class}`Logger <nemo_rl.utils.logger.Logger>` wrapper class will also implement {py:class}`LoggerInterface <nemo_rl.utils.logger.LoggerInterface>` and maintain a list of loggers to which it delegates writing logs. This will be the main class the user uses in the training loop. Usage example:
 
 ```python
-# Initialize logger with wandb, tensorboard, mlflow and swanlab enabled
+# Initialize logger with wandb, trackio, tensorboard, mlflow and swanlab enabled
 logging_config = {
     "wandb_enabled": True,
+    "trackio_enabled": False,
     "tensorboard_enabled": False,
     "mlflow_enabled": True,
 
     "wandb": {
         "project": "grpo-dev",
         "name": "grpo-dev-logging",
+    },
+    "trackio": {
+        "project": "grpo-dev",
+        "name": "grpo-dev-logging",
+        "space_id": None,
+        "server_url": None,
+        "bucket_id": None,
+        "resume": "never",
+        "embed": False,
+        "auto_log_gpu": False,
+        "dir": None,
     },
     "swanlab": {
         "project": "nemo-rl",
@@ -71,13 +84,63 @@ logger.log_metrics({
 
 ## Supported Logging Backends
 
-The logger supports three main logging backends:
+The logger supports five logging backends:
 
 ### WandB (Weights & Biases)
 - Provides cloud-based experiment tracking
 - Supports custom step metrics for better visualization
 - Includes built-in hyperparameter logging
 - Offers rich visualization and collaboration features
+
+### Trackio
+- Local-first experiment tracking with optional Hugging Face Spaces or self-hosted server logging
+- Uses an optional dependency extra and can be enabled independently of WandB
+- Supports scalar metrics, hyperparameters, matplotlib figures as images, and histograms
+
+#### Trackio Configuration
+
+Trackio is an optional dependency. Install it before enabling the backend:
+
+```bash
+uv sync --extra trackio
+```
+
+Then enable it in a run:
+
+```bash
+uv run --extra trackio examples/run_grpo.py \
+  logger.trackio_enabled=true \
+  logger.trackio.project=nemo-rl \
+  logger.trackio.name=grpo-trackio
+```
+
+Trackio can be configured with the following parameters:
+
+```python
+trackio:
+  project: "nemo-rl"
+  name: "grpo-trackio"
+  group: null
+  space_id: null       # Optional Hugging Face Space, e.g. "username/space"
+  server_url: null     # Optional self-hosted Trackio server URL
+  bucket_id: null      # Optional Hugging Face Bucket for Space persistence
+  resume: "never"
+  private: null
+  embed: false
+  auto_log_gpu: false  # Keep false when using NeMo RL's Ray GPU monitor
+  gpu_log_interval: 10.0
+  webhook_url: null
+  webhook_min_level: null
+  dir: null            # Optional TRACKIO_DIR override
+```
+
+For local runs, view results with:
+
+```bash
+trackio show --project nemo-rl
+```
+
+By default, local Trackio project databases are stored under `TRACKIO_DIR`, which defaults to `~/.cache/huggingface/trackio`. Set `logger.trackio.dir` to use a run-specific local storage directory.
 
 ### Swanlab
 - Training visualization (Android, iOS, Wechat public account and Web)
@@ -159,6 +222,7 @@ The logger supports pretty-formatted logging of validation samples to help visua
 ```python
 logger:
   wandb_enabled: false
+  trackio_enabled: false
   swanlab_enabled: false
   tensorboard_enabled: false
   mlflow_enabled: false
@@ -179,7 +243,7 @@ When enabled, the pretty logging will generate formatted text similar to:
 
 ## GPU Metric Logging
 
-NeMo RL monitors GPU memory and utilization through [system metrics](https://docs.ray.io/en/latest/ray-observability/reference/system-metrics.html#system-metrics) exposed by Ray nodes. While Ray makes these metrics available for tools like Prometheus, NeMo RL directly polls GPU memory and utilization data and logs them to TensorBoard, WandB, MLflow and/or SwanLab.
+NeMo RL monitors GPU memory and utilization through [system metrics](https://docs.ray.io/en/latest/ray-observability/reference/system-metrics.html#system-metrics) exposed by Ray nodes. While Ray makes these metrics available for tools like Prometheus, NeMo RL directly polls GPU memory and utilization data and logs them to TensorBoard, WandB, Trackio, MLflow and/or SwanLab.
 
 This approach allows us to offer the same GPU metric tracking on all loggers and simplifies the implementation greatly.
 
@@ -188,6 +252,7 @@ This feature is enabled with the `monitor_gpus` configuration parameter. The fre
 ```python
 logger:
   wandb_enabled: false
+  trackio_enabled: false
   swanlab_enabled: false
   tensorboard_enabled: false
   mlflow_enabled: false
@@ -202,7 +267,7 @@ logger:
 > * Logs sent back to the driver do not introduce significant overhead.
 > * Metrics remain clear and interpretable, avoiding issues like double counting caused by colocated workers.
 > * Workers can gracefully flush their logs in case of failure.
-> * Logging behaves consistently across TensorBoard, WandB, MLflow and Swanlab.
+> * Logging behaves consistently across TensorBoard, WandB, Trackio, MLflow and Swanlab.
 > * Workers that spawn other workers accurately report the total resource usage of any grandchild workers.
 >
 > Due to these complexities, we opted for a simpler approach: collecting metrics exposed by the Ray metrics server from the driver.

--- a/examples/configs/distillation_math.yaml
+++ b/examples/configs/distillation_math.yaml
@@ -241,6 +241,7 @@ logger:
     log_dir: "logs/distillation"
     num_val_samples_to_print: 5
     wandb_enabled: true
+    trackio_enabled: false # Install with `uv sync --extra trackio` before enabling
     tensorboard_enabled: true
     mlflow_enabled: false
     swanlab_enabled: false
@@ -248,6 +249,21 @@ logger:
     wandb:
         project: "nemo-distillation"
         name: "distillation-${data.train.dataset_name}-${teacher.model_name}-${policy.model_name}-${loss_fn.kl_type}-${distillation.topk_logits_k}"
+    trackio:
+        project: "nemo-distillation"
+        name: "distillation-${data.train.dataset_name}-${teacher.model_name}-${policy.model_name}-${loss_fn.kl_type}-${distillation.topk_logits_k}"
+        group: null
+        space_id: null
+        server_url: null
+        bucket_id: null
+        resume: "never"
+        private: null
+        embed: false
+        auto_log_gpu: false
+        gpu_log_interval: 10.0
+        webhook_url: null
+        webhook_min_level: null
+        dir: null
     swanlab:
         project: "nemo-distillation"
         name: "distillation-${data.train.dataset_name}-${teacher.model_name}-${policy.model_name}-${loss_fn.kl_type}-${distillation.topk_logits_k}"

--- a/examples/configs/dpo.yaml
+++ b/examples/configs/dpo.yaml
@@ -269,6 +269,7 @@ data:
 logger:
   log_dir: "logs"  # Base directory for all logs
   wandb_enabled: false # Make sure you do a ``wandb login [Your API key]'' before running
+  trackio_enabled: false # Install with `uv sync --extra trackio` before enabling
 
   tensorboard_enabled: false
   mlflow_enabled: false  # Disable MLflow logging
@@ -278,6 +279,21 @@ logger:
   wandb:
     project: "dpo-dev"
     name: "dpo"
+  trackio:
+    project: "dpo-dev"
+    name: "dpo"
+    group: null
+    space_id: null
+    server_url: null
+    bucket_id: null
+    resume: "never"
+    private: null
+    embed: false
+    auto_log_gpu: false
+    gpu_log_interval: 10.0
+    webhook_url: null
+    webhook_min_level: null
+    dir: null
   swanlab:
     project: "dpo-dev"
     name: "dpo"

--- a/examples/configs/gdpo_math_1B.yaml
+++ b/examples/configs/gdpo_math_1B.yaml
@@ -54,6 +54,9 @@ logger:
   wandb:
     project: "gdpo-dev"
     name: "gdpo-dev-logger"
+  trackio:
+    project: "gdpo-dev"
+    name: "gdpo-dev-logger"
   swanlab:
     project: "gdpo-dev"
     name: "gdpo-dev-logger"

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -368,6 +368,7 @@ logger:
   log_dir: "logs"  # Base directory for all logs
   num_val_samples_to_print: 0 # Number of validation samples to pretty print on terminal
   wandb_enabled: false
+  trackio_enabled: false # Install with `uv sync --extra trackio` before enabling
   tensorboard_enabled: false
   mlflow_enabled: false  # Disable MLflow logging
   swanlab_enabled: false # Disable SwanLab logging
@@ -375,6 +376,21 @@ logger:
   wandb:
     project: "grpo-dev"
     name: "grpo-dev-logger"
+  trackio:
+    project: "grpo-dev"
+    name: "grpo-dev-logger"
+    group: null
+    space_id: null
+    server_url: null
+    bucket_id: null
+    resume: "never"
+    private: null
+    embed: false
+    auto_log_gpu: false
+    gpu_log_interval: 10.0
+    webhook_url: null
+    webhook_min_level: null
+    dir: null
   swanlab:
     project: "grpo-dev"
     name: "grpo-dev-logger"

--- a/examples/configs/grpo_sliding_puzzle.yaml
+++ b/examples/configs/grpo_sliding_puzzle.yaml
@@ -61,6 +61,7 @@ logger:
   log_dir: "logs"  # Base directory for all logs
   num_val_samples_to_print: 0 # Number of validation samples to pretty print on terminal
   wandb_enabled: false
+  trackio_enabled: false # Install with `uv sync --extra trackio` before enabling
   tensorboard_enabled: false
   mlflow_enabled: false
   swanlab_enabled: false # Disable SwanLab logging
@@ -68,6 +69,21 @@ logger:
   wandb:
     project: "grpo-dev"
     name: "grpo-dev-sliding_puzzle"
+  trackio:
+    project: "grpo-dev"
+    name: "grpo-dev-sliding_puzzle"
+    group: null
+    space_id: null
+    server_url: null
+    bucket_id: null
+    resume: "never"
+    private: null
+    embed: false
+    auto_log_gpu: false
+    gpu_log_interval: 10.0
+    webhook_url: null
+    webhook_min_level: null
+    dir: null
   swanlab:
     project: "grpo-dev"
     name: "grpo-dev-sliding_puzzle"

--- a/examples/configs/rm.yaml
+++ b/examples/configs/rm.yaml
@@ -196,6 +196,7 @@ data:
 logger:
   log_dir: "logs"  # Base directory for all logs
   wandb_enabled: true # Make sure you do a ``wandb login [Your API key]'' before running
+  trackio_enabled: false # Install with `uv sync --extra trackio` before enabling
   tensorboard_enabled: true
   mlflow_enabled: false
   swanlab_enabled: false # Disable SwanLab logging
@@ -203,6 +204,21 @@ logger:
   wandb:
     project: "rm-dev"
     name: "rm-dev-${data.train.dataset_name}"
+  trackio:
+    project: "rm-dev"
+    name: "rm-dev-${data.train.dataset_name}"
+    group: null
+    space_id: null
+    server_url: null
+    bucket_id: null
+    resume: "never"
+    private: null
+    embed: false
+    auto_log_gpu: false
+    gpu_log_interval: 10.0
+    webhook_url: null
+    webhook_min_level: null
+    dir: null
   swanlab:
     project: "rm-dev"
     name: "rm-dev-${data.train.dataset_name}"

--- a/examples/configs/sft.yaml
+++ b/examples/configs/sft.yaml
@@ -246,6 +246,7 @@ data:
 logger:
   log_dir: "logs"  # Base directory for all logs
   wandb_enabled: true # Make sure you do a ``wandb login [Your API key]'' before running
+  trackio_enabled: false # Install with `uv sync --extra trackio` before enabling
   tensorboard_enabled: true
   mlflow_enabled: false
   swanlab_enabled: false # Disable SwanLab logging
@@ -253,6 +254,21 @@ logger:
   wandb:
     project: "sft-dev"
     name: "sft-dev-${data.train.dataset_name}"
+  trackio:
+    project: "sft-dev"
+    name: "sft-dev-${data.train.dataset_name}"
+    group: null
+    space_id: null
+    server_url: null
+    bucket_id: null
+    resume: "never"
+    private: null
+    embed: false
+    auto_log_gpu: false
+    gpu_log_interval: 10.0
+    webhook_url: null
+    webhook_min_level: null
+    dir: null
   swanlab:
     project: "sft-dev"
     name: "sft-dev-${data.train.dataset_name}"

--- a/examples/nemo_gym/run_grpo_nemo_gym.py
+++ b/examples/nemo_gym/run_grpo_nemo_gym.py
@@ -59,9 +59,7 @@ from nemo_rl.utils.logger import get_next_experiment_dir
 def parse_args() -> tuple[argparse.Namespace, list[str]]:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description="Run GRPO training with configuration")
-    parser.add_argument(
-        "--config", type=str, default=None, help="Path to YAML config file"
-    )
+    parser.add_argument("--config", type=str, default=None, help="Path to YAML config file")
 
     # Parse known args for the script
     args, overrides = parser.parse_known_args()
@@ -143,18 +141,12 @@ def main() -> None:
     config["logger"]["log_dir"] = get_next_experiment_dir(config["logger"]["log_dir"])
     print(f"📊 Using log directory: {config['logger']['log_dir']}")
     if config["checkpointing"]["enabled"]:
-        print(
-            f"📊 Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}"
-        )
+        print(f"📊 Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}")
 
     # setup tokenizer
     tokenizer = get_tokenizer(config["policy"]["tokenizer"])
-    assert config["policy"]["generation"] is not None, (
-        "A generation config is required for GRPO"
-    )
-    config["policy"]["generation"] = configure_generation_config(
-        config["policy"]["generation"], tokenizer
-    )
+    assert config["policy"]["generation"] is not None, "A generation config is required for GRPO"
+    config["policy"]["generation"] = configure_generation_config(config["policy"]["generation"], tokenizer)
 
     # NeMo-Gym specific config setup.
     setup_nemo_gym_config(config, tokenizer)
@@ -164,9 +156,7 @@ def main() -> None:
 
     # NeMo-Gym environment needs to get dp_openai_server_base_urls from policy_generation, so we don't setup env here.
     print("\n▶ Setting up data...")
-    train_dataset, val_dataset = setup_response_data(
-        tokenizer, config["data"], env_configs=None
-    )
+    train_dataset, val_dataset = setup_response_data(tokenizer, config["data"], env_configs=None)
 
     # Validation dataset config setup.
     if config["grpo"]["max_val_samples"] is not None:
@@ -191,115 +181,112 @@ The validation set you pass in will directly be used for validation with no addi
 
     init_ray()
 
-    (
-        policy,
-        policy_generation,
-        cluster,
-        dataloader,
-        val_dataloader,
-        loss_fn,
-        logger,
-        checkpointer,
-        grpo_state,
-        master_config,
-    ) = setup(config, tokenizer, train_dataset, val_dataset)
-
-    is_trajectory_collection = (
-        config["env"]["nemo_gym"].pop("is_trajectory_collection", False) or False
-    )
-    nemo_gym_config = NemoGymConfig(
-        model_name=policy_generation.cfg["model_name"],
-        base_urls=policy_generation.dp_openai_server_base_urls,
-        initial_global_config_dict=config["env"]["nemo_gym"],
-    )
-    nemo_gym = create_env(env_name="nemo_gym", env_config=nemo_gym_config)
-    # Blocking wait for NeMo-Gym to spin up
-    ray.get(nemo_gym.health_check.remote())
-
-    # Bind task_to_env and val_task_to_env for nemo_gym env
-    # Hardcode here to match `run_async_nemo_gym_rollout`
-    task_to_env = {"nemo_gym": nemo_gym}
-    val_task_to_env = task_to_env
-
-    if is_trajectory_collection:
-        collect_trajectories(
-            policy=policy,
-            policy_generation=policy_generation,
-            val_dataloader=val_dataloader,
-            tokenizer=tokenizer,
-            val_task_to_env=val_task_to_env,
-            logger=logger,
-            master_config=master_config,
-        )
-    # Check if async mode is enabled
-    elif "async_grpo" in config["grpo"] and config["grpo"]["async_grpo"]["enabled"]:
-        # Async GRPO does not support dynamic sampling, reward scaling, or reward shaping (DAPO features)
-        unsupported_features = [
-            "use_dynamic_sampling",
-            "reward_scaling",
-            "reward_shaping",
-        ]
-
-        for feature in unsupported_features:
-            if feature not in config["grpo"]:
-                continue
-
-            if feature == "use_dynamic_sampling":
-                if config["grpo"][feature]:
-                    raise NotImplementedError(
-                        f"{feature} is not supported with async GRPO"
-                    )
-            else:
-                if config["grpo"][feature]["enabled"]:
-                    raise NotImplementedError(
-                        f"{feature} is not supported with async GRPO"
-                    )
-
-        # Async GRPO does not support multiple dataloaders
-        if config["data"]["use_multiple_dataloader"]:
-            raise NotImplementedError(
-                "use_multiple_dataloader is not supported with async GRPO"
-            )
-
-        from nemo_rl.algorithms.grpo import async_grpo_train
-
-        print("🚀 Running async GRPO training")
-
-        async_config = config["grpo"]["async_grpo"]
-        # Run async GRPO training
-        async_grpo_train(
-            policy=policy,
-            policy_generation=policy_generation,
-            dataloader=dataloader,
-            val_dataloader=val_dataloader,
-            tokenizer=tokenizer,
-            loss_fn=loss_fn,
-            task_to_env=task_to_env,
-            val_task_to_env=val_task_to_env,
-            logger=logger,
-            checkpointer=checkpointer,
-            grpo_save_state=grpo_state,
-            master_config=master_config,
-            max_trajectory_age_steps=async_config["max_trajectory_age_steps"],
-        )
-    else:
-        print("🚀 Running synchronous GRPO training")
-
-        # Run standard GRPO training
-        grpo_train(
+    logger = None
+    try:
+        (
             policy,
             policy_generation,
+            cluster,
             dataloader,
             val_dataloader,
-            tokenizer,
             loss_fn,
-            task_to_env,
-            val_task_to_env,
             logger,
             checkpointer,
             grpo_state,
             master_config,
+        ) = setup(config, tokenizer, train_dataset, val_dataset)
+
+        is_trajectory_collection = config["env"]["nemo_gym"].pop("is_trajectory_collection", False) or False
+        nemo_gym_config = NemoGymConfig(
+            model_name=policy_generation.cfg["model_name"],
+            base_urls=policy_generation.dp_openai_server_base_urls,
+            initial_global_config_dict=config["env"]["nemo_gym"],
         )
+        nemo_gym = create_env(env_name="nemo_gym", env_config=nemo_gym_config)
+        # Blocking wait for NeMo-Gym to spin up
+        ray.get(nemo_gym.health_check.remote())
+
+        # Bind task_to_env and val_task_to_env for nemo_gym env
+        # Hardcode here to match `run_async_nemo_gym_rollout`
+        task_to_env = {"nemo_gym": nemo_gym}
+        val_task_to_env = task_to_env
+
+        if is_trajectory_collection:
+            collect_trajectories(
+                policy=policy,
+                policy_generation=policy_generation,
+                val_dataloader=val_dataloader,
+                tokenizer=tokenizer,
+                val_task_to_env=val_task_to_env,
+                logger=logger,
+                master_config=master_config,
+            )
+        # Check if async mode is enabled
+        elif "async_grpo" in config["grpo"] and config["grpo"]["async_grpo"]["enabled"]:
+            # Async GRPO does not support dynamic sampling, reward scaling, or reward shaping (DAPO features)
+            unsupported_features = [
+                "use_dynamic_sampling",
+                "reward_scaling",
+                "reward_shaping",
+            ]
+
+            for feature in unsupported_features:
+                if feature not in config["grpo"]:
+                    continue
+
+                if feature == "use_dynamic_sampling":
+                    if config["grpo"][feature]:
+                        raise NotImplementedError(f"{feature} is not supported with async GRPO")
+                else:
+                    if config["grpo"][feature]["enabled"]:
+                        raise NotImplementedError(f"{feature} is not supported with async GRPO")
+
+            # Async GRPO does not support multiple dataloaders
+            if config["data"]["use_multiple_dataloader"]:
+                raise NotImplementedError("use_multiple_dataloader is not supported with async GRPO")
+
+            from nemo_rl.algorithms.grpo import async_grpo_train
+
+            print("🚀 Running async GRPO training")
+
+            async_config = config["grpo"]["async_grpo"]
+            # Run async GRPO training
+            async_grpo_train(
+                policy=policy,
+                policy_generation=policy_generation,
+                dataloader=dataloader,
+                val_dataloader=val_dataloader,
+                tokenizer=tokenizer,
+                loss_fn=loss_fn,
+                task_to_env=task_to_env,
+                val_task_to_env=val_task_to_env,
+                logger=logger,
+                checkpointer=checkpointer,
+                grpo_save_state=grpo_state,
+                master_config=master_config,
+                max_trajectory_age_steps=async_config["max_trajectory_age_steps"],
+            )
+        else:
+            print("🚀 Running synchronous GRPO training")
+
+            # Run standard GRPO training
+            grpo_train(
+                policy,
+                policy_generation,
+                dataloader,
+                val_dataloader,
+                tokenizer,
+                loss_fn,
+                task_to_env,
+                val_task_to_env,
+                logger,
+                checkpointer,
+                grpo_state,
+                master_config,
+            )
+    finally:
+        if logger is not None:
+            logger.close()
 
 
 if __name__ == "__main__":

--- a/examples/run_distillation.py
+++ b/examples/run_distillation.py
@@ -32,12 +32,8 @@ from nemo_rl.utils.logger import get_next_experiment_dir
 
 def parse_args() -> tuple[argparse.Namespace, list[str]]:
     """Parse command line arguments."""
-    parser = argparse.ArgumentParser(
-        description="Run distillation training with configuration"
-    )
-    parser.add_argument(
-        "--config", type=str, default=None, help="Path to YAML config file"
-    )
+    parser = argparse.ArgumentParser(description="Run distillation training with configuration")
+    parser.add_argument("--config", type=str, default=None, help="Path to YAML config file")
 
     # Parse known args for the script
     args, overrides = parser.parse_known_args()
@@ -52,9 +48,7 @@ def main() -> None:
     args, overrides = parse_args()
 
     if not args.config:
-        args.config = os.path.join(
-            os.path.dirname(__file__), "configs", "distillation_math.yaml"
-        )
+        args.config = os.path.join(os.path.dirname(__file__), "configs", "distillation_math.yaml")
 
     config = load_config(args.config)
     if overrides:
@@ -70,9 +64,7 @@ def main() -> None:
     tokenizer = get_tokenizer(config["policy"]["tokenizer"])
 
     if config["policy"]["generation"] is not None:
-        config["policy"]["generation"] = configure_generation_config(
-            config["policy"]["generation"], tokenizer
-        )
+        config["policy"]["generation"] = configure_generation_config(config["policy"]["generation"], tokenizer)
     else:
         print("  ⚠️ No generation config found, this may cause issues")
 
@@ -84,34 +76,39 @@ def main() -> None:
         val_task_to_env,
     ) = setup_response_data(tokenizer, config["data"], config["env"])
 
-    (
-        student_policy,
-        teacher_policy,
-        student_generation,
-        dataloader,
-        val_dataloader,
-        loss_fn,
-        logger,
-        checkpointer,
-        distillation_state,
-        master_config,
-    ) = setup(config, tokenizer, dataset, val_dataset)
+    logger = None
+    try:
+        (
+            student_policy,
+            teacher_policy,
+            student_generation,
+            dataloader,
+            val_dataloader,
+            loss_fn,
+            logger,
+            checkpointer,
+            distillation_state,
+            master_config,
+        ) = setup(config, tokenizer, dataset, val_dataset)
 
-    distillation_train(
-        student_policy,
-        teacher_policy,
-        student_generation,
-        dataloader,
-        val_dataloader,
-        tokenizer,  # pass tokenizer parameter
-        loss_fn,
-        task_to_env,
-        val_task_to_env,
-        logger,
-        checkpointer,
-        distillation_state,
-        master_config,
-    )
+        distillation_train(
+            student_policy,
+            teacher_policy,
+            student_generation,
+            dataloader,
+            val_dataloader,
+            tokenizer,  # pass tokenizer parameter
+            loss_fn,
+            task_to_env,
+            val_task_to_env,
+            logger,
+            checkpointer,
+            distillation_state,
+            master_config,
+        )
+    finally:
+        if logger is not None:
+            logger.close()
 
 
 if __name__ == "__main__":

--- a/examples/run_dpo.py
+++ b/examples/run_dpo.py
@@ -29,9 +29,7 @@ from nemo_rl.utils.logger import get_next_experiment_dir
 def parse_args():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description="Run DPO training with configuration")
-    parser.add_argument(
-        "--config", type=str, default=None, help="Path to YAML config file"
-    )
+    parser.add_argument("--config", type=str, default=None, help="Path to YAML config file")
 
     # Parse known args for the script
     args, overrides = parser.parse_known_args()
@@ -63,9 +61,7 @@ def main():
     config["logger"]["log_dir"] = get_next_experiment_dir(config["logger"]["log_dir"])
     print(f"📊 Using log directory: {config['logger']['log_dir']}")
     if config["checkpointing"]["enabled"]:
-        print(
-            f"📊 Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}"
-        )
+        print(f"📊 Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}")
 
     init_ray()
 
@@ -75,29 +71,34 @@ def main():
     # setup data
     dataset, val_dataset = setup_preference_data(tokenizer, config["data"])
 
-    (
-        policy,
-        cluster,
-        train_dataloader,
-        val_dataloader,
-        loss_fn,
-        logger,
-        checkpointer,
-        dpo_save_state,
-        master_config,
-    ) = setup(config, tokenizer, dataset, val_dataset)
+    logger = None
+    try:
+        (
+            policy,
+            cluster,
+            train_dataloader,
+            val_dataloader,
+            loss_fn,
+            logger,
+            checkpointer,
+            dpo_save_state,
+            master_config,
+        ) = setup(config, tokenizer, dataset, val_dataset)
 
-    dpo_train(
-        policy,
-        train_dataloader,
-        val_dataloader,
-        tokenizer,
-        loss_fn,
-        master_config,
-        logger,
-        checkpointer,
-        dpo_save_state,
-    )
+        dpo_train(
+            policy,
+            train_dataloader,
+            val_dataloader,
+            tokenizer,
+            loss_fn,
+            master_config,
+            logger,
+            checkpointer,
+            dpo_save_state,
+        )
+    finally:
+        if logger is not None:
+            logger.close()
 
 
 if __name__ == "__main__":

--- a/examples/run_grpo.py
+++ b/examples/run_grpo.py
@@ -34,9 +34,7 @@ from nemo_rl.utils.logger import get_next_experiment_dir
 def parse_args() -> tuple[argparse.Namespace, list[str]]:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description="Run GRPO training with configuration")
-    parser.add_argument(
-        "--config", type=str, default=None, help="Path to YAML config file"
-    )
+    parser.add_argument("--config", type=str, default=None, help="Path to YAML config file")
 
     # Parse known args for the script
     args, overrides = parser.parse_known_args()
@@ -51,9 +49,7 @@ def main() -> None:
     args, overrides = parse_args()
 
     if not args.config:
-        args.config = os.path.join(
-            os.path.dirname(__file__), "configs", "grpo_math_1B.yaml"
-        )
+        args.config = os.path.join(os.path.dirname(__file__), "configs", "grpo_math_1B.yaml")
 
     config = load_config(args.config)
     print(f"Loaded configuration from: {args.config}")
@@ -73,17 +69,13 @@ def main() -> None:
     config["logger"]["log_dir"] = get_next_experiment_dir(config["logger"]["log_dir"])
     print(f"📊 Using log directory: {config['logger']['log_dir']}")
     if config["checkpointing"]["enabled"]:
-        print(
-            f"📊 Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}"
-        )
+        print(f"📊 Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}")
 
     init_ray()
 
     # setup tokenizer
     tokenizer = get_tokenizer(config["policy"]["tokenizer"])
-    assert config["policy"]["generation"] is not None, (
-        "A generation config is required for GRPO"
-    )
+    assert config["policy"]["generation"] is not None, "A generation config is required for GRPO"
     has_refit_draft_weights = bool(config["policy"]["draft"]["enabled"])
     config["policy"]["generation"] = configure_generation_config(
         config["policy"]["generation"],
@@ -99,88 +91,87 @@ def main() -> None:
         val_task_to_env,
     ) = setup_response_data(tokenizer, config["data"], config["env"])
 
-    (
-        policy,
-        policy_generation,
-        cluster,
-        dataloader,
-        val_dataloader,
-        loss_fn,
-        logger,
-        checkpointer,
-        grpo_state,
-        master_config,
-    ) = setup(config, tokenizer, dataset, val_dataset)
-
-    # Check if async mode is enabled
-    if "async_grpo" in config["grpo"] and config["grpo"]["async_grpo"]["enabled"]:
-        # Async GRPO does not support dynamic sampling, reward scaling, or reward shaping (DAPO features)
-        unsupported_features = [
-            "use_dynamic_sampling",
-            "reward_scaling",
-            "reward_shaping",
-        ]
-
-        for feature in unsupported_features:
-            if feature not in config["grpo"]:
-                continue
-
-            if feature == "use_dynamic_sampling":
-                if config["grpo"][feature]:
-                    raise NotImplementedError(
-                        f"{feature} is not supported with async GRPO"
-                    )
-            else:
-                if config["grpo"][feature]["enabled"]:
-                    raise NotImplementedError(
-                        f"{feature} is not supported with async GRPO"
-                    )
-
-        # Async GRPO does not support multiple dataloaders
-        if config["data"]["use_multiple_dataloader"]:
-            raise NotImplementedError(
-                "use_multiple_dataloader is not supported with async GRPO"
-            )
-
-        from nemo_rl.algorithms.grpo import async_grpo_train
-
-        print("🚀 Running async GRPO training")
-
-        async_config = config["grpo"]["async_grpo"]
-        # Run async GRPO training
-        async_grpo_train(
-            policy=policy,
-            policy_generation=policy_generation,
-            dataloader=dataloader,
-            val_dataloader=val_dataloader,
-            tokenizer=tokenizer,
-            loss_fn=loss_fn,
-            task_to_env=task_to_env,
-            val_task_to_env=val_task_to_env,
-            logger=logger,
-            checkpointer=checkpointer,
-            grpo_save_state=grpo_state,
-            master_config=master_config,
-            max_trajectory_age_steps=async_config["max_trajectory_age_steps"],
-        )
-    else:
-        print("🚀 Running synchronous GRPO training")
-
-        # Run standard GRPO training
-        grpo_train(
+    logger = None
+    try:
+        (
             policy,
             policy_generation,
+            cluster,
             dataloader,
             val_dataloader,
-            tokenizer,
             loss_fn,
-            task_to_env,
-            val_task_to_env,
             logger,
             checkpointer,
             grpo_state,
             master_config,
-        )
+        ) = setup(config, tokenizer, dataset, val_dataset)
+
+        # Check if async mode is enabled
+        if "async_grpo" in config["grpo"] and config["grpo"]["async_grpo"]["enabled"]:
+            # Async GRPO does not support dynamic sampling, reward scaling, or reward shaping (DAPO features)
+            unsupported_features = [
+                "use_dynamic_sampling",
+                "reward_scaling",
+                "reward_shaping",
+            ]
+
+            for feature in unsupported_features:
+                if feature not in config["grpo"]:
+                    continue
+
+                if feature == "use_dynamic_sampling":
+                    if config["grpo"][feature]:
+                        raise NotImplementedError(f"{feature} is not supported with async GRPO")
+                else:
+                    if config["grpo"][feature]["enabled"]:
+                        raise NotImplementedError(f"{feature} is not supported with async GRPO")
+
+            # Async GRPO does not support multiple dataloaders
+            if config["data"]["use_multiple_dataloader"]:
+                raise NotImplementedError("use_multiple_dataloader is not supported with async GRPO")
+
+            from nemo_rl.algorithms.grpo import async_grpo_train
+
+            print("🚀 Running async GRPO training")
+
+            async_config = config["grpo"]["async_grpo"]
+            # Run async GRPO training
+            async_grpo_train(
+                policy=policy,
+                policy_generation=policy_generation,
+                dataloader=dataloader,
+                val_dataloader=val_dataloader,
+                tokenizer=tokenizer,
+                loss_fn=loss_fn,
+                task_to_env=task_to_env,
+                val_task_to_env=val_task_to_env,
+                logger=logger,
+                checkpointer=checkpointer,
+                grpo_save_state=grpo_state,
+                master_config=master_config,
+                max_trajectory_age_steps=async_config["max_trajectory_age_steps"],
+            )
+        else:
+            print("🚀 Running synchronous GRPO training")
+
+            # Run standard GRPO training
+            grpo_train(
+                policy,
+                policy_generation,
+                dataloader,
+                val_dataloader,
+                tokenizer,
+                loss_fn,
+                task_to_env,
+                val_task_to_env,
+                logger,
+                checkpointer,
+                grpo_state,
+                master_config,
+            )
+    finally:
+        if logger is not None:
+            logger.close()
 
 
 if __name__ == "__main__":

--- a/examples/run_grpo_sliding_puzzle.py
+++ b/examples/run_grpo_sliding_puzzle.py
@@ -45,9 +45,7 @@ from nemo_rl.utils.logger import get_next_experiment_dir
 def parse_args():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description="Run GRPO training with configuration")
-    parser.add_argument(
-        "--config", type=str, default=None, help="Path to YAML config file"
-    )
+    parser.add_argument("--config", type=str, default=None, help="Path to YAML config file")
     args, overrides = parser.parse_known_args()
     return args, overrides
 
@@ -94,9 +92,7 @@ def generate_puzzle_datum(
         add_generation_prompt=True,
         add_special_tokens=False,
     ).strip()
-    tokenized_prompt = tokenizer(
-        initial_prompt_content, return_tensors="pt", add_special_tokens=False
-    )["input_ids"][0]
+    tokenized_prompt = tokenizer(initial_prompt_content, return_tensors="pt", add_special_tokens=False)["input_ids"][0]
     message_log: LLMMessageLogType = [
         {
             "role": "user",
@@ -104,9 +100,7 @@ def generate_puzzle_datum(
             "token_ids": tokenized_prompt,
         }
     ]
-    metadata = SlidingPuzzleMetadata(
-        game_state=initial_game_state, num_moves=0, max_moves=max_moves
-    )
+    metadata = SlidingPuzzleMetadata(game_state=initial_game_state, num_moves=0, max_moves=max_moves)
     datum: DatumSpec = {
         "message_log": message_log,
         "length": len(tokenized_prompt),
@@ -122,9 +116,7 @@ def generate_puzzle_datum(
 class IterablePuzzleDataset(IterableDataset):
     """An IterableDataset that generates sliding puzzle data indefinitely."""
 
-    def __init__(
-        self, tokenizer, game_config, max_moves, task_name, add_system_prompt, length
-    ):
+    def __init__(self, tokenizer, game_config, max_moves, task_name, add_system_prompt, length):
         super().__init__()
         self.tokenizer = tokenizer
         self.game_config = game_config
@@ -198,9 +190,7 @@ def main():
     args, overrides = parse_args()
 
     if not args.config:
-        args.config = os.path.join(
-            os.path.dirname(__file__), "configs", "grpo_sliding_puzzle.yaml"
-        )
+        args.config = os.path.join(os.path.dirname(__file__), "configs", "grpo_sliding_puzzle.yaml")
 
     config = load_config(args.config)
     print(f"Loaded configuration from: {args.config}")
@@ -220,9 +210,7 @@ def main():
     config["logger"]["log_dir"] = get_next_experiment_dir(config["logger"]["log_dir"])
     print(f"📊 Using log directory: {config['logger']['log_dir']}")
     if config["checkpointing"]["enabled"]:
-        print(
-            f"📊 Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}"
-        )
+        print(f"📊 Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}")
 
     init_ray()
 
@@ -230,9 +218,7 @@ def main():
 
     # setup tokenizer
     tokenizer = get_tokenizer(config["policy"]["tokenizer"])
-    config["policy"]["generation"] = configure_generation_config(
-        config["policy"]["generation"], tokenizer
-    )
+    config["policy"]["generation"] = configure_generation_config(config["policy"]["generation"], tokenizer)
 
     # setup data & env map
     ds_length = (
@@ -249,33 +235,38 @@ def main():
         add_system_prompt=config["data"]["add_system_prompt"],
     )
 
-    (
-        policy,
-        policy_generation,
-        cluster,
-        dataloader,
-        val_dataloader,
-        loss_fn,
-        logger,
-        checkpointer,
-        grpo_state,
-        master_config,
-    ) = setup(config, tokenizer, dataset, val_dataset)
+    logger = None
+    try:
+        (
+            policy,
+            policy_generation,
+            cluster,
+            dataloader,
+            val_dataloader,
+            loss_fn,
+            logger,
+            checkpointer,
+            grpo_state,
+            master_config,
+        ) = setup(config, tokenizer, dataset, val_dataset)
 
-    grpo_train(
-        policy,
-        policy_generation,
-        dataloader,
-        val_dataloader,
-        tokenizer,
-        loss_fn,
-        task_to_env,
-        val_task_to_env,
-        logger,
-        checkpointer,
-        grpo_state,
-        master_config,
-    )
+        grpo_train(
+            policy,
+            policy_generation,
+            dataloader,
+            val_dataloader,
+            tokenizer,
+            loss_fn,
+            task_to_env,
+            val_task_to_env,
+            logger,
+            checkpointer,
+            grpo_state,
+            master_config,
+        )
+    finally:
+        if logger is not None:
+            logger.close()
 
 
 if __name__ == "__main__":

--- a/examples/run_rm.py
+++ b/examples/run_rm.py
@@ -29,9 +29,7 @@ from nemo_rl.utils.logger import get_next_experiment_dir
 def parse_args():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description="Run RM training with configuration")
-    parser.add_argument(
-        "--config", type=str, default=None, help="Path to YAML config file"
-    )
+    parser.add_argument("--config", type=str, default=None, help="Path to YAML config file")
 
     # Parse known args for the script
     args, overrides = parser.parse_known_args()
@@ -66,9 +64,7 @@ def main():
     config["logger"]["log_dir"] = get_next_experiment_dir(config["logger"]["log_dir"])
     print(f"📊 Using log directory: {config['logger']['log_dir']}")
     if config["checkpointing"]["enabled"]:
-        print(
-            f"📊 Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}"
-        )
+        print(f"📊 Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}")
 
     init_ray()
 
@@ -78,29 +74,34 @@ def main():
     # setup data
     dataset, val_dataset = setup_preference_data(tokenizer, config["data"])
 
-    (
-        policy,
-        cluster,
-        train_dataloader,
-        val_dataloader,
-        loss_fn,
-        logger,
-        checkpointer,
-        rm_save_state,
-        master_config,
-    ) = setup(config, tokenizer, dataset, val_dataset)
+    logger = None
+    try:
+        (
+            policy,
+            cluster,
+            train_dataloader,
+            val_dataloader,
+            loss_fn,
+            logger,
+            checkpointer,
+            rm_save_state,
+            master_config,
+        ) = setup(config, tokenizer, dataset, val_dataset)
 
-    rm_train(
-        policy,
-        train_dataloader,
-        val_dataloader,
-        tokenizer,
-        loss_fn,
-        master_config,
-        logger,
-        checkpointer,
-        rm_save_state,
-    )
+        rm_train(
+            policy,
+            train_dataloader,
+            val_dataloader,
+            tokenizer,
+            loss_fn,
+            master_config,
+            logger,
+            checkpointer,
+            rm_save_state,
+        )
+    finally:
+        if logger is not None:
+            logger.close()
 
 
 if __name__ == "__main__":

--- a/examples/run_sft.py
+++ b/examples/run_sft.py
@@ -41,9 +41,7 @@ from nemo_rl.utils.logger import get_next_experiment_dir
 def parse_args():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description="Run SFT training with configuration")
-    parser.add_argument(
-        "--config", type=str, default=None, help="Path to YAML config file"
-    )
+    parser.add_argument("--config", type=str, default=None, help="Path to YAML config file")
 
     # Parse known args for the script
     args, overrides = parser.parse_known_args()
@@ -113,9 +111,7 @@ def setup_data(tokenizer: AutoTokenizer, data_config: DataConfig):
             task_name = data.task_name
             val_task_data_processors[task_name] = task_data_processors[task_name]
             if task_name in task_data_preprocessors:
-                val_task_data_preprocessors[task_name] = task_data_preprocessors[
-                    task_name
-                ]
+                val_task_data_preprocessors[task_name] = task_data_preprocessors[task_name]
 
     # validation dataset from config
     if "validation" in data_config and data_config["validation"] is not None:
@@ -184,9 +180,7 @@ def main(is_vlm: bool = False):
     config["logger"]["log_dir"] = get_next_experiment_dir(config["logger"]["log_dir"])
     print(f"📊 Using log directory: {config['logger']['log_dir']}")
     if config["checkpointing"]["enabled"]:
-        print(
-            f"📊 Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}"
-        )
+        print(f"📊 Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}")
 
     init_ray()
 
@@ -196,29 +190,34 @@ def main(is_vlm: bool = False):
     # setup data
     dataset, val_dataset = setup_data(tokenizer, config["data"])
 
-    (
-        policy,
-        cluster,
-        train_dataloader,
-        val_dataloader,
-        loss_fn,
-        logger,
-        checkpointer,
-        sft_save_state,
-        master_config,
-    ) = setup(config, tokenizer, dataset, val_dataset)
+    logger = None
+    try:
+        (
+            policy,
+            cluster,
+            train_dataloader,
+            val_dataloader,
+            loss_fn,
+            logger,
+            checkpointer,
+            sft_save_state,
+            master_config,
+        ) = setup(config, tokenizer, dataset, val_dataset)
 
-    sft_train(
-        policy,
-        train_dataloader,
-        val_dataloader,
-        tokenizer,
-        loss_fn,
-        master_config,
-        logger,
-        checkpointer,
-        sft_save_state,
-    )
+        sft_train(
+            policy,
+            train_dataloader,
+            val_dataloader,
+            tokenizer,
+            loss_fn,
+            master_config,
+            logger,
+            checkpointer,
+            sft_save_state,
+        )
+    finally:
+        if logger is not None:
+            logger.close()
 
 
 if __name__ == "__main__":

--- a/examples/run_vlm_grpo.py
+++ b/examples/run_vlm_grpo.py
@@ -34,9 +34,7 @@ from nemo_rl.utils.logger import get_next_experiment_dir
 def parse_args() -> tuple[argparse.Namespace, list[str]]:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description="Run GRPO training with configuration")
-    parser.add_argument(
-        "--config", type=str, default=None, help="Path to YAML config file"
-    )
+    parser.add_argument("--config", type=str, default=None, help="Path to YAML config file")
     # Parse known args for the script
     args, overrides = parser.parse_known_args()
     return args, overrides
@@ -49,9 +47,7 @@ def main() -> None:
     args, overrides = parse_args()
 
     if not args.config:
-        args.config = os.path.join(
-            os.path.dirname(__file__), "configs", "vlm_grpo_3B.yaml"
-        )
+        args.config = os.path.join(os.path.dirname(__file__), "configs", "vlm_grpo_3B.yaml")
 
     config = load_config(args.config)
     print(f"Loaded configuration from: {args.config}")
@@ -71,9 +67,7 @@ def main() -> None:
     config["logger"]["log_dir"] = get_next_experiment_dir(config["logger"]["log_dir"])
     print(f"📊 Using log directory: {config['logger']['log_dir']}")
     if config["checkpointing"]["enabled"]:
-        print(
-            f"📊 Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}"
-        )
+        print(f"📊 Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}")
 
     init_ray()
 
@@ -81,18 +75,12 @@ def main() -> None:
     processor = get_tokenizer(config["policy"]["tokenizer"], get_processor=True)
     tokenizer = processor.tokenizer
 
-    assert config["policy"]["generation"] is not None, (
-        "A generation config is required for GRPO"
-    )
-    config["policy"]["generation"] = configure_generation_config(
-        config["policy"]["generation"], processor.tokenizer
-    )
+    assert config["policy"]["generation"] is not None, "A generation config is required for GRPO"
+    config["policy"]["generation"] = configure_generation_config(config["policy"]["generation"], processor.tokenizer)
     if "vllm_cfg" in config["policy"]["generation"]:
         assert (
             config["policy"]["generation"]["vllm_cfg"]["skip_tokenizer_init"] == False
-        ), (
-            "VLMs require tokenizer to be initialized before generation, so skip_tokenizer_init must be set to False."
-        )
+        ), "VLMs require tokenizer to be initialized before generation, so skip_tokenizer_init must be set to False."
 
     # setup data
     # this function is local to this script, and can be extended to other VLM datasets
@@ -103,33 +91,38 @@ def main() -> None:
         val_task_to_env,
     ) = setup_response_data(processor, config["data"], config["env"], is_vlm=True)
 
-    (
-        policy,
-        policy_generation,
-        cluster,
-        dataloader,
-        val_dataloader,
-        loss_fn,
-        logger,
-        checkpointer,
-        grpo_state,
-        master_config,
-    ) = setup(config, tokenizer, dataset, val_dataset, processor=processor)
+    logger = None
+    try:
+        (
+            policy,
+            policy_generation,
+            cluster,
+            dataloader,
+            val_dataloader,
+            loss_fn,
+            logger,
+            checkpointer,
+            grpo_state,
+            master_config,
+        ) = setup(config, tokenizer, dataset, val_dataset, processor=processor)
 
-    grpo_train(
-        policy,
-        policy_generation,
-        dataloader,
-        val_dataloader,
-        tokenizer,
-        loss_fn,
-        task_to_env,
-        val_task_to_env,
-        logger,
-        checkpointer,
-        grpo_state,
-        master_config,
-    )
+        grpo_train(
+            policy,
+            policy_generation,
+            dataloader,
+            val_dataloader,
+            tokenizer,
+            loss_fn,
+            task_to_env,
+            val_task_to_env,
+            logger,
+            checkpointer,
+            grpo_state,
+            master_config,
+        )
+    finally:
+        if logger is not None:
+            logger.close()
 
 
 if __name__ == "__main__":

--- a/nemo_rl/utils/logger.py
+++ b/nemo_rl/utils/logger.py
@@ -14,6 +14,7 @@
 
 
 import glob
+import io
 import json
 import logging
 import os
@@ -53,6 +54,23 @@ class WandbConfig(TypedDict):
     entity: NotRequired[str]
 
 
+class TrackioConfig(TypedDict):
+    project: NotRequired[str]
+    name: NotRequired[str | None]
+    group: NotRequired[str | None]
+    space_id: NotRequired[str | None]
+    server_url: NotRequired[str | None]
+    bucket_id: NotRequired[str | None]
+    resume: NotRequired[str]
+    private: NotRequired[bool | None]
+    embed: NotRequired[bool]
+    auto_log_gpu: NotRequired[bool]
+    gpu_log_interval: NotRequired[int | float]
+    webhook_url: NotRequired[str | None]
+    webhook_min_level: NotRequired[str | None]
+    dir: NotRequired[str | None]
+
+
 class SwanlabConfig(TypedDict):
     project: NotRequired[str]
     name: NotRequired[str]
@@ -78,10 +96,12 @@ class GPUMonitoringConfig(TypedDict):
 class LoggerConfig(TypedDict):
     log_dir: str
     wandb_enabled: bool
+    trackio_enabled: NotRequired[bool]
     swanlab_enabled: bool
     tensorboard_enabled: bool
     mlflow_enabled: bool
     wandb: WandbConfig
+    trackio: NotRequired[TrackioConfig]
     tensorboard: NotRequired[TensorboardConfig]
     swanlab: NotRequired[SwanlabConfig]
     mlflow: NotRequired[MLflowConfig]
@@ -217,9 +237,7 @@ class WandbLogger(LoggerInterface):
 
         self._log_code()
         self._log_diffs()
-        print(
-            f"Initialized WandbLogger for project {cfg.get('project')}, run {cfg.get('name')} at {log_dir}"
-        )
+        print(f"Initialized WandbLogger for project {cfg.get('project')}, run {cfg.get('name')} at {log_dir}")
 
     def _log_diffs(self):
         """Log git diffs to wandb.
@@ -239,20 +257,14 @@ class WandbLogger(LoggerInterface):
             )
             current_branch = branch_result.stdout.strip()
 
-            diff_artifact = wandb.Artifact(
-                name=f"git-diffs-{self.run.project}-{self.run.id}", type="git-diffs"
-            )
+            diff_artifact = wandb.Artifact(name=f"git-diffs-{self.run.project}-{self.run.id}", type="git-diffs")
 
             # 1. Log uncommitted changes (working tree diff)
-            uncommitted_result = subprocess.run(
-                ["git", "diff", "HEAD"], capture_output=True, text=True, check=True
-            )
+            uncommitted_result = subprocess.run(["git", "diff", "HEAD"], capture_output=True, text=True, check=True)
             uncommitted_diff = uncommitted_result.stdout
 
             if uncommitted_diff:
-                diff_path = os.path.join(
-                    wandb.run.dir if wandb.run else ".", "uncommitted_changes_diff.txt"
-                )
+                diff_path = os.path.join(wandb.run.dir if wandb.run else ".", "uncommitted_changes_diff.txt")
                 with open(diff_path, "w") as f:
                     f.write(uncommitted_diff)
 
@@ -272,9 +284,7 @@ class WandbLogger(LoggerInterface):
 
                 if working_diff:
                     # Save diff to a temporary file
-                    diff_path = os.path.join(
-                        wandb.run.dir if wandb.run else ".", "main_diff.txt"
-                    )
+                    diff_path = os.path.join(wandb.run.dir if wandb.run else ".", "main_diff.txt")
                     with open(diff_path, "w") as f:
                         f.write(working_diff)
 
@@ -298,21 +308,15 @@ class WandbLogger(LoggerInterface):
         and manually uploads them to the current wandb run as an artifact.
         """
         try:
-            result = subprocess.run(
-                ["git", "ls-files"], capture_output=True, text=True, check=True
-            )
+            result = subprocess.run(["git", "ls-files"], capture_output=True, text=True, check=True)
 
             tracked_files = result.stdout.strip().split("\n")
 
             if not tracked_files:
-                print(
-                    "Warning: No git repository found. Wandb logs will not track code changes for reproducibility."
-                )
+                print("Warning: No git repository found. Wandb logs will not track code changes for reproducibility.")
                 return
 
-            code_artifact = wandb.Artifact(
-                name=f"source-code-{self.run.project}", type="code"
-            )
+            code_artifact = wandb.Artifact(name=f"source-code-{self.run.project}", type="code")
 
             for file_path in tracked_files:
                 if os.path.isfile(file_path):
@@ -360,10 +364,7 @@ class WandbLogger(LoggerInterface):
                          of the provided step value
         """
         if prefix:
-            metrics = {
-                f"{prefix}/{k}" if k != step_metric else k: v
-                for k, v in metrics.items()
-            }
+            metrics = {f"{prefix}/{k}" if k != step_metric else k: v for k, v in metrics.items()}
 
         # If step_metric is provided, use the corresponding value from metrics as step
         if step_metric and step_metric in metrics:
@@ -404,6 +405,105 @@ class WandbLogger(LoggerInterface):
         self.run.log({name: wandb.Histogram(histogram)}, step=step)
 
 
+class TrackioLogger(LoggerInterface):
+    """Trackio logger backend."""
+
+    _INIT_KEYS = {
+        "project",
+        "name",
+        "group",
+        "space_id",
+        "server_url",
+        "bucket_id",
+        "resume",
+        "private",
+        "embed",
+        "auto_log_gpu",
+        "gpu_log_interval",
+        "webhook_url",
+        "webhook_min_level",
+    }
+
+    def __init__(self, cfg: TrackioConfig, log_dir: Optional[str] = None):
+        trackio_dir = cfg.get("dir")
+        if trackio_dir:
+            os.makedirs(trackio_dir, exist_ok=True)
+            os.environ["TRACKIO_DIR"] = trackio_dir
+
+        self._trackio = self._import_trackio()
+        self._closed = False
+
+        init_kwargs = {key: value for key, value in cfg.items() if key in self._INIT_KEYS and value is not None}
+        if "project" not in init_kwargs:
+            raise ValueError("Trackio logging requires logger.trackio.project")
+
+        self.run = self._trackio.init(**init_kwargs)
+        print(
+            f"Initialized TrackioLogger for project {cfg.get('project')}, run {cfg.get('name')} at {trackio_dir or log_dir}"
+        )
+
+    @staticmethod
+    def _import_trackio() -> Any:
+        try:
+            import trackio
+        except ImportError as e:
+            raise ImportError(
+                "Trackio logging requires the optional Trackio dependency. "
+                "Install it with `uv sync --extra trackio` or run with `uv run --extra trackio ...`."
+            ) from e
+        return trackio
+
+    def log_metrics(
+        self,
+        metrics: dict[str, Any],
+        step: int,
+        prefix: Optional[str] = "",
+        step_metric: Optional[str] = None,
+        step_finished: bool = False,
+    ) -> None:
+        """Log metrics to Trackio."""
+        if prefix:
+            metrics = {f"{prefix}/{k}" if k != step_metric else k: v for k, v in metrics.items()}
+
+        if step_metric and step_metric in metrics:
+            step = int(metrics[step_metric])
+
+        self.run.log(metrics, step=step)
+
+    def log_hyperparams(self, params: Mapping[str, Any]) -> None:
+        """Attach hyperparameters to the Trackio run config."""
+        if hasattr(self.run, "config") and isinstance(self.run.config, dict):
+            self.run.config.update(params)
+
+    def log_plot(self, figure: plt.Figure, step: int, name: str) -> None:
+        """Log a matplotlib figure to Trackio as an image."""
+        from PIL import Image
+
+        image_buffer = io.BytesIO()
+        figure.savefig(image_buffer, format="png", bbox_inches="tight")
+        image_buffer.seek(0)
+        image = Image.open(image_buffer).copy()
+        self.run.log({name: self._trackio.Image(image)}, step=step)
+
+    def log_histogram(self, histogram: list[Any], step: int, name: str) -> None:
+        """Log histogram metrics to Trackio."""
+        self.run.log({name: self._trackio.Histogram(histogram)}, step=step)
+
+    def close(self) -> None:
+        """Finish the Trackio run and flush queued logs."""
+        if self._closed:
+            return
+        self._closed = True
+        self.run.finish()
+
+    def __del__(self) -> None:
+        """Clean up resources when the logger is destroyed."""
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
 class SwanlabLogger(LoggerInterface):
     """SwanLab logger backend."""
 
@@ -436,10 +536,7 @@ class SwanlabLogger(LoggerInterface):
             step_metric (Optional[str]): Name of a metric that should be excluded from prefixing.
         """
         if prefix:
-            metrics = {
-                f"{prefix}/{k}" if k != step_metric else k: v
-                for k, v in metrics.items()
-            }
+            metrics = {f"{prefix}/{k}" if k != step_metric else k: v for k, v in metrics.items()}
 
         self.run.log(metrics, step=step)
 
@@ -494,9 +591,7 @@ class RayGpuMonitorLogger:
         self.metric_prefix = metric_prefix
         self.step_metric = step_metric
         self.parent_logger = parent_logger
-        self.metrics_buffer: list[
-            GpuMetricSnapshot
-        ] = []  # Store metrics with timestamps
+        self.metrics_buffer: list[GpuMetricSnapshot] = []  # Store metrics with timestamps
         self.last_flush_time = time.time()
         self.is_running = False
         self.collection_thread: Optional[threading.Thread] = None
@@ -547,9 +642,7 @@ class RayGpuMonitorLogger:
                     with self.lock:
                         self.metrics_buffer.append(
                             {
-                                "step": int(
-                                    relative_time
-                                ),  # Store the relative time as step
+                                "step": int(relative_time),  # Store the relative time as step
                                 "metrics": metrics,
                             }
                         )
@@ -562,9 +655,7 @@ class RayGpuMonitorLogger:
 
                 time.sleep(self.collection_interval)
             except Exception as e:
-                print(
-                    f"Error in GPU monitoring collection loop or stopped abruptly: {e}"
-                )
+                print(f"Error in GPU monitoring collection loop or stopped abruptly: {e}")
                 time.sleep(self.collection_interval)  # Continue despite errors
 
     def _parse_metric(self, sample: Sample, node_idx: int) -> dict[str, Any]:
@@ -621,10 +712,7 @@ class RayGpuMonitorLogger:
 
         metric_name = sample.name
         # Only return SKU if the metric is one of these which publish these metrics
-        if (
-            metric_name != "ray_node_gpus_utilization"
-            and metric_name != "ray_node_gram_used"
-        ):
+        if metric_name != "ray_node_gpus_utilization" and metric_name != "ray_node_gram_used":
             # Skip unexpected metrics
             return {}
 
@@ -662,9 +750,7 @@ class RayGpuMonitorLogger:
         Returns:
             Dictionary of collected metrics
         """
-        assert metrics ^ sku, (
-            f"Must collect either metrics or sku, not both: {metrics=}, {sku=}"
-        )
+        assert metrics ^ sku, f"Must collect either metrics or sku, not both: {metrics=}, {sku=}"
         parser_fn = self._parse_metric if metrics else self._parse_gpu_sku
 
         if not ray.is_initialized():
@@ -690,9 +776,7 @@ class RayGpuMonitorLogger:
             # Process each node's metrics
             collected_metrics: dict[str, Any] = {}
             for node_idx, metric_address in enumerate(unique_metric_addresses):
-                metrics = self._fetch_and_parse_metrics(
-                    node_idx, metric_address, parser_fn
-                )
+                metrics = self._fetch_and_parse_metrics(node_idx, metric_address, parser_fn)
                 collected_metrics.update(metrics)
 
             return collected_metrics
@@ -701,9 +785,7 @@ class RayGpuMonitorLogger:
             print(f"Error collecting GPU metrics: {e}")
             return {}
 
-    def _fetch_and_parse_metrics(
-        self, node_idx: int, metric_address: str, parser_fn: Callable
-    ):
+    def _fetch_and_parse_metrics(self, node_idx: int, metric_address: str, parser_fn: Callable):
         """Fetch metrics from a node and parse GPU metrics.
 
         Args:
@@ -778,9 +860,7 @@ class MLflowLogger(LoggerInterface):
             mlflow.set_tracking_uri(tracking_uri)
 
         run_id = cfg.get("run_id") or os.getenv("MLFLOW_RUN_ID")
-        experiment_name = cfg.get("experiment_name") or os.getenv(
-            "MLFLOW_EXPERIMENT_NAME"
-        )
+        experiment_name = cfg.get("experiment_name") or os.getenv("MLFLOW_EXPERIMENT_NAME")
         run_name = cfg.get("run_name") or os.getenv("MLFLOW_RUN_NAME")
 
         run = mlflow.active_run()
@@ -817,9 +897,7 @@ class MLflowLogger(LoggerInterface):
 
         self.run = run
         self.run_id = run.info.run_id
-        print(
-            f"Initialized MLflowLogger for experiment {experiment_name}, run {run_name}"
-        )
+        print(f"Initialized MLflowLogger for experiment {experiment_name}, run {run_name}")
 
     def log_metrics(
         self,
@@ -864,9 +942,7 @@ class MLflowLogger(LoggerInterface):
             name: Name of the plot
         """
         # Use bbox_inches="tight" to remove extra whitespace/padding around the plot
-        mlflow.log_figure(
-            figure, f"plots/{name}.png", save_kwargs={"bbox_inches": "tight"}
-        )
+        mlflow.log_figure(figure, f"plots/{name}.png", save_kwargs={"bbox_inches": "tight"})
 
     def log_histogram(self, histogram: list[Any], step: int, name: str) -> None:
         """Log histogram metrics to MLflow."""
@@ -890,14 +966,17 @@ class Logger(LoggerInterface):
         Parameters:
             cfg (LoggerConfig): Configuration mapping. Expected keys include:
                 - "log_dir": base directory for backend logs.
-                - "wandb_enabled", "swanlab_enabled", "tensorboard_enabled", "mlflow_enabled": booleans to enable backends.
-                - "wandb", "swanlab", "tensorboard", "mlflow": per-backend configuration dicts.
+                - "wandb_enabled", "trackio_enabled", "swanlab_enabled", "tensorboard_enabled", "mlflow_enabled": booleans to enable backends.
+                - "wandb", "trackio", "swanlab", "tensorboard", "mlflow": per-backend configuration dicts.
                 - "monitor_gpus": boolean to enable Ray GPU monitoring.
                 - "gpu_monitoring": dict with "collection_interval" and "flush_interval" when GPU monitoring is enabled.
         """
         self.loggers: list[LoggerInterface] = []
         self.wandb_logger = None
+        self.trackio_logger = None
         self.swanlab_logger = None
+        self.gpu_monitor = None
+        self._closed = False
 
         self.base_log_dir = cfg["log_dir"]
         os.makedirs(self.base_log_dir, exist_ok=True)
@@ -908,6 +987,12 @@ class Logger(LoggerInterface):
             self.wandb_logger = WandbLogger(cfg["wandb"], log_dir=wandb_log_dir)
             self.loggers.append(self.wandb_logger)
 
+        if cfg.get("trackio_enabled", False):
+            trackio_log_dir = os.path.join(self.base_log_dir, "trackio")
+            os.makedirs(trackio_log_dir, exist_ok=True)
+            self.trackio_logger = TrackioLogger(cfg.get("trackio", {}), log_dir=trackio_log_dir)
+            self.loggers.append(self.trackio_logger)
+
         if cfg["swanlab_enabled"]:
             swanlab_log_dir = os.path.join(self.base_log_dir, "swanlab")
             os.makedirs(swanlab_log_dir, exist_ok=True)
@@ -917,9 +1002,7 @@ class Logger(LoggerInterface):
         if cfg["tensorboard_enabled"]:
             tensorboard_log_dir = os.path.join(self.base_log_dir, "tensorboard")
             os.makedirs(tensorboard_log_dir, exist_ok=True)
-            tensorboard_logger = TensorboardLogger(
-                cfg["tensorboard"], log_dir=tensorboard_log_dir
-            )
+            tensorboard_logger = TensorboardLogger(cfg["tensorboard"], log_dir=tensorboard_log_dir)
             self.loggers.append(tensorboard_logger)
 
         if cfg["mlflow_enabled"]:
@@ -931,14 +1014,11 @@ class Logger(LoggerInterface):
             self.loggers.append(mlflow_logger)
 
         # Initialize GPU monitoring if requested
-        self.gpu_monitor = None
         if cfg["monitor_gpus"]:
             metric_prefix = "ray"
             step_metric = f"{metric_prefix}/ray_step"
             if cfg["wandb_enabled"] and self.wandb_logger:
-                self.wandb_logger.define_metric(
-                    f"{metric_prefix}/*", step_metric=step_metric
-                )
+                self.wandb_logger.define_metric(f"{metric_prefix}/*", step_metric=step_metric)
 
             self.gpu_monitor = RayGpuMonitorLogger(
                 collection_interval=cfg["gpu_monitoring"]["collection_interval"],
@@ -981,9 +1061,7 @@ class Logger(LoggerInterface):
         for logger in self.loggers:
             logger.log_hyperparams(params)
 
-    def log_batched_dict_as_jsonl(
-        self, to_log: BatchedDataDict[Any] | dict[str, Any], filename: str
-    ) -> None:
+    def log_batched_dict_as_jsonl(self, to_log: BatchedDataDict[Any] | dict[str, Any], filename: str) -> None:
         """Log a list of dictionaries to a JSONL file.
 
         Args:
@@ -1044,15 +1122,11 @@ class Logger(LoggerInterface):
             timeline_interval: Interval between timeline points (in seconds)
         """
         if not metrics:
-            print(
-                f"Skipping {name} per-worker timeline logging because no metrics were provided."
-            )
+            print(f"Skipping {name} per-worker timeline logging because no metrics were provided.")
             return
 
         if timeline_interval <= 0:
-            raise ValueError(
-                f"timeline_interval must be positive; received {timeline_interval}"
-            )
+            raise ValueError(f"timeline_interval must be positive; received {timeline_interval}")
 
         # Plot the per-worker timeline metrics
         x_series: list[list[float]] = []
@@ -1060,9 +1134,7 @@ class Logger(LoggerInterface):
         series_labels: list[str] = []
 
         if not any(metrics.values()):
-            print(
-                f"Skipping {name} per-worker timeline logging because all series were empty."
-            )
+            print(f"Skipping {name} per-worker timeline logging because all series were empty.")
             return
 
         for worker_id in sorted(metrics.keys()):
@@ -1126,9 +1198,7 @@ class Logger(LoggerInterface):
         for logger in self.loggers:
             logger.log_plot(figure, step, name)
 
-    def log_plot_token_mult_prob_error(
-        self, data: dict[str, Any], step: int, name: str
-    ) -> None:
+    def log_plot_token_mult_prob_error(self, data: dict[str, Any], step: int, name: str) -> None:
         """Log a plot of log probability errors in samples.
 
         This function logs & plots the per-token log-probabilities and errors over the sequence
@@ -1167,13 +1237,9 @@ class Logger(LoggerInterface):
             )
             return
 
-        generation_logprob = generation_logprobs[
-            sample_idx, int(generation_start_idx) : int(generation_end_idx)
-        ]
+        generation_logprob = generation_logprobs[sample_idx, int(generation_start_idx) : int(generation_end_idx)]
         prev_logprob = (
-            prev_logprobs[
-                sample_idx, int(generation_start_idx) : int(generation_end_idx)
-            ]
+            prev_logprobs[sample_idx, int(generation_start_idx) : int(generation_end_idx)]
             * mask[sample_idx, int(generation_start_idx) : int(generation_end_idx)]
         )
         diff_i = diff[sample_idx, int(generation_start_idx) : int(generation_end_idx)]
@@ -1227,8 +1293,25 @@ class Logger(LoggerInterface):
 
     def __del__(self) -> None:
         """Clean up resources when the logger is destroyed."""
+        try:
+            self.close()
+        except Exception:
+            pass
+
+    def close(self) -> None:
+        """Close logger backends and flush any buffered logs."""
+        if self._closed:
+            return
+        self._closed = True
+
         if self.gpu_monitor:
             self.gpu_monitor.stop()
+            self.gpu_monitor = None
+
+        for logger in self.loggers:
+            close = getattr(logger, "close", None)
+            if callable(close):
+                close()
 
 
 def flatten_dict(d: Mapping[str, Any], sep: str = ".") -> dict[str, Any]:
@@ -1286,9 +1369,7 @@ Functions for setting up rich console logging and visualizing model outputs.
 """
 
 
-def configure_rich_logging(
-    level: str = "INFO", show_time: bool = True, show_path: bool = True
-) -> None:
+def configure_rich_logging(level: str = "INFO", show_time: bool = True, show_path: bool = True) -> None:
     """Configure rich logging for more visually appealing log output.
 
     Args:
@@ -1345,9 +1426,7 @@ def print_message_log_samples(
         print("⚠️ No valid message logs to display")
         return
 
-    assert len(message_logs) == len(rewards), (
-        "Message logs and rewards must have the same length"
-    )
+    assert len(message_logs) == len(rewards), "Message logs and rewards must have the same length"
 
     # Sample up to num_samples (or all if less)
     num_to_show = min(num_samples, len(message_logs))
@@ -1419,9 +1498,7 @@ def print_message_log_samples(
 
         bar = f"[{color}]{bar_char * bar_len}[/]"
         # Format with color based on reward value
-        discrete_lines.append(
-            f"{emoji} Reward [bold {color}]{reward:.4f}[/]: {bar} ({count} samples)"
-        )
+        discrete_lines.append(f"{emoji} Reward [bold {color}]{reward:.4f}[/]: {bar} ({count} samples)")
 
     # Create a summary panel
     avg_reward = sum(all_rewards) / len(all_rewards) if all_rewards else 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ mcore = [
   "deep_ep @ git+https://github.com/deepseek-ai/DeepEP.git@bfded34800dfec415b71503f8205181de90b2480",
 ]
 nemo_gym = ["nemo_gym"]
+trackio = ["trackio==0.25.1"]
 
 [dependency-groups]
 

--- a/tests/unit/utils/test_logger.py
+++ b/tests/unit/utils/test_logger.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import shutil
+import sys
 import tempfile
 from unittest.mock import MagicMock, call, patch
 
@@ -25,6 +26,7 @@ from nemo_rl.utils.logger import (
     RayGpuMonitorLogger,
     SwanlabLogger,
     TensorboardLogger,
+    TrackioLogger,
     WandbLogger,
     flatten_dict,
     print_message_log_samples,
@@ -342,9 +344,7 @@ class TestWandbLogger:
 
         # Check that define_metric was called
         mock_run = mock_wandb.init.return_value
-        mock_run.define_metric.assert_called_once_with(
-            "ray/*", step_metric="ray/ray_step"
-        )
+        mock_run.define_metric.assert_called_once_with("ray/*", step_metric="ray/ray_step")
 
     @patch("nemo_rl.utils.logger.wandb")
     def test_log_hyperparams(self, mock_wandb):
@@ -358,6 +358,159 @@ class TestWandbLogger:
         # Check that config.update was called with params
         mock_run = mock_wandb.init.return_value
         mock_run.config.update.assert_called_once_with(params, allow_val_change=True)
+
+
+class TestTrackioLogger:
+    """Test the TrackioLogger class."""
+
+    @pytest.fixture
+    def temp_dir(self):
+        """Create a temporary directory for logs."""
+        temp_dir = tempfile.mkdtemp()
+        yield temp_dir
+        shutil.rmtree(temp_dir)
+
+    def _mock_trackio(self):
+        mock_trackio = MagicMock()
+        mock_run = MagicMock()
+        mock_run.config = {}
+        mock_trackio.init.return_value = mock_run
+        return mock_trackio, mock_run
+
+    def test_init_custom_config(self, temp_dir):
+        """Test initialization of TrackioLogger with custom config."""
+        mock_trackio, _ = self._mock_trackio()
+        cfg = {
+            "project": "custom-project",
+            "name": "custom-run",
+            "group": "custom-group",
+            "space_id": "org/space",
+            "server_url": "http://localhost:7860",
+            "bucket_id": "org/bucket",
+            "resume": "allow",
+            "private": True,
+            "embed": False,
+            "auto_log_gpu": False,
+            "gpu_log_interval": 5.0,
+            "webhook_url": "http://hooks.example",
+            "webhook_min_level": "warn",
+            "dir": temp_dir,
+        }
+
+        with patch.dict(sys.modules, {"trackio": mock_trackio}):
+            with patch.dict("os.environ", {}, clear=False):
+                TrackioLogger(cfg, log_dir=temp_dir)
+
+        mock_trackio.init.assert_called_once_with(
+            project="custom-project",
+            name="custom-run",
+            group="custom-group",
+            space_id="org/space",
+            server_url="http://localhost:7860",
+            bucket_id="org/bucket",
+            resume="allow",
+            private=True,
+            embed=False,
+            auto_log_gpu=False,
+            gpu_log_interval=5.0,
+            webhook_url="http://hooks.example",
+            webhook_min_level="warn",
+        )
+
+    def test_init_missing_dependency(self):
+        """Test a helpful error when Trackio is not installed."""
+        original_import = __import__
+
+        def import_side_effect(name, *args, **kwargs):
+            if name == "trackio":
+                raise ImportError("No module named trackio")
+            return original_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=import_side_effect):
+            with pytest.raises(ImportError, match="uv sync --extra trackio"):
+                TrackioLogger({"project": "test-project"})
+
+    def test_init_requires_project(self):
+        """Test Trackio project validation."""
+        mock_trackio, _ = self._mock_trackio()
+
+        with patch.dict(sys.modules, {"trackio": mock_trackio}):
+            with pytest.raises(ValueError, match="logger.trackio.project"):
+                TrackioLogger({})
+
+    def test_log_metrics(self):
+        """Test logging metrics to TrackioLogger."""
+        mock_trackio, mock_run = self._mock_trackio()
+        with patch.dict(sys.modules, {"trackio": mock_trackio}):
+            logger = TrackioLogger({"project": "test-project"})
+
+        metrics = {"loss": 0.5, "accuracy": 0.8}
+        logger.log_metrics(metrics, step=10)
+
+        mock_run.log.assert_called_once_with(metrics, step=10)
+
+    def test_log_metrics_with_prefix_and_step_metric(self):
+        """Test logging prefixed metrics to TrackioLogger."""
+        mock_trackio, mock_run = self._mock_trackio()
+        with patch.dict(sys.modules, {"trackio": mock_trackio}):
+            logger = TrackioLogger({"project": "test-project"})
+
+        metrics = {"loss": 0.5, "iteration": 15}
+        logger.log_metrics(metrics, step=10, prefix="train", step_metric="train/iteration")
+
+        mock_run.log.assert_called_once_with({"train/loss": 0.5, "train/iteration": 15}, step=15)
+
+    def test_log_hyperparams(self):
+        """Test logging hyperparameters to TrackioLogger."""
+        mock_trackio, mock_run = self._mock_trackio()
+        with patch.dict(sys.modules, {"trackio": mock_trackio}):
+            logger = TrackioLogger({"project": "test-project"})
+
+        params = {"lr": 0.001, "model": {"hidden_size": 128}}
+        logger.log_hyperparams(params)
+
+        assert mock_run.config == params
+
+    def test_log_plot(self):
+        """Test logging plots to TrackioLogger."""
+        from matplotlib import pyplot as plt
+
+        mock_trackio, mock_run = self._mock_trackio()
+        mock_trackio.Image.return_value = "trackio-image"
+        with patch.dict(sys.modules, {"trackio": mock_trackio}):
+            logger = TrackioLogger({"project": "test-project"})
+
+        fig, ax = plt.subplots()
+        ax.plot([1, 2], [3, 4])
+        logger.log_plot(fig, step=10, name="test_plot")
+        plt.close(fig)
+
+        mock_trackio.Image.assert_called_once()
+        mock_run.log.assert_called_once_with({"test_plot": "trackio-image"}, step=10)
+
+    def test_log_histogram(self):
+        """Test logging histograms to TrackioLogger."""
+        mock_trackio, mock_run = self._mock_trackio()
+        mock_trackio.Histogram.return_value = "trackio-histogram"
+        with patch.dict(sys.modules, {"trackio": mock_trackio}):
+            logger = TrackioLogger({"project": "test-project"})
+
+        histogram = [1, 2, 3]
+        logger.log_histogram(histogram, step=10, name="values")
+
+        mock_trackio.Histogram.assert_called_once_with(histogram)
+        mock_run.log.assert_called_once_with({"values": "trackio-histogram"}, step=10)
+
+    def test_close_is_idempotent(self):
+        """Test Trackio run finish is called once."""
+        mock_trackio, mock_run = self._mock_trackio()
+        with patch.dict(sys.modules, {"trackio": mock_trackio}):
+            logger = TrackioLogger({"project": "test-project"})
+
+        logger.close()
+        logger.close()
+
+        mock_run.finish.assert_called_once()
 
 
 class TestSwanlabLogger:
@@ -540,9 +693,7 @@ class TestMLflowLogger:
 
         # Check that log_metric was called for each metric
         assert mock_mlflow.log_metrics.call_count == 1
-        mock_mlflow.log_metrics.assert_any_call(
-            {"loss": 0.5, "accuracy": 0.8}, step=10, run_id=logger.run_id
-        )
+        mock_mlflow.log_metrics.assert_any_call({"loss": 0.5, "accuracy": 0.8}, step=10, run_id=logger.run_id)
 
     @patch("nemo_rl.utils.logger.mlflow")
     def test_log_metrics_with_prefix(self, mock_mlflow, temp_dir):
@@ -644,9 +795,7 @@ class TestMLflowLogger:
         MLflowLogger(cfg, log_dir=None)
 
         # Verify create_experiment was called without artifact_location
-        mock_mlflow.create_experiment.assert_called_once_with(
-            name="test-experiment", artifact_location=None
-        )
+        mock_mlflow.create_experiment.assert_called_once_with(name="test-experiment", artifact_location=None)
         mock_mlflow.start_run.assert_called_once_with(run_name="test-run")
 
     @patch("nemo_rl.utils.logger.mlflow")
@@ -665,9 +814,7 @@ class TestMLflowLogger:
         MLflowLogger(cfg, log_dir="/custom/path")
 
         # Verify create_experiment was called with artifact_location
-        mock_mlflow.create_experiment.assert_called_once_with(
-            name="test-experiment", artifact_location="/custom/path"
-        )
+        mock_mlflow.create_experiment.assert_called_once_with(name="test-experiment", artifact_location="/custom/path")
         mock_mlflow.start_run.assert_called_once_with(run_name="test-run")
 
     @patch("nemo_rl.utils.logger.mlflow")
@@ -739,9 +886,7 @@ class TestMLflowLogger:
         MLflowLogger(cfg, log_dir=log_dir)
 
         # Verify create_experiment was called with log_dir as artifact_location
-        mock_mlflow.create_experiment.assert_called_once_with(
-            name=cfg["experiment_name"], artifact_location=log_dir
-        )
+        mock_mlflow.create_experiment.assert_called_once_with(name=cfg["experiment_name"], artifact_location=log_dir)
         mock_mlflow.set_tracking_uri.assert_called_once_with(cfg["tracking_uri"])
         mock_mlflow.start_run.assert_called_once_with(run_name=cfg["run_name"])
 
@@ -1012,9 +1157,7 @@ ray_node_gram_used{{GpuIndex="0",GpuDeviceName="NVIDIA Test GPU"}} {80.0 * 1024}
             )
 
             # Verify request was made correctly
-            mock_get.assert_called_once_with(
-                "http://test_ip:test_port/metrics", timeout=5.0
-            )
+            mock_get.assert_called_once_with("http://test_ip:test_port/metrics", timeout=5.0)
 
             # Verify parsing was done for both metrics
             assert mock_parse.call_count == 2
@@ -1232,12 +1375,8 @@ ray_node_gram_used{{GpuIndex="0",GpuDeviceName="NVIDIA Test GPU"}} {80.0 * 1024}
 
                 # Verify monitor.metrics_buffer has the collected metrics
                 assert len(monitor.metrics_buffer) == 1
-                assert (
-                    monitor.metrics_buffer[0]["step"] == 10
-                )  # relative time (110 - 100)
-                assert monitor.metrics_buffer[0]["metrics"] == {
-                    "node.0.gpu.0.util": 75.5
-                }
+                assert monitor.metrics_buffer[0]["step"] == 10  # relative time (110 - 100)
+                assert monitor.metrics_buffer[0]["metrics"] == {"node.0.gpu.0.util": 75.5}
 
                 # Verify flush was called (flush_interval elapsed)
                 mock_flush.assert_called_once()
@@ -1245,9 +1384,7 @@ ray_node_gram_used{{GpuIndex="0",GpuDeviceName="NVIDIA Test GPU"}} {80.0 * 1024}
     @patch("nemo_rl.utils.logger.WandbLogger")
     @patch("nemo_rl.utils.logger.TensorboardLogger")
     @patch("nemo_rl.utils.logger.RayGpuMonitorLogger")
-    def test_init_with_gpu_monitoring(
-        self, mock_gpu_monitor, mock_tb_logger, mock_wandb_logger, temp_dir
-    ):
+    def test_init_with_gpu_monitoring(self, mock_gpu_monitor, mock_tb_logger, mock_wandb_logger, temp_dir):
         """Test initialization with GPU monitoring enabled."""
         cfg = {
             "wandb_enabled": True,
@@ -1285,16 +1422,12 @@ ray_node_gram_used{{GpuIndex="0",GpuDeviceName="NVIDIA Test GPU"}} {80.0 * 1024}
 
         # Check that wandb metrics are defined with the step metric
         mock_wandb_instance = mock_wandb_logger.return_value
-        mock_wandb_instance.define_metric.assert_called_once_with(
-            "ray/*", step_metric="ray/ray_step"
-        )
+        mock_wandb_instance.define_metric.assert_called_once_with("ray/*", step_metric="ray/ray_step")
 
     @patch("nemo_rl.utils.logger.WandbLogger")
     @patch("nemo_rl.utils.logger.TensorboardLogger")
     @patch("nemo_rl.utils.logger.RayGpuMonitorLogger")
-    def test_gpu_monitoring_without_wandb(
-        self, mock_gpu_monitor, mock_tb_logger, mock_wandb_logger, temp_dir
-    ):
+    def test_gpu_monitoring_without_wandb(self, mock_gpu_monitor, mock_tb_logger, mock_wandb_logger, temp_dir):
         """Test GPU monitoring initialization when wandb is disabled."""
         cfg = {
             "wandb_enabled": False,
@@ -1332,9 +1465,7 @@ ray_node_gram_used{{GpuIndex="0",GpuDeviceName="NVIDIA Test GPU"}} {80.0 * 1024}
     @patch("nemo_rl.utils.logger.WandbLogger")
     @patch("nemo_rl.utils.logger.TensorboardLogger")
     @patch("nemo_rl.utils.logger.RayGpuMonitorLogger")
-    def test_gpu_monitoring_no_main_loggers(
-        self, mock_gpu_monitor, mock_tb_logger, mock_wandb_logger, temp_dir
-    ):
+    def test_gpu_monitoring_no_main_loggers(self, mock_gpu_monitor, mock_tb_logger, mock_wandb_logger, temp_dir):
         """Test GPU monitoring initialization when no main loggers (wandb/tensorboard) are enabled."""
         cfg = {
             "wandb_enabled": False,
@@ -1422,6 +1553,53 @@ class TestLogger:
         mock_wandb_logger.assert_called_once()
         wandb_cfg = mock_wandb_logger.call_args[0][0]
         assert wandb_cfg == {"project": "test-project"}
+        mock_tb_logger.assert_not_called()
+
+    @patch("nemo_rl.utils.logger.WandbLogger")
+    @patch("nemo_rl.utils.logger.TrackioLogger")
+    @patch("nemo_rl.utils.logger.TensorboardLogger")
+    def test_init_trackio_only(self, mock_tb_logger, mock_trackio_logger, mock_wandb_logger, temp_dir):
+        """Test initialization with only TrackioLogger enabled."""
+        cfg = {
+            "wandb_enabled": False,
+            "trackio_enabled": True,
+            "tensorboard_enabled": False,
+            "mlflow_enabled": False,
+            "swanlab_enabled": False,
+            "monitor_gpus": False,
+            "trackio": {"project": "test-project"},
+            "log_dir": temp_dir,
+        }
+        logger = Logger(cfg)
+
+        assert len(logger.loggers) == 1
+        mock_trackio_logger.assert_called_once()
+        trackio_cfg = mock_trackio_logger.call_args[0][0]
+        assert trackio_cfg == {"project": "test-project"}
+        mock_wandb_logger.assert_not_called()
+        mock_tb_logger.assert_not_called()
+
+    @patch("nemo_rl.utils.logger.WandbLogger")
+    @patch("nemo_rl.utils.logger.TrackioLogger")
+    @patch("nemo_rl.utils.logger.TensorboardLogger")
+    def test_init_wandb_and_trackio(self, mock_tb_logger, mock_trackio_logger, mock_wandb_logger, temp_dir):
+        """Test initialization with WandbLogger and TrackioLogger enabled."""
+        cfg = {
+            "wandb_enabled": True,
+            "trackio_enabled": True,
+            "tensorboard_enabled": False,
+            "mlflow_enabled": False,
+            "swanlab_enabled": False,
+            "monitor_gpus": False,
+            "wandb": {"project": "wandb-project"},
+            "trackio": {"project": "trackio-project"},
+            "log_dir": temp_dir,
+        }
+        logger = Logger(cfg)
+
+        assert len(logger.loggers) == 2
+        mock_wandb_logger.assert_called_once()
+        mock_trackio_logger.assert_called_once()
         mock_tb_logger.assert_not_called()
 
     @patch("nemo_rl.utils.logger.WandbLogger")
@@ -1517,12 +1695,8 @@ class TestLogger:
         logger.log_metrics(metrics, step)
 
         # Check that log_metrics was called on both loggers
-        mock_wandb_instance.log_metrics.assert_called_once_with(
-            metrics, step, "", None, False
-        )
-        mock_tb_instance.log_metrics.assert_called_once_with(
-            metrics, step, "", None, False
-        )
+        mock_wandb_instance.log_metrics.assert_called_once_with(metrics, step, "", None, False)
+        mock_tb_instance.log_metrics.assert_called_once_with(metrics, step, "", None, False)
 
     @patch("nemo_rl.utils.logger.WandbLogger")
     @patch("nemo_rl.utils.logger.TensorboardLogger")
@@ -1554,9 +1728,7 @@ class TestLogger:
     @patch("nemo_rl.utils.logger.WandbLogger")
     @patch("nemo_rl.utils.logger.TensorboardLogger")
     @patch("nemo_rl.utils.logger.RayGpuMonitorLogger")
-    def test_init_with_gpu_monitoring(
-        self, mock_gpu_monitor, mock_tb_logger, mock_wandb_logger, temp_dir
-    ):
+    def test_init_with_gpu_monitoring(self, mock_gpu_monitor, mock_tb_logger, mock_wandb_logger, temp_dir):
         """Test initialization with GPU monitoring enabled."""
         cfg = {
             "wandb_enabled": True,
@@ -1594,15 +1766,11 @@ class TestLogger:
 
         # Check that wandb metrics are defined with the step metric
         mock_wandb_instance = mock_wandb_logger.return_value
-        mock_wandb_instance.define_metric.assert_called_once_with(
-            "ray/*", step_metric="ray/ray_step"
-        )
+        mock_wandb_instance.define_metric.assert_called_once_with("ray/*", step_metric="ray/ray_step")
 
     @patch("nemo_rl.utils.logger.WandbLogger")
     @patch("nemo_rl.utils.logger.TensorboardLogger")
-    def test_log_metrics_with_prefix_and_step_metric(
-        self, mock_tb_logger, mock_wandb_logger, temp_dir
-    ):
+    def test_log_metrics_with_prefix_and_step_metric(self, mock_tb_logger, mock_wandb_logger, temp_dir):
         """Test logging metrics with prefix and step_metric."""
         cfg = {
             "wandb_enabled": True,
@@ -1630,18 +1798,12 @@ class TestLogger:
         logger.log_metrics(metrics, step, prefix=prefix, step_metric=step_metric)
 
         # Check that log_metrics was called on both loggers with correct parameters
-        mock_wandb_instance.log_metrics.assert_called_once_with(
-            metrics, step, prefix, step_metric, False
-        )
-        mock_tb_instance.log_metrics.assert_called_once_with(
-            metrics, step, prefix, step_metric, False
-        )
+        mock_wandb_instance.log_metrics.assert_called_once_with(metrics, step, prefix, step_metric, False)
+        mock_tb_instance.log_metrics.assert_called_once_with(metrics, step, prefix, step_metric, False)
 
     @patch("nemo_rl.utils.logger.WandbLogger")
     @patch("nemo_rl.utils.logger.TensorboardLogger")
-    def test_log_plot_token_mult_prob_error(
-        self, mock_tb_logger, mock_wandb_logger, temp_dir
-    ):
+    def test_log_plot_token_mult_prob_error(self, mock_tb_logger, mock_wandb_logger, temp_dir):
         """Test logging token probability error plots."""
         cfg = {
             "wandb_enabled": True,
@@ -1697,9 +1859,7 @@ class TestLogger:
     @patch("nemo_rl.utils.logger.WandbLogger")
     @patch("nemo_rl.utils.logger.TensorboardLogger")
     @patch("nemo_rl.utils.logger.MLflowLogger")
-    def test_init_mlflow_only(
-        self, mock_mlflow_logger, mock_tb_logger, mock_wandb_logger, temp_dir
-    ):
+    def test_init_mlflow_only(self, mock_mlflow_logger, mock_tb_logger, mock_wandb_logger, temp_dir):
         """Test initialization with only MLflowLogger enabled."""
         cfg = {
             "wandb_enabled": False,
@@ -1800,18 +1960,10 @@ class TestLogger:
         logger.log_metrics(metrics, step)
 
         # Check that log_metrics was called on all loggers
-        mock_wandb_instance.log_metrics.assert_called_once_with(
-            metrics, step, "", None, False
-        )
-        mock_swanlab_instance.log_metrics.assert_called_once_with(
-            metrics, step, "", None, False
-        )
-        mock_tb_instance.log_metrics.assert_called_once_with(
-            metrics, step, "", None, False
-        )
-        mock_mlflow_instance.log_metrics.assert_called_once_with(
-            metrics, step, "", None, False
-        )
+        mock_wandb_instance.log_metrics.assert_called_once_with(metrics, step, "", None, False)
+        mock_swanlab_instance.log_metrics.assert_called_once_with(metrics, step, "", None, False)
+        mock_tb_instance.log_metrics.assert_called_once_with(metrics, step, "", None, False)
+        mock_mlflow_instance.log_metrics.assert_called_once_with(metrics, step, "", None, False)
 
     @patch("nemo_rl.utils.logger.WandbLogger")
     @patch("nemo_rl.utils.logger.TensorboardLogger")

--- a/uv.lock
+++ b/uv.lock
@@ -2066,6 +2066,22 @@ wheels = [
 ]
 
 [[package]]
+name = "gradio-client"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fsspec" },
+    { name = "httpx" },
+    { name = "huggingface-hub" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/e6/6b6029f5fe2ad7f1211105d530e34d991014c2cae463f9223033031cfc4f/gradio_client-2.5.0.tar.gz", hash = "sha256:4cde99bad62149595c30c90876ca2e405e3a13687ecf895474f3412cb476673d", size = 59013, upload-time = "2026-04-20T23:16:21.518Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/81/0a861b8e1ff42960139c6cd4c7dd591292fa09ea1ae2d87677441cba4c00/gradio_client-2.5.0-py3-none-any.whl", hash = "sha256:d43e2179c29076292a76485ad7ed2e6eaa19d14ac58283bd7f5beabfe4ca958c", size = 59952, upload-time = "2026-04-20T23:16:20.186Z" },
+]
+
+[[package]]
 name = "graphene"
 version = "3.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2237,31 +2253,34 @@ wheels = [
 
 [[package]]
 name = "hf-xet"
-version = "1.2.0"
+version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/6e/0f11bacf08a67f7fb5ee09740f2ca54163863b07b70d579356e9222ce5d8/hf_xet-1.2.0.tar.gz", hash = "sha256:a8c27070ca547293b6890c4bf389f713f80e8c478631432962bb7f4bc0bd7d7f", size = 506020, upload-time = "2025-10-24T19:04:32.129Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/92/ec9ad04d0b5728dca387a45af7bc98fbb0d73b2118759f5f6038b61a57e8/hf_xet-1.4.3.tar.gz", hash = "sha256:8ddedb73c8c08928c793df2f3401ec26f95be7f7e516a7bee2fbb546f6676113", size = 670477, upload-time = "2026-03-31T22:40:07.874Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/a5/85ef910a0aa034a2abcfadc360ab5ac6f6bc4e9112349bd40ca97551cff0/hf_xet-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ceeefcd1b7aed4956ae8499e2199607765fbd1c60510752003b6cc0b8413b649", size = 2861870, upload-time = "2025-10-24T19:04:11.422Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/40/e2e0a7eb9a51fe8828ba2d47fe22a7e74914ea8a0db68a18c3aa7449c767/hf_xet-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b70218dd548e9840224df5638fdc94bd033552963cfa97f9170829381179c813", size = 2717584, upload-time = "2025-10-24T19:04:09.586Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/7d/daf7f8bc4594fdd59a8a596f9e3886133fdc68e675292218a5e4c1b7e834/hf_xet-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d40b18769bb9a8bc82a9ede575ce1a44c75eb80e7375a01d76259089529b5dc", size = 3315004, upload-time = "2025-10-24T19:04:00.314Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/ba/45ea2f605fbf6d81c8b21e4d970b168b18a53515923010c312c06cd83164/hf_xet-1.2.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd3a6027d59cfb60177c12d6424e31f4b5ff13d8e3a1247b3a584bf8977e6df5", size = 3222636, upload-time = "2025-10-24T19:03:58.111Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/1d/04513e3cab8f29ab8c109d309ddd21a2705afab9d52f2ba1151e0c14f086/hf_xet-1.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6de1fc44f58f6dd937956c8d304d8c2dea264c80680bcfa61ca4a15e7b76780f", size = 3408448, upload-time = "2025-10-24T19:04:20.951Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/7c/60a2756d7feec7387db3a1176c632357632fbe7849fce576c5559d4520c7/hf_xet-1.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f182f264ed2acd566c514e45da9f2119110e48a87a327ca271027904c70c5832", size = 3503401, upload-time = "2025-10-24T19:04:22.549Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/64/48fffbd67fb418ab07451e4ce641a70de1c40c10a13e25325e24858ebe5a/hf_xet-1.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:293a7a3787e5c95d7be1857358a9130694a9c6021de3f27fa233f37267174382", size = 2900866, upload-time = "2025-10-24T19:04:33.461Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/51/f7e2caae42f80af886db414d4e9885fac959330509089f97cccb339c6b87/hf_xet-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:10bfab528b968c70e062607f663e21e34e2bba349e8038db546646875495179e", size = 2861861, upload-time = "2025-10-24T19:04:19.01Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/1d/a641a88b69994f9371bd347f1dd35e5d1e2e2460a2e350c8d5165fc62005/hf_xet-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2a212e842647b02eb6a911187dc878e79c4aa0aa397e88dd3b26761676e8c1f8", size = 2717699, upload-time = "2025-10-24T19:04:17.306Z" },
-    { url = "https://files.pythonhosted.org/packages/df/e0/e5e9bba7d15f0318955f7ec3f4af13f92e773fbb368c0b8008a5acbcb12f/hf_xet-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:30e06daccb3a7d4c065f34fc26c14c74f4653069bb2b194e7f18f17cbe9939c0", size = 3314885, upload-time = "2025-10-24T19:04:07.642Z" },
-    { url = "https://files.pythonhosted.org/packages/21/90/b7fe5ff6f2b7b8cbdf1bd56145f863c90a5807d9758a549bf3d916aa4dec/hf_xet-1.2.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:29c8fc913a529ec0a91867ce3d119ac1aac966e098cf49501800c870328cc090", size = 3221550, upload-time = "2025-10-24T19:04:05.55Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/cb/73f276f0a7ce46cc6a6ec7d6c7d61cbfe5f2e107123d9bbd0193c355f106/hf_xet-1.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e159cbfcfbb29f920db2c09ed8b660eb894640d284f102ada929b6e3dc410a", size = 3408010, upload-time = "2025-10-24T19:04:28.598Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/1e/d642a12caa78171f4be64f7cd9c40e3ca5279d055d0873188a58c0f5fbb9/hf_xet-1.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c91d5ae931510107f148874e9e2de8a16052b6f1b3ca3c1b12f15ccb491390f", size = 3503264, upload-time = "2025-10-24T19:04:30.397Z" },
-    { url = "https://files.pythonhosted.org/packages/17/b5/33764714923fa1ff922770f7ed18c2daae034d21ae6e10dbf4347c854154/hf_xet-1.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:210d577732b519ac6ede149d2f2f34049d44e8622bf14eb3d63bbcd2d4b332dc", size = 2901071, upload-time = "2025-10-24T19:04:37.463Z" },
-    { url = "https://files.pythonhosted.org/packages/96/2d/22338486473df5923a9ab7107d375dbef9173c338ebef5098ef593d2b560/hf_xet-1.2.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:46740d4ac024a7ca9b22bebf77460ff43332868b661186a8e46c227fdae01848", size = 2866099, upload-time = "2025-10-24T19:04:15.366Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/8c/c5becfa53234299bc2210ba314eaaae36c2875e0045809b82e40a9544f0c/hf_xet-1.2.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:27df617a076420d8845bea087f59303da8be17ed7ec0cd7ee3b9b9f579dff0e4", size = 2722178, upload-time = "2025-10-24T19:04:13.695Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/92/cf3ab0b652b082e66876d08da57fcc6fa2f0e6c70dfbbafbd470bb73eb47/hf_xet-1.2.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3651fd5bfe0281951b988c0facbe726aa5e347b103a675f49a3fa8144c7968fd", size = 3320214, upload-time = "2025-10-24T19:04:03.596Z" },
-    { url = "https://files.pythonhosted.org/packages/46/92/3f7ec4a1b6a65bf45b059b6d4a5d38988f63e193056de2f420137e3c3244/hf_xet-1.2.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d06fa97c8562fb3ee7a378dd9b51e343bc5bc8190254202c9771029152f5e08c", size = 3229054, upload-time = "2025-10-24T19:04:01.949Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/dd/7ac658d54b9fb7999a0ccb07ad863b413cbaf5cf172f48ebcd9497ec7263/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4c1428c9ae73ec0939410ec73023c4f842927f39db09b063b9482dac5a3bb737", size = 3413812, upload-time = "2025-10-24T19:04:24.585Z" },
-    { url = "https://files.pythonhosted.org/packages/92/68/89ac4e5b12a9ff6286a12174c8538a5930e2ed662091dd2572bbe0a18c8a/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a55558084c16b09b5ed32ab9ed38421e2d87cf3f1f89815764d1177081b99865", size = 3508920, upload-time = "2025-10-24T19:04:26.927Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/44/870d44b30e1dcfb6a65932e3e1506c103a8a5aea9103c337e7a53180322c/hf_xet-1.2.0-cp37-abi3-win_amd64.whl", hash = "sha256:e6584a52253f72c9f52f9e549d5895ca7a471608495c4ecaa6cc73dba2b24d69", size = 2905735, upload-time = "2025-10-24T19:04:35.928Z" },
+    { url = "https://files.pythonhosted.org/packages/72/43/724d307b34e353da0abd476e02f72f735cdd2bc86082dee1b32ea0bfee1d/hf_xet-1.4.3-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7551659ba4f1e1074e9623996f28c3873682530aee0a846b7f2f066239228144", size = 3800935, upload-time = "2026-03-31T22:39:49.618Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d2/8bee5996b699262edb87dbb54118d287c0e1b2fc78af7cdc41857ba5e3c4/hf_xet-1.4.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:bee693ada985e7045997f05f081d0e12c4c08bd7626dc397f8a7c487e6c04f7f", size = 3558942, upload-time = "2026-03-31T22:39:47.938Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/a1/e993d09cbe251196fb60812b09a58901c468127b7259d2bf0f68bf6088eb/hf_xet-1.4.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:21644b404bb0100fe3857892f752c4d09642586fd988e61501c95bbf44b393a3", size = 4207657, upload-time = "2026-03-31T22:39:39.69Z" },
+    { url = "https://files.pythonhosted.org/packages/64/44/9eb6d21e5c34c63e5e399803a6932fa983cabdf47c0ecbcfe7ea97684b8c/hf_xet-1.4.3-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:987f09cfe418237812896a6736b81b1af02a3a6dcb4b4944425c4c4fca7a7cf8", size = 3986765, upload-time = "2026-03-31T22:39:37.936Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7b/8ad6f16fdb82f5f7284a34b5ec48645bd575bdcd2f6f0d1644775909c486/hf_xet-1.4.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:60cf7fc43a99da0a853345cf86d23738c03983ee5249613a6305d3e57a5dca74", size = 4188162, upload-time = "2026-03-31T22:39:58.382Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c4/39d6e136cbeea9ca5a23aad4b33024319222adbdc059ebcda5fc7d9d5ff4/hf_xet-1.4.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2815a49a7a59f3e2edf0cf113ae88e8cb2ca2a221bf353fb60c609584f4884d4", size = 4424525, upload-time = "2026-03-31T22:40:00.225Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f2/adc32dae6bdbc367853118b9878139ac869419a4ae7ba07185dc31251b76/hf_xet-1.4.3-cp313-cp313t-win_amd64.whl", hash = "sha256:42ee323265f1e6a81b0e11094564fb7f7e0ec75b5105ffd91ae63f403a11931b", size = 3671610, upload-time = "2026-03-31T22:40:10.42Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/19/25d897dcc3f81953e0c2cde9ec186c7a0fee413eb0c9a7a9130d87d94d3a/hf_xet-1.4.3-cp313-cp313t-win_arm64.whl", hash = "sha256:27c976ba60079fb8217f485b9c5c7fcd21c90b0367753805f87cb9f3cdc4418a", size = 3528529, upload-time = "2026-03-31T22:40:09.106Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/36/3e8f85ca9fe09b8de2b2e10c63b3b3353d7dda88a0b3d426dffbe7b8313b/hf_xet-1.4.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:5251d5ece3a81815bae9abab41cf7ddb7bcb8f56411bce0827f4a3071c92fdc6", size = 3801019, upload-time = "2026-03-31T22:39:56.651Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9c/defb6cb1de28bccb7bd8d95f6e60f72a3d3fa4cb3d0329c26fb9a488bfe7/hf_xet-1.4.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1feb0f3abeacee143367c326a128a2e2b60868ec12a36c225afb1d6c5a05e6d2", size = 3558746, upload-time = "2026-03-31T22:39:54.766Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/bd/8d001191893178ff8e826e46ad5299446e62b93cd164e17b0ffea08832ec/hf_xet-1.4.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8b301fc150290ca90b4fccd079829b84bb4786747584ae08b94b4577d82fb791", size = 4207692, upload-time = "2026-03-31T22:39:46.246Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/6790b402803250e9936435613d3a78b9aaeee7973439f0918848dde58309/hf_xet-1.4.3-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d972fbe95ddc0d3c0fc49b31a8a69f47db35c1e3699bf316421705741aab6653", size = 3986281, upload-time = "2026-03-31T22:39:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/51/56/ea62552fe53db652a9099eda600b032d75554d0e86c12a73824bfedef88b/hf_xet-1.4.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c5b48db1ee344a805a1b9bd2cda9b6b65fe77ed3787bd6e87ad5521141d317cd", size = 4187414, upload-time = "2026-03-31T22:40:04.951Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f5/bc1456d4638061bea997e6d2db60a1a613d7b200e0755965ec312dc1ef79/hf_xet-1.4.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:22bdc1f5fb8b15bf2831440b91d1c9bbceeb7e10c81a12e8d75889996a5c9da8", size = 4424368, upload-time = "2026-03-31T22:40:06.347Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/76/ab597bae87e1f06d18d3ecb8ed7f0d3c9a37037fc32ce76233d369273c64/hf_xet-1.4.3-cp314-cp314t-win_amd64.whl", hash = "sha256:0392c79b7cf48418cd61478c1a925246cf10639f4cd9d94368d8ca1e8df9ea07", size = 3672280, upload-time = "2026-03-31T22:40:16.401Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/2e462d34e23a09a74d73785dbed71cc5dbad82a72eee2ad60a72a554155d/hf_xet-1.4.3-cp314-cp314t-win_arm64.whl", hash = "sha256:681c92a07796325778a79d76c67011764ecc9042a8c3579332b61b63ae512075", size = 3528945, upload-time = "2026-03-31T22:40:14.995Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/9f/9c23e4a447b8f83120798f9279d0297a4d1360bdbf59ef49ebec78fe2545/hf_xet-1.4.3-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d0da85329eaf196e03e90b84c2d0aca53bd4573d097a75f99609e80775f98025", size = 3805048, upload-time = "2026-03-31T22:39:53.105Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/f8/7aacb8e5f4a7899d39c787b5984e912e6c18b11be136ef13947d7a66d265/hf_xet-1.4.3-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e23717ce4186b265f69afa66e6f0069fe7efbf331546f5c313d00e123dc84583", size = 3562178, upload-time = "2026-03-31T22:39:51.295Z" },
+    { url = "https://files.pythonhosted.org/packages/df/9a/a24b26dc8a65f0ecc0fe5be981a19e61e7ca963b85e062c083f3a9100529/hf_xet-1.4.3-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc360b70c815bf340ed56c7b8c63aacf11762a4b099b2fe2c9bd6d6068668c08", size = 4212320, upload-time = "2026-03-31T22:39:42.922Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/46d493db155d2ee2801b71fb1b0fd67696359047fdd8caee2c914cc50c79/hf_xet-1.4.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:39f2d2e9654cd9b4319885733993807aab6de9dfbd34c42f0b78338d6617421f", size = 3991546, upload-time = "2026-03-31T22:39:41.335Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f5/067363e1c96c6b17256910830d1b54099d06287e10f4ec6ec4e7e08371fc/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:49ad8a8cead2b56051aa84d7fce3e1335efe68df3cf6c058f22a65513885baac", size = 4193200, upload-time = "2026-03-31T22:40:01.936Z" },
+    { url = "https://files.pythonhosted.org/packages/42/4b/53951592882d9c23080c7644542fda34a3813104e9e11fa1a7d82d419cb8/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7716d62015477a70ea272d2d68cd7cad140f61c52ee452e133e139abfe2c17ba", size = 4429392, upload-time = "2026-03-31T22:40:03.492Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/21/75a6c175b4e79662ad8e62f46a40ce341d8d6b206b06b4320d07d55b188c/hf_xet-1.4.3-cp37-abi3-win_amd64.whl", hash = "sha256:6b591fcad34e272a5b02607485e4f2a1334aebf1bc6d16ce8eb1eb8978ac2021", size = 3677359, upload-time = "2026-03-31T22:40:13.619Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/7c/44314ecd0e89f8b2b51c9d9e5e7a60a9c1c82024ac471d415860557d3cd8/hf_xet-1.4.3-cp37-abi3-win_arm64.whl", hash = "sha256:7c2c7e20bcfcc946dc67187c203463f5e932e395845d098cc2a93f5b67ca0b47", size = 3533664, upload-time = "2026-03-31T22:40:12.152Z" },
 ]
 
 [[package]]
@@ -2349,7 +2368,7 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.4.1"
+version = "1.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
@@ -2358,14 +2377,13 @@ dependencies = [
     { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
-    { name = "shellingham" },
     { name = "tqdm" },
-    { name = "typer-slim" },
+    { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/fc/eb9bc06130e8bbda6a616e1b80a7aa127681c448d6b49806f61db2670b61/huggingface_hub-1.4.1.tar.gz", hash = "sha256:b41131ec35e631e7383ab26d6146b8d8972abc8b6309b963b306fbcca87f5ed5", size = 642156, upload-time = "2026-02-06T09:20:03.013Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/52/1b54cb569509c725a32c1315261ac9fd0e6b91bbbf74d86fca10d3376164/huggingface_hub-1.12.0.tar.gz", hash = "sha256:7c3fe85e24b652334e5d456d7a812cd9a071e75630fac4365d9165ab5e4a34b6", size = 763091, upload-time = "2026-04-24T13:32:08.674Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/ae/2f6d96b4e6c5478d87d606a1934b5d436c4a2bce6bb7c6fdece891c128e3/huggingface_hub-1.4.1-py3-none-any.whl", hash = "sha256:9931d075fb7a79af5abc487106414ec5fba2c0ae86104c0c62fd6cae38873d18", size = 553326, upload-time = "2026-02-06T09:20:00.728Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/2b/ef03ddb96bd1123503c2bd6932001020292deea649e9bf4caa2cb65a85bf/huggingface_hub-1.12.0-py3-none-any.whl", hash = "sha256:d74939969585ee35748bd66de09baf84099d461bda7287cd9043bfb99b0e424d", size = 646806, upload-time = "2026-04-24T13:32:06.717Z" },
 ]
 
 [[package]]
@@ -4059,6 +4077,9 @@ sglang = [
     { name = "sgl-kernel" },
     { name = "sglang" },
 ]
+trackio = [
+    { name = "trackio" },
+]
 vllm = [
     { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'darwin' and extra == 'extra-7-nemo-rl-fsdp' and extra != 'extra-7-nemo-rl-mcore') or (sys_platform != 'darwin' and extra != 'extra-7-nemo-rl-automodel' and extra != 'extra-7-nemo-rl-mcore' and extra != 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-fsdp') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-mcore') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-vllm') or (extra == 'extra-7-nemo-rl-fsdp' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-vllm') or (extra == 'extra-7-nemo-rl-sglang' and extra == 'extra-7-nemo-rl-vllm')" },
     { name = "cuda-python", version = "13.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'extra-7-nemo-rl-fsdp' and extra != 'extra-7-nemo-rl-mcore') or (sys_platform == 'darwin' and extra != 'extra-7-nemo-rl-automodel' and extra != 'extra-7-nemo-rl-mcore' and extra != 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-fsdp' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-fsdp') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-mcore') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-vllm') or (extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-vllm') or (extra == 'extra-7-nemo-rl-sglang' and extra == 'extra-7-nemo-rl-vllm')" },
@@ -4171,6 +4192,7 @@ requires-dist = [
     { name = "torchdata" },
     { name = "torchvision", marker = "sys_platform != 'darwin'", specifier = "==0.25.0", index = "https://download.pytorch.org/whl/cu129" },
     { name = "torchvision", marker = "sys_platform == 'darwin'", specifier = "==0.25.0", index = "https://pypi.org/simple" },
+    { name = "trackio", marker = "extra == 'trackio'", specifier = "==0.25.1" },
     { name = "transformer-engine", extras = ["pytorch"], marker = "extra == 'automodel'", specifier = ">=2.9.0a0,<2.12.0" },
     { name = "transformer-engine", extras = ["pytorch"], marker = "extra == 'mcore'", specifier = "==2.12.0" },
     { name = "transformers", specifier = "==5.3.0" },
@@ -4179,7 +4201,7 @@ requires-dist = [
     { name = "vllm", marker = "extra == 'vllm'", specifier = "==0.17.1" },
     { name = "wandb", specifier = ">=0.25.1" },
 ]
-provides-extras = ["fsdp", "automodel", "vllm", "sglang", "mcore", "nemo-gym"]
+provides-extras = ["fsdp", "automodel", "vllm", "sglang", "mcore", "nemo-gym", "trackio"]
 
 [package.metadata.requires-dev]
 build = [
@@ -7680,14 +7702,14 @@ dependencies = [
     { name = "typing-extensions", marker = "sys_platform != 'darwin' or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-fsdp') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-mcore') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-vllm') or (extra == 'extra-7-nemo-rl-fsdp' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-vllm') or (extra == 'extra-7-nemo-rl-sglang' and extra == 'extra-7-nemo-rl-vllm')" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu129/torch-2.10.0%2Bcu129-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:08dc9eb950efbf2b65a7973e6d00c8c770d697140296841dc3d86cbc8d372a76" },
-    { url = "https://download-r2.pytorch.org/whl/cu129/torch-2.10.0%2Bcu129-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e116126decbfbd1fc6f8e07c0d1527f014b0b787b50479d84592ccc44870f8d5" },
-    { url = "https://download-r2.pytorch.org/whl/cu129/torch-2.10.0%2Bcu129-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:426cd15b348547131a3de733056396dea0edfb511cd5e351a6ba9efa561dfb86" },
-    { url = "https://download-r2.pytorch.org/whl/cu129/torch-2.10.0%2Bcu129-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:3f62b9033869ea62c76edb803b129d4889b4c094d295d86a79cabb4a36a597d9" },
-    { url = "https://download-r2.pytorch.org/whl/cu129/torch-2.10.0%2Bcu129-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:e9649b8b5cbeee7a237d08c81390bb02f20cab2caa1a8e4f4d96bae3d26a2836" },
-    { url = "https://download-r2.pytorch.org/whl/cu129/torch-2.10.0%2Bcu129-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:09a88b6a21952bbb664fdd6b2539364aa9e52b9789cc8aa22ed3ccfcd6d3c779" },
-    { url = "https://download-r2.pytorch.org/whl/cu129/torch-2.10.0%2Bcu129-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:97dec29569355524ae67ef4f7172ab5f367b489bbfcc0ecf29fc07949217eb6d" },
-    { url = "https://download-r2.pytorch.org/whl/cu129/torch-2.10.0%2Bcu129-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a12016c1dd639e7063c9067a7d205e7b1ad9423eaca2d267b2a054b29ef8f198" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torch-2.10.0%2Bcu129-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:08dc9eb950efbf2b65a7973e6d00c8c770d697140296841dc3d86cbc8d372a76", upload-time = "2026-01-21T18:55:48Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torch-2.10.0%2Bcu129-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e116126decbfbd1fc6f8e07c0d1527f014b0b787b50479d84592ccc44870f8d5", upload-time = "2026-01-21T18:56:26Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torch-2.10.0%2Bcu129-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:426cd15b348547131a3de733056396dea0edfb511cd5e351a6ba9efa561dfb86", upload-time = "2026-01-21T18:55:50Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torch-2.10.0%2Bcu129-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:3f62b9033869ea62c76edb803b129d4889b4c094d295d86a79cabb4a36a597d9", upload-time = "2026-01-21T18:56:58Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torch-2.10.0%2Bcu129-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:e9649b8b5cbeee7a237d08c81390bb02f20cab2caa1a8e4f4d96bae3d26a2836", upload-time = "2026-01-21T18:55:48Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torch-2.10.0%2Bcu129-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:09a88b6a21952bbb664fdd6b2539364aa9e52b9789cc8aa22ed3ccfcd6d3c779", upload-time = "2026-01-21T18:57:16Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torch-2.10.0%2Bcu129-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:97dec29569355524ae67ef4f7172ab5f367b489bbfcc0ecf29fc07949217eb6d", upload-time = "2026-01-21T18:56:24Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torch-2.10.0%2Bcu129-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a12016c1dd639e7063c9067a7d205e7b1ad9423eaca2d267b2a054b29ef8f198", upload-time = "2026-01-21T18:57:13Z" },
 ]
 
 [[package]]
@@ -7808,14 +7830,14 @@ dependencies = [
     { name = "torch", version = "2.10.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.10.0%2Bcu129-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:7da6d91ff23575a220202fa8b1db1531c2b126ad6cf7515f2e28afe95979ed55" },
-    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.10.0%2Bcu129-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:25f99b060c867bedae2d5520acc3504afca0e75255724abdc4e05142a6c537cd" },
-    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.10.0%2Bcu129-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:b64d03ab8ef46a158987a6943957c5cf537cc6fb8cb82e6eb80cd4eee1691b65" },
-    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.10.0%2Bcu129-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:411826a1d33e62404b69908242a017820e62f5a05facd277efc225a90a409570" },
-    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.10.0%2Bcu129-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:1e949dcec56d58469a80c9f4cb0d2ed377cb3b88512ff94cec4a2c5a167a6aa6" },
-    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.10.0%2Bcu129-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:37bec8b2993d76f4ad5f810f12eb46f8d2e74fcfc9047fe7b157922f0d6e3b7d" },
-    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.10.0%2Bcu129-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:1de7f85a39861093178ee425301023f85f7c3b3ce01667a6279f24e848658b84" },
-    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.10.0%2Bcu129-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c87e8bc610ef9c77456edaefa29d0ada3f4b8e1e903f735ec4eb48a4d91ec8f6" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.10.0%2Bcu129-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:7da6d91ff23575a220202fa8b1db1531c2b126ad6cf7515f2e28afe95979ed55", upload-time = "2026-01-21T15:05:50Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.10.0%2Bcu129-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:25f99b060c867bedae2d5520acc3504afca0e75255724abdc4e05142a6c537cd", upload-time = "2026-01-21T15:05:50Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.10.0%2Bcu129-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:b64d03ab8ef46a158987a6943957c5cf537cc6fb8cb82e6eb80cd4eee1691b65", upload-time = "2026-01-21T15:05:50Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.10.0%2Bcu129-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:411826a1d33e62404b69908242a017820e62f5a05facd277efc225a90a409570", upload-time = "2026-01-21T15:05:50Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.10.0%2Bcu129-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:1e949dcec56d58469a80c9f4cb0d2ed377cb3b88512ff94cec4a2c5a167a6aa6", upload-time = "2026-01-21T15:05:50Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.10.0%2Bcu129-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:37bec8b2993d76f4ad5f810f12eb46f8d2e74fcfc9047fe7b157922f0d6e3b7d", upload-time = "2026-01-21T15:05:50Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.10.0%2Bcu129-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:1de7f85a39861093178ee425301023f85f7c3b3ce01667a6279f24e848658b84", upload-time = "2026-01-21T15:05:50Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchaudio-2.10.0%2Bcu129-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c87e8bc610ef9c77456edaefa29d0ada3f4b8e1e903f735ec4eb48a4d91ec8f6", upload-time = "2026-01-21T15:05:50Z" },
 ]
 
 [[package]]
@@ -7932,14 +7954,14 @@ dependencies = [
     { name = "torch", version = "2.10.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "sys_platform != 'darwin' or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-fsdp') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-mcore') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-vllm') or (extra == 'extra-7-nemo-rl-fsdp' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-vllm') or (extra == 'extra-7-nemo-rl-sglang' and extra == 'extra-7-nemo-rl-vllm')" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu129/torchvision-0.25.0%2Bcu129-cp313-cp313-manylinux_2_28_aarch64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cu129/torchvision-0.25.0%2Bcu129-cp313-cp313-manylinux_2_28_x86_64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cu129/torchvision-0.25.0%2Bcu129-cp313-cp313t-manylinux_2_28_aarch64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cu129/torchvision-0.25.0%2Bcu129-cp313-cp313t-manylinux_2_28_x86_64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cu129/torchvision-0.25.0%2Bcu129-cp314-cp314-manylinux_2_28_aarch64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cu129/torchvision-0.25.0%2Bcu129-cp314-cp314-manylinux_2_28_x86_64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cu129/torchvision-0.25.0%2Bcu129-cp314-cp314t-manylinux_2_28_aarch64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cu129/torchvision-0.25.0%2Bcu129-cp314-cp314t-manylinux_2_28_x86_64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchvision-0.25.0%2Bcu129-cp313-cp313-manylinux_2_28_aarch64.whl", upload-time = "2026-01-20T18:32:46Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchvision-0.25.0%2Bcu129-cp313-cp313-manylinux_2_28_x86_64.whl", upload-time = "2026-01-20T18:32:46Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchvision-0.25.0%2Bcu129-cp313-cp313t-manylinux_2_28_aarch64.whl", upload-time = "2026-01-20T18:32:46Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchvision-0.25.0%2Bcu129-cp313-cp313t-manylinux_2_28_x86_64.whl", upload-time = "2026-01-20T18:32:46Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchvision-0.25.0%2Bcu129-cp314-cp314-manylinux_2_28_aarch64.whl", upload-time = "2026-01-20T18:32:46Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchvision-0.25.0%2Bcu129-cp314-cp314-manylinux_2_28_x86_64.whl", upload-time = "2026-01-20T18:32:47Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchvision-0.25.0%2Bcu129-cp314-cp314t-manylinux_2_28_aarch64.whl", upload-time = "2026-01-20T18:32:47Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu129/torchvision-0.25.0%2Bcu129-cp314-cp314t-manylinux_2_28_x86_64.whl", upload-time = "2026-01-20T18:32:47Z" },
 ]
 
 [[package]]
@@ -7952,6 +7974,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "trackio"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gradio-client" },
+    { name = "huggingface-hub" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-fsdp') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-mcore') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-fsdp' and extra != 'extra-7-nemo-rl-mcore') or (extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-vllm') or (extra == 'extra-7-nemo-rl-sglang' and extra == 'extra-7-nemo-rl-vllm') or (extra != 'extra-7-nemo-rl-automodel' and extra != 'extra-7-nemo-rl-mcore' and extra != 'extra-7-nemo-rl-sglang') or (extra != 'extra-7-nemo-rl-fsdp' and extra != 'extra-7-nemo-rl-mcore' and extra != 'extra-7-nemo-rl-sglang' and extra == 'extra-7-nemo-rl-vllm')" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-7-nemo-rl-automodel' or extra == 'extra-7-nemo-rl-mcore' or extra == 'extra-7-nemo-rl-sglang'" },
+    { name = "orjson" },
+    { name = "pillow" },
+    { name = "python-multipart" },
+    { name = "starlette" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9a/80caa250ef9e0e465db883958764c9b27a413c8b246349f60c237b820201/trackio-0.25.1-py3-none-any.whl", hash = "sha256:d019b79a8dfb14264db1055b7e9b2681984138b827dabd5ec01585c0bd24116d", size = 1653922, upload-time = "2026-04-26T02:13:41.814Z" },
 ]
 
 [[package]]
@@ -8044,14 +8085,14 @@ resolution-markers = [
     "platform_machine != 'aarch64' and platform_machine != 's390x' and sys_platform == 'linux' and extra != 'extra-7-nemo-rl-automodel' and extra != 'extra-7-nemo-rl-fsdp' and extra != 'extra-7-nemo-rl-mcore' and extra != 'extra-7-nemo-rl-sglang'",
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/triton-3.6.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:58d57d6796b0004076315433526fe9d4af42044d430afdee1e6cd42a76bd6d09" },
-    { url = "https://download-r2.pytorch.org/whl/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0075039ff27765480083b1a109999bf27110f3542f1f9fad95f0f9065a36da79" },
-    { url = "https://download-r2.pytorch.org/whl/triton-3.6.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:29ff9ec4c96f405bf2735c531af27f8cc2215927440e52fb1fbc8014961d5d12" },
-    { url = "https://download-r2.pytorch.org/whl/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a619c81f8e77116b1d10aec34d62db72daa5c0fb70a6478c9afab25edb729c52" },
-    { url = "https://download-r2.pytorch.org/whl/triton-3.6.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20ed2f770f7217b8a994cba99e7cac37e7be735a3991344990b80ab4fea964c4" },
-    { url = "https://download-r2.pytorch.org/whl/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6d800bda666ebbe7ec2146e3f5eb271ee87f8fac724011dc7f25dee9bfb5f7f" },
-    { url = "https://download-r2.pytorch.org/whl/triton-3.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:89b87d2837849a9bcd3d960ad2e3dac0345c6e1359b9859e29f68083cbda9b1d" },
-    { url = "https://download-r2.pytorch.org/whl/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:621c0e5973d834507ec69dcf909f35f0b02c5df490fde100433cef83359b7eeb" },
+    { url = "https://download-r2.pytorch.org/whl/triton-3.6.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:58d57d6796b0004076315433526fe9d4af42044d430afdee1e6cd42a76bd6d09", upload-time = "2026-01-22T23:13:51Z" },
+    { url = "https://download-r2.pytorch.org/whl/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0075039ff27765480083b1a109999bf27110f3542f1f9fad95f0f9065a36da79", upload-time = "2026-01-22T23:14:00Z" },
+    { url = "https://download-r2.pytorch.org/whl/triton-3.6.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:29ff9ec4c96f405bf2735c531af27f8cc2215927440e52fb1fbc8014961d5d12", upload-time = "2026-01-22T23:14:09Z" },
+    { url = "https://download-r2.pytorch.org/whl/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a619c81f8e77116b1d10aec34d62db72daa5c0fb70a6478c9afab25edb729c52", upload-time = "2026-01-22T23:14:19Z" },
+    { url = "https://download-r2.pytorch.org/whl/triton-3.6.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20ed2f770f7217b8a994cba99e7cac37e7be735a3991344990b80ab4fea964c4", upload-time = "2026-01-22T23:14:28Z" },
+    { url = "https://download-r2.pytorch.org/whl/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6d800bda666ebbe7ec2146e3f5eb271ee87f8fac724011dc7f25dee9bfb5f7f", upload-time = "2026-01-22T23:14:40Z" },
+    { url = "https://download-r2.pytorch.org/whl/triton-3.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:89b87d2837849a9bcd3d960ad2e3dac0345c6e1359b9859e29f68083cbda9b1d", upload-time = "2026-01-22T23:14:51Z" },
+    { url = "https://download-r2.pytorch.org/whl/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:621c0e5973d834507ec69dcf909f35f0b02c5df490fde100433cef83359b7eeb", upload-time = "2026-01-22T23:15:01Z" },
 ]
 
 [[package]]
@@ -8094,18 +8135,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fd/07/b822e1b307d40e263e8253d2384cf98c51aa2368cc7ba9a07e523a1d964b/typer-0.23.1.tar.gz", hash = "sha256:2070374e4d31c83e7b61362fd859aa683576432fd5b026b060ad6b4cd3b86134", size = 120047, upload-time = "2026-02-13T10:04:30.984Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/91/9b286ab899c008c2cb05e8be99814807e7fbbd33f0c0c960470826e5ac82/typer-0.23.1-py3-none-any.whl", hash = "sha256:3291ad0d3c701cbf522012faccfbb29352ff16ad262db2139e6b01f15781f14e", size = 56813, upload-time = "2026-02-13T10:04:32.008Z" },
-]
-
-[[package]]
-name = "typer-slim"
-version = "0.23.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/22/b9c47b8655937b6877d40791b937931702ba9c5f9d28753199266aa96f50/typer_slim-0.23.1.tar.gz", hash = "sha256:dfe92a6317030ee2380f65bf92e540d7c77fefcc689e10d585b4925b45b5e06a", size = 4762, upload-time = "2026-02-13T10:04:26.416Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/8a/5764b851659345f34787f1b6eb30b9d308bbd6c294825cbe38b6b869c97a/typer_slim-0.23.1-py3-none-any.whl", hash = "sha256:8146d5df1eb89f628191c4c604c8464fa841885d0733c58e6e700ff0228adac5", size = 3397, upload-time = "2026-02-13T10:04:27.132Z" },
 ]
 
 [[package]]
@@ -8192,11 +8221,11 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-fsdp') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-mcore') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-vllm') or (extra == 'extra-7-nemo-rl-fsdp' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-sglang') or (extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-vllm') or (extra == 'extra-7-nemo-rl-sglang' and extra == 'extra-7-nemo-rl-vllm')" },
     { name = "httptools" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
-    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "uvloop", marker = "(platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32') or (platform_python_implementation == 'PyPy' and extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-fsdp') or (platform_python_implementation == 'PyPy' and extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-mcore') or (platform_python_implementation == 'PyPy' and extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-sglang') or (platform_python_implementation == 'PyPy' and extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-vllm') or (platform_python_implementation == 'PyPy' and extra == 'extra-7-nemo-rl-fsdp' and extra == 'extra-7-nemo-rl-sglang') or (platform_python_implementation == 'PyPy' and extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-sglang') or (platform_python_implementation == 'PyPy' and extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-vllm') or (platform_python_implementation == 'PyPy' and extra == 'extra-7-nemo-rl-sglang' and extra == 'extra-7-nemo-rl-vllm') or (sys_platform == 'cygwin' and extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-fsdp') or (sys_platform == 'cygwin' and extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-mcore') or (sys_platform == 'cygwin' and extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-sglang') or (sys_platform == 'cygwin' and extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-vllm') or (sys_platform == 'cygwin' and extra == 'extra-7-nemo-rl-fsdp' and extra == 'extra-7-nemo-rl-sglang') or (sys_platform == 'cygwin' and extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-sglang') or (sys_platform == 'cygwin' and extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-vllm') or (sys_platform == 'cygwin' and extra == 'extra-7-nemo-rl-sglang' and extra == 'extra-7-nemo-rl-vllm') or (sys_platform == 'win32' and extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-fsdp') or (sys_platform == 'win32' and extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-mcore') or (sys_platform == 'win32' and extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-sglang') or (sys_platform == 'win32' and extra == 'extra-7-nemo-rl-automodel' and extra == 'extra-7-nemo-rl-vllm') or (sys_platform == 'win32' and extra == 'extra-7-nemo-rl-fsdp' and extra == 'extra-7-nemo-rl-sglang') or (sys_platform == 'win32' and extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-sglang') or (sys_platform == 'win32' and extra == 'extra-7-nemo-rl-mcore' and extra == 'extra-7-nemo-rl-vllm') or (sys_platform == 'win32' and extra == 'extra-7-nemo-rl-sglang' and extra == 'extra-7-nemo-rl-vllm')" },
     { name = "watchfiles" },
     { name = "websockets" },
 ]


### PR DESCRIPTION
## Summary

- Add Trackio as an optional logging backend pinned to `trackio==0.25.1`.
- Add lazy Trackio import, metrics/config/media/histogram logging, and explicit close/finish handling.
- Add Trackio config blocks to canonical configs and document install/run/viewing usage.
- Close loggers from runner scripts in `finally` so buffered backends flush on failure paths.

## Test Plan

- `uv lock`
- `.venv/bin/ruff check nemo_rl/utils/logger.py tests/unit/utils/test_logger.py examples/run_grpo.py examples/run_dpo.py examples/run_distillation.py examples/run_rm.py examples/run_sft.py examples/run_vlm_grpo.py examples/run_grpo_sliding_puzzle.py examples/nemo_gym/run_grpo_nemo_gym.py`
- `black --check nemo_rl/utils/logger.py tests/unit/utils/test_logger.py examples/run_grpo.py examples/run_dpo.py examples/run_distillation.py examples/run_rm.py examples/run_sft.py examples/run_vlm_grpo.py examples/run_grpo_sliding_puzzle.py examples/nemo_gym/run_grpo_nemo_gym.py`
- YAML parse check for touched canonical config files.
- Slurm smoke: `22092393`, 1-step GRPO with `logger.trackio_enabled=true` and `logger.wandb_enabled=true`.
  - Completed with `ExitCode=0:0`.
  - W&B offline run written under `logs/trackio-wandb-smoke-2/exp_001/wandb/...`.
  - Trackio DB written at `logs/trackio-smoke-db-2/nemo-rl-smoke.db`.
  - Trackio DB verification: `metrics=7`, `configs=1`, run `trackio-wandb-smoke-20260427-143146` reached step `1`.

## Notes

- W&B smoke used `WANDB_MODE=offline` because this environment does not expose a W&B API key.
- A direct pytest run in the host venv is blocked before collection by a local CUDA library mismatch while importing Torch (`libcusparse.so.12` / `__nvJitLinkGetErrorLogSize_12_9`).
