### PR TITLE
fix: stable mooncake test with backend reuse

### DIFF
--- a/tests/unit/data_plane/test_seqpack_equivalence.py
+++ b/tests/unit/data_plane/test_seqpack_equivalence.py
@@ -91,6 +91,7 @@ def _make_tq_cfg(backend: str) -> dict:
 
 
 @pytest.fixture(
+    scope="module",
     params=["simple", "mooncake_cpu"],
     ids=["simple", "mooncake_cpu"],
 )
@@ -99,6 +100,14 @@ def tq_client(request):
 
     mooncake_cpu is skipped when the mooncake wheel is not installed.
     Set NEMO_RL_REQUIRE_MOONCAKE=1 to promote the skip to a loud failure.
+
+    Module-scoped so the mooncake_master + Transfer Engine survive across
+    the test cases in this file: each test uses its own ``partition_id``
+    ("seqpack-eq" / "dynbatch-eq" / "nopack-eq") so no cross-test data
+    leak is possible, and reusing one client avoids the close→re-init
+    race in mooncake's C++ mount registry (upstream ``transfer_queue``
+    leaks the master process on close; the C++ engine then keeps stale
+    endpoint references that 404 against the next run's fresh master).
 
     Relies on parent autouse ``init_ray_cluster`` for the Ray runtime.
     """

--- a/tests/unit/data_plane/test_tq_lifecycle.py
+++ b/tests/unit/data_plane/test_tq_lifecycle.py
@@ -176,38 +176,37 @@ def test_smoke_round_trip_backends(tq_client_backends) -> None:
     client.clear_samples(sample_ids=None, partition_id="smoke-backend")
 
 
-def test_smoke_round_trip_1d_fields(tq_client) -> None:
+def test_smoke_round_trip_1d_fields(tq_client_backends) -> None:
     """A 1D (N,) tensor put into TQ must come back as (N,), not (N,1).
 
     Regression guard for R-C2: TQ's KVStorageManager path silently unsqueezes
-    1D fields. The adapter's `_promote_1d_leaves` + `_from_wire` pair fix
-    this for the mooncake_cpu backend; this test verifies simple backend does
-    not introduce the regression.
+    1D fields. The adapter's `_promote_1d_leaves` + `_from_wire` pair fixes
+    this for mooncake_cpu; simple passes the tensor through unchanged.
     """
     n = 6
     reward = torch.arange(n, dtype=torch.float32)
 
-    tq_client.register_partition(
+    tq_client_backends.register_partition(
         partition_id="smoke-1d",
         fields=["reward"],
         num_samples=n,
         consumer_tasks=["read"],
     )
     keys = [f"k{i}" for i in range(n)]
-    tq_client.put_samples(
+    tq_client_backends.put_samples(
         sample_ids=keys,
         partition_id="smoke-1d",
         fields=TensorDict({"reward": reward}, batch_size=[n]),
     )
 
-    meta = tq_client.claim_meta(
+    meta = tq_client_backends.claim_meta(
         partition_id="smoke-1d",
         task_name="read",
         required_fields=["reward"],
         batch_size=n,
         timeout_s=30.0,
     )
-    data = tq_client.get_data(meta)
+    data = tq_client_backends.get_data(meta)
 
     assert data["reward"].shape == reward.shape, (
         f"Expected shape {tuple(reward.shape)} for 1D field, "
@@ -215,7 +214,7 @@ def test_smoke_round_trip_1d_fields(tq_client) -> None:
         "TQ must not unsqueeze 1D tensors silently (R-C2)."
     )
 
-    tq_client.clear_samples(sample_ids=None, partition_id="smoke-1d")
+    tq_client_backends.clear_samples(sample_ids=None, partition_id="smoke-1d")
 
 
 # ── Object-field round-trip across backends ───────────────────────────────────

--- a/tests/unit/data_plane/test_tq_lifecycle.py
+++ b/tests/unit/data_plane/test_tq_lifecycle.py
@@ -66,6 +66,7 @@ def tq_client():
 
 
 @pytest.fixture(
+    scope="module",
     params=["simple", "mooncake_cpu"],
     ids=["simple", "mooncake_cpu"],
 )
@@ -74,6 +75,9 @@ def tq_client_backends(request):
 
     mooncake_cpu is skipped when the mooncake wheel is not installed.
     Set NEMO_RL_REQUIRE_MOONCAKE=1 to promote the skip to a loud failure.
+
+    Module-scoped to dodge mooncake's close→re-init race (stale C++ mount
+    registry); safe because each test uses a distinct ``partition_id``.
     """
     backend = request.param
     if backend == "mooncake_cpu" and not mooncake_available():


### PR DESCRIPTION
# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
