### PR TITLE
feat: Enable NeMo Gym rollouts for distillation

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,19 @@ uv run python examples/run_distillation.py \
   cluster.gpus_per_node=8
 ```
 
+### On-policy Distillation with NeMo Gym
+
+On-policy distillation can use NeMo Gym for multi-step or multi-turn rollout collection. Use the NeMo Gym distillation entrypoint with the example config. The checked-in config uses placeholder dataset paths, so override them for your local data:
+
+```sh
+uv run python examples/nemo_gym/run_distillation_nemo_gym.py \
+  --config examples/nemo_gym/distillation_qwen3_0_6b.yaml \
+  data.train.data_path=/path/to/train.jsonl \
+  data.validation.data_path=/path/to/validation.jsonl
+```
+
+NeMo Gym controls the rollout turn count from its environment and agent configuration. The standard distillation `distillation.max_rollout_turns` setting is not used by the NeMo Gym rollout path.
+
 ### On-policy Distillation Multi-node
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -395,19 +395,6 @@ uv run python examples/run_distillation.py \
   cluster.gpus_per_node=8
 ```
 
-### On-policy Distillation with NeMo Gym
-
-On-policy distillation can use NeMo Gym for multi-step or multi-turn rollout collection. Use the NeMo Gym distillation entrypoint with the example config. The checked-in config uses placeholder dataset paths, so override them for your local data:
-
-```sh
-uv run python examples/nemo_gym/run_distillation_nemo_gym.py \
-  --config examples/nemo_gym/distillation_qwen3_0_6b.yaml \
-  data.train.data_path=/path/to/train.jsonl \
-  data.validation.data_path=/path/to/validation.jsonl
-```
-
-NeMo Gym controls the rollout turn count from its environment and agent configuration. The standard distillation `distillation.max_rollout_turns` setting is not used by the NeMo Gym rollout path.
-
 ### On-policy Distillation Multi-node
 
 ```sh

--- a/docs/about/algorithms/on-policy-distillation.md
+++ b/docs/about/algorithms/on-policy-distillation.md
@@ -22,6 +22,35 @@ uv run python examples/run_distillation.py \
   cluster.gpus_per_node=8
 ```
 
+### On-policy Distillation with NeMo Gym
+
+On-policy distillation can use NeMo Gym for multi-step or multi-turn rollout collection. In this mode, NeMo RL exposes the student vLLM generation worker as an OpenAI-compatible HTTP server, NeMo Gym runs the environment interaction, and the resulting student samples are used for teacher-logit distillation.
+
+Use the NeMo Gym distillation entrypoint with the example config. The checked-in config uses placeholder dataset paths, so override them for your local data:
+
+```sh
+uv run python examples/nemo_gym/run_distillation_nemo_gym.py \
+  --config examples/nemo_gym/distillation_qwen3_0_6b.yaml \
+  data.train.data_path=/path/to/train.jsonl \
+  data.validation.data_path=/path/to/validation.jsonl
+```
+
+The config must enable the vLLM async HTTP server and NeMo Gym:
+
+```yaml
+policy:
+  generation:
+    backend: vllm
+    vllm_cfg:
+      async_engine: true
+      expose_http_server: true
+
+env:
+  should_use_nemo_gym: true
+```
+
+NeMo Gym controls the rollout turn count from its environment and agent configuration. The standard distillation `distillation.max_rollout_turns` setting is not used by the NeMo Gym rollout path.
+
 ## On-policy Distillation Multi-node
 
 ```sh

--- a/docs/design-docs/nemo-gym-integration.md
+++ b/docs/design-docs/nemo-gym-integration.md
@@ -1,6 +1,6 @@
 # NeMo Gym Integration
 
-This document describes how NeMo RL integrates with [NeMo Gym](https://docs.nvidia.com/nemo/gym/v0.2.1/index.html) for multi-step and multi-turn reinforcement learning training.
+This document describes how NeMo RL integrates with [NeMo Gym](https://docs.nvidia.com/nemo/gym/v0.2.1/index.html) for multi-step and multi-turn rollout collection. NeMo Gym rollouts are supported by GRPO and on-policy distillation.
 
 ## Overview
 
@@ -9,6 +9,10 @@ NeMo Gym provides HTTP-based training environments for LLMs. **NeMo Gym is CPU-o
 - **Decoupled architecture**: Environments don't need direct access to model internals
 - **Multi-step/multi-turn support**: Agents can orchestrate complex interactions with tools
 - **Refit compatibility**: NeMo RL's weight synchronization works transparently
+
+The same NeMo Gym rollout path is used by GRPO and on-policy distillation when `env.should_use_nemo_gym` is enabled. Distillation uses the generated NeMo Gym conversations as the student on-policy samples before computing teacher logits and the distillation loss.
+
+For on-policy distillation, NeMo Gym controls the rollout turn count from its environment and agent configuration. The standard distillation `distillation.max_rollout_turns` setting is not used by the NeMo Gym rollout path.
 
 ## Configuration
 
@@ -31,7 +35,7 @@ env:
       - responses_api_agents/simple_agent/configs/simple_agent.yaml
 ```
 
-For a complete example, see `examples/nemo_gym/` and its associated configs.
+For complete examples, see `examples/nemo_gym/run_grpo_nemo_gym.py`, `examples/nemo_gym/run_distillation_nemo_gym.py`, and their associated configs under `examples/nemo_gym/`.
 
 ### Version Requirements
 
@@ -43,7 +47,7 @@ NeMo Gym runs as a Ray actor within NeMo RL's Ray cluster, so the same Ray and P
 %%{init: {'theme': 'default', 'themeVariables': { 'lineColor': '#5c6bc0', 'primaryTextColor': '#333'}}}%%
 flowchart LR
     subgraph RL["NeMo RL"]
-        GRPO["GRPO Loop"]
+        Loop["Training Loop<br/>(GRPO or Distillation)"]
         vLLM["vLLM + HTTP"]
         Bridge["NemoGym Actor"]
     end
@@ -54,8 +58,8 @@ flowchart LR
         Resources["Resources"]
     end
     
-    GRPO -->|refit| vLLM
-    GRPO -->|run_rollouts| Bridge
+    Loop -->|refit| vLLM
+    Loop -->|run_rollouts| Bridge
     Bridge -->|spawns| Gym
     Agent <--> Model
     Agent <--> Resources
@@ -83,7 +87,7 @@ The integration is handled by the `NemoGym` Ray actor at `nemo_rl/environments/n
 %%{init: {'theme': 'default', 'themeVariables': { 'lineColor': '#5c6bc0', 'primaryTextColor': '#333'}}}%%
 flowchart LR
     subgraph RL["NeMo RL"]
-        GRPO["GRPO Loop"]
+        Loop["Training Loop<br/>(GRPO or Distillation)"]
         Actor["NemoGym Actor"]
     end
     
@@ -92,18 +96,18 @@ flowchart LR
         Agent["Agent Server"]
     end
     
-    GRPO --> Actor
+    Loop --> Actor
     Actor --> Agent
     Agent --> RCH
     RCH --> Actor
-    Actor --> GRPO
+    Actor --> Loop
 
     style RL fill:#e3f2fd,stroke:#1565c0,stroke-width:2px
     style Gym fill:#fff3e0,stroke:#ef6c00,stroke-width:2px
 ```
 
 The flow is:
-1. GRPO Loop calls `run_rollouts.remote(batch)` on the NemoGym Actor
+1. The GRPO or distillation loop calls `run_rollouts.remote(batch)` on the NemoGym Actor
 2. Actor sends `POST /run` to the Agent Server
 3. Agent Server orchestrates the rollout via RolloutCollectionHelper
 4. Results return to the Actor
@@ -155,7 +159,7 @@ sequenceDiagram
 sequenceDiagram
     autonumber
     box rgb(227, 242, 253) NeMo RL
-        participant GRPO as GRPO Loop
+        participant Loop as Training Loop
         participant Policy as Policy Workers
         participant vLLM as vLLM HTTP
         participant Bridge as NemoGym Actor
@@ -166,9 +170,9 @@ sequenceDiagram
         participant Resource as Resource Server
     end
     
-    GRPO->>Policy: Refit (trigger weight sync)
+    Loop->>Policy: Refit (trigger weight sync)
     Policy->>vLLM: Sync weights to vLLM
-    GRPO->>Bridge: run_rollouts.remote(batch)
+    Loop->>Bridge: run_rollouts.remote(batch)
     Bridge->>Agent: POST /run
     Agent->>Model: POST /v1/responses
     Model->>vLLM: POST /v1/chat/completions
@@ -177,8 +181,8 @@ sequenceDiagram
     Agent->>Resource: Execute tool / compute reward
     Resource-->>Agent: Tool result / reward
     Agent-->>Bridge: Results + rewards
-    Bridge-->>GRPO: Token IDs, logprobs, rewards
-    GRPO->>Policy: Compute loss and train
+    Bridge-->>Loop: Token IDs, logprobs, rewards
+    Loop->>Policy: Compute loss and train
 ```
 
 > **NeMo Gym server types** (see [Core Components](https://docs.nvidia.com/nemo/gym/v0.2.1/about/concepts/core-components/)):
@@ -191,7 +195,7 @@ sequenceDiagram
 | Step | Location | Description |
 |------|----------|-------------|
 | **Refit** | NeMo RL | Synchronizes policy weights to vLLM workers. For async RL, refit timing may differ—see {doc}`generation` for details. |
-| **run_rollouts.remote()** | NeMo RL | Ray remote call from GRPO loop to the NemoGym actor |
+| **run_rollouts.remote()** | NeMo RL | Ray remote call from the training loop to the NemoGym actor |
 | **POST /run** | NeMo RL → NeMo Gym | HTTP request from NemoGym actor to Agent Server subprocess |
 | **Rollout orchestration** | NeMo Gym | Agent calls Model Server and Resources Server via HTTP |
 | **POST /v1/chat/completions** | NeMo Gym → NeMo RL | Model Server proxies to NeMo RL's vLLM HTTP endpoint |

--- a/examples/nemo_gym/distillation_qwen3_0_6b.yaml
+++ b/examples/nemo_gym/distillation_qwen3_0_6b.yaml
@@ -1,0 +1,123 @@
+defaults: "../configs/distillation_math.yaml"
+
+distillation:
+  num_prompts_per_step: 2
+  num_generations_per_prompt: 1
+  max_num_steps: 1
+  max_num_epochs: 1
+  val_batch_size: 2
+  val_period: 1
+  max_val_samples: null
+  topk_logits_k: 16
+
+loss_fn:
+  kl_type: reverse
+
+policy:
+  model_name: Qwen/Qwen3-0.6B
+  tokenizer:
+    name: ${..model_name}
+  train_global_batch_size: 2
+  train_micro_batch_size: 1
+  generation_batch_size: 2
+  logprob_batch_size: 1
+  max_total_sequence_length: 4096
+  make_sequence_length_divisible_by: 1
+  dtensor_cfg:
+    enabled: true
+    _v2: false
+    tensor_parallel_size: 1
+    context_parallel_size: 1
+  megatron_cfg:
+    enabled: false
+    tensor_model_parallel_size: 1
+    pipeline_model_parallel_size: 1
+    context_parallel_size: 1
+  dynamic_batching:
+    enabled: false
+  generation:
+    max_new_tokens: 128
+    temperature: 1.0
+    top_p: 1.0
+    top_k: null
+    vllm_cfg:
+      async_engine: true
+      expose_http_server: true
+      tensor_parallel_size: 1
+      pipeline_parallel_size: 1
+      gpu_memory_utilization: 0.6
+      max_model_len: ${...max_total_sequence_length}
+    colocated:
+      enabled: true
+      resources:
+        gpus_per_node: null
+        num_nodes: null
+
+teacher:
+  model_name: Qwen/Qwen3-0.6B
+  train_global_batch_size: 2
+  logprob_batch_size: 1
+  max_total_sequence_length: 4096
+  make_sequence_length_divisible_by: 1
+  dtensor_cfg:
+    enabled: true
+    _v2: false
+    tensor_parallel_size: 1
+    context_parallel_size: 1
+  megatron_cfg:
+    enabled: false
+    tensor_model_parallel_size: 1
+    pipeline_model_parallel_size: 1
+    context_parallel_size: 1
+  dynamic_batching:
+    enabled: false
+
+data:
+  max_input_seq_length: null
+  shuffle: false
+  num_workers: 1
+  train:
+    dataset_name: NemoGymDataset
+    data_path: /path/to/train.jsonl
+  validation:
+    dataset_name: NemoGymDataset
+    data_path: /path/to/validation.jsonl
+    repeat: 1
+  default:
+    dataset_name: NemoGymDataset
+    env_name: nemo_gym
+    prompt_file: null
+    system_prompt_file: null
+    processor: nemo_gym_data_processor
+
+env:
+  should_use_nemo_gym: true
+  should_log_nemo_gym_responses: false
+  nemo_gym:
+    port_range_low: 15001
+    port_range_high: 20000
+    config_paths:
+      - responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
+      - resources_servers/example_multi_step/configs/example_multi_step.yaml
+    policy_model:
+      responses_api_models:
+        vllm_model:
+          uses_reasoning_parser: false
+          extra_body:
+            chat_template_kwargs:
+              enable_thinking: false
+
+logger:
+  log_dir: logs/distillation-qwen3-0.6b-nemo-gym
+  wandb_enabled: false
+  tensorboard_enabled: true
+  monitor_gpus: true
+
+checkpointing:
+  enabled: false
+  checkpoint_dir: checkpoints/distillation-qwen3-0.6b-nemo-gym
+  save_period: 1
+
+cluster:
+  gpus_per_node: 1
+  num_nodes: 1

--- a/examples/nemo_gym/distillation_qwen3_0_6b.yaml
+++ b/examples/nemo_gym/distillation_qwen3_0_6b.yaml
@@ -25,7 +25,7 @@ policy:
   make_sequence_length_divisible_by: 1
   dtensor_cfg:
     enabled: true
-    _v2: false
+    _v2: true
     tensor_parallel_size: 1
     context_parallel_size: 1
   megatron_cfg:
@@ -54,14 +54,14 @@ policy:
         num_nodes: null
 
 teacher:
-  model_name: Qwen/Qwen3-0.6B
+  model_name: Qwen/Qwen3-1.7B
   train_global_batch_size: 2
   logprob_batch_size: 1
   max_total_sequence_length: 4096
   make_sequence_length_divisible_by: 1
   dtensor_cfg:
     enabled: true
-    _v2: false
+    _v2: true
     tensor_parallel_size: 1
     context_parallel_size: 1
   megatron_cfg:

--- a/examples/nemo_gym/run_distillation_nemo_gym.py
+++ b/examples/nemo_gym/run_distillation_nemo_gym.py
@@ -1,0 +1,201 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import pprint
+
+# Increase the W&B single object size warning threshold. Initially 100_000 (100 KB) -> 10_000_000 (10 MB)
+import wandb.util
+
+wandb.util.VALUE_BYTES_LIMIT = 10_000_000
+
+import ray
+from omegaconf import OmegaConf
+
+from nemo_rl.algorithms.distillation import (
+    MasterConfig,
+    distillation_train,
+    setup,
+)
+from nemo_rl.algorithms.grpo import _should_use_nemo_gym
+from nemo_rl.algorithms.utils import get_tokenizer
+from nemo_rl.data.utils import setup_response_data
+from nemo_rl.distributed.virtual_cluster import init_ray
+from nemo_rl.environments.nemo_gym import (
+    NemoGymConfig,
+    setup_nemo_gym_config,
+)
+from nemo_rl.environments.utils import create_env
+from nemo_rl.models.generation import configure_generation_config
+from nemo_rl.utils.config import (
+    load_config,
+    parse_hydra_overrides,
+    register_omegaconf_resolvers,
+)
+from nemo_rl.utils.logger import get_next_experiment_dir
+
+
+def parse_args() -> tuple[argparse.Namespace, list[str]]:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Run distillation training with configuration"
+    )
+    parser.add_argument(
+        "--config", type=str, default=None, help="Path to YAML config file"
+    )
+
+    # Parse known args for the script
+    args, overrides = parser.parse_known_args()
+
+    return args, overrides
+
+
+def main() -> None:
+    """Main entry point."""
+    register_omegaconf_resolvers()
+    args, overrides = parse_args()
+
+    if not args.config:
+        args.config = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "configs",
+            "distillation_math.yaml",
+        )
+
+    config = load_config(args.config)
+    print(f"Loaded configuration from: {args.config}")
+
+    if overrides:
+        print(f"Overrides: {overrides}")
+        config = parse_hydra_overrides(config, overrides)
+
+    config = OmegaConf.to_container(config, resolve=True)
+    config = MasterConfig(**config)
+    print("Applied CLI overrides")
+
+    # Get the next experiment directory with incremented ID
+    config.logger["log_dir"] = get_next_experiment_dir(config.logger["log_dir"])
+    print(f"📊 Using log directory: {config.logger['log_dir']}")
+    if config.checkpointing["enabled"]:
+        print(
+            f"📊 Using checkpoint directory: {config.checkpointing['checkpoint_dir']}"
+        )
+
+    # setup tokenizer
+    tokenizer = get_tokenizer(config.policy["tokenizer"])
+
+    if config.policy["generation"] is not None:
+        config.policy["generation"] = configure_generation_config(
+            config.policy["generation"], tokenizer
+        )
+    else:
+        raise ValueError(
+            "A vLLM generation config is required for NeMo-Gym distillation"
+        )
+
+    # NeMo-Gym specific config setup.
+    setup_nemo_gym_config(config, tokenizer)
+
+    # We assert here since this is right after the final config has been materialized.
+    assert _should_use_nemo_gym(config)
+
+    # NeMo-Gym environment needs to get dp_openai_server_base_urls from
+    # student_generation, so we don't setup env here.
+    print("\n▶ Setting up data...")
+    train_dataset, val_dataset = setup_response_data(
+        tokenizer, config.data, env_configs=None
+    )
+
+    # Validation dataset config setup. Same Gym principle as run_grpo_nemo_gym.py:
+    # max_val_samples is derived from len(val_dataset); user-set values are rejected.
+    if config.distillation["max_val_samples"] is not None:
+        raise ValueError(
+            """A non-null `distillation.max_val_samples` parameter is not supported.
+
+Gym principle is that there is no hidden data pre or post processing from you. What you see is what you get.
+
+The validation set you pass in will directly be used for validation with no additional preprocessing. If you want to have some number of repetitions, please include that in your dataset, via ``num_repeats``, in your dataset config and `ng_prepare_data` will prepare it accordingly."""
+        )
+
+    if val_dataset is not None:
+        print(
+            f"Setting `distillation.max_val_samples` and `distillation.val_batch_size` to the length of the validation dataset, which is {len(val_dataset)}"
+        )
+        config.distillation["max_val_samples"] = len(val_dataset)
+        config.distillation["val_batch_size"] = config.distillation["max_val_samples"]
+
+    # Print config
+    print("Final config:")
+    pprint.pprint(config)
+
+    init_ray()
+
+    (
+        student_policy,
+        teacher_policy,
+        student_generation,
+        dataloader,
+        val_dataloader,
+        loss_fn,
+        logger,
+        checkpointer,
+        distillation_state,
+        master_config,
+    ) = setup(config, tokenizer, train_dataset, val_dataset)
+
+    if student_generation is None:
+        raise ValueError("NeMo-Gym distillation requires a vLLM generation backend")
+
+    invalid_tool_call_patterns = config.env["nemo_gym"].pop(
+        "invalid_tool_call_patterns", None
+    )
+    thinking_tags = config.env["nemo_gym"].pop("thinking_tags", None)
+    nemo_gym_config = NemoGymConfig(
+        model_name=student_generation.cfg["model_name"],
+        base_urls=student_generation.dp_openai_server_base_urls,
+        invalid_tool_call_patterns=invalid_tool_call_patterns,
+        thinking_tags=thinking_tags,
+        initial_global_config_dict=config.env["nemo_gym"],
+    )
+    nemo_gym = create_env(env_name="nemo_gym", env_config=nemo_gym_config)
+    # Blocking wait for NeMo-Gym to spin up
+    ray.get(nemo_gym.health_check.remote())
+
+    # Bind task_to_env and val_task_to_env for nemo_gym env
+    # Hardcode here to match `run_async_nemo_gym_rollout`
+    task_to_env = {"nemo_gym": nemo_gym}
+    val_task_to_env = task_to_env
+
+    print("🚀 Running distillation training")
+    distillation_train(
+        student_policy,
+        teacher_policy,
+        student_generation,
+        dataloader,
+        val_dataloader,
+        tokenizer,
+        loss_fn,
+        task_to_env,
+        val_task_to_env,
+        logger,
+        checkpointer,
+        distillation_state,
+        master_config,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -23,7 +23,13 @@ from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import AutoConfig, AutoTokenizer
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
-from nemo_rl.algorithms.grpo import _should_use_async_rollouts, refit_policy_generation
+from nemo_rl.algorithms.grpo import (
+    _should_log_nemo_gym_responses,
+    _should_use_async_rollouts,
+    _should_use_nemo_gym,
+    aggregate_rollout_metrics,
+    refit_policy_generation,
+)
 from nemo_rl.algorithms.loss import (
     DistillationLossConfig,
     DistillationLossDataDict,
@@ -47,6 +53,7 @@ from nemo_rl.distributed.virtual_cluster import (
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.experience.rollouts import (
     run_async_multi_turn_rollout,
+    run_async_nemo_gym_rollout,
     run_multi_turn_rollout,
 )
 from nemo_rl.models.generation.interfaces import (
@@ -84,7 +91,7 @@ class DistillationConfig(TypedDict):
     # Whether to run validation on the last training step. Setting this to True ensures the
     # final checkpoint has validation metrics, which is required for get_best_checkpoint_path().
     val_at_end: bool
-    max_val_samples: int
+    max_val_samples: int | None  # None for NeMo-Gym compatibility
     topk_logits_k: int
     seed: int
 
@@ -536,7 +543,10 @@ def distillation_train(
         student_generation = student_policy  # type: ignore
         NEED_REFIT = False
     POLICY_GENERATION_STALE = True  # tracks if generation needs a refit before running
-    assert student_generation is not None
+    assert student_generation is not None  # for mypy type check
+    use_nemo_gym = _should_use_nemo_gym(master_config)
+    if use_nemo_gym:
+        print("▶ Using NeMo-Gym rollouts for distillation", flush=True)
 
     # common config/state items
     current_epoch = distillation_save_state["current_epoch"]  # current epoch
@@ -629,8 +639,31 @@ def distillation_train(
                         student_generation.prepare_for_generation()
 
                 with timer.time("generation"):
+                    # We cascade NeMo-Gym first since NeMo-Gym requires async rollouts.
+                    if use_nemo_gym:
+                        generation_config = master_config.policy["generation"]
+                        nemo_gym_rollout_result = run_async_nemo_gym_rollout(
+                            policy_generation=student_generation,
+                            input_batch=repeated_batch,
+                            tokenizer=tokenizer,
+                            task_to_env=task_to_env,
+                            max_seq_len=None,
+                            generation_config=generation_config,
+                            max_rollout_turns=None,
+                            greedy=False,
+                        )
+                        repeated_batch = nemo_gym_rollout_result.final_batch
+                        rollout_metrics = nemo_gym_rollout_result.rollout_metrics
+                        del nemo_gym_rollout_result
+
+                        # NeMo Gym responses can be very large and expensive to log.
+                        # Here we have logic to opt-in to logging.
+                        if not _should_log_nemo_gym_responses(master_config):
+                            for key in list(rollout_metrics):
+                                if "full_result" in key:
+                                    rollout_metrics.pop(key)
                     # Use async rollouts if vLLM async engine is enabled
-                    if _should_use_async_rollouts(master_config):
+                    elif _should_use_async_rollouts(master_config):
                         (
                             repeated_batch,
                             rollout_metrics,
@@ -973,6 +1006,8 @@ def validate(
         )
         return {}, {}
 
+    use_nemo_gym = _should_use_nemo_gym(master_config)
+
     timer = Timer()
     with timer.time("total_validation_time"):
         print(f"▶ Starting validation at step {step}...", flush=True)
@@ -986,13 +1021,35 @@ def validate(
             + master_config.distillation["val_batch_size"]
             - 1
         ) // master_config.distillation["val_batch_size"]
+        validation_rollout_metrics: dict[str, list[Any]] = {}
         for batch_idx, val_batch in enumerate(val_dataloader):
             if batch_idx >= max_batches:
                 break
 
             # Generate responses (updates the LLMMessageLogType in batch_with_msg_logs)
+            # We cascade NeMo-Gym first since NeMo-Gym requires async rollouts.
+            if use_nemo_gym:
+                generation_config = master_config.policy["generation"]
+                nemo_gym_rollout_result = run_async_nemo_gym_rollout(
+                    policy_generation=policy_generation,
+                    input_batch=val_batch,
+                    tokenizer=tokenizer,
+                    task_to_env=val_task_to_env,
+                    max_seq_len=None,
+                    generation_config=generation_config,
+                    max_rollout_turns=None,
+                    greedy=False,
+                )
+                val_batch = nemo_gym_rollout_result.final_batch
+                gen_metrics = nemo_gym_rollout_result.rollout_metrics
+                if not _should_log_nemo_gym_responses(master_config):
+                    for key in list(gen_metrics):
+                        if "full_result" in key:
+                            gen_metrics.pop(key)
+                for key, value in gen_metrics.items():
+                    validation_rollout_metrics.setdefault(key, []).append(value)
             # Use async rollouts if vLLM async engine is enabled
-            if _should_use_async_rollouts(master_config):
+            elif _should_use_async_rollouts(master_config):
                 val_batch, gen_metrics = run_async_multi_turn_rollout(
                     policy_generation,
                     val_batch,
@@ -1038,6 +1095,7 @@ def validate(
         val_metrics = {
             "accuracy": accuracy,
             "avg_length": avg_length,
+            **aggregate_rollout_metrics(validation_rollout_metrics),
         }
 
         # Print sample conversations only once at the end of validation

--- a/tests/functional/L1_Functional_Tests_Gym.sh
+++ b/tests/functional/L1_Functional_Tests_Gym.sh
@@ -35,6 +35,7 @@ run_test() {
 }
 
 run_test fast uv run --no-sync bash ./tests/functional/grpo_async_gym.sh
+run_test      uv run --no-sync bash ./tests/functional/distillation_nemo_gym.sh
 
 cd ${PROJECT_ROOT}/tests
 if compgen -G ".coverage*" > /dev/null; then

--- a/tests/functional/distillation_nemo_gym.sh
+++ b/tests/functional/distillation_nemo_gym.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+PROJECT_ROOT=$(realpath $SCRIPT_DIR/../..)
+# Mark the current repo as safe, since wandb fetches metadata about the repo
+git config --global --add safe.directory $PROJECT_ROOT
+
+set -eou pipefail
+
+EXP_NAME=$(basename $0 .sh)
+EXP_DIR=$SCRIPT_DIR/$EXP_NAME
+LOG_DIR=$EXP_DIR/logs
+JSON_METRICS=$EXP_DIR/metrics.json
+RUN_LOG=$EXP_DIR/run.log
+CHECKPOINT_DIR=$EXP_DIR/checkpoints
+DATA_DIR=$EXP_DIR/data
+export PYTHONPATH=${PROJECT_ROOT}:${PYTHONPATH:-}
+
+rm -rf $EXP_DIR $LOG_DIR
+mkdir -p $EXP_DIR $LOG_DIR $CHECKPOINT_DIR $DATA_DIR
+
+# clean up checkpoint directory on exit
+trap "rm -rf $CHECKPOINT_DIR" EXIT
+
+cd $PROJECT_ROOT
+
+# Reuse the checked-in NeMo-Gym sanity fixture so this functional test does not
+# depend on external dataset download. The fixture rows use
+# `example_multi_step_simple_agent`, which is provided by Gym's
+# resources_servers/example_multi_step config.
+TRAIN_PATH=$DATA_DIR/example_multi_step_train.jsonl
+VALIDATION_PATH=$DATA_DIR/example_multi_step_validation.jsonl
+python - <<'PY' "$PROJECT_ROOT/tests/unit/environments/nemo_gym_test_data/test_nemo_gym_sanity.json" "$TRAIN_PATH" "$VALIDATION_PATH"
+import json
+import sys
+
+fixture_path, train_path, validation_path = sys.argv[1:]
+with open(fixture_path) as f:
+    rows = json.load(f)["input"]
+
+for output_path in (train_path, validation_path):
+    with open(output_path, "w") as f:
+        for row in rows:
+            f.write(json.dumps(row, separators=(",", ":")) + "\n")
+PY
+
+uv run coverage run -a --data-file=$PROJECT_ROOT/tests/.coverage --source=$PROJECT_ROOT/nemo_rl \
+    $PROJECT_ROOT/examples/nemo_gym/run_distillation_nemo_gym.py \
+    --config $PROJECT_ROOT/examples/nemo_gym/distillation_qwen3_0_6b.yaml \
+    logger.log_dir=$LOG_DIR \
+    logger.wandb_enabled=false \
+    checkpointing.enabled=false \
+    checkpointing.checkpoint_dir=$CHECKPOINT_DIR \
+    data.train.data_path=$TRAIN_PATH \
+    data.validation.data_path=$VALIDATION_PATH \
+    $@ \
+    2>&1 | tee $RUN_LOG
+
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+
+uv run tests/check_metrics.py $JSON_METRICS \
+    'data["train/loss"]["1"] < 0.5' \
+    'data["timing/train/generation"]["1"] > 0' \
+    'data["train/mean_gen_tokens_per_sample"]["1"] > 0'

--- a/tests/functional/distillation_nemo_gym.sh
+++ b/tests/functional/distillation_nemo_gym.sh
@@ -27,7 +27,9 @@ cd $PROJECT_ROOT
 # Reuse the checked-in NeMo-Gym sanity fixture so this functional test does not
 # depend on external dataset download. The fixture rows use
 # `example_multi_step_simple_agent`, which is provided by Gym's
-# resources_servers/example_multi_step config.
+# resources_servers/example_multi_step config. The model overrides use the same
+# small non-identical Qwen3 pair as other distillation functional tests so this
+# stays cheap while still catching a degenerate zero-KL path.
 TRAIN_PATH=$DATA_DIR/example_multi_step_train.jsonl
 VALIDATION_PATH=$DATA_DIR/example_multi_step_validation.jsonl
 python - <<'PY' "$PROJECT_ROOT/tests/unit/environments/nemo_gym_test_data/test_nemo_gym_sanity.json" "$TRAIN_PATH" "$VALIDATION_PATH"
@@ -47,10 +49,19 @@ PY
 uv run coverage run -a --data-file=$PROJECT_ROOT/tests/.coverage --source=$PROJECT_ROOT/nemo_rl \
     $PROJECT_ROOT/examples/nemo_gym/run_distillation_nemo_gym.py \
     --config $PROJECT_ROOT/examples/nemo_gym/distillation_qwen3_0_6b.yaml \
+    policy.model_name=Qwen/Qwen3-0.6B-Base \
+    policy.tokenizer.name=Qwen/Qwen3-0.6B-Base \
+    teacher.model_name=Qwen/Qwen3-0.6B \
     logger.log_dir=$LOG_DIR \
     logger.wandb_enabled=false \
     checkpointing.enabled=false \
     checkpointing.checkpoint_dir=$CHECKPOINT_DIR \
+    cluster.gpus_per_node=2 \
+    policy.dtensor_cfg.tensor_parallel_size=1 \
+    policy.dtensor_cfg.context_parallel_size=2 \
+    policy.make_sequence_length_divisible_by=2 \
+    teacher.dtensor_cfg.tensor_parallel_size=2 \
+    teacher.dtensor_cfg.context_parallel_size=1 \
     data.train.data_path=$TRAIN_PATH \
     data.validation.data_path=$VALIDATION_PATH \
     $@ \
@@ -59,6 +70,7 @@ uv run coverage run -a --data-file=$PROJECT_ROOT/tests/.coverage --source=$PROJE
 uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
 
 uv run tests/check_metrics.py $JSON_METRICS \
-    'data["train/loss"]["1"] < 0.5' \
+    'data["train/loss"]["1"] > 0' \
+    'data["train/loss"]["1"] < 2.0' \
     'data["timing/train/generation"]["1"] > 0' \
     'data["train/mean_gen_tokens_per_sample"]["1"] > 0'

--- a/tests/unit/algorithms/test_distillation.py
+++ b/tests/unit/algorithms/test_distillation.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -162,6 +163,11 @@ def mock_components():
             "data": {
                 "dataset_name": "test_dataset",
             },
+            "env": {
+                "math": {
+                    "num_workers": 1,
+                },
+            },
             "logger": {
                 "num_val_samples_to_print": 5,
             },
@@ -218,6 +224,61 @@ def test_distillation_train_max_steps(mock_components):
     )
 
     assert mock_components["student_policy"].train.call_count == 5
+
+
+def test_distillation_train_uses_nemo_gym_rollout_when_enabled(mock_components):
+    master_config = mock_components["master_config"]
+    master_config.distillation["max_num_steps"] = 1
+    master_config.distillation["max_num_epochs"] = 1
+    master_config.distillation["val_period"] = 0
+    master_config.env["should_use_nemo_gym"] = True
+    master_config.policy["generation"]["backend"] = "vllm"
+    master_config.policy["generation"]["vllm_cfg"] = {
+        "async_engine": True,
+        "expose_http_server": True,
+    }
+
+    mock_rollout_result = SimpleNamespace(
+        final_batch=next(iter(mock_components["train_dataloader"])),
+        rollout_metrics={"mean_gen_tokens_per_sample": 3.0},
+    )
+
+    with (
+        patch(
+            "nemo_rl.algorithms.distillation.run_async_nemo_gym_rollout",
+            return_value=mock_rollout_result,
+        ) as mock_nemo_gym_rollout,
+        patch(
+            "nemo_rl.algorithms.distillation.run_async_multi_turn_rollout"
+        ) as mock_async_rollout,
+        patch("nemo_rl.algorithms.distillation.run_multi_turn_rollout") as mock_rollout,
+    ):
+        distillation_train(
+            mock_components["student_policy"],
+            mock_components["teacher_policy"],
+            mock_components["student_generation"],
+            mock_components["train_dataloader"],
+            mock_components["val_dataloader"],
+            mock_components["tokenizer"],
+            mock_components["loss_fn"],
+            mock_components["task_to_env"],
+            mock_components["val_task_to_env"],
+            mock_components["logger"],
+            mock_components["checkpointer"],
+            _default_distillation_save_state(),
+            master_config,
+        )
+
+    mock_nemo_gym_rollout.assert_called_once()
+    mock_async_rollout.assert_not_called()
+    mock_rollout.assert_not_called()
+    train_metric_calls = [
+        call
+        for call in mock_components["logger"].log_metrics.call_args_list
+        if call.kwargs.get("prefix") == "train"
+    ]
+    assert train_metric_calls
+    assert train_metric_calls[-1].args[0]["mean_gen_tokens_per_sample"] == 3.0
 
 
 def test_exit_on_timeout(mock_components, capsys):

--- a/tests/unit/algorithms/test_distillation.py
+++ b/tests/unit/algorithms/test_distillation.py
@@ -358,6 +358,83 @@ def test_validate_function(mock_components):
     # Note: validate() function itself doesn't call logger.log_metrics - that's done by the caller
 
 
+def test_validate_uses_nemo_gym_rollout_when_enabled(mock_components):
+    master_config = mock_components["master_config"]
+    master_config.distillation["max_val_samples"] = 1
+    master_config.distillation["val_batch_size"] = 1
+    master_config.env["should_use_nemo_gym"] = True
+    master_config.env["should_log_nemo_gym_responses"] = False
+    master_config.policy["generation"]["backend"] = "vllm"
+    master_config.policy["generation"]["vllm_cfg"] = {
+        "async_engine": True,
+        "expose_http_server": True,
+    }
+
+    final_batch = BatchedDataDict[DatumSpec](
+        {
+            "message_log": [
+                [
+                    {
+                        "token_ids": torch.tensor([1, 2]),
+                        "role": "user",
+                        "content": "What is 1+1?",
+                    },
+                    {
+                        "token_ids": torch.tensor([3, 4]),
+                        "role": "assistant",
+                        "content": "2",
+                    },
+                ]
+            ],
+            "total_reward": torch.tensor([1.0]),
+        }
+    )
+    mock_rollout_result = SimpleNamespace(
+        final_batch=final_batch,
+        rollout_metrics={
+            "mean_gen_tokens_per_sample": 2.0,
+            "score": 0.5,
+            "full_result_debug": {"large_response": True},
+        },
+    )
+
+    with (
+        patch(
+            "nemo_rl.algorithms.distillation.run_async_nemo_gym_rollout",
+            return_value=mock_rollout_result,
+        ) as mock_nemo_gym_rollout,
+        patch(
+            "nemo_rl.algorithms.distillation.run_async_multi_turn_rollout"
+        ) as mock_async_rollout,
+        patch("nemo_rl.algorithms.distillation.run_multi_turn_rollout") as mock_rollout,
+    ):
+        val_metrics, validation_timings = validate(
+            mock_components["student_generation"],
+            mock_components["val_dataloader"],
+            mock_components["tokenizer"],
+            mock_components["val_task_to_env"],
+            step=0,
+            master_config=master_config,
+        )
+
+    mock_nemo_gym_rollout.assert_called_once()
+    rollout_kwargs = mock_nemo_gym_rollout.call_args.kwargs
+    assert rollout_kwargs["policy_generation"] is mock_components["student_generation"]
+    assert rollout_kwargs["task_to_env"] is mock_components["val_task_to_env"]
+    assert rollout_kwargs["generation_config"] is master_config.policy["generation"]
+    assert rollout_kwargs["max_seq_len"] is None
+    assert rollout_kwargs["max_rollout_turns"] is None
+    assert rollout_kwargs["greedy"] is False
+    mock_async_rollout.assert_not_called()
+    mock_rollout.assert_not_called()
+    assert val_metrics["accuracy"] == 1.0
+    assert val_metrics["avg_length"] == 2.0
+    assert val_metrics["mean_gen_tokens_per_sample"] == 2.0
+    assert val_metrics["score"] == 0.5
+    assert "full_result_debug" not in val_metrics
+    assert isinstance(validation_timings, dict)
+
+
 def test_check_vocab_equality_pass(monkeypatch):
     student_tokenizer = MagicMock()
     student_tokenizer.get_vocab.return_value = {"a": 0, "b": 1}


### PR DESCRIPTION
# What does this PR do ?

Distillation can now reuse the NeMo Gym rollout path that GRPO already uses, while keeping the new runner and smoke coverage scoped to the distillation integration. Mirror GRPO's full NeMo Gym test matrix | distillation only adds orchestration around the shared rollout and environment layers

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
```sh
uv run python examples/nemo_gym/run_distillation_nemo_gym.py \
  --config examples/nemo_gym/distillation_qwen3_0_6b.yaml \
  data.train.data_path=/path/to/train.jsonl \
  data.validation.data_path=/path/to/validation.jsonl
```


# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* This is a dep of PR https://github.com/NVIDIA-NeMo/RL/pull/2442, which adds a nano3 QA-OPD example.
