### PR TITLE
refactor(loss): migrate DPOLossConfig, DistillationLossConfig, DraftC…

### DIFF
--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -25,9 +25,8 @@ from nemo_rl.distributed.model_utils import DistributedCrossEntropy
 Tensor = TypeVar("Tensor", bound=torch.Tensor)
 
 
-class DraftCrossEntropyLossConfig(BaseModel, extra="allow"):
-    model_config = {"arbitrary_types_allowed": True}
-    vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None
+class DraftCrossEntropyLossConfig(TypedDict):
+    vocab_parallel_group: Optional[torch.distributed.ProcessGroup]
 
 
 class DraftCrossEntropyLossDataDict(TypedDict):
@@ -969,9 +968,7 @@ class DistillationLossFn(LossFunction):
     loss_type = LossType.TOKEN_LEVEL
     input_type = LossInputType.DISTILLATION
 
-    def __init__(self, cfg: DistillationLossConfig | dict):
-        if isinstance(cfg, dict):
-            cfg = DistillationLossConfig(**cfg)
+    def __init__(self, cfg: DistillationLossConfig):
         self.kl_type = cfg.kl_type
         self.mixed_kl_weight = cfg.mixed_kl_weight
         self.zero_outside_topk = cfg.zero_outside_topk

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -787,11 +787,11 @@ class PreferenceLossFn(LossFunction):
 
 
 class DPOLossConfig(BaseModel, extra="allow"):
-    reference_policy_kl_penalty: float
-    preference_loss_weight: float
-    sft_loss_weight: float
-    preference_average_log_probs: bool
-    sft_average_log_probs: bool
+    reference_policy_kl_penalty: float = 0.05
+    preference_loss_weight: float = 1.0
+    sft_loss_weight: float = 0.0
+    preference_average_log_probs: bool = False
+    sft_average_log_probs: bool = False
 
 
 class DPOLossDataDict(TypedDict):
@@ -949,9 +949,9 @@ class DPOLossFn(PreferenceLossFn):
 
 
 class DistillationLossConfig(BaseModel, extra="allow"):
-    kl_type: str
-    mixed_kl_weight: float
-    zero_outside_topk: bool
+    kl_type: str = "mixed"
+    mixed_kl_weight: float = 0.5
+    zero_outside_topk: bool = False
 
 
 class DistillationLossDataDict(TypedDict):

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -862,7 +862,9 @@ class DPOLossFn(PreferenceLossFn):
     loss_type = LossType.SEQUENCE_LEVEL
     input_type = LossInputType.LOGPROB
 
-    def __init__(self, cfg: DPOLossConfig, use_linear_ce_fusion: bool = False):
+    def __init__(self, cfg: DPOLossConfig | dict, use_linear_ce_fusion: bool = False):
+        if isinstance(cfg, dict):
+            cfg = DPOLossConfig(**cfg)
         self.reference_policy_kl_penalty = cfg.reference_policy_kl_penalty
         self.preference_loss_weight = cfg.preference_loss_weight
         self.sft_loss_weight = cfg.sft_loss_weight
@@ -967,7 +969,9 @@ class DistillationLossFn(LossFunction):
     loss_type = LossType.TOKEN_LEVEL
     input_type = LossInputType.DISTILLATION
 
-    def __init__(self, cfg: DistillationLossConfig):
+    def __init__(self, cfg: DistillationLossConfig | dict):
+        if isinstance(cfg, dict):
+            cfg = DistillationLossConfig(**cfg)
         self.kl_type = cfg.kl_type
         self.mixed_kl_weight = cfg.mixed_kl_weight
         self.zero_outside_topk = cfg.zero_outside_topk

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -25,8 +25,9 @@ from nemo_rl.distributed.model_utils import DistributedCrossEntropy
 Tensor = TypeVar("Tensor", bound=torch.Tensor)
 
 
-class DraftCrossEntropyLossConfig(TypedDict):
-    vocab_parallel_group: Optional[torch.distributed.ProcessGroup]
+class DraftCrossEntropyLossConfig(BaseModel, extra="allow"):
+    model_config = {"arbitrary_types_allowed": True}
+    vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None
 
 
 class DraftCrossEntropyLossDataDict(TypedDict):
@@ -785,7 +786,7 @@ class PreferenceLossFn(LossFunction):
         }
 
 
-class DPOLossConfig(TypedDict):
+class DPOLossConfig(BaseModel, extra="allow"):
     reference_policy_kl_penalty: float
     preference_loss_weight: float
     sft_loss_weight: float
@@ -862,11 +863,11 @@ class DPOLossFn(PreferenceLossFn):
     input_type = LossInputType.LOGPROB
 
     def __init__(self, cfg: DPOLossConfig, use_linear_ce_fusion: bool = False):
-        self.reference_policy_kl_penalty = cfg["reference_policy_kl_penalty"]
-        self.preference_loss_weight = cfg["preference_loss_weight"]
-        self.sft_loss_weight = cfg["sft_loss_weight"]
-        self.preference_average_log_probs = cfg["preference_average_log_probs"]
-        self.sft_average_log_probs = cfg["sft_average_log_probs"]
+        self.reference_policy_kl_penalty = cfg.reference_policy_kl_penalty
+        self.preference_loss_weight = cfg.preference_loss_weight
+        self.sft_loss_weight = cfg.sft_loss_weight
+        self.preference_average_log_probs = cfg.preference_average_log_probs
+        self.sft_average_log_probs = cfg.sft_average_log_probs
         self.use_linear_ce_fusion = use_linear_ce_fusion
         self.sft_loss = NLLLossFn(use_linear_ce_fusion=use_linear_ce_fusion)
 
@@ -945,7 +946,7 @@ class DPOLossFn(PreferenceLossFn):
         }
 
 
-class DistillationLossConfig(TypedDict):
+class DistillationLossConfig(BaseModel, extra="allow"):
     kl_type: str
     mixed_kl_weight: float
     zero_outside_topk: bool
@@ -967,9 +968,9 @@ class DistillationLossFn(LossFunction):
     input_type = LossInputType.DISTILLATION
 
     def __init__(self, cfg: DistillationLossConfig):
-        self.kl_type = cfg["kl_type"]
-        self.mixed_kl_weight = cfg["mixed_kl_weight"]
-        self.zero_outside_topk = cfg["zero_outside_topk"]
+        self.kl_type = cfg.kl_type
+        self.mixed_kl_weight = cfg.mixed_kl_weight
+        self.zero_outside_topk = cfg.zero_outside_topk
         self.log_infinitesimal = -100
 
         assert self.kl_type in ["forward", "reverse", "mixed"], "Invalid KL type"

--- a/tests/unit/algorithms/test_distillation.py
+++ b/tests/unit/algorithms/test_distillation.py
@@ -26,7 +26,7 @@ from nemo_rl.algorithms.distillation import (
     distillation_train,
     validate,
 )
-from nemo_rl.algorithms.loss import DistillationLossFn
+from nemo_rl.algorithms.loss import DistillationLossConfig, DistillationLossFn
 from nemo_rl.data.interfaces import DatumSpec
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 
@@ -107,11 +107,11 @@ def mock_components():
     tokenizer.pad_token_id = 0
 
     loss_fn = DistillationLossFn(
-        {
-            "kl_type": "forward",
-            "mixed_kl_weight": 0.5,
-            "zero_outside_topk": False,
-        }
+        DistillationLossConfig(
+            kl_type="forward",
+            mixed_kl_weight=0.5,
+            zero_outside_topk=False,
+        )
     )
 
     logger = MagicMock()

--- a/tests/unit/algorithms/test_loss_functions.py
+++ b/tests/unit/algorithms/test_loss_functions.py
@@ -19,6 +19,7 @@ import torch
 from nemo_rl.algorithms.loss import (
     ClippedPGLossConfig,
     ClippedPGLossFn,
+    DistillationLossConfig,
     DistillationLossFn,
     DPOLossFn,
     NLLLossFn,
@@ -1804,11 +1805,11 @@ def test_distillation_loss_different_settings(kl_type, zero_outside_topk):
     data, student_logits = setup_distillation_test_data()
 
     loss_fn = DistillationLossFn(
-        {
-            "kl_type": kl_type,
-            "mixed_kl_weight": 0.3,
-            "zero_outside_topk": zero_outside_topk,
-        }
+        DistillationLossConfig(
+            kl_type=kl_type,
+            mixed_kl_weight=0.3,
+            zero_outside_topk=zero_outside_topk,
+        )
     )
 
     loss_input, data = prepare_loss_input(student_logits, data, loss_fn)
@@ -1849,11 +1850,11 @@ def test_distillation_loss_topk_filtering(k, zero_outside_topk):
     data, student_logits = setup_distillation_test_data(topk=k)
 
     loss_fn = DistillationLossFn(
-        {
-            "kl_type": "forward",
-            "mixed_kl_weight": 0.5,
-            "zero_outside_topk": zero_outside_topk,
-        }
+        DistillationLossConfig(
+            kl_type="forward",
+            mixed_kl_weight=0.5,
+            zero_outside_topk=zero_outside_topk,
+        )
     )
 
     loss_input, data = prepare_loss_input(student_logits, data, loss_fn)
@@ -1887,11 +1888,11 @@ def test_distillation_loss_invalid_k_zero():
     data, student_logits = setup_distillation_test_data(topk=0)
 
     loss_fn = DistillationLossFn(
-        {
-            "kl_type": "forward",
-            "mixed_kl_weight": 0.5,
-            "zero_outside_topk": False,
-        }
+        DistillationLossConfig(
+            kl_type="forward",
+            mixed_kl_weight=0.5,
+            zero_outside_topk=False,
+        )
     )
 
     # This should raise a ValueError for k=0
@@ -1907,11 +1908,11 @@ def test_distillation_loss_gradient_flow():
     student_logits.requires_grad_(True)
 
     loss_fn = DistillationLossFn(
-        {
-            "kl_type": "forward",
-            "mixed_kl_weight": 0.5,
-            "zero_outside_topk": False,
-        }
+        DistillationLossConfig(
+            kl_type="forward",
+            mixed_kl_weight=0.5,
+            zero_outside_topk=False,
+        )
     )
 
     loss_input, data = prepare_loss_input(student_logits, data, loss_fn)
@@ -1939,11 +1940,11 @@ def test_distillation_loss_edge_cases():
     data, student_logits = setup_distillation_test_data()
 
     loss_fn = DistillationLossFn(
-        {
-            "kl_type": "forward",
-            "mixed_kl_weight": 0.5,
-            "zero_outside_topk": False,
-        }
+        DistillationLossConfig(
+            kl_type="forward",
+            mixed_kl_weight=0.5,
+            zero_outside_topk=False,
+        )
     )
 
     # Test with all-zero logits
@@ -1992,22 +1993,22 @@ def test_distillation_loss_edge_cases():
 def test_distillation_loss_fn_initialization():
     """Test DistillationLossFn initialization."""
     # Test with default values
-    default_config = {
-        "kl_type": "forward",
-        "mixed_kl_weight": 0.5,
-        "zero_outside_topk": False,
-    }
+    default_config = DistillationLossConfig(
+        kl_type="forward",
+        mixed_kl_weight=0.5,
+        zero_outside_topk=False,
+    )
     loss_fn = DistillationLossFn(default_config)
     assert loss_fn.kl_type == "forward"
     assert loss_fn.mixed_kl_weight == 0.5
     assert not loss_fn.zero_outside_topk
 
     # Test with custom values
-    custom_config = {
-        "kl_type": "reverse",
-        "mixed_kl_weight": 0.3,
-        "zero_outside_topk": True,
-    }
+    custom_config = DistillationLossConfig(
+        kl_type="reverse",
+        mixed_kl_weight=0.3,
+        zero_outside_topk=True,
+    )
     loss_fn = DistillationLossFn(custom_config)
     assert loss_fn.kl_type == "reverse"
     assert loss_fn.mixed_kl_weight == 0.3
@@ -2019,11 +2020,11 @@ def test_distillation_loss_fn_call():
     data, student_logits = setup_distillation_test_data()
 
     loss_fn = DistillationLossFn(
-        {
-            "kl_type": "forward",
-            "mixed_kl_weight": 0.5,
-            "zero_outside_topk": False,
-        }
+        DistillationLossConfig(
+            kl_type="forward",
+            mixed_kl_weight=0.5,
+            zero_outside_topk=False,
+        )
     )
 
     loss_input, data = prepare_loss_input(student_logits, data, loss_fn)


### PR DESCRIPTION
…rossEntropyLossConfig to BaseModel

Convert 3 TypedDict loss config classes to pydantic BaseModel with extra="allow". Update dict-style access (cfg["key"]) to attribute access (cfg.key) in their __init__ methods.

- DPOLossConfig: 5 required fields, used by DPOLossFn
- DistillationLossConfig: 3 required fields, used by DistillationLossFn
- DraftCrossEntropyLossConfig: 1 optional field (arbitrary_types_allowed for ProcessGroup)

# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
