### PR TITLE
fix(grpo): grpo_sync dict unpack of seq_logprob error (#2559 follow-up)

### DIFF
--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -769,17 +769,18 @@ def grpo_train_sync(
                         }
                     )
 
-                    (
-                        max_seq_mult_prob_error,
-                        num_masked_seqs,
-                        masked_correct_pct,
-                    ) = compute_and_apply_seq_logprob_error_masking(
+                    seq_error_result = compute_and_apply_seq_logprob_error_masking(
                         train_data=masking_data,
                         rewards=rewards,
                         seq_logprob_error_threshold=master_config.grpo[
                             "seq_logprob_error_threshold"
                         ],
                     )
+                    max_seq_mult_prob_error = seq_error_result[
+                        "max_seq_mult_prob_error"
+                    ]
+                    num_masked_seqs = seq_error_result["num_masked_seqs"]
+                    masked_correct_pct = seq_error_result["masked_correct_pct"]
                     # masking may have mutated sample_mask in place —
                     # capture the post-masking value for delta-write.
                     sample_mask = masking_data["sample_mask"]

--- a/tests/unit/algorithms/test_grpo_sync_seq_err.py
+++ b/tests/unit/algorithms/test_grpo_sync_seq_err.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Targeted coverage for the dict-access fix in ``grpo_sync.py``.
+
+PR #2607 replaces a 3-tuple unpack with a single dict assignment plus three
+explicit dict-key reads:
+
+    seq_error_result = compute_and_apply_seq_logprob_error_masking(...)
+    max_seq_mult_prob_error = seq_error_result["max_seq_mult_prob_error"]
+    num_masked_seqs = seq_error_result["num_masked_seqs"]
+    masked_correct_pct = seq_error_result["masked_correct_pct"]
+
+This module covers (a) the contract those reads depend on and (b) the
+import binding tests must use when monkeypatching the function inside
+``grpo_sync``.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from nemo_rl.algorithms import grpo_sync as grpo_sync_mod
+from nemo_rl.algorithms.grpo import compute_and_apply_seq_logprob_error_masking
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_train_data(
+    batch_size: int = 4,
+    seq_length: int = 10,
+    *,
+    err: float = 0.5,
+) -> BatchedDataDict:
+    """Build a tiny CPU-only train_data dict the masking function can chew on."""
+    prev_logprobs = torch.zeros(batch_size, seq_length)
+    generation_logprobs = torch.zeros(batch_size, seq_length)
+    # Inject a non-zero error on the back half so the metric is non-trivial.
+    generation_logprobs[batch_size // 2 :, 1:5] = err
+
+    return BatchedDataDict(
+        {
+            "token_mask": torch.ones(batch_size, seq_length),
+            "sample_mask": torch.ones(batch_size),
+            "prev_logprobs": prev_logprobs,
+            "generation_logprobs": generation_logprobs,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_grpo_sync_imports_masking_fn_for_monkeypatching() -> None:
+    """``grpo_sync.py`` does ``from nemo_rl.algorithms.grpo import ...``.
+
+    Tests that monkeypatch ``grpo_train_sync`` need to target the binding
+    inside ``nemo_rl.algorithms.grpo_sync``, not the source module — this
+    test pins that contract so we notice if someone refactors the import.
+    """
+    assert hasattr(grpo_sync_mod, "compute_and_apply_seq_logprob_error_masking")
+    assert (
+        grpo_sync_mod.compute_and_apply_seq_logprob_error_masking
+        is compute_and_apply_seq_logprob_error_masking
+    )
+
+
+def test_seq_error_result_exposes_keys_read_by_grpo_sync() -> None:
+    """The 3 keys ``grpo_sync.py:773-783`` reads must be present and scalar.
+
+    grpo_sync.py extracts these three values from the dict returned by
+    ``compute_and_apply_seq_logprob_error_masking``:
+
+        seq_error_result["max_seq_mult_prob_error"]
+        seq_error_result["num_masked_seqs"]
+        seq_error_result["masked_correct_pct"]
+    """
+    train_data = _make_train_data(batch_size=4, seq_length=10, err=0.5)
+    rewards = torch.tensor([1.0, 0.0, 1.0, 0.0])
+
+    seq_error_result = compute_and_apply_seq_logprob_error_masking(
+        train_data=train_data,
+        rewards=rewards,
+        seq_logprob_error_threshold=1.2,
+    )
+
+    # Mirror the grpo_sync.py:772-783 access pattern verbatim.
+    max_seq_mult_prob_error = seq_error_result["max_seq_mult_prob_error"]
+    num_masked_seqs = seq_error_result["num_masked_seqs"]
+    masked_correct_pct = seq_error_result["masked_correct_pct"]
+
+    # Each of those values needs to be a usable scalar — grpo_sync.py
+    # forwards them straight into the train-metrics payload.
+    assert isinstance(max_seq_mult_prob_error, (int, float))
+    assert isinstance(num_masked_seqs, int)
+    assert isinstance(masked_correct_pct, float)
+    assert max_seq_mult_prob_error >= 0.0
+    assert num_masked_seqs >= 0
+    assert 0.0 <= masked_correct_pct <= 1.0
+
+
+def test_seq_error_result_full_key_set_matches_grpo_sync_consumers() -> None:
+    """Lock the full key set so grpo_sync.py never breaks silently.
+
+    grpo_sync.py reads three keys explicitly; the rest flow into metrics
+    via the surrounding aggregation. If any of the eight keys disappear,
+    both grpo.py and grpo_sync.py train-metrics payloads will regress.
+    """
+    train_data = _make_train_data()
+    rewards = torch.tensor([1.0, 0.0, 1.0, 0.0])
+
+    seq_error_result = compute_and_apply_seq_logprob_error_masking(
+        train_data=train_data,
+        rewards=rewards,
+        seq_logprob_error_threshold=None,
+    )
+
+    expected_keys = {
+        "max_seq_mult_prob_error",
+        "mean_seq_mult_prob_error",
+        "min_seq_mult_prob_error",
+        "max_seq_mult_prob_error_after_mask",
+        "mean_seq_mult_prob_error_after_mask",
+        "min_seq_mult_prob_error_after_mask",
+        "num_masked_seqs",
+        "masked_correct_pct",
+    }
+    assert expected_keys.issubset(set(seq_error_result.keys()))
+
+
+def test_grpo_sync_dict_access_pattern_with_monkeypatched_fn(monkeypatch) -> None:
+    """Drive the exact grpo_sync.py:772-783 dict-access block via a stub.
+
+    We cannot cheaply spin up ``grpo_train_sync`` in a unit test (it needs
+    Ray + TQ + a real policy), so instead we monkeypatch the function in
+    the grpo_sync namespace — exactly as a future ``grpo_train_sync`` test
+    would — and then exercise the same dict-access ladder. This pins the
+    namespace target callers must use.
+    """
+    fake_result = {
+        "max_seq_mult_prob_error": 2.5,
+        "mean_seq_mult_prob_error": 1.5,
+        "min_seq_mult_prob_error": 1.0,
+        "max_seq_mult_prob_error_after_mask": 1.2,
+        "mean_seq_mult_prob_error_after_mask": 1.1,
+        "min_seq_mult_prob_error_after_mask": 1.0,
+        "num_masked_seqs": 2,
+        "masked_correct_pct": 0.5,
+    }
+
+    captured: dict[str, object] = {}
+
+    def _stub(*_args, **kwargs) -> dict[str, object]:
+        captured["threshold"] = kwargs.get("seq_logprob_error_threshold")
+        return fake_result
+
+    monkeypatch.setattr(
+        grpo_sync_mod, "compute_and_apply_seq_logprob_error_masking", _stub
+    )
+
+    # Re-resolve the function via the grpo_sync namespace — the same
+    # binding ``grpo_train_sync`` uses internally.
+    fn = grpo_sync_mod.compute_and_apply_seq_logprob_error_masking
+    seq_error_result = fn(
+        train_data=_make_train_data(),
+        rewards=torch.tensor([1.0, 0.0, 1.0, 0.0]),
+        seq_logprob_error_threshold=1.2,
+    )
+
+    # This is the verbatim 3-line access pattern from grpo_sync.py:773-783.
+    max_seq_mult_prob_error = seq_error_result["max_seq_mult_prob_error"]
+    num_masked_seqs = seq_error_result["num_masked_seqs"]
+    masked_correct_pct = seq_error_result["masked_correct_pct"]
+
+    assert max_seq_mult_prob_error == 2.5
+    assert num_masked_seqs == 2
+    assert masked_correct_pct == 0.5
+    assert captured["threshold"] == 1.2


### PR DESCRIPTION
## Summary

PR #2559 changed `compute_and_apply_seq_logprob_error_masking` in
`nemo_rl/algorithms/grpo.py:1294` from a 3-tuple return to a dict
return, and migrated the two existing call sites in grpo.py
(lines 1935 and 3064) to consume the dict via key access. However,
the same day, PR #2439 (data plane transfer queue integration) merged
a NEW call site at `nemo_rl/algorithms/grpo_sync.py:772-781`. PR #2559
never touched grpo_sync.py, so this new call site retained its
3-tuple unpack and now raises `ValueError: too many values to unpack
(expected 3)` at GRPO sync step=1 the moment `data_plane.enabled=true`
is set on `origin/main`.

This PR replaces the 3-tuple unpack in grpo_sync.py with the same
dict-key access pattern used in grpo.py, preserving the existing local
variable names (`max_seq_mult_prob_error`, `num_masked_seqs`,
`masked_correct_pct`) so the downstream metrics emission at
grpo_sync.py:1014-1016 is unchanged.

```diff
-                    (
-                        max_seq_mult_prob_error,
-                        num_masked_seqs,
-                        masked_correct_pct,
-                    ) = compute_and_apply_seq_logprob_error_masking(
+                    seq_error_result = compute_and_apply_seq_logprob_error_masking(
                         train_data=masking_data,
                         rewards=rewards,
                         seq_logprob_error_threshold=master_config.grpo[
                             "seq_logprob_error_threshold"
                         ],
                     )
+                    max_seq_mult_prob_error = seq_error_result[
+                        "max_seq_mult_prob_error"
+                    ]
+                    num_masked_seqs = seq_error_result["num_masked_seqs"]
+                    masked_correct_pct = seq_error_result["masked_correct_pct"]
```

## Root cause

Two PRs landed on `origin/main` within hours of each other on
2026-05-28:

- `64be007eb` "feat(grpo): add sequence-level logprob error metrics" (#2559)
  — refactored `compute_and_apply_seq_logprob_error_masking` to return a
  dict with 8 keys (added `mean_*`, `min_*`, `*_after_mask` variants on
  top of the original 3 fields). Updated the 2 call sites it knew
  about: `grpo.py:1935` and `grpo.py:3064`.
- `4454fa64e` "feat: data plane transfer queue integration" (#2439)
  — added a NEW call site at `grpo_sync.py:772-781` that destructures
  the legacy 3-tuple. This file was never touched by #2559.

Because the two diffs do not overlap textually (different files,
different functions), neither PR's CI run saw the mismatch — each PR
passed in isolation. The bug only surfaces post-merge when both diffs
are present and `data_plane.enabled=true` exercises `grpo_sync.py`.

## Why the existing test did not catch this

The repo's `test_grpo_data_plane_transfer_queue_daily_pr.sh` testcase
(introduced by #2439) does exercise this exact code path. It started
failing immediately on `origin/main` once #2559 merged. This PR is
the fix surfaced by that testcase.

## Test command (functional / e2e)

Container: `/lustre/fsw/coreai_dlalgo_ci/qiaochuz/containers/nemo-rl-nightly-20260528.sqsh`
Cluster: EOS, `coreai_dlalgo_qa`, partition=batch, 1 node, 2× H100
Command (drives both BEFORE and AFTER runs through the daily-PR
testcase plumbing — `_runtime_cherry_pick.sh` ensures `/opt/nemo-rl`
matches `origin/main` HEAD `64be007eb` post-#2559):

```
uv run /opt/nemo-rl/examples/run_grpo.py \
    policy.model_name=Qwen/Qwen3-0.6B \
    grpo.num_prompts_per_step=2 \
    grpo.num_generations_per_prompt=6 \
    grpo.adv_estimator.name=reinforce_plus_plus \
    policy.train_global_batch_size=6 \
    policy.train_micro_batch_size=2 \
    cluster.gpus_per_node=2 \
    grpo.max_num_steps=2 \
    logger.tensorboard_enabled=true \
    logger.wandb_enabled=false \
    checkpointing.enabled=false \
    data_plane.enabled=true \
    data_plane.impl=transfer_queue \
    data_plane.backend=simple
```

## Before fix — run output

SLURM job 5342797 (EOS, `coreai_dlalgo_qa-qiaochuz`, 2× H100,
nemo-rl-nightly-20260528.sqsh, `/opt/nemo-rl` HEAD = `5494d14d5`
post-#2559):

```
==== buggy tuple-unpack at grpo_sync.py:772-781 (BEFORE patch) ====
                    (
                        max_seq_mult_prob_error,
                        num_masked_seqs,
                        masked_correct_pct,
                    ) = compute_and_apply_seq_logprob_error_masking(
                        train_data=masking_data,
                        rewards=rewards,
                        seq_logprob_error_threshold=master_config.grpo[
                            "seq_logprob_error_threshold"
                        ],
                    )
                    sample_mask = masking_data["sample_mask"]
==== end buggy snippet ====

# Run reaches GRPO step=1, generates rollouts, computes rewards, then crashes:

Traceback (most recent call last):
  File "/opt/nemo-rl/examples/run_grpo.py", line 224, in <module>
    main()
  File "/opt/nemo-rl/examples/run_grpo.py", line 207, in main
    trainer(
        policy,
        ...
        master_config,
    )
  File "/opt/nemo-rl/nemo_rl/algorithms/grpo_sync.py", line 772, in grpo_train_sync
    (
    ...
    ) = compute_and_apply_seq_logprob_error_masking(
ValueError: too many values to unpack (expected 3)

# Run finished: status=failed
```

## After fix — run output

SLURM job 5342817 (same cluster + container; patched `grpo_sync.py`
file-overlay'd into `/opt/nemo-rl/nemo_rl/algorithms/grpo_sync.py`
before launching `run_grpo.py`):

```
==== patched grpo_sync.py snippet (AFTER patch) ====
                    seq_error_result = compute_and_apply_seq_logprob_error_masking(
                        train_data=masking_data,
                        rewards=rewards,
                        seq_logprob_error_threshold=master_config.grpo[
                            "seq_logprob_error_threshold"
                        ],
                    )
                    max_seq_mult_prob_error = seq_error_result[
                        "max_seq_mult_prob_error"
                    ]
                    num_masked_seqs = seq_error_result["num_masked_seqs"]
                    masked_correct_pct = seq_error_result["masked_correct_pct"]
                    sample_mask = masking_data["sample_mask"]
==== end patched snippet ====

# Both training steps complete with valid metrics:

🔹 train/loss - 2 steps
  Step 1     Step 2
  -3.06e-05  -2.59e-05

🔹 train/sampling_importance_ratio - 2 steps
Min: 0.999982   Max: 1.00099   Avg: 1.00049

🔹 train/token_mult_prob_error - 2 steps
Min: 1.01462   Max: 1.01717   Avg: 1.01589

🔹 train/total_num_tokens - 2 steps
  Step 1   Step 2
  6144     6144

# Metric-check verdict:

                                 Metric Checks
┏━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
┃ Status ┃ Check                             ┃ Value                 ┃ Message ┃
┡━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
│ PASS   │ len(data["train/loss"]) >= 1      │ 2                     │         │
│ PASS   │ max(data["train/gen_kl_error"]) < │ 0.0007329469081014395 │         │
│        │ 0.02                              │                       │         │
└────────┴───────────────────────────────────┴───────────────────────┴─────────┘
PASS: AFTER-fix GRPO data-plane TransferQueue path completed
```

## Detected by

- NeMo daily-PR impact pipeline gap testcase
  `test_grpo_data_plane_transfer_queue_daily_pr.sh`
- Testcase path:
  `nemo_llm/test_suite/rl/testcases/algorithms/test_grpo_data_plane_transfer_queue_daily_pr.sh`

## Test plan

- [x] Functional / e2e test passes on the patched checkout (logs above)
- [x] Local variable names preserved → metrics emission at
      `grpo_sync.py:1014-1016` unchanged
- [x] Behavior identical to `grpo.py:1935-1962` migration done by #2559
- [ ] Codecov/patch ≥ 80% — a follow-up commit will add a unit test
      covering the 3 new dict-access lines

