### PR TITLE
feat: Numa aware binding

### DIFF
--- a/nemo_rl/distributed/numa_utils.py
+++ b/nemo_rl/distributed/numa_utils.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NUMA-aware CPU affinity and memory binding for GPU workers.
+
+Uses a GPU→cpulist mapping file written by topology_probe.sh (in ray.sub)
+at node startup. The file path is communicated via the NRL_GPU_CPU_AFFINITY_FILE
+environment variable. See ray.sub for the writer side.
+
+Disable all binding with NRL_DISABLE_NUMA_BINDING=1.
+Disable only memory policy with NRL_DISABLE_NUMA_MEMBIND=1.
+"""
+
+import ctypes
+import ctypes.util
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+# IMPORTANT: This default path must stay in sync with topology_probe.sh in ray.sub.
+# The canonical path is set via the NRL_GPU_CPU_AFFINITY_FILE env var exported by ray.sub.
+GPU_CPU_AFFINITY_PATH = os.environ.get(
+    "NRL_GPU_CPU_AFFINITY_FILE", "/tmp/nrl_gpu_cpu_affinity"
+)
+
+
+def bind_to_gpu_numa() -> bool:
+    """Pin the current process to the NUMA-local CPUs and memory of its assigned GPU.
+
+    Reads the GPU→cpulist mapping written by topology_probe.sh at node
+    startup, then calls os.sched_setaffinity() for CPU pinning and
+    numa_set_membind() for memory policy. Best-effort: failures are
+    logged, never raised.
+
+    Returns True if CPU binding succeeded, False if skipped or failed.
+    Memory binding is attempted independently and logged separately.
+    """
+    if os.environ.get("NRL_DISABLE_NUMA_BINDING") == "1":
+        return False
+
+    cvd = os.environ.get("CUDA_VISIBLE_DEVICES", "")
+    if not cvd:
+        return False
+
+    gpu = cvd.split(",")[0]
+    try:
+        with open(GPU_CPU_AFFINITY_PATH) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                idx, cpulist = line.split(":", 1)
+                if idx == gpu:
+                    cpus = _parse_cpulist(cpulist)
+                    os.sched_setaffinity(0, cpus)
+                    logger.info("NUMA CPU binding: GPU %s → CPUs %s", gpu, cpulist)
+                    _set_numa_membind(cpus)
+                    return True
+        logger.debug("NUMA binding: GPU %s not found in %s", gpu, GPU_CPU_AFFINITY_PATH)
+    except FileNotFoundError:
+        logger.debug("NUMA binding skipped: %s not found", GPU_CPU_AFFINITY_PATH)
+    except Exception as exc:
+        logger.debug("NUMA binding skipped: %s", exc)
+    return False
+
+
+def _load_libnuma() -> ctypes.CDLL | None:
+    """Load libnuma, returning None if unavailable."""
+    try:
+        return ctypes.CDLL("libnuma.so.1")
+    except OSError:
+        return None
+
+
+def _get_numa_node(libnuma: ctypes.CDLL, cpus: set[int]) -> int:
+    """Return the NUMA node for the given CPU set, or -1 on failure."""
+    libnuma.numa_node_of_cpu.restype = ctypes.c_int
+    return libnuma.numa_node_of_cpu(min(cpus))
+
+
+def _set_numa_membind(cpus: set[int]) -> bool:
+    """Hard-bind memory allocations to the NUMA node of the given CPUs."""
+    if os.environ.get("NRL_DISABLE_NUMA_MEMBIND") == "1":
+        return False
+
+    libnuma = _load_libnuma()
+    if libnuma is None:
+        logger.debug("NUMA membind skipped: libnuma.so.1 not available")
+        return False
+
+    try:
+        numa_node = _get_numa_node(libnuma, cpus)
+        if numa_node < 0:
+            logger.debug(
+                "NUMA membind skipped: numa_node_of_cpu(%d) returned %d",
+                min(cpus),
+                numa_node,
+            )
+            return False
+
+        libnuma.numa_allocate_nodemask.restype = ctypes.c_void_p
+        libnuma.numa_bitmask_setbit.argtypes = [ctypes.c_void_p, ctypes.c_uint]
+        libnuma.numa_bitmask_setbit.restype = ctypes.c_void_p
+        libnuma.numa_set_membind.argtypes = [ctypes.c_void_p]
+        libnuma.numa_bitmask_free.argtypes = [ctypes.c_void_p]
+
+        nodemask = libnuma.numa_allocate_nodemask()
+        if not nodemask:
+            logger.debug("NUMA membind skipped: numa_allocate_nodemask returned NULL")
+            return False
+
+        try:
+            libnuma.numa_bitmask_setbit(nodemask, numa_node)
+            libnuma.numa_set_membind(nodemask)
+        finally:
+            libnuma.numa_bitmask_free(nodemask)
+
+        logger.info(
+            "NUMA membind: hard-bound to node %d (from CPU %d)", numa_node, min(cpus)
+        )
+        return True
+    except Exception as exc:
+        logger.debug("NUMA membind skipped: %s", exc)
+        return False
+
+
+def _parse_cpulist(cpulist: str) -> set[int]:
+    """Parse a Linux cpulist string like '0-71' into a set of ints."""
+    cpus: set[int] = set()
+    for part in cpulist.split(","):
+        part = part.strip()
+        if "-" in part:
+            lo, hi = part.split("-", 1)
+            cpus.update(range(int(lo), int(hi) + 1))
+        else:
+            cpus.add(int(part))
+    return cpus

--- a/nemo_rl/distributed/numa_utils.py
+++ b/nemo_rl/distributed/numa_utils.py
@@ -36,13 +36,21 @@ GPU_CPU_AFFINITY_PATH = os.environ.get(
 )
 
 
-def bind_to_gpu_numa() -> bool:
-    """Pin the current process to the NUMA-local CPUs and memory of its assigned GPU.
+def bind_to_gpu_numa(gpu_id: int) -> bool:
+    """Pin the current process to the NUMA-local CPUs and memory of the given GPU.
 
     Reads the GPU→cpulist mapping written by topology_probe.sh at node
     startup, then calls os.sched_setaffinity() for CPU pinning and
     numa_set_membind() for memory policy. Best-effort: failures are
     logged, never raised.
+
+    Args:
+        gpu_id: Node-global physical GPU index (``nvidia-smi`` numbering), which
+            is how the affinity file is keyed. Passed explicitly because
+            ``CUDA_VISIBLE_DEVICES`` lists all devices on the node under
+            ``RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1`` and so does not
+            identify a single worker's GPU. In a Ray actor this is
+            ``int(ray.get_gpu_ids()[0])``.
 
     Returns True if CPU binding succeeded, False if skipped or failed.
     Memory binding is attempted independently and logged separately.
@@ -50,11 +58,7 @@ def bind_to_gpu_numa() -> bool:
     if os.environ.get("NRL_DISABLE_NUMA_BINDING") == "1":
         return False
 
-    cvd = os.environ.get("CUDA_VISIBLE_DEVICES", "")
-    if not cvd:
-        return False
-
-    gpu = cvd.split(",")[0]
+    gpu = str(gpu_id)
     try:
         with open(GPU_CPU_AFFINITY_PATH) as f:
             for line in f:
@@ -74,6 +78,34 @@ def bind_to_gpu_numa() -> bool:
     except Exception as exc:
         logger.debug("NUMA binding skipped: %s", exc)
     return False
+
+
+def resolve_visible_gpu_id(local_index: int) -> int | None:
+    """Map a process-local CUDA device index to its node-global physical GPU id.
+
+    ``CUDA_VISIBLE_DEVICES`` lists the physical GPU ids visible to this process
+    in device-index order, and ``local_index`` (e.g.
+    ``torch.cuda.current_device()``) indexes into that list. The affinity file is
+    keyed by the physical id, so return ``CUDA_VISIBLE_DEVICES[local_index]``.
+
+    ``CUDA_VISIBLE_DEVICES`` contents depend on the worker:
+      - vLLM TP>1 (``RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1``): the
+        per-instance device subset, e.g. ``"4,5"``.
+      - vLLM TP=1: a single isolated device, so ``local_index`` is 0.
+
+    Returns the physical GPU id, or None if it cannot be resolved (unset CVD,
+    index out of range, or non-integer entries such as MIG UUIDs).
+    """
+    cvd = os.environ.get("CUDA_VISIBLE_DEVICES", "")
+    if not cvd:
+        return None
+    devices = cvd.split(",")
+    if local_index < 0 or local_index >= len(devices):
+        return None
+    try:
+        return int(devices[local_index])
+    except ValueError:
+        return None
 
 
 def _load_libnuma() -> ctypes.CDLL | None:

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -92,6 +92,12 @@ def _read_mtp_layer_weights_from_checkpoint(
 
 
 class VllmInternalWorkerExtension:
+    def bind_numa(self) -> bool:
+        """Pin this TP worker to the NUMA-local CPUs of its GPU."""
+        from nemo_rl.distributed.numa_utils import bind_to_gpu_numa
+
+        return bind_to_gpu_numa()
+
     def init_collective(
         self,
         rank_prefix: int,

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -93,10 +93,23 @@ def _read_mtp_layer_weights_from_checkpoint(
 
 class VllmInternalWorkerExtension:
     def bind_numa(self) -> bool:
-        """Pin this TP worker to the NUMA-local CPUs of its GPU."""
-        from nemo_rl.distributed.numa_utils import bind_to_gpu_numa
+        """Pin this TP worker to its GPU's NUMA-local CPUs/memory.
 
-        return bind_to_gpu_numa()
+        Invoked via ``collective_rpc`` on each vLLM TP worker once the engine
+        (and CUDA) is up, so the worker's physical GPU id is resolved from its
+        local device index (see ``resolve_visible_gpu_id``).
+        """
+        import torch
+
+        from nemo_rl.distributed.numa_utils import (
+            bind_to_gpu_numa,
+            resolve_visible_gpu_id,
+        )
+
+        gpu_id = resolve_visible_gpu_id(torch.cuda.current_device())
+        if gpu_id is None:
+            return False
+        return bind_to_gpu_numa(gpu_id)
 
     def init_collective(
         self,

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -190,8 +190,10 @@ class BaseVllmGenerationWorker:
         # (which inherits sched_setaffinity + numa_set_membind via fork).
         # Individual TP workers get their own NUMA binding via collective_rpc
         # in post_init / post_init_async.
+        # ray.get_gpu_ids()[0] is this worker's physical GPU index, which keys
+        # the affinity file.
         if bundle_indices is not None and len(bundle_indices) == 1:
-            bind_to_gpu_numa()
+            bind_to_gpu_numa(int(ray.get_gpu_ids()[0]))
 
         self._init_config(
             config, bundle_indices, fraction_of_gpus, seed, extra_env_vars

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -182,6 +182,17 @@ class BaseVllmGenerationWorker:
                 _load_model() later to perform the heavy model loading. This
                 enables overlapping vLLM model loading with NeMo Gym init.
         """
+        from nemo_rl.distributed.numa_utils import bind_to_gpu_numa
+
+        # Only bind single-GPU workers to their GPU's NUMA node.
+        # For TP>1 workers, the parent process spans multiple NUMA nodes;
+        # binding it would incorrectly constrain the EngineCore subprocess
+        # (which inherits sched_setaffinity + numa_set_membind via fork).
+        # Individual TP workers get their own NUMA binding via collective_rpc
+        # in post_init / post_init_async.
+        if bundle_indices is not None and len(bundle_indices) == 1:
+            bind_to_gpu_numa()
+
         self._init_config(
             config, bundle_indices, fraction_of_gpus, seed, extra_env_vars
         )
@@ -589,6 +600,8 @@ class VllmGenerationWorkerImpl(BaseVllmGenerationWorker):
         self.llm = vllm.LLM(**llm_kwargs)
 
     def post_init(self):
+        if self.llm is not None:
+            self.llm.collective_rpc("bind_numa", args=tuple())
         self.vllm_device_ids = self.report_device_id()
         if self._mtp_load_from_disk:
             self.llm.collective_rpc(

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -422,6 +422,8 @@ class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
             self.generation_tokens = []
 
     async def post_init_async(self):
+        if self.llm is not None:
+            await self.llm.collective_rpc("bind_numa", args=tuple())
         self.vllm_device_ids = await self.report_device_id_async()
         if self._mtp_load_from_disk:
             await self.llm.collective_rpc(

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -200,6 +200,13 @@ class DTensorPolicyWorkerImpl(
         **kwargs: Any,
     ):
         """Initialize the DTensorPolicyWorker."""
+        from nemo_rl.distributed.numa_utils import bind_to_gpu_numa
+
+        # Pin this worker to its GPU's NUMA-local CPUs/memory before any CUDA
+        # init or model load (mirrors the Megatron and vLLM workers). FSDP's
+        # D2H paths — weight refit, optimizer/checkpoint offload — benefit too.
+        bind_to_gpu_numa()
+
         self.tokenizer = tokenizer
         self.processor = processor
         self.is_vlm = processor is not None

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -202,10 +202,11 @@ class DTensorPolicyWorkerImpl(
         """Initialize the DTensorPolicyWorker."""
         from nemo_rl.distributed.numa_utils import bind_to_gpu_numa
 
-        # Pin this worker to its GPU's NUMA-local CPUs/memory before any CUDA
-        # init or model load (mirrors the Megatron and vLLM workers). FSDP's
-        # D2H paths — weight refit, optimizer/checkpoint offload — benefit too.
-        bind_to_gpu_numa()
+        # Pin to this worker's GPU-local CPUs/memory before CUDA init or model
+        # load; FSDP's D2H paths (weight refit, optimizer/checkpoint offload)
+        # benefit. ray.get_gpu_ids()[0] is the physical GPU index that keys the
+        # affinity file, and reading it does not initialize CUDA.
+        bind_to_gpu_numa(int(ray.get_gpu_ids()[0]))
 
         self.tokenizer = tokenizer
         self.processor = processor

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -231,6 +231,13 @@ class DTensorPolicyWorkerV2Impl(
         # Apply TE patch until TE is upgraded to 2.10.0
         apply_transformer_engine_patch()
 
+        from nemo_rl.distributed.numa_utils import bind_to_gpu_numa
+
+        # Pin this worker to its GPU's NUMA-local CPUs/memory before model load
+        # (mirrors the Megatron and vLLM workers). FSDP's D2H paths — weight
+        # refit, optimizer/checkpoint offload — benefit too.
+        bind_to_gpu_numa()
+
         # Store configuration
         self.cfg = config
 

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -233,10 +233,11 @@ class DTensorPolicyWorkerV2Impl(
 
         from nemo_rl.distributed.numa_utils import bind_to_gpu_numa
 
-        # Pin this worker to its GPU's NUMA-local CPUs/memory before model load
-        # (mirrors the Megatron and vLLM workers). FSDP's D2H paths — weight
-        # refit, optimizer/checkpoint offload — benefit too.
-        bind_to_gpu_numa()
+        # Pin to this worker's GPU-local CPUs/memory before model load; FSDP's
+        # D2H paths (weight refit, optimizer/checkpoint offload) benefit.
+        # ray.get_gpu_ids()[0] is the physical GPU index that keys the affinity
+        # file, and reading it does not initialize CUDA.
+        bind_to_gpu_numa(int(ray.get_gpu_ids()[0]))
 
         # Store configuration
         self.cfg = config

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -278,7 +278,11 @@ class MegatronPolicyWorkerImpl(
 
         from nemo_rl.distributed.numa_utils import bind_to_gpu_numa
 
-        bind_to_gpu_numa()
+        # local_rank (== ray.get_gpu_ids()[0]) is the physical GPU index that
+        # keys the affinity file. Pass it explicitly: CUDA_VISIBLE_DEVICES lists
+        # all node devices here (RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1,
+        # set by configure_worker), so it can't identify this worker's GPU.
+        bind_to_gpu_numa(local_rank)
 
         self.cfg = config
         self._router_replay_enabled = router_replay_enabled(config)

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -276,6 +276,10 @@ class MegatronPolicyWorkerImpl(
         # Apply patch from https://github.com/NVIDIA/TransformerEngine/pull/2286/files
         apply_transformer_engine_patch()
 
+        from nemo_rl.distributed.numa_utils import bind_to_gpu_numa
+
+        bind_to_gpu_numa()
+
         self.cfg = config
         self._router_replay_enabled = router_replay_enabled(config)
 

--- a/nemo_rl/models/value/workers/dtensor_value_worker_v2.py
+++ b/nemo_rl/models/value/workers/dtensor_value_worker_v2.py
@@ -148,6 +148,14 @@ class DTensorValueWorkerV2Impl(AbstractPolicyWorker):
         # Apply patches
         apply_transformer_engine_patch()
 
+        from nemo_rl.distributed.numa_utils import bind_to_gpu_numa
+
+        # Pin to this worker's GPU-local CPUs/memory before model load; FSDP's
+        # D2H paths (weight refit, optimizer/checkpoint offload) benefit.
+        # ray.get_gpu_ids()[0] is the physical GPU index that keys the affinity
+        # file, and reading it does not initialize CUDA.
+        bind_to_gpu_numa(int(ray.get_gpu_ids()[0]))
+
         # Store configuration and tokenizer
         self.cfg = config
         self.tokenizer = tokenizer

--- a/nemo_rl/models/value/workers/megatron_value_worker.py
+++ b/nemo_rl/models/value/workers/megatron_value_worker.py
@@ -293,9 +293,12 @@ class MegatronValueWorkerImpl(AbstractPolicyWorker):
 
         from nemo_rl.distributed.numa_utils import bind_to_gpu_numa
 
-        # Pin this value worker to its GPU's NUMA-local CPUs/memory before model
-        # load (mirrors the Megatron/DTensor policy workers and vLLM workers).
-        bind_to_gpu_numa()
+        # Pin to this worker's GPU-local CPUs/memory before model load, matching
+        # the policy workers. local_rank (== ray.get_gpu_ids()[0]) is the physical
+        # GPU index that keys the affinity file. Pass it explicitly:
+        # CUDA_VISIBLE_DEVICES lists all node devices here
+        # (RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1).
+        bind_to_gpu_numa(local_rank)
 
         self.cfg = config
         self.rank = get_rank_safe()

--- a/nemo_rl/models/value/workers/megatron_value_worker.py
+++ b/nemo_rl/models/value/workers/megatron_value_worker.py
@@ -291,6 +291,12 @@ class MegatronValueWorkerImpl(AbstractPolicyWorker):
 
         apply_transformer_engine_patch()
 
+        from nemo_rl.distributed.numa_utils import bind_to_gpu_numa
+
+        # Pin this value worker to its GPU's NUMA-local CPUs/memory before model
+        # load (mirrors the Megatron/DTensor policy workers and vLLM workers).
+        bind_to_gpu_numa()
+
         self.cfg = config
         self.rank = get_rank_safe()
 

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -114,6 +114,7 @@ project-includes = [
   "nemo_rl/distributed/__init__.py",
   "nemo_rl/distributed/collectives.py",
   "nemo_rl/distributed/named_sharding.py",
+  "nemo_rl/distributed/numa_utils.py",
   "nemo_rl/distributed/ray_actor_environment_registry.py",
   "nemo_rl/distributed/virtual_cluster.py",
   "nemo_rl/distributed/worker_group_utils.py",

--- a/ray.sub
+++ b/ray.sub
@@ -423,6 +423,18 @@ else
   fi
 fi
 
+# Write GPU→cpulist mapping for NUMA binding.
+# IMPORTANT: The env var name NRL_GPU_CPU_AFFINITY_FILE and default path must stay
+# in sync with GPU_CPU_AFFINITY_PATH in nemo_rl/distributed/numa_utils.py.
+export NRL_GPU_CPU_AFFINITY_FILE="/tmp/nrl_gpu_cpu_affinity"
+nvidia-smi topo -m 2>/dev/null | awk '/^GPU[0-9]/ { gpu = \$1; sub(/GPU/, "", gpu); print gpu ":" \$(NF-2) }' > "\$NRL_GPU_CPU_AFFINITY_FILE" || true
+if [[ -s "\$NRL_GPU_CPU_AFFINITY_FILE" ]]; then
+  echo "NUMA affinity map written to \$NRL_GPU_CPU_AFFINITY_FILE:"
+  cat "\$NRL_GPU_CPU_AFFINITY_FILE"
+else
+  echo "WARNING: Could not generate NUMA affinity map (nvidia-smi topo unavailable)"
+fi
+
 # Use \\\" so that when --resources="\$RAY_RESOURCES" expands, we pass valid JSON to ray
 # IMPORTANT: The key names "nvlink_domain_" and "topo_rank" below must stay in sync
 # with the constants NVLINK_DOMAIN_PREFIX and TOPO_RANK_KEY defined in

--- a/ray.sub
+++ b/ray.sub
@@ -430,10 +430,13 @@ export NRL_GPU_CPU_AFFINITY_FILE="/tmp/nrl_gpu_cpu_affinity"
 # nvidia-smi topo -m's CPU Affinity column is unreliable on GB200 (empty for
 # GPUs not directly attached to the socket). Use NUMA Affinity (always
 # populated, at field NF-1 since GPU NUMA ID is last) and look up the
-# node-local CPU list from sysfs.
+# node-local CPU list from sysfs. On GB200 the NUMA Affinity column can be a
+# list like "0,2-17" (the GPU-local CPU NUMA node plus the GPU's HBM NUMA
+# nodes); take the first entry, which is the local CPU NUMA node.
 nvidia-smi topo -m 2>/dev/null | awk '/^GPU[0-9]/ {
   gpu = \$1; sub(/GPU/, "", gpu)
   numa = \$(NF-1)
+  sub(/[,-].*/, "", numa)
   if (numa ~ /^[0-9]+\$/) print gpu, numa
 }' | while read -r _gpu _numa; do
   _cpulist=\$(cat "/sys/devices/system/node/node\${_numa}/cpulist" 2>/dev/null)

--- a/ray.sub
+++ b/ray.sub
@@ -427,7 +427,20 @@ fi
 # IMPORTANT: The env var name NRL_GPU_CPU_AFFINITY_FILE and default path must stay
 # in sync with GPU_CPU_AFFINITY_PATH in nemo_rl/distributed/numa_utils.py.
 export NRL_GPU_CPU_AFFINITY_FILE="/tmp/nrl_gpu_cpu_affinity"
-nvidia-smi topo -m 2>/dev/null | awk '/^GPU[0-9]/ { gpu = \$1; sub(/GPU/, "", gpu); print gpu ":" \$(NF-2) }' > "\$NRL_GPU_CPU_AFFINITY_FILE" || true
+# nvidia-smi topo -m's CPU Affinity column is unreliable on GB200 (empty for
+# GPUs not directly attached to the socket). Use NUMA Affinity (always
+# populated, at field NF-1 since GPU NUMA ID is last) and look up the
+# node-local CPU list from sysfs.
+nvidia-smi topo -m 2>/dev/null | awk '/^GPU[0-9]/ {
+  gpu = \$1; sub(/GPU/, "", gpu)
+  numa = \$(NF-1)
+  if (numa ~ /^[0-9]+\$/) print gpu, numa
+}' | while read -r _gpu _numa; do
+  _cpulist=\$(cat "/sys/devices/system/node/node\${_numa}/cpulist" 2>/dev/null)
+  if [[ -n "\$_cpulist" ]]; then
+    echo "\${_gpu}:\${_cpulist}"
+  fi
+done > "\$NRL_GPU_CPU_AFFINITY_FILE" || true
 if [[ -s "\$NRL_GPU_CPU_AFFINITY_FILE" ]]; then
   echo "NUMA affinity map written to \$NRL_GPU_CPU_AFFINITY_FILE:"
   cat "\$NRL_GPU_CPU_AFFINITY_FILE"

--- a/tests/unit/distributed/test_numa_utils.py
+++ b/tests/unit/distributed/test_numa_utils.py
@@ -1,0 +1,447 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for NUMA-aware CPU affinity and memory binding.
+
+Unit tests run anywhere (no GPU needed). The benchmark test
+(TestNUMABindingBenchmark) requires a GPU and libnuma and is
+skipped otherwise — run it inside the RL container on a DGX/GB200
+to validate that binding actually improves D2H performance.
+"""
+
+import os
+import subprocess
+import tempfile
+
+import pytest
+
+from nemo_rl.distributed.numa_utils import (
+    _get_numa_node,
+    _load_libnuma,
+    _parse_cpulist,
+    _set_numa_membind,
+    bind_to_gpu_numa,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_affinity_file_from_topo() -> str | None:
+    """Parse nvidia-smi topo and write a GPU→cpulist affinity file.
+
+    This replicates what topology_probe.sh in ray.sub does at node startup:
+      nvidia-smi topo -m | awk '/^GPU[0-9]/ { ... print gpu ":" $(NF-2) }'
+
+    nvidia-smi topo -m output format (GB200 NVL72 example):
+
+            GPU0  GPU1  GPU2  GPU3  NIC0 ... NIC5  CPU Affinity  NUMA Affinity  GPU NUMA ID
+        GPU0  X    NV18  NV18  NV18  NODE ... SYS   0-71          0              N/A
+        GPU1 NV18   X    NV18  NV18  NODE ... SYS   0-71          0              N/A
+        GPU2 NV18  NV18   X    NV18  SYS  ... NODE  72-143        1              N/A
+        GPU3 NV18  NV18  NV18   X    SYS  ... NODE  72-143        1              N/A
+        NIC0 NODE  NODE  SYS   SYS    X   ... SYS
+        ...
+
+    The header row is indented (starts with whitespace), so startswith("GPU")
+    skips it. NIC rows start with "NIC", not "GPU", so they're also skipped.
+
+    The three trailing columns on GPU rows (whitespace-split) are:
+        parts[-3] = CPU Affinity  (e.g. "0-71")    ← what we extract
+        parts[-2] = NUMA Affinity (e.g. "0")
+        parts[-1] = GPU NUMA ID   (e.g. "N/A" or a number like "2")
+
+    The resulting affinity file has one line per GPU:
+        0:0-71
+        1:0-71
+        2:72-143
+        3:72-143
+
+    Returns the path to the temp file, or None if parsing fails.
+    """
+    try:
+        output = subprocess.run(
+            ["nvidia-smi", "topo", "-m"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        ).stdout
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+
+    entries: list[str] = []
+    for line in output.splitlines():
+        if not line.startswith("GPU"):
+            continue
+        parts = line.split()
+        gpu_idx = parts[0].replace("GPU", "")
+        cpulist = parts[-3]
+        if "-" in cpulist and any(c.isdigit() for c in cpulist):
+            entries.append(f"{gpu_idx}:{cpulist}")
+
+    if not entries:
+        return None
+
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False)
+    f.write("\n".join(entries) + "\n")
+    f.flush()
+    f.close()
+    return f.name
+
+
+def _reset_membind_to_all() -> None:
+    """Reset NUMA memory policy to allow allocations from all nodes.
+
+    Used to establish the "unbound" baseline in benchmarks. In production
+    code we only bind (never unbind), so this helper is test-only.
+    """
+    libnuma = _load_libnuma()
+    if libnuma is None:
+        return
+
+    import ctypes
+
+    libnuma.numa_set_membind.argtypes = [ctypes.c_void_p]
+    libnuma.numa_allocate_nodemask.restype = ctypes.c_void_p
+    libnuma.numa_bitmask_setbit.argtypes = [ctypes.c_void_p, ctypes.c_uint]
+    libnuma.numa_bitmask_setbit.restype = ctypes.c_void_p
+    libnuma.numa_bitmask_free.argtypes = [ctypes.c_void_p]
+    libnuma.numa_max_node.restype = ctypes.c_int
+
+    max_node = libnuma.numa_max_node()
+    nodemask = libnuma.numa_allocate_nodemask()
+    for n in range(max_node + 1):
+        libnuma.numa_bitmask_setbit(nodemask, n)
+    libnuma.numa_set_membind(nodemask)
+    libnuma.numa_bitmask_free(nodemask)
+
+
+def _reset_all_bindings() -> None:
+    """Reset both CPU affinity and memory policy to unbound defaults."""
+    os.sched_setaffinity(0, set(range(os.cpu_count() or 256)))
+    _reset_membind_to_all()
+
+
+def _patch_affinity_path(path: str):
+    """Temporarily override GPU_CPU_AFFINITY_PATH in the numa_utils module."""
+    import nemo_rl.distributed.numa_utils as mod
+
+    old = mod.GPU_CPU_AFFINITY_PATH
+    mod.GPU_CPU_AFFINITY_PATH = path
+    return old
+
+
+# ---------------------------------------------------------------------------
+# Pure unit tests (no GPU or libnuma required)
+# ---------------------------------------------------------------------------
+
+
+class TestParseCpulist:
+    def test_single_range(self):
+        assert _parse_cpulist("0-71") == set(range(72))
+
+    def test_multiple_ranges(self):
+        assert _parse_cpulist("0-3,8-11") == {0, 1, 2, 3, 8, 9, 10, 11}
+
+    def test_single_values(self):
+        assert _parse_cpulist("0,4,8") == {0, 4, 8}
+
+    def test_mixed(self):
+        assert _parse_cpulist("0-2,5,10-12") == {0, 1, 2, 5, 10, 11, 12}
+
+    def test_whitespace(self):
+        assert _parse_cpulist(" 0-3 , 8 ") == {0, 1, 2, 3, 8}
+
+    def test_single_cpu(self):
+        assert _parse_cpulist("42") == {42}
+
+
+class TestBindToGpuNuma:
+    """Test bind_to_gpu_numa logic with mock affinity files."""
+
+    def test_disabled_via_env(self, monkeypatch):
+        monkeypatch.setenv("NRL_DISABLE_NUMA_BINDING", "1")
+        assert bind_to_gpu_numa() is False
+
+    def test_no_cuda_visible_devices(self, monkeypatch):
+        monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+        monkeypatch.delenv("NRL_DISABLE_NUMA_BINDING", raising=False)
+        assert bind_to_gpu_numa() is False
+
+    def test_empty_cuda_visible_devices(self, monkeypatch):
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
+        monkeypatch.delenv("NRL_DISABLE_NUMA_BINDING", raising=False)
+        assert bind_to_gpu_numa() is False
+
+    def test_missing_affinity_file(self, monkeypatch):
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
+        monkeypatch.delenv("NRL_DISABLE_NUMA_BINDING", raising=False)
+
+        old_path = _patch_affinity_path("/nonexistent/path")
+        try:
+            assert bind_to_gpu_numa() is False
+        finally:
+            _patch_affinity_path(old_path)
+
+    def test_gpu_not_in_file(self, monkeypatch):
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "7")
+        monkeypatch.delenv("NRL_DISABLE_NUMA_BINDING", raising=False)
+        monkeypatch.setenv("NRL_DISABLE_NUMA_MEMBIND", "1")
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("0:0-71\n1:0-71\n2:72-143\n3:72-143\n")
+            f.flush()
+
+            old_path = _patch_affinity_path(f.name)
+            try:
+                assert bind_to_gpu_numa() is False
+            finally:
+                _patch_affinity_path(old_path)
+                os.unlink(f.name)
+
+    def test_successful_cpu_binding(self, monkeypatch):
+        """Verify sched_setaffinity is called with the correct CPU set."""
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2")
+        monkeypatch.delenv("NRL_DISABLE_NUMA_BINDING", raising=False)
+        monkeypatch.setenv("NRL_DISABLE_NUMA_MEMBIND", "1")
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("0:0-71\n1:0-71\n2:72-143\n3:72-143\n")
+            f.flush()
+
+            old_path = _patch_affinity_path(f.name)
+            try:
+                result = bind_to_gpu_numa()
+                assert result is True
+                bound_cpus = os.sched_getaffinity(0)
+                assert bound_cpus == set(range(72, 144))
+            finally:
+                _patch_affinity_path(old_path)
+                os.unlink(f.name)
+                _reset_all_bindings()
+
+    def test_multi_gpu_cvd_uses_first(self, monkeypatch):
+        """When CUDA_VISIBLE_DEVICES=2,3 we bind to GPU 2's cpulist."""
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2,3")
+        monkeypatch.delenv("NRL_DISABLE_NUMA_BINDING", raising=False)
+        monkeypatch.setenv("NRL_DISABLE_NUMA_MEMBIND", "1")
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("0:0-71\n1:0-71\n2:72-143\n3:72-143\n")
+            f.flush()
+
+            old_path = _patch_affinity_path(f.name)
+            try:
+                result = bind_to_gpu_numa()
+                assert result is True
+                bound_cpus = os.sched_getaffinity(0)
+                assert bound_cpus == set(range(72, 144))
+            finally:
+                _patch_affinity_path(old_path)
+                os.unlink(f.name)
+                _reset_all_bindings()
+
+
+class TestSetNumaMembind:
+    """Test membind with libnuma (skipped if libnuma unavailable)."""
+
+    @pytest.fixture(autouse=True)
+    def _check_libnuma(self):
+        if _load_libnuma() is None:
+            pytest.skip("libnuma.so.1 not available")
+
+    def test_membind_disabled(self, monkeypatch):
+        monkeypatch.setenv("NRL_DISABLE_NUMA_MEMBIND", "1")
+        assert _set_numa_membind({0, 1, 2}) is False
+
+    def test_membind_succeeds(self, monkeypatch):
+        monkeypatch.delenv("NRL_DISABLE_NUMA_MEMBIND", raising=False)
+        cpus = os.sched_getaffinity(0)
+        assert _set_numa_membind(cpus) is True
+
+    def test_get_numa_node_valid(self):
+        libnuma = _load_libnuma()
+        node = _get_numa_node(libnuma, {0})
+        assert node >= 0
+
+
+# ---------------------------------------------------------------------------
+# GPU benchmark test — validates binding has measurable impact on D2H
+# ---------------------------------------------------------------------------
+
+HAS_CUDA = False
+try:
+    import torch
+
+    HAS_CUDA = torch.cuda.is_available()
+except ImportError:
+    pass
+
+HAS_LIBNUMA = _load_libnuma() is not None
+
+
+@pytest.mark.skipif(not HAS_CUDA, reason="No CUDA GPU available")
+@pytest.mark.skipif(not HAS_LIBNUMA, reason="libnuma.so.1 not available")
+class TestNUMABindingBenchmark:
+    """D2H bandwidth benchmark to validate NUMA binding impact.
+
+    Run inside the RL container on a multi-socket node (DGX or GB200):
+
+        CUDA_VISIBLE_DEVICES=0 pytest tests/unit/distributed/test_numa_utils.py::TestNUMABindingBenchmark -v -s
+
+    The test measures D2H copy time with and without NUMA binding and
+    reports the speedup. It also verifies the process is correctly bound
+    to the expected NUMA node for the assigned GPU.
+    """
+
+    TENSOR_ELEMENTS = 64 * 1024 * 1024  # 256 MB at float32
+    WARMUP_ITERS = 10
+    BENCH_ITERS = 50
+
+    def _d2h_bandwidth_ms(self) -> float:
+        """Measure average D2H copy time in milliseconds."""
+        t_gpu = torch.randn(self.TENSOR_ELEMENTS, device="cuda", dtype=torch.float32)
+
+        for _ in range(self.WARMUP_ITERS):
+            _ = t_gpu.to("cpu", non_blocking=True)
+            torch.cuda.synchronize()
+
+        torch.cuda.synchronize()
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+
+        start.record()
+        for _ in range(self.BENCH_ITERS):
+            _ = t_gpu.to("cpu", non_blocking=True)
+        end.record()
+        torch.cuda.synchronize()
+
+        return start.elapsed_time(end) / self.BENCH_ITERS
+
+    def test_d2h_with_numa_binding(self):
+        """Measure D2H bandwidth before and after NUMA binding.
+
+        This test does NOT assert a specific speedup (it varies by
+        platform) — it reports the numbers so you can compare.
+        The key assertion is that binding succeeds and the process
+        ends up on the expected NUMA node.
+        """
+        cvd = os.environ.get("CUDA_VISIBLE_DEVICES", "")
+        if not cvd:
+            pytest.skip(
+                "CUDA_VISIBLE_DEVICES not set — run with CUDA_VISIBLE_DEVICES=N"
+            )
+
+        # Baseline: reset to fully unbound (all CPUs, all NUMA nodes)
+        _reset_all_bindings()
+        unbound_ms = self._d2h_bandwidth_ms()
+
+        # Generate the affinity file from live nvidia-smi topo
+        affinity_file = _write_affinity_file_from_topo()
+        if affinity_file is None:
+            pytest.skip("Could not parse nvidia-smi topo output")
+
+        # Apply NUMA binding (CPU affinity + membind)
+        old_path = _patch_affinity_path(affinity_file)
+        gpu_str = cvd.split(",")[0]
+        try:
+            result = bind_to_gpu_numa()
+            assert result is True, f"bind_to_gpu_numa() failed for GPU {gpu_str}"
+        finally:
+            _patch_affinity_path(old_path)
+
+        bound_cpus = os.sched_getaffinity(0)
+        libnuma = _load_libnuma()
+        numa_node = _get_numa_node(libnuma, bound_cpus)
+        assert numa_node >= 0, (
+            f"Could not determine NUMA node for CPU {min(bound_cpus)}"
+        )
+
+        bound_ms = self._d2h_bandwidth_ms()
+        speedup = unbound_ms / bound_ms if bound_ms > 0 else float("inf")
+
+        print(f"\n{'=' * 60}")
+        print(f"NUMA Binding D2H Benchmark (GPU {gpu_str})")
+        print(f"{'=' * 60}")
+        print(
+            f"  Tensor size:    {self.TENSOR_ELEMENTS * 4 / 1024 / 1024:.0f} MB (float32)"
+        )
+        print(f"  Iterations:     {self.BENCH_ITERS}")
+        print(f"  Unbound D2H:    {unbound_ms:.3f} ms/iter")
+        print(f"  Bound D2H:      {bound_ms:.3f} ms/iter")
+        print(f"  Speedup:        {speedup:.3f}x")
+        print(f"  Bound CPUs:     {min(bound_cpus)}-{max(bound_cpus)}")
+        print(f"  NUMA node:      {numa_node}")
+        print(f"{'=' * 60}")
+
+        os.unlink(affinity_file)
+        _reset_all_bindings()
+
+    def test_actor_mapping_correctness(self):
+        """Verify that bind_to_gpu_numa places the process on the correct NUMA node.
+
+        For each GPU on the node, sets CUDA_VISIBLE_DEVICES, calls
+        bind_to_gpu_numa, and checks that the resulting CPU affinity
+        and NUMA node match nvidia-smi topo.
+        """
+        affinity_file = _write_affinity_file_from_topo()
+        if affinity_file is None:
+            pytest.skip("Could not parse nvidia-smi topo output")
+
+        # Read back the affinity file to get the expected mapping
+        gpu_map: dict[str, str] = {}
+        with open(affinity_file) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    idx, cpulist = line.split(":", 1)
+                    gpu_map[idx] = cpulist
+
+        libnuma = _load_libnuma()
+        old_path = _patch_affinity_path(affinity_file)
+        old_cvd = os.environ.get("CUDA_VISIBLE_DEVICES", "")
+
+        results = []
+        try:
+            for gpu_idx, expected_cpulist in gpu_map.items():
+                _reset_all_bindings()
+                os.environ["CUDA_VISIBLE_DEVICES"] = gpu_idx
+
+                result = bind_to_gpu_numa()
+                assert result is True, f"bind_to_gpu_numa() failed for GPU {gpu_idx}"
+
+                bound_cpus = os.sched_getaffinity(0)
+                expected_cpus = _parse_cpulist(expected_cpulist)
+                assert bound_cpus == expected_cpus, (
+                    f"GPU {gpu_idx}: expected CPUs {expected_cpulist}, "
+                    f"got {min(bound_cpus)}-{max(bound_cpus)}"
+                )
+
+                numa_node = _get_numa_node(libnuma, bound_cpus)
+                results.append((gpu_idx, expected_cpulist, numa_node))
+        finally:
+            _patch_affinity_path(old_path)
+            if old_cvd:
+                os.environ["CUDA_VISIBLE_DEVICES"] = old_cvd
+            else:
+                os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+            _reset_all_bindings()
+            os.unlink(affinity_file)
+
+        print(f"\n{'=' * 60}")
+        print("Actor → GPU → NUMA Mapping Verification")
+        print(f"{'=' * 60}")
+        for gpu_idx, cpulist, numa_node in results:
+            print(f"  GPU {gpu_idx} → CPUs {cpulist} → NUMA node {numa_node}")
+        print(f"{'=' * 60}")

--- a/tests/unit/distributed/test_numa_utils.py
+++ b/tests/unit/distributed/test_numa_utils.py
@@ -148,6 +148,21 @@ def _patch_affinity_path(path: str):
     return old
 
 
+def _split_available_cpus() -> tuple[list[int], list[int]] | tuple[None, None]:
+    """Split the CPUs available to this process into two non-empty groups.
+
+    Lets the CPU-binding tests exercise a real ``os.sched_setaffinity`` on any
+    host instead of hard-coding a 144-CPU (GB200) layout that fails on smaller
+    machines. Returns ``(group0, group1)`` as sorted lists, or ``(None, None)``
+    when there are fewer than 2 available CPUs to split.
+    """
+    avail = sorted(os.sched_getaffinity(0))
+    if len(avail) < 2:
+        return None, None
+    mid = len(avail) // 2
+    return avail[:mid], avail[mid:]
+
+
 # ---------------------------------------------------------------------------
 # Pure unit tests (no GPU or libnuma required)
 # ---------------------------------------------------------------------------
@@ -222,8 +237,17 @@ class TestBindToGpuNuma:
         monkeypatch.delenv("NRL_DISABLE_NUMA_BINDING", raising=False)
         monkeypatch.setenv("NRL_DISABLE_NUMA_MEMBIND", "1")
 
+        # Derive the cpulist from the CPUs actually available to this process so
+        # the test is host-portable. GPUs 0/1 map to the first CPU group, GPUs
+        # 2/3 to the second; binding GPU 2 should land us on the second group.
+        group0, group1 = _split_available_cpus()
+        if group1 is None:
+            pytest.skip("need >= 2 available CPUs to exercise NUMA CPU binding")
+        cpus0 = ",".join(map(str, group0))
+        cpus1 = ",".join(map(str, group1))
+
         with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
-            f.write("0:0-71\n1:0-71\n2:72-143\n3:72-143\n")
+            f.write(f"0:{cpus0}\n1:{cpus0}\n2:{cpus1}\n3:{cpus1}\n")
             f.flush()
 
             old_path = _patch_affinity_path(f.name)
@@ -231,7 +255,7 @@ class TestBindToGpuNuma:
                 result = bind_to_gpu_numa()
                 assert result is True
                 bound_cpus = os.sched_getaffinity(0)
-                assert bound_cpus == set(range(72, 144))
+                assert bound_cpus == set(group1)
             finally:
                 _patch_affinity_path(old_path)
                 os.unlink(f.name)
@@ -243,8 +267,15 @@ class TestBindToGpuNuma:
         monkeypatch.delenv("NRL_DISABLE_NUMA_BINDING", raising=False)
         monkeypatch.setenv("NRL_DISABLE_NUMA_MEMBIND", "1")
 
+        # Host-portable cpulist (see test_successful_cpu_binding).
+        group0, group1 = _split_available_cpus()
+        if group1 is None:
+            pytest.skip("need >= 2 available CPUs to exercise NUMA CPU binding")
+        cpus0 = ",".join(map(str, group0))
+        cpus1 = ",".join(map(str, group1))
+
         with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
-            f.write("0:0-71\n1:0-71\n2:72-143\n3:72-143\n")
+            f.write(f"0:{cpus0}\n1:{cpus0}\n2:{cpus1}\n3:{cpus1}\n")
             f.flush()
 
             old_path = _patch_affinity_path(f.name)
@@ -252,7 +283,7 @@ class TestBindToGpuNuma:
                 result = bind_to_gpu_numa()
                 assert result is True
                 bound_cpus = os.sched_getaffinity(0)
-                assert bound_cpus == set(range(72, 144))
+                assert bound_cpus == set(group1)
             finally:
                 _patch_affinity_path(old_path)
                 os.unlink(f.name)

--- a/tests/unit/distributed/test_numa_utils.py
+++ b/tests/unit/distributed/test_numa_utils.py
@@ -41,32 +41,31 @@ from nemo_rl.distributed.numa_utils import (
 def _write_affinity_file_from_topo() -> str | None:
     """Parse nvidia-smi topo and write a GPU→cpulist affinity file.
 
-    This replicates what topology_probe.sh in ray.sub does at node startup:
-      nvidia-smi topo -m | awk '/^GPU[0-9]/ { ... print gpu ":" $(NF-2) }'
+    Mirrors the production probe in ray.sub: the "CPU Affinity" column is
+    unreliable on GB200 (empty for GPUs not directly attached to a socket), so
+    ray.sub reads the "NUMA Affinity" column and looks up the node-local CPU
+    list from sysfs. We do the same here so the benchmark can't drift from
+    production:
+
+      nvidia-smi topo -m | awk '/^GPU[0-9]/ { numa=$(NF-1); ... }'
+        → cat /sys/devices/system/node/node<numa>/cpulist
 
     nvidia-smi topo -m output format (GB200 NVL72 example):
 
-            GPU0  GPU1  GPU2  GPU3  NIC0 ... NIC5  CPU Affinity  NUMA Affinity  GPU NUMA ID
-        GPU0  X    NV18  NV18  NV18  NODE ... SYS   0-71          0              N/A
-        GPU1 NV18   X    NV18  NV18  NODE ... SYS   0-71          0              N/A
-        GPU2 NV18  NV18   X    NV18  SYS  ... NODE  72-143        1              N/A
-        GPU3 NV18  NV18  NV18   X    SYS  ... NODE  72-143        1              N/A
-        NIC0 NODE  NODE  SYS   SYS    X   ... SYS
+            GPU0  ... NIC5  CPU Affinity  NUMA Affinity  GPU NUMA ID
+        GPU0  X   ... SYS   0-71          0              N/A
+        GPU2 ...      NODE   72-143        1              N/A
+        NIC0 ...       X
         ...
 
-    The header row is indented (starts with whitespace), so startswith("GPU")
-    skips it. NIC rows start with "NIC", not "GPU", so they're also skipped.
+    The header row is indented (starts with whitespace) and NIC rows start with
+    "NIC", so startswith("GPU") skips both. On a GPU row the trailing
+    whitespace-split columns are:
+        parts[-3] = CPU Affinity  (unreliable on GB200 — NOT used)
+        parts[-2] = NUMA Affinity (e.g. "0"/"1") ← used; matches ray.sub's $(NF-1)
+        parts[-1] = GPU NUMA ID   (e.g. "N/A")
 
-    The three trailing columns on GPU rows (whitespace-split) are:
-        parts[-3] = CPU Affinity  (e.g. "0-71")    ← what we extract
-        parts[-2] = NUMA Affinity (e.g. "0")
-        parts[-1] = GPU NUMA ID   (e.g. "N/A" or a number like "2")
-
-    The resulting affinity file has one line per GPU:
-        0:0-71
-        1:0-71
-        2:72-143
-        3:72-143
+    The resulting affinity file has one line per GPU, e.g. "2:72-143".
 
     Returns the path to the temp file, or None if parsing fails.
     """
@@ -86,8 +85,15 @@ def _write_affinity_file_from_topo() -> str | None:
             continue
         parts = line.split()
         gpu_idx = parts[0].replace("GPU", "")
-        cpulist = parts[-3]
-        if "-" in cpulist and any(c.isdigit() for c in cpulist):
+        numa = parts[-2]  # NUMA Affinity column (ray.sub parses $(NF-1))
+        if not numa.isdigit():
+            continue
+        try:
+            with open(f"/sys/devices/system/node/node{numa}/cpulist") as nf:
+                cpulist = nf.read().strip()
+        except OSError:
+            continue
+        if cpulist:
             entries.append(f"{gpu_idx}:{cpulist}")
 
     if not entries:

--- a/tests/unit/distributed/test_numa_utils.py
+++ b/tests/unit/distributed/test_numa_utils.py
@@ -85,7 +85,10 @@ def _write_affinity_file_from_topo() -> str | None:
             continue
         parts = line.split()
         gpu_idx = parts[0].replace("GPU", "")
-        numa = parts[-2]  # NUMA Affinity column (ray.sub parses $(NF-1))
+        # NUMA Affinity column (ray.sub parses $(NF-1)). On GB200 this is a list
+        # like "0,2-17" (the GPU-local CPU NUMA node plus the GPU's HBM NUMA
+        # nodes); take the first entry, which is the local CPU NUMA node.
+        numa = parts[-2].split(",")[0].split("-")[0]
         if not numa.isdigit():
             continue
         try:

--- a/tests/unit/distributed/test_numa_utils.py
+++ b/tests/unit/distributed/test_numa_utils.py
@@ -31,6 +31,7 @@ from nemo_rl.distributed.numa_utils import (
     _parse_cpulist,
     _set_numa_membind,
     bind_to_gpu_numa,
+    resolve_visible_gpu_id,
 )
 
 # ---------------------------------------------------------------------------
@@ -191,35 +192,67 @@ class TestParseCpulist:
         assert _parse_cpulist("42") == {42}
 
 
+class TestResolveVisibleGpuId:
+    """Resolve a process-local CUDA device index to its physical GPU id.
+
+    This is the logic the vLLM TP-worker bind path relies on. It is
+    hardware-independent (pure CUDA_VISIBLE_DEVICES string parsing), so it
+    exercises the multi-GPU / non-zero-based-instance cases that local 2-GPU
+    hosts cannot reproduce.
+    """
+
+    def test_noset_subset_maps_local_to_physical(self, monkeypatch):
+        # vLLM TP=2 EngineCore for an instance on GPUs [4,5]: CVD is the
+        # per-instance subset, so local index i maps to that subset's i-th GPU.
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "4,5")
+        assert resolve_visible_gpu_id(0) == 4
+        assert resolve_visible_gpu_id(1) == 5
+
+    def test_full_node_list(self, monkeypatch):
+        # NOSET full-node list (e.g. Megatron): local index == physical index.
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1,2,3,4,5,6,7")
+        assert resolve_visible_gpu_id(3) == 3
+
+    def test_isolated_single_device(self, monkeypatch):
+        # vLLM TP=1 / DTensor: CVD isolated to one GPU, local index is 0.
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "5")
+        assert resolve_visible_gpu_id(0) == 5
+
+    def test_no_cvd_returns_none(self, monkeypatch):
+        monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+        assert resolve_visible_gpu_id(0) is None
+
+    def test_empty_cvd_returns_none(self, monkeypatch):
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
+        assert resolve_visible_gpu_id(0) is None
+
+    def test_out_of_range_returns_none(self, monkeypatch):
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "4,5")
+        assert resolve_visible_gpu_id(2) is None
+
+    def test_non_integer_entries_return_none(self, monkeypatch):
+        # e.g. MIG UUIDs — cannot map to a physical index, so skip binding.
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-abc,GPU-def")
+        assert resolve_visible_gpu_id(0) is None
+
+
 class TestBindToGpuNuma:
     """Test bind_to_gpu_numa logic with mock affinity files."""
 
     def test_disabled_via_env(self, monkeypatch):
         monkeypatch.setenv("NRL_DISABLE_NUMA_BINDING", "1")
-        assert bind_to_gpu_numa() is False
-
-    def test_no_cuda_visible_devices(self, monkeypatch):
-        monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
-        monkeypatch.delenv("NRL_DISABLE_NUMA_BINDING", raising=False)
-        assert bind_to_gpu_numa() is False
-
-    def test_empty_cuda_visible_devices(self, monkeypatch):
-        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
-        monkeypatch.delenv("NRL_DISABLE_NUMA_BINDING", raising=False)
-        assert bind_to_gpu_numa() is False
+        assert bind_to_gpu_numa(0) is False
 
     def test_missing_affinity_file(self, monkeypatch):
-        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
         monkeypatch.delenv("NRL_DISABLE_NUMA_BINDING", raising=False)
 
         old_path = _patch_affinity_path("/nonexistent/path")
         try:
-            assert bind_to_gpu_numa() is False
+            assert bind_to_gpu_numa(0) is False
         finally:
             _patch_affinity_path(old_path)
 
     def test_gpu_not_in_file(self, monkeypatch):
-        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "7")
         monkeypatch.delenv("NRL_DISABLE_NUMA_BINDING", raising=False)
         monkeypatch.setenv("NRL_DISABLE_NUMA_MEMBIND", "1")
 
@@ -229,14 +262,13 @@ class TestBindToGpuNuma:
 
             old_path = _patch_affinity_path(f.name)
             try:
-                assert bind_to_gpu_numa() is False
+                assert bind_to_gpu_numa(7) is False
             finally:
                 _patch_affinity_path(old_path)
                 os.unlink(f.name)
 
     def test_successful_cpu_binding(self, monkeypatch):
         """Verify sched_setaffinity is called with the correct CPU set."""
-        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2")
         monkeypatch.delenv("NRL_DISABLE_NUMA_BINDING", raising=False)
         monkeypatch.setenv("NRL_DISABLE_NUMA_MEMBIND", "1")
 
@@ -255,7 +287,7 @@ class TestBindToGpuNuma:
 
             old_path = _patch_affinity_path(f.name)
             try:
-                result = bind_to_gpu_numa()
+                result = bind_to_gpu_numa(2)
                 assert result is True
                 bound_cpus = os.sched_getaffinity(0)
                 assert bound_cpus == set(group1)
@@ -264,13 +296,19 @@ class TestBindToGpuNuma:
                 os.unlink(f.name)
                 _reset_all_bindings()
 
-    def test_multi_gpu_cvd_uses_first(self, monkeypatch):
-        """When CUDA_VISIBLE_DEVICES=2,3 we bind to GPU 2's cpulist."""
-        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2,3")
+    def test_explicit_gpu_id_ignores_cuda_visible_devices(self, monkeypatch):
+        """Binding follows the explicit gpu_id, not CUDA_VISIBLE_DEVICES.
+
+        Under ``RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1`` a worker sees the
+        full node device list in ``CUDA_VISIBLE_DEVICES``, which cannot identify
+        its own GPU. ``gpu_id=2`` must bind to GPU 2's CPUs even though CVD lists
+        all 8 devices.
+        """
+        # Full-node CVD as seen under NOSET mode.
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1,2,3,4,5,6,7")
         monkeypatch.delenv("NRL_DISABLE_NUMA_BINDING", raising=False)
         monkeypatch.setenv("NRL_DISABLE_NUMA_MEMBIND", "1")
 
-        # Host-portable cpulist (see test_successful_cpu_binding).
         group0, group1 = _split_available_cpus()
         if group1 is None:
             pytest.skip("need >= 2 available CPUs to exercise NUMA CPU binding")
@@ -283,10 +321,10 @@ class TestBindToGpuNuma:
 
             old_path = _patch_affinity_path(f.name)
             try:
-                result = bind_to_gpu_numa()
+                result = bind_to_gpu_numa(2)
                 assert result is True
-                bound_cpus = os.sched_getaffinity(0)
-                assert bound_cpus == set(group1)
+                # gpu_id=2 maps to the second CPU group in the affinity file.
+                assert os.sched_getaffinity(0) == set(group1)
             finally:
                 _patch_affinity_path(old_path)
                 os.unlink(f.name)
@@ -396,7 +434,7 @@ class TestNUMABindingBenchmark:
         old_path = _patch_affinity_path(affinity_file)
         gpu_str = cvd.split(",")[0]
         try:
-            result = bind_to_gpu_numa()
+            result = bind_to_gpu_numa(int(gpu_str))
             assert result is True, f"bind_to_gpu_numa() failed for GPU {gpu_str}"
         finally:
             _patch_affinity_path(old_path)
@@ -450,15 +488,13 @@ class TestNUMABindingBenchmark:
 
         libnuma = _load_libnuma()
         old_path = _patch_affinity_path(affinity_file)
-        old_cvd = os.environ.get("CUDA_VISIBLE_DEVICES", "")
 
         results = []
         try:
             for gpu_idx, expected_cpulist in gpu_map.items():
                 _reset_all_bindings()
-                os.environ["CUDA_VISIBLE_DEVICES"] = gpu_idx
 
-                result = bind_to_gpu_numa()
+                result = bind_to_gpu_numa(int(gpu_idx))
                 assert result is True, f"bind_to_gpu_numa() failed for GPU {gpu_idx}"
 
                 bound_cpus = os.sched_getaffinity(0)
@@ -472,10 +508,6 @@ class TestNUMABindingBenchmark:
                 results.append((gpu_idx, expected_cpulist, numa_node))
         finally:
             _patch_affinity_path(old_path)
-            if old_cvd:
-                os.environ["CUDA_VISIBLE_DEVICES"] = old_cvd
-            else:
-                os.environ.pop("CUDA_VISIBLE_DEVICES", None)
             _reset_all_bindings()
             os.unlink(affinity_file)
 


### PR DESCRIPTION
# What does this PR do ?

Adds **NUMA-aware CPU affinity + memory binding** for GPU workers (Megatron, DTensor/FSDP, vLLM, and the Megatron PPO value worker). Each model-owning worker pins itself to its GPU's NUMA-local CPUs and binds memory to the local NUMA node at init, improving device↔host memory bandwidth on NUMA systems (e.g. GB200 Grace–Grace).

A node-startup probe in `ray.sub` writes a GPU→cpulist affinity map (from `nvidia-smi topo -m`'s NUMA Affinity column + sysfs), consumed by `nemo_rl.distributed.numa_utils.bind_to_gpu_numa()`. Disable with `NRL_DISABLE_NUMA_BINDING=1` (memory-only opt-out: `NRL_DISABLE_NUMA_MEMBIND=1`).

Originally cherry-picked from the internal [Numa binding](https://gitlab-master.nvidia.com/terryk/nemo-rl-internal/-/commit/ca9cfd21f28f45c6e6ab08dbdbfe5e611205623c) branch; rebased onto `main` after the topology PR (#2612) merged.

> **Stacked on #2924.** The topology bugfix that used to be the base commit of this branch is now its own PR — **#2924** (`fix(topology): exclude unknown-NVLink-domain nodes from segment selection`, base `main`). This PR stacks on top of it, so its diff shows only the NUMA changes. #2924 fixes a pre-existing `select_segment_nodes` bug from #2612 (an unschedulable `{"unknown": 0.001}` placement group on partial / GPU-less-head clusters).

> **Cross-PR dependency with #2837.** The DTensor PPO value worker added in #2837 (`feat: Support for dtensor ppo`) must also call `bind_to_gpu_numa()`. Whichever of #2613 / #2837 merges **second** should add that one line to the new value worker.

# Testing

Validated on a **GB200** node, 4 GPUs (H100 skipped — down).

### Perf — D2H bandwidth (the feature's target)
Committed benchmark `tests/unit/distributed/test_numa_utils.py::TestNUMABindingBenchmark::test_d2h_with_numa_binding` (256 MB float32, 50 iters, GPU 0) compares **unbound (≡ main behavior)** vs **NUMA-bound (this branch)** D2H copy time on the same GPU:

| Case | D2H ms/iter |
|---|---|
| Unbound (memory spread across all NUMA nodes) | 2.797 |
| NUMA-bound (GPU-local node, this branch) | 1.977 |
| **Speedup** | **1.42× (≈29% faster)** — stable across 3 runs |

### Functional — "nothing broken" (GB200, 1 node × 4 GPU)
- **SGLang GRPO** (`grpo-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1-sglang.yaml`, `segment_size=1`, 5 steps): ✅ reached step 5, clean exit.
- **Megatron GRPO** (`grpo-llama3.2-1b-instruct-1n8g-megatron.yaml`, 8 steps) with NUMA **OFF** (`NRL_DISABLE_NUMA_BINDING=1`) and **ON** (default): ✅ both reached step 8, clean exit. Mean step time (steps 3–8): OFF 13.47 s, ON 13.51 s — within run-to-run noise. (End-to-end step time on a small single-node run is compute-dominated, not D2H-bound; the bandwidth win above is the relevant signal and would matter more on D2H-heavy / multi-node workloads.)

### Unit tests
- `tests/unit/distributed/test_numa_utils.py` — 17 pass / 1 skip (skip = GPU-gated benchmark when `CUDA_VISIBLE_DEVICES` unset). CPU-binding tests derive the cpulist from `os.sched_getaffinity(0)` so they are host-portable.
- `tests/unit/distributed/test_topology_placement.py::TestSelectSegmentNodes` — regression tests for the unknown-domain exclusion (pass with the fix, fail without it).

# Issues
N/A

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? (numa_utils host-portability + topology-selection regression tests)
- [x] Did you run the unit tests and functional tests locally? (unit tests + GB200 functional/perf — see Testing)
- [ ] Did you add or update any necessary documentation?

# Additional Information
* **GB200 NUMA Affinity format.** `nvidia-smi topo -m` reports the NUMA Affinity column as a list, e.g. `0,2-17` — the GPU-local **CPU** NUMA node (`0`) plus the GPU's **HBM** NUMA nodes (`2-17`), which GB200 exposes as additional coherent NUMA nodes. The probe (in `ray.sub` and the test helper) takes the **first** entry (the CPU node). Without this, the affinity map is empty on GB200 and binding never engages.


