### PR TITLE
fix(vllm): pass ignore_eos to vLLM SamplingParams in _build_sampling_params

### DIFF
--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -726,6 +726,7 @@ class BaseVllmGenerationWorker:
             stop_token_ids=self.cfg["stop_token_ids"],
             stop=stop_strings,
             include_stop_str_in_output=True,
+            ignore_eos=self.cfg.get("ignore_eos", False),
         )
 
     def start_gpu_profiling(self) -> None:


### PR DESCRIPTION
# What does this PR do ?

`_build_sampling_params` cleared `stop_token_ids` when `ignore_eos=true` but never set `SamplingParams.ignore_eos=True` on the vLLM side, so generation still stopped at the tokenizer's built-in EOS token regardless of the config flag. One-line fix: pass `ignore_eos` through to `SamplingParams`.

# Issues

N/A

# Usage

No API change. Set `ignore_eos: true` in the vLLM config as before; generation now correctly ignores EOS.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

The fix uses `.get("ignore_eos", False)` (defensive access) since `ignore_eos` is optional in the vLLM config.