### PR TITLE
fix: fix grpo-gptoss-20b-8n8g-megatron

### DIFF
--- a/examples/configs/recipes/llm/grpo-gptoss-20b-8n8g-megatron.yaml
+++ b/examples/configs/recipes/llm/grpo-gptoss-20b-8n8g-megatron.yaml
@@ -21,6 +21,8 @@ policy:
   generation:
     vllm_cfg:
       tensor_parallel_size: 2
+    vllm_kwargs:
+      moe_backend: triton
 cluster:
   num_nodes: 8
   gpus_per_node: 8

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -38,20 +38,6 @@ except ImportError:
     )
 
 
-def fix_gpt_oss_export_transpose(key: str, weight: torch.Tensor) -> torch.Tensor:
-    """Apply GPT-OSS down_proj transpose fix to the weight.
-
-    This is a workaround for the issue that the down_proj layout is not the same across different frameworks.
-        - HF needs [in, out] layout.
-        - Megatron needs [in, out] layout.
-        - vLLM needs [out, in] layout.
-    See https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/3271 for more details.
-    """
-    if key.endswith("mlp.experts.down_proj"):
-        weight = weight.transpose(-2, -1).contiguous()
-    return weight
-
-
 def fix_gemma3_vision_weight_name(key: str) -> str:
     """Re-insert the `vision_model` segment into Gemma3 vision-tower weights.
 
@@ -225,21 +211,13 @@ class VllmInternalWorkerExtension:
         draft_model.load_weights(weights=draft_weights)
 
     def _load_weights(self, weights):
-        """Load weights with GptOss transpose fix, FP8, and draft-weight support.
+        """Load weights with Gemma3 vision-tower weight name fix, FP8, and draft-weight support.
 
-        Applies GPT-OSS down_proj transpose if needed, splits policy/draft
+        Applies Gemma3 vision-tower weight name fix if needed, splits policy/draft
         weights, applies FP8 conversion if needed, and loads draft weights
         into the drafter model.
         """
         from nemo_rl.models.generation.vllm.quantization import fp8
-
-        if (
-            "GptOssForCausalLM"
-            in self.model_runner.vllm_config.model_config.architectures
-        ):
-            for idx, (key, weight) in enumerate(weights):
-                weight = fix_gpt_oss_export_transpose(key, weight)
-                weights[idx] = (key, weight)
 
         if (
             "Gemma3ForConditionalGeneration"
@@ -304,12 +282,6 @@ class VllmInternalWorkerExtension:
                         .view(dtype=dtype)
                         .view(shape)
                     )
-                    # apply gpt-oss transpose fix
-                    if (
-                        "GptOssForCausalLM"
-                        in self.model_runner.vllm_config.model_config.architectures
-                    ):
-                        weight = fix_gpt_oss_export_transpose(key, weight)
                     weights.append((key, weight))
 
                     # Move offset to the next weight


### PR DESCRIPTION
as title, verified `grpo-gptoss-20b-8n8g-megatron` could pass.

1. remove previous patch.
2. set vllm `moe_backend=triton` to keep same behavior with vllm==0.17