### PR TITLE
fix(workers): extend offload guard to v2 + Megatron paths

### DIFF
--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -226,6 +226,21 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
         self.offload_optimizer_for_logprob = self.cfg["offload_optimizer_for_logprob"]
         self.max_grad_norm = self.cfg["max_grad_norm"]
 
+        # Tracks whether the worker's weights have been *explicitly* offloaded
+        # to CPU via offload_after_refit. Control flow in lm_policy.py is
+        # expected to call prepare_for_training() or prepare_for_lp_inference()
+        # before any train()/get_logprobs()/score() call so weights are back
+        # on GPU. Custom training loops that skip the prepare step would
+        # otherwise crash inside CUDA with an opaque "illegal memory access"
+        # error; checking this flag at the entry of GPU-bound methods turns
+        # that into a clear RuntimeError pointing at the right fix
+        # (issue #1141).
+        #
+        # NOTE: this is distinct from the dtensor_cfg.cpu_offload mode, which
+        # keeps weights on CPU but transparently shuttles them per-layer.
+        # That mode is supported throughout and does not flip this flag.
+        self._weights_offloaded: bool = False
+
         if self.cfg["precision"] == "float32":
             self.dtype = torch.float32
         elif self.cfg["precision"] == "bfloat16":
@@ -554,6 +569,29 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
 
             yield
 
+    def _assert_weights_on_device(self, method_name: str) -> None:
+        """Surface a clear error when weights are still offloaded to CPU.
+
+        Without this guard, a follow-up CUDA op against the CPU-resident
+        weights crashes with an opaque "illegal memory access" — see
+        issue #1141. The hint points users at the prepare step they
+        skipped so the underlying contract is obvious from the message.
+        """
+        if self._weights_offloaded:
+            prepare_method = (
+                "prepare_for_training()"
+                if method_name == "train"
+                else "prepare_for_lp_inference()"
+            )
+            raise RuntimeError(
+                f"{method_name}() was called while the policy weights are "
+                "offloaded to CPU. This usually means a custom training loop "
+                f"forgot to call {prepare_method} after offload_after_refit(). "
+                "Call the appropriate prepare step before invoking "
+                f"{method_name}(); otherwise the underlying CUDA op will fail "
+                'with "illegal memory access". See issue #1141.'
+            )
+
     @wrap_with_nvtx_name("dtensor_policy_worker/train")
     def train(
         self,
@@ -564,6 +602,7 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
         mbs: Optional[int] = None,
     ) -> dict[str, Any]:
         """Train the policy on a batch of data with a given loss function."""
+        self._assert_weights_on_device("train")
         if gbs is None:
             gbs = self.cfg["train_global_batch_size"]
         if mbs is None:
@@ -977,6 +1016,7 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
           We use the convention that the logprob of the first token is 0 so that the sequence length is maintained.
           The logprob of input token i is specified at position i in the output logprobs tensor.
         """
+        self._assert_weights_on_device("get_logprobs")
         logprob_batch_size = (
             micro_batch_size
             if micro_batch_size is not None
@@ -1284,6 +1324,7 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
     # TODO @Rayen Tian: Related Issue: Refactor shared logic between score() and get_logprobs() (https://github.com/NVIDIA-NeMo/RL/issues/1094)
     @wrap_with_nvtx_name("dtensor_policy_worker/score")
     def score(self, data: BatchedDataDict) -> BatchedDataDict[ScoreOutputSpec]:
+        self._assert_weights_on_device("score")
         global_batch_size = min(self.cfg["batch_size"], data.size)
 
         sequence_dim = 1
@@ -1883,6 +1924,13 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
 
     @wrap_with_nvtx_name("dtensor_policy_worker/prepare_for_lp_inference")
     def prepare_for_lp_inference(self) -> None:
+        """Onload weights to GPU and switch the model to eval mode.
+
+        Must be called before ``get_logprobs()``/``score()`` whenever the
+        worker has been offloaded by ``offload_after_refit()``. Forgetting
+        this step would otherwise crash inside CUDA with an opaque
+        "illegal memory access" error (issue #1141).
+        """
         # onload model to cuda
         if not self.cpu_offload:
             self.move_to_cuda(self.model)
@@ -1898,9 +1946,19 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
 
         gc.collect()
         torch.cuda.empty_cache()
+        # Weights are now back on GPU; clear the offload flag so the
+        # entry-guard on train()/get_logprobs()/score() lets calls through.
+        self._weights_offloaded = False
 
     @wrap_with_nvtx_name("dtensor_policy_worker/prepare_for_training")
     def prepare_for_training(self, *args, **kwargs) -> None:
+        """Onload weights and optimizer state to GPU and switch to train mode.
+
+        Must be called before ``train()`` whenever the worker has been
+        offloaded by ``offload_after_refit()``. Forgetting this step would
+        otherwise crash inside CUDA with an opaque "illegal memory access"
+        error (issue #1141).
+        """
         # onload models and optimizer state to cuda
         if not self.cpu_offload:
             self.move_to_cuda(self.model)
@@ -1920,6 +1978,9 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
             self.move_optimizer_to_device("cuda")
 
         torch.cuda.empty_cache()
+        # Weights are now back on GPU; clear the offload flag so the
+        # entry-guard on train()/get_logprobs()/score() lets calls through.
+        self._weights_offloaded = False
 
     @torch.no_grad()
     @wrap_with_nvtx_name("dtensor_policy_worker/offload_before_refit")
@@ -1935,11 +1996,19 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
     @torch.no_grad()
     @wrap_with_nvtx_name("dtensor_policy_worker/offload_after_refit")
     def offload_after_refit(self) -> None:
-        """Offload as much as possible on the CPU."""
+        """Offload as much as possible on the CPU.
+
+        After this returns, weights live on CPU. Callers must invoke
+        ``prepare_for_training()`` or ``prepare_for_lp_inference()`` before
+        any subsequent ``train()``/``get_logprobs()``/``score()`` call;
+        otherwise the entry-guard on those methods raises a clear
+        ``RuntimeError`` (issue #1141).
+        """
         self.model = self.move_to_cpu(self.model)
         self.model.eval()
         torch.randn(1).cuda()  # wake up torch allocator
         self.offload_before_refit()  # rerun the old offload function
+        self._weights_offloaded = True
 
         # Print memory stats after offloading
         allocated = torch.cuda.memory_allocated() / (1024**3)  # Convert to GB

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -1467,6 +1467,7 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
         - Supports context parallelism with proper CP gather.
         - Otherwise, computes local top-k on full-vocab tensor.
         """
+        self._assert_weights_on_device("get_topk_logits")
         topk_batch_size = (
             micro_batch_size
             if micro_batch_size is not None

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -1533,6 +1533,7 @@ class DTensorPolicyWorkerImpl(
         - Supports context parallelism with proper CP gather.
         - Otherwise, computes local top-k on full-vocab tensor.
         """
+        self._assert_weights_on_device("get_topk_logits")
         self.timer.start("get_topk_logits")
         topk_batch_size = (
             micro_batch_size

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -274,6 +274,21 @@ class DTensorPolicyWorkerImpl(
         self.offload_optimizer_for_logprob = self.cfg["offload_optimizer_for_logprob"]
         self.max_grad_norm = self.cfg["max_grad_norm"]
 
+        # Tracks whether the worker's weights have been *explicitly* offloaded
+        # to CPU via offload_after_refit. Control flow in lm_policy.py is
+        # expected to call prepare_for_training() or prepare_for_lp_inference()
+        # before any train()/get_logprobs()/score() call so weights are back
+        # on GPU. Custom training loops that skip the prepare step would
+        # otherwise crash inside CUDA with an opaque "illegal memory access"
+        # error; checking this flag at the entry of GPU-bound methods turns
+        # that into a clear RuntimeError pointing at the right fix
+        # (issue #1141).
+        #
+        # NOTE: this is distinct from the dtensor_cfg.cpu_offload mode, which
+        # keeps weights on CPU but transparently shuttles them per-layer.
+        # That mode is supported throughout and does not flip this flag.
+        self._weights_offloaded: bool = False
+
         if self.cfg["precision"] == "float32":
             self.dtype = torch.float32
         elif self.cfg["precision"] == "bfloat16":
@@ -603,6 +618,29 @@ class DTensorPolicyWorkerImpl(
 
             yield
 
+    def _assert_weights_on_device(self, method_name: str) -> None:
+        """Surface a clear error when weights are still offloaded to CPU.
+
+        Without this guard, a follow-up CUDA op against the CPU-resident
+        weights crashes with an opaque "illegal memory access" — see
+        issue #1141. The hint points users at the prepare step they
+        skipped so the underlying contract is obvious from the message.
+        """
+        if self._weights_offloaded:
+            prepare_method = (
+                "prepare_for_training()"
+                if method_name == "train"
+                else "prepare_for_lp_inference()"
+            )
+            raise RuntimeError(
+                f"{method_name}() was called while the policy weights are "
+                "offloaded to CPU. This usually means a custom training loop "
+                f"forgot to call {prepare_method} after offload_after_refit(). "
+                "Call the appropriate prepare step before invoking "
+                f"{method_name}(); otherwise the underlying CUDA op will fail "
+                'with "illegal memory access". See issue #1141.'
+            )
+
     @wrap_with_nvtx_name("dtensor_policy_worker/train")
     def train(
         self,
@@ -614,6 +652,7 @@ class DTensorPolicyWorkerImpl(
         check_dim_skip_keys: Optional[Iterable[str]] = None,
     ) -> dict[str, Any]:
         """Train the policy on a batch of data with a given loss function."""
+        self._assert_weights_on_device("train")
         self.timer.start("train")
         if gbs is None:
             gbs = self.cfg["train_global_batch_size"]
@@ -1040,6 +1079,7 @@ class DTensorPolicyWorkerImpl(
           We use the convention that the logprob of the first token is 0 so that the sequence length is maintained.
           The logprob of input token i is specified at position i in the output logprobs tensor.
         """
+        self._assert_weights_on_device("get_logprobs")
         self.timer.start("get_logprobs")
         logprob_batch_size = (
             micro_batch_size
@@ -1350,6 +1390,7 @@ class DTensorPolicyWorkerImpl(
     # TODO @Rayen Tian: Related Issue: Refactor shared logic between score() and get_logprobs() (https://github.com/NVIDIA-NeMo/RL/issues/1094)
     @wrap_with_nvtx_name("dtensor_policy_worker/score")
     def score(self, data: BatchedDataDict) -> BatchedDataDict[ScoreOutputSpec]:
+        self._assert_weights_on_device("score")
         global_batch_size = min(self.cfg["batch_size"], data.size)
 
         sequence_dim = 1
@@ -2010,9 +2051,19 @@ class DTensorPolicyWorkerImpl(
 
         gc.collect()
         torch.cuda.empty_cache()
+        # Weights are now back on GPU; clear the offload flag so the
+        # entry-guard on train()/get_logprobs()/score() lets calls through.
+        self._weights_offloaded = False
 
     @wrap_with_nvtx_name("dtensor_policy_worker/prepare_for_training")
     def prepare_for_training(self, *args, **kwargs) -> None:
+        """Onload weights and optimizer state to GPU and switch to train mode.
+
+        Must be called before ``train()`` whenever the worker has been
+        offloaded by ``offload_after_refit()``. Forgetting this step would
+        otherwise crash inside CUDA with an opaque "illegal memory access"
+        error (issue #1141).
+        """
         # onload models and optimizer state to cuda
         if not self.cpu_offload:
             self.move_to_cuda(self.model)
@@ -2029,6 +2080,9 @@ class DTensorPolicyWorkerImpl(
             self.move_optimizer_to_device("cuda")
 
         torch.cuda.empty_cache()
+        # Weights are now back on GPU; clear the offload flag so the
+        # entry-guard on train()/get_logprobs()/score() lets calls through.
+        self._weights_offloaded = False
 
     @torch.no_grad()
     @wrap_with_nvtx_name("dtensor_policy_worker/offload_before_refit")
@@ -2046,12 +2100,20 @@ class DTensorPolicyWorkerImpl(
     @torch.no_grad()
     @wrap_with_nvtx_name("dtensor_policy_worker/offload_after_refit")
     def offload_after_refit(self) -> None:
-        """Offload as much as possible on the CPU."""
+        """Offload as much as possible on the CPU.
+
+        After this returns, weights live on CPU. Callers must invoke
+        ``prepare_for_training()`` or ``prepare_for_lp_inference()`` before
+        any subsequent ``train()``/``get_logprobs()``/``score()`` call;
+        otherwise the entry-guard on those methods raises a clear
+        ``RuntimeError`` (issue #1141).
+        """
         self.timer.start("offload_after_refit")
         self.model = self.move_to_cpu(self.model)
         self.model.eval()
         torch.randn(1).cuda()  # wake up torch allocator
         self.offload_before_refit()  # rerun the old offload function
+        self._weights_offloaded = True
 
         # Print memory stats after offloading
         allocated = torch.cuda.memory_allocated() / (1024**3)  # Convert to GB

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -715,6 +715,7 @@ class DTensorPolicyWorkerV2Impl(AbstractPolicyWorker, ColocatablePolicyInterface
         - Supports context parallelism with proper CP gather.
         - Otherwise, computes local top-k on full-vocab tensor.
         """
+        self._assert_weights_on_device("get_topk_logits")
         topk_batch_size = (
             micro_batch_size
             if micro_batch_size is not None

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -324,6 +324,37 @@ class DTensorPolicyWorkerV2Impl(AbstractPolicyWorker, ColocatablePolicyInterface
             _runtime_is_reward_model,  # Duplicate, already set as _is_reward_model
         ) = runtime_config
 
+        # Tracks the explicit phase-level offload performed by
+        # offload_after_refit(). The entry-guard on train()/get_logprobs()/
+        # score() turns the otherwise-opaque CUDA "illegal memory access"
+        # crash into a clear RuntimeError pointing at the missing prepare
+        # step (issue #1141). Distinct from dtensor_cfg.cpu_offload, which
+        # transparently shuttles weights per-layer and stays compatible
+        # with the same guard.
+        self._weights_offloaded: bool = False
+
+    def _assert_weights_on_device(self, method_name: str) -> None:
+        """Surface a clear error when weights are still offloaded to CPU.
+
+        Without this guard, a follow-up CUDA op against the CPU-resident
+        weights crashes with an opaque "illegal memory access" — see
+        issue #1141.
+        """
+        if self._weights_offloaded:
+            prepare_method = (
+                "prepare_for_training()"
+                if method_name == "train"
+                else "prepare_for_lp_inference()"
+            )
+            raise RuntimeError(
+                f"{method_name}() was called while the policy weights are "
+                "offloaded to CPU. This usually means a custom training loop "
+                f"forgot to call {prepare_method} after offload_after_refit(). "
+                "Call the appropriate prepare step before invoking "
+                f"{method_name}(); otherwise the underlying CUDA op will fail "
+                'with "illegal memory access". See issue #1141.'
+            )
+
     @wrap_with_nvtx_name("dtensor_policy_worker_v2/train")
     def train(
         self,
@@ -334,6 +365,7 @@ class DTensorPolicyWorkerV2Impl(AbstractPolicyWorker, ColocatablePolicyInterface
         mbs: Optional[int] = None,
     ) -> dict[str, Any]:
         """Train the policy on a batch of data with a given loss function."""
+        self._assert_weights_on_device("train")
         if gbs is None:
             gbs = self.cfg["train_global_batch_size"]
         if mbs is None:
@@ -523,6 +555,7 @@ class DTensorPolicyWorkerV2Impl(AbstractPolicyWorker, ColocatablePolicyInterface
           We use the convention that the logprob of the first token is 0 so that the sequence length is maintained.
           The logprob of input token i is specified at position i in the output logprobs tensor.
         """
+        self._assert_weights_on_device("get_logprobs")
         logprob_batch_size = (
             micro_batch_size
             if micro_batch_size is not None
@@ -603,6 +636,7 @@ class DTensorPolicyWorkerV2Impl(AbstractPolicyWorker, ColocatablePolicyInterface
 
     @wrap_with_nvtx_name("dtensor_policy_worker_v2/score")
     def score(self, data: BatchedDataDict) -> BatchedDataDict[ScoreOutputSpec]:
+        self._assert_weights_on_device("score")
         global_batch_size = min(self.cfg["batch_size"], data.size)
 
         # Validate sequence dimension
@@ -989,6 +1023,11 @@ class DTensorPolicyWorkerV2Impl(AbstractPolicyWorker, ColocatablePolicyInterface
 
     @wrap_with_nvtx_name("dtensor_policy_worker_v2/prepare_for_lp_inference")
     def prepare_for_lp_inference(self) -> None:
+        """Onload weights to GPU and switch the model to eval mode.
+
+        Must be called before ``get_logprobs()``/``score()`` whenever the
+        worker has been offloaded by ``offload_after_refit()`` (issue #1141).
+        """
         # onload model to cuda
         if not self.cpu_offload:
             self.move_to_cuda(self.model)
@@ -1004,9 +1043,15 @@ class DTensorPolicyWorkerV2Impl(AbstractPolicyWorker, ColocatablePolicyInterface
 
         gc.collect()
         torch.cuda.empty_cache()
+        self._weights_offloaded = False
 
     @wrap_with_nvtx_name("dtensor_policy_worker_v2/prepare_for_training")
     def prepare_for_training(self, *args, **kwargs) -> None:
+        """Onload weights and optimizer state to GPU and switch to train mode.
+
+        Must be called before ``train()`` whenever the worker has been
+        offloaded by ``offload_after_refit()`` (issue #1141).
+        """
         # onload models and optimizer state to cuda
         if not self.cpu_offload:
             self.move_to_cuda(self.model)
@@ -1026,6 +1071,7 @@ class DTensorPolicyWorkerV2Impl(AbstractPolicyWorker, ColocatablePolicyInterface
             self.move_optimizer_to_device("cuda")
 
         torch.cuda.empty_cache()
+        self._weights_offloaded = False
 
     @torch.no_grad()
     @wrap_with_nvtx_name("dtensor_policy_worker_v2/offload_before_refit")
@@ -1041,7 +1087,14 @@ class DTensorPolicyWorkerV2Impl(AbstractPolicyWorker, ColocatablePolicyInterface
     @torch.no_grad()
     @wrap_with_nvtx_name("dtensor_policy_worker_v2/offload_after_refit")
     def offload_after_refit(self) -> None:
-        """Offload as much as possible on the CPU."""
+        """Offload as much as possible on the CPU.
+
+        After this returns, weights live on CPU. Callers must invoke
+        ``prepare_for_training()`` or ``prepare_for_lp_inference()`` before
+        any subsequent ``train()``/``get_logprobs()``/``score()`` call;
+        otherwise the entry-guard on those methods raises a clear
+        ``RuntimeError`` (issue #1141).
+        """
         self.model = self.move_to_cpu(self.model)
         self.model.eval()
         torch.randn(1).cuda()  # wake up torch allocator
@@ -1053,6 +1106,7 @@ class DTensorPolicyWorkerV2Impl(AbstractPolicyWorker, ColocatablePolicyInterface
         print(
             f"GPU Memory after optimizer offload: {allocated:.2f}GB allocated, {reserved:.2f}GB reserved"
         )
+        self._weights_offloaded = True
 
     def move_optimizer_to_device(self, device: str | torch.device) -> None:
         for state in self.optimizer.state.values():

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -770,6 +770,7 @@ class DTensorPolicyWorkerV2Impl(
         - Supports context parallelism with proper CP gather.
         - Otherwise, computes local top-k on full-vocab tensor.
         """
+        self._assert_weights_on_device("get_topk_logits")
         topk_batch_size = (
             micro_batch_size
             if micro_batch_size is not None

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -373,6 +373,36 @@ class DTensorPolicyWorkerV2Impl(
             _runtime_is_reward_model,  # Duplicate, already set as _is_reward_model
         ) = runtime_config
 
+        # Tracks the explicit phase-level offload performed by
+        # offload_after_refit(). The entry-guard on train()/get_logprobs()/
+        # score() turns the otherwise-opaque CUDA "illegal memory access"
+        # crash into a clear RuntimeError pointing at the missing prepare
+        # step (issue #1141). Distinct from dtensor_cfg.cpu_offload, which
+        # transparently shuttles weights per-layer and stays compatible
+        # with the same guard.
+        self._weights_offloaded: bool = False
+
+    def _assert_weights_on_device(self, method_name: str) -> None:
+        """Surface a clear error when weights are still offloaded to CPU.
+
+        Without this guard, a follow-up CUDA op against the CPU-resident
+        weights crashes with an opaque "illegal memory access" — see
+        issue #1141.
+        """
+        if self._weights_offloaded:
+            prepare_method = (
+                "prepare_for_training()"
+                if method_name == "train"
+                else "prepare_for_lp_inference()"
+            )
+            raise RuntimeError(
+                f"{method_name}() was called while the policy weights are "
+                "offloaded to CPU. This usually means a custom training loop "
+                f"forgot to call {prepare_method} after offload_after_refit(). "
+                "Call the appropriate prepare step before invoking "
+                f"{method_name}(); otherwise the underlying CUDA op will fail "
+                'with "illegal memory access". See issue #1141.'
+            )
     def _update_moe_gate_bias_if_supported(self) -> None:
         """Update the non-gradient MoE routing bias after the optimizer step."""
         update_moe_gate_bias = getattr(self.model, "update_moe_gate_bias", None)
@@ -400,6 +430,7 @@ class DTensorPolicyWorkerV2Impl(
         check_dim_skip_keys: Optional[Iterable[str]] = None,
     ) -> dict[str, Any]:
         """Train the policy on a batch of data with a given loss function."""
+        self._assert_weights_on_device("train")
         self.timer.start("train")
         if gbs is None:
             gbs = self.cfg["train_global_batch_size"]
@@ -581,6 +612,7 @@ class DTensorPolicyWorkerV2Impl(
           We use the convention that the logprob of the first token is 0 so that the sequence length is maintained.
           The logprob of input token i is specified at position i in the output logprobs tensor.
         """
+        self._assert_weights_on_device("get_logprobs")
         self.timer.start("get_logprobs")
         logprob_batch_size = (
             micro_batch_size
@@ -659,6 +691,7 @@ class DTensorPolicyWorkerV2Impl(
 
     @wrap_with_nvtx_name("dtensor_policy_worker_v2/score")
     def score(self, data: BatchedDataDict) -> BatchedDataDict[ScoreOutputSpec]:
+        self._assert_weights_on_device("score")
         global_batch_size = min(self.cfg["batch_size"], data.size)
 
         # Validate sequence dimension
@@ -1253,9 +1286,15 @@ class DTensorPolicyWorkerV2Impl(
 
         gc.collect()
         torch.cuda.empty_cache()
+        self._weights_offloaded = False
 
     @wrap_with_nvtx_name("dtensor_policy_worker_v2/prepare_for_training")
     def prepare_for_training(self, *args, **kwargs) -> None:
+        """Onload weights and optimizer state to GPU and switch to train mode.
+
+        Must be called before ``train()`` whenever the worker has been
+        offloaded by ``offload_after_refit()`` (issue #1141).
+        """
         # onload models and optimizer state to cuda
         if not self.cpu_offload:
             self.move_to_cuda(self.model)
@@ -1272,6 +1311,7 @@ class DTensorPolicyWorkerV2Impl(
             self.move_optimizer_to_device("cuda")
 
         torch.cuda.empty_cache()
+        self._weights_offloaded = False
 
     def finish_inference(self) -> None:
         """Offload model params to CPU after inference. Only used in PPO."""
@@ -1295,7 +1335,14 @@ class DTensorPolicyWorkerV2Impl(
     @torch.no_grad()
     @wrap_with_nvtx_name("dtensor_policy_worker_v2/offload_after_refit")
     def offload_after_refit(self) -> None:
-        """Offload as much as possible on the CPU."""
+        """Offload as much as possible on the CPU.
+
+        After this returns, weights live on CPU. Callers must invoke
+        ``prepare_for_training()`` or ``prepare_for_lp_inference()`` before
+        any subsequent ``train()``/``get_logprobs()``/``score()`` call;
+        otherwise the entry-guard on those methods raises a clear
+        ``RuntimeError`` (issue #1141).
+        """
         self.model = self.move_to_cpu(self.model)
         self.model.eval()
         torch.randn(1).cuda()  # wake up torch allocator
@@ -1307,6 +1354,7 @@ class DTensorPolicyWorkerV2Impl(
         print(
             f"GPU Memory after optimizer offload: {allocated:.2f}GB allocated, {reserved:.2f}GB reserved"
         )
+        self._weights_offloaded = True
 
     def move_optimizer_to_device(self, device: str | torch.device) -> None:
         for state in self.optimizer.state.values():

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -237,6 +237,28 @@ class MegatronPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface)
         assert isinstance(self.model, DistributedDataParallel)
         self.model.disable_forward_pre_hook(param_sync=param_sync)
 
+    def _assert_weights_on_device(self, method_name: str) -> None:
+        """Surface a clear error when weights are still offloaded to CPU.
+
+        Without this guard, a follow-up CUDA op against the CPU-resident
+        weights crashes with an opaque "illegal memory access" — see
+        issue #1141.
+        """
+        if getattr(self, "_weights_offloaded", False):
+            prepare_method = (
+                "prepare_for_training()"
+                if method_name == "train"
+                else "prepare_for_lp_inference()"
+            )
+            raise RuntimeError(
+                f"{method_name}() was called while the policy weights are "
+                "offloaded to CPU. This usually means a custom training loop "
+                f"forgot to call {prepare_method} after offload_after_refit(). "
+                "Call the appropriate prepare step before invoking "
+                f"{method_name}(); otherwise the underlying CUDA op will fail "
+                'with "illegal memory access". See issue #1141.'
+            )
+
     @wrap_with_nvtx_name("megatron_policy_worker/train")
     def train(
         self,
@@ -247,6 +269,7 @@ class MegatronPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface)
         mbs: Optional[int] = None,
     ) -> dict[str, Any]:
         """Train the policy on a batch of data with a given loss function."""
+        self._assert_weights_on_device("train")
         # Note: zero_grad_buffer is called at the start of each global batch iteration
         # in the loop below, so we don't need to call it here.
         if hasattr(self.model, "inference_params"):
@@ -462,6 +485,7 @@ class MegatronPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface)
           We use the convention that the logprob of the first token is 0 so that the sequence length is maintained.
           The logprob of input token i is specified at position i in the output logprobs tensor.
         """
+        self._assert_weights_on_device("get_logprobs")
         no_grad = torch.no_grad()
         no_grad.__enter__()
         logprob_batch_size = (
@@ -1110,6 +1134,11 @@ class MegatronPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface)
         )
 
     def prepare_for_lp_inference(self):
+        """Onload weights to GPU and switch the model to eval mode.
+
+        Must be called before ``get_logprobs()`` whenever the worker has been
+        offloaded by ``offload_after_refit()`` (issue #1141).
+        """
         self.model = self.move_model(self.model, "cuda", move_grads=False)
         self.model.eval()
 
@@ -1130,8 +1159,14 @@ class MegatronPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface)
 
         gc.collect()
         torch.cuda.empty_cache()
+        self._weights_offloaded = False
 
     def prepare_for_training(self, *args, **kwargs):
+        """Onload weights and optimizer state to GPU and switch to train mode.
+
+        Must be called before ``train()`` whenever the worker has been
+        offloaded by ``offload_after_refit()`` (issue #1141).
+        """
         # onload models and optimizer state to cuda
         self.model = self.move_model(
             self.model, "cuda", move_grads=True, move_params=True
@@ -1150,6 +1185,7 @@ class MegatronPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface)
 
         if self.cfg["megatron_cfg"]["empty_unused_memory_level"] >= 1:
             torch.cuda.empty_cache()
+        self._weights_offloaded = False
 
     @wrap_with_nvtx_name("megatron_policy_worker/offload_before_refit")
     def offload_before_refit(self):
@@ -1185,7 +1221,14 @@ class MegatronPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface)
 
     @wrap_with_nvtx_name("megatron_policy_worker/offload_after_refit")
     def offload_after_refit(self):
-        """Offload as much as possible on the CPU."""
+        """Offload as much as possible on the CPU.
+
+        After this returns, weights live on CPU. Callers must invoke
+        ``prepare_for_training()`` or ``prepare_for_lp_inference()`` before
+        any subsequent ``train()``/``get_logprobs()`` call; otherwise the
+        entry-guard on those methods raises a clear ``RuntimeError``
+        (issue #1141).
+        """
         no_grad = torch.no_grad()
         no_grad.__enter__()
         self.model = self.move_model(self.model, "cpu")
@@ -1199,6 +1242,7 @@ class MegatronPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface)
             f"GPU Memory after refit complete: {allocated:.2f}GB allocated, {reserved:.2f}GB reserved"
         )
         no_grad.__exit__(None, None, None)
+        self._weights_offloaded = True
 
     @torch.no_grad()
     def move_model(

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -689,6 +689,7 @@ class MegatronPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface)
                 - topk_logits: Tensor of top-k logits for each position in the sequence
                 - topk_indices: Tensor of top-k indices for each position in the sequence
         """
+        self._assert_weights_on_device("get_topk_logits")
         no_grad = torch.no_grad()
         no_grad.__enter__()
 
@@ -776,6 +777,7 @@ class MegatronPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface)
                 - logprobs: Log probabilities for each token
                 - generation_lengths: Lengths of each response
         """
+        self._assert_weights_on_device("generate")
         # 512 bATCH SIZE (200 tokens)
         no_grad = torch.no_grad()
         no_grad.__enter__()

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -2114,6 +2114,7 @@ class MegatronPolicyWorkerImpl(
                 - topk_logits: Tensor of top-k logits for each position in the sequence
                 - topk_indices: Tensor of top-k indices for each position in the sequence
         """
+        self._assert_weights_on_device("get_topk_logits")
         no_grad = torch.no_grad()
         no_grad.__enter__()
 

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -711,6 +711,27 @@ class MegatronPolicyWorkerImpl(
             self._copy_main_params_to_param_buffer(zero_grad_buffer=True)
         self.model.disable_forward_pre_hook(param_sync=param_sync)
 
+    def _assert_weights_on_device(self, method_name: str) -> None:
+        """Surface a clear error when weights are still offloaded to CPU.
+
+        Without this guard, a follow-up CUDA op against the CPU-resident
+        weights crashes with an opaque "illegal memory access" — see
+        issue #1141.
+        """
+        if getattr(self, "_weights_offloaded", False):
+            prepare_method = (
+                "prepare_for_training()"
+                if method_name == "train"
+                else "prepare_for_lp_inference()"
+            )
+            raise RuntimeError(
+                f"{method_name}() was called while the policy weights are "
+                "offloaded to CPU. This usually means a custom training loop "
+                f"forgot to call {prepare_method} after offload_after_refit(). "
+                "Call the appropriate prepare step before invoking "
+                f"{method_name}(); otherwise the underlying CUDA op will fail "
+                'with "illegal memory access". See issue #1141.'
+            )
     def _forward_pre_hook_enabled(self) -> bool:
         if not isinstance(self.model, DistributedDataParallel):
             return False
@@ -794,6 +815,7 @@ class MegatronPolicyWorkerImpl(
             "check_dim_skip_keys is only supported by the v2 DTensor worker; "
             "Megatron does not run cross-tokenizer distillation."
         )
+        self._assert_weights_on_device("train")
         self.timer.start("train")
         # Note: zero_grad_buffer is called at the start of each global batch iteration
         # in the loop below, so we don't need to call it here.
@@ -1867,6 +1889,7 @@ class MegatronPolicyWorkerImpl(
           We use the convention that the logprob of the first token is 0 so that the sequence length is maintained.
           The logprob of input token i is specified at position i in the output logprobs tensor.
         """
+        self._assert_weights_on_device("get_logprobs")
         self.timer.start("get_logprobs")
         no_grad = torch.no_grad()
         no_grad.__enter__()
@@ -3291,6 +3314,7 @@ class MegatronPolicyWorkerImpl(
 
         gc.collect()
         torch.cuda.empty_cache()
+        self._weights_offloaded = False
         self._log_gpu_mem("lp_prep_exit")
 
     def _build_colocated_inference_model(self, config: PolicyConfig) -> None:
@@ -3317,6 +3341,11 @@ class MegatronPolicyWorkerImpl(
         self._colocated_reshard_plan = None
 
     def prepare_for_training(self, *args, **kwargs):
+        """Onload weights and optimizer state to GPU and switch to train mode.
+
+        Must be called before ``train()`` whenever the worker has been
+        offloaded by ``offload_after_refit()`` (issue #1141).
+        """
         # onload models and optimizer state to cuda
         self.model = self.move_model(
             self.model, "cuda", move_grads=True, move_params=True
@@ -3334,6 +3363,7 @@ class MegatronPolicyWorkerImpl(
 
         if self.cfg["megatron_cfg"]["empty_unused_memory_level"] >= 1:
             torch.cuda.empty_cache()
+        self._weights_offloaded = False
         # The interval peak reported here covers the logprob phase and the
         # grad/optimizer onload, which is the figure that decides whether keeping
         # the train buffers resident fits in HBM.
@@ -3473,7 +3503,14 @@ class MegatronPolicyWorkerImpl(
 
     @wrap_with_nvtx_name("megatron_policy_worker/offload_after_refit")
     def offload_after_refit(self):
-        """Offload as much as possible on the CPU."""
+        """Offload as much as possible on the CPU.
+
+        After this returns, weights live on CPU. Callers must invoke
+        ``prepare_for_training()`` or ``prepare_for_lp_inference()`` before
+        any subsequent ``train()``/``get_logprobs()`` call; otherwise the
+        entry-guard on those methods raises a clear ``RuntimeError``
+        (issue #1141).
+        """
         # Finalize before replacing model-buffer storage. With cached NVRx async
         # saves, the persistent writer otherwise retains CUDA IPC handles to the
         # old storage after the model is moved to CPU.
@@ -3503,6 +3540,7 @@ class MegatronPolicyWorkerImpl(
             f"GPU Memory after refit complete: {allocated:.2f}GB allocated, {reserved:.2f}GB reserved"
         )
         no_grad.__exit__(None, None, None)
+        self._weights_offloaded = True
 
     @torch.no_grad()
     def move_model(

--- a/tests/unit/models/policy/test_dtensor_worker_offload_guard.py
+++ b/tests/unit/models/policy/test_dtensor_worker_offload_guard.py
@@ -46,10 +46,11 @@ def test_assert_weights_on_device_passes_when_weights_on_gpu() -> None:
     """When weights are on GPU, the guard is a no-op for any caller."""
     worker = _make_worker_under_test(weights_offloaded=False)
 
-    # All three known callers must pass without raising.
+    # All four known GPU-bound callers must pass without raising.
     worker._assert_weights_on_device("train")
     worker._assert_weights_on_device("get_logprobs")
     worker._assert_weights_on_device("score")
+    worker._assert_weights_on_device("get_topk_logits")
 
 
 def test_assert_weights_on_device_train_raises_with_helpful_message() -> None:
@@ -70,7 +71,7 @@ def test_assert_weights_on_device_train_raises_with_helpful_message() -> None:
     assert "#1141" in msg
 
 
-@pytest.mark.parametrize("method_name", ["get_logprobs", "score"])
+@pytest.mark.parametrize("method_name", ["get_logprobs", "score", "get_topk_logits"])
 def test_assert_weights_on_device_inference_raises_with_helpful_message(
     method_name: str,
 ) -> None:

--- a/tests/unit/models/policy/test_dtensor_worker_offload_guard.py
+++ b/tests/unit/models/policy/test_dtensor_worker_offload_guard.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Lightweight unit tests for the DTensor worker's offload guard.
+
+These tests focus on the behavior of ``_assert_weights_on_device`` and do
+not spin up a real Ray worker, model, or GPU — the goal is to lock in the
+contract from issue #1141 (custom training loops that skip
+``prepare_for_*`` get a clear ``RuntimeError`` instead of a CUDA
+``illegal memory access``) at the L0 unit-test tier.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nemo_rl.models.policy.workers.dtensor_policy_worker import (
+    DTensorPolicyWorkerImpl,
+)
+
+
+def _make_worker_under_test(*, weights_offloaded: bool) -> DTensorPolicyWorkerImpl:
+    """Build a bare ``DTensorPolicyWorkerImpl`` instance without running
+    ``__init__``.
+
+    The full ``__init__`` requires Ray, distributed, and a model. We only
+    need to exercise the ``_assert_weights_on_device`` branch, which
+    depends solely on ``self._weights_offloaded``.
+    """
+    worker = DTensorPolicyWorkerImpl.__new__(DTensorPolicyWorkerImpl)
+    worker._weights_offloaded = weights_offloaded
+    return worker
+
+
+def test_assert_weights_on_device_passes_when_weights_on_gpu() -> None:
+    """When weights are on GPU, the guard is a no-op for any caller."""
+    worker = _make_worker_under_test(weights_offloaded=False)
+
+    # All three known callers must pass without raising.
+    worker._assert_weights_on_device("train")
+    worker._assert_weights_on_device("get_logprobs")
+    worker._assert_weights_on_device("score")
+
+
+def test_assert_weights_on_device_train_raises_with_helpful_message() -> None:
+    """train() should point users at prepare_for_training()."""
+    worker = _make_worker_under_test(weights_offloaded=True)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        worker._assert_weights_on_device("train")
+
+    msg = str(excinfo.value)
+    # The message must name the failing method, the prepare step that
+    # was skipped, and reference the underlying CUDA failure mode so
+    # users searching their logs land here.
+    assert "train()" in msg
+    assert "prepare_for_training()" in msg
+    assert "offload_after_refit()" in msg
+    assert "illegal memory access" in msg
+    assert "#1141" in msg
+
+
+@pytest.mark.parametrize("method_name", ["get_logprobs", "score"])
+def test_assert_weights_on_device_inference_raises_with_helpful_message(
+    method_name: str,
+) -> None:
+    """Inference-side methods should point at prepare_for_lp_inference()."""
+    worker = _make_worker_under_test(weights_offloaded=True)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        worker._assert_weights_on_device(method_name)
+
+    msg = str(excinfo.value)
+    assert f"{method_name}()" in msg
+    assert "prepare_for_lp_inference()" in msg
+    assert "offload_after_refit()" in msg

--- a/tests/unit/models/policy/test_worker_offload_guard_v2_mcore.py
+++ b/tests/unit/models/policy/test_worker_offload_guard_v2_mcore.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Lightweight unit tests for the v2 + Megatron worker offload guards.
+
+These mirror the dtensor v1 guard tests in
+``test_dtensor_worker_offload_guard.py`` and lock in the same #1141
+contract on the v2 and Megatron paths. They build a bare worker
+instance via ``__new__`` and patch the flag, so they run at the L0
+unit-test tier without Ray, distributed, or a real model.
+
+The Megatron worker test is marked ``@pytest.mark.mcore`` because
+``MegatronPolicyWorkerImpl`` itself imports megatron-bridge at module
+load time.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _make_v2_worker(*, weights_offloaded: bool):
+    from nemo_rl.models.policy.workers.dtensor_policy_worker_v2 import (
+        DTensorPolicyWorkerV2Impl,
+    )
+
+    worker = DTensorPolicyWorkerV2Impl.__new__(DTensorPolicyWorkerV2Impl)
+    worker._weights_offloaded = weights_offloaded
+    return worker
+
+
+def test_v2_passes_when_on_gpu() -> None:
+    worker = _make_v2_worker(weights_offloaded=False)
+    worker._assert_weights_on_device("train")
+    worker._assert_weights_on_device("get_logprobs")
+    worker._assert_weights_on_device("score")
+
+
+def test_v2_train_message_points_at_prepare_for_training() -> None:
+    worker = _make_v2_worker(weights_offloaded=True)
+    with pytest.raises(RuntimeError) as excinfo:
+        worker._assert_weights_on_device("train")
+    msg = str(excinfo.value)
+    assert "train()" in msg
+    assert "prepare_for_training()" in msg
+    assert "offload_after_refit()" in msg
+    assert "#1141" in msg
+
+
+@pytest.mark.parametrize("method_name", ["get_logprobs", "score"])
+def test_v2_inference_message_points_at_prepare_for_lp_inference(
+    method_name: str,
+) -> None:
+    worker = _make_v2_worker(weights_offloaded=True)
+    with pytest.raises(RuntimeError) as excinfo:
+        worker._assert_weights_on_device(method_name)
+    msg = str(excinfo.value)
+    assert f"{method_name}()" in msg
+    assert "prepare_for_lp_inference()" in msg
+
+
+@pytest.mark.mcore
+class TestMegatronOffloadGuard:
+    """Megatron worker imports megatron-bridge at module load, so these
+    tests are marked ``mcore`` and only run under ``--mcore-only``.
+
+    The guard logic is identical to v1/v2 — the implementation in
+    ``megatron_policy_worker.py`` uses ``getattr(self, '_weights_offloaded',
+    False)`` so the flag does not need to be set before the first prepare
+    call.
+    """
+
+    def _make_worker(self, *, weights_offloaded: bool | None):
+        from nemo_rl.models.policy.workers.megatron_policy_worker import (
+            MegatronPolicyWorkerImpl,
+        )
+
+        worker = MegatronPolicyWorkerImpl.__new__(MegatronPolicyWorkerImpl)
+        if weights_offloaded is not None:
+            worker._weights_offloaded = weights_offloaded
+        return worker
+
+    def test_passes_when_on_gpu(self) -> None:
+        worker = self._make_worker(weights_offloaded=False)
+        worker._assert_weights_on_device("train")
+        worker._assert_weights_on_device("get_logprobs")
+
+    def test_passes_when_flag_unset(self) -> None:
+        """Before the first offload, the flag may not exist on the
+        instance yet. The guard must treat that as 'on GPU'."""
+        worker = self._make_worker(weights_offloaded=None)
+        worker._assert_weights_on_device("train")
+        worker._assert_weights_on_device("get_logprobs")
+
+    def test_train_message(self) -> None:
+        worker = self._make_worker(weights_offloaded=True)
+        with pytest.raises(RuntimeError) as excinfo:
+            worker._assert_weights_on_device("train")
+        msg = str(excinfo.value)
+        assert "train()" in msg
+        assert "prepare_for_training()" in msg
+        assert "offload_after_refit()" in msg
+        assert "#1141" in msg
+
+    def test_get_logprobs_message(self) -> None:
+        worker = self._make_worker(weights_offloaded=True)
+        with pytest.raises(RuntimeError) as excinfo:
+            worker._assert_weights_on_device("get_logprobs")
+        msg = str(excinfo.value)
+        assert "get_logprobs()" in msg
+        assert "prepare_for_lp_inference()" in msg

--- a/tests/unit/models/policy/test_worker_offload_guard_v2_mcore.py
+++ b/tests/unit/models/policy/test_worker_offload_guard_v2_mcore.py
@@ -44,6 +44,7 @@ def test_v2_passes_when_on_gpu() -> None:
     worker._assert_weights_on_device("train")
     worker._assert_weights_on_device("get_logprobs")
     worker._assert_weights_on_device("score")
+    worker._assert_weights_on_device("get_topk_logits")
 
 
 def test_v2_train_message_points_at_prepare_for_training() -> None:
@@ -57,7 +58,7 @@ def test_v2_train_message_points_at_prepare_for_training() -> None:
     assert "#1141" in msg
 
 
-@pytest.mark.parametrize("method_name", ["get_logprobs", "score"])
+@pytest.mark.parametrize("method_name", ["get_logprobs", "score", "get_topk_logits"])
 def test_v2_inference_message_points_at_prepare_for_lp_inference(
     method_name: str,
 ) -> None:
@@ -92,15 +93,15 @@ class TestMegatronOffloadGuard:
 
     def test_passes_when_on_gpu(self) -> None:
         worker = self._make_worker(weights_offloaded=False)
-        worker._assert_weights_on_device("train")
-        worker._assert_weights_on_device("get_logprobs")
+        for method in ("train", "get_logprobs", "get_topk_logits", "generate"):
+            worker._assert_weights_on_device(method)
 
     def test_passes_when_flag_unset(self) -> None:
         """Before the first offload, the flag may not exist on the
         instance yet. The guard must treat that as 'on GPU'."""
         worker = self._make_worker(weights_offloaded=None)
-        worker._assert_weights_on_device("train")
-        worker._assert_weights_on_device("get_logprobs")
+        for method in ("train", "get_logprobs", "get_topk_logits", "generate"):
+            worker._assert_weights_on_device(method)
 
     def test_train_message(self) -> None:
         worker = self._make_worker(weights_offloaded=True)
@@ -112,10 +113,13 @@ class TestMegatronOffloadGuard:
         assert "offload_after_refit()" in msg
         assert "#1141" in msg
 
-    def test_get_logprobs_message(self) -> None:
+    @pytest.mark.parametrize(
+        "method_name", ["get_logprobs", "get_topk_logits", "generate"]
+    )
+    def test_inference_message(self, method_name: str) -> None:
         worker = self._make_worker(weights_offloaded=True)
         with pytest.raises(RuntimeError) as excinfo:
-            worker._assert_weights_on_device("get_logprobs")
+            worker._assert_weights_on_device(method_name)
         msg = str(excinfo.value)
-        assert "get_logprobs()" in msg
+        assert f"{method_name}()" in msg
         assert "prepare_for_lp_inference()" in msg

--- a/tests/unit/models/policy/test_worker_offload_guard_v2_mcore.py
+++ b/tests/unit/models/policy/test_worker_offload_guard_v2_mcore.py
@@ -44,6 +44,7 @@ def test_v2_passes_when_on_gpu() -> None:
     worker._assert_weights_on_device("train")
     worker._assert_weights_on_device("get_logprobs")
     worker._assert_weights_on_device("score")
+    worker._assert_weights_on_device("get_topk_logits")
 
 
 def test_v2_train_message_points_at_prepare_for_training() -> None:
@@ -57,7 +58,7 @@ def test_v2_train_message_points_at_prepare_for_training() -> None:
     assert "#1141" in msg
 
 
-@pytest.mark.parametrize("method_name", ["get_logprobs", "score"])
+@pytest.mark.parametrize("method_name", ["get_logprobs", "score", "get_topk_logits"])
 def test_v2_inference_message_points_at_prepare_for_lp_inference(
     method_name: str,
 ) -> None:
@@ -92,15 +93,15 @@ class TestMegatronOffloadGuard:
 
     def test_passes_when_on_gpu(self) -> None:
         worker = self._make_worker(weights_offloaded=False)
-        worker._assert_weights_on_device("train")
-        worker._assert_weights_on_device("get_logprobs")
+        for method in ("train", "get_logprobs", "get_topk_logits"):
+            worker._assert_weights_on_device(method)
 
     def test_passes_when_flag_unset(self) -> None:
         """Before the first offload, the flag may not exist on the
         instance yet. The guard must treat that as 'on GPU'."""
         worker = self._make_worker(weights_offloaded=None)
-        worker._assert_weights_on_device("train")
-        worker._assert_weights_on_device("get_logprobs")
+        for method in ("train", "get_logprobs", "get_topk_logits"):
+            worker._assert_weights_on_device(method)
 
     def test_train_message(self) -> None:
         worker = self._make_worker(weights_offloaded=True)
@@ -112,10 +113,13 @@ class TestMegatronOffloadGuard:
         assert "offload_after_refit()" in msg
         assert "#1141" in msg
 
-    def test_get_logprobs_message(self) -> None:
+    @pytest.mark.parametrize(
+        "method_name", ["get_logprobs", "get_topk_logits"]
+    )
+    def test_inference_message(self, method_name: str) -> None:
         worker = self._make_worker(weights_offloaded=True)
         with pytest.raises(RuntimeError) as excinfo:
-            worker._assert_weights_on_device("get_logprobs")
+            worker._assert_weights_on_device(method_name)
         msg = str(excinfo.value)
-        assert "get_logprobs()" in msg
+        assert f"{method_name}()" in msg
         assert "prepare_for_lp_inference()" in msg


### PR DESCRIPTION
## Summary

**Stacks on #2392.** Brings the same offload guard from #2392 to the
\`DTensorPolicyWorkerV2\` and \`MegatronPolicyWorker\` paths, so users
on the v2 dtensor backend and the Megatron-Core backend get the same
clear \`RuntimeError\` instead of a CUDA "illegal memory access" when a
custom training loop forgets \`prepare_for_*\` after
\`offload_after_refit\`. Together with #2392 this completes the
policy-worker side of #1141.

## What changes

Both workers now:

- Track \`self._weights_offloaded\`. v2 sets it to \`False\` at the end
  of \`__init__\`; the Megatron guard uses \`getattr(self, '_weights_offloaded', False)\`
  because its \`__init__\` is split across many private helpers and
  the flag only becomes meaningful once a phase-level offload is
  possible.
- Flip the flag in \`offload_after_refit\` and unflip in both
  \`prepare_for_training\` and \`prepare_for_lp_inference\`.
- Call a new \`_assert_weights_on_device(method_name)\` helper as the
  first line of \`train\`, \`get_logprobs\`, and (v2 only) \`score\`.
- Pick up docstrings on the prepare/offload methods making the
  contract explicit.

The error text matches #2392 — same format, same hint, same issue link
— so the user-visible behaviour is uniform across the three workers.

## Coverage

New \`tests/unit/models/policy/test_worker_offload_guard_v2_mcore.py\`:

- v2 tests (no marker, run at L0):
  - \`test_v2_passes_when_on_gpu\`
  - \`test_v2_train_message_points_at_prepare_for_training\`
  - \`test_v2_inference_message_points_at_prepare_for_lp_inference\` (parametrized over \`get_logprobs\` / \`score\`)
- Megatron tests (\`@pytest.mark.mcore\`):
  - \`test_passes_when_on_gpu\`
  - \`test_passes_when_flag_unset\` — extra case covering the
    \`getattr(..., False)\` branch.
  - \`test_train_message\`, \`test_get_logprobs_message\`

The tests build a bare worker via \`__new__\` and patch the flag, so
they need neither Ray, distributed init, nor a real model.

## Stacking note

This branch is built on top of #2392's branch. Until #2392 merges, the
diff GitHub shows here will include #2392's changes. After #2392
merges this PR's diff will narrow to the additions documented above
(~221 lines).

## Out of scope

- Documentation in user-facing guides (the docstring updates in this
  PR + #2392 carry the contract; a more comprehensive doc page on the
  offload/onload lifecycle could be a separate \`docs:\` PR).
- VLM / Automodel paths if they have their own offload semantics —
  those workers were not flagged in #1141 and are not touched here.

## Test plan

- [x] \`ruff check\` — clean
- [x] \`ruff format\` — clean
- [x] \`python3 -m py_compile\` — clean
- [ ] CI \`L0\` (v2 tests run as part of \`L0_Unit_Tests_Other.sh\`)
- [ ] CI \`L0\` with \`--mcore-only\` (Megatron tests).

Refs: #1141
Depends on: #2392