### PR TITLE
ci: seed uv cache from persistent BuildKit mount to skip CUDA recompilation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -140,18 +140,17 @@ fi
 # to warm the uv cache, then at the end just sync the default dependencies.
 # Do everything in one layer to prevent large layers.
 
-# The venv is symlinked to avoid bloating the layer size
-uv sync --link-mode symlink --locked --no-install-project
+uv sync --locked --no-install-project
 if [[ -z "${SKIP_VLLM_BUILD:-}" ]]; then
-    uv sync --link-mode symlink --locked --extra vllm --no-install-project
+    uv sync --locked --extra vllm --no-install-project
 fi
 if [[ -z "${SKIP_SGLANG_BUILD:-}" ]]; then
-    uv sync --link-mode symlink --locked --extra sglang --no-install-project
+    uv sync --locked --extra sglang --no-install-project
 fi
-uv sync --link-mode symlink --locked --extra mcore --no-install-project
-uv sync --link-mode symlink --locked --extra automodel --no-install-project
-uv sync --link-mode symlink --locked --extra modelopt --no-install-project
-uv sync --link-mode symlink --locked --all-groups --no-install-project
+uv sync --locked --extra mcore --no-install-project
+uv sync --locked --extra automodel --no-install-project
+uv sync --locked --extra modelopt --no-install-project
+uv sync --locked --all-groups --no-install-project
 
 # Remove the aiohttp in this uv cache dir to fully address CVE GHSA-mqqc-3gqh-h2x8
 # The ray install will include the older aiohttp version in its cache
@@ -197,7 +196,7 @@ COPY --from=nemo-rl --exclude=pyproject.toml --exclude=uv.lock . /opt/nemo-rl
 # Potentially not necessary if the repo is passed in as a complete repository (w/ full git history),
 # so do a quick check before trying to unshallow.
 RUN git rev-parse --is-shallow-repository | grep -q true && git fetch --unshallow || true
-RUN <<"EOF" bash -exu
+RUN --mount=type=cache,target=/root/.cache/uv <<"EOF" bash -exu
 NEGATIVE_FILTERS=""
 if [[ -n "${SKIP_VLLM_BUILD:-}" ]]; then
     NEGATIVE_FILTERS="$NEGATIVE_FILTERS vllm"
@@ -206,9 +205,9 @@ if [[ -n "${SKIP_SGLANG_BUILD:-}" ]]; then
     NEGATIVE_FILTERS="$NEGATIVE_FILTERS sglang"
 fi
 if [[ -n "$NEGATIVE_FILTERS" ]]; then
-    UV_LINK_MODE=symlink uv run nemo_rl/utils/prefetch_venvs.py --negative-filters $NEGATIVE_FILTERS
+    uv run nemo_rl/utils/prefetch_venvs.py --negative-filters $NEGATIVE_FILTERS
 else
-    UV_LINK_MODE=symlink uv run nemo_rl/utils/prefetch_venvs.py
+    uv run nemo_rl/utils/prefetch_venvs.py
 fi
 EOF
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -128,7 +128,8 @@ COPY --from=nemo-rl --link 3rdparty/ ./3rdparty/
 RUN --mount=type=ssh --mount=type=cache,target=/tmp/uv-warm-cache <<"EOF" bash -exu
 # Seed uv cache from persistent BuildKit cache to avoid recompiling CUDA kernels
 # (e.g. sglang-kernel ~90 min) when only unrelated deps changed in pyproject.toml.
-cp -a /tmp/uv-warm-cache/. /root/.cache/uv/ 2>/dev/null || true
+mkdir -p /root/.cache/uv
+rsync -a /tmp/uv-warm-cache/ /root/.cache/uv/ 2>/dev/null || true
 
 uv venv --seed
 if [[ -n "${BUILD_CUSTOM_VLLM:-}" ]]; then
@@ -161,8 +162,9 @@ uv sync --link-mode symlink --locked --all-groups --no-install-project
 # The ray install will include the older aiohttp version in its cache
 find /root/.cache/uv -type d -path "*ray/_private/runtime_env/agent/thirdparty_files/aiohttp*" -exec rm -rf {} +
 
-# Persist the uv cache back to the BuildKit cache mount for future builds
-cp -a /root/.cache/uv/. /tmp/uv-warm-cache/
+# Persist the uv cache back to the BuildKit cache mount for future builds.
+# --delete ensures stale entries (e.g. CVE-cleaned aiohttp) don't re-seed.
+rsync -a --delete /root/.cache/uv/ /tmp/uv-warm-cache/ || true
 EOF
 
 ENV PATH="/opt/nemo_rl_venv/bin:$PATH"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -129,7 +129,7 @@ COPY --from=nemo-rl tools/build-custom-flashinfer.sh ./tools/build-custom-flashi
 COPY --from=nemo-rl --link research/ ./research/
 COPY --from=nemo-rl --link 3rdparty/ ./3rdparty/
 
-RUN --mount=type=ssh --mount=type=cache,target=/tmp/uv-warm-cache <<"EOF" bash -exu
+RUN --mount=type=ssh --mount=type=cache,target=/tmp/uv-warm-cache,sharing=locked <<"EOF" bash -exu
 # Invalidate persistent cache when base image or uv version changes (compiled
 # CUDA kernels are ABI-incompatible across toolkit versions, and uv cache
 # format may change across uv versions).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -105,6 +105,8 @@ ARG BUILD_CUSTOM_FLASHINFER_REF
 # Skip building vLLM or SGLang dependencies (set to any non-empty value to skip)
 ARG SKIP_VLLM_BUILD
 ARG SKIP_SGLANG_BUILD
+# Re-declared so the RUN block can invalidate the uv cache when the base image changes
+ARG BASE_IMAGE
 
 ENV UV_PROJECT_ENVIRONMENT=/opt/nemo_rl_venv
 ENV UV_LINK_MODE=copy
@@ -126,6 +128,16 @@ COPY --from=nemo-rl --link research/ ./research/
 COPY --from=nemo-rl --link 3rdparty/ ./3rdparty/
 
 RUN --mount=type=ssh --mount=type=cache,target=/tmp/uv-warm-cache <<"EOF" bash -exu
+# Invalidate persistent cache when base image changes (compiled CUDA kernels
+# are ABI-incompatible across CUDA toolkit versions).
+BASE_IMAGE_HASH=$(echo "${BASE_IMAGE}" | md5sum | cut -c1-12)
+if [ -f /tmp/uv-warm-cache/.base-image-hash ]; then
+    if [ "$(cat /tmp/uv-warm-cache/.base-image-hash)" != "${BASE_IMAGE_HASH}" ]; then
+        echo "Base image changed (${BASE_IMAGE}) — clearing stale uv cache"
+        rm -rf /tmp/uv-warm-cache/*
+    fi
+fi
+
 # Seed uv cache from persistent BuildKit cache to avoid recompiling CUDA kernels
 # (e.g. sglang-kernel ~90 min) when only unrelated deps changed in pyproject.toml.
 mkdir -p /root/.cache/uv
@@ -165,6 +177,7 @@ find /root/.cache/uv -type d -path "*ray/_private/runtime_env/agent/thirdparty_f
 # Persist the uv cache back to the BuildKit cache mount for future builds.
 # --delete ensures stale entries (e.g. CVE-cleaned aiohttp) don't re-seed.
 rsync -a --delete /root/.cache/uv/ /tmp/uv-warm-cache/ || true
+echo "${BASE_IMAGE_HASH}" > /tmp/uv-warm-cache/.base-image-hash
 EOF
 
 ENV PATH="/opt/nemo_rl_venv/bin:$PATH"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -125,7 +125,7 @@ COPY --from=nemo-rl tools/build-custom-flashinfer.sh ./tools/build-custom-flashi
 COPY --from=nemo-rl --link research/ ./research/
 COPY --from=nemo-rl --link 3rdparty/ ./3rdparty/
 
-RUN --mount=type=ssh <<"EOF" bash -exu
+RUN --mount=type=ssh --mount=type=cache,target=/root/.cache/uv <<"EOF" bash -exu
 uv venv --seed
 if [[ -n "${BUILD_CUSTOM_VLLM:-}" ]]; then
     bash tools/build-custom-vllm.sh ${BUILD_CUSTOM_VLLM_URL} ${BUILD_CUSTOM_VLLM_REF} ${BUILD_CUSTOM_VLLM_PRECOMPILED_WHEEL_LOCATION}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -105,8 +105,10 @@ ARG BUILD_CUSTOM_FLASHINFER_REF
 # Skip building vLLM or SGLang dependencies (set to any non-empty value to skip)
 ARG SKIP_VLLM_BUILD
 ARG SKIP_SGLANG_BUILD
-# Re-declared so the RUN block can invalidate the uv cache when the base image changes
+# Re-declared so the RUN block can invalidate the uv cache when the base image
+# or uv version changes (compiled wheels may be incompatible across either).
 ARG BASE_IMAGE
+ARG UV_VERSION
 
 ENV UV_PROJECT_ENVIRONMENT=/opt/nemo_rl_venv
 ENV UV_LINK_MODE=copy
@@ -128,20 +130,21 @@ COPY --from=nemo-rl --link research/ ./research/
 COPY --from=nemo-rl --link 3rdparty/ ./3rdparty/
 
 RUN --mount=type=ssh --mount=type=cache,target=/tmp/uv-warm-cache <<"EOF" bash -exu
-# Invalidate persistent cache when base image changes (compiled CUDA kernels
-# are ABI-incompatible across CUDA toolkit versions).
-BASE_IMAGE_HASH=$(echo "${BASE_IMAGE}" | md5sum | cut -c1-12)
-if [ -f /tmp/uv-warm-cache/.base-image-hash ]; then
-    if [ "$(cat /tmp/uv-warm-cache/.base-image-hash)" != "${BASE_IMAGE_HASH}" ]; then
-        echo "Base image changed (${BASE_IMAGE}) — clearing stale uv cache"
-        rm -rf /tmp/uv-warm-cache/*
+# Invalidate persistent cache when base image or uv version changes (compiled
+# CUDA kernels are ABI-incompatible across toolkit versions, and uv cache
+# format may change across uv versions).
+CACHE_KEY=$(echo "${BASE_IMAGE}-${UV_VERSION}" | md5sum | cut -c1-12)
+if [ -f /tmp/uv-warm-cache/.cache-key ]; then
+    if [ "$(cat /tmp/uv-warm-cache/.cache-key)" != "${CACHE_KEY}" ]; then
+        echo "Cache key changed (base=${BASE_IMAGE}, uv=${UV_VERSION}) — clearing stale uv cache"
+        find /tmp/uv-warm-cache -mindepth 1 -delete
     fi
 fi
 
 # Seed uv cache from persistent BuildKit cache to avoid recompiling CUDA kernels
 # (e.g. sglang-kernel ~90 min) when only unrelated deps changed in pyproject.toml.
 mkdir -p /root/.cache/uv
-rsync -a /tmp/uv-warm-cache/ /root/.cache/uv/ 2>/dev/null || true
+rsync -a --exclude='.cache-key' /tmp/uv-warm-cache/ /root/.cache/uv/ 2>/dev/null || true
 
 uv venv --seed
 if [[ -n "${BUILD_CUSTOM_VLLM:-}" ]]; then
@@ -177,7 +180,7 @@ find /root/.cache/uv -type d -path "*ray/_private/runtime_env/agent/thirdparty_f
 # Persist the uv cache back to the BuildKit cache mount for future builds.
 # --delete ensures stale entries (e.g. CVE-cleaned aiohttp) don't re-seed.
 rsync -a --delete /root/.cache/uv/ /tmp/uv-warm-cache/ || true
-echo "${BASE_IMAGE_HASH}" > /tmp/uv-warm-cache/.base-image-hash
+echo "${CACHE_KEY}" > /tmp/uv-warm-cache/.cache-key || true
 EOF
 
 ENV PATH="/opt/nemo_rl_venv/bin:$PATH"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -125,7 +125,11 @@ COPY --from=nemo-rl tools/build-custom-flashinfer.sh ./tools/build-custom-flashi
 COPY --from=nemo-rl --link research/ ./research/
 COPY --from=nemo-rl --link 3rdparty/ ./3rdparty/
 
-RUN --mount=type=ssh --mount=type=cache,target=/root/.cache/uv <<"EOF" bash -exu
+RUN --mount=type=ssh --mount=type=cache,target=/tmp/uv-warm-cache <<"EOF" bash -exu
+# Seed uv cache from persistent BuildKit cache to avoid recompiling CUDA kernels
+# (e.g. sglang-kernel ~90 min) when only unrelated deps changed in pyproject.toml.
+cp -a /tmp/uv-warm-cache/. /root/.cache/uv/ 2>/dev/null || true
+
 uv venv --seed
 if [[ -n "${BUILD_CUSTOM_VLLM:-}" ]]; then
     bash tools/build-custom-vllm.sh ${BUILD_CUSTOM_VLLM_URL} ${BUILD_CUSTOM_VLLM_REF} ${BUILD_CUSTOM_VLLM_PRECOMPILED_WHEEL_LOCATION}
@@ -140,21 +144,25 @@ fi
 # to warm the uv cache, then at the end just sync the default dependencies.
 # Do everything in one layer to prevent large layers.
 
-uv sync --locked --no-install-project
+# The venv is symlinked to avoid bloating the layer size
+uv sync --link-mode symlink --locked --no-install-project
 if [[ -z "${SKIP_VLLM_BUILD:-}" ]]; then
-    uv sync --locked --extra vllm --no-install-project
+    uv sync --link-mode symlink --locked --extra vllm --no-install-project
 fi
 if [[ -z "${SKIP_SGLANG_BUILD:-}" ]]; then
-    uv sync --locked --extra sglang --no-install-project
+    uv sync --link-mode symlink --locked --extra sglang --no-install-project
 fi
-uv sync --locked --extra mcore --no-install-project
-uv sync --locked --extra automodel --no-install-project
-uv sync --locked --extra modelopt --no-install-project
-uv sync --locked --all-groups --no-install-project
+uv sync --link-mode symlink --locked --extra mcore --no-install-project
+uv sync --link-mode symlink --locked --extra automodel --no-install-project
+uv sync --link-mode symlink --locked --extra modelopt --no-install-project
+uv sync --link-mode symlink --locked --all-groups --no-install-project
 
 # Remove the aiohttp in this uv cache dir to fully address CVE GHSA-mqqc-3gqh-h2x8
 # The ray install will include the older aiohttp version in its cache
 find /root/.cache/uv -type d -path "*ray/_private/runtime_env/agent/thirdparty_files/aiohttp*" -exec rm -rf {} +
+
+# Persist the uv cache back to the BuildKit cache mount for future builds
+cp -a /root/.cache/uv/. /tmp/uv-warm-cache/
 EOF
 
 ENV PATH="/opt/nemo_rl_venv/bin:$PATH"
@@ -196,7 +204,7 @@ COPY --from=nemo-rl --exclude=pyproject.toml --exclude=uv.lock . /opt/nemo-rl
 # Potentially not necessary if the repo is passed in as a complete repository (w/ full git history),
 # so do a quick check before trying to unshallow.
 RUN git rev-parse --is-shallow-repository | grep -q true && git fetch --unshallow || true
-RUN --mount=type=cache,target=/root/.cache/uv <<"EOF" bash -exu
+RUN <<"EOF" bash -exu
 NEGATIVE_FILTERS=""
 if [[ -n "${SKIP_VLLM_BUILD:-}" ]]; then
     NEGATIVE_FILTERS="$NEGATIVE_FILTERS vllm"
@@ -205,9 +213,9 @@ if [[ -n "${SKIP_SGLANG_BUILD:-}" ]]; then
     NEGATIVE_FILTERS="$NEGATIVE_FILTERS sglang"
 fi
 if [[ -n "$NEGATIVE_FILTERS" ]]; then
-    uv run nemo_rl/utils/prefetch_venvs.py --negative-filters $NEGATIVE_FILTERS
+    UV_LINK_MODE=symlink uv run nemo_rl/utils/prefetch_venvs.py --negative-filters $NEGATIVE_FILTERS
 else
-    uv run nemo_rl/utils/prefetch_venvs.py
+    UV_LINK_MODE=symlink uv run nemo_rl/utils/prefetch_venvs.py
 fi
 EOF
 


### PR DESCRIPTION
## Summary
- Adds a persistent BuildKit cache mount at `/tmp/uv-warm-cache` to the hermetic stage's dependency-install RUN
- Seeds the in-layer uv cache (`/root/.cache/uv`) from the persistent mount before `uv sync`, and persists it back afterward
- When `pyproject.toml` or `uv.lock` changes (e.g., unrelated dep bumps), Docker invalidates the layer and today recompiles all CUDA kernels from scratch — sglang-kernel alone takes **~90 minutes**
- With the seeded cache, uv finds previously compiled wheels and skips recompilation

## How it works
```
BuildKit persistent cache (/tmp/uv-warm-cache)
    ↓ cp -a (seed before sync)
In-layer uv cache (/root/.cache/uv)
    ↓ uv sync --link-mode symlink
Venv (/opt/nemo_rl_venv) with symlinks into cache
    ↓ after sync
In-layer uv cache → cp -a → BuildKit persistent cache (update for next build)
```

## What does NOT change
- **Image size**: identical — same symlink mode, same in-layer cache structure
- **Release stage**: completely untouched — worker venvs still use symlinks into the hermetic stage's in-layer cache
- **Link mode**: `--link-mode symlink` preserved everywhere (no symlink→copy switch)
- **Runtime behavior**: zero changes — the persistent mount only exists during the build

## Impact
| Scenario | Before | After |
|----------|--------|-------|
| Unrelated dep change (e.g., bump ray) | ~90 min sglang-kernel recompilation | ~1 min (cache seed + install from cached wheel) |
| sglang version bump | ~90 min | ~90 min (cache miss on new version) |
| First build on a new runner | ~90 min | ~90 min (cold cache) |

## Open questions
- [ ] Are CI build runners persistent (long-lived VMs) or ephemeral (scale-to-zero)? If ephemeral, the persistent cache is empty every build and this change is a no-op. Need to confirm with infra.

## Test plan
- [ ] CI container build succeeds
- [ ] Container starts and Python imports work (validates symlinks are intact)
- [ ] Subsequent build with a trivial dep change on the same runner reuses compiled wheels

🤖 Generated with [Claude Code](https://claude.com/claude-code)