### PR TITLE
feat: full Kubernetes multi-node support (Kubeflow PyTorchJob + KubeRay)

### DIFF
--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -182,6 +182,16 @@ sbatch ray.sub \
 
 This guide outlines the process of migrating NemoRL training jobs from a Slurm environment to a Kubernetes cluster utilizing Ray orchestration and NVIDIA GPUs.
 
+Two entrypoint patterns are supported. Choose based on which Kubernetes operator your cluster uses:
+
+| Pattern | Operator | Script |
+|---|---|---|
+| [KubeRay RayCluster / RayJob](#kubernetesk8s-entry) | KubeRay | `k8s_entry.sh` or direct `uv run` |
+| [KubeFlow PyTorchJob](#kubeflow-pytorchjob) | kubeflow/training-operator | `k8s_entry.sh` |
+
+`k8s_entry.sh` (repo root) auto-detects which pattern applies and takes the
+appropriate role. It is the Kubernetes equivalent of `ray.sub` for Slurm.
+
 ---
 
 ## Prerequisites
@@ -525,6 +535,110 @@ logger:
 ### 5. Monitoring
 * **Console:** Watch job progress directly in the terminal where you ran `uv run`.
 * **WandB:** If enabled, check the Weights & Biases web interface.
+
+---
+
+(kubernetesk8s-entry)=
+## Using k8s_entry.sh
+
+`k8s_entry.sh` is a single entrypoint script that handles both KubeRay and
+PyTorchJob environments.  It auto-detects which mode applies:
+
+* **KubeRay** — Ray is already running (detected via `RAY_ADDRESS` or a live
+  `ray status`).  The script skips cluster setup and executes the training
+  command with `ray.init(address="auto")`.
+* **PyTorchJob** — `RANK` and `MASTER_ADDR` are present (injected by the
+  kubeflow/training-operator).  The script sets up Ray across all pods and
+  runs the training command on rank 0.
+
+### KubeRay RayJob example
+
+Use `k8s_entry.sh` as the `spec.entrypoint` of a `RayJob`, or simply run
+`uv run` directly — both work because Ray is already set up by KubeRay:
+
+```yaml
+# RayJob spec (excerpt)
+spec:
+  entrypoint: >
+    bash /opt/nemo-rl/k8s_entry.sh
+    uv run --locked examples/run_grpo.py
+    --config examples/configs/grpo_math_1B.yaml
+    cluster.num_nodes=2
+```
+
+Alternatively, skip `k8s_entry.sh` entirely and call `uv run` directly in
+`spec.entrypoint` — the result is identical because KubeRay already owns
+the cluster lifecycle.
+
+(kubeflow-pytorchjob)=
+## KubeFlow PyTorchJob
+
+> [!NOTE]
+> The [KubeFlow training-operator](https://github.com/kubeflow/training-operator)
+> must be installed on your cluster to use this pattern.
+
+In a PyTorchJob every pod runs the **same** container command.  The operator
+injects `RANK`, `MASTER_ADDR`, and `WORLD_SIZE` into each pod, which is
+exactly what `k8s_entry.sh` uses to assign roles:
+
+* **Rank 0 (Master replica):** starts the Ray head, waits for all workers to
+  join, runs the training command, then calls `ray stop` to signal shutdown.
+* **Rank N (Worker replicas):** connect to the Ray cluster and block until the
+  head stops, then exit with code 0 so the job reports success.
+
+### Example manifest
+
+A ready-to-run manifest is provided at
+[`infra/examples/pytorchjob-grpo.yaml`](https://github.com/NVIDIA-NeMo/RL/blob/main/infra/examples/pytorchjob-grpo.yaml).
+Both replicas run the identical command — `k8s_entry.sh` uses `RANK` to decide
+whether a pod is the Ray head (rank 0) or a worker. Set `Worker.replicas` to
+`num_nodes - 1` and update the image / PVC to match your cluster:
+
+```yaml
+# infra/examples/pytorchjob-grpo.yaml (excerpt)
+command: ["bash", "-c"]
+args:
+  - |
+    bash k8s_entry.sh uv run --locked examples/run_grpo.py \
+      --config examples/configs/grpo_math_1B.yaml \
+      cluster.num_nodes=${WORLD_SIZE} cluster.gpus_per_node=${GPUS_PER_NODE}
+```
+
+**Apply and monitor:**
+
+```bash
+kubectl apply -f infra/examples/pytorchjob-grpo.yaml
+
+# Watch pod status
+kubectl get pods -l training.kubeflow.org/job-name=grpo-job -w
+
+# Stream driver logs from the Master pod
+kubectl logs -f -l training.kubeflow.org/replica-type=master
+```
+
+### PyTorchJob environment variables
+
+All variables from the [Slurm environment table](#slurm-environment-variables)
+that control Ray ports and resources apply to the PyTorchJob path as well.
+The most commonly overridden ones are:
+
+``````{list-table}
+:header-rows: 1
+
+* - Variable (default)
+  - Description
+* - `GPUS_PER_NODE=8`
+  - GPUs per node reported to Ray as `worker_units`. Match your node shape.
+* - `RAY_PORT=6379`
+  - Ray GCS port. Change if 6379 is in use.
+* - `COMMAND`
+  - Training command string. Equivalent to passing positional args.
+``````
+
+> [!TIP]
+> The NeMo-RL config option `cluster.num_nodes` must equal the total number
+> of pods (Master + Worker replicas).  For the example above (1 Master + 1 Worker)
+> set `cluster.num_nodes=2`.
 
 ---
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -55,6 +55,8 @@ kubectl apply -f ../examples/endpoint-registry-rbac.yaml
 kubectl apply -f ../examples/rayjob-monolithic.yaml      # single-cluster RayJob
 kubectl apply -f ../examples/disagg-rayclusters.yaml      # disagg via KubeRay
 kubectl apply -f ../examples/disagg-jobset.yaml           # disagg via JobSet
+kubectl apply -f ../examples/rayjob-grpo.yaml             # GRPO via KubeRay + k8s_entry.sh
+kubectl apply -f ../examples/pytorchjob-grpo.yaml         # GRPO via Kubeflow PyTorchJob + k8s_entry.sh
 ```
 
 ### Testing locally with kind
@@ -175,6 +177,8 @@ infra/
 │       └── kuberay-operator.yaml
 ├── examples/                          # Workload examples
 │   ├── rayjob-monolithic.yaml        # Single-cluster RayJob (1 GPU)
+│   ├── rayjob-grpo.yaml              # GRPO via KubeRay + k8s_entry.sh
+│   ├── pytorchjob-grpo.yaml          # GRPO via Kubeflow PyTorchJob + k8s_entry.sh
 │   ├── disagg-rayclusters.yaml       # Disagg RL + Gym via KubeRay RayClusters
 │   ├── disagg-jobset.yaml            # Disagg RL + Gym via JobSet (no KubeRay)
 │   ├── endpoint-registry-rbac.yaml   # RBAC for ConfigMap service discovery

--- a/infra/examples/pytorchjob-grpo.yaml
+++ b/infra/examples/pytorchjob-grpo.yaml
@@ -1,0 +1,91 @@
+# Kubeflow PyTorchJob example for NeMo RL using k8s_entry.sh.
+#
+# The PyTorchJob is used purely as a gang-scheduled pod group + rendezvous: the
+# training-operator injects RANK / WORLD_SIZE / MASTER_ADDR / MASTER_PORT into
+# every pod, and k8s_entry.sh turns that into a Ray cluster (rank 0 == head). No
+# torchrun is involved -- every pod runs the same command and the script uses
+# RANK to decide head vs. worker.
+#
+# Prerequisites:
+#   - Kubeflow training-operator installed (provides the PyTorchJob CRD).
+#   - A NeMo RL image and a shared PVC (here: rl-workspace) mounted at /workspace.
+#   - For multi-node NCCL you typically also want hostNetwork / RDMA tuning;
+#     omitted here for clarity.
+#
+# Usage:
+#   kubectl apply -f pytorchjob-grpo.yaml
+#   kubectl get pytorchjob grpo-job -w
+#   kubectl logs -f grpo-job-master-0
+apiVersion: "kubeflow.org/v1"
+kind: PyTorchJob
+metadata:
+  name: grpo-job
+spec:
+  # PyTorchJob sets RANK=0 on Master and RANK=1.. on Workers, plus a shared
+  # WORLD_SIZE / MASTER_ADDR / MASTER_PORT. k8s_entry.sh reads these directly.
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        spec:
+          imagePullSecrets:
+          - name: nvcr-secret
+          containers:
+          - name: pytorch
+            image: nvcr.io/nvidian/nemo-rl:nightly
+            command: ["/bin/bash", "-c"]
+            args:
+            - |
+              cd /opt/nemo-rl
+              export GPUS_PER_NODE=8
+              # The training command is passed as positional args; k8s_entry.sh
+              # runs it on rank 0 and treats other ranks as Ray workers.
+              bash k8s_entry.sh uv run --locked examples/run_grpo.py \
+                --config examples/configs/grpo_math_1B.yaml \
+                cluster.num_nodes=${WORLD_SIZE} \
+                cluster.gpus_per_node=${GPUS_PER_NODE}
+            resources:
+              limits:
+                nvidia.com/gpu: 8
+            volumeMounts:
+            - { name: rl-workspace, mountPath: /workspace }
+            - { name: dshm, mountPath: /dev/shm }
+          volumes:
+          - name: rl-workspace
+            persistentVolumeClaim: { claimName: rl-workspace }
+          - name: dshm
+            emptyDir: { medium: Memory }
+    Worker:
+      replicas: 1   # total nodes = 1 (master) + replicas
+      restartPolicy: Never
+      template:
+        spec:
+          imagePullSecrets:
+          - name: nvcr-secret
+          containers:
+          - name: pytorch
+            image: nvcr.io/nvidian/nemo-rl:nightly
+            command: ["/bin/bash", "-c"]
+            args:
+            - |
+              cd /opt/nemo-rl
+              export GPUS_PER_NODE=8
+              # Workers run the same command; k8s_entry.sh sees RANK > 0 and
+              # joins the cluster as a Ray worker (training args are ignored off
+              # rank 0).
+              bash k8s_entry.sh uv run --locked examples/run_grpo.py \
+                --config examples/configs/grpo_math_1B.yaml \
+                cluster.num_nodes=${WORLD_SIZE} \
+                cluster.gpus_per_node=${GPUS_PER_NODE}
+            resources:
+              limits:
+                nvidia.com/gpu: 8
+            volumeMounts:
+            - { name: rl-workspace, mountPath: /workspace }
+            - { name: dshm, mountPath: /dev/shm }
+          volumes:
+          - name: rl-workspace
+            persistentVolumeClaim: { claimName: rl-workspace }
+          - name: dshm
+            emptyDir: { medium: Memory }

--- a/infra/examples/rayjob-grpo.yaml
+++ b/infra/examples/rayjob-grpo.yaml
@@ -1,0 +1,89 @@
+
+# KubeRay RayJob example for NeMo RL using k8s_entry.sh as the entrypoint.
+#
+# Here KubeRay owns the Ray cluster bringup (head + workers). k8s_entry.sh
+# detects the already-running cluster (KUBERAY_GEN_RAY_START_CMD is set on
+# KubeRay pods) and therefore does NOT start a second Ray instance -- it just
+# runs the training command as the driver. You may also skip k8s_entry.sh and
+# call `uv run ...` directly here, since KubeRay already owns the cluster
+# lifecycle. This is the recommended path when you want KubeRay to manage
+# autoscaling, restarts, and teardown for you.
+
+#
+# Prerequisites:
+#   - KubeRay operator installed (provides the RayJob / RayCluster CRDs).
+#   - A NeMo RL image and a shared PVC (here: rl-workspace) mounted at /workspace.
+#
+# Usage:
+#   kubectl apply -f rayjob-grpo.yaml
+#   kubectl get rayjob grpo-rayjob -w
+
+apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: grpo-rayjob
+spec:
+  # k8s_entry.sh sees the KubeRay-managed cluster and only runs the driver.
+  entrypoint: >-
+    bash /opt/nemo-rl/k8s_entry.sh
+    uv run --locked examples/run_grpo.py
+    --config examples/configs/grpo_math_1B.yaml
+    cluster.num_nodes=2 cluster.gpus_per_node=8
+
+  submissionMode: HTTPMode
+  shutdownAfterJobFinishes: true
+  ttlSecondsAfterFinished: 60
+  rayClusterSpec:
+    rayVersion: "2.52.0"
+    headGroupSpec:
+      rayStartParams:
+        dashboard-host: "0.0.0.0"
+      template:
+        spec:
+          imagePullSecrets:
+          - name: nvcr-secret
+          containers:
+          - name: ray-head
+            image: nvcr.io/nvidian/nemo-rl:nightly
+            resources:
+              requests: { cpu: "2", memory: "8Gi" }
+              limits:   { cpu: "8", memory: "32Gi" }
+            ports:
+            - { containerPort: 6379, name: gcs-server }
+            - { containerPort: 8265, name: dashboard }
+            - { containerPort: 10001, name: client }
+            volumeMounts:
+            - { name: rl-workspace, mountPath: /workspace }
+            - { name: dshm, mountPath: /dev/shm }
+          volumes:
+          - name: rl-workspace
+            persistentVolumeClaim: { claimName: rl-workspace }
+          - name: dshm
+            emptyDir: { medium: Memory }
+    workerGroupSpecs:
+    - groupName: gpu-workers
+      replicas: 2
+      minReplicas: 2
+      maxReplicas: 2
+      rayStartParams:
+        # Advertise the worker_units tag init_ray() expects (one per GPU).
+        num-gpus: "8"
+        resources: '{"worker_units": 8, "slurm_managed_ray_cluster": 1}'
+      template:
+        spec:
+          imagePullSecrets:
+          - name: nvcr-secret
+          containers:
+          - name: ray-worker
+            image: nvcr.io/nvidian/nemo-rl:nightly
+            resources:
+              requests: { cpu: "32", memory: "200Gi", nvidia.com/gpu: "8" }
+              limits:   { cpu: "128", memory: "800Gi", nvidia.com/gpu: "8" }
+            volumeMounts:
+            - { name: rl-workspace, mountPath: /workspace }
+            - { name: dshm, mountPath: /dev/shm }
+          volumes:
+          - name: rl-workspace
+            persistentVolumeClaim: { claimName: rl-workspace }
+          - name: dshm
+            emptyDir: { medium: Memory }

--- a/k8s_entry.sh
+++ b/k8s_entry.sh
@@ -1,0 +1,359 @@
+#!/bin/bash
+
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# =============================================================================
+# k8s_entry.sh - In-container Ray bootstrap for NeMo RL on Kubernetes.
+#
+# This is the Kubernetes counterpart of ray.sub (Slurm). It is meant to be the
+# *container entrypoint command* of every pod in a multi-node K8s training job.
+# It brings up (or attaches to) a Ray cluster matching what init_ray() expects,
+# then -- on the head/rank-0 pod only -- runs the training command.
+#
+# It auto-detects the two mainstream ways to run distributed jobs on K8s, so no
+# bespoke YAML is required from NeMo RL:
+#
+#   * KubeRay (RayCluster / RayJob) -- Ray is already running (detected via
+#     KUBERAY_GEN_RAY_START_CMD or a reachable RAY_ADDRESS / live `ray status`).
+#     The script skips cluster setup and just runs the training command, which
+#     attaches with ray.init(address="auto").
+#
+#   * Kubeflow PyTorchJob (and any launcher that injects torch-distributed style
+#     env vars: RANK / WORLD_SIZE / MASTER_ADDR) -- the script sets up Ray across
+#     all pods (rank 0 == head) and runs the training command on rank 0. Workers
+#     block until the head calls `ray stop`, then exit 0 so the job reports
+#     success.
+#
+# The Ray resource tags ("worker_units" + an externally-managed marker) match
+# ray.sub so that nemo_rl.distributed.virtual_cluster.init_ray() takes its
+# "connect to existing externally-managed cluster" path on every backend.
+#
+# -----------------------------------------------------------------------------
+# Usage
+#
+#   The training command may be passed either as positional args or via the
+#   COMMAND environment variable (positional args take precedence):
+#
+#     bash k8s_entry.sh uv run --locked examples/run_grpo.py --config ...
+#     COMMAND="uv run --locked examples/run_grpo.py --config ..." bash k8s_entry.sh
+#
+#   In a Kubeflow PyTorchJob, every pod (Master + Worker) runs the *same*
+#   command; this script uses RANK to decide head vs. worker. As a KubeRay
+#   RayJob entrypoint, the script detects the managed cluster and only runs the
+#   training command as the driver.
+#
+# -----------------------------------------------------------------------------
+# Environment variables (all optional unless noted):
+#
+#   COMMAND          Training command to run on the head/rank-0 pod. Ignored if
+#                    positional args are given. If neither is set, the head
+#                    idles (sleep infinity) for interactive `kubectl exec`.
+#   SETUP_COMMAND    Optional command run on every pod before starting Ray.
+#   GPUS_PER_NODE    GPUs advertised per pod to Ray as worker_units (default: 8).
+#   NUM_NODES        Total pods in the job. Defaults to WORLD_SIZE, then 1.
+#   RANK             This pod's rank (0 == head). Defaults to RANK, then
+#                    PET_NODE_RANK (torchrun), then JOB_COMPLETION_INDEX
+#                    (indexed Jobs / JobSet), then 0.
+#   MASTER_ADDR      Hostname/IP of the head pod (injected by PyTorchJob).
+#   RAY_PORT                 Ray GCS port (default: 6379).
+#   RAY_DASHBOARD_PORT       Dashboard port (default: 8265).
+#   RAY_CLIENT_SERVER_PORT   Ray client server port (default: 10001).
+#   GCS_WAIT_TIMEOUT         Seconds a worker waits for the head GCS (default: 600).
+#   CLUSTER_WAIT_TIMEOUT     Seconds the head waits for all workers (default: 1800).
+# =============================================================================
+
+set -eou pipefail
+
+# ---------------------------------------------------------------------------
+# Logging helpers (match the [INFO]/[WARN]/[ERROR] convention used elsewhere).
+# ---------------------------------------------------------------------------
+log_info()  { echo "[INFO]  $*"; }
+log_warn()  { echo "[WARN]  $*" >&2; }
+log_error() { echo "[ERROR] $*" >&2; }
+die()       { log_error "$*"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Resolve the training command. Positional args win; otherwise fall back to the
+# COMMAND env var. An empty result means "idle" (interactive head).
+# ---------------------------------------------------------------------------
+if [[ "$#" -gt 0 ]]; then
+  TRAIN_CMD=("$@")
+elif [[ -n "${COMMAND:-}" ]]; then
+  # shellcheck disable=SC2206  # intentional word-splitting of the COMMAND string
+  TRAIN_CMD=(bash -c "${COMMAND}")
+else
+  TRAIN_CMD=()
+fi
+
+# ---------------------------------------------------------------------------
+# Defaults. Every value can be overridden by exporting it before invocation.
+# We deliberately read the same env vars that Kubeflow's training-operator,
+# torchrun, and indexed Jobs / JobSet inject, so no manifest changes are needed.
+# ---------------------------------------------------------------------------
+GPUS_PER_NODE="${GPUS_PER_NODE:-8}"
+RAY_PORT="${RAY_PORT:-6379}"
+RAY_DASHBOARD_PORT="${RAY_DASHBOARD_PORT:-8265}"
+RAY_CLIENT_SERVER_PORT="${RAY_CLIENT_SERVER_PORT:-10001}"
+GCS_WAIT_TIMEOUT="${GCS_WAIT_TIMEOUT:-600}"
+CLUSTER_WAIT_TIMEOUT="${CLUSTER_WAIT_TIMEOUT:-1800}"
+SETUP_COMMAND="${SETUP_COMMAND:-}"
+
+# Rank: first env var that is set wins (PyTorchJob/torchrun/indexed-Job/JobSet).
+RANK="${RANK:-${PET_NODE_RANK:-${JOB_COMPLETION_INDEX:-0}}}"
+
+# World size / node count: WORLD_SIZE is set by PyTorchJob & torchrun.
+NUM_NODES="${NUM_NODES:-${WORLD_SIZE:-1}}"
+
+# Head address: MASTER_ADDR is set by PyTorchJob & torchrun.
+MASTER_ADDR="${MASTER_ADDR:-}"
+
+# After ray>=2.47 a per-task uv venv feature is on by default and conflicts with
+# NeMo RL's once-per-node venv handling (see ray.sub for the same setting).
+export RAY_ENABLE_UV_RUN_RUNTIME_ENV="${RAY_ENABLE_UV_RUN_RUNTIME_ENV:-0}"
+
+# Fixed Ray component ports (mirrors ray.sub). On Kubernetes the head and worker
+# run in separate pods, so every Ray component must bind a *known* port for the
+# worker raylet to register with the head GCS -- otherwise Ray picks random
+# high ports that a headless Service / NetworkPolicy may not allow, and the
+# worker times out with "RPC error: Deadline Exceeded" during startup. The head
+# uses the base port + 1 (matching ray.sub) so a co-located worker on the head
+# pod would not collide; worker pods use the base ports.
+NODE_MANAGER_PORT="${NODE_MANAGER_PORT:-53001}"
+OBJECT_MANAGER_PORT="${OBJECT_MANAGER_PORT:-53003}"
+RUNTIME_ENV_AGENT_PORT="${RUNTIME_ENV_AGENT_PORT:-53005}"
+DASHBOARD_AGENT_GRPC_PORT="${DASHBOARD_AGENT_GRPC_PORT:-53007}"
+DASHBOARD_AGENT_LISTEN_PORT="${DASHBOARD_AGENT_LISTEN_PORT:-52365}"
+METRICS_EXPORT_PORT="${METRICS_EXPORT_PORT:-53009}"
+MIN_WORKER_PORT="${MIN_WORKER_PORT:-10002}"
+MAX_WORKER_PORT="${MAX_WORKER_PORT:-11000}"
+
+
+# ---------------------------------------------------------------------------
+# Resolve a hostname to an IP, trying several tools (mirrors ray.sub robustness).
+# Echoes the original value if resolution fails.
+# ---------------------------------------------------------------------------
+resolve_host() {
+  local host="$1" ip=""
+  [[ -z "$host" ]] && return 0
+  ip=$(getent hosts "$host" 2>/dev/null | awk '{print $1}' | head -n1 || true)
+  if [[ -z "$ip" ]] && command -v host >/dev/null 2>&1; then
+    ip=$(host "$host" 2>/dev/null | awk '/has address/ {print $4}' | head -n1 || true)
+  fi
+  if [[ -z "$ip" ]] && command -v nslookup >/dev/null 2>&1; then
+    ip=$(nslookup "$host" 2>/dev/null | awk '/^Address: / {print $2}' | head -n1 || true)
+  fi
+  echo "${ip:-$host}"
+}
+
+# Best-effort detection of this pod's primary IP for `--node-ip-address`.
+detect_self_ip() {
+  local ip=""
+  ip=$(hostname -I 2>/dev/null | awk '{print $1}' || true)
+  if [[ -z "$ip" ]]; then
+    ip=$(ip route get 1 2>/dev/null | awk '{print $(NF-2); exit}' || true)
+  fi
+  echo "${ip:-127.0.0.1}"
+}
+
+# ---------------------------------------------------------------------------
+# Ray best-practice: raise the open-file soft limit (session-scoped only).
+# ---------------------------------------------------------------------------
+raise_ulimit() {
+  local hard
+  hard=$(ulimit -Hn)
+  if [[ "$hard" == "unlimited" ]] || [[ 65535 -lt "$hard" ]]; then
+    ulimit -Sn 65535 || true
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Wait until the Ray cluster reports >= expected worker_units (one per GPU),
+# matching the bringup gate that ray.sub performs before launching the driver.
+# ---------------------------------------------------------------------------
+wait_for_worker_units() {
+  local expected="$1" timeout="$2" start
+  start=$(date +%s)
+  log_info "Waiting for ${expected} worker_units to come online (timeout ${timeout}s)..."
+  while true; do
+    local status online
+    status=$(ray status 2>/dev/null || true)
+    online=$(echo "$status" | grep "worker_units" | awk -F'[/. ]' '{print $4}' | head -n1 || true)
+    online="${online:-0}"
+    [[ "$online" =~ ^[0-9]+$ ]] || online=0
+    log_info "worker_units online: ${online}/${expected}"
+    if (( online >= expected )); then
+      log_info "All worker_units online. Cluster is ready."
+      return 0
+    fi
+    if (( $(date +%s) - start > timeout )); then
+      die "Timed out waiting for worker_units (${online}/${expected})."
+    fi
+    sleep 5
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Wait until the head's GCS answers health checks (used by worker pods).
+# ---------------------------------------------------------------------------
+wait_for_gcs() {
+  local address="$1" timeout="$2" start
+  start=$(date +%s)
+  log_info "Waiting for Ray GCS at ${address} (timeout ${timeout}s)..."
+  while true; do
+    if ray health-check --address "$address" >/dev/null 2>&1; then
+      log_info "Ray GCS at ${address} is ready."
+      return 0
+    fi
+    if (( $(date +%s) - start > timeout )); then
+      die "Timed out waiting for Ray GCS at ${address}."
+    fi
+    sleep 5
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Block until the head's GCS becomes unreachable (head ran `ray stop`), so the
+# worker pod can exit 0 and let the PyTorchJob report success.
+# ---------------------------------------------------------------------------
+wait_until_head_stops() {
+  local address="$1"
+  log_info "Worker joined cluster. Waiting until head GCS at ${address} stops..."
+  while ray health-check --address "$address" >/dev/null 2>&1; do
+    sleep 10
+  done
+  log_info "Head GCS at ${address} is gone; worker exiting 0."
+}
+
+# ---------------------------------------------------------------------------
+# Run the training command (or idle) on the head pod.
+# ---------------------------------------------------------------------------
+run_driver_or_idle() {
+  if [[ "${#TRAIN_CMD[@]}" -gt 0 ]]; then
+    log_info "Launching training command on head pod: ${TRAIN_CMD[*]}"
+    "${TRAIN_CMD[@]}"
+  else
+    log_info "No training command given; cluster is idle. Use 'kubectl exec' to attach."
+    sleep infinity
+  fi
+}
+
+# ===========================================================================
+# Main
+# ===========================================================================
+raise_ulimit
+
+if [[ -n "$SETUP_COMMAND" ]]; then
+  log_info "Running SETUP_COMMAND on this pod..."
+  bash -c "$SETUP_COMMAND"
+fi
+
+log_info "===================================================="
+log_info "NeMo RL Kubernetes Ray bootstrap (k8s_entry.sh)"
+log_info "  RANK            = ${RANK}"
+log_info "  NUM_NODES       = ${NUM_NODES}"
+log_info "  GPUS_PER_NODE   = ${GPUS_PER_NODE}"
+log_info "  MASTER_ADDR     = ${MASTER_ADDR:-<unset>}"
+log_info "  RAY_PORT        = ${RAY_PORT}"
+log_info "===================================================="
+
+# ---------------------------------------------------------------------------
+# Mode A: a Ray cluster is already managed for us (KubeRay / RayJob). Do not
+# start a second Ray; just run the training command as the driver. KubeRay sets
+# KUBERAY_GEN_RAY_START_CMD on its pods; RAY_ADDRESS is the "attach here" hint.
+# ---------------------------------------------------------------------------
+externally_managed=false
+if [[ -n "${KUBERAY_GEN_RAY_START_CMD:-}" ]]; then
+  externally_managed=true
+  log_info "Detected KubeRay-managed Ray cluster (KUBERAY_GEN_RAY_START_CMD set)."
+elif [[ -n "${RAY_ADDRESS:-}" ]] && ray health-check --address "${RAY_ADDRESS}" >/dev/null 2>&1; then
+  externally_managed=true
+  log_info "Detected reachable Ray cluster via RAY_ADDRESS=${RAY_ADDRESS}."
+fi
+
+if [[ "$externally_managed" == "true" ]]; then
+  run_driver_or_idle
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Mode B: we own the Ray bringup (Kubeflow PyTorchJob / JobSet / indexed Job).
+# Rank 0 is the head; all other ranks are workers that attach to MASTER_ADDR.
+# ---------------------------------------------------------------------------
+if [[ -z "$MASTER_ADDR" ]]; then
+  if [[ "$RANK" == "0" ]]; then
+    MASTER_ADDR=$(detect_self_ip)
+    log_warn "MASTER_ADDR not set; head auto-detected its IP as ${MASTER_ADDR}."
+  else
+    die "MASTER_ADDR must be set for worker pods (rank ${RANK})."
+  fi
+fi
+
+head_ip=$(resolve_host "$MASTER_ADDR")
+gcs_address="${head_ip}:${RAY_PORT}"
+
+# Advertise the same resource tags ray.sub uses so init_ray() treats this as an
+# externally-managed cluster and reuses it (rather than starting a local one).
+ray_resources="{\"worker_units\": ${GPUS_PER_NODE}, \"slurm_managed_ray_cluster\": 1}"
+
+if [[ "$RANK" == "0" ]]; then
+  self_ip=$(detect_self_ip)
+  log_info "Starting Ray HEAD on ${self_ip} (advertising as ${head_ip})..."
+  ray start --head \
+    --disable-usage-stats \
+    --resources="${ray_resources}" \
+    --num-gpus="${GPUS_PER_NODE}" \
+    --node-ip-address="${self_ip}" \
+    --port="${RAY_PORT}" \
+    --ray-client-server-port="${RAY_CLIENT_SERVER_PORT}" \
+    --dashboard-host=0.0.0.0 \
+    --dashboard-port="${RAY_DASHBOARD_PORT}" \
+    --node-manager-port=$((NODE_MANAGER_PORT + 1)) \
+    --object-manager-port=$((OBJECT_MANAGER_PORT + 1)) \
+    --runtime-env-agent-port=$((RUNTIME_ENV_AGENT_PORT + 1)) \
+    --dashboard-agent-grpc-port=$((DASHBOARD_AGENT_GRPC_PORT + 1)) \
+    --dashboard-agent-listen-port=$((DASHBOARD_AGENT_LISTEN_PORT + 1)) \
+    --metrics-export-port=$((METRICS_EXPORT_PORT + 1)) \
+    --include-dashboard=True
+
+  wait_for_worker_units "$((NUM_NODES * GPUS_PER_NODE))" "$CLUSTER_WAIT_TIMEOUT"
+
+  # Run the driver, then stop Ray so worker pods unblock and exit 0.
+  set +e
+  run_driver_or_idle
+  driver_rc=$?
+  set -e
+  log_info "Training command finished (rc=${driver_rc}); stopping Ray head."
+  ray stop >/dev/null 2>&1 || true
+  exit "$driver_rc"
+else
+  log_info "Starting Ray WORKER (rank ${RANK}) attaching to ${gcs_address}..."
+  wait_for_gcs "$gcs_address" "$GCS_WAIT_TIMEOUT"
+  worker_ip=$(detect_self_ip)
+  ray start --address="${gcs_address}" \
+    --disable-usage-stats \
+    --resources="${ray_resources}" \
+    --num-gpus="${GPUS_PER_NODE}" \
+    --node-ip-address="${worker_ip}" \
+    --min-worker-port="${MIN_WORKER_PORT}" \
+    --max-worker-port="${MAX_WORKER_PORT}" \
+    --node-manager-port="${NODE_MANAGER_PORT}" \
+    --object-manager-port="${OBJECT_MANAGER_PORT}" \
+    --runtime-env-agent-port="${RUNTIME_ENV_AGENT_PORT}" \
+    --dashboard-agent-grpc-port="${DASHBOARD_AGENT_GRPC_PORT}" \
+    --dashboard-agent-listen-port="${DASHBOARD_AGENT_LISTEN_PORT}" \
+    --metrics-export-port="${METRICS_EXPORT_PORT}"
+  # Block until the head stops Ray, then exit 0 so the job is marked successful.
+  wait_until_head_stops "$gcs_address"
+fi

--- a/nemo_rl/utils/venvs.py
+++ b/nemo_rl/utils/venvs.py
@@ -76,8 +76,26 @@ def create_local_venv(
 
     logger.info(f"Creating new venv at {venv_path}")
 
+    # Resolve the interpreter version the project is pinned to (.python-version
+    # at the git root). The venv is created by a Ray actor whose cwd is *not*
+    # the git root, so `uv venv` cannot discover the pin on its own and would
+    # silently fall back to whatever system interpreter it finds (e.g. 3.12).
+    # That mismatch makes uv re-resolve dependencies for the wrong Python and
+    # can pull in different package versions than the base venv -- most notably
+    # a different `ray`, which then fails Ray worker startup across nodes with
+    # "connect() got an unexpected keyword argument". Pin the version explicitly
+    # so every per-actor venv matches the driver/base venv.
+    python_version_file = os.path.join(git_root, ".python-version")
+    pinned_python_version = ""
+    if os.path.exists(python_version_file):
+        with open(python_version_file) as f:
+            pinned_python_version = f.read().strip()
+
     # Create the virtual environment
-    uv_venv_cmd = ["uv", "venv", "--allow-existing", venv_path]
+    uv_venv_cmd = ["uv", "venv", "--allow-existing"]
+    if pinned_python_version:
+        uv_venv_cmd += ["--python", pinned_python_version]
+    uv_venv_cmd.append(venv_path)
     subprocess.run(uv_venv_cmd, check=True)
 
     # Execute the command with the virtual environment
@@ -86,6 +104,7 @@ def create_local_venv(
     #  one call to this in the driver. It is not safe to use this in a multi-process
     #  context.
     #  https://docs.astral.sh/uv/concepts/projects/config/#project-environment-path
+
     env["UV_PROJECT_ENVIRONMENT"] = venv_path
 
     # Split the py_executable into command and arguments


### PR DESCRIPTION
# feat: full Kubernetes multi-node support (Kubeflow PyTorchJob + KubeRay)

## What does this PR do?

Adds first-class multi-node support on Kubernetes, matching what `ray.sub`
already provides on Slurm. A multi-node GRPO/SFT/DPO run can now be launched on a
stock cluster using either mainstream distributed-job operator:

- **Kubeflow PyTorchJob** (`kubeflow/training-operator`)
- **KubeRay** (`RayJob` / `RayCluster`)

The core is `k8s_entry.sh`, a single container entrypoint that auto-detects the
environment and brings up / attaches to Ray accordingly — the K8s counterpart of
`ray.sub`.

## How does it work?

`k8s_entry.sh` picks one of two modes:

- **KubeRay** — Ray is already managed by the operator (detected via
  `RAY_ADDRESS` / live `ray status`). The script skips cluster setup and runs the
  training command as the driver.
- **PyTorchJob** — the operator injects `RANK` / `WORLD_SIZE` / `MASTER_ADDR`.
  Rank 0 starts the Ray head and runs the driver; other ranks join as workers and
  block until the head calls `ray stop`.

In both modes it advertises the same Ray resource tags as `ray.sub` so
`init_ray()` takes its existing "connect to externally-managed cluster" path, and
it pins the Ray component ports so cross-pod raylet registration works behind
headless Services.

## Changes

- `k8s_entry.sh` (new) — auto-detecting entrypoint for KubeRay and PyTorchJob.
- `nemo_rl/utils/venvs.py` — pin the per-actor venv to the project's
  `.python-version`. The actor cwd is not the git root, so `uv venv` could fall
  back to a system interpreter and re-resolve a mismatched `ray`, breaking
  cross-node worker startup.
- `infra/examples/pytorchjob-grpo.yaml`, `infra/examples/rayjob-grpo.yaml` —
  example manifests for both operators.
- `infra/README.md`, `docs/cluster.md` — document the two entrypoint patterns.

## Testing

Validated on a 2-node × 1-GPU Kubeflow PyTorchJob (official `nemo-rl:v0.6.0`
image): Ray came up across both pods, `init_ray()` connected, vLLM and DTensor
workers initialized on both nodes, and the GRPO driver progressed into model
setup and cross-node NCCL. Cluster-specific fabric tuning (e.g.
`NCCL_SOCKET_IFNAME`) is left to the operator.

## Notes

- No changes to the Slurm path; this is purely additive.
- Example manifests are intentionally minimal — production fabrics will want
  hostNetwork/RDMA/NCCL tuning on top.
