### PR TITLE
feat(megatron): expose hardcoded infrastructure params to user config

### DIFF
--- a/examples/configs/grpo_math_1B_megatron.yaml
+++ b/examples/configs/grpo_math_1B_megatron.yaml
@@ -82,6 +82,12 @@ policy:
     empty_unused_memory_level: 1  # 1 is the minimum recommendation for RL since we almost always need to offload before beginning generation. Setting to 0 is faster, but you are more likely to run out of GPU memory.
     activation_checkpointing: false
     converter_type: "Qwen2ForCausalLM"
+    # Optional infrastructure knobs (issue #2229). When unset, the historical
+    # hard-coded defaults are used.
+    # distributed_timeout_minutes: 120  # Increase NCCL init timeout for very large checkpoint conversions
+    # async_save: false                 # Set true to write checkpoints asynchronously
+    # check_for_nan_in_grad: true       # Set false to skip the per-step NaN/Inf grad check in steady-state training
+    # logging_level: 0                  # Megatron-LM LoggerConfig verbosity (0 = quiet)
     tensor_model_parallel_size: 1
     expert_tensor_parallel_size: 1
     expert_model_parallel_size: 1

--- a/examples/configs/grpo_math_1B_megatron.yaml
+++ b/examples/configs/grpo_math_1B_megatron.yaml
@@ -88,6 +88,11 @@ policy:
     force_reconvert_from_hf: False # Set to True to force reconvert of the model from Hugging Face
     empty_unused_memory_level: 1  # 1 is the minimum recommendation for RL since we almost always need to offload before beginning generation. Setting to 0 is faster, but you are more likely to run out of GPU memory.
     activation_checkpointing: false
+    # Optional infrastructure knobs. When unset, the historical hard-coded
+    # defaults are used.
+    # distributed_timeout_minutes: 120  # NCCL init timeout for very large checkpoint conversions
+    # logging_level: 0                  # Megatron-LM LoggerConfig verbosity (0 = quiet)
+    # check_for_nan_in_grad: true       # Set false to skip the per-step NaN/Inf grad check
     # Training CUDA Graph settings; modules and warmup are inactive with impl "none".
     cuda_graph_impl: "none"
     cuda_graph_modules: []

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -17,6 +17,7 @@ import json
 import os
 import time
 import warnings
+from datetime import timedelta
 from typing import Any, Callable, Optional, TypeVar
 
 import torch
@@ -143,15 +144,34 @@ def destroy_parallel_state():
         pass
 
 
-def setup_distributed() -> None:
-    """Handle NCCL settings, dtype mapping, and basic config setup."""
+def setup_distributed(config: Optional[Any] = None) -> None:
+    """Handle NCCL settings, dtype mapping, and basic config setup.
+
+    Args:
+        config: Optional ``PolicyConfig``. When provided and
+            ``config["megatron_cfg"]["distributed_timeout_minutes"]`` is set,
+            that value is forwarded as the ``timeout`` argument to
+            ``torch.distributed.init_process_group``. The default NCCL timeout
+            (currently ~10 minutes) can be too short for very large models on
+            slow storage during initial checkpoint conversion, so this knob
+            lets users extend it.
+    """
     # Disable dynamo autotune_local_cache to avoid crash when there's already a cache
     # with different order of node_bundles
     configure_dynamo_cache()
     # Ensure clean slate before import
     destroy_parallel_state()
     # Need to initialize the process group before calling into Megatron-Bridge, otherwise Megatron-Bridge will try to set an incorrect device
-    torch.distributed.init_process_group("nccl")
+    init_kwargs: dict[str, Any] = {}
+    if (
+        config is not None
+        and "megatron_cfg" in config
+        and "distributed_timeout_minutes" in config["megatron_cfg"]
+    ):
+        init_kwargs["timeout"] = timedelta(
+            minutes=config["megatron_cfg"]["distributed_timeout_minutes"]
+        )
+    torch.distributed.init_process_group("nccl", **init_kwargs)
 
 
 def validate_and_set_config(
@@ -352,7 +372,7 @@ def setup_model_config(
 
     # Create checkpoint configs
     checkpoint_config = _create_checkpoint_config(
-        pretrained_path, weights_path, optimizer_path
+        pretrained_path, weights_path, optimizer_path, config
     )
 
     # Validate training configuration
@@ -543,16 +563,33 @@ def _validate_chunking_config(config: PolicyConfig) -> None:
 
 
 def _create_checkpoint_config(
-    pretrained_path: str, weights_path: Optional[str], optimizer_path: Optional[str]
+    pretrained_path: str,
+    weights_path: Optional[str],
+    optimizer_path: Optional[str],
+    config: Optional[Any] = None,
 ) -> CheckpointConfig:
-    """Create checkpoint configurations."""
+    """Create checkpoint configurations.
+
+    The ``async_save`` flag is read from ``config["megatron_cfg"]`` when set,
+    so that users can opt in to non-blocking checkpoint writes (the
+    underlying Megatron-Core plumbing already supports it). When the key is
+    absent, async saving is left disabled — matching the historical default.
+    """
+    async_save: bool = False
+    if (
+        config is not None
+        and "megatron_cfg" in config
+        and "async_save" in config["megatron_cfg"]
+    ):
+        async_save = config["megatron_cfg"]["async_save"]
+
     return CheckpointConfig(
         save_interval=100,
         save=weights_path,
         load=weights_path,
         load_optim=optimizer_path is not None,
         pretrained_checkpoint=pretrained_path,
-        async_save=False,
+        async_save=async_save,
         fully_parallel_save=True,
         fully_parallel_load=True,
         load_rng=False,
@@ -625,10 +662,21 @@ def _create_megatron_config(
     dtype: torch.dtype,
 ) -> ConfigContainer:
     """Create the final Megatron configuration container."""
+    # Read optional infrastructure knobs from megatron_cfg, falling back to the
+    # values that were previously hard-coded so behavior is unchanged for any
+    # config that doesn't set them.
+    logging_level: int = 0
+    if "logging_level" in config["megatron_cfg"]:
+        logging_level = config["megatron_cfg"]["logging_level"]
+
+    check_for_nan_in_grad: bool = True
+    if "check_for_nan_in_grad" in config["megatron_cfg"]:
+        check_for_nan_in_grad = config["megatron_cfg"]["check_for_nan_in_grad"]
+
     return ConfigContainer(
         model=model_cfg,
         checkpoint=checkpoint_config,
-        logger=LoggerConfig(logging_level=0),
+        logger=LoggerConfig(logging_level=logging_level),
         train=TrainingConfig(
             micro_batch_size=1,  # ignored
             global_batch_size=config["train_global_batch_size"],  # ignored
@@ -636,7 +684,7 @@ def _create_megatron_config(
         ),
         optimizer=OptimizerConfig(**config["megatron_cfg"]["optimizer"]),
         ddp=DistributedDataParallelConfig(
-            check_for_nan_in_grad=True,
+            check_for_nan_in_grad=check_for_nan_in_grad,
             grad_reduce_in_fp32=config["megatron_cfg"][
                 "distributed_data_parallel_config"
             ]["grad_reduce_in_fp32"],

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -19,6 +19,7 @@ import os
 import threading
 import time
 import warnings
+from datetime import timedelta
 from collections.abc import Mapping
 from dataclasses import fields, is_dataclass, replace
 from typing import Any, Callable, Optional, TypeVar
@@ -334,7 +335,12 @@ def setup_distributed(config) -> None:
     # Ensure clean slate before import
     destroy_parallel_state()
     # Initialize process group
-    torch.distributed.init_process_group("nccl")
+    init_kwargs: dict[str, Any] = {}
+    if "distributed_timeout_minutes" in config["megatron_cfg"]:
+        init_kwargs["timeout"] = timedelta(
+            minutes=config["megatron_cfg"]["distributed_timeout_minutes"]
+        )
+    torch.distributed.init_process_group("nccl", **init_kwargs)
 
 
 def validate_and_set_config(
@@ -1536,10 +1542,18 @@ def _create_megatron_config(
             "use_gloo_process_groups"
         ]
 
+    logging_level = 0
+    if "logging_level" in config["megatron_cfg"]:
+        logging_level = config["megatron_cfg"]["logging_level"]
+
+    check_for_nan_in_grad = True
+    if "check_for_nan_in_grad" in config["megatron_cfg"]:
+        check_for_nan_in_grad = config["megatron_cfg"]["check_for_nan_in_grad"]
+
     return ConfigContainer(
         model=model_cfg,
         checkpoint=checkpoint_config,
-        logger=LoggerConfig(logging_level=0),
+        logger=LoggerConfig(logging_level=logging_level),
         dist=dist_cfg,
         train=TrainingConfig(
             micro_batch_size=1,  # ignored
@@ -1548,7 +1562,7 @@ def _create_megatron_config(
         ),
         optimizer=OptimizerConfig(**optimizer_kwargs),
         ddp=DistributedDataParallelConfig(
-            check_for_nan_in_grad=True,
+            check_for_nan_in_grad=check_for_nan_in_grad,
             grad_reduce_in_fp32=config["megatron_cfg"][
                 "distributed_data_parallel_config"
             ]["grad_reduce_in_fp32"],

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -251,6 +251,24 @@ class MegatronConfig(TypedDict):
     linear_ce_fusion_chunk_size: NotRequired[int]
     # When mtp_num_layers=0, Multi-Token Prediction is disabled.
     mtp_num_layers: NotRequired[int]
+    # Timeout (in minutes) passed to torch.distributed.init_process_group.
+    # Increase from the framework default when initial weight conversion or
+    # checkpoint load can exceed the default NCCL timeout (e.g. very large
+    # models on slow storage). When unset, the upstream default is used.
+    distributed_timeout_minutes: NotRequired[int]
+    # When True, save checkpoints asynchronously so training does not block on
+    # filesystem I/O. Defaults to False when unset (matching the historical
+    # behavior). The async save plumbing already exists in Megatron-Core; this
+    # toggle exposes it to the user.
+    async_save: NotRequired[bool]
+    # When True, Megatron-LM's DDP performs a per-step NaN/Inf grad check.
+    # Useful for debugging numerical stability but adds non-trivial overhead
+    # in steady-state training. Defaults to True when unset (matching the
+    # historical behavior).
+    check_for_nan_in_grad: NotRequired[bool]
+    # Verbosity level forwarded to Megatron-LM's LoggerConfig (0 = quiet).
+    # Defaults to 0 when unset.
+    logging_level: NotRequired[int]
 
 
 class DraftConfigDisabled(TypedDict):

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -432,6 +432,18 @@ class MegatronConfig(TypedDict):
     # Create gloo process groups during Megatron distributed init.
     # Omitted: use the Megatron Bridge default.
     use_gloo_process_groups: NotRequired[bool]
+    # Timeout (in minutes) passed to torch.distributed.init_process_group.
+    # Increase when initial weight conversion or checkpoint load can exceed
+    # the default NCCL timeout (e.g. very large models on slow storage).
+    # Omitted: use the torch.distributed default.
+    distributed_timeout_minutes: NotRequired[int]
+    # Verbosity forwarded to Megatron-LM's LoggerConfig.
+    # Omitted: 0 (quiet), the historical hard-coded value.
+    logging_level: NotRequired[int]
+    # Per-step NaN/Inf grad check in Megatron-LM's DDP. Useful for debugging
+    # numerical stability but adds overhead in steady-state training.
+    # Omitted: True, the historical hard-coded value.
+    check_for_nan_in_grad: NotRequired[bool]
     # Enable grouped GEMM for MoE experts via CUTLASS. Significant throughput
     # gain when multiple experts are assigned per rank (num_local_experts > 1).
     # Requires TE >= 1.11.0 for FP8 and Ampere (sm_80) or newer.

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -130,7 +130,7 @@ class MegatronPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface)
         self.rank = get_rank_safe()
 
         # Step 1: Setup distributed
-        setup_distributed()
+        setup_distributed(config)
 
         # Step 2: Validate and setup model paths
         hf_model_name, pretrained_path, pt_checkpoint_exists = validate_model_paths(

--- a/tests/unit/models/megatron/test_megatron_setup.py
+++ b/tests/unit/models/megatron/test_megatron_setup.py
@@ -559,6 +559,103 @@ class TestCreateCheckpointConfig:
         assert checkpoint_config.fully_parallel_load is True
         assert checkpoint_config.load_rng is False
 
+    def test_async_save_default_when_config_absent(self, tmp_path):
+        """When no config is passed, async_save must remain disabled
+        (matches the historical hard-coded default).
+        """
+        from nemo_rl.models.megatron.setup import _create_checkpoint_config
+
+        checkpoint_config = _create_checkpoint_config(
+            str(tmp_path / "pretrained"),
+            str(tmp_path / "weights"),
+            str(tmp_path / "optimizer"),
+        )
+        assert checkpoint_config.async_save is False
+
+    def test_async_save_default_when_key_absent(self, tmp_path):
+        """When megatron_cfg is present but lacks async_save, the flag
+        must remain disabled (don't surprise existing configs).
+        """
+        from nemo_rl.models.megatron.setup import _create_checkpoint_config
+
+        config = {"megatron_cfg": {}}
+        checkpoint_config = _create_checkpoint_config(
+            str(tmp_path / "pretrained"),
+            str(tmp_path / "weights"),
+            str(tmp_path / "optimizer"),
+            config,
+        )
+        assert checkpoint_config.async_save is False
+
+    def test_async_save_enabled_via_config(self, tmp_path):
+        """When config sets ``async_save: true``, the value flows through
+        to the underlying CheckpointConfig — issue #2229.
+        """
+        from nemo_rl.models.megatron.setup import _create_checkpoint_config
+
+        config = {"megatron_cfg": {"async_save": True}}
+        checkpoint_config = _create_checkpoint_config(
+            str(tmp_path / "pretrained"),
+            str(tmp_path / "weights"),
+            str(tmp_path / "optimizer"),
+            config,
+        )
+        assert checkpoint_config.async_save is True
+
+
+@pytest.mark.mcore
+class TestSetupDistributedTimeout:
+    """Tests for the optional distributed_timeout_minutes config knob."""
+
+    def test_no_timeout_kwarg_when_config_absent(self):
+        """Without a config argument, ``init_process_group`` is called with
+        no extra kwargs — preserving the historical default timeout.
+        """
+        from nemo_rl.models.megatron import setup as setup_mod
+
+        with (
+            patch.object(setup_mod, "configure_dynamo_cache"),
+            patch.object(setup_mod, "destroy_parallel_state"),
+            patch.object(setup_mod.torch.distributed, "init_process_group") as ipg,
+        ):
+            setup_mod.setup_distributed()
+
+        ipg.assert_called_once_with("nccl")
+
+    def test_no_timeout_kwarg_when_key_absent(self):
+        """A megatron_cfg block without distributed_timeout_minutes must
+        not cause a timeout to be set — protects existing user configs.
+        """
+        from nemo_rl.models.megatron import setup as setup_mod
+
+        config = {"megatron_cfg": {}}
+        with (
+            patch.object(setup_mod, "configure_dynamo_cache"),
+            patch.object(setup_mod, "destroy_parallel_state"),
+            patch.object(setup_mod.torch.distributed, "init_process_group") as ipg,
+        ):
+            setup_mod.setup_distributed(config)
+
+        ipg.assert_called_once_with("nccl")
+
+    def test_timeout_forwarded_when_set(self):
+        """``distributed_timeout_minutes`` must be forwarded as a
+        ``timedelta`` on the ``timeout`` kwarg — issue #2229.
+        """
+        from datetime import timedelta
+
+        from nemo_rl.models.megatron import setup as setup_mod
+
+        config = {"megatron_cfg": {"distributed_timeout_minutes": 120}}
+        with (
+            patch.object(setup_mod, "configure_dynamo_cache"),
+            patch.object(setup_mod, "destroy_parallel_state"),
+            patch.object(setup_mod.torch.distributed, "init_process_group") as ipg,
+        ):
+            setup_mod.setup_distributed(config)
+
+        ipg.assert_called_once_with("nccl", timeout=timedelta(minutes=120))
+
 
 @pytest.mark.mcore
 class TestValidateTrainingConfig:

--- a/tests/unit/models/megatron/test_megatron_setup.py
+++ b/tests/unit/models/megatron/test_megatron_setup.py
@@ -2435,6 +2435,104 @@ class TestCreateMegatronConfigGlooProcessGroups:
 
 
 @pytest.mark.mcore
+class TestCreateMegatronConfigInfraKnobs:
+    """Tests for logging_level / check_for_nan_in_grad plumbing in _create_megatron_config."""
+
+    @staticmethod
+    def _config(**megatron_overrides):
+        megatron_cfg = {
+            "optimizer": {"use_distributed_optimizer": False},
+            "scheduler": {},
+            "distributed_data_parallel_config": {
+                "overlap_param_gather": False,
+                "grad_reduce_in_fp32": False,
+                "overlap_grad_reduce": False,
+                "data_parallel_sharding_strategy": "no_shard",
+            },
+            "train_iters": 10,
+        }
+        megatron_cfg.update(megatron_overrides)
+        return {"megatron_cfg": megatron_cfg, "train_global_batch_size": 8}
+
+    def _container_call_kwargs(self, config):
+        """Run _create_megatron_config with mocked sub-configs and return the
+        kwargs handed to the LoggerConfig and DistributedDataParallelConfig mocks."""
+        from nemo_rl.models.megatron.setup import _create_megatron_config
+
+        with (
+            patch("nemo_rl.models.megatron.setup.ConfigContainer"),
+            patch("nemo_rl.models.megatron.setup.TrainingConfig"),
+            patch("nemo_rl.models.megatron.setup.OptimizerConfig"),
+            patch(
+                "nemo_rl.models.megatron.setup.DistributedDataParallelConfig"
+            ) as mock_ddp,
+            patch("nemo_rl.models.megatron.setup.SchedulerConfig"),
+            patch("nemo_rl.models.megatron.setup.TokenizerConfig"),
+            patch("nemo_rl.models.megatron.setup.LoggerConfig") as mock_logger,
+        ):
+            _create_megatron_config(
+                model_cfg=MagicMock(),
+                checkpoint_config=MagicMock(),
+                config=config,
+                hf_model_name="test-model",
+                dtype=torch.bfloat16,
+            )
+
+        return mock_logger.call_args.kwargs, mock_ddp.call_args.kwargs
+
+    def test_logging_level_forwarded(self):
+        logger_kwargs, _ = self._container_call_kwargs(self._config(logging_level=2))
+        assert logger_kwargs["logging_level"] == 2
+
+    def test_logging_level_absent_keeps_historical_default(self):
+        logger_kwargs, _ = self._container_call_kwargs(self._config())
+        assert logger_kwargs["logging_level"] == 0
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_check_for_nan_in_grad_forwarded(self, value):
+        _, ddp_kwargs = self._container_call_kwargs(
+            self._config(check_for_nan_in_grad=value)
+        )
+        assert ddp_kwargs["check_for_nan_in_grad"] is value
+
+    def test_check_for_nan_in_grad_absent_keeps_historical_default(self):
+        _, ddp_kwargs = self._container_call_kwargs(self._config())
+        assert ddp_kwargs["check_for_nan_in_grad"] is True
+
+
+@pytest.mark.mcore
+class TestSetupDistributedTimeout:
+    """Tests for distributed_timeout_minutes plumbing in setup_distributed."""
+
+    def _init_process_group_kwargs(self, megatron_cfg):
+        from nemo_rl.models.megatron.setup import setup_distributed
+
+        config = {
+            "megatron_cfg": megatron_cfg,
+            "generation": None,
+        }
+        with (
+            patch("nemo_rl.models.megatron.setup.configure_refit_environment"),
+            patch("nemo_rl.models.megatron.setup.configure_dynamo_cache"),
+            patch("nemo_rl.models.megatron.setup.destroy_parallel_state"),
+            patch("torch.distributed.init_process_group") as mock_init,
+        ):
+            setup_distributed(config)
+
+        return mock_init.call_args.kwargs
+
+    def test_timeout_forwarded_when_set(self):
+        from datetime import timedelta
+
+        kwargs = self._init_process_group_kwargs({"distributed_timeout_minutes": 120})
+        assert kwargs["timeout"] == timedelta(minutes=120)
+
+    def test_timeout_absent_uses_torch_default(self):
+        kwargs = self._init_process_group_kwargs({})
+        assert "timeout" not in kwargs
+
+
+@pytest.mark.mcore
 class TestCreateMegatronConfigOptimizerFp8Recipe:
     """Tests for optimizer FP8 recipe plumbing in _create_megatron_config."""
 


### PR DESCRIPTION
## Summary

Closes #2229 (subset — see "Out of scope" below).

Several Megatron-LM infrastructure knobs were hard-coded inside
\`nemo_rl/models/megatron/setup.py\` even though the underlying
framework already supports them as configurable. Users running on
varied storage backends (NFS) or training very large models (e.g.
Nemotron 3 Super 120B) had to patch the source file to override them
— the workaround documented in the issue itself.

Expose four of those knobs as \`NotRequired\` fields on
\`MegatronConfig\`. When unset, the historical hard-coded behaviour
is preserved exactly, so existing user configs are untouched.

## What's exposed

| Config key | Old hard-coded value | Why expose it |
|---|---|---|
| \`policy.megatron_cfg.distributed_timeout_minutes\` | NCCL default (~10 min) | Initial weight conversion for 100B+ models on NFS exceeds the default and crashes \`init_process_group\` |
| \`policy.megatron_cfg.async_save\` | \`False\` | Non-blocking checkpoint writes; the Megatron-Core plumbing already exists, this just turns it on |
| \`policy.megatron_cfg.check_for_nan_in_grad\` | \`True\` | Disable in steady-state production for ~per-step overhead reduction |
| \`policy.megatron_cfg.logging_level\` | \`0\` | Bump for debugging; previously not overridable |

## Wiring

- \`setup_distributed()\` now accepts an optional policy config and threads \`distributed_timeout_minutes\` into \`torch.distributed.init_process_group(timeout=...)\`.
- \`_create_checkpoint_config()\` accepts the policy config and reads \`async_save\`.
- \`_create_megatron_config()\` reads \`check_for_nan_in_grad\` and \`logging_level\` from the \`config\` it already receives.
- \`MegatronPolicyWorker\` passes \`config\` to \`setup_distributed\`.

## Coverage

New tests in \`tests/unit/models/megatron/test_megatron_setup.py\`:

- \`TestSetupDistributedTimeout\` — three test cases covering no-config / config-without-key / config-with-key. Patches \`init_process_group\` and asserts the right kwargs flow through.
- \`TestCreateCheckpointConfig\` extended with three new tests for the \`async_save\` default-vs-override behaviour.

All marked \`@pytest.mark.mcore\` to fit the project's test-tier conventions.

## Backward compatibility

All four fields are typed \`NotRequired\` and the code uses explicit \`if "key" in config["megatron_cfg"]:\` checks (matching the existing pattern in this file for \`force_reconvert_from_hf\` and friends). When a key is absent, the value used is identical to the previous hard-coded constant. No exemplar YAML or recipe needs to change for this PR to be safe.

The \`grpo_math_1B_megatron.yaml\` exemplar is updated with commented-out examples so users can copy/paste the right keys.

## Out of scope

\`fully_parallel_save\`, \`fully_parallel_load\`, and \`load_rng\` are also called out in #2229. They're referenced in **two** places — \`_create_checkpoint_config\` and \`setup_reference_model_state\` — and exposing them affects checkpoint-format and reproducibility behaviour that could nudge convergence tests. Worth a focused follow-up PR with its own test plan rather than bundling here.

The unconstrained \`accelerate\` dependency is being addressed in #2388.

## Test plan

- [x] \`ruff check\` — clean
- [x] \`ruff format\` — clean
- [x] \`python3 -m py_compile\` on all touched files — clean
- [ ] CI \`L0\` (\`L0_Unit_Tests_Other.sh\` runs \`tests/unit/models/megatron/test_megatron_setup.py\` under \`--mcore-only\`)
- [ ] Spot-check on a real run: confirm a config with \`distributed_timeout_minutes: 120\` actually extends the \`init_process_group\` timeout (best done by the maintainers with the 120B repro from #2229)

Refs: #2229