### PR TITLE
fix(automodel): support combined projection tensor sync

### DIFF
--- a/examples/configs/dpo.yaml
+++ b/examples/configs/dpo.yaml
@@ -63,7 +63,7 @@ policy:
 
     # Automodel kwargs passed to from_pretrained.
     # Uncomment force_hf if the custom model's adapter doesn't support per-tensor
-    # weight conversion (e.g. Qwen2, Llama). Auto-detected if not set.
+    # weight conversion. Auto-detected for incomplete adapters if not set.
     # See https://github.com/NVIDIA-NeMo/RL/issues/2072
     automodel_kwargs: {}
       # force_hf: true

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -108,7 +108,7 @@ policy:
 
     # Automodel kwargs passed to from_pretrained.
     # Uncomment force_hf if the custom model's adapter doesn't support per-tensor
-    # weight conversion (e.g. Qwen2, Llama). Auto-detected if not set.
+    # weight conversion. Auto-detected for incomplete adapters if not set.
     # See https://github.com/NVIDIA-NeMo/RL/issues/2072
     automodel_kwargs: {}
       # force_hf: true

--- a/examples/configs/sft.yaml
+++ b/examples/configs/sft.yaml
@@ -50,7 +50,7 @@ policy:
 
     # Automodel kwargs passed to from_pretrained.
     # Uncomment force_hf if the custom model's adapter doesn't support per-tensor
-    # weight conversion (e.g. Qwen2, Llama). Auto-detected if not set.
+    # weight conversion. Auto-detected for incomplete adapters if not set.
     # See https://github.com/NVIDIA-NeMo/RL/issues/2072
     automodel_kwargs: {}
       # force_hf: true

--- a/nemo_rl/models/automodel/setup.py
+++ b/nemo_rl/models/automodel/setup.py
@@ -59,10 +59,10 @@ STRING_TO_DTYPE = {
 def _maybe_set_force_hf(automodel_kwargs: dict, model_config) -> None:
     """Validate and maybe auto-set force_hf based on adapter compatibility.
 
-    Custom model implementations (e.g. Qwen2, Llama) use state_dict_adapters to
-    convert between native and HF weight formats. NeMo RL's weight syncing requires
-    the adapter to implement `convert_single_tensor_to_hf`. Some adapters (like
-    CombinedProjectionStateDictAdapter) don't implement this yet.
+    Custom model implementations use state_dict_adapters to convert between
+    native and HF weight formats. NeMo RL's weight syncing requires the adapter
+    to implement `convert_single_tensor_to_hf`. Older or incomplete adapters may
+    not implement this yet.
 
     This function checks the adapter BEFORE model loading to avoid wasting time:
     - force_hf=True: no check needed, HF model won't have an adapter.

--- a/tests/unit/models/automodel/test_automodel_setup.py
+++ b/tests/unit/models/automodel/test_automodel_setup.py
@@ -15,6 +15,8 @@
 """Unit tests for automodel setup utilities."""
 
 import os
+import sys
+import types
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -2029,6 +2031,39 @@ class TestMaybeSetForceHf:
         config.architectures = [arch]
         return config
 
+    def _register_incomplete_adapter(self, monkeypatch):
+        """Register a synthetic custom model with an incomplete adapter."""
+        from nemo_automodel._transformers.registry import ModelRegistry
+
+        root_module = types.ModuleType("nemo_rl_tests")
+        root_module.__path__ = []
+        package_module = types.ModuleType("nemo_rl_tests.incomplete")
+        package_module.__path__ = []
+        adapter_module = types.ModuleType("nemo_rl_tests.incomplete.state_dict_adapter")
+
+        class IncompleteForCausalLM:
+            pass
+
+        class IncompleteStateDictAdapter:
+            pass
+
+        IncompleteForCausalLM.__module__ = "nemo_rl_tests.incomplete.model"
+        adapter_module.IncompleteStateDictAdapter = IncompleteStateDictAdapter
+
+        monkeypatch.setitem(sys.modules, "nemo_rl_tests", root_module)
+        monkeypatch.setitem(sys.modules, "nemo_rl_tests.incomplete", package_module)
+        monkeypatch.setitem(
+            sys.modules,
+            "nemo_rl_tests.incomplete.state_dict_adapter",
+            adapter_module,
+        )
+        monkeypatch.setitem(
+            ModelRegistry.model_arch_name_to_cls,
+            "IncompleteForCausalLM",
+            IncompleteForCausalLM,
+        )
+        return "IncompleteForCausalLM"
+
     def test_force_hf_true_skips_check(self):
         """When force_hf=True, no check is needed."""
         kwargs = {"force_hf": True}
@@ -2051,9 +2086,8 @@ class TestMaybeSetForceHf:
         _maybe_set_force_hf(kwargs, config)
         assert "force_hf" not in kwargs
 
-    def test_qwen2_auto_sets_force_hf(self):
-        """Qwen2's CombinedProjectionStateDictAdapter lacks convert_single_tensor_to_hf,
-        so force_hf should be auto-set when not explicitly configured."""
+    def test_qwen2_adapter_no_force_hf(self):
+        """Qwen2's adapter supports per-tensor conversion."""
         from nemo_automodel._transformers.registry import ModelRegistry
 
         if "Qwen2ForCausalLM" not in ModelRegistry.model_arch_name_to_cls:
@@ -2062,10 +2096,22 @@ class TestMaybeSetForceHf:
         kwargs = {}
         config = self._make_config("Qwen2ForCausalLM")
         _maybe_set_force_hf(kwargs, config)
-        assert kwargs.get("force_hf") is True
+        assert "force_hf" not in kwargs
 
-    def test_llama_auto_sets_force_hf(self):
-        """Llama also uses CombinedProjectionStateDictAdapter."""
+    def test_qwen2_explicit_false_allowed(self):
+        """force_hf=False is allowed when the adapter is compatible."""
+        from nemo_automodel._transformers.registry import ModelRegistry
+
+        if "Qwen2ForCausalLM" not in ModelRegistry.model_arch_name_to_cls:
+            pytest.skip("Qwen2ForCausalLM not in registry")
+
+        kwargs = {"force_hf": False}
+        config = self._make_config("Qwen2ForCausalLM")
+        _maybe_set_force_hf(kwargs, config)
+        assert kwargs["force_hf"] is False
+
+    def test_llama_adapter_no_force_hf(self):
+        """Llama also uses the compatible combined-projection adapter."""
         from nemo_automodel._transformers.registry import ModelRegistry
 
         if "LlamaForCausalLM" not in ModelRegistry.model_arch_name_to_cls:
@@ -2074,17 +2120,23 @@ class TestMaybeSetForceHf:
         kwargs = {}
         config = self._make_config("LlamaForCausalLM")
         _maybe_set_force_hf(kwargs, config)
+        assert "force_hf" not in kwargs
+
+    def test_incomplete_adapter_auto_sets_force_hf(self, monkeypatch):
+        """When an adapter is incomplete, force_hf should still be auto-set."""
+        arch = self._register_incomplete_adapter(monkeypatch)
+
+        kwargs = {}
+        config = self._make_config(arch)
+        _maybe_set_force_hf(kwargs, config)
         assert kwargs.get("force_hf") is True
 
-    def test_qwen2_explicit_false_raises(self):
+    def test_incomplete_adapter_explicit_false_raises(self, monkeypatch):
         """When force_hf is explicitly False and adapter is incompatible, raise."""
-        from nemo_automodel._transformers.registry import ModelRegistry
-
-        if "Qwen2ForCausalLM" not in ModelRegistry.model_arch_name_to_cls:
-            pytest.skip("Qwen2ForCausalLM not in registry")
+        arch = self._register_incomplete_adapter(monkeypatch)
 
         kwargs = {"force_hf": False}
-        config = self._make_config("Qwen2ForCausalLM")
+        config = self._make_config(arch)
         with pytest.raises(RuntimeError, match="force_hf=False"):
             _maybe_set_force_hf(kwargs, config)
 

--- a/tests/unit/models/policy/test_dtensor_worker_v2.py
+++ b/tests/unit/models/policy/test_dtensor_worker_v2.py
@@ -15,6 +15,7 @@
 import contextlib
 import os
 import tempfile
+from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -496,6 +497,21 @@ def test_dtensor_v2_mixed_precision_training_and_logprobs(
 class TestMaybeAdaptTensorToHF:
     """Tests for the _maybe_adapt_tensor_to_hf helper function."""
 
+    def _combined_projection_adapter(self):
+        """Create a small combined-projection adapter for regression tests."""
+        from nemo_automodel.components.models.common.combined_projection.state_dict_adapter import (
+            CombinedProjectionStateDictAdapter,
+        )
+
+        return CombinedProjectionStateDictAdapter(
+            SimpleNamespace(
+                num_hidden_layers=1,
+                num_attention_heads=4,
+                num_key_value_heads=2,
+                hidden_size=8,
+            )
+        )
+
     def test_no_adapter_returns_single_tuple(self):
         """Test that when model has no adapter, returns single FQN-tensor tuple."""
         # Arrange
@@ -585,11 +601,54 @@ class TestMaybeAdaptTensorToHF:
             "Should exclude extra_state tensors"
         )
 
+    def test_combined_projection_adapter_splits_qkv_weight(self):
+        """Regression test for Automodel combined projections in tensor sync."""
+        adapter = self._combined_projection_adapter()
+        q_weight = torch.randn(8, 3)
+        k_weight = torch.randn(4, 3)
+        v_weight = torch.randn(4, 3)
+        qkv_weight = adapter._interleave_qkv(q_weight, k_weight, v_weight)
+        model = nn.Module()
+        model.state_dict_adapter = adapter
+
+        result = dict(
+            _maybe_adapt_tensor_to_hf(
+                model,
+                "model.layers.0.self_attn.qkv_proj.weight",
+                qkv_weight,
+            )
+        )
+
+        torch.testing.assert_close(
+            result["model.layers.0.self_attn.q_proj.weight"], q_weight
+        )
+        torch.testing.assert_close(
+            result["model.layers.0.self_attn.k_proj.weight"], k_weight
+        )
+        torch.testing.assert_close(
+            result["model.layers.0.self_attn.v_proj.weight"], v_weight
+        )
+
 
 @pytest.mark.automodel
 @pytest.mark.skipif(not NEMO_AUTOMODEL_AVAILABLE, reason="nemo_automodel not available")
 class TestDTensorParamsGenerator:
     """Tests for the dtensor_params_generator helper function."""
+
+    def _combined_projection_adapter(self):
+        """Create a small combined-projection adapter for regression tests."""
+        from nemo_automodel.components.models.common.combined_projection.state_dict_adapter import (
+            CombinedProjectionStateDictAdapter,
+        )
+
+        return CombinedProjectionStateDictAdapter(
+            SimpleNamespace(
+                num_hidden_layers=1,
+                num_attention_heads=4,
+                num_key_value_heads=2,
+                hidden_size=8,
+            )
+        )
 
     def test_simple_model_yields_adapted_tensors(self):
         """Test that generator yields correct (name, tensor) pairs for a simple model."""
@@ -720,6 +779,42 @@ class TestDTensorParamsGenerator:
         for name, tensor in results:
             assert tensor.dtype == target_dtype
             assert tensor.is_contiguous()
+
+    def test_combined_projection_adapter_emits_hf_split_keys(self):
+        """Generator should emit HF split keys for custom Automodel state dicts."""
+        adapter = self._combined_projection_adapter()
+        q_weight = torch.randn(8, 3)
+        k_weight = torch.randn(4, 3)
+        v_weight = torch.randn(4, 3)
+        qkv_weight = adapter._interleave_qkv(q_weight, k_weight, v_weight)
+
+        class CombinedProjectionModel(nn.Module):
+            def __init__(self, weight, state_dict_adapter):
+                super().__init__()
+                layer = nn.Module()
+                layer.self_attn = nn.Module()
+                layer.self_attn.qkv_proj = nn.Linear(3, 16, bias=False)
+                with torch.no_grad():
+                    layer.self_attn.qkv_proj.weight.copy_(weight)
+
+                self.model = nn.Module()
+                self.model.layers = nn.ModuleList([layer])
+                self.state_dict_adapter = state_dict_adapter
+
+        model = CombinedProjectionModel(qkv_weight, adapter)
+
+        results = dict(dtensor_params_generator(model, torch.float32))
+
+        assert "model.layers.0.self_attn.qkv_proj.weight" not in results
+        torch.testing.assert_close(
+            results["model.layers.0.self_attn.q_proj.weight"], q_weight
+        )
+        torch.testing.assert_close(
+            results["model.layers.0.self_attn.k_proj.weight"], k_weight
+        )
+        torch.testing.assert_close(
+            results["model.layers.0.self_attn.v_proj.weight"], v_weight
+        )
 
 
 @pytest.mark.automodel


### PR DESCRIPTION
## Problem

Fixes https://github.com/NVIDIA-NeMo/RL/issues/2072.

LoRA weight syncing with the DTensor v2 Automodel path fails for Qwen2/Llama-style custom Automodels because the sync path streams individual tensors through `_maybe_adapt_tensor_to_hf()`, but Automodel's combined-projection adapter did not provide `convert_single_tensor_to_hf()`.

That left affected runs with two bad options:

- fail when a custom model adapter was used for streamed weight sync, or
- force the HF implementation with `policy.dtensor_cfg.automodel_kwargs.force_hf=true`.

## Root Cause

`CombinedProjectionStateDictAdapter` already handled full state-dict conversion in `to_hf()`, including:

- `qkv_proj` -> `q_proj`, `k_proj`, `v_proj`
- `gate_up_proj` -> `gate_proj`, `up_proj`
- LoRA-A duplication
- output-side/base/LoRA-B splitting
- 1-D bias gather/restore handling

However, the adapter lacked the equivalent single-tensor conversion hook required by NeMo-RL's streamed weight update path.

## Changes

- Update the Automodel submodule to companion draft PR https://github.com/NVIDIA-NeMo/Automodel/pull/2202.
- Add `CombinedProjectionStateDictAdapter.convert_single_tensor_to_hf()` in Automodel.
- Cover single-tensor QKV/gate-up conversion for base weights, biases, LoRA-A, LoRA-B, excluded `_extra_state` keys, and pass-through tensors.
- Keep NeMo-RL's `force_hf` compatibility fallback for older or incomplete future adapters.
- Update NeMo-RL tests so Qwen2/Llama adapters no longer auto-enable `force_hf`, while synthetic incomplete adapters still do.
- Add NeMo-RL DTensor worker regression tests using the real combined-projection adapter through `_maybe_adapt_tensor_to_hf()` and `dtensor_params_generator()`.
- Refresh exemplar config comments so Qwen2/Llama are no longer documented as requiring `force_hf`.

## Validation

Passed:

- `uvx ruff check 3rdparty/Automodel-workspace/Automodel/nemo_automodel/components/models/common/combined_projection/state_dict_adapter.py 3rdparty/Automodel-workspace/Automodel/tests/unit_tests/models/common/test_combined_projection_state_dict_adapter.py tests/unit/models/automodel/test_automodel_setup.py tests/unit/models/policy/test_dtensor_worker_v2.py`
- `uvx ruff format --check 3rdparty/Automodel-workspace/Automodel/nemo_automodel/components/models/common/combined_projection/state_dict_adapter.py 3rdparty/Automodel-workspace/Automodel/tests/unit_tests/models/common/test_combined_projection_state_dict_adapter.py tests/unit/models/automodel/test_automodel_setup.py tests/unit/models/policy/test_dtensor_worker_v2.py`
- `git diff --check` in the RL repo and Automodel submodule
- `/usr/local/bin/python3.13 -m py_compile ...` on the touched Python files
- `pytest 3rdparty/Automodel-workspace/Automodel/tests/unit_tests/models/common/test_combined_projection_state_dict_adapter.py`

The full Automodel combined-projection adapter file passed locally: 22 passed.

Partially blocked locally:

- `pytest tests/unit/models/automodel/test_automodel_setup.py -k MaybeSetForceHf` collected after adding ad-hoc optional deps/stubs, but the session-wide Ray fixture failed before test bodies due missing Ray dashboard dependencies in this macOS ad-hoc environment (`aiohttp_cors`). This is environment setup noise, not a failure in the changed logic.

## Draft Note

This is a draft because the parent RL PR advances the Automodel submodule to a commit currently published on the contributor fork and represented by companion Automodel draft PR https://github.com/NVIDIA-NeMo/Automodel/pull/2202. Before marking ready, the submodule pointer should be reconciled with the final Automodel upstream commit/merge strategy.
