### PR TITLE
ci: add NVSkills CI workflow for skill signing

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -1,0 +1,22 @@
+name: Request NVSkills CI
+
+on:
+  issue_comment:
+    types: [created]
+  push:
+
+jobs:
+  request:
+    if: >
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/nvskills-ci')) ||
+      (github.event_name == 'push' &&
+        github.actor == (vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-skills-ci[bot]') &&
+        startsWith(github.event.head_commit.message, vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures'))
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: NVIDIA/skills/.github/workflows/team-request.yml@main
+    secrets:
+      NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/request-nvskills-ci.yml` from [NVIDIA/skills](https://github.com/NVIDIA/skills/blob/main/.github/workflows/request-nvskills-ci.yml)
- Enables NV-CARPS skill signing by commenting `/nvskills-ci` on PRs
- Also triggers automatically when the `nv-skills-ci[bot]` pushes signature commits

## Prerequisites
- The `NVSKILLS_CI_DISPATCH_TOKEN` secret must be configured in the repo settings
- Optionally set `NVSKILLS_SIGNATURE_PUSH_ACTOR` and `NVSKILLS_SIGNATURE_COMMIT_TITLE` repo variables if defaults need overriding

## Test plan
- [ ] Verify `NVSKILLS_CI_DISPATCH_TOKEN` secret is set in repo settings
- [ ] Open a test PR with a skill change and comment `/nvskills-ci` to confirm the workflow triggers