### PR TITLE
feat(grpo): add Mistral 3.x recipes for GRPO (closes #2542)

### DIFF
--- a/examples/configs/recipes/llm/grpo-mistral-medium-3.5-128b-16n8g-fsdp2tp8-actckpt-long.yaml
+++ b/examples/configs/recipes/llm/grpo-mistral-medium-3.5-128b-16n8g-fsdp2tp8-actckpt-long.yaml
@@ -1,0 +1,53 @@
+# GRPO recipe for Mistral-Medium-3.5-128B — the only model in Mistral's
+# released catalog that actually carries the "3.5" version tag
+# (https://huggingface.co/mistralai/Mistral-Medium-3.5-128B). Addresses the
+# 128B side of https://github.com/NVIDIA-NeMo/RL/issues/2542.
+#
+# Uses FSDP2 (not Megatron) because the Megatron converter_type for this
+# model is not yet validated in NeMo-RL — FSDP2 + HF AutoModel loading is the
+# more portable path until the converter is added. Sharding mirrors the
+# Gemma3-27B recipe, scaled up to 16 nodes × 8 GPUs to accommodate the ~5x
+# parameter count and KV cache.
+defaults: ../../grpo_math_1B.yaml
+grpo:
+  num_prompts_per_step: 64
+  num_generations_per_prompt: 16
+  max_num_steps: 20
+checkpointing:
+  checkpoint_dir: results/grpo-mistral-medium-3.5-128b-16n8g-fsdp2tp8-actckpt-long
+  model_save_format: null
+policy:
+  model_name: mistralai/Mistral-Medium-3.5-128B
+  tokenizer:
+    name: mistralai/Mistral-Medium-3.5-128B
+  train_micro_batch_size: 1
+  max_total_sequence_length: 8192
+  dtensor_cfg:
+    activation_checkpointing: true
+    tensor_parallel_size: 8
+    sequence_parallel: true
+    _v2: false
+  sequence_packing:
+    enabled: true
+  make_sequence_length_divisible_by: 8
+  optimizer:
+    kwargs:
+      lr: 1.0e-07
+  generation:
+    max_new_tokens: 8192
+    vllm_cfg:
+      tensor_parallel_size: 8
+      max_model_len: 8192
+      gpu_memory_utilization: 0.55
+data:
+  max_input_seq_length: 8192
+logger:
+  log_dir: logs/grpo-mistral-medium-3.5-128b-16n8g-fsdp2tp8-actckpt-long
+  wandb_enabled: true
+  tensorboard_enabled: true
+  wandb:
+    project: nemo-rl
+    name: grpo-mistral-medium-3.5-128b-16n8g-fsdp2tp8-actckpt-long
+cluster:
+  gpus_per_node: 8
+  num_nodes: 16

--- a/examples/configs/recipes/llm/grpo-mistral-small-3.2-24b-instruct-8n8g-fsdp2tp8-actckpt-long.yaml
+++ b/examples/configs/recipes/llm/grpo-mistral-small-3.2-24b-instruct-8n8g-fsdp2tp8-actckpt-long.yaml
@@ -1,0 +1,53 @@
+# GRPO recipe for Mistral-Small-3.2-24B-Instruct-2506 (text-only path).
+#
+# This is the closest existing model to the "Mistral 3.5" target in
+# https://github.com/NVIDIA-NeMo/RL/issues/2542 — Mistral's Small line skipped
+# 3.5 (went 3.1 → 3.2 → 4), so 3.2-24B is the closest 24B stand-in.
+#
+# Mistral-Small-3.2 is an image-text-to-text model (architecture
+# Mistral3ForConditionalGeneration). The "mistral3" entry in
+# nemo_rl/models/policy/utils.py:AUTOMODEL_FACTORY already maps to
+# AutoModelForImageTextToText, and parallelize.py already extracts the
+# language_model submodule, so text-only GRPO math reuses the existing path —
+# the vision tower is loaded but unused.
+defaults: ../../grpo_math_1B.yaml
+grpo:
+  num_prompts_per_step: 64
+  num_generations_per_prompt: 32
+  max_num_steps: 20
+checkpointing:
+  checkpoint_dir: results/grpo-mistral-small-3.2-24b-instruct-8n8g-fsdp2tp8-actckpt-long
+  model_save_format: null
+policy:
+  model_name: mistralai/Mistral-Small-3.2-24B-Instruct-2506
+  tokenizer:
+    name: mistralai/Mistral-Small-3.2-24B-Instruct-2506
+  train_micro_batch_size: 1
+  max_total_sequence_length: 16384
+  dtensor_cfg:
+    activation_checkpointing: true
+    tensor_parallel_size: 8
+    _v2: false
+  sequence_packing:
+    enabled: false
+  make_sequence_length_divisible_by: 8
+  optimizer:
+    kwargs:
+      lr: 3.0e-07
+  generation:
+    max_new_tokens: 16384
+    vllm_cfg:
+      tensor_parallel_size: 4
+      max_model_len: 16384
+data:
+  max_input_seq_length: 16384
+logger:
+  log_dir: logs/grpo-mistral-small-3.2-24b-instruct-8n8g-fsdp2tp8-actckpt-long
+  wandb_enabled: true
+  tensorboard_enabled: true
+  wandb:
+    project: nemo-rl
+    name: grpo-mistral-small-3.2-24b-instruct-8n8g-fsdp2tp8-actckpt-long
+cluster:
+  gpus_per_node: 8
+  num_nodes: 8

--- a/examples/configs/recipes/vlm/vlm_grpo-mistral-small-3.2-24b-instruct-clevr-2n8g-dtensor2tp4.v1.yaml
+++ b/examples/configs/recipes/vlm/vlm_grpo-mistral-small-3.2-24b-instruct-clevr-2n8g-dtensor2tp4.v1.yaml
@@ -1,0 +1,82 @@
+# VLM GRPO recipe for Mistral-Small-3.2-24B-Instruct-2506.
+#
+# Mistral-Small-3.2 is an image-text-to-text model
+# (Mistral3ForConditionalGeneration). This recipe exercises the multimodal
+# path on the CLEVR-CoGenT dataset, mirroring vlm_grpo_3B.yaml (Qwen2.5-VL-3B)
+# with sharding scaled up for the 24B parameter count.
+#
+# The "mistral3" entry in nemo_rl/models/policy/utils.py:AUTOMODEL_FACTORY
+# already routes to AutoModelForImageTextToText, and parallelize.py has the
+# Mistral3 vision-tower + language-model split codepath.
+defaults: ../../grpo_math_1B.yaml
+
+grpo:
+  num_prompts_per_step: 8
+  reward_shaping:
+    overlong_buffer_length: 512
+  max_num_steps: 20
+
+checkpointing:
+  checkpoint_dir: results/vlm_grpo-mistral-small-3.2-24b-instruct-clevr-2n8g-dtensor2tp4
+  model_save_format: null
+
+policy:
+  model_name: mistralai/Mistral-Small-3.2-24B-Instruct-2506
+  tokenizer:
+    name: mistralai/Mistral-Small-3.2-24B-Instruct-2506
+  train_global_batch_size: 128
+  train_micro_batch_size: 1
+  logprob_batch_size: 1
+  max_total_sequence_length: 4096
+  dtensor_cfg:
+    activation_checkpointing: true
+    tensor_parallel_size: 4
+    _v2: false
+  dynamic_batching:
+    enabled: true
+  sequence_packing:
+    enabled: false
+  make_sequence_length_divisible_by: 4
+  optimizer:
+    kwargs:
+      lr: 5.0e-07
+  generation:
+    max_new_tokens: 1024
+    vllm_cfg:
+      tensor_parallel_size: 4
+      max_model_len: 4096
+      skip_tokenizer_init: false
+    vllm_kwargs:
+      # See vlm_grpo_3B.yaml — mm_processor_cache_gb caching has known issues
+      mm_processor_cache_gb: 0
+
+data:
+  max_input_seq_length: 4096
+  train:
+    dataset_name: clevr-cogent
+    split: train
+  validation:
+    dataset_name: clevr-cogent
+    split: valA
+  default:
+    prompt_file: examples/prompts/clevr_cogent_cot.txt
+    processor: vlm_hf_data_processor
+    env_name: clevr-cogent
+
+env:
+  clevr-cogent:
+    num_workers: 8
+    reward_functions:
+    - name: format
+      weight: 0.2
+    - name: exact_alnum
+      weight: 0.8
+
+logger:
+  log_dir: logs/vlm_grpo-mistral-small-3.2-24b-instruct-clevr-2n8g-dtensor2tp4
+  tensorboard_enabled: true
+  monitor_gpus: false
+
+cluster:
+  gpus_per_node: 8
+  num_nodes: 2


### PR DESCRIPTION
## Summary

Adds three GRPO recipe configs for the Mistral 3.x family, addressing the "Support GRPO for Mistral 3.5" feature request in #2542. No code changes — purely configuration.

**About the model targeting:** The issue title says "Mistral 3.5", but Mistral's released catalog (as of this PR) does not contain a `Mistral-Small-3.5`; the Small line went 3.1 → 3.2 → 4, skipping 3.5 entirely. The only model carrying the literal `3.5` tag is `mistralai/Mistral-Medium-3.5-128B`. I've therefore added recipes for:

| File | Target HF model | Backend | Shape |
|---|---|---|---|
| `examples/configs/recipes/llm/grpo-mistral-small-3.2-24b-instruct-8n8g-fsdp2tp8-actckpt-long.yaml` | `mistralai/Mistral-Small-3.2-24B-Instruct-2506` | FSDP2, text-only GRPO math | 8n8g, TP=8, actckpt, 16K seq |
| `examples/configs/recipes/vlm/vlm_grpo-mistral-small-3.2-24b-instruct-clevr-2n8g-dtensor2tp4.v1.yaml` | `mistralai/Mistral-Small-3.2-24B-Instruct-2506` | FSDP2, VLM GRPO on CLEVR-CoGenT | 2n8g, TP=4, dynamic batching |
| `examples/configs/recipes/llm/grpo-mistral-medium-3.5-128b-16n8g-fsdp2tp8-actckpt-long.yaml` | `mistralai/Mistral-Medium-3.5-128B` | FSDP2, text-only GRPO math | 16n8g, TP=8, sequence parallel + packing |

Existing infra reused (no code edits): `mistral3` is already registered in `nemo_rl/models/policy/utils.py:AUTOMODEL_FACTORY` → `AutoModelForImageTextToText`, and `nemo_rl/models/dtensor/parallelize.py` already has the `Mistral3ForConditionalGeneration` language-model split and vision-tower codepath. Mistral-Medium-3.5-128B is text-only and falls through to the default `AutoModelForCausalLM` path.

## Why FSDP2 (not Megatron) for the 128B recipe

`grpo_math_70B_megatron.yaml` uses `converter_type: "LlamaForCausalLM"`. There is no validated Megatron converter for Mistral-Medium-3.5 yet, so the recipe uses FSDP2 + HF AutoModel loading, which is the portable path until a Megatron-Bridge converter is added. Happy to add a Megatron variant in a follow-up once the converter exists.

## Test plan

### What was validated locally
- [x] All three configs load via `nemo_rl.utils.config.load_config_with_inheritance`
- [x] OmegaConf interpolations (`${...}`) resolve cleanly with `register_omegaconf_resolvers()` applied
- [x] All expected top-level keys present (`grpo`, `policy`, `loss_fn`, `data`, `env`, `logger`, `cluster`, `checkpointing`)
- [x] TP-accuracy invariant from `tests/unit/test_config_validation.py::test_all_config_no_tp_size_accuracy_issues` holds — all three have TP≥4 and `train_micro_batch_size == logprob_batch_size == 1`

### What needs CI / reviewer validation
- [ ] Strict Pydantic `MasterConfig` validation (`tests/unit/test_config_validation.py::test_all_config_files_have_required_keys`) — couldn't run locally because the repo's `uv` workspace requires populated git submodules + a Linux torch build
- [ ] Actual GRPO training step on real GPUs (Ampere+ required)
- [ ] HF download verification — `Mistral-Medium-3.5-128B` is likely gated; reviewers should confirm an HF token with model access works
- [ ] vLLM compatibility check for `Mistral-Medium-3.5-128B` (architecture may not be supported in pinned vLLM yet — recommend running `tools/model_diagnostics/1.max_model_len_respected.py` and `4.vllm_precision_compilation_test.py` before merge)

## Confidence per recipe

| Recipe | Confidence | Notes |
|---|---|---|
| `grpo-mistral-small-3.2-24b-instruct-...` (text) | **High** | Mistral3 codepath already exists; sharding mirrors a known-working Gemma3-27B recipe. Main risk: chat template handling for the multimodal model class on pure-text inputs |
| `vlm_grpo-mistral-small-3.2-24b-instruct-clevr-...` | **Medium** | VLM scaffolding exists for Qwen2.5-VL-3B; scaling to 24B + a different VLM architecture is untested. Sharding (TP=4) may need tuning |
| `grpo-mistral-medium-3.5-128b-...` | **Low** | Model is gated and I couldn't verify its HF config / vLLM support. Sharding numbers are extrapolated from the 70B recipe and should be treated as a starting point, not a tuned config |

## Notes for reviewers

- The 3.2-24B text recipe is the highest-value addition; the 128B recipe is best treated as a scaffold pending GPU validation
- If the maintainers prefer the 128B recipe to wait until a Megatron converter exists, I can drop that file and resubmit
- Happy to add a `docs/model-quirks.md` entry for Mistral3 if real-run testing surfaces anything specific