### PR TITLE
feat: expose `use_gloo_process_groups` toggle for megatron policy workers

### DIFF
--- a/examples/configs/distillation_math.yaml
+++ b/examples/configs/distillation_math.yaml
@@ -123,6 +123,7 @@ policy: &POLICY_BASE
         moe_enable_deepep: false
         moe_token_dispatcher_type: "alltoall"
         moe_shared_expert_overlap: false
+        use_gloo_process_groups: false
         gradient_accumulation_fusion: false
         use_fused_weighted_squared_relu: false
         optimizer:

--- a/examples/configs/distillation_math_megatron.yaml
+++ b/examples/configs/distillation_math_megatron.yaml
@@ -72,6 +72,7 @@ policy: &POLICY_BASE
         moe_enable_deepep: false
         moe_token_dispatcher_type: "alltoall"
         moe_shared_expert_overlap: false
+        use_gloo_process_groups: false
         peft:
             enabled: false
             target_modules: []

--- a/examples/configs/dpo.yaml
+++ b/examples/configs/dpo.yaml
@@ -163,6 +163,7 @@ policy:
     moe_enable_deepep: false
     moe_token_dispatcher_type: "alltoall"
     moe_shared_expert_overlap: false
+    use_gloo_process_groups: false
     gradient_accumulation_fusion: false
     use_fused_weighted_squared_relu: false
 

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -201,6 +201,7 @@ policy:
     moe_enable_deepep: false
     moe_token_dispatcher_type: "alltoall"
     moe_shared_expert_overlap: false
+    use_gloo_process_groups: false
     # Multi-Token Prediction (MTP). mtp_num_layers=0 disables MTP.
     mtp_num_layers: 0
     # MTP loss weight added to the main next-token loss (0.0 disables the MTP loss contribution).

--- a/examples/configs/grpo_math_1B_megatron.yaml
+++ b/examples/configs/grpo_math_1B_megatron.yaml
@@ -114,6 +114,7 @@ policy:
     moe_enable_deepep: false
     moe_token_dispatcher_type: "alltoall"
     moe_shared_expert_overlap: false
+    use_gloo_process_groups: false
     #gives ~20% training perf speedup with sequence packing
     apply_rope_fusion: True
 

--- a/examples/configs/ppo_math_1B.yaml
+++ b/examples/configs/ppo_math_1B.yaml
@@ -143,6 +143,7 @@ policy:
     moe_enable_deepep: false
     moe_token_dispatcher_type: "allgather"
     moe_shared_expert_overlap: false
+    use_gloo_process_groups: false
     apply_rope_fusion: True
     bias_activation_fusion: True
     gradient_accumulation_fusion: false
@@ -325,6 +326,7 @@ value:
     moe_enable_deepep: false
     moe_token_dispatcher_type: "allgather"
     moe_shared_expert_overlap: false
+    use_gloo_process_groups: false
     apply_rope_fusion: True
     bias_activation_fusion: True
     gradient_accumulation_fusion: false

--- a/examples/configs/sft.yaml
+++ b/examples/configs/sft.yaml
@@ -148,6 +148,7 @@ policy:
     moe_enable_deepep: false
     moe_token_dispatcher_type: "alltoall"
     moe_shared_expert_overlap: false
+    use_gloo_process_groups: false
     gradient_accumulation_fusion: false
     use_fused_weighted_squared_relu: false
 

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -35,6 +35,7 @@ from megatron.bridge.training.config import (
     CheckpointConfig,
     ConfigContainer,
     DistributedDataParallelConfig,
+    DistributedInitConfig,
     LoggerConfig,
     OptimizerConfig,
     SchedulerConfig,
@@ -1019,10 +1020,18 @@ def _create_megatron_config(
             "Set policy.megatron_cfg.distributed_data_parallel_config."
             "overlap_param_gather=false."
         )
+
+    dist_cfg = DistributedInitConfig()
+    if "use_gloo_process_groups" in config["megatron_cfg"]:
+        dist_cfg.use_gloo_process_groups = config["megatron_cfg"][
+            "use_gloo_process_groups"
+        ]
+
     return ConfigContainer(
         model=model_cfg,
         checkpoint=checkpoint_config,
         logger=LoggerConfig(logging_level=0),
+        dist=dist_cfg,
         train=TrainingConfig(
             micro_batch_size=1,  # ignored
             global_batch_size=config["train_global_batch_size"],  # ignored

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -306,6 +306,9 @@ class MegatronConfig(TypedDict):
     moe_pad_experts_for_cuda_graph_inference: NotRequired[bool]
     # Can be used only with 'alltoall' token dispatcher
     moe_shared_expert_overlap: bool
+    # Create gloo process groups during Megatron distributed init.
+    # Omitted: use the Megatron Bridge default.
+    use_gloo_process_groups: NotRequired[bool]
     # Enable grouped GEMM for MoE experts via CUTLASS. Significant throughput
     # gain when multiple experts are assigned per rank (num_local_experts > 1).
     # Requires TE >= 1.11.0 for FP8 and Ampere (sm_80) or newer.

--- a/tests/unit/models/megatron/test_megatron_setup.py
+++ b/tests/unit/models/megatron/test_megatron_setup.py
@@ -1437,6 +1437,75 @@ class TestValidateDtypeConfig:
 
 
 @pytest.mark.mcore
+class TestCreateMegatronConfigGlooProcessGroups:
+    """Tests for use_gloo_process_groups plumbing in _create_megatron_config."""
+
+    @staticmethod
+    def _config(**megatron_overrides):
+        megatron_cfg = {
+            "optimizer": {"use_distributed_optimizer": False},
+            "scheduler": {},
+            "distributed_data_parallel_config": {
+                "overlap_param_gather": False,
+                "grad_reduce_in_fp32": False,
+                "overlap_grad_reduce": False,
+                "data_parallel_sharding_strategy": "no_shard",
+            },
+            "train_iters": 10,
+        }
+        megatron_cfg.update(megatron_overrides)
+        return {"megatron_cfg": megatron_cfg, "train_global_batch_size": 8}
+
+    def _dist_config_passed_to_container(self, config):
+        """Return the dist config _create_megatron_config hands to ConfigContainer.
+
+        The container and sibling sub-config builders are patched so only the
+        DistributedInitConfig branch is exercised; DistributedInitConfig itself
+        stays real so the asserted attribute reflects actual behavior.
+        """
+        from nemo_rl.models.megatron.setup import _create_megatron_config
+
+        with (
+            patch("nemo_rl.models.megatron.setup.ConfigContainer") as mock_container,
+            patch("nemo_rl.models.megatron.setup.TrainingConfig"),
+            patch("nemo_rl.models.megatron.setup.OptimizerConfig"),
+            patch("nemo_rl.models.megatron.setup.DistributedDataParallelConfig"),
+            patch("nemo_rl.models.megatron.setup.SchedulerConfig"),
+            patch("nemo_rl.models.megatron.setup.TokenizerConfig"),
+            patch("nemo_rl.models.megatron.setup.LoggerConfig"),
+        ):
+            _create_megatron_config(
+                model_cfg=MagicMock(),
+                checkpoint_config=MagicMock(),
+                config=config,
+                hf_model_name="test-model",
+                dtype=torch.bfloat16,
+            )
+
+        return mock_container.call_args.kwargs["dist"]
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_explicit_value_is_forwarded(self, value):
+        """An explicit use_gloo_process_groups is applied to the dist config."""
+        dist_config = self._dist_config_passed_to_container(
+            self._config(use_gloo_process_groups=value)
+        )
+
+        assert dist_config.use_gloo_process_groups is value
+
+    def test_absent_key_defers_to_bridge_default(self):
+        """Omitting the key leaves the Megatron Bridge default untouched."""
+        from megatron.bridge.training.config import DistributedInitConfig
+
+        dist_config = self._dist_config_passed_to_container(self._config())
+
+        assert (
+            dist_config.use_gloo_process_groups
+            == DistributedInitConfig().use_gloo_process_groups
+        )
+
+
+@pytest.mark.mcore
 class TestValidateAndSetConfig:
     """Tests for validate_and_set_config function."""
 

--- a/tests/unit/reference_configs/distillation_math.yaml
+++ b/tests/unit/reference_configs/distillation_math.yaml
@@ -114,6 +114,7 @@ policy: &POLICY_BASE
         moe_enable_deepep: false
         moe_token_dispatcher_type: "alltoall"
         moe_shared_expert_overlap: false
+        use_gloo_process_groups: false
         gradient_accumulation_fusion: false
         use_fused_weighted_squared_relu: false
 

--- a/tests/unit/reference_configs/dpo.yaml
+++ b/tests/unit/reference_configs/dpo.yaml
@@ -149,6 +149,7 @@ policy:
     moe_enable_deepep: false
     moe_token_dispatcher_type: "alltoall"
     moe_shared_expert_overlap: false
+    use_gloo_process_groups: false
     gradient_accumulation_fusion: false
     use_fused_weighted_squared_relu: false
 

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -196,6 +196,7 @@ policy:
     moe_enable_deepep: false
     moe_token_dispatcher_type: "alltoall"
     moe_shared_expert_overlap: false
+    use_gloo_process_groups: false
     # Multi-Token Prediction (MTP). mtp_num_layers=0 disables MTP.
     mtp_num_layers: 0
     # MTP loss weight added to the main next-token loss (0.0 disables the MTP loss contribution).

--- a/tests/unit/reference_configs/ppo_math_1B_megatron.yaml
+++ b/tests/unit/reference_configs/ppo_math_1B_megatron.yaml
@@ -144,6 +144,7 @@ policy:
     moe_enable_deepep: false
     moe_token_dispatcher_type: "allgather"
     moe_shared_expert_overlap: false
+    use_gloo_process_groups: false
     apply_rope_fusion: True
     bias_activation_fusion: True
     gradient_accumulation_fusion: false
@@ -310,6 +311,7 @@ value:
     moe_enable_deepep: false
     moe_token_dispatcher_type: "allgather"
     moe_shared_expert_overlap: false
+    use_gloo_process_groups: false
     apply_rope_fusion: True
     bias_activation_fusion: True
     gradient_accumulation_fusion: false

--- a/tests/unit/reference_configs/sft.yaml
+++ b/tests/unit/reference_configs/sft.yaml
@@ -134,6 +134,7 @@ policy:
     moe_enable_deepep: false
     moe_token_dispatcher_type: "alltoall"
     moe_shared_expert_overlap: false
+    use_gloo_process_groups: false
     gradient_accumulation_fusion: false
     use_fused_weighted_squared_relu: false
 


### PR DESCRIPTION
# What does this PR do ?

Plumb Megatron Bridge's DistributedInitConfig.use_gloo_process_groups through nemo-rl's MegatronConfig so it can be controlled via YAML. The toggle is applied when constructing the ConfigContainer in _create_megatron_config; when omitted, Megatron Bridge defaults apply (the gloo groups are created).

Disable gloo process group creation in the megatron recipe configs (added only to the base recipe of each inheritance chain so inheriting recipes pick it up via defaults merge). This removes gloo group creation cost and a scaling error-surface for large-node runs. 

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
