### PR TITLE
perf: pool IsolatedWorkerInitializer per node instead of per worker

### DIFF
--- a/nemo_rl/distributed/worker_groups.py
+++ b/nemo_rl/distributed/worker_groups.py
@@ -473,6 +473,28 @@ class RayWorkerGroup:
                 available_addresses.append(addr)
                 available_ports.append(port)
 
+        # Pool one IsolatedWorkerInitializer per unique pg_idx instead of one
+        # per worker. All workers on a node share the same py_executable, so
+        # the initializer only needs that in its runtime_env — per-worker
+        # env_vars are passed through create_worker(). This reduces GCS actor
+        # registrations from N_workers to N_nodes.
+        unique_pg_indices = sorted({pg_idx for pg_idx, _ in bundle_indices_list})
+        initializer_runtime_env = {"py_executable": py_executable}
+        self._initializer_pool: dict[int, ray.actor.ActorHandle] = {}
+        for pg_idx in unique_pg_indices:
+            # num_cpus=0 so the initializer doesn't consume a CPU slot — it
+            # sits idle after creating workers and only exists for GC lifetime.
+            self._initializer_pool[pg_idx] = (
+                RayWorkerBuilder.IsolatedWorkerInitializer.options(  # type: ignore
+                    num_cpus=0,
+                    runtime_env=initializer_runtime_env,
+                ).remote(
+                    remote_worker_builder.ray_actor_class_fqn,
+                    *remote_worker_builder.args,
+                    **remote_worker_builder.kwargs,
+                )
+            )
+
         for group_idx, (pg_idx, local_bundle_indices) in enumerate(bundle_indices_list):
             current_group = []
 
@@ -527,7 +549,7 @@ class RayWorkerGroup:
                     else 0
                 )
 
-                # Pass these options to the remote_worker_builder
+                # Build the worker's runtime_env with per-worker env_vars
                 runtime_env = {
                     "env_vars": worker_env_vars,
                     "py_executable": py_executable,
@@ -540,18 +562,19 @@ class RayWorkerGroup:
 
                 extra_options = {"runtime_env": runtime_env, "name": name}
 
-                # start worker creation asynchronously
-                worker_future, initializer = remote_worker_builder.create_worker_async(
-                    placement_group=pg,
-                    placement_group_bundle_index=bundle_idx,
-                    num_gpus=num_gpus,
-                    bundle_indices=worker_bundle_indices,
+                # Reuse the pooled initializer for this pg_idx
+                initializer = self._initializer_pool[pg_idx]
+                worker_future = initializer.create_worker.remote(
+                    pg,
+                    bundle_idx,
+                    num_gpus,
+                    worker_bundle_indices,
                     **extra_options,
                 )
 
                 # Store the future and metadata
                 worker_idx = len(worker_futures)
-                worker_futures.append((worker_future, initializer))
+                worker_futures.append(worker_future)
                 worker_info.append(
                     {
                         "group_idx": group_idx,
@@ -570,7 +593,7 @@ class RayWorkerGroup:
 
         # Wait for all workers to initialize with timing and progress bar
         num_workers = len(worker_futures)
-        worker_refs = [future for future, _ in worker_futures]
+        worker_refs = worker_futures
 
         start_time = time.perf_counter()
 
@@ -602,8 +625,7 @@ class RayWorkerGroup:
             flush=True,
         )
 
-        for idx, (worker, (_, initializer)) in enumerate(zip(workers, worker_futures)):
-            worker._RAY_INITIALIZER_ACTOR_REF_TO_AVOID_GC = initializer
+        for idx, worker in enumerate(workers):
             self._workers.append(worker)
 
             # Get the corresponding metadata
@@ -1052,29 +1074,25 @@ class RayWorkerGroup:
         # Even after successful graceful cleanup, actors remain alive in Ray's registry
         # which prevents creating new actors with the same name.
         if True:
-            initializers_to_kill = []
             for worker in self._workers:
-                if hasattr(worker, "_RAY_INITIALIZER_ACTOR_REF_TO_AVOID_GC"):
-                    # Store the initializer ref before the main worker is killed,
-                    # as killing the worker might affect accessibility of this attribute later.
-                    initializer = getattr(
-                        worker, "_RAY_INITIALIZER_ACTOR_REF_TO_AVOID_GC", None
-                    )
-                    if initializer:
-                        initializers_to_kill.append(initializer)
                 try:
                     ray.kill(worker)
                 except Exception as e:
                     success = False
                     print(f"Error killing worker: {e}")
 
-            # Now, explicitly kill the initializer actors
-            # This makes their termination more deterministic than relying solely on Ray's GC.
-            for initializer in initializers_to_kill:
-                try:
-                    ray.kill(initializer)
-                except Exception as e:
-                    print(f"Error killing initializer actor for a worker: {e}")
+            # Kill pooled initializers. These keep workers alive via Ray's owner
+            # lifecycle — kill them after the workers so workers don't get
+            # unexpectedly reaped mid-cleanup.
+            if hasattr(self, "_initializer_pool"):
+                for pg_idx, initializer in self._initializer_pool.items():
+                    try:
+                        ray.kill(initializer)
+                    except Exception as e:
+                        print(
+                            f"Error killing pooled initializer for pg_idx={pg_idx}: {e}"
+                        )
+                self._initializer_pool = {}
 
         # Clear worker lists
         self._workers = []

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -16,6 +16,7 @@ import copy
 import gc
 import os
 import sys
+from contextlib import contextmanager
 from importlib.util import find_spec
 from typing import Any, Optional, cast
 
@@ -223,6 +224,42 @@ class BaseVllmGenerationWorker:
 
             return file_path
 
+        @contextmanager
+        def _locked_file_patch(file_path: str):
+            """Yield (content, writer) under an exclusive file lock.
+
+            Multiple workers on the same node call _apply_vllm_patches
+            concurrently. Without a lock, one worker's ``open(path, "w")``
+            truncates the file while another is reading it, causing spurious
+            "expected code snippet not found" warnings.
+
+            Usage::
+
+                with _locked_file_patch(path) as (content, write_back):
+                    if already_patched(content):
+                        return
+                    content = content.replace(old, new)
+                    write_back(content)
+            """
+            import fcntl
+
+            lock_path = file_path + ".patch_lock"
+            lock_fd = open(lock_path, "w")
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX)
+
+                with open(file_path, "r") as f:
+                    content = f.read()
+
+                def write_back(new_content: str):
+                    with open(file_path, "w") as f:
+                        f.write(new_content)
+
+                yield content, write_back
+            finally:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                lock_fd.close()
+
         def _patch_vllm_init_workers_ray():
             """Patch the vLLM ray_distributed_executor.py file.
 
@@ -233,9 +270,6 @@ class BaseVllmGenerationWorker:
                 - See https://github.com/NVIDIA-NeMo/RL/pull/898 for more details.
             """
             file_to_patch = _get_vllm_file("v1/executor/ray_executor.py")
-
-            with open(file_to_patch, "r") as f:
-                content = f.read()
 
             old_lines = [
                 "self._init_workers_ray(placement_group)",
@@ -250,19 +284,16 @@ class BaseVllmGenerationWorker:
                 f'ADDITIONAL_ENV_VARS = {{"HF_TOKEN", "HUGGING_FACE_HUB_TOKEN", "NCCL_CUMEM_ENABLE", "NCCL_NVLS_ENABLE", "RAY_ENABLE_UV_RUN_RUNTIME_ENV", {extra_env_str}}}',
             ]
 
-            need_replace = False
-            for old_line, new_line in zip(old_lines, new_lines):
-                if new_line in content or old_line not in content:
-                    continue
-                content = content.replace(old_line, new_line)
-                need_replace = True
+            with _locked_file_patch(file_to_patch) as (content, write_back):
+                need_replace = False
+                for old_line, new_line in zip(old_lines, new_lines):
+                    if new_line in content or old_line not in content:
+                        continue
+                    content = content.replace(old_line, new_line)
+                    need_replace = True
 
-            if not need_replace:
-                return
-
-            # Write back the patched content
-            with open(file_to_patch, "w") as f:
-                f.write(content)
+                if need_replace:
+                    write_back(content)
 
         def _patch_vllm_llama_eagle3_own_lm_head():
             """Patch LlamaEagle3 to keep truncated draft lm_head ownership."""
@@ -272,13 +303,6 @@ class BaseVllmGenerationWorker:
                 logger.warning(
                     "Could not locate llama_eagle3.py for lm_head ownership patch."
                 )
-                return
-
-            with open(file_to_patch, "r") as f:
-                content = f.read()
-
-            if "self.has_own_lm_head = (" in content:
-                logger.info("llama_eagle3 lm_head ownership patch already applied.")
                 return
 
             old_snippet = (
@@ -304,19 +328,22 @@ class BaseVllmGenerationWorker:
                 "        self.logits_processor = LogitsProcessor(\n"
             )
 
-            if old_snippet not in content:
-                logger.warning(
-                    "Could not apply llama_eagle3 lm_head ownership patch: "
-                    "expected code snippet not found in %s. "
-                    "The vLLM version may have changed.",
-                    file_to_patch,
-                )
-                return
+            with _locked_file_patch(file_to_patch) as (content, write_back):
+                if "self.has_own_lm_head = (" in content:
+                    logger.info("llama_eagle3 lm_head ownership patch already applied.")
+                    return
 
-            content = content.replace(old_snippet, new_snippet, 1)
+                if old_snippet not in content:
+                    logger.warning(
+                        "Could not apply llama_eagle3 lm_head ownership patch: "
+                        "expected code snippet not found in %s. "
+                        "The vLLM version may have changed.",
+                        file_to_patch,
+                    )
+                    return
 
-            with open(file_to_patch, "w") as f:
-                f.write(content)
+                content = content.replace(old_snippet, new_snippet, 1)
+                write_back(content)
 
             logger.info("Successfully patched llama_eagle3 lm_head ownership.")
 
@@ -344,13 +371,6 @@ class BaseVllmGenerationWorker:
             - https://github.com/PrimeIntellect-ai/prime-rl/pull/1837
             """
             file_to_patch = _get_vllm_file("tool_parsers/hermes_tool_parser.py")
-
-            with open(file_to_patch, "r") as f:
-                content = f.read()
-
-            if "_tokenizer_cache" in content:
-                logger.info("Hermes tool parser thread-safety patch already applied.")
-                return
 
             old_import = "import json\nfrom collections.abc import Sequence"
             new_import = (
@@ -422,21 +442,26 @@ class BaseVllmGenerationWorker:
                 "                    }"
             )
 
-            if old_init_snippet not in content:
-                logger.warning(
-                    "Could not apply hermes tool parser thread-safety patch: "
-                    "expected code snippet not found in %s. "
-                    "The vLLM version may have changed.",
-                    file_to_patch,
-                )
-                return
+            with _locked_file_patch(file_to_patch) as (content, write_back):
+                if "_tokenizer_cache" in content:
+                    logger.info(
+                        "Hermes tool parser thread-safety patch already applied."
+                    )
+                    return
 
-            content = content.replace(old_import, new_import, 1)
-            content = content.replace(old_class_line, new_class_line, 1)
-            content = content.replace(old_init_snippet, new_init_snippet, 1)
+                if old_init_snippet not in content:
+                    logger.warning(
+                        "Could not apply hermes tool parser thread-safety patch: "
+                        "expected code snippet not found in %s. "
+                        "The vLLM version may have changed.",
+                        file_to_patch,
+                    )
+                    return
 
-            with open(file_to_patch, "w") as f:
-                f.write(content)
+                content = content.replace(old_import, new_import, 1)
+                content = content.replace(old_class_line, new_class_line, 1)
+                content = content.replace(old_init_snippet, new_init_snippet, 1)
+                write_back(content)
 
             logger.info("Successfully patched hermes tool parser for thread-safety.")
 

--- a/tests/unit/distributed/test_worker_groups.py
+++ b/tests/unit/distributed/test_worker_groups.py
@@ -288,6 +288,48 @@ def test_basic_worker_creation_and_method_calls(register_test_actor, virtual_clu
     worker_group.shutdown(force=True)
 
 
+def test_initializer_pool_is_per_node_single_node(worker_group_1d_sharding):
+    """One IsolatedWorkerInitializer is pooled per node (pg_idx), not per worker.
+
+    The 1d fixture places 2 workers on a single node, so the pool holds a
+    single initializer even though there are 2 workers.
+    """
+    worker_group = worker_group_1d_sharding
+    assert len(worker_group.workers) == 2
+    assert len(worker_group._initializer_pool) == 1
+    assert set(worker_group._initializer_pool.keys()) == {0}
+
+
+def test_initializer_pool_is_per_node_multi_node(worker_group_2d_sharding):
+    """The pool holds one initializer per unique pg_idx across multiple nodes.
+
+    The 2d fixture spans 2 nodes with 4 workers total, so the pool holds 2
+    initializers — a per-node count, not the per-worker count of 4.
+    """
+    worker_group = worker_group_2d_sharding
+    assert len(worker_group.workers) == 4
+    assert len(worker_group._initializer_pool) == 2
+    assert set(worker_group._initializer_pool.keys()) == {0, 1}
+
+
+def test_shutdown_clears_initializer_pool(
+    register_test_actor, virtual_cluster_4_bundles
+):
+    """shutdown() kills the pooled initializers and clears the pool."""
+    builder = RayWorkerBuilder(register_test_actor)
+    sharding = NamedSharding(layout=[[0, 1], [2, 3]], names=["dp", "tp"])
+    worker_group = RayWorkerGroup(
+        cluster=virtual_cluster_4_bundles,
+        remote_worker_builder=builder,
+        workers_per_node=None,
+        sharding_annotations=sharding,
+    )
+    assert len(worker_group._initializer_pool) == 2
+
+    assert worker_group.shutdown(force=True) is True
+    assert worker_group._initializer_pool == {}
+
+
 def test_actor_initialization_with_args_kwargs(register_test_actor, virtual_cluster):
     actor_fqn = register_test_actor
     init_args = ("arg1", 123)


### PR DESCRIPTION
# What does this PR do ?

Create one `IsolatedWorkerInitializer` actor per unique placement-group index (node) instead of one per worker. All workers on a node share a `py_executable`, so the initializer only needs that in its runtime_env; per-worker env_vars are passed through create_worker().

This reduces GCS actor registrations from N_workers to N_nodes (`|num_gpus/node|` reduction for Megatron, `|TP size|` for vLLM), cutting RPC traffic to Ray's single-threaded GCS so large-scale runs don't overload it.

Cleanup is simplified: pooled initializers are killed after workers in shutdown, and the per-worker `_RAY_INITIALIZER_ACTOR_REF_TO_AVOID_GC` attribute is no longer needed.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
