### PR TITLE
perf: Fix DSV3 perf regression & boost weight loading time (dsv3 MTP)

### DIFF
--- a/examples/run_grpo.py
+++ b/examples/run_grpo.py
@@ -102,10 +102,13 @@ def main() -> None:
         "A generation config is required for GRPO"
     )
     has_refit_draft_weights = bool(config.policy["draft"]["enabled"])
+    megatron_cfg = config.policy.get("megatron_cfg") or {}
+    trains_mtp = bool(megatron_cfg.get("mtp_num_layers"))
     config.policy["generation"] = configure_generation_config(
         config.policy["generation"],
         tokenizer,
         has_refit_draft_weights=has_refit_draft_weights,
+        trains_mtp=trains_mtp,
     )
 
     # setup data

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1766,7 +1766,6 @@ def refit_policy_generation(
             if isinstance(policy_generation, MegatronGeneration):
                 futures_train = policy.swap_weights_via_reshard(is_source=True)
             else:
-                policy.offload_before_refit()
                 futures_train = policy.broadcast_weights_for_collective(
                     kv_scales=kv_scales
                 )
@@ -1775,7 +1774,6 @@ def refit_policy_generation(
             ray.get(futures_train)
             results = ray.get(futures_inference)
             update_success = all(result for result in results if result is not None)
-            policy.prepare_for_training()
 
         # check if update is successful
         if not update_success:

--- a/nemo_rl/models/generation/__init__.py
+++ b/nemo_rl/models/generation/__init__.py
@@ -46,10 +46,12 @@ def configure_generation_config(
         # set load_format
         config["vllm_cfg"]["load_format"] = "auto" if is_eval else "dummy"
         speculative_config = config.get("vllm_kwargs", {}).get("speculative_config")
-        if speculative_config:
-            # Speculative decoding needs real startup weights unless the draft
-            # weights will be pushed into vLLM during the initial refit.
-            if not is_eval and not has_refit_draft_weights:
+        if speculative_config and not is_eval and not has_refit_draft_weights:
+            # Speculative decoding needs real draft weights at startup, since the
+            # draft is not covered by the initial refit.
+            if speculative_config.get("method") not in ("deepseek_mtp", "mtp"):
+                # Non-MTP methods (e.g. Eagle) must read the drafter's real
+                # weights from the checkpoint, so load everything.
                 warnings.warn(
                     "Speculative decoding is enabled without draft refit sync. "
                     "Setting vllm_cfg['load_format'] to 'auto' so the drafter does "

--- a/nemo_rl/models/generation/__init__.py
+++ b/nemo_rl/models/generation/__init__.py
@@ -61,7 +61,7 @@ def configure_generation_config(
                 config["vllm_cfg"]["load_format"] = "auto"
 
         # MTP draft weights arrive via refit if the trainer trains the MTP layer.
-        # If the trainer does not train the MTP layer, the weights need to be 
+        # If the trainer does not train the MTP layer, the weights need to be
         # loaded from the checkpoint.
         config["_mtp_weights_from_refit"] = trains_mtp
 

--- a/nemo_rl/models/generation/__init__.py
+++ b/nemo_rl/models/generation/__init__.py
@@ -27,6 +27,7 @@ def configure_generation_config(
     tokenizer: TokenizerType,
     is_eval: bool = False,
     has_refit_draft_weights: bool = False,
+    trains_mtp: bool = False,
 ) -> GenerationConfig:
     """Apply specific configurations to generation config."""
     # tokenizer setting
@@ -58,6 +59,11 @@ def configure_generation_config(
                     "not start from dummy weights."
                 )
                 config["vllm_cfg"]["load_format"] = "auto"
+
+        # MTP draft weights arrive via refit if the trainer trains the MTP layer.
+        # If the trainer does not train the MTP layer, the weights need to be 
+        # loaded from the checkpoint.
+        config["_mtp_weights_from_refit"] = trains_mtp
 
         # Respect the skip_tokenizer_init setting from the config. VLMs for example, require this to be False.
         if "skip_tokenizer_init" not in config["vllm_cfg"]:

--- a/nemo_rl/models/generation/interfaces.py
+++ b/nemo_rl/models/generation/interfaces.py
@@ -132,6 +132,8 @@ class GenerationConfig(TypedDict):
     use_async_rollouts: NotRequired[bool]
     # This isn't meant to be passed by the user, but is populated by nemo_rl.models.generation.__init__.configure_generation_config
     _pad_token_id: NotRequired[int]
+    # MTP draft weights arrive via refit if the trainer trains the MTP layer.
+    _mtp_weights_from_refit: NotRequired[bool]
 
 
 class GenerationDatumSpec(TypedDict):

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -48,6 +48,49 @@ def fix_gemma3_vision_weight_name(key: str) -> str:
     )
 
 
+def _read_mtp_layer_weights_from_checkpoint(
+    model_path: str, mtp_layer_indices: set[int]
+) -> list[tuple[str, torch.Tensor]]:
+    """Read only the MTP draft layer weights from a sharded HF safetensors checkpoint.
+
+    Uses the checkpoint's ``model.safetensors.index.json`` to open only the
+    shards that contain the requested transformer layer indices, so the
+    multi-terabyte base-model weights are never read from disk.
+
+    Args:
+        model_path: Path to the HF checkpoint directory.
+        mtp_layer_indices: Transformer layer indices belonging to the MTP module(s).
+
+    Returns:
+        A list of ``(weight_name, tensor)`` pairs for the requested layers, with
+        tensors on CPU.
+    """
+    import json
+    import os
+
+    from safetensors import safe_open
+
+    index_path = os.path.join(model_path, "model.safetensors.index.json")
+    with open(index_path) as f:
+        weight_map = json.load(f)["weight_map"]
+
+    layer_re = re.compile(r"(?:^|\.)layers\.(\d+)\.")
+    shard_to_names: dict[str, list[str]] = {}
+    for name, shard in weight_map.items():
+        match = layer_re.search(name)
+        if match is not None and int(match.group(1)) in mtp_layer_indices:
+            shard_to_names.setdefault(shard, []).append(name)
+
+    weights: list[tuple[str, torch.Tensor]] = []
+    for shard, names in shard_to_names.items():
+        with safe_open(
+            os.path.join(model_path, shard), framework="pt", device="cpu"
+        ) as reader:
+            for name in names:
+                weights.append((name, reader.get_tensor(name)))
+    return weights
+
+
 class VllmInternalWorkerExtension:
     def init_collective(
         self,
@@ -209,6 +252,63 @@ class VllmInternalWorkerExtension:
             return
         draft_weights = self._trim_vocab_padding(draft_model, draft_weights)
         draft_model.load_weights(weights=draft_weights)
+
+    def load_mtp_weights_from_disk(self, model_path: str) -> bool:
+        """Load only the MTP (multi-token-prediction) draft weights from disk.
+
+        Used when an MTP speculative-decoding policy runs with
+        ``load_format="dummy"``: the main model receives real weights via refit,
+        but the MTP draft layer is not covered by refit (the trainer runs with
+        ``mtp_num_layers=0``), so its weights must come from the checkpoint. Only
+        the MTP layer(s) are read, avoiding a full base-model load (~1.3 TB for
+        DeepSeek-V3) on every inference replica.
+
+        Args:
+            model_path: Path to the HF checkpoint directory.
+
+        Returns:
+            bool: True if MTP weights were loaded.
+        """
+        draft_owner = getattr(self.model_runner, "drafter", None)
+        draft_model = getattr(draft_owner, "model", None) if draft_owner else None
+        if draft_model is None:
+            print("[mtp] Drafter unavailable; cannot load MTP weights from disk.")
+            return False
+
+        predictor = draft_model.model
+        mtp_layer_indices = set(
+            range(
+                predictor.mtp_start_layer_idx,
+                predictor.mtp_start_layer_idx + predictor.num_mtp_layers,
+            )
+        )
+        weights = _read_mtp_layer_weights_from_checkpoint(model_path, mtp_layer_indices)
+        if not weights:
+            raise ValueError(
+                f"No MTP layer weights for layers {sorted(mtp_layer_indices)} "
+                f"found in checkpoint at {model_path}. The checkpoint must "
+                f"include MTP layer weights to run deepseek_mtp speculative decoding."
+            )
+
+        self._load_draft_weights(weights)
+
+        # The MTP block contains MoE experts whose weights need post-load
+        # processing (e.g. grouped-GEMM layout), matching the main-model path.
+        from vllm.config import set_current_vllm_config
+        from vllm.model_executor.model_loader.utils import (
+            process_weights_after_loading,
+        )
+
+        draft_model_config = (
+            self.model_runner.vllm_config.speculative_config.draft_model_config
+        )
+        with set_current_vllm_config(self.model_runner.vllm_config):
+            process_weights_after_loading(draft_model, draft_model_config, self.device)
+        print(
+            f"[mtp] Loaded MTP draft weights for layers "
+            f"{sorted(mtp_layer_indices)} from {model_path}"
+        )
+        return True
 
     def _load_weights(self, weights):
         """Load weights with Gemma3 vision-tower weight name fix, FP8, and draft-weight support.

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -304,6 +304,17 @@ class BaseVllmGenerationWorker:
         if ModelFlag.VLLM_LOAD_FORMAT_AUTO.matches(self.model_name):
             load_format = "auto"
 
+        # MTP speculative decoding with load_format="dummy" gets its policy
+        # weights via refit, but the MTP draft layer is not covered by refit, so
+        # those layers are loaded directly from the checkpoint after engine init
+        # (see VllmInternalWorkerExtension.load_mtp_weights_from_disk).
+        spec_cfg = self.cfg.get("vllm_kwargs", {}).get("speculative_config")
+        self._mtp_load_from_disk: bool = (
+            load_format == "dummy"
+            and spec_cfg is not None
+            and spec_cfg.get("method") in ("deepseek_mtp", "mtp")
+        )
+
         if (
             len(get_nsight_config_if_pattern_matches("vllm_generation_worker")) > 0
             and vllm_kwargs["distributed_executor_backend"] == "ray"
@@ -542,6 +553,10 @@ class VllmGenerationWorkerImpl(BaseVllmGenerationWorker):
 
     def post_init(self):
         self.vllm_device_ids = self.report_device_id()
+        if self._mtp_load_from_disk:
+            self.llm.collective_rpc(
+                "load_mtp_weights_from_disk", args=(self.model_name,)
+            )
 
     def init_collective(
         self,

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -309,10 +309,12 @@ class BaseVllmGenerationWorker:
         # those layers are loaded directly from the checkpoint after engine init
         # (see VllmInternalWorkerExtension.load_mtp_weights_from_disk).
         spec_cfg = self.cfg.get("vllm_kwargs", {}).get("speculative_config")
+        mtp_weights_from_refit = bool(self.cfg.get("_mtp_weights_from_refit"))
         self._mtp_load_from_disk: bool = (
             load_format == "dummy"
             and spec_cfg is not None
             and spec_cfg.get("method") in ("deepseek_mtp", "mtp")
+            and not mtp_weights_from_refit
         )
 
         if (

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -408,6 +408,10 @@ class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
 
     async def post_init_async(self):
         self.vllm_device_ids = await self.report_device_id_async()
+        if self._mtp_load_from_disk:
+            await self.llm.collective_rpc(
+                "load_mtp_weights_from_disk", args=(self.model_name,)
+            )
 
     async def get_reserved_url(self) -> Optional[str]:
         """Return the URL from the reserved socket, available before model loading."""

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -1634,45 +1634,6 @@ def test_setup_auto_enables_skip_reference_policy_logprobs_when_kl_penalty_zero(
     assert master_config.grpo["skip_reference_policy_logprobs_calculation"] is True
 
 
-def test_refit_policy_generation_non_colocated_offloads_and_restores(monkeypatch):
-    from nemo_rl.algorithms import grpo as grpo_mod
-
-    calls = []
-    kv_scales = {"layer_0": 1.0}
-
-    class DummyPolicy:
-        def offload_before_refit(self):
-            calls.append("offload_before_refit")
-
-        def broadcast_weights_for_collective(self, kv_scales=None):
-            calls.append(("broadcast_weights_for_collective", kv_scales))
-            return ["train-ok"]
-
-        def prepare_for_training(self):
-            calls.append("prepare_for_training")
-
-    class DummyGeneration:
-        def update_weights_from_collective(self):
-            calls.append("update_weights_from_collective")
-            return ["inference-ok"]
-
-    monkeypatch.setattr(grpo_mod.ray, "get", lambda x: x)
-
-    grpo_mod.refit_policy_generation(
-        policy=DummyPolicy(),
-        policy_generation=DummyGeneration(),
-        colocated_inference=False,
-        kv_scales=kv_scales,
-    )
-
-    assert calls == [
-        "offload_before_refit",
-        ("broadcast_weights_for_collective", kv_scales),
-        "update_weights_from_collective",
-        "prepare_for_training",
-    ]
-
-
 def test_grpo_train_collects_generation_logger_and_seq_metrics(
     monkeypatch, mock_grpo_components
 ):

--- a/tests/unit/models/generation/test_vllm_backend.py
+++ b/tests/unit/models/generation/test_vllm_backend.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: vllm_backend imports `vllm` eagerly at module top, so it is only imported
+# inside the test bodies (which are marked @pytest.mark.vllm). This keeps the
+# module collectable in the non-vllm unit lane, where these tests are deselected.
+
+import contextlib
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+
+def _write_sharded_checkpoint(model_dir, shards):
+    """Write safetensors shards plus a model.safetensors.index.json.
+
+    Args:
+        model_dir: Directory (pathlib.Path) to write the checkpoint into.
+        shards: Mapping of shard filename -> {weight_name: tensor}.
+    """
+    model_dir.mkdir(parents=True, exist_ok=True)
+    weight_map = {}
+    for shard_name, tensors in shards.items():
+        save_file(tensors, str(model_dir / shard_name))
+        for name in tensors:
+            weight_map[name] = shard_name
+    with open(model_dir / "model.safetensors.index.json", "w") as f:
+        json.dump({"metadata": {}, "weight_map": weight_map}, f)
+
+
+def _make_extension_with_drafter(mtp_start_layer_idx, num_mtp_layers):
+    """Build a VllmInternalWorkerExtension with a mocked drafter and stubbed refit."""
+    from nemo_rl.models.generation.vllm.vllm_backend import (
+        VllmInternalWorkerExtension,
+    )
+
+    ext = VllmInternalWorkerExtension.__new__(VllmInternalWorkerExtension)
+    ext.device = torch.device("cpu")
+    predictor = SimpleNamespace(
+        mtp_start_layer_idx=mtp_start_layer_idx, num_mtp_layers=num_mtp_layers
+    )
+    ext.model_runner = MagicMock()
+    ext.model_runner.drafter.model = SimpleNamespace(model=predictor)
+    # Isolate this test from _load_draft_weights internals.
+    ext._load_draft_weights = MagicMock()
+    return ext
+
+
+def _patch_vllm_postload(monkeypatch):
+    """Stub the vLLM post-load helpers imported inside load_mtp_weights_from_disk."""
+    monkeypatch.setattr(
+        "vllm.config.set_current_vllm_config", lambda cfg: contextlib.nullcontext()
+    )
+    process_weights = MagicMock()
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.utils.process_weights_after_loading",
+        process_weights,
+    )
+    return process_weights
+
+
+@pytest.mark.vllm
+def test_read_mtp_layer_weights_from_checkpoint_filters_and_reads(tmp_path):
+    """Only the requested MTP layer tensors are read, across the shards holding them."""
+    from nemo_rl.models.generation.vllm.vllm_backend import (
+        _read_mtp_layer_weights_from_checkpoint,
+    )
+
+    model_dir = tmp_path / "ckpt"
+    mtp_block = torch.randn(4, 4)
+    mtp_head = torch.randn(2, 4)
+    other_layer = torch.randn(4, 4)
+    embed = torch.randn(8, 4)
+    # MTP layer index is 2; layer 0 and the top-level embed must be ignored.
+    _write_sharded_checkpoint(
+        model_dir,
+        {
+            "model-00001-of-00002.safetensors": {
+                "model.layers.2.mlp.up_proj.weight": mtp_block,  # MTP, shard 1
+                "model.layers.0.mlp.up_proj.weight": other_layer,  # non-MTP, same shard
+            },
+            "model-00002-of-00002.safetensors": {
+                "model.layers.2.shared_head.head.weight": mtp_head,  # MTP, shard 2
+                "model.embed_tokens.weight": embed,  # non-MTP, no layer index
+            },
+        },
+    )
+
+    weights = _read_mtp_layer_weights_from_checkpoint(str(model_dir), {2})
+
+    by_name = dict(weights)
+    assert set(by_name) == {
+        "model.layers.2.mlp.up_proj.weight",
+        "model.layers.2.shared_head.head.weight",
+    }
+    assert torch.equal(by_name["model.layers.2.mlp.up_proj.weight"], mtp_block)
+    assert torch.equal(by_name["model.layers.2.shared_head.head.weight"], mtp_head)
+
+
+@pytest.mark.vllm
+def test_load_mtp_weights_from_disk_loads_only_mtp_layer(tmp_path, monkeypatch):
+    """Success path: only MTP-layer weights are handed to the drafter, then post-loaded."""
+    model_dir = tmp_path / "ckpt"
+    _write_sharded_checkpoint(
+        model_dir,
+        {
+            "model-00001-of-00001.safetensors": {
+                "model.layers.2.mlp.up_proj.weight": torch.randn(4, 4),  # MTP
+                "model.layers.2.embed_tokens.weight": torch.randn(8, 4),  # MTP
+                "model.layers.0.mlp.up_proj.weight": torch.randn(4, 4),  # non-MTP
+                "model.embed_tokens.weight": torch.randn(8, 4),  # non-MTP
+            }
+        },
+    )
+    ext = _make_extension_with_drafter(mtp_start_layer_idx=2, num_mtp_layers=1)
+    process_weights = _patch_vllm_postload(monkeypatch)
+
+    result = ext.load_mtp_weights_from_disk(str(model_dir))
+
+    assert result is True
+    ext._load_draft_weights.assert_called_once()
+    loaded_names = {name for name, _ in ext._load_draft_weights.call_args[0][0]}
+    assert loaded_names == {
+        "model.layers.2.mlp.up_proj.weight",
+        "model.layers.2.embed_tokens.weight",
+    }
+    process_weights.assert_called_once()
+
+
+@pytest.mark.vllm
+def test_load_mtp_weights_from_disk_returns_false_without_drafter(tmp_path):
+    """When vLLM has not built a drafter, the load is skipped (no exception)."""
+    from nemo_rl.models.generation.vllm.vllm_backend import (
+        VllmInternalWorkerExtension,
+    )
+
+    ext = VllmInternalWorkerExtension.__new__(VllmInternalWorkerExtension)
+    ext.device = torch.device("cpu")
+    ext.model_runner = MagicMock()
+    ext.model_runner.drafter = None
+    ext._load_draft_weights = MagicMock()
+
+    assert ext.load_mtp_weights_from_disk(str(tmp_path)) is False
+    ext._load_draft_weights.assert_not_called()
+
+
+@pytest.mark.vllm
+def test_load_mtp_weights_from_disk_raises_when_mtp_weights_missing(
+    tmp_path, monkeypatch
+):
+    """A checkpoint without the MTP layer(s) fails loudly instead of silently."""
+    model_dir = tmp_path / "ckpt"
+    _write_sharded_checkpoint(
+        model_dir,
+        {
+            "model-00001-of-00001.safetensors": {
+                "model.layers.0.mlp.up_proj.weight": torch.randn(4, 4),
+                "model.embed_tokens.weight": torch.randn(8, 4),
+            }
+        },
+    )
+    ext = _make_extension_with_drafter(mtp_start_layer_idx=2, num_mtp_layers=1)
+    _patch_vllm_postload(monkeypatch)
+
+    with pytest.raises(ValueError, match="No MTP layer weights"):
+        ext.load_mtp_weights_from_disk(str(model_dir))
+    ext._load_draft_weights.assert_not_called()

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -469,6 +469,33 @@ def test_configure_generation_config_keeps_dummy_startup_weights_with_draft_refi
     assert configured["vllm_cfg"]["load_format"] == "dummy"
 
 
+@pytest.mark.parametrize("method", ["deepseek_mtp", "mtp"])
+def test_configure_generation_config_keeps_dummy_startup_weights_for_mtp(method):
+    """MTP keeps dummy startup weights even without draft refit.
+
+    The policy weights arrive via refit and only the MTP draft layer is loaded
+    from disk on the worker, so we must not force load_format="auto" (which would
+    read the full base-model checkpoint).
+    """
+    vllm_config = deepcopy(basic_vllm_test_config)
+    vllm_config["vllm_kwargs"] = {
+        "speculative_config": {
+            "method": method,
+            "num_speculative_tokens": 1,
+        }
+    }
+    tokenizer = MagicMock(pad_token_id=0, eos_token_id=1)
+
+    configured = configure_generation_config(
+        vllm_config,
+        tokenizer,
+        is_eval=False,
+        has_refit_draft_weights=False,
+    )
+
+    assert configured["vllm_cfg"]["load_format"] == "dummy"
+
+
 def get_basic_megatron_test_config(
     tp: int = 1,
     pp: int = 1,


### PR DESCRIPTION
# What does this PR do ?

1. Fix the performance regression caused by #2672
2. Enhance the weight loading time when the MTP spec dec is enabled. Mostly targeting for dsv3 recipe update.(#2779)

Without this fix, MTP-enabled dsv3 takes 30-40mins for the model loading to load the entire ~1300 GB models from the storage.  This fix makes the code to follow the `load_format == "dummy"` trick that relies on the refit to fill the model weights and perform the load from storage only for the MTP layers.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
