### PR TITLE
feat(vllm): support custom reasoning parser plugins

### DIFF
--- a/examples/nemo_gym/grpo_nanov3.yaml
+++ b/examples/nemo_gym/grpo_nanov3.yaml
@@ -210,10 +210,11 @@ policy:
       num_last_layers_in_bf16: 0
       num_first_layers_in_bf16: 0
       expose_http_server: true
+      reasoning_parser_plugin: nemo_rl/models/generation/vllm/reasoning_parsers/nano_v3_reasoning_parser.py
       http_server_serving_chat_kwargs:
         enable_auto_tools: true
         tool_parser: qwen3_coder
-        reasoning_parser: deepseek_r1
+        reasoning_parser: nano_v3
 
     vllm_kwargs:
       mamba_ssm_cache_dtype: "float32"

--- a/nemo_rl/models/generation/vllm/config.py
+++ b/nemo_rl/models/generation/vllm/config.py
@@ -39,6 +39,8 @@ class VllmSpecificArgs(TypedDict):
     # Miscellaneous top level vLLM HTTP server arguments.
     # A filepath that can be imported to register a vLLM tool parser
     tool_parser_plugin: NotRequired[str]
+    # A filepath that can be imported to register a vLLM reasoning parser
+    reasoning_parser_plugin: NotRequired[str]
 
 
 class VllmConfig(GenerationConfig):

--- a/nemo_rl/models/generation/vllm/reasoning_parsers/nano_v3_reasoning_parser.py
+++ b/nemo_rl/models/generation/vllm/reasoning_parsers/nano_v3_reasoning_parser.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from vllm.reasoning.abs_reasoning_parsers import ReasoningParserManager
+from vllm.reasoning.deepseek_r1_reasoning_parser import DeepSeekR1ReasoningParser
+
+
+@ReasoningParserManager.register_module("nano_v3")
+class NanoV3ReasoningParser(DeepSeekR1ReasoningParser):
+    """Reasoning parser for NVIDIA Nemotron Nano v3 models."""
+
+    def extract_reasoning(self, model_output, request):
+        reasoning_content, final_content = super().extract_reasoning(
+            model_output, request
+        )
+        chat_template_kwargs = getattr(request, "chat_template_kwargs", None)
+        if (
+            chat_template_kwargs
+            and chat_template_kwargs.get("enable_thinking") is False
+            and final_content is None
+        ):
+            return None, reasoning_content
+
+        return reasoning_content, final_content

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -350,12 +350,21 @@ class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
             OpenAIServingTokenization,
         )
         from vllm.exceptions import VLLMValidationError
+        from vllm.reasoning.abs_reasoning_parsers import ReasoningParserManager
         from vllm.tool_parsers.abstract_tool_parser import ToolParserManager
         from vllm.v1.engine.async_llm import logger as vllm_async_llm_logger
 
         maybe_tool_parser_plugin = self.cfg["vllm_cfg"].get("tool_parser_plugin")
         if maybe_tool_parser_plugin:
             ToolParserManager.import_tool_parser(maybe_tool_parser_plugin)
+
+        maybe_reasoning_parser_plugin = self.cfg["vllm_cfg"].get(
+            "reasoning_parser_plugin"
+        )
+        if maybe_reasoning_parser_plugin:
+            ReasoningParserManager.import_reasoning_parser(
+                maybe_reasoning_parser_plugin
+            )
 
         engine_client = self.llm
         model_config = self.llm_async_engine_args.create_model_config()

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -147,6 +147,7 @@ project-includes = [
   "nemo_rl/models/generation/vllm/__init__.py",
   "nemo_rl/models/generation/vllm/config.py",
   "nemo_rl/models/generation/vllm/quantization/fp8_train_utils.py",
+  "nemo_rl/models/generation/vllm/reasoning_parsers/nano_v3_reasoning_parser.py",
   "nemo_rl/models/generation/vllm/utils.py",
   "nemo_rl/models/generation/vllm/vllm_backend.py",
   "nemo_rl/models/huggingface/__init__.py",

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -14,6 +14,8 @@
 
 import json
 import os
+import sys
+import types
 from copy import deepcopy
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -178,6 +180,166 @@ def skip_fp8_known_failures() -> None:
             f"Skipping FP8 vLLM test on {device_name} due to a known failure. "
             "See https://github.com/NVIDIA-NeMo/RL/issues/2081"
         )
+
+
+def _install_fake_vllm_openai_modules(monkeypatch):
+    for module_name in (
+        "vllm",
+        "vllm.entrypoints",
+        "vllm.entrypoints.openai",
+        "vllm.entrypoints.openai.chat_completion",
+        "vllm.entrypoints.openai.engine",
+        "vllm.entrypoints.openai.models",
+        "vllm.entrypoints.serve",
+        "vllm.entrypoints.serve.render",
+        "vllm.entrypoints.serve.tokenize",
+        "vllm.reasoning",
+        "vllm.tool_parsers",
+        "vllm.v1",
+        "vllm.v1.engine",
+    ):
+        monkeypatch.setitem(sys.modules, module_name, types.ModuleType(module_name))
+
+    def make_module(name: str, **attrs):
+        module = types.ModuleType(name)
+        for attr_name, attr_value in attrs.items():
+            setattr(module, attr_name, attr_value)
+        monkeypatch.setitem(sys.modules, name, module)
+        return module
+
+    class BaseModelPath:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class OpenAIServingModels:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.registry = "registry"
+
+    class OpenAIServingRender:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.renderer = kwargs["renderer"]
+
+    class OpenAIServingChat:
+        instances = []
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.instances.append(self)
+
+    class OpenAIServingTokenization:
+        instances = []
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.instances.append(self)
+
+    class VLLMValidationError(Exception):
+        pass
+
+    class ToolParserManager:
+        import_tool_parser = MagicMock()
+
+    class ReasoningParserManager:
+        import_reasoning_parser = MagicMock()
+
+    make_module(
+        "vllm.entrypoints.openai.chat_completion.protocol",
+        ChatCompletionRequest=type("ChatCompletionRequest", (), {}),
+        ChatCompletionResponse=type("ChatCompletionResponse", (), {}),
+    )
+    make_module(
+        "vllm.entrypoints.openai.chat_completion.serving",
+        OpenAIServingChat=OpenAIServingChat,
+    )
+    make_module(
+        "vllm.entrypoints.openai.engine.protocol",
+        ErrorResponse=type("ErrorResponse", (), {}),
+    )
+    make_module(
+        "vllm.entrypoints.openai.models.protocol",
+        BaseModelPath=BaseModelPath,
+    )
+    make_module(
+        "vllm.entrypoints.openai.models.serving",
+        OpenAIServingModels=OpenAIServingModels,
+    )
+    make_module(
+        "vllm.entrypoints.serve.tokenize.protocol",
+        TokenizeChatRequest=type("TokenizeChatRequest", (), {}),
+        TokenizeCompletionRequest=type("TokenizeCompletionRequest", (), {}),
+        TokenizeResponse=type("TokenizeResponse", (), {}),
+    )
+    make_module(
+        "vllm.entrypoints.serve.render.serving",
+        OpenAIServingRender=OpenAIServingRender,
+    )
+    make_module(
+        "vllm.entrypoints.serve.tokenize.serving",
+        OpenAIServingTokenization=OpenAIServingTokenization,
+    )
+    make_module("vllm.exceptions", VLLMValidationError=VLLMValidationError)
+    make_module(
+        "vllm.reasoning.abs_reasoning_parsers",
+        ReasoningParserManager=ReasoningParserManager,
+    )
+    make_module(
+        "vllm.tool_parsers.abstract_tool_parser",
+        ToolParserManager=ToolParserManager,
+    )
+    make_module("vllm.v1.engine.async_llm", logger=MagicMock())
+    return ToolParserManager, ReasoningParserManager, OpenAIServingChat
+
+
+class _FakeFastAPIApp:
+    def __init__(self):
+        self.routes = []
+
+    def post(self, path):
+        def decorator(func):
+            self.routes.append((path, func))
+            return func
+
+        return decorator
+
+
+def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch):
+    (
+        tool_parser_manager,
+        reasoning_parser_manager,
+        openai_serving_chat,
+    ) = _install_fake_vllm_openai_modules(monkeypatch)
+
+    worker = VllmAsyncGenerationWorkerImpl.__new__(VllmAsyncGenerationWorkerImpl)
+    worker.cfg = {
+        "temperature": 1.0,
+        "top_p": 1.0,
+        "vllm_cfg": {
+            "tool_parser_plugin": "/plugins/tool_parser.py",
+            "reasoning_parser_plugin": "/plugins/reasoning_parser.py",
+            "http_server_serving_chat_kwargs": {
+                "reasoning_parser": "nano_v3",
+            },
+        },
+    }
+    worker.llm = MagicMock(model_config="model-config", renderer="renderer")
+    model_config = MagicMock(served_model_name="served-model", model="model-path")
+    worker.llm_async_engine_args = MagicMock()
+    worker.llm_async_engine_args.create_model_config.return_value = model_config
+
+    app = _FakeFastAPIApp()
+    assert worker._setup_vllm_openai_api_server(app) is app
+
+    tool_parser_manager.import_tool_parser.assert_called_once_with(
+        "/plugins/tool_parser.py"
+    )
+    reasoning_parser_manager.import_reasoning_parser.assert_called_once_with(
+        "/plugins/reasoning_parser.py"
+    )
+    assert openai_serving_chat.instances[0].kwargs["reasoning_parser"] == "nano_v3"
+    # make sure that the config attribute does not leak into `http_server_serving_chat_kwargs`
+    assert "reasoning_parser_plugin" not in openai_serving_chat.instances[0].kwargs
 
 
 def test_configure_generation_config_uses_real_startup_weights_without_draft_refit():

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib.util
 import json
 import os
 import sys
@@ -39,6 +40,7 @@ from nemo_rl.models.generation.vllm.vllm_worker import (
     _resolve_enable_prefix_caching,
 )
 from nemo_rl.models.generation.vllm.vllm_worker_async import (
+    VllmAsyncGenerationWorkerImpl,
     _replace_prefix_tokens,
 )
 from nemo_rl.models.policy import LoRAConfig, PolicyConfig
@@ -340,6 +342,86 @@ def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch):
     assert openai_serving_chat.instances[0].kwargs["reasoning_parser"] == "nano_v3"
     # make sure that the config attribute does not leak into `http_server_serving_chat_kwargs`
     assert "reasoning_parser_plugin" not in openai_serving_chat.instances[0].kwargs
+
+
+def test_nano_v3_reasoning_parser_swaps_reasoning_when_thinking_disabled(
+    monkeypatch,
+):
+    registered_reasoning_parsers = {}
+
+    for module_name in (
+        "vllm",
+        "vllm.reasoning",
+    ):
+        monkeypatch.setitem(sys.modules, module_name, types.ModuleType(module_name))
+
+    class ReasoningParserManager:
+        @staticmethod
+        def register_module(name):
+            def decorator(parser_cls):
+                registered_reasoning_parsers[name] = parser_cls
+                return parser_cls
+
+            return decorator
+
+    class DeepSeekR1ReasoningParser:
+        def __init__(self, tokenizer, *args, **kwargs):
+            self.tokenizer = tokenizer
+
+        def extract_reasoning(self, model_output, request):
+            return model_output
+
+    abs_reasoning_parsers = types.ModuleType("vllm.reasoning.abs_reasoning_parsers")
+    abs_reasoning_parsers.ReasoningParserManager = ReasoningParserManager
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.reasoning.abs_reasoning_parsers",
+        abs_reasoning_parsers,
+    )
+
+    deepseek_reasoning_parser = types.ModuleType(
+        "vllm.reasoning.deepseek_r1_reasoning_parser"
+    )
+    deepseek_reasoning_parser.DeepSeekR1ReasoningParser = DeepSeekR1ReasoningParser
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.reasoning.deepseek_r1_reasoning_parser",
+        deepseek_reasoning_parser,
+    )
+
+    repo_root = Path(__file__).resolve().parents[4]
+    parser_path = (
+        repo_root
+        / "nemo_rl/models/generation/vllm/reasoning_parsers/nano_v3_reasoning_parser.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "test_nano_v3_reasoning_parser",
+        parser_path,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    parser_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(parser_module)
+
+    assert (
+        registered_reasoning_parsers["nano_v3"] is parser_module.NanoV3ReasoningParser
+    )
+    parser = parser_module.NanoV3ReasoningParser(tokenizer=object())
+
+    request = types.SimpleNamespace(chat_template_kwargs={"enable_thinking": False})
+    assert parser.extract_reasoning(("answer", None), request) == (None, "answer")
+
+    request.chat_template_kwargs["enable_thinking"] = True
+    assert parser.extract_reasoning(("reasoning", None), request) == (
+        "reasoning",
+        None,
+    )
+
+    request.chat_template_kwargs["enable_thinking"] = False
+    assert parser.extract_reasoning(("reasoning", "final"), request) == (
+        "reasoning",
+        "final",
+    )
 
 
 def test_configure_generation_config_uses_real_startup_weights_without_draft_refit():


### PR DESCRIPTION
# What does this PR do ?

**Adds support for registering custom vLLM reasoning parser plugins when exposing the async vLLM OpenAI-compatible HTTP server.**

Also adds `nano_v3_reasoning_parser.py` and makes appropriate config changes in `grpo_nano_v3.yaml`

# Issues
Fixes custom reasoning parser part of https://github.com/NVIDIA-NeMo/RL/issues/1906


# Usage
Add `reasoning_parser_plugin` under `policy.generation.vllm_cfg` and select the registered parser through `http_server_serving_chat_kwargs`:

```yaml
policy:
  generation:
    vllm_cfg:
      expose_http_server: true
      reasoning_parser_plugin: /plugins/reasoning_parser.py
      http_server_serving_chat_kwargs:
        reasoning_parser: custom_reasoning_parser
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
