### PR TITLE
feat(sft): make only_unmask_final configurable in SFTConfig

### DIFF
--- a/examples/configs/sft.yaml
+++ b/examples/configs/sft.yaml
@@ -12,6 +12,7 @@ sft:
   val_at_start: true
   val_at_end: false
   seed: 42
+  only_unmask_final: false
 
 checkpointing:
   enabled: true

--- a/nemo_rl/algorithms/sft.py
+++ b/nemo_rl/algorithms/sft.py
@@ -272,7 +272,7 @@ def validate(
             add_loss_mask_to_message_log(
                 val_batch["message_log"],
                 roles_to_train_on=["assistant"],
-                only_unmask_final=master_config["sft"]["only_unmask_final"],
+                only_unmask_final=master_config.sft["only_unmask_final"],
             )
 
             cat_and_padded, input_lengths = batched_message_log_to_flat_message(
@@ -436,7 +436,7 @@ def sft_train(
                     add_loss_mask_to_message_log(
                         batch["message_log"],
                         roles_to_train_on=["assistant"],
-                        only_unmask_final=master_config["sft"]["only_unmask_final"],
+                        only_unmask_final=master_config.sft["only_unmask_final"],
                     )
 
                     cat_and_padded, input_lengths = batched_message_log_to_flat_message(

--- a/nemo_rl/algorithms/sft.py
+++ b/nemo_rl/algorithms/sft.py
@@ -73,6 +73,7 @@ class SFTConfig(TypedDict):
     # final checkpoint has validation metrics, which is required for get_best_checkpoint_path().
     val_at_end: bool
     seed: int
+    only_unmask_final: bool
 
 
 class MasterConfig(BaseModel, extra="allow"):
@@ -271,6 +272,7 @@ def validate(
             add_loss_mask_to_message_log(
                 val_batch["message_log"],
                 roles_to_train_on=["assistant"],
+                only_unmask_final=master_config["sft"]["only_unmask_final"],
             )
 
             cat_and_padded, input_lengths = batched_message_log_to_flat_message(
@@ -434,6 +436,7 @@ def sft_train(
                     add_loss_mask_to_message_log(
                         batch["message_log"],
                         roles_to_train_on=["assistant"],
+                        only_unmask_final=master_config["sft"]["only_unmask_final"],
                     )
 
                     cat_and_padded, input_lengths = batched_message_log_to_flat_message(

--- a/tests/unit/algorithms/test_sft.py
+++ b/tests/unit/algorithms/test_sft.py
@@ -73,6 +73,7 @@ def mock_components():
             "val_micro_batch_size": 1,
             "val_at_start": False,
             "val_at_end": False,
+            "only_unmask_final": False,
         },
         policy={
             "train_global_batch_size": 1,

--- a/tests/unit/reference_configs/sft.yaml
+++ b/tests/unit/reference_configs/sft.yaml
@@ -12,6 +12,7 @@ sft:
   val_at_start: true
   val_at_end: false
   seed: 42
+  only_unmask_final: false
 
 checkpointing:
   enabled: true


### PR DESCRIPTION
Continues #2268, thanks for the contribution @Ai-chan-0411.

## Issue
Closes https://github.com/NVIDIA-NeMo/RL/issues/2219.

## Summary

- Add `only_unmask_final: bool` to `SFTConfig` and `sft.yaml` (defaults to `false`).
- Pass it through to `add_loss_mask_to_message_log` in both the train and validation paths.

## Test plan

- [x] Covered by existing `test_add_loss_mask_to_chat_message_log` tests.