### PR TITLE
feat: change SFT YaRN recipe from 64k to 128k

### DIFF
--- a/docs/guides/yarn-long-context.md
+++ b/docs/guides/yarn-long-context.md
@@ -15,7 +15,7 @@ YaRN is configured through `policy.hf_config_overrides.rope_scaling`. All YaRN f
 
 ```yaml
 policy:
-  max_total_sequence_length: 65536
+  max_total_sequence_length: 131072
   megatron_cfg:
     enabled: true
   dtensor_cfg:
@@ -24,7 +24,7 @@ policy:
     rope_scaling:
       rope_type: yarn
       rope_theta: 1000000
-      factor: 1.6
+      factor: 3.2
       original_max_position_embeddings: 40960
       truncate: true
       beta_fast: 32
@@ -80,14 +80,14 @@ This re-runs the HF → Megatron conversion and overwrites the cached checkpoint
 
 Two end-to-end YaRN recipes ship with NeMo RL:
 
-- **SFT, 64K context**: [`examples/configs/recipes/llm/sft-qwen3-0.6B-1n8g-megatron-yarn-64k.yaml`](../../examples/configs/recipes/llm/sft-qwen3-0.6B-1n8g-megatron-yarn-64k.yaml) — Qwen3-0.6B fine-tuned to a 64K sequence length on Nemotron-Cascade-2-SFT-Math using `factor: 1.6` (64K / 40960).
+- **SFT, 128K context**: [`examples/configs/recipes/llm/sft-qwen3-0.6B-1n8g-megatron-yarn-128k.yaml`](../../examples/configs/recipes/llm/sft-qwen3-0.6B-1n8g-megatron-yarn-128k.yaml) — Qwen3-0.6B fine-tuned to a 128K sequence length on Nemotron-Cascade-2-SFT-Math using `factor: 3.2` (128K / 40960).
 - **GRPO, 256K context**: [`examples/configs/recipes/llm/grpo-qwen2.5-1.5B-4n8g-megatron-yarn-256k.yaml`](../../examples/configs/recipes/llm/grpo-qwen2.5-1.5B-4n8g-megatron-yarn-256k.yaml) — Qwen2.5-1.5B trained at 256K sequence length with `factor` derived from `max_total_sequence_length / original_max_position_embeddings`.
 
 Launch them the same way as any other recipe:
 
 ```bash
 uv run examples/run_sft.py \
-    --config examples/configs/recipes/llm/sft-qwen3-0.6B-1n8g-megatron-yarn-64k.yaml
+    --config examples/configs/recipes/llm/sft-qwen3-0.6B-1n8g-megatron-yarn-128k.yaml
 
 uv run examples/run_grpo_math.py \
     --config examples/configs/recipes/llm/grpo-qwen2.5-1.5B-4n8g-megatron-yarn-256k.yaml
@@ -95,7 +95,7 @@ uv run examples/run_grpo_math.py \
 
 ## Practical Tips
 
-- **Set context parallelism appropriately.** Long sequences typically require `policy.megatron_cfg.context_parallel_size > 1`. The 256K recipe uses `context_parallel_size: 32`; the 64K recipe uses `8`.
+- **Set context parallelism appropriately.** Long sequences typically require `policy.megatron_cfg.context_parallel_size > 1`. The 256K recipe uses `context_parallel_size: 32`; the 128K recipe uses `8`.
 - **Check `make_sequence_length_divisible_by`.** Long-context recipes usually need a larger divisor (e.g. `64` at 256K) so sequences align with CP/TP shapes.
 - **Keep override configs identical across trainer and generator.** Because `hf_config_overrides` flows into both Megatron and vLLM, editing only one side will cause mismatched RoPE behavior.
 - **Reconvert after changing overrides.** Cached checkpoints are keyed by override hash, so a new hash produces a new cache entry — but if you deliberately mutate an existing cache path, use `force_reconvert_from_hf: true`.

--- a/examples/configs/recipes/llm/sft-qwen3-0.6B-1n8g-megatron-yarn-128k.yaml
+++ b/examples/configs/recipes/llm/sft-qwen3-0.6B-1n8g-megatron-yarn-128k.yaml
@@ -2,12 +2,12 @@ defaults: ../../sft.yaml
 sft:
   max_num_steps: 100
 checkpointing:
-  checkpoint_dir: results/sft-qwen3-0.6B-1n8g-megatron-yarn-64k
+  checkpoint_dir: results/sft-qwen3-0.6B-1n8g-megatron-yarn-128k
   save_period: 20
 policy:
   model_name: Qwen/Qwen3-0.6B
   train_global_batch_size: 16
-  max_total_sequence_length: 65536
+  max_total_sequence_length: 131072
   dtensor_cfg:
     enabled: false
   megatron_cfg:
@@ -34,7 +34,7 @@ policy:
     rope_scaling:
       rope_type: yarn
       rope_theta: 1000000
-      factor: 1.6
+      factor: 3.2
       original_max_position_embeddings: 40960
       truncate: true
       beta_fast: 32
@@ -51,8 +51,8 @@ data:
 logger:
   wandb:
     project: yarn
-    name: sft-qwen3-0.6B-1n8g-megatron-yarn-64k
+    name: sft-qwen3-0.6B-1n8g-megatron-yarn-128k
   tensorboard:
-    log_dir: tb_logs-sft-qwen3-0.6B-1n8g-megatron-yarn-64k
+    log_dir: tb_logs-sft-qwen3-0.6B-1n8g-megatron-yarn-128k
 cluster:
   gpus_per_node: 8

--- a/tests/test_suites/llm/sft-qwen3-0.6B-1n8g-megatron-yarn-128k.sh
+++ b/tests/test_suites/llm/sft-qwen3-0.6B-1n8g-megatron-yarn-128k.sh
@@ -33,7 +33,7 @@ uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
 
 if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
     uv run tests/check_metrics.py $JSON_METRICS \
-        'data["train/loss"]["1"] < 1.3' \
+        'data["train/loss"]["1"] < 1.4' \
         'data["train/loss"]["20"] < 0.9' \
         'data["validation/val_loss"]["20"] < 1.0'
 

--- a/tests/test_suites/nightly.txt
+++ b/tests/test_suites/nightly.txt
@@ -136,7 +136,7 @@ tests/test_suites/llm/sft-nanov3-30BA3B-2n8g-fsdp2.sh
 tests/test_suites/llm/sft-nanov3-30BA3B-2n8g-fsdp2-lora.sh
 
 # Yarn
-tests/test_suites/llm/sft-qwen3-0.6B-1n8g-megatron-yarn-64k.sh
+tests/test_suites/llm/sft-qwen3-0.6B-1n8g-megatron-yarn-128k.sh
 
 #######
 # DPO #


### PR DESCRIPTION
# What does this PR do ?

Change the SFT YaRN long-context recipe from 64K to 128K context length. 

# Issues

Closes #1875 

# Usage

```bash
uv run examples/run_sft.py \                                                                                                                                                     
    --config examples/configs/recipes/llm/sft-qwen3-0.6B-1n8g-megatron-yarn-128k.yaml
```

# Changes

  - Rename sft-qwen3-0.6B-1n8g-megatron-yarn-64k recipe/test to 128k                                                                                                               
  - Update max_total_sequence_length: 65536 → 131072                                                                                                                               
  - Update YaRN rope_scaling.factor: 1.6 → 3.2 (128K / 40960)                                                                                                                      
  - Update docs/guides/yarn-long-context.md to reflect 128K                                                                                                                        
  - Update nightly.txt test entry

# Test
<img width="1600" height="1874" alt="image" src="https://github.com/user-attachments/assets/50453c3f-9134-4811-bab2-44cdec1d4d05" />

Ran three experiments on 1N8G (Qwen3-0.6B, Nemotron-Cascade-2-SFT-Math):
                                                                                                                                                                                 
| Run | Context Length | Steps | train/loss (final) | val_loss (final) |
|-----|---------------|-------|--------------------|------------------|                                                                                                          
| sft-qwen3-0.6B-1n8g-megatron-yarn-64k | 64K | 20 | ~0.88 | ~0.90 |   
| sft-qwen3-0.6B-1n8g-megatron-yarn-128k | 128K | 20 | ~0.85 | ~0.93 |                                                                                                           
| sft-qwen3-0.6B-1n8g-megatron-yarn-128k-150step | 128K | 150 | ~0.78 | ~0.82 |                                                                                                  
                                                                                                                                                                                 
**Observations:**                                                                                                                                                                
- The 128K recipe has a slightly higher initial val_loss (~1.25) compared to 64K (~1.18), which is expected since the longer context window increases task difficulty with YaRN scaling.                                                                                                                                                                         
- Over the first 20 steps, 64K and 128K train/loss curves track closely, confirming the 128K recipe trains correctly.                                                            
- The 128K 150-step run shows continued convergence with train/loss dropping to ~0.78 and val_loss to ~0.82, with no signs of divergence or instability.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

- N/A