### PR TITLE
fix: avoid duplicating assistant content in multi-turn reasoning templates

### DIFF
--- a/nemo_rl/data/llm_message_utils.py
+++ b/nemo_rl/data/llm_message_utils.py
@@ -426,6 +426,60 @@ def get_first_index_that_differs(str1: str, str2: str) -> int:
     return min(len(str1), len(str2))
 
 
+def _derive_turn_markers(tokenizer: TokenizerType) -> list[str]:
+    """Per-role turn-opening markers of a chat template, longest-first.
+
+    Each role's opener is recovered by rendering it after a stable anchor and diffing;
+    its first token is the boundary marker. Uniform templates (ChatML, Llama-3) yield
+    one marker (``<|im_start|>``, ``<|start_header_id|>``), per-role templates (e.g.
+    DeepSeek) yield several. Cached on the tokenizer; empty if none can be derived.
+    """
+    cached = getattr(tokenizer, "_nemo_rl_turn_markers", None)
+    if cached is not None:
+        return cached
+    anchor = [
+        {"role": "user", "content": "anchor"},
+        {"role": "assistant", "content": "prior"},
+    ]
+    markers: set[str] = set()
+    for role in ("system", "user", "assistant", "tool"):
+        probe: dict[str, Any] = {"role": role, "content": "probe"}
+        if role == "tool":
+            probe.update(tool_call_id="c", name="f")
+        try:
+            base = tokenizer.apply_chat_template(  # type: ignore
+                anchor,
+                tokenize=False,
+                add_generation_prompt=False,
+                add_special_tokens=False,
+            )
+            full = tokenizer.apply_chat_template(  # type: ignore
+                anchor + [probe],
+                tokenize=False,
+                add_generation_prompt=False,
+                add_special_tokens=False,
+            )
+        except Exception:
+            continue
+        ## opener = the text the probe turn prepends before its content; its first
+        ## token is the role-opening boundary marker (skip if render isn't stable)
+        if not full.startswith(base):
+            continue
+        content_at = full.find("probe", len(base))
+        if content_at <= len(base):
+            continue
+        opener = full[len(base) : content_at]
+        tid = tokenizer.encode(opener, add_special_tokens=False)
+        if tid:
+            markers.add(tokenizer.decode([tid[0]]))
+    result = sorted(markers, key=len, reverse=True)
+    try:
+        tokenizer._nemo_rl_turn_markers = result  # type: ignore[attr-defined]
+    except Exception:
+        pass
+    return result
+
+
 def get_formatted_message_log(
     message_log: LLMMessageLogType,
     tokenizer: TokenizerType,
@@ -452,6 +506,11 @@ def get_formatted_message_log(
     """
     new_message_log: LLMMessageLogType = []
     prev_formatted_message = ""
+    ## running concat of the chunks actually emitted; used by the overlap fallback
+    ## when re-anchoring duplicated history (see the loop below)
+    emitted_text = ""
+    ## per-role turn markers, derived lazily on the first non-monotonic render
+    turn_markers: Optional[list[str]] = None
     message_log_strs: list[dict[str, str]] = cast(
         list[dict[str, str]], message_log
     )  # we just use the str:str parts here
@@ -540,6 +599,33 @@ def get_formatted_message_log(
         ## pull out the chunk corresponding to the current message
         message_chunk = formatted_message[prev_message_len_no_eos:]
 
+        ## reasoning templates (Qwen3, DeepSeek-R1, ...) strip <think> from history
+        ## turns, so prev render is not a prefix of the current one and the diff
+        ## re-includes the previous turn's content, duplicating it. This turn is the
+        ## last message turn and keeps its own <think>, so recover just it via the
+        ## suffix after its turn marker. A trailing generation prompt opens its own
+        ## marker, so step back past it. No marker (non-ChatML) -> strip the overlap
+        ## with the emitted text.
+        if prev_message_len_no_eos < len(prev_formatted_message) and message_chunk:
+            if turn_markers is None:
+                turn_markers = _derive_turn_markers(tokenizer)
+            anchor = max((formatted_message.rfind(m) for m in turn_markers), default=-1)
+            if anchor > 0 and template_kwargs["add_generation_prompt"]:
+                before = max(
+                    (formatted_message.rfind(m, 0, anchor) for m in turn_markers),
+                    default=-1,
+                )
+                if before != -1:
+                    anchor = before
+            if anchor != -1:
+                message_chunk = formatted_message[anchor:]
+            elif emitted_text:
+                max_overlap = min(len(emitted_text), len(message_chunk))
+                for overlap in range(max_overlap, 0, -1):
+                    if emitted_text[-overlap:] == message_chunk[:overlap]:
+                        message_chunk = message_chunk[overlap:]
+                        break
+
         # Debug: Print each message turn separately
         if debug:
             if i == 0:
@@ -591,6 +677,8 @@ def get_formatted_message_log(
                     )
                 elif not stripped_message_chunk.endswith(tokenizer.eos_token):
                     message_chunk += tokenizer.eos_token
+
+        emitted_text += message_chunk
 
         # get images too (extend this for other modalities)
         media_cur_message = load_media_from_message(

--- a/tests/unit/data/test_llm_message_utils.py
+++ b/tests/unit/data/test_llm_message_utils.py
@@ -27,10 +27,23 @@ from nemo_rl.data.llm_message_utils import (
     _validate_tensor_consistency,
     add_loss_mask_to_message_log,
     batched_message_log_to_flat_message,
+    _derive_turn_markers,
     get_first_index_that_differs,
     get_formatted_message_log,
     get_keys_from_message_log,
     message_log_to_flat_messages,
+)
+
+# Reasoning template (ChatML-style): renders reasoning_content as <think> only for
+# the last assistant turn and strips it from history turns (mirrors Qwen3 / kanana).
+_REASONING_CHAT_TEMPLATE = (
+    "{%- for m in messages -%}"
+    "{%- if m['role'] == 'user' -%}<|im_start|>user\n{{ m['content'] }}<|im_end|>\n"
+    "{%- elif m['role'] == 'assistant' -%}"
+    "{%- if loop.last and m.reasoning_content is defined and m.reasoning_content -%}"
+    "<|im_start|>assistant\n<think>{{ m.reasoning_content }}</think>{{ m['content'] }}<|im_end|>\n"
+    "{%- else -%}<|im_start|>assistant\n{{ m['content'] }}<|im_end|>\n{%- endif -%}"
+    "{%- endif -%}{%- endfor -%}"
 )
 
 
@@ -528,6 +541,79 @@ def test_get_formatted_message_log_qwen3_enable_thinking(
     actual_text = [m["content"] for m in result]
 
     assert actual_text == expected_text
+
+
+def test_derive_turn_markers() -> None:
+    """Per-role turn-opening markers are derived from the chat template."""
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-0.5B-Instruct")
+    assert _derive_turn_markers(tokenizer) == ["<|im_start|>"]
+
+    tokenizer.chat_template = _REASONING_CHAT_TEMPLATE
+    delattr(tokenizer, "_nemo_rl_turn_markers")  # markers are cached on the tokenizer
+    assert _derive_turn_markers(tokenizer) == ["<|im_start|>"]
+
+
+def test_get_formatted_message_log_multiturn_reasoning_no_duplication() -> None:
+    """Reasoning templates must not duplicate the previous assistant turn's content
+    into the following turn's chunk; each turn keeps its own <think>."""
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-0.5B-Instruct")
+    tokenizer.chat_template = _REASONING_CHAT_TEMPLATE
+
+    message_log = [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "ANSWER1", "reasoning_content": "THINK1"},
+        {"role": "user", "content": "q2"},
+        {"role": "assistant", "content": "ANSWER2", "reasoning_content": "THINK2"},
+    ]
+    result = get_formatted_message_log(
+        [dict(m) for m in message_log],
+        tokenizer,
+        TaskDataSpec(task_name="test"),
+        add_bos_token=False,
+        add_eos_token=False,
+        add_generation_prompt=False,
+    )
+
+    full = "".join(m["content"] for m in result)
+    ## each answer and its <think> block appears exactly once
+    assert full.count("ANSWER1") == 1
+    assert full.count("ANSWER2") == 1
+    assert full.count("THINK1") == 1
+    assert full.count("THINK2") == 1
+    assert full == (
+        "<|im_start|>user\nq1<|im_end|>"
+        "<|im_start|>assistant\n<think>THINK1</think>ANSWER1<|im_end|>"
+        "<|im_start|>user\nq2<|im_end|>"
+        "<|im_start|>assistant\n<think>THINK2</think>ANSWER2<|im_end|>"
+    )
+
+
+def test_get_formatted_message_log_multiturn_normal_template_unchanged() -> None:
+    """A non-reasoning template is unaffected: concatenated chunks equal the full
+    chat-template render."""
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-0.5B-Instruct")
+    message_log = [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "q2"},
+        {"role": "assistant", "content": "a2"},
+    ]
+    result = get_formatted_message_log(
+        [dict(m) for m in message_log],
+        tokenizer,
+        TaskDataSpec(task_name="test"),
+        add_bos_token=False,
+        add_eos_token=False,
+        add_generation_prompt=False,
+    )
+    full = "".join(m["content"] for m in result)
+    expected = tokenizer.apply_chat_template(
+        message_log,
+        tokenize=False,
+        add_generation_prompt=False,
+        add_special_tokens=False,
+    )
+    assert full == expected
 
 
 @pytest.mark.hf_gated


### PR DESCRIPTION
# What does this PR do ?

`get_formatted_message_log` extracts each turn's token chunk via an incremental string diff (`get_first_index_that_differs`) of the turn's render against the previous render. This assumes the previous render is always a prefix of the current one.

Reasoning chat templates (Qwen3, DeepSeek-R1, kanana) break that assumption: they keep `<think>...</think>` for the *current* assistant turn but strip it from past (history) assistant turns. The renders then diverge *before* the previous turn's content, so the diff re-includes that content and the prior assistant answer gets **duplicated** into the following turn's chunk, corrupting multi-turn training sequences.

This PR detects the non-monotonic case (previous render is not a prefix of the current one) and re-anchors the turn's chunk at its turn-opening marker, derived **per role** from the chat template (uniform `<|im_start|>` / `<|start_header_id|>`, or per-role like DeepSeek). It anchors at the last marker, stepping back past a trailing generation prompt when one was appended. When no marker can be derived, it falls back to stripping the chunk's overlap with the text emitted so far. Each assistant turn keeps its `<think>` block — consistent with how NeMo-RL's multi-turn rollout concatenates per-turn `token_ids` verbatim — and the monotonic (normal-template) path is unchanged.

# Issues
closes https://github.com/NVIDIA-NeMo/RL/issues/2821

# Usage
* N/A — bug fix in data tokenization; no API or config changes.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* Single-turn and non-reasoning multi-turn behavior is unchanged; the re-anchoring only triggers when a reasoning template re-renders history.
