### PR TITLE
fix: increase nightly test time 1820 -> 1890

### DIFF
--- a/tests/unit/test_recipes_and_test_suites.py
+++ b/tests/unit/test_recipes_and_test_suites.py
@@ -234,7 +234,7 @@ def test_all_recipe_yamls_accounted_for_in_test_suites(
     )
 
 
-def test_nightly_compute_stays_below_1820_hours(nightly_test_suite, tracker):
+def test_nightly_compute_stays_below_1890_hours(nightly_test_suite, tracker):
     command = f"DRYRUN=1 HF_HOME=... HF_DATASETS_CACHE=... CONTAINER= ACCOUNT= PARTITION= ./tools/launch {' '.join(nightly_test_suite)}"
 
     print(f"Running command: {command}")
@@ -266,8 +266,8 @@ def test_nightly_compute_stays_below_1820_hours(nightly_test_suite, tracker):
         f"Last line of output was not as expected: '{last_line}'"
     )
     total_gpu_hours = float(last_line.split(":")[-1].strip())
-    assert total_gpu_hours <= 1820, (
-        f"Total GPU hours exceeded 1820: {last_line}. We should revisit the test suites to reduce the total GPU hours."
+    assert total_gpu_hours <= 1890, (
+        f"Total GPU hours exceeded 1890: {last_line}. We should revisit the test suites to reduce the total GPU hours."
     )
     tracker.track("total_nightly_gpu_hours", total_gpu_hours)
 


### PR DESCRIPTION
fix `test_nightly_compute_stays_below_1820_hours` which is skipped by `CI:docs` in #2769.
https://github.com/NVIDIA-NeMo/RL/actions/runs/27322340912/job/80728668156