### PR TITLE
fix: interleave Eagle3 draft QKV into Megatron's per-group layout

### DIFF
--- a/nemo_rl/models/megatron/draft/utils.py
+++ b/nemo_rl/models/megatron/draft/utils.py
@@ -173,6 +173,47 @@ class _EagleModelLayout:
         return {layer.layer_index: layer for layer in self.layers}
 
 
+def _qkv_head_dims(config: TransformerConfig) -> tuple[int, int, int]:
+    """Return ``(num_attention_heads, num_query_groups, head_dim)`` for the qkv weight."""
+    nh = int(config.num_attention_heads)
+    ng = int(getattr(config, "num_query_groups", None) or nh)
+    hd = int(getattr(config, "kv_channels", None) or int(config.hidden_size) // nh)
+    return nh, ng, hd
+
+
+def _interleave_qkv(
+    q: Tensor, k: Tensor, v: Tensor, config: TransformerConfig
+) -> Tensor:
+    """Reorder HF ``[all_q; all_k; all_v]`` into Megatron's interleaved qkv layout.
+
+    Megatron's ``SelfAttention`` reads ``linear_qkv`` per query group as
+    ``[g0: q.. k v | g1: q.. k v | ...]`` (shape ``[num_query_groups,
+    (heads_per_group + 2) * head_dim, in]``), so a naive ``cat([q, k, v])`` is
+    silently mis-read for GQA (``num_query_groups < num_attention_heads``).
+    """
+    nh, ng, hd = _qkv_head_dims(config)
+    r = nh // ng
+    fused = torch.cat(
+        [q.reshape(ng, r * hd, -1), k.reshape(ng, hd, -1), v.reshape(ng, hd, -1)],
+        dim=1,
+    )
+    return fused.reshape(-1, q.shape[1]).contiguous()
+
+
+def _deinterleave_qkv(
+    fused: Tensor, config: TransformerConfig
+) -> tuple[Tensor, Tensor, Tensor]:
+    """Inverse of :func:`_interleave_qkv`: recover HF ``(q, k, v)`` projections."""
+    nh, ng, hd = _qkv_head_dims(config)
+    r = nh // ng
+    g = fused.reshape(ng, (r + 2) * hd, -1)
+    return (
+        g[:, : r * hd].reshape(nh * hd, -1).contiguous(),
+        g[:, r * hd : (r + 1) * hd].reshape(ng * hd, -1).contiguous(),
+        g[:, (r + 1) * hd :].reshape(ng * hd, -1).contiguous(),
+    )
+
+
 def _combine_or_shard_weight_parts(
     *,
     parameter_name: str,
@@ -253,17 +294,27 @@ class _PendingLayerWeights:
         layer: _EagleLayerLayout,
         model_state: Mapping[str, Tensor],
         tp_rank: int,
+        config: TransformerConfig,
     ) -> None:
-        qkv_weight = _combine_or_shard_weight_parts(
-            parameter_name=layer.qkv_weight_key,
-            fused_weight=self.qkv_weight,
-            component_weights=(self.q_weight, self.k_weight, self.v_weight),
-            target=model_state.get(layer.qkv_weight_key),
-            tp_rank=tp_rank,
-            incomplete_error=(
+        if self.qkv_weight is not None:
+            # Pre-fused checkpoint qkv is assumed to already be Megatron-interleaved.
+            qkv_weight: Tensor | None = self.qkv_weight
+        elif (
+            self.q_weight is not None
+            and self.k_weight is not None
+            and self.v_weight is not None
+        ):
+            # Separate HF q/k/v are head-major; reorder to Megatron's interleaved
+            # layout (_shard_to_local_tp applies the dim-0 TP chunk afterwards).
+            qkv_weight = _interleave_qkv(
+                self.q_weight, self.k_weight, self.v_weight, config
+            )
+        elif self.q_weight is None and self.k_weight is None and self.v_weight is None:
+            qkv_weight = None
+        else:
+            raise RuntimeError(
                 "[draft] Incomplete QKV tensors. Expected q_proj, k_proj, and v_proj."
-            ),
-        )
+            )
         if qkv_weight is not None:
             mapped_state[layer.qkv_weight_key] = qkv_weight
 
@@ -310,38 +361,22 @@ def _all_gather_tp_shards(local_weight: Tensor) -> list[Tensor]:
 
 def _gather_tp_qkv_weight(
     local_fused_weight: Tensor,
-    q_dim: int,
-    kv_dim: int,
+    config: TransformerConfig,
 ) -> tuple[Tensor, Tensor, Tensor]:
+    """Gather TP shards of the Megatron fused qkv weight and split into HF q/k/v.
+
+    Each TP rank owns a contiguous, group-aligned dim-0 chunk, so all-gathering
+    and concatenating in rank order reconstructs the full interleaved weight,
+    which is de-interleaved back into HF ``(q, k, v)`` (inverse of the load-time
+    :func:`_interleave_qkv`).
+    """
     shards = _all_gather_tp_shards(local_fused_weight)
-    if len(shards) == 1 and local_fused_weight.shape[0] == q_dim + 2 * kv_dim:
-        return local_fused_weight.split([q_dim, kv_dim, kv_dim], dim=0)
-
-    tp_world_size = len(shards)
-    if q_dim % tp_world_size != 0 or kv_dim % tp_world_size != 0:
-        raise RuntimeError(
-            "QKV dimensions are not divisible by the tensor-parallel world size."
-        )
-
-    q_shards = []
-    k_shards = []
-    v_shards = []
-    local_q_dim = q_dim // tp_world_size
-    local_kv_dim = kv_dim // tp_world_size
-    for shard in shards:
-        q_local, k_local, v_local = shard.split(
-            [local_q_dim, local_kv_dim, local_kv_dim],
-            dim=0,
-        )
-        q_shards.append(q_local)
-        k_shards.append(k_local)
-        v_shards.append(v_local)
-
-    return (
-        torch.cat(q_shards, dim=0).contiguous(),
-        torch.cat(k_shards, dim=0).contiguous(),
-        torch.cat(v_shards, dim=0).contiguous(),
+    full_fused = (
+        local_fused_weight
+        if len(shards) == 1
+        else torch.cat(shards, dim=0).contiguous()
     )
+    return _deinterleave_qkv(full_fused, config)
 
 
 def _gather_tp_gate_up_weight(
@@ -809,6 +844,7 @@ def _map_hf_state_to_eagle_state(
     model_state: Mapping[str, Tensor],
     layout: _EagleModelLayout,
     checkpoint_source: str,
+    config: TransformerConfig,
 ) -> StateDict:
     mapped_state: StateDict = {}
     pending_weights_by_layer = {
@@ -872,6 +908,7 @@ def _map_hf_state_to_eagle_state(
             layer,
             model_state=model_state,
             tp_rank=tp_rank,
+            config=config,
         )
 
     if not mapped_state:
@@ -911,6 +948,7 @@ def load_hf_weights_to_eagle(
         model_state=model_state,
         layout=layout,
         checkpoint_source=model_name,
+        config=unwrap_model(model).config,
     )
 
     return model.load_state_dict(new_state, strict=False)
@@ -955,8 +993,7 @@ def _export_layer_weights_to_hf(
     *,
     source_state: Mapping[str, Tensor],
     layer: _EagleLayerLayout,
-    q_dim: int,
-    kv_dim: int,
+    config: TransformerConfig,
     hidden_size: int,
     ffn_hidden_size: int,
 ) -> list[tuple[str, Tensor]]:
@@ -981,8 +1018,7 @@ def _export_layer_weights_to_hf(
 
     q_proj, k_proj, v_proj = _gather_tp_qkv_weight(
         _require_state_tensor(source_state, layer.qkv_weight_key),
-        q_dim=q_dim,
-        kv_dim=kv_dim,
+        config=config,
     )
     hf_state.append((f"{layer_prefix}.self_attn.q_proj.weight", q_proj))
     hf_state.append((f"{layer_prefix}.self_attn.k_proj.weight", k_proj))
@@ -1029,8 +1065,6 @@ def export_eagle_weights_to_hf(
     config = unwrapped_model.config
     layout = _EagleModelLayout.detect(source_state)
 
-    q_dim = config.num_attention_heads * config.kv_channels
-    kv_dim = config.num_query_groups * config.kv_channels
     ffn_hidden_size = config.ffn_hidden_size
     num_aux_hidden_states = _get_num_aux_hidden_states(config)
 
@@ -1049,8 +1083,7 @@ def export_eagle_weights_to_hf(
             _export_layer_weights_to_hf(
                 source_state=source_state,
                 layer=layer,
-                q_dim=q_dim,
-                kv_dim=kv_dim,
+                config=config,
                 hidden_size=config.hidden_size,
                 ffn_hidden_size=ffn_hidden_size,
             )

--- a/tests/unit/models/megatron/test_eagle_qkv_layout.py
+++ b/tests/unit/models/megatron/test_eagle_qkv_layout.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Eagle draft QKV weight layout tests.
+
+Megatron's ``SelfAttention.get_query_key_value_tensors`` interprets
+``linear_qkv.weight`` as an *interleaved* per-query-group layout
+(``[g0: q.. k v | g1: q.. k v | ...]``). Loading an HF Eagle3 checkpoint
+(separate head-major ``q_proj``/``k_proj``/``v_proj``) must reorder into this
+layout, and export must reverse it. A naive ``cat([q, k, v])`` is silently
+mis-read for GQA models (``num_query_groups < num_attention_heads``), so the
+trainer-side draft attention diverges from the HF/vLLM-side attention: draft
+training loss decreases while speculative-decoding acceptance degrades.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from nemo_rl.models.megatron.draft.utils import (
+    _deinterleave_qkv,
+    _EagleModelLayout,
+    _interleave_qkv,
+    _map_hf_state_to_eagle_state,
+)
+
+
+def _cfg(n_heads, n_kv, head_dim):
+    return SimpleNamespace(
+        num_attention_heads=n_heads,
+        num_query_groups=n_kv,
+        kv_channels=head_dim,
+        hidden_size=n_heads * head_dim,
+    )
+
+
+def _megatron_split_reference(fused, n_heads, n_kv, head_dim):
+    """Independent re-implementation of the q/k/v split Megatron's SelfAttention
+    performs on ``linear_qkv`` (megatron/core/transformer/attention.py): view the
+    row dim as ``[num_query_groups, (heads_per_group + 2) * head_dim]`` and slice
+    q/k/v within each group. Deliberately not expressed via the production helpers.
+    """
+    r = n_heads // n_kv
+    in_dim = fused.shape[1]
+    g = fused.reshape(n_kv, (r + 2) * head_dim, in_dim)
+    q = g[:, : r * head_dim, :].reshape(n_heads * head_dim, in_dim)
+    k = g[:, r * head_dim : (r + 1) * head_dim, :].reshape(n_kv * head_dim, in_dim)
+    v = g[:, (r + 1) * head_dim :, :].reshape(n_kv * head_dim, in_dim)
+    return q, k, v
+
+
+def _head_identifiable(n, head_dim, in_dim, base):
+    """[n*head_dim, in_dim] where every row of head h holds the value base+h."""
+    w = torch.empty(n * head_dim, in_dim, dtype=torch.float32)
+    for h in range(n):
+        w[h * head_dim : (h + 1) * head_dim] = float(base + h)
+    return w
+
+
+# GQA (the bug-triggering case) and MHA (must keep working).
+_CONFIGS = [
+    pytest.param(4, 2, 8, 16, id="gqa-4h-2kv"),
+    pytest.param(16, 8, 8, 16, id="gqa-16h-8kv"),
+    pytest.param(4, 4, 8, 16, id="mha-4h-4kv"),
+]
+
+
+@pytest.mark.mcore
+@pytest.mark.parametrize("n_heads,n_kv,head_dim,in_dim", _CONFIGS)
+def test_interleave_is_read_correctly_by_megatron_split(
+    n_heads, n_kv, head_dim, in_dim
+):
+    """Interleaved layout must round-trip through Megatron's split contract."""
+    cfg = _cfg(n_heads, n_kv, head_dim)
+    q = _head_identifiable(n_heads, head_dim, in_dim, base=100.0)
+    k = _head_identifiable(n_kv, head_dim, in_dim, base=200.0)
+    v = _head_identifiable(n_kv, head_dim, in_dim, base=300.0)
+
+    fused = _interleave_qkv(q, k, v, cfg)
+    assert fused.shape == (n_heads * head_dim + 2 * n_kv * head_dim, in_dim)
+
+    rq, rk, rv = _megatron_split_reference(fused, n_heads, n_kv, head_dim)
+    assert torch.equal(rq, q), "Megatron would not recover q_proj from loaded qkv"
+    assert torch.equal(rk, k), "Megatron would not recover k_proj from loaded qkv"
+    assert torch.equal(rv, v), "Megatron would not recover v_proj from loaded qkv"
+
+
+@pytest.mark.mcore
+def test_naive_cat_is_misread_for_gqa():
+    """Guards the test's relevance: the old naive cat is wrong for GQA."""
+    n_heads, n_kv, head_dim, in_dim = 4, 2, 8, 16
+    q = _head_identifiable(n_heads, head_dim, in_dim, base=100.0)
+    k = _head_identifiable(n_kv, head_dim, in_dim, base=200.0)
+    v = _head_identifiable(n_kv, head_dim, in_dim, base=300.0)
+
+    naive = torch.cat([q, k, v], dim=0)
+    rq, rk, rv = _megatron_split_reference(naive, n_heads, n_kv, head_dim)
+    # For GQA, Megatron grabs query rows where it expects key/value rows.
+    assert not (torch.equal(rq, q) and torch.equal(rk, k) and torch.equal(rv, v))
+
+
+@pytest.mark.mcore
+@pytest.mark.parametrize("n_heads,n_kv,head_dim,in_dim", _CONFIGS)
+def test_interleave_deinterleave_roundtrip(n_heads, n_kv, head_dim, in_dim):
+    cfg = _cfg(n_heads, n_kv, head_dim)
+    q = torch.randn(n_heads * head_dim, in_dim)
+    k = torch.randn(n_kv * head_dim, in_dim)
+    v = torch.randn(n_kv * head_dim, in_dim)
+    rq, rk, rv = _deinterleave_qkv(_interleave_qkv(q, k, v, cfg), cfg)
+    assert torch.equal(rq, q)
+    assert torch.equal(rk, k)
+    assert torch.equal(rv, v)
+
+
+@pytest.mark.mcore
+def test_load_maps_hf_qkv_to_megatron_interleaved_layout():
+    """End-to-end load: _map_hf_state_to_eagle_state must store linear_qkv in the
+    interleaved layout Megatron reads, for a GQA Eagle3 checkpoint."""
+    n_heads, n_kv, head_dim, in_dim = 16, 8, 8, 16  # GQA, eagle3-like
+    cfg = _cfg(n_heads, n_kv, head_dim)
+    q_dim, kv_dim = n_heads * head_dim, n_kv * head_dim
+
+    qkv_key = "eagle_module.decoder.layers.0.self_attention.linear_qkv.weight"
+    model_state = {qkv_key: torch.zeros(q_dim + 2 * kv_dim, in_dim)}  # single TP rank
+    layout = _EagleModelLayout.detect(model_state)
+
+    q = _head_identifiable(n_heads, head_dim, in_dim, base=1000.0)
+    k = _head_identifiable(n_kv, head_dim, in_dim, base=2000.0)
+    v = _head_identifiable(n_kv, head_dim, in_dim, base=3000.0)
+    hf_state = {
+        "midlayer.self_attn.q_proj.weight": q,
+        "midlayer.self_attn.k_proj.weight": k,
+        "midlayer.self_attn.v_proj.weight": v,
+    }
+
+    mapped = _map_hf_state_to_eagle_state(
+        hf_state_dict=hf_state,
+        model_state=model_state,
+        layout=layout,
+        checkpoint_source="unit-test",
+        config=cfg,
+    )
+
+    loaded_qkv = mapped[qkv_key]
+    assert loaded_qkv.shape == (q_dim + 2 * kv_dim, in_dim)
+    rq, rk, rv = _megatron_split_reference(loaded_qkv, n_heads, n_kv, head_dim)
+    assert torch.equal(rq, q), "loaded qkv mis-routes query heads for GQA"
+    assert torch.equal(rk, k), "loaded qkv mis-routes key heads for GQA"
+    assert torch.equal(rv, v), "loaded qkv mis-routes value heads for GQA"


### PR DESCRIPTION
# What does this PR do ?

Fixes a QKV weight-layout bug in the Eagle3 online draft path: online draft training degraded /
stalled speculative-decoding acceptance even though the draft loss was decreasing. After this
change, acceptance tracks the draft loss as expected.

**Root cause.** `load_hf_weights_to_eagle` / `export_eagle_weights_to_hf` fuse the draft's
attention projections with a naive `cat([q, k, v])` (head-major), but Megatron's
`SelfAttention.get_query_key_value_tensors` reads `linear_qkv` as an **interleaved
per-query-group** layout (`[g0: q.. k v | g1: q.. k v | ...]`). For GQA models (e.g. Qwen3-1.7B:
16 query heads / 8 KV heads) these layouts differ, so the trainer-side draft attention is fed
scrambled q/k/v.

**Fix.** Reorder HF q/k/v into Megatron's interleaved layout on load (`_interleave_qkv`) and
reverse it on export (`_deinterleave_qkv`). `o_proj`, MLP gate/up, and MHA paths are unaffected;
for an untrained draft the exported weights are byte-identical to before (no change to the frozen
path).

# Issues

N/A — bug in the existing Eagle3 online draft path; no tracking issue.

# Usage

No usage change. Existing Eagle3 online recipes
(`examples/configs/recipes/llm/grpo-qwen3-1.7b-1n{4,8}g-megatron-eagle3.yaml`) work as before; the
draft just trains correctly now.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? — `tests/unit/models/megatron/test_eagle_qkv_layout.py`
- [x] Did you run the unit tests and functional tests locally? — unit tests pass (`-m mcore`); validated end-to-end with a 300-step online GRPO A/B
- [x] Did you add or update any necessary documentation? — N/A (bugfix to existing feature; no doc change needed)

# Additional Information

**Validation.**

Unit test (`test_eagle_qkv_layout.py`): asserts the loaded weight satisfies Megatron's q/k/v split
contract, the load↔export round-trip, and both GQA and MHA configs.

End-to-end 300-step online GRPO A/B (Qwen3-1.7B + `AngelSlim/Qwen3-1.7B_eagle3`, 4×H100):

| | acceptance length (first→last) | draft loss |
|---|---|---|
| **Fixed (interleaved)** | **1.94 → 2.53 (+30%)**, plateau ~2.52 | 1.69 → 0.87 |
| **Buggy (naive-cat)** | flat ~1.88 | 8.5 → 3.0 |

<img width="2022" height="1062" alt="W B Chart 6_12_2026, 4_03_37 PM" src="https://github.com/user-attachments/assets/555d1153-5051-4a70-8561-fdc1cd8af7a0" />
<img width="2022" height="1062" alt="W B Chart 6_12_2026, 4_03_43 PM" src="https://github.com/user-attachments/assets/c168d93f-f6c2-4bbb-9234-5ed71cb5a2ce" />