### PR TITLE
fix: fix preserving dataset merge

### DIFF
--- a/examples/run_sft.py
+++ b/examples/run_sft.py
@@ -17,7 +17,6 @@ import os
 import pprint
 from functools import partial
 
-from datasets import concatenate_datasets
 from omegaconf import OmegaConf
 from transformers import AutoTokenizer
 
@@ -27,6 +26,7 @@ from nemo_rl.data import DataConfig
 from nemo_rl.data.datasets import (
     AllTaskProcessedDataset,
     load_response_dataset,
+    merge_map_style_datasets,
     update_single_dataset_config,
 )
 from nemo_rl.distributed.virtual_cluster import init_ray
@@ -89,7 +89,7 @@ def setup_data(tokenizer: AutoTokenizer, data_config: DataConfig):
         if hasattr(data, "preprocessor") and data.preprocessor is not None:
             task_data_preprocessors[data.task_name] = data.preprocessor
 
-    merged_data = concatenate_datasets([data.dataset for data in data_list])
+    merged_data = merge_map_style_datasets([data.dataset for data in data_list])
     dataset = AllTaskProcessedDataset(
         merged_data,
         tokenizer,
@@ -144,7 +144,7 @@ def setup_data(tokenizer: AutoTokenizer, data_config: DataConfig):
 
     val_dataset = None
     if len(val_data_list) > 0:
-        merged_val_data = concatenate_datasets(val_data_list)
+        merged_val_data = merge_map_style_datasets(val_data_list)
         val_dataset = AllTaskProcessedDataset(
             merged_val_data,
             tokenizer,

--- a/examples/run_sft.py
+++ b/examples/run_sft.py
@@ -26,7 +26,7 @@ from nemo_rl.data import DataConfig
 from nemo_rl.data.datasets import (
     AllTaskProcessedDataset,
     load_response_dataset,
-    merge_map_style_datasets,
+    merge_datasets,
     update_single_dataset_config,
 )
 from nemo_rl.distributed.virtual_cluster import init_ray
@@ -89,7 +89,7 @@ def setup_data(tokenizer: AutoTokenizer, data_config: DataConfig):
         if hasattr(data, "preprocessor") and data.preprocessor is not None:
             task_data_preprocessors[data.task_name] = data.preprocessor
 
-    merged_data = merge_map_style_datasets([data.dataset for data in data_list])
+    merged_data = merge_datasets([data.dataset for data in data_list])
     dataset = AllTaskProcessedDataset(
         merged_data,
         tokenizer,
@@ -144,7 +144,7 @@ def setup_data(tokenizer: AutoTokenizer, data_config: DataConfig):
 
     val_dataset = None
     if len(val_data_list) > 0:
-        merged_val_data = merge_map_style_datasets(val_data_list)
+        merged_val_data = merge_datasets(val_data_list)
         val_dataset = AllTaskProcessedDataset(
             merged_val_data,
             tokenizer,

--- a/nemo_rl/data/datasets/__init__.py
+++ b/nemo_rl/data/datasets/__init__.py
@@ -19,6 +19,7 @@ from nemo_rl.data.datasets.response_datasets import load_response_dataset
 from nemo_rl.data.datasets.utils import (
     assert_no_double_bos,
     extract_necessary_env_names,
+    merge_map_style_datasets,
     update_single_dataset_config,
 )
 
@@ -29,5 +30,6 @@ __all__ = [
     "load_response_dataset",
     "assert_no_double_bos",
     "extract_necessary_env_names",
+    "merge_map_style_datasets",
     "update_single_dataset_config",
 ]

--- a/nemo_rl/data/datasets/__init__.py
+++ b/nemo_rl/data/datasets/__init__.py
@@ -19,7 +19,7 @@ from nemo_rl.data.datasets.response_datasets import load_response_dataset
 from nemo_rl.data.datasets.utils import (
     assert_no_double_bos,
     extract_necessary_env_names,
-    merge_map_style_datasets,
+    merge_datasets,
     update_single_dataset_config,
 )
 
@@ -30,6 +30,6 @@ __all__ = [
     "load_response_dataset",
     "assert_no_double_bos",
     "extract_necessary_env_names",
-    "merge_map_style_datasets",
+    "merge_datasets",
     "update_single_dataset_config",
 ]

--- a/nemo_rl/data/datasets/utils.py
+++ b/nemo_rl/data/datasets/utils.py
@@ -16,12 +16,19 @@ import base64
 import io
 import os
 from pathlib import Path
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 import torch
-from datasets import DatasetDict, load_dataset, load_from_disk
+from datasets import (
+    Dataset,
+    DatasetDict,
+    concatenate_datasets,
+    load_dataset,
+    load_from_disk,
+)
 from huggingface_hub.utils._cache_manager import _scan_cached_repo
 from PIL import Image
+from torch.utils.data import ConcatDataset
 from transformers import AutoProcessor, PreTrainedTokenizerBase
 
 TokenizerType = Union[PreTrainedTokenizerBase, AutoProcessor]
@@ -125,6 +132,27 @@ def update_single_dataset_config(data_config: dict, default_data_config: dict) -
     for key in default_data_config.keys():
         if key not in data_config:
             data_config[key] = default_data_config[key]
+
+
+def merge_map_style_datasets(datasets: list[Any]) -> Any:
+    """Merge map-style datasets while supporting non-HF wrappers.
+
+    Hugging Face's ``concatenate_datasets`` only accepts HF ``Dataset`` objects.
+    Some response datasets, such as ``PreservingDataset``, intentionally bypass the
+    HF schema machinery to preserve heterogeneous nested structures. When those
+    datasets are present, fall back to a generic concatenation wrapper that still
+    provides ``__len__`` and integer ``__getitem__`` for downstream processing.
+    """
+    if not datasets:
+        raise ValueError("Expected at least one dataset to merge.")
+
+    if len(datasets) == 1:
+        return datasets[0]
+
+    if all(isinstance(dataset, Dataset) for dataset in datasets):
+        return concatenate_datasets(datasets)
+
+    return ConcatDataset(datasets)
 
 
 def extract_necessary_env_names(data_config: dict) -> list[str]:

--- a/nemo_rl/data/datasets/utils.py
+++ b/nemo_rl/data/datasets/utils.py
@@ -134,7 +134,7 @@ def update_single_dataset_config(data_config: dict, default_data_config: dict) -
             data_config[key] = default_data_config[key]
 
 
-def merge_map_style_datasets(datasets: list[Any]) -> Any:
+def merge_datasets(datasets: list[Any]) -> Any:
     """Merge map-style datasets while supporting non-HF wrappers.
 
     Hugging Face's ``concatenate_datasets`` only accepts HF ``Dataset`` objects.

--- a/nemo_rl/data/utils.py
+++ b/nemo_rl/data/utils.py
@@ -17,7 +17,6 @@ from typing import Any, Optional, Union
 
 import torch
 import yaml
-from datasets import concatenate_datasets
 from transformers import AutoProcessor, AutoTokenizer
 
 from nemo_rl.data import DataConfig
@@ -26,6 +25,7 @@ from nemo_rl.data.datasets import (
     extract_necessary_env_names,
     load_preference_dataset,
     load_response_dataset,
+    merge_map_style_datasets,
     update_single_dataset_config,
 )
 from nemo_rl.data.processors import preference_preprocessor
@@ -207,7 +207,7 @@ def setup_response_data(
         }
     else:
         # merge datasets into a single dataset
-        merged_data = concatenate_datasets([data.dataset for data in data_list])
+        merged_data = merge_map_style_datasets([data.dataset for data in data_list])
         dataset = AllTaskProcessedDataset(
             merged_data,
             tokenizer,
@@ -272,7 +272,7 @@ def setup_response_data(
     # merge datasets
     val_dataset = None
     if len(val_data_list) > 0:
-        merged_val_data = concatenate_datasets(val_data_list)
+        merged_val_data = merge_map_style_datasets(val_data_list)
         val_dataset = AllTaskProcessedDataset(
             merged_val_data,
             tokenizer,

--- a/nemo_rl/data/utils.py
+++ b/nemo_rl/data/utils.py
@@ -25,7 +25,7 @@ from nemo_rl.data.datasets import (
     extract_necessary_env_names,
     load_preference_dataset,
     load_response_dataset,
-    merge_map_style_datasets,
+    merge_datasets,
     update_single_dataset_config,
 )
 from nemo_rl.data.processors import preference_preprocessor
@@ -207,7 +207,7 @@ def setup_response_data(
         }
     else:
         # merge datasets into a single dataset
-        merged_data = merge_map_style_datasets([data.dataset for data in data_list])
+        merged_data = merge_datasets([data.dataset for data in data_list])
         dataset = AllTaskProcessedDataset(
             merged_data,
             tokenizer,
@@ -272,7 +272,7 @@ def setup_response_data(
     # merge datasets
     val_dataset = None
     if len(val_data_list) > 0:
-        merged_val_data = merge_map_style_datasets(val_data_list)
+        merged_val_data = merge_datasets(val_data_list)
         val_dataset = AllTaskProcessedDataset(
             merged_val_data,
             tokenizer,

--- a/tests/unit/data/datasets/test_preserving_dataset.py
+++ b/tests/unit/data/datasets/test_preserving_dataset.py
@@ -17,7 +17,12 @@ import tempfile
 
 import pytest
 from datasets import Dataset
+from torch.utils.data import ConcatDataset
 
+from nemo_rl.data.datasets import (
+    AllTaskProcessedDataset,
+    merge_map_style_datasets,
+)
 from nemo_rl.data.datasets.response_datasets.oai_format_dataset import (
     PreservingDataset,
 )
@@ -313,3 +318,55 @@ class TestOpenAIFormatDatasetWithHeterogeneousTools:
         preserving_dataset = PreservingDataset(data)
         assert preserving_dataset[0]["tool_id"] == "123"
         assert "tool_id" not in preserving_dataset[1]  # Key doesn't exist
+
+
+def _passthrough_processor(entry, task_data_spec, tokenizer, max_seq_length, idx):
+    return {
+        "message_log": [],
+        "task_name": entry["task_name"],
+        "idx": idx,
+    }
+
+
+def test_merge_map_style_datasets_uses_hf_concatenation():
+    dataset_a = Dataset.from_list([{"task_name": "hf_a", "value": 1}])
+    dataset_b = Dataset.from_list([{"task_name": "hf_b", "value": 2}])
+
+    merged = merge_map_style_datasets([dataset_a, dataset_b])
+
+    assert isinstance(merged, Dataset)
+    assert len(merged) == 2
+    assert merged[0]["task_name"] == "hf_a"
+    assert merged[1]["task_name"] == "hf_b"
+
+
+def test_merge_map_style_datasets_supports_preserving_dataset():
+    dataset_a = PreservingDataset([{"task_name": "preserving_a", "tool_id": "123"}])
+    dataset_b = PreservingDataset([{"task_name": "preserving_b"}])
+
+    merged = merge_map_style_datasets([dataset_a, dataset_b])
+
+    assert isinstance(merged, ConcatDataset)
+    assert len(merged) == 2
+    assert merged[0]["tool_id"] == "123"
+    assert "tool_id" not in merged[1]
+
+
+def test_all_task_processed_dataset_accepts_mixed_merged_dataset():
+    dataset_a = Dataset.from_list([{"task_name": "hf_task", "value": 1}])
+    dataset_b = PreservingDataset([{"task_name": "preserving_task", "value": 2}])
+
+    merged = merge_map_style_datasets([dataset_a, dataset_b])
+    dataset = AllTaskProcessedDataset(
+        merged,
+        tokenizer=None,
+        default_task_data_spec=None,
+        task_data_processors={
+            "hf_task": (None, _passthrough_processor),
+            "preserving_task": (None, _passthrough_processor),
+        },
+        max_seq_length=128,
+    )
+
+    assert dataset[0]["task_name"] == "hf_task"
+    assert dataset[1]["task_name"] == "preserving_task"

--- a/tests/unit/data/datasets/test_preserving_dataset.py
+++ b/tests/unit/data/datasets/test_preserving_dataset.py
@@ -19,13 +19,8 @@ import pytest
 from datasets import Dataset
 from torch.utils.data import ConcatDataset
 
-from nemo_rl.data.datasets import (
-    AllTaskProcessedDataset,
-    merge_map_style_datasets,
-)
-from nemo_rl.data.datasets.response_datasets.oai_format_dataset import (
-    PreservingDataset,
-)
+from nemo_rl.data.datasets import AllTaskProcessedDataset, merge_datasets
+from nemo_rl.data.datasets.response_datasets.oai_format_dataset import PreservingDataset
 
 
 class TestPreservingDataset:
@@ -328,11 +323,11 @@ def _passthrough_processor(entry, task_data_spec, tokenizer, max_seq_length, idx
     }
 
 
-def test_merge_map_style_datasets_uses_hf_concatenation():
+def test_merge_datasets_uses_hf_concatenation():
     dataset_a = Dataset.from_list([{"task_name": "hf_a", "value": 1}])
     dataset_b = Dataset.from_list([{"task_name": "hf_b", "value": 2}])
 
-    merged = merge_map_style_datasets([dataset_a, dataset_b])
+    merged = merge_datasets([dataset_a, dataset_b])
 
     assert isinstance(merged, Dataset)
     assert len(merged) == 2
@@ -340,11 +335,11 @@ def test_merge_map_style_datasets_uses_hf_concatenation():
     assert merged[1]["task_name"] == "hf_b"
 
 
-def test_merge_map_style_datasets_supports_preserving_dataset():
+def test_merge_datasets_supports_preserving_dataset():
     dataset_a = PreservingDataset([{"task_name": "preserving_a", "tool_id": "123"}])
     dataset_b = PreservingDataset([{"task_name": "preserving_b"}])
 
-    merged = merge_map_style_datasets([dataset_a, dataset_b])
+    merged = merge_datasets([dataset_a, dataset_b])
 
     assert isinstance(merged, ConcatDataset)
     assert len(merged) == 2
@@ -356,7 +351,7 @@ def test_all_task_processed_dataset_accepts_mixed_merged_dataset():
     dataset_a = Dataset.from_list([{"task_name": "hf_task", "value": 1}])
     dataset_b = PreservingDataset([{"task_name": "preserving_task", "value": 2}])
 
-    merged = merge_map_style_datasets([dataset_a, dataset_b])
+    merged = merge_datasets([dataset_a, dataset_b])
     dataset = AllTaskProcessedDataset(
         merged,
         tokenizer=None,


### PR DESCRIPTION
Continues #2218, thanks for the contribution @Bungmint.

## Issue
Closes https://github.com/NVIDIA-NeMo/RL/issues/2116.

## Summary

- Replace `concatenate_datasets` with a new `merge_datasets` helper throughout the SFT data pipeline (`run_sft.py`, `nemo_rl/data/utils.py`).
- `merge_datasets` falls back to `torch.utils.data.ConcatDataset` when any dataset is not a HF `Dataset` (e.g. `PreservingDataset`), avoiding the schema validation crash from `concatenate_datasets`.

## Test plan

- [x] `tests/unit/data/datasets/test_preserving_dataset.py` passes (new tests cover HF-only, `PreservingDataset`-only, and mixed merge cases).