### PR TITLE
fix(dtensor): clear error when train/get_logprobs/score run offloaded

### DIFF
--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -226,6 +226,21 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
         self.offload_optimizer_for_logprob = self.cfg["offload_optimizer_for_logprob"]
         self.max_grad_norm = self.cfg["max_grad_norm"]
 
+        # Tracks whether the worker's weights have been *explicitly* offloaded
+        # to CPU via offload_after_refit. Control flow in lm_policy.py is
+        # expected to call prepare_for_training() or prepare_for_lp_inference()
+        # before any train()/get_logprobs()/score() call so weights are back
+        # on GPU. Custom training loops that skip the prepare step would
+        # otherwise crash inside CUDA with an opaque "illegal memory access"
+        # error; checking this flag at the entry of GPU-bound methods turns
+        # that into a clear RuntimeError pointing at the right fix
+        # (issue #1141).
+        #
+        # NOTE: this is distinct from the dtensor_cfg.cpu_offload mode, which
+        # keeps weights on CPU but transparently shuttles them per-layer.
+        # That mode is supported throughout and does not flip this flag.
+        self._weights_offloaded: bool = False
+
         if self.cfg["precision"] == "float32":
             self.dtype = torch.float32
         elif self.cfg["precision"] == "bfloat16":
@@ -554,6 +569,29 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
 
             yield
 
+    def _assert_weights_on_device(self, method_name: str) -> None:
+        """Surface a clear error when weights are still offloaded to CPU.
+
+        Without this guard, a follow-up CUDA op against the CPU-resident
+        weights crashes with an opaque "illegal memory access" — see
+        issue #1141. The hint points users at the prepare step they
+        skipped so the underlying contract is obvious from the message.
+        """
+        if self._weights_offloaded:
+            prepare_method = (
+                "prepare_for_training()"
+                if method_name == "train"
+                else "prepare_for_lp_inference()"
+            )
+            raise RuntimeError(
+                f"{method_name}() was called while the policy weights are "
+                "offloaded to CPU. This usually means a custom training loop "
+                f"forgot to call {prepare_method} after offload_after_refit(). "
+                "Call the appropriate prepare step before invoking "
+                f"{method_name}(); otherwise the underlying CUDA op will fail "
+                'with "illegal memory access". See issue #1141.'
+            )
+
     @wrap_with_nvtx_name("dtensor_policy_worker/train")
     def train(
         self,
@@ -564,6 +602,7 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
         mbs: Optional[int] = None,
     ) -> dict[str, Any]:
         """Train the policy on a batch of data with a given loss function."""
+        self._assert_weights_on_device("train")
         if gbs is None:
             gbs = self.cfg["train_global_batch_size"]
         if mbs is None:
@@ -977,6 +1016,7 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
           We use the convention that the logprob of the first token is 0 so that the sequence length is maintained.
           The logprob of input token i is specified at position i in the output logprobs tensor.
         """
+        self._assert_weights_on_device("get_logprobs")
         logprob_batch_size = (
             micro_batch_size
             if micro_batch_size is not None
@@ -1284,6 +1324,7 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
     # TODO @Rayen Tian: Related Issue: Refactor shared logic between score() and get_logprobs() (https://github.com/NVIDIA-NeMo/RL/issues/1094)
     @wrap_with_nvtx_name("dtensor_policy_worker/score")
     def score(self, data: BatchedDataDict) -> BatchedDataDict[ScoreOutputSpec]:
+        self._assert_weights_on_device("score")
         global_batch_size = min(self.cfg["batch_size"], data.size)
 
         sequence_dim = 1
@@ -1883,6 +1924,13 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
 
     @wrap_with_nvtx_name("dtensor_policy_worker/prepare_for_lp_inference")
     def prepare_for_lp_inference(self) -> None:
+        """Onload weights to GPU and switch the model to eval mode.
+
+        Must be called before ``get_logprobs()``/``score()`` whenever the
+        worker has been offloaded by ``offload_after_refit()``. Forgetting
+        this step would otherwise crash inside CUDA with an opaque
+        "illegal memory access" error (issue #1141).
+        """
         # onload model to cuda
         if not self.cpu_offload:
             self.move_to_cuda(self.model)
@@ -1898,9 +1946,19 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
 
         gc.collect()
         torch.cuda.empty_cache()
+        # Weights are now back on GPU; clear the offload flag so the
+        # entry-guard on train()/get_logprobs()/score() lets calls through.
+        self._weights_offloaded = False
 
     @wrap_with_nvtx_name("dtensor_policy_worker/prepare_for_training")
     def prepare_for_training(self, *args, **kwargs) -> None:
+        """Onload weights and optimizer state to GPU and switch to train mode.
+
+        Must be called before ``train()`` whenever the worker has been
+        offloaded by ``offload_after_refit()``. Forgetting this step would
+        otherwise crash inside CUDA with an opaque "illegal memory access"
+        error (issue #1141).
+        """
         # onload models and optimizer state to cuda
         if not self.cpu_offload:
             self.move_to_cuda(self.model)
@@ -1920,6 +1978,9 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
             self.move_optimizer_to_device("cuda")
 
         torch.cuda.empty_cache()
+        # Weights are now back on GPU; clear the offload flag so the
+        # entry-guard on train()/get_logprobs()/score() lets calls through.
+        self._weights_offloaded = False
 
     @torch.no_grad()
     @wrap_with_nvtx_name("dtensor_policy_worker/offload_before_refit")
@@ -1935,11 +1996,19 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
     @torch.no_grad()
     @wrap_with_nvtx_name("dtensor_policy_worker/offload_after_refit")
     def offload_after_refit(self) -> None:
-        """Offload as much as possible on the CPU."""
+        """Offload as much as possible on the CPU.
+
+        After this returns, weights live on CPU. Callers must invoke
+        ``prepare_for_training()`` or ``prepare_for_lp_inference()`` before
+        any subsequent ``train()``/``get_logprobs()``/``score()`` call;
+        otherwise the entry-guard on those methods raises a clear
+        ``RuntimeError`` (issue #1141).
+        """
         self.model = self.move_to_cpu(self.model)
         self.model.eval()
         torch.randn(1).cuda()  # wake up torch allocator
         self.offload_before_refit()  # rerun the old offload function
+        self._weights_offloaded = True
 
         # Print memory stats after offloading
         allocated = torch.cuda.memory_allocated() / (1024**3)  # Convert to GB

--- a/tests/unit/models/policy/test_dtensor_worker_offload_guard.py
+++ b/tests/unit/models/policy/test_dtensor_worker_offload_guard.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Lightweight unit tests for the DTensor worker's offload guard.
+
+These tests focus on the behavior of ``_assert_weights_on_device`` and do
+not spin up a real Ray worker, model, or GPU — the goal is to lock in the
+contract from issue #1141 (custom training loops that skip
+``prepare_for_*`` get a clear ``RuntimeError`` instead of a CUDA
+``illegal memory access``) at the L0 unit-test tier.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nemo_rl.models.policy.workers.dtensor_policy_worker import (
+    DTensorPolicyWorkerImpl,
+)
+
+
+def _make_worker_under_test(*, weights_offloaded: bool) -> DTensorPolicyWorkerImpl:
+    """Build a bare ``DTensorPolicyWorkerImpl`` instance without running
+    ``__init__``.
+
+    The full ``__init__`` requires Ray, distributed, and a model. We only
+    need to exercise the ``_assert_weights_on_device`` branch, which
+    depends solely on ``self._weights_offloaded``.
+    """
+    worker = DTensorPolicyWorkerImpl.__new__(DTensorPolicyWorkerImpl)
+    worker._weights_offloaded = weights_offloaded
+    return worker
+
+
+def test_assert_weights_on_device_passes_when_weights_on_gpu() -> None:
+    """When weights are on GPU, the guard is a no-op for any caller."""
+    worker = _make_worker_under_test(weights_offloaded=False)
+
+    # All three known callers must pass without raising.
+    worker._assert_weights_on_device("train")
+    worker._assert_weights_on_device("get_logprobs")
+    worker._assert_weights_on_device("score")
+
+
+def test_assert_weights_on_device_train_raises_with_helpful_message() -> None:
+    """train() should point users at prepare_for_training()."""
+    worker = _make_worker_under_test(weights_offloaded=True)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        worker._assert_weights_on_device("train")
+
+    msg = str(excinfo.value)
+    # The message must name the failing method, the prepare step that
+    # was skipped, and reference the underlying CUDA failure mode so
+    # users searching their logs land here.
+    assert "train()" in msg
+    assert "prepare_for_training()" in msg
+    assert "offload_after_refit()" in msg
+    assert "illegal memory access" in msg
+    assert "#1141" in msg
+
+
+@pytest.mark.parametrize("method_name", ["get_logprobs", "score"])
+def test_assert_weights_on_device_inference_raises_with_helpful_message(
+    method_name: str,
+) -> None:
+    """Inference-side methods should point at prepare_for_lp_inference()."""
+    worker = _make_worker_under_test(weights_offloaded=True)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        worker._assert_weights_on_device(method_name)
+
+    msg = str(excinfo.value)
+    assert f"{method_name}()" in msg
+    assert "prepare_for_lp_inference()" in msg
+    assert "offload_after_refit()" in msg


### PR DESCRIPTION
## Summary

Closes #1141 (dtensor path; mcore + dtensor-v2 are tracked as out-of-scope below).

Custom training loops sometimes skip \`prepare_for_training()\` /
\`prepare_for_lp_inference()\` after \`offload_after_refit()\` has been
called. The model is still on CPU, so the next \`train()\`,
\`get_logprobs()\`, or \`score()\` call drives a CUDA op against
CPU-resident weights and crashes with the opaque

\`\`\`
CUDA error: an illegal memory access was encountered
\`\`\`

There is no signal in that error pointing at the missing prepare step,
so debugging it is painful — especially for users writing their first
custom loop.

## Behavioural change

Track the offload state on the worker and surface a clear
\`RuntimeError\` at the entry of each GPU-bound public method:

\`\`\`
RuntimeError: train() was called while the policy weights are offloaded
to CPU. This usually means a custom training loop forgot to call
prepare_for_training() after offload_after_refit(). Call the
appropriate prepare step before invoking train(); otherwise the
underlying CUDA op will fail with "illegal memory access". See
issue #1141.
\`\`\`

The same shape of message is emitted for \`get_logprobs()\` and
\`score()\`, with the prepare step in the hint adjusted accordingly
(\`prepare_for_lp_inference()\` for both).

## Implementation

- Add \`self._weights_offloaded: bool\` (init \`False\`) on
  \`DTensorPolicyWorkerImpl\`.
- \`offload_after_refit()\` flips it \`True\`.
- \`prepare_for_training()\` and \`prepare_for_lp_inference()\` flip it
  back to \`False\` (and pick up docstrings that document the contract).
- New \`_assert_weights_on_device(method_name)\` helper raises the
  detailed \`RuntimeError\` when the flag is set.
- \`train()\`, \`get_logprobs()\`, \`score()\` call the helper as the
  first line of their body.

The flag is **only** about the explicit phase-level offload performed
by \`offload_after_refit()\`. The \`dtensor_cfg.cpu_offload\` mode
(which keeps weights on CPU but transparently shuttles them per-layer)
is unaffected — the flag stays \`False\` under that mode and the
existing behaviour is preserved exactly.

## Coverage

New \`tests/unit/models/policy/test_dtensor_worker_offload_guard.py\`:

- \`test_assert_weights_on_device_passes_when_weights_on_gpu\` — the
  guard is a no-op for all three callers when weights are on GPU.
- \`test_assert_weights_on_device_train_raises_with_helpful_message\` —
  validates the message names \`train()\`,
  \`prepare_for_training()\`, the underlying CUDA failure mode, and
  the issue number.
- \`test_assert_weights_on_device_inference_raises_with_helpful_message\`
  — parametrized over \`get_logprobs\` / \`score\`, validates the
  inference-side message points at \`prepare_for_lp_inference()\`.

The tests build a bare worker via \`__new__\` and patch the flag, so
they run at the L0 tier without Ray, distributed init, or a real
model.

## Out of scope

The same guard pattern would be useful in
\`megatron_policy_worker.py\` and \`dtensor_policy_worker_v2.py\`.
Those workers have a slightly different offload state model
(MegatronCore's own offload semantics, FSDP2 vs FSDP1, etc.) and
merit their own focused PRs. Documentation of the contract via
docstrings on the prepare/offload methods covers the most common path
in the meantime.

## Test plan

- [x] \`ruff check\` — clean
- [x] \`ruff format\` — clean
- [x] \`python3 -m py_compile\` — clean
- [ ] CI \`L0\` (\`L0_Unit_Tests_Other.sh\` runs the new test file).

Refs: #1141