### PR TITLE
feat: add HMMT eval benchmark.

### DIFF
--- a/docs/guides/eval.md
+++ b/docs/guides/eval.md
@@ -105,6 +105,7 @@ score=0.1000 (3.0/30)
 
 - [AIME-2024 and AIME-2025](../../nemo_rl/data/datasets/eval_datasets/aime.py): the corresponding `data.dataset_name` are `"aime2024"` and `"aime2025"`.
 - [GPQA and GPQA-diamond](../../nemo_rl/data/datasets/eval_datasets/gpqa.py): the corresponding `data.dataset_name` are `"gpqa"` and `"gpqa_diamond"`.
+- [HMMT-2025-Feb, HMMT-2025-Nov, and HMMT-2026-Feb](../../nemo_rl/data/datasets/eval_datasets/hmmt.py): the corresponding `data.dataset_name` are `"hmmt2025_feb"`, `"hmmt2025_nov"`, and `"hmmt2026_feb"`.
 - [MATH and MATH-500](../../nemo_rl/data/datasets/eval_datasets/math.py): the corresponding `data.dataset_name` are `"math"` and `"math500"`.
 - [MMLU](../../nemo_rl/data/datasets/eval_datasets/mmlu.py): this also includes MMMLU (Multilingual MMLU), a total of 14 languages. When `data.dataset_name` is set to `mmlu`, the English version is used. If one wants to run evaluation on another language, `data.dataset_name` should be set to `mmlu_{language}` where `language` is one of following 14 values, `["AR-XY", "BN-BD", "DE-DE", "ES-LA", "FR-FR", "HI-IN", "ID-ID", "IT-IT", "JA-JP", "KO-KR", "PT-BR", "ZH-CN", "SW-KE", "YO-NG"]`.
 - [MMLU-Pro](../../nemo_rl/data/datasets/eval_datasets/mmlu_pro.py): the corresponding `data.dataset_name` is `"mmlu_pro"`.

--- a/examples/configs/evals/hmmt.yaml
+++ b/examples/configs/evals/hmmt.yaml
@@ -1,0 +1,9 @@
+# HMMT evaluation Configuration
+defaults: "eval.yaml"
+
+generation:
+  model_name: "Qwen/Qwen2.5-7B-Instruct"
+
+data:
+  prompt_file: "examples/prompts/cot.txt"
+  dataset_name: "hmmt2025_feb"  # "hmmt2025_feb", "hmmt2025_nov", "hmmt2026_feb"

--- a/nemo_rl/data/datasets/eval_datasets/__init__.py
+++ b/nemo_rl/data/datasets/eval_datasets/__init__.py
@@ -14,6 +14,7 @@
 
 from nemo_rl.data.datasets.eval_datasets.aime import AIMEDataset
 from nemo_rl.data.datasets.eval_datasets.gpqa import GPQADataset
+from nemo_rl.data.datasets.eval_datasets.hmmt import HmmtDataset
 from nemo_rl.data.datasets.eval_datasets.local_math_dataset import LocalMathDataset
 from nemo_rl.data.datasets.eval_datasets.math import MathDataset
 from nemo_rl.data.datasets.eval_datasets.mmau import MMAUDataset
@@ -78,6 +79,24 @@ def load_eval_dataset(data_config):
             prompt_file=data_config["prompt_file"],
             system_prompt_file=data_config["system_prompt_file"],
         )
+    elif dataset_name == "hmmt2025_feb":
+        base_dataset = HmmtDataset(
+            variant="2025_feb",
+            prompt_file=data_config["prompt_file"],
+            system_prompt_file=data_config["system_prompt_file"],
+        )
+    elif dataset_name == "hmmt2025_nov":
+        base_dataset = HmmtDataset(
+            variant="2025_nov",
+            prompt_file=data_config["prompt_file"],
+            system_prompt_file=data_config["system_prompt_file"],
+        )
+    elif dataset_name == "hmmt2026_feb":
+        base_dataset = HmmtDataset(
+            variant="2026_feb",
+            prompt_file=data_config["prompt_file"],
+            system_prompt_file=data_config["system_prompt_file"],
+        )
     # math
     elif dataset_name == "math":
         base_dataset = MathDataset(
@@ -117,6 +136,7 @@ def load_eval_dataset(data_config):
 __all__ = [
     "AIMEDataset",
     "GPQADataset",
+    "HmmtDataset",
     "LocalMathDataset",
     "MathDataset",
     "MMAUDataset",

--- a/nemo_rl/data/datasets/eval_datasets/hmmt.py
+++ b/nemo_rl/data/datasets/eval_datasets/hmmt.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HMMT dataset.
+
+HMMT stands for the Harvard-MIT Mathematics Tournament. It is an annual
+mathematics competition for high school students, organized and staffed
+by students at Harvard University and the Massachusetts Institute of
+Technology (MIT).
+"""
+
+from typing import Any, Literal, Optional
+
+from datasets import load_dataset
+
+from nemo_rl.data import processors
+from nemo_rl.data.interfaces import TaskDataSpec
+
+VERSION_MAPPINGS = {
+    "2025_feb": "MathArena/hmmt_feb_2025",
+    "2025_nov": "MathArena/hmmt_nov_2025",
+    "2026_feb": "MathArena/hmmt_feb_2026",
+}
+
+
+class HmmtDataset:
+    def __init__(
+        self,
+        variant: Literal["2025_feb", "2025_nov", "2026_feb"] = "2025_feb",
+        prompt_file: Optional[str] = None,
+        system_prompt_file: Optional[str] = None,
+    ):
+        ds = load_dataset(VERSION_MAPPINGS[variant], split="train")
+        self.rekeyed_ds = ds.map(self._rekey, remove_columns=ds.column_names)
+        self.task_spec = TaskDataSpec(
+            task_name=f"hmmt{variant}",
+            prompt_file=prompt_file,
+            system_prompt_file=system_prompt_file,
+        )
+        self.processor = processors.math_data_processor
+
+    def _rekey(self, data: dict[str, Any]):
+        return {
+            "problem": data["problem"],
+            "expected_answer": data["answer"],
+        }


### PR DESCRIPTION
# What does this PR do ?

**Add HMMT related eval benchmarks.**

Qwen3.5 reported scores on HMMT so I added this dataset to validate the correctness of Qwen3.5 models. I was able to get 81% using the Qwen3.5-9B model on HMMT2025-Feb, which is similar to the one reported by themselves.

# Issues
N/A

# Usage
* **Launch eval on HMMT using the Qwen3.5-9B model:**

```bash
uv run examples/run_eval.py --config examples/configs/evals/hmmt.yaml cluster.gpus_per_node=8 generation.vllm_cfg.max_model_len=81920 generation.model_name="Qwen/Qwen3.5-9B" generation.temperature=1.0 generation.top_p=0.95 generation.top_k=20 eval.num_tests_per_prompt=16
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.
