### PR TITLE
fix(grpo): update grpo_sync seq_logprob_error_masking call site

### DIFF
--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -769,17 +769,37 @@ def grpo_train_sync(
                         }
                     )
 
-                    (
-                        max_seq_mult_prob_error,
-                        num_masked_seqs,
-                        masked_correct_pct,
-                    ) = compute_and_apply_seq_logprob_error_masking(
+                    seq_error_result = compute_and_apply_seq_logprob_error_masking(
                         train_data=masking_data,
                         rewards=rewards,
                         seq_logprob_error_threshold=master_config.grpo[
                             "seq_logprob_error_threshold"
                         ],
                     )
+                    seq_logprob_error_metrics = {
+                        "max_seq_mult_prob_error": seq_error_result[
+                            "max_seq_mult_prob_error"
+                        ],
+                        "mean_seq_mult_prob_error": seq_error_result[
+                            "mean_seq_mult_prob_error"
+                        ],
+                        "min_seq_mult_prob_error": seq_error_result[
+                            "min_seq_mult_prob_error"
+                        ],
+                        "max_seq_mult_prob_error_after_mask": seq_error_result[
+                            "max_seq_mult_prob_error_after_mask"
+                        ],
+                        "mean_seq_mult_prob_error_after_mask": seq_error_result[
+                            "mean_seq_mult_prob_error_after_mask"
+                        ],
+                        "min_seq_mult_prob_error_after_mask": seq_error_result[
+                            "min_seq_mult_prob_error_after_mask"
+                        ],
+                        "num_masked_seqs_by_logprob_error": seq_error_result[
+                            "num_masked_seqs"
+                        ],
+                        "masked_correct_pct": seq_error_result["masked_correct_pct"],
+                    }
                     # masking may have mutated sample_mask in place —
                     # capture the post-masking value for delta-write.
                     sample_mask = masking_data["sample_mask"]
@@ -1011,9 +1031,7 @@ def grpo_train_sync(
                 metrics["generation_logger_metrics"] = generation_logger_metrics
                 total_valid_tokens += metrics["global_valid_toks"]
 
-                metrics["max_seq_mult_prob_error"] = max_seq_mult_prob_error
-                metrics["num_masked_seqs_by_logprob_error"] = num_masked_seqs
-                metrics["masked_correct_pct"] = masked_correct_pct
+                metrics.update(seq_logprob_error_metrics)
 
                 consumed_samples += master_config.grpo["num_prompts_per_step"]
                 timeout.mark_iteration()


### PR DESCRIPTION
## Summary

- Fixes regression on `main` introduced when [PR #2559](https://github.com/NVIDIA-NeMo/RL/pull/2559) changed `compute_and_apply_seq_logprob_error_masking` to return a dict but missed updating the call site in `grpo_sync.py`.
- L1_Functional_Tests_GPU on `main` is currently failing with `ValueError: too many values to unpack (expected 3)` at `nemo_rl/algorithms/grpo_sync.py:772` — see [failing job](https://github.com/NVIDIA-NeMo/RL/actions/runs/26559706966/job/78260627397).
- Aligns `grpo_sync.py` with the dict-based pattern already in use at `grpo.py:1935-1963` and `grpo.py:3064-3091`, so the sync recipe now also surfaces the richer mean / min / after-mask metrics.

## Test plan

- [ ] CI L1 (`/ok to test <sha>`) — should turn `L1_Functional_Tests_GPU` green again.
- [ ] Local sanity: grep confirms the only remaining 3-tuple unpacking is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)