### PR TITLE
docs(fp8): fix YAML key names for pow2 scaling factors

### DIFF
--- a/docs/fp8.md
+++ b/docs/fp8.md
@@ -53,8 +53,8 @@ FP8 generations are recommended to be configured with the following settings:
                 num_first_layers_in_bf16: 0
                 # Use FP32 scaling factors. Rounding scaling factors to the nearest pow2 may improve quantization 
                 # fidelity however this feature is still under research.
-                use_weight_pow2_scale: False
-                use_activation_pow2_scale: False
+                pow2_weight_scaling_factors: False
+                pow2_activation_scaling_factors: False
 ```
 
 To train with FP8, you need to set the Megatron path and configure it using the following settings:


### PR DESCRIPTION
# What does this PR do ?

docs(fp8): fix YAML key names for pow2 scaling factors

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
