### PR TITLE
Add nano_v3 vLLM reasoning parser plugin

### DIFF
--- a/nemo_rl/utils/nano_v3_reasoning_parser.py
+++ b/nemo_rl/utils/nano_v3_reasoning_parser.py
@@ -1,0 +1,33 @@
+import logging
+
+from vllm.reasoning.abs_reasoning_parsers import ReasoningParserManager
+from vllm.reasoning.deepseek_r1_reasoning_parser import DeepSeekR1ReasoningParser
+
+logger = logging.getLogger(__name__)
+
+# This will print when the module is imported/loaded
+print("=" * 60)
+print("NanoV3ReasoningParser plugin loaded and registered!")
+print("=" * 60)
+
+
+@ReasoningParserManager.register_module("nano_v3")
+class NanoV3ReasoningParser(DeepSeekR1ReasoningParser):
+    def __init__(self, tokenizer, *args, **kwargs):
+        super().__init__(tokenizer, *args, **kwargs)
+        print(f"NanoV3ReasoningParser initialized with tokenizer: {type(tokenizer)}")
+
+    def extract_reasoning(self, model_output, request):
+        reasoning_content, final_content = super().extract_reasoning(
+            model_output, request
+        )
+        if (
+            hasattr(request, "chat_template_kwargs")
+            and request.chat_template_kwargs
+            and request.chat_template_kwargs.get("enable_thinking") is False
+            and final_content is None
+        ):
+            print("NanoV3ReasoningParser: Swapping reasoning and final content (enable_thinking=False)")
+            reasoning_content, final_content = final_content, reasoning_content
+
+        return reasoning_content, final_content


### PR DESCRIPTION
vLLM reasoning-parser plugin for the Nemotron Nano v3 reasoning format, needed when serving Nano v3.5 with --reasoning-parser nano_v3 for reward profiling.

# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
