### PR TITLE
feat(distillation): add TransferQueue support for On-Policy Distillation

### DIFF
--- a/examples/configs/distillation_math.yaml
+++ b/examples/configs/distillation_math.yaml
@@ -282,3 +282,18 @@ cluster:
     master_port_range_low: 25000
     master_port_range_high: 28000
     segment_size: null  # Nodes per NVLink domain segment for topology-aware alignment; null to disable
+
+# TransferQueue-mediated data plane for on-policy distillation.
+# Off by default; set enabled=true to keep teacher top-k logits in TQ
+# instead of returning them to the driver.
+data_plane:
+    enabled: false
+    impl: transfer_queue
+    backend: "simple"
+    storage_capacity: 1000000
+    num_storage_units: 2
+    claim_meta_poll_interval_s: 0.5
+    global_segment_size: 549755813888
+    local_buffer_size: 68719476736
+    # observability:
+    #   enabled: false

--- a/examples/configs/distillation_math_tq.yaml
+++ b/examples/configs/distillation_math_tq.yaml
@@ -1,0 +1,17 @@
+# TransferQueue-enabled variant of distillation_math.yaml.
+# Uses the same model/data defaults and selects the TQ distillation trainer
+# through examples/run_distillation.py when data_plane.enabled=true.
+defaults: distillation_math.yaml
+
+checkpointing:
+    checkpoint_dir: "checkpoints/distillation-tq-${policy.model_name}"
+
+logger:
+    log_dir: "logs/distillation-tq"
+    wandb:
+        name: "distillation-tq-${data.train.dataset_name}-${teacher.model_name}-${policy.model_name}-${loss_fn.kl_type}-${distillation.topk_logits_k}"
+    tensorboard:
+        log_dir: "tb_logs-distillation-tq-${data.train.dataset_name}"
+
+data_plane:
+    enabled: true

--- a/examples/configs/recipes/llm/distillation-qwen3-32b-to-1.7b-base-1n8g-fsdp2tp1-tq.v1.yaml
+++ b/examples/configs/recipes/llm/distillation-qwen3-32b-to-1.7b-base-1n8g-fsdp2tp1-tq.v1.yaml
@@ -1,0 +1,58 @@
+defaults: ../../distillation_math_tq.yaml
+distillation:
+  num_prompts_per_step: 64
+  max_num_steps: 20
+  val_batch_size: 32
+  val_period: 10
+  max_val_samples: 256
+loss_fn:
+  kl_type: reverse
+checkpointing:
+  checkpoint_dir: checkpoints/distillation-qwen3-32b-to-1.7b-base-tq
+policy:
+  train_global_batch_size: 32
+  generation_batch_size: 32
+  dtensor_cfg:
+    tensor_parallel_size: 1
+    context_parallel_size: 1
+  dynamic_batching:
+    enabled: false
+  make_sequence_length_divisible_by: 1
+  scheduler:
+  - name: torch.optim.lr_scheduler.LinearLR
+    kwargs:
+      start_factor: 0.1
+      end_factor: 1.0
+      total_iters: 20
+  - name: torch.optim.lr_scheduler.ConstantLR
+    kwargs:
+      factor: 1.0
+      total_iters: 10000000000
+  - milestones:
+    - 20
+teacher:
+  model_name: Qwen/Qwen3-32B
+  train_global_batch_size: 32
+  generation_batch_size: 32
+  dtensor_cfg:
+    context_parallel_size: 1
+  dynamic_batching:
+    enabled: false
+  make_sequence_length_divisible_by: 1
+  scheduler:
+  - name: torch.optim.lr_scheduler.LinearLR
+    kwargs:
+      start_factor: 0.1
+      end_factor: 1.0
+      total_iters: 20
+  - name: torch.optim.lr_scheduler.ConstantLR
+    kwargs:
+      factor: 1.0
+      total_iters: 10000000000
+  - milestones:
+    - 20
+logger:
+  log_dir: logs/distillation-qwen3-32b-to-1.7b-base-tq
+  wandb:
+    project: nemo-rl
+    name: distillation-qwen3-32b-to-1.7b-base-tq

--- a/examples/run_distillation.py
+++ b/examples/run_distillation.py
@@ -30,6 +30,18 @@ from nemo_rl.utils.config import (
 from nemo_rl.utils.logger import get_next_experiment_dir
 
 
+def _select_trainer(master_config: MasterConfig):
+    """Pick the distillation trainer based on ``data_plane.enabled``."""
+    dp_cfg = master_config.data_plane or {}
+    if dp_cfg.get("enabled", False):
+        from nemo_rl.algorithms.distillation_sync import distillation_train_sync
+
+        print("🚀 Running on-policy distillation training (TransferQueue)")
+        return distillation_train_sync
+    print("🚀 Running on-policy distillation training (legacy)")
+    return distillation_train
+
+
 def parse_args() -> tuple[argparse.Namespace, list[str]]:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
@@ -86,6 +98,17 @@ def main() -> None:
         val_task_to_env,
     ) = setup_response_data(tokenizer, config.data, config.env)
 
+    _dp_cfg = config.data_plane or {}
+    if _dp_cfg.get("enabled", False):
+        from nemo_rl.models.policy.tq_policy import TQPolicy
+
+        def _make_student_policy(**kwargs):
+            return TQPolicy(**kwargs, dp_cfg=_dp_cfg)
+
+        _student_policy_factory = _make_student_policy
+    else:
+        _student_policy_factory = None
+
     (
         student_policy,
         teacher_policy,
@@ -98,9 +121,16 @@ def main() -> None:
         checkpointer,
         distillation_state,
         master_config,
-    ) = setup(config, tokenizer, dataset, val_dataset)
+    ) = setup(
+        config,
+        tokenizer,
+        dataset,
+        val_dataset,
+        student_policy_factory=_student_policy_factory,
+    )
 
-    distillation_train(
+    trainer = _select_trainer(master_config)
+    trainer(
         student_policy,
         teacher_policy,
         student_generation,

--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -14,7 +14,7 @@
 import os
 import warnings
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, NotRequired, Optional, TypedDict, TypeVar, cast
+from typing import Any, Callable, NotRequired, Optional, TypedDict, TypeVar, cast
 
 import numpy as np
 import ray
@@ -47,6 +47,11 @@ from nemo_rl.data.llm_message_utils import (
     get_keys_from_message_log,
 )
 from nemo_rl.data.utils import load_dataloader_state
+from nemo_rl.data_plane.interfaces import DataPlaneConfig
+from nemo_rl.data_plane.transport_metrics import (
+    add_byte_metric_derivatives,
+    topk_payload_nbytes,
+)
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.virtual_cluster import (
     ClusterConfig,
@@ -140,6 +145,7 @@ class MasterConfig(BaseModel, extra="allow"):
     logger: LoggerConfig  # Logger configuration
     cluster: ClusterConfig  # Cluster configuration
     checkpointing: CheckpointingConfig  # Checkpointing configuration
+    data_plane: Optional[DataPlaneConfig] = None
 
 
 # ===============================================================================
@@ -178,6 +184,7 @@ def setup(
     tokenizer: TokenizerType,
     train_dataset: AllTaskProcessedDataset,
     val_dataset: Optional[AllTaskProcessedDataset],
+    student_policy_factory: Optional[Callable[..., ColocatablePolicyInterface]] = None,
 ) -> tuple[
     ColocatablePolicyInterface,  # student_policy
     ColocatablePolicyInterface,  # teacher_policy
@@ -192,6 +199,14 @@ def setup(
     MasterConfig,
 ]:
     """Main entry point for distillation algorithm.
+
+    Args:
+        master_config: Fully resolved distillation configuration.
+        tokenizer: Student tokenizer or processor.
+        train_dataset: Training dataset.
+        val_dataset: Optional validation dataset.
+        student_policy_factory: Optional constructor for the student
+            policy. ``None`` keeps the legacy plain ``Policy`` path.
 
     Returns:
         tuple of student_policy, teacher_policy, student_generation, nemo_gym,
@@ -575,7 +590,10 @@ def setup(
         )
         policy_config["megatron_cfg"]["train_iters"] = total_train_iters
 
-    student_policy = Policy(
+    make_student_policy = (
+        student_policy_factory if student_policy_factory is not None else Policy
+    )
+    student_policy = make_student_policy(
         name_prefix="student",
         cluster=train_cluster,
         config=policy_config,
@@ -866,6 +884,33 @@ def distillation_train(
                     )
                     train_data["teacher_topk_logits"] = teacher_topk["topk_logits"]
                     train_data["teacher_topk_indices"] = teacher_topk["topk_indices"]
+                    teacher_topk_payload_bytes = topk_payload_nbytes(
+                        teacher_topk["topk_logits"],
+                        teacher_topk["topk_indices"],
+                    )
+                    teacher_topk_valid_payload_bytes = topk_payload_nbytes(
+                        teacher_topk["topk_logits"],
+                        teacher_topk["topk_indices"],
+                        [int(length) for length in input_lengths.tolist()],
+                    )
+                    transport_metrics: dict[str, float | int] = {
+                        "teacher_topk_payload_bytes": teacher_topk_payload_bytes,
+                        "teacher_topk_valid_payload_bytes": (
+                            teacher_topk_valid_payload_bytes
+                        ),
+                        "teacher_topk_padding_overhead_bytes": max(
+                            teacher_topk_payload_bytes
+                            - teacher_topk_valid_payload_bytes,
+                            0,
+                        ),
+                        "driver_rx_teacher_topk_bytes": teacher_topk_payload_bytes,
+                        "driver_tx_teacher_topk_bytes": teacher_topk_payload_bytes,
+                        "driver_teacher_topk_bytes": 2 * teacher_topk_payload_bytes,
+                        "driver_teacher_topk_bytes_avoided": 0,
+                        "tq_teacher_topk_write_bytes": 0,
+                        "tq_teacher_topk_write_ms_sum": 0.0,
+                        "tq_teacher_topk_write_ms_max": 0.0,
+                    }
 
                 print("▶ Preparing for training...", flush=True)
                 with timer.time("training_prep"):
@@ -1086,8 +1131,13 @@ def distillation_train(
             timing_metrics["valid_tokens_per_sec_per_gpu"] = (
                 metrics["global_valid_toks"] / total_time / total_num_gpus
             )
+            add_byte_metric_derivatives(
+                transport_metrics,
+                token_count=metrics["total_num_tokens"],
+            )
             logger.log_metrics(metrics, total_steps + 1, prefix="train")
             logger.log_metrics(timing_metrics, total_steps + 1, prefix="timing/train")
+            logger.log_metrics(transport_metrics, total_steps + 1, prefix="transport")
 
             timer.reset()
             current_step += 1

--- a/nemo_rl/algorithms/distillation_sync.py
+++ b/nemo_rl/algorithms/distillation_sync.py
@@ -1,0 +1,682 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""On-policy distillation trainer using TransferQueue for teacher top-k."""
+
+from __future__ import annotations
+
+import os
+import warnings
+from collections.abc import Mapping
+from contextlib import nullcontext
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any, Optional, cast
+
+if TYPE_CHECKING:
+    from nemo_rl.models.policy.tq_policy import TQPolicy
+
+import numpy as np
+import ray
+import torch
+from torchdata.stateful_dataloader import StatefulDataLoader
+
+from nemo_rl.algorithms.distillation import (
+    DistillationSaveState,
+    MasterConfig,
+    TokenizerType,
+    validate,
+)
+from nemo_rl.algorithms.grpo import refit_policy_generation
+from nemo_rl.algorithms.loss import DistillationLossFn
+from nemo_rl.data.interfaces import DatumSpec
+from nemo_rl.data.llm_message_utils import batched_message_log_to_flat_message
+from nemo_rl.data.multimodal_utils import (
+    PackedTensor,
+    get_multimodal_keys_from_processor,
+)
+from nemo_rl.data_plane.column_io import stamp_global_forward_pad_seqlen
+from nemo_rl.data_plane.interfaces import KVBatchMeta
+from nemo_rl.data_plane.preshard import shard_meta_for_dp
+from nemo_rl.data_plane.schema import (
+    DISTILLATION_TRAIN_FIELDS,
+    TEACHER_TOPK_SEED_FIELDS,
+)
+from nemo_rl.data_plane.transport_metrics import add_byte_metric_derivatives
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.environments.interfaces import EnvironmentInterface
+from nemo_rl.experience.distillation_rollout_actor import DistillationRolloutActor
+from nemo_rl.models.generation.interfaces import GenerationInterface
+from nemo_rl.models.policy.interfaces import ColocatablePolicyInterface
+from nemo_rl.utils.checkpoint import CheckpointManager
+from nemo_rl.utils.logger import Logger
+from nemo_rl.utils.nsys import maybe_gpu_profile_step
+from nemo_rl.utils.timer import TimeoutChecker, Timer
+from nemo_rl.utils.venvs import make_actor_runtime_env
+
+
+def _dedupe_fields(*field_groups: list[str] | tuple[str, ...]) -> list[str]:
+    """Concatenate field groups while preserving first occurrence order."""
+    out: list[str] = []
+    seen: set[str] = set()
+    for group in field_groups:
+        for field in group:
+            if field in seen:
+                continue
+            seen.add(field)
+            out.append(field)
+    return out
+
+
+def _as_row_aligned_tensor(value: Any, expected_rows: int) -> Optional[torch.Tensor]:
+    """Return a tensor only when TQ can store it under row-addressed keys."""
+    if isinstance(value, PackedTensor):
+        value = value.as_tensor()
+    if not isinstance(value, torch.Tensor):
+        return None
+    if value.dim() == 0 or value.shape[0] != expected_rows:
+        return None
+    return value
+
+
+def derive_model_input_fields(
+    prompt_batch: BatchedDataDict[DatumSpec],
+    tokenizer: TokenizerType,
+    master_config: MasterConfig,
+) -> list[str]:
+    """Derive positive model-input extras before partition registration."""
+    flat, _ = batched_message_log_to_flat_message(
+        prompt_batch["message_log"],
+        pad_value_dict={"token_ids": tokenizer.pad_token_id},
+        make_sequence_length_divisible_by=master_config.policy[
+            "make_sequence_length_divisible_by"
+        ],
+    )
+    expected_rows = int(prompt_batch.size)
+    processor_fields = set(get_multimodal_keys_from_processor(tokenizer))
+    optional_tensor_fields = set(BatchedDataDict.ADDITIONAL_OPTIONAL_KEY_TENSORS)
+    fields: list[str] = []
+    for field, value in flat.items():
+        if (
+            field not in processor_fields
+            and field not in optional_tensor_fields
+            and not isinstance(value, PackedTensor)
+        ):
+            continue
+        if _as_row_aligned_tensor(value, expected_rows) is not None:
+            fields.append(field)
+    return fields
+
+
+def _packing_args_for_policy(
+    policy: ColocatablePolicyInterface,
+    mb_tokens_key: str,
+) -> tuple[Optional[dict[str, Any]], Optional[dict[str, Any]]]:
+    """Resolve packing args for a plain Policy-like object."""
+    if getattr(policy, "use_dynamic_batches", False):
+        args = dict(policy.dynamic_batching_args)  # type: ignore[attr-defined]
+        args["max_tokens_per_microbatch"] = policy.cfg["dynamic_batching"][  # type: ignore[attr-defined]
+            mb_tokens_key
+        ]
+        return None, args
+    if getattr(policy, "use_sequence_packing", False):
+        args = dict(policy.sequence_packing_args)  # type: ignore[attr-defined]
+        args["max_tokens_per_microbatch"] = policy.cfg["sequence_packing"][  # type: ignore[attr-defined]
+            mb_tokens_key
+        ]
+        return args, None
+    return None, None
+
+
+def _stamp_policy_pad_seqlen(
+    policy: ColocatablePolicyInterface,
+    meta: KVBatchMeta,
+    *,
+    mb_tokens_key: str,
+) -> None:
+    """Stamp the forward pad target for a plain Policy-like dispatch."""
+    _, dba = _packing_args_for_policy(policy, mb_tokens_key)
+    sequence_length_round = int(dba["sequence_length_round"]) if dba is not None else 1
+    stamp_global_forward_pad_seqlen(
+        meta,
+        sequence_length_round=sequence_length_round,
+    )
+
+
+def attach_policy_workers_to_data_plane(
+    policy: ColocatablePolicyInterface,
+    dp_cfg: dict[str, Any],
+) -> None:
+    """Attach plain policy workers to an already bootstrapped data plane."""
+    ray.get(
+        policy.worker_group.run_all_workers_single_data(  # type: ignore[attr-defined]
+            "setup_data_plane", cfg=dp_cfg
+        )
+    )
+
+
+def _aggregate_teacher_topk_transport_results(
+    results: list[Any],
+) -> dict[str, float | int]:
+    """Aggregate scalar teacher top-k transport acks from workers."""
+    transport_metrics: dict[str, float | int] = {
+        "teacher_topk_payload_bytes": 0,
+        "teacher_topk_valid_payload_bytes": 0,
+        "teacher_topk_padding_overhead_bytes": 0,
+        "driver_rx_teacher_topk_bytes": 0,
+        "driver_tx_teacher_topk_bytes": 0,
+        "driver_teacher_topk_bytes": 0,
+        "driver_teacher_topk_bytes_avoided": 0,
+        "tq_teacher_topk_write_bytes": 0,
+        "tq_teacher_topk_write_num_samples": 0,
+        "tq_teacher_topk_write_ms_sum": 0.0,
+        "tq_teacher_topk_write_ms_max": 0.0,
+    }
+    for result in results:
+        if result in ({}, None):
+            continue
+        if not isinstance(result, Mapping):
+            raise RuntimeError(
+                "teacher top-k writeback path must return scalar metric acks; "
+                f"got {type(result).__name__}."
+            )
+        tensor_keys = [k for k, v in result.items() if isinstance(v, torch.Tensor)]
+        if tensor_keys:
+            raise RuntimeError(
+                "teacher top-k writeback path returned tensor payloads for "
+                f"{tensor_keys}; expected scalar metric acks only."
+            )
+        transport_metrics["teacher_topk_payload_bytes"] += int(
+            result.get("teacher_topk_payload_bytes", 0)
+        )
+        transport_metrics["teacher_topk_valid_payload_bytes"] += int(
+            result.get("teacher_topk_valid_payload_bytes", 0)
+        )
+        transport_metrics["teacher_topk_padding_overhead_bytes"] += int(
+            result.get("teacher_topk_padding_overhead_bytes", 0)
+        )
+        transport_metrics["tq_teacher_topk_write_bytes"] += int(
+            result.get("tq_teacher_topk_write_bytes", 0)
+        )
+        transport_metrics["tq_teacher_topk_write_num_samples"] += int(
+            result.get("tq_teacher_topk_write_num_samples", 0)
+        )
+        write_ms = float(result.get("tq_teacher_topk_write_ms", 0.0))
+        transport_metrics["tq_teacher_topk_write_ms_sum"] += write_ms
+        transport_metrics["tq_teacher_topk_write_ms_max"] = max(
+            float(transport_metrics["tq_teacher_topk_write_ms_max"]),
+            write_ms,
+        )
+
+    payload_bytes = int(transport_metrics["teacher_topk_payload_bytes"])
+    transport_metrics["driver_teacher_topk_bytes_avoided"] = 2 * payload_bytes
+    return transport_metrics
+
+
+def dispatch_teacher_topk_writeback(
+    teacher_policy: ColocatablePolicyInterface,
+    meta: KVBatchMeta,
+    *,
+    fields: list[str],
+    k: int,
+    timer: Optional[Timer] = None,
+) -> dict[str, float | int]:
+    """Compute teacher top-k on workers and write it back to TQ only."""
+    _stamp_policy_pad_seqlen(
+        teacher_policy,
+        meta,
+        mb_tokens_key="logprob_mb_tokens",
+    )
+    spa, dba = _packing_args_for_policy(teacher_policy, "logprob_mb_tokens")
+    teacher_meta = replace(meta, fields=list(fields), task_name="teacher_topk")
+
+    with timer.time("teacher_topk/shard_meta") if timer else nullcontext():
+        dp_metas, _ = shard_meta_for_dp(
+            teacher_meta,
+            dp_world=teacher_policy.sharding_annotations.get_axis_size(  # type: ignore[attr-defined]
+                "data_parallel"
+            ),
+            batch_size=None,
+            sequence_packing_args=spa,
+            dynamic_batching_args=dba,
+        )
+
+    with timer.time("teacher_topk/submit_futures") if timer else nullcontext():
+        futures = teacher_policy.worker_group.run_all_workers_sharded_data(  # type: ignore[attr-defined]
+            "get_topk_logits_presharded",
+            meta=dp_metas,
+            in_sharded_axes=["data_parallel"],
+            replicate_on_axes=[
+                "context_parallel",
+                "tensor_parallel",
+                "pipeline_parallel",
+            ],
+            output_is_replicated=[
+                "context_parallel",
+                "tensor_parallel",
+                "pipeline_parallel",
+            ],
+            common_kwargs={"k": k},
+        )
+    results = teacher_policy.worker_group.get_all_worker_results(futures)  # type: ignore[attr-defined]
+    return _aggregate_teacher_topk_transport_results(results)
+
+
+def distillation_train_sync(
+    student_policy: ColocatablePolicyInterface,
+    teacher_policy: ColocatablePolicyInterface,
+    student_generation: Optional[GenerationInterface],
+    dataloader: StatefulDataLoader,
+    val_dataloader: Optional[StatefulDataLoader],
+    tokenizer: TokenizerType,
+    loss_fn: DistillationLossFn,
+    task_to_env: dict[str, EnvironmentInterface],
+    val_task_to_env: Optional[dict[str, EnvironmentInterface]],
+    logger: Logger,
+    checkpointer: CheckpointManager,
+    distillation_save_state: DistillationSaveState,
+    master_config: MasterConfig,
+) -> None:
+    """Run on-policy distillation with teacher top-k resident in TQ."""
+    dp_cfg = master_config.data_plane
+    if not dp_cfg or not dp_cfg["enabled"]:
+        raise ValueError(
+            "distillation_train_sync requires data_plane.enabled=true. "
+            "Use nemo_rl.algorithms.distillation.distillation_train for the "
+            "legacy driver-mediated path."
+        )
+    if not hasattr(student_policy, "dp_cfg"):
+        raise ValueError(
+            "distillation_train_sync requires the student policy to be a "
+            "TQPolicy constructed by examples/run_distillation.py."
+        )
+    student_tq_policy = cast("TQPolicy", student_policy)
+    attach_policy_workers_to_data_plane(teacher_policy, dp_cfg)
+
+    timer = Timer()
+    timeout = TimeoutChecker(
+        timeout=master_config.checkpointing["checkpoint_must_save_by"],
+        fit_last_save_time=True,
+    )
+    timeout.start_iterations()
+
+    need_refit = True
+    if student_generation is None:
+        student_generation = student_policy  # type: ignore[assignment]
+        need_refit = False
+    policy_generation_stale = True
+    assert student_generation is not None
+
+    current_epoch = distillation_save_state["current_epoch"]
+    current_step = distillation_save_state["current_step"]
+    total_steps = distillation_save_state["total_steps"]
+    consumed_samples = distillation_save_state["consumed_samples"]
+    total_valid_tokens = distillation_save_state["total_valid_tokens"]
+    val_period = master_config.distillation["val_period"]
+    val_at_start = master_config.distillation["val_at_start"]
+    val_at_end = master_config.distillation["val_at_end"]
+    colocated_inference = master_config.policy["generation"]["colocated"]["enabled"]
+    max_epochs = master_config.distillation["max_num_epochs"]
+    max_steps = master_config.distillation["max_num_steps"]
+
+    rollout_actor = DistillationRolloutActor.options(
+        runtime_env=make_actor_runtime_env(
+            "nemo_rl.experience.distillation_rollout_actor.DistillationRolloutActor"
+        ),
+    ).remote(
+        policy_generation=student_generation,
+        tokenizer=tokenizer,
+        task_to_env=task_to_env,
+        master_config=master_config,
+        dp_cfg=dp_cfg,
+    )
+
+    if val_at_start and total_steps == 0:
+        print("\n🔍 Running initial validation...", flush=True)
+        if need_refit and policy_generation_stale:
+            refit_policy_generation(
+                student_policy, student_generation, colocated_inference
+            )
+            policy_generation_stale = False
+        else:
+            student_generation.prepare_for_generation()
+        val_metrics, validation_timings = validate(
+            student_generation,
+            val_dataloader,
+            tokenizer,
+            val_task_to_env,
+            step=total_steps,
+            master_config=master_config,
+        )
+        student_generation.finish_generation()
+        logger.log_metrics(val_metrics, total_steps, prefix="validation")
+        logger.log_metrics(validation_timings, total_steps, prefix="timing/validation")
+
+    batch: BatchedDataDict[DatumSpec]
+    while total_steps < max_steps and current_epoch < max_epochs:
+        print(
+            f"\n{'=' * 25} Epoch {current_epoch + 1}/{max_epochs} {'=' * 25}",
+            flush=True,
+        )
+
+        for batch in dataloader:
+            print(
+                f"\n{'=' * 25} Step {current_step + 1}/{min(len(dataloader), max_steps)} {'=' * 25}",
+                flush=True,
+            )
+            maybe_gpu_profile_step(student_policy, total_steps + 1)
+            if student_policy != student_generation:
+                maybe_gpu_profile_step(student_generation, total_steps + 1)
+            val_metrics, validation_timings = None, None
+            should_save_by_timeout = False
+
+            with timer.time("total_step_time"):
+                print("▶ Preparing batch...", flush=True)
+                with timer.time("data_processing"):
+                    repeated_batch: BatchedDataDict[DatumSpec] = (
+                        batch.repeat_interleave(
+                            master_config.distillation["num_generations_per_prompt"]
+                        )
+                    )
+                    model_input_fields = derive_model_input_fields(
+                        repeated_batch,
+                        tokenizer,
+                        master_config,
+                    )
+                    distillation_train_fields = _dedupe_fields(
+                        DISTILLATION_TRAIN_FIELDS,
+                        model_input_fields,
+                    )
+                    teacher_fetch_fields = _dedupe_fields(
+                        TEACHER_TOPK_SEED_FIELDS,
+                        model_input_fields,
+                    )
+
+                student_tq_policy.prepare_step(
+                    num_samples=int(repeated_batch.size),
+                    fields=distillation_train_fields,
+                    consumer_tasks=["teacher_topk", "train"],
+                )
+
+                print(
+                    f"▶ Generating responses for batch of size {repeated_batch.size}...",
+                    flush=True,
+                )
+                with timer.time("prepare_for_generation"):
+                    if need_refit and policy_generation_stale:
+                        refit_policy_generation(
+                            student_policy,
+                            student_generation,
+                            colocated_inference,
+                            timer=timer,
+                        )
+                        policy_generation_stale = False
+                    else:
+                        student_generation.prepare_for_generation()
+
+                with timer.time("generation"):
+                    meta, driver_carry, rollout_metrics, _ = ray.get(
+                        rollout_actor.rollout_to_tq.remote(
+                            repeated_batch,
+                            partition_id=student_tq_policy.tq_partition_id,
+                            model_input_fields=model_input_fields,
+                        )
+                    )
+
+                print("▶ Preparing for teacher logprob inference...", flush=True)
+                with timer.time("teacher_logprob_inference_prep"):
+                    teacher_policy.prepare_for_lp_inference()
+
+                print("▶ Computing teacher top-k writeback...", flush=True)
+                with timer.time("teacher_logprob_inference"):
+                    transport_metrics = dispatch_teacher_topk_writeback(
+                        teacher_policy,
+                        meta,
+                        fields=teacher_fetch_fields,
+                        k=master_config.distillation["topk_logits_k"],
+                        timer=timer,
+                    )
+
+                print("▶ Preparing for training...", flush=True)
+                with timer.time("training_prep"):
+                    teacher_policy.offload_after_refit()
+                    student_policy.prepare_for_training()
+                    policy_generation_stale = True
+
+                print("▶ Training policy...", flush=True)
+                with timer.time("policy_training"):
+                    train_results = student_tq_policy.train_from_meta(
+                        meta,
+                        loss_fn,
+                        timer=timer,
+                        fields=distillation_train_fields,
+                    )
+
+                log_content = driver_carry["content"]
+                log_input_lengths = driver_carry["input_lengths"]
+                mean_prompt_length = driver_carry["length"]
+                student_tq_policy.finish_step(meta)
+
+                is_last_step = (total_steps + 1 >= max_steps) or (
+                    (current_epoch + 1 == max_epochs)
+                    and (current_step + 1 == len(dataloader))
+                )
+
+                if (val_period > 0 and (total_steps + 1) % val_period == 0) or (
+                    val_at_end and is_last_step
+                ):
+                    if need_refit and policy_generation_stale:
+                        refit_policy_generation(
+                            student_policy, student_generation, colocated_inference
+                        )
+                        policy_generation_stale = False
+                    else:
+                        student_generation.prepare_for_generation()
+                    val_metrics, validation_timings = validate(
+                        student_generation,
+                        val_dataloader,
+                        tokenizer,
+                        val_task_to_env,
+                        step=total_steps + 1,
+                        master_config=master_config,
+                    )
+                    student_generation.finish_generation()
+                    logger.log_metrics(
+                        validation_timings, total_steps + 1, prefix="timing/validation"
+                    )
+                    logger.log_metrics(
+                        val_metrics, total_steps + 1, prefix="validation"
+                    )
+
+                metrics = {
+                    "loss": train_results["loss"].numpy(),
+                    "grad_norm": train_results["grad_norm"].numpy(),
+                    "mean_prompt_length": mean_prompt_length.numpy(),
+                    "total_num_tokens": log_input_lengths.numpy(),
+                }
+                metrics.update(train_results["all_mb_metrics"])
+                for k, v in metrics.items():
+                    if k in {
+                        "lr",
+                        "wd",
+                        "global_valid_seqs",
+                        "global_valid_toks",
+                        "mean_prompt_length",
+                    }:
+                        metrics[k] = np.mean(v).item()
+                    else:
+                        metrics[k] = np.sum(v).item()
+                metrics.update(rollout_metrics)
+                total_valid_tokens += metrics["global_valid_toks"]
+
+                consumed_samples += master_config.distillation["num_prompts_per_step"]
+                timeout.mark_iteration()
+                should_save_by_step = (
+                    is_last_step
+                    or (total_steps + 1) % master_config.checkpointing["save_period"]
+                    == 0
+                )
+                should_save_by_timeout = timeout.check_save()
+
+                if master_config.checkpointing["enabled"] and (
+                    should_save_by_step or should_save_by_timeout
+                ):
+                    student_policy.prepare_for_training()
+
+                    distillation_save_state["current_epoch"] = current_epoch
+                    distillation_save_state["current_step"] = current_step + 1
+                    distillation_save_state["total_steps"] = total_steps + 1
+                    distillation_save_state["total_valid_tokens"] = total_valid_tokens
+                    if val_metrics is not None:
+                        distillation_save_state["val_reward"] = val_metrics["accuracy"]
+                    elif "val_reward" in distillation_save_state:
+                        del distillation_save_state["val_reward"]
+                    distillation_save_state["consumed_samples"] = consumed_samples
+
+                    full_metric_name = master_config.checkpointing["metric_name"]
+                    if full_metric_name is not None:
+                        assert full_metric_name.startswith(
+                            "train:"
+                        ) or full_metric_name.startswith("val:"), (
+                            f"metric_name={full_metric_name} must start with 'val:' or 'train:',\n"
+                            f'followed by the corresponding name in the "val" or "train" metrics dictionary.'
+                            f"  If you are using an old config, please updated checkpointing.metric_name to the new format, "
+                            f" e.g. 'val_reward --> 'val:accuracy'"
+                        )
+                        prefix, metric_name = full_metric_name.split(":", 1)
+                        metrics_source = metrics if prefix == "train" else val_metrics
+                        if not metrics_source:
+                            warnings.warn(
+                                f"You asked to save checkpoints based on {metric_name} but no {prefix} metrics were collected. "
+                                "This checkpoint will not be saved as top-k.",
+                                stacklevel=2,
+                            )
+                            if full_metric_name in distillation_save_state:
+                                del distillation_save_state[full_metric_name]
+                        elif metric_name not in metrics_source:
+                            raise ValueError(
+                                f"Metric {metric_name} not found in {prefix} metrics"
+                            )
+                        else:
+                            distillation_save_state[full_metric_name] = metrics_source[
+                                metric_name
+                            ]
+
+                    with timer.time("checkpointing"):
+                        print(
+                            f"Saving checkpoint for step {total_steps + 1}...",
+                            flush=True,
+                        )
+                        checkpoint_path = checkpointer.init_tmp_checkpoint(
+                            total_steps + 1, distillation_save_state, master_config
+                        )
+                        student_policy.save_checkpoint(
+                            weights_path=os.path.join(
+                                checkpoint_path, "policy", "weights"
+                            ),
+                            optimizer_path=os.path.join(
+                                checkpoint_path, "policy", "optimizer"
+                            )
+                            if checkpointer.save_optimizer
+                            else None,
+                            tokenizer_path=os.path.join(
+                                checkpoint_path, "policy", "tokenizer"
+                            ),
+                            checkpointing_cfg=master_config.checkpointing,
+                        )
+                        torch.save(
+                            dataloader.state_dict(),
+                            os.path.join(checkpoint_path, "train_dataloader.pt"),
+                        )
+                        checkpointer.finalize_checkpoint(checkpoint_path)
+
+            log_data = {"content": log_content.tolist()}
+            log_data["input_lengths"] = log_input_lengths.tolist()
+            logger.log_batched_dict_as_jsonl(
+                log_data, f"train_data_step{total_steps + 1}.jsonl"
+            )
+
+            timing_metrics: dict[str, float] = timer.get_timing_metrics(
+                reduction_op="sum"
+            )
+
+            print("\n📊 Training Results:")
+            print(f"  • Loss: {metrics['loss']:.4f}")
+            print(
+                f"  • Mean Generation Length: {rollout_metrics['mean_gen_tokens_per_sample']:.4f}"
+            )
+            if "total_flops" in train_results:
+                total_tflops = (
+                    train_results["total_flops"]
+                    / timing_metrics["policy_training"]
+                    / 1e12
+                )
+                num_ranks = train_results["num_ranks"]
+                print(
+                    f"  • Training FLOPS: {total_tflops:.2f} TFLOPS ({total_tflops / num_ranks:.2f} TFLOPS per rank)",
+                    flush=True,
+                )
+                if "theoretical_tflops" in train_results:
+                    theoretical_tflops = train_results["theoretical_tflops"]
+                    print(
+                        f"  • Training Model Floating Point Utilization: {100 * total_tflops / theoretical_tflops:.2f}%",
+                        flush=True,
+                    )
+                    metrics["train_fp_utilization"] = total_tflops / theoretical_tflops
+
+            print("\n⏱️  Timing:", flush=True)
+            total_time = timing_metrics.get("total_step_time", 0)
+            total_num_gpus = (
+                master_config.cluster["num_nodes"]
+                * master_config.cluster["gpus_per_node"]
+            )
+            metrics.update(
+                {
+                    "tokens_per_sec_per_gpu": metrics["total_num_tokens"]
+                    / total_time
+                    / total_num_gpus
+                }
+            )
+            print(f"  • Total step time: {total_time:.2f}s", flush=True)
+            for k, v in sorted(
+                timing_metrics.items(), key=lambda item: item[1], reverse=True
+            ):
+                if k != "total_step_time":
+                    percent = (v / total_time * 100) if total_time > 0 else 0
+                    print(f"  • {k}: {v:.2f}s ({percent:.1f}%)", flush=True)
+
+            timing_metrics["valid_tokens_per_sec_per_gpu"] = (
+                metrics["global_valid_toks"] / total_time / total_num_gpus
+            )
+            add_byte_metric_derivatives(
+                transport_metrics,
+                token_count=metrics["total_num_tokens"],
+            )
+            logger.log_metrics(metrics, total_steps + 1, prefix="train")
+            logger.log_metrics(timing_metrics, total_steps + 1, prefix="timing/train")
+            logger.log_metrics(transport_metrics, total_steps + 1, prefix="transport")
+
+            timer.reset()
+            current_step += 1
+            total_steps += 1
+            if should_save_by_timeout:
+                print("Timeout has been reached, stopping training early", flush=True)
+                return
+            if total_steps >= max_steps:
+                print(
+                    "Max number of steps has been reached, stopping training early",
+                    flush=True,
+                )
+                return
+
+        current_epoch += 1
+        current_step = 0

--- a/nemo_rl/data_plane/column_io.py
+++ b/nemo_rl/data_plane/column_io.py
@@ -61,6 +61,34 @@ def round_up(value: int, multiple: int) -> int:
     return ((value + multiple - 1) // multiple) * multiple
 
 
+def stamp_global_forward_pad_seqlen(
+    meta: KVBatchMeta,
+    *,
+    sequence_length_round: int = 1,
+) -> None:
+    """Mint ``GLOBAL_FORWARD_PAD_SEQLEN`` onto ``meta.extra_info``.
+
+    Workers and driver-side reads use this value to materialize all DP
+    slices to one forward-pass sequence length. The helper is idempotent
+    so callers can stamp before every dispatch without coordinating.
+
+    Args:
+        meta: Full-batch metadata to mutate.
+        sequence_length_round: Dynamic-batching sequence-length round.
+            ``1`` disables extra dynamic-batching alignment.
+    """
+    if not meta.sequence_lengths:
+        return
+    pad_mult = int(meta.extra_info.get("pad_to_multiple", 1))
+    target = round_up(
+        max(meta.sequence_lengths), max(pad_mult, int(sequence_length_round))
+    )
+    existing = int(meta.extra_info.get(GLOBAL_FORWARD_PAD_SEQLEN, 0))
+    if existing >= target:
+        return
+    meta.extra_info[GLOBAL_FORWARD_PAD_SEQLEN] = target
+
+
 def read_columns(
     dp_client: DataPlaneClient,
     meta: KVBatchMeta,

--- a/nemo_rl/data_plane/schema.py
+++ b/nemo_rl/data_plane/schema.py
@@ -29,27 +29,50 @@ INPUT_IDS = "input_ids"
 INPUT_LENGTHS = "input_lengths"
 SAMPLE_MASK = "sample_mask"
 META_IDX = "meta_idx"
+TOKEN_MASK = "token_mask"
+TEACHER_TOPK_LOGITS = "teacher_topk_logits"
+TEACHER_TOPK_INDICES = "teacher_topk_indices"
 
 # Tensor fields in the train partition. Rollout writes the input
 # subset on first put; later stages add prev_logprobs /
 # reference_policy_logprobs (workers) and advantages (driver).
 DP_TRAIN_FIELDS = (
-    "input_ids",
-    "input_lengths",
+    INPUT_IDS,
+    INPUT_LENGTHS,
     "generation_logprobs",
     "prev_logprobs",
     "reference_policy_logprobs",
     "advantages",
-    "token_mask",
-    "sample_mask",
+    TOKEN_MASK,
+    SAMPLE_MASK,
 )
 
 # Subset fetched by logprob / ref-logprob workers.
 LP_SEED_FIELDS = (
-    "input_ids",
-    "input_lengths",
-    "token_mask",
-    "sample_mask",
+    INPUT_IDS,
+    INPUT_LENGTHS,
+    TOKEN_MASK,
+    SAMPLE_MASK,
+)
+
+# Fixed fields used by TQ-mediated on-policy distillation training.
+# Runtime model-input extras (for example model-specific multimodal
+# tensors) are discovered separately and appended by the trainer before
+# partition registration.
+DISTILLATION_TRAIN_FIELDS = (
+    INPUT_IDS,
+    INPUT_LENGTHS,
+    TOKEN_MASK,
+    SAMPLE_MASK,
+    TEACHER_TOPK_LOGITS,
+    TEACHER_TOPK_INDICES,
+)
+
+# Minimal teacher inference seed fields. Runtime model-input extras are
+# appended by distillation_sync before teacher dispatch.
+TEACHER_TOPK_SEED_FIELDS = (
+    INPUT_IDS,
+    INPUT_LENGTHS,
 )
 
 # Fields requested for KV-scale calibration. Positive include-list:

--- a/nemo_rl/data_plane/transport_metrics.py
+++ b/nemo_rl/data_plane/transport_metrics.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for logging tensor transport volume."""
+
+from __future__ import annotations
+
+from math import prod
+from typing import Any, MutableMapping, Sequence
+
+import torch
+
+
+def tensor_nbytes(value: Any) -> int:
+    """Return tensor payload bytes, or zero for non-tensors."""
+    if not isinstance(value, torch.Tensor):
+        return 0
+    return int(value.numel() * value.element_size())
+
+
+def valid_token_tensor_nbytes(
+    tensor: torch.Tensor,
+    sequence_lengths: Sequence[int] | None,
+) -> int:
+    """Return bytes for the valid token prefix of a batched sequence tensor.
+
+    Args:
+        tensor: Tensor with shape ``[B, S, ...]``.
+        sequence_lengths: Per-row valid sequence lengths. When absent or
+            incompatible with ``tensor``, the full tensor byte count is used.
+
+    Returns:
+        Byte count for ``sum(sequence_lengths)`` token positions times the
+        trailing per-token element count.
+    """
+    if sequence_lengths is None or tensor.dim() < 2:
+        return tensor_nbytes(tensor)
+    if tensor.shape[0] != len(sequence_lengths):
+        return tensor_nbytes(tensor)
+
+    max_seq_len = int(tensor.shape[1])
+    valid_tokens = sum(
+        min(max(int(length), 0), max_seq_len) for length in sequence_lengths
+    )
+    trailing_elems = (
+        prod(int(size) for size in tensor.shape[2:]) if tensor.dim() > 2 else 1
+    )
+    return int(valid_tokens * trailing_elems * tensor.element_size())
+
+
+def topk_payload_nbytes(
+    topk_logits: torch.Tensor,
+    topk_indices: torch.Tensor,
+    sequence_lengths: Sequence[int] | None = None,
+) -> int:
+    """Return combined top-k logits and indices payload bytes."""
+    if sequence_lengths is None:
+        return tensor_nbytes(topk_logits) + tensor_nbytes(topk_indices)
+    return valid_token_tensor_nbytes(
+        topk_logits, sequence_lengths
+    ) + valid_token_tensor_nbytes(topk_indices, sequence_lengths)
+
+
+def add_byte_metric_derivatives(
+    metrics: MutableMapping[str, float | int],
+    *,
+    token_count: float | int,
+) -> None:
+    """Add GiB and per-token derivatives for every ``*_bytes`` metric."""
+    denom = float(token_count)
+    for name, value in list(metrics.items()):
+        if not name.endswith("_bytes"):
+            continue
+        byte_value = float(value)
+        stem = name[: -len("_bytes")]
+        metrics[f"{stem}_gib"] = byte_value / float(1024**3)
+        if denom > 0:
+            metrics[f"{name}_per_token"] = byte_value / denom

--- a/nemo_rl/data_plane/worker_mixin.py
+++ b/nemo_rl/data_plane/worker_mixin.py
@@ -27,6 +27,7 @@ TP=CP=PP=1) and inherit ``train`` / ``get_logprobs`` /
 
 from __future__ import annotations
 
+from time import monotonic
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
 import torch
@@ -39,8 +40,11 @@ from nemo_rl.data_plane.schema import (
     GLOBAL_FORWARD_PAD_SEQLEN,
     MICRO_BATCH_INDICES,
     MICRO_BATCH_LENGTHS,
+    TEACHER_TOPK_INDICES,
+    TEACHER_TOPK_LOGITS,
     Layout,
 )
+from nemo_rl.data_plane.transport_metrics import topk_payload_nbytes
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.utils.nsys import wrap_with_nvtx_name
 from nemo_rl.utils.r3_trace import trace_tq_fetch_payload
@@ -516,3 +520,86 @@ class TQWorkerMixin:
             tq_field="reference_policy_logprobs",
         )
         del result
+
+    @wrap_with_nvtx_name("policy_worker/get_topk_logits_presharded")
+    def get_topk_logits_presharded(
+        self,
+        meta: "KVBatchMeta",
+        k: int,
+        micro_batch_size: Optional[int] = None,
+    ) -> dict[str, Any]:
+        """Per-rank teacher top-k entrypoint.
+
+        Fetches only the seed/model-input fields named by ``meta.fields``,
+        computes top-k logits with the worker's existing implementation,
+        writes both teacher columns back to TQ, and returns only an ack.
+        """
+        from collections.abc import Mapping
+
+        data = self._fetch(meta)
+        data = self._attach_or_repack_pack_metadata(data, meta)
+        result = self.get_topk_logits(  # type: ignore[attr-defined]
+            data=data,
+            k=k,
+            micro_batch_size=micro_batch_size,
+        )
+        if not isinstance(result, Mapping):
+            raise RuntimeError(
+                "get_topk_logits_presharded expected get_topk_logits to return "
+                f"a mapping, got {type(result).__name__}."
+            )
+        topk_logits = result.get("topk_logits")
+        topk_indices = result.get("topk_indices")
+        if not isinstance(topk_logits, torch.Tensor):
+            raise TypeError(
+                "get_topk_logits_presharded expected result['topk_logits'] "
+                f"to be a torch.Tensor, got {type(topk_logits).__name__}."
+            )
+        if not isinstance(topk_indices, torch.Tensor):
+            raise TypeError(
+                "get_topk_logits_presharded expected result['topk_indices'] "
+                f"to be a torch.Tensor, got {type(topk_indices).__name__}."
+            )
+        if topk_logits.shape[0] != len(meta.sample_ids):
+            raise ValueError(
+                "get_topk_logits_presharded topk_logits batch dim "
+                f"{topk_logits.shape[0]} does not match {len(meta.sample_ids)} "
+                "sample ids."
+            )
+        if topk_indices.shape[0] != len(meta.sample_ids):
+            raise ValueError(
+                "get_topk_logits_presharded topk_indices batch dim "
+                f"{topk_indices.shape[0]} does not match {len(meta.sample_ids)} "
+                "sample ids."
+            )
+        is_writeback_leader = self._is_replica_leader()
+        teacher_topk_payload_bytes = (
+            topk_payload_nbytes(topk_logits, topk_indices) if is_writeback_leader else 0
+        )
+        teacher_topk_valid_payload_bytes = (
+            topk_payload_nbytes(topk_logits, topk_indices, meta.sequence_lengths)
+            if is_writeback_leader
+            else 0
+        )
+        write_start = monotonic()
+        self._write_back(
+            meta,
+            {
+                TEACHER_TOPK_LOGITS: topk_logits.detach().to("cpu"),
+                TEACHER_TOPK_INDICES: topk_indices.detach().to("cpu"),
+            },
+        )
+        write_ms = (monotonic() - write_start) * 1000.0 if is_writeback_leader else 0.0
+        return {
+            "teacher_topk_payload_bytes": teacher_topk_payload_bytes,
+            "teacher_topk_valid_payload_bytes": teacher_topk_valid_payload_bytes,
+            "teacher_topk_padding_overhead_bytes": max(
+                teacher_topk_payload_bytes - teacher_topk_valid_payload_bytes,
+                0,
+            ),
+            "tq_teacher_topk_write_bytes": teacher_topk_valid_payload_bytes,
+            "tq_teacher_topk_write_num_samples": len(meta.sample_ids)
+            if is_writeback_leader
+            else 0,
+            "tq_teacher_topk_write_ms": write_ms,
+        }

--- a/nemo_rl/distributed/batched_data_dict.py
+++ b/nemo_rl/distributed/batched_data_dict.py
@@ -77,6 +77,15 @@ class BatchedDataDict(UserDict, Generic[DictT]):
     ADDITIONAL_OPTIONAL_KEY_TENSORS = [
         "token_type_ids",  # specific to gemma3 that tells where the image tokens are in the sequence, not required for llm-only inference/training
         "mm_token_type_ids",  # specific to qwen2.5-vl (transformers>=5.3): tells model which tokens are text(0)/image(1)/video(2) for 3D RoPE position encoding
+        "pixel_values",
+        "image_grid_thw",
+        "video_grid_thw",
+        "pixel_attention_mask",
+        "patch_attention_mask",
+        "image_sizes",
+        "image_flags",
+        "input_features",
+        "feature_attention_mask",
     ]
 
     def __init__(self, *args, **kwargs):

--- a/nemo_rl/distributed/ray_actor_environment_registry.py
+++ b/nemo_rl/distributed/ray_actor_environment_registry.py
@@ -53,6 +53,8 @@ ACTOR_ENVIRONMENT_REGISTRY: dict[str, str] = {
     # (2) same-node colocation with VllmGenerationWorker avoids duplicate
     # venv caches.
     "nemo_rl.experience.sync_rollout_actor.SyncRolloutActor": PY_EXECUTABLES.VLLM,
+    # DistillationRolloutActor has the same vLLM/TQ dependency surface as SyncRolloutActor
+    "nemo_rl.experience.distillation_rollout_actor.DistillationRolloutActor": PY_EXECUTABLES.VLLM,
     "nemo_rl.environments.tools.retriever.RAGEnvironment": PY_EXECUTABLES.SYSTEM,
     "nemo_rl.environments.nemo_gym.NemoGym": PY_EXECUTABLES.NEMO_GYM,
 }

--- a/nemo_rl/experience/distillation_rollout_actor.py
+++ b/nemo_rl/experience/distillation_rollout_actor.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""TransferQueue rollout actor for on-policy distillation."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Optional
+
+import numpy as np
+import ray
+import torch
+
+from nemo_rl.algorithms.grpo import _should_use_async_rollouts
+from nemo_rl.data.llm_message_utils import (
+    add_loss_mask_to_message_log,
+    batched_message_log_to_flat_message,
+)
+from nemo_rl.data.multimodal_utils import PackedTensor
+from nemo_rl.data_plane.column_io import kv_first_write
+from nemo_rl.data_plane.interfaces import KVBatchMeta
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.environments.interfaces import EnvironmentInterface
+from nemo_rl.experience.rollouts import (
+    run_async_multi_turn_rollout,
+    run_multi_turn_rollout,
+)
+from nemo_rl.models.generation.interfaces import GenerationInterface
+
+
+def _as_tq_tensor(value: Any, expected_rows: int) -> Optional[torch.Tensor]:
+    """Return a TQ-storable tensor only when it is row-aligned."""
+    if isinstance(value, PackedTensor):
+        value = value.as_tensor()
+    if not isinstance(value, torch.Tensor):
+        return None
+    if value.dim() == 0 or value.shape[0] != expected_rows:
+        return None
+    return value
+
+
+@ray.remote  # pragma: no cover
+class DistillationRolloutActor:
+    """Runs distillation rollout processing and seeds the TQ partition."""
+
+    def __init__(
+        self,
+        policy_generation: GenerationInterface,
+        tokenizer: Any,
+        task_to_env: dict[str, EnvironmentInterface],
+        master_config: Any,
+        dp_cfg: dict[str, Any],
+    ) -> None:
+        self.policy_generation = policy_generation
+        self.tokenizer = tokenizer
+        self.task_to_env = task_to_env
+        self.master_config = master_config
+
+        from nemo_rl.data_plane import build_data_plane_client
+
+        self._dp_client = build_data_plane_client(dp_cfg, bootstrap=False)
+
+    def rollout_to_tq(
+        self,
+        input_batch: BatchedDataDict[Any],
+        *,
+        partition_id: str,
+        model_input_fields: list[str],
+        first_iter: bool = True,
+        finish_generation: bool = True,
+        task_to_env_override: Optional[dict[str, EnvironmentInterface]] = None,
+    ) -> tuple[
+        KVBatchMeta,
+        BatchedDataDict[Any],
+        dict[str, Any],
+        Optional[dict[str, Any]],
+    ]:
+        """Run rollout, flatten training tensors, and write seed columns to TQ."""
+        if first_iter and hasattr(self.policy_generation, "snapshot_step_metrics"):
+            self.policy_generation.snapshot_step_metrics()
+        if hasattr(self.policy_generation, "clear_logger_metrics"):
+            self.policy_generation.clear_logger_metrics()
+
+        cfg = self.master_config
+        task_to_env = (
+            task_to_env_override
+            if task_to_env_override is not None
+            else self.task_to_env
+        )
+        rollout_kwargs = dict(
+            policy_generation=self.policy_generation,
+            input_batch=input_batch,
+            tokenizer=self.tokenizer,
+            task_to_env=task_to_env,
+            max_seq_len=cfg.policy["max_total_sequence_length"],
+            max_rollout_turns=cfg.distillation["max_rollout_turns"],
+            greedy=False,
+        )
+        if _should_use_async_rollouts(cfg):
+            final_batch, rollout_metrics = run_async_multi_turn_rollout(
+                **rollout_kwargs
+            )
+        else:
+            final_batch, rollout_metrics = run_multi_turn_rollout(**rollout_kwargs)
+
+        final_batch = final_batch.to("cpu")
+        add_loss_mask_to_message_log(final_batch["message_log"])
+        flat, input_lengths = batched_message_log_to_flat_message(
+            final_batch["message_log"],
+            pad_value_dict={"token_ids": self.tokenizer.pad_token_id},
+            make_sequence_length_divisible_by=cfg.policy[
+                "make_sequence_length_divisible_by"
+            ],
+        )
+
+        bulk_batch = BatchedDataDict(
+            {
+                "input_ids": flat["token_ids"],
+                "input_lengths": input_lengths,
+                "token_mask": flat["token_loss_mask"],
+                "sample_mask": final_batch["loss_multiplier"],
+            }
+        )
+        expected_rows = int(bulk_batch["sample_mask"].shape[0])
+        for field in model_input_fields:
+            if field not in flat:
+                raise KeyError(f"model input field {field!r} was not produced")
+            tensor = _as_tq_tensor(flat[field], expected_rows)
+            if tensor is None:
+                raise ValueError(
+                    f"model input field {field!r} is not row-aligned for TQ"
+                )
+            bulk_batch[field] = tensor
+        bulk_batch.to("cpu")
+
+        sample_ids = [str(uuid.uuid4()) for _ in range(expected_rows)]
+        meta = kv_first_write(
+            bulk_batch,
+            sample_ids=sample_ids,
+            dp_client=self._dp_client,
+            partition_id=partition_id,
+            task_name=partition_id,
+            pad_to_multiple=int(cfg.policy["make_sequence_length_divisible_by"]),
+        )
+
+        length = final_batch.get("length", input_lengths)
+        if not isinstance(length, torch.Tensor):
+            length = torch.tensor(length)
+        content_values = flat.get("content", [""] * expected_rows)
+        content = np.empty(expected_rows, dtype=object)
+        for i, item in enumerate(content_values):
+            content[i] = item
+        driver_carry = BatchedDataDict(
+            {
+                "length": length,
+                "input_lengths": input_lengths,
+                "content": content,
+            }
+        )
+
+        if finish_generation:
+            self.policy_generation.finish_generation()
+        generation_metrics = (
+            self.policy_generation.get_logger_metrics()
+            if hasattr(self.policy_generation, "get_logger_metrics")
+            else None
+        )
+        return meta, driver_carry, rollout_metrics, generation_metrics
+
+    def shutdown(self) -> None:
+        """Close this actor's data-plane client."""
+        try:
+            self._dp_client.close()
+        except Exception:
+            pass

--- a/nemo_rl/models/policy/tq_policy.py
+++ b/nemo_rl/models/policy/tq_policy.py
@@ -39,11 +39,14 @@ import ray
 
 from nemo_rl.algorithms.loss.interfaces import LossFunction
 from nemo_rl.data_plane import KVBatchMeta, build_data_plane_client
-from nemo_rl.data_plane.column_io import read_columns, round_up, write_columns
+from nemo_rl.data_plane.column_io import (
+    read_columns,
+    stamp_global_forward_pad_seqlen,
+    write_columns,
+)
 from nemo_rl.data_plane.preshard import shard_meta_for_dp
 from nemo_rl.data_plane.schema import (
     DP_TRAIN_FIELDS,
-    GLOBAL_FORWARD_PAD_SEQLEN,
     LP_SEED_FIELDS,
     fields_with_optional_routed_experts,
 )
@@ -146,6 +149,9 @@ class TQPolicy(Policy):
         self,
         num_samples: int,
         group_size: Optional[int] = None,
+        *,
+        fields: Optional[list[str]] = None,
+        consumer_tasks: Optional[list[str]] = None,
     ) -> None:
         """Register the per-step TQ partition.
 
@@ -157,14 +163,26 @@ class TQPolicy(Policy):
         Args:
             num_samples: Expected total samples this step.
             group_size: GRPO group size for balanced sampling; ``None`` disables grouping.
+            fields: Optional partition schema override. Defaults to
+                GRPO's ``DP_TRAIN_FIELDS``.
+            consumer_tasks: Optional consumer task override. Defaults to
+                GRPO's ``["prev_lp", "ref_lp", "train"]``.
         """
         self.dp_client.register_partition(
             partition_id=self.tq_partition_id,
-            fields=fields_with_optional_routed_experts(
-                DP_TRAIN_FIELDS, enabled=self._router_replay_enabled
+            fields=list(
+                fields
+                if fields is not None
+                else fields_with_optional_routed_experts(
+                    DP_TRAIN_FIELDS, enabled=self._router_replay_enabled
+                )
             ),
             num_samples=num_samples,
-            consumer_tasks=["prev_lp", "ref_lp", "train"],
+            consumer_tasks=list(
+                consumer_tasks
+                if consumer_tasks is not None
+                else ["prev_lp", "ref_lp", "train"]
+            ),
             grpo_group_size=group_size,
         )
 
@@ -207,13 +225,11 @@ class TQPolicy(Policy):
         """
         if not meta.sequence_lengths:
             return
-        if GLOBAL_FORWARD_PAD_SEQLEN in meta.extra_info:
-            return
         _, dba = self._packing_args("train_mb_tokens")
         seq_round = int(dba["sequence_length_round"]) if dba is not None else 1
-        pad_mult = int(meta.extra_info.get("pad_to_multiple", 1))
-        meta.extra_info[GLOBAL_FORWARD_PAD_SEQLEN] = round_up(
-            max(meta.sequence_lengths), max(pad_mult, seq_round)
+        stamp_global_forward_pad_seqlen(
+            meta,
+            sequence_length_round=seq_round,
         )
 
     def read_from_dataplane(
@@ -364,6 +380,8 @@ class TQPolicy(Policy):
         gbs: Optional[int] = None,
         mbs: Optional[int] = None,
         timer: Optional[Timer] = None,
+        *,
+        fields: Optional[list[str]] = None,
     ) -> dict[str, Any]:
         """1-hop counterpart to :meth:`train`.
 
@@ -379,6 +397,8 @@ class TQPolicy(Policy):
             gbs: Global batch size; defaults to ``cfg["train_global_batch_size"]``.
             mbs: Micro batch size; defaults to ``cfg["train_micro_batch_size"]``.
             timer: Optional timer for nested ``policy_training/*`` measurements.
+            fields: Optional train fetch field override. Defaults to
+                GRPO's ``DP_TRAIN_FIELDS``.
 
         Returns:
             Aggregated training-step output dict.
@@ -388,14 +408,17 @@ class TQPolicy(Policy):
 
         self._stamp_pad_seqlen(meta)
         spa, dba = self._packing_args("train_mb_tokens")
-        # Train workers fetch the full DP_TRAIN_FIELDS schema (rollout +
-        # logprob deltas + advantages + sample_mask). Caller is responsible
-        # for ensuring those columns have been written to TQ before this
-        # call (workers + driver delta-writes).
+        # Train workers fetch the requested train schema. Caller is
+        # responsible for ensuring those columns have been written to TQ
+        # before this call.
         train_meta = replace(
             meta,
-            fields=fields_with_optional_routed_experts(
-                DP_TRAIN_FIELDS, enabled=self._router_replay_enabled
+            fields=list(
+                fields
+                if fields is not None
+                else fields_with_optional_routed_experts(
+                    DP_TRAIN_FIELDS, enabled=self._router_replay_enabled
+                )
             ),
             task_name="train",
         )

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -107,6 +107,7 @@ project-includes = [
   "nemo_rl/data_plane/observability.py",
   "nemo_rl/data_plane/preshard.py",
   "nemo_rl/data_plane/schema.py",
+  "nemo_rl/data_plane/transport_metrics.py",
   "nemo_rl/data_plane/worker_mixin.py",
   "nemo_rl/distributed/__init__.py",
   "nemo_rl/distributed/collectives.py",

--- a/tests/test_suites/llm/distillation-qwen3-32b-to-1.7b-base-1n8g-fsdp2tp1-tq.v1.sh
+++ b/tests/test_suites/llm/distillation-qwen3-32b-to-1.7b-base-1n8g-fsdp2tp1-tq.v1.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $SCRIPT_DIR/common.env
+
+# ===== BEGIN CONFIG =====
+NUM_NODES=1
+STEPS_PER_RUN=10
+MAX_STEPS=10
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=60
+# ===== END CONFIG =====
+
+exit_if_max_steps_reached
+
+# Run the experiment
+cd $PROJECT_ROOT
+uv run examples/run_distillation.py \
+    --config $CONFIG_PATH \
+    distillation.max_num_steps=$MAX_STEPS \
+    distillation.val_period=20 \
+    logger.log_dir=$LOG_DIR \
+    logger.wandb_enabled=True \
+    logger.wandb.project=nemo-rl \
+    logger.wandb.name=$EXP_NAME \
+    logger.monitor_gpus=True \
+    logger.tensorboard_enabled=True \
+    checkpointing.enabled=True \
+    checkpointing.checkpoint_dir=$CKPT_DIR \
+    $@ \
+    2>&1 | tee $RUN_LOG
+
+# Convert tensorboard logs to json
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+
+# Only run metrics if the target step is reached
+if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
+    uv run tests/check_metrics.py $JSON_METRICS \
+        'data["train/loss"]["1"] < 1.5' \
+        'data["train/loss"]["10"] < 0.5' \
+        'max(data["ray/node.0.gpu.0.mem_gb"]) < 70' \
+        'mean(data["timing/train/total_step_time"], -6, -1) < 80'
+
+    # Clean up checkpoint directory after successful run to save space.
+    rm -rf "$CKPT_DIR"
+fi

--- a/tests/unit/data_plane/test_architecture_invariants.py
+++ b/tests/unit/data_plane/test_architecture_invariants.py
@@ -70,6 +70,25 @@ def test_sync_trainer_rejects_message_level_advantage_penalties():
         _raise_if_message_level_advantage_penalties_enabled(cfg_enabled)
 
 
+def test_run_distillation_dispatches_both_trainers():
+    """``examples/run_distillation._select_trainer`` mirrors GRPO dispatch."""
+    import sys
+
+    sys.path.insert(0, str(REPO / "examples"))
+    try:
+        from run_distillation import _select_trainer
+    finally:
+        sys.path.pop(0)
+    from nemo_rl.algorithms.distillation import MasterConfig, distillation_train
+    from nemo_rl.algorithms.distillation_sync import distillation_train_sync
+
+    cfg_legacy = MasterConfig.model_construct(data_plane=None)
+    assert _select_trainer(cfg_legacy) is distillation_train
+
+    cfg_sync = MasterConfig.model_construct(data_plane={"enabled": True})
+    assert _select_trainer(cfg_sync) is distillation_train_sync
+
+
 @pytest.mark.parametrize(
     "method",
     [

--- a/tests/unit/data_plane/test_distillation_tq.py
+++ b/tests/unit/data_plane/test_distillation_tq.py
@@ -16,9 +16,8 @@ from __future__ import annotations
 from dataclasses import replace
 from types import SimpleNamespace
 
-import torch
-
 import pytest
+import torch
 
 from nemo_rl.algorithms import distillation_sync
 from nemo_rl.data.multimodal_utils import PackedTensor

--- a/tests/unit/data_plane/test_distillation_tq.py
+++ b/tests/unit/data_plane/test_distillation_tq.py
@@ -18,7 +18,10 @@ from types import SimpleNamespace
 
 import torch
 
+import pytest
+
 from nemo_rl.algorithms import distillation_sync
+from nemo_rl.data.multimodal_utils import PackedTensor
 from nemo_rl.data_plane.adapters.noop import NoOpDataPlaneClient
 from nemo_rl.data_plane.column_io import kv_first_write, read_columns, write_columns
 from nemo_rl.data_plane.interfaces import KVBatchMeta
@@ -31,7 +34,9 @@ from nemo_rl.data_plane.schema import (
 )
 from nemo_rl.data_plane.transport_metrics import (
     add_byte_metric_derivatives,
+    tensor_nbytes,
     topk_payload_nbytes,
+    valid_token_tensor_nbytes,
 )
 from nemo_rl.data_plane.worker_mixin import TQWorkerMixin
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
@@ -404,3 +409,165 @@ def test_topk_payload_metrics_account_for_valid_lengths() -> None:
 
     assert metrics["teacher_topk_payload_gib"] == 300 / float(1024**3)
     assert metrics["teacher_topk_payload_bytes_per_token"] == 10
+
+
+def test_dedupe_fields_preserves_first_occurrence_order() -> None:
+    assert distillation_sync._dedupe_fields() == []
+    assert distillation_sync._dedupe_fields(["a", "a", "b"]) == ["a", "b"]
+    # First occurrence across groups wins; tuples and lists interoperate.
+    assert distillation_sync._dedupe_fields(["a", "b"], ("b", "c"), ["a", "d"]) == [
+        "a",
+        "b",
+        "c",
+        "d",
+    ]
+
+
+def test_as_row_aligned_tensor_branches() -> None:
+    rows = 3
+    valid = torch.arange(rows * 4, dtype=torch.float32).reshape(rows, 4)
+
+    # Row-aligned 2D tensor is returned unchanged.
+    assert distillation_sync._as_row_aligned_tensor(valid, rows) is valid
+    # Non-tensors are not TQ-storable.
+    assert distillation_sync._as_row_aligned_tensor([1, 2, 3], rows) is None
+    # Scalar (0-dim) tensors carry no row axis.
+    assert distillation_sync._as_row_aligned_tensor(torch.tensor(1.0), rows) is None
+    # Row-count mismatch is rejected.
+    assert distillation_sync._as_row_aligned_tensor(valid, rows + 1) is None
+    # PackedTensor is unwrapped via as_tensor() before the row check.
+    packed = PackedTensor(valid, dim_to_pack=0)
+    result = distillation_sync._as_row_aligned_tensor(packed, rows)
+    assert result is not None and result.shape == (rows, 4)
+
+
+def test_aggregate_teacher_topk_transport_results_skips_empty_and_none() -> None:
+    metrics = distillation_sync._aggregate_teacher_topk_transport_results([{}, None])
+    assert metrics["teacher_topk_payload_bytes"] == 0
+    assert metrics["driver_teacher_topk_bytes_avoided"] == 0
+    assert metrics["tq_teacher_topk_write_ms_max"] == 0.0
+
+
+def test_aggregate_teacher_topk_transport_results_sums_and_maxes() -> None:
+    metrics = distillation_sync._aggregate_teacher_topk_transport_results(
+        [
+            {
+                "teacher_topk_payload_bytes": 100,
+                "tq_teacher_topk_write_num_samples": 2,
+                "tq_teacher_topk_write_ms": 1.5,
+            },
+            {
+                "teacher_topk_payload_bytes": 200,
+                "tq_teacher_topk_write_num_samples": 4,
+                "tq_teacher_topk_write_ms": 0.5,
+            },
+        ]
+    )
+    assert metrics["teacher_topk_payload_bytes"] == 300
+    assert metrics["tq_teacher_topk_write_num_samples"] == 6
+    assert metrics["tq_teacher_topk_write_ms_sum"] == 2.0
+    assert metrics["tq_teacher_topk_write_ms_max"] == 1.5
+    # Avoided driver bytes are twice the resident payload (RX + TX hop).
+    assert metrics["driver_teacher_topk_bytes_avoided"] == 600
+
+
+def test_aggregate_teacher_topk_transport_results_rejects_non_mapping() -> None:
+    with pytest.raises(RuntimeError, match="scalar metric acks"):
+        distillation_sync._aggregate_teacher_topk_transport_results([("not", "a map")])
+
+
+def test_aggregate_teacher_topk_transport_results_rejects_tensor_payloads() -> None:
+    with pytest.raises(RuntimeError, match="tensor payloads"):
+        distillation_sync._aggregate_teacher_topk_transport_results(
+            [{"teacher_topk_payload_bytes": torch.zeros(2)}]
+        )
+
+
+def test_packing_args_for_policy_selects_branch() -> None:
+    dynamic_policy = SimpleNamespace(
+        use_dynamic_batches=True,
+        use_sequence_packing=False,
+        dynamic_batching_args={"sequence_length_round": 8},
+        cfg={"dynamic_batching": {"logprob_mb_tokens": 512}},
+    )
+    spa, dba = distillation_sync._packing_args_for_policy(
+        dynamic_policy, "logprob_mb_tokens"
+    )
+    assert spa is None
+    assert dba == {"sequence_length_round": 8, "max_tokens_per_microbatch": 512}
+
+    packing_policy = SimpleNamespace(
+        use_dynamic_batches=False,
+        use_sequence_packing=True,
+        sequence_packing_args={"algorithm": "first_fit"},
+        cfg={"sequence_packing": {"logprob_mb_tokens": 256}},
+    )
+    spa, dba = distillation_sync._packing_args_for_policy(
+        packing_policy, "logprob_mb_tokens"
+    )
+    assert dba is None
+    assert spa == {"algorithm": "first_fit", "max_tokens_per_microbatch": 256}
+
+    plain_policy = SimpleNamespace(
+        use_dynamic_batches=False, use_sequence_packing=False
+    )
+    assert distillation_sync._packing_args_for_policy(
+        plain_policy, "logprob_mb_tokens"
+    ) == (None, None)
+
+
+def test_stamp_policy_pad_seqlen_uses_pad_to_multiple_for_plain_policy() -> None:
+    policy = SimpleNamespace(use_dynamic_batches=False, use_sequence_packing=False)
+    meta = KVBatchMeta(
+        partition_id="train",
+        task_name="train",
+        sample_ids=["u0", "u1"],
+        fields=list(DISTILLATION_TRAIN_FIELDS),
+        sequence_lengths=[5, 7],
+        extra_info={"pad_to_multiple": 4},
+    )
+    distillation_sync._stamp_policy_pad_seqlen(
+        policy, meta, mb_tokens_key="logprob_mb_tokens"
+    )
+    # round_up(max(5, 7), max(4, 1)) == 8
+    assert meta.extra_info[GLOBAL_FORWARD_PAD_SEQLEN] == 8
+
+
+def test_stamp_policy_pad_seqlen_honors_dynamic_sequence_length_round() -> None:
+    policy = SimpleNamespace(
+        use_dynamic_batches=True,
+        use_sequence_packing=False,
+        dynamic_batching_args={"sequence_length_round": 16},
+        cfg={"dynamic_batching": {"logprob_mb_tokens": 512}},
+    )
+    meta = KVBatchMeta(
+        partition_id="train",
+        task_name="train",
+        sample_ids=["u0"],
+        fields=list(DISTILLATION_TRAIN_FIELDS),
+        sequence_lengths=[5],
+    )
+    distillation_sync._stamp_policy_pad_seqlen(
+        policy, meta, mb_tokens_key="logprob_mb_tokens"
+    )
+    # round_up(5, max(1, 16)) == 16
+    assert meta.extra_info[GLOBAL_FORWARD_PAD_SEQLEN] == 16
+
+
+def test_tensor_nbytes_counts_only_tensors() -> None:
+    assert tensor_nbytes("not a tensor") == 0
+    assert tensor_nbytes(torch.zeros((2, 3), dtype=torch.float32)) == 2 * 3 * 4
+    assert tensor_nbytes(torch.zeros((4,), dtype=torch.int64)) == 4 * 8
+
+
+def test_valid_token_tensor_nbytes_accounts_for_valid_prefix() -> None:
+    tensor = torch.zeros((2, 5, 3), dtype=torch.float32)
+    # No lengths -> full tensor.
+    assert valid_token_tensor_nbytes(tensor, None) == 2 * 5 * 3 * 4
+    # Lengths clamped to [0, max_seq_len]; trailing dims multiply through.
+    assert valid_token_tensor_nbytes(tensor, [5, 9]) == (5 + 5) * 3 * 4
+    assert valid_token_tensor_nbytes(tensor, [2, -1]) == (2 + 0) * 3 * 4
+    # Row-count mismatch falls back to the full tensor byte count.
+    assert valid_token_tensor_nbytes(tensor, [5]) == 2 * 5 * 3 * 4
+    # 1D tensors have no sequence axis -> full byte count.
+    assert valid_token_tensor_nbytes(torch.zeros((4,)), [2]) == 4 * 4

--- a/tests/unit/data_plane/test_distillation_tq.py
+++ b/tests/unit/data_plane/test_distillation_tq.py
@@ -1,0 +1,406 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import torch
+
+from nemo_rl.algorithms import distillation_sync
+from nemo_rl.data_plane.adapters.noop import NoOpDataPlaneClient
+from nemo_rl.data_plane.column_io import kv_first_write, read_columns, write_columns
+from nemo_rl.data_plane.interfaces import KVBatchMeta
+from nemo_rl.data_plane.schema import (
+    DISTILLATION_TRAIN_FIELDS,
+    GLOBAL_FORWARD_PAD_SEQLEN,
+    TEACHER_TOPK_INDICES,
+    TEACHER_TOPK_LOGITS,
+    TEACHER_TOPK_SEED_FIELDS,
+)
+from nemo_rl.data_plane.transport_metrics import (
+    add_byte_metric_derivatives,
+    topk_payload_nbytes,
+)
+from nemo_rl.data_plane.worker_mixin import TQWorkerMixin
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.models.policy.tq_policy import TQPolicy
+
+
+def _distillation_seed_batch(batch_size: int, seq_len: int) -> BatchedDataDict:
+    return BatchedDataDict(
+        {
+            "input_ids": torch.arange(batch_size * seq_len, dtype=torch.long).reshape(
+                batch_size, seq_len
+            ),
+            "input_lengths": torch.tensor([seq_len] * batch_size, dtype=torch.long),
+            "token_mask": torch.ones((batch_size, seq_len), dtype=torch.long),
+            "sample_mask": torch.ones((batch_size,), dtype=torch.long),
+        }
+    )
+
+
+def test_teacher_topk_columns_roundtrip_as_bsk() -> None:
+    batch_size, seq_len, k = 3, 5, 4
+    client = NoOpDataPlaneClient()
+    client.register_partition(
+        partition_id="train",
+        fields=list(DISTILLATION_TRAIN_FIELDS),
+        num_samples=batch_size,
+        consumer_tasks=["teacher_topk", "train"],
+    )
+    meta = kv_first_write(
+        _distillation_seed_batch(batch_size, seq_len),
+        sample_ids=[f"u{i}" for i in range(batch_size)],
+        dp_client=client,
+        partition_id="train",
+    )
+    logits = torch.randn(batch_size, seq_len, k, dtype=torch.bfloat16)
+    indices = torch.arange(batch_size * seq_len * k, dtype=torch.long).reshape(
+        batch_size, seq_len, k
+    )
+
+    write_columns(
+        client,
+        meta,
+        fields={
+            TEACHER_TOPK_LOGITS: logits,
+            TEACHER_TOPK_INDICES: indices,
+        },
+    )
+    fetched = read_columns(
+        client,
+        meta,
+        select_fields=[TEACHER_TOPK_LOGITS, TEACHER_TOPK_INDICES],
+    )
+
+    assert fetched[TEACHER_TOPK_LOGITS].shape == (batch_size, seq_len, k)
+    assert fetched[TEACHER_TOPK_INDICES].shape == (batch_size, seq_len, k)
+    assert fetched[TEACHER_TOPK_LOGITS].dtype == torch.bfloat16
+    assert fetched[TEACHER_TOPK_INDICES].dtype == torch.long
+    assert torch.equal(fetched[TEACHER_TOPK_LOGITS], logits)
+    assert torch.equal(fetched[TEACHER_TOPK_INDICES], indices)
+
+
+def test_tq_policy_prepare_step_accepts_custom_fields_and_tasks() -> None:
+    calls = []
+
+    class _Client:
+        def register_partition(self, **kwargs):
+            calls.append(kwargs)
+
+    policy = TQPolicy.__new__(TQPolicy)
+    policy.dp_client = _Client()
+    policy.tq_partition_id = "train"
+
+    TQPolicy.prepare_step(
+        policy,
+        num_samples=7,
+        fields=["input_ids", TEACHER_TOPK_LOGITS],
+        consumer_tasks=["teacher_topk", "train"],
+    )
+
+    assert calls == [
+        {
+            "partition_id": "train",
+            "fields": ["input_ids", TEACHER_TOPK_LOGITS],
+            "num_samples": 7,
+            "consumer_tasks": ["teacher_topk", "train"],
+            "grpo_group_size": None,
+        }
+    ]
+
+
+def test_tq_policy_train_from_meta_uses_custom_fetch_fields() -> None:
+    class _ShardingAnnotations:
+        def get_axis_size(self, axis: str) -> int:
+            assert axis == "data_parallel"
+            return 1
+
+    class _WorkerGroup:
+        def __init__(self) -> None:
+            self.method = None
+            self.submitted_meta = None
+            self.cluster = SimpleNamespace(world_size=lambda: 1)
+
+        def run_all_workers_sharded_data(self, method: str, **kwargs):
+            self.method = method
+            self.submitted_meta = kwargs["meta"]
+            return ["future"]
+
+        def get_all_worker_results(self, futures):
+            assert futures == ["future"]
+            return [
+                {
+                    "global_loss": torch.tensor(1.0),
+                    "grad_norm": torch.tensor(2.0),
+                    "all_mb_metrics": {},
+                }
+            ]
+
+        def shutdown(self, **_) -> None:
+            return None
+
+    policy = TQPolicy.__new__(TQPolicy)
+    policy.cfg = {"train_global_batch_size": 2, "train_micro_batch_size": 1}
+    policy.use_dynamic_batches = False
+    policy.use_sequence_packing = False
+    policy.sharding_annotations = _ShardingAnnotations()
+    policy.worker_group = _WorkerGroup()
+    policy.flops_tracker = None
+    meta = KVBatchMeta(
+        partition_id="train",
+        task_name="train",
+        sample_ids=["u0", "u1"],
+        fields=list(DISTILLATION_TRAIN_FIELDS),
+        sequence_lengths=[4, 4],
+    )
+    custom_fields = ["input_ids", TEACHER_TOPK_LOGITS, TEACHER_TOPK_INDICES]
+
+    result = TQPolicy.train_from_meta(
+        policy,
+        meta,
+        loss_fn=object(),
+        fields=custom_fields,
+    )
+
+    assert result["loss"].item() == 1.0
+    assert policy.worker_group.method == "train_presharded"
+    assert len(policy.worker_group.submitted_meta) == 1
+    assert policy.worker_group.submitted_meta[0].fields == custom_fields
+
+
+class _TopKWorker(TQWorkerMixin):
+    tokenizer = SimpleNamespace(pad_token_id=0)
+    cfg = {
+        "sequence_packing": {"enabled": False},
+        "dynamic_batching": {"enabled": False},
+    }
+
+    def __init__(self, client: NoOpDataPlaneClient) -> None:
+        self._dp_client = client
+
+    def get_topk_logits(self, *, data, k: int, micro_batch_size=None):
+        del micro_batch_size
+        batch_size, seq_len = data["input_ids"].shape
+        logits = torch.arange(batch_size * seq_len * k, dtype=torch.float32).reshape(
+            batch_size, seq_len, k
+        )
+        indices = (
+            torch.arange(k, dtype=torch.long)
+            .reshape(1, 1, k)
+            .expand(batch_size, seq_len, k)
+        )
+        return BatchedDataDict({"topk_logits": logits, "topk_indices": indices})
+
+
+def test_teacher_worker_topk_writeback_returns_only_scalar_ack() -> None:
+    batch_size, seq_len, k = 2, 6, 3
+    client = NoOpDataPlaneClient()
+    client.register_partition(
+        partition_id="train",
+        fields=list(DISTILLATION_TRAIN_FIELDS),
+        num_samples=batch_size,
+        consumer_tasks=["teacher_topk", "train"],
+    )
+    meta = kv_first_write(
+        _distillation_seed_batch(batch_size, seq_len),
+        sample_ids=[f"u{i}" for i in range(batch_size)],
+        dp_client=client,
+        partition_id="train",
+    )
+    worker = _TopKWorker(client)
+
+    result = worker.get_topk_logits_presharded(
+        replace(meta, fields=list(TEACHER_TOPK_SEED_FIELDS)),
+        k=k,
+    )
+
+    expected_bytes = (
+        batch_size
+        * seq_len
+        * k
+        * (
+            torch.tensor([], dtype=torch.float32).element_size()
+            + torch.tensor([], dtype=torch.long).element_size()
+        )
+    )
+    assert result["teacher_topk_payload_bytes"] == expected_bytes
+    assert result["teacher_topk_valid_payload_bytes"] == expected_bytes
+    assert result["tq_teacher_topk_write_bytes"] == expected_bytes
+    assert result["tq_teacher_topk_write_num_samples"] == batch_size
+    assert result["tq_teacher_topk_write_ms"] >= 0.0
+    assert all(not isinstance(v, torch.Tensor) for v in result.values())
+    fetched = read_columns(
+        client,
+        meta,
+        select_fields=[TEACHER_TOPK_LOGITS, TEACHER_TOPK_INDICES],
+    )
+    assert fetched[TEACHER_TOPK_LOGITS].shape == (batch_size, seq_len, k)
+    assert fetched[TEACHER_TOPK_INDICES].shape == (batch_size, seq_len, k)
+
+
+def test_attach_policy_workers_to_data_plane_after_student_bootstrap(
+    monkeypatch,
+) -> None:
+    calls = []
+    monkeypatch.setattr(distillation_sync.ray, "get", lambda value: value)
+
+    class _WorkerGroup:
+        def run_all_workers_single_data(self, method: str, cfg: dict):
+            calls.append((method, cfg))
+            return ["ok"]
+
+    policy = SimpleNamespace(worker_group=_WorkerGroup())
+    dp_cfg = {"enabled": True, "impl": "transfer_queue"}
+
+    distillation_sync.attach_policy_workers_to_data_plane(policy, dp_cfg)
+
+    assert calls == [("setup_data_plane", dp_cfg)]
+
+
+def test_teacher_dispatch_uses_writeback_method_and_not_driver_topk() -> None:
+    class _ShardingAnnotations:
+        def get_axis_size(self, axis: str) -> int:
+            assert axis == "data_parallel"
+            return 1
+
+    class _WorkerGroup:
+        def __init__(self) -> None:
+            self.method = None
+            self.meta = None
+            self.common_kwargs = None
+
+        def run_all_workers_sharded_data(self, method: str, meta, common_kwargs, **_):
+            self.method = method
+            self.meta = meta
+            self.common_kwargs = common_kwargs
+            return ["future"]
+
+        def get_all_worker_results(self, futures):
+            assert futures == ["future"]
+            return [{}]
+
+    def _driver_topk_should_not_run(*_, **__):
+        raise AssertionError("driver get_topk_logits must not be called")
+
+    worker_group = _WorkerGroup()
+    policy = SimpleNamespace(
+        use_dynamic_batches=False,
+        use_sequence_packing=False,
+        sharding_annotations=_ShardingAnnotations(),
+        worker_group=worker_group,
+        get_topk_logits=_driver_topk_should_not_run,
+    )
+    meta = KVBatchMeta(
+        partition_id="train",
+        task_name="train",
+        sample_ids=["u0", "u1"],
+        fields=list(DISTILLATION_TRAIN_FIELDS),
+        sequence_lengths=[5, 5],
+        extra_info={"pad_to_multiple": 4},
+    )
+
+    metrics = distillation_sync.dispatch_teacher_topk_writeback(
+        policy,
+        meta,
+        fields=list(TEACHER_TOPK_SEED_FIELDS),
+        k=8,
+    )
+
+    assert worker_group.method == "get_topk_logits_presharded"
+    assert worker_group.common_kwargs == {"k": 8}
+    assert worker_group.meta[0].fields == list(TEACHER_TOPK_SEED_FIELDS)
+    assert GLOBAL_FORWARD_PAD_SEQLEN in meta.extra_info
+    assert metrics["teacher_topk_payload_bytes"] == 0
+    assert metrics["driver_teacher_topk_bytes_avoided"] == 0
+
+
+def test_teacher_dispatch_aggregates_transport_metrics() -> None:
+    class _ShardingAnnotations:
+        def get_axis_size(self, axis: str) -> int:
+            assert axis == "data_parallel"
+            return 1
+
+    class _WorkerGroup:
+        def run_all_workers_sharded_data(self, *_, **__):
+            return ["future"]
+
+        def get_all_worker_results(self, futures):
+            assert futures == ["future"]
+            return [
+                {
+                    "teacher_topk_payload_bytes": 100,
+                    "teacher_topk_valid_payload_bytes": 80,
+                    "teacher_topk_padding_overhead_bytes": 20,
+                    "tq_teacher_topk_write_bytes": 80,
+                    "tq_teacher_topk_write_num_samples": 2,
+                    "tq_teacher_topk_write_ms": 1.5,
+                },
+                {
+                    "teacher_topk_payload_bytes": 200,
+                    "teacher_topk_valid_payload_bytes": 160,
+                    "teacher_topk_padding_overhead_bytes": 40,
+                    "tq_teacher_topk_write_bytes": 160,
+                    "tq_teacher_topk_write_num_samples": 4,
+                    "tq_teacher_topk_write_ms": 2.5,
+                },
+            ]
+
+    policy = SimpleNamespace(
+        use_dynamic_batches=False,
+        use_sequence_packing=False,
+        sharding_annotations=_ShardingAnnotations(),
+        worker_group=_WorkerGroup(),
+    )
+    meta = KVBatchMeta(
+        partition_id="train",
+        task_name="train",
+        sample_ids=["u0", "u1"],
+        fields=list(DISTILLATION_TRAIN_FIELDS),
+        sequence_lengths=[5, 5],
+    )
+
+    metrics = distillation_sync.dispatch_teacher_topk_writeback(
+        policy,
+        meta,
+        fields=list(TEACHER_TOPK_SEED_FIELDS),
+        k=8,
+    )
+
+    assert metrics["teacher_topk_payload_bytes"] == 300
+    assert metrics["teacher_topk_valid_payload_bytes"] == 240
+    assert metrics["teacher_topk_padding_overhead_bytes"] == 60
+    assert metrics["driver_rx_teacher_topk_bytes"] == 0
+    assert metrics["driver_tx_teacher_topk_bytes"] == 0
+    assert metrics["driver_teacher_topk_bytes"] == 0
+    assert metrics["driver_teacher_topk_bytes_avoided"] == 600
+    assert metrics["tq_teacher_topk_write_bytes"] == 240
+    assert metrics["tq_teacher_topk_write_num_samples"] == 6
+    assert metrics["tq_teacher_topk_write_ms_sum"] == 4.0
+    assert metrics["tq_teacher_topk_write_ms_max"] == 2.5
+
+
+def test_topk_payload_metrics_account_for_valid_lengths() -> None:
+    logits = torch.zeros((2, 5, 3), dtype=torch.bfloat16)
+    indices = torch.zeros((2, 5, 3), dtype=torch.long)
+
+    assert topk_payload_nbytes(logits, indices) == 2 * 5 * 3 * (2 + 8)
+    assert topk_payload_nbytes(logits, indices, [5, 2]) == 7 * 3 * (2 + 8)
+
+    metrics: dict[str, float | int] = {"teacher_topk_payload_bytes": 300}
+    add_byte_metric_derivatives(metrics, token_count=30)
+
+    assert metrics["teacher_topk_payload_gib"] == 300 / float(1024**3)
+    assert metrics["teacher_topk_payload_bytes_per_token"] == 10

--- a/tests/unit/data_plane/test_smoke.py
+++ b/tests/unit/data_plane/test_smoke.py
@@ -54,6 +54,20 @@ def test_sync_rollout_actor_registered_under_vllm_tier() -> None:
     )
 
 
+def test_distillation_rollout_actor_registered_under_vllm_tier() -> None:
+    """Distillation TQ runs need the same env tier as sync rollout actors."""
+    from nemo_rl.distributed.ray_actor_environment_registry import (
+        get_actor_python_env,
+    )
+    from nemo_rl.distributed.virtual_cluster import PY_EXECUTABLES
+
+    fqn = "nemo_rl.experience.distillation_rollout_actor.DistillationRolloutActor"
+    env = get_actor_python_env(fqn)
+    assert env in (PY_EXECUTABLES.VLLM, PY_EXECUTABLES.SYSTEM), (
+        f"unexpected env tier for {fqn}: {env!r}"
+    )
+
+
 def test_kvbatchmeta_schema_unchanged() -> None:
     """Schema break check — KVBatchMeta is the cross-process boundary;
     adding/removing a field silently would break adapters that pickle it."""

--- a/tests/unit/reference_configs/distillation_math.yaml
+++ b/tests/unit/reference_configs/distillation_math.yaml
@@ -271,3 +271,13 @@ cluster:
     master_port_range_low: 25000
     master_port_range_high: 28000
     segment_size: null
+
+data_plane:
+    enabled: false
+    impl: transfer_queue
+    backend: "simple"
+    storage_capacity: 1000000
+    num_storage_units: 2
+    claim_meta_poll_interval_s: 0.5
+    global_segment_size: 549755813888
+    local_buffer_size: 68719476736


### PR DESCRIPTION
# What does this PR do ?

Adds TransferQueue-backed on-policy distillation so teacher top-k logits can stay in the data plane instead of being returned through the driver.

This PR extends the data-plane support that already exists for GRPO to the distillation workflow. When `data_plane.enabled=true`, `examples/run_distillation.py` now builds the student policy as a `TQPolicy` and dispatches to a new TQ-aware distillation trainer. The legacy distillation path remains the default when the data plane is disabled.

Key pieces added:

- A new `distillation_train_sync` implementation that orchestrates rollout, teacher top-k inference, and student training through TransferQueue metadata.
- A `DistillationRolloutActor` that runs generation/rollout processing and seeds the TQ partition with row-aligned distillation training tensors.
- Worker-side `get_topk_logits_presharded` support so teacher workers write `teacher_topk_logits` and `teacher_topk_indices` back to TQ directly.
- Distillation-specific data-plane schema fields for teacher top-k seed inputs and train-time top-k columns.
- `TQPolicy` extensions for custom partition fields, consumer task names, and custom train fetch fields so the same policy wrapper can serve GRPO and distillation.
- Transport-volume metrics for teacher top-k payloads, valid-token payloads, padding overhead, TQ write volume, and driver bytes avoided.
- A TQ exemplar config and a runnable recipe/test-suite script for Qwen3 32B-to-1.7B distillation.

# Issues

None.

# Usage

Enable the TQ distillation path by using the new exemplar or recipe:

```bash
uv run examples/run_distillation.py \
  --config examples/configs/distillation_math_tq.yaml \
  data_plane.enabled=true
```

The recipe added in this PR can be launched through the test-suite wrapper:

```bash
tests/test_suites/llm/distillation-qwen3-32b-to-1.7b-base-1n8g-fsdp2tp1-tq.v1.sh
```

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

