### PR TITLE
docs: add policy lifecycle guide for custom training loops

### DIFF
--- a/docs/design-docs/policy-lifecycle.md
+++ b/docs/design-docs/policy-lifecycle.md
@@ -1,0 +1,133 @@
+# Policy Lifecycle and Resource Preparation
+
+> **TL;DR.** Every GPU-bound call on a `LMPolicy` (`train`, `get_logprobs`,
+> `score`, `get_topk_logits`, `generate`) requires the model weights to
+> be **on the GPU** at the moment of the call. You move them there by
+> calling `prepare_for_training()` or `prepare_for_lp_inference()`. If
+> you forget, you will see opaque CUDA errors — most often
+> `RuntimeError: CUDA error: an illegal memory access was encountered`.
+
+This document is aimed at users writing their own training loops (or
+making large changes to existing ones) on top of NeMo RL. The built-in
+algorithms (`grpo`, `sft`, `dpo`, `rm`, `distillation`) already call
+these methods in the right places; you only need this if you are
+replacing or extending them.
+
+## The state machine
+
+A policy worker can be in one of three logical states:
+
+| State | Weights on | Optimizer on | What you can call |
+| --- | --- | --- | --- |
+| **Training** | GPU | GPU | `train`, `get_logprobs`, `score`, `save_checkpoint` |
+| **Logprob / inference** | GPU | offloaded (CPU/disk) or absent | `get_logprobs`, `score`, `get_topk_logits`, `generate` |
+| **Offloaded** | CPU/disk | CPU/disk | `prepare_*`, refit helpers — **nothing GPU-bound** |
+
+The transitions are:
+
+```text
+            prepare_for_training()
+   Offloaded ─────────────────────► Training
+        ▲                              │
+        │ offload_*                    │ prepare_for_lp_inference()
+        │                              ▼
+        └──────────────────────── Logprob/inference
+```
+
+The reason this matters: training mode pins the optimizer state on the
+GPU, which can be large. RL pipelines that interleave training with
+generation routinely **offload** the optimizer (and sometimes the
+weights) to make room for the inference engine, then move them back
+before the next training step.
+
+## The two preparation methods
+
+Both methods live on
+[`PolicyInterface`](../../nemo_rl/models/policy/interfaces.py) and are
+implemented by every policy worker backend (`dtensor_policy_worker`,
+`dtensor_policy_worker_v2`, `megatron_policy_worker`).
+
+### `prepare_for_training()`
+
+Call this **before** any of:
+
+- `policy.train(...)`
+- `policy.save_checkpoint(...)`
+
+This moves the optimizer state back to the GPU (if it was offloaded)
+and switches the model to train mode. After this call the policy can
+do backward passes and step the optimizer.
+
+### `prepare_for_lp_inference()`
+
+Call this **before** any of:
+
+- `policy.get_logprobs(...)`
+- `policy.score(...)`
+- `policy.get_topk_logits(...)`
+- `policy.generate(...)` (Megatron backend only)
+
+This moves model weights to the GPU (if they were offloaded), switches
+the model to eval mode, and frees optimizer state that is not needed
+for inference. It is cheaper than `prepare_for_training()` and is what
+you want between training steps when you only need forward passes (for
+example to compute reference/policy logprobs against a rollout).
+
+### Symmetry
+
+There is no separate `finish_*` call you must make. The next
+`prepare_*` or `offload_*` call handles the transition. Use
+`offload_before_refit()` / `offload_after_refit()` explicitly when you
+need to make room for an external inference engine (e.g. vLLM) during
+refit. See `nemo_rl/algorithms/grpo.py` for the canonical
+training-loop example.
+
+## What happens if you skip the prepare step
+
+If you call a GPU-bound API while the policy is in an offloaded state,
+you will typically see one of:
+
+- `RuntimeError: CUDA error: an illegal memory access was encountered`
+- `RuntimeError: Expected all tensors to be on the same device`
+- A silent crash with no Python traceback (the worker process dies)
+
+The traceback usually points deep into the model forward pass and gives
+no hint that the cause was a missing `prepare_for_*` call. If you see
+any of these in a custom training loop, **first** check that the most
+recent state transition was a `prepare_for_lp_inference()` or
+`prepare_for_training()` matching the call you are about to make.
+
+## A minimal custom training loop
+
+```python
+from nemo_rl.models.policy.lm_policy import LMPolicy
+
+policy: LMPolicy = ...  # constructed by the example runners
+
+for step in range(num_steps):
+    # 1. Generate rollouts. Weights need to be on the GPU.
+    policy.prepare_for_lp_inference()
+    rollouts = my_rollout_fn(policy, batch)
+
+    # 2. Compute reference logprobs (still inference mode).
+    ref_logprobs = policy.get_logprobs(rollouts)
+
+    # 3. Switch to training mode before the train step.
+    policy.prepare_for_training()
+    train_metrics = policy.train(rollouts, ref_logprobs, ...)
+
+    # 4. Optionally offload to free GPU for an external generator.
+    policy.offload_before_refit()
+    refit_external_engine(policy)
+    policy.offload_after_refit()
+```
+
+If you replace any of these steps but keep the surrounding ones, keep
+the `prepare_*` calls in the same relative position — they are not
+optional.
+
+## Cross-references
+
+- Interface: [`nemo_rl/models/policy/interfaces.py`](../../nemo_rl/models/policy/interfaces.py)
+- Reference loop: [`nemo_rl/algorithms/grpo.py`](../../nemo_rl/algorithms/grpo.py)
+- Related issues: [#1141](https://github.com/NVIDIA-NeMo/RL/issues/1141)

--- a/docs/design-docs/policy-lifecycle.md
+++ b/docs/design-docs/policy-lifecycle.md
@@ -15,13 +15,17 @@ replacing or extending them.
 
 ## The state machine
 
-A policy worker can be in one of three logical states:
+A policy worker can be in one of three logical states. Whether the
+optimizer follows the weights is controlled by the
+`offload_optimizer_for_logprob` config flag (and, for colocated
+generation, by `is_generation_colocated`); the table below shows the
+default behavior when those are enabled.
 
-| State | Weights on | Optimizer on | What you can call |
+| State | Weights on | Optimizer on (default) | What you can call |
 | --- | --- | --- | --- |
 | **Training** | GPU | GPU | `train`, `get_logprobs`, `score`, `save_checkpoint` |
-| **Logprob / inference** | GPU | offloaded (CPU/disk) or absent | `get_logprobs`, `score`, `get_topk_logits`, `generate` |
-| **Offloaded** | CPU/disk | CPU/disk | `prepare_*`, refit helpers — **nothing GPU-bound** |
+| **Logprob / inference** | GPU | CPU (when `offload_optimizer_for_logprob=true`) else GPU | `get_logprobs`, `score`, `get_topk_logits`, `generate` |
+| **Offloaded (refit)** | CPU / device-streamed | CPU | `prepare_*`, refit helpers — **nothing GPU-bound** |
 
 The transitions are:
 
@@ -34,11 +38,11 @@ The transitions are:
         └──────────────────────── Logprob/inference
 ```
 
-The reason this matters: training mode pins the optimizer state on the
-GPU, which can be large. RL pipelines that interleave training with
-generation routinely **offload** the optimizer (and sometimes the
-weights) to make room for the inference engine, then move them back
-before the next training step.
+The reason this matters: training pins both weights and the optimizer
+state on the GPU, which can be large. RL pipelines that interleave
+training with generation routinely **offload** the optimizer (and
+sometimes the weights) to make room for the inference engine, then
+move them back before the next training step.
 
 ## The two preparation methods
 
@@ -54,9 +58,11 @@ Call this **before** any of:
 - `policy.train(...)`
 - `policy.save_checkpoint(...)`
 
-This moves the optimizer state back to the GPU (if it was offloaded)
-and switches the model to train mode. After this call the policy can
-do backward passes and step the optimizer.
+This ensures the model is on the GPU and switches it to train mode.
+When `offload_optimizer_for_logprob=true` or generation is colocated
+(and the optimizer is not configured for permanent CPU offload), it
+also moves the optimizer state back to the GPU. After this call the
+policy can do backward passes and step the optimizer.
 
 ### `prepare_for_lp_inference()`
 
@@ -67,11 +73,12 @@ Call this **before** any of:
 - `policy.get_topk_logits(...)`
 - `policy.generate(...)` (Megatron backend only)
 
-This moves model weights to the GPU (if they were offloaded), switches
-the model to eval mode, and frees optimizer state that is not needed
-for inference. It is cheaper than `prepare_for_training()` and is what
-you want between training steps when you only need forward passes (for
-example to compute reference/policy logprobs against a rollout).
+This ensures the model is on the GPU and switches it to eval mode.
+When `offload_optimizer_for_logprob=true`, it also offloads optimizer
+state to CPU to free GPU memory for inference. It is cheaper than
+`prepare_for_training()` and is what you want between training steps
+when you only need forward passes (for example to compute
+reference/policy logprobs against a rollout).
 
 ### Symmetry
 

--- a/docs/design-docs/policy-lifecycle.md
+++ b/docs/design-docs/policy-lifecycle.md
@@ -1,7 +1,7 @@
 # Policy Lifecycle and Resource Preparation
 
 > **TL;DR.** Every GPU-bound call on a `LMPolicy` (`train`, `get_logprobs`,
-> `score`, `get_topk_logits`, `generate`) requires the model weights to
+> `score`, `get_topk_logits`) requires the model weights to
 > be **on the GPU** at the moment of the call. You move them there by
 > calling `prepare_for_training()` or `prepare_for_lp_inference()`. If
 > you forget, you will see opaque CUDA errors — most often
@@ -15,13 +15,17 @@ replacing or extending them.
 
 ## The state machine
 
-A policy worker can be in one of three logical states:
+A policy worker can be in one of three logical states. Whether the
+optimizer follows the weights is controlled by the
+`offload_optimizer_for_logprob` config flag (and, for colocated
+generation, by `is_generation_colocated`); the table below shows the
+default behavior when those are enabled.
 
-| State | Weights on | Optimizer on | What you can call |
+| State | Weights on | Optimizer on (default) | What you can call |
 | --- | --- | --- | --- |
 | **Training** | GPU | GPU | `train`, `get_logprobs`, `score`, `save_checkpoint` |
-| **Logprob / inference** | GPU | offloaded (CPU/disk) or absent | `get_logprobs`, `score`, `get_topk_logits`, `generate` |
-| **Offloaded** | CPU/disk | CPU/disk | `prepare_*`, refit helpers — **nothing GPU-bound** |
+| **Logprob / inference** | GPU | CPU (when `offload_optimizer_for_logprob=true`) else GPU | `get_logprobs`, `score`, `get_topk_logits` |
+| **Offloaded (refit)** | CPU / device-streamed | CPU | `prepare_*`, refit helpers — **nothing GPU-bound** |
 
 The transitions are:
 
@@ -34,11 +38,11 @@ The transitions are:
         └──────────────────────── Logprob/inference
 ```
 
-The reason this matters: training mode pins the optimizer state on the
-GPU, which can be large. RL pipelines that interleave training with
-generation routinely **offload** the optimizer (and sometimes the
-weights) to make room for the inference engine, then move them back
-before the next training step.
+The reason this matters: training pins both weights and the optimizer
+state on the GPU, which can be large. RL pipelines that interleave
+training with generation routinely **offload** the optimizer (and
+sometimes the weights) to make room for the inference engine, then
+move them back before the next training step.
 
 ## The two preparation methods
 
@@ -54,9 +58,11 @@ Call this **before** any of:
 - `policy.train(...)`
 - `policy.save_checkpoint(...)`
 
-This moves the optimizer state back to the GPU (if it was offloaded)
-and switches the model to train mode. After this call the policy can
-do backward passes and step the optimizer.
+This ensures the model is on the GPU and switches it to train mode.
+When `offload_optimizer_for_logprob=true` or generation is colocated
+(and the optimizer is not configured for permanent CPU offload), it
+also moves the optimizer state back to the GPU. After this call the
+policy can do backward passes and step the optimizer.
 
 ### `prepare_for_lp_inference()`
 
@@ -65,13 +71,16 @@ Call this **before** any of:
 - `policy.get_logprobs(...)`
 - `policy.score(...)`
 - `policy.get_topk_logits(...)`
-- `policy.generate(...)` (Megatron backend only)
 
-This moves model weights to the GPU (if they were offloaded), switches
-the model to eval mode, and frees optimizer state that is not needed
-for inference. It is cheaper than `prepare_for_training()` and is what
-you want between training steps when you only need forward passes (for
-example to compute reference/policy logprobs against a rollout).
+This ensures the model is on the GPU and switches it to eval mode.
+When `offload_optimizer_for_logprob=true`, it also offloads optimizer
+state to CPU to free GPU memory for inference. It is cheaper than
+`prepare_for_training()` and is what you want between training steps
+when you only need forward passes (for example to compute
+reference/policy logprobs against a rollout). Pass
+`keep_train_buffers=True` only when a train step is already open and
+its accumulated gradients and optimizer state must stay resident on
+the GPU across the call.
 
 ### Symmetry
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -294,6 +294,7 @@ design-docs/training-backends.md
 design-docs/sequence-packing-and-dynamic-batching.md
 design-docs/env-vars.md
 design-docs/nemo-gym-integration.md
+design-docs/policy-lifecycle.md
 ```
 
 ```{toctree}

--- a/docs/index.md
+++ b/docs/index.md
@@ -386,6 +386,7 @@ design-docs/modelopt-real-quant-architecture.md
 design-docs/nccl-reshard-refit.md
 design-docs/media-token-validity-mask.md
 design-docs/automodel-context-parallel.md
+design-docs/policy-lifecycle.md
 ```
 
 ```{toctree}

--- a/nemo_rl/models/policy/interfaces.py
+++ b/nemo_rl/models/policy/interfaces.py
@@ -148,12 +148,14 @@ class PolicyInterface(ABC):
 
     @abstractmethod
     def prepare_for_training(self, *args: Any, **kwargs: Any) -> None:
-        """Move weights + optimizer state to the GPU and switch to train mode.
+        """Ensure weights are on the GPU and switch the model to train mode.
 
         Must be called before ``train`` or ``save_checkpoint`` whenever the
-        policy may have been offloaded or last used for inference. Skipping
-        this call typically surfaces as an opaque CUDA "illegal memory
-        access" inside the model forward pass. See
+        policy may have been offloaded or last used for inference. Also
+        moves optimizer state back to the GPU when
+        ``offload_optimizer_for_logprob=true`` or generation is colocated.
+        Skipping this call typically surfaces as an opaque CUDA "illegal
+        memory access" inside the model forward pass. See
         ``docs/design-docs/policy-lifecycle.md`` for the full state
         machine.
         """
@@ -217,12 +219,13 @@ class ColocatablePolicyInterface(PolicyInterface):
 
     @abstractmethod
     def prepare_for_lp_inference(self) -> None:
-        """Move weights to the GPU and switch to eval mode for inference.
+        """Ensure weights are on the GPU and switch the model to eval mode.
 
         Must be called before any GPU-bound inference API on the policy:
         ``get_logprobs``, ``score``, ``get_topk_logits``, and (Megatron
-        only) ``generate``. Optimizer state stays offloaded, so this is
-        cheaper than ``prepare_for_training``. See
+        only) ``generate``. When ``offload_optimizer_for_logprob=true``,
+        also offloads optimizer state to CPU, making this cheaper than
+        ``prepare_for_training``. See
         ``docs/design-docs/policy-lifecycle.md`` for the full state
         machine.
         """

--- a/nemo_rl/models/policy/interfaces.py
+++ b/nemo_rl/models/policy/interfaces.py
@@ -148,6 +148,15 @@ class PolicyInterface(ABC):
 
     @abstractmethod
     def prepare_for_training(self, *args: Any, **kwargs: Any) -> None:
+        """Move weights + optimizer state to the GPU and switch to train mode.
+
+        Must be called before ``train`` or ``save_checkpoint`` whenever the
+        policy may have been offloaded or last used for inference. Skipping
+        this call typically surfaces as an opaque CUDA "illegal memory
+        access" inside the model forward pass. See
+        ``docs/design-docs/policy-lifecycle.md`` for the full state
+        machine.
+        """
         pass
 
     @abstractmethod
@@ -208,4 +217,13 @@ class ColocatablePolicyInterface(PolicyInterface):
 
     @abstractmethod
     def prepare_for_lp_inference(self) -> None:
+        """Move weights to the GPU and switch to eval mode for inference.
+
+        Must be called before any GPU-bound inference API on the policy:
+        ``get_logprobs``, ``score``, ``get_topk_logits``, and (Megatron
+        only) ``generate``. Optimizer state stays offloaded, so this is
+        cheaper than ``prepare_for_training``. See
+        ``docs/design-docs/policy-lifecycle.md`` for the full state
+        machine.
+        """
         pass

--- a/nemo_rl/models/policy/interfaces.py
+++ b/nemo_rl/models/policy/interfaces.py
@@ -148,12 +148,14 @@ class PolicyInterface(ABC):
 
     @abstractmethod
     def prepare_for_training(self, *args: Any, **kwargs: Any) -> None:
-        """Move weights + optimizer state to the GPU and switch to train mode.
+        """Ensure weights are on the GPU and switch the model to train mode.
 
         Must be called before ``train`` or ``save_checkpoint`` whenever the
-        policy may have been offloaded or last used for inference. Skipping
-        this call typically surfaces as an opaque CUDA "illegal memory
-        access" inside the model forward pass. See
+        policy may have been offloaded or last used for inference. Also
+        moves optimizer state back to the GPU when
+        ``offload_optimizer_for_logprob=true`` or generation is colocated.
+        Skipping this call typically surfaces as an opaque CUDA "illegal
+        memory access" inside the model forward pass. See
         ``docs/design-docs/policy-lifecycle.md`` for the full state
         machine.
         """
@@ -286,11 +288,19 @@ class ColocatablePolicyInterface(PolicyInterface):
 
     @abstractmethod
     def prepare_for_lp_inference(self, keep_train_buffers: bool = False) -> None:
-        """Put the policy in eval mode for logprob inference.
+        """Ensure weights are on the GPU and switch the model to eval mode.
 
         Must be called before any GPU-bound inference API on the policy:
-        ``get_logprobs``, ``score``, and ``get_topk_logits``. Optimizer
-        state stays offloaded, so this is cheaper than
+        ``get_logprobs``, ``score``, and ``get_topk_logits``. When
+        ``offload_optimizer_for_logprob=true``, also offloads optimizer
+        state to CPU, making this cheaper than ``prepare_for_training``.
+        See ``docs/design-docs/policy-lifecycle.md`` for the full state
+        machine.
+
+        Args:
+            keep_train_buffers: Leave grad buffers and optimizer state on CUDA
+                because a train step is already open and its accumulated
+                gradients must survive this call.
         ``prepare_for_training``. See
         ``docs/design-docs/policy-lifecycle.md`` for the full state
         machine.

--- a/nemo_rl/models/policy/interfaces.py
+++ b/nemo_rl/models/policy/interfaces.py
@@ -148,6 +148,15 @@ class PolicyInterface(ABC):
 
     @abstractmethod
     def prepare_for_training(self, *args: Any, **kwargs: Any) -> None:
+        """Move weights + optimizer state to the GPU and switch to train mode.
+
+        Must be called before ``train`` or ``save_checkpoint`` whenever the
+        policy may have been offloaded or last used for inference. Skipping
+        this call typically surfaces as an opaque CUDA "illegal memory
+        access" inside the model forward pass. See
+        ``docs/design-docs/policy-lifecycle.md`` for the full state
+        machine.
+        """
         pass
 
     @abstractmethod
@@ -278,6 +287,13 @@ class ColocatablePolicyInterface(PolicyInterface):
     @abstractmethod
     def prepare_for_lp_inference(self, keep_train_buffers: bool = False) -> None:
         """Put the policy in eval mode for logprob inference.
+
+        Must be called before any GPU-bound inference API on the policy:
+        ``get_logprobs``, ``score``, and ``get_topk_logits``. Optimizer
+        state stays offloaded, so this is cheaper than
+        ``prepare_for_training``. See
+        ``docs/design-docs/policy-lifecycle.md`` for the full state
+        machine.
 
         Args:
             keep_train_buffers: Leave grad buffers and optimizer state on CUDA


### PR DESCRIPTION
## Summary

Closes #1141.

The issue asked for either documentation or a more helpful error when a user writes a custom training loop and forgets to call \`prepare_for_lp_inference()\` / \`prepare_for_training()\` before a GPU-bound API call. The typical symptom — an opaque \`RuntimeError: CUDA error: an illegal memory access\` deep in a model forward pass — gives no hint that the cause is a missing \`prepare_*\` call.

This PR is the **documentation half** of that ask. The runtime-error half is covered by PRs #2392 / #2393 (offload guards) which raise an actionable \`RuntimeError\` naming the missing \`prepare_*\` call.

## What changed

- **New doc: \`docs/design-docs/policy-lifecycle.md\`** — explains the policy state machine (training ↔ logprob/inference ↔ offloaded), the contract for \`prepare_for_training()\` / \`prepare_for_lp_inference()\`, what happens if you skip the prepare step, and a minimal custom training-loop example that calls everything in the right order.
- **Docstrings: \`nemo_rl/models/policy/interfaces.py\`** — filled in the previously-empty docstrings on \`prepare_for_training\` and \`prepare_for_lp_inference\` with a one-paragraph summary + pointer to the new doc, so \`help(PolicyInterface)\` is immediately useful when reading the source.
- **\`docs/index.md\`** — added the new doc to the \`Design Docs\` toctree.

## Test plan

- [x] \`ruff check\` on the interface change — clean
- [x] \`python3 -m py_compile\` on the interface change — clean
- [ ] Markdown lint / Sphinx build in CI (purely additive doc + toctree entry, no broken cross-refs)

## Cross-refs

- Issue: #1141
- Related runtime-error PRs (the \"give more helpful error message\" half): #2392, #2393