### PR TITLE
fix(grpo): handle seq logprob metrics in sync trainer

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1937,30 +1937,11 @@ def grpo_train(
                         rewards=rewards,
                         seq_logprob_error_threshold=seq_logprob_error_threshold,
                     )
-                    seq_logprob_error_metrics = {
-                        "max_seq_mult_prob_error": seq_error_result[
-                            "max_seq_mult_prob_error"
-                        ],
-                        "mean_seq_mult_prob_error": seq_error_result[
-                            "mean_seq_mult_prob_error"
-                        ],
-                        "min_seq_mult_prob_error": seq_error_result[
-                            "min_seq_mult_prob_error"
-                        ],
-                        "max_seq_mult_prob_error_after_mask": seq_error_result[
-                            "max_seq_mult_prob_error_after_mask"
-                        ],
-                        "mean_seq_mult_prob_error_after_mask": seq_error_result[
-                            "mean_seq_mult_prob_error_after_mask"
-                        ],
-                        "min_seq_mult_prob_error_after_mask": seq_error_result[
-                            "min_seq_mult_prob_error_after_mask"
-                        ],
-                        "num_masked_seqs_by_logprob_error": seq_error_result[
-                            "num_masked_seqs"
-                        ],
-                        "masked_correct_pct": seq_error_result["masked_correct_pct"],
-                    }
+                    seq_logprob_error_metrics = seq_error_result
+                    if "num_masked_seqs" in seq_logprob_error_metrics:
+                        seq_logprob_error_metrics[
+                            "num_masked_seqs_by_logprob_error"
+                        ] = seq_logprob_error_metrics.pop("num_masked_seqs")
 
                 # Compute advantages with adv_estimator using correct mask and logprobs
                 with timer.time("advantage_calculation"):
@@ -3066,30 +3047,11 @@ def async_grpo_train(
                         rewards=rewards,
                         seq_logprob_error_threshold=seq_logprob_error_threshold,
                     )
-                    seq_logprob_error_metrics = {
-                        "max_seq_mult_prob_error": seq_error_result[
-                            "max_seq_mult_prob_error"
-                        ],
-                        "mean_seq_mult_prob_error": seq_error_result[
-                            "mean_seq_mult_prob_error"
-                        ],
-                        "min_seq_mult_prob_error": seq_error_result[
-                            "min_seq_mult_prob_error"
-                        ],
-                        "max_seq_mult_prob_error_after_mask": seq_error_result[
-                            "max_seq_mult_prob_error_after_mask"
-                        ],
-                        "mean_seq_mult_prob_error_after_mask": seq_error_result[
-                            "mean_seq_mult_prob_error_after_mask"
-                        ],
-                        "min_seq_mult_prob_error_after_mask": seq_error_result[
-                            "min_seq_mult_prob_error_after_mask"
-                        ],
-                        "num_masked_seqs_by_logprob_error": seq_error_result[
-                            "num_masked_seqs"
-                        ],
-                        "masked_correct_pct": seq_error_result["masked_correct_pct"],
-                    }
+                    seq_logprob_error_metrics = seq_error_result
+                    if "num_masked_seqs" in seq_logprob_error_metrics:
+                        seq_logprob_error_metrics[
+                            "num_masked_seqs_by_logprob_error"
+                        ] = seq_logprob_error_metrics.pop("num_masked_seqs")
 
                 # Compute advantages with adv_estimator using correct mask and logprobs
                 with timer.time("advantage_calculation"):

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -304,6 +304,38 @@ def validate_sync(
     return val_metrics, timing_metrics
 
 
+def _compute_seq_logprob_error_metrics(
+    *,
+    token_mask: torch.Tensor,
+    sample_mask: torch.Tensor,
+    prev_logprobs: torch.Tensor,
+    generation_logprobs: torch.Tensor,
+    rewards: torch.Tensor,
+    seq_logprob_error_threshold: Optional[float],
+) -> tuple[torch.Tensor, dict[str, Any]]:
+    # Thin BDD for the data-driven masking call: take
+    # the slice you need, transform, write delta back.
+    masking_data = BatchedDataDict[ClippedPGLossDataDict](
+        {
+            "token_mask": token_mask,
+            "sample_mask": sample_mask,
+            "prev_logprobs": prev_logprobs,
+            "generation_logprobs": generation_logprobs,
+        }
+    )
+    seq_error_result = compute_and_apply_seq_logprob_error_masking(
+        train_data=masking_data,
+        rewards=rewards,
+        seq_logprob_error_threshold=seq_logprob_error_threshold,
+    )
+    seq_logprob_error_metrics = seq_error_result
+    if "num_masked_seqs" in seq_logprob_error_metrics:
+        seq_logprob_error_metrics["num_masked_seqs_by_logprob_error"] = (
+            seq_logprob_error_metrics.pop("num_masked_seqs")
+        )
+    return masking_data["sample_mask"], seq_logprob_error_metrics
+
+
 def grpo_train_sync(
     policy: ColocatablePolicyInterface,
     policy_generation: Optional[GenerationInterface],
@@ -758,31 +790,18 @@ def grpo_train_sync(
                         extras_bdd["reference_policy_logprobs"] if compute_ref else None
                     )
 
-                    # Thin BDD for the data-driven masking call: take
-                    # the slice you need, transform, write delta back.
-                    masking_data = BatchedDataDict[ClippedPGLossDataDict](
-                        {
-                            "token_mask": token_mask,
-                            "sample_mask": loss_multiplier,
-                            "prev_logprobs": prev_logprobs,
-                            "generation_logprobs": generation_logprobs,
-                        }
+                    sample_mask, seq_logprob_error_metrics = (
+                        _compute_seq_logprob_error_metrics(
+                            token_mask=token_mask,
+                            sample_mask=loss_multiplier,
+                            prev_logprobs=prev_logprobs,
+                            generation_logprobs=generation_logprobs,
+                            rewards=rewards,
+                            seq_logprob_error_threshold=master_config.grpo[
+                                "seq_logprob_error_threshold"
+                            ],
+                        )
                     )
-
-                    (
-                        max_seq_mult_prob_error,
-                        num_masked_seqs,
-                        masked_correct_pct,
-                    ) = compute_and_apply_seq_logprob_error_masking(
-                        train_data=masking_data,
-                        rewards=rewards,
-                        seq_logprob_error_threshold=master_config.grpo[
-                            "seq_logprob_error_threshold"
-                        ],
-                    )
-                    # masking may have mutated sample_mask in place —
-                    # capture the post-masking value for delta-write.
-                    sample_mask = masking_data["sample_mask"]
 
                 with timer.time("advantage_calculation"):
                     print("▶ Computing advantages...", flush=True)
@@ -1011,9 +1030,7 @@ def grpo_train_sync(
                 metrics["generation_logger_metrics"] = generation_logger_metrics
                 total_valid_tokens += metrics["global_valid_toks"]
 
-                metrics["max_seq_mult_prob_error"] = max_seq_mult_prob_error
-                metrics["num_masked_seqs_by_logprob_error"] = num_masked_seqs
-                metrics["masked_correct_pct"] = masked_correct_pct
+                metrics.update(seq_logprob_error_metrics)
 
                 consumed_samples += master_config.grpo["num_prompts_per_step"]
                 timeout.mark_iteration()

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -75,6 +75,52 @@ def _logged_train_metrics_with_key(logger, key: str):
     raise AssertionError(f"No train metrics payload contained {key}")
 
 
+def test_grpo_sync_seq_logprob_error_helper_accepts_dict_result(monkeypatch):
+    from nemo_rl.algorithms import grpo_sync as grpo_sync_mod
+
+    seq_error_result = {
+        "max_seq_mult_prob_error": 2.5,
+        "mean_seq_mult_prob_error": 1.5,
+        "min_seq_mult_prob_error": 1.0,
+        "max_seq_mult_prob_error_after_mask": 1.2,
+        "mean_seq_mult_prob_error_after_mask": 1.1,
+        "min_seq_mult_prob_error_after_mask": 1.0,
+        "num_masked_seqs": 2,
+        "masked_correct_pct": 0.5,
+    }
+
+    def fake_masking(train_data, rewards, seq_logprob_error_threshold):
+        assert seq_logprob_error_threshold == 1.2
+        assert rewards.tolist() == [1.0, 0.0]
+        train_data["sample_mask"] = torch.tensor([1.0, 0.0])
+        return seq_error_result
+
+    monkeypatch.setattr(
+        grpo_sync_mod,
+        "compute_and_apply_seq_logprob_error_masking",
+        fake_masking,
+    )
+
+    sample_mask, metrics = grpo_sync_mod._compute_seq_logprob_error_metrics(
+        token_mask=torch.ones(2, 3),
+        sample_mask=torch.ones(2),
+        prev_logprobs=torch.zeros(2, 3),
+        generation_logprobs=torch.zeros(2, 3),
+        rewards=torch.tensor([1.0, 0.0]),
+        seq_logprob_error_threshold=1.2,
+    )
+
+    assert torch.equal(sample_mask, torch.tensor([1.0, 0.0]))
+    assert metrics["max_seq_mult_prob_error"] == 2.5
+    assert metrics["mean_seq_mult_prob_error"] == 1.5
+    assert metrics["min_seq_mult_prob_error"] == 1.0
+    assert metrics["max_seq_mult_prob_error_after_mask"] == 1.2
+    assert metrics["mean_seq_mult_prob_error_after_mask"] == 1.1
+    assert metrics["min_seq_mult_prob_error_after_mask"] == 1.0
+    assert metrics["num_masked_seqs_by_logprob_error"] == 2
+    assert metrics["masked_correct_pct"] == 0.5
+
+
 # ============================================================================
 # Stub classes for async GRPO testing (non-Ray versions for easy mocking)
 # ============================================================================


### PR DESCRIPTION
# What does this PR do ?

**Context**: The merged PR: https://github.com/NVIDIA-NeMo/RL/pull/2559 was causing failures in `./tests/functional/grpo_dp_simple.sh` (look [here](https://github.com/NVIDIA-NeMo/RL/actions/runs/26559706966/job/78260627397)). The bug was that the changes were not trickled to `grpo_sync.py`.

This PR:
1. Adds relevant changes into `grpo_sync.py`
2. Cleans up some redundant `dict` creations in `grpo.py`
3. Adds unit test to catch this bug.  

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
