### PR TITLE
refactor: clarify next-token logprob utilities

### DIFF
--- a/nemo_rl/distributed/model_utils.py
+++ b/nemo_rl/distributed/model_utils.py
@@ -825,9 +825,10 @@ class ChunkedDistributedGatherLogprob(torch.autograd.Function):
         return grad_input, None, None, None, None, None, None
 
 
-def dtensor_from_parallel_logits_to_logprobs(
+def _compute_next_token_logprobs_from_vocab_parallel_logits(
     vocab_parallel_logits: torch.Tensor,
     target: DTensor | torch.Tensor,
+    *,
     vocab_start_index: int,
     vocab_end_index: int,
     tp_group: torch.distributed.ProcessGroup,
@@ -836,24 +837,29 @@ def dtensor_from_parallel_logits_to_logprobs(
     chunk_size: Optional[int] = None,
     sampling_params: Optional[TrainingSamplingParams] = None,
 ) -> torch.Tensor:
-    """Get log probabilities from TP+CP sharded vocab logits.
+    """Compute next-token logprobs from local vocab-parallel logits.
+
+    This is the DTensor implementation helper for
+    `get_next_token_logprobs_from_vocab_parallel_logits`. It shifts targets
+    internally and gathers the next-token logprob from TP-sharded vocab logits.
 
     Args:
-        vocab_parallel_logits (orch.Tensor): Logits distributed across tensor parallel workers,
+        vocab_parallel_logits (torch.Tensor): Logits local to this tensor-parallel worker,
             with shape [batch_size, seq_len, vocab_size/tp_size].
-        target (DTensor): Target token indices with shape [batch_size, seq_len].
-            NOTE: Must be the unmodified targets as this function will shift them internally.
+        target (DTensor | torch.Tensor): Unshifted token IDs with shape [batch_size, seq_len].
         vocab_start_index (int): Starting vocabulary index for this worker's partition.
         vocab_end_index (int): Ending vocabulary index for this worker's partition.
         tp_group (torch.distributed.ProcessGroup): Process group for distributed communication.
         inference_only (bool, optional): If True, tensors won't be saved for backward pass. Defaults to False.
         seq_index (Optional[torch.Tensor]): Sequence index tensor with shape [seq_len].
-            It is only provided for cp sharded logits. It represents how tensor is sharded across the sequence dimension.
+            It is only provided for cp sharded logits. It represents how tensor
+            is sharded across the sequence dimension.
         chunk_size (Optional[int]): Sequence dimension chunk size for computing the log probabilities.
-        sampling_params (TrainingSamplingParams, optional): Sampling parameters for Top-k/Top-p filtering and temperature scaling.
+        sampling_params (TrainingSamplingParams, optional): Sampling parameters
+            for Top-k/Top-p filtering and temperature scaling.
 
     Returns:
-        torch.Tensor: Log probabilities tensor with shape [batch_size, seq_len-1].
+        torch.Tensor: Next-token log probabilities with shape [batch_size, seq_len-1].
             The sequence dimension is reduced by 1 due to the target shifting.
     """
     cp_size = 1
@@ -957,7 +963,8 @@ def from_parallel_logits_to_logprobs(
         inference_only (bool, optional): If True, tensors won't be saved for backward pass. Defaults to False.
         cp_group (torch.distributed.ProcessGroup, optional): Context parallelism process group. Defaults to None.
         chunk_size (int, optional): Sequence dimension chunk size for computing the log probabilities.
-        sampling_params (TrainingSamplingParams, optional): Sampling parameters for Top-k/Top-p filtering and temperature scaling.
+        sampling_params (TrainingSamplingParams, optional): Sampling parameters
+            for Top-k/Top-p filtering and temperature scaling.
 
     Returns:
         torch.Tensor: Log probabilities tensor with shape [batch_size, seq_len-1].
@@ -1294,30 +1301,33 @@ class AllGatherCPTensor(torch.autograd.Function):
         return grad_input, None, None  # , None
 
 
-def get_logprobs_from_vocab_parallel_logits(
+def get_next_token_logprobs_from_vocab_parallel_logits(
     vocab_parallel_logits: DTensor,
     input_ids: torch.Tensor | DTensor,
     seq_index: Optional[torch.Tensor] = None,
     chunk_size: Optional[int] = None,
     sampling_params: Optional[TrainingSamplingParams] = None,
-):
-    """Computes log probabilities from vocabulary-parallel logits.
+) -> torch.Tensor:
+    """Compute next-token logprobs from DTensor vocab-parallel logits.
 
-    This function takes logits that are sharded across the vocabulary dimension (tensor parallel)
-    and computes the log probabilities for the given input IDs.
+    This is the public DTensor adapter for logits sharded across the vocabulary
+    dimension. It shifts `input_ids` internally and returns gathered
+    next-token logprobs rather than the full log-softmax tensor.
 
     Args:
         vocab_parallel_logits (DTensor): Logits distributed across tensor parallel workers,
             with shape [batch_size, seq_len, vocab_size/tp_size].
-        input_ids (torch.Tensor | DTensor): Input token IDs for which to compute log probabilities,
+        input_ids (torch.Tensor | DTensor): Unshifted input token IDs,
             with shape [batch_size, seq_len].
         seq_index (Optional[torch.Tensor]): Sequence index for the input IDs,
-            with shape [sequence_length].
+            with shape [seq_len]. Required when context parallelism shards the
+            sequence dimension.
         chunk_size (Optional[int]): Sequence dimension chunk size for computing log probabilities.
-        sampling_params (TrainingSamplingParams, optional): Sampling parameters for Top-k/Top-p filtering and temperature scaling.
+        sampling_params (TrainingSamplingParams, optional): Sampling parameters
+            for Top-k/Top-p filtering and temperature scaling.
 
     Returns:
-        torch.Tensor: Log probabilities for the given input IDs.
+        torch.Tensor: Next-token log probabilities with shape [batch_size, seq_len - 1].
     """
     device_mesh = vocab_parallel_logits.device_mesh
     if seq_index is not None:
@@ -1334,12 +1344,12 @@ def get_logprobs_from_vocab_parallel_logits(
 
     vocab_interval_per_rank = vocab_parallel_logits.shape[-1] // tp_size
 
-    return dtensor_from_parallel_logits_to_logprobs(
+    return _compute_next_token_logprobs_from_vocab_parallel_logits(
         vocab_parallel_logits.to_local(),
         input_ids,
-        vocab_interval_per_rank * tp_rank,
-        (tp_rank + 1) * vocab_interval_per_rank,
-        tp_group,
+        vocab_start_index=vocab_interval_per_rank * tp_rank,
+        vocab_end_index=(tp_rank + 1) * vocab_interval_per_rank,
+        tp_group=tp_group,
         inference_only=not torch.is_grad_enabled(),
         seq_index=seq_index,
         chunk_size=chunk_size,
@@ -1349,31 +1359,33 @@ def get_logprobs_from_vocab_parallel_logits(
 
 def get_next_token_logprobs_from_logits(
     input_ids: torch.Tensor,
-    next_token_logits: torch.Tensor,
+    next_token_logits: torch.Tensor | DTensor,
     seq_index: Optional[torch.Tensor] = None,
     vocab_parallel_rank: Optional[int] = None,
     vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
     context_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
     sampling_params: Optional[TrainingSamplingParams] = None,
 ) -> torch.Tensor:
-    """Compute token log-probabilities from logits, handling parallel and non-parallel cases.
+    """Compute next-token logprobs from logits across supported layouts.
 
     This function handles three cases:
-    1. Vocab parallel (Megatron-style): uses from_parallel_logits_to_logprobs
-    2. DTensor: uses get_logprobs_from_vocab_parallel_logits
-    3. Non-parallel: applies top-k/top-p filtering, log_softmax, and gather
+    1. Vocab parallel (Megatron-style): uses from_parallel_logits_to_logprobs.
+    2. DTensor: uses get_next_token_logprobs_from_vocab_parallel_logits.
+    3. Non-parallel: applies top-k/top-p filtering, log_softmax, and gather.
 
     Args:
-        input_ids: Input token IDs of shape [batch_size, seq_len]
-        next_token_logits: Logits tensor of shape [batch_size, seq_len, vocab_size]
-        seq_index: Sequence index tensor for DTensor path
-        vocab_parallel_rank: Rank in the vocab parallel group (required if vocab_parallel_group is provided)
-        vocab_parallel_group: Process group for vocab parallelism
-        context_parallel_group: Process group for context parallelism
-        sampling_params: Sampling parameters for top-k/top-p filtering
+        input_ids: Unshifted input token IDs of shape [batch_size, seq_len].
+        next_token_logits: Logits tensor of shape [batch_size, seq_len, vocab_size],
+            or a DTensor with the vocabulary dimension sharded.
+        seq_index: Sequence index tensor for the DTensor context-parallel path.
+        vocab_parallel_rank: Rank in the vocab parallel group. Required if
+            `vocab_parallel_group` is provided.
+        vocab_parallel_group: Process group for Megatron-style vocab parallelism.
+        context_parallel_group: Process group for context parallelism.
+        sampling_params: Sampling parameters for top-k/top-p filtering.
 
     Returns:
-        Token log-probabilities of shape [batch_size, seq_len - 1]
+        torch.Tensor: Next-token log probabilities with shape [batch_size, seq_len - 1].
     """
     next_token_logits = next_token_logits.to(torch.float32)
 
@@ -1394,8 +1406,8 @@ def get_next_token_logprobs_from_logits(
         # slice off to the correct length to remove potential CP padding
         logprobs = logprobs[:, : input_ids.shape[1] - 1]
 
-    elif isinstance(next_token_logits, torch.distributed.tensor.DTensor):
-        logprobs = get_logprobs_from_vocab_parallel_logits(
+    elif isinstance(next_token_logits, DTensor):
+        logprobs = get_next_token_logprobs_from_vocab_parallel_logits(
             next_token_logits,
             input_ids,
             seq_index=seq_index,
@@ -1415,7 +1427,7 @@ def get_next_token_logprobs_from_logits(
         next_token_logprobs = torch.nn.functional.log_softmax(
             next_token_logits_wo_last, dim=-1
         )
-        next_tokens = input_ids[:, 1:].cuda()  # Skip first token
+        next_tokens = input_ids[:, 1:].to(next_token_logprobs.device)
         logprobs = next_token_logprobs.gather(
             dim=-1, index=next_tokens.unsqueeze(-1)
         ).squeeze(-1)

--- a/nemo_rl/models/automodel/train.py
+++ b/nemo_rl/models/automodel/train.py
@@ -48,7 +48,7 @@ from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.model_utils import (
     allgather_cp_sharded_tensor,
     distributed_vocab_topk,
-    get_logprobs_from_vocab_parallel_logits,
+    get_next_token_logprobs_from_vocab_parallel_logits,
 )
 from nemo_rl.models.automodel.data import ProcessedInputs, ProcessedMicrobatch
 from nemo_rl.models.policy import PolicyConfig
@@ -667,23 +667,27 @@ class LogprobsPostProcessor:
                 logits, self.device_mesh, self.cp_mesh, sequence_dim
             )
 
-            token_logprobs = get_logprobs_from_vocab_parallel_logits(
-                logits,
-                input_ids_dtensor,
-                seq_index_tensor,
-                chunk_size=self.logprob_chunk_size,
-                sampling_params=self.sampling_params,  # top-k and top-p filtering
+            token_logprobs = (
+                get_next_token_logprobs_from_vocab_parallel_logits(
+                    logits,
+                    input_ids_dtensor,
+                    seq_index_tensor,
+                    chunk_size=self.logprob_chunk_size,
+                    sampling_params=self.sampling_params,  # top-k and top-p filtering
+                )
             )
 
             assert token_logprobs.shape[1] == seq_len - 1
         else:
             if isinstance(logits, DTensor):
                 # DTensor path with TP sharding
-                token_logprobs = get_logprobs_from_vocab_parallel_logits(
-                    logits,
-                    processed_inputs.input_ids,
-                    chunk_size=self.logprob_chunk_size,
-                    sampling_params=self.sampling_params,  # top-k and top-p filtering
+                token_logprobs = (
+                    get_next_token_logprobs_from_vocab_parallel_logits(
+                        logits,
+                        processed_inputs.input_ids,
+                        chunk_size=self.logprob_chunk_size,
+                        sampling_params=self.sampling_params,  # top-k and top-p filtering
+                    )
                 )
             else:
                 # Non-DTensor path (no TP sharding)

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -62,7 +62,7 @@ from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.model_utils import (
     allgather_cp_sharded_tensor,
     distributed_vocab_topk,
-    get_logprobs_from_vocab_parallel_logits,
+    get_next_token_logprobs_from_vocab_parallel_logits,
 )
 from nemo_rl.models.dtensor.parallelize import (
     _parallelize_model,
@@ -1162,22 +1162,26 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
                                 placements=[Shard(sequence_dim), Shard(-1)],
                             )
 
-                        token_logprobs = get_logprobs_from_vocab_parallel_logits(
-                            logits,
-                            input_ids_dtensor,
-                            seq_index_tensor,
-                            chunk_size=logprob_chunk_size,
-                            sampling_params=self.sampling_params,
+                        token_logprobs = (
+                            get_next_token_logprobs_from_vocab_parallel_logits(
+                                logits,
+                                input_ids_dtensor,
+                                seq_index_tensor,
+                                chunk_size=logprob_chunk_size,
+                                sampling_params=self.sampling_params,
+                            )
                         )
 
                         assert token_logprobs.shape[1] == seq_len - 1
                     else:
                         if isinstance(logits, DTensor):
-                            token_logprobs = get_logprobs_from_vocab_parallel_logits(
-                                logits,
-                                input_ids,
-                                chunk_size=logprob_chunk_size,
-                                sampling_params=self.sampling_params,
+                            token_logprobs = (
+                                get_next_token_logprobs_from_vocab_parallel_logits(
+                                    logits,
+                                    input_ids,
+                                    chunk_size=logprob_chunk_size,
+                                    sampling_params=self.sampling_params,
+                                )
                             )
                         else:
                             if logprob_chunk_size is not None:

--- a/tests/unit/distributed/test_distributed_logprob.py
+++ b/tests/unit/distributed/test_distributed_logprob.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for DistributedLogprob and ChunkedDistributedLogprob using mp.spawn.
+"""Tests for distributed logprob kernels and logprob adapters.
 
-These tests use the distributed_test_runner fixture (torch.multiprocessing.spawn)
-so that code coverage is captured by pytest-cov, unlike the Ray actor-based tests
-in test_model_utils.py where execution happens in separate Ray worker processes.
+Most distributed kernel tests use the distributed_test_runner fixture
+(torch.multiprocessing.spawn) so that code coverage is captured by pytest-cov,
+unlike the Ray actor-based tests in test_model_utils.py where execution happens
+in separate Ray worker processes.
 """
 
 import functools
@@ -24,12 +25,17 @@ import functools
 import pytest
 import torch
 
+from nemo_rl.algorithms.logits_sampling_utils import (
+    TrainingSamplingParams,
+    apply_top_k_top_p,
+)
 from nemo_rl.distributed.model_utils import (
     ChunkedDistributedEntropy,
     ChunkedDistributedGatherLogprob,
     ChunkedDistributedLogprob,
     DistributedLogprob,
     _compute_distributed_log_softmax,
+    get_next_token_logprobs_from_logits,
 )
 
 
@@ -40,6 +46,95 @@ def _torch_baseline_logprob(full_logits, target):
     target_mask = target >= 0
     log_probs = log_probs * target_mask.float()
     return log_probs
+
+
+def test_get_next_token_logprobs_from_logits_local_matches_torch_cpu():
+    """Test the backend-neutral local logits adapter on CPU tensors."""
+    input_ids = torch.tensor(
+        [
+            [0, 3, 1, 4],
+            [2, 0, 2, 1],
+        ],
+        dtype=torch.long,
+    )
+    logits = torch.tensor(
+        [
+            [
+                [0.2, 0.4, 0.1, 1.2, -0.5],
+                [1.0, 1.4, 0.2, -0.1, 0.5],
+                [0.0, 0.3, 0.7, 0.9, 1.3],
+                [0.5, 0.6, 0.7, 0.8, 0.9],
+            ],
+            [
+                [2.0, 0.1, -0.2, 0.4, 0.3],
+                [0.2, 0.9, 1.7, 0.3, -0.4],
+                [0.0, 2.1, 0.5, 0.7, 0.1],
+                [0.4, 0.2, 0.1, 0.3, 0.5],
+            ],
+        ],
+        dtype=torch.float32,
+    )
+
+    actual = get_next_token_logprobs_from_logits(
+        input_ids=input_ids,
+        next_token_logits=logits,
+    )
+
+    expected_logprobs = torch.nn.functional.log_softmax(logits[:, :-1], dim=-1)
+    expected = expected_logprobs.gather(
+        dim=-1, index=input_ids[:, 1:].unsqueeze(-1)
+    ).squeeze(-1)
+
+    assert actual.device == logits.device
+    torch.testing.assert_close(actual, expected)
+
+
+def test_get_next_token_logprobs_from_logits_local_with_top_k_matches_filtering():
+    """Test local logits adapter with top-k filtering on CPU tensors."""
+    input_ids = torch.tensor(
+        [
+            [0, 3, 1, 4],
+            [2, 0, 2, 1],
+        ],
+        dtype=torch.long,
+    )
+    logits = torch.tensor(
+        [
+            [
+                [0.0, 1.0, 2.0, 4.0, 3.0],
+                [0.0, 4.0, 1.0, 3.0, 2.0],
+                [2.0, 1.0, 0.0, 3.0, 4.0],
+                [0.5, 0.6, 0.7, 0.8, 0.9],
+            ],
+            [
+                [5.0, 1.0, 0.5, 3.0, 2.0],
+                [0.0, 1.0, 5.0, 3.0, 2.0],
+                [2.0, 5.0, 0.0, 3.0, 4.0],
+                [0.4, 0.2, 0.1, 0.3, 0.5],
+            ],
+        ],
+        dtype=torch.float32,
+    )
+    sampling_params = TrainingSamplingParams(top_k=2)
+
+    actual = get_next_token_logprobs_from_logits(
+        input_ids=input_ids,
+        next_token_logits=logits,
+        sampling_params=sampling_params,
+    )
+
+    filtered_logits, _ = apply_top_k_top_p(
+        logits[:, :-1],
+        top_k=sampling_params.top_k,
+        top_p=sampling_params.top_p,
+    )
+    expected_logprobs = torch.nn.functional.log_softmax(filtered_logits, dim=-1)
+    expected = expected_logprobs.gather(
+        dim=-1, index=input_ids[:, 1:].unsqueeze(-1)
+    ).squeeze(-1)
+
+    assert actual.device == logits.device
+    torch.testing.assert_close(actual, expected)
 
 
 def _run_logprob_forward_and_backward(rank, world_size, tp_size, chunk_size):


### PR DESCRIPTION
## Summary

- Rename the DTensor vocab-parallel logprob adapter so it explicitly describes next-token logprob behavior.
- Make the local DTensor implementation helper private and align its naming/docstring with its actual role.
- Update AutoModel and DTensor policy worker callsites to use the clearer public helper.
- Keep the local non-parallel logits adapter device-neutral by replacing the CUDA-only token move.
- Add CPU-local coverage for the backend-neutral adapter with and without top-k filtering.

## Root Cause

Issue #2033 tracks cleanup requested from PR #1920 review feedback. The previous helper names suggested generic logprob conversion and exposed a DTensor implementation detail as a public function, while the code actually shifts input IDs internally and gathers next-token logprobs. The local logits branch also forced target tokens onto CUDA, which made the backend-neutral adapter fail for CPU tensors.

## Validation

- `git diff --check`
- Python 3.13 AST parse of all edited files
- Search confirmed no remaining references to `get_logprobs_from_vocab_parallel_logits` or `dtensor_from_parallel_logits_to_logprobs` under `nemo_rl` / `tests`
- Added-line length check

Blocked locally by environment/toolchain issue:

- `uv run pytest tests/unit/distributed/test_distributed_logprob.py -k get_next_token_logprobs_from_logits_local`
- `uv run ruff check nemo_rl/distributed/model_utils.py nemo_rl/models/automodel/train.py nemo_rl/models/policy/workers/dtensor_policy_worker.py tests/unit/distributed/test_distributed_logprob.py`

Both `uv` commands failed before running because `uv` rejected `/usr/local/bin/python3.13`: `platform.mac_ver()` returned an empty value on this host.

Closes #2033.
