### PR TITLE
feat(data-plane): add TQ fault tolerance APIs

### DIFF
--- a/nemo_rl/data_plane/README.md
+++ b/nemo_rl/data_plane/README.md
@@ -187,6 +187,34 @@ Worker write-backs append new columns under the same keys.
 
 ---
 
+## Recovery/control-plane
+
+`DataPlaneClient` exposes a small controller-facing recovery surface:
+
+- `ping(timeout_s)` — health-check the real data-plane request path.
+- `list_metadata(partition_id) → list[DataPlaneGroupMeta]` — non-consuming
+  rollout-group metadata for controller recovery.
+- `depth(partition_id) → int` — count committed, complete groups visible to
+  recovery.
+- `pop(keys, partition_id)` — remove successfully trained keys.
+- `evict(keys, partition_id)` — remove stale or abandoned keys.
+- `get_capabilities() → DataPlaneCapabilities` — backend recovery guarantees.
+
+`list_metadata` is deliberately separate from `get_meta`: it must not advance
+TransferQueue's per-task consumption counters. SingleController should use
+`list_metadata` to reconstruct capacity and `pop`/`evict` to release capacity
+only after the data plane reports a successful clear.
+
+Recovery-aware producers should tag every rollout key with:
+
+- `group_id` — rollout group identity; all keys in a group share it.
+- `weight_version` — policy version used to produce the row.
+- `created_at` — producer timestamp for stale uncommitted cleanup.
+- `committed` — `True` only after the row is safe to train on.
+- `expected_num_keys` or `num_keys` — complete group size.
+
+---
+
 ## Concrete examples
 
 ### Call shapes

--- a/nemo_rl/data_plane/__init__.py
+++ b/nemo_rl/data_plane/__init__.py
@@ -21,15 +21,35 @@ detail of a specific adapter.
 from nemo_rl.data_plane.codec import materialize
 from nemo_rl.data_plane.factory import build_data_plane_client
 from nemo_rl.data_plane.interfaces import (
+    DataPlaneBadRequest,
+    DataPlaneCapabilities,
     DataPlaneClient,
     DataPlaneConfig,
+    DataPlaneError,
+    DataPlaneGroupMeta,
+    DataPlaneNotReady,
+    DataPlaneReadError,
+    DataPlaneTimeout,
+    DataPlaneUnavailable,
+    DataPlaneWriteError,
+    DataPlaneClearError,
     KVBatchMeta,
 )
 from nemo_rl.data_plane.observability import MetricsDataPlaneClient, log_event
 
 __all__ = [
+    "DataPlaneBadRequest",
+    "DataPlaneCapabilities",
+    "DataPlaneClearError",
     "DataPlaneClient",
     "DataPlaneConfig",
+    "DataPlaneError",
+    "DataPlaneGroupMeta",
+    "DataPlaneNotReady",
+    "DataPlaneReadError",
+    "DataPlaneTimeout",
+    "DataPlaneUnavailable",
+    "DataPlaneWriteError",
     "KVBatchMeta",
     "MetricsDataPlaneClient",
     "build_data_plane_client",

--- a/nemo_rl/data_plane/adapters/noop.py
+++ b/nemo_rl/data_plane/adapters/noop.py
@@ -32,7 +32,13 @@ import torch
 from tensordict import TensorDict
 
 from nemo_rl.data_plane.codec import stack_or_nest as _stack_or_nest
-from nemo_rl.data_plane.interfaces import DataPlaneClient, KVBatchMeta
+from nemo_rl.data_plane.interfaces import (
+    DataPlaneCapabilities,
+    DataPlaneClient,
+    DataPlaneGroupMeta,
+    DataPlaneUnavailable,
+    KVBatchMeta,
+)
 
 
 def _reject_non_tensor_leaves(td: TensorDict) -> None:
@@ -55,6 +61,32 @@ def _reject_non_tensor_leaves(td: TensorDict) -> None:
             "Tensorize via codec helpers, use `tags=` for primitives, "
             "or use the Ray object store for arbitrary Python objects."
         )
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.lower() in {"1", "true", "yes"}
+    return bool(value)
 
 
 @dataclass
@@ -236,6 +268,53 @@ class NoOpDataPlaneClient(DataPlaneClient):
             rec.tags.pop(sid, None)
             for s in rec.consumed.values():
                 s.discard(sid)
+
+    def ping(self, timeout_s: float | None = None) -> None:
+        del timeout_s
+        if self._closed:
+            raise DataPlaneUnavailable("NoOp data plane is closed")
+
+    def list_metadata(self, partition_id: str) -> list[DataPlaneGroupMeta]:
+        rec = self._partitions.get(partition_id)
+        if rec is None:
+            return []
+
+        grouped: dict[str, list[tuple[str, dict[str, Any]]]] = {}
+        for key in sorted(set(rec.rows) | set(rec.tags)):
+            tag = rec.tags.get(key, {})
+            group_id = str(tag.get("group_id") or key)
+            grouped.setdefault(group_id, []).append((key, tag))
+
+        groups: list[DataPlaneGroupMeta] = []
+        for group_id, rows in grouped.items():
+            keys = [key for key, _ in rows]
+            tags = [tag for _, tag in rows]
+            first_tag = dict(tags[0]) if tags else {}
+            expected_num_keys = _as_int(
+                first_tag.get("expected_num_keys", first_tag.get("num_keys"))
+            )
+            groups.append(
+                DataPlaneGroupMeta(
+                    partition_id=partition_id,
+                    group_id=group_id,
+                    keys=keys,
+                    weight_version=_as_int(first_tag.get("weight_version")),
+                    created_at=_as_float(first_tag.get("created_at")),
+                    committed=all(_as_bool(t.get("committed", False)) for t in tags),
+                    expected_num_keys=expected_num_keys,
+                    size_bytes=_as_int(first_tag.get("size_bytes")),
+                    tags=first_tag,
+                )
+            )
+        return groups
+
+    def get_capabilities(self) -> DataPlaneCapabilities:
+        return DataPlaneCapabilities(
+            supports_persistent_recovery=False,
+            supports_server_side_filtering=False,
+            supports_atomic_batch_put=True,
+            supports_verified_clear=True,
+        )
 
     def close(self) -> None:
         if self._closed:

--- a/nemo_rl/data_plane/adapters/transfer_queue.py
+++ b/nemo_rl/data_plane/adapters/transfer_queue.py
@@ -27,6 +27,8 @@ import os
 import socket
 import subprocess
 import time
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from importlib import resources
 from typing import Any
 
@@ -35,10 +37,29 @@ import transfer_queue as tq
 from tensordict import TensorDict
 
 from nemo_rl.data_plane.interfaces import (
+    DataPlaneBadRequest,
+    DataPlaneCapabilities,
+    DataPlaneClearError,
     DataPlaneClient,
     DataPlaneConfig,
+    DataPlaneError,
+    DataPlaneGroupMeta,
+    DataPlaneReadError,
+    DataPlaneTimeout,
+    DataPlaneUnavailable,
+    DataPlaneWriteError,
     KVBatchMeta,
 )
+
+try:
+    from ray.exceptions import RayActorError
+except ImportError:
+    G_TQ_UNAVAILABLE_ERROR_TYPES: tuple[type[BaseException], ...] = (
+        ConnectionError,
+        OSError,
+    )
+else:
+    G_TQ_UNAVAILABLE_ERROR_TYPES = (RayActorError, ConnectionError, OSError)
 
 # ──────────────────────────────────────────────────────────────────────────
 # Backend init — lifted from rl-arena/arena/backends.py.
@@ -380,6 +401,63 @@ def _from_wire(td: TensorDict) -> TensorDict:
     return new_td
 
 
+def _as_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.lower() in {"1", "true", "yes"}
+    return bool(value)
+
+
+G_TQ_UNAVAILABLE_PATTERNS = (
+    "actor",
+    "connection refused",
+    "controller",
+    "crashed",
+    "no controller registered",
+    "storage unit may be overloaded",
+    "zmq recv timeout",
+)
+
+
+def _translate_tq_error(
+    operation: str,
+    exc: BaseException,
+    default_error: type[DataPlaneError],
+) -> DataPlaneError:
+    if isinstance(exc, DataPlaneError):
+        return exc
+    message = f"{operation} failed: {exc}"
+    if isinstance(exc, TimeoutError | FutureTimeoutError):
+        return DataPlaneTimeout(message)
+    if isinstance(exc, G_TQ_UNAVAILABLE_ERROR_TYPES):
+        return DataPlaneUnavailable(message)
+    if isinstance(exc, ValueError | KeyError | TypeError):
+        return DataPlaneBadRequest(message)
+    text = str(exc).lower()
+    if any(pattern in text for pattern in G_TQ_UNAVAILABLE_PATTERNS):
+        return DataPlaneUnavailable(message)
+    return default_error(message)
+
+
 class TQDataPlaneClient(DataPlaneClient):
     """Adapter façade — maps NeMo-RL calls onto TransferQueue's public API."""
 
@@ -432,8 +510,37 @@ class TQDataPlaneClient(DataPlaneClient):
             _init_tq(cfg)
         else:
             _connect_existing()
+        self._tq = tq
         self._poll_interval_s = cfg["claim_meta_poll_interval_s"]
         self._closed = False
+
+    def _call_tq(
+        self,
+        operation: str,
+        fn,
+        default_error: type[DataPlaneError],
+        *,
+        timeout_s: float | None = None,
+    ):
+        if timeout_s is None:
+            try:
+                return fn()
+            except Exception as exc:
+                raise _translate_tq_error(operation, exc, default_error) from exc
+
+        executor = ThreadPoolExecutor(max_workers=1)
+        future = executor.submit(fn)
+        try:
+            return future.result(timeout=timeout_s)
+        except FutureTimeoutError as exc:
+            future.cancel()
+            raise DataPlaneTimeout(
+                f"{operation} timed out after {timeout_s}s"
+            ) from exc
+        except Exception as exc:
+            raise _translate_tq_error(operation, exc, default_error) from exc
+        finally:
+            executor.shutdown(wait=False, cancel_futures=True)
 
     # ── (A) task-mediated ───────────────────────────────────────────────
 
@@ -461,7 +568,7 @@ class TQDataPlaneClient(DataPlaneClient):
         # client request races with a put removes the trigger entirely.
         if not fields:
             return
-        client = tq.get_client()
+        client = self._tq.get_client()
         dummy_td = TensorDict(
             {f: torch.zeros(1) for f in fields},
             batch_size=[1],
@@ -479,20 +586,24 @@ class TQDataPlaneClient(DataPlaneClient):
         blocking: bool = True,
         timeout_s: float = 60.0,
     ) -> KVBatchMeta:
-        client = tq.get_client()
+        client = self._tq.get_client()
         deadline = time.time() + max(0.0, timeout_s)
         sampling_config: dict[str, Any] = {}
         if dp_rank is not None:
             sampling_config["dp_rank"] = dp_rank
 
         while True:
-            tq_meta = client.get_meta(
-                data_fields=list(required_fields),
-                batch_size=int(batch_size),
-                partition_id=partition_id,
-                task_name=task_name,
-                mode="fetch",
-                sampling_config=sampling_config,
+            tq_meta = self._call_tq(
+                "get_meta",
+                lambda: client.get_meta(
+                    data_fields=list(required_fields),
+                    batch_size=int(batch_size),
+                    partition_id=partition_id,
+                    task_name=task_name,
+                    mode="fetch",
+                    sampling_config=sampling_config,
+                ),
+                DataPlaneReadError,
             )
             if getattr(tq_meta, "size", 0) > 0:
                 break
@@ -504,15 +615,19 @@ class TQDataPlaneClient(DataPlaneClient):
                     fields=list(required_fields),
                 )
             if time.time() >= deadline:
-                raise TimeoutError(
+                raise DataPlaneTimeout(
                     f"claim_meta(partition={partition_id}, task={task_name}) "
                     f"timed out after {timeout_s}s"
                 )
             time.sleep(self._poll_interval_s)
 
-        keys: list[str] = client.kv_retrieve_keys(
-            global_indexes=list(tq_meta.global_indexes),
-            partition_id=partition_id,
+        keys: list[str] = self._call_tq(
+            "kv_retrieve_keys",
+            lambda: client.kv_retrieve_keys(
+                global_indexes=list(tq_meta.global_indexes),
+                partition_id=partition_id,
+            ),
+            DataPlaneReadError,
         )
 
         # Propagate per-key tags. ``sequence_lengths`` is lifted out of
@@ -550,7 +665,7 @@ class TQDataPlaneClient(DataPlaneClient):
     def check_consumption_status(
         self, partition_id: str, task_names: list[str]
     ) -> bool:
-        client = tq.get_client()
+        client = self._tq.get_client()
         for t in task_names:
             if not client.check_consumption_status(
                 task_name=t, partition_id=partition_id
@@ -587,12 +702,15 @@ class TQDataPlaneClient(DataPlaneClient):
                 wire_fields = _promote_1d_leaves(wire_fields)  # type: ignore[bad-argument-type]
             field_names = list(wire_fields.keys())
 
-        # TQ's wire vocabulary is `keys=` — translation point.
-        tq.kv_batch_put(
-            keys=list(sample_ids),
-            partition_id=partition_id,
-            fields=wire_fields,
-            tags=tags,
+        self._call_tq(
+            "kv_batch_put",
+            lambda: self._tq.kv_batch_put(
+                keys=list(sample_ids),
+                partition_id=partition_id,
+                fields=wire_fields,
+                tags=tags,
+            ),
+            DataPlaneWriteError,
         )
 
         return KVBatchMeta(
@@ -611,11 +729,14 @@ class TQDataPlaneClient(DataPlaneClient):
     ) -> TensorDict:
         if not sample_ids:
             return TensorDict({}, batch_size=(0,))
-        # TQ's wire vocabulary is `keys=` — translation point.
-        td = tq.kv_batch_get(
-            keys=list(sample_ids),
-            partition_id=partition_id,
-            select_fields=select_fields,
+        td = self._call_tq(
+            "kv_batch_get",
+            lambda: self._tq.kv_batch_get(
+                keys=list(sample_ids),
+                partition_id=partition_id,
+                select_fields=list(select_fields),
+            ),
+            DataPlaneReadError,
         )
         if self._promote_1d:
             td = _from_wire(td)
@@ -628,7 +749,11 @@ class TQDataPlaneClient(DataPlaneClient):
             # set in this partition. ``kv_list`` errors propagate; we
             # don't want a network blip to silently turn into "cleared
             # nothing".
-            listing = tq.kv_list(partition_id=partition_id)
+            listing = self._call_tq(
+                "kv_list for clear",
+                lambda: self._tq.kv_list(partition_id=partition_id),
+                DataPlaneClearError,
+            )
             sample_ids = list(listing.get(partition_id, {}).keys())
         if not sample_ids:
             if cleared_via_none:
@@ -646,15 +771,80 @@ class TQDataPlaneClient(DataPlaneClient):
                 )
             return
         # TQ's wire vocabulary is `keys=` — translation point.
-        tq.kv_clear(keys=list(sample_ids), partition_id=partition_id)
+        self._call_tq(
+            "kv_clear",
+            lambda: self._tq.kv_clear(
+                keys=list(sample_ids),
+                partition_id=partition_id,
+            ),
+            DataPlaneClearError,
+        )
 
-    # ── (C) lifecycle ──────────────────────────────────────────────────
+    # ── (C) recovery/control-plane ─────────────────────────────────────
+
+    def ping(self, timeout_s: float | None = None) -> None:
+        def _ping():
+            client = self._tq.get_client()
+            try:
+                get_partition_list = client.get_partition_list
+            except AttributeError:
+                self._tq.kv_list(partition_id="__nemo_rl_ping__")
+            else:
+                get_partition_list()
+
+        self._call_tq("ping", _ping, DataPlaneReadError, timeout_s=timeout_s)
+
+    def list_metadata(self, partition_id: str) -> list[DataPlaneGroupMeta]:
+        listing = self._call_tq(
+            "kv_list",
+            lambda: self._tq.kv_list(partition_id=partition_id),
+            DataPlaneReadError,
+        )
+        partition_listing = listing.get(partition_id, {})
+        grouped: dict[str, list[tuple[str, dict[str, Any]]]] = {}
+        for key in sorted(partition_listing):
+            tag = partition_listing[key] or {}
+            group_id = str(tag.get("group_id") or key)
+            grouped.setdefault(group_id, []).append((key, tag))
+
+        groups: list[DataPlaneGroupMeta] = []
+        for group_id, rows in grouped.items():
+            keys = [key for key, _ in rows]
+            tags = [tag for _, tag in rows]
+            first_tag = dict(tags[0]) if tags else {}
+            expected_num_keys = _as_int(
+                first_tag.get("expected_num_keys", first_tag.get("num_keys"))
+            )
+            groups.append(
+                DataPlaneGroupMeta(
+                    partition_id=partition_id,
+                    group_id=group_id,
+                    keys=keys,
+                    weight_version=_as_int(first_tag.get("weight_version")),
+                    created_at=_as_float(first_tag.get("created_at")),
+                    committed=all(_as_bool(t.get("committed", False)) for t in tags),
+                    expected_num_keys=expected_num_keys,
+                    size_bytes=_as_int(first_tag.get("size_bytes")),
+                    tags=first_tag,
+                )
+            )
+        return groups
+
+    def get_capabilities(self) -> DataPlaneCapabilities:
+        return DataPlaneCapabilities(
+            supports_persistent_recovery=False,
+            supports_server_side_filtering=False,
+            supports_atomic_batch_put=False,
+            supports_verified_clear=False,
+        )
+
+    # ── (D) lifecycle ──────────────────────────────────────────────────
 
     def close(self) -> None:
         if self._closed:
             return
         self._closed = True
         try:
-            tq.close()
+            self._tq.close()
         except Exception:
             pass

--- a/nemo_rl/data_plane/interfaces.py
+++ b/nemo_rl/data_plane/interfaces.py
@@ -220,6 +220,75 @@ class KVBatchMeta:
         )
 
 
+@dataclass(frozen=True)
+class DataPlaneCapabilities:
+    """Recovery-relevant behavior promised by a data-plane backend."""
+
+    supports_persistent_recovery: bool = False
+    supports_server_side_filtering: bool = False
+    supports_atomic_batch_put: bool = False
+    supports_verified_clear: bool = False
+
+
+@dataclass(frozen=True)
+class DataPlaneGroupMeta:
+    """Non-consuming metadata record used by SingleController recovery.
+
+    A rollout group may span multiple transfer-queue keys. The fields here
+    are intentionally control-plane only: SC can reconstruct capacity and
+    select trainable groups without fetching tensor payloads.
+    """
+
+    partition_id: str
+    group_id: str
+    keys: list[str]
+    weight_version: int | None
+    created_at: float | None
+    committed: bool
+    expected_num_keys: int | None = None
+    size_bytes: int | None = None
+    tags: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_complete(self) -> bool:
+        """Whether the listed keys match the producer-declared group size."""
+        if self.expected_num_keys is None:
+            return True
+        return len(self.keys) == self.expected_num_keys
+
+
+class DataPlaneError(RuntimeError):
+    """Base class for data-plane failures surfaced to controllers."""
+
+
+class DataPlaneUnavailable(DataPlaneError):
+    """The data-plane controller or storage path is unavailable."""
+
+
+class DataPlaneTimeout(DataPlaneError, TimeoutError):
+    """A data-plane operation exceeded its caller-visible timeout."""
+
+
+class DataPlaneReadError(DataPlaneError):
+    """A data-plane read or metadata-list operation failed."""
+
+
+class DataPlaneWriteError(DataPlaneError):
+    """A data-plane write operation failed."""
+
+
+class DataPlaneClearError(DataPlaneError):
+    """A data-plane clear/pop/evict operation failed."""
+
+
+class DataPlaneNotReady(DataPlaneError):
+    """Requested data exists but is not ready for consumption."""
+
+
+class DataPlaneBadRequest(DataPlaneError):
+    """The caller supplied invalid keys, fields, partition, or arguments."""
+
+
 class DataPlaneClient(ABC):
     """Stable, swappable data-plane boundary.
 
@@ -415,7 +484,37 @@ class DataPlaneClient(ABC):
             partition_id: Partition the samples live in.
         """
 
-    # ── (C) lifecycle ──────────────────────────────────────────────────
+    # ── (C) recovery/control-plane ─────────────────────────────────────
+
+    @abstractmethod
+    def ping(self, timeout_s: float | None = None) -> None:
+        """Raise if the data-plane request path is not healthy."""
+
+    @abstractmethod
+    def list_metadata(self, partition_id: str) -> list[DataPlaneGroupMeta]:
+        """Return non-consuming rollout-group metadata for ``partition_id``."""
+
+    def depth(self, partition_id: str) -> int:
+        """Count committed, complete groups visible to recovery."""
+        return sum(
+            1
+            for group in self.list_metadata(partition_id)
+            if group.committed and group.is_complete
+        )
+
+    def pop(self, keys: list[str], partition_id: str) -> None:
+        """Remove successfully trained keys from the data plane."""
+        self.clear_samples(sample_ids=keys, partition_id=partition_id)
+
+    def evict(self, keys: list[str], partition_id: str) -> None:
+        """Remove stale or abandoned keys from the data plane."""
+        self.clear_samples(sample_ids=keys, partition_id=partition_id)
+
+    @abstractmethod
+    def get_capabilities(self) -> DataPlaneCapabilities:
+        """Describe backend guarantees relevant to recovery."""
+
+    # ── (D) lifecycle ──────────────────────────────────────────────────
 
     @abstractmethod
     def close(self) -> None:

--- a/nemo_rl/data_plane/observability.py
+++ b/nemo_rl/data_plane/observability.py
@@ -47,7 +47,12 @@ class DataPlaneEvent(TypedDict):
 import torch
 from tensordict import TensorDict
 
-from nemo_rl.data_plane.interfaces import DataPlaneClient, KVBatchMeta
+from nemo_rl.data_plane.interfaces import (
+    DataPlaneCapabilities,
+    DataPlaneClient,
+    DataPlaneGroupMeta,
+    KVBatchMeta,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -195,6 +200,8 @@ class MetricsDataPlaneClient(DataPlaneClient):
             n_bytes = _td_bytes(out)
         elif isinstance(out, KVBatchMeta) and not n_keys:
             n_keys = len(out.sample_ids)
+        elif isinstance(out, list) and not n_keys:
+            n_keys = len(out)
         self._emit(op, partition_id, n_keys, n_bytes, t0, "ok")
         return out
 
@@ -336,6 +343,51 @@ class MetricsDataPlaneClient(DataPlaneClient):
             n_keys=n_keys,
         )
         self._record_clear(partition_id, sample_ids_list)
+
+    def ping(self, timeout_s=None) -> None:
+        self._run(
+            "ping",
+            "",
+            lambda: self._inner.ping(timeout_s=timeout_s),
+        )
+
+    def list_metadata(self, partition_id) -> list[DataPlaneGroupMeta]:
+        out = self._run(
+            "list_metadata",
+            partition_id,
+            lambda: self._inner.list_metadata(partition_id),
+        )
+        return out
+
+    def depth(self, partition_id) -> int:
+        return self._run(
+            "depth",
+            partition_id,
+            lambda: self._inner.depth(partition_id),
+        )
+
+    def pop(self, keys, partition_id) -> None:
+        keys_list = keys if isinstance(keys, list) else list(keys)
+        self._run(
+            "pop",
+            partition_id,
+            lambda: self._inner.pop(keys_list, partition_id),
+            n_keys=len(keys_list),
+        )
+        self._record_clear(partition_id, keys_list)
+
+    def evict(self, keys, partition_id) -> None:
+        keys_list = keys if isinstance(keys, list) else list(keys)
+        self._run(
+            "evict",
+            partition_id,
+            lambda: self._inner.evict(keys_list, partition_id),
+            n_keys=len(keys_list),
+        )
+        self._record_clear(partition_id, keys_list)
+
+    def get_capabilities(self) -> DataPlaneCapabilities:
+        return self._inner.get_capabilities()
 
     def close(self) -> None:
         self._run(

--- a/tests/unit/data_plane/test_architecture_invariants.py
+++ b/tests/unit/data_plane/test_architecture_invariants.py
@@ -58,6 +58,12 @@ def test_run_grpo_dispatches_both_trainers():
         "get_samples",
         "clear_samples",
         "check_consumption_status",
+        "ping",
+        "list_metadata",
+        "depth",
+        "pop",
+        "evict",
+        "get_capabilities",
         "close",
     ],
 )

--- a/tests/unit/data_plane/test_interface_contract.py
+++ b/tests/unit/data_plane/test_interface_contract.py
@@ -26,6 +26,7 @@ from tensordict import TensorDict
 
 from nemo_rl.data_plane import (
     DataPlaneClient,
+    DataPlaneUnavailable,
     KVBatchMeta,
     build_data_plane_client,
 )
@@ -87,6 +88,97 @@ def test_claim_meta_advances_consumption(client: DataPlaneClient):
     assert isinstance(meta, KVBatchMeta)
     assert meta.size == 2
     assert client.check_consumption_status("p", ["read"])
+
+
+def test_recovery_metadata_is_non_consuming(client: DataPlaneClient):
+    client.register_partition(
+        partition_id="p",
+        fields=["x"],
+        num_samples=3,
+        consumer_tasks=["read"],
+    )
+    fields = TensorDict({"x": torch.tensor([10, 20, 30])}, batch_size=[3])
+    client.put_samples(
+        sample_ids=["a", "b"],
+        partition_id="p",
+        fields=fields[:2],
+        tags=[
+            {
+                "group_id": "g1",
+                "weight_version": 2,
+                "created_at": 100.0,
+                "committed": True,
+                "expected_num_keys": 2,
+            },
+            {
+                "group_id": "g1",
+                "weight_version": 2,
+                "created_at": 100.0,
+                "committed": True,
+                "expected_num_keys": 2,
+            },
+        ],
+    )
+    client.put_samples(
+        sample_ids=["c"],
+        partition_id="p",
+        fields=fields[2:],
+        tags=[
+            {
+                "group_id": "g2",
+                "weight_version": 3,
+                "committed": False,
+                "expected_num_keys": 1,
+            }
+        ],
+    )
+
+    first = {group.group_id: group for group in client.list_metadata("p")}
+    second = {group.group_id: group for group in client.list_metadata("p")}
+
+    assert first == second
+    assert first["g1"].keys == ["a", "b"]
+    assert first["g1"].weight_version == 2
+    assert first["g1"].committed
+    assert first["g1"].is_complete
+    assert not first["g2"].committed
+    assert client.depth("p") == 1
+
+    meta = client.claim_meta(
+        partition_id="p", task_name="read", required_fields=["x"], batch_size=3
+    )
+    assert meta.sample_ids == ["a", "b", "c"]
+
+
+def test_recovery_pop_and_evict_remove_keys(client: DataPlaneClient):
+    client.register_partition(
+        partition_id="p",
+        fields=["x"],
+        num_samples=3,
+        consumer_tasks=["read"],
+    )
+    client.put_samples(
+        sample_ids=["a", "b", "c"],
+        partition_id="p",
+        fields=TensorDict({"x": torch.tensor([1, 2, 3])}, batch_size=[3]),
+        tags=[
+            {"group_id": "trained", "committed": True},
+            {"group_id": "trained", "committed": True},
+            {"group_id": "stale", "committed": False},
+        ],
+    )
+
+    client.pop(keys=["a", "b"], partition_id="p")
+    assert [group.group_id for group in client.list_metadata("p")] == ["stale"]
+
+    client.evict(keys=["c"], partition_id="p")
+    assert client.list_metadata("p") == []
+
+
+def test_ping_reports_closed_client(client: DataPlaneClient):
+    client.close()
+    with pytest.raises(DataPlaneUnavailable):
+        client.ping()
 
 
 def test_get_data_requires_field_selection(client: DataPlaneClient):

--- a/tests/unit/data_plane/test_observability.py
+++ b/tests/unit/data_plane/test_observability.py
@@ -89,6 +89,30 @@ def test_register_and_clear_recorded(wrapped_client):
     assert ops.count("clear") == 1
 
 
+def test_recovery_ops_recorded(wrapped_client):
+    client, events = wrapped_client
+    client.register_partition(
+        partition_id="p", fields=["x"], num_samples=1, consumer_tasks=["r"]
+    )
+    client.put_samples(
+        sample_ids=["a"],
+        partition_id="p",
+        fields=TensorDict({"x": torch.ones(1)}, batch_size=[1]),
+        tags=[{"group_id": "g", "committed": True}],
+    )
+
+    client.ping()
+    assert client.depth("p") == 1
+    groups = client.list_metadata("p")
+    client.pop(keys=groups[0].keys, partition_id="p")
+
+    ops = [e["op"] for e in events]
+    assert "ping" in ops
+    assert "depth" in ops
+    assert "list_metadata" in ops
+    assert "pop" in ops
+
+
 def test_error_status_recorded_and_reraised(wrapped_client):
     """Decorator does NOT swallow errors — re-raise after recording."""
     client, events = wrapped_client

--- a/tests/unit/data_plane/test_smoke.py
+++ b/tests/unit/data_plane/test_smoke.py
@@ -90,6 +90,10 @@ def test_dataplane_client_abc_surface() -> None:
         "put_samples",
         "get_samples",
         "clear_samples",
+        # recovery/control-plane
+        "ping",
+        "list_metadata",
+        "get_capabilities",
         # lifecycle
         "close",
     }

--- a/tests/unit/data_plane/test_tq_recovery_api.py
+++ b/tests/unit/data_plane/test_tq_recovery_api.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Recovery API tests for the TransferQueue adapter without booting Ray/TQ."""
+
+from __future__ import annotations
+
+import pytest
+
+from nemo_rl.data_plane.adapters.transfer_queue import TQDataPlaneClient
+from nemo_rl.data_plane.interfaces import (
+    DataPlaneClearError,
+    DataPlaneReadError,
+    DataPlaneTimeout,
+)
+
+
+class _FakeTQ:
+    def __init__(self, listing=None, *, clear_error=None, list_error=None):
+        self.listing = listing or {}
+        self.clear_error = clear_error
+        self.list_error = list_error
+        self.cleared: list[tuple[list[str], str]] = []
+
+    def kv_list(self, partition_id):
+        if self.list_error is not None:
+            raise self.list_error
+        return {partition_id: self.listing.get(partition_id, {})}
+
+    def kv_clear(self, keys, partition_id):
+        if self.clear_error is not None:
+            raise self.clear_error
+        self.cleared.append((list(keys), partition_id))
+
+
+def _client(tq) -> TQDataPlaneClient:
+    client = TQDataPlaneClient.__new__(TQDataPlaneClient)
+    client._tq = tq
+    client._partitions = {}
+    client._closed = False
+    return client
+
+
+def test_tq_list_metadata_groups_key_tags():
+    client = _client(
+        _FakeTQ(
+            {
+                "p": {
+                    "a": {
+                        "group_id": "g",
+                        "weight_version": "4",
+                        "created_at": "12.5",
+                        "committed": "true",
+                        "expected_num_keys": "2",
+                    },
+                    "b": {
+                        "group_id": "g",
+                        "weight_version": 4,
+                        "committed": True,
+                        "expected_num_keys": 2,
+                    },
+                    "c": {"group_id": "partial", "committed": False},
+                }
+            }
+        )
+    )
+
+    groups = {group.group_id: group for group in client.list_metadata("p")}
+
+    assert groups["g"].keys == ["a", "b"]
+    assert groups["g"].weight_version == 4
+    assert groups["g"].created_at == 12.5
+    assert groups["g"].committed
+    assert groups["g"].is_complete
+    assert not groups["partial"].committed
+    assert client.depth("p") == 1
+
+
+def test_tq_clear_errors_are_typed():
+    client = _client(_FakeTQ({"p": {"a": {}}}, clear_error=RuntimeError("clear failed")))
+
+    with pytest.raises(DataPlaneClearError):
+        client.pop(keys=["a"], partition_id="p")
+
+
+def test_tq_list_errors_are_typed():
+    client = _client(_FakeTQ(list_error=RuntimeError("bad metadata")))
+
+    with pytest.raises(DataPlaneReadError):
+        client.list_metadata("p")
+
+
+def test_tq_call_timeout_is_typed():
+    client = _client(_FakeTQ())
+
+    with pytest.raises(DataPlaneTimeout):
+        client._call_tq(
+            "hang",
+            lambda: __import__("time").sleep(1.0),
+            DataPlaneReadError,
+            timeout_s=0.001,
+        )


### PR DESCRIPTION
# What does this PR do ?

Adds the recovery/control-plane API surface that the async SingleController needs to coordinate TransferQueue from metadata only, without moving tensor payloads through the controller.

# Issues

N/A

# Usage

The async controller-facing methods added to `DataPlaneClient` are:

```python
dp_client.ping(timeout_s=1.0)
groups = dp_client.list_metadata(partition_id="train")
ready_groups = [g for g in groups if g.committed and g.is_complete]
depth = dp_client.depth(partition_id="train")
dp_client.pop(keys=trained_keys, partition_id="train")
dp_client.evict(keys=stale_keys, partition_id="train")
caps = dp_client.get_capabilities()
```

## Methods Added for Async Controller Support

- `ping(timeout_s)` health-checks the real data-plane request path so SingleController can detect data-plane/TQ availability failures.
- `list_metadata(partition_id) -> list[DataPlaneGroupMeta]` returns non-consuming rollout-group metadata. This lets SingleController inspect queued groups without advancing TQ consumer counters or fetching tensors.
- `depth(partition_id) -> int` counts committed, complete groups visible to recovery. This supports rebuilding queue capacity after controller or data-plane recovery.
- `pop(keys, partition_id)` removes successfully trained keys. The base implementation routes through `clear_samples()`, and the TQ adapter translates that to backend `kv_clear`.
- `evict(keys, partition_id)` removes stale or abandoned keys, using the same `clear_samples()` path.
- `get_capabilities() -> DataPlaneCapabilities` exposes backend recovery guarantees such as persistent recovery, server-side filtering, atomic batch put, and verified clear support.

## Supporting Types and Behavior

- Adds `DataPlaneGroupMeta` for control-plane-only rollout group records: `group_id`, `keys`, `weight_version`, `created_at`, `committed`, `expected_num_keys`, `size_bytes`, and `tags`.
- Adds `DataPlaneCapabilities` so adapters can advertise recovery-relevant behavior.
- Adds typed data-plane failures including `DataPlaneUnavailable`, `DataPlaneTimeout`, `DataPlaneReadError`, `DataPlaneWriteError`, `DataPlaneClearError`, and `DataPlaneBadRequest`.
- Updates `TQDataPlaneClient` to translate Ray/TQ/storage errors into typed data-plane exceptions.
- Updates the NoOp adapter and `MetricsDataPlaneClient` so the recovery API is testable and observable without booting Ray/TQ.

## Why This Helps Async SingleController

SingleController needs to orchestrate async rollout, training, recovery, cleanup, and backpressure while preserving the invariant that it never handles tensor payloads. These APIs give it a metadata-only boundary:

- `list_metadata()` lets SC reconstruct queue state and select trainable groups.
- `depth()` lets SC rebuild capacity accounting after restart or TQ recovery.
- `pop()` centralizes cleanup of rows that trained successfully.
- `evict()` gives SC an explicit stale-row cleanup path.
- `ping()` and typed failures give SC clear recovery triggers instead of parsing generic Ray/TQ exceptions.

This PR does not implement SingleController. It adds the TransferQueue/DataPlane support methods needed by that controller.

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

Testing was not run after the rebase per request. An earlier `uv run pytest ...` attempt did not execute tests because this workspace does not have the repo-required Python `3.13.13` interpreter available to `uv`.
