### PR TITLE
fix: Fix DAPO crash due to discard generation weights

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1593,7 +1593,7 @@ def grpo_train(
                         )
                     # We cannot discard generation weights and make it stale when using dynamic sampling
                     # because if this batch is not complete, we need to continue generation without refit
-                    # and making it stale will trigger refit and crash. 
+                    # and making it stale will trigger refit and crash.
                     # TODO(guyueh): a proper fix to not sleep the engine if batch is incomplete
                     make_generation_stale_by_discard_weights = (
                         not master_config.grpo["use_dynamic_sampling"]

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1591,10 +1591,18 @@ def grpo_train(
                             max_rollout_turns=master_config.grpo["max_rollout_turns"],
                             greedy=False,
                         )
-                    policy_generation.finish_generation(
-                        discard_weights=colocated_inference
+                    # We cannot discard generation weights and make it stale when using dynamic sampling
+                    # because if this batch is not complete, we need to continue generation without refit
+                    # and making it stale will trigger refit and crash. 
+                    # TODO(guyueh): a proper fix to not sleep the engine if batch is incomplete
+                    make_generation_stale_by_discard_weights = (
+                        not master_config.grpo["use_dynamic_sampling"]
+                        and colocated_inference
                     )
-                    if colocated_inference:
+                    policy_generation.finish_generation(
+                        discard_weights=make_generation_stale_by_discard_weights
+                    )
+                    if make_generation_stale_by_discard_weights:
                         POLICY_GENERATION_STALE = True
                     # Collect generation logger metrics for performance reporting after each generation step
                     # inflight batch sizes and num pending samples are collected from each worker


### PR DESCRIPTION
# What does this PR do ?

Fix an issue introduced by #2495 : when using dynamic sampling, at end of generation phase, we cannot simply discard generation weights and mark it stale, because if the batch is decided to be incomplete for training, we directly jump to next step and start generation again, in that case marking it stale will trigger a refit which will crash. 

This is just a temporal patch, but it does not enable the intended optimization of #2495 for DAPO; I will propose a proper fix in another PR.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
