### PR TITLE
build: consolidate deep_ep pins into a single deep-ep extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,8 +108,15 @@ fsdp = [
   "mamba-ssm",
   "causal-conv1d",
 ]
+deep-ep = [
+  # Pinned per-arch for HybridEP support. Single source of truth — update here to affect automodel, vllm, and mcore.
+  # Note: override-dependencies below must be kept in sync (uv overrides cannot reference extras).
+  "deep_ep @ git+https://github.com/deepseek-ai/DeepEP.git@bfded34800dfec415b71503f8205181de90b2480 ; platform_machine == 'x86_64'",
+  "deep_ep @ git+https://github.com/deepseek-ai/DeepEP.git@a48493600c4886c1b297aaa78db0e1ebc2d8dd6c ; platform_machine == 'aarch64'",
+]
 automodel = [
   "nemo-automodel[moe]",
+  "nemo-rl[deep-ep]",
   # Flash-attn version should be selected to satisfy both TE + vLLM requirements (xformers in particular)
   # https://github.com/NVIDIA/TransformerEngine/blob/v2.3/transformer_engine/pytorch/attention/dot_product_attention/utils.py#L108
   # https://github.com/facebookresearch/xformers/blob/8354497deb2c04c67fbb2e2ad911e86530da0e90/xformers/ops/fmha/flash.py#L76
@@ -121,17 +128,14 @@ automodel = [
   "causal-conv1d",
   "nv-grouped-gemm",
   "transformer-engine[pytorch,core_cu13] @ git+https://github.com/NVIDIA/TransformerEngine.git@v2.14.1",
-  "deep_ep @ git+https://github.com/deepseek-ai/DeepEP.git@bfded34800dfec415b71503f8205181de90b2480 ; platform_machine == 'x86_64'",
-  "deep_ep @ git+https://github.com/deepseek-ai/DeepEP.git@a48493600c4886c1b297aaa78db0e1ebc2d8dd6c ; platform_machine == 'aarch64'",
 ]
 vllm = [
   "cuda-python",
+  "nemo-rl[deep-ep]",
   "deep_gemm @ git+https://github.com/deepseek-ai/DeepGEMM.git@7b6b5563b9d4c1ae07ffbce7f78ad3ac9204827c",
   # deep_ep also needs libibverbs-dev
   # sudo apt-get update
   # sudo apt-get install libibverbs-dev
-  "deep_ep @ git+https://github.com/deepseek-ai/DeepEP.git@bfded34800dfec415b71503f8205181de90b2480 ; platform_machine == 'x86_64'",
-  "deep_ep @ git+https://github.com/deepseek-ai/DeepEP.git@a48493600c4886c1b297aaa78db0e1ebc2d8dd6c ; platform_machine == 'aarch64'",
   # Default wheels on GitHub are cu130. See v0.20.0 release assets:
   # https://github.com/vllm-project/vllm/releases/tag/v0.20.0
   "vllm @ https://github.com/vllm-project/vllm/releases/download/v0.20.0/vllm-0.20.0-cp38-abi3-manylinux_2_35_aarch64.whl ; sys_platform == 'linux' and platform_machine == 'aarch64'",
@@ -168,8 +172,7 @@ mcore = [
   "flash-attn @ https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.1/flash_attn-2.8.1+cu13torch2.10cxx11abiTRUE-cp313-cp313-linux_x86_64.whl ; sys_platform == 'linux' and platform_machine == 'x86_64'",
   "flash-attn==2.8.1 ; sys_platform != 'linux' or (platform_machine != 'aarch64' and platform_machine != 'x86_64')",
   "emerging-optimizers==0.2.0",
-  "deep_ep @ git+https://github.com/deepseek-ai/DeepEP.git@bfded34800dfec415b71503f8205181de90b2480 ; platform_machine == 'x86_64'",
-  "deep_ep @ git+https://github.com/deepseek-ai/DeepEP.git@a48493600c4886c1b297aaa78db0e1ebc2d8dd6c ; platform_machine == 'aarch64'",
+  "nemo-rl[deep-ep]",
 ]
 modelopt = ["nvidia-modelopt"]
 nvrx = [


### PR DESCRIPTION
# What does this PR do ?

Consolidates the `deep_ep` platform-conditional commit pins into a single `deep-ep` optional-dependency group as a single source of truth. Previously the two arch-specific hashes (x86_64 and aarch64) were duplicated across the `automodel`, `vllm`, and `mcore` extras. Each of those groups now references `nemo-rl[deep-ep]` instead.

Note:`override-dependencies` still contains the hashes directly, uv's override syntax does not support extras references, so that entry must be kept in sync manually.

# Issues
Closes #2522


# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for
how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development
Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.