### PR TITLE
fix(rollouts): fail loudly on silent NeMo-Gym agent failure

### DIFF
--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -1163,6 +1163,24 @@ def run_async_nemo_gym_rollout(
             )
         )
 
+        # Fail loudly if the NeMo-Gym agent returned fewer (or zero) results
+        # than the number of input rows. Silently producing an empty/partial
+        # batch lets training continue with "empty epochs" downstream
+        # (see issue #2305), which usually masks a CPU OOM or another
+        # silent agent crash inside Gym.
+        expected = len(nemo_gym_rows)
+        got = len(results)
+        if got != expected:
+            raise RuntimeError(
+                f"NeMo-Gym returned {got} rollout result(s) for {expected} "
+                "input row(s). This usually means the Gym agent crashed "
+                "silently (most commonly CPU OOM during rollout collection "
+                "for large batches). Check the Gym agent logs for OOM / "
+                "killed-process messages and consider reducing "
+                "grpo.num_prompts_per_step * grpo.num_generations_per_prompt, "
+                "or the per-row max_output_tokens, to fit available memory."
+            )
+
         # Tensorize all token ids
         for r in results:
             _tensorize_by_key(r["input_message_log"], "token_ids")

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -805,6 +805,81 @@ def test_run_async_nemo_gym_rollout_warns_when_max_seq_len_exceeds_engine():
             )
 
 
+def test_run_async_nemo_gym_rollout_raises_on_silent_agent_failure(monkeypatch):
+    """Regression test for issue #2305.
+
+    When the NeMo-Gym agent crashes silently (e.g. CPU OOM during rollout
+    collection), `run_rollouts.remote(...)` may return fewer results than
+    input rows. Previously this produced "empty epochs" downstream; now we
+    raise a clear RuntimeError naming the size mismatch and OOM as the
+    likely culprit.
+    """
+
+    class _FakePolicyGeneration:
+        cfg = {"vllm_cfg": {"max_model_len": 100}}
+
+    # Two input rows with the minimum fields read before the ray.get call.
+    rows = [
+        {"responses_create_params": {}, "agent_ref": {"name": "a"}},
+        {"responses_create_params": {}, "agent_ref": {"name": "b"}},
+    ]
+
+    class _FakeRunRolloutsHandle:
+        @staticmethod
+        def remote(*args, **kwargs):
+            return "_sentinel_object_ref_"
+
+    class _FakeNemoGymEnv:
+        run_rollouts = _FakeRunRolloutsHandle()
+
+    # Pretend Gym agent silently dropped one row → length mismatch.
+    monkeypatch.setattr(
+        "nemo_rl.experience.rollouts.ray.get",
+        lambda _ref: ([rows[0]], {}),
+    )
+
+    with pytest.raises(RuntimeError, match="NeMo-Gym returned 1 rollout result"):
+        run_async_nemo_gym_rollout(
+            policy_generation=_FakePolicyGeneration(),
+            input_batch={"extra_env_info": rows},
+            tokenizer=None,
+            task_to_env={"nemo_gym": _FakeNemoGymEnv()},
+            generation_config={
+                "stop_strings": None,
+                "stop_token_ids": None,
+                "top_k": None,
+                "temperature": 1.0,
+                "top_p": 1.0,
+                "max_new_tokens": 50,
+            },
+            max_seq_len=None,
+            max_rollout_turns=None,
+        )
+
+    # And: zero results (full agent crash) is also caught.
+    monkeypatch.setattr(
+        "nemo_rl.experience.rollouts.ray.get",
+        lambda _ref: ([], {}),
+    )
+    with pytest.raises(RuntimeError, match="NeMo-Gym returned 0 rollout result"):
+        run_async_nemo_gym_rollout(
+            policy_generation=_FakePolicyGeneration(),
+            input_batch={"extra_env_info": rows},
+            tokenizer=None,
+            task_to_env={"nemo_gym": _FakeNemoGymEnv()},
+            generation_config={
+                "stop_strings": None,
+                "stop_token_ids": None,
+                "top_k": None,
+                "temperature": 1.0,
+                "top_p": 1.0,
+                "max_new_tokens": 50,
+            },
+            max_seq_len=None,
+            max_rollout_turns=None,
+        )
+
+
 @pytest.mark.nemo_gym
 def test_run_async_nemo_gym_rollout(
     nemo_gym,  # noqa: F811


### PR DESCRIPTION
## Summary

Closes #2305.

When the NeMo-Gym agent crashes silently — most commonly CPU OOM during rollout collection on oversized batches — \`run_rollouts.remote(...)\` may return fewer results than input rows. The previous code accepted the mismatch and built a partial \`final_batch\` from whatever came back, producing \"empty epochs\" downstream. Training continued without crashing, masking the underlying agent failure (exactly what was reported in #2305).

## What changed

\`run_async_nemo_gym_rollout\` in \`nemo_rl/experience/rollouts.py\` now compares \`len(results)\` against \`len(nemo_gym_rows)\` immediately after the \`ray.get\` and raises a \`RuntimeError\` if they don't match:

\`\`\`
RuntimeError: NeMo-Gym returned 0 rollout result(s) for 1024 input row(s).
This usually means the Gym agent crashed silently (most commonly CPU OOM
during rollout collection for large batches). Check the Gym agent logs
for OOM / killed-process messages and consider reducing
grpo.num_prompts_per_step * grpo.num_generations_per_prompt, or the
per-row max_output_tokens, to fit available memory.
\`\`\`

The error names the size mismatch, the likely cause, where to look (Gym agent logs), and which knobs to turn. The check is O(1) and only fires on the failure path; the success case (one result per input row) is unaffected.

## Test plan

- [x] New regression test \`test_run_async_nemo_gym_rollout_raises_on_silent_agent_failure\` covers both partial (1-of-2 returned) and total (0-of-2 returned) agent failures by monkeypatching \`ray.get\`. Runs without GPU / Gym / Ray.
- [x] \`ruff check\` — clean
- [x] \`ruff format --check\` — clean
- [x] \`python3 -m py_compile\` — clean
- [ ] CI \`L0_Unit_Tests\` — runs the new test
- [ ] CI \`tests/functional/grpo_async_gym.sh\` — exercises the happy path and confirms no false-positive

Refs: #2305