### PR TITLE
feat: upstreaming refit prefetching optimization

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1385,8 +1385,8 @@ def refit_policy_generation(
                 )
                 futures_inference = policy_generation.update_weights_via_ipc_zmq()
                 # wait for all futures to complete
-                ray.get(futures_train)
-                results = ray.get(futures_inference)
+                all_results = ray.get(list(futures_train) + list(futures_inference))
+                results = all_results[len(futures_train) :]
                 update_success = all(result for result in results if result is not None)
         else:
             # update weights through nccl
@@ -1399,8 +1399,8 @@ def refit_policy_generation(
             futures_train = policy.broadcast_weights_for_collective(kv_scales=kv_scales)
             futures_inference = policy_generation.update_weights_from_collective()
             # wait for all futures to complete
-            ray.get(futures_train)
-            results = ray.get(futures_inference)
+            all_results = ray.get(list(futures_train) + list(futures_inference))
+            results = all_results[len(futures_train) :]
             update_success = all(result for result in results if result is not None)
             policy.prepare_for_training()
 

--- a/nemo_rl/utils/packed_tensor.py
+++ b/nemo_rl/utils/packed_tensor.py
@@ -14,8 +14,9 @@
 
 import math
 import os
+from collections import deque
 from functools import lru_cache
-from typing import Any, List, Tuple
+from typing import Any, Callable, Deque, Iterator, List, Optional, Tuple
 
 import torch
 
@@ -36,6 +37,142 @@ def get_num_buffers():
     return int(os.getenv("NRL_REFIT_NUM_BUFFERS", "2"))
 
 
+@lru_cache(maxsize=1)
+def get_prefetch_depth():
+    return int(os.getenv("NRL_REFIT_PREFETCH_DEPTH", "4"))
+
+
+# Cached resources. Both producer and consumer are called many times per
+# training run (once per refit), and ``packed_broadcast_producer`` /
+# ``packed_broadcast_consumer`` historically created fresh CUDA streams and
+# ``torch.cat``-allocated fresh packed buffers on every call.
+
+
+_cached_streams: dict[str, list[torch.cuda.Stream]] = {}  # role -> list[Stream]
+_cached_buffers: dict[
+    tuple[str, int], list[torch.Tensor]
+] = {}  # (role, size_bytes) -> list[Tensor]
+
+
+def _get_cached_streams(role: str, num_buffers: int) -> list[torch.cuda.Stream]:
+    """Return ``num_buffers`` CUDA streams, lazily allocated once per role.
+
+    role: "producer" or "consumer"
+    """
+    streams = _cached_streams.get(role)
+    if streams is None:
+        streams = [torch.cuda.Stream() for _ in range(num_buffers)]
+        _cached_streams[role] = streams
+    return streams
+
+
+def _get_cached_buffers(
+    role: str, num_buffers: int, size_bytes: int
+) -> list[torch.Tensor]:
+    # Return num_buffers persistent CUDA buffers of size_bytes.
+    # Buffers are reallocated only if a larger size is requested.
+    key = (role, size_bytes)
+    buffers = _cached_buffers.get(key)
+    if buffers is not None:
+        return buffers
+
+    # Drop any smaller-capacity cache entries for the same role.
+    # We only keep the largest capacity we've ever needed.
+    for existing_key in list(_cached_buffers.keys()):
+        if existing_key[0] == role:
+            del _cached_buffers[existing_key]
+
+    buffers = [
+        torch.empty(size_bytes, dtype=torch.uint8, device="cuda")
+        for _ in range(num_buffers)
+    ]
+    _cached_buffers[key] = buffers
+    return buffers
+
+
+class _PrefetchingTensorIterator:
+    """Runs ``post_iter_func(next(iterator))`` ahead on a side CUDA stream.
+
+    Keeps up to ``depth`` converted tensors queued with per-item CUDA events
+    so the consumer can order its packing stream on the producer stream via
+    ``stream.wait_event(event)`` — without any CPU-side synchronize.
+
+    Each produced element is the result of
+    ``post_iter_func(next(iterator)).view(torch.uint8).view(-1)``, i.e. a
+    linearized uint8 view suitable for direct ``torch.cat`` into the packing
+    buffer. Doing the view here (rather than in the consumer) keeps the
+    prefetch stream as the sole writer to the underlying storage and
+    simplifies ordering.
+
+    When ``depth <= 0`` the prefetcher degrades to an eager no-prefetch path
+    that records an event on the default stream (semantically identical to
+    the pre-prefetch implementation apart from the extra event), so callers
+    can always consume via the same API.
+    """
+
+    def __init__(
+        self,
+        iterator: Iterator[Any],
+        post_iter_func: Callable[[Any], torch.Tensor],
+        depth: int,
+    ) -> None:
+        self._iterator = iterator
+        self._post_iter_func = post_iter_func
+        self._depth = max(depth, 0)
+        self._queue: Deque[Tuple[Optional[torch.cuda.Event], torch.Tensor]] = deque()
+        self._stream: torch.cuda.Stream = torch.cuda.Stream()
+        self._exhausted = False
+
+    def try_prefetch(self) -> None:
+        """Top up the internal queue to ``depth`` without blocking.
+
+        Safe to call from any stream context; the prefetch work is issued on
+        the dedicated prefetch stream. Silently stops once the underlying
+        iterator is exhausted.
+        """
+        if self._exhausted or self._depth == 0:
+            return
+        while len(self._queue) < self._depth:
+            try:
+                with torch.cuda.stream(self._stream):  # type: ignore[arg-type]
+                    tensor = (
+                        self._post_iter_func(next(self._iterator))
+                        .contiguous()
+                        .view(torch.uint8)
+                        .view(-1)
+                    )
+                    event = torch.cuda.Event()
+                    event.record(self._stream)  # type: ignore[arg-type]
+                self._queue.append((event, tensor))
+            except StopIteration:
+                self._exhausted = True
+                return
+
+    def next_on(self, consumer_stream: torch.cuda.Stream) -> torch.Tensor:
+        """Return the next prefetched tensor, ordered on ``consumer_stream``.
+
+        Raises ``StopIteration`` when the underlying iterator is drained.
+        """
+        if self._depth == 0:
+            # No prefetch: do the conversion inline on the consumer stream.
+            tensor = (
+                self._post_iter_func(next(self._iterator))
+                .contiguous()
+                .view(torch.uint8)
+                .view(-1)
+            )
+            return tensor
+
+        if not self._queue:
+            self.try_prefetch()
+        if not self._queue:
+            raise StopIteration
+        event, tensor = self._queue.popleft()
+        # Ensure the consumer stream observes the prefetch stream's writes.
+        consumer_stream.wait_event(event)
+        return tensor
+
+
 def packed_broadcast_producer(iterator, group, src, post_iter_func):
     """Broadcast a list of tensors in a packed manner.
 
@@ -47,19 +184,49 @@ def packed_broadcast_producer(iterator, group, src, post_iter_func):
 
     Returns:
         None
-
     """
     target_packed_tensor_size = get_target_packed_tensor_size()
 
     num_buffers = get_num_buffers()
-    streams = [torch.cuda.Stream() for _ in range(num_buffers)]
+    # Streams and packed buffers are cached across refits to avoid per-call
+    # ``torch.cuda.Stream()`` construction and large uint8 buffer churn
+    # through the PyTorch caching allocator. ``torch.cat`` below writes into
+    # a slice of the persistent buffer via ``out=`` and the broadcast uses
+    # the slice, so correctness is unaffected.
+    streams = _get_cached_streams("producer", num_buffers)
     buffer_idx = 0
 
-    packing_tensor_list = [[] for _ in range(num_buffers)]
+    packing_tensor_list: list[list[torch.Tensor]] = [[] for _ in range(num_buffers)]
     packing_tensor_sizes = [0 for _ in range(num_buffers)]
-    packed_tensors = [
-        torch.empty(0, dtype=torch.uint8, device="cuda") for _ in range(num_buffers)
-    ]
+    # Pre-allocate ``target_packed_tensor_size`` per buffer. ``_pack_and_broadcast``
+    # will grow the cache on demand if a single packed buffer overshoots
+    # ``target_packed_tensor_size`` (the pack loop only breaks *after* exceeding).
+    packed_buffers = _get_cached_buffers(
+        "producer", num_buffers, target_packed_tensor_size
+    )
+
+    def _pack_and_broadcast(idx: int) -> None:
+        nonlocal packed_buffers
+        total_size = packing_tensor_sizes[idx]
+        if total_size > packed_buffers[idx].numel():
+            # Grow the cache for both buffers (keeps them uniformly sized so
+            # a subsequent buffer swap doesn't re-allocate). The cache
+            # helper drops any smaller-capacity entries for this role, so
+            # we don't leak memory across growths.
+            packed_buffers = _get_cached_buffers("producer", num_buffers, total_size)
+        out_view = packed_buffers[idx].narrow(0, 0, total_size)
+        torch.cat(packing_tensor_list[idx], dim=0, out=out_view)
+        group.broadcast(out_view, src=src)
+
+    prefetcher = _PrefetchingTensorIterator(
+        iterator=iterator,
+        post_iter_func=post_iter_func,
+        depth=get_prefetch_depth(),
+    )
+
+    # try_prefetch will initiate the prefetching process
+    # while the prefetched tensors < prefetch_depth
+    prefetcher.try_prefetch()
 
     while True:
         # Move to the next buffer
@@ -74,31 +241,24 @@ def packed_broadcast_producer(iterator, group, src, post_iter_func):
                 packing_tensor_sizes[buffer_idx] = 0
                 # Pack the tensors
                 while True:
-                    # Apply backend specific post processing and then convert to linearized uint8 tensor.
-                    # contiguous() is required because the upstream iterator may
-                    # yield non-contiguous tensors that view(...) cannot handle.
-                    tensor = (
-                        post_iter_func(next(iterator))
-                        .contiguous()
-                        .view(torch.uint8)
-                        .view(-1)
-                    )
+                    # Apply backend specific post processing and then convert to linearized uint8 tensor
+                    tensor = prefetcher.next_on(streams[buffer_idx])
                     packing_tensor_list[buffer_idx].append(tensor)
                     packing_tensor_sizes[buffer_idx] += tensor.view(torch.uint8).numel()
+                    # Triger the prefetcher to prefetch the next tensor
+                    prefetcher.try_prefetch()
                     if packing_tensor_sizes[buffer_idx] > target_packed_tensor_size:
                         break
-                # Pack the tensors and call broadcast collective
-                packed_tensors[buffer_idx] = torch.cat(
-                    packing_tensor_list[buffer_idx], dim=0
-                )
-                group.broadcast(packed_tensors[buffer_idx], src=src)
+                # Pack into the persistent buffer and broadcast.
+                _pack_and_broadcast(buffer_idx)
+                # Nudge the prefetcher once more so the next buffer's tasks
+                # begin enqueuing TP/PP NCCL work on the prefetch stream
+                # concurrently with this buffer's outbound group.broadcast.
+                prefetcher.try_prefetch()
             except StopIteration:
                 # do the last broadcast if there are remaining tensors
                 if len(packing_tensor_list[buffer_idx]) > 0:
-                    packed_tensors[buffer_idx] = torch.cat(
-                        packing_tensor_list[buffer_idx], dim=0
-                    )
-                    group.broadcast(packed_tensors[buffer_idx], src=src)
+                    _pack_and_broadcast(buffer_idx)
                 break
 
 
@@ -147,15 +307,28 @@ def packed_broadcast_consumer(iterator, group, src, post_unpack_func):
     target_packed_tensor_size = get_target_packed_tensor_size()
 
     num_buffers = get_num_buffers()
-    streams = [torch.cuda.Stream() for _ in range(num_buffers)]
+    # Same caching rationale as the producer: reuse streams and packed
+    # receive buffers across refits. Each iteration slices the persistent
+    # buffer to the exact packed size before ``group.broadcast`` so NCCL
+    # sees the right receive length.
+    streams = _get_cached_streams("consumer", num_buffers)
     buffer_idx = 0
 
-    packing_tensor_meta_data = [[] for _ in range(num_buffers)]
+    packing_tensor_meta_data: list[list[Any]] = [[] for _ in range(num_buffers)]
     packing_tensor_sizes = [0 for _ in range(num_buffers)]
     offsets = [0 for _ in range(num_buffers)]
-    packed_tensors = [
-        torch.empty(0, dtype=torch.uint8, device="cuda") for _ in range(num_buffers)
-    ]
+    packed_buffers = _get_cached_buffers(
+        "consumer", num_buffers, target_packed_tensor_size
+    )
+
+    def _recv_and_unpack(idx: int) -> None:
+        nonlocal packed_buffers
+        total_size = packing_tensor_sizes[idx]
+        if total_size > packed_buffers[idx].numel():
+            packed_buffers = _get_cached_buffers("consumer", num_buffers, total_size)
+        recv_view = packed_buffers[idx].narrow(0, 0, total_size)
+        group.broadcast(recv_view, src=src)
+        post_unpack_func(unpack_tensor(recv_view, packing_tensor_meta_data[idx]))
 
     while True:
         # Move to the next buffer
@@ -179,32 +352,9 @@ def packed_broadcast_consumer(iterator, group, src, post_unpack_func):
                     offsets[buffer_idx] += tensor_size
                     if packing_tensor_sizes[buffer_idx] > target_packed_tensor_size:
                         break
-                # Create a packed tensor and broadcast it
-                packed_tensors[buffer_idx] = torch.empty(
-                    packing_tensor_sizes[buffer_idx], dtype=torch.uint8, device="cuda"
-                )
-                group.broadcast(packed_tensors[buffer_idx], src=src)
-                # Load the packed tensor into the model
-                post_unpack_func(
-                    unpack_tensor(
-                        packed_tensors[buffer_idx], packing_tensor_meta_data[buffer_idx]
-                    )
-                )
+                _recv_and_unpack(buffer_idx)
             except StopIteration:
                 # do the last broadcast if there are remaining tensors
                 if len(packing_tensor_meta_data[buffer_idx]) > 0:
-                    # Create a packed tensor and broadcast it
-                    packed_tensors[buffer_idx] = torch.empty(
-                        packing_tensor_sizes[buffer_idx],
-                        dtype=torch.uint8,
-                        device="cuda",
-                    )
-                    group.broadcast(packed_tensors[buffer_idx], src=src)
-                    # Load the packed tensor into the model
-                    post_unpack_func(
-                        unpack_tensor(
-                            packed_tensors[buffer_idx],
-                            packing_tensor_meta_data[buffer_idx],
-                        )
-                    )
+                    _recv_and_unpack(buffer_idx)
                 break


### PR DESCRIPTION
# What does this PR do ?

Upstreaming prefetch optimization for the non-colocated refit ([ref](https://gitlab-master.nvidia.com/terryk/nemo-rl-internal/-/merge_requests/266/diffs#40342d3add605a36398701f980c6d4d7b99ecbc5)) from the ultra-v3 branch.

| Test case | Baseline | Patch | Δ vs baseline |
|-----------|-----------|--------|---------------|
| dsv3-64n4g | 6.28s (3225704, n=5) | 6.07s (3228643, n=7: 6.10, 6.02, 6.09, 6.05, 6.05, 6.11, 6.04) | −0.21s (−3.3%) |
| qwen3-235b-32n4g | 3.10s (3225718, n=3) | 3.07s (3228641, n=6: 3.10, 2.89, 3.45, 3.07, 2.94, 2.96) | −0.03s (−1%) |
| qwen3-30ba3b-4n4g | 3.68s (3225719, n=3) | 3.01s (3228642, n=5: 2.79, 2.88, 2.82, 3.44, 3.13) | −0.67s (−18%) |


Wandb log: https://wandb.ai/nvidia/nemorl-refit-benchmark?nw=nwuseryoungeunk&panelDisplayName=timing%2Ftrain%2Fweight_sync&panelSectionName=timing

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
