### PR TITLE
ci: seed uv cache from registry to skip CUDA recompilation on ephemeral runners

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -308,7 +308,6 @@ jobs:
     needs: [build-container, org-member-pre-flight]
     if: >-
       ${{
-        github.ref == 'refs/heads/main' &&
         needs.build-container.result == 'success'
       }}
     runs-on: ${{ contains(needs.org-member-pre-flight.outputs.runner_prefix, 'azure') && format('{0}-gpu-x2', needs.org-member-pre-flight.outputs.runner_prefix) || format('{0}-gpu-x2', needs.org-member-pre-flight.outputs.runner_prefix) }}

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -308,6 +308,7 @@ jobs:
     needs: [build-container, org-member-pre-flight]
     if: >-
       ${{
+        github.ref == 'refs/heads/main' &&
         needs.build-container.result == 'success'
       }}
     runs-on: ${{ contains(needs.org-member-pre-flight.outputs.runner_prefix, 'azure') && format('{0}-gpu-x2', needs.org-member-pre-flight.outputs.runner_prefix) || format('{0}-gpu-x2', needs.org-member-pre-flight.outputs.runner_prefix) }}

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -300,7 +300,6 @@ jobs:
         ${{ vars.UV_BUILD_CACHE == 'enabled' && format('uv-cache-seed=docker-image://{0}/{1}-uv-cache:latest', needs.org-member-pre-flight.outputs.registry, vars.CI_CONTAINER_NAME) || '' }}
       build-args: |
         MAX_JOBS=4
-        SKIP_SGLANG_BUILD=1
         NEMO_RL_COMMIT=${{ needs.pre-flight.outputs.test_sha }}
 
   update-uv-cache:

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -311,7 +311,7 @@ jobs:
         github.ref == 'refs/heads/main' &&
         needs.build-container.result == 'success'
       }}
-    runs-on: ${{ contains(needs.org-member-pre-flight.outputs.runner_prefix, 'azure') && format('{0}-gpu-x2', needs.org-member-pre-flight.outputs.runner_prefix) || format('{0}-gpu-x2', needs.org-member-pre-flight.outputs.runner_prefix) }}
+    runs-on: ${{ format('{0}-gpu-x2', needs.org-member-pre-flight.outputs.runner_prefix) }}
     environment: nemo-ci
     env:
       REGISTRY: ${{ needs.org-member-pre-flight.outputs.registry }}

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -297,10 +297,41 @@ jobs:
       registry: ${{ needs.org-member-pre-flight.outputs.registry }}
       build-contexts: |
         nemo-rl=${{ github.run_id }}/
+        ${{ vars.UV_BUILD_CACHE == 'enabled' && format('uv-cache-seed=docker-image://{0}/{1}-uv-cache:latest', needs.org-member-pre-flight.outputs.registry, vars.CI_CONTAINER_NAME) || '' }}
       build-args: |
         MAX_JOBS=4
         SKIP_SGLANG_BUILD=1
         NEMO_RL_COMMIT=${{ needs.pre-flight.outputs.test_sha }}
+
+  update-uv-cache:
+    name: Update uv build cache
+    needs: [build-container, org-member-pre-flight]
+    if: >-
+      ${{
+        github.ref == 'refs/heads/main' &&
+        needs.build-container.result == 'success'
+      }}
+    runs-on: ${{ contains(needs.org-member-pre-flight.outputs.runner_prefix, 'azure') && format('{0}-gpu-x2', needs.org-member-pre-flight.outputs.runner_prefix) || format('{0}-gpu-x2', needs.org-member-pre-flight.outputs.runner_prefix) }}
+    environment: nemo-ci
+    env:
+      REGISTRY: ${{ needs.org-member-pre-flight.outputs.registry }}
+      IMAGE_NAME: ${{ vars.CI_CONTAINER_NAME }}
+    steps:
+      - name: Extract and push uv cache image
+        run: |
+          set -euo pipefail
+          SRC="${REGISTRY}/${IMAGE_NAME}:${{ github.run_id }}"
+          DST="${REGISTRY}/${IMAGE_NAME}-uv-cache:latest"
+
+          docker pull "${SRC}"
+          CID=$(docker create "${SRC}" true)
+          mkdir -p /tmp/uv-cache
+          docker cp "${CID}:/root/.cache/uv/." /tmp/uv-cache/
+          docker rm "${CID}"
+
+          printf 'FROM scratch\nCOPY uv-cache/ /\n' > /tmp/Dockerfile.uv-cache
+          docker build -t "${DST}" -f /tmp/Dockerfile.uv-cache /tmp
+          docker push "${DST}"
 
   cicd-doc-tests:
     strategy:

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -332,6 +332,9 @@ jobs:
           docker build -t "${DST}" -f /tmp/Dockerfile.uv-cache /tmp
           docker push "${DST}"
 
+          docker rmi "${SRC}" "${DST}" 2>/dev/null || true
+          rm -rf /tmp/uv-cache /tmp/Dockerfile.uv-cache
+
   cicd-doc-tests:
     strategy:
       fail-fast: false

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -108,6 +108,8 @@ ARG BUILD_CUSTOM_FLASHINFER_REF
 # Skip building vLLM or SGLang dependencies (set to any non-empty value to skip)
 ARG SKIP_VLLM_BUILD
 ARG SKIP_SGLANG_BUILD
+ARG BASE_IMAGE
+ARG UV_VERSION
 
 ENV UV_PROJECT_ENVIRONMENT=/opt/nemo_rl_venv
 ENV UV_LINK_MODE=copy
@@ -130,8 +132,15 @@ COPY --from=nemo-rl --link 3rdparty/ ./3rdparty/
 
 RUN --mount=type=ssh \
     --mount=type=bind,from=uv-cache-seed,source=.,target=/tmp/uv-cache-seed <<"EOF" bash -exu
-mkdir -p /root/.cache/uv
-rsync -a /tmp/uv-cache-seed/ /root/.cache/uv/ 2>/dev/null || true
+CACHE_KEY=$(echo "${BASE_IMAGE}-${UV_VERSION}" | md5sum | cut -c1-12)
+SEED_KEY=$(cat /tmp/uv-cache-seed/.cache-key 2>/dev/null || echo "")
+if [ -n "$SEED_KEY" ] && [ "$SEED_KEY" != "$CACHE_KEY" ]; then
+    echo "Cache key mismatch (base image or uv version changed) — skipping stale seed"
+elif [ -n "$SEED_KEY" ]; then
+    echo "Seeding uv cache (key=${CACHE_KEY})"
+    mkdir -p /root/.cache/uv
+    rsync -a --exclude='.cache-key' /tmp/uv-cache-seed/ /root/.cache/uv/ 2>/dev/null || true
+fi
 
 uv venv --seed
 if [[ -n "${BUILD_CUSTOM_VLLM:-}" ]]; then
@@ -163,6 +172,8 @@ uv sync --link-mode symlink --locked --all-groups --no-install-project
 # Remove the aiohttp in this uv cache dir to fully address CVE GHSA-mqqc-3gqh-h2x8
 # The ray install will include the older aiohttp version in its cache
 find /root/.cache/uv -type d -path "*ray/_private/runtime_env/agent/thirdparty_files/aiohttp*" -exec rm -rf {} +
+
+echo "${CACHE_KEY}" > /root/.cache/uv/.cache-key
 EOF
 
 ENV PATH="/opt/nemo_rl_venv/bin:$PATH"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,9 @@ FROM scratch AS nemo-rl
 ARG NRL_GIT_REF=main
 ADD --keep-git-dir=true https://github.com/NVIDIA-NeMo/RL.git#${NRL_GIT_REF} /
 
+# Empty default; CI overrides with --build-context to inject pre-compiled wheels
+FROM scratch AS uv-cache-seed
+
 FROM ${BASE_IMAGE} AS base
 # An environment variable to indicate that we are in a container.
 ENV NRL_CONTAINER=1
@@ -125,7 +128,11 @@ COPY --from=nemo-rl tools/build-custom-flashinfer.sh ./tools/build-custom-flashi
 COPY --from=nemo-rl --link research/ ./research/
 COPY --from=nemo-rl --link 3rdparty/ ./3rdparty/
 
-RUN --mount=type=ssh <<"EOF" bash -exu
+RUN --mount=type=ssh \
+    --mount=type=bind,from=uv-cache-seed,source=.,target=/tmp/uv-cache-seed <<"EOF" bash -exu
+mkdir -p /root/.cache/uv
+rsync -a /tmp/uv-cache-seed/ /root/.cache/uv/ 2>/dev/null || true
+
 uv venv --seed
 if [[ -n "${BUILD_CUSTOM_VLLM:-}" ]]; then
     bash tools/build-custom-vllm.sh ${BUILD_CUSTOM_VLLM_URL} ${BUILD_CUSTOM_VLLM_REF} ${BUILD_CUSTOM_VLLM_PRECOMPILED_WHEEL_LOCATION}

--- a/tests/functional/L1_Functional_Tests_GPU.sh
+++ b/tests/functional/L1_Functional_Tests_GPU.sh
@@ -66,7 +66,7 @@ run_test      uv run --no-sync bash ./tests/functional/grpo_multiple_dataloaders
 run_test      uv run --no-sync bash ./tests/functional/grpo_multiturn.sh
 run_test      uv run --no-sync bash ./tests/functional/grpo_non_colocated.sh
 run_test      uv run --no-sync bash ./tests/functional/grpo_rm_env.sh
-# run_test      uv run --no-sync bash ./tests/functional/grpo_sglang.sh
+run_test      uv run --no-sync bash ./tests/functional/grpo_sglang.sh
 run_test fast uv run --no-sync bash ./tests/functional/grpo_topp_topk.sh
 run_test      uv run --no-sync bash ./tests/functional/prorlv2.sh
 run_test      uv run --no-sync bash ./tests/functional/qa_distillation_megatron.sh

--- a/tests/unit/L0_Unit_Tests_Generation.sh
+++ b/tests/unit/L0_Unit_Tests_Generation.sh
@@ -57,10 +57,10 @@ else
     uv run --extra vllm bash -x ./tests/run_unit.sh "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --cov=nemo_rl --cov-append --cov-report=term-missing --cov-report=json --hf-gated --vllm-only
 fi
 
-# # Check and run sglang tests
-# exit_code=$(cd ${PROJECT_ROOT}/tests && uv run --extra sglang pytest "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --collect-only --hf-gated --sglang-only -q >/dev/null 2>&1; echo $?)
-# if [[ $exit_code -eq 5 ]]; then
-#     echo "No sglang tests to run"
-# else
-#     uv run --extra sglang bash -x ./tests/run_unit.sh "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --cov=nemo_rl --cov-append --cov-report=term-missing --cov-report=json --hf-gated --sglang-only
-# fi
+# Check and run sglang tests
+exit_code=$(cd ${PROJECT_ROOT}/tests && uv run --extra sglang pytest "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --collect-only --hf-gated --sglang-only -q >/dev/null 2>&1; echo $?)
+if [[ $exit_code -eq 5 ]]; then
+    echo "No sglang tests to run"
+else
+    uv run --extra sglang bash -x ./tests/run_unit.sh "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --cov=nemo_rl --cov-append --cov-report=term-missing --cov-report=json --hf-gated --sglang-only
+fi

--- a/tests/unit/L0_Unit_Tests_Other.sh
+++ b/tests/unit/L0_Unit_Tests_Other.sh
@@ -57,13 +57,13 @@ else
     uv run --extra vllm bash -x ./tests/run_unit.sh "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --cov=nemo_rl --cov-append --cov-report=term-missing --cov-report=json --hf-gated --vllm-only
 fi
 
-# # Check and run sglang tests
-# exit_code=$(cd ${PROJECT_ROOT}/tests && uv run --extra sglang pytest "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --collect-only --hf-gated --sglang-only -q >/dev/null 2>&1; echo $?)
-# if [[ $exit_code -eq 5 ]]; then
-#     echo "No sglang tests to run"
-# else
-#     uv run --extra sglang bash -x ./tests/run_unit.sh "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --cov=nemo_rl --cov-append --cov-report=term-missing --cov-report=json --hf-gated --sglang-only
-# fi
+# Check and run sglang tests
+exit_code=$(cd ${PROJECT_ROOT}/tests && uv run --extra sglang pytest "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --collect-only --hf-gated --sglang-only -q >/dev/null 2>&1; echo $?)
+if [[ $exit_code -eq 5 ]]; then
+    echo "No sglang tests to run"
+else
+    uv run --extra sglang bash -x ./tests/run_unit.sh "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --cov=nemo_rl --cov-append --cov-report=term-missing --cov-report=json --hf-gated --sglang-only
+fi
 
 # Check and run nemo_gym tests
 exit_code=$(cd ${PROJECT_ROOT}/tests && uv run --extra nemo_gym pytest "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --collect-only --nemo-gym-only -q >/dev/null 2>&1; echo $?)

--- a/tests/unit/L0_Unit_Tests_Policy.sh
+++ b/tests/unit/L0_Unit_Tests_Policy.sh
@@ -57,10 +57,10 @@ else
     uv run --extra vllm bash -x ./tests/run_unit.sh "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --cov=nemo_rl --cov-append --cov-report=term-missing --cov-report=json --hf-gated --vllm-only
 fi
 
-# # Check and run sglang tests
-# exit_code=$(cd ${PROJECT_ROOT}/tests && uv run --extra sglang pytest "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --collect-only --hf-gated --sglang-only -q >/dev/null 2>&1; echo $?)
-# if [[ $exit_code -eq 5 ]]; then
-#     echo "No sglang tests to run"
-# else
-#     uv run --extra sglang bash -x ./tests/run_unit.sh "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --cov=nemo_rl --cov-append --cov-report=term-missing --cov-report=json --hf-gated --sglang-only
-# fi
+# Check and run sglang tests
+exit_code=$(cd ${PROJECT_ROOT}/tests && uv run --extra sglang pytest "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --collect-only --hf-gated --sglang-only -q >/dev/null 2>&1; echo $?)
+if [[ $exit_code -eq 5 ]]; then
+    echo "No sglang tests to run"
+else
+    uv run --extra sglang bash -x ./tests/run_unit.sh "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --cov=nemo_rl --cov-append --cov-report=term-missing --cov-report=json --hf-gated --sglang-only
+fi


### PR DESCRIPTION
## Summary
- Adds an external uv cache mechanism that survives ephemeral runner teardown
- Stores pre-compiled wheels as a container image in the existing registry — no new infrastructure needed
- On main merges, a post-build job extracts `/root/.cache/uv` and pushes it as `<image>-uv-cache:latest`
- Subsequent builds bind-mount the cached wheels into the `uv sync` step, skipping CUDA kernel recompilation
- Cache key validation ensures stale wheels are rejected when `BASE_IMAGE` or `UV_VERSION` changes

Supersedes #2477.

## Why
BuildKit's `--mount=type=cache` stores data in the daemon's internal storage, which is lost on ephemeral runners. Docker's layer cache (`--cache-from`/`--cache-to`) caches layers but can't help when the `uv sync` layer is invalidated by a `pyproject.toml`/`uv.lock` change. This fills the gap: even when the layer is rebuilt, uv finds pre-compiled wheels in the seeded cache and skips recompilation.

## How it works
```
Registry: <image>-uv-cache:latest (pre-compiled wheels + .cache-key)
    ↓ docker-image:// build context (pulled by BuildKit)
Bind mount: /tmp/uv-cache-seed (read-only during RUN)
    ↓ validate .cache-key matches BASE_IMAGE + UV_VERSION
    ↓ rsync (only if key matches)
/root/.cache/uv (uv finds cached wheels)
    ↓ uv sync
Venv built with cached wheels — CUDA recompilation skipped
    ↓ post-build job (main merges only)
Extract /root/.cache/uv → push as updated cache image
```

## What changes

**Dockerfile** (`docker/Dockerfile`):
- `FROM scratch AS uv-cache-seed` — empty default stage, overridden by CI via `--build-context`
- Re-declares `ARG BASE_IMAGE` and `ARG UV_VERSION` in the hermetic stage for cache key computation
- `--mount=type=bind,from=uv-cache-seed,...` added to the `uv sync` RUN
- Cache key validation: computes `md5(BASE_IMAGE-UV_VERSION)`, compares against `.cache-key` in the seed. Skips seeding on mismatch (prevents using CUDA-incompatible wheels after a base image change)
- Writes `.cache-key` into `/root/.cache/uv/` after sync so it travels with the cache

**CI workflow** (`.github/workflows/cicd-main.yml`):
- `build-contexts` conditionally adds `uv-cache-seed=docker-image://...` when `vars.UV_BUILD_CACHE == 'enabled'`
- New `update-uv-cache` job (main merges only): extracts cache from built image, pushes as `<image>-uv-cache:latest`, cleans up runner disk

## What does NOT change
- **Image size**: identical — bind mount is read-only and not part of any layer
- **Local builds**: `FROM scratch AS uv-cache-seed` provides an empty fallback — `docker buildx build -f docker/Dockerfile .` works as before
- **Release stage**: untouched
- **Existing layer caching**: inline/registry cache is unchanged

## Impact
| Scenario | Before | After |
|----------|--------|-------|
| Unrelated dep change (e.g., bump ray) | ~90 min sglang-kernel recompilation | ~1 min (cached wheel) |
| sglang version bump | ~90 min | ~90 min (cache miss) |
| BASE_IMAGE or UV_VERSION change | ~90 min | ~90 min (cache key mismatch, seed skipped) |
| First build / cache disabled | ~90 min | ~90 min (empty seed) |


## Test plan
- [x] After enabling `UV_BUILD_CACHE`, build pulls cache image and seeds uv cache
- [x] Build logs show `"Seeding uv cache (key=...)"` when cache key matches
- [x] `update-uv-cache` job successfully pushes cache image on main merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)