### PR TITLE
fix(ci): align nightly concurrency group with Automodel and Megatron-Bridge

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -39,8 +39,8 @@ on:
         default: ""
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'schedule' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 jobs:
   pre-flight:

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -39,8 +39,8 @@ on:
         default: ""
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'schedule' && github.run_id || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'schedule' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.label.name || 'main' }}-${{ github.event_name }}
+  cancel-in-progress: true
 
 jobs:
   pre-flight:


### PR DESCRIPTION
## Summary
- Nightly schedule CI runs were sharing a concurrency group with push-triggered runs on `main`, causing `cancel-in-progress` to kill nightly runs mid-flight when a PR merges
- Align concurrency group format with Automodel and Megatron-Bridge: include `event_name` in the group key so scheduled and push runs never collide

🤖 Generated with [Claude Code](https://claude.com/claude-code)