### PR TITLE
fix: handle non-contiguous tensors in IPC weight refit

### DIFF
--- a/nemo_rl/models/policy/utils.py
+++ b/nemo_rl/models/policy/utils.py
@@ -315,8 +315,10 @@ def stream_weights_via_ipc_zmq_impl(
     def pack_tensor(buffer, tensor, used_bytes) -> int:
         """Pack tensor into buffer and return new used_bytes."""
         tensor_bytes = tensor.nbytes
+        # reshape(-1) (not view(-1)): the params iterator may yield
+        # non-contiguous tensors and view would raise on incompatible stride.
         buffer[used_bytes : used_bytes + tensor_bytes].data.copy_(
-            tensor.data.view(-1).view(dtype=torch.uint8), non_blocking=True
+            tensor.data.reshape(-1).view(dtype=torch.uint8), non_blocking=True
         )
         return used_bytes + calculate_aligned_size(tensor_bytes)
 

--- a/nemo_rl/utils/packed_tensor.py
+++ b/nemo_rl/utils/packed_tensor.py
@@ -74,8 +74,15 @@ def packed_broadcast_producer(iterator, group, src, post_iter_func):
                 packing_tensor_sizes[buffer_idx] = 0
                 # Pack the tensors
                 while True:
-                    # Apply backend specific post processing and then convert to linearized uint8 tensor
-                    tensor = post_iter_func(next(iterator)).view(torch.uint8).view(-1)
+                    # Apply backend specific post processing and then convert to linearized uint8 tensor.
+                    # contiguous() is required because the upstream iterator may
+                    # yield non-contiguous tensors that view(...) cannot handle.
+                    tensor = (
+                        post_iter_func(next(iterator))
+                        .contiguous()
+                        .view(torch.uint8)
+                        .view(-1)
+                    )
                     packing_tensor_list[buffer_idx].append(tensor)
                     packing_tensor_sizes[buffer_idx] += tensor.view(torch.uint8).numel()
                     if packing_tensor_sizes[buffer_idx] > target_packed_tensor_size:

--- a/tests/unit/models/policy/test_utils.py
+++ b/tests/unit/models/policy/test_utils.py
@@ -293,6 +293,38 @@ class TestStreamWeightsViaIPC:
             (name, torch.randn(*shape, dtype=dtype))
             for name, shape, dtype in tensor_specs
         ]
+        self._run_stream_weights_roundtrip(test_case, known_tensors, buffer_size_bytes)
+
+    def test_stream_weights_via_ipc_zmq_impl_non_contiguous(self):
+        """Regression: tensors yielded by the params iterator may be non-contiguous.
+
+        For example, ``Megatron-Bridge``'s ``QKVMapping.megatron_to_hf`` returns
+        Q/K/V shards via advanced indexing + ``reshape`` that can produce views
+        with non-canonical strides. Before the fix, ``pack_tensor`` called
+        ``view(-1)`` which raises ``RuntimeError: view size is not compatible
+        with input tensor's size and stride``.
+        """
+        # transpose(): non-contiguous, contains all elements
+        t1 = torch.randn(8, 16, dtype=torch.float32).t()
+        # slicing with stride: non-contiguous
+        t2 = torch.randn(40, 60, dtype=torch.float32)[:, ::2]
+        # permute on 3D: non-contiguous
+        t3 = torch.randn(4, 8, 12, dtype=torch.bfloat16).permute(2, 0, 1)
+        for t in (t1, t2, t3):
+            assert not t.is_contiguous(), "test tensor must be non-contiguous"
+
+        known_tensors = [("qkv_q_proj", t1), ("qkv_k_proj", t2), ("qkv_v_proj", t3)]
+        self._run_stream_weights_roundtrip(
+            "non_contiguous", known_tensors, buffer_size_bytes=100 * 1024
+        )
+
+    def _run_stream_weights_roundtrip(
+        self,
+        test_case: str,
+        known_tensors: list[tuple[str, torch.Tensor]],
+        buffer_size_bytes: int,
+    ) -> None:
+        """Shared driver: spawn server/client and validate the round-trip."""
         known_tensors_data = [
             (name, list(t.shape), t.dtype, t) for name, t in known_tensors
         ]


### PR DESCRIPTION

# What does this PR do ?

Make `pack_tensor` and `packed_broadcast_producer` accept non-contiguous tensors yielded by the params iterator, instead of crashing with `RuntimeError: view size is not compatible with input tensor's size and stride`.

# Issues

Fixes #2417

# Usage

No user-facing API change. Internal helpers (`stream_weights_via_ipc_zmq_impl.pack_tensor` and `packed_broadcast_producer`) become robust to non-contiguous inputs:

```python
# before: RuntimeError
tensor.data.view(-1).view(dtype=torch.uint8)

# after: works whether the tensor is contiguous or not
tensor.data.reshape(-1).view(dtype=torch.uint8)
```

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?  → `tests/unit/models/policy/test_utils.py::TestStreamWeightsViaIPC::test_stream_weights_via_ipc_zmq_impl_non_contiguous`
- [ ] Did you run the unit tests and functional tests locally?  → ran `ruff check` and `ruff format --check` on the touched files; the unit test requires CUDA which I don't have locally
- [x] Did you add or update any necessary documentation?  → no docs change needed (internal helper, behaviour is now strictly more permissive)

# Additional Information

**Root cause.** `stream_weights_via_ipc_zmq_impl` consumes tensors from `megatron_bridge.export_hf_weights`. For the `Qwen3ForCausalLM` converter, `QKVMapping.megatron_to_hf → split_qkv_weights` finishes with `q.reshape(-1, hidden_size)` (and same for k, v). `Tensor.reshape` is allowed to return a view with strides that are compatible with `reshape` but **not** with `view`. The next step in NeMo-RL was `tensor.data.view(-1)`, which raises.

**Fix.**

1. `nemo_rl/models/policy/utils.py` — `pack_tensor` now uses `reshape(-1)` instead of `view(-1)`. `reshape` returns the same view in the contiguous case (zero copy) and falls back to a copy when not — and since the next operation is `.copy_()` into a buffer, the extra copy in the rare non-contiguous case has no extra cost.
2. `nemo_rl/utils/packed_tensor.py` — `packed_broadcast_producer` adds `.contiguous()` before `.view(torch.uint8).view(-1)` (defense in depth — same root cause).
3. `tests/unit/models/policy/test_utils.py` — refactored the existing IPC roundtrip test into a reusable helper `_run_stream_weights_roundtrip`, and added `test_stream_weights_via_ipc_zmq_impl_non_contiguous` that exercises the helper with three kinds of non-contiguous inputs (`transpose`, strided slicing, `permute`). Without the fix, these new inputs trigger the original `RuntimeError`.

**Tested manually.**

| Model | `converter_type` | Result before fix | Result after fix |
|---|---|---|---|
| `Qwen/Qwen3-1.7B` | `Qwen2ForCausalLM` | refit works | refit works |
| `Qwen/Qwen3.5-2B` | `Qwen3ForCausalLM` | crashes in `pack_tensor` | refit works |

**Compatibility.** Strictly additive — when the input tensor is already contiguous (the common path) the behaviour is identical to before.
