### PR TITLE
revert: Discard weight when finish generation in the main loop (#2495)

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1680,11 +1680,7 @@ def grpo_train(
                             max_rollout_turns=master_config.grpo["max_rollout_turns"],
                             greedy=False,
                         )
-                    policy_generation.finish_generation(
-                        discard_weights=colocated_inference
-                    )
-                    if colocated_inference:
-                        POLICY_GENERATION_STALE = True
+                    policy_generation.finish_generation()
                     # Collect generation logger metrics for performance reporting after each generation step
                     # inflight batch sizes and num pending samples are collected from each worker
                     if policy_generation is not None:

--- a/nemo_rl/models/generation/vllm/vllm_generation.py
+++ b/nemo_rl/models/generation/vllm/vllm_generation.py
@@ -732,12 +732,10 @@ class VllmGeneration(GenerationInterface):
                     if self.cfg["vllm_cfg"]["async_engine"]
                     else "reset_prefix_cache"
                 )
-                kwargs = {}
             # Use run_all_workers_single_data for methods that don't need data
             futures = self.worker_group.run_all_workers_single_data(
                 method_name,
                 run_rank_0_only_axes=["tensor_parallel", "pipeline_parallel"],
-                **kwargs,
             )
             # Wait for all futures to complete
             results = ray.get(futures)

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -988,7 +988,7 @@ class VllmGenerationWorkerImpl(BaseVllmGenerationWorker):
         gc.collect()
         torch.cuda.empty_cache()
 
-    def sleep(self, discard_weights: bool = False):
+    def sleep(self):
         """Put the vLLM engine to sleep."""
         assert self.llm is not None, (
             "Attempting to sleep with either an uninitialized vLLM or non-model-owner"
@@ -1011,7 +1011,7 @@ class VllmGenerationWorkerImpl(BaseVllmGenerationWorker):
             self.llm.renderer, "clear_mm_cache"
         ):
             self.llm.renderer.clear_mm_cache()
-        self.llm.sleep(level=2 if discard_weights else 1)
+        self.llm.sleep(level=1)
 
         gc.collect()
         torch.cuda.empty_cache()

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -1241,7 +1241,7 @@ class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
         gc.collect()
         torch.cuda.empty_cache()
 
-    async def sleep_async(self, discard_weights: bool = False):
+    async def sleep_async(self):
         """Async version of sleep."""
         assert self.llm is not None, (
             "Attempting to sleep with either an uninitialized vLLM or non-model-owner"
@@ -1260,7 +1260,7 @@ class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
         # the receiver and sends data=None, causing an assertion error.
         if hasattr(self.llm, "reset_mm_cache"):
             await self.llm.reset_mm_cache()
-        await self.llm.sleep(level=2 if discard_weights else 1)
+        await self.llm.sleep(level=1)
 
         gc.collect()
         torch.cuda.empty_cache()

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -1584,7 +1584,6 @@ def test_grpo_train_collects_generation_logger_and_seq_metrics(
     )
 
     assert policy_generation.clear_logger_metrics.called
-    policy_generation.finish_generation.assert_called_once_with(discard_weights=True)
     assert policy_generation.get_logger_metrics.called
     train_metrics = _logged_train_metrics_with_key(
         mock_grpo_components["logger"], "generation_logger_metrics"

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -16,7 +16,7 @@ import json
 import os
 from copy import deepcopy
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 import ray
@@ -33,9 +33,7 @@ from nemo_rl.models.generation.interfaces import (
     GenerationDatumSpec,
 )
 from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration
-from nemo_rl.models.generation.vllm.vllm_worker import VllmGenerationWorkerImpl
 from nemo_rl.models.generation.vllm.vllm_worker_async import (
-    VllmAsyncGenerationWorkerImpl,
     _replace_prefix_tokens,
 )
 from nemo_rl.models.policy import LoRAConfig, PolicyConfig
@@ -155,85 +153,6 @@ def skip_fp8_known_failures() -> None:
             f"Skipping FP8 vLLM test on {device_name} due to a known failure. "
             "See https://github.com/NVIDIA-NeMo/RL/issues/2081"
         )
-
-
-@pytest.mark.parametrize(
-    "colocated,async_engine,expected_method,expected_kwargs",
-    [
-        (True, False, "sleep", {"discard_weights": True}),
-        (True, True, "sleep_async", {"discard_weights": True}),
-        (False, False, "reset_prefix_cache", {}),
-        (False, True, "reset_prefix_cache_async", {}),
-    ],
-)
-def test_vllm_finish_generation_routes_discard_weights(
-    monkeypatch, colocated, async_engine, expected_method, expected_kwargs
-):
-    vllm_generation = VllmGeneration.__new__(VllmGeneration)
-    vllm_generation.cfg = {
-        "colocated": {"enabled": colocated},
-        "vllm_cfg": {"async_engine": async_engine},
-    }
-    vllm_generation.worker_group = MagicMock()
-    vllm_generation.worker_group.run_all_workers_single_data.return_value = [
-        "worker_future"
-    ]
-    monkeypatch.setattr(
-        "nemo_rl.models.generation.vllm.vllm_generation.ray.get",
-        lambda futures: [True],
-    )
-
-    assert vllm_generation.finish_generation(discard_weights=True)
-
-    vllm_generation.worker_group.run_all_workers_single_data.assert_called_once_with(
-        expected_method,
-        run_rank_0_only_axes=["tensor_parallel", "pipeline_parallel"],
-        **expected_kwargs,
-    )
-
-
-def test_vllm_worker_sleep_uses_discard_weight_level(monkeypatch):
-    worker = VllmGenerationWorkerImpl.__new__(VllmGenerationWorkerImpl)
-    worker.cfg = {"vllm_cfg": {"async_engine": False}}
-    worker.llm = MagicMock()
-    monkeypatch.setattr(
-        "nemo_rl.models.generation.vllm.vllm_worker.gc.collect", lambda: None
-    )
-    monkeypatch.setattr(
-        "nemo_rl.models.generation.vllm.vllm_worker.torch.cuda.empty_cache",
-        lambda: None,
-    )
-
-    worker.sleep(discard_weights=False)
-    worker.llm.sleep.assert_called_once_with(level=1)
-
-    worker.llm.sleep.reset_mock()
-    worker.sleep(discard_weights=True)
-    worker.llm.sleep.assert_called_once_with(level=2)
-
-
-@pytest.mark.asyncio
-async def test_vllm_async_worker_sleep_uses_discard_weight_level(monkeypatch):
-    worker = VllmAsyncGenerationWorkerImpl.__new__(VllmAsyncGenerationWorkerImpl)
-    worker.cfg = {"vllm_cfg": {"async_engine": True}}
-    worker.llm = MagicMock()
-    worker.llm.reset_prefix_cache = AsyncMock()
-    worker.llm.reset_mm_cache = AsyncMock()
-    worker.llm.sleep = AsyncMock()
-    monkeypatch.setattr(
-        "nemo_rl.models.generation.vllm.vllm_worker_async.gc.collect", lambda: None
-    )
-    monkeypatch.setattr(
-        "nemo_rl.models.generation.vllm.vllm_worker_async.torch.cuda.empty_cache",
-        lambda: None,
-    )
-
-    await worker.sleep_async(discard_weights=False)
-    worker.llm.sleep.assert_awaited_once_with(level=1)
-
-    worker.llm.sleep.reset_mock()
-    await worker.sleep_async(discard_weights=True)
-    worker.llm.sleep.assert_awaited_once_with(level=2)
 
 
 def test_configure_generation_config_uses_real_startup_weights_without_draft_refit():


### PR DESCRIPTION
# What does this PR do?

Reverts #2495 which introduced vLLM sleep level 2 (weight discarding) for colocated inference. The optimization caused silent failures with DAPO and speculative decoding (#2646). Reverting until the feature is fully tested against these cases.

## Changes

- **grpo.py**: Remove `discard_weights=colocated_inference` from `finish_generation()` call and remove `POLICY_GENERATION_STALE = True` flag
- **vllm_generation.py**: Remove `kwargs = {}` and `**kwargs` passthrough in `finish_generation`
- **vllm_worker.py**: Remove `discard_weights` param from `sleep()`, revert to `level=1`
- **vllm_worker_async.py**: Remove `discard_weights` param from `sleep_async()`, revert to `level=1`
- **test_grpo.py**: Remove `discard_weights=True` assertion
- **test_vllm_generation.py**: Remove three test functions for discard weight routing/levels

## Issues

Related to https://github.com/NVIDIA-NeMo/RL/issues/2646

## Before your PR is \"Ready for review\"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally?
- [x] Did you add or update any necessary documentation?