### PR TITLE
fix: remove stale Penguin reference from async_utils comment

### DIFF
--- a/nemo_rl/algorithms/async_utils.py
+++ b/nemo_rl/algorithms/async_utils.py
@@ -1170,7 +1170,7 @@ class AsyncTrajectoryCollector:
                 f"❌ Error in prompt group worker (prompt_idx={prompt_idx}, target_weight={target_weight_version}, retry={retry_count}): {e}"
             )
 
-            # Retry logic for transient errors (e.g., HTTP 500 from Penguin server)
+            # Retry logic for transient errors (e.g., HTTP 500 from nemo_gym server)
             if retry_count < MAX_RETRIES and self.running:
                 retry_delay = RETRY_DELAY_BASE * (2 ** retry_count)  # Exponential backoff
                 print(


### PR DESCRIPTION
## What

Issue #2273 points to a leftover `Penguin` reference in `nemo_rl/algorithms/async_utils.py:1173` on the `super-v3` branch. Penguin was renamed to `nemo_gym`. This PR updates the comment to match.

```diff
- # Retry logic for transient errors (e.g., HTTP 500 from Penguin server)
+ # Retry logic for transient errors (e.g., HTTP 500 from nemo_gym server)
```

## Why

Stale internal name in a code comment — minor but visible to anyone reading the async retry path.

## Scope

- 1 line, comment-only.
- No behavioural change.
- Targets `super-v3` (where the reference still exists; `main` has already been refactored).

Closes #2273