### PR TITLE
fix(test): increase timeout for grpo-llama3.2-1b-1n4g nightly test

### DIFF
--- a/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n4g-fsdp2tp1.v3.sh
+++ b/tests/test_suites/llm/grpo-llama3.2-1b-instruct-1n4g-fsdp2tp1.v3.sh
@@ -8,7 +8,7 @@ GPUS_PER_NODE=4
 STEPS_PER_RUN=500
 MAX_STEPS=500
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
-NUM_MINUTES=150
+NUM_MINUTES=160
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached


### PR DESCRIPTION
## Summary
- Bump `NUM_MINUTES` from 150 to 160 for `grpo-llama3.2-1b-instruct-1n4g-fsdp2tp1.v3` nightly test
- The test consistently times out around step 495/500, so 10 extra minutes provides sufficient headroom


🤖 Generated with [Claude Code](https://claude.com/claude-code)