### PR TITLE
refactor: defer decord2 initialization for audio fallback

### DIFF
--- a/nemo_rl/data/multimodal_utils.py
+++ b/nemo_rl/data/multimodal_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import base64
+import importlib
 import inspect
 import logging
 import re
@@ -20,7 +21,6 @@ from collections import defaultdict
 from io import BytesIO
 from typing import Any, Optional, Union
 
-import decord
 import requests
 import torch
 from PIL import Image
@@ -65,6 +65,16 @@ MEDIA_TAG_PATTERN = re.compile(
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _load_decord():
+    try:
+        return importlib.import_module("decord")
+    except ImportError as exc:
+        raise ImportError(
+            "decord2 is required for the audio loading fallback. Install decord2 or "
+            "ensure transformers can load the audio file directly."
+        ) from exc
 
 
 class PackedTensor:
@@ -356,9 +366,10 @@ def load_media_from_message(
                     loaded_media["audio"].append(
                         load_audio(aud, **multimodal_load_kwargs["audio"])
                     )
-                except (RuntimeError, FileNotFoundError, OSError) as e:
-                    logger.warning("Audio loading failed. Fall back to decord.")
+                except (RuntimeError, FileNotFoundError, OSError):
                     # use decord
+                    decord = _load_decord()
+                    logger.warning("Audio loading failed. Falling back to decord.")
                     loaded_audio = decord.AudioReader(
                         aud,
                         sample_rate=multimodal_load_kwargs["audio"]["sampling_rate"],

--- a/tests/unit/data/test_multimodal_utils.py
+++ b/tests/unit/data/test_multimodal_utils.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemo_rl.data import multimodal_utils
+
+
+def test_load_decord_reports_decord2_install_hint(monkeypatch):
+    def import_without_decord(name):
+        assert name == "decord"
+        raise ImportError("No module named 'decord'")
+
+    monkeypatch.setattr(
+        multimodal_utils.importlib, "import_module", import_without_decord
+    )
+
+    with pytest.raises(ImportError, match="decord2 is required"):
+        multimodal_utils._load_decord()
+
+
+def test_audio_fallback_reports_missing_decord(monkeypatch):
+    def raise_runtime_error(*args, **kwargs):
+        raise RuntimeError("audio load failed")
+
+    def raise_missing_decord():
+        raise ImportError("decord2 is required")
+
+    monkeypatch.setattr(multimodal_utils, "load_audio", raise_runtime_error)
+    monkeypatch.setattr(multimodal_utils, "_load_decord", raise_missing_decord)
+
+    with pytest.raises(ImportError, match="decord2 is required"):
+        multimodal_utils.load_media_from_message(
+            {"content": [{"type": "audio", "audio": "audio.wav"}]},
+            multimodal_load_kwargs={"audio": {"sampling_rate": 16000}},
+        )
+
+
+def test_audio_fallback_uses_decord(monkeypatch):
+    def raise_runtime_error(*args, **kwargs):
+        raise RuntimeError("audio load failed")
+
+    class FakeAudio:
+        def asnumpy(self):
+            return ["channel0", "channel1"]
+
+    class FakeDecord:
+        class AudioReader:
+            def __init__(self, path, *, sample_rate, mono):
+                assert path == "audio.wav"
+                assert sample_rate == 16000
+                assert mono is True
+
+            def __getitem__(self, index):
+                assert index == slice(None)
+                return FakeAudio()
+
+    monkeypatch.setattr(multimodal_utils, "load_audio", raise_runtime_error)
+    monkeypatch.setattr(multimodal_utils, "_load_decord", lambda: FakeDecord)
+
+    loaded_media = multimodal_utils.load_media_from_message(
+        {"content": [{"type": "audio", "audio": "audio.wav"}]},
+        processor=object(),
+        multimodal_load_kwargs={"audio": {"sampling_rate": 16000}},
+    )
+
+    assert loaded_media["audio"] == ["channel0"]


### PR DESCRIPTION
Summary
- Remove the eager decord import from multimodal_utils.
- Load decord2 only when transformers audio loading fails and the audio fallback is actually used.
- Improve the missing-dependency message to point at decord2.
- Add tests for the install hint and fallback behavior.

Validation
- PYTHONPYCACHEPREFIX=/tmp/codex-pycache python3 -m py_compile nemo_rl/data/multimodal_utils.py tests/unit/data/test_multimodal_utils.py
- git diff --check
- uv run pytest tests/unit/data/test_multimodal_utils.py -q (blocked locally: fresh worktree is missing 3rdparty/Gym-workspace/Gym pyproject metadata)

Notes
- This does not make decord2 an optional package; pyproject still lists it as a hard dependency. It just avoids loading the extension at Nemo-RL import time.
- Claude adversarial review found no blockers.