### PR TITLE
feat: Make vllm sleep level customizable

### DIFF
--- a/nemo_rl/models/generation/vllm/config.py
+++ b/nemo_rl/models/generation/vllm/config.py
@@ -27,7 +27,7 @@ class VllmSpecificArgs(TypedDict):
     skip_tokenizer_init: bool
     async_engine: bool
     # vLLM sleep level used after generation. Defaults to 1 when unset.
-    sleep_level: NotRequired[Literal[1, 2]]
+    sleep_level: NotRequired[Literal[0, 1, 2]]
     load_format: NotRequired[str]
     precision: NotRequired[str]
     kv_cache_dtype: Literal["auto", "fp8", "fp8_e4m3"]

--- a/nemo_rl/models/generation/vllm/config.py
+++ b/nemo_rl/models/generation/vllm/config.py
@@ -26,6 +26,8 @@ class VllmSpecificArgs(TypedDict):
     # Additional arguments for vLLM inserted by nemo rl based on the context of when vllm is used
     skip_tokenizer_init: bool
     async_engine: bool
+    # vLLM sleep level used after generation. Defaults to 1 when unset.
+    sleep_level: NotRequired[Literal[1, 2]]
     load_format: NotRequired[str]
     precision: NotRequired[str]
     kv_cache_dtype: Literal["auto", "fp8", "fp8_e4m3"]

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -39,27 +39,12 @@ from nemo_rl.utils.nsys import wrap_with_nvtx_name
 
 # Use a base class to share some functions to avoid code duplication.
 class BaseVllmGenerationWorker:
-    cfg: VllmConfig
-
     def __repr__(self) -> str:
         """Customizes the actor's prefix in the Ray logs.
 
         This makes it easier to identify which worker is producing specific log messages.
         """
         return f"{self.__class__.__name__}"
-
-    def _sleep_level(self) -> int:
-        sleep_level = self.cfg["vllm_cfg"].get("sleep_level", 1)
-        if (
-            not isinstance(sleep_level, int)
-            # bool is a subclass of int, but YAML booleans should not be valid sleep levels.
-            or isinstance(sleep_level, bool)
-            or sleep_level not in (0, 1, 2)
-        ):
-            raise ValueError(
-                f"vllm_cfg.sleep_level must be 0, 1, or 2, got {sleep_level!r}"
-            )
-        return sleep_level
 
     @staticmethod
     def configure_worker(
@@ -150,6 +135,17 @@ class BaseVllmGenerationWorker:
                           the vLLM worker subprocess (e.g. for quantization configs).
         """
         self.cfg = config
+        sleep_level = self.cfg["vllm_cfg"].get("sleep_level", 1)
+        if (
+            not isinstance(sleep_level, int)
+            # bool is a subclass of int, but YAML booleans should not be valid sleep levels.
+            or isinstance(sleep_level, bool)
+            or sleep_level not in (0, 1, 2)
+        ):
+            raise ValueError(
+                f"vllm_cfg.sleep_level must be 0, 1, or 2, got {sleep_level!r}"
+            )
+        self.sleep_level = sleep_level
         self.model_name = self.cfg["model_name"]
         self.tensor_parallel_size = self.cfg["vllm_cfg"]["tensor_parallel_size"]
         self.pipeline_parallel_size = self.cfg["vllm_cfg"]["pipeline_parallel_size"]
@@ -1024,7 +1020,7 @@ class VllmGenerationWorkerImpl(BaseVllmGenerationWorker):
             self.llm.renderer, "clear_mm_cache"
         ):
             self.llm.renderer.clear_mm_cache()
-        self.llm.sleep(level=self._sleep_level())
+        self.llm.sleep(level=self.sleep_level)
 
         gc.collect()
         torch.cuda.empty_cache()

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -39,12 +39,27 @@ from nemo_rl.utils.nsys import wrap_with_nvtx_name
 
 # Use a base class to share some functions to avoid code duplication.
 class BaseVllmGenerationWorker:
+    cfg: VllmConfig
+
     def __repr__(self) -> str:
         """Customizes the actor's prefix in the Ray logs.
 
         This makes it easier to identify which worker is producing specific log messages.
         """
         return f"{self.__class__.__name__}"
+
+    def _sleep_level(self) -> int:
+        sleep_level = self.cfg["vllm_cfg"].get("sleep_level", 1)
+        if (
+            not isinstance(sleep_level, int)
+            # bool is a subclass of int, but YAML booleans should not be valid sleep levels.
+            or isinstance(sleep_level, bool)
+            or sleep_level not in (1, 2)
+        ):
+            raise ValueError(
+                f"vllm_cfg.sleep_level must be 1 or 2, got {sleep_level!r}"
+            )
+        return sleep_level
 
     @staticmethod
     def configure_worker(
@@ -1003,13 +1018,13 @@ class VllmGenerationWorkerImpl(BaseVllmGenerationWorker):
         # stays in sync with the receiver cache that vLLM clears internally
         # during sleep.  Without this, the sender thinks images are already
         # cached on the receiver and sends data=None, causing an assertion
-        # error.  We only clear the renderer (sender) cache here — the
+        # error.  We only clear the renderer (sender) cache here; the
         # receiver and worker-level caches are reset by sleep() internally.
         if hasattr(self.llm, "renderer") and hasattr(
             self.llm.renderer, "clear_mm_cache"
         ):
             self.llm.renderer.clear_mm_cache()
-        self.llm.sleep(level=1)
+        self.llm.sleep(level=self._sleep_level())
 
         gc.collect()
         torch.cuda.empty_cache()

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -54,10 +54,10 @@ class BaseVllmGenerationWorker:
             not isinstance(sleep_level, int)
             # bool is a subclass of int, but YAML booleans should not be valid sleep levels.
             or isinstance(sleep_level, bool)
-            or sleep_level not in (1, 2)
+            or sleep_level not in (0, 1, 2)
         ):
             raise ValueError(
-                f"vllm_cfg.sleep_level must be 1 or 2, got {sleep_level!r}"
+                f"vllm_cfg.sleep_level must be 0, 1, or 2, got {sleep_level!r}"
             )
         return sleep_level
 

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -1148,7 +1148,7 @@ class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
         # the receiver and sends data=None, causing an assertion error.
         if hasattr(self.llm, "reset_mm_cache"):
             await self.llm.reset_mm_cache()
-        await self.llm.sleep(level=self._sleep_level())
+        await self.llm.sleep(level=self.sleep_level)
 
         gc.collect()
         torch.cuda.empty_cache()

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -1148,7 +1148,7 @@ class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
         # the receiver and sends data=None, causing an assertion error.
         if hasattr(self.llm, "reset_mm_cache"):
             await self.llm.reset_mm_cache()
-        await self.llm.sleep(level=1)
+        await self.llm.sleep(level=self._sleep_level())
 
         gc.collect()
         torch.cuda.empty_cache()

--- a/tests/unit/models/generation/test_vllm_worker.py
+++ b/tests/unit/models/generation/test_vllm_worker.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, cast
+
+import pytest
+
+from nemo_rl.models.generation.vllm.config import VllmConfig
+from nemo_rl.models.generation.vllm.vllm_worker import BaseVllmGenerationWorker
+
+
+def _worker_with_vllm_cfg(vllm_cfg: dict[str, Any]) -> BaseVllmGenerationWorker:
+    worker = object.__new__(BaseVllmGenerationWorker)
+    worker.cfg = cast(VllmConfig, {"vllm_cfg": vllm_cfg})
+    return worker
+
+
+def test_vllm_sleep_level_defaults_to_level_1():
+    worker = _worker_with_vllm_cfg({})
+
+    assert worker._sleep_level() == 1
+
+
+@pytest.mark.parametrize("sleep_level", [1, 2])
+def test_vllm_sleep_level_accepts_supported_levels(sleep_level):
+    worker = _worker_with_vllm_cfg({"sleep_level": sleep_level})
+
+    assert worker._sleep_level() == sleep_level
+
+
+@pytest.mark.parametrize("sleep_level", [0, 3, "2", True])
+def test_vllm_sleep_level_rejects_unsupported_levels(sleep_level):
+    worker = _worker_with_vllm_cfg({"sleep_level": sleep_level})
+
+    with pytest.raises(ValueError, match="vllm_cfg.sleep_level must be 1 or 2"):
+        worker._sleep_level()

--- a/tests/unit/models/generation/test_vllm_worker.py
+++ b/tests/unit/models/generation/test_vllm_worker.py
@@ -21,27 +21,38 @@ from nemo_rl.models.generation.vllm.vllm_worker import BaseVllmGenerationWorker
 
 
 def _worker_with_vllm_cfg(vllm_cfg: dict[str, Any]) -> BaseVllmGenerationWorker:
-    worker = object.__new__(BaseVllmGenerationWorker)
-    worker.cfg = cast(VllmConfig, {"vllm_cfg": vllm_cfg})
-    return worker
+    config = {
+        "model_name": "dummy-model",
+        "vllm_cfg": {
+            "tensor_parallel_size": 1,
+            "pipeline_parallel_size": 1,
+            "expert_parallel_size": 1,
+            "gpu_memory_utilization": 0.5,
+            "max_model_len": 128,
+            "skip_tokenizer_init": True,
+            "async_engine": False,
+            "precision": "bfloat16",
+            "kv_cache_dtype": "auto",
+            **vllm_cfg,
+        },
+    }
+    return BaseVllmGenerationWorker(cast(VllmConfig, config), bundle_indices=None)
 
 
 def test_vllm_sleep_level_defaults_to_level_1():
     worker = _worker_with_vllm_cfg({})
 
-    assert worker._sleep_level() == 1
+    assert worker.sleep_level == 1
 
 
 @pytest.mark.parametrize("sleep_level", [0, 1, 2])
 def test_vllm_sleep_level_accepts_supported_levels(sleep_level):
     worker = _worker_with_vllm_cfg({"sleep_level": sleep_level})
 
-    assert worker._sleep_level() == sleep_level
+    assert worker.sleep_level == sleep_level
 
 
 @pytest.mark.parametrize("sleep_level", [-1, 3, "2", True])
 def test_vllm_sleep_level_rejects_unsupported_levels(sleep_level):
-    worker = _worker_with_vllm_cfg({"sleep_level": sleep_level})
-
     with pytest.raises(ValueError, match=r"vllm_cfg\.sleep_level must be 0, 1, or 2"):
-        worker._sleep_level()
+        _worker_with_vllm_cfg({"sleep_level": sleep_level})

--- a/tests/unit/models/generation/test_vllm_worker.py
+++ b/tests/unit/models/generation/test_vllm_worker.py
@@ -43,5 +43,5 @@ def test_vllm_sleep_level_accepts_supported_levels(sleep_level):
 def test_vllm_sleep_level_rejects_unsupported_levels(sleep_level):
     worker = _worker_with_vllm_cfg({"sleep_level": sleep_level})
 
-    with pytest.raises(ValueError, match="vllm_cfg.sleep_level must be 0, 1, or 2"):
+    with pytest.raises(ValueError, match=r"vllm_cfg\.sleep_level must be 0, 1, or 2"):
         worker._sleep_level()

--- a/tests/unit/models/generation/test_vllm_worker.py
+++ b/tests/unit/models/generation/test_vllm_worker.py
@@ -32,16 +32,16 @@ def test_vllm_sleep_level_defaults_to_level_1():
     assert worker._sleep_level() == 1
 
 
-@pytest.mark.parametrize("sleep_level", [1, 2])
+@pytest.mark.parametrize("sleep_level", [0, 1, 2])
 def test_vllm_sleep_level_accepts_supported_levels(sleep_level):
     worker = _worker_with_vllm_cfg({"sleep_level": sleep_level})
 
     assert worker._sleep_level() == sleep_level
 
 
-@pytest.mark.parametrize("sleep_level", [0, 3, "2", True])
+@pytest.mark.parametrize("sleep_level", [-1, 3, "2", True])
 def test_vllm_sleep_level_rejects_unsupported_levels(sleep_level):
     worker = _worker_with_vllm_cfg({"sleep_level": sleep_level})
 
-    with pytest.raises(ValueError, match="vllm_cfg.sleep_level must be 1 or 2"):
+    with pytest.raises(ValueError, match="vllm_cfg.sleep_level must be 0, 1, or 2"):
         worker._sleep_level()


### PR DESCRIPTION
# What does this PR do ?

Makes vllm sleep level customizable. E.g. sleep level 2 is useful for cases when CPU memory is limited

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * vLLM generation now supports configurable sleep levels (0, 1, or 2) via configuration, defaulting to level 1 when unset.

* **Tests**
  * Added unit tests validating sleep level configuration behavior and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/RL/pull/2523?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->