### PR TITLE
perf: Performance script tuning

### DIFF
--- a/examples/configs/recipes/llm/performance/dapo-deepseek-v3-64n8g.v2.yaml
+++ b/examples/configs/recipes/llm/performance/dapo-deepseek-v3-64n8g.v2.yaml
@@ -36,6 +36,8 @@ policy:
   train_micro_batch_size: 1
   logprob_batch_size: 1
   max_total_sequence_length: 1536
+  sequence_packing:
+    fuse_loss: true
   dtensor_cfg:
     enabled: false
   make_sequence_length_divisible_by: ${mul:${policy.megatron_cfg.tensor_model_parallel_size},

--- a/examples/configs/recipes/llm/performance/dapo-deepseek-v3-64n8g.v2.yaml
+++ b/examples/configs/recipes/llm/performance/dapo-deepseek-v3-64n8g.v2.yaml
@@ -36,8 +36,6 @@ policy:
   train_micro_batch_size: 1
   logprob_batch_size: 1
   max_total_sequence_length: 1536
-  sequence_packing:
-    fuse_loss: true
   dtensor_cfg:
     enabled: false
   make_sequence_length_divisible_by: ${mul:${policy.megatron_cfg.tensor_model_parallel_size},
@@ -64,6 +62,7 @@ policy:
       lr_warmup_init: 5.0e-08
   sequence_packing:
     enabled: true
+    fuse_loss: true
   generation:
     max_new_tokens: 1536
     vllm_cfg:

--- a/examples/configs/recipes/llm/performance/grpo-deepseek-v3-32n8g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-deepseek-v3-32n8g.yaml
@@ -7,6 +7,7 @@ grpo:
   max_val_samples: 16
 loss_fn:
   use_importance_sampling_correction: true
+  force_on_policy_ratio: true
 checkpointing:
   checkpoint_dir: results/grpo-deepseek-v3-32n8g
 policy:

--- a/examples/configs/recipes/llm/performance/grpo-qwen3-235b-16n8g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-qwen3-235b-16n8g.yaml
@@ -7,6 +7,7 @@ grpo:
   max_val_samples: 16
 loss_fn:
   use_importance_sampling_correction: true
+  force_on_policy_ratio: true
 checkpointing:
   checkpoint_dir: results/grpo-qwen3-235b-16n8g
 policy:
@@ -17,6 +18,8 @@ policy:
   logprob_batch_size: 1
   max_total_sequence_length: 8192
   make_sequence_length_divisible_by: 8
+  sequence_packing:
+    fuse_loss: true
   dtensor_cfg:
     enabled: false
   megatron_cfg:

--- a/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n4g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n4g.yaml
@@ -10,6 +10,8 @@ policy:
   train_micro_batch_size: 1
   logprob_batch_size: 2
   max_total_sequence_length: 4096
+  sequence_packing:
+    fuse_loss: true
   dtensor_cfg:
     enabled: false
   optimizer: null

--- a/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n8g-40K.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n8g-40K.yaml
@@ -10,6 +10,8 @@ policy:
   train_micro_batch_size: 1
   logprob_batch_size: 4
   max_total_sequence_length: 40960
+  sequence_packing:
+    fuse_loss: true
   dtensor_cfg:
     enabled: false
   optimizer: null

--- a/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n8g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n8g.yaml
@@ -10,6 +10,8 @@ policy:
   train_micro_batch_size: 1
   logprob_batch_size: 4
   max_total_sequence_length: 4096
+  sequence_packing:
+    fuse_loss: true
   dtensor_cfg:
     enabled: false
   optimizer: null

--- a/tests/test_suites/llm/performance/grpo-deepseek-v3-64n8g-fp8-async-1off.sh
+++ b/tests/test_suites/llm/performance/grpo-deepseek-v3-64n8g-fp8-async-1off.sh
@@ -20,6 +20,12 @@ NUM_MINUTES=240
 
 exit_if_max_steps_reached
 
+# envvars for better fp8 inference performance
+export VLLM_USE_FLASHINFER_MOE_FP8=1
+export VLLM_FLASHINFER_MOE_BACKEND=latency
+export VLLM_FLASHINFER_ALLREDUCE_BACKEND=mnnvl
+export VLLM_ALLREDUCE_USE_FLASHINFER=1
+
 # Run the experiment
 cd $PROJECT_ROOT
 uv run examples/run_grpo.py \


### PR DESCRIPTION


# What does this PR do ?

Performance script tuning

1. use force_on_policy_ratio to skip prev_logprobs compute in dsv3 and qwen3-235b
2. use fuse loss in qwen3-235b
3. use flashinfer flags for dsv3 fp8

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
