### PR TITLE
feat(eval): support NeMo-Gym multi-turn rollouts

### DIFF
--- a/examples/configs/evals/eval.yaml
+++ b/examples/configs/evals/eval.yaml
@@ -1,10 +1,17 @@
 # Evaluation Configuration
 eval:
-  metric: "pass@k" # pass@k and cons@k are supported
+  # single_turn uses one env step; nemo_gym delegates multi-turn rollout to NeMo-Gym
+  rollout_mode: "single_turn"
+  # maximum turns for native eval rollouts; set null for rollout_mode=nemo_gym
+  max_rollout_turns: 1
+  # single_turn supports pass@k and cons@k; nemo_gym supports mean_reward and pass@k
+  metric: "pass@k"
   num_tests_per_prompt: 1 # every prompt will be tested num_tests_per_prompt times and use the average score as the final score
   seed: 42
   k_value: 1
   save_path: null # Path to save evaluation results and configuration of the evaluation. Set to null to disable saving. Example: "results/eval_output" or "/path/to/evaluation_results"
+  # when rollout_mode=nemo_gym, include the full NeMo-Gym result payload in saved JSON
+  save_full_gym_result: false
 
 generation:
   backend: "vllm" # only vllm is supported for evaluation

--- a/examples/configs/evals/mmau.yaml
+++ b/examples/configs/evals/mmau.yaml
@@ -1,9 +1,12 @@
 eval:
+  rollout_mode: "single_turn"
+  max_rollout_turns: 1
   metric: "pass@k"
   num_tests_per_prompt: 1
   seed: 42
   k_value: 1
   save_path: null
+  save_full_gym_result: false
 
 generation:
   backend: "vllm"

--- a/examples/configs/evals/nemo_gym_eval.yaml
+++ b/examples/configs/evals/nemo_gym_eval.yaml
@@ -1,0 +1,62 @@
+# NeMo-Gym evaluation Configuration
+eval:
+  rollout_mode: "nemo_gym"
+  max_rollout_turns: null # NeMo-Gym owns task turn limits through env.nemo_gym
+  metric: "mean_reward" # nemo_gym supports mean_reward and pass@k
+  num_tests_per_prompt: 1 # prompt repeats are not supported in the eval driver for nemo_gym
+  seed: 42
+  k_value: 1
+  save_path: null
+  save_full_gym_result: false
+
+generation:
+  backend: "vllm"
+  max_new_tokens: ${generation.vllm_cfg.max_model_len}
+  temperature: 0.0
+  top_p: 1.0
+  top_k: null # top-k is not OpenAI-compatible and must be null for nemo_gym
+  num_prompts_per_step: 16
+  model_name: "Qwen/Qwen2.5-7B-Instruct"
+  stop_token_ids: null
+  stop_strings: null
+  vllm_cfg:
+    async_engine: true
+    expose_http_server: true
+    precision: "bfloat16"
+    tensor_parallel_size: 1
+    pipeline_parallel_size: 1
+    expert_parallel_size: 1
+    gpu_memory_utilization: 0.9
+    max_model_len: 8192
+    enforce_eager: False
+  colocated:
+    enabled: true
+    resources:
+      gpus_per_node: null
+      num_nodes: null
+
+tokenizer:
+  name: ${generation.model_name}
+  chat_template: "default"
+  chat_template_kwargs: null
+
+data:
+  max_input_seq_length: null
+  dataset_name: "NemoGymDataset"
+  data_path: "/path/to/nemo_gym/validation.jsonl"
+  env_name: "nemo_gym"
+  prompt_file: null
+  system_prompt_file: null
+  processor: "nemo_gym_data_processor"
+  repeat: 1
+
+env:
+  nemo_gym:
+    rollout_max_attempts_to_avoid_lp_nan: 1
+    config_paths:
+    - responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
+    - resources_servers/example_multi_step/configs/example_multi_step.yaml
+
+cluster:
+  gpus_per_node: 1
+  num_nodes: 1

--- a/examples/run_eval.py
+++ b/examples/run_eval.py
@@ -19,14 +19,28 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+import ray
 from omegaconf import OmegaConf
 
 from nemo_rl.algorithms.utils import get_tokenizer
-from nemo_rl.data.datasets import AllTaskProcessedDataset, load_eval_dataset
+from nemo_rl.data.datasets import (
+    AllTaskProcessedDataset,
+    load_eval_dataset,
+    load_response_dataset,
+)
 from nemo_rl.data.datasets.eval_datasets import _is_multimodal_dataset
 from nemo_rl.distributed.virtual_cluster import init_ray
+from nemo_rl.environments.nemo_gym import (
+    NemoGymConfig,
+    configure_nemo_gym_generation_config,
+)
 from nemo_rl.environments.utils import create_env
-from nemo_rl.evals.eval import MasterConfig, run_env_eval, setup
+from nemo_rl.evals.eval import (
+    NEMO_GYM_ROLLOUT_MODE,
+    MasterConfig,
+    run_env_eval,
+    setup,
+)
 from nemo_rl.models.generation import configure_generation_config
 from nemo_rl.utils.config import load_config
 
@@ -47,8 +61,20 @@ def parse_args():
     return args, overrides
 
 
-def setup_data(tokenizer, data_config, env_configs):
+def setup_data(tokenizer, data_config, env_configs, rollout_mode):
     print("Setting up data...")
+
+    if rollout_mode == NEMO_GYM_ROLLOUT_MODE:
+        base_dataset = load_response_dataset(data_config)
+        dataset = AllTaskProcessedDataset(
+            dataset=base_dataset.dataset,
+            tokenizer=tokenizer,
+            default_task_data_spec=base_dataset.task_spec,
+            task_data_processors=base_dataset.processor,
+            task_data_preprocessors=getattr(base_dataset, "preprocessor", None),
+            max_seq_length=data_config["max_input_seq_length"],
+        )
+        return dataset, None, tokenizer
 
     # load dataset
     base_dataset = load_eval_dataset(data_config)
@@ -70,6 +96,31 @@ def setup_data(tokenizer, data_config, env_configs):
     )
 
     return dataset, env, tokenizer
+
+
+def setup_nemo_gym_env(vllm_generation, env_configs):
+    """Create the NeMo-Gym env after vLLM exposes OpenAI-compatible servers."""
+    if NEMO_GYM_ROLLOUT_MODE not in env_configs:
+        raise ValueError("env.nemo_gym is required for rollout_mode='nemo_gym'")
+
+    base_urls = [
+        base_url for base_url in vllm_generation.dp_openai_server_base_urls if base_url
+    ]
+    if not base_urls:
+        raise RuntimeError(
+            "No vLLM OpenAI server URLs were reported. "
+            "Set generation.vllm_cfg.async_engine=true and "
+            "generation.vllm_cfg.expose_http_server=true."
+        )
+
+    nemo_gym_config = NemoGymConfig(
+        model_name=vllm_generation.cfg["model_name"],
+        base_urls=base_urls,
+        initial_global_config_dict=env_configs[NEMO_GYM_ROLLOUT_MODE],
+    )
+    env = create_env(env_name=NEMO_GYM_ROLLOUT_MODE, env_config=nemo_gym_config)
+    ray.get(env.health_check.remote())
+    return env
 
 
 def main():
@@ -100,19 +151,27 @@ def main():
     # Init ray
     init_ray()
 
+    rollout_mode = config["eval"]["rollout_mode"]
+
     # Setup tokenizer — get_tokenizer handles both text-only and multimodal
-    is_multimodal = _is_multimodal_dataset(config["data"]["dataset_name"])
+    is_multimodal = (
+        False
+        if rollout_mode == NEMO_GYM_ROLLOUT_MODE
+        else _is_multimodal_dataset(config["data"]["dataset_name"])
+    )
     tokenizer = get_tokenizer(config["tokenizer"], get_processor=is_multimodal)
     config["generation"] = configure_generation_config(
         config["generation"], tokenizer, is_eval=True
     )
+    if rollout_mode == NEMO_GYM_ROLLOUT_MODE:
+        configure_nemo_gym_generation_config(config["generation"])
 
     # Setup data
     (
         dataset,
         env,
         tokenizer,
-    ) = setup_data(tokenizer, config["data"], config["env"])
+    ) = setup_data(tokenizer, config["data"], config["env"], rollout_mode)
 
     # Setup
     (
@@ -121,12 +180,16 @@ def main():
         master_config,
     ) = setup(config, tokenizer, dataset)
 
+    if rollout_mode == NEMO_GYM_ROLLOUT_MODE:
+        env = setup_nemo_gym_env(vllm_generation, config["env"])
+
     # Run evaluation
     run_env_eval(
         vllm_generation,
         dataloader,
         env,
         master_config,
+        tokenizer,
     )
 
 

--- a/nemo_rl/data/__init__.py
+++ b/nemo_rl/data/__init__.py
@@ -177,6 +177,24 @@ class MMAUEvalDataConfig(TypedDict):
     env_name: NotRequired[str]
 
 
+class NemoGymEvalDataConfig(TypedDict):
+    """Config for NeMo-Gym JSONL datasets used by eval rollout_mode=nemo_gym.
+
+    Each JSONL row must be a NeMo-Gym example containing responses_create_params
+    and agent_ref. The dataset is processed with nemo_gym_data_processor and
+    scored by the NeMo-Gym environment instead of a single-turn eval env.
+    """
+
+    max_input_seq_length: None
+    dataset_name: Literal["NemoGymDataset"]
+    data_path: str
+    processor: Literal["nemo_gym_data_processor"]
+    env_name: Literal["nemo_gym"]
+    repeat: NotRequired[int]
+    prompt_file: NotRequired[str | None]
+    system_prompt_file: NotRequired[str | None]
+
+
 # Union type for all eval dataset configs
 EvalDataConfigType = Union[
     MMLUEvalDataConfig,
@@ -185,5 +203,6 @@ EvalDataConfigType = Union[
     GPQAEvalDataConfig,
     MathEvalDataConfig,
     MMAUEvalDataConfig,
+    NemoGymEvalDataConfig,
     LocalMathEvalDataConfig,
 ]

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -274,8 +274,11 @@ Output prompt token IDs: {output_item_dict["prompt_token_ids"]}
 
 
 def setup_nemo_gym_config(config, tokenizer) -> None:
-    generation_config = config["policy"]["generation"]
+    configure_nemo_gym_generation_config(config["policy"]["generation"])
 
+
+def configure_nemo_gym_generation_config(generation_config: dict[str, Any]) -> None:
+    """Configure generation settings required by the NeMo-Gym rollout path."""
     # Enable the http server. Requires both async engine and the expose_http_server flag
     generation_config["vllm_cfg"]["async_engine"] = True
     generation_config["vllm_cfg"]["expose_http_server"] = True

--- a/nemo_rl/evals/eval.py
+++ b/nemo_rl/evals/eval.py
@@ -17,7 +17,7 @@ import json
 import os
 from collections import Counter
 from itertools import combinations
-from typing import NotRequired, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 
 import ray
 import torch
@@ -26,13 +26,17 @@ from transformers import AutoTokenizer
 
 from nemo_rl.algorithms.utils import set_seed
 from nemo_rl.data import EvalDataConfigType
-from nemo_rl.data.collate_fn import eval_collate_fn
+from nemo_rl.data.collate_fn import eval_collate_fn, rl_collate_fn
 from nemo_rl.data.datasets import AllTaskProcessedDataset
 from nemo_rl.data.llm_message_utils import get_keys_from_message_log
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.virtual_cluster import ClusterConfig, RayVirtualCluster
 from nemo_rl.environments.math_environment import MathEnvConfig
 from nemo_rl.environments.vlm_environment import VLMEnvConfig
+from nemo_rl.experience.rollouts import (
+    AsyncNemoGymRolloutResult,
+    run_async_nemo_gym_rollout,
+)
 from nemo_rl.models.generation.interfaces import GenerationConfig
 from nemo_rl.models.generation.vllm import VllmGeneration
 from nemo_rl.models.policy import TokenizerConfig
@@ -41,19 +45,33 @@ from nemo_rl.models.policy import TokenizerConfig
 # Configuration
 # ===============================================================================
 
+SINGLE_TURN_ROLLOUT_MODE = "single_turn"
+NEMO_GYM_ROLLOUT_MODE = "nemo_gym"
+SUPPORTED_ROLLOUT_MODES = (SINGLE_TURN_ROLLOUT_MODE, NEMO_GYM_ROLLOUT_MODE)
+SINGLE_TURN_METRICS = ("pass@k", "cons@k")
+NEMO_GYM_METRICS = ("mean_reward", "pass@k")
+
 
 class EvalConfig(TypedDict):
+    # Supported values: "single_turn" for the existing one-step env flow,
+    # "nemo_gym" for NeMo-Gym-managed multi-turn rollouts.
+    rollout_mode: Literal["single_turn", "nemo_gym"]
+    # Maximum turns for native eval rollouts. NeMo-Gym owns turn limits itself,
+    # so this must be null when rollout_mode is "nemo_gym".
+    max_rollout_turns: int | None
     metric: str
     num_tests_per_prompt: int
     seed: int
     k_value: int
     save_path: str | None
+    save_full_gym_result: bool
 
 
 # TODO: this should updated, but is left to avoid breaking changes
 class _PassThroughEnvConfig(TypedDict):
     math: NotRequired[MathEnvConfig]
     mmau: NotRequired[VLMEnvConfig]
+    nemo_gym: NotRequired[dict[str, Any]]
 
 
 class MasterConfig(TypedDict):
@@ -68,6 +86,84 @@ class MasterConfig(TypedDict):
 # ===============================================================================
 # Setup & Initialization
 # ===============================================================================
+
+
+def _validate_eval_config(master_config: MasterConfig) -> None:
+    """Validate eval settings that depend on rollout mode."""
+    eval_config = master_config["eval"]
+    generation_config = master_config["generation"]
+
+    rollout_mode = eval_config["rollout_mode"]
+    assert rollout_mode in SUPPORTED_ROLLOUT_MODES, (
+        f"Invalid rollout_mode: {rollout_mode}. "
+        f"Supported modes: {SUPPORTED_ROLLOUT_MODES}"
+    )
+
+    metric = eval_config["metric"]
+    k_value = eval_config["k_value"]
+    num_tests_per_prompt = eval_config["num_tests_per_prompt"]
+    temperature = generation_config["temperature"]
+    top_k = generation_config["top_k"]
+
+    if rollout_mode == SINGLE_TURN_ROLLOUT_MODE:
+        assert metric in SINGLE_TURN_METRICS, (
+            f"Invalid metric for single-turn eval: {metric}. "
+            f"Supported metrics: {SINGLE_TURN_METRICS}"
+        )
+        assert eval_config["max_rollout_turns"] == 1, (
+            "eval.max_rollout_turns must be 1 for rollout_mode='single_turn'. "
+            "Use rollout_mode='nemo_gym' for NeMo-Gym-managed multi-turn eval."
+        )
+        if num_tests_per_prompt > 1:
+            assert temperature > 0 and top_k != 1, (
+                "temperature > 0 and top_k != 1 are required for multiple samples"
+            )
+    elif rollout_mode == NEMO_GYM_ROLLOUT_MODE:
+        assert metric in NEMO_GYM_METRICS, (
+            f"Invalid metric for NeMo-Gym eval: {metric}. "
+            f"Supported metrics: {NEMO_GYM_METRICS}"
+        )
+        assert eval_config["max_rollout_turns"] is None, (
+            "eval.max_rollout_turns must be null for rollout_mode='nemo_gym'. "
+            "Configure turn limits inside the NeMo-Gym task/environment config."
+        )
+        assert num_tests_per_prompt == 1, (
+            "eval.num_tests_per_prompt > 1 is not supported for "
+            "rollout_mode='nemo_gym'. Repeat rows in the NeMo-Gym dataset if "
+            "multiple independent rollouts per prompt are required."
+        )
+        assert generation_config["backend"] == "vllm", (
+            "Only vLLM backend is supported for NeMo-Gym evaluation"
+        )
+        assert generation_config["vllm_cfg"]["async_engine"], (
+            "rollout_mode='nemo_gym' requires generation.vllm_cfg.async_engine=true"
+        )
+        assert generation_config["vllm_cfg"].get("expose_http_server", None), (
+            "rollout_mode='nemo_gym' requires "
+            "generation.vllm_cfg.expose_http_server=true"
+        )
+        assert generation_config["top_k"] is None, (
+            "rollout_mode='nemo_gym' requires generation.top_k=null because "
+            "top-k is not OpenAI-compatible"
+        )
+        assert generation_config["stop_strings"] is None, (
+            "rollout_mode='nemo_gym' requires generation.stop_strings=null"
+        )
+        assert generation_config["stop_token_ids"] is None, (
+            "rollout_mode='nemo_gym' requires generation.stop_token_ids=null"
+        )
+
+    assert k_value >= 1, "k_value must be greater than or equal to 1"
+    assert num_tests_per_prompt >= k_value, (
+        "num_tests_per_prompt must be greater than or equal to k_value "
+    )
+
+
+def _get_eval_collate_fn(rollout_mode: str):
+    """Return the collate function required by the selected eval rollout mode."""
+    if rollout_mode == NEMO_GYM_ROLLOUT_MODE:
+        return rl_collate_fn
+    return eval_collate_fn
 
 
 def setup(
@@ -98,24 +194,7 @@ def setup(
     # Set seed for reproducibility
     set_seed(eval_config["seed"])
 
-    # Check settings
-    metric = eval_config["metric"]
-    k_value = eval_config["k_value"]
-    num_tests_per_prompt = eval_config["num_tests_per_prompt"]
-    temperature = generation_config["temperature"]
-    top_k = generation_config["top_k"]
-
-    # Validate metrics
-    assert metric in ["pass@k", "cons@k"], f"Invalid metric: {metric}"
-    if num_tests_per_prompt > 1:
-        assert temperature > 0 and top_k != 1, (
-            "temperature > 0 and top_k != 1 are required for multiple samples"
-        )
-
-    assert k_value >= 1, "k_value must be greater than or equal to 1"
-    assert num_tests_per_prompt >= k_value, (
-        "num_tests_per_prompt must be greater than or equal to k_value "
-    )
+    _validate_eval_config(master_config)
 
     # ==========================
     #           Data
@@ -126,7 +205,7 @@ def setup(
         dataset,
         batch_size=generation_config["num_prompts_per_step"],
         shuffle=False,
-        collate_fn=eval_collate_fn,
+        collate_fn=_get_eval_collate_fn(eval_config["rollout_mode"]),
     )
     print(f"  ✓ Evaluation dataset loaded with {len(dataset)} samples")
 
@@ -276,7 +355,7 @@ def eval_cons_k(
     return cons_k_score
 
 
-def run_env_eval(vllm_generation, dataloader, env, master_config):
+def run_env_eval(vllm_generation, dataloader, env, master_config, tokenizer):
     """Main entry point for running evaluation using environment.
 
     Generates model responses and evaluates them by env.
@@ -286,24 +365,89 @@ def run_env_eval(vllm_generation, dataloader, env, master_config):
         dataloader: Data loader with evaluation samples.
         env: Environment that scores responses.
         master_config: Configuration settings.
+        tokenizer: Tokenizer used by NeMo-Gym result postprocessing.
     """
     # Check if async engine is enabled and run appropriate version
     if master_config["generation"]["vllm_cfg"]["async_engine"]:
         asyncio.run(
             _run_env_eval_impl(
-                vllm_generation, dataloader, env, master_config, use_async=True
+                vllm_generation,
+                dataloader,
+                env,
+                master_config,
+                tokenizer,
+                use_async=True,
             )
         )
     else:
         asyncio.run(
             _run_env_eval_impl(
-                vllm_generation, dataloader, env, master_config, use_async=False
+                vllm_generation,
+                dataloader,
+                env,
+                master_config,
+                tokenizer,
+                use_async=False,
             )
         )
 
 
+def _score_batch_rewards(
+    rewards: torch.Tensor,
+    metric: str,
+    num_tests_per_prompt: int,
+    k_value: int,
+    extracted_answers: list[str | None] | None = None,
+) -> float:
+    """Score one eval batch according to the selected metric."""
+    if metric == "mean_reward":
+        return rewards.sum().item()
+    if metric == "pass@k":
+        return eval_pass_k(rewards, num_tests_per_prompt, k_value)
+    if metric == "cons@k":
+        assert extracted_answers is not None, (
+            "extracted_answers are required for cons@k"
+        )
+        return eval_cons_k(rewards, num_tests_per_prompt, k_value, extracted_answers)
+    raise ValueError(f"Invalid metric: {metric}")
+
+
+def _collect_nemo_gym_evaluation_data(
+    batch: BatchedDataDict,
+    rollout_result: AsyncNemoGymRolloutResult,
+    include_full_gym_result: bool,
+    start_sample_index: int,
+) -> list[dict[str, Any]]:
+    """Build serializable per-sample records for NeMo-Gym eval results."""
+    final_batch = rollout_result.final_batch
+    raw_results = rollout_result.raw_results or [{} for _ in final_batch["message_log"]]
+    samples = []
+
+    for i, (message_log, reward, agent_ref, extra_info, raw_result) in enumerate(
+        zip(
+            final_batch["message_log"],
+            final_batch["total_reward"].tolist(),
+            final_batch["agent_ref"],
+            batch["extra_env_info"],
+            raw_results,
+        )
+    ):
+        sample = {
+            "reward": reward,
+            "message_log": message_log,
+            "agent_ref": agent_ref,
+            "extra_env_info": extra_info,
+            "sample_index": start_sample_index + i,
+        }
+        if include_full_gym_result and raw_result.get("full_result") is not None:
+            sample["full_result"] = raw_result["full_result"]
+        samples.append(sample)
+
+    return samples
+
+
 async def _run_env_eval_impl(
-    vllm_generation, dataloader, env, master_config, use_async=False
+    vllm_generation, dataloader, env, master_config, tokenizer, use_async=False
 ):
     """Unified implementation for both sync and async evaluation."""
     # Extract for easier access
@@ -312,13 +456,39 @@ async def _run_env_eval_impl(
     metric = eval_config["metric"]
     num_tests_per_prompt = eval_config["num_tests_per_prompt"]
     k_value = eval_config["k_value"]
+    rollout_mode = eval_config["rollout_mode"]
 
-    # List to collect evaluation data for parquet file
+    # List to collect evaluation data for JSON output.
     evaluation_data = []
 
     # Run evaluation loop
     score = 0.0
     for batch in dataloader:
+        if rollout_mode == NEMO_GYM_ROLLOUT_MODE:
+            rollout_result = run_async_nemo_gym_rollout(
+                policy_generation=vllm_generation,
+                input_batch=batch,
+                tokenizer=tokenizer,
+                task_to_env={NEMO_GYM_ROLLOUT_MODE: env},
+                generation_config=generation_config,
+                max_seq_len=None,
+                max_rollout_turns=None,
+                greedy=False,
+            )
+            rewards = rollout_result.final_batch["total_reward"]
+            evaluation_data.extend(
+                _collect_nemo_gym_evaluation_data(
+                    batch,
+                    rollout_result,
+                    eval_config["save_full_gym_result"],
+                    len(evaluation_data),
+                )
+            )
+            score += _score_batch_rewards(
+                rewards, metric, num_tests_per_prompt, k_value
+            )
+            continue
+
         # measure multiple samples
         if num_tests_per_prompt > 1:
             batch = batch.repeat_interleave(num_tests_per_prompt)
@@ -401,15 +571,10 @@ async def _run_env_eval_impl(
             )
 
         # update stats
-        if metric == "pass@k":
-            score += eval_pass_k(rewards, num_tests_per_prompt, k_value)
-        elif metric == "cons@k":
-            extracted_answers = env_return.answers
-            score += eval_cons_k(
-                rewards, num_tests_per_prompt, k_value, extracted_answers
-            )
-        else:
-            raise ValueError(f"Invalid metric: {metric}")
+        extracted_answers = env_return.answers if metric == "cons@k" else None
+        score += _score_batch_rewards(
+            rewards, metric, num_tests_per_prompt, k_value, extracted_answers
+        )
 
     # Cleanup before printing results
     ray.get(env.shutdown.remote())
@@ -466,9 +631,12 @@ def _save_evaluation_data_to_json(evaluation_data, master_config, save_path):
     config_data = {
         "model_name": master_config["generation"]["model_name"],
         "dataset_name": master_config["data"]["dataset_name"],
+        "rollout_mode": master_config["eval"]["rollout_mode"],
         "metric": master_config["eval"]["metric"],
         "k_value": master_config["eval"]["k_value"],
         "num_tests_per_prompt": master_config["eval"]["num_tests_per_prompt"],
+        "max_rollout_turns": master_config["eval"]["max_rollout_turns"],
+        "save_full_gym_result": master_config["eval"]["save_full_gym_result"],
         "temperature": master_config["generation"]["temperature"],
         "top_p": master_config["generation"]["top_p"],
         "top_k": master_config["generation"]["top_k"],
@@ -483,33 +651,48 @@ def _save_evaluation_data_to_json(evaluation_data, master_config, save_path):
     eval_data_path = os.path.join(save_dir, "evaluation_data.json")
     config_path = os.path.join(save_dir, "config.json")
 
-    # Prepare the data to save
-    data_to_save = {"evaluation_data": evaluation_data}
-
     # Save configuration to separate JSON file
-    with open(config_path, "w") as f:
+    with open(config_path, "w", encoding="utf-8") as f:
         json.dump(config_data, f, indent=2)
     print(f"\n✓ Configuration saved to: {config_path}")
 
     # Process data to make it JSON serializable
-    processed_data = []
-    for sample in evaluation_data:
-        processed_sample = sample.copy()
-        # Convert non-serializable objects to strings
-        processed_sample["message_log"] = str(sample["message_log"])
-        processed_sample["extra_env_info"] = str(sample["extra_env_info"])
-        processed_data.append(processed_sample)
-
-    # Update data to save with processed version
-    data_to_save["evaluation_data"] = processed_data
+    processed_data = [_make_json_serializable(sample) for sample in evaluation_data]
 
     # Save to JSON file
-    with open(eval_data_path, "w") as f:
-        json.dump(data_to_save, f, indent=2)
+    with open(eval_data_path, "w", encoding="utf-8") as f:
+        json.dump({"evaluation_data": processed_data}, f, indent=2)
 
     print(f"\n✓ Evaluation data saved to: {eval_data_path}")
     print(f"  Total samples: {len(evaluation_data)}")
     print(f"  File size: {os.path.getsize(eval_data_path) / 1024 / 1024:.2f} MB")
+
+
+def _make_json_serializable(value):
+    """Convert nested tensors and other values into JSON-serializable objects."""
+    if isinstance(value, torch.Tensor):
+        if value.ndim == 0:
+            return value.item()
+        return value.tolist()
+    if isinstance(value, dict):
+        return {str(k): _make_json_serializable(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_make_json_serializable(v) for v in value]
+    if isinstance(value, tuple):
+        return [_make_json_serializable(v) for v in value]
+
+    try:
+        json.dumps(value)
+    except TypeError:
+        return str(value)
+    return value
+
+
+def _format_metric_name(metric: str, k_value: int) -> str:
+    """Format metric labels for terminal output."""
+    if metric.endswith("@k"):
+        return f"{metric[:-1]}{k_value}"
+    return metric
 
 
 def _print_results(
@@ -530,10 +713,11 @@ def _print_results(
     top_p = generation_config["top_p"]
     top_k = generation_config["top_k"]
     average_score = score / dataset_size
+    metric_name = _format_metric_name(metric, k_value)
 
     print("\n" + "=" * 60)
     print(f"{model_name=} {dataset_name=}")
     print(f"{max_new_tokens=} {temperature=} {top_p=} {top_k=} {seed=}\n")
-    print(f"metric={metric[:-1]}{k_value} {num_tests_per_prompt=}\n")
+    print(f"metric={metric_name} {num_tests_per_prompt=}\n")
     print(f"score={average_score:.4f} ({score}/{dataset_size})")
     print("=" * 60 + "\n")

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -1068,6 +1068,7 @@ class AsyncNemoGymRolloutResult:
     input_ids: torch.Tensor
     final_batch: BatchedDataDict[DatumSpec]
     rollout_metrics: dict[str, Any]
+    raw_results: list[dict[str, Any]] | None = None
 
 
 def _calculate_single_metric(
@@ -1288,4 +1289,5 @@ def run_async_nemo_gym_rollout(
         input_ids=input_ids,
         final_batch=final_batch,
         rollout_metrics=rollout_metrics,
+        raw_results=results,
     )

--- a/tests/unit/evals/test_eval.py
+++ b/tests/unit/evals/test_eval.py
@@ -16,10 +16,84 @@
 import pytest
 import torch
 
+from nemo_rl.data.collate_fn import eval_collate_fn, rl_collate_fn
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.evals.eval import (
+    NEMO_GYM_ROLLOUT_MODE,
+    SINGLE_TURN_ROLLOUT_MODE,
+    _collect_nemo_gym_evaluation_data,
+    _get_eval_collate_fn,
+    _make_json_serializable,
+    _score_batch_rewards,
+    _validate_eval_config,
     eval_cons_k,
     eval_pass_k,
 )
+from nemo_rl.experience.rollouts import AsyncNemoGymRolloutResult
+
+
+def _base_master_config(rollout_mode=SINGLE_TURN_ROLLOUT_MODE):
+    return {
+        "eval": {
+            "rollout_mode": rollout_mode,
+            "max_rollout_turns": 1,
+            "metric": "pass@k",
+            "num_tests_per_prompt": 1,
+            "seed": 42,
+            "k_value": 1,
+            "save_path": None,
+            "save_full_gym_result": False,
+        },
+        "generation": {
+            "backend": "vllm",
+            "max_new_tokens": 128,
+            "temperature": 0.0,
+            "top_p": 1.0,
+            "top_k": -1,
+            "num_prompts_per_step": 1,
+            "model_name": "test-model",
+            "stop_token_ids": None,
+            "stop_strings": None,
+            "vllm_cfg": {
+                "async_engine": False,
+                "expose_http_server": False,
+                "max_model_len": 128,
+            },
+        },
+        "tokenizer": {"name": "test-model"},
+        "data": {"max_input_seq_length": 128, "dataset_name": "aime2024"},
+        "env": {"math": {"num_workers": 1}},
+        "cluster": {"gpus_per_node": 1, "num_nodes": 1},
+    }
+
+
+def _nemo_gym_master_config():
+    config = _base_master_config(NEMO_GYM_ROLLOUT_MODE)
+    config["eval"].update(
+        {
+            "max_rollout_turns": None,
+            "metric": "mean_reward",
+        }
+    )
+    config["generation"].update(
+        {
+            "top_k": None,
+            "vllm_cfg": {
+                "async_engine": True,
+                "expose_http_server": True,
+                "max_model_len": 128,
+            },
+        }
+    )
+    config["data"] = {
+        "max_input_seq_length": None,
+        "dataset_name": "NemoGymDataset",
+        "data_path": "/tmp/example.jsonl",
+        "processor": "nemo_gym_data_processor",
+        "env_name": "nemo_gym",
+    }
+    config["env"] = {"nemo_gym": {"config_paths": ["example.yaml"]}}
+    return config
 
 
 def test_eval_pass_k_basic():
@@ -33,6 +107,117 @@ def test_eval_pass_k_basic():
     expected = 2 / 3
     assert isinstance(average_score, float)
     assert average_score == pytest.approx(expected, rel=1e-6)
+
+
+def test_validate_single_turn_eval_config():
+    """Test validation for the existing single-turn eval mode."""
+    _validate_eval_config(_base_master_config())
+
+
+def test_validate_single_turn_eval_rejects_multi_turn_limit():
+    """Test that single-turn eval does not silently ignore multi-turn config."""
+    config = _base_master_config()
+    config["eval"]["max_rollout_turns"] = 2
+
+    with pytest.raises(AssertionError, match="max_rollout_turns"):
+        _validate_eval_config(config)
+
+
+def test_validate_nemo_gym_eval_config():
+    """Test validation for NeMo-Gym eval mode."""
+    _validate_eval_config(_nemo_gym_master_config())
+
+
+def test_get_eval_collate_fn_selects_rollout_mode_collator():
+    """Test that NeMo-Gym eval uses the RL collator for Gym metadata fields."""
+    assert _get_eval_collate_fn(SINGLE_TURN_ROLLOUT_MODE) is eval_collate_fn
+    assert _get_eval_collate_fn(NEMO_GYM_ROLLOUT_MODE) is rl_collate_fn
+
+
+def test_validate_nemo_gym_eval_requires_no_prompt_repeats():
+    """Test that NeMo-Gym eval rejects driver-level prompt repeats."""
+    config = _nemo_gym_master_config()
+    config["eval"]["num_tests_per_prompt"] = 2
+
+    with pytest.raises(AssertionError, match="num_tests_per_prompt"):
+        _validate_eval_config(config)
+
+
+def test_validate_nemo_gym_eval_requires_openai_server():
+    """Test that NeMo-Gym eval requires exposed vLLM HTTP servers."""
+    config = _nemo_gym_master_config()
+    config["generation"]["vllm_cfg"]["expose_http_server"] = False
+
+    with pytest.raises(AssertionError, match="expose_http_server"):
+        _validate_eval_config(config)
+
+
+def test_validate_nemo_gym_eval_requires_top_k_null():
+    """Test that NeMo-Gym eval rejects top-k sampling."""
+    config = _nemo_gym_master_config()
+    config["generation"]["top_k"] = -1
+
+    with pytest.raises(AssertionError, match="top-k"):
+        _validate_eval_config(config)
+
+
+def test_score_batch_rewards_mean_reward():
+    """Test mean_reward scoring sums batch rewards before dataset averaging."""
+    rewards = torch.tensor([1.5, -0.5, 2.0])
+
+    assert _score_batch_rewards(rewards, "mean_reward", 1, 1) == pytest.approx(3.0)
+
+
+def test_collect_nemo_gym_evaluation_data_controls_full_result():
+    """Test saved NeMo-Gym eval rows include full results only when requested."""
+    batch = BatchedDataDict(
+        {
+            "extra_env_info": [
+                {"responses_create_params": {"input": []}, "agent_ref": {"name": "a"}}
+            ]
+        }
+    )
+    rollout_result = AsyncNemoGymRolloutResult(
+        input_ids=torch.tensor([[1, 2, 3]]),
+        final_batch=BatchedDataDict(
+            {
+                "message_log": [
+                    [{"role": "assistant", "token_ids": torch.tensor([3])}]
+                ],
+                "total_reward": torch.tensor([0.75]),
+                "agent_ref": [{"name": "a"}],
+            }
+        ),
+        rollout_metrics={},
+        raw_results=[{"full_result": {"reward": 0.75, "details": {"ok": True}}}],
+    )
+
+    without_full_result = _collect_nemo_gym_evaluation_data(
+        batch, rollout_result, include_full_gym_result=False, start_sample_index=10
+    )
+    with_full_result = _collect_nemo_gym_evaluation_data(
+        batch, rollout_result, include_full_gym_result=True, start_sample_index=10
+    )
+
+    assert without_full_result[0]["sample_index"] == 10
+    assert "full_result" not in without_full_result[0]
+    assert with_full_result[0]["full_result"] == {
+        "reward": 0.75,
+        "details": {"ok": True},
+    }
+
+
+def test_make_json_serializable_preserves_structured_tensors():
+    """Test that saved eval data keeps nested structure instead of stringifying it."""
+    value = {
+        "message_log": [{"role": "assistant", "token_ids": torch.tensor([1, 2])}],
+        "reward": torch.tensor(1.25),
+    }
+
+    serializable = _make_json_serializable(value)
+
+    assert serializable["message_log"] == [{"role": "assistant", "token_ids": [1, 2]}]
+    assert serializable["reward"] == pytest.approx(1.25)
 
 
 def test_eval_pass_k_all_correct():


### PR DESCRIPTION
## Problem

Standalone eval currently supports only the single-turn environment step path. NeMo-Gym already owns the multi-turn rollout loop used by training, but `examples/run_eval.py` cannot route eval datasets through that Gym-backed rollout path.

Closes NVIDIA-NeMo/RL#1089.

## Root Cause

The eval driver always loads eval datasets, creates a single scoring environment, generates one assistant response, and calls `env.step(...)`. NeMo-Gym data and environments require a different path:

- `NemoGymDataset` and `nemo_gym_data_processor` preserve Gym row metadata in `extra_env_info`
- `rl_collate_fn` preserves the metadata and training-style fields expected by the Gym rollout helper
- vLLM must expose OpenAI-compatible HTTP server URLs for Gym to call the policy
- `run_async_nemo_gym_rollout` owns the multi-turn rollout, reward extraction, and result postprocessing

## Changes

- Add `eval.rollout_mode` with `single_turn` and `nemo_gym` modes.
- Add eval config validation for Gym requirements:
  - `max_rollout_turns: null`
  - `num_tests_per_prompt: 1`
  - async vLLM engine with HTTP server exposure
  - `top_k: null`
  - no stop strings or stop token IDs
- Route `rollout_mode=nemo_gym` through `NemoGymDataset`, `rl_collate_fn`, `NemoGym`, and `run_async_nemo_gym_rollout`.
- Add `mean_reward` scoring for Gym eval while keeping `pass@k` available when Gym rewards are binary.
- Preserve existing single-turn eval behavior and explicitly reject ignored multi-turn limits in single-turn mode.
- Save structured JSON eval outputs instead of stringifying message logs and env metadata.
- Add `examples/configs/evals/nemo_gym_eval.yaml` and update existing eval exemplars with the new required config keys.
- Extend eval unit tests for rollout-mode validation, collator selection, mean-reward scoring, and Gym result saving.

## Validation

- `tests/unit/evals/test_eval.py`: 16 passed
- Focused eval YAML schema validation over all `examples/configs/evals/*.yaml`: passed
- `uvx ruff check examples/run_eval.py nemo_rl/evals/eval.py nemo_rl/environments/nemo_gym.py nemo_rl/experience/rollouts.py nemo_rl/data/__init__.py tests/unit/evals/test_eval.py`: passed
- `uvx ruff format --check examples/run_eval.py nemo_rl/evals/eval.py nemo_rl/environments/nemo_gym.py nemo_rl/experience/rollouts.py nemo_rl/data/__init__.py tests/unit/evals/test_eval.py`: passed
- `python -m py_compile` on changed Python files: passed
- `git diff --check`: passed

Note: the local repo-native `uv run` path is blocked on this macOS host because `/usr/local/bin/python3.13` reports an empty `platform.mac_ver()` to `uv`. The focused pytest run was executed in a temporary Python 3.13 uv environment with the repo import dependencies and a temporary `decord` import stub outside the repository, because `decord` has no usable macOS arm64 CPython 3.13 wheel here and this test file does not exercise video decoding.
