### PR TITLE
test: cover converter CLI entry points

### DIFF
--- a/tests/functional/test_converter_roundtrip.py
+++ b/tests/functional/test_converter_roundtrip.py
@@ -28,9 +28,11 @@ import copy
 import gc
 import importlib.util
 import os
+import sys
 import tempfile
 import time
 from typing import Any, Dict
+from unittest import mock
 
 import torch
 import yaml
@@ -45,16 +47,40 @@ from nemo_rl.models.megatron.community_import import (
 from nemo_rl.models.policy.lm_policy import Policy
 from nemo_rl.utils.native_checkpoint import convert_dcp_to_hf
 
-_CONVERTER_PATH = os.path.normpath(
-    os.path.join(
-        os.path.dirname(__file__), "../../examples/converters/convert_lora_to_hf.py"
+
+def _load_converter_script(filename: str):
+    """Load a converter script under ``examples/converters/`` as a module.
+
+    The converter scripts are not part of the ``nemo_rl`` package, so we
+    pull them in by file path. Each call returns a fresh module so tests
+    that patch ``sys.argv`` cannot leak state into one another.
+    """
+    path = os.path.normpath(
+        os.path.join(os.path.dirname(__file__), "../../examples/converters", filename)
     )
-)
-_spec = importlib.util.spec_from_file_location("convert_lora_to_hf", _CONVERTER_PATH)
-_convert_lora_mod = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(_convert_lora_mod)
+    spec = importlib.util.spec_from_file_location(
+        f"_converter_{filename.replace('.', '_')}", path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_convert_lora_mod = _load_converter_script("convert_lora_to_hf.py")
 merge_lora_to_hf = _convert_lora_mod.merge_lora_to_hf
 export_lora_adapter_to_hf = _convert_lora_mod.export_lora_adapter_to_hf
+
+
+def _run_script_main(module, argv: list) -> None:
+    """Invoke ``module.main()`` with a patched ``sys.argv``.
+
+    Importing argparse-driven scripts and calling their ``main()``
+    in-process keeps the test in a single Ray/CUDA context and exercises
+    the exact ``parse_args() + main()`` code paths a user would hit on
+    the command line.
+    """
+    with mock.patch.object(sys, "argv", argv):
+        module.main()
 
 
 def create_test_config() -> Dict[str, Any]:
@@ -726,9 +752,165 @@ def main():
             "✓ Dtensor V1 and Dtensor V2 DCP, Megatron, and LoRA merged models can perform forward passes"
         )
 
+        # ------------------------------------------------------------------
+        # STEP 10: Exercise the converter scripts' CLI entry points end-to-end
+        #
+        # The steps above only call the underlying *library* functions
+        # (convert_dcp_to_hf, export_model_from_megatron, merge_lora_to_hf).
+        # The argparse + main() shells of the converter scripts are what
+        # users actually invoke from the command line; without exercising
+        # them in CI, regressions (for example a missing flag or a broken
+        # config-vs-CLI override) ship silently. We invoke each script's
+        # main() in-process via sys.argv patching so the parse_args + main
+        # code paths are covered against real model artifacts produced
+        # earlier in this test.
+        # ------------------------------------------------------------------
+        print("\n" + "=" * 60)
+        print("STEP 10: Exercising converter CLI entry points (parse_args + main)")
+        print("=" * 60)
+
+        cli_config_path = os.path.join(temp_dir, "cli_config.yaml")
+        with open(cli_config_path, "w") as f:
+            yaml.safe_dump(
+                {
+                    "policy": {
+                        "model_name": model_name,
+                        "tokenizer": {"name": model_name},
+                    }
+                },
+                f,
+            )
+
+        # 10a) convert_dcp_to_hf.py CLI on the v1 DCP checkpoint.
+        # Save a tokenizer next to the DCP ckpt so the script also
+        # exercises the local-tokenizer-path branch (the common path
+        # users hit after a real training run).
+        cli_tokenizer_dir = os.path.join(temp_dir, "tokenizer")
+        original_tokenizer.save_pretrained(cli_tokenizer_dir)
+
+        cli_dcp_to_hf_path = os.path.join(temp_dir, "cli_dcp_to_hf_v1")
+        dcp_to_hf_module = _load_converter_script("convert_dcp_to_hf.py")
+        _run_script_main(
+            dcp_to_hf_module,
+            [
+                "convert_dcp_to_hf.py",
+                "--config",
+                cli_config_path,
+                "--dcp-ckpt-path",
+                dcp_checkpoint_path_v1,
+                "--hf-ckpt-path",
+                cli_dcp_to_hf_path,
+            ],
+        )
+        cli_dcp_model = AutoModelForCausalLM.from_pretrained(
+            cli_dcp_to_hf_path, torch_dtype=torch.bfloat16, trust_remote_code=True
+        )
+        assert_state_dicts_equal(
+            get_model_state_dict(cli_dcp_model),
+            original_state_dict,
+            "convert_dcp_to_hf.py CLI output",
+            "Original HF model",
+        )
+        del cli_dcp_model
+        gc.collect()
+        print("✓ convert_dcp_to_hf.py CLI matches the original model")
+
+        # 10b) convert_megatron_to_hf.py CLI on the Megatron checkpoint.
+        cli_megatron_to_hf_path = os.path.join(temp_dir, "cli_megatron_to_hf")
+        megatron_to_hf_module = _load_converter_script("convert_megatron_to_hf.py")
+        _run_script_main(
+            megatron_to_hf_module,
+            [
+                "convert_megatron_to_hf.py",
+                "--config",
+                cli_config_path,
+                "--hf-model-name",
+                model_name,
+                "--megatron-ckpt-path",
+                megatron_checkpoint_path,
+                "--hf-ckpt-path",
+                cli_megatron_to_hf_path,
+            ],
+        )
+        cli_megatron_model = AutoModelForCausalLM.from_pretrained(
+            cli_megatron_to_hf_path,
+            torch_dtype=torch.bfloat16,
+            trust_remote_code=True,
+        )
+        assert_state_dicts_equal(
+            get_model_state_dict(cli_megatron_model),
+            original_state_dict,
+            "convert_megatron_to_hf.py CLI output",
+            "Original HF model",
+        )
+        del cli_megatron_model
+        gc.collect()
+        print("✓ convert_megatron_to_hf.py CLI matches the original model")
+
+        # 10c) convert_lora_to_hf.py CLI — merged-model branch (no --adapter-only).
+        cli_lora_merged_path = os.path.join(temp_dir, "cli_lora_merged")
+        _run_script_main(
+            _convert_lora_mod,
+            [
+                "convert_lora_to_hf.py",
+                "--base-ckpt",
+                megatron_checkpoint_path,
+                "--adapter-ckpt",
+                lora_adapter_path,
+                "--hf-model-name",
+                model_name,
+                "--hf-ckpt-path",
+                cli_lora_merged_path,
+            ],
+        )
+        cli_lora_merged_model = AutoModelForCausalLM.from_pretrained(
+            cli_lora_merged_path, torch_dtype=torch.bfloat16, trust_remote_code=True
+        )
+        assert_state_dicts_equal(
+            get_model_state_dict(cli_lora_merged_model),
+            lora_merged_state_dict,
+            "convert_lora_to_hf.py CLI (merged) output",
+            "Step 7c lora merged",
+        )
+        del cli_lora_merged_model
+        gc.collect()
+        print("✓ convert_lora_to_hf.py CLI (merged branch) matches Step 7c output")
+
+        # 10d) convert_lora_to_hf.py CLI — adapter-only branch (--adapter-only).
+        cli_lora_adapter_path = os.path.join(temp_dir, "cli_lora_adapter")
+        _run_script_main(
+            _convert_lora_mod,
+            [
+                "convert_lora_to_hf.py",
+                "--base-ckpt",
+                megatron_checkpoint_path,
+                "--adapter-ckpt",
+                lora_adapter_path,
+                "--hf-model-name",
+                model_name,
+                "--hf-ckpt-path",
+                cli_lora_adapter_path,
+                "--adapter-only",
+            ],
+        )
+        adapter_cfg = os.path.join(cli_lora_adapter_path, "adapter_config.json")
+        assert os.path.exists(adapter_cfg), (
+            f"convert_lora_to_hf.py --adapter-only did not produce {adapter_cfg}"
+        )
+        cli_adapter_weight_found = any(
+            os.path.exists(os.path.join(cli_lora_adapter_path, f))
+            for f in ("adapter_model.safetensors", "adapter_model.bin")
+        )
+        assert cli_adapter_weight_found, (
+            "convert_lora_to_hf.py --adapter-only did not produce a weight file"
+        )
+        print(
+            "✓ convert_lora_to_hf.py CLI (adapter-only branch) produced expected PEFT layout"
+        )
+
         print("\n" + "=" * 80)
         print(
-            "✓ ALL TESTS PASSED (DCP v1, DCP v2, Megatron, LoRA merge, LoRA adapter-only PEFT)!"
+            "✓ ALL TESTS PASSED (DCP v1, DCP v2, Megatron, LoRA merge, LoRA adapter-only PEFT, CLI entry points)!"
         )
         print("=" * 80)
 

--- a/tests/unit/converters/test_convert_dcp_to_hf_args.py
+++ b/tests/unit/converters/test_convert_dcp_to_hf_args.py
@@ -1,0 +1,270 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the ``examples/converters/convert_dcp_to_hf.py`` CLI surface.
+
+These tests exercise ``parse_args()`` and ``main()``'s argument-handling
+logic. The underlying ``convert_dcp_to_hf`` library function is patched
+out, so the tests stay fast (no model loading, no Ray, no GPU). The
+real end-to-end conversion is covered by
+``tests/functional/test_converter_roundtrip.py``.
+"""
+
+import importlib.util
+import os
+import sys
+from types import ModuleType
+from unittest import mock
+
+import pytest
+
+_CONVERTER_PATH = os.path.normpath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "..",
+        "examples",
+        "converters",
+        "convert_dcp_to_hf.py",
+    )
+)
+
+
+def _load_module() -> ModuleType:
+    """Load ``convert_dcp_to_hf.py`` as a module via ``importlib``.
+
+    The converter scripts live under ``examples/`` and are not packaged,
+    so we load them by file path. Each test gets a freshly imported
+    module to avoid leaking ``sys.argv`` patches across tests.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "convert_dcp_to_hf_under_test", _CONVERTER_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def converter_module() -> ModuleType:
+    return _load_module()
+
+
+def test_parse_args_all_flags(converter_module: ModuleType) -> None:
+    """All long-form flags populate the expected fields."""
+    argv = [
+        "convert_dcp_to_hf.py",
+        "--config",
+        "/tmp/cfg.yaml",
+        "--dcp-ckpt-path",
+        "/tmp/dcp",
+        "--hf-ckpt-path",
+        "/tmp/hf",
+    ]
+    with mock.patch.object(sys, "argv", argv):
+        args = converter_module.parse_args()
+
+    assert args.config == "/tmp/cfg.yaml"
+    assert args.dcp_ckpt_path == "/tmp/dcp"
+    assert args.hf_ckpt_path == "/tmp/hf"
+
+
+def test_parse_args_defaults_are_none(converter_module: ModuleType) -> None:
+    """Unset flags must default to ``None`` so ``main()`` can fail loudly
+    instead of silently using an unintended path."""
+    with mock.patch.object(sys, "argv", ["convert_dcp_to_hf.py"]):
+        args = converter_module.parse_args()
+
+    assert args.config is None
+    assert args.dcp_ckpt_path is None
+    assert args.hf_ckpt_path is None
+
+
+def test_parse_args_unknown_flag_exits(converter_module: ModuleType) -> None:
+    """Unknown flags must trigger an argparse SystemExit (exit code 2)."""
+    argv = ["convert_dcp_to_hf.py", "--definitely-not-a-flag", "x"]
+    with mock.patch.object(sys, "argv", argv):
+        with pytest.raises(SystemExit) as excinfo:
+            converter_module.parse_args()
+    assert excinfo.value.code == 2
+
+
+def test_main_propagates_missing_config(converter_module: ModuleType, tmp_path) -> None:
+    """``main()`` should fail with FileNotFoundError when --config points
+    to a non-existent path, rather than silently swallowing the error."""
+    missing = tmp_path / "does_not_exist.yaml"
+    argv = [
+        "convert_dcp_to_hf.py",
+        "--config",
+        str(missing),
+        "--dcp-ckpt-path",
+        str(tmp_path / "dcp"),
+        "--hf-ckpt-path",
+        str(tmp_path / "hf"),
+    ]
+    with mock.patch.object(sys, "argv", argv):
+        with pytest.raises(FileNotFoundError):
+            converter_module.main()
+
+
+def _write_minimal_config(path, *, hf_overrides=None) -> None:
+    """Write a minimal config.yaml accepted by ``convert_dcp_to_hf.main()``."""
+    cfg = {
+        "policy": {
+            "model_name": "dummy/Model",
+            "tokenizer": {"name": "dummy/Tokenizer"},
+        }
+    }
+    if hf_overrides is not None:
+        cfg["policy"]["hf_overrides"] = hf_overrides
+    import yaml  # local import to keep top-level imports minimal
+
+    path.write_text(yaml.safe_dump(cfg))
+
+
+def test_main_uses_local_tokenizer_when_directory_present(
+    converter_module: ModuleType, tmp_path
+) -> None:
+    """When ``<dcp_ckpt_path>/../tokenizer`` exists, ``main()`` must pass
+    that path (not the config tokenizer name) to ``convert_dcp_to_hf``.
+
+    This is the branch users hit after a real training run, where the
+    train loop saves the tokenizer next to the DCP weights.
+    """
+    cfg_path = tmp_path / "cfg.yaml"
+    _write_minimal_config(cfg_path)
+
+    dcp_dir = tmp_path / "weights"
+    dcp_dir.mkdir()
+    tokenizer_dir = tmp_path / "tokenizer"
+    tokenizer_dir.mkdir()
+
+    argv = [
+        "convert_dcp_to_hf.py",
+        "--config",
+        str(cfg_path),
+        "--dcp-ckpt-path",
+        str(dcp_dir),
+        "--hf-ckpt-path",
+        str(tmp_path / "hf"),
+    ]
+    with (
+        mock.patch.object(sys, "argv", argv),
+        mock.patch.object(converter_module, "convert_dcp_to_hf") as mock_convert,
+    ):
+        converter_module.main()
+
+    mock_convert.assert_called_once()
+    kwargs = mock_convert.call_args.kwargs
+    assert kwargs["dcp_ckpt_path"] == str(dcp_dir)
+    assert kwargs["hf_ckpt_path"] == str(tmp_path / "hf")
+    assert kwargs["model_name_or_path"] == "dummy/Model"
+    # Local tokenizer dir takes precedence over the config tokenizer name.
+    assert os.path.samefile(kwargs["tokenizer_name_or_path"], tokenizer_dir)
+
+
+def test_main_falls_back_to_config_tokenizer_without_local_dir(
+    converter_module: ModuleType, tmp_path
+) -> None:
+    """When no local tokenizer dir exists alongside the DCP ckpt, the
+    fallback must use the tokenizer name from the config file."""
+    cfg_path = tmp_path / "cfg.yaml"
+    _write_minimal_config(cfg_path)
+
+    dcp_dir = tmp_path / "weights"
+    dcp_dir.mkdir()
+    # NOTE: deliberately do NOT create tmp_path/tokenizer
+
+    argv = [
+        "convert_dcp_to_hf.py",
+        "--config",
+        str(cfg_path),
+        "--dcp-ckpt-path",
+        str(dcp_dir),
+        "--hf-ckpt-path",
+        str(tmp_path / "hf"),
+    ]
+    with (
+        mock.patch.object(sys, "argv", argv),
+        mock.patch.object(converter_module, "convert_dcp_to_hf") as mock_convert,
+    ):
+        converter_module.main()
+
+    kwargs = mock_convert.call_args.kwargs
+    assert kwargs["tokenizer_name_or_path"] == "dummy/Tokenizer"
+
+
+def test_main_passes_hf_overrides_when_present(
+    converter_module: ModuleType, tmp_path
+) -> None:
+    """``hf_overrides`` from the config must be forwarded verbatim."""
+    cfg_path = tmp_path / "cfg.yaml"
+    _write_minimal_config(cfg_path, hf_overrides={"some_key": "some_value"})
+
+    dcp_dir = tmp_path / "weights"
+    dcp_dir.mkdir()
+
+    argv = [
+        "convert_dcp_to_hf.py",
+        "--config",
+        str(cfg_path),
+        "--dcp-ckpt-path",
+        str(dcp_dir),
+        "--hf-ckpt-path",
+        str(tmp_path / "hf"),
+    ]
+    with (
+        mock.patch.object(sys, "argv", argv),
+        mock.patch.object(converter_module, "convert_dcp_to_hf") as mock_convert,
+    ):
+        converter_module.main()
+
+    kwargs = mock_convert.call_args.kwargs
+    assert kwargs["hf_overrides"] == {"some_key": "some_value"}
+
+
+def test_main_collapses_null_hf_overrides_to_empty_dict(
+    converter_module: ModuleType, tmp_path
+) -> None:
+    """A YAML ``hf_overrides: null`` (often emitted by humans) must be
+    treated as ``{}`` rather than passed through as ``None``."""
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(
+        "policy:\n"
+        "  model_name: dummy/Model\n"
+        "  tokenizer:\n"
+        "    name: dummy/Tokenizer\n"
+        "  hf_overrides: null\n"
+    )
+
+    dcp_dir = tmp_path / "weights"
+    dcp_dir.mkdir()
+
+    argv = [
+        "convert_dcp_to_hf.py",
+        "--config",
+        str(cfg_path),
+        "--dcp-ckpt-path",
+        str(dcp_dir),
+        "--hf-ckpt-path",
+        str(tmp_path / "hf"),
+    ]
+    with (
+        mock.patch.object(sys, "argv", argv),
+        mock.patch.object(converter_module, "convert_dcp_to_hf") as mock_convert,
+    ):
+        converter_module.main()
+
+    kwargs = mock_convert.call_args.kwargs
+    assert kwargs["hf_overrides"] == {}

--- a/tests/unit/converters/test_convert_lora_to_hf_args.py
+++ b/tests/unit/converters/test_convert_lora_to_hf_args.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the ``examples/converters/convert_lora_to_hf.py`` CLI surface.
+
+The script's top-level imports are stdlib + ``yaml``; the heavy
+``megatron.*`` imports are deferred inside ``_build_megatron_model_with_lora``.
+These tests therefore run without the mcore extra and validate the
+argparse contract plus ``main()`` dispatch logic.
+"""
+
+import importlib.util
+import os
+import sys
+from types import ModuleType
+from unittest import mock
+
+import pytest
+
+_CONVERTER_PATH = os.path.normpath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "..",
+        "examples",
+        "converters",
+        "convert_lora_to_hf.py",
+    )
+)
+
+_REQUIRED_ARGS = [
+    "--base-ckpt",
+    "/tmp/base",
+    "--adapter-ckpt",
+    "/tmp/adapter",
+    "--hf-model-name",
+    "zai-org/GLM-5",
+    "--hf-ckpt-path",
+    "/tmp/out",
+]
+
+
+def _load_module() -> ModuleType:
+    """Load ``convert_lora_to_hf.py`` as a module via ``importlib``."""
+    spec = importlib.util.spec_from_file_location(
+        "convert_lora_to_hf_under_test", _CONVERTER_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def converter_module() -> ModuleType:
+    return _load_module()
+
+
+def test_parse_args_required_args_present(converter_module: ModuleType) -> None:
+    argv = ["convert_lora_to_hf.py", *_REQUIRED_ARGS]
+    with mock.patch.object(sys, "argv", argv):
+        args = converter_module.parse_args()
+
+    assert args.base_ckpt == "/tmp/base"
+    assert args.adapter_ckpt == "/tmp/adapter"
+    assert args.hf_model_name == "zai-org/GLM-5"
+    assert args.hf_ckpt_path == "/tmp/out"
+    assert args.adapter_only is False
+
+
+def test_parse_args_adapter_only_toggle(converter_module: ModuleType) -> None:
+    """``--adapter-only`` flips the boolean to True."""
+    argv = ["convert_lora_to_hf.py", *_REQUIRED_ARGS, "--adapter-only"]
+    with mock.patch.object(sys, "argv", argv):
+        args = converter_module.parse_args()
+    assert args.adapter_only is True
+
+
+@pytest.mark.parametrize(
+    "missing_flag",
+    ["--base-ckpt", "--adapter-ckpt", "--hf-model-name", "--hf-ckpt-path"],
+)
+def test_parse_args_required_flag_missing_exits(
+    converter_module: ModuleType, missing_flag: str
+) -> None:
+    """Each ``required=True`` argparse flag must enforce its requirement."""
+    argv = ["convert_lora_to_hf.py"]
+    skip_next = False
+    for token in _REQUIRED_ARGS:
+        if skip_next:
+            skip_next = False
+            continue
+        if token == missing_flag:
+            skip_next = True  # also drop the value following the flag
+            continue
+        argv.append(token)
+    with mock.patch.object(sys, "argv", argv):
+        with pytest.raises(SystemExit) as excinfo:
+            converter_module.parse_args()
+    assert excinfo.value.code == 2
+
+
+def test_main_dispatches_to_merge_by_default(converter_module: ModuleType) -> None:
+    """Without ``--adapter-only`` ``main()`` calls ``merge_lora_to_hf``."""
+    argv = ["convert_lora_to_hf.py", *_REQUIRED_ARGS]
+    with (
+        mock.patch.object(sys, "argv", argv),
+        mock.patch.object(converter_module, "merge_lora_to_hf") as mock_merge,
+        mock.patch.object(converter_module, "export_lora_adapter_to_hf") as mock_export,
+    ):
+        converter_module.main()
+
+    mock_merge.assert_called_once_with(
+        base_ckpt="/tmp/base",
+        adapter_ckpt="/tmp/adapter",
+        hf_model_name="zai-org/GLM-5",
+        hf_ckpt_path="/tmp/out",
+    )
+    mock_export.assert_not_called()
+
+
+def test_main_dispatches_to_adapter_only_when_flag_set(
+    converter_module: ModuleType,
+) -> None:
+    """With ``--adapter-only`` ``main()`` calls ``export_lora_adapter_to_hf``."""
+    argv = ["convert_lora_to_hf.py", *_REQUIRED_ARGS, "--adapter-only"]
+    with (
+        mock.patch.object(sys, "argv", argv),
+        mock.patch.object(converter_module, "merge_lora_to_hf") as mock_merge,
+        mock.patch.object(converter_module, "export_lora_adapter_to_hf") as mock_export,
+    ):
+        converter_module.main()
+
+    mock_export.assert_called_once_with(
+        base_ckpt="/tmp/base",
+        adapter_ckpt="/tmp/adapter",
+        hf_model_name="zai-org/GLM-5",
+        hf_ckpt_path="/tmp/out",
+    )
+    mock_merge.assert_not_called()
+
+
+def test_merge_lora_to_hf_rejects_existing_output(
+    converter_module: ModuleType, tmp_path
+) -> None:
+    """Both export functions must refuse to overwrite an existing output dir."""
+    existing = tmp_path / "already_there"
+    existing.mkdir()
+    with pytest.raises(FileExistsError):
+        converter_module.merge_lora_to_hf(
+            base_ckpt=str(tmp_path / "base"),
+            adapter_ckpt=str(tmp_path / "adapter"),
+            hf_model_name="zai-org/GLM-5",
+            hf_ckpt_path=str(existing),
+        )
+
+
+def test_export_lora_adapter_to_hf_rejects_existing_output(
+    converter_module: ModuleType, tmp_path
+) -> None:
+    existing = tmp_path / "already_there"
+    existing.mkdir()
+    with pytest.raises(FileExistsError):
+        converter_module.export_lora_adapter_to_hf(
+            base_ckpt=str(tmp_path / "base"),
+            adapter_ckpt=str(tmp_path / "adapter"),
+            hf_model_name="zai-org/GLM-5",
+            hf_ckpt_path=str(existing),
+        )

--- a/tests/unit/converters/test_convert_megatron_to_hf_args.py
+++ b/tests/unit/converters/test_convert_megatron_to_hf_args.py
@@ -1,0 +1,207 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the ``examples/converters/convert_megatron_to_hf.py`` CLI surface.
+
+The script imports ``nemo_rl.models.megatron.community_import`` at module
+load time, which transitively imports ``megatron.bridge``. These tests
+are therefore marked ``mcore`` and only run when the mcore extra is
+installed (``--mcore-only``).
+"""
+
+import importlib.util
+import os
+import sys
+from types import ModuleType
+from unittest import mock
+
+import pytest
+
+pytestmark = pytest.mark.mcore
+
+_CONVERTER_PATH = os.path.normpath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "..",
+        "examples",
+        "converters",
+        "convert_megatron_to_hf.py",
+    )
+)
+
+
+def _load_module() -> ModuleType:
+    """Load ``convert_megatron_to_hf.py`` as a module via ``importlib``."""
+    spec = importlib.util.spec_from_file_location(
+        "convert_megatron_to_hf_under_test", _CONVERTER_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def converter_module() -> ModuleType:
+    return _load_module()
+
+
+def test_parse_args_all_flags(converter_module: ModuleType) -> None:
+    """All long-form flags populate the expected fields."""
+    argv = [
+        "convert_megatron_to_hf.py",
+        "--config",
+        "/tmp/cfg.yaml",
+        "--hf-model-name",
+        "Qwen/Qwen2-0.5B",
+        "--megatron-ckpt-path",
+        "/tmp/megatron",
+        "--hf-ckpt-path",
+        "/tmp/hf",
+    ]
+    with mock.patch.object(sys, "argv", argv):
+        args = converter_module.parse_args()
+
+    assert args.config == "/tmp/cfg.yaml"
+    assert args.hf_model_name == "Qwen/Qwen2-0.5B"
+    assert args.megatron_ckpt_path == "/tmp/megatron"
+    assert args.hf_ckpt_path == "/tmp/hf"
+    # --no-strict defaults to False (i.e. strict=True at the API call site).
+    assert args.no_strict is False
+
+
+def test_parse_args_no_strict_flag_is_a_boolean_toggle(
+    converter_module: ModuleType,
+) -> None:
+    """``--no-strict`` is a flag (no value); presence flips the bool."""
+    argv = [
+        "convert_megatron_to_hf.py",
+        "--config",
+        "/tmp/cfg.yaml",
+        "--megatron-ckpt-path",
+        "/tmp/megatron",
+        "--hf-ckpt-path",
+        "/tmp/hf",
+        "--no-strict",
+    ]
+    with mock.patch.object(sys, "argv", argv):
+        args = converter_module.parse_args()
+    assert args.no_strict is True
+
+
+def test_parse_args_defaults_are_none(converter_module: ModuleType) -> None:
+    """Unset flags default to ``None`` so misuse fails loudly downstream."""
+    with mock.patch.object(sys, "argv", ["convert_megatron_to_hf.py"]):
+        args = converter_module.parse_args()
+
+    assert args.config is None
+    assert args.hf_model_name is None
+    assert args.megatron_ckpt_path is None
+    assert args.hf_ckpt_path is None
+    assert args.no_strict is False
+
+
+def test_parse_args_unknown_flag_exits(converter_module: ModuleType) -> None:
+    """Unknown flags must trigger an argparse SystemExit (exit code 2)."""
+    argv = ["convert_megatron_to_hf.py", "--bogus-flag", "1"]
+    with mock.patch.object(sys, "argv", argv):
+        with pytest.raises(SystemExit) as excinfo:
+            converter_module.parse_args()
+    assert excinfo.value.code == 2
+
+
+def test_main_invokes_export_with_strict_flag(
+    converter_module: ModuleType, tmp_path
+) -> None:
+    """``main()`` should pass ``strict=not args.no_strict`` to the
+    underlying ``export_model_from_megatron`` call.
+
+    We patch the call site so this test stays fast and does not actually
+    materialize a Megatron model. This is the first place a regression
+    in the ``--no-strict`` wiring would show up.
+    """
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(
+        "policy:\n  model_name: dummy/Model\n  tokenizer:\n    name: dummy/Tokenizer\n"
+    )
+
+    argv = [
+        "convert_megatron_to_hf.py",
+        "--config",
+        str(cfg_path),
+        "--megatron-ckpt-path",
+        str(tmp_path / "megatron"),
+        "--hf-ckpt-path",
+        str(tmp_path / "hf"),
+        "--no-strict",
+    ]
+
+    # Patch on the script module — this is where the symbol is bound.
+    with (
+        mock.patch.object(sys, "argv", argv),
+        mock.patch.object(
+            converter_module, "export_model_from_megatron"
+        ) as mock_export,
+    ):
+        converter_module.main()
+
+    mock_export.assert_called_once()
+    kwargs = mock_export.call_args.kwargs
+    assert kwargs["hf_model_name"] == "dummy/Model"
+    assert kwargs["hf_tokenizer_path"] == "dummy/Tokenizer"
+    assert kwargs["input_path"] == str(tmp_path / "megatron")
+    assert kwargs["output_path"] == str(tmp_path / "hf")
+    assert kwargs["strict"] is False  # --no-strict was passed
+    # Empty/None ``hf_overrides`` in the config must collapse to an empty dict.
+    assert kwargs["hf_overrides"] == {}
+
+
+def test_main_uses_hf_model_name_override(
+    converter_module: ModuleType, tmp_path
+) -> None:
+    """When ``--hf-model-name`` is supplied it must override the value in
+    the config file."""
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(
+        "policy:\n"
+        "  model_name: from/Config\n"
+        "  tokenizer:\n"
+        "    name: from/ConfigTokenizer\n"
+    )
+
+    argv = [
+        "convert_megatron_to_hf.py",
+        "--config",
+        str(cfg_path),
+        "--hf-model-name",
+        "from/CLI",
+        "--megatron-ckpt-path",
+        str(tmp_path / "megatron"),
+        "--hf-ckpt-path",
+        str(tmp_path / "hf"),
+    ]
+
+    with (
+        mock.patch.object(sys, "argv", argv),
+        mock.patch.object(
+            converter_module, "export_model_from_megatron"
+        ) as mock_export,
+    ):
+        converter_module.main()
+
+    kwargs = mock_export.call_args.kwargs
+    assert kwargs["hf_model_name"] == "from/CLI"
+    # Tokenizer is never overridden — it always comes from config.
+    assert kwargs["hf_tokenizer_path"] == "from/ConfigTokenizer"
+    assert kwargs["strict"] is True  # --no-strict not passed


### PR DESCRIPTION
## Summary

Closes the test-coverage gap identified in #2259 — the CLI entry points
(`parse_args` + `main`) of the three converter scripts under
`examples/converters/` are now exercised by tests, both quickly via
unit tests and end-to-end against real model artifacts in the existing
functional roundtrip test.

The existing `tests/functional/test_converter_roundtrip.py` only called
the underlying *library* functions (`convert_dcp_to_hf`,
`export_model_from_megatron`, `merge_lora_to_hf`,
`export_lora_adapter_to_hf`). The argparse + `main()` shells of
`convert_dcp_to_hf.py`, `convert_megatron_to_hf.py`, and
`convert_lora_to_hf.py` were never invoked, so regressions in their CLI
contracts (missing flags, broken config-vs-CLI overrides, wrong dispatch
on `--adapter-only`, etc.) shipped silently.

## What's covered

### New fast unit tests under `tests/unit/converters/`

These run without GPU, Ray, or model downloads. The underlying library
calls are mocked out so the tests stay in the L0 budget.

- `test_convert_dcp_to_hf_args.py` — flags, defaults, unknown-flag
  exit code, plus `main()`'s local-tokenizer-vs-config-fallback branch
  selection and `hf_overrides` forwarding (including the YAML
  `null → {}` collapse).
- `test_convert_megatron_to_hf_args.py` (marked `mcore`) — flags,
  defaults, the `--no-strict` toggle wiring through to the `strict=`
  kwarg, and the `--hf-model-name` override path.
- `test_convert_lora_to_hf_args.py` — required-flag enforcement
  (parametrized over each), `--adapter-only` dispatch in both
  branches, and the refuse-to-overwrite contract on existing output
  paths.

### Extended functional test (`tests/functional/test_converter_roundtrip.py`)

Added a **STEP 10** that invokes each script's `main()` in-process via
`sys.argv` patching, against the same model artifacts produced earlier
in the test, and compares the resulting HF checkpoints against the
previously validated state dicts:

- 10a) `convert_dcp_to_hf.py` CLI on the v1 DCP checkpoint (also
  exercises the local-tokenizer-path branch by saving the tokenizer
  next to the DCP ckpt).
- 10b) `convert_megatron_to_hf.py` CLI on the Megatron checkpoint.
- 10c) `convert_lora_to_hf.py` CLI — merged-model branch (no
  `--adapter-only`).
- 10d) `convert_lora_to_hf.py` CLI — adapter-only branch
  (`--adapter-only`), verified by checking the resulting PEFT
  directory layout.

## Test plan

- [x] `ruff check tests/unit/converters/ tests/functional/test_converter_roundtrip.py` — clean
- [x] `ruff format` — applied
- [x] `python3 -m py_compile` — clean
- [ ] L0_Unit_Tests_Other (CI) — runs the new `tests/unit/converters/` suite
- [ ] L0_Unit_Tests with `--mcore-only` (CI) — runs
      `test_convert_megatron_to_hf_args.py`
- [ ] `tests/functional/test_converters.sh` (CI) — runs the extended
      roundtrip including STEP 10

## Notes

- All three new unit-test files have the NVIDIA copyright header per
  repo convention.
- Each `main()`-exercising unit test uses a fresh `importlib`-loaded
  module copy so `sys.argv` patches cannot leak across tests.
- The functional test's new helper `_run_script_main` invokes `main()`
  in-process to keep STEP 10 inside the same Ray/CUDA context as the
  rest of the test.

Refs: #2259