### PR TITLE
feat(megatron): expose checkpoint parallelism and RNG knobs

### DIFF
--- a/examples/configs/grpo_math_1B_megatron.yaml
+++ b/examples/configs/grpo_math_1B_megatron.yaml
@@ -88,6 +88,9 @@ policy:
     # async_save: false                 # Set true to write checkpoints asynchronously
     # check_for_nan_in_grad: true       # Set false to skip the per-step NaN/Inf grad check in steady-state training
     # logging_level: 0                  # Megatron-LM LoggerConfig verbosity (0 = quiet)
+    # fully_parallel_save: true         # Set false to simplify debugging at the cost of throughput
+    # fully_parallel_load: true         # Set false to simplify debugging at the cost of throughput
+    # load_rng: false                   # Set true to include/restore RNG state for bit-exact resume
     tensor_model_parallel_size: 1
     expert_tensor_parallel_size: 1
     expert_model_parallel_size: 1

--- a/examples/configs/grpo_math_1B_megatron.yaml
+++ b/examples/configs/grpo_math_1B_megatron.yaml
@@ -82,6 +82,12 @@ policy:
     empty_unused_memory_level: 1  # 1 is the minimum recommendation for RL since we almost always need to offload before beginning generation. Setting to 0 is faster, but you are more likely to run out of GPU memory.
     activation_checkpointing: false
     converter_type: "Qwen2ForCausalLM"
+    # Optional infrastructure knobs (issue #2229). When unset, the historical
+    # hard-coded defaults are used.
+    # distributed_timeout_minutes: 120  # Increase NCCL init timeout for very large checkpoint conversions
+    # async_save: false                 # Set true to write checkpoints asynchronously
+    # check_for_nan_in_grad: true       # Set false to skip the per-step NaN/Inf grad check in steady-state training
+    # logging_level: 0                  # Megatron-LM LoggerConfig verbosity (0 = quiet)
     tensor_model_parallel_size: 1
     expert_tensor_parallel_size: 1
     expert_model_parallel_size: 1

--- a/examples/configs/grpo_math_1B_megatron.yaml
+++ b/examples/configs/grpo_math_1B_megatron.yaml
@@ -88,6 +88,12 @@ policy:
     force_reconvert_from_hf: False # Set to True to force reconvert of the model from Hugging Face
     empty_unused_memory_level: 1  # 1 is the minimum recommendation for RL since we almost always need to offload before beginning generation. Setting to 0 is faster, but you are more likely to run out of GPU memory.
     activation_checkpointing: false
+    # Optional checkpoint-I/O knobs forwarded to Megatron Bridge's
+    # CheckpointConfig. When unset, the historical hard-coded defaults are used.
+    # checkpoint:
+    #   fully_parallel_save: true   # Set false to simplify debugging at the cost of throughput
+    #   fully_parallel_load: true   # Set false to simplify debugging at the cost of throughput
+    #   load_rng: false             # Set true to include/restore RNG state for bit-exact resume
     # Training CUDA Graph settings; modules and warmup are inactive with impl "none".
     cuda_graph_impl: "none"
     cuda_graph_modules: []

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -576,16 +576,16 @@ def _create_checkpoint_config(
     patching this module. When a key is absent, the historical hard-coded
     default is used.
     """
-    megatron_cfg = config["megatron_cfg"] if config and "megatron_cfg" in config else {}
+    megatron_cfg = (
+        config["megatron_cfg"]
+        if config is not None and "megatron_cfg" in config
+        else {}
+    )
 
-    async_save: bool = megatron_cfg.get("async_save", False) if megatron_cfg else False
-    fully_parallel_save: bool = (
-        megatron_cfg.get("fully_parallel_save", True) if megatron_cfg else True
-    )
-    fully_parallel_load: bool = (
-        megatron_cfg.get("fully_parallel_load", True) if megatron_cfg else True
-    )
-    load_rng: bool = megatron_cfg.get("load_rng", False) if megatron_cfg else False
+    async_save: bool = megatron_cfg.get("async_save", False)
+    fully_parallel_save: bool = megatron_cfg.get("fully_parallel_save", True)
+    fully_parallel_load: bool = megatron_cfg.get("fully_parallel_load", True)
+    load_rng: bool = megatron_cfg.get("load_rng", False)
 
     return CheckpointConfig(
         save_interval=100,

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -570,18 +570,22 @@ def _create_checkpoint_config(
 ) -> CheckpointConfig:
     """Create checkpoint configurations.
 
-    The ``async_save`` flag is read from ``config["megatron_cfg"]`` when set,
-    so that users can opt in to non-blocking checkpoint writes (the
-    underlying Megatron-Core plumbing already supports it). When the key is
-    absent, async saving is left disabled — matching the historical default.
+    The ``async_save``, ``fully_parallel_save``, ``fully_parallel_load``, and
+    ``load_rng`` flags are read from ``config["megatron_cfg"]`` when set, so
+    users can override Megatron-Core's checkpoint I/O behavior without
+    patching this module. When a key is absent, the historical hard-coded
+    default is used.
     """
-    async_save: bool = False
-    if (
-        config is not None
-        and "megatron_cfg" in config
-        and "async_save" in config["megatron_cfg"]
-    ):
-        async_save = config["megatron_cfg"]["async_save"]
+    megatron_cfg = config["megatron_cfg"] if config and "megatron_cfg" in config else {}
+
+    async_save: bool = megatron_cfg.get("async_save", False) if megatron_cfg else False
+    fully_parallel_save: bool = (
+        megatron_cfg.get("fully_parallel_save", True) if megatron_cfg else True
+    )
+    fully_parallel_load: bool = (
+        megatron_cfg.get("fully_parallel_load", True) if megatron_cfg else True
+    )
+    load_rng: bool = megatron_cfg.get("load_rng", False) if megatron_cfg else False
 
     return CheckpointConfig(
         save_interval=100,
@@ -590,9 +594,9 @@ def _create_checkpoint_config(
         load_optim=optimizer_path is not None,
         pretrained_checkpoint=pretrained_path,
         async_save=async_save,
-        fully_parallel_save=True,
-        fully_parallel_load=True,
-        load_rng=False,
+        fully_parallel_save=fully_parallel_save,
+        fully_parallel_load=fully_parallel_load,
+        load_rng=load_rng,
     )
 
 
@@ -1031,13 +1035,20 @@ def setup_reference_model_state(
     config: PolicyConfig, megatron_cfg: ConfigContainer, pretrained_path: str
 ) -> dict:
     """Setup the reference model for inference and return its state dict."""
+    # Mirror the user-overridable knobs from _create_checkpoint_config so the
+    # reference model honors the same checkpoint-I/O preferences. When a key
+    # is absent, the historical hard-coded default is used.
+    user_megatron_cfg = config.get("megatron_cfg", {}) or {}
+    fully_parallel_load: bool = user_megatron_cfg.get("fully_parallel_load", True)
+    load_rng: bool = user_megatron_cfg.get("load_rng", False)
+
     # Create reference checkpoint config
     ref_checkpoint_config = CheckpointConfig(
         pretrained_checkpoint=pretrained_path,
         save=None,
         load=None,
-        fully_parallel_load=True,
-        load_rng=False,
+        fully_parallel_load=fully_parallel_load,
+        load_rng=load_rng,
     )
 
     ref_ckpt_context = init_checkpointing_context(ref_checkpoint_config)

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -17,6 +17,7 @@ import json
 import os
 import time
 import warnings
+from datetime import timedelta
 from typing import Any, Callable, Optional, TypeVar
 
 import torch
@@ -143,15 +144,34 @@ def destroy_parallel_state():
         pass
 
 
-def setup_distributed() -> None:
-    """Handle NCCL settings, dtype mapping, and basic config setup."""
+def setup_distributed(config: Optional[Any] = None) -> None:
+    """Handle NCCL settings, dtype mapping, and basic config setup.
+
+    Args:
+        config: Optional ``PolicyConfig``. When provided and
+            ``config["megatron_cfg"]["distributed_timeout_minutes"]`` is set,
+            that value is forwarded as the ``timeout`` argument to
+            ``torch.distributed.init_process_group``. The default NCCL timeout
+            (currently ~10 minutes) can be too short for very large models on
+            slow storage during initial checkpoint conversion, so this knob
+            lets users extend it.
+    """
     # Disable dynamo autotune_local_cache to avoid crash when there's already a cache
     # with different order of node_bundles
     configure_dynamo_cache()
     # Ensure clean slate before import
     destroy_parallel_state()
     # Need to initialize the process group before calling into Megatron-Bridge, otherwise Megatron-Bridge will try to set an incorrect device
-    torch.distributed.init_process_group("nccl")
+    init_kwargs: dict[str, Any] = {}
+    if (
+        config is not None
+        and "megatron_cfg" in config
+        and "distributed_timeout_minutes" in config["megatron_cfg"]
+    ):
+        init_kwargs["timeout"] = timedelta(
+            minutes=config["megatron_cfg"]["distributed_timeout_minutes"]
+        )
+    torch.distributed.init_process_group("nccl", **init_kwargs)
 
 
 def validate_and_set_config(
@@ -352,7 +372,7 @@ def setup_model_config(
 
     # Create checkpoint configs
     checkpoint_config = _create_checkpoint_config(
-        pretrained_path, weights_path, optimizer_path
+        pretrained_path, weights_path, optimizer_path, config
     )
 
     # Validate training configuration
@@ -543,16 +563,33 @@ def _validate_chunking_config(config: PolicyConfig) -> None:
 
 
 def _create_checkpoint_config(
-    pretrained_path: str, weights_path: Optional[str], optimizer_path: Optional[str]
+    pretrained_path: str,
+    weights_path: Optional[str],
+    optimizer_path: Optional[str],
+    config: Optional[Any] = None,
 ) -> CheckpointConfig:
-    """Create checkpoint configurations."""
+    """Create checkpoint configurations.
+
+    The ``async_save`` flag is read from ``config["megatron_cfg"]`` when set,
+    so that users can opt in to non-blocking checkpoint writes (the
+    underlying Megatron-Core plumbing already supports it). When the key is
+    absent, async saving is left disabled — matching the historical default.
+    """
+    async_save: bool = False
+    if (
+        config is not None
+        and "megatron_cfg" in config
+        and "async_save" in config["megatron_cfg"]
+    ):
+        async_save = config["megatron_cfg"]["async_save"]
+
     return CheckpointConfig(
         save_interval=100,
         save=weights_path,
         load=weights_path,
         load_optim=optimizer_path is not None,
         pretrained_checkpoint=pretrained_path,
-        async_save=False,
+        async_save=async_save,
         fully_parallel_save=True,
         fully_parallel_load=True,
         load_rng=False,
@@ -625,10 +662,21 @@ def _create_megatron_config(
     dtype: torch.dtype,
 ) -> ConfigContainer:
     """Create the final Megatron configuration container."""
+    # Read optional infrastructure knobs from megatron_cfg, falling back to the
+    # values that were previously hard-coded so behavior is unchanged for any
+    # config that doesn't set them.
+    logging_level: int = 0
+    if "logging_level" in config["megatron_cfg"]:
+        logging_level = config["megatron_cfg"]["logging_level"]
+
+    check_for_nan_in_grad: bool = True
+    if "check_for_nan_in_grad" in config["megatron_cfg"]:
+        check_for_nan_in_grad = config["megatron_cfg"]["check_for_nan_in_grad"]
+
     return ConfigContainer(
         model=model_cfg,
         checkpoint=checkpoint_config,
-        logger=LoggerConfig(logging_level=0),
+        logger=LoggerConfig(logging_level=logging_level),
         train=TrainingConfig(
             micro_batch_size=1,  # ignored
             global_batch_size=config["train_global_batch_size"],  # ignored
@@ -636,7 +684,7 @@ def _create_megatron_config(
         ),
         optimizer=OptimizerConfig(**config["megatron_cfg"]["optimizer"]),
         ddp=DistributedDataParallelConfig(
-            check_for_nan_in_grad=True,
+            check_for_nan_in_grad=check_for_nan_in_grad,
             grad_reduce_in_fp32=config["megatron_cfg"][
                 "distributed_data_parallel_config"
             ]["grad_reduce_in_fp32"],

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -1412,6 +1412,9 @@ def _create_checkpoint_config(
         "ckpt_fully_parallel_save_process_group",
         "ckpt_fully_parallel_load_process_group",
         "ckpt_fully_parallel_load_exchange_algo",
+        "fully_parallel_save",
+        "fully_parallel_load",
+        "load_rng",
     )
     for field in _optional_ckpt_fields:
         if field in cfg:
@@ -2187,14 +2190,22 @@ def setup_reference_model_state(
     pre_load_checkpoint_hook: Optional[Callable] = None,
 ) -> dict:
     """Setup the reference model for inference and return its state dict."""
-    # Create reference checkpoint config
-    ref_checkpoint_config = CheckpointConfig(
+    # Create reference checkpoint config. Mirror the user-overridable load
+    # knobs from _create_checkpoint_config so the reference model honors the
+    # same checkpoint-I/O preferences; absent keys keep the historical
+    # hard-coded values.
+    ref_ckpt_kwargs: dict[str, Any] = dict(
         pretrained_checkpoint=pretrained_path,
         save=None,
         load=None,
         fully_parallel_load=True,
         load_rng=False,
     )
+    ckpt_cfg = config["megatron_cfg"].get("checkpoint") or {}
+    for knob in ("fully_parallel_load", "load_rng"):
+        if knob in ckpt_cfg:
+            ref_ckpt_kwargs[knob] = ckpt_cfg[knob]
+    ref_checkpoint_config = CheckpointConfig(**ref_ckpt_kwargs)
 
     ref_ckpt_context = init_checkpointing_context(ref_checkpoint_config)
 

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -251,6 +251,24 @@ class MegatronConfig(TypedDict):
     linear_ce_fusion_chunk_size: NotRequired[int]
     # When mtp_num_layers=0, Multi-Token Prediction is disabled.
     mtp_num_layers: NotRequired[int]
+    # Timeout (in minutes) passed to torch.distributed.init_process_group.
+    # Increase from the framework default when initial weight conversion or
+    # checkpoint load can exceed the default NCCL timeout (e.g. very large
+    # models on slow storage). When unset, the upstream default is used.
+    distributed_timeout_minutes: NotRequired[int]
+    # When True, save checkpoints asynchronously so training does not block on
+    # filesystem I/O. Defaults to False when unset (matching the historical
+    # behavior). The async save plumbing already exists in Megatron-Core; this
+    # toggle exposes it to the user.
+    async_save: NotRequired[bool]
+    # When True, Megatron-LM's DDP performs a per-step NaN/Inf grad check.
+    # Useful for debugging numerical stability but adds non-trivial overhead
+    # in steady-state training. Defaults to True when unset (matching the
+    # historical behavior).
+    check_for_nan_in_grad: NotRequired[bool]
+    # Verbosity level forwarded to Megatron-LM's LoggerConfig (0 = quiet).
+    # Defaults to 0 when unset.
+    logging_level: NotRequired[int]
 
 
 class DraftConfigDisabled(TypedDict):

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -269,6 +269,15 @@ class MegatronConfig(TypedDict):
     # Verbosity level forwarded to Megatron-LM's LoggerConfig (0 = quiet).
     # Defaults to 0 when unset.
     logging_level: NotRequired[int]
+    # When True, checkpoint save/load uses Megatron-Core's fully-parallel
+    # path. Defaults to True when unset (matching the historical behavior).
+    # Setting to False can simplify debugging at the cost of throughput.
+    fully_parallel_save: NotRequired[bool]
+    fully_parallel_load: NotRequired[bool]
+    # When True, RNG state is included in saved checkpoints and restored on
+    # load — needed for bit-exact resume. Defaults to False when unset
+    # (matching the historical behavior).
+    load_rng: NotRequired[bool]
 
 
 class DraftConfigDisabled(TypedDict):

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -322,6 +322,14 @@ class MegatronCheckpointConfig(TypedDict, total=False):
     ckpt_fully_parallel_save_process_group: str  # "dp" | "ep_dp"
     ckpt_fully_parallel_load_process_group: str  # "dp" | "ep_dp"
     ckpt_fully_parallel_load_exchange_algo: str  # "broadcast" | "gather_rounds"
+    # Use Megatron-Core's fully-parallel checkpoint save/load path. Setting
+    # either to False can simplify debugging at the cost of throughput.
+    # Omitted: True, the historical hard-coded values.
+    fully_parallel_save: bool
+    fully_parallel_load: bool
+    # Include RNG state in saved checkpoints and restore it on load — needed
+    # for bit-exact resume. Omitted: False, the historical hard-coded value.
+    load_rng: bool
 
 
 class MegatronConfig(TypedDict):

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -130,7 +130,7 @@ class MegatronPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface)
         self.rank = get_rank_safe()
 
         # Step 1: Setup distributed
-        setup_distributed()
+        setup_distributed(config)
 
         # Step 2: Validate and setup model paths
         hf_model_name, pretrained_path, pt_checkpoint_exists = validate_model_paths(

--- a/tests/unit/models/megatron/test_megatron_setup.py
+++ b/tests/unit/models/megatron/test_megatron_setup.py
@@ -602,6 +602,43 @@ class TestCreateCheckpointConfig:
         )
         assert checkpoint_config.async_save is True
 
+    def test_parallelism_and_rng_flags_default_when_absent(self, tmp_path):
+        """When the new parallelism/RNG keys are absent the historical
+        defaults must hold — fully_parallel_save/load default True,
+        load_rng defaults False."""
+        from nemo_rl.models.megatron.setup import _create_checkpoint_config
+
+        checkpoint_config = _create_checkpoint_config(
+            str(tmp_path / "pretrained"),
+            str(tmp_path / "weights"),
+            str(tmp_path / "optimizer"),
+            {"megatron_cfg": {}},
+        )
+        assert checkpoint_config.fully_parallel_save is True
+        assert checkpoint_config.fully_parallel_load is True
+        assert checkpoint_config.load_rng is False
+
+    def test_parallelism_and_rng_flags_overridable_via_config(self, tmp_path):
+        """User config can flip the parallelism/RNG knobs — issue #2229."""
+        from nemo_rl.models.megatron.setup import _create_checkpoint_config
+
+        config = {
+            "megatron_cfg": {
+                "fully_parallel_save": False,
+                "fully_parallel_load": False,
+                "load_rng": True,
+            }
+        }
+        checkpoint_config = _create_checkpoint_config(
+            str(tmp_path / "pretrained"),
+            str(tmp_path / "weights"),
+            str(tmp_path / "optimizer"),
+            config,
+        )
+        assert checkpoint_config.fully_parallel_save is False
+        assert checkpoint_config.fully_parallel_load is False
+        assert checkpoint_config.load_rng is True
+
 
 @pytest.mark.mcore
 class TestSetupDistributedTimeout:

--- a/tests/unit/models/megatron/test_megatron_setup.py
+++ b/tests/unit/models/megatron/test_megatron_setup.py
@@ -559,6 +559,103 @@ class TestCreateCheckpointConfig:
         assert checkpoint_config.fully_parallel_load is True
         assert checkpoint_config.load_rng is False
 
+    def test_async_save_default_when_config_absent(self, tmp_path):
+        """When no config is passed, async_save must remain disabled
+        (matches the historical hard-coded default).
+        """
+        from nemo_rl.models.megatron.setup import _create_checkpoint_config
+
+        checkpoint_config = _create_checkpoint_config(
+            str(tmp_path / "pretrained"),
+            str(tmp_path / "weights"),
+            str(tmp_path / "optimizer"),
+        )
+        assert checkpoint_config.async_save is False
+
+    def test_async_save_default_when_key_absent(self, tmp_path):
+        """When megatron_cfg is present but lacks async_save, the flag
+        must remain disabled (don't surprise existing configs).
+        """
+        from nemo_rl.models.megatron.setup import _create_checkpoint_config
+
+        config = {"megatron_cfg": {}}
+        checkpoint_config = _create_checkpoint_config(
+            str(tmp_path / "pretrained"),
+            str(tmp_path / "weights"),
+            str(tmp_path / "optimizer"),
+            config,
+        )
+        assert checkpoint_config.async_save is False
+
+    def test_async_save_enabled_via_config(self, tmp_path):
+        """When config sets ``async_save: true``, the value flows through
+        to the underlying CheckpointConfig — issue #2229.
+        """
+        from nemo_rl.models.megatron.setup import _create_checkpoint_config
+
+        config = {"megatron_cfg": {"async_save": True}}
+        checkpoint_config = _create_checkpoint_config(
+            str(tmp_path / "pretrained"),
+            str(tmp_path / "weights"),
+            str(tmp_path / "optimizer"),
+            config,
+        )
+        assert checkpoint_config.async_save is True
+
+
+@pytest.mark.mcore
+class TestSetupDistributedTimeout:
+    """Tests for the optional distributed_timeout_minutes config knob."""
+
+    def test_no_timeout_kwarg_when_config_absent(self):
+        """Without a config argument, ``init_process_group`` is called with
+        no extra kwargs — preserving the historical default timeout.
+        """
+        from nemo_rl.models.megatron import setup as setup_mod
+
+        with (
+            patch.object(setup_mod, "configure_dynamo_cache"),
+            patch.object(setup_mod, "destroy_parallel_state"),
+            patch.object(setup_mod.torch.distributed, "init_process_group") as ipg,
+        ):
+            setup_mod.setup_distributed()
+
+        ipg.assert_called_once_with("nccl")
+
+    def test_no_timeout_kwarg_when_key_absent(self):
+        """A megatron_cfg block without distributed_timeout_minutes must
+        not cause a timeout to be set — protects existing user configs.
+        """
+        from nemo_rl.models.megatron import setup as setup_mod
+
+        config = {"megatron_cfg": {}}
+        with (
+            patch.object(setup_mod, "configure_dynamo_cache"),
+            patch.object(setup_mod, "destroy_parallel_state"),
+            patch.object(setup_mod.torch.distributed, "init_process_group") as ipg,
+        ):
+            setup_mod.setup_distributed(config)
+
+        ipg.assert_called_once_with("nccl")
+
+    def test_timeout_forwarded_when_set(self):
+        """``distributed_timeout_minutes`` must be forwarded as a
+        ``timedelta`` on the ``timeout`` kwarg — issue #2229.
+        """
+        from datetime import timedelta
+
+        from nemo_rl.models.megatron import setup as setup_mod
+
+        config = {"megatron_cfg": {"distributed_timeout_minutes": 120}}
+        with (
+            patch.object(setup_mod, "configure_dynamo_cache"),
+            patch.object(setup_mod, "destroy_parallel_state"),
+            patch.object(setup_mod.torch.distributed, "init_process_group") as ipg,
+        ):
+            setup_mod.setup_distributed(config)
+
+        ipg.assert_called_once_with("nccl", timeout=timedelta(minutes=120))
+
 
 @pytest.mark.mcore
 class TestValidateTrainingConfig:

--- a/tests/unit/models/megatron/test_megatron_setup.py
+++ b/tests/unit/models/megatron/test_megatron_setup.py
@@ -2054,6 +2054,42 @@ class TestCreateCheckpointConfig:
         assert checkpoint_config.async_save is False
         assert checkpoint_config.ckpt_assume_constant_structure is True
 
+    @pytest.mark.parametrize(
+        "field, value",
+        [
+            ("fully_parallel_save", False),
+            ("fully_parallel_load", False),
+            ("load_rng", True),
+        ],
+    )
+    def test_parallel_io_and_rng_knobs_forwarded(self, tmp_path, field, value):
+        """Explicit fully_parallel_save/load and load_rng override the historical values."""
+        from nemo_rl.models.megatron.setup import _create_checkpoint_config
+
+        checkpoint_config = _create_checkpoint_config(
+            str(tmp_path / "pretrained"),
+            str(tmp_path / "weights"),
+            str(tmp_path / "optimizer"),
+            ckpt_cfg={field: value},
+        )
+
+        assert getattr(checkpoint_config, field) is value
+
+    def test_parallel_io_and_rng_knobs_absent_keep_historical_defaults(self, tmp_path):
+        """An empty checkpoint block keeps the historical hard-coded values."""
+        from nemo_rl.models.megatron.setup import _create_checkpoint_config
+
+        checkpoint_config = _create_checkpoint_config(
+            str(tmp_path / "pretrained"),
+            str(tmp_path / "weights"),
+            str(tmp_path / "optimizer"),
+            ckpt_cfg={},
+        )
+
+        assert checkpoint_config.fully_parallel_save is True
+        assert checkpoint_config.fully_parallel_load is True
+        assert checkpoint_config.load_rng is False
+
     def test_absent_ckpt_assume_constant_structure_uses_bridge_default(self, tmp_path):
         """ckpt_assume_constant_structure is omitted unless set in YAML."""
         from megatron.bridge.training.config import (


### PR DESCRIPTION
## Summary

**Stacks on #2390.** Completes the rest of the issue scope from #2229
that was deferred from #2390.

Three more Megatron-LM checkpoint knobs are now read from
\`policy.megatron_cfg\` instead of being hard-coded:

| Config key | Old hard-coded value | Why expose it |
|---|---|---|
| \`policy.megatron_cfg.fully_parallel_save\` | \`True\` | Some storage backends prefer the non-parallel path; disabling also simplifies debugging |
| \`policy.megatron_cfg.fully_parallel_load\` | \`True\` | Same — useful for both NFS quirks and step-by-step debugging |
| \`policy.megatron_cfg.load_rng\` | \`False\` | Enable to include/restore RNG state for bit-exact resume |

When unset the historical hard-coded behaviour is preserved exactly,
so existing user configs are untouched.

## Wiring

- \`_create_checkpoint_config()\` reads all three keys from the config
  it now receives (added by #2390).
- \`setup_reference_model_state()\` mirrors \`fully_parallel_load\` and
  \`load_rng\` so the reference model honours the same checkpoint-I/O
  preferences as the main model.

## Coverage

\`tests/unit/models/megatron/test_megatron_setup.py\`:

- \`test_parallelism_and_rng_flags_default_when_absent\` — verifies the
  three keys default to their historical values when omitted.
- \`test_parallelism_and_rng_flags_overridable_via_config\` — verifies
  that user values flow through the call.

The reference-model code path is exercised by the existing end-to-end
Megatron tests (no new heavy fixtures needed).

## Stacking note

This branch is built on top of the \`feat/2229-expose-megatron-infra-params\`
branch from #2390. Until #2390 merges, the diff GitHub shows here will
include #2390's changes too. After #2390 merges, this PR's diff will
narrow to only the additions documented above (~76 lines).

## Backward compatibility

All three new fields are typed \`NotRequired\`. Existing user configs
that don't set the keys see no behaviour change. The exemplar
\`grpo_math_1B_megatron.yaml\` is updated with commented-out examples
so users can copy/paste the right keys.

## Test plan

- [x] \`ruff check\` — clean
- [x] \`ruff format\` — clean
- [x] \`python3 -m py_compile\` — clean
- [ ] CI \`L0\` (\`L0_Unit_Tests_Other.sh\` runs the new test cases under
      \`--mcore-only\`)

Refs: #2229
Depends on: #2390