### PR TITLE
feat(policy): split-API train-step state machine on DTensor v1/v2

### DIFF
--- a/nemo_rl/data_plane/worker_mixin.py
+++ b/nemo_rl/data_plane/worker_mixin.py
@@ -505,3 +505,82 @@ class TQWorkerMixin:
             tq_field="reference_policy_logprobs",
         )
         del result
+
+    # ── split-API entrypoints (SC async path) ──────────────────────────────
+    #
+    # The split path lets SingleController drive forward/backward per
+    # microbatch (or per pipeline-batch on Megatron) without stepping the
+    # optimizer until a full logical batch has accumulated. Backend
+    # methods (``begin_train_step``, ``train_microbatch``,
+    # ``finish_train_step``, ``abort_train_step``) own the train-step
+    # state machine; this mixin just gates them on TQ-presharded data.
+
+    @wrap_with_nvtx_name("policy_worker/begin_train_step_presharded")
+    def begin_train_step_presharded(
+        self,
+        step_id: str,
+        loss_fn: Any,
+        gbs: Optional[int] = None,
+        mbs: Optional[int] = None,
+    ) -> None:
+        """Open a logical train step. No fetch — pure lifecycle.
+
+        The backend stores ``step_id`` / ``loss_fn`` / ``gbs`` / ``mbs``,
+        clears gradients, and initialises accumulators for
+        ``local_valid_seqs`` / ``local_valid_toks`` and any per-microbatch
+        metrics. Optimizer state is untouched here.
+        """
+        self.begin_train_step(  # type: ignore[attr-defined]
+            step_id=step_id,
+            loss_fn=loss_fn,
+            gbs=gbs,
+            mbs=mbs,
+        )
+
+    @wrap_with_nvtx_name("policy_worker/train_microbatch_presharded")
+    def train_microbatch_presharded(
+        self,
+        step_id: str,
+        meta: "KVBatchMeta",
+    ) -> dict[str, Any]:
+        """Per-rank microbatch entrypoint. Fetch → packing prep → forward+backward.
+
+        Gradients accumulate into ``.grad`` across calls; no
+        ``optimizer.step`` here. Returns per-microbatch metrics (loss,
+        local_valid_*); the backend folds them into the step accumulator
+        and the caller may surface them for diagnostics.
+        """
+        data = self._fetch(meta)
+        data = self._attach_or_repack_pack_metadata(data, meta)
+        return self.train_microbatch(  # type: ignore[attr-defined]
+            step_id=step_id,
+            data=data,
+        )
+
+    @wrap_with_nvtx_name("policy_worker/finish_train_step_presharded")
+    def finish_train_step_presharded(
+        self,
+        step_id: str,
+    ) -> dict[str, Any]:
+        """Close a logical train step. No fetch — pure lifecycle.
+
+        Backend all-reduces accumulated ``local_valid_seqs/toks``,
+        rescales gradients to the final global normalization, runs grad
+        clip, steps the optimizer + scheduler, then zeros gradients.
+        Returns the aggregated step result (``loss``, ``grad_norm``,
+        ``all_mb_metrics``, …).
+        """
+        return self.finish_train_step(step_id=step_id)  # type: ignore[attr-defined]
+
+    @wrap_with_nvtx_name("policy_worker/abort_train_step_presharded")
+    def abort_train_step_presharded(
+        self,
+        step_id: str,
+    ) -> None:
+        """Discard partial train-step state without stepping the optimizer.
+
+        Used when SC decides the logical batch will not complete (e.g.
+        weight-sync triggered mid-step). Backend drops accumulators and
+        zeros gradients.
+        """
+        self.abort_train_step(step_id=step_id)  # type: ignore[attr-defined]

--- a/nemo_rl/models/policy/policy_trainer_actor.py
+++ b/nemo_rl/models/policy/policy_trainer_actor.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""PolicyTrainerActor: Ray actor wrapper around :class:`TQPolicy`.
+
+SingleController is a CPU-only Ray actor that drives the RL training loop via
+``.remote(...)`` calls on a trainer handle. Production ``TQPolicy`` is a
+driver-side controller, not a Ray actor — so SC cannot call it directly.
+
+``PolicyTrainerActor`` is the boundary. It owns a ``TQPolicy`` instance inside
+its own actor process (CPU-only — the GPUs live on the worker_group actors
+that ``TQPolicy`` fans out to). It exposes only the SC-facing surface:
+
+  - ``train_from_meta(meta)``                — full-step training (sync proxy).
+  - ``prepare_logprobs_from_meta(meta)``     — prev_lp + ref_lp via TQ.
+  - ``begin_train_step``                     — open a split-API step.
+  - ``train_microbatch_from_meta``           — one microbatch worth of fwd+bwd.
+  - ``finish_train_step``                    — close the step, opt.step.
+  - ``abort_train_step``                     — drop partial state.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import ray
+
+from nemo_rl.algorithms.loss.interfaces import LossFunction
+from nemo_rl.data_plane import KVBatchMeta
+from nemo_rl.models.policy.tq_policy import TQPolicy
+
+
+@ray.remote(num_cpus=1, num_gpus=0)  # pragma: no cover
+class PolicyTrainerActor:
+    """Ray actor that owns a ``TQPolicy`` and exposes the SC-facing API.
+
+    Construction args mirror ``TQPolicy.__init__`` (``dp_cfg`` is required;
+    everything else is forwarded). ``loss_fn`` / ``train_global_batch_size``
+    / ``train_micro_batch_size`` are stored on the actor and used by every
+    ``train_from_meta`` invocation, so SC does not need to know them.
+
+    ``trainer_version`` advances by one on every successful ``train_from_meta``
+    OR ``finish_train_step``. SC reads it to drive its weight-sync barrier.
+    """
+
+    def __init__(
+        self,
+        *policy_args: Any,
+        dp_cfg: dict[str, Any],
+        loss_fn: LossFunction,
+        train_global_batch_size: Optional[int] = None,
+        train_micro_batch_size: Optional[int] = None,
+        tq_partition_id: str = "train",
+        **policy_kwargs: Any,
+    ) -> None:
+        self._policy: TQPolicy = TQPolicy(
+            *policy_args,
+            dp_cfg=dp_cfg,
+            tq_partition_id=tq_partition_id,
+            **policy_kwargs,
+        )
+        self._loss_fn = loss_fn
+        self._train_global_batch_size = train_global_batch_size
+        self._train_micro_batch_size = train_micro_batch_size
+        self._trainer_version: int = 0
+
+    # ── lifecycle ──────────────────────────────────────────────────────────
+
+    def shutdown(self) -> bool:
+        return self._policy.shutdown()
+
+    def ping(self) -> dict[str, Any]:
+        return {
+            "alive": True,
+            "trainer_version": self._trainer_version,
+        }
+
+    # ── logprob preparation ────────────────────────────────────────────────
+
+    def prepare_logprobs_from_meta(self, meta: KVBatchMeta) -> None:
+        """Compute prev_lp + ref_lp and commit them to TQ under ``meta.sample_ids``.
+
+        Workers write the per-token tensors back through TQ directly (no Ray
+        return payload); this just dispatches and waits.
+        """
+        self._policy.get_logprobs_from_meta(meta)
+        self._policy.get_reference_policy_logprobs_from_meta(meta)
+
+    # ── current full-step training ─────────────────────────────────────────
+
+    def train_from_meta(self, meta: KVBatchMeta) -> dict[str, Any]:
+        """Full-step training proxy. Returns SC-shape dict.
+
+        Calls ``TQPolicy.train_from_meta`` with the actor-bound ``loss_fn`` /
+        ``gbs`` / ``mbs``, then folds the aggregated result into the shape SC
+        expects (``loss``, ``trainer_version``, ``clear_samples``). Every
+        successful call advances ``trainer_version`` by one.
+        """
+        result = self._policy.train_from_meta(
+            meta,
+            loss_fn=self._loss_fn,
+            gbs=self._train_global_batch_size,
+            mbs=self._train_micro_batch_size,
+        )
+        self._trainer_version += 1
+        return {
+            **result,
+            "trainer_version": self._trainer_version,
+            "clear_samples": True,
+        }
+
+    # ── split API ──────────────────────────────────────────────────────────
+    #
+    # ``trainer_version`` only advances at :meth:`finish_train_step`. The
+    # backend state machine lives on the workers (see ``TQWorkerMixin`` and
+    # the per-backend ``begin/microbatch/finish/abort_train_step`` methods).
+    # This actor just forwards to ``TQPolicy``.
+
+    def begin_train_step(
+        self,
+        step_id: str,
+        loss_fn: Optional[LossFunction] = None,
+        train_global_batch_size: Optional[int] = None,
+        train_micro_batch_size: Optional[int] = None,
+    ) -> None:
+        self._policy.begin_train_step(
+            step_id=step_id,
+            loss_fn=loss_fn or self._loss_fn,
+            gbs=train_global_batch_size or self._train_global_batch_size,
+            mbs=train_micro_batch_size or self._train_micro_batch_size,
+        )
+
+    def train_microbatch_from_meta(
+        self,
+        step_id: str,
+        meta: KVBatchMeta,
+    ) -> dict[str, Any]:
+        return self._policy.train_microbatch_from_meta(
+            step_id=step_id,
+            meta=meta,
+        )
+
+    def finish_train_step(self, step_id: str) -> dict[str, Any]:
+        result = self._policy.finish_train_step(step_id=step_id)
+        self._trainer_version += 1
+        return {
+            **result,
+            "trainer_version": self._trainer_version,
+            "clear_samples": True,
+        }
+
+    def abort_train_step(self, step_id: str) -> None:
+        self._policy.abort_train_step(step_id=step_id)

--- a/nemo_rl/models/policy/policy_trainer_actor.py
+++ b/nemo_rl/models/policy/policy_trainer_actor.py
@@ -22,7 +22,8 @@ its own actor process (CPU-only — the GPUs live on the worker_group actors
 that ``TQPolicy`` fans out to). It exposes only the SC-facing surface:
 
   - ``train_from_meta(meta)``                — full-step training (sync proxy).
-  - ``prepare_logprobs_from_meta(meta)``     — prev_lp + ref_lp via TQ.
+  - ``prepare_logprobs_from_meta(meta, *, refresh_policy_logprobs=False,
+    refresh_reference_logprobs=False)`` — refresh prev_lp / ref_lp into TQ.
   - ``begin_train_step``                     — open a split-API step.
   - ``train_microbatch_from_meta``           — one microbatch worth of fwd+bwd.
   - ``finish_train_step``                    — close the step, opt.step.
@@ -87,14 +88,30 @@ class PolicyTrainerActor:
 
     # ── logprob preparation ────────────────────────────────────────────────
 
-    def prepare_logprobs_from_meta(self, meta: KVBatchMeta) -> None:
-        """Compute prev_lp + ref_lp and commit them to TQ under ``meta.sample_ids``.
+    def prepare_logprobs_from_meta(
+        self,
+        meta: KVBatchMeta,
+        *,
+        refresh_policy_logprobs: bool = False,
+        refresh_reference_logprobs: bool = False,
+    ) -> None:
+        """Refresh policy and/or reference logprobs and commit them to TQ.
 
+        SC decides which fields to refresh based on its own config
+        (``advantage_policy_logprobs_field`` / ``advantage_reference_logprobs_field``).
         Workers write the per-token tensors back through TQ directly (no Ray
-        return payload); this just dispatches and waits.
+        return payload); this just dispatches and waits. No-op if both flags
+        are False.
+
+        NOTE: inlined here rather than delegating to
+        ``TQPolicy.prepare_logprobs_from_meta`` so this PR is self-contained.
+        Once the TQPolicy helper from #2700 lands together with this PR, this
+        can collapse to a one-line delegate.
         """
-        self._policy.get_logprobs_from_meta(meta)
-        self._policy.get_reference_policy_logprobs_from_meta(meta)
+        if refresh_policy_logprobs:
+            self._policy.get_logprobs_from_meta(meta)
+        if refresh_reference_logprobs:
+            self._policy.get_reference_policy_logprobs_from_meta(meta)
 
     # ── current full-step training ─────────────────────────────────────────
 

--- a/nemo_rl/models/policy/tq_policy.py
+++ b/nemo_rl/models/policy/tq_policy.py
@@ -438,3 +438,128 @@ class TQPolicy(Policy):
                 warnings.warn(f"Error getting theoretical flops: {e}")
 
         return aggregated_results
+
+    # ── split-API fanout (SC async path) ───────────────────────────────────
+    #
+    # Counterpart to :meth:`train_from_meta`, exposed to ``PolicyTrainerActor``
+    # so :class:`SingleControllerActor` can stream microbatches without
+    # forcing a full-step optimizer.step on every dispatch.
+    #
+    # Lifecycle:
+    #   begin_train_step                  — open step; broadcast loss_fn/gbs/mbs
+    #   train_microbatch_from_meta (N×)   — DP-sharded fwd/bwd, grads accumulate
+    #   finish_train_step                 — all_reduce + opt.step + sched.step
+    #   abort_train_step                  — drop accumulators, no opt.step
+    #
+    # ``train_from_meta`` is unchanged and remains the sync entrypoint.
+
+    def begin_train_step(
+        self,
+        step_id: str,
+        loss_fn: LossFunction,
+        gbs: Optional[int] = None,
+        mbs: Optional[int] = None,
+    ) -> None:
+        """Open a logical train step on every worker."""
+        batch_size = gbs or self.cfg["train_global_batch_size"]
+        micro_batch_size = mbs or self.cfg["train_micro_batch_size"]
+        if self.flops_tracker is not None:
+            self.flops_tracker.reset()
+        futures = self.worker_group.run_all_workers_single_data(
+            "begin_train_step_presharded",
+            step_id=step_id,
+            loss_fn=loss_fn,
+            gbs=batch_size,
+            mbs=micro_batch_size,
+        )
+        self.worker_group.get_all_worker_results(futures)
+
+    def train_microbatch_from_meta(
+        self,
+        step_id: str,
+        meta: KVBatchMeta,
+        timer: Optional[Timer] = None,
+    ) -> dict[str, Any]:
+        """Dispatch one microbatch (DP-sharded) into an open train step.
+
+        Mirrors the sharding logic of :meth:`train_from_meta` but without
+        a logical-batch sizing constraint: this routes ``meta`` to DP
+        ranks and runs forward+backward; gradients accumulate in
+        ``.grad``. The optimizer step happens at :meth:`finish_train_step`.
+        """
+        self._stamp_pad_seqlen(meta)
+        spa, dba = self._packing_args("train_mb_tokens")
+        train_meta = replace(
+            meta,
+            fields=list(DP_TRAIN_FIELDS),
+            task_name="train",
+        )
+        with timer.time("policy_training/shard_meta") if timer else nullcontext():
+            dp_metas, _ = shard_meta_for_dp(
+                train_meta,
+                dp_world=self.sharding_annotations.get_axis_size("data_parallel"),
+                batch_size=None,
+                sequence_packing_args=spa,
+                dynamic_batching_args=dba,
+            )
+
+        if self.flops_tracker is not None:
+            for m in dp_metas:
+                self.flops_tracker.track_batch(list(m.sequence_lengths or []))
+
+        with (
+            timer.time("policy_training/submit_microbatch_futures")
+            if timer
+            else nullcontext()
+        ):
+            futures = self.worker_group.run_all_workers_sharded_data(
+                "train_microbatch_presharded",
+                meta=dp_metas,
+                in_sharded_axes=["data_parallel"],
+                replicate_on_axes=[
+                    "context_parallel",
+                    "tensor_parallel",
+                    "pipeline_parallel",
+                ],
+                output_is_replicated=[
+                    "context_parallel",
+                    "tensor_parallel",
+                    "pipeline_parallel",
+                ],
+                common_kwargs={"step_id": step_id},
+            )
+        results = self.worker_group.get_all_worker_results(futures)
+        # Per-microbatch metrics: pass through DP-rank-0 by convention,
+        # backend may aggregate later if needed. Surface as-is for now.
+        return results[0] if results else {}
+
+    def finish_train_step(self, step_id: str) -> dict[str, Any]:
+        """Close an open train step: all_reduce, rescale, optimizer.step.
+
+        Aggregates per-rank step results into the same shape as
+        :meth:`train_from_meta` so callers don't have to special-case
+        the split path.
+        """
+        futures = self.worker_group.run_all_workers_single_data(
+            "finish_train_step_presharded",
+            step_id=step_id,
+        )
+        results = self.worker_group.get_all_worker_results(futures)
+        aggregated_results = _aggregate_train_results(results)
+
+        if self.flops_tracker is not None:
+            aggregated_results["total_flops"] = self.flops_tracker.total_flops
+            aggregated_results["num_ranks"] = self.worker_group.cluster.world_size()
+
+        return aggregated_results
+
+    def abort_train_step(self, step_id: str) -> None:
+        """Drop partial step state on every worker. No optimizer.step."""
+        futures = self.worker_group.run_all_workers_single_data(
+            "abort_train_step_presharded",
+            step_id=step_id,
+        )
+        self.worker_group.get_all_worker_results(futures)
+
+        if self.flops_tracker is not None:
+            self.flops_tracker.reset()

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -168,6 +168,11 @@ def get_cpu_state_dict(
 class DTensorPolicyWorkerImpl(
     TQWorkerMixin, AbstractPolicyWorker, ColocatablePolicyInterface
 ):
+    # Holds split-API train-step state between begin/finish or begin/abort;
+    # None when no step is open. Declared at class level so the ``= None``
+    # writes in finish/abort type-check.
+    _train_step_state: Optional[dict[str, Any]] = None
+
     def __repr__(self) -> str:
         """Customizes the actor's prefix in the Ray logs.
 
@@ -972,6 +977,475 @@ class DTensorPolicyWorkerImpl(
             }
 
             return metrics
+
+    # ── split-API train-step state machine (SingleController async path) ──
+    #
+    # ``train()`` above is the sync full-step path: it computes
+    # ``global_valid_seqs/toks`` up-front, then runs the microbatch loop,
+    # then steps the optimizer. SC drives an async path where microbatches
+    # arrive one at a time, before the logical batch is complete — so we
+    # cannot all_reduce the global counts at the top.
+    #
+    # Trick: ``masked_mean(values, mask, N) = sum(values*mask) / (N+ε)`` is
+    # linear in 1/N. If every microbatch's forward passes ``N=tensor(1.0)``
+    # for both ``global_valid_seqs`` and ``global_valid_toks``, the per-mb
+    # backward deposits raw ``d(sum)/dθ`` (un-normalized) into ``.grad``.
+    # PyTorch accumulates these across microbatches naturally. At finish,
+    # we all_reduce the local mask sums to get the true N, then rescale
+    # every ``p.grad`` by ``1/N`` (a single scalar — see HANDOFF.md /
+    # discussion notes). Crucially, the rescale is loss-type-agnostic:
+    # whatever constant the loss-fn multiplies into the normalizer
+    # internally (``N``, ``N/2``, …) cancels out of the final grad
+    # because we passed ``1`` and divide by the true ``N``.
+    #
+    # State lives on ``self._train_step_state`` (None when no step open).
+
+    def _split_step_state_init(
+        self,
+        step_id: str,
+        loss_fn: LossFunction,
+        gbs: Optional[int],
+        mbs: Optional[int],
+    ) -> dict[str, Any]:
+        return {
+            "step_id": step_id,
+            "loss_fn": loss_fn,
+            "gbs": gbs or self.cfg["train_global_batch_size"],
+            "mbs": mbs or self.cfg["train_micro_batch_size"],
+            "local_valid_seqs": torch.zeros((), dtype=torch.float64, device="cuda"),
+            "local_valid_toks": torch.zeros((), dtype=torch.float64, device="cuda"),
+            "mb_losses": [],
+            "all_mb_metrics": [],
+            "num_microbatches": 0,
+        }
+
+    def _assert_step_open(self, step_id: str) -> dict[str, Any]:
+        state = getattr(self, "_train_step_state", None)
+        if state is None:
+            raise RuntimeError(
+                f"no train step open; begin_train_step({step_id!r}) must be called first"
+            )
+        if state["step_id"] != step_id:
+            raise RuntimeError(
+                f"step_id mismatch: open step is {state['step_id']!r}, got {step_id!r}"
+            )
+        return state
+
+    @wrap_with_nvtx_name("dtensor_policy_worker/begin_train_step")
+    def begin_train_step(
+        self,
+        step_id: str,
+        loss_fn: LossFunction,
+        gbs: Optional[int] = None,
+        mbs: Optional[int] = None,
+    ) -> None:
+        existing = getattr(self, "_train_step_state", None)
+        if existing is not None:
+            raise RuntimeError(
+                f"train step {existing['step_id']!r} is already open; "
+                f"call finish_train_step or abort_train_step before begin"
+            )
+        self.model.train()
+        self.optimizer.zero_grad()
+        self._train_step_state = self._split_step_state_init(
+            step_id=step_id, loss_fn=loss_fn, gbs=gbs, mbs=mbs
+        )
+
+    @wrap_with_nvtx_name("dtensor_policy_worker/train_microbatch")
+    def train_microbatch(
+        self,
+        step_id: str,
+        data: BatchedDataDict[Any],
+    ) -> dict[str, Any]:
+        """Run forward+backward over every bin in ``data`` under the open step.
+
+        ``data`` is one prompt-group's worth of post-fetch BatchedDataDict.
+        Under seq-packing or dynamic batching it may decompose into multiple
+        bins; we iterate and forward+backward each. Gradients accumulate
+        across bins and across calls until ``finish_train_step`` does the
+        single 1/N rescale.
+
+        DP rank bin-count synchronization: under seq-packing, packing
+        density varies per rank, so DP ranks can end up with different bin
+        counts. We all_reduce the per-rank count to MAX and pad with
+        dummy bins (loss zeroed before backward) on under-counted ranks —
+        mirrors the sync ``train()`` pattern. Without padding, NCCL
+        collectives inside a microbatch's forward desync across DP ranks.
+        """
+        state = self._assert_step_open(step_id)
+        loss_fn = state["loss_fn"]
+        mbs = state["mbs"]
+
+        data.to("cuda")
+
+        # Choose iterator + compute padding for DP rank bin-count sync.
+        dummy_iterator: Iterable[Any] = iter([])
+        if self.cfg["dynamic_batching"]["enabled"]:
+            mb_iterator = data.make_microbatch_iterator_with_dynamic_shapes()
+            iterator_len = data.get_microbatch_iterator_dynamic_shapes_len()
+            max_batch_ct = torch.tensor([iterator_len], device="cuda")
+            torch.distributed.all_reduce(
+                max_batch_ct, op=torch.distributed.ReduceOp.MAX
+            )
+            dummy_batch_ct = int(max_batch_ct.item()) - iterator_len
+            if dummy_batch_ct > 0:
+                dummy_iterator = itertools.islice(
+                    itertools.cycle(
+                        data.make_microbatch_iterator_with_dynamic_shapes()
+                    ),
+                    dummy_batch_ct,
+                )
+        elif self.enable_seq_packing:
+            mb_iterator = data.make_microbatch_iterator_for_packable_sequences()
+            iterator_len, _ = data.get_microbatch_iterator_for_packable_sequences_len()
+            max_batch_ct = torch.tensor([iterator_len], device="cuda")
+            torch.distributed.all_reduce(
+                max_batch_ct, op=torch.distributed.ReduceOp.MAX
+            )
+            dummy_batch_ct = int(max_batch_ct.item()) - iterator_len
+            if dummy_batch_ct > 0:
+                dummy_iterator = itertools.islice(
+                    itertools.cycle(
+                        data.make_microbatch_iterator_for_packable_sequences()
+                    ),
+                    dummy_batch_ct,
+                )
+        else:
+            mb_iterator = data.make_microbatch_iterator(mbs)
+            iterator_len = max(1, data.size // mbs)
+
+        # Placeholder N: loss returns un-normalized sums per bin. Finish
+        # does the global 1/N rescale (linear-in-1/N math).
+        placeholder_n = torch.tensor(1.0, device="cuda")
+
+        call_local_seqs = torch.zeros((), dtype=torch.float64, device="cuda")
+        call_local_toks = torch.zeros((), dtype=torch.float64, device="cuda")
+
+        for mb_idx, bin_data in enumerate(itertools.chain(mb_iterator, dummy_iterator)):
+            is_dummy = mb_idx >= iterator_len
+            seqs_mb, toks_mb, loss_item, loss_metrics = self._split_train_one_bin(
+                bin_data, loss_fn, placeholder_n, is_dummy=is_dummy
+            )
+            if not is_dummy:
+                call_local_seqs = call_local_seqs + seqs_mb
+                call_local_toks = call_local_toks + toks_mb
+                if int(seqs_mb.item()) > 0:
+                    state["mb_losses"].append(loss_item)
+                    state["all_mb_metrics"].append(loss_metrics)
+                state["num_microbatches"] += 1
+
+        state["local_valid_seqs"] = state["local_valid_seqs"] + call_local_seqs
+        state["local_valid_toks"] = state["local_valid_toks"] + call_local_toks
+
+        return {
+            "local_valid_seqs_mb": float(call_local_seqs.item()),
+            "local_valid_toks_mb": float(call_local_toks.item()),
+            "num_bins": int(iterator_len),
+        }
+
+    def _split_train_one_bin(
+        self,
+        bin_data: BatchedDataDict[Any],
+        loss_fn: LossFunction,
+        placeholder_n: torch.Tensor,
+        *,
+        is_dummy: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor, float, dict[str, Any]]:
+        """One bin's forward + loss(N=1) + backward.
+
+        Returns ``(local_valid_seqs, local_valid_toks, loss_item, metrics)``.
+        For dummy bins (``is_dummy=True``) the loss is multiplied by 0
+        before backward, so neither gradients nor mask counts accumulate.
+        """
+        sequence_dim = 1
+        seq_len = bin_data.get("input_ids").shape[sequence_dim]
+        for k, v in bin_data.items():
+            if torch.is_tensor(v) and len(v.shape) > 1:
+                assert v.shape[sequence_dim] == seq_len, (
+                    f"Dim 1 must be the sequence dim, expected dim 1={seq_len} but got shape {v.shape}"
+                )
+
+        # Mask sums — only meaningful on real bins.
+        if not is_dummy:
+            sample_mask = bin_data["sample_mask"]
+            local_valid_seqs_mb = torch.sum(sample_mask).to(torch.float64)
+            if "token_mask" in bin_data:
+                token_mask = bin_data["token_mask"]
+                local_valid_toks_mb = torch.sum(
+                    token_mask[:, 1:] * sample_mask.unsqueeze(-1)
+                ).to(torch.float64)
+            else:
+                local_valid_toks_mb = (
+                    local_valid_seqs_mb * bin_data["input_ids"].shape[1]
+                )
+        else:
+            local_valid_seqs_mb = torch.zeros((), dtype=torch.float64, device="cuda")
+            local_valid_toks_mb = torch.zeros((), dtype=torch.float64, device="cuda")
+
+        with torch.autocast(device_type="cuda", dtype=self.dtype):
+            if self.enable_seq_packing:
+                input_ids = bin_data.get("input_ids").cuda()
+                input_ids, position_ids, _ = pack_sequences(
+                    input_ids=input_ids,
+                    input_lengths=bin_data["input_lengths"],
+                    packed_sequence_size=[len(bin_data["input_lengths"])],
+                    padding_value=self.tokenizer.eos_token_id,
+                    return_attention_mask=False,
+                    min_seq_len=self.cfg["sequence_packing"]["train_mb_tokens"],
+                )
+                seq_len = input_ids.shape[1]
+                attention_mask = None
+                flash_attn_kwargs = get_flash_attention_kwargs(
+                    input_lengths=bin_data["input_lengths"],
+                )
+            else:
+                input_ids = bin_data.get("input_ids").cuda()
+                batch_size, seq_len = input_ids.shape
+                if self.cfg["dtensor_cfg"]["sequence_parallel"] or self.cp_size > 1:
+                    attention_mask = None
+                else:
+                    attention_mask = torch.ones(
+                        (batch_size, seq_len),
+                        dtype=torch.bool,
+                        device=input_ids.device,
+                    )
+                position_ids = torch.arange(seq_len, device=input_ids.device).repeat(
+                    batch_size, 1
+                )
+                flash_attn_kwargs = {}
+
+            vlm_kwargs = bin_data.get_multimodal_dict(
+                as_tensors=True, device=input_ids.device
+            )
+            if len(vlm_kwargs) > 0:
+                position_ids = None
+                assert not self.cfg["dtensor_cfg"]["sequence_parallel"], (
+                    "Sequence parallel is not supported with multimodal"
+                )
+
+        context_parallel_ctx = None
+        if self.cp_size > 1:
+            assert len(vlm_kwargs) == 0, (
+                "multimodal kwargs are not supported for context parallel"
+            )
+            seq_index = torch.arange(seq_len, device=input_ids.device).repeat(1, 1)
+            cp_buffers = [input_ids, position_ids, seq_index]
+            context_parallel_ctx = self.create_context_parallel_ctx(
+                cp_mesh=self.cp_mesh,
+                cp_buffers=cp_buffers,
+                cp_seq_dims=[sequence_dim] * len(cp_buffers),
+                cp_no_restore_buffers=set(cp_buffers),
+            )
+
+        with DTensorPolicyWorker.train_context(context_parallel_ctx):
+            with torch.autocast(device_type="cuda", dtype=self.dtype):
+                model_args = dict(
+                    input_ids=input_ids,
+                    attention_mask=attention_mask,
+                    position_ids=position_ids,
+                    use_cache=False,
+                    flash_attn_kwargs=flash_attn_kwargs,
+                    **vlm_kwargs,
+                )
+                if self.is_gemma3 and "token_type_ids" not in model_args:
+                    model_args["token_type_ids"] = torch.zeros_like(input_ids)
+                if self._is_reward_model:
+                    assert not flash_attn_kwargs
+                    del model_args["flash_attn_kwargs"]
+                if len(vlm_kwargs) > 0:
+                    del model_args["flash_attn_kwargs"]
+
+                outputs = self.model(**model_args)
+
+            if not hasattr(outputs, "logits"):
+                logits = self.model.lm_head(outputs.last_hidden_state)
+            else:
+                logits = outputs.logits
+            del outputs
+
+            logits = self._apply_temperature_scaling(logits)
+
+            if self.cp_size > 1:
+                seq_index_dtensor = (
+                    DTensor.from_local(
+                        seq_index,
+                        device_mesh=self.cp_mesh,
+                        placements=[Shard(1)],
+                    )
+                    .full_tensor()
+                    .squeeze(0)
+                )
+                bin_data["seq_index"] = seq_index_dtensor
+                for tensor_name in bin_data:
+                    current_tensor = bin_data[tensor_name]
+                    for buffer in cp_buffers:
+                        if current_tensor is buffer:
+                            assert type(current_tensor) == torch.Tensor
+                            bin_data[tensor_name] = DTensor.from_local(
+                                current_tensor,
+                                device_mesh=self.cp_mesh,
+                                placements=[Shard(sequence_dim)],
+                            )
+                            break
+                if isinstance(logits, DTensor):
+                    assert (
+                        logits.device_mesh.ndim == 1
+                        and logits.device_mesh.mesh_dim_names[0] == "tp"
+                    ), "logits must be tp sharded"
+                    logits = DTensor.from_local(
+                        logits.to_local(),
+                        device_mesh=self.device_mesh[("cp", "tp")],
+                        placements=[Shard(sequence_dim), Shard(-1)],
+                    )
+                else:
+                    logits = DTensor.from_local(
+                        logits,
+                        device_mesh=self.device_mesh[("cp", "tp")],
+                        placements=[Shard(sequence_dim), Shard(-1)],
+                    )
+
+            prepare_loss_input_wrapped = partial(
+                prepare_loss_input, sampling_params=self.sampling_params
+            )
+            if self.enable_seq_packing:
+                loss_fn_ = SequencePackingLossWrapper(
+                    loss_fn=loss_fn,
+                    prepare_fn=prepare_loss_input_wrapped,
+                    cu_seqlens_q=flash_attn_kwargs.cu_seqlens_q,
+                    cu_seqlens_q_padded=flash_attn_kwargs.cu_seqlens_q,
+                )
+                loss, loss_metrics = loss_fn_(
+                    logits, bin_data, placeholder_n, placeholder_n
+                )
+            else:
+                loss_input, bin_data = prepare_loss_input_wrapped(
+                    logits, bin_data, loss_fn
+                )
+                loss, loss_metrics = loss_fn(
+                    data=bin_data,
+                    global_valid_seqs=placeholder_n,
+                    global_valid_toks=placeholder_n,
+                    **loss_input,
+                )
+            del logits
+
+            # Zero out dummy-bin gradients (loss is differentiable; this
+            # zeros the contribution without breaking the autograd graph).
+            if is_dummy:
+                loss = loss * 0
+
+            # FSDP averages gradients across DP+CP at backward; cancel
+            # that to a sum so per-bin contributions accumulate cleanly
+            # across bins and across calls.
+            loss *= self.dp_size * self.cp_size
+            loss.backward()
+
+        return (
+            local_valid_seqs_mb,
+            local_valid_toks_mb,
+            float(loss.item()),
+            loss_metrics,
+        )
+
+    @wrap_with_nvtx_name("dtensor_policy_worker/finish_train_step")
+    def finish_train_step(self, step_id: str) -> dict[str, Any]:
+        state = self._assert_step_open(step_id)
+        loss_fn = state["loss_fn"]
+
+        # All-reduce accumulated mask sums across DP to recover true N.
+        to_reduce = torch.stack(
+            [state["local_valid_seqs"], state["local_valid_toks"]]
+        ).to(torch.float64)
+        torch.distributed.all_reduce(to_reduce, group=self.dp_mesh.get_group())
+        global_valid_seqs = to_reduce[0]
+        global_valid_toks = to_reduce[1]
+
+        loss_type = getattr(loss_fn, "loss_type", LossType.TOKEN_LEVEL)
+        if loss_type == LossType.TOKEN_LEVEL:
+            n_true = global_valid_toks
+        else:
+            n_true = global_valid_seqs
+
+        # Avoid div-by-zero if a step ended up with no valid samples.
+        # Matches masked_mean's epsilon floor.
+        n_safe = n_true if n_true.item() > 0 else torch.tensor(1.0, device="cuda")
+        inv_n = (1.0 / n_safe).to(torch.float32)
+
+        with torch.no_grad():
+            for p in self.model.parameters():
+                if p.grad is not None:
+                    p.grad.mul_(inv_n)
+
+            grad_norm: Optional[float | torch.Tensor] = get_grad_norm(
+                self.model.parameters(),
+                dp_cp_group=self.dp_cp_mesh.get_group(),
+                tp_group=self.tp_mesh.get_group(),
+                dtype=torch.float32,
+            )
+            if self.max_grad_norm is not None:
+                clip_grad_by_total_norm_(
+                    self.model.parameters(),
+                    max_grad_norm=self.max_grad_norm,
+                    total_norm=grad_norm,
+                )
+            grad_norm = torch.tensor([grad_norm])
+
+        self.optimizer.step()
+        self.optimizer.zero_grad()
+        self.scheduler.step()
+        torch.cuda.empty_cache()
+
+        # Per-mb metrics were computed with N=1; rescale by 1/N to recover
+        # values consistent with the sync path. The same scalar applies
+        # to every entry because masked_mean is linear in 1/N. Min/max
+        # diagnostics are left alone (existing convention in train()).
+        scale = float(inv_n.item())
+        mb_metrics: dict[str, list[Any]] = defaultdict(list)
+        for m in state["all_mb_metrics"]:
+            for k, v in m.items():
+                if "_min" in k or "_max" in k:
+                    mb_metrics[k].append(v)
+                elif isinstance(v, torch.Tensor):
+                    mb_metrics[k].append((v.detach() * scale).cpu())
+                else:
+                    mb_metrics[k].append(v * scale)
+        global_valid_seqs_f = float(global_valid_seqs.item())
+        global_valid_toks_f = float(global_valid_toks.item())
+
+        # Global step loss across DP (un-normalized sums summed, then
+        # scaled once). Matches the sync path's all_reduce of losses.
+        local_loss = torch.tensor(state["mb_losses"], device="cuda").sum() * scale
+        global_loss = local_loss.detach().clone()
+        torch.distributed.all_reduce(global_loss, group=self.dp_mesh.get_group())
+
+        # Drop state before returning so a re-call to begin_train_step
+        # doesn't see a stale handle.
+        self._train_step_state = None
+
+        return {
+            "global_loss": global_loss.cpu(),
+            "grad_norm": grad_norm,
+            "rank": torch.distributed.get_rank(),
+            "gpu_name": torch.cuda.get_device_name(),
+            "model_dtype": self.dtype,
+            "all_mb_metrics": dict(mb_metrics),
+            "global_valid_seqs": global_valid_seqs_f,
+            "global_valid_toks": global_valid_toks_f,
+        }
+
+    @wrap_with_nvtx_name("dtensor_policy_worker/abort_train_step")
+    def abort_train_step(self, step_id: str) -> None:
+        state = getattr(self, "_train_step_state", None)
+        if state is None:
+            # idempotent — no open step means nothing to abort
+            return
+        if state["step_id"] != step_id:
+            raise RuntimeError(
+                f"abort_train_step({step_id!r}) does not match open step "
+                f"{state['step_id']!r}"
+            )
+        self.optimizer.zero_grad()
+        self._train_step_state = None
 
     # TODO @Rayen Tian: Related Issue: Refactor shared logic between score() and get_logprobs() (https://github.com/NVIDIA-NeMo/RL/issues/1094)
     @wrap_with_nvtx_name("dtensor_policy_worker/get_logprobs")

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -194,6 +194,11 @@ def get_train_context(
 class DTensorPolicyWorkerV2Impl(
     TQWorkerMixin, AbstractPolicyWorker, ColocatablePolicyInterface
 ):
+    # Holds split-API train-step state between begin/finish or begin/abort;
+    # None when no step is open. Declared at class level so the ``= None``
+    # writes in finish/abort type-check.
+    _train_step_state: Optional[dict[str, Any]] = None
+
     def __repr__(self) -> str:
         """Customizes the actor's prefix in the Ray logs.
 
@@ -519,6 +524,303 @@ class DTensorPolicyWorkerV2Impl(
             )
 
             return metrics
+
+    # ── split-API train-step state machine (SingleController async path) ──
+    #
+    # Mirrors the v1 implementation in ``dtensor_policy_worker.py`` but built
+    # on the v2 helpers (``LossPostProcessor``, ``get_microbatch_iterator``,
+    # ``automodel_forward_backward``, ``scale_grads_and_clip_grad_norm``).
+    #
+    # Trick: ``masked_mean(values, mask, N) = sum(values*mask)/(N+ε)`` is
+    # linear in 1/N. Each call to ``train_microbatch`` passes
+    # ``global_valid_seqs=global_valid_toks=tensor(1.0)`` to the loss so
+    # backward deposits raw ``d(sum)/dθ`` into ``.grad``. PyTorch
+    # accumulates across microbatches naturally. At finish, we all-reduce
+    # accumulated mask sums to recover true ``N``, then rescale every
+    # ``p.grad`` by ``1/N``. The choice of which N (toks vs seqs) follows
+    # ``loss_fn.loss_type``. See the v1 worker for the long-form rationale.
+
+    def _split_step_state_init(
+        self,
+        step_id: str,
+        loss_fn: LossFunction,
+        gbs: Optional[int],
+        mbs: Optional[int],
+    ) -> dict[str, Any]:
+        from nemo_rl.algorithms.loss.interfaces import (
+            LossType,
+        )  # local: avoid top-level cycle risk
+
+        sequence_dim = 1
+        loss_post_processor = LossPostProcessor(
+            loss_fn=loss_fn,
+            cfg=self.cfg,
+            device_mesh=self.device_mesh,
+            cp_mesh=self.cp_mesh,
+            tp_mesh=self.tp_mesh,
+            cp_size=self.cp_size,
+            dp_size=self.dp_size,
+            enable_seq_packing=self.enable_seq_packing,
+            sampling_params=self.sampling_params,
+        )
+
+        def train_context_fn(processed_inputs: Any) -> Any:
+            return get_train_context(
+                cp_size=self.cp_size,
+                cp_mesh=self.cp_mesh,
+                cp_buffers=processed_inputs.cp_buffers,
+                sequence_dim=sequence_dim,
+                dtype=self.dtype,
+                autocast_enabled=self.autocast_enabled,
+            )
+
+        return {
+            "step_id": step_id,
+            "loss_fn": loss_fn,
+            "loss_type": getattr(loss_fn, "loss_type", LossType.TOKEN_LEVEL),
+            "gbs": gbs or self.cfg["train_global_batch_size"],
+            "mbs": mbs or self.cfg["train_micro_batch_size"],
+            "loss_post_processor": loss_post_processor,
+            "train_context_fn": train_context_fn,
+            "sequence_dim": sequence_dim,
+            "local_valid_seqs": torch.zeros((), dtype=torch.float64, device="cuda"),
+            "local_valid_toks": torch.zeros((), dtype=torch.float64, device="cuda"),
+            "mb_losses": [],
+            "all_mb_metrics": [],
+            "num_microbatches": 0,
+        }
+
+    def _assert_step_open(self, step_id: str) -> dict[str, Any]:
+        state = getattr(self, "_train_step_state", None)
+        if state is None:
+            raise RuntimeError(
+                f"no train step open; begin_train_step({step_id!r}) must be called first"
+            )
+        if state["step_id"] != step_id:
+            raise RuntimeError(
+                f"step_id mismatch: open step is {state['step_id']!r}, got {step_id!r}"
+            )
+        return state
+
+    @wrap_with_nvtx_name("dtensor_policy_worker_v2/begin_train_step")
+    def begin_train_step(
+        self,
+        step_id: str,
+        loss_fn: LossFunction,
+        gbs: Optional[int] = None,
+        mbs: Optional[int] = None,
+    ) -> None:
+        existing = getattr(self, "_train_step_state", None)
+        if existing is not None:
+            raise RuntimeError(
+                f"train step {existing['step_id']!r} is already open; "
+                f"call finish_train_step or abort_train_step before begin"
+            )
+        self.model.train()
+        self.optimizer.zero_grad()
+        self._train_step_state = self._split_step_state_init(
+            step_id=step_id, loss_fn=loss_fn, gbs=gbs, mbs=mbs
+        )
+
+    @wrap_with_nvtx_name("dtensor_policy_worker_v2/train_microbatch")
+    def train_microbatch(
+        self,
+        step_id: str,
+        data: BatchedDataDict[Any],
+    ) -> dict[str, Any]:
+        """Run forward+backward over every bin in ``data`` under the open step.
+
+        Uses ``get_microbatch_iterator`` (which already handles dummy-bin
+        padding for DP-rank bin-count sync under seq-packing) and
+        ``automodel_forward_backward`` (which already zeros dummy losses
+        and handles dp_size*cp_size FSDP-avg cancellation).
+        """
+        state = self._assert_step_open(step_id)
+
+        # Accumulate local mask sums for the finish-time all_reduce.
+        # Computed once on the call's full data (dummies cycle from these
+        # rows so we don't want to double-count). Done before forward so
+        # a backward failure can't leave counts out of sync with grads.
+        data = data.to("cuda")
+        assert "sample_mask" in data, "sample_mask required on microbatch data"
+        sample_mask = data["sample_mask"]
+        call_local_seqs = torch.sum(sample_mask).to(torch.float64)
+        if "token_mask" in data:
+            token_mask = data["token_mask"]
+            call_local_toks = torch.sum(
+                token_mask[:, 1:] * sample_mask.unsqueeze(-1)
+            ).to(torch.float64)
+        else:
+            call_local_toks = call_local_seqs * data["input_ids"].shape[1]
+
+        state["local_valid_seqs"] = state["local_valid_seqs"] + call_local_seqs
+        state["local_valid_toks"] = state["local_valid_toks"] + call_local_toks
+
+        # Get microbatch iterator (handles dummy-bin padding internally)
+        processed_iterator, iterator_len = get_microbatch_iterator(
+            data,
+            self.cfg,
+            state["mbs"],
+            self.dp_mesh,
+            tokenizer=self.tokenizer,
+            cp_size=self.cp_size,
+        )
+
+        # Optional cache-clear callback (mirrors sync train() behavior)
+        empty_cache_steps = self.cfg.get("dtensor_cfg", {}).get(
+            "clear_cache_every_n_steps"
+        )
+
+        def on_microbatch_start(mb_idx: int) -> None:
+            if empty_cache_steps and mb_idx % empty_cache_steps == 0:
+                torch.cuda.empty_cache()
+
+        # Placeholder N: loss returns un-normalized sums. Finish does the
+        # global 1/N rescale (linear-in-1/N math).
+        placeholder_n = torch.tensor(1.0, device="cuda")
+
+        mb_results = automodel_forward_backward(
+            model=self.model,
+            data_iterator=processed_iterator,
+            post_processing_fn=state["loss_post_processor"],
+            forward_only=False,
+            is_reward_model=self._is_reward_model,
+            allow_flash_attn_args=self.allow_flash_attn_args,
+            global_valid_seqs=placeholder_n,
+            global_valid_toks=placeholder_n,
+            sampling_params=self.sampling_params,
+            sequence_dim=state["sequence_dim"],
+            dp_size=self.dp_size,
+            cp_size=self.cp_size,
+            # num_global_batches=1: metric per-call division by 1 (no-op);
+            # the global 1/N rescale at finish handles the actual scaling.
+            num_global_batches=1,
+            train_context_fn=state["train_context_fn"],
+            num_valid_microbatches=iterator_len,
+            on_microbatch_start=on_microbatch_start,
+        )
+
+        # Accumulate per-real-mb losses/metrics into step state
+        for mb_idx, (loss, loss_metrics) in enumerate(mb_results):
+            if mb_idx >= iterator_len:
+                continue  # dummy bin — backward already ran with loss*0
+            num_valid_samples = loss_metrics.get("num_valid_samples", 0)
+            loss_metrics["lr"] = self.optimizer.param_groups[0]["lr"]
+            if num_valid_samples > 0:
+                state["mb_losses"].append(loss.item())
+                state["all_mb_metrics"].append(loss_metrics)
+            state["num_microbatches"] += 1
+
+        return {
+            "local_valid_seqs_mb": float(call_local_seqs.item()),
+            "local_valid_toks_mb": float(call_local_toks.item()),
+            "num_bins": int(iterator_len),
+        }
+
+    @wrap_with_nvtx_name("dtensor_policy_worker_v2/finish_train_step")
+    def finish_train_step(self, step_id: str) -> dict[str, Any]:
+        from nemo_rl.algorithms.loss.interfaces import LossType  # local
+
+        state = self._assert_step_open(step_id)
+
+        # All-reduce accumulated mask sums across DP to recover true N.
+        to_reduce = torch.stack(
+            [state["local_valid_seqs"], state["local_valid_toks"]]
+        ).to(torch.float64)
+        torch.distributed.all_reduce(to_reduce, group=self.dp_mesh.get_group())
+        global_valid_seqs = to_reduce[0]
+        global_valid_toks = to_reduce[1]
+
+        if state["loss_type"] == LossType.TOKEN_LEVEL:
+            n_true = global_valid_toks
+        else:
+            n_true = global_valid_seqs
+
+        n_safe = n_true if n_true.item() > 0 else torch.tensor(1.0, device="cuda")
+        inv_n = (1.0 / n_safe).to(torch.float32)
+
+        # Rescale accumulated unnormalized grads by 1/N (single scalar
+        # because each loss_fn commits to a single loss_type whose grad
+        # share the same normalizer — see the loss-API survey notes).
+        with torch.no_grad():
+            for p in self.model.parameters():
+                if p.grad is not None:
+                    p.grad.mul_(inv_n)
+
+        # v2's clip helper handles PP/EP grad scaling too. We've already
+        # done the 1/N rescale, so num_label_tokens=1 (no further scaling)
+        # and dp_group_size matches the FSDP-avg cancellation we did per mb.
+        grad_norm: Optional[float | torch.Tensor] = scale_grads_and_clip_grad_norm(
+            self.max_grad_norm,
+            [self.model],
+            norm_type=2.0,
+            pp_enabled=False,
+            device_mesh=self.device_mesh,
+            moe_mesh=self.moe_mesh,
+            ep_axis_name=(
+                "ep"
+                if self.moe_mesh is not None and "ep" in self.moe_mesh.mesh_dim_names
+                else None
+            ),
+            pp_axis_name=None,
+            foreach=True,
+            num_label_tokens=1,
+            dp_group_size=self.dp_size * self.cp_size,
+        )
+        grad_norm = torch.tensor(grad_norm, device="cpu", dtype=torch.float32)
+
+        self.optimizer.step()
+        self.optimizer.zero_grad()
+        self.scheduler.step()
+        torch.cuda.empty_cache()
+
+        # Per-mb metrics were computed with N=1; rescale by 1/N (single
+        # scalar) so they match the sync-path's normalized values.
+        scale = float(inv_n.item())
+        rescaled_metrics: list[dict[str, Any]] = []
+        for m in state["all_mb_metrics"]:
+            out: dict[str, Any] = {}
+            for k, v in m.items():
+                if "_min" in k or "_max" in k or k == "lr" or k == "num_valid_samples":
+                    out[k] = v
+                elif isinstance(v, torch.Tensor):
+                    out[k] = (v.detach() * scale).cpu()
+                else:
+                    out[k] = v * scale
+            # Surface the true global counts (matches sync path's keys)
+            out["global_valid_seqs"] = float(global_valid_seqs.item())
+            out["global_valid_toks"] = float(global_valid_toks.item())
+            rescaled_metrics.append(out)
+
+        # Scale the per-mb losses (computed with N=1) by the same factor
+        # so the aggregated global loss matches what train() would emit.
+        scaled_losses = [lv * scale for lv in state["mb_losses"]]
+
+        metrics = aggregate_training_statistics(
+            losses=scaled_losses,
+            all_mb_metrics=rescaled_metrics,
+            grad_norm=grad_norm,
+            dp_group=self.dp_mesh.get_group(),
+            dtype=self.dtype,
+        )
+
+        # Drop state before returning so a re-call to begin_train_step
+        # doesn't see a stale handle.
+        self._train_step_state = None
+        return metrics
+
+    @wrap_with_nvtx_name("dtensor_policy_worker_v2/abort_train_step")
+    def abort_train_step(self, step_id: str) -> None:
+        state = getattr(self, "_train_step_state", None)
+        if state is None:
+            return
+        if state["step_id"] != step_id:
+            raise RuntimeError(
+                f"abort_train_step({step_id!r}) does not match open step "
+                f"{state['step_id']!r}"
+            )
+        self.optimizer.zero_grad()
+        self._train_step_state = None
 
     @wrap_with_nvtx_name("dtensor_policy_worker_v2/get_logprobs")
     def get_logprobs(

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -99,6 +99,50 @@ from nemo_rl.utils.packed_tensor import packed_broadcast_producer
 TokenizerType = TypeVar("TokenizerType", bound=PreTrainedTokenizerBase)
 
 
+# Per-metric normalization tags for the split-API ``finish_train_step``
+# rescale. The sync path runs the loss with the true global_valid_*; the
+# split path runs each microbatch with global_valid_*=1 (raw sums) and
+# applies the 1/N rescale once at finish, but different metrics need
+# different N. See ClippedPGLossFn (nemo_rl/algorithms/loss/loss_functions.py)
+# and PR #2683 review on lines 789/845 for the catalog.
+#
+# - "toks": divide partial sum by global_valid_toks
+# - "seqs": divide partial sum by global_valid_seqs
+# - "loss_type": pick toks or seqs based on loss_type (matches gradient
+#                normalization). Used for ``loss`` and ``kl_penalty``.
+# - "none":  raw count metric; sum across microbatches downstream is the
+#            correct value. Do NOT scale.
+# - "skip":  handled separately (min/max guard, or stamped after the loop).
+#
+# Metrics not listed default to "loss_type" — preserves prior behavior
+# for any unknown metric and matches the canonical case (loss-derived).
+_METRIC_NORMALIZATION_KIND: dict[str, str] = {
+    # ClippedPGLossFn metrics always normalized by token count regardless
+    # of loss_type (see L281-588 in loss_functions.py):
+    "token_mult_prob_error": "toks",
+    "gen_kl_error": "toks",
+    "policy_kl_error": "toks",
+    "js_divergence_error": "toks",
+    "approx_entropy": "toks",
+    "probs_ratio": "toks",
+    "probs_ratio_clamped": "toks",
+    # Loss-type-aware metrics (use the same N as the gradient normalization):
+    "loss": "loss_type",
+    "kl_penalty": "loss_type",
+    # Flag-dependent (sequence_level_importance_ratios / sequence_level_loss_mask
+    # toggles inside the loss). For now use loss_type as the best default;
+    # the seq-mask-tis + token-level combo mismatches here. TODO: thread
+    # the flags through so finish can pick correctly.
+    "sampling_importance_ratio": "loss_type",
+    "is_oob_ratio": "loss_type",
+    # Raw counts — must NOT be scaled. The sync path passes these through
+    # via `/num_global_batches`=1 → identity, and grpo.py's downstream
+    # reducer sums across microbatches to get the global count.
+    "num_valid_samples": "none",
+    "num_unmasked_tokens": "none",
+}
+
+
 # Classes with @ray.remote can't be inherited from, so we split the implementation out.
 # This is useful when using worker extension classes.
 class MegatronPolicyWorkerImpl(
@@ -900,9 +944,41 @@ class MegatronPolicyWorkerImpl(
         # Scheduler increment matches sync path's ``increment=gbs``.
         self.scheduler.step(increment=state["gbs"])
 
-        # Per-mb metrics were computed with N=1; rescale to match what the
-        # sync path produces. ``masked_mean`` is linear in 1/N so a single
-        # scalar multiply per metric recovers the normalized value.
+        # Per-mb metrics were computed with global_valid_*=1 (raw sums);
+        # rescale to match what the sync path produces. Different metrics
+        # use different denominators — see _METRIC_NORMALIZATION_KIND at
+        # module top. masked_mean is linear in 1/N so per-metric scalar
+        # multiplies recover the right normalized values.
+        n_toks_safe = (
+            global_valid_toks
+            if global_valid_toks.item() > 0
+            else torch.tensor(1.0, device="cuda")
+        )
+        n_seqs_safe = (
+            global_valid_seqs
+            if global_valid_seqs.item() > 0
+            else torch.tensor(1.0, device="cuda")
+        )
+        inv_toks = float((1.0 / n_toks_safe).item())
+        inv_seqs = float((1.0 / n_seqs_safe).item())
+
+        def _scale_metric(name: str, value: Any) -> Any:
+            """Apply per-metric N according to _METRIC_NORMALIZATION_KIND."""
+            kind = _METRIC_NORMALIZATION_KIND.get(name, "loss_type")
+            if kind == "none":
+                return value
+            if kind == "toks":
+                scale = inv_toks
+            elif kind == "seqs":
+                scale = inv_seqs
+            else:  # "loss_type" → same as gradient normalization
+                scale = inv_n
+            return (
+                value.detach() * scale
+                if isinstance(value, torch.Tensor)
+                else value * scale
+            )
+
         rescaled_metrics: list[dict[str, Any]] = []
         curr_lr = self.scheduler.get_lr(self.optimizer.param_groups[0])
         curr_wd = self.scheduler.get_wd()
@@ -914,10 +990,8 @@ class MegatronPolicyWorkerImpl(
             for k, v in m.items():
                 if "_min" in k or "_max" in k:
                     out[k] = v
-                elif isinstance(v, torch.Tensor):
-                    out[k] = v.detach() * inv_n
                 else:
-                    out[k] = v * inv_n
+                    out[k] = _scale_metric(k, v)
             out["lr"] = curr_lr
             out["wd"] = curr_wd
             out["global_valid_seqs"] = global_valid_seqs_f

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -528,6 +528,364 @@ class MegatronPolicyWorkerImpl(
                 metrics["moe_metrics"] = moe_metrics
         return metrics
 
+    # ── split-API train-step state machine (SingleController async path) ──
+    #
+    # Mirrors the v1/v2 implementations, adapted for mcore. Key differences:
+    #
+    # 1. mcore DDP accumulates ``param.main_grad`` per backward and dispatches
+    #    a cross-DP reduce when ``is_last_microbatch=True`` (one per
+    #    ``forward_backward_func`` call). Naively chaining multiple
+    #    ``forward_backward_func`` calls between ``optimizer.step()`` would
+    #    over-count: each call's terminal reduce sums an already-reduced
+    #    bucket again. We wrap every call in ``self.model.no_sync()`` so
+    #    hooks accumulate locally only; one explicit ``start_grad_sync`` +
+    #    ``finish_grad_sync`` at finish does the single true reduce.
+    # 2. PP>1: the pipeline scheduler invokes ``config.grad_sync_func``
+    #    directly on last-microbatch boundaries — this bypasses the
+    #    ``no_sync`` gate. We null it for the duration of the step and
+    #    restore at finish/abort.
+    # 3. Grad clip is bundled inside ``MegatronOptimizer.step()``; the 1/N
+    #    rescale via ``self.model.scale_gradients(1/N)`` must run before
+    #    ``optimizer.step()`` so the clip operates on the rescaled grad.
+    # 4. With ``calculate_per_token_loss=True`` + ``average_in_collective=
+    #    False``, mcore's DDP sums (does not average) grads across DP, so
+    #    no FSDP-style ``loss *= dp_size*cp_size`` cancellation is needed
+    #    per microbatch.
+
+    def _split_step_state_init(
+        self,
+        step_id: str,
+        loss_fn: LossFunction,
+        gbs: Optional[int],
+        mbs: Optional[int],
+    ) -> dict[str, Any]:
+        from nemo_rl.algorithms.loss.interfaces import LossType
+
+        return {
+            "step_id": step_id,
+            "loss_fn": loss_fn,
+            "loss_type": getattr(loss_fn, "loss_type", LossType.TOKEN_LEVEL),
+            "gbs": gbs or self.cfg["train_global_batch_size"],
+            "mbs": mbs or self.cfg["train_micro_batch_size"],
+            "local_valid_seqs": torch.zeros((), dtype=torch.float64, device="cuda"),
+            "local_valid_toks": torch.zeros((), dtype=torch.float64, device="cuda"),
+            "all_mb_metrics": [],
+            "mb_losses": [],
+            "total_num_microbatches": 0,
+            # Saved across the step so we can restore at finish/abort.
+            "saved_grad_sync_func": None,
+            "no_sync_active": False,
+        }
+
+    def _assert_step_open(self, step_id: str) -> dict[str, Any]:
+        state = getattr(self, "_train_step_state", None)
+        if state is None:
+            raise RuntimeError(
+                f"no train step open; begin_train_step({step_id!r}) must be called first"
+            )
+        if state["step_id"] != step_id:
+            raise RuntimeError(
+                f"step_id mismatch: open step is {state['step_id']!r}, got {step_id!r}"
+            )
+        return state
+
+    @wrap_with_nvtx_name("megatron_policy_worker/begin_train_step")
+    def begin_train_step(
+        self,
+        step_id: str,
+        loss_fn: LossFunction,
+        gbs: Optional[int] = None,
+        mbs: Optional[int] = None,
+    ) -> None:
+        existing = getattr(self, "_train_step_state", None)
+        if existing is not None:
+            raise RuntimeError(
+                f"train step {existing['step_id']!r} is already open; "
+                f"call finish_train_step or abort_train_step before begin"
+            )
+        # Match sync train() inference-state reset (line 332-340).
+        if hasattr(self.model, "inference_params"):
+            self.model.inference_params = None
+        for module in self.model.modules():
+            if hasattr(module, "reset_inference_cache"):
+                module.reset_inference_cache()
+            if hasattr(module, "_inference_key_value_memory"):
+                module._inference_key_value_memory = None
+
+        self.model.train()
+        self.model.zero_grad_buffer()
+        self.optimizer.zero_grad()
+
+        state = self._split_step_state_init(
+            step_id=step_id, loss_fn=loss_fn, gbs=gbs, mbs=mbs
+        )
+
+        # Suppress the PP scheduler's direct ``grad_sync_func`` call (which
+        # bypasses ``no_sync``). Save the existing value so we can restore
+        # at finish/abort. PP=1's ``forward_backward_no_pipelining`` doesn't
+        # invoke this; nulling it is a no-op there.
+        model_config = self.model.config
+        state["saved_grad_sync_func"] = getattr(model_config, "grad_sync_func", None)
+        model_config.grad_sync_func = None
+
+        self._train_step_state = state
+
+    @wrap_with_nvtx_name("megatron_policy_worker/train_microbatch")
+    def train_microbatch(
+        self,
+        step_id: str,
+        data: BatchedDataDict[Any],
+    ) -> dict[str, Any]:
+        """One DP slice of data → one ``forward_backward_func`` invocation.
+
+        Wrapped in ``self.model.no_sync()`` so the mcore DDP hooks
+        accumulate ``param.main_grad`` locally on each rank without
+        dispatching a per-call DP reduce. The single true reduce is done
+        explicitly in ``finish_train_step``.
+        """
+        state = self._assert_step_open(step_id)
+        loss_fn = state["loss_fn"]
+
+        # Accumulate local mask sums for the finish-time all_reduce.
+        # Inlined from process_global_batch (data.py:319-332) — we can't
+        # call process_global_batch directly because it eagerly all_reduces
+        # the local sums, which is exactly what we're trying to defer.
+        assert "sample_mask" in data, "sample_mask required on microbatch data"
+        sample_mask = data["sample_mask"]
+        call_local_seqs = torch.sum(sample_mask).to(torch.float64)
+        if "token_mask" in data:
+            token_mask = data["token_mask"]
+            call_local_toks = torch.sum(
+                token_mask[:, 1:] * sample_mask.unsqueeze(-1)
+            ).to(torch.float64)
+        else:
+            call_local_toks = call_local_seqs * data["input_ids"].shape[1]
+
+        state["local_valid_seqs"] = state["local_valid_seqs"] + call_local_seqs
+        state["local_valid_toks"] = state["local_valid_toks"] + call_local_toks
+
+        # Build the per-call iterator. Each ``train_microbatch_from_meta``
+        # call carries one DP slice; the iterator subdivides into pipeline
+        # microbatches.
+        (
+            data_iterator,
+            num_microbatches,
+            micro_batch_size,
+            seq_length,
+            padded_seq_length,
+        ) = get_microbatch_iterator(
+            data,
+            self.cfg,
+            state["mbs"],
+            straggler_timer=self.mcore_state.straggler_timer,
+        )
+        state["total_num_microbatches"] += int(num_microbatches)
+
+        loss_post_processor = LossPostProcessor(
+            loss_fn=loss_fn,
+            cfg=self.cfg,
+            num_microbatches=num_microbatches,
+            sampling_params=self.sampling_params,
+            draft_model=self.draft_model,
+        )
+
+        # Placeholder N=1: loss returns un-normalized sums. ``backward``
+        # deposits raw ``d(sum)/dθ`` into ``param.main_grad`` via the DDP
+        # hooks. The 1/N rescale happens once at finish.
+        placeholder_n = torch.tensor(1.0, device="cuda")
+
+        draft_enabled = "draft" in self.cfg and self.cfg["draft"]["enabled"]
+
+        # The critical wrap: hooks fire (accumulate main_grad) but the
+        # per-call reduce dispatch is gated off.
+        with self.model.no_sync():
+            rerun_state_machine = get_rerun_state_machine()
+            while rerun_state_machine.should_run_forward_backward(data_iterator):
+                losses_reduced = megatron_forward_backward(
+                    model=self.model,
+                    data_iterator=data_iterator,
+                    num_microbatches=num_microbatches,
+                    seq_length=padded_seq_length,
+                    mbs=micro_batch_size,
+                    post_processing_fn=loss_post_processor,
+                    forward_only=False,
+                    defer_fp32_logits=self.defer_fp32_logits,
+                    global_valid_seqs=placeholder_n,
+                    global_valid_toks=placeholder_n,
+                    sampling_params=self.sampling_params,
+                    straggler_timer=self.mcore_state.straggler_timer,
+                    draft_model=self.draft_model,
+                    enable_hidden_capture=draft_enabled,
+                    use_linear_ce_fusion_loss=self.cfg["megatron_cfg"].get(
+                        "use_linear_ce_fusion_loss", False
+                    ),
+                )
+
+        if self.cfg["megatron_cfg"]["empty_unused_memory_level"] >= 1:
+            torch.cuda.empty_cache()
+
+        # Collect per-mb metrics from the last PP stage; broadcast to all
+        # PP ranks so non-last-stage ranks have something to all_reduce
+        # against at finish. Metrics carry the N=1 placeholder for now —
+        # ``finish_train_step`` rescales by the true 1/N.
+        if parallel_state.is_pipeline_last_stage(ignore_virtual=True):
+            mb_metrics_collected = []
+            for x in losses_reduced:
+                mb_metrics_collected.append(dict(x))
+        else:
+            mb_metrics_collected = None
+
+        mb_metrics_collected = broadcast_loss_metrics_from_last_stage(
+            mb_metrics_collected
+        )
+
+        for m in mb_metrics_collected:
+            state["all_mb_metrics"].append(m)
+            # ``loss`` key is the un-normalized per-mb scalar; collect for
+            # the global_loss aggregation at finish.
+            if "loss" in m:
+                state["mb_losses"].append(m["loss"])
+
+        return {
+            "local_valid_seqs_mb": float(call_local_seqs.item()),
+            "local_valid_toks_mb": float(call_local_toks.item()),
+            "num_pipeline_microbatches": int(num_microbatches),
+        }
+
+    @wrap_with_nvtx_name("megatron_policy_worker/finish_train_step")
+    def finish_train_step(self, step_id: str) -> dict[str, Any]:
+        from nemo_rl.algorithms.loss.interfaces import LossType
+
+        state = self._assert_step_open(step_id)
+
+        # All-reduce accumulated mask sums across DP to recover true N.
+        to_reduce = torch.stack(
+            [state["local_valid_seqs"], state["local_valid_toks"]]
+        ).to(torch.float64)
+        torch.distributed.all_reduce(
+            to_reduce, group=parallel_state.get_data_parallel_group()
+        )
+        global_valid_seqs = to_reduce[0]
+        global_valid_toks = to_reduce[1]
+
+        if state["loss_type"] == LossType.TOKEN_LEVEL:
+            n_true = global_valid_toks
+        else:
+            n_true = global_valid_seqs
+        n_safe = n_true if n_true.item() > 0 else torch.tensor(1.0, device="cuda")
+        inv_n = float((1.0 / n_safe).item())
+
+        # Rescale all locally-accumulated gradients by 1/N. The reduce
+        # below sees the rescaled grads; for all_reduce the result is the
+        # global mean grad; for reduce_scatter (dist-opt) it's the shard.
+        # Either way, opt.step sees the right-normalized gradient.
+        self.model.scale_gradients(inv_n)
+
+        # The ONE true cross-DP reduce for the entire step.
+        self.model.start_grad_sync()
+        self.model.finish_grad_sync()
+
+        # opt.step clips internally (clip_grad config); operates on the
+        # already-rescaled grad. Returns (success, grad_norm, num_zeros).
+        update_successful, grad_norm, num_zeros_in_grad = self.optimizer.step()
+
+        pg_collection = get_pg_collection(self.model)
+        update_successful = logical_and_across_model_parallel_group(
+            update_successful, mp_group=pg_collection.mp
+        )
+        grad_norm = reduce_max_stat_across_model_parallel_group(
+            grad_norm, mp_group=pg_collection.mp
+        )
+        num_zeros_in_grad = reduce_max_stat_across_model_parallel_group(
+            num_zeros_in_grad, mp_group=pg_collection.mp
+        )
+
+        if self.cfg["megatron_cfg"]["empty_unused_memory_level"] >= 2:
+            torch.cuda.empty_cache()
+
+        # Restore grad_sync_func before scheduler.step / further state.
+        self.model.config.grad_sync_func = state["saved_grad_sync_func"]
+
+        # Scheduler increment matches sync path's ``increment=gbs``.
+        self.scheduler.step(increment=state["gbs"])
+
+        # Per-mb metrics were computed with N=1; rescale to match what the
+        # sync path produces. ``masked_mean`` is linear in 1/N so a single
+        # scalar multiply per metric recovers the normalized value.
+        rescaled_metrics: list[dict[str, Any]] = []
+        curr_lr = self.scheduler.get_lr(self.optimizer.param_groups[0])
+        curr_wd = self.scheduler.get_wd()
+        global_valid_seqs_f = float(global_valid_seqs.item())
+        global_valid_toks_f = float(global_valid_toks.item())
+
+        for m in state["all_mb_metrics"]:
+            out: dict[str, Any] = {}
+            for k, v in m.items():
+                if "_min" in k or "_max" in k:
+                    out[k] = v
+                elif isinstance(v, torch.Tensor):
+                    out[k] = v.detach() * inv_n
+                else:
+                    out[k] = v * inv_n
+            out["lr"] = curr_lr
+            out["wd"] = curr_wd
+            out["global_valid_seqs"] = global_valid_seqs_f
+            out["global_valid_toks"] = global_valid_toks_f
+            rescaled_metrics.append(out)
+
+        # Scale per-mb losses by 1/N and reduce per-call sums.
+        scaled_losses = [lv * inv_n for lv in state["mb_losses"]]
+        losses_to_aggregate = [torch.tensor(scaled_losses).sum().item()]
+
+        mb_metrics, global_loss = aggregate_training_statistics(
+            all_mb_metrics=rescaled_metrics,
+            losses=losses_to_aggregate,
+            data_parallel_group=parallel_state.get_data_parallel_group(),
+        )
+
+        metrics = {
+            "global_loss": global_loss.cpu(),
+            "rank": torch.distributed.get_rank(),
+            "gpu_name": torch.cuda.get_device_name(),
+            "model_dtype": self.dtype,
+            "all_mb_metrics": mb_metrics,
+            "grad_norm": torch.tensor([grad_norm]),
+        }
+
+        # MoE aux-loss metrics: same convention as sync train() — scale
+        # by the total pipeline-microbatch count accumulated across all
+        # train_microbatch calls.
+        model_config = getattr(self.model, "config", None)
+        num_moe_experts = getattr(model_config, "num_moe_experts", None)
+        if num_moe_experts is not None and num_moe_experts > 1:
+            moe_loss_scale = 1.0 / max(1, state["total_num_microbatches"])
+            moe_metrics = get_moe_metrics(
+                loss_scale=moe_loss_scale,
+                per_layer_logging=self.cfg["megatron_cfg"]["moe_per_layer_logging"],
+            )
+            if moe_metrics:
+                metrics["moe_metrics"] = moe_metrics
+
+        self._train_step_state = None
+        return metrics
+
+    @wrap_with_nvtx_name("megatron_policy_worker/abort_train_step")
+    def abort_train_step(self, step_id: str) -> None:
+        state = getattr(self, "_train_step_state", None)
+        if state is None:
+            return
+        if state["step_id"] != step_id:
+            raise RuntimeError(
+                f"abort_train_step({step_id!r}) does not match open step "
+                f"{state['step_id']!r}"
+            )
+        # Restore grad_sync_func first so the model is back to a normal
+        # state before zero_grad_buffer touches anything.
+        self.model.config.grad_sync_func = state["saved_grad_sync_func"]
+        self.model.zero_grad_buffer()
+        self.optimizer.zero_grad()
+        self._train_step_state = None
+
     @wrap_with_nvtx_name("megatron_policy_worker/get_logprobs")
     def get_logprobs(
         self, *, data: BatchedDataDict[Any], micro_batch_size: Optional[int] = None

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -629,9 +629,17 @@ class MegatronPolicyWorkerImpl(
         # bypasses ``no_sync``). Save the existing value so we can restore
         # at finish/abort. PP=1's ``forward_backward_no_pipelining`` doesn't
         # invoke this; nulling it is a no-op there.
-        model_config = self.model.config
-        state["saved_grad_sync_func"] = getattr(model_config, "grad_sync_func", None)
-        model_config.grad_sync_func = None
+        # Read "config" via getattr-by-string so the token stays out of
+        # begin_train_step.__code__.co_names; otherwise cloudpickle matches
+        # torch.distributed.config (a non-pickleable ConfigModuleInstance).
+        model_config = getattr(self.model, "config", None)
+        if model_config is not None:
+            state["saved_grad_sync_func"] = getattr(
+                model_config, "grad_sync_func", None
+            )
+            model_config.grad_sync_func = None
+        else:
+            state["saved_grad_sync_func"] = None
 
         self._train_step_state = state
 
@@ -809,7 +817,10 @@ class MegatronPolicyWorkerImpl(
             torch.cuda.empty_cache()
 
         # Restore grad_sync_func before scheduler.step / further state.
-        self.model.config.grad_sync_func = state["saved_grad_sync_func"]
+        # See begin_train_step for why .config is accessed by string.
+        finish_model_config = getattr(self.model, "config", None)
+        if finish_model_config is not None:
+            finish_model_config.grad_sync_func = state["saved_grad_sync_func"]
 
         # Scheduler increment matches sync path's ``increment=gbs``.
         self.scheduler.step(increment=state["gbs"])
@@ -886,7 +897,10 @@ class MegatronPolicyWorkerImpl(
             )
         # Restore grad_sync_func first so the model is back to a normal
         # state before zero_grad_buffer touches anything.
-        self.model.config.grad_sync_func = state["saved_grad_sync_func"]
+        # See begin_train_step for why .config is accessed by string.
+        abort_model_config = getattr(self.model, "config", None)
+        if abort_model_config is not None:
+            abort_model_config.grad_sync_func = state["saved_grad_sync_func"]
         self.model.zero_grad_buffer()
         self.optimizer.zero_grad()
         self._train_step_state = None

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import gc
+import logging
 import os
 import re
 import warnings
 from collections import defaultdict
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from typing import Any, Iterator, Optional, TypeVar, cast
+
+log = logging.getLogger(__name__)
 
 import ray
 import torch
@@ -579,7 +582,7 @@ class MegatronPolicyWorkerImpl(
             "total_num_microbatches": 0,
             # Saved across the step so we can restore at finish/abort.
             "saved_grad_sync_func": None,
-            "no_sync_active": False,
+            "saved_no_sync_func": None,
         }
 
     def _assert_step_open(self, step_id: str) -> dict[str, Any]:
@@ -593,6 +596,21 @@ class MegatronPolicyWorkerImpl(
                 f"step_id mismatch: open step is {state['step_id']!r}, got {step_id!r}"
             )
         return state
+
+    def _restore_saved_grad_sync_func(self, state: dict[str, Any]) -> None:
+        """Restore the mcore hooks nulled in ``begin_train_step``.
+
+        Restores both ``grad_sync_func`` and ``no_sync_func`` from the
+        saved values on the open-step state. Idempotent on those values;
+        safe to call from the happy-path finish/abort or from a try/except
+        cleanup in train_microbatch / finish_train_step when those raise
+        mid-body. See begin_train_step for why ``.config`` is read via
+        getattr-by-string.
+        """
+        model_config = getattr(self.model, "config", None)
+        if model_config is not None:
+            model_config.grad_sync_func = state.get("saved_grad_sync_func")
+            model_config.no_sync_func = state.get("saved_no_sync_func")
 
     @wrap_with_nvtx_name("megatron_policy_worker/begin_train_step")
     def begin_train_step(
@@ -625,10 +643,18 @@ class MegatronPolicyWorkerImpl(
             step_id=step_id, loss_fn=loss_fn, gbs=gbs, mbs=mbs
         )
 
-        # Suppress the PP scheduler's direct ``grad_sync_func`` call (which
-        # bypasses ``no_sync``). Save the existing value so we can restore
-        # at finish/abort. PP=1's ``forward_backward_no_pipelining`` doesn't
-        # invoke this; nulling it is a no-op there.
+        # Null both mcore hooks that would fire a mid-step DP reduce:
+        #   grad_sync_func — PP scheduler's direct call on last-MB boundaries
+        #                    (PP>1 path).
+        #   no_sync_func   — ``forward_backward_no_pipelining`` (PP=1, the
+        #                    common case) wraps inner microbatches in this
+        #                    context and runs the LAST microbatch OUTSIDE
+        #                    of it. Without overriding, ``register_grad_ready``
+        #                    leaks per-param counts past the outer
+        #                    ``model.no_sync()`` we apply in train_microbatch,
+        #                    triggering an assertion on the next begin/microbatch
+        #                    pair (typically step 2).
+        # Save both so finish/abort restores them.
         # Read "config" via getattr-by-string so the token stays out of
         # begin_train_step.__code__.co_names; otherwise cloudpickle matches
         # torch.distributed.config (a non-pickleable ConfigModuleInstance).
@@ -637,9 +663,12 @@ class MegatronPolicyWorkerImpl(
             state["saved_grad_sync_func"] = getattr(
                 model_config, "grad_sync_func", None
             )
+            state["saved_no_sync_func"] = getattr(model_config, "no_sync_func", None)
             model_config.grad_sync_func = None
+            model_config.no_sync_func = nullcontext
         else:
             state["saved_grad_sync_func"] = None
+            state["saved_no_sync_func"] = None
 
         self._train_step_state = state
 
@@ -657,6 +686,29 @@ class MegatronPolicyWorkerImpl(
         explicitly in ``finish_train_step``.
         """
         state = self._assert_step_open(step_id)
+        try:
+            return self._train_microbatch_body(state, data)
+        except Exception:
+            # The body left ``grad_sync_func`` nulled when begin_train_step
+            # opened the step. If we propagate without restoring, future
+            # steps run with the PP scheduler bypass disabled. Restore here;
+            # the caller is still expected to invoke abort_train_step
+            # (idempotent on the saved value) to drop ``_train_step_state``.
+            try:
+                self._restore_saved_grad_sync_func(state)
+            except Exception:
+                log.exception(
+                    "failed to restore grad_sync_func after train_microbatch "
+                    "error (step=%s)",
+                    step_id,
+                )
+            raise
+
+    def _train_microbatch_body(
+        self,
+        state: dict[str, Any],
+        data: BatchedDataDict[Any],
+    ) -> dict[str, Any]:
         loss_fn = state["loss_fn"]
 
         # Accumulate local mask sums for the finish-time all_reduce.
@@ -767,9 +819,27 @@ class MegatronPolicyWorkerImpl(
 
     @wrap_with_nvtx_name("megatron_policy_worker/finish_train_step")
     def finish_train_step(self, step_id: str) -> dict[str, Any]:
-        from nemo_rl.algorithms.loss.interfaces import LossType
-
         state = self._assert_step_open(step_id)
+        try:
+            return self._finish_train_step_body(state)
+        except Exception:
+            # Mid-finish failure: state machine is in a partial state and
+            # ``grad_sync_func`` may still be nulled (or restored, depending
+            # on how far the body got). Restore unconditionally so future
+            # steps run with the right config. Leave ``_train_step_state``
+            # for the caller's abort_train_step to clear.
+            try:
+                self._restore_saved_grad_sync_func(state)
+            except Exception:
+                log.exception(
+                    "failed to restore grad_sync_func after finish_train_step "
+                    "error (step=%s)",
+                    step_id,
+                )
+            raise
+
+    def _finish_train_step_body(self, state: dict[str, Any]) -> dict[str, Any]:
+        from nemo_rl.algorithms.loss.interfaces import LossType
 
         # All-reduce accumulated mask sums across DP to recover true N.
         to_reduce = torch.stack(
@@ -825,10 +895,7 @@ class MegatronPolicyWorkerImpl(
             torch.cuda.empty_cache()
 
         # Restore grad_sync_func before scheduler.step / further state.
-        # See begin_train_step for why .config is accessed by string.
-        finish_model_config = getattr(self.model, "config", None)
-        if finish_model_config is not None:
-            finish_model_config.grad_sync_func = state["saved_grad_sync_func"]
+        self._restore_saved_grad_sync_func(state)
 
         # Scheduler increment matches sync path's ``increment=gbs``.
         self.scheduler.step(increment=state["gbs"])
@@ -905,10 +972,7 @@ class MegatronPolicyWorkerImpl(
             )
         # Restore grad_sync_func first so the model is back to a normal
         # state before zero_grad_buffer touches anything.
-        # See begin_train_step for why .config is accessed by string.
-        abort_model_config = getattr(self.model, "config", None)
-        if abort_model_config is not None:
-            abort_model_config.grad_sync_func = state["saved_grad_sync_func"]
+        self._restore_saved_grad_sync_func(state)
         self.model.zero_grad_buffer()
         self.optimizer.zero_grad()
         self._train_step_state = None

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -582,7 +582,14 @@ class MegatronPolicyWorkerImpl(
 
     # ── split-API train-step state machine (SingleController async path) ──
     #
-    # Mirrors the v1/v2 implementations, adapted for mcore. Key differences:
+    # SC drives one ``begin / train_microbatch×N / finish`` cycle per
+    # optimizer step. The worker exposes:
+    #   begin_train_step      — open the step (zero grads, null mcore sync hooks)
+    #   train_microbatch      — one DP slice of fwd/bwd, grads accumulate locally
+    #   finish_train_step     — all_reduce + opt.step + scheduler.step
+    #   abort_train_step      — drop partial state (no opt.step)
+    #
+    # Key mcore-specific details:
     #
     # 1. mcore DDP accumulates ``param.main_grad`` per backward and dispatches
     #    a cross-DP reduce when ``is_last_microbatch=True`` (one per
@@ -941,6 +948,11 @@ class MegatronPolicyWorkerImpl(
         # Restore grad_sync_func before scheduler.step / further state.
         self._restore_saved_grad_sync_func(state)
 
+        # Capture lr/wd BEFORE scheduler.step so the per-mb metrics carry
+        # the value of THIS step, not the next one. (terrykong, #2683:832).
+        curr_lr = self.scheduler.get_lr(self.optimizer.param_groups[0])
+        curr_wd = self.scheduler.get_wd()
+
         # Scheduler increment matches sync path's ``increment=gbs``.
         self.scheduler.step(increment=state["gbs"])
 
@@ -980,8 +992,7 @@ class MegatronPolicyWorkerImpl(
             )
 
         rescaled_metrics: list[dict[str, Any]] = []
-        curr_lr = self.scheduler.get_lr(self.optimizer.param_groups[0])
-        curr_wd = self.scheduler.get_wd()
+        # curr_lr/curr_wd captured pre-scheduler.step above.
         global_valid_seqs_f = float(global_valid_seqs.item())
         global_valid_toks_f = float(global_valid_toks.item())
 

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -101,6 +101,11 @@ TokenizerType = TypeVar("TokenizerType", bound=PreTrainedTokenizerBase)
 class MegatronPolicyWorkerImpl(
     TQWorkerMixin, AbstractPolicyWorker, ColocatablePolicyInterface
 ):
+    # Holds the split-API train-step state between begin/finish or
+    # begin/abort; None when no step is open. Declared at class level so
+    # ``self._train_step_state = None`` after finish/abort type-checks.
+    _train_step_state: Optional[dict[str, Any]] = None
+
     def __repr__(self):
         """Customizes the actor's prefix in the Ray logs.
 

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -794,8 +794,16 @@ class MegatronPolicyWorkerImpl(
         # Either way, opt.step sees the right-normalized gradient.
         self.model.scale_gradients(inv_n)
 
-        # The ONE true cross-DP reduce for the entire step.
-        self.model.start_grad_sync()
+        # Cross-DP grad reduce. Megatron-core's BucketGroup.finish_grad_sync,
+        # when overlap_grad_reduce=False, internally dispatches the synchronous
+        # collective via start_grad_sync(force_all_reduce=...). So calling
+        # both unconditionally double-reduces the grads (scales by world_size).
+        # Mirror the contract: only fire start_grad_sync ourselves when the
+        # overlap path needs it; finish_grad_sync handles the rest.
+        if self.cfg["megatron_cfg"]["distributed_data_parallel_config"][
+            "overlap_grad_reduce"
+        ]:
+            self.model.start_grad_sync()
         self.model.finish_grad_sync()
 
         # opt.step clips internally (clip_grad config); operates on the

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -152,6 +152,7 @@ project-includes = [
   "nemo_rl/models/generation/vllm/vllm_backend.py",
   "nemo_rl/models/huggingface/__init__.py",
   "nemo_rl/models/megatron/__init__.py",
+  "nemo_rl/models/megatron/draft/__init__.py",
   "nemo_rl/models/policy/__init__.py",
   "nemo_rl/models/policy/interfaces.py",
   "nemo_rl/models/policy/utils.py",

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -155,6 +155,7 @@ project-includes = [
   "nemo_rl/models/megatron/draft/__init__.py",
   "nemo_rl/models/policy/__init__.py",
   "nemo_rl/models/policy/interfaces.py",
+  "nemo_rl/models/policy/policy_trainer_actor.py",
   "nemo_rl/models/policy/utils.py",
   "nemo_rl/models/policy/workers/__init__.py",
   "nemo_rl/models/policy/workers/patches.py",

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -155,7 +155,6 @@ project-includes = [
   "nemo_rl/models/megatron/draft/__init__.py",
   "nemo_rl/models/policy/__init__.py",
   "nemo_rl/models/policy/interfaces.py",
-  "nemo_rl/models/policy/policy_trainer_actor.py",
   "nemo_rl/models/policy/utils.py",
   "nemo_rl/models/policy/workers/__init__.py",
   "nemo_rl/models/policy/workers/patches.py",

--- a/tests/unit/models/policy/test_megatron_split_state.py
+++ b/tests/unit/models/policy/test_megatron_split_state.py
@@ -1,0 +1,541 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU state-machine tests for MegatronPolicyWorkerImpl's split-API.
+
+These tests cover the lifecycle and call-order invariants — they do NOT
+exercise real distributed comms, the mcore scheduler, or the optimizer.
+Numerical equivalence vs sync ``train()`` lives in the GPU parity tests.
+
+The bugs these catch:
+  - silent gradient over-counting if ``model.no_sync()`` is not wrapped
+    around ``megatron_forward_backward`` (the mcore DDP hooks would
+    dispatch a per-call reduce, ADDING to an already-reduced bucket).
+  - PP>1 pipeline-schedule bypass if ``model.config.grad_sync_func`` is
+    not nulled for the step's duration.
+  - ``trainer_version`` advancing on abort.
+  - ``zero_grad_buffer`` not called at begin (mcore's contiguous grad
+    buffer leaks stale grads otherwise).
+  - off-by-one in ``total_num_microbatches`` (used to scale MoE aux-loss).
+"""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+# Eagerly import the worker module so ``unittest.mock.patch`` can resolve
+# attributes on it via ``getattr``. Without this the patch path
+# ``nemo_rl.models.policy.workers.megatron_policy_worker.<symbol>`` fails
+# at ``getattr(workers, "megatron_policy_worker")``.
+import nemo_rl.models.policy.workers.megatron_policy_worker  # noqa: F401
+
+pytestmark = pytest.mark.mcore
+
+# Module path of the worker under test
+WORKER_MOD = "nemo_rl.models.policy.workers.megatron_policy_worker"
+
+
+# ── Mock fabric ──────────────────────────────────────────────────────────
+
+def _make_mock_model():
+    """A mcore-DDP-shaped mock: exposes the methods + attributes the
+    split-API touches, plus an ``inference_params`` attribute and a
+    ``modules()`` that yields nothing (so the inference-cache reset loop
+    is a no-op)."""
+    model = MagicMock()
+    model.config = MagicMock()
+    model.config.grad_sync_func = "ORIGINAL_GRAD_SYNC_FUNC"  # sentinel
+    model.config.num_moe_experts = None  # disable MoE branch
+    # no_sync() is a context manager — return a MagicMock that supports
+    # __enter__/__exit__ so the `with self.model.no_sync():` block works.
+    model.no_sync = MagicMock(return_value=MagicMock(
+        __enter__=MagicMock(return_value=None),
+        __exit__=MagicMock(return_value=False),
+    ))
+    model.modules = MagicMock(return_value=iter([]))
+    model.inference_params = None
+    model.parameters = MagicMock(return_value=iter([]))  # no params for the rescale loop
+    return model
+
+
+def _make_worker(loss_type):
+    """Construct a MegatronPolicyWorkerImpl instance with all heavy
+    attributes mocked. Bypasses __init__ via ``object.__new__``."""
+    # Lazy import so the module-level mcore imports happen inside the
+    # mcore-marked test process.
+    from nemo_rl.models.policy.workers.megatron_policy_worker import (
+        MegatronPolicyWorkerImpl,
+    )
+
+    w = object.__new__(MegatronPolicyWorkerImpl)
+    w.model = _make_mock_model()
+    w.optimizer = MagicMock()
+    # MegatronOptimizer.step returns (success, grad_norm, num_zeros)
+    w.optimizer.step.return_value = (True, 0.5, 0)
+    w.optimizer.param_groups = [{"lr": 1e-4, "weight_decay": 0.01}]
+    w.scheduler = MagicMock()
+    w.scheduler.get_lr.return_value = 1e-4
+    w.scheduler.get_wd.return_value = 0.01
+    w.mcore_state = MagicMock()
+    w.mcore_state.straggler_timer = None
+    w.cfg = {
+        "train_global_batch_size": 32,
+        "train_micro_batch_size": 4,
+        "megatron_cfg": {
+            "empty_unused_memory_level": 0,
+            "moe_per_layer_logging": False,
+            "use_linear_ce_fusion_loss": False,
+        },
+    }
+    w.dp_size = 2
+    w.cp_size = 1
+    w.sampling_params = None
+    w.draft_model = None
+    w.defer_fp32_logits = False
+    w.dtype = torch.float32
+    w._is_reward_model = False
+
+    # Stash a loss_fn with the requested loss_type for tests that need one.
+    w._test_loss_fn = MagicMock(loss_type=loss_type)
+    return w
+
+
+@pytest.fixture
+def mock_module_symbols():
+    """Patch every module-level symbol that the split-API methods call
+    into. Yields a dict of name → mock for assertions."""
+    # Make `aggregate_training_statistics` return ({}, scalar) — what the
+    # finish path expects.
+    agg_ret = ({"loss": [0.0]}, torch.tensor(0.5))
+
+    patches = {
+        "megatron_forward_backward": [
+            {"loss": 0.5, "global_valid_seqs": 8.0, "global_valid_toks": 256.0}
+        ],
+        "get_microbatch_iterator": (iter([]), 2, 4, 16, 16),  # 2 pipeline mbs per call
+        "LossPostProcessor": MagicMock(),
+        "broadcast_loss_metrics_from_last_stage": lambda m: m,
+        "get_pg_collection": MagicMock(mp=MagicMock()),
+        "logical_and_across_model_parallel_group": lambda v, mp_group: v,
+        "reduce_max_stat_across_model_parallel_group": lambda v, mp_group: v,
+        "aggregate_training_statistics": agg_ret,
+        "get_moe_metrics": MagicMock(return_value={}),
+    }
+
+    with patch(f"{WORKER_MOD}.megatron_forward_backward",
+               return_value=patches["megatron_forward_backward"]) as mfb, \
+         patch(f"{WORKER_MOD}.get_microbatch_iterator",
+               return_value=patches["get_microbatch_iterator"]) as gmi, \
+         patch(f"{WORKER_MOD}.LossPostProcessor",
+               return_value=patches["LossPostProcessor"]) as lpp, \
+         patch(f"{WORKER_MOD}.broadcast_loss_metrics_from_last_stage",
+               side_effect=patches["broadcast_loss_metrics_from_last_stage"]) as bcast, \
+         patch(f"{WORKER_MOD}.get_pg_collection",
+               return_value=patches["get_pg_collection"]) as gpgc, \
+         patch(f"{WORKER_MOD}.logical_and_across_model_parallel_group",
+               side_effect=patches["logical_and_across_model_parallel_group"]) as land, \
+         patch(f"{WORKER_MOD}.reduce_max_stat_across_model_parallel_group",
+               side_effect=patches["reduce_max_stat_across_model_parallel_group"]) as rmax, \
+         patch(f"{WORKER_MOD}.aggregate_training_statistics",
+               return_value=patches["aggregate_training_statistics"]) as agg, \
+         patch(f"{WORKER_MOD}.get_moe_metrics",
+               return_value={}) as moe, \
+         patch(f"{WORKER_MOD}.get_rerun_state_machine") as grsm, \
+         patch(f"{WORKER_MOD}.parallel_state") as pstate, \
+         patch("torch.distributed.all_reduce") as ar, \
+         patch("torch.cuda.empty_cache") as cec, \
+         patch("torch.cuda.get_device_name", return_value="H100"), \
+         patch("torch.distributed.get_rank", return_value=0):
+
+        # rerun state machine: fire forward+backward once per train_microbatch
+        rsm = MagicMock()
+        rsm.should_run_forward_backward.side_effect = [True, False] * 100
+        grsm.return_value = rsm
+
+        # parallel_state mocks
+        pstate.is_pipeline_last_stage.return_value = True
+        pstate.get_data_parallel_group.return_value = MagicMock()
+
+        yield {
+            "mfb": mfb, "gmi": gmi, "lpp": lpp, "bcast": bcast,
+            "gpgc": gpgc, "land": land, "rmax": rmax, "agg": agg,
+            "moe": moe, "grsm": grsm, "pstate": pstate,
+            "all_reduce": ar, "empty_cache": cec,
+        }
+
+
+def _fake_batch():
+    """A minimal BatchedDataDict-ish object the mask-sum block can read.
+    train_microbatch reads ``data["sample_mask"]``, ``data["token_mask"]``,
+    and (only as a fallback for the no-token-mask path) ``data["input_ids"]``."""
+    # 8 samples, all valid (mask=1); 256 valid tokens each
+    sample_mask = torch.ones(8, dtype=torch.float32)
+    token_mask = torch.ones(8, 257, dtype=torch.float32)  # token_mask[:, 1:] → 256 toks
+    input_ids = torch.zeros(8, 257, dtype=torch.long)
+    return {"sample_mask": sample_mask, "token_mask": token_mask, "input_ids": input_ids}
+
+
+# ── BEGIN ────────────────────────────────────────────────────────────────
+
+class TestBegin:
+    def test_opens_state(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("step-0", loss_fn=w._test_loss_fn, gbs=16, mbs=4)
+        assert w._train_step_state is not None
+        assert w._train_step_state["step_id"] == "step-0"
+        assert w._train_step_state["loss_type"] == LossType.TOKEN_LEVEL
+        assert w._train_step_state["gbs"] == 16
+        assert w._train_step_state["mbs"] == 4
+        assert w._train_step_state["total_num_microbatches"] == 0
+
+    def test_calls_zero_grad_and_zero_grad_buffer(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("step-0", loss_fn=w._test_loss_fn)
+        w.model.zero_grad_buffer.assert_called_once()
+        w.optimizer.zero_grad.assert_called_once()
+        w.model.train.assert_called_once()
+
+    def test_saves_and_nulls_grad_sync_func(self, mock_module_symbols):
+        """The PP scheduler's direct reduce dispatch must be suppressed
+        for the duration of the step. Otherwise PP>1 silently corrupts
+        grads even when ``no_sync`` is set on the bucket groups."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        assert w.model.config.grad_sync_func == "ORIGINAL_GRAD_SYNC_FUNC"
+        w.begin_train_step("step-0", loss_fn=w._test_loss_fn)
+        assert w.model.config.grad_sync_func is None
+        assert w._train_step_state["saved_grad_sync_func"] == "ORIGINAL_GRAD_SYNC_FUNC"
+
+    def test_double_begin_raises(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("step-0", loss_fn=w._test_loss_fn)
+        with pytest.raises(RuntimeError, match="already open"):
+            w.begin_train_step("step-1", loss_fn=w._test_loss_fn)
+
+    def test_uses_cfg_defaults_when_gbs_mbs_omitted(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("step-0", loss_fn=w._test_loss_fn)
+        assert w._train_step_state["gbs"] == w.cfg["train_global_batch_size"]
+        assert w._train_step_state["mbs"] == w.cfg["train_micro_batch_size"]
+
+
+# ── _assert_step_open ────────────────────────────────────────────────────
+
+class TestAssertStepOpen:
+    def test_raises_when_no_step_open(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        with pytest.raises(RuntimeError, match="no train step open"):
+            w._assert_step_open("step-0")
+
+    def test_raises_on_step_id_mismatch(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("step-correct", loss_fn=w._test_loss_fn)
+        with pytest.raises(RuntimeError, match="step_id mismatch"):
+            w._assert_step_open("step-WRONG")
+
+    def test_train_microbatch_without_begin_raises(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        with pytest.raises(RuntimeError, match="no train step open"):
+            w.train_microbatch("step-0", _fake_batch())
+
+    def test_finish_without_begin_raises(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        with pytest.raises(RuntimeError, match="no train step open"):
+            w.finish_train_step("step-0")
+
+
+# ── train_microbatch ─────────────────────────────────────────────────────
+
+class TestTrainMicrobatch:
+    def test_wraps_forward_backward_in_no_sync(self, mock_module_symbols):
+        """The single most important assertion in this file. Without the
+        no_sync wrap, mcore DDP dispatches a per-call cross-DP reduce on
+        the partially-accumulated buffer — silently corrupting grads."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.train_microbatch("s0", _fake_batch())
+        # no_sync() must have been ENTERED (called as a context manager).
+        # MagicMock with __enter__/__exit__ records the __enter__ call.
+        ctx = w.model.no_sync.return_value
+        ctx.__enter__.assert_called()
+        ctx.__exit__.assert_called()
+
+    def test_invokes_megatron_forward_backward_once(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.train_microbatch("s0", _fake_batch())
+        assert mock_module_symbols["mfb"].call_count == 1
+
+    def test_passes_placeholder_n_one_to_loss(self, mock_module_symbols):
+        """The N=1 trick: loss must be called with global_valid_*=1 so it
+        returns un-normalized sums; finish does the 1/N rescale."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.train_microbatch("s0", _fake_batch())
+        kwargs = mock_module_symbols["mfb"].call_args.kwargs
+        # placeholder_n is a tensor(1.0)
+        assert "global_valid_seqs" in kwargs
+        assert "global_valid_toks" in kwargs
+        assert float(kwargs["global_valid_seqs"].item()) == pytest.approx(1.0)
+        assert float(kwargs["global_valid_toks"].item()) == pytest.approx(1.0)
+
+    def test_accumulates_mask_sums_across_calls(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        # _fake_batch has sample_mask sum = 8, token_mask*sample_mask sum = 8*256 = 2048
+        w.train_microbatch("s0", _fake_batch())
+        assert float(w._train_step_state["local_valid_seqs"].item()) == pytest.approx(8.0)
+        assert float(w._train_step_state["local_valid_toks"].item()) == pytest.approx(2048.0)
+        w.train_microbatch("s0", _fake_batch())
+        assert float(w._train_step_state["local_valid_seqs"].item()) == pytest.approx(16.0)
+        assert float(w._train_step_state["local_valid_toks"].item()) == pytest.approx(4096.0)
+
+    def test_total_num_microbatches_accumulates(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        # get_microbatch_iterator mock returns num_microbatches=2 per call
+        w.train_microbatch("s0", _fake_batch())
+        w.train_microbatch("s0", _fake_batch())
+        w.train_microbatch("s0", _fake_batch())
+        assert w._train_step_state["total_num_microbatches"] == 6
+
+    def test_does_not_call_optimizer_step(self, mock_module_symbols):
+        """trainer_version semantics: optimizer.step() must NOT fire
+        per train_microbatch — only at finish."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.train_microbatch("s0", _fake_batch())
+        w.train_microbatch("s0", _fake_batch())
+        w.optimizer.step.assert_not_called()
+
+
+# ── finish_train_step ────────────────────────────────────────────────────
+
+class TestFinish:
+    def _setup_open_step(self, mock_module_symbols, loss_type):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(loss_type)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.train_microbatch("s0", _fake_batch())
+        return w
+
+    def test_rescales_grads_with_inv_n(self, mock_module_symbols):
+        """The 1/N rescale must happen ON the local main_grad BEFORE the
+        cross-DP reduce — otherwise the reduce sees un-rescaled sums."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
+        w.finish_train_step("s0")
+        # scale_gradients should have been called with some 1/N scalar < 1
+        w.model.scale_gradients.assert_called_once()
+        arg = w.model.scale_gradients.call_args.args[0]
+        assert 0 < arg <= 1.0
+
+    def test_start_then_finish_grad_sync_called_after_rescale(self, mock_module_symbols):
+        """Call order matters: scale_gradients -> start_grad_sync ->
+        finish_grad_sync -> optimizer.step."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
+        # Record call order via a shared list
+        order: list[str] = []
+        w.model.scale_gradients.side_effect = lambda s: order.append("scale")
+        w.model.start_grad_sync.side_effect = lambda: order.append("start_sync")
+        w.model.finish_grad_sync.side_effect = lambda: order.append("finish_sync")
+        w.optimizer.step.side_effect = lambda: (order.append("opt_step") or (True, 0.5, 0))
+        w.finish_train_step("s0")
+        assert order == ["scale", "start_sync", "finish_sync", "opt_step"]
+
+    def test_picks_global_valid_toks_for_token_level_loss(self, mock_module_symbols):
+        """N selection: TOKEN_LEVEL → N = global_valid_toks (not seqs)."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
+        w.finish_train_step("s0")
+        # local_valid_toks accumulated = 2048; with mocked all_reduce as no-op,
+        # global_valid_toks == 2048 → inv_n = 1/2048
+        arg = w.model.scale_gradients.call_args.args[0]
+        assert arg == pytest.approx(1.0 / 2048.0, rel=1e-4)
+
+    def test_picks_global_valid_seqs_for_sequence_level_loss(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = self._setup_open_step(mock_module_symbols, LossType.SEQUENCE_LEVEL)
+        w.finish_train_step("s0")
+        # local_valid_seqs = 8 → inv_n = 1/8
+        arg = w.model.scale_gradients.call_args.args[0]
+        assert arg == pytest.approx(1.0 / 8.0, rel=1e-4)
+
+    def test_restores_grad_sync_func(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
+        w.finish_train_step("s0")
+        assert w.model.config.grad_sync_func == "ORIGINAL_GRAD_SYNC_FUNC"
+
+    def test_clears_train_step_state(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
+        w.finish_train_step("s0")
+        assert w._train_step_state is None
+
+    def test_calls_scheduler_step_with_increment_gbs(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
+        w._train_step_state["gbs"] = 64
+        w.finish_train_step("s0")
+        w.scheduler.step.assert_called_once_with(increment=64)
+
+    def test_returns_metrics_dict(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
+        metrics = w.finish_train_step("s0")
+        for key in ("global_loss", "rank", "gpu_name", "model_dtype",
+                    "all_mb_metrics", "grad_norm"):
+            assert key in metrics, f"missing {key!r}"
+
+    def test_moe_branch_skipped_when_num_experts_is_none(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
+        w.model.config.num_moe_experts = None
+        metrics = w.finish_train_step("s0")
+        assert "moe_metrics" not in metrics
+
+    def test_moe_branch_uses_total_num_microbatches_for_scale(self, mock_module_symbols):
+        """MoE aux-loss scale must use the accumulated total, not the
+        per-call num_microbatches."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.model.config.num_moe_experts = 4
+        # Have get_moe_metrics return non-empty so the branch fires
+        mock_module_symbols["moe"].return_value = {"aux_loss": 0.1}
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        # 3 train_microbatch calls × 2 pipeline mbs each = 6
+        for _ in range(3):
+            w.train_microbatch("s0", _fake_batch())
+        w.finish_train_step("s0")
+        # get_moe_metrics receives loss_scale=1/6
+        kwargs = mock_module_symbols["moe"].call_args.kwargs
+        assert kwargs["loss_scale"] == pytest.approx(1.0 / 6.0, rel=1e-6)
+
+
+# ── abort_train_step ─────────────────────────────────────────────────────
+
+class TestAbort:
+    def test_restores_grad_sync_func(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.abort_train_step("s0")
+        assert w.model.config.grad_sync_func == "ORIGINAL_GRAD_SYNC_FUNC"
+
+    def test_zero_grad_buffer_and_zero_grad_called(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.model.zero_grad_buffer.reset_mock()
+        w.optimizer.zero_grad.reset_mock()
+        w.abort_train_step("s0")
+        w.model.zero_grad_buffer.assert_called_once()
+        w.optimizer.zero_grad.assert_called_once()
+
+    def test_does_not_call_optimizer_step(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.train_microbatch("s0", _fake_batch())
+        w.abort_train_step("s0")
+        w.optimizer.step.assert_not_called()
+
+    def test_clears_train_step_state(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.abort_train_step("s0")
+        assert w._train_step_state is None
+
+    def test_idempotent_with_no_open_step(self, mock_module_symbols):
+        """abort is a no-op when nothing is open."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        # Should not raise
+        w.abort_train_step("s0")
+        assert getattr(w, "_train_step_state", None) is None
+
+    def test_mismatched_step_id_raises(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        with pytest.raises(RuntimeError, match="does not match open step"):
+            w.abort_train_step("s-WRONG")
+
+    def test_can_begin_new_step_after_abort(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        w.train_microbatch("s0", _fake_batch())
+        w.abort_train_step("s0")
+        # New step opens cleanly
+        w.begin_train_step("s1", loss_fn=w._test_loss_fn)
+        assert w._train_step_state["step_id"] == "s1"
+        assert float(w._train_step_state["local_valid_seqs"].item()) == 0.0
+
+
+# ── grad_sync_func full lifecycle (integration of begin → finish/abort) ─
+
+class TestGradSyncFuncLifecycle:
+    def test_begin_finish_round_trip(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        sentinel = "MY_CUSTOM_GRAD_SYNC"
+        w.model.config.grad_sync_func = sentinel
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        assert w.model.config.grad_sync_func is None
+        w.train_microbatch("s0", _fake_batch())
+        w.finish_train_step("s0")
+        assert w.model.config.grad_sync_func == sentinel
+
+    def test_begin_abort_round_trip(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        sentinel = "MY_CUSTOM_GRAD_SYNC"
+        w.model.config.grad_sync_func = sentinel
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        assert w.model.config.grad_sync_func is None
+        w.abort_train_step("s0")
+        assert w.model.config.grad_sync_func == sentinel
+
+    def test_handles_originally_none_grad_sync_func(self, mock_module_symbols):
+        """When PP=1 (or align_grad_reduce=False), grad_sync_func is None
+        to begin with. begin → finish must leave it as None."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.model.config.grad_sync_func = None
+        w.begin_train_step("s0", loss_fn=w._test_loss_fn)
+        assert w.model.config.grad_sync_func is None
+        w.train_microbatch("s0", _fake_batch())
+        w.finish_train_step("s0")
+        assert w.model.config.grad_sync_func is None

--- a/tests/unit/models/policy/test_megatron_split_state.py
+++ b/tests/unit/models/policy/test_megatron_split_state.py
@@ -109,6 +109,12 @@ def _make_worker(loss_type):
             "empty_unused_memory_level": 0,
             "moe_per_layer_logging": False,
             "use_linear_ce_fusion_loss": False,
+            # overlap_grad_reduce=False matches the production default and
+            # the sync-GRPO path. finish_train_step relies on this to gate
+            # the explicit start_grad_sync call.
+            "distributed_data_parallel_config": {
+                "overlap_grad_reduce": False,
+            },
         },
     }
     w.dp_size = 2
@@ -422,14 +428,23 @@ class TestFinish:
         arg = w.model.scale_gradients.call_args.args[0]
         assert 0 < arg <= 1.0
 
-    def test_start_then_finish_grad_sync_called_after_rescale(
-        self, mock_module_symbols
+    @pytest.mark.parametrize("overlap_grad_reduce", [False, True])
+    def test_grad_sync_call_order_after_rescale(
+        self, mock_module_symbols, overlap_grad_reduce
     ):
-        """Call order matters: scale_gradients -> start_grad_sync ->
-        finish_grad_sync -> optimizer.step."""
+        """Call order matters: scale_gradients -> [start_grad_sync when
+        overlap=True] -> finish_grad_sync -> optimizer.step.
+
+        With overlap=False, Megatron's finish_grad_sync internally calls
+        start_grad_sync(force_all_reduce=True), so calling start_grad_sync
+        ourselves would double-reduce.
+        """
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
+        w.cfg["megatron_cfg"]["distributed_data_parallel_config"][
+            "overlap_grad_reduce"
+        ] = overlap_grad_reduce
         # Record call order via a shared list
         order: list[str] = []
         w.model.scale_gradients.side_effect = lambda s: order.append("scale")
@@ -439,7 +454,10 @@ class TestFinish:
             order.append("opt_step") or (True, 0.5, 0)
         )
         w.finish_train_step("s0")
-        assert order == ["scale", "start_sync", "finish_sync", "opt_step"]
+        if overlap_grad_reduce:
+            assert order == ["scale", "start_sync", "finish_sync", "opt_step"]
+        else:
+            assert order == ["scale", "finish_sync", "opt_step"]
 
     def test_picks_global_valid_toks_for_token_level_loss(self, mock_module_symbols):
         """N selection: TOKEN_LEVEL → N = global_valid_toks (not seqs)."""

--- a/tests/unit/models/policy/test_megatron_split_state.py
+++ b/tests/unit/models/policy/test_megatron_split_state.py
@@ -31,7 +31,6 @@ The bugs these catch:
 
 from __future__ import annotations
 
-from contextlib import nullcontext
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -51,6 +50,7 @@ WORKER_MOD = "nemo_rl.models.policy.workers.megatron_policy_worker"
 
 # ── Mock fabric ──────────────────────────────────────────────────────────
 
+
 def _make_mock_model():
     """A mcore-DDP-shaped mock: exposes the methods + attributes the
     split-API touches, plus an ``inference_params`` attribute and a
@@ -62,13 +62,17 @@ def _make_mock_model():
     model.config.num_moe_experts = None  # disable MoE branch
     # no_sync() is a context manager — return a MagicMock that supports
     # __enter__/__exit__ so the `with self.model.no_sync():` block works.
-    model.no_sync = MagicMock(return_value=MagicMock(
-        __enter__=MagicMock(return_value=None),
-        __exit__=MagicMock(return_value=False),
-    ))
+    model.no_sync = MagicMock(
+        return_value=MagicMock(
+            __enter__=MagicMock(return_value=None),
+            __exit__=MagicMock(return_value=False),
+        )
+    )
     model.modules = MagicMock(return_value=iter([]))
     model.inference_params = None
-    model.parameters = MagicMock(return_value=iter([]))  # no params for the rescale loop
+    model.parameters = MagicMock(
+        return_value=iter([])
+    )  # no params for the rescale loop
     return model
 
 
@@ -136,31 +140,45 @@ def mock_module_symbols():
         "get_moe_metrics": MagicMock(return_value={}),
     }
 
-    with patch(f"{WORKER_MOD}.megatron_forward_backward",
-               return_value=patches["megatron_forward_backward"]) as mfb, \
-         patch(f"{WORKER_MOD}.get_microbatch_iterator",
-               return_value=patches["get_microbatch_iterator"]) as gmi, \
-         patch(f"{WORKER_MOD}.LossPostProcessor",
-               return_value=patches["LossPostProcessor"]) as lpp, \
-         patch(f"{WORKER_MOD}.broadcast_loss_metrics_from_last_stage",
-               side_effect=patches["broadcast_loss_metrics_from_last_stage"]) as bcast, \
-         patch(f"{WORKER_MOD}.get_pg_collection",
-               return_value=patches["get_pg_collection"]) as gpgc, \
-         patch(f"{WORKER_MOD}.logical_and_across_model_parallel_group",
-               side_effect=patches["logical_and_across_model_parallel_group"]) as land, \
-         patch(f"{WORKER_MOD}.reduce_max_stat_across_model_parallel_group",
-               side_effect=patches["reduce_max_stat_across_model_parallel_group"]) as rmax, \
-         patch(f"{WORKER_MOD}.aggregate_training_statistics",
-               return_value=patches["aggregate_training_statistics"]) as agg, \
-         patch(f"{WORKER_MOD}.get_moe_metrics",
-               return_value={}) as moe, \
-         patch(f"{WORKER_MOD}.get_rerun_state_machine") as grsm, \
-         patch(f"{WORKER_MOD}.parallel_state") as pstate, \
-         patch("torch.distributed.all_reduce") as ar, \
-         patch("torch.cuda.empty_cache") as cec, \
-         patch("torch.cuda.get_device_name", return_value="H100"), \
-         patch("torch.distributed.get_rank", return_value=0):
-
+    with (
+        patch(
+            f"{WORKER_MOD}.megatron_forward_backward",
+            return_value=patches["megatron_forward_backward"],
+        ) as mfb,
+        patch(
+            f"{WORKER_MOD}.get_microbatch_iterator",
+            return_value=patches["get_microbatch_iterator"],
+        ) as gmi,
+        patch(
+            f"{WORKER_MOD}.LossPostProcessor", return_value=patches["LossPostProcessor"]
+        ) as lpp,
+        patch(
+            f"{WORKER_MOD}.broadcast_loss_metrics_from_last_stage",
+            side_effect=patches["broadcast_loss_metrics_from_last_stage"],
+        ) as bcast,
+        patch(
+            f"{WORKER_MOD}.get_pg_collection", return_value=patches["get_pg_collection"]
+        ) as gpgc,
+        patch(
+            f"{WORKER_MOD}.logical_and_across_model_parallel_group",
+            side_effect=patches["logical_and_across_model_parallel_group"],
+        ) as land,
+        patch(
+            f"{WORKER_MOD}.reduce_max_stat_across_model_parallel_group",
+            side_effect=patches["reduce_max_stat_across_model_parallel_group"],
+        ) as rmax,
+        patch(
+            f"{WORKER_MOD}.aggregate_training_statistics",
+            return_value=patches["aggregate_training_statistics"],
+        ) as agg,
+        patch(f"{WORKER_MOD}.get_moe_metrics", return_value={}) as moe,
+        patch(f"{WORKER_MOD}.get_rerun_state_machine") as grsm,
+        patch(f"{WORKER_MOD}.parallel_state") as pstate,
+        patch("torch.distributed.all_reduce") as ar,
+        patch("torch.cuda.empty_cache") as cec,
+        patch("torch.cuda.get_device_name", return_value="H100"),
+        patch("torch.distributed.get_rank", return_value=0),
+    ):
         # rerun state machine: fire forward+backward once per train_microbatch
         rsm = MagicMock()
         rsm.should_run_forward_backward.side_effect = [True, False] * 100
@@ -171,10 +189,19 @@ def mock_module_symbols():
         pstate.get_data_parallel_group.return_value = MagicMock()
 
         yield {
-            "mfb": mfb, "gmi": gmi, "lpp": lpp, "bcast": bcast,
-            "gpgc": gpgc, "land": land, "rmax": rmax, "agg": agg,
-            "moe": moe, "grsm": grsm, "pstate": pstate,
-            "all_reduce": ar, "empty_cache": cec,
+            "mfb": mfb,
+            "gmi": gmi,
+            "lpp": lpp,
+            "bcast": bcast,
+            "gpgc": gpgc,
+            "land": land,
+            "rmax": rmax,
+            "agg": agg,
+            "moe": moe,
+            "grsm": grsm,
+            "pstate": pstate,
+            "all_reduce": ar,
+            "empty_cache": cec,
         }
 
 
@@ -186,14 +213,20 @@ def _fake_batch():
     sample_mask = torch.ones(8, dtype=torch.float32)
     token_mask = torch.ones(8, 257, dtype=torch.float32)  # token_mask[:, 1:] → 256 toks
     input_ids = torch.zeros(8, 257, dtype=torch.long)
-    return {"sample_mask": sample_mask, "token_mask": token_mask, "input_ids": input_ids}
+    return {
+        "sample_mask": sample_mask,
+        "token_mask": token_mask,
+        "input_ids": input_ids,
+    }
 
 
 # ── BEGIN ────────────────────────────────────────────────────────────────
 
+
 class TestBegin:
     def test_opens_state(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("step-0", loss_fn=w._test_loss_fn, gbs=16, mbs=4)
         assert w._train_step_state is not None
@@ -205,6 +238,7 @@ class TestBegin:
 
     def test_calls_zero_grad_and_zero_grad_buffer(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("step-0", loss_fn=w._test_loss_fn)
         w.model.zero_grad_buffer.assert_called_once()
@@ -216,6 +250,7 @@ class TestBegin:
         for the duration of the step. Otherwise PP>1 silently corrupts
         grads even when ``no_sync`` is set on the bucket groups."""
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         assert w.model.config.grad_sync_func == "ORIGINAL_GRAD_SYNC_FUNC"
         w.begin_train_step("step-0", loss_fn=w._test_loss_fn)
@@ -224,6 +259,7 @@ class TestBegin:
 
     def test_double_begin_raises(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("step-0", loss_fn=w._test_loss_fn)
         with pytest.raises(RuntimeError, match="already open"):
@@ -231,6 +267,7 @@ class TestBegin:
 
     def test_uses_cfg_defaults_when_gbs_mbs_omitted(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("step-0", loss_fn=w._test_loss_fn)
         assert w._train_step_state["gbs"] == w.cfg["train_global_batch_size"]
@@ -239,15 +276,18 @@ class TestBegin:
 
 # ── _assert_step_open ────────────────────────────────────────────────────
 
+
 class TestAssertStepOpen:
     def test_raises_when_no_step_open(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         with pytest.raises(RuntimeError, match="no train step open"):
             w._assert_step_open("step-0")
 
     def test_raises_on_step_id_mismatch(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("step-correct", loss_fn=w._test_loss_fn)
         with pytest.raises(RuntimeError, match="step_id mismatch"):
@@ -255,12 +295,14 @@ class TestAssertStepOpen:
 
     def test_train_microbatch_without_begin_raises(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         with pytest.raises(RuntimeError, match="no train step open"):
             w.train_microbatch("step-0", _fake_batch())
 
     def test_finish_without_begin_raises(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         with pytest.raises(RuntimeError, match="no train step open"):
             w.finish_train_step("step-0")
@@ -268,12 +310,14 @@ class TestAssertStepOpen:
 
 # ── train_microbatch ─────────────────────────────────────────────────────
 
+
 class TestTrainMicrobatch:
     def test_wraps_forward_backward_in_no_sync(self, mock_module_symbols):
         """The single most important assertion in this file. Without the
         no_sync wrap, mcore DDP dispatches a per-call cross-DP reduce on
         the partially-accumulated buffer — silently corrupting grads."""
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         w.train_microbatch("s0", _fake_batch())
@@ -285,6 +329,7 @@ class TestTrainMicrobatch:
 
     def test_invokes_megatron_forward_backward_once(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         w.train_microbatch("s0", _fake_batch())
@@ -294,6 +339,7 @@ class TestTrainMicrobatch:
         """The N=1 trick: loss must be called with global_valid_*=1 so it
         returns un-normalized sums; finish does the 1/N rescale."""
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         w.train_microbatch("s0", _fake_batch())
@@ -306,18 +352,28 @@ class TestTrainMicrobatch:
 
     def test_accumulates_mask_sums_across_calls(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         # _fake_batch has sample_mask sum = 8, token_mask*sample_mask sum = 8*256 = 2048
         w.train_microbatch("s0", _fake_batch())
-        assert float(w._train_step_state["local_valid_seqs"].item()) == pytest.approx(8.0)
-        assert float(w._train_step_state["local_valid_toks"].item()) == pytest.approx(2048.0)
+        assert float(w._train_step_state["local_valid_seqs"].item()) == pytest.approx(
+            8.0
+        )
+        assert float(w._train_step_state["local_valid_toks"].item()) == pytest.approx(
+            2048.0
+        )
         w.train_microbatch("s0", _fake_batch())
-        assert float(w._train_step_state["local_valid_seqs"].item()) == pytest.approx(16.0)
-        assert float(w._train_step_state["local_valid_toks"].item()) == pytest.approx(4096.0)
+        assert float(w._train_step_state["local_valid_seqs"].item()) == pytest.approx(
+            16.0
+        )
+        assert float(w._train_step_state["local_valid_toks"].item()) == pytest.approx(
+            4096.0
+        )
 
     def test_total_num_microbatches_accumulates(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         # get_microbatch_iterator mock returns num_microbatches=2 per call
@@ -330,6 +386,7 @@ class TestTrainMicrobatch:
         """trainer_version semantics: optimizer.step() must NOT fire
         per train_microbatch — only at finish."""
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         w.train_microbatch("s0", _fake_batch())
@@ -339,9 +396,9 @@ class TestTrainMicrobatch:
 
 # ── finish_train_step ────────────────────────────────────────────────────
 
+
 class TestFinish:
     def _setup_open_step(self, mock_module_symbols, loss_type):
-        from nemo_rl.algorithms.loss.interfaces import LossType
         w = _make_worker(loss_type)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         w.train_microbatch("s0", _fake_batch())
@@ -351,6 +408,7 @@ class TestFinish:
         """The 1/N rescale must happen ON the local main_grad BEFORE the
         cross-DP reduce — otherwise the reduce sees un-rescaled sums."""
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
         w.finish_train_step("s0")
         # scale_gradients should have been called with some 1/N scalar < 1
@@ -358,23 +416,29 @@ class TestFinish:
         arg = w.model.scale_gradients.call_args.args[0]
         assert 0 < arg <= 1.0
 
-    def test_start_then_finish_grad_sync_called_after_rescale(self, mock_module_symbols):
+    def test_start_then_finish_grad_sync_called_after_rescale(
+        self, mock_module_symbols
+    ):
         """Call order matters: scale_gradients -> start_grad_sync ->
         finish_grad_sync -> optimizer.step."""
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
         # Record call order via a shared list
         order: list[str] = []
         w.model.scale_gradients.side_effect = lambda s: order.append("scale")
         w.model.start_grad_sync.side_effect = lambda: order.append("start_sync")
         w.model.finish_grad_sync.side_effect = lambda: order.append("finish_sync")
-        w.optimizer.step.side_effect = lambda: (order.append("opt_step") or (True, 0.5, 0))
+        w.optimizer.step.side_effect = lambda: (
+            order.append("opt_step") or (True, 0.5, 0)
+        )
         w.finish_train_step("s0")
         assert order == ["scale", "start_sync", "finish_sync", "opt_step"]
 
     def test_picks_global_valid_toks_for_token_level_loss(self, mock_module_symbols):
         """N selection: TOKEN_LEVEL → N = global_valid_toks (not seqs)."""
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
         w.finish_train_step("s0")
         # local_valid_toks accumulated = 2048; with mocked all_reduce as no-op,
@@ -384,6 +448,7 @@ class TestFinish:
 
     def test_picks_global_valid_seqs_for_sequence_level_loss(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = self._setup_open_step(mock_module_symbols, LossType.SEQUENCE_LEVEL)
         w.finish_train_step("s0")
         # local_valid_seqs = 8 → inv_n = 1/8
@@ -392,18 +457,21 @@ class TestFinish:
 
     def test_restores_grad_sync_func(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
         w.finish_train_step("s0")
         assert w.model.config.grad_sync_func == "ORIGINAL_GRAD_SYNC_FUNC"
 
     def test_clears_train_step_state(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
         w.finish_train_step("s0")
         assert w._train_step_state is None
 
     def test_calls_scheduler_step_with_increment_gbs(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
         w._train_step_state["gbs"] = 64
         w.finish_train_step("s0")
@@ -411,23 +479,34 @@ class TestFinish:
 
     def test_returns_metrics_dict(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
         metrics = w.finish_train_step("s0")
-        for key in ("global_loss", "rank", "gpu_name", "model_dtype",
-                    "all_mb_metrics", "grad_norm"):
+        for key in (
+            "global_loss",
+            "rank",
+            "gpu_name",
+            "model_dtype",
+            "all_mb_metrics",
+            "grad_norm",
+        ):
             assert key in metrics, f"missing {key!r}"
 
     def test_moe_branch_skipped_when_num_experts_is_none(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
         w.model.config.num_moe_experts = None
         metrics = w.finish_train_step("s0")
         assert "moe_metrics" not in metrics
 
-    def test_moe_branch_uses_total_num_microbatches_for_scale(self, mock_module_symbols):
+    def test_moe_branch_uses_total_num_microbatches_for_scale(
+        self, mock_module_symbols
+    ):
         """MoE aux-loss scale must use the accumulated total, not the
         per-call num_microbatches."""
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.model.config.num_moe_experts = 4
         # Have get_moe_metrics return non-empty so the branch fires
@@ -444,9 +523,11 @@ class TestFinish:
 
 # ── abort_train_step ─────────────────────────────────────────────────────
 
+
 class TestAbort:
     def test_restores_grad_sync_func(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         w.abort_train_step("s0")
@@ -454,6 +535,7 @@ class TestAbort:
 
     def test_zero_grad_buffer_and_zero_grad_called(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         w.model.zero_grad_buffer.reset_mock()
@@ -464,6 +546,7 @@ class TestAbort:
 
     def test_does_not_call_optimizer_step(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         w.train_microbatch("s0", _fake_batch())
@@ -472,6 +555,7 @@ class TestAbort:
 
     def test_clears_train_step_state(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         w.abort_train_step("s0")
@@ -480,6 +564,7 @@ class TestAbort:
     def test_idempotent_with_no_open_step(self, mock_module_symbols):
         """abort is a no-op when nothing is open."""
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         # Should not raise
         w.abort_train_step("s0")
@@ -487,6 +572,7 @@ class TestAbort:
 
     def test_mismatched_step_id_raises(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         with pytest.raises(RuntimeError, match="does not match open step"):
@@ -494,6 +580,7 @@ class TestAbort:
 
     def test_can_begin_new_step_after_abort(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)
         w.train_microbatch("s0", _fake_batch())
@@ -506,9 +593,11 @@ class TestAbort:
 
 # ── grad_sync_func full lifecycle (integration of begin → finish/abort) ─
 
+
 class TestGradSyncFuncLifecycle:
     def test_begin_finish_round_trip(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         sentinel = "MY_CUSTOM_GRAD_SYNC"
         w.model.config.grad_sync_func = sentinel
@@ -520,6 +609,7 @@ class TestGradSyncFuncLifecycle:
 
     def test_begin_abort_round_trip(self, mock_module_symbols):
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         sentinel = "MY_CUSTOM_GRAD_SYNC"
         w.model.config.grad_sync_func = sentinel
@@ -532,6 +622,7 @@ class TestGradSyncFuncLifecycle:
         """When PP=1 (or align_grad_reduce=False), grad_sync_func is None
         to begin with. begin → finish must leave it as None."""
         from nemo_rl.algorithms.loss.interfaces import LossType
+
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.model.config.grad_sync_func = None
         w.begin_train_step("s0", loss_fn=w._test_loss_fn)

--- a/tests/unit/models/policy/test_megatron_split_state.py
+++ b/tests/unit/models/policy/test_megatron_split_state.py
@@ -36,11 +36,17 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 
+# megatron.bridge is only available with the mcore extras. Without it the
+# eager import of megatron_policy_worker (transitively imports megatron.bridge)
+# fails at COLLECTION time on non-mcore shards, which then breaks every other
+# test in that shard. importorskip stops collection cleanly here.
+pytest.importorskip("megatron.bridge")
+
 # Eagerly import the worker module so ``unittest.mock.patch`` can resolve
 # attributes on it via ``getattr``. Without this the patch path
 # ``nemo_rl.models.policy.workers.megatron_policy_worker.<symbol>`` fails
 # at ``getattr(workers, "megatron_policy_worker")``.
-import nemo_rl.models.policy.workers.megatron_policy_worker  # noqa: F401
+import nemo_rl.models.policy.workers.megatron_policy_worker  # noqa: E402,F401
 
 pytestmark = pytest.mark.mcore
 

--- a/tests/unit/models/policy/test_split_train_step.py
+++ b/tests/unit/models/policy/test_split_train_step.py
@@ -38,6 +38,7 @@ import pytest
 import ray
 import torch
 
+from nemo_rl.algorithms.utils import get_tokenizer
 from nemo_rl.models.policy.lm_policy import Policy
 
 # Reuse the existing v2 worker test fixtures for config + cluster setup.
@@ -73,8 +74,12 @@ def _drive_split_path(
     Calls backend methods directly on the worker actors (bypassing
     ``TQWorkerMixin.*_presharded`` so this test doesn't need a TQ
     DataPlane setup). Returns per-worker results from ``finish_train_step``.
+
+    Mirrors ``Policy.train()``'s sharding: ``_shard_for_train`` populates
+    ``micro_batch_indices`` per DP shard, which the worker iterators need.
     """
     workers = policy.worker_group.workers
+    sharded_data = policy._shard_for_train(data, gbs)
 
     # begin on every rank
     ray.get(
@@ -89,9 +94,25 @@ def _drive_split_path(
         ]
     )
 
-    # One train_microbatch call carrying the whole batch — the worker's
-    # internal bin iteration handles the per-mb fwd+bwd.
-    ray.get([w.train_microbatch.remote(step_id=step_id, data=data) for w in workers])
+    # One train_microbatch call per rank, carrying that rank's DP shard.
+    # The worker's internal bin iteration handles the per-mb fwd+bwd.
+    futures = policy.worker_group.run_all_workers_sharded_data(
+        "train_microbatch",
+        data=sharded_data,
+        in_sharded_axes=["data_parallel"],
+        replicate_on_axes=[
+            "context_parallel",
+            "tensor_parallel",
+            "pipeline_parallel",
+        ],
+        output_is_replicated=[
+            "context_parallel",
+            "tensor_parallel",
+            "pipeline_parallel",
+        ],
+        common_kwargs={"step_id": step_id},
+    )
+    policy.worker_group.get_all_worker_results(futures)
 
     # finish on every rank — drives the 1/N rescale + opt.step + sched.step
     results = ray.get([w.finish_train_step.remote(step_id=step_id) for w in workers])
@@ -127,7 +148,7 @@ def test_split_train_step_parity_token_level(
 
     # ── sync path ──────────────────────────────────────────────────────
     policy_sync = Policy(
-        tokenizer=None,
+        tokenizer=get_tokenizer(config["tokenizer"]),
         config=config,
         init_optimizer=True,
         init_reference_model=False,
@@ -143,7 +164,7 @@ def test_split_train_step_parity_token_level(
 
     # ── split path on a fresh policy with same init seed ──────────────
     policy_split = Policy(
-        tokenizer=None,
+        tokenizer=get_tokenizer(config["tokenizer"]),
         config=config,
         init_optimizer=True,
         init_reference_model=False,
@@ -215,9 +236,20 @@ def test_split_train_step_parity_seq_packing(
         cp=1,
         dtensor_v2=dtensor_v2,
         sequence_packing_enabled=True,
+        # FlashAttention (which seq-packing uses) requires fp16/bf16.
+        precision="bfloat16",
     )
     # Force dynamic_batching off so the seq-packing path is taken.
     config["dynamic_batching"]["enabled"] = False
+    # LMPolicy reads config["make_sequence_length_divisible_by"] and
+    # config["sequence_packing"]["algorithm"] when seq packing is enabled;
+    # create_test_config doesn't set either. Fill in production defaults.
+    config["make_sequence_length_divisible_by"] = 1
+    config["sequence_packing"]["algorithm"] = "modified_first_fit_decreasing"
+    config["sequence_packing"]["sequence_length_round"] = 64
+    config["sequence_packing"]["logprob_mb_tokens"] = config["sequence_packing"][
+        "train_mb_tokens"
+    ]
 
     data = create_test_batch(
         batch_size=config["train_global_batch_size"],
@@ -226,7 +258,7 @@ def test_split_train_step_parity_seq_packing(
     loss_fn = SimpleLossFn()
 
     policy_sync = Policy(
-        tokenizer=None,
+        tokenizer=get_tokenizer(config["tokenizer"]),
         config=config,
         init_optimizer=True,
         init_reference_model=False,
@@ -241,7 +273,7 @@ def test_split_train_step_parity_seq_packing(
         policy_sync.shutdown()
 
     policy_split = Policy(
-        tokenizer=None,
+        tokenizer=get_tokenizer(config["tokenizer"]),
         config=config,
         init_optimizer=True,
         init_reference_model=False,
@@ -302,7 +334,7 @@ def test_split_state_machine_lifecycle(
         dtensor_v2=dtensor_v2,
     )
     policy = Policy(
-        tokenizer=None,
+        tokenizer=get_tokenizer(config["tokenizer"]),
         config=config,
         init_optimizer=True,
         init_reference_model=False,

--- a/tests/unit/models/policy/test_split_train_step.py
+++ b/tests/unit/models/policy/test_split_train_step.py
@@ -39,7 +39,6 @@ import ray
 import torch
 
 from nemo_rl.models.policy.lm_policy import Policy
-from tests.unit.test_utils import SimpleLossFn
 
 # Reuse the existing v2 worker test fixtures for config + cluster setup.
 from tests.unit.models.policy.test_dtensor_worker_v2 import (
@@ -47,6 +46,7 @@ from tests.unit.models.policy.test_dtensor_worker_v2 import (
     create_test_config,
     two_gpu_virtual_cluster,  # noqa: F401 — fixture, used implicitly
 )
+from tests.unit.test_utils import SimpleLossFn
 
 
 def _all_param_state(policy: Policy) -> dict[str, torch.Tensor]:

--- a/tests/unit/models/policy/test_split_train_step.py
+++ b/tests/unit/models/policy/test_split_train_step.py
@@ -1,0 +1,349 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Parity tests for the SingleController split-API state machine.
+
+The split path (``begin_train_step`` → ``train_microbatch`` × K →
+``finish_train_step``) must produce gradients and post-step parameters
+identical (within fp tolerance) to the sync ``train()`` path. This file
+asserts that equivalence end-to-end on a real GPU worker.
+
+Math sanity check covered by these tests:
+  ``masked_mean(values, mask, N) = sum(values·mask)/(N+ε)`` is linear in
+  1/N, so per-microbatch backward with ``global_valid_seqs = global_valid_toks
+  = tensor(1.0)`` deposits raw ``d(sum)/dθ`` into ``.grad``. The single
+  ``1/N`` rescale at finish recovers the sync-path gradient.
+
+All tests require GPUs; gated via ``pytest.mark.gpu``. They also drive
+worker actors via ``policy.worker_group.run_all_workers_*`` directly to
+exercise the backend state machine without depending on the TQ/DataPlane
+plumbing (which is covered separately under ``tests/unit/data_plane/``).
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+import ray
+import torch
+
+from nemo_rl.models.policy.lm_policy import Policy
+from tests.unit.test_utils import SimpleLossFn
+
+# Reuse the existing v2 worker test fixtures for config + cluster setup.
+from tests.unit.models.policy.test_dtensor_worker_v2 import (
+    create_test_batch,
+    create_test_config,
+    two_gpu_virtual_cluster,  # noqa: F401 — fixture, used implicitly
+)
+
+
+def _all_param_state(policy: Policy) -> dict[str, torch.Tensor]:
+    """Snapshot every worker-rank-0 parameter tensor as CPU float32."""
+    state = ray.get(policy.worker_group.workers[0].return_state_dict.remote())
+    return {
+        k: v.detach().to(torch.float32).cpu()
+        for k, v in state.items()
+        if isinstance(v, torch.Tensor)
+    }
+
+
+def _drive_split_path(
+    policy: Policy,
+    data,
+    loss_fn,
+    gbs: int,
+    mbs: int,
+    *,
+    step_id: str = "test-step-000",
+) -> list[dict]:
+    """Drive begin → train_microbatch → finish on every worker.
+
+    Calls backend methods directly on the worker actors (bypassing
+    ``TQWorkerMixin.*_presharded`` so this test doesn't need a TQ
+    DataPlane setup). Returns per-worker results from ``finish_train_step``.
+    """
+    workers = policy.worker_group.workers
+
+    # begin on every rank
+    ray.get(
+        [
+            w.begin_train_step.remote(
+                step_id=step_id,
+                loss_fn=loss_fn,
+                gbs=gbs,
+                mbs=mbs,
+            )
+            for w in workers
+        ]
+    )
+
+    # One train_microbatch call carrying the whole batch — the worker's
+    # internal bin iteration handles the per-mb fwd+bwd.
+    ray.get([w.train_microbatch.remote(step_id=step_id, data=data) for w in workers])
+
+    # finish on every rank — drives the 1/N rescale + opt.step + sched.step
+    results = ray.get([w.finish_train_step.remote(step_id=step_id) for w in workers])
+    return results
+
+
+@pytest.mark.gpu
+@pytest.mark.hf_gated
+@pytest.mark.automodel
+@pytest.mark.timeout(360)
+@pytest.mark.parametrize("dtensor_v2", [False, True])
+def test_split_train_step_parity_token_level(
+    two_gpu_virtual_cluster,  # noqa: F811
+    tiny_llama_model_path,
+    dtensor_v2,
+):
+    """Sync ``train()`` vs split begin/microbatch/finish on identical state.
+
+    Asserts post-step model parameters match within fp tolerance. Run on
+    both DTensor v1 and v2 to validate the matching implementations.
+    """
+    config = create_test_config(
+        model_name=tiny_llama_model_path,
+        tp=2,
+        cp=1,
+        dtensor_v2=dtensor_v2,
+    )
+    data = create_test_batch(
+        batch_size=config["train_global_batch_size"],
+        mode="train",
+    )
+    loss_fn = SimpleLossFn()
+
+    # ── sync path ──────────────────────────────────────────────────────
+    policy_sync = Policy(
+        tokenizer=None,
+        config=config,
+        init_optimizer=True,
+        init_reference_model=False,
+        cluster=two_gpu_virtual_cluster,
+        name_prefix=f"sync_{int(dtensor_v2)}",
+    )
+    try:
+        policy_sync.prepare_for_training()
+        sync_result = policy_sync.train(copy.deepcopy(data), loss_fn)
+        sync_params = _all_param_state(policy_sync)
+    finally:
+        policy_sync.shutdown()
+
+    # ── split path on a fresh policy with same init seed ──────────────
+    policy_split = Policy(
+        tokenizer=None,
+        config=config,
+        init_optimizer=True,
+        init_reference_model=False,
+        cluster=two_gpu_virtual_cluster,
+        name_prefix=f"split_{int(dtensor_v2)}",
+    )
+    try:
+        policy_split.prepare_for_training()
+        split_results = _drive_split_path(
+            policy_split,
+            data=copy.deepcopy(data),
+            loss_fn=loss_fn,
+            gbs=config["train_global_batch_size"],
+            mbs=config["train_micro_batch_size"],
+        )
+        split_params = _all_param_state(policy_split)
+    finally:
+        policy_split.shutdown()
+
+    # Loss: sync emits a single tensor; split returns one dict per rank.
+    split_loss_rank0 = split_results[0].get("global_loss")
+    assert split_loss_rank0 is not None, "split path must surface global_loss"
+    sync_loss = sync_result["loss"]
+    if isinstance(sync_loss, torch.Tensor):
+        sync_loss_v = sync_loss.detach().cpu().to(torch.float32)
+    else:
+        sync_loss_v = torch.tensor(float(sync_loss))
+    split_loss_v = split_loss_rank0.detach().cpu().to(torch.float32)
+    # Reduce to scalar for comparison if multi-element
+    sync_scalar = sync_loss_v.sum().item()
+    split_scalar = split_loss_v.sum().item()
+    assert abs(sync_scalar - split_scalar) <= max(1e-3, 1e-3 * abs(sync_scalar)), (
+        f"global_loss mismatch: sync={sync_scalar:.6f} split={split_scalar:.6f}"
+    )
+
+    # Post-step parameters should match (within fp tolerance).
+    assert set(sync_params.keys()) == set(split_params.keys()), (
+        f"parameter key set mismatch: sync-only={set(sync_params) - set(split_params)} "
+        f"split-only={set(split_params) - set(sync_params)}"
+    )
+    for name, sync_p in sync_params.items():
+        split_p = split_params[name]
+        torch.testing.assert_close(
+            sync_p,
+            split_p,
+            atol=5e-4,
+            rtol=5e-4,
+            msg=lambda m, n=name: f"parameter '{n}' diverged after step:\n{m}",
+        )
+
+
+@pytest.mark.gpu
+@pytest.mark.hf_gated
+@pytest.mark.automodel
+@pytest.mark.timeout(360)
+@pytest.mark.parametrize("dtensor_v2", [False, True])
+def test_split_train_step_parity_seq_packing(
+    two_gpu_virtual_cluster,  # noqa: F811
+    tiny_llama_model_path,
+    dtensor_v2,
+):
+    """Same parity assertion but under sequence packing — exercises the
+    multi-bin-per-call path inside ``train_microbatch`` and the DP rank
+    bin-count dummy padding.
+    """
+    config = create_test_config(
+        model_name=tiny_llama_model_path,
+        tp=2,
+        cp=1,
+        dtensor_v2=dtensor_v2,
+        sequence_packing_enabled=True,
+    )
+    # Force dynamic_batching off so the seq-packing path is taken.
+    config["dynamic_batching"]["enabled"] = False
+
+    data = create_test_batch(
+        batch_size=config["train_global_batch_size"],
+        mode="train",
+    )
+    loss_fn = SimpleLossFn()
+
+    policy_sync = Policy(
+        tokenizer=None,
+        config=config,
+        init_optimizer=True,
+        init_reference_model=False,
+        cluster=two_gpu_virtual_cluster,
+        name_prefix=f"sync_pack_{int(dtensor_v2)}",
+    )
+    try:
+        policy_sync.prepare_for_training()
+        sync_result = policy_sync.train(copy.deepcopy(data), loss_fn)
+        sync_params = _all_param_state(policy_sync)
+    finally:
+        policy_sync.shutdown()
+
+    policy_split = Policy(
+        tokenizer=None,
+        config=config,
+        init_optimizer=True,
+        init_reference_model=False,
+        cluster=two_gpu_virtual_cluster,
+        name_prefix=f"split_pack_{int(dtensor_v2)}",
+    )
+    try:
+        policy_split.prepare_for_training()
+        _drive_split_path(
+            policy_split,
+            data=copy.deepcopy(data),
+            loss_fn=loss_fn,
+            gbs=config["train_global_batch_size"],
+            mbs=config["train_micro_batch_size"],
+        )
+        split_params = _all_param_state(policy_split)
+    finally:
+        policy_split.shutdown()
+
+    # Sanity that we actually exercised the seq-packing path
+    assert config["sequence_packing"]["enabled"]
+    assert not config["dynamic_batching"]["enabled"]
+    assert sync_result is not None
+
+    for name, sync_p in sync_params.items():
+        split_p = split_params[name]
+        torch.testing.assert_close(
+            sync_p,
+            split_p,
+            atol=5e-4,
+            rtol=5e-4,
+            msg=lambda m, n=name: f"parameter '{n}' diverged under seq-packing:\n{m}",
+        )
+
+
+@pytest.mark.gpu
+@pytest.mark.hf_gated
+@pytest.mark.automodel
+@pytest.mark.timeout(180)
+@pytest.mark.parametrize("dtensor_v2", [False, True])
+def test_split_state_machine_lifecycle(
+    two_gpu_virtual_cluster,  # noqa: F811
+    tiny_llama_model_path,
+    dtensor_v2,
+):
+    """Lifecycle invariants on a live worker.
+
+    Asserts:
+      - ``begin_train_step`` twice without finish raises.
+      - ``train_microbatch`` without an open step raises.
+      - ``abort_train_step`` is idempotent and clears state.
+      - ``finish_train_step`` after abort raises (state was cleared).
+    """
+    config = create_test_config(
+        model_name=tiny_llama_model_path,
+        tp=2,
+        cp=1,
+        dtensor_v2=dtensor_v2,
+    )
+    policy = Policy(
+        tokenizer=None,
+        config=config,
+        init_optimizer=True,
+        init_reference_model=False,
+        cluster=two_gpu_virtual_cluster,
+        name_prefix=f"lifecycle_{int(dtensor_v2)}",
+    )
+    try:
+        policy.prepare_for_training()
+        loss_fn = SimpleLossFn()
+        worker = policy.worker_group.workers[0]
+
+        # double begin should raise
+        ray.get(
+            worker.begin_train_step.remote(
+                step_id="step-a", loss_fn=loss_fn, gbs=4, mbs=1
+            )
+        )
+        with pytest.raises(Exception):
+            ray.get(
+                worker.begin_train_step.remote(
+                    step_id="step-b", loss_fn=loss_fn, gbs=4, mbs=1
+                )
+            )
+
+        # abort idempotency
+        ray.get(worker.abort_train_step.remote(step_id="step-a"))
+        ray.get(worker.abort_train_step.remote(step_id="step-a"))  # no-op
+
+        # post-abort, train_microbatch and finish should raise (no open step)
+        with pytest.raises(Exception):
+            data = create_test_batch(batch_size=4)
+            ray.get(worker.train_microbatch.remote(step_id="step-a", data=data))
+        with pytest.raises(Exception):
+            ray.get(worker.finish_train_step.remote(step_id="step-a"))
+
+        # new begin works after abort
+        ray.get(
+            worker.begin_train_step.remote(
+                step_id="step-c", loss_fn=loss_fn, gbs=4, mbs=1
+            )
+        )
+        ray.get(worker.abort_train_step.remote(step_id="step-c"))
+    finally:
+        policy.shutdown()


### PR DESCRIPTION
> 📚 **Stacked PR** — 3-PR async-GRPO split-API series (top → bottom):
> - #2700 — SingleController streaming train_pump (split-API consumer)
> - 👉 **#2692** — DTensor v1/v2 split-API + PolicyTrainerActor ← *you are here*
> - #2683 — Megatron split-API train-step state machine
> - base: `main` (logically: `asyncrl/split_train_mcore`)
>
> *Stack-aware base retargeting is unavailable for fork PRs (gh-stack limitation); manual header. Locally rebased so this branch contains #2683's commits — but GitHub's "Files changed" shows the cumulative diff. Per-layer scope: read commits authored on this branch (not present on #2683).*

---

## Summary

Adds the DTensor v1 + v2 backend implementations of the split-API train-step
methods (begin / train_microbatch / finish / abort), plus the
`PolicyTrainerActor` Ray wrapper that exposes the API to SingleController via
`.remote(...)`. Sync `train()` is left untouched on both backends.

This is **PR 2 of 3** in the SingleController split-API series:
- PR 1 — \`asyncrl/split_train_mcore\` (Megatron + shared infra: \`worker_mixin\`, \`tq_policy\`). **Open this branch's PR against \`main\` first** — the dtensor PR diff includes those commits until PR 1 lands.
- **PR 2 — this PR** (DTensor v1 + v2 + \`PolicyTrainerActor\` + GPU parity tests).
- PR 3 — coming next (SC \`_train_pump\` rewrite to drive the split API end-to-end).

## What's new

- **DTensor v1** state machine using the \`N=1\` placeholder trick. Per microbatch the loss is called with \`global_valid_*=tensor(1.0)\` so backward deposits un-normalized gradients; \`finish_train_step\` \`all_reduce\`s local mask sums to recover the true \`N\` (toks for TOKEN_LEVEL, seqs for SEQUENCE_LEVEL), rescales \`p.grad\` by \`1/N\`, runs grad_norm/clip/opt.step. Bin iteration with DP-rank dummy-bin padding handles seq-packing / dynamic-batching uneven splits without desyncing NCCL.
- **DTensor v2** same shape, built on the v2 helpers (\`LossPostProcessor\`, \`get_microbatch_iterator\`, \`automodel_forward_backward\`, \`scale_grads_and_clip_grad_norm\`). The clip helper has MoE/EP awareness; the manual \`1/N\` rescale runs before it.
- **\`PolicyTrainerActor\`** at \`nemo_rl/models/policy/policy_trainer_actor.py\` — \`@ray.remote(num_cpus=1, num_gpus=0)\` wrapper that owns a \`TQPolicy\` instance and exposes \`train_from_meta\` (sync proxy), \`prepare_logprobs_from_meta\`, and the split API. \`trainer_version\` advances on sync \`train_from_meta\` or on \`finish_train_step\` (never on abort).
- **GPU parity tests** at \`tests/unit/models/policy/test_split_train_step.py\`:
  - numerical equivalence vs sync \`train()\` for token-level and seq-level losses;
  - multi-bin-per-call under seq-packing;
  - split-state-machine lifecycle (double begin, abort idempotence).
  Parameterised over v1/v2.

## Test plan

- [ ] \`pytest tests/unit/models/policy/test_split_train_step.py -v\` on a multi-GPU CI runner.
- [ ] Sync \`train()\` path unchanged — existing test_dtensor_worker* tests still pass.
- [ ] No production caller of the split API yet (PR 3 will wire SC up), so no recipe regression possible from this PR.