### PR TITLE
perf: Update the dsv3 perf recipe

### DIFF
--- a/docs/guides/deepseek.md
+++ b/docs/guides/deepseek.md
@@ -23,6 +23,6 @@ python fp8_cast_bf16.py --input-fp8-hf-path ../../DeepSeek-V3-FP8 --output-bf16-
 cd ../..
 cp DeepSeek-V3-FP8/{tokenizer_config.json,tokenizer.json,modeling_deepseek.py,configuration_deepseek.py} DeepSeek-V3-BF16/
 
-# copy config.json, remove `quantization_config`, and set num_nextn_predict_layers to 0 (we currently do not support mtp):
-jq 'del(.quantization_config) | .num_nextn_predict_layers=0' DeepSeek-V3-FP8/config.json > DeepSeek-V3-BF16/config.json
+# copy config.json, remove `quantization_config`
+jq 'del(.quantization_config)' DeepSeek-V3-FP8/config.json > DeepSeek-V3-BF16/config.json
 ```

--- a/examples/configs/recipes/llm/performance/dapo-deepseek-v3-64n8g.v2.yaml
+++ b/examples/configs/recipes/llm/performance/dapo-deepseek-v3-64n8g.v2.yaml
@@ -73,6 +73,10 @@ policy:
       # vLLM 0.20's default FlashInfer TRTLLM MoE backend isn't refit-compatible,
       # change to triton to keep same behavior as vLLM 0.17.
       moe_backend: triton
+      speculative_config:
+        method: "deepseek_mtp"
+        num_speculative_tokens: 1
+
 data:
   max_input_seq_length: 512  # max_prompt_length
   prompt_file: null

--- a/examples/configs/recipes/llm/performance/grpo-deepseek-v3-32n8g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-deepseek-v3-32n8g.yaml
@@ -51,6 +51,9 @@ policy:
       # vLLM 0.20's default FlashInfer TRTLLM MoE backend isn't refit-compatible,
       # change to triton to keep same behavior as vLLM 0.17.
       moe_backend: triton
+      speculative_config:
+        method: "deepseek_mtp"
+        num_speculative_tokens: 1
 logger:
   log_dir: logs/grpo-deepseek-v3-32n8g
   wandb_enabled: true


### PR DESCRIPTION
# What does this PR do ?

DSV3 major perf recipe improvement for v0.7.0 release

GB200: with #2612 and #2613 (~1.35x) + MTP spec dec (1.35x) enablement shoule give ~1.8x speedup compared to v0.6.0 recipe

This PR expects https://github.com/NVIDIA-NeMo/RL/pull/2794 to be merged first.

## GB200
TODO

## H100 Test
Test case | Metric | Baseline | MTP | Δ
-- | -- | -- | -- | --
32n8g (colocated, bf16) | E2E tok/s/gpu | 14.10 | 16.68 | +18%
. | step time | 121.2 s | 100.5 s | -17%
. | gen latency¹ | 57.4 s | 40.1 s | -30%
. | KL err | 0.0020 | 0.0021 | parity
64n8g-async-1off (non-colo, bf16)² | E2E tok/s/gpu | 14.19 | 17.64 | +24%
. | step time | 70.2 s | 52.5 s | -25%
. | KL err | 0.0021 | 0.0021 | parity

Wandb: https://wandb.ai/nvidia/nemorl-dsv3-recipe-update?nw=nwuseryoungeunk&panelDisplayName=timing%2Ftrain%2Ftotal_step_time&panelSectionName=timing

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
