### PR TITLE
fix(grpo): clearer error when overlong_filtering finds no `truncated` field

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1673,6 +1673,22 @@ def grpo_train(
                 with timer.time("data_processing"):
                     use_overlong_filtering = master_config["grpo"]["overlong_filtering"]
                     if use_overlong_filtering:
+                        if "truncated" not in repeated_batch:
+                            # Surface a clear error for rollout backends that
+                            # didn't populate ``truncated``. The previous bare
+                            # ``repeated_batch["truncated"]`` produced an
+                            # opaque ``KeyError`` deep in the train loop —
+                            # see issue #2163.
+                            raise RuntimeError(
+                                "grpo.overlong_filtering=true requires the "
+                                "rollout backend to populate a per-sample "
+                                "``truncated`` field on the rollout batch, "
+                                "but the current batch is missing it. "
+                                "Either disable overlong_filtering or update "
+                                "the rollout backend to set ``truncated`` "
+                                "(see ``nemo_rl/experience/rollouts.py`` for "
+                                "examples). Refs issue #2163."
+                            )
                         loss_multiplier = repeated_batch["loss_multiplier"].clone()
                         truncated = repeated_batch["truncated"]
 


### PR DESCRIPTION
## Summary

Defensive coding follow-up to issue #2163.

The original repro:

\`\`\`
File "nemo_rl/algorithms/grpo.py", line 1280, in grpo_train
    truncated = repeated_batch["truncated"]
KeyError: 'truncated'
\`\`\`

was filed against \`v0.5.0\`. Since then \`run_async_nemo_gym_rollout\`
in \`nemo_rl/experience/rollouts.py\` populates \`truncated\` on the
final batch (mirroring \`hit_max_tokens\`, parity with the multi-turn
rollout path), so the original \`KeyError\` no longer reproduces on
\`main\`. **No behaviour change for existing users.**

This PR locks in the contract for future rollout backends: when
\`grpo.overlong_filtering=true\` but the batch lacks a \`truncated\`
key, raise a clear \`RuntimeError\` instead of letting it fail
opaquely deep inside the train loop:

\`\`\`
RuntimeError: grpo.overlong_filtering=true requires the rollout
backend to populate a per-sample \`truncated\` field on the rollout
batch, but the current batch is missing it. Either disable
overlong_filtering or update the rollout backend to set \`truncated\`
(see \`nemo_rl/experience/rollouts.py\` for examples). Refs issue #2163.
\`\`\`

## Why this matters

- Future backends that forget the field hit the loud error instead of
  a stack trace deep in batch handling.
- The error names the offending config option, the missing field, and
  the file containing reference implementations — actionable in one
  read.
- Adds zero overhead on the success path (a single \`in\` check before
  the existing access).

## Test plan

- [x] \`ruff check\` — clean
- [x] \`ruff format\` — clean
- [x] \`python3 -m py_compile\` — clean
- [ ] CI \`L0\`

Refs: #2163