### PR TITLE
feat: Introduce generation backend registry and decouple algorithms

### DIFF
--- a/examples/nemo_gym/run_grpo_nemo_gym.py
+++ b/examples/nemo_gym/run_grpo_nemo_gym.py
@@ -196,6 +196,7 @@ The validation set you pass in will directly be used for validation with no addi
         policy,
         policy_generation,
         cluster,
+        weight_sync,
         dataloader,
         val_dataloader,
         loss_fn,
@@ -282,6 +283,7 @@ The validation set you pass in will directly be used for validation with no addi
             grpo_save_state=grpo_state,
             master_config=master_config,
             max_trajectory_age_steps=async_config["max_trajectory_age_steps"],
+            weight_sync=weight_sync,
         )
     else:
         print("🚀 Running synchronous GRPO training")
@@ -300,6 +302,7 @@ The validation set you pass in will directly be used for validation with no addi
             checkpointer,
             grpo_state,
             master_config,
+            weight_sync=weight_sync,
         )
 
 

--- a/examples/nemo_gym/run_grpo_nemo_gym.py
+++ b/examples/nemo_gym/run_grpo_nemo_gym.py
@@ -26,7 +26,6 @@ from omegaconf import OmegaConf
 from wandb import Table
 
 from nemo_rl.algorithms.grpo import (
-    ColocatablePolicyInterface,
     EnvironmentInterface,
     GenerationInterface,
     Logger,
@@ -71,7 +70,7 @@ def parse_args() -> tuple[argparse.Namespace, list[str]]:
 
 # These types are directly imported from grpo_train since if something about the architecture changes we want to immediately fail.
 def collect_trajectories(
-    policy: ColocatablePolicyInterface,
+    policy,
     policy_generation: GenerationInterface,
     val_dataloader: StatefulDataLoader,
     tokenizer: TokenizerType,

--- a/examples/nemo_gym/run_grpo_nemo_gym.py
+++ b/examples/nemo_gym/run_grpo_nemo_gym.py
@@ -34,9 +34,9 @@ from nemo_rl.algorithms.grpo import (
     TokenizerType,
     _should_use_nemo_gym,
     grpo_train,
-    refit_policy_generation,
     setup,
 )
+from nemo_rl.weight_sync import WeightSynchronizer
 from nemo_rl.algorithms.utils import get_tokenizer
 from nemo_rl.data.utils import setup_response_data
 from nemo_rl.distributed.virtual_cluster import init_ray
@@ -77,11 +77,13 @@ def collect_trajectories(
     val_task_to_env: dict[str, EnvironmentInterface],
     logger: Logger,
     master_config: MasterConfig,
+    weight_sync: WeightSynchronizer | None = None,
 ) -> None:
     """Run trajectory collection."""
-    # common config/state items
-    colocated_inference = master_config.policy["generation"]["colocated"]["enabled"]
-    refit_policy_generation(policy, policy_generation, colocated_inference)
+    if weight_sync is not None:
+        weight_sync.sync_weights()
+    else:
+        policy_generation.prepare_for_generation()
 
     log_filename = "trajectory_collection.jsonl"
 
@@ -231,6 +233,7 @@ The validation set you pass in will directly be used for validation with no addi
             val_task_to_env=val_task_to_env,
             logger=logger,
             master_config=master_config,
+            weight_sync=weight_sync,
         )
     # Check if async mode is enabled
     elif "async_grpo" in config.grpo and config.grpo["async_grpo"]["enabled"]:

--- a/examples/run_grpo.py
+++ b/examples/run_grpo.py
@@ -134,6 +134,7 @@ def main() -> None:
         policy,
         policy_generation,
         cluster,
+        weight_sync,
         dataloader,
         val_dataloader,
         loss_fn,
@@ -199,6 +200,7 @@ def main() -> None:
             grpo_save_state=grpo_state,
             master_config=master_config,
             max_trajectory_age_steps=async_config["max_trajectory_age_steps"],
+            weight_sync=weight_sync,
         )
     else:
         # Two parallel synchronous trainers (verl-style — main_ppo.py vs
@@ -217,6 +219,7 @@ def main() -> None:
             checkpointer,
             grpo_state,
             master_config,
+            weight_sync=weight_sync,
         )
 
 

--- a/examples/run_grpo_sliding_puzzle.py
+++ b/examples/run_grpo_sliding_puzzle.py
@@ -254,6 +254,7 @@ def main():
         policy,
         policy_generation,
         cluster,
+        weight_sync,
         dataloader,
         val_dataloader,
         loss_fn,
@@ -276,6 +277,7 @@ def main():
         checkpointer,
         grpo_state,
         master_config,
+        weight_sync=weight_sync,
     )
 
 

--- a/examples/run_vlm_grpo.py
+++ b/examples/run_vlm_grpo.py
@@ -108,6 +108,7 @@ def main() -> None:
         policy,
         policy_generation,
         cluster,
+        weight_sync,
         dataloader,
         val_dataloader,
         loss_fn,
@@ -130,6 +131,7 @@ def main() -> None:
         checkpointer,
         grpo_state,
         master_config,
+        weight_sync=weight_sync,
     )
 
 

--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -23,7 +23,8 @@ from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import AutoConfig, AutoTokenizer
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
-from nemo_rl.algorithms.grpo import _should_use_async_rollouts, refit_policy_generation
+from nemo_rl.algorithms.grpo import _should_use_async_rollouts
+from nemo_rl.weight_sync import WeightSynchronizer, create_weight_synchronizer
 from nemo_rl.algorithms.loss import (
     DistillationLossConfig,
     DistillationLossDataDict,
@@ -165,6 +166,7 @@ def setup(
     ColocatablePolicyInterface,  # student_policy
     ColocatablePolicyInterface,  # teacher_policy
     Optional[GenerationInterface],  # student_generation
+    Optional[WeightSynchronizer],  # weight_sync
     StatefulDataLoader,
     Optional[StatefulDataLoader],
     DistillationLossFn,
@@ -176,7 +178,7 @@ def setup(
     """Main entry point for distillation algorithm.
 
     Returns:
-        tuple of student_policy, teacher_policy, student_generation,
+        tuple of student_policy, teacher_policy, student_generation, weight_sync,
         train_dataloader, val_dataloader,
         loss_fn, logger, checkpointer, distillation_save_state, master_config
     """
@@ -455,26 +457,18 @@ def setup(
         init_reference_model=False,
     )
 
+    # Create weight synchronizer and initialize communication channels
+    weight_sync: Optional[WeightSynchronizer] = None
     if student_generation is not None:
-        state_dict_info = student_policy.prepare_refit_info()
-        student_generation.prepare_refit_info(state_dict_info)
-
-    # if it is not colocated inference, initialize collective communication for update weights
-    if not colocated_inference:
-        ip, port = train_cluster.get_master_address_and_port()
-        print(f"Using ip: {ip}, port: {port} for collective communication", flush=True)
-        train_world_size = train_cluster.world_size()
-        # inference cluster + head node of the train cluster
-        world_size = train_world_size + inference_nodes * inference_gpus_per_node
-        # init collective
-        futures_train = student_policy.init_collective(
-            ip, port, world_size, train_world_size=train_world_size
+        weight_sync = create_weight_synchronizer(
+            policy=student_policy,
+            generation=student_generation,
+            generation_backend=backend,
+            colocated=colocated_inference,
+            train_cluster=train_cluster if not colocated_inference else None,
+            inference_cluster=inference_cluster if not colocated_inference else None,
         )
-        futures_inference = student_generation.init_collective(
-            ip, port, world_size, train_world_size=train_world_size
-        )  # type: ignore
-        # wait for all futures to complete
-        ray.get(futures_train + futures_inference)
+        weight_sync.init_communicator()
 
     loss_fn = DistillationLossFn(loss_config)
 
@@ -486,6 +480,7 @@ def setup(
         student_policy,
         teacher_policy,
         student_generation,
+        weight_sync,
         dataloader,
         val_dataloader,
         loss_fn,
@@ -515,6 +510,7 @@ def distillation_train(
     checkpointer: CheckpointManager,
     distillation_save_state: DistillationSaveState,
     master_config: MasterConfig,
+    weight_sync: Optional[WeightSynchronizer] = None,
 ) -> None:
     """Run Distillation training algorithm."""
     timer = Timer()
@@ -524,13 +520,10 @@ def distillation_train(
     )
     timeout.start_iterations()
 
-    NEED_REFIT = True
     # If student_generation is None, use the student_policy as the generation interface (megatron framework backend)
     if student_generation is None:
         student_generation = student_policy  # type: ignore
-        NEED_REFIT = False
-    POLICY_GENERATION_STALE = True  # tracks if generation needs a refit before running
-    assert student_generation is not None
+    assert student_generation is not None  # for mypy type check
 
     # common config/state items
     current_epoch = distillation_save_state["current_epoch"]  # current epoch
@@ -556,11 +549,8 @@ def distillation_train(
     # Run validation at the start if configured
     if val_at_start and total_steps == 0:
         print("\n🔍 Running initial validation...", flush=True)
-        if NEED_REFIT and POLICY_GENERATION_STALE:
-            refit_policy_generation(
-                student_policy, student_generation, colocated_inference
-            )
-            POLICY_GENERATION_STALE = False
+        if weight_sync is not None and weight_sync.is_stale:
+            weight_sync.sync_weights()
         else:
             student_generation.prepare_for_generation()
         val_metrics, validation_timings = validate(
@@ -611,14 +601,8 @@ def distillation_train(
                     flush=True,
                 )
                 with timer.time("prepare_for_generation"):
-                    if NEED_REFIT and POLICY_GENERATION_STALE:
-                        refit_policy_generation(
-                            student_policy,
-                            student_generation,
-                            colocated_inference,
-                            timer=timer,
-                        )
-                        POLICY_GENERATION_STALE = False
+                    if weight_sync is not None and weight_sync.is_stale:
+                        weight_sync.sync_weights(timer=timer)
                     else:
                         student_generation.prepare_for_generation()
 
@@ -712,7 +696,8 @@ def distillation_train(
                 with timer.time("training_prep"):
                     teacher_policy.offload_after_refit()
                     student_policy.prepare_for_training()  # set model train and reload optim to GPU
-                    POLICY_GENERATION_STALE = True
+                    if weight_sync is not None:
+                        weight_sync.mark_stale()
 
                 print("▶ Training policy...", flush=True)
                 with timer.time("policy_training"):
@@ -731,11 +716,8 @@ def distillation_train(
                 if (val_period > 0 and (total_steps + 1) % val_period == 0) or (
                     val_at_end and is_last_step
                 ):
-                    if NEED_REFIT and POLICY_GENERATION_STALE:
-                        refit_policy_generation(
-                            student_policy, student_generation, colocated_inference
-                        )
-                        POLICY_GENERATION_STALE = False
+                    if weight_sync is not None and weight_sync.is_stale:
+                        weight_sync.sync_weights()
                     else:
                         student_generation.prepare_for_generation()
                     val_metrics, validation_timings = validate(

--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -50,10 +50,9 @@ from nemo_rl.experience.rollouts import (
     run_async_multi_turn_rollout,
     run_multi_turn_rollout,
 )
-from nemo_rl.models.generation.interfaces import (
-    GenerationInterface,
-)
-from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration
+from nemo_rl.models.generation import create_generation
+from nemo_rl.models.generation.constants import MEGATRON_BACKEND, VLLM_BACKEND
+from nemo_rl.models.generation.interfaces import GenerationInterface
 from nemo_rl.models.policy import PolicyConfig
 from nemo_rl.models.policy.interfaces import OffloadMode, PolicyTrainerInterface
 from nemo_rl.models.policy.lm_policy import Policy
@@ -298,7 +297,7 @@ def setup(
             use_gpus=True,
             num_gpus_per_node=cluster_config["gpus_per_node"],
             max_colocated_worker_groups=1
-            if generation_config["backend"] == "megatron"
+            if generation_config["backend"] == MEGATRON_BACKEND
             else 3,
         )
         train_cluster = cluster
@@ -308,7 +307,7 @@ def setup(
             flush=True,
         )
     else:
-        assert generation_config["backend"] != "megatron", (
+        assert generation_config["backend"] != MEGATRON_BACKEND, (
             "Non-colocated inference is not supported for Megatron generation backends. "
             "Please use vLLM backend for generation."
         )
@@ -412,21 +411,22 @@ def setup(
     backend = generation_config["backend"]
     generation_config["model_name"] = policy_config["model_name"]  # Needed for vLLM
 
-    if backend == "megatron":
+    if backend == MEGATRON_BACKEND:
         student_generation = None
-    elif backend == "vllm":
-        generation_config = cast(VllmConfig, generation_config)
-        if "vllm_cfg" in generation_config:
-            ## make vllm hf overrides match the training policy
-            generation_config["vllm_kwargs"]["hf_overrides"] = policy_config.get(
+    else:
+        if backend == VLLM_BACKEND and "vllm_cfg" in generation_config:
+            generation_config["vllm_cfg"]["hf_overrides"] = policy_config.get(
                 "hf_config_overrides", {}
             )
-        student_generation = VllmGeneration(
-            cluster=inference_cluster, config=generation_config
+
+        student_generation = create_generation(
+            backend=backend,
+            cluster=inference_cluster,
+            config=generation_config,
         )
         student_generation.finish_generation()
         print(
-            f"  ✓ Using vLLM backend for generation with {policy_config['model_name']}",
+            f"  ✓ Using {backend} backend for generation with {policy_config['model_name']}",
             flush=True,
         )
 

--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -55,7 +55,7 @@ from nemo_rl.models.generation.interfaces import (
 )
 from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration
 from nemo_rl.models.policy import PolicyConfig
-from nemo_rl.models.policy.interfaces import ColocatablePolicyInterface
+from nemo_rl.models.policy.interfaces import OffloadMode, PolicyTrainerInterface
 from nemo_rl.models.policy.lm_policy import Policy
 from nemo_rl.utils.checkpoint import CheckpointingConfig, CheckpointManager
 from nemo_rl.utils.logger import (
@@ -163,8 +163,8 @@ def setup(
     train_dataset: AllTaskProcessedDataset,
     val_dataset: Optional[AllTaskProcessedDataset],
 ) -> tuple[
-    ColocatablePolicyInterface,  # student_policy
-    ColocatablePolicyInterface,  # teacher_policy
+    PolicyTrainerInterface,  # student_policy
+    PolicyTrainerInterface,  # teacher_policy
     Optional[GenerationInterface],  # student_generation
     Optional[WeightSynchronizer],  # weight_sync
     StatefulDataLoader,
@@ -404,7 +404,7 @@ def setup(
         init_optimizer=False,
         init_reference_model=False,
     )
-    teacher_policy.offload_after_refit()
+    teacher_policy.finish_training()
 
     # ==========================
     #    Student Generation Interface
@@ -497,8 +497,8 @@ def setup(
 
 
 def distillation_train(
-    student_policy: ColocatablePolicyInterface,
-    teacher_policy: ColocatablePolicyInterface,
+    student_policy: PolicyTrainerInterface,
+    teacher_policy: PolicyTrainerInterface,
     student_generation: Optional[GenerationInterface],
     dataloader: StatefulDataLoader,
     val_dataloader: Optional[StatefulDataLoader],
@@ -680,7 +680,7 @@ def distillation_train(
 
                 print("▶ Preparing for teacher logprob inference...", flush=True)
                 with timer.time("teacher_logprob_inference_prep"):
-                    teacher_policy.prepare_for_lp_inference()
+                    teacher_policy.finish_training(offload_mode=OffloadMode.EVAL_ONLY)
 
                 print("▶ Computing teacher logprobs...", flush=True)
                 with timer.time("teacher_logprob_inference"):
@@ -694,7 +694,7 @@ def distillation_train(
 
                 print("▶ Preparing for training...", flush=True)
                 with timer.time("training_prep"):
-                    teacher_policy.offload_after_refit()
+                    teacher_policy.finish_training()
                     student_policy.prepare_for_training()  # set model train and reload optim to GPU
                     if weight_sync is not None:
                         weight_sync.mark_stale()

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -85,6 +85,7 @@ from nemo_rl.utils.memory_tracker import MemoryTracker
 from nemo_rl.utils.nsys import maybe_gpu_profile_step
 from nemo_rl.utils.timer import TimeoutChecker, Timer
 from nemo_rl.utils.venvs import create_local_venv_on_each_node
+from nemo_rl.weight_sync import WeightSynchronizer, create_weight_synchronizer
 
 # ===============================================================================
 # Configuration
@@ -227,6 +228,7 @@ def setup(
     ColocatablePolicyInterface,
     Optional[GenerationInterface],
     tuple[RayVirtualCluster, RayVirtualCluster],
+    Optional[WeightSynchronizer],
     StatefulDataLoader | MultipleDataloaderWrapper,
     Optional[StatefulDataLoader],
     ClippedPGLossFn,
@@ -238,7 +240,8 @@ def setup(
     """Main entry point for running GRPO algorithm.
 
     Returns:
-        tuple of policy, cluster, dataloader, tokenizer, loss_fn, math_env, logger, master_config, val_dataloader
+        tuple of policy, policy_generation, clusters, weight_sync, dataloader,
+        val_dataloader, loss_fn, logger, checkpointer, grpo_save_state, master_config
     """
     # Start timing the entire setup process
     setup_start_time = time.perf_counter()
@@ -758,30 +761,23 @@ def setup(
     # print the node IP and GPU ID of the policy workers for debugging
     policy.print_node_ip_and_gpu_id()
 
-    # if it is not colocated inference, initialize collective communication for update weights
-    if not colocated_inference:
-        t0 = time.perf_counter()
-        ip, port = train_cluster.get_master_address_and_port()
-        print(f"Using ip: {ip}, port: {port} for collective communication", flush=True)
-        # world includes all training workers and all inference workers
-        train_world_size = train_cluster.world_size()
-        inference_world_size = inference_nodes * inference_gpus_per_node
-        world_size = train_world_size + inference_world_size
-        # init collective
-        futures_train = policy.init_collective(
-            ip, port, world_size, train_world_size=train_world_size
-        )
-        futures_inference = policy_generation.init_collective(
-            ip, port, world_size, train_world_size=train_world_size
-        )  # type: ignore
-        # wait for all futures to complete
-        ray.get(futures_train + futures_inference)
-        worker_init_timing_metrics["collective_init_time_s"] = time.perf_counter() - t0
-
-    # prepare refit info
-    state_dict_info = policy.prepare_refit_info()
+    # Create weight synchronizer and initialize communication channels
+    weight_sync: Optional[WeightSynchronizer] = None
     if policy_generation is not None:
-        policy_generation.prepare_refit_info(state_dict_info)
+        weight_sync = create_weight_synchronizer(
+            policy=policy,
+            generation=policy_generation,
+            generation_backend=backend,
+            colocated=colocated_inference,
+            train_cluster=train_cluster if not colocated_inference else None,
+            inference_cluster=inference_cluster if not colocated_inference else None,
+        )
+        t0 = time.perf_counter()
+        weight_sync.init_communicator()
+        if not colocated_inference:
+            worker_init_timing_metrics["collective_init_time_s"] = (
+                time.perf_counter() - t0
+            )
 
     # Calculate total setup time
     total_setup_time = time.perf_counter() - setup_start_time
@@ -820,6 +816,7 @@ def setup(
         policy,
         policy_generation,
         (train_cluster, inference_cluster),
+        weight_sync,
         dataloader,
         val_dataloader,
         loss_fn,
@@ -1138,6 +1135,10 @@ def refit_policy_generation(
 ) -> None:
     """Refit the policy generation interface with the latest policy weights.
 
+    .. deprecated::
+        Use :class:`~nemo_rl.weight_sync.WeightSynchronizer` and call
+        ``sync_weights()`` instead.
+
     Args:
         policy: The policy to provide weights to the inference engine.
         policy_generation: The inference engine to refit.
@@ -1147,6 +1148,12 @@ def refit_policy_generation(
         timer: Optional Timer used to time the prepare/transfer/update phase
         kv_scales: Optional dictionary of KV cache scales for FP8 quantization.
     """
+    warnings.warn(
+        "refit_policy_generation() is deprecated. "
+        "Use WeightSynchronizer.sync_weights() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     if colocated_inference:
         policy.offload_before_refit()
         policy_generation.prepare_for_generation(tags=["weights"])
@@ -1350,6 +1357,7 @@ def grpo_train(
     checkpointer: CheckpointManager,
     grpo_save_state: GRPOSaveState,
     master_config: MasterConfig,
+    weight_sync: Optional[WeightSynchronizer] = None,
 ) -> None:
     """Run GRPO training algorithm."""
     timer = Timer()
@@ -1362,13 +1370,10 @@ def grpo_train(
 
     kv_scales_cache = None  # Cache reused for computed kv scales
 
-    NEED_REFIT = True
     # If policy_generation is None, use the policy as the generation interface (megatron framework backend)
     if policy_generation is None:
         policy_generation = policy  # type: ignore
-        NEED_REFIT = False
-    POLICY_GENERATION_STALE = True  # tracks if generation needs a refit before running
-    assert policy_generation is not None
+    assert policy_generation is not None  # for mypy type check
 
     # Check if we need to sync KV cache scales
     # When fallback to policy as the policy_generation, we use getattr to check.
@@ -1404,9 +1409,8 @@ def grpo_train(
         print("\n🔍 Running initial validation...", flush=True)
         memory_tracker.snapshot_start_of_stage("Initial validation", dir())
 
-        if NEED_REFIT and POLICY_GENERATION_STALE:
-            refit_policy_generation(policy, policy_generation, colocated_inference)
-            POLICY_GENERATION_STALE = False
+        if weight_sync is not None and weight_sync.is_stale:
+            weight_sync.sync_weights()
         else:
             policy_generation.prepare_for_generation()
         val_metrics, validation_timings = validate(
@@ -1483,7 +1487,7 @@ def grpo_train(
                     flush=True,
                 )
                 with timer.time("prepare_for_generation/total"):
-                    if NEED_REFIT and POLICY_GENERATION_STALE:
+                    if weight_sync is not None and weight_sync.is_stale:
                         # Compute KV scales if needed for FP8 quantization
                         if sync_kv_scales and kv_scales_cache is None:
                             print("▶ Computing KV cache scales...", flush=True)
@@ -1515,14 +1519,10 @@ def grpo_train(
                                 calibration_data, include_q=True
                             )["layers"]
 
-                        refit_policy_generation(
-                            policy,
-                            policy_generation,
-                            colocated_inference,
+                        weight_sync.sync_weights(
                             timer=timer,
                             kv_scales=kv_scales_cache if sync_kv_scales else None,
                         )
-                        POLICY_GENERATION_STALE = False
                     else:
                         if colocated_inference:
                             policy.offload_after_refit()  # unload optimizer to make space for generation
@@ -1881,7 +1881,8 @@ def grpo_train(
                 print("▶ Preparing for training...", flush=True)
                 with timer.time("training_prep"):
                     policy.prepare_for_training()  # set model train and reload optim to GPU
-                    POLICY_GENERATION_STALE = True
+                    if weight_sync is not None:
+                        weight_sync.mark_stale()
 
                 print("▶ Training policy...", flush=True)
                 with timer.time("policy_training"):
@@ -1902,7 +1903,8 @@ def grpo_train(
                             train_data, include_q=True
                         )["layers"]
                         # Set generation as stale to force refit with new scales
-                        POLICY_GENERATION_STALE = True
+                        if weight_sync is not None:
+                            weight_sync.mark_stale()
 
                 is_last_step = total_steps + 1 >= max_num_steps
                 if not master_config.data["use_multiple_dataloader"]:
@@ -1916,14 +1918,10 @@ def grpo_train(
                     val_at_end and is_last_step
                 ):
                     memory_tracker.snapshot_start_of_stage("Validation", dir())
-                    if NEED_REFIT and POLICY_GENERATION_STALE:
-                        refit_policy_generation(
-                            policy,
-                            policy_generation,
-                            colocated_inference,
+                    if weight_sync is not None and weight_sync.is_stale:
+                        weight_sync.sync_weights(
                             kv_scales=kv_scales_cache if sync_kv_scales else None,
                         )
-                        POLICY_GENERATION_STALE = False
                     else:
                         if colocated_inference:
                             policy.offload_after_refit()  # unload optimizer to make space for generation
@@ -2488,6 +2486,7 @@ def async_grpo_train(
     grpo_save_state: GRPOSaveState,
     master_config: MasterConfig,
     max_trajectory_age_steps: int = 1,
+    weight_sync: Optional[WeightSynchronizer] = None,
 ) -> None:
     """Run asynchronous GRPO training with replay buffer.
 
@@ -2505,6 +2504,7 @@ def async_grpo_train(
         grpo_save_state: Training state
         master_config: Master configuration
         max_trajectory_age_steps: Maximum age (in training steps) for trajectories to be used in training
+        weight_sync: Optional WeightSynchronizer for weight transfer
     """
     # Ensure we are running with a compatible async generation backend
     assert _should_use_async_rollouts(master_config), (
@@ -2531,13 +2531,10 @@ def async_grpo_train(
         fit_last_save_time=True,
     )
     timeout.start_iterations()
-    NEED_REFIT = True
 
     # Setup generation interface
     if policy_generation is None:
         policy_generation = policy
-        NEED_REFIT = False
-    POLICY_GENERATION_STALE = True
     assert policy_generation is not None
 
     # Training state
@@ -2658,12 +2655,11 @@ def async_grpo_train(
     )
 
     print("⏳ Preparing policy generation for training...")
-    if NEED_REFIT and POLICY_GENERATION_STALE:
+    if weight_sync is not None and weight_sync.is_stale:
         print("🔄 Refitting policy generation with actual model weights...")
         try:
-            refit_policy_generation(policy, policy_generation, colocated_inference)
+            weight_sync.sync_weights()
             print("✅ Policy generation refit completed successfully")
-            POLICY_GENERATION_STALE = False
         except Exception as e:
             print(f"❌ Policy generation refit failed: {e}")
             import traceback
@@ -2984,7 +2980,8 @@ def async_grpo_train(
                 print("▶ Preparing for training...")
                 with timer.time("training_prep"):
                     policy.prepare_for_training()
-                    POLICY_GENERATION_STALE = True
+                    if weight_sync is not None:
+                        weight_sync.mark_stale()
 
                 print("▶ Training policy...")
                 with timer.time("policy_training"):
@@ -2996,7 +2993,7 @@ def async_grpo_train(
 
                 print("🔄 Synchronizing policy weights to trajectory collector…")
                 generation_logger_metrics = None
-                if NEED_REFIT:
+                if weight_sync is not None:
                     # Measure pending-generation wait as exposed_generation time
                     print("🔄 Coordinating with trajectory collector before refit...")
                     with timer.time("exposed_generation"):
@@ -3012,10 +3009,7 @@ def async_grpo_train(
                     # Only the actual refit/weight transfer should be counted as weight_sync
                     print("🔄 Performing policy generation refit...")
                     with timer.time("weight_sync"):
-                        refit_policy_generation(
-                            policy, policy_generation, colocated_inference
-                        )
-                        POLICY_GENERATION_STALE = False
+                        weight_sync.sync_weights()
 
                         # Update weight version before resuming trajectory collection so that all trajectories are updated with the new correct weight version
                         weight_version += 1
@@ -3037,11 +3031,8 @@ def async_grpo_train(
                     # Pause trajectory collection during validation to reduce memory pressure
                     trajectory_collector.pause.remote()
 
-                    if NEED_REFIT and POLICY_GENERATION_STALE:
-                        refit_policy_generation(
-                            policy, policy_generation, colocated_inference
-                        )
-                        POLICY_GENERATION_STALE = False
+                    if weight_sync is not None and weight_sync.is_stale:
+                        weight_sync.sync_weights()
                     else:
                         policy_generation.prepare_for_generation()
                     val_metrics, validation_timings = validate(

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -73,7 +73,7 @@ from nemo_rl.models.generation.interfaces import GenerationInterface
 from nemo_rl.models.generation.sglang import SGLangConfig, SGLangGeneration
 from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration
 from nemo_rl.models.policy import PolicyConfig
-from nemo_rl.models.policy.interfaces import ColocatablePolicyInterface
+from nemo_rl.models.policy.interfaces import OffloadMode, PolicyTrainerInterface
 from nemo_rl.models.policy.lm_policy import Policy
 from nemo_rl.utils.checkpoint import CheckpointingConfig, CheckpointManager
 from nemo_rl.utils.logger import (
@@ -225,7 +225,7 @@ def setup(
     processor: Optional[AutoProcessor] = None,
     policy_factory: Optional[Callable[..., ColocatablePolicyInterface]] = None,
 ) -> tuple[
-    ColocatablePolicyInterface,
+    PolicyTrainerInterface,
     Optional[GenerationInterface],
     tuple[RayVirtualCluster, RayVirtualCluster],
     Optional[WeightSynchronizer],
@@ -1126,7 +1126,7 @@ def _extract_prompt_only_messages(message_logs: list) -> list:
 
 
 def refit_policy_generation(
-    policy: ColocatablePolicyInterface,
+    policy: PolicyTrainerInterface,
     policy_generation: GenerationInterface,
     colocated_inference: bool,
     _refit_buffer_size_gb: Optional[int] = None,
@@ -1154,26 +1154,23 @@ def refit_policy_generation(
         DeprecationWarning,
         stacklevel=2,
     )
+    from nemo_rl.models.policy.interfaces import OffloadMode
+
     if colocated_inference:
-        policy.offload_before_refit()
+        policy.finish_training(offload_mode=OffloadMode.OPTIMIZER_ONLY)
         policy_generation.prepare_for_generation(tags=["weights"])
 
-    # Create a context manager that does nothing when timer is None
     timer_context = (
         timer.time("prepare_for_generation/transfer_and_update_weights")
         if timer is not None
         else nullcontext()
     )
     with timer_context:
-        # update weights
         update_success = False
         if colocated_inference:
-            # get model param keys, which is grouped by size
             if _refit_buffer_size_gb is not None:
                 buffer_size_bytes = _refit_buffer_size_gb * (1024**3)
             else:
-                # Empirically sets ratio as 30% to maximize efficiency.
-                # The remaining 70% is a necessary buffer reserved for the parameter all-gathering across the expert-parallelism dimension.
                 memory_ratio = os.getenv("NRL_REFIT_BUFFER_MEMORY_RATIO", "0.3")
                 buffer_size_bytes = int(
                     policy.get_free_memory_bytes() * float(memory_ratio)
@@ -1183,41 +1180,33 @@ def refit_policy_generation(
                 sglang_url_to_gpu_uuids = (
                     policy_generation.get_sglang_url_to_gpu_uuids()
                 )
-                # Stream weights via HTTP
                 flush_success = policy_generation.invalidate_kv_cache()
                 if not flush_success:
                     print("SGLang KV cache invalidation failed before weight update. ")
                 futures_train = policy.stream_weights_via_http(
                     sglang_url_to_gpu_uuids=sglang_url_to_gpu_uuids,
                 )
-                # Wait for all workers to complete
                 ray.get(futures_train)
                 update_success = True
             else:
-                # Original ZMQ IPC path for vLLM
                 futures_train = policy.stream_weights_via_ipc_zmq(
                     buffer_size_bytes=buffer_size_bytes
                 )
                 futures_inference = policy_generation.update_weights_via_ipc_zmq()
-                # wait for all futures to complete
                 ray.get(futures_train)
                 results = ray.get(futures_inference)
                 update_success = all(result for result in results if result is not None)
         else:
-            # update weights through nccl
-            # SGLang haven't implemented non-colocated inference mode.
             if isinstance(policy_generation, SGLangGeneration):
                 raise NotImplementedError(
                     "SGLang haven't implemented non-colocated inference mode. "
                 )
             futures_train = policy.broadcast_weights_for_collective(kv_scales=kv_scales)
             futures_inference = policy_generation.update_weights_from_collective()
-            # wait for all futures to complete
             ray.get(futures_train)
             results = ray.get(futures_inference)
             update_success = all(result for result in results if result is not None)
 
-        # check if update is successful
         if not update_success:
             error_tag = "cuda-ipc" if colocated_inference else "nccl"
             error_message = (
@@ -1228,7 +1217,7 @@ def refit_policy_generation(
             raise RuntimeError(error_message)
 
     if colocated_inference:
-        policy.offload_after_refit()
+        policy.finish_training(offload_mode=OffloadMode.FULL)
         policy_generation.prepare_for_generation(tags=["kv_cache"])
 
 
@@ -1345,7 +1334,7 @@ def compute_and_apply_seq_logprob_error_masking(
 
 
 def grpo_train(
-    policy: ColocatablePolicyInterface,
+    policy: PolicyTrainerInterface,
     policy_generation: Optional[GenerationInterface],
     wrapped_dataloader: StatefulDataLoader | MultipleDataloaderWrapper,
     val_dataloader: Optional[StatefulDataLoader],
@@ -1491,7 +1480,7 @@ def grpo_train(
                         # Compute KV scales if needed for FP8 quantization
                         if sync_kv_scales and kv_scales_cache is None:
                             print("▶ Computing KV cache scales...", flush=True)
-                            policy.prepare_for_lp_inference()
+                            policy.finish_training(offload_mode=OffloadMode.EVAL_ONLY)
                             # Align with training data processing to ensure parallel training compatibility
                             calib_flat, calib_input_lengths = (
                                 batched_message_log_to_flat_message(
@@ -1525,7 +1514,7 @@ def grpo_train(
                         )
                     else:
                         if colocated_inference:
-                            policy.offload_after_refit()  # unload optimizer to make space for generation
+                            policy.finish_training()
                         policy_generation.prepare_for_generation()
 
                 dynamic_sampling_num_gen_batches += 1
@@ -1785,7 +1774,7 @@ def grpo_train(
                 else:
                     print("▶ Preparing for logprob inference...", flush=True)
                     with timer.time("logprob_inference_prep"):
-                        policy.prepare_for_lp_inference()
+                        policy.finish_training(offload_mode=OffloadMode.EVAL_ONLY)
 
                 print("▶ Computing logprobs...", flush=True)
                 with timer.time("policy_and_reference_logprobs"):
@@ -1924,7 +1913,7 @@ def grpo_train(
                         )
                     else:
                         if colocated_inference:
-                            policy.offload_after_refit()  # unload optimizer to make space for generation
+                            policy.finish_training()
                         policy_generation.prepare_for_generation()
                     val_metrics, validation_timings = validate(
                         policy_generation,
@@ -2473,7 +2462,7 @@ def aggregate_rollout_metrics(
 
 
 def async_grpo_train(
-    policy: ColocatablePolicyInterface,
+    policy: PolicyTrainerInterface,
     policy_generation: Optional[GenerationInterface],
     dataloader: StatefulDataLoader,
     val_dataloader: Optional[StatefulDataLoader],
@@ -2902,7 +2891,7 @@ def async_grpo_train(
                 else:
                     print("▶ Preparing for logprob inference...")
                     with timer.time("logprob_inference_prep"):
-                        policy.prepare_for_lp_inference()
+                        policy.finish_training(offload_mode=OffloadMode.EVAL_ONLY)
 
                 print("▶ Computing logprobs...", flush=True)
                 with timer.time("policy_and_reference_logprobs"):
@@ -3204,6 +3193,7 @@ def async_grpo_train(
                             os.path.join(checkpoint_path, "train_dataloader.pt"),
                         )
                         checkpointer.finalize_checkpoint(checkpoint_path)
+                    policy.finish_training()
 
             # Logging
             # Log training data (match sync GRPO logging payload for parity)

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -17,6 +17,7 @@ import time
 import warnings
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import nullcontext
+from pathlib import Path
 from typing import Any, Callable, NotRequired, Optional, TypedDict, TypeVar, cast
 
 import numpy as np
@@ -69,9 +70,13 @@ from nemo_rl.experience.rollouts import (
     run_async_nemo_gym_rollout,
     run_multi_turn_rollout,
 )
+from nemo_rl.models.generation import create_generation
+from nemo_rl.models.generation.constants import (
+    MEGATRON_BACKEND,
+    SGLANG_BACKEND,
+    VLLM_BACKEND,
+)
 from nemo_rl.models.generation.interfaces import GenerationInterface
-from nemo_rl.models.generation.sglang import SGLangConfig, SGLangGeneration
-from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration
 from nemo_rl.models.policy import PolicyConfig
 from nemo_rl.models.policy.interfaces import OffloadMode, PolicyTrainerInterface
 from nemo_rl.models.policy.lm_policy import Policy
@@ -452,7 +457,7 @@ def setup(
             use_gpus=True,
             num_gpus_per_node=policy_gpus_per_node,
             max_colocated_worker_groups=1
-            if generation_config["backend"] == "megatron"
+            if generation_config["backend"] == MEGATRON_BACKEND
             else 2,
         )
         train_cluster = cluster
@@ -463,7 +468,7 @@ def setup(
         )
 
     else:
-        assert generation_config["backend"] != "megatron", (
+        assert generation_config["backend"] != MEGATRON_BACKEND, (
             "Non-colocated inference is not supported for Megatron generation backends. "
             "Please use vLLM backend for generation."
         )
@@ -606,17 +611,14 @@ def setup(
         )
         return p, time.perf_counter() - t0
 
-    def init_vllm():
-        """Initialize vLLM generation workers."""
+    def init_generation():
+        """Initialize generation backend workers via the registry."""
         t0 = time.perf_counter()
-        pg = VllmGeneration(cluster=inference_cluster, config=generation_config)
-        pg.finish_generation()
-        return pg, time.perf_counter() - t0
-
-    def init_sglang():
-        """Initialize SGLang generation workers."""
-        t0 = time.perf_counter()
-        pg = SGLangGeneration(cluster=inference_cluster, config=generation_config)
+        pg = create_generation(
+            backend=backend,
+            cluster=inference_cluster,
+            config=generation_config,
+        )
         pg.finish_generation()
         return pg, time.perf_counter() - t0
 
@@ -682,7 +684,7 @@ def setup(
         return policy_generation, policy
 
     # Handle generation-specific setup
-    if backend == "megatron":
+    if backend == MEGATRON_BACKEND:
         # Megatron generation: policy_generation is None, only initialize policy
         policy_generation = None
         print(
@@ -693,65 +695,46 @@ def setup(
         policy, policy_time = init_policy()
         worker_init_timing_metrics["policy_init_time_s"] = policy_time
 
-    elif backend == "vllm":
-        # vLLM generation: setup config, then initialize with policy
-        generation_config = cast(VllmConfig, generation_config)
-        if generation_config["vllm_cfg"]["precision"] == "fp8":
-            assert loss_config.use_importance_sampling_correction, (
-                "Importance sampling must be enabled for vLLM FP8 generation for good convergence!"
-            )
-        if generation_config["vllm_cfg"]["kv_cache_dtype"].startswith("fp8"):
-            # FP8 KV cache requires FP8 model precision
-            assert generation_config["vllm_cfg"]["precision"] == "fp8", (
-                f"kv_cache_dtype='{generation_config['vllm_cfg']['kv_cache_dtype']}' requires precision='fp8'. "
-                "FP8 KV cache can only be used together with FP8 model weights."
-            )
-            # FP8 KV cache compatibility checks
-            assert policy_config["dtensor_cfg"]["enabled"] == False, (
-                "DTensor backend is not supported with kv cache fp8 enabled."
-            )
-            assert not _should_use_async_rollouts(master_config), (
-                "Async rollouts is not supported with kv cache fp8 enabled."
-            )
-            assert policy_config["megatron_cfg"]["pipeline_model_parallel_size"] == 1, (
-                "Currently when using FP8 KV cache in generation, then in megatron we only support pipeline_model_parallel_size=1. We will add more support in future."
+    else:
+        # Backend-specific config validation / defaults
+        if backend == VLLM_BACKEND:
+            if generation_config["vllm_cfg"]["precision"] == "fp8":
+                assert loss_config["use_importance_sampling_correction"] is True, (
+                    "Importance sampling must be enabled for vLLM FP8 generation for good convergence!"
+                )
+            if generation_config["vllm_cfg"]["kv_cache_dtype"].startswith("fp8"):
+                assert generation_config["vllm_cfg"]["precision"] == "fp8", (
+                    f"kv_cache_dtype='{generation_config['vllm_cfg']['kv_cache_dtype']}' requires precision='fp8'. "
+                    "FP8 KV cache can only be used together with FP8 model weights."
+                )
+                assert policy_config["dtensor_cfg"]["enabled"] == False, (
+                    "DTensor backend is not supported with kv cache fp8 enabled."
+                )
+                assert not _should_use_async_rollouts(master_config), (
+                    "Async rollouts is not supported with kv cache fp8 enabled."
+                )
+                assert policy_config["megatron_cfg"]["pipeline_model_parallel_size"] == 1, (
+                    "Currently when using FP8 KV cache in generation, then in megatron we only support pipeline_model_parallel_size=1. We will add more support in future."
+                )
+
+            generation_config["vllm_cfg"]["hf_overrides"] = policy_config.get(
+                "hf_config_overrides", {}
             )
 
-        ## make vllm hf overrides match the training policy
-        generation_config["vllm_kwargs"]["hf_overrides"] = policy_config.get(
-            "hf_config_overrides", {}
-        )
+        elif backend == SGLANG_BACKEND:
+            if "model_path" not in generation_config["sglang_cfg"]:
+                generation_config["sglang_cfg"]["model_path"] = policy_config["model_name"]
 
         policy_generation, policy = initialize_generation_with_policy(
-            init_generation_fn=init_vllm,
-            generation_name="vLLM",
-            init_time_key="vllm_init_time_s",
+            init_generation_fn=init_generation,
+            generation_name=backend,
+            init_time_key=f"{backend}_init_time_s",
             colocated_inference=colocated_inference,
             worker_init_timing_metrics=worker_init_timing_metrics,
         )
 
         print(
-            f"  ✓ Using vLLM backend for generation with {policy_config['model_name']}",
-            flush=True,
-        )
-
-    elif backend == "sglang":
-        generation_config = cast(SGLangConfig, generation_config)
-
-        # Set model_path if not already set
-        if "model_path" not in generation_config["sglang_cfg"]:
-            generation_config["sglang_cfg"]["model_path"] = policy_config["model_name"]
-
-        policy_generation, policy = initialize_generation_with_policy(
-            init_generation_fn=init_sglang,
-            generation_name="SGLang",
-            init_time_key="sglang_init_time_s",
-            colocated_inference=colocated_inference,
-            worker_init_timing_metrics=worker_init_timing_metrics,
-        )
-
-        print(
-            f"  ✓ Using SGLang backend for generation with {policy_config['model_name']}",
+            f"  ✓ Using {backend} backend for generation with {policy_config['model_name']}",
             flush=True,
         )
 
@@ -787,12 +770,13 @@ def setup(
     if worker_init_timing_metrics:
         print("\n▶ Worker Initialization Timing:")
 
-        vllm_time = worker_init_timing_metrics.get("vllm_init_time_s", 0)
+        gen_time_key = f"{backend}_init_time_s"
+        gen_time = worker_init_timing_metrics.get(gen_time_key, 0)
         policy_time = worker_init_timing_metrics.get("policy_init_time_s", 0)
         total_setup = worker_init_timing_metrics.get("total_setup_time_s", 0)
 
-        if vllm_time:
-            print(f"  vLLM init: {vllm_time:.1f}s")
+        if gen_time:
+            print(f"  {backend} init: {gen_time:.1f}s")
 
         if policy_time:
             print(f"  Policy init: {policy_time:.1f}s")
@@ -1017,7 +1001,7 @@ def _should_use_async_rollouts(master_config: MasterConfig) -> bool:
         return False
 
     backend = generation_config.get("backend", "")
-    if backend != "vllm":
+    if backend != VLLM_BACKEND:
         return False
 
     vllm_cfg = generation_config.get("vllm_cfg", {})
@@ -1124,101 +1108,6 @@ def _extract_prompt_only_messages(message_logs: list) -> list:
         prompt_only_message_logs.append(prompt_only_log)
     return prompt_only_message_logs
 
-
-def refit_policy_generation(
-    policy: PolicyTrainerInterface,
-    policy_generation: GenerationInterface,
-    colocated_inference: bool,
-    _refit_buffer_size_gb: Optional[int] = None,
-    timer: Optional[Timer] = None,
-    kv_scales: Optional[dict[str, float]] = None,
-) -> None:
-    """Refit the policy generation interface with the latest policy weights.
-
-    .. deprecated::
-        Use :class:`~nemo_rl.weight_sync.WeightSynchronizer` and call
-        ``sync_weights()`` instead.
-
-    Args:
-        policy: The policy to provide weights to the inference engine.
-        policy_generation: The inference engine to refit.
-        _refit_buffer_size_gb: The size of the buffer to use for refitting.
-            If it is None, the buffer size will be computed by the remaining memory.
-            This parameter is primarily used for testing.
-        timer: Optional Timer used to time the prepare/transfer/update phase
-        kv_scales: Optional dictionary of KV cache scales for FP8 quantization.
-    """
-    warnings.warn(
-        "refit_policy_generation() is deprecated. "
-        "Use WeightSynchronizer.sync_weights() instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    from nemo_rl.models.policy.interfaces import OffloadMode
-
-    if colocated_inference:
-        policy.finish_training(offload_mode=OffloadMode.OPTIMIZER_ONLY)
-        policy_generation.prepare_for_generation(tags=["weights"])
-
-    timer_context = (
-        timer.time("prepare_for_generation/transfer_and_update_weights")
-        if timer is not None
-        else nullcontext()
-    )
-    with timer_context:
-        update_success = False
-        if colocated_inference:
-            if _refit_buffer_size_gb is not None:
-                buffer_size_bytes = _refit_buffer_size_gb * (1024**3)
-            else:
-                memory_ratio = os.getenv("NRL_REFIT_BUFFER_MEMORY_RATIO", "0.3")
-                buffer_size_bytes = int(
-                    policy.get_free_memory_bytes() * float(memory_ratio)
-                )
-
-            if isinstance(policy_generation, SGLangGeneration):
-                sglang_url_to_gpu_uuids = (
-                    policy_generation.get_sglang_url_to_gpu_uuids()
-                )
-                flush_success = policy_generation.invalidate_kv_cache()
-                if not flush_success:
-                    print("SGLang KV cache invalidation failed before weight update. ")
-                futures_train = policy.stream_weights_via_http(
-                    sglang_url_to_gpu_uuids=sglang_url_to_gpu_uuids,
-                )
-                ray.get(futures_train)
-                update_success = True
-            else:
-                futures_train = policy.stream_weights_via_ipc_zmq(
-                    buffer_size_bytes=buffer_size_bytes
-                )
-                futures_inference = policy_generation.update_weights_via_ipc_zmq()
-                ray.get(futures_train)
-                results = ray.get(futures_inference)
-                update_success = all(result for result in results if result is not None)
-        else:
-            if isinstance(policy_generation, SGLangGeneration):
-                raise NotImplementedError(
-                    "SGLang haven't implemented non-colocated inference mode. "
-                )
-            futures_train = policy.broadcast_weights_for_collective(kv_scales=kv_scales)
-            futures_inference = policy_generation.update_weights_from_collective()
-            ray.get(futures_train)
-            results = ray.get(futures_inference)
-            update_success = all(result for result in results if result is not None)
-
-        if not update_success:
-            error_tag = "cuda-ipc" if colocated_inference else "nccl"
-            error_message = (
-                "❌ Error: Updating weights for the generation policy failed during refit.\n"
-                f"This often indicates an issue with {error_tag} or "
-                "a problem within the generation backend (e.g., vLLM worker).\n"
-            )
-            raise RuntimeError(error_message)
-
-    if colocated_inference:
-        policy.finish_training(offload_mode=OffloadMode.FULL)
-        policy_generation.prepare_for_generation(tags=["kv_cache"])
 
 
 def _log_mixed_rewards_and_advantages_information(

--- a/nemo_rl/models/generation/__init__.py
+++ b/nemo_rl/models/generation/__init__.py
@@ -16,7 +16,13 @@ from typing import cast
 
 from transformers import PreTrainedTokenizerBase
 
+from nemo_rl.models.generation.constants import VLLM_BACKEND
 from nemo_rl.models.generation.interfaces import GenerationConfig
+from nemo_rl.models.generation.registry import (
+    create_generation,
+    get_registered_backends,
+    register_generation_backend,
+)
 from nemo_rl.models.generation.vllm import VllmConfig
 
 TokenizerType = PreTrainedTokenizerBase
@@ -41,7 +47,7 @@ def configure_generation_config(
         config["stop_token_ids"] = [tokenizer.eos_token_id]
 
     # vllm setting
-    if config["backend"] == "vllm":
+    if config["backend"] == VLLM_BACKEND:
         config = cast(VllmConfig, config)
         # set load_format
         config["vllm_cfg"]["load_format"] = "auto" if is_eval else "dummy"

--- a/nemo_rl/models/generation/interfaces.py
+++ b/nemo_rl/models/generation/interfaces.py
@@ -220,7 +220,7 @@ class GenerationOutputSpec(TypedDict):
 
 
 class GenerationInterface(ABC):
-    """Abstract base class defining the interface for RL policies."""
+    """Abstract base class defining the interface for generation backends."""
 
     @abstractmethod
     def init_collective(
@@ -237,10 +237,12 @@ class GenerationInterface(ABC):
 
     @abstractmethod
     def prepare_for_generation(self, *args: Any, **kwargs: Any) -> bool:
+        """Transition to generation phase. Load weights, allocate KV cache, etc."""
         pass
 
     @abstractmethod
     def finish_generation(self, *args: Any, **kwargs: Any) -> bool:
+        """Transition out of generation phase. Free GPU resources for training."""
         pass
 
     @property

--- a/nemo_rl/models/generation/registry.py
+++ b/nemo_rl/models/generation/registry.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generation backend registry.
+
+Provides a registry/factory that maps backend name strings (e.g.
+``"vllm"``, ``"sglang"``) to their concrete
+:class:`~nemo_rl.models.generation.interfaces.GenerationInterface`
+classes and config types.  Algorithm code uses :func:`create_generation`
+instead of importing backend modules directly, keeping it decoupled from
+any particular backend implementation.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional, TypedDict
+
+from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
+from nemo_rl.models.generation.constants import SGLANG_BACKEND, VLLM_BACKEND
+from nemo_rl.models.generation.interfaces import GenerationInterface
+
+
+class _BackendEntry(TypedDict):
+    factory: Callable[..., GenerationInterface]
+    config_type: Optional[type]
+
+
+_REGISTRY: dict[str, _BackendEntry] = {}
+
+
+def register_generation_backend(
+    name: str,
+    factory: Callable[..., GenerationInterface],
+    config_type: Optional[type] = None,
+) -> None:
+    """Register a generation backend.
+
+    Args:
+        name: Backend identifier (e.g. ``"vllm"``).
+        factory: Callable that creates a ``GenerationInterface`` instance.
+            Must accept at least ``cluster`` and ``config`` keyword
+            arguments.
+        config_type: Optional ``TypedDict`` subclass used for casting the
+            generation config before passing it to *factory*.
+    """
+    _REGISTRY[name] = _BackendEntry(factory=factory, config_type=config_type)
+
+
+def get_registered_backends() -> list[str]:
+    """Return names of all registered generation backends."""
+    return list(_REGISTRY.keys())
+
+
+def create_generation(
+    backend: str,
+    cluster: RayVirtualCluster,
+    config: dict[str, Any],
+) -> GenerationInterface:
+    """Instantiate a registered generation backend.
+
+    Args:
+        backend: Backend identifier (must have been registered via
+            :func:`register_generation_backend`).
+        cluster: The :class:`RayVirtualCluster` to host the workers.
+        config: Generation configuration dict.  If the backend was
+            registered with a *config_type*, the dict is cast to that
+            type before being forwarded to the factory.
+
+    Returns:
+        A fully-constructed :class:`GenerationInterface` instance.
+
+    Raises:
+        ValueError: If *backend* has not been registered.
+    """
+    _ensure_builtins_registered()
+
+    if backend not in _REGISTRY:
+        available = ", ".join(sorted(_REGISTRY.keys()))
+        raise ValueError(
+            f"Unknown generation backend {backend!r}. "
+            f"Registered backends: {available}"
+        )
+
+    entry = _REGISTRY[backend]
+    if entry["config_type"] is not None:
+        from typing import cast
+
+        config = cast(entry["config_type"], config)
+
+    return entry["factory"](cluster=cluster, config=config)
+
+
+# ---------------------------------------------------------------------------
+# Built-in backends (lazy-registered on first use to avoid heavy imports at
+# module load time)
+# ---------------------------------------------------------------------------
+
+_BUILTINS_REGISTERED = False
+
+
+def _ensure_builtins_registered() -> None:
+    global _BUILTINS_REGISTERED
+    if _BUILTINS_REGISTERED:
+        return
+    _BUILTINS_REGISTERED = True
+
+    def _vllm_factory(
+        cluster: RayVirtualCluster, config: Any
+    ) -> GenerationInterface:
+        from nemo_rl.models.generation.vllm import VllmGeneration
+
+        return VllmGeneration(cluster=cluster, config=config)
+
+    def _sglang_factory(
+        cluster: RayVirtualCluster, config: Any
+    ) -> GenerationInterface:
+        from nemo_rl.models.generation.sglang import SGLangGeneration
+
+        return SGLangGeneration(cluster=cluster, config=config)
+
+    from nemo_rl.models.generation.vllm import VllmConfig
+    from nemo_rl.models.generation.sglang import SGLangConfig
+
+    register_generation_backend(VLLM_BACKEND, _vllm_factory, config_type=VllmConfig)
+    register_generation_backend(SGLANG_BACKEND, _sglang_factory, config_type=SGLangConfig)

--- a/nemo_rl/models/policy/interfaces.py
+++ b/nemo_rl/models/policy/interfaces.py
@@ -12,15 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import ABC, abstractmethod
+from enum import Enum
 from typing import Any, Optional, TypedDict
 
-import ray
 import torch
 
 from nemo_rl.algorithms.loss.interfaces import LossFunction
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.models.generation.interfaces import GenerationDatumSpec
 from nemo_rl.utils.timer import Timer
+
+
+class OffloadMode(Enum):
+    """Controls how aggressively to offload during finish_training().
+
+    EVAL_ONLY: keep model on GPU in eval mode, optionally offload optimizer
+        based on worker config (offload_optimizer_for_logprob). Used by
+        algorithm code before logprob / KV-scale inference.
+    OPTIMIZER_ONLY: offload optimizer, keep model on GPU in its current mode.
+        Used by colocated weight synchronizers before weight transfer (model
+        must stay on GPU for CUDA IPC / HTTP streaming).
+    FULL: offload everything appropriate for the deployment topology. In
+        colocated mode this offloads model + optimizer; in non-colocated mode
+        this sets eval mode, keeps model on GPU, and optionally offloads
+        optimizer.
+    """
+
+    EVAL_ONLY = "eval_only"
+    OPTIMIZER_ONLY = "optimizer_only"
+    FULL = "full"
 
 
 class LogprobOutputSpec(TypedDict):
@@ -48,8 +68,8 @@ class TopkLogitsOutputSpec(TypedDict):
     topk_indices: torch.Tensor
 
 
-class PolicyInterface(ABC):
-    """Abstract base class defining the interface for RL policies."""
+class PolicyTrainerInterface(ABC):
+    """Abstract base class defining the interface for RL policy training."""
 
     @abstractmethod
     def get_logprobs(
@@ -148,10 +168,18 @@ class PolicyInterface(ABC):
 
     @abstractmethod
     def prepare_for_training(self, *args: Any, **kwargs: Any) -> None:
+        """Transition to training phase. Load model and optimizer to GPU, set train mode."""
         pass
 
     @abstractmethod
     def finish_training(self, *args: Any, **kwargs: Any) -> None:
+        """Transition out of training phase. Free GPU resources.
+
+        Accepts an optional ``offload_mode`` kwarg (OffloadMode enum):
+          - EVAL_ONLY: model on GPU in eval mode (for logprob inference).
+          - OPTIMIZER_ONLY: offload optimizer only (for weight staging).
+          - FULL (default): full offload based on deployment topology.
+        """
         pass
 
     @abstractmethod
@@ -163,49 +191,5 @@ class PolicyInterface(ABC):
         pass
 
 
-class ColocatablePolicyInterface(PolicyInterface):
-    @abstractmethod
-    def init_collective(
-        self, ip: str, port: int, world_size: int, *, train_world_size: int
-    ) -> list[ray.ObjectRef]:
-        pass
-
-    @abstractmethod
-    def offload_before_refit(self) -> None:
-        pass
-
-    @abstractmethod
-    def offload_after_refit(self) -> None:
-        pass
-
-    @abstractmethod
-    def prepare_refit_info(self) -> Optional[dict[str, Any]]:
-        pass
-
-    @abstractmethod
-    def stream_weights_via_ipc_zmq(
-        self, *args: Any, **kwargs: Any
-    ) -> list[ray.ObjectRef]:
-        pass
-
-    def stream_weights_via_http(
-        self, sglang_url_to_gpu_uuids: dict[str, list[str]]
-    ) -> list[ray.ObjectRef]:
-        """Stream model weights to SGLang servers via HTTP API.
-
-        Args:
-            sglang_url_to_gpu_uuids: Dict mapping SGLang server URL to list of GPU UUIDs it uses
-        """
-        raise NotImplementedError(
-            "stream_weights_via_http is not implemented for this policy worker"
-        )
-
-    @abstractmethod
-    def broadcast_weights_for_collective(
-        self, kv_scales: Optional[dict[str, float]] = None
-    ) -> list[ray.ObjectRef]:
-        pass
-
-    @abstractmethod
-    def prepare_for_lp_inference(self) -> None:
-        pass
+# Backward compatibility
+PolicyInterface = PolicyTrainerInterface

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -40,8 +40,8 @@ from nemo_rl.models.generation.interfaces import (
 )
 from nemo_rl.models.policy import PolicyConfig
 from nemo_rl.models.policy.interfaces import (
-    ColocatablePolicyInterface,
     LogprobOutputSpec,
+    PolicyTrainerInterface,
     ReferenceLogprobOutputSpec,
     ScoreOutputSpec,
     TopkLogitsOutputSpec,
@@ -58,7 +58,7 @@ from nemo_rl.utils.timer import Timer
 PathLike = Union[str, "os.PathLike[Any]"]
 
 
-class Policy(ColocatablePolicyInterface, GenerationInterface):
+class Policy(PolicyTrainerInterface, GenerationInterface):
     def __init__(
         self,
         cluster: RayVirtualCluster,
@@ -773,14 +773,7 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
         futures = self.worker_group.run_all_workers_single_data("prepare_for_training")
         ray.get(futures)
 
-    def prepare_for_lp_inference(self, *args: Any, **kwargs: Any) -> None:
-        futures = self.worker_group.run_all_workers_single_data(
-            "prepare_for_lp_inference"
-        )
-        ray.get(futures)
-
     def finish_generation(self, *args: Any, **kwargs: Any) -> bool:
-        # We don't need to do anything here
         return True
 
     def invalidate_kv_cache(self, *args: Any, **kwargs: Any) -> bool:
@@ -799,8 +792,10 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
         return results[0]
 
     def finish_training(self, *args: Any, **kwargs: Any) -> None:
-        # Placeholder implementation
-        pass
+        futures = self.worker_group.run_all_workers_single_data(
+            "finish_training", **kwargs
+        )
+        ray.get(futures)
 
     def calibrate_qkv_fp8_scales(
         self,
@@ -908,15 +903,6 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
         # this function should co-work with vllm, so we should wait for all futures to complete outside
         return futures
 
-    def offload_before_refit(self) -> None:
-        """Offload the optimizer and buffers to the CPU."""
-        futures = self.worker_group.run_all_workers_single_data("offload_before_refit")
-        ray.get(futures)
-
-    def offload_after_refit(self) -> None:
-        """Offload the optimizer and buffers to the CPU."""
-        futures = self.worker_group.run_all_workers_single_data("offload_after_refit")
-        ray.get(futures)
 
     def save_checkpoint(
         self,

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -77,8 +77,8 @@ from nemo_rl.models.huggingface.common import (
 )
 from nemo_rl.models.policy import PolicyConfig
 from nemo_rl.models.policy.interfaces import (
-    ColocatablePolicyInterface,
     LogprobOutputSpec,
+    OffloadMode,
     ScoreOutputSpec,
 )
 from nemo_rl.models.policy.utils import (
@@ -1894,37 +1894,14 @@ class DTensorPolicyWorkerImpl(
         if self.cpu_offload:
             self.model = self.move_to_cpu(self.model)
 
-    @wrap_with_nvtx_name("dtensor_policy_worker/prepare_for_lp_inference")
-    def prepare_for_lp_inference(self) -> None:
-        # onload model to cuda
-        if not self.cpu_offload:
-            self.move_to_cuda(self.model)
-        else:
-            self.model = self.move_buffer_to_device(self.model, "cuda")
-
-        self.model.eval()
-
-        # offload optimizer to cpu
-        torch.randn(1).cuda()  # wake up torch allocator
-        if self.optimizer is not None and self.offload_optimizer_for_logprob:
-            self.move_optimizer_to_device("cpu")
-
-        gc.collect()
-        torch.cuda.empty_cache()
-
     @wrap_with_nvtx_name("dtensor_policy_worker/prepare_for_training")
     def prepare_for_training(self, *args, **kwargs) -> None:
-        # onload models and optimizer state to cuda
         if not self.cpu_offload:
             self.move_to_cuda(self.model)
         else:
-            # when cpu offload is enabled, the buffers do not get moved
-            # to cuda automatically, so we need to do that manually
             self.model = self.move_buffer_to_device(self.model, "cuda")
 
         self.model.train()
-        # Move optimizer state to CUDA if it exists
-        # colocated generation will always offload optimizer to cuda before refit
         if (
             self.optimizer is not None
             and not self.cpu_offload
@@ -1935,31 +1912,56 @@ class DTensorPolicyWorkerImpl(
         torch.cuda.empty_cache()
 
     @torch.no_grad()
-    @wrap_with_nvtx_name("dtensor_policy_worker/offload_before_refit")
-    def offload_before_refit(self) -> None:
-        """Offload the optimizer to the CPU."""
-        torch.randn(1).cuda()  # wake up torch allocator
-        if self.optimizer is not None:
-            self.move_optimizer_to_device("cpu")
+    @wrap_with_nvtx_name("dtensor_policy_worker/finish_training")
+    def finish_training(self, *args, **kwargs) -> None:
+        offload_mode = kwargs.get("offload_mode", OffloadMode.FULL)
 
-        gc.collect()
-        torch.cuda.empty_cache()
+        if offload_mode == OffloadMode.EVAL_ONLY:
+            if not self.cpu_offload:
+                self.move_to_cuda(self.model)
+            else:
+                self.model = self.move_buffer_to_device(self.model, "cuda")
+            self.model.eval()
+            torch.randn(1).cuda()
+            if self.optimizer is not None and self.offload_optimizer_for_logprob:
+                self.move_optimizer_to_device("cpu")
+            gc.collect()
+            torch.cuda.empty_cache()
+        elif offload_mode == OffloadMode.OPTIMIZER_ONLY:
+            if not self.is_generation_colocated:
+                return
+            torch.randn(1).cuda()
+            if self.optimizer is not None:
+                self.move_optimizer_to_device("cpu")
+            gc.collect()
+            torch.cuda.empty_cache()
+        else:
+            if self.is_generation_colocated:
+                self.model = self.move_to_cpu(self.model)
+                self.model.eval()
+                torch.randn(1).cuda()
+                if self.optimizer is not None:
+                    self.move_optimizer_to_device("cpu")
+                gc.collect()
+                torch.cuda.empty_cache()
 
-    @torch.no_grad()
-    @wrap_with_nvtx_name("dtensor_policy_worker/offload_after_refit")
-    def offload_after_refit(self) -> None:
-        """Offload as much as possible on the CPU."""
-        self.model = self.move_to_cpu(self.model)
-        self.model.eval()
-        torch.randn(1).cuda()  # wake up torch allocator
-        self.offload_before_refit()  # rerun the old offload function
-
-        # Print memory stats after offloading
-        allocated = torch.cuda.memory_allocated() / (1024**3)  # Convert to GB
-        reserved = torch.cuda.memory_reserved() / (1024**3)  # Convert to GB
-        print(
-            f"GPU Memory after optimizer offload: {allocated:.2f}GB allocated, {reserved:.2f}GB reserved"
-        )
+                allocated = torch.cuda.memory_allocated() / (1024**3)
+                reserved = torch.cuda.memory_reserved() / (1024**3)
+                print(
+                    f"GPU Memory after finish_training (colocated): "
+                    f"{allocated:.2f}GB allocated, {reserved:.2f}GB reserved"
+                )
+            else:
+                if not self.cpu_offload:
+                    self.move_to_cuda(self.model)
+                else:
+                    self.model = self.move_buffer_to_device(self.model, "cuda")
+                self.model.eval()
+                torch.randn(1).cuda()
+                if self.optimizer is not None and self.offload_optimizer_for_logprob:
+                    self.move_optimizer_to_device("cpu")
+                gc.collect()
+                torch.cuda.empty_cache()
 
     def move_optimizer_to_device(self, device: str | torch.device) -> None:
         for state in self.optimizer.state.values():

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -62,8 +62,8 @@ from nemo_rl.models.automodel.train import (
 )
 from nemo_rl.models.policy import PolicyConfig
 from nemo_rl.models.policy.interfaces import (
-    ColocatablePolicyInterface,
     LogprobOutputSpec,
+    OffloadMode,
     ScoreOutputSpec,
 )
 from nemo_rl.models.policy.utils import get_runtime_env_for_policy_worker
@@ -1000,37 +1000,14 @@ class DTensorPolicyWorkerV2Impl(
         if self.cpu_offload:
             self.model = self.move_to_cpu(self.model)
 
-    @wrap_with_nvtx_name("dtensor_policy_worker_v2/prepare_for_lp_inference")
-    def prepare_for_lp_inference(self) -> None:
-        # onload model to cuda
-        if not self.cpu_offload:
-            self.move_to_cuda(self.model)
-        else:
-            self.model = self.move_buffer_to_device(self.model, "cuda")
-
-        self.model.eval()
-
-        # offload optimizer to cpu
-        torch.randn(1).cuda()  # wake up torch allocator
-        if self.optimizer is not None and self.offload_optimizer_for_logprob:
-            self.move_optimizer_to_device("cpu")
-
-        gc.collect()
-        torch.cuda.empty_cache()
-
     @wrap_with_nvtx_name("dtensor_policy_worker_v2/prepare_for_training")
     def prepare_for_training(self, *args, **kwargs) -> None:
-        # onload models and optimizer state to cuda
         if not self.cpu_offload:
             self.move_to_cuda(self.model)
         else:
-            # when cpu offload is enabled, the buffers do not get moved
-            # to cuda automatically, so we need to do that manually
             self.model = self.move_buffer_to_device(self.model, "cuda")
 
         self.model.train()
-        # Move optimizer state to CUDA if it exists
-        # colocated generation will always offload optimizer to cuda before refit
         if (
             self.optimizer is not None
             and not self.cpu_offload
@@ -1041,31 +1018,56 @@ class DTensorPolicyWorkerV2Impl(
         torch.cuda.empty_cache()
 
     @torch.no_grad()
-    @wrap_with_nvtx_name("dtensor_policy_worker_v2/offload_before_refit")
-    def offload_before_refit(self) -> None:
-        """Offload the optimizer to the CPU."""
-        torch.randn(1).cuda()  # wake up torch allocator
-        if self.optimizer is not None:
-            self.move_optimizer_to_device("cpu")
+    @wrap_with_nvtx_name("dtensor_policy_worker_v2/finish_training")
+    def finish_training(self, *args, **kwargs) -> None:
+        offload_mode = kwargs.get("offload_mode", OffloadMode.FULL)
 
-        gc.collect()
-        torch.cuda.empty_cache()
+        if offload_mode == OffloadMode.EVAL_ONLY:
+            if not self.cpu_offload:
+                self.move_to_cuda(self.model)
+            else:
+                self.model = self.move_buffer_to_device(self.model, "cuda")
+            self.model.eval()
+            torch.randn(1).cuda()
+            if self.optimizer is not None and self.offload_optimizer_for_logprob:
+                self.move_optimizer_to_device("cpu")
+            gc.collect()
+            torch.cuda.empty_cache()
+        elif offload_mode == OffloadMode.OPTIMIZER_ONLY:
+            if not self.is_generation_colocated:
+                return
+            torch.randn(1).cuda()
+            if self.optimizer is not None:
+                self.move_optimizer_to_device("cpu")
+            gc.collect()
+            torch.cuda.empty_cache()
+        else:
+            if self.is_generation_colocated:
+                self.model = self.move_to_cpu(self.model)
+                self.model.eval()
+                torch.randn(1).cuda()
+                if self.optimizer is not None:
+                    self.move_optimizer_to_device("cpu")
+                gc.collect()
+                torch.cuda.empty_cache()
 
-    @torch.no_grad()
-    @wrap_with_nvtx_name("dtensor_policy_worker_v2/offload_after_refit")
-    def offload_after_refit(self) -> None:
-        """Offload as much as possible on the CPU."""
-        self.model = self.move_to_cpu(self.model)
-        self.model.eval()
-        torch.randn(1).cuda()  # wake up torch allocator
-        self.offload_before_refit()  # rerun the old offload function
-
-        # Print memory stats after offloading
-        allocated = torch.cuda.memory_allocated() / (1024**3)  # Convert to GB
-        reserved = torch.cuda.memory_reserved() / (1024**3)  # Convert to GB
-        print(
-            f"GPU Memory after optimizer offload: {allocated:.2f}GB allocated, {reserved:.2f}GB reserved"
-        )
+                allocated = torch.cuda.memory_allocated() / (1024**3)
+                reserved = torch.cuda.memory_reserved() / (1024**3)
+                print(
+                    f"GPU Memory after finish_training (colocated): "
+                    f"{allocated:.2f}GB allocated, {reserved:.2f}GB reserved"
+                )
+            else:
+                if not self.cpu_offload:
+                    self.move_to_cuda(self.model)
+                else:
+                    self.model = self.move_buffer_to_device(self.model, "cuda")
+                self.model.eval()
+                torch.randn(1).cuda()
+                if self.optimizer is not None and self.offload_optimizer_for_logprob:
+                    self.move_optimizer_to_device("cpu")
+                gc.collect()
+                torch.cuda.empty_cache()
 
     def move_optimizer_to_device(self, device: str | torch.device) -> None:
         for state in self.optimizer.state.values():

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -84,8 +84,8 @@ from nemo_rl.models.megatron.train import (
 )
 from nemo_rl.models.policy import PolicyConfig
 from nemo_rl.models.policy.interfaces import (
-    ColocatablePolicyInterface,
     LogprobOutputSpec,
+    OffloadMode,
 )
 from nemo_rl.models.policy.utils import get_runtime_env_for_policy_worker
 from nemo_rl.models.policy.workers.base_policy_worker import AbstractPolicyWorker
@@ -1192,37 +1192,12 @@ class MegatronPolicyWorkerImpl(
             post_iter_func=lambda x: x[1],
         )
 
-    def prepare_for_lp_inference(self):
-        self.model = self.move_model(self.model, "cuda", move_grads=False)
-        self.model.eval()
-
-        # offload grads to cpu
-        self.model = self.move_model(
-            self.model, "cpu", move_params=False, move_grads=True
-        )  # get rid of grad buffers
-
-        # offload optimizer to cpu
-        torch.randn(1).cuda()  # wake up torch allocator
-        if (
-            hasattr(self, "optimizer")
-            and self.optimizer is not None
-            and not self.optimizer_cpu_offload
-            and self.offload_optimizer_for_logprob
-        ):
-            self.move_optimizer("cpu")
-
-        gc.collect()
-        torch.cuda.empty_cache()
-
     def prepare_for_training(self, *args, **kwargs):
-        # onload models and optimizer state to cuda
         self.model = self.move_model(
             self.model, "cuda", move_grads=True, move_params=True
         )
         self.model.train()
 
-        # Move optimizer state to CUDA if it exists
-        # colocated generation will always offload optimizer to cuda before refit
         if (
             hasattr(self, "optimizer")
             and self.optimizer is not None
@@ -1234,53 +1209,97 @@ class MegatronPolicyWorkerImpl(
         if self.cfg["megatron_cfg"]["empty_unused_memory_level"] >= 1:
             torch.cuda.empty_cache()
 
-    @wrap_with_nvtx_name("megatron_policy_worker/offload_before_refit")
-    def offload_before_refit(self):
-        """Offload the optimizer and buffers to the CPU."""
+    @wrap_with_nvtx_name("megatron_policy_worker/finish_training")
+    def finish_training(self, *args, **kwargs):
+        offload_mode = kwargs.get("offload_mode", OffloadMode.FULL)
         no_grad = torch.no_grad()
         no_grad.__enter__()
-        allocated = torch.cuda.memory_allocated() / (1024**3)  # Convert to GB
-        reserved = torch.cuda.memory_reserved() / (1024**3)  # Convert to GB
-        print(
-            f"GPU Memory before optimizer offload: {allocated:.2f}GB allocated, {reserved:.2f}GB reserved"
-        )
-        self.model = self.move_model(
-            self.model, "cpu", move_params=False, move_grads=True
-        )  # get rid of grad buffers
-        torch.randn(1).cuda()  # wake up torch allocator
-        if (
-            hasattr(self, "optimizer")
-            and self.optimizer is not None
-            and not self.optimizer_cpu_offload
-        ):
-            self.move_optimizer("cpu")
 
-        gc.collect()
-        torch.cuda.empty_cache()
+        if offload_mode == OffloadMode.EVAL_ONLY:
+            self.model = self.move_model(self.model, "cuda", move_grads=False)
+            self.model.eval()
+            self.model = self.move_model(
+                self.model, "cpu", move_params=False, move_grads=True
+            )
+            torch.randn(1).cuda()
+            if (
+                hasattr(self, "optimizer")
+                and self.optimizer is not None
+                and not self.optimizer_cpu_offload
+                and self.offload_optimizer_for_logprob
+            ):
+                self.move_optimizer("cpu")
+            gc.collect()
+            torch.cuda.empty_cache()
+        elif offload_mode == OffloadMode.OPTIMIZER_ONLY:
+            if not self.is_generation_colocated:
+                no_grad.__exit__(None, None, None)
+                return
+            allocated = torch.cuda.memory_allocated() / (1024**3)
+            reserved = torch.cuda.memory_reserved() / (1024**3)
+            print(
+                f"GPU Memory before optimizer offload: "
+                f"{allocated:.2f}GB allocated, {reserved:.2f}GB reserved"
+            )
+            self.model = self.move_model(
+                self.model, "cpu", move_params=False, move_grads=True
+            )
+            torch.randn(1).cuda()
+            if (
+                hasattr(self, "optimizer")
+                and self.optimizer is not None
+                and not self.optimizer_cpu_offload
+            ):
+                self.move_optimizer("cpu")
+            gc.collect()
+            torch.cuda.empty_cache()
 
-        # Print memory stats after offloading
-        allocated = torch.cuda.memory_allocated() / (1024**3)  # Convert to GB
-        reserved = torch.cuda.memory_reserved() / (1024**3)  # Convert to GB
-        print(
-            f"GPU Memory after optimizer offload: {allocated:.2f}GB allocated, {reserved:.2f}GB reserved"
-        )
-        no_grad.__exit__(None, None, None)
+            allocated = torch.cuda.memory_allocated() / (1024**3)
+            reserved = torch.cuda.memory_reserved() / (1024**3)
+            print(
+                f"GPU Memory after optimizer offload: "
+                f"{allocated:.2f}GB allocated, {reserved:.2f}GB reserved"
+            )
+        else:
+            if self.is_generation_colocated:
+                self.model = self.move_model(self.model, "cpu")
+                self.model.eval()
+                torch.randn(1).cuda()
+                self.model = self.move_model(
+                    self.model, "cpu", move_params=False, move_grads=True
+                )
+                if (
+                    hasattr(self, "optimizer")
+                    and self.optimizer is not None
+                    and not self.optimizer_cpu_offload
+                ):
+                    self.move_optimizer("cpu")
+                gc.collect()
+                torch.cuda.empty_cache()
 
-    @wrap_with_nvtx_name("megatron_policy_worker/offload_after_refit")
-    def offload_after_refit(self):
-        """Offload as much as possible on the CPU."""
-        no_grad = torch.no_grad()
-        no_grad.__enter__()
-        self.model = self.move_model(self.model, "cpu")
-        self.model.eval()
-        torch.randn(1).cuda()  # wake up torch allocator
-        self.offload_before_refit()  # rerun the old offload function
+                allocated = torch.cuda.memory_allocated() / (1024**3)
+                reserved = torch.cuda.memory_reserved() / (1024**3)
+                print(
+                    f"GPU Memory after finish_training (colocated): "
+                    f"{allocated:.2f}GB allocated, {reserved:.2f}GB reserved"
+                )
+            else:
+                self.model = self.move_model(self.model, "cuda", move_grads=False)
+                self.model.eval()
+                self.model = self.move_model(
+                    self.model, "cpu", move_params=False, move_grads=True
+                )
+                torch.randn(1).cuda()
+                if (
+                    hasattr(self, "optimizer")
+                    and self.optimizer is not None
+                    and not self.optimizer_cpu_offload
+                    and self.offload_optimizer_for_logprob
+                ):
+                    self.move_optimizer("cpu")
+                gc.collect()
+                torch.cuda.empty_cache()
 
-        allocated = torch.cuda.memory_allocated() / (1024**3)  # Convert to GB
-        reserved = torch.cuda.memory_reserved() / (1024**3)  # Convert to GB
-        print(
-            f"GPU Memory after refit complete: {allocated:.2f}GB allocated, {reserved:.2f}GB reserved"
-        )
         no_grad.__exit__(None, None, None)
 
     @torch.no_grad()

--- a/nemo_rl/weight_sync/collective_weight_synchronizer.py
+++ b/nemo_rl/weight_sync/collective_weight_synchronizer.py
@@ -24,8 +24,8 @@ Lifecycle per sync:
      generation.update_weights_from_collective()  -- receive via NCCL
   2. Verify transfer success
 
-No offload/restore steps are needed since policy and generation run on
-separate GPUs with dedicated memory.
+No finish_training()/prepare_for_training() calls are needed since policy
+and generation run on separate GPUs with dedicated memory.
 """
 
 from contextlib import nullcontext
@@ -44,7 +44,7 @@ class CollectiveWeightSynchronizer(WeightSynchronizer):
     synchronized via NCCL broadcast over a pre-established process group.
 
     Args:
-        policy: Policy object implementing ColocatablePolicyInterface.
+        policy: Policy object implementing PolicyTrainerInterface.
         generation: Generation object implementing GenerationInterface.
         train_cluster: RayVirtualCluster for the training workers, used to
             obtain the master address/port and world size for collective init.

--- a/nemo_rl/weight_sync/factory.py
+++ b/nemo_rl/weight_sync/factory.py
@@ -41,7 +41,7 @@ def create_weight_synchronizer(
     """Create the appropriate WeightSynchronizer for the given deployment.
 
     Args:
-        policy: Policy object (ColocatablePolicyInterface).
+        policy: Policy object (PolicyTrainerInterface).
         generation: Generation object (GenerationInterface).
         generation_backend: Name of the generation backend ("vllm", "sglang", "megatron").
         colocated: Whether policy and generation share the same GPUs.

--- a/nemo_rl/weight_sync/http_weight_synchronizer.py
+++ b/nemo_rl/weight_sync/http_weight_synchronizer.py
@@ -19,12 +19,12 @@ backend using HTTP streaming. SGLang exposes an HTTP endpoint for weight
 updates, so the policy streams weights directly to SGLang servers.
 
 Lifecycle per sync:
-  1. policy.offload_before_refit()       -- free GPU for weight staging
-  2. generation.prepare_for_generation(tags=["weights"])  -- allocate buffers
-  3. generation.invalidate_kv_cache()    -- clear stale KV cache
-  4. policy.stream_weights_via_http()    -- push weights via HTTP
-  5. policy.offload_after_refit()        -- restore optimizer state
-  6. generation.prepare_for_generation(tags=["kv_cache"]) -- rebuild KV cache
+  1. policy.finish_training(OPTIMIZER_ONLY)  -- free optimizer for weight staging
+  2. generation.prepare_for_generation()     -- allocate weight buffers
+  3. generation.invalidate_kv_cache()        -- clear stale KV cache
+  4. policy.stream_weights_via_http()        -- push weights via HTTP
+  5. policy.finish_training(FULL)            -- exit training phase (offload model)
+  6. generation.prepare_for_generation()     -- rebuild KV cache
 """
 
 from contextlib import nullcontext
@@ -32,6 +32,7 @@ from typing import Any, Optional
 
 import ray
 
+from nemo_rl.models.policy.interfaces import OffloadMode
 from nemo_rl.utils.timer import Timer
 from nemo_rl.weight_sync.interfaces import WeightSynchronizer
 
@@ -43,7 +44,7 @@ class HTTPWeightSynchronizer(WeightSynchronizer):
     are streamed to SGLang servers via their HTTP weight-update API.
 
     Args:
-        policy: Policy object implementing ColocatablePolicyInterface.
+        policy: Policy object implementing PolicyTrainerInterface.
         generation: SGLangGeneration instance exposing get_sglang_url_to_gpu_uuids().
     """
 
@@ -58,7 +59,7 @@ class HTTPWeightSynchronizer(WeightSynchronizer):
         timer: Optional[Timer] = None,
         kv_scales: Optional[dict[str, float]] = None,
     ) -> None:
-        self._policy.offload_before_refit()
+        self._policy.finish_training(offload_mode=OffloadMode.OPTIMIZER_ONLY)
         self._generation.prepare_for_generation(tags=["weights"])
 
         sync_succeeded = False
@@ -81,7 +82,7 @@ class HTTPWeightSynchronizer(WeightSynchronizer):
                 ray.get(futures_train)
             sync_succeeded = True
         finally:
-            self._policy.offload_after_refit()
+            self._policy.finish_training(offload_mode=OffloadMode.FULL)
             self._generation.prepare_for_generation(tags=["kv_cache"])
 
         self._stale = not sync_succeeded

--- a/nemo_rl/weight_sync/ipc_weight_synchronizer.py
+++ b/nemo_rl/weight_sync/ipc_weight_synchronizer.py
@@ -19,12 +19,12 @@ backend using ZMQ IPC sockets and CUDA IPC handles. This is the primary
 transport for colocated vLLM deployments.
 
 Lifecycle per sync:
-  1. policy.offload_before_refit()       -- free GPU for weight staging
-  2. generation.prepare_for_generation(tags=["weights"])  -- allocate buffers
-  3. policy.stream_weights_via_ipc_zmq() -- send weights via ZMQ
+  1. policy.finish_training(OPTIMIZER_ONLY)  -- free optimizer for weight staging
+  2. generation.prepare_for_generation()     -- allocate weight buffers
+  3. policy.stream_weights_via_ipc_zmq()     -- send weights via ZMQ
      generation.update_weights_via_ipc_zmq() -- receive weights
-  4. policy.offload_after_refit()        -- restore optimizer state
-  5. generation.prepare_for_generation(tags=["kv_cache"]) -- rebuild KV cache
+  4. policy.finish_training(FULL)            -- exit training phase (offload model)
+  5. generation.prepare_for_generation()     -- rebuild KV cache
 """
 
 import os
@@ -33,6 +33,7 @@ from typing import Any, Optional
 
 import ray
 
+from nemo_rl.models.policy.interfaces import OffloadMode
 from nemo_rl.utils.timer import Timer
 from nemo_rl.weight_sync.interfaces import WeightSynchronizer
 
@@ -45,7 +46,7 @@ class IPCWeightSynchronizer(WeightSynchronizer):
     any network overhead.
 
     Args:
-        policy: Policy object implementing ColocatablePolicyInterface.
+        policy: Policy object implementing PolicyTrainerInterface.
         generation: Generation object implementing GenerationInterface
             (concretely a VllmGeneration instance).
         refit_buffer_size_gb: Fixed buffer size in GB for weight staging.
@@ -69,7 +70,7 @@ class IPCWeightSynchronizer(WeightSynchronizer):
         timer: Optional[Timer] = None,
         kv_scales: Optional[dict[str, float]] = None,
     ) -> None:
-        self._policy.offload_before_refit()
+        self._policy.finish_training(offload_mode=OffloadMode.OPTIMIZER_ONLY)
         self._generation.prepare_for_generation(tags=["weights"])
 
         sync_succeeded = False
@@ -98,7 +99,7 @@ class IPCWeightSynchronizer(WeightSynchronizer):
                     )
             sync_succeeded = True
         finally:
-            self._policy.offload_after_refit()
+            self._policy.finish_training(offload_mode=OffloadMode.FULL)
             self._generation.prepare_for_generation(tags=["kv_cache"])
 
         self._stale = not sync_succeeded

--- a/research/template_project/single_update.py
+++ b/research/template_project/single_update.py
@@ -35,21 +35,15 @@ from omegaconf import OmegaConf
 from rich.pretty import pprint
 from template_project.data_utils import create_batch_from
 
-from nemo_rl.algorithms.grpo import MasterConfig, refit_policy_generation
+from nemo_rl.algorithms.grpo import MasterConfig
 from nemo_rl.algorithms.loss import NLLLossFn
 from nemo_rl.algorithms.utils import get_tokenizer
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
-from nemo_rl.distributed.ray_actor_environment_registry import (
-    ACTOR_ENVIRONMENT_REGISTRY,
-)
-from nemo_rl.distributed.virtual_cluster import (
-    PY_EXECUTABLES,
-    RayVirtualCluster,
-    init_ray,
-)
-from nemo_rl.models.generation import configure_generation_config
-from nemo_rl.models.generation.vllm import VllmGeneration
+from nemo_rl.distributed.virtual_cluster import RayVirtualCluster, init_ray
+from nemo_rl.models.generation import configure_generation_config, create_generation
+from nemo_rl.models.generation.constants import MEGATRON_BACKEND
 from nemo_rl.models.policy.lm_policy import Policy
+from nemo_rl.weight_sync import create_weight_synchronizer
 from nemo_rl.utils.config import (
     load_config,
     parse_hydra_overrides,
@@ -80,20 +74,19 @@ def main(config: MasterConfig) -> None:
         use_gpus=True,
         num_gpus_per_node=config.cluster["gpus_per_node"],
         max_colocated_worker_groups=1
-        if policy_config["generation"]["backend"] == "megatron"
+        if policy_config["generation"]["backend"] == MEGATRON_BACKEND
         else 2,
     )
 
-    # 2) Initialize vLLM generation first for a clean GPU environment
-    print("\n▶ Initializing vLLM generation...")
-    # Initialize vLLM directly from config
+    # 2) Initialize generation backend first for a clean GPU environment
+    backend = policy_config["generation"]["backend"]
+    print(f"\n▶ Initializing {backend} generation...")
     policy_config["generation"]["model_name"] = policy_config["model_name"]
-    policy_generation = VllmGeneration(
-        cluster=cluster, config=policy_config["generation"]
+    policy_generation = create_generation(
+        backend=backend, cluster=cluster, config=policy_config["generation"]
     )
-    # Pre-initialize workers to avoid contention later
     policy_generation.finish_generation()
-    print("  ✓ vLLM generation ready")
+    print(f"  ✓ {backend} generation ready")
 
     # 3) Initialize policy (LM)
     print("\n▶ Initializing LM Policy...")
@@ -106,22 +99,15 @@ def main(config: MasterConfig) -> None:
     )
     print("  ✓ Policy created")
 
-    # 4) Executes custom methods on all workers
-    # 4.1) Run a method on all workers in parallel with the same data
-    print("\n▶ Running a method on all workers in parallel with the same data...")
-    results = policy.run_all_workers_single_data("get_worker_rank")
-    print(f"  ✓ Results for get_worker_rank: {results}")
-
-    # 4.2) Run a method on all workers in parallel with different data
-    print("\n▶ Running a method on all workers in parallel with different data...")
-    worker_nums = config.cluster["gpus_per_node"] * config.cluster["num_nodes"]
-    input_list = [i for i in range(worker_nums)]
-    results = policy.run_all_workers_multiple_data("return_input", input=input_list)
-    print(f"  ✓ Results for return_input: {results}")
-
-    # Prepare refit info once before first refit
-    state_dict_info = policy.prepare_refit_info()
-    policy_generation.prepare_refit_info(state_dict_info or {})
+    # Set up weight synchronizer for transferring policy weights to generation
+    colocated = policy_config["generation"]["colocated"]["enabled"]
+    weight_sync = create_weight_synchronizer(
+        policy=policy,
+        generation=policy_generation,
+        generation_backend=backend,
+        colocated=colocated,
+    )
+    weight_sync.init_communicator()
 
     # Create tiny numeric batch and train with NLLLossFn
     print("\n▶ Creating tiny numeric batch and training with NLLLossFn...")
@@ -160,14 +146,9 @@ def main(config: MasterConfig) -> None:
             }
         )
 
-        # 5) Refits the generation engine with the latest policy weights
-        print("  • Refit generation with latest policy weights...")
-        refit_policy_generation(
-            policy=policy,
-            policy_generation=policy_generation,
-            colocated_inference=policy_config["generation"]["colocated"]["enabled"],
-        )
-        print("  ✓ Refit complete")
+        print("  • Syncing generation with latest policy weights...")
+        weight_sync.sync_weights()
+        print("  ✓ Sync complete")
 
         policy_generation.prepare_for_generation()
         gen_outputs = policy_generation.generate(

--- a/tests/unit/algorithms/test_distillation.py
+++ b/tests/unit/algorithms/test_distillation.py
@@ -568,7 +568,7 @@ def test_distillation_setup_non_colocated_smoke(monkeypatch):
         def prepare_refit_info(self):
             return {}
 
-        def offload_after_refit(self):
+        def finish_training(self, **kwargs):
             return None
 
         def init_collective(self, *args, **kwargs):

--- a/tests/unit/algorithms/test_distillation.py
+++ b/tests/unit/algorithms/test_distillation.py
@@ -55,7 +55,7 @@ def mock_components():
     }
 
     # Set student_generation to None to avoid Ray-related refit issues
-    # This makes NEED_REFIT = False, so refit_policy_generation won't be called
+    # This means weight_sync will be None, so no weight sync is performed
     student_generation = None
 
     # Create a proper message log structure with token_ids (similar to SFT)
@@ -587,6 +587,8 @@ def test_distillation_setup_non_colocated_smoke(monkeypatch):
         def init_collective(self, *args, **kwargs):
             return [MagicMock()]
 
+    mock_weight_sync = MagicMock()
+
     with (
         patch.object(distil_mod, "RayVirtualCluster", DummyCluster),
         patch.object(distil_mod, "Logger"),
@@ -595,6 +597,9 @@ def test_distillation_setup_non_colocated_smoke(monkeypatch):
         patch.object(distil_mod, "Policy", DummyPolicy),
         patch.object(distil_mod, "VllmGeneration", DummyVllmGeneration),
         patch.object(distil_mod, "ray") as mock_ray,
+        patch.object(
+            distil_mod, "create_weight_synchronizer", return_value=mock_weight_sync
+        ),
     ):
         mock_ckpt_mgr.return_value.get_latest_checkpoint_path.return_value = None
         mock_ckpt_mgr.return_value.get_resume_paths.return_value = (None, None)

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -419,10 +419,7 @@ def mock_async_grpo_infrastructure(mock_batch, mock_rollout_metrics):
         )
     )
 
-    # Patch refit and validate functions
-    stack.enter_context(
-        patch("nemo_rl.algorithms.grpo.refit_policy_generation", return_value=None)
-    )
+    # Patch validate function
     stack.enter_context(
         patch("nemo_rl.algorithms.grpo.validate", return_value=({}, {}))
     )
@@ -1342,77 +1339,6 @@ def test_setup_sglang_sets_model_path_and_parallel_flag(
     assert logged["metrics"]["parallel_init_enabled"] == expected_parallel
 
 
-def test_refit_policy_generation_sglang_colocated_http(monkeypatch):
-    from nemo_rl.algorithms import grpo as grpo_mod
-
-    from nemo_rl.models.policy.interfaces import OffloadMode
-
-    calls = {
-        "prepare_for_generation_tags": [],
-        "invalidate_kv_cache": 0,
-        "stream_weights_via_http": [],
-        "finish_training_modes": [],
-    }
-
-    class DummySGLangGeneration:
-        def prepare_for_generation(self, tags=None):
-            calls["prepare_for_generation_tags"].append(tags)
-
-        def get_sglang_url_to_gpu_uuids(self):
-            return {"http://localhost:12345": ["gpu-uuid-0"]}
-
-        def invalidate_kv_cache(self):
-            calls["invalidate_kv_cache"] += 1
-            return True
-
-    class DummyPolicy:
-        def finish_training(self, **kwargs):
-            calls["finish_training_modes"].append(
-                kwargs.get("offload_mode", OffloadMode.FULL)
-            )
-
-        def get_free_memory_bytes(self):
-            return 1024 * 1024 * 1024
-
-        def stream_weights_via_http(self, sglang_url_to_gpu_uuids):
-            calls["stream_weights_via_http"].append(sglang_url_to_gpu_uuids)
-            return ["ok"]
-
-    monkeypatch.setattr(grpo_mod, "SGLangGeneration", DummySGLangGeneration)
-    monkeypatch.setattr(grpo_mod.ray, "get", lambda x: x)
-
-    grpo_mod.refit_policy_generation(
-        policy=DummyPolicy(),
-        policy_generation=DummySGLangGeneration(),
-        colocated_inference=True,
-    )
-
-    assert calls["finish_training_modes"] == [
-        OffloadMode.OPTIMIZER_ONLY,
-        OffloadMode.FULL,
-    ]
-    assert calls["invalidate_kv_cache"] == 1
-    assert calls["stream_weights_via_http"] == [
-        {"http://localhost:12345": ["gpu-uuid-0"]}
-    ]
-    assert calls["prepare_for_generation_tags"] == [["weights"], ["kv_cache"]]
-
-
-def test_refit_policy_generation_sglang_non_colocated_raises(monkeypatch):
-    from nemo_rl.algorithms import grpo as grpo_mod
-
-    class DummySGLangGeneration:
-        pass
-
-    monkeypatch.setattr(grpo_mod, "SGLangGeneration", DummySGLangGeneration)
-
-    with pytest.raises(NotImplementedError):
-        grpo_mod.refit_policy_generation(
-            policy=object(),
-            policy_generation=DummySGLangGeneration(),
-            colocated_inference=False,
-        )
-
 
 def test_grpo_train_collects_generation_logger_metrics(
     monkeypatch, mock_grpo_components
@@ -1464,9 +1390,6 @@ def test_grpo_train_collects_generation_logger_metrics(
         grpo_mod,
         "calculate_baseline_and_std_per_prompt",
         lambda *_args, **_kwargs: (torch.tensor([0.1]), torch.tensor([1.0])),
-    )
-    monkeypatch.setattr(
-        grpo_mod, "refit_policy_generation", lambda *_args, **_kwargs: None
     )
     monkeypatch.setattr(
         grpo_mod, "print_performance_metrics", lambda *_args, **_kwargs: {}

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -1256,6 +1256,10 @@ def test_setup_sglang_sets_model_path_and_parallel_flag(
         "SGLangGeneration",
         lambda *_args, **_kwargs: DummySGLangGeneration(),
     )
+    mock_weight_sync = MagicMock()
+    monkeypatch.setattr(
+        grpo_mod, "create_weight_synchronizer", lambda **_kwargs: mock_weight_sync
+    )
     monkeypatch.setattr(grpo_mod.ray, "get", lambda x: x)
 
     generation_resources = {
@@ -1481,6 +1485,9 @@ def test_grpo_train_collects_generation_logger_metrics(
     master_config.grpo["val_at_start"] = False
     master_config.grpo["use_dynamic_sampling"] = False
 
+    mock_weight_sync = MagicMock()
+    mock_weight_sync.is_stale = True
+
     grpo_mod.grpo_train(
         mock_grpo_components["policy"],
         policy_generation,
@@ -1494,8 +1501,10 @@ def test_grpo_train_collects_generation_logger_metrics(
         mock_grpo_components["checkpointer"],
         _default_grpo_save_state(),
         master_config,
+        weight_sync=mock_weight_sync,
     )
 
+    assert mock_weight_sync.sync_weights.called
     assert policy_generation.clear_logger_metrics.called
     policy_generation.finish_generation.assert_called_once_with(discard_weights=True)
     assert policy_generation.get_logger_metrics.called

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -1345,12 +1345,13 @@ def test_setup_sglang_sets_model_path_and_parallel_flag(
 def test_refit_policy_generation_sglang_colocated_http(monkeypatch):
     from nemo_rl.algorithms import grpo as grpo_mod
 
+    from nemo_rl.models.policy.interfaces import OffloadMode
+
     calls = {
         "prepare_for_generation_tags": [],
         "invalidate_kv_cache": 0,
         "stream_weights_via_http": [],
-        "offload_before_refit": 0,
-        "offload_after_refit": 0,
+        "finish_training_modes": [],
     }
 
     class DummySGLangGeneration:
@@ -1365,11 +1366,10 @@ def test_refit_policy_generation_sglang_colocated_http(monkeypatch):
             return True
 
     class DummyPolicy:
-        def offload_before_refit(self):
-            calls["offload_before_refit"] += 1
-
-        def offload_after_refit(self):
-            calls["offload_after_refit"] += 1
+        def finish_training(self, **kwargs):
+            calls["finish_training_modes"].append(
+                kwargs.get("offload_mode", OffloadMode.FULL)
+            )
 
         def get_free_memory_bytes(self):
             return 1024 * 1024 * 1024
@@ -1387,8 +1387,10 @@ def test_refit_policy_generation_sglang_colocated_http(monkeypatch):
         colocated_inference=True,
     )
 
-    assert calls["offload_before_refit"] == 1
-    assert calls["offload_after_refit"] == 1
+    assert calls["finish_training_modes"] == [
+        OffloadMode.OPTIMIZER_ONLY,
+        OffloadMode.FULL,
+    ]
     assert calls["invalidate_kv_cache"] == 1
     assert calls["stream_weights_via_http"] == [
         {"http://localhost:12345": ["gpu-uuid-0"]}

--- a/tests/unit/excluded_unit_tests.sh
+++ b/tests/unit/excluded_unit_tests.sh
@@ -24,8 +24,6 @@ EXCLUDED_UNIT_TESTS=(
     --deselect=tests/unit/algorithms/test_grpo.py::test_calculate_rewards_multiple_tasks
     --deselect=tests/unit/algorithms/test_grpo.py::test_calculate_rewards_missing_environment
     --deselect=tests/unit/algorithms/test_grpo.py::test_noncolocated_inference_requires_explicit_gpus_per_node_multi_node
-    --deselect=tests/unit/algorithms/test_grpo.py::test_refit_policy_generation_sglang_colocated_http
-    --deselect=tests/unit/algorithms/test_grpo.py::test_refit_policy_generation_sglang_non_colocated_raises
 
     # test_utils.py — exclude only HF gated tokenizer tests
     --deselect=tests/unit/algorithms/test_utils.py::test_get_tokenizer_no_chat_template

--- a/tests/unit/models/generation/test_sglang_generation.py
+++ b/tests/unit/models/generation/test_sglang_generation.py
@@ -321,8 +321,8 @@ def test_sglang_worker_seed_behavior(cluster, tokenizer):
     Key: Use gpus_per_server=1 to create 2 independent SGLang servers (each with its own seed),
     rather than 1 server with TP=2.
     """
-    from nemo_rl.algorithms.grpo import refit_policy_generation
     from nemo_rl.models.policy.lm_policy import Policy
+    from nemo_rl.weight_sync import create_weight_synchronizer
 
     unique_prompts = [
         "Hello, my name is",
@@ -371,7 +371,14 @@ def test_sglang_worker_seed_behavior(cluster, tokenizer):
     policy.prepare_refit_info(state_dict_info)
 
     print("Refitting SGLang policy...")
-    refit_policy_generation(lm_policy, policy, sglang_config["colocated"]["enabled"])
+    ws = create_weight_synchronizer(
+        policy=lm_policy,
+        generation=policy,
+        generation_backend="sglang",
+        colocated=sglang_config["colocated"]["enabled"],
+    )
+    ws.init_communicator()
+    ws.sync_weights()
 
     try:
         # Generate with duplicated prompts
@@ -689,8 +696,8 @@ def test_sglang_non_divisible_batch_handling(policy):
 @pytest.mark.timeout(300)
 def test_sglang_generation_with_hf_training_colocated(cluster, tokenizer):
     """Test that DTensor policy can work together with colocated SGLang policy."""
-    from nemo_rl.algorithms.grpo import refit_policy_generation
     from nemo_rl.models.policy.lm_policy import Policy
+    from nemo_rl.weight_sync import create_weight_synchronizer
 
     sglang_config = deepcopy(basic_sglang_test_config)
     sglang_config = configure_sglang_config(sglang_config, tokenizer)
@@ -712,14 +719,15 @@ def test_sglang_generation_with_hf_training_colocated(cluster, tokenizer):
         print("Creating DTensor policy...")
         lm_policy = Policy(cluster, dtensor_config, tokenizer)
 
-        print("Preparing refit info...")
-        state_dict_info = lm_policy.prepare_refit_info()
-        sglang_policy.prepare_refit_info(state_dict_info)
-
-        print("Refitting SGLang policy...")
-        refit_policy_generation(
-            lm_policy, sglang_policy, sglang_config["colocated"]["enabled"]
+        print("Syncing SGLang policy...")
+        ws = create_weight_synchronizer(
+            policy=lm_policy,
+            generation=sglang_policy,
+            generation_backend="sglang",
+            colocated=sglang_config["colocated"]["enabled"],
         )
+        ws.init_communicator()
+        ws.sync_weights()
 
         # Test generation
         test_prompts = ["Hello, my name is", "The capital of France is"]
@@ -760,8 +768,8 @@ def test_sglang_generation_with_hf_training_non_colocated(
     policy_cluster_separate, tokenizer
 ):
     """Test that DTensor policy can work together with non-colocated SGLang policy."""
-    from nemo_rl.algorithms.grpo import refit_policy_generation
     from nemo_rl.models.policy.lm_policy import Policy
+    from nemo_rl.weight_sync import create_weight_synchronizer
 
     generation_cluster_separate = get_generation_cluster_separate(2)
 
@@ -787,26 +795,17 @@ def test_sglang_generation_with_hf_training_non_colocated(
         print("Creating DTensor policy...")
         lm_policy = Policy(policy_cluster_separate, dtensor_config, tokenizer)
 
-        # Initialize collective communication
-        ip, port = policy_cluster_separate.get_master_address_and_port()
-        train_world_size = policy_cluster_separate.world_size()
-        inference_world_size = generation_cluster_separate.world_size()
-        world_size = train_world_size + inference_world_size
-
-        futures_train = lm_policy.init_collective(
-            ip, port, world_size=world_size, train_world_size=train_world_size
+        print("Syncing SGLang policy...")
+        ws = create_weight_synchronizer(
+            policy=lm_policy,
+            generation=sglang_policy,
+            generation_backend="sglang",
+            colocated=False,
+            train_cluster=policy_cluster_separate,
+            inference_cluster=generation_cluster_separate,
         )
-        futures_inference = sglang_policy.init_collective(
-            ip, port, world_size=world_size, train_world_size=train_world_size
-        )
-        ray.get(futures_train + futures_inference)
-
-        # Prepare refit info
-        state_dict_info = lm_policy.prepare_refit_info()
-        sglang_policy.prepare_refit_info(state_dict_info)
-
-        print("Refitting SGLang policy...")
-        refit_policy_generation(lm_policy, sglang_policy, False)
+        ws.init_communicator()
+        ws.sync_weights()
 
         # Test generation
         test_prompts = ["Hello, my name is", "The capital of France is"]

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -23,7 +23,6 @@ import ray
 import requests
 import torch
 
-from nemo_rl.algorithms.grpo import refit_policy_generation
 from nemo_rl.algorithms.loss import NLLLossFn
 from nemo_rl.algorithms.utils import get_tokenizer
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
@@ -34,12 +33,27 @@ from nemo_rl.models.generation.interfaces import (
 )
 from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration
 from nemo_rl.models.generation.vllm.vllm_worker import VllmGenerationWorkerImpl
+from nemo_rl.weight_sync import create_weight_synchronizer
 from nemo_rl.models.generation.vllm.vllm_worker_async import (
     VllmAsyncGenerationWorkerImpl,
     _replace_prefix_tokens,
 )
 from nemo_rl.models.policy import LoRAConfig, PolicyConfig
 from nemo_rl.models.policy.lm_policy import Policy
+
+
+def sync_weights(policy, generation, colocated, refit_buffer_size_gb=None):
+    """Create a weight synchronizer and sync weights from policy to generation."""
+    ws = create_weight_synchronizer(
+        policy=policy,
+        generation=generation,
+        generation_backend="vllm",
+        colocated=colocated,
+        refit_buffer_size_gb=refit_buffer_size_gb,
+    )
+    ws.init_communicator()
+    ws.sync_weights()
+
 
 model_name = "Qwen/Qwen3-0.6B"
 # Define basic vLLM test config
@@ -605,7 +619,7 @@ async def test_vllm_policy_generation_async(
         async_policy.prepare_refit_info(state_dict_info)
 
         print("refitting vllm policy...")
-        refit_policy_generation(
+        sync_weights(
             lm_policy, async_policy, vllm_config["colocated"]["enabled"]
         )
 
@@ -706,7 +720,7 @@ def test_vllm_worker_seed_behavior(cluster, tokenizer):
     policy.prepare_refit_info(state_dict_info)
 
     print("refitting vllm policy...")
-    refit_policy_generation(lm_policy, policy, vllm_config["colocated"]["enabled"])
+    sync_weights(lm_policy, policy, vllm_config["colocated"]["enabled"])
 
     try:
         # Generate with duplicated prompts
@@ -845,7 +859,7 @@ async def run_hf_train_process(
         )
 
         print("refitting vllm policy...")
-        refit_policy_generation(lm_policy, vllm_policy, colocated)
+        sync_weights(lm_policy, vllm_policy, colocated)
 
         # Step 1: Use vLLM for generation
         print("Using vLLM policy for fast generation...")
@@ -956,7 +970,7 @@ async def run_hf_train_process(
         print(f"Training loss: {results['loss']}")
 
         lm_policy.finish_training()
-        refit_policy_generation(lm_policy, vllm_policy, colocated)
+        sync_weights(lm_policy, vllm_policy, colocated)
 
         # Step 4: Use vLLM for generation again to complete the workflow
         print("Using vLLM for generation again...")
@@ -1889,11 +1903,11 @@ def test_vllm_weight_update_memory(cluster, tokenizer, train_backend):
     # reset peak memory stats before refit
     workers = lm_policy.worker_group.workers
     ray.get([w.reset_peak_memory_stats.remote() for w in workers])
-    refit_policy_generation(
+    sync_weights(
         lm_policy,
         vllm_policy,
         vllm_config["colocated"]["enabled"],
-        _refit_buffer_size_gb=1.5,
+        refit_buffer_size_gb=1.5,
     )
     gpu_infos = ray.get([w.get_gpu_info.remote() for w in workers])
 
@@ -1958,7 +1972,7 @@ def test_vllm_generation_with_stop(cluster, test_input_data, tokenizer, is_eval)
         vllm_generation.prepare_refit_info(state_dict_info)
 
         print("refitting vllm policy...")
-        refit_policy_generation(
+        sync_weights(
             lm_policy, vllm_generation, vllm_config["colocated"]["enabled"]
         )
 
@@ -2097,7 +2111,7 @@ async def test_vllm_refit_non_colocated_update_weights(
     vllm_generation.prepare_refit_info(state_dict_info)
 
     print("refitting vllm policy...")
-    refit_policy_generation(lm_policy, vllm_generation, False)
+    sync_weights(lm_policy, vllm_generation, False)
 
     # test generate
     if async_engine:
@@ -2231,7 +2245,7 @@ def test_vllm_generation_with_megatron_training(
         vllm_policy.prepare_refit_info(state_dict_info)
 
         print("Refitting vLLM policy with Megatron weights...")
-        refit_policy_generation(
+        sync_weights(
             megatron_policy, vllm_policy, vllm_config["colocated"]["enabled"]
         )
 
@@ -2403,7 +2417,7 @@ def test_vllm_generation_with_megatron_training_moe_model(
         vllm_policy.prepare_refit_info(state_dict_info)
 
         print("Refitting vLLM policy with Megatron weights...")
-        refit_policy_generation(
+        sync_weights(
             megatron_policy, vllm_policy, vllm_config["colocated"]["enabled"]
         )
 
@@ -2536,11 +2550,11 @@ def test_vllm_megatron_weight_update_memory(cluster, tokenizer):
     workers = megatron_policy.worker_group.workers
     ray.get([w.reset_peak_memory_stats.remote() for w in workers])
 
-    refit_policy_generation(
+    sync_weights(
         megatron_policy,
         vllm_policy,
         vllm_config["colocated"]["enabled"],
-        _refit_buffer_size_gb=1.5,
+        refit_buffer_size_gb=1.5,
     )
 
     gpu_infos = ray.get([w.get_gpu_info.remote() for w in workers])
@@ -2638,7 +2652,7 @@ def test_vllm_megatron_pipeline_parallel(cluster, tokenizer):
         vllm_policy.prepare_refit_info(state_dict_info)
 
         print("Refitting vLLM with Megatron PP=2 weights...")
-        refit_policy_generation(
+        sync_weights(
             megatron_policy, vllm_policy, vllm_config["colocated"]["enabled"]
         )
 
@@ -2704,7 +2718,7 @@ def test_vllm_megatron_weight_update_with_packing(cluster, test_input_data):
         vllm_generation.prepare_refit_info(state_dict_info)
 
         print("refitting vllm policy...")
-        refit_policy_generation(
+        sync_weights(
             megatron_policy, vllm_generation, vllm_config["colocated"]["enabled"]
         )
 

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -880,7 +880,9 @@ async def run_hf_train_process(
             }
         )
         # Get logprobs from HF policy
-        lm_policy.prepare_for_lp_inference()
+        from nemo_rl.models.policy.interfaces import OffloadMode
+
+        lm_policy.finish_training(offload_mode=OffloadMode.EVAL_ONLY)
         fprop_results = lm_policy.get_logprobs(fprop_logprob_data)
         # Zero out logprobs for input tokens
 
@@ -1881,7 +1883,9 @@ def test_vllm_weight_update_memory(cluster, tokenizer, train_backend):
 
     print("refitting vllm policy...")
     # take it outside statistics to get clean peak memory during refit
-    lm_policy.offload_before_refit()
+    from nemo_rl.models.policy.interfaces import OffloadMode
+
+    lm_policy.finish_training(offload_mode=OffloadMode.OPTIMIZER_ONLY)
     # reset peak memory stats before refit
     workers = lm_policy.worker_group.workers
     ray.get([w.reset_peak_memory_stats.remote() for w in workers])
@@ -2289,7 +2293,6 @@ def test_vllm_generation_with_megatron_training(
         print(f"Training loss: {results['loss']}")
 
         megatron_policy.finish_training()
-        megatron_policy.offload_after_refit()
 
         # Step 4: Use vLLM for generation again
         print("Using vLLM for generation again...")
@@ -2462,7 +2465,6 @@ def test_vllm_generation_with_megatron_training_moe_model(
         print(f"Training loss: {results['loss']}")
 
         megatron_policy.finish_training()
-        megatron_policy.offload_after_refit()
 
         # Step 4: Use vLLM for generation again
         print("Using vLLM for generation again...")
@@ -2527,7 +2529,9 @@ def test_vllm_megatron_weight_update_memory(cluster, tokenizer):
 
     print("Refitting vLLM policy with Megatron...")
     # Take it outside statistics to get clean peak memory during refit
-    megatron_policy.offload_before_refit()
+    from nemo_rl.models.policy.interfaces import OffloadMode
+
+    megatron_policy.finish_training(offload_mode=OffloadMode.OPTIMIZER_ONLY)
     # Reset peak memory stats before refit
     workers = megatron_policy.worker_group.workers
     ray.get([w.reset_peak_memory_stats.remote() for w in workers])

--- a/tests/unit/models/policy/test_dtensor_worker.py
+++ b/tests/unit/models/policy/test_dtensor_worker.py
@@ -343,7 +343,9 @@ def _test_dtensor_worker_logprob(policy, data, logprobs):
 
     # Generate logprobs
     print("\nGenerating logprobs...")
-    policy.prepare_for_lp_inference()
+    from nemo_rl.models.policy.interfaces import OffloadMode
+
+    policy.finish_training(offload_mode=OffloadMode.EVAL_ONLY)
     policy_logprobs = policy.get_logprobs(data)["logprobs"]
 
     print("## MAX DIFF ###", torch.max(torch.abs(policy_logprobs - logprobs)))
@@ -492,7 +494,9 @@ class TestSingleGPUCluster:
             expected_logprobs = calculate_token_logprobs(tiny_llama_model_path, data)
 
             # Test logprob computation
-            policy.prepare_for_lp_inference()
+            from nemo_rl.models.policy.interfaces import OffloadMode
+
+            policy.finish_training(offload_mode=OffloadMode.EVAL_ONLY)
             policy_logprobs = policy.get_logprobs(data)["logprobs"]
 
             max_diff = torch.max(torch.abs(policy_logprobs - expected_logprobs))

--- a/tests/unit/models/policy/test_dtensor_worker_v2.py
+++ b/tests/unit/models/policy/test_dtensor_worker_v2.py
@@ -466,7 +466,9 @@ def test_dtensor_v2_mixed_precision_training_and_logprobs(
         # --- Test Logprobs ---
         logprob_data = create_test_batch(mode="logprob")
 
-        policy.prepare_for_lp_inference()
+        from nemo_rl.models.policy.interfaces import OffloadMode
+
+        policy.finish_training(offload_mode=OffloadMode.EVAL_ONLY)
         logprobs = policy.get_logprobs(logprob_data)
 
         # Verify logprobs were computed successfully

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -753,7 +753,9 @@ def test_megatron_policy_logprobs(logprob_setup):
 
     # Generate logprobs
     print("\nGenerating logprobs...")
-    policy.prepare_for_lp_inference()
+    from nemo_rl.models.policy.interfaces import OffloadMode
+
+    policy.finish_training(offload_mode=OffloadMode.EVAL_ONLY)
     policy_logprobs = policy.get_logprobs(data)["logprobs"]
 
     # Basic validation
@@ -1013,7 +1015,9 @@ def test_megatron_reference_policy_functionality(tiny_llama_model_path):
     )
 
     # Get initial logprobs from policy
-    policy.prepare_for_lp_inference()
+    from nemo_rl.models.policy.interfaces import OffloadMode
+
+    policy.finish_training(offload_mode=OffloadMode.EVAL_ONLY)
     initial_logprobs = policy.get_logprobs(data)["logprobs"]
 
     # Get logprobs from reference policy
@@ -1057,7 +1061,7 @@ def test_megatron_reference_policy_functionality(tiny_llama_model_path):
     )
 
     # Get logprobs after training
-    policy.prepare_for_lp_inference()
+    policy.finish_training(offload_mode=OffloadMode.EVAL_ONLY)
     post_train_logprobs = policy.get_logprobs(data)["logprobs"]
     post_train_reference_logprobs = policy.get_reference_policy_logprobs(data)[
         "reference_logprobs"
@@ -1175,7 +1179,9 @@ def test_megatron_checkpoint_save_kill_and_restore(
 
             # Get parameters from the worker - need to call the remote method properly
             # We'll use the logprob computation to extract parameters indirectly
-            policy1.prepare_for_lp_inference()
+            from nemo_rl.models.policy.interfaces import OffloadMode
+
+            policy1.finish_training(offload_mode=OffloadMode.EVAL_ONLY)
 
             # Get a sample of the model state by running inference and observing outputs
             # This is a proxy for parameter values since we can't directly access the distributed model
@@ -1239,7 +1245,7 @@ def test_megatron_checkpoint_save_kill_and_restore(
             policy2 = Policy(cluster=cluster2, config=fresh_config, tokenizer=tokenizer)
 
             # Get logprobs from fresh policy (should be different from saved)
-            policy2.prepare_for_lp_inference()
+            policy2.finish_training(offload_mode=OffloadMode.EVAL_ONLY)
             logprobs_fresh = policy2.get_logprobs(sample_data)["logprobs"]
             print(f"Logprobs from fresh policy: {logprobs_fresh[0, :5]}")
 
@@ -1282,7 +1288,7 @@ def test_megatron_checkpoint_save_kill_and_restore(
 
             # Get logprobs from restored policy (should match the saved state)
             print("Getting logprobs from restored policy...")
-            policy3.prepare_for_lp_inference()
+            policy3.finish_training(offload_mode=OffloadMode.EVAL_ONLY)
             logprobs_restored = policy3.get_logprobs(sample_data)["logprobs"]
             print(f"Logprobs from restored policy: {logprobs_restored[0, :5]}")
 
@@ -1607,7 +1613,7 @@ def test_megatron_policy_topk_logits(topk_setup):
 
     # Generate top-k logits
     print("\nGenerating top-k logits...")
-    policy.prepare_for_lp_inference()
+    policy.finish_training(offload_mode=OffloadMode.EVAL_ONLY)
     k = 5
     outputs = policy.get_topk_logits(data, k=k)
 
@@ -1720,7 +1726,7 @@ def test_megatron_context_parallel_topk_agreement(tiny_qwen2_model_path):
     )
 
     # Get top-k from non-CP model with sequence packing
-    policy_no_cp.prepare_for_lp_inference()
+    policy_no_cp.finish_training(offload_mode=OffloadMode.EVAL_ONLY)
     out_no_cp = policy_no_cp.get_topk_logits(data, k=k)
     logits_no_cp = out_no_cp["topk_logits"] * attention_mask.unsqueeze(-1)
     indices_no_cp = out_no_cp["topk_indices"]
@@ -1737,7 +1743,7 @@ def test_megatron_context_parallel_topk_agreement(tiny_qwen2_model_path):
         name_prefix="lm_policy_nocp_nopack",
         init_reference_model=False,
     )
-    policy_no_cp_no_packing.prepare_for_lp_inference()
+    policy_no_cp_no_packing.finish_training(offload_mode=OffloadMode.EVAL_ONLY)
     out_no_cp_np = policy_no_cp_no_packing.get_topk_logits(data, k=k)
     logits_no_cp_np = out_no_cp_np["topk_logits"] * attention_mask.unsqueeze(-1)
     indices_no_cp_np = out_no_cp_np["topk_indices"]
@@ -1800,7 +1806,7 @@ def test_megatron_context_parallel_topk_agreement(tiny_qwen2_model_path):
         name_prefix="lm_policy_cp",
         init_reference_model=False,
     )
-    policy_cp.prepare_for_lp_inference()
+    policy_cp.finish_training(offload_mode=OffloadMode.EVAL_ONLY)
     out_cp = policy_cp.get_topk_logits(data, k=k)
     logits_cp = out_cp["topk_logits"] * attention_mask.unsqueeze(-1)
     indices_cp = out_cp["topk_indices"]
@@ -2178,7 +2184,9 @@ def test_megatron_context_parallel_logprob_agreement(tiny_llama_model_path):
     )
 
     # Get logprobs from non-CP model with sequence packing
-    policy_no_cp.prepare_for_lp_inference()
+    from nemo_rl.models.policy.interfaces import OffloadMode
+
+    policy_no_cp.finish_training(offload_mode=OffloadMode.EVAL_ONLY)
     logprobs_no_cp = policy_no_cp.get_logprobs(data)["logprobs"]
     logprobs_no_cp = logprobs_no_cp * attention_mask
     print(f"Non-CP logprobs shape: {logprobs_no_cp.shape}")
@@ -2199,7 +2207,7 @@ def test_megatron_context_parallel_logprob_agreement(tiny_llama_model_path):
         init_reference_model=False,
     )
     # Get logprobs from non-CP model with sequence packing
-    policy_no_cp_no_packing.prepare_for_lp_inference()
+    policy_no_cp_no_packing.finish_training(offload_mode=OffloadMode.EVAL_ONLY)
     logprobs_no_cp_no_packing = policy_no_cp_no_packing.get_logprobs(data)["logprobs"]
     logprobs_no_cp_no_packing = logprobs_no_cp_no_packing * attention_mask
     print(f"Non-CP logprobs no packing shape: {logprobs_no_cp_no_packing.shape}")
@@ -2262,7 +2270,7 @@ def test_megatron_context_parallel_logprob_agreement(tiny_llama_model_path):
     )
 
     # Get logprobs from CP model with sequence packing
-    policy_cp.prepare_for_lp_inference()
+    policy_cp.finish_training(offload_mode=OffloadMode.EVAL_ONLY)
     logprobs_cp = policy_cp.get_logprobs(data)["logprobs"]
     print(f"CP logprobs shape: {logprobs_cp.shape}")
     print(f"CP logprobs sample: {logprobs_cp[0, :5]}")

--- a/tests/unit/weight_sync/test_weight_synchronizer.py
+++ b/tests/unit/weight_sync/test_weight_synchronizer.py
@@ -42,8 +42,7 @@ from nemo_rl.weight_sync.ipc_weight_synchronizer import (
 
 def _mock_policy(**overrides):
     policy = MagicMock()
-    policy.offload_before_refit.return_value = None
-    policy.offload_after_refit.return_value = None
+    policy.finish_training.return_value = None
     policy.prepare_refit_info.return_value = {"layer_0": {"shape": [4096, 4096]}}
     policy.stream_weights_via_ipc_zmq.return_value = [MagicMock()]
     policy.stream_weights_via_http.return_value = [MagicMock()]
@@ -114,11 +113,13 @@ class TestIPCWeightSynchronizer:
         sync.sync_weights()
         assert not sync.is_stale
 
-        policy.offload_before_refit.assert_called_once()
+        from nemo_rl.models.policy.interfaces import OffloadMode
+
+        policy.finish_training.assert_any_call(offload_mode=OffloadMode.OPTIMIZER_ONLY)
         gen.prepare_for_generation.assert_any_call(tags=["weights"])
         policy.stream_weights_via_ipc_zmq.assert_called_once()
         gen.update_weights_via_ipc_zmq.assert_called_once()
-        policy.offload_after_refit.assert_called_once()
+        policy.finish_training.assert_any_call(offload_mode=OffloadMode.FULL)
         gen.prepare_for_generation.assert_any_call(tags=["kv_cache"])
 
     @patch("nemo_rl.weight_sync.ipc_weight_synchronizer.ray")
@@ -236,12 +237,14 @@ class TestHTTPWeightSynchronizer:
         sync.sync_weights()
         assert not sync.is_stale
 
-        policy.offload_before_refit.assert_called_once()
+        from nemo_rl.models.policy.interfaces import OffloadMode
+
+        policy.finish_training.assert_any_call(offload_mode=OffloadMode.OPTIMIZER_ONLY)
         gen.prepare_for_generation.assert_any_call(tags=["weights"])
         gen.get_sglang_url_to_gpu_uuids.assert_called_once()
         gen.invalidate_kv_cache.assert_called_once()
         policy.stream_weights_via_http.assert_called_once()
-        policy.offload_after_refit.assert_called_once()
+        policy.finish_training.assert_any_call(offload_mode=OffloadMode.FULL)
         gen.prepare_for_generation.assert_any_call(tags=["kv_cache"])
 
     @patch("nemo_rl.weight_sync.http_weight_synchronizer.ray")

--- a/tools/refit_verifier.py
+++ b/tools/refit_verifier.py
@@ -440,7 +440,9 @@ def generate_and_compare_logprobs(policy, vllm_inference_policy, generation_data
     ]
 
     # Get logprobs from Megatron
-    policy.prepare_for_lp_inference()
+    from nemo_rl.models.policy.interfaces import OffloadMode
+
+    policy.finish_training(offload_mode=OffloadMode.EVAL_ONLY)
     megatron_generation_data = policy.get_logprobs(megatron_input_data)
     print(f"Megatron Generation shape: {megatron_generation_data['logprobs'].shape}")
     print(

--- a/tools/refit_verifier.py
+++ b/tools/refit_verifier.py
@@ -72,12 +72,11 @@ import ray
 import torch
 from transformers import AutoTokenizer
 
-from nemo_rl.algorithms.grpo import refit_policy_generation
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
-from nemo_rl.models.generation import configure_generation_config
-from nemo_rl.models.generation.vllm import VllmGeneration
+from nemo_rl.models.generation import configure_generation_config, create_generation
 from nemo_rl.models.policy.lm_policy import Policy
+from nemo_rl.weight_sync import create_weight_synchronizer
 
 
 def parse_args():
@@ -344,8 +343,10 @@ def setup_clusters_and_policies(args, megatron_config, vllm_config, tokenizer):
     )
 
     # Create vLLM policy for inference-only logprobs
-    vllm_inference_policy = VllmGeneration(
-        cluster=megatron_cluster, config=vllm_inference_config
+    vllm_inference_policy = create_generation(
+        backend=vllm_inference_config["backend"],
+        cluster=megatron_cluster,
+        config=vllm_inference_config,
     )
 
     return megatron_cluster, policy, vllm_inference_policy
@@ -397,14 +398,15 @@ def run_model_refitting(policy, vllm_inference_policy, refit_buffer_size_gb):
     """
     print("\n--- Performing Model Refitting ---")
 
-    # Perform the refitting between policies using GRPO's refit function
-    # Note: colocated_inference=True since we're using the same cluster
-    refit_policy_generation(
-        policy,
-        vllm_inference_policy,
-        colocated_inference=True,
-        _refit_buffer_size_gb=refit_buffer_size_gb,
+    weight_sync = create_weight_synchronizer(
+        policy=policy,
+        generation=vllm_inference_policy,
+        generation_backend="vllm",
+        colocated=True,
+        refit_buffer_size_gb=refit_buffer_size_gb,
     )
+    weight_sync.init_communicator()
+    weight_sync.sync_weights()
     print("Model refitting completed")
 
 


### PR DESCRIPTION
# What does this PR do?
Adds a generation backend registry (nemo_rl/models/generation/registry.py) that maps backend name strings to their concrete GenerationInterface implementations via a factory pattern, and refactors all algorithm/tool/test code to use create_generation() instead of directly importing VllmGeneration/SGLangGeneration. Also removes the deprecated refit_policy_generation() function in favor of the WeightSynchronizer API introduced in prior PRs.

Issues
Part of the modularity/generation-registry effort to make NeMo-RL pluggable with third-party generation backends.

Usage
```python
from nemo_rl.models.generation import create_generation, register_generation_backend
# Built-in backends ("vllm", "sglang") are auto-registered.
generation = create_generation(
    backend="vllm",
    cluster=my_cluster,
    config=generation_config,
)
# Register a custom backend:
register_generation_backend("my_backend", my_factory_fn, config_type=MyConfig)
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
