### PR TITLE
fix: update ray executor import for vLLM 0.20

### DIFF
--- a/nemo_rl/models/generation/vllm/quantization/fp8.py
+++ b/nemo_rl/models/generation/vllm/quantization/fp8.py
@@ -82,7 +82,7 @@ def monkey_patch_vllm_ray_executor(fp8_config):
     if fp8_config.model_parallel_size > 1:
         # we patch vllm's collective_rpc so that before vllm initalizes the model on each rank, we execute
         # a ray remote that patches each worker with the required fp8 vllm patches
-        from vllm.v1.executor.ray_distributed_executor import RayDistributedExecutor
+        from vllm.v1.executor.ray_executor import RayDistributedExecutor
 
         original_run_workers = RayDistributedExecutor.collective_rpc
 


### PR DESCRIPTION
# What does this PR do ?
fix: update ray executor import for vLLM 0.20

# Issues
vLLM 0.20 renamed the executor module from ray_distributed_executor to ray_executor; the class name RayDistributedExecutor and its collective_rpc method are unchanged. Without this fix, any FP8 generation path that goes through monkey_patch_vllm_ray_executor() with TP*PP > 1 (i.e. any multi-GPU vllm_cfg.precision='fp8' run) fails at worker init with:

  ModuleNotFoundError: No module named 'vllm.v1.executor.ray_distributed_executor'


# Usage
 Verified by running GLM-5.1 64n8g with vllm_cfg.precision='fp8' on sl/glm5.1 before the fix (crashes immediately) and after (5/5 training steps complete cleanly).

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
