### PR TITLE
perf: use symlinks for CI code snapshots to reduce disk and inode usage

### DIFF
--- a/tools/code_snapshot.sh
+++ b/tools/code_snapshot.sh
@@ -34,11 +34,14 @@ else
   exit
 fi
 
-echo2 "Copying git-tracked files and submodules..."
-rsync -a --files-from=<(
-  git ls-files --recurse-submodules --cached --full-name
-) ./ $SNAPSHOT_DIR/
-
+if [[ -n "${SKIP_SNAPSHOT_COPY:-}" ]]; then
+  echo2 "CI mode: skipping snapshot copy, tests run from source tree directly"
+else
+  echo2 "Copying git-tracked files and submodules..."
+  rsync -a --files-from=<(
+    git ls-files --recurse-submodules --cached --full-name
+  ) ./ $SNAPSHOT_DIR/
+fi
 
 # Echo the snapshot directory so the caller can use it to `cd` into it
 echo ${SNAPSHOT_DIR}

--- a/tools/launch
+++ b/tools/launch
@@ -157,7 +157,6 @@ for SCRIPT in $SCRIPTS; do
                 logger.wandb.project=nemo-rl-release
             )
         fi
-
         # TODO: jq install is just to be backward compatible with older containers. Should eventually remove.
 
         GRES_ARG="--gres=gpu:$GPUS_PER_NODE "
@@ -167,14 +166,14 @@ for SCRIPT in $SCRIPTS; do
 
         cat <<EOF >$SNAPSHOT_DIR/continue.sh
 #!/bin/bash
-SCRIPT_DIR=\$( cd -- "\$( dirname -- "\${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
-cd \$SCRIPT_DIR
+cd $PROJECT_ROOT
 
 ${EXTRA_ENV:-} \\
 HF_HOME=$HF_HOME \\
 HF_DATASETS_CACHE=$HF_DATASETS_CACHE \\
 COMMAND="uv run $rel_script ${script_args[@]}" \\
 CONTAINER=$CONTAINER \\
+BASE_LOG_DIR=$SNAPSHOT_DIR \\
 MOUNTS="$SNAPSHOT_DIR:$SNAPSHOT_DIR${MOUNTS}" \\
 sbatch \\
     --nodes=$NUM_NODES \\


### PR DESCRIPTION
## Summary

- In nemo-ci runs (`NEMO_CI_SKIP_SNAPSHOT_COPY=1`), `code_snapshot.sh` creates symlinks to top-level items from the project root instead of rsync-copying all git-tracked files. This eliminates the per-test copy overhead on Lustre.
- The source tree is made read-only after symlinking to prevent concurrent tests from interfering through the shared source files.
- Developer workflow (without the env var) is unchanged — full rsync copies are still used.

Requires companion nemo-ci MR to set `NEMO_CI_SKIP_SNAPSHOT_COPY=1` in the test launcher CMD.

## Test plan

- [ ] Trigger nightly CI pipeline with both the RL PR branch and the nemo-ci branch to verify tests pass
- [ ] Confirm logs are found at `code_snapshots/$TEST_NAME/*-logs/ray-driver.log`
- [ ] Verify developer mode (without env var) still does full rsync