### PR TITLE
feat: add online DPO training

### DIFF
--- a/docs/about/algorithms/index.md
+++ b/docs/about/algorithms/index.md
@@ -11,6 +11,7 @@ NeMo RL supports multiple training algorithms for post-training large language m
 | [On-policy Distillation](on-policy-distillation.md) | [Distillation Single Node](on-policy-distillation.md#on-policy-distillation-single-node) | [Distillation Multi-node](on-policy-distillation.md#on-policy-distillation-multi-node) |
 | [Supervised Fine-Tuning (SFT)](sft.md) | [SFT Single Node](sft.md#sft-single-node) | [SFT Multi-node](sft.md#sft-multi-node) |
 | [DPO](dpo.md) | [DPO Single Node](dpo.md#dpo-single-node) | [DPO Multi-node](dpo.md#dpo-multi-node) |
+| [Online DPO](../../guides/online-dpo.md) | [Online DPO Guide](../../guides/online-dpo.md) | Not yet supported |
 | [RM](rm.md) | [RM Single Node](rm.md#rm-single-node) | [RM Multi-node](rm.md#rm-multi-node) |
 
 On-policy distillation is also supported in the PyTorch DTensor path.

--- a/docs/guides/online-dpo.md
+++ b/docs/guides/online-dpo.md
@@ -1,0 +1,69 @@
+# Online DPO in NeMo RL
+
+Online DPO samples multiple responses from the current policy, scores those responses with a NeMo RL environment, converts the scored responses into chosen/rejected preference pairs, and trains the policy with the existing DPO loss against a frozen reference policy.
+
+The first implementation is intentionally narrow:
+
+- text-only LLM prompts
+- one rollout turn
+- exactly two sampled responses per prompt
+- scalar environment rewards
+- colocated generation
+- no sequence packing or dynamic batching
+- no NeMo-Gym rollouts or multiple prompt dataloaders
+
+These constraints keep pair construction and DPO masking predictable. The rollout helpers append the environment observation after scoring; Online DPO strips that trailing observation and trains only on the sampled assistant response.
+
+## Launch an Online DPO Run
+
+Use [examples/run_online_dpo.py](../../examples/run_online_dpo.py):
+
+```bash
+uv run examples/run_online_dpo.py --config <PATH TO YAML CONFIG> <OVERRIDES>
+```
+
+If `--config` is omitted, the script uses [examples/configs/online_dpo.yaml](../../examples/configs/online_dpo.yaml).
+
+For example, to run a short local smoke test:
+
+```bash
+uv run examples/run_online_dpo.py \
+    policy.model_name=Qwen/Qwen3-0.6B \
+    cluster.gpus_per_node=2 \
+    online_dpo.num_prompts_per_step=2 \
+    policy.train_global_batch_size=2 \
+    policy.train_micro_batch_size=1 \
+    online_dpo.max_num_steps=2 \
+    checkpointing.enabled=false
+```
+
+## Data and Environments
+
+Online DPO uses response-style prompt datasets, the same data surface used by GRPO. Each prompt is rolled out twice, and both responses are scored by the configured environment. The higher-reward response becomes `chosen`; the lower-reward response becomes `rejected`.
+
+Pairs are dropped when:
+
+- the absolute reward difference is less than or equal to `online_dpo.min_reward_margin`
+- either response is truncated and `online_dpo.drop_truncated_pairs` is `true`
+
+The trainer collects enough usable pairs to fill `policy.train_global_batch_size`. If the dataloader ends before a full usable batch is available, the partial batch is discarded rather than carried across epochs.
+
+## Important Configuration
+
+- `online_dpo.num_generations_per_prompt` must be `2`.
+- `online_dpo.max_rollout_turns` must be `1`.
+- `online_dpo.num_prompts_per_step` must match `policy.train_global_batch_size`.
+- `policy.sequence_packing.enabled` and `policy.dynamic_batching.enabled` must be `false`.
+- `checkpointing.metric_name` can use `val:reward` for environment rollout validation.
+
+Online DPO reuses the DPO loss keys under `online_dpo`:
+
+- `reference_policy_kl_penalty`
+- `preference_average_log_probs`
+- `sft_average_log_probs`
+- `preference_loss_weight`
+- `sft_loss_weight`
+
+## Validation
+
+Validation performs normal environment rollouts with one response per prompt and reports reward and average generated length. It does not build online preference pairs or run a validation DPO loss.

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,7 +62,7 @@ Learn about DTensor and Megatron Core training backends, their capabilities, and
 :link: about/algorithms/index
 :link-type: doc
 
-Discover supported algorithms including GRPO, SFT, DPO, RM, and on-policy distillation with detailed guides and examples.
+Discover supported algorithms including GRPO, SFT, DPO, Online DPO, RM, and on-policy distillation with detailed guides and examples.
 :::
 
 :::{grid-item-card} {octicon}`graph` Evaluation
@@ -236,6 +236,7 @@ guides/nemotron-3-nano.md
 adding-new-models.md
 guides/sft.md
 guides/dpo.md
+guides/online-dpo.md
 guides/dapo.md
 guides/prorlv2.md
 guides/grpo.md

--- a/examples/configs/online_dpo.yaml
+++ b/examples/configs/online_dpo.yaml
@@ -1,0 +1,285 @@
+# Online DPO Algorithm Configuration
+online_dpo:
+  # Online DPO samples exactly two responses per prompt and trains the winner
+  # against the loser using the standard DPO loss.
+  num_prompts_per_step: 32
+  num_generations_per_prompt: 2
+  max_rollout_turns: 1
+  max_num_epochs: 1
+  max_num_steps: 1000000
+  val_period: 10
+  val_at_start: false
+  val_at_end: false
+  max_val_samples: 256
+  val_batch_size: 256
+  seed: 42
+  min_reward_margin: 0.0
+  drop_truncated_pairs: true
+
+  reference_policy_kl_penalty: 0.05
+  preference_average_log_probs: false
+  sft_average_log_probs: ${.preference_average_log_probs}
+  preference_loss_weight: 1.0
+  sft_loss_weight: 0.0
+
+checkpointing:
+  enabled: true
+  checkpoint_dir: "results/online_dpo"
+  metric_name: "val:reward"
+  higher_is_better: true
+  keep_top_k: 3
+  save_period: 10
+  checkpoint_must_save_by: null
+  model_save_format: "safetensors"
+  save_consolidated: false
+  save_optimizer: true
+
+policy:
+  model_name: "Qwen/Qwen2.5-1.5B"
+  tokenizer:
+    name: ${policy.model_name}
+    chat_template_kwargs: null
+  hf_config_overrides: {}
+  # This counts online preference pairs. Each pair becomes two model sequences
+  # after collation, so Online DPO trains with an effective model batch of 2x.
+  train_global_batch_size: ${online_dpo.num_prompts_per_step}
+  train_micro_batch_size: 2
+  generation_batch_size: 32
+  logprob_batch_size: ${policy.train_micro_batch_size}
+  max_total_sequence_length: 512
+  precision: "bfloat16"
+  logprob_chunk_size: null
+  offload_optimizer_for_logprob: false
+
+  dtensor_cfg:
+    _v2: true
+    enabled: true
+    cpu_offload: false
+    sequence_parallel: false
+    activation_checkpointing: false
+    tensor_parallel_size: 1
+    context_parallel_size: 1
+    custom_parallel_plan: null
+    automodel_kwargs: {}
+    lora_cfg:
+      enabled: false
+      target_modules: []
+      exclude_modules: []
+      match_all_linear: true
+      dim: 8
+      alpha: 32
+      dropout: 0.0
+      dropout_position: "post"
+      lora_A_init: "xavier"
+      use_triton: true
+
+  megatron_cfg:
+    enabled: false
+    force_reconvert_from_hf: false
+    empty_unused_memory_level: 1
+    activation_checkpointing: false
+    use_linear_ce_fusion_loss: false
+    linear_ce_fusion_chunk_size: 256
+    converter_type: "Qwen2ForCausalLM"
+    tensor_model_parallel_size: 1
+    expert_tensor_parallel_size: 1
+    expert_model_parallel_size: 1
+    pipeline_model_parallel_size: 1
+    num_layers_in_first_pipeline_stage: null
+    num_layers_in_last_pipeline_stage: null
+    context_parallel_size: 1
+    pipeline_dtype: ${policy.precision}
+    sequence_parallel: false
+    freeze_moe_router: true
+    moe_router_dtype: "fp64"
+    moe_router_load_balancing_type: "none"
+    moe_router_bias_update_rate: 0.0
+    moe_permute_fusion: true
+    apply_rope_fusion: true
+    bias_activation_fusion: true
+    defer_fp32_logits: false
+    moe_per_layer_logging: false
+    moe_enable_deepep: false
+    moe_token_dispatcher_type: "alltoall"
+    moe_shared_expert_overlap: false
+    gradient_accumulation_fusion: false
+    peft:
+      enabled: false
+      target_modules: []
+      exclude_modules: []
+      dim: 8
+      alpha: 32
+      dropout: 0.0
+      dropout_position: "post"
+      lora_A_init_method: "xavier"
+      lora_B_init_method: "zero"
+      a2a_experimental: false
+      lora_dtype: null
+    optimizer:
+      optimizer: "adam"
+      lr: 5.0e-6
+      min_lr: 5.0e-7
+      weight_decay: 0.01
+      bf16: true
+      fp16: false
+      params_dtype: "float32"
+      adam_beta1: 0.9
+      adam_beta2: 0.999
+      adam_eps: 1e-8
+      sgd_momentum: 0.9
+      use_distributed_optimizer: true
+      use_precision_aware_optimizer: true
+      clip_grad: ${policy.max_grad_norm}
+      optimizer_cpu_offload: false
+      optimizer_offload_fraction: 0.0
+    scheduler:
+      start_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
+      end_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
+      weight_decay_incr_style: "constant"
+      lr_decay_style: "constant"
+      lr_decay_iters: 1000
+      lr_warmup_iters: 13
+      lr_warmup_init: 5.0e-7
+    distributed_data_parallel_config:
+      grad_reduce_in_fp32: false
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+      use_custom_fsdp: false
+      data_parallel_sharding_strategy: "optim_grads_params"
+    fp8_cfg:
+      enabled: false
+      fp8: "e4m3"
+      fp8_recipe: "blockwise"
+      fp8_param: false
+    env_vars: null
+
+  draft:
+    enabled: false
+    model_name: null
+    loss_weight: 0.1
+    num_layers: null
+    aux_layer_indices: null
+
+  dynamic_batching:
+    enabled: false
+    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
+    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
+    sequence_length_round: 64
+
+  sequence_packing:
+    enabled: false
+    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
+    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
+    algorithm: "modified_first_fit_decreasing"
+    sequence_length_round: 64
+
+  make_sequence_length_divisible_by: ${policy.dtensor_cfg.tensor_parallel_size}
+  max_grad_norm: 1.0
+
+  optimizer:
+    name: "torch.optim.AdamW"
+    kwargs:
+      lr: 5.0e-6
+      weight_decay: 0.01
+      betas: [0.9, 0.999]
+      eps: 1e-8
+      foreach: false
+      fused: false
+
+  scheduler:
+    - name: "torch.optim.lr_scheduler.LinearLR"
+      kwargs:
+        start_factor: 0.1
+        end_factor: 1.0
+        total_iters: 50
+    - name: "torch.optim.lr_scheduler.ConstantLR"
+      kwargs:
+        factor: 1.0
+        total_iters: 10000000000
+    - milestones: [50]
+
+  generation:
+    backend: "vllm"
+    max_new_tokens: ${policy.max_total_sequence_length}
+    temperature: 1.0
+    top_p: 1.0
+    top_k: null
+    stop_token_ids: null
+    stop_strings: null
+    mcore_generation_config:
+      buffer_size_gb: 10
+      num_cuda_graphs: 4
+      block_size_tokens: 256
+      use_cuda_graphs_for_non_decode_steps: true
+      enable_chunked_prefill: true
+      unified_memory_level: 0
+      max_tokens: 16384
+    vllm_cfg:
+      async_engine: false
+      precision: ${policy.precision}
+      kv_cache_dtype: "auto"
+      tensor_parallel_size: 1
+      pipeline_parallel_size: 1
+      expert_parallel_size: 1
+      gpu_memory_utilization: 0.6
+      max_model_len: ${policy.max_total_sequence_length}
+      enforce_eager: false
+      use_deep_gemm: false
+      num_last_layers_in_bf16: 0
+      num_first_layers_in_bf16: 0
+      enable_vllm_metrics_logger: true
+      vllm_metrics_logger_interval: 0.5
+    vllm_kwargs: {}
+    colocated:
+      enabled: true
+      resources:
+        gpus_per_node: null
+        num_nodes: null
+
+data:
+  max_input_seq_length: ${policy.max_total_sequence_length}
+  shuffle: true
+  num_workers: 1
+  use_multiple_dataloader: false
+  train:
+    dataset_name: OpenMathInstruct-2
+    split_validation_size: 0.05
+    seed: ${online_dpo.seed}
+  validation: null
+  default:
+    prompt_file: "examples/prompts/cot.txt"
+    system_prompt_file: null
+    processor: "math_hf_data_processor"
+    env_name: "math"
+
+env:
+  math:
+    num_workers: 8
+    math_verify_impl: "hf_math_verify"
+
+logger:
+  log_dir: "logs"
+  num_val_samples_to_print: 0
+  wandb_enabled: false
+  tensorboard_enabled: false
+  mlflow_enabled: false
+  swanlab_enabled: false
+  monitor_gpus: true
+  wandb:
+    project: "online-dpo-dev"
+    name: "online-dpo-dev-logger"
+  swanlab:
+    project: "online-dpo-dev"
+    name: "online-dpo-dev-logger"
+  tensorboard: {}
+  mlflow:
+    experiment_name: "online-dpo-dev"
+    run_name: "online-dpo-dev-logger"
+    tracking_uri: "http://localhost:5000"
+  gpu_monitoring:
+    collection_interval: 10
+    flush_interval: 10
+
+cluster:
+  gpus_per_node: 1
+  num_nodes: 1

--- a/examples/run_online_dpo.py
+++ b/examples/run_online_dpo.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import pprint
+
+from omegaconf import OmegaConf
+
+from nemo_rl.algorithms.online_dpo import MasterConfig, online_dpo_train, setup
+from nemo_rl.algorithms.utils import get_tokenizer
+from nemo_rl.data.utils import setup_response_data
+from nemo_rl.distributed.virtual_cluster import init_ray
+from nemo_rl.models.generation import configure_generation_config
+from nemo_rl.utils.config import (
+    load_config,
+    parse_hydra_overrides,
+    register_omegaconf_resolvers,
+)
+from nemo_rl.utils.logger import get_next_experiment_dir
+
+
+def parse_args() -> tuple[argparse.Namespace, list[str]]:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Run Online DPO training with configuration"
+    )
+    parser.add_argument(
+        "--config", type=str, default=None, help="Path to YAML config file"
+    )
+    args, overrides = parser.parse_known_args()
+    return args, overrides
+
+
+def main() -> None:
+    """Main entry point."""
+    register_omegaconf_resolvers()
+    args, overrides = parse_args()
+
+    if not args.config:
+        args.config = os.path.join(
+            os.path.dirname(__file__), "configs", "online_dpo.yaml"
+        )
+
+    config = load_config(args.config)
+    print(f"Loaded configuration from: {args.config}")
+
+    if overrides:
+        print(f"Overrides: {overrides}")
+        config = parse_hydra_overrides(config, overrides)
+
+    config: MasterConfig = OmegaConf.to_container(config, resolve=True)
+    print("Applied CLI overrides")
+
+    print("Final config:")
+    pprint.pprint(config)
+
+    config["logger"]["log_dir"] = get_next_experiment_dir(config["logger"]["log_dir"])
+    print(f"Using log directory: {config['logger']['log_dir']}")
+    if config["checkpointing"]["enabled"]:
+        print(
+            f"Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}"
+        )
+
+    init_ray()
+
+    tokenizer = get_tokenizer(config["policy"]["tokenizer"])
+    assert config["policy"]["generation"] is not None, (
+        "A generation config is required for Online DPO."
+    )
+    has_refit_draft_weights = bool(config["policy"]["draft"]["enabled"])
+    config["policy"]["generation"] = configure_generation_config(
+        config["policy"]["generation"],
+        tokenizer,
+        has_refit_draft_weights=has_refit_draft_weights,
+    )
+
+    dataset, val_dataset, task_to_env, val_task_to_env = setup_response_data(
+        tokenizer,
+        config["data"],
+        config["env"],
+    )
+
+    (
+        policy,
+        policy_generation,
+        _cluster,
+        train_dataloader,
+        val_dataloader,
+        loss_fn,
+        logger,
+        checkpointer,
+        online_dpo_state,
+        master_config,
+    ) = setup(config, tokenizer, dataset, val_dataset)
+
+    online_dpo_train(
+        policy,
+        policy_generation,
+        train_dataloader,
+        val_dataloader,
+        tokenizer,
+        loss_fn,
+        task_to_env,
+        val_task_to_env,
+        logger,
+        checkpointer,
+        online_dpo_state,
+        master_config,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/nemo_rl/algorithms/online_dpo.py
+++ b/nemo_rl/algorithms/online_dpo.py
@@ -1,0 +1,1185 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import copy
+import gc
+import os
+import time
+import warnings
+from typing import Any, NotRequired, Optional, TypedDict, TypeVar, cast
+
+import numpy as np
+import torch
+from torchdata.stateful_dataloader import StatefulDataLoader
+from transformers import AutoProcessor
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+
+from nemo_rl.algorithms.grpo import (
+    _should_log_nemo_gym_responses,
+    _should_use_async_rollouts,
+    refit_policy_generation,
+)
+from nemo_rl.algorithms.loss import DPOLossFn
+from nemo_rl.algorithms.utils import set_seed
+from nemo_rl.data import DataConfig
+from nemo_rl.data.collate_fn import preference_collate_fn, rl_collate_fn
+from nemo_rl.data.datasets import AllTaskProcessedDataset
+from nemo_rl.data.interfaces import LLMMessageLogType, PreferenceDatumSpec
+from nemo_rl.data.llm_message_utils import get_keys_from_message_log
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.distributed.virtual_cluster import ClusterConfig, RayVirtualCluster
+from nemo_rl.environments.interfaces import EnvironmentInterface
+from nemo_rl.experience.rollouts import (
+    run_async_multi_turn_rollout,
+    run_multi_turn_rollout,
+)
+from nemo_rl.models.generation.interfaces import GenerationInterface
+from nemo_rl.models.generation.sglang import SGLangConfig, SGLangGeneration
+from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration
+from nemo_rl.models.policy import PolicyConfig
+from nemo_rl.models.policy.interfaces import ColocatablePolicyInterface
+from nemo_rl.models.policy.lm_policy import Policy
+from nemo_rl.utils.checkpoint import CheckpointingConfig, CheckpointManager
+from nemo_rl.utils.logger import Logger, LoggerConfig, print_message_log_samples
+from nemo_rl.utils.nsys import maybe_gpu_profile_step
+from nemo_rl.utils.timer import TimeoutChecker, Timer
+
+TokenizerType = TypeVar("TokenizerType", bound=PreTrainedTokenizerBase)
+
+
+class OnlineDPOConfig(TypedDict):
+    """Configuration for online DPO.
+
+    Required keys:
+        num_prompts_per_step: Number of prompts sampled for each online generation
+            batch. Recommended default: equal to policy.train_global_batch_size.
+        num_generations_per_prompt: Number of responses sampled per prompt. Online
+            DPO currently requires exactly 2.
+        max_num_epochs: Maximum passes over the prompt dataloader.
+        max_num_steps: Maximum policy optimizer steps.
+        max_rollout_turns: Maximum environment turns per generated response. Online
+            DPO currently requires 1 so the final trainable target is the sampled
+            assistant response.
+        val_period: Run environment rollout validation every N optimizer steps. Use
+            0 to disable periodic validation.
+        val_batch_size: Number of prompts per validation rollout batch.
+        val_at_start: Whether to run validation before the first optimizer step.
+        val_at_end: Whether to run validation on the final optimizer step.
+        max_val_samples: Maximum validation samples to roll out when validation runs.
+        seed: Random seed for data, model, and generation setup.
+        min_reward_margin: Minimum absolute reward difference required to keep a
+            generated pair. Recommended default: 0.0.
+        drop_truncated_pairs: Whether to drop pairs where either response hit a
+            rollout truncation condition. Recommended default: true.
+        reference_policy_kl_penalty: DPO beta parameter.
+        preference_average_log_probs: Whether to average DPO logprob differences
+            over response tokens.
+        sft_average_log_probs: Whether to average the auxiliary SFT term over
+            response tokens.
+        preference_loss_weight: Weight for the DPO preference loss.
+        sft_loss_weight: Weight for the auxiliary SFT loss on chosen responses.
+    """
+
+    num_prompts_per_step: int
+    num_generations_per_prompt: int
+    max_num_epochs: int
+    max_num_steps: int
+    max_rollout_turns: int
+    val_period: int
+    val_batch_size: int
+    val_at_start: bool
+    val_at_end: bool
+    max_val_samples: int
+    seed: int
+    min_reward_margin: float
+    drop_truncated_pairs: bool
+    reference_policy_kl_penalty: float
+    preference_average_log_probs: bool
+    sft_average_log_probs: bool
+    preference_loss_weight: float
+    sft_loss_weight: float
+
+
+class OnlineDPOSaveState(TypedDict):
+    consumed_samples: int
+    current_step: int
+    current_prompt_batch: int
+    current_epoch: int
+    total_steps: int
+    total_valid_tokens: int
+    val_reward: NotRequired[float]
+
+
+class OnlineDPOLoggerConfig(LoggerConfig):
+    num_val_samples_to_print: int
+
+
+class MasterConfig(TypedDict):
+    policy: PolicyConfig
+    env: dict[str, Any]
+    data: DataConfig
+    online_dpo: OnlineDPOConfig
+    logger: OnlineDPOLoggerConfig
+    cluster: ClusterConfig
+    checkpointing: CheckpointingConfig
+
+
+def _default_online_dpo_save_state() -> OnlineDPOSaveState:
+    return {
+        "consumed_samples": 0,
+        "current_step": 0,
+        "current_prompt_batch": 0,
+        "current_epoch": 0,
+        "total_steps": 0,
+        "total_valid_tokens": 0,
+        "val_reward": -99999999.0,
+    }
+
+
+def _validate_online_dpo_config(
+    master_config: MasterConfig, processor: Optional[AutoProcessor]
+) -> None:
+    online_dpo_config = master_config["online_dpo"]
+    policy_config = master_config["policy"]
+    data_config = master_config["data"]
+
+    assert online_dpo_config["num_generations_per_prompt"] == 2, (
+        "Online DPO currently requires online_dpo.num_generations_per_prompt=2 "
+        "so each prompt produces one chosen/rejected pair."
+    )
+    assert online_dpo_config["max_rollout_turns"] == 1, (
+        "Online DPO currently supports one rollout turn. Multi-turn trajectories "
+        "need a richer pair construction policy before they can be trained safely."
+    )
+    assert online_dpo_config["num_prompts_per_step"] > 0
+    assert online_dpo_config["max_num_epochs"] > 0
+    assert online_dpo_config["max_num_steps"] > 0
+    assert online_dpo_config["val_period"] >= 0
+    assert online_dpo_config["val_batch_size"] > 0
+    assert online_dpo_config["max_val_samples"] >= 0
+    assert online_dpo_config["min_reward_margin"] >= 0
+    assert not data_config["use_multiple_dataloader"], (
+        "Online DPO currently supports a single prompt dataloader."
+    )
+    assert processor is None, "Online DPO currently supports text-only LLM data."
+    assert not policy_config["dynamic_batching"]["enabled"], (
+        "Dynamic batching is currently not supported with Online DPO because "
+        "DPO relies on stable chosen/rejected ordering within each pair."
+    )
+    assert not policy_config["sequence_packing"]["enabled"], (
+        "Sequence packing is currently not supported with Online DPO because "
+        "DPO relies on stable chosen/rejected ordering within each pair."
+    )
+    assert not bool(master_config["env"].get("should_use_nemo_gym")), (
+        "Online DPO currently uses NeMo RL EnvironmentInterface environments, "
+        "not NeMo-Gym rollouts."
+    )
+
+    generation_config = policy_config["generation"]
+    assert generation_config is not None, (
+        "A generation config in policy.generation is required for Online DPO."
+    )
+    assert generation_config["colocated"]["enabled"], (
+        "Online DPO currently supports colocated generation only."
+    )
+    assert (
+        policy_config["train_global_batch_size"]
+        == online_dpo_config["num_prompts_per_step"]
+    ), (
+        "For the first Online DPO implementation, policy.train_global_batch_size "
+        "must equal online_dpo.num_prompts_per_step. This keeps each optimizer "
+        "step at one full batch of usable preference pairs."
+    )
+
+
+def setup(
+    master_config: MasterConfig,
+    tokenizer: TokenizerType,
+    dataset: AllTaskProcessedDataset,
+    val_dataset: Optional[AllTaskProcessedDataset],
+    processor: Optional[AutoProcessor] = None,
+) -> tuple[
+    ColocatablePolicyInterface,
+    Optional[GenerationInterface],
+    RayVirtualCluster,
+    StatefulDataLoader,
+    Optional[StatefulDataLoader],
+    DPOLossFn,
+    Logger,
+    CheckpointManager,
+    OnlineDPOSaveState,
+    MasterConfig,
+]:
+    """Set up Online DPO training components."""
+    setup_start_time = time.perf_counter()
+    _validate_online_dpo_config(master_config, processor)
+
+    policy_config = master_config["policy"]
+    generation_config = policy_config["generation"]
+    online_dpo_config = master_config["online_dpo"]
+    data_config = master_config["data"]
+    logger_config = master_config["logger"]
+    cluster_config = master_config["cluster"]
+    assert generation_config is not None
+
+    set_seed(online_dpo_config["seed"])
+
+    logger = Logger(logger_config)
+    logger.log_hyperparams(master_config)
+
+    checkpointer = CheckpointManager(master_config["checkpointing"])
+    last_checkpoint_path = checkpointer.get_latest_checkpoint_path()
+    online_dpo_save_state: Optional[OnlineDPOSaveState] = cast(
+        Optional[OnlineDPOSaveState],
+        checkpointer.load_training_info(last_checkpoint_path),
+    )
+    if online_dpo_save_state is None:
+        online_dpo_save_state = _default_online_dpo_save_state()
+
+    train_dataloader = StatefulDataLoader(
+        dataset,
+        batch_size=online_dpo_config["num_prompts_per_step"],
+        shuffle=data_config["shuffle"],
+        collate_fn=rl_collate_fn,
+        drop_last=True,
+        num_workers=data_config["num_workers"],
+    )
+    if last_checkpoint_path is not None:
+        dataloader_state_dict = torch.load(
+            os.path.join(last_checkpoint_path, "train_dataloader.pt")
+        )
+        train_dataloader.load_state_dict(dataloader_state_dict)
+    print(f"  - Online DPO train dataloader loaded with {len(dataset)} prompts")
+
+    val_dataloader: Optional[StatefulDataLoader] = None
+    if (
+        online_dpo_config["val_period"] > 0
+        or online_dpo_config["val_at_start"]
+        or online_dpo_config["val_at_end"]
+    ):
+        assert val_dataset is not None, (
+            "Validation dataset is required when Online DPO validation is enabled."
+        )
+        val_dataloader = StatefulDataLoader(
+            val_dataset,
+            batch_size=online_dpo_config["val_batch_size"],
+            shuffle=False,
+            collate_fn=rl_collate_fn,
+            drop_last=False,
+            num_workers=data_config["num_workers"],
+        )
+        print(
+            f"  - Online DPO validation dataloader loaded with {len(val_dataset)} prompts"
+        )
+
+    print("\nSetting up compute cluster...", flush=True)
+    backend = generation_config["backend"]
+    cluster = RayVirtualCluster(
+        name="online_dpo_cluster",
+        bundle_ct_per_node_list=[cluster_config["gpus_per_node"]]
+        * cluster_config["num_nodes"],
+        use_gpus=True,
+        num_gpus_per_node=cluster_config["gpus_per_node"],
+        max_colocated_worker_groups=1 if backend == "megatron" else 2,
+    )
+    print(
+        f"  - Ray cluster initialized with {cluster_config['num_nodes']} node(s)",
+        flush=True,
+    )
+
+    print("\nSetting up model and generation...", flush=True)
+    generation_config["model_name"] = policy_config["model_name"]
+    weights_path, optimizer_path = checkpointer.get_resume_paths(last_checkpoint_path)
+
+    if policy_config["megatron_cfg"]["enabled"]:
+        total_train_iters = min(
+            online_dpo_config["max_num_steps"],
+            online_dpo_config["max_num_epochs"] * len(train_dataloader),
+        )
+        policy_config["megatron_cfg"]["train_iters"] = total_train_iters * 2
+        if "scheduler" in policy_config["megatron_cfg"]:
+            for key in policy_config["megatron_cfg"]["scheduler"]:
+                if "iters" in key:
+                    policy_config["megatron_cfg"]["scheduler"][key] *= 2
+
+    policy_generation: Optional[GenerationInterface]
+    if backend == "megatron":
+        policy_generation = None
+        print(
+            f"  - Using {backend} backend for generation with {policy_config['model_name']}",
+            flush=True,
+        )
+    elif backend == "vllm":
+        generation_config = cast(VllmConfig, generation_config)
+        if "hf_config_overrides" in policy_config:
+            generation_config["vllm_kwargs"]["hf_overrides"] = policy_config[
+                "hf_config_overrides"
+            ]
+        policy_generation = VllmGeneration(cluster=cluster, config=generation_config)
+        policy_generation.finish_generation()
+        print(
+            f"  - Using vLLM backend for generation with {policy_config['model_name']}",
+            flush=True,
+        )
+    elif backend == "sglang":
+        generation_config = cast(SGLangConfig, generation_config)
+        if "model_path" not in generation_config["sglang_cfg"]:
+            generation_config["sglang_cfg"]["model_path"] = policy_config["model_name"]
+        policy_generation = SGLangGeneration(cluster=cluster, config=generation_config)
+        policy_generation.finish_generation()
+        print(
+            f"  - Using SGLang backend for generation with {policy_config['model_name']}",
+            flush=True,
+        )
+    else:
+        raise ValueError(f"Unsupported generation backend for Online DPO: {backend}")
+
+    policy = Policy(
+        cluster=cluster,
+        config=policy_config,
+        tokenizer=tokenizer,
+        processor=processor,
+        weights_path=weights_path,
+        optimizer_path=optimizer_path,
+        init_optimizer=True,
+        init_reference_model=True,
+    )
+    policy.print_node_ip_and_gpu_id()
+
+    state_dict_info = policy.prepare_refit_info()
+    if policy_generation is not None:
+        policy_generation.prepare_refit_info(state_dict_info)
+
+    loss_fn = DPOLossFn(
+        online_dpo_config,
+        use_linear_ce_fusion=policy_config["megatron_cfg"]["enabled"]
+        and policy_config["megatron_cfg"]["use_linear_ce_fusion_loss"],
+    )
+
+    print(f"  - Setup complete in {time.perf_counter() - setup_start_time:.2f}s")
+
+    return (
+        policy,
+        policy_generation,
+        cluster,
+        train_dataloader,
+        val_dataloader,
+        loss_fn,
+        logger,
+        checkpointer,
+        online_dpo_save_state,
+        master_config,
+    )
+
+
+def strip_trailing_environment_messages(
+    message_log: LLMMessageLogType,
+) -> LLMMessageLogType:
+    """Return a copy of a rollout log ending at the last assistant response.
+
+    Rollout helpers append the environment observation after scoring. DPO should
+    optimize the sampled assistant response, not the trailing environment message.
+    """
+    last_assistant_idx = None
+    for idx in range(len(message_log) - 1, -1, -1):
+        if message_log[idx]["role"] == "assistant":
+            last_assistant_idx = idx
+            break
+    if last_assistant_idx is None:
+        raise ValueError(
+            "Cannot build an Online DPO pair without an assistant response."
+        )
+    return copy.deepcopy(message_log[: last_assistant_idx + 1])
+
+
+def _message_log_length(message_log: LLMMessageLogType) -> int:
+    length = 0
+    for message in message_log:
+        token_ids = message.get("token_ids")
+        if token_ids is None:
+            raise ValueError("Online DPO message logs must contain token_ids.")
+        assert isinstance(token_ids, torch.Tensor)
+        length += int(token_ids.numel())
+    return length
+
+
+def _as_float(value: Any) -> float:
+    if isinstance(value, torch.Tensor):
+        return float(value.item())
+    return float(value)
+
+
+def _as_int(value: Any) -> int:
+    if isinstance(value, torch.Tensor):
+        return int(value.item())
+    return int(value)
+
+
+def build_preference_datums_from_rollouts(
+    rollout_batch: BatchedDataDict,
+    *,
+    min_reward_margin: float,
+    drop_truncated_pairs: bool,
+    max_pairs: Optional[int] = None,
+) -> tuple[list[PreferenceDatumSpec], dict[str, float]]:
+    """Create chosen/rejected Online DPO records from a two-sample rollout batch."""
+    if rollout_batch.size % 2 != 0:
+        raise ValueError(
+            f"Online DPO expects an even rollout batch size, got {rollout_batch.size}."
+        )
+    if "total_reward" not in rollout_batch:
+        raise ValueError("Online DPO rollout batch is missing total_reward.")
+
+    preference_datums: list[PreferenceDatumSpec] = []
+    reward_margins = []
+    chosen_rewards = []
+    rejected_rewards = []
+    tie_pairs = 0
+    truncated_pairs = 0
+    dropped_pairs = 0
+    processed_pairs = 0
+
+    truncated = rollout_batch.get("truncated")
+
+    for pair_start in range(0, rollout_batch.size, 2):
+        processed_pairs += 1
+        first_idx = pair_start
+        second_idx = pair_start + 1
+
+        if drop_truncated_pairs and truncated is not None:
+            first_truncated = bool(truncated[first_idx])
+            second_truncated = bool(truncated[second_idx])
+            if first_truncated or second_truncated:
+                truncated_pairs += 1
+                dropped_pairs += 1
+                continue
+
+        first_reward = _as_float(rollout_batch["total_reward"][first_idx])
+        second_reward = _as_float(rollout_batch["total_reward"][second_idx])
+        margin = abs(first_reward - second_reward)
+        if margin <= min_reward_margin:
+            tie_pairs += 1
+            dropped_pairs += 1
+            continue
+
+        if first_reward > second_reward:
+            chosen_idx, rejected_idx = first_idx, second_idx
+            chosen_reward, rejected_reward = first_reward, second_reward
+        else:
+            chosen_idx, rejected_idx = second_idx, first_idx
+            chosen_reward, rejected_reward = second_reward, first_reward
+
+        chosen_log = strip_trailing_environment_messages(
+            cast(LLMMessageLogType, rollout_batch["message_log"][chosen_idx])
+        )
+        rejected_log = strip_trailing_environment_messages(
+            cast(LLMMessageLogType, rollout_batch["message_log"][rejected_idx])
+        )
+
+        loss_multiplier = min(
+            _as_float(rollout_batch["loss_multiplier"][chosen_idx]),
+            _as_float(rollout_batch["loss_multiplier"][rejected_idx]),
+        )
+        datum: dict[str, Any] = {
+            "message_log_chosen": chosen_log,
+            "message_log_rejected": rejected_log,
+            "length_chosen": _message_log_length(chosen_log),
+            "length_rejected": _message_log_length(rejected_log),
+            "loss_multiplier": loss_multiplier,
+            "idx": _as_int(rollout_batch["idx"][pair_start]),
+        }
+        if "task_name" in rollout_batch:
+            datum["task_name"] = rollout_batch["task_name"][pair_start]
+        preference_datums.append(cast(PreferenceDatumSpec, datum))
+        reward_margins.append(margin)
+        chosen_rewards.append(chosen_reward)
+        rejected_rewards.append(rejected_reward)
+
+        if max_pairs is not None and len(preference_datums) >= max_pairs:
+            break
+
+    generated_pairs = rollout_batch.size // 2
+    discarded_pairs = max(0, generated_pairs - processed_pairs)
+    metrics = {
+        "generated_pairs": float(generated_pairs),
+        "usable_pairs": float(len(preference_datums)),
+        "dropped_pairs": float(dropped_pairs),
+        "discarded_pairs": float(discarded_pairs),
+        "tie_pairs": float(tie_pairs),
+        "truncated_pairs": float(truncated_pairs),
+        "chosen_reward": float(np.mean(chosen_rewards)) if chosen_rewards else 0.0,
+        "rejected_reward": float(np.mean(rejected_rewards))
+        if rejected_rewards
+        else 0.0,
+        "reward_margin": float(np.mean(reward_margins)) if reward_margins else 0.0,
+    }
+    return preference_datums, metrics
+
+
+def collate_preference_datums(
+    preference_datums: list[PreferenceDatumSpec],
+    tokenizer: TokenizerType,
+    make_sequence_length_divisible_by: int,
+) -> BatchedDataDict:
+    """Collate Online DPO preference records with the offline DPO collator."""
+    return preference_collate_fn(
+        preference_datums,
+        tokenizer=tokenizer,
+        make_sequence_length_divisible_by=make_sequence_length_divisible_by,
+        add_loss_mask=True,
+    )
+
+
+def add_reference_logprobs_to_preference_batch(
+    preference_batch: BatchedDataDict,
+    policy: ColocatablePolicyInterface,
+    *,
+    micro_batch_size: int,
+    timer: Optional[Timer] = None,
+) -> BatchedDataDict:
+    """Append rolled reference-policy logprobs required by DPOLossFn."""
+    reference_logprobs = policy.get_reference_policy_logprobs(
+        preference_batch,
+        micro_batch_size=micro_batch_size,
+        timer=timer,
+    )["reference_logprobs"]
+    preference_batch["reference_policy_logprobs"] = torch.roll(
+        reference_logprobs, -1, dims=-1
+    )
+    return preference_batch
+
+
+def _run_rollout(
+    policy_generation: GenerationInterface,
+    batch: BatchedDataDict,
+    tokenizer: TokenizerType,
+    task_to_env: dict[str, EnvironmentInterface],
+    master_config: MasterConfig,
+) -> tuple[BatchedDataDict, dict[str, Any]]:
+    if _should_use_async_rollouts(master_config):
+        return run_async_multi_turn_rollout(
+            policy_generation=policy_generation,
+            input_batch=batch,
+            tokenizer=tokenizer,
+            task_to_env=task_to_env,
+            max_seq_len=master_config["policy"]["max_total_sequence_length"],
+            max_rollout_turns=master_config["online_dpo"]["max_rollout_turns"],
+            greedy=False,
+        )
+    return run_multi_turn_rollout(
+        policy_generation=policy_generation,
+        input_batch=batch,
+        tokenizer=tokenizer,
+        task_to_env=task_to_env,
+        max_seq_len=master_config["policy"]["max_total_sequence_length"],
+        max_rollout_turns=master_config["online_dpo"]["max_rollout_turns"],
+        greedy=False,
+    )
+
+
+def _aggregate_numeric_metrics(metrics: list[dict[str, Any]]) -> dict[str, float]:
+    aggregated: dict[str, float] = {}
+    metric_values: dict[str, list[float]] = {}
+    for metric_dict in metrics:
+        for key, value in metric_dict.items():
+            if isinstance(value, (int, float)):
+                metric_values.setdefault(key, []).append(float(value))
+    for key, values in metric_values.items():
+        aggregated[key] = float(np.mean(values))
+    return aggregated
+
+
+def _aggregate_pair_metrics(metrics: list[dict[str, float]]) -> dict[str, float]:
+    count_keys = {
+        "generated_pairs",
+        "usable_pairs",
+        "dropped_pairs",
+        "discarded_pairs",
+        "tie_pairs",
+        "truncated_pairs",
+    }
+    aggregated = {key: 0.0 for key in count_keys}
+    weighted_keys = {"chosen_reward", "rejected_reward", "reward_margin"}
+    weighted_values = {key: 0.0 for key in weighted_keys}
+    total_usable_pairs = 0.0
+
+    for metric_dict in metrics:
+        for key in count_keys:
+            aggregated[key] += metric_dict.get(key, 0.0)
+        usable_pairs = metric_dict.get("usable_pairs", 0.0)
+        total_usable_pairs += usable_pairs
+        for key in weighted_keys:
+            weighted_values[key] += metric_dict.get(key, 0.0) * usable_pairs
+
+    for key in weighted_keys:
+        aggregated[key] = (
+            weighted_values[key] / total_usable_pairs if total_usable_pairs > 0 else 0.0
+        )
+
+    return aggregated
+
+
+def _prepare_generation(
+    policy: ColocatablePolicyInterface,
+    policy_generation: GenerationInterface,
+    *,
+    need_refit: bool,
+    generation_stale: bool,
+    colocated_inference: bool,
+    timer: Optional[Timer] = None,
+) -> bool:
+    if need_refit and generation_stale:
+        refit_policy_generation(
+            policy,
+            policy_generation,
+            colocated_inference,
+            timer=timer,
+        )
+        return False
+
+    if colocated_inference and need_refit:
+        policy.offload_after_refit()
+    policy_generation.prepare_for_generation()
+    return generation_stale
+
+
+def _collect_preference_batch(
+    dataloader_iter,
+    policy_generation: GenerationInterface,
+    tokenizer: TokenizerType,
+    task_to_env: dict[str, EnvironmentInterface],
+    master_config: MasterConfig,
+    timer: Timer,
+) -> tuple[Optional[BatchedDataDict], dict[str, float], dict[str, Any], int, int]:
+    online_dpo_config = master_config["online_dpo"]
+    target_pairs = master_config["policy"]["train_global_batch_size"]
+    preference_datums: list[PreferenceDatumSpec] = []
+    pair_metrics = []
+    rollout_metrics = []
+    consumed_prompts = 0
+    consumed_prompt_batches = 0
+
+    while len(preference_datums) < target_pairs:
+        try:
+            batch = next(dataloader_iter)
+        except StopIteration:
+            break
+
+        consumed_prompts += batch.size
+        consumed_prompt_batches += 1
+        repeated_batch = batch.repeat_interleave(
+            online_dpo_config["num_generations_per_prompt"]
+        )
+
+        with timer.time("generation"):
+            rollout_batch, current_rollout_metrics = _run_rollout(
+                policy_generation,
+                repeated_batch,
+                tokenizer,
+                task_to_env,
+                master_config,
+            )
+        rollout_metrics.append(current_rollout_metrics)
+
+        remaining_pairs = target_pairs - len(preference_datums)
+        new_datums, current_pair_metrics = build_preference_datums_from_rollouts(
+            rollout_batch,
+            min_reward_margin=online_dpo_config["min_reward_margin"],
+            drop_truncated_pairs=online_dpo_config["drop_truncated_pairs"],
+            max_pairs=remaining_pairs,
+        )
+        preference_datums.extend(new_datums)
+        pair_metrics.append(current_pair_metrics)
+
+        del repeated_batch
+        del rollout_batch
+
+    if len(preference_datums) < target_pairs:
+        return (
+            None,
+            _aggregate_pair_metrics(pair_metrics),
+            {},
+            consumed_prompts,
+            consumed_prompt_batches,
+        )
+
+    preference_batch = collate_preference_datums(
+        preference_datums,
+        tokenizer,
+        master_config["policy"]["make_sequence_length_divisible_by"],
+    )
+    preference_batch.to("cpu")
+
+    return (
+        preference_batch,
+        _aggregate_pair_metrics(pair_metrics),
+        _aggregate_numeric_metrics(rollout_metrics),
+        consumed_prompts,
+        consumed_prompt_batches,
+    )
+
+
+def validate(
+    policy_generation: GenerationInterface,
+    val_dataloader: Optional[StatefulDataLoader],
+    tokenizer: TokenizerType,
+    val_task_to_env: Optional[dict[str, EnvironmentInterface]],
+    step: int,
+    master_config: MasterConfig,
+    logger: Optional[Logger] = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Run environment rollout validation for Online DPO."""
+    if val_dataloader is None:
+        assert (
+            val_dataloader is not None or master_config["online_dpo"]["val_period"] == 0
+        ), "val_dataloader is None, so online_dpo.val_period must be 0"
+        print("  - No validation dataloader provided, skipping validation", flush=True)
+        return {}, {}
+    assert val_task_to_env is not None
+
+    timer = Timer()
+    total_rewards = []
+    total_lengths = []
+    all_message_logs = []
+    rollout_metric_batches = []
+
+    with timer.time("total_validation_time"):
+        print(f"Starting Online DPO validation at step {step}...", flush=True)
+        online_dpo_config = master_config["online_dpo"]
+        max_batches = (
+            max(
+                1,
+                (
+                    online_dpo_config["max_val_samples"]
+                    + online_dpo_config["val_batch_size"]
+                    - 1
+                )
+                // online_dpo_config["val_batch_size"],
+            )
+            if online_dpo_config["max_val_samples"] > 0
+            else len(val_dataloader)
+        )
+
+        for batch_idx, val_batch in enumerate(val_dataloader):
+            if batch_idx >= max_batches:
+                break
+
+            val_batch, rollout_metrics = _run_rollout(
+                policy_generation,
+                val_batch,
+                tokenizer,
+                val_task_to_env,
+                master_config,
+            )
+            rollout_metric_batches.append(rollout_metrics)
+            total_rewards.extend(val_batch["total_reward"].tolist())
+            total_lengths.append(rollout_metrics["mean_gen_tokens_per_sample"])
+            all_message_logs.extend(
+                [
+                    get_keys_from_message_log(
+                        val_batch["message_log"][i], ["role", "content"]
+                    )
+                    for i in range(len(val_batch["message_log"]))
+                ]
+            )
+
+    num_samples = len(total_rewards)
+    reward = (
+        float(torch.tensor(total_rewards, dtype=torch.float32).mean().item())
+        if num_samples
+        else 0.0
+    )
+    avg_length = (
+        float(sum(total_lengths) / len(total_lengths)) if total_lengths else 0.0
+    )
+    val_metrics = {
+        "reward": reward,
+        "avg_length": avg_length,
+        "num_samples": float(num_samples),
+        **_aggregate_numeric_metrics(rollout_metric_batches),
+    }
+
+    try:
+        print_message_log_samples(
+            all_message_logs,
+            total_rewards,
+            num_samples=min(
+                master_config["logger"]["num_val_samples_to_print"],
+                len(all_message_logs),
+            ),
+            step=step,
+        )
+    except Exception as e:
+        print(f"Error displaying validation samples: {str(e)}", flush=True)
+
+    timing_metrics = timer.get_timing_metrics(reduction_op="sum")
+    print("\nOnline DPO validation results:")
+    print(f"  - Reward: {reward:.4f}")
+    print(f"  - Average response length: {avg_length:.1f} tokens")
+    print(f"  - Samples processed: {num_samples}", flush=True)
+
+    if logger is not None:
+        logger.log_batched_dict_as_jsonl(
+            {"content": all_message_logs, "rewards": total_rewards},
+            f"val_data_step{step}.jsonl",
+        )
+
+    timer.reset()
+    gc.collect()
+    torch.cuda.empty_cache()
+    return val_metrics, timing_metrics
+
+
+def _aggregate_train_metrics(train_results: dict[str, Any]) -> dict[str, float]:
+    metrics = {
+        "loss": train_results["loss"].numpy(),
+        "grad_norm": train_results["grad_norm"].numpy(),
+    }
+    if "moe_metrics" in train_results:
+        metrics.update({f"moe/{k}": v for k, v in train_results["moe_metrics"].items()})
+    metrics.update(train_results["all_mb_metrics"])
+
+    aggregated = {}
+    for key, value in metrics.items():
+        if key in {"lr", "wd", "global_valid_seqs", "global_valid_toks"}:
+            aggregated[key] = float(np.mean(value).item())
+        else:
+            aggregated[key] = float(np.sum(value).item())
+    return aggregated
+
+
+def online_dpo_train(
+    policy: ColocatablePolicyInterface,
+    policy_generation: Optional[GenerationInterface],
+    train_dataloader: StatefulDataLoader,
+    val_dataloader: Optional[StatefulDataLoader],
+    tokenizer: TokenizerType,
+    loss_fn: DPOLossFn,
+    task_to_env: dict[str, EnvironmentInterface],
+    val_task_to_env: Optional[dict[str, EnvironmentInterface]],
+    logger: Logger,
+    checkpointer: CheckpointManager,
+    online_dpo_save_state: OnlineDPOSaveState,
+    master_config: MasterConfig,
+) -> None:
+    """Run Online DPO training."""
+    timer = Timer()
+    timeout = TimeoutChecker(
+        timeout=master_config["checkpointing"]["checkpoint_must_save_by"],
+        fit_last_save_time=True,
+    )
+    timeout.start_iterations()
+
+    need_refit = True
+    if policy_generation is None:
+        policy_generation = policy  # type: ignore
+        need_refit = False
+    assert policy_generation is not None
+    generation_stale = True
+    colocated_inference = master_config["policy"]["generation"]["colocated"]["enabled"]
+
+    current_step = online_dpo_save_state["current_step"]
+    current_prompt_batch = online_dpo_save_state.get(
+        "current_prompt_batch", current_step
+    )
+    total_steps = online_dpo_save_state["total_steps"]
+    current_epoch = online_dpo_save_state["current_epoch"]
+    consumed_samples = online_dpo_save_state["consumed_samples"]
+    total_valid_tokens = online_dpo_save_state.get("total_valid_tokens", 0)
+
+    online_dpo_config = master_config["online_dpo"]
+    max_num_steps = online_dpo_config["max_num_steps"]
+    max_num_epochs = online_dpo_config["max_num_epochs"]
+    val_period = online_dpo_config["val_period"]
+
+    if online_dpo_config["val_at_start"] and total_steps == 0:
+        print("\nRunning initial Online DPO validation...", flush=True)
+        generation_stale = _prepare_generation(
+            policy,
+            policy_generation,
+            need_refit=need_refit,
+            generation_stale=generation_stale,
+            colocated_inference=colocated_inference,
+        )
+        val_metrics, validation_timings = validate(
+            policy_generation,
+            val_dataloader,
+            tokenizer,
+            val_task_to_env,
+            step=0,
+            master_config=master_config,
+            logger=logger,
+        )
+        policy_generation.finish_generation()
+        logger.log_metrics(val_metrics, current_step, prefix="validation")
+        logger.log_metrics(validation_timings, current_step, prefix="timing/validation")
+
+    while current_epoch < max_num_epochs and total_steps < max_num_steps:
+        print(f"\n{'=' * 25} Epoch {current_epoch + 1}/{max_num_epochs} {'=' * 25}")
+        dataloader_iter = iter(train_dataloader)
+
+        while total_steps < max_num_steps:
+            print(
+                f"\n{'=' * 25} Step {current_step + 1}/{min(len(train_dataloader), max_num_steps)} {'=' * 25}",
+                flush=True,
+            )
+            maybe_gpu_profile_step(policy, total_steps + 1)
+            if policy != policy_generation:
+                maybe_gpu_profile_step(policy_generation, total_steps + 1)
+
+            val_metrics, validation_timings = None, None
+            with timer.time("total_step_time"):
+                print("Preparing online preference batch...", flush=True)
+                with timer.time("prepare_for_generation/total"):
+                    generation_stale = _prepare_generation(
+                        policy,
+                        policy_generation,
+                        need_refit=need_refit,
+                        generation_stale=generation_stale,
+                        colocated_inference=colocated_inference,
+                        timer=timer,
+                    )
+
+                (
+                    preference_batch,
+                    pair_metrics,
+                    rollout_metrics,
+                    consumed_prompts,
+                    consumed_prompt_batches,
+                ) = _collect_preference_batch(
+                    dataloader_iter,
+                    policy_generation,
+                    tokenizer,
+                    task_to_env,
+                    master_config,
+                    timer,
+                )
+                current_prompt_batch += consumed_prompt_batches
+                policy_generation.finish_generation()
+                if preference_batch is None:
+                    if consumed_prompts > 0:
+                        warnings.warn(
+                            "Discarding the final partial Online DPO batch because it "
+                            "did not contain enough usable preference pairs."
+                        )
+                    timer.reset()
+                    break
+
+                logger.log_metrics(rollout_metrics, total_steps + 1, prefix="train")
+
+                print("Computing reference policy logprobs...", flush=True)
+                with timer.time("logprob_inference_prep"):
+                    policy.prepare_for_lp_inference()
+                with timer.time("reference_policy_logprobs"):
+                    preference_batch = add_reference_logprobs_to_preference_batch(
+                        preference_batch,
+                        policy,
+                        micro_batch_size=master_config["policy"][
+                            "train_micro_batch_size"
+                        ]
+                        * 2,
+                        timer=timer,
+                    )
+
+                print("Training policy with DPO loss...", flush=True)
+                with timer.time("training_prep"):
+                    policy.prepare_for_training()
+                    generation_stale = True
+                with timer.time("policy_training"):
+                    train_results = policy.train(
+                        preference_batch,
+                        loss_fn,
+                        eval_mode=False,
+                        gbs=master_config["policy"]["train_global_batch_size"] * 2,
+                        mbs=master_config["policy"]["train_micro_batch_size"] * 2,
+                        timer=timer,
+                    )
+
+                is_last_step = total_steps + 1 >= max_num_steps or (
+                    current_epoch + 1 == max_num_epochs
+                    and current_prompt_batch >= len(train_dataloader)
+                )
+
+                if (val_period > 0 and (total_steps + 1) % val_period == 0) or (
+                    online_dpo_config["val_at_end"] and is_last_step
+                ):
+                    generation_stale = _prepare_generation(
+                        policy,
+                        policy_generation,
+                        need_refit=need_refit,
+                        generation_stale=generation_stale,
+                        colocated_inference=colocated_inference,
+                    )
+                    val_metrics, validation_timings = validate(
+                        policy_generation,
+                        val_dataloader,
+                        tokenizer,
+                        val_task_to_env,
+                        step=total_steps + 1,
+                        master_config=master_config,
+                        logger=logger,
+                    )
+                    policy_generation.finish_generation()
+                    logger.log_metrics(
+                        validation_timings, total_steps + 1, prefix="timing/validation"
+                    )
+                    logger.log_metrics(
+                        val_metrics, total_steps + 1, prefix="validation"
+                    )
+
+                metrics = _aggregate_train_metrics(train_results)
+                metrics.update({f"online_dpo/{k}": v for k, v in pair_metrics.items()})
+                metrics.update(rollout_metrics)
+                total_valid_tokens += metrics["global_valid_toks"]
+
+                consumed_samples += consumed_prompts
+                timeout.mark_iteration()
+
+                should_save_by_step = (
+                    is_last_step
+                    or (total_steps + 1) % master_config["checkpointing"]["save_period"]
+                    == 0
+                )
+                should_save_by_timeout = timeout.check_save()
+
+                if master_config["checkpointing"]["enabled"] and (
+                    should_save_by_step or should_save_by_timeout
+                ):
+                    policy.prepare_for_training()
+                    online_dpo_save_state["current_step"] = current_step + 1
+                    online_dpo_save_state["current_prompt_batch"] = current_prompt_batch
+                    online_dpo_save_state["total_steps"] = total_steps + 1
+                    online_dpo_save_state["current_epoch"] = current_epoch
+                    online_dpo_save_state["total_valid_tokens"] = total_valid_tokens
+                    online_dpo_save_state["consumed_samples"] = consumed_samples
+                    if val_metrics is not None:
+                        online_dpo_save_state["val_reward"] = val_metrics["reward"]
+                    elif "val_reward" in online_dpo_save_state:
+                        del online_dpo_save_state["val_reward"]
+
+                    full_metric_name = master_config["checkpointing"]["metric_name"]
+                    if full_metric_name is not None:
+                        assert full_metric_name.startswith(
+                            "train:"
+                        ) or full_metric_name.startswith("val:"), (
+                            f"metric_name={full_metric_name} must start with "
+                            "'val:' or 'train:'."
+                        )
+                        prefix, metric_name = full_metric_name.split(":", 1)
+                        metrics_source = metrics if prefix == "train" else val_metrics
+                        if not metrics_source:
+                            warnings.warn(
+                                f"No {prefix} metrics were collected for "
+                                f"checkpoint metric {metric_name}.",
+                                stacklevel=2,
+                            )
+                            if full_metric_name in online_dpo_save_state:
+                                del online_dpo_save_state[full_metric_name]
+                        elif metric_name not in metrics_source:
+                            raise ValueError(
+                                f"Metric {metric_name} not found in {prefix} metrics"
+                            )
+                        else:
+                            online_dpo_save_state[full_metric_name] = metrics_source[
+                                metric_name
+                            ]
+
+                    with timer.time("checkpointing"):
+                        print(f"Saving checkpoint for step {total_steps + 1}...")
+                        checkpoint_path = checkpointer.init_tmp_checkpoint(
+                            total_steps + 1, online_dpo_save_state, master_config
+                        )
+                        policy.save_checkpoint(
+                            weights_path=os.path.join(
+                                checkpoint_path, "policy", "weights"
+                            ),
+                            optimizer_path=os.path.join(
+                                checkpoint_path, "policy", "optimizer"
+                            )
+                            if checkpointer.save_optimizer
+                            else None,
+                            tokenizer_path=os.path.join(
+                                checkpoint_path, "policy", "tokenizer"
+                            ),
+                            checkpointing_cfg=master_config["checkpointing"],
+                        )
+                        torch.save(
+                            train_dataloader.state_dict(),
+                            os.path.join(checkpoint_path, "train_dataloader.pt"),
+                        )
+                        checkpointer.finalize_checkpoint(checkpoint_path)
+
+            timing_metrics = timer.get_timing_metrics(reduction_op="sum")
+            total_time = timing_metrics.get("total_step_time", 0)
+            total_num_gpus = (
+                master_config["cluster"]["num_nodes"]
+                * master_config["cluster"]["gpus_per_node"]
+            )
+            timing_metrics["valid_tokens_per_sec_per_gpu"] = (
+                metrics["global_valid_toks"] / total_time / total_num_gpus
+                if total_time > 0
+                else 0.0
+            )
+
+            print("\nOnline DPO training results:")
+            print(f"  - Loss: {metrics['loss']:.4f}")
+            print(f"  - Preference loss: {metrics['preference_loss']:.4f}")
+            print(f"  - Accuracy: {metrics['accuracy']:.4f}")
+            print(f"  - Usable pairs: {metrics['online_dpo/usable_pairs']:.0f}")
+            print(f"  - Dropped pairs: {metrics['online_dpo/dropped_pairs']:.0f}")
+            print(f"  - Reward margin: {metrics['online_dpo/reward_margin']:.4f}")
+            print("\nTiming:")
+            print(f"  - Total step time: {total_time:.2f}s")
+            for key, value in sorted(
+                timing_metrics.items(), key=lambda item: item[1], reverse=True
+            ):
+                if key != "total_step_time":
+                    percent = (value / total_time * 100) if total_time > 0 else 0
+                    print(f"  - {key}: {value:.2f}s ({percent:.1f}%)")
+
+            logger.log_metrics(metrics, total_steps + 1, prefix="train")
+            logger.log_metrics(
+                timing_metrics,
+                total_steps + 1,
+                prefix="timing/train",
+                step_finished=True,
+            )
+
+            if not _should_log_nemo_gym_responses(master_config):
+                logger.log_batched_dict_as_jsonl(
+                    {
+                        "input_lengths": preference_batch["input_lengths"].tolist(),
+                        "token_ids": preference_batch["input_ids"].tolist(),
+                        "token_loss_mask": preference_batch["token_mask"].tolist(),
+                        "sample_loss_mask": preference_batch["sample_mask"].tolist(),
+                    },
+                    f"train_data_step{total_steps + 1}.jsonl",
+                )
+
+            del preference_batch
+            del train_results
+            del metrics
+            timer.reset()
+            current_step += 1
+            total_steps += 1
+
+            if should_save_by_timeout:
+                print("Timeout has been reached, stopping training early", flush=True)
+                return
+            if total_steps >= max_num_steps:
+                print("Max number of steps has been reached, stopping training early")
+                return
+
+        current_epoch += 1
+        current_step = 0
+        current_prompt_batch = 0

--- a/tests/functional/L1_Functional_Tests_GPU.sh
+++ b/tests/functional/L1_Functional_Tests_GPU.sh
@@ -67,6 +67,7 @@ run_test      uv run --no-sync bash ./tests/functional/grpo_non_colocated.sh
 run_test      uv run --no-sync bash ./tests/functional/grpo_rm_env.sh
 run_test      uv run --no-sync bash ./tests/functional/grpo_sglang.sh
 run_test fast uv run --no-sync bash ./tests/functional/grpo_topp_topk.sh
+run_test fast uv run --no-sync bash ./tests/functional/online_dpo.sh
 run_test      uv run --no-sync bash ./tests/functional/prorlv2.sh
 run_test      uv run --no-sync bash ./tests/functional/qa_distillation_megatron.sh
 run_test      uv run --no-sync bash ./tests/functional/rm.sh

--- a/tests/functional/online_dpo.sh
+++ b/tests/functional/online_dpo.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+PROJECT_ROOT=$(realpath $SCRIPT_DIR/../..)
+# Mark the current repo as safe, since wandb fetches metadata about the repo
+git config --global --add safe.directory $PROJECT_ROOT
+
+set -eou pipefail
+
+EXP_NAME=$(basename $0 .sh)
+EXP_DIR=$SCRIPT_DIR/$EXP_NAME
+LOG_DIR=$EXP_DIR/logs
+JSON_METRICS=$EXP_DIR/metrics.json
+RUN_LOG=$EXP_DIR/run.log
+export PYTHONPATH=${PROJECT_ROOT}:${PYTHONPATH:-}
+
+rm -rf $EXP_DIR $LOG_DIR
+mkdir -p $EXP_DIR $LOG_DIR
+
+cd $PROJECT_ROOT
+uv run coverage run -a --data-file=$PROJECT_ROOT/tests/.coverage --source=$PROJECT_ROOT/nemo_rl \
+    $PROJECT_ROOT/examples/run_online_dpo.py \
+    policy.model_name=Qwen/Qwen3-0.6B \
+    online_dpo.num_prompts_per_step=2 \
+    online_dpo.num_generations_per_prompt=2 \
+    policy.train_global_batch_size=2 \
+    policy.train_micro_batch_size=1 \
+    cluster.gpus_per_node=2 \
+    online_dpo.max_num_steps=2 \
+    online_dpo.val_at_start=false \
+    online_dpo.val_period=0 \
+    logger.tensorboard_enabled=true \
+    logger.log_dir=$LOG_DIR \
+    logger.wandb_enabled=false \
+    logger.monitor_gpus=true \
+    checkpointing.enabled=false \
+    $@ \
+    2>&1 | tee $RUN_LOG
+
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+
+uv run tests/check_metrics.py $JSON_METRICS \
+    'data["train/loss"]["2"] > 0.0' \
+    'data["train/online_dpo/usable_pairs"]["2"] == 2.0'

--- a/tests/unit/algorithms/test_online_dpo.py
+++ b/tests/unit/algorithms/test_online_dpo.py
@@ -1,0 +1,180 @@
+from unittest.mock import MagicMock
+
+import torch
+
+from nemo_rl.algorithms.online_dpo import (
+    add_reference_logprobs_to_preference_batch,
+    build_preference_datums_from_rollouts,
+    collate_preference_datums,
+    strip_trailing_environment_messages,
+)
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+
+
+def _message_log(response_tokens: list[int], response_content: str):
+    return [
+        {
+            "role": "user",
+            "content": "question",
+            "token_ids": torch.tensor([1, 2]),
+        },
+        {
+            "role": "assistant",
+            "content": response_content,
+            "token_ids": torch.tensor(response_tokens),
+        },
+        {
+            "role": "user",
+            "content": "environment observation",
+            "token_ids": torch.tensor([99]),
+        },
+    ]
+
+
+def _rollout_batch(
+    rewards: torch.Tensor,
+    *,
+    truncated: torch.Tensor | None = None,
+) -> BatchedDataDict:
+    batch = BatchedDataDict(
+        {
+            "message_log": [
+                _message_log([3, 4], "first"),
+                _message_log([5, 6, 7], "second"),
+            ],
+            "total_reward": rewards,
+            "loss_multiplier": torch.tensor([1.0, 1.0]),
+            "idx": [123, 123],
+            "task_name": ["math", "math"],
+        }
+    )
+    if truncated is not None:
+        batch["truncated"] = truncated
+    return batch
+
+
+def _two_pair_rollout_batch() -> BatchedDataDict:
+    return BatchedDataDict(
+        {
+            "message_log": [
+                _message_log([3], "a"),
+                _message_log([4], "b"),
+                _message_log([5], "c"),
+                _message_log([6], "d"),
+            ],
+            "total_reward": torch.tensor([0.0, 1.0, 0.2, 0.9]),
+            "loss_multiplier": torch.ones(4),
+            "idx": [0, 0, 1, 1],
+            "task_name": ["math", "math", "math", "math"],
+        }
+    )
+
+
+def test_strip_trailing_environment_messages_keeps_final_assistant():
+    stripped = strip_trailing_environment_messages(_message_log([3, 4], "answer"))
+
+    assert [message["role"] for message in stripped] == ["user", "assistant"]
+    assert stripped[-1]["content"] == "answer"
+
+
+def test_build_preference_datums_orders_by_reward_and_strips_env_observation():
+    datums, metrics = build_preference_datums_from_rollouts(
+        _rollout_batch(torch.tensor([0.25, 0.75])),
+        min_reward_margin=0.0,
+        drop_truncated_pairs=True,
+    )
+
+    assert len(datums) == 1
+    assert datums[0]["message_log_chosen"][-1]["content"] == "second"
+    assert datums[0]["message_log_rejected"][-1]["content"] == "first"
+    assert datums[0]["length_chosen"] == 5
+    assert datums[0]["length_rejected"] == 4
+    assert metrics["usable_pairs"] == 1.0
+    assert metrics["reward_margin"] == 0.5
+
+
+def test_build_preference_datums_respects_max_pairs_and_counts_discards():
+    datums, metrics = build_preference_datums_from_rollouts(
+        _two_pair_rollout_batch(),
+        min_reward_margin=0.0,
+        drop_truncated_pairs=True,
+        max_pairs=1,
+    )
+
+    assert len(datums) == 1
+    assert datums[0]["idx"] == 0
+    assert metrics["generated_pairs"] == 2.0
+    assert metrics["usable_pairs"] == 1.0
+    assert metrics["discarded_pairs"] == 1.0
+
+
+def test_build_preference_datums_drops_ties_within_margin():
+    datums, metrics = build_preference_datums_from_rollouts(
+        _rollout_batch(torch.tensor([0.25, 0.30])),
+        min_reward_margin=0.1,
+        drop_truncated_pairs=True,
+    )
+
+    assert datums == []
+    assert metrics["tie_pairs"] == 1.0
+    assert metrics["dropped_pairs"] == 1.0
+
+
+def test_build_preference_datums_drops_truncated_pairs_when_enabled():
+    datums, metrics = build_preference_datums_from_rollouts(
+        _rollout_batch(
+            torch.tensor([0.25, 0.75]),
+            truncated=torch.tensor([False, True]),
+        ),
+        min_reward_margin=0.0,
+        drop_truncated_pairs=True,
+    )
+
+    assert datums == []
+    assert metrics["truncated_pairs"] == 1.0
+    assert metrics["dropped_pairs"] == 1.0
+
+
+def test_collate_preference_datums_uses_dpo_interleaving_and_final_mask():
+    tokenizer = MagicMock()
+    tokenizer.pad_token_id = 0
+    datums, _ = build_preference_datums_from_rollouts(
+        _rollout_batch(torch.tensor([0.25, 0.75])),
+        min_reward_margin=0.0,
+        drop_truncated_pairs=True,
+    )
+
+    batch = collate_preference_datums(
+        datums,
+        tokenizer=tokenizer,
+        make_sequence_length_divisible_by=1,
+    )
+
+    assert batch["input_ids"].shape[0] == 2
+    assert batch["sample_mask"].tolist() == [1.0, 1.0]
+    assert batch["token_mask"][0].sum().item() == 3
+    assert batch["token_mask"][1].sum().item() == 2
+
+
+def test_add_reference_logprobs_rolls_reference_output():
+    preference_batch = BatchedDataDict({"input_ids": torch.ones(2, 3)})
+    policy = MagicMock()
+    policy.get_reference_policy_logprobs.return_value = {
+        "reference_logprobs": torch.tensor([[1, 2, 3], [4, 5, 6]])
+    }
+
+    add_reference_logprobs_to_preference_batch(
+        preference_batch,
+        policy,
+        micro_batch_size=2,
+    )
+
+    assert preference_batch["reference_policy_logprobs"].tolist() == [
+        [2, 3, 1],
+        [5, 6, 4],
+    ]
+    policy.get_reference_policy_logprobs.assert_called_once_with(
+        preference_batch,
+        micro_batch_size=2,
+        timer=None,
+    )


### PR DESCRIPTION
## Summary

Adds a first Online DPO training path that samples two policy responses per prompt, scores them through NeMo RL environments, converts the higher/lower reward responses into chosen/rejected preference pairs, and trains with the existing DPO loss.

Closes #1816.

## What Changed

- Added `examples/run_online_dpo.py` as the Online DPO entrypoint.
- Added `nemo_rl/algorithms/online_dpo.py` with rollout collection, online preference-pair construction, reference logprob calculation, DPO training, validation, checkpointing, and resume state.
- Added `examples/configs/online_dpo.yaml` as the exemplar config and source of defaults.
- Added Online DPO documentation and linked it from the main docs index and algorithm matrix.
- Added unit coverage for pair construction, environment-observation stripping, DPO collation, and reference-logprob rolling.
- Added a functional smoke script and wired it into the fast L1 GPU suite.

## Initial Scope

The implementation is intentionally narrow to keep the first version predictable:

- text-only LLM prompts
- one rollout turn
- exactly two generations per prompt
- scalar environment rewards
- single prompt dataloader
- colocated generation
- no NeMo-Gym rollouts
- no dynamic batching or sequence packing

Unsupported surfaces are rejected during setup instead of being silently accepted.

## Validation

Passed locally:

- `uvx ruff check nemo_rl/algorithms/online_dpo.py examples/run_online_dpo.py tests/unit/algorithms/test_online_dpo.py`
- `uvx ruff format --check nemo_rl/algorithms/online_dpo.py examples/run_online_dpo.py tests/unit/algorithms/test_online_dpo.py`
- `bash -n tests/functional/online_dpo.sh`
- `bash -n tests/functional/L1_Functional_Tests_GPU.sh`
- `git diff --cached --check`
- `/usr/local/bin/python3.13 -m py_compile nemo_rl/algorithms/online_dpo.py examples/run_online_dpo.py tests/unit/algorithms/test_online_dpo.py`
- YAML parse check for `examples/configs/online_dpo.yaml`

Could not run the focused pytest locally because the default `/usr/local/bin/python3.13` is not inspectable by `uv` on this machine (`platform.mac_ver()` returns empty), the available uv-managed Python is 3.13.12 while this repo requires `>=3.13.13`, and the direct 3.13.13 interpreter does not have project dependencies such as `torch` and `pytest`.
