### PR TITLE
ci: build container on Azure for main builds

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -335,6 +335,27 @@ jobs:
           docker rmi "${SRC}" "${DST}" 2>/dev/null || true
           rm -rf /tmp/uv-cache /tmp/Dockerfile.uv-cache
 
+  build-container-azure:
+    if: >-
+      ${{
+        github.ref == 'refs/heads/main' &&
+        needs.pre-flight.outputs.test_level != 'none' &&
+        needs.pre-flight.outputs.image_tag == ''
+      }}
+    needs: [pre-flight, org-member-pre-flight]
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_container.yml@v0.78.0
+    with:
+      build-ref: ${{ needs.pre-flight.outputs.test_sha }}
+      image-name: ${{ vars.CI_CONTAINER_NAME }}
+      dockerfile: docker/Dockerfile
+      runner: ${{ format('{0}-gpu-x2', vars.NON_NVIDIA_RUNNER_PREFIX) }}
+      image-label: ${{ vars.CI_CONTAINER_NAME }}
+      target: release
+      registry: ${{ vars.NON_NVIDIA_CONTAINER_REGISTRY }}
+      build-args: |
+        MAX_JOBS=4
+        NEMO_RL_COMMIT=${{ needs.pre-flight.outputs.test_sha }}
+
   cicd-doc-tests:
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- Adds a `build-container-azure` job to `cicd-main.yml` that builds and pushes the container image to `nemoci.azurecr.io` on every main branch build (including nightly)
- Runs in parallel with the existing GCP build — needed because GCP runners are ARM64 and Azure runners are x86_64, so images can't be copied across
- Keeps the Azure `:main` tag fresh so external contributor PR builds have a warm inline cache and can run `CI:Lfast`/`CI:docs` (which reuse the `:main` image)

## Context
External contributor builds run on Azure x86_64 runners and use `nemoci.azurecr.io/rl:main` as an inline Docker cache source. Since main branch builds only ran on GCP ARM64 runners, the Azure `:main` tag was never updated — causing two issues:

1. **Cache misses on Dockerfile changes**: When the base image changed to `cuda-dl-base:26.03-cuda13.2` in #2332, BuildKit couldn't find cached layers and tried pulling from nvcr.io directly, hitting rate-limit 401 errors (e.g. #2469)
2. **`CI:Lfast` / `CI:docs` broken for external contributors**: These test levels skip the container build and reuse the `:main` image, which didn't exist on the Azure registry

## Test plan
- [x] Verified the Azure build job runs and completes successfully
- [ ] After merge, verify `build-container-azure` runs on next nightly/main push
- [ ] Re-run PR #2469 CI to confirm external contributor builds work
- [ ] Verify `CI:Lfast` works for an external contributor PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)