### PR TITLE
feat: Add configurable DTensor load precision

### DIFF
--- a/examples/configs/distillation_math.yaml
+++ b/examples/configs/distillation_math.yaml
@@ -226,8 +226,12 @@ teacher:
     model_name: "Qwen/Qwen3-4B"
     dtensor_cfg:
         <<: *DTENSOR_BASE
-        context_parallel_size: 2 
+        context_parallel_size: 2
         tensor_parallel_size: 4
+        # Teacher is a reference worker (init_optimizer=False), so it can
+        # load weights in bfloat16 to halve init-time + resident memory.
+        # Trainable (policy) workers must keep the float32 default.
+        load_precision: "bfloat16"
 
 data:
     max_input_seq_length: ${policy.max_total_sequence_length} # upper bound, real truncation occurs at vllm.max_model_len

--- a/nemo_rl/models/automodel/config.py
+++ b/nemo_rl/models/automodel/config.py
@@ -49,6 +49,7 @@ class RuntimeConfig(NamedTuple):
     model_class: type
     model_config: Any  # AutoConfig
     hf_config_overrides: dict[str, Any]
+    model_load_dtype: torch.dtype
 
     # Attention configuration
     allow_flash_attn_args: bool

--- a/nemo_rl/models/automodel/setup.py
+++ b/nemo_rl/models/automodel/setup.py
@@ -272,9 +272,7 @@ def validate_and_prepare_config(
     precision = config["precision"]
     dtype = _precision_to_dtype(precision, "precision")
     load_precision = config["dtensor_cfg"].get("load_precision", "float32")
-    model_load_dtype = _precision_to_dtype(
-        load_precision, "dtensor_cfg.load_precision"
-    )
+    model_load_dtype = _precision_to_dtype(load_precision, "dtensor_cfg.load_precision")
     if init_optimizer and model_load_dtype != torch.float32:
         raise ValueError(
             "dtensor_cfg.load_precision must be float32 for trainable workers "

--- a/nemo_rl/models/automodel/setup.py
+++ b/nemo_rl/models/automodel/setup.py
@@ -56,6 +56,12 @@ STRING_TO_DTYPE = {
 }
 
 
+def _precision_to_dtype(precision: str, field_name: str) -> torch.dtype:
+    if precision not in STRING_TO_DTYPE:
+        raise ValueError(f"Unknown {field_name}: {precision}")
+    return STRING_TO_DTYPE[precision]
+
+
 def _maybe_set_force_hf(automodel_kwargs: dict, model_config) -> None:
     """Validate and maybe auto-set force_hf based on adapter compatibility.
 
@@ -259,9 +265,11 @@ def validate_and_prepare_config(
 
     # Parse precision
     precision = config["precision"]
-    if precision not in STRING_TO_DTYPE:
-        raise ValueError(f"Unknown precision: {precision}")
-    dtype = STRING_TO_DTYPE[precision]
+    dtype = _precision_to_dtype(precision, "precision")
+    load_precision = config["dtensor_cfg"].get("load_precision", "float32")
+    model_load_dtype = _precision_to_dtype(
+        load_precision, "dtensor_cfg.load_precision"
+    )
 
     # Get other configuration values
     cpu_offload = config["dtensor_cfg"]["cpu_offload"]
@@ -302,7 +310,10 @@ def validate_and_prepare_config(
     # Load model config
     model_config = AutoConfig.from_pretrained(
         model_name,
-        torch_dtype=torch.float32,  # Always load in float32 for master weights
+        # Default remains float32 to preserve previous master-weight behavior.
+        # Reference/teacher workers can set dtensor_cfg.load_precision=bfloat16
+        # to reduce initialization and resident parameter memory.
+        torch_dtype=model_load_dtype,
         trust_remote_code=True,
         attn_implementation="flash_attention_2" if enable_seq_packing else None,
         **hf_config_overrides,
@@ -364,6 +375,7 @@ def validate_and_prepare_config(
         model_class=model_class,
         model_config=model_config,
         hf_config_overrides=hf_config_overrides,
+        model_load_dtype=model_load_dtype,
         allow_flash_attn_args=allow_flash_attn_args,
         attn_impl=attn_impl,
         dtype=dtype,
@@ -533,6 +545,7 @@ def setup_model_and_optimizer(
     attn_impl = runtime_config.attn_impl
     cpu_offload = runtime_config.cpu_offload
     is_reward_model = runtime_config.is_reward_model
+    model_load_dtype = runtime_config.model_load_dtype
 
     # Extract distributed configuration from context
     rank = torch.distributed.get_rank()
@@ -596,7 +609,10 @@ def setup_model_and_optimizer(
         cfg_dict_with_dtype = {**lora_cfg, "lora_dtype": "torch.float32"}
         peft_config = PeftConfig.from_dict(cfg_dict_with_dtype)
 
-    print(f"[Rank {rank}] Initializing model via from_pretrained...")
+    print(
+        f"[Rank {rank}] Initializing model via from_pretrained "
+        f"(load_dtype={model_load_dtype}, precision={runtime_config.dtype})..."
+    )
 
     # Prepare automodel kwargs
     automodel_kwargs = config["dtensor_cfg"].get("automodel_kwargs", {})
@@ -668,7 +684,7 @@ def setup_model_and_optimizer(
         activation_checkpointing=config["dtensor_cfg"]["activation_checkpointing"],
         peft_config=peft_config,
         attn_implementation=attn_impl,
-        torch_dtype=str(model_config.torch_dtype),
+        torch_dtype=model_load_dtype,
         trust_remote_code=True,
         sdpa_method=sdpa_method,
         **from_pretrained_kwargs,

--- a/nemo_rl/models/automodel/setup.py
+++ b/nemo_rl/models/automodel/setup.py
@@ -221,6 +221,7 @@ def validate_and_prepare_config(
     config: PolicyConfig,
     processor: Optional[AutoProcessor],
     rank: int,
+    init_optimizer: bool = True,
 ) -> RuntimeConfig:
     """Validate configuration and prepare runtime settings.
 
@@ -231,6 +232,10 @@ def validate_and_prepare_config(
         config: Policy configuration dictionary
         processor: Optional processor for multimodal models
         rank: Current process rank
+        init_optimizer: Whether the worker will train (and therefore needs an
+            optimizer). Trainable workers must keep their weights in float32 to
+            preserve master-weight precision; this flag is consulted to reject
+            a non-float32 ``dtensor_cfg.load_precision`` on such workers.
 
     Returns:
         RuntimeConfig named tuple containing validated configuration values
@@ -270,6 +275,13 @@ def validate_and_prepare_config(
     model_load_dtype = _precision_to_dtype(
         load_precision, "dtensor_cfg.load_precision"
     )
+    if init_optimizer and model_load_dtype != torch.float32:
+        raise ValueError(
+            "dtensor_cfg.load_precision must be float32 for trainable workers "
+            "(init_optimizer=True) to preserve master-weight precision; it is "
+            "only intended for reference/teacher workers, but got "
+            f"{load_precision!r}."
+        )
 
     # Get other configuration values
     cpu_offload = config["dtensor_cfg"]["cpu_offload"]

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -112,6 +112,7 @@ class DTensorConfig(TypedDict):
     # Model config
     lora_cfg: NotRequired[LoRAConfig | LoRAConfigDisabled]
     automodel_kwargs: NotRequired[AutomodelKwargs]
+    load_precision: NotRequired[str]
     # Runtime
     clear_cache_every_n_steps: NotRequired[int | None]
 

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -112,6 +112,12 @@ class DTensorConfig(TypedDict):
     # Model config
     lora_cfg: NotRequired[LoRAConfig | LoRAConfigDisabled]
     automodel_kwargs: NotRequired[AutomodelKwargs]
+    # Dtype used when loading weights via from_pretrained. Valid values:
+    # "float32" (default), "bfloat16", "float16". Reference/teacher workers
+    # (init_optimizer=False) can set this to "bfloat16" / "float16" to halve
+    # init-time and resident parameter memory. Trainable workers MUST keep
+    # the default "float32" to preserve master-weight precision; non-float32
+    # is rejected by validate_and_prepare_config when init_optimizer=True.
     load_precision: NotRequired[str]
     # Runtime
     clear_cache_every_n_steps: NotRequired[int | None]

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -257,6 +257,7 @@ class DTensorPolicyWorkerV2Impl(
             config=config,
             processor=self.processor,
             rank=0,  # Temporary, will be updated after distributed init
+            init_optimizer=init_optimizer,
         )
 
         # Set up distributed environment (returns DistributedContext)

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -325,6 +325,7 @@ class DTensorPolicyWorkerV2Impl(
             self.model_class,  # Already set above, but includes in tuple for completeness
             self.model_config,  # Already set above, but includes in tuple for completeness
             self.hf_config_overrides,
+            self.model_load_dtype,
             self.allow_flash_attn_args,
             self.attn_impl,
             self.dtype,

--- a/tests/unit/models/automodel/test_automodel_setup.py
+++ b/tests/unit/models/automodel/test_automodel_setup.py
@@ -32,6 +32,7 @@ from nemo_rl.models.automodel.setup import (
     ModelAndOptimizerState,
     RuntimeConfig,
     _maybe_set_force_hf,
+    _precision_to_dtype,
     get_tokenizer,
     setup_distributed,
     setup_model_and_optimizer,
@@ -551,6 +552,115 @@ class TestValidateAndPrepareConfig:
         )
 
         assert result.hf_config_overrides == {}
+
+    def test_precision_to_dtype_supported(self):
+        """_precision_to_dtype maps each supported name to the right torch.dtype."""
+        assert _precision_to_dtype("float32", "precision") == torch.float32
+        assert _precision_to_dtype("bfloat16", "precision") == torch.bfloat16
+        assert _precision_to_dtype("float16", "precision") == torch.float16
+
+    def test_precision_to_dtype_invalid(self):
+        """_precision_to_dtype raises ValueError on unknown name."""
+        with pytest.raises(ValueError, match="Unknown dtensor_cfg.load_precision"):
+            _precision_to_dtype("fp4", "dtensor_cfg.load_precision")
+
+    @patch("nemo_rl.models.automodel.setup.AutoConfig")
+    @patch("nemo_rl.models.automodel.setup.resolve_model_class")
+    @patch("nemo_rl.models.automodel.setup.configure_dynamo_cache")
+    def test_load_precision_default_is_float32(
+        self,
+        mock_dynamo,
+        mock_resolve_class,
+        mock_autoconfig_class,
+        mock_config,
+        mock_autoconfig,
+    ):
+        """Unset load_precision defaults to float32 and does not trip the guard."""
+        mock_autoconfig_class.from_pretrained.return_value = mock_autoconfig
+        mock_resolve_class.return_value = Mock
+        assert "load_precision" not in mock_config["dtensor_cfg"]
+
+        result = validate_and_prepare_config(
+            config=mock_config,
+            processor=None,
+            rank=0,
+            init_optimizer=True,
+        )
+        assert result.model_load_dtype == torch.float32
+
+    @patch("nemo_rl.models.automodel.setup.AutoConfig")
+    @patch("nemo_rl.models.automodel.setup.resolve_model_class")
+    @patch("nemo_rl.models.automodel.setup.configure_dynamo_cache")
+    def test_load_precision_bfloat16_reference_passes(
+        self,
+        mock_dynamo,
+        mock_resolve_class,
+        mock_autoconfig_class,
+        mock_config,
+        mock_autoconfig,
+    ):
+        """Reference/teacher workers (init_optimizer=False) can load in bfloat16."""
+        mock_autoconfig_class.from_pretrained.return_value = mock_autoconfig
+        mock_resolve_class.return_value = Mock
+        mock_config["dtensor_cfg"]["load_precision"] = "bfloat16"
+
+        result = validate_and_prepare_config(
+            config=mock_config,
+            processor=None,
+            rank=0,
+            init_optimizer=False,
+        )
+        assert result.model_load_dtype == torch.bfloat16
+
+    @patch("nemo_rl.models.automodel.setup.AutoConfig")
+    @patch("nemo_rl.models.automodel.setup.resolve_model_class")
+    @patch("nemo_rl.models.automodel.setup.configure_dynamo_cache")
+    def test_load_precision_bfloat16_trainable_raises(
+        self,
+        mock_dynamo,
+        mock_resolve_class,
+        mock_autoconfig_class,
+        mock_config,
+    ):
+        """Trainable workers (init_optimizer=True) must use float32; bfloat16 raises."""
+        mock_config["dtensor_cfg"]["load_precision"] = "bfloat16"
+
+        with pytest.raises(
+            ValueError,
+            match="load_precision must be float32 for trainable workers",
+        ):
+            validate_and_prepare_config(
+                config=mock_config,
+                processor=None,
+                rank=0,
+                init_optimizer=True,
+            )
+
+    @patch("nemo_rl.models.automodel.setup.AutoConfig")
+    @patch("nemo_rl.models.automodel.setup.resolve_model_class")
+    @patch("nemo_rl.models.automodel.setup.configure_dynamo_cache")
+    def test_load_precision_passed_to_autoconfig_from_pretrained(
+        self,
+        mock_dynamo,
+        mock_resolve_class,
+        mock_autoconfig_class,
+        mock_config,
+        mock_autoconfig,
+    ):
+        """model_load_dtype is forwarded to AutoConfig.from_pretrained as torch_dtype."""
+        mock_autoconfig_class.from_pretrained.return_value = mock_autoconfig
+        mock_resolve_class.return_value = Mock
+        mock_config["dtensor_cfg"]["load_precision"] = "bfloat16"
+
+        validate_and_prepare_config(
+            config=mock_config,
+            processor=None,
+            rank=0,
+            init_optimizer=False,
+        )
+        assert mock_autoconfig_class.from_pretrained.called
+        kwargs = mock_autoconfig_class.from_pretrained.call_args.kwargs
+        assert kwargs["torch_dtype"] == torch.bfloat16
 
 
 @pytest.mark.automodel

--- a/tests/unit/reference_configs/distillation_math.yaml
+++ b/tests/unit/reference_configs/distillation_math.yaml
@@ -217,8 +217,9 @@ teacher:
     model_name: "Qwen/Qwen3-4B"
     dtensor_cfg:
         <<: *DTENSOR_BASE
-        context_parallel_size: 2 
+        context_parallel_size: 2
         tensor_parallel_size: 4
+        load_precision: "bfloat16"
 
 data:
     max_input_seq_length: ${policy.max_total_sequence_length} # upper bound, real truncation occurs at vllm.max_model_len


### PR DESCRIPTION
# What does this PR do ?

**Adds a configurable `dtensor_cfg.load_precision` knob so reference/teacher DTensor workers can load model weights at a non-fp32 precision (e.g. bf16), cutting initialization time and resident parameter memory. Default remains fp32, so existing configs are unchanged.**

# Issues
None — quality-of-life / memory optimization.

# Usage
Add `load_precision` under `dtensor_cfg` in any config that needs it
(typically the reference/teacher worker, where master weights aren't
required):

```yaml
policy:
  dtensor_cfg:
    load_precision: bfloat16   # default "float32" preserves prior behavior

load_precision accepts the same strings as precision
(float32 | bfloat16 | float16) and is validated via the shared
_precision_to_dtype helper added in this PR.
```

# Before your PR is "Ready for review"
**Pre checks**:
- Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- Did you write any new necessary tests?
- Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
Motivation. When the policy/teacher worker only needs forward passes (no optimizer state, no master-weight tracking), holding the full model in fp32 wastes ~2× the memory needed for activations and intermediate tensors. On a 14B–32B teacher this is the difference between fitting in a single shard and needing extra TP/PP. Letting users opt into bf16 for the load reclaims that headroom without affecting training workers.

Backwards compatibility. load_precision defaults to "float32", so behavior is unchanged for every existing config.

One subtle behavior change. Inside setup_model_and_optimizer, the torch_dtype passed to model_class.from_pretrained(...) was previously str(model_config.torch_dtype) (a string like "torch.float32"). It now passes the torch.dtype object directly (model_load_dtype). nemo_automodel.from_pretrained accepts both forms, but flagging it here in case it matters for a downstream consumer.

Files touched.
- nemo_rl/models/automodel/config.py — add model_load_dtype field to RuntimeConfig
- nemo_rl/models/automodel/setup.py — _precision_to_dtype helper, read + validate load_precision, plumb through to AutoConfig + model_class.from_pretrained
- nemo_rl/models/policy/__init__.py — add load_precision: NotRequired[str] to DTensorConfig TypedDict
- nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py — destructure model_load_dtype from RuntimeConfig
