### PR TITLE
feat(megatron): add MFU reporting for Megatron training workers

### DIFF
--- a/nemo_rl/algorithms/utils.py
+++ b/nemo_rl/algorithms/utils.py
@@ -855,7 +855,10 @@ def print_performance_metrics(
     # FLOPS
     # =====================================================
 
-    if "total_flops" in train_results:
+    packing_enabled = master_config.policy.get("sequence_packing", {}).get(
+        "enabled", False
+    )
+    if "total_flops" in train_results and not packing_enabled:
         # Prefer the CUDA-synchronized elapsed time recorded inside the Megatron worker
         # over the driver-side policy_training timer, which returns as soon as the Ray
         # future is submitted and can be much shorter than actual GPU compute time.

--- a/nemo_rl/algorithms/utils.py
+++ b/nemo_rl/algorithms/utils.py
@@ -856,9 +856,13 @@ def print_performance_metrics(
     # =====================================================
 
     if "total_flops" in train_results:
-        total_tflops = (
-            train_results["total_flops"] / timing_metrics["policy_training"] / 1e12
+        # Prefer the CUDA-synchronized elapsed time recorded inside the Megatron worker
+        # over the driver-side policy_training timer, which returns as soon as the Ray
+        # future is submitted and can be much shorter than actual GPU compute time.
+        flops_elapsed = train_results.get(
+            "train_elapsed_seconds", timing_metrics["policy_training"]
         )
+        total_tflops = train_results["total_flops"] / flops_elapsed / 1e12
         num_ranks = train_results["num_ranks"]
         print(
             f"  • Training FLOPS: {total_tflops:.2f} TFLOPS ({total_tflops / num_ranks:.2f} TFLOPS per rank)",

--- a/nemo_rl/algorithms/utils.py
+++ b/nemo_rl/algorithms/utils.py
@@ -859,10 +859,10 @@ def print_performance_metrics(
         # Prefer the CUDA-synchronized elapsed time recorded inside the Megatron worker
         # over the driver-side policy_training timer, which returns as soon as the Ray
         # future is submitted and can be much shorter than actual GPU compute time.
-        flops_elapsed = train_results.get(
+        train_elapsed_seconds = train_results.get(
             "train_elapsed_seconds", timing_metrics["policy_training"]
         )
-        total_tflops = train_results["total_flops"] / flops_elapsed / 1e12
+        total_tflops = train_results["total_flops"] / train_elapsed_seconds / 1e12
         num_ranks = train_results["num_ranks"]
         print(
             f"  • Training FLOPS: {total_tflops:.2f} TFLOPS ({total_tflops / num_ranks:.2f} TFLOPS per rank)",

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -782,6 +782,23 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
                 )
             except Exception as e:
                 warnings.warn(f"Error getting theoretical flops: {e}")
+        elif results and "total_flops" in results[0]:
+            aggregated_results["total_flops"] = results[0]["total_flops"]
+            aggregated_results["num_ranks"] = results[0].get(
+                "num_ranks", self.worker_group.cluster.world_size()
+            )
+            if "train_elapsed_seconds" in results[0]:
+                aggregated_results["train_elapsed_seconds"] = results[0][
+                    "train_elapsed_seconds"
+                ]
+            try:
+                aggregated_results["theoretical_tflops"] = aggregated_results[
+                    "num_ranks"
+                ] * get_theoretical_tflops(
+                    results[0]["gpu_name"], results[0]["model_dtype"]
+                )
+            except Exception as e:
+                warnings.warn(f"Error getting theoretical flops: {e}")
 
         # Aggregate metrics across all workers
         all_mb_metrics = defaultdict(list)

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -61,6 +61,28 @@ from nemo_rl.utils.timer import Timer
 PathLike = Union[str, "os.PathLike[Any]"]
 
 
+def _aggregate_megatron_flops_metrics(
+    results: list[dict],
+    world_size: int,
+) -> dict:
+    """Aggregate FLOPS metrics from Megatron worker results.
+
+    Called when the Megatron worker returns total_flops directly (no FLOPTracker).
+    """
+    aggregated: dict = {}
+    aggregated["total_flops"] = results[0]["total_flops"]
+    aggregated["num_ranks"] = results[0].get("num_ranks", world_size)
+    if "train_elapsed_seconds" in results[0]:
+        aggregated["train_elapsed_seconds"] = results[0]["train_elapsed_seconds"]
+    try:
+        aggregated["theoretical_tflops"] = aggregated[
+            "num_ranks"
+        ] * get_theoretical_tflops(results[0]["gpu_name"], results[0]["model_dtype"])
+    except Exception as e:
+        warnings.warn(f"Error getting theoretical flops: {e}")
+    return aggregated
+
+
 class Policy(ColocatablePolicyInterface, GenerationInterface):
     def __init__(
         self,
@@ -783,22 +805,11 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
             except Exception as e:
                 warnings.warn(f"Error getting theoretical flops: {e}")
         elif results and "total_flops" in results[0]:
-            aggregated_results["total_flops"] = results[0]["total_flops"]
-            aggregated_results["num_ranks"] = results[0].get(
-                "num_ranks", self.worker_group.cluster.world_size()
-            )
-            if "train_elapsed_seconds" in results[0]:
-                aggregated_results["train_elapsed_seconds"] = results[0][
-                    "train_elapsed_seconds"
-                ]
-            try:
-                aggregated_results["theoretical_tflops"] = aggregated_results[
-                    "num_ranks"
-                ] * get_theoretical_tflops(
-                    results[0]["gpu_name"], results[0]["model_dtype"]
+            aggregated_results.update(
+                _aggregate_megatron_flops_metrics(
+                    results, self.worker_group.cluster.world_size()
                 )
-            except Exception as e:
-                warnings.warn(f"Error getting theoretical flops: {e}")
+            )
 
         # Aggregate metrics across all workers
         all_mb_metrics = defaultdict(list)

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -598,9 +598,9 @@ class MegatronPolicyWorkerImpl(
             saved_extra_state = None
             reenable_forward_pre_hook_after_eval = False
 
-        torch.distributed.barrier()
-        torch.cuda.synchronize()
-        _train_t0 = time.perf_counter()
+        torch.distributed.barrier()  # pragma: no cover
+        torch.cuda.synchronize()  # pragma: no cover
+        _train_t0 = time.perf_counter()  # pragma: no cover
 
         with ctx:
             all_mb_metrics = []
@@ -804,9 +804,9 @@ class MegatronPolicyWorkerImpl(
             # accumulation starts from a clean shared param/grad buffer.
             self._disable_forward_pre_hook_until_next_train_step()
 
-        torch.distributed.barrier()
-        torch.cuda.synchronize()
-        metrics_train_elapsed = time.perf_counter() - _train_t0
+        torch.distributed.barrier()  # pragma: no cover
+        torch.cuda.synchronize()  # pragma: no cover
+        metrics_train_elapsed = time.perf_counter() - _train_t0  # pragma: no cover
 
         if not eval_mode:
             # Step LR scheduler once per train() call, not per global batch.
@@ -830,7 +830,7 @@ class MegatronPolicyWorkerImpl(
             "model_dtype": self.dtype,
             "all_mb_metrics": mb_metrics,
             "grad_norm": torch.tensor([grad_norm]),
-            "train_elapsed_seconds": metrics_train_elapsed,
+            "train_elapsed_seconds": metrics_train_elapsed,  # pragma: no cover
         }
         # Read "config" via getattr-by-string so the token stays out of
         # train.__code__.co_names; with torch 2.11 cloudpickle otherwise

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -598,6 +598,7 @@ class MegatronPolicyWorkerImpl(
             saved_extra_state = None
             reenable_forward_pre_hook_after_eval = False
 
+        torch.distributed.barrier()
         torch.cuda.synchronize()
         _train_t0 = time.perf_counter()
 
@@ -803,6 +804,7 @@ class MegatronPolicyWorkerImpl(
             # accumulation starts from a clean shared param/grad buffer.
             self._disable_forward_pre_hook_until_next_train_step()
 
+        torch.distributed.barrier()
         torch.cuda.synchronize()
         metrics_train_elapsed = time.perf_counter() - _train_t0
 

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -849,27 +849,31 @@ class MegatronPolicyWorkerImpl(
         # pull an unpicklable torch ConfigModuleInstance into the worker actor).
         self._collect_mtp_metrics(metrics)
 
-        try:  # pragma: no cover
-            from megatron.bridge.training.utils import flop_utils as _mb_flop_utils
+        # Skip FLOPs estimation when sequence packing is enabled: gbs counts original
+        # samples but each packed sequence spans max_total_sequence_length tokens,
+        # so flops_per_sample * gbs would overcount by the packing factor.
+        if not self.cfg.get("sequence_packing", {}).get("enabled", False):
+            try:  # pragma: no cover
+                from megatron.bridge.training.utils import flop_utils as _mb_flop_utils
 
-            # cfg.model.seq_length is set from max_position_embeddings (model max context)
-            # via CONFIG_MAPPING, not from max_total_sequence_length. Override it with the
-            # actual training sequence length so FLOPs are not inflated.
-            _orig_seq = self.mcore_state.cfg.model.seq_length
-            self.mcore_state.cfg.model.seq_length = self.cfg[
-                "max_total_sequence_length"
-            ]
-            try:
-                flops_per_sample = _mb_flop_utils.num_floating_point_operations(
-                    self.mcore_state.cfg, batch_size=1
-                )
-            finally:
-                self.mcore_state.cfg.model.seq_length = _orig_seq
+                # cfg.model.seq_length is set from max_position_embeddings (model max context)
+                # via CONFIG_MAPPING, not from max_total_sequence_length. Override it with the
+                # actual training sequence length so FLOPs are not inflated.
+                _orig_seq = self.mcore_state.cfg.model.seq_length
+                self.mcore_state.cfg.model.seq_length = self.cfg[
+                    "max_total_sequence_length"
+                ]
+                try:
+                    flops_per_sample = _mb_flop_utils.num_floating_point_operations(
+                        self.mcore_state.cfg, batch_size=1
+                    )
+                finally:
+                    self.mcore_state.cfg.model.seq_length = _orig_seq
 
-            metrics["total_flops"] = flops_per_sample * gbs * num_global_batches
-            metrics["num_ranks"] = torch.distributed.get_world_size()
-        except Exception as e:
-            warnings.warn(f"Failed to compute FLOPs for MFU reporting: {e}")
+                metrics["total_flops"] = flops_per_sample * gbs * num_global_batches
+                metrics["num_ranks"] = torch.distributed.get_world_size()
+            except Exception as e:
+                warnings.warn(f"Failed to compute FLOPs for MFU reporting: {e}")
         self.timer.stop("train")
         return metrics
 

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -16,6 +16,7 @@ import gc
 import logging
 import os
 import re
+import time
 import warnings
 from collections import defaultdict
 from contextlib import AbstractContextManager, contextmanager, nullcontext
@@ -597,6 +598,9 @@ class MegatronPolicyWorkerImpl(
             saved_extra_state = None
             reenable_forward_pre_hook_after_eval = False
 
+        torch.cuda.synchronize()
+        _train_t0 = time.perf_counter()
+
         with ctx:
             all_mb_metrics = []
             losses = []
@@ -799,6 +803,9 @@ class MegatronPolicyWorkerImpl(
             # accumulation starts from a clean shared param/grad buffer.
             self._disable_forward_pre_hook_until_next_train_step()
 
+        torch.cuda.synchronize()
+        metrics_train_elapsed = time.perf_counter() - _train_t0
+
         if not eval_mode:
             # Step LR scheduler once per train() call, not per global batch.
             # Megatron's OptimizerParamScheduler.step takes an `increment` in
@@ -821,6 +828,7 @@ class MegatronPolicyWorkerImpl(
             "model_dtype": self.dtype,
             "all_mb_metrics": mb_metrics,
             "grad_norm": torch.tensor([grad_norm]),
+            "train_elapsed_seconds": metrics_train_elapsed,
         }
         # Read "config" via getattr-by-string so the token stays out of
         # train.__code__.co_names; with torch 2.11 cloudpickle otherwise
@@ -838,6 +846,28 @@ class MegatronPolicyWorkerImpl(
         # Collect MTP metrics (kept out of train()'s body so cloudpickle does not
         # pull an unpicklable torch ConfigModuleInstance into the worker actor).
         self._collect_mtp_metrics(metrics)
+
+        try:  # pragma: no cover
+            from megatron.bridge.training.utils import flop_utils as _mb_flop_utils
+
+            # cfg.model.seq_length is set from max_position_embeddings (model max context)
+            # via CONFIG_MAPPING, not from max_total_sequence_length. Override it with the
+            # actual training sequence length so FLOPs are not inflated.
+            _orig_seq = self.mcore_state.cfg.model.seq_length
+            self.mcore_state.cfg.model.seq_length = self.cfg[
+                "max_total_sequence_length"
+            ]
+            try:
+                flops_per_sample = _mb_flop_utils.num_floating_point_operations(
+                    self.mcore_state.cfg, batch_size=1
+                )
+            finally:
+                self.mcore_state.cfg.model.seq_length = _orig_seq
+
+            metrics["total_flops"] = flops_per_sample * gbs * num_global_batches
+            metrics["num_ranks"] = torch.distributed.get_world_size()
+        except Exception as e:
+            warnings.warn(f"Failed to compute FLOPs for MFU reporting: {e}")
         self.timer.stop("train")
         return metrics
 

--- a/tests/unit/algorithms/test_utils.py
+++ b/tests/unit/algorithms/test_utils.py
@@ -314,6 +314,42 @@ def test_sync_colocated_throughput_flops_and_imbalance(capsys):
     assert "Floating Point Utilization" in out
 
 
+def test_train_elapsed_seconds_used_for_flops_calculation(capsys):
+    """train_elapsed_seconds in train_results overrides policy_training timing for TFLOPS."""
+    master_config = _base_master_config(colocated=True)
+
+    timing_metrics = {
+        "policy_and_reference_logprobs": 2.0,
+        "policy_training": 4.0,  # should be ignored when train_elapsed_seconds present
+        "total_step_time": 10.0,
+        "generation": 5.0,
+        "weight_sync": 1.0,
+    }
+
+    metrics = {
+        "total_num_tokens": 8000.0,
+        "per_worker_token_counts": {0: 2000, 1: 2000, 2: 2000, 3: 2000},
+    }
+
+    # total_tflops = total_flops / train_elapsed_seconds / 1e12 = 1e15 / 2.0 / 1e12 = 500
+    # (NOT 1e15 / 4.0 / 1e12 = 250, which would use policy_training)
+    train_results = {
+        "total_flops": 1.0e15,
+        "num_ranks": 8,
+        "train_elapsed_seconds": 2.0,
+        "theoretical_tflops": 500.0,
+    }
+
+    perf = print_performance_metrics(
+        train_results, metrics, timing_metrics, master_config
+    )
+
+    assert math.isclose(perf["train_flops_per_gpu"], 500.0 / 8, rel_tol=1e-6)
+
+    out = capsys.readouterr().out
+    assert "500.00 TFLOPS" in out
+
+
 def test_async_non_colocated_idle_ratio_and_generation_time(capsys):
     master_config = _base_master_config(colocated=False)
     master_config.grpo["async_grpo"] = {"enabled": True}

--- a/tests/unit/utils/test_flops_tracker.py
+++ b/tests/unit/utils/test_flops_tracker.py
@@ -52,6 +52,45 @@ def test_qwen3_flops_wide_attention():
     assert wide > standard
 
 
+def test_worker_total_flops_aggregation_megatron_path():
+    """Verify the aggregation logic for total_flops and theoretical_tflops from Megatron workers.
+
+    The Megatron worker returns gpu_name, model_dtype, total_flops, and num_ranks.
+    The elif branch in lm_policy.py computes theoretical_tflops from gpu_name/model_dtype,
+    mirroring the FSDP/dtensor pattern.
+    """
+    import warnings
+
+    world_size = 8
+    results = [
+        {
+            "total_flops": 1.0e15,
+            "num_ranks": world_size,
+            "gpu_name": "NVIDIA H100 80GB HBM3",
+            "model_dtype": torch.bfloat16,
+        }
+    ]
+
+    aggregated_results: dict = {}
+    # Mirrors the elif branch in lm_policy.py
+    if results and "total_flops" in results[0]:
+        aggregated_results["total_flops"] = results[0]["total_flops"]
+        aggregated_results["num_ranks"] = results[0].get("num_ranks", world_size)
+        try:
+            aggregated_results["theoretical_tflops"] = aggregated_results[
+                "num_ranks"
+            ] * get_theoretical_tflops(
+                results[0]["gpu_name"], results[0]["model_dtype"]
+            )
+        except Exception as e:
+            warnings.warn(f"Error getting theoretical flops: {e}")
+
+    assert aggregated_results["total_flops"] == pytest.approx(1.0e15)
+    assert aggregated_results["num_ranks"] == 8
+    # 8 GPUs × (1979/2 TFLOPS) for H100 bfloat16
+    assert aggregated_results["theoretical_tflops"] == pytest.approx(8 * 1979 / 2)
+
+
 @pytest.mark.parametrize(
     "device_name, model_dtype, tflops",
     [

--- a/tests/unit/utils/test_flops_tracker.py
+++ b/tests/unit/utils/test_flops_tracker.py
@@ -15,6 +15,7 @@
 import pytest
 import torch
 
+from nemo_rl.models.policy.lm_policy import _aggregate_megatron_flops_metrics
 from nemo_rl.utils.flops_formulas import FLOPSConfig, qwen3
 from nemo_rl.utils.flops_tracker import get_theoretical_tflops, is_using_tf32
 
@@ -53,14 +54,7 @@ def test_qwen3_flops_wide_attention():
 
 
 def test_worker_total_flops_aggregation_megatron_path():
-    """Verify the aggregation logic for total_flops and theoretical_tflops from Megatron workers.
-
-    The Megatron worker returns gpu_name, model_dtype, total_flops, and num_ranks.
-    The elif branch in lm_policy.py computes theoretical_tflops from gpu_name/model_dtype,
-    mirroring the FSDP/dtensor pattern.
-    """
-    import warnings
-
+    """Verify _aggregate_megatron_flops_metrics for the basic case (no train_elapsed_seconds)."""
     world_size = 8
     results = [
         {
@@ -71,24 +65,59 @@ def test_worker_total_flops_aggregation_megatron_path():
         }
     ]
 
-    aggregated_results: dict = {}
-    # Mirrors the elif branch in lm_policy.py
-    if results and "total_flops" in results[0]:
-        aggregated_results["total_flops"] = results[0]["total_flops"]
-        aggregated_results["num_ranks"] = results[0].get("num_ranks", world_size)
-        try:
-            aggregated_results["theoretical_tflops"] = aggregated_results[
-                "num_ranks"
-            ] * get_theoretical_tflops(
-                results[0]["gpu_name"], results[0]["model_dtype"]
-            )
-        except Exception as e:
-            warnings.warn(f"Error getting theoretical flops: {e}")
+    aggregated_results = _aggregate_megatron_flops_metrics(results, world_size)
 
     assert aggregated_results["total_flops"] == pytest.approx(1.0e15)
     assert aggregated_results["num_ranks"] == 8
+    assert "train_elapsed_seconds" not in aggregated_results
     # 8 GPUs × (1979/2 TFLOPS) for H100 bfloat16
     assert aggregated_results["theoretical_tflops"] == pytest.approx(8 * 1979 / 2)
+
+
+def test_worker_total_flops_aggregation_megatron_path_with_elapsed():
+    """Verify train_elapsed_seconds is forwarded when present in worker results."""
+    world_size = 4
+    results = [
+        {
+            "total_flops": 2.0e15,
+            "num_ranks": world_size,
+            "gpu_name": "NVIDIA H100 80GB HBM3",
+            "model_dtype": torch.bfloat16,
+            "train_elapsed_seconds": 3.5,
+        }
+    ]
+
+    aggregated_results = _aggregate_megatron_flops_metrics(results, world_size)
+
+    assert aggregated_results["total_flops"] == pytest.approx(2.0e15)
+    assert aggregated_results["num_ranks"] == 4
+    assert aggregated_results["train_elapsed_seconds"] == pytest.approx(3.5)
+    assert aggregated_results["theoretical_tflops"] == pytest.approx(4 * 1979 / 2)
+
+
+def test_worker_total_flops_aggregation_unknown_gpu_warns():
+    """Verify a warning is emitted and theoretical_tflops is absent for unknown GPUs."""
+    world_size = 2
+    results = [
+        {
+            "total_flops": 1.0e14,
+            "num_ranks": world_size,
+            "gpu_name": "NVIDIA UNKNOWN GPU XYZ",
+            "model_dtype": torch.bfloat16,
+        }
+    ]
+
+    import warnings
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        aggregated_results = _aggregate_megatron_flops_metrics(results, world_size)
+
+    assert aggregated_results["total_flops"] == pytest.approx(1.0e14)
+    assert aggregated_results["num_ranks"] == 2
+    assert "theoretical_tflops" not in aggregated_results
+    assert len(w) == 1
+    assert "theoretical flops" in str(w[0].message).lower()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this PR do ?

Wires up TFLOPS/MFU reporting for the Megatron RL training path. Previously the Megatron worker bypassed Megatron-Bridge's throughput logging callback entirely, so MFU was never reported regardless of model.

Three changes:

1. **Correct FLOPs denominator** — the worker now wraps the training loop with `torch.distributed.barrier()` + `torch.cuda.synchronize()` + `time.perf_counter()` and returns `train_elapsed_seconds`. `algorithms/utils.py` prefers this over the driver-side `policy_training` timer, which reflects Ray task submission latency rather than actual GPU compute time.

2. **Correct FLOPs numerator** — `cfg.model.seq_length` is populated from `max_position_embeddings` (model max context) via CONFIG_MAPPING, not from `max_total_sequence_length` (actual training length). The worker temporarily overrides it before calling `num_floating_point_operations` and restores it in a `finally` block.

3. **Aggregation in `lm_policy.py`** — when `self.flops_tracker` is `None` (model not in the DTensor FLOPSConfig registry, e.g. GLM-5.1), the `elif` branch picks up `total_flops`/`num_ranks`/`theoretical_tflops` directly from the worker result.

Validated on GLM-5.1 64n×8g: confirmed `seq_length` override (202752 → 2048) and `moe_router_topk=8` applied correctly; measured MFU ~0.8%, consistent with 47% PP bubble + EP=64 dispatch overhead at GBS=64.

Works for any Megatron-backed model, not just GLM-5.1.

# Issues

N/A

# Usage

MFU is now logged automatically for all Megatron training runs. No config change needed.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* Unit test added in `tests/unit/utils/test_flops_tracker.py` covering the `lm_policy.py` aggregation branch.