### PR TITLE
fix(nrl-k8s): rewrite `--config` in entrypoint to honor CLI RECIPE arg

### DIFF
--- a/infra/nrl_k8s/src/nrl_k8s/cli.py
+++ b/infra/nrl_k8s/src/nrl_k8s/cli.py
@@ -580,6 +580,15 @@ def run(
     invocations. ``--mode interactive`` (default) uses port-forward +
     working_dir upload and tails logs; ``--mode batch`` uses kubectl exec +
     in-image code and returns as soon as the driver is running via nohup.
+
+    **Recipe path substitution.** ``nrl-k8s run RECIPE`` rewrites
+    ``--config <path>.yaml`` in the training entrypoint to point at
+    the user-supplied RECIPE (translated to its in-pod path:
+    ``nrl_k8s_run.yaml`` in ``--code-source upload``, repo-relative in
+    ``image`` / ``lustre``). Without this, the pod would silently run
+    whatever recipe the infra entrypoint hardcoded; with it, the CLI
+    argument is authoritative and existing infras keep working
+    unchanged. Daemon entrypoints (gym/generation) are not rewritten.
     """
     from . import orchestrate
     from . import submit as submit_mod

--- a/infra/nrl_k8s/src/nrl_k8s/orchestrate.py
+++ b/infra/nrl_k8s/src/nrl_k8s/orchestrate.py
@@ -505,7 +505,9 @@ def submit_training(
     # merging, never the pod. Daemon entrypoints (gym/generation) are
     # not touched here; they have their own configs and go through a
     # separate submission path.
-    entrypoint = _rewrite_entrypoint_recipe(launch.entrypoint, loaded, repo_root, upload=upload, log=log)
+    entrypoint = _rewrite_entrypoint_recipe(
+        launch.entrypoint, loaded, repo_root, upload=upload, log=log
+    )
 
     try:
         handle = submitter.submit(
@@ -538,9 +540,7 @@ def default_run_id(role: str) -> str:
 # can substitute it. The mandatory ``\s|=`` after ``--config`` keeps us
 # from accidentally matching Hydra's ``--config-name`` /
 # ``--config-dir`` / ``--config-path``.
-_CONFIG_FLAG_RE = re.compile(
-    r"(--config(?:\s+|=))(['\"]?)([^\s'\"]+\.ya?ml)\2"
-)
+_CONFIG_FLAG_RE = re.compile(r"(--config(?:\s+|=))(['\"]?)([^\s'\"]+\.ya?ml)\2")
 
 
 def _recipe_path_in_pod(
@@ -576,10 +576,10 @@ def _rewrite_entrypoint_recipe(
     upload: bool,
     log: callable,
 ) -> str:
-    """Rewrite ``--config <path>.yaml`` flags in the train entrypoint to
-    point at the CLI's RECIPE.
+    """Rewrite ``--config <path>.yaml`` flags in the train entrypoint.
 
-    Without this rewrite, ``nrl-k8s run RECIPE_A --infra X`` silently
+    Rewrites flags to point at the CLI's RECIPE. Without this rewrite,
+    ``nrl-k8s run RECIPE_A --infra X`` silently
     runs whatever recipe the entrypoint hardcoded — RECIPE_A would only
     affect client-side validation + Hydra override merging, never the
     pod. Substituting the path in-place makes the CLI argument

--- a/infra/nrl_k8s/src/nrl_k8s/orchestrate.py
+++ b/infra/nrl_k8s/src/nrl_k8s/orchestrate.py
@@ -496,11 +496,22 @@ def submit_training(
     if run_id:
         env_vars.setdefault("NRL_K8S_RUN_ID", run_id)
 
+    # Make the CLI's RECIPE argument actually control what runs in the
+    # pod. Rewrites ``--config <something>.yaml`` in the train entrypoint
+    # to point at the user-supplied recipe (translated to its in-pod
+    # path). Without this rewrite, ``nrl-k8s run RECIPE_A --infra X``
+    # silently runs whatever recipe the entrypoint hardcoded — RECIPE_A
+    # would only affect client-side validation + Hydra override
+    # merging, never the pod. Daemon entrypoints (gym/generation) are
+    # not touched here; they have their own configs and go through a
+    # separate submission path.
+    entrypoint = _rewrite_entrypoint_recipe(launch.entrypoint, loaded, repo_root, upload=upload, log=log)
+
     try:
         handle = submitter.submit(
             name,
             infra.namespace,
-            entrypoint=launch.entrypoint,
+            entrypoint=entrypoint,
             run_id=run_id or "",
             env_vars=env_vars,
             working_dir=wd,
@@ -520,6 +531,91 @@ def submit_training(
 def default_run_id(role: str) -> str:
     """Human-readable default id when the user didn't supply ``--run-id``."""
     return f"{role}-{int(time.time())}"
+
+
+# ``--config <path>.yaml`` (with optional ``=`` separator and surrounding
+# quotes) — captures the path so :func:`_rewrite_entrypoint_recipe`
+# can substitute it. The mandatory ``\s|=`` after ``--config`` keeps us
+# from accidentally matching Hydra's ``--config-name`` /
+# ``--config-dir`` / ``--config-path``.
+_CONFIG_FLAG_RE = re.compile(
+    r"(--config(?:\s+|=))(['\"]?)([^\s'\"]+\.ya?ml)\2"
+)
+
+
+def _recipe_path_in_pod(
+    loaded: LoadedConfig, repo_root: Path, *, upload: bool
+) -> str | None:
+    """Translate the user's recipe path to the path the pod should read.
+
+    * ``upload`` mode — ``nrl_k8s_run.yaml`` (the staged copy of the
+      resolved recipe inside the working_dir; see the
+      ``stage_workdir(extra_files=...)`` call in :func:`submit_training`).
+    * ``image`` / ``lustre`` mode — the recipe path relative to the
+      repo root. The entrypoint's standard ``cd /opt/nemo-rl`` (or
+      equivalent) puts that path at the working directory inside the
+      pod, since Lustre/in-image code mounts mirror the repo tree.
+
+    Returns ``None`` if the recipe lives outside the repo root in
+    image/lustre mode — we can't translate the path so the caller
+    leaves the entrypoint alone.
+    """
+    if upload:
+        return "nrl_k8s_run.yaml"
+    try:
+        return loaded.source_path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return None
+
+
+def _rewrite_entrypoint_recipe(
+    entrypoint: str,
+    loaded: LoadedConfig,
+    repo_root: Path,
+    *,
+    upload: bool,
+    log: callable,
+) -> str:
+    """Rewrite ``--config <path>.yaml`` flags in the train entrypoint to
+    point at the CLI's RECIPE.
+
+    Without this rewrite, ``nrl-k8s run RECIPE_A --infra X`` silently
+    runs whatever recipe the entrypoint hardcoded — RECIPE_A would only
+    affect client-side validation + Hydra override merging, never the
+    pod. Substituting the path in-place makes the CLI argument
+    authoritative without forcing every infra YAML to be updated.
+
+    Behaviour:
+    * Replaces every ``--config <path>.yaml`` (or ``--config=<path>.yaml``,
+      with optional surrounding quotes) with the in-pod path of the
+      user-supplied recipe. Hydra's ``--config-name`` / ``--config-dir``
+      / ``--config-path`` are not matched.
+    * Logs the substitution at info level when the original path
+      differs from the new one, so the rewrite is visible in the
+      submission log.
+    * No-op when the recipe lives outside the repo root in image/lustre
+      mode (can't translate path) or when the entrypoint has no
+      ``--config <yaml>`` to replace.
+    * Quoting is preserved — if the original had ``--config "foo.yaml"``
+      the result has ``--config "<new>"``.
+    """
+    new_path = _recipe_path_in_pod(loaded, repo_root, upload=upload)
+    if new_path is None:
+        return entrypoint
+
+    seen: set[str] = set()
+
+    def _sub(match: re.Match) -> str:
+        flag, quote, original = match.group(1), match.group(2), match.group(3)
+        if original != new_path and original not in seen:
+            log(
+                f"[training] rewrote `--config {original}` -> "
+                f"`--config {new_path}` from CLI recipe arg"
+            )
+            seen.add(original)
+        return f"{flag}{quote}{new_path}{quote}"
+
+    return _CONFIG_FLAG_RE.sub(_sub, entrypoint)
 
 
 def run(

--- a/infra/nrl_k8s/tests/unit/test_orchestrate.py
+++ b/infra/nrl_k8s/tests/unit/test_orchestrate.py
@@ -518,9 +518,7 @@ class TestRewriteEntrypointRecipe:
         loaded.source_path = recipe
         return loaded
 
-    def test_rewrites_hardcoded_config_to_cli_recipe(
-        self, tmp_path: Path, log
-    ) -> None:
+    def test_rewrites_hardcoded_config_to_cli_recipe(self, tmp_path: Path, log) -> None:
         log_fn, lines = log
         repo = tmp_path / "repo"
         loaded = self._loaded_for(repo, "infra/recipes/x.yaml")
@@ -585,10 +583,7 @@ class TestRewriteEntrypointRecipe:
         log_fn, lines = log
         repo = tmp_path / "repo"
         loaded = self._loaded_for(repo, "x.yaml")
-        ep = (
-            "python train.py --config-name=foo --config-dir=bar "
-            "--config-path conf"
-        )
+        ep = "python train.py --config-name=foo --config-dir=bar --config-path conf"
 
         result = orchestrate._rewrite_entrypoint_recipe(
             ep, loaded, repo, upload=False, log=log_fn

--- a/infra/nrl_k8s/tests/unit/test_orchestrate.py
+++ b/infra/nrl_k8s/tests/unit/test_orchestrate.py
@@ -463,3 +463,198 @@ class TestResetEndpointRegistry:
 
         orchestrate._reset_endpoint_registry(loaded, log=log_fn)
         delete_cm.assert_not_called()
+
+
+# =============================================================================
+# Recipe path translation + entrypoint --config rewrite
+# =============================================================================
+
+
+class TestRecipePathInPod:
+    def test_upload_returns_staged_filename(self, tmp_path: Path) -> None:
+        loaded = _loaded()
+        loaded.source_path = tmp_path / "subdir" / "recipe.yaml"
+        # repo_root irrelevant in upload mode — recipe is staged into
+        # the working_dir as a fixed filename.
+        assert (
+            orchestrate._recipe_path_in_pod(loaded, tmp_path, upload=True)
+            == "nrl_k8s_run.yaml"
+        )
+
+    def test_image_lustre_returns_repo_relative_path(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        recipe = repo / "infra" / "nrl_k8s" / "examples" / "x.yaml"
+        recipe.parent.mkdir(parents=True)
+        recipe.write_text("policy: {}")
+        loaded = _loaded()
+        loaded.source_path = recipe
+
+        result = orchestrate._recipe_path_in_pod(loaded, repo, upload=False)
+        assert result == "infra/nrl_k8s/examples/x.yaml"
+
+    def test_image_lustre_recipe_outside_repo_returns_none(
+        self, tmp_path: Path
+    ) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        outside = tmp_path / "elsewhere" / "recipe.yaml"
+        outside.parent.mkdir()
+        outside.write_text("policy: {}")
+        loaded = _loaded()
+        loaded.source_path = outside
+
+        # None makes the rewriter leave the entrypoint alone rather
+        # than invent a path the pod can't resolve.
+        assert orchestrate._recipe_path_in_pod(loaded, repo, upload=False) is None
+
+
+class TestRewriteEntrypointRecipe:
+    @staticmethod
+    def _loaded_for(repo: Path, recipe_relpath: str) -> LoadedConfig:
+        recipe = repo / recipe_relpath
+        recipe.parent.mkdir(parents=True, exist_ok=True)
+        recipe.write_text("policy: {}")
+        loaded = _loaded()
+        loaded.source_path = recipe
+        return loaded
+
+    def test_rewrites_hardcoded_config_to_cli_recipe(
+        self, tmp_path: Path, log
+    ) -> None:
+        log_fn, lines = log
+        repo = tmp_path / "repo"
+        loaded = self._loaded_for(repo, "infra/recipes/x.yaml")
+        ep = "cd /opt/nemo-rl && python train.py --config a/b.yaml --foo"
+
+        result = orchestrate._rewrite_entrypoint_recipe(
+            ep, loaded, repo, upload=False, log=log_fn
+        )
+
+        assert "--config infra/recipes/x.yaml" in result
+        assert "a/b.yaml" not in result
+        # Substitution is logged so it shows up in the submission log.
+        assert any("rewrote" in ln and "a/b.yaml" in ln for ln in lines)
+
+    def test_no_op_when_paths_already_match(self, tmp_path: Path, log) -> None:
+        log_fn, lines = log
+        repo = tmp_path / "repo"
+        loaded = self._loaded_for(repo, "infra/recipes/x.yaml")
+        ep = "python train.py --config infra/recipes/x.yaml"
+
+        result = orchestrate._rewrite_entrypoint_recipe(
+            ep, loaded, repo, upload=False, log=log_fn
+        )
+
+        assert result == ep
+        # No log noise when nothing was actually rewritten.
+        assert lines == []
+
+    def test_handles_equals_separator(self, tmp_path: Path, log) -> None:
+        # Some shells / hydra invocations write ``--config=path`` with
+        # no space. Keep the same separator the user used.
+        log_fn, _ = log
+        repo = tmp_path / "repo"
+        loaded = self._loaded_for(repo, "x.yaml")
+        ep = "python train.py --config=a/b.yaml"
+
+        result = orchestrate._rewrite_entrypoint_recipe(
+            ep, loaded, repo, upload=False, log=log_fn
+        )
+
+        assert "--config=x.yaml" in result
+
+    def test_preserves_quoting(self, tmp_path: Path, log) -> None:
+        log_fn, _ = log
+        repo = tmp_path / "repo"
+        loaded = self._loaded_for(repo, "x.yaml")
+
+        for ep, expected in (
+            ('python t.py --config "a/b.yaml"', '--config "x.yaml"'),
+            ("python t.py --config 'a/b.yaml'", "--config 'x.yaml'"),
+        ):
+            result = orchestrate._rewrite_entrypoint_recipe(
+                ep, loaded, repo, upload=False, log=log_fn
+            )
+            assert expected in result
+
+    def test_does_not_touch_config_name_or_config_dir(
+        self, tmp_path: Path, log
+    ) -> None:
+        # Hydra's ``--config-name`` / ``--config-dir`` / ``--config-path``
+        # look superficially similar but aren't recipe paths.
+        log_fn, lines = log
+        repo = tmp_path / "repo"
+        loaded = self._loaded_for(repo, "x.yaml")
+        ep = (
+            "python train.py --config-name=foo --config-dir=bar "
+            "--config-path conf"
+        )
+
+        result = orchestrate._rewrite_entrypoint_recipe(
+            ep, loaded, repo, upload=False, log=log_fn
+        )
+
+        assert result == ep
+        assert lines == []
+
+    def test_no_op_when_no_config_flag_present(self, tmp_path: Path, log) -> None:
+        log_fn, lines = log
+        repo = tmp_path / "repo"
+        loaded = self._loaded_for(repo, "x.yaml")
+        ep = "python train.py --some-other-flag"
+
+        result = orchestrate._rewrite_entrypoint_recipe(
+            ep, loaded, repo, upload=False, log=log_fn
+        )
+
+        assert result == ep
+        assert lines == []
+
+    def test_no_op_when_recipe_outside_repo(self, tmp_path: Path, log) -> None:
+        log_fn, lines = log
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        outside = tmp_path / "elsewhere.yaml"
+        outside.write_text("policy: {}")
+        loaded = _loaded()
+        loaded.source_path = outside
+        ep = "python train.py --config a/b.yaml"
+
+        result = orchestrate._rewrite_entrypoint_recipe(
+            ep, loaded, repo, upload=False, log=log_fn
+        )
+
+        # Cannot translate path; leave entrypoint alone rather than
+        # invent something.
+        assert result == ep
+
+    def test_upload_mode_uses_staged_filename(self, tmp_path: Path, log) -> None:
+        log_fn, _ = log
+        loaded = _loaded()
+        loaded.source_path = tmp_path / "anywhere.yaml"
+        ep = "python train.py --config a/b.yaml"
+
+        result = orchestrate._rewrite_entrypoint_recipe(
+            ep, loaded, tmp_path, upload=True, log=log_fn
+        )
+
+        assert "--config nrl_k8s_run.yaml" in result
+
+    def test_rewrites_multiple_config_flags(self, tmp_path: Path, log) -> None:
+        # Defensive: if an entrypoint somehow has multiple ``--config``
+        # flags (e.g. an experimental harness chaining), all get the
+        # same recipe substitution. Single log line per distinct
+        # original path.
+        log_fn, lines = log
+        repo = tmp_path / "repo"
+        loaded = self._loaded_for(repo, "x.yaml")
+        ep = "python train.py --config a.yaml ; python verify.py --config a.yaml"
+
+        result = orchestrate._rewrite_entrypoint_recipe(
+            ep, loaded, repo, upload=False, log=log_fn
+        )
+
+        assert result.count("--config x.yaml") == 2
+        assert "a.yaml" not in result
+        # De-duplicated: same original path → one log line.
+        assert sum("rewrote" in ln for ln in lines) == 1


### PR DESCRIPTION
## Summary

Rewrite every `--config <path>.yaml` in the train entrypoint to point at the user-supplied RECIPE before submitting to the pod. Existing infras keep working unchanged; the CLI's `RECIPE` argument is now authoritative without forcing infra YAMLs to be edited.

## Why

`nrl-k8s run RECIPE --infra INFRA` previously parsed `RECIPE` only on the client side (Hydra defaults + override merging). The pod ran whatever recipe the infra entrypoint hardcoded — so `nrl-k8s run RECIPE_A` against an infra that hardcodes `--config RECIPE_B` would silently run `RECIPE_B` while the user thought they were running `RECIPE_A`.

## Behavior

In `submit_training`, before handing the entrypoint to the submitter, rewrite every `--config <path>.yaml` to use the in-pod path of the user's RECIPE:

| Mode | In-pod path |
|---|---|
| `codeSource=upload` | `nrl_k8s_run.yaml` (the staged copy of the resolved recipe in the working_dir) |
| `codeSource=image\|lustre` | RECIPE path relative to repo root |
| Recipe outside repo root | No-op (can't translate path) |

Quoting and `=`/space separator are preserved (`--config "a.yaml"` → `--config "x.yaml"`, `--config=a.yaml` → `--config=x.yaml`). Hydra's `--config-name` / `--config-dir` / `--config-path` are not matched. Daemon entrypoints (gym/generation) are not touched — they have their own configs distinct from the train recipe.

When a substitution actually changes the path, it's logged: `[training] rewrote \`--config a.yaml\` -> \`--config x.yaml\` from CLI recipe arg` — so the rewrite is visible in submission logs.

## Test plan

- [x] `pytest tests/unit/test_orchestrate.py` — 32 tests pass (12 new in `TestRecipePathInPod` + `TestRewriteEntrypointRecipe`).
- [x] Verified the rewrite hits a real-world FT 30B infra entrypoint that hardcodes `--config infra/nrl_k8s/examples/qwen3_30b_if_fault_tolerant_full.yaml` when invoked with a different RECIPE.
- [ ] Existing infras still work unchanged (back-compat — they hardcode the path, the rewrite either no-ops or substitutes to the same path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)