### PR TITLE
feat: Introduce GenerationBackendInterface as generation-only contract

### DIFF
--- a/nemo_rl/models/generation/__init__.py
+++ b/nemo_rl/models/generation/__init__.py
@@ -16,7 +16,11 @@ from typing import cast
 
 from transformers import PreTrainedTokenizerBase
 
-from nemo_rl.models.generation.interfaces import GenerationConfig
+from nemo_rl.models.generation.interfaces import (  # noqa: F401
+    GenerationBackendInterface,
+    GenerationConfig,
+    GenerationInterface,
+)
 from nemo_rl.models.generation.vllm import VllmConfig
 
 TokenizerType = PreTrainedTokenizerBase

--- a/nemo_rl/models/generation/interfaces.py
+++ b/nemo_rl/models/generation/interfaces.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Generation interfaces for NeMo-RL."""
+
 from abc import ABC, abstractmethod
 from typing import Any, NotRequired, TypedDict, Union
 
@@ -217,6 +220,58 @@ class GenerationOutputSpec(TypedDict):
         torch.Tensor
     ]  # Whether each sequence was truncated and hit max_tokens without stop token
     __extra__: Any
+
+
+class GenerationBackendInterface(ABC):
+    """Generation-focused backend interface.
+
+    .. warning::
+        This interface is experimental and subject to change.
+        Do not use in production code yet.
+    """
+
+    @abstractmethod
+    def generate(
+        self, data: BatchedDataDict["GenerationDatumSpec"], greedy: bool
+    ) -> BatchedDataDict["GenerationOutputSpec"]:
+        """Generate completions for a batch of prompts.
+
+        Args:
+            data: BatchedDataDict conforming to GenerationDatumSpec
+                  (input_ids, input_lengths, optional stop_strings).
+            greedy: If True, use greedy decoding. Otherwise sample.
+
+        Returns:
+            BatchedDataDict conforming to GenerationOutputSpec
+            (output_ids, generation_lengths, unpadded_sequence_lengths, logprobs).
+        """
+        pass
+
+    @property
+    def requires_kv_scale_sync(self) -> bool:
+        """Whether the generation backend requires KV cache scales synchronization."""
+        return False
+
+    def clear_logger_metrics(self) -> None:
+        """Clear telemetry metrics for performance reporting.
+
+        Optional — backends may override. Default does nothing.
+        """
+        pass
+
+    def get_logger_metrics(self) -> dict[str, Any]:
+        """Get telemetry metrics for performance reporting.
+
+        Optional — backends may override. Default returns empty dict.
+        """
+        return {}
+
+    def shutdown(self) -> bool:
+        """Release resources (GPU memory, engine processes).
+
+        Returns True if clean shutdown, False on error.
+        """
+        return True
 
 
 class GenerationInterface(ABC):


### PR DESCRIPTION
Adds GenerationBackendInterface as the clean, focused interface for generation backends that separates generation from weight sync/refit.

# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
