### PR TITLE
Add shard-before-load option for DTensor model loading

### DIFF
--- a/nemo_rl/models/automodel/setup.py
+++ b/nemo_rl/models/automodel/setup.py
@@ -17,6 +17,7 @@
 import importlib
 import inspect
 import os
+from contextlib import contextmanager
 from functools import partial
 from typing import Any, Optional, Union
 
@@ -54,6 +55,28 @@ STRING_TO_DTYPE = {
     "bfloat16": torch.bfloat16,
     "float16": torch.float16,
 }
+
+
+@contextmanager
+def _force_shard_before_load(enabled: bool):
+    if not enabled:
+        yield
+        return
+
+    import nemo_automodel._transformers.infrastructure as automodel_infrastructure
+
+    original_should_load_before_shard = automodel_infrastructure._should_load_before_shard
+
+    def _always_load_after_shard(**_kwargs: Any) -> bool:
+        return False
+
+    automodel_infrastructure._should_load_before_shard = _always_load_after_shard
+    try:
+        yield
+    finally:
+        automodel_infrastructure._should_load_before_shard = (
+            original_should_load_before_shard
+        )
 
 
 def _maybe_set_force_hf(automodel_kwargs: dict, model_config) -> None:
@@ -584,7 +607,11 @@ def setup_model_and_optimizer(
         cfg_dict_with_dtype = {**lora_cfg, "lora_dtype": "torch.float32"}
         peft_config = PeftConfig.from_dict(cfg_dict_with_dtype)
 
-    print(f"[Rank {rank}] Initializing model via from_pretrained...")
+    shard_before_load = bool(config["dtensor_cfg"].get("shard_before_load", False))
+    print(
+        f"[Rank {rank}] Initializing model via from_pretrained "
+        f"(shard_before_load={shard_before_load})..."
+    )
 
     # Prepare automodel kwargs
     automodel_kwargs = config["dtensor_cfg"].get("automodel_kwargs", {})
@@ -647,21 +674,22 @@ def setup_model_and_optimizer(
 
     # Create model via from_pretrained - handles meta device init, parallelization,
     # LoRA, and base weight loading internally
-    model = model_class.from_pretrained(
-        model_name,
-        device_mesh=device_mesh,
-        moe_mesh=moe_mesh,
-        distributed_config=fsdp2_config,
-        moe_config=moe_config if ep_size > 1 else None,
-        activation_checkpointing=config["dtensor_cfg"]["activation_checkpointing"],
-        peft_config=peft_config,
-        attn_implementation=attn_impl,
-        torch_dtype=str(model_config.torch_dtype),
-        trust_remote_code=True,
-        sdpa_method=sdpa_method,
-        **from_pretrained_kwargs,
-        **automodel_kwargs,
-    )
+    with _force_shard_before_load(shard_before_load):
+        model = model_class.from_pretrained(
+            model_name,
+            device_mesh=device_mesh,
+            moe_mesh=moe_mesh,
+            distributed_config=fsdp2_config,
+            moe_config=moe_config if ep_size > 1 else None,
+            activation_checkpointing=config["dtensor_cfg"]["activation_checkpointing"],
+            peft_config=peft_config,
+            attn_implementation=attn_impl,
+            torch_dtype=str(model_config.torch_dtype),
+            trust_remote_code=True,
+            sdpa_method=sdpa_method,
+            **from_pretrained_kwargs,
+            **automodel_kwargs,
+        )
 
     print(model)
 

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -110,6 +110,7 @@ class DTensorConfig(TypedDict):
     # Model config
     lora_cfg: NotRequired[LoRAConfig | LoRAConfigDisabled]
     automodel_kwargs: NotRequired[AutomodelKwargs]
+    shard_before_load: NotRequired[bool]
     # Runtime
     clear_cache_every_n_steps: NotRequired[int | None]
 


### PR DESCRIPTION
# What does this PR do ?

**Adds an opt-in `dtensor_cfg.shard_before_load` knob that forces DTensor's `from_pretrained` to shard parameters across the device mesh **before** materializing weights. This avoids the temporary memory spike where the loading rank briefly holds the full unsharded model, which matters for large teacher models that wouldn't otherwise fit.**

# Issues
None — memory-footprint optimization for large reference/teacher models.

# Usage
```yaml
policy:                       # or teacher / reference worker config
  dtensor_cfg:
    shard_before_load: true   # default false preserves prior behavior
``` 

When enabled, the model is sharded into DTensor placements first and then weights are loaded directly into each rank's local shard — each rank never holds more than its own slice.

# Before your PR is "Ready for review"
**Pre checks**:
- Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- Did you write any new necessary tests?
- Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
Motivation. nemo_automodel's default _should_load_before_shard heuristic chooses load-then-shard for most paths, which makes rank 0 peak at roughly the full model size before sharding. On a 32B teacher in bf16, that's ~64 GB transient on a single rank — enough to OOM the load before training even starts. With shard_before_load=true, each rank only ever holds its own shard, so peak memory during init scales as model_size / world_size instead of model_size.

Implementation. A small context manager _force_shard_before_load monkey-patches nemo_automodel._transformers.infrastructure._should_load_before_shard to always return False for the duration of the model_class.from_pretrained call, then restores the original function on exit. The override is scoped exactly to one call site — no global mutation, no side effects outside the with block.

Backwards compatibility. Default is False, so the context manager short-circuits to a no-op yield and behavior is identical to today.

Files touched.
- nemo_rl/models/automodel/setup.py — _force_shard_before_load context manager + wrap the from_pretrained call
- nemo_rl/models/policy/__init__.py — add shard_before_load: NotRequired[bool] to DTensorConfig TypedDict

---
