### PR TITLE
ci: use registry cache for container builds

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -295,6 +295,10 @@ jobs:
       image-label: ${{ vars.CI_CONTAINER_NAME }}
       target: release
       registry: ${{ needs.org-member-pre-flight.outputs.registry }}
+      # Ephemeral build runners cannot rely on local Docker state or inline cache
+      # from previous jobs. Use the template's registry cache so the uv sync
+      # dependency layer is shared across fresh runners.
+      use-inline-cache: false
       build-contexts: |
         nemo-rl=${{ github.run_id }}/
       build-args: |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# What does this PR do ?

Switches the container build job from inline BuildKit cache to the reusable workflow's registry-backed cache. This lets fresh/ephemeral build runners reuse the expensive Docker layer that runs `uv sync` across dependency extras.

# Issues

Linear: AUT-492

# Usage

N/A - CI workflow change only.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? Workflow syntax validation only; no runtime code changed.
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? No docs needed for this CI-only change.

# Additional Information

Validation run locally:
- `python3` YAML parse/assertion for `.github/workflows/cicd-main.yml`
- `git diff --check`

`actionlint` and Docker are not installed in this cloud environment, so a full container build must run in CI.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AUT-492](https://linear.app/nvidia/issue/AUT-492/fix-container-build-failure)

<div><a href="https://cursor.com/agents/bc-54037e04-6e4a-49d2-9ddb-42cda5d84026"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54037e04-6e4a-49d2-9ddb-42cda5d84026"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

