### PR TITLE
fix: fix rollout metric name in RolloutManager unit test

### DIFF
--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -1241,6 +1241,8 @@ def test_async_rollout_manager_matches_original(
     def _translate_legacy_key(key: str) -> str:
         if key == "avg_turns_per_sample":
             return "turns_per_sample/mean"
+        if key == "max_turns_reached_rate":
+            return key
         for prefix, suffix in (("mean_", "/mean"), ("max_", "/max"), ("min_", "/min")):
             if key.startswith(prefix):
                 return f"{key[len(prefix) :]}{suffix}"


### PR DESCRIPTION
fix `test_async_rollout_manager_matches_original` which is skipped by `CI:Lfast` in #2567.
https://github.com/NVIDIA-NeMo/RL/actions/runs/27322340912/job/80728668060