### PR TITLE
docs: use @file-path notation for file references in skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,4 +20,4 @@ When reviewing code, follow these principles:
 
 ## Kubernetes / nrl-k8s
 
-For launching, monitoring, stopping, and debugging NeMo-RL recipes on Kubernetes, see the skill at `skills/launch-nemo-rl/SKILL.md`.
+For launching, monitoring, stopping, and debugging NeMo-RL recipes on Kubernetes, see the skill at @skills/launch-nemo-rl/SKILL.md.

--- a/skills/config-conventions/SKILL.md
+++ b/skills/config-conventions/SKILL.md
@@ -97,4 +97,4 @@ if "milestones" in scheduler_cfg:
     configure_milestones(scheduler_cfg["milestones"])
 ```
 
-See also: [TypedDict and Configuration Defaults](docs/design-docs/design-and-philosophy.md#typeddict-and-configuration-defaults).
+See also: @docs/design-docs/design-and-philosophy.md (TypedDict and Configuration Defaults section).

--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -7,7 +7,7 @@ description: Documentation conventions for NeMo-RL. Covers docs/index.md updates
 
 ## Keep docs/index.md Up to Date
 
-When a new markdown doc is added under `docs/**/*.md` or a markdown file is renamed, ensure that `docs/index.md` is updated and the document appears in the most appropriate section.
+When a new markdown doc is added under `docs/**/*.md` or a markdown file is renamed, ensure that @docs/index.md is updated and the document appears in the most appropriate section.
 
 ## Docstring Format
 
@@ -17,6 +17,6 @@ For interfaces that may be used outside a file, prefer docstrings over comments.
 
 ## Document New Features
 
-When a new feature is added, update or create documentation in the `docs/` directory that most closely matches the feature. Look at existing docs to find the best fit — if none exists, create a new doc and add it to `docs/index.md`.
+When a new feature is added, update or create documentation in the `docs/` directory that most closely matches the feature. Look at existing docs to find the best fit — if none exists, create a new doc and add it to @docs/index.md.
 
 Documentation changes are **not required** for bug fixes or CI-related changes.

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -66,7 +66,7 @@ No MCP calls needed.
 
 ### Both modes — local reads
 
-7. Read `CLAUDE.md` from repo root for review philosophy
+7. Read @CLAUDE.md from repo root for review philosophy
 8. Read all `.claude/skills/*/SKILL.md` files (except `review-pr`) for guideline rules
 9. Glob `.claude/review-memory/*.md` — if any exist, read them for learned patterns
 

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -38,7 +38,7 @@ Create a shell script in the matching domain (`tests/test_suites/llm/` or `tests
 
 ### 3. Add to nightly list
 
-Append the driver script path (relative to `tests/test_suites/`) to `tests/test_suites/nightly.txt`.
+Append the driver script path (relative to `tests/test_suites/`) to @tests/test_suites/nightly.txt.
 
 ## Recipe Naming Rules
 


### PR DESCRIPTION
<details><summary>Claude summary</summary>

File references in `AGENTS.md` and `SKILL.md` files now use `@<path>` syntax so Claude Code automatically includes those files in context when the skill is loaded or the file is mentioned.

### Changes

- `AGENTS.md`: `skills/launch-nemo-rl/SKILL.md` reference converted from backtick to `@skills/launch-nemo-rl/SKILL.md`
- `skills/config-conventions/SKILL.md`: markdown hyperlink `[TypedDict and Configuration Defaults](docs/design-docs/design-and-philosophy.md#...)` converted to `@docs/design-docs/design-and-philosophy.md`
- `skills/docs/SKILL.md`: two occurrences of backtick `docs/index.md` in prose directives converted to `@docs/index.md`
- `skills/review-pr/SKILL.md`: backtick `CLAUDE.md` in the "Both modes — local reads" step converted to `@CLAUDE.md`
- `skills/testing/SKILL.md`: backtick `tests/test_suites/nightly.txt` in the "Add to nightly list" step converted to `@tests/test_suites/nightly.txt`

All referenced paths were verified to exist in the repo before conversion. References in bash code blocks, glob patterns, structural tables, and example filenames were left unchanged.

</details>
