### PR TITLE
feat(vllm): add deferred model load for overlapped NeMo Gym init

### DIFF
--- a/nemo_rl/models/generation/vllm/vllm_generation.py
+++ b/nemo_rl/models/generation/vllm/vllm_generation.py
@@ -51,10 +51,25 @@ class VllmGeneration(GenerationInterface):
         config: VllmConfig,
         name_prefix: str = "vllm_policy",
         workers_per_node: Optional[Union[int, list[int]]] = None,
+        defer_model_load: bool = False,
     ):
-        """Initialize a vLLM policy with distributed workers."""
+        """Initialize a vLLM policy with distributed workers.
+
+        When defer_model_load=True, workers only reserve ports (seconds) and
+        dp_openai_server_base_urls is populated immediately from reserved ports.
+        Call load_and_start() later to perform heavy model loading. This enables
+        overlapping vLLM model loading with NeMo Gym init.
+
+        Args:
+            cluster: Virtual cluster for worker placement
+            config: VllmConfig dictionary
+            name_prefix: Prefix for Ray actor names
+            workers_per_node: Workers per node override
+            defer_model_load: If True, defer model loading for overlapped init
+        """
         # Store config
         self.cfg = config
+        self._defer_model_load = defer_model_load
         self.tp_size = self.cfg["vllm_cfg"]["tensor_parallel_size"]
         self.pp_size = self.cfg["vllm_cfg"]["pipeline_parallel_size"]
         self.ep_size = self.cfg["vllm_cfg"]["expert_parallel_size"]
@@ -145,7 +160,12 @@ class VllmGeneration(GenerationInterface):
                 "nemo_rl.models.generation.vllm.vllm_worker.VllmGenerationWorker"
             )
         worker_cls = resolve_generation_worker_cls(worker_cls, self.cfg)
-        worker_builder = RayWorkerBuilder(worker_cls, config)
+        if self.cfg["vllm_cfg"]["async_engine"]:
+            worker_builder = RayWorkerBuilder(
+                worker_cls, config, defer_model_load=defer_model_load
+            )
+        else:
+            worker_builder = RayWorkerBuilder(worker_cls, config)
 
         # It's necessary to set env_vars here to ensure that vllm non-leader workers also have these env_vars
         env_vars = {}
@@ -192,13 +212,6 @@ class VllmGeneration(GenerationInterface):
                 env_vars=env_vars,
             )
 
-        # Call some collective rpc functions in VllmGenerationWorker when initializing the vLLM engine
-        # This is necessary for async engine to work
-        self._post_init()
-
-        # dp_openai_server_base_urls is only returned by Async vLLM flow when http server is active
-        self.dp_openai_server_base_urls = self._report_dp_openai_server_base_urls()
-
         # Number of data parallel groups is the number of tied worker groups
         assert self.dp_size == self.worker_group.dp_size, (
             f"Data parallel size mismatch. Expected {self.dp_size}, got {self.worker_group.dp_size}"
@@ -207,8 +220,20 @@ class VllmGeneration(GenerationInterface):
         # Used to track the round-robin selection of worker groups for generate_async
         self.current_generate_dp_shard_idx = 0
 
-        # Save the device uuids for the workers
-        self.device_uuids = self._report_device_id()
+        if defer_model_load:
+            # Workers only reserved ports — collect URLs immediately and defer
+            # the heavy model loading (and HTTP server start) to load_and_start().
+            self.dp_openai_server_base_urls = self._collect_reserved_urls()
+            self.device_uuids = None
+        else:
+            # Full init: call some collective rpc functions in the worker when
+            # initializing the vLLM engine (necessary for async engine to work),
+            # then report server URLs and device ids.
+            self._post_init()
+            # dp_openai_server_base_urls is only returned by the async vLLM flow
+            # when the http server is active.
+            self.dp_openai_server_base_urls = self._report_dp_openai_server_base_urls()
+            self.device_uuids = self._report_device_id()
 
         self._step_metrics_snapshot: dict[str | tuple[str, int], float] | None = None
 
@@ -356,6 +381,45 @@ class VllmGeneration(GenerationInterface):
         # Wait for all futures to complete
         results = ray.get(futures)
         return results
+
+    def _collect_reserved_urls(self) -> list[Optional[str]]:
+        """Collect reserved URLs from DP leaders before model loading.
+
+        Only called when defer_model_load=True. Workers have bound ports
+        during __init__ and can report their reserved URLs immediately.
+        """
+        if not self.cfg["vllm_cfg"]["async_engine"]:
+            return [None]
+
+        futures = self.worker_group.run_all_workers_single_data(
+            "get_reserved_url",
+            run_rank_0_only_axes=["tensor_parallel", "pipeline_parallel"],
+        )
+        results = ray.get(futures)
+        return results
+
+    def load_and_start(self) -> None:
+        """Load models on all workers and start HTTP servers.
+
+        Called after a deferred init (defer_model_load=True) to perform the
+        heavy model loading. Updates dp_openai_server_base_urls with the actual
+        running server URLs and populates device_uuids.
+        """
+        # Call load_model() on all model-owner workers
+        futures = self.worker_group.run_all_workers_single_data(
+            "load_model",
+            run_rank_0_only_axes=["tensor_parallel", "pipeline_parallel"],
+        )
+        ray.get(futures)
+
+        # Post-init (collective rpc functions needed for async engine)
+        self._post_init()
+
+        # Refresh URLs from the actual running servers
+        self.dp_openai_server_base_urls = self._report_dp_openai_server_base_urls()
+
+        # Save device UUIDs
+        self.device_uuids = self._report_device_id()
 
     def _post_init(self):
         # Choose the appropriate method based on async_engine setting

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -149,6 +149,7 @@ class BaseVllmGenerationWorker:
         fraction_of_gpus: float = 1.0,
         seed: Optional[int] = None,
         extra_env_vars: Optional[list[str]] = None,
+        defer_model_load: bool = False,
     ):
         """Initialize a vLLM worker for distributed inference.
 
@@ -160,7 +161,29 @@ class BaseVllmGenerationWorker:
             seed: Random seed for initialization
             extra_env_vars: Additional environment variable names to forward into
                           the vLLM worker subprocess (e.g. for quantization configs).
+            defer_model_load: If True, skip model loading during init. Call
+                _load_model() later to perform the heavy model loading. This
+                enables overlapping vLLM model loading with NeMo Gym init.
         """
+        self._init_config(
+            config, bundle_indices, fraction_of_gpus, seed, extra_env_vars
+        )
+
+        if not self.is_model_owner:
+            return
+
+        if not defer_model_load:
+            self._load_model(bundle_indices, seed)
+
+    def _init_config(
+        self,
+        config: VllmConfig,
+        bundle_indices: Optional[list[int]],
+        fraction_of_gpus: float,
+        seed: Optional[int],
+        extra_env_vars: Optional[list[str]],
+    ):
+        """Lightweight config setup. No model loading, no heavy imports."""
         self.cfg = config
         self.model_name = self.cfg["model_name"]
         self.tensor_parallel_size = self.cfg["vllm_cfg"]["tensor_parallel_size"]
@@ -171,9 +194,12 @@ class BaseVllmGenerationWorker:
         self.precision = self.cfg["vllm_cfg"]["precision"]
         self.fraction_of_gpus = fraction_of_gpus
         self.is_model_owner = bundle_indices is not None
+        self._extra_env_vars = extra_env_vars
 
         # Store the Python executable being used by this worker
         self.py_executable = sys.executable
+
+        self._apply_vllm_patches()
 
         # Skip model loading if we're not the model owner
         if not self.is_model_owner:
@@ -188,10 +214,15 @@ class BaseVllmGenerationWorker:
         self.rank = 0
         self.world_size = 1
 
-        # Monkey patches for vLLM behavior. We avoid importing vllm modules
-        # here to prevent side effects during initialization and instead
-        # locate the files via importlib metadata.
+    def _apply_vllm_patches(self):
+        """Apply file-on-disk patches to vLLM source files.
 
+        These patches are idempotent (check before writing) and applied early
+        during ``_init_config`` so that **all** workers -- including non-model
+        owners -- see the patched files before any vLLM import. We avoid
+        importing vllm modules here to prevent side effects during
+        initialization and instead locate the files via importlib metadata.
+        """
         from vllm.logger import init_logger
 
         logger = init_logger("vllm_patch")
@@ -276,7 +307,7 @@ class BaseVllmGenerationWorker:
                 'ADDITIONAL_ENV_VARS = {"HF_TOKEN", "HUGGING_FACE_HUB_TOKEN"}',
             ]
             extra_env_str = ", ".join(
-                [f'"{env_var}"' for env_var in (extra_env_vars or [])]
+                [f'"{env_var}"' for env_var in (self._extra_env_vars or [])]
             )
 
             new_lines = [
@@ -470,6 +501,16 @@ class BaseVllmGenerationWorker:
 
         _patch_vllm_llama_eagle3_own_lm_head()
         _patch_vllm_hermes_tool_parser_thread_safety()
+
+    def _load_model(self, bundle_indices, seed):
+        """Perform the heavy model loading and engine creation.
+
+        Split out from __init__ so it can be deferred (defer_model_load=True)
+        and run after ports are reserved, overlapping with NeMo Gym init.
+        """
+        from vllm.logger import init_logger
+
+        logger = init_logger("vllm_load_model")
 
         try:
             import vllm

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -150,6 +150,93 @@ Template repr (detokenized): {repr(tokenizer.decode(template_token_ids))}"""
 
 
 class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
+    def __init__(
+        self,
+        config,
+        bundle_indices=None,
+        fraction_of_gpus: float = 1.0,
+        seed=None,
+        extra_env_vars: Optional[list[str]] = None,
+        defer_model_load: bool = False,
+    ):
+        """Initialize an async vLLM worker.
+
+        When defer_model_load=True, only stores config and reserves a port for
+        the HTTP server (if expose_http_server is enabled). Call load_model()
+        later to perform the heavy model loading. This enables overlapping vLLM
+        model loading with NeMo Gym init.
+
+        Args:
+            config: Configuration dictionary for the policy
+            bundle_indices: List of local bundle indices within a node for parallelism.
+            fraction_of_gpus: Fraction of GPUs to use for this worker
+            seed: Random seed for initialization
+            extra_env_vars: Additional environment variable names to forward into
+                          the vLLM worker subprocess.
+            defer_model_load: If True, skip model loading and only reserve port
+        """
+        # Deferred-loading state. Always initialized so every instance has a
+        # consistent set of attributes regardless of init path.
+        self._reserved_socket = None
+        self._reserved_port = None
+        self._reserved_node_ip = None
+        self._deferred_bundle_indices = None
+        self._deferred_seed = None
+
+        super().__init__(
+            config,
+            bundle_indices,
+            fraction_of_gpus,
+            seed,
+            extra_env_vars,
+            defer_model_load,
+        )
+
+        if not self.is_model_owner or not defer_model_load:
+            return
+
+        self._deferred_bundle_indices = bundle_indices
+        self._deferred_seed = seed
+
+        if self.cfg["vllm_cfg"].get("expose_http_server"):
+            self._reserve_port()
+
+        self.llm = None
+        self.vllm_device_ids = None
+
+    def _reserve_port(self) -> None:
+        """Bind and listen on a TCP socket to reserve a free port from the OS.
+
+        The socket is held open in LISTENING state and later passed directly to
+        uvicorn via the ``sockets=`` parameter in ``server.serve()``. The socket
+        is never closed and re-opened, so there is zero gap where another process
+        could steal the port.
+        """
+        import socket
+
+        from nemo_rl.distributed.virtual_cluster import _get_node_ip_local
+
+        self._reserved_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._reserved_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._reserved_socket.bind(("", 0))
+        self._reserved_socket.listen(128)
+        self._reserved_socket.setblocking(False)
+        self._reserved_port = self._reserved_socket.getsockname()[1]
+        self._reserved_node_ip = _get_node_ip_local()
+        print(
+            f"Reserved port {self._reserved_port} on {self._reserved_node_ip} "
+            f"for vLLM HTTP server"
+        )
+
+    def load_model(self) -> None:
+        """Load the vLLM model and create the engine.
+
+        Called after a deferred init to perform the heavy model loading.
+        """
+        if not self.is_model_owner:
+            return
+        self._load_model(self._deferred_bundle_indices, self._deferred_seed)
+
     def _create_engine(self, llm_kwargs: dict[str, Any]) -> None:
         from vllm.config import CompilationConfig
         from vllm.engine.arg_utils import AsyncEngineArgs
@@ -315,6 +402,12 @@ class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
 
     async def post_init_async(self):
         self.vllm_device_ids = await self.report_device_id_async()
+
+    async def get_reserved_url(self) -> Optional[str]:
+        """Return the URL from the reserved socket, available before model loading."""
+        if self._reserved_socket is not None:
+            return f"http://{self._reserved_node_ip}:{self._reserved_port}/v1"
+        return None
 
     async def report_dp_openai_server_base_url(self) -> Optional[str]:
         return self.base_url
@@ -755,14 +848,24 @@ class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
         # Server spinup
         ########################################
 
-        node_ip = _get_node_ip_local()
-        port_range_low = self.cfg.get(
-            "port_range_low", DEFAULT_GENERATION_PORT_RANGE_LOW
-        )
-        port_range_high = self.cfg.get(
-            "port_range_high", DEFAULT_GENERATION_PORT_RANGE_HIGH
-        )
-        free_port = _get_free_port_local(port_range_low, port_range_high)
+        if self._reserved_socket is not None:
+            # Use the socket reserved during __init__ (deferred model load path).
+            # Pass it directly to uvicorn via sockets= — zero gap, the socket is
+            # never closed and re-opened, so no other process can steal the port.
+            node_ip = self._reserved_node_ip
+            free_port = self._reserved_port
+            reserved_sock = self._reserved_socket
+            self._reserved_socket = None  # Transfer ownership to uvicorn
+        else:
+            node_ip = _get_node_ip_local()
+            port_range_low = self.cfg.get(
+                "port_range_low", DEFAULT_GENERATION_PORT_RANGE_LOW
+            )
+            port_range_high = self.cfg.get(
+                "port_range_high", DEFAULT_GENERATION_PORT_RANGE_HIGH
+            )
+            free_port = _get_free_port_local(port_range_low, port_range_high)
+            reserved_sock = None
 
         base_url = f"http://{node_ip}:{free_port}/v1"
         print(f"Starting server on {base_url}")
@@ -787,7 +890,19 @@ class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
         uvicorn_logger = getLogger("uvicorn.access")
         uvicorn_logger.addFilter(No200Filter())
 
-        thread = threading.Thread(target=server.run, daemon=True)
+        if reserved_sock is not None:
+            # Hand the pre-bound listening socket directly to uvicorn's asyncio
+            # server via server.serve(sockets=). No close-and-rebind needed.
+            import asyncio
+
+            def _run_with_socket():
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                loop.run_until_complete(server.serve(sockets=[reserved_sock]))
+
+            thread = threading.Thread(target=_run_with_socket, daemon=True)
+        else:
+            thread = threading.Thread(target=server.run, daemon=True)
         thread.start()
 
         return thread, base_url, server

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -1619,6 +1619,91 @@ def test_vllm_http_server(cluster, tokenizer):
         )
 
 
+def test_vllm_deferred_model_load(cluster, tokenizer):
+    """Test deferred model loading for overlapped initialization.
+
+    Verifies:
+    1. defer_model_load=True returns URLs immediately without loading the model
+    2. Reserved URLs are valid (non-None for each DP rank)
+    3. load_and_start() loads model and starts HTTP server on the reserved port
+    4. Final reported URLs match the reserved URLs (same port)
+    5. HTTP server is functional after load_and_start()
+    """
+    generation_config = configure_http_server_config(tokenizer)
+    generation_config["temperature"] = 0.0
+
+    # Phase 1: Deferred init — only reserve ports, no model loading
+    vllm_generation = VllmGeneration(cluster, generation_config, defer_model_load=True)
+
+    # URLs should be available immediately from reserved ports
+    reserved_urls = vllm_generation.dp_openai_server_base_urls
+    assert len(reserved_urls) == cluster.num_gpus_per_node, (
+        f"Expected {cluster.num_gpus_per_node} URLs, got {len(reserved_urls)}"
+    )
+    for url in reserved_urls:
+        assert url is not None, "Reserved URL should not be None for async engine"
+        assert url.startswith("http://"), f"URL should start with http://, got {url}"
+        assert url.endswith("/v1"), f"URL should end with /v1, got {url}"
+
+    # Model should NOT be loaded yet — device_uuids should be None
+    assert vllm_generation.device_uuids is None, (
+        "device_uuids should be None before load_and_start()"
+    )
+
+    # HTTP server should NOT be running yet
+    try:
+        requests.get(reserved_urls[0], timeout=1)
+        # If we somehow get a response, something is wrong
+        assert False, "HTTP server should not be running before load_and_start()"
+    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
+        pass  # Expected — server is not running yet
+
+    # Phase 2: Load model and start HTTP server
+    vllm_generation.load_and_start()
+
+    # Final URLs should match reserved URLs (same port was used)
+    final_urls = vllm_generation.dp_openai_server_base_urls
+    assert len(final_urls) == len(reserved_urls)
+    for reserved, final in zip(reserved_urls, final_urls):
+        # Extract port from URLs and verify they match
+        reserved_port = reserved.split(":")[-1].split("/")[0]
+        final_port = final.split(":")[-1].split("/")[0]
+        assert reserved_port == final_port, (
+            f"Port mismatch: reserved {reserved_port} != final {final_port}. "
+            f"Reserved URL: {reserved}, Final URL: {final}"
+        )
+
+    # device_uuids should be populated now
+    assert vllm_generation.device_uuids is not None, (
+        "device_uuids should be populated after load_and_start()"
+    )
+
+    # HTTP server should be functional
+    _wait_for_vllm_http_server_spinup(final_urls[0])
+
+    body = dict(
+        model=generation_config["model_name"],
+        messages=[
+            {"role": "user", "content": "count to 5"},
+        ],
+        temperature=generation_config["temperature"],
+        top_p=generation_config["top_p"],
+        logprobs=True,
+        return_tokens_as_token_ids=True,
+        max_tokens=1,
+    )
+    response = requests.post(url=f"{final_urls[0]}/chat/completions", json=body)
+    assert response.status_code == 200, (
+        f"HTTP server returned {response.status_code} after load_and_start()"
+    )
+    result = response.json()
+    assert "choices" in result, "Response should contain choices"
+    assert len(result["choices"]) > 0, "Response should have at least one choice"
+
+    # Clean up
+    vllm_generation.shutdown()
+
+
 def test_VllmAsyncGenerationWorker_replace_prefix_tokens(tokenizer):
     # This test assumes the tokenizer model is for the Qwen 3 family
     eos_token_id = tokenizer.eos_token_id


### PR DESCRIPTION
Port the deferred-load mechanism from the super/ultra-v3 lineage (eb401ba4), adapted to main's refactored vLLM workers:

- VllmGeneration: defer_model_load flag; when set, workers only reserve ports and dp_openai_server_base_urls is populated immediately via _collect_reserved_urls(); load_and_start() performs the heavy load later.
- BaseVllmGenerationWorker: split __init__ into _init_config()/_apply_vllm_patches() /_load_model(); patches now applied for all workers (incl. non-owners).
- VllmAsyncGenerationWorker: reserve a listening socket in __init__ and hand it to uvicorn via server.serve(sockets=) (no close/rebind race); load_model() and get_reserved_url() added.
- Add test_vllm_deferred_model_load.

Enables overlapping vLLM model loading with NeMo Gym spinup. Split out from the NeMo Gym integration work so the vLLM mechanism can land and be tested independently. Original PR combining the two https://github.com/NVIDIA-NeMo/RL/pull/2741

# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
