### PR TITLE
fix(infra): dev pod RBAC, macOS install scripts, helm fixes

### DIFF
--- a/infra/kind/get-helm.sh
+++ b/infra/kind/get-helm.sh
@@ -16,21 +16,25 @@
 set -eou pipefail
 HELM_VERSION=${HELM_VERSION:-v3.17.3}
 
-mkdir -p ~/bin/
-NAMED_HELM=~/bin/helm-$HELM_VERSION
+HELM_BIN="$HOME/bin/helm"
+mkdir -p "$HOME/bin"
 
-if [[ ! -f $NAMED_HELM ]]; then
-  ARCH=$(uname -m)
-  case $ARCH in
-    x86_64)  ARCH=amd64 ;;
-    aarch64) ARCH=arm64 ;;
-    *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
-  esac
-  tmp_helm_dir=$(mktemp -d)
-  curl -sSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" | tar -xz -C "$tmp_helm_dir" --strip-components=1
-  cp "$tmp_helm_dir/helm" "$NAMED_HELM"
-  rm -rf "$tmp_helm_dir"
+ARCH=$(uname -m)
+case $ARCH in
+  x86_64)  ARCH=amd64 ;;
+  aarch64|arm64) ARCH=arm64 ;;
+  *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+tmp_helm_dir=$(mktemp -d)
+curl -sSL "https://get.helm.sh/helm-${HELM_VERSION}-${OS}-${ARCH}.tar.gz" | tar -xz -C "$tmp_helm_dir" --strip-components=1
+cp "$tmp_helm_dir/helm" "$HELM_BIN"
+rm -rf "$tmp_helm_dir"
+
+echo "Installed helm $HELM_VERSION at $HELM_BIN"
+if command -v helm &>/dev/null; then
+  echo "helm is already on your PATH: $(command -v helm)"
+else
+  echo "helm is not on your PATH. To add it, run:"
+  echo "  export PATH=\"\$HOME/bin:\$PATH\""
 fi
-
-echo "Installed helm at $NAMED_HELM"
-echo "To use, you may set 'alias helm=$NAMED_HELM'"

--- a/infra/kind/get-kubectl.sh
+++ b/infra/kind/get-kubectl.sh
@@ -17,31 +17,31 @@ set -eou pipefail
 
 KUBECTL_VERSION=${KUBECTL_VERSION:-latest}
 
-echo ==============================================
-echo "Currently installed versions of kubectl:"
-ls ~/bin/kubectl* 2>/dev/null || true
-echo ==============================================
+KUBECTL_BIN="$HOME/bin/kubectl"
+mkdir -p "$HOME/bin"
 
-mkdir -p ~/bin
-NAMED_KUBECTL=~/bin/kubectl-$KUBECTL_VERSION
+ARCH=$(uname -m)
+case $ARCH in
+  x86_64)  ARCH=amd64 ;;
+  aarch64|arm64) ARCH=arm64 ;;
+  *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 
-if [[ ! -f $NAMED_KUBECTL ]]; then
-  ARCH=$(uname -m)
-  case $ARCH in
-    x86_64)  ARCH=amd64 ;;
-    aarch64) ARCH=arm64 ;;
-    *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
-  esac
-  if [[ $KUBECTL_VERSION == latest ]]; then
-    curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/$ARCH/kubectl" -o "$NAMED_KUBECTL"
-  else
-    curl -L "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/$ARCH/kubectl" -o "$NAMED_KUBECTL"
-  fi
+if [[ $KUBECTL_VERSION == latest ]]; then
+  curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/${OS}/${ARCH}/kubectl" -o "$KUBECTL_BIN"
+else
+  curl -L "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/${OS}/${ARCH}/kubectl" -o "$KUBECTL_BIN"
 fi
-chmod +x "$NAMED_KUBECTL"
+chmod +x "$KUBECTL_BIN"
 
-echo "Installed kubectl at $NAMED_KUBECTL"
-echo "To use, you may set 'alias kubectl=$NAMED_KUBECTL'"
+echo "Installed kubectl at $KUBECTL_BIN"
+if command -v kubectl &>/dev/null; then
+  echo "kubectl is already on your PATH: $(command -v kubectl)"
+else
+  echo "kubectl is not on your PATH. To add it, run:"
+  echo "  export PATH=\"\$HOME/bin:\$PATH\""
+fi
 
 if [[ ! -f ~/.krew/bin/kubectl-krew ]]; then
   (
@@ -59,11 +59,11 @@ fi
 
 export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
 
-$NAMED_KUBECTL krew install ctx
-$NAMED_KUBECTL krew install ns
-$NAMED_KUBECTL krew install stern
-$NAMED_KUBECTL krew install view-allocations
-$NAMED_KUBECTL krew install whoami
+$KUBECTL_BIN krew install ctx
+$KUBECTL_BIN krew install ns
+$KUBECTL_BIN krew install stern
+$KUBECTL_BIN krew install view-allocations
+$KUBECTL_BIN krew install whoami
 
 cat <<EOF
 Installed krew at $HOME/.krew

--- a/infra/nrl_k8s/src/nrl_k8s/cli.py
+++ b/infra/nrl_k8s/src/nrl_k8s/cli.py
@@ -36,6 +36,84 @@ from .config import LoadedConfig, load_recipe_with_infra
 from .orchestrate import ALL_ROLES
 from .schema import ClusterSpec, CodeSource, RunMode, SubmitterMode
 
+
+class _VerbatimEpilogCommand(click.Command):
+    """Click command that prints the epilog as-is, without word-wrapping."""
+
+    def format_epilog(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
+        if self.epilog:
+            formatter.write("\n")
+            formatter.write(self.epilog)
+            formatter.write("\n")
+
+
+_DEV_POD_RBAC_YAML = """\
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nrl-k8s-edit-aggregate
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules: []  # auto-filled by aggregation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nrl-k8s-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - apiGroups: [ray.io]
+    resources: [rayjobs, rayclusters]
+    verbs: [get, list, watch, create, update, patch, delete]
+  - apiGroups: [resource.nvidia.com]
+    resources: [computedomains]
+    verbs: [get, list, watch, create, update, patch, delete]
+  - apiGroups: [nvidia.com]
+    resources: [dynamographdeployments]
+    verbs: [get, list, watch, create, update, patch, delete]
+  - apiGroups: [resource.k8s.io]
+    resources: [resourceclaimtemplates]
+    verbs: [get, list, watch, create, update, patch, delete]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-reader
+rules:
+  - apiGroups: [""]
+    resources: [nodes]
+    verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: default-sa-nrl-k8s-edit
+  namespace: <NAMESPACE>
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: <NAMESPACE>
+roleRef:
+  kind: ClusterRole
+  name: nrl-k8s-edit-aggregate
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: default-sa-nrl-k8s-node-reader-<NAMESPACE>
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: <NAMESPACE>
+roleRef:
+  kind: ClusterRole
+  name: node-reader
+  apiGroup: rbac.authorization.k8s.io"""
+
 _INFRA_OPTION = click.option(
     "--infra",
     "infra_path",
@@ -1362,7 +1440,15 @@ def dev():
     """Manage a lightweight dev pod on the cluster."""
 
 
-@dev.command("connect")
+@dev.command(
+    "connect",
+    cls=_VerbatimEpilogCommand,
+    epilog=(
+        "Required RBAC:\n\n"
+        "NAMESPACE=default  # change as needed\n"
+        f"kubectl apply -f - <<EOF\n{_DEV_POD_RBAC_YAML}\nEOF"
+    ).replace("<NAMESPACE>", "${NAMESPACE}"),
+)
 @click.option(
     "--image",
     default="nvcr.io/nvidian/nemo-rl:nightly",
@@ -1688,7 +1774,7 @@ def _check_dev_pod_rbac(namespace: str) -> None:
     if "cannot impersonate" in result.stderr or "Forbidden" in result.stderr:
         # User lacks impersonation privileges (e.g. engineer role).
         # Fall back to checking whether the expected RoleBinding exists.
-        rb = _rolebinding_exists("default-sa-edit", namespace)
+        rb = _rolebinding_exists("default-sa-nrl-k8s-edit", namespace)
         if rb is True:
             return
         if rb is None:
@@ -1700,50 +1786,8 @@ def _check_dev_pod_rbac(namespace: str) -> None:
             )
             return
 
-    heredoc = (
-        f"kubectl apply -f - <<'EOF'\n"
-        f"apiVersion: rbac.authorization.k8s.io/v1\n"
-        f"kind: ClusterRole\n"
-        f"metadata:\n"
-        f"  name: edit-with-ray\n"
-        f"aggregationRule:\n"
-        f"  clusterRoleSelectors:\n"
-        f"    - matchLabels:\n"
-        f'        rbac.authorization.k8s.io/aggregate-to-edit: "true"\n'
-        f"rules: []  # auto-filled by aggregation\n"
-        f"---\n"
-        f"apiVersion: rbac.authorization.k8s.io/v1\n"
-        f"kind: ClusterRole\n"
-        f"metadata:\n"
-        f"  name: ray-edit\n"
-        f"  labels:\n"
-        f'    rbac.authorization.k8s.io/aggregate-to-edit: "true"\n'
-        f"rules:\n"
-        f"  - apiGroups: [ray.io]\n"
-        f"    resources: [rayjobs, rayclusters]\n"
-        f"    verbs: [get, list, watch, create, update, patch, delete]\n"
-        f"  - apiGroups: [resource.nvidia.com]\n"
-        f"    resources: [computedomains]\n"
-        f"    verbs: [get, list, watch, create, update, patch, delete]\n"
-        f"  - apiGroups: [resource.k8s.io]\n"
-        f"    resources: [resourceclaimtemplates]\n"
-        f"    verbs: [get, list, watch, create, update, patch, delete]\n"
-        f"---\n"
-        f"apiVersion: rbac.authorization.k8s.io/v1\n"
-        f"kind: RoleBinding\n"
-        f"metadata:\n"
-        f"  name: default-sa-edit\n"
-        f"  namespace: {namespace}\n"
-        f"subjects:\n"
-        f"  - kind: ServiceAccount\n"
-        f"    name: default\n"
-        f"    namespace: {namespace}\n"
-        f"roleRef:\n"
-        f"  kind: ClusterRole\n"
-        f"  name: edit-with-ray\n"
-        f"  apiGroup: rbac.authorization.k8s.io\n"
-        f"EOF"
-    )
+    manifest = _DEV_POD_RBAC_YAML.replace("<NAMESPACE>", namespace)
+    heredoc = f"kubectl apply -f - <<'EOF'\n{manifest}\nEOF"
     _cli_error(
         f"the default service account in {namespace} lacks edit permissions — "
         f"kubectl won't work inside the dev pod",

--- a/infra/nrl_k8s/src/nrl_k8s/cli.py
+++ b/infra/nrl_k8s/src/nrl_k8s/cli.py
@@ -1648,6 +1648,30 @@ def _check_stale_rayjobs(loaded: LoadedConfig, namespace: str) -> None:
     _error_on_stale(_find_stale_resources(checks), namespace)
 
 
+def _rolebinding_exists(name: str, namespace: str) -> bool | None:
+    """Check whether a RoleBinding exists in *namespace* via the K8s API.
+
+    Returns True/False when the check succeeds, or None when the caller
+    lacks permission to read RoleBindings (403).
+    """
+    from kubernetes import client as k8s_client
+
+    from . import k8s
+
+    k8s.load_kubeconfig()
+    try:
+        k8s_client.RbacAuthorizationV1Api().read_namespaced_role_binding(
+            name, namespace
+        )
+        return True
+    except ApiException as exc:
+        if exc.status == 404:
+            return False
+        if exc.status == 403:
+            return None
+        raise
+
+
 def _check_dev_pod_rbac(namespace: str) -> None:
     """Verify the default SA has edit access so kubectl works inside the dev pod."""
     import subprocess
@@ -1660,6 +1684,22 @@ def _check_dev_pod_rbac(namespace: str) -> None:
     )
     if result.stdout.strip() == "yes":
         return
+
+    if "cannot impersonate" in result.stderr or "Forbidden" in result.stderr:
+        # User lacks impersonation privileges (e.g. engineer role).
+        # Fall back to checking whether the expected RoleBinding exists.
+        rb = _rolebinding_exists("default-sa-edit", namespace)
+        if rb is True:
+            return
+        if rb is None:
+            # Can't impersonate *or* read RBAC — skip the check with a warning.
+            click.echo(
+                "warning: cannot verify default SA permissions (impersonate + "
+                "RBAC read both denied) — assuming they are configured correctly",
+                err=True,
+            )
+            return
+
     heredoc = (
         f"kubectl apply -f - <<'EOF'\n"
         f"apiVersion: rbac.authorization.k8s.io/v1\n"


### PR DESCRIPTION
## Summary

- **RBAC resource rename and node-reader**: Rename ClusterRoles (`edit-with-ray` → `nrl-k8s-edit-aggregate`, `ray-edit` → `nrl-k8s-edit`, `default-sa-edit` → `default-sa-nrl-k8s-edit`) to clarify purpose. Add `node-reader` ClusterRole/ClusterRoleBinding for read-only node access from dev pods. Add `DynamoGraphDeployment` CRD permissions. Surface RBAC YAML as a copy-pasteable snippet in `nrl-k8s dev connect --help`.
- **Skip RBAC impersonation check**: `nrl-k8s dev connect` now falls back to verifying the RoleBinding exists via the K8s API when the user lacks impersonation privileges (e.g. engineer-role contexts), and gracefully skips with a warning when neither check is possible.
- **macOS support for install scripts**: `get-helm.sh` and `get-kubectl.sh` no longer hardcode `linux` — they detect OS via `uname` and handle macOS `arm64` arch. Installs to `~/bin/helm` and `~/bin/kubectl` with PATH guidance.
- **Helm install fix**: Fix helm install flow.

## Test plan

- [ ] `nrl-k8s dev connect` works when user has impersonation privileges
- [ ] `nrl-k8s dev connect` falls back gracefully when user lacks impersonation privileges
- [ ] `nrl-k8s dev connect --help` shows RBAC YAML snippet
- [ ] `get-helm.sh` works on both Linux and macOS
- [ ] `get-kubectl.sh` works on both Linux and macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)