### PR TITLE
fix(vllm): selectively port NeMo Gym/vLLM cherry-pick fixes

### DIFF
--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -187,6 +187,7 @@ Depending on your data shape, you may want to change these values."""
 
         nemo_rl_message_log = []
         seen_token_ids: List[int] = []
+        batch_decode_items = []
         for output_item_dict in nemo_gym_result["response"]["output"]:
             # Nemo RL really only has two types of messages: assistant and not assistant since that is all that it is concerned with (i.e. to train or not to train)
             # Here we map all the trainable messages to assistant and all the non-trainable messages to user.
@@ -204,37 +205,48 @@ Seen token IDs: {seen_token_ids}
 Output prompt token IDs: {output_item_dict["prompt_token_ids"]}
 """
 
+            prompt_token_ids = output_item_dict.pop("prompt_token_ids")
+            generation_token_ids = output_item_dict.pop("generation_token_ids")
+            generation_log_probs = output_item_dict.pop("generation_log_probs")
+            new_prompt_token_ids = prompt_token_ids[len(seen_token_ids) :]
+
             nemo_rl_message_log.append(
                 {
                     "role": "user",
                     "content": "",
-                    "token_ids": torch.tensor(
-                        output_item_dict["prompt_token_ids"][len(seen_token_ids) :]
-                    ),
+                    "token_ids": torch.tensor(new_prompt_token_ids),
                 }
             )
             nemo_rl_message_log.append(
                 {
                     "role": "assistant",
                     "content": "",
-                    "token_ids": torch.tensor(output_item_dict["generation_token_ids"]),
-                    "generation_logprobs": torch.tensor(
-                        output_item_dict["generation_log_probs"]
-                    ),
+                    "token_ids": torch.tensor(generation_token_ids),
+                    "generation_logprobs": torch.tensor(generation_log_probs),
                 }
             )
 
-            seen_token_ids.extend(nemo_rl_message_log[-2]["token_ids"])
-            seen_token_ids.extend(nemo_rl_message_log[-1]["token_ids"])
+            seen_token_ids.extend(new_prompt_token_ids)
+            seen_token_ids.extend(generation_token_ids)
 
             # We pop to remove larger tensors from logging.
-            output_item_dict["prompt_str"] = tokenizer.decode(
-                output_item_dict.pop("prompt_token_ids")
+            batch_decode_items.append(
+                (output_item_dict, prompt_token_ids, generation_token_ids)
             )
-            output_item_dict["generation_str"] = tokenizer.decode(
-                output_item_dict.pop("generation_token_ids")
+
+        if batch_decode_items:
+            prompt_strs = tokenizer.batch_decode(
+                [item[1] for item in batch_decode_items]
             )
-            output_item_dict.pop("generation_log_probs")
+            generation_strs = tokenizer.batch_decode(
+                [item[2] for item in batch_decode_items]
+            )
+
+            for (output_item_dict, _, _), prompt_str, generation_str in zip(
+                batch_decode_items, prompt_strs, generation_strs
+            ):
+                output_item_dict["prompt_str"] = prompt_str
+                output_item_dict["generation_str"] = generation_str
 
         if not nemo_rl_message_log:
             input_messages = nemo_gym_result["responses_create_params"]["input"]

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -37,6 +37,13 @@ from nemo_rl.models.policy.utils import is_vllm_v1_engine_enabled
 from nemo_rl.utils.nsys import wrap_with_nvtx_name
 
 
+def _resolve_enable_prefix_caching(vllm_cfg: dict[str, Any]) -> bool:
+    enable_prefix_caching = vllm_cfg.get("enable_prefix_caching", None)
+    if enable_prefix_caching is None:
+        enable_prefix_caching = torch.cuda.get_device_capability()[0] >= 8
+    return enable_prefix_caching
+
+
 # Use a base class to share some functions to avoid code duplication.
 class BaseVllmGenerationWorker:
     def __repr__(self) -> str:
@@ -554,9 +561,7 @@ class BaseVllmGenerationWorker:
             pipeline_parallel_size=self.pipeline_parallel_size,
             enable_expert_parallel=self.enable_expert_parallel,
             gpu_memory_utilization=self.gpu_memory_utilization,
-            enable_prefix_caching=self.cfg["vllm_cfg"].get(
-                "enable_prefix_caching", torch.cuda.get_device_capability()[0] >= 8
-            ),
+            enable_prefix_caching=_resolve_enable_prefix_caching(self.cfg["vllm_cfg"]),
             dtype=self.precision,
             seed=seed,
             enforce_eager=self.cfg["vllm_cfg"]["enforce_eager"],

--- a/tests/unit/environments/test_nemo_gym.py
+++ b/tests/unit/environments/test_nemo_gym.py
@@ -168,6 +168,54 @@ def _write_actual_test_data(original_input: list, actual_result: list):
     print(f"Wrote updated test data to {output_path}")
 
 
+def test_nemo_gym_postprocess_uses_batch_decode():
+    class _Tokenizer:
+        def __init__(self):
+            self.batch_decode_calls = []
+
+        def batch_decode(self, batch):
+            self.batch_decode_calls.append([list(token_ids) for token_ids in batch])
+            return [" ".join(map(str, token_ids)) for token_ids in batch]
+
+    tokenizer = _Tokenizer()
+    nemo_gym_result = {
+        "response": {
+            "output": [
+                {
+                    "prompt_token_ids": [1, 2],
+                    "generation_token_ids": [3],
+                    "generation_log_probs": [-0.1],
+                },
+                {
+                    "prompt_token_ids": [1, 2, 3, 4, 5],
+                    "generation_token_ids": [6, 7],
+                    "generation_log_probs": [-0.2, -0.3],
+                },
+            ]
+        },
+        "responses_create_params": {"input": []},
+    }
+
+    result = (
+        NemoGym.__ray_metadata__.modified_class._postprocess_nemo_gym_to_nemo_rl_result(
+            None, nemo_gym_result, tokenizer
+        )
+    )
+
+    assert tokenizer.batch_decode_calls == [
+        [[1, 2], [1, 2, 3, 4, 5]],
+        [[3], [6, 7]],
+    ]
+    assert result["message_log"][0]["token_ids"].tolist() == [1, 2]
+    assert result["message_log"][1]["token_ids"].tolist() == [3]
+    assert result["message_log"][2]["token_ids"].tolist() == [4, 5]
+    assert result["message_log"][3]["token_ids"].tolist() == [6, 7]
+    assert nemo_gym_result["response"]["output"][0]["prompt_str"] == "1 2"
+    assert nemo_gym_result["response"]["output"][0]["generation_str"] == "3"
+    assert nemo_gym_result["response"]["output"][1]["prompt_str"] == "1 2 3 4 5"
+    assert nemo_gym_result["response"]["output"][1]["generation_str"] == "6 7"
+
+
 @pytest.mark.nemo_gym
 def test_nemo_gym_sanity(
     nemo_gym,

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -33,6 +33,9 @@ from nemo_rl.models.generation.interfaces import (
     GenerationDatumSpec,
 )
 from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration
+from nemo_rl.models.generation.vllm.vllm_worker import (
+    _resolve_enable_prefix_caching,
+)
 from nemo_rl.models.generation.vllm.vllm_worker_async import (
     _replace_prefix_tokens,
 )
@@ -129,6 +132,28 @@ basic_dtensor_test_config: PolicyConfig = {
     "make_sequence_length_divisible_by": 1,
     "generation": deepcopy(basic_vllm_test_config),
 }
+
+
+def test_resolve_enable_prefix_caching_respects_explicit_config(monkeypatch):
+    def raise_if_called():
+        raise AssertionError("CUDA capability should not be queried")
+
+    monkeypatch.setattr(torch.cuda, "get_device_capability", raise_if_called)
+
+    assert _resolve_enable_prefix_caching({"enable_prefix_caching": False}) is False
+    assert _resolve_enable_prefix_caching({"enable_prefix_caching": True}) is True
+
+
+def test_resolve_enable_prefix_caching_uses_cuda_capability_for_auto(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda: (8, 0))
+
+    assert _resolve_enable_prefix_caching({}) is True
+    assert _resolve_enable_prefix_caching({"enable_prefix_caching": None}) is True
+
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda: (7, 5))
+
+    assert _resolve_enable_prefix_caching({}) is False
+
 
 basic_lora_test_config: LoRAConfig = {
     "enabled": False,


### PR DESCRIPTION
# What does this PR do ?

This PR selectively backports the low-risk pieces of upstream [3fa3e32e8f29589a71be44fac0bc488b4253d17f](https://github.com/NVIDIA-NeMo/RL/commit/3fa3e32e8f29589a71be44fac0bc488b4253d17f):

- avoids probing CUDA device capability when `vllm_cfg.enable_prefix_caching` is explicitly configured
- batches NeMo-Gym rollout log string decoding with `tokenizer.batch_decode`
- adds unit coverage for both changes

# Issues
Closes https://github.com/NVIDIA-NeMo/RL/issues/1947


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
