### PR TITLE
fix(grpo): penalize invalid tool call and malformed thinking

### DIFF
--- a/docs/guides/prorlv2.md
+++ b/docs/guides/prorlv2.md
@@ -248,7 +248,7 @@ In addition to task rewards/accuracy, a few stability signals are particularly u
 
 - **Dynamic sampling efficiency**: if enabled, watch how often batches need multiple generation rounds (see `dapo.md` for detailed guidance).
 - **Training–generation mismatch**: `token_mult_prob_error`, `gen_kl_error`, `policy_kl_error`, `js_divergence_error` are computed in `ClippedPGLossFn` (see the [GRPO metrics section](grpo.md#metrics)).
-- **IS out-of-bounds ratio** (`is_oob_ratio`): the fraction of tokens (ICE-POP) or sequences (seq-mask-tis) filtered out by truncated IS. A persistently high value suggests large backend mismatch — check precision settings or relax the bounds.
+- **IS out-of-bounds ratio** (`is_oob_ratio`): the fraction of tokens (TIS clamped above the max, ICE-POP outside [min, max]) or sequences (seq-mask-tis) whose importance weight falls outside the truncation bounds. A persistently high value suggests large backend mismatch — check precision settings or relax the bounds.
 - **Truncation rate**: if high, either increase `policy.max_total_sequence_length`/`policy.generation.max_model_len` or relax truncation penalty (`stop_properly_penalty_coef`).
 
 ## References

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -40,6 +40,10 @@ grpo:
     target_min: 0.0
     target_max: 1.0
   seq_logprob_error_threshold: null
+  # Advantage value assigned to invalid tool call tokens (e.g. -5.0 to penalize). null disables.
+  invalid_tool_call_advantage: null
+  # Advantage value assigned to tokens with malformed <think>/</think> tags (e.g. -5.0). null disables.
+  malformed_thinking_advantage: null
 
   async_grpo:
     enabled: false # Set to true to enable async training mode

--- a/examples/nemo_gym/grpo_nanov3.yaml
+++ b/examples/nemo_gym/grpo_nanov3.yaml
@@ -30,6 +30,10 @@ grpo:
     enabled: False
 
   seq_logprob_error_threshold: 2
+  # Advantage value assigned to invalid tool call tokens (e.g. -5.0 to penalize). null disables.
+  invalid_tool_call_advantage: null
+  # Advantage value assigned to tokens with malformed <think>/</think> tags (e.g. -5.0). null disables.
+  malformed_thinking_advantage: null
 
 loss_fn:
   reference_policy_kl_penalty: 0
@@ -258,6 +262,11 @@ env:
     # vLLM (20001+). See ray.sub for the full port layout.
     port_range_low: 15001
     port_range_high: 20000
+    # Optional substrings/tags used to flag malformed assistant turns for advantage
+    # penalties (see grpo.invalid_tool_call_advantage / malformed_thinking_advantage).
+    # Omit to use the built-in defaults (DEFAULT_INVALID_TOOL_CALL_PATTERNS / DEFAULT_THINKING_TAGS).
+    # invalid_tool_call_patterns: ["<tool_call>", "</tool_call>", "<function_call>", "</function_call>"]
+    # thinking_tags: ["<think>", "</think>"]
     config_paths:
     - responses_api_models/vllm_model/configs/vllm_model_for_training.yaml  # Required! And it must be *for_training
     - resources_servers/math_with_judge/configs/math_with_judge.yaml

--- a/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
+++ b/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
@@ -38,6 +38,10 @@ grpo:
     target_max: 1.0
   skip_reference_policy_logprobs_calculation: true
   seq_logprob_error_threshold: null
+  # Advantage value assigned to invalid tool call tokens (e.g. -5.0 to penalize). null disables.
+  invalid_tool_call_advantage: null
+  # Advantage value assigned to tokens with malformed <think>/</think> tags (e.g. -5.0). null disables.
+  malformed_thinking_advantage: null
 
   async_grpo:
     enabled: false # Set to true to enable async training mode

--- a/examples/nemo_gym/run_grpo_nemo_gym.py
+++ b/examples/nemo_gym/run_grpo_nemo_gym.py
@@ -208,9 +208,18 @@ The validation set you pass in will directly be used for validation with no addi
     is_trajectory_collection = (
         config.env["nemo_gym"].pop("is_trajectory_collection", False) or False
     )
+    # Pop NeMo-RL-side detection knobs out of the env dict so they reach NemoGymConfig
+    # as top-level fields (where the detector reads them) and are not forwarded into
+    # NeMo-Gym's own global config.
+    invalid_tool_call_patterns = config.env["nemo_gym"].pop(
+        "invalid_tool_call_patterns", None
+    )
+    thinking_tags = config.env["nemo_gym"].pop("thinking_tags", None)
     nemo_gym_config = NemoGymConfig(
         model_name=policy_generation.cfg["model_name"],
         base_urls=policy_generation.dp_openai_server_base_urls,
+        invalid_tool_call_patterns=invalid_tool_call_patterns,
+        thinking_tags=thinking_tags,
         initial_global_config_dict=config.env["nemo_gym"],
     )
     nemo_gym = create_env(env_name="nemo_gym", env_config=nemo_gym_config)

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -177,6 +177,12 @@ class GRPOConfig(TypedDict):
     # Sequence-level logprob error masking for training stability. If set, mask sequences with mult_prob_error exceeding this threshold (same scale as token_mult_prob_error metric, e.g., 1.5)
     # Note that this is slightly different than Masked Importance Sampling (MIS) because this uses the absolute value of the difference between the training and generation logprobs, whereas MIS just uses the difference between the training and generation logprobs.
     seq_logprob_error_threshold: float | None
+    # Advantage value to assign to invalid tool call tokens. When set (e.g. -5.0), overwrites the
+    # computed advantage for those tokens to penalize them; absent/None disables the penalty.
+    invalid_tool_call_advantage: NotRequired[float | None]
+    # Advantage value to assign to tokens with malformed <think>/</think> tags. When set (e.g. -5.0),
+    # overwrites the computed advantage for those tokens; absent/None disables the penalty.
+    malformed_thinking_advantage: NotRequired[float | None]
     # Advantage estimator configuration (grpo or reinforce_plus_plus)
     adv_estimator: NotRequired[AdvEstimatorConfig]
 
@@ -1088,6 +1094,122 @@ def add_grpo_token_loss_masks_and_generation_logprobs(
                 )
 
 
+def _resolve_message_level_advantage_penalties(
+    master_config: MasterConfig,
+) -> tuple[float | None, float | None]:
+    """Return configured message-level penalties and validate feature support."""
+    invalid_tool_call_advantage = master_config.grpo.get("invalid_tool_call_advantage")
+    malformed_thinking_advantage = master_config.grpo.get(
+        "malformed_thinking_advantage"
+    )
+    if invalid_tool_call_advantage is None and malformed_thinking_advantage is None:
+        return invalid_tool_call_advantage, malformed_thinking_advantage
+
+    # The is_invalid_tool_call / has_malformed_thinking flags these penalties rely on
+    # are only populated by the NeMo-Gym environment. Without that path the penalties
+    # would silently no-op, so fail loudly instead.
+    assert _should_use_nemo_gym(master_config), (
+        "grpo.invalid_tool_call_advantage / grpo.malformed_thinking_advantage require "
+        "the NeMo-Gym path (env.should_use_nemo_gym=true); they are not supported with "
+        "the native generation path."
+    )
+    return invalid_tool_call_advantage, malformed_thinking_advantage
+
+
+def _apply_message_level_advantage_penalties(
+    train_data: BatchedDataDict[ClippedPGLossDataDict],
+    message_logs: list[LLMMessageLogType | VLMMessageLogType],
+    invalid_tool_call_advantage: float | None,
+    malformed_thinking_advantage: float | None,
+    log_config: bool = False,
+) -> None:
+    """Overwrite advantages for flagged assistant-message token spans.
+
+    For each assistant message flagged by the NeMo-Gym detector as an invalid
+    tool call or malformed thinking, overwrite that message's advantage span in
+    ``train_data["advantages"]`` with the configured negative value. No-op when
+    neither ``grpo.invalid_tool_call_advantage`` nor
+    ``grpo.malformed_thinking_advantage`` is set.
+
+    Args:
+        train_data: Training batch; ``advantages`` is modified in place.
+        message_logs: Batch of message logs with per-message flags.
+        invalid_tool_call_advantage: Advantage value assigned to invalid tool calls.
+        malformed_thinking_advantage: Advantage value assigned to malformed thinking.
+        log_config: If True, print the configured penalty values once.
+    """
+    invalid_neg_adv = invalid_tool_call_advantage
+    malformed_neg_adv = malformed_thinking_advantage
+    if invalid_neg_adv is None and malformed_neg_adv is None:
+        return
+
+    if log_config:
+        print(
+            f"Invalid tool call advantage: {invalid_neg_adv}",
+            flush=True,
+        )
+        print(
+            f"Malformed thinking advantage: {malformed_neg_adv}",
+            flush=True,
+        )
+
+    for i, message_log in enumerate(message_logs):
+        token_offset = 0
+        for j, message in enumerate(message_log):
+            token_ids = cast(torch.Tensor, message["token_ids"])
+            msg_len = len(token_ids)
+            is_assistant = (
+                message["role"] == "assistant" and "generation_logprobs" in message
+            )
+            is_invalid = (
+                is_assistant
+                and invalid_neg_adv is not None
+                and message.get("is_invalid_tool_call", False)
+            )
+            is_malformed_thinking = (
+                is_assistant
+                and malformed_neg_adv is not None
+                and message.get("has_malformed_thinking", False)
+            )
+            if is_invalid:
+                print(
+                    f"Setting negative advantage ({invalid_neg_adv}) for invalid tool call in assistant message {i} {j}",
+                    flush=True,
+                )
+                train_data["advantages"][i, token_offset : token_offset + msg_len] = (
+                    invalid_neg_adv
+                )
+            elif is_malformed_thinking:
+                print(
+                    f"Setting negative advantage ({malformed_neg_adv}) for malformed thinking in assistant message {i} {j}",
+                    flush=True,
+                )
+                train_data["advantages"][i, token_offset : token_offset + msg_len] = (
+                    malformed_neg_adv
+                )
+            token_offset += msg_len
+
+
+def _apply_configured_message_level_advantage_penalties(
+    train_data: BatchedDataDict[ClippedPGLossDataDict],
+    message_logs: list[LLMMessageLogType | VLMMessageLogType],
+    master_config: MasterConfig,
+    log_config: bool = False,
+) -> None:
+    """Resolve config and apply message-level advantage penalties."""
+    (
+        invalid_tool_call_advantage,
+        malformed_thinking_advantage,
+    ) = _resolve_message_level_advantage_penalties(master_config)
+    _apply_message_level_advantage_penalties(
+        train_data=train_data,
+        message_logs=message_logs,
+        invalid_tool_call_advantage=invalid_tool_call_advantage,
+        malformed_thinking_advantage=malformed_thinking_advantage,
+        log_config=log_config,
+    )
+
+
 def _should_use_async_rollouts(master_config: MasterConfig) -> bool:
     """Determine if async rollouts should be used based on the configuration.
 
@@ -1997,6 +2119,10 @@ def grpo_train(
                         advantages=train_data["advantages"],
                     )
                     del baseline_for_log
+
+                    _apply_configured_message_level_advantage_penalties(
+                        train_data, repeated_batch["message_log"], master_config
+                    )
 
                     # Clip advantages to prevent extreme values from small std normalization
                     train_data["advantages"] = _clip_grpo_advantages(
@@ -3130,6 +3256,13 @@ def async_grpo_train(
                     advantages = train_data["advantages"]
                     print(
                         f"  📊 Advantages stats: min={advantages.min():.4f}, max={advantages.max():.4f}, mean={advantages.mean():.4f}, std={advantages.std():.4f}"
+                    )
+
+                    _apply_configured_message_level_advantage_penalties(
+                        train_data,
+                        repeated_batch["message_log"],
+                        master_config,
+                        log_config=True,
                     )
 
                     # Clip advantages to prevent extreme values from small std normalization

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -84,6 +84,36 @@ from nemo_rl.utils.nsys import maybe_gpu_profile_step
 from nemo_rl.utils.timer import TimeoutChecker, Timer
 from nemo_rl.utils.venvs import make_actor_runtime_env
 
+
+def _raise_if_message_level_advantage_penalties_enabled(
+    master_config: MasterConfig,
+) -> None:
+    """Raise if message-level advantage penalties are set in the sync trainer.
+
+    Message-level advantage penalties are not supported with
+    ``data_plane.enabled=true``. Raises NotImplementedError listing the
+    offending keys so the user can disable them or switch to the legacy GRPO
+    trainer.
+    """
+    unsupported_keys = [
+        key
+        for key in (
+            "invalid_tool_call_advantage",
+            "malformed_thinking_advantage",
+        )
+        if master_config.grpo.get(key) is not None
+    ]
+    if not unsupported_keys:
+        return
+
+    raise NotImplementedError(
+        "Message-level advantage penalties are not supported with "
+        "data_plane.enabled=true yet. Disable "
+        f"{', '.join(f'grpo.{key}' for key in unsupported_keys)} or use the "
+        "legacy GRPO trainer."
+    )
+
+
 # ── DAPO non-zero-std dynamic sampling, slice-only ─────────────────────
 # Slice-only formulation of nemo_rl.algorithms.grpo.dynamic_sampling: filter
 # on std != 0, accumulate survivors across iterations, slice on overflow.
@@ -402,8 +432,6 @@ def grpo_train_sync(
     val_period = master_config.grpo["val_period"]
     colocated_inference = master_config.policy["generation"]["colocated"]["enabled"]
 
-    adv_estimator = _create_advantage_estimator(master_config)
-
     # ── Data-plane setup (mandatory in the sync trainer) ───────────────
     # Sync trainer requires a TQ-mediated policy. The TQPolicy actor
     # bootstraps the controller and attaches workers; ``policy.dp_cfg``
@@ -417,6 +445,8 @@ def grpo_train_sync(
             "Use the legacy nemo_rl.algorithms.grpo.grpo_train trainer if you don't "
             "want TransferQueue."
         )
+    _raise_if_message_level_advantage_penalties_enabled(master_config)
+    adv_estimator = _create_advantage_estimator(master_config)
 
     # Driver-side pad-value dict for materialize() — the wire emits
     # jagged tensors for variable-length token fields (input_ids,

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -457,16 +457,19 @@ class ClippedPGLossFn(LossFunction):
         #                  IS ratio ∉ [min, max]; retained sequences keep
         #                  raw (non-truncated) token-level IS weights      (ref bounds: 0.999–1.002)
         #   Blog: https://yingru.notion.site/When-Speed-Kills-Stability-Demystifying-RL-Collapse-from-the-Training-Inference-Mismatch-271211a558b7808d8b12d403fd15edda
+        # is_oob_ratio: fraction of tokens (tis/icepop) or sequences (seq-mask-tis)
+        # whose importance weight falls outside the truncation bounds. Each microbatch
+        # contributes its out-of-bounds count divided by the *global* valid token/seq
+        # count, so the np.sum aggregation in grpo.py recovers the correct global fraction.
         if self.truncated_importance_sampling_ratio is not None:
             if self.truncated_importance_sampling_type == "tis":
-                token_in_bounds = (
+                token_oob_mask = (
                     actor_importance_weights_expanded
-                    <= self.truncated_importance_sampling_ratio
+                    > self.truncated_importance_sampling_ratio
                 )
                 _is_filter_metrics = {
-                    "is_oob_ratio": 1.0
-                    - masked_mean(
-                        token_in_bounds.float(),
+                    "is_oob_ratio": masked_mean(
+                        token_oob_mask.float(),
                         mask,
                         global_normalization_factor=global_valid_toks,
                     ).item(),
@@ -484,9 +487,8 @@ class ClippedPGLossFn(LossFunction):
                     <= self.truncated_importance_sampling_ratio
                 )
                 _is_filter_metrics = {
-                    "is_oob_ratio": 1.0
-                    - masked_mean(
-                        token_kept_mask.float(),
+                    "is_oob_ratio": masked_mean(
+                        (~token_kept_mask).float(),
                         mask,
                         global_normalization_factor=global_valid_toks,
                     ).item(),
@@ -516,9 +518,8 @@ class ClippedPGLossFn(LossFunction):
                     & (seq_geomean_is_ratio <= self.truncated_importance_sampling_ratio)
                 ).float()  # [B]
                 _is_filter_metrics = {
-                    "is_oob_ratio": 1.0
-                    - masked_mean(
-                        seq_kept_mask,
+                    "is_oob_ratio": masked_mean(
+                        1.0 - seq_kept_mask,
                         sample_mask,
                         global_normalization_factor=global_valid_seqs,
                     ).item(),

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -27,6 +27,14 @@ from nemo_rl.distributed.virtual_cluster import (
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.utils.timer import Timer
 
+DEFAULT_INVALID_TOOL_CALL_PATTERNS = [
+    "<tool_call>",
+    "</tool_call>",
+    "<function_call>",
+    "</function_call>",
+]
+DEFAULT_THINKING_TAGS = ["<think>", "</think>"]
+
 
 class NemoGymConfig(TypedDict):
     model_name: str
@@ -37,6 +45,72 @@ class NemoGymConfig(TypedDict):
     # nemo_rl.distributed.virtual_cluster.  See the port layout there.
     port_range_low: NotRequired[int]
     port_range_high: NotRequired[int]
+    invalid_tool_call_patterns: NotRequired[
+        List[str] | None
+    ]  # Substrings in assistant text content that indicate an invalid tool call
+    thinking_tags: NotRequired[
+        List[str] | None
+    ]  # Thinking tags to check for malformed usage
+
+
+def _detect_invalid_tool_call_and_malformed_thinking(
+    output_item_dict: dict[str, Any],
+    invalid_tool_call_patterns: list[str] | None = None,
+    thinking_tags: list[str] | None = None,
+) -> tuple[bool, bool]:
+    """Flag a NeMo-Gym output item as an invalid tool call / malformed thinking.
+
+    Inspects the final output item of a model turn. For a final *content*
+    message, any thinking tag is malformed (thinking should never leak into the
+    answer); for a *reasoning* summary, only a repeated tag (count > 1) is
+    malformed (a single pair is expected). A textual tool-call pattern in either
+    indicates an invalid (unexecuted) tool call.
+
+    Returns:
+        (is_invalid_tool_call, has_malformed_thinking).
+    """
+    invalid_tool_call_patterns = (
+        invalid_tool_call_patterns or DEFAULT_INVALID_TOOL_CALL_PATTERNS
+    )
+    thinking_tags = thinking_tags or DEFAULT_THINKING_TAGS
+
+    is_output_message = (
+        "content" in output_item_dict
+        and len(output_item_dict["content"]) > 0
+        and "text" in output_item_dict["content"][0]
+    )
+    # NeMo-Gym only attaches generation_token_ids to the last output item of a
+    # model call (see vllm_model/app.py postprocess_chat_response). So this item
+    # is guaranteed to be the final thing the model produced for this turn.
+    # If it's a reasoning item, the model output only reasoning (no content/tool calls).
+    is_reasoning_message = (
+        output_item_dict.get("type") == "reasoning"
+        and len(output_item_dict.get("summary", [])) > 0
+        and "text" in output_item_dict["summary"][0]
+    )
+
+    is_invalid_tool_call = False
+    has_malformed_thinking = False
+    if is_output_message:
+        assistant_message_content = output_item_dict["content"][0]["text"]
+        if any(
+            pattern in assistant_message_content
+            for pattern in invalid_tool_call_patterns
+        ):
+            is_invalid_tool_call = True
+        if any(tag in assistant_message_content for tag in thinking_tags):
+            has_malformed_thinking = True
+    elif is_reasoning_message:
+        assistant_message_content = output_item_dict["summary"][0]["text"]
+        if any(
+            pattern in assistant_message_content
+            for pattern in invalid_tool_call_patterns
+        ):
+            is_invalid_tool_call = True
+        if any(assistant_message_content.count(tag) > 1 for tag in thinking_tags):
+            has_malformed_thinking = True
+
+    return is_invalid_tool_call, has_malformed_thinking
 
 
 @ray.remote(max_restarts=-1, max_task_retries=-1)  # pragma: no cover
@@ -243,12 +317,27 @@ Output prompt token IDs: {output_item_dict["prompt_token_ids"]}
                     "token_ids": torch.tensor(new_prompt_token_ids),
                 }
             )
+            # Valid tool calls go through the structured API (tool_calls field) and get
+            # executed by NeMo-Gym. If tool call patterns appear in the text content instead,
+            # the call was invalid and never executed — flag it so training can penalize it.
+            is_invalid_tool_call, has_malformed_thinking = (
+                _detect_invalid_tool_call_and_malformed_thinking(
+                    output_item_dict,
+                    invalid_tool_call_patterns=self.cfg.get(
+                        "invalid_tool_call_patterns"
+                    ),
+                    thinking_tags=self.cfg.get("thinking_tags"),
+                )
+            )
+
             nemo_rl_message_log.append(
                 {
                     "role": "assistant",
                     "content": "",
                     "token_ids": torch.tensor(generation_token_ids),
                     "generation_logprobs": torch.tensor(generation_log_probs),
+                    "is_invalid_tool_call": is_invalid_tool_call,
+                    "has_malformed_thinking": has_malformed_thinking,
                 }
             )
 

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -27,7 +27,10 @@ from nemo_rl.algorithms.advantage_estimator import (
 )
 from nemo_rl.algorithms.grpo import (
     MasterConfig,
+    _apply_configured_message_level_advantage_penalties,
+    _apply_message_level_advantage_penalties,
     _default_grpo_save_state,
+    _resolve_message_level_advantage_penalties,
     aggregate_rollout_metrics,
     async_grpo_train,
     compute_and_apply_seq_logprob_error_masking,
@@ -73,6 +76,173 @@ def _logged_train_metrics_with_key(logger, key: str):
         if call.kwargs.get("prefix") == "train" and key in metrics:
             return metrics
     raise AssertionError(f"No train metrics payload contained {key}")
+
+
+def test_apply_message_level_advantage_penalties_targets_flagged_message_spans():
+    train_data = BatchedDataDict(
+        {
+            "advantages": torch.tensor(
+                [
+                    [0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+                    [10.0, 11.0, 12.0, 13.0, 14.0, 15.0],
+                ]
+            )
+        }
+    )
+    repeated_batch = BatchedDataDict(
+        {
+            "message_log": [
+                [
+                    {
+                        "role": "user",
+                        "token_ids": torch.tensor([1, 2]),
+                        "is_invalid_tool_call": True,
+                    },
+                    {
+                        "role": "assistant",
+                        "token_ids": torch.tensor([3, 4]),
+                        "generation_logprobs": torch.tensor([0.1, 0.2]),
+                        "is_invalid_tool_call": True,
+                    },
+                    {
+                        "role": "assistant",
+                        "token_ids": torch.tensor([5, 6]),
+                        "generation_logprobs": torch.tensor([0.3, 0.4]),
+                    },
+                ],
+                [
+                    {
+                        "role": "user",
+                        "token_ids": torch.tensor([7]),
+                    },
+                    {
+                        "role": "assistant",
+                        "token_ids": torch.tensor([8, 9, 10]),
+                        "generation_logprobs": torch.tensor([0.5, 0.6, 0.7]),
+                        "has_malformed_thinking": True,
+                    },
+                    {
+                        "role": "assistant",
+                        "token_ids": torch.tensor([11, 12]),
+                        "generation_logprobs": torch.tensor([0.8, 0.9]),
+                    },
+                ],
+            ]
+        }
+    )
+    _apply_message_level_advantage_penalties(
+        train_data=train_data,
+        message_logs=repeated_batch["message_log"],
+        invalid_tool_call_advantage=-5.0,
+        malformed_thinking_advantage=-7.0,
+    )
+
+    expected = torch.tensor(
+        [
+            [0.0, 1.0, -5.0, -5.0, 4.0, 5.0],
+            [10.0, -7.0, -7.0, -7.0, 14.0, 15.0],
+        ]
+    )
+    torch.testing.assert_close(train_data["advantages"], expected)
+
+
+def test_apply_configured_message_level_advantage_penalties_noops_when_disabled():
+    train_data = BatchedDataDict(
+        {"advantages": torch.tensor([[1.0, 2.0]], dtype=torch.float32)}
+    )
+    message_logs = [
+        [
+            {
+                "role": "assistant",
+                "token_ids": torch.tensor([1, 2]),
+                "generation_logprobs": torch.tensor([0.1, 0.2]),
+                "is_invalid_tool_call": True,
+            }
+        ]
+    ]
+    master_config = MasterConfig.model_construct(grpo={})
+
+    with patch("nemo_rl.algorithms.grpo._should_use_nemo_gym") as should_use_nemo_gym:
+        _apply_configured_message_level_advantage_penalties(
+            train_data, message_logs, master_config
+        )
+
+    should_use_nemo_gym.assert_not_called()
+    torch.testing.assert_close(
+        train_data["advantages"], torch.tensor([[1.0, 2.0]], dtype=torch.float32)
+    )
+
+
+def test_apply_configured_message_level_advantage_penalties_uses_config(capsys):
+    train_data = BatchedDataDict(
+        {"advantages": torch.tensor([[0.0, 1.0, 2.0]], dtype=torch.float32)}
+    )
+    message_logs = [
+        [
+            {
+                "role": "user",
+                "token_ids": torch.tensor([1]),
+            },
+            {
+                "role": "assistant",
+                "token_ids": torch.tensor([2, 3]),
+                "generation_logprobs": torch.tensor([0.1, 0.2]),
+                "is_invalid_tool_call": True,
+            },
+        ]
+    ]
+    master_config = MasterConfig.model_construct(
+        grpo={
+            "invalid_tool_call_advantage": -4.0,
+            "malformed_thinking_advantage": -6.0,
+        }
+    )
+
+    with patch(
+        "nemo_rl.algorithms.grpo._should_use_nemo_gym", return_value=True
+    ) as should_use_nemo_gym:
+        _apply_configured_message_level_advantage_penalties(
+            train_data, message_logs, master_config, log_config=True
+        )
+
+    should_use_nemo_gym.assert_called_once_with(master_config)
+    torch.testing.assert_close(
+        train_data["advantages"], torch.tensor([[0.0, -4.0, -4.0]])
+    )
+    captured = capsys.readouterr()
+    assert "Invalid tool call advantage: -4.0" in captured.out
+    assert "Malformed thinking advantage: -6.0" in captured.out
+
+
+def test_resolve_message_level_advantage_penalties_requires_nemo_gym():
+    master_config = MasterConfig.model_construct(
+        grpo={"invalid_tool_call_advantage": -5.0}
+    )
+
+    with patch("nemo_rl.algorithms.grpo._should_use_nemo_gym", return_value=False):
+        with pytest.raises(AssertionError, match="NeMo-Gym path"):
+            _resolve_message_level_advantage_penalties(master_config)
+
+
+def test_raise_if_message_level_advantage_penalties_enabled_noops_when_unset():
+    from nemo_rl.algorithms.grpo_sync import (
+        _raise_if_message_level_advantage_penalties_enabled,
+    )
+
+    master_config = MasterConfig.model_construct(grpo={})
+    _raise_if_message_level_advantage_penalties_enabled(master_config)
+
+
+def test_raise_if_message_level_advantage_penalties_enabled_raises_when_set():
+    from nemo_rl.algorithms.grpo_sync import (
+        _raise_if_message_level_advantage_penalties_enabled,
+    )
+
+    master_config = MasterConfig.model_construct(
+        grpo={"invalid_tool_call_advantage": -5.0}
+    )
+    with pytest.raises(NotImplementedError, match="data_plane.enabled=true"):
+        _raise_if_message_level_advantage_penalties_enabled(master_config)
 
 
 def test_grpo_sync_seq_logprob_error_helper_accepts_dict_result(monkeypatch):

--- a/tests/unit/algorithms/test_loss_functions.py
+++ b/tests/unit/algorithms/test_loss_functions.py
@@ -1239,6 +1239,33 @@ def test_clipped_pg_loss_icepop_importance_sampling():
     torch.testing.assert_close(actual_loss, expected_loss, atol=1e-4, rtol=1e-3)
 
 
+def test_clipped_pg_loss_reports_is_oob_ratio_tis():
+    device = "cpu"
+    data, _, seq_len, _ = _setup_clipped_pg_test_data(device=device)
+
+    cfg = ClippedPGLossConfig(
+        reference_policy_kl_penalty=0.0,
+        use_importance_sampling_correction=True,
+        truncated_importance_sampling_type="tis",
+        truncated_importance_sampling_ratio=2.0,
+    )
+    loss_fn = ClippedPGLossFn(cfg)
+
+    data["advantages"][0, 1:] = torch.tensor([1.0, 1.0, 1.0])
+    data["prev_logprobs"][0, 1:] = torch.log(torch.tensor([1.0, 3.0, 0.5]))
+    data["generation_logprobs"][0, 1:] = torch.zeros(3)
+    next_token_logprobs = torch.zeros((1, seq_len - 1))
+
+    _, metrics = loss_fn(
+        next_token_logprobs=next_token_logprobs,
+        data=data,
+        global_valid_seqs=torch.sum(data["sample_mask"]),
+        global_valid_toks=torch.sum(data["sample_mask"] * data["token_mask"]),
+    )
+
+    assert metrics["is_oob_ratio"] == pytest.approx(1.0 / 3.0)
+
+
 def test_clipped_pg_loss_seq_mask_tis():
     """Tests ClippedPGLossFn with seq-mask-tis, including nan_to_num on -inf.
 

--- a/tests/unit/data_plane/test_architecture_invariants.py
+++ b/tests/unit/data_plane/test_architecture_invariants.py
@@ -48,6 +48,28 @@ def test_run_grpo_dispatches_both_trainers():
     assert _select_trainer(cfg_sync) is grpo_train_sync
 
 
+def test_sync_trainer_rejects_message_level_advantage_penalties():
+    from nemo_rl.algorithms.grpo import MasterConfig
+    from nemo_rl.algorithms.grpo_sync import (
+        _raise_if_message_level_advantage_penalties_enabled,
+    )
+
+    cfg_disabled = MasterConfig.model_construct(grpo={})
+    _raise_if_message_level_advantage_penalties_enabled(cfg_disabled)
+
+    cfg_enabled = MasterConfig.model_construct(
+        grpo={
+            "invalid_tool_call_advantage": -5.0,
+            "malformed_thinking_advantage": None,
+        }
+    )
+    with pytest.raises(
+        NotImplementedError,
+        match="grpo.invalid_tool_call_advantage",
+    ):
+        _raise_if_message_level_advantage_penalties_enabled(cfg_enabled)
+
+
 @pytest.mark.parametrize(
     "method",
     [

--- a/tests/unit/environments/test_nemo_gym.py
+++ b/tests/unit/environments/test_nemo_gym.py
@@ -25,7 +25,11 @@ from nemo_rl.algorithms.grpo import MasterConfig
 from nemo_rl.distributed.ray_actor_environment_registry import (
     get_actor_python_env,
 )
-from nemo_rl.environments.nemo_gym import NemoGym, NemoGymConfig, setup_nemo_gym_config
+from nemo_rl.environments.nemo_gym import (
+    NemoGym,
+    NemoGymConfig,
+    setup_nemo_gym_config,
+)
 from nemo_rl.models.generation.vllm import VllmGeneration
 
 # cluster and tokenizer are fixture imports
@@ -196,9 +200,12 @@ def test_nemo_gym_postprocess_uses_batch_decode():
         "responses_create_params": {"input": []},
     }
 
+    class _MockSelf:
+        cfg = {}
+
     result = (
         NemoGym.__ray_metadata__.modified_class._postprocess_nemo_gym_to_nemo_rl_result(
-            None, nemo_gym_result, tokenizer
+            _MockSelf(), nemo_gym_result, tokenizer
         )
     )
 
@@ -272,6 +279,8 @@ def test_nemo_gym_sanity(
                 message["prompt_str"] = "dummy prompt_str"
             if "generation_str" in message:
                 message["generation_str"] = "dummy generation_str"
+            message.setdefault("is_invalid_tool_call", False)
+            message.setdefault("has_malformed_thinking", False)
 
         return d
 

--- a/tests/unit/environments/test_nemo_gym_utils.py
+++ b/tests/unit/environments/test_nemo_gym_utils.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pure-Python (vllm-free) unit tests for NeMo-Gym helpers.
+
+These run in the default L0 suite. Keep this module free of heavy imports
+(e.g. vllm) so the fast detector tests are not gated behind the nemo_gym extra.
+"""
+
+import pytest
+
+from nemo_rl.environments.nemo_gym import (
+    _detect_invalid_tool_call_and_malformed_thinking,
+)
+
+
+@pytest.mark.parametrize(
+    ("output_item_dict", "expected_invalid_tool_call", "expected_malformed_thinking"),
+    [
+        (
+            {"content": [{"text": "use <tool_call>{}</tool_call>"}]},
+            True,
+            False,
+        ),
+        (
+            {"content": [{"text": "final answer leaked <think>reasoning</think>"}]},
+            False,
+            True,
+        ),
+        (
+            {"type": "reasoning", "summary": [{"text": "<think>a</think>"}]},
+            False,
+            False,
+        ),
+        (
+            {"type": "reasoning", "summary": [{"text": "<think>a</think><think>b"}]},
+            False,
+            True,
+        ),
+        (
+            {"type": "reasoning", "summary": [{"text": "bad <function_call>{}"}]},
+            True,
+            False,
+        ),
+    ],
+)
+def test_detect_invalid_tool_call_and_malformed_thinking(
+    output_item_dict,
+    expected_invalid_tool_call,
+    expected_malformed_thinking,
+):
+    assert _detect_invalid_tool_call_and_malformed_thinking(output_item_dict) == (
+        expected_invalid_tool_call,
+        expected_malformed_thinking,
+    )

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -40,6 +40,10 @@ grpo:
     target_min: 0.0
     target_max: 1.0
   seq_logprob_error_threshold: null
+  # Advantage value assigned to invalid tool call tokens (e.g. -5.0 to penalize). null disables.
+  invalid_tool_call_advantage: null
+  # Advantage value assigned to tokens with malformed <think>/</think> tags (e.g. -5.0). null disables.
+  malformed_thinking_advantage: null
 
   async_grpo:
     enabled: false # Set to true to enable async training mode


### PR DESCRIPTION
# What does this PR do ?

Support to penalize textual tool calls and malformed thinking output. Currently, applicable only in legacy grpo and nemo-gym pathways.

Look at `Additional Information` below

# Issues
Closes https://github.com/NVIDIA-NeMo/RL/issues/2012


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

Adds GRPO support for penalizing malformed NeMo-Gym assistant outputs:

- flags invalid textual tool calls in NeMo-Gym rollouts, e.g. leaked `<tool_call>` / `<function_call>` tags
- flags malformed thinking output, e.g. `<think>` tags in final content or repeated thinking tags in reasoning summaries
- applies configured negative advantages to the flagged assistant-message token span
- adds `tis_clipped_fraction` to clipped PG loss metrics
- documents the new GRPO penalty knobs in the exemplar config
- wires optional NeMo-Gym detector pattern overrides through `run_grpo_nemo_gym.py`
- fails loudly for `data_plane.enabled=true`, where message-level advantage penalties are not supported yet

This combines behavior from:
- `2da2585984634b4f17a932a70c2b5d2854e217ff`
- `d6b27b5446818a2512785ea64397efd8a16fc10e`
- `b941004d2e0be87d67309763521c6b9e8d292ecd`
- `c21c87e640448734e2df4b3d3416abb4cd4080db`
