### PR TITLE
feat(grpo): log per-optimizer step metrics

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -176,6 +176,7 @@ class GRPOSaveState(TypedDict):
     current_step: int
     current_epoch: int
     total_steps: int
+    total_optim_steps: NotRequired[int]
     total_valid_tokens: int  # Track total number of non-padding tokens during training
     val_reward: NotRequired[
         float
@@ -188,9 +189,105 @@ def _default_grpo_save_state() -> GRPOSaveState:
         "current_step": 0,
         "current_epoch": 0,
         "total_steps": 0,
+        "total_optim_steps": 0,
         "total_valid_tokens": 0,
         "val_reward": -99999999.0,
     }
+
+
+def _get_num_optim_steps_per_rl_step(
+    train_batch_size: int, train_global_batch_size: int
+) -> int:
+    if train_global_batch_size <= 0:
+        raise ValueError(
+            f"train_global_batch_size must be positive, got {train_global_batch_size}"
+        )
+    if train_batch_size <= 0:
+        raise ValueError(f"train batch size must be positive, got {train_batch_size}")
+    if train_batch_size % train_global_batch_size != 0:
+        raise ValueError(
+            "train batch size must be divisible by policy.train_global_batch_size "
+            f"to report optimizer-step metrics, got {train_batch_size=} and "
+            f"{train_global_batch_size=}"
+        )
+    return train_batch_size // train_global_batch_size
+
+
+def _expected_num_optim_steps_per_rl_step(master_config: "MasterConfig") -> int:
+    train_batch_size = (
+        master_config["grpo"]["num_prompts_per_step"]
+        * master_config["grpo"]["num_generations_per_prompt"]
+    )
+    return _get_num_optim_steps_per_rl_step(
+        train_batch_size, master_config["policy"]["train_global_batch_size"]
+    )
+
+
+def _get_total_optim_steps(
+    grpo_save_state: GRPOSaveState, master_config: "MasterConfig"
+) -> int:
+    if "total_optim_steps" in grpo_save_state:
+        return grpo_save_state["total_optim_steps"]
+
+    total_steps = max(grpo_save_state["total_steps"], grpo_save_state["current_step"])
+    try:
+        return total_steps * _expected_num_optim_steps_per_rl_step(master_config)
+    except ValueError as e:
+        warnings.warn(
+            "Could not infer total optimizer steps from an older checkpoint. "
+            f"Falling back to total_steps={total_steps}. Reason: {e}",
+            stacklevel=2,
+        )
+        return total_steps
+
+
+def _add_step_counters(
+    metrics: dict[str, Any],
+    *,
+    rl_step: int,
+    optim_step: int,
+    num_optim_steps_per_rl_step: int,
+) -> None:
+    metrics["rl_step"] = rl_step
+    metrics["optim_step"] = optim_step
+    metrics["num_optim_steps_per_rl_step"] = num_optim_steps_per_rl_step
+
+
+def _get_optim_step_metrics(
+    train_results: dict[str, Any], expected_num_optim_steps: int
+) -> list[dict[str, Any]]:
+    optim_step_metrics = train_results.get("optim_step_metrics")
+    if optim_step_metrics is None:
+        return [{} for _ in range(expected_num_optim_steps)]
+    if len(optim_step_metrics) != expected_num_optim_steps:
+        raise ValueError(
+            "policy.train returned a different number of optimizer-step metric "
+            f"groups than GRPO expected, got {len(optim_step_metrics)} and "
+            f"{expected_num_optim_steps=}"
+        )
+    return optim_step_metrics
+
+
+def _log_optim_step_metrics(
+    logger: Logger,
+    optim_step_metrics: list[dict[str, Any]],
+    *,
+    rl_step: int,
+    starting_optim_step: int,
+) -> None:
+    for optim_step_in_rl_step, metrics in enumerate(optim_step_metrics, start=1):
+        optim_step = starting_optim_step + optim_step_in_rl_step - 1
+        prefixed_metrics = {f"optim/{k}": v for k, v in metrics.items()}
+        prefixed_metrics["optim/optim_step_in_rl_step"] = optim_step_in_rl_step
+        prefixed_metrics["rl_step"] = rl_step
+        prefixed_metrics["optim_step"] = optim_step
+        logger.log_metrics(
+            prefixed_metrics,
+            optim_step,
+            prefix="train",
+            step_metric="train/optim_step",
+            step_finished=True,
+        )
 
 
 class GRPOLoggerConfig(LoggerConfig):
@@ -1349,6 +1446,7 @@ def grpo_train(
     # common config/state times
     current_step = grpo_save_state["current_step"]  # current step within an epoch
     total_steps = grpo_save_state["total_steps"]  # total steps across all epochs
+    total_optim_steps = _get_total_optim_steps(grpo_save_state, master_config)
     max_num_steps = master_config["grpo"][
         "max_num_steps"
     ]  # max number of steps to train for
@@ -1814,6 +1912,15 @@ def grpo_train(
                         loss_fn,
                         timer=timer,
                     )
+                rl_step = total_steps + 1
+                num_optim_steps_per_rl_step = _get_num_optim_steps_per_rl_step(
+                    repeated_batch.size,
+                    master_config["policy"]["train_global_batch_size"],
+                )
+                completed_optim_step = total_optim_steps + num_optim_steps_per_rl_step
+                optim_step_metrics = _get_optim_step_metrics(
+                    train_results, num_optim_steps_per_rl_step
+                )
 
                 # Recompute KV scales after policy training if needed
                 if sync_kv_scales:
@@ -1942,6 +2049,12 @@ def grpo_train(
                 metrics["max_seq_mult_prob_error"] = max_seq_mult_prob_error
                 metrics["num_masked_seqs_by_logprob_error"] = num_masked_seqs
                 metrics["masked_correct_pct"] = masked_correct_pct
+                _add_step_counters(
+                    metrics,
+                    rl_step=rl_step,
+                    optim_step=completed_optim_step,
+                    num_optim_steps_per_rl_step=num_optim_steps_per_rl_step,
+                )
 
                 ## Checkpointing
                 consumed_samples += master_config["grpo"]["num_prompts_per_step"]
@@ -1965,6 +2078,7 @@ def grpo_train(
                     # +1 because step is 0-indexed
                     grpo_save_state["current_step"] = current_step + 1
                     grpo_save_state["total_steps"] = total_steps + 1
+                    grpo_save_state["total_optim_steps"] = completed_optim_step
                     grpo_save_state["current_epoch"] = current_epoch
                     grpo_save_state["total_valid_tokens"] = total_valid_tokens
                     if val_metrics is not None:
@@ -2163,14 +2277,20 @@ def grpo_train(
                 train_results, metrics, timing_metrics, master_config
             )
 
-            logger.log_metrics(metrics, total_steps + 1, prefix="train")
+            _log_optim_step_metrics(
+                logger,
+                optim_step_metrics,
+                rl_step=rl_step,
+                starting_optim_step=total_optim_steps + 1,
+            )
+            logger.log_metrics(metrics, completed_optim_step, prefix="train")
             logger.log_metrics(
-                performance_metrics, total_steps + 1, prefix="performance"
+                performance_metrics, completed_optim_step, prefix="performance"
             )
             # step_finished=True here since this is the final log of our current step.
             logger.log_metrics(
                 timing_metrics,
-                total_steps + 1,
+                completed_optim_step,
                 prefix="timing/train",
                 step_finished=True,
             )
@@ -2194,6 +2314,7 @@ def grpo_train(
             timer.reset()
             current_step += 1
             total_steps += 1
+            total_optim_steps = completed_optim_step
             if should_save_by_timeout:
                 memory_tracker.snapshot_start_of_stage("", dir())
                 print("Timeout has been reached, stopping training early", flush=True)
@@ -2432,6 +2553,7 @@ def async_grpo_train(
 
     # Training state
     step = grpo_save_state["current_step"]
+    total_optim_steps = _get_total_optim_steps(grpo_save_state, master_config)
     weight_version = step  # Tracks refitted weight versions
     consumed_samples = grpo_save_state["consumed_samples"]
     total_valid_tokens = grpo_save_state.get(
@@ -2858,6 +2980,15 @@ def async_grpo_train(
                         loss_fn,
                         timer=timer,
                     )
+                rl_step = step + 1
+                num_optim_steps_per_rl_step = _get_num_optim_steps_per_rl_step(
+                    repeated_batch.size,
+                    master_config["policy"]["train_global_batch_size"],
+                )
+                completed_optim_step = total_optim_steps + num_optim_steps_per_rl_step
+                optim_step_metrics = _get_optim_step_metrics(
+                    train_results, num_optim_steps_per_rl_step
+                )
 
                 print("🔄 Synchronizing policy weights to trajectory collector…")
                 generation_logger_metrics = None
@@ -2997,6 +3128,12 @@ def async_grpo_train(
                 metrics["max_seq_mult_prob_error"] = max_seq_mult_prob_error
                 metrics["num_masked_seqs_by_logprob_error"] = num_masked_seqs
                 metrics["masked_correct_pct"] = masked_correct_pct
+                _add_step_counters(
+                    metrics,
+                    rl_step=rl_step,
+                    optim_step=completed_optim_step,
+                    num_optim_steps_per_rl_step=num_optim_steps_per_rl_step,
+                )
 
                 # Checkpointing (same as sync version)
                 consumed_samples += master_config["grpo"]["num_prompts_per_step"]
@@ -3014,6 +3151,8 @@ def async_grpo_train(
                     should_save_by_step or should_save_by_timeout
                 ):
                     grpo_save_state["current_step"] = step + 1
+                    grpo_save_state["total_steps"] = step + 1
+                    grpo_save_state["total_optim_steps"] = completed_optim_step
                     grpo_save_state["total_valid_tokens"] = total_valid_tokens
                     if val_metrics is not None:
                         grpo_save_state["val_reward"] = val_metrics["accuracy"]
@@ -3168,12 +3307,26 @@ def async_grpo_train(
                 train_results, metrics, timing_metrics, master_config
             )
 
-            logger.log_metrics(performance_metrics, step + 1, prefix="performance")
-            logger.log_metrics(metrics, step + 1, prefix="train")
-            logger.log_metrics(timing_metrics, step + 1, prefix="timing/train")
+            _log_optim_step_metrics(
+                logger,
+                optim_step_metrics,
+                rl_step=rl_step,
+                starting_optim_step=total_optim_steps + 1,
+            )
+            logger.log_metrics(
+                performance_metrics, completed_optim_step, prefix="performance"
+            )
+            logger.log_metrics(metrics, completed_optim_step, prefix="train")
+            logger.log_metrics(
+                timing_metrics,
+                completed_optim_step,
+                prefix="timing/train",
+                step_finished=True,
+            )
 
             timer.reset()
             step += 1
+            total_optim_steps = completed_optim_step
             if should_save_by_timeout:
                 print("Timeout has been reached, stopping training early", flush=True)
                 return

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -46,7 +46,10 @@ from nemo_rl.models.policy.interfaces import (
     ScoreOutputSpec,
     TopkLogitsOutputSpec,
 )
-from nemo_rl.models.policy.utils import resolve_policy_worker_cls
+from nemo_rl.models.policy.utils import (
+    aggregate_optim_step_metrics_by_index,
+    resolve_policy_worker_cls,
+)
 from nemo_rl.utils.checkpoint import CheckpointingConfig
 from nemo_rl.utils.flops_tracker import (
     FLOPTracker,
@@ -692,6 +695,13 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
             for k, v in r["all_mb_metrics"].items():
                 all_mb_metrics[k].extend(v)
         aggregated_results["all_mb_metrics"] = dict(all_mb_metrics)
+        worker_optim_step_metrics = [r.get("optim_step_metrics", []) for r in results]
+        if any(worker_optim_step_metrics):
+            aggregated_results["optim_step_metrics"] = (
+                aggregate_optim_step_metrics_by_index(worker_optim_step_metrics)
+            )
+        else:
+            aggregated_results["optim_step_metrics"] = []
 
         return aggregated_results
 

--- a/nemo_rl/models/policy/utils.py
+++ b/nemo_rl/models/policy/utils.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 
 import gc
+from collections import defaultdict
+from numbers import Number
 import os
 import traceback
 from enum import Enum
 from typing import Any, Dict, Optional, cast
 
+import numpy as np
 import requests
 import torch
 import torch.distributed as dist
@@ -104,6 +107,90 @@ POLICY_WORKER_OVERRIDES = {
     "nemo_rl.models.policy.workers.dtensor_policy_worker.DTensorPolicyWorker": "nemo_rl.modelopt.models.policy.workers.dtensor_quant_policy_worker.DTensorQuantPolicyWorker",
     "nemo_rl.models.policy.workers.dtensor_policy_worker_v2.DTensorPolicyWorkerV2": "nemo_rl.modelopt.models.policy.workers.dtensor_quant_policy_worker_v2.DTensorQuantPolicyWorkerV2",
 }
+
+OPTIM_STEP_MEAN_METRIC_NAMES = {
+    "global_valid_seqs",
+    "global_valid_toks",
+    "lr",
+    "wd",
+}
+
+
+def unscale_loss_metrics_for_optim_step(
+    metrics: dict[str, Any], num_global_batches: int
+) -> dict[str, Any]:
+    """Return per-optimizer-step metrics before legacy rollout-level scaling."""
+    if num_global_batches <= 0:
+        raise ValueError(
+            f"num_global_batches must be positive, got {num_global_batches}"
+        )
+
+    unscaled_metrics = {}
+    for name, value in metrics.items():
+        if "_min" in name or "_max" in name:
+            unscaled_metrics[name] = value
+        else:
+            unscaled_metrics[name] = value * num_global_batches
+    return unscaled_metrics
+
+
+def aggregate_metric_dicts(metric_dicts: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate metric dictionaries with the same reductions used by GRPO logs."""
+    grouped_metrics: dict[str, list[Any]] = defaultdict(list)
+    for metric_dict in metric_dicts:
+        for name, value in metric_dict.items():
+            grouped_metrics[name].append(_coerce_metric_number(value))
+
+    aggregated_metrics: dict[str, Any] = {}
+    for name, values in grouped_metrics.items():
+        if any(not isinstance(value, Number) for value in values):
+            continue
+        if "_min" in name:
+            aggregated_metrics[name] = min(values)
+        elif "_max" in name:
+            aggregated_metrics[name] = max(values)
+        elif name in OPTIM_STEP_MEAN_METRIC_NAMES:
+            aggregated_metrics[name] = sum(values) / len(values)
+        else:
+            aggregated_metrics[name] = sum(values)
+    return aggregated_metrics
+
+
+def aggregate_optim_step_metrics_by_index(
+    worker_optim_step_metrics: list[list[dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    """Aggregate optimizer-step metrics from workers while preserving step index."""
+    if not worker_optim_step_metrics:
+        return []
+
+    num_optim_steps = len(worker_optim_step_metrics[0])
+    for metrics in worker_optim_step_metrics:
+        if len(metrics) != num_optim_steps:
+            raise ValueError(
+                "All workers must report the same number of optimizer-step metric "
+                f"groups, got {[len(m) for m in worker_optim_step_metrics]}"
+            )
+
+    return [
+        aggregate_metric_dicts(
+            [metrics[step_idx] for metrics in worker_optim_step_metrics]
+        )
+        for step_idx in range(num_optim_steps)
+    ]
+
+
+def _coerce_metric_number(value: Any) -> Any:
+    if isinstance(value, torch.Tensor):
+        if value.numel() != 1:
+            return value
+        return value.detach().cpu().item()
+    if isinstance(value, np.ndarray):
+        if value.size != 1:
+            return value
+        return value.item()
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
 
 
 def resolve_policy_worker_cls(default_cls: str, config: dict) -> str:

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -81,6 +81,7 @@ from nemo_rl.models.policy.interfaces import (
     ScoreOutputSpec,
 )
 from nemo_rl.models.policy.utils import (
+    aggregate_metric_dicts,
     configure_dynamo_cache,
     get_runtime_env_for_policy_worker,
     resolve_model_class,
@@ -600,6 +601,7 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
 
             losses = []
             all_mb_metrics = []
+            optim_step_metrics = []
             for gb_idx in range(num_global_batches):
                 global_batch = data.get_batch(batch_idx=gb_idx, batch_size=local_gbs)
 
@@ -633,6 +635,7 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
 
                 self.optimizer.zero_grad()
                 mb_losses = []
+                gb_optim_mb_metrics = []
                 batch = data.get_batch(batch_idx=gb_idx, batch_size=local_gbs)
                 # Calculate number of microbatches to process
                 # make_microbatch_iterator assumes that the batch size is a multiple of the microbatch size
@@ -878,6 +881,7 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
 
                         # skip the update for dummy batches
                         if mb_idx < iterator_len:
+                            optim_loss_metrics = dict(loss_metrics)
                             ## scale by the number of global batches so we get the correct
                             ## value when summing metrics across all microbatches
                             for k in loss_metrics.keys():
@@ -888,6 +892,15 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
                             loss_metrics["lr"] = self.optimizer.param_groups[0]["lr"]
                             loss_metrics["global_valid_seqs"] = global_valid_seqs.item()
                             loss_metrics["global_valid_toks"] = global_valid_toks.item()
+                            optim_loss_metrics["lr"] = self.optimizer.param_groups[0][
+                                "lr"
+                            ]
+                            optim_loss_metrics["global_valid_seqs"] = (
+                                global_valid_seqs.item()
+                            )
+                            optim_loss_metrics["global_valid_toks"] = (
+                                global_valid_toks.item()
+                            )
                         else:
                             loss *= 0
 
@@ -902,9 +915,10 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
                             loss *= self.dp_size * self.cp_size
                             loss.backward()
 
-                    if num_valid_samples > 0:
+                    if mb_idx < iterator_len and num_valid_samples > 0:
                         mb_losses.append(loss.item())
                         all_mb_metrics.append(loss_metrics)
+                        gb_optim_mb_metrics.append(optim_loss_metrics)
 
                 grad_norm: Optional[float | torch.Tensor] = None
                 if not eval_mode:
@@ -927,6 +941,7 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
                     self.optimizer.step()
 
                 losses.append(torch.tensor(mb_losses).sum().item())
+                optim_step_metrics.append(aggregate_metric_dicts(gb_optim_mb_metrics))
 
             # release gradient memory before rollouts
             self.optimizer.zero_grad()
@@ -956,6 +971,7 @@ class DTensorPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface):
                 "gpu_name": torch.cuda.get_device_name(),
                 "model_dtype": self.dtype,
                 "all_mb_metrics": dict(mb_metrics),
+                "optim_step_metrics": optim_step_metrics,
             }
 
             return metrics

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -65,7 +65,11 @@ from nemo_rl.models.policy.interfaces import (
     LogprobOutputSpec,
     ScoreOutputSpec,
 )
-from nemo_rl.models.policy.utils import get_runtime_env_for_policy_worker
+from nemo_rl.models.policy.utils import (
+    aggregate_metric_dicts,
+    get_runtime_env_for_policy_worker,
+    unscale_loss_metrics_for_optim_step,
+)
 from nemo_rl.models.policy.workers.base_policy_worker import AbstractPolicyWorker
 from nemo_rl.models.policy.workers.patches import (
     apply_transformer_engine_patch,
@@ -401,6 +405,7 @@ class DTensorPolicyWorkerV2Impl(AbstractPolicyWorker, ColocatablePolicyInterface
 
             losses = []
             all_mb_metrics = []
+            optim_step_metrics = []
             for gb_idx in range(num_global_batches):
                 # Process global batch and compute normalization factors
                 gb_result = process_global_batch(
@@ -448,17 +453,29 @@ class DTensorPolicyWorkerV2Impl(AbstractPolicyWorker, ColocatablePolicyInterface
 
                 # Extract losses and metrics from results
                 mb_losses = []
+                gb_optim_mb_metrics = []
                 for mb_idx, (loss, loss_metrics) in enumerate(mb_results):
                     # Only process valid (non-dummy) batches for metrics
                     if mb_idx < iterator_len:
+                        optim_loss_metrics = unscale_loss_metrics_for_optim_step(
+                            loss_metrics, num_global_batches
+                        )
                         num_valid_samples = loss_metrics["num_valid_samples"]
                         loss_metrics["lr"] = self.optimizer.param_groups[0]["lr"]
                         loss_metrics["global_valid_seqs"] = global_valid_seqs.item()
                         loss_metrics["global_valid_toks"] = global_valid_toks.item()
+                        optim_loss_metrics["lr"] = self.optimizer.param_groups[0]["lr"]
+                        optim_loss_metrics["global_valid_seqs"] = (
+                            global_valid_seqs.item()
+                        )
+                        optim_loss_metrics["global_valid_toks"] = (
+                            global_valid_toks.item()
+                        )
 
                         if num_valid_samples > 0:
                             mb_losses.append(loss.item())
                             all_mb_metrics.append(loss_metrics)
+                            gb_optim_mb_metrics.append(optim_loss_metrics)
 
                 grad_norm: Optional[float | torch.Tensor] = None
                 if not eval_mode:
@@ -486,6 +503,7 @@ class DTensorPolicyWorkerV2Impl(AbstractPolicyWorker, ColocatablePolicyInterface
                     self.optimizer.step()
 
                 losses.append(torch.tensor(mb_losses).sum().item())
+                optim_step_metrics.append(aggregate_metric_dicts(gb_optim_mb_metrics))
 
             # release gradient memory before rollouts
             self.optimizer.zero_grad()
@@ -504,6 +522,7 @@ class DTensorPolicyWorkerV2Impl(AbstractPolicyWorker, ColocatablePolicyInterface
                 dp_group=self.dp_mesh.get_group(),
                 dtype=self.dtype,
             )
+            metrics["optim_step_metrics"] = optim_step_metrics
 
             return metrics
 

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -86,7 +86,10 @@ from nemo_rl.models.policy.interfaces import (
     ColocatablePolicyInterface,
     LogprobOutputSpec,
 )
-from nemo_rl.models.policy.utils import get_runtime_env_for_policy_worker
+from nemo_rl.models.policy.utils import (
+    aggregate_metric_dicts,
+    get_runtime_env_for_policy_worker,
+)
 from nemo_rl.models.policy.workers.base_policy_worker import AbstractPolicyWorker
 from nemo_rl.models.policy.workers.patches import apply_transformer_engine_patch
 from nemo_rl.utils.nsys import wrap_with_nvtx_name
@@ -299,6 +302,7 @@ class MegatronPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface)
 
         with ctx:
             all_mb_metrics = []
+            optim_step_metrics = []
             losses = []
             total_num_microbatches = 0
             for gb_idx in range(num_global_batches):
@@ -399,8 +403,10 @@ class MegatronPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface)
                 if parallel_state.is_pipeline_last_stage(ignore_virtual=True):
                     # keep all microbatch metrics to be normalized later
                     gb_loss_metrics = []
+                    gb_optim_mb_metrics = []
                     mb_losses = []
                     for x in losses_reduced:
+                        optim_loss_metrics = dict(x)
                         loss_metrics = {}
                         for k in x.keys():
                             if "_min" in k or "_max" in k:
@@ -414,19 +420,33 @@ class MegatronPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface)
                         loss_metrics["wd"] = curr_wd
                         loss_metrics["global_valid_seqs"] = global_valid_seqs.item()
                         loss_metrics["global_valid_toks"] = global_valid_toks.item()
+                        optim_loss_metrics["lr"] = curr_lr
+                        optim_loss_metrics["wd"] = curr_wd
+                        optim_loss_metrics["global_valid_seqs"] = (
+                            global_valid_seqs.item()
+                        )
+                        optim_loss_metrics["global_valid_toks"] = (
+                            global_valid_toks.item()
+                        )
                         mb_losses.append(loss_metrics["loss"])
+                        gb_optim_mb_metrics.append(optim_loss_metrics)
 
                 else:
                     gb_loss_metrics = None
+                    gb_optim_mb_metrics = None
 
                 # Broadcast loss metrics from last stage to all stages
                 gb_loss_metrics = broadcast_loss_metrics_from_last_stage(
                     gb_loss_metrics
                 )
+                gb_optim_mb_metrics = broadcast_loss_metrics_from_last_stage(
+                    gb_optim_mb_metrics
+                )
                 if not parallel_state.is_pipeline_last_stage(ignore_virtual=True):
                     mb_losses = [x["loss"] for x in gb_loss_metrics]
 
                 all_mb_metrics.extend(gb_loss_metrics)
+                optim_step_metrics.append(aggregate_metric_dicts(gb_optim_mb_metrics))
                 losses.append(torch.tensor(mb_losses).sum().item())
 
         if not eval_mode:
@@ -448,6 +468,7 @@ class MegatronPolicyWorkerImpl(AbstractPolicyWorker, ColocatablePolicyInterface)
             "gpu_name": torch.cuda.get_device_name(),
             "model_dtype": self.dtype,
             "all_mb_metrics": mb_metrics,
+            "optim_step_metrics": optim_step_metrics,
             "grad_norm": torch.tensor([grad_norm]),
         }
         # Collect MoE aux metrics averaged across microbatches

--- a/nemo_rl/utils/logger.py
+++ b/nemo_rl/utils/logger.py
@@ -367,8 +367,7 @@ class WandbLogger(LoggerInterface):
 
         # If step_metric is provided, use the corresponding value from metrics as step
         if step_metric and step_metric in metrics:
-            # commit=False so the step does not get incremented
-            self.run.log(metrics, commit=False)
+            self.run.log(metrics, commit=step_finished)
         elif step_finished:
             # Commit param defaults to None. By default if step is set, then commit defaults to False
             # Here, we have an explicit fork for commit in case W&B ever decides to change their default logic.
@@ -911,6 +910,9 @@ class Logger(LoggerInterface):
             wandb_log_dir = os.path.join(self.base_log_dir, "wandb")
             os.makedirs(wandb_log_dir, exist_ok=True)
             self.wandb_logger = WandbLogger(cfg["wandb"], log_dir=wandb_log_dir)
+            self.wandb_logger.define_metric(
+                "train/optim/*", step_metric="train/optim_step"
+            )
             self.loggers.append(self.wandb_logger)
 
         if cfg["swanlab_enabled"]:

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -25,7 +25,12 @@ from nemo_rl.algorithms.advantage_estimator import (
     ReinforcePlusPlusAdvantageEstimator,
 )
 from nemo_rl.algorithms.grpo import (
+    _add_step_counters,
     _default_grpo_save_state,
+    _get_num_optim_steps_per_rl_step,
+    _get_optim_step_metrics,
+    _get_total_optim_steps,
+    _log_optim_step_metrics,
     async_grpo_train,
     compute_and_apply_seq_logprob_error_masking,
     dynamic_sampling,
@@ -44,6 +49,115 @@ from nemo_rl.utils.timer import Timer
 from tests.unit.algorithms.utils import (
     create_mock_batch,
 )
+
+
+def _minimal_step_counter_config(train_global_batch_size: int = 4):
+    return {
+        "grpo": {
+            "num_prompts_per_step": 2,
+            "num_generations_per_prompt": 4,
+        },
+        "policy": {
+            "train_global_batch_size": train_global_batch_size,
+        },
+    }
+
+
+def test_get_num_optim_steps_per_rl_step():
+    assert _get_num_optim_steps_per_rl_step(2048, 512) == 4
+    assert _get_num_optim_steps_per_rl_step(1024, 64) == 16
+
+
+@pytest.mark.parametrize(
+    ("train_batch_size", "train_global_batch_size"),
+    [(7, 4), (8, 0), (0, 4)],
+)
+def test_get_num_optim_steps_per_rl_step_rejects_invalid_values(
+    train_batch_size, train_global_batch_size
+):
+    with pytest.raises(ValueError):
+        _get_num_optim_steps_per_rl_step(train_batch_size, train_global_batch_size)
+
+
+def test_add_step_counters():
+    metrics = {"loss": 1.0}
+
+    _add_step_counters(
+        metrics,
+        rl_step=3,
+        optim_step=12,
+        num_optim_steps_per_rl_step=4,
+    )
+
+    assert metrics == {
+        "loss": 1.0,
+        "rl_step": 3,
+        "optim_step": 12,
+        "num_optim_steps_per_rl_step": 4,
+    }
+
+
+def test_get_total_optim_steps_uses_checkpoint_value():
+    save_state = _default_grpo_save_state()
+    save_state["total_steps"] = 5
+    save_state["total_optim_steps"] = 17
+
+    assert _get_total_optim_steps(save_state, _minimal_step_counter_config()) == 17
+
+
+def test_get_total_optim_steps_derives_older_checkpoint_value():
+    save_state = _default_grpo_save_state()
+    save_state["total_steps"] = 5
+    del save_state["total_optim_steps"]
+
+    assert _get_total_optim_steps(save_state, _minimal_step_counter_config()) == 10
+
+
+def test_get_total_optim_steps_uses_current_step_for_older_async_checkpoints():
+    save_state = _default_grpo_save_state()
+    save_state["current_step"] = 5
+    save_state["total_steps"] = 0
+    del save_state["total_optim_steps"]
+
+    assert _get_total_optim_steps(save_state, _minimal_step_counter_config()) == 10
+
+
+def test_get_optim_step_metrics_validates_expected_count():
+    train_results = {"optim_step_metrics": [{"loss": 1.0}, {"loss": 2.0}]}
+
+    assert (
+        _get_optim_step_metrics(train_results, 2) == train_results["optim_step_metrics"]
+    )
+    with pytest.raises(ValueError):
+        _get_optim_step_metrics(train_results, 3)
+
+
+def test_log_optim_step_metrics_uses_issue_requested_counter_names():
+    logger = MagicMock()
+
+    _log_optim_step_metrics(
+        logger,
+        [{"loss": 1.0}, {"loss": 2.0}],
+        rl_step=3,
+        starting_optim_step=10,
+    )
+
+    assert logger.log_metrics.call_args_list[0].args == (
+        {
+            "optim/loss": 1.0,
+            "optim/optim_step_in_rl_step": 1,
+            "rl_step": 3,
+            "optim_step": 10,
+        },
+        10,
+    )
+    assert logger.log_metrics.call_args_list[0].kwargs == {
+        "prefix": "train",
+        "step_metric": "train/optim_step",
+        "step_finished": True,
+    }
+    assert logger.log_metrics.call_args_list[1].args[0]["optim_step"] == 11
+
 
 # ============================================================================
 # Stub classes for async GRPO testing (non-Ray versions for easy mocking)

--- a/tests/unit/models/policy/test_utils.py
+++ b/tests/unit/models/policy/test_utils.py
@@ -25,11 +25,71 @@ import zmq
 
 from nemo_rl.models.policy.utils import (
     IPCProtocol,
+    aggregate_metric_dicts,
+    aggregate_optim_step_metrics_by_index,
     calculate_aligned_size,
     get_megatron_checkpoint_dir,
     rebuild_cuda_tensor_from_ipc,
     stream_weights_via_ipc_zmq_impl,
+    unscale_loss_metrics_for_optim_step,
 )
+
+
+def test_unscale_loss_metrics_for_optim_step_preserves_min_max_metrics():
+    metrics = {
+        "loss": torch.tensor(0.25),
+        "num_valid_samples": 2.0,
+        "probs_ratio_min": 0.1,
+        "probs_ratio_max": 1.5,
+    }
+
+    unscaled = unscale_loss_metrics_for_optim_step(metrics, num_global_batches=4)
+
+    assert unscaled["loss"].item() == pytest.approx(1.0)
+    assert unscaled["num_valid_samples"] == pytest.approx(8.0)
+    assert unscaled["probs_ratio_min"] == pytest.approx(0.1)
+    assert unscaled["probs_ratio_max"] == pytest.approx(1.5)
+
+
+def test_aggregate_metric_dicts_matches_grpo_reductions():
+    metrics = aggregate_metric_dicts(
+        [
+            {
+                "loss": 1.0,
+                "lr": 0.1,
+                "global_valid_toks": 8,
+                "probs_ratio_min": 0.5,
+                "probs_ratio_max": 1.2,
+            },
+            {
+                "loss": 2.0,
+                "lr": 0.3,
+                "global_valid_toks": 12,
+                "probs_ratio_min": 0.2,
+                "probs_ratio_max": 1.8,
+            },
+        ]
+    )
+
+    assert metrics["loss"] == pytest.approx(3.0)
+    assert metrics["lr"] == pytest.approx(0.2)
+    assert metrics["global_valid_toks"] == pytest.approx(10.0)
+    assert metrics["probs_ratio_min"] == pytest.approx(0.2)
+    assert metrics["probs_ratio_max"] == pytest.approx(1.8)
+
+
+def test_aggregate_optim_step_metrics_by_index_preserves_step_boundaries():
+    metrics = aggregate_optim_step_metrics_by_index(
+        [
+            [{"loss": 1.0, "lr": 0.1}, {"loss": 2.0, "lr": 0.1}],
+            [{"loss": 3.0, "lr": 0.3}, {"loss": 4.0, "lr": 0.3}],
+        ]
+    )
+
+    assert metrics == [
+        {"loss": 4.0, "lr": pytest.approx(0.2)},
+        {"loss": 6.0, "lr": pytest.approx(0.2)},
+    ]
 
 
 class TestGetMegatronCheckpointDir:

--- a/tests/unit/utils/test_logger.py
+++ b/tests/unit/utils/test_logger.py
@@ -306,6 +306,24 @@ class TestWandbLogger:
         mock_run.log.assert_called_once_with(metrics, commit=False)
 
     @patch("nemo_rl.utils.logger.wandb")
+    def test_log_metrics_with_step_metric_and_step_finished(self, mock_wandb):
+        """Test that custom step metrics can commit completed rows."""
+        cfg = {}
+        logger = WandbLogger(cfg)
+
+        metrics = {"loss": 0.5, "optim_step": 15}
+
+        logger.log_metrics(
+            metrics,
+            step=10,
+            step_metric="optim_step",
+            step_finished=True,
+        )
+
+        mock_run = mock_wandb.init.return_value
+        mock_run.log.assert_called_once_with(metrics, commit=True)
+
+    @patch("nemo_rl.utils.logger.wandb")
     def test_log_metrics_with_prefix_and_step_metric(self, mock_wandb):
         """Test logging metrics with both prefix and step metric."""
         cfg = {}
@@ -1285,9 +1303,10 @@ ray_node_gram_used{{GpuIndex="0",GpuDeviceName="NVIDIA Test GPU"}} {80.0 * 1024}
 
         # Check that wandb metrics are defined with the step metric
         mock_wandb_instance = mock_wandb_logger.return_value
-        mock_wandb_instance.define_metric.assert_called_once_with(
-            "ray/*", step_metric="ray/ray_step"
-        )
+        assert mock_wandb_instance.define_metric.call_args_list == [
+            call("train/optim/*", step_metric="train/optim_step"),
+            call("ray/*", step_metric="ray/ray_step"),
+        ]
 
     @patch("nemo_rl.utils.logger.WandbLogger")
     @patch("nemo_rl.utils.logger.TensorboardLogger")
@@ -1594,9 +1613,10 @@ class TestLogger:
 
         # Check that wandb metrics are defined with the step metric
         mock_wandb_instance = mock_wandb_logger.return_value
-        mock_wandb_instance.define_metric.assert_called_once_with(
-            "ray/*", step_metric="ray/ray_step"
-        )
+        assert mock_wandb_instance.define_metric.call_args_list == [
+            call("train/optim/*", step_metric="train/optim_step"),
+            call("ray/*", step_metric="ray/ray_step"),
+        ]
 
     @patch("nemo_rl.utils.logger.WandbLogger")
     @patch("nemo_rl.utils.logger.TensorboardLogger")


### PR DESCRIPTION
## Summary
- Add explicit optimizer-step counters to GRPO logging so each PPO optimization step is emitted under `train/optim/*` with `train/optim_step`.
- Preserve RL-step visibility by adding `train/rl_step`, `train/optim_step`, and `train/num_optim_steps_per_rl_step` to aggregate train logs.
- Carry per-optimizer-step metrics through DTensor v1, DTensor v2, and Megatron workers, then aggregate them across policy workers by optimizer-step index.
- Persist `total_optim_steps` in GRPO checkpoints with fallback inference for older checkpoints.

## Root Cause
GRPO policy training can run multiple optimizer steps inside one RL step, but metrics were only aggregated and logged once per RL step. That hid per-step behavior and made off-policy PPO diagnostics hard to read.

## Validation
- `uvx ruff check nemo_rl/algorithms/grpo.py nemo_rl/models/policy/lm_policy.py nemo_rl/models/policy/utils.py nemo_rl/models/policy/workers/dtensor_policy_worker.py nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py nemo_rl/models/policy/workers/megatron_policy_worker.py nemo_rl/utils/logger.py tests/unit/algorithms/test_grpo.py tests/unit/models/policy/test_utils.py tests/unit/utils/test_logger.py`
- `uvx ruff format --check nemo_rl/algorithms/grpo.py nemo_rl/models/policy/lm_policy.py nemo_rl/models/policy/utils.py nemo_rl/models/policy/workers/dtensor_policy_worker.py nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py nemo_rl/models/policy/workers/megatron_policy_worker.py nemo_rl/utils/logger.py tests/unit/algorithms/test_grpo.py tests/unit/models/policy/test_utils.py tests/unit/utils/test_logger.py`
- `/usr/local/bin/python3.10` source compile for all touched files
- Direct source-extracted GRPO helper checks
- `/Users/vuductai/Documents/Projects/RL/.venv-dev/bin/python -m pytest tests/unit/models/policy/test_utils.py tests/unit/utils/test_logger.py -q -k "optim_step_metrics or aggregate_metric_dicts or unscale_loss_metrics or step_metric or gpu_monitoring"` (`13 passed, 69 deselected`)

## Local Environment Notes
- `uv run pytest ...` is blocked locally by a broken `/usr/local/bin/python3.13` install.
- Focused `tests/unit/algorithms/test_grpo.py` collection is blocked in the local venv by missing optional `soundfile` after adding Megatron submodule paths.

Closes #1435.