### PR TITLE
fix(nemo-gym): clamp max_new_tokens to prompt + output <= max_model_len

### DIFF
--- a/examples/nemo_gym/grpo_nanov3.yaml
+++ b/examples/nemo_gym/grpo_nanov3.yaml
@@ -181,7 +181,7 @@ policy:
 
   generation:
     backend: "vllm"
-    max_new_tokens: 8192
+    max_new_tokens: ${policy.max_total_sequence_length}
     temperature: 1.0
     top_p: 1.0
     top_k: null

--- a/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
+++ b/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
@@ -208,7 +208,7 @@ policy:
 
   generation:
     backend: "vllm"
-    max_new_tokens: 8192
+    max_new_tokens: ${policy.max_total_sequence_length}
     temperature: 1.0
     top_p: 1.0
     top_k: null

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -1143,15 +1143,15 @@ def run_async_nemo_gym_rollout(
         responses_create_params = row["responses_create_params"]
         responses_create_params["temperature"] = generation_config["temperature"]
         responses_create_params["top_p"] = generation_config["top_p"]
-        if generation_config["max_new_tokens"] is not None:
-            existing_max_output_tokens = responses_create_params.get(
-                "max_output_tokens"
-            )
-            responses_create_params["max_output_tokens"] = (
-                min(existing_max_output_tokens, generation_config["max_new_tokens"])
-                if existing_max_output_tokens is not None
-                else generation_config["max_new_tokens"]
-            )
+
+        # Configure max_output_tokens to respect the max_new_tokens setting.
+        # Will clamp max_output_tokens in vllm_worker_async.py so that input + output <= max_seq_len
+        existing_max_output_tokens = responses_create_params.get("max_output_tokens")
+        responses_create_params["max_output_tokens"] = (
+            min(existing_max_output_tokens, generation_config["max_new_tokens"])
+            if existing_max_output_tokens is not None
+            else generation_config["max_new_tokens"]
+        )
 
         row["_rowidx"] = rowidx
 

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -378,9 +378,13 @@ class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
                 self, request, request_max_tokens: int, prompt_token_ids: list[int]
             ) -> None:
                 """Clamp the request's max output tokens so that input + output <= max_model_len."""
-                remaining = max(
-                    0, self.model_config.max_model_len - len(prompt_token_ids)
-                )
+                remaining = self.model_config.max_model_len - len(prompt_token_ids)
+                if remaining <= 0:
+                    raise ValueError(
+                        f"Prompt length ({len(prompt_token_ids)}) fills or exceeds "
+                        f"max_model_len ({self.model_config.max_model_len}). "
+                        f"No room for output tokens."
+                    )
                 max_tokens = min(request_max_tokens, remaining)
                 self._set_max_tokens(request, max_tokens)
 
@@ -411,7 +415,9 @@ class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
                 actual_request_max_tokens = None
                 if isinstance(request, NeMoRLChatCompletionRequest):
                     actual_request_max_tokens = (
-                        request.max_completion_tokens or request.max_tokens
+                        request.max_completion_tokens
+                        if request.max_completion_tokens is not None
+                        else request.max_tokens
                     )
                     # If max_completion_tokens or max_tokens is not set, we don't need to do _clamp_max_tokens.
                     # So we don't need to set the request's max output tokens to 1 here.

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -362,6 +362,28 @@ class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
                 return super().model_post_init(context)
 
         class NeMoRLOpenAIServingMixin:
+            @staticmethod
+            def _set_max_tokens(request, max_tokens: int) -> None:
+                """Set the request's max output tokens.
+
+                Mutates the request in place. Handles both max_completion_tokens (newer OpenAI API)
+                and max_tokens (deprecated but still supported by vLLM).
+                """
+                if request.max_completion_tokens is not None:
+                    request.max_completion_tokens = max_tokens
+                elif request.max_tokens is not None:
+                    request.max_tokens = max_tokens
+
+            def _clamp_max_tokens(
+                self, request, request_max_tokens: int, prompt_token_ids: list[int]
+            ) -> None:
+                """Clamp the request's max output tokens so that input + output <= max_model_len."""
+                remaining = max(
+                    0, self.model_config.max_model_len - len(prompt_token_ids)
+                )
+                max_tokens = min(request_max_tokens, remaining)
+                self._set_max_tokens(request, max_tokens)
+
             # vLLM 0.20 moved chat preprocessing from
             # OpenAIServing._preprocess_chat to OpenAIServingRender.preprocess_chat,
             # so this override now applies via the render subclass.
@@ -383,6 +405,18 @@ class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
                         message["tool_calls"] = list(message["tool_calls"])
 
                 messages_for_replace_prefix_tokens = deepcopy(messages)
+
+                # Temporarily set to 1 so vLLM's pre-tokenization length check passes;
+                # the actual value will be set through _clamp_max_tokens later.
+                actual_request_max_tokens = None
+                if isinstance(request, NeMoRLChatCompletionRequest):
+                    actual_request_max_tokens = (
+                        request.max_completion_tokens or request.max_tokens
+                    )
+                    # If max_completion_tokens or max_tokens is not set, we don't need to do _clamp_max_tokens.
+                    # So we don't need to set the request's max output tokens to 1 here.
+                    if actual_request_max_tokens is not None:
+                        self._set_max_tokens(request, 1)
 
                 try:
                     res = await super().preprocess_chat(
@@ -409,6 +443,13 @@ class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
                     not hasattr(request, "required_prefix_token_ids")
                     or request.required_prefix_token_ids is None
                 ):
+                    # Clamp the request's max output tokens so that input + output <= max_model_len.
+                    if actual_request_max_tokens is not None:
+                        self._clamp_max_tokens(
+                            request,
+                            actual_request_max_tokens,
+                            res[1][0]["prompt_token_ids"],
+                        )
                     return res
 
                 last_assistant_message_idx = None
@@ -457,6 +498,14 @@ class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
                 )
 
                 engine_prompt["prompt_token_ids"] = final_prompt_token_ids
+
+                # Clamp after prefix replacement since the prompt length may have changed.
+                if actual_request_max_tokens is not None:
+                    self._clamp_max_tokens(
+                        request,
+                        actual_request_max_tokens,
+                        final_prompt_token_ids,
+                    )
 
                 return res
 

--- a/tests/functional/grpo_async_gym.sh
+++ b/tests/functional/grpo_async_gym.sh
@@ -66,7 +66,6 @@ uv run coverage run -a --data-file=$PROJECT_ROOT/tests/.coverage --source=$PROJE
     policy.generation.vllm_cfg.tensor_parallel_size=1 \
     policy.generation.vllm_cfg.async_engine=true \
     policy.max_total_sequence_length=512 \
-    policy.generation.max_new_tokens=128 \
     policy.generation.colocated.enabled=false \
     policy.generation.colocated.resources.num_nodes=1 \
     policy.generation.colocated.resources.gpus_per_node=1 \


### PR DESCRIPTION
## Summary

- Revert the hardcoded `max_new_tokens` introduced in #2365.
- Match pre-2365 / native async vLLM behavior: clamp `max_output_tokens` so that `prompt_tokens + max_output_tokens <= max_model_len` (analogous to `allowed_new_tokens` in vLLM's native async path).

## Changes

- `vllm_worker_async.py`: add `_set_max_tokens` / `_clamp_max_tokens` helpers; apply clamping in `_preprocess_chat` for both the normal path and the prefix-replacement path.
- `rollouts.py`: always write `generation_config["max_new_tokens"]` into `responses_create_params["max_output_tokens"]` (remove the `is not None` guard since it's always `not None`).
- Revert config/test changes from #2365: `grpo_nanov3.yaml`, `grpo_workplace_assistant_nemotron_nano_v2_9b.yaml`, `tests/functional/grpo_async_gym.sh`.

## Test plan

- [x] `tests/functional/grpo_async_gym.sh` passes without overriding `max_new_tokens`.
- [x] Behavior is consistent with pre-2365.

cc @binhu-nv 