### PR TITLE
feat(xtoken): support TP/CP/diff-DP sharded cross-tokenizer distillation

### DIFF
--- a/examples/configs/recipes/llm/distillation-xtoken-off-policy-qwen3-4b-to-llama3.2-1b-1n8g-dtensor-tp4cp2.yaml
+++ b/examples/configs/recipes/llm/distillation-xtoken-off-policy-qwen3-4b-to-llama3.2-1b-1n8g-dtensor-tp4cp2.yaml
@@ -1,0 +1,39 @@
+defaults: ../../xtoken_off_policy_distillation.yaml
+distillation:
+  num_prompts_per_step: 8
+  max_num_steps: 20
+  val_period: 10
+  val_at_start: true
+data:
+  train:
+    split_validation_size: 64
+    seed: 42
+policy:
+  train_global_batch_size: 8
+  max_total_sequence_length: 1024
+  dtensor_cfg:
+    tensor_parallel_size: 4
+    context_parallel_size: 2
+  scheduler:
+  - name: torch.optim.lr_scheduler.LinearLR
+    kwargs:
+      start_factor: 0.1
+      end_factor: 1.0
+      total_iters: 5
+  - name: torch.optim.lr_scheduler.ConstantLR
+    kwargs:
+      factor: 1.0
+      total_iters: 10000000000
+  - milestones:
+    - 5
+teacher:
+  train_global_batch_size: 8
+  max_total_sequence_length: 1024
+  dtensor_cfg:
+    tensor_parallel_size: 2
+    context_parallel_size: 2
+logger:
+  log_dir: logs/distillation-xtoken-off-policy-qwen3-4b-to-llama3.2-1b-1n8g-dtensor-tp4cp2
+  wandb:
+    project: nemo-rl
+    name: distillation-xtoken-off-policy-qwen3-4b-to-llama3.2-1b-1n8g-dtensor-tp4cp2

--- a/examples/configs/xtoken_off_policy_distillation.yaml
+++ b/examples/configs/xtoken_off_policy_distillation.yaml
@@ -14,6 +14,9 @@ distillation:
   val_period: 0               # validation disabled by default
   val_at_start: false
   val_at_end: false
+  # Teacher microbatch size for the validation logits export. Defaults to
+  # teacher.train_micro_batch_size if unset. Independent of training MBS.
+  val_teacher_micro_batch_size: 1
 
 loss_fn:
   # Path to the (student, teacher) projection matrix .pt file. Override via

--- a/examples/configs/xtoken_off_policy_distillation.yaml
+++ b/examples/configs/xtoken_off_policy_distillation.yaml
@@ -14,9 +14,10 @@ distillation:
   val_period: 0               # validation disabled by default
   val_at_start: false
   val_at_end: false
-  # Teacher microbatch size for the validation logits export. Defaults to
-  # teacher.train_micro_batch_size if unset. Independent of training MBS.
-  val_teacher_micro_batch_size: 1
+  # Teacher microbatch size for the validation logits export. Defaults to the
+  # teacher's train MBS via interpolation; override with a literal to tune the
+  # val export independently of training.
+  val_teacher_micro_batch_size: ${teacher.train_micro_batch_size}
 
 loss_fn:
   # Path to the (student, teacher) projection matrix .pt file. Override via

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -20,16 +20,24 @@ from pydantic import BaseModel
 from nemo_rl.algorithms.loss.interfaces import LossFunction, LossInputType, LossType
 from nemo_rl.algorithms.utils import calculate_kl, masked_mean
 from nemo_rl.algorithms.x_token.loss_utils import (
-    Fp32SparseMM,
-    alignment_from_flat_batch,
+    LocalizedAlignment,
     build_exact_token_map,
+    ce_label_mask,
     chunk_average_log_probs,
-    dp_all_reduce_sum,
     get_sparse_projection_matrix,
+    next_token_accuracy,
+    project_student_to_teacher_vocab,
+    select_teacher_topk_indices,
+    student_next_token_ce,
     valid_chunk_mask,
 )
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
-from nemo_rl.distributed.model_utils import DistributedCrossEntropy
+from nemo_rl.distributed.model_utils import (
+    DistributedCrossEntropy,
+    dp_all_reduce_sum,
+    vocab_parallel_full_log_softmax,
+    vocab_parallel_log_softmax,
+)
 
 Tensor = TypeVar("Tensor", bound=torch.Tensor)
 
@@ -1328,14 +1336,13 @@ class CrossTokenizerDistillationLossDataDict(TypedDict):
     input_lengths: torch.Tensor
     token_mask: torch.Tensor
     sample_mask: torch.Tensor
-    # Full-vocab teacher logits shipped via CUDA IPC. List[B] of dicts; every
-    # entry within one DP rank carries the same ``rank_logits_ipc`` handle
-    # (taken on the producer's ``[B_r, T_t, V_t]`` tray) plus its own
-    # ``sample_idx_within_rank``. The consumer rebuilds the single rank-level
-    # handle and slices ``[mb_start:mb_end]`` for a contiguous view — no
-    # ``torch.stack``. Produced by ``Policy.get_full_logits_ipc``. The loss
-    # fn either derives a microbatch-global top-k subset internally (P-KL
-    # path) or uses full vocab end-to-end (gold-loss path).
+    # Teacher logits shipped via per-rank CUDA IPC shards. List[B] of handle
+    # dicts (``payload_ipc`` + ``buf_idx``/``sample_index_in_buf`` + TP/CP
+    # shard metadata) produced by ``Policy.get_full_logits_ipc``;
+    # ``rebuild_teacher_full_logits_from_ipc`` (called in ``prepare_loss_input``)
+    # P2P-reads and reassembles full-vocab teacher logits, routing across
+    # heterogeneous teacher/student TP/CP. The loss fn then derives a
+    # microbatch-global top-k subset (P-KL) or uses full vocab (gold-loss).
     teacher_full_logits_ipc: list[dict[str, Any]]
     alignment_pair_valid: torch.Tensor  # [B, max_pairs]
     alignment_pair_is_correct: torch.Tensor  # [B, max_pairs]
@@ -1428,11 +1435,27 @@ class CrossTokenizerDistillationLossFn(LossFunction):
         global_valid_toks: torch.Tensor,
         logits: torch.Tensor,
         teacher_full_logits: torch.Tensor,
+        student_logits_contig: torch.Tensor,
+        align: LocalizedAlignment,
+        *,
+        tp_group: Optional[torch.distributed.ProcessGroup] = None,
+        cp_group: Optional[torch.distributed.ProcessGroup] = None,
     ) -> tuple[torch.Tensor, dict[str, Any]]:
-        """Compute the cross-tokenizer distillation loss for one microbatch."""
+        """Compute the cross-tokenizer distillation loss for one microbatch.
+
+        ``student_logits_contig`` (CP-relaid) and ``align`` (localized + next-token
+        shifted chunk ids) are precomputed in ``prepare_loss_input`` and shared by
+        both loss paths; the raw ``logits`` is kept for the CE / accuracy terms.
+        """
         if self.gold_loss:
             kd_loss, kl_common, l1_uncommon, num_valid_chunks, top1_acc = (
-                self._compute_gold(logits, data, teacher_full_logits)
+                self._compute_gold(
+                    student_logits_contig,
+                    teacher_full_logits,
+                    align,
+                    tp_group=tp_group,
+                    cp_group=cp_group,
+                )
             )
             ce_loss = self._compute_ce(logits, data, global_valid_toks)
             # Combine the H-KL distillation loss with next-token CE, mirroring
@@ -1463,24 +1486,24 @@ class CrossTokenizerDistillationLossFn(LossFunction):
             return loss, metrics
 
         kl_loss, num_valid_pairs, proj_acc = self._compute_p_kl(
-            logits, data, teacher_full_logits
+            student_logits_contig,
+            teacher_full_logits,
+            align,
+            tp_group=tp_group,
+            cp_group=cp_group,
         )
         ce_loss = self._compute_ce(logits, data, global_valid_toks)
 
         # Next-token accuracy on the student side, masked to valid tokens.
-        # Quick per-step signal on the student's next-token prediction
-        # quality.
-        with torch.no_grad():
-            student_argmax = logits[:, :-1].argmax(dim=-1)
-            shift_labels = data["input_ids"][:, 1:]
-            acc_mask = (
-                data["token_mask"][:, 1:].float()
-                * data["sample_mask"].unsqueeze(-1).float()
-            )
-            denom = acc_mask.sum().clamp(min=1.0)
-            accuracy = (
-                (student_argmax == shift_labels).float() * acc_mask
-            ).sum() / denom
+        # Quick per-step signal on the student's next-token prediction quality.
+        accuracy = next_token_accuracy(
+            logits,
+            input_ids=data["input_ids"],
+            token_mask=data["token_mask"],
+            sample_mask=data["sample_mask"],
+            tp_group=tp_group,
+            cp_group=cp_group,
+        )
 
         if self.dynamic_loss_scaling:
             # Dynamic loss scaling:
@@ -1517,58 +1540,56 @@ class CrossTokenizerDistillationLossFn(LossFunction):
     # ------------------------------------------------------------------ #
     def _compute_p_kl(
         self,
-        logits: torch.Tensor,
-        data: BatchedDataDict[CrossTokenizerDistillationLossDataDict],
+        student_logits: torch.Tensor,
         teacher_full_logits: torch.Tensor,
+        align: LocalizedAlignment,
+        *,
+        tp_group: Optional[torch.distributed.ProcessGroup] = None,
+        cp_group: Optional[torch.distributed.ProcessGroup] = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """P-KL: chunk-averaged KL over a microbatch-global top-k teacher subset.
+
+        ``student_logits`` (CP-relaid to contiguous) and ``align`` (localized,
+        with next-token-shifted chunk ids) are precomputed in
+        ``prepare_loss_input``.
 
         Steps:
 
         1. Project full-vocab student probs through ``M`` to teacher vocab.
         2. Use the full teacher logits materialized by ``prepare_loss_input``.
-        3. Align each predictor with the token it predicts by shifting the
-           per-position tensors and chunk ids by one (drop the last
-           predictor position and the first chunk label), symmetrically on
-           student and teacher. Matches the next-token shift already used by
-           the CE term.
-        4. Compute one ``global_top_indices [k]`` per microbatch from the
+        3. Compute one ``global_top_indices [k]`` per microbatch from the
            teacher's importance: ``max`` over flat ``(B*T_t)``, ``topk``
            over ``V_t``. Same vocab subset across every sample/position —
            keeps chunk-averaged KL well-defined.
-        5. Slice both the projected student probs and the teacher logits
+        4. Slice both the projected student probs and the teacher logits
            to those ``k`` columns.
-        6. Build per-token chunk masks from ``alignment_*_chunk_id`` and
+        5. Build per-token chunk masks from ``alignment_*_chunk_id`` and
            chunk-average via ``bmm`` (shared helper).
-        7. Renormalize student chunk distributions inside the top-k subset
+        6. Renormalize student chunk distributions inside the top-k subset
            (avg-then-renormalize, log).
-        8. Forward (or reverse) KL between chunk distributions.
+        7. Forward (or reverse) KL between chunk distributions.
         """
         T = self.temperature
-        device = logits.device
+        device = student_logits.device
         eps = 1e-10
 
-        b, t_s, v_s = logits.shape
-        student_log_probs = torch.log_softmax(logits.float() / T, dim=-1)
-        student_probs = student_log_probs.exp()  # [B, T_s, V_s]
+        # Vocab-sharded (TP) students keep the shard with globally-correct
+        # normalization; the result is projected onto the teacher vocab next.
+        student_log_probs = vocab_parallel_log_softmax(
+            student_logits, T, tp_group=tp_group
+        )
+        student_probs = student_log_probs.exp()  # [B, T_s_local, V_s_local]
 
-        # Project to full teacher vocab. Sparse matmul via M.T trick.
-        # `Fp32SparseMM` keeps the op in FP32 on both forward and backward;
-        # `torch.sparse.mm` has no BF16 kernel and the worker's autocast(BF16)
-        # context wraps loss.backward(), so a plain `.float()` cast isn't
-        # enough — the backward kernel is still dispatched as BF16.
-        M = get_sparse_projection_matrix(
+        sparse_projection = get_sparse_projection_matrix(
             self.projection_matrix_path,
             device,
             student_vocab_size=self.student_vocab_size,
             teacher_vocab_size=self.teacher_vocab_size,
         )  # [V_s, V_t] sparse COO, fp32
-        flat = student_probs.reshape(b * t_s, v_s)
-        # Fp32SparseMM internally computes M.t() @ dense; passing M (not
-        # M.t()) avoids a sparse `.t()` on a saved tensor in backward.
-        projected_full = Fp32SparseMM.apply(M, flat.t()).t()  # [B*T_s, V_t]
-        v_t = projected_full.shape[-1]
-        projected_full = projected_full.reshape(b, t_s, v_t)  # [B, T_s, V_t]
+        projected_full = project_student_to_teacher_vocab(
+            student_probs, sparse_projection, tp_group=tp_group
+        )  # [B, T_s_local, V_t]
+        full_teacher_vocab_size = projected_full.shape[-1]
 
         # `teacher_full_logits` [B, T_t, V_t_model] is materialized by
         # `prepare_loss_input` (rebuilt from the IPC handles). Same transport
@@ -1581,56 +1602,40 @@ class CrossTokenizerDistillationLossFn(LossFunction):
         # columns aren't real tokens and the projection has no entries
         # there. Slice to the projection's V_t to keep the projected
         # student probs and the teacher logits on the same vocab axis.
-        if teacher_full_logits.shape[-1] > v_t:
-            teacher_full_logits = teacher_full_logits[..., :v_t]
+        if teacher_full_logits.shape[-1] > full_teacher_vocab_size:
+            teacher_full_logits = teacher_full_logits[..., :full_teacher_vocab_size]
 
-        # Chunk-alignment data.
-        alignment = alignment_from_flat_batch(data)
-        student_chunk_id = alignment.student_chunk_id  # [B, T_s] long
-        teacher_chunk_id = alignment.teacher_chunk_id  # [B, T_t] long
-        pair_valid = alignment.pair_valid  # [B, max_pairs]
+        # Chunk ids (localized + next-token-shifted) come from `prepare_loss_input`.
+        student_chunk_id = align.student_chunk_id
+        teacher_chunk_id = align.teacher_chunk_id
+        pair_valid = align.pair_valid  # [B, max_pairs]
         if self.exact_token_match_only:
-            pair_valid = pair_valid & alignment.pair_is_correct
+            pair_valid = pair_valid & align.pair_is_correct
         max_chunks = pair_valid.shape[1]
 
-        # A model's distribution at position t predicts the token at t+1, so
-        # align each predictor with the token it predicts: drop the last
-        # predictor position (nothing past the sequence to predict) and the
-        # first chunk label (no predictor precedes it). Applied symmetrically
-        # to student and teacher. Same next-token convention the CE term uses.
-        projected_full = projected_full[:, :-1, :]
-        teacher_full_logits = teacher_full_logits[:, :-1, :]
-        student_chunk_id = student_chunk_id[:, 1:]
-        teacher_chunk_id = teacher_chunk_id[:, 1:]
-
-        # global_top_indices: max over flat (B*T_t) → [V_t] → topk → [k].
-        vocab_topk = min(self.vocab_topk, v_t)
-        with torch.no_grad():
-            # reshape (not view): the shift above leaves teacher_full_logits
-            # non-contiguous.
-            teacher_flat = teacher_full_logits.reshape(-1, v_t)
-            global_importance = teacher_flat.max(dim=0).values
-            global_top_indices = torch.topk(
-                global_importance, k=vocab_topk, dim=-1
-            ).indices
-            global_top_indices = global_top_indices.sort().values  # [k]
+        # One microbatch-global top-k teacher subset (CP-reduced so every rank
+        # agrees on the same vocab columns), shared across all samples/positions.
+        vocab_topk = min(self.vocab_topk, full_teacher_vocab_size)
+        global_top_indices = select_teacher_topk_indices(
+            teacher_full_logits, vocab_topk, cp_group=cp_group
+        )  # [k]
 
         # Slice both sides to the shared [k] columns.
-        projected_topk = projected_full[..., global_top_indices]  # [B, T_s-1, k]
+        projected_topk = projected_full[..., global_top_indices]  # [B, T_s, k]
         teacher_topk_logits = teacher_full_logits[
             ..., global_top_indices
-        ]  # [B, T_t-1, k]
+        ]  # [B, T_t, k]
         target_log_probs = torch.log_softmax(
             teacher_topk_logits / T, dim=-1
-        )  # [B, T_t-1, k] (renormalized within the [k] subset).
+        )  # [B, T_t, k] (renormalized within the [k] subset).
 
         # Chunk-average both sides via the shared helper.
         proj_chunks, proj_sizes = chunk_average_log_probs(
-            projected_topk, student_chunk_id, max_chunks
-        )  # [B, C, k] / [B, C]
+            projected_topk, student_chunk_id, max_chunks, cp_group=cp_group
+        )
         tgt_log_chunks, tgt_sizes = chunk_average_log_probs(
-            target_log_probs, teacher_chunk_id, max_chunks
-        )  # [B, C, k] / [B, C]
+            target_log_probs, teacher_chunk_id, max_chunks, cp_group=cp_group
+        )
 
         # Renormalize the projected chunk distribution within the top-k
         # subset, then take log. Teacher side is already log-probs (avg of
@@ -1646,7 +1651,7 @@ class CrossTokenizerDistillationLossFn(LossFunction):
         # global count so the KL is normalized by
         # `sum(global_valid_chunks)` rather than a per-rank mean —
         # mirrors the `global_valid_toks` convention used by CE.
-        sample_mask_bool = data["sample_mask"].bool()
+        sample_mask_bool = align.sample_mask.bool()
         valid_bool = chunk_mask & sample_mask_bool.unsqueeze(-1)
         global_valid_chunks = dp_all_reduce_sum(valid_bool.sum())
         if global_valid_chunks.item() == 0:
@@ -1680,25 +1685,32 @@ class CrossTokenizerDistillationLossFn(LossFunction):
                 proj_log_chunks, tgt_log_chunks, reduction="none", log_target=True
             ).sum(dim=-1)
 
-        sample_mask = data["sample_mask"].to(per_chunk_kl.dtype)  # [B]
+        sample_mask = align.sample_mask.to(per_chunk_kl.dtype)  # [B]
         valid = chunk_mask.to(per_chunk_kl.dtype) * sample_mask.unsqueeze(-1)
         denom = global_valid_chunks.to(per_chunk_kl.dtype).clamp(min=1.0)
         kl_loss = (per_chunk_kl * valid).sum() / denom * (T * T)
+
         return kl_loss, valid.sum().detach(), proj_acc.detach()
 
     def _compute_gold(
         self,
-        logits: torch.Tensor,
-        data: BatchedDataDict[CrossTokenizerDistillationLossDataDict],
+        student_logits: torch.Tensor,
         teacher_full_logits: torch.Tensor,
+        align: LocalizedAlignment,
+        *,
+        tp_group: Optional[torch.distributed.ProcessGroup] = None,
+        cp_group: Optional[torch.distributed.ProcessGroup] = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """Gold-loss path: KL on common (exact-mapped) vocab + L1 on uncommon.
 
+        ``student_logits`` (CP-relaid to contiguous) and ``align`` (localized,
+        with next-token-shifted chunk ids) are precomputed in
+        ``prepare_loss_input``.
+
         1. Lazy-build the exact-token map (cached per device).
         2. Use the full teacher logits materialized by ``prepare_loss_input``.
-        3. ``log_softmax`` on full vocab both sides; shift each predictor to
-           the token it predicts (drop the last predictor position, first
-           chunk label); chunk-average via the shared helper.
+        3. ``log_softmax`` on full vocab both sides; chunk-average via the
+           shared helper using the precomputed next-token-shifted chunk ids.
         4. Slice each chunk-averaged tensor to ``common_*`` indices and
            compute (forward or reverse) KL, reduced as
            ``sum / valid_chunk.sum()`` where ``valid_chunk`` is the
@@ -1715,7 +1727,7 @@ class CrossTokenizerDistillationLossFn(LossFunction):
         Components other than ``loss`` are detached.
         """
         T = self.temperature
-        device = logits.device
+        device = student_logits.device
 
         exact_map = build_exact_token_map(
             self.projection_matrix_path,
@@ -1739,39 +1751,34 @@ class CrossTokenizerDistillationLossFn(LossFunction):
         if teacher_full_logits.shape[-1] > v_teacher:
             teacher_full_logits = teacher_full_logits[..., :v_teacher]
 
-        student_log_probs = torch.log_softmax(
-            logits.float() / T, dim=-1
-        )  # [B, T_s, V_s]
+        # common_s / uncommon_s are arbitrary V_s indices, so the gold path needs
+        # full-vocab student log-probs (TP-sharded students are all-gathered).
+        student_log_probs = vocab_parallel_full_log_softmax(
+            student_logits, T, tp_group=tp_group
+        )
+        # teacher_full_logits is already vocab-full (consumer-side routing
+        # P2P-concat'd across TP siblings); local log_softmax is correct.
         teacher_log_probs = torch.log_softmax(
             teacher_full_logits / T, dim=-1
-        )  # [B, T_t, V_t]
+        )  # [B, T_t_local, V_t]
 
-        alignment = alignment_from_flat_batch(data)
-        student_chunk_id = alignment.student_chunk_id
-        teacher_chunk_id = alignment.teacher_chunk_id
-        pair_valid = alignment.pair_valid
+        # Chunk ids (localized + next-token-shifted) come from `prepare_loss_input`.
+        student_chunk_id = align.student_chunk_id
+        teacher_chunk_id = align.teacher_chunk_id
+        pair_valid = align.pair_valid
         max_chunks = pair_valid.shape[1]
 
-        # A model's distribution at position t predicts the token at t+1, so
-        # align each predictor with the token it predicts: drop the last
-        # predictor position and the first chunk label, symmetrically on
-        # student and teacher. See the matching note in `_compute_p_kl`.
-        student_log_probs = student_log_probs[:, :-1, :]
-        teacher_log_probs = teacher_log_probs[:, :-1, :]
-        student_chunk_id = student_chunk_id[:, 1:]
-        teacher_chunk_id = teacher_chunk_id[:, 1:]
-
         student_chunks, s_sizes = chunk_average_log_probs(
-            student_log_probs, student_chunk_id, max_chunks
-        )  # [B, C, V_s] / [B, C]
+            student_log_probs, student_chunk_id, max_chunks, cp_group=cp_group
+        )
         teacher_chunks, t_sizes = chunk_average_log_probs(
-            teacher_log_probs, teacher_chunk_id, max_chunks
-        )  # [B, C, V_t] / [B, C]
+            teacher_log_probs, teacher_chunk_id, max_chunks, cp_group=cp_group
+        )
 
         chunk_mask = valid_chunk_mask(s_sizes, t_sizes, pair_valid)
         # Match the P-KL path: a chunk only contributes if its alignment is
         # geometrically valid AND its sample isn't masked out by sample_mask.
-        sample_mask = data["sample_mask"]  # [B]
+        sample_mask = align.sample_mask  # [B]
         valid_chunk = chunk_mask & sample_mask.bool().unsqueeze(-1)
         zero_dtype = student_log_probs.dtype
         # Compute the DP-global valid-chunk count BEFORE any potentially
@@ -1900,24 +1907,18 @@ class CrossTokenizerDistillationLossFn(LossFunction):
         data: BatchedDataDict[CrossTokenizerDistillationLossDataDict],
         global_valid_toks: torch.Tensor,
     ) -> torch.Tensor:
-        """Standard next-token CE on the student side.
-
-        Uses ``token_mask[:, 1:]`` so padded tokens don't contribute.
-        """
-        input_ids = data["input_ids"]
-        token_mask = data["token_mask"][:, 1:]
-        sample_mask = data["sample_mask"]
-
-        shift_logits = logits[:, :-1].contiguous()
-        shift_labels = input_ids[:, 1:].contiguous()
-
-        per_token_ce = torch.nn.functional.cross_entropy(
-            shift_logits.reshape(-1, shift_logits.shape[-1]).float(),
-            shift_labels.reshape(-1),
-            reduction="none",
-        ).reshape(shift_labels.shape)
-
-        mask = token_mask.float() * sample_mask.unsqueeze(-1).float()
+        """Next-token CE on the student side (TP/CP handled by the helpers)."""
+        per_token_ce = student_next_token_ce(
+            logits, input_ids=data["input_ids"], seq_index=data.get("seq_index")
+        )
+        label_mask = ce_label_mask(
+            token_mask=data["token_mask"],
+            sample_mask=data["sample_mask"],
+            ce_seq_len=per_token_ce.shape[1],
+            dtype=per_token_ce.dtype,
+        )
         return masked_mean(
-            per_token_ce, mask, global_normalization_factor=global_valid_toks
+            per_token_ce,
+            label_mask,
+            global_normalization_factor=global_valid_toks,
         )

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -34,7 +34,7 @@ from nemo_rl.algorithms.x_token.loss_utils import (
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.model_utils import (
     DistributedCrossEntropy,
-    dp_all_reduce_sum,
+    group_all_reduce_sum,
     vocab_parallel_full_log_softmax,
     vocab_parallel_log_softmax,
 )
@@ -1496,10 +1496,13 @@ class CrossTokenizerDistillationLossFn(LossFunction):
 
         # Next-token accuracy on the student side, masked to valid tokens.
         # Quick per-step signal on the student's next-token prediction quality.
+        # Feed the contiguous student logits / input_ids / token_mask
+        # (CP-relaid in prepare_loss_input) so the CP-aware next-token shift
+        # pairs predictors with the right labels under load-balanced sharding.
         accuracy = next_token_accuracy(
-            logits,
-            input_ids=data["input_ids"],
-            token_mask=data["token_mask"],
+            student_logits_contig,
+            input_ids=align.student_input_ids,
+            token_mask=align.student_token_mask,
             sample_mask=data["sample_mask"],
             tp_group=tp_group,
             cp_group=cp_group,
@@ -1653,7 +1656,7 @@ class CrossTokenizerDistillationLossFn(LossFunction):
         # mirrors the `global_valid_toks` convention used by CE.
         sample_mask_bool = align.sample_mask.bool()
         valid_bool = chunk_mask & sample_mask_bool.unsqueeze(-1)
-        global_valid_chunks = dp_all_reduce_sum(valid_bool.sum())
+        global_valid_chunks = group_all_reduce_sum(valid_bool.sum())
         if global_valid_chunks.item() == 0:
             zero = torch.zeros((), device=device, dtype=proj_log_chunks.dtype)
             return (
@@ -1786,7 +1789,7 @@ class CrossTokenizerDistillationLossFn(LossFunction):
         # both `kl_common` and `l1_uncommon` use this as their denom so
         # the loss is normalized by `sum(global_valid_chunks)`, not a
         # per-rank mean.
-        global_valid_chunks = dp_all_reduce_sum(valid_chunk.sum())
+        global_valid_chunks = group_all_reduce_sum(valid_chunk.sum())
         if global_valid_chunks.item() == 0:
             zero = torch.zeros((), device=device, dtype=zero_dtype)
             return (

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -1656,7 +1656,9 @@ class CrossTokenizerDistillationLossFn(LossFunction):
         # mirrors the `global_valid_toks` convention used by CE.
         sample_mask_bool = align.sample_mask.bool()
         valid_bool = chunk_mask & sample_mask_bool.unsqueeze(-1)
-        global_valid_chunks = group_all_reduce_sum(valid_bool.sum())
+        global_valid_chunks = group_all_reduce_sum(
+            valid_bool.sum().to(torch.float32), group=torch.distributed.group.WORLD
+        )
         if global_valid_chunks.item() == 0:
             zero = torch.zeros((), device=device, dtype=proj_log_chunks.dtype)
             return (
@@ -1789,7 +1791,9 @@ class CrossTokenizerDistillationLossFn(LossFunction):
         # both `kl_common` and `l1_uncommon` use this as their denom so
         # the loss is normalized by `sum(global_valid_chunks)`, not a
         # per-rank mean.
-        global_valid_chunks = group_all_reduce_sum(valid_chunk.sum())
+        global_valid_chunks = group_all_reduce_sum(
+            valid_chunk.sum().to(torch.float32), group=torch.distributed.group.WORLD
+        )
         if global_valid_chunks.item() == 0:
             zero = torch.zeros((), device=device, dtype=zero_dtype)
             return (

--- a/nemo_rl/algorithms/loss/utils.py
+++ b/nemo_rl/algorithms/loss/utils.py
@@ -22,6 +22,9 @@ from nemo_rl.algorithms.logits_sampling_utils import (
 )
 from nemo_rl.algorithms.loss.interfaces import LossFunction, LossInputType
 from nemo_rl.algorithms.utils import mask_out_neg_inf_logprobs
+from nemo_rl.algorithms.x_token.loss_utils import (
+    prepare_xtoken_cross_tokenizer_loss_input,
+)
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.model_utils import (
     _get_tokens_on_this_cp_rank,
@@ -134,17 +137,25 @@ def prepare_loss_input(
             "H_all": H_all,
         }
     elif loss_fn.input_type == LossInputType.DISTILLATION_CROSS_TOKENIZER:
-        # Materialize the teacher-side loss input: rebuild the microbatch's
-        # full-vocab teacher logits from the CUDA IPC handles shipped on the
-        # data dict. The student logits pass straight through; the loss fn
-        # does the projection / chunk-average / KL reductions on both.
-        from nemo_rl.algorithms.x_token.loss_utils import (
-            rebuild_teacher_full_logits_from_ipc,
+        # Rebuild the full-vocab teacher logits from the per-rank CUDA IPC
+        # handles and do the shared CP-resolution both loss paths need; the loss
+        # fn does the projection / chunk-average / KL reductions. The TP/CP groups
+        # are derived from the student logits' own device mesh.
+        teacher_full_logits, student_logits_contig, align, tp_group, cp_group = (
+            prepare_xtoken_cross_tokenizer_loss_input(
+                logits,
+                data,
+                vocab_parallel_group=vocab_parallel_group,
+                context_parallel_group=context_parallel_group,
+            )
         )
-
         loss_input = {
             "logits": logits,
-            "teacher_full_logits": rebuild_teacher_full_logits_from_ipc(data),
+            "teacher_full_logits": teacher_full_logits,
+            "student_logits_contig": student_logits_contig,
+            "align": align,
+            "tp_group": tp_group,
+            "cp_group": cp_group,
         }
     elif loss_fn.input_type == LossInputType.DRAFT:
         from megatron.core.transformer.multi_token_prediction import roll_tensor

--- a/nemo_rl/algorithms/x_token/loss_utils.py
+++ b/nemo_rl/algorithms/x_token/loss_utils.py
@@ -21,7 +21,8 @@ Used by both :mod:`token_aligner` and
 - Chunk aggregation: :func:`chunk_log_prob_sums` / :func:`chunk_average_finalize`
   / :func:`chunk_average_log_probs` / :func:`valid_chunk_mask` (the
   partial/finalize split lets callers insert a CP all-reduce between), plus
-  :func:`dp_all_reduce_sum` for the global valid-chunk denominator.
+  :func:`nemo_rl.distributed.model_utils.group_all_reduce_sum` for the global
+  valid-chunk denominator.
 - Teacher-logit IPC: :func:`rebuild_teacher_full_logits_from_ipc`,
   :func:`assemble_teacher_logits_from_shards`,
   :func:`collect_overlapping_teacher_shards` reassemble full-vocab teacher
@@ -265,6 +266,8 @@ class LocalizedAlignment:
     pair_valid: torch.Tensor
     pair_is_correct: torch.Tensor
     sample_mask: torch.Tensor
+    student_input_ids: Optional[torch.Tensor] = None
+    student_token_mask: Optional[torch.Tensor] = None
 
 
 def localize_alignment(
@@ -276,9 +279,12 @@ def localize_alignment(
     """Localize the chunk-alignment data-dict fields for the local CP shard.
 
     Unwraps the ``alignment_*`` / ``sample_mask`` entries from DTensor to their
-    local tensors. Student-seq fields (``student_chunk_id``) are contiguously
-    CP-sharded via ``cp_buffers`` (rank r holds the r-th contiguous seq slice);
-    the teacher-seq ``teacher_chunk_id`` is full, so it is sliced contiguously to
+    local tensors. Student-seq fields (``student_chunk_id``) come from
+    ``cp_buffers`` in PyTorch's *load-balanced* (``2*cp`` interleaved) CP layout,
+    not contiguous — the caller
+    (:func:`prepare_xtoken_cross_tokenizer_loss_input`) must relayout them to this
+    rank's contiguous window via :func:`cp_load_balanced_to_contiguous` before use.
+    The teacher-seq ``teacher_chunk_id`` is full, so it is sliced contiguously to
     this CP rank's ``teacher_seq_len`` window to match the IPC consumer's
     contiguous teacher-logit slice.
     """
@@ -318,7 +324,7 @@ def student_next_token_ce(
         next_token_logprobs = get_logprobs_from_vocab_parallel_logits(
             logits, input_ids, seq_index=seq_index
         )
-        return -next_token_logprobs[:, :-1]  # drop CP-roll wrap-around
+        return -next_token_logprobs
     shift_logits = logits[:, :-1].contiguous()
     shift_labels = input_ids[:, 1:].contiguous()
     return torch.nn.functional.cross_entropy(
@@ -951,8 +957,9 @@ def prepare_xtoken_cross_tokenizer_loss_input(
 
     Rebuilds the teacher full-vocab logits from the per-rank CUDA IPC handles and
     does the shared CP-resolution the P-KL and gold paths need (contiguous student
-    logits + localized, next-token-shifted alignment). TP/CP groups come from the
-    student ``logits``' device mesh, falling back to the passed groups for
+    logits + localized, next-token-shifted alignment), plus the contiguous student
+    ``input_ids`` / ``token_mask`` the accuracy metric consumes. TP/CP groups come
+    from the student ``logits``' device mesh, falling back to the passed groups for
     non-DTensor logits.
 
     Returns:
@@ -982,4 +989,14 @@ def prepare_xtoken_cross_tokenizer_loss_input(
         fill=-1,
     )
     align.teacher_chunk_id = cp_shift_next(align.teacher_chunk_id, cp_group, fill=-1)
+    # Relay the student input_ids / token_mask from CP load-balanced to this
+    # rank's contiguous window so the next-token accuracy metric (which applies
+    # its own contiguous next-token shift) stays consistent with the contiguous
+    # student logits. Unshifted here: the metric does the shift itself.
+    align.student_input_ids = cp_load_balanced_to_contiguous(
+        data["input_ids"], cp_group=cp_group
+    )
+    align.student_token_mask = cp_load_balanced_to_contiguous(
+        data["token_mask"], cp_group=cp_group
+    )
     return teacher_full_logits, student_logits, align, tp_group, cp_group

--- a/nemo_rl/algorithms/x_token/loss_utils.py
+++ b/nemo_rl/algorithms/x_token/loss_utils.py
@@ -46,10 +46,10 @@ from torch.distributed.tensor import DTensor
 
 from nemo_rl.algorithms.x_token.token_aligner import AlignmentBatch
 from nemo_rl.distributed.model_utils import (
-    AllReduceSum,
     cp_load_balanced_to_contiguous,
     cp_shift_next,
     get_logprobs_from_vocab_parallel_logits,
+    group_all_reduce_sum_with_grad,
     vocab_parallel_argmax,
 )
 from nemo_rl.models.dtensor.parallelize import to_local_if_dtensor
@@ -106,8 +106,8 @@ def chunk_log_prob_sums(
     """Local bmm + bucket count, no division.
 
     Output is summable across CP; callers that need cross-rank chunks to
-    aggregate correctly should ``AllReduceSum`` both tensors before
-    :func:`chunk_average_finalize`. ``chunk_id == -1`` contributes to no
+    aggregate correctly should ``group_all_reduce_sum_with_grad`` both tensors
+    before :func:`chunk_average_finalize`. ``chunk_id == -1`` contributes to no
     bucket.
     """
     device = log_probs.device
@@ -140,8 +140,8 @@ def chunk_average_log_probs(
 
     Builds a one-hot chunk mask from ``chunk_id`` (``-1`` = no chunk), then
     ``bmm``-aggregates and divides by chunk sizes. When ``cp_group`` has world
-    > 1, the per-chunk sums are ``AllReduceSum``'d across CP ranks before the
-    divide (mean is non-linear, so the reduce must precede it).
+    > 1, the per-chunk sums are ``group_all_reduce_sum_with_grad``'d across CP
+    ranks before the divide (mean is non-linear, so the reduce must precede it).
 
     Args:
         log_probs: ``[B, T, V]`` log-probabilities.
@@ -155,8 +155,8 @@ def chunk_average_log_probs(
     """
     chunk_sums, chunk_sizes = chunk_log_prob_sums(log_probs, chunk_id, max_chunks)
     if cp_group is not None and torch.distributed.get_world_size(cp_group) > 1:
-        chunk_sums = AllReduceSum.apply(chunk_sums, cp_group)
-        chunk_sizes = AllReduceSum.apply(chunk_sizes, cp_group)
+        chunk_sums = group_all_reduce_sum_with_grad(chunk_sums, cp_group)
+        chunk_sizes = group_all_reduce_sum_with_grad(chunk_sizes, cp_group)
     return chunk_average_finalize(chunk_sums, chunk_sizes)
 
 
@@ -204,9 +204,9 @@ def project_student_to_teacher_vocab(
     ``sparse_projection`` is the full ``[V_s, V_t]`` sparse-COO matrix. With
     ``tp_group`` world > 1 the student probs cover only this rank's ``V_s/TP``
     rows, so the matrix is row-sliced to that range, the sparse matmul produces a
-    partial teacher-vocab sum, and an ``AllReduceSum`` over the TP group combines
-    the partials into the full ``V_s`` contraction. Otherwise a single sparse
-    matmul over the full matrix is used.
+    partial teacher-vocab sum, and a ``group_all_reduce_sum_with_grad`` over the
+    TP group combines the partials into the full ``V_s`` contraction. Otherwise a
+    single sparse matmul over the full matrix is used.
     """
     batch_size, seq_len, local_vocab_size = student_probs.shape
     flat = student_probs.reshape(batch_size * seq_len, local_vocab_size)
@@ -221,7 +221,9 @@ def project_student_to_teacher_vocab(
             row_end=(tp_rank + 1) * rows_per_rank,
         )
         projected_partial = Fp32SparseMM.apply(local_projection, flat.t()).t()
-        projected = AllReduceSum.apply(projected_partial.contiguous(), tp_group)
+        projected = group_all_reduce_sum_with_grad(
+            projected_partial.contiguous(), tp_group
+        )
     else:
         # Fp32SparseMM internally computes M.t() @ dense; passing M (not M.t())
         # avoids a sparse ``.t()`` on a saved tensor in backward.
@@ -266,6 +268,9 @@ class LocalizedAlignment:
     pair_valid: torch.Tensor
     pair_is_correct: torch.Tensor
     sample_mask: torch.Tensor
+    # Filled post-construction by prepare_xtoken_cross_tokenizer_loss_input (None when
+    # built via localize_alignment); read only by the P-KL next-token-accuracy metric --
+    # the gold path leaves them unset.
     student_input_ids: Optional[torch.Tensor] = None
     student_token_mask: Optional[torch.Tensor] = None
 
@@ -442,6 +447,12 @@ def assemble_teacher_logits_from_shards(
         raise ValueError("teacher_shards must be non-empty")
     full_seq_len = int(teacher_shards[0]["full_seq_len"])
     full_vocab_size = int(teacher_shards[0]["full_vocab_size"])
+    # CP seq-padding guarantees this; assert it so the contiguous-window math
+    # below (and the `dest` size) can't silently go out of bounds if a caller
+    # ever passes an unpadded length.
+    assert full_seq_len % student_cp_size == 0, (
+        f"full_seq_len={full_seq_len} not divisible by student_cp_size={student_cp_size}"
+    )
     local_seq_len = full_seq_len // student_cp_size
 
     dest = torch.zeros(

--- a/nemo_rl/algorithms/x_token/loss_utils.py
+++ b/nemo_rl/algorithms/x_token/loss_utils.py
@@ -13,44 +13,45 @@
 # limitations under the License.
 """Shared utilities for cross-tokenizer distillation.
 
-Hosts pieces that are used by both :mod:`token_aligner` (in this package)
-and :mod:`nemo_rl.algorithms.loss.loss_functions`:
+Used by both :mod:`token_aligner` and
+:mod:`nemo_rl.algorithms.loss.loss_functions`:
 
-    - :class:`Fp32SparseMM` — FP32 sparse-dense matmul autograd Function
-      that ignores the surrounding BF16 autocast (PyTorch has no BF16
-      sparse-mm kernel).
-    - :func:`chunk_average_log_probs`, :func:`valid_chunk_mask` —
-      chunk-aggregation helpers for the cross-tokenizer KL paths.
-    - :func:`dp_all_reduce_sum` — sum-reduce a scalar count across the
-      data-parallel group so the chunk-KL denominator is the global
-      valid-chunk count rather than a per-rank mean.
-    - :func:`parse_projection_file` — single source of truth for
-      reading the on-disk projection matrix file (both the dense top-k
-      format and the sparse ``dict[(s, t)] -> count`` format) into COO
-      components. Callers retain their own validation / sizing rules.
-    - :func:`get_sparse_projection_matrix`, :func:`get_topk_projection`
-      — process-local lazy caches for the materialized projection
-      matrix on a given device. Driver processes never trigger a fill;
-      each Ray worker populates its own cache on the first loss call.
-    - :func:`build_exact_token_map` — derived common/uncommon vocab
-      partition for the gold-loss path. Cached per
-      ``(path, device, xtoken_loss, teacher_vocab_size)`` because the
-      partition depends on those four inputs.
-    - :func:`alignment_from_flat_batch` — rehydrate the flat
-      ``alignment_*`` transport keys on the loss data dict into a single
-      :class:`AlignmentBatch` so the loss bodies access alignment via
-      attributes instead of repeating flat field names.
+- :class:`Fp32SparseMM` — FP32 sparse-dense matmul that ignores BF16
+  autocast (no BF16 sparse-mm kernel exists).
+- Chunk aggregation: :func:`chunk_log_prob_sums` / :func:`chunk_average_finalize`
+  / :func:`chunk_average_log_probs` / :func:`valid_chunk_mask` (the
+  partial/finalize split lets callers insert a CP all-reduce between), plus
+  :func:`dp_all_reduce_sum` for the global valid-chunk denominator.
+- Teacher-logit IPC: :func:`rebuild_teacher_full_logits_from_ipc`,
+  :func:`assemble_teacher_logits_from_shards`,
+  :func:`collect_overlapping_teacher_shards` reassemble full-vocab teacher
+  logits from per-rank shards across heterogeneous TP/CP.
+- Projection: :func:`parse_projection_file`, the
+  :func:`get_sparse_projection_matrix` / :func:`get_topk_projection`
+  process-local caches, :func:`slice_sparse_projection_rows`, and
+  :func:`build_exact_token_map` (cached common/uncommon partition).
+- :func:`alignment_from_flat_batch` rehydrates the flat ``alignment_*``
+  data-dict keys into an :class:`AlignmentBatch`.
 """
 
 from __future__ import annotations
 
 import os
-from dataclasses import fields
-from typing import Any, Dict, Mapping, Tuple, Union
+from dataclasses import dataclass, fields
+from typing import Any, Dict, Mapping, Optional, Tuple, Union
 
 import torch
+from torch.distributed.tensor import DTensor
 
 from nemo_rl.algorithms.x_token.token_aligner import AlignmentBatch
+from nemo_rl.distributed.model_utils import (
+    AllReduceSum,
+    cp_load_balanced_to_contiguous,
+    cp_shift_next,
+    get_logprobs_from_vocab_parallel_logits,
+    vocab_parallel_argmax,
+)
+from nemo_rl.models.dtensor.parallelize import to_local_if_dtensor
 
 
 def alignment_from_flat_batch(data: Mapping[str, Any]) -> AlignmentBatch:
@@ -62,57 +63,6 @@ def alignment_from_flat_batch(data: Mapping[str, Any]) -> AlignmentBatch:
     return AlignmentBatch(
         **{f.name: data[f"alignment_{f.name}"] for f in fields(AlignmentBatch)}
     )
-
-
-def rebuild_teacher_full_logits_from_ipc(data: Mapping[str, Any]) -> torch.Tensor:
-    """View-only rebuild of the microbatch's teacher-logits slice from IPC.
-
-    The producer maintains a **persistent** IPC buffer on its GPU sized
-    ``[B_r, T_t, V_t]``; the buffer (and the IPC handle it was captured
-    with) survives across training steps, with fresh logits ``.copy_()``-ed
-    in each step. Because the producer never frees the buffer between steps,
-    holding a view into the IPC-imported storage is safe: the producer-side
-    allocation isn't fighting the consumer's refcount, it's simply alive for
-    the worker's lifetime.
-
-    Every per-sample entry in ``teacher_full_logits_ipc`` carries the same
-    stable rank-level handle plus its rank-local ``sample_idx_within_rank``.
-    We rebuild that single handle once and slice ``[mb_start:mb_end]`` for
-    the current microbatch -- zero allocation on the consumer, dtype
-    preserved (the loss fn casts if/where it needs fp32).
-
-    Args:
-        data: The loss data dict, carrying ``teacher_full_logits_ipc`` -- a
-            list of per-sample IPC handle dicts produced by
-            ``Policy.get_full_logits_ipc``.
-
-    Returns:
-        A ``[mb_B, T_t, V_t]`` view into the producer's GPU memory (no copy).
-    """
-    from nemo_rl.models.policy.utils import rebuild_cuda_tensor_from_ipc
-
-    entries = data["teacher_full_logits_ipc"]
-    consumer_device = torch.cuda.current_device()
-
-    first = entries[0]
-    last = entries[-1]
-    rank_view = rebuild_cuda_tensor_from_ipc(
-        first["rank_logits_ipc"], consumer_device
-    )  # [B_r, T_t, V_t] view into producer's GPU memory
-
-    mb_start = first["sample_idx_within_rank"]
-    mb_end = last["sample_idx_within_rank"] + 1
-    # Contract: BatchedDataDict.slice and shard_by_batch_size preserve
-    # contiguous sample order, so sample_idx_within_rank is monotone in
-    # the microbatch. If a future change ever reorders samples, fall back
-    # to advanced indexing (which DOES copy -- defeats the no-copy win);
-    # assert loudly instead of silently regressing.
-    assert mb_end - mb_start == len(entries), (
-        "expected contiguous monotonic sample_idx_within_rank within a "
-        f"microbatch; got entries with indices "
-        f"{[e['sample_idx_within_rank'] for e in entries]}"
-    )
-    return rank_view[mb_start:mb_end]  # [mb_B, T_t, V_t] view, no copy
 
 
 class Fp32SparseMM(torch.autograd.Function):
@@ -147,36 +97,476 @@ class Fp32SparseMM(torch.autograd.Function):
         return None, grad_dense
 
 
-def chunk_average_log_probs(
+def chunk_log_prob_sums(
     log_probs: torch.Tensor,
     chunk_id: torch.Tensor,
     max_chunks: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Average ``log_probs`` over the chunks defined by ``chunk_id``.
+    """Local bmm + bucket count, no division.
 
-    Builds a one-hot chunk mask from ``chunk_id`` (``-1`` means "no
-    chunk", contributes to no bucket), then ``bmm``-aggregates and
-    divides by chunk sizes.
+    Output is summable across CP; callers that need cross-rank chunks to
+    aggregate correctly should ``AllReduceSum`` both tensors before
+    :func:`chunk_average_finalize`. ``chunk_id == -1`` contributes to no
+    bucket.
+    """
+    device = log_probs.device
+    chunk_arange = torch.arange(max_chunks, device=device).view(1, 1, -1)
+    chunk_mask = chunk_id.unsqueeze(-1) == chunk_arange
+    chunk_mask_f = chunk_mask.transpose(1, 2).to(log_probs.dtype)
+    chunk_sums = torch.bmm(chunk_mask_f, log_probs)  # [B, C, V]
+    chunk_sizes = chunk_mask.sum(dim=1).float()  # [B, C]
+    return chunk_sums, chunk_sizes
+
+
+def chunk_average_finalize(
+    chunk_sums: torch.Tensor,
+    chunk_sizes: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Divide sums by sizes; ``eps`` guards empty buckets."""
+    eps = 1e-10
+    chunk_log_probs = chunk_sums / (chunk_sizes.unsqueeze(-1) + eps)
+    return chunk_log_probs, chunk_sizes
+
+
+def chunk_average_log_probs(
+    log_probs: torch.Tensor,
+    chunk_id: torch.Tensor,
+    max_chunks: int,
+    *,
+    cp_group: Optional[torch.distributed.ProcessGroup] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Average ``log_probs`` over chunks defined by ``chunk_id``.
+
+    Builds a one-hot chunk mask from ``chunk_id`` (``-1`` = no chunk), then
+    ``bmm``-aggregates and divides by chunk sizes. When ``cp_group`` has world
+    > 1, the per-chunk sums are ``AllReduceSum``'d across CP ranks before the
+    divide (mean is non-linear, so the reduce must precede it).
 
     Args:
         log_probs: ``[B, T, V]`` log-probabilities.
         chunk_id: ``[B, T]`` long tensor, values in ``[-1, max_chunks)``.
         max_chunks: number of chunk buckets.
+        cp_group: context-parallel group for cross-rank chunk aggregation.
 
     Returns:
         chunk_log_probs: ``[B, max_chunks, V]`` averaged log-probs.
-        chunk_sizes:    ``[B, max_chunks]`` float tensor of bucket sizes.
+        chunk_sizes: ``[B, max_chunks]`` float tensor of bucket sizes.
     """
-    eps = 1e-10
-    device = log_probs.device
-    chunk_arange = torch.arange(max_chunks, device=device).view(1, 1, -1)
-    # [B, T, max_chunks] — -1 entries compare false everywhere.
-    chunk_mask = chunk_id.unsqueeze(-1) == chunk_arange
-    chunk_mask_f = chunk_mask.transpose(1, 2).to(log_probs.dtype)
-    chunk_sums = torch.bmm(chunk_mask_f, log_probs)  # [B, C, V]
-    chunk_sizes = chunk_mask.sum(dim=1).float()  # [B, C]
-    chunk_log_probs = chunk_sums / (chunk_sizes.unsqueeze(-1) + eps)
-    return chunk_log_probs, chunk_sizes
+    chunk_sums, chunk_sizes = chunk_log_prob_sums(log_probs, chunk_id, max_chunks)
+    if cp_group is not None and torch.distributed.get_world_size(cp_group) > 1:
+        chunk_sums = AllReduceSum.apply(chunk_sums, cp_group)
+        chunk_sizes = AllReduceSum.apply(chunk_sizes, cp_group)
+    return chunk_average_finalize(chunk_sums, chunk_sizes)
+
+
+def slice_sparse_projection_rows(
+    sparse_matrix: torch.Tensor,
+    row_start: int,
+    row_end: int,
+) -> torch.Tensor:
+    """Row-slice a sparse-COO projection ``[V_s, V_t]`` to ``[row_end-row_start, V_t]``.
+
+    Filters COO indices in-place: keeps entries with row in ``[row_start, row_end)``
+    and shifts the row index by ``-row_start``. Used by the TP-aware P-KL path
+    where each rank owns a contiguous slab of the student vocab axis.
+    """
+    indices = sparse_matrix.indices()
+    values = sparse_matrix.values()
+    mask = (indices[0] >= row_start) & (indices[0] < row_end)
+    local_indices = indices[:, mask].clone()
+    local_indices[0] -= row_start
+    local_values = values[mask]
+    return torch.sparse_coo_tensor(
+        local_indices,
+        local_values,
+        (row_end - row_start, sparse_matrix.size(1)),
+        device=sparse_matrix.device,
+        dtype=sparse_matrix.dtype,
+    ).coalesce()
+
+
+# ---------------------------------------------------------------------------
+# TP/CP-aware loss primitives
+#
+# Each of these collapses to the plain single-rank torch op when the relevant
+# process group has world size 1, so the cross-tokenizer loss body stays free
+# of any ``tp_world > 1`` / rank / offset branching.
+# ---------------------------------------------------------------------------
+def project_student_to_teacher_vocab(
+    student_probs: torch.Tensor,
+    sparse_projection: torch.Tensor,
+    *,
+    tp_group: Optional[torch.distributed.ProcessGroup] = None,
+) -> torch.Tensor:
+    """Project student vocab probs ``[B, T, V_s(/TP)]`` to teacher vocab ``[B, T, V_t]``.
+
+    ``sparse_projection`` is the full ``[V_s, V_t]`` sparse-COO matrix. With
+    ``tp_group`` world > 1 the student probs cover only this rank's ``V_s/TP``
+    rows, so the matrix is row-sliced to that range, the sparse matmul produces a
+    partial teacher-vocab sum, and an ``AllReduceSum`` over the TP group combines
+    the partials into the full ``V_s`` contraction. Otherwise a single sparse
+    matmul over the full matrix is used.
+    """
+    batch_size, seq_len, local_vocab_size = student_probs.shape
+    flat = student_probs.reshape(batch_size * seq_len, local_vocab_size)
+    tp_world = torch.distributed.get_world_size(tp_group) if tp_group is not None else 1
+    if tp_world > 1:
+        tp_rank = torch.distributed.get_rank(tp_group)
+        full_student_vocab_size = sparse_projection.size(0)
+        rows_per_rank = full_student_vocab_size // tp_world
+        local_projection = slice_sparse_projection_rows(
+            sparse_projection,
+            row_start=tp_rank * rows_per_rank,
+            row_end=(tp_rank + 1) * rows_per_rank,
+        )
+        projected_partial = Fp32SparseMM.apply(local_projection, flat.t()).t()
+        projected = AllReduceSum.apply(projected_partial.contiguous(), tp_group)
+    else:
+        # Fp32SparseMM internally computes M.t() @ dense; passing M (not M.t())
+        # avoids a sparse ``.t()`` on a saved tensor in backward.
+        projected = Fp32SparseMM.apply(sparse_projection, flat.t()).t()
+    teacher_vocab_size = projected.shape[-1]
+    return projected.reshape(batch_size, seq_len, teacher_vocab_size)
+
+
+def select_teacher_topk_indices(
+    teacher_logits: torch.Tensor,
+    k: int,
+    *,
+    cp_group: Optional[torch.distributed.ProcessGroup] = None,
+) -> torch.Tensor:
+    """Sorted global top-``k`` teacher-vocab ids by max importance over the microbatch.
+
+    Importance is the per-vocab max over flattened ``(B*T)`` teacher logits. With
+    ``cp_group`` world > 1 the sequence is CP-sharded, so the local max only sees
+    this rank's slice; an ``all_reduce(MAX)`` makes every rank pick the same
+    subset. No gradient.
+    """
+    vocab_size = teacher_logits.shape[-1]
+    with torch.no_grad():
+        # reshape (not view): a preceding next-token shift can leave the teacher
+        # logits non-contiguous.
+        teacher_flat = teacher_logits.reshape(-1, vocab_size)
+        importance = teacher_flat.max(dim=0).values
+        if cp_group is not None and torch.distributed.get_world_size(cp_group) > 1:
+            torch.distributed.all_reduce(
+                importance, op=torch.distributed.ReduceOp.MAX, group=cp_group
+            )
+        top_indices = torch.topk(importance, k=k, dim=-1).indices
+        return top_indices.sort().values
+
+
+@dataclass
+class LocalizedAlignment:
+    """CP-localized chunk-alignment tensors consumed by the loss reductions."""
+
+    student_chunk_id: torch.Tensor
+    teacher_chunk_id: torch.Tensor
+    pair_valid: torch.Tensor
+    pair_is_correct: torch.Tensor
+    sample_mask: torch.Tensor
+
+
+def localize_alignment(
+    data: Mapping[str, Any],
+    *,
+    teacher_seq_len: int,
+    cp_group: Optional[torch.distributed.ProcessGroup] = None,
+) -> LocalizedAlignment:
+    """Localize the chunk-alignment data-dict fields for the local CP shard.
+
+    Unwraps the ``alignment_*`` / ``sample_mask`` entries from DTensor to their
+    local tensors. Student-seq fields (``student_chunk_id``) are contiguously
+    CP-sharded via ``cp_buffers`` (rank r holds the r-th contiguous seq slice);
+    the teacher-seq ``teacher_chunk_id`` is full, so it is sliced contiguously to
+    this CP rank's ``teacher_seq_len`` window to match the IPC consumer's
+    contiguous teacher-logit slice.
+    """
+    teacher_chunk_id_full = to_local_if_dtensor(data["alignment_teacher_chunk_id"])
+    cp_rank = (
+        torch.distributed.get_rank(cp_group)
+        if cp_group is not None and torch.distributed.get_world_size(cp_group) > 1
+        else 0
+    )
+    teacher_seq_start = cp_rank * teacher_seq_len
+    teacher_chunk_id = teacher_chunk_id_full[
+        :, teacher_seq_start : teacher_seq_start + teacher_seq_len
+    ]
+    return LocalizedAlignment(
+        student_chunk_id=to_local_if_dtensor(data["alignment_student_chunk_id"]),
+        teacher_chunk_id=teacher_chunk_id,
+        pair_valid=to_local_if_dtensor(data["alignment_pair_valid"]),
+        pair_is_correct=to_local_if_dtensor(data["alignment_pair_is_correct"]),
+        sample_mask=to_local_if_dtensor(data["sample_mask"]),
+    )
+
+
+def student_next_token_ce(
+    logits: torch.Tensor,
+    *,
+    input_ids: torch.Tensor,
+    seq_index: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Per-token next-token cross-entropy ``[B, T-1]`` on the student.
+
+    DTensor (TP/CP) logits route through the vocab-parallel log-prob helper
+    (which also handles the CP roll); plain logits use a local shifted
+    ``cross_entropy``. The next-token shift (drop the last predictor) matches the
+    convention the KL terms use.
+    """
+    if isinstance(logits, DTensor):
+        next_token_logprobs = get_logprobs_from_vocab_parallel_logits(
+            logits, input_ids, seq_index=seq_index
+        )
+        return -next_token_logprobs[:, :-1]  # drop CP-roll wrap-around
+    shift_logits = logits[:, :-1].contiguous()
+    shift_labels = input_ids[:, 1:].contiguous()
+    return torch.nn.functional.cross_entropy(
+        shift_logits.reshape(-1, shift_logits.shape[-1]).float(),
+        shift_labels.reshape(-1),
+        reduction="none",
+    ).reshape(shift_labels.shape)
+
+
+def ce_label_mask(
+    *,
+    token_mask: torch.Tensor,
+    sample_mask: torch.Tensor,
+    ce_seq_len: int,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Next-token label mask ``[B, ce_seq_len]`` = shifted token_mask * sample_mask.
+
+    ``token_mask`` is gathered to the full sequence (CP) before the shift; both
+    inputs are DTensor-unwrapped.
+    """
+    token_mask = (
+        token_mask.full_tensor() if isinstance(token_mask, DTensor) else token_mask
+    )
+    sample_mask = to_local_if_dtensor(sample_mask)
+    return (token_mask[:, 1 : ce_seq_len + 1] * sample_mask.unsqueeze(-1)).to(dtype)
+
+
+def next_token_accuracy(
+    logits: torch.Tensor,
+    *,
+    input_ids: torch.Tensor,
+    token_mask: torch.Tensor,
+    sample_mask: torch.Tensor,
+    tp_group: Optional[torch.distributed.ProcessGroup] = None,
+    cp_group: Optional[torch.distributed.ProcessGroup] = None,
+) -> torch.Tensor:
+    """Masked next-token top-1 accuracy of the student (scalar, no gradient).
+
+    Uses :func:`vocab_parallel_argmax` for the (possibly TP-sharded) argmax. The
+    next-token shift on labels/mask is CP-aware (:func:`cp_shift_next`) so the
+    boundary token crosses CP ranks, and the correct/total counts are CP-reduced
+    so every rank reports the same global accuracy.
+    """
+    with torch.no_grad():
+        argmax = vocab_parallel_argmax(logits, tp_group=tp_group)
+        next_labels = cp_shift_next(to_local_if_dtensor(input_ids), cp_group, fill=0)
+        next_mask = cp_shift_next(to_local_if_dtensor(token_mask), cp_group, fill=0)
+        acc_mask = (
+            next_mask.float() * to_local_if_dtensor(sample_mask).unsqueeze(-1).float()
+        )
+        correct = ((argmax == next_labels).float() * acc_mask).sum()
+        denom = acc_mask.sum()
+        if cp_group is not None and torch.distributed.get_world_size(cp_group) > 1:
+            stats = torch.stack([correct, denom])
+            torch.distributed.all_reduce(stats, group=cp_group)
+            correct, denom = stats[0], stats[1]
+        return correct / denom.clamp(min=1.0)
+
+
+def collect_overlapping_teacher_shards(
+    teacher_shards: list[dict[str, Any]],
+    student_cp_rank: int,
+    student_cp_size: int,
+    full_seq_len: int,
+) -> list[tuple[dict[str, Any], slice, slice, slice, slice]]:
+    """Plan ``(src_seq, src_vocab, dest_seq, dest_vocab)`` slices per teacher shard.
+
+    Dest is ``[T_t/CP_s, V_t]`` (vocab fully reassembled, seq is this
+    student CP rank's range). Shards with no seq overlap are skipped.
+    """
+    student_seq_start = student_cp_rank * full_seq_len // student_cp_size
+    student_seq_end = (student_cp_rank + 1) * full_seq_len // student_cp_size
+
+    matches: list[tuple[dict[str, Any], slice, slice, slice, slice]] = []
+    for handle in teacher_shards:
+        teacher_vocab_start = int(handle["vocab_start_index"])
+        teacher_vocab_end = int(handle["vocab_end_index"])
+        teacher_seq_start = int(handle["global_seq_start"])
+        teacher_seq_end = teacher_seq_start + int(handle["actual_shape"][0])
+
+        overlap_seq_start = max(student_seq_start, teacher_seq_start)
+        overlap_seq_end = min(student_seq_end, teacher_seq_end)
+        if overlap_seq_end <= overlap_seq_start:
+            continue
+
+        src_seq = slice(
+            overlap_seq_start - teacher_seq_start,
+            overlap_seq_end - teacher_seq_start,
+        )
+        src_vocab = slice(0, teacher_vocab_end - teacher_vocab_start)
+        dest_seq = slice(
+            overlap_seq_start - student_seq_start,
+            overlap_seq_end - student_seq_start,
+        )
+        dest_vocab = slice(teacher_vocab_start, teacher_vocab_end)
+        matches.append((handle, src_seq, src_vocab, dest_seq, dest_vocab))
+    return matches
+
+
+def assemble_teacher_logits_from_shards(
+    teacher_shards: list[dict[str, Any]],
+    student_cp_rank: int,
+    student_cp_size: int,
+    device: int,
+) -> torch.Tensor:
+    """P2P-IPC-read overlapping teacher shards into a ``[T_t/CP_s, V_t]`` dest.
+
+    ``device`` is a CUDA device index (matches
+    :func:`rebuild_cuda_tensor_from_ipc`'s ``device_id`` signature).
+    """
+    from nemo_rl.models.policy.utils import rebuild_cuda_tensor_from_ipc
+
+    if not teacher_shards:
+        raise ValueError("teacher_shards must be non-empty")
+    full_seq_len = int(teacher_shards[0]["full_seq_len"])
+    full_vocab_size = int(teacher_shards[0]["full_vocab_size"])
+    local_seq_len = full_seq_len // student_cp_size
+
+    dest = torch.zeros(
+        (local_seq_len, full_vocab_size),
+        dtype=torch.float32,
+        device=device,
+    )
+    matches = collect_overlapping_teacher_shards(
+        teacher_shards,
+        student_cp_rank=student_cp_rank,
+        student_cp_size=student_cp_size,
+        full_seq_len=full_seq_len,
+    )
+    for handle, src_seq, src_vocab, dest_seq, dest_vocab in matches:
+        # Producer's IPC payload is the full contiguous storage
+        # [N_microbatches, B_mb, T_t_local, V_t_local]; index the slot
+        # then the sample row, then apply the seq/vocab overlap slices.
+        src_full = rebuild_cuda_tensor_from_ipc(handle["payload_ipc"], device).detach()
+        buf_idx = int(handle["buf_idx"])
+        sample_idx = int(handle["sample_index_in_buf"])
+        local_seq_t, local_vocab_t = handle["actual_shape"]
+        src = src_full[buf_idx, sample_idx, :local_seq_t, :local_vocab_t]
+        dest[dest_seq, dest_vocab] = src[src_seq, src_vocab].to(torch.float32)
+    return dest
+
+
+def _try_zero_copy_teacher_logits(
+    per_sample_entries: list[dict[str, Any]],
+    *,
+    student_cp_rank: int,
+    student_cp_size: int,
+    device: int,
+) -> Optional[torch.Tensor]:
+    """Zero-copy ``[B, T_t/CP_s, V_t]`` view of the teacher logits, or None.
+
+    Returns a view into the producer's IPC storage only when reassembly is
+    unnecessary: every sample's seq range is covered by a single full-vocab
+    teacher shard (i.e. teacher ``tp_size == 1`` and ``teacher_cp == student_cp``
+    or ``teacher_cp == 1``), and the microbatch's samples are a contiguous slab
+    (same payload + ``buf_idx``, sample rows ``0..B-1``) in one storage slot.
+    Otherwise returns None and the caller falls back to assemble + stack.
+    """
+    if not per_sample_entries:
+        return None
+    from nemo_rl.models.policy.utils import rebuild_cuda_tensor_from_ipc
+
+    first_shards = per_sample_entries[0]["teacher_shards"]
+    if not first_shards:
+        return None
+    full_seq_len = int(first_shards[0]["full_seq_len"])
+    full_vocab_size = int(first_shards[0]["full_vocab_size"])
+    student_seq_start = student_cp_rank * full_seq_len // student_cp_size
+    student_seq_end = (student_cp_rank + 1) * full_seq_len // student_cp_size
+
+    # Exactly one full-vocab shard must cover this student rank's seq range.
+    chosen: list[dict[str, Any]] = []
+    for entry in per_sample_entries:
+        covering = [
+            h
+            for h in entry["teacher_shards"]
+            if int(h["vocab_start_index"]) == 0
+            and int(h["vocab_end_index"]) == full_vocab_size
+            and int(h["global_seq_start"]) <= student_seq_start
+            and int(h["global_seq_start"]) + int(h["actual_shape"][0])
+            >= student_seq_end
+        ]
+        if len(covering) != 1:
+            return None
+        chosen.append(covering[0])
+
+    # All samples must form a contiguous slab in one storage slot.
+    h0 = chosen[0]
+    payload = h0["payload_ipc"]
+    buf_idx = int(h0["buf_idx"])
+    teacher_seq_start = int(h0["global_seq_start"])
+    for i, h in enumerate(chosen):
+        if (
+            h["payload_ipc"] != payload
+            or int(h["buf_idx"]) != buf_idx
+            or int(h["sample_index_in_buf"]) != i
+            or int(h["global_seq_start"]) != teacher_seq_start
+        ):
+            return None
+
+    src_full = rebuild_cuda_tensor_from_ipc(payload, device).detach()
+    seq_lo = student_seq_start - teacher_seq_start
+    seq_hi = student_seq_end - teacher_seq_start
+    return src_full[buf_idx, : len(chosen), seq_lo:seq_hi, :full_vocab_size]
+
+
+def rebuild_teacher_full_logits_from_ipc(
+    per_sample_entries: list[dict[str, Any]],
+    cp_group: Optional[torch.distributed.ProcessGroup],
+    device: int,
+) -> torch.Tensor:
+    """Rebuild ``[B, T_t/CP_s, V_t]`` teacher logits for this student rank.
+
+    Fast path (zero-copy view via :func:`_try_zero_copy_teacher_logits`): when the
+    teacher is not vocab-sharded and each sample's seq range is covered by a
+    single shard, return a view into the IPC storage. Otherwise reassemble each
+    sample from its overlapping shards and stack.
+    """
+    student_cp_rank = (
+        torch.distributed.get_rank(cp_group) if cp_group is not None else 0
+    )
+    student_cp_size = (
+        torch.distributed.get_world_size(cp_group) if cp_group is not None else 1
+    )
+
+    # Bypass: when the teacher layout lines up with this student rank (no
+    # vocab sharding, seq covered by one shard), skip reassembly and return a
+    # zero-copy view of the IPC storage. Returns None when reassembly is needed.
+    view = _try_zero_copy_teacher_logits(
+        per_sample_entries,
+        student_cp_rank=student_cp_rank,
+        student_cp_size=student_cp_size,
+        device=device,
+    )
+    if view is not None:
+        return view
+
+    rebuilt = [
+        assemble_teacher_logits_from_shards(
+            entry["teacher_shards"],
+            student_cp_rank=student_cp_rank,
+            student_cp_size=student_cp_size,
+            device=device,
+        )
+        for entry in per_sample_entries
+    ]
+    return torch.stack(rebuilt, dim=0)
 
 
 def valid_chunk_mask(
@@ -186,29 +576,6 @@ def valid_chunk_mask(
 ) -> torch.Tensor:
     """Per-chunk validity gate: both sides non-empty and pair is valid."""
     return (s_sizes > 0) & (t_sizes > 0) & pair_valid
-
-
-def dp_all_reduce_sum(local: torch.Tensor) -> torch.Tensor:
-    """Sum-reduce a scalar count across the data-parallel group.
-
-    Used to compute ``global_valid_chunks`` from each rank's local
-    chunk count, so the chunk-KL denominator matches the
-    ``sum(global_valid_chunk_kl) / sum(global_valid_chunks)`` objective
-    (the same convention CE follows via ``global_valid_toks``). The
-    cross-tokenizer setup asserts ``tensor_parallel_size=1`` and
-    ``context_parallel_size=1`` in
-    ``xtoken_off_policy_distillation.setup``, so the default process
-    group equals the DP group — calling all-reduce on the default group
-    therefore sums across DP only.
-
-    Returns a fresh ``float32`` scalar; the input tensor is not
-    modified. Falls back to a copy of the local value when distributed
-    is not initialized (unit tests).
-    """
-    out = local.detach().to(torch.float32).clone()
-    if torch.distributed.is_initialized():
-        torch.distributed.all_reduce(out)
-    return out
 
 
 def parse_projection_file(
@@ -565,3 +932,54 @@ def build_exact_token_map(
     }
     _EXACT_TOKEN_MAP_CACHE[key] = result
     return result
+
+
+def prepare_xtoken_cross_tokenizer_loss_input(
+    logits: torch.Tensor,
+    data: Mapping[str, Any],
+    *,
+    vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
+    context_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    LocalizedAlignment,
+    Optional[torch.distributed.ProcessGroup],
+    Optional[torch.distributed.ProcessGroup],
+]:
+    """Compute the cross-tokenizer distillation loss pieces from student logits + IPC teacher data.
+
+    Rebuilds the teacher full-vocab logits from the per-rank CUDA IPC handles and
+    does the shared CP-resolution the P-KL and gold paths need (contiguous student
+    logits + localized, next-token-shifted alignment). TP/CP groups come from the
+    student ``logits``' device mesh, falling back to the passed groups for
+    non-DTensor logits.
+
+    Returns:
+        ``(teacher_full_logits, student_logits_contig, align, tp_group, cp_group)``.
+    """
+    if isinstance(logits, DTensor):
+        mesh = logits.device_mesh
+        mesh_names = mesh.mesh_dim_names or ()
+        cp_group = mesh.get_group("cp") if "cp" in mesh_names else None
+        tp_group = mesh.get_group("tp") if "tp" in mesh_names else None
+    else:
+        cp_group = context_parallel_group
+        tp_group = vocab_parallel_group
+
+    teacher_full_logits = rebuild_teacher_full_logits_from_ipc(
+        data["teacher_full_logits_ipc"],
+        cp_group=cp_group,
+        device=torch.cuda.current_device(),
+    )
+    student_logits = cp_load_balanced_to_contiguous(logits, cp_group=cp_group)
+    align = localize_alignment(
+        data, teacher_seq_len=teacher_full_logits.shape[1], cp_group=cp_group
+    )
+    align.student_chunk_id = cp_shift_next(
+        cp_load_balanced_to_contiguous(align.student_chunk_id, cp_group=cp_group),
+        cp_group,
+        fill=-1,
+    )
+    align.teacher_chunk_id = cp_shift_next(align.teacher_chunk_id, cp_group, fill=-1)
+    return teacher_full_logits, student_logits, align, tp_group, cp_group

--- a/nemo_rl/algorithms/x_token/utils.py
+++ b/nemo_rl/algorithms/x_token/utils.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Batch-grid helpers for cross-tokenizer off-policy distillation.
+
+Teacher and student may run at different data-parallel degrees / microbatch
+sizes while consuming the same global batch. These helpers validate that the
+global batch tiles cleanly across both grids
+(:func:`assert_teacher_student_batch_grid`) and pad an uneven validation batch
+up to a tileable size (:func:`pad_distillation_val_batch`).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+
+
+def assert_teacher_student_batch_grid(
+    *,
+    global_batch_size: int,
+    student_gbs: int,
+    teacher_gbs: int,
+    student_dp: int,
+    teacher_dp: int,
+    student_mbs: int,
+    teacher_mbs: int,
+) -> None:
+    """Fail fast unless teacher and student share one global batch and both tile it.
+
+    A cross-tokenizer teacher and student may run at different data-parallel
+    degrees and microbatch sizes, but they consume the SAME global batch in the
+    SAME global order (the teacher exports a global-batch-ordered per-sample
+    logits list and the student slices it by its own DP/MBS). That requires both
+    sides' ``train_global_batch_size`` to agree with the step's
+    ``global_batch_size``, and each side to split that batch into whole
+    per-DP-rank chunks and whole microbatches. Not specific to distillation —
+    any xtoken teacher/student pairing needs it.
+    """
+    assert student_gbs == teacher_gbs == global_batch_size, (
+        "student/teacher train_global_batch_size and the step global_batch_size "
+        f"must all match, got student={student_gbs}, teacher={teacher_gbs}, "
+        f"global_batch_size={global_batch_size}."
+    )
+    gbs = global_batch_size
+    assert gbs % student_dp == 0, (
+        f"global batch size ({gbs}) must be divisible by student "
+        f"data_parallel size ({student_dp})."
+    )
+    assert gbs % teacher_dp == 0, (
+        f"global batch size ({gbs}) must be divisible by teacher "
+        f"data_parallel size ({teacher_dp})."
+    )
+    assert (gbs // student_dp) % student_mbs == 0, (
+        f"student local batch (gbs/student_dp = {gbs // student_dp}) must be "
+        f"divisible by student micro batch size ({student_mbs})."
+    )
+    assert (gbs // teacher_dp) % teacher_mbs == 0, (
+        f"teacher local batch (gbs/teacher_dp = {gbs // teacher_dp}) must be "
+        f"divisible by teacher micro batch size ({teacher_mbs})."
+    )
+
+
+def pad_distillation_val_batch(
+    batch: BatchedDataDict[Any], target_size: int
+) -> BatchedDataDict[Any]:
+    """Pad every key of a validation batch up to ``target_size`` (batch axis).
+
+    Validation uses ``drop_last=False``, so the final batch can be smaller
+    than ``num_prompts_per_step`` and may not tile evenly across the teacher
+    and student DP/MBS grids. Padding the whole batch symmetrically (student,
+    teacher and alignment keys together) lets both sides run the existing
+    even-split path with zero shared-code changes. The padded rows carry
+    ``sample_mask == 0``, so they are excluded from the valid-sample counts in
+    ``process_global_batch`` and contribute nothing to the loss or gradients.
+    """
+    current_size = batch.size
+    if target_size == current_size:
+        return batch
+    assert target_size > current_size, (
+        f"target_size ({target_size}) must be >= batch size ({current_size})."
+    )
+    pad = target_size - current_size
+
+    padded: BatchedDataDict[Any] = BatchedDataDict()
+    for key, value in batch.items():
+        if torch.is_tensor(value):
+            pad_rows = value[-1:].repeat(pad, *([1] * (value.dim() - 1)))
+            padded[key] = torch.cat([value, pad_rows], dim=0)
+        else:
+            padded[key] = list(value) + [value[-1]] * pad
+    padded["sample_mask"][current_size:] = 0
+    return padded

--- a/nemo_rl/algorithms/x_token/utils.py
+++ b/nemo_rl/algorithms/x_token/utils.py
@@ -74,6 +74,55 @@ def assert_teacher_student_batch_grid(
     )
 
 
+def assert_xtoken_ipc_node_local(
+    *,
+    num_nodes: int,
+    gpus_per_node: int,
+    student_tp: int,
+    student_cp: int,
+    teacher_tp: int,
+    teacher_cp: int,
+    student_dp: int,
+    teacher_dp: int,
+) -> None:
+    """Fail fast if the teacher->student logit transport would cross a node.
+
+    Teacher logits reach the student via CUDA IPC (``cudaIpcOpenMemHandle``),
+    which can only map a buffer created by a process on the SAME physical node.
+    A single-node job is therefore always safe; a multi-node job is only safe
+    when every student rank's required teacher shards live on its own node.
+
+    """
+    if num_nodes <= 1:
+        return
+
+    student_group = student_tp * student_cp
+    teacher_group = teacher_tp * teacher_cp
+    assert teacher_dp == student_dp, (
+        "Multi-node xtoken distillation uses node-local CUDA IPC for the teacher "
+        "logits, which requires teacher and student to share a data_parallel "
+        f"degree (got teacher_dp={teacher_dp}, student_dp={student_dp}); "
+        "otherwise a student rank must read teacher shards from another node. "
+        "Use a single node, or matching DP, or a cross-node transport."
+    )
+    assert teacher_group == student_group, (
+        "Multi-node xtoken distillation requires teacher and student to share "
+        f"the same model-parallel group size tp*cp (got teacher={teacher_group}, "
+        f"student={student_group}); differing sizes imply a non-colocated grid "
+        "whose teacher shards are not node-local."
+    )
+    assert student_group <= gpus_per_node, (
+        f"Multi-node xtoken distillation needs the model-parallel group tp*cp "
+        f"({student_group}) to fit within one node ({gpus_per_node} GPUs); a "
+        "group spanning nodes makes the teacher-logit IPC cross-node."
+    )
+    assert gpus_per_node % student_group == 0, (
+        f"Multi-node xtoken distillation needs gpus_per_node ({gpus_per_node}) "
+        f"to be a multiple of the model-parallel group tp*cp ({student_group}) "
+        "so DP groups are node-aligned and never straddle a node boundary."
+    )
+
+
 def pad_distillation_val_batch(
     batch: BatchedDataDict[Any], target_size: int
 ) -> BatchedDataDict[Any]:

--- a/nemo_rl/algorithms/xtoken_off_policy_distillation.py
+++ b/nemo_rl/algorithms/xtoken_off_policy_distillation.py
@@ -32,6 +32,7 @@ loss function does only loss math; this module is just plumbing.
 
 from __future__ import annotations
 
+import math
 import os
 from typing import Any, NotRequired, Optional, TypedDict, cast
 
@@ -47,6 +48,10 @@ from nemo_rl.algorithms.loss.loss_functions import (
 )
 from nemo_rl.algorithms.utils import set_seed
 from nemo_rl.algorithms.x_token import TokenAligner
+from nemo_rl.algorithms.x_token.utils import (
+    assert_teacher_student_batch_grid,
+    pad_distillation_val_batch,
+)
 from nemo_rl.data import DataConfig
 from nemo_rl.data.cross_tokenizer_collate import CrossTokenizerCollator
 from nemo_rl.data.datasets import AllTaskProcessedDataset
@@ -101,6 +106,10 @@ class OffPolicyDistillationConfig(TypedDict):
         val_period: Validation cadence in steps. ``0`` disables validation.
         val_at_start: Run validation before training begins.
         val_at_end: Run validation on the final step.
+        val_teacher_micro_batch_size: Teacher microbatch size used for the
+            validation logits export. Defaults to the teacher's
+            ``train_micro_batch_size``; tune independently for val
+            memory/throughput.
     """
 
     num_prompts_per_step: int
@@ -110,6 +119,7 @@ class OffPolicyDistillationConfig(TypedDict):
     val_period: int
     val_at_start: bool
     val_at_end: bool
+    val_teacher_micro_batch_size: NotRequired[int]
 
 
 class OffPolicyDistillationSaveState(TypedDict):
@@ -181,18 +191,6 @@ def setup(
         "dtensor_cfg"
     ].get("_v2"), (
         "xtoken distillation requires teacher.dtensor_cfg.enabled=true and _v2=true."
-    )
-
-    # The cross-tokenizer loss reduces ``global_valid_chunks`` with an
-    # all-reduce on the default process group (see
-    # ``loss_utils.dp_all_reduce_sum``), which only equals the DP group
-    # when there is no TP/CP sharding. Enforce that here so the chunk-KL
-    # denominator stays correct.
-    assert (
-        policy_config["dtensor_cfg"]["tensor_parallel_size"] == 1
-        and policy_config["dtensor_cfg"]["context_parallel_size"] == 1
-    ), (
-        "xtoken distillation requires policy tensor_parallel_size=1 and context_parallel_size=1."
     )
 
     set_seed(distillation_config["seed"])
@@ -318,6 +316,40 @@ def setup(
     )
 
     # ==========================
+    #   Teacher/student grid
+    # ==========================
+    # Teacher and student may differ in DP and MBS, but they must agree on the
+    # global batch size (one dataloader batch feeds both, in the same global
+    # order) and tile it cleanly into per-DP-rank chunks and whole microbatches.
+    # assert_teacher_student_batch_grid checks both (GBS agreement + tiling).
+    student_dp = student_policy.data_parallel_size
+    teacher_dp = teacher_policy.data_parallel_size
+    val_teacher_mbs = distillation_config.get(
+        "val_teacher_micro_batch_size", teacher_config["train_micro_batch_size"]
+    )
+    # Training grid.
+    assert_teacher_student_batch_grid(
+        global_batch_size=distillation_config["num_prompts_per_step"],
+        student_gbs=policy_config["train_global_batch_size"],
+        teacher_gbs=teacher_config["train_global_batch_size"],
+        student_dp=student_dp,
+        teacher_dp=teacher_dp,
+        student_mbs=policy_config["train_micro_batch_size"],
+        teacher_mbs=teacher_config["train_micro_batch_size"],
+    )
+    # Validation grid: the student reuses its train MBS in eval mode; the
+    # teacher uses val_teacher_micro_batch_size for the val export.
+    assert_teacher_student_batch_grid(
+        global_batch_size=distillation_config["num_prompts_per_step"],
+        student_gbs=policy_config["train_global_batch_size"],
+        teacher_gbs=teacher_config["train_global_batch_size"],
+        student_dp=student_dp,
+        teacher_dp=teacher_dp,
+        student_mbs=policy_config["train_micro_batch_size"],
+        teacher_mbs=val_teacher_mbs,
+    )
+
+    # ==========================
     #         Loss
     # ==========================
     # Inject both tokenizer vocab sizes so the projection matrix's V_s
@@ -427,7 +459,11 @@ def xtoken_off_policy_distillation_train(
                     # full vocab (gold path) or derives a microbatch-global
                     # top-k from this inline (P-KL path).
                     teacher_handles = teacher_policy.get_full_logits_ipc(
-                        teacher_data, timer=timer
+                        teacher_data,
+                        micro_batch_size=master_config.teacher[
+                            "train_micro_batch_size"
+                        ],
+                        timer=timer,
                     )
                     # Model offload frees the teacher's PARAMS to CPU; the
                     # IPC-stashed logit tensors live in worker Python state
@@ -469,13 +505,15 @@ def xtoken_off_policy_distillation_train(
                             timer=timer,
                             check_dim_skip_keys=XTOKEN_NON_STUDENT_SEQ_KEYS,
                         )
-                    finally:
-                        # No-op under the persistent IPC buffer design (the
-                        # teacher reuses one buffer across steps via copy_),
-                        # kept for driver-side contract compatibility. Called
-                        # in finally so the contract holds even if the
-                        # student step raised.
+                    except Exception:
+                        # Free the producer's IPC buffer before propagating so a
+                        # failed step doesn't leak the teacher logits. The happy
+                        # path keeps the buffer persistent across steps (reused
+                        # via copy_) and releases once at loop exit — releasing
+                        # every step here frees + reallocs the large teacher
+                        # logits buffer and fragments the GPU into an OOM.
                         teacher_policy.release_ipc_buffer()
+                        raise
 
                 is_last_step = (total_steps + 1 >= max_steps) or (
                     (current_epoch + 1 == max_epochs)
@@ -662,13 +700,16 @@ def xtoken_off_policy_distillation_train(
 
             if should_save_by_timeout:
                 print("Timeout reached, stopping training early.", flush=True)
+                teacher_policy.release_ipc_buffer()
                 return
             if total_steps >= max_steps:
                 print("Max steps reached, stopping training.", flush=True)
+                teacher_policy.release_ipc_buffer()
                 return
 
         current_epoch += 1
         current_step = 0
+    teacher_policy.release_ipc_buffer()
 
 
 # ===============================================================================
@@ -701,16 +742,33 @@ def validate(
     kl_common_losses: list[float] = []
     l1_uncommon_losses: list[float] = []
 
+    # Teacher and student may differ in DP/MBS; the final val batch (with
+    # drop_last=False) can be ragged. Pad each batch up to the smallest size
+    # that tiles cleanly on both grids so the existing even-split path applies.
+    student_dp = student_policy.data_parallel_size
+    teacher_dp = teacher_policy.data_parallel_size
+    student_mbs = master_config.policy["train_micro_batch_size"]
+    val_teacher_mbs = distill_cfg.get(
+        "val_teacher_micro_batch_size",
+        master_config.teacher["train_micro_batch_size"],
+    )
+    pad_quantum = math.lcm(student_dp * student_mbs, teacher_dp * val_teacher_mbs)
+
     with timer.time("validation_total"):
         teacher_policy.prepare_for_lp_inference()
         for batch in val_dataloader:
+            target_size = math.ceil(batch.size / pad_quantum) * pad_quantum
+            batch = pad_distillation_val_batch(batch, target_size)
+
             teacher_data = BatchedDataDict(
                 input_ids=batch["teacher_input_ids"],
                 input_lengths=batch["teacher_input_lengths"],
                 token_mask=batch["teacher_token_mask"],
                 sample_mask=batch["sample_mask"],
             )
-            teacher_handles = teacher_policy.get_full_logits_ipc(teacher_data)
+            teacher_handles = teacher_policy.get_full_logits_ipc(
+                teacher_data, micro_batch_size=val_teacher_mbs
+            )
 
             train_data: BatchedDataDict[Any] = BatchedDataDict(
                 input_ids=batch["input_ids"],
@@ -739,9 +797,10 @@ def validate(
                     eval_mode=True,
                     check_dim_skip_keys=XTOKEN_NON_STUDENT_SEQ_KEYS,
                 )
-            finally:
+            except Exception:
                 teacher_policy.release_ipc_buffer()
-            losses.append(float(results["loss"].numpy()))
+                raise
+            losses.append(float(np.mean(results["loss"].numpy())))
             mb_metrics = results.get("all_mb_metrics", {})
             if "kl_loss" in mb_metrics:
                 kl_losses.append(float(np.mean(mb_metrics["kl_loss"])))
@@ -751,6 +810,7 @@ def validate(
                 kl_common_losses.append(float(np.mean(mb_metrics["kl_common"])))
             if "l1_uncommon" in mb_metrics:
                 l1_uncommon_losses.append(float(np.mean(mb_metrics["l1_uncommon"])))
+        teacher_policy.release_ipc_buffer()
         teacher_policy.offload_after_refit()
 
     metrics: dict[str, Any] = {

--- a/nemo_rl/algorithms/xtoken_off_policy_distillation.py
+++ b/nemo_rl/algorithms/xtoken_off_policy_distillation.py
@@ -50,6 +50,7 @@ from nemo_rl.algorithms.utils import set_seed
 from nemo_rl.algorithms.x_token import TokenAligner
 from nemo_rl.algorithms.x_token.utils import (
     assert_teacher_student_batch_grid,
+    assert_xtoken_ipc_node_local,
     pad_distillation_val_batch,
 )
 from nemo_rl.data import DataConfig
@@ -345,6 +346,19 @@ def setup(
         teacher_dp=teacher_dp,
         student_mbs=policy_config["train_micro_batch_size"],
         teacher_mbs=val_teacher_mbs,
+    )
+    # The teacher->student logit transport is node-local CUDA IPC; on >1 node it
+    # only works when teacher/student share DP and a node-aligned model-parallel
+    # group, else a student rank must read teacher shards from another node.
+    assert_xtoken_ipc_node_local(
+        num_nodes=cluster_config["num_nodes"],
+        gpus_per_node=cluster_config["gpus_per_node"],
+        student_tp=policy_config["dtensor_cfg"]["tensor_parallel_size"],
+        student_cp=policy_config["dtensor_cfg"]["context_parallel_size"],
+        teacher_tp=teacher_config["dtensor_cfg"]["tensor_parallel_size"],
+        teacher_cp=teacher_config["dtensor_cfg"]["context_parallel_size"],
+        student_dp=student_dp,
+        teacher_dp=teacher_dp,
     )
 
     # ==========================

--- a/nemo_rl/algorithms/xtoken_off_policy_distillation.py
+++ b/nemo_rl/algorithms/xtoken_off_policy_distillation.py
@@ -107,9 +107,9 @@ class OffPolicyDistillationConfig(TypedDict):
         val_at_start: Run validation before training begins.
         val_at_end: Run validation on the final step.
         val_teacher_micro_batch_size: Teacher microbatch size used for the
-            validation logits export. Defaults to the teacher's
-            ``train_micro_batch_size``; tune independently for val
-            memory/throughput.
+            validation logits export. The exemplar defaults it to
+            ``teacher.train_micro_batch_size`` via interpolation; override with a
+            literal to tune the val export independently of training.
     """
 
     num_prompts_per_step: int
@@ -119,7 +119,7 @@ class OffPolicyDistillationConfig(TypedDict):
     val_period: int
     val_at_start: bool
     val_at_end: bool
-    val_teacher_micro_batch_size: NotRequired[int]
+    val_teacher_micro_batch_size: int
 
 
 class OffPolicyDistillationSaveState(TypedDict):
@@ -324,9 +324,7 @@ def setup(
     # assert_teacher_student_batch_grid checks both (GBS agreement + tiling).
     student_dp = student_policy.data_parallel_size
     teacher_dp = teacher_policy.data_parallel_size
-    val_teacher_mbs = distillation_config.get(
-        "val_teacher_micro_batch_size", teacher_config["train_micro_batch_size"]
-    )
+    val_teacher_mbs = distillation_config["val_teacher_micro_batch_size"]
     # Training grid.
     assert_teacher_student_batch_grid(
         global_batch_size=distillation_config["num_prompts_per_step"],
@@ -748,10 +746,7 @@ def validate(
     student_dp = student_policy.data_parallel_size
     teacher_dp = teacher_policy.data_parallel_size
     student_mbs = master_config.policy["train_micro_batch_size"]
-    val_teacher_mbs = distill_cfg.get(
-        "val_teacher_micro_batch_size",
-        master_config.teacher["train_micro_batch_size"],
-    )
+    val_teacher_mbs = distill_cfg["val_teacher_micro_batch_size"]
     pad_quantum = math.lcm(student_dp * student_mbs, teacher_dp * val_teacher_mbs)
 
     with timer.time("validation_total"):

--- a/nemo_rl/distributed/model_utils.py
+++ b/nemo_rl/distributed/model_utils.py
@@ -1233,14 +1233,20 @@ def allgather_cp_sharded_tensor(
     return AllGatherCPTensor.apply(tensor, cp_group, seq_dim)  # , unpadded_seqlen)
 
 
-class AllReduceSum(torch.autograd.Function):
-    """Autograd-aware SUM all-reduce; forward clones + reduces, backward is identity.
+class _AllReduceSum(torch.autograd.Function):
+    """Autograd-aware SUM all-reduce primitive; forward clones + reduces, backward is identity.
 
     Math: ``y = Σ_r x_r`` ⇒ ``dy/dx_r = 1``. Every rank holds the same
     ``y`` after forward, so the upstream grad is identical across ranks
     — passing it back as ``grad_x_r`` lets the rank-local chain rule
     route gradients to each rank's own input shard with no cross-rank
     coupling.
+
+    Use the functional wrappers :func:`group_all_reduce_sum_with_grad` (keeps
+    the gradient) and :func:`group_all_reduce_sum` (no gradient) rather than
+    calling ``.apply`` directly. A ``group`` of ``None`` (or world size <= 1,
+    or an uninitialized process group) is a no-op so single-process / CPU paths
+    work unchanged.
     """
 
     @staticmethod
@@ -1250,7 +1256,11 @@ class AllReduceSum(torch.autograd.Function):
         group: Optional[torch.distributed.ProcessGroup],
     ) -> torch.Tensor:
         ctx.group = group
-        if group is None or torch.distributed.get_world_size(group) <= 1:
+        if (
+            group is None
+            or not torch.distributed.is_initialized()
+            or torch.distributed.get_world_size(group) <= 1
+        ):
             return x
         out = x.clone()
         torch.distributed.all_reduce(
@@ -1263,6 +1273,37 @@ class AllReduceSum(torch.autograd.Function):
         ctx: Any, grad_out: torch.Tensor
     ) -> tuple[torch.Tensor, None]:
         return grad_out, None
+
+
+def group_all_reduce_sum_with_grad(
+    x: torch.Tensor,
+    group: Optional[torch.distributed.ProcessGroup],
+) -> torch.Tensor:
+    """Differentiable SUM all-reduce of ``x`` over ``group``.
+
+    Gradients flow back through the reduce (backward is identity), so this is
+    the variant for forward-path reductions whose result feeds the loss — e.g.
+    CP chunk-sum aggregation and TP projection-partial combination. ``group``
+    of ``None`` (or world size <= 1, or dist uninitialized) is a no-op.
+    """
+    return _AllReduceSum.apply(x, group)
+
+
+def group_all_reduce_sum(
+    x: torch.Tensor,
+    group: Optional[torch.distributed.ProcessGroup],
+) -> torch.Tensor:
+    """Non-differentiable variant of :func:`group_all_reduce_sum_with_grad`.
+
+    Same reduction, but no gradient flows through it — use for normalizers /
+    denominators that must be treated as constants (e.g. the global
+    valid-token or valid-chunk counts). Pass an explicit ``group`` (e.g.
+    ``torch.distributed.group.WORLD`` to reduce over the full DP×CP×TP mesh, or
+    a narrower process group); ``None`` (or world size <= 1, or dist
+    uninitialized) is a no-op that returns the local value.
+    """
+    with torch.no_grad():
+        return _AllReduceSum.apply(x, group)
 
 
 class AllGatherCPTensor(torch.autograd.Function):
@@ -1379,25 +1420,6 @@ def cp_shift_next(
     gathered = [torch.empty_like(first) for _ in range(cp_size)]
     torch.distributed.all_gather(gathered, first, group=cp_group)
     out[:, -1] = gathered[cp_rank + 1] if cp_rank < cp_size - 1 else fill
-    return out
-
-
-def group_all_reduce_sum(
-    local: torch.Tensor,
-    group: Optional[torch.distributed.ProcessGroup] = None,
-) -> torch.Tensor:
-    """Sum a scalar over ``group`` (default ``None`` = WORLD, the full DP×CP×TP mesh), no grad.
-
-    Note the default group is WORLD, not DP: the reduction spans every rank,
-    including TP replicas. That TP-replication inflation is intentional —
-    normalizers whose numerator sums over the same group cancel it, so the
-    result stays parallelism-invariant. Pass an explicit ``group`` to reduce
-    over a narrower scope. Returns a fresh float32 scalar (falls back to a local
-    copy when dist is uninitialized).
-    """
-    out = local.detach().to(torch.float32).clone()
-    if torch.distributed.is_initialized():
-        torch.distributed.all_reduce(out, group=group)
     return out
 
 

--- a/nemo_rl/distributed/model_utils.py
+++ b/nemo_rl/distributed/model_utils.py
@@ -15,6 +15,7 @@
 from typing import TYPE_CHECKING, Any, Optional
 
 import torch
+import torch.distributed.nn.functional
 from torch.distributed.tensor import DTensor, distribute_tensor
 
 from nemo_rl.algorithms.logits_sampling_utils import (
@@ -29,24 +30,23 @@ if TYPE_CHECKING:
     from megatron.core.models.gpt import GPTModel
 
 
-@torch.no_grad()
-def _compute_distributed_log_softmax(
+def _compute_distributed_log_softmax_with_grad(
     vocab_parallel_logits: torch.Tensor, group: torch.distributed.ProcessGroup
 ) -> torch.Tensor:
-    """Compute a stable distributed log softmax across tensor parallel workers.
-
-    Taken from: https://github.com/NVIDIA/NeMo-Aligner/blob/9faab404f21994a7eb1d6ed5890b76152b941636/nemo_aligner/utils/distributed.py#L265
+    """Differentiable stable distributed log_softmax across tensor parallel workers.
 
     Args:
-        vocab_parallel_logits (torch.Tensor): Logits tensor with shape [batch_size, seq_length, vocab_size//TP]
-            where TP is the tensor parallel size.
-        group (torch.distributed.ProcessGroup): Process group for the all-reduce operations.
+        vocab_parallel_logits (torch.Tensor): Logits with shape
+            [batch_size, seq_length, vocab_size // TP], where TP is the tensor
+            parallel size.
+        group (torch.distributed.ProcessGroup): Process group for the all-reduces.
 
     Returns:
-        torch.Tensor: Log softmax output with the same shape as input, but values represent
-            log probabilities normalized across the full vocabulary dimension.
+        torch.Tensor: Log probabilities, same shape as the input, normalized across
+            the full vocabulary dimension. Differentiable (gradients flow through
+            the all-reduces).
     """
-    logits_max = torch.amax(vocab_parallel_logits, dim=-1, keepdim=True)
+    logits_max = torch.amax(vocab_parallel_logits, dim=-1, keepdim=True).detach()
     torch.distributed.all_reduce(
         logits_max,
         op=torch.distributed.ReduceOp.MAX,
@@ -58,13 +58,25 @@ def _compute_distributed_log_softmax(
 
     sum_exp_logits = vocab_parallel_logits.exp().sum(-1, keepdim=True).float()
 
-    torch.distributed.all_reduce(
+    sum_exp_logits = torch.distributed.nn.functional.all_reduce(
         sum_exp_logits,
         op=torch.distributed.ReduceOp.SUM,
         group=group,
     )
 
-    return vocab_parallel_logits - sum_exp_logits.log_().to(vocab_parallel_logits.dtype)
+    return vocab_parallel_logits - sum_exp_logits.log().to(vocab_parallel_logits.dtype)
+
+
+@torch.no_grad()
+def _compute_distributed_log_softmax(
+    vocab_parallel_logits: torch.Tensor, group: torch.distributed.ProcessGroup
+) -> torch.Tensor:
+    """Non-differentiable variant of :func:`_compute_distributed_log_softmax_with_grad`.
+
+    Same math and shape contract, wrapped in ``torch.no_grad()`` for the
+    inference / logprob paths that don't need gradients.
+    """
+    return _compute_distributed_log_softmax_with_grad(vocab_parallel_logits, group)
 
 
 @torch.no_grad()
@@ -1221,6 +1233,38 @@ def allgather_cp_sharded_tensor(
     return AllGatherCPTensor.apply(tensor, cp_group, seq_dim)  # , unpadded_seqlen)
 
 
+class AllReduceSum(torch.autograd.Function):
+    """Autograd-aware SUM all-reduce; forward clones + reduces, backward is identity.
+
+    Math: ``y = Σ_r x_r`` ⇒ ``dy/dx_r = 1``. Every rank holds the same
+    ``y`` after forward, so the upstream grad is identical across ranks
+    — passing it back as ``grad_x_r`` lets the rank-local chain rule
+    route gradients to each rank's own input shard with no cross-rank
+    coupling.
+    """
+
+    @staticmethod
+    def forward(  # pyrefly: ignore[bad-override]
+        ctx: Any,
+        x: torch.Tensor,
+        group: Optional[torch.distributed.ProcessGroup],
+    ) -> torch.Tensor:
+        ctx.group = group
+        if group is None or torch.distributed.get_world_size(group) <= 1:
+            return x
+        out = x.clone()
+        torch.distributed.all_reduce(
+            out, op=torch.distributed.ReduceOp.SUM, group=group
+        )
+        return out
+
+    @staticmethod
+    def backward(  # pyrefly: ignore[bad-override]
+        ctx: Any, grad_out: torch.Tensor
+    ) -> tuple[torch.Tensor, None]:
+        return grad_out, None
+
+
 class AllGatherCPTensor(torch.autograd.Function):
     def forward(
         ctx, tensor, cp_group: torch.distributed.ProcessGroup, seq_dim=1
@@ -1285,6 +1329,149 @@ class AllGatherCPTensor(torch.autograd.Function):
         )
 
         return grad_input, None, None  # , None
+
+
+def cp_load_balanced_to_contiguous(
+    x: torch.Tensor,
+    *,
+    cp_group: Optional[torch.distributed.ProcessGroup] = None,
+    seq_dim: int = 1,
+) -> torch.Tensor:
+    """Re-layout a tensor from load-balanced CP order to this rank's contiguous window.
+
+    PyTorch ``context_parallel`` shards the sequence in a load-balanced
+    (``2*cp`` interleaved) order. :func:`allgather_cp_sharded_tensor` undoes the
+    chunking to the full contiguous sequence; this re-slices to this CP rank's
+    contiguous ``[cp_rank*L, (cp_rank+1)*L)`` window. No-op when CP world <= 1.
+    Uses the grad-preserving ``DTensor.to_local()`` so the gradient is kept.
+    """
+    if cp_group is None or torch.distributed.get_world_size(cp_group) <= 1:
+        return x
+    local = x.to_local() if isinstance(x, DTensor) else x
+    full = allgather_cp_sharded_tensor(local, cp_group, seq_dim=seq_dim)
+    cp_size = torch.distributed.get_world_size(cp_group)
+    cp_rank = torch.distributed.get_rank(cp_group)
+    local_len = full.shape[seq_dim] // cp_size
+    return full.narrow(seq_dim, cp_rank * local_len, local_len).contiguous()
+
+
+def cp_shift_next(
+    x: torch.Tensor,
+    cp_group: Optional[torch.distributed.ProcessGroup] = None,
+    *,
+    fill: float,
+) -> torch.Tensor:
+    """Next-token (left-by-1) shift along seq dim 1, CP-aware for contiguous sharding.
+
+    Returns ``out[:, t] = x[:, t + 1]`` over the *global* sequence: interior
+    positions roll locally, each rank's last position takes the next CP rank's
+    first row (contiguous CP sharding), and the global-last position is set to
+    ``fill`` (no next token). With no / size-1 ``cp_group`` this is a plain local
+    left-roll with the last position set to ``fill``.
+    """
+    out = torch.roll(x, shifts=-1, dims=1)
+    cp_size = torch.distributed.get_world_size(cp_group) if cp_group is not None else 1
+    if cp_size <= 1:
+        out[:, -1] = fill
+        return out
+    cp_rank = torch.distributed.get_rank(cp_group)
+    first = x[:, 0].contiguous()
+    gathered = [torch.empty_like(first) for _ in range(cp_size)]
+    torch.distributed.all_gather(gathered, first, group=cp_group)
+    out[:, -1] = gathered[cp_rank + 1] if cp_rank < cp_size - 1 else fill
+    return out
+
+
+def dp_all_reduce_sum(local: torch.Tensor) -> torch.Tensor:
+    """Sum a scalar over the worker's default (full-mesh DP×CP×TP) group, no grad.
+
+    The TP-replication inflation is intentional: normalizers whose numerator sums
+    over the same mesh cancel it, so the result stays parallelism-invariant. Returns
+    a fresh float32 scalar (falls back to a local copy when dist is uninitialized).
+    """
+    out = local.detach().to(torch.float32).clone()
+    if torch.distributed.is_initialized():
+        torch.distributed.all_reduce(out)
+    return out
+
+
+def vocab_parallel_log_softmax(
+    logits: torch.Tensor,
+    temperature: float,
+    *,
+    tp_group: Optional[torch.distributed.ProcessGroup] = None,
+) -> torch.Tensor:
+    """TP-aware ``log_softmax(logits / temperature)`` keeping the vocab shard.
+
+    With ``tp_group`` world > 1 the logits are vocab-sharded, so the softmax
+    normalization is reduced across the TP group (kept differentiable) while the
+    result stays sharded on the same vocab axis. Otherwise this is a plain local
+    ``log_softmax``. DTensor inputs are unwrapped to their local shard.
+    """
+    if isinstance(logits, DTensor):
+        logits = logits.to_local()
+    scaled = logits.float() / temperature
+    if tp_group is not None and torch.distributed.get_world_size(tp_group) > 1:
+        return _compute_distributed_log_softmax_with_grad(scaled, group=tp_group)
+    return torch.log_softmax(scaled, dim=-1)
+
+
+def vocab_parallel_full_log_softmax(
+    logits: torch.Tensor,
+    temperature: float,
+    *,
+    tp_group: Optional[torch.distributed.ProcessGroup] = None,
+) -> torch.Tensor:
+    """TP-aware ``log_softmax`` gathered to the full vocab ``[B, T, V]``.
+
+    Unlike :func:`vocab_parallel_log_softmax` (which keeps the result
+    vocab-sharded), callers that slice arbitrary vocab indices need the full
+    vocab axis. With ``tp_group`` world > 1 the sharded log-probs are all-gathered
+    via Megatron's autograd-aware gather; otherwise a plain local ``log_softmax``.
+    """
+    if isinstance(logits, DTensor):
+        logits = logits.to_local()
+    scaled = logits.float() / temperature
+    if tp_group is not None and torch.distributed.get_world_size(tp_group) > 1:
+        # Local import keeps the optional Megatron dependency boundary intact.
+        from megatron.core.tensor_parallel import (
+            gather_from_tensor_model_parallel_region,
+        )
+
+        sharded_log_probs = _compute_distributed_log_softmax_with_grad(
+            scaled, group=tp_group
+        )
+        return gather_from_tensor_model_parallel_region(
+            sharded_log_probs, group=tp_group
+        )
+    return torch.log_softmax(scaled, dim=-1)
+
+
+def vocab_parallel_argmax(
+    logits: torch.Tensor,
+    *,
+    tp_group: Optional[torch.distributed.ProcessGroup] = None,
+) -> torch.Tensor:
+    """Per-position global argmax token id over the (possibly TP-sharded) vocab.
+
+    Returns ``[B, T]`` global token ids. With ``tp_group`` world > 1 the vocab is
+    sharded, so a distributed top-1 recovers the global argmax; otherwise a plain
+    local ``argmax``. No gradient.
+    """
+    local_logits = logits.to_local() if isinstance(logits, DTensor) else logits
+    tp_world = torch.distributed.get_world_size(tp_group) if tp_group is not None else 1
+    if tp_world > 1:
+        tp_rank = torch.distributed.get_rank(tp_group)
+        local_vocab_size = int(local_logits.shape[-1])
+        _, topk_global_idx = distributed_vocab_topk(
+            local_logits,
+            k=1,
+            tp_group=tp_group,
+            vocab_start_index=tp_rank * local_vocab_size,
+            vocab_end_index=(tp_rank + 1) * local_vocab_size,
+        )
+        return topk_global_idx.squeeze(-1)
+    return local_logits.argmax(dim=-1)
 
 
 def get_logprobs_from_vocab_parallel_logits(

--- a/nemo_rl/distributed/model_utils.py
+++ b/nemo_rl/distributed/model_utils.py
@@ -1382,16 +1382,22 @@ def cp_shift_next(
     return out
 
 
-def dp_all_reduce_sum(local: torch.Tensor) -> torch.Tensor:
-    """Sum a scalar over the worker's default (full-mesh DP×CP×TP) group, no grad.
+def group_all_reduce_sum(
+    local: torch.Tensor,
+    group: Optional[torch.distributed.ProcessGroup] = None,
+) -> torch.Tensor:
+    """Sum a scalar over ``group`` (default ``None`` = WORLD, the full DP×CP×TP mesh), no grad.
 
-    The TP-replication inflation is intentional: normalizers whose numerator sums
-    over the same mesh cancel it, so the result stays parallelism-invariant. Returns
-    a fresh float32 scalar (falls back to a local copy when dist is uninitialized).
+    Note the default group is WORLD, not DP: the reduction spans every rank,
+    including TP replicas. That TP-replication inflation is intentional —
+    normalizers whose numerator sums over the same group cancel it, so the
+    result stays parallelism-invariant. Pass an explicit ``group`` to reduce
+    over a narrower scope. Returns a fresh float32 scalar (falls back to a local
+    copy when dist is uninitialized).
     """
     out = local.detach().to(torch.float32).clone()
     if torch.distributed.is_initialized():
-        torch.distributed.all_reduce(out)
+        torch.distributed.all_reduce(out, group=group)
     return out
 
 

--- a/nemo_rl/models/automodel/data.py
+++ b/nemo_rl/models/automodel/data.py
@@ -283,6 +283,22 @@ def process_microbatch(
         seq_index = torch.arange(seq_len, device=input_ids.device).repeat(1, 1)
         cp_buffers = [input_ids, position_ids, seq_index]
 
+        # Cross-tokenizer distillation rides student-seq-aligned alignment /
+        # mask fields on the same mb. CP-shard the student-seq fields with
+        # the student cp_mesh so the loss sees matching seq dims against
+        # the redistributed student logits. Teacher-seq fields (T_t may
+        # differ from T_s) stay full; the loss slices them contiguously by
+        # student CP rank because the IPC consumer ships contiguous teacher
+        # slices (see FullLogitsPostProcessor un-interleave in train.py).
+        if "alignment_student_chunk_id" in mb:
+            for student_seq_field in (
+                "token_mask",
+                "alignment_student_chunk_id",
+                "alignment_student_exact_partition_mask",
+            ):
+                if student_seq_field in mb:
+                    cp_buffers.append(mb[student_seq_field])
+
     return ProcessedInputs(
         input_ids=input_ids,
         attention_mask=attention_mask,

--- a/nemo_rl/models/automodel/train.py
+++ b/nemo_rl/models/automodel/train.py
@@ -47,6 +47,7 @@ from nemo_rl.algorithms.utils import mask_out_neg_inf_logprobs
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.model_utils import (
     allgather_cp_sharded_tensor,
+    cp_load_balanced_to_contiguous,
     distributed_vocab_topk,
     get_logprobs_from_vocab_parallel_logits,
 )
@@ -988,22 +989,15 @@ class TopkLogitsPostProcessor:
 
 
 class FullLogitsPostProcessor:
-    """Post-processor that returns the full teacher vocab logits unchanged.
+    """Export this rank's raw teacher logits (full vocab, no reduction at the worker).
 
-    Used by cross-tokenizer distillation: the loss fn needs the entire
-    ``[B, S, V_t]`` teacher logits tensor — no vocab reduction is done at
-    the worker. The loss fn either (a) derives a microbatch-global top-k
-    subset internally (``gold_loss=False`` path, matching PT
-    ``global_top_indices`` math) or (b) operates on full vocab directly
-    (``gold_loss=True`` path, matching PT gold). Doing the reduction in
-    the loss fn (not here) keeps transport faithful to the PT reference.
-
-    Output:
-        logits: ``[B, S, V_t]`` raw teacher logits cast to ``float32``.
-
-    v0 limitation: only the no-TP, no-CP, no-seq-packing path is
-    implemented. Asserts on the unsupported configurations — distributed
-    full-vocab gather requires TP-aware reduction not on the smoke path.
+    Used by cross-tokenizer distillation; the loss fn does all vocab
+    reduction (none at the worker) so the distributed result matches the
+    single-GPU PyTorch reference. Teacher TP/CP
+    are supported and may differ from the student's: under TP each rank emits
+    its vocab shard, under CP it allgathers and re-emits its contiguous seq
+    slice; the IPC consumer reassembles the global ``[B, T_t, V_t]``.
+    Sequence packing raises ``NotImplementedError``.
     """
 
     def __init__(
@@ -1031,34 +1025,26 @@ class FullLogitsPostProcessor:
         original_seq_len: int,
         sequence_dim: int = 1,
     ) -> torch.Tensor:
-        if self.cp_size > 1:
-            raise NotImplementedError(
-                "FullLogitsPostProcessor: context_parallel_size > 1 is "
-                "not supported in v0."
-            )
         if self.enable_seq_packing:
             raise NotImplementedError(
                 "FullLogitsPostProcessor: sequence packing is not supported in v0."
             )
         if isinstance(logits, DTensor):
-            tp_group = self.tp_mesh.get_group() if self.tp_mesh is not None else None
-            tp_size = (
-                torch.distributed.get_world_size(tp_group)
-                if tp_group is not None
-                else 1
-            )
-            if tp_size > 1:
-                raise NotImplementedError(
-                    "FullLogitsPostProcessor: tensor_parallel_size > 1 "
-                    "is not supported in v0."
-                )
             logits = logits.to_local()
+        # fp32 for the consumer's precision-sensitive log_softmax / top-k /
+        # projection (KL math), and a dtype-consistent IPC buffer producer<->consumer.
+        logits = logits.to(torch.float32)
 
-        # Teacher is frozen (init_optimizer=False) and the consumer does not
-        # backprop into these logits; downstream log_softmax/KL kernels upcast
-        # to fp32 internally where they need it. Ship native compute dtype
-        # (bf16 under autocast) to halve the IPC buffer footprint.
-        return logits  # [B, S, V_t]
+        # context_parallel shards the seq dim load-balanced (interleaved), but the
+        # IPC consumer routes by contiguous ``global_seq_start`` over the teacher CP
+        # group. Restore global order and emit this rank's contiguous slice, else
+        # heterogeneous teacher_cp != student_cp lands teacher data at the wrong
+        # seq positions in the consumer's dest tensor.
+        if self.cp_size > 1 and self.cp_mesh is not None:
+            logits = cp_load_balanced_to_contiguous(
+                logits, cp_group=self.cp_mesh.get_group(), seq_dim=sequence_dim
+            )
+        return logits  # [B, S_local_contiguous, V_t]
 
 
 class ScorePostProcessor:

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -649,16 +649,20 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
     ) -> list[dict[str, Any]]:
         """Ship the teacher's full-vocab logits to the student via CUDA IPC.
 
-        Used by cross-tokenizer distillation. Returns a flat ``list[B]`` of
-        per-sample IPC handle dicts; each entry's ``logits_ipc``
-        reconstructs a ``[T_t, V_t]`` CUDA tensor on the consumer device.
-        The loss fn then either (a) derives a microbatch-global top-k
-        subset internally to match the PT non-gold path, or (b) uses the
-        full vocab end-to-end to match the PT gold path.
+        Used by cross-tokenizer distillation; supports heterogeneous teacher
+        TP/CP. Gathers each worker's ``{"dp_rank", "per_sample_handles"}`` and
+        returns the global-batch-ordered list produced by
+        :func:`aggregate_per_sample_handles`: a length-``gbs`` list where
+        element ``i`` is ``{"teacher_shards": [shard, ...]}`` holding every
+        TP×CP shard of global sample ``i``. Each shard carries the IPC payload
+        plus the ``buf_idx`` / ``sample_index_in_buf`` slot index and the TP/CP
+        shard metadata; the loss consumer reassembles the full ``[T_t, V_t]``
+        teacher logits (or its CP-local window) from these shards.
 
-        Caller must invoke :meth:`release_ipc_buffer` after the student
-        finishes consuming the handles — otherwise the producer-side
-        CUDA tensors leak.
+        The producer-side IPC storage is persistent and reused across calls
+        (via ``copy_``); the caller releases it once via
+        :meth:`release_ipc_buffer` at the end of training / validation (and on
+        error), not per call.
 
         v0 limitation: no dynamic batching, no sequence packing.
         """

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -46,7 +46,10 @@ from nemo_rl.models.policy.interfaces import (
     ScoreOutputSpec,
     TopkLogitsOutputSpec,
 )
-from nemo_rl.models.policy.utils import resolve_policy_worker_cls
+from nemo_rl.models.policy.utils import (
+    aggregate_per_sample_handles,
+    resolve_policy_worker_cls,
+)
 from nemo_rl.utils.checkpoint import CheckpointingConfig
 from nemo_rl.utils.flops_tracker import (
     FLOPTracker,
@@ -321,6 +324,11 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
 
         self.cfg = config
 
+    @property
+    def data_parallel_size(self) -> int:
+        """Data-parallel degree, read from the policy's sharding annotations."""
+        return self.sharding_annotations.get_axis_size("data_parallel")
+
     def run_all_workers_single_data(self, method_name: str, *args, **kwargs) -> Any:
         """Run a method on all workers in parallel with the same data.
 
@@ -420,7 +428,7 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
         is the inverse permutation needed to undo seqpack/dynbatch reorder
         (``None`` when neither is enabled).
         """
-        dp_size = self.sharding_annotations.get_axis_size("data_parallel")
+        dp_size = self.data_parallel_size
         if self.use_dynamic_batches:
             self.dynamic_batching_args["max_tokens_per_microbatch"] = self.cfg[
                 "dynamic_batching"
@@ -461,7 +469,7 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
         does not return ``unsorted_data_indices`` because train returns
         scalar metrics (no per-row outputs to reorder).
         """
-        dp_size = self.sharding_annotations.get_axis_size("data_parallel")
+        dp_size = self.data_parallel_size
         if self.use_dynamic_batches:
             self.dynamic_batching_args["max_tokens_per_microbatch"] = self.cfg[
                 "dynamic_batching"
@@ -659,7 +667,7 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
                 "get_full_logits_ipc does not support dynamic batching "
                 "or sequence packing in v0."
             )
-        dp_size = self.sharding_annotations.get_axis_size("data_parallel")
+        dp_size = self.data_parallel_size
         with timer.time("get_full_logits_ipc/shard_data") if timer else nullcontext():
             sharded_data = data.shard_by_batch_size(  # type: ignore
                 dp_size,
@@ -675,18 +683,12 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
                     "tensor_parallel",
                     "pipeline_parallel",
                 ],
-                output_is_replicated=[
-                    "context_parallel",
-                    "tensor_parallel",
-                    "pipeline_parallel",
-                ],
+                # Keep every TP × CP output; consumer routes via overlap.
+                output_is_replicated=["pipeline_parallel"],
                 common_kwargs={"micro_batch_size": micro_batch_size},
             )
         worker_results = self.worker_group.get_all_worker_results(futures)
-        all_handles: list[dict[str, Any]] = []
-        for wr in worker_results:
-            all_handles.extend(wr["per_sample_handles"])
-        return all_handles
+        return aggregate_per_sample_handles(worker_results)
 
     def release_ipc_buffer(self) -> None:
         """Tell all workers to drop their stashed IPC tensors."""
@@ -798,7 +800,7 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
         )
         assert self.cfg["generation"] is not None, "Generation config is not set"
 
-        dp_size = self.sharding_annotations.get_axis_size("data_parallel")
+        dp_size = self.data_parallel_size
         sharded_data = data.shard_by_batch_size(dp_size, batch_size=None)
         futures = self.worker_group.run_all_workers_sharded_data(
             "generate",
@@ -839,7 +841,7 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
             "Missing required input fields"
         )
 
-        dp_size = self.sharding_annotations.get_axis_size("data_parallel")
+        dp_size = self.data_parallel_size
         sharded_data = data.shard_by_batch_size(dp_size, batch_size=None)
         futures = self.worker_group.run_all_workers_sharded_data(
             "score",
@@ -929,7 +931,7 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
         distributed reduction, returning results merged across ranks. Therefore, we shard the
         input by DP and call in parallel, then take the result from the first worker.
         """
-        dp_size = self.sharding_annotations.get_axis_size("data_parallel")
+        dp_size = self.data_parallel_size
         if self.use_dynamic_batches:
             self.dynamic_batching_args["max_tokens_per_microbatch"] = self.cfg[
                 "dynamic_batching"

--- a/nemo_rl/models/policy/utils.py
+++ b/nemo_rl/models/policy/utils.py
@@ -16,7 +16,7 @@ import gc
 import os
 import traceback
 from enum import Enum
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Iterable, Optional
 
 import requests
 import torch

--- a/nemo_rl/models/policy/utils.py
+++ b/nemo_rl/models/policy/utils.py
@@ -259,6 +259,84 @@ def get_handle_from_tensor(tensor: torch.Tensor) -> tuple[Any]:
     return reduce_tensor(tensor.detach())[1:]
 
 
+def ensure_teacher_ipc_buffer(
+    storage: Optional[torch.Tensor],
+    handle: Optional[tuple[Any, ...]],
+    num_microbatches: int,
+    batch_size: int,
+    seq_len: int,
+    vocab_size: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> tuple[torch.Tensor, tuple[Any, ...]]:
+    """Lazy-alloc / grow ``[N_mb, B, T, V]`` teacher-logits IPC storage.
+
+    Returns the (possibly reallocated) ``(storage, handle)``. Reallocates and
+    re-exports the IPC handle whenever any dim of the requested shape exceeds
+    the current storage, or dtype/device changed; otherwise the existing
+    storage and cached handle are returned unchanged.
+    """
+    needs_realloc = (
+        storage is None
+        or storage.shape[0] < num_microbatches
+        or storage.shape[1] < batch_size
+        or storage.shape[2] < seq_len
+        or storage.shape[3] < vocab_size
+        or storage.dtype != dtype
+        or storage.device != device
+    )
+    if needs_realloc:
+        storage = torch.empty(
+            (num_microbatches, batch_size, seq_len, vocab_size),
+            dtype=dtype,
+            device=device,
+        )
+        handle = get_handle_from_tensor(storage)
+    assert storage is not None and handle is not None
+    return storage, handle
+
+
+def aggregate_per_sample_handles(
+    worker_results: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Flatten teacher per-sample IPC handles into a global-batch-ordered list.
+
+    Each worker returns ``{"dp_rank": int, "per_sample_handles": list}`` where
+    the handle list is in local sample order; the several workers sharing a
+    ``dp_rank`` are TP/CP replicas that each contribute one shard per sample.
+    Concatenating samples in ``sorted(dp_rank)`` order reproduces the original
+    global sample order (rank 0 holds the first ``gbs/dp`` samples, rank 1 the
+    next, ...), so the result is a length-``gbs`` list independent of the
+    teacher's DP degree. Element ``i`` is ``{"teacher_shards": [shard, ...]}``
+    holding all TP×CP shards of global sample ``i``.
+    """
+    handles_by_dp_rank: dict[int, list[list[dict[str, Any]]]] = {}
+    for worker_result in worker_results:
+        dp_rank = worker_result["dp_rank"]
+        handles_by_dp_rank.setdefault(dp_rank, []).append(
+            worker_result["per_sample_handles"]
+        )
+    aggregated: list[dict[str, Any]] = []
+    for dp_rank in sorted(handles_by_dp_rank.keys()):
+        worker_handles_in_dp = handles_by_dp_rank[dp_rank]
+        num_samples = len(worker_handles_in_dp[0])
+        for worker_handles in worker_handles_in_dp:
+            assert len(worker_handles) == num_samples, (
+                f"dp={dp_rank}: per_sample_handles length mismatch "
+                f"{[len(h) for h in worker_handles_in_dp]}"
+            )
+        for sample_idx in range(num_samples):
+            aggregated.append(
+                {
+                    "teacher_shards": [
+                        worker_handles[sample_idx]
+                        for worker_handles in worker_handles_in_dp
+                    ]
+                }
+            )
+    return aggregated
+
+
 def calculate_aligned_size(size_bytes: int, alignment: int = 512) -> int:
     """Calculate aligned size for memory alignment.
 

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -918,21 +918,21 @@ class DTensorPolicyWorkerV2Impl(
                         vals, (0, 0, 0, pad_needed, 0, 0), mode="constant", value=0.0
                     )
                 batch_size_mb, seq_len_mb, local_vocab_size = vals.shape
-                if storage is None:
-                    self._teacher_ipc_storage, self._teacher_ipc_handle = (
-                        ensure_teacher_ipc_buffer(
-                            self._teacher_ipc_storage,
-                            self._teacher_ipc_handle,
-                            iterator_len,
-                            batch_size_mb,
-                            target_local_seq,
-                            local_vocab_size,
-                            vals.dtype,
-                            vals.device,
-                        )
+
+                self._teacher_ipc_storage, self._teacher_ipc_handle = (
+                    ensure_teacher_ipc_buffer(
+                        self._teacher_ipc_storage,
+                        self._teacher_ipc_handle,
+                        iterator_len,
+                        batch_size_mb,
+                        target_local_seq,
+                        local_vocab_size,
+                        vals.dtype,
+                        vals.device,
                     )
-                    storage = self._teacher_ipc_storage
-                    payload_ipc = self._teacher_ipc_handle
+                )
+                storage = self._teacher_ipc_storage
+                payload_ipc = self._teacher_ipc_handle
                 storage[buf_idx, :batch_size_mb, :seq_len_mb, :local_vocab_size].copy_(
                     vals
                 )

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -68,7 +68,7 @@ from nemo_rl.models.policy.interfaces import (
     ScoreOutputSpec,
 )
 from nemo_rl.models.policy.utils import (
-    get_handle_from_tensor,
+    ensure_teacher_ipc_buffer,
     get_runtime_env_for_policy_worker,
 )
 from nemo_rl.models.policy.workers.base_policy_worker import AbstractPolicyWorker
@@ -258,14 +258,13 @@ class DTensorPolicyWorkerV2Impl(
 
         # Persistent CUDA IPC buffer for cross-tokenizer teacher logits.
         # Allocated once on first ``get_full_logits_ipc`` call (or
-        # reallocated if dims grow), ``.copy_()``-ed into each step, and
-        # exposed via a stable IPC handle captured at allocation. With a
-        # persistent buffer the producer never tries to free between
-        # steps, so the consumer can safely hold a view into the
-        # IPC-imported storage without keeping a now-orphaned producer
-        # allocation pinned via refcount.
-        self._teacher_ipc_buffer: Optional[torch.Tensor] = None
-        self._teacher_ipc_handle: Optional[tuple] = None
+        # reallocated if dims grow), with fresh logits ``.copy_()``-ed into
+        # each microbatch slot per step and exposed via a stable IPC handle
+        # captured at allocation. Persistent storage means the producer never
+        # frees between steps, so the consumer can safely hold a view into the
+        # IPC-imported storage without pinning an orphaned producer allocation.
+        self._teacher_ipc_storage: Optional[torch.Tensor] = None
+        self._teacher_ipc_handle: Optional[tuple[Any, ...]] = None
 
         # Validate configuration and prepare runtime settings
         runtime_config = validate_and_prepare_config(
@@ -839,34 +838,16 @@ class DTensorPolicyWorkerV2Impl(
         data: BatchedDataDict[Any],
         micro_batch_size: Optional[int] = None,
     ) -> dict[str, Any]:
-        """Cross-tokenizer teacher forward; full-vocab logits leave via CUDA IPC.
+        """Teacher forward; full-vocab logits exposed via persistent CUDA IPC storage.
 
-        Used by cross-tokenizer distillation. Returns the full teacher
-        vocab logits ``[T_t, V_t]`` per sample as a CUDA IPC handle so the
-        student worker (a separate Ray actor on the same node) can rebuild
-        the tensor without a CPU round-trip. Both gold-loss and projection-
-        KL paths consume full vocab: PT gold operates on full vocab end to
-        end; PT non-gold computes its ``global_top_indices`` reduction
-        *inside the loss*, not at the worker.
-
-        Lifetime: the source ``[B_r, T_t, V_t]`` CUDA tensor is a
-        **persistent** IPC buffer (``self._teacher_ipc_buffer``)
-        allocated once and reused across every training step. The
-        captured IPC handle (``self._teacher_ipc_handle``) is also
-        stable — each step ``.copy_()``-s fresh logits into the same
-        backing memory. :meth:`release_ipc_buffer` is a no-op kept for
-        driver-side contract compatibility.
-
-        Returns:
-            dict with:
-              - ``per_sample_handles``: ``list[B_r]`` of dicts. Every entry
-                carries the **same** rank-level handle ``rank_logits_ipc``
-                (taken on the whole ``[B_r, T_t, V_t]`` tray) plus its own
-                ``sample_idx_within_rank``. The consumer rebuilds that one
-                handle and slices ``[mb_start:mb_end]`` for the current
-                microbatch — no ``torch.stack``, no extra allocation.
-
-        v0 limitation: TP=1, CP=1, no sequence packing.
+        Used by cross-tokenizer distillation; supports heterogeneous teacher
+        TP/CP. Each microbatch writes into slot
+        ``self._teacher_ipc_storage[buf_idx]`` and shares one cached IPC
+        handle. Returns ``{"per_sample_handles": list, "dp_rank": int}`` where
+        each handle carries ``buf_idx`` and ``sample_index_in_buf`` for the
+        consumer to index the slot view, plus the TP/CP shard metadata
+        (``vocab_start_index``, ``global_seq_start``, ...) the consumer uses to
+        route shards across heterogeneous teacher/student TP/CP.
         """
         forward_batch_size = (
             micro_batch_size
@@ -874,8 +855,10 @@ class DTensorPolicyWorkerV2Impl(
             else self.cfg["logprob_batch_size"]
         )
         sequence_dim, seq_dim_size = check_sequence_dim(data)
+        target_local_seq = (
+            seq_dim_size // self.cp_size if self.cp_size > 1 else seq_dim_size
+        )
 
-        out_vals: list[torch.Tensor] = []
         self.model.eval()
 
         post_processor = FullLogitsPostProcessor(
@@ -887,6 +870,16 @@ class DTensorPolicyWorkerV2Impl(
             enable_seq_packing=self.enable_seq_packing,
         )
 
+        tp_rank = self.tp_mesh.get_local_rank() if self.tp_mesh is not None else 0
+        cp_rank = self.cp_mesh.get_local_rank() if self.cp_mesh is not None else 0
+        dp_rank = self.dp_mesh.get_local_rank() if self.dp_mesh is not None else 0
+        world_rank = torch.distributed.get_rank()
+        full_seq_len = target_local_seq * self.cp_size
+        global_seq_start = cp_rank * full_seq_len // self.cp_size
+
+        per_sample_handles: list[dict[str, Any]] = []
+        storage: Optional[torch.Tensor] = None
+        payload_ipc: Optional[tuple[Any, ...]] = None
         with torch.no_grad():
             data.to("cuda")
             processed_iterator, iterator_len = get_microbatch_iterator(
@@ -897,7 +890,7 @@ class DTensorPolicyWorkerV2Impl(
                 tokenizer=self.tokenizer,
                 cp_size=self.cp_size,
             )
-            for batch_idx, processed_mb in enumerate(processed_iterator):
+            for buf_idx, processed_mb in enumerate(processed_iterator):
                 processed_inputs = processed_mb.processed_inputs
                 with get_train_context(
                     cp_size=self.cp_size,
@@ -916,102 +909,73 @@ class DTensorPolicyWorkerV2Impl(
                         sampling_params=self.sampling_params,
                         sequence_dim=sequence_dim,
                     )
-                if batch_idx >= iterator_len:
+                if buf_idx >= iterator_len:
                     continue
-                # Keep vals on CUDA for IPC; pad seq dim now so the stash
-                # tensor matches the canonical [B_r, T_t, V_t] shape.
-                pad_needed = seq_dim_size - vals.shape[1]
+                # Pad to canonical seq so the cached IPC handle stays shape-stable.
+                pad_needed = target_local_seq - vals.shape[1]
                 if pad_needed > 0:
                     vals = torch.nn.functional.pad(
                         vals, (0, 0, 0, pad_needed, 0, 0), mode="constant", value=0.0
                     )
-                out_vals.append(vals.contiguous())
-
-        final_vals = (
-            torch.cat(out_vals, dim=0) if len(out_vals) > 1 else out_vals[0]
-        )  # CUDA [B_r, T_t, V_t]
-
-        # Lazy-allocate the persistent IPC buffer (sized at first call,
-        # reallocated only if dims grow). The IPC handle is captured once
-        # at allocation and reused across all training steps — the
-        # consumer's view-only rebuild is safe because this buffer is
-        # never freed between steps.
-        B_r, T_t, V_t = final_vals.shape
-        self._ensure_teacher_ipc_buffer(
-            B_r, T_t, V_t, final_vals.dtype, final_vals.device
-        )
-        self._teacher_ipc_buffer[:B_r, :T_t, :V_t].copy_(final_vals)
-        # The copy_ is async on the current stream; force it to complete
-        # before the IPC handle is consumed by the student process, so the
-        # consumer can't observe a partially written buffer (mirrors the
-        # sync in nemo_rl/models/policy/utils.py before exposing handles).
+                batch_size_mb, seq_len_mb, local_vocab_size = vals.shape
+                if storage is None:
+                    self._teacher_ipc_storage, self._teacher_ipc_handle = (
+                        ensure_teacher_ipc_buffer(
+                            self._teacher_ipc_storage,
+                            self._teacher_ipc_handle,
+                            iterator_len,
+                            batch_size_mb,
+                            target_local_seq,
+                            local_vocab_size,
+                            vals.dtype,
+                            vals.device,
+                        )
+                    )
+                    storage = self._teacher_ipc_storage
+                    payload_ipc = self._teacher_ipc_handle
+                storage[buf_idx, :batch_size_mb, :seq_len_mb, :local_vocab_size].copy_(
+                    vals
+                )
+                del vals
+                full_vocab_size = local_vocab_size * self.tp_size
+                vocab_start_index = tp_rank * local_vocab_size
+                vocab_end_index = (tp_rank + 1) * local_vocab_size
+                for sample_index_in_buf in range(batch_size_mb):
+                    per_sample_handles.append(
+                        {
+                            "payload_ipc": payload_ipc,
+                            "buf_idx": buf_idx,
+                            "sample_index_in_buf": sample_index_in_buf,
+                            "storage_shape": tuple(storage.shape),
+                            "actual_shape": (target_local_seq, local_vocab_size),
+                            "dtype": storage.dtype,
+                            "tp_rank": tp_rank,
+                            "cp_rank": cp_rank,
+                            "tp_size": self.tp_size,
+                            "cp_size": self.cp_size,
+                            "world_rank": world_rank,
+                            "vocab_start_index": vocab_start_index,
+                            "vocab_end_index": vocab_end_index,
+                            "global_seq_start": global_seq_start,
+                            "full_vocab_size": full_vocab_size,
+                            "full_seq_len": full_seq_len,
+                            "vocab_sharded": self.tp_size > 1,
+                            "sequence_sharded": self.cp_size > 1,
+                        }
+                    )
+        # The storage copies above are async on the current stream; force them
+        # to complete before the IPC handles are consumed by the student
+        # process, so the consumer can't observe a partially written buffer
+        # (ports the sync added upstream for the single-buffer export path).
         torch.cuda.synchronize()
-        del (
-            final_vals,
-            out_vals,
-        )  # drop the cat intermediate; only the persistent buffer holds the data now
-
-        # Every per-sample entry carries the same stable rank-level
-        # handle plus its rank-local sample index. The consumer rebuilds
-        # the single handle once and slices into the contiguous
-        # microbatch range — no torch.stack, no allocation.
-        rank_shape = (B_r, T_t, V_t)
-        rank_dtype = self._teacher_ipc_buffer.dtype
-
-        per_sample_handles: list[dict[str, Any]] = [
-            {
-                "rank_logits_ipc": self._teacher_ipc_handle,
-                "rank_shape": rank_shape,
-                "dtype": rank_dtype,
-                "sample_idx_within_rank": i,
-            }
-            for i in range(B_r)
-        ]
-        return {"per_sample_handles": per_sample_handles}
-
-    def _ensure_teacher_ipc_buffer(
-        self,
-        B_r: int,
-        T_t: int,
-        V_t: int,
-        dtype: torch.dtype,
-        device: torch.device,
-    ) -> None:
-        """Allocate the persistent teacher-logits IPC buffer if needed.
-
-        On first call: allocates ``[B_r, T_t, V_t]`` on ``device`` with
-        ``dtype`` and captures the IPC handle. On subsequent calls:
-        no-op as long as the existing buffer can hold the requested
-        shape and matches dtype/device. If any dim grew or dtype/device
-        changed, reallocates and re-captures the handle (the consumer
-        will receive the new handle in the next ``get_full_logits_ipc``
-        return value).
-        """
-        if (
-            self._teacher_ipc_buffer is not None
-            and self._teacher_ipc_buffer.shape[0] >= B_r
-            and self._teacher_ipc_buffer.shape[1] >= T_t
-            and self._teacher_ipc_buffer.shape[2] >= V_t
-            and self._teacher_ipc_buffer.dtype == dtype
-            and self._teacher_ipc_buffer.device == device
-        ):
-            return
-        self._teacher_ipc_buffer = torch.empty(
-            (B_r, T_t, V_t), dtype=dtype, device=device
-        )
-        self._teacher_ipc_handle = get_handle_from_tensor(self._teacher_ipc_buffer)
+        return {"per_sample_handles": per_sample_handles, "dp_rank": dp_rank}
 
     def release_ipc_buffer(self) -> None:
-        """No-op under the persistent IPC buffer design.
-
-        The teacher-logits IPC buffer is allocated once on first
-        ``get_full_logits_ipc`` and lives for the worker's lifetime;
-        each step ``.copy_()``-s fresh logits into the same memory
-        backing the same stable IPC handle. The driver still calls
-        this method in its ``finally`` block — keep that contract,
-        but with persistent storage there is nothing to release.
-        """
-        return
+        """Free the persistent teacher-logit IPC storage. Called once at end of training/validation."""
+        self._teacher_ipc_storage = None
+        self._teacher_ipc_handle = None
+        gc.collect()
+        torch.cuda.empty_cache()
 
     @contextmanager
     def use_reference_model(self) -> Generator[None, None, None]:

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -52,6 +52,7 @@ project-includes = [
   "nemo_rl/algorithms/reward_functions.py",
   "nemo_rl/algorithms/utils.py",
   "nemo_rl/algorithms/x_token/__init__.py",
+  "nemo_rl/algorithms/x_token/utils.py",
   "nemo_rl/data/__init__.py",
   "nemo_rl/data/chat_templates.py",
   "nemo_rl/data/collate_fn.py",

--- a/tests/test_suites/llm/distillation-xtoken-off-policy-qwen3-4b-to-llama3.2-1b-1n8g-dtensor-tp4cp2.sh
+++ b/tests/test_suites/llm/distillation-xtoken-off-policy-qwen3-4b-to-llama3.2-1b-1n8g-dtensor-tp4cp2.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $SCRIPT_DIR/common.env
+
+# ===== BEGIN CONFIG =====
+NUM_NODES=1
+MAX_STEPS=100
+NUM_MINUTES=20
+STUDENT_MODEL=meta-llama/Llama-3.2-1B
+TEACHER_MODEL=Qwen/Qwen3-4B
+# ===== END CONFIG =====
+
+exit_if_max_steps_reached
+
+cd $PROJECT_ROOT
+
+# Build the (student, teacher) runtime projection matrix on the fly from the HF
+# tokenizer pair, so this test carries no binary dependency. --enable-exact-match
+# constructs a usable matrix from tokenizer surface forms directly, skipping the
+# optional (slow) embedding-seed pass that build_projection_matrix.sh runs.
+PROJ_DIR=$EXP_DIR/projection
+mkdir -p $PROJ_DIR
+PROJ_PATH=$PROJ_DIR/xtoken_nightly_special.pt
+if [[ ! -f $PROJ_PATH ]]; then
+  uv run python -m tools.x_token.minimal_projection_via_multitoken \
+      --student-model $STUDENT_MODEL \
+      --teacher-model $TEACHER_MODEL \
+      --top-k 4 \
+      --enable-special-token-mapping \
+      --enable-exact-match \
+      --disable-reverse-pass \
+      --disable-scale-trick \
+      --output-filename xtoken_nightly \
+      --output-dir $PROJ_DIR
+fi
+
+# Run the experiment. Parallelism (student TP4xCP2 <- teacher TP2xCP2), models,
+# loss mode (P-KL), and batch/seq sizes live in the recipe YAML.
+uv run examples/run_xtoken_off_policy_distillation.py \
+    --config $CONFIG_PATH \
+    distillation.max_num_steps=$MAX_STEPS \
+    loss_fn.projection_matrix_path=$PROJ_PATH \
+    logger.log_dir=$LOG_DIR \
+    logger.wandb_enabled=True \
+    logger.wandb.project=nemo-rl \
+    logger.wandb.name=$EXP_NAME \
+    logger.monitor_gpus=True \
+    logger.tensorboard_enabled=True \
+    checkpointing.enabled=False \
+    $@ \
+    2>&1 | tee $RUN_LOG
+
+# Convert tensorboard logs to json
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+
+# Only run metrics if the target step is reached
+if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
+    # train/loss is the total P-KL+CE loss. Over 100 steps the sharded student
+    # goes from step1 ~1.88 to mean(last5) ~0.97 and accuracy 0.78 -> ~0.86
+    # (per-step loss is noisy at this tiny GBS, so checks keep margin). A
+    # student-logit gradient bug under TP/CP would leave the loss flat near
+    # step1 and accuracy flat, which the decrease + accuracy checks catch.
+    # validation/kl_loss is the held-out distillation KL (val_period=10): it
+    # falls ~0.057 -> ~0.029 (to ~0.5x). A CP-non-invariance regression in the
+    # sharded loss would leave the held-out KL elevated, which the val checks
+    # below catch.
+    uv run tests/check_metrics.py $JSON_METRICS \
+        'data["train/loss"]["1"] < 2.2' \
+        'mean(data["train/loss"], -5, -1) < 1.15' \
+        'mean(data["train/loss"], -5, -1) < 0.7 * data["train/loss"]["1"]' \
+        'mean(data["train/accuracy"], -5, -1) > 0.80' \
+        'data["validation/kl_loss"]["100"] < 0.04' \
+        'data["validation/kl_loss"]["100"] < 0.65 * data["validation/kl_loss"]["0"]' \
+        'max(data["ray/node.0.gpu.0.mem_gb"]) < 30'
+fi

--- a/tests/test_suites/nightly.txt
+++ b/tests/test_suites/nightly.txt
@@ -229,6 +229,9 @@ tests/test_suites/llm/distillation-qwen3-1.7b-1n8g-megatron-qa-nvfp4.sh
 # policy.disable_modelopt_layer_spec=false to cover modelopt_mamba_stack_spec.
 tests/test_suites/llm/distillation-nano3-30ba3b-4n4g-megatron-qa-nvfp4-modelopt-spec.sh
 
+# Cross-tokenizer off-policy distillation (xtoken): Qwen3-4B -> Llama-3.2-1B P-KL, student TP4xCP2 <- teacher TP2xCP2, guards sharded-loss parallelism-invariance.
+tests/test_suites/llm/distillation-xtoken-off-policy-qwen3-4b-to-llama3.2-1b-1n8g-dtensor-tp4cp2.sh
+
 #######
 # PPO #
 #######

--- a/tests/unit/algorithms/test_loss_functions.py
+++ b/tests/unit/algorithms/test_loss_functions.py
@@ -2294,7 +2294,7 @@ def test_distillation_loss_fn_call():
 # gold path (KL on the exact-mapped common partition + L1 on the uncommon
 # tail) and the next-token CE term. Unlike the DistillationLossFn tests
 # above, these run on CPU: the gold and CE paths use no GPU-pinned ops, and
-# ``dp_all_reduce_sum`` falls back to the local sum when torch.distributed
+# ``group_all_reduce_sum`` falls back to the local sum when torch.distributed
 # is not initialized.
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/algorithms/test_loss_functions.py
+++ b/tests/unit/algorithms/test_loss_functions.py
@@ -30,9 +30,14 @@ from nemo_rl.algorithms.utils import calculate_kl, masked_mean
 from nemo_rl.algorithms.x_token.loss_utils import (
     build_exact_token_map,
     chunk_average_log_probs,
+    localize_alignment,
     valid_chunk_mask,
 )
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.distributed.model_utils import (
+    cp_load_balanced_to_contiguous,
+    cp_shift_next,
+)
 
 
 def setup_dpo_loss_test_data(vocab_size=16, batch_size=1):
@@ -2370,6 +2375,22 @@ def _ct_gold_data(student_chunk_id, teacher_chunk_id, pair_valid, sample_mask):
     )
 
 
+def _ct_gold_prep(logits, teacher_logits, data):
+    """Mirror ``prepare_loss_input``'s shared prep for the single-rank (no-CP)
+    gold path: CP-relaid student logits + localized, next-token-shifted align."""
+    student_logits = cp_load_balanced_to_contiguous(logits, cp_group=None)
+    align = localize_alignment(
+        data, teacher_seq_len=teacher_logits.shape[1], cp_group=None
+    )
+    align.student_chunk_id = cp_shift_next(
+        cp_load_balanced_to_contiguous(align.student_chunk_id, cp_group=None),
+        None,
+        fill=-1,
+    )
+    align.teacher_chunk_id = cp_shift_next(align.teacher_chunk_id, None, fill=-1)
+    return student_logits, align
+
+
 def test_cross_tokenizer_gold_loss_matches_reference(tmp_path):
     """Gold path == (KL on common + L1 on uncommon) * T**2, with no CE term.
 
@@ -2391,8 +2412,9 @@ def test_cross_tokenizer_gold_loss_matches_reference(tmp_path):
     logits = torch.randn(1, 3, _CT_V_STUDENT)
     teacher_logits = torch.randn(1, 3, _CT_V_TEACHER)
 
+    student_logits, align = _ct_gold_prep(logits, teacher_logits, data)
     loss, kl_common, l1_uncommon, n_valid, _ = loss_fn._compute_gold(
-        logits, data, teacher_logits
+        student_logits, teacher_logits, align
     )
 
     assert torch.isfinite(loss)
@@ -2446,7 +2468,10 @@ def test_cross_tokenizer_gold_loss_all_samples_masked_is_zero(tmp_path):
     logits = torch.randn(1, 3, _CT_V_STUDENT)
     teacher_logits = torch.randn(1, 3, _CT_V_TEACHER)
 
-    loss, _, _, n_valid, _ = loss_fn._compute_gold(logits, data, teacher_logits)
+    student_logits, align = _ct_gold_prep(logits, teacher_logits, data)
+    loss, _, _, n_valid, _ = loss_fn._compute_gold(
+        student_logits, teacher_logits, align
+    )
     assert n_valid.item() == 0
     assert torch.equal(loss.detach(), torch.zeros(()))
 

--- a/tests/unit/algorithms/x_token/__init__.py
+++ b/tests/unit/algorithms/x_token/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit/algorithms/x_token/test_loss_utils.py
+++ b/tests/unit/algorithms/x_token/test_loss_utils.py
@@ -13,31 +13,48 @@
 # limitations under the License.
 """Unit tests for ``nemo_rl/algorithms/x_token/loss_utils.py``.
 
-CPU-only. ``Fp32SparseMM`` is GPU-pinned via ``custom_fwd(device_type="cuda")``
-and is intentionally not covered here.
+Most tests here are CPU-only. ``Fp32SparseMM`` is GPU-pinned via
+``custom_fwd(device_type="cuda")`` and is intentionally not covered. The TP/CP
+> 1 code paths require real collectives, so they live in the multi-GPU NCCL
+tests at the bottom of this file (skipped when < 2 GPUs are available).
 """
 
 from __future__ import annotations
 
+import os
+import traceback
 from dataclasses import fields
 from pathlib import Path
 
+import numpy as np
 import pytest
+import ray
 import torch
 
 from nemo_rl.algorithms.x_token.loss_utils import (
     _EXACT_TOKEN_MAP_CACHE,
     _SPARSE_PROJECTION_CACHE,
     _TOPK_PROJECTION_CACHE,
+    _try_zero_copy_teacher_logits,
     alignment_from_flat_batch,
     build_exact_token_map,
     chunk_average_log_probs,
+    collect_overlapping_teacher_shards,
     get_sparse_projection_matrix,
     get_topk_projection,
+    localize_alignment,
     parse_projection_file,
     valid_chunk_mask,
 )
 from nemo_rl.algorithms.x_token.token_aligner import AlignmentBatch
+from nemo_rl.distributed.model_utils import AllReduceSum
+from nemo_rl.distributed.named_sharding import NamedSharding
+from nemo_rl.distributed.ray_actor_environment_registry import (
+    ACTOR_ENVIRONMENT_REGISTRY,
+    PY_EXECUTABLES,
+)
+from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
+from nemo_rl.distributed.worker_groups import RayWorkerBuilder, RayWorkerGroup
 
 # ---------------------------------------------------------------------------
 # alignment_from_flat_batch
@@ -417,3 +434,299 @@ class TestBuildExactTokenMap:
         assert out["common_teacher"].tolist() == [1, 0]
         assert out["uncommon_student"].tolist() == [1, 2]
         assert out["uncommon_teacher"].tolist() == [2]
+
+
+# NOTE: the TP/CP > 1 paths of vocab_parallel_log_softmax / vocab_parallel_full_log_softmax /
+# project_student_to_teacher_vocab / vocab_parallel_argmax /
+# select_teacher_topk_indices are covered by the real multi-GPU NCCL tests at
+# the bottom of this file (single-rank fallbacks would not exercise any of the
+# collectives).
+class TestLocalizeAlignment:
+    def _data(self, B: int = 2, T_s: int = 5, T_t: int = 6, P: int = 3) -> dict:
+        return {
+            "alignment_student_chunk_id": torch.zeros((B, T_s), dtype=torch.long),
+            "alignment_teacher_chunk_id": torch.arange(B * T_t).reshape(B, T_t),
+            "alignment_pair_valid": torch.ones((B, P), dtype=torch.bool),
+            "alignment_pair_is_correct": torch.zeros((B, P), dtype=torch.bool),
+            "sample_mask": torch.ones(B, dtype=torch.bool),
+        }
+
+    def test_no_cp_keeps_full_teacher_chunk_id(self):
+        data = self._data()
+        align = localize_alignment(data, teacher_seq_len=6, cp_group=None)
+        # cp_group=None → start offset 0, full teacher_chunk_id passed through.
+        assert torch.equal(align.teacher_chunk_id, data["alignment_teacher_chunk_id"])
+        assert torch.equal(align.student_chunk_id, data["alignment_student_chunk_id"])
+        assert torch.equal(align.pair_valid, data["alignment_pair_valid"])
+        assert torch.equal(align.pair_is_correct, data["alignment_pair_is_correct"])
+        assert torch.equal(align.sample_mask, data["sample_mask"])
+
+
+class TestCollectOverlappingTeacherShards:
+    @staticmethod
+    def _shard(vstart, vend, gss, seq):
+        return {
+            "vocab_start_index": vstart,
+            "vocab_end_index": vend,
+            "global_seq_start": gss,
+            "actual_shape": (seq, vend - vstart),
+        }
+
+    def test_single_full_shard_no_cp(self):
+        m = collect_overlapping_teacher_shards(
+            [self._shard(0, 5, 0, 4)],
+            student_cp_rank=0,
+            student_cp_size=1,
+            full_seq_len=4,
+        )
+        assert len(m) == 1
+        _, src_seq, src_vocab, dest_seq, dest_vocab = m[0]
+        assert (src_seq, dest_seq) == (slice(0, 4), slice(0, 4))
+        assert (src_vocab, dest_vocab) == (slice(0, 5), slice(0, 5))
+
+    def test_cp_selects_matching_rank_only(self):
+        s0, s1 = self._shard(0, 5, 0, 4), self._shard(0, 5, 4, 4)
+        m = collect_overlapping_teacher_shards(
+            [s0, s1], student_cp_rank=1, student_cp_size=2, full_seq_len=8
+        )
+        assert len(m) == 1 and m[0][0] is s1
+        assert m[0][3] == slice(0, 4)
+
+    def test_tp_shards_map_to_vocab_ranges(self):
+        m = collect_overlapping_teacher_shards(
+            [self._shard(0, 4, 0, 2), self._shard(4, 8, 0, 2)],
+            student_cp_rank=0,
+            student_cp_size=1,
+            full_seq_len=2,
+        )
+        assert [x[4] for x in m] == [slice(0, 4), slice(4, 8)]
+
+
+class TestZeroCopyTeacherLogits:
+    @staticmethod
+    def _entry(sample_idx, vend=5, buf=0, payload=("p",)):
+        return {
+            "teacher_shards": [
+                {
+                    "payload_ipc": payload,
+                    "buf_idx": buf,
+                    "sample_index_in_buf": sample_idx,
+                    "vocab_start_index": 0,
+                    "vocab_end_index": vend,
+                    "global_seq_start": 0,
+                    "actual_shape": (4, vend),
+                    "full_seq_len": 4,
+                    "full_vocab_size": vend,
+                }
+            ]
+        }
+
+    def test_fastpath_returns_zero_copy_view(self, monkeypatch):
+        storage = torch.arange(2 * 4 * 5, dtype=torch.float32).reshape(1, 2, 4, 5)
+        monkeypatch.setattr(
+            "nemo_rl.models.policy.utils.rebuild_cuda_tensor_from_ipc",
+            lambda h, d: storage,
+        )
+        out = _try_zero_copy_teacher_logits(
+            [self._entry(0), self._entry(1)],
+            student_cp_rank=0,
+            student_cp_size=1,
+            device=0,
+        )
+        assert out is not None and out.data_ptr() == storage.data_ptr()
+        assert torch.equal(out, storage[0, :2])
+
+    def test_none_when_vocab_sharded(self):
+        e = self._entry(0)
+        e["teacher_shards"][0]["vocab_end_index"] = 3
+        assert (
+            _try_zero_copy_teacher_logits(
+                [e], student_cp_rank=0, student_cp_size=1, device=0
+            )
+            is None
+        )
+
+    def test_none_when_samples_not_contiguous(self):
+        assert (
+            _try_zero_copy_teacher_logits(
+                [self._entry(0), self._entry(2)],
+                student_cp_rank=0,
+                student_cp_size=1,
+                device=0,
+            )
+            is None
+        )
+
+
+# ---------------------------------------------------------------------------
+# Real multi-GPU (NCCL) tests for the TP/CP loss helpers.
+#
+# tp2cp1 vocab-shards the student logits across 2 ranks; tp1cp2 seq-shards the
+# teacher logits across 2 ranks. Each rank compares its sharded helper output
+# against the single-rank full-tensor reference. Skipped when < 2 GPUs.
+# ---------------------------------------------------------------------------
+
+
+@ray.remote(num_gpus=1)
+class XtokenShardTestActor:
+    def __init__(self, tp_size, cp_size, sharding):
+        self.tp_size = tp_size
+        self.cp_size = cp_size
+
+    def run_tp(self):
+        from nemo_rl.algorithms.x_token.loss_utils import (
+            project_student_to_teacher_vocab,
+        )
+        from nemo_rl.distributed.model_utils import (
+            vocab_parallel_argmax,
+            vocab_parallel_full_log_softmax,
+            vocab_parallel_log_softmax,
+        )
+
+        try:
+            torch.distributed.init_process_group(backend="nccl")
+            rank = int(os.environ["RANK"])
+            ws = int(os.environ["WORLD_SIZE"])
+            tp = torch.distributed.new_group(ranks=list(range(ws)))
+
+            torch.manual_seed(0)
+            B, T, Vs, Vt, temp = 2, 4, 8, 6, 1.5
+            shard = Vs // ws
+            sl = slice(rank * shard, (rank + 1) * shard)
+            full = torch.randn(B, T, Vs, device="cuda")
+            full_log = torch.log_softmax(full.float() / temp, dim=-1)
+            local = full[:, :, sl].contiguous()
+
+            torch.testing.assert_close(
+                vocab_parallel_log_softmax(local, temp, tp_group=tp),
+                full_log[:, :, sl],
+                rtol=1e-4,
+                atol=1e-4,
+            )
+            torch.testing.assert_close(
+                vocab_parallel_full_log_softmax(local, temp, tp_group=tp),
+                full_log,
+                rtol=1e-4,
+                atol=1e-4,
+            )
+            torch.testing.assert_close(
+                vocab_parallel_argmax(local, tp_group=tp), full.argmax(dim=-1)
+            )
+
+            idx = torch.tensor(
+                [[0, 1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 0, 1]], device="cuda"
+            )
+            m = torch.sparse_coo_tensor(
+                idx, torch.ones(8, device="cuda"), (Vs, Vt)
+            ).coalesce()
+            full_probs = full_log.exp()
+            proj = project_student_to_teacher_vocab(
+                full_probs[:, :, sl].contiguous(), m, tp_group=tp
+            )
+            ref = (full_probs.reshape(-1, Vs) @ m.to_dense()).reshape(B, T, Vt)
+            torch.testing.assert_close(proj, ref, rtol=1e-4, atol=1e-4)
+            return {"success": True, "error": None}
+        except Exception:
+            return {"success": False, "error": traceback.format_exc()}
+        finally:
+            if torch.distributed.is_initialized():
+                torch.distributed.destroy_process_group()
+
+    def run_cp(self):
+        from nemo_rl.algorithms.x_token.loss_utils import (
+            chunk_average_log_probs,
+            select_teacher_topk_indices,
+        )
+
+        try:
+            torch.distributed.init_process_group(backend="nccl")
+            rank = int(os.environ["RANK"])
+            ws = int(os.environ["WORLD_SIZE"])
+            cp = torch.distributed.new_group(ranks=list(range(ws)))
+
+            torch.manual_seed(0)
+            B, T, V, k = 2, 8, 6, 3
+            shard = T // ws
+            sl = slice(rank * shard, (rank + 1) * shard)
+            full = torch.randn(B, T, V, device="cuda")
+
+            torch.testing.assert_close(
+                select_teacher_topk_indices(
+                    full[:, sl, :].contiguous(), k, cp_group=cp
+                ),
+                torch.topk(full.reshape(-1, V).max(dim=0).values, k)
+                .indices.sort()
+                .values,
+            )
+
+            full_lp = torch.log_softmax(full, dim=-1)
+            cid = torch.tensor(
+                [[0, 0, 0, 0, 1, 1, 1, 1], [0, 0, 1, 1, 1, 1, 0, 0]], device="cuda"
+            )
+            avg, sizes = chunk_average_log_probs(
+                full_lp[:, sl, :].contiguous(), cid[:, sl].contiguous(), 2, cp_group=cp
+            )
+            ref_avg, ref_sizes = chunk_average_log_probs(full_lp, cid, 2, cp_group=None)
+            torch.testing.assert_close(avg, ref_avg, rtol=1e-4, atol=1e-4)
+            torch.testing.assert_close(sizes, ref_sizes)
+
+            x = torch.full((3,), float(rank + 1), device="cuda", requires_grad=True)
+            y = AllReduceSum.apply(x, cp)
+            torch.testing.assert_close(
+                y, torch.full((3,), float(ws * (ws + 1) // 2), device="cuda")
+            )
+            y.sum().backward()
+            torch.testing.assert_close(x.grad, torch.ones(3, device="cuda"))
+            return {"success": True, "error": None}
+        except Exception:
+            return {"success": False, "error": traceback.format_exc()}
+        finally:
+            if torch.distributed.is_initialized():
+                torch.distributed.destroy_process_group()
+
+
+_ACTOR_FQN = f"{XtokenShardTestActor.__module__}.XtokenShardTestActor"
+
+
+@pytest.fixture
+def register_actor():
+    original = ACTOR_ENVIRONMENT_REGISTRY.get(_ACTOR_FQN)
+    ACTOR_ENVIRONMENT_REGISTRY[_ACTOR_FQN] = PY_EXECUTABLES.SYSTEM
+    yield _ACTOR_FQN
+    if original is None:
+        ACTOR_ENVIRONMENT_REGISTRY.pop(_ACTOR_FQN, None)
+    else:
+        ACTOR_ENVIRONMENT_REGISTRY[_ACTOR_FQN] = original
+
+
+def _run(register_actor, tp_size, cp_size, method):
+    world_size = tp_size * cp_size
+    if not torch.cuda.is_available() or torch.cuda.device_count() < world_size:
+        pytest.skip(f"need {world_size} GPUs, got {torch.cuda.device_count()}")
+    cluster = RayVirtualCluster(bundle_ct_per_node_list=[world_size], use_gpus=True)
+    try:
+        sharding = NamedSharding(
+            layout=np.arange(world_size).reshape(tp_size, cp_size), names=["tp", "cp"]
+        )
+        worker_group = RayWorkerGroup(
+            cluster=cluster,
+            remote_worker_builder=RayWorkerBuilder(
+                register_actor, tp_size, cp_size, sharding
+            ),
+            workers_per_node=None,
+            sharding_annotations=sharding,
+        )
+        results = ray.get(worker_group.run_all_workers_single_data(method))
+        for i, r in enumerate(results):
+            assert r["success"], f"rank {i} failed:\n{r['error']}"
+        worker_group.shutdown(force=True)
+    finally:
+        cluster.shutdown()
+
+
+def test_tp2cp1_sharded_helpers(register_actor):
+    _run(register_actor, tp_size=2, cp_size=1, method="run_tp")
+
+
+def test_tp1cp2_sharded_helpers(register_actor):
+    _run(register_actor, tp_size=1, cp_size=2, method="run_cp")

--- a/tests/unit/algorithms/x_token/test_loss_utils.py
+++ b/tests/unit/algorithms/x_token/test_loss_utils.py
@@ -37,6 +37,7 @@ from nemo_rl.algorithms.x_token.loss_utils import (
     _TOPK_PROJECTION_CACHE,
     _try_zero_copy_teacher_logits,
     alignment_from_flat_batch,
+    assemble_teacher_logits_from_shards,
     build_exact_token_map,
     chunk_average_log_probs,
     collect_overlapping_teacher_shards,
@@ -47,7 +48,7 @@ from nemo_rl.algorithms.x_token.loss_utils import (
     valid_chunk_mask,
 )
 from nemo_rl.algorithms.x_token.token_aligner import AlignmentBatch
-from nemo_rl.distributed.model_utils import AllReduceSum
+from nemo_rl.distributed.model_utils import group_all_reduce_sum_with_grad
 from nemo_rl.distributed.named_sharding import NamedSharding
 from nemo_rl.distributed.ray_actor_environment_registry import (
     ACTOR_ENVIRONMENT_REGISTRY,
@@ -581,6 +582,87 @@ class TestZeroCopyTeacherLogits:
         )
 
 
+class TestAssembleTeacherLogitsFromShards:
+    """CPU coverage of the heterogeneous teacher-TP/CP -> student-CP reassembly.
+
+    Monkeypatches ``rebuild_cuda_tensor_from_ipc`` so the IPC slice-write logic
+    (the #2682 path) is exercised without GPUs/IPC. A known full teacher-logit
+    tensor is split into a teacher TP2xCP2 grid (4 shards); each student CP rank
+    must reassemble exactly its ``[T_t/CP_s, V_t]`` contiguous-seq, full-vocab
+    window.
+    """
+
+    @staticmethod
+    def _build_tp2cp2(full):
+        """Split ``full`` [T, V] into a teacher TP2xCP2 grid -> (shards, storage_map)."""
+        full_seq_len, full_vocab_size = full.shape
+        seq_mid, vocab_mid = full_seq_len // 2, full_vocab_size // 2
+        storage_map = {}
+        shards = []
+        for cp, (s0, s1) in enumerate([(0, seq_mid), (seq_mid, full_seq_len)]):
+            for tp, (v0, v1) in enumerate(
+                [(0, vocab_mid), (vocab_mid, full_vocab_size)]
+            ):
+                payload = (f"cp{cp}tp{tp}",)
+                # Producer storage layout: [N_microbatches, B_mb, T_local, V_local].
+                storage_map[payload] = (
+                    full[s0:s1, v0:v1].clone().reshape(1, 1, s1 - s0, v1 - v0)
+                )
+                shards.append(
+                    {
+                        "payload_ipc": payload,
+                        "buf_idx": 0,
+                        "sample_index_in_buf": 0,
+                        "vocab_start_index": v0,
+                        "vocab_end_index": v1,
+                        "global_seq_start": s0,
+                        "actual_shape": (s1 - s0, v1 - v0),
+                        "full_seq_len": full_seq_len,
+                        "full_vocab_size": full_vocab_size,
+                    }
+                )
+        return shards, storage_map
+
+    @pytest.mark.parametrize("student_cp_rank", [0, 1])
+    def test_tp2cp2_reassembly(self, monkeypatch, student_cp_rank):
+        full = torch.arange(8 * 6, dtype=torch.float32).reshape(8, 6)
+        shards, storage_map = self._build_tp2cp2(full)
+        monkeypatch.setattr(
+            "nemo_rl.models.policy.utils.rebuild_cuda_tensor_from_ipc",
+            lambda payload, device: storage_map[payload],
+        )
+        out = assemble_teacher_logits_from_shards(
+            shards,
+            student_cp_rank=student_cp_rank,
+            student_cp_size=2,
+            device="cpu",
+        )
+        lo, hi = student_cp_rank * 4, (student_cp_rank + 1) * 4
+        assert out.shape == (4, 6)
+        assert torch.equal(out, full[lo:hi, :])
+
+    def test_non_divisible_seq_len_asserts(self):
+        # full_seq_len=7 not divisible by student_cp_size=2 -> guard fires before
+        # the out-of-bounds dest write the assert protects against.
+        shards = [
+            {
+                "payload_ipc": ("x",),
+                "buf_idx": 0,
+                "sample_index_in_buf": 0,
+                "vocab_start_index": 0,
+                "vocab_end_index": 6,
+                "global_seq_start": 0,
+                "actual_shape": (7, 6),
+                "full_seq_len": 7,
+                "full_vocab_size": 6,
+            }
+        ]
+        with pytest.raises(AssertionError):
+            assemble_teacher_logits_from_shards(
+                shards, student_cp_rank=0, student_cp_size=2, device="cpu"
+            )
+
+
 # ---------------------------------------------------------------------------
 # Real multi-GPU (NCCL) tests for the TP/CP loss helpers.
 #
@@ -694,7 +776,7 @@ class XtokenShardTestActor:
             torch.testing.assert_close(sizes, ref_sizes)
 
             x = torch.full((3,), float(rank + 1), device="cuda", requires_grad=True)
-            y = AllReduceSum.apply(x, cp)
+            y = group_all_reduce_sum_with_grad(x, cp)
             torch.testing.assert_close(
                 y, torch.full((3,), float(ws * (ws + 1) // 2), device="cuda")
             )

--- a/tests/unit/algorithms/x_token/test_loss_utils.py
+++ b/tests/unit/algorithms/x_token/test_loss_utils.py
@@ -536,6 +536,29 @@ class TestZeroCopyTeacherLogits:
         assert out is not None and out.data_ptr() == storage.data_ptr()
         assert torch.equal(out, storage[0, :2])
 
+    def test_fastpath_applies_cp_seq_offset(self, monkeypatch):
+        # student_cp_size=2, rank=1: the view must be sliced to this rank's
+        # contiguous seq window [T//2 : T], not the whole sequence. With
+        # cp_size=1 (above) seq_lo/seq_hi collapse to [0:T], so this case is
+        # what guards the `student_seq_start - teacher_seq_start` offset.
+        storage = torch.arange(2 * 4 * 5, dtype=torch.float32).reshape(1, 2, 4, 5)
+        monkeypatch.setattr(
+            "nemo_rl.models.policy.utils.rebuild_cuda_tensor_from_ipc",
+            lambda h, d: storage,
+        )
+        out = _try_zero_copy_teacher_logits(
+            [self._entry(0), self._entry(1)],
+            student_cp_rank=1,
+            student_cp_size=2,
+            device=0,
+        )
+        # full_seq_len=4 -> rank 1 owns seq [2:4]; teacher_seq_start=0. Still a
+        # zero-copy view, but starting at the seq-offset row (so its data_ptr
+        # matches the offset slice, not storage's base pointer).
+        expected = storage[0, :2, 2:4, :]
+        assert out is not None and out.data_ptr() == expected.data_ptr()
+        assert torch.equal(out, expected)
+
     def test_none_when_vocab_sharded(self):
         e = self._entry(0)
         e["teacher_shards"][0]["vocab_end_index"] = 3

--- a/tests/unit/algorithms/x_token/test_utils.py
+++ b/tests/unit/algorithms/x_token/test_utils.py
@@ -20,6 +20,7 @@ import torch
 
 from nemo_rl.algorithms.x_token.utils import (
     assert_teacher_student_batch_grid,
+    assert_xtoken_ipc_node_local,
     pad_distillation_val_batch,
 )
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
@@ -53,6 +54,49 @@ class TestAssertTeacherStudentBatchGrid:
     def test_not_divisible_by_mbs_raises(self):
         with pytest.raises(AssertionError):
             self._check(student_mbs=3)
+
+
+class TestAssertXtokenIpcNodeLocal:
+    def _check(self, **kw):
+        args = dict(
+            num_nodes=2,
+            gpus_per_node=4,
+            student_tp=2,
+            student_cp=2,
+            teacher_tp=2,
+            teacher_cp=2,
+            student_dp=1,
+            teacher_dp=1,
+        )
+        args.update(kw)
+        assert_xtoken_ipc_node_local(**args)
+
+    def test_single_node_always_ok(self):
+        # Even an otherwise-disallowed multi-node grid passes on one node.
+        self._check(num_nodes=1, student_dp=1, teacher_dp=2, teacher_tp=4, teacher_cp=2)
+
+    def test_multinode_matched_grid_ok(self):
+        self._check()
+
+    def test_multinode_mismatched_dp_raises(self):
+        with pytest.raises(AssertionError):
+            self._check(student_dp=1, teacher_dp=2)
+
+    def test_multinode_mismatched_group_raises(self):
+        with pytest.raises(AssertionError):
+            self._check(student_tp=1, teacher_tp=2)  # groups 2 vs 4
+
+    def test_multinode_group_exceeds_node_raises(self):
+        with pytest.raises(AssertionError):
+            self._check(
+                gpus_per_node=2, student_tp=2, student_cp=2, teacher_tp=2, teacher_cp=2
+            )  # group 4 > 2
+
+    def test_multinode_group_not_node_aligned_raises(self):
+        with pytest.raises(AssertionError):
+            self._check(
+                gpus_per_node=6, student_tp=2, student_cp=2, teacher_tp=2, teacher_cp=2
+            )  # 6 % 4 != 0
 
 
 class TestPadDistillationValBatch:

--- a/tests/unit/algorithms/x_token/test_utils.py
+++ b/tests/unit/algorithms/x_token/test_utils.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for ``nemo_rl/algorithms/x_token/utils.py`` (CPU-only)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from nemo_rl.algorithms.x_token.utils import (
+    assert_teacher_student_batch_grid,
+    pad_distillation_val_batch,
+)
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+
+
+class TestAssertTeacherStudentBatchGrid:
+    def _check(self, **kw):
+        args = dict(
+            global_batch_size=8,
+            student_gbs=8,
+            teacher_gbs=8,
+            student_dp=4,
+            teacher_dp=2,
+            student_mbs=1,
+            teacher_mbs=1,
+        )
+        args.update(kw)
+        assert_teacher_student_batch_grid(**args)
+
+    def test_valid_passes(self):
+        self._check()
+
+    def test_gbs_disagreement_raises(self):
+        with pytest.raises(AssertionError):
+            self._check(student_gbs=4)
+
+    def test_not_divisible_by_dp_raises(self):
+        with pytest.raises(AssertionError):
+            self._check(global_batch_size=6, student_gbs=6, teacher_gbs=6)
+
+    def test_not_divisible_by_mbs_raises(self):
+        with pytest.raises(AssertionError):
+            self._check(student_mbs=3)
+
+
+class TestPadDistillationValBatch:
+    def test_pads_tensors_lists_and_zeros_mask(self):
+        batch = BatchedDataDict(
+            {
+                "x": torch.arange(2 * 3).reshape(2, 3),
+                "sample_mask": torch.ones(2),
+                "meta": ["a", "b"],
+            }
+        )
+        out = pad_distillation_val_batch(batch, 4)
+        assert out["x"].shape == (4, 3)
+        assert torch.equal(out["x"][:2], batch["x"])
+        assert out["meta"] == ["a", "b", "b", "b"]
+        assert out["sample_mask"].tolist() == [1, 1, 0, 0]
+
+    def test_noop_when_target_equals_size(self):
+        batch = BatchedDataDict({"sample_mask": torch.ones(2)})
+        assert pad_distillation_val_batch(batch, 2) is batch

--- a/tests/unit/algorithms/x_token/test_xtoken_off_policy_distillation.py
+++ b/tests/unit/algorithms/x_token/test_xtoken_off_policy_distillation.py
@@ -112,6 +112,7 @@ def _make_master_config(
                 "val_period": val_period,
                 "val_at_start": val_at_start,
                 "val_at_end": val_at_end,
+                "val_teacher_micro_batch_size": 1,
             },
             "policy": {
                 "dtensor_cfg": {

--- a/tests/unit/algorithms/x_token/test_xtoken_off_policy_distillation.py
+++ b/tests/unit/algorithms/x_token/test_xtoken_off_policy_distillation.py
@@ -38,38 +38,45 @@ from nemo_rl.algorithms.xtoken_off_policy_distillation import (
     validate,
     xtoken_off_policy_distillation_train,
 )
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
-def _make_batch(batch_size: int = 1, t_student: int = 4, t_teacher: int = 4) -> dict:
+def _make_batch(
+    batch_size: int = 1, t_student: int = 4, t_teacher: int = 4
+) -> BatchedDataDict:
     """Synthetic batch with every key the algo's train_data packer reads."""
-    return {
-        "input_ids": torch.zeros((batch_size, t_student), dtype=torch.long),
-        "input_lengths": torch.full((batch_size,), t_student, dtype=torch.long),
-        "token_mask": torch.ones((batch_size, t_student), dtype=torch.long),
-        "sample_mask": torch.ones((batch_size,), dtype=torch.long),
-        "teacher_input_ids": torch.zeros((batch_size, t_teacher), dtype=torch.long),
-        "teacher_input_lengths": torch.full((batch_size,), t_teacher, dtype=torch.long),
-        "teacher_token_mask": torch.ones((batch_size, t_teacher), dtype=torch.long),
-        "alignment_pair_valid": torch.ones((batch_size, 2), dtype=torch.bool),
-        "alignment_pair_is_correct": torch.ones((batch_size, 2), dtype=torch.bool),
-        "alignment_student_exact_partition_mask": torch.zeros(
-            (batch_size, t_student), dtype=torch.bool
-        ),
-        "alignment_teacher_exact_partition_mask": torch.zeros(
-            (batch_size, t_teacher), dtype=torch.bool
-        ),
-        "alignment_student_chunk_id": torch.zeros(
-            (batch_size, t_student), dtype=torch.long
-        ),
-        "alignment_teacher_chunk_id": torch.zeros(
-            (batch_size, t_teacher), dtype=torch.long
-        ),
-        "alignment_num_chunks": torch.tensor([1] * batch_size, dtype=torch.long),
-    }
+    return BatchedDataDict(
+        {
+            "input_ids": torch.zeros((batch_size, t_student), dtype=torch.long),
+            "input_lengths": torch.full((batch_size,), t_student, dtype=torch.long),
+            "token_mask": torch.ones((batch_size, t_student), dtype=torch.long),
+            "sample_mask": torch.ones((batch_size,), dtype=torch.long),
+            "teacher_input_ids": torch.zeros((batch_size, t_teacher), dtype=torch.long),
+            "teacher_input_lengths": torch.full(
+                (batch_size,), t_teacher, dtype=torch.long
+            ),
+            "teacher_token_mask": torch.ones((batch_size, t_teacher), dtype=torch.long),
+            "alignment_pair_valid": torch.ones((batch_size, 2), dtype=torch.bool),
+            "alignment_pair_is_correct": torch.ones((batch_size, 2), dtype=torch.bool),
+            "alignment_student_exact_partition_mask": torch.zeros(
+                (batch_size, t_student), dtype=torch.bool
+            ),
+            "alignment_teacher_exact_partition_mask": torch.zeros(
+                (batch_size, t_teacher), dtype=torch.bool
+            ),
+            "alignment_student_chunk_id": torch.zeros(
+                (batch_size, t_student), dtype=torch.long
+            ),
+            "alignment_teacher_chunk_id": torch.zeros(
+                (batch_size, t_teacher), dtype=torch.long
+            ),
+            "alignment_num_chunks": torch.tensor([1] * batch_size, dtype=torch.long),
+        }
+    )
 
 
 def _mock_dataloader(num_batches: int) -> MagicMock:
@@ -115,6 +122,8 @@ def _make_master_config(
                 },
                 "max_total_sequence_length": 64,
                 "make_sequence_length_divisible_by": 8,
+                "train_global_batch_size": 1,
+                "train_micro_batch_size": 1,
                 "tokenizer": {"name": "student-tok"},
             },
             "teacher": {
@@ -126,6 +135,8 @@ def _make_master_config(
                 },
                 "max_total_sequence_length": 64,
                 "make_sequence_length_divisible_by": 8,
+                "train_global_batch_size": 1,
+                "train_micro_batch_size": 1,
                 "tokenizer": {"name": "teacher-tok"},
             },
             "loss_fn": {
@@ -176,9 +187,12 @@ def mock_xtoken_components():
         "grad_norm": torch.tensor(1.0),
         "all_mb_metrics": {"global_valid_toks": [10], "kl_loss": [0.3]},
     }
+    # validate() derives the DP degree for the val-batch pad quantum.
+    student_policy.data_parallel_size = 1
 
     teacher_policy = MagicMock()
     teacher_policy.get_full_logits_ipc.return_value = [{"shape": (4, 32)}]
+    teacher_policy.data_parallel_size = 1
 
     train_dataloader = _mock_dataloader(num_batches=10)
     val_dataloader = _mock_dataloader(num_batches=2)
@@ -230,7 +244,15 @@ def _patched_setup_call(master_config, *, student_vocab=32, teacher_vocab=24):
         mock_cp_cls.return_value.load_training_info.return_value = None
         mock_cp_cls.return_value.get_resume_paths.return_value = (None, None)
         mock_dl_cls.side_effect = lambda *a, **kw: MagicMock(spec=StatefulDataLoader)
-        mock_policy_cls.side_effect = lambda *a, **kw: MagicMock()
+
+        def _make_policy(*a, **kw):
+            # Policy.data_parallel_size feeds the diff-DP grid assert in
+            # setup(); it needs a real int, not a MagicMock.
+            policy = MagicMock()
+            policy.data_parallel_size = 1
+            return policy
+
+        mock_policy_cls.side_effect = _make_policy
 
         result = setup(
             master_config,
@@ -336,7 +358,15 @@ def test_setup_val_dataloader_gating(
         mock_cp_cls.return_value.load_training_info.return_value = None
         mock_cp_cls.return_value.get_resume_paths.return_value = (None, None)
         mock_dl_cls.side_effect = lambda *a, **kw: MagicMock(spec=StatefulDataLoader)
-        mock_policy_cls.side_effect = lambda *a, **kw: MagicMock()
+
+        def _make_policy(*a, **kw):
+            # Policy.data_parallel_size feeds the diff-DP grid assert in
+            # setup(); it needs a real int, not a MagicMock.
+            policy = MagicMock()
+            policy.data_parallel_size = 1
+            return policy
+
+        mock_policy_cls.side_effect = _make_policy
 
         (
             _student,
@@ -486,9 +516,24 @@ def test_ipc_buffer_released_on_student_train_failure(mock_xtoken_components):
     with pytest.raises(RuntimeError):
         _run_train(c)
 
-    # Even though student.train raised, the try/finally must have invoked
-    # teacher_policy.release_ipc_buffer.
+    # Even though student.train raised, the except branch must have invoked
+    # teacher_policy.release_ipc_buffer before propagating.
     assert c.teacher_policy.release_ipc_buffer.call_count >= 1
+
+
+def test_ipc_buffer_not_released_on_happy_path(mock_xtoken_components):
+    c = mock_xtoken_components
+    c.master_config.distillation["max_num_steps"] = 3
+    c.master_config.distillation["max_num_epochs"] = 10
+
+    _run_train(c)
+
+    # The teacher reuses one persistent IPC buffer across steps via copy_, so
+    # successful steps must not release it (releasing every step would free +
+    # realloc the large teacher-logits buffer and fragment the GPU into an OOM).
+    # It is released exactly once at termination -- not per step, which the old
+    # try/finally would have done (3 steps + 1 exit = 4 releases).
+    assert c.teacher_policy.release_ipc_buffer.call_count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/models/policy/test_utils.py
+++ b/tests/unit/models/policy/test_utils.py
@@ -25,7 +25,9 @@ import zmq
 
 from nemo_rl.models.policy.utils import (
     IPCProtocol,
+    aggregate_per_sample_handles,
     calculate_aligned_size,
+    ensure_teacher_ipc_buffer,
     get_megatron_checkpoint_dir,
     rebuild_cuda_tensor_from_ipc,
     stream_weights_via_ipc_zmq_impl,
@@ -375,3 +377,46 @@ class TestStreamWeightsViaIPC:
 
             if os.path.exists(socket_path):
                 os.unlink(socket_path)
+
+
+class TestAggregatePerSampleHandles:
+    def test_orders_by_dp_rank(self):
+        out = aggregate_per_sample_handles(
+            [
+                {"dp_rank": 1, "per_sample_handles": ["b0", "b1"]},
+                {"dp_rank": 0, "per_sample_handles": ["a0", "a1"]},
+            ]
+        )
+        assert [e["teacher_shards"] for e in out] == [["a0"], ["a1"], ["b0"], ["b1"]]
+
+    def test_collects_replicas_per_sample(self):
+        out = aggregate_per_sample_handles(
+            [
+                {"dp_rank": 0, "per_sample_handles": ["r0s0", "r0s1"]},
+                {"dp_rank": 0, "per_sample_handles": ["r1s0", "r1s1"]},
+            ]
+        )
+        assert [e["teacher_shards"] for e in out] == [
+            ["r0s0", "r1s0"],
+            ["r0s1", "r1s1"],
+        ]
+
+    def test_length_mismatch_raises(self):
+        with pytest.raises(AssertionError):
+            aggregate_per_sample_handles(
+                [
+                    {"dp_rank": 0, "per_sample_handles": ["a0", "a1"]},
+                    {"dp_rank": 0, "per_sample_handles": ["b0"]},
+                ]
+            )
+
+
+class TestEnsureTeacherIpcBuffer:
+    def test_alloc_reuse_and_grow(self):
+        dev = torch.device("cpu")
+        s, h = ensure_teacher_ipc_buffer(None, None, 2, 1, 4, 8, torch.float32, dev)
+        assert s.shape == (2, 1, 4, 8) and h is not None
+        s2, h2 = ensure_teacher_ipc_buffer(s, h, 2, 1, 4, 8, torch.float32, dev)
+        assert s2 is s and h2 is h
+        s3, _ = ensure_teacher_ipc_buffer(s, h, 3, 1, 4, 8, torch.float32, dev)
+        assert s3 is not s and s3.shape == (3, 1, 4, 8)


### PR DESCRIPTION
# What does this PR do ?
Adds TP / CP / heterogeneous-DP sharding support to the cross-tokenizer (xtoken) off-policy distillation loss (P-KL + gold) on the DTensor v2 worker, fixes a context-parallel loss-invariance bug, and adds a parallelism-invariance nightly.

# Issues
Closes https://github.com/NVIDIA-NeMo/RL/issues/2682

Following:
1. https://github.com/NVIDIA-NeMo/RL/issues/2792 (Make building the (student, teacher) projection matrix inflight )
2. https://github.com/NVIDIA-NeMo/RL/issues/2927 (Multi node support)
# Result

Teacher : Qwen/Qwen3-4B TP2 CP2 DP2
Student : meta-llama/Llama-3.2-1B  TP4 CP2 DP1
## KL Loss
<img width="3111" height="1578" alt="image" src="https://github.com/user-attachments/assets/35c3e5d4-cdab-4371-8d19-396d90e88411" />

## Gold Loss
<img width="3173" height="1092" alt="image" src="https://github.com/user-attachments/assets/78f09098-9fb6-4965-9535-235a97228560" />

## XT Loss
<img width="2785" height="1143" alt="image" src="https://github.com/user-attachments/assets/9c74a959-9bac-47ce-963b-92e8d9eb090b" />


# Usage

```bash
# 1. Build the (student, teacher) projection matrix from the tokenizer pair (one-time, offline) -> writes <output-dir>/<output-filename>_special.pt.
uv run python -m tools.x_token.minimal_projection_via_multitoken --student-model meta-llama/Llama-3.2-1B --teacher-model Qwen/Qwen3-4B --top-k 4 --enable-special-token-mapping --enable-exact-match --disable-reverse-pass --disable-scale-trick --output-filename xtoken_proj --output-dir /tmp/xtoken_proj
# 2. Distill: student TP4×CP2 from a teacher running TP2×CP2 (heterogeneous layout); the loss stays parallelism-invariant across TP/CP/DP.
uv run examples/run_xtoken_off_policy_distillation.py --config examples/configs/recipes/llm/xtoken-off-policy-distillation-qwen3-4b-to-llama3.2-1b-1n8g-dtensor-tp4cp2.yaml loss_fn.projection_matrix_path=/tmp/xtoken_proj/xtoken_proj_special.pt
# key knobs: policy.dtensor_cfg.{tensor_parallel_size=4,context_parallel_size=2}, teacher.dtensor_cfg.{tensor_parallel_size=2,context_parallel_size=2}
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
