### PR TITLE
feat(grpo): checkpoint async replay buffer

### DIFF
--- a/nemo_rl/algorithms/async_utils/interfaces.py
+++ b/nemo_rl/algorithms/async_utils/interfaces.py
@@ -74,11 +74,19 @@ class ReplayBufferProtocol(Protocol):
         ...
 
     def get_trajectories_needed(
-        self, target_step: int, num_prompts_per_step: int
+        self,
+        target_step: int,
+        num_prompts_per_step: int,
+        max_age_steps: int | None = None,
     ) -> int:
         """Return additional trajectories needed for ``target_step``."""
         ...
 
-    def has_complete_batch(self, target_step: int, num_prompts_per_step: int) -> bool:
+    def has_complete_batch(
+        self,
+        target_step: int,
+        num_prompts_per_step: int,
+        max_age_steps: int | None = None,
+    ) -> bool:
         """Return whether ``target_step`` has enough trajectories to train."""
         ...

--- a/nemo_rl/algorithms/async_utils/interfaces.py
+++ b/nemo_rl/algorithms/async_utils/interfaces.py
@@ -15,7 +15,7 @@
 from typing import Any, Optional, Protocol
 
 
-class ReplayBufferProtocol(Protocol):
+class ReplayBufferProtocol(Protocol):  # pragma: no cover
     """Interface for the replay buffer used in async RL training."""
 
     def add(

--- a/nemo_rl/algorithms/async_utils/interfaces.py
+++ b/nemo_rl/algorithms/async_utils/interfaces.py
@@ -58,3 +58,27 @@ class ReplayBufferProtocol(Protocol):
     def clear(self) -> None:
         """Clear the buffer."""
         ...
+
+    def state_dict(self) -> dict[str, Any]:
+        """Return serializable state for checkpointing."""
+        ...
+
+    def load_state_dict(
+        self,
+        state: dict[str, Any],
+        num_prompts_per_step: int | None = None,
+        current_training_step: int | None = None,
+        max_age_steps: int | None = None,
+    ) -> None:
+        """Restore state produced by ``state_dict``."""
+        ...
+
+    def get_trajectories_needed(
+        self, target_step: int, num_prompts_per_step: int
+    ) -> int:
+        """Return additional trajectories needed for ``target_step``."""
+        ...
+
+    def has_complete_batch(self, target_step: int, num_prompts_per_step: int) -> bool:
+        """Return whether ``target_step`` has enough trajectories to train."""
+        ...

--- a/nemo_rl/algorithms/async_utils/replay_buffer.py
+++ b/nemo_rl/algorithms/async_utils/replay_buffer.py
@@ -418,6 +418,24 @@ class ReplayBufferImpl(ReplayBufferProtocol):
         )
         self._remove_indices(indices_to_remove)
 
+    def _count_for_target(
+        self, target_step: int, max_age_steps: int | None = None
+    ) -> int:
+        """Count trajectories usable for ``target_step``.
+
+        Must be called while holding ``self._lock``.
+        """
+        return sum(
+            1
+            for trajectory_version, target in zip(
+                self.trajectory_versions, self.target_weight_versions
+            )
+            if target == target_step
+            and self._is_valid_for_target(
+                trajectory_version, target_step, max_age_steps
+            )
+        )
+
     def _truncate_to_max_size(self, current_training_step: int | None = None) -> None:
         """Truncate restored state to ``max_size`` after resume cleanup.
 
@@ -450,21 +468,25 @@ class ReplayBufferImpl(ReplayBufferProtocol):
         ]
 
     def get_trajectories_needed(
-        self, target_step: int, num_prompts_per_step: int
+        self,
+        target_step: int,
+        num_prompts_per_step: int,
+        max_age_steps: int | None = None,
     ) -> int:
         """Return additional trajectories needed for ``target_step``."""
         with self._lock:
-            current_count = sum(
-                1 for target in self.target_weight_versions if target == target_step
-            )
+            current_count = self._count_for_target(target_step, max_age_steps)
             return max(0, num_prompts_per_step - current_count)
 
-    def has_complete_batch(self, target_step: int, num_prompts_per_step: int) -> bool:
+    def has_complete_batch(
+        self,
+        target_step: int,
+        num_prompts_per_step: int,
+        max_age_steps: int | None = None,
+    ) -> bool:
         """Return whether ``target_step`` has enough trajectories to train."""
         with self._lock:
-            current_count = sum(
-                1 for target in self.target_weight_versions if target == target_step
-            )
+            current_count = self._count_for_target(target_step, max_age_steps)
             return current_count >= num_prompts_per_step
 
     def _remove_incomplete_target_steps(self, num_prompts_per_step: int) -> None:

--- a/nemo_rl/algorithms/async_utils/replay_buffer.py
+++ b/nemo_rl/algorithms/async_utils/replay_buffer.py
@@ -129,14 +129,20 @@ class ReplayBufferImpl(ReplayBufferProtocol):
             min_valid_version = max(0, current_weight_version - max_age_steps)
             print(f"   {min_valid_version=}")
 
-            # Check for unexpected old trajectories
-            old_trajectories = [
-                v for v in self.trajectory_versions if v < min_valid_version
+            # Evict old trajectories that are beyond the age window. This can
+            # happen after checkpoint restore when old trajectories remain.
+            old_indices = [
+                i
+                for i, v in enumerate(self.trajectory_versions)
+                if v < min_valid_version
             ]
-            if old_trajectories:
-                raise ValueError(
-                    f"Found {len(old_trajectories)} trajectories older than min_valid_version {min_valid_version}"
+            if old_indices:
+                print(
+                    f"   Evicting {len(old_indices)} stale trajectories "
+                    f"(version < {min_valid_version})"
                 )
+                self._remove_indices(old_indices)
+                total_trajectories = len(self.trajectories)
 
             # Filter for valid trajectories without modifying the buffer
             valid_indices = [
@@ -221,6 +227,288 @@ class ReplayBufferImpl(ReplayBufferProtocol):
             self.trajectories.clear()
             self.trajectory_versions.clear()
             self.target_weight_versions.clear()
+
+    def state_dict(self) -> dict[str, Any]:
+        """Return serializable state for checkpointing."""
+        with self._lock:
+            return {
+                "trajectories": list(self.trajectories),
+                "trajectory_versions": list(self.trajectory_versions),
+                "target_weight_versions": list(self.target_weight_versions),
+                "last_target_weight_already_generated": (
+                    self.last_target_weight_already_generated
+                ),
+                "max_size": self.max_size,
+            }
+
+    def load_state_dict(
+        self,
+        state: dict[str, Any],
+        num_prompts_per_step: int | None = None,
+        current_training_step: int | None = None,
+        max_age_steps: int | None = None,
+    ) -> None:
+        """Restore replay buffer state from a checkpoint.
+
+        Args:
+            state: State returned by ``state_dict``.
+            num_prompts_per_step: Number of prompt groups required for one
+                training step. When provided, incomplete target steps can be
+                removed or prepared for gap filling.
+            current_training_step: Step being resumed. When provided with
+                ``num_prompts_per_step``, past target steps are dropped and
+                incomplete current/future target steps are kept for gap filling.
+            max_age_steps: Maximum allowed age for restored trajectories. When
+                provided, stale trajectories are removed during restore.
+
+        Raises:
+            ValueError: If the checkpoint is missing required fields or has
+                inconsistent parallel list lengths.
+        """
+        with self._lock:
+            required_keys = {
+                "trajectories",
+                "trajectory_versions",
+                "target_weight_versions",
+                "last_target_weight_already_generated",
+            }
+            missing_keys = required_keys - set(state)
+            if missing_keys:
+                raise ValueError(f"Checkpoint missing required keys: {missing_keys}")
+
+            trajectories = list(state["trajectories"])
+            trajectory_versions = list(state["trajectory_versions"])
+            target_weight_versions = list(state["target_weight_versions"])
+            if not (
+                len(trajectories)
+                == len(trajectory_versions)
+                == len(target_weight_versions)
+            ):
+                raise ValueError(
+                    "Checkpoint has inconsistent replay buffer lengths: "
+                    f"trajectories={len(trajectories)}, "
+                    f"trajectory_versions={len(trajectory_versions)}, "
+                    f"target_weight_versions={len(target_weight_versions)}"
+                )
+
+            if "max_size" in state and state["max_size"] != self.max_size:
+                print(
+                    "ReplayBuffer max_size changed: "
+                    f"checkpoint={state['max_size']}, current={self.max_size}. "
+                    "Using current config value."
+                )
+
+            self.trajectories = trajectories
+            self.trajectory_versions = trajectory_versions
+            self.target_weight_versions = target_weight_versions
+            self.last_target_weight_already_generated = state[
+                "last_target_weight_already_generated"
+            ]
+
+            if current_training_step is not None and num_prompts_per_step is not None:
+                self._prepare_for_training_step(
+                    current_step=current_training_step,
+                    num_prompts_per_step=num_prompts_per_step,
+                )
+            elif num_prompts_per_step is not None and self.trajectories:
+                self._remove_incomplete_target_steps(num_prompts_per_step)
+
+            if max_age_steps is not None and self.trajectories:
+                self._remove_stale_trajectories(max_age_steps)
+                if current_training_step is None and num_prompts_per_step is not None:
+                    self._remove_incomplete_target_steps(num_prompts_per_step)
+
+            self._truncate_to_max_size(current_training_step)
+
+            print(
+                f"ReplayBuffer restored: {len(self.trajectories)} trajectories, "
+                "last_target_weight_already_generated="
+                f"{self.last_target_weight_already_generated}"
+            )
+
+    def _prepare_for_training_step(
+        self, current_step: int, num_prompts_per_step: int
+    ) -> None:
+        """Prepare restored state so training can resume at ``current_step``."""
+        print(f"   Preparing replay buffer for training step {current_step}...")
+
+        original_count = len(self.trajectories)
+        indices_to_keep = [
+            i
+            for i, target in enumerate(self.target_weight_versions)
+            if target >= current_step
+        ]
+
+        if len(indices_to_keep) < original_count:
+            removed_past = original_count - len(indices_to_keep)
+            self.trajectories = [self.trajectories[i] for i in indices_to_keep]
+            self.trajectory_versions = [
+                self.trajectory_versions[i] for i in indices_to_keep
+            ]
+            self.target_weight_versions = [
+                self.target_weight_versions[i] for i in indices_to_keep
+            ]
+            print(
+                f"   Removed {removed_past} trajectories for past steps "
+                f"(target < {current_step})"
+            )
+
+        if not self.trajectories:
+            self.last_target_weight_already_generated = current_step - 1
+            print(
+                "   No restored trajectories remain; collector will generate "
+                f"from step {current_step}"
+            )
+            return
+
+        target_counts = Counter(self.target_weight_versions)
+        complete_targets = {
+            target
+            for target, count in target_counts.items()
+            if count >= num_prompts_per_step
+        }
+        incomplete_targets = {
+            target
+            for target, count in target_counts.items()
+            if count < num_prompts_per_step
+        }
+
+        print(
+            "   Complete targets: "
+            f"{sorted(complete_targets) if complete_targets else 'none'}"
+        )
+        for target in sorted(incomplete_targets):
+            print(
+                f"   Incomplete target {target}: "
+                f"{target_counts[target]}/{num_prompts_per_step}"
+            )
+
+        # Let the collector ask each target from current_step onward how many
+        # trajectories are still needed, so incomplete restored batches can be
+        # gap-filled and complete batches can be skipped.
+        self.last_target_weight_already_generated = current_step - 1
+
+    @staticmethod
+    def _is_valid_for_target(
+        trajectory_version: int, target_step: int, max_age_steps: int | None
+    ) -> bool:
+        if max_age_steps is None:
+            return True
+        min_valid_version = max(0, target_step - max_age_steps)
+        return min_valid_version <= trajectory_version <= target_step
+
+    def _remove_stale_trajectories(self, max_age_steps: int) -> None:
+        """Remove restored trajectories that are stale for their target step.
+
+        Must be called while holding ``self._lock``.
+        """
+        indices_to_remove = [
+            i
+            for i, (trajectory_version, target) in enumerate(
+                zip(self.trajectory_versions, self.target_weight_versions)
+            )
+            if not self._is_valid_for_target(trajectory_version, target, max_age_steps)
+        ]
+        if not indices_to_remove:
+            return
+
+        print(
+            f"   Removing {len(indices_to_remove)} stale restored trajectories "
+            f"(max_age_steps={max_age_steps})"
+        )
+        self._remove_indices(indices_to_remove)
+
+    def _truncate_to_max_size(self, current_training_step: int | None = None) -> None:
+        """Truncate restored state to ``max_size`` after resume cleanup.
+
+        Must be called while holding ``self._lock``.
+        """
+        if len(self.trajectories) <= self.max_size:
+            return
+
+        print(
+            f"Truncating restored buffer from {len(self.trajectories)} "
+            f"to max_size={self.max_size}"
+        )
+        if current_training_step is None:
+            indices_to_keep = list(
+                range(len(self.trajectories) - self.max_size, len(self.trajectories))
+            )
+        else:
+            prioritized_indices = sorted(
+                range(len(self.trajectories)),
+                key=lambda i: (self.target_weight_versions[i], i),
+            )
+            indices_to_keep = sorted(prioritized_indices[: self.max_size])
+
+        self.trajectories = [self.trajectories[i] for i in indices_to_keep]
+        self.trajectory_versions = [
+            self.trajectory_versions[i] for i in indices_to_keep
+        ]
+        self.target_weight_versions = [
+            self.target_weight_versions[i] for i in indices_to_keep
+        ]
+
+    def get_trajectories_needed(
+        self, target_step: int, num_prompts_per_step: int
+    ) -> int:
+        """Return additional trajectories needed for ``target_step``."""
+        with self._lock:
+            current_count = sum(
+                1 for target in self.target_weight_versions if target == target_step
+            )
+            return max(0, num_prompts_per_step - current_count)
+
+    def has_complete_batch(self, target_step: int, num_prompts_per_step: int) -> bool:
+        """Return whether ``target_step`` has enough trajectories to train."""
+        with self._lock:
+            current_count = sum(
+                1 for target in self.target_weight_versions if target == target_step
+            )
+            return current_count >= num_prompts_per_step
+
+    def _remove_incomplete_target_steps(self, num_prompts_per_step: int) -> None:
+        """Remove target steps without a complete batch.
+
+        Must be called while holding ``self._lock``.
+        """
+        target_counts = Counter(self.target_weight_versions)
+        incomplete_targets = {
+            target
+            for target, count in target_counts.items()
+            if count < num_prompts_per_step
+        }
+        if not incomplete_targets:
+            print(f"   All target steps have complete batches ({num_prompts_per_step})")
+            return
+
+        print(f"   Removing incomplete target steps: {sorted(incomplete_targets)}")
+        original_count = len(self.trajectories)
+        indices_to_keep = [
+            i
+            for i, target in enumerate(self.target_weight_versions)
+            if target not in incomplete_targets
+        ]
+        self.trajectories = [self.trajectories[i] for i in indices_to_keep]
+        self.trajectory_versions = [
+            self.trajectory_versions[i] for i in indices_to_keep
+        ]
+        self.target_weight_versions = [
+            self.target_weight_versions[i] for i in indices_to_keep
+        ]
+        print(
+            f"   Removed {original_count - len(self.trajectories)} trajectories "
+            "from incomplete target steps"
+        )
+
+        if self.target_weight_versions:
+            first_remaining_target = min(self.target_weight_versions)
+            self.last_target_weight_already_generated = min(
+                self.last_target_weight_already_generated,
+                first_remaining_target - 1,
+            )
+        else:
+            self.last_target_weight_already_generated = -1
 
 
 @ray.remote  # pragma: no cover

--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -123,6 +123,9 @@ class AsyncTrajectoryCollector:
         """Get the next target weight that needs generation (if any)."""
         target_weights = self._calculate_target_weights(generation_weight_version)
         num_prompts = int(self.master_config.grpo["num_prompts_per_step"])
+        max_age_steps = int(
+            self.master_config.grpo["async_grpo"]["max_trajectory_age_steps"]
+        )
         last_target_weight_already_generated = ray.get(
             self.replay_buffer.get_last_target_weight_already_generated.remote()
         )
@@ -136,7 +139,7 @@ class AsyncTrajectoryCollector:
 
                 trajectories_needed = ray.get(
                     self.replay_buffer.get_trajectories_needed.remote(
-                        target_weight, num_prompts
+                        target_weight, num_prompts, max_age_steps
                     )
                 )
                 if trajectories_needed <= 0:
@@ -170,6 +173,9 @@ class AsyncTrajectoryCollector:
         try:
             target_weights = self._calculate_target_weights(self.current_weight_version)
             num_prompts = int(self.master_config.grpo["num_prompts_per_step"])
+            max_age_steps = int(
+                self.master_config.grpo["async_grpo"]["max_trajectory_age_steps"]
+            )
             last_target_weight_already_generated = ray.get(
                 self.replay_buffer.get_last_target_weight_already_generated.remote()
             )
@@ -183,7 +189,7 @@ class AsyncTrajectoryCollector:
                         continue
                     trajectories_needed = ray.get(
                         self.replay_buffer.get_trajectories_needed.remote(
-                            target_weight, num_prompts
+                            target_weight, num_prompts, max_age_steps
                         )
                     )
                     if trajectories_needed > 0:
@@ -273,6 +279,9 @@ class AsyncTrajectoryCollector:
             num_generations = self.master_config.grpo["num_generations_per_prompt"]
             num_prompts_in_batch = batch.size
             num_prompts_per_step = int(self.master_config.grpo["num_prompts_per_step"])
+            max_age_steps = int(
+                self.master_config.grpo["async_grpo"]["max_trajectory_age_steps"]
+            )
 
             # Get the next target weight that needs generation
             target_weight = self._get_next_target_for_generation(
@@ -291,7 +300,7 @@ class AsyncTrajectoryCollector:
 
             trajectories_needed = ray.get(
                 self.replay_buffer.get_trajectories_needed.remote(
-                    target_weight, num_prompts_per_step
+                    target_weight, num_prompts_per_step, max_age_steps
                 )
             )
             num_prompts_to_generate = min(num_prompts_in_batch, trajectories_needed)

--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -122,19 +122,35 @@ class AsyncTrajectoryCollector:
     ) -> Optional[int]:
         """Get the next target weight that needs generation (if any)."""
         target_weights = self._calculate_target_weights(generation_weight_version)
+        num_prompts = int(self.master_config.grpo["num_prompts_per_step"])
         last_target_weight_already_generated = ray.get(
             self.replay_buffer.get_last_target_weight_already_generated.remote()
         )
 
         with self._generation_check_lock:
             for target_weight in target_weights:
-                if (
-                    target_weight > last_target_weight_already_generated
-                    and target_weight not in self._generating_targets
-                ):
-                    self._generating_targets.add(target_weight)
+                if target_weight <= last_target_weight_already_generated:
+                    continue
+                if target_weight in self._generating_targets:
+                    continue
+
+                trajectories_needed = ray.get(
+                    self.replay_buffer.get_trajectories_needed.remote(
+                        target_weight, num_prompts
+                    )
+                )
+                if trajectories_needed <= 0:
+                    continue
+
+                self._generating_targets.add(target_weight)
+                if trajectories_needed < num_prompts:
+                    print(
+                        f"🎯 Reserved target weight {target_weight} for gap-filling "
+                        f"(need {trajectories_needed}/{num_prompts} more trajectories)"
+                    )
+                else:
                     print(f"🎯 Reserved target weight {target_weight} for generation")
-                    return target_weight
+                return target_weight
 
         return None
 
@@ -153,6 +169,7 @@ class AsyncTrajectoryCollector:
         """Check if collection should be paused due to generation limits."""
         try:
             target_weights = self._calculate_target_weights(self.current_weight_version)
+            num_prompts = int(self.master_config.grpo["num_prompts_per_step"])
             last_target_weight_already_generated = ray.get(
                 self.replay_buffer.get_last_target_weight_already_generated.remote()
             )
@@ -160,10 +177,16 @@ class AsyncTrajectoryCollector:
             # Check if any target weight in our range needs generation
             with self._generation_check_lock:
                 for target_weight in target_weights:
-                    if (
-                        target_weight > last_target_weight_already_generated
-                        and target_weight not in self._generating_targets
-                    ):
+                    if target_weight <= last_target_weight_already_generated:
+                        continue
+                    if target_weight in self._generating_targets:
+                        continue
+                    trajectories_needed = ray.get(
+                        self.replay_buffer.get_trajectories_needed.remote(
+                            target_weight, num_prompts
+                        )
+                    )
+                    if trajectories_needed > 0:
                         return False  # Found a target that needs generation
 
             print(
@@ -248,7 +271,8 @@ class AsyncTrajectoryCollector:
         try:
             generation_weight_version = self.current_weight_version
             num_generations = self.master_config.grpo["num_generations_per_prompt"]
-            num_prompts = batch.size
+            num_prompts_in_batch = batch.size
+            num_prompts_per_step = int(self.master_config.grpo["num_prompts_per_step"])
 
             # Get the next target weight that needs generation
             target_weight = self._get_next_target_for_generation(
@@ -265,8 +289,29 @@ class AsyncTrajectoryCollector:
                 f"🎯 Generating for target weight {target_weight} from generation_weight_version {generation_weight_version}"
             )
 
-            # Generate for all prompts in this batch for the target weight
-            for prompt_idx in range(num_prompts):
+            trajectories_needed = ray.get(
+                self.replay_buffer.get_trajectories_needed.remote(
+                    target_weight, num_prompts_per_step
+                )
+            )
+            num_prompts_to_generate = min(num_prompts_in_batch, trajectories_needed)
+            if num_prompts_to_generate == 0:
+                print(
+                    f"🔄 Target {target_weight} already has enough trajectories, skipping"
+                )
+                with self._generation_check_lock:
+                    self._generating_targets.discard(target_weight)
+                return
+
+            if num_prompts_to_generate < num_prompts_in_batch:
+                print(
+                    f"🎯 Gap-filling for target weight {target_weight}: "
+                    f"generating {num_prompts_to_generate}/{num_prompts_in_batch} "
+                    f"prompts (need {trajectories_needed} more trajectories)"
+                )
+
+            # Generate only the prompt groups needed for this target.
+            for prompt_idx in range(num_prompts_to_generate):
                 # Wait for refit to complete if in progress
                 if not self._refit_pause_cleared.is_set() and self.running:
                     with self._threads_lock:

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -2703,6 +2703,27 @@ def async_grpo_train(
         max_size=optimal_buffer_size
     )
 
+    last_checkpoint_path = checkpointer.get_latest_checkpoint_path()
+    if last_checkpoint_path is not None:
+        replay_buffer_path = os.path.join(last_checkpoint_path, "replay_buffer.pt")
+        if os.path.exists(replay_buffer_path):
+            print(f"📦 Restoring replay buffer from checkpoint: {replay_buffer_path}")
+            replay_buffer_state = torch.load(replay_buffer_path, weights_only=False)
+            ray.get(
+                replay_buffer.load_state_dict.remote(
+                    replay_buffer_state,
+                    num_prompts_per_step=num_prompts_per_step,
+                    current_training_step=step,
+                    max_age_steps=max_trajectory_age_steps,
+                )
+            )
+            print("✅ Replay buffer restored from checkpoint")
+        else:
+            print(
+                f"⚠️ No replay buffer checkpoint found at {replay_buffer_path}. "
+                "Starting with an empty replay buffer."
+            )
+
     _tc_py_exec = get_actor_python_env(
         "nemo_rl.algorithms.async_utils.AsyncTrajectoryCollector"
     )
@@ -2811,24 +2832,38 @@ def async_grpo_train(
     if policy_generation is not None:
         policy_generation.clear_logger_metrics()
 
-    # Wait for initial buffer fill
+    # Wait for initial buffer fill for the current training step.
     print(
-        f"⏳ Waiting for replay buffer to have sufficient trajectories ({min_trajectories_needed} trajectories)..."
+        f"⏳ Waiting for replay buffer to have sufficient trajectories for step {step}..."
     )
     wait_iterations = 0
     while True:
         buffer_size_current = ray.get(replay_buffer.size.remote())
-
-        print(
-            f"  Wait iteration {wait_iterations}: buffer_filled_ratio={buffer_size_current}/{min_trajectories_needed}"
+        current_step_ready = ray.get(
+            replay_buffer.has_complete_batch.remote(step, num_prompts_per_step)
         )
 
-        if buffer_size_current >= min_trajectories_needed:
+        print(
+            f"  Wait iteration {wait_iterations}: buffer_size={buffer_size_current}, "
+            f"step {step} ready={current_step_ready}"
+        )
+
+        if current_step_ready:
             break
 
+        trajectories_needed = ray.get(
+            replay_buffer.get_trajectories_needed.remote(step, num_prompts_per_step)
+        )
+        if buffer_size_current >= min_trajectories_needed and trajectories_needed > 0:
+            print(
+                f"  ⏳ Gap-filling in progress: need {trajectories_needed} more "
+                f"trajectories for step {step}"
+            )
+
+        wait_iterations += 1
         time.sleep(1.0)
 
-    print("✅ Buffer ready! Starting training loop...")
+    print(f"✅ Buffer ready for step {step}! Starting training loop...")
 
     # Main training loop
     try:
@@ -3309,6 +3344,16 @@ def async_grpo_train(
                         torch.save(
                             actual_dataloader_state,
                             os.path.join(checkpoint_path, "train_dataloader.pt"),
+                        )
+                        print("📦 Saving replay buffer state...")
+                        replay_buffer_state = ray.get(replay_buffer.state_dict.remote())
+                        torch.save(
+                            replay_buffer_state,
+                            os.path.join(checkpoint_path, "replay_buffer.pt"),
+                        )
+                        print(
+                            "✅ Saved replay buffer with "
+                            f"{len(replay_buffer_state['trajectories'])} trajectories"
                         )
                         checkpointer.finalize_checkpoint(checkpoint_path)
 

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -2840,7 +2840,9 @@ def async_grpo_train(
     while True:
         buffer_size_current = ray.get(replay_buffer.size.remote())
         current_step_ready = ray.get(
-            replay_buffer.has_complete_batch.remote(step, num_prompts_per_step)
+            replay_buffer.has_complete_batch.remote(
+                step, num_prompts_per_step, max_trajectory_age_steps
+            )
         )
 
         print(
@@ -2852,7 +2854,9 @@ def async_grpo_train(
             break
 
         trajectories_needed = ray.get(
-            replay_buffer.get_trajectories_needed.remote(step, num_prompts_per_step)
+            replay_buffer.get_trajectories_needed.remote(
+                step, num_prompts_per_step, max_trajectory_age_steps
+            )
         )
         if buffer_size_current >= min_trajectories_needed and trajectories_needed > 0:
             print(

--- a/tests/unit/algorithms/test_async_utils.py
+++ b/tests/unit/algorithms/test_async_utils.py
@@ -541,6 +541,38 @@ class TestReplayBuffer:
 
         ray.kill(buffer)
 
+    def test_replay_buffer_readiness_ignores_stale_trajectories(self):
+        """Test readiness helpers match sample's age-window filtering."""
+        buffer = ReplayBuffer.remote(max_size=10)
+
+        for version in [0, 1, 4]:
+            ray.get(
+                buffer.add.remote(
+                    {"batch": {"data": f"version_{version}"}},
+                    weight_version=version,
+                    target_weight_version=5,
+                )
+            )
+
+        assert ray.get(buffer.has_complete_batch.remote(5, 3))
+        assert ray.get(buffer.get_trajectories_needed.remote(5, 3)) == 0
+
+        assert not ray.get(buffer.has_complete_batch.remote(5, 3, 1))
+        assert ray.get(buffer.get_trajectories_needed.remote(5, 3, 1)) == 2
+
+        assert (
+            ray.get(
+                buffer.sample.remote(
+                    num_prompt_groups=3,
+                    current_weight_version=5,
+                    max_age_steps=1,
+                )
+            )
+            is None
+        )
+
+        ray.kill(buffer)
+
     def test_replay_buffer_load_state_dict_missing_keys(self):
         """Test load_state_dict raises for missing required keys."""
         buffer = ReplayBuffer.remote(max_size=10)

--- a/tests/unit/algorithms/test_async_utils.py
+++ b/tests/unit/algorithms/test_async_utils.py
@@ -32,7 +32,10 @@ from nemo_rl.algorithms.async_utils import (
     AsyncTrajectoryCollector,
     ReplayBuffer,
 )
-from nemo_rl.algorithms.async_utils.replay_buffer import ReplayBufferNew
+from nemo_rl.algorithms.async_utils.replay_buffer import (
+    ReplayBufferImpl,
+    ReplayBufferNew,
+)
 from nemo_rl.algorithms.grpo import (
     MasterConfig,
     add_grpo_token_loss_masks_and_generation_logprobs,
@@ -92,6 +95,179 @@ class MockGenerationInterface:
 
     def finish_generation(self):
         self.finish_calls += 1
+
+
+class TestReplayBufferImplCheckpointing:
+    """Direct implementation tests for checkpoint coverage.
+
+    Ray actor execution is not reliably attributed to source coverage, so these
+    tests cover the checkpoint/restore helpers on the local implementation class.
+    """
+
+    def _state(
+        self,
+        trajectory_versions: list[int],
+        target_weight_versions: list[int],
+        last_target_weight_already_generated: int,
+        max_size: int = 10,
+    ) -> dict:
+        return {
+            "trajectories": [
+                {"batch": {"data": f"traj_{idx}"}, "rollout_metrics": {}}
+                for idx in range(len(trajectory_versions))
+            ],
+            "trajectory_versions": trajectory_versions,
+            "target_weight_versions": target_weight_versions,
+            "last_target_weight_already_generated": (
+                last_target_weight_already_generated
+            ),
+            "max_size": max_size,
+        }
+
+    def test_local_restore_prepares_current_step_for_gap_fill(self):
+        buffer = ReplayBufferImpl(max_size=10)
+        state = self._state(
+            trajectory_versions=[0, 1, 1, 2],
+            target_weight_versions=[1, 2, 2, 3],
+            last_target_weight_already_generated=3,
+        )
+
+        buffer.load_state_dict(
+            state,
+            num_prompts_per_step=2,
+            current_training_step=2,
+        )
+
+        assert buffer.get_debug_info()["trajectory_versions"] == [1, 1, 2]
+        assert buffer.get_debug_info()["target_weight_versions"] == [2, 2, 3]
+        assert buffer.get_last_target_weight_already_generated() == 1
+        assert buffer.has_complete_batch(2, 2)
+        assert not buffer.has_complete_batch(3, 2)
+        assert buffer.get_trajectories_needed(2, 2) == 0
+        assert buffer.get_trajectories_needed(3, 2) == 1
+
+    def test_local_restore_empty_state_resets_generation_watermark(self):
+        buffer = ReplayBufferImpl(max_size=10)
+        state = self._state(
+            trajectory_versions=[],
+            target_weight_versions=[],
+            last_target_weight_already_generated=7,
+        )
+
+        buffer.load_state_dict(
+            state,
+            num_prompts_per_step=2,
+            current_training_step=5,
+        )
+
+        assert buffer.size() == 0
+        assert buffer.get_last_target_weight_already_generated() == 4
+        assert buffer.get_trajectories_needed(5, 2) == 2
+
+    def test_local_restore_removes_stale_trajectories(self):
+        buffer = ReplayBufferImpl(max_size=10)
+        state = self._state(
+            trajectory_versions=[0, 1, 4],
+            target_weight_versions=[5, 5, 5],
+            last_target_weight_already_generated=5,
+        )
+
+        buffer.load_state_dict(
+            state,
+            num_prompts_per_step=2,
+            current_training_step=5,
+            max_age_steps=1,
+        )
+
+        assert buffer.get_debug_info()["trajectory_versions"] == [4]
+        assert buffer.get_debug_info()["target_weight_versions"] == [5]
+        assert not buffer.has_complete_batch(5, 2)
+        assert buffer.get_trajectories_needed(5, 2) == 1
+
+    def test_local_restore_truncates_after_resume_cleanup(self):
+        buffer = ReplayBufferImpl(max_size=2)
+        state = self._state(
+            trajectory_versions=[0, 1, 2, 3],
+            target_weight_versions=[1, 2, 3, 4],
+            last_target_weight_already_generated=4,
+            max_size=4,
+        )
+
+        buffer.load_state_dict(
+            state,
+            num_prompts_per_step=1,
+            current_training_step=2,
+        )
+
+        assert buffer.get_debug_info()["trajectory_versions"] == [1, 2]
+        assert buffer.get_debug_info()["target_weight_versions"] == [2, 3]
+
+    def test_local_restore_without_current_step_rechecks_after_stale_removal(self):
+        buffer = ReplayBufferImpl(max_size=10)
+        state = self._state(
+            trajectory_versions=[0, 4, 4],
+            target_weight_versions=[5, 5, 6],
+            last_target_weight_already_generated=6,
+        )
+
+        buffer.load_state_dict(
+            state,
+            num_prompts_per_step=2,
+            max_age_steps=1,
+        )
+
+        assert buffer.size() == 0
+        assert buffer.get_last_target_weight_already_generated() == -1
+
+    def test_local_sample_evicts_stale_restored_trajectories(self):
+        buffer = ReplayBufferImpl(max_size=10)
+        assert (
+            buffer.add(
+                {"batch": {"data": "stale"}, "rollout_metrics": {}},
+                weight_version=0,
+                target_weight_version=5,
+            )
+            == "success"
+        )
+        assert (
+            buffer.add(
+                {"batch": {"data": "valid"}, "rollout_metrics": {}},
+                weight_version=4,
+                target_weight_version=5,
+            )
+            == "success"
+        )
+
+        sample_result = buffer.sample(
+            num_prompt_groups=1,
+            current_weight_version=5,
+            max_age_steps=1,
+        )
+
+        assert sample_result is not None
+        assert sample_result["trajectories"][0]["batch"]["data"] == "valid"
+        assert buffer.size() == 0
+
+    def test_local_load_state_dict_validates_checkpoint_shape(self):
+        buffer = ReplayBufferImpl(max_size=10)
+
+        with pytest.raises(ValueError, match="Checkpoint missing required keys"):
+            buffer.load_state_dict(
+                {
+                    "trajectories": [],
+                    "trajectory_versions": [],
+                }
+            )
+
+        with pytest.raises(ValueError, match="inconsistent replay buffer lengths"):
+            buffer.load_state_dict(
+                {
+                    "trajectories": [{"batch": {"data": "test"}}],
+                    "trajectory_versions": [0, 1],
+                    "target_weight_versions": [1],
+                    "last_target_weight_already_generated": 1,
+                }
+            )
 
 
 class TestReplayBuffer:

--- a/tests/unit/algorithms/test_async_utils.py
+++ b/tests/unit/algorithms/test_async_utils.py
@@ -235,7 +235,7 @@ class TestReplayBuffer:
         ray.kill(buffer)
 
     def test_replay_buffer_age_filtering(self):
-        """Test that old trajectories are filtered out."""
+        """Test that old trajectories are evicted."""
         buffer = ReplayBuffer.remote(max_size=10)
 
         # Push trajectories with different ages
@@ -254,18 +254,20 @@ class TestReplayBuffer:
             )
         )
 
-        # Sample with current_weight_version=3 and max_age_steps=1
-        # This should filter out the trajectory with weight_version=0 (too old)
-        with pytest.raises(
-            ValueError, match="Found .* trajectories older than min_valid_version"
-        ):
-            ray.get(
-                buffer.sample.remote(
-                    num_prompt_groups=1,
-                    current_weight_version=3,
-                    max_age_steps=1,
-                )
+        assert ray.get(buffer.size.remote()) == 2
+
+        sample_result = ray.get(
+            buffer.sample.remote(
+                num_prompt_groups=1,
+                current_weight_version=3,
+                max_age_steps=1,
             )
+        )
+
+        assert sample_result is not None
+        assert len(sample_result["trajectories"]) == 1
+        assert sample_result["trajectories"][0]["batch"]["data"] == "recent"
+        assert ray.get(buffer.size.remote()) == 0
 
         ray.kill(buffer)
 
@@ -356,6 +358,317 @@ class TestReplayBuffer:
         assert debug_info["target_weight_versions"] == []
 
         ray.kill(buffer)
+
+    def test_replay_buffer_state_dict(self):
+        """Test state_dict serialization for checkpointing."""
+        buffer = ReplayBuffer.remote(max_size=10)
+
+        trajectory1 = {"batch": {"data": "test1"}, "rollout_metrics": {"reward": 1.0}}
+        trajectory2 = {"batch": {"data": "test2"}, "rollout_metrics": {"reward": 2.0}}
+
+        ray.get(
+            buffer.add.remote(trajectory1, weight_version=5, target_weight_version=6)
+        )
+        ray.get(
+            buffer.add.remote(trajectory2, weight_version=6, target_weight_version=7)
+        )
+
+        state = ray.get(buffer.state_dict.remote())
+
+        assert state["trajectories"][0]["batch"]["data"] == "test1"
+        assert state["trajectories"][1]["batch"]["data"] == "test2"
+        assert state["trajectory_versions"] == [5, 6]
+        assert state["target_weight_versions"] == [6, 7]
+        assert state["last_target_weight_already_generated"] == 7
+        assert state["max_size"] == 10
+
+        ray.kill(buffer)
+
+    def test_replay_buffer_load_state_dict(self):
+        """Test load_state_dict restoration from checkpoint."""
+        buffer1 = ReplayBuffer.remote(max_size=10)
+
+        trajectory1 = {"batch": {"data": "test1"}, "rollout_metrics": {"reward": 1.0}}
+        trajectory2 = {"batch": {"data": "test2"}, "rollout_metrics": {"reward": 2.0}}
+
+        ray.get(
+            buffer1.add.remote(trajectory1, weight_version=5, target_weight_version=6)
+        )
+        ray.get(
+            buffer1.add.remote(trajectory2, weight_version=6, target_weight_version=7)
+        )
+
+        state = ray.get(buffer1.state_dict.remote())
+        ray.kill(buffer1)
+
+        buffer2 = ReplayBuffer.remote(max_size=10)
+        assert ray.get(buffer2.size.remote()) == 0
+
+        ray.get(buffer2.load_state_dict.remote(state))
+
+        assert ray.get(buffer2.size.remote()) == 2
+        debug_info = ray.get(buffer2.get_debug_info.remote())
+        assert debug_info["trajectory_versions"] == [5, 6]
+        assert debug_info["target_weight_versions"] == [6, 7]
+        assert ray.get(buffer2.get_last_target_weight_already_generated.remote()) == 7
+
+        ray.kill(buffer2)
+
+    def test_replay_buffer_state_dict_round_trip_sampling(self):
+        """Test save/restore preserves sampling behavior."""
+        buffer1 = ReplayBuffer.remote(max_size=10)
+
+        for i in range(3):
+            trajectory = {
+                "batch": {"data": f"test{i}"},
+                "rollout_metrics": {"reward": float(i)},
+            }
+            ray.get(
+                buffer1.add.remote(
+                    trajectory, weight_version=i, target_weight_version=i + 1
+                )
+            )
+
+        state = ray.get(buffer1.state_dict.remote())
+        ray.kill(buffer1)
+
+        buffer2 = ReplayBuffer.remote(max_size=10)
+        ray.get(buffer2.load_state_dict.remote(state))
+
+        sample_result = ray.get(
+            buffer2.sample.remote(
+                num_prompt_groups=1,
+                current_weight_version=2,
+                max_age_steps=2,
+            )
+        )
+
+        assert sample_result is not None
+        assert sample_result["trajectories"][0]["batch"]["data"] == "test1"
+
+        ray.kill(buffer2)
+
+    def test_replay_buffer_load_state_dict_max_size_change(self):
+        """Test load_state_dict truncates after resume cleanup."""
+        buffer1 = ReplayBuffer.remote(max_size=5)
+
+        for i in range(4):
+            trajectory = {
+                "batch": {"data": f"test{i}"},
+                "rollout_metrics": {"reward": float(i)},
+            }
+            ray.get(
+                buffer1.add.remote(
+                    trajectory, weight_version=i, target_weight_version=i + 1
+                )
+            )
+
+        state = ray.get(buffer1.state_dict.remote())
+        ray.kill(buffer1)
+
+        buffer2 = ReplayBuffer.remote(max_size=2)
+        ray.get(
+            buffer2.load_state_dict.remote(
+                state,
+                num_prompts_per_step=1,
+                current_training_step=2,
+            )
+        )
+
+        assert ray.get(buffer2.size.remote()) == 2
+        debug_info = ray.get(buffer2.get_debug_info.remote())
+        assert debug_info["trajectory_versions"] == [1, 2]
+        assert debug_info["target_weight_versions"] == [2, 3]
+
+        ray.kill(buffer2)
+
+    def test_replay_buffer_load_empty_state_resets_generation_watermark(self):
+        """Test empty restore can generate from the current step."""
+        buffer = ReplayBuffer.remote(max_size=10)
+
+        state = {
+            "trajectories": [],
+            "trajectory_versions": [],
+            "target_weight_versions": [],
+            "last_target_weight_already_generated": 7,
+            "max_size": 10,
+        }
+
+        ray.get(
+            buffer.load_state_dict.remote(
+                state,
+                num_prompts_per_step=2,
+                current_training_step=5,
+            )
+        )
+
+        assert ray.get(buffer.size.remote()) == 0
+        assert ray.get(buffer.get_last_target_weight_already_generated.remote()) == 4
+        assert ray.get(buffer.get_trajectories_needed.remote(5, 2)) == 2
+
+        ray.kill(buffer)
+
+    def test_replay_buffer_restore_removes_stale_trajectories(self):
+        """Test stale restored trajectories do not make a step look complete."""
+        buffer = ReplayBuffer.remote(max_size=10)
+
+        state = {
+            "trajectories": [
+                {"batch": {"data": "stale_a"}},
+                {"batch": {"data": "stale_b"}},
+                {"batch": {"data": "valid_a"}},
+            ],
+            "trajectory_versions": [0, 1, 4],
+            "target_weight_versions": [5, 5, 5],
+            "last_target_weight_already_generated": 5,
+            "max_size": 10,
+        }
+
+        ray.get(
+            buffer.load_state_dict.remote(
+                state,
+                num_prompts_per_step=2,
+                current_training_step=5,
+                max_age_steps=1,
+            )
+        )
+
+        debug_info = ray.get(buffer.get_debug_info.remote())
+        assert debug_info["trajectory_versions"] == [4]
+        assert debug_info["target_weight_versions"] == [5]
+        assert not ray.get(buffer.has_complete_batch.remote(5, 2))
+        assert ray.get(buffer.get_trajectories_needed.remote(5, 2)) == 1
+
+        ray.kill(buffer)
+
+    def test_replay_buffer_load_state_dict_missing_keys(self):
+        """Test load_state_dict raises for missing required keys."""
+        buffer = ReplayBuffer.remote(max_size=10)
+
+        incomplete_state = {
+            "trajectories": [],
+            "trajectory_versions": [],
+        }
+
+        with pytest.raises(ValueError, match="Checkpoint missing required keys"):
+            ray.get(buffer.load_state_dict.remote(incomplete_state))
+
+        ray.kill(buffer)
+
+    def test_replay_buffer_load_state_dict_inconsistent_lengths(self):
+        """Test load_state_dict raises for inconsistent parallel lists."""
+        buffer = ReplayBuffer.remote(max_size=10)
+
+        bad_state = {
+            "trajectories": [{"batch": {"data": "test"}}],
+            "trajectory_versions": [0, 1],
+            "target_weight_versions": [1],
+            "last_target_weight_already_generated": 1,
+        }
+
+        with pytest.raises(ValueError, match="inconsistent replay buffer lengths"):
+            ray.get(buffer.load_state_dict.remote(bad_state))
+
+        ray.kill(buffer)
+
+    def test_replay_buffer_restore_for_training_step_gap_fill_accounting(self):
+        """Test resume cleanup keeps incomplete future targets for gap filling."""
+        buffer = ReplayBuffer.remote(max_size=10)
+
+        state = {
+            "trajectories": [
+                {"batch": {"data": "past"}},
+                {"batch": {"data": "step2_a"}},
+                {"batch": {"data": "step2_b"}},
+                {"batch": {"data": "step3_a"}},
+            ],
+            "trajectory_versions": [0, 1, 1, 2],
+            "target_weight_versions": [1, 2, 2, 3],
+            "last_target_weight_already_generated": 3,
+            "max_size": 10,
+        }
+
+        ray.get(
+            buffer.load_state_dict.remote(
+                state,
+                num_prompts_per_step=2,
+                current_training_step=2,
+            )
+        )
+
+        debug_info = ray.get(buffer.get_debug_info.remote())
+        assert debug_info["trajectory_versions"] == [1, 1, 2]
+        assert debug_info["target_weight_versions"] == [2, 2, 3]
+        assert ray.get(buffer.has_complete_batch.remote(2, 2))
+        assert not ray.get(buffer.has_complete_batch.remote(3, 2))
+        assert ray.get(buffer.get_trajectories_needed.remote(2, 2)) == 0
+        assert ray.get(buffer.get_trajectories_needed.remote(3, 2)) == 1
+        assert ray.get(buffer.get_last_target_weight_already_generated.remote()) == 1
+
+        ray.kill(buffer)
+
+    def test_replay_buffer_remove_incomplete_resets_watermark_before_first_remaining_target(
+        self,
+    ):
+        """Test fallback cleanup does not skip gaps after removing partial targets."""
+        buffer = ReplayBuffer.remote(max_size=10)
+
+        state = {
+            "trajectories": [
+                {"batch": {"data": "step5_a"}},
+                {"batch": {"data": "step5_b"}},
+                {"batch": {"data": "step6_a"}},
+                {"batch": {"data": "step8_a"}},
+                {"batch": {"data": "step8_b"}},
+            ],
+            "trajectory_versions": [4, 4, 5, 7, 7],
+            "target_weight_versions": [5, 5, 6, 8, 8],
+            "last_target_weight_already_generated": 8,
+            "max_size": 10,
+        }
+
+        ray.get(buffer.load_state_dict.remote(state, num_prompts_per_step=2))
+
+        debug_info = ray.get(buffer.get_debug_info.remote())
+        assert debug_info["target_weight_versions"] == [5, 5, 8, 8]
+        assert ray.get(buffer.get_last_target_weight_already_generated.remote()) == 4
+
+        ray.kill(buffer)
+
+    def test_replay_buffer_checkpoint_with_torch_save(self):
+        """Test that state_dict can be saved and loaded with torch.save/load."""
+        buffer1 = ReplayBuffer.remote(max_size=10)
+
+        trajectory = {
+            "batch": {
+                "token_ids": torch.tensor([1, 2, 3]),
+                "rewards": torch.tensor([0.5]),
+            },
+            "rollout_metrics": {"reward": 1.0, "length": 10},
+            "timestamp": 12345.0,
+        }
+        ray.get(
+            buffer1.add.remote(trajectory, weight_version=5, target_weight_version=6)
+        )
+
+        state = ray.get(buffer1.state_dict.remote())
+        with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+            torch.save(state, f.name)
+            checkpoint_path = f.name
+
+        ray.kill(buffer1)
+
+        loaded_state = torch.load(checkpoint_path, weights_only=False)
+        buffer2 = ReplayBuffer.remote(max_size=10)
+        ray.get(buffer2.load_state_dict.remote(loaded_state))
+
+        assert ray.get(buffer2.size.remote()) == 1
+        debug_info = ray.get(buffer2.get_debug_info.remote())
+        assert debug_info["trajectory_versions"] == [5]
+        assert debug_info["target_weight_versions"] == [6]
+
+        os.unlink(checkpoint_path)
+        ray.kill(buffer2)
 
 
 class TestReplayBufferNew:

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -183,6 +183,61 @@ class StubReplayBuffer:
         )
         return mock
 
+    @property
+    def state_dict(self):
+        """Return a mock that returns checkpointable buffer state."""
+        trajectories = self._trajectories or [
+            {
+                "batch": self._mock_batch,
+                "rollout_metrics": self._mock_rollout_metrics,
+            }
+            for _ in range(self._size)
+        ]
+        mock = MagicMock()
+        mock.remote = MagicMock(
+            return_value={
+                "trajectories": list(trajectories),
+                "trajectory_versions": [0] * len(trajectories),
+                "target_weight_versions": [0] * len(trajectories),
+                "last_target_weight_already_generated": 0,
+                "max_size": self._size,
+            }
+        )
+        return mock
+
+    @property
+    def load_state_dict(self):
+        """Return a mock that accepts restored buffer state."""
+
+        def _load_state_dict(state, *args, **kwargs):
+            self._trajectories = list(state["trajectories"])
+            self._size = len(self._trajectories)
+
+        mock = MagicMock()
+        mock.remote = MagicMock(side_effect=_load_state_dict)
+        return mock
+
+    @property
+    def get_trajectories_needed(self):
+        """Return a mock that reports how many prompt groups are still needed."""
+        mock = MagicMock()
+        mock.remote = MagicMock(
+            side_effect=lambda _target_step, num_prompts_per_step: max(
+                0, num_prompts_per_step - self._size
+            )
+        )
+        return mock
+
+    @property
+    def has_complete_batch(self):
+        """Return a mock that reports whether the current step can train."""
+        mock = MagicMock()
+        mock.remote = MagicMock(
+            side_effect=lambda _target_step, num_prompts_per_step: self._size
+            >= num_prompts_per_step
+        )
+        return mock
+
 
 class StubAsyncTrajectoryCollector:
     """Non-Ray stub of AsyncTrajectoryCollector for unit testing
@@ -310,6 +365,7 @@ def mock_grpo_components():
     loss_fn = ClippedPGLossFn(loss_config)
     logger = MagicMock()
     checkpointer = MagicMock()
+    checkpointer.get_latest_checkpoint_path.return_value = None
 
     # Create mock environment
     task_to_env = {"math": MagicMock()}

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -222,7 +222,7 @@ class StubReplayBuffer:
         """Return a mock that reports how many prompt groups are still needed."""
         mock = MagicMock()
         mock.remote = MagicMock(
-            side_effect=lambda _target_step, num_prompts_per_step: max(
+            side_effect=lambda _target_step, num_prompts_per_step, *_args: max(
                 0, num_prompts_per_step - self._size
             )
         )
@@ -233,7 +233,7 @@ class StubReplayBuffer:
         """Return a mock that reports whether the current step can train."""
         mock = MagicMock()
         mock.remote = MagicMock(
-            side_effect=lambda _target_step, num_prompts_per_step: self._size
+            side_effect=lambda _target_step, num_prompts_per_step, *_args: self._size
             >= num_prompts_per_step
         )
         return mock


### PR DESCRIPTION
# What does this PR do ?

Adds replay-buffer checkpointing via state_dict()/load_state_dict(), saved as replay_buffer.pt alongside the dataloader state and restored on resume.

# Issues
Closes `Allow replay buffer checkpointing and reloading capability` part of https://github.com/NVIDIA-NeMo/RL/issues/1906

# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
## Restore Behavior

On restore, the replay buffer is prepared for the current training step:
- drops trajectories for past target steps
- preserves current/future target steps so incomplete restored batches can be gap-filled
- resets `last_target_weight_already_generated` to `current_step - 1` so the collector re-checks current/future targets by count
- handles empty restored buffers without skipping the resumed step
- removes restored trajectories that are stale for their target step when `max_age_steps` is provided
- truncates after restore cleanup if current `max_size` is smaller than the checkpointed buffer

## Behavioral Differences From [Upstream Commit](https://github.com/NVIDIA-NeMo/RL/commit/0bb29f4452ca57d194138d0229915dd34dc4869e)

- Empty replay-buffer restore resets `last_target_weight_already_generated` to `current_step - 1`.
  - Reason: upstream only prepared the buffer when restored trajectories existed. If the restored buffer was empty but the checkpoint watermark was high, the collector could skip the resumed step and training would wait forever.

- Restore truncation happens after resume cleanup, not before.
  - Reason: upstream truncated immediately and kept the oldest entries. If `max_size` shrank, this could keep past-step trajectories and discard current/future ones needed for resume.

- When `current_training_step` is known, max-size truncation prioritizes the nearest current/future target steps.
  - Reason: after dropping past targets, the most useful restored trajectories are for the current training step first, then later steps. Keeping oldest-by-index is not necessarily the right behavior after resume.

- Restore can remove trajectories that are already stale for their target step via `max_age_steps`.
  - Reason: without this, restored stale trajectories could remain in the buffer until `sample()` evicts them later. Cleaning them during restore makes the restored state match what training can actually consume.

- GRPO passes `max_trajectory_age_steps` into replay-buffer restore.
  - Reason: restore needs the configured staleness window to remove stale restored trajectories consistently.
