### PR TITLE
fix: Preserve quant worker hook overrides during fp8 setup

### DIFF
--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -379,7 +379,7 @@ class MegatronPolicyWorkerImpl(
     def _disable_forward_pre_hook_until_next_train_step(self) -> None:
         assert isinstance(self.model, DistributedDataParallel)
         if self._forward_pre_hook_enabled():
-            self.model.disable_forward_pre_hook(param_sync=False)
+            self.disable_forward_pre_hook(param_sync=False)
         model_config = get_model_config(self.model)
         self._first_train_step_param_sync_func = model_config.param_sync_func
         model_config.param_sync_func = None

--- a/tests/functional/L1_Functional_Tests_Megatron_3.sh
+++ b/tests/functional/L1_Functional_Tests_Megatron_3.sh
@@ -35,7 +35,7 @@ run_test() {
 }
 
 run_test      uv run --no-sync bash ./tests/functional/distillation_megatron.sh
-run_test      uv run --no-sync bash ./tests/functional/qa_distillation_megatron.sh
+run_test fast uv run --no-sync bash ./tests/functional/qa_distillation_megatron.sh
 run_test      uv run --no-sync bash ./tests/functional/dpo_megatron.sh
 run_test      uv run --no-sync bash ./tests/functional/sft_megatron.sh
 

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -16,6 +16,7 @@ import os
 import tempfile
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Optional
 
 import numpy as np
@@ -88,29 +89,46 @@ def test_disable_forward_pre_hook_until_next_step_uses_worker_override():
         and node.name == "_disable_forward_pre_hook_until_next_train_step"
     )
 
-    worker_disable_calls = [
-        node
-        for node in ast.walk(method)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "disable_forward_pre_hook"
-        and isinstance(node.func.value, ast.Name)
-        and node.func.value.id == "self"
-    ]
-    raw_ddp_disable_calls = [
-        node
-        for node in ast.walk(method)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "disable_forward_pre_hook"
-        and isinstance(node.func.value, ast.Attribute)
-        and node.func.value.attr == "model"
-        and isinstance(node.func.value.value, ast.Name)
-        and node.func.value.value.id == "self"
-    ]
+    class_kwargs = {
+        "name": "_Worker",
+        "bases": [],
+        "keywords": [],
+        "body": [method],
+        "decorator_list": [],
+    }
+    if "type_params" in ast.ClassDef._fields:
+        class_kwargs["type_params"] = []
+    test_module = ast.Module(
+        body=[ast.ClassDef(**class_kwargs)],
+        type_ignores=[],
+    )
+    ast.fix_missing_locations(test_module)
 
-    assert len(worker_disable_calls) == 1
-    assert raw_ddp_disable_calls == []
+    class FakeDDP:
+        def disable_forward_pre_hook(self, param_sync=True):
+            raise AssertionError("raw DDP hook disable should not be called directly")
+
+    model_config = SimpleNamespace(param_sync_func="sync")
+    namespace = {
+        "DistributedDataParallel": FakeDDP,
+        "get_model_config": lambda _: model_config,
+    }
+    exec(compile(test_module, str(source_path), "exec"), namespace)
+
+    worker = namespace["_Worker"]()
+    worker.model = FakeDDP()
+    worker._forward_pre_hook_enabled = lambda: True
+    disable_calls = []
+    worker.disable_forward_pre_hook = lambda param_sync=True: disable_calls.append(
+        param_sync
+    )
+
+    worker._disable_forward_pre_hook_until_next_train_step()
+
+    assert disable_calls == [False]
+    assert worker._first_train_step_param_sync_func == "sync"
+    assert model_config.param_sync_func is None
+    assert worker._first_train_step_forward_pre_hook_disabled is True
 
 
 def create_megatron_test_config(

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -11,9 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import ast
 import os
 import tempfile
 import time
+from pathlib import Path
 from typing import Optional
 
 import numpy as np
@@ -68,6 +70,47 @@ def test_megatron_prepare_for_training_restores_optimizer():
 
     assert model.train_called
     assert restored_devices == ["cuda"]
+
+
+def test_disable_forward_pre_hook_until_next_step_uses_worker_override():
+    source_path = (
+        Path(__file__).parents[4]
+        / "nemo_rl/models/policy/workers/megatron_policy_worker.py"
+    )
+    tree = ast.parse(source_path.read_text())
+    method = next(
+        node
+        for class_node in tree.body
+        if isinstance(class_node, ast.ClassDef)
+        and class_node.name == "MegatronPolicyWorkerImpl"
+        for node in class_node.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_disable_forward_pre_hook_until_next_train_step"
+    )
+
+    worker_disable_calls = [
+        node
+        for node in ast.walk(method)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "disable_forward_pre_hook"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "self"
+    ]
+    raw_ddp_disable_calls = [
+        node
+        for node in ast.walk(method)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "disable_forward_pre_hook"
+        and isinstance(node.func.value, ast.Attribute)
+        and node.func.value.attr == "model"
+        and isinstance(node.func.value.value, ast.Name)
+        and node.func.value.value.id == "self"
+    ]
+
+    assert len(worker_disable_calls) == 1
+    assert raw_ddp_disable_calls == []
 
 
 def create_megatron_test_config(


### PR DESCRIPTION
# What does this PR do ?

Fix the issue by #2633, The fp8_params initialization path disabled Megatron DDP forward pre-hooks by calling the raw DDP method directly. ModelOpt quant workers already override the worker-level hook toggles to hide TensorQuantizer modules from DDP module iteration, so the raw call bypassed that protection and exposed TensorQuantizer(disabled) entries that had no registered hook handle.

We didn't have any QARL test in CI Lfast, I moved the small QA-distill to fast, so people won't miss QARL things next time.

# Issues
closes https://github.com/NVIDIA-NeMo/RL/issues/2805

# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
