### PR TITLE
fix(nrl-k8s): follow RayJob status cluster name

### DIFF
--- a/infra/nrl_k8s/src/nrl_k8s/inspect.py
+++ b/infra/nrl_k8s/src/nrl_k8s/inspect.py
@@ -69,16 +69,29 @@ def collect_status(loaded: LoadedConfig) -> list[ClusterStatus]:
 
 
 def _status_for(role: str, cluster: ClusterSpec, infra: InfraConfig) -> ClusterStatus:
+    # In `--rayjob` mode KubeRay creates the RayCluster with a random suffix
+    # (`<cluster.name>-<5 chars>`) and writes the suffixed name to the
+    # owning RayJob's `.status.rayClusterName`. A bare lookup on cluster.name
+    # 404s, so fall through to the RayJob to find the actual cluster.
     obj = k8s.get_raycluster(cluster.name, infra.namespace)
+    resolved_name = cluster.name
+    if obj is None:
+        rayjob = k8s.get_rayjob(cluster.name, infra.namespace)
+        suffixed = (rayjob or {}).get("status", {}).get("rayClusterName")
+        if suffixed:
+            obj = k8s.get_raycluster(suffixed, infra.namespace)
+            if obj is not None:
+                resolved_name = suffixed
+
     state = (obj or {}).get("status", {}).get("state", "—") if obj else "(not found)"
 
-    pods = list_cluster_pods(cluster.name, infra.namespace)
+    pods = list_cluster_pods(resolved_name, infra.namespace)
 
     daemon_id: str | None = None
     daemon_status: str | None = None
     if obj is not None and state == "ready" and cluster.daemon is not None:
         daemon_id, daemon_status = _latest_daemon_job(
-            cluster.name, infra.namespace, cluster.daemon.submissionId
+            resolved_name, infra.namespace, cluster.daemon.submissionId
         )
 
     return ClusterStatus(

--- a/infra/nrl_k8s/tests/unit/test_inspect.py
+++ b/infra/nrl_k8s/tests/unit/test_inspect.py
@@ -157,3 +157,76 @@ class TestLatestDaemonJob:
         sid, status = ins._latest_daemon_job("rc-gym", "ns-a", "gym-daemon")
         assert sid == "gym-daemon"
         assert status is None
+
+
+# =============================================================================
+# _status_for — RayJob auto-suffix fallback
+# =============================================================================
+
+
+def _fake_cluster_spec(name: str, daemon=None):
+    """Stand-in for `ClusterSpec` — only the attrs `_status_for` reads."""
+    return SimpleNamespace(name=name, daemon=daemon)
+
+
+def _fake_infra(namespace: str = "ns-a"):
+    return SimpleNamespace(namespace=namespace)
+
+
+class TestStatusForRayJobSuffix:
+    """In `--rayjob` mode KubeRay creates the RayCluster with a random
+    suffix and writes it to the RayJob's `.status.rayClusterName`. The
+    bare cluster.name is gone, so `_status_for` must follow the RayJob.
+    """
+
+    def test_falls_back_to_rayjob_when_bare_cluster_missing(
+        self, monkeypatch
+    ) -> None:
+        cluster = _fake_cluster_spec("rc-train")
+
+        # Bare cluster.name 404s; suffixed name resolves.
+        def _get_rc(name, _ns):
+            return (
+                {"status": {"state": "ready"}}
+                if name == "rc-train-abc12"
+                else None
+            )
+
+        monkeypatch.setattr(ins.k8s, "get_raycluster", _get_rc)
+        monkeypatch.setattr(
+            ins.k8s,
+            "get_rayjob",
+            lambda name, _ns: {"status": {"rayClusterName": "rc-train-abc12"}},
+        )
+
+        captured: dict = {}
+
+        def _list_pods(cluster_name, _ns):
+            captured["cluster_name"] = cluster_name
+            return ins.RayClusterPods(head_name="rc-train-abc12-head-x")
+
+        monkeypatch.setattr(ins, "list_cluster_pods", _list_pods)
+
+        result = ins._status_for("training", cluster, _fake_infra())
+
+        assert result.state == "ready"
+        assert result.head_pod == "rc-train-abc12-head-x"
+        assert captured["cluster_name"] == "rc-train-abc12"
+        # The displayed name stays the configured one — matches how users
+        # reference the cluster in their recipe.
+        assert result.name == "rc-train"
+
+    def test_reports_not_found_when_neither_cluster_nor_rayjob_exists(
+        self, monkeypatch
+    ) -> None:
+        cluster = _fake_cluster_spec("rc-train")
+        monkeypatch.setattr(ins.k8s, "get_raycluster", lambda *_a: None)
+        monkeypatch.setattr(ins.k8s, "get_rayjob", lambda *_a: None)
+        monkeypatch.setattr(
+            ins,
+            "list_cluster_pods",
+            lambda *_a: ins.RayClusterPods(),
+        )
+
+        result = ins._status_for("training", cluster, _fake_infra())
+        assert result.state == "(not found)"


### PR DESCRIPTION
## Summary
- make nrl-k8s status fall back through RayJob.status.rayClusterName when KubeRay creates a suffixed RayCluster for --rayjob runs
- use the resolved RayCluster name for pod and daemon lookup while keeping the configured name in the status display
- add focused unit coverage for the RayJob suffix fallback

## Testing
- git diff --check HEAD~1..HEAD
- python3 -m py_compile infra/nrl_k8s/src/nrl_k8s/inspect.py infra/nrl_k8s/tests/unit/test_inspect.py

Note: focused pytest was not run because system Python lacks pytest and the uv test-env run was interrupted before completion.