### PR TITLE
refactor: update skills frontmatter

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "printf '{\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"MANDATORY WORKFLOW — never skip or reorder: (1) Read the artifact first (commit, file, error, PR). (2) Identify and invoke the relevant skill via the Skill tool BEFORE forming any answer or plan — even when the answer seems obvious. (3) Only then answer using the skill context. Skipping step 2 is not allowed.\"}}'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -19,8 +19,8 @@ jobs:
         Mandatory workflow — never skip or reorder:
         1. Read the PR diff first.
         2. Based on the changed files and areas, identify relevant skills from skills/<name>/SKILL.md.
-           Common skill names: linting-and-formatting, testing, contributing, copyright, docs,
-           error-handling, config-conventions, launch-nemo-rl, review-pr.
+           Common skill names: linting-and-formatting, testing, cicd, build-and-dependency,
+           contributing, copyright, docs, error-handling, config-conventions, launch-nemo-rl.
         3. Read the SKILL.md files for all relevant areas using the Read tool.
         4. Only then perform the review using the skill context.
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -16,9 +16,15 @@ jobs:
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@v0.79.0
     with:
       prompt: |
-        You are doing a light code review. Keep it concise and actionable.
+        Mandatory workflow — never skip or reorder:
+        1. Read the PR diff first.
+        2. Based on the changed files and areas, identify relevant skills from skills/<name>/SKILL.md.
+           Common skill names: linting-and-formatting, testing, contributing, copyright, docs,
+           error-handling, config-conventions, launch-nemo-rl, review-pr.
+        3. Read the SKILL.md files for all relevant areas using the Read tool.
+        4. Only then perform the review using the skill context.
 
-        Read and follow the review guidelines in CLAUDE.md and the coding guideline skills in .claude/skills/ at the repository root.
+        You are doing a light code review. Keep it concise and actionable.
 
         Focus ONLY on:
         - Critical bugs or logic errors

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,22 @@
 
 NeMo-RL is an RLHF training framework built on Ray and PyTorch (FSDP2 / Megatron-Core). It supports algorithms like GRPO, DPO, and SFT for LLMs and VLMs.
 
-## Coding Guidelines
+## Skills
 
-Coding guidelines are organized as Claude skills in `skills/`. Each skill covers a specific topic (style, config conventions, error handling, testing, copyright, docs).
+Coding guidelines and operational procedures are organized as Claude skills in
+`skills/`. **Always read the relevant `SKILL.md` before starting any task it
+covers — skills are mandatory context, not optional background reading.**
+
+**Workflow — mandatory order for every task:**
+1. **Pull information first.** Read the commit, PR, error log, file, or
+   whatever artifact the task is about. Do not reason about it yet.
+2. **Select and invoke the skill.** Based on what you just read, identify
+   the relevant skill and invoke it before forming any answer or plan.
+3. **Answer or implement.** Only after the skill is loaded, use its context
+   to reason, diagnose, or write code.
+
+Never skip or reorder these steps. Do not wait for the user to name the right
+skill keyword — infer it from the artifact you read.
 
 ## Code Review
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -119,6 +119,12 @@ linkcheck_ignore = [
     ".*githubusercontent\\.com.*",
 ]
 
+# PyTorch docs anchor IDs change between stable versions; verify the page
+# loads but skip anchor validation to avoid spurious failures on redirects.
+linkcheck_anchors_ignore_for_url = [
+    "https://docs.pytorch.org/.*",
+]
+
 
 def _convert_gh_admonitions_inplace(contents: list[str]) -> None:
     """Mutate contents to convert GitHub blockquote admonitions to MyST.

--- a/skills/build-and-dependency/SKILL.md
+++ b/skills/build-and-dependency/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: build-and-dependency
+description: Build and dependency management for NeMo-RL. Covers Docker image building and running, uv usage, venv setup, and adding dependencies.
+when_to_use: Setting up a dev environment; building or running the Docker container; adding or removing a dependency; uv errors; 'how do I install', 'ModuleNotFoundError', 'build the image', 'run in Docker', 'uv sync fails'.
+---
+
+# Build and Dependency Guide
+
+---
+
+## Docker Images
+
+Build the release image (includes all dependencies and pre-fetched venvs):
+
+```bash
+# Build from local source
+docker buildx build -f docker/Dockerfile --tag nemo-rl:latest .
+
+# Build from a specific git ref (no local clone needed)
+docker buildx build -f docker/Dockerfile \
+    --build-arg NRL_GIT_REF=main \
+    --tag nemo-rl:latest \
+    https://github.com/NVIDIA-NeMo/RL.git
+```
+
+Skip optional backends to reduce build time:
+
+```bash
+# Skip vLLM and SGLang
+docker buildx build -f docker/Dockerfile \
+    --build-arg SKIP_VLLM_BUILD=1 \
+    --build-arg SKIP_SGLANG_BUILD=1 \
+    --tag nemo-rl:latest .
+```
+
+See @docs/docker.md for full options.
+
+---
+
+## Always Use uv
+
+**Never use `pip install` directly** — always go through `uv`.
+
+```bash
+# Run a script
+uv run examples/run_grpo.py
+
+# Run tests
+uv run --group test bash tests/run_unit.sh
+
+# Install all deps from lockfile
+uv sync --locked
+```
+
+Exception: `Dockerfile.ngc_pytorch` is exempt from this rule.
+
+---
+
+## Adding Dependencies
+
+```bash
+# Add a runtime dependency
+uv add <package>
+
+# Add an optional dependency
+uv add --optional --extra <group> <package>
+
+# Regenerate the lockfile after changes
+uv lock
+```
+
+Commit both `pyproject.toml` and `uv.lock` together:
+
+```bash
+git add pyproject.toml uv.lock
+git commit -s -m "build: add <package> dependency"
+```
+
+---
+
+## Common Pitfalls
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| `uv sync --locked` fails | Dependency conflict or stale lockfile | Re-run `uv lock` and commit updated lock |
+| `ModuleNotFoundError` after pip install | pip installed outside uv-managed venv | Use `uv add` + `uv sync`, never bare `pip install` |
+| Docker build fails at vLLM | vLLM build time overhead | Pass `--build-arg SKIP_VLLM_BUILD=1` |

--- a/skills/cicd/SKILL.md
+++ b/skills/cicd/SKILL.md
@@ -36,6 +36,35 @@ Use `git rev-parse HEAD` (not the short form) to get the full SHA.
 
 ---
 
+## CI Labels
+
+Every PR **must** have exactly one `CI:*` label — the quality-check job stays
+red until one is attached. Labels control which test tier runs and whether a
+new container image is built.
+
+| Label | What runs | Container |
+|-------|-----------|-----------|
+| `CI:docs` | Doc tests only | Reuses main container |
+| `CI:Lfast` | Fast test subset | Reuses main container |
+| `CI:L0` | Unit tests + docs + lint | Builds new image |
+| `CI:L1` | L0 + functional tests | Builds new image |
+| `CI:L2` | L1 + convergence tests | Builds new image |
+| `Skip CICD` | Nothing (skips all tests) | — |
+
+**Default on merge group / push to main**: L1.
+
+**Which label to attach when opening a PR:**
+
+| Changed paths / nature of change | Label |
+|----------------------------------|-------|
+| Docs only (`docs/`, `*.md`, docstrings) | `CI:docs` |
+| Trivial fix, no logic change | `CI:Lfast` |
+| New code, bug fix, refactor | `CI:L0` |
+| Changes that could affect model behaviour | `CI:L1` |
+| Changes that could affect convergence | `CI:L2` |
+
+---
+
 ## CI Failure Investigation
 
 ```bash

--- a/skills/cicd/SKILL.md
+++ b/skills/cicd/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: cicd
+description: CI/CD reference for NeMo-RL. Covers GitHub Actions pipeline structure, CI triggering via /ok to test, and CI failure investigation.
+when_to_use: Investigating a CI failure; understanding the pipeline structure; triggering CI; 'CI is red', 'how do I trigger CI', '/ok to test', 'PR workflow', 'where are the logs', 'CI did not run', 'copy-pr-bot'.
+---
+
+# CI/CD Guide
+
+---
+
+## How CI Works
+
+NeMo-RL CI runs on GitHub Actions. Workflows live in `.github/workflows/`.
+
+The main test workflow triggers on pushes to `pull-request/<number>` branches.
+These branches are created automatically by **copy-pr-bot** when a contributor
+pushes to their fork and the PR receives a trust signal:
+- The commit is GPG-signed by a maintainer, **or**
+- A maintainer posts `/ok to test <full-sha>` as a PR comment.
+
+---
+
+## Triggering CI
+
+After pushing a new commit to your PR, trigger CI with:
+
+```
+/ok to test <full-commit-sha>
+```
+
+Use `git rev-parse HEAD` (not the short form) to get the full SHA.
+
+> **Re-triggering after new commits**: each `/ok to test <sha>` is specific to
+> that SHA. After pushing additional commits, post a new comment with the
+> updated SHA.
+
+---
+
+## CI Failure Investigation
+
+```bash
+# List recent workflow runs for the PR
+gh run list --repo NVIDIA-NeMo/RL --branch "pull-request/<pr-number>"
+
+# View failing run summary
+gh run view <run-id> --repo NVIDIA-NeMo/RL
+
+# Stream failing job output
+gh run view <run-id> --repo NVIDIA-NeMo/RL --log-failed
+```
+
+Common failure patterns:
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| CI never starts | No trust signal or copy-pr-bot not triggered | Post `/ok to test <sha>` |
+| `semantic-pull-request` fails | PR title doesn't follow Conventional Commits | Fix PR title; see `contributing` skill |
+| Linting fails | Style violation | Run `uv run ruff check --fix . && uv run ruff format .` |
+| Unit test failure | Code regression or missing dependency | Reproduce locally; see `testing` skill |

--- a/skills/config-conventions/SKILL.md
+++ b/skills/config-conventions/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: config-conventions
-description: Configuration conventions for NeMo-RL. YAML is the single source of truth for defaults. Covers TypedDict usage, exemplar YAML updates, and forbidden default patterns. Auto-invoked during code review.
+description: Configuration conventions for NeMo-RL. YAML is the single source of truth for defaults. Covers TypedDict usage, exemplar YAML updates, and forbidden default patterns.
+when_to_use: Adding or modifying config fields; reviewing config changes; 'where do I set defaults', 'TypedDict pattern', 'exemplar YAML', 'forbidden default patterns', during code review of config files.
 ---
 
 # Configuration Conventions

--- a/skills/contributing/SKILL.md
+++ b/skills/contributing/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: contributing
-description: Contribution conventions for NeMo-RL. Covers PR title format, commit sign-off, and CI triggering. Auto-invoked during code review.
+description: Contribution conventions for NeMo-RL. Covers PR title format, commit sign-off, and CI triggering.
+when_to_use: Opening a PR; writing a commit message; triggering CI; 'PR title format', 'sign-off', 'conventional commits', 'how do I trigger CI', during code review of PR process.
 ---
 
 # Contributing Conventions

--- a/skills/copyright/SKILL.md
+++ b/skills/copyright/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: copyright
-description: NVIDIA copyright header requirements for NeMo-RL. Covers which files need headers and the exact header text. Auto-invoked during code review.
+description: NVIDIA copyright header requirements for NeMo-RL. Covers which files need headers and the exact header text.
+when_to_use: Adding a new file; checking copyright headers; 'missing copyright', 'NVIDIA header', 'license header', 'is a header required here', during code review.
 ---
 
 # NVIDIA Copyright Header

--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: docs
-description: Documentation conventions for NeMo-RL. Covers docs/index.md updates and docstring format. Auto-invoked during code review.
+description: Documentation conventions for NeMo-RL. Covers docs/index.md updates and docstring format.
+when_to_use: Adding or updating documentation; adding a new markdown file; reviewing docstrings; 'docs/index.md', 'docstring format', 'Sphinx', 'where do I add docs', during code review.
 ---
 
 # Documentation Conventions

--- a/skills/error-handling/SKILL.md
+++ b/skills/error-handling/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: error-handling
-description: Error handling guidelines for NeMo-RL. Covers exception specificity, minimal try bodies, and else blocks. Auto-invoked during code review.
+description: Error handling guidelines for NeMo-RL. Covers exception specificity, minimal try bodies, and else blocks.
+when_to_use: Writing or reviewing exception handling; 'try-except', 'catch all exceptions', 'bare except', 'how to handle errors', during code review.
 ---
 
 # Error Handling

--- a/skills/launch-nemo-rl/SKILL.md
+++ b/skills/launch-nemo-rl/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: launch-nemo-rl
-description: Playbook for launching, monitoring, stopping, and debugging NeMo-RL recipes on a Kubernetes cluster via the nrl-k8s CLI. Use when asked to run/launch/submit/test a recipe on k8s, bring up or tear down a RayCluster, choose between ephemeral (default `nrl-k8s run`, auto-teardown) and long-lived (`nrl-k8s run --raycluster`) modes, iterate on an existing run, debug a hung or failed training job, or structure a new recipe+infra pair for a new hardware profile.
+description: Playbook for launching, monitoring, stopping, and debugging NeMo-RL recipes on a Kubernetes cluster via the nrl-k8s CLI. Covers ephemeral vs long-lived RayCluster modes, iterating on runs, and debugging hung or failed training jobs.
 when_to_use: "run this recipe on k8s", "launch on the cluster", "submit a training job", "tear down the cluster", "resubmit as rayjob", "why is the run stuck", "how do I get logs for job X", "bring the cluster back up".
 allowed-tools: Bash Read Grep Glob Edit Write
 ---

--- a/skills/linting-and-formatting/SKILL.md
+++ b/skills/linting-and-formatting/SKILL.md
@@ -1,6 +1,7 @@
 ---
-name: code-style
-description: Code style guidelines for NeMo-RL (Python and shell). Covers naming, indentation, comments, docstrings, reflection avoidance, and uv usage. Auto-invoked during code review.
+name: linting-and-formatting
+description: Code style guidelines for NeMo-RL (Python and shell). Covers naming, indentation, comments, docstrings, reflection avoidance, and uv usage.
+when_to_use: Reviewing code style; writing or checking Python or shell code; 'is this naming right', 'docstring format', 'style violation', 'how should I format this', during code review.
 ---
 
 # Code Style

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: review-pr
 description: Interactive code review for NVIDIA-NeMo/RL pull requests. Checks out PR locally, reads existing comments, applies coding guidelines from skills, previews findings, and posts review comments. Also supports reviewing the current branch locally.
+when_to_use: Reviewing a PR; '/review-pr <number>'; 'review this PR', 'check PR', 'code review for PR'.
 argument-hint: [<pr-number>] [update] [--deep]
 allowed-tools: [AskUserQuestion, Bash, Read, Glob, Grep, Agent, mcp__github__pull_request_read, mcp__github__pull_request_review_write, mcp__github__add_comment_to_pending_review, mcp__github__add_reply_to_pull_request_comment, mcp__github__add_issue_comment]
 ---

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: testing
-description: Testing conventions for NeMo-RL. Covers Ray actor coverage pragmas, nightly test requirements, and recipe naming rules. Auto-invoked during code review.
+description: Testing conventions for NeMo-RL. Covers Ray actor coverage pragmas, nightly test requirements, and recipe naming rules.
+when_to_use: Writing or reviewing tests; adding a nightly test; naming a recipe; 'coverage pragma', 'Ray actor test', 'nightly test requirement', 'how to name recipes', during code review of test files.
 ---
 
 # Testing Conventions


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Ports the learnings from [NVIDIA-NeMo/Megatron-Bridge#3621](https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/3621) to NeMo-RL.

## Changes

**Rename `skills/code-style/` → `skills/linting-and-formatting/`** — aligns with the Megatron-Bridge naming; updates `name:` frontmatter field accordingly.

**Add `when_to_use` field to all skill frontmatters** — strips "Auto-invoked during code review" and "Use when..." from `description:` fields; moves intent into `when_to_use:` trigger phrases per the Anthropic skill spec.

**Add mandatory 3-step skill workflow to AGENTS.md** — makes skill invocation structural: read artifact → invoke skill → answer.

**Add `.claude/settings.json` with UserPromptSubmit hook** — enforces the mandatory read→skill→answer workflow on every prompt.

**Add mandatory skill-loading instruction to `claude-review.yml`** — instructs Claude to read relevant SKILL.md files before performing a code review.

**Add `skills/cicd/`** — CI pipeline structure, copy-pr-bot, `/ok to test` triggering, failure investigation patterns.

**Add `skills/build-and-dependency/`** — Docker image building, uv usage, adding dependencies, common pitfalls.

</details>
