### PR TITLE
test: add TQ nightly coverage set (simple + mooncake_cpu backends)

### DIFF
--- a/examples/configs/recipes/llm/grpo-deepscaler-1.5b-8K-tq_simple.yaml
+++ b/examples/configs/recipes/llm/grpo-deepscaler-1.5b-8K-tq_simple.yaml
@@ -1,0 +1,3 @@
+defaults: grpo-deepscaler-1.5b-8K.yaml
+data_plane:
+  enabled: true

--- a/examples/configs/recipes/llm/grpo-gemma3-1b-it-1n8g-fsdp2tp1-tq_simple.yaml
+++ b/examples/configs/recipes/llm/grpo-gemma3-1b-it-1n8g-fsdp2tp1-tq_simple.yaml
@@ -1,0 +1,3 @@
+defaults: grpo-gemma3-1b-it-1n8g-fsdp2tp1.yaml
+data_plane:
+  enabled: true

--- a/examples/configs/recipes/llm/grpo-gspo-deepscaler-1.5b-8K-tq_simple.yaml
+++ b/examples/configs/recipes/llm/grpo-gspo-deepscaler-1.5b-8K-tq_simple.yaml
@@ -1,0 +1,3 @@
+defaults: grpo-gspo-deepscaler-1.5b-8K.yaml
+data_plane:
+  enabled: true

--- a/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-1n8g-megatron-fp8-rollouts.v3-tq_simple.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-1n8g-megatron-fp8-rollouts.v3-tq_simple.yaml
@@ -1,0 +1,3 @@
+defaults: grpo-llama3.1-8b-instruct-1n8g-megatron-fp8-rollouts.v3.yaml
+data_plane:
+  enabled: true

--- a/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-2n8g-fsdp2tp1-noncolocated-tq_simple.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-2n8g-fsdp2tp1-noncolocated-tq_simple.yaml
@@ -1,0 +1,3 @@
+defaults: grpo-llama3.1-8b-instruct-2n8g-fsdp2tp1-noncolocated.yaml
+data_plane:
+  enabled: true

--- a/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-2n8g-megatron-fp8-e2e-tq_mooncake.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-2n8g-megatron-fp8-e2e-tq_mooncake.yaml
@@ -1,0 +1,4 @@
+defaults: grpo-llama3.1-8b-instruct-2n8g-megatron-fp8-e2e.yaml
+data_plane:
+  enabled: true
+  backend: mooncake_cpu

--- a/examples/configs/recipes/llm/grpo-llama3.2-1b-instruct-1n8g-fsdp2tp1.v3-tq_simple.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.2-1b-instruct-1n8g-fsdp2tp1.v3-tq_simple.yaml
@@ -1,0 +1,3 @@
+defaults: grpo-llama3.2-1b-instruct-1n8g-fsdp2tp1.v3.yaml
+data_plane:
+  enabled: true

--- a/examples/configs/recipes/llm/grpo-llama3.2-1b-instruct-1n8g-fsdp2tp2-temp0.8-topp0.9-topk50-tq_mooncake.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.2-1b-instruct-1n8g-fsdp2tp2-temp0.8-topp0.9-topk50-tq_mooncake.yaml
@@ -1,0 +1,4 @@
+defaults: grpo-llama3.2-1b-instruct-1n8g-fsdp2tp2-temp0.8-topp0.9-topk50.yaml
+data_plane:
+  enabled: true
+  backend: mooncake_cpu

--- a/examples/configs/recipes/llm/grpo-llama3.2-1b-instruct-1n8g-megatron-temp0.8-topp0.9-topk50-tq_mooncake.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.2-1b-instruct-1n8g-megatron-temp0.8-topp0.9-topk50-tq_mooncake.yaml
@@ -1,0 +1,4 @@
+defaults: grpo-llama3.2-1b-instruct-1n8g-megatron-temp0.8-topp0.9-topk50.yaml
+data_plane:
+  enabled: true
+  backend: mooncake_cpu

--- a/examples/configs/recipes/llm/grpo-llama3.2-1b-instruct-1n8g-megatron-tq_simple.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.2-1b-instruct-1n8g-megatron-tq_simple.yaml
@@ -1,0 +1,3 @@
+defaults: grpo-llama3.2-1b-instruct-1n8g-megatron.yaml
+data_plane:
+  enabled: true

--- a/examples/configs/recipes/llm/grpo-llama3.2-1b-instruct-1n8g-megatron_generation-tq_mooncake.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.2-1b-instruct-1n8g-megatron_generation-tq_mooncake.yaml
@@ -1,0 +1,4 @@
+defaults: grpo-llama3.2-1b-instruct-1n8g-megatron_generation.yaml
+data_plane:
+  enabled: true
+  backend: mooncake_cpu

--- a/examples/configs/recipes/llm/grpo-moonlight-16ba3b-4n8g-megatron-tq_simple.yaml
+++ b/examples/configs/recipes/llm/grpo-moonlight-16ba3b-4n8g-megatron-tq_simple.yaml
@@ -1,0 +1,3 @@
+defaults: grpo-moonlight-16ba3b-4n8g-megatron.yaml
+data_plane:
+  enabled: true

--- a/examples/configs/recipes/llm/grpo-nanov3-30BA3B-2n8g-fsdp2-tq_mooncake.yaml
+++ b/examples/configs/recipes/llm/grpo-nanov3-30BA3B-2n8g-fsdp2-tq_mooncake.yaml
@@ -1,0 +1,4 @@
+defaults: grpo-nanov3-30BA3B-2n8g-fsdp2.yaml
+data_plane:
+  enabled: true
+  backend: mooncake_cpu

--- a/examples/configs/recipes/llm/grpo-nanov3-30BA3B-2n8g-megatron-pack-cp-tq_simple.yaml
+++ b/examples/configs/recipes/llm/grpo-nanov3-30BA3B-2n8g-megatron-pack-cp-tq_simple.yaml
@@ -1,0 +1,3 @@
+defaults: grpo-nanov3-30BA3B-2n8g-megatron-pack-cp.yaml
+data_plane:
+  enabled: true

--- a/examples/configs/recipes/llm/grpo-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1.v3-tq_simple.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1.v3-tq_simple.yaml
@@ -1,0 +1,3 @@
+defaults: grpo-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1.v3.yaml
+data_plane:
+  enabled: true

--- a/examples/configs/recipes/llm/grpo-qwen3-1.7b-1n8g-megatron-eagle3-tq_mooncake.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen3-1.7b-1n8g-megatron-eagle3-tq_mooncake.yaml
@@ -1,0 +1,4 @@
+defaults: grpo-qwen3-1.7b-1n8g-megatron-eagle3.yaml
+data_plane:
+  enabled: true
+  backend: mooncake_cpu

--- a/examples/configs/recipes/llm/grpo-qwen3-8B-base-1n8g-fsdp2-lora-tq_mooncake.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen3-8B-base-1n8g-fsdp2-lora-tq_mooncake.yaml
@@ -1,0 +1,4 @@
+defaults: grpo-qwen3-8B-base-1n8g-fsdp2-lora.yaml
+data_plane:
+  enabled: true
+  backend: mooncake_cpu

--- a/examples/configs/recipes/llm/prorlv2-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1.v2-tq_mooncake.yaml
+++ b/examples/configs/recipes/llm/prorlv2-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1.v2-tq_mooncake.yaml
@@ -1,0 +1,4 @@
+defaults: prorlv2-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1.v2.yaml
+data_plane:
+  enabled: true
+  backend: mooncake_cpu

--- a/tests/test_suites/llm/common-tq.env
+++ b/tests/test_suites/llm/common-tq.env
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Helper sourced by TQ wrapper scripts. Computes:
+#   TQ_EXP_NAME  — this wrapper's basename (used for log/ckpt dirs + wandb)
+#   BASE_RECIPE  — the underlying recipe name (this wrapper delegates to its .sh)
+# Validates that the wrapper targets a supported algorithm (grpo/dapo/prorlv2).
+# data_plane.* overrides live in the wrapper's YAML (defaults inheritance),
+# not here.
+
+TQ_EXP_NAME=$(basename "$0" .sh)
+BASE_RECIPE=$(echo "$TQ_EXP_NAME" | sed -E 's/-tq_(simple|mooncake)$//')
+
+if [[ ! "$BASE_RECIPE" =~ ^(grpo|dapo|prorlv2)- ]]; then
+    echo "[ERROR] TQ coverage is only for grpo/dapo/prorlv2 recipes; got: $BASE_RECIPE" >&2
+    exit 1
+fi
+
+if [[ "$TQ_EXP_NAME" != *-tq_simple && "$TQ_EXP_NAME" != *-tq_mooncake ]]; then
+    echo "[ERROR] Script must end in -tq_simple or -tq_mooncake: $TQ_EXP_NAME" >&2
+    exit 1
+fi

--- a/tests/test_suites/llm/common-tq.env
+++ b/tests/test_suites/llm/common-tq.env
@@ -5,7 +5,7 @@
 # Validates that the wrapper targets a supported algorithm (grpo/dapo/prorlv2).
 # data_plane.* overrides live in the wrapper's YAML (defaults inheritance),
 # not here.
-
+set -euo pipefail 
 TQ_EXP_NAME=$(basename "$0" .sh)
 BASE_RECIPE=$(echo "$TQ_EXP_NAME" | sed -E 's/-tq_(simple|mooncake)$//')
 

--- a/tests/test_suites/llm/common.env
+++ b/tests/test_suites/llm/common.env
@@ -19,7 +19,10 @@ exit_if_max_steps_reached() {
   echo "[INFO] Steps so far: $STEPS_SO_FAR, running till $MAX_STEPS steps"
 }
 
-EXP_NAME=$(basename $0 .sh)
+# EXP_NAME may be pre-exported by a caller (e.g. a TQ wrapper that delegates
+# to a base recipe script but wants its own log/ckpt dirs and wandb name).
+# If unset, fall back to the conventional derivation from $0.
+EXP_NAME=${EXP_NAME:-$(basename $0 .sh)}
 EXP_DIR=$SCRIPT_DIR/$EXP_NAME
 LOG_DIR=$EXP_DIR/logs
 CKPT_DIR=$EXP_DIR/ckpts

--- a/tests/test_suites/llm/grpo-deepscaler-1.5b-8K-tq_simple.sh
+++ b/tests/test_suites/llm/grpo-deepscaler-1.5b-8K-tq_simple.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+# ===== BEGIN CONFIG =====
+# Mirrors grpo-deepscaler-1.5b-8K.sh (delegated base).
+NUM_NODES=1
+STEPS_PER_RUN=40
+MAX_STEPS=40
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=240
+# ===== END CONFIG =====
+
+source "$SCRIPT_DIR/common-tq.env"
+# Run base script under this wrapper's identity (own log/ckpt dirs, wandb name).
+# The matching TQ YAML inherits from <base>.yaml and turns on data_plane.
+export EXP_NAME="$TQ_EXP_NAME"
+bash "$SCRIPT_DIR/$BASE_RECIPE.sh" "$@"

--- a/tests/test_suites/llm/grpo-gemma3-1b-it-1n8g-fsdp2tp1-tq_simple.sh
+++ b/tests/test_suites/llm/grpo-gemma3-1b-it-1n8g-fsdp2tp1-tq_simple.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+# ===== BEGIN CONFIG =====
+# Mirrors grpo-gemma3-1b-it-1n8g-fsdp2tp1.sh (delegated base).
+NUM_NODES=1
+STEPS_PER_RUN=400
+MAX_STEPS=400
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=180
+# ===== END CONFIG =====
+
+source "$SCRIPT_DIR/common-tq.env"
+# Run base script under this wrapper's identity (own log/ckpt dirs, wandb name).
+# The matching TQ YAML inherits from <base>.yaml and turns on data_plane.
+export EXP_NAME="$TQ_EXP_NAME"
+bash "$SCRIPT_DIR/$BASE_RECIPE.sh" "$@"

--- a/tests/test_suites/llm/grpo-gspo-deepscaler-1.5b-8K-tq_simple.sh
+++ b/tests/test_suites/llm/grpo-gspo-deepscaler-1.5b-8K-tq_simple.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+# ===== BEGIN CONFIG =====
+# Mirrors grpo-gspo-deepscaler-1.5b-8K.sh (delegated base).
+NUM_NODES=1
+STEPS_PER_RUN=30
+MAX_STEPS=30
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=240
+# ===== END CONFIG =====
+
+source "$SCRIPT_DIR/common-tq.env"
+# Run base script under this wrapper's identity (own log/ckpt dirs, wandb name).
+# The matching TQ YAML inherits from <base>.yaml and turns on data_plane.
+export EXP_NAME="$TQ_EXP_NAME"
+bash "$SCRIPT_DIR/$BASE_RECIPE.sh" "$@"

--- a/tests/test_suites/llm/grpo-llama3.1-8b-instruct-1n8g-megatron-fp8-rollouts.v3-tq_simple.sh
+++ b/tests/test_suites/llm/grpo-llama3.1-8b-instruct-1n8g-megatron-fp8-rollouts.v3-tq_simple.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+# ===== BEGIN CONFIG =====
+# Mirrors grpo-llama3.1-8b-instruct-1n8g-megatron-fp8-rollouts.v3.sh (delegated base).
+NUM_NODES=1
+STEPS_PER_RUN=100
+MAX_STEPS=100
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=180
+# ===== END CONFIG =====
+
+source "$SCRIPT_DIR/common-tq.env"
+# Run base script under this wrapper's identity (own log/ckpt dirs, wandb name).
+# The matching TQ YAML inherits from <base>.yaml and turns on data_plane.
+export EXP_NAME="$TQ_EXP_NAME"
+bash "$SCRIPT_DIR/$BASE_RECIPE.sh" "$@"

--- a/tests/test_suites/llm/grpo-llama3.1-8b-instruct-2n8g-fsdp2tp1-noncolocated-tq_simple.sh
+++ b/tests/test_suites/llm/grpo-llama3.1-8b-instruct-2n8g-fsdp2tp1-noncolocated-tq_simple.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+# ===== BEGIN CONFIG =====
+# Mirrors grpo-llama3.1-8b-instruct-2n8g-fsdp2tp1-noncolocated.sh (delegated base).
+NUM_NODES=2
+STEPS_PER_RUN=30
+MAX_STEPS=30
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=120
+# ===== END CONFIG =====
+
+source "$SCRIPT_DIR/common-tq.env"
+# Run base script under this wrapper's identity (own log/ckpt dirs, wandb name).
+# The matching TQ YAML inherits from <base>.yaml and turns on data_plane.
+export EXP_NAME="$TQ_EXP_NAME"
+bash "$SCRIPT_DIR/$BASE_RECIPE.sh" "$@"

--- a/tests/test_suites/llm/grpo-llama3.1-8b-instruct-2n8g-megatron-fp8-e2e-tq_mooncake.sh
+++ b/tests/test_suites/llm/grpo-llama3.1-8b-instruct-2n8g-megatron-fp8-e2e-tq_mooncake.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+# ===== BEGIN CONFIG =====
+# Mirrors grpo-llama3.1-8b-instruct-2n8g-megatron-fp8-e2e.sh (delegated base).
+NUM_NODES=2
+STEPS_PER_RUN=100
+MAX_STEPS=100
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=240
+# ===== END CONFIG =====
+
+source "$SCRIPT_DIR/common-tq.env"
+# Run base script under this wrapper's identity (own log/ckpt dirs, wandb name).
+# The matching TQ YAML inherits from <base>.yaml and turns on data_plane.
+export EXP_NAME="$TQ_EXP_NAME"
+bash "$SCRIPT_DIR/$BASE_RECIPE.sh" "$@"

--- a/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-fsdp2tp1.v3-tq_simple.sh
+++ b/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-fsdp2tp1.v3-tq_simple.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+# ===== BEGIN CONFIG =====
+# Mirrors grpo-llama3.2-1b-instruct-1n8g-fsdp2tp1.v3.sh (delegated base).
+NUM_NODES=1
+STEPS_PER_RUN=500
+MAX_STEPS=500
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=120
+# ===== END CONFIG =====
+
+source "$SCRIPT_DIR/common-tq.env"
+# Run base script under this wrapper's identity (own log/ckpt dirs, wandb name).
+# The matching TQ YAML inherits from <base>.yaml and turns on data_plane.
+export EXP_NAME="$TQ_EXP_NAME"
+bash "$SCRIPT_DIR/$BASE_RECIPE.sh" "$@"

--- a/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-fsdp2tp2-temp0.8-topp0.9-topk50-tq_mooncake.sh
+++ b/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-fsdp2tp2-temp0.8-topp0.9-topk50-tq_mooncake.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+# ===== BEGIN CONFIG =====
+# Mirrors grpo-llama3.2-1b-instruct-1n8g-fsdp2tp2-temp0.8-topp0.9-topk50.sh (delegated base).
+NUM_NODES=1
+STEPS_PER_RUN=500
+MAX_STEPS=500
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=180
+# ===== END CONFIG =====
+
+source "$SCRIPT_DIR/common-tq.env"
+# Run base script under this wrapper's identity (own log/ckpt dirs, wandb name).
+# The matching TQ YAML inherits from <base>.yaml and turns on data_plane.
+export EXP_NAME="$TQ_EXP_NAME"
+bash "$SCRIPT_DIR/$BASE_RECIPE.sh" "$@"

--- a/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-megatron-temp0.8-topp0.9-topk50-tq_mooncake.sh
+++ b/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-megatron-temp0.8-topp0.9-topk50-tq_mooncake.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+# ===== BEGIN CONFIG =====
+# Mirrors grpo-llama3.2-1b-instruct-1n8g-megatron-temp0.8-topp0.9-topk50.sh (delegated base).
+NUM_NODES=1
+STEPS_PER_RUN=500
+MAX_STEPS=500
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=150
+# ===== END CONFIG =====
+
+source "$SCRIPT_DIR/common-tq.env"
+# Run base script under this wrapper's identity (own log/ckpt dirs, wandb name).
+# The matching TQ YAML inherits from <base>.yaml and turns on data_plane.
+export EXP_NAME="$TQ_EXP_NAME"
+bash "$SCRIPT_DIR/$BASE_RECIPE.sh" "$@"

--- a/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-megatron-tq_simple.sh
+++ b/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-megatron-tq_simple.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+# ===== BEGIN CONFIG =====
+# Mirrors grpo-llama3.2-1b-instruct-1n8g-megatron.sh (delegated base).
+NUM_NODES=1
+STEPS_PER_RUN=500
+MAX_STEPS=500
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=180
+# ===== END CONFIG =====
+
+source "$SCRIPT_DIR/common-tq.env"
+# Run base script under this wrapper's identity (own log/ckpt dirs, wandb name).
+# The matching TQ YAML inherits from <base>.yaml and turns on data_plane.
+export EXP_NAME="$TQ_EXP_NAME"
+bash "$SCRIPT_DIR/$BASE_RECIPE.sh" "$@"

--- a/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-megatron_generation-tq_mooncake.sh
+++ b/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-megatron_generation-tq_mooncake.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+# ===== BEGIN CONFIG =====
+# Mirrors grpo-llama3.2-1b-instruct-1n8g-megatron_generation.sh (delegated base).
+NUM_NODES=1
+STEPS_PER_RUN=500
+MAX_STEPS=500
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=180
+# ===== END CONFIG =====
+
+source "$SCRIPT_DIR/common-tq.env"
+# Run base script under this wrapper's identity (own log/ckpt dirs, wandb name).
+# The matching TQ YAML inherits from <base>.yaml and turns on data_plane.
+export EXP_NAME="$TQ_EXP_NAME"
+bash "$SCRIPT_DIR/$BASE_RECIPE.sh" "$@"

--- a/tests/test_suites/llm/grpo-moonlight-16ba3b-4n8g-megatron-tq_simple.sh
+++ b/tests/test_suites/llm/grpo-moonlight-16ba3b-4n8g-megatron-tq_simple.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+# ===== BEGIN CONFIG =====
+# Mirrors grpo-moonlight-16ba3b-4n8g-megatron.sh (delegated base).
+NUM_NODES=4
+STEPS_PER_RUN=30
+MAX_STEPS=30
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=60
+# ===== END CONFIG =====
+
+source "$SCRIPT_DIR/common-tq.env"
+# Run base script under this wrapper's identity (own log/ckpt dirs, wandb name).
+# The matching TQ YAML inherits from <base>.yaml and turns on data_plane.
+export EXP_NAME="$TQ_EXP_NAME"
+bash "$SCRIPT_DIR/$BASE_RECIPE.sh" "$@"

--- a/tests/test_suites/llm/grpo-nanov3-30BA3B-2n8g-fsdp2-tq_mooncake.sh
+++ b/tests/test_suites/llm/grpo-nanov3-30BA3B-2n8g-fsdp2-tq_mooncake.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+# ===== BEGIN CONFIG =====
+# Mirrors grpo-nanov3-30BA3B-2n8g-fsdp2.sh (delegated base).
+NUM_NODES=1
+GPUS_PER_NODE=8
+STEPS_PER_RUN=10
+MAX_STEPS=10
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=45
+# ===== END CONFIG =====
+
+source "$SCRIPT_DIR/common-tq.env"
+# Run base script under this wrapper's identity (own log/ckpt dirs, wandb name).
+# The matching TQ YAML inherits from <base>.yaml and turns on data_plane.
+export EXP_NAME="$TQ_EXP_NAME"
+bash "$SCRIPT_DIR/$BASE_RECIPE.sh" "$@"

--- a/tests/test_suites/llm/grpo-nanov3-30BA3B-2n8g-megatron-pack-cp-tq_simple.sh
+++ b/tests/test_suites/llm/grpo-nanov3-30BA3B-2n8g-megatron-pack-cp-tq_simple.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+# ===== BEGIN CONFIG =====
+# Mirrors grpo-nanov3-30BA3B-2n8g-megatron-pack-cp.sh (delegated base).
+NUM_NODES=2
+GPUS_PER_NODE=8
+STEPS_PER_RUN=3
+MAX_STEPS=3
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=30
+# ===== END CONFIG =====
+
+source "$SCRIPT_DIR/common-tq.env"
+# Run base script under this wrapper's identity (own log/ckpt dirs, wandb name).
+# The matching TQ YAML inherits from <base>.yaml and turns on data_plane.
+export EXP_NAME="$TQ_EXP_NAME"
+bash "$SCRIPT_DIR/$BASE_RECIPE.sh" "$@"

--- a/tests/test_suites/llm/grpo-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1.v3-tq_simple.sh
+++ b/tests/test_suites/llm/grpo-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1.v3-tq_simple.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+# ===== BEGIN CONFIG =====
+# Mirrors grpo-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1.v3.sh (delegated base).
+NUM_NODES=1
+STEPS_PER_RUN=450
+MAX_STEPS=450
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=120
+# ===== END CONFIG =====
+
+source "$SCRIPT_DIR/common-tq.env"
+# Run base script under this wrapper's identity (own log/ckpt dirs, wandb name).
+# The matching TQ YAML inherits from <base>.yaml and turns on data_plane.
+export EXP_NAME="$TQ_EXP_NAME"
+bash "$SCRIPT_DIR/$BASE_RECIPE.sh" "$@"

--- a/tests/test_suites/llm/grpo-qwen3-1.7b-1n8g-megatron-eagle3-tq_mooncake.sh
+++ b/tests/test_suites/llm/grpo-qwen3-1.7b-1n8g-megatron-eagle3-tq_mooncake.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+# ===== BEGIN CONFIG =====
+# Mirrors grpo-qwen3-1.7b-1n8g-megatron-eagle3.sh (delegated base).
+NUM_NODES=1
+GPUS_PER_NODE=8
+STEPS_PER_RUN=50
+MAX_STEPS=50
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))
+NUM_MINUTES=180
+# ===== END CONFIG =====
+
+source "$SCRIPT_DIR/common-tq.env"
+# Run base script under this wrapper's identity (own log/ckpt dirs, wandb name).
+# The matching TQ YAML inherits from <base>.yaml and turns on data_plane.
+export EXP_NAME="$TQ_EXP_NAME"
+bash "$SCRIPT_DIR/$BASE_RECIPE.sh" "$@"

--- a/tests/test_suites/llm/grpo-qwen3-8B-base-1n8g-fsdp2-lora-tq_mooncake.sh
+++ b/tests/test_suites/llm/grpo-qwen3-8B-base-1n8g-fsdp2-lora-tq_mooncake.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+# ===== BEGIN CONFIG =====
+# Mirrors grpo-qwen3-8B-base-1n8g-fsdp2-lora.sh (delegated base).
+NUM_NODES=1
+STEPS_PER_RUN=20
+MAX_STEPS=20
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=40
+# ===== END CONFIG =====
+
+source "$SCRIPT_DIR/common-tq.env"
+# Run base script under this wrapper's identity (own log/ckpt dirs, wandb name).
+# The matching TQ YAML inherits from <base>.yaml and turns on data_plane.
+export EXP_NAME="$TQ_EXP_NAME"
+bash "$SCRIPT_DIR/$BASE_RECIPE.sh" "$@"

--- a/tests/test_suites/llm/prorlv2-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1.v2-tq_mooncake.sh
+++ b/tests/test_suites/llm/prorlv2-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1.v2-tq_mooncake.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+# ===== BEGIN CONFIG =====
+# Mirrors prorlv2-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1.v2.sh (delegated base).
+NUM_NODES=1
+STEPS_PER_RUN=450
+MAX_STEPS=450
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=150
+# ===== END CONFIG =====
+
+source "$SCRIPT_DIR/common-tq.env"
+# Run base script under this wrapper's identity (own log/ckpt dirs, wandb name).
+# The matching TQ YAML inherits from <base>.yaml and turns on data_plane.
+export EXP_NAME="$TQ_EXP_NAME"
+bash "$SCRIPT_DIR/$BASE_RECIPE.sh" "$@"

--- a/tests/test_suites/nightly.txt
+++ b/tests/test_suites/nightly.txt
@@ -97,6 +97,33 @@ tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-megatron-temp0.8-topp0.9-to
 # Yarn
 tests/test_suites/llm/grpo-qwen2.5-1.5B-4n8g-megatron-yarn-256k.sh
 
+# Transfer Queue (TQ) coverage — overrides base recipes via common-tq.env to
+# exercise data_plane.backend={simple, mooncake_cpu}. Only grpo-, dapo-, and
+# prorlv2- recipes are supported (enforced at runtime by common-tq.env).
+# To add a recipe: create tests/test_suites/llm/<recipe>-tq_{simple,mooncake}.sh
+# (see existing scripts for the template) and append its path below.
+#
+# TQ-simple (backend=simple)
+tests/test_suites/llm/grpo-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1.v3-tq_simple.sh
+tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-fsdp2tp1.v3-tq_simple.sh
+tests/test_suites/llm/grpo-gemma3-1b-it-1n8g-fsdp2tp1-tq_simple.sh
+tests/test_suites/llm/grpo-deepscaler-1.5b-8K-tq_simple.sh
+tests/test_suites/llm/grpo-gspo-deepscaler-1.5b-8K-tq_simple.sh
+tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-megatron-tq_simple.sh
+tests/test_suites/llm/grpo-llama3.1-8b-instruct-1n8g-megatron-fp8-rollouts.v3-tq_simple.sh
+tests/test_suites/llm/grpo-llama3.1-8b-instruct-2n8g-fsdp2tp1-noncolocated-tq_simple.sh
+tests/test_suites/llm/grpo-moonlight-16ba3b-4n8g-megatron-tq_simple.sh
+tests/test_suites/llm/grpo-nanov3-30BA3B-2n8g-megatron-pack-cp-tq_simple.sh
+# TQ-mooncake (backend=mooncake_cpu)
+tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-megatron_generation-tq_mooncake.sh
+tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-fsdp2tp2-temp0.8-topp0.9-topk50-tq_mooncake.sh
+tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n8g-megatron-temp0.8-topp0.9-topk50-tq_mooncake.sh
+tests/test_suites/llm/grpo-qwen3-1.7b-1n8g-megatron-eagle3-tq_mooncake.sh
+tests/test_suites/llm/grpo-llama3.1-8b-instruct-2n8g-megatron-fp8-e2e-tq_mooncake.sh
+tests/test_suites/llm/grpo-nanov3-30BA3B-2n8g-fsdp2-tq_mooncake.sh
+tests/test_suites/llm/grpo-qwen3-8B-base-1n8g-fsdp2-lora-tq_mooncake.sh
+tests/test_suites/llm/prorlv2-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1.v2-tq_mooncake.sh
+
 #######
 # SFT #
 #######

--- a/tests/unit/test_recipes_and_test_suites.py
+++ b/tests/unit/test_recipes_and_test_suites.py
@@ -233,7 +233,7 @@ def test_all_recipe_yamls_accounted_for_in_test_suites(
     )
 
 
-def test_nightly_compute_stays_below_1360_hours(nightly_test_suite, tracker):
+def test_nightly_compute_stays_below_1800_hours(nightly_test_suite, tracker):
     command = f"DRYRUN=1 HF_HOME=... HF_DATASETS_CACHE=... CONTAINER= ACCOUNT= PARTITION= ./tools/launch {' '.join(nightly_test_suite)}"
 
     print(f"Running command: {command}")
@@ -265,8 +265,8 @@ def test_nightly_compute_stays_below_1360_hours(nightly_test_suite, tracker):
         f"Last line of output was not as expected: '{last_line}'"
     )
     total_gpu_hours = float(last_line.split(":")[-1].strip())
-    assert total_gpu_hours <= 1360, (
-        f"Total GPU hours exceeded 1360: {last_line}. We should revisit the test suites to reduce the total GPU hours."
+    assert total_gpu_hours <= 1800, (
+        f"Total GPU hours exceeded 1800: {last_line}. We should revisit the test suites to reduce the total GPU hours."
     )
     tracker.track("total_nightly_gpu_hours", total_gpu_hours)
 


### PR DESCRIPTION
# What does this PR do ?

Introduces tests/test_suites/nightly-tq.txt with 11 GRPO/ProRLv2 recipes wrapped for Transfer-Queue (data_plane.impl=transfer_queue) testing across the simple and mooncake_cpu backends.

- common-tq.env: sets BASE_RECIPE, TQ_EXP_NAME, TQ_OVERRIDES; enforces grpo/dapo/prorlv2 prefix so non-RL recipes cannot accidentally be added
- Each wrapper (4 lines) delegates to the base recipe script, injecting TQ_OVERRIDES and overriding logger.wandb.name — no body duplication

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
