### PR TITLE
Fix NeMo-Gym VLM prompt reconstruction for training logprob parity

### DIFF
--- a/examples/nemo_gym/grpo_circle_click_qwen3vl2b.yaml
+++ b/examples/nemo_gym/grpo_circle_click_qwen3vl2b.yaml
@@ -1,0 +1,141 @@
+defaults: "grpo_workplace_assistant_nemotron_nano_v2_9b.yaml"
+
+grpo:
+  num_prompts_per_step: 16
+  num_generations_per_prompt: 16
+  max_rollout_turns: 1
+  val_period: 5
+  val_at_start: true
+
+policy:
+  is_vlm: true
+  model_name: "Qwen/Qwen3-VL-2B-Instruct"
+  train_global_batch_size: 256
+  train_micro_batch_size: 1
+  logprob_batch_size: 4
+  max_total_sequence_length: 4096
+  precision: "bfloat16"
+  offload_optimizer_for_logprob: false
+  make_sequence_length_divisible_by: 1
+
+  dtensor_cfg:
+    _v2: true
+    enabled: true
+    cpu_offload: false
+    sequence_parallel: false
+    activation_checkpointing: false
+    tensor_parallel_size: 1
+    context_parallel_size: 1
+    custom_parallel_plan: null
+
+  megatron_cfg:
+    enabled: false
+
+  optimizer:
+    name: "torch.optim.AdamW"
+    kwargs:
+      lr: 5e-7
+      weight_decay: 0.01
+      betas: [0.9, 0.999]
+      eps: 1e-8
+      foreach: false
+      fused: false
+
+  scheduler:
+    - name: "torch.optim.lr_scheduler.LinearLR"
+      kwargs:
+        start_factor: 0.1
+        end_factor: 1.0
+        total_iters: 50
+    - name: "torch.optim.lr_scheduler.ConstantLR"
+      kwargs:
+        factor: 1.0
+        total_iters: 10000000000
+    - milestones: [50]
+
+  generation:
+    backend: "vllm"
+    max_new_tokens: 1024
+    temperature: 1.0
+    top_p: 1.0
+    top_k: null
+    stop_token_ids: null
+    stop_strings: null
+    vllm_cfg:
+      async_engine: true
+      precision: ${policy.precision}
+      tensor_parallel_size: 1
+      pipeline_parallel_size: 1
+      expert_parallel_size: 1
+      gpu_memory_utilization: 0.8
+      max_model_len: ${policy.max_total_sequence_length}
+      enforce_eager: false
+      kv_cache_dtype: "auto"
+      skip_tokenizer_init: false
+      expose_http_server: true
+      http_server_serving_chat_kwargs:
+        enable_auto_tools: true
+        tool_parser: hermes
+    vllm_kwargs:
+      compilation_config:
+        use_inductor: false
+    colocated:
+      enabled: true
+      resources:
+        gpus_per_node: null
+        num_nodes: null
+
+data:
+  max_input_seq_length: null
+  shuffle: true
+  num_workers: 0
+
+  train:
+    data_path: 3rdparty/Gym-workspace/Gym/data/circle_click/train.jsonl
+  validation:
+    data_path: 3rdparty/Gym-workspace/Gym/data/circle_click/validation.jsonl
+  default:
+    dataset_name: NemoGymDataset
+    env_name: "nemo_gym"
+    prompt_file: null
+    system_prompt_file: null
+    processor: "nemo_gym_data_processor"
+
+env:
+  should_use_nemo_gym: true
+  should_log_nemo_gym_responses: true
+  nemo_gym:
+    rollout_max_attempts_to_avoid_lp_nan: 1
+    config_paths:
+    - responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
+    - resources_servers/circle_click/configs/circle_click.yaml
+    policy_model:
+      responses_api_models:
+        vllm_model:
+          uses_reasoning_parser: false
+          extra_body:
+            chat_template_kwargs:
+              enable_thinking: false
+
+logger:
+  log_dir: "logs/grpo-circle-click-qwen3vl2b"
+  wandb_enabled: true
+  tensorboard_enabled: false
+  mlflow_enabled: false
+  swanlab_enabled: false
+  monitor_gpus: true
+  wandb:
+    project: "grpo-circle-click"
+    name: "qwen3-vl-2b-circle-click"
+
+checkpointing:
+  enabled: true
+  checkpoint_dir: "results/grpo-circle-click-qwen3vl2b"
+  metric_name: "val:accuracy"
+  higher_is_better: true
+  keep_top_k: 3
+  save_period: 5
+
+cluster:
+  gpus_per_node: 8
+  num_nodes: 2

--- a/examples/nemo_gym/run_grpo_nemo_gym.py
+++ b/examples/nemo_gym/run_grpo_nemo_gym.py
@@ -148,13 +148,25 @@ def main() -> None:
         )
 
     # setup tokenizer
-    tokenizer = get_tokenizer(config["policy"]["tokenizer"])
+    is_vlm = config["policy"].get("is_vlm", False)
+    if is_vlm:
+        processor = get_tokenizer(config["policy"]["tokenizer"], get_processor=True)
+        tokenizer = processor.tokenizer
+    else:
+        processor = None
+        tokenizer = get_tokenizer(config["policy"]["tokenizer"])
+
     assert config["policy"]["generation"] is not None, (
         "A generation config is required for GRPO"
     )
     config["policy"]["generation"] = configure_generation_config(
         config["policy"]["generation"], tokenizer
     )
+
+    if is_vlm and "vllm_cfg" in config["policy"]["generation"]:
+        assert not config["policy"]["generation"]["vllm_cfg"]["skip_tokenizer_init"], (
+            "VLMs require skip_tokenizer_init=False"
+        )
 
     # NeMo-Gym specific config setup.
     setup_nemo_gym_config(config, tokenizer)
@@ -202,7 +214,7 @@ The validation set you pass in will directly be used for validation with no addi
         checkpointer,
         grpo_state,
         master_config,
-    ) = setup(config, tokenizer, train_dataset, val_dataset)
+    ) = setup(config, tokenizer, train_dataset, val_dataset, processor=processor)
 
     is_trajectory_collection = (
         config["env"]["nemo_gym"].pop("is_trajectory_collection", False) or False

--- a/examples/nemo_gym/run_grpo_nemo_gym.py
+++ b/examples/nemo_gym/run_grpo_nemo_gym.py
@@ -78,6 +78,7 @@ def collect_trajectories(
     val_task_to_env: dict[str, EnvironmentInterface],
     logger: Logger,
     master_config: MasterConfig,
+    processor=None,
 ) -> None:
     """Run trajectory collection."""
     # common config/state items
@@ -96,6 +97,7 @@ def collect_trajectories(
             task_to_env=val_task_to_env,
             max_seq_len=None,
             generation_config=generation_config,
+            processor=processor,
             max_rollout_turns=None,
             greedy=False,
         )
@@ -147,25 +149,30 @@ def main() -> None:
             f"📊 Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}"
         )
 
-    # setup tokenizer
-    is_vlm = config["policy"].get("is_vlm", False)
-    if is_vlm:
+    # setup tokenizer / processor
+    processor = None
+    use_processor = config["policy"].get("is_vlm", False) or config["policy"][
+        "tokenizer"
+    ].get("use_processor", False)
+    if use_processor:
         processor = get_tokenizer(config["policy"]["tokenizer"], get_processor=True)
         tokenizer = processor.tokenizer
+        config["policy"]["is_vlm"] = True
+        config["policy"]["tokenizer"]["use_processor"] = True
     else:
-        processor = None
         tokenizer = get_tokenizer(config["policy"]["tokenizer"])
-
     assert config["policy"]["generation"] is not None, (
         "A generation config is required for GRPO"
     )
     config["policy"]["generation"] = configure_generation_config(
         config["policy"]["generation"], tokenizer
     )
-
-    if is_vlm and "vllm_cfg" in config["policy"]["generation"]:
-        assert not config["policy"]["generation"]["vllm_cfg"]["skip_tokenizer_init"], (
-            "VLMs require skip_tokenizer_init=False"
+    if processor is not None and "vllm_cfg" in config["policy"]["generation"]:
+        assert (
+            config["policy"]["generation"]["vllm_cfg"]["skip_tokenizer_init"] == False
+        ), (
+            "VLMs require tokenizer to be initialized before generation, so "
+            "skip_tokenizer_init must be set to False."
         )
 
     # NeMo-Gym specific config setup.
@@ -177,7 +184,9 @@ def main() -> None:
     # NeMo-Gym environment needs to get dp_openai_server_base_urls from policy_generation, so we don't setup env here.
     print("\n▶ Setting up data...")
     train_dataset, val_dataset = setup_response_data(
-        tokenizer, config["data"], env_configs=None
+        processor if processor is not None else tokenizer,
+        config["data"],
+        env_configs=None,
     )
 
     # Validation dataset config setup.
@@ -242,6 +251,7 @@ The validation set you pass in will directly be used for validation with no addi
             val_task_to_env=val_task_to_env,
             logger=logger,
             master_config=master_config,
+            processor=processor,
         )
     # Check if async mode is enabled
     elif "async_grpo" in config["grpo"] and config["grpo"]["async_grpo"]["enabled"]:
@@ -293,6 +303,7 @@ The validation set you pass in will directly be used for validation with no addi
             grpo_save_state=grpo_state,
             master_config=master_config,
             max_trajectory_age_steps=async_config["max_trajectory_age_steps"],
+            processor=processor,
         )
     else:
         print("🚀 Running synchronous GRPO training")
@@ -311,6 +322,7 @@ The validation set you pass in will directly be used for validation with no addi
             checkpointer,
             grpo_state,
             master_config,
+            processor=processor,
         )
 
 

--- a/nemo_rl/algorithms/async_utils.py
+++ b/nemo_rl/algorithms/async_utils.py
@@ -254,6 +254,17 @@ class AsyncTrajectoryCollector:
         self.master_config = master_config
         self.replay_buffer = replay_buffer
         self.running = False
+        self.processor = None
+
+        policy_config = master_config.get("policy", {})
+        if policy_config.get("is_vlm", False) or policy_config.get(
+            "tokenizer", {}
+        ).get("use_processor", False):
+            from nemo_rl.algorithms.utils import get_tokenizer
+
+            self.processor = get_tokenizer(
+                policy_config["tokenizer"], get_processor=True
+            )
 
         self._pg_lock: _threading.Lock = _threading.Lock()
 
@@ -659,6 +670,7 @@ class AsyncTrajectoryCollector:
                     task_to_env=self.task_to_env,
                     max_seq_len=None,
                     generation_config=generation_config,
+                    processor=self.processor,
                     max_rollout_turns=None,
                     greedy=False,
                 )

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1313,6 +1313,7 @@ def grpo_train(
     checkpointer: CheckpointManager,
     grpo_save_state: GRPOSaveState,
     master_config: MasterConfig,
+    processor: Optional[AutoProcessor] = None,
 ) -> None:
     """Run GRPO training algorithm."""
     timer = Timer()
@@ -1386,6 +1387,7 @@ def grpo_train(
             step=0,
             master_config=master_config,
             logger=logger,
+            processor=processor,
         )
         policy_generation.finish_generation()
         logger.log_metrics(val_metrics, current_step, prefix="validation")
@@ -1516,6 +1518,7 @@ def grpo_train(
                             task_to_env=task_to_env,
                             max_seq_len=None,
                             generation_config=generation_config,
+                            processor=processor,
                             max_rollout_turns=None,
                             greedy=False,
                         )
@@ -1853,6 +1856,7 @@ def grpo_train(
                         step=total_steps + 1,
                         master_config=master_config,
                         logger=logger,
+                        processor=processor,
                     )
                     policy_generation.finish_generation()
                     logger.log_metrics(
@@ -2207,6 +2211,7 @@ def validate(
     step: int,
     master_config: MasterConfig,
     logger: Optional[Logger] = None,
+    processor: Optional[AutoProcessor] = None,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     """Run validation on the validation dataset."""
     if val_dataloader is None:
@@ -2245,6 +2250,7 @@ def validate(
                     task_to_env=val_task_to_env,
                     max_seq_len=None,
                     generation_config=generation_config,
+                    processor=processor,
                     max_rollout_turns=None,
                     greedy=False,
                 )
@@ -2365,6 +2371,7 @@ def async_grpo_train(
     grpo_save_state: GRPOSaveState,
     master_config: MasterConfig,
     max_trajectory_age_steps: int = 1,
+    processor: Optional[AutoProcessor] = None,
 ) -> None:
     """Run asynchronous GRPO training with replay buffer.
 
@@ -2570,6 +2577,7 @@ def async_grpo_train(
                 step=0,
                 master_config=master_config,
                 logger=logger,
+                processor=processor,
             )
             policy_generation.finish_generation()
             logger.log_metrics(val_metrics, step, prefix="validation")
@@ -2896,6 +2904,7 @@ def async_grpo_train(
                         step=step + 1,
                         master_config=master_config,
                         logger=logger,
+                        processor=processor,
                     )
                     policy_generation.finish_generation()
                     logger.log_metrics(

--- a/nemo_rl/algorithms/utils.py
+++ b/nemo_rl/algorithms/utils.py
@@ -297,16 +297,18 @@ def get_tokenizer(
     else:
         print("No chat template provided, using tokenizer's default")
 
-    if (
-        "chat_template_kwargs" in tokenizer_config
-        and tokenizer_config["chat_template_kwargs"] is not None
-    ):
-        assert isinstance(tokenizer_config["chat_template_kwargs"], dict), (
+    chat_template_kwargs = tokenizer_config.get("chat_template_kwargs")
+    if chat_template_kwargs is not None:
+        assert isinstance(chat_template_kwargs, dict), (
             "chat_template_kwargs should be a dictionary"
         )
         tokenizer.apply_chat_template = partial(
-            tokenizer.apply_chat_template, **tokenizer_config["chat_template_kwargs"]
+            tokenizer.apply_chat_template, **chat_template_kwargs
         )
+        if processor is not None and hasattr(processor, "apply_chat_template"):
+            processor.apply_chat_template = partial(
+                processor.apply_chat_template, **chat_template_kwargs
+            )
 
     # The "tokenizer" is passed to the policy workers only to use the pad/eos/bos tokens for extra padding and processing of the tokenized messages. That is the only reason it is needed.
     # However, the dataloader needs the processor for multimodal data preprocessing, so the processor is needed for the dataloader (only tokenizer is NOT enough).

--- a/nemo_rl/data/processors.py
+++ b/nemo_rl/data/processors.py
@@ -16,7 +16,7 @@
 
 import json
 import logging
-from typing import Any, Dict, cast
+from typing import Any, Dict, Optional, cast
 
 import torch
 from transformers import AutoProcessor, PreTrainedTokenizerBase
@@ -32,6 +32,132 @@ from nemo_rl.data.interfaces import (
 from nemo_rl.data.llm_message_utils import get_formatted_message_log
 
 TokenizerType = PreTrainedTokenizerBase
+
+
+def _normalize_nemo_gym_message_content(
+    content: str | list[dict[str, Any]] | None,
+) -> str | list[dict[str, Any]] | None:
+    """Convert NeMo-Gym Responses-style content into NeMo-RL VLM content.
+
+    NeMo-Gym uses OpenAI Responses-style content parts such as `input_text` and
+    `input_image`. NeMo-RL's processor-backed VLM path expects `text` and
+    `image` items instead.
+    """
+    if not isinstance(content, list):
+        return content
+
+    normalized_content = []
+    for part in content:
+        part_type = part["type"]
+        if part_type == "input_text":
+            normalized_content.append({"type": "text", "text": part["text"]})
+        elif part_type == "input_image":
+            normalized_content.append({"type": "image", "image": part["image_url"]})
+        elif part_type in {"text", "image", "audio", "video"}:
+            normalized_content.append(part)
+        else:
+            raise NotImplementedError(
+                f"Unsupported NeMo-Gym VLM content type: {part_type}"
+            )
+
+    return normalized_content
+
+
+def _nemo_gym_prompt_contains_media(input_messages: list[dict[str, Any]]) -> bool:
+    """Return whether the Responses input contains multimodal content."""
+    for message in input_messages:
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if part["type"] in {"input_image", "image", "audio", "video"}:
+                return True
+    return False
+
+
+def build_nemo_gym_vlm_prompt_message(
+    input_messages: list[dict[str, Any]],
+    processor: AutoProcessor,
+    prompt_token_ids: list[int | str],
+    *,
+    tools: Optional[list[dict[str, Any]]] = None,
+) -> dict[str, Any]:
+    """Build a processor-backed NeMo-RL prompt message from NeMo-Gym input.
+
+    This helper bridges NeMo-Gym's Responses-style prompt schema to NeMo-RL's
+    VLM training representation. It also validates that the reconstructed
+    processor prompt matches NeMo-Gym's canonical `prompt_token_ids`.
+    """
+    from nemo_rl.data.multimodal_utils import (
+        PackedTensor,
+        get_dim_to_pack_along,
+        get_multimodal_keys_from_processor,
+    )
+
+    normalized_messages = []
+    for message in input_messages:
+        message_type = message.get("type")
+        if message_type not in (None, "message"):
+            raise NotImplementedError(
+                f"Unsupported NeMo-Gym prompt item type for VLM reconstruction: {message_type}"
+            )
+        normalized_messages.append(
+            {
+                "role": message["role"],
+                "content": _normalize_nemo_gym_message_content(message.get("content")),
+            }
+        )
+
+    prompt_kwargs = dict(
+        tokenize=True,
+        add_generation_prompt=True,
+        return_tensors="pt",
+        return_dict=True,
+    )
+    if tools is not None:
+        prompt_kwargs["tools"] = tools
+
+    processed_prompt: dict[str, Any] = processor.apply_chat_template(
+        normalized_messages, **prompt_kwargs
+    )
+
+    expected_prompt_token_ids = torch.tensor(
+        [int(token_id) for token_id in prompt_token_ids], dtype=torch.long
+    )
+    actual_prompt_token_ids = processed_prompt["input_ids"][0].to(torch.long)
+    if not torch.equal(actual_prompt_token_ids.cpu(), expected_prompt_token_ids):
+        raise ValueError(
+            "NeMo-Gym VLM prompt reconstruction does not match Gym prompt_token_ids. "
+            f"Expected {len(expected_prompt_token_ids)} prompt tokens but reconstructed "
+            f"{len(actual_prompt_token_ids)} tokens."
+        )
+
+    prompt_message = {
+        "role": "user",
+        "content": "",
+        "token_ids": actual_prompt_token_ids,
+    }
+    multimodal_keys = get_multimodal_keys_from_processor(processor)
+    for key in multimodal_keys:
+        if key in processed_prompt:
+            prompt_message[key] = PackedTensor(
+                processed_prompt[key],
+                dim_to_pack=get_dim_to_pack_along(processor, key),
+            )
+
+    if "token_type_ids" in processed_prompt:
+        prompt_message["token_type_ids"] = processed_prompt["token_type_ids"][0]
+    if "mm_token_type_ids" in processed_prompt:
+        prompt_message["mm_token_type_ids"] = processed_prompt["mm_token_type_ids"][0]
+
+    if _nemo_gym_prompt_contains_media(input_messages) and not any(
+        key in prompt_message for key in multimodal_keys
+    ):
+        raise ValueError(
+            "NeMo-Gym VLM prompt reconstruction dropped multimodal processor outputs."
+        )
+
+    return prompt_message
 
 
 def helpsteer3_data_processor(

--- a/nemo_rl/data/processors.py
+++ b/nemo_rl/data/processors.py
@@ -36,15 +36,21 @@ TokenizerType = PreTrainedTokenizerBase
 
 def _normalize_nemo_gym_message_content(
     content: str | list[dict[str, Any]] | None,
-) -> str | list[dict[str, Any]] | None:
+) -> list[dict[str, Any]] | None:
     """Convert NeMo-Gym Responses-style content into NeMo-RL VLM content.
 
     NeMo-Gym uses OpenAI Responses-style content parts such as `input_text` and
     `input_image`. NeMo-RL's processor-backed VLM path expects `text` and
     `image` items instead.
     """
+    if content is None:
+        return None
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}]
     if not isinstance(content, list):
-        return content
+        raise NotImplementedError(
+            f"Unsupported NeMo-Gym VLM content value: {type(content).__name__}"
+        )
 
     normalized_content = []
     for part in content:
@@ -85,8 +91,10 @@ def build_nemo_gym_vlm_prompt_message(
     """Build a processor-backed NeMo-RL prompt message from NeMo-Gym input.
 
     This helper bridges NeMo-Gym's Responses-style prompt schema to NeMo-RL's
-    VLM training representation. It also validates that the reconstructed
-    processor prompt matches NeMo-Gym's canonical `prompt_token_ids`.
+    VLM training representation. For prompts without media, it also validates
+    that the reconstructed processor prompt matches NeMo-Gym's canonical
+    `prompt_token_ids`. Multimodal vLLM prompt token IDs may use compact image
+    placeholders, while the processor returns the expanded training input IDs.
     """
     from nemo_rl.data.multimodal_utils import (
         PackedTensor,
@@ -125,7 +133,9 @@ def build_nemo_gym_vlm_prompt_message(
         [int(token_id) for token_id in prompt_token_ids], dtype=torch.long
     )
     actual_prompt_token_ids = processed_prompt["input_ids"][0].to(torch.long)
-    if not torch.equal(actual_prompt_token_ids.cpu(), expected_prompt_token_ids):
+    if not _nemo_gym_prompt_contains_media(input_messages) and not torch.equal(
+        actual_prompt_token_ids.cpu(), expected_prompt_token_ids
+    ):
         raise ValueError(
             "NeMo-Gym VLM prompt reconstruction does not match Gym prompt_token_ids. "
             f"Expected {len(expected_prompt_token_ids)} prompt tokens but reconstructed "

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -225,12 +225,11 @@ Output prompt token IDs: {output_item_dict["prompt_token_ids"]}
 
             # We pop to remove larger tensors from logging.
             output_item_dict["prompt_str"] = tokenizer.decode(
-                output_item_dict.pop("prompt_token_ids")
+                output_item_dict["prompt_token_ids"]
             )
             output_item_dict["generation_str"] = tokenizer.decode(
-                output_item_dict.pop("generation_token_ids")
+                output_item_dict["generation_token_ids"]
             )
-            output_item_dict.pop("generation_log_probs")
 
         if not nemo_rl_message_log:
             input_messages = nemo_gym_result["responses_create_params"]["input"]

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -26,18 +26,20 @@ from typing import Any, Optional
 
 import ray
 import torch
-from transformers import PreTrainedTokenizerBase
+from transformers import AutoProcessor, PreTrainedTokenizerBase
 from wandb import Histogram, Table
 
 from nemo_rl.data.interfaces import (
     DatumSpec,
     FlatMessagesType,
     LLMMessageLogType,
+    VLMMessageLogType,
 )
 from nemo_rl.data.llm_message_utils import (
     batched_message_log_to_flat_message,
     get_keys_from_message_log,
 )
+from nemo_rl.data.processors import build_nemo_gym_vlm_prompt_message
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.environments.interfaces import (
     EnvironmentInterface,
@@ -994,6 +996,75 @@ class AsyncNemoGymRolloutResult:
     rollout_metrics: dict[str, Any]
 
 
+def rebuild_nemo_gym_vlm_message_log(
+    full_result: dict[str, Any], processor: AutoProcessor
+) -> tuple[VLMMessageLogType, VLMMessageLogType]:
+    """Rebuild a NeMo-Gym rollout message log with processor-backed VLM prompt data.
+
+    The NeMo-Gym environment currently reconstructs prompt-side messages from raw
+    token deltas. For VLMs that drops the processor outputs required by the
+    training-side logprob path. This helper restores the first prompt using the
+    original structured NeMo-Gym input and keeps later prompt deltas token-based.
+    """
+
+    def _to_int_list(token_ids: list[int | str]) -> list[int]:
+        return [int(token_id) for token_id in token_ids]
+
+    output_items = full_result["response"]["output"]
+    generation_items = [
+        output_item
+        for output_item in output_items
+        if "generation_token_ids" in output_item
+    ]
+    if not generation_items:
+        raise ValueError("Expected at least one NeMo-Gym generation item for VLM.")
+
+    first_generation = generation_items[0]
+    prompt_message = build_nemo_gym_vlm_prompt_message(
+        full_result["responses_create_params"]["input"],
+        processor,
+        first_generation["prompt_token_ids"],
+        tools=full_result["responses_create_params"].get("tools"),
+    )
+
+    input_message_log: VLMMessageLogType = [copy.deepcopy(prompt_message)]
+    message_log: VLMMessageLogType = [prompt_message]
+    seen_token_ids = prompt_message["token_ids"].tolist()
+
+    for output_item in generation_items:
+        prompt_token_ids = _to_int_list(output_item["prompt_token_ids"])
+        assert seen_token_ids == prompt_token_ids[: len(seen_token_ids)], (
+            "Non-contiguous prompt tokens found while rebuilding a NeMo-Gym VLM "
+            "message log. This indicates prompt reconstruction drift."
+        )
+
+        prompt_delta = prompt_token_ids[len(seen_token_ids) :]
+        if prompt_delta:
+            message_log.append(
+                {
+                    "role": "user",
+                    "content": "",
+                    "token_ids": torch.tensor(prompt_delta, dtype=torch.long),
+                }
+            )
+            seen_token_ids.extend(prompt_delta)
+
+        generation_token_ids = _to_int_list(output_item["generation_token_ids"])
+        message_log.append(
+            {
+                "role": "assistant",
+                "content": "",
+                "token_ids": torch.tensor(generation_token_ids, dtype=torch.long),
+                "generation_logprobs": torch.tensor(
+                    output_item["generation_log_probs"]
+                ),
+            }
+        )
+        seen_token_ids.extend(generation_token_ids)
+
+    return input_message_log, message_log
+
+
 def _calculate_single_metric(
     values: list[float], batch_size: int, key_name: str
 ) -> dict:
@@ -1013,6 +1084,7 @@ def run_async_nemo_gym_rollout(
     tokenizer: TokenizerType,
     task_to_env: dict[str, EnvironmentInterface],
     generation_config: GenerationConfig,
+    processor: Optional[AutoProcessor] = None,
     max_seq_len: Optional[int] = None,
     max_rollout_turns: Optional[int] = None,
     greedy: bool = False,
@@ -1065,6 +1137,15 @@ def run_async_nemo_gym_rollout(
                 nemo_gym_rows, tokenizer, timer_prefix
             )
         )
+
+        if processor is not None:
+            for result in results:
+                (
+                    result["input_message_log"],
+                    result["message_log"],
+                ) = rebuild_nemo_gym_vlm_message_log(
+                    result["full_result"], processor
+                )
 
         # Tensorize all token ids
         for r in results:

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -1029,16 +1029,18 @@ def rebuild_nemo_gym_vlm_message_log(
 
     input_message_log: VLMMessageLogType = [copy.deepcopy(prompt_message)]
     message_log: VLMMessageLogType = [prompt_message]
-    seen_token_ids = prompt_message["token_ids"].tolist()
+    rollout_seen_token_ids = _to_int_list(first_generation["prompt_token_ids"])
 
     for output_item in generation_items:
         prompt_token_ids = _to_int_list(output_item["prompt_token_ids"])
-        assert seen_token_ids == prompt_token_ids[: len(seen_token_ids)], (
+        assert rollout_seen_token_ids == prompt_token_ids[
+            : len(rollout_seen_token_ids)
+        ], (
             "Non-contiguous prompt tokens found while rebuilding a NeMo-Gym VLM "
             "message log. This indicates prompt reconstruction drift."
         )
 
-        prompt_delta = prompt_token_ids[len(seen_token_ids) :]
+        prompt_delta = prompt_token_ids[len(rollout_seen_token_ids) :]
         if prompt_delta:
             message_log.append(
                 {
@@ -1047,7 +1049,7 @@ def rebuild_nemo_gym_vlm_message_log(
                     "token_ids": torch.tensor(prompt_delta, dtype=torch.long),
                 }
             )
-            seen_token_ids.extend(prompt_delta)
+            rollout_seen_token_ids.extend(prompt_delta)
 
         generation_token_ids = _to_int_list(output_item["generation_token_ids"])
         message_log.append(
@@ -1060,7 +1062,7 @@ def rebuild_nemo_gym_vlm_message_log(
                 ),
             }
         )
-        seen_token_ids.extend(generation_token_ids)
+        rollout_seen_token_ids.extend(generation_token_ids)
 
     return input_message_log, message_log
 

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -292,3 +292,4 @@ class PolicyConfig(TypedDict):
         | SchedulerMilestones
         | None
     ]
+    is_vlm: NotRequired[bool]

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -262,6 +262,7 @@ class DynamicBatchingConfig(TypedDict):
 
 class PolicyConfig(TypedDict):
     model_name: str
+    is_vlm: NotRequired[bool]
     tokenizer: TokenizerConfig
     train_global_batch_size: int
     train_micro_batch_size: int

--- a/nemo_rl/models/policy/utils.py
+++ b/nemo_rl/models/policy/utils.py
@@ -52,6 +52,7 @@ from nemo_rl.distributed.worker_group_utils import get_nsight_config_if_pattern_
 AUTOMODEL_FACTORY: Dict[str, Any] = {
     "qwen2_5_vl": AutoModelForImageTextToText,
     "qwen2_vl": AutoModelForImageTextToText,
+    "qwen3_vl": AutoModelForImageTextToText,
     "qwen2_5_omni": AutoModelForTextToWaveform,
     "llava": AutoModelForImageTextToText,
     "internvl": AutoModelForImageTextToText,
@@ -65,6 +66,7 @@ if NEMO_AUTOMODEL_AVAILABLE:
     AUTOMODEL_FACTORY = {
         "qwen2_5_vl": NeMoAutoModelForImageTextToText,
         "qwen2_vl": NeMoAutoModelForImageTextToText,
+        "qwen3_vl": NeMoAutoModelForImageTextToText,
         "qwen2_5_omni": NeMoAutoModelForTextToWaveform,
         "llava": NeMoAutoModelForImageTextToText,
         "internvl": NeMoAutoModelForImageTextToText,

--- a/tests/unit/algorithms/test_utils.py
+++ b/tests/unit/algorithms/test_utils.py
@@ -14,6 +14,7 @@
 
 import math
 from datetime import datetime
+from unittest.mock import MagicMock
 
 import pytest
 import torch
@@ -218,6 +219,45 @@ def test_maybe_pad_last_batch():
     assert result["sample_mask"].shape[0] == expected_size
     assert "token_mask" not in result
     assert "reference_policy_logprobs" not in result
+
+
+def test_get_tokenizer_processor_applies_chat_template_kwargs(monkeypatch):
+    tokenizer = MagicMock()
+    tokenizer.pad_token = "<pad>"
+    tokenizer.eos_token = "<eos>"
+    tokenizer.bos_token = "<bos>"
+    tokenizer.pad_token_id = 0
+    tokenizer.eos_token_id = 1
+    tokenizer.bos_token_id = 2
+    tokenizer.name_or_path = "test-vlm"
+
+    original_processor_apply_chat_template = MagicMock(return_value="formatted")
+    processor = MagicMock()
+    processor.tokenizer = tokenizer
+    processor.apply_chat_template = original_processor_apply_chat_template
+
+    def _mock_from_pretrained(*args, **kwargs):
+        del args, kwargs
+        return processor
+
+    monkeypatch.setattr(
+        "nemo_rl.algorithms.utils.AutoProcessor.from_pretrained",
+        _mock_from_pretrained,
+    )
+
+    result = get_tokenizer(
+        {
+            "name": "test-vlm",
+            "chat_template_kwargs": {"enable_thinking": False},
+        },
+        get_processor=True,
+    )
+
+    result.apply_chat_template([], tokenize=False)
+
+    original_processor_apply_chat_template.assert_called_once_with(
+        [], tokenize=False, enable_thinking=False
+    )
 
 
 # Performance Metrics Tests

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -27,7 +27,11 @@ from nemo_rl.data.collate_fn import rl_collate_fn
 from nemo_rl.data.datasets.response_datasets import NemoGymDataset
 from nemo_rl.data.interfaces import DatumSpec
 from nemo_rl.data.llm_message_utils import batched_message_log_to_flat_message
-from nemo_rl.data.processors import nemo_gym_data_processor
+from nemo_rl.data.multimodal_utils import PackedTensor
+from nemo_rl.data.processors import (
+    build_nemo_gym_vlm_prompt_message,
+    nemo_gym_data_processor,
+)
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
 from nemo_rl.environments.games.sliding_puzzle import (
@@ -38,6 +42,7 @@ from nemo_rl.environments.games.sliding_puzzle import (
 )
 from nemo_rl.experience.rollouts import (
     _calculate_single_metric,
+    rebuild_nemo_gym_vlm_message_log,
     run_async_multi_turn_rollout,
     run_async_nemo_gym_rollout,
     run_multi_turn_rollout,
@@ -63,6 +68,48 @@ from tests.unit.test_envs import (
 )
 
 MODEL_NAME = "Qwen/Qwen2.5-1.5B-Instruct"
+
+
+class _FakeImageProcessor:
+    model_input_names = ["pixel_values", "image_grid_thw"]
+
+
+class _FakeVLMProcessor:
+    def __init__(self, prompt_token_ids: list[int]):
+        self.prompt_token_ids = prompt_token_ids
+        self.image_processor = _FakeImageProcessor()
+        self.tokenizer = type(
+            "TokenizerStub",
+            (),
+            {"pad_token_id": 0, "model_input_names": ["input_ids"]},
+        )()
+        self.last_messages = None
+        self.last_tools = None
+
+    def apply_chat_template(
+        self,
+        messages,
+        *,
+        tokenize,
+        add_generation_prompt,
+        return_tensors,
+        return_dict,
+        tools=None,
+    ):
+        assert tokenize is True
+        assert add_generation_prompt is True
+        assert return_tensors == "pt"
+        assert return_dict is True
+        self.last_messages = messages
+        self.last_tools = tools
+        seq_len = len(self.prompt_token_ids)
+        return {
+            "input_ids": torch.tensor([self.prompt_token_ids], dtype=torch.long),
+            "pixel_values": torch.arange(6, dtype=torch.float32).reshape(1, 6),
+            "image_grid_thw": torch.tensor([[1, 2, 3]], dtype=torch.long),
+            "token_type_ids": torch.arange(seq_len, dtype=torch.long).unsqueeze(0),
+            "mm_token_type_ids": torch.full((1, seq_len), 7, dtype=torch.long),
+        }
 
 
 class TestCalculateSingleMetric:
@@ -99,6 +146,113 @@ class TestCalculateSingleMetric:
         result = _calculate_single_metric([5.0, 5.0], batch_size=2, key_name="test")
 
         assert result["test/stddev"] == 0.0
+
+
+def test_build_nemo_gym_vlm_prompt_message_normalizes_responses_input() -> None:
+    prompt_token_ids = [11, 12, 13, 14]
+    processor = _FakeVLMProcessor(prompt_token_ids)
+    tools = [{"name": "click"}]
+    prompt_message = build_nemo_gym_vlm_prompt_message(
+        [
+            {"role": "system", "content": "You are helpful."},
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_image",
+                        "image_url": "data:image/png;base64,AAAA",
+                        "detail": "auto",
+                    },
+                    {"type": "input_text", "text": "Click the red circle."},
+                ],
+            },
+        ],
+        processor,
+        prompt_token_ids,
+        tools=tools,
+    )
+
+    assert processor.last_messages == [
+        {"role": "system", "content": "You are helpful."},
+        {
+            "role": "user",
+            "content": [
+                {"type": "image", "image": "data:image/png;base64,AAAA"},
+                {"type": "text", "text": "Click the red circle."},
+            ],
+        },
+    ]
+    assert processor.last_tools == tools
+    assert prompt_message["token_ids"].tolist() == prompt_token_ids
+    assert isinstance(prompt_message["pixel_values"], PackedTensor)
+    assert isinstance(prompt_message["image_grid_thw"], PackedTensor)
+    assert prompt_message["token_type_ids"].tolist() == [0, 1, 2, 3]
+    assert prompt_message["mm_token_type_ids"].tolist() == [7, 7, 7, 7]
+
+
+def test_build_nemo_gym_vlm_prompt_message_rejects_prompt_token_mismatch() -> None:
+    processor = _FakeVLMProcessor([1, 2, 3])
+    with pytest.raises(ValueError, match="prompt_token_ids"):
+        build_nemo_gym_vlm_prompt_message(
+            [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+            processor,
+            [1, 2],
+        )
+
+
+def test_rebuild_nemo_gym_vlm_message_log_preserves_later_prompt_deltas() -> None:
+    prompt_token_ids = [11, 12, 13]
+    processor = _FakeVLMProcessor(prompt_token_ids)
+    full_result = {
+        "responses_create_params": {
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_image", "image_url": "data:image/png;base64,AAAA"},
+                        {"type": "input_text", "text": "Click the red circle."},
+                    ],
+                }
+            ],
+            "tools": [{"name": "click"}],
+        },
+        "response": {
+            "output": [
+                {
+                    "prompt_token_ids": prompt_token_ids,
+                    "generation_token_ids": [21, 22],
+                    "generation_log_probs": [-0.1, -0.2],
+                },
+                {
+                    "prompt_token_ids": prompt_token_ids + [21, 22, 31],
+                    "generation_token_ids": [41],
+                    "generation_log_probs": [-0.3],
+                },
+            ]
+        },
+    }
+
+    input_message_log, message_log = rebuild_nemo_gym_vlm_message_log(
+        full_result, processor
+    )
+
+    assert len(input_message_log) == 1
+    assert input_message_log[0]["token_ids"].tolist() == prompt_token_ids
+    assert isinstance(input_message_log[0]["pixel_values"], PackedTensor)
+
+    assert [message["role"] for message in message_log] == [
+        "user",
+        "assistant",
+        "user",
+        "assistant",
+    ]
+    assert message_log[1]["token_ids"].tolist() == [21, 22]
+    assert torch.allclose(
+        message_log[1]["generation_logprobs"],
+        torch.tensor([-0.1, -0.2]),
+    )
+    assert message_log[2]["token_ids"].tolist() == [31]
+    assert message_log[3]["token_ids"].tolist() == [41]
 
 
 @pytest.fixture(scope="function")

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -173,7 +173,7 @@ def test_build_nemo_gym_vlm_prompt_message_normalizes_responses_input() -> None:
     )
 
     assert processor.last_messages == [
-        {"role": "system", "content": "You are helpful."},
+        {"role": "system", "content": [{"type": "text", "text": "You are helpful."}]},
         {
             "role": "user",
             "content": [
@@ -251,6 +251,56 @@ def test_rebuild_nemo_gym_vlm_message_log_preserves_later_prompt_deltas() -> Non
         message_log[1]["generation_logprobs"],
         torch.tensor([-0.1, -0.2]),
     )
+    assert message_log[2]["token_ids"].tolist() == [31]
+    assert message_log[3]["token_ids"].tolist() == [41]
+
+
+def test_rebuild_nemo_gym_vlm_message_log_allows_expanded_processor_prompt() -> None:
+    rollout_prompt_token_ids = [11, 12, 13]
+    processor_prompt_token_ids = [101, 102, 103, 104, 105, 106]
+    processor = _FakeVLMProcessor(processor_prompt_token_ids)
+    full_result = {
+        "responses_create_params": {
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_image", "image_url": "data:image/png;base64,AAAA"},
+                        {"type": "input_text", "text": "Click the red circle."},
+                    ],
+                }
+            ],
+        },
+        "response": {
+            "output": [
+                {
+                    "prompt_token_ids": rollout_prompt_token_ids,
+                    "generation_token_ids": [21, 22],
+                    "generation_log_probs": [-0.1, -0.2],
+                },
+                {
+                    "prompt_token_ids": rollout_prompt_token_ids + [21, 22, 31],
+                    "generation_token_ids": [41],
+                    "generation_log_probs": [-0.3],
+                },
+            ]
+        },
+    }
+
+    input_message_log, message_log = rebuild_nemo_gym_vlm_message_log(
+        full_result, processor
+    )
+
+    assert input_message_log[0]["token_ids"].tolist() == processor_prompt_token_ids
+    assert message_log[0]["token_ids"].tolist() == processor_prompt_token_ids
+    assert isinstance(message_log[0]["pixel_values"], PackedTensor)
+    assert [message["role"] for message in message_log] == [
+        "user",
+        "assistant",
+        "user",
+        "assistant",
+    ]
+    assert message_log[1]["token_ids"].tolist() == [21, 22]
     assert message_log[2]["token_ids"].tolist() == [31]
     assert message_log[3]["token_ids"].tolist() == [41]
 


### PR DESCRIPTION
This fixes NeMo-Gym VLM rollout reconstruction so the DTensor training/logprob path receives the same effective multimodal prompt that vLLM used for generation.

PR #2296 correctly rebuilt NeMo-Gym VLM prompts through the HF processor, but Qwen3-VL image prompts expose two different token spaces:

- vLLM rollout `prompt_token_ids` use compact image placeholders
- the HF processor returns expanded VLM training `input_ids` plus multimodal tensors

The previous reconstruction mixed those token spaces, causing failures or drift when slicing later prompt deltas. This change preserves the processor-expanded first prompt for training while tracking compact rollout token IDs separately for continuity checks and multi-turn prompt deltas.

Also normalizes string content into typed text content for processor-backed VLM messages and adds regression coverage for expanded processor prompts.

## Validation

- Focused ruff passed on touched files
- Focused rollout unit tests passed
- 5-step Qwen3-VL circle-click smoke run completed
- `gen_kl_error` improved from the previous high-mismatch range to:
  - step 1: `0.0276`
  - step 2: `0.0205`
  - step 3: `0.0137`
  - step 4: `0.0072`
  - step 5: `0.0090`
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Vision Language Model (VLM) support for GRPO training with multimodal models
  * Integrated processor support for handling image and text inputs together
  * Enabled Qwen3-VL-2B model configuration for circle-click environment training
  * Added chat template customization capabilities for model behavior control

* **Tests**
  * Added comprehensive unit tests for VLM prompt reconstruction and processor integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->