### PR TITLE
deps: re-export LD_LIBRARY_PATH for AWS EFA OFI discovery

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -176,6 +176,12 @@ LABEL com.nvidia.build.ref="${NVIDIA_BUILD_REF}"
 
 ENV NEMO_RL_VENV_DIR=/opt/ray_venvs
 
+# Add AWS EFA and OFI plugin library paths to the dynamic linker search path so
+# that NCCL discovers libnccl-net-ofi.so at runtime on AWS instances (P4d/P5/P5en).
+# Without this, NCCL silently falls back to the Socket transport even when the
+# EFA userspace + aws-ofi-nccl plugin are mounted into the container. Closes #1973.
+ENV LD_LIBRARY_PATH="/opt/amazon/aws-ofi-nccl/lib:/opt/amazon/efa/lib:${LD_LIBRARY_PATH}"
+
 # Copy in source from build context (defaults to cloned repo, can be overridden)
 # Exclude pyproject.toml and uv.lock since those may be altered by build-custom-vllm.sh
 COPY --from=nemo-rl --exclude=pyproject.toml --exclude=uv.lock . /opt/nemo-rl

--- a/docker/Dockerfile.ngc_pytorch
+++ b/docker/Dockerfile.ngc_pytorch
@@ -131,6 +131,12 @@ LABEL com.nvidia.build.ref="${NVIDIA_BUILD_REF}"
 
 ENV NEMO_RL_VENV_DIR=/opt/ray_venvs
 
+# Add AWS EFA and OFI plugin library paths to the dynamic linker search path so
+# that NCCL discovers libnccl-net-ofi.so at runtime on AWS instances (P4d/P5/P5en).
+# Without this, NCCL silently falls back to the Socket transport even when the
+# EFA userspace + aws-ofi-nccl plugin are mounted into the container. Closes #1973.
+ENV LD_LIBRARY_PATH="/opt/amazon/aws-ofi-nccl/lib:/opt/amazon/efa/lib:${LD_LIBRARY_PATH}"
+
 # Copy in source from build context (defaults to cloned repo, can be overridden)
 COPY --from=nemo-rl . /opt/nemo-rl
 # Unshallow the repo to get the full history (in the case it was from the scratch layer).

--- a/examples/configs/recipes/llm/aws-efa-grpo-qwen3-30ba3b-2n8g-megatron.yaml
+++ b/examples/configs/recipes/llm/aws-efa-grpo-qwen3-30ba3b-2n8g-megatron.yaml
@@ -1,0 +1,58 @@
+# AWS EFA worked-example GRPO recipe for Qwen3-30B-A3B on 2-node p5en.48xlarge (H200).
+#
+# This recipe exercises the DeepEP flex token dispatcher on the EFA-backed OFI transport.
+# It is a smoke-shaped GRPO run: small batch, short sequence, minimal validation. The goal
+# is to flex the dispatch/combine path, not to converge on a reward.
+#
+# Prerequisites (must be set on the pod before launch):
+#   FI_PROVIDER=efa
+#   NCCL_NET_PLUGIN=ofi             # AWS OFI plugin
+#   NCCL_GIN_TYPE=2                 # NCCL GIN Type 2 CPU proxy
+#   DEEP_EP_BACKEND=nccl            # DeepEP routes via NCCL GIN on EFA
+#   EP_EFA_MAX_QPS=2                # Conservative per deepseek-ai/DeepEP PR #612
+#   EP_EFA_RDMA_GBS=25.0            # EFA per-NIC bandwidth budget
+#
+# Ensure `docker/Dockerfile` has `ENV LD_LIBRARY_PATH=...` extended with
+# `/opt/amazon/aws-ofi-nccl/lib:/opt/amazon/efa/lib`, otherwise NCCL silently falls back
+# to sockets and EFA is never touched. See issue #1973.
+#
+# Recommended DeepEP: deepseek-ai/DeepEP PR #612 (or dmvevents/DeepEP-1@aws-efa-auto-qp-cap-v2)
+# provides EFA-aware auto-QP cap, get_rdma_gbs() fast path, and kScaleoutUpdateInterval
+# tuning. Vanilla DeepEP still runs; PR #612 gives approximately a 22% D+C speedup on EFA.
+defaults: ./grpo-qwen3-30ba3b-8n8g-megatron.yaml
+grpo:
+  num_prompts_per_step: 16
+  num_generations_per_prompt: 8
+checkpointing:
+  enabled: false
+  checkpoint_dir: results/aws-efa-grpo-qwen3-30ba3b-2n8g-megatron
+policy:
+  train_micro_batch_size: 1
+  max_total_sequence_length: 2048
+  megatron_cfg:
+    tensor_model_parallel_size: 4
+    pipeline_model_parallel_size: 2
+    expert_model_parallel_size: 2
+    sequence_parallel: true
+    # DeepEP flex dispatcher enables the EFA-backed MoE fast path.
+    moe_enable_deepep: true
+    moe_token_dispatcher_type: flex
+    # moe_shared_expert_overlap must stay false when moe_enable_deepep is true
+    # (see nemo_rl/models/policy/__init__.py comment on moe_enable_deepep).
+    moe_shared_expert_overlap: false
+    env_vars:
+      PYTORCH_CUDA_ALLOC_CONF: expandable_segments:False
+  generation:
+    vllm_cfg:
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.7
+logger:
+  log_dir: logs/aws-efa-grpo-qwen3-30ba3b-2n8g-megatron
+  wandb_enabled: false
+  tensorboard_enabled: true
+  wandb:
+    project: nemo-rl
+    name: aws-efa-grpo-qwen3-30ba3b-2n8g-megatron
+cluster:
+  gpus_per_node: 8
+  num_nodes: 2


### PR DESCRIPTION
# deps: re-export LD_LIBRARY_PATH for AWS EFA OFI discovery

## Summary

Extends `LD_LIBRARY_PATH` in the release stage of `docker/Dockerfile`
and `docker/Dockerfile.ngc_pytorch` so NCCL can discover
`libnccl-net-ofi.so` at runtime on AWS instances, and adds
`examples/configs/recipes/llm/aws-efa-grpo-qwen3-30ba3b-2n8g-megatron.yaml`
as a worked end-to-end example that exercises the DeepEP flex dispatcher
on 2-node p5en.48xlarge (H200) EFA.

## Why

Tracked in #1973. On AWS P4d / P5 / P5en, the aws-ofi-nccl plugin
(`libnccl-net-ofi.so`) is installed at `/opt/amazon/aws-ofi-nccl/lib`
and the EFA userspace at `/opt/amazon/efa/lib`. Today NeMo-RL's
container Dockerfiles do not prepend either to `LD_LIBRARY_PATH` in
the release stage. When a user launches training on an EFA-enabled
pod, `ldconfig -p | grep libnccl-net` returns nothing and NCCL
silently falls back to its Socket transport. The end-to-end effect is
multi-node collectives running over TCP/IP, not the EFA SRD fabric,
with no error surfaced to the user.

This is the same problem reported in #1973 and the same fix proposed
in the now-closed PR #2359 (closed without merge, no reason given).
That PR targeted a cuDNN `LD_LIBRARY_PATH` block which does not exist
at the current base; this commit re-does it as a fresh `ENV` line
rather than modifying an unrelated pre-existing line.

## What changes

- `docker/Dockerfile`: +6 lines. Release stage now prepends
  `/opt/amazon/aws-ofi-nccl/lib` and `/opt/amazon/efa/lib` to
  `LD_LIBRARY_PATH`.
- `docker/Dockerfile.ngc_pytorch`: +6 lines, same prepend.
- `examples/configs/recipes/llm/aws-efa-grpo-qwen3-30ba3b-2n8g-megatron.yaml`:
  new file, 58 lines. 2-node GRPO recipe that sets
  `moe_enable_deepep=true`, `moe_token_dispatcher_type=flex`,
  `moe_shared_expert_overlap=false`, EP=2, TP=4, PP=2. Comments list the
  required env vars (`FI_PROVIDER=efa`, `NCCL_NET_PLUGIN=ofi`,
  `NCCL_GIN_TYPE=2`, `EP_EFA_MAX_QPS=2`, `EP_EFA_RDMA_GBS=25.0`) and
  link out to deepseek-ai/DeepEP#612 for the recommended DeepEP build
  on EFA.

Three files changed, +70 lines, -0 lines. No Python source touched.

## Testing

Reviewer reproduction recipe (no private-repo access required):

1. `git clone https://github.com/NVIDIA-NeMo/RL && cd RL`
2. `gh pr checkout <this PR>`
3. `docker buildx build -f docker/Dockerfile -t nemo-rl:efa-pr .`
4. Launch the image on any 2-node EFA-enabled cluster (p4d / p5 / p5en).
5. `kubectl -n <ns> exec pod0 -- ldconfig -p | grep libnccl-net`
   -> should resolve `libnccl-net-ofi.so` (pre-patch: empty output).
6. `uv run examples/run_grpo_math.py --config=examples/configs/recipes/llm/aws-efa-grpo-qwen3-30ba3b-2n8g-megatron.yaml`
7. Expected NCCL log tail:
   ```
   NCCL INFO NET/OFI Initializing aws-ofi-nccl ...
   NCCL INFO NET/OFI Selected provider is efa, fabric is efa-direct (found 32 nics)
   NCCL INFO NET/OFI Using transport protocol RDMA
   ```
   Pre-patch the same tail prints `NCCL INFO NET/Socket ...` (TCP
   fallback). The `efa-direct` + `RDMA` pair confirms the plugin was
   found at runtime.

A fully reproducible end-to-end recipe (Dockerfile + K8s manifest +
training driver) that validates this patch alongside DeepEP V2 is
published at
[`antonai-work/nemo-rl-deepep-v2-efa`](https://github.com/antonai-work/nemo-rl-deepep-v2-efa).
That repo's `docker/Dockerfile` applies this PR's diff verbatim as
[`patches/0007-nemo-rl-ld-library-path.patch`](https://github.com/antonai-work/nemo-rl-deepep-v2-efa/blob/main/patches/0007-nemo-rl-ld-library-path.patch),
builds from vanilla `nvidia/cuda:12.9.0-devel-ubuntu24.04`, and
produces the NCCL tail above on 2-node p5.48xlarge. Expected output
contract (EFA TX counter delta ≥ 1 GB, NCCL NET/OFI init log, absence
of NET/Socket fallback) is documented in
[`docs/VALIDATION.md`](https://github.com/antonai-work/nemo-rl-deepep-v2-efa/blob/main/docs/VALIDATION.md).

## Risk / scope

- Container-build-only change to the release stage. No runtime code
  path, no dependency bump, no test framework changes.
- The prepended paths only resolve libraries if they exist in the
  mounted filesystem at runtime. On non-AWS hosts where
  `/opt/amazon/*` is not mounted, `ld.so` silently skips them -- no
  regression.
- New YAML is additive under `examples/configs/recipes/llm/` and
  requires explicit `--config` opt-in. Does not alter any existing
  default behaviour.

## Related

- Closes: #1973
- Refs: #2359 (closed without merge; this commit resurrects and adapts
  the same fix)
- Refs (recommended, optional): deepseek-ai/DeepEP#612 -- EFA-aware
  auto-QP cap, `get_rdma_gbs()` fast path, and
  `kScaleoutUpdateInterval` tuning. Approximately a 22% D+C speedup on
  EFA over vanilla DeepEP. Not required for this PR to land; recipe
  comments point users at it as a follow-up.

## Known follow-up (not in this PR)

`pyproject.toml` pins `deep_ep @ ...@bfded348` (2025-10-29). That
commit predates the DeepEP V2 merge (`b306af0`, 2026-04-29) and does
not contain `deep_ep/buffers/elastic.py`. Workloads that want the V2
`ElasticBuffer` dispatch path need a follow-up `pyproject.toml` bump
to `b306af0` (or later). The `moe_enable_deepep=true` flag in the
recipe still functions against the pinned commit (pre-V2 path), but
EFA-optimised behaviour requires V2.
