### PR TITLE
ci: skip sglang build and tests for external contributors

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -301,6 +301,7 @@ jobs:
       build-args: |
         MAX_JOBS=4
         NEMO_RL_COMMIT=${{ needs.pre-flight.outputs.test_sha }}
+        ${{ needs.org-member-pre-flight.outputs.is_member != 'true' && 'SKIP_SGLANG_BUILD=1' || '' }}
 
   update-uv-cache:
     name: Update uv build cache

--- a/tests/functional/L1_Functional_Tests_GPU.sh
+++ b/tests/functional/L1_Functional_Tests_GPU.sh
@@ -66,7 +66,10 @@ run_test      uv run --no-sync bash ./tests/functional/grpo_multiple_dataloaders
 run_test      uv run --no-sync bash ./tests/functional/grpo_multiturn.sh
 run_test      uv run --no-sync bash ./tests/functional/grpo_non_colocated.sh
 run_test      uv run --no-sync bash ./tests/functional/grpo_rm_env.sh
-run_test      uv run --no-sync bash ./tests/functional/grpo_sglang.sh
+# Skip sglang functional test if sglang was not built into the container
+if python -c "import sglang" 2>/dev/null; then
+    run_test      uv run --no-sync bash ./tests/functional/grpo_sglang.sh
+fi
 run_test fast uv run --no-sync bash ./tests/functional/grpo_topp_topk.sh
 run_test      uv run --no-sync bash ./tests/functional/prorlv2.sh
 run_test      uv run --no-sync bash ./tests/functional/qa_distillation_megatron.sh

--- a/tests/unit/L0_Unit_Tests_Generation.sh
+++ b/tests/unit/L0_Unit_Tests_Generation.sh
@@ -57,10 +57,14 @@ else
     uv run --extra vllm bash -x ./tests/run_unit.sh "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --cov=nemo_rl --cov-append --cov-report=term-missing --cov-report=json --hf-gated --vllm-only
 fi
 
-# Check and run sglang tests
-exit_code=$(cd ${PROJECT_ROOT}/tests && uv run --extra sglang pytest "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --collect-only --hf-gated --sglang-only -q >/dev/null 2>&1; echo $?)
-if [[ $exit_code -eq 5 ]]; then
-    echo "No sglang tests to run"
+# Check and run sglang tests (skip if sglang was not built into the container)
+if python -c "import sglang" 2>/dev/null; then
+    exit_code=$(cd ${PROJECT_ROOT}/tests && uv run --extra sglang pytest "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --collect-only --hf-gated --sglang-only -q >/dev/null 2>&1; echo $?)
+    if [[ $exit_code -eq 5 ]]; then
+        echo "No sglang tests to run"
+    else
+        uv run --extra sglang bash -x ./tests/run_unit.sh "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --cov=nemo_rl --cov-append --cov-report=term-missing --cov-report=json --hf-gated --sglang-only
+    fi
 else
-    uv run --extra sglang bash -x ./tests/run_unit.sh "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --cov=nemo_rl --cov-append --cov-report=term-missing --cov-report=json --hf-gated --sglang-only
+    echo "sglang not installed, skipping sglang tests"
 fi

--- a/tests/unit/L0_Unit_Tests_Other.sh
+++ b/tests/unit/L0_Unit_Tests_Other.sh
@@ -57,12 +57,16 @@ else
     uv run --extra vllm bash -x ./tests/run_unit.sh "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --cov=nemo_rl --cov-append --cov-report=term-missing --cov-report=json --hf-gated --vllm-only
 fi
 
-# Check and run sglang tests
-exit_code=$(cd ${PROJECT_ROOT}/tests && uv run --extra sglang pytest "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --collect-only --hf-gated --sglang-only -q >/dev/null 2>&1; echo $?)
-if [[ $exit_code -eq 5 ]]; then
-    echo "No sglang tests to run"
+# Check and run sglang tests (skip if sglang was not built into the container)
+if python -c "import sglang" 2>/dev/null; then
+    exit_code=$(cd ${PROJECT_ROOT}/tests && uv run --extra sglang pytest "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --collect-only --hf-gated --sglang-only -q >/dev/null 2>&1; echo $?)
+    if [[ $exit_code -eq 5 ]]; then
+        echo "No sglang tests to run"
+    else
+        uv run --extra sglang bash -x ./tests/run_unit.sh "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --cov=nemo_rl --cov-append --cov-report=term-missing --cov-report=json --hf-gated --sglang-only
+    fi
 else
-    uv run --extra sglang bash -x ./tests/run_unit.sh "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --cov=nemo_rl --cov-append --cov-report=term-missing --cov-report=json --hf-gated --sglang-only
+    echo "sglang not installed, skipping sglang tests"
 fi
 
 # Check and run nemo_gym tests

--- a/tests/unit/L0_Unit_Tests_Policy.sh
+++ b/tests/unit/L0_Unit_Tests_Policy.sh
@@ -57,10 +57,14 @@ else
     uv run --extra vllm bash -x ./tests/run_unit.sh "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --cov=nemo_rl --cov-append --cov-report=term-missing --cov-report=json --hf-gated --vllm-only
 fi
 
-# Check and run sglang tests
-exit_code=$(cd ${PROJECT_ROOT}/tests && uv run --extra sglang pytest "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --collect-only --hf-gated --sglang-only -q >/dev/null 2>&1; echo $?)
-if [[ $exit_code -eq 5 ]]; then
-    echo "No sglang tests to run"
+# Check and run sglang tests (skip if sglang was not built into the container)
+if python -c "import sglang" 2>/dev/null; then
+    exit_code=$(cd ${PROJECT_ROOT}/tests && uv run --extra sglang pytest "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --collect-only --hf-gated --sglang-only -q >/dev/null 2>&1; echo $?)
+    if [[ $exit_code -eq 5 ]]; then
+        echo "No sglang tests to run"
+    else
+        uv run --extra sglang bash -x ./tests/run_unit.sh "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --cov=nemo_rl --cov-append --cov-report=term-missing --cov-report=json --hf-gated --sglang-only
+    fi
 else
-    uv run --extra sglang bash -x ./tests/run_unit.sh "${TEST_PATHS[@]}" "${IGNORE[@]}" "${EXCLUDED_UNIT_TESTS[@]}" --cov=nemo_rl --cov-append --cov-report=term-missing --cov-report=json --hf-gated --sglang-only
+    echo "sglang not installed, skipping sglang tests"
 fi


### PR DESCRIPTION
## Summary
- Temporarily skip sglang tests when sglang is not installed, so the test scripts handle missing sglang gracefully instead of failing
- Disable sglang build for external contributors (non-NVIDIA SSO members) until the external contributor Lfast flow can be fixed

### Changes
- **`.github/workflows/cicd-main.yml`**: Pass `SKIP_SGLANG_BUILD=1` to the container build when `org-member-pre-flight.outputs.is_member \!= 'true'`
- **`tests/unit/L0_Unit_Tests_{Generation,Other,Policy}.sh`**: Guard sglang test blocks with `python -c "import sglang"` check — skip gracefully if sglang is not available
- **`tests/functional/L1_Functional_Tests_GPU.sh`**: Same guard for the `grpo_sglang.sh` functional test

## Test plan
- [ ] Verify NVIDIA member PRs still build sglang and run sglang tests (no change in behavior)
- [ ] Verify external contributor PRs skip sglang build and gracefully skip sglang tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)