### PR TITLE
ci: Skip sglang prefetch for Lfast CI label

### DIFF
--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -160,7 +160,7 @@ runs:
             # fingerprint once upfront instead of using NRL_FORCE_REBUILD_VENVS=true which
             # rebuilds on every Ray remote call.
             if [[ "${FAST:-0}" == "1" ]]; then
-              UV_LINK_MODE=symlink uv run nemo_rl/utils/prefetch_venvs.py
+              UV_LINK_MODE=symlink uv run nemo_rl/utils/prefetch_venvs.py --negative-filters sglang
               python tools/generate_fingerprint.py > /opt/nemo_rl_container_fingerprint
             fi
             bash tests/${{ inputs.is_doc_test == 'true' && 'docs' || (inputs.is_unit_test == 'true' && 'unit' || 'functional') }}/${{ inputs.script }}.sh && \


### PR DESCRIPTION
# What does this PR do ?

ci: Skip sglang prefetch for Lfast CI label

With Lfast, the sglang tests are skipped anyway. Otherwise, the venv prefetch step would attempt to build sglang still.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
