### PR TITLE
fix: reset dataloader index when dataset changes on resume

### DIFF
--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -38,6 +38,7 @@ from nemo_rl.data.llm_message_utils import (
     batched_message_log_to_flat_message,
     get_keys_from_message_log,
 )
+from nemo_rl.data.utils import load_dataloader_state
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.virtual_cluster import (
     ClusterConfig,
@@ -253,10 +254,7 @@ def setup(
     )
 
     if last_checkpoint_path:
-        dataloader_state_dict = torch.load(
-            os.path.join(last_checkpoint_path, "train_dataloader.pt")
-        )
-        dataloader.load_state_dict(dataloader_state_dict)
+        load_dataloader_state(dataloader, last_checkpoint_path, data_config)
 
     print(
         f"  ✓ Training dataloader loaded with {len(train_dataset)} samples", flush=True

--- a/nemo_rl/algorithms/dpo.py
+++ b/nemo_rl/algorithms/dpo.py
@@ -28,6 +28,7 @@ from nemo_rl.algorithms.utils import maybe_pad_last_batch, set_seed
 from nemo_rl.data import DataConfig
 from nemo_rl.data.collate_fn import preference_collate_fn
 from nemo_rl.data.datasets import AllTaskProcessedDataset
+from nemo_rl.data.utils import load_dataloader_state
 from nemo_rl.distributed.virtual_cluster import ClusterConfig, RayVirtualCluster
 from nemo_rl.models.policy import PolicyConfig
 from nemo_rl.models.policy.interfaces import PolicyInterface
@@ -197,10 +198,7 @@ def setup(
     )
 
     if last_checkpoint_path is not None:
-        dataloader_state_dict = torch.load(
-            os.path.join(last_checkpoint_path, "train_dataloader.pt")
-        )
-        train_dataloader.load_state_dict(dataloader_state_dict)
+        load_dataloader_state(train_dataloader, last_checkpoint_path, data_config)
 
     val_dataloader = {
         k: StatefulDataLoader(

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -58,7 +58,7 @@ from nemo_rl.data.llm_message_utils import (
     batched_message_log_to_flat_message,
     get_keys_from_message_log,
 )
-from nemo_rl.data.utils import extract_necessary_env_names
+from nemo_rl.data.utils import extract_necessary_env_names, load_dataloader_state
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.ray_actor_environment_registry import get_actor_python_env
 from nemo_rl.distributed.virtual_cluster import ClusterConfig, RayVirtualCluster
@@ -319,10 +319,7 @@ def setup(
             num_workers=data_config["num_workers"],
         )
         if last_checkpoint_path is not None:
-            dataloader_state_dict = torch.load(
-                os.path.join(last_checkpoint_path, f"train_dataloader{suffix}.pt")
-            )
-            dataloader.load_state_dict(dataloader_state_dict)
+            load_dataloader_state(dataloader, last_checkpoint_path, data_config, suffix)
         return dataloader
 
     if data_config["use_multiple_dataloader"]:

--- a/nemo_rl/algorithms/rm.py
+++ b/nemo_rl/algorithms/rm.py
@@ -29,6 +29,7 @@ from nemo_rl.data import DataConfig
 from nemo_rl.data.collate_fn import preference_collate_fn
 from nemo_rl.data.datasets import AllTaskProcessedDataset
 from nemo_rl.data.interfaces import TaskDataSpec
+from nemo_rl.data.utils import load_dataloader_state
 from nemo_rl.distributed.virtual_cluster import ClusterConfig, RayVirtualCluster
 from nemo_rl.models.policy import PolicyConfig
 from nemo_rl.models.policy.interfaces import PolicyInterface
@@ -176,10 +177,7 @@ def setup(
     )
 
     if last_checkpoint_path is not None:
-        dataloader_state_dict = torch.load(
-            os.path.join(last_checkpoint_path, "train_dataloader.pt")
-        )
-        train_dataloader.load_state_dict(dataloader_state_dict)
+        load_dataloader_state(train_dataloader, last_checkpoint_path, data_config)
 
     val_dataloader = {
         k: StatefulDataLoader(

--- a/nemo_rl/algorithms/sft.py
+++ b/nemo_rl/algorithms/sft.py
@@ -30,6 +30,7 @@ from nemo_rl.data.llm_message_utils import (
     add_loss_mask_to_message_log,
     batched_message_log_to_flat_message,
 )
+from nemo_rl.data.utils import load_dataloader_state
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.virtual_cluster import ClusterConfig, RayVirtualCluster
 from nemo_rl.models.policy import PolicyConfig
@@ -149,10 +150,7 @@ def setup(
     )
 
     if last_checkpoint_path is not None:
-        dataloader_state_dict = torch.load(
-            os.path.join(last_checkpoint_path, "train_dataloader.pt")
-        )
-        train_dataloader.load_state_dict(dataloader_state_dict)
+        load_dataloader_state(train_dataloader, last_checkpoint_path, data_config)
 
     if val_dataset is not None:
         val_dataloader = StatefulDataLoader(

--- a/nemo_rl/data/utils.py
+++ b/nemo_rl/data/utils.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from typing import Any, Optional, Union
 
+import torch
+import yaml
 from datasets import concatenate_datasets
 from transformers import AutoProcessor, AutoTokenizer
 
@@ -28,6 +31,76 @@ from nemo_rl.data.datasets import (
 from nemo_rl.data.processors import preference_preprocessor
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.environments.utils import create_env
+
+
+def get_train_dataset_name(data_config: DataConfig) -> Optional[str]:
+    """Return the training ``dataset_name`` from a data config.
+
+    The shape of ``data_config["train"]`` is not consistent across algorithms
+    at the point where checkpoint save/load happens:
+    - ``setup_response_data`` (used by GRPO/Distillation) and ``setup_data``
+      in ``run_sft.py`` normalize a single-dataset dict into ``[dict]``.
+    - ``setup_preference_data`` (used by DPO/RM) leaves it as a ``dict``.
+
+    This helper tolerates both shapes and returns ``None`` when the dataset
+    name cannot be determined (e.g. legacy checkpoints with no name written,
+    multi-dataset training, or malformed configs).
+    """
+    if not data_config:
+        return None
+    train = data_config.get("train")
+    if isinstance(train, list):
+        train = train[0] if train else None
+    if isinstance(train, dict):
+        return train.get("dataset_name")
+    return None
+
+
+def load_dataloader_state(
+    dataloader: Any,
+    checkpoint_path: str,
+    data_config: DataConfig,
+    suffix: str = "",
+) -> None:
+    """Restore a dataloader's state from a checkpoint, with dataset-swap guard.
+
+    Loads ``{checkpoint_path}/train_dataloader{suffix}.pt`` and, when a
+    ``config.yaml`` is also present in the checkpoint dir (always written by
+    ``CheckpointManager.init_tmp_checkpoint``), compares the saved
+    ``dataset_name`` to the current run's ``dataset_name``. On mismatch the
+    dataloader state restore is **skipped** so the new dataset starts from
+    index 0 — otherwise ``StatefulDataLoader`` would inherit ``samples_yielded``
+    from the old run, silently skipping samples and (when the new dataset is
+    shorter than that count) crashing with ``StopIteration`` during ``iter()``.
+
+    No on-disk format change is needed: ``train_dataloader{suffix}.pt`` keeps
+    its existing raw-``state_dict`` shape, and the saved ``dataset_name`` is
+    read out of the sibling ``config.yaml`` so every existing checkpoint is
+    automatically compatible.
+    """
+    saved_state = torch.load(
+        os.path.join(checkpoint_path, f"train_dataloader{suffix}.pt")
+    )
+
+    config_path = os.path.join(checkpoint_path, "config.yaml")
+    if os.path.exists(config_path):
+        with open(config_path) as f:
+            saved_config = yaml.safe_load(f) or {}
+        saved_name = get_train_dataset_name(saved_config.get("data"))
+        current_name = get_train_dataset_name(data_config)
+        if (
+            saved_name is not None
+            and current_name is not None
+            and saved_name != current_name
+        ):
+            print(
+                f"  ⚠ Dataset swap detected: was {saved_name!r}, now {current_name!r}. "
+                f"Skipping dataloader state restore; new dataset starts from index 0.",
+                flush=True,
+            )
+            return
+
+    dataloader.load_state_dict(saved_state)
 
 
 # TODO: @yukih: unify to setup_data after dataset refactored

--- a/tests/unit/data/test_utils.py
+++ b/tests/unit/data/test_utils.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for ``nemo_rl.data.utils.get_train_dataset_name`` and
+``nemo_rl.data.utils.load_dataloader_state``.
+
+These helpers underpin the dataset-swap-aware checkpoint resume logic: when
+the saved ``dataset_name`` (read from the ``config.yaml`` written alongside
+``train_dataloader.pt``) differs from the current run's ``dataset_name``, the
+loader skips restoring ``samples_yielded`` so the new dataset starts from
+index 0. They are pure Python and require no GPUs / Ray / models.
+"""
+
+import os
+from typing import Any, Optional
+
+import pytest
+import torch
+import yaml
+from torchdata.stateful_dataloader import StatefulDataLoader
+
+from nemo_rl.data.utils import get_train_dataset_name, load_dataloader_state
+
+# ---------------------------------------------------------------------------
+# Test fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+class _RangeDataset:
+    """Tiny dataset returning integer-keyed strings so consumed samples are
+    identifiable after a save/restore cycle."""
+
+    def __init__(self, name: str, n: int):
+        self.name = name
+        self.n = n
+
+    def __len__(self) -> int:
+        return self.n
+
+    def __getitem__(self, idx: int) -> str:
+        if idx < 0 or idx >= self.n:
+            raise IndexError(f"{self.name}: idx={idx} out of range [0, {self.n})")
+        return f"{self.name}-{idx:04d}"
+
+
+def _id_collate(batch: list[Any]) -> list[Any]:
+    return list(batch)
+
+
+def _make_dl(name: str, n: int, batch_size: int = 1) -> StatefulDataLoader:
+    return StatefulDataLoader(
+        _RangeDataset(name, n),
+        batch_size=batch_size,
+        shuffle=False,
+        collate_fn=_id_collate,
+        drop_last=False,
+    )
+
+
+def _consume(dl: StatefulDataLoader, n_batches: int) -> list[Any]:
+    """Consume ``n_batches`` batches and return what was yielded."""
+    out = []
+    it = iter(dl)
+    for _ in range(n_batches):
+        out.append(next(it))
+    return out
+
+
+def _write_checkpoint(
+    dir_path: str,
+    state: Any,
+    saved_dataset_name: Optional[str] = None,
+    write_config: bool = True,
+    suffix: str = "",
+) -> str:
+    """Mimic what ``CheckpointManager.save_checkpoint`` writes for our purposes.
+
+    Always writes ``train_dataloader{suffix}.pt`` as a raw state dict (the
+    format the algorithms have always written). When ``write_config`` is true,
+    also writes a sibling ``config.yaml`` carrying the saved ``dataset_name``
+    under ``data.train.dataset_name``, exactly as the real checkpointer does
+    via ``yaml.safe_dump(run_config.model_dump())``.
+    """
+    os.makedirs(dir_path, exist_ok=True)
+    torch.save(state, os.path.join(dir_path, f"train_dataloader{suffix}.pt"))
+    if write_config:
+        cfg = {"data": {"train": {"dataset_name": saved_dataset_name}}}
+        with open(os.path.join(dir_path, "config.yaml"), "w") as f:
+            yaml.safe_dump(cfg, f)
+    return dir_path
+
+
+# ---------------------------------------------------------------------------
+# get_train_dataset_name
+# ---------------------------------------------------------------------------
+
+
+class TestGetTrainDatasetName:
+    """``get_train_dataset_name`` must tolerate every shape of
+    ``data_config["train"]`` that the algorithms may produce, and must also
+    work on the plain dict produced by ``yaml.safe_load(config.yaml)``."""
+
+    def test_dict_shape_returns_name(self):
+        # setup_preference_data (DPO/RM) leaves train as a dict.
+        assert get_train_dataset_name({"train": {"dataset_name": "A"}}) == "A"
+
+    def test_list_of_one_returns_name(self):
+        # setup_response_data (GRPO/Distillation) and run_sft.setup_data
+        # normalize a single-dataset dict into [dict].
+        assert get_train_dataset_name({"train": [{"dataset_name": "A"}]}) == "A"
+
+    def test_list_of_many_returns_first(self):
+        # Multi-dataset concat (single dataloader, N datasets) — we use the
+        # first dataset's name as a fingerprint so a swap is still detected.
+        assert (
+            get_train_dataset_name(
+                {"train": [{"dataset_name": "A"}, {"dataset_name": "B"}]}
+            )
+            == "A"
+        )
+
+    def test_empty_list_returns_none(self):
+        assert get_train_dataset_name({"train": []}) is None
+
+    def test_none_train_returns_none(self):
+        assert get_train_dataset_name({"train": None}) is None
+
+    def test_missing_train_returns_none(self):
+        assert get_train_dataset_name({}) is None
+
+    def test_none_config_returns_none(self):
+        assert get_train_dataset_name(None) is None
+
+    def test_dict_without_dataset_name_returns_none(self):
+        assert get_train_dataset_name({"train": {"foo": "bar"}}) is None
+
+    def test_list_with_dict_missing_dataset_name_returns_none(self):
+        assert get_train_dataset_name({"train": [{"foo": "bar"}]}) is None
+
+
+# ---------------------------------------------------------------------------
+# load_dataloader_state
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDataloaderState:
+    """End-to-end behavior of ``load_dataloader_state`` against
+    ``StatefulDataLoader``: matching names restore state, mismatched names
+    skip + warn, and checkpoints without a sibling ``config.yaml`` fall back
+    to the historical raw-load behavior."""
+
+    def test_match_restores_state(self, tmp_path):
+        # Train on D1 for 5 batches, save state + config.yaml(dataset_name=D1).
+        dl_save = _make_dl("D1", 20)
+        _consume(dl_save, 5)
+        _write_checkpoint(str(tmp_path), dl_save.state_dict(), saved_dataset_name="D1")
+
+        # Resume on a fresh dataloader with the same name -> state restored.
+        dl_new = _make_dl("D1", 20)
+        load_dataloader_state(dl_new, str(tmp_path), {"train": {"dataset_name": "D1"}})
+        # The next yielded sample should skip the 5 already consumed.
+        assert next(iter(dl_new))[0] == "D1-0005"
+
+    def test_mismatch_skips_state_and_warns(self, tmp_path, capsys):
+        # Save under D1.
+        dl_save = _make_dl("D1", 20)
+        _consume(dl_save, 5)
+        _write_checkpoint(str(tmp_path), dl_save.state_dict(), saved_dataset_name="D1")
+
+        # Resume with a *different* dataset name -> swap detected.
+        dl_new = _make_dl("D2", 20)
+        load_dataloader_state(dl_new, str(tmp_path), {"train": {"dataset_name": "D2"}})
+        captured = capsys.readouterr()
+        assert "Dataset swap detected" in captured.out
+        assert "'D1'" in captured.out and "'D2'" in captured.out
+
+        # Because state was NOT restored, iteration starts from index 0.
+        assert next(iter(dl_new))[0] == "D2-0000"
+
+    def test_mismatch_with_short_new_dataset_does_not_crash(self, tmp_path):
+        """Regression: when ``len(new_dataset) <= samples_yielded`` of the old
+        dataset, the unguarded torchdata path crashes with ``StopIteration``
+        during ``iter()`` construction. The swap-skip must make this safe."""
+        dl_save = _make_dl("D1", 100)
+        _consume(dl_save, 50)  # samples_yielded == 50
+        _write_checkpoint(str(tmp_path), dl_save.state_dict(), saved_dataset_name="D1")
+
+        # New dataset is shorter than 50 -- without the swap-skip this would
+        # raise StopIteration on the first ``iter(dl_new)``.
+        dl_new = _make_dl("D2_short", 5)
+        load_dataloader_state(
+            dl_new, str(tmp_path), {"train": {"dataset_name": "D2_short"}}
+        )
+        items = list(dl_new)
+        assert items[0][0] == "D2_short-0000"
+        assert len(items) == 5
+
+    def test_no_config_yaml_falls_back_to_load(self, tmp_path):
+        """Backward compat for very old checkpoints that somehow have no
+        sibling ``config.yaml``: behave like the pre-fix code and just load
+        the raw state. (Real nemo-rl checkpoints always write ``config.yaml``,
+        so this branch mostly guards corrupt / hand-rolled dirs.)"""
+        dl_save = _make_dl("D1", 20)
+        _consume(dl_save, 5)
+        _write_checkpoint(str(tmp_path), dl_save.state_dict(), write_config=False)
+
+        dl_new = _make_dl("D1", 20)
+        load_dataloader_state(dl_new, str(tmp_path), {"train": {"dataset_name": "D1"}})
+        assert next(iter(dl_new))[0] == "D1-0005"
+
+    def test_saved_name_none_loads_state(self, tmp_path):
+        # config.yaml exists but has no dataset_name -> "can't determine" ->
+        # load state to preserve legacy behavior.
+        dl_save = _make_dl("D1", 20)
+        _consume(dl_save, 5)
+        _write_checkpoint(str(tmp_path), dl_save.state_dict(), saved_dataset_name=None)
+
+        dl_new = _make_dl("D1", 20)
+        load_dataloader_state(dl_new, str(tmp_path), {"train": {"dataset_name": "D1"}})
+        assert next(iter(dl_new))[0] == "D1-0005"
+
+    def test_current_name_none_loads_state(self, tmp_path):
+        # Saved name known, current name unknown -> load state.
+        dl_save = _make_dl("D1", 20)
+        _consume(dl_save, 5)
+        _write_checkpoint(str(tmp_path), dl_save.state_dict(), saved_dataset_name="D1")
+
+        dl_new = _make_dl("D1", 20)
+        load_dataloader_state(dl_new, str(tmp_path), {"train": None})
+        assert next(iter(dl_new))[0] == "D1-0005"
+
+    def test_suffix_routes_to_correct_file(self, tmp_path):
+        """GRPO's multi-dataloader path uses ``suffix=f"_{task_name}"`` --
+        verify the helper honors it. There is still just one ``config.yaml``
+        per step dir, shared across all suffixed ``.pt`` files."""
+        dl_save = _make_dl("D1", 20)
+        _consume(dl_save, 5)
+        _write_checkpoint(
+            str(tmp_path),
+            dl_save.state_dict(),
+            saved_dataset_name="D1",
+            suffix="_math",
+        )
+
+        dl_new = _make_dl("D1", 20)
+        load_dataloader_state(
+            dl_new,
+            str(tmp_path),
+            {"train": {"dataset_name": "D1"}},
+            suffix="_math",
+        )
+        assert next(iter(dl_new))[0] == "D1-0005"
+
+    def test_missing_file_raises(self, tmp_path):
+        """No ``train_dataloader.pt`` at the expected path should propagate
+        as an error (consistent with the pre-fix behavior)."""
+        dl_new = _make_dl("D1", 20)
+        with pytest.raises((FileNotFoundError, RuntimeError)):
+            load_dataloader_state(
+                dl_new, str(tmp_path), {"train": {"dataset_name": "D1"}}
+            )


### PR DESCRIPTION
# What does this PR do ?

When resuming a single-dataloader run with a different `data.train.dataset_name`, `StatefulDataLoader.load_state_dict()` silently skips the first N samples of the new dataset (where N = `samples_yielded` from the previous run), or hard-crashes with `StopIteration` during `iter()` if `len(new_dataset) <= N`.

This PR tags each `train_dataloader.pt` save with the active `dataset_name` and skips the state restore when it differs from the current config, printing a warning so the swap is visible. Legacy saves (raw state dict) are still loaded as before for backward compatibility.

Applied to **GRPO (sync + async), SFT, DPO, RM, Distillation**. The multi-dataloader save path is intentionally left untouched in this PR.

# Issues
N/A

# Usage

No new API. Behavior is automatic:

```bash
# step 1: train on dataset A and checkpoint
uv run examples/run_grpo_math.py --config ... data.train.dataset_name=OpenMathInstruct-2

# step 2: resume from the checkpoint with a *different* dataset
uv run examples/run_grpo_math.py --config ... data.train.dataset_name=gsm8k checkpointing.checkpoint_must_exist=true
```

Previously, step 2 would silently skip the first N samples of `gsm8k` (or crash if `N >= len(gsm8k)`). Now the new dataset starts from index 0 and a warning is printed.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed Contributor guidelines
- [x] Wrote standalone empirical + identity-logic tests locally (not upstreamed)
- [x] Ran existing unit tests locally:
  - `tests/unit/algorithms/test_sft.py`: **5 passed**
  - `tests/unit/algorithms/test_dpo.py`: **4 passed**
  - `tests/unit/algorithms/test_rm.py`: **3 passed**
  - `tests/unit/algorithms/test_distillation.py`: **10 passed**
  - `tests/unit/algorithms/test_grpo.py`: running at PR time, relying on CI
- [x] No new documentation required

# Additional Information
* **Backward compatible**: old checkpoints with the legacy raw-state format still load via an `isinstance` fallback.
* The save payload is now `{"state": <state>, "dataset_name": <name>}`.
* Multi-dataloader save path is unchanged in this PR; per-dataset state semantics can be added in a follow-up.
