### PR TITLE
feat(megatron): split-API train-step state machine on MegatronPolicyWorker

### DIFF
--- a/nemo_rl/algorithms/loss/interfaces.py
+++ b/nemo_rl/algorithms/loss/interfaces.py
@@ -25,6 +25,30 @@ class LossType(enum.Enum):
     SEQUENCE_LEVEL = "sequence_level"
 
 
+class MetricNormalizer(enum.Enum):
+    """Global denominator a loss-returned metric was normalized by.
+
+    Losses reduce most metrics with ``masked_mean(...,
+    global_normalization_factor=...)`` where the factor is the global valid
+    *token* count, the global valid *sequence* count, or absent entirely (raw
+    counts, per-microbatch means, extrema). Split-API trainers run each
+    microbatch with placeholder ``global_valid_*=1`` (collecting raw sums) and
+    rescale once per optimizer step — to do that they must know, per metric,
+    which denominator applies.
+
+    Losses advertise the mapping via a ``metric_normalizations:
+    dict[str, MetricNormalizer]`` instance attribute, built in ``__init__``
+    from the same flags that pick the denominators, so it lives next to the
+    metric definitions instead of in a consumer-side table. Metrics absent
+    from the mapping fall back to the gradient normalization (the
+    ``loss_type`` denominator) on the consumer side.
+    """
+
+    TOKENS = "tokens"  # divided by global_valid_toks
+    SEQUENCES = "sequences"  # divided by global_valid_seqs
+    NONE = "none"  # not normalized: raw counts, local means, min/max
+
+
 class LossInputType(enum.Enum):
     LOGIT = "logit"
     LOGPROB = "logprob"
@@ -38,6 +62,12 @@ class LossFunction(Protocol):
 
     Loss functions compute a scalar loss value and associated metrics from
     model logprobs and other data contained in a BatchedDataDict.
+
+    Losses may additionally expose a ``metric_normalizations:
+    dict[str, MetricNormalizer]`` attribute advertising the global denominator
+    each returned metric was normalized by (see ``MetricNormalizer``). It is
+    optional: consumers fall back to the ``loss_type`` denominator for
+    metrics (or losses) that do not advertise.
     """
 
     loss_type: LossType

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -17,7 +17,12 @@ from typing import Any, NotRequired, Optional, TypedDict, TypeVar
 import torch
 from pydantic import BaseModel
 
-from nemo_rl.algorithms.loss.interfaces import LossFunction, LossInputType, LossType
+from nemo_rl.algorithms.loss.interfaces import (
+    LossFunction,
+    LossInputType,
+    LossType,
+    MetricNormalizer,
+)
 from nemo_rl.algorithms.utils import calculate_kl, masked_mean
 from nemo_rl.algorithms.x_token.loss_utils import (
     LocalizedAlignment,
@@ -313,6 +318,54 @@ class ClippedPGLossFn(LossFunction):
                     "seq-mask-tis uses token-level IS correction with sequence-level masking, "
                     "and is incompatible with sequence_level_importance_ratios=True"
                 )
+
+        # Advertise, per returned metric, the global denominator it was
+        # normalized by (see MetricNormalizer). Built here — next to the flags
+        # that pick the denominators — so split-API trainers can undo the
+        # placeholder global_valid_*=1 normalization without maintaining a
+        # consumer-side table. Keep in sync with __call__'s return dict.
+        grad_normalizer = (
+            MetricNormalizer.TOKENS
+            if self.loss_type == LossType.TOKEN_LEVEL
+            else MetricNormalizer.SEQUENCES
+        )
+        self.metric_normalizations: dict[str, MetricNormalizer] = {
+            # Normalized like the gradient (loss_type-dependent).
+            "loss": grad_normalizer,
+            "kl_penalty": grad_normalizer,
+            # Token-normalized diagnostics, independent of loss_type.
+            "probs_ratio": MetricNormalizer.TOKENS,
+            "probs_ratio_clamped": MetricNormalizer.TOKENS,
+            "token_mult_prob_error": MetricNormalizer.TOKENS,
+            "gen_kl_error": MetricNormalizer.TOKENS,
+            "policy_kl_error": MetricNormalizer.TOKENS,
+            "js_divergence_error": MetricNormalizer.TOKENS,
+            "approx_entropy": MetricNormalizer.TOKENS,
+            # Keyed on sequence_level_importance_ratios, NOT loss_type.
+            "sampling_importance_ratio": (
+                MetricNormalizer.SEQUENCES
+                if self.sequence_level_importance_ratios
+                else MetricNormalizer.TOKENS
+            ),
+            # Raw count — the downstream per-microbatch sum IS the value.
+            "num_valid_samples": MetricNormalizer.NONE,
+            # Normalized by the microbatch's own correct-token count, not a
+            # global factor — already a per-microbatch mean.
+            "positive_nll_loss": MetricNormalizer.NONE,
+            # Extrema — combined downstream with min/max, never scaled.
+            "probs_ratio_min": MetricNormalizer.NONE,
+            "probs_ratio_max": MetricNormalizer.NONE,
+            "probs_ratio_clamped_min": MetricNormalizer.NONE,
+            "probs_ratio_clamped_max": MetricNormalizer.NONE,
+        }
+        if self.truncated_importance_sampling_type is not None:
+            # Keyed on the TIS type, NOT loss_type: seq-mask-tis masks whole
+            # sequences (÷ global_valid_seqs); tis/icepop are token-level.
+            self.metric_normalizations["is_oob_ratio"] = (
+                MetricNormalizer.SEQUENCES
+                if self.truncated_importance_sampling_type == "seq-mask-tis"
+                else MetricNormalizer.TOKENS
+            )
 
     def __call__(
         self,
@@ -739,6 +792,13 @@ class NLLLossFn(LossFunction):
 
     def __init__(self, use_fused_linear_logprobs: bool = False):
         self.use_fused_linear_logprobs = use_fused_linear_logprobs
+        # See MetricNormalizer — split-API trainers use this to undo the
+        # placeholder global_valid_*=1 normalization per metric.
+        self.metric_normalizations: dict[str, MetricNormalizer] = {
+            "loss": MetricNormalizer.TOKENS,
+            "num_unmasked_tokens": MetricNormalizer.NONE,
+            "num_valid_samples": MetricNormalizer.NONE,
+        }
 
     def __call__(
         self,

--- a/nemo_rl/data_plane/worker_mixin.py
+++ b/nemo_rl/data_plane/worker_mixin.py
@@ -516,3 +516,82 @@ class TQWorkerMixin:
             tq_field="reference_policy_logprobs",
         )
         del result
+
+    # ── split-API entrypoints (SC async path) ──────────────────────────────
+    #
+    # The split path lets SingleController drive forward/backward per
+    # microbatch (or per pipeline-batch on Megatron) without stepping the
+    # optimizer until a full logical batch has accumulated. Backend
+    # methods (``begin_train_step``, ``train_microbatch``,
+    # ``finish_train_step``, ``abort_train_step``) own the train-step
+    # state machine; this mixin just gates them on TQ-presharded data.
+
+    @wrap_with_nvtx_name("policy_worker/begin_train_step_presharded")
+    def begin_train_step_presharded(
+        self,
+        step_id: str,
+        loss_fn: Any,
+        gbs: Optional[int] = None,
+        mbs: Optional[int] = None,
+    ) -> None:
+        """Open a logical train step. No fetch — pure lifecycle.
+
+        The backend stores ``step_id`` / ``loss_fn`` / ``gbs`` / ``mbs``,
+        clears gradients, and initialises accumulators for
+        ``local_valid_seqs`` / ``local_valid_toks`` and any per-microbatch
+        metrics. Optimizer state is untouched here.
+        """
+        self.begin_train_step(  # type: ignore[attr-defined]
+            step_id=step_id,
+            loss_fn=loss_fn,
+            gbs=gbs,
+            mbs=mbs,
+        )
+
+    @wrap_with_nvtx_name("policy_worker/train_microbatch_presharded")
+    def train_microbatch_presharded(
+        self,
+        step_id: str,
+        meta: "KVBatchMeta",
+    ) -> dict[str, Any]:
+        """Per-rank microbatch entrypoint. Fetch → packing prep → forward+backward.
+
+        Gradients accumulate into ``.grad`` across calls; no
+        ``optimizer.step`` here. Returns per-microbatch metrics (loss,
+        local_valid_*); the backend folds them into the step accumulator
+        and the caller may surface them for diagnostics.
+        """
+        data = self._fetch(meta)
+        data = self._attach_or_repack_pack_metadata(data, meta)
+        return self.train_microbatch(  # type: ignore[attr-defined]
+            step_id=step_id,
+            data=data,
+        )
+
+    @wrap_with_nvtx_name("policy_worker/finish_train_step_presharded")
+    def finish_train_step_presharded(
+        self,
+        step_id: str,
+    ) -> dict[str, Any]:
+        """Close a logical train step. No fetch — pure lifecycle.
+
+        Backend all-reduces accumulated ``local_valid_seqs/toks``,
+        rescales gradients to the final global normalization, runs grad
+        clip, steps the optimizer + scheduler, then zeros gradients.
+        Returns the aggregated step result (``loss``, ``grad_norm``,
+        ``all_mb_metrics``, …).
+        """
+        return self.finish_train_step(step_id=step_id)  # type: ignore[attr-defined]
+
+    @wrap_with_nvtx_name("policy_worker/abort_train_step_presharded")
+    def abort_train_step_presharded(
+        self,
+        step_id: str,
+    ) -> None:
+        """Discard partial train-step state without stepping the optimizer.
+
+        Used when SC decides the logical batch will not complete (e.g.
+        weight-sync triggered mid-step). Backend drops accumulators and
+        zeros gradients.
+        """
+        self.abort_train_step(step_id=step_id)  # type: ignore[attr-defined]

--- a/nemo_rl/data_plane/worker_mixin.py
+++ b/nemo_rl/data_plane/worker_mixin.py
@@ -552,17 +552,17 @@ class TQWorkerMixin:
     def train_microbatch_presharded(
         self,
         meta: "KVBatchMeta",
-    ) -> dict[str, Any]:
+    ) -> None:
         """Per-rank microbatch entrypoint. Fetch → packing prep → forward+backward.
 
         Gradients accumulate into ``.grad`` across calls; no
-        ``optimizer.step`` here. Returns per-microbatch metrics (loss,
-        local_valid_*); the backend folds them into the step accumulator
-        and the caller may surface them for diagnostics.
+        ``optimizer.step`` here. Returns nothing — per-microbatch metrics
+        accumulate in the backend's open-step state and surface once via
+        ``finish_train_step_presharded``.
         """
         data = self._fetch(meta)
         data = self._attach_or_repack_pack_metadata(data, meta)
-        return self.train_microbatch(  # type: ignore[attr-defined]
+        self.train_microbatch(  # type: ignore[attr-defined]
             data=data,
         )
 

--- a/nemo_rl/data_plane/worker_mixin.py
+++ b/nemo_rl/data_plane/worker_mixin.py
@@ -529,20 +529,20 @@ class TQWorkerMixin:
     @wrap_with_nvtx_name("policy_worker/begin_train_step_presharded")
     def begin_train_step_presharded(
         self,
-        step_id: str,
         loss_fn: Any,
         gbs: Optional[int] = None,
         mbs: Optional[int] = None,
     ) -> None:
         """Open a logical train step. No fetch — pure lifecycle.
 
-        The backend stores ``step_id`` / ``loss_fn`` / ``gbs`` / ``mbs``,
-        clears gradients, and initialises accumulators for
-        ``local_valid_seqs`` / ``local_valid_toks`` and any per-microbatch
-        metrics. Optimizer state is untouched here.
+        The backend stores ``loss_fn`` / ``gbs`` / ``mbs``, clears
+        gradients, and initialises accumulators for ``local_valid_seqs``
+        / ``local_valid_toks`` and any per-microbatch metrics. Only one
+        step can be open at a time — the backend raises on a second
+        ``begin`` — so no step identifier is needed. Optimizer state is
+        untouched here.
         """
         self.begin_train_step(  # type: ignore[attr-defined]
-            step_id=step_id,
             loss_fn=loss_fn,
             gbs=gbs,
             mbs=mbs,
@@ -551,7 +551,6 @@ class TQWorkerMixin:
     @wrap_with_nvtx_name("policy_worker/train_microbatch_presharded")
     def train_microbatch_presharded(
         self,
-        step_id: str,
         meta: "KVBatchMeta",
     ) -> dict[str, Any]:
         """Per-rank microbatch entrypoint. Fetch → packing prep → forward+backward.
@@ -564,15 +563,11 @@ class TQWorkerMixin:
         data = self._fetch(meta)
         data = self._attach_or_repack_pack_metadata(data, meta)
         return self.train_microbatch(  # type: ignore[attr-defined]
-            step_id=step_id,
             data=data,
         )
 
     @wrap_with_nvtx_name("policy_worker/finish_train_step_presharded")
-    def finish_train_step_presharded(
-        self,
-        step_id: str,
-    ) -> dict[str, Any]:
+    def finish_train_step_presharded(self) -> dict[str, Any]:
         """Close a logical train step. No fetch — pure lifecycle.
 
         Backend all-reduces accumulated ``local_valid_seqs/toks``,
@@ -589,19 +584,16 @@ class TQWorkerMixin:
         inflates every per-token aggregate (gen_kl_error, probs_ratio,
         etc.) by that same factor.
         """
-        result = self.finish_train_step(step_id=step_id)  # type: ignore[attr-defined]
+        result = self.finish_train_step()  # type: ignore[attr-defined]
         result["is_replica_leader"] = bool(self._is_replica_leader())
         return result
 
     @wrap_with_nvtx_name("policy_worker/abort_train_step_presharded")
-    def abort_train_step_presharded(
-        self,
-        step_id: str,
-    ) -> None:
+    def abort_train_step_presharded(self) -> None:
         """Discard partial train-step state without stepping the optimizer.
 
         Used when SC decides the logical batch will not complete (e.g.
         weight-sync triggered mid-step). Backend drops accumulators and
         zeros gradients.
         """
-        self.abort_train_step(step_id=step_id)  # type: ignore[attr-defined]
+        self.abort_train_step()  # type: ignore[attr-defined]

--- a/nemo_rl/data_plane/worker_mixin.py
+++ b/nemo_rl/data_plane/worker_mixin.py
@@ -580,8 +580,18 @@ class TQWorkerMixin:
         clip, steps the optimizer + scheduler, then zeros gradients.
         Returns the aggregated step result (``loss``, ``grad_norm``,
         ``all_mb_metrics``, …).
+
+        Tags the result with ``is_replica_leader`` so the driver-side
+        aggregator can dedupe TP/CP/non-last-PP-stage twins that hold
+        identical copies of this DP shard's metrics. Without it the
+        driver's ``run_all_workers_single_data`` returns one dict per
+        GPU and the metric list ends up TP×CP×PP times too long, which
+        inflates every per-token aggregate (gen_kl_error, probs_ratio,
+        etc.) by that same factor.
         """
-        return self.finish_train_step(step_id=step_id)  # type: ignore[attr-defined]
+        result = self.finish_train_step(step_id=step_id)  # type: ignore[attr-defined]
+        result["is_replica_leader"] = bool(self._is_replica_leader())
+        return result
 
     @wrap_with_nvtx_name("policy_worker/abort_train_step_presharded")
     def abort_train_step_presharded(

--- a/nemo_rl/models/policy/tq_policy.py
+++ b/nemo_rl/models/policy/tq_policy.py
@@ -457,3 +457,128 @@ class TQPolicy(Policy):
                 warnings.warn(f"Error getting theoretical flops: {e}")
 
         return aggregated_results
+
+    # ── split-API fanout (SC async path) ───────────────────────────────────
+    #
+    # Counterpart to :meth:`train_from_meta`, exposed to ``PolicyTrainerActor``
+    # so :class:`SingleControllerActor` can stream microbatches without
+    # forcing a full-step optimizer.step on every dispatch.
+    #
+    # Lifecycle:
+    #   begin_train_step                  — open step; broadcast loss_fn/gbs/mbs
+    #   train_microbatch_from_meta (N×)   — DP-sharded fwd/bwd, grads accumulate
+    #   finish_train_step                 — all_reduce + opt.step + sched.step
+    #   abort_train_step                  — drop accumulators, no opt.step
+    #
+    # ``train_from_meta`` is unchanged and remains the sync entrypoint.
+
+    def begin_train_step(
+        self,
+        step_id: str,
+        loss_fn: LossFunction,
+        gbs: Optional[int] = None,
+        mbs: Optional[int] = None,
+    ) -> None:
+        """Open a logical train step on every worker."""
+        batch_size = gbs or self.cfg["train_global_batch_size"]
+        micro_batch_size = mbs or self.cfg["train_micro_batch_size"]
+        if self.flops_tracker is not None:
+            self.flops_tracker.reset()
+        futures = self.worker_group.run_all_workers_single_data(
+            "begin_train_step_presharded",
+            step_id=step_id,
+            loss_fn=loss_fn,
+            gbs=batch_size,
+            mbs=micro_batch_size,
+        )
+        self.worker_group.get_all_worker_results(futures)
+
+    def train_microbatch_from_meta(
+        self,
+        step_id: str,
+        meta: KVBatchMeta,
+        timer: Optional[Timer] = None,
+    ) -> dict[str, Any]:
+        """Dispatch one microbatch (DP-sharded) into an open train step.
+
+        Mirrors the sharding logic of :meth:`train_from_meta` but without
+        a logical-batch sizing constraint: this routes ``meta`` to DP
+        ranks and runs forward+backward; gradients accumulate in
+        ``.grad``. The optimizer step happens at :meth:`finish_train_step`.
+        """
+        self._stamp_pad_seqlen(meta)
+        spa, dba = self._packing_args("train_mb_tokens")
+        train_meta = replace(
+            meta,
+            fields=list(DP_TRAIN_FIELDS),
+            task_name="train",
+        )
+        with timer.time("policy_training/shard_meta") if timer else nullcontext():
+            dp_metas, _ = shard_meta_for_dp(
+                train_meta,
+                dp_world=self.sharding_annotations.get_axis_size("data_parallel"),
+                batch_size=None,
+                sequence_packing_args=spa,
+                dynamic_batching_args=dba,
+            )
+
+        if self.flops_tracker is not None:
+            for m in dp_metas:
+                self.flops_tracker.track_batch(list(m.sequence_lengths or []))
+
+        with (
+            timer.time("policy_training/submit_microbatch_futures")
+            if timer
+            else nullcontext()
+        ):
+            futures = self.worker_group.run_all_workers_sharded_data(
+                "train_microbatch_presharded",
+                meta=dp_metas,
+                in_sharded_axes=["data_parallel"],
+                replicate_on_axes=[
+                    "context_parallel",
+                    "tensor_parallel",
+                    "pipeline_parallel",
+                ],
+                output_is_replicated=[
+                    "context_parallel",
+                    "tensor_parallel",
+                    "pipeline_parallel",
+                ],
+                common_kwargs={"step_id": step_id},
+            )
+        results = self.worker_group.get_all_worker_results(futures)
+        # Per-microbatch metrics: pass through DP-rank-0 by convention,
+        # backend may aggregate later if needed. Surface as-is for now.
+        return results[0] if results else {}
+
+    def finish_train_step(self, step_id: str) -> dict[str, Any]:
+        """Close an open train step: all_reduce, rescale, optimizer.step.
+
+        Aggregates per-rank step results into the same shape as
+        :meth:`train_from_meta` so callers don't have to special-case
+        the split path.
+        """
+        futures = self.worker_group.run_all_workers_single_data(
+            "finish_train_step_presharded",
+            step_id=step_id,
+        )
+        results = self.worker_group.get_all_worker_results(futures)
+        aggregated_results = _aggregate_train_results(results)
+
+        if self.flops_tracker is not None:
+            aggregated_results["total_flops"] = self.flops_tracker.total_flops
+            aggregated_results["num_ranks"] = self.worker_group.cluster.world_size()
+
+        return aggregated_results
+
+    def abort_train_step(self, step_id: str) -> None:
+        """Drop partial step state on every worker. No optimizer.step."""
+        futures = self.worker_group.run_all_workers_single_data(
+            "abort_train_step_presharded",
+            step_id=step_id,
+        )
+        self.worker_group.get_all_worker_results(futures)
+
+        if self.flops_tracker is not None:
+            self.flops_tracker.reset()

--- a/nemo_rl/models/policy/tq_policy.py
+++ b/nemo_rl/models/policy/tq_policy.py
@@ -464,17 +464,17 @@ class TQPolicy(Policy):
     # so :class:`SingleControllerActor` can stream microbatches without
     # forcing a full-step optimizer.step on every dispatch.
     #
-    # Lifecycle:
-    #   begin_train_step                  — open step; broadcast loss_fn/gbs/mbs
-    #   train_microbatch_from_meta (N×)   — DP-sharded fwd/bwd, grads accumulate
-    #   finish_train_step                 — all_reduce + opt.step + sched.step
-    #   abort_train_step                  — drop accumulators, no opt.step
+    # Lifecycle (one step open at a time — workers raise on a second
+    # ``begin``, so no step identifier is threaded through the API):
+    #   begin_train_step                    — open step; broadcast loss_fn/gbs/mbs
+    #   train_microbatches_from_meta (N×)   — DP-sharded fwd/bwd, grads accumulate
+    #   finish_train_step                   — all_reduce + opt.step + sched.step
+    #   abort_train_step                    — drop accumulators, no opt.step
     #
     # ``train_from_meta`` is unchanged and remains the sync entrypoint.
 
     def begin_train_step(
         self,
-        step_id: str,
         loss_fn: LossFunction,
         gbs: Optional[int] = None,
         mbs: Optional[int] = None,
@@ -486,20 +486,23 @@ class TQPolicy(Policy):
             self.flops_tracker.reset()
         futures = self.worker_group.run_all_workers_single_data(
             "begin_train_step_presharded",
-            step_id=step_id,
             loss_fn=loss_fn,
             gbs=batch_size,
             mbs=micro_batch_size,
         )
         self.worker_group.get_all_worker_results(futures)
 
-    def train_microbatch_from_meta(
+    def train_microbatches_from_meta(
         self,
-        step_id: str,
         meta: KVBatchMeta,
         timer: Optional[Timer] = None,
     ) -> dict[str, Any]:
-        """Dispatch one microbatch (DP-sharded) into an open train step.
+        """Dispatch one meta slice (DP-sharded) into an open train step.
+
+        Named plural because one call fans out to every DP rank and the
+        backend then iterates its own internal (pipeline/packed)
+        microbatches — with a 2x packing ratio a group of G generations is
+        G/2 backend microbatches inside this single call, not G/2 calls.
 
         Mirrors the sharding logic of :meth:`train_from_meta` but without
         a logical-batch sizing constraint: this routes ``meta`` to DP
@@ -545,14 +548,13 @@ class TQPolicy(Policy):
                     "tensor_parallel",
                     "pipeline_parallel",
                 ],
-                common_kwargs={"step_id": step_id},
             )
         results = self.worker_group.get_all_worker_results(futures)
         # Per-microbatch metrics: pass through DP-rank-0 by convention,
         # backend may aggregate later if needed. Surface as-is for now.
         return results[0] if results else {}
 
-    def finish_train_step(self, step_id: str) -> dict[str, Any]:
+    def finish_train_step(self) -> dict[str, Any]:
         """Close an open train step: all_reduce, rescale, optimizer.step.
 
         Aggregates per-rank step results into the same shape as
@@ -561,7 +563,6 @@ class TQPolicy(Policy):
         """
         futures = self.worker_group.run_all_workers_single_data(
             "finish_train_step_presharded",
-            step_id=step_id,
         )
         results = self.worker_group.get_all_worker_results(futures)
         # Filter to DP-replica leaders only. ``run_all_workers_single_data``
@@ -580,11 +581,10 @@ class TQPolicy(Policy):
 
         return aggregated_results
 
-    def abort_train_step(self, step_id: str) -> None:
+    def abort_train_step(self) -> None:
         """Drop partial step state on every worker. No optimizer.step."""
         futures = self.worker_group.run_all_workers_single_data(
             "abort_train_step_presharded",
-            step_id=step_id,
         )
         self.worker_group.get_all_worker_results(futures)
 

--- a/nemo_rl/models/policy/tq_policy.py
+++ b/nemo_rl/models/policy/tq_policy.py
@@ -564,7 +564,15 @@ class TQPolicy(Policy):
             step_id=step_id,
         )
         results = self.worker_group.get_all_worker_results(futures)
-        aggregated_results = _aggregate_train_results(results)
+        # Filter to DP-replica leaders only. ``run_all_workers_single_data``
+        # returns one result per GPU (TP×CP×PP×DP), but TP/CP/non-last-PP
+        # twins hold identical copies of their DP shard's metric list.
+        # Aggregating without dedup inflates every per-token metric by
+        # TP*CP*(1 if PP==1 else PP_last_stage_count). ``train_from_meta``
+        # gets this for free via ``output_is_replicated`` on its sharded
+        # dispatch; finish has no data to shard, so we dedupe here.
+        leader_results = [r for r in results if r.get("is_replica_leader", True)]
+        aggregated_results = _aggregate_train_results(leader_results)
 
         if self.flops_tracker is not None:
             aggregated_results["total_flops"] = self.flops_tracker.total_flops

--- a/nemo_rl/models/policy/tq_policy.py
+++ b/nemo_rl/models/policy/tq_policy.py
@@ -499,7 +499,7 @@ class TQPolicy(Policy):
         self,
         meta: KVBatchMeta,
         timer: Optional[Timer] = None,
-    ) -> dict[str, Any]:
+    ) -> None:
         """Dispatch one meta slice (DP-sharded) into an open train step.
 
         Named plural because one call fans out to every DP rank and the
@@ -510,7 +510,9 @@ class TQPolicy(Policy):
         Mirrors the sharding logic of :meth:`train_from_meta` but without
         a logical-batch sizing constraint: this routes ``meta`` to DP
         ranks and runs forward+backward; gradients accumulate in
-        ``.grad``. The optimizer step happens at :meth:`finish_train_step`.
+        ``.grad``. Returns nothing — per-microbatch metrics accumulate in
+        the workers' open-step state and surface once via
+        :meth:`finish_train_step`.
         """
         self._stamp_pad_seqlen(meta)
         spa, dba = self._packing_args("train_mb_tokens")
@@ -552,10 +554,9 @@ class TQPolicy(Policy):
                     "pipeline_parallel",
                 ],
             )
-        results = self.worker_group.get_all_worker_results(futures)
-        # Per-microbatch metrics: pass through DP-rank-0 by convention,
-        # backend may aggregate later if needed. Surface as-is for now.
-        return results[0] if results else {}
+        # Wait for completion only — workers return None (metrics
+        # accumulate in their open-step state until finish_train_step).
+        self.worker_group.get_all_worker_results(futures)
 
     def finish_train_step(self) -> dict[str, Any]:
         """Close an open train step: all_reduce, rescale, optimizer.step.

--- a/nemo_rl/models/policy/tq_policy.py
+++ b/nemo_rl/models/policy/tq_policy.py
@@ -484,13 +484,16 @@ class TQPolicy(Policy):
         micro_batch_size = mbs or self.cfg["train_micro_batch_size"]
         if self.flops_tracker is not None:
             self.flops_tracker.reset()
+        # run_all_workers_single_data returns plain ObjectRefs (one per
+        # GPU), not a MultiWorkerFuture — consume with ray.get, matching
+        # every other single-data fan-out in lm_policy.
         futures = self.worker_group.run_all_workers_single_data(
             "begin_train_step_presharded",
             loss_fn=loss_fn,
             gbs=batch_size,
             mbs=micro_batch_size,
         )
-        self.worker_group.get_all_worker_results(futures)
+        ray.get(futures)
 
     def train_microbatches_from_meta(
         self,
@@ -564,7 +567,7 @@ class TQPolicy(Policy):
         futures = self.worker_group.run_all_workers_single_data(
             "finish_train_step_presharded",
         )
-        results = self.worker_group.get_all_worker_results(futures)
+        results = ray.get(futures)
         # Filter to DP-replica leaders only. ``run_all_workers_single_data``
         # returns one result per GPU (TP×CP×PP×DP), but TP/CP/non-last-PP
         # twins hold identical copies of their DP shard's metric list.
@@ -586,7 +589,7 @@ class TQPolicy(Policy):
         futures = self.worker_group.run_all_workers_single_data(
             "abort_train_step_presharded",
         )
-        self.worker_group.get_all_worker_results(futures)
+        ray.get(futures)
 
         if self.flops_tracker is not None:
             self.flops_tracker.reset()

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -143,6 +143,11 @@ class MegatronPolicyWorkerImpl(
     AbstractPolicyWorker,
     ColocatablePolicyInterface,
 ):
+    # Holds the split-API train-step state between begin/finish or
+    # begin/abort; None when no step is open. Declared at class level so
+    # ``self._train_step_state = None`` after finish/abort type-checks.
+    _train_step_state: Optional[dict[str, Any]] = None
+
     def __repr__(self):
         """Customizes the actor's prefix in the Ray logs.
 

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -894,7 +894,6 @@ class MegatronPolicyWorkerImpl(
 
     def _split_step_state_init(
         self,
-        step_id: str,
         loss_fn: LossFunction,
         gbs: Optional[int],
         mbs: Optional[int],
@@ -910,7 +909,6 @@ class MegatronPolicyWorkerImpl(
             metric_normalizations = {}
 
         return {
-            "step_id": step_id,
             "loss_fn": loss_fn,
             "loss_type": getattr(loss_fn, "loss_type", LossType.TOKEN_LEVEL),
             "metric_normalizations": metric_normalizations,
@@ -926,15 +924,11 @@ class MegatronPolicyWorkerImpl(
             "saved_no_sync_func": None,
         }
 
-    def _assert_step_open(self, step_id: str) -> dict[str, Any]:
+    def _assert_step_open(self) -> dict[str, Any]:
         state = getattr(self, "_train_step_state", None)
         if state is None:
             raise RuntimeError(
-                f"no train step open; begin_train_step({step_id!r}) must be called first"
-            )
-        if state["step_id"] != step_id:
-            raise RuntimeError(
-                f"step_id mismatch: open step is {state['step_id']!r}, got {step_id!r}"
+                "no train step open; begin_train_step must be called first"
             )
         return state
 
@@ -956,7 +950,6 @@ class MegatronPolicyWorkerImpl(
     @wrap_with_nvtx_name("megatron_policy_worker/begin_train_step")
     def begin_train_step(
         self,
-        step_id: str,
         loss_fn: LossFunction,
         gbs: Optional[int] = None,
         mbs: Optional[int] = None,
@@ -964,8 +957,8 @@ class MegatronPolicyWorkerImpl(
         existing = getattr(self, "_train_step_state", None)
         if existing is not None:
             raise RuntimeError(
-                f"train step {existing['step_id']!r} is already open; "
-                f"call finish_train_step or abort_train_step before begin"
+                "a train step is already open; "
+                "call finish_train_step or abort_train_step before begin"
             )
         # Match sync train() inference-state reset (line 332-340).
         if hasattr(self.model, "inference_params"):
@@ -980,9 +973,7 @@ class MegatronPolicyWorkerImpl(
         self.model.zero_grad_buffer()
         self.optimizer.zero_grad()
 
-        state = self._split_step_state_init(
-            step_id=step_id, loss_fn=loss_fn, gbs=gbs, mbs=mbs
-        )
+        state = self._split_step_state_init(loss_fn=loss_fn, gbs=gbs, mbs=mbs)
 
         # Null both mcore hooks that would fire a mid-step DP reduce:
         #   grad_sync_func — PP scheduler's direct call on last-MB boundaries
@@ -1016,7 +1007,6 @@ class MegatronPolicyWorkerImpl(
     @wrap_with_nvtx_name("megatron_policy_worker/train_microbatch")
     def train_microbatch(
         self,
-        step_id: str,
         data: BatchedDataDict[Any],
     ) -> dict[str, Any]:
         """One DP slice of data → one ``forward_backward_func`` invocation.
@@ -1026,7 +1016,7 @@ class MegatronPolicyWorkerImpl(
         dispatching a per-call DP reduce. The single true reduce is done
         explicitly in ``finish_train_step``.
         """
-        state = self._assert_step_open(step_id)
+        state = self._assert_step_open()
         try:
             return self._train_microbatch_body(state, data)
         except Exception:
@@ -1039,9 +1029,7 @@ class MegatronPolicyWorkerImpl(
                 self._restore_saved_grad_sync_func(state)
             except Exception:
                 log.exception(
-                    "failed to restore grad_sync_func after train_microbatch "
-                    "error (step=%s)",
-                    step_id,
+                    "failed to restore grad_sync_func after train_microbatch error"
                 )
             raise
 
@@ -1070,7 +1058,7 @@ class MegatronPolicyWorkerImpl(
         state["local_valid_seqs"] = state["local_valid_seqs"] + call_local_seqs
         state["local_valid_toks"] = state["local_valid_toks"] + call_local_toks
 
-        # Build the per-call iterator. Each ``train_microbatch_from_meta``
+        # Build the per-call iterator. Each ``train_microbatches_from_meta``
         # call carries one DP slice; the iterator subdivides into pipeline
         # microbatches.
         (
@@ -1159,8 +1147,8 @@ class MegatronPolicyWorkerImpl(
         }
 
     @wrap_with_nvtx_name("megatron_policy_worker/finish_train_step")
-    def finish_train_step(self, step_id: str) -> dict[str, Any]:
-        state = self._assert_step_open(step_id)
+    def finish_train_step(self) -> dict[str, Any]:
+        state = self._assert_step_open()
         try:
             return self._finish_train_step_body(state)
         except Exception:
@@ -1173,9 +1161,7 @@ class MegatronPolicyWorkerImpl(
                 self._restore_saved_grad_sync_func(state)
             except Exception:
                 log.exception(
-                    "failed to restore grad_sync_func after finish_train_step "
-                    "error (step=%s)",
-                    step_id,
+                    "failed to restore grad_sync_func after finish_train_step error"
                 )
             raise
 
@@ -1345,15 +1331,10 @@ class MegatronPolicyWorkerImpl(
         return metrics
 
     @wrap_with_nvtx_name("megatron_policy_worker/abort_train_step")
-    def abort_train_step(self, step_id: str) -> None:
+    def abort_train_step(self) -> None:
         state = getattr(self, "_train_step_state", None)
         if state is None:
             return
-        if state["step_id"] != step_id:
-            raise RuntimeError(
-                f"abort_train_step({step_id!r}) does not match open step "
-                f"{state['step_id']!r}"
-            )
         # Restore grad_sync_func first so the model is back to a normal
         # state before zero_grad_buffer touches anything.
         self._restore_saved_grad_sync_func(state)

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -135,6 +135,48 @@ def _model_self_packs_for_cp(model: Any) -> bool:
     unwrapped = unwrap_model(model)
     chunks = unwrapped if isinstance(unwrapped, (list, tuple)) else [unwrapped]
     return any(isinstance(chunk, Qwen3VLModel) for chunk in chunks)
+# Per-metric normalization tags for the split-API ``finish_train_step``
+# rescale. The sync path runs the loss with the true global_valid_*; the
+# split path runs each microbatch with global_valid_*=1 (raw sums) and
+# applies the 1/N rescale once at finish, but different metrics need
+# different N. See ClippedPGLossFn (nemo_rl/algorithms/loss/loss_functions.py)
+# and PR #2683 review on lines 789/845 for the catalog.
+#
+# - "toks": divide partial sum by global_valid_toks
+# - "seqs": divide partial sum by global_valid_seqs
+# - "loss_type": pick toks or seqs based on loss_type (matches gradient
+#                normalization). Used for ``loss`` and ``kl_penalty``.
+# - "none":  raw count metric; sum across microbatches downstream is the
+#            correct value. Do NOT scale.
+# - "skip":  handled separately (min/max guard, or stamped after the loop).
+#
+# Metrics not listed default to "loss_type" — preserves prior behavior
+# for any unknown metric and matches the canonical case (loss-derived).
+_METRIC_NORMALIZATION_KIND: dict[str, str] = {
+    # ClippedPGLossFn metrics always normalized by token count regardless
+    # of loss_type (see L281-588 in loss_functions.py):
+    "token_mult_prob_error": "toks",
+    "gen_kl_error": "toks",
+    "policy_kl_error": "toks",
+    "js_divergence_error": "toks",
+    "approx_entropy": "toks",
+    "probs_ratio": "toks",
+    "probs_ratio_clamped": "toks",
+    # Loss-type-aware metrics (use the same N as the gradient normalization):
+    "loss": "loss_type",
+    "kl_penalty": "loss_type",
+    # Flag-dependent (sequence_level_importance_ratios / sequence_level_loss_mask
+    # toggles inside the loss). For now use loss_type as the best default;
+    # the seq-mask-tis + token-level combo mismatches here. TODO: thread
+    # the flags through so finish can pick correctly.
+    "sampling_importance_ratio": "loss_type",
+    "is_oob_ratio": "loss_type",
+    # Raw counts — must NOT be scaled. The sync path passes these through
+    # via `/num_global_batches`=1 → identity, and grpo.py's downstream
+    # reducer sums across microbatches to get the global count.
+    "num_valid_samples": "none",
+    "num_unmasked_tokens": "none",
+}
 
 
 # Classes with @ray.remote can't be inherited from, so we split the implementation out.
@@ -1224,9 +1266,41 @@ class MegatronPolicyWorkerImpl(
         # Scheduler increment matches sync path's ``increment=gbs``.
         self.scheduler.step(increment=state["gbs"])
 
-        # Per-mb metrics were computed with N=1; rescale to match what the
-        # sync path produces. ``masked_mean`` is linear in 1/N so a single
-        # scalar multiply per metric recovers the normalized value.
+        # Per-mb metrics were computed with global_valid_*=1 (raw sums);
+        # rescale to match what the sync path produces. Different metrics
+        # use different denominators — see _METRIC_NORMALIZATION_KIND at
+        # module top. masked_mean is linear in 1/N so per-metric scalar
+        # multiplies recover the right normalized values.
+        n_toks_safe = (
+            global_valid_toks
+            if global_valid_toks.item() > 0
+            else torch.tensor(1.0, device="cuda")
+        )
+        n_seqs_safe = (
+            global_valid_seqs
+            if global_valid_seqs.item() > 0
+            else torch.tensor(1.0, device="cuda")
+        )
+        inv_toks = float((1.0 / n_toks_safe).item())
+        inv_seqs = float((1.0 / n_seqs_safe).item())
+
+        def _scale_metric(name: str, value: Any) -> Any:
+            """Apply per-metric N according to _METRIC_NORMALIZATION_KIND."""
+            kind = _METRIC_NORMALIZATION_KIND.get(name, "loss_type")
+            if kind == "none":
+                return value
+            if kind == "toks":
+                scale = inv_toks
+            elif kind == "seqs":
+                scale = inv_seqs
+            else:  # "loss_type" → same as gradient normalization
+                scale = inv_n
+            return (
+                value.detach() * scale
+                if isinstance(value, torch.Tensor)
+                else value * scale
+            )
+
         rescaled_metrics: list[dict[str, Any]] = []
         curr_lr = self.scheduler.get_lr(self.optimizer.param_groups[0])
         curr_wd = self.scheduler.get_wd()
@@ -1238,10 +1312,8 @@ class MegatronPolicyWorkerImpl(
             for k, v in m.items():
                 if "_min" in k or "_max" in k:
                     out[k] = v
-                elif isinstance(v, torch.Tensor):
-                    out[k] = v.detach() * inv_n
                 else:
-                    out[k] = v * inv_n
+                    out[k] = _scale_metric(k, v)
             out["lr"] = curr_lr
             out["wd"] = curr_wd
             out["global_valid_seqs"] = global_valid_seqs_f

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -135,6 +135,8 @@ def _model_self_packs_for_cp(model: Any) -> bool:
     unwrapped = unwrap_model(model)
     chunks = unwrapped if isinstance(unwrapped, (list, tuple)) else [unwrapped]
     return any(isinstance(chunk, Qwen3VLModel) for chunk in chunks)
+
+
 # Per-metric normalization tags for the split-API ``finish_train_step``
 # rescale. The sync path runs the loss with the true global_valid_*; the
 # split path runs each microbatch with global_valid_*=1 (raw sums) and
@@ -902,6 +904,7 @@ class MegatronPolicyWorkerImpl(
         return_data = BatchedDataDict[ReferenceLogprobOutputSpec]()
         return_data["reference_logprobs"] = reference_logprobs["logprobs"].cpu()
         return return_data
+
     # ── split-API train-step state machine (SingleController async path) ──
     #
     # SC drives one ``begin / train_microbatch×N / finish`` cycle per

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -1118,8 +1118,16 @@ class MegatronPolicyWorkerImpl(
         # Either way, opt.step sees the right-normalized gradient.
         self.model.scale_gradients(inv_n)
 
-        # The ONE true cross-DP reduce for the entire step.
-        self.model.start_grad_sync()
+        # Cross-DP grad reduce. Megatron-core's BucketGroup.finish_grad_sync,
+        # when overlap_grad_reduce=False, internally dispatches the synchronous
+        # collective via start_grad_sync(force_all_reduce=...). So calling
+        # both unconditionally double-reduces the grads (scales by world_size).
+        # Mirror the contract: only fire start_grad_sync ourselves when the
+        # overlap path needs it; finish_grad_sync handles the rest.
+        if self.cfg["megatron_cfg"]["distributed_data_parallel_config"][
+            "overlap_grad_reduce"
+        ]:
+            self.model.start_grad_sync()
         self.model.finish_grad_sync()
 
         # opt.step clips internally (clip_grad config); operates on the

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -852,6 +852,363 @@ class MegatronPolicyWorkerImpl(
         return_data = BatchedDataDict[ReferenceLogprobOutputSpec]()
         return_data["reference_logprobs"] = reference_logprobs["logprobs"].cpu()
         return return_data
+    # ── split-API train-step state machine (SingleController async path) ──
+    #
+    # Mirrors the v1/v2 implementations, adapted for mcore. Key differences:
+    #
+    # 1. mcore DDP accumulates ``param.main_grad`` per backward and dispatches
+    #    a cross-DP reduce when ``is_last_microbatch=True`` (one per
+    #    ``forward_backward_func`` call). Naively chaining multiple
+    #    ``forward_backward_func`` calls between ``optimizer.step()`` would
+    #    over-count: each call's terminal reduce sums an already-reduced
+    #    bucket again. We wrap every call in ``self.model.no_sync()`` so
+    #    hooks accumulate locally only; one explicit ``start_grad_sync`` +
+    #    ``finish_grad_sync`` at finish does the single true reduce.
+    # 2. PP>1: the pipeline scheduler invokes ``config.grad_sync_func``
+    #    directly on last-microbatch boundaries — this bypasses the
+    #    ``no_sync`` gate. We null it for the duration of the step and
+    #    restore at finish/abort.
+    # 3. Grad clip is bundled inside ``MegatronOptimizer.step()``; the 1/N
+    #    rescale via ``self.model.scale_gradients(1/N)`` must run before
+    #    ``optimizer.step()`` so the clip operates on the rescaled grad.
+    # 4. With ``calculate_per_token_loss=True`` + ``average_in_collective=
+    #    False``, mcore's DDP sums (does not average) grads across DP, so
+    #    no FSDP-style ``loss *= dp_size*cp_size`` cancellation is needed
+    #    per microbatch.
+
+    def _split_step_state_init(
+        self,
+        step_id: str,
+        loss_fn: LossFunction,
+        gbs: Optional[int],
+        mbs: Optional[int],
+    ) -> dict[str, Any]:
+        from nemo_rl.algorithms.loss.interfaces import LossType
+
+        return {
+            "step_id": step_id,
+            "loss_fn": loss_fn,
+            "loss_type": getattr(loss_fn, "loss_type", LossType.TOKEN_LEVEL),
+            "gbs": gbs or self.cfg["train_global_batch_size"],
+            "mbs": mbs or self.cfg["train_micro_batch_size"],
+            "local_valid_seqs": torch.zeros((), dtype=torch.float64, device="cuda"),
+            "local_valid_toks": torch.zeros((), dtype=torch.float64, device="cuda"),
+            "all_mb_metrics": [],
+            "mb_losses": [],
+            "total_num_microbatches": 0,
+            # Saved across the step so we can restore at finish/abort.
+            "saved_grad_sync_func": None,
+            "no_sync_active": False,
+        }
+
+    def _assert_step_open(self, step_id: str) -> dict[str, Any]:
+        state = getattr(self, "_train_step_state", None)
+        if state is None:
+            raise RuntimeError(
+                f"no train step open; begin_train_step({step_id!r}) must be called first"
+            )
+        if state["step_id"] != step_id:
+            raise RuntimeError(
+                f"step_id mismatch: open step is {state['step_id']!r}, got {step_id!r}"
+            )
+        return state
+
+    @wrap_with_nvtx_name("megatron_policy_worker/begin_train_step")
+    def begin_train_step(
+        self,
+        step_id: str,
+        loss_fn: LossFunction,
+        gbs: Optional[int] = None,
+        mbs: Optional[int] = None,
+    ) -> None:
+        existing = getattr(self, "_train_step_state", None)
+        if existing is not None:
+            raise RuntimeError(
+                f"train step {existing['step_id']!r} is already open; "
+                f"call finish_train_step or abort_train_step before begin"
+            )
+        # Match sync train() inference-state reset (line 332-340).
+        if hasattr(self.model, "inference_params"):
+            self.model.inference_params = None
+        for module in self.model.modules():
+            if hasattr(module, "reset_inference_cache"):
+                module.reset_inference_cache()
+            if hasattr(module, "_inference_key_value_memory"):
+                module._inference_key_value_memory = None
+
+        self.model.train()
+        self.model.zero_grad_buffer()
+        self.optimizer.zero_grad()
+
+        state = self._split_step_state_init(
+            step_id=step_id, loss_fn=loss_fn, gbs=gbs, mbs=mbs
+        )
+
+        # Suppress the PP scheduler's direct ``grad_sync_func`` call (which
+        # bypasses ``no_sync``). Save the existing value so we can restore
+        # at finish/abort. PP=1's ``forward_backward_no_pipelining`` doesn't
+        # invoke this; nulling it is a no-op there.
+        model_config = self.model.config
+        state["saved_grad_sync_func"] = getattr(model_config, "grad_sync_func", None)
+        model_config.grad_sync_func = None
+
+        self._train_step_state = state
+
+    @wrap_with_nvtx_name("megatron_policy_worker/train_microbatch")
+    def train_microbatch(
+        self,
+        step_id: str,
+        data: BatchedDataDict[Any],
+    ) -> dict[str, Any]:
+        """One DP slice of data → one ``forward_backward_func`` invocation.
+
+        Wrapped in ``self.model.no_sync()`` so the mcore DDP hooks
+        accumulate ``param.main_grad`` locally on each rank without
+        dispatching a per-call DP reduce. The single true reduce is done
+        explicitly in ``finish_train_step``.
+        """
+        state = self._assert_step_open(step_id)
+        loss_fn = state["loss_fn"]
+
+        # Accumulate local mask sums for the finish-time all_reduce.
+        # Inlined from process_global_batch (data.py:319-332) — we can't
+        # call process_global_batch directly because it eagerly all_reduces
+        # the local sums, which is exactly what we're trying to defer.
+        assert "sample_mask" in data, "sample_mask required on microbatch data"
+        sample_mask = data["sample_mask"]
+        call_local_seqs = torch.sum(sample_mask).to(torch.float64)
+        if "token_mask" in data:
+            token_mask = data["token_mask"]
+            call_local_toks = torch.sum(
+                token_mask[:, 1:] * sample_mask.unsqueeze(-1)
+            ).to(torch.float64)
+        else:
+            call_local_toks = call_local_seqs * data["input_ids"].shape[1]
+
+        state["local_valid_seqs"] = state["local_valid_seqs"] + call_local_seqs
+        state["local_valid_toks"] = state["local_valid_toks"] + call_local_toks
+
+        # Build the per-call iterator. Each ``train_microbatch_from_meta``
+        # call carries one DP slice; the iterator subdivides into pipeline
+        # microbatches.
+        (
+            data_iterator,
+            num_microbatches,
+            micro_batch_size,
+            seq_length,
+            padded_seq_length,
+        ) = get_microbatch_iterator(
+            data,
+            self.cfg,
+            state["mbs"],
+            straggler_timer=self.mcore_state.straggler_timer,
+        )
+        state["total_num_microbatches"] += int(num_microbatches)
+
+        loss_post_processor = LossPostProcessor(
+            loss_fn=loss_fn,
+            cfg=self.cfg,
+            num_microbatches=num_microbatches,
+            sampling_params=self.sampling_params,
+            draft_model=self.draft_model,
+        )
+
+        # Placeholder N=1: loss returns un-normalized sums. ``backward``
+        # deposits raw ``d(sum)/dθ`` into ``param.main_grad`` via the DDP
+        # hooks. The 1/N rescale happens once at finish.
+        placeholder_n = torch.tensor(1.0, device="cuda")
+
+        draft_enabled = "draft" in self.cfg and self.cfg["draft"]["enabled"]
+
+        # The critical wrap: hooks fire (accumulate main_grad) but the
+        # per-call reduce dispatch is gated off.
+        with self.model.no_sync():
+            rerun_state_machine = get_rerun_state_machine()
+            while rerun_state_machine.should_run_forward_backward(data_iterator):
+                losses_reduced = megatron_forward_backward(
+                    model=self.model,
+                    data_iterator=data_iterator,
+                    num_microbatches=num_microbatches,
+                    seq_length=padded_seq_length,
+                    mbs=micro_batch_size,
+                    post_processing_fn=loss_post_processor,
+                    forward_only=False,
+                    defer_fp32_logits=self.defer_fp32_logits,
+                    global_valid_seqs=placeholder_n,
+                    global_valid_toks=placeholder_n,
+                    sampling_params=self.sampling_params,
+                    straggler_timer=self.mcore_state.straggler_timer,
+                    draft_model=self.draft_model,
+                    enable_hidden_capture=draft_enabled,
+                    use_linear_ce_fusion_loss=self.cfg["megatron_cfg"].get(
+                        "use_linear_ce_fusion_loss", False
+                    ),
+                )
+
+        if self.cfg["megatron_cfg"]["empty_unused_memory_level"] >= 1:
+            torch.cuda.empty_cache()
+
+        # Collect per-mb metrics from the last PP stage; broadcast to all
+        # PP ranks so non-last-stage ranks have something to all_reduce
+        # against at finish. Metrics carry the N=1 placeholder for now —
+        # ``finish_train_step`` rescales by the true 1/N.
+        if parallel_state.is_pipeline_last_stage(ignore_virtual=True):
+            mb_metrics_collected = []
+            for x in losses_reduced:
+                mb_metrics_collected.append(dict(x))
+        else:
+            mb_metrics_collected = None
+
+        mb_metrics_collected = broadcast_loss_metrics_from_last_stage(
+            mb_metrics_collected
+        )
+
+        for m in mb_metrics_collected:
+            state["all_mb_metrics"].append(m)
+            # ``loss`` key is the un-normalized per-mb scalar; collect for
+            # the global_loss aggregation at finish.
+            if "loss" in m:
+                state["mb_losses"].append(m["loss"])
+
+        return {
+            "local_valid_seqs_mb": float(call_local_seqs.item()),
+            "local_valid_toks_mb": float(call_local_toks.item()),
+            "num_pipeline_microbatches": int(num_microbatches),
+        }
+
+    @wrap_with_nvtx_name("megatron_policy_worker/finish_train_step")
+    def finish_train_step(self, step_id: str) -> dict[str, Any]:
+        from nemo_rl.algorithms.loss.interfaces import LossType
+
+        state = self._assert_step_open(step_id)
+
+        # All-reduce accumulated mask sums across DP to recover true N.
+        to_reduce = torch.stack(
+            [state["local_valid_seqs"], state["local_valid_toks"]]
+        ).to(torch.float64)
+        torch.distributed.all_reduce(
+            to_reduce, group=parallel_state.get_data_parallel_group()
+        )
+        global_valid_seqs = to_reduce[0]
+        global_valid_toks = to_reduce[1]
+
+        if state["loss_type"] == LossType.TOKEN_LEVEL:
+            n_true = global_valid_toks
+        else:
+            n_true = global_valid_seqs
+        n_safe = n_true if n_true.item() > 0 else torch.tensor(1.0, device="cuda")
+        inv_n = float((1.0 / n_safe).item())
+
+        # Rescale all locally-accumulated gradients by 1/N. The reduce
+        # below sees the rescaled grads; for all_reduce the result is the
+        # global mean grad; for reduce_scatter (dist-opt) it's the shard.
+        # Either way, opt.step sees the right-normalized gradient.
+        self.model.scale_gradients(inv_n)
+
+        # The ONE true cross-DP reduce for the entire step.
+        self.model.start_grad_sync()
+        self.model.finish_grad_sync()
+
+        # opt.step clips internally (clip_grad config); operates on the
+        # already-rescaled grad. Returns (success, grad_norm, num_zeros).
+        update_successful, grad_norm, num_zeros_in_grad = self.optimizer.step()
+
+        pg_collection = get_pg_collection(self.model)
+        update_successful = logical_and_across_model_parallel_group(
+            update_successful, mp_group=pg_collection.mp
+        )
+        grad_norm = reduce_max_stat_across_model_parallel_group(
+            grad_norm, mp_group=pg_collection.mp
+        )
+        num_zeros_in_grad = reduce_max_stat_across_model_parallel_group(
+            num_zeros_in_grad, mp_group=pg_collection.mp
+        )
+
+        if self.cfg["megatron_cfg"]["empty_unused_memory_level"] >= 2:
+            torch.cuda.empty_cache()
+
+        # Restore grad_sync_func before scheduler.step / further state.
+        self.model.config.grad_sync_func = state["saved_grad_sync_func"]
+
+        # Scheduler increment matches sync path's ``increment=gbs``.
+        self.scheduler.step(increment=state["gbs"])
+
+        # Per-mb metrics were computed with N=1; rescale to match what the
+        # sync path produces. ``masked_mean`` is linear in 1/N so a single
+        # scalar multiply per metric recovers the normalized value.
+        rescaled_metrics: list[dict[str, Any]] = []
+        curr_lr = self.scheduler.get_lr(self.optimizer.param_groups[0])
+        curr_wd = self.scheduler.get_wd()
+        global_valid_seqs_f = float(global_valid_seqs.item())
+        global_valid_toks_f = float(global_valid_toks.item())
+
+        for m in state["all_mb_metrics"]:
+            out: dict[str, Any] = {}
+            for k, v in m.items():
+                if "_min" in k or "_max" in k:
+                    out[k] = v
+                elif isinstance(v, torch.Tensor):
+                    out[k] = v.detach() * inv_n
+                else:
+                    out[k] = v * inv_n
+            out["lr"] = curr_lr
+            out["wd"] = curr_wd
+            out["global_valid_seqs"] = global_valid_seqs_f
+            out["global_valid_toks"] = global_valid_toks_f
+            rescaled_metrics.append(out)
+
+        # Scale per-mb losses by 1/N and reduce per-call sums.
+        scaled_losses = [lv * inv_n for lv in state["mb_losses"]]
+        losses_to_aggregate = [torch.tensor(scaled_losses).sum().item()]
+
+        mb_metrics, global_loss = aggregate_training_statistics(
+            all_mb_metrics=rescaled_metrics,
+            losses=losses_to_aggregate,
+            data_parallel_group=parallel_state.get_data_parallel_group(),
+        )
+
+        metrics = {
+            "global_loss": global_loss.cpu(),
+            "rank": torch.distributed.get_rank(),
+            "gpu_name": torch.cuda.get_device_name(),
+            "model_dtype": self.dtype,
+            "all_mb_metrics": mb_metrics,
+            "grad_norm": torch.tensor([grad_norm]),
+        }
+
+        # MoE aux-loss metrics: same convention as sync train() — scale
+        # by the total pipeline-microbatch count accumulated across all
+        # train_microbatch calls.
+        model_config = getattr(self.model, "config", None)
+        num_moe_experts = getattr(model_config, "num_moe_experts", None)
+        if num_moe_experts is not None and num_moe_experts > 1:
+            moe_loss_scale = 1.0 / max(1, state["total_num_microbatches"])
+            moe_metrics = get_moe_metrics(
+                loss_scale=moe_loss_scale,
+                per_layer_logging=self.cfg["megatron_cfg"]["moe_per_layer_logging"],
+            )
+            if moe_metrics:
+                metrics["moe_metrics"] = moe_metrics
+
+        self._train_step_state = None
+        return metrics
+
+    @wrap_with_nvtx_name("megatron_policy_worker/abort_train_step")
+    def abort_train_step(self, step_id: str) -> None:
+        state = getattr(self, "_train_step_state", None)
+        if state is None:
+            return
+        if state["step_id"] != step_id:
+            raise RuntimeError(
+                f"abort_train_step({step_id!r}) does not match open step "
+                f"{state['step_id']!r}"
+            )
+        # Restore grad_sync_func first so the model is back to a normal
+        # state before zero_grad_buffer touches anything.
+        self.model.config.grad_sync_func = state["saved_grad_sync_func"]
+        self.model.zero_grad_buffer()
+        self.optimizer.zero_grad()
+        self._train_step_state = None
 
     @wrap_with_nvtx_name("megatron_policy_worker/get_logprobs")
     def get_logprobs(

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -13,12 +13,15 @@
 # limitations under the License.
 import copy
 import gc
+import logging
 import os
 import re
 import warnings
 from collections import defaultdict
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from typing import Any, Iterable, Iterator, Optional, TypeVar, cast
+
+log = logging.getLogger(__name__)
 
 import ray
 import torch
@@ -903,7 +906,7 @@ class MegatronPolicyWorkerImpl(
             "total_num_microbatches": 0,
             # Saved across the step so we can restore at finish/abort.
             "saved_grad_sync_func": None,
-            "no_sync_active": False,
+            "saved_no_sync_func": None,
         }
 
     def _assert_step_open(self, step_id: str) -> dict[str, Any]:
@@ -917,6 +920,21 @@ class MegatronPolicyWorkerImpl(
                 f"step_id mismatch: open step is {state['step_id']!r}, got {step_id!r}"
             )
         return state
+
+    def _restore_saved_grad_sync_func(self, state: dict[str, Any]) -> None:
+        """Restore the mcore hooks nulled in ``begin_train_step``.
+
+        Restores both ``grad_sync_func`` and ``no_sync_func`` from the
+        saved values on the open-step state. Idempotent on those values;
+        safe to call from the happy-path finish/abort or from a try/except
+        cleanup in train_microbatch / finish_train_step when those raise
+        mid-body. See begin_train_step for why ``.config`` is read via
+        getattr-by-string.
+        """
+        model_config = getattr(self.model, "config", None)
+        if model_config is not None:
+            model_config.grad_sync_func = state.get("saved_grad_sync_func")
+            model_config.no_sync_func = state.get("saved_no_sync_func")
 
     @wrap_with_nvtx_name("megatron_policy_worker/begin_train_step")
     def begin_train_step(
@@ -949,10 +967,18 @@ class MegatronPolicyWorkerImpl(
             step_id=step_id, loss_fn=loss_fn, gbs=gbs, mbs=mbs
         )
 
-        # Suppress the PP scheduler's direct ``grad_sync_func`` call (which
-        # bypasses ``no_sync``). Save the existing value so we can restore
-        # at finish/abort. PP=1's ``forward_backward_no_pipelining`` doesn't
-        # invoke this; nulling it is a no-op there.
+        # Null both mcore hooks that would fire a mid-step DP reduce:
+        #   grad_sync_func — PP scheduler's direct call on last-MB boundaries
+        #                    (PP>1 path).
+        #   no_sync_func   — ``forward_backward_no_pipelining`` (PP=1, the
+        #                    common case) wraps inner microbatches in this
+        #                    context and runs the LAST microbatch OUTSIDE
+        #                    of it. Without overriding, ``register_grad_ready``
+        #                    leaks per-param counts past the outer
+        #                    ``model.no_sync()`` we apply in train_microbatch,
+        #                    triggering an assertion on the next begin/microbatch
+        #                    pair (typically step 2).
+        # Save both so finish/abort restores them.
         # Read "config" via getattr-by-string so the token stays out of
         # begin_train_step.__code__.co_names; otherwise cloudpickle matches
         # torch.distributed.config (a non-pickleable ConfigModuleInstance).
@@ -961,9 +987,12 @@ class MegatronPolicyWorkerImpl(
             state["saved_grad_sync_func"] = getattr(
                 model_config, "grad_sync_func", None
             )
+            state["saved_no_sync_func"] = getattr(model_config, "no_sync_func", None)
             model_config.grad_sync_func = None
+            model_config.no_sync_func = nullcontext
         else:
             state["saved_grad_sync_func"] = None
+            state["saved_no_sync_func"] = None
 
         self._train_step_state = state
 
@@ -981,6 +1010,29 @@ class MegatronPolicyWorkerImpl(
         explicitly in ``finish_train_step``.
         """
         state = self._assert_step_open(step_id)
+        try:
+            return self._train_microbatch_body(state, data)
+        except Exception:
+            # The body left ``grad_sync_func`` nulled when begin_train_step
+            # opened the step. If we propagate without restoring, future
+            # steps run with the PP scheduler bypass disabled. Restore here;
+            # the caller is still expected to invoke abort_train_step
+            # (idempotent on the saved value) to drop ``_train_step_state``.
+            try:
+                self._restore_saved_grad_sync_func(state)
+            except Exception:
+                log.exception(
+                    "failed to restore grad_sync_func after train_microbatch "
+                    "error (step=%s)",
+                    step_id,
+                )
+            raise
+
+    def _train_microbatch_body(
+        self,
+        state: dict[str, Any],
+        data: BatchedDataDict[Any],
+    ) -> dict[str, Any]:
         loss_fn = state["loss_fn"]
 
         # Accumulate local mask sums for the finish-time all_reduce.
@@ -1091,9 +1143,27 @@ class MegatronPolicyWorkerImpl(
 
     @wrap_with_nvtx_name("megatron_policy_worker/finish_train_step")
     def finish_train_step(self, step_id: str) -> dict[str, Any]:
-        from nemo_rl.algorithms.loss.interfaces import LossType
-
         state = self._assert_step_open(step_id)
+        try:
+            return self._finish_train_step_body(state)
+        except Exception:
+            # Mid-finish failure: state machine is in a partial state and
+            # ``grad_sync_func`` may still be nulled (or restored, depending
+            # on how far the body got). Restore unconditionally so future
+            # steps run with the right config. Leave ``_train_step_state``
+            # for the caller's abort_train_step to clear.
+            try:
+                self._restore_saved_grad_sync_func(state)
+            except Exception:
+                log.exception(
+                    "failed to restore grad_sync_func after finish_train_step "
+                    "error (step=%s)",
+                    step_id,
+                )
+            raise
+
+    def _finish_train_step_body(self, state: dict[str, Any]) -> dict[str, Any]:
+        from nemo_rl.algorithms.loss.interfaces import LossType
 
         # All-reduce accumulated mask sums across DP to recover true N.
         to_reduce = torch.stack(
@@ -1149,10 +1219,7 @@ class MegatronPolicyWorkerImpl(
             torch.cuda.empty_cache()
 
         # Restore grad_sync_func before scheduler.step / further state.
-        # See begin_train_step for why .config is accessed by string.
-        finish_model_config = getattr(self.model, "config", None)
-        if finish_model_config is not None:
-            finish_model_config.grad_sync_func = state["saved_grad_sync_func"]
+        self._restore_saved_grad_sync_func(state)
 
         # Scheduler increment matches sync path's ``increment=gbs``.
         self.scheduler.step(increment=state["gbs"])
@@ -1229,10 +1296,7 @@ class MegatronPolicyWorkerImpl(
             )
         # Restore grad_sync_func first so the model is back to a normal
         # state before zero_grad_buffer touches anything.
-        # See begin_train_step for why .config is accessed by string.
-        abort_model_config = getattr(self.model, "config", None)
-        if abort_model_config is not None:
-            abort_model_config.grad_sync_func = state["saved_grad_sync_func"]
+        self._restore_saved_grad_sync_func(state)
         self.model.zero_grad_buffer()
         self.optimizer.zero_grad()
         self._train_step_state = None

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -1089,10 +1089,19 @@ class MegatronPolicyWorkerImpl(
         placeholder_n = torch.tensor(1.0, device="cuda")
 
         draft_enabled = "draft" in self.cfg and self.cfg["draft"]["enabled"]
+        use_router_replay = _should_use_router_replay(
+            enabled=self._router_replay_enabled,
+            data=data,
+            stage="train",
+            require=True,
+        )
 
         # The critical wrap: hooks fire (accumulate main_grad) but the
         # per-call reduce dispatch is gated off.
-        with self.model.no_sync():
+        with (
+            maybe_r3_trace_stage("train", enabled=use_router_replay),
+            self.model.no_sync(),
+        ):
             rerun_state_machine = get_rerun_state_machine()
             while rerun_state_machine.should_run_forward_backward(data_iterator):
                 losses_reduced = megatron_forward_backward(
@@ -1110,9 +1119,11 @@ class MegatronPolicyWorkerImpl(
                     straggler_timer=self.mcore_state.straggler_timer,
                     draft_model=self.draft_model,
                     enable_hidden_capture=draft_enabled,
-                    use_linear_ce_fusion_loss=self.cfg["megatron_cfg"].get(
-                        "use_linear_ce_fusion_loss", False
+                    use_fused_linear_logprobs=self.cfg["megatron_cfg"].get(
+                        "use_fused_linear_logprobs", False
                     ),
+                    use_router_replay=use_router_replay,
+                    router_replay_train=True,
                 )
 
         if self.cfg["megatron_cfg"]["empty_unused_memory_level"] >= 1:

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -953,9 +953,17 @@ class MegatronPolicyWorkerImpl(
         # bypasses ``no_sync``). Save the existing value so we can restore
         # at finish/abort. PP=1's ``forward_backward_no_pipelining`` doesn't
         # invoke this; nulling it is a no-op there.
-        model_config = self.model.config
-        state["saved_grad_sync_func"] = getattr(model_config, "grad_sync_func", None)
-        model_config.grad_sync_func = None
+        # Read "config" via getattr-by-string so the token stays out of
+        # begin_train_step.__code__.co_names; otherwise cloudpickle matches
+        # torch.distributed.config (a non-pickleable ConfigModuleInstance).
+        model_config = getattr(self.model, "config", None)
+        if model_config is not None:
+            state["saved_grad_sync_func"] = getattr(
+                model_config, "grad_sync_func", None
+            )
+            model_config.grad_sync_func = None
+        else:
+            state["saved_grad_sync_func"] = None
 
         self._train_step_state = state
 
@@ -1133,7 +1141,10 @@ class MegatronPolicyWorkerImpl(
             torch.cuda.empty_cache()
 
         # Restore grad_sync_func before scheduler.step / further state.
-        self.model.config.grad_sync_func = state["saved_grad_sync_func"]
+        # See begin_train_step for why .config is accessed by string.
+        finish_model_config = getattr(self.model, "config", None)
+        if finish_model_config is not None:
+            finish_model_config.grad_sync_func = state["saved_grad_sync_func"]
 
         # Scheduler increment matches sync path's ``increment=gbs``.
         self.scheduler.step(increment=state["gbs"])
@@ -1210,7 +1221,10 @@ class MegatronPolicyWorkerImpl(
             )
         # Restore grad_sync_func first so the model is back to a normal
         # state before zero_grad_buffer touches anything.
-        self.model.config.grad_sync_func = state["saved_grad_sync_func"]
+        # See begin_train_step for why .config is accessed by string.
+        abort_model_config = getattr(self.model, "config", None)
+        if abort_model_config is not None:
+            abort_model_config.grad_sync_func = state["saved_grad_sync_func"]
         self.model.zero_grad_buffer()
         self.optimizer.zero_grad()
         self._train_step_state = None

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -137,50 +137,6 @@ def _model_self_packs_for_cp(model: Any) -> bool:
     return any(isinstance(chunk, Qwen3VLModel) for chunk in chunks)
 
 
-# Per-metric normalization tags for the split-API ``finish_train_step``
-# rescale. The sync path runs the loss with the true global_valid_*; the
-# split path runs each microbatch with global_valid_*=1 (raw sums) and
-# applies the 1/N rescale once at finish, but different metrics need
-# different N. See ClippedPGLossFn (nemo_rl/algorithms/loss/loss_functions.py)
-# and PR #2683 review on lines 789/845 for the catalog.
-#
-# - "toks": divide partial sum by global_valid_toks
-# - "seqs": divide partial sum by global_valid_seqs
-# - "loss_type": pick toks or seqs based on loss_type (matches gradient
-#                normalization). Used for ``loss`` and ``kl_penalty``.
-# - "none":  raw count metric; sum across microbatches downstream is the
-#            correct value. Do NOT scale.
-# - "skip":  handled separately (min/max guard, or stamped after the loop).
-#
-# Metrics not listed default to "loss_type" — preserves prior behavior
-# for any unknown metric and matches the canonical case (loss-derived).
-_METRIC_NORMALIZATION_KIND: dict[str, str] = {
-    # ClippedPGLossFn metrics always normalized by token count regardless
-    # of loss_type (see L281-588 in loss_functions.py):
-    "token_mult_prob_error": "toks",
-    "gen_kl_error": "toks",
-    "policy_kl_error": "toks",
-    "js_divergence_error": "toks",
-    "approx_entropy": "toks",
-    "probs_ratio": "toks",
-    "probs_ratio_clamped": "toks",
-    # Loss-type-aware metrics (use the same N as the gradient normalization):
-    "loss": "loss_type",
-    "kl_penalty": "loss_type",
-    # Flag-dependent (sequence_level_importance_ratios / sequence_level_loss_mask
-    # toggles inside the loss). For now use loss_type as the best default;
-    # the seq-mask-tis + token-level combo mismatches here. TODO: thread
-    # the flags through so finish can pick correctly.
-    "sampling_importance_ratio": "loss_type",
-    "is_oob_ratio": "loss_type",
-    # Raw counts — must NOT be scaled. The sync path passes these through
-    # via `/num_global_batches`=1 → identity, and grpo.py's downstream
-    # reducer sums across microbatches to get the global count.
-    "num_valid_samples": "none",
-    "num_unmasked_tokens": "none",
-}
-
-
 # Classes with @ray.remote can't be inherited from, so we split the implementation out.
 # This is useful when using worker extension classes.
 class MegatronPolicyWorkerImpl(
@@ -945,10 +901,19 @@ class MegatronPolicyWorkerImpl(
     ) -> dict[str, Any]:
         from nemo_rl.algorithms.loss.interfaces import LossType
 
+        # Losses advertise per-metric denominators (see MetricNormalizer in
+        # the loss interfaces); guard the type so non-advertising losses and
+        # auto-attributed test doubles fall back to gradient normalization
+        # for every metric.
+        metric_normalizations = getattr(loss_fn, "metric_normalizations", None)
+        if not isinstance(metric_normalizations, dict):
+            metric_normalizations = {}
+
         return {
             "step_id": step_id,
             "loss_fn": loss_fn,
             "loss_type": getattr(loss_fn, "loss_type", LossType.TOKEN_LEVEL),
+            "metric_normalizations": metric_normalizations,
             "gbs": gbs or self.cfg["train_global_batch_size"],
             "mbs": mbs or self.cfg["train_micro_batch_size"],
             "local_valid_seqs": torch.zeros((), dtype=torch.float64, device="cuda"),
@@ -1283,9 +1248,10 @@ class MegatronPolicyWorkerImpl(
 
         # Per-mb metrics were computed with global_valid_*=1 (raw sums);
         # rescale to match what the sync path produces. Different metrics
-        # use different denominators — see _METRIC_NORMALIZATION_KIND at
-        # module top. masked_mean is linear in 1/N so per-metric scalar
-        # multiplies recover the right normalized values.
+        # use different denominators — the loss advertises them per metric
+        # (see MetricNormalizer in the loss interfaces). masked_mean is
+        # linear in 1/N so per-metric scalar multiplies recover the right
+        # normalized values.
         n_toks_safe = (
             global_valid_toks
             if global_valid_toks.item() > 0
@@ -1299,16 +1265,24 @@ class MegatronPolicyWorkerImpl(
         inv_toks = float((1.0 / n_toks_safe).item())
         inv_seqs = float((1.0 / n_seqs_safe).item())
 
+        from nemo_rl.algorithms.loss.interfaces import MetricNormalizer
+
+        metric_normalizations: dict[str, Any] = state["metric_normalizations"]
+
         def _scale_metric(name: str, value: Any) -> Any:
-            """Apply per-metric N according to _METRIC_NORMALIZATION_KIND."""
-            kind = _METRIC_NORMALIZATION_KIND.get(name, "loss_type")
-            if kind == "none":
+            """Apply the loss-advertised per-metric denominator.
+
+            Metrics the loss did not advertise fall back to the gradient
+            normalization (the ``loss_type`` denominator).
+            """
+            kind = metric_normalizations.get(name)
+            if kind is MetricNormalizer.NONE:
                 return value
-            if kind == "toks":
+            if kind is MetricNormalizer.TOKENS:
                 scale = inv_toks
-            elif kind == "seqs":
+            elif kind is MetricNormalizer.SEQUENCES:
                 scale = inv_seqs
-            else:  # "loss_type" → same as gradient normalization
+            else:  # not advertised → same as gradient normalization
                 scale = inv_n
             return (
                 value.detach() * scale

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -1008,17 +1008,19 @@ class MegatronPolicyWorkerImpl(
     def train_microbatch(
         self,
         data: BatchedDataDict[Any],
-    ) -> dict[str, Any]:
+    ) -> None:
         """One DP slice of data → one ``forward_backward_func`` invocation.
 
         Wrapped in ``self.model.no_sync()`` so the mcore DDP hooks
         accumulate ``param.main_grad`` locally on each rank without
         dispatching a per-call DP reduce. The single true reduce is done
-        explicitly in ``finish_train_step``.
+        explicitly in ``finish_train_step``. Returns nothing: gradients
+        land in ``param.main_grad`` and per-microbatch metrics accumulate
+        in the open-step state until ``finish_train_step`` surfaces them.
         """
         state = self._assert_step_open()
         try:
-            return self._train_microbatch_body(state, data)
+            self._train_microbatch_body(state, data)
         except Exception:
             # The body left ``grad_sync_func`` nulled when begin_train_step
             # opened the step. If we propagate without restoring, future
@@ -1037,7 +1039,7 @@ class MegatronPolicyWorkerImpl(
         self,
         state: dict[str, Any],
         data: BatchedDataDict[Any],
-    ) -> dict[str, Any]:
+    ) -> None:
         loss_fn = state["loss_fn"]
 
         # Accumulate local mask sums for the finish-time all_reduce.
@@ -1150,12 +1152,6 @@ class MegatronPolicyWorkerImpl(
             # the global_loss aggregation at finish.
             if "loss" in m:
                 state["mb_losses"].append(m["loss"])
-
-        return {
-            "local_valid_seqs_mb": float(call_local_seqs.item()),
-            "local_valid_toks_mb": float(call_local_toks.item()),
-            "num_pipeline_microbatches": int(num_microbatches),
-        }
 
     @wrap_with_nvtx_name("megatron_policy_worker/finish_train_step")
     def finish_train_step(self) -> dict[str, Any]:

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -904,7 +904,14 @@ class MegatronPolicyWorkerImpl(
         return return_data
     # ── split-API train-step state machine (SingleController async path) ──
     #
-    # Mirrors the v1/v2 implementations, adapted for mcore. Key differences:
+    # SC drives one ``begin / train_microbatch×N / finish`` cycle per
+    # optimizer step. The worker exposes:
+    #   begin_train_step      — open the step (zero grads, null mcore sync hooks)
+    #   train_microbatch      — one DP slice of fwd/bwd, grads accumulate locally
+    #   finish_train_step     — all_reduce + opt.step + scheduler.step
+    #   abort_train_step      — drop partial state (no opt.step)
+    #
+    # Key mcore-specific details:
     #
     # 1. mcore DDP accumulates ``param.main_grad`` per backward and dispatches
     #    a cross-DP reduce when ``is_last_microbatch=True`` (one per
@@ -1263,6 +1270,11 @@ class MegatronPolicyWorkerImpl(
         # Restore grad_sync_func before scheduler.step / further state.
         self._restore_saved_grad_sync_func(state)
 
+        # Capture lr/wd BEFORE scheduler.step so the per-mb metrics carry
+        # the value of THIS step, not the next one. (terrykong, #2683:832).
+        curr_lr = self.scheduler.get_lr(self.optimizer.param_groups[0])
+        curr_wd = self.scheduler.get_wd()
+
         # Scheduler increment matches sync path's ``increment=gbs``.
         self.scheduler.step(increment=state["gbs"])
 
@@ -1302,8 +1314,7 @@ class MegatronPolicyWorkerImpl(
             )
 
         rescaled_metrics: list[dict[str, Any]] = []
-        curr_lr = self.scheduler.get_lr(self.optimizer.param_groups[0])
-        curr_wd = self.scheduler.get_wd()
+        # curr_lr/curr_wd captured pre-scheduler.step above.
         global_valid_seqs_f = float(global_valid_seqs.item())
         global_valid_toks_f = float(global_valid_toks.item())
 

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -165,6 +165,7 @@ project-includes = [
   "nemo_rl/models/generation/vllm/vllm_backend.py",
   "nemo_rl/models/huggingface/__init__.py",
   "nemo_rl/models/megatron/__init__.py",
+  "nemo_rl/models/megatron/draft/__init__.py",
   "nemo_rl/models/policy/__init__.py",
   "nemo_rl/models/policy/interfaces.py",
   "nemo_rl/models/policy/utils.py",

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -168,7 +168,6 @@ project-includes = [
   "nemo_rl/models/megatron/draft/__init__.py",
   "nemo_rl/models/policy/__init__.py",
   "nemo_rl/models/policy/interfaces.py",
-  "nemo_rl/models/policy/policy_trainer_actor.py",
   "nemo_rl/models/policy/utils.py",
   "nemo_rl/models/policy/workers/__init__.py",
   "nemo_rl/models/policy/workers/patches.py",

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -168,6 +168,7 @@ project-includes = [
   "nemo_rl/models/megatron/draft/__init__.py",
   "nemo_rl/models/policy/__init__.py",
   "nemo_rl/models/policy/interfaces.py",
+  "nemo_rl/models/policy/policy_trainer_actor.py",
   "nemo_rl/models/policy/utils.py",
   "nemo_rl/models/policy/workers/__init__.py",
   "nemo_rl/models/policy/workers/patches.py",

--- a/tests/unit/algorithms/test_loss_functions.py
+++ b/tests/unit/algorithms/test_loss_functions.py
@@ -25,6 +25,7 @@ from nemo_rl.algorithms.loss import (
     NLLLossFn,
     prepare_loss_input,
 )
+from nemo_rl.algorithms.loss.interfaces import MetricNormalizer
 from nemo_rl.algorithms.loss.loss_functions import CrossTokenizerDistillationLossFn
 from nemo_rl.algorithms.utils import calculate_kl, masked_mean
 from nemo_rl.algorithms.x_token.loss_utils import (
@@ -2677,3 +2678,159 @@ def test_cross_tokenizer_ce_respects_sample_mask(tmp_path):
     ce_single = loss_fn._compute_ce(logits[:1], data_single, gvt_single)
 
     assert torch.allclose(ce_masked, ce_single, atol=1e-6)
+
+
+# ── Metric-normalization advertisement (PR #2683) ─────────────────────────
+
+
+class TestMetricNormalizationAdvertisement:
+    """Losses advertise per-metric global denominators (MetricNormalizer)
+    built from the same flags that pick the denominators inside __call__."""
+
+    def test_default_grpo_config(self):
+        norms = ClippedPGLossFn(ClippedPGLossConfig()).metric_normalizations
+        # token_level_loss=True default → gradient normalizer is TOKENS
+        assert norms["loss"] is MetricNormalizer.TOKENS
+        assert norms["kl_penalty"] is MetricNormalizer.TOKENS
+        assert norms["sampling_importance_ratio"] is MetricNormalizer.TOKENS
+        for key in (
+            "probs_ratio",
+            "probs_ratio_clamped",
+            "token_mult_prob_error",
+            "gen_kl_error",
+            "policy_kl_error",
+            "js_divergence_error",
+            "approx_entropy",
+        ):
+            assert norms[key] is MetricNormalizer.TOKENS
+        # raw counts / local means / extrema are never rescaled
+        assert norms["num_valid_samples"] is MetricNormalizer.NONE
+        assert norms["positive_nll_loss"] is MetricNormalizer.NONE
+        assert norms["probs_ratio_min"] is MetricNormalizer.NONE
+        assert norms["probs_ratio_max"] is MetricNormalizer.NONE
+        # no TIS configured → the metric is never emitted, so not advertised
+        assert "is_oob_ratio" not in norms
+
+    def test_gspo_config_keys_on_sequence_flags(self):
+        norms = ClippedPGLossFn(
+            ClippedPGLossConfig(
+                token_level_loss=False,
+                sequence_level_importance_ratios=True,
+                use_importance_sampling_correction=True,
+            )
+        ).metric_normalizations
+        assert norms["loss"] is MetricNormalizer.SEQUENCES
+        assert norms["kl_penalty"] is MetricNormalizer.SEQUENCES
+        assert norms["sampling_importance_ratio"] is MetricNormalizer.SEQUENCES
+        # the always-token diagnostics do NOT follow loss_type
+        assert norms["token_mult_prob_error"] is MetricNormalizer.TOKENS
+        assert norms["probs_ratio"] is MetricNormalizer.TOKENS
+
+    def test_seq_mask_tis_with_token_level_loss(self):
+        """is_oob_ratio keys on the TIS type, not loss_type: seq-mask-tis
+        reduces it by global_valid_seqs even under a token-level loss
+        (PR #2683 review, F-SEQ)."""
+        norms = ClippedPGLossFn(
+            ClippedPGLossConfig(
+                token_level_loss=True,
+                use_importance_sampling_correction=True,
+                truncated_importance_sampling_type="seq-mask-tis",
+                truncated_importance_sampling_ratio=2.0,
+                truncated_importance_sampling_ratio_min=0.5,
+            )
+        ).metric_normalizations
+        assert norms["loss"] is MetricNormalizer.TOKENS
+        assert norms["is_oob_ratio"] is MetricNormalizer.SEQUENCES
+
+    def test_tis_under_sequence_level_loss_stays_tokens(self):
+        """The converse mismatch: tis normalizes is_oob_ratio by tokens even
+        when the loss itself is sequence-level."""
+        norms = ClippedPGLossFn(
+            ClippedPGLossConfig(
+                token_level_loss=False,
+                use_importance_sampling_correction=True,
+                truncated_importance_sampling_type="tis",
+                truncated_importance_sampling_ratio=2.0,
+            )
+        ).metric_normalizations
+        assert norms["loss"] is MetricNormalizer.SEQUENCES
+        assert norms["is_oob_ratio"] is MetricNormalizer.TOKENS
+
+    def test_nll_loss_advertises_counts_as_none(self):
+        norms = NLLLossFn().metric_normalizations
+        assert norms["loss"] is MetricNormalizer.TOKENS
+        assert norms["num_unmasked_tokens"] is MetricNormalizer.NONE
+        assert norms["num_valid_samples"] is MetricNormalizer.NONE
+
+
+def test_split_rescale_matches_sync_normalization():
+    """Metric parity of split-API rescale vs sync normalization.
+
+    Sync path: the loss runs per microbatch with the TRUE global valid
+    counts; downstream sums the per-microbatch fragments. Split path: the
+    loss runs per microbatch with placeholder global_valid_*=1 (raw sums)
+    and the trainer rescales the summed fragments by the advertised
+    denominator at finish. The two must agree for every advertised metric
+    (PR #2683 review, F-TESTGAP — metric half; uses seq-mask-tis + token
+    level loss so the flag-keyed F-SEQ metrics are exercised too).
+    """
+    torch.manual_seed(1234)
+    cfg = ClippedPGLossConfig(
+        token_level_loss=True,
+        use_importance_sampling_correction=True,
+        truncated_importance_sampling_type="seq-mask-tis",
+        truncated_importance_sampling_ratio=1.5,
+        truncated_importance_sampling_ratio_min=0.7,
+    )
+    loss_fn = ClippedPGLossFn(cfg)
+
+    batch_size, seq_len = 4, 8
+    microbatches = []
+    for _ in range(2):
+        data, *_ = _setup_clipped_pg_test_data(
+            batch_size=batch_size, seq_len=seq_len, device="cpu"
+        )
+        data["advantages"] = torch.randn(batch_size, seq_len)
+        data["prev_logprobs"] = -torch.rand(batch_size, seq_len)
+        data["generation_logprobs"] = -torch.rand(batch_size, seq_len)
+        data["reference_policy_logprobs"] = -torch.rand(batch_size, seq_len)
+        # drop one sample + a few tokens so the valid counts are non-trivial
+        data["sample_mask"] = torch.tensor([1, 1, 1, 0], dtype=torch.int64)
+        data["token_mask"][0, -2:] = 0
+        logprobs = -torch.rand(batch_size, seq_len - 1)
+        microbatches.append((data, logprobs))
+
+    total_seqs = sum(d["sample_mask"].sum() for d, _ in microbatches).float()
+    total_toks = sum(
+        (d["token_mask"][:, 1:] * d["sample_mask"].unsqueeze(-1)).sum()
+        for d, _ in microbatches
+    ).float()
+
+    # Sync style: true global counts per call; fragments summed downstream.
+    sync_totals: dict[str, float] = {}
+    for data, logprobs in microbatches:
+        _, metrics = loss_fn(logprobs, data, total_seqs, total_toks)
+        for key, value in metrics.items():
+            sync_totals[key] = sync_totals.get(key, 0.0) + value
+
+    # Split style: placeholder counts per call; raw sums rescaled at finish
+    # by the advertised denominator.
+    one = torch.tensor(1.0)
+    raw_totals: dict[str, float] = {}
+    for data, logprobs in microbatches:
+        _, metrics = loss_fn(logprobs, data, one, one)
+        for key, value in metrics.items():
+            raw_totals[key] = raw_totals.get(key, 0.0) + value
+
+    norms = loss_fn.metric_normalizations
+    for key, kind in norms.items():
+        if kind is MetricNormalizer.NONE:
+            continue  # extrema/counts: identical fragments in both styles
+        denom = total_toks if kind is MetricNormalizer.TOKENS else total_seqs
+        assert raw_totals[key] / denom.item() == pytest.approx(
+            sync_totals[key], rel=1e-5, abs=1e-7
+        ), f"metric {key!r} (normalizer={kind}) diverges between sync and split"
+    # counts pass through unchanged in both styles
+    assert raw_totals["num_valid_samples"] == pytest.approx(
+        sync_totals["num_valid_samples"]
+    )

--- a/tests/unit/models/policy/test_megatron_split_parity.py
+++ b/tests/unit/models/policy/test_megatron_split_parity.py
@@ -26,6 +26,7 @@ split-path result aggregation.
 
 import numpy as np
 import pytest
+import ray
 import torch
 
 # megatron.bridge is only available with the mcore extras; stop collection
@@ -111,7 +112,10 @@ def _run_split(
     policy.prepare_for_training()
     results = []
     for _step in range(NUM_STEPS):
-        wg.get_all_worker_results(
+        # Single-data fan-outs return plain ObjectRefs — consume with
+        # ray.get (get_all_worker_results is for MultiWorkerFuture bundles
+        # from sharded dispatch).
+        ray.get(
             wg.run_all_workers_single_data(
                 "begin_train_step_presharded",
                 loss_fn=loss_fn,
@@ -137,7 +141,7 @@ def _run_split(
                 ],
             )
         )
-        finish_results = wg.get_all_worker_results(
+        finish_results = ray.get(
             wg.run_all_workers_single_data("finish_train_step_presharded")
         )
         leaders = [r for r in finish_results if r.get("is_replica_leader", True)]

--- a/tests/unit/models/policy/test_megatron_split_parity.py
+++ b/tests/unit/models/policy/test_megatron_split_parity.py
@@ -1,0 +1,227 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GPU numerical-parity A/B: split-API vs sync ``train()`` on a real model.
+
+PR #2683 review (F-TESTGAP): the split-state suite mocks out all gradient
+math, so nothing there can observe a normalization or grad-path divergence.
+This test runs the same GRPO batch through the sync ``train()`` path and
+the ``begin_train_step`` / ``train_microbatch`` / ``finish_train_step``
+split path on freshly-initialized identical models, for multiple optimizer
+steps, and asserts the loss curve, grad norm, and every per-microbatch
+metric agree. TP=2 additionally exercises the replica-leader dedup in the
+split-path result aggregation.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+# megatron.bridge is only available with the mcore extras; stop collection
+# cleanly on non-mcore shards (same pattern as test_megatron_split_state).
+pytest.importorskip("megatron.bridge")
+
+from nemo_rl.algorithms.loss import ClippedPGLossConfig, ClippedPGLossFn
+from nemo_rl.algorithms.utils import get_tokenizer
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
+from nemo_rl.models.generation import configure_generation_config
+from nemo_rl.models.policy.lm_policy import Policy
+from nemo_rl.models.policy.tq_policy import _aggregate_train_results
+from tests.unit.models.policy.test_megatron_worker import create_megatron_test_config
+
+pytestmark = pytest.mark.mcore
+
+NUM_GPUS = 2
+NUM_STEPS = 2
+SEQ_LEN = 64
+VOCAB_SIZE = 32000
+
+
+def _make_policy(model_name: str, tp: int, cluster_name: str):
+    cluster = RayVirtualCluster(
+        name=cluster_name,
+        bundle_ct_per_node_list=[NUM_GPUS],
+        use_gpus=True,
+        num_gpus_per_node=NUM_GPUS,
+        max_colocated_worker_groups=1,
+    )
+    config = create_megatron_test_config(model_name=model_name, tp=tp, pp=1)
+    tokenizer = get_tokenizer(config["tokenizer"])
+    config["generation"] = configure_generation_config(config["generation"], tokenizer)
+    policy = Policy(
+        cluster=cluster,
+        config=config,
+        tokenizer=tokenizer,
+        init_reference_model=False,
+    )
+    return policy, cluster, config
+
+
+def _make_grpo_batch(batch_size: int) -> BatchedDataDict:
+    """Deterministic ClippedPG batch with non-trivial masks."""
+    torch.manual_seed(42)
+    input_ids = torch.randint(0, VOCAB_SIZE, (batch_size, SEQ_LEN))
+    attention_mask = torch.ones(batch_size, SEQ_LEN)
+    token_mask = torch.ones(batch_size, SEQ_LEN)
+    token_mask[:, :8] = 0  # mask a "prompt" prefix
+    token_mask[0, -4:] = 0  # ragged tail so valid counts are non-trivial
+    return BatchedDataDict(
+        {
+            "input_ids": input_ids,
+            "input_lengths": attention_mask.sum(dim=1).to(torch.int32),
+            "attention_mask": attention_mask,
+            "token_mask": token_mask,
+            "sample_mask": torch.ones(batch_size),
+            "advantages": torch.randn(batch_size, SEQ_LEN),
+            "prev_logprobs": -torch.rand(batch_size, SEQ_LEN),
+            "generation_logprobs": -torch.rand(batch_size, SEQ_LEN),
+            "reference_policy_logprobs": -torch.rand(batch_size, SEQ_LEN),
+        }
+    )
+
+
+def _run_sync(policy: Policy, data: BatchedDataDict, loss_fn) -> list[dict]:
+    policy.prepare_for_training()
+    results = [policy.train(data, loss_fn) for _ in range(NUM_STEPS)]
+    policy.finish_training()
+    return results
+
+
+def _run_split(
+    policy: Policy, data: BatchedDataDict, loss_fn, gbs: int, mbs: int
+) -> list[dict]:
+    """Drive the worker split API the way TQPolicy does, minus the TQ
+    data plane: presharded begin/finish fan-out + replica-leader dedup +
+    the shared ``_aggregate_train_results``; the microbatch dispatch uses
+    the backend ``train_microbatch`` with driver-sharded tensors instead
+    of ``train_microbatch_from_meta`` (which requires a TQ partition)."""
+    wg = policy.worker_group
+    policy.prepare_for_training()
+    results = []
+    for step in range(NUM_STEPS):
+        step_id = f"parity-{step}"
+        wg.get_all_worker_results(
+            wg.run_all_workers_single_data(
+                "begin_train_step_presharded",
+                step_id=step_id,
+                loss_fn=loss_fn,
+                gbs=gbs,
+                mbs=mbs,
+            )
+        )
+        sharded = policy._shard_for_train(data, gbs)
+        wg.get_all_worker_results(
+            wg.run_all_workers_sharded_data(
+                "train_microbatch",
+                data=sharded,
+                in_sharded_axes=["data_parallel"],
+                replicate_on_axes=[
+                    "context_parallel",
+                    "tensor_parallel",
+                    "pipeline_parallel",
+                ],
+                output_is_replicated=[
+                    "context_parallel",
+                    "tensor_parallel",
+                    "pipeline_parallel",
+                ],
+                common_kwargs={"step_id": step_id},
+            )
+        )
+        finish_results = wg.get_all_worker_results(
+            wg.run_all_workers_single_data(
+                "finish_train_step_presharded", step_id=step_id
+            )
+        )
+        leaders = [r for r in finish_results if r.get("is_replica_leader", True)]
+        results.append(_aggregate_train_results(leaders))
+    policy.finish_training()
+    return results
+
+
+def _reduce_metric(key: str, values: list) -> float:
+    """Collapse a per-microbatch metric list the way grpo.py's reducer does."""
+    if "_min" in key:
+        return float(np.min(values))
+    if "_max" in key:
+        return float(np.max(values))
+    if key in ("lr", "wd", "global_valid_seqs", "global_valid_toks"):
+        return float(np.mean(values))
+    return float(np.sum(values))
+
+
+@pytest.mark.hf_gated
+@pytest.mark.timeout(600)
+@pytest.mark.parametrize("tp", [1, 2], ids=["2gpu_dp2", "2gpu_tp2"])
+def test_split_train_matches_sync_train(tp, tiny_llama_model_path):
+    """Grad-norm / loss-curve / metric A/B of split vs sync train()."""
+    loss_fn = ClippedPGLossFn(
+        ClippedPGLossConfig(use_importance_sampling_correction=True)
+    )
+
+    # Two fresh policies from the same checkpoint → identical initial
+    # weights and optimizer state; the sync one runs (and is torn down)
+    # first so each path sees identical GPU memory conditions.
+    policy, cluster, config = _make_policy(
+        tiny_llama_model_path, tp, f"parity-sync-tp{tp}"
+    )
+    gbs = config["train_global_batch_size"]
+    mbs = config["train_micro_batch_size"]
+    data = _make_grpo_batch(batch_size=gbs)
+    try:
+        sync_results = _run_sync(policy, data, loss_fn)
+    finally:
+        policy.shutdown()
+        cluster.shutdown()
+
+    policy, cluster, _ = _make_policy(tiny_llama_model_path, tp, f"parity-split-tp{tp}")
+    try:
+        split_results = _run_split(policy, data, loss_fn, gbs=gbs, mbs=mbs)
+    finally:
+        policy.shutdown()
+        cluster.shutdown()
+
+    for step, (sync_r, split_r) in enumerate(zip(sync_results, split_results)):
+        torch.testing.assert_close(
+            split_r["loss"],
+            sync_r["loss"],
+            rtol=1e-3,
+            atol=1e-5,
+            msg=f"step {step}: global loss diverged "
+            f"(sync={sync_r['loss']}, split={split_r['loss']})",
+        )
+        torch.testing.assert_close(
+            split_r["grad_norm"].float(),
+            sync_r["grad_norm"].float(),
+            rtol=1e-3,
+            atol=1e-5,
+            msg=f"step {step}: grad_norm diverged "
+            f"(sync={sync_r['grad_norm']}, split={split_r['grad_norm']})",
+        )
+
+        sync_mb = sync_r["all_mb_metrics"]
+        split_mb = split_r["all_mb_metrics"]
+        assert set(split_mb) == set(sync_mb), (
+            f"step {step}: metric coverage differs: "
+            f"sync-only={set(sync_mb) - set(split_mb)}, "
+            f"split-only={set(split_mb) - set(sync_mb)}"
+        )
+        for key in sorted(sync_mb):
+            sync_val = _reduce_metric(key, sync_mb[key])
+            split_val = _reduce_metric(key, split_mb[key])
+            assert split_val == pytest.approx(sync_val, rel=1e-3, abs=1e-5), (
+                f"step {step}: metric {key!r} diverged "
+                f"(sync={sync_val}, split={split_val})"
+            )

--- a/tests/unit/models/policy/test_megatron_split_parity.py
+++ b/tests/unit/models/policy/test_megatron_split_parity.py
@@ -106,16 +106,14 @@ def _run_split(
     data plane: presharded begin/finish fan-out + replica-leader dedup +
     the shared ``_aggregate_train_results``; the microbatch dispatch uses
     the backend ``train_microbatch`` with driver-sharded tensors instead
-    of ``train_microbatch_from_meta`` (which requires a TQ partition)."""
+    of ``train_microbatches_from_meta`` (which requires a TQ partition)."""
     wg = policy.worker_group
     policy.prepare_for_training()
     results = []
-    for step in range(NUM_STEPS):
-        step_id = f"parity-{step}"
+    for _step in range(NUM_STEPS):
         wg.get_all_worker_results(
             wg.run_all_workers_single_data(
                 "begin_train_step_presharded",
-                step_id=step_id,
                 loss_fn=loss_fn,
                 gbs=gbs,
                 mbs=mbs,
@@ -137,13 +135,10 @@ def _run_split(
                     "tensor_parallel",
                     "pipeline_parallel",
                 ],
-                common_kwargs={"step_id": step_id},
             )
         )
         finish_results = wg.get_all_worker_results(
-            wg.run_all_workers_single_data(
-                "finish_train_step_presharded", step_id=step_id
-            )
+            wg.run_all_workers_single_data("finish_train_step_presharded")
         )
         leaders = [r for r in finish_results if r.get("is_replica_leader", True)]
         results.append(_aggregate_train_results(leaders))

--- a/tests/unit/models/policy/test_megatron_split_state.py
+++ b/tests/unit/models/policy/test_megatron_split_state.py
@@ -1,0 +1,541 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU state-machine tests for MegatronPolicyWorkerImpl's split-API.
+
+These tests cover the lifecycle and call-order invariants — they do NOT
+exercise real distributed comms, the mcore scheduler, or the optimizer.
+Numerical equivalence vs sync ``train()`` lives in the GPU parity tests.
+
+The bugs these catch:
+  - silent gradient over-counting if ``model.no_sync()`` is not wrapped
+    around ``megatron_forward_backward`` (the mcore DDP hooks would
+    dispatch a per-call reduce, ADDING to an already-reduced bucket).
+  - PP>1 pipeline-schedule bypass if ``model.config.grad_sync_func`` is
+    not nulled for the step's duration.
+  - ``trainer_version`` advancing on abort.
+  - ``zero_grad_buffer`` not called at begin (mcore's contiguous grad
+    buffer leaks stale grads otherwise).
+  - off-by-one in ``total_num_microbatches`` (used to scale MoE aux-loss).
+"""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+# Eagerly import the worker module so ``unittest.mock.patch`` can resolve
+# attributes on it via ``getattr``. Without this the patch path
+# ``nemo_rl.models.policy.workers.megatron_policy_worker.<symbol>`` fails
+# at ``getattr(workers, "megatron_policy_worker")``.
+import nemo_rl.models.policy.workers.megatron_policy_worker  # noqa: F401
+
+pytestmark = pytest.mark.mcore
+
+# Module path of the worker under test
+WORKER_MOD = "nemo_rl.models.policy.workers.megatron_policy_worker"
+
+
+# ── Mock fabric ──────────────────────────────────────────────────────────
+
+def _make_mock_model():
+    """A mcore-DDP-shaped mock: exposes the methods + attributes the
+    split-API touches, plus an ``inference_params`` attribute and a
+    ``modules()`` that yields nothing (so the inference-cache reset loop
+    is a no-op)."""
+    model = MagicMock()
+    model.config = MagicMock()
+    model.config.grad_sync_func = "ORIGINAL_GRAD_SYNC_FUNC"  # sentinel
+    model.config.num_moe_experts = None  # disable MoE branch
+    # no_sync() is a context manager — return a MagicMock that supports
+    # __enter__/__exit__ so the `with self.model.no_sync():` block works.
+    model.no_sync = MagicMock(return_value=MagicMock(
+        __enter__=MagicMock(return_value=None),
+        __exit__=MagicMock(return_value=False),
+    ))
+    model.modules = MagicMock(return_value=iter([]))
+    model.inference_params = None
+    model.parameters = MagicMock(return_value=iter([]))  # no params for the rescale loop
+    return model
+
+
+def _make_worker(loss_type):
+    """Construct a MegatronPolicyWorkerImpl instance with all heavy
+    attributes mocked. Bypasses __init__ via ``object.__new__``."""
+    # Lazy import so the module-level mcore imports happen inside the
+    # mcore-marked test process.
+    from nemo_rl.models.policy.workers.megatron_policy_worker import (
+        MegatronPolicyWorkerImpl,
+    )
+
+    w = object.__new__(MegatronPolicyWorkerImpl)
+    w.model = _make_mock_model()
+    w.optimizer = MagicMock()
+    # MegatronOptimizer.step returns (success, grad_norm, num_zeros)
+    w.optimizer.step.return_value = (True, 0.5, 0)
+    w.optimizer.param_groups = [{"lr": 1e-4, "weight_decay": 0.01}]
+    w.scheduler = MagicMock()
+    w.scheduler.get_lr.return_value = 1e-4
+    w.scheduler.get_wd.return_value = 0.01
+    w.mcore_state = MagicMock()
+    w.mcore_state.straggler_timer = None
+    w.cfg = {
+        "train_global_batch_size": 32,
+        "train_micro_batch_size": 4,
+        "megatron_cfg": {
+            "empty_unused_memory_level": 0,
+            "moe_per_layer_logging": False,
+            "use_linear_ce_fusion_loss": False,
+        },
+    }
+    w.dp_size = 2
+    w.cp_size = 1
+    w.sampling_params = None
+    w.draft_model = None
+    w.defer_fp32_logits = False
+    w.dtype = torch.float32
+    w._is_reward_model = False
+
+    # Stash a loss_fn with the requested loss_type for tests that need one.
+    w._test_loss_fn = MagicMock(loss_type=loss_type)
+    return w
+
+
+@pytest.fixture
+def mock_module_symbols():
+    """Patch every module-level symbol that the split-API methods call
+    into. Yields a dict of name → mock for assertions."""
+    # Make `aggregate_training_statistics` return ({}, scalar) — what the
+    # finish path expects.
+    agg_ret = ({"loss": [0.0]}, torch.tensor(0.5))
+
+    patches = {
+        "megatron_forward_backward": [
+            {"loss": 0.5, "global_valid_seqs": 8.0, "global_valid_toks": 256.0}
+        ],
+        "get_microbatch_iterator": (iter([]), 2, 4, 16, 16),  # 2 pipeline mbs per call
+        "LossPostProcessor": MagicMock(),
+        "broadcast_loss_metrics_from_last_stage": lambda m: m,
+        "get_pg_collection": MagicMock(mp=MagicMock()),
+        "logical_and_across_model_parallel_group": lambda v, mp_group: v,
+        "reduce_max_stat_across_model_parallel_group": lambda v, mp_group: v,
+        "aggregate_training_statistics": agg_ret,
+        "get_moe_metrics": MagicMock(return_value={}),
+    }
+
+    with patch(f"{WORKER_MOD}.megatron_forward_backward",
+               return_value=patches["megatron_forward_backward"]) as mfb, \
+         patch(f"{WORKER_MOD}.get_microbatch_iterator",
+               return_value=patches["get_microbatch_iterator"]) as gmi, \
+         patch(f"{WORKER_MOD}.LossPostProcessor",
+               return_value=patches["LossPostProcessor"]) as lpp, \
+         patch(f"{WORKER_MOD}.broadcast_loss_metrics_from_last_stage",
+               side_effect=patches["broadcast_loss_metrics_from_last_stage"]) as bcast, \
+         patch(f"{WORKER_MOD}.get_pg_collection",
+               return_value=patches["get_pg_collection"]) as gpgc, \
+         patch(f"{WORKER_MOD}.logical_and_across_model_parallel_group",
+               side_effect=patches["logical_and_across_model_parallel_group"]) as land, \
+         patch(f"{WORKER_MOD}.reduce_max_stat_across_model_parallel_group",
+               side_effect=patches["reduce_max_stat_across_model_parallel_group"]) as rmax, \
+         patch(f"{WORKER_MOD}.aggregate_training_statistics",
+               return_value=patches["aggregate_training_statistics"]) as agg, \
+         patch(f"{WORKER_MOD}.get_moe_metrics",
+               return_value={}) as moe, \
+         patch(f"{WORKER_MOD}.get_rerun_state_machine") as grsm, \
+         patch(f"{WORKER_MOD}.parallel_state") as pstate, \
+         patch("torch.distributed.all_reduce") as ar, \
+         patch("torch.cuda.empty_cache") as cec, \
+         patch("torch.cuda.get_device_name", return_value="H100"), \
+         patch("torch.distributed.get_rank", return_value=0):
+
+        # rerun state machine: fire forward+backward once per train_microbatch
+        rsm = MagicMock()
+        rsm.should_run_forward_backward.side_effect = [True, False] * 100
+        grsm.return_value = rsm
+
+        # parallel_state mocks
+        pstate.is_pipeline_last_stage.return_value = True
+        pstate.get_data_parallel_group.return_value = MagicMock()
+
+        yield {
+            "mfb": mfb, "gmi": gmi, "lpp": lpp, "bcast": bcast,
+            "gpgc": gpgc, "land": land, "rmax": rmax, "agg": agg,
+            "moe": moe, "grsm": grsm, "pstate": pstate,
+            "all_reduce": ar, "empty_cache": cec,
+        }
+
+
+def _fake_batch():
+    """A minimal BatchedDataDict-ish object the mask-sum block can read.
+    train_microbatch reads ``data["sample_mask"]``, ``data["token_mask"]``,
+    and (only as a fallback for the no-token-mask path) ``data["input_ids"]``."""
+    # 8 samples, all valid (mask=1); 256 valid tokens each
+    sample_mask = torch.ones(8, dtype=torch.float32)
+    token_mask = torch.ones(8, 257, dtype=torch.float32)  # token_mask[:, 1:] → 256 toks
+    input_ids = torch.zeros(8, 257, dtype=torch.long)
+    return {"sample_mask": sample_mask, "token_mask": token_mask, "input_ids": input_ids}
+
+
+# ── BEGIN ────────────────────────────────────────────────────────────────
+
+class TestBegin:
+    def test_opens_state(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("step-0", loss_fn=w._test_loss_fn, gbs=16, mbs=4)
+        assert w._train_step_state is not None
+        assert w._train_step_state["step_id"] == "step-0"
+        assert w._train_step_state["loss_type"] == LossType.TOKEN_LEVEL
+        assert w._train_step_state["gbs"] == 16
+        assert w._train_step_state["mbs"] == 4
+        assert w._train_step_state["total_num_microbatches"] == 0
+
+    def test_calls_zero_grad_and_zero_grad_buffer(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("step-0", loss_fn=w._test_loss_fn)
+        w.model.zero_grad_buffer.assert_called_once()
+        w.optimizer.zero_grad.assert_called_once()
+        w.model.train.assert_called_once()
+
+    def test_saves_and_nulls_grad_sync_func(self, mock_module_symbols):
+        """The PP scheduler's direct reduce dispatch must be suppressed
+        for the duration of the step. Otherwise PP>1 silently corrupts
+        grads even when ``no_sync`` is set on the bucket groups."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        assert w.model.config.grad_sync_func == "ORIGINAL_GRAD_SYNC_FUNC"
+        w.begin_train_step("step-0", loss_fn=w._test_loss_fn)
+        assert w.model.config.grad_sync_func is None
+        assert w._train_step_state["saved_grad_sync_func"] == "ORIGINAL_GRAD_SYNC_FUNC"
+
+    def test_double_begin_raises(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("step-0", loss_fn=w._test_loss_fn)
+        with pytest.raises(RuntimeError, match="already open"):
+            w.begin_train_step("step-1", loss_fn=w._test_loss_fn)
+
+    def test_uses_cfg_defaults_when_gbs_mbs_omitted(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("step-0", loss_fn=w._test_loss_fn)
+        assert w._train_step_state["gbs"] == w.cfg["train_global_batch_size"]
+        assert w._train_step_state["mbs"] == w.cfg["train_micro_batch_size"]
+
+
+# ── _assert_step_open ────────────────────────────────────────────────────
+
+class TestAssertStepOpen:
+    def test_raises_when_no_step_open(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        with pytest.raises(RuntimeError, match="no train step open"):
+            w._assert_step_open("step-0")
+
+    def test_raises_on_step_id_mismatch(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("step-correct", loss_fn=w._test_loss_fn)
+        with pytest.raises(RuntimeError, match="step_id mismatch"):
+            w._assert_step_open("step-WRONG")
+
+    def test_train_microbatch_without_begin_raises(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        with pytest.raises(RuntimeError, match="no train step open"):
+            w.train_microbatch("step-0", _fake_batch())
+
+    def test_finish_without_begin_raises(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        with pytest.raises(RuntimeError, match="no train step open"):
+            w.finish_train_step("step-0")
+
+
+# ── train_microbatch ─────────────────────────────────────────────────────
+
+class TestTrainMicrobatch:
+    def test_wraps_forward_backward_in_no_sync(self, mock_module_symbols):
+        """The single most important assertion in this file. Without the
+        no_sync wrap, mcore DDP dispatches a per-call cross-DP reduce on
+        the partially-accumulated buffer — silently corrupting grads."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.train_microbatch("s0", _fake_batch())
+        # no_sync() must have been ENTERED (called as a context manager).
+        # MagicMock with __enter__/__exit__ records the __enter__ call.
+        ctx = w.model.no_sync.return_value
+        ctx.__enter__.assert_called()
+        ctx.__exit__.assert_called()
+
+    def test_invokes_megatron_forward_backward_once(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.train_microbatch("s0", _fake_batch())
+        assert mock_module_symbols["mfb"].call_count == 1
+
+    def test_passes_placeholder_n_one_to_loss(self, mock_module_symbols):
+        """The N=1 trick: loss must be called with global_valid_*=1 so it
+        returns un-normalized sums; finish does the 1/N rescale."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.train_microbatch("s0", _fake_batch())
+        kwargs = mock_module_symbols["mfb"].call_args.kwargs
+        # placeholder_n is a tensor(1.0)
+        assert "global_valid_seqs" in kwargs
+        assert "global_valid_toks" in kwargs
+        assert float(kwargs["global_valid_seqs"].item()) == pytest.approx(1.0)
+        assert float(kwargs["global_valid_toks"].item()) == pytest.approx(1.0)
+
+    def test_accumulates_mask_sums_across_calls(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        # _fake_batch has sample_mask sum = 8, token_mask*sample_mask sum = 8*256 = 2048
+        w.train_microbatch("s0", _fake_batch())
+        assert float(w._train_step_state["local_valid_seqs"].item()) == pytest.approx(8.0)
+        assert float(w._train_step_state["local_valid_toks"].item()) == pytest.approx(2048.0)
+        w.train_microbatch("s0", _fake_batch())
+        assert float(w._train_step_state["local_valid_seqs"].item()) == pytest.approx(16.0)
+        assert float(w._train_step_state["local_valid_toks"].item()) == pytest.approx(4096.0)
+
+    def test_total_num_microbatches_accumulates(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        # get_microbatch_iterator mock returns num_microbatches=2 per call
+        w.train_microbatch("s0", _fake_batch())
+        w.train_microbatch("s0", _fake_batch())
+        w.train_microbatch("s0", _fake_batch())
+        assert w._train_step_state["total_num_microbatches"] == 6
+
+    def test_does_not_call_optimizer_step(self, mock_module_symbols):
+        """trainer_version semantics: optimizer.step() must NOT fire
+        per train_microbatch — only at finish."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.train_microbatch("s0", _fake_batch())
+        w.train_microbatch("s0", _fake_batch())
+        w.optimizer.step.assert_not_called()
+
+
+# ── finish_train_step ────────────────────────────────────────────────────
+
+class TestFinish:
+    def _setup_open_step(self, mock_module_symbols, loss_type):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(loss_type)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.train_microbatch("s0", _fake_batch())
+        return w
+
+    def test_rescales_grads_with_inv_n(self, mock_module_symbols):
+        """The 1/N rescale must happen ON the local main_grad BEFORE the
+        cross-DP reduce — otherwise the reduce sees un-rescaled sums."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
+        w.finish_train_step("s0")
+        # scale_gradients should have been called with some 1/N scalar < 1
+        w.model.scale_gradients.assert_called_once()
+        arg = w.model.scale_gradients.call_args.args[0]
+        assert 0 < arg <= 1.0
+
+    def test_start_then_finish_grad_sync_called_after_rescale(self, mock_module_symbols):
+        """Call order matters: scale_gradients -> start_grad_sync ->
+        finish_grad_sync -> optimizer.step."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
+        # Record call order via a shared list
+        order: list[str] = []
+        w.model.scale_gradients.side_effect = lambda s: order.append("scale")
+        w.model.start_grad_sync.side_effect = lambda: order.append("start_sync")
+        w.model.finish_grad_sync.side_effect = lambda: order.append("finish_sync")
+        w.optimizer.step.side_effect = lambda: (order.append("opt_step") or (True, 0.5, 0))
+        w.finish_train_step("s0")
+        assert order == ["scale", "start_sync", "finish_sync", "opt_step"]
+
+    def test_picks_global_valid_toks_for_token_level_loss(self, mock_module_symbols):
+        """N selection: TOKEN_LEVEL → N = global_valid_toks (not seqs)."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
+        w.finish_train_step("s0")
+        # local_valid_toks accumulated = 2048; with mocked all_reduce as no-op,
+        # global_valid_toks == 2048 → inv_n = 1/2048
+        arg = w.model.scale_gradients.call_args.args[0]
+        assert arg == pytest.approx(1.0 / 2048.0, rel=1e-4)
+
+    def test_picks_global_valid_seqs_for_sequence_level_loss(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = self._setup_open_step(mock_module_symbols, LossType.SEQUENCE_LEVEL)
+        w.finish_train_step("s0")
+        # local_valid_seqs = 8 → inv_n = 1/8
+        arg = w.model.scale_gradients.call_args.args[0]
+        assert arg == pytest.approx(1.0 / 8.0, rel=1e-4)
+
+    def test_restores_grad_sync_func(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
+        w.finish_train_step("s0")
+        assert w.model.config.grad_sync_func == "ORIGINAL_GRAD_SYNC_FUNC"
+
+    def test_clears_train_step_state(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
+        w.finish_train_step("s0")
+        assert w._train_step_state is None
+
+    def test_calls_scheduler_step_with_increment_gbs(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
+        w._train_step_state["gbs"] = 64
+        w.finish_train_step("s0")
+        w.scheduler.step.assert_called_once_with(increment=64)
+
+    def test_returns_metrics_dict(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
+        metrics = w.finish_train_step("s0")
+        for key in ("global_loss", "rank", "gpu_name", "model_dtype",
+                    "all_mb_metrics", "grad_norm"):
+            assert key in metrics, f"missing {key!r}"
+
+    def test_moe_branch_skipped_when_num_experts_is_none(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
+        w.model.config.num_moe_experts = None
+        metrics = w.finish_train_step("s0")
+        assert "moe_metrics" not in metrics
+
+    def test_moe_branch_uses_total_num_microbatches_for_scale(self, mock_module_symbols):
+        """MoE aux-loss scale must use the accumulated total, not the
+        per-call num_microbatches."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.model.config.num_moe_experts = 4
+        # Have get_moe_metrics return non-empty so the branch fires
+        mock_module_symbols["moe"].return_value = {"aux_loss": 0.1}
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        # 3 train_microbatch calls × 2 pipeline mbs each = 6
+        for _ in range(3):
+            w.train_microbatch("s0", _fake_batch())
+        w.finish_train_step("s0")
+        # get_moe_metrics receives loss_scale=1/6
+        kwargs = mock_module_symbols["moe"].call_args.kwargs
+        assert kwargs["loss_scale"] == pytest.approx(1.0 / 6.0, rel=1e-6)
+
+
+# ── abort_train_step ─────────────────────────────────────────────────────
+
+class TestAbort:
+    def test_restores_grad_sync_func(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.abort_train_step("s0")
+        assert w.model.config.grad_sync_func == "ORIGINAL_GRAD_SYNC_FUNC"
+
+    def test_zero_grad_buffer_and_zero_grad_called(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.model.zero_grad_buffer.reset_mock()
+        w.optimizer.zero_grad.reset_mock()
+        w.abort_train_step("s0")
+        w.model.zero_grad_buffer.assert_called_once()
+        w.optimizer.zero_grad.assert_called_once()
+
+    def test_does_not_call_optimizer_step(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.train_microbatch("s0", _fake_batch())
+        w.abort_train_step("s0")
+        w.optimizer.step.assert_not_called()
+
+    def test_clears_train_step_state(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.abort_train_step("s0")
+        assert w._train_step_state is None
+
+    def test_idempotent_with_no_open_step(self, mock_module_symbols):
+        """abort is a no-op when nothing is open."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        # Should not raise
+        w.abort_train_step("s0")
+        assert getattr(w, "_train_step_state", None) is None
+
+    def test_mismatched_step_id_raises(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        with pytest.raises(RuntimeError, match="does not match open step"):
+            w.abort_train_step("s-WRONG")
+
+    def test_can_begin_new_step_after_abort(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.train_microbatch("s0", _fake_batch())
+        w.abort_train_step("s0")
+        # New step opens cleanly
+        w.begin_train_step("s1", loss_fn=w._test_loss_fn)
+        assert w._train_step_state["step_id"] == "s1"
+        assert float(w._train_step_state["local_valid_seqs"].item()) == 0.0
+
+
+# ── grad_sync_func full lifecycle (integration of begin → finish/abort) ─
+
+class TestGradSyncFuncLifecycle:
+    def test_begin_finish_round_trip(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        sentinel = "MY_CUSTOM_GRAD_SYNC"
+        w.model.config.grad_sync_func = sentinel
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        assert w.model.config.grad_sync_func is None
+        w.train_microbatch("s0", _fake_batch())
+        w.finish_train_step("s0")
+        assert w.model.config.grad_sync_func == sentinel
+
+    def test_begin_abort_round_trip(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        sentinel = "MY_CUSTOM_GRAD_SYNC"
+        w.model.config.grad_sync_func = sentinel
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        assert w.model.config.grad_sync_func is None
+        w.abort_train_step("s0")
+        assert w.model.config.grad_sync_func == sentinel
+
+    def test_handles_originally_none_grad_sync_func(self, mock_module_symbols):
+        """When PP=1 (or align_grad_reduce=False), grad_sync_func is None
+        to begin with. begin → finish must leave it as None."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.model.config.grad_sync_func = None
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        assert w.model.config.grad_sync_func is None
+        w.train_microbatch("s0", _fake_batch())
+        w.finish_train_step("s0")
+        assert w.model.config.grad_sync_func is None

--- a/tests/unit/models/policy/test_megatron_split_state.py
+++ b/tests/unit/models/policy/test_megatron_split_state.py
@@ -109,6 +109,12 @@ def _make_worker(loss_type):
             "empty_unused_memory_level": 0,
             "moe_per_layer_logging": False,
             "use_linear_ce_fusion_loss": False,
+            # overlap_grad_reduce=False matches the production default and
+            # the sync-GRPO path. finish_train_step relies on this to gate
+            # the explicit start_grad_sync call.
+            "distributed_data_parallel_config": {
+                "overlap_grad_reduce": False,
+            },
         },
     }
     w.dp_size = 2
@@ -422,14 +428,23 @@ class TestFinish:
         arg = w.model.scale_gradients.call_args.args[0]
         assert 0 < arg <= 1.0
 
-    def test_start_then_finish_grad_sync_called_after_rescale(
-        self, mock_module_symbols
+    @pytest.mark.parametrize("overlap_grad_reduce", [False, True])
+    def test_grad_sync_call_order_after_rescale(
+        self, mock_module_symbols, overlap_grad_reduce
     ):
-        """Call order matters: scale_gradients -> start_grad_sync ->
-        finish_grad_sync -> optimizer.step."""
+        """Call order matters: scale_gradients -> [start_grad_sync when
+        overlap=True] -> finish_grad_sync -> optimizer.step.
+
+        With overlap=False, Megatron's finish_grad_sync internally calls
+        start_grad_sync(force_all_reduce=True), so calling start_grad_sync
+        ourselves would double-reduce.
+        """
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
+        w.cfg["megatron_cfg"]["distributed_data_parallel_config"][
+            "overlap_grad_reduce"
+        ] = overlap_grad_reduce
         # Record call order via a shared list
         order: list[str] = []
         w.model.scale_gradients.side_effect = lambda s: order.append("scale")
@@ -439,7 +454,10 @@ class TestFinish:
             order.append("opt_step") or (True, 0.5, 0)
         )
         w.finish_train_step("s0")
-        assert order == ["scale", "start_sync", "finish_sync", "opt_step"]
+        if overlap_grad_reduce:
+            assert order == ["scale", "start_sync", "finish_sync", "opt_step"]
+        else:
+            assert order == ["scale", "finish_sync", "opt_step"]
 
     def test_picks_global_valid_toks_for_token_level_loss(self, mock_module_symbols):
         """N selection: TOKEN_LEVEL → N = global_valid_toks (not seqs)."""

--- a/tests/unit/models/policy/test_megatron_split_state.py
+++ b/tests/unit/models/policy/test_megatron_split_state.py
@@ -31,7 +31,6 @@ The bugs these catch:
 
 from __future__ import annotations
 
-from contextlib import nullcontext
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -51,6 +50,7 @@ WORKER_MOD = "nemo_rl.models.policy.workers.megatron_policy_worker"
 
 # ── Mock fabric ──────────────────────────────────────────────────────────
 
+
 def _make_mock_model():
     """A mcore-DDP-shaped mock: exposes the methods + attributes the
     split-API touches, plus an ``inference_params`` attribute and a
@@ -62,13 +62,17 @@ def _make_mock_model():
     model.config.num_moe_experts = None  # disable MoE branch
     # no_sync() is a context manager — return a MagicMock that supports
     # __enter__/__exit__ so the `with self.model.no_sync():` block works.
-    model.no_sync = MagicMock(return_value=MagicMock(
-        __enter__=MagicMock(return_value=None),
-        __exit__=MagicMock(return_value=False),
-    ))
+    model.no_sync = MagicMock(
+        return_value=MagicMock(
+            __enter__=MagicMock(return_value=None),
+            __exit__=MagicMock(return_value=False),
+        )
+    )
     model.modules = MagicMock(return_value=iter([]))
     model.inference_params = None
-    model.parameters = MagicMock(return_value=iter([]))  # no params for the rescale loop
+    model.parameters = MagicMock(
+        return_value=iter([])
+    )  # no params for the rescale loop
     return model
 
 
@@ -136,31 +140,45 @@ def mock_module_symbols():
         "get_moe_metrics": MagicMock(return_value={}),
     }
 
-    with patch(f"{WORKER_MOD}.megatron_forward_backward",
-               return_value=patches["megatron_forward_backward"]) as mfb, \
-         patch(f"{WORKER_MOD}.get_microbatch_iterator",
-               return_value=patches["get_microbatch_iterator"]) as gmi, \
-         patch(f"{WORKER_MOD}.LossPostProcessor",
-               return_value=patches["LossPostProcessor"]) as lpp, \
-         patch(f"{WORKER_MOD}.broadcast_loss_metrics_from_last_stage",
-               side_effect=patches["broadcast_loss_metrics_from_last_stage"]) as bcast, \
-         patch(f"{WORKER_MOD}.get_pg_collection",
-               return_value=patches["get_pg_collection"]) as gpgc, \
-         patch(f"{WORKER_MOD}.logical_and_across_model_parallel_group",
-               side_effect=patches["logical_and_across_model_parallel_group"]) as land, \
-         patch(f"{WORKER_MOD}.reduce_max_stat_across_model_parallel_group",
-               side_effect=patches["reduce_max_stat_across_model_parallel_group"]) as rmax, \
-         patch(f"{WORKER_MOD}.aggregate_training_statistics",
-               return_value=patches["aggregate_training_statistics"]) as agg, \
-         patch(f"{WORKER_MOD}.get_moe_metrics",
-               return_value={}) as moe, \
-         patch(f"{WORKER_MOD}.get_rerun_state_machine") as grsm, \
-         patch(f"{WORKER_MOD}.parallel_state") as pstate, \
-         patch("torch.distributed.all_reduce") as ar, \
-         patch("torch.cuda.empty_cache") as cec, \
-         patch("torch.cuda.get_device_name", return_value="H100"), \
-         patch("torch.distributed.get_rank", return_value=0):
-
+    with (
+        patch(
+            f"{WORKER_MOD}.megatron_forward_backward",
+            return_value=patches["megatron_forward_backward"],
+        ) as mfb,
+        patch(
+            f"{WORKER_MOD}.get_microbatch_iterator",
+            return_value=patches["get_microbatch_iterator"],
+        ) as gmi,
+        patch(
+            f"{WORKER_MOD}.LossPostProcessor", return_value=patches["LossPostProcessor"]
+        ) as lpp,
+        patch(
+            f"{WORKER_MOD}.broadcast_loss_metrics_from_last_stage",
+            side_effect=patches["broadcast_loss_metrics_from_last_stage"],
+        ) as bcast,
+        patch(
+            f"{WORKER_MOD}.get_pg_collection", return_value=patches["get_pg_collection"]
+        ) as gpgc,
+        patch(
+            f"{WORKER_MOD}.logical_and_across_model_parallel_group",
+            side_effect=patches["logical_and_across_model_parallel_group"],
+        ) as land,
+        patch(
+            f"{WORKER_MOD}.reduce_max_stat_across_model_parallel_group",
+            side_effect=patches["reduce_max_stat_across_model_parallel_group"],
+        ) as rmax,
+        patch(
+            f"{WORKER_MOD}.aggregate_training_statistics",
+            return_value=patches["aggregate_training_statistics"],
+        ) as agg,
+        patch(f"{WORKER_MOD}.get_moe_metrics", return_value={}) as moe,
+        patch(f"{WORKER_MOD}.get_rerun_state_machine") as grsm,
+        patch(f"{WORKER_MOD}.parallel_state") as pstate,
+        patch("torch.distributed.all_reduce") as ar,
+        patch("torch.cuda.empty_cache") as cec,
+        patch("torch.cuda.get_device_name", return_value="H100"),
+        patch("torch.distributed.get_rank", return_value=0),
+    ):
         # rerun state machine: fire forward+backward once per train_microbatch
         rsm = MagicMock()
         rsm.should_run_forward_backward.side_effect = [True, False] * 100
@@ -171,10 +189,19 @@ def mock_module_symbols():
         pstate.get_data_parallel_group.return_value = MagicMock()
 
         yield {
-            "mfb": mfb, "gmi": gmi, "lpp": lpp, "bcast": bcast,
-            "gpgc": gpgc, "land": land, "rmax": rmax, "agg": agg,
-            "moe": moe, "grsm": grsm, "pstate": pstate,
-            "all_reduce": ar, "empty_cache": cec,
+            "mfb": mfb,
+            "gmi": gmi,
+            "lpp": lpp,
+            "bcast": bcast,
+            "gpgc": gpgc,
+            "land": land,
+            "rmax": rmax,
+            "agg": agg,
+            "moe": moe,
+            "grsm": grsm,
+            "pstate": pstate,
+            "all_reduce": ar,
+            "empty_cache": cec,
         }
 
 
@@ -186,14 +213,20 @@ def _fake_batch():
     sample_mask = torch.ones(8, dtype=torch.float32)
     token_mask = torch.ones(8, 257, dtype=torch.float32)  # token_mask[:, 1:] → 256 toks
     input_ids = torch.zeros(8, 257, dtype=torch.long)
-    return {"sample_mask": sample_mask, "token_mask": token_mask, "input_ids": input_ids}
+    return {
+        "sample_mask": sample_mask,
+        "token_mask": token_mask,
+        "input_ids": input_ids,
+    }
 
 
 # ── BEGIN ────────────────────────────────────────────────────────────────
 
+
 class TestBegin:
     def test_opens_state(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("step-0", loss_fn=w._test_loss_fn, gbs=16, mbs=4)
         assert w._train_step_state is not None
@@ -205,6 +238,7 @@ class TestBegin:
 
     def test_calls_zero_grad_and_zero_grad_buffer(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("step-0", loss_fn=w._test_loss_fn)
         w.model.zero_grad_buffer.assert_called_once()
@@ -216,6 +250,7 @@ class TestBegin:
         for the duration of the step. Otherwise PP>1 silently corrupts
         grads even when ``no_sync`` is set on the bucket groups."""
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         assert w.model.config.grad_sync_func == "ORIGINAL_GRAD_SYNC_FUNC"
         w.begin_train_step("step-0", loss_fn=w._test_loss_fn)
@@ -224,6 +259,7 @@ class TestBegin:
 
     def test_double_begin_raises(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("step-0", loss_fn=w._test_loss_fn)
         with pytest.raises(RuntimeError, match="already open"):
@@ -231,6 +267,7 @@ class TestBegin:
 
     def test_uses_cfg_defaults_when_gbs_mbs_omitted(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("step-0", loss_fn=w._test_loss_fn)
         assert w._train_step_state["gbs"] == w.cfg["train_global_batch_size"]
@@ -239,15 +276,18 @@ class TestBegin:
 
 # ── _assert_step_open ────────────────────────────────────────────────────
 
+
 class TestAssertStepOpen:
     def test_raises_when_no_step_open(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         with pytest.raises(RuntimeError, match="no train step open"):
             w._assert_step_open("step-0")
 
     def test_raises_on_step_id_mismatch(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("step-correct", loss_fn=w._test_loss_fn)
         with pytest.raises(RuntimeError, match="step_id mismatch"):
@@ -255,12 +295,14 @@ class TestAssertStepOpen:
 
     def test_train_microbatch_without_begin_raises(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         with pytest.raises(RuntimeError, match="no train step open"):
             w.train_microbatch("step-0", _fake_batch())
 
     def test_finish_without_begin_raises(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         with pytest.raises(RuntimeError, match="no train step open"):
             w.finish_train_step("step-0")
@@ -268,12 +310,14 @@ class TestAssertStepOpen:
 
 # ── train_microbatch ─────────────────────────────────────────────────────
 
+
 class TestTrainMicrobatch:
     def test_wraps_forward_backward_in_no_sync(self, mock_module_symbols):
         """The single most important assertion in this file. Without the
         no_sync wrap, mcore DDP dispatches a per-call cross-DP reduce on
         the partially-accumulated buffer — silently corrupting grads."""
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         w.train_microbatch("s0", _fake_batch())
@@ -285,6 +329,7 @@ class TestTrainMicrobatch:
 
     def test_invokes_megatron_forward_backward_once(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         w.train_microbatch("s0", _fake_batch())
@@ -294,6 +339,7 @@ class TestTrainMicrobatch:
         """The N=1 trick: loss must be called with global_valid_*=1 so it
         returns un-normalized sums; finish does the 1/N rescale."""
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         w.train_microbatch("s0", _fake_batch())
@@ -306,18 +352,28 @@ class TestTrainMicrobatch:
 
     def test_accumulates_mask_sums_across_calls(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         # _fake_batch has sample_mask sum = 8, token_mask*sample_mask sum = 8*256 = 2048
         w.train_microbatch("s0", _fake_batch())
-        assert float(w._train_step_state["local_valid_seqs"].item()) == pytest.approx(8.0)
-        assert float(w._train_step_state["local_valid_toks"].item()) == pytest.approx(2048.0)
+        assert float(w._train_step_state["local_valid_seqs"].item()) == pytest.approx(
+            8.0
+        )
+        assert float(w._train_step_state["local_valid_toks"].item()) == pytest.approx(
+            2048.0
+        )
         w.train_microbatch("s0", _fake_batch())
-        assert float(w._train_step_state["local_valid_seqs"].item()) == pytest.approx(16.0)
-        assert float(w._train_step_state["local_valid_toks"].item()) == pytest.approx(4096.0)
+        assert float(w._train_step_state["local_valid_seqs"].item()) == pytest.approx(
+            16.0
+        )
+        assert float(w._train_step_state["local_valid_toks"].item()) == pytest.approx(
+            4096.0
+        )
 
     def test_total_num_microbatches_accumulates(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         # get_microbatch_iterator mock returns num_microbatches=2 per call
@@ -330,6 +386,7 @@ class TestTrainMicrobatch:
         """trainer_version semantics: optimizer.step() must NOT fire
         per train_microbatch — only at finish."""
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         w.train_microbatch("s0", _fake_batch())
@@ -339,9 +396,9 @@ class TestTrainMicrobatch:
 
 # ── finish_train_step ────────────────────────────────────────────────────
 
+
 class TestFinish:
     def _setup_open_step(self, mock_module_symbols, loss_type):
-        from nemo_rl.algorithms.loss.interfaces import LossType
         w = _make_worker(loss_type)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         w.train_microbatch("s0", _fake_batch())
@@ -351,6 +408,7 @@ class TestFinish:
         """The 1/N rescale must happen ON the local main_grad BEFORE the
         cross-DP reduce — otherwise the reduce sees un-rescaled sums."""
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
         w.finish_train_step("s0")
         # scale_gradients should have been called with some 1/N scalar < 1
@@ -358,23 +416,29 @@ class TestFinish:
         arg = w.model.scale_gradients.call_args.args[0]
         assert 0 < arg <= 1.0
 
-    def test_start_then_finish_grad_sync_called_after_rescale(self, mock_module_symbols):
+    def test_start_then_finish_grad_sync_called_after_rescale(
+        self, mock_module_symbols
+    ):
         """Call order matters: scale_gradients -> start_grad_sync ->
         finish_grad_sync -> optimizer.step."""
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
         # Record call order via a shared list
         order: list[str] = []
         w.model.scale_gradients.side_effect = lambda s: order.append("scale")
         w.model.start_grad_sync.side_effect = lambda: order.append("start_sync")
         w.model.finish_grad_sync.side_effect = lambda: order.append("finish_sync")
-        w.optimizer.step.side_effect = lambda: (order.append("opt_step") or (True, 0.5, 0))
+        w.optimizer.step.side_effect = lambda: (
+            order.append("opt_step") or (True, 0.5, 0)
+        )
         w.finish_train_step("s0")
         assert order == ["scale", "start_sync", "finish_sync", "opt_step"]
 
     def test_picks_global_valid_toks_for_token_level_loss(self, mock_module_symbols):
         """N selection: TOKEN_LEVEL → N = global_valid_toks (not seqs)."""
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
         w.finish_train_step("s0")
         # local_valid_toks accumulated = 2048; with mocked all_reduce as no-op,
@@ -384,6 +448,7 @@ class TestFinish:
 
     def test_picks_global_valid_seqs_for_sequence_level_loss(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = self._setup_open_step(mock_module_symbols, LossType.SEQUENCE_LEVEL)
         w.finish_train_step("s0")
         # local_valid_seqs = 8 → inv_n = 1/8
@@ -392,18 +457,21 @@ class TestFinish:
 
     def test_restores_grad_sync_func(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
         w.finish_train_step("s0")
         assert w.model.config.grad_sync_func == "ORIGINAL_GRAD_SYNC_FUNC"
 
     def test_clears_train_step_state(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
         w.finish_train_step("s0")
         assert w._train_step_state is None
 
     def test_calls_scheduler_step_with_increment_gbs(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
         w._train_step_state["gbs"] = 64
         w.finish_train_step("s0")
@@ -411,23 +479,34 @@ class TestFinish:
 
     def test_returns_metrics_dict(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
         metrics = w.finish_train_step("s0")
-        for key in ("global_loss", "rank", "gpu_name", "model_dtype",
-                    "all_mb_metrics", "grad_norm"):
+        for key in (
+            "global_loss",
+            "rank",
+            "gpu_name",
+            "model_dtype",
+            "all_mb_metrics",
+            "grad_norm",
+        ):
             assert key in metrics, f"missing {key!r}"
 
     def test_moe_branch_skipped_when_num_experts_is_none(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
         w.model.config.num_moe_experts = None
         metrics = w.finish_train_step("s0")
         assert "moe_metrics" not in metrics
 
-    def test_moe_branch_uses_total_num_microbatches_for_scale(self, mock_module_symbols):
+    def test_moe_branch_uses_total_num_microbatches_for_scale(
+        self, mock_module_symbols
+    ):
         """MoE aux-loss scale must use the accumulated total, not the
         per-call num_microbatches."""
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.model.config.num_moe_experts = 4
         # Have get_moe_metrics return non-empty so the branch fires
@@ -444,9 +523,11 @@ class TestFinish:
 
 # ── abort_train_step ─────────────────────────────────────────────────────
 
+
 class TestAbort:
     def test_restores_grad_sync_func(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         w.abort_train_step("s0")
@@ -454,6 +535,7 @@ class TestAbort:
 
     def test_zero_grad_buffer_and_zero_grad_called(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         w.model.zero_grad_buffer.reset_mock()
@@ -464,6 +546,7 @@ class TestAbort:
 
     def test_does_not_call_optimizer_step(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         w.train_microbatch("s0", _fake_batch())
@@ -472,6 +555,7 @@ class TestAbort:
 
     def test_clears_train_step_state(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         w.abort_train_step("s0")
@@ -480,6 +564,7 @@ class TestAbort:
     def test_idempotent_with_no_open_step(self, mock_module_symbols):
         """abort is a no-op when nothing is open."""
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         # Should not raise
         w.abort_train_step("s0")
@@ -487,6 +572,7 @@ class TestAbort:
 
     def test_mismatched_step_id_raises(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         with pytest.raises(RuntimeError, match="does not match open step"):
@@ -494,6 +580,7 @@ class TestAbort:
 
     def test_can_begin_new_step_after_abort(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         w.train_microbatch("s0", _fake_batch())
@@ -506,9 +593,11 @@ class TestAbort:
 
 # ── grad_sync_func full lifecycle (integration of begin → finish/abort) ─
 
+
 class TestGradSyncFuncLifecycle:
     def test_begin_finish_round_trip(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         sentinel = "MY_CUSTOM_GRAD_SYNC"
         w.model.config.grad_sync_func = sentinel
@@ -520,6 +609,7 @@ class TestGradSyncFuncLifecycle:
 
     def test_begin_abort_round_trip(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         sentinel = "MY_CUSTOM_GRAD_SYNC"
         w.model.config.grad_sync_func = sentinel
@@ -532,6 +622,7 @@ class TestGradSyncFuncLifecycle:
         """When PP=1 (or align_grad_reduce=False), grad_sync_func is None
         to begin with. begin → finish must leave it as None."""
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.model.config.grad_sync_func = None
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)

--- a/tests/unit/models/policy/test_megatron_split_state.py
+++ b/tests/unit/models/policy/test_megatron_split_state.py
@@ -36,11 +36,17 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 
+# megatron.bridge is only available with the mcore extras. Without it the
+# eager import of megatron_policy_worker (transitively imports megatron.bridge)
+# fails at COLLECTION time on non-mcore shards, which then breaks every other
+# test in that shard. importorskip stops collection cleanly here.
+pytest.importorskip("megatron.bridge")
+
 # Eagerly import the worker module so ``unittest.mock.patch`` can resolve
 # attributes on it via ``getattr``. Without this the patch path
 # ``nemo_rl.models.policy.workers.megatron_policy_worker.<symbol>`` fails
 # at ``getattr(workers, "megatron_policy_worker")``.
-import nemo_rl.models.policy.workers.megatron_policy_worker  # noqa: F401
+import nemo_rl.models.policy.workers.megatron_policy_worker  # noqa: E402,F401
 
 pytestmark = pytest.mark.mcore
 

--- a/tests/unit/models/policy/test_megatron_split_state.py
+++ b/tests/unit/models/policy/test_megatron_split_state.py
@@ -108,7 +108,7 @@ def _make_worker(loss_type):
         "megatron_cfg": {
             "empty_unused_memory_level": 0,
             "moe_per_layer_logging": False,
-            "use_linear_ce_fusion_loss": False,
+            "use_fused_linear_logprobs": False,
             # overlap_grad_reduce=False matches the production default and
             # the sync-GRPO path. finish_train_step relies on this to gate
             # the explicit start_grad_sync call.
@@ -124,6 +124,7 @@ def _make_worker(loss_type):
     w.defer_fp32_logits = False
     w.dtype = torch.float32
     w._is_reward_model = False
+    w._router_replay_enabled = False
 
     # Stash a loss_fn with the requested loss_type for tests that need one.
     w._test_loss_fn = MagicMock(loss_type=loss_type)

--- a/tests/unit/models/policy/test_megatron_split_state.py
+++ b/tests/unit/models/policy/test_megatron_split_state.py
@@ -240,9 +240,8 @@ class TestBegin:
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = _make_worker(LossType.TOKEN_LEVEL)
-        w.begin_train_step("step-0", loss_fn=w._test_loss_fn, gbs=16, mbs=4)
+        w.begin_train_step(loss_fn=w._test_loss_fn, gbs=16, mbs=4)
         assert w._train_step_state is not None
-        assert w._train_step_state["step_id"] == "step-0"
         assert w._train_step_state["loss_type"] == LossType.TOKEN_LEVEL
         assert w._train_step_state["gbs"] == 16
         assert w._train_step_state["mbs"] == 4
@@ -252,7 +251,7 @@ class TestBegin:
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = _make_worker(LossType.TOKEN_LEVEL)
-        w.begin_train_step("step-0", loss_fn=w._test_loss_fn)
+        w.begin_train_step(loss_fn=w._test_loss_fn)
         w.model.zero_grad_buffer.assert_called_once()
         w.optimizer.zero_grad.assert_called_once()
         w.model.train.assert_called_once()
@@ -265,7 +264,7 @@ class TestBegin:
 
         w = _make_worker(LossType.TOKEN_LEVEL)
         assert w.model.config.grad_sync_func == "ORIGINAL_GRAD_SYNC_FUNC"
-        w.begin_train_step("step-0", loss_fn=w._test_loss_fn)
+        w.begin_train_step(loss_fn=w._test_loss_fn)
         assert w.model.config.grad_sync_func is None
         assert w._train_step_state["saved_grad_sync_func"] == "ORIGINAL_GRAD_SYNC_FUNC"
 
@@ -273,15 +272,15 @@ class TestBegin:
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = _make_worker(LossType.TOKEN_LEVEL)
-        w.begin_train_step("step-0", loss_fn=w._test_loss_fn)
+        w.begin_train_step(loss_fn=w._test_loss_fn)
         with pytest.raises(RuntimeError, match="already open"):
-            w.begin_train_step("step-1", loss_fn=w._test_loss_fn)
+            w.begin_train_step(loss_fn=w._test_loss_fn)
 
     def test_uses_cfg_defaults_when_gbs_mbs_omitted(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = _make_worker(LossType.TOKEN_LEVEL)
-        w.begin_train_step("step-0", loss_fn=w._test_loss_fn)
+        w.begin_train_step(loss_fn=w._test_loss_fn)
         assert w._train_step_state["gbs"] == w.cfg["train_global_batch_size"]
         assert w._train_step_state["mbs"] == w.cfg["train_micro_batch_size"]
 
@@ -295,29 +294,21 @@ class TestAssertStepOpen:
 
         w = _make_worker(LossType.TOKEN_LEVEL)
         with pytest.raises(RuntimeError, match="no train step open"):
-            w._assert_step_open("step-0")
-
-    def test_raises_on_step_id_mismatch(self, mock_module_symbols):
-        from nemo_rl.algorithms.loss.interfaces import LossType
-
-        w = _make_worker(LossType.TOKEN_LEVEL)
-        w.begin_train_step("step-correct", loss_fn=w._test_loss_fn)
-        with pytest.raises(RuntimeError, match="step_id mismatch"):
-            w._assert_step_open("step-WRONG")
+            w._assert_step_open()
 
     def test_train_microbatch_without_begin_raises(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = _make_worker(LossType.TOKEN_LEVEL)
         with pytest.raises(RuntimeError, match="no train step open"):
-            w.train_microbatch("step-0", _fake_batch())
+            w.train_microbatch(_fake_batch())
 
     def test_finish_without_begin_raises(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = _make_worker(LossType.TOKEN_LEVEL)
         with pytest.raises(RuntimeError, match="no train step open"):
-            w.finish_train_step("step-0")
+            w.finish_train_step()
 
 
 # ── train_microbatch ─────────────────────────────────────────────────────
@@ -331,8 +322,8 @@ class TestTrainMicrobatch:
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = _make_worker(LossType.TOKEN_LEVEL)
-        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
-        w.train_microbatch("s0", _fake_batch())
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.train_microbatch(_fake_batch())
         # no_sync() must have been ENTERED (called as a context manager).
         # MagicMock with __enter__/__exit__ records the __enter__ call.
         ctx = w.model.no_sync.return_value
@@ -343,8 +334,8 @@ class TestTrainMicrobatch:
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = _make_worker(LossType.TOKEN_LEVEL)
-        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
-        w.train_microbatch("s0", _fake_batch())
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.train_microbatch(_fake_batch())
         assert mock_module_symbols["mfb"].call_count == 1
 
     def test_passes_placeholder_n_one_to_loss(self, mock_module_symbols):
@@ -353,8 +344,8 @@ class TestTrainMicrobatch:
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = _make_worker(LossType.TOKEN_LEVEL)
-        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
-        w.train_microbatch("s0", _fake_batch())
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.train_microbatch(_fake_batch())
         kwargs = mock_module_symbols["mfb"].call_args.kwargs
         # placeholder_n is a tensor(1.0)
         assert "global_valid_seqs" in kwargs
@@ -366,16 +357,16 @@ class TestTrainMicrobatch:
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = _make_worker(LossType.TOKEN_LEVEL)
-        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.begin_train_step(loss_fn=w._test_loss_fn)
         # _fake_batch has sample_mask sum = 8, token_mask*sample_mask sum = 8*256 = 2048
-        w.train_microbatch("s0", _fake_batch())
+        w.train_microbatch(_fake_batch())
         assert float(w._train_step_state["local_valid_seqs"].item()) == pytest.approx(
             8.0
         )
         assert float(w._train_step_state["local_valid_toks"].item()) == pytest.approx(
             2048.0
         )
-        w.train_microbatch("s0", _fake_batch())
+        w.train_microbatch(_fake_batch())
         assert float(w._train_step_state["local_valid_seqs"].item()) == pytest.approx(
             16.0
         )
@@ -387,11 +378,11 @@ class TestTrainMicrobatch:
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = _make_worker(LossType.TOKEN_LEVEL)
-        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.begin_train_step(loss_fn=w._test_loss_fn)
         # get_microbatch_iterator mock returns num_microbatches=2 per call
-        w.train_microbatch("s0", _fake_batch())
-        w.train_microbatch("s0", _fake_batch())
-        w.train_microbatch("s0", _fake_batch())
+        w.train_microbatch(_fake_batch())
+        w.train_microbatch(_fake_batch())
+        w.train_microbatch(_fake_batch())
         assert w._train_step_state["total_num_microbatches"] == 6
 
     def test_does_not_call_optimizer_step(self, mock_module_symbols):
@@ -400,9 +391,9 @@ class TestTrainMicrobatch:
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = _make_worker(LossType.TOKEN_LEVEL)
-        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
-        w.train_microbatch("s0", _fake_batch())
-        w.train_microbatch("s0", _fake_batch())
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.train_microbatch(_fake_batch())
+        w.train_microbatch(_fake_batch())
         w.optimizer.step.assert_not_called()
 
 
@@ -412,8 +403,8 @@ class TestTrainMicrobatch:
 class TestFinish:
     def _setup_open_step(self, mock_module_symbols, loss_type):
         w = _make_worker(loss_type)
-        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
-        w.train_microbatch("s0", _fake_batch())
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.train_microbatch(_fake_batch())
         return w
 
     def test_rescales_grads_with_inv_n(self, mock_module_symbols):
@@ -422,7 +413,7 @@ class TestFinish:
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
-        w.finish_train_step("s0")
+        w.finish_train_step()
         # scale_gradients should have been called with some 1/N scalar < 1
         w.model.scale_gradients.assert_called_once()
         arg = w.model.scale_gradients.call_args.args[0]
@@ -453,7 +444,7 @@ class TestFinish:
         w.optimizer.step.side_effect = lambda: (
             order.append("opt_step") or (True, 0.5, 0)
         )
-        w.finish_train_step("s0")
+        w.finish_train_step()
         if overlap_grad_reduce:
             assert order == ["scale", "start_sync", "finish_sync", "opt_step"]
         else:
@@ -464,7 +455,7 @@ class TestFinish:
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
-        w.finish_train_step("s0")
+        w.finish_train_step()
         # local_valid_toks accumulated = 2048; with mocked all_reduce as no-op,
         # global_valid_toks == 2048 → inv_n = 1/2048
         arg = w.model.scale_gradients.call_args.args[0]
@@ -474,7 +465,7 @@ class TestFinish:
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = self._setup_open_step(mock_module_symbols, LossType.SEQUENCE_LEVEL)
-        w.finish_train_step("s0")
+        w.finish_train_step()
         # local_valid_seqs = 8 → inv_n = 1/8
         arg = w.model.scale_gradients.call_args.args[0]
         assert arg == pytest.approx(1.0 / 8.0, rel=1e-4)
@@ -483,14 +474,14 @@ class TestFinish:
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
-        w.finish_train_step("s0")
+        w.finish_train_step()
         assert w.model.config.grad_sync_func == "ORIGINAL_GRAD_SYNC_FUNC"
 
     def test_clears_train_step_state(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
-        w.finish_train_step("s0")
+        w.finish_train_step()
         assert w._train_step_state is None
 
     def test_calls_scheduler_step_with_increment_gbs(self, mock_module_symbols):
@@ -498,14 +489,14 @@ class TestFinish:
 
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
         w._train_step_state["gbs"] = 64
-        w.finish_train_step("s0")
+        w.finish_train_step()
         w.scheduler.step.assert_called_once_with(increment=64)
 
     def test_returns_metrics_dict(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
-        metrics = w.finish_train_step("s0")
+        metrics = w.finish_train_step()
         for key in (
             "global_loss",
             "rank",
@@ -521,7 +512,7 @@ class TestFinish:
 
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
         w.model.config.num_moe_experts = None
-        metrics = w.finish_train_step("s0")
+        metrics = w.finish_train_step()
         assert "moe_metrics" not in metrics
 
     def test_moe_branch_uses_total_num_microbatches_for_scale(
@@ -535,11 +526,11 @@ class TestFinish:
         w.model.config.num_moe_experts = 4
         # Have get_moe_metrics return non-empty so the branch fires
         mock_module_symbols["moe"].return_value = {"aux_loss": 0.1}
-        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.begin_train_step(loss_fn=w._test_loss_fn)
         # 3 train_microbatch calls × 2 pipeline mbs each = 6
         for _ in range(3):
-            w.train_microbatch("s0", _fake_batch())
-        w.finish_train_step("s0")
+            w.train_microbatch(_fake_batch())
+        w.finish_train_step()
         # get_moe_metrics receives loss_scale=1/6
         kwargs = mock_module_symbols["moe"].call_args.kwargs
         assert kwargs["loss_scale"] == pytest.approx(1.0 / 6.0, rel=1e-6)
@@ -564,9 +555,9 @@ class TestFinish:
                 "other_metric": 2048.0,
             }
         ]
-        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
-        w.train_microbatch("s0", _fake_batch())  # 8 seqs / 2048 valid toks
-        w.finish_train_step("s0")
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.train_microbatch(_fake_batch())  # 8 seqs / 2048 valid toks
+        w.finish_train_step()
         m = mock_module_symbols["agg"].call_args.kwargs["all_mb_metrics"][0]
         assert m["tok_metric"] == pytest.approx(1.0)  # 2048 / 2048
         assert m["seq_metric"] == pytest.approx(1.0)  # 8 / 8
@@ -589,9 +580,9 @@ class TestFinish:
         mock_module_symbols["mfb"].return_value = [
             {"loss": 0.5, "num_valid_samples": 8.0, "num_unmasked_tokens": 2048.0}
         ]
-        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
-        w.train_microbatch("s0", _fake_batch())  # inv_n = 1/2048
-        w.finish_train_step("s0")
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.train_microbatch(_fake_batch())  # inv_n = 1/2048
+        w.finish_train_step()
         m = mock_module_symbols["agg"].call_args.kwargs["all_mb_metrics"][0]
         assert m["num_valid_samples"] == pytest.approx(8.0)
         assert m["num_unmasked_tokens"] == pytest.approx(2048.0)
@@ -625,9 +616,9 @@ class TestFinish:
                 "sampling_importance_ratio": 2048.0,
             }
         ]
-        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
-        w.train_microbatch("s0", _fake_batch())  # 8 seqs / 2048 valid toks
-        w.finish_train_step("s0")
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.train_microbatch(_fake_batch())  # 8 seqs / 2048 valid toks
+        w.finish_train_step()
         m = mock_module_symbols["agg"].call_args.kwargs["all_mb_metrics"][0]
         assert m["loss"] == pytest.approx(1.0)  # ÷ toks (loss_type)
         assert m["is_oob_ratio"] == pytest.approx(1.0)  # ÷ seqs, NOT toks
@@ -642,18 +633,18 @@ class TestAbort:
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = _make_worker(LossType.TOKEN_LEVEL)
-        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
-        w.abort_train_step("s0")
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.abort_train_step()
         assert w.model.config.grad_sync_func == "ORIGINAL_GRAD_SYNC_FUNC"
 
     def test_zero_grad_buffer_and_zero_grad_called(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = _make_worker(LossType.TOKEN_LEVEL)
-        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.begin_train_step(loss_fn=w._test_loss_fn)
         w.model.zero_grad_buffer.reset_mock()
         w.optimizer.zero_grad.reset_mock()
-        w.abort_train_step("s0")
+        w.abort_train_step()
         w.model.zero_grad_buffer.assert_called_once()
         w.optimizer.zero_grad.assert_called_once()
 
@@ -661,17 +652,17 @@ class TestAbort:
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = _make_worker(LossType.TOKEN_LEVEL)
-        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
-        w.train_microbatch("s0", _fake_batch())
-        w.abort_train_step("s0")
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.train_microbatch(_fake_batch())
+        w.abort_train_step()
         w.optimizer.step.assert_not_called()
 
     def test_clears_train_step_state(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = _make_worker(LossType.TOKEN_LEVEL)
-        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
-        w.abort_train_step("s0")
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.abort_train_step()
         assert w._train_step_state is None
 
     def test_idempotent_with_no_open_step(self, mock_module_symbols):
@@ -680,27 +671,19 @@ class TestAbort:
 
         w = _make_worker(LossType.TOKEN_LEVEL)
         # Should not raise
-        w.abort_train_step("s0")
+        w.abort_train_step()
         assert getattr(w, "_train_step_state", None) is None
-
-    def test_mismatched_step_id_raises(self, mock_module_symbols):
-        from nemo_rl.algorithms.loss.interfaces import LossType
-
-        w = _make_worker(LossType.TOKEN_LEVEL)
-        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
-        with pytest.raises(RuntimeError, match="does not match open step"):
-            w.abort_train_step("s-WRONG")
 
     def test_can_begin_new_step_after_abort(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = _make_worker(LossType.TOKEN_LEVEL)
-        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
-        w.train_microbatch("s0", _fake_batch())
-        w.abort_train_step("s0")
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.train_microbatch(_fake_batch())
+        w.abort_train_step()
         # New step opens cleanly
-        w.begin_train_step("s1", loss_fn=w._test_loss_fn)
-        assert w._train_step_state["step_id"] == "s1"
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        assert w._train_step_state is not None
         assert float(w._train_step_state["local_valid_seqs"].item()) == 0.0
 
 
@@ -714,10 +697,10 @@ class TestGradSyncFuncLifecycle:
         w = _make_worker(LossType.TOKEN_LEVEL)
         sentinel = "MY_CUSTOM_GRAD_SYNC"
         w.model.config.grad_sync_func = sentinel
-        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.begin_train_step(loss_fn=w._test_loss_fn)
         assert w.model.config.grad_sync_func is None
-        w.train_microbatch("s0", _fake_batch())
-        w.finish_train_step("s0")
+        w.train_microbatch(_fake_batch())
+        w.finish_train_step()
         assert w.model.config.grad_sync_func == sentinel
 
     def test_begin_abort_round_trip(self, mock_module_symbols):
@@ -726,9 +709,9 @@ class TestGradSyncFuncLifecycle:
         w = _make_worker(LossType.TOKEN_LEVEL)
         sentinel = "MY_CUSTOM_GRAD_SYNC"
         w.model.config.grad_sync_func = sentinel
-        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.begin_train_step(loss_fn=w._test_loss_fn)
         assert w.model.config.grad_sync_func is None
-        w.abort_train_step("s0")
+        w.abort_train_step()
         assert w.model.config.grad_sync_func == sentinel
 
     def test_handles_originally_none_grad_sync_func(self, mock_module_symbols):
@@ -738,8 +721,8 @@ class TestGradSyncFuncLifecycle:
 
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.model.config.grad_sync_func = None
-        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.begin_train_step(loss_fn=w._test_loss_fn)
         assert w.model.config.grad_sync_func is None
-        w.train_microbatch("s0", _fake_batch())
-        w.finish_train_step("s0")
+        w.train_microbatch(_fake_batch())
+        w.finish_train_step()
         assert w.model.config.grad_sync_func is None

--- a/tests/unit/models/policy/test_megatron_split_state.py
+++ b/tests/unit/models/policy/test_megatron_split_state.py
@@ -544,6 +544,95 @@ class TestFinish:
         kwargs = mock_module_symbols["moe"].call_args.kwargs
         assert kwargs["loss_scale"] == pytest.approx(1.0 / 6.0, rel=1e-6)
 
+    def test_loss_advertised_normalizers_applied(self, mock_module_symbols):
+        """finish scales each metric by the denominator the loss advertised:
+        TOKENS → 1/global_valid_toks, SEQUENCES → 1/global_valid_seqs,
+        NONE → unscaled, unadvertised → gradient normalization (inv_n)."""
+        from nemo_rl.algorithms.loss.interfaces import LossType, MetricNormalizer
+
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w._test_loss_fn.metric_normalizations = {
+            "tok_metric": MetricNormalizer.TOKENS,
+            "seq_metric": MetricNormalizer.SEQUENCES,
+            "raw_metric": MetricNormalizer.NONE,
+        }
+        mock_module_symbols["mfb"].return_value = [
+            {
+                "tok_metric": 2048.0,
+                "seq_metric": 8.0,
+                "raw_metric": 8.0,
+                "other_metric": 2048.0,
+            }
+        ]
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.train_microbatch("s0", _fake_batch())  # 8 seqs / 2048 valid toks
+        w.finish_train_step("s0")
+        m = mock_module_symbols["agg"].call_args.kwargs["all_mb_metrics"][0]
+        assert m["tok_metric"] == pytest.approx(1.0)  # 2048 / 2048
+        assert m["seq_metric"] == pytest.approx(1.0)  # 8 / 8
+        assert m["raw_metric"] == pytest.approx(8.0)  # unscaled
+        # unadvertised → inv_n of the loss_type (TOKEN_LEVEL → 1/2048)
+        assert m["other_metric"] == pytest.approx(1.0)
+
+    def test_raw_count_metrics_not_rescaled_by_inv_n(self, mock_module_symbols):
+        """Raw-count metrics (num_valid_samples, num_unmasked_tokens) are
+        absolute counts the loss advertises as NONE; finish must leave them
+        unscaled so the downstream sum recovers the true global count
+        (PR #2683 review, F-COUNT)."""
+        from nemo_rl.algorithms.loss.interfaces import LossType, MetricNormalizer
+
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w._test_loss_fn.metric_normalizations = {
+            "num_valid_samples": MetricNormalizer.NONE,
+            "num_unmasked_tokens": MetricNormalizer.NONE,
+        }
+        mock_module_symbols["mfb"].return_value = [
+            {"loss": 0.5, "num_valid_samples": 8.0, "num_unmasked_tokens": 2048.0}
+        ]
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.train_microbatch("s0", _fake_batch())  # inv_n = 1/2048
+        w.finish_train_step("s0")
+        m = mock_module_symbols["agg"].call_args.kwargs["all_mb_metrics"][0]
+        assert m["num_valid_samples"] == pytest.approx(8.0)
+        assert m["num_unmasked_tokens"] == pytest.approx(2048.0)
+
+    def test_flag_keyed_normalizers_from_real_loss(self, mock_module_symbols):
+        """seq-mask-tis + token-level loss: is_oob_ratio was reduced by
+        global_valid_seqs even though the gradient normalizer is tokens.
+        The advertised mapping from a real ClippedPGLossFn must key it on
+        the TIS type, not loss_type (PR #2683 review, F-SEQ)."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        from nemo_rl.algorithms.loss.loss_functions import (
+            ClippedPGLossConfig,
+            ClippedPGLossFn,
+        )
+
+        real_loss = ClippedPGLossFn(
+            ClippedPGLossConfig(
+                token_level_loss=True,
+                use_importance_sampling_correction=True,
+                truncated_importance_sampling_type="seq-mask-tis",
+                truncated_importance_sampling_ratio=2.0,
+                truncated_importance_sampling_ratio_min=0.5,
+            )
+        )
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w._test_loss_fn.metric_normalizations = real_loss.metric_normalizations
+        mock_module_symbols["mfb"].return_value = [
+            {
+                "loss": 2048.0,
+                "is_oob_ratio": 8.0,
+                "sampling_importance_ratio": 2048.0,
+            }
+        ]
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.train_microbatch("s0", _fake_batch())  # 8 seqs / 2048 valid toks
+        w.finish_train_step("s0")
+        m = mock_module_symbols["agg"].call_args.kwargs["all_mb_metrics"][0]
+        assert m["loss"] == pytest.approx(1.0)  # ÷ toks (loss_type)
+        assert m["is_oob_ratio"] == pytest.approx(1.0)  # ÷ seqs, NOT toks
+        assert m["sampling_importance_ratio"] == pytest.approx(1.0)  # ÷ toks
+
 
 # ── abort_train_step ─────────────────────────────────────────────────────
 

--- a/tests/unit/models/policy/test_split_api_wrappers.py
+++ b/tests/unit/models/policy/test_split_api_wrappers.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU tests for the split-API presharded wrappers and TQPolicy fan-out.
+
+These two layers sit between the SC driver and the backend state machine
+and were previously exercised only by the GPU-gated parity test — the
+latent bugs the PR #2683 review surfaced (futures consumed with the wrong
+API, an unused per-microbatch return) lived exactly here. Pin the
+contracts cheaply:
+  - ``*_presharded`` wrappers: pass-through begin/finish/abort, the
+    fetch → attach → backend chain in ``train_microbatch_presharded``
+    (returning None), and the ``is_replica_leader`` tag on finish.
+  - TQPolicy driver: single-data futures consumed via ``ray.get``,
+    replica-twin dedup in ``finish_train_step`` aggregation, and
+    ``train_microbatches_from_meta`` returning None.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from nemo_rl.data_plane import KVBatchMeta
+from nemo_rl.data_plane.worker_mixin import TQWorkerMixin
+from nemo_rl.models.policy.tq_policy import TQPolicy
+
+
+class _SplitStubWorker(TQWorkerMixin):
+    """Mixin host recording backend calls; fetch/attach are stubbed."""
+
+    def __init__(self, is_leader: bool = True):
+        self.calls: list[tuple] = []
+        self._leader = is_leader
+
+    def _fetch(self, meta):
+        self.calls.append(("fetch", meta))
+        return {"data_from": meta}
+
+    def _attach_or_repack_pack_metadata(self, data, meta):
+        self.calls.append(("attach", meta))
+        return data
+
+    def _is_replica_leader(self) -> bool:
+        return self._leader
+
+    # backend split API
+    def begin_train_step(self, loss_fn, gbs=None, mbs=None):
+        self.calls.append(("begin", loss_fn, gbs, mbs))
+
+    def train_microbatch(self, data):
+        self.calls.append(("train_microbatch", data))
+
+    def finish_train_step(self):
+        self.calls.append(("finish",))
+        return {
+            "global_loss": 1.0,
+            "grad_norm": 0.5,
+            "all_mb_metrics": {"loss": [1.0]},
+        }
+
+    def abort_train_step(self):
+        self.calls.append(("abort",))
+
+
+def _meta() -> KVBatchMeta:
+    return KVBatchMeta(
+        partition_id="train",
+        task_name="train",
+        sample_ids=["s0", "s1"],
+    )
+
+
+class TestPreshardedWrappers:
+    def test_begin_forwards_args(self):
+        w = _SplitStubWorker()
+        loss_fn = object()
+        w.begin_train_step_presharded(loss_fn=loss_fn, gbs=8, mbs=2)
+        assert w.calls == [("begin", loss_fn, 8, 2)]
+
+    def test_train_microbatch_fetches_attaches_then_dispatches(self):
+        w = _SplitStubWorker()
+        meta = _meta()
+        out = w.train_microbatch_presharded(meta=meta)
+        assert out is None  # metrics accumulate in the open-step state
+        assert [c[0] for c in w.calls] == ["fetch", "attach", "train_microbatch"]
+        assert w.calls[-1][1] == {"data_from": meta}
+
+    def test_finish_tags_replica_leader(self):
+        leader = _SplitStubWorker(is_leader=True)
+        twin = _SplitStubWorker(is_leader=False)
+        assert leader.finish_train_step_presharded()["is_replica_leader"] is True
+        result = twin.finish_train_step_presharded()
+        assert result["is_replica_leader"] is False
+        # backend payload passes through untouched
+        assert result["global_loss"] == 1.0
+
+    def test_abort_forwards(self):
+        w = _SplitStubWorker()
+        w.abort_train_step_presharded()
+        assert w.calls == [("abort",)]
+
+
+def _make_tq_policy() -> tuple[TQPolicy, MagicMock]:
+    """Bare TQPolicy with the attributes the split fan-out touches."""
+    p = object.__new__(TQPolicy)
+    p.cfg = {"train_global_batch_size": 8, "train_micro_batch_size": 2}
+    p.flops_tracker = None
+    wg = MagicMock()
+    wg.run_all_workers_single_data.return_value = ["f0", "f1"]
+    p.worker_group = wg
+    p.sharding_annotations = MagicMock()
+    p.sharding_annotations.get_axis_size.return_value = 2
+    return p, wg
+
+
+class TestTQPolicySplitFanout:
+    def test_begin_consumes_single_data_futures_with_ray_get(self):
+        """run_all_workers_single_data returns plain ObjectRefs, not a
+        MultiWorkerFuture — the fan-out must ray.get them (PR #2683
+        review; first execution of this path raised AttributeError)."""
+        p, wg = _make_tq_policy()
+        with patch("nemo_rl.models.policy.tq_policy.ray") as mock_ray:
+            p.begin_train_step(loss_fn="LF")
+        wg.run_all_workers_single_data.assert_called_once_with(
+            "begin_train_step_presharded", loss_fn="LF", gbs=8, mbs=2
+        )
+        mock_ray.get.assert_called_once_with(["f0", "f1"])
+        wg.get_all_worker_results.assert_not_called()
+
+    def test_train_microbatches_from_meta_dispatches_and_returns_none(self):
+        p, wg = _make_tq_policy()
+        meta = _meta()
+        with (
+            patch.object(TQPolicy, "_stamp_pad_seqlen"),
+            patch.object(TQPolicy, "_packing_args", return_value=(None, None)),
+            patch(
+                "nemo_rl.models.policy.tq_policy.shard_meta_for_dp",
+                return_value=([meta, meta], None),
+            ),
+        ):
+            out = p.train_microbatches_from_meta(meta)
+        assert out is None
+        assert (
+            wg.run_all_workers_sharded_data.call_args.args[0]
+            == "train_microbatch_presharded"
+        )
+        # sharded dispatch returns a MultiWorkerFuture → waited via
+        # get_all_worker_results (unlike the single-data fan-outs)
+        wg.get_all_worker_results.assert_called_once()
+
+    def test_finish_dedupes_replica_twins(self):
+        """TP/CP twins return identical metric copies; aggregating without
+        the is_replica_leader filter inflates every per-token metric."""
+
+        def _result(leader: bool) -> dict:
+            return {
+                "global_loss": 1.0,
+                "grad_norm": 0.5,
+                "all_mb_metrics": {"loss": [0.1]},
+                "is_replica_leader": leader,
+            }
+
+        p, wg = _make_tq_policy()
+        with patch("nemo_rl.models.policy.tq_policy.ray") as mock_ray:
+            # 2 DP leaders + 2 TP twins
+            mock_ray.get.return_value = [
+                _result(True),
+                _result(False),
+                _result(True),
+                _result(False),
+            ]
+            out = p.finish_train_step()
+        assert out["all_mb_metrics"]["loss"] == [0.1, 0.1]  # twins dropped
+        # _aggregate_train_results surfaces global_loss under "loss"
+        assert out["loss"] == 1.0
+
+    def test_abort_consumes_single_data_futures_with_ray_get(self):
+        p, wg = _make_tq_policy()
+        with patch("nemo_rl.models.policy.tq_policy.ray") as mock_ray:
+            p.abort_train_step()
+        wg.run_all_workers_single_data.assert_called_once_with(
+            "abort_train_step_presharded"
+        )
+        mock_ray.get.assert_called_once_with(["f0", "f1"])


### PR DESCRIPTION
> 📚 **Stacked PR** — 3-PR async-GRPO split-API series (top → bottom):
> - #2700 — SingleController streaming train_pump (split-API consumer)
> - #2692 — DTensor v1/v2 split-API + PolicyTrainerActor
> - 👉 **#2683** — Megatron split-API train-step state machine ← *you are here*
> - base: `main`
>
> *Stack-aware base retargeting is unavailable for fork PRs (gh-stack limitation); manual header. Locally rebased so each layer's branch contains its parents' commits — but GitHub's "Files changed" shows cumulative diff. Per-layer scope: read commits authored on this branch.*

---



Adds begin_train_step / train_microbatch / finish_train_step / abort_train_step on MegatronPolicyWorkerImpl, mirroring the DTensor v1/v2 implementations but adapted for mcore's contiguous grad bucket + pipeline-schedule reduce path.

Mechanism:
- begin_train_step: zero_grad_buffer + optimizer.zero_grad, store loss_fn / gbs / mbs / local_valid_seqs/toks accumulators on _train_step_state, and null model.config.grad_sync_func (saved for restore) so the PP scheduler's direct reduce dispatch cannot bypass no_sync.
- train_microbatch(data): wrap one ``megatron_forward_backward`` invocation in ``with self.model.no_sync():`` so mcore DDP hooks accumulate ``param.main_grad`` locally without dispatching the cross-DP reduce. Pass ``global_valid_seqs/toks=tensor(1.0)`` so the loss returns un-normalized sums; backward deposits raw d(sum)/dθ. Accumulate local mask sums + per-mb metrics + the total pipeline-microbatch count (for finish-time MoE aux-loss scaling).
- finish_train_step: all_reduce mask sums to get true N (toks for TOKEN_LEVEL loss, seqs for SEQUENCE_LEVEL), call self.model.scale_gradients(1/N), then the one true cross-DP reduce via start_grad_sync + finish_grad_sync, optimizer.step (clips internally), restore grad_sync_func, scheduler.step(increment=gbs). Rescale per-mb metrics by 1/N (linear-in-1/N math), aggregate, surface global counts.
- abort_train_step: restore grad_sync_func, zero_grad_buffer + zero_grad, drop state. ``trainer_version`` unchanged.

Sync ``train()`` is left untouched.

Includes CPU unit tests at tests/unit/models/policy/test_megatron_split_state.py covering the lifecycle and call-order invariants (no_sync wrap, grad_sync_func save/restore, mask-sum accumulation, N selection by loss_type, abort idempotence, MoE scaling). Marked pytest.mark.mcore so they run only in mcore-enabled CI containers.

# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...