### PR TITLE
ci: guard coverage combine against empty coverage glob in fast shards

### DIFF
--- a/tests/functional/L1_Functional_Tests_AutoModel.sh
+++ b/tests/functional/L1_Functional_Tests_AutoModel.sh
@@ -42,4 +42,6 @@ run_test      uv run --no-sync bash ./tests/functional/sft_automodel_lora.sh
 run_test      uv run --no-sync bash ./tests/functional/test_automodel_extra_installed_correctly.sh
 
 cd ${PROJECT_ROOT}/tests
-coverage combine .coverage*
+if compgen -G ".coverage*" > /dev/null; then
+    coverage combine .coverage*
+fi

--- a/tests/functional/L1_Functional_Tests_Eval.sh
+++ b/tests/functional/L1_Functional_Tests_Eval.sh
@@ -39,4 +39,6 @@ run_test      uv run --no-sync bash ./tests/functional/eval_async.sh
 run_test fast uv run --no-sync bash ./tests/functional/eval_audio.sh
 
 cd ${PROJECT_ROOT}/tests
-coverage combine .coverage*
+if compgen -G ".coverage*" > /dev/null; then
+    coverage combine .coverage*
+fi

--- a/tests/functional/L1_Functional_Tests_GRPO_1.sh
+++ b/tests/functional/L1_Functional_Tests_GRPO_1.sh
@@ -44,4 +44,6 @@ run_test fast uv run --no-sync bash ./tests/functional/grpo_dp_simple.sh
 run_test fast uv run --no-sync bash ./tests/functional/grpo_dp_mooncake.sh
 
 cd ${PROJECT_ROOT}/tests
-coverage combine .coverage*
+if compgen -G ".coverage*" > /dev/null; then
+    coverage combine .coverage*
+fi

--- a/tests/functional/L1_Functional_Tests_GRPO_2.sh
+++ b/tests/functional/L1_Functional_Tests_GRPO_2.sh
@@ -40,4 +40,6 @@ run_test      uv run --no-sync bash ./tests/functional/grpo_multiturn.sh
 run_test      uv run --no-sync bash ./tests/functional/grpo_non_colocated.sh
 
 cd ${PROJECT_ROOT}/tests
-coverage combine .coverage*
+if compgen -G ".coverage*" > /dev/null; then
+    coverage combine .coverage*
+fi

--- a/tests/functional/L1_Functional_Tests_GRPO_3.sh
+++ b/tests/functional/L1_Functional_Tests_GRPO_3.sh
@@ -39,4 +39,6 @@ run_test fast uv run --no-sync bash ./tests/functional/grpo_topp_topk.sh
 run_test      uv run --no-sync bash ./tests/functional/vlm_grpo.sh
 
 cd ${PROJECT_ROOT}/tests
-coverage combine .coverage*
+if compgen -G ".coverage*" > /dev/null; then
+    coverage combine .coverage*
+fi

--- a/tests/functional/L1_Functional_Tests_Gym.sh
+++ b/tests/functional/L1_Functional_Tests_Gym.sh
@@ -37,4 +37,6 @@ run_test() {
 run_test fast uv run --no-sync bash ./tests/functional/grpo_async_gym.sh
 
 cd ${PROJECT_ROOT}/tests
-coverage combine .coverage*
+if compgen -G ".coverage*" > /dev/null; then
+    coverage combine .coverage*
+fi

--- a/tests/functional/L1_Functional_Tests_Megatron_1.sh
+++ b/tests/functional/L1_Functional_Tests_Megatron_1.sh
@@ -41,4 +41,6 @@ run_test fast uv run --no-sync bash ./tests/functional/grpo_megatron_eagle3_onli
 run_test      uv run --no-sync bash ./tests/functional/grpo_megatron_generation.sh
 
 cd ${PROJECT_ROOT}/tests
-coverage combine .coverage*
+if compgen -G ".coverage*" > /dev/null; then
+    coverage combine .coverage*
+fi

--- a/tests/functional/L1_Functional_Tests_Megatron_2.sh
+++ b/tests/functional/L1_Functional_Tests_Megatron_2.sh
@@ -40,4 +40,6 @@ run_test fast uv run --no-sync bash ./tests/functional/dpo_megatron_lora.sh
 run_test      uv run --no-sync bash ./tests/functional/sft_megatron_lora.sh
 
 cd ${PROJECT_ROOT}/tests
-coverage combine .coverage*
+if compgen -G ".coverage*" > /dev/null; then
+    coverage combine .coverage*
+fi

--- a/tests/functional/L1_Functional_Tests_Megatron_3.sh
+++ b/tests/functional/L1_Functional_Tests_Megatron_3.sh
@@ -40,4 +40,6 @@ run_test      uv run --no-sync bash ./tests/functional/dpo_megatron.sh
 run_test      uv run --no-sync bash ./tests/functional/sft_megatron.sh
 
 cd ${PROJECT_ROOT}/tests
-coverage combine .coverage*
+if compgen -G ".coverage*" > /dev/null; then
+    coverage combine .coverage*
+fi

--- a/tests/functional/L1_Functional_Tests_Other_1.sh
+++ b/tests/functional/L1_Functional_Tests_Other_1.sh
@@ -52,4 +52,6 @@ if [[ "${FAST:-0}" != "1" ]]; then
 fi
 
 cd ${PROJECT_ROOT}/tests
-coverage combine .coverage*
+if compgen -G ".coverage*" > /dev/null; then
+    coverage combine .coverage*
+fi

--- a/tests/functional/L1_Functional_Tests_Other_2.sh
+++ b/tests/functional/L1_Functional_Tests_Other_2.sh
@@ -40,4 +40,6 @@ run_test      uv run --no-sync bash ./tests/functional/prorlv2.sh
 run_test      uv run --no-sync bash ./tests/functional/rm.sh
 
 cd ${PROJECT_ROOT}/tests
-coverage combine .coverage*
+if compgen -G ".coverage*" > /dev/null; then
+    coverage combine .coverage*
+fi

--- a/tests/functional/L1_Functional_Tests_SFT.sh
+++ b/tests/functional/L1_Functional_Tests_SFT.sh
@@ -39,4 +39,6 @@ run_test      uv run --no-sync bash ./tests/functional/sft_avlm.sh
 run_test      uv run --no-sync bash ./tests/functional/sft_resume_diamond.sh
 
 cd ${PROJECT_ROOT}/tests
-coverage combine .coverage*
+if compgen -G ".coverage*" > /dev/null; then
+    coverage combine .coverage*
+fi

--- a/tests/functional/L1_Functional_Tests_SGLang.sh
+++ b/tests/functional/L1_Functional_Tests_SGLang.sh
@@ -37,4 +37,6 @@ run_test() {
 run_test      uv run --no-sync bash ./tests/functional/grpo_sglang.sh
 
 cd ${PROJECT_ROOT}/tests
-coverage combine .coverage*
+if compgen -G ".coverage*" > /dev/null; then
+    coverage combine .coverage*
+fi


### PR DESCRIPTION
## What

Guard the trailing `coverage combine .coverage*` in all 13 `L1_Functional_Tests_*.sh` shard scripts so it is skipped when no coverage files were produced.

```bash
cd ${PROJECT_ROOT}/tests
if compgen -G ".coverage*" > /dev/null; then
    coverage combine .coverage*
fi
```

## Why

#2345 split the monolithic L1 functional tests into per-domain shards, each ending with an unconditional `coverage combine .coverage*`. Under `CI:Lfast` (`FAST=1`), `run_test` skips every sub-test not marked `fast`. The **AutoModel** and **Megatron_3** shards have *zero* `run_test fast` tests, so nothing runs and no `.coverage*` files are produced. The glob then expands to the literal `.coverage*`, `coverage combine` exits non-zero (*"Couldn't combine from non-existent path"*), and with `set -euo pipefail` the whole shard aborts → the harness reports **"Did not finish." → FAILURE**.

This makes `fast_L1_Functional_Tests_AutoModel` and `fast_L1_Functional_Tests_Megatron_3` red on **every** `CI:Lfast` PR since #2345 merged. The other shards survive only because they each happen to have ≥1 fast test producing a coverage file.

## Fix scope

The broken-today shards are AutoModel and Megatron_3, but the identical unguarded tail exists in all 13 shards, so the guard is applied uniformly to prevent the same latent failure if the last fast test is ever removed from another shard.

The guard still surfaces *genuine* `coverage combine` failures when coverage files do exist — it only no-ops the empty case.

Labeled `CI:Lfast` so the previously-failing AutoModel/Megatron_3 fast shards exercise this fix directly.

cc @chtruong814 (author of #2345)