### PR TITLE
fix: token mult prob error plot masking

### DIFF
--- a/nemo_rl/utils/logger.py
+++ b/nemo_rl/utils/logger.py
@@ -1147,20 +1147,38 @@ class Logger(LoggerInterface):
             step: Global step value
             name: Name of the plot
         """
-        # find the sample with the highest log probability error
+        # Find the unmasked sample with the highest log probability error.
         token_mask = data["token_mask"][:, 1:]
         sample_mask = data["sample_mask"]
         generation_logprobs = data["generation_logprobs"][:, 1:]
         prev_logprobs = data["prev_logprobs"][:, 1:]
-        mask = token_mask * sample_mask.unsqueeze(-1)
 
         diff = (generation_logprobs - prev_logprobs).abs() * token_mask
         mask = token_mask * sample_mask.unsqueeze(-1)
 
-        mult_prob_error = (torch.exp(diff) * mask).sum(dim=-1) / mask.sum(dim=-1)
+        valid_token_counts = mask.sum(dim=-1)
+        valid_sample_mask = valid_token_counts > 0
+        if not valid_sample_mask.any():
+            print(
+                "Skipping token_mult_prob_error plot because no unmasked samples contain valid tokens."
+            )
+            return
 
-        sample_idx = torch.argmax(mult_prob_error)
-        sample_error = mult_prob_error[sample_idx]
+        # Masked samples have zero denominator after sequence-level logprob
+        # masking. Exclude them so the plot does not select a masked sample
+        # and report token_mult_prob_error=nan.
+        mult_prob_error = torch.full(
+            (mask.shape[0],),
+            float("-inf"),
+            dtype=generation_logprobs.dtype,
+            device=generation_logprobs.device,
+        )
+        mult_prob_error[valid_sample_mask] = (torch.exp(diff) * mask).sum(dim=-1)[
+            valid_sample_mask
+        ] / valid_token_counts[valid_sample_mask]
+
+        sample_idx = torch.argmax(mult_prob_error).item()
+        sample_error = mult_prob_error[sample_idx].item()
 
         # plot the sample with the highest log probability error
         # offset by 1 token for next token prediction
@@ -1178,12 +1196,9 @@ class Logger(LoggerInterface):
         generation_logprob = generation_logprobs[
             sample_idx, int(generation_start_idx) : int(generation_end_idx)
         ]
-        prev_logprob = (
-            prev_logprobs[
-                sample_idx, int(generation_start_idx) : int(generation_end_idx)
-            ]
-            * mask[sample_idx, int(generation_start_idx) : int(generation_end_idx)]
-        )
+        prev_logprob = prev_logprobs[
+            sample_idx, int(generation_start_idx) : int(generation_end_idx)
+        ]
         diff_i = diff[sample_idx, int(generation_start_idx) : int(generation_end_idx)]
 
         # Find max absolute error token
@@ -1201,7 +1216,7 @@ class Logger(LoggerInterface):
         step_idx = torch.arange(int(generation_start_idx), int(generation_end_idx))
 
         plt.plot(step_idx, generation_logprob, label="logprob (inference engine)")
-        plt.plot(step_idx, prev_logprob, label="logprob (reference policy)")
+        plt.plot(step_idx, prev_logprob, label="logprob (training policy recompute)")
         plt.plot(
             step_idx,
             diff_i,

--- a/tests/unit/utils/test_logger.py
+++ b/tests/unit/utils/test_logger.py
@@ -1659,14 +1659,25 @@ class TestLogger:
         mock_wandb_instance = mock_wandb_logger.return_value
         mock_tb_instance = mock_tb_logger.return_value
 
-        # Create sample data
+        # Create sample data where the largest raw mismatch belongs to a masked
+        # sequence. The plot should select the valid sequence instead.
         data = {
-            "token_mask": torch.ones((1, 10)),
-            "sample_mask": torch.ones(1),
-            "generation_logprobs": torch.randn((1, 10)),
-            "prev_logprobs": torch.randn((1, 10)),
-            "prompt_lengths": torch.tensor([2]),
-            "full_lengths": torch.tensor([8]),
+            "token_mask": torch.ones((2, 6)),
+            "sample_mask": torch.tensor([0.0, 1.0]),
+            "generation_logprobs": torch.tensor(
+                [
+                    [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    [0.0, -0.1, -0.2, -0.3, -0.4, -0.5],
+                ]
+            ),
+            "prev_logprobs": torch.tensor(
+                [
+                    [0.0, -10.0, -10.0, -10.0, -10.0, -10.0],
+                    [0.0, -0.1, -0.2, -0.1, -0.4, -0.5],
+                ]
+            ),
+            "prompt_lengths": torch.tensor([1, 2]),
+            "full_lengths": torch.tensor([6, 5]),
         }
         step = 10
         name = "test_plot"
@@ -1691,6 +1702,10 @@ class TestLogger:
 
         # Verify the legend labels
         legend_texts = [text.get_text() for text in ax.get_legend().get_texts()]
+        assert "logprob (training policy recompute)" in legend_texts
+        assert "logprob (reference policy)" not in legend_texts
+        assert all("token_mult_prob_error=nan" not in text for text in legend_texts)
+        assert list(ax.lines[0].get_ydata()) == pytest.approx([-0.2, -0.3, -0.4])
         assert any("Max abs error" in text for text in legend_texts)
         assert any("Max rel error (prob)" in text for text in legend_texts)
 


### PR DESCRIPTION
# What does this PR do ?

Fixes the `token_mult_prob_error` debug plot so it does not select fully masked samples and labels the recomputed policy logprobs accurately.

# Issues

N/A

# Usage

N/A. This is a logging/debug-plot fix.

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

The plot previously computed the per-sequence multiplicative probability error after applying `sample_mask`, but still allowed rows with zero valid tokens to participate in `argmax`. Fully masked rows therefore produced `0 / 0 = nan`, and the plot could show `token_mult_prob_error=nan`.

The orange logprob line was also labeled as `reference policy`, but the data comes from `prev_logprobs`, i.e. the training policy recomputation used for GRPO's behavior-policy comparison, not the frozen reference policy.

Before fix, the debug plot could select a fully masked sequence and show both symptoms:

![Before fix: token_mult_prob_error is nan and the mislabeled reference policy line is flat](https://raw.githubusercontent.com/1ytic/RL/codex/pr-assets-token-plot/pr-assets/nemo-rl-token-mult-prob-error-before.png)

After fix, the plot selects an unmasked sequence, reports a finite `token_mult_prob_error`, and labels the orange line as the training policy recompute:

![After fix: token_mult_prob_error is finite and the orange line is labeled training policy recompute](https://raw.githubusercontent.com/1ytic/RL/codex/pr-assets-token-plot/pr-assets/nemo-rl-token-mult-prob-error-after.png)
