### PR TITLE
fix(vllm): fix FP8 MoE kernel initialization for CUDA graph mode

### DIFF
--- a/nemo_rl/models/generation/vllm/quantization/fp8.py
+++ b/nemo_rl/models/generation/vllm/quantization/fp8.py
@@ -564,9 +564,12 @@ def process_weights_after_loading_moe(self, layer) -> None:
     getattr(layer, f"w13_{self.weight_scale_name}").copy_(w13_scale)
     getattr(layer, f"w2_{self.weight_scale_name}").copy_(w2_scale)
 
-    # Set up the MoE kernel (same as upstream _setup_kernel but without replace_parameter).
+    # Set up the MoE kernel on initial load only (same as upstream _setup_kernel
+    # but without replace_parameter). Gate on is None, not hasattr, because
+    # FusedMoEMethodBase.__init__ always sets moe_kernel=None. Also skips refit
+    # calls (finalize_layerwise_reload) which lack set_current_vllm_config context.
     self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-    if self.moe_quant_config:
+    if self.moe_quant_config and self.moe_kernel is None:
         from vllm.model_executor.layers.quantization.fp8 import make_fp8_moe_kernel
 
         assert self.experts_cls is not None


### PR DESCRIPTION
# What does this PR do ?

Fixes two bugs in `fp8.py` that prevented FP8 blockwise vLLM generation from working with CUDA graphs (`enforce_eager: false`):

1. **`hasattr` guard always True** — `FusedMoEMethodBase.__init__` sets `self.moe_kernel = None`, so the guard never triggered and `make_fp8_moe_kernel` was never called. Fix: gate on `self.moe_kernel is None`.
2. **Kernel re-created on every weight refit** — `process_weights_after_loading` runs outside a `set_current_vllm_config` context, crashing on `get_current_vllm_config()`. Fix: skip re-creation if `moe_kernel` is already set.

Validated on GLM-5.1 64n×8g — ~3.7× faster generation vs bf16 eager after this fix.

# Issues

N/A

# Usage

No API change. FP8 + CUDA graphs now works without requiring `enforce_eager: true`.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* N/A