### PR TITLE
fix: Make moe_backend triton to fix refit issue with moonlight

### DIFF
--- a/examples/configs/recipes/llm/grpo-moonlight-16b-automodel-1n8g-ep8.yaml
+++ b/examples/configs/recipes/llm/grpo-moonlight-16b-automodel-1n8g-ep8.yaml
@@ -48,6 +48,12 @@ policy:
       total_iters: 10000000000
   - milestones:
     - 13
+  generation:
+    vllm_kwargs:
+      # vLLM 0.20's FlashInfer TRTLLM MoE backend stores bf16 expert
+      # weights in a blocked runtime layout that its load_weights path cannot
+      # refit. Use TRITON to keep the refit-compatible 3D MoE layout.
+      moe_backend: triton
 data:
   max_input_seq_length: 4096
 cluster:

--- a/examples/configs/recipes/llm/grpo-moonlight-16ba3b-4n8g-megatron.yaml
+++ b/examples/configs/recipes/llm/grpo-moonlight-16ba3b-4n8g-megatron.yaml
@@ -13,6 +13,12 @@ policy:
   generation_batch_size: 64
   logprob_batch_size: 1
   max_total_sequence_length: 8192
+  generation:
+    vllm_kwargs:
+      # vLLM 0.20's FlashInfer TRTLLM MoE backend stores bf16 expert
+      # weights in a blocked runtime layout that its load_weights path cannot
+      # refit. Use TRITON to keep the refit-compatible 3D MoE layout.
+      moe_backend: triton
   dtensor_cfg:
     enabled: false
   sequence_packing:


### PR DESCRIPTION
# What does this PR do ?

After bumping vllm to 0.20.0 the moonlight model start to show high logprob error on H100 and crashes on GB200. From vllm 0.17.1 -> 0.20.0 the default MoE kernel backend for this model changes from "TRITON" to "FLASHINFER_CUTLASS" thus the regression; for now hardcode it to triton, but in a follow up PR we should to fix refit for FLASHINFER_CUTLASS too. 

Logprob error is normal after fix:
<img width="976" height="354" alt="image" src="https://github.com/user-attachments/assets/32db4322-7036-4c46-9f36-ad1ffea5ecde" />



# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
