### PR TITLE
fix(nemo-gym): plumb max_new_tokens into row-level max_output_tokens

### DIFF
--- a/examples/nemo_gym/grpo_nanov3.yaml
+++ b/examples/nemo_gym/grpo_nanov3.yaml
@@ -181,7 +181,7 @@ policy:
 
   generation:
     backend: "vllm"
-    max_new_tokens: ${policy.max_total_sequence_length}
+    max_new_tokens: 8192
     temperature: 1.0
     top_p: 1.0
     top_k: null

--- a/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
+++ b/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
@@ -208,7 +208,7 @@ policy:
 
   generation:
     backend: "vllm"
-    max_new_tokens: ${policy.max_total_sequence_length}
+    max_new_tokens: 8192
     temperature: 1.0
     top_p: 1.0
     top_k: null

--- a/examples/nemo_gym/run_grpo_nemo_gym.py
+++ b/examples/nemo_gym/run_grpo_nemo_gym.py
@@ -94,7 +94,7 @@ def collect_trajectories(
             input_batch=val_batch,
             tokenizer=tokenizer,
             task_to_env=val_task_to_env,
-            max_seq_len=None,
+            max_seq_len=master_config["policy"]["max_total_sequence_length"],
             generation_config=generation_config,
             max_rollout_turns=None,
             greedy=False,

--- a/nemo_rl/algorithms/async_utils.py
+++ b/nemo_rl/algorithms/async_utils.py
@@ -657,7 +657,9 @@ class AsyncTrajectoryCollector:
                     input_batch=repeated_batch,
                     tokenizer=self.tokenizer,
                     task_to_env=self.task_to_env,
-                    max_seq_len=None,
+                    max_seq_len=self.master_config["policy"][
+                        "max_total_sequence_length"
+                    ],
                     generation_config=generation_config,
                     max_rollout_turns=None,
                     greedy=False,

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1517,7 +1517,9 @@ def grpo_train(
                             input_batch=repeated_batch,
                             tokenizer=tokenizer,
                             task_to_env=task_to_env,
-                            max_seq_len=None,
+                            max_seq_len=master_config["policy"][
+                                "max_total_sequence_length"
+                            ],
                             generation_config=generation_config,
                             max_rollout_turns=None,
                             greedy=False,
@@ -2254,7 +2256,7 @@ def validate(
                     input_batch=val_batch,
                     tokenizer=tokenizer,
                     task_to_env=val_task_to_env,
-                    max_seq_len=None,
+                    max_seq_len=master_config["policy"]["max_total_sequence_length"],
                     generation_config=generation_config,
                     max_rollout_turns=None,
                     greedy=False,

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -1103,7 +1103,6 @@ def run_async_nemo_gym_rollout(
     assert max_rollout_turns is None, (
         "`max_rollout_turns` is not supported in NeMo-Gym path!"
     )
-    assert max_seq_len is None, "`max_seq_len` is not supported in NeMo-Gym path!"
     # We don't use these stop criteria
     assert not generation_config["stop_strings"], (
         "Stop strings is not supported in the generation config in NeMo-Gym path!"
@@ -1121,16 +1120,23 @@ def run_async_nemo_gym_rollout(
     timer.start(f"{timer_prefix}/total")
 
     for rowidx, row in enumerate(nemo_gym_rows):
-        # We may need better handling here. The max tokens set here would be the max new generated tokens, not the total max tokens.
-        # Currently, we just rely on the underlying vLLM engine to do the truncation for us using the max model seq len set in the config.
-        # row["max_tokens"] = max_seq_len
+        # We accept max_seq_len for API parity with the other rollout paths, but NeMo-Gym
+        # still relies on the underlying model server's configured context/window limits.
+        # We do not translate max_seq_len into row-level max_tokens here because that would
+        # change semantics from "total sequence length" to "max new tokens".
 
         responses_create_params = row["responses_create_params"]
         responses_create_params["temperature"] = generation_config["temperature"]
         responses_create_params["top_p"] = generation_config["top_p"]
-
-        # Max new tokens, just like max_seq_len above is ignored and we rely on the underlying vLLM engine for truncation.
-        # generation_config["max_new_tokens"]
+        if generation_config["max_new_tokens"] is not None:
+            existing_max_output_tokens = responses_create_params.get(
+                "max_output_tokens"
+            )
+            responses_create_params["max_output_tokens"] = (
+                min(existing_max_output_tokens, generation_config["max_new_tokens"])
+                if existing_max_output_tokens is not None
+                else generation_config["max_new_tokens"]
+            )
 
         row["_rowidx"] = rowidx
 

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -20,6 +20,7 @@ import copy
 import json
 import math
 import statistics
+import warnings
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, Optional
@@ -1094,6 +1095,8 @@ def run_async_nemo_gym_rollout(
     greedy: bool = False,
 ) -> AsyncNemoGymRolloutResult:
     """Run multi-turn rollouts with NeMo-Gym. Please refer to the `run_async_multi_turn_rollout` docs for more information on the parameters."""
+    # We accept max_seq_len for API parity with the other rollout paths, but NeMo-Gym
+    # still relies on the underlying model server's configured context/window limits.
     # We leverage the same `extra_env_info` key as `run_async_multi_turn_rollout`.
     nemo_gym_rows = input_batch["extra_env_info"]
 
@@ -1103,6 +1106,14 @@ def run_async_nemo_gym_rollout(
     assert max_rollout_turns is None, (
         "`max_rollout_turns` is not supported in NeMo-Gym path!"
     )
+    engine_max_model_len = policy_generation.cfg["vllm_cfg"]["max_model_len"]
+    if max_seq_len is not None and max_seq_len > engine_max_model_len:
+        warnings.warn(
+            f"policy max_total_sequence_length ({max_seq_len}) is greater than the "
+            f"generation engine's max_model_len ({engine_max_model_len}). The engine "
+            "will truncate sequences to its own limit, so the policy cap will not be "
+            "honored. Lower max_total_sequence_length or raise the engine's max_model_len."
+        )
     # We don't use these stop criteria
     assert not generation_config["stop_strings"], (
         "Stop strings is not supported in the generation config in NeMo-Gym path!"
@@ -1120,11 +1131,8 @@ def run_async_nemo_gym_rollout(
     timer.start(f"{timer_prefix}/total")
 
     for rowidx, row in enumerate(nemo_gym_rows):
-        # We accept max_seq_len for API parity with the other rollout paths, but NeMo-Gym
-        # still relies on the underlying model server's configured context/window limits.
         # We do not translate max_seq_len into row-level max_tokens here because that would
         # change semantics from "total sequence length" to "max new tokens".
-
         responses_create_params = row["responses_create_params"]
         responses_create_params["temperature"] = generation_config["temperature"]
         responses_create_params["top_p"] = generation_config["top_p"]

--- a/tests/functional/grpo_async_gym.sh
+++ b/tests/functional/grpo_async_gym.sh
@@ -66,6 +66,7 @@ uv run coverage run -a --data-file=$PROJECT_ROOT/tests/.coverage --source=$PROJE
     policy.generation.vllm_cfg.tensor_parallel_size=1 \
     policy.generation.vllm_cfg.async_engine=true \
     policy.max_total_sequence_length=512 \
+    policy.generation.max_new_tokens=128 \
     policy.generation.colocated.enabled=false \
     policy.generation.colocated.resources.num_nodes=1 \
     policy.generation.colocated.resources.gpus_per_node=1 \

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -809,15 +809,23 @@ def test_run_async_nemo_gym_rollout(
     ]
 
     input_batch: BatchedDataDict[DatumSpec] = rl_collate_fn(nemo_rl_compatible_examples)
+    for row in input_batch["extra_env_info"]:
+        assert "max_output_tokens" not in row["responses_create_params"]
+
     actual_result = run_async_nemo_gym_rollout(
         policy_generation=nemo_gym_vllm_generation,
         input_batch=input_batch,
         tokenizer=nemo_gym_tokenizer,
         task_to_env={"nemo_gym": nemo_gym},
-        max_seq_len=None,
+        max_seq_len=65536,
         generation_config=nemo_gym_vllm_generation.cfg,
         max_rollout_turns=None,
     )
+    for row in input_batch["extra_env_info"]:
+        assert (
+            row["responses_create_params"]["max_output_tokens"]
+            == nemo_gym_vllm_generation.cfg["max_new_tokens"]
+        )
     actual_result = asdict(actual_result)
     actual_result["final_batch"] = actual_result["final_batch"].get_dict()
 

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -828,9 +828,7 @@ def test_run_async_nemo_gym_rollout(
         max_rollout_turns=None,
     )
     for row in rows:
-        assert (
-            row["responses_create_params"]["max_output_tokens"] == max_new_tokens
-        )
+        assert row["responses_create_params"]["max_output_tokens"] == max_new_tokens
     actual_result = asdict(actual_result)
     actual_result["final_batch"] = actual_result["final_batch"].get_dict()
 

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -809,8 +809,14 @@ def test_run_async_nemo_gym_rollout(
     ]
 
     input_batch: BatchedDataDict[DatumSpec] = rl_collate_fn(nemo_rl_compatible_examples)
-    for row in input_batch["extra_env_info"]:
-        assert "max_output_tokens" not in row["responses_create_params"]
+    rows = input_batch["extra_env_info"]
+    assert len(rows) >= 2, "test expects the fixture to provide at least two rows"
+
+    max_new_tokens = nemo_gym_vllm_generation.cfg["max_new_tokens"]
+    # Row 0: per-agent override looser than the configured cap — min() should clamp down to max_new_tokens.
+    # Row 1: no per-agent override — should fall back to max_new_tokens.
+    rows[0]["responses_create_params"]["max_output_tokens"] = max_new_tokens + 1
+    assert "max_output_tokens" not in rows[1]["responses_create_params"]
 
     actual_result = run_async_nemo_gym_rollout(
         policy_generation=nemo_gym_vllm_generation,
@@ -821,10 +827,9 @@ def test_run_async_nemo_gym_rollout(
         generation_config=nemo_gym_vllm_generation.cfg,
         max_rollout_turns=None,
     )
-    for row in input_batch["extra_env_info"]:
+    for row in rows:
         assert (
-            row["responses_create_params"]["max_output_tokens"]
-            == nemo_gym_vllm_generation.cfg["max_new_tokens"]
+            row["responses_create_params"]["max_output_tokens"] == max_new_tokens
         )
     actual_result = asdict(actual_result)
     actual_result["final_batch"] = actual_result["final_batch"].get_dict()

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -786,6 +786,25 @@ def test_run_sliding_puzzle_vllm(sliding_puzzle_setup_vllm):
     print("\nSliding Puzzle VLLM Test assertions passed.")
 
 
+def test_run_async_nemo_gym_rollout_warns_when_max_seq_len_exceeds_engine():
+    class _FakePolicyGeneration:
+        cfg = {"vllm_cfg": {"max_model_len": 100}}
+
+    # stop_strings is truthy so the function hits the next assert and exits
+    # right after emitting the warning — keeps this test free of any rollout work.
+    with pytest.warns(UserWarning, match="greater than the"):
+        with pytest.raises(AssertionError, match="Stop strings"):
+            run_async_nemo_gym_rollout(
+                policy_generation=_FakePolicyGeneration(),
+                input_batch={"extra_env_info": []},
+                tokenizer=None,
+                task_to_env={},
+                generation_config={"stop_strings": "x", "max_new_tokens": 50},
+                max_seq_len=200,
+                max_rollout_turns=None,
+            )
+
+
 @pytest.mark.nemo_gym
 def test_run_async_nemo_gym_rollout(
     nemo_gym,  # noqa: F811

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -823,7 +823,7 @@ def test_run_async_nemo_gym_rollout(
         input_batch=input_batch,
         tokenizer=nemo_gym_tokenizer,
         task_to_env={"nemo_gym": nemo_gym},
-        max_seq_len=65536,
+        max_seq_len=nemo_gym_vllm_generation.cfg["vllm_cfg"]["max_model_len"],
         generation_config=nemo_gym_vllm_generation.cfg,
         max_rollout_turns=None,
     )


### PR DESCRIPTION
## Summary
- `run_async_nemo_gym_rollout` previously asserted `max_seq_len is None` and discarded `generation_config["max_new_tokens"]`, leaving every row's `responses_create_params` with whatever `max_output_tokens` the agent template happened to set (often unset). With no per-request cap, generations could exceed the configured budget and either run away or get killed by vLLM after wasting compute.
- Drop the `assert max_seq_len is None` and document why we accept `max_seq_len` for API parity without translating it into row-level `max_tokens` (the semantics differ — total sequence length vs. max new tokens).
- Write `generation_config["max_new_tokens"]` into each row's `responses_create_params["max_output_tokens"]`, taking `min` with any existing per-row value so per-agent overrides still win when stricter.
- Update the four call sites (grpo train, grpo validate, async trajectory collector, `run_grpo_nemo_gym.py` example) to pass `master_config["policy"]["max_total_sequence_length"]` instead of `None` so the rollout parameter actually reflects the configured cap.
- Update `test_run_async_nemo_gym_rollout` to verify `max_output_tokens` gets populated from `generation_config["max_new_tokens"]`.

## Test plan
- [ ] `tests/unit/experience/test_rollouts.py::test_run_async_nemo_gym_rollout` passes (asserts `max_output_tokens` is set on every row after the rollout).
- [ ] Run a NeMo-Gym GRPO recipe end-to-end and confirm generations respect `policy.generation.max_new_tokens` (no runaway sequences) and that the call sites no longer trip the removed assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)