### PR TITLE
feat: add AsyncRolloutManager for native async per-prompt rollouts

### DIFF
--- a/nemo_rl/experience/interfaces.py
+++ b/nemo_rl/experience/interfaces.py
@@ -22,8 +22,8 @@ from nemo_rl.data.interfaces import LLMMessageLogType, VLMMessageLogType
 class Completion:
     """A single generated completion for one prompt."""
 
-    message_log: LLMMessageLogType
-    env_extras: dict[str, Any]
+    message_log: LLMMessageLogType | VLMMessageLogType
+    env_extras: Optional[dict[str, Any]]
     truncated: bool
     reward: float
 

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -57,6 +57,9 @@ class AsyncRolloutManager:
         num_generations_per_prompt: int,
         max_rollout_turns: int = 999999,
     ) -> None:
+        assert num_generations_per_prompt >= 1, (
+            "num_generations_per_prompt must be >= 1"
+        )
         self._policy_generation = policy_generation
         self._tokenizer = tokenizer
         self._task_to_env = task_to_env

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -87,7 +87,9 @@ class AsyncRolloutManager:
             all_sample_metrics = [m for _, m in results]
 
         with timer.time(f"{timer_prefix}/aggregate_metrics"):
-            rollout_metrics = self._aggregate_rollout_metrics(all_sample_metrics)
+            rollout_metrics = self._aggregate_rollout_metrics(
+                completions, all_sample_metrics
+            )
 
         timer.stop(f"{timer_prefix}/total")
         rollout_metrics.update(timer.get_timing_metrics("sum"))
@@ -209,7 +211,8 @@ class AsyncRolloutManager:
                 if env_output.metadata[0] is not None:
                     current_extra_env_info = env_output.metadata[0]
 
-        if turn_count >= self._max_rollout_turns:
+        else:
+            # Reached max turns without termination or truncation.
             max_turns_reached = True
 
         completion = Completion(
@@ -224,9 +227,7 @@ class AsyncRolloutManager:
             "assistant_tokens": assistant_token_count,
             "env_tokens": env_token_count,
             "terminated": terminated,
-            "truncated": truncated,
             "max_turns_reached": max_turns_reached,
-            "total_reward": total_reward,
             "turn_gen_tokens": turn_gen_tokens,
             "turn_input_tokens": turn_input_tokens,
             "turn_total_tokens": turn_total_tokens,
@@ -235,40 +236,46 @@ class AsyncRolloutManager:
         return completion, sample_metrics
 
     def _aggregate_rollout_metrics(
-        self, all_sample_metrics: list[dict]
+        self, completions: list[Completion], all_sample_metrics: list[dict]
     ) -> dict[str, Any]:
         """Aggregate per-sample metrics across all completions."""
+        # Prepare lists of values for each metric.
+        total_reward = [c.reward for c in completions]
+        turn_count = [m["turn_count"] for m in all_sample_metrics]
+        # token metrics
+        total_tokens = [m["total_tokens"] for m in all_sample_metrics]
+        assistant_tokens = [m["assistant_tokens"] for m in all_sample_metrics]
+        env_tokens = [m["env_tokens"] for m in all_sample_metrics]
+        # truncated metrics
+        truncated = [c.truncated for c in completions]
+        terminated = [m["terminated"] for m in all_sample_metrics]
+        max_turns_reached = [m["max_turns_reached"] for m in all_sample_metrics]
+
+        # Aggregate metrics across all samples.
         n = len(all_sample_metrics)
         rollout_metrics: dict[str, Any] = {
-            "total_turns": sum(m["turn_count"] for m in all_sample_metrics),
-            "avg_turns_per_sample": sum(m["turn_count"] for m in all_sample_metrics)
-            / n,
-            "max_turns_per_sample": max(m["turn_count"] for m in all_sample_metrics),
-            "natural_termination_rate": sum(m["terminated"] for m in all_sample_metrics)
-            / n,
-            "truncation_rate": sum(m["truncated"] for m in all_sample_metrics) / n,
-            "max_turns_reached_rate": sum(
-                m["max_turns_reached"] for m in all_sample_metrics
-            )
-            / n,
-            "mean_total_tokens_per_sample": sum(
-                m["total_tokens"] for m in all_sample_metrics
-            )
-            / n,
-            "mean_gen_tokens_per_sample": sum(
-                m["assistant_tokens"] for m in all_sample_metrics
-            )
-            / n,
-            "max_gen_tokens_per_sample": max(
-                m["assistant_tokens"] for m in all_sample_metrics
+            **self._aggregate_single_metric(
+                "total_reward", total_reward, ["mean", "max", "min"], n
             ),
-            "mean_env_tokens_per_sample": sum(
-                m["env_tokens"] for m in all_sample_metrics
-            )
-            / n,
-            "mean_total_reward": sum(m["total_reward"] for m in all_sample_metrics) / n,
-            "max_total_reward": max(m["total_reward"] for m in all_sample_metrics),
-            "min_total_reward": min(m["total_reward"] for m in all_sample_metrics),
+            # turn metrics
+            "total_turns": sum(turn_count),
+            **self._aggregate_single_metric(
+                "turns_per_sample", turn_count, ["mean", "max"], n
+            ),
+            # token metrics
+            **self._aggregate_single_metric(
+                "total_tokens_per_sample", total_tokens, ["mean"], n
+            ),
+            **self._aggregate_single_metric(
+                "gen_tokens_per_sample", assistant_tokens, ["mean", "max"], n
+            ),
+            **self._aggregate_single_metric(
+                "env_tokens_per_sample", env_tokens, ["mean"], n
+            ),
+            # truncated metrics
+            "truncation_rate": sum(truncated) / n,
+            "natural_termination_rate": sum(terminated) / n,
+            "max_turns_reached_rate": sum(max_turns_reached) / n,
         }
 
         if "per_worker_token_counts" in all_sample_metrics[0]:
@@ -290,6 +297,26 @@ class AsyncRolloutManager:
         ]
 
         return rollout_metrics
+
+    @staticmethod
+    def _aggregate_single_metric(
+        name: str,
+        values: list[float],
+        agg_method: list[str],
+        n: Optional[int] = None,
+    ) -> dict:
+        """Calculate a single metric across a list of values."""
+        metrics = {}
+
+        if "mean" in agg_method:
+            assert n is not None, "n must be provided for mean aggregation"
+            metrics[f"mean_{name}"] = sum(values) / n
+        if "max" in agg_method:
+            metrics[f"max_{name}"] = max(values)
+        if "min" in agg_method:
+            metrics[f"min_{name}"] = min(values)
+
+        return metrics
 
 
 class AsyncNemoGymRolloutManager:

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -611,7 +611,7 @@ class AsyncNemoGymRolloutManager:
         agent_extras = [c.env_extras for c in completions]
         for key in agent_extras[0].keys():
             values = [
-                float(r[key])
+                float(r[key])  # type: ignore
                 for r in agent_extras
                 if isinstance(r.get(key), (bool, int, float))
             ]

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -78,8 +78,8 @@ class AsyncRolloutManager:
             results = list(
                 await asyncio.gather(
                     *[
-                        self._run_single_rollout(input_sample, gen_idx)
-                        for gen_idx in range(self._num_generations_per_prompt)
+                        self._run_single_rollout(input_sample, traj_idx)
+                        for traj_idx in range(self._num_generations_per_prompt)
                     ]
                 )
             )
@@ -104,7 +104,7 @@ class AsyncRolloutManager:
         )
 
     async def _run_single_rollout(
-        self, input_sample: DatumSpec, gen_idx: int
+        self, input_sample: DatumSpec, traj_idx: int
     ) -> tuple[Completion, dict]:
         """Run one multi-turn rollout for a single generation index."""
         current_message_log = copy.deepcopy(input_sample["message_log"])
@@ -114,16 +114,21 @@ class AsyncRolloutManager:
 
         total_reward = 0.0
         turn_count = 0
-        token_count = 0
+        # token statistics
+        total_token_count = 0
         assistant_token_count = 0
         env_token_count = 0
+        # truncated statistics
         terminated = False
         truncated = False
         max_turns_reached = False
-        turn_gen_tokens: list[int] = []
-        turn_input_tokens: list[int] = []
-        turn_total_tokens: list[int] = []
-        per_worker_token_counts: dict[int, int] = {}
+
+        # Track per-turn metrics
+        turn_gen_tokens = []
+        turn_input_tokens = []
+        turn_total_tokens = []
+        # Track per-turn per-worker token accounting if available
+        per_worker_token_counts = {}  # worker_idx -> token_count
 
         for _ in range(self._max_rollout_turns):
             if terminated or truncated:
@@ -131,6 +136,7 @@ class AsyncRolloutManager:
 
             turn_count += 1
 
+            # Generate response for this sample using async generation
             try:
                 (
                     updated_message_log,
@@ -146,16 +152,19 @@ class AsyncRolloutManager:
                 )
                 current_message_log = updated_message_log
 
+                # Check if response was truncated (hit max_tokens without stop token)
                 response_truncated = gen_metrics.pop("_response_truncated", None)
                 if response_truncated is not None and response_truncated[0]:
                     truncated = True
 
+                # Update token counts
                 gen_token_count = len(generated_tokens)
                 assistant_token_count += gen_token_count
-                token_count += gen_token_count
+                total_token_count += gen_token_count
                 turn_gen_tokens.append(gen_token_count)
                 turn_input_tokens.append(int(input_lengths))
                 turn_total_tokens.append(int(input_lengths) + gen_token_count)
+                # Per-worker load accounting
                 if "gen_leader_worker_idx" in gen_metrics:
                     worker_idx = int(gen_metrics["gen_leader_worker_idx"])
                     per_worker_token_counts[worker_idx] = (
@@ -163,9 +172,10 @@ class AsyncRolloutManager:
                     )
 
             except Exception as e:
-                print(f"Error generating response for gen_idx {gen_idx}: {e}")
+                print(f"Error generating response for prompt_idx {input_sample['idx']}, traj_idx {traj_idx}: {e}")
                 break
 
+            # Create single-sample batch for environment interaction
             sample_batch = BatchedDataDict[DatumSpec](
                 {
                     "message_log": [current_message_log],
@@ -173,10 +183,17 @@ class AsyncRolloutManager:
                     "task_name": [task_name],
                 }
             )
+            # Get environment feedback.
+            # calculate_rewards uses blocking ray.get internally. Running it
+            # directly on the asyncio event loop (which this coroutine runs on)
+            # blocks every other in-flight rollout coroutine for the entire env
+            # step. In this case, need to wrap with asyncio.to_thread to make
+            # this function yieldable.
             env_output = await asyncio.to_thread(
                 calculate_rewards, sample_batch, self._task_to_env
             )
 
+            # Update reward and termination statistics
             total_reward += float(env_output.rewards[0].item())
             terminated = env_output.terminateds[0].item()
             env_obs_content = env_output.observations[0]["content"]
@@ -184,10 +201,12 @@ class AsyncRolloutManager:
                 env_obs_content, return_tensors="pt", add_special_tokens=False
             ).input_ids[0]
 
+            # Check for sequence length overflow
             if (
                 input_lengths + gen_token_count + len(tokenized_obs)
                 >= self._max_seq_len
             ):
+                # Truncate environment observation
                 max_env_tokens = self._max_seq_len - input_lengths - gen_token_count
                 if max_env_tokens > 0:
                     tokenized_obs = tokenized_obs[:max_env_tokens]
@@ -202,9 +221,12 @@ class AsyncRolloutManager:
                     "token_ids": tokenized_obs,
                 }
             )
-            env_token_count += len(tokenized_obs)
-            token_count += len(tokenized_obs)
 
+            # Update token counts
+            env_token_count += len(tokenized_obs)
+            total_token_count += len(tokenized_obs)
+
+            # Update sample state for next turn
             if not terminated and not truncated:
                 if env_output.next_stop_strings[0] is not None:
                     current_stop_strings = env_output.next_stop_strings[0]
@@ -223,7 +245,7 @@ class AsyncRolloutManager:
         )
         sample_metrics = {
             "turn_count": turn_count,
-            "total_tokens": token_count,
+            "total_tokens": total_token_count,
             "assistant_tokens": assistant_token_count,
             "env_tokens": env_token_count,
             "terminated": terminated,

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -73,7 +73,7 @@ class AsyncRolloutManager:
         timer.start(f"{timer_prefix}/total")
 
         with timer.time(f"{timer_prefix}/run_rollouts"):
-            completions = list(
+            results = list(
                 await asyncio.gather(
                     *[
                         self._generate_single_completion(input_sample, gen_idx)
@@ -81,9 +81,11 @@ class AsyncRolloutManager:
                     ]
                 )
             )
+            completions = [c for c, _ in results]
+            all_sample_metrics = [m for _, m in results]
 
-        with timer.time(f"{timer_prefix}/compute_metrics"):
-            rollout_metrics = self._compute_rollout_metrics(completions)
+        with timer.time(f"{timer_prefix}/aggregate_metrics"):
+            rollout_metrics = self._aggregate_rollout_metrics(all_sample_metrics)
 
         timer.stop(f"{timer_prefix}/total")
         rollout_metrics.update(timer.get_timing_metrics("sum"))
@@ -99,8 +101,8 @@ class AsyncRolloutManager:
 
     async def _generate_single_completion(
         self, input_sample: DatumSpec, gen_idx: int
-    ) -> Completion:
-        """Run one rollout for a single generation index and return a Completion."""
+    ) -> tuple[Completion, dict]:
+        """Run one rollout for a single generation index and return a Completion with its sample_metrics."""
         sample_state = {
             "message_log": copy.deepcopy(input_sample["message_log"]),
             "extra_env_info": copy.deepcopy(input_sample["extra_env_info"]),
@@ -125,57 +127,68 @@ class AsyncRolloutManager:
                     float(v.item()) if isinstance(v, torch.Tensor) else float(v)
                 )
 
-        return Completion(
+        completion = Completion(
             message_log=final_state["message_log"],
             env_extras=env_extras,
             truncated=sample_metrics["truncated"],
             reward=float(final_state["total_reward"].item()),
         )
+        return completion, sample_metrics
 
-    def _compute_rollout_metrics(
-        self, completions: list[Completion]
+    def _aggregate_rollout_metrics(
+        self, all_sample_metrics: list[dict]
     ) -> dict[str, Any]:
         """Aggregate per-sample metrics across all completions."""
-        n = len(completions)
+        n = len(all_sample_metrics)
         rollout_metrics: dict[str, Any] = {
-            **_calculate_single_metric(
-                [
-                    sum(1 for m in c.message_log if m["role"] == "user")
-                    for c in completions
-                ],
-                n,
-                "turns_per_sample",
+            "total_turns": sum(m["turn_count"] for m in all_sample_metrics),
+            "avg_turns_per_sample": sum(m["turn_count"] for m in all_sample_metrics)
+            / n,
+            "max_turns_per_sample": max(m["turn_count"] for m in all_sample_metrics),
+            "natural_termination_rate": sum(m["terminated"] for m in all_sample_metrics)
+            / n,
+            "truncation_rate": sum(m["truncated"] for m in all_sample_metrics) / n,
+            "max_turns_reached_rate": sum(
+                m["max_turns_reached"] for m in all_sample_metrics
+            )
+            / n,
+            "mean_total_tokens_per_sample": sum(
+                m["total_tokens"] for m in all_sample_metrics
+            )
+            / n,
+            "mean_gen_tokens_per_sample": sum(
+                m["assistant_tokens"] for m in all_sample_metrics
+            )
+            / n,
+            "max_gen_tokens_per_sample": max(
+                m["assistant_tokens"] for m in all_sample_metrics
             ),
-            **_calculate_single_metric(
-                [sum(len(m["token_ids"]) for m in c.message_log) for c in completions],
-                n,
-                "total_tokens_per_sample",
-            ),
-            **_calculate_single_metric(
-                [
-                    sum(
-                        len(m["token_ids"])
-                        for m in c.message_log
-                        if m["role"] == "assistant"
-                    )
-                    for c in completions
-                ],
-                n,
-                "gen_tokens_per_sample",
-            ),
-            **_calculate_single_metric(
-                [c.reward for c in completions],
-                n,
-                "total_reward",
-            ),
-            "natural_termination_rate": sum(not c.truncated for c in completions) / n,
-            "truncation_rate": sum(c.truncated for c in completions) / n,
+            "mean_env_tokens_per_sample": sum(
+                m["env_tokens"] for m in all_sample_metrics
+            )
+            / n,
+            "mean_total_reward": sum(m["total_reward"] for m in all_sample_metrics) / n,
+            "max_total_reward": max(m["total_reward"] for m in all_sample_metrics),
+            "min_total_reward": min(m["total_reward"] for m in all_sample_metrics),
         }
 
-        # Necessary for downstream nemo rl logging/printing.
-        rollout_metrics["mean_gen_tokens_per_sample"] = rollout_metrics[
-            "gen_tokens_per_sample/mean"
+        if "per_worker_token_counts" in all_sample_metrics[0]:
+            per_worker_token_counts: dict[int, int] = {}
+            for m in all_sample_metrics:
+                for k, v in m["per_worker_token_counts"].items():
+                    per_worker_token_counts[k] = per_worker_token_counts.get(k, 0) + v
+            rollout_metrics["per_worker_token_counts"] = per_worker_token_counts
+
+        rollout_metrics["histogram/gen_tokens_length"] = [
+            t for m in all_sample_metrics for t in m["turn_gen_tokens"]
         ]
+        rollout_metrics["histogram/input_tokens_length"] = [
+            t for m in all_sample_metrics for t in m["turn_input_tokens"]
+        ]
+        rollout_metrics["histogram/total_tokens_length"] = [
+            t for m in all_sample_metrics for t in m["turn_total_tokens"]
+        ]
+
         return rollout_metrics
 
 

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -23,12 +23,14 @@ from transformers import PreTrainedTokenizerBase
 from wandb import Table
 
 from nemo_rl.data.interfaces import DatumSpec
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.experience.interfaces import Completion, PromptGroupRecord
 from nemo_rl.experience.rollouts import (
     _calculate_single_metric,
     _tensorize_by_key,
-    run_sample_multi_turn_rollout,
+    async_generate_response_for_sample_turn,
+    calculate_rewards,
 )
 from nemo_rl.models.generation.interfaces import GenerationConfig, GenerationInterface
 from nemo_rl.utils.timer import Timer
@@ -102,45 +104,135 @@ class AsyncRolloutManager:
     async def _run_single_rollout(
         self, input_sample: DatumSpec, gen_idx: int
     ) -> tuple[Completion, dict]:
-        """Run one rollout for a single generation index and return a Completion with its sample_metrics."""
-        sample_state = {
-            "message_log": copy.deepcopy(input_sample["message_log"]),
-            "extra_env_info": copy.deepcopy(input_sample["extra_env_info"]),
-            "task_name": input_sample["task_name"],
-            "stop_strings": input_sample.get("stop_strings", None),
-            "idx": gen_idx,
-        }
-        final_state, sample_metrics = await run_sample_multi_turn_rollout(
-            sample_idx=gen_idx,
-            initial_sample_state=sample_state,
-            policy_generation=self._policy_generation,
-            tokenizer=self._tokenizer,
-            task_to_env=self._task_to_env,
-            max_seq_len=self._max_seq_len,
-            max_rollout_turns=self._max_rollout_turns,
-        )
+        """Run one multi-turn rollout for a single generation index."""
+        current_message_log = copy.deepcopy(input_sample["message_log"])
+        current_extra_env_info = copy.deepcopy(input_sample["extra_env_info"])
+        current_stop_strings = input_sample.get("stop_strings", None)
+        task_name = input_sample["task_name"]
 
-        completion = self._result_to_completion(final_state, sample_metrics)
-        return completion, sample_metrics
+        total_reward = 0.0
+        turn_count = 0
+        token_count = 0
+        assistant_token_count = 0
+        env_token_count = 0
+        terminated = False
+        truncated = False
+        max_turns_reached = False
+        turn_gen_tokens: list[int] = []
+        turn_input_tokens: list[int] = []
+        turn_total_tokens: list[int] = []
+        per_worker_token_counts: dict[int, int] = {}
 
-    def _result_to_completion(
-        self, final_state: dict, sample_metrics: dict
-    ) -> Completion:
-        """Convert one run_rollouts result dict and sample metrics into a Completion."""
-        # Handle multiple rewards used by GDPO.
-        env_extras: dict[str, Any] = dict(final_state["extra_env_info"])
-        for k, v in final_state.items():
-            if isinstance(k, str) and k.startswith("reward") and k[6:].isdigit():
-                env_extras[k] = (
-                    float(v.item()) if isinstance(v, torch.Tensor) else float(v)
+        for _ in range(self._max_rollout_turns):
+            if terminated or truncated:
+                break
+
+            turn_count += 1
+
+            try:
+                (
+                    updated_message_log,
+                    generated_tokens,
+                    input_lengths,
+                    gen_metrics,
+                ) = await async_generate_response_for_sample_turn(
+                    self._policy_generation,
+                    current_message_log,
+                    current_stop_strings,
+                    self._tokenizer,
+                    self._max_seq_len,
                 )
+                current_message_log = updated_message_log
 
-        return Completion(
-            message_log=final_state["message_log"],
-            env_extras=env_extras,
-            truncated=sample_metrics["truncated"],
-            reward=sample_metrics["total_reward"],
+                response_truncated = gen_metrics.pop("_response_truncated", None)
+                if response_truncated is not None and response_truncated[0]:
+                    truncated = True
+
+                gen_token_count = len(generated_tokens)
+                assistant_token_count += gen_token_count
+                token_count += gen_token_count
+                turn_gen_tokens.append(gen_token_count)
+                turn_input_tokens.append(int(input_lengths))
+                turn_total_tokens.append(int(input_lengths) + gen_token_count)
+                if "gen_leader_worker_idx" in gen_metrics:
+                    worker_idx = int(gen_metrics["gen_leader_worker_idx"])
+                    per_worker_token_counts[worker_idx] = (
+                        per_worker_token_counts.get(worker_idx, 0) + gen_token_count
+                    )
+
+            except Exception as e:
+                print(f"Error generating response for gen_idx {gen_idx}: {e}")
+                break
+
+            sample_batch = BatchedDataDict[DatumSpec](
+                {
+                    "message_log": [current_message_log],
+                    "extra_env_info": [current_extra_env_info],
+                    "task_name": [task_name],
+                }
+            )
+            env_output = await asyncio.to_thread(
+                calculate_rewards, sample_batch, self._task_to_env
+            )
+
+            total_reward += float(env_output.rewards[0].item())
+            terminated = env_output.terminateds[0].item()
+            env_obs_content = env_output.observations[0]["content"]
+            tokenized_obs = self._tokenizer(
+                env_obs_content, return_tensors="pt", add_special_tokens=False
+            ).input_ids[0]
+
+            if (
+                input_lengths + gen_token_count + len(tokenized_obs)
+                >= self._max_seq_len
+            ):
+                max_env_tokens = self._max_seq_len - input_lengths - gen_token_count
+                if max_env_tokens > 0:
+                    tokenized_obs = tokenized_obs[:max_env_tokens]
+                else:
+                    tokenized_obs = torch.empty(0, dtype=tokenized_obs.dtype)
+                truncated = True
+
+            current_message_log.append(
+                {
+                    "role": env_output.observations[0]["role"],
+                    "content": env_obs_content,
+                    "token_ids": tokenized_obs,
+                }
+            )
+            env_token_count += len(tokenized_obs)
+            token_count += len(tokenized_obs)
+
+            if not terminated and not truncated:
+                if env_output.next_stop_strings[0] is not None:
+                    current_stop_strings = env_output.next_stop_strings[0]
+                if env_output.metadata[0] is not None:
+                    current_extra_env_info = env_output.metadata[0]
+
+        if turn_count >= self._max_rollout_turns:
+            max_turns_reached = True
+
+        completion = Completion(
+            message_log=current_message_log,
+            env_extras=current_extra_env_info,
+            truncated=truncated,
+            reward=total_reward,
         )
+        sample_metrics = {
+            "turn_count": turn_count,
+            "total_tokens": token_count,
+            "assistant_tokens": assistant_token_count,
+            "env_tokens": env_token_count,
+            "terminated": terminated,
+            "truncated": truncated,
+            "max_turns_reached": max_turns_reached,
+            "total_reward": total_reward,
+            "turn_gen_tokens": turn_gen_tokens,
+            "turn_input_tokens": turn_input_tokens,
+            "turn_total_tokens": turn_total_tokens,
+            "per_worker_token_counts": per_worker_token_counts,
+        }
+        return completion, sample_metrics
 
     def _aggregate_rollout_metrics(
         self, all_sample_metrics: list[dict]
@@ -186,6 +278,7 @@ class AsyncRolloutManager:
                     per_worker_token_counts[k] = per_worker_token_counts.get(k, 0) + v
             rollout_metrics["per_worker_token_counts"] = per_worker_token_counts
 
+        # Histogram metrics.
         rollout_metrics["histogram/gen_tokens_length"] = [
             t for m in all_sample_metrics for t in m["turn_gen_tokens"]
         ]

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -29,10 +29,13 @@ from nemo_rl.experience.interfaces import Completion, PromptGroupRecord
 from nemo_rl.experience.rollouts import (
     _calculate_single_metric,
     _tensorize_by_key,
-    async_generate_response_for_sample_turn,
     calculate_rewards,
 )
-from nemo_rl.models.generation.interfaces import GenerationConfig, GenerationInterface
+from nemo_rl.models.generation.interfaces import (
+    GenerationConfig,
+    GenerationDatumSpec,
+    GenerationInterface,
+)
 from nemo_rl.utils.timer import Timer
 
 TokenizerType = PreTrainedTokenizerBase
@@ -139,18 +142,14 @@ class AsyncRolloutManager:
             # Generate response for this sample using async generation
             try:
                 (
-                    updated_message_log,
-                    generated_tokens,
+                    assistant_message,
                     input_lengths,
                     gen_metrics,
-                ) = await async_generate_response_for_sample_turn(
-                    self._policy_generation,
+                ) = await self._generate_response(
                     current_message_log,
                     current_stop_strings,
-                    self._tokenizer,
-                    self._max_seq_len,
                 )
-                current_message_log = updated_message_log
+                current_message_log.append(assistant_message)
 
                 # Check if response was truncated (hit max_tokens without stop token)
                 response_truncated = gen_metrics.pop("_response_truncated", None)
@@ -158,7 +157,7 @@ class AsyncRolloutManager:
                     truncated = True
 
                 # Update token counts
-                gen_token_count = len(generated_tokens)
+                gen_token_count = len(assistant_message["token_ids"])
                 assistant_token_count += gen_token_count
                 total_token_count += gen_token_count
                 turn_gen_tokens.append(gen_token_count)
@@ -172,7 +171,9 @@ class AsyncRolloutManager:
                     )
 
             except Exception as e:
-                print(f"Error generating response for prompt_idx {input_sample['idx']}, traj_idx {traj_idx}: {e}")
+                print(
+                    f"Error generating response for prompt_idx {input_sample['idx']}, traj_idx {traj_idx}: {e}"
+                )
                 break
 
             # Create single-sample batch for environment interaction
@@ -256,6 +257,66 @@ class AsyncRolloutManager:
             "per_worker_token_counts": per_worker_token_counts,
         }
         return completion, sample_metrics
+
+    async def _generate_response(
+        self,
+        message_log: list[dict],
+        stop_strings: list[str] | None,
+    ) -> tuple[dict, torch.Tensor, dict[str, Any]]:
+        """Generate a single-turn response for one sample.
+
+        Returns:
+            Tuple of (assistant_message, input_lengths, gen_metrics)
+        """
+        # Prepare generation input
+        input_ids = torch.cat([m["token_ids"] for m in message_log]).unsqueeze(0)
+        input_lengths = torch.tensor([input_ids.shape[1]], dtype=torch.int32)
+        generation_input_data = BatchedDataDict[GenerationDatumSpec](
+            {
+                "input_ids": input_ids,
+                "input_lengths": input_lengths,
+                "stop_strings": [stop_strings],
+            }
+        )
+
+        # Generate response
+        # TODO: update generate_async to return a single item directly
+        output = None
+        async for _idx, output in self._policy_generation.generate_async(
+            generation_input_data
+        ):
+            pass
+
+        # Build assistant message
+        input_len = int(input_lengths[0].item())
+        total_len = int(output["unpadded_sequence_lengths"][0].item())
+        output_ids = output["output_ids"]
+        generated_ids = output_ids[0, input_len:total_len]
+
+        assistant_message: dict = {
+            "role": "assistant",
+            "content": self._tokenizer.decode(generated_ids, skip_special_tokens=True),
+            "token_ids": generated_ids,
+        }
+        if "logprobs" in output:
+            assistant_message["generation_logprobs"] = output["logprobs"][
+                0, input_len:total_len
+            ]
+
+        # Calculate generation metrics
+        gen_metrics: dict[str, Any] = {}
+        if "gen_leader_worker_idx" in output:
+            v = output["gen_leader_worker_idx"][0]
+            try:
+                gen_metrics["gen_leader_worker_idx"] = (
+                    int(v[0]) if isinstance(v, list) else int(v)
+                )
+            except Exception as e:
+                print(f"Error extracting gen_leader_worker_idx: {e}")
+        if "truncated" in output:
+            gen_metrics["_response_truncated"] = output["truncated"]
+
+        return assistant_message, input_lengths, gen_metrics
 
     def _aggregate_rollout_metrics(
         self, completions: list[Completion], all_sample_metrics: list[dict]

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -76,7 +76,7 @@ class AsyncRolloutManager:
             results = list(
                 await asyncio.gather(
                     *[
-                        self._generate_single_completion(input_sample, gen_idx)
+                        self._run_single_rollout(input_sample, gen_idx)
                         for gen_idx in range(self._num_generations_per_prompt)
                     ]
                 )
@@ -92,14 +92,14 @@ class AsyncRolloutManager:
 
         return PromptGroupRecord(
             prompt_idx=input_sample["idx"],
-            prompt=copy.deepcopy(input_sample["message_log"]),
+            prompt=input_sample["message_log"],
             extra_env_info=input_sample["extra_env_info"],
             metadata={"task_name": input_sample["task_name"]},
             completions=completions,
             rollout_metrics=rollout_metrics,
         )
 
-    async def _generate_single_completion(
+    async def _run_single_rollout(
         self, input_sample: DatumSpec, gen_idx: int
     ) -> tuple[Completion, dict]:
         """Run one rollout for a single generation index and return a Completion with its sample_metrics."""
@@ -120,6 +120,14 @@ class AsyncRolloutManager:
             max_rollout_turns=self._max_rollout_turns,
         )
 
+        completion = self._result_to_completion(final_state, sample_metrics)
+        return completion, sample_metrics
+
+    def _result_to_completion(
+        self, final_state: dict, sample_metrics: dict
+    ) -> Completion:
+        """Convert one run_rollouts result dict and sample metrics into a Completion."""
+        # Handle multiple rewards used by GDPO.
         env_extras: dict[str, Any] = dict(final_state["extra_env_info"])
         for k, v in final_state.items():
             if isinstance(k, str) and k.startswith("reward") and k[6:].isdigit():
@@ -127,13 +135,12 @@ class AsyncRolloutManager:
                     float(v.item()) if isinstance(v, torch.Tensor) else float(v)
                 )
 
-        completion = Completion(
+        return Completion(
             message_log=final_state["message_log"],
             env_extras=env_extras,
             truncated=sample_metrics["truncated"],
-            reward=float(final_state["total_reward"].item()),
+            reward=sample_metrics["total_reward"],
         )
-        return completion, sample_metrics
 
     def _aggregate_rollout_metrics(
         self, all_sample_metrics: list[dict]

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -12,22 +12,171 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import copy
 import json
 import warnings
 from typing import Any, Optional
 
+import torch
 from transformers import PreTrainedTokenizerBase
 from wandb import Table
 
 from nemo_rl.data.interfaces import DatumSpec
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.experience.interfaces import Completion, PromptGroupRecord
-from nemo_rl.experience.rollouts import _calculate_single_metric, _tensorize_by_key
-from nemo_rl.models.generation.interfaces import GenerationConfig
+from nemo_rl.experience.rollouts import (
+    _calculate_single_metric,
+    _tensorize_by_key,
+    run_sample_multi_turn_rollout,
+)
+from nemo_rl.models.generation.interfaces import GenerationConfig, GenerationInterface
 from nemo_rl.utils.timer import Timer
 
 TokenizerType = PreTrainedTokenizerBase
+
+
+class AsyncRolloutManager:
+    """Manages per-prompt multi-turn rollouts, producing a PromptGroupRecord per call.
+
+    Each run_rollout takes one prompt and returns num_generations_per_prompt completions
+    generated concurrently via asyncio.gather.
+    """
+
+    def __init__(
+        self,
+        policy_generation: GenerationInterface,
+        tokenizer: TokenizerType,
+        task_to_env: dict[str, EnvironmentInterface],
+        max_seq_len: int,
+        num_generations_per_prompt: int,
+        max_rollout_turns: int = 999999,
+    ) -> None:
+        self._policy_generation = policy_generation
+        self._tokenizer = tokenizer
+        self._task_to_env = task_to_env
+        self._max_seq_len = max_seq_len
+        self._num_generations_per_prompt = num_generations_per_prompt
+        self._max_rollout_turns = max_rollout_turns
+
+    async def run_rollout(self, input_sample: DatumSpec) -> PromptGroupRecord:
+        """Run num_generations_per_prompt rollouts for one prompt.
+
+        Args:
+            input_sample: A single prompt (one DatumSpec entry).
+
+        Returns:
+            PromptGroupRecord with num_generations_per_prompt completions.
+        """
+        timer = Timer()
+        timer_prefix = "timing/rollout"
+        timer.start(f"{timer_prefix}/total")
+
+        with timer.time(f"{timer_prefix}/run_rollouts"):
+            completions = list(
+                await asyncio.gather(
+                    *[
+                        self._generate_single_completion(input_sample, gen_idx)
+                        for gen_idx in range(self._num_generations_per_prompt)
+                    ]
+                )
+            )
+
+        with timer.time(f"{timer_prefix}/compute_metrics"):
+            rollout_metrics = self._compute_rollout_metrics(completions)
+
+        timer.stop(f"{timer_prefix}/total")
+        rollout_metrics.update(timer.get_timing_metrics("sum"))
+
+        return PromptGroupRecord(
+            prompt_idx=input_sample["idx"],
+            prompt=copy.deepcopy(input_sample["message_log"]),
+            extra_env_info=input_sample["extra_env_info"],
+            metadata={"task_name": input_sample["task_name"]},
+            completions=completions,
+            rollout_metrics=rollout_metrics,
+        )
+
+    async def _generate_single_completion(
+        self, input_sample: DatumSpec, gen_idx: int
+    ) -> Completion:
+        """Run one rollout for a single generation index and return a Completion."""
+        sample_state = {
+            "message_log": copy.deepcopy(input_sample["message_log"]),
+            "extra_env_info": copy.deepcopy(input_sample["extra_env_info"]),
+            "task_name": input_sample["task_name"],
+            "stop_strings": input_sample.get("stop_strings", None),
+            "idx": gen_idx,
+        }
+        final_state, sample_metrics = await run_sample_multi_turn_rollout(
+            sample_idx=gen_idx,
+            initial_sample_state=sample_state,
+            policy_generation=self._policy_generation,
+            tokenizer=self._tokenizer,
+            task_to_env=self._task_to_env,
+            max_seq_len=self._max_seq_len,
+            max_rollout_turns=self._max_rollout_turns,
+        )
+
+        env_extras: dict[str, Any] = dict(final_state["extra_env_info"])
+        for k, v in final_state.items():
+            if isinstance(k, str) and k.startswith("reward") and k[6:].isdigit():
+                env_extras[k] = (
+                    float(v.item()) if isinstance(v, torch.Tensor) else float(v)
+                )
+
+        return Completion(
+            message_log=final_state["message_log"],
+            env_extras=env_extras,
+            truncated=sample_metrics["truncated"],
+            reward=float(final_state["total_reward"].item()),
+        )
+
+    def _compute_rollout_metrics(
+        self, completions: list[Completion]
+    ) -> dict[str, Any]:
+        """Aggregate per-sample metrics across all completions."""
+        n = len(completions)
+        rollout_metrics: dict[str, Any] = {
+            **_calculate_single_metric(
+                [
+                    sum(1 for m in c.message_log if m["role"] == "user")
+                    for c in completions
+                ],
+                n,
+                "turns_per_sample",
+            ),
+            **_calculate_single_metric(
+                [sum(len(m["token_ids"]) for m in c.message_log) for c in completions],
+                n,
+                "total_tokens_per_sample",
+            ),
+            **_calculate_single_metric(
+                [
+                    sum(
+                        len(m["token_ids"])
+                        for m in c.message_log
+                        if m["role"] == "assistant"
+                    )
+                    for c in completions
+                ],
+                n,
+                "gen_tokens_per_sample",
+            ),
+            **_calculate_single_metric(
+                [c.reward for c in completions],
+                n,
+                "total_reward",
+            ),
+            "natural_termination_rate": sum(not c.truncated for c in completions) / n,
+            "truncation_rate": sum(c.truncated for c in completions) / n,
+        }
+
+        # Necessary for downstream nemo rl logging/printing.
+        rollout_metrics["mean_gen_tokens_per_sample"] = rollout_metrics[
+            "gen_tokens_per_sample/mean"
+        ]
+        return rollout_metrics
 
 
 class AsyncNemoGymRolloutManager:

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -44,6 +44,7 @@ from nemo_rl.environments.interfaces import (
     EnvironmentInterface,
     EnvironmentReturn,
 )
+from nemo_rl.experience.interfaces import Completion, PromptGroupRecord
 from nemo_rl.models.generation.interfaces import (
     GenerationConfig,
     GenerationDatumSpec,
@@ -1309,4 +1310,85 @@ def run_async_nemo_gym_rollout(
         input_ids=input_ids,
         final_batch=final_batch,
         rollout_metrics=rollout_metrics,
+    )
+
+
+async def run_async_multi_turn_rollout_by_prompt(
+    policy_generation: GenerationInterface,
+    input_sample: DatumSpec,
+    tokenizer: TokenizerType,
+    task_to_env: dict[str, EnvironmentInterface],
+    max_seq_len: int,
+    num_generations_per_prompt: int,
+    max_rollout_turns: int = 999999,
+    greedy: bool = False,
+) -> PromptGroupRecord:
+    """Run multi-turn rollouts for a single prompt, producing multiple completions.
+
+    Each completion is generated independently via run_sample_multi_turn_rollout.
+    All completions are produced concurrently via asyncio.gather.
+
+    Args:
+        policy_generation: The generation interface (policy)
+        input_sample: A single prompt (one DatumSpec entry, not a batch)
+        tokenizer: The tokenizer
+        task_to_env: Dictionary mapping task names to environment instances
+        max_seq_len: Maximum sequence length allowed
+        num_generations_per_prompt: Number of completions to generate
+        max_rollout_turns: Maximum number of agent-environment interaction turns
+        greedy: Whether to use greedy decoding
+
+    Returns:
+        PromptGroupRecord with num_generations_per_prompt completions
+    """
+    prompt_idx = input_sample["idx"]
+    task_name = input_sample["task_name"]
+
+    async def _generate_one(idx: int) -> tuple[dict, dict]:
+        sample_state = {
+            "message_log": copy.deepcopy(input_sample["message_log"]),
+            "extra_env_info": copy.deepcopy(input_sample["extra_env_info"]),
+            "task_name": task_name,
+            "stop_strings": input_sample.get("stop_strings", None),
+            "idx": idx,
+        }
+        return await run_sample_multi_turn_rollout(
+            sample_idx=idx,
+            initial_sample_state=sample_state,
+            policy_generation=policy_generation,
+            tokenizer=tokenizer,
+            task_to_env=task_to_env,
+            max_seq_len=max_seq_len,
+            max_rollout_turns=max_rollout_turns,
+            greedy=greedy,
+        )
+
+    results = await asyncio.gather(
+        *[_generate_one(idx) for idx in range(num_generations_per_prompt)]
+    )
+
+    completions = []
+    for final_state, sample_metrics in results:
+        # Collect per-component reward keys (reward1, reward2, ...) into env_extras
+        env_extras: dict[str, Any] = dict(final_state["extra_env_info"])
+        for k, v in final_state.items():
+            if isinstance(k, str) and k.startswith("reward") and k[6:].isdigit():
+                env_extras[k] = (
+                    float(v.item()) if isinstance(v, torch.Tensor) else float(v)
+                )
+        completions.append(
+            Completion(
+                message_log=final_state["message_log"],
+                env_extras=env_extras,
+                truncated=sample_metrics["truncated"],
+                reward=float(final_state["total_reward"].item()),
+            )
+        )
+
+    return PromptGroupRecord(
+        prompt_idx=prompt_idx,
+        prompt=copy.deepcopy(input_sample["message_log"]),
+        extra_env_info=input_sample["extra_env_info"],
+        metadata={"task_name": task_name},
+        completions=completions,
     )

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -44,7 +44,6 @@ from nemo_rl.environments.interfaces import (
     EnvironmentInterface,
     EnvironmentReturn,
 )
-from nemo_rl.experience.interfaces import Completion, PromptGroupRecord
 from nemo_rl.models.generation.interfaces import (
     GenerationConfig,
     GenerationDatumSpec,
@@ -1310,85 +1309,4 @@ def run_async_nemo_gym_rollout(
         input_ids=input_ids,
         final_batch=final_batch,
         rollout_metrics=rollout_metrics,
-    )
-
-
-async def run_async_multi_turn_rollout_by_prompt(
-    policy_generation: GenerationInterface,
-    input_sample: DatumSpec,
-    tokenizer: TokenizerType,
-    task_to_env: dict[str, EnvironmentInterface],
-    max_seq_len: int,
-    num_generations_per_prompt: int,
-    max_rollout_turns: int = 999999,
-    greedy: bool = False,
-) -> PromptGroupRecord:
-    """Run multi-turn rollouts for a single prompt, producing multiple completions.
-
-    Each completion is generated independently via run_sample_multi_turn_rollout.
-    All completions are produced concurrently via asyncio.gather.
-
-    Args:
-        policy_generation: The generation interface (policy)
-        input_sample: A single prompt (one DatumSpec entry, not a batch)
-        tokenizer: The tokenizer
-        task_to_env: Dictionary mapping task names to environment instances
-        max_seq_len: Maximum sequence length allowed
-        num_generations_per_prompt: Number of completions to generate
-        max_rollout_turns: Maximum number of agent-environment interaction turns
-        greedy: Whether to use greedy decoding
-
-    Returns:
-        PromptGroupRecord with num_generations_per_prompt completions
-    """
-    prompt_idx = input_sample["idx"]
-    task_name = input_sample["task_name"]
-
-    async def _generate_one(idx: int) -> tuple[dict, dict]:
-        sample_state = {
-            "message_log": copy.deepcopy(input_sample["message_log"]),
-            "extra_env_info": copy.deepcopy(input_sample["extra_env_info"]),
-            "task_name": task_name,
-            "stop_strings": input_sample.get("stop_strings", None),
-            "idx": idx,
-        }
-        return await run_sample_multi_turn_rollout(
-            sample_idx=idx,
-            initial_sample_state=sample_state,
-            policy_generation=policy_generation,
-            tokenizer=tokenizer,
-            task_to_env=task_to_env,
-            max_seq_len=max_seq_len,
-            max_rollout_turns=max_rollout_turns,
-            greedy=greedy,
-        )
-
-    results = await asyncio.gather(
-        *[_generate_one(idx) for idx in range(num_generations_per_prompt)]
-    )
-
-    completions = []
-    for final_state, sample_metrics in results:
-        # Collect per-component reward keys (reward1, reward2, ...) into env_extras
-        env_extras: dict[str, Any] = dict(final_state["extra_env_info"])
-        for k, v in final_state.items():
-            if isinstance(k, str) and k.startswith("reward") and k[6:].isdigit():
-                env_extras[k] = (
-                    float(v.item()) if isinstance(v, torch.Tensor) else float(v)
-                )
-        completions.append(
-            Completion(
-                message_log=final_state["message_log"],
-                env_extras=env_extras,
-                truncated=sample_metrics["truncated"],
-                reward=float(final_state["total_reward"].item()),
-            )
-        )
-
-    return PromptGroupRecord(
-        prompt_idx=prompt_idx,
-        prompt=copy.deepcopy(input_sample["message_log"]),
-        extra_env_info=input_sample["extra_env_info"],
-        metadata={"task_name": task_name},
-        completions=completions,
     )

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -1111,6 +1111,8 @@ def test_async_rollout_manager_matches_original(
     then calls AsyncRolloutManager with 1 prompt and N generations.
     Asserts that both produce N results with matching message-log depth, rewards,
     and rollout_metrics numeric values.
+
+    TODO: remove this test together with run_async_multi_turn_rollout when the legacy path is deleted.
     """
     vllm_generation, rollout_tokenizer, task_to_env, _, _ = multi_step_setup_vllm_async
     input_sample = single_multi_step_calculator_input_sample

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -358,10 +358,7 @@ def multi_step_setup_vllm_async(
         print("VllmGeneration cleanup finished (async engine, Multi-Step Calc Test).")
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < 1,
-    reason="VLLM test requires at least 1 GPU",
-)
+@pytest.mark.vllm
 def test_run_multi_step_calculator_vllm_sync(multi_step_setup_vllm_sync):
     """Tests multi-step calculator rollout with VllmGeneration using sync generation and sync rollout."""
     vllm_generation, rollout_tokenizer, task_to_env, initial_batch, rollout_cluster = (
@@ -442,10 +439,7 @@ def test_run_multi_step_calculator_vllm_sync(multi_step_setup_vllm_sync):
     print("\nSync Multi-Step Calculator VLLM Test assertions passed for all samples.")
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < 1,
-    reason="VLLM test requires at least 1 GPU",
-)
+@pytest.mark.vllm
 def test_run_multi_step_calculator_vllm_async(multi_step_setup_vllm_async):
     """Tests multi-step calculator rollout with VllmGeneration using async generation and async rollout."""
     vllm_generation, rollout_tokenizer, task_to_env, initial_batch, rollout_cluster = (
@@ -528,10 +522,7 @@ def test_run_multi_step_calculator_vllm_async(multi_step_setup_vllm_async):
     print("\nAsync Multi-Step Calculator VLLM Test assertions passed for all samples.")
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < 1,
-    reason="VLLM test requires at least 1 GPU",
-)
+@pytest.mark.vllm
 def test_max_seqlen_respected_sync(multi_step_setup_vllm_sync):
     """Tests multi-step calculator rollout with VllmGeneration (sync)."""
     vllm_generation, rollout_tokenizer, task_to_env, initial_batch, rollout_cluster = (
@@ -567,10 +558,7 @@ def test_max_seqlen_respected_sync(multi_step_setup_vllm_sync):
     )
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < 1,
-    reason="VLLM test requires at least 1 GPU",
-)
+@pytest.mark.vllm
 def test_max_seqlen_respected_async(multi_step_setup_vllm_async):
     """Tests multi-step calculator rollout with VllmGeneration (async)."""
     vllm_generation, rollout_tokenizer, task_to_env, initial_batch, rollout_cluster = (
@@ -735,10 +723,7 @@ def sliding_puzzle_setup_vllm(
         print("VllmGeneration cleanup finished (Sliding Puzzle Test).")
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < 1,
-    reason="VLLM test requires at least 1 GPU",
-)
+@pytest.mark.vllm
 def test_run_sliding_puzzle_vllm(sliding_puzzle_setup_vllm):
     """Tests sliding puzzle rollout with VllmGeneration."""
     vllm_generation, rollout_tokenizer, task_to_env, initial_batch, rollout_cluster = (
@@ -1037,6 +1022,7 @@ def single_multi_step_calculator_input_sample(rollout_tokenizer):
     }
 
 
+@pytest.mark.vllm
 def test_async_rollout_manager(
     multi_step_setup_vllm_async,
     single_multi_step_calculator_input_sample,
@@ -1101,6 +1087,7 @@ def test_async_rollout_manager(
     assert record.completions[0].message_log is not record.completions[1].message_log
 
 
+@pytest.mark.vllm
 def test_async_rollout_manager_truncation(
     multi_step_setup_vllm_async,
     single_multi_step_calculator_input_sample,
@@ -1130,6 +1117,7 @@ def test_async_rollout_manager_truncation(
     assert record.rollout_metrics["natural_termination_rate"] == 0.0
 
 
+@pytest.mark.vllm
 def test_async_rollout_manager_matches_original(
     multi_step_setup_vllm_async,
     single_multi_step_calculator_input_sample,

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -1196,10 +1196,14 @@ def test_async_rollout_manager_matches_original(
         if key.startswith("timing/") or key.startswith("histogram/"):
             continue
 
-        assert key in new_metrics, f"rollout_metrics[{key!r}] missing from manager"
+        # renamed in new impl
+        new_key = "mean_turns_per_sample" if key == "avg_turns_per_sample" else key
+        assert new_key in new_metrics, (
+            f"rollout_metrics[{new_key!r}] missing from manager"
+        )
 
         orig_val = original_metrics[key]
-        new_val = new_metrics[key]
+        new_val = new_metrics[new_key]
 
         assert type(orig_val) == type(new_val), (
             f"rollout_metrics[{key!r}] type mismatch: {type(orig_val)} != {type(new_val)}"

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -42,6 +42,7 @@ from nemo_rl.experience.rollout_manager import AsyncNemoGymRolloutManager
 from nemo_rl.experience.rollouts import (
     _calculate_single_metric,
     run_async_multi_turn_rollout,
+    run_async_multi_turn_rollout_by_prompt,
     run_async_nemo_gym_rollout,
     run_multi_turn_rollout,
 )
@@ -973,6 +974,167 @@ def test_run_async_nemo_gym_rollout(
     1. In nemo_rl/experience/rollouts.py::run_async_nemo_gym_rollout, the sampling params are passed appropriately
     2. In nemo_rl/models/generation/vllm/vllm_worker_async.py::VllmAsyncGenerationWorker::_setup_vllm_server::create_chat_completion, the sampling params (like top_k) are set as appropriate
     """
+
+
+# ---------------------------------------------------------------------------
+# Tests for run_async_multi_turn_rollout_by_prompt
+# ---------------------------------------------------------------------------
+
+
+def test_run_async_multi_turn_rollout_by_prompt(
+    multi_step_setup_vllm_async,
+    single_multi_step_calculator_input_sample,
+):
+    """Standalone test for run_async_multi_turn_rollout_by_prompt.
+
+    Given 1 prompt with num_generations_per_prompt=N, asserts:
+    - output is a PromptGroupRecord with N Completion objects
+    - each Completion has a reward (float)
+    - each Completion's message_log has at least 2 messages (prompt + response)
+    - completions hold independent (not aliased) message_log objects
+    """
+    vllm_generation, rollout_tokenizer, task_to_env, _, _ = multi_step_setup_vllm_async
+    input_sample = single_multi_step_calculator_input_sample
+    num_generations = 2
+    max_seq_len = 1024
+    max_rollout_turns = input_sample["extra_env_info"]["max_steps"] + 1
+
+    vllm_generation.prepare_for_generation()
+    record = asyncio.run(
+        run_async_multi_turn_rollout_by_prompt(
+            policy_generation=vllm_generation,
+            input_sample=input_sample,
+            tokenizer=rollout_tokenizer,
+            task_to_env=task_to_env,
+            max_seq_len=max_seq_len,
+            num_generations_per_prompt=num_generations,
+            max_rollout_turns=max_rollout_turns,
+        )
+    )
+    vllm_generation.finish_generation()
+
+    assert isinstance(record, PromptGroupRecord)
+    assert len(record.completions) == num_generations, (
+        f"Expected {num_generations} completions, got {len(record.completions)}"
+    )
+    assert record.prompt_idx == input_sample["idx"]
+
+    for i, completion in enumerate(record.completions):
+        assert isinstance(completion, Completion)
+
+        # 1. message_log length
+        assert len(completion.message_log) == 7, (
+            f"Completion {i}: expected 7 messages, got {len(completion.message_log)}"
+        )
+
+        # 2. last assistant content
+        last_assistant = next(
+            (m for m in reversed(completion.message_log) if m["role"] == "assistant"),
+            None,
+        )
+        assert last_assistant is not None, f"Completion {i}: no assistant message found"
+        assert last_assistant["content"] == " 16", (
+            f"Completion {i}: last assistant content {last_assistant['content']!r} != ' 16'"
+        )
+
+        # 3. reward
+        assert completion.reward == 1.0, (
+            f"Completion {i}: reward {completion.reward} != 1.0"
+        )
+
+    # completions hold independent (not aliased) message_log objects
+    assert record.completions[0].message_log is not record.completions[1].message_log
+
+
+def test_run_async_multi_turn_rollout_by_prompt_matches_original(
+    multi_step_setup_vllm_async,
+    single_multi_step_calculator_input_sample,
+):
+    """Comparison test: _by_prompt output is structurally equivalent to the original.
+
+    Calls run_async_multi_turn_rollout with a batch of N identical prompts,
+    then calls run_async_multi_turn_rollout_by_prompt with 1 prompt and N generations.
+    Asserts that both produce N results with the same message-log depth and reward range.
+    """
+    vllm_generation, rollout_tokenizer, task_to_env, _, _ = multi_step_setup_vllm_async
+    input_sample = single_multi_step_calculator_input_sample
+    num_generations = 2
+    max_seq_len = 1024
+    max_rollout_turns = input_sample["extra_env_info"]["max_steps"] + 1
+
+    # Build a batch of N identical prompts for the original function
+    batch = BatchedDataDict(
+        {
+            "message_log": [
+                deepcopy(input_sample["message_log"]) for _ in range(num_generations)
+            ],
+            "extra_env_info": [
+                deepcopy(input_sample["extra_env_info"]) for _ in range(num_generations)
+            ],
+            "task_name": [input_sample["task_name"]] * num_generations,
+            "stop_strings": [input_sample["stop_strings"]] * num_generations,
+            "idx": list(range(num_generations)),
+            "loss_multiplier": [1.0] * num_generations,
+        }
+    )
+
+    vllm_generation.prepare_for_generation()
+    original_batch, _ = run_async_multi_turn_rollout(
+        policy_generation=vllm_generation,
+        input_batch=batch,
+        tokenizer=rollout_tokenizer,
+        task_to_env=task_to_env,
+        max_seq_len=max_seq_len,
+        max_rollout_turns=max_rollout_turns,
+    )
+
+    record = asyncio.run(
+        run_async_multi_turn_rollout_by_prompt(
+            policy_generation=vllm_generation,
+            input_sample=input_sample,
+            tokenizer=rollout_tokenizer,
+            task_to_env=task_to_env,
+            max_seq_len=max_seq_len,
+            num_generations_per_prompt=num_generations,
+            max_rollout_turns=max_rollout_turns,
+        )
+    )
+    vllm_generation.finish_generation()
+
+    # Both should produce N results
+    assert len(record.completions) == num_generations
+    assert len(original_batch["message_log"]) == num_generations
+
+    for i in range(num_generations):
+        orig_msg_log = original_batch["message_log"][i]
+        new_msg_log = record.completions[i].message_log
+
+        # 1. message_log length matches
+        assert len(orig_msg_log) == len(new_msg_log), (
+            f"Completion {i}: message_log length {len(new_msg_log)} != original {len(orig_msg_log)}"
+        )
+
+        # 2. last assistant content matches
+        def _last_assistant_content(msg_log):
+            for m in reversed(msg_log):
+                if m["role"] == "assistant":
+                    return m.get("content", "")
+            return ""
+
+        orig_last = _last_assistant_content(orig_msg_log)
+        new_last = _last_assistant_content(new_msg_log)
+        assert orig_last == new_last, (
+            f"Completion {i}: last assistant content mismatch\n"
+            f"  original:  {orig_last!r}\n"
+            f"  by_prompt: {new_last!r}"
+        )
+
+        # 3. reward matches
+        orig_reward = original_batch["total_reward"][i].item()
+        new_reward = record.completions[i].reward
+        assert orig_reward == new_reward, (
+            f"Completion {i}: reward mismatch — original {orig_reward}, by_prompt {new_reward}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -978,6 +978,11 @@ def test_run_async_nemo_gym_rollout(
     """
 
 
+# ---------------------------------------------------------------------------
+# Tests for AsyncRolloutManager (native async path)
+# ---------------------------------------------------------------------------
+
+
 @pytest.fixture(scope="function")
 def single_multi_step_calculator_input_sample(rollout_tokenizer):
     """Returns a single DatumSpec prompt dict (problem 0) for AsyncRolloutManager tests."""
@@ -1030,11 +1035,6 @@ def single_multi_step_calculator_input_sample(rollout_tokenizer):
         "stop_strings": ["<call: calculator>"],
         "idx": 0,
     }
-
-
-# ---------------------------------------------------------------------------
-# Tests for AsyncRolloutManager (native async path)
-# ---------------------------------------------------------------------------
 
 
 def test_async_rollout_manager(

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -1078,8 +1078,8 @@ def test_async_rollout_manager(
         assert isinstance(completion, Completion)
 
         # 1. message_log length
-        assert len(completion.message_log) == 7, (
-            f"Completion {i}: expected 7 messages, got {len(completion.message_log)}"
+        assert len(completion.message_log) >= 4, (
+            f"Completion {i}: expected >= 4 messages, got {len(completion.message_log)}"
         )
 
         # 2. last assistant content
@@ -1088,8 +1088,8 @@ def test_async_rollout_manager(
             None,
         )
         assert last_assistant is not None, f"Completion {i}: no assistant message found"
-        assert last_assistant["content"] == " 16", (
-            f"Completion {i}: last assistant content {last_assistant['content']!r} != ' 16'"
+        assert last_assistant["content"].strip() == "16", (
+            f"Completion {i}: last assistant content {last_assistant['content']!r} != '16'"
         )
 
         # 3. reward
@@ -1099,6 +1099,35 @@ def test_async_rollout_manager(
 
     # completions must be independent objects
     assert record.completions[0].message_log is not record.completions[1].message_log
+
+
+def test_async_rollout_manager_truncation(
+    multi_step_setup_vllm_async,
+    single_multi_step_calculator_input_sample,
+):
+    """Small max_seq_len forces truncation and truncation_rate=1.0."""
+    vllm_generation, rollout_tokenizer, task_to_env, _, _ = multi_step_setup_vllm_async
+    input_sample = single_multi_step_calculator_input_sample
+    num_generations = 2
+    max_seq_len = 290
+    max_rollout_turns = input_sample["extra_env_info"]["max_steps"] + 1
+
+    manager = AsyncRolloutManager(
+        policy_generation=vllm_generation,
+        tokenizer=rollout_tokenizer,
+        task_to_env=task_to_env,
+        max_seq_len=max_seq_len,
+        num_generations_per_prompt=num_generations,
+        max_rollout_turns=max_rollout_turns,
+    )
+    vllm_generation.prepare_for_generation()
+    record = asyncio.run(manager.run_rollout(input_sample))
+    vllm_generation.finish_generation()
+
+    assert len(record.completions) == num_generations
+    assert all(c.truncated for c in record.completions)
+    assert record.rollout_metrics["truncation_rate"] == 1.0
+    assert record.rollout_metrics["natural_termination_rate"] == 0.0
 
 
 def test_async_rollout_manager_matches_original(

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -976,6 +976,60 @@ def test_run_async_nemo_gym_rollout(
     """
 
 
+@pytest.fixture(scope="function")
+def single_multi_step_calculator_input_sample(rollout_tokenizer):
+    """Returns a single DatumSpec prompt dict (problem 0) for AsyncRolloutManager tests."""
+    problem_text = "(5 + 3) * 2"
+    expected_answer = 16.0
+    max_steps = 5
+
+    tool_instructions = (
+        "You have a calculator tool. To use it, respond with:\n"
+        "'[operand1, operand2, operation_name]<call: calculator>'\n"
+        "The valid 'operation_name' values are exactly: 'sum', 'diff', 'prod', 'div'.\n"
+        "Example: [5, 3, sum]<call: calculator>\n"
+        "You will receive the result of your calculation as <result>...</result>\n"
+        "Use this result to make the next calculation if needed.\n"
+        "IMPORTANT: Only perform one calculation step (one tool call) before waiting for a result and making a new tool call.\n"
+        "IMPORTANT: Do not perform any other calculations or operations aside from the tool call and result. Doing so will result in failure.\n"
+        "To give the final answer, just output the number. numbers inside of <result> don't count, so output just the final number yourself outside of this.\n"
+        "Example full output: [2, 4, sum]<call: calculator>\n<result>6.0</result>\n[6, 6, diff]<call: calculator>\n<result>0.0</result> 0\n(note how you have to output the final 0 outside of the tags)"
+        "------\n"
+        f"Solve: {problem_text}"
+    )
+
+    initial_prompt_content = rollout_tokenizer.apply_chat_template(
+        [{"role": "user", "content": tool_instructions}],
+        tokenize=False,
+        add_system_prompt=False,
+        add_generation_prompt=True,
+        add_special_tokens=False,
+    )
+    tokenized_prompt = rollout_tokenizer(
+        initial_prompt_content, return_tensors="pt", add_special_tokens=False
+    )["input_ids"][0]
+    message_log = [
+        {
+            "role": "user",
+            "content": initial_prompt_content,
+            "token_ids": tokenized_prompt,
+        }
+    ]
+    metadata = MultiStepCalcMetadata(
+        problem=problem_text,
+        expected_final_answer=expected_answer,
+        max_steps=max_steps,
+        current_step=0,
+    )
+    return {
+        "message_log": message_log,
+        "extra_env_info": metadata,
+        "task_name": "multi_step_calculator_game",
+        "stop_strings": ["<call: calculator>"],
+        "idx": 0,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Tests for run_async_multi_turn_rollout_by_prompt
 # ---------------------------------------------------------------------------

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -38,11 +38,13 @@ from nemo_rl.environments.games.sliding_puzzle import (
     SlidingPuzzleMetadata,
 )
 from nemo_rl.experience.interfaces import Completion, PromptGroupRecord
-from nemo_rl.experience.rollout_manager import AsyncNemoGymRolloutManager
+from nemo_rl.experience.rollout_manager import (
+    AsyncNemoGymRolloutManager,
+    AsyncRolloutManager,
+)
 from nemo_rl.experience.rollouts import (
     _calculate_single_metric,
     run_async_multi_turn_rollout,
-    run_async_multi_turn_rollout_by_prompt,
     run_async_nemo_gym_rollout,
     run_multi_turn_rollout,
 )
@@ -1031,20 +1033,20 @@ def single_multi_step_calculator_input_sample(rollout_tokenizer):
 
 
 # ---------------------------------------------------------------------------
-# Tests for run_async_multi_turn_rollout_by_prompt
+# Tests for AsyncRolloutManager (native async path)
 # ---------------------------------------------------------------------------
 
 
-def test_run_async_multi_turn_rollout_by_prompt(
+def test_async_rollout_manager(
     multi_step_setup_vllm_async,
     single_multi_step_calculator_input_sample,
 ):
-    """Standalone test for run_async_multi_turn_rollout_by_prompt.
+    """Standalone test for AsyncRolloutManager.
 
     Given 1 prompt with num_generations_per_prompt=N, asserts:
     - output is a PromptGroupRecord with N Completion objects
-    - each Completion has a reward (float)
-    - each Completion's message_log has at least 2 messages (prompt + response)
+    - each Completion has a reward (float) and a non-empty message_log
+    - rollout_metrics has the expected keys with correct types
     - completions hold independent (not aliased) message_log objects
     """
     vllm_generation, rollout_tokenizer, task_to_env, _, _ = multi_step_setup_vllm_async
@@ -1053,18 +1055,17 @@ def test_run_async_multi_turn_rollout_by_prompt(
     max_seq_len = 1024
     max_rollout_turns = input_sample["extra_env_info"]["max_steps"] + 1
 
-    vllm_generation.prepare_for_generation()
-    record = asyncio.run(
-        run_async_multi_turn_rollout_by_prompt(
-            policy_generation=vllm_generation,
-            input_sample=input_sample,
-            tokenizer=rollout_tokenizer,
-            task_to_env=task_to_env,
-            max_seq_len=max_seq_len,
-            num_generations_per_prompt=num_generations,
-            max_rollout_turns=max_rollout_turns,
-        )
+    manager = AsyncRolloutManager(
+        policy_generation=vllm_generation,
+        tokenizer=rollout_tokenizer,
+        task_to_env=task_to_env,
+        max_seq_len=max_seq_len,
+        num_generations_per_prompt=num_generations,
+        max_rollout_turns=max_rollout_turns,
     )
+
+    vllm_generation.prepare_for_generation()
+    record = asyncio.run(manager.run_rollout(input_sample))
     vllm_generation.finish_generation()
 
     assert isinstance(record, PromptGroupRecord)
@@ -1096,19 +1097,20 @@ def test_run_async_multi_turn_rollout_by_prompt(
             f"Completion {i}: reward {completion.reward} != 1.0"
         )
 
-    # completions hold independent (not aliased) message_log objects
+    # completions must be independent objects
     assert record.completions[0].message_log is not record.completions[1].message_log
 
 
-def test_run_async_multi_turn_rollout_by_prompt_matches_original(
+def test_async_rollout_manager_matches_original(
     multi_step_setup_vllm_async,
     single_multi_step_calculator_input_sample,
 ):
-    """Comparison test: _by_prompt output is structurally equivalent to the original.
+    """Comparison test: AsyncRolloutManager output is structurally equivalent to the original.
 
     Calls run_async_multi_turn_rollout with a batch of N identical prompts,
-    then calls run_async_multi_turn_rollout_by_prompt with 1 prompt and N generations.
-    Asserts that both produce N results with the same message-log depth and reward range.
+    then calls AsyncRolloutManager with 1 prompt and N generations.
+    Asserts that both produce N results with matching message-log depth, rewards,
+    and rollout_metrics numeric values.
     """
     vllm_generation, rollout_tokenizer, task_to_env, _, _ = multi_step_setup_vllm_async
     input_sample = single_multi_step_calculator_input_sample
@@ -1133,7 +1135,7 @@ def test_run_async_multi_turn_rollout_by_prompt_matches_original(
     )
 
     vllm_generation.prepare_for_generation()
-    original_batch, _ = run_async_multi_turn_rollout(
+    original_batch, original_metrics = run_async_multi_turn_rollout(
         policy_generation=vllm_generation,
         input_batch=batch,
         tokenizer=rollout_tokenizer,
@@ -1142,22 +1144,20 @@ def test_run_async_multi_turn_rollout_by_prompt_matches_original(
         max_rollout_turns=max_rollout_turns,
     )
 
-    record = asyncio.run(
-        run_async_multi_turn_rollout_by_prompt(
-            policy_generation=vllm_generation,
-            input_sample=input_sample,
-            tokenizer=rollout_tokenizer,
-            task_to_env=task_to_env,
-            max_seq_len=max_seq_len,
-            num_generations_per_prompt=num_generations,
-            max_rollout_turns=max_rollout_turns,
-        )
+    manager = AsyncRolloutManager(
+        policy_generation=vllm_generation,
+        tokenizer=rollout_tokenizer,
+        task_to_env=task_to_env,
+        max_seq_len=max_seq_len,
+        num_generations_per_prompt=num_generations,
+        max_rollout_turns=max_rollout_turns,
     )
+    record = asyncio.run(manager.run_rollout(input_sample))
     vllm_generation.finish_generation()
 
     # Both should produce N results
-    assert len(record.completions) == num_generations
     assert len(original_batch["message_log"]) == num_generations
+    assert len(record.completions) == num_generations
 
     for i in range(num_generations):
         orig_msg_log = original_batch["message_log"][i]
@@ -1180,14 +1180,35 @@ def test_run_async_multi_turn_rollout_by_prompt_matches_original(
         assert orig_last == new_last, (
             f"Completion {i}: last assistant content mismatch\n"
             f"  original:  {orig_last!r}\n"
-            f"  by_prompt: {new_last!r}"
+            f"  manager:   {new_last!r}"
         )
 
         # 3. reward matches
         orig_reward = original_batch["total_reward"][i].item()
         new_reward = record.completions[i].reward
         assert orig_reward == new_reward, (
-            f"Completion {i}: reward mismatch — original {orig_reward}, by_prompt {new_reward}"
+            f"Completion {i}: reward mismatch — original {orig_reward}, manager {new_reward}"
+        )
+
+    # 4. rollout_metrics numeric values match (timing and histogram fields are excluded)
+    new_metrics = record.rollout_metrics
+    for key in original_metrics.keys():
+        if key.startswith("timing/") or key.startswith("histogram/"):
+            continue
+
+        assert key in new_metrics, f"rollout_metrics[{key!r}] missing from manager"
+
+        orig_val = original_metrics[key]
+        new_val = new_metrics[key]
+
+        assert type(orig_val) == type(new_val), (
+            f"rollout_metrics[{key!r}] type mismatch: {type(orig_val)} != {type(new_val)}"
+        )
+        if not isinstance(orig_val, (bool, int, float)):
+            continue
+
+        assert orig_val == pytest.approx(new_val), (
+            f"rollout_metrics[{key!r}] mismatch — original {orig_val}, manager {new_val}"
         )
 
 


### PR DESCRIPTION
## Issue

Part of RL-729. Based on #2528.

## Summary

Adds `AsyncRolloutManager` to `rollout_manager.py` to support native async per-prompt multi-turn rollouts.

- `run_rollout` fans out `num_generations_per_prompt` concurrent `_run_single_rollout` coroutines via `asyncio.gather` and returns a `PromptGroupRecord`.
- `_run_single_rollout` is a pure mirror of `run_sample_multi_turn_rollout` (multi-reward support dropped for now).
- `_generate_response` mirrors `async_generate_response_for_sample_turn` + `generate_responses_async`, with simplified logic (single-sample path, no batching indirection).

## Tests

- Extended `tests/unit/experience/test_rollouts.py` with unit tests for `AsyncRolloutManager`.