### PR TITLE
fix: lower mooncake memory in functional test

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -176,11 +176,11 @@ jobs:
   org-member-pre-flight:
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@v0.80.1
     with:
-      default_runner_prefix: ${{ vars.NON_NVIDIA_RUNNER_PREFIX }}
+      default_runner_prefix: ${{ vars.DEFAULT_RUNNER_PREFIX }}
       non_nvidia_runner_prefix: ${{ vars.NON_NVIDIA_RUNNER_PREFIX }}
-      default_test_data_path: ${{ vars.NON_NVIDIA_TEST_DATA_PATH }}
+      default_test_data_path: ${{ vars.DEFAULT_TEST_DATA_PATH }}
       non_nvidia_test_data_path: ${{ vars.NON_NVIDIA_TEST_DATA_PATH }}
-      default_registry: ${{ vars.NON_NVIDIA_CONTAINER_REGISTRY }}
+      default_registry: ${{ vars.DEFAULT_CONTAINER_REGISTRY }}
       non_nvidia_registry: ${{ vars.NON_NVIDIA_CONTAINER_REGISTRY }}
       sso_users_filename: ${{ vars.SSO_USERS_FILENAME }}
     secrets:

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -176,11 +176,11 @@ jobs:
   org-member-pre-flight:
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@v0.80.1
     with:
-      default_runner_prefix: ${{ vars.DEFAULT_RUNNER_PREFIX }}
+      default_runner_prefix: ${{ vars.NON_NVIDIA_RUNNER_PREFIX }}
       non_nvidia_runner_prefix: ${{ vars.NON_NVIDIA_RUNNER_PREFIX }}
-      default_test_data_path: ${{ vars.DEFAULT_TEST_DATA_PATH }}
+      default_test_data_path: ${{ vars.NON_NVIDIA_TEST_DATA_PATH }}
       non_nvidia_test_data_path: ${{ vars.NON_NVIDIA_TEST_DATA_PATH }}
-      default_registry: ${{ vars.DEFAULT_CONTAINER_REGISTRY }}
+      default_registry: ${{ vars.NON_NVIDIA_CONTAINER_REGISTRY }}
       non_nvidia_registry: ${{ vars.NON_NVIDIA_CONTAINER_REGISTRY }}
       sso_users_filename: ${{ vars.SSO_USERS_FILENAME }}
     secrets:

--- a/tests/functional/grpo_dp_mooncake.sh
+++ b/tests/functional/grpo_dp_mooncake.sh
@@ -38,6 +38,8 @@ uv run coverage run -a --data-file=$PROJECT_ROOT/tests/.coverage --source=$PROJE
     data_plane.enabled=true \
     data_plane.impl=transfer_queue \
     data_plane.backend=mooncake_cpu \
+    data_plane.global_segment_size=4294967296 \
+    data_plane.local_buffer_size=1073741824 \
     $@ \
     2>&1 | tee $RUN_LOG
 


### PR DESCRIPTION
## Summary
fix `./tests/functional/grpo_dp_mooncake.sh` fail in CI ([action link](https://github.com/NVIDIA-NeMo/RL/actions/runs/26456020523/job/77989567727?pr=2376)) when using A100 by lower mooncake memory suggested by @ZhiyuLi-Nvidia 

## Test Result
confirmed in [action link](https://github.com/NVIDIA-NeMo/RL/actions/runs/26502572771/job/78063079591?pr=2584) using https://github.com/NVIDIA-NeMo/RL/pull/2584/commits/3fbc3f8e1e88539c8ce96b1f51bd141b2ccbbc11.

```
✓ Merged data written to 
/opt/nemo-rl/tests/functional/grpo_dp_mooncake/metrics.json
                                 Metric Checks                                  
┏━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
┃ Status ┃ Check                             ┃ Value                 ┃ Message ┃
┡━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
│ PASS   │ max(data["train/gen_kl_error"]) < │ 0.0006355919758789241 │         │
│        │ 0.002                             │                       │         │
│ PASS   │ min(data["train/probs_ratio_clam… │ 0.800000011920929     │         │
│        │ > 0.79                            │                       │         │
│ PASS   │ max(data["train/probs_ratio_clam… │ 1.0                   │         │
│        │ < 1.21                            │                       │         │
│ PASS   │ min(data["train/probs_ratio_clam… │ 1.0                   │         │
│        │ > 0.79                            │                       │         │
│ PASS   │ max(data["train/probs_ratio_clam… │ 1.2000000476837158    │         │
│        │ < 1.21                            │                       │         │
└────────┴───────────────────────────────────┴───────────────────────┴─────────┘
```