### PR TITLE
docs: organize guides section into subcategories

### DIFF
--- a/docs/guides/advanced-training-guides.md
+++ b/docs/guides/advanced-training-guides.md
@@ -1,0 +1,14 @@
+# Advanced Training Techniques
+
+Guides for speeding up and extending training runs with quantization, speculative decoding, long-context scaling, cross-tokenizer distillation, parameter-efficient fine-tuning, and alternative optimizers.
+
+```{toctree}
+:maxdepth: 1
+
+quantization-aware-rl
+eagle3-speculative-decoding
+yarn-long-context
+xtoken-off-policy-distillation
+lora
+muon-optimizer
+```

--- a/docs/guides/advanced-training-guides.md
+++ b/docs/guides/advanced-training-guides.md
@@ -1,0 +1,18 @@
+# Advanced Training Techniques
+
+Guides for speeding up and extending training runs with quantization, speculative decoding, long-context scaling, cross-tokenizer distillation, parameter-efficient fine-tuning, alternative optimizers, single-controller execution, and weight-refit strategies for the generation backend.
+
+```{toctree}
+:maxdepth: 1
+
+quantization-aware-rl
+eagle3-speculative-decoding
+yarn-long-context
+xtoken-off-policy-distillation
+lora
+muon-optimizer
+single-controller
+refit
+checkpoint-engine-refit
+dynamo-generation
+```

--- a/docs/guides/evaluation-environments-guides.md
+++ b/docs/guides/evaluation-environments-guides.md
@@ -1,0 +1,10 @@
+# Evaluation and Environments
+
+Guides for evaluating trained models and building custom reward environments for RL training.
+
+```{toctree}
+:maxdepth: 1
+
+eval
+environments
+```

--- a/docs/guides/grpo-ppo-guides.md
+++ b/docs/guides/grpo-ppo-guides.md
@@ -1,0 +1,19 @@
+# GRPO and PPO
+
+Guides for training models with Group Relative Policy Optimization (GRPO), its variants (DAPO, CISPO, ProRLv2), and Proximal Policy Optimization (PPO), from algorithm walkthroughs to end-to-end recipes and asynchronous rollouts.
+
+```{toctree}
+:maxdepth: 1
+
+grpo
+grpo-deepscaler
+grpo-sliding-puzzle
+grpo-audio
+grpo-audio-visual
+swe-rl-qwen3
+async-grpo
+dapo
+cispo
+prorlv2
+ppo
+```

--- a/docs/guides/model-guides.md
+++ b/docs/guides/model-guides.md
@@ -1,0 +1,14 @@
+# Models
+
+Model-specific recipes, instructions for adding support for new model architectures, and known model quirks.
+
+```{toctree}
+:maxdepth: 1
+
+nemotron-3-nano
+nemotron-3-nano-omni
+nemotron-3-super
+deepseek
+../adding-new-models
+../model-quirks
+```

--- a/docs/guides/model-guides.md
+++ b/docs/guides/model-guides.md
@@ -1,0 +1,12 @@
+# Models
+
+Model-family guides, model-specific recipes, instructions for adding support for new model architectures, and known model quirks.
+
+```{toctree}
+:maxdepth: 1
+
+models/index
+deepseek
+../adding-new-models
+../model-quirks
+```

--- a/docs/guides/sft-dpo-rm-guides.md
+++ b/docs/guides/sft-dpo-rm-guides.md
@@ -1,0 +1,11 @@
+# SFT, DPO, and RM
+
+Guides for supervised fine-tuning, direct preference optimization, and reward model training.
+
+```{toctree}
+:maxdepth: 1
+
+sft
+dpo
+rm
+```

--- a/docs/guides/sft-dpo-rm-guides.md
+++ b/docs/guides/sft-dpo-rm-guides.md
@@ -1,0 +1,12 @@
+# SFT, DPO, and RM
+
+Guides for supervised fine-tuning, preference optimization (DPO, MPO), and reward model training.
+
+```{toctree}
+:maxdepth: 1
+
+sft
+dpo
+nemotron-omni-mpo
+rm
+```

--- a/docs/guides/troubleshooting-reliability-guides.md
+++ b/docs/guides/troubleshooting-reliability-guides.md
@@ -1,0 +1,11 @@
+# Troubleshooting and Reliability
+
+Guides for diagnosing accuracy issues and keeping long-running distributed training jobs alive.
+
+```{toctree}
+:maxdepth: 1
+
+dtensor-tp-accuracy
+router-replay
+ft-launcher-guide
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -261,37 +261,12 @@ guides/sft-openmathinstruct2.md
 ```{toctree}
 :caption: Guides
 
-guides/nemotron-3-nano.md
-guides/nemotron-3-nano-omni.md
-guides/nemotron-3-super.md
-adding-new-models.md
-guides/sft.md
-guides/dpo.md
-guides/dapo.md
-guides/lora.md
-guides/cispo.md
-guides/prorlv2.md
-guides/swe-rl-qwen3.md
-guides/grpo.md
-guides/ppo.md
-guides/grpo-deepscaler.md
-guides/grpo-sliding-puzzle.md
-guides/grpo-audio.md
-guides/grpo-audio-visual.md
-guides/rm.md
-guides/environments.md
-guides/eval.md
-guides/deepseek.md
-model-quirks.md
-guides/async-grpo.md
-guides/quantization-aware-rl.md
-guides/eagle3-speculative-decoding.md
-guides/yarn-long-context.md
-guides/xtoken-off-policy-distillation.md
-guides/router-replay.md
-guides/muon-optimizer.md
-guides/dtensor-tp-accuracy.md
-guides/ft-launcher-guide.md
+guides/grpo-ppo-guides.md
+guides/sft-dpo-rm-guides.md
+guides/evaluation-environments-guides.md
+guides/model-guides.md
+guides/advanced-training-guides.md
+guides/troubleshooting-reliability-guides.md
 ```
 
 ```{toctree}

--- a/docs/index.md
+++ b/docs/index.md
@@ -303,40 +303,12 @@ guides/sft-openmathinstruct2.md
 ```{toctree}
 :caption: Guides
 
-adding-new-models.md
-guides/sft.md
-guides/dpo.md
-guides/nemotron-omni-mpo.md
-guides/dapo.md
-guides/lora.md
-guides/cispo.md
-guides/prorlv2.md
-guides/swe-rl-qwen3.md
-guides/grpo.md
-guides/ppo.md
-guides/grpo-deepscaler.md
-guides/grpo-sliding-puzzle.md
-guides/grpo-audio.md
-guides/grpo-audio-visual.md
-guides/rm.md
-guides/environments.md
-guides/eval.md
-guides/deepseek.md
-guides/models/index.md
-model-quirks.md
-guides/async-grpo.md
-guides/single-controller.md
-guides/quantization-aware-rl.md
-guides/eagle3-speculative-decoding.md
-guides/yarn-long-context.md
-guides/xtoken-off-policy-distillation.md
-guides/refit.md
-guides/checkpoint-engine-refit.md
-guides/dynamo-generation.md
-guides/router-replay.md
-guides/muon-optimizer.md
-guides/dtensor-tp-accuracy.md
-guides/ft-launcher-guide.md
+guides/grpo-ppo-guides.md
+guides/sft-dpo-rm-guides.md
+guides/evaluation-environments-guides.md
+guides/model-guides.md
+guides/advanced-training-guides.md
+guides/troubleshooting-reliability-guides.md
 ```
 
 ```{toctree}


### PR DESCRIPTION
## What does this PR do ?

Closes NVIDIA-NeMo/RL#2705.

The **Guides** section of the docs sidebar was a single flat list of 25 entries, which made it hard to find algorithm-specific content. This PR organizes it into six subcategories, following the suggestion in NVIDIA-NeMo/RL#2705 (GRPO, SFT, Evaluation, Environments) extended to cover all existing guides:

<!-- linear:table-colwidths:400,400 -->
| Subcategory | Guides |
| -- | -- |
| **GRPO and PPO** | grpo, grpo-deepscaler, grpo-sliding-puzzle, grpo-audio, async-grpo, dapo, cispo, prorlv2, ppo |
| **SFT, DPO, and RM** | sft, dpo, rm |
| **Evaluation and Environments** | eval, environments |
| **Models** | nemotron-3-nano, deepseek, adding-new-models, model-quirks |
| **Advanced Training Techniques** | quantization-aware-rl, eagle3-speculative-decoding, yarn-long-context, xtoken-off-policy-distillation, muon-optimizer |
| **Troubleshooting and Reliability** | dtensor-tp-accuracy, ft-launcher-guide |

Each subcategory is a small landing page with a one-line description and a visible `{toctree}`, following the existing pattern in `docs/about/algorithms/index.md`. In the sidebar, each subcategory renders as a collapsible entry under the **Guides** caption.

### Design notes

* **No files are moved and no URLs change.** Existing guide pages stay at their current paths, so the \~30 inbound references (README, source docstrings, example configs, published doc URLs) all remain valid. Only the toctree wiring in `docs/index.md` changes, plus six new landing pages.
* `guides/sft-openmathinstruct2.md` (E2E Examples) and `guides/use-custom-vllm.md` (Development) keep their current sections, as before.
* The "Installation" grouping suggested in the issue is not part of the Guides toctree (installation docs live under *About*), so it is not included here.

## Issues

Closes NVIDIA-NeMo/RL#2705

## Usage

N/A — documentation-only change.

## Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](<https://github.com/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md>)
- [ ] Did you write any new necessary tests? N/A (docs only)
- [ ] Did you run the unit tests and functional tests locally? N/A (docs only; verified with a local `sphinx-build` — no new warnings)
- [ ] Did you add or update any necessary documentation? Yes, this PR is documentation-only

**Additional Information**

* Verified locally with `sphinx-build`: build succeeds and all guides remain reachable from exactly one toctree.