### PR TITLE
feat(modelopt): support real NVFP4 QAT rollout

### DIFF
--- a/docs/guides/quantization-aware-rl.md
+++ b/docs/guides/quantization-aware-rl.md
@@ -145,8 +145,14 @@ For Slurm, wrap the same command in `ray.sub` as shown in [Running QA-GRPO](#run
 Real-quant rollout is sensitive to stale Megatron conversion checkpoints. For a clean first-step comparison, move aside or remove both the training checkpoint and the converted Megatron checkpoint before launching:
 
 ```bash
+# Training checkpoint: matches `checkpointing.checkpoint_dir` in your config.
 mv checkpoints/grpo-qwen2.5-0.5b-dapo-1n8g-w4a16 checkpoints/grpo-qwen2.5-0.5b-dapo-1n8g-w4a16.old
-mv /path/to/megatron_ckpt/dapo8b_2n_long_w4a16 /path/to/megatron_ckpt/dapo8b_2n_long_w4a16.old
+
+# Converted Megatron checkpoint: under `$NRL_MEGATRON_CHECKPOINT_DIR` if set,
+# else `$HF_HOME/nemo_rl` or `~/.cache/huggingface/nemo_rl`. The subdirectory is
+# named after the HF model; see "Megatron Checkpoint Directory" below.
+MEGATRON_CKPT_ROOT="${NRL_MEGATRON_CHECKPOINT_DIR:-${HF_HOME:-$HOME/.cache/huggingface}/nemo_rl}"
+mv "$MEGATRON_CKPT_ROOT/<hf-model-subdir>" "$MEGATRON_CKPT_ROOT/<hf-model-subdir>.old"
 ```
 
 If `NRL_MEGATRON_CHECKPOINT_DIR` is set, clear the subdirectory used by the run. On first startup, the log should show that iteration 0 was saved or loaded from a freshly generated conversion checkpoint.

--- a/docs/guides/quantization-aware-rl.md
+++ b/docs/guides/quantization-aware-rl.md
@@ -1,10 +1,15 @@
 # Quantization-Aware RL (QARL)
 
-Quantization-Aware RL (QARL) integrates [NVIDIA Model Optimizer (ModelOpt)](https://github.com/NVIDIA/Model-Optimizer) into the NeMo RL training loop, enabling quantization-aware training and generation for both GRPO and on-policy distillation workflows. QARL automatically quantizes a standard model at initialization, maintains quantizer state (amax values) throughout training, and transfers them to vLLM during weight refit for fake-quantized generation. The goal is to reduce quantization error through quantization-aware training.
+Quantization-Aware RL (QARL) integrates [NVIDIA Model Optimizer (ModelOpt)](https://github.com/NVIDIA/Model-Optimizer) into the NeMo RL training loop, enabling quantization-aware training and generation for both GRPO and on-policy distillation workflows. QARL automatically quantizes a standard model at initialization, maintains quantizer state (amax values) throughout training, and transfers quantized state to vLLM during weight refit. By default, vLLM generation uses fake-quantized modules. For NVFP4 W4A16 rollout experiments, NeMo RL can instead stream packed real-quant ModelOpt NVFP4 weights into vLLM.
 
 ## Overview
 
-In a standard NeMo RL loop, model weights are trained in full precision and refitted into vLLM for generation. QARL applies fake quantization so that both the policy forward pass (training) and the rollout forward pass (vLLM generation) use quantized weights and activations. The policy backward pass remains in full precision, using the straight-through estimator to propagate gradients through the quantization nodes.
+In a standard NeMo RL loop, model weights are trained in full precision and refitted into vLLM for generation. QARL applies quantization-aware modules so that both the policy forward pass and rollout generation exercise quantized weights and, depending on the recipe, quantized activations. The policy backward pass remains in full precision, using the straight-through estimator to propagate gradients through the quantization nodes.
+
+There are two vLLM rollout modes:
+
+- **Fake-quant rollout**: vLLM receives folded full-precision weights and runs fake-quantized layers. This is the default when `policy.generation.quant_cfg` is set.
+- **Real-quant rollout**: vLLM is initialized with ModelOpt NVFP4 kernels and receives packed NVFP4 weights plus scale tensors during every refit. Enable this with `policy.generation.real_quant: true`.
 
 See [Verified Configurations](#verified-configurations) for the workflow + recipe combinations that have been empirically validated, and [Supported Quantization Formats](#supported-quantization-formats) for the full set of available formats. W4A4 (`NVFP4_DEFAULT_CFG`) converges for on-policy distillation but has been observed to have convergence issues on GRPO; W4A16 (NVFP4 weights, native-dtype activations) works for GRPO.
 
@@ -16,11 +21,13 @@ The following workflow + quantization recipe combinations have been validated en
 |---|---|---|---|---|
 | QA-Distillation | W4A4 | `NVFP4_DEFAULT_CFG` (NVFP4 weights + NVFP4 activations) | ✅ Converges | `examples/modelopt/qa_distillation_math_megatron.yaml` |
 | QA-GRPO | W4A16 | `examples/modelopt/quant_configs/nvfp4_a16.yaml` (NVFP4 weights, native-dtype activations) | ✅ Converges | `examples/modelopt/qa_grpo_llama8b_megatron.v2.yaml` |
+| QA-GRPO | W4A8 | `examples/modelopt/quant_configs/nvfp4_w4a8_fp8.yaml` (NVFP4 weights, FP8 input activations) | ✅ Converges | `examples/configs/recipes/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron-qa-nvfp4-w4a8-fake.yaml` |
 | QA-GRPO | W4A4 | `NVFP4_DEFAULT_CFG` | ⚠️ Known convergence issue | `examples/modelopt/qa_grpo_math_megatron.yaml` |
 | QA-Distillation | W4A4 | `examples/modelopt/quant_configs/nano3_nvfp4_default.yaml` | ✅ Converges | `examples/modelopt/qa_distillation_nano3_megatron.yaml` |
 | QA-GRPO | W4A16 | `NVFP4_MLP_WEIGHT_ONLY_CFG` | ✅ Smoke tested on MoE | `examples/modelopt/qa_grpo_qwen3_30ba3b_megatron.yaml` |
+| QA-GRPO real quantization rollout | W4A16 | `examples/modelopt/quant_configs/nvfp4_a16.yaml` with `policy.generation.real_quant: true` | ✅ Converges | `examples/configs/recipes/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron-qa-nvfp4-w4a16.yaml` |
 
-The `nvfp4_a16.yaml` custom YAML enables NVFP4 e2m1 weight quantization (with dynamic e4m3 micro-block scales) and leaves activations unquantized; weights are still exercised through both Megatron training and vLLM generation.
+The `nvfp4_a16.yaml` custom YAML enables NVFP4 e2m1 weight quantization (with dynamic e4m3 micro-block scales) and leaves activations unquantized; weights are still exercised through both Megatron training and vLLM generation. The `nvfp4_w4a8_fp8.yaml` recipe uses the same NVFP4 weight format and enables FP8 e4m3 input activation fake quantization.
 
 ## ModelOpt Layer Spec Toggle
 
@@ -81,6 +88,120 @@ sbatch \
     ray.sub
 ```
 
+## Real-Quant NVFP4 Rollout (W4A16)
+
+Real-quant rollout is intended for checking the deployment-style vLLM path during RL, not only the fake-quant training path. With `policy.generation.real_quant: true`, the Megatron policy worker exports ModelOpt QAT weights as packed NVFP4 tensors during refit, and the vLLM worker loads them into ModelOpt NVFP4 layers. This exercises vLLM's real FP4 kernel path during rollout while the policy training worker remains a QAT model.
+
+This path is validated for W4A16.
+
+### Minimal Configuration
+
+Start from a Megatron GRPO config and add the ModelOpt weight-only recipe to both the policy and generation sections:
+
+```yaml
+policy:
+  quant_cfg: examples/modelopt/quant_configs/nvfp4_a16.yaml
+
+  generation:
+    backend: vllm
+    quant_cfg: examples/modelopt/quant_configs/nvfp4_a16.yaml
+    real_quant: true
+```
+
+The ready-to-run 1-node DAPO smoke recipe is:
+
+```text
+examples/configs/recipes/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron-qa-nvfp4-w4a16.yaml
+```
+
+Use the matching BF16 recipe as the baseline:
+
+```text
+examples/configs/recipes/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron.yaml
+```
+
+### Running the Example
+
+From the repository root inside the NeMo RL container:
+
+```bash
+uv run --extra mcore --extra modelopt --extra vllm \
+  examples/run_grpo.py \
+  --config examples/configs/recipes/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron-qa-nvfp4-w4a16.yaml
+```
+
+For a BF16 comparison run:
+
+```bash
+uv run --extra mcore --extra vllm \
+  examples/run_grpo.py \
+  --config examples/configs/recipes/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron.yaml
+```
+
+For Slurm, wrap the same command in `ray.sub` as shown in [Running QA-GRPO](#running-qa-grpo). Keep the W4A16 and BF16 runs separate and use distinct checkpoint directories.
+
+### Checkpoints and Fresh Starts
+
+Real-quant rollout is sensitive to stale Megatron conversion checkpoints. For a clean first-step comparison, move aside or remove both the training checkpoint and the converted Megatron checkpoint before launching:
+
+```bash
+mv checkpoints/grpo-qwen2.5-0.5b-dapo-1n8g-w4a16 checkpoints/grpo-qwen2.5-0.5b-dapo-1n8g-w4a16.old
+mv /path/to/megatron_ckpt/dapo8b_2n_long_w4a16 /path/to/megatron_ckpt/dapo8b_2n_long_w4a16.old
+```
+
+If `NRL_MEGATRON_CHECKPOINT_DIR` is set, clear the subdirectory used by the run. On first startup, the log should show that iteration 0 was saved or loaded from a freshly generated conversion checkpoint.
+
+For long runs on queues with short wall times, enable periodic checkpointing and submit dependency jobs with `afterany` so the next job can resume from the checkpoint written by the previous job.
+
+### Log Checks
+
+A healthy W4A16 real-rollout run should include these lines or equivalent vLLM logs:
+
+```text
+quantization=modelopt_fp4
+Using NvFp4LinearBackend.MARLIN for NVFP4 GEMM
+MegatronQuantPolicyWorker[rank=0]: Packed ... groups of tensors
+```
+
+It should not include:
+
+```text
+Using rollout logprobs
+negative scales
+CUDA error: invalid argument
+```
+
+For an initial sanity check, compare the first `Generation KL Error` with the BF16 baseline. They should be close on step 1. A substantially larger W4A16 first-step KL usually means the rollout model does not match the policy model, the run reused a stale checkpoint, or the real-quant export/refit path did not load the expected tensors.
+
+### Troubleshooting
+
+| Symptom | Likely Cause | Action |
+|---|---|---|
+| vLLM does not log `quantization=modelopt_fp4` | `policy.generation.real_quant` is not set or generation is not using vLLM | Check the YAML under `policy.generation` |
+| `Using rollout logprobs` appears | The run is bypassing policy/reference logprob computation | Do not use rollout logprobs for real-quant validation |
+| First-step W4A16 `Generation KL Error` is much higher than BF16 | Stale converted Megatron checkpoint or refit/export mismatch | Clear checkpoints and rerun; confirm packed tensors are streamed |
+| `negative scales` warning appears | Invalid or stale NVFP4 scale tensors reached vLLM | Clear checkpoints and verify `nvfp4_a16.yaml` is used for both policy and generation |
+| CUDA invalid argument during refit or generation | vLLM consumed malformed packed tensors or stale IPC state | Restart from a fresh job and inspect the first real-quant refit logs |
+
+## Fake-Quant NVFP4 Rollout (W4A8)
+
+W4A8 rollout is supported through the fake-quant vLLM path. The policy and vLLM workers both use a ModelOpt recipe with NVFP4 weights and FP8 input activations, while refit transfers folded weights and quantizer amax state instead of packed deployment tensors.
+
+```yaml
+policy:
+  quant_cfg: examples/modelopt/quant_configs/nvfp4_w4a8_fp8.yaml
+
+  generation:
+    backend: vllm
+    quant_cfg: examples/modelopt/quant_configs/nvfp4_w4a8_fp8.yaml
+```
+
+The ready-to-run 1-node DAPO smoke recipe is:
+
+```text
+examples/configs/recipes/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron-qa-nvfp4-w4a8-fake.yaml
+```
+
 ## Quantization-Aware Distillation (On-Policy QAD)
 
 QAD combines on-policy distillation with quantization. The student model is quantized while the teacher remains in full precision, allowing the student to recover accuracy lost from quantization through knowledge distillation.
@@ -125,6 +246,14 @@ These parameters are added under the `policy` section:
 
 The `policy.generation.quant_cfg` should match `policy.quant_cfg` to ensure consistent quantization between training and generation.
 
+Generation-specific parameters are added under `policy.generation`:
+
+| Parameter | Description |
+|---|---|
+| `quant_cfg` | Quantization config used by the vLLM generation worker. For QARL, this should normally match `policy.quant_cfg`. |
+| `real_quant` | When `true`, vLLM uses ModelOpt NVFP4 real kernels and receives packed quantized weights during refit. When unset or `false`, vLLM uses fake-quantized generation. |
+| `real_quant_ignore` | Optional list of vLLM parameter name patterns that should stay in native dtype during real-quant rollout. If omitted, NeMo RL uses the default ModelOpt NVFP4 ignore set for sensitive layers such as attention and output heads. |
+
 ## Megatron Checkpoint Directory
 
 On first run, the HF model is automatically converted to a Megatron checkpoint. By default, this checkpoint is saved under `$HF_HOME/nemo_rl` (or `~/.cache/huggingface/nemo_rl` if `HF_HOME` is not set). To control where the converted checkpoint is stored — for example, to keep it alongside your experiment outputs — set the `NRL_MEGATRON_CHECKPOINT_DIR` environment variable:
@@ -139,11 +268,12 @@ QARL (via ModelOpt) and NeMo RL's built-in [FP8 training](../fp8.md) (via Transf
 
 - **TransformerEngine FP8** focuses on **speeding up pre-training and fine-tuning** using real quantization. It replaces linear layers with FP8-native implementations that compute directly in reduced precision for throughput gains.
 
-- **ModelOpt QARL** focuses on **recovering accuracy under quantization** using fake quantization (quantization-aware training). The forward pass uses quantized weights and activations while the backward pass uses full-precision gradients, so the model learns to be robust to quantization error. Both training and vLLM generation use fake-quantized forward passes for consistency.
+- **ModelOpt QARL** focuses on **recovering accuracy under quantization** using quantization-aware training. The policy forward pass uses quantized weights and, depending on the recipe, quantized activations while the backward pass uses full-precision gradients, so the model learns to be robust to quantization error. vLLM generation can run fake-quantized layers for W4A8/W4A16 recipes.
+  W4A16 experiments can also use real ModelOpt NVFP4 kernels.
 
 ## Supported Quantization Formats
 
-- **Weight quantization**: per-tensor, per-channel, and block-wise formats are all supported. Weights are pre-folded on the policy (Megatron) side before transfer to vLLM.
+- **Weight quantization**: per-tensor, per-channel, and block-wise formats are all supported. In fake-quant rollout, weights are pre-folded on the policy (Megatron) side before transfer to vLLM. In W4A16 real-quant rollout, weights are packed as NVFP4 tensors and streamed with their scale tensors.
 - **Input (activation) quantization**: only per-tensor is supported. The input quantizer amax is synced to vLLM as a per-tensor scalar.
 
 ## Exporting Checkpoints
@@ -175,5 +305,7 @@ uv run --extra mcore --extra modelopt \
 
 - **Generation**: Currently only vLLM is supported for generation.
 - **DTensor backend**: Quantization support for the DTensor policy worker is not yet implemented.
+- **Real-quant rollout**: W4A16 real rollout is supported for dense vLLM ModelOpt NVFP4 layers.
+- **W4A8 rollout**: W4A8 is supported through fake-quant rollout.
 - **Input quantization**: Only per-tensor input (activation) quantization is supported.
 - **Model support**: Dense Transformer, MoE (Mixture of Experts), and hybrid MoE/Mamba models are supported on the Megatron policy + vLLM generation path when Megatron-Bridge and ModelOpt support the model architecture and quantization recipe. MoE/Mamba support is currently covered by smoke-tested example configs rather than broad convergence guarantees.

--- a/docs/guides/quantization-aware-rl.md
+++ b/docs/guides/quantization-aware-rl.md
@@ -25,9 +25,9 @@ The following workflow + quantization recipe combinations have been validated en
 | QA-GRPO | W4A4 | `NVFP4_DEFAULT_CFG` | ⚠️ Known convergence issue | `examples/modelopt/qa_grpo_math_megatron.yaml` |
 | QA-Distillation | W4A4 | `examples/modelopt/quant_configs/nano3_nvfp4_default.yaml` | ✅ Converges | `examples/modelopt/qa_distillation_nano3_megatron.yaml` |
 | QA-GRPO | W4A16 | `NVFP4_MLP_WEIGHT_ONLY_CFG` | ✅ Smoke tested on MoE | `examples/modelopt/qa_grpo_qwen3_30ba3b_megatron.yaml` |
-| QA-GRPO real quantization rollout | W4A16 | `examples/modelopt/quant_configs/nvfp4_a16.yaml` with `policy.generation.real_quant: true` | ✅ Converges | `examples/configs/recipes/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron-qa-nvfp4-w4a16.yaml` |
+| QA-GRPO real quantization rollout | W4A16 | `examples/modelopt/quant_configs/nvfp4_a16_mlp_only.yaml` with `policy.generation.real_quant: true` | ✅ Converges | `examples/configs/recipes/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron-qa-nvfp4-w4a16.yaml` |
 
-The `nvfp4_a16.yaml` custom YAML enables NVFP4 e2m1 weight quantization (with dynamic e4m3 micro-block scales) and leaves activations unquantized; weights are still exercised through both Megatron training and vLLM generation. The `nvfp4_w4a8_fp8.yaml` recipe uses the same NVFP4 weight format and enables FP8 e4m3 input activation fake quantization.
+The `nvfp4_a16.yaml` custom YAML enables NVFP4 e2m1 weight quantization (with dynamic e4m3 micro-block scales) and leaves activations unquantized; weights are still exercised through both Megatron training and vLLM generation. The `nvfp4_a16_mlp_only.yaml` recipe restricts W4A16 to MLP weights for real-quant rollout. The `nvfp4_w4a8_fp8.yaml` recipe uses the same NVFP4 weight format and enables FP8 e4m3 input activation fake quantization.
 
 ## ModelOpt Layer Spec Toggle
 
@@ -100,11 +100,11 @@ Start from a Megatron GRPO config and add the ModelOpt weight-only recipe to bot
 
 ```yaml
 policy:
-  quant_cfg: examples/modelopt/quant_configs/nvfp4_a16.yaml
+  quant_cfg: examples/modelopt/quant_configs/nvfp4_a16_mlp_only.yaml
 
   generation:
     backend: vllm
-    quant_cfg: examples/modelopt/quant_configs/nvfp4_a16.yaml
+    quant_cfg: examples/modelopt/quant_configs/nvfp4_a16_mlp_only.yaml
     real_quant: true
 ```
 
@@ -180,7 +180,7 @@ For an initial sanity check, compare the first `Generation KL Error` with the BF
 | vLLM does not log `quantization=modelopt_fp4` | `policy.generation.real_quant` is not set or generation is not using vLLM | Check the YAML under `policy.generation` |
 | `Using rollout logprobs` appears | The run is bypassing policy/reference logprob computation | Do not use rollout logprobs for real-quant validation |
 | First-step W4A16 `Generation KL Error` is much higher than BF16 | Stale converted Megatron checkpoint or refit/export mismatch | Clear checkpoints and rerun; confirm packed tensors are streamed |
-| `negative scales` warning appears | Invalid or stale NVFP4 scale tensors reached vLLM | Clear checkpoints and verify `nvfp4_a16.yaml` is used for both policy and generation |
+| `negative scales` warning appears | Invalid or stale NVFP4 scale tensors reached vLLM | Clear checkpoints and verify `nvfp4_a16_mlp_only.yaml` is used for both policy and generation |
 | CUDA invalid argument during refit or generation | vLLM consumed malformed packed tensors or stale IPC state | Restart from a fresh job and inspect the first real-quant refit logs |
 
 ## Fake-Quant NVFP4 Rollout (W4A8)
@@ -238,7 +238,7 @@ These parameters are added under the `policy` section:
 
 | Parameter | Description |
 |---|---|
-| `quant_cfg` | Quantization config. Accepts: a built-in ModelOpt config name (e.g. `"NVFP4_DEFAULT_CFG"`), a built-in ModelOpt PTQ recipe name (e.g. `"general/ptq/nvfp4_default-fp8_kv"`, suffix optional), or the path to a custom YAML recipe (e.g. `"examples/modelopt/quant_configs/nvfp4_a16.yaml"`). See `examples/modelopt/quant_configs/` for an example and `modelopt_recipes/general/ptq/` in Model-Optimizer for the canonical YAML format. |
+| `quant_cfg` | Quantization config. Accepts: a built-in ModelOpt config name (e.g. `"NVFP4_DEFAULT_CFG"`), a built-in ModelOpt PTQ recipe name (e.g. `"general/ptq/nvfp4_default-fp8_kv"`, suffix optional), or the path to a custom YAML recipe (e.g. `"examples/modelopt/quant_configs/nvfp4_a16.yaml"`). Use absolute paths for user-authored recipes in Ray/container workers. See `examples/modelopt/quant_configs/` for an example and `modelopt_recipes/general/ptq/` in Model-Optimizer for the canonical YAML format. |
 | `quant_calib_data` | Dataset name used for calibration. See the [ModelOpt PTQ examples](https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/llm_ptq) for supported datasets. |
 | `quant_calib_size` | Number of samples for the calibration pass |
 | `quant_batch_size` | Batch size during calibration |

--- a/docs/index.md
+++ b/docs/index.md
@@ -188,7 +188,9 @@ Optimize large language models with FP8 quantization for faster training and inf
 :link: guides/quantization-aware-rl
 :link-type: doc
 
-Run quantization aware GRPO and distillation using NVIDIA ModelOpt (NVFP4, FP8).
+Run quantization-aware GRPO and distillation using NVIDIA ModelOpt.
+Includes NVFP4 W4A16 real rollout.
+W4A8 rollout uses fake quantization.
 :::
 
 :::{grid-item-card} {octicon}`container` Docker Containers

--- a/examples/configs/recipes/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron-qa-nvfp4-w4a16.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron-qa-nvfp4-w4a16.yaml
@@ -1,0 +1,18 @@
+# DAPO + Qwen2.5-0.5B + NVFP4 W4A16 + Megatron, 1 node x 8 GPUs.
+defaults: ./grpo-qwen2.5-0.5b-dapo-1n8g-megatron.yaml
+
+policy:
+  quant_cfg: examples/modelopt/quant_configs/nvfp4_a16.yaml
+  generation:
+    quant_cfg: examples/modelopt/quant_configs/nvfp4_a16.yaml
+    real_quant: true
+
+checkpointing:
+  checkpoint_dir: checkpoints/grpo-qwen2.5-0.5b-dapo-1n8g-w4a16
+
+logger:
+  log_dir: logs/grpo-qwen2.5-0.5b-dapo-1n8g-w4a16
+  wandb:
+    name: grpo-qwen2.5-0.5b-dapo-1n8g-w4a16
+  tensorboard:
+    log_dir: tb_logs-grpo-qwen2.5-0.5b-dapo-1n8g-w4a16

--- a/examples/configs/recipes/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron-qa-nvfp4-w4a16.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron-qa-nvfp4-w4a16.yaml
@@ -2,9 +2,9 @@
 defaults: ./grpo-qwen2.5-0.5b-dapo-1n8g-megatron.yaml
 
 policy:
-  quant_cfg: examples/modelopt/quant_configs/nvfp4_a16.yaml
+  quant_cfg: examples/modelopt/quant_configs/nvfp4_a16_mlp_only.yaml
   generation:
-    quant_cfg: examples/modelopt/quant_configs/nvfp4_a16.yaml
+    quant_cfg: examples/modelopt/quant_configs/nvfp4_a16_mlp_only.yaml
     real_quant: true
 
 checkpointing:

--- a/examples/configs/recipes/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron-qa-nvfp4-w4a8-fake.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron-qa-nvfp4-w4a8-fake.yaml
@@ -1,0 +1,22 @@
+# DAPO + Qwen2.5-0.5B + NVFP4 W4A8 + Megatron, 1 node x 8 GPUs.
+# Uses vLLM fake-quant rollout.
+defaults: ./grpo-qwen2.5-0.5b-dapo-1n8g-megatron.yaml
+
+policy:
+  quant_cfg: examples/modelopt/quant_configs/nvfp4_w4a8_fp8.yaml
+  quant_calib_data: cnn_dailymail
+  quant_calib_size: 4
+  quant_batch_size: 1
+  quant_sequence_length: 128
+  generation:
+    quant_cfg: examples/modelopt/quant_configs/nvfp4_w4a8_fp8.yaml
+
+checkpointing:
+  checkpoint_dir: checkpoints/grpo-qwen2.5-0.5b-dapo-1n8g-w4a8-fake
+
+logger:
+  log_dir: logs/grpo-qwen2.5-0.5b-dapo-1n8g-w4a8-fake
+  wandb:
+    name: grpo-qwen2.5-0.5b-dapo-1n8g-w4a8-fake
+  tensorboard:
+    log_dir: tb_logs-grpo-qwen2.5-0.5b-dapo-1n8g-w4a8-fake

--- a/examples/configs/recipes/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron.yaml
@@ -1,0 +1,78 @@
+defaults: ../../grpo_math_1B.yaml
+grpo:
+  batch_multiplier: 2
+  max_num_epochs: 1000000
+  use_leave_one_out_baseline: false
+  use_dynamic_sampling: true
+  max_val_samples: 8
+  val_batch_size: 8
+  reward_scaling:
+    enabled: true
+    target_min: -1.0
+  reward_shaping:
+    enabled: true
+    overlong_buffer_length: 16
+    max_response_length: 128
+loss_fn:
+  reference_policy_kl_penalty: 0.0
+  ratio_clip_max: 0.28
+  ratio_clip_c: 10
+  use_importance_sampling_correction: true
+policy:
+  model_name: Qwen/Qwen2.5-0.5B
+  train_global_batch_size: 4
+  train_micro_batch_size: 1
+  logprob_batch_size: 4
+  max_total_sequence_length: 256
+  refit_buffer_size_gb: 1
+  dtensor_cfg:
+    enabled: false
+  optimizer: null
+  scheduler: null
+  megatron_cfg:
+    enabled: true
+    converter_type: Qwen2ForCausalLM
+    optimizer:
+      lr: 1.0e-06
+      min_lr: 1.0e-06
+      weight_decay: 0.1
+      use_precision_aware_optimizer: false
+    scheduler:
+      lr_decay_iters: null
+      lr_warmup_iters: 10
+      lr_warmup_init: 1.0e-08
+  make_sequence_length_divisible_by: ${mul:${policy.megatron_cfg.tensor_model_parallel_size},
+    2}
+  generation:
+    max_new_tokens: 128
+    vllm_cfg:
+      max_model_len: 256
+      gpu_memory_utilization: 0.5
+      enforce_eager: true
+data:
+  max_input_seq_length: 128
+  train:
+    dataset_name: DAPOMath17K
+  validation:
+    dataset_name: DAPOMathAIME2024
+  default:
+    prompt_file: null
+env:
+  dapo:
+    num_workers: 2
+  math:
+    num_workers: 2
+    math_verify_impl: dapo_math_verify
+checkpointing:
+  checkpoint_dir: checkpoints/grpo-qwen2.5-0.5b-dapo-1n8g-bf16
+  model_save_format: null
+logger:
+  log_dir: logs/grpo-qwen2.5-0.5b-dapo-1n8g-bf16
+  wandb_enabled: true
+  wandb:
+    project: nemo-rl-qarl
+    name: grpo-qwen2.5-0.5b-dapo-1n8g-bf16
+  tensorboard:
+    log_dir: tb_logs-grpo-qwen2.5-0.5b-dapo-1n8g-bf16
+cluster:
+  gpus_per_node: 8

--- a/examples/modelopt/quant_configs/nvfp4_a16.yaml
+++ b/examples/modelopt/quant_configs/nvfp4_a16.yaml
@@ -11,9 +11,9 @@
 # ``metadata:`` section is informational.
 #
 # Defines W4A16: NVFP4 (e2m1, dynamic e4m3 micro-block scales) on weights
-# only; activations stay in the model's native dtype (BF16/FP16). Sensitive
-# layers (lm_head, MoE gate/router, BatchNorm, etc.) are disabled to match
-# the built-in defaults.
+# only; activations stay in the model's native dtype (BF16/FP16). Attention
+# and other sensitive layers (lm_head, MoE gate/router, BatchNorm, etc.) are
+# disabled to match the real-quant vLLM rollout ignore set.
 #
 # Recommended for QA-GRPO, where W4A4 (NVFP4 on both weights and
 # activations) has shown convergence issues. For QA-Distillation, the
@@ -38,6 +38,10 @@ quantize:
           type: dynamic
           scale_bits: e4m3
         num_bits: e2m1
+    - quantizer_name: '*self_attention*'
+      enable: false
+    - quantizer_name: '*self_attn*'
+      enable: false
     - quantizer_name: '*lm_head*'
       enable: false
     - quantizer_name: '*output_layer*'

--- a/examples/modelopt/quant_configs/nvfp4_a16_mlp_only.yaml
+++ b/examples/modelopt/quant_configs/nvfp4_a16_mlp_only.yaml
@@ -1,9 +1,9 @@
-# NVFP4 weight-only (W4A16) custom quantization recipe for QARL.
+# NVFP4 MLP-only weight-only (W4A16) custom quantization recipe for QARL.
 #
 # Reference this file from a NeMo-RL YAML config via:
 #
 #     policy:
-#       quant_cfg: "examples/modelopt/quant_configs/nvfp4_a16.yaml"
+#       quant_cfg: "examples/modelopt/quant_configs/nvfp4_a16_mlp_only.yaml"
 #
 # This recipe uses ModelOpt's standard PTQ recipe layout (see
 # ``modelopt_recipes/general/ptq/`` in the NVIDIA/Model-Optimizer repo:
@@ -11,27 +11,21 @@
 # Only the ``quantize:`` section is consumed by ``mtq.quantize``; the
 # ``metadata:`` section is informational.
 #
-# Defines W4A16: NVFP4 (e2m1, dynamic e4m3 micro-block scales) on weights
-# only; activations stay in the model's native dtype (BF16/FP16). Sensitive
-# layers (lm_head, MoE gate/router, BatchNorm, etc.) are disabled to match
-# the built-in defaults.
+# Defines MLP-only W4A16: NVFP4 (e2m1, dynamic e4m3 micro-block scales) on
+# MLP weights only; activations and non-MLP layers stay in the model's native
+# dtype (BF16/FP16).
 #
-# Recommended for QA-GRPO, where W4A4 (NVFP4 on both weights and
-# activations) has shown convergence issues. For QA-Distillation, the
-# built-in ``NVFP4_DEFAULT_CFG`` (W4A4) converges fine and remains the
-# default choice.
-#
-# See https://github.com/NVIDIA/Model-Optimizer for the full set of
-# supported quantizer options and built-in PTQ recipes.
+# This mirrors the intent of ModelOpt's ``NVFP4_MLP_WEIGHT_ONLY_CFG`` while
+# keeping a YAML recipe available for examples that need an explicit file.
 metadata:
   recipe_type: ptq
-  description: NVFP4 weight-only (W4A16) recipe.
+  description: NVFP4 MLP-only weight-only (W4A16) recipe.
 quantize:
   algorithm: max
   quant_cfg:
     - quantizer_name: '*'
       enable: false
-    - quantizer_name: '*weight_quantizer'
+    - quantizer_name: '*mlp*weight_quantizer'
       enable: true
       cfg:
         block_sizes:
@@ -41,11 +35,17 @@ quantize:
         num_bits: e2m1
     - quantizer_name: '*lm_head*'
       enable: false
+    - quantizer_name: '*proj_out.*'
+      enable: false
     - quantizer_name: '*output_layer*'
+      enable: false
+    - quantizer_name: 'output.*'
       enable: false
     - quantizer_name: '*router*'
       enable: false
     - quantizer_name: '*mlp.gate.*'
+      enable: false
+    - quantizer_name: '*mlp.shared_expert_gate.*'
       enable: false
     - quantizer_name: '*block_sparse_moe.gate*'
       enable: false
@@ -56,5 +56,8 @@ quantize:
       quantizer_name: '*'
       enable: false
     - parent_class: 'nn.BatchNorm3d'
+      quantizer_name: '*'
+      enable: false
+    - parent_class: 'nn.LeakyReLU'
       quantizer_name: '*'
       enable: false

--- a/examples/modelopt/quant_configs/nvfp4_w4a8_fp8.yaml
+++ b/examples/modelopt/quant_configs/nvfp4_w4a8_fp8.yaml
@@ -21,7 +21,6 @@ quantize:
       enable: true
       cfg:
         num_bits: e4m3
-        use_constant_amax: true
     - quantizer_name: '*self_attention*'
       enable: false
     - quantizer_name: '*self_attn*'

--- a/examples/modelopt/quant_configs/nvfp4_w4a8_fp8.yaml
+++ b/examples/modelopt/quant_configs/nvfp4_w4a8_fp8.yaml
@@ -35,6 +35,8 @@ quantize:
       enable: false
     - quantizer_name: '*gate_up_proj.input_quantizer'
       enable: false
+    - quantizer_name: '*linear_fc1.input_quantizer'
+      enable: false
     - quantizer_name: '*block_sparse_moe.gate*'
       enable: false
     - parent_class: 'nn.BatchNorm1d'

--- a/examples/modelopt/quant_configs/nvfp4_w4a8_fp8.yaml
+++ b/examples/modelopt/quant_configs/nvfp4_w4a8_fp8.yaml
@@ -1,0 +1,49 @@
+# NVFP4 W4A8 custom quantization recipe for QARL.
+#
+# Defines W4A8: NVFP4 e2m1 weights with FP8 e4m3 input activations.
+metadata:
+  recipe_type: ptq
+  description: NVFP4 weights with FP8 input activations for W4A8 QAT.
+quantize:
+  algorithm: max
+  quant_cfg:
+    - quantizer_name: '*'
+      enable: false
+    - quantizer_name: '*weight_quantizer'
+      enable: true
+      cfg:
+        block_sizes:
+          -1: 16
+          type: dynamic
+          scale_bits: e4m3
+        num_bits: e2m1
+    - quantizer_name: '*input_quantizer'
+      enable: true
+      cfg:
+        num_bits: e4m3
+        use_constant_amax: true
+    - quantizer_name: '*self_attention*'
+      enable: false
+    - quantizer_name: '*self_attn*'
+      enable: false
+    - quantizer_name: '*lm_head*'
+      enable: false
+    - quantizer_name: '*output_layer*'
+      enable: false
+    - quantizer_name: '*router*'
+      enable: false
+    - quantizer_name: '*mlp.gate.*'
+      enable: false
+    - quantizer_name: '*gate_up_proj.input_quantizer'
+      enable: false
+    - quantizer_name: '*block_sparse_moe.gate*'
+      enable: false
+    - parent_class: 'nn.BatchNorm1d'
+      quantizer_name: '*'
+      enable: false
+    - parent_class: 'nn.BatchNorm2d'
+      quantizer_name: '*'
+      enable: false
+    - parent_class: 'nn.BatchNorm3d'
+      quantizer_name: '*'
+      enable: false

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1680,7 +1680,7 @@ def refit_policy_generation(
     policy: ColocatablePolicyInterface,
     policy_generation: GenerationInterface,
     colocated_inference: bool,
-    _refit_buffer_size_gb: Optional[int] = None,
+    _refit_buffer_size_gb: Optional[float] = None,
     timer: Optional[Timer] = None,
     kv_scales: Optional[dict[str, float]] = None,
 ) -> None:
@@ -1689,9 +1689,8 @@ def refit_policy_generation(
     Args:
         policy: The policy to provide weights to the inference engine.
         policy_generation: The inference engine to refit.
-        _refit_buffer_size_gb: The size of the buffer to use for refitting.
-            If it is None, the buffer size will be computed by the remaining memory.
-            This parameter is primarily used for testing.
+        _refit_buffer_size_gb: Fixed refit buffer size in GiB. If it is None,
+            the buffer size is computed from remaining memory.
         timer: Optional Timer used to time the prepare/transfer/update phase
         kv_scales: Optional dictionary of KV cache scales for FP8 quantization.
     """
@@ -1728,7 +1727,7 @@ def refit_policy_generation(
         if colocated_inference:
             # get model param keys, which is grouped by size
             if _refit_buffer_size_gb is not None:
-                buffer_size_bytes = _refit_buffer_size_gb * (1024**3)
+                buffer_size_bytes = int(_refit_buffer_size_gb * (1024**3))
             else:
                 # Empirically sets ratio as 30% to maximize efficiency.
                 # The remaining 70% is a necessary buffer reserved for the parameter all-gathering across the expert-parallelism dimension.
@@ -2011,6 +2010,7 @@ def grpo_train(
     val_at_end = master_config.grpo["val_at_end"]
     val_period = master_config.grpo["val_period"]
     colocated_inference = master_config.policy["generation"]["colocated"]["enabled"]
+    refit_buffer_size_gb = master_config.policy.get("refit_buffer_size_gb")
 
     # Initialize advantage estimator
     adv_estimator = _create_advantage_estimator(master_config)
@@ -2022,7 +2022,12 @@ def grpo_train(
         memory_tracker.snapshot_start_of_stage("Initial validation", dir())
 
         if NEED_REFIT and POLICY_GENERATION_STALE:
-            refit_policy_generation(policy, policy_generation, colocated_inference)
+            refit_policy_generation(
+                policy,
+                policy_generation,
+                colocated_inference,
+                _refit_buffer_size_gb=refit_buffer_size_gb,
+            )
             POLICY_GENERATION_STALE = False
         else:
             policy_generation.prepare_for_generation()
@@ -2136,6 +2141,7 @@ def grpo_train(
                             policy,
                             policy_generation,
                             colocated_inference,
+                            _refit_buffer_size_gb=refit_buffer_size_gb,
                             timer=timer,
                             kv_scales=kv_scales_cache if sync_kv_scales else None,
                         )
@@ -2580,6 +2586,7 @@ def grpo_train(
                             policy,
                             policy_generation,
                             colocated_inference,
+                            _refit_buffer_size_gb=refit_buffer_size_gb,
                             kv_scales=kv_scales_cache if sync_kv_scales else None,
                         )
                         POLICY_GENERATION_STALE = False

--- a/nemo_rl/modelopt/models/generation/vllm_modelopt_patch.py
+++ b/nemo_rl/modelopt/models/generation/vllm_modelopt_patch.py
@@ -1,0 +1,162 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""vLLM ModelOpt NVFP4 patches for dense rollout weight reloads."""
+
+import torch
+from torch.nn import Parameter
+
+_DENSE_HF_PARAMS = ("weight", "weight_scale", "weight_scale_2")
+
+
+def _unwrap_vllm_model(model: torch.nn.Module) -> torch.nn.Module:
+    return model.model if hasattr(model, "model") else model
+
+
+def _canonicalize_nvfp4_weight_scale(layer: torch.nn.Module) -> None:
+    weight_scale = layer.weight_scale
+    scale = weight_scale.data.to(torch.float32).abs().to(weight_scale.dtype)
+    weight_scale.data.copy_(scale)
+
+
+def _convert_nvfp4_linear_kernel_format(quant_method, layer: torch.nn.Module) -> None:
+    kernel = getattr(quant_method, "kernel", None)
+    if kernel is not None:
+        kernel.process_weights_after_loading(layer)
+        return
+
+    from vllm.model_executor.layers.quantization.utils.nvfp4_utils import (
+        convert_to_nvfp4_linear_kernel_format,
+    )
+
+    convert_to_nvfp4_linear_kernel_format(quant_method.backend, layer)
+
+
+def _modelopt_dense_process_weights(self, layer: torch.nn.Module) -> None:
+    """Convert dense ModelOpt NVFP4 weights after initial load or refit."""
+    if not hasattr(layer, "_nrl_modelopt_param_meta"):
+        layer._nrl_modelopt_param_meta = {}
+        layer._nrl_modelopt_weight_loaders = {}
+        for param_name in _DENSE_HF_PARAMS:
+            param = getattr(layer, param_name)
+            meta = {
+                "shape": tuple(param.shape),
+                "dtype": param.dtype,
+                "device": str(param.device),
+                "param_class": type(param),
+            }
+            if hasattr(param, "_input_dim"):
+                meta["input_dim"] = param._input_dim
+            if hasattr(param, "_output_dim"):
+                meta["output_dim"] = param._output_dim
+            layer._nrl_modelopt_param_meta[param_name] = meta
+            if hasattr(param, "weight_loader"):
+                layer._nrl_modelopt_weight_loaders[param_name] = param.weight_loader
+
+    input_global_scale = torch.ones(
+        (),
+        dtype=torch.float32,
+        device=layer.weight.device,
+    )
+    layer.input_global_scale = Parameter(input_global_scale, requires_grad=False)
+
+    weight_global_scale = layer.weight_scale_2.max().to(torch.float32)
+    layer.weight_global_scale = Parameter(weight_global_scale, requires_grad=False)
+    delattr(layer, "weight_scale_2")
+
+    layer.alpha = Parameter(
+        layer.input_global_scale * layer.weight_global_scale,
+        requires_grad=False,
+    )
+    layer.input_global_scale_inv = Parameter(
+        (1.0 / layer.input_global_scale).to(torch.float32),
+        requires_grad=False,
+    )
+
+    _canonicalize_nvfp4_weight_scale(layer)
+    _convert_nvfp4_linear_kernel_format(self, layer)
+
+
+def prepare_modelopt_for_weight_reload(model, device=None) -> None:
+    """Prepare a dense ModelOpt-vLLM model for one weight reload cycle."""
+    inner_model = _unwrap_vllm_model(model)
+    for module in inner_model.modules():
+        layer_meta = getattr(module, "_nrl_modelopt_param_meta", None)
+        if layer_meta is None:
+            continue
+        for param_name, meta in layer_meta.items():
+            param = getattr(module, param_name, None)
+            weight_loader = module._nrl_modelopt_weight_loaders.get(param_name)
+            param_class = meta["param_class"]
+            if (
+                param is None
+                or tuple(param.shape) != tuple(meta["shape"])
+                or param.dtype != meta["dtype"]
+                or (
+                    weight_loader is not None
+                    and (
+                        not isinstance(param, param_class)
+                        or not hasattr(param, "weight_loader")
+                    )
+                )
+            ):
+                data = torch.empty(
+                    meta["shape"],
+                    dtype=meta["dtype"],
+                    device=device or meta["device"],
+                )
+                if param_class is not Parameter and weight_loader is not None:
+                    kwargs = {"data": data, "weight_loader": weight_loader}
+                    if "input_dim" in meta:
+                        kwargs["input_dim"] = meta["input_dim"]
+                    if "output_dim" in meta:
+                        kwargs["output_dim"] = meta["output_dim"]
+                    replacement = param_class(**kwargs)
+                else:
+                    replacement = Parameter(data, requires_grad=False)
+                    if weight_loader is not None:
+                        replacement.weight_loader = weight_loader
+                setattr(module, param_name, replacement)
+
+
+def modelopt_process_weights_after_loading(model) -> None:
+    """Run vLLM ModelOpt post-load processing for dense quantized layers."""
+    actual_model = _unwrap_vllm_model(model)
+
+    for module in actual_model.modules():
+        quant_method = getattr(module, "quant_method", None)
+        if quant_method.__class__.__name__ == "ModelOptNvFp4LinearMethod":
+            quant_method.process_weights_after_loading(module)
+
+
+_patched = False
+
+
+def apply_modelopt_nvfp4_patches() -> None:
+    """Patch vLLM's dense ModelOpt NVFP4 method for rollout refits."""
+    global _patched
+
+    if _patched:
+        return
+
+    from vllm.model_executor.layers.quantization.modelopt import (
+        ModelOptNvFp4LinearMethod,
+    )
+
+    ModelOptNvFp4LinearMethod.process_weights_after_loading = (
+        _modelopt_dense_process_weights
+    )
+
+    _patched = True

--- a/nemo_rl/modelopt/models/generation/vllm_modelopt_patch.py
+++ b/nemo_rl/modelopt/models/generation/vllm_modelopt_patch.py
@@ -19,6 +19,10 @@ import torch
 from torch.nn import Parameter
 
 _DENSE_HF_PARAMS = ("weight", "weight_scale", "weight_scale_2")
+_MODELOPT_W4A16_QUANT_MODES = frozenset({"w4a16_nvfp4", "nvfp4_w4a16"})
+_MODELOPT_W4A16_ATTR = "_nrl_weight_only_w4a16"
+_ORIGINAL_NVFP4_CONFIG_FROM_CONFIG_ATTR = "_nrl_original_from_config"
+_ORIGINAL_LINEAR_APPLY_ATTR = "_nrl_original_apply"
 
 
 def _unwrap_vllm_model(model: torch.nn.Module) -> torch.nn.Module:
@@ -29,6 +33,37 @@ def _canonicalize_nvfp4_weight_scale(layer: torch.nn.Module) -> None:
     weight_scale = layer.weight_scale
     scale = weight_scale.data.to(torch.float32).abs().to(weight_scale.dtype)
     weight_scale.data.copy_(scale)
+
+
+def _requests_w4a16_modelopt_config(config: dict) -> bool:
+    quant_mode = config.get("quant_mode")
+    if (
+        isinstance(quant_mode, str)
+        and quant_mode.lower() in _MODELOPT_W4A16_QUANT_MODES
+    ):
+        return True
+    if config.get("weight_only") is True:
+        return True
+
+    nested = config.get("quantization")
+    return isinstance(nested, dict) and _requests_w4a16_modelopt_config(nested)
+
+
+def _is_w4a16_modelopt_quant_config(quant_config) -> bool:
+    return bool(getattr(quant_config, _MODELOPT_W4A16_ATTR, False))
+
+
+def _modelopt_nvfp4_config_from_config(cls, *args, **kwargs):
+    original_from_config = getattr(cls, _ORIGINAL_NVFP4_CONFIG_FROM_CONFIG_ATTR)
+    quant_config = original_from_config(*args, **kwargs)
+
+    original_config = kwargs.get("original_config")
+    if isinstance(original_config, dict) and _requests_w4a16_modelopt_config(
+        original_config
+    ):
+        setattr(quant_config, _MODELOPT_W4A16_ATTR, True)
+
+    return quant_config
 
 
 def _convert_nvfp4_linear_kernel_format(quant_method, layer: torch.nn.Module) -> None:
@@ -44,26 +79,68 @@ def _convert_nvfp4_linear_kernel_format(quant_method, layer: torch.nn.Module) ->
     convert_to_nvfp4_linear_kernel_format(quant_method.backend, layer)
 
 
-def _modelopt_dense_process_weights(self, layer: torch.nn.Module) -> None:
-    """Convert dense ModelOpt NVFP4 weights after initial load or refit."""
+def _convert_w4a16_linear_kernel_format(layer: torch.nn.Module) -> None:
+    from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
+        prepare_fp4_layer_for_marlin,
+    )
+
+    prepare_fp4_layer_for_marlin(layer)
+
+
+def _capture_modelopt_dense_param_reload_meta(layer: torch.nn.Module) -> None:
     if not hasattr(layer, "_nrl_modelopt_param_meta"):
         layer._nrl_modelopt_param_meta = {}
         layer._nrl_modelopt_weight_loaders = {}
-        for param_name in _DENSE_HF_PARAMS:
-            param = getattr(layer, param_name)
-            meta = {
-                "shape": tuple(param.shape),
-                "dtype": param.dtype,
-                "device": str(param.device),
-                "param_class": type(param),
-            }
-            if hasattr(param, "_input_dim"):
-                meta["input_dim"] = param._input_dim
-            if hasattr(param, "_output_dim"):
-                meta["output_dim"] = param._output_dim
-            layer._nrl_modelopt_param_meta[param_name] = meta
-            if hasattr(param, "weight_loader"):
-                layer._nrl_modelopt_weight_loaders[param_name] = param.weight_loader
+    elif not hasattr(layer, "_nrl_modelopt_weight_loaders"):
+        layer._nrl_modelopt_weight_loaders = {}
+
+    for param_name in _DENSE_HF_PARAMS:
+        if param_name in layer._nrl_modelopt_param_meta:
+            continue
+        param = getattr(layer, param_name)
+        meta = {
+            "shape": tuple(param.shape),
+            "dtype": param.dtype,
+            "device": str(param.device),
+            "param_class": type(param),
+        }
+        if hasattr(param, "_input_dim"):
+            meta["input_dim"] = param._input_dim
+        if hasattr(param, "_output_dim"):
+            meta["output_dim"] = param._output_dim
+        layer._nrl_modelopt_param_meta[param_name] = meta
+        if hasattr(param, "weight_loader"):
+            layer._nrl_modelopt_weight_loaders[param_name] = param.weight_loader
+
+
+def _modelopt_dense_process_w4a16_weights(self, layer: torch.nn.Module) -> None:
+    """Convert dense ModelOpt NVFP4 W4A16 weights for Marlin weight-only GEMM."""
+    _capture_modelopt_dense_param_reload_meta(layer)
+
+    weight_global_scale = layer.weight_scale_2.max().to(torch.float32)
+    layer.weight_global_scale = Parameter(weight_global_scale, requires_grad=False)
+    delattr(layer, "weight_scale_2")
+
+    for attr in (
+        "input_scale",
+        "input_global_scale",
+        "alpha",
+        "input_global_scale_inv",
+    ):
+        if hasattr(layer, attr):
+            delattr(layer, attr)
+
+    _canonicalize_nvfp4_weight_scale(layer)
+    _convert_w4a16_linear_kernel_format(layer)
+
+
+def _modelopt_dense_process_weights(self, layer: torch.nn.Module) -> None:
+    """Convert dense ModelOpt NVFP4 weights after initial load or refit."""
+    if _is_w4a16_modelopt_quant_config(getattr(self, "quant_config", None)):
+        _modelopt_dense_process_w4a16_weights(self, layer)
+        return
+
+    _capture_modelopt_dense_param_reload_meta(layer)
 
     input_global_scale = torch.ones(
         (),
@@ -87,6 +164,35 @@ def _modelopt_dense_process_weights(self, layer: torch.nn.Module) -> None:
 
     _canonicalize_nvfp4_weight_scale(layer)
     _convert_nvfp4_linear_kernel_format(self, layer)
+
+
+def _modelopt_dense_apply(
+    self,
+    layer: torch.nn.Module,
+    x: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if _is_w4a16_modelopt_quant_config(getattr(self, "quant_config", None)):
+        from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
+            apply_fp4_marlin_linear,
+        )
+
+        return apply_fp4_marlin_linear(
+            input=x,
+            weight=layer.weight,
+            weight_scale=layer.weight_scale,
+            weight_global_scale=layer.weight_global_scale,
+            workspace=layer.workspace,
+            size_n=layer.output_size_per_partition,
+            size_k=layer.input_size_per_partition,
+            bias=bias,
+        )
+
+    original_apply = getattr(type(self), _ORIGINAL_LINEAR_APPLY_ATTR, None)
+    if original_apply is not None:
+        return original_apply(self, layer, x, bias)
+
+    return self.kernel.apply_weights(layer=layer, x=x, bias=bias)
 
 
 def prepare_modelopt_for_weight_reload(model, device=None) -> None:
@@ -152,11 +258,27 @@ def apply_modelopt_nvfp4_patches() -> None:
         return
 
     from vllm.model_executor.layers.quantization.modelopt import (
+        ModelOptNvFp4Config,
         ModelOptNvFp4LinearMethod,
     )
 
+    if not hasattr(ModelOptNvFp4Config, _ORIGINAL_NVFP4_CONFIG_FROM_CONFIG_ATTR):
+        setattr(
+            ModelOptNvFp4Config,
+            _ORIGINAL_NVFP4_CONFIG_FROM_CONFIG_ATTR,
+            ModelOptNvFp4Config._from_config,
+        )
+    ModelOptNvFp4Config._from_config = classmethod(_modelopt_nvfp4_config_from_config)
+
+    if not hasattr(ModelOptNvFp4LinearMethod, _ORIGINAL_LINEAR_APPLY_ATTR):
+        setattr(
+            ModelOptNvFp4LinearMethod,
+            _ORIGINAL_LINEAR_APPLY_ATTR,
+            ModelOptNvFp4LinearMethod.apply,
+        )
     ModelOptNvFp4LinearMethod.process_weights_after_loading = (
         _modelopt_dense_process_weights
     )
+    ModelOptNvFp4LinearMethod.apply = _modelopt_dense_apply
 
     _patched = True

--- a/nemo_rl/modelopt/models/generation/vllm_quant_backend.py
+++ b/nemo_rl/modelopt/models/generation/vllm_quant_backend.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gc
+import os
 import types
 from contextlib import ExitStack, contextmanager
 
@@ -19,10 +21,29 @@ import torch
 import vllm  # noqa: F401
 from modelopt.torch.quantization.nn.modules.tensor_quantizer import TensorQuantizer
 
+from nemo_rl.modelopt.utils import (
+    iter_quant_ignore_name_candidates,
+    matches_quant_ignore_pattern,
+)
 from nemo_rl.models.generation.vllm.vllm_backend import VllmInternalWorkerExtension
+from nemo_rl.models.policy.utils import (
+    IPCProtocol,
+    calculate_aligned_size,
+    rebuild_cuda_tensor_from_ipc,
+)
+
+if os.environ.get("VLLM_MODELOPT_REAL_QUANT", "0") == "1":
+    from nemo_rl.modelopt.models.generation.vllm_modelopt_patch import (
+        apply_modelopt_nvfp4_patches,
+    )
+
+    apply_modelopt_nvfp4_patches()
 
 
 class VllmQuantInternalWorkerExtension(VllmInternalWorkerExtension):
+    def _is_real_quant_model(self) -> bool:
+        return os.environ.get("VLLM_MODELOPT_REAL_QUANT", "0") == "1"
+
     @contextmanager
     def _patch_named_parameters_to_include_buffers(self, model):
         """Temporarily patches model.named_parameters() to also yield input_quantizer buffers.
@@ -54,8 +75,7 @@ class VllmQuantInternalWorkerExtension(VllmInternalWorkerExtension):
         finally:
             model.named_parameters = original_named_parameters
             for buf in patched_quantizer_buffers:
-                if hasattr(buf, "weight_loader"):
-                    del buf.weight_loader
+                del buf.weight_loader
 
     def _load_weights(self, weights):
         """Load pre-folded weights and input_quantizer amax buffers.
@@ -63,12 +83,124 @@ class VllmQuantInternalWorkerExtension(VllmInternalWorkerExtension):
         Weights arrive already folded from the Megatron side (weight_quantizer
         applied during export), so no fold_weight step is needed here.
         """
+        if self._is_real_quant_model():
+            quant_config = (
+                self.model_runner.vllm_config.model_config.hf_config.quantization_config
+            )
+            ignore_patterns = quant_config.get("ignore", []) or []
+            # Built lazily on first use: only the rare ignored, floating-point
+            # weights (typically just lm_head) need a parameter lookup, so most
+            # refit chunks skip the full named_parameters() scan entirely.
+            params = None
+            filtered = []
+            for name, weight in weights:
+                suffix = name.rsplit(".", 1)[-1]
+                ignored = matches_quant_ignore_pattern(name, ignore_patterns)
+                if ignored and suffix in {"weight_scale", "weight_scale_2"}:
+                    continue
+
+                if ignored and suffix == "weight" and weight.is_floating_point():
+                    if params is None:
+                        params = dict(self.model_runner.model.named_parameters())
+                    copied = False
+                    for candidate in iter_quant_ignore_name_candidates(name):
+                        param = params.get(candidate)
+                        if param is not None and tuple(param.shape) == tuple(
+                            weight.shape
+                        ):
+                            param.data.copy_(
+                                weight.to(device=param.device, dtype=param.dtype)
+                            )
+                            copied = True
+                            break
+                    if copied:
+                        continue
+
+                filtered.append((name, weight))
+            weights = filtered
+            if not weights:
+                return None
+            return super()._load_weights(weights)
+
         with ExitStack() as contexts:
             for _, child in self.model_runner.model.named_children():
                 contexts.enter_context(
                     self._patch_named_parameters_to_include_buffers(child)
                 )
             return super()._load_weights(weights)
+
+    def update_weights_via_ipc_zmq(self) -> bool:
+        """Receive and update weights through CUDA IPC."""
+        if not self._is_real_quant_model():
+            return super().update_weights_via_ipc_zmq()
+
+        from nemo_rl.modelopt.models.generation.vllm_modelopt_patch import (
+            modelopt_process_weights_after_loading,
+            prepare_modelopt_for_weight_reload,
+        )
+
+        prepare_modelopt_for_weight_reload(self.model_runner.model, device=self.device)
+        self.maybe_init_zmq()
+        while True:
+            payload = self.zmq_socket.recv_pyobj()
+
+            if payload == IPCProtocol.COMPLETE:
+                modelopt_process_weights_after_loading(self.model_runner.model)
+                torch.cuda.synchronize()
+                self.zmq_socket.send(IPCProtocol.ACK.value.encode())
+                break
+
+            ipc_handle, list_keys, used_bytes = payload
+            buffer = rebuild_cuda_tensor_from_ipc(ipc_handle, self.device.index)
+
+            weights = []
+            offset = 0
+            for key in list_keys:
+                shape, dtype = self.state_dict_info[key]
+                if isinstance(shape, list):
+                    shape = torch.Size(shape)
+
+                size_in_bytes = dtype.itemsize * shape.numel()
+                weight = (
+                    buffer[offset : offset + size_in_bytes]
+                    .view(dtype=dtype)
+                    .view(shape)
+                )
+                weights.append((key, weight))
+
+                offset += calculate_aligned_size(size_in_bytes)
+
+            assert offset == used_bytes, (
+                "Offset is not equal to used bytes, usually indicate inaccurate "
+                "info like keys or cached dtype in state_dict_info"
+            )
+
+            self._load_weights(weights)
+            torch.cuda.synchronize()
+
+            del weights, buffer
+            self.zmq_socket.send(IPCProtocol.ACK.value.encode())
+
+        self._maybe_process_fp8_kv_cache()
+        gc.collect()
+        torch.cuda.empty_cache()
+        return True
+
+    def update_weights_from_collective(self) -> bool:
+        """Receive and update weights through collective communication."""
+        if not self._is_real_quant_model():
+            return super().update_weights_from_collective()
+
+        from nemo_rl.modelopt.models.generation.vllm_modelopt_patch import (
+            modelopt_process_weights_after_loading,
+            prepare_modelopt_for_weight_reload,
+        )
+
+        prepare_modelopt_for_weight_reload(self.model_runner.model, device=self.device)
+        result = super().update_weights_from_collective()
+        if result:
+            modelopt_process_weights_after_loading(self.model_runner.model)
+        return result
 
     def get_weight_snapshot(self, name: str) -> torch.Tensor:
         """Return a CPU copy of a named parameter for before/after comparison."""
@@ -77,18 +209,6 @@ class VllmQuantInternalWorkerExtension(VllmInternalWorkerExtension):
             if n == name:
                 return p.detach().cpu().clone()
         raise KeyError(f"Parameter '{name}' not found in model")
-
-    def export_amax(self) -> dict[str, torch.Tensor]:
-        """Export amax buffers from the model for testing/debugging."""
-        try:
-            model = self.model_runner.model
-            return {
-                n: b.detach().cpu()
-                for n, b in model.named_buffers()
-                if n.endswith("amax")
-            }
-        except AttributeError:
-            return {}
 
     def get_quantizer_stats(self) -> dict:
         """Return summary statistics for all TensorQuantizer modules.
@@ -99,10 +219,7 @@ class VllmQuantInternalWorkerExtension(VllmInternalWorkerExtension):
         enabled = 0
         with_amax = 0
         positive_amax = 0
-        try:
-            model = self.model_runner.model
-        except AttributeError:
-            return {"total": 0, "enabled": 0, "with_amax": 0, "positive_amax": 0}
+        model = self.model_runner.model
         for _, module in model.named_modules():
             if isinstance(module, TensorQuantizer):
                 total += 1

--- a/nemo_rl/modelopt/models/generation/vllm_quant_worker.py
+++ b/nemo_rl/modelopt/models/generation/vllm_quant_worker.py
@@ -19,6 +19,7 @@ from typing import Any
 import ray
 
 from nemo_rl.distributed.worker_group_utils import get_nsight_config_if_pattern_matches
+from nemo_rl.models.generation.vllm.config import VllmConfig
 from nemo_rl.models.generation.vllm.vllm_worker import (
     VllmGenerationWorkerImpl,
 )
@@ -26,16 +27,42 @@ from nemo_rl.models.generation.vllm.vllm_worker_async import (
     VllmAsyncGenerationWorkerImpl,
 )
 
+_EXTRA_ENV_VARS = (
+    "VLLM_QUANT_CFG",
+    "VLLM_MODELOPT_REAL_QUANT",
+)
 
-def _configure_quant_vllm_kwargs(llm_kwargs: dict[str, Any]) -> None:
-    llm_kwargs["worker_cls"] = (
-        "nemo_rl.modelopt.models.generation.vllm_quant_patch.FakeQuantWorker"
-    )
+
+def _configure_quant_engine_kwargs(
+    cfg: VllmConfig,
+    llm_kwargs: dict[str, Any],
+) -> None:
     llm_kwargs["worker_extension_cls"] = (
         "nemo_rl.modelopt.models.generation.vllm_quant_backend.VllmQuantInternalWorkerExtension"
     )
-    # Expert fakequant needs a decomposed MoE path; explicit user config still wins.
-    llm_kwargs.setdefault("moe_backend", "triton")
+    real_quant = bool(cfg.get("real_quant"))
+    if real_quant:
+        from nemo_rl.modelopt.models.generation.vllm_modelopt_patch import (
+            apply_modelopt_nvfp4_patches,
+        )
+        from nemo_rl.modelopt.utils import build_vllm_modelopt_nvfp4_config
+
+        apply_modelopt_nvfp4_patches()
+        os.environ["VLLM_MODELOPT_REAL_QUANT"] = "1"
+
+        hf_overrides = llm_kwargs.setdefault("hf_overrides", {})
+        hf_overrides["quantization_config"] = build_vllm_modelopt_nvfp4_config(
+            ignore=cfg.get("real_quant_ignore"),
+        )
+        llm_kwargs["quantization"] = "modelopt"
+    else:
+        llm_kwargs["worker_cls"] = (
+            "nemo_rl.modelopt.models.generation.vllm_quant_patch.FakeQuantWorker"
+        )
+        # Expert fakequant needs a decomposed MoE path; explicit user config still wins.
+        llm_kwargs.setdefault("moe_backend", "triton")
+        if cfg["quant_cfg"]:
+            os.environ["VLLM_QUANT_CFG"] = cfg["quant_cfg"]
 
 
 @ray.remote(
@@ -43,46 +70,22 @@ def _configure_quant_vllm_kwargs(llm_kwargs: dict[str, Any]) -> None:
 )  # pragma: no cover
 class VllmQuantGenerationWorker(VllmGenerationWorkerImpl):
     def __init__(self, *args, **kwargs):
-        kwargs["extra_env_vars"] = ["VLLM_QUANT_CFG"]
+        kwargs["extra_env_vars"] = _EXTRA_ENV_VARS
         super().__init__(*args, **kwargs)
 
     def _create_engine(self, llm_kwargs: dict[str, Any]) -> None:
-        _configure_quant_vllm_kwargs(llm_kwargs)
-        if self.cfg["quant_cfg"]:
-            print("setting VLLM_QUANT_CFG to: ", self.cfg["quant_cfg"])
-            os.environ["VLLM_QUANT_CFG"] = self.cfg["quant_cfg"]
-
+        _configure_quant_engine_kwargs(self.cfg, llm_kwargs)
         super()._create_engine(llm_kwargs)
-
-    def _collective_rpc_or_empty(self, method: str) -> dict[str, Any]:
-        """Best-effort RPC call; returns {} on any failure.
-
-        collective_rpc can propagate arbitrary exceptions from the internal
-        worker (RuntimeError, AttributeError, etc.), so broad except is
-        intentional here -- consistent with the base class pattern.
-        """
-        if not hasattr(self, "llm"):
-            return {}
-        try:
-            results = self.llm.collective_rpc(method, args=tuple())
-            return results[0] if results else {}
-        except Exception:
-            return {}
-
-    def export_amax(self) -> dict[str, Any]:
-        """Export amax buffers for testing/debugging."""
-        return self._collective_rpc_or_empty("export_amax")
 
     def get_quantizer_stats(self) -> dict[str, Any]:
         """Return quantizer statistics. Mirrors MegatronQuantPolicyWorker.get_quantizer_stats()."""
-        return self._collective_rpc_or_empty("get_quantizer_stats")
+        results = self.llm.collective_rpc("get_quantizer_stats", args=tuple())
+        return results[0]
 
     def get_weight_snapshot(self, name: str) -> Any:
         """Return a CPU copy of a named parameter for before/after comparison."""
-        if not hasattr(self, "llm"):
-            return None
         results = self.llm.collective_rpc("get_weight_snapshot", args=(name,))
-        return results[0] if results else None
+        return results[0]
 
 
 @ray.remote(
@@ -90,40 +93,19 @@ class VllmQuantGenerationWorker(VllmGenerationWorkerImpl):
 )  # pragma: no cover
 class VllmQuantAsyncGenerationWorker(VllmAsyncGenerationWorkerImpl):
     def __init__(self, *args, **kwargs):
-        kwargs["extra_env_vars"] = ["VLLM_QUANT_CFG"]
+        kwargs["extra_env_vars"] = _EXTRA_ENV_VARS
         super().__init__(*args, **kwargs)
 
     def _create_engine(self, llm_kwargs: dict[str, Any]) -> None:
-        _configure_quant_vllm_kwargs(llm_kwargs)
-        if self.cfg["quant_cfg"]:
-            os.environ["VLLM_QUANT_CFG"] = self.cfg["quant_cfg"]
-
+        _configure_quant_engine_kwargs(self.cfg, llm_kwargs)
         super()._create_engine(llm_kwargs)
-
-    async def _collective_rpc_or_empty(self, method: str) -> dict[str, Any]:
-        """Best-effort async RPC call; returns {} on any failure.
-
-        See sync counterpart for rationale on broad except.
-        """
-        if not hasattr(self, "llm"):
-            return {}
-        try:
-            results = await self.llm.collective_rpc(method, args=tuple())
-            return results[0] if results else {}
-        except Exception:
-            return {}
-
-    async def export_amax(self) -> dict[str, Any]:
-        """Export amax buffers for testing/debugging."""
-        return await self._collective_rpc_or_empty("export_amax")
 
     async def get_quantizer_stats(self) -> dict[str, Any]:
         """Return quantizer statistics. Mirrors MegatronQuantPolicyWorker.get_quantizer_stats()."""
-        return await self._collective_rpc_or_empty("get_quantizer_stats")
+        results = await self.llm.collective_rpc("get_quantizer_stats", args=tuple())
+        return results[0]
 
     async def get_weight_snapshot(self, name: str) -> Any:
         """Return a CPU copy of a named parameter for before/after comparison."""
-        if not hasattr(self, "llm"):
-            return None
         results = await self.llm.collective_rpc("get_weight_snapshot", args=(name,))
-        return results[0] if results else None
+        return results[0]

--- a/nemo_rl/modelopt/models/policy/workers/megatron_quant_policy_worker.py
+++ b/nemo_rl/modelopt/models/policy/workers/megatron_quant_policy_worker.py
@@ -440,6 +440,50 @@ class MegatronQuantPolicyWorker(MegatronPolicyWorkerImpl):
                 return wq
         return None
 
+    @staticmethod
+    def _iter_hf_input_amax_names(mapping):
+        hf_param = mapping.hf_param
+        if isinstance(hf_param, str) and hf_param.endswith(".weight"):
+            yield hf_param.removesuffix(".weight") + ".input_quantizer._amax"
+
+    @staticmethod
+    def _get_enabled_input_amax(task):
+        input_quantizer = getattr(task.megatron_module, "input_quantizer", None)
+        if not isinstance(input_quantizer, TensorQuantizer):
+            return None
+        if not input_quantizer.is_enabled:
+            return None
+
+        amax = getattr(input_quantizer, "_amax", None)
+        if amax is None:
+            amax = getattr(input_quantizer, "amax", None)
+        if amax is None:
+            raise RuntimeError(
+                f"Missing input quantizer amax for '{task.global_param_name}'"
+            )
+        if not bool(torch.isfinite(amax).all().item()) or not bool(
+            (amax > 0).all().item()
+        ):
+            raise RuntimeError(
+                f"Invalid input quantizer amax for '{task.global_param_name}'"
+            )
+        return amax.detach()
+
+    def _iter_input_quantizer_amax_params(self, conversion_tasks, existing_names):
+        for task in conversion_tasks:
+            if task.param_weight is None or task.megatron_module is None:
+                continue
+            if not task.global_param_name.endswith(".weight"):
+                continue
+
+            amax = self._get_enabled_input_amax(task)
+            if amax is None:
+                continue
+
+            for name in self._iter_hf_input_amax_names(task.mapping):
+                if name not in existing_names:
+                    yield name, amax
+
     def _iter_params_with_optional_kv_scales(self, kv_scales=None):
         """Pre-fold weights on-the-fly via lazy proxy tasks.
 
@@ -506,10 +550,16 @@ class MegatronQuantPolicyWorker(MegatronPolicyWorkerImpl):
         original_tasks = self.refit_conversion_tasks
         self.refit_conversion_tasks = folded_tasks
         try:
+            yielded_names = set()
             for name, tensor in super()._iter_params_with_optional_kv_scales(kv_scales):
                 if "weight_quantizer" in name:
                     continue
+                yielded_names.add(name)
                 yield name, tensor
+            yield from self._iter_input_quantizer_amax_params(
+                original_tasks,
+                yielded_names,
+            )
         except RuntimeError:
             raise
         except Exception as e:

--- a/nemo_rl/modelopt/models/policy/workers/megatron_quant_policy_worker.py
+++ b/nemo_rl/modelopt/models/policy/workers/megatron_quant_policy_worker.py
@@ -17,8 +17,8 @@ import os
 from contextlib import contextmanager
 from typing import Generator
 
-import modelopt.torch.quantization as mtq
 import ray
+import torch
 from megatron.bridge.training.post_training.checkpointing import (
     has_modelopt_state,
     load_modelopt_state,
@@ -82,29 +82,21 @@ class MegatronQuantPolicyWorker(MegatronPolicyWorkerImpl):
                     self.reference_state_dict[name] = item.detach().to(
                         device="cpu", non_blocking=True, copy=True
                     )
-        if self.rank == 0:
-            print(f"Quantized model: {self.model}")
-            mtq.print_quant_summary(self.model)
 
     def _quantize(self, model):
         """Quantize the model if the model is not quantized yet."""
-        quant_cfg = self.cfg["quant_cfg"]
-        quant_calib_data = self.cfg["quant_calib_data"]
-        quant_calib_size = self.cfg["quant_calib_size"]
-        quant_batch_size = self.cfg["quant_batch_size"]
-        quant_sequence_length = self.cfg["quant_sequence_length"]
         unwrapped_model = unwrap_model(model)[0]
 
         tokenizer = get_tokenizer(self.cfg["model_name"])
         quantize_model(
             model=unwrapped_model,
-            quant_cfg=quant_cfg,
+            quant_cfg=self.cfg["quant_cfg"],
             tokenizer=tokenizer,
-            calib_size=quant_calib_size,
+            calib_size=self.cfg.get("quant_calib_size"),
             is_megatron=True,
-            batch_size=quant_batch_size,
-            data=quant_calib_data,
-            max_sample_length=quant_sequence_length,
+            batch_size=self.cfg.get("quant_batch_size"),
+            data=self.cfg.get("quant_calib_data"),
+            max_sample_length=self.cfg.get("quant_sequence_length"),
         )
         return model
 
@@ -143,7 +135,7 @@ class MegatronQuantPolicyWorker(MegatronPolicyWorkerImpl):
         megatron_policy_worker.validate_model_paths = _validate_model_paths
 
     def _patch_setup_model_and_optimizer(self):
-        """Patch setup_model_and_optimizer to restore modelopt state when loading quantized checkpoints."""
+        """Patch setup_model_and_optimizer to restore modelopt state."""
         if getattr(
             megatron_policy_worker.setup_model_and_optimizer, "_is_patched", False
         ):
@@ -160,7 +152,6 @@ class MegatronQuantPolicyWorker(MegatronPolicyWorkerImpl):
             if os.path.exists(os.path.join(model_path, "iter_0000000")):
                 model_path = os.path.join(model_path, "iter_0000000")
             if has_modelopt_state(model_path):
-                print("setting restore_modelopt_state to True")
                 disable_modelopt_layer_spec = policy_cfg.get(
                     "disable_modelopt_layer_spec", False
                 )
@@ -279,7 +270,7 @@ class MegatronQuantPolicyWorker(MegatronPolicyWorkerImpl):
 
     @contextmanager
     def without_model_config(self):
-        """Context manager that temporarily removes the ``config`` attribute from TensorQuantizer modules.
+        """Temporarily remove TensorQuantizer ``config`` attributes.
 
         Used by :meth:`use_reference_model` and :meth:`save_checkpoint`. Both
         of these flows traverse the module tree (e.g. for state-dict swapping
@@ -341,6 +332,62 @@ class MegatronQuantPolicyWorker(MegatronPolicyWorkerImpl):
         with self.without_model_config():
             return super().save_checkpoint(*args, **kwargs)
 
+    def _use_real_quant_refit(self) -> bool:
+        generation_cfg = self.cfg.get("generation") or {}
+        return (
+            generation_cfg.get("backend") == "vllm"
+            and generation_cfg.get("quant_cfg") is not None
+            and bool(generation_cfg.get("real_quant"))
+        )
+
+    def _iter_real_quant_refit_params(self, kv_scales=None):
+        """Export packed NVFP4 weights and scales for real-quant vLLM rollout."""
+        from nemo_rl.modelopt.utils import DEFAULT_NVFP4_IGNORE
+
+        generation_cfg = self.cfg.get("generation") or {}
+        vllm_cfg = generation_cfg.get("vllm_cfg", {})
+        ignore = generation_cfg.get("real_quant_ignore")
+        if ignore is None:
+            ignore = DEFAULT_NVFP4_IGNORE
+        yield from self.megatron_bridge.export_hf_weights_modelopt(
+            [self.model],
+            quant_mode="nvfp4",
+            cpu=True,
+            show_progress=False,
+            conversion_tasks=self.refit_conversion_tasks,
+            ignore_patterns=ignore,
+        )
+
+        if self.draft_model is not None:
+            from nemo_rl.models.megatron.draft import export_eagle_weights_to_hf
+
+            for name, tensor in export_eagle_weights_to_hf(self.draft_model):
+                yield f"draft.{name}", tensor
+
+        if not vllm_cfg.get("kv_cache_dtype", "").startswith("fp8"):
+            return
+
+        from nemo_rl.models.generation.vllm.quantization.fp8_train_utils import (
+            get_vllm_qkv_scale_names,
+        )
+
+        keys: list[str] = []
+        for layer_idx in range(self.megatron_bridge.transformer_config.num_layers):
+            keys.extend(get_vllm_qkv_scale_names(layer_idx).values())
+
+        for param_name in keys:
+            scale_value = (
+                kv_scales[param_name] if kv_scales and param_name in kv_scales else 1.0
+            )
+            yield (
+                param_name,
+                torch.tensor(
+                    scale_value,
+                    dtype=torch.float32,
+                    device="cuda",
+                ).reshape(1),
+            )
+
     @staticmethod
     def _find_weight_quantizer(module, param_weight):
         """Find the enabled weight quantizer that corresponds to ``param_weight``.
@@ -377,6 +424,9 @@ class MegatronQuantPolicyWorker(MegatronPolicyWorkerImpl):
             RuntimeError: If weight folding fails for a specific parameter,
                 with context about which parameter caused the failure.
         """
+        if self._use_real_quant_refit():
+            yield from self._iter_real_quant_refit_params(kv_scales)
+            return
 
         class _FoldedTask:
             """Proxy that applies weight_quantizer(param_weight) on access."""
@@ -402,7 +452,6 @@ class MegatronQuantPolicyWorker(MegatronPolicyWorkerImpl):
                 return getattr(self._task, name)
 
         folded_tasks = []
-        skipped_fold = []
         for task in self.refit_conversion_tasks:
             matched_wq = self._find_weight_quantizer(
                 task.megatron_module, task.param_weight
@@ -410,20 +459,7 @@ class MegatronQuantPolicyWorker(MegatronPolicyWorkerImpl):
             if matched_wq is not None:
                 folded_tasks.append(_FoldedTask(task, matched_wq))
             else:
-                if (
-                    task.param_weight is not None
-                    and isinstance(task.megatron_module, QuantModule)
-                    and next(task.megatron_module.iter_weights_for_calibration(), None)
-                    is not None
-                ):
-                    skipped_fold.append(task.param_name)
                 folded_tasks.append(task)
-
-        if skipped_fold and self.rank == 0:
-            print(
-                f"[QuantFold] Skipped folding {len(skipped_fold)} non-GEMM params "
-                f"that share a module with weight_quantizer: {skipped_fold[:5]}"
-            )
 
         original_tasks = self.refit_conversion_tasks
         self.refit_conversion_tasks = folded_tasks
@@ -432,14 +468,5 @@ class MegatronQuantPolicyWorker(MegatronPolicyWorkerImpl):
                 if "weight_quantizer" in name:
                     continue
                 yield name, tensor
-        except RuntimeError:
-            raise
-        except Exception as e:
-            raise RuntimeError(
-                f"Failed during quantized weight refit iteration. "
-                f"Folded {len(folded_tasks)} tasks, skipped folding for: "
-                f"{skipped_fold[:5] if skipped_fold else 'none'}. "
-                f"Cause: {e}"
-            ) from e
         finally:
             self.refit_conversion_tasks = original_tasks

--- a/nemo_rl/modelopt/models/policy/workers/megatron_quant_policy_worker.py
+++ b/nemo_rl/modelopt/models/policy/workers/megatron_quant_policy_worker.py
@@ -42,6 +42,29 @@ from nemo_rl.models.policy.workers.megatron_policy_worker import (
 )
 
 
+@contextmanager
+def _w4a16_modelopt_exporter():
+    """Temporarily adapt Bridge's NVFP4 exporter for W4A16 rollout metadata.
+
+    Get this removed when Bridge fixed the logic here.
+    """
+    from megatron.bridge.models.conversion import modelopt_utils
+    from modelopt.torch.export.quant_utils import QUANTIZATION_W4A16_NVFP4
+
+    original_get_exporter = modelopt_utils.get_modelopt_quant_exporter
+
+    def _get_modelopt_quant_exporter(quant_mode: str):
+        if quant_mode.lower() == "w4a16_nvfp4":
+            return QUANTIZATION_W4A16_NVFP4, modelopt_utils.quantize_nvfp4_weight
+        return original_get_exporter(quant_mode)
+
+    modelopt_utils.get_modelopt_quant_exporter = _get_modelopt_quant_exporter
+    try:
+        yield
+    finally:
+        modelopt_utils.get_modelopt_quant_exporter = original_get_exporter
+
+
 @ray.remote(
     runtime_env=get_runtime_env_for_policy_worker("megatron_quant_policy_worker")
 )  # pragma: no cover
@@ -353,14 +376,15 @@ class MegatronQuantPolicyWorker(MegatronPolicyWorkerImpl):
         ignore = generation_cfg.get("real_quant_ignore")
         if ignore is None:
             ignore = DEFAULT_NVFP4_IGNORE
-        yield from self.megatron_bridge.export_hf_weights_modelopt(
-            [self.model],
-            quant_mode="nvfp4",
-            cpu=True,
-            show_progress=False,
-            conversion_tasks=self.refit_conversion_tasks,
-            ignore_patterns=ignore,
-        )
+        with _w4a16_modelopt_exporter():
+            yield from self.megatron_bridge.export_hf_weights_modelopt(
+                [self.model],
+                quant_mode="w4a16_nvfp4",
+                cpu=True,
+                show_progress=False,
+                conversion_tasks=self.refit_conversion_tasks,
+                ignore_patterns=ignore,
+            )
 
         if self.draft_model is not None:
             from nemo_rl.models.megatron.draft import export_eagle_weights_to_hf

--- a/nemo_rl/modelopt/models/policy/workers/megatron_quant_policy_worker.py
+++ b/nemo_rl/modelopt/models/policy/workers/megatron_quant_policy_worker.py
@@ -17,6 +17,7 @@ import os
 from contextlib import contextmanager
 from typing import Generator
 
+import modelopt.torch.quantization as mtq
 import ray
 import torch
 from megatron.bridge.training.post_training.checkpointing import (
@@ -82,6 +83,9 @@ class MegatronQuantPolicyWorker(MegatronPolicyWorkerImpl):
                     self.reference_state_dict[name] = item.detach().to(
                         device="cpu", non_blocking=True, copy=True
                     )
+        if self.rank == 0:
+            print(f"Quantized model: {self.model}")
+            mtq.print_quant_summary(self.model)
 
     def _quantize(self, model):
         """Quantize the model if the model is not quantized yet."""
@@ -452,6 +456,7 @@ class MegatronQuantPolicyWorker(MegatronPolicyWorkerImpl):
                 return getattr(self._task, name)
 
         folded_tasks = []
+        skipped_fold = []
         for task in self.refit_conversion_tasks:
             matched_wq = self._find_weight_quantizer(
                 task.megatron_module, task.param_weight
@@ -459,7 +464,20 @@ class MegatronQuantPolicyWorker(MegatronPolicyWorkerImpl):
             if matched_wq is not None:
                 folded_tasks.append(_FoldedTask(task, matched_wq))
             else:
+                if (
+                    task.param_weight is not None
+                    and isinstance(task.megatron_module, QuantModule)
+                    and next(task.megatron_module.iter_weights_for_calibration(), None)
+                    is not None
+                ):
+                    skipped_fold.append(task.param_name)
                 folded_tasks.append(task)
+
+        if skipped_fold and self.rank == 0:
+            print(
+                f"[QuantFold] Skipped folding {len(skipped_fold)} non-GEMM params "
+                f"that share a module with weight_quantizer: {skipped_fold[:5]}"
+            )
 
         original_tasks = self.refit_conversion_tasks
         self.refit_conversion_tasks = folded_tasks
@@ -468,5 +486,14 @@ class MegatronQuantPolicyWorker(MegatronPolicyWorkerImpl):
                 if "weight_quantizer" in name:
                     continue
                 yield name, tensor
+        except RuntimeError:
+            raise
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed during quantized weight refit iteration. "
+                f"Folded {len(folded_tasks)} tasks, skipped folding for: "
+                f"{skipped_fold[:5] if skipped_fold else 'none'}. "
+                f"Cause: {e}"
+            ) from e
         finally:
             self.refit_conversion_tasks = original_tasks

--- a/nemo_rl/modelopt/models/policy/workers/utils.py
+++ b/nemo_rl/modelopt/models/policy/workers/utils.py
@@ -16,6 +16,7 @@
 import os
 from functools import partial
 from pathlib import Path
+from typing import Any
 
 import modelopt.torch.quantization as mtq
 import torch
@@ -26,7 +27,7 @@ from megatron.bridge.models.mamba.mamba_provider import (
     transformer_engine_mamba_stack_spec,
 )
 from megatron.core.post_training.modelopt.gpt.model_specs import get_gpt_modelopt_spec
-from modelopt.torch.quantization.config import need_calibration
+from modelopt.torch.quantization.config import normalize_quant_cfg_list
 from modelopt.torch.utils.dataset_utils import (
     create_forward_loop,
     get_dataset_dataloader,
@@ -39,6 +40,10 @@ from nemo_rl.modelopt.utils import resolve_quant_cfg
 
 MAX_SEQ_LEN = 2048
 MAX_OUTPUT_LEN = 512
+# Calibration dataloader defaults used when the optional
+# policy.quant_batch_size / policy.quant_sequence_length config keys are unset.
+DEFAULT_CALIB_BATCH_SIZE = 32
+DEFAULT_CALIB_SAMPLE_LENGTH = 1024
 
 
 def symlink_pre_quantized_model(src: str, pretrained_path: str) -> None:
@@ -76,6 +81,34 @@ class _DictDataset(Dataset):
         return len(next(iter(self.data.values())))
 
 
+def _pad_or_truncate_input_ids(
+    input_ids: torch.Tensor,
+    *,
+    max_length: int | None = None,
+    multiple: int = 1,
+    pad_token_id: int = 0,
+) -> torch.Tensor:
+    if max_length is not None and input_ids.shape[-1] > max_length:
+        input_ids = input_ids[..., :max_length]
+
+    if multiple <= 1:
+        return input_ids.contiguous()
+
+    seq_len = input_ids.shape[-1]
+    padded_len = ((seq_len + multiple - 1) // multiple) * multiple
+    pad_len = padded_len - seq_len
+    if pad_len == 0:
+        return input_ids.contiguous()
+
+    padding = torch.full(
+        (*input_ids.shape[:-1], pad_len),
+        pad_token_id,
+        dtype=input_ids.dtype,
+        device=input_ids.device,
+    )
+    return torch.cat((input_ids, padding), dim=-1).contiguous()
+
+
 def get_forward_loop_func(
     is_megatron: bool,
     calib_dataloader: DataLoader,
@@ -84,11 +117,53 @@ def get_forward_loop_func(
     if not is_megatron:
         return create_forward_loop(dataloader=calib_dataloader)
 
+    from megatron.core import parallel_state
+
+    cp_size = parallel_state.get_context_parallel_world_size()
+    pad_multiple = max(1, 2 * cp_size)
+
     def _forward_loop(model):
         for batch in calib_dataloader:
-            megatron_prefill(model, batch["input_ids"], skip_return_logits=True)
+            input_ids = _pad_or_truncate_input_ids(
+                batch["input_ids"],
+                multiple=pad_multiple,
+            )
+            megatron_prefill(model, input_ids, skip_return_logits=True)
 
     return _forward_loop
+
+
+def _requires_forward_calibration(config: dict[str, Any]) -> bool:
+    """Return whether this config needs data-driven activation calibration."""
+    algorithm = config.get("algorithm")
+    if algorithm is not None and algorithm != "max":
+        return True
+
+    def _needs_stats(cfg: dict[str, Any]) -> bool:
+        if not cfg.get("enable", True):
+            return False
+        if cfg.get("type") == "dynamic":
+            return False
+        return not cfg.get("use_constant_amax", False)
+
+    for entry in normalize_quant_cfg_list(config.get("quant_cfg") or []):
+        name = entry["quantizer_name"]
+        if "weight_quantizer" in name:
+            continue
+
+        raw_cfg = entry.get("cfg")
+        if isinstance(raw_cfg, list):
+            if any(_needs_stats(dict(cfg)) for cfg in raw_cfg):
+                return True
+            continue
+
+        cfg = dict(raw_cfg or {})
+        if "enable" in entry:
+            cfg["enable"] = entry["enable"]
+        if _needs_stats(cfg):
+            return True
+
+    return False
 
 
 def quantize_model(
@@ -97,9 +172,9 @@ def quantize_model(
     tokenizer,
     calib_size,
     is_megatron: bool = False,
-    batch_size=32,
-    data="cnn_dailymail",
-    max_sample_length=1024,
+    batch_size=None,
+    data=None,
+    max_sample_length=None,
 ):
     """Quantizes the model with the provided calibration dataset.
 
@@ -113,37 +188,47 @@ def quantize_model(
         auto_quantize_bits: The effective bits constraint for auto_quantize.
         data: the name of the calibration dataset.
     """
-    device = (
-        model.device if hasattr(model, "device") else next(model.parameters()).device
-    )
-    if data == "random":
-        calib_size = 1
-        calib_dataloader = DataLoader(
-            _DictDataset({"input_ids": torch.randint(0, 100, (1, 5), device=device)}),
-            batch_size=1,
-        )
-    else:
-        calib_dataloader = get_dataset_dataloader(
-            dataset_name=data,
-            tokenizer=tokenizer,
-            batch_size=batch_size,
-            num_samples=calib_size,
-            device=device,
-            include_labels=False,
-            max_sample_length=max_sample_length,
-        )
-
     mtq_cfg = resolve_quant_cfg(quant_cfg)
-
-    forward_loop = None
-    use_calibration = need_calibration(mtq_cfg)
+    use_calibration = _requires_forward_calibration(mtq_cfg)
     if not use_calibration:
-        print("Dynamic quantization. Calibration skipped.")
+        forward_loop = None
     else:
+        if data is None:
+            raise ValueError(
+                "policy.quant_calib_data is required by this quantization config."
+            )
+        device = (
+            model.device
+            if hasattr(model, "device")
+            else next(model.parameters()).device
+        )
+        if data == "random":
+            calib_size = 1
+            calib_dataloader = DataLoader(
+                _DictDataset(
+                    {"input_ids": torch.randint(0, 100, (1, 5), device=device)}
+                ),
+                batch_size=1,
+            )
+        else:
+            calib_dataloader = get_dataset_dataloader(
+                dataset_name=data,
+                tokenizer=tokenizer,
+                batch_size=batch_size
+                if batch_size is not None
+                else DEFAULT_CALIB_BATCH_SIZE,
+                num_samples=calib_size,
+                device=device,
+                include_labels=False,
+                max_sample_length=(
+                    max_sample_length
+                    if max_sample_length is not None
+                    else DEFAULT_CALIB_SAMPLE_LENGTH
+                ),
+            )
         forward_loop = get_forward_loop_func(is_megatron, calib_dataloader)
 
-    model = mtq.quantize(model, mtq_cfg, forward_loop)
-    mtq.print_quant_summary(model)
+    mtq.quantize(model, mtq_cfg, forward_loop)
 
 
 def get_modelopt_checkpoint_dir() -> str:

--- a/nemo_rl/modelopt/models/policy/workers/utils.py
+++ b/nemo_rl/modelopt/models/policy/workers/utils.py
@@ -16,7 +16,6 @@
 import os
 from functools import partial
 from pathlib import Path
-from typing import Any
 
 import modelopt.torch.quantization as mtq
 import torch
@@ -27,7 +26,7 @@ from megatron.bridge.models.mamba.mamba_provider import (
     transformer_engine_mamba_stack_spec,
 )
 from megatron.core.post_training.modelopt.gpt.model_specs import get_gpt_modelopt_spec
-from modelopt.torch.quantization.config import normalize_quant_cfg_list
+from modelopt.torch.quantization.config import need_calibration
 from modelopt.torch.utils.dataset_utils import (
     create_forward_loop,
     get_dataset_dataloader,
@@ -81,34 +80,6 @@ class _DictDataset(Dataset):
         return len(next(iter(self.data.values())))
 
 
-def _pad_or_truncate_input_ids(
-    input_ids: torch.Tensor,
-    *,
-    max_length: int | None = None,
-    multiple: int = 1,
-    pad_token_id: int = 0,
-) -> torch.Tensor:
-    if max_length is not None and input_ids.shape[-1] > max_length:
-        input_ids = input_ids[..., :max_length]
-
-    if multiple <= 1:
-        return input_ids.contiguous()
-
-    seq_len = input_ids.shape[-1]
-    padded_len = ((seq_len + multiple - 1) // multiple) * multiple
-    pad_len = padded_len - seq_len
-    if pad_len == 0:
-        return input_ids.contiguous()
-
-    padding = torch.full(
-        (*input_ids.shape[:-1], pad_len),
-        pad_token_id,
-        dtype=input_ids.dtype,
-        device=input_ids.device,
-    )
-    return torch.cat((input_ids, padding), dim=-1).contiguous()
-
-
 def get_forward_loop_func(
     is_megatron: bool,
     calib_dataloader: DataLoader,
@@ -117,53 +88,11 @@ def get_forward_loop_func(
     if not is_megatron:
         return create_forward_loop(dataloader=calib_dataloader)
 
-    from megatron.core import parallel_state
-
-    cp_size = parallel_state.get_context_parallel_world_size()
-    pad_multiple = max(1, 2 * cp_size)
-
     def _forward_loop(model):
         for batch in calib_dataloader:
-            input_ids = _pad_or_truncate_input_ids(
-                batch["input_ids"],
-                multiple=pad_multiple,
-            )
-            megatron_prefill(model, input_ids, skip_return_logits=True)
+            megatron_prefill(model, batch["input_ids"], skip_return_logits=True)
 
     return _forward_loop
-
-
-def _requires_forward_calibration(config: dict[str, Any]) -> bool:
-    """Return whether this config needs data-driven activation calibration."""
-    algorithm = config.get("algorithm")
-    if algorithm is not None and algorithm != "max":
-        return True
-
-    def _needs_stats(cfg: dict[str, Any]) -> bool:
-        if not cfg.get("enable", True):
-            return False
-        if cfg.get("type") == "dynamic":
-            return False
-        return not cfg.get("use_constant_amax", False)
-
-    for entry in normalize_quant_cfg_list(config.get("quant_cfg") or []):
-        name = entry["quantizer_name"]
-        if "weight_quantizer" in name:
-            continue
-
-        raw_cfg = entry.get("cfg")
-        if isinstance(raw_cfg, list):
-            if any(_needs_stats(dict(cfg)) for cfg in raw_cfg):
-                return True
-            continue
-
-        cfg = dict(raw_cfg or {})
-        if "enable" in entry:
-            cfg["enable"] = entry["enable"]
-        if _needs_stats(cfg):
-            return True
-
-    return False
 
 
 def quantize_model(
@@ -189,8 +118,9 @@ def quantize_model(
         data: the name of the calibration dataset.
     """
     mtq_cfg = resolve_quant_cfg(quant_cfg)
-    use_calibration = _requires_forward_calibration(mtq_cfg)
+    use_calibration = need_calibration(mtq_cfg)
     if not use_calibration:
+        print("Dynamic quantization. Calibration skipped.")
         forward_loop = None
     else:
         if data is None:
@@ -228,7 +158,8 @@ def quantize_model(
             )
         forward_loop = get_forward_loop_func(is_megatron, calib_dataloader)
 
-    mtq.quantize(model, mtq_cfg, forward_loop)
+    model = mtq.quantize(model, mtq_cfg, forward_loop)
+    mtq.print_quant_summary(model)
 
 
 def get_modelopt_checkpoint_dir() -> str:

--- a/nemo_rl/modelopt/models/policy/workers/utils.py
+++ b/nemo_rl/modelopt/models/policy/workers/utils.py
@@ -127,6 +127,10 @@ def quantize_model(
             raise ValueError(
                 "policy.quant_calib_data is required by this quantization config."
             )
+        if calib_size is None:
+            raise ValueError(
+                "policy.quant_calib_size is required by this quantization config."
+            )
         device = (
             model.device
             if hasattr(model, "device")

--- a/nemo_rl/modelopt/utils.py
+++ b/nemo_rl/modelopt/utils.py
@@ -118,11 +118,13 @@ def resolve_quant_cfg(quant_cfg: str) -> dict[str, Any]:
        files; NeMo-RL repo-relative recipe paths are not resolved here.
 
     YAML recipes are expected to follow the standard ModelOpt PTQ recipe layout
-    with a top-level ``quantize:`` section in the
-    ``{"quant_cfg": [...], "algorithm": ...}`` shape that ``mtq.quantize``
-    expects. A bare ``{"quant_cfg": [...], "algorithm": ...}`` document (without
-    a wrapping ``quantize:`` key) is also accepted for convenience. The
-    extracted dict — not the full recipe — is returned.
+    with a top-level ``quantize:`` section in the ``{"quant_cfg": [...],
+    "algorithm": ...}`` shape that ``mtq.quantize`` expects. A bare
+    ``{"quant_cfg": [...], "algorithm": ...}`` document (without a wrapping
+    ``quantize:`` key) is also accepted for convenience. If ``algorithm`` is
+    omitted, it defaults to ``"max"`` so ModelOpt's calibration helpers see the
+    same normalized config as ``mtq.quantize``. The extracted dict — not the full
+    recipe — is returned.
 
     See ``modelopt_recipes/general/ptq/`` in the NVIDIA/Model-Optimizer repo
     (https://github.com/NVIDIA/Model-Optimizer) for the canonical format and
@@ -131,9 +133,24 @@ def resolve_quant_cfg(quant_cfg: str) -> dict[str, Any]:
     import modelopt.torch.quantization as mtq
     from modelopt.recipe import load_config
 
+    def _normalize_mtq_cfg(config: dict[str, Any]) -> dict[str, Any]:
+        if not isinstance(config, dict):
+            raise ValueError(
+                f"Quantization recipe '{quant_cfg}' must resolve to a dict."
+            )
+        mtq_cfg = config.get("quantize", config)
+        if not isinstance(mtq_cfg, dict) or "quant_cfg" not in mtq_cfg:
+            raise ValueError(
+                f"Quantization recipe '{quant_cfg}' must contain a 'quant_cfg' "
+                f"entry (optionally nested under a top-level 'quantize:' section)."
+            )
+        if "algorithm" not in mtq_cfg:
+            mtq_cfg = {**mtq_cfg, "algorithm": "max"}
+        return mtq_cfg
+
     builtin = getattr(mtq, quant_cfg, None)
     if builtin is not None:
-        return builtin
+        return _normalize_mtq_cfg(builtin)
 
     try:
         loaded = load_config(quant_cfg)
@@ -146,10 +163,4 @@ def resolve_quant_cfg(quant_cfg: str) -> dict[str, Any]:
             f"YAML quantization recipe."
         ) from e
 
-    quantize = loaded.get("quantize", loaded)
-    if not isinstance(quantize, dict) or "quant_cfg" not in quantize:
-        raise ValueError(
-            f"Quantization recipe '{quant_cfg}' must contain a 'quant_cfg' "
-            f"entry (optionally nested under a top-level 'quantize:' section)."
-        )
-    return quantize
+    return _normalize_mtq_cfg(loaded)

--- a/nemo_rl/modelopt/utils.py
+++ b/nemo_rl/modelopt/utils.py
@@ -14,10 +14,91 @@
 
 """Lightweight quantization config resolver usable by both Megatron and vLLM workers."""
 
-from typing import Any
+from __future__ import annotations
 
-import modelopt.torch.quantization as mtq
-from modelopt.recipe import load_config
+from fnmatch import fnmatchcase
+from pathlib import Path
+from typing import Any, Iterator
+
+_QUANT_IGNORE_NAME_SUFFIXES = (
+    ".weight",
+    ".weight_scale",
+    ".weight_scale_2",
+)
+
+# Layers kept in native dtype by the real-quant vLLM rollout. Shared between the
+# vLLM quantization_config and the Megatron export-side ignore patterns.
+DEFAULT_NVFP4_IGNORE = [
+    "lm_head",
+    "*output_layer*",
+    "*mlp.gate",
+    "*router*",
+    "*block_sparse_moe.gate*",
+    "*self_attention*",
+    "*self_attn*",
+]
+
+
+def _iter_quant_ignore_suffix_variants(name: str) -> Iterator[str]:
+    """Yield ``name`` and, if it ends in a known quant suffix, the stripped form."""
+    yield name
+    for suffix in _QUANT_IGNORE_NAME_SUFFIXES:
+        if name.endswith(suffix):
+            yield name[: -len(suffix)]
+            break
+
+
+def iter_quant_ignore_name_candidates(name: str) -> Iterator[str]:
+    """Yield name variants matched by ModelOpt real-quant ignore patterns."""
+    yield from _iter_quant_ignore_suffix_variants(name)
+
+    alternate = (
+        name.removeprefix("model.") if name.startswith("model.") else f"model.{name}"
+    )
+    if alternate == name:
+        return
+
+    yield from _iter_quant_ignore_suffix_variants(alternate)
+
+
+def matches_quant_ignore_pattern(name: str, patterns: list[str]) -> bool:
+    """Return whether ``name`` matches any ModelOpt real-quant ignore pattern."""
+    return any(
+        fnmatchcase(candidate, pattern)
+        for candidate in iter_quant_ignore_name_candidates(name)
+        for pattern in patterns
+    )
+
+
+def build_vllm_modelopt_nvfp4_config(
+    *,
+    ignore: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build the HuggingFace quantization_config consumed by vLLM ModelOpt NVFP4.
+
+    NeMo-RL's ``quant_cfg`` recipes are ModelOpt PTQ/QAT configs consumed by
+    ``mtq.quantize``. vLLM expects the deployment/export-side
+    ``quantization_config`` shape instead.
+    """
+    return {
+        "quant_method": "modelopt",
+        "config_groups": {
+            "group_0": {
+                "input_activations": None,
+                "weights": {
+                    "dynamic": False,
+                    "num_bits": 4,
+                    "type": "float",
+                    "group_size": 16,
+                },
+                "targets": ["Linear"],
+            }
+        },
+        "ignore": ignore if ignore is not None else list(DEFAULT_NVFP4_IGNORE),
+        "quant_algo": "NVFP4",
+        "group_size": 16,
+        "producer": {"name": "modelopt"},
+    }
 
 
 def resolve_quant_cfg(quant_cfg: str) -> dict[str, Any]:
@@ -46,9 +127,18 @@ def resolve_quant_cfg(quant_cfg: str) -> dict[str, Any]:
     for the canonical format and ``examples/modelopt/quant_configs/`` for a
     user-authored example.
     """
+    import modelopt.torch.quantization as mtq
+    from modelopt.recipe import load_config
+
     builtin = getattr(mtq, quant_cfg, None)
     if builtin is not None:
         return builtin
+
+    config_path = Path(quant_cfg)
+    if not config_path.is_absolute():
+        repo_config_path = Path(__file__).resolve().parents[2] / config_path
+        if repo_config_path.is_file():
+            quant_cfg = str(repo_config_path)
 
     try:
         loaded = load_config(quant_cfg)

--- a/nemo_rl/modelopt/utils.py
+++ b/nemo_rl/modelopt/utils.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 from fnmatch import fnmatchcase
-from pathlib import Path
 from typing import Any, Iterator
 
 _QUANT_IGNORE_NAME_SUFFIXES = (
@@ -123,9 +122,9 @@ def resolve_quant_cfg(quant_cfg: str) -> dict[str, Any]:
     a wrapping ``quantize:`` key) is also accepted for convenience. The
     extracted dict — not the full recipe — is returned.
 
-    See ``modelopt_recipes/general/ptq/`` in the TensorRT-Model-Optimizer repo
-    for the canonical format and ``examples/modelopt/quant_configs/`` for a
-    user-authored example.
+    See ``modelopt_recipes/general/ptq/`` in the NVIDIA/Model-Optimizer repo
+    (https://github.com/NVIDIA/Model-Optimizer) for the canonical format and
+    ``examples/modelopt/quant_configs/`` for a user-authored example.
     """
     import modelopt.torch.quantization as mtq
     from modelopt.recipe import load_config
@@ -133,12 +132,6 @@ def resolve_quant_cfg(quant_cfg: str) -> dict[str, Any]:
     builtin = getattr(mtq, quant_cfg, None)
     if builtin is not None:
         return builtin
-
-    config_path = Path(quant_cfg)
-    if not config_path.is_absolute():
-        repo_config_path = Path(__file__).resolve().parents[2] / config_path
-        if repo_config_path.is_file():
-            quant_cfg = str(repo_config_path)
 
     try:
         loaded = load_config(quant_cfg)

--- a/nemo_rl/modelopt/utils.py
+++ b/nemo_rl/modelopt/utils.py
@@ -95,6 +95,8 @@ def build_vllm_modelopt_nvfp4_config(
         },
         "ignore": ignore if ignore is not None else list(DEFAULT_NVFP4_IGNORE),
         "quant_algo": "NVFP4",
+        "quant_mode": "w4a16_nvfp4",
+        "weight_only": True,
         "group_size": 16,
         "producer": {"name": "modelopt"},
     }

--- a/nemo_rl/models/generation/vllm/config.py
+++ b/nemo_rl/models/generation/vllm/config.py
@@ -56,3 +56,8 @@ class VllmConfig(GenerationConfig):
 
     # quantization config
     quant_cfg: NotRequired[str | None]
+    # When set with ``quant_cfg``, initialize rollout vLLM with real ModelOpt
+    # NVFP4 kernels and stream packed quantized weights instead of fake-quant
+    # modules. This is intended for ModelOpt NVFP4 rollout experiments.
+    real_quant: NotRequired[bool]
+    real_quant_ignore: NotRequired[list[str]]

--- a/nemo_rl/models/policy/utils.py
+++ b/nemo_rl/models/policy/utils.py
@@ -416,8 +416,11 @@ def stream_weights_via_ipc_zmq_impl(
         for name, tensor in params_generator:
             # Initialize device and buffers on first tensor
             if buffer_a is None:
-                buffer_a = allocate_buffer(tensor.device)
-                buffer_b = allocate_buffer(tensor.device)
+                buffer_device = tensor.device
+                if buffer_device.type == "cpu" and torch.cuda.is_available():
+                    buffer_device = torch.device("cuda", torch.cuda.current_device())
+                buffer_a = allocate_buffer(buffer_device)
+                buffer_b = allocate_buffer(buffer_device)
                 current_buffer = buffer_a
 
             aligned_size = calculate_aligned_size(tensor.nbytes)

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -1338,11 +1338,6 @@ class MegatronPolicyWorkerImpl(
         self, buffer_size_bytes: int = 0, kv_scales: Optional[dict[str, float]] = None
     ) -> None:
         """Stream model weights to peer process via ZMQ IPC socket."""
-        self.model = self.move_model(
-            self.model, "cuda", move_params=True, move_grads=False
-        )
-        torch.cuda.current_stream().synchronize()
-
         self.maybe_init_zmq()
 
         from nemo_rl.models.policy.utils import stream_weights_via_ipc_zmq_impl
@@ -1370,6 +1365,9 @@ class MegatronPolicyWorkerImpl(
             src=0,
             post_iter_func=lambda x: x[1],
         )
+
+    def _use_real_quant_refit(self) -> bool:
+        return False
 
     def prepare_for_lp_inference(self):
         self.model = self.move_model(self.model, "cuda", move_grads=False)

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -1338,6 +1338,11 @@ class MegatronPolicyWorkerImpl(
         self, buffer_size_bytes: int = 0, kv_scales: Optional[dict[str, float]] = None
     ) -> None:
         """Stream model weights to peer process via ZMQ IPC socket."""
+        self.model = self.move_model(
+            self.model, "cuda", move_params=True, move_grads=False
+        )
+        torch.cuda.current_stream().synchronize()
+
         self.maybe_init_zmq()
 
         from nemo_rl.models.policy.utils import stream_weights_via_ipc_zmq_impl

--- a/tests/functional/L1_Functional_Tests_Megatron_3.sh
+++ b/tests/functional/L1_Functional_Tests_Megatron_3.sh
@@ -38,6 +38,7 @@ run_test      uv run --no-sync bash ./tests/functional/distillation_megatron.sh
 run_test fast uv run --no-sync bash ./tests/functional/qa_distillation_megatron.sh
 run_test      uv run --no-sync bash ./tests/functional/dpo_megatron.sh
 run_test      uv run --no-sync bash ./tests/functional/sft_megatron.sh
+run_test      uv run --no-sync bash ./tests/functional/modelopt_quant_rollout.sh
 
 cd ${PROJECT_ROOT}/tests
 if compgen -G ".coverage*" > /dev/null; then

--- a/tests/functional/modelopt_quant_rollout.sh
+++ b/tests/functional/modelopt_quant_rollout.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
-PROJECT_ROOT=$(realpath $SCRIPT_DIR/../..)
+PROJECT_ROOT=$(realpath "$SCRIPT_DIR/../..")
 
 set -euo pipefail
 
-EXP_NAME=$(basename $0 .sh)
+EXP_NAME=$(basename "$0" .sh)
 EXP_DIR=$SCRIPT_DIR/$EXP_NAME
 export PYTHONPATH=${PROJECT_ROOT}:${PYTHONPATH:-}
 
-rm -rf $EXP_DIR
-mkdir -p $EXP_DIR
+rm -rf "$EXP_DIR"
+mkdir -p "$EXP_DIR"
 
 assert_grep() {
     local pattern=$1
@@ -37,9 +37,17 @@ run_quant_rollout_case() {
     local gen_kl_error_step1_max=$4
     local token_mult_prob_error_max=$5
     local model_name=$6
-    local log_dir=$EXP_DIR/$case_name/logs
-    local metrics_json=$EXP_DIR/$case_name/metrics.json
-    local run_log=$EXP_DIR/$case_name/run.log
+    local log_dir="$EXP_DIR/$case_name/logs"
+    local metrics_json="$EXP_DIR/$case_name/metrics.json"
+    local run_log="$EXP_DIR/$case_name/run.log"
+    local megatron_cache_root="${NRL_MEGATRON_CHECKPOINT_DIR:-$PROJECT_ROOT/.cache/modelopt_quant_rollout/megatron}"
+    local quant_cfg_hash
+    if [[ -f "$PROJECT_ROOT/$quant_cfg" ]]; then
+        quant_cfg_hash=$(sha256sum "$PROJECT_ROOT/$quant_cfg" | cut -c1-12)
+    else
+        quant_cfg_hash=$(printf '%s' "$quant_cfg" | sha256sum | cut -c1-12)
+    fi
+    local megatron_cache_dir="$megatron_cache_root/$case_name-$quant_cfg_hash"
     local real_quant_override=()
     shift 6
 
@@ -47,14 +55,15 @@ run_quant_rollout_case() {
         real_quant_override+=(++policy.generation.real_quant=true)
     fi
 
-    rm -rf $EXP_DIR/$case_name
-    mkdir -p $log_dir
+    rm -rf "$EXP_DIR/$case_name"
+    mkdir -p "$log_dir" "$megatron_cache_dir"
 
-    cd $PROJECT_ROOT
+    cd "$PROJECT_ROOT"
+    NRL_MEGATRON_CHECKPOINT_DIR="$megatron_cache_dir" \
     uv run --extra modelopt --group test \
-        coverage run -a --data-file=$PROJECT_ROOT/tests/.coverage --source=$PROJECT_ROOT/nemo_rl \
-        $PROJECT_ROOT/examples/run_grpo.py \
-        --config $PROJECT_ROOT/examples/modelopt/qa_grpo_math_megatron.yaml \
+        coverage run -a --data-file="$PROJECT_ROOT/tests/.coverage" --source="$PROJECT_ROOT/nemo_rl" \
+        "$PROJECT_ROOT/examples/run_grpo.py" \
+        --config "$PROJECT_ROOT/examples/modelopt/qa_grpo_math_megatron.yaml" \
         policy.model_name=$model_name \
         policy.tokenizer.name=$model_name \
         policy.quant_cfg=$quant_cfg \
@@ -79,17 +88,17 @@ run_quant_rollout_case() {
         env.math.num_workers=2 \
         cluster.gpus_per_node=2 \
         logger.tensorboard_enabled=true \
-        logger.log_dir=$log_dir \
+        logger.log_dir="$log_dir" \
         logger.wandb_enabled=false \
         logger.monitor_gpus=true \
         checkpointing.enabled=false \
         "${real_quant_override[@]}" \
-        $@ \
-        2>&1 | tee $run_log
+        "$@" \
+        2>&1 | tee "$run_log"
 
-    uv run --extra modelopt --group test tests/json_dump_tb_logs.py $log_dir --output_path $metrics_json
+    uv run --extra modelopt --group test tests/json_dump_tb_logs.py "$log_dir" --output_path "$metrics_json"
 
-    uv run --extra modelopt --group test tests/check_metrics.py $metrics_json \
+    uv run --extra modelopt --group test tests/check_metrics.py "$metrics_json" \
         "data[\"train/gen_kl_error\"][\"1\"] < $gen_kl_error_step1_max" \
         "max(data[\"train/token_mult_prob_error\"]) < $token_mult_prob_error_max"
 
@@ -106,6 +115,6 @@ run_quant_rollout_case() {
 }
 
 run_quant_rollout_case w4a16_real_quant examples/modelopt/quant_configs/nvfp4_a16_mlp_only.yaml true 0.003 1.05 Qwen/Qwen2.5-0.5B "$@"
-run_quant_rollout_case w4a8_fake_quant examples/modelopt/quant_configs/nvfp4_w4a8_fp8.yaml false 0.008 1.08 Qwen/Qwen2.5-0.5B "$@"
+run_quant_rollout_case w4a8_fake_quant examples/modelopt/quant_configs/nvfp4_w4a8_fp8.yaml false 0.006 1.06 Qwen/Qwen2.5-0.5B "$@"
 
 echo "[PASS] ModelOpt W4A16 real-quant and W4A8 fake-quant rollout functional test"

--- a/tests/functional/modelopt_quant_rollout.sh
+++ b/tests/functional/modelopt_quant_rollout.sh
@@ -105,7 +105,7 @@ run_quant_rollout_case() {
     fi
 }
 
-run_quant_rollout_case w4a16_real_quant examples/modelopt/quant_configs/nvfp4_a16.yaml true 0.003 1.05 Qwen/Qwen2.5-0.5B "$@"
+run_quant_rollout_case w4a16_real_quant examples/modelopt/quant_configs/nvfp4_a16_mlp_only.yaml true 0.003 1.05 Qwen/Qwen2.5-0.5B "$@"
 run_quant_rollout_case w4a8_fake_quant examples/modelopt/quant_configs/nvfp4_w4a8_fp8.yaml false 0.008 1.08 Qwen/Qwen2.5-0.5B "$@"
 
 echo "[PASS] ModelOpt W4A16 real-quant and W4A8 fake-quant rollout functional test"

--- a/tests/functional/modelopt_quant_rollout.sh
+++ b/tests/functional/modelopt_quant_rollout.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+PROJECT_ROOT=$(realpath $SCRIPT_DIR/../..)
+
+set -euo pipefail
+
+EXP_NAME=$(basename $0 .sh)
+EXP_DIR=$SCRIPT_DIR/$EXP_NAME
+export PYTHONPATH=${PROJECT_ROOT}:${PYTHONPATH:-}
+
+rm -rf $EXP_DIR
+mkdir -p $EXP_DIR
+
+assert_grep() {
+    local pattern=$1
+    local file=$2
+    grep -q "$pattern" "$file" || {
+        echo "[FAIL] expected '$pattern' in $file"
+        exit 1
+    }
+}
+
+assert_not_grep() {
+    local pattern=$1
+    local file=$2
+    if grep -q "$pattern" "$file"; then
+        echo "[FAIL] did not expect '$pattern' in $file"
+        exit 1
+    fi
+}
+
+run_quant_rollout_case() {
+    local case_name=$1
+    local quant_cfg=$2
+    local real_quant=$3
+    local gen_kl_error_step1_max=$4
+    local token_mult_prob_error_max=$5
+    local model_name=$6
+    local log_dir=$EXP_DIR/$case_name/logs
+    local metrics_json=$EXP_DIR/$case_name/metrics.json
+    local run_log=$EXP_DIR/$case_name/run.log
+    local real_quant_override=()
+    shift 6
+
+    if [[ "$real_quant" == "true" ]]; then
+        real_quant_override+=(++policy.generation.real_quant=true)
+    fi
+
+    rm -rf $EXP_DIR/$case_name
+    mkdir -p $log_dir
+
+    cd $PROJECT_ROOT
+    uv run --extra modelopt --group test \
+        coverage run -a --data-file=$PROJECT_ROOT/tests/.coverage --source=$PROJECT_ROOT/nemo_rl \
+        $PROJECT_ROOT/examples/run_grpo.py \
+        --config $PROJECT_ROOT/examples/modelopt/qa_grpo_math_megatron.yaml \
+        policy.model_name=$model_name \
+        policy.tokenizer.name=$model_name \
+        policy.quant_cfg=$quant_cfg \
+        policy.generation.quant_cfg=$quant_cfg \
+        policy.quant_calib_size=4 \
+        policy.quant_batch_size=1 \
+        policy.quant_sequence_length=128 \
+        policy.max_total_sequence_length=256 \
+        policy.train_global_batch_size=4 \
+        policy.train_micro_batch_size=1 \
+        policy.logprob_batch_size=4 \
+        policy.generation.max_new_tokens=128 \
+        policy.generation.vllm_cfg.max_model_len=256 \
+        policy.generation.vllm_cfg.gpu_memory_utilization=0.5 \
+        policy.generation.vllm_cfg.enforce_eager=true \
+        grpo.num_prompts_per_step=2 \
+        grpo.num_generations_per_prompt=2 \
+        grpo.max_num_steps=1 \
+        grpo.val_period=1 \
+        grpo.max_val_samples=8 \
+        grpo.val_batch_size=8 \
+        env.math.num_workers=2 \
+        cluster.gpus_per_node=2 \
+        logger.tensorboard_enabled=true \
+        logger.log_dir=$log_dir \
+        logger.wandb_enabled=false \
+        logger.monitor_gpus=true \
+        checkpointing.enabled=false \
+        "${real_quant_override[@]}" \
+        $@ \
+        2>&1 | tee $run_log
+
+    uv run --extra modelopt --group test tests/json_dump_tb_logs.py $log_dir --output_path $metrics_json
+
+    uv run --extra modelopt --group test tests/check_metrics.py $metrics_json \
+        "data[\"train/gen_kl_error\"][\"1\"] < $gen_kl_error_step1_max" \
+        "max(data[\"train/token_mult_prob_error\"]) < $token_mult_prob_error_max"
+
+    assert_grep "VllmQuantInternalWorkerExtension" "$run_log"
+    if [[ "$real_quant" == "true" ]]; then
+        assert_grep "Detected ModelOpt NVFP4 checkpoint" "$run_log"
+        assert_not_grep "FakeQuantWorker" "$run_log"
+        assert_not_grep "VLLM_QUANT_CFG" "$run_log"
+    else
+        assert_grep "FakeQuantWorker" "$run_log"
+        assert_grep "VLLM_QUANT_CFG" "$run_log"
+        assert_not_grep "Detected ModelOpt NVFP4 checkpoint" "$run_log"
+    fi
+}
+
+run_quant_rollout_case w4a16_real_quant examples/modelopt/quant_configs/nvfp4_a16.yaml true 0.003 1.05 Qwen/Qwen2.5-0.5B "$@"
+run_quant_rollout_case w4a8_fake_quant examples/modelopt/quant_configs/nvfp4_w4a8_fp8.yaml false 0.008 1.08 Qwen/Qwen2.5-0.5B "$@"
+
+echo "[PASS] ModelOpt W4A16 real-quant and W4A8 fake-quant rollout functional test"

--- a/tests/test_suites/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron-qa-nvfp4-w4a16.sh
+++ b/tests/test_suites/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron-qa-nvfp4-w4a16.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $SCRIPT_DIR/common.env
+
+# ===== BEGIN CONFIG =====
+NUM_NODES=1
+GPUS_PER_NODE=8
+STEPS_PER_RUN=1
+MAX_STEPS=1
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=60
+# ===== END CONFIG =====
+
+exit_if_max_steps_reached
+
+# Run the experiment
+cd $PROJECT_ROOT
+uv run examples/run_grpo.py \
+    --config $CONFIG_PATH \
+    policy.model_name=Qwen/Qwen2.5-0.5B \
+    policy.tokenizer.name=Qwen/Qwen2.5-0.5B \
+    policy.megatron_cfg.converter_type=Qwen2ForCausalLM \
+    policy.megatron_cfg.tensor_model_parallel_size=1 \
+    policy.megatron_cfg.pipeline_model_parallel_size=1 \
+    policy.megatron_cfg.sequence_parallel=false \
+    policy.megatron_cfg.activation_checkpointing=false \
+    policy.megatron_cfg.apply_rope_fusion=true \
+    policy.max_total_sequence_length=256 \
+    policy.train_global_batch_size=4 \
+    policy.train_micro_batch_size=1 \
+    policy.logprob_batch_size=4 \
+    policy.quant_calib_size=4 \
+    policy.quant_batch_size=1 \
+    policy.quant_sequence_length=128 \
+    policy.generation.max_new_tokens=128 \
+    policy.generation.vllm_cfg.tensor_parallel_size=1 \
+    policy.generation.vllm_cfg.max_model_len=256 \
+    policy.generation.vllm_cfg.gpu_memory_utilization=0.5 \
+    policy.generation.vllm_cfg.enforce_eager=true \
+    grpo.num_prompts_per_step=2 \
+    grpo.num_generations_per_prompt=2 \
+    grpo.max_num_steps=$MAX_STEPS \
+    grpo.val_period=1 \
+    grpo.max_val_samples=8 \
+    grpo.val_batch_size=8 \
+    env.math.num_workers=2 \
+    cluster.num_nodes=$NUM_NODES \
+    cluster.gpus_per_node=$GPUS_PER_NODE \
+    logger.log_dir=$LOG_DIR \
+    logger.wandb_enabled=True \
+    logger.wandb.project=nemo-rl \
+    logger.wandb.name=$EXP_NAME \
+    logger.monitor_gpus=True \
+    logger.tensorboard_enabled=True \
+    checkpointing.enabled=True \
+    checkpointing.checkpoint_dir=$CKPT_DIR \
+    $@ \
+    2>&1 | tee $RUN_LOG
+
+# Convert tensorboard logs to json
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+
+# Only run metrics if the target step is reached
+if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
+    uv run tests/check_metrics.py $JSON_METRICS \
+        'data["train/gen_kl_error"]["1"] < 0.003' \
+        'max(data["train/token_mult_prob_error"]) < 1.05'
+
+    grep -q "VllmQuantInternalWorkerExtension" "$RUN_LOG"
+    grep -q "Detected ModelOpt NVFP4 checkpoint" "$RUN_LOG"
+    ! grep -q "FakeQuantWorker" "$RUN_LOG"
+    ! grep -q "VLLM_QUANT_CFG" "$RUN_LOG"
+
+    # Clean up checkpoint directory after successful run to save space.
+    rm -rf "$CKPT_DIR"
+fi

--- a/tests/test_suites/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron-qa-nvfp4-w4a8-fake.sh
+++ b/tests/test_suites/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron-qa-nvfp4-w4a8-fake.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $SCRIPT_DIR/common.env
+
+# ===== BEGIN CONFIG =====
+NUM_NODES=1
+GPUS_PER_NODE=8
+STEPS_PER_RUN=1
+MAX_STEPS=1
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=60
+# ===== END CONFIG =====
+
+exit_if_max_steps_reached
+
+# Run the experiment
+cd $PROJECT_ROOT
+uv run examples/run_grpo.py \
+    --config $CONFIG_PATH \
+    policy.model_name=Qwen/Qwen2.5-0.5B \
+    policy.tokenizer.name=Qwen/Qwen2.5-0.5B \
+    policy.megatron_cfg.converter_type=Qwen2ForCausalLM \
+    policy.megatron_cfg.tensor_model_parallel_size=1 \
+    policy.megatron_cfg.pipeline_model_parallel_size=1 \
+    policy.megatron_cfg.sequence_parallel=false \
+    policy.megatron_cfg.activation_checkpointing=false \
+    policy.megatron_cfg.apply_rope_fusion=true \
+    policy.max_total_sequence_length=256 \
+    policy.train_global_batch_size=4 \
+    policy.train_micro_batch_size=1 \
+    policy.logprob_batch_size=4 \
+    policy.quant_calib_size=4 \
+    policy.quant_batch_size=1 \
+    policy.quant_sequence_length=128 \
+    policy.generation.max_new_tokens=128 \
+    policy.generation.vllm_cfg.tensor_parallel_size=1 \
+    policy.generation.vllm_cfg.max_model_len=256 \
+    policy.generation.vllm_cfg.gpu_memory_utilization=0.5 \
+    policy.generation.vllm_cfg.enforce_eager=true \
+    grpo.num_prompts_per_step=2 \
+    grpo.num_generations_per_prompt=2 \
+    grpo.max_num_steps=$MAX_STEPS \
+    grpo.val_period=1 \
+    grpo.max_val_samples=8 \
+    grpo.val_batch_size=8 \
+    env.math.num_workers=2 \
+    cluster.num_nodes=$NUM_NODES \
+    cluster.gpus_per_node=$GPUS_PER_NODE \
+    logger.log_dir=$LOG_DIR \
+    logger.wandb_enabled=True \
+    logger.wandb.project=nemo-rl \
+    logger.wandb.name=$EXP_NAME \
+    logger.monitor_gpus=True \
+    logger.tensorboard_enabled=True \
+    checkpointing.enabled=True \
+    checkpointing.checkpoint_dir=$CKPT_DIR \
+    $@ \
+    2>&1 | tee $RUN_LOG
+
+# Convert tensorboard logs to json
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+
+# Only run metrics if the target step is reached
+if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
+    uv run tests/check_metrics.py $JSON_METRICS \
+        'data["train/gen_kl_error"]["1"] < 0.008' \
+        'max(data["train/token_mult_prob_error"]) < 1.06'
+
+    grep -q "FakeQuantWorker" "$RUN_LOG"
+    grep -q "VLLM_QUANT_CFG" "$RUN_LOG"
+    ! grep -q "Detected ModelOpt NVFP4 checkpoint" "$RUN_LOG"
+
+    # Clean up checkpoint directory after successful run to save space.
+    rm -rf "$CKPT_DIR"
+fi

--- a/tests/test_suites/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron.sh
+++ b/tests/test_suites/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $SCRIPT_DIR/common.env
+
+# ===== BEGIN CONFIG =====
+NUM_NODES=1
+GPUS_PER_NODE=8
+STEPS_PER_RUN=1
+MAX_STEPS=1
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=60
+# ===== END CONFIG =====
+
+exit_if_max_steps_reached
+
+# Run the experiment
+cd $PROJECT_ROOT
+uv run examples/run_grpo.py \
+    --config $CONFIG_PATH \
+    policy.model_name=Qwen/Qwen2.5-0.5B \
+    policy.tokenizer.name=Qwen/Qwen2.5-0.5B \
+    policy.megatron_cfg.converter_type=Qwen2ForCausalLM \
+    policy.megatron_cfg.tensor_model_parallel_size=1 \
+    policy.megatron_cfg.pipeline_model_parallel_size=1 \
+    policy.megatron_cfg.sequence_parallel=false \
+    policy.megatron_cfg.activation_checkpointing=false \
+    policy.megatron_cfg.apply_rope_fusion=true \
+    policy.max_total_sequence_length=256 \
+    policy.train_global_batch_size=4 \
+    policy.train_micro_batch_size=1 \
+    policy.logprob_batch_size=4 \
+    policy.generation.max_new_tokens=128 \
+    policy.generation.vllm_cfg.tensor_parallel_size=1 \
+    policy.generation.vllm_cfg.max_model_len=256 \
+    policy.generation.vllm_cfg.gpu_memory_utilization=0.5 \
+    policy.generation.vllm_cfg.enforce_eager=true \
+    grpo.num_prompts_per_step=2 \
+    grpo.num_generations_per_prompt=2 \
+    grpo.max_num_steps=$MAX_STEPS \
+    grpo.val_period=1 \
+    grpo.max_val_samples=8 \
+    grpo.val_batch_size=8 \
+    env.math.num_workers=2 \
+    cluster.num_nodes=$NUM_NODES \
+    cluster.gpus_per_node=$GPUS_PER_NODE \
+    logger.log_dir=$LOG_DIR \
+    logger.wandb_enabled=True \
+    logger.wandb.project=nemo-rl \
+    logger.wandb.name=$EXP_NAME \
+    logger.monitor_gpus=True \
+    logger.tensorboard_enabled=True \
+    checkpointing.enabled=True \
+    checkpointing.checkpoint_dir=$CKPT_DIR \
+    $@ \
+    2>&1 | tee $RUN_LOG
+
+# Convert tensorboard logs to json
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+
+# Only run metrics if the target step is reached
+if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
+    uv run tests/check_metrics.py $JSON_METRICS \
+        'data["train/gen_kl_error"]["1"] < 0.003' \
+        'max(data["train/token_mult_prob_error"]) < 1.05'
+
+    # Clean up checkpoint directory after successful run to save space.
+    rm -rf "$CKPT_DIR"
+fi

--- a/tests/test_suites/nightly.txt
+++ b/tests/test_suites/nightly.txt
@@ -82,6 +82,11 @@ tests/test_suites/llm/grpo-llama3.1-8b-instruct-2n8g-megatron-fp8-e2e.sh
 tests/test_suites/llm/grpo-moonlight-16ba3b-4n8g-megatron-fp8-e2e.sh
 tests/test_suites/llm/grpo-qwen3-8b-base-1n8g-fp8-kvcache-megatron.sh
 
+# ModelOpt quant rollout smoke tests
+tests/test_suites/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron.sh
+tests/test_suites/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron-qa-nvfp4-w4a16.sh
+tests/test_suites/llm/grpo-qwen2.5-0.5b-dapo-1n8g-megatron-qa-nvfp4-w4a8-fake.sh
+
 # Non-colocated
 tests/test_suites/llm/grpo-llama3.1-8b-instruct-2n8g-fsdp2tp1-noncolocated.sh
 tests/test_suites/llm/grpo-llama3.2-1b-instruct-2n8g-megatron_generation-noncolocated.sh

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -2870,6 +2870,7 @@ def test_vllm_megatron_pipeline_parallel(cluster, tokenizer):
     vllm_config["model_name"] = model_name
     vllm_config["tokenizer"]["name"] = model_name
     vllm_config = configure_generation_config(vllm_config, test_tokenizer)
+    vllm_config["vllm_cfg"]["max_model_len"] = 128
 
     megatron_config = get_basic_megatron_test_config(
         tp=1,

--- a/tests/unit/models/generation/test_vllm_modelopt_real_quant_config.py
+++ b/tests/unit/models/generation/test_vllm_modelopt_real_quant_config.py
@@ -16,7 +16,6 @@ import importlib
 import os
 import sys
 import types
-from pathlib import Path
 
 import pytest
 import torch
@@ -206,7 +205,7 @@ def test_configure_quant_engine_kwargs_for_real_quant(monkeypatch):
     llm_kwargs = {}
     worker_mod._configure_quant_engine_kwargs(
         {
-            "quant_cfg": "examples/modelopt/quant_configs/nvfp4_a16.yaml",
+            "quant_cfg": "examples/modelopt/quant_configs/nvfp4_a16_mlp_only.yaml",
             "real_quant": True,
             "real_quant_ignore": ["lm_head"],
         },
@@ -852,7 +851,7 @@ def test_get_quantizer_stats_counts_enabled_positive_amax(monkeypatch):
     }
 
 
-def test_resolve_quant_cfg_accepts_repo_relative_yaml(monkeypatch):
+def test_resolve_quant_cfg_passes_relative_names_to_modelopt(monkeypatch):
     modelopt_recipe = pytest.importorskip("modelopt.recipe")
     captured = {}
 
@@ -867,9 +866,7 @@ def test_resolve_quant_cfg_accepts_repo_relative_yaml(monkeypatch):
         "algorithm": "max",
     }
 
-    config_file = Path(captured["config_file"])
-    assert config_file.is_absolute()
-    assert config_file.name == "nvfp4_a16.yaml"
+    assert captured["config_file"] == "examples/modelopt/quant_configs/nvfp4_a16.yaml"
 
 
 def test_resolve_quant_cfg_accepts_builtin_modelopt_constant(monkeypatch):

--- a/tests/unit/models/generation/test_vllm_modelopt_real_quant_config.py
+++ b/tests/unit/models/generation/test_vllm_modelopt_real_quant_config.py
@@ -23,6 +23,7 @@ import torch
 from nemo_rl.modelopt.models.generation.vllm_modelopt_patch import (
     _canonicalize_nvfp4_weight_scale,
     _convert_nvfp4_linear_kernel_format,
+    _modelopt_dense_apply,
     _modelopt_dense_process_weights,
     apply_modelopt_nvfp4_patches,
     modelopt_process_weights_after_loading,
@@ -99,6 +100,8 @@ def test_w4a16_real_quant_config_keeps_weight_only_default():
     group = cfg["config_groups"]["group_0"]
     assert cfg["quant_method"] == "modelopt"
     assert cfg["quant_algo"] == "NVFP4"
+    assert cfg["quant_mode"] == "w4a16_nvfp4"
+    assert cfg["weight_only"] is True
     assert cfg["group_size"] == 16
     assert group["input_activations"] is None
     assert group["weights"] == {
@@ -1061,9 +1064,19 @@ def test_apply_modelopt_nvfp4_patches_updates_vllm_method(monkeypatch):
         "vllm.model_executor.layers.quantization.modelopt"
     )
 
+    class FakeModelOptNvFp4Config:
+        @classmethod
+        def _from_config(cls, **kwargs):
+            return types.SimpleNamespace()
+
+    def fake_linear_apply(self, layer, x, bias=None):
+        pass
+
     class FakeModelOptNvFp4LinearMethod:
+        apply = fake_linear_apply
         process_weights_after_loading = None
 
+    modelopt_module.ModelOptNvFp4Config = FakeModelOptNvFp4Config
     modelopt_module.ModelOptNvFp4LinearMethod = FakeModelOptNvFp4LinearMethod
     monkeypatch.setitem(
         sys.modules,
@@ -1075,10 +1088,21 @@ def test_apply_modelopt_nvfp4_patches_updates_vllm_method(monkeypatch):
     apply_modelopt_nvfp4_patches()
     apply_modelopt_nvfp4_patches()
 
+    cfg = FakeModelOptNvFp4Config._from_config(
+        quant_method="NVFP4",
+        kv_cache_quant_method=None,
+        exclude_modules=[],
+        original_config=build_vllm_modelopt_nvfp4_config(),
+        group_size=16,
+    )
+
+    assert getattr(cfg, "_nrl_weight_only_w4a16") is True
+    assert FakeModelOptNvFp4LinearMethod._nrl_original_apply is fake_linear_apply
     assert (
         FakeModelOptNvFp4LinearMethod.process_weights_after_loading
         is _modelopt_dense_process_weights
     )
+    assert FakeModelOptNvFp4LinearMethod.apply is _modelopt_dense_apply
     assert patch_mod._patched is True
 
 
@@ -1154,3 +1178,77 @@ def test_modelopt_dense_process_uses_vllm_kernel_api():
     assert layer._nrl_modelopt_param_meta["weight"]["input_dim"] == 1
     assert layer._nrl_modelopt_param_meta["weight"]["output_dim"] == 0
     assert "weight" in layer._nrl_modelopt_weight_loaders
+
+
+def test_modelopt_dense_process_w4a16_uses_marlin_weight_only(monkeypatch):
+    module_names = [
+        "vllm",
+        "vllm.model_executor",
+        "vllm.model_executor.layers",
+        "vllm.model_executor.layers.quantization",
+        "vllm.model_executor.layers.quantization.utils",
+    ]
+    for module_name in module_names:
+        monkeypatch.setitem(sys.modules, module_name, types.ModuleType(module_name))
+
+    marlin_utils = types.ModuleType(
+        "vllm.model_executor.layers.quantization.utils.marlin_utils_fp4"
+    )
+    calls = []
+
+    def fake_prepare(layer):
+        calls.append(("prepare", layer))
+        layer.workspace = torch.empty(1)
+
+    def fake_apply(**kwargs):
+        calls.append(("apply", kwargs))
+        return "out"
+
+    marlin_utils.prepare_fp4_layer_for_marlin = fake_prepare
+    marlin_utils.apply_fp4_marlin_linear = fake_apply
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.model_executor.layers.quantization.utils.marlin_utils_fp4",
+        marlin_utils,
+    )
+
+    layer = torch.nn.Module()
+    layer.weight = torch.nn.Parameter(torch.ones(2, 1), requires_grad=False)
+    layer.weight_scale = torch.nn.Parameter(
+        torch.tensor([[1.0, -2.0], [-0.5, 4.0]]),
+        requires_grad=False,
+    )
+    layer.weight_scale_2 = torch.nn.Parameter(torch.tensor([2.0]), requires_grad=False)
+    layer.input_scale = torch.nn.Parameter(torch.tensor([3.0]), requires_grad=False)
+    layer.input_global_scale = torch.nn.Parameter(
+        torch.tensor([4.0]),
+        requires_grad=False,
+    )
+    layer.alpha = torch.nn.Parameter(torch.tensor([5.0]), requires_grad=False)
+    layer.input_global_scale_inv = torch.nn.Parameter(
+        torch.tensor([6.0]),
+        requires_grad=False,
+    )
+    layer.output_size_per_partition = 2
+    layer.input_size_per_partition = 2
+    quant_method = types.SimpleNamespace(
+        quant_config=types.SimpleNamespace(_nrl_weight_only_w4a16=True)
+    )
+
+    _modelopt_dense_process_weights(quant_method, layer)
+    result = _modelopt_dense_apply(quant_method, layer, torch.ones(1, 2))
+
+    assert result == "out"
+    assert calls[0] == ("prepare", layer)
+    assert calls[1][0] == "apply"
+    assert not hasattr(layer, "input_scale")
+    assert not hasattr(layer, "input_global_scale")
+    assert not hasattr(layer, "alpha")
+    assert not hasattr(layer, "input_global_scale_inv")
+    assert not hasattr(layer, "weight_scale_2")
+    torch.testing.assert_close(layer.weight_global_scale, torch.tensor(2.0))
+    torch.testing.assert_close(
+        layer.weight_scale,
+        torch.tensor([[1.0, 2.0], [0.5, 4.0]]),
+    )
+    assert calls[1][1]["weight_global_scale"] is layer.weight_global_scale

--- a/tests/unit/models/generation/test_vllm_modelopt_real_quant_config.py
+++ b/tests/unit/models/generation/test_vllm_modelopt_real_quant_config.py
@@ -880,6 +880,21 @@ def test_resolve_quant_cfg_accepts_builtin_modelopt_constant(monkeypatch):
     assert resolve_quant_cfg("UNIT_TEST_CFG") is sentinel
 
 
+def test_resolve_quant_cfg_defaults_missing_algorithm_to_max(monkeypatch):
+    modelopt_recipe = pytest.importorskip("modelopt.recipe")
+
+    monkeypatch.setattr(
+        modelopt_recipe,
+        "load_config",
+        lambda config_name: {"quant_cfg": [{"name": config_name}]},
+    )
+
+    assert resolve_quant_cfg("unit-test-recipe") == {
+        "quant_cfg": [{"name": "unit-test-recipe"}],
+        "algorithm": "max",
+    }
+
+
 def test_resolve_quant_cfg_extracts_nested_quantize_section(monkeypatch):
     modelopt_recipe = pytest.importorskip("modelopt.recipe")
 

--- a/tests/unit/models/generation/test_vllm_modelopt_real_quant_config.py
+++ b/tests/unit/models/generation/test_vllm_modelopt_real_quant_config.py
@@ -1,0 +1,1159 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+
+from nemo_rl.modelopt.models.generation.vllm_modelopt_patch import (
+    _canonicalize_nvfp4_weight_scale,
+    _convert_nvfp4_linear_kernel_format,
+    _modelopt_dense_process_weights,
+    apply_modelopt_nvfp4_patches,
+    modelopt_process_weights_after_loading,
+    prepare_modelopt_for_weight_reload,
+)
+from nemo_rl.modelopt.utils import (
+    build_vllm_modelopt_nvfp4_config,
+    iter_quant_ignore_name_candidates,
+    matches_quant_ignore_pattern,
+    resolve_quant_cfg,
+)
+
+
+def _import_vllm_quant_backend(monkeypatch):
+    """Import the NeMo-RL backend without requiring the vLLM C extension."""
+    monkeypatch.delenv("VLLM_MODELOPT_REAL_QUANT", raising=False)
+    monkeypatch.setitem(sys.modules, "vllm", types.ModuleType("vllm"))
+    _install_fake_modelopt_tensor_quantizer(monkeypatch)
+    sys.modules.pop("nemo_rl.modelopt.models.generation.vllm_quant_backend", None)
+    sys.modules.pop("nemo_rl.models.generation.vllm.vllm_backend", None)
+    try:
+        return importlib.import_module(
+            "nemo_rl.modelopt.models.generation.vllm_quant_backend"
+        )
+    except ImportError as exc:
+        pytest.skip(f"could not import vLLM quant backend: {exc}")
+
+
+def _install_fake_modelopt_tensor_quantizer(monkeypatch):
+    """Install the minimal ModelOpt module hierarchy needed by vLLM backend import."""
+    module_names = [
+        "modelopt",
+        "modelopt.torch",
+        "modelopt.torch.quantization",
+        "modelopt.torch.quantization.nn",
+        "modelopt.torch.quantization.nn.modules",
+    ]
+    modules = {}
+    for module_name in module_names:
+        module = types.ModuleType(module_name)
+        module.__path__ = []
+        modules[module_name] = module
+        monkeypatch.setitem(sys.modules, module_name, module)
+
+    tensor_quantizer_module = types.ModuleType(
+        "modelopt.torch.quantization.nn.modules.tensor_quantizer"
+    )
+
+    class FakeTensorQuantizer(torch.nn.Module):
+        pass
+
+    tensor_quantizer_module.TensorQuantizer = FakeTensorQuantizer
+    monkeypatch.setitem(
+        sys.modules,
+        "modelopt.torch.quantization.nn.modules.tensor_quantizer",
+        tensor_quantizer_module,
+    )
+    modules["modelopt"].torch = modules["modelopt.torch"]
+    modules["modelopt.torch"].quantization = modules["modelopt.torch.quantization"]
+    modules["modelopt.torch.quantization"].nn = modules[
+        "modelopt.torch.quantization.nn"
+    ]
+    modules["modelopt.torch.quantization.nn"].modules = modules[
+        "modelopt.torch.quantization.nn.modules"
+    ]
+    modules[
+        "modelopt.torch.quantization.nn.modules"
+    ].tensor_quantizer = tensor_quantizer_module
+
+
+def test_w4a16_real_quant_config_keeps_weight_only_default():
+    cfg = build_vllm_modelopt_nvfp4_config()
+
+    group = cfg["config_groups"]["group_0"]
+    assert cfg["quant_method"] == "modelopt"
+    assert cfg["quant_algo"] == "NVFP4"
+    assert cfg["group_size"] == 16
+    assert group["input_activations"] is None
+    assert group["weights"] == {
+        "dynamic": False,
+        "num_bits": 4,
+        "type": "float",
+        "group_size": 16,
+    }
+    assert cfg["ignore"] == [
+        "lm_head",
+        "*output_layer*",
+        "*mlp.gate",
+        "*router*",
+        "*block_sparse_moe.gate*",
+        "*self_attention*",
+        "*self_attn*",
+    ]
+
+
+def test_real_quant_config_allows_explicit_ignore_override():
+    cfg = build_vllm_modelopt_nvfp4_config(ignore=["lm_head"])
+
+    assert cfg["ignore"] == ["lm_head"]
+
+
+def test_default_ignore_patterns_match_expected_layers():
+    ignore_patterns = build_vllm_modelopt_nvfp4_config()["ignore"]
+
+    assert matches_quant_ignore_pattern(
+        "model.layers.0.self_attn.o_proj.weight", ignore_patterns
+    )
+    assert matches_quant_ignore_pattern(
+        "layers.0.self_attn.o_proj.weight", ignore_patterns
+    )
+    assert matches_quant_ignore_pattern(
+        "model.layers.0.mlp.gate.weight", ignore_patterns
+    )
+    assert matches_quant_ignore_pattern("model.layers.0.router.weight", ignore_patterns)
+    assert matches_quant_ignore_pattern("lm_head.weight", ignore_patterns)
+    assert matches_quant_ignore_pattern(
+        "model.layers.0.mlp.gate.weight_scale", ignore_patterns
+    )
+    assert not matches_quant_ignore_pattern(
+        "model.layers.0.mlp.experts.0.w1.weight", ignore_patterns
+    )
+
+
+def test_quant_ignore_name_candidates_include_model_prefix_and_base_names():
+    assert list(
+        iter_quant_ignore_name_candidates("layers.0.self_attn.q_proj.weight")
+    ) == [
+        "layers.0.self_attn.q_proj.weight",
+        "layers.0.self_attn.q_proj",
+        "model.layers.0.self_attn.q_proj.weight",
+        "model.layers.0.self_attn.q_proj",
+    ]
+    assert list(iter_quant_ignore_name_candidates("model.lm_head.weight_scale")) == [
+        "model.lm_head.weight_scale",
+        "model.lm_head",
+        "lm_head.weight_scale",
+        "lm_head",
+    ]
+
+
+def test_configure_quant_engine_kwargs_for_fake_quant(monkeypatch):
+    worker_mod = pytest.importorskip(
+        "nemo_rl.modelopt.models.generation.vllm_quant_worker"
+    )
+    monkeypatch.delenv("VLLM_QUANT_CFG", raising=False)
+    monkeypatch.delenv("VLLM_MODELOPT_REAL_QUANT", raising=False)
+
+    llm_kwargs = {}
+    worker_mod._configure_quant_engine_kwargs(
+        {"quant_cfg": "examples/modelopt/quant_configs/nvfp4_w4a8_fp8.yaml"},
+        llm_kwargs,
+    )
+
+    assert llm_kwargs["worker_cls"] == (
+        "nemo_rl.modelopt.models.generation.vllm_quant_patch.FakeQuantWorker"
+    )
+    assert llm_kwargs["worker_extension_cls"] == (
+        "nemo_rl.modelopt.models.generation.vllm_quant_backend.VllmQuantInternalWorkerExtension"
+    )
+    assert os.environ["VLLM_QUANT_CFG"] == (
+        "examples/modelopt/quant_configs/nvfp4_w4a8_fp8.yaml"
+    )
+    assert "quantization" not in llm_kwargs
+
+
+def test_configure_quant_engine_kwargs_for_real_quant(monkeypatch):
+    worker_mod = pytest.importorskip(
+        "nemo_rl.modelopt.models.generation.vllm_quant_worker"
+    )
+    patch_mod = pytest.importorskip(
+        "nemo_rl.modelopt.models.generation.vllm_modelopt_patch"
+    )
+    monkeypatch.delenv("VLLM_QUANT_CFG", raising=False)
+    monkeypatch.delenv("VLLM_MODELOPT_REAL_QUANT", raising=False)
+    patch_calls = []
+    monkeypatch.setattr(
+        patch_mod, "apply_modelopt_nvfp4_patches", lambda: patch_calls.append(True)
+    )
+
+    llm_kwargs = {}
+    worker_mod._configure_quant_engine_kwargs(
+        {
+            "quant_cfg": "examples/modelopt/quant_configs/nvfp4_a16.yaml",
+            "real_quant": True,
+            "real_quant_ignore": ["lm_head"],
+        },
+        llm_kwargs,
+    )
+
+    assert patch_calls == [True]
+    assert os.environ["VLLM_MODELOPT_REAL_QUANT"] == "1"
+    assert "VLLM_QUANT_CFG" not in os.environ
+    assert "worker_cls" not in llm_kwargs
+    assert llm_kwargs["quantization"] == "modelopt"
+    assert llm_kwargs["hf_overrides"]["quantization_config"] == (
+        build_vllm_modelopt_nvfp4_config(ignore=["lm_head"])
+    )
+
+
+def test_configure_quant_engine_kwargs_preserves_hf_overrides(monkeypatch):
+    worker_mod = pytest.importorskip(
+        "nemo_rl.modelopt.models.generation.vllm_quant_worker"
+    )
+    patch_mod = pytest.importorskip(
+        "nemo_rl.modelopt.models.generation.vllm_modelopt_patch"
+    )
+    monkeypatch.delenv("VLLM_MODELOPT_REAL_QUANT", raising=False)
+    monkeypatch.setattr(patch_mod, "apply_modelopt_nvfp4_patches", lambda: None)
+
+    llm_kwargs = {"hf_overrides": {"trust_remote_code": True}}
+    worker_mod._configure_quant_engine_kwargs(
+        {"quant_cfg": "NVFP4_DEFAULT_CFG", "real_quant": True},
+        llm_kwargs,
+    )
+
+    assert llm_kwargs["hf_overrides"]["trust_remote_code"] is True
+    assert (
+        llm_kwargs["hf_overrides"]["quantization_config"]["quant_method"] == "modelopt"
+    )
+
+
+def test_configure_quant_engine_kwargs_for_fake_quant_without_quant_cfg(monkeypatch):
+    worker_mod = pytest.importorskip(
+        "nemo_rl.modelopt.models.generation.vllm_quant_worker"
+    )
+    monkeypatch.delenv("VLLM_QUANT_CFG", raising=False)
+    monkeypatch.delenv("VLLM_MODELOPT_REAL_QUANT", raising=False)
+
+    llm_kwargs = {}
+    worker_mod._configure_quant_engine_kwargs({"quant_cfg": None}, llm_kwargs)
+
+    assert "VLLM_QUANT_CFG" not in os.environ
+    assert llm_kwargs["worker_cls"] == (
+        "nemo_rl.modelopt.models.generation.vllm_quant_patch.FakeQuantWorker"
+    )
+
+
+def test_quant_generation_worker_create_engine_configures_quant(monkeypatch):
+    worker_mod = pytest.importorskip(
+        "nemo_rl.modelopt.models.generation.vllm_quant_worker"
+    )
+    worker_cls = worker_mod.VllmQuantGenerationWorker.__ray_metadata__.modified_class
+    worker = object.__new__(worker_cls)
+    worker.cfg = {"quant_cfg": None}
+    calls = []
+
+    def fake_configure(cfg, llm_kwargs):
+        calls.append(("configure", cfg, llm_kwargs))
+        llm_kwargs["configured"] = True
+
+    def fake_base_create_engine(self, llm_kwargs):
+        calls.append(("base", dict(llm_kwargs)))
+
+    monkeypatch.setattr(worker_mod, "_configure_quant_engine_kwargs", fake_configure)
+    monkeypatch.setattr(
+        worker_mod.VllmGenerationWorkerImpl,
+        "_create_engine",
+        fake_base_create_engine,
+    )
+
+    llm_kwargs = {}
+    worker._create_engine(llm_kwargs)
+
+    assert calls == [
+        ("configure", worker.cfg, {"configured": True}),
+        ("base", {"configured": True}),
+    ]
+
+
+def test_quant_generation_worker_collective_rpc_accessors():
+    worker_mod = pytest.importorskip(
+        "nemo_rl.modelopt.models.generation.vllm_quant_worker"
+    )
+    worker_cls = worker_mod.VllmQuantGenerationWorker.__ray_metadata__.modified_class
+    worker = object.__new__(worker_cls)
+    calls = []
+
+    class FakeLLM:
+        def collective_rpc(self, name, args):
+            calls.append((name, args))
+            return [{"name": name, "args": args}]
+
+    worker.llm = FakeLLM()
+
+    assert worker.get_quantizer_stats() == {
+        "name": "get_quantizer_stats",
+        "args": tuple(),
+    }
+    assert worker.get_weight_snapshot("weight") == {
+        "name": "get_weight_snapshot",
+        "args": ("weight",),
+    }
+    assert calls == [
+        ("get_quantizer_stats", tuple()),
+        ("get_weight_snapshot", ("weight",)),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_quant_generation_worker_collective_rpc_accessors():
+    worker_mod = pytest.importorskip(
+        "nemo_rl.modelopt.models.generation.vllm_quant_worker"
+    )
+    worker_cls = (
+        worker_mod.VllmQuantAsyncGenerationWorker.__ray_metadata__.modified_class
+    )
+    worker = object.__new__(worker_cls)
+    calls = []
+
+    class FakeLLM:
+        async def collective_rpc(self, name, args):
+            calls.append((name, args))
+            return [{"name": name, "args": args}]
+
+    worker.llm = FakeLLM()
+
+    assert await worker.get_quantizer_stats() == {
+        "name": "get_quantizer_stats",
+        "args": tuple(),
+    }
+    assert await worker.get_weight_snapshot("weight") == {
+        "name": "get_weight_snapshot",
+        "args": ("weight",),
+    }
+    assert calls == [
+        ("get_quantizer_stats", tuple()),
+        ("get_weight_snapshot", ("weight",)),
+    ]
+
+
+def test_vllm_modelopt_backend_imports_without_gpt_oss_helper(monkeypatch):
+    _import_vllm_quant_backend(monkeypatch)
+
+
+def test_vllm_modelopt_backend_applies_real_quant_patch_on_import(monkeypatch):
+    patch_mod = pytest.importorskip(
+        "nemo_rl.modelopt.models.generation.vllm_modelopt_patch"
+    )
+    calls = []
+
+    monkeypatch.setenv("VLLM_MODELOPT_REAL_QUANT", "1")
+    monkeypatch.setitem(sys.modules, "vllm", types.ModuleType("vllm"))
+    _install_fake_modelopt_tensor_quantizer(monkeypatch)
+    monkeypatch.setattr(
+        patch_mod,
+        "apply_modelopt_nvfp4_patches",
+        lambda: calls.append("patched"),
+    )
+    sys.modules.pop("nemo_rl.modelopt.models.generation.vllm_quant_backend", None)
+
+    importlib.import_module("nemo_rl.modelopt.models.generation.vllm_quant_backend")
+
+    assert calls == ["patched"]
+
+
+def test_real_quant_load_weights_copies_ignored_float_weights(monkeypatch):
+    backend = _import_vllm_quant_backend(monkeypatch)
+
+    class TinyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.lm_head = torch.nn.Linear(2, 2, bias=False)
+            self.keep = torch.nn.Linear(2, 2, bias=False)
+
+    model = TinyModel()
+    extension = object.__new__(backend.VllmQuantInternalWorkerExtension)
+    extension.model_runner = types.SimpleNamespace(
+        model=model,
+        vllm_config=types.SimpleNamespace(
+            model_config=types.SimpleNamespace(
+                hf_config=types.SimpleNamespace(
+                    quantization_config={"ignore": ["lm_head"]}
+                )
+            )
+        ),
+    )
+
+    forwarded = []
+
+    def fake_base_load_weights(self, weights):
+        forwarded.extend(weights)
+        return "loaded"
+
+    monkeypatch.setattr(
+        backend.VllmQuantInternalWorkerExtension,
+        "_is_real_quant_model",
+        lambda self: True,
+    )
+    monkeypatch.setattr(
+        backend.VllmInternalWorkerExtension,
+        "_load_weights",
+        fake_base_load_weights,
+    )
+
+    ignored_weight = torch.full_like(model.lm_head.weight, 7.0)
+    kept_weight = torch.full_like(model.keep.weight, 3.0)
+
+    assert (
+        extension._load_weights(
+            [
+                ("lm_head.weight", ignored_weight),
+                ("lm_head.weight_scale", torch.ones(1)),
+                ("keep.weight", kept_weight),
+            ]
+        )
+        == "loaded"
+    )
+
+    torch.testing.assert_close(model.lm_head.weight, ignored_weight)
+    assert [name for name, _ in forwarded] == ["keep.weight"]
+    torch.testing.assert_close(forwarded[0][1], kept_weight)
+
+
+def test_real_quant_load_weights_returns_when_only_ignored_weights(monkeypatch):
+    backend = _import_vllm_quant_backend(monkeypatch)
+    model = torch.nn.Module()
+    model.lm_head = torch.nn.Linear(2, 2, bias=False)
+    extension = object.__new__(backend.VllmQuantInternalWorkerExtension)
+    extension.model_runner = types.SimpleNamespace(
+        model=model,
+        vllm_config=types.SimpleNamespace(
+            model_config=types.SimpleNamespace(
+                hf_config=types.SimpleNamespace(
+                    quantization_config={"ignore": ["lm_head"]}
+                )
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        backend.VllmQuantInternalWorkerExtension,
+        "_is_real_quant_model",
+        lambda self: True,
+    )
+
+    assert (
+        extension._load_weights(
+            [
+                ("lm_head.weight", torch.full_like(model.lm_head.weight, 1.5)),
+                ("lm_head.weight_scale", torch.ones(1)),
+                ("lm_head.weight_scale_2", torch.ones(1)),
+            ]
+        )
+        is None
+    )
+    torch.testing.assert_close(
+        model.lm_head.weight,
+        torch.full_like(model.lm_head.weight, 1.5),
+    )
+
+
+def test_real_quant_load_weights_forwards_ignored_shape_mismatch(monkeypatch):
+    backend = _import_vllm_quant_backend(monkeypatch)
+
+    model = torch.nn.Module()
+    model.lm_head = torch.nn.Linear(2, 2, bias=False)
+    extension = object.__new__(backend.VllmQuantInternalWorkerExtension)
+    extension.model_runner = types.SimpleNamespace(
+        model=model,
+        vllm_config=types.SimpleNamespace(
+            model_config=types.SimpleNamespace(
+                hf_config=types.SimpleNamespace(
+                    quantization_config={"ignore": ["lm_head"]}
+                )
+            )
+        ),
+    )
+    forwarded = []
+
+    monkeypatch.setattr(
+        backend.VllmQuantInternalWorkerExtension,
+        "_is_real_quant_model",
+        lambda self: True,
+    )
+    monkeypatch.setattr(
+        backend.VllmInternalWorkerExtension,
+        "_load_weights",
+        lambda self, weights: forwarded.extend(weights) or "loaded",
+    )
+
+    mismatched = torch.ones(1, dtype=model.lm_head.weight.dtype)
+
+    assert extension._load_weights([("lm_head.weight", mismatched)]) == "loaded"
+    assert forwarded == [("lm_head.weight", mismatched)]
+
+
+def test_fake_quant_load_weights_exposes_input_quantizer_buffers(monkeypatch):
+    backend = _import_vllm_quant_backend(monkeypatch)
+
+    child = torch.nn.Module()
+    child.weight = torch.nn.Parameter(torch.ones(1))
+    child.register_buffer("input_quantizer_amax", torch.tensor([1.0]))
+    child.register_buffer("weight_quantizer_amax", torch.tensor([2.0]))
+    model = torch.nn.Module()
+    model.child = child
+    extension = object.__new__(backend.VllmQuantInternalWorkerExtension)
+    extension.model_runner = types.SimpleNamespace(model=model)
+    seen_names = []
+
+    def fake_base_load_weights(self, weights):
+        params = dict(child.named_parameters())
+        seen_names.extend(params)
+        params["input_quantizer_amax"].weight_loader(
+            params["input_quantizer_amax"],
+            torch.tensor([3.0]),
+        )
+        return "loaded"
+
+    monkeypatch.setattr(
+        backend.VllmQuantInternalWorkerExtension,
+        "_is_real_quant_model",
+        lambda self: False,
+    )
+    monkeypatch.setattr(
+        backend.VllmInternalWorkerExtension,
+        "_load_weights",
+        fake_base_load_weights,
+    )
+
+    assert extension._load_weights([("unused", torch.ones(1))]) == "loaded"
+
+    assert "weight" in seen_names
+    assert "input_quantizer_amax" in seen_names
+    assert "weight_quantizer_amax" not in seen_names
+    assert not hasattr(child.input_quantizer_amax, "weight_loader")
+    torch.testing.assert_close(child.input_quantizer_amax, torch.tensor([3.0]))
+
+
+def test_real_quant_collective_reload_runs_modelopt_hooks(monkeypatch):
+    backend = _import_vllm_quant_backend(monkeypatch)
+    patch_mod = pytest.importorskip(
+        "nemo_rl.modelopt.models.generation.vllm_modelopt_patch"
+    )
+
+    model = torch.nn.Linear(1, 1)
+    extension = object.__new__(backend.VllmQuantInternalWorkerExtension)
+    extension.model_runner = types.SimpleNamespace(model=model)
+    calls = []
+
+    monkeypatch.setattr(
+        backend.VllmQuantInternalWorkerExtension,
+        "_is_real_quant_model",
+        lambda self: True,
+    )
+    monkeypatch.setattr(
+        patch_mod,
+        "prepare_modelopt_for_weight_reload",
+        lambda model_arg, device: calls.append(("prepare", model_arg, device)),
+    )
+    monkeypatch.setattr(
+        patch_mod,
+        "modelopt_process_weights_after_loading",
+        lambda model_arg: calls.append(("process", model_arg)),
+    )
+    monkeypatch.setattr(
+        backend.VllmInternalWorkerExtension,
+        "update_weights_from_collective",
+        lambda self: True,
+    )
+    extension.device = torch.device("cpu")
+
+    assert extension.update_weights_from_collective() is True
+    assert calls == [
+        ("prepare", model, torch.device("cpu")),
+        ("process", model),
+    ]
+
+
+def test_real_quant_collective_reload_skips_processing_when_base_fails(monkeypatch):
+    backend = _import_vllm_quant_backend(monkeypatch)
+    patch_mod = pytest.importorskip(
+        "nemo_rl.modelopt.models.generation.vllm_modelopt_patch"
+    )
+
+    model = torch.nn.Linear(1, 1)
+    extension = object.__new__(backend.VllmQuantInternalWorkerExtension)
+    extension.model_runner = types.SimpleNamespace(model=model)
+    extension.device = torch.device("cpu")
+    calls = []
+
+    monkeypatch.setattr(
+        backend.VllmQuantInternalWorkerExtension,
+        "_is_real_quant_model",
+        lambda self: True,
+    )
+    monkeypatch.setattr(
+        patch_mod,
+        "prepare_modelopt_for_weight_reload",
+        lambda model_arg, device: calls.append(("prepare", model_arg, device)),
+    )
+    monkeypatch.setattr(
+        patch_mod,
+        "modelopt_process_weights_after_loading",
+        lambda model_arg: calls.append(("process", model_arg)),
+    )
+    monkeypatch.setattr(
+        backend.VllmInternalWorkerExtension,
+        "update_weights_from_collective",
+        lambda self: False,
+    )
+
+    assert extension.update_weights_from_collective() is False
+    assert calls == [("prepare", model, torch.device("cpu"))]
+
+
+def test_non_real_quant_collective_reload_delegates(monkeypatch):
+    backend = _import_vllm_quant_backend(monkeypatch)
+
+    extension = object.__new__(backend.VllmQuantInternalWorkerExtension)
+    monkeypatch.setattr(
+        backend.VllmQuantInternalWorkerExtension,
+        "_is_real_quant_model",
+        lambda self: False,
+    )
+    monkeypatch.setattr(
+        backend.VllmInternalWorkerExtension,
+        "update_weights_from_collective",
+        lambda self: "delegated",
+    )
+
+    assert extension.update_weights_from_collective() == "delegated"
+
+
+def test_real_quant_ipc_complete_processes_modelopt_and_acks(monkeypatch):
+    backend = _import_vllm_quant_backend(monkeypatch)
+    patch_mod = pytest.importorskip(
+        "nemo_rl.modelopt.models.generation.vllm_modelopt_patch"
+    )
+    from nemo_rl.models.policy.utils import IPCProtocol
+
+    class FakeSocket:
+        def __init__(self):
+            self.sent = []
+
+        def recv_pyobj(self):
+            return IPCProtocol.COMPLETE
+
+        def send(self, payload):
+            self.sent.append(payload)
+
+    model = torch.nn.Linear(1, 1)
+    socket = FakeSocket()
+    extension = object.__new__(backend.VllmQuantInternalWorkerExtension)
+    extension.model_runner = types.SimpleNamespace(model=model)
+    extension.device = torch.device("cpu")
+    extension.zmq_socket = socket
+    extension.maybe_init_zmq = lambda: None
+    extension._maybe_process_fp8_kv_cache = lambda: None
+    calls = []
+
+    monkeypatch.setattr(
+        backend.VllmQuantInternalWorkerExtension,
+        "_is_real_quant_model",
+        lambda self: True,
+    )
+    monkeypatch.setattr(
+        patch_mod,
+        "prepare_modelopt_for_weight_reload",
+        lambda model_arg, device: calls.append(("prepare", model_arg, device)),
+    )
+    monkeypatch.setattr(
+        patch_mod,
+        "modelopt_process_weights_after_loading",
+        lambda model_arg: calls.append(("process", model_arg)),
+    )
+    monkeypatch.setattr(backend.torch.cuda, "synchronize", lambda: calls.append("sync"))
+    monkeypatch.setattr(
+        backend.torch.cuda, "empty_cache", lambda: calls.append("empty")
+    )
+
+    assert extension.update_weights_via_ipc_zmq() is True
+    assert calls == [
+        ("prepare", model, torch.device("cpu")),
+        ("process", model),
+        "sync",
+        "empty",
+    ]
+    assert socket.sent == [IPCProtocol.ACK.value.encode()]
+
+
+def test_real_quant_ipc_payload_loads_weights_and_handles_gpt_oss(monkeypatch):
+    backend = _import_vllm_quant_backend(monkeypatch)
+    patch_mod = pytest.importorskip(
+        "nemo_rl.modelopt.models.generation.vllm_modelopt_patch"
+    )
+    from nemo_rl.models.policy.utils import IPCProtocol
+
+    payload_weight = torch.tensor([1.0, 2.0], dtype=torch.float32)
+    payload_buffer = payload_weight.view(torch.uint8)
+    used_bytes = backend.calculate_aligned_size(payload_weight.nbytes)
+    loaded = []
+    calls = []
+
+    class FakeSocket:
+        def __init__(self):
+            self.payloads = iter(
+                [
+                    ("ipc-handle", ["decoder.weight"], used_bytes),
+                    IPCProtocol.COMPLETE,
+                ]
+            )
+            self.sent = []
+
+        def recv_pyobj(self):
+            return next(self.payloads)
+
+        def send(self, payload):
+            self.sent.append(payload)
+
+    model = torch.nn.Linear(1, 1)
+    extension = object.__new__(backend.VllmQuantInternalWorkerExtension)
+    extension.model_runner = types.SimpleNamespace(
+        model=model,
+        vllm_config=types.SimpleNamespace(
+            model_config=types.SimpleNamespace(architectures=["GptOssForCausalLM"])
+        ),
+    )
+    extension.device = torch.device("cuda:0")
+    extension.zmq_socket = FakeSocket()
+    extension.state_dict_info = {"decoder.weight": ([2], torch.float32)}
+    extension.maybe_init_zmq = lambda: None
+    extension._maybe_process_fp8_kv_cache = lambda: calls.append("kv")
+    extension._load_weights = lambda weights: loaded.extend(weights)
+
+    monkeypatch.setattr(
+        backend.VllmQuantInternalWorkerExtension,
+        "_is_real_quant_model",
+        lambda self: True,
+    )
+    monkeypatch.setattr(
+        patch_mod,
+        "prepare_modelopt_for_weight_reload",
+        lambda model_arg, device: calls.append(("prepare", model_arg, device)),
+    )
+    monkeypatch.setattr(
+        patch_mod,
+        "modelopt_process_weights_after_loading",
+        lambda model_arg: calls.append(("process", model_arg)),
+    )
+    monkeypatch.setattr(
+        backend,
+        "rebuild_cuda_tensor_from_ipc",
+        lambda ipc_handle, device_index: payload_buffer,
+    )
+    monkeypatch.setattr(backend.torch.cuda, "synchronize", lambda: calls.append("sync"))
+    monkeypatch.setattr(
+        backend.torch.cuda, "empty_cache", lambda: calls.append("empty")
+    )
+    monkeypatch.setattr(backend.gc, "collect", lambda: calls.append("gc"))
+
+    assert extension.update_weights_via_ipc_zmq() is True
+
+    assert extension.zmq_socket.sent == [
+        IPCProtocol.ACK.value.encode(),
+        IPCProtocol.ACK.value.encode(),
+    ]
+    assert loaded[0][0] == "decoder.weight"
+    torch.testing.assert_close(loaded[0][1], payload_weight)
+    assert calls == [
+        ("prepare", model, torch.device("cuda:0")),
+        "sync",
+        ("process", model),
+        "sync",
+        "kv",
+        "gc",
+        "empty",
+    ]
+
+
+def test_non_real_quant_ipc_delegates(monkeypatch):
+    backend = _import_vllm_quant_backend(monkeypatch)
+
+    extension = object.__new__(backend.VllmQuantInternalWorkerExtension)
+    monkeypatch.setattr(
+        backend.VllmQuantInternalWorkerExtension,
+        "_is_real_quant_model",
+        lambda self: False,
+    )
+    monkeypatch.setattr(
+        backend.VllmInternalWorkerExtension,
+        "update_weights_via_ipc_zmq",
+        lambda self: "delegated",
+    )
+
+    assert extension.update_weights_via_ipc_zmq() == "delegated"
+
+
+def test_weight_snapshot_returns_cpu_clone_and_missing_name_raises(monkeypatch):
+    backend = _import_vllm_quant_backend(monkeypatch)
+
+    model = torch.nn.Linear(2, 1, bias=False)
+    extension = object.__new__(backend.VllmQuantInternalWorkerExtension)
+    extension.model_runner = types.SimpleNamespace(model=model)
+
+    snapshot = extension.get_weight_snapshot("weight")
+    model.weight.data.add_(1.0)
+
+    assert snapshot.device.type == "cpu"
+    assert not torch.equal(snapshot, model.weight.detach().cpu())
+    with pytest.raises(KeyError, match="missing"):
+        extension.get_weight_snapshot("missing")
+
+
+def test_get_quantizer_stats_counts_enabled_positive_amax(monkeypatch):
+    backend = _import_vllm_quant_backend(monkeypatch)
+
+    class FakeQuantizer(torch.nn.Module):
+        def __init__(self, enabled, amax):
+            super().__init__()
+            self.is_enabled = enabled
+            self.amax = amax
+
+    model = torch.nn.Module()
+    model.q_enabled_positive = FakeQuantizer(True, torch.tensor([1.0]))
+    model.q_enabled_missing = FakeQuantizer(True, None)
+    model.q_disabled_positive = FakeQuantizer(False, torch.tensor([2.0]))
+    model.q_enabled_zero = FakeQuantizer(True, torch.tensor([0.0]))
+    extension = object.__new__(backend.VllmQuantInternalWorkerExtension)
+    extension.model_runner = types.SimpleNamespace(model=model)
+    monkeypatch.setattr(backend, "TensorQuantizer", FakeQuantizer)
+
+    assert extension.get_quantizer_stats() == {
+        "total": 4,
+        "enabled": 3,
+        "with_amax": 2,
+        "positive_amax": 1,
+    }
+
+
+def test_resolve_quant_cfg_accepts_repo_relative_yaml(monkeypatch):
+    modelopt_recipe = pytest.importorskip("modelopt.recipe")
+    captured = {}
+
+    def fake_load_config(config_file):
+        captured["config_file"] = config_file
+        return {"quant_cfg": [{"name": "mock"}], "algorithm": "max"}
+
+    monkeypatch.setattr(modelopt_recipe, "load_config", fake_load_config)
+
+    assert resolve_quant_cfg("examples/modelopt/quant_configs/nvfp4_a16.yaml") == {
+        "quant_cfg": [{"name": "mock"}],
+        "algorithm": "max",
+    }
+
+    config_file = Path(captured["config_file"])
+    assert config_file.is_absolute()
+    assert config_file.name == "nvfp4_a16.yaml"
+
+
+def test_resolve_quant_cfg_accepts_builtin_modelopt_constant(monkeypatch):
+    mtq = pytest.importorskip("modelopt.torch.quantization")
+    sentinel = {"quant_cfg": [{"name": "builtin"}], "algorithm": "max"}
+    monkeypatch.setattr(mtq, "UNIT_TEST_CFG", sentinel, raising=False)
+
+    assert resolve_quant_cfg("UNIT_TEST_CFG") is sentinel
+
+
+def test_resolve_quant_cfg_extracts_nested_quantize_section(monkeypatch):
+    modelopt_recipe = pytest.importorskip("modelopt.recipe")
+
+    monkeypatch.setattr(
+        modelopt_recipe,
+        "load_config",
+        lambda config_name: {
+            "quantize": {
+                "quant_cfg": [{"name": config_name}],
+                "algorithm": "max",
+            }
+        },
+    )
+
+    assert resolve_quant_cfg("unit-test-recipe") == {
+        "quant_cfg": [{"name": "unit-test-recipe"}],
+        "algorithm": "max",
+    }
+
+
+def test_resolve_quant_cfg_rejects_unknown_config(monkeypatch):
+    modelopt_recipe = pytest.importorskip("modelopt.recipe")
+
+    def fake_load_config(config_name):
+        raise FileNotFoundError(config_name)
+
+    monkeypatch.setattr(modelopt_recipe, "load_config", fake_load_config)
+
+    with pytest.raises(ValueError, match="Unknown quant_cfg"):
+        resolve_quant_cfg("does-not-exist")
+
+
+def test_resolve_quant_cfg_rejects_recipe_without_quant_cfg(monkeypatch):
+    modelopt_recipe = pytest.importorskip("modelopt.recipe")
+    monkeypatch.setattr(modelopt_recipe, "load_config", lambda config_name: {})
+
+    with pytest.raises(ValueError, match="must contain a 'quant_cfg'"):
+        resolve_quant_cfg("missing-quant-cfg")
+
+
+def test_vllm_reload_canonicalizes_nvfp4_scales_before_kernel_conversion():
+    layer = torch.nn.Module()
+    layer.weight_scale = torch.nn.Parameter(
+        torch.tensor([[1.0, -2.0], [-0.5, 4.0]]),
+        requires_grad=False,
+    )
+
+    _canonicalize_nvfp4_weight_scale(layer)
+
+    torch.testing.assert_close(
+        layer.weight_scale,
+        torch.tensor([[1.0, 2.0], [0.5, 4.0]]),
+    )
+
+
+def test_prepare_modelopt_for_weight_reload_restores_deleted_dense_params():
+    layer = torch.nn.Module()
+    layer.weight = torch.nn.Parameter(torch.ones(2, 2), requires_grad=False)
+    layer.weight_scale = torch.nn.Parameter(torch.ones(2, 1), requires_grad=False)
+    layer._nrl_modelopt_param_meta = {
+        "weight": {
+            "shape": (2, 2),
+            "dtype": torch.float32,
+            "device": "cpu",
+            "param_class": torch.nn.Parameter,
+        },
+        "weight_scale_2": {
+            "shape": (1,),
+            "dtype": torch.float32,
+            "device": "cpu",
+            "param_class": torch.nn.Parameter,
+        },
+    }
+    layer._nrl_modelopt_weight_loaders = {}
+    model = torch.nn.Module()
+    model.layer = layer
+
+    prepare_modelopt_for_weight_reload(model, device=torch.device("cpu"))
+
+    assert hasattr(layer, "weight_scale_2")
+    assert tuple(layer.weight_scale_2.shape) == (1,)
+    assert layer.weight_scale_2.dtype == torch.float32
+    assert layer.weight_scale_2.device.type == "cpu"
+
+
+def test_prepare_modelopt_for_weight_reload_restores_loader_class_when_shape_matches():
+    class FakeModelWeightParameter(torch.nn.Parameter):
+        def __new__(cls, data, **kwargs):
+            return super().__new__(cls, data=data, requires_grad=False)
+
+        def __init__(self, data, weight_loader, input_dim=1, output_dim=0):
+            self.weight_loader = weight_loader
+            self._input_dim = input_dim
+            self._output_dim = output_dim
+
+    def fake_merged_loader(param, loaded_weight, shard_id):
+        shard_size = loaded_weight.shape[0]
+        shard_offset = shard_id * shard_size
+        param.data.narrow(0, shard_offset, shard_size).copy_(loaded_weight)
+
+    layer = torch.nn.Module()
+    layer.weight = torch.nn.Parameter(torch.zeros(4, 2), requires_grad=False)
+    layer._nrl_modelopt_param_meta = {
+        "weight": {
+            "shape": (4, 2),
+            "dtype": torch.float32,
+            "device": "cpu",
+            "param_class": FakeModelWeightParameter,
+            "input_dim": 1,
+            "output_dim": 0,
+        },
+    }
+    layer._nrl_modelopt_weight_loaders = {"weight": fake_merged_loader}
+    model = torch.nn.Module()
+    model.layer = layer
+
+    prepare_modelopt_for_weight_reload(model, device=torch.device("cpu"))
+
+    assert isinstance(layer.weight, FakeModelWeightParameter)
+    assert layer.weight.weight_loader is fake_merged_loader
+    layer.weight.data.zero_()
+    layer.weight.weight_loader(layer.weight, torch.ones(2, 2), 1)
+    torch.testing.assert_close(layer.weight[:2], torch.zeros(2, 2))
+    torch.testing.assert_close(layer.weight[2:], torch.ones(2, 2))
+
+
+def test_prepare_modelopt_for_weight_reload_restores_plain_parameter_loader():
+    def fake_loader(param, loaded_weight):
+        param.data.copy_(loaded_weight)
+
+    layer = torch.nn.Module()
+    layer.weight = torch.nn.Parameter(torch.zeros(2, 2), requires_grad=False)
+    layer._nrl_modelopt_param_meta = {
+        "weight": {
+            "shape": (2, 2),
+            "dtype": torch.float32,
+            "device": "cpu",
+            "param_class": torch.nn.Parameter,
+        },
+    }
+    layer._nrl_modelopt_weight_loaders = {"weight": fake_loader}
+    model = torch.nn.Module()
+    model.layer = layer
+
+    prepare_modelopt_for_weight_reload(model, device=torch.device("cpu"))
+
+    assert isinstance(layer.weight, torch.nn.Parameter)
+    assert layer.weight.weight_loader is fake_loader
+    layer.weight.weight_loader(layer.weight, torch.ones(2, 2))
+    torch.testing.assert_close(layer.weight, torch.ones(2, 2))
+
+
+def test_modelopt_process_weights_after_loading_runs_dense_quant_method():
+    calls = []
+
+    class ModelOptNvFp4LinearMethod:
+        def process_weights_after_loading(self, layer):
+            calls.append(layer)
+
+    model = torch.nn.Module()
+    model.layer = torch.nn.Module()
+    model.layer.quant_method = ModelOptNvFp4LinearMethod()
+
+    modelopt_process_weights_after_loading(model)
+
+    assert calls == [model.layer]
+
+
+def test_apply_modelopt_nvfp4_patches_updates_vllm_method(monkeypatch):
+    patch_mod = pytest.importorskip(
+        "nemo_rl.modelopt.models.generation.vllm_modelopt_patch"
+    )
+    module_names = [
+        "vllm",
+        "vllm.model_executor",
+        "vllm.model_executor.layers",
+        "vllm.model_executor.layers.quantization",
+    ]
+    for module_name in module_names:
+        monkeypatch.setitem(sys.modules, module_name, types.ModuleType(module_name))
+    modelopt_module = types.ModuleType(
+        "vllm.model_executor.layers.quantization.modelopt"
+    )
+
+    class FakeModelOptNvFp4LinearMethod:
+        process_weights_after_loading = None
+
+    modelopt_module.ModelOptNvFp4LinearMethod = FakeModelOptNvFp4LinearMethod
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.model_executor.layers.quantization.modelopt",
+        modelopt_module,
+    )
+    monkeypatch.setattr(patch_mod, "_patched", False)
+
+    apply_modelopt_nvfp4_patches()
+    apply_modelopt_nvfp4_patches()
+
+    assert (
+        FakeModelOptNvFp4LinearMethod.process_weights_after_loading
+        is _modelopt_dense_process_weights
+    )
+    assert patch_mod._patched is True
+
+
+def test_convert_nvfp4_linear_kernel_format_uses_vllm_fallback(monkeypatch):
+    calls = []
+    module_names = [
+        "vllm",
+        "vllm.model_executor",
+        "vllm.model_executor.layers",
+        "vllm.model_executor.layers.quantization",
+        "vllm.model_executor.layers.quantization.utils",
+    ]
+    for module_name in module_names:
+        monkeypatch.setitem(sys.modules, module_name, types.ModuleType(module_name))
+    nvfp4_utils = types.ModuleType(
+        "vllm.model_executor.layers.quantization.utils.nvfp4_utils"
+    )
+
+    def fake_convert(backend, layer):
+        calls.append((backend, layer))
+
+    nvfp4_utils.convert_to_nvfp4_linear_kernel_format = fake_convert
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.model_executor.layers.quantization.utils.nvfp4_utils",
+        nvfp4_utils,
+    )
+    layer = torch.nn.Module()
+    quant_method = types.SimpleNamespace(backend="backend")
+
+    _convert_nvfp4_linear_kernel_format(quant_method, layer)
+
+    assert calls == [("backend", layer)]
+
+
+def test_modelopt_dense_process_uses_vllm_kernel_api():
+    layer = torch.nn.Module()
+    layer.weight = torch.nn.Parameter(torch.ones(2, 1), requires_grad=False)
+    layer.weight._input_dim = 1
+    layer.weight._output_dim = 0
+    layer.weight.weight_loader = lambda param, loaded_weight: None
+    layer.weight_scale = torch.nn.Parameter(
+        torch.tensor([[1.0, -2.0], [-0.5, 4.0]]),
+        requires_grad=False,
+    )
+    layer.weight_scale_2 = torch.nn.Parameter(torch.tensor([2.0]), requires_grad=False)
+
+    calls = []
+
+    class FakeKernel:
+        def process_weights_after_loading(self, processed_layer):
+            calls.append(processed_layer)
+            torch.testing.assert_close(
+                processed_layer.weight_scale,
+                torch.tensor([[1.0, 2.0], [0.5, 4.0]]),
+            )
+
+    quant_method = types.SimpleNamespace(kernel=FakeKernel())
+
+    _modelopt_dense_process_weights(quant_method, layer)
+
+    assert calls == [layer]
+    assert not hasattr(layer, "weight_scale_2")
+    torch.testing.assert_close(layer.input_global_scale, torch.tensor(1.0))
+    torch.testing.assert_close(layer.weight_global_scale, torch.tensor(2.0))
+    torch.testing.assert_close(layer.alpha, torch.tensor(2.0))
+    torch.testing.assert_close(layer.input_global_scale_inv, torch.tensor(1.0))
+    assert set(layer._nrl_modelopt_param_meta) == {
+        "weight",
+        "weight_scale",
+        "weight_scale_2",
+    }
+    assert layer._nrl_modelopt_param_meta["weight"]["input_dim"] == 1
+    assert layer._nrl_modelopt_param_meta["weight"]["output_dim"] == 0
+    assert "weight" in layer._nrl_modelopt_weight_loaders

--- a/tests/unit/models/policy/test_megatron_quant_worker.py
+++ b/tests/unit/models/policy/test_megatron_quant_worker.py
@@ -87,7 +87,7 @@ def _make_real_quant_worker():
     worker.cfg = {
         "generation": {
             "backend": "vllm",
-            "quant_cfg": "examples/modelopt/quant_configs/nvfp4_a16.yaml",
+            "quant_cfg": "examples/modelopt/quant_configs/nvfp4_a16_mlp_only.yaml",
             "real_quant": True,
             "real_quant_ignore": ["lm_head"],
             "vllm_cfg": {},

--- a/tests/unit/models/policy/test_megatron_quant_worker.py
+++ b/tests/unit/models/policy/test_megatron_quant_worker.py
@@ -15,6 +15,7 @@
 import os
 import tempfile
 from copy import deepcopy
+from types import SimpleNamespace
 
 import pytest
 import ray
@@ -70,6 +71,36 @@ _BATCH_SIZE = 8
 _NUM_GPUS = 2
 
 
+class _FakeModelOptBridge:
+    def __init__(self):
+        self.transformer_config = SimpleNamespace(num_layers=0)
+        self.calls = []
+
+    def export_hf_weights_modelopt(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        yield "model.layers.0.mlp.down_proj.weight", torch.ones(2, 2)
+
+
+def _make_real_quant_worker():
+    worker_cls = MegatronQuantPolicyWorker.__ray_metadata__.modified_class
+    worker = object.__new__(worker_cls)
+    worker.cfg = {
+        "generation": {
+            "backend": "vllm",
+            "quant_cfg": "examples/modelopt/quant_configs/nvfp4_a16.yaml",
+            "real_quant": True,
+            "real_quant_ignore": ["lm_head"],
+            "vllm_cfg": {},
+        }
+    }
+    worker.model = object()
+    worker.draft_model = None
+    worker.refit_conversion_tasks = ["task"]
+    worker.megatron_bridge = _FakeModelOptBridge()
+    worker.rank = 0
+    return worker
+
+
 def create_quant_megatron_test_config(model_name, tp=1, pp=1, precision="float32"):
     """Wrap the base Megatron test config with quantization fields."""
     config = create_megatron_test_config(
@@ -110,6 +141,99 @@ def test_modelopt_layer_spec_config_selects_layer_specs():
     assert isinstance(layer_spec, partial)
     assert layer_spec.func is get_gpt_modelopt_spec
     assert get_quantization_mamba_stack_spec(False) is modelopt_mamba_stack_spec
+
+
+@requires_weight_folding
+def test_real_quant_refit_detection_requires_vllm_quant_cfg_and_flag():
+    worker = _make_real_quant_worker()
+
+    assert worker._use_real_quant_refit()
+
+    worker.cfg["generation"]["real_quant"] = False
+    assert not worker._use_real_quant_refit()
+
+    worker.cfg["generation"]["real_quant"] = True
+    worker.cfg["generation"]["quant_cfg"] = None
+    assert not worker._use_real_quant_refit()
+
+    worker.cfg["generation"]["quant_cfg"] = "NVFP4_DEFAULT_CFG"
+    worker.cfg["generation"]["backend"] = "megatron"
+    assert not worker._use_real_quant_refit()
+
+
+@requires_weight_folding
+def test_iter_real_quant_refit_params_uses_megatron_bridge_export():
+    worker = _make_real_quant_worker()
+
+    output = list(worker._iter_real_quant_refit_params())
+
+    assert output[0][0] == "model.layers.0.mlp.down_proj.weight"
+    args, kwargs = worker.megatron_bridge.calls[0]
+    assert args == ([worker.model],)
+    assert kwargs["quant_mode"] == "nvfp4"
+    assert kwargs["cpu"] is True
+    assert kwargs["show_progress"] is False
+    assert kwargs["conversion_tasks"] == worker.refit_conversion_tasks
+    assert kwargs["ignore_patterns"] == ["lm_head"]
+
+
+@requires_weight_folding
+def test_iter_params_with_optional_kv_scales_uses_real_quant_export(monkeypatch):
+    worker = _make_real_quant_worker()
+    monkeypatch.setattr(
+        worker,
+        "_iter_real_quant_refit_params",
+        lambda kv_scales=None: iter([("real.weight", torch.ones(1))]),
+    )
+
+    output = list(worker._iter_params_with_optional_kv_scales({"scale": 1.0}))
+
+    assert output[0][0] == "real.weight"
+    torch.testing.assert_close(output[0][1], torch.ones(1))
+
+
+@requires_weight_folding
+def test_stream_weights_via_ipc_zmq_uses_real_quant_generator(monkeypatch):
+    from nemo_rl.modelopt.models.policy.workers import megatron_quant_policy_worker
+    from nemo_rl.models.policy import utils as policy_utils
+
+    worker = _make_real_quant_worker()
+    worker.zmq_socket = object()
+    moved_model = object()
+    calls = []
+
+    monkeypatch.setattr(worker, "maybe_init_zmq", lambda: calls.append("init_zmq"))
+    monkeypatch.setattr(
+        worker,
+        "move_model",
+        lambda model, device, move_params, move_grads: moved_model,
+    )
+    monkeypatch.setattr(
+        megatron_quant_policy_worker.torch.cuda,
+        "current_stream",
+        lambda: SimpleNamespace(synchronize=lambda: calls.append("sync")),
+    )
+
+    def fake_stream_weights_via_ipc_zmq_impl(**kwargs):
+        calls.append(kwargs)
+        assert list(kwargs["params_generator"])[0][0] == (
+            "model.layers.0.mlp.down_proj.weight"
+        )
+
+    monkeypatch.setattr(
+        policy_utils,
+        "stream_weights_via_ipc_zmq_impl",
+        fake_stream_weights_via_ipc_zmq_impl,
+    )
+
+    worker.stream_weights_via_ipc_zmq(buffer_size_bytes=123, kv_scales={"scale": 1.0})
+
+    assert calls[0] == "sync"
+    assert calls[1] == "init_zmq"
+    assert worker.model is moved_model
+    assert calls[2]["buffer_size_bytes"] == 123
+    assert calls[2]["zmq_socket"] is worker.zmq_socket
+    assert calls[2]["rank"] == 0
 
 
 def _make_cluster(name):

--- a/tests/unit/models/policy/test_megatron_quant_worker.py
+++ b/tests/unit/models/policy/test_megatron_quant_worker.py
@@ -193,6 +193,60 @@ def test_iter_params_with_optional_kv_scales_uses_real_quant_export(monkeypatch)
 
 
 @requires_weight_folding
+def test_iter_params_with_optional_kv_scales_exports_input_amax(monkeypatch):
+    from nemo_rl.modelopt.models.policy.workers import megatron_quant_policy_worker
+    from nemo_rl.models.policy.workers.megatron_policy_worker import (
+        MegatronPolicyWorkerImpl,
+    )
+
+    class FakeTensorQuantizer:
+        def __init__(self, amax):
+            self.is_enabled = True
+            self._amax = amax
+
+    class FakeQuantModule:
+        def __init__(self):
+            self.input_quantizer = FakeTensorQuantizer(torch.tensor([3.0]))
+
+    worker_cls = MegatronQuantPolicyWorker.__ray_metadata__.modified_class
+    worker = object.__new__(worker_cls)
+    worker.cfg = {"generation": {"backend": "vllm", "quant_cfg": "FP8_DEFAULT_CFG"}}
+    worker.rank = 0
+    worker.refit_conversion_tasks = [
+        SimpleNamespace(
+            param_name="decoder.layers.0.mlp.linear_fc2.weight",
+            global_param_name="decoder.layers.0.mlp.linear_fc2.weight",
+            param_weight=torch.ones(2, 2),
+            megatron_module=FakeQuantModule(),
+            mapping=SimpleNamespace(
+                hf_param="model.layers.0.mlp.down_proj.weight",
+            ),
+        )
+    ]
+
+    monkeypatch.setattr(
+        megatron_quant_policy_worker,
+        "TensorQuantizer",
+        FakeTensorQuantizer,
+    )
+    monkeypatch.setattr(
+        MegatronPolicyWorkerImpl,
+        "_iter_params_with_optional_kv_scales",
+        lambda self, kv_scales=None: iter(
+            [("model.layers.0.mlp.down_proj.weight", torch.ones(2, 2))]
+        ),
+    )
+
+    output = list(worker._iter_params_with_optional_kv_scales())
+
+    assert [name for name, _ in output] == [
+        "model.layers.0.mlp.down_proj.weight",
+        "model.layers.0.mlp.down_proj.input_quantizer._amax",
+    ]
+    torch.testing.assert_close(output[1][1], torch.tensor([3.0]))
+
+
+@requires_weight_folding
 def test_stream_weights_via_ipc_zmq_uses_real_quant_generator(monkeypatch):
     from nemo_rl.modelopt.models.policy.workers import megatron_quant_policy_worker
     from nemo_rl.models.policy import utils as policy_utils

--- a/tests/unit/models/policy/test_megatron_quant_worker.py
+++ b/tests/unit/models/policy/test_megatron_quant_worker.py
@@ -170,7 +170,7 @@ def test_iter_real_quant_refit_params_uses_megatron_bridge_export():
     assert output[0][0] == "model.layers.0.mlp.down_proj.weight"
     args, kwargs = worker.megatron_bridge.calls[0]
     assert args == ([worker.model],)
-    assert kwargs["quant_mode"] == "nvfp4"
+    assert kwargs["quant_mode"] == "w4a16_nvfp4"
     assert kwargs["cpu"] is True
     assert kwargs["show_progress"] is False
     assert kwargs["conversion_tasks"] == worker.refit_conversion_tasks
@@ -247,26 +247,21 @@ def test_iter_params_with_optional_kv_scales_exports_input_amax(monkeypatch):
 
 
 @requires_weight_folding
-def test_stream_weights_via_ipc_zmq_uses_real_quant_generator(monkeypatch):
-    from nemo_rl.modelopt.models.policy.workers import megatron_quant_policy_worker
+def test_stream_weights_via_ipc_zmq_uses_real_quant_generator_without_move(
+    monkeypatch,
+):
     from nemo_rl.models.policy import utils as policy_utils
 
     worker = _make_real_quant_worker()
     worker.zmq_socket = object()
-    moved_model = object()
     calls = []
 
     monkeypatch.setattr(worker, "maybe_init_zmq", lambda: calls.append("init_zmq"))
-    monkeypatch.setattr(
-        worker,
-        "move_model",
-        lambda model, device, move_params, move_grads: moved_model,
-    )
-    monkeypatch.setattr(
-        megatron_quant_policy_worker.torch.cuda,
-        "current_stream",
-        lambda: SimpleNamespace(synchronize=lambda: calls.append("sync")),
-    )
+
+    def fail_move_model(*args, **kwargs):
+        raise AssertionError("stream_weights_via_ipc_zmq should not move the model")
+
+    monkeypatch.setattr(worker, "move_model", fail_move_model)
 
     def fake_stream_weights_via_ipc_zmq_impl(**kwargs):
         calls.append(kwargs)
@@ -282,12 +277,51 @@ def test_stream_weights_via_ipc_zmq_uses_real_quant_generator(monkeypatch):
 
     worker.stream_weights_via_ipc_zmq(buffer_size_bytes=123, kv_scales={"scale": 1.0})
 
-    assert calls[0] == "sync"
-    assert calls[1] == "init_zmq"
-    assert worker.model is moved_model
-    assert calls[2]["buffer_size_bytes"] == 123
-    assert calls[2]["zmq_socket"] is worker.zmq_socket
-    assert calls[2]["rank"] == 0
+    assert calls[0] == "init_zmq"
+    assert calls[1]["buffer_size_bytes"] == 123
+    assert calls[1]["zmq_socket"] is worker.zmq_socket
+    assert calls[1]["rank"] == 0
+
+
+@requires_weight_folding
+def test_stream_weights_via_ipc_zmq_does_not_move_without_real_quant(monkeypatch):
+    from nemo_rl.models.policy import utils as policy_utils
+
+    worker = _make_real_quant_worker()
+    worker.cfg["generation"]["real_quant"] = False
+    worker.zmq_socket = object()
+    calls = []
+
+    monkeypatch.setattr(worker, "maybe_init_zmq", lambda: calls.append("init_zmq"))
+
+    def fail_move_model(*args, **kwargs):
+        raise AssertionError("stream_weights_via_ipc_zmq should not move the model")
+
+    monkeypatch.setattr(worker, "move_model", fail_move_model)
+    monkeypatch.setattr(
+        worker,
+        "_iter_params_with_optional_kv_scales",
+        lambda kv_scales=None: iter([("model.weight", torch.ones(1))]),
+    )
+
+    def fake_stream_weights_via_ipc_zmq_impl(**kwargs):
+        calls.append(kwargs)
+        params = list(kwargs["params_generator"])
+        assert params[0][0] == "model.weight"
+        torch.testing.assert_close(params[0][1], torch.ones(1))
+
+    monkeypatch.setattr(
+        policy_utils,
+        "stream_weights_via_ipc_zmq_impl",
+        fake_stream_weights_via_ipc_zmq_impl,
+    )
+
+    worker.stream_weights_via_ipc_zmq(buffer_size_bytes=123, kv_scales={"scale": 1.0})
+
+    assert calls[0] == "init_zmq"
+    assert calls[1]["buffer_size_bytes"] == 123
+    assert calls[1]["zmq_socket"] is worker.zmq_socket
+    assert calls[1]["rank"] == 0
 
 
 def _make_cluster(name):

--- a/tests/unit/models/policy/test_modelopt_worker_utils.py
+++ b/tests/unit/models/policy/test_modelopt_worker_utils.py
@@ -51,9 +51,10 @@ def _ensure_module(name):
 def _install_optional_dependency_stubs():
     modelopt_quant = _ensure_package("modelopt.torch.quantization")
     modelopt_quant.quantize = lambda model, cfg, forward_loop: model
+    modelopt_quant.print_quant_summary = lambda model: None
 
     modelopt_config = _ensure_module("modelopt.torch.quantization.config")
-    modelopt_config.normalize_quant_cfg_list = lambda quant_cfg: quant_cfg
+    modelopt_config.need_calibration = lambda cfg: False
 
     dataset_utils = _ensure_module("modelopt.torch.utils.dataset_utils")
     dataset_utils.create_forward_loop = lambda dataloader: (
@@ -119,56 +120,11 @@ def test_get_tokenizer_applies_modelopt_calibration_defaults(monkeypatch):
     assert tokenizer.model_max_length == 128
 
 
-def test_pad_or_truncate_input_ids_truncates_then_pads_to_multiple():
-    input_ids = torch.tensor([[1, 2, 3, 4, 5]])
-
-    output = worker_utils._pad_or_truncate_input_ids(
-        input_ids,
-        max_length=3,
-        multiple=4,
-        pad_token_id=0,
-    )
-
-    torch.testing.assert_close(output, torch.tensor([[1, 2, 3, 0]]))
-    assert output.is_contiguous()
-
-
-def test_pad_or_truncate_input_ids_returns_contiguous_without_padding():
-    input_ids = torch.tensor([[1, 2, 3, 4]])
-    transposed = input_ids.t()
-
-    output = worker_utils._pad_or_truncate_input_ids(
-        transposed,
-        multiple=1,
-        pad_token_id=0,
-    )
-
-    torch.testing.assert_close(output, transposed)
-    assert output.is_contiguous()
-
-
-def test_pad_or_truncate_input_ids_skips_padding_when_already_aligned():
-    input_ids = torch.tensor([[1, 2, 3, 4]])
-
-    output = worker_utils._pad_or_truncate_input_ids(input_ids, multiple=4)
-
-    torch.testing.assert_close(output, input_ids)
-    assert output.is_contiguous()
-
-
-def test_megatron_forward_loop_pads_for_context_parallel(monkeypatch):
+def test_megatron_forward_loop_prefills_batch_input_ids(monkeypatch):
     seen = []
     dataloader = DataLoader(
         worker_utils._DictDataset({"input_ids": torch.tensor([[1, 2, 3]])}),
         batch_size=1,
-    )
-
-    from megatron.core import parallel_state
-
-    monkeypatch.setattr(
-        parallel_state,
-        "get_context_parallel_world_size",
-        lambda: 2,
     )
     monkeypatch.setattr(
         worker_utils,
@@ -182,71 +138,8 @@ def test_megatron_forward_loop_pads_for_context_parallel(monkeypatch):
     loop("model")
 
     assert seen[0][0] == "model"
-    torch.testing.assert_close(seen[0][1], torch.tensor([[1, 2, 3, 0]]))
+    torch.testing.assert_close(seen[0][1], torch.tensor([[1, 2, 3]]))
     assert seen[0][2] is True
-
-
-@pytest.mark.parametrize(
-    ("entries", "expected"),
-    [
-        ([{"quantizer_name": "*weight_quantizer", "cfg": {}}], False),
-        ([{"quantizer_name": "*input_quantizer", "cfg": {"enable": False}}], False),
-        ([{"quantizer_name": "*input_quantizer", "cfg": {"type": "dynamic"}}], False),
-        (
-            [
-                {
-                    "quantizer_name": "*input_quantizer",
-                    "cfg": {"use_constant_amax": True},
-                }
-            ],
-            False,
-        ),
-        ([{"quantizer_name": "*input_quantizer", "cfg": {}}], True),
-        (
-            [
-                {
-                    "quantizer_name": "*input_quantizer",
-                    "cfg": [{"enable": False}, {"enable": True}],
-                }
-            ],
-            True,
-        ),
-    ],
-)
-def test_requires_forward_calibration_for_activation_quantizers(
-    monkeypatch,
-    entries,
-    expected,
-):
-    monkeypatch.setattr(
-        worker_utils,
-        "normalize_quant_cfg_list",
-        lambda quant_cfg: entries,
-    )
-
-    assert (
-        worker_utils._requires_forward_calibration({"quant_cfg": entries}) is expected
-    )
-
-
-def test_requires_forward_calibration_for_non_max_algorithm():
-    assert worker_utils._requires_forward_calibration({"algorithm": "smoothquant"})
-
-
-def test_requires_forward_calibration_honors_entry_level_disable(monkeypatch):
-    monkeypatch.setattr(
-        worker_utils,
-        "normalize_quant_cfg_list",
-        lambda quant_cfg: [
-            {
-                "quantizer_name": "*input_quantizer",
-                "enable": False,
-                "cfg": {},
-            }
-        ],
-    )
-
-    assert not worker_utils._requires_forward_calibration({"quant_cfg": [{}]})
 
 
 def test_quantize_model_skips_forward_loop_for_weight_only_config(monkeypatch):
@@ -258,16 +151,16 @@ def test_quantize_model_skips_forward_loop_for_weight_only_config(monkeypatch):
         "resolve_quant_cfg",
         lambda quant_cfg: {"quant_cfg": [{"name": quant_cfg}]},
     )
-    monkeypatch.setattr(
-        worker_utils, "_requires_forward_calibration", lambda cfg: False
-    )
+    monkeypatch.setattr(worker_utils, "need_calibration", lambda cfg: False)
     monkeypatch.setattr(
         worker_utils.mtq,
         "quantize",
         lambda model_arg, cfg, forward_loop: calls.append(
             (model_arg, cfg, forward_loop)
-        ),
+        )
+        or model_arg,
     )
+    monkeypatch.setattr(worker_utils.mtq, "print_quant_summary", lambda model: None)
 
     worker_utils.quantize_model(
         model,
@@ -284,7 +177,7 @@ def test_quantize_model_skips_forward_loop_for_weight_only_config(monkeypatch):
 def test_quantize_model_requires_calibration_data(monkeypatch):
     model = torch.nn.Linear(1, 1)
     monkeypatch.setattr(worker_utils, "resolve_quant_cfg", lambda quant_cfg: {})
-    monkeypatch.setattr(worker_utils, "_requires_forward_calibration", lambda cfg: True)
+    monkeypatch.setattr(worker_utils, "need_calibration", lambda cfg: True)
 
     with pytest.raises(ValueError, match="policy.quant_calib_data"):
         worker_utils.quantize_model(
@@ -301,7 +194,7 @@ def test_quantize_model_uses_random_calibration_loop(monkeypatch):
     calls = []
 
     monkeypatch.setattr(worker_utils, "resolve_quant_cfg", lambda quant_cfg: {})
-    monkeypatch.setattr(worker_utils, "_requires_forward_calibration", lambda cfg: True)
+    monkeypatch.setattr(worker_utils, "need_calibration", lambda cfg: True)
     monkeypatch.setattr(
         worker_utils,
         "get_forward_loop_func",
@@ -314,8 +207,9 @@ def test_quantize_model_uses_random_calibration_loop(monkeypatch):
     monkeypatch.setattr(
         worker_utils.mtq,
         "quantize",
-        lambda model_arg, cfg, forward_loop: calls.append(forward_loop),
+        lambda model_arg, cfg, forward_loop: calls.append(forward_loop) or model_arg,
     )
+    monkeypatch.setattr(worker_utils.mtq, "print_quant_summary", lambda model: None)
 
     worker_utils.quantize_model(
         model,
@@ -338,7 +232,7 @@ def test_quantize_model_uses_named_calibration_dataset(monkeypatch):
     calls = []
 
     monkeypatch.setattr(worker_utils, "resolve_quant_cfg", lambda quant_cfg: {})
-    monkeypatch.setattr(worker_utils, "_requires_forward_calibration", lambda cfg: True)
+    monkeypatch.setattr(worker_utils, "need_calibration", lambda cfg: True)
     monkeypatch.setattr(
         worker_utils,
         "get_dataset_dataloader",
@@ -358,8 +252,10 @@ def test_quantize_model_uses_named_calibration_dataset(monkeypatch):
         "quantize",
         lambda model_arg, cfg, forward_loop: calls.append(
             ("quantize", model_arg, cfg, forward_loop)
-        ),
+        )
+        or model_arg,
     )
+    monkeypatch.setattr(worker_utils.mtq, "print_quant_summary", lambda model: None)
 
     worker_utils.quantize_model(
         model,
@@ -412,18 +308,14 @@ def test_get_modelopt_checkpoint_dir_falls_back_to_home(monkeypatch):
     )
 
 
-def test_get_quantization_layer_spec_can_be_disabled(monkeypatch):
-    monkeypatch.setenv("DISABLE_MODELOPT_LAYER_SPEC", "1")
-
-    assert worker_utils.get_quantization_layer_spec() is (
+def test_get_quantization_layer_spec_can_be_disabled():
+    assert worker_utils.get_quantization_layer_spec(True) is (
         worker_utils.transformer_engine_layer_spec
     )
 
 
-def test_get_quantization_layer_spec_returns_modelopt_partial(monkeypatch):
-    monkeypatch.delenv("DISABLE_MODELOPT_LAYER_SPEC", raising=False)
-
-    layer_spec = worker_utils.get_quantization_layer_spec()
+def test_get_quantization_layer_spec_returns_modelopt_partial():
+    layer_spec = worker_utils.get_quantization_layer_spec(False)
 
     assert isinstance(layer_spec, partial)
     assert layer_spec.func is worker_utils.get_gpt_modelopt_spec

--- a/tests/unit/models/policy/test_modelopt_worker_utils.py
+++ b/tests/unit/models/policy/test_modelopt_worker_utils.py
@@ -1,0 +1,430 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import os
+import sys
+import types
+from functools import partial
+
+import pytest
+import torch
+from torch.utils.data import DataLoader
+
+
+def _ensure_package(name):
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        module.__path__ = []
+        sys.modules[name] = module
+    parent_name, _, child_name = name.rpartition(".")
+    if parent_name:
+        parent = _ensure_package(parent_name)
+        setattr(parent, child_name, module)
+    return module
+
+
+def _ensure_module(name):
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+    parent_name, _, child_name = name.rpartition(".")
+    if parent_name:
+        parent = _ensure_package(parent_name)
+        setattr(parent, child_name, module)
+    return module
+
+
+def _install_optional_dependency_stubs():
+    modelopt_quant = _ensure_package("modelopt.torch.quantization")
+    modelopt_quant.quantize = lambda model, cfg, forward_loop: model
+
+    modelopt_config = _ensure_module("modelopt.torch.quantization.config")
+    modelopt_config.normalize_quant_cfg_list = lambda quant_cfg: quant_cfg
+
+    dataset_utils = _ensure_module("modelopt.torch.utils.dataset_utils")
+    dataset_utils.create_forward_loop = lambda dataloader: (
+        lambda model: [model(batch) for batch in dataloader]
+    )
+    dataset_utils.get_dataset_dataloader = lambda **kwargs: DataLoader(
+        _SimpleDataset({"input_ids": torch.ones(1, 1, dtype=torch.long)}),
+        batch_size=1,
+    )
+
+    plugins = _ensure_module("modelopt.torch.utils.plugins")
+    plugins.megatron_prefill = lambda model, input_ids, skip_return_logits: None
+
+    gpt_provider = _ensure_module("megatron.bridge.models.gpt_provider")
+    gpt_provider.transformer_engine_layer_spec = object()
+
+    mamba_provider = _ensure_module("megatron.bridge.models.mamba.mamba_provider")
+    mamba_provider.modelopt_mamba_stack_spec = object()
+    mamba_provider.transformer_engine_mamba_stack_spec = object()
+
+    model_specs = _ensure_module("megatron.core.post_training.modelopt.gpt.model_specs")
+
+    def fake_gpt_modelopt_spec(**kwargs):
+        return kwargs
+
+    model_specs.get_gpt_modelopt_spec = fake_gpt_modelopt_spec
+
+    parallel_state = _ensure_module("megatron.core.parallel_state")
+    parallel_state.get_context_parallel_world_size = lambda: 1
+
+
+class _SimpleDataset(torch.utils.data.Dataset):
+    def __init__(self, data):
+        self.data = data
+
+    def __getitem__(self, idx):
+        return {key: val[idx] for key, val in self.data.items()}
+
+    def __len__(self):
+        return len(next(iter(self.data.values())))
+
+
+try:
+    worker_utils = importlib.import_module(
+        "nemo_rl.modelopt.models.policy.workers.utils"
+    )
+except ImportError:
+    _install_optional_dependency_stubs()
+    sys.modules.pop("nemo_rl.modelopt.models.policy.workers.utils", None)
+    worker_utils = importlib.import_module(
+        "nemo_rl.modelopt.models.policy.workers.utils"
+    )
+
+
+def test_get_tokenizer_applies_modelopt_calibration_defaults(monkeypatch):
+    tokenizer = types.SimpleNamespace(padding_side="right", model_max_length=0)
+    monkeypatch.setattr(worker_utils, "_base_get_tokenizer", lambda cfg: tokenizer)
+
+    result = worker_utils.get_tokenizer("checkpoint-path", max_seq_len=128)
+
+    assert result is tokenizer
+    assert tokenizer.padding_side == "left"
+    assert tokenizer.model_max_length == 128
+
+
+def test_pad_or_truncate_input_ids_truncates_then_pads_to_multiple():
+    input_ids = torch.tensor([[1, 2, 3, 4, 5]])
+
+    output = worker_utils._pad_or_truncate_input_ids(
+        input_ids,
+        max_length=3,
+        multiple=4,
+        pad_token_id=0,
+    )
+
+    torch.testing.assert_close(output, torch.tensor([[1, 2, 3, 0]]))
+    assert output.is_contiguous()
+
+
+def test_pad_or_truncate_input_ids_returns_contiguous_without_padding():
+    input_ids = torch.tensor([[1, 2, 3, 4]])
+    transposed = input_ids.t()
+
+    output = worker_utils._pad_or_truncate_input_ids(
+        transposed,
+        multiple=1,
+        pad_token_id=0,
+    )
+
+    torch.testing.assert_close(output, transposed)
+    assert output.is_contiguous()
+
+
+def test_pad_or_truncate_input_ids_skips_padding_when_already_aligned():
+    input_ids = torch.tensor([[1, 2, 3, 4]])
+
+    output = worker_utils._pad_or_truncate_input_ids(input_ids, multiple=4)
+
+    torch.testing.assert_close(output, input_ids)
+    assert output.is_contiguous()
+
+
+def test_megatron_forward_loop_pads_for_context_parallel(monkeypatch):
+    seen = []
+    dataloader = DataLoader(
+        worker_utils._DictDataset({"input_ids": torch.tensor([[1, 2, 3]])}),
+        batch_size=1,
+    )
+
+    from megatron.core import parallel_state
+
+    monkeypatch.setattr(
+        parallel_state,
+        "get_context_parallel_world_size",
+        lambda: 2,
+    )
+    monkeypatch.setattr(
+        worker_utils,
+        "megatron_prefill",
+        lambda model, input_ids, skip_return_logits: seen.append(
+            (model, input_ids.clone(), skip_return_logits)
+        ),
+    )
+
+    loop = worker_utils.get_forward_loop_func(True, dataloader)
+    loop("model")
+
+    assert seen[0][0] == "model"
+    torch.testing.assert_close(seen[0][1], torch.tensor([[1, 2, 3, 0]]))
+    assert seen[0][2] is True
+
+
+@pytest.mark.parametrize(
+    ("entries", "expected"),
+    [
+        ([{"quantizer_name": "*weight_quantizer", "cfg": {}}], False),
+        ([{"quantizer_name": "*input_quantizer", "cfg": {"enable": False}}], False),
+        ([{"quantizer_name": "*input_quantizer", "cfg": {"type": "dynamic"}}], False),
+        (
+            [
+                {
+                    "quantizer_name": "*input_quantizer",
+                    "cfg": {"use_constant_amax": True},
+                }
+            ],
+            False,
+        ),
+        ([{"quantizer_name": "*input_quantizer", "cfg": {}}], True),
+        (
+            [
+                {
+                    "quantizer_name": "*input_quantizer",
+                    "cfg": [{"enable": False}, {"enable": True}],
+                }
+            ],
+            True,
+        ),
+    ],
+)
+def test_requires_forward_calibration_for_activation_quantizers(
+    monkeypatch,
+    entries,
+    expected,
+):
+    monkeypatch.setattr(
+        worker_utils,
+        "normalize_quant_cfg_list",
+        lambda quant_cfg: entries,
+    )
+
+    assert (
+        worker_utils._requires_forward_calibration({"quant_cfg": entries}) is expected
+    )
+
+
+def test_requires_forward_calibration_for_non_max_algorithm():
+    assert worker_utils._requires_forward_calibration({"algorithm": "smoothquant"})
+
+
+def test_requires_forward_calibration_honors_entry_level_disable(monkeypatch):
+    monkeypatch.setattr(
+        worker_utils,
+        "normalize_quant_cfg_list",
+        lambda quant_cfg: [
+            {
+                "quantizer_name": "*input_quantizer",
+                "enable": False,
+                "cfg": {},
+            }
+        ],
+    )
+
+    assert not worker_utils._requires_forward_calibration({"quant_cfg": [{}]})
+
+
+def test_quantize_model_skips_forward_loop_for_weight_only_config(monkeypatch):
+    model = torch.nn.Linear(1, 1)
+    calls = []
+
+    monkeypatch.setattr(
+        worker_utils,
+        "resolve_quant_cfg",
+        lambda quant_cfg: {"quant_cfg": [{"name": quant_cfg}]},
+    )
+    monkeypatch.setattr(
+        worker_utils, "_requires_forward_calibration", lambda cfg: False
+    )
+    monkeypatch.setattr(
+        worker_utils.mtq,
+        "quantize",
+        lambda model_arg, cfg, forward_loop: calls.append(
+            (model_arg, cfg, forward_loop)
+        ),
+    )
+
+    worker_utils.quantize_model(
+        model,
+        "NVFP4_DEFAULT_CFG",
+        tokenizer=None,
+        calib_size=8,
+    )
+
+    assert calls == [
+        (model, {"quant_cfg": [{"name": "NVFP4_DEFAULT_CFG"}]}, None),
+    ]
+
+
+def test_quantize_model_requires_calibration_data(monkeypatch):
+    model = torch.nn.Linear(1, 1)
+    monkeypatch.setattr(worker_utils, "resolve_quant_cfg", lambda quant_cfg: {})
+    monkeypatch.setattr(worker_utils, "_requires_forward_calibration", lambda cfg: True)
+
+    with pytest.raises(ValueError, match="policy.quant_calib_data"):
+        worker_utils.quantize_model(
+            model,
+            "activation-cfg",
+            tokenizer=None,
+            calib_size=8,
+            data=None,
+        )
+
+
+def test_quantize_model_uses_random_calibration_loop(monkeypatch):
+    model = torch.nn.Linear(1, 1)
+    calls = []
+
+    monkeypatch.setattr(worker_utils, "resolve_quant_cfg", lambda quant_cfg: {})
+    monkeypatch.setattr(worker_utils, "_requires_forward_calibration", lambda cfg: True)
+    monkeypatch.setattr(
+        worker_utils,
+        "get_forward_loop_func",
+        lambda is_megatron, dataloader: (
+            "loop",
+            is_megatron,
+            len(dataloader.dataset),
+        ),
+    )
+    monkeypatch.setattr(
+        worker_utils.mtq,
+        "quantize",
+        lambda model_arg, cfg, forward_loop: calls.append(forward_loop),
+    )
+
+    worker_utils.quantize_model(
+        model,
+        "activation-cfg",
+        tokenizer=None,
+        calib_size=8,
+        is_megatron=True,
+        data="random",
+    )
+
+    assert calls == [("loop", True, 1)]
+
+
+def test_quantize_model_uses_named_calibration_dataset(monkeypatch):
+    model = torch.nn.Linear(1, 1)
+    dataset = worker_utils._DictDataset(
+        {"input_ids": torch.ones(2, 3, dtype=torch.long)}
+    )
+    dataloader = DataLoader(dataset, batch_size=2)
+    calls = []
+
+    monkeypatch.setattr(worker_utils, "resolve_quant_cfg", lambda quant_cfg: {})
+    monkeypatch.setattr(worker_utils, "_requires_forward_calibration", lambda cfg: True)
+    monkeypatch.setattr(
+        worker_utils,
+        "get_dataset_dataloader",
+        lambda **kwargs: calls.append(("dataset", kwargs)) or dataloader,
+    )
+    monkeypatch.setattr(
+        worker_utils,
+        "get_forward_loop_func",
+        lambda is_megatron, calib_dataloader: (
+            "loop",
+            is_megatron,
+            calib_dataloader,
+        ),
+    )
+    monkeypatch.setattr(
+        worker_utils.mtq,
+        "quantize",
+        lambda model_arg, cfg, forward_loop: calls.append(
+            ("quantize", model_arg, cfg, forward_loop)
+        ),
+    )
+
+    worker_utils.quantize_model(
+        model,
+        "activation-cfg",
+        tokenizer="tokenizer",
+        calib_size=8,
+        batch_size=4,
+        data="cnn_dailymail",
+        max_sample_length=16,
+    )
+
+    assert calls[0] == (
+        "dataset",
+        {
+            "dataset_name": "cnn_dailymail",
+            "tokenizer": "tokenizer",
+            "batch_size": 4,
+            "num_samples": 8,
+            "device": model.weight.device,
+            "include_labels": False,
+            "max_sample_length": 16,
+        },
+    )
+    assert calls[1] == ("quantize", model, {}, ("loop", False, dataloader))
+
+
+def test_get_modelopt_checkpoint_dir_env_precedence(monkeypatch):
+    monkeypatch.setenv("NRL_MODELOPT_CHECKPOINT_DIR", "/custom/modelopt")
+    monkeypatch.setenv("HF_HOME", "/hf/home")
+
+    assert worker_utils.get_modelopt_checkpoint_dir() == "/custom/modelopt"
+
+
+def test_get_modelopt_checkpoint_dir_uses_hf_home(monkeypatch):
+    monkeypatch.delenv("NRL_MODELOPT_CHECKPOINT_DIR", raising=False)
+    monkeypatch.setenv("HF_HOME", "/hf/home")
+
+    assert worker_utils.get_modelopt_checkpoint_dir() == os.path.join(
+        "/hf/home", "nemo_rl"
+    )
+
+
+def test_get_modelopt_checkpoint_dir_falls_back_to_home(monkeypatch):
+    monkeypatch.delenv("NRL_MODELOPT_CHECKPOINT_DIR", raising=False)
+    monkeypatch.delenv("HF_HOME", raising=False)
+    monkeypatch.setattr(worker_utils.os.path, "expanduser", lambda path: "/home/test")
+
+    assert worker_utils.get_modelopt_checkpoint_dir() == os.path.join(
+        "/home/test", ".cache", "huggingface", "nemo_rl"
+    )
+
+
+def test_get_quantization_layer_spec_can_be_disabled(monkeypatch):
+    monkeypatch.setenv("DISABLE_MODELOPT_LAYER_SPEC", "1")
+
+    assert worker_utils.get_quantization_layer_spec() is (
+        worker_utils.transformer_engine_layer_spec
+    )
+
+
+def test_get_quantization_layer_spec_returns_modelopt_partial(monkeypatch):
+    monkeypatch.delenv("DISABLE_MODELOPT_LAYER_SPEC", raising=False)
+
+    layer_spec = worker_utils.get_quantization_layer_spec()
+
+    assert isinstance(layer_spec, partial)
+    assert layer_spec.func is worker_utils.get_gpt_modelopt_spec
+    assert layer_spec.keywords["real_quant_cfg"] == "None"

--- a/tests/unit/models/policy/test_utils.py
+++ b/tests/unit/models/policy/test_utils.py
@@ -122,6 +122,94 @@ class TestGetMegatronCheckpointDir:
             assert result == expected_dir
 
 
+class _FakeIpcSocket:
+    def __init__(self):
+        self.sent = []
+
+    def send_pyobj(self, payload):
+        self.sent.append(payload)
+
+    def recv(self):
+        return b""
+
+    def getsockopt(self, _option):
+        return 0
+
+
+def test_stream_weights_via_ipc_zmq_uses_cuda_buffer_for_cpu_tensors(monkeypatch):
+    """CPU-exported tensors should still be packed into CUDA IPC buffers."""
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for CUDA IPC buffer allocation")
+
+    tensor = torch.ones(4, dtype=torch.float32)
+    captured = {}
+
+    def fake_get_handle_from_tensor(tensor):
+        captured["buffer_device"] = tensor.device
+        return ("ipc-handle",)
+
+    monkeypatch.setattr(
+        "nemo_rl.models.policy.utils.get_handle_from_tensor",
+        fake_get_handle_from_tensor,
+    )
+
+    socket = _FakeIpcSocket()
+    stream_weights_via_ipc_zmq_impl(
+        params_generator=iter([("weight", tensor)]),
+        buffer_size_bytes=4096,
+        zmq_socket=socket,
+        rank=0,
+        worker_name="test_worker",
+    )
+
+    assert captured["buffer_device"].type == "cuda"
+    payload = socket.sent[0]
+    assert payload[0] == ("ipc-handle",)
+    assert payload[1] == ["weight"]
+    assert payload[2] == calculate_aligned_size(tensor.nbytes)
+    assert socket.sent[-1] == IPCProtocol.COMPLETE
+
+
+def test_stream_weights_via_ipc_zmq_aligns_cpu_tensor_groups(monkeypatch):
+    """CPU-exported tensor groups report aligned byte offsets."""
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for CUDA IPC buffer allocation")
+
+    tensors = [
+        ("weight", torch.ones(4, dtype=torch.float32)),
+        ("bias", torch.ones(3, dtype=torch.float16)),
+    ]
+    captured = {}
+
+    def fake_get_handle_from_tensor(tensor):
+        captured["buffer_device"] = tensor.device
+        return ("ipc-handle",)
+
+    monkeypatch.setattr(
+        "nemo_rl.models.policy.utils.get_handle_from_tensor",
+        fake_get_handle_from_tensor,
+    )
+
+    socket = _FakeIpcSocket()
+    stream_weights_via_ipc_zmq_impl(
+        params_generator=iter(tensors),
+        buffer_size_bytes=4096,
+        zmq_socket=socket,
+        rank=0,
+        worker_name="test_worker",
+    )
+
+    assert captured["buffer_device"].type == "cuda"
+    payload = socket.sent[0]
+    assert payload[1] == ["weight", "bias"]
+    assert payload[2] == sum(
+        calculate_aligned_size(tensor.nbytes) for _, tensor in tensors
+    )
+    assert socket.sent[-1] == IPCProtocol.COMPLETE
+
+
 def server_process(
     zmq_addr: str,
     known_tensors: list[tuple[str, torch.Tensor]],


### PR DESCRIPTION
# What does this PR do ?

Support QAT rollout real quant for ModelOpt NVFP4 W4A16.

This PR adds the real-quant rollout path for vLLM + Megatron QAT, including:
- exporting packed NVFP4 weights and scale tensors from Megatron policy workers, now this is at https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/4102
- configuring vLLM with ModelOpt `quantization_config` for W4A16
- patching vLLM ModelOpt NVFP4 reload handling for rollout refits
- supporting real-quant generation config knobs: `real_quant`, `real_quant_mode`, `real_quant_group_size`, and `real_quant_ignore`
- adding Qwen3-8B DAPO recipe variants for W4A16
- adding unit coverage for vLLM ModelOpt NVFP4 config and exporter behavior

# Issues

N/A

# Usage

```yaml
policy:
  quant_cfg: examples/modelopt/quant_configs/nvfp4_a16.yaml
  generation:
    quant_cfg: examples/modelopt/quant_configs/nvfp4_a16.yaml
    real_quant: true
```

Example recipes:
```bash
uv run ./examples/run_grpo.py \
  --config examples/configs/recipes/llm/grpo-qwen3-8b-base-dapo-2n8g-long-megatron-qa-nvfp4-w4a16.yaml
```

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

Adds `tests/unit/models/generation/test_vllm_modelopt_real_quant_config.py` for focused regression coverage.

# Experiment results
<img width="948" height="600" alt="image" src="https://github.com/user-attachments/assets/59d40c00-ab4d-4e79-a063-893cc78d42e7" />
<img width="938" height="568" alt="image" src="https://github.com/user-attachments/assets/59ed1ab4-9510-4755-891f-8028fe2574c8" />
<img width="922" height="552" alt="image" src="https://github.com/user-attachments/assets/4b2cb802-2307-46bd-b8e5-1c2e94c0f5da" />
<img width="932" height="558" alt="image" src="https://github.com/user-attachments/assets/534c98ad-8c82-461a-9a11-72bfe1da678f" />

