### PR TITLE
fix: pass trust_remote_code=True to remaining AutoConfig.from_pretrained sites

### DIFF
--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -148,8 +148,12 @@ def check_vocab_equality(
     )
 
     # 3) Chech model.config.vocab_size to guarantee the last dimension of the logits is the same
-    student_config = AutoConfig.from_pretrained(student_model_name)
-    teacher_config = AutoConfig.from_pretrained(teacher_model_name)
+    student_config = AutoConfig.from_pretrained(
+        student_model_name, trust_remote_code=True
+    )
+    teacher_config = AutoConfig.from_pretrained(
+        teacher_model_name, trust_remote_code=True
+    )
     assert student_config.vocab_size == teacher_config.vocab_size, (
         f"Model config vocab sizes differ between student and teacher. {skip_hint}"
     )

--- a/nemo_rl/models/generation/vllm/quantization/fp8.py
+++ b/nemo_rl/models/generation/vllm/quantization/fp8.py
@@ -154,7 +154,7 @@ def apply_fp8_patches(self, fp8_config):
 
 
 def init_fp8(vllm_cfg, model_name, model_parallel_size):
-    config = AutoConfig.from_pretrained(model_name)
+    config = AutoConfig.from_pretrained(model_name, trust_remote_code=True)
     global global_fp8_config
     # Determine if we're using FP8 weights based on precision setting
     use_fp8_weights = vllm_cfg.get("precision") == "fp8"

--- a/nemo_rl/models/megatron/draft/utils.py
+++ b/nemo_rl/models/megatron/draft/utils.py
@@ -1188,7 +1188,11 @@ def build_draft_model(
     )
 
     model_name = draft_config.get("model_name")
-    hf_config = AutoConfig.from_pretrained(model_name).to_dict() if model_name else {}
+    hf_config = (
+        AutoConfig.from_pretrained(model_name, trust_remote_code=True).to_dict()
+        if model_name
+        else {}
+    )
     draft_num_layers = draft_config.get("num_layers")
     config = TransformerConfig(
         normalization="RMSNorm",


### PR DESCRIPTION
# What does this PR do ?

Three call sites in the codebase still invoked `AutoConfig.from_pretrained` without `trust_remote_code=True`. This crashes for any model that ships custom modeling code via `auto_map` in `config.json`, since `transformers` then tries to interactively prompt the user, which raises `EOFError` inside a Ray worker (stdin is closed) and finally surfaces the underlying `ValueError`:

```
ValueError: The repository <path> contains custom code which must be executed
to correctly load the model. ... Please pass the argument
`trust_remote_code=True` to allow custom code to be run.
```

The rest of the codebase already passes `trust_remote_code=True` at every other `from_pretrained` site (`flops_tracker.py`, `native_checkpoint.py`, `sglang_worker.py`, `vllm_worker.py`, `dtensor_policy_worker.py`, `automodel/setup.py`, `huggingface/common.py`, `megatron/setup.py`, `megatron/community_import.py`, `algorithms/utils.py`), so this PR just restores consistency at the three remaining sites.

Patched sites:

| File | Function | Why it crashes |
|---|---|---|
| `nemo_rl/algorithms/distillation.py` | `check_vocab_equality` | Probes student and teacher configs at setup. The crash is fatal because it happens before any model weights are loaded, so distillation is fully blocked for any custom-arch student or teacher. |
| `nemo_rl/models/generation/vllm/quantization/fp8.py` | `init_fp8` | Probes the model config to decide FP8 quant plumbing for vLLM. |
| `nemo_rl/models/megatron/draft/utils.py` | `build_draft_model` | Probes the draft model config for Megatron speculative decoding. |

The `distillation.py` site is the one I actually hit in practice (on-policy distillation with a custom-arch HF student that ships `modeling_*.py` and `configuration_*.py` via `auto_map`). The other two are the same precondition violation in lower-traffic paths and were caught while looking at the surrounding `AutoConfig.from_pretrained` usages.

# Issues

None filed; this is a small consistency fix discovered while debugging a custom-arch distillation run.

# Usage

No new API or configuration. After this patch a distillation run with a custom-arch student or teacher, e.g.

```yaml
policy:
  model_name: /path/to/custom-arch-student   # config.json has auto_map.AutoModelForCausalLM
distillation:
  teacher:
    model_name: /path/to/custom-arch-teacher
```

proceeds past `check_vocab_equality` instead of dying at setup.

# Before your PR is \"Ready for review\"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

* No new tests. This is a 3 line consistency fix mirroring existing call sites; happy to add a unit test that mocks `AutoConfig.from_pretrained` and asserts the kwarg is forwarded if the reviewers prefer.
* Verified locally by applying the same patch in a downstream fork and re-running the failing distillation recipe; `check_vocab_equality` passes and the driver proceeds normally.