### PR TITLE
fix(grpo): materialize advantages before message penalties

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1276,6 +1276,8 @@ def _apply_message_level_advantage_penalties(
             flush=True,
         )
 
+    advantages = train_data["advantages"]
+    materialized_advantages = False
     for i, message_log in enumerate(message_logs):
         token_offset = 0
         for j, message in enumerate(message_log):
@@ -1294,22 +1296,25 @@ def _apply_message_level_advantage_penalties(
                 and malformed_neg_adv is not None
                 and message.get("has_malformed_thinking", False)
             )
+            if (is_invalid or is_malformed_thinking) and not materialized_advantages:
+                # GRPO/GDPO may expand per-sample advantages into zero-stride views;
+                # clone before span writes so penalties only affect targeted tokens.
+                advantages = advantages.clone()
+                train_data["advantages"] = advantages
+                materialized_advantages = True
+
             if is_invalid:
                 print(
                     f"Setting negative advantage ({invalid_neg_adv}) for invalid tool call in assistant message {i} {j}",
                     flush=True,
                 )
-                train_data["advantages"][i, token_offset : token_offset + msg_len] = (
-                    invalid_neg_adv
-                )
+                advantages[i, token_offset : token_offset + msg_len] = invalid_neg_adv
             elif is_malformed_thinking:
                 print(
                     f"Setting negative advantage ({malformed_neg_adv}) for malformed thinking in assistant message {i} {j}",
                     flush=True,
                 )
-                train_data["advantages"][i, token_offset : token_offset + msg_len] = (
-                    malformed_neg_adv
-                )
+                advantages[i, token_offset : token_offset + msg_len] = malformed_neg_adv
             token_offset += msg_len
 
 

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -325,6 +325,64 @@ def test_apply_message_level_advantage_penalties_targets_flagged_message_spans()
     torch.testing.assert_close(train_data["advantages"], expected)
 
 
+def test_apply_message_level_advantage_penalties_materializes_broadcasted_advantages():
+    per_sample_advantages = torch.tensor([[1.0], [10.0]])
+    train_data = BatchedDataDict({"advantages": per_sample_advantages.expand(2, 6)})
+    message_logs = [
+        [
+            {
+                "role": "user",
+                "token_ids": torch.tensor([1]),
+            },
+            {
+                "role": "assistant",
+                "token_ids": torch.tensor([2, 3, 4]),
+                "generation_logprobs": torch.tensor([0.1, 0.2, 0.3]),
+                "is_invalid_tool_call": True,
+            },
+            {
+                "role": "assistant",
+                "token_ids": torch.tensor([5, 6]),
+                "generation_logprobs": torch.tensor([0.4, 0.5]),
+            },
+        ],
+        [
+            {
+                "role": "user",
+                "token_ids": torch.tensor([7, 8]),
+            },
+            {
+                "role": "assistant",
+                "token_ids": torch.tensor([9, 10]),
+                "generation_logprobs": torch.tensor([0.6, 0.7]),
+                "has_malformed_thinking": True,
+            },
+            {
+                "role": "assistant",
+                "token_ids": torch.tensor([11, 12]),
+                "generation_logprobs": torch.tensor([0.8, 0.9]),
+            },
+        ],
+    ]
+
+    _apply_message_level_advantage_penalties(
+        train_data=train_data,
+        message_logs=message_logs,
+        invalid_tool_call_advantage=-5.0,
+        malformed_thinking_advantage=-7.0,
+    )
+
+    expected = torch.tensor(
+        [
+            [1.0, -5.0, -5.0, -5.0, 1.0, 1.0],
+            [10.0, 10.0, -7.0, -7.0, 10.0, 10.0],
+        ]
+    )
+    torch.testing.assert_close(train_data["advantages"], expected)
+    torch.testing.assert_close(per_sample_advantages, torch.tensor([[1.0], [10.0]]))
+    assert train_data["advantages"].stride(-1) != 0
+
+
 def test_apply_configured_message_level_advantage_penalties_noops_when_disabled(
     mock_grpo_components,
 ):


### PR DESCRIPTION
# What does this PR do ?

## Summary

Fix message-level GRPO advantage penalties when advantages come from a broadcasted token-level view.

GRPO/GDPO advantage estimators can expand per-sample advantages from shape `(B, 1)` to `(B, seq_len)`, producing a zero-stride view along the token dimension. Applying message-span penalties directly to that view can alias the per-sample scalar instead of only updating the targeted token span.
This PR materializes `train_data["advantages"]` with a lazy `.clone()` before the first message-level penalty write, preserving the no-op path when no flagged message is present.

## Changes
- Clone expanded advantages once before applying invalid-tool-call or malformed-thinking span penalties.
- Keep invalid-tool-call precedence over malformed-thinking penalties.
- Add a regression test covering expanded `(B, 1) -> (B, seq_len)` advantages.

## Test plan

 ```bash
 uv run pytest tests/unit/algorithms/test_grpo.py::test_apply_message_level_advantage_penalties_materializes_broadcasted_advantages
```

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
