### PR TITLE
fix: pass weight shape instead of tensor to should_use_deepgemm_for_fp8_linear

### DIFF
--- a/nemo_rl/models/generation/vllm/quantization/fp8.py
+++ b/nemo_rl/models/generation/vllm/quantization/fp8.py
@@ -475,7 +475,7 @@ def maybe_post_process_fp8_weight_block(layer: torch.nn.Module):
     # requantize the weight and input to the specific scale
     # at the same time.
     should_use_deepgemm = should_use_deepgemm_for_fp8_linear(
-        layer.orig_dtype, layer.weight
+        layer.orig_dtype, layer.weight.shape
     )
     if should_use_deepgemm:
         dg_weight, dg_weight_scale = deepgemm_post_process_fp8_weight_block(


### PR DESCRIPTION
## Summary
- `should_use_deepgemm_for_fp8_linear` in vLLM 0.20.0 expects `weight_shape: tuple[int, int]`, but NeMo-RL was passing `layer.weight` (the full FP8 tensor)
- This caused `NotImplementedError: "remainder_cuda" not implemented for 'Float8_e4m3fn'` during weight loading when DeepGEMM is enabled
- Fix: pass `layer.weight.shape` instead of `layer.weight`

## Root cause
The vLLM 0.17→0.20 upgrade (#2384) changed the `should_use_deepgemm_for_fp8_linear` API from accepting a tensor to accepting a shape tuple. The call site in `maybe_post_process_fp8_weight_block` was not updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)