### PR TITLE
ci: add MODEL_FAMILY and TEST_TYPE to test CONFIG blocks

### DIFF
--- a/tests/test_suites/llm/dapo-qwen2.5-7b-16n4g-fsdp2cp2.sh
+++ b/tests/test_suites/llm/dapo-qwen2.5-7b-16n4g-fsdp2cp2.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=10
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=qwen2.5
+TEST_TYPE=dapo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/dapo-qwen2.5-7b.sh
+++ b/tests/test_suites/llm/dapo-qwen2.5-7b.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=20
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=qwen2.5
+TEST_TYPE=dapo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/distillation-qwen3-1.7b-1n8g-megatron-qa-nvfp4.sh
+++ b/tests/test_suites/llm/distillation-qwen3-1.7b-1n8g-megatron-qa-nvfp4.sh
@@ -18,6 +18,8 @@ STEPS_PER_RUN=25
 MAX_STEPS=25
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=60
+MODEL_FAMILY=qwen3
+TEST_TYPE=distillation
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/distillation-qwen3-32b-to-1.7b-base-1n4g-fsdp2tp1.v1.sh
+++ b/tests/test_suites/llm/distillation-qwen3-32b-to-1.7b-base-1n4g-fsdp2tp1.v1.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=10
 MAX_STEPS=10
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=60
+MODEL_FAMILY=qwen3
+TEST_TYPE=distillation
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/distillation-qwen3-32b-to-1.7b-base-1n4g-megatron-tp1pp2cp2-pack.sh
+++ b/tests/test_suites/llm/distillation-qwen3-32b-to-1.7b-base-1n4g-megatron-tp1pp2cp2-pack.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=10
 MAX_STEPS=10
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=60
+MODEL_FAMILY=qwen3
+TEST_TYPE=distillation
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/distillation-qwen3-32b-to-1.7b-base-1n8g-fsdp2tp1.v1.sh
+++ b/tests/test_suites/llm/distillation-qwen3-32b-to-1.7b-base-1n8g-fsdp2tp1.v1.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=10
 MAX_STEPS=10
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=60
+MODEL_FAMILY=qwen3
+TEST_TYPE=distillation
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/distillation-qwen3-32b-to-1.7b-base-1n8g-megatron-tp2pp2cp2-pack.sh
+++ b/tests/test_suites/llm/distillation-qwen3-32b-to-1.7b-base-1n8g-megatron-tp2pp2cp2-pack.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=10
 MAX_STEPS=10
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=60
+MODEL_FAMILY=qwen3
+TEST_TYPE=distillation
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/distillation-qwen3-32b-to-4b-base-1n8g-fsdp2tp2-dynamicbatch.v1.sh
+++ b/tests/test_suites/llm/distillation-qwen3-32b-to-4b-base-1n8g-fsdp2tp2-dynamicbatch.v1.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=20
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=120
+MODEL_FAMILY=qwen3
+TEST_TYPE=distillation
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/distillation-qwen3-32b-to-4b-base-2n4g-fsdp2tp1-long.v1.sh
+++ b/tests/test_suites/llm/distillation-qwen3-32b-to-4b-base-2n4g-fsdp2tp1-long.v1.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=50
 MAX_STEPS=100
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=qwen3
+TEST_TYPE=distillation
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/distillation-qwen3-32b-to-4b-base-2n8g-fsdp2tp2-long.v1.sh
+++ b/tests/test_suites/llm/distillation-qwen3-32b-to-4b-base-2n8g-fsdp2tp2-long.v1.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=50
 MAX_STEPS=100
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=qwen3
+TEST_TYPE=distillation
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/distillation-qwen3-32b-to-4b-base-2n8g-fsdp2tp2-seqpack.v1.sh
+++ b/tests/test_suites/llm/distillation-qwen3-32b-to-4b-base-2n8g-fsdp2tp2-seqpack.v1.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=20
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=120
+MODEL_FAMILY=qwen3
+TEST_TYPE=distillation
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/distillation-qwen3-32b-to-4b-base-2n8g-fsdp2tp8-noncolocated.v1.sh
+++ b/tests/test_suites/llm/distillation-qwen3-32b-to-4b-base-2n8g-fsdp2tp8-noncolocated.v1.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=20
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=120
+MODEL_FAMILY=qwen3
+TEST_TYPE=distillation
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/dpo-llama3.1-8b-instruct-4n4g-megatrontp1pp2-quick.sh
+++ b/tests/test_suites/llm/dpo-llama3.1-8b-instruct-4n4g-megatrontp1pp2-quick.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=20
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=30
+MODEL_FAMILY=llama3.1
+TEST_TYPE=dpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp4.sh
+++ b/tests/test_suites/llm/dpo-llama3.1-8b-instruct-4n8g-fsdp2tp4.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=150
 MAX_STEPS=150
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=140
+MODEL_FAMILY=llama3.1
+TEST_TYPE=dpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/dpo-llama3.1-8b-instruct-4n8g-megatron.v2.sh
+++ b/tests/test_suites/llm/dpo-llama3.1-8b-instruct-4n8g-megatron.v2.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=150
 MAX_STEPS=150
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=140
+MODEL_FAMILY=llama3.1
+TEST_TYPE=dpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/dpo-llama3.1-8b-instruct-4n8g-megatrontp2pp2-quick.sh
+++ b/tests/test_suites/llm/dpo-llama3.1-8b-instruct-4n8g-megatrontp2pp2-quick.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=20
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=30
+MODEL_FAMILY=llama3.1
+TEST_TYPE=dpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/dpo-llama3.1-8b-tulu3-1n8g-fsdp2tp1.sh
+++ b/tests/test_suites/llm/dpo-llama3.1-8b-tulu3-1n8g-fsdp2tp1.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=150
 MAX_STEPS=150
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=45
+MODEL_FAMILY=llama3.1
+TEST_TYPE=dpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/dpo-llama3.2-1b-instruct-1n4g-fsdp2tp1.v2.sh
+++ b/tests/test_suites/llm/dpo-llama3.2-1b-instruct-1n4g-fsdp2tp1.v2.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=150
 MAX_STEPS=150
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=45
+MODEL_FAMILY=llama3.2
+TEST_TYPE=dpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/dpo-llama3.2-1b-instruct-1n8g-fsdp2tp1.v2.sh
+++ b/tests/test_suites/llm/dpo-llama3.2-1b-instruct-1n8g-fsdp2tp1.v2.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=150
 MAX_STEPS=150
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=45
+MODEL_FAMILY=llama3.2
+TEST_TYPE=dpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/dpo-mistral-nemo-instruct-2407-1n8g-fsdp2tp8-actckpt-long.sh
+++ b/tests/test_suites/llm/dpo-mistral-nemo-instruct-2407-1n8g-fsdp2tp8-actckpt-long.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=100
 MAX_STEPS=100
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=60
+MODEL_FAMILY=mistral
+TEST_TYPE=dpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/dpo-nanov3-30B3AB-1n4g-fsdp4ep4-automodel.sh
+++ b/tests/test_suites/llm/dpo-nanov3-30B3AB-1n4g-fsdp4ep4-automodel.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=15
 MAX_STEPS=15
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=30
+MODEL_FAMILY=nemotron-nano-v3
+TEST_TYPE=dpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/dpo-nanov3-30B3AB-1n8g-fsdp8ep8-automodel.sh
+++ b/tests/test_suites/llm/dpo-nanov3-30B3AB-1n8g-fsdp8ep8-automodel.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=15
 MAX_STEPS=15
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=30
+MODEL_FAMILY=nemotron-nano-v3
+TEST_TYPE=dpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/dpo-qwen2.5-math7b-1n8g-megatron_chunked_linear_ce_loss.sh
+++ b/tests/test_suites/llm/dpo-qwen2.5-math7b-1n8g-megatron_chunked_linear_ce_loss.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=10
 MAX_STEPS=10
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=25
+MODEL_FAMILY=qwen2.5
+TEST_TYPE=dpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-dapomath17k-dsv3-32n4g-megatron.sh
+++ b/tests/test_suites/llm/grpo-dapomath17k-dsv3-32n4g-megatron.sh
@@ -11,6 +11,8 @@ STEPS_PER_RUN=10
 MAX_STEPS=10
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=deepseek-v3
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-dapomath17k-dsv3-megatron.sh
+++ b/tests/test_suites/llm/grpo-dapomath17k-dsv3-megatron.sh
@@ -10,6 +10,8 @@ STEPS_PER_RUN=10
 MAX_STEPS=10
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=deepseek-v3
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-deepscaler-1.5b-16K.sh
+++ b/tests/test_suites/llm/grpo-deepscaler-1.5b-16K.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=20
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=deepscaler
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-deepscaler-1.5b-1n4g-8K.sh
+++ b/tests/test_suites/llm/grpo-deepscaler-1.5b-1n4g-8K.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=20
 MAX_STEPS=40
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=150
+MODEL_FAMILY=deepscaler
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-deepscaler-1.5b-24K.sh
+++ b/tests/test_suites/llm/grpo-deepscaler-1.5b-24K.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=10
 MAX_STEPS=10
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=deepscaler
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-deepscaler-1.5b-8K.sh
+++ b/tests/test_suites/llm/grpo-deepscaler-1.5b-8K.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=40
 MAX_STEPS=40
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=deepscaler
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-gemma3-1b-it-1n4g-fsdp2tp1.sh
+++ b/tests/test_suites/llm/grpo-gemma3-1b-it-1n4g-fsdp2tp1.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=400
 MAX_STEPS=400
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=180
+MODEL_FAMILY=gemma3
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-gemma3-1b-it-1n8g-fsdp2tp1.sh
+++ b/tests/test_suites/llm/grpo-gemma3-1b-it-1n8g-fsdp2tp1.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=400
 MAX_STEPS=400
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=180  # bumped from 120: cold venv rebuild takes ~100min + 400 steps × ~12s
+MODEL_FAMILY=gemma3
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-gemma3-27b-it-8n4g-fsdp2tp4-actckpt-long.sh
+++ b/tests/test_suites/llm/grpo-gemma3-27b-it-8n4g-fsdp2tp4-actckpt-long.sh
@@ -11,6 +11,8 @@ STEPS_PER_RUN=20
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=gemma3
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-gemma3-27b-it-8n8g-fsdp2tp8-actckpt-long.sh
+++ b/tests/test_suites/llm/grpo-gemma3-27b-it-8n8g-fsdp2tp8-actckpt-long.sh
@@ -10,6 +10,8 @@ STEPS_PER_RUN=20
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=gemma3
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-glm47-flash-4n8g-automodel.sh
+++ b/tests/test_suites/llm/grpo-glm47-flash-4n8g-automodel.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=30
 MAX_STEPS=30
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=glm4
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-gptoss-20b-8n4g-megatron.sh
+++ b/tests/test_suites/llm/grpo-gptoss-20b-8n4g-megatron.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=60
 MAX_STEPS=60
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=gpt-oss
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-gptoss-20b-8n8g-megatron.sh
+++ b/tests/test_suites/llm/grpo-gptoss-20b-8n8g-megatron.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=60
 MAX_STEPS=60
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=gpt-oss
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-gspo-deepscaler-1.5b-8K.sh
+++ b/tests/test_suites/llm/grpo-gspo-deepscaler-1.5b-8K.sh
@@ -10,6 +10,8 @@ STEPS_PER_RUN=30
 MAX_STEPS=30
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=deepscaler
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-llama3.1-8b-instruct-1n8g-megatron-fp8-rollouts.v3.sh
+++ b/tests/test_suites/llm/grpo-llama3.1-8b-instruct-1n8g-megatron-fp8-rollouts.v3.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=100
 MAX_STEPS=100
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=180
+MODEL_FAMILY=llama3.1
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-llama3.1-8b-instruct-2n4g-fsdp2tp1-noncolocated.sh
+++ b/tests/test_suites/llm/grpo-llama3.1-8b-instruct-2n4g-fsdp2tp1-noncolocated.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=30
 MAX_STEPS=30
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=120
+MODEL_FAMILY=llama3.1
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-llama3.1-8b-instruct-2n8g-fsdp2tp1-noncolocated.sh
+++ b/tests/test_suites/llm/grpo-llama3.1-8b-instruct-2n8g-fsdp2tp1-noncolocated.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=30
 MAX_STEPS=30
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=120
+MODEL_FAMILY=llama3.1
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-llama3.1-8b-instruct-2n8g-megatron-fp8-e2e.sh
+++ b/tests/test_suites/llm/grpo-llama3.1-8b-instruct-2n8g-megatron-fp8-e2e.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=100
 MAX_STEPS=100
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=llama3.1
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-llama3.1-8b-instruct-4n4g-fsdp2tp1-long.v3.sh
+++ b/tests/test_suites/llm/grpo-llama3.1-8b-instruct-4n4g-fsdp2tp1-long.v3.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=200
 MAX_STEPS=500
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=llama3.1
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-llama3.1-8b-instruct-4n8g-fsdp2tp1-long.v3.sh
+++ b/tests/test_suites/llm/grpo-llama3.1-8b-instruct-4n8g-fsdp2tp1-long.v3.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=190
 MAX_STEPS=500
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=llama3.1
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n4g-fsdp2tp1.v3.sh
+++ b/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n4g-fsdp2tp1.v3.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=500
 MAX_STEPS=500
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=150
+MODEL_FAMILY=llama3.2
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n4g-megatron.sh
+++ b/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n4g-megatron.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=500
 MAX_STEPS=500
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=180
+MODEL_FAMILY=llama3.2
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n4g-megatron_generation.sh
+++ b/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n4g-megatron_generation.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=500
 MAX_STEPS=500
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=llama3.2
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-fsdp2tp1.v3.sh
+++ b/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-fsdp2tp1.v3.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=500
 MAX_STEPS=500
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=120
+MODEL_FAMILY=llama3.2
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-fsdp2tp2-temp0.8-topp0.9-topk50.sh
+++ b/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-fsdp2tp2-temp0.8-topp0.9-topk50.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=500
 MAX_STEPS=500
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=180
+MODEL_FAMILY=llama3.2
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-megatron-temp0.8-topp0.9-topk50.sh
+++ b/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-megatron-temp0.8-topp0.9-topk50.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=500
 MAX_STEPS=500
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=150
+MODEL_FAMILY=llama3.2
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-megatron.sh
+++ b/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-megatron.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=500
 MAX_STEPS=500
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=180
+MODEL_FAMILY=llama3.2
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-megatron_generation.sh
+++ b/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-megatron_generation.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=500
 MAX_STEPS=500
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=180
+MODEL_FAMILY=llama3.2
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-math-qwen3-30ba3b-megatron-tp4-32k.sh
+++ b/tests/test_suites/llm/grpo-math-qwen3-30ba3b-megatron-tp4-32k.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=3
 MAX_STEPS=3
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=qwen3
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-moonlight-16b-automodel-1n8g-ep8.sh
+++ b/tests/test_suites/llm/grpo-moonlight-16b-automodel-1n8g-ep8.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=30
 MAX_STEPS=30
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=180
+MODEL_FAMILY=moonlight
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-moonlight-16ba3b-4n4g-megatron.sh
+++ b/tests/test_suites/llm/grpo-moonlight-16ba3b-4n4g-megatron.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=30
 MAX_STEPS=30
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=60
+MODEL_FAMILY=moonlight
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-moonlight-16ba3b-4n8g-megatron-fp8-e2e.sh
+++ b/tests/test_suites/llm/grpo-moonlight-16ba3b-4n8g-megatron-fp8-e2e.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=30
 MAX_STEPS=30
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=60
+MODEL_FAMILY=moonlight
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-moonlight-16ba3b-4n8g-megatron.sh
+++ b/tests/test_suites/llm/grpo-moonlight-16ba3b-4n8g-megatron.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=30
 MAX_STEPS=30
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=60
+MODEL_FAMILY=moonlight
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-nano-v2-12b-1n4g-megatron.sh
+++ b/tests/test_suites/llm/grpo-nano-v2-12b-1n4g-megatron.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=30
 MAX_STEPS=30
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=60
+MODEL_FAMILY=nemotron-nano-v2
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-nano-v2-12b-1n8g-megatron.sh
+++ b/tests/test_suites/llm/grpo-nano-v2-12b-1n8g-megatron.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=30
 MAX_STEPS=30
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=60
+MODEL_FAMILY=nemotron-nano-v2
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-nano-v2-12b-2n4g-fsdp2tp1.sh
+++ b/tests/test_suites/llm/grpo-nano-v2-12b-2n4g-fsdp2tp1.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=30
 MAX_STEPS=30
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=60
+MODEL_FAMILY=nemotron-nano-v2
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-nano-v2-12b-2n8g-fsdp2tp1.sh
+++ b/tests/test_suites/llm/grpo-nano-v2-12b-2n8g-fsdp2tp1.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=30
 MAX_STEPS=30
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=60
+MODEL_FAMILY=nemotron-nano-v2
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-nanov3-30BA3B-2n8g-fsdp2-lora.sh
+++ b/tests/test_suites/llm/grpo-nanov3-30BA3B-2n8g-fsdp2-lora.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=10
 MAX_STEPS=10
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=50
+MODEL_FAMILY=nemotron-nano-v3
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-nanov3-30BA3B-2n8g-fsdp2.sh
+++ b/tests/test_suites/llm/grpo-nanov3-30BA3B-2n8g-fsdp2.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=10
 MAX_STEPS=10
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=45
+MODEL_FAMILY=nemotron-nano-v3
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-nanov3-30BA3B-2n8g-megatron-lora.sh
+++ b/tests/test_suites/llm/grpo-nanov3-30BA3B-2n8g-megatron-lora.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=10
 MAX_STEPS=10
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=45
+MODEL_FAMILY=nemotron-nano-v3
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-qwen2.5-1.5B-4n8g-megatron-yarn-256k.sh
+++ b/tests/test_suites/llm/grpo-qwen2.5-1.5B-4n8g-megatron-yarn-256k.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=30
 MAX_STEPS=30
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=60
+MODEL_FAMILY=qwen2.5
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-qwen2.5-32b-32n4g-fsdp2tp4-actckpt-long.v3.sh
+++ b/tests/test_suites/llm/grpo-qwen2.5-32b-32n4g-fsdp2tp4-actckpt-long.v3.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=20
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=120
+MODEL_FAMILY=qwen2.5
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-qwen2.5-32b-32n8g-fsdp2tp8-actckpt-long.v3.sh
+++ b/tests/test_suites/llm/grpo-qwen2.5-32b-32n8g-fsdp2tp8-actckpt-long.v3.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=20
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=120
+MODEL_FAMILY=qwen2.5
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-qwen2.5-32b-32n8g-fsdp2tp8-actckpt.v3.sh
+++ b/tests/test_suites/llm/grpo-qwen2.5-32b-32n8g-fsdp2tp8-actckpt.v3.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=2  # step_time: [220, 310]
 MAX_STEPS=2
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=30
+MODEL_FAMILY=qwen2.5
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-qwen2.5-7b-instruct-4n4g-fsdp2tp2.v3.sh
+++ b/tests/test_suites/llm/grpo-qwen2.5-7b-instruct-4n4g-fsdp2tp2.v3.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=30
 MAX_STEPS=30
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=180
+MODEL_FAMILY=qwen2.5
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-qwen2.5-7b-instruct-4n4g-megatron.sh
+++ b/tests/test_suites/llm/grpo-qwen2.5-7b-instruct-4n4g-megatron.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=30
 MAX_STEPS=30
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=40
+MODEL_FAMILY=qwen2.5
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-qwen2.5-7b-instruct-4n8g-megatron.sh
+++ b/tests/test_suites/llm/grpo-qwen2.5-7b-instruct-4n8g-megatron.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=30
 MAX_STEPS=30
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=180
+MODEL_FAMILY=qwen2.5
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-qwen2.5-math-1.5b-instruct-1n4g-fsdp2tp1.v3.sh
+++ b/tests/test_suites/llm/grpo-qwen2.5-math-1.5b-instruct-1n4g-fsdp2tp1.v3.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=450
 MAX_STEPS=450
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=180
+MODEL_FAMILY=qwen2.5
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1-sglang.sh
+++ b/tests/test_suites/llm/grpo-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1-sglang.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=450
 MAX_STEPS=450
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=150  # bumped from 120: ~13.7s/step without piecewise CUDA graphs
+MODEL_FAMILY=qwen2.5
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1.v3.sh
+++ b/tests/test_suites/llm/grpo-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1.v3.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=450
 MAX_STEPS=450
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=120
+MODEL_FAMILY=qwen2.5
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-qwen3-0.6b-1n8g-sglang.sh
+++ b/tests/test_suites/llm/grpo-qwen3-0.6b-1n8g-sglang.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=500
 MAX_STEPS=500
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=180  # bumped from 120: ~18.5s/step without piecewise CUDA graphs
+MODEL_FAMILY=qwen3
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-qwen3-1.7b-1n4g-megatron-eagle3.sh
+++ b/tests/test_suites/llm/grpo-qwen3-1.7b-1n4g-megatron-eagle3.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=50
 MAX_STEPS=50
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=180
+MODEL_FAMILY=qwen3
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-qwen3-1.7b-1n8g-megatron-eagle3.sh
+++ b/tests/test_suites/llm/grpo-qwen3-1.7b-1n8g-megatron-eagle3.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=50
 MAX_STEPS=50
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))
 NUM_MINUTES=180
+MODEL_FAMILY=qwen3
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-qwen3-30ba3b-8n4g-megatron.sh
+++ b/tests/test_suites/llm/grpo-qwen3-30ba3b-8n4g-megatron.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=30
 MAX_STEPS=30
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=qwen3
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-qwen3-30ba3b-8n8g-megatron.sh
+++ b/tests/test_suites/llm/grpo-qwen3-30ba3b-8n8g-megatron.sh
@@ -10,6 +10,8 @@ STEPS_PER_RUN=30
 MAX_STEPS=30
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=qwen3
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-qwen3-8B-base-1n8g-fsdp2-lora.sh
+++ b/tests/test_suites/llm/grpo-qwen3-8B-base-1n8g-fsdp2-lora.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=20
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=40
+MODEL_FAMILY=qwen3
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-qwen3-8b-base-1n8g-fp8-kvcache-megatron.sh
+++ b/tests/test_suites/llm/grpo-qwen3-8b-base-1n8g-fp8-kvcache-megatron.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=60
 MAX_STEPS=60
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=qwen3
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-qwen3-8b-base-1n8g-megatron-lora.sh
+++ b/tests/test_suites/llm/grpo-qwen3-8b-base-1n8g-megatron-lora.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=20
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=40
+MODEL_FAMILY=qwen3
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-qwen3.5-35ba3b-2n8g-automodel-ep16.sh
+++ b/tests/test_suites/llm/grpo-qwen3.5-35ba3b-2n8g-automodel-ep16.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=20
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=qwen3.5
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-qwen3.5-35ba3b-2n8g-megatron-ep16.sh
+++ b/tests/test_suites/llm/grpo-qwen3.5-35ba3b-2n8g-megatron-ep16.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=20
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=qwen3.5
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-qwen3.5-35ba3b-dapo-4n8g-automodel.sh
+++ b/tests/test_suites/llm/grpo-qwen3.5-35ba3b-dapo-4n8g-automodel.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=30
 MAX_STEPS=30
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=qwen3.5
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-qwen3.5-397ba17b-32n8g-megatron.sh
+++ b/tests/test_suites/llm/grpo-qwen3.5-397ba17b-32n8g-megatron.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=20
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=qwen3.5
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-qwen3.5-9b-1n8g-megatron.sh
+++ b/tests/test_suites/llm/grpo-qwen3.5-9b-1n8g-megatron.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=20
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=qwen3.5
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/prorlv2-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1.sh
+++ b/tests/test_suites/llm/prorlv2-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=450
 MAX_STEPS=450
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=150
+MODEL_FAMILY=qwen2.5
+TEST_TYPE=prorlv2
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/sft-gpt-oss-20b-1n4g-fsdp4ep4-automodel.sh
+++ b/tests/test_suites/llm/sft-gpt-oss-20b-1n4g-fsdp4ep4-automodel.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=50
 MAX_STEPS=50
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=30
+MODEL_FAMILY=gpt-oss
+TEST_TYPE=sft
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/sft-gpt-oss-20b-1n8g-fsdp8ep8-automodel.sh
+++ b/tests/test_suites/llm/sft-gpt-oss-20b-1n8g-fsdp8ep8-automodel.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=50
 MAX_STEPS=50
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=30
+MODEL_FAMILY=gpt-oss
+TEST_TYPE=sft
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/sft-llama3.1-70b-8n4g-tp2pp2-long-megatron.sh
+++ b/tests/test_suites/llm/sft-llama3.1-70b-8n4g-tp2pp2-long-megatron.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=300
 MAX_STEPS=300
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=170
+MODEL_FAMILY=llama3.1
+TEST_TYPE=sft
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/sft-llama3.1-70b-8n8g-tp4pp2-long-megatron.sh
+++ b/tests/test_suites/llm/sft-llama3.1-70b-8n8g-tp4pp2-long-megatron.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=300
 MAX_STEPS=300
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=llama3.1
+TEST_TYPE=sft
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/sft-llama3.1-8b-1n4g-fsdp2tp1-long.sh
+++ b/tests/test_suites/llm/sft-llama3.1-8b-1n4g-fsdp2tp1-long.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=250
 MAX_STEPS=250
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=130
+MODEL_FAMILY=llama3.1
+TEST_TYPE=sft
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/sft-llama3.1-8b-1n8g-fsdp2tp1-long.sh
+++ b/tests/test_suites/llm/sft-llama3.1-8b-1n8g-fsdp2tp1-long.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=250
 MAX_STEPS=250
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=120
+MODEL_FAMILY=llama3.1
+TEST_TYPE=sft
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/sft-llama3.1-8b-1n8g-fsdp2tp1-lora.sh
+++ b/tests/test_suites/llm/sft-llama3.1-8b-1n8g-fsdp2tp1-lora.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=50
 MAX_STEPS=50
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=30
+MODEL_FAMILY=llama3.1
+TEST_TYPE=sft
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/sft-llama3.1-8b-1n8g-fsdp2tp2.sh
+++ b/tests/test_suites/llm/sft-llama3.1-8b-1n8g-fsdp2tp2.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=50
 MAX_STEPS=50
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=45
+MODEL_FAMILY=llama3.1
+TEST_TYPE=sft
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/sft-llama3.1-8b-1n8g-fsdp2tp4-dynamicbatch.sh
+++ b/tests/test_suites/llm/sft-llama3.1-8b-1n8g-fsdp2tp4-dynamicbatch.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=250
 MAX_STEPS=250
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=120
+MODEL_FAMILY=llama3.1
+TEST_TYPE=sft
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/sft-llama3.1-8b-1n8g-megatron-lora.sh
+++ b/tests/test_suites/llm/sft-llama3.1-8b-1n8g-megatron-lora.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=50
 MAX_STEPS=50
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=30
+MODEL_FAMILY=llama3.1
+TEST_TYPE=sft
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/sft-llama3.1-8b-1n8g-megatron-seqpack.sh
+++ b/tests/test_suites/llm/sft-llama3.1-8b-1n8g-megatron-seqpack.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=250
 MAX_STEPS=250
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=120
+MODEL_FAMILY=llama3.1
+TEST_TYPE=sft
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/sft-llama3.1-8b-1n8g-megatron.sh
+++ b/tests/test_suites/llm/sft-llama3.1-8b-1n8g-megatron.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=250
 MAX_STEPS=250
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=120
+MODEL_FAMILY=llama3.1
+TEST_TYPE=sft
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/sft-llama3.2-1b-1n4g-fsdp2tp1.v3.sh
+++ b/tests/test_suites/llm/sft-llama3.2-1b-1n4g-fsdp2tp1.v3.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=250
 MAX_STEPS=250
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=25
+MODEL_FAMILY=llama3.2
+TEST_TYPE=sft
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/sft-llama3.2-1b-1n8g-fsdp2tp1.v3.sh
+++ b/tests/test_suites/llm/sft-llama3.2-1b-1n8g-fsdp2tp1.v3.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=250
 MAX_STEPS=250
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=30
+MODEL_FAMILY=llama3.2
+TEST_TYPE=sft
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/sft-nanov3-30BA3B-2n4g-fsdp2-lora.sh
+++ b/tests/test_suites/llm/sft-nanov3-30BA3B-2n4g-fsdp2-lora.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=20  # step_time ~ 10sec
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=60 # Usually 15 minutes is enough for 20 steps, but we add a buffer of 3 minutes in metrics check
+MODEL_FAMILY=nemotron-nano-v3
+TEST_TYPE=sft
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/sft-nanov3-30BA3B-2n4g-fsdp2.sh
+++ b/tests/test_suites/llm/sft-nanov3-30BA3B-2n4g-fsdp2.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=20  # step_time ~ 15sec
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=60
+MODEL_FAMILY=nemotron-nano-v3
+TEST_TYPE=sft
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/sft-nanov3-30BA3B-2n8g-fsdp2-lora.sh
+++ b/tests/test_suites/llm/sft-nanov3-30BA3B-2n8g-fsdp2-lora.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=20  # step_time ~ 10sec
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=30 # Usually 15 minutes is enough for 20 steps, but we add a buffer of 3 minutes in metrics check (30min to buffer for initial ckpt download)
+MODEL_FAMILY=nemotron-nano-v3
+TEST_TYPE=sft
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/sft-nanov3-30BA3B-2n8g-fsdp2.sh
+++ b/tests/test_suites/llm/sft-nanov3-30BA3B-2n8g-fsdp2.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=20
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=30
+MODEL_FAMILY=nemotron-nano-v3
+TEST_TYPE=sft
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/sft-qwen2.5-32b-4n8g-fsdp2tp8sp-actckpt.v3.sh
+++ b/tests/test_suites/llm/sft-qwen2.5-32b-4n8g-fsdp2tp8sp-actckpt.v3.sh
@@ -11,6 +11,8 @@ STEPS_PER_RUN=20  # step_time ~ 29sec
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=30
+MODEL_FAMILY=qwen2.5
+TEST_TYPE=sft
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/sft-qwen2.5-math7b-1n8g-megatron_chunked_linear_ce_loss.sh
+++ b/tests/test_suites/llm/sft-qwen2.5-math7b-1n8g-megatron_chunked_linear_ce_loss.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=10
 MAX_STEPS=10
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=25
+MODEL_FAMILY=qwen2.5
+TEST_TYPE=sft
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/sft-qwen2.5-math7b-2n4g-megatron.sh
+++ b/tests/test_suites/llm/sft-qwen2.5-math7b-2n4g-megatron.sh
@@ -12,6 +12,8 @@ STEPS_PER_RUN=80  # step_time ~ 29sec
 MAX_STEPS=80
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=30
+MODEL_FAMILY=qwen2.5
+TEST_TYPE=sft
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/sft-qwen2.5-math7b-2n8g-megatron.sh
+++ b/tests/test_suites/llm/sft-qwen2.5-math7b-2n8g-megatron.sh
@@ -11,6 +11,8 @@ STEPS_PER_RUN=80  # step_time ~ 29sec
 MAX_STEPS=80
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=30
+MODEL_FAMILY=qwen2.5
+TEST_TYPE=sft
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/sft-qwen3-0.6B-1n8g-megatron-yarn-128k.sh
+++ b/tests/test_suites/llm/sft-qwen3-0.6B-1n8g-megatron-yarn-128k.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=20
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=15
+MODEL_FAMILY=qwen3
+TEST_TYPE=sft
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/vlm/vlm_grpo-qwen2.5-omni-3b-avqa-1n8g-megatron.v1.sh
+++ b/tests/test_suites/vlm/vlm_grpo-qwen2.5-omni-3b-avqa-1n8g-megatron.v1.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=20
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=60
+MODEL_FAMILY=qwen2.5-omni
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/vlm/vlm_grpo-qwen2.5-vl-3b-instruct-clevr-1n4g-dtensor2tp1.v1.sh
+++ b/tests/test_suites/vlm/vlm_grpo-qwen2.5-vl-3b-instruct-clevr-1n4g-dtensor2tp1.v1.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=200
 MAX_STEPS=200
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=120
+MODEL_FAMILY=qwen2.5-vl
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/vlm/vlm_grpo-qwen2.5-vl-3b-instruct-clevr-1n4g-megatrontp1.v1.sh
+++ b/tests/test_suites/vlm/vlm_grpo-qwen2.5-vl-3b-instruct-clevr-1n4g-megatrontp1.v1.sh
@@ -9,6 +9,8 @@ STEPS_PER_RUN=200
 MAX_STEPS=200
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=130
+MODEL_FAMILY=qwen2.5-vl
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/vlm/vlm_grpo-qwen2.5-vl-3b-instruct-clevr-1n8g-dtensor2tp1.v1.sh
+++ b/tests/test_suites/vlm/vlm_grpo-qwen2.5-vl-3b-instruct-clevr-1n8g-dtensor2tp1.v1.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=200
 MAX_STEPS=200
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=120
+MODEL_FAMILY=qwen2.5-vl
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/vlm/vlm_grpo-qwen2.5-vl-3b-instruct-clevr-1n8g-megatrontp2.v1.sh
+++ b/tests/test_suites/vlm/vlm_grpo-qwen2.5-vl-3b-instruct-clevr-1n8g-megatrontp2.v1.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=200
 MAX_STEPS=200
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=120
+MODEL_FAMILY=qwen2.5-vl
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/vlm/vlm_grpo-qwen3.5-35ba3b-geo3k-2n8g-automodel-ep16.sh
+++ b/tests/test_suites/vlm/vlm_grpo-qwen3.5-35ba3b-geo3k-2n8g-automodel-ep16.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=20
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=qwen3.5
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/vlm/vlm_grpo-qwen3.5-35ba3b-geo3k-2n8g-megatron-ep16.sh
+++ b/tests/test_suites/vlm/vlm_grpo-qwen3.5-35ba3b-geo3k-2n8g-megatron-ep16.sh
@@ -8,6 +8,8 @@ STEPS_PER_RUN=20
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=240
+MODEL_FAMILY=qwen3.5
+TEST_TYPE=grpo
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached


### PR DESCRIPTION
## Summary
- Adds `MODEL_FAMILY` and `TEST_TYPE` fields to every test script's `# ===== BEGIN CONFIG =====` block (117 files)
- `MODEL_FAMILY`: canonical model identifier (e.g., `qwen2.5`, `llama3.1`, `gemma3`, `deepseek-v3`)
- `TEST_TYPE`: algorithm/task type (e.g., `grpo`, `sft`, `dpo`, `distillation`, `dapo`)

## Motivation
nemo-ci is adding a standardized `test_metadata.json` artifact to every CI job ([MR !2240](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/merge_requests/2240)). The `model_family` and `test_type` fields currently fall back to the full test name (e.g., `llm_sft_qwen3_0_6B_1n8g_megatron_yarn_128k`) because there are no structured metadata variables in the CONFIG block. This PR adds them so nemo-ci can emit clean, queryable values.

## Non-breaking
- `generate_rl_dynamic.sh` in nemo-ci parses the CONFIG block with `get_cfg_val()` which ignores unknown keys
- Older nemo-ci versions will simply not read these fields
- No changes to test behavior — these are metadata-only additions

## Test plan
- [x] Verify all 117 scripts have correct MODEL_FAMILY and TEST_TYPE values
- [ ] Validate with nemo-ci's `generate_rl_dynamic.sh` (will be wired in follow-up nemo-ci MR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)