### PR TITLE
feat: per-task validation metrics in GRPO/Distillation, optional max_val_samples

### DIFF
--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -976,6 +976,10 @@ def validate(
         total_rewards = []  # Can be any metric. Setted to 'accuracy' by default.
         total_lengths = []
         all_message_logs = []  # Collect all message logs
+        # Per-task accuracy breakdown. Multi-validation concatenates several
+        # datasets into one dataloader; without this split the aggregated
+        # `accuracy` hides per-task progress (e.g. gsm8k vs math500).
+        per_task_rewards: dict[str, list[float]] = {}
 
         max_val_samples = master_config.distillation.get("max_val_samples")
         if max_val_samples is None:
@@ -1011,9 +1015,20 @@ def validate(
                     greedy=False,
                 )
             rewards = val_batch["total_reward"]
+            rewards_list = rewards.tolist()
 
-            total_rewards.extend(rewards.tolist())
+            total_rewards.extend(rewards_list)
             total_lengths.append(gen_metrics["mean_gen_tokens_per_sample"])
+
+            # task_name is set per sample by rl_collate_fn from
+            # DatumSpec.task_name. Skip entries that lack it for backwards
+            # compatibility with single-task or legacy datasets.
+            batch_task_names = val_batch.get("task_name")
+            if batch_task_names is not None:
+                for r, t in zip(rewards_list, batch_task_names):
+                    if t is None:
+                        continue
+                    per_task_rewards.setdefault(t, []).append(r)
 
             # Collect message logs for later display
             to_env = [
@@ -1037,6 +1052,11 @@ def validate(
             "accuracy": accuracy,
             "avg_length": avg_length,
         }
+        for task_name, task_rewards in per_task_rewards.items():
+            val_metrics[f"accuracy_{task_name}"] = sum(task_rewards) / len(
+                task_rewards
+            )
+            val_metrics[f"num_samples_{task_name}"] = len(task_rewards)
 
         # Print sample conversations only once at the end of validation
         try:
@@ -1062,6 +1082,14 @@ def validate(
     print(f"    • Accuracy: {accuracy:.4f}")
     print(f"    • Average response length: {avg_length:.1f} tokens")
     print(f"    • Samples processed: {len(total_rewards)}", flush=True)
+    if per_task_rewards:
+        print("    • Per-task accuracy:")
+        for task_name in sorted(per_task_rewards.keys()):
+            tr = per_task_rewards[task_name]
+            print(
+                f"        - {task_name}: {sum(tr) / len(tr):.4f} (n={len(tr)})",
+                flush=True,
+            )
 
     # Print timing information
     print("\n  ⏱️  Validation Timing:")

--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -83,7 +83,7 @@ class DistillationConfig(TypedDict):
     # Whether to run validation on the last training step. Setting this to True ensures the
     # final checkpoint has validation metrics, which is required for get_best_checkpoint_path().
     val_at_end: bool
-    max_val_samples: int
+    max_val_samples: NotRequired[int]
     topk_logits_k: int
     seed: int
 
@@ -977,11 +977,13 @@ def validate(
         total_lengths = []
         all_message_logs = []  # Collect all message logs
 
-        max_batches = (
-            master_config.distillation["max_val_samples"]
-            + master_config.distillation["val_batch_size"]
-            - 1
-        ) // master_config.distillation["val_batch_size"]
+        max_val_samples = master_config.distillation.get("max_val_samples")
+        if max_val_samples is None:
+            max_batches = len(val_dataloader)
+        else:
+            max_batches = (
+                max_val_samples // master_config.distillation["val_batch_size"]
+            )
         for batch_idx, val_batch in enumerate(val_dataloader):
             if batch_idx >= max_batches:
                 break

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -2288,10 +2288,11 @@ def validate(
         total_lengths = []
         all_message_logs = []  # Collect all message logs
 
-        max_batches = (
-            master_config.grpo["max_val_samples"]
-            // master_config.grpo["val_batch_size"]
-        )
+        max_val_samples = master_config.grpo.get("max_val_samples")
+        if max_val_samples is None:
+            max_batches = len(val_dataloader)
+        else:
+            max_batches = max_val_samples // master_config.grpo["val_batch_size"]
         for batch_idx, val_batch in enumerate(val_dataloader):
             if batch_idx >= max_batches:
                 break

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -2287,6 +2287,10 @@ def validate(
         total_rewards = []
         total_lengths = []
         all_message_logs = []  # Collect all message logs
+        # Per-task accuracy breakdown. Multi-validation concatenates several
+        # datasets into one dataloader; without this split the aggregated
+        # `accuracy` hides per-task progress (e.g. gsm8k vs math500).
+        per_task_rewards: dict[str, list[float]] = {}
 
         max_val_samples = master_config.grpo.get("max_val_samples")
         if max_val_samples is None:
@@ -2337,8 +2341,19 @@ def validate(
                     greedy=False,
                 )
 
-            total_rewards.extend(val_batch["total_reward"].tolist())
+            rewards_list = val_batch["total_reward"].tolist()
+            total_rewards.extend(rewards_list)
             total_lengths.append(gen_metrics["mean_gen_tokens_per_sample"])
+
+            # task_name is set per sample by rl_collate_fn from
+            # DatumSpec.task_name. Skip entries that lack it for backwards
+            # compatibility with single-task or legacy datasets.
+            batch_task_names = val_batch.get("task_name")
+            if batch_task_names is not None:
+                for r, t in zip(rewards_list, batch_task_names):
+                    if t is None:
+                        continue
+                    per_task_rewards.setdefault(t, []).append(r)
 
             # Collect message logs for later display
             to_env = [
@@ -2367,6 +2382,11 @@ def validate(
             "avg_length": avg_length,
             **additional_metrics_to_report,
         }
+        for task_name, task_rewards in per_task_rewards.items():
+            val_metrics[f"accuracy_{task_name}"] = sum(task_rewards) / len(
+                task_rewards
+            )
+            val_metrics[f"num_samples_{task_name}"] = len(task_rewards)
 
         # Print sample conversations only once at the end of validation
         try:
@@ -2392,6 +2412,14 @@ def validate(
     print(f"    • Accuracy: {accuracy:.4f}")
     print(f"    • Average response length: {avg_length:.1f} tokens")
     print(f"    • Samples processed: {len(total_rewards)}", flush=True)
+    if per_task_rewards:
+        print("    • Per-task accuracy:")
+        for task_name in sorted(per_task_rewards.keys()):
+            tr = per_task_rewards[task_name]
+            print(
+                f"        - {task_name}: {sum(tr) / len(tr):.4f} (n={len(tr)})",
+                flush=True,
+            )
 
     # Print timing information
     print("\n  ⏱️  Validation Timing:")

--- a/tests/unit/algorithms/test_distillation.py
+++ b/tests/unit/algorithms/test_distillation.py
@@ -329,6 +329,58 @@ def test_validate_iterates_full_dataloader_when_max_val_samples_is_none(
     assert mock_rollout.call_count == expected_batches
 
 
+def test_validate_emits_per_task_accuracy_keys(mock_components):
+    """Multi-task validation produces accuracy_<task> and num_samples_<task> entries."""
+    config = mock_components["master_config"]
+    config.distillation["max_val_samples"] = 4
+    config.distillation["val_batch_size"] = 1
+
+    # Two batches per task; reward 1.0 for gsm8k, 0.0 for math500.
+    task_sequence = ["gsm8k", "math500", "gsm8k", "math500"]
+    reward_sequence = [1.0, 0.0, 1.0, 0.0]
+
+    def make_batch(task, reward):
+        batch = BatchedDataDict[DatumSpec](
+            {
+                "message_log": [
+                    [
+                        {"token_ids": torch.tensor([1, 2]), "role": "user", "content": "q"},
+                        {"token_ids": torch.tensor([3, 4]), "role": "assistant", "content": "a"},
+                    ]
+                ],
+                "loss_multiplier": torch.tensor([1.0]),
+                "task_name": [task],
+                "extra_env_info": [{}],
+                "length": torch.tensor([4]),
+                "idx": torch.tensor([0]),
+                "total_reward": torch.tensor([reward]),
+            }
+        )
+        return batch
+
+    rollout_batches = [make_batch(t, r) for t, r in zip(task_sequence, reward_sequence)]
+
+    with patch.object(distil_mod, "run_multi_turn_rollout") as mock_rollout:
+        mock_rollout.side_effect = [
+            (b, {"mean_gen_tokens_per_sample": 4.0}) for b in rollout_batches
+        ]
+        val_metrics, _ = validate(
+            mock_components["student_generation"],
+            mock_components["val_dataloader"],
+            mock_components["tokenizer"],
+            mock_components["val_task_to_env"],
+            step=0,
+            master_config=config,
+        )
+
+    assert val_metrics["accuracy_gsm8k"] == 1.0
+    assert val_metrics["accuracy_math500"] == 0.0
+    assert val_metrics["num_samples_gsm8k"] == 2
+    assert val_metrics["num_samples_math500"] == 2
+    # Aggregated key is preserved with the same definition (sample-weighted mean).
+    assert val_metrics["accuracy"] == pytest.approx(0.5)
+
+
 def test_validate_floor_divides_max_val_samples_by_val_batch_size(mock_components):
     """When max_val_samples is set, validate truncates with floor division (matches GRPO)."""
     config = mock_components["master_config"]

--- a/tests/unit/algorithms/test_distillation.py
+++ b/tests/unit/algorithms/test_distillation.py
@@ -297,6 +297,61 @@ def test_validate_function(mock_components):
     # Note: validate() function itself doesn't call logger.log_metrics - that's done by the caller
 
 
+def _rollout_return_for(batch):
+    enriched = BatchedDataDict[DatumSpec](dict(batch))
+    enriched["total_reward"] = torch.tensor([1.0])
+    return (enriched, {"mean_gen_tokens_per_sample": 10.0})
+
+
+def test_validate_iterates_full_dataloader_when_max_val_samples_is_none(
+    mock_components,
+):
+    """When max_val_samples is omitted, validate iterates the entire val_dataloader."""
+    config = mock_components["master_config"]
+    # Simulate a recipe that does not specify max_val_samples.
+    config.distillation.pop("max_val_samples", None)
+    config.distillation["val_batch_size"] = 1
+
+    expected_batches = mock_components["val_dataloader"].__len__.return_value
+    sample_batch = next(iter(mock_components["val_dataloader"]))
+
+    with patch.object(distil_mod, "run_multi_turn_rollout") as mock_rollout:
+        mock_rollout.return_value = _rollout_return_for(sample_batch)
+        validate(
+            mock_components["student_generation"],
+            mock_components["val_dataloader"],
+            mock_components["tokenizer"],
+            mock_components["val_task_to_env"],
+            step=0,
+            master_config=config,
+        )
+
+    assert mock_rollout.call_count == expected_batches
+
+
+def test_validate_floor_divides_max_val_samples_by_val_batch_size(mock_components):
+    """When max_val_samples is set, validate truncates with floor division (matches GRPO)."""
+    config = mock_components["master_config"]
+    config.distillation["max_val_samples"] = 7
+    config.distillation["val_batch_size"] = 2
+
+    sample_batch = next(iter(mock_components["val_dataloader"]))
+
+    with patch.object(distil_mod, "run_multi_turn_rollout") as mock_rollout:
+        mock_rollout.return_value = _rollout_return_for(sample_batch)
+        validate(
+            mock_components["student_generation"],
+            mock_components["val_dataloader"],
+            mock_components["tokenizer"],
+            mock_components["val_task_to_env"],
+            step=0,
+            master_config=config,
+        )
+
+    # 7 // 2 == 3 batches; previous ceiling-division behaviour would have been 4.
+    assert mock_rollout.call_count == 3
+
+
 def test_check_vocab_equality_pass(monkeypatch):
     student_tokenizer = MagicMock()
     student_tokenizer.get_vocab.return_value = {"a": 0, "b": 1}

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -2433,6 +2433,108 @@ class TestValidateFunction:
 
         assert mock_rollout.call_count == num_batches
 
+    def test_validate_emits_per_task_accuracy_keys(self):
+        """Multi-task validation produces accuracy_<task> and num_samples_<task> keys."""
+        mock_policy_gen = MagicMock()
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.pad_token_id = 0
+
+        def make_batch(task, reward):
+            return BatchedDataDict[DatumSpec](
+                {
+                    "message_log": [
+                        [
+                            {
+                                "role": "user",
+                                "content": "q",
+                                "token_ids": torch.tensor([1, 2]),
+                            },
+                            {
+                                "role": "assistant",
+                                "content": "a",
+                                "token_ids": torch.tensor([3, 4]),
+                            },
+                        ],
+                    ],
+                    "task_name": [task],
+                    "extra_env_info": [{}],
+                    "loss_multiplier": torch.tensor([1.0]),
+                    "idx": torch.tensor([0]),
+                    "length": torch.tensor([4]),
+                    "total_reward": torch.tensor([reward]),
+                }
+            )
+
+        # Two batches per task; gsm8k all correct, math500 all wrong.
+        task_sequence = ["gsm8k", "math500", "gsm8k", "math500"]
+        reward_sequence = [1.0, 0.0, 1.0, 0.0]
+        rollout_batches = [
+            make_batch(t, r) for t, r in zip(task_sequence, reward_sequence)
+        ]
+
+        mock_dataloader = MagicMock(spec=StatefulDataLoader)
+        mock_dataloader.__iter__ = MagicMock(
+            return_value=iter([make_batch("placeholder", 0.0)] * len(rollout_batches))
+        )
+        mock_dataloader.__len__ = MagicMock(return_value=len(rollout_batches))
+
+        mock_env = MagicMock(spec=EnvironmentInterface)
+        mock_env.global_post_process_and_metrics.return_value = (
+            rollout_batches[0],
+            {},
+        )
+
+        mock_config = MasterConfig.model_construct(
+            **{
+                "grpo": {
+                    "max_val_samples": 4,
+                    "val_batch_size": 1,
+                    "max_rollout_turns": 1,
+                },
+                "policy": {
+                    "max_total_sequence_length": 2048,
+                    "generation": {
+                        "temperature": 1.0,
+                        "top_p": 1.0,
+                        "top_k": None,
+                        "backend": "vllm",
+                        "colocated": {"enabled": True},
+                        "vllm_cfg": {"async_engine": False},
+                    },
+                },
+                "logger": {"num_val_samples_to_print": 1},
+            }
+        )
+
+        with patch("nemo_rl.algorithms.grpo.run_multi_turn_rollout") as mock_rollout:
+            mock_rollout.side_effect = [
+                (b, {"mean_gen_tokens_per_sample": 4.0}) for b in rollout_batches
+            ]
+            with patch(
+                "nemo_rl.algorithms.grpo._should_use_nemo_gym", return_value=False
+            ):
+                with patch(
+                    "nemo_rl.algorithms.grpo._should_use_async_rollouts",
+                    return_value=False,
+                ):
+                    with patch("nemo_rl.algorithms.grpo.print_message_log_samples"):
+                        val_metrics, _ = validate(
+                            mock_policy_gen,
+                            mock_dataloader,
+                            mock_tokenizer,
+                            {"math": mock_env},
+                            step=0,
+                            master_config=mock_config,
+                            logger=None,
+                        )
+
+        assert val_metrics["accuracy_gsm8k"] == 1.0
+        assert val_metrics["accuracy_math500"] == 0.0
+        assert val_metrics["num_samples_gsm8k"] == 2
+        assert val_metrics["num_samples_math500"] == 2
+        # Aggregated key is preserved with the same definition.
+        assert val_metrics["accuracy"] == pytest.approx(0.5)
+
 
 # ============================================================================
 # Tests for compute_and_apply_seq_logprob_error_masking function

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -2346,6 +2346,93 @@ class TestValidateFunction:
         assert val_metrics == {}
         assert timing == {}
 
+    def test_validate_iterates_full_dataloader_when_max_val_samples_is_none(self):
+        """When max_val_samples is None, validate iterates the entire val_dataloader."""
+        mock_policy_gen = MagicMock()
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.pad_token_id = 0
+
+        mock_batch = BatchedDataDict[DatumSpec](
+            {
+                "message_log": [
+                    [
+                        {
+                            "role": "user",
+                            "content": "test",
+                            "token_ids": torch.tensor([1, 2, 3]),
+                        },
+                        {
+                            "role": "assistant",
+                            "content": "response",
+                            "token_ids": torch.tensor([4, 5, 6]),
+                        },
+                    ],
+                ],
+                "task_name": ["math"],
+                "extra_env_info": [{}],
+                "loss_multiplier": torch.tensor([1.0]),
+                "idx": torch.tensor([0]),
+                "length": torch.tensor([6]),
+                "total_reward": torch.tensor([1.0]),
+            }
+        )
+
+        num_batches = 3
+        mock_dataloader = MagicMock(spec=StatefulDataLoader)
+        mock_dataloader.__iter__ = MagicMock(
+            return_value=iter([mock_batch] * num_batches)
+        )
+        mock_dataloader.__len__ = MagicMock(return_value=num_batches)
+
+        mock_env = MagicMock(spec=EnvironmentInterface)
+        mock_env.global_post_process_and_metrics.return_value = (mock_batch, {})
+
+        mock_config = MasterConfig.model_construct(
+            **{
+                "grpo": {
+                    "max_val_samples": None,
+                    "val_batch_size": 1,
+                    "max_rollout_turns": 1,
+                },
+                "policy": {
+                    "max_total_sequence_length": 2048,
+                    "generation": {
+                        "temperature": 1.0,
+                        "top_p": 1.0,
+                        "top_k": None,
+                        "backend": "vllm",
+                        "colocated": {"enabled": True},
+                        "vllm_cfg": {"async_engine": False},
+                    },
+                },
+                "logger": {"num_val_samples_to_print": 1},
+            }
+        )
+
+        mock_rollout_metrics = {"mean_gen_tokens_per_sample": 10.0}
+
+        with patch("nemo_rl.algorithms.grpo.run_multi_turn_rollout") as mock_rollout:
+            mock_rollout.return_value = (mock_batch, mock_rollout_metrics)
+            with patch(
+                "nemo_rl.algorithms.grpo._should_use_nemo_gym", return_value=False
+            ):
+                with patch(
+                    "nemo_rl.algorithms.grpo._should_use_async_rollouts",
+                    return_value=False,
+                ):
+                    with patch("nemo_rl.algorithms.grpo.print_message_log_samples"):
+                        validate(
+                            mock_policy_gen,
+                            mock_dataloader,
+                            mock_tokenizer,
+                            {"math": mock_env},
+                            step=0,
+                            master_config=mock_config,
+                            logger=None,
+                        )
+
+        assert mock_rollout.call_count == num_batches
+
 
 # ============================================================================
 # Tests for compute_and_apply_seq_logprob_error_masking function


### PR DESCRIPTION
# What does this PR do ?

Closes #2497.

Two related improvements to the `validate()` function in GRPO and Distillation, bundled into one PR because they touch the same function in the same way.

### 1. Per-task validation metrics (main change)

When `data.validation` is configured as a list of multiple datasets the multi-validation path correctly loads them all and dispatches per-task to the right environment during rollout, but the validation aggregator collapses everything into a single sample-weighted `accuracy` and `avg_length`. Per-task progress (e.g. gsm8k vs math500) is silently lost.

`task_name` is already on every sample (`DatumSpec.task_name`, preserved through `rl_collate_fn` into `val_batch[\"task_name\"]`); `validate()` simply did not read it. This PR teaches both `validate()` functions to track rewards per task during the loop and emit:

* `accuracy_<task>` for each task seen
* `num_samples_<task>` for each task seen

The aggregated `accuracy` key is preserved unchanged so existing dashboards continue to work. Single-task runs and legacy datasets without `task_name` are unaffected (the per-task block is skipped).

The driver-log summary also gains a per-task block:

```
📊 Validation Results:
    • Accuracy: 0.5957
    • Average response length: 512.8 tokens
    • Samples processed: 1819
    • Per-task accuracy:
        - data-math500: 0.4320 (n=500)
        - gsm8k: 0.6580 (n=1319)
```

### 2. `max_val_samples` becomes optional, Distillation truncation matches GRPO

Bundled because the patches sit a few lines apart in the same `validate()` block.

* `grpo.GRPOConfig.max_val_samples` was already typed as `int | None` (`grpo.py:150`) for NeMo-Gym compatibility but the main path crashed on `None`. Distillation's TypedDict required `int` outright. Both now accept `None`/absent and fall back to the full `val_dataloader`.
* Distillation's truncation switches from ceiling division to floor division, matching GRPO. Behaviour change is bounded to runs whose `max_val_samples` is not divisible by `val_batch_size`; all shipped recipes under `examples/configs/recipes/llm/` use values that divide cleanly so none are affected.

### Files touched

| File | Change |
|---|---|
| `nemo_rl/algorithms/grpo.py` | Per-task tracking in `validate()`. Optional `max_val_samples` branch. Per-task block in summary print. |
| `nemo_rl/algorithms/distillation.py` | Same per-task tracking. TypedDict widened to `NotRequired[int]`. Truncation switched to floor division. |
| `tests/unit/algorithms/test_grpo.py` | `test_validate_emits_per_task_accuracy_keys`, `test_validate_iterates_full_dataloader_when_max_val_samples_is_none`. |
| `tests/unit/algorithms/test_distillation.py` | Same plus `test_validate_floor_divides_max_val_samples_by_val_batch_size` to guard the GRPO/Distillation parity. |

### Out of scope

* **DPO** already emits per-dataset metrics via its `dict[str, StatefulDataLoader]` architecture (see `nemo_rl/algorithms/dpo.py:332-377`, prefix `validation-{dataset_name}`). No change needed.
* **NeMo-Gym path in GRPO** is left untouched. It clobbers `val_batch_size` to `len(val_dataset)` at setup time, which is specific to its single-batch eval and not something the main paths should adopt.
* Exemplar YAMLs (`examples/configs/grpo_math_1B.yaml`, `examples/configs/distillation_math.yaml`) keep their explicit `max_val_samples` so the recommended default stays documented.

### Backwards compatibility

* Aggregated `validation/accuracy` key unchanged in value.
* Single-task validation: `per_task_rewards` ends up with one key, you get one extra `validation/accuracy_<the-only-task>` metric. Harmless.
* Datasets without `task_name`: per-task block is skipped, behaviour matches the old code.

# Issues

Closes #2497.

# Usage

A recipe with multiple validation datasets now reports per-task metrics:

```yaml
data:
  validation:
    - dataset_name: gsm8k
      split: test
    - dataset_name: ResponseDataset
      data_path: data/math500.parquet
distillation:
  val_batch_size: 8
  # max_val_samples omitted -> evaluate the entire val dataset
```

wandb will plot `validation/accuracy`, `validation/accuracy_gsm8k`, and `validation/accuracy_ResponseDataset` separately. The existing aggregated `validation/accuracy` panel keeps working unchanged.

# Before your PR is \"Ready for review\"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

* Followed the `config-conventions` skill: optional `max_val_samples` field expressed via `NotRequired`, no hidden defaults, exemplar YAMLs keep their explicit recommended values.
* Two commits, one per logical change, to make the per-task and the max_val_samples patches reviewable independently.
* Open question for reviewers: should task-name slugification be added (e.g. `data-math500` → `data_math500`)? Hyphens work in wandb but render slightly oddly in some downstream stores. Current patch keeps the name verbatim; happy to slugify if preferred.
* Branched off `origin/main` in a separate worktree to keep the change isolated from #2496 (`fix/autoconfig-trust-remote-code`); the two PRs touch disjoint files.