### PR TITLE
Fix "No backend type associated with device type cpu" error with dynamic sampling

### DIFF
--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -1043,7 +1043,17 @@ class DTensorPolicyWorkerV2Impl(
     @torch.no_grad()
     @wrap_with_nvtx_name("dtensor_policy_worker_v2/offload_before_refit")
     def offload_before_refit(self) -> None:
-        """Offload the optimizer to the CPU."""
+        """Ensure model is on CUDA and offload the optimizer to the CPU.
+
+        The model must be on CUDA for weight streaming. With colocated inference and
+        dynamic sampling, offload_after_refit() may have placed it on CPU between
+        consecutive refit calls (when no training step ran in between).
+        """
+        # Ensure model is on CUDA for weight streaming. With colocated inference and
+        # dynamic sampling, offload_after_refit() may have placed it on CPU between
+        # consecutive refit calls when no training step ran in between. model.to("cuda")
+        # is essentially a no-op when already on CUDA (no data movement, no allocation).
+        self.model = self.move_to_device(self.model, "cuda")
         torch.randn(1).cuda()  # wake up torch allocator
         if self.optimizer is not None:
             self.move_optimizer_to_device("cpu")

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -1043,12 +1043,7 @@ class DTensorPolicyWorkerV2Impl(
     @torch.no_grad()
     @wrap_with_nvtx_name("dtensor_policy_worker_v2/offload_before_refit")
     def offload_before_refit(self) -> None:
-        """Ensure model is on CUDA and offload the optimizer to the CPU.
-
-        The model must be on CUDA for weight streaming. With colocated inference and
-        dynamic sampling, offload_after_refit() may have placed it on CPU between
-        consecutive refit calls (when no training step ran in between).
-        """
+        """Ensure model is on CUDA and offload the optimizer to the CPU."""
         # Ensure model is on CUDA for weight streaming. With colocated inference and
         # dynamic sampling, offload_after_refit() may have placed it on CPU between
         # consecutive refit calls when no training step ran in between. model.to("cuda")

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -1236,9 +1236,15 @@ class MegatronPolicyWorkerImpl(
 
     @wrap_with_nvtx_name("megatron_policy_worker/offload_before_refit")
     def offload_before_refit(self):
-        """Offload the optimizer and buffers to the CPU."""
+        """Ensure model params are on CUDA and offload grad buffers and optimizer to the CPU."""
         no_grad = torch.no_grad()
         no_grad.__enter__()
+        # Ensure model params are on CUDA for weight streaming. With colocated inference and
+        # dynamic sampling, offload_after_refit() may have placed them on CPU between
+        # consecutive refit calls when no training step ran in between.
+        # reload_from_cpu checks param_data.storage().size() == 0, so this is a no-op
+        # when the model is already on CUDA.
+        self.model = self.move_model(self.model, "cuda", move_params=True, move_grads=False)
         allocated = torch.cuda.memory_allocated() / (1024**3)  # Convert to GB
         reserved = torch.cuda.memory_reserved() / (1024**3)  # Convert to GB
         print(

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -1236,7 +1236,7 @@ class MegatronPolicyWorkerImpl(
 
     @wrap_with_nvtx_name("megatron_policy_worker/offload_before_refit")
     def offload_before_refit(self):
-        """Ensure model params are on CUDA and offload grad buffers and optimizer to the CPU."""
+        """Offload the optimizer and buffers to the CPU."""
         no_grad = torch.no_grad()
         no_grad.__enter__()
         # Ensure model params are on CUDA for weight streaming. With colocated inference and


### PR DESCRIPTION
# What does this PR do ?
When using dynamic sampling, we skip training and continue with generation when we don't have enough samples with non-zero std to fill a training batch. In this case, the model has been offloaded to CPU, but `refit_policy_generation` requires the model to be on GPU. This PR fixes the problem by moving the model to GPU if it's not already there before proceeding with `offload_before_refit`.

# Issues
Closes  #2610 


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
