### PR TITLE
refactor: unify per-prompt rollout to RolloutManager

### DIFF
--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -15,7 +15,6 @@
 import asyncio
 import copy
 import json
-import warnings
 from typing import Any, Optional
 
 import torch
@@ -429,7 +428,6 @@ class AsyncNemoGymRolloutImpl:
         self._num_generations_per_prompt = num_generations_per_prompt
         self._max_seq_len = max_seq_len
         self._max_rollout_turns = max_rollout_turns
-        self._engine_max_model_len = generation_config["vllm_cfg"]["max_model_len"]  # type: ignore
 
         self._validate_init_params()
 
@@ -469,18 +467,6 @@ class AsyncNemoGymRolloutImpl:
         for key in ["stop_strings", "stop_token_ids", "top_k"]:
             assert not self._generation_config[key], (  # type: ignore
                 f"{key} is not supported in the generation config in NeMo-Gym path!"
-            )
-
-        # Validate max_seq_len.
-        if (
-            self._max_seq_len is not None
-            and self._max_seq_len > self._engine_max_model_len
-        ):
-            warnings.warn(
-                f"policy max_total_sequence_length ({self._max_seq_len}) is greater than the "
-                f"generation engine's max_model_len ({self._engine_max_model_len}). The engine "
-                "will truncate sequences to its own limit, so the policy cap will not be "
-                "honored. Lower max_total_sequence_length or raise the engine's max_model_len."
             )
 
         # Validate max_rollout_turns.
@@ -557,8 +543,7 @@ class AsyncNemoGymRolloutImpl:
 
         # Calculate truncation.
         truncated = (
-            sum(len(m["token_ids"]) for m in result["message_log"])
-            == self._engine_max_model_len
+            sum(len(m["token_ids"]) for m in result["message_log"]) == self._max_seq_len
         )
 
         return Completion(
@@ -644,17 +629,14 @@ class RolloutManager:
         tokenizer: TokenizerType,
         task_to_env: dict[str, EnvironmentInterface],
         num_generations_per_prompt: int,
-        use_nemo_gym: bool = False,
-        max_seq_len: Optional[int] = None,
+        max_seq_len: int,
         max_rollout_turns: Optional[int] = None,
         policy_generation: Optional[GenerationInterface] = None,
         generation_config: Optional[GenerationConfig] = None,
+        use_nemo_gym: bool = False,
     ) -> None:
         if not use_nemo_gym:
             rollout_cls = AsyncRolloutImpl
-            assert max_seq_len is not None, (
-                "max_seq_len is required for the native async path"
-            )
             assert policy_generation is not None, (
                 "policy_generation is required for the native async path"
             )

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -49,23 +49,20 @@ class AsyncRolloutImpl:
 
     def __init__(
         self,
-        policy_generation: GenerationInterface,
         tokenizer: TokenizerType,
         task_to_env: dict[str, EnvironmentInterface],
-        max_seq_len: int,
         num_generations_per_prompt: int,
+        max_seq_len: int,
+        policy_generation: GenerationInterface,
         max_rollout_turns: int = 999999,
         **kwargs: Any,
     ) -> None:
-        assert num_generations_per_prompt >= 1, (
-            "num_generations_per_prompt must be >= 1"
-        )
-        self._policy_generation = policy_generation
         self._tokenizer = tokenizer
         self._task_to_env = task_to_env
-        self._max_seq_len = max_seq_len
         self._num_generations_per_prompt = num_generations_per_prompt
+        self._max_seq_len = max_seq_len
         self._max_rollout_turns = max_rollout_turns
+        self._policy_generation = policy_generation
 
     async def run_rollout(self, input_sample: DatumSpec) -> PromptGroupRecord:
         """Run num_generations_per_prompt rollouts for one prompt.
@@ -416,18 +413,18 @@ class AsyncNemoGymRolloutImpl:
         self,
         tokenizer: TokenizerType,
         task_to_env: dict[str, EnvironmentInterface],
-        generation_config: GenerationConfig,
         num_generations_per_prompt: int,
-        max_seq_len: Optional[int] = None,
+        max_seq_len: int,
+        generation_config: GenerationConfig,
         max_rollout_turns: Optional[int] = None,
         **kwargs: Any,
     ) -> None:
         self._tokenizer = tokenizer
         self._task_to_env = task_to_env
-        self._generation_config = generation_config
         self._num_generations_per_prompt = num_generations_per_prompt
         self._max_seq_len = max_seq_len
         self._max_rollout_turns = max_rollout_turns
+        self._generation_config = generation_config
 
         self._validate_init_params()
 
@@ -472,11 +469,6 @@ class AsyncNemoGymRolloutImpl:
         # Validate max_rollout_turns.
         assert self._max_rollout_turns is None, (
             "`max_rollout_turns` is not supported in NeMo-Gym path!"
-        )
-
-        # Validate num_generations_per_prompt.
-        assert self._num_generations_per_prompt >= 1, (
-            "`num_generations_per_prompt` must be >= 1!"
         )
 
     def _build_inputs(self, input_sample: DatumSpec) -> list[dict]:
@@ -635,6 +627,10 @@ class RolloutManager:
         generation_config: Optional[GenerationConfig] = None,
         use_nemo_gym: bool = False,
     ) -> None:
+        assert num_generations_per_prompt >= 1, (
+            "num_generations_per_prompt must be >= 1"
+        )
+
         if not use_nemo_gym:
             rollout_cls = AsyncRolloutImpl
             assert policy_generation is not None, (
@@ -653,8 +649,8 @@ class RolloutManager:
             task_to_env=task_to_env,
             num_generations_per_prompt=num_generations_per_prompt,
             max_seq_len=max_seq_len,
-            max_rollout_turns=max_rollout_turns,
-            policy_generation=policy_generation,
+            max_rollout_turns=max_rollout_turns,  # type: ignore
+            policy_generation=policy_generation,  # type: ignore
             generation_config=generation_config,
         )
 

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -41,7 +41,7 @@ from nemo_rl.utils.timer import Timer
 TokenizerType = PreTrainedTokenizerBase
 
 
-class AsyncRolloutManager:
+class AsyncRolloutImpl:
     """Manages per-prompt multi-turn rollouts, producing a PromptGroupRecord per call.
 
     Each run_rollout takes one prompt and returns num_generations_per_prompt completions
@@ -56,6 +56,7 @@ class AsyncRolloutManager:
         max_seq_len: int,
         num_generations_per_prompt: int,
         max_rollout_turns: int = 999999,
+        **kwargs: Any,
     ) -> None:
         assert num_generations_per_prompt >= 1, (
             "num_generations_per_prompt must be >= 1"
@@ -405,7 +406,7 @@ class AsyncRolloutManager:
         return metrics
 
 
-class AsyncNemoGymRolloutManager:
+class AsyncNemoGymRolloutImpl:
     """Manages per-prompt NeMo-Gym rollouts, producing a PromptGroupRecord per call.
 
     Each run_rollout takes one prompt and returns num_generations_per_prompt completions
@@ -420,6 +421,7 @@ class AsyncNemoGymRolloutManager:
         num_generations_per_prompt: int,
         max_seq_len: Optional[int] = None,
         max_rollout_turns: Optional[int] = None,
+        **kwargs: Any,
     ) -> None:
         self._tokenizer = tokenizer
         self._task_to_env = task_to_env
@@ -632,3 +634,51 @@ class AsyncNemoGymRolloutManager:
             "gen_tokens_per_sample/mean"
         ]
         return rollout_metrics
+
+
+class RolloutManager:
+    """Factory that routes to AsyncRolloutImpl (native async) or AsyncNemoGymRolloutImpl (NeMo-Gym).
+
+    Pass ``policy_generation`` for the native async path, or ``generation_config``
+    for the NeMo-Gym path. Exactly one must be provided.
+    """
+
+    def __init__(
+        self,
+        tokenizer: TokenizerType,
+        task_to_env: dict[str, EnvironmentInterface],
+        num_generations_per_prompt: int,
+        use_nemo_gym: bool = False,
+        max_seq_len: Optional[int] = None,
+        max_rollout_turns: Optional[int] = None,
+        policy_generation: Optional[GenerationInterface] = None,
+        generation_config: Optional[GenerationConfig] = None,
+    ) -> None:
+        if not use_nemo_gym:
+            rollout_cls = AsyncRolloutImpl
+            assert max_seq_len is not None, (
+                "max_seq_len is required for the native async path"
+            )
+            assert policy_generation is not None, (
+                "policy_generation is required for the native async path"
+            )
+            if max_rollout_turns is None:
+                max_rollout_turns = 999999  # use AsyncRolloutImpl's default value
+        else:
+            rollout_cls = AsyncNemoGymRolloutImpl
+            assert generation_config is not None, (
+                "generation_config is required for the NeMo-Gym path"
+            )
+
+        self._impl: AsyncRolloutImpl | AsyncNemoGymRolloutImpl = rollout_cls(
+            tokenizer=tokenizer,
+            task_to_env=task_to_env,
+            num_generations_per_prompt=num_generations_per_prompt,
+            max_seq_len=max_seq_len,
+            max_rollout_turns=max_rollout_turns,
+            policy_generation=policy_generation,
+            generation_config=generation_config,
+        )
+
+    async def run_rollout(self, input_sample: DatumSpec) -> PromptGroupRecord:
+        return await self._impl.run_rollout(input_sample)

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -637,11 +637,7 @@ class AsyncNemoGymRolloutImpl:
 
 
 class RolloutManager:
-    """Factory that routes to AsyncRolloutImpl (native async) or AsyncNemoGymRolloutImpl (NeMo-Gym).
-
-    Pass ``policy_generation`` for the native async path, or ``generation_config``
-    for the NeMo-Gym path. Exactly one must be provided.
-    """
+    """Factory that routes to AsyncRolloutImpl (native async) or AsyncNemoGymRolloutImpl (NeMo-Gym)."""
 
     def __init__(
         self,

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -337,24 +337,14 @@ class AsyncRolloutImpl:
         # Aggregate metrics across all samples.
         n = len(all_sample_metrics)
         rollout_metrics: dict[str, Any] = {
-            **self._aggregate_single_metric(
-                "total_reward", total_reward, ["mean", "max", "min"], n
-            ),
+            **_calculate_single_metric(total_reward, n, "total_reward"),
             # turn metrics
             "total_turns": sum(turn_count),
-            **self._aggregate_single_metric(
-                "turns_per_sample", turn_count, ["mean", "max"], n
-            ),
+            **_calculate_single_metric(turn_count, n, "turns_per_sample"),
             # token metrics
-            **self._aggregate_single_metric(
-                "total_tokens_per_sample", total_tokens, ["mean"], n
-            ),
-            **self._aggregate_single_metric(
-                "gen_tokens_per_sample", assistant_tokens, ["mean", "max"], n
-            ),
-            **self._aggregate_single_metric(
-                "env_tokens_per_sample", env_tokens, ["mean"], n
-            ),
+            **_calculate_single_metric(total_tokens, n, "total_tokens_per_sample"),
+            **_calculate_single_metric(assistant_tokens, n, "gen_tokens_per_sample"),
+            **_calculate_single_metric(env_tokens, n, "env_tokens_per_sample"),
             # truncated metrics
             "truncation_rate": sum(truncated) / n,
             "natural_termination_rate": sum(terminated) / n,
@@ -368,7 +358,8 @@ class AsyncRolloutImpl:
                     per_worker_token_counts[k] = per_worker_token_counts.get(k, 0) + v
             rollout_metrics["per_worker_token_counts"] = per_worker_token_counts
 
-        # Histogram metrics.
+        # Per-turn token histograms (flat across all turns, distinct from the
+        # per-sample histograms emitted via _calculate_single_metric above).
         rollout_metrics["histogram/gen_tokens_length"] = [
             t for m in all_sample_metrics for t in m["turn_gen_tokens"]
         ]
@@ -379,27 +370,11 @@ class AsyncRolloutImpl:
             t for m in all_sample_metrics for t in m["turn_total_tokens"]
         ]
 
+        # Necessary for downstream nemo rl logging/printing.
+        rollout_metrics["mean_gen_tokens_per_sample"] = rollout_metrics[
+            "gen_tokens_per_sample/mean"
+        ]
         return rollout_metrics
-
-    @staticmethod
-    def _aggregate_single_metric(
-        name: str,
-        values: list[float],
-        agg_method: list[str],
-        n: Optional[int] = None,
-    ) -> dict:
-        """Calculate a single metric across a list of values."""
-        metrics = {}
-
-        if "mean" in agg_method:
-            assert n is not None, "n must be provided for mean aggregation"
-            metrics[f"mean_{name}"] = sum(values) / n
-        if "max" in agg_method:
-            metrics[f"max_{name}"] = max(values)
-        if "min" in agg_method:
-            metrics[f"min_{name}"] = min(values)
-
-        return metrics
 
 
 class AsyncNemoGymRolloutImpl:
@@ -551,42 +526,34 @@ class AsyncNemoGymRolloutImpl:
         agent_name: str,
     ) -> dict[str, Any]:
         """Aggregate per-sample and per-agent metrics."""
-        n = len(completions)
+        # Prepare lists of values for each metric.
+        total_reward = [c.reward for c in completions]
+        turn_count = [
+            sum(1 for m in c.message_log if m["role"] == "user") for c in completions
+        ]
+        # token metrics
+        total_tokens = [
+            sum(len(m["token_ids"]) for m in c.message_log) for c in completions
+        ]
+        assistant_tokens = [
+            sum(len(m["token_ids"]) for m in c.message_log if m["role"] == "assistant")
+            for c in completions
+        ]
+        # truncated metrics
+        truncated = [c.truncated for c in completions]
 
-        # Aggregate metrics across all samples
+        # Aggregate metrics across all samples.
+        n = len(completions)
         rollout_metrics: dict[str, Any] = {
-            **_calculate_single_metric(
-                [
-                    sum(1 for m in c.message_log if m["role"] == "user")
-                    for c in completions
-                ],
-                n,
-                "turns_per_sample",
-            ),
-            **_calculate_single_metric(
-                [sum(len(m["token_ids"]) for m in c.message_log) for c in completions],
-                n,
-                "total_tokens_per_sample",
-            ),
-            **_calculate_single_metric(
-                [
-                    sum(
-                        len(m["token_ids"])
-                        for m in c.message_log
-                        if m["role"] == "assistant"
-                    )
-                    for c in completions
-                ],
-                n,
-                "gen_tokens_per_sample",
-            ),
-            **_calculate_single_metric(
-                [c.reward for c in completions],
-                n,
-                "total_reward",
-            ),
-            "natural_termination_rate": sum(not c.truncated for c in completions) / n,
-            "truncation_rate": sum(c.truncated for c in completions) / n,
+            **_calculate_single_metric(total_reward, n, "total_reward"),
+            # turn metrics
+            **_calculate_single_metric(turn_count, n, "turns_per_sample"),
+            # token metrics
+            **_calculate_single_metric(total_tokens, n, "total_tokens_per_sample"),
+            **_calculate_single_metric(assistant_tokens, n, "gen_tokens_per_sample"),
+            # truncated metrics
+            "natural_termination_rate": sum(not t for t in truncated) / n,
+            "truncation_rate": sum(truncated) / n,
         }
 
         # Agent-level metrics.

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -22,6 +22,7 @@ import math
 import statistics
 import warnings
 from collections import defaultdict
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -1079,7 +1080,7 @@ class AsyncNemoGymRolloutResult:
 
 
 def _calculate_single_metric(
-    values: list[float], batch_size: int, key_name: str
+    values: Sequence[float | int], batch_size: int, key_name: str
 ) -> dict:
     return {
         f"{key_name}/mean": sum(values) / batch_size,

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -39,8 +39,9 @@ from nemo_rl.environments.games.sliding_puzzle import (
 )
 from nemo_rl.experience.interfaces import Completion, PromptGroupRecord
 from nemo_rl.experience.rollout_manager import (
-    AsyncNemoGymRolloutManager,
-    AsyncRolloutManager,
+    AsyncNemoGymRolloutImpl,
+    AsyncRolloutImpl,
+    RolloutManager,
 )
 from nemo_rl.experience.rollouts import (
     _calculate_single_metric,
@@ -964,6 +965,25 @@ def test_run_async_nemo_gym_rollout(
 
 
 # ---------------------------------------------------------------------------
+# Tests for RolloutManager
+# ---------------------------------------------------------------------------
+
+
+def test_rollout_manager_raises_without_impl_params():
+    """RolloutManager raises AssertionError when required params are missing."""
+    common = dict(tokenizer=None, task_to_env={}, num_generations_per_prompt=1)
+
+    with pytest.raises(AssertionError, match="policy_generation is required"):
+        RolloutManager(**common, use_nemo_gym=False, max_seq_len=1024)
+
+    with pytest.raises(AssertionError, match="max_seq_len is required"):
+        RolloutManager(**common, use_nemo_gym=False, policy_generation=object())
+
+    with pytest.raises(AssertionError, match="generation_config is required"):
+        RolloutManager(**common, use_nemo_gym=True)
+
+
+# ---------------------------------------------------------------------------
 # Tests for AsyncRolloutManager (native async path)
 # ---------------------------------------------------------------------------
 
@@ -1041,7 +1061,7 @@ def test_async_rollout_manager(
     max_seq_len = 1024
     max_rollout_turns = input_sample["extra_env_info"]["max_steps"] + 1
 
-    manager = AsyncRolloutManager(
+    manager = AsyncRolloutImpl(
         policy_generation=vllm_generation,
         tokenizer=rollout_tokenizer,
         task_to_env=task_to_env,
@@ -1163,7 +1183,7 @@ def test_async_rollout_manager_matches_original(
         max_rollout_turns=max_rollout_turns,
     )
 
-    manager = AsyncRolloutManager(
+    manager = AsyncRolloutImpl(
         policy_generation=vllm_generation,
         tokenizer=rollout_tokenizer,
         task_to_env=task_to_env,
@@ -1281,7 +1301,7 @@ def test_async_nemo_gym_rollout_manager(
     }
     num_generations = 2
 
-    manager = AsyncNemoGymRolloutManager(
+    manager = AsyncNemoGymRolloutImpl(
         tokenizer=nemo_gym_tokenizer,
         task_to_env={"nemo_gym": nemo_gym},
         generation_config=nemo_gym_vllm_generation.cfg,
@@ -1391,7 +1411,7 @@ def test_async_nemo_gym_rollout_manager_matches_original(
         max_rollout_turns=None,
     )
 
-    manager = AsyncNemoGymRolloutManager(
+    manager = AsyncNemoGymRolloutImpl(
         tokenizer=nemo_gym_tokenizer,
         task_to_env={"nemo_gym": nemo_gym},
         generation_config=nemo_gym_vllm_generation.cfg,

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -1234,14 +1234,23 @@ def test_async_rollout_manager_matches_original(
             f"Completion {i}: reward mismatch — original {orig_reward}, manager {new_reward}"
         )
 
-    # 4. rollout_metrics numeric values match (timing and histogram fields are excluded)
+    # 4. rollout_metrics numeric values match (timing and histogram fields are excluded).
+    # The new impl emits slash-style keys (X/mean, X/max, X/min) via _calculate_single_metric;
+    # translate the legacy prefix-style keys before comparing.
+    def _translate_legacy_key(key: str) -> str:
+        if key == "avg_turns_per_sample":
+            return "turns_per_sample/mean"
+        for prefix, suffix in (("mean_", "/mean"), ("max_", "/max"), ("min_", "/min")):
+            if key.startswith(prefix):
+                return f"{key[len(prefix) :]}{suffix}"
+        return key
+
     new_metrics = record.rollout_metrics
     for key in original_metrics.keys():
         if key.startswith("timing/") or key.startswith("histogram/"):
             continue
 
-        # renamed in new impl
-        new_key = "mean_turns_per_sample" if key == "avg_turns_per_sample" else key
+        new_key = _translate_legacy_key(key)
         assert new_key in new_metrics, (
             f"rollout_metrics[{new_key!r}] missing from manager"
         )

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -1123,13 +1123,14 @@ def test_async_rollout_manager_truncation(
     max_seq_len = 290
     max_rollout_turns = input_sample["extra_env_info"]["max_steps"] + 1
 
-    manager = AsyncRolloutManager(
-        policy_generation=vllm_generation,
+    manager = RolloutManager(
+        use_nemo_gym=False,
         tokenizer=rollout_tokenizer,
         task_to_env=task_to_env,
-        max_seq_len=max_seq_len,
         num_generations_per_prompt=num_generations,
+        max_seq_len=max_seq_len,
         max_rollout_turns=max_rollout_turns,
+        policy_generation=vllm_generation,
     )
     vllm_generation.prepare_for_generation()
     record = asyncio.run(manager.run_rollout(input_sample))

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -967,13 +967,20 @@ def test_run_async_nemo_gym_rollout(
 
 def test_rollout_manager_raises_without_impl_params():
     """RolloutManager raises AssertionError when required params are missing."""
-    common = dict(tokenizer=None, task_to_env={}, num_generations_per_prompt=1)
+    common = {
+        "tokenizer": None,
+        "task_to_env": {},
+        "num_generations_per_prompt": 1,
+        "max_seq_len": 1,
+    }
+
+    with pytest.raises(AssertionError, match="num_generations_per_prompt must be >= 1"):
+        updated_common = common.copy()
+        updated_common["num_generations_per_prompt"] = 0
+        RolloutManager(**updated_common, use_nemo_gym=False)
 
     with pytest.raises(AssertionError, match="policy_generation is required"):
-        RolloutManager(**common, use_nemo_gym=False, max_seq_len=1024)
-
-    with pytest.raises(AssertionError, match="max_seq_len is required"):
-        RolloutManager(**common, use_nemo_gym=False, policy_generation=object())
+        RolloutManager(**common, use_nemo_gym=False)
 
     with pytest.raises(AssertionError, match="generation_config is required"):
         RolloutManager(**common, use_nemo_gym=True)
@@ -1059,12 +1066,12 @@ def test_async_rollout_manager(
 
     manager = RolloutManager(
         use_nemo_gym=False,
-        policy_generation=vllm_generation,
         tokenizer=rollout_tokenizer,
         task_to_env=task_to_env,
-        max_seq_len=max_seq_len,
         num_generations_per_prompt=num_generations,
+        max_seq_len=max_seq_len,
         max_rollout_turns=max_rollout_turns,
+        policy_generation=vllm_generation,
     )
 
     vllm_generation.prepare_for_generation()
@@ -1182,12 +1189,12 @@ def test_async_rollout_manager_matches_original(
 
     manager = RolloutManager(
         use_nemo_gym=False,
-        policy_generation=vllm_generation,
         tokenizer=rollout_tokenizer,
         task_to_env=task_to_env,
-        max_seq_len=max_seq_len,
         num_generations_per_prompt=num_generations,
+        max_seq_len=max_seq_len,
         max_rollout_turns=max_rollout_turns,
+        policy_generation=vllm_generation,
     )
     record = asyncio.run(manager.run_rollout(input_sample))
     vllm_generation.finish_generation()
@@ -1303,9 +1310,9 @@ def test_async_nemo_gym_rollout_manager(
         use_nemo_gym=True,
         tokenizer=nemo_gym_tokenizer,
         task_to_env={"nemo_gym": nemo_gym},
-        generation_config=nemo_gym_vllm_generation.cfg,
         num_generations_per_prompt=num_generations,
         max_seq_len=nemo_gym_vllm_generation.cfg["vllm_cfg"]["max_model_len"],
+        generation_config=nemo_gym_vllm_generation.cfg,
     )
     record = asyncio.run(manager.run_rollout(single_prompt))
 
@@ -1414,9 +1421,9 @@ def test_async_nemo_gym_rollout_manager_matches_original(
         use_nemo_gym=True,
         tokenizer=nemo_gym_tokenizer,
         task_to_env={"nemo_gym": nemo_gym},
-        generation_config=nemo_gym_vllm_generation.cfg,
         num_generations_per_prompt=num_generations,
         max_seq_len=nemo_gym_vllm_generation.cfg["vllm_cfg"]["max_model_len"],
+        generation_config=nemo_gym_vllm_generation.cfg,
     )
     record = asyncio.run(manager.run_rollout(single_prompt))
 

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -38,11 +38,7 @@ from nemo_rl.environments.games.sliding_puzzle import (
     SlidingPuzzleMetadata,
 )
 from nemo_rl.experience.interfaces import Completion, PromptGroupRecord
-from nemo_rl.experience.rollout_manager import (
-    AsyncNemoGymRolloutImpl,
-    AsyncRolloutImpl,
-    RolloutManager,
-)
+from nemo_rl.experience.rollout_manager import RolloutManager
 from nemo_rl.experience.rollouts import (
     _calculate_single_metric,
     run_async_multi_turn_rollout,
@@ -1061,7 +1057,8 @@ def test_async_rollout_manager(
     max_seq_len = 1024
     max_rollout_turns = input_sample["extra_env_info"]["max_steps"] + 1
 
-    manager = AsyncRolloutImpl(
+    manager = RolloutManager(
+        use_nemo_gym=False,
         policy_generation=vllm_generation,
         tokenizer=rollout_tokenizer,
         task_to_env=task_to_env,
@@ -1183,7 +1180,8 @@ def test_async_rollout_manager_matches_original(
         max_rollout_turns=max_rollout_turns,
     )
 
-    manager = AsyncRolloutImpl(
+    manager = RolloutManager(
+        use_nemo_gym=False,
         policy_generation=vllm_generation,
         tokenizer=rollout_tokenizer,
         task_to_env=task_to_env,
@@ -1301,7 +1299,8 @@ def test_async_nemo_gym_rollout_manager(
     }
     num_generations = 2
 
-    manager = AsyncNemoGymRolloutImpl(
+    manager = RolloutManager(
+        use_nemo_gym=True,
         tokenizer=nemo_gym_tokenizer,
         task_to_env={"nemo_gym": nemo_gym},
         generation_config=nemo_gym_vllm_generation.cfg,
@@ -1411,7 +1410,8 @@ def test_async_nemo_gym_rollout_manager_matches_original(
         max_rollout_turns=None,
     )
 
-    manager = AsyncNemoGymRolloutImpl(
+    manager = RolloutManager(
+        use_nemo_gym=True,
         tokenizer=nemo_gym_tokenizer,
         task_to_env={"nemo_gym": nemo_gym},
         generation_config=nemo_gym_vllm_generation.cfg,


### PR DESCRIPTION
## Issue

Part of RL-729. Based on #2566.

## Summary

Refactors `AsyncRolloutManager` and `AsyncNemoGymRolloutManager` into a unified `RolloutManager` factory.

- Rename the two concrete classes to `AsyncRolloutImpl` / `AsyncNemoGymRolloutImpl`
- Add `RolloutManager` that accepts `use_nemo_gym: bool` and routes to the appropriate impl, with assertions for required path-specific args
- Add `**kwargs` to both impl constructors to accept the combined parameter set

## Tests

- Updated all existing `AsyncRolloutManager` / `AsyncNemoGymRolloutManager` callsites in `tests/unit/experience/test_rollouts.py` to use `RolloutManager`
- Added `test_rollout_manager_raises_without_impl_params` to cover the three assertion paths