### PR TITLE
refactor: handle GDPO multi-reward by dict instead of positional list

### DIFF
--- a/docs/guides/environments.md
+++ b/docs/guides/environments.md
@@ -41,27 +41,30 @@ Therefore, the return batch of `run_multi_turn_rollout` in rollouts.py would hav
 # Add total rewards to the final batch
 current_batch["total_reward"] = total_rewards
 current_batch["truncated"] = sample_truncated
-# Expose per-component rewards (reward1, reward2, ...) for multi-reward envs only; GRPO uses total_reward
+# Expose per-component rewards for multi-reward envs (e.g. GDPO advantage calculation).
 if multi_rewards is not None:
-    num_reward_components = multi_rewards.shape[1]
-    for i in range(num_reward_components):
-        current_batch[f"reward{i + 1}"] = multi_rewards[:, i].clone()
+    for name, reward_tensor in multi_rewards.items():
+        current_batch[name] = reward_tensor
 ```
 
 ### Multi-reward support (GDPO)
 
-Environments can expose a **single reward** (standard GRPO) or **multiple reward components** (for GDPO).
+Environments can expose a **single reward** (standard GRPO) or **multiple named reward components** (for GDPO).
 
-- **Single-reward**: Your env’s `step` returns `rewards` with shape `(batch_size,)`. The rollout stores only `total_reward`. Use `grpo.adv_estimator.name: "grpo"` (default).
-- **Multi-reward**: Your env’s `step` returns `rewards` with shape `(batch_size, num_components)` (e.g. one column per objective). The rollout stores `total_reward` (sum across components) and per-component keys `reward1`, `reward2`, … so GDPO can compute per-component baselines and combine advantages.
+- **Single-reward**: Your env’s `step` returns `rewards` as a `Tensor` of shape `(batch_size,)`. The rollout stores only `total_reward`. Use `grpo.adv_estimator.name: "grpo"` (default).
+- **Multi-reward**: Your env’s `step` returns `rewards` as a `dict[str, Tensor]` mapping component names to per-sample tensors of shape `(batch_size,)`. Each key must use the `reward/` prefix (e.g. `reward/correctness`). The rollout stores `total_reward` (sum across components) and each named component so GDPO can compute per-component baselines and combine advantages.
 
 **Returning multi-reward from the environment**
 
-Return a 2D tensor of shape `(batch_size, num_reward_components)`:
+Return a dict of named reward tensors:
 
 ```python
-# rewards: shape (batch_size, num_reward_components), e.g. (N, 3) for three objectives
-rewards = torch.tensor(results).T.cpu()
+# rewards: dict mapping reward component names to Tensor[batch_size]
+rewards = {
+    "reward/correctness": torch.tensor(correctness_scores, dtype=torch.float32),
+    "reward/integer": torch.tensor(integer_scores, dtype=torch.float32),
+    "reward/format": torch.tensor(format_scores, dtype=torch.float32),
+}
 
 return EnvironmentReturn(
     observations=observations,
@@ -75,19 +78,18 @@ return EnvironmentReturn(
 
 **How the rollout uses it**
 
-When the environment returns 2D rewards, `run_multi_turn_rollout` in `rollouts.py` keeps `total_reward` and also exposes each component as `reward1`, `reward2`, … in the batch. Single-reward envs do not get `reward1` keys; only `total_reward` is stored:
+When the environment returns a dict of rewards, `run_multi_turn_rollout` in `rollouts.py` keeps `total_reward` (sum of all components) and also exposes each named component in the batch. Single-reward envs only store `total_reward`:
 
 ```python
 # Add total rewards to the final batch
 current_batch["total_reward"] = total_rewards
 current_batch["truncated"] = sample_truncated
-# Expose per-component rewards (reward1, reward2, ...) for multi-reward envs only; GRPO uses total_reward
+# Expose per-component rewards for multi-reward envs (e.g. GDPO advantage calculation).
 if multi_rewards is not None:
-    num_reward_components = multi_rewards.shape[1]
-    for i in range(num_reward_components):
-        current_batch[f"reward{i + 1}"] = multi_rewards[:, i].clone()
+    for name, reward_tensor in multi_rewards.items():
+        current_batch[name] = reward_tensor
 ```
-For instance, when running `examples/configs/gdpo_math_1B.yaml`, `reward1` maps to `correctness_reward`, `reward2` to `int_reward`, and `reward3` to `format_reward`. More details can be found in `HFMultiRewardVerifyWorker`. Users can also implement their own environments that support multi-reward GDPO training by following this example.
+For instance, when running `examples/configs/gdpo_math_1B.yaml`, the batch will contain `reward/correctness`, `reward/integer`, and `reward/format`. More details can be found in `HFMultiRewardVerifyWorker`. Users can implement their own multi-reward environments by returning a dict from `step()` with keys using the `reward/` prefix.
 
 ## Code Environment
 

--- a/nemo_rl/algorithms/advantage_estimator.py
+++ b/nemo_rl/algorithms/advantage_estimator.py
@@ -34,6 +34,7 @@ from nemo_rl.algorithms.loss import ClippedPGLossConfig
 from nemo_rl.algorithms.utils import (
     calculate_baseline_and_std_per_prompt,
     calculate_kl,
+    get_gdpo_reward_component_keys,
     masked_mean,
     masked_var,
 )
@@ -111,26 +112,22 @@ class GDPOAdvantageEstimator:
         Returns:
             Advantages tensor of shape [batch_size, seq_len].
         """
-        reward_components = {
-            k: repeated_batch[k]
-            for k in repeated_batch
-            if isinstance(k, str) and k.startswith("reward/")
-        }
-        if len(reward_components) < 2:
+        reward_component_keys = get_gdpo_reward_component_keys(repeated_batch)
+        if len(reward_component_keys) < 2:
             raise ValueError(
                 f"GDPO requires multiple reward components (reward/name1, reward/name2, ...). "
-                f"This batch has {len(reward_components)} component(s): {list(reward_components.keys())}. "
+                f"This batch has {len(reward_component_keys)} component(s): {reward_component_keys}. "
                 "Switch to GRPO by setting grpo.adv_estimator.name to 'grpo' in your config."
             )
-        first_reward = next(iter(reward_components.values()))
-        valid = torch.ones_like(first_reward)
+        valid = torch.ones_like(repeated_batch[reward_component_keys[0]])
         leave_one_out = self.use_leave_one_out_baseline
         assert prompt_ids.shape[0] == valid.shape[0], (
             "prompt_ids must match reward batch size; "
             f"got {prompt_ids.shape[0]} vs {valid.shape[0]}"
         )
         advantage_parts = []
-        for key, r in sorted(reward_components.items()):
+        for key in reward_component_keys:
+            r = repeated_batch[key]
             base, std_k = calculate_baseline_and_std_per_prompt(
                 prompt_ids,
                 r,

--- a/nemo_rl/algorithms/advantage_estimator.py
+++ b/nemo_rl/algorithms/advantage_estimator.py
@@ -34,7 +34,6 @@ from nemo_rl.algorithms.loss import ClippedPGLossConfig
 from nemo_rl.algorithms.utils import (
     calculate_baseline_and_std_per_prompt,
     calculate_kl,
-    get_gdpo_reward_component_keys,
     masked_mean,
     masked_var,
 )

--- a/nemo_rl/algorithms/advantage_estimator.py
+++ b/nemo_rl/algorithms/advantage_estimator.py
@@ -105,29 +105,33 @@ class GDPOAdvantageEstimator:
         Args:
             prompt_ids: Tensor identifying which prompt each sample belongs to (for per-prompt baselines).
             rewards: Unused; for interface consistency.
-            repeated_batch: Batch containing reward1, reward2, ... keys.
+            repeated_batch: Batch containing named reward component keys (e.g. reward/correctness, reward/format).
             mask: Response token mask of shape [batch_size, seq_len], 1 for valid response tokens, 0 for padding.
             **kwargs: Additional arguments (unused).
 
         Returns:
             Advantages tensor of shape [batch_size, seq_len].
         """
-        reward_component_keys = get_gdpo_reward_component_keys(repeated_batch)
-        if len(reward_component_keys) < 2:
+        reward_components = {
+            k: repeated_batch[k]
+            for k in repeated_batch
+            if isinstance(k, str) and k.startswith("reward/")
+        }
+        if len(reward_components) < 2:
             raise ValueError(
-                f"GDPO requires multiple reward components (reward1, reward2, ...). "
-                f"This batch has {len(reward_component_keys)} component(s). "
+                f"GDPO requires multiple reward components (reward/name1, reward/name2, ...). "
+                f"This batch has {len(reward_components)} component(s): {list(reward_components.keys())}. "
                 "Switch to GRPO by setting grpo.adv_estimator.name to 'grpo' in your config."
             )
-        valid = torch.ones_like(repeated_batch[reward_component_keys[0]])
+        first_reward = next(iter(reward_components.values()))
+        valid = torch.ones_like(first_reward)
         leave_one_out = self.use_leave_one_out_baseline
         assert prompt_ids.shape[0] == valid.shape[0], (
             "prompt_ids must match reward batch size; "
             f"got {prompt_ids.shape[0]} vs {valid.shape[0]}"
         )
         advantage_parts = []
-        for key in reward_component_keys:
-            r = repeated_batch[key]
+        for key, r in sorted(reward_components.items()):
             base, std_k = calculate_baseline_and_std_per_prompt(
                 prompt_ids,
                 r,

--- a/nemo_rl/algorithms/utils.py
+++ b/nemo_rl/algorithms/utils.py
@@ -14,7 +14,6 @@
 
 import math
 import random
-import re
 import warnings
 from functools import partial, wraps
 from typing import Any, Optional
@@ -32,10 +31,11 @@ from nemo_rl.models.policy import TokenizerConfig
 from nemo_rl.utils.logger import Logger
 
 
-def get_gdpo_reward_component_keys(batch) -> list:
-    """Return batch keys that are reward components (reward1, reward2, ...) in sorted order."""
-    keys = [k for k in batch.keys() if re.match(r"reward\d+$", str(k))]
-    return sorted(keys, key=lambda k: int(re.search(r"\d+", str(k)).group()))
+def get_gdpo_reward_component_keys(batch) -> list[str]:
+    """Return batch keys that are named reward components (e.g. reward/correctness) in sorted order."""
+    return sorted(
+        k for k in batch.keys() if isinstance(k, str) and k.startswith("reward/")
+    )
 
 
 def calculate_kl(

--- a/nemo_rl/environments/interfaces.py
+++ b/nemo_rl/environments/interfaces.py
@@ -44,7 +44,9 @@ class EnvironmentReturn(NamedTuple, Generic[MetadataT]):
     observations: list[dict[str, str]]
     metadata: list[MetadataT]
     next_stop_strings: list[list[str] | None] | list[None]
-    rewards: Tensor  ## Shape [B] for single-reward, [B, num_reward_components] for multi-reward (e.g. GDPO)
+    rewards: (
+        Tensor | dict[str, Tensor]
+    )  ## Tensor[B] for single-reward, dict of {name: Tensor[B]} for multi-reward (e.g. GDPO)
     terminateds: Tensor
     answers: list[str | None] | None
 

--- a/nemo_rl/environments/math_environment.py
+++ b/nemo_rl/environments/math_environment.py
@@ -233,10 +233,15 @@ class EnglishMultichoiceVerifyWorker:
 
 @ray.remote  # pragma: no cover
 class HFMultiRewardVerifyWorker:
+    # Reward component names returned by this worker.
+    REWARD_NAMES: list[str] = [
+        "reward/correctness",
+        "reward/integer",
+        "reward/format",
+    ]
+
     def __init__(self) -> None:
         logging.getLogger("math_multi_reward_verify").setLevel(logging.CRITICAL)
-
-        self.number_of_rewards = 3
 
         # Use Latex and plain math extraction from predictions
         # https://github.com/huggingface/Math-Verify?tab=readme-ov-file#extraction-targets
@@ -254,7 +259,10 @@ class HFMultiRewardVerifyWorker:
         ground_truths: list[str],
         return_extracted_answer: bool = False,
         **kwargs,
-    ) -> Union[list[list[float]], tuple[list[list[float]], list[str | None]]]:
+    ) -> Union[
+        dict[str, list[float]],
+        tuple[dict[str, list[float]], list[str | None]],
+    ]:
         """Verify the correctness of the predicted responses against the ground truth.
 
         Args:
@@ -262,9 +270,9 @@ class HFMultiRewardVerifyWorker:
             ground_truths: list[str]. The ground truth responses.
 
         Returns:
-            Union[list[float], tuple[list[float], list[str | None]]].
-            If return_extracted_answer is False, returns only the scores.
-            If return_extracted_answer is True, returns (scores, extracted_answers).
+            If return_extracted_answer is False, returns dict mapping reward component
+            names to per-sample scores.
+            If return_extracted_answer is True, returns (scores_dict, extracted_answers).
         """
 
         def extract_xml_answer(text: str) -> str:
@@ -297,7 +305,7 @@ class HFMultiRewardVerifyWorker:
 
             return rewards
 
-        results = [[] for _ in range(self.number_of_rewards)]
+        results: dict[str, list[float]] = {name: [] for name in self.REWARD_NAMES}
         extracted_answers: list[str | None] = []
 
         for response, ground_truth in zip(pred_responses, ground_truths):
@@ -312,9 +320,9 @@ class HFMultiRewardVerifyWorker:
                         f"Unknown math_verify_impl: {math_verify_impl}. Expected 'hf_math_verify'"
                     )
 
-                results[0].extend(cor_reward)
-                results[1].extend(int_reward)
-                results[2].extend(format_reward)
+                results["reward/correctness"].extend(cor_reward)
+                results["reward/integer"].extend(int_reward)
+                results["reward/format"].extend(format_reward)
 
                 if return_extracted_answer:
                     extracted_answer = extract_xml_answer(response)
@@ -324,15 +332,13 @@ class HFMultiRewardVerifyWorker:
             # it actually subclasses from BaseException and math-verify itself does not
             # to catch it.
             except (Exception, TimeoutException):
-                results[0].append(0.0)
-                results[1].append(0.0)
-                results[2].append(0.0)
+                for name in self.REWARD_NAMES:
+                    results[name].append(0.0)
                 extracted_answers.append(None)
 
         if return_extracted_answer:
             return results, extracted_answers
         else:
-            # return results --> [[0,1,0], [0,2,0], .........]
             return results
 
 
@@ -375,10 +381,13 @@ class BaseMathEnvironment(EnvironmentInterface[MathEnvironmentMetadata]):
         Every rank will run this function, so you're free to use distributed
         calculations if you'd prefer for heavy metrics.
         """
-        # for multi-reward environment, index 0 always store corretness reward
-        rewards = (
-            batch["rewards"] if batch["rewards"].ndim == 1 else batch["rewards"][:, 0]
-        )
+        # For multi-reward environments the batch stores per-component reward
+        # tensors under named keys (e.g. "reward/correctness").  For single-reward
+        # environments it stores a flat Tensor under "rewards".
+        if "reward/correctness" in batch:
+            rewards = batch["reward/correctness"]
+        else:
+            rewards = batch["rewards"]
 
         # set a reward of 0 for any incorrectly ended sequences
         rewards = rewards * batch["is_end"]
@@ -581,9 +590,10 @@ class MathMultiRewardEnvironment(BaseMathEnvironment):
 
         worker_results = ray.get(futures)
 
-        # Flatten the results and extract both scores and answers
-        number_of_rewards = len(worker_results[0])
-        results = [[] for _ in range(number_of_rewards)]
+        # Flatten the results and extract both scores and answers.
+        # Each worker returns dict[str, list[float]] (or a tuple with extracted answers).
+        reward_names: list[str] | None = None
+        results: dict[str, list[float]] = {}
         extracted_answers: list[str | None] | None = (
             [] if return_extracted_answer else None
         )
@@ -593,23 +603,32 @@ class MathMultiRewardEnvironment(BaseMathEnvironment):
             if return_extracted_answer:
                 worker_scores, worker_answers = worker_result
                 extracted_answers.extend(worker_answers)
-            for i in range(number_of_rewards):
-                results[i].extend(worker_scores[i])
+            if reward_names is None:
+                reward_names = list(worker_scores.keys())
+                results = {name: [] for name in reward_names}
+            for name in reward_names:
+                results[name].extend(worker_scores[name])
 
+        # Use the correctness reward component (first key) for observations
+        assert reward_names is not None, "No reward components found from workers"
+        correctness_key = reward_names[0]
         observations = [
             {
                 "role": "environment",
                 "content": "Environment: correct"
-                if result
+                if score
                 else "Environment: incorrect",
             }
-            for result in results[0]  ## index 0 always store corretness reward
+            for score in results[correctness_key]
         ]
 
-        # create a tensor of rewards and done flags
-        rewards = torch.tensor(results).T.cpu()  ## Shape Batch_size, Number_rewards
-        ## hard fixed this done to
-        done = torch.ones(rewards.shape[0]).cpu()
+        # Build dict of reward tensors: {name: Tensor[B]}
+        rewards: dict[str, torch.Tensor] = {
+            name: torch.tensor(scores, dtype=torch.float32).cpu()
+            for name, scores in results.items()
+        }
+        batch_size = len(results[correctness_key])
+        done = torch.ones(batch_size).cpu()
         next_stop_strings = [None] * len(message_log_batch)
 
         return EnvironmentReturn(

--- a/nemo_rl/environments/math_environment.py
+++ b/nemo_rl/environments/math_environment.py
@@ -609,9 +609,7 @@ class MathMultiRewardEnvironment(BaseMathEnvironment):
             for name in reward_names:
                 results[name].extend(worker_scores[name])
 
-        # Use the correctness reward component (first key) for observations
-        assert reward_names is not None, "No reward components found from workers"
-        correctness_key = reward_names[0]
+        correctness_key = "reward/correctness"
         observations = [
             {
                 "role": "environment",

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -195,6 +195,8 @@ class AsyncRolloutImpl:
             )
 
             # Update reward and termination statistics
+            # Per-prompt rollouts always use single-reward (Tensor), not dict.
+            assert isinstance(env_output.rewards, torch.Tensor)
             total_reward += float(env_output.rewards[0].item())
             terminated = env_output.terminateds[0].item()
             env_obs_content = env_output.observations[0]["content"]

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -196,6 +196,8 @@ class AsyncRolloutImpl:
 
             # Update reward and termination statistics
             # Per-prompt rollouts always use single-reward (Tensor), not dict.
+            # Multi-reward isn't supported in RolloutManager now, see
+            # https://github.com/NVIDIA-NeMo/RL/issues/2625 for more details.
             assert isinstance(env_output.rewards, torch.Tensor)
             total_reward += float(env_output.rewards[0].item())
             terminated = env_output.terminateds[0].item()

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -195,7 +195,7 @@ class AsyncRolloutImpl:
             )
 
             # Update reward and termination statistics
-            # Per-prompt rollouts always use single-reward (Tensor), not dict.
+            # Multi-reward isn't supported in RolloutManager now, see https://github.com/NVIDIA-NeMo/RL/issues/2625 for more details.
             # Multi-reward isn't supported in RolloutManager now, see
             # https://github.com/NVIDIA-NeMo/RL/issues/2625 for more details.
             assert isinstance(env_output.rewards, torch.Tensor)

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -195,7 +195,6 @@ class AsyncRolloutImpl:
             )
 
             # Update reward and termination statistics
-            # Multi-reward isn't supported in RolloutManager now, see https://github.com/NVIDIA-NeMo/RL/issues/2625 for more details.
             # Multi-reward isn't supported in RolloutManager now, see
             # https://github.com/NVIDIA-NeMo/RL/issues/2625 for more details.
             assert isinstance(env_output.rewards, torch.Tensor)

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -568,7 +568,8 @@ def calculate_rewards(
     # Build rewards: dict-based for multi-reward envs, tensor for single-reward.
     if all_dict_rewards is not None:
         assert len(all_rewards) == 0, (
-            "something like different shape reward is not support now"
+            "Mixing dict-based and scalar rewards across environments is not supported. "
+            "All environments must return the same reward format (all dict or all scalar)."
         )
         rewards: torch.Tensor | dict[str, torch.Tensor] = {
             name: torch.stack([vals[i] for i in sorted_indices])

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -550,6 +550,7 @@ def calculate_rewards(
             if is_dict_rewards:
                 # all_dict_rewards is initialized above whenever is_dict_rewards is
                 # True; assert narrows the Optional for the type checker.
+                assert all_dict_rewards is not None
                 for name in task_rewards:
                     all_dict_rewards[name].append(task_rewards[name][i])
             else:

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -32,6 +32,7 @@ from pydantic import BaseModel
 from transformers import PreTrainedTokenizerBase
 from wandb import Histogram, Table
 
+from nemo_rl.algorithms.utils import get_gdpo_reward_component_keys
 from nemo_rl.data.interfaces import (
     DatumSpec,
     FlatMessagesType,
@@ -510,8 +511,9 @@ def calculate_rewards(
         future_to_indices[future] = indices
 
     results = ray.get(futures)
-    all_rewards: list = []  # list of per-sample scalars/tensors OR None (set below for dict rewards)
+    all_rewards: list = []  # list of per-sample scalars/tensors (single-reward envs)
     all_dict_rewards: dict[str, list] | None = None  # for dict-based multi-reward envs
+    is_dict_rewards = False
     all_env_observations = []
     all_terminateds = []
     all_next_stop_strings = []
@@ -532,23 +534,21 @@ def calculate_rewards(
         ) = result
 
         is_dict_rewards = isinstance(task_rewards, dict)
-        num_samples = (
-            len(next(iter(task_rewards.values())))
-            if is_dict_rewards
-            else len(task_rewards)
-        )
 
         if next_stop_strings is None:
-            next_stop_strings = [None] * num_samples
+            next_stop_strings = [None] * len(terminateds)
         if answers is None:
-            answers = [None] * num_samples
+            answers = [None] * len(terminateds)
+
+        # Initialize dict-reward accumulator on first encounter (outside inner loop).
+        if is_dict_rewards and all_dict_rewards is None:
+            all_dict_rewards = {name: [] for name in task_rewards}
 
         # Store results with their original indices
         for i, idx in enumerate(indices):
             all_indices_order.append(idx)
             if is_dict_rewards:
-                if all_dict_rewards is None:
-                    all_dict_rewards = {name: [] for name in task_rewards}
+                assert all_dict_rewards is not None
                 for name in task_rewards:
                     all_dict_rewards[name].append(task_rewards[name][i])
             else:
@@ -565,7 +565,8 @@ def calculate_rewards(
     )
 
     # Build rewards: dict-based for multi-reward envs, tensor for single-reward.
-    if all_dict_rewards is not None:
+    if is_dict_rewards:
+        assert all_dict_rewards is not None
         rewards: torch.Tensor | dict[str, torch.Tensor] = {
             name: torch.stack([vals[i] for i in sorted_indices])
             for name, vals in all_dict_rewards.items()
@@ -1221,8 +1222,7 @@ def run_async_multi_turn_rollout(
             set(
                 k
                 for state in final_sample_states
-                for k in state
-                if isinstance(k, str) and k.startswith("reward/")
+                for k in get_gdpo_reward_component_keys(state)
             )
         )
         for key in reward_component_keys:

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -564,8 +564,8 @@ def calculate_rewards(
     )
 
     # Build rewards: dict-based for multi-reward envs, tensor for single-reward.
-    if is_dict_rewards:
-        assert all_dict_rewards is not None
+    if all_dict_rewards is not None:
+        assert len(all_rewards) == 0, "something like different shape reward is not support now"
         rewards: torch.Tensor | dict[str, torch.Tensor] = {
             name: torch.stack([vals[i] for i in sorted_indices])
             for name, vals in all_dict_rewards.items()

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -548,11 +548,8 @@ def calculate_rewards(
         for i, idx in enumerate(indices):
             all_indices_order.append(idx)
             if is_dict_rewards:
-                # all_dict_rewards is initialized above whenever is_dict_rewards is
-                # True; assert narrows the Optional for the type checker.
-                assert all_dict_rewards is not None
                 for name in task_rewards:
-                    all_dict_rewards[name].append(task_rewards[name][i])
+                    all_dict_rewards[name].append(task_rewards[name][i])  # type: ignore
             else:
                 all_rewards.append(task_rewards[i])
             all_env_observations.append(env_observations[i])

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -548,7 +548,6 @@ def calculate_rewards(
         for i, idx in enumerate(indices):
             all_indices_order.append(idx)
             if is_dict_rewards:
-                assert all_dict_rewards is not None
                 for name in task_rewards:
                     all_dict_rewards[name].append(task_rewards[name][i])
             else:

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -550,7 +550,6 @@ def calculate_rewards(
             if is_dict_rewards:
                 # all_dict_rewards is initialized above whenever is_dict_rewards is
                 # True; assert narrows the Optional for the type checker.
-                assert all_dict_rewards is not None
                 for name in task_rewards:
                     all_dict_rewards[name].append(task_rewards[name][i])
             else:

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -565,7 +565,9 @@ def calculate_rewards(
 
     # Build rewards: dict-based for multi-reward envs, tensor for single-reward.
     if all_dict_rewards is not None:
-        assert len(all_rewards) == 0, "something like different shape reward is not support now"
+        assert len(all_rewards) == 0, (
+            "something like different shape reward is not support now"
+        )
         rewards: torch.Tensor | dict[str, torch.Tensor] = {
             name: torch.stack([vals[i] for i in sorted_indices])
             for name, vals in all_dict_rewards.items()

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -548,6 +548,9 @@ def calculate_rewards(
         for i, idx in enumerate(indices):
             all_indices_order.append(idx)
             if is_dict_rewards:
+                # all_dict_rewards is initialized above whenever is_dict_rewards is
+                # True; assert narrows the Optional for the type checker.
+                assert all_dict_rewards is not None
                 for name in task_rewards:
                     all_dict_rewards[name].append(task_rewards[name][i])
             else:

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -510,7 +510,8 @@ def calculate_rewards(
         future_to_indices[future] = indices
 
     results = ray.get(futures)
-    all_rewards = []
+    all_rewards: list = []  # list of per-sample scalars/tensors OR None (set below for dict rewards)
+    all_dict_rewards: dict[str, list] | None = None  # for dict-based multi-reward envs
     all_env_observations = []
     all_terminateds = []
     all_next_stop_strings = []
@@ -529,15 +530,29 @@ def calculate_rewards(
             terminateds,
             answers,
         ) = result
+
+        is_dict_rewards = isinstance(task_rewards, dict)
+        num_samples = (
+            len(next(iter(task_rewards.values())))
+            if is_dict_rewards
+            else len(task_rewards)
+        )
+
         if next_stop_strings is None:
-            next_stop_strings = [None] * len(task_rewards)
+            next_stop_strings = [None] * num_samples
         if answers is None:
-            answers = [None] * len(task_rewards)
+            answers = [None] * num_samples
 
         # Store results with their original indices
         for i, idx in enumerate(indices):
             all_indices_order.append(idx)
-            all_rewards.append(task_rewards[i])
+            if is_dict_rewards:
+                if all_dict_rewards is None:
+                    all_dict_rewards = {name: [] for name in task_rewards}
+                for name in task_rewards:
+                    all_dict_rewards[name].append(task_rewards[name][i])
+            else:
+                all_rewards.append(task_rewards[i])
             all_env_observations.append(env_observations[i])
             all_terminateds.append(terminateds[i])
             all_next_stop_strings.append(next_stop_strings[i])
@@ -549,8 +564,13 @@ def calculate_rewards(
         range(len(all_indices_order)), key=lambda k: all_indices_order[k]
     )
 
-    # Stack rewards: each element may be scalar (single-reward env) or 1d (multi-reward env).
-    if len(all_rewards) > 0 and isinstance(all_rewards[0], torch.Tensor):
+    # Build rewards: dict-based for multi-reward envs, tensor for single-reward.
+    if all_dict_rewards is not None:
+        rewards: torch.Tensor | dict[str, torch.Tensor] = {
+            name: torch.stack([vals[i] for i in sorted_indices])
+            for name, vals in all_dict_rewards.items()
+        }
+    elif len(all_rewards) > 0 and isinstance(all_rewards[0], torch.Tensor):
         rewards = torch.stack([all_rewards[i] for i in sorted_indices])
     else:
         rewards = torch.tensor([all_rewards[i] for i in sorted_indices])
@@ -601,9 +621,8 @@ def run_multi_turn_rollout(
     active_indices = torch.arange(batch_size)
     total_rewards = torch.zeros(batch_size, dtype=torch.float32)
 
-    # Multi_rewards: number of components inferred from first env_output (1 for single-reward envs)
-    number_of_rewards: int | None = None
-    multi_rewards: torch.Tensor | None = None
+    # Multi-reward accumulator: dict of {name: Tensor[B]} for multi-reward envs (e.g. GDPO), None for single-reward.
+    multi_rewards: dict[str, torch.Tensor] | None = None
 
     # Initialize stop_strings from the initial batch if present
     current_stop_strings = current_batch.get("stop_strings", [None] * batch_size)
@@ -692,23 +711,20 @@ def run_multi_turn_rollout(
         # Calculate rewards and get environment feedback
         env_output: EnvironmentReturn = calculate_rewards(active_batch, task_to_env)
 
-        # Infer number of reward components on first turn (supports single- and multi-reward envs)
-        if number_of_rewards is None:
-            if env_output.rewards.ndim >= 2:
-                number_of_rewards = int(env_output.rewards.shape[1])
-                multi_rewards = torch.zeros(
-                    batch_size, number_of_rewards, dtype=torch.float32
-                )
-            else:
-                number_of_rewards = 1
-                # multi_rewards left None: GRPO uses total_reward only; multi_rewards unused
-
-        # Accumulate rewards: env may return shape (N,) or (N, K)
-        if number_of_rewards > 1:
+        # Accumulate rewards: env returns dict[str, Tensor] for multi-reward, Tensor for single-reward.
+        if isinstance(env_output.rewards, dict):
+            # Initialize accumulators on first encounter
+            if multi_rewards is None:
+                multi_rewards = {
+                    name: torch.zeros(batch_size, dtype=torch.float32)
+                    for name in env_output.rewards
+                }
             # this assert is to infer the type of multi_rewards for pyrefly
             assert multi_rewards is not None
-            multi_rewards[active_indices] += env_output.rewards
-            total_rewards[active_indices] += env_output.rewards.sum(dim=1)
+            reward_dict: dict[str, torch.Tensor] = multi_rewards
+            for name, r in env_output.rewards.items():
+                reward_dict[name][active_indices] += r
+            total_rewards[active_indices] += sum(env_output.rewards.values())
         else:
             total_rewards[active_indices] += env_output.rewards
 
@@ -794,11 +810,10 @@ def run_multi_turn_rollout(
     # Add total rewards to the final batch
     current_batch["total_reward"] = total_rewards
     current_batch["truncated"] = sample_truncated
-    # Expose per-component rewards (reward1, reward2, ...) for multi-reward envs only; GRPO uses total_reward
+    # Expose per-component rewards for multi-reward envs (e.g. GDPO advantage calculation).
     if multi_rewards is not None:
-        num_reward_components = multi_rewards.shape[1]
-        for i in range(num_reward_components):
-            current_batch[f"reward{i + 1}"] = multi_rewards[:, i].clone()
+        for name, reward_tensor in multi_rewards.items():
+            current_batch[name] = reward_tensor
 
     # Calculate aggregate metrics
     rollout_metrics = {
@@ -929,9 +944,7 @@ async def run_sample_multi_turn_rollout(
 
     # Sample-level metrics
     total_reward = 0.0
-    reward_acc_list: list[
-        float
-    ] = []  # per-component rewards, length set on first multi-reward
+    reward_acc_dict: dict[str, float] = {}  # per-component reward accumulators (named)
     multi_reward_seen = False
     turn_count = 0
     token_count = 0
@@ -1012,15 +1025,14 @@ async def run_sample_multi_turn_rollout(
         env_output = await asyncio.to_thread(
             calculate_rewards, sample_batch, task_to_env
         )
-        # Update total reward and optional per-reward signals (reward1, reward2, ... rewardN)
-        if env_output.rewards.ndim == 2 and env_output.rewards.shape[1] >= 1:
+        # Update total reward and optional per-component reward signals.
+        if isinstance(env_output.rewards, dict):
             multi_reward_seen = True
-            n = env_output.rewards.shape[1]
-            if len(reward_acc_list) == 0:
-                reward_acc_list = [0.0] * n
-            total_reward += float(env_output.rewards[0].sum().item())
-            for j in range(n):
-                reward_acc_list[j] += float(env_output.rewards[0, j].item())
+            for name, r in env_output.rewards.items():
+                reward_acc_dict[name] = reward_acc_dict.get(name, 0.0) + float(
+                    r[0].item()
+                )
+            total_reward += sum(float(r[0].item()) for r in env_output.rewards.values())
         else:
             total_reward += float(env_output.rewards[0].item())
         # Check termination
@@ -1078,8 +1090,8 @@ async def run_sample_multi_turn_rollout(
         "idx": sample_idx,
     }
     if multi_reward_seen:
-        for j in range(len(reward_acc_list)):
-            final_sample_state[f"reward{j + 1}"] = torch.tensor(reward_acc_list[j])
+        for name, acc in reward_acc_dict.items():
+            final_sample_state[name] = torch.tensor(acc)
 
     # Sample metrics
     sample_metrics = {
@@ -1203,19 +1215,15 @@ def run_async_multi_turn_rollout(
             }
         )
 
-        # Expose per-component rewards (reward1, reward2, ...) for multi-reward envs for GDPO advantage calculation.
-        # Collect all reward component keys from any sample state (samples may come from different envs).
+        # Expose per-component rewards for multi-reward envs (GDPO advantage calculation).
+        # Collect named reward keys (e.g. "reward/correctness") from sample states.
         reward_component_keys = sorted(
             set(
                 k
                 for state in final_sample_states
                 for k in state
-                if isinstance(k, str)
-                and k.startswith("reward")
-                and len(k) > 6
-                and k[6:].isdigit()
-            ),
-            key=lambda k: int(k[6:]),
+                if isinstance(k, str) and k.startswith("reward/")
+            )
         )
         for key in reward_component_keys:
             # Stack per-sample values; use 0.0 for samples that did not have this component (e.g. single-reward env)

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -2508,9 +2508,9 @@ def test_gdpo_advantage_estimator_multiple_rewards():
     prompt_ids = torch.tensor([[0], [0]])
     mask = torch.ones(2, 3)
     repeated_batch = {
-        "reward1": torch.tensor([1.0, 1.0]),
-        "reward2": torch.tensor([1.0, -1.0]),
-        "reward3": torch.tensor([1.0, 0.0]),
+        "reward/correctness": torch.tensor([1.0, 1.0]),
+        "reward/integer": torch.tensor([1.0, -1.0]),
+        "reward/format": torch.tensor([1.0, 0.0]),
     }
 
     result = estimator.compute_advantage(prompt_ids, None, mask, repeated_batch)
@@ -2530,7 +2530,7 @@ def test_gdpo_advantage_estimator_single_reward():
 
     prompt_ids = torch.tensor([[0], [0]])
     mask = torch.ones(2, 3)
-    repeated_batch = {"reward1": torch.tensor([1.0, 3.0])}
+    repeated_batch = {"reward/correctness": torch.tensor([1.0, 3.0])}
 
     with pytest.raises(ValueError):
         estimator.compute_advantage(prompt_ids, None, mask, repeated_batch)

--- a/tests/unit/environments/test_math_environment.py
+++ b/tests/unit/environments/test_math_environment.py
@@ -274,20 +274,28 @@ def test_multi_reward_env_step_basic(math_multi_reward_env, multi_reward_test_da
         "Metadata should be unchanged"
     )
 
-    # Check rewards: shape (batch_size=3, number_of_rewards=3)
-    assert result.rewards.shape == (3, 3), "Rewards should be a tensor of shape (3, 3)"
+    # Check rewards: dict with 3 named components, each Tensor of shape (3,)
+    assert isinstance(result.rewards, dict), "Rewards should be a dict"
+    expected_keys = {"reward/correctness", "reward/integer", "reward/format"}
+    assert set(result.rewards.keys()) == expected_keys, (
+        f"Reward keys should be {expected_keys}, got {set(result.rewards.keys())}"
+    )
+    for name, tensor in result.rewards.items():
+        assert tensor.shape == (3,), f"{name} should be a tensor of shape (3,)"
 
     # Check rewards for each data point
-    # First reward: correctness reward 1.0, int reward 1.0, format reward 1.0
-    assert (result.rewards[0] == 1.0).all(), "First reward should be 1.0"
-    # Second reward: correctness reward 0.0, int reward 0.0, format reward 1.0
-    assert result.rewards[1][0] == 0.0
-    assert result.rewards[1][1] == 0.0
-    assert result.rewards[1][2] == 1.0
-    # Third reward: correctness reward 1.0, int reward 1.0, format reward 0.0
-    assert result.rewards[2][0] == 1.0
-    assert result.rewards[2][1] == 1.0
-    assert result.rewards[2][2] == 0.0
+    # Sample 0: correct answer "4", integer, valid format -> all 1.0
+    assert result.rewards["reward/correctness"][0] == 1.0
+    assert result.rewards["reward/integer"][0] == 1.0
+    assert result.rewards["reward/format"][0] == 1.0
+    # Sample 1: wrong answer, not integer, valid format -> only format 1.0
+    assert result.rewards["reward/correctness"][1] == 0.0
+    assert result.rewards["reward/integer"][1] == 0.0
+    assert result.rewards["reward/format"][1] == 1.0
+    # Sample 2: correct answer "4", integer, bad format -> correctness+integer 1.0
+    assert result.rewards["reward/correctness"][2] == 1.0
+    assert result.rewards["reward/integer"][2] == 1.0
+    assert result.rewards["reward/format"][2] == 0.0
 
     # Check terminated flags
     assert result.terminateds.shape == (3,), (


### PR DESCRIPTION
Replace positional Tensor[B,K] multi-reward with named dict[str, Tensor] using reward/ prefix (e.g. reward/correctness, reward/integer, reward/format).

Changes across 4 layers:
- Environment: EnvironmentReturn.rewards supports dict type; HFMultiRewardVerifyWorker returns named reward components
- Rollouts: sync/async paths accumulate and discover rewards by name (reward/ prefix) instead of regex reward\d+
- Algorithm: get_gdpo_reward_component_keys() uses prefix matching; GDPOAdvantageEstimator unchanged in logic
- Docs & tests updated to match

Closes: NVIDIA-NeMo/RL#2107

# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
