### PR TITLE
fix(nemo-gym): bind default_host to actor node IP for multinode

### DIFF
--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -56,6 +56,10 @@ class NemoGym(EnvironmentInterface):
             "dummy_key"  # No key necessary for training.
         )
         initial_global_config_dict["policy_base_url"] = self.cfg["base_urls"]
+        # In multinode runs, Gym-managed service configs must advertise a real node IP
+        # rather than falling back to localhost, or remote workers will connect to
+        # their own loopback interface instead of the actor-hosted service.
+        initial_global_config_dict.setdefault("default_host", self.node_ip)
 
         initial_global_config_dict.setdefault(
             "global_aiohttp_connector_limit_per_host", 16_384


### PR DESCRIPTION
## Summary
- In multinode runs, `NemoGym` actors can land on any worker node. Without an explicit `default_host`, Gym-managed service configs fall back to `localhost`, so remote workers connect to their own loopback interface instead of the actor-hosted service and the rollout hangs / errors.
- Set `initial_global_config_dict.setdefault("default_host", self.node_ip)` before passing the config into NeMo-Gym so service URLs advertise the real node IP.
- Single-node runs continue to work because `node_ip` resolves locally; users who want to override can still set `default_host` explicitly via `initial_global_config_dict` (the `setdefault` only fills it when unset).

## Test plan
- [ ] Run a multinode NeMo-Gym recipe and confirm worker nodes successfully reach the actor-hosted service (no localhost-loopback connect errors).
- [ ] Run a single-node NeMo-Gym recipe and confirm behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)