### PR TITLE
fix: filter out unschedulable head nodes in venv creation

### DIFF
--- a/nemo_rl/utils/venvs.py
+++ b/nemo_rl/utils/venvs.py
@@ -158,8 +158,15 @@ def create_local_venv_on_each_node(py_executable: str, venv_name: str):
     Returns:
         str: Path to the python executable in the created virtual environment
     """
-    # Determine the number of alive Ray nodes
-    nodes = [n for n in ray.nodes() if n.get("Alive", False)]
+    # Determine the number of alive GPU Ray nodes (skip head/CPU-only nodes
+    # that have no GPUs — venvs are only needed on GPU workers, and including
+    # nodes with 0 CPUs makes the STRICT_SPREAD placement group infeasible).
+    nodes = [
+        n for n in ray.nodes()
+        if n.get("Alive", False)
+        and n.get("Resources", {}).get("CPU", 0) > 0
+        and n.get("Resources", {}).get("GPU", 0) > 0
+    ]
     num_nodes = len(nodes)
     # Reserve one CPU on each node using a STRICT_SPREAD placement group
     bundles = [{"CPU": 1} for _ in range(num_nodes)]

--- a/nemo_rl/utils/venvs.py
+++ b/nemo_rl/utils/venvs.py
@@ -158,14 +158,12 @@ def create_local_venv_on_each_node(py_executable: str, venv_name: str):
     Returns:
         str: Path to the python executable in the created virtual environment
     """
-    # Determine the number of alive GPU Ray nodes (skip head/CPU-only nodes
-    # that have no GPUs — venvs are only needed on GPU workers, and including
-    # nodes with 0 CPUs makes the STRICT_SPREAD placement group infeasible).
+    # Skip nodes with 0 CPUs (e.g. unschedulable head nodes) — including them
+    # makes the STRICT_SPREAD placement group infeasible.
     nodes = [
         n for n in ray.nodes()
         if n.get("Alive", False)
         and n.get("Resources", {}).get("CPU", 0) > 0
-        and n.get("Resources", {}).get("GPU", 0) > 0
     ]
     num_nodes = len(nodes)
     # Reserve one CPU on each node using a STRICT_SPREAD placement group

--- a/nemo_rl/utils/venvs.py
+++ b/nemo_rl/utils/venvs.py
@@ -161,9 +161,9 @@ def create_local_venv_on_each_node(py_executable: str, venv_name: str):
     # Skip nodes with 0 CPUs (e.g. unschedulable head nodes) — including them
     # makes the STRICT_SPREAD placement group infeasible.
     nodes = [
-        n for n in ray.nodes()
-        if n.get("Alive", False)
-        and n.get("Resources", {}).get("CPU", 0) > 0
+        n
+        for n in ray.nodes()
+        if n.get("Alive", False) and n.get("Resources", {}).get("CPU", 0) > 0
     ]
     num_nodes = len(nodes)
     # Reserve one CPU on each node using a STRICT_SPREAD placement group


### PR DESCRIPTION
## Summary
- Filter out head/CPU-only nodes (with 0 CPUs or 0 GPUs) when building the STRICT_SPREAD placement group for venv creation
- Prevents the placement group from hanging indefinitely when the Ray cluster head node is unschedulable

## Context
When a Ray cluster is configured with an unschedulable head node (no CPUs/GPUs), `create_local_venv_on_each_node` includes it in the node count and creates a bundle for it. Since the head can't schedule anything, the placement group never becomes ready and hangs forever.

## Test plan
- [x] Lint passes
- [ ] CI passes