### PR TITLE
perf: reduce srun overhead in ray.sub and gate driver on sandbox readiness

### DIFF
--- a/ray.sub
+++ b/ray.sub
@@ -122,9 +122,23 @@ if [[ -n "${UV_CACHE_DIR_OVERRIDE:-}" ]]; then
 fi
 
 # Create logs directory
+# NOTE: LOG_DIR must be on a shared filesystem visible to both the submit host and
+# all compute nodes. File-based signaling between the submit host and the containers
+# (STARTED_RAY_HEAD, ray_worker_units, ENDED, sandbox readiness) relies on this.
 BASE_LOG_DIR=${BASE_LOG_DIR:-$SLURM_SUBMIT_DIR}
-LOG_DIR="$BASE_LOG_DIR/$SLURM_JOB_ID-logs"
+# On a Slurm requeue/restart, suffix the restart count so we don't clobber the
+# previous attempt's logs (and signal files) under the same job ID.
+if [[ -n "${SLURM_RESTART_COUNT:-}" ]]; then
+  LOG_DIR="$BASE_LOG_DIR/$SLURM_JOB_ID-$SLURM_RESTART_COUNT-logs"
+else
+  LOG_DIR="$BASE_LOG_DIR/$SLURM_JOB_ID-logs"
+fi
 mkdir -p $LOG_DIR
+
+# LOG_DIR must be shared across all nodes. Write a canary the head and worker
+# containers check at startup: a node that can't see it isn't on the shared FS, so
+# we fail there immediately instead of hanging on signal files that never appear.
+echo "$SLURM_JOB_ID" > "$LOG_DIR/.shared_fs_canary"
 
 # Write setup commands to a file so they can be executed inside each container
 # without heredoc escaping surprises.
@@ -133,6 +147,15 @@ if [[ -n "$SETUP_COMMAND" ]]; then
   SETUP_COMMAND_FILE="$LOG_DIR/setup_command.sh"
   echo "$SETUP_COMMAND" > "$SETUP_COMMAND_FILE"
   chmod +x "$SETUP_COMMAND_FILE"
+fi
+
+# Write COMMAND to a file so the head container can run it without heredoc/quoting
+# issues. Its presence is also how the head decides non-interactive vs interactive.
+DRIVER_COMMAND_FILE=""
+if [[ -n "$COMMAND" ]]; then
+  DRIVER_COMMAND_FILE="$LOG_DIR/driver_command.sh"
+  printf '%s' "$COMMAND" > "$DRIVER_COMMAND_FILE"
+  chmod +x "$DRIVER_COMMAND_FILE"
 fi
 
 # Number of GPUs per worker node
@@ -158,7 +181,13 @@ COMMON_SRUN_ARGS+=" -A $SLURM_JOB_ACCOUNT"
 # Number of CPUs per worker node
 CPUS_PER_WORKER=${CPUS_PER_WORKER:-$((GPUS_PER_NODE * 16))}
 
+# The head is retried a few times. Workers may need more attempts since they can
+# race the head's GCS coming up: `ray start --address` fails until GCS is listening.
 num_retries=3
+WORKER_NUM_RETRIES=20
+
+# Total Ray worker_units expected once every node has registered with the head.
+NUM_ACTORS=$((GPUS_PER_NODE * SLURM_JOB_NUM_NODES))
 
 # Track backgrounded srun client PIDs for head and workers
 declare -A SRUN_PIDS
@@ -306,15 +335,36 @@ RAY_RESOURCES+='}'
 export RAY_RESOURCES
 TOPO_PROBE_EOF
 
+# Set up the sandbox ports/signal directory on the shared FS before building the
+# head script, so the head can gate the driver on sandbox readiness. Arbitrary
+# extra mounts are supported via SANDBOX_EXTRA_MOUNTS (e.g. a shared temp dir).
+SANDBOX_PORTS_DIR=""
+if [[ -n "${SANDBOX_CONTAINER:-}" ]] && [[ -n "${SANDBOX_COMMAND:-}" ]]; then
+  SANDBOX_PORTS_DIR="$LOG_DIR/sandbox"
+  mkdir -p "$SANDBOX_PORTS_DIR"
+fi
+
 # First we start the head of the ray cluster on one of the physical nodes
 # Give the head node actual resources to make it schedulable
 
 head_cmd=$(cat <<EOF
-# Touch a file to indicate that the head node has started
-# Overlapping srun commands will check this file to determine if we can overlap a container command
-touch $LOG_DIR/STARTED_RAY_HEAD
 if [[ "\${RAY_SUB_DEBUG_ENV:-0}" == "1" ]]; then
   env | grep -viE '(WANDB_API_KEY|HF_TOKEN|API_KEY|TOKEN|SECRET|PASSWORD)=' || true
+fi
+
+# Turn on pipefail here; it does not carry into this 'bash -c' subshell from the
+# submit host. Without it, 'ray status | grep worker_units | awk ...' exits 0 even
+# when grep matches nothing (awk's status wins), so the '|| echo 0' fallback never
+# fires. Do NOT add 'set -e': the retry loops and '-eq' polls below need non-zero
+# exit codes to stay non-fatal.
+set -o pipefail
+
+# If this node can't see the canary, LOG_DIR is not shared. Fail now instead of
+# waiting forever for signal files the submit host writes but this node can't read.
+if [[ ! -f "$LOG_DIR/.shared_fs_canary" ]]; then
+  echo "[ERROR] $LOG_DIR/.shared_fs_canary not visible on the head node; LOG_DIR must be on a shared filesystem." >&2
+  touch "$LOG_DIR/ENDED" 2>/dev/null || true
+  exit 1
 fi
 
 exit-dramatically() {
@@ -370,12 +420,46 @@ log-sync-sidecar() {
 }
 log-sync-sidecar &
 
+# Background process that publishes the live worker_units count to a file on the
+# shared FS, which the submit host reads to track how many workers have joined.
+ray-status-sidecar() {
+  set +x
+  while true; do
+    sleep 10
+    units=\$(ray status 2>/dev/null | grep "worker_units" | awk -F'[/. ]' '{print \$4}' || echo 0)
+    # Write to a temp file, then rename. A plain '>' truncates before writing, so the
+    # submit host (reading this over the shared FS from another node) could catch it
+    # empty or half-written. rename is atomic: the reader always gets either the old
+    # value or the full new one.
+    echo "\$units" > "$LOG_DIR/.ray_worker_units.tmp"
+    mv "$LOG_DIR/.ray_worker_units.tmp" "$LOG_DIR/ray_worker_units"
+    if [[ -f "$LOG_DIR/ENDED" ]]; then break; fi
+  done
+}
+ray-status-sidecar &
+
 # Patch nsight.py before starting Ray head
 sed -i 's/context\.py_executable = " "\.join(self\.nsight_cmd) + " python"/context.py_executable = " ".join(self.nsight_cmd) + f" {context.py_executable}"/g' /opt/nemo_rl_venv/lib64/python*/site-packages/ray/_private/runtime_env/nsight.py
 
 source $LOG_DIR/topology_probe.sh
 
-cat <<EOFINNER | tee /launch-head.sh
+# Start the head without --block. 'ray start --head' then returns as soon as the
+# GCS is listening, so we touch STARTED_RAY_HEAD only after the head is actually up.
+# Workers gate on that file, so they only try to connect once the GCS is accepting
+# connections.
+count=0
+while [[ \$count -lt $num_retries ]]; do
+  # Clean up stale Ray state before every attempt. A timed-out attempt leaves a
+  # session directory behind, and the next 'ray start --head' would otherwise hit:
+  #   AssertionError: Session name ... does not match persisted value ...
+  ray stop || true
+  rm -rf /tmp/ray/session_* || true
+
+  if [[ -n "$SETUP_COMMAND_FILE" ]] && [[ -f "$SETUP_COMMAND_FILE" ]]; then
+    echo "[INFO] Running setup command from $SETUP_COMMAND_FILE..."
+    bash "$SETUP_COMMAND_FILE"
+  fi
+  if cat <<EOFINNER | bash; then
 ray start --head \
     --disable-usage-stats \
     --resources="\$RAY_RESOURCES" \
@@ -392,42 +476,95 @@ ray start --head \
     --dashboard-agent-grpc-port=$((${DASHBOARD_AGENT_GRPC_PORT} + 1)) \
     --dashboard-agent-listen-port=$((${DASHBOARD_AGENT_LISTEN_PORT} + 1)) \
     --metrics-export-port=$((${METRICS_EXPORT_PORT} + 1)) \
-    $RAY_DEBUGGER_ARGS \
-    \
-    --block 
+    $RAY_DEBUGGER_ARGS
 EOFINNER
-chmod +x /launch-head.sh
-
-count=0
-while [[ \$count -lt $num_retries ]]; do
-  if [[ -n "$SETUP_COMMAND_FILE" ]] && [[ -f "$SETUP_COMMAND_FILE" ]]; then
-    echo "[INFO] Running setup command from $SETUP_COMMAND_FILE..."
-    bash "$SETUP_COMMAND_FILE"
+    echo "[INFO] Ray head started successfully (attempt \$((count+1))/$num_retries)"
+    break
   fi
-  bash /launch-head.sh
   count=\$((count+1))
-  echo "Head node failed \$count/$num_retries times, restarting in 5 seconds..."
+  echo "[WARN] Head node failed \$count/$num_retries times, restarting in 5 seconds..."
   sleep 5
 done
-touch $LOG_DIR/ENDED
-exit 1
+if [[ \$count -ge $num_retries ]]; then
+  touch "$LOG_DIR/ENDED"
+  exit 1
+fi
+
+# Signal workers and the submit host that the Ray head GCS is now listening.
+touch $LOG_DIR/STARTED_RAY_HEAD
+
+if [[ -n "$DRIVER_COMMAND_FILE" ]]; then
+  # Non-interactive: wait for all workers to connect and, if a sandbox is
+  # configured, for every sandbox instance to be ready, then run the driver. Poll
+  # both in one loop with separate deadlines, checking the shorter sandbox deadline
+  # first, so a stuck sandbox fails at 10 min instead of only after the 30-min
+  # worker wait.
+  WORKER_DEADLINE=\$((SECONDS + 1800))
+  SANDBOX_DEADLINE=\$((SECONDS + 600))
+  workers_ready=0
+  # Each sandbox task touches SANDBOX_READY_<hostname> when its port comes up (see
+  # the sandbox srun below). With no sandbox configured, count it ready up front.
+  if [[ -n "$SANDBOX_PORTS_DIR" ]]; then sandbox_ready=0; else sandbox_ready=1; fi
+  while true; do
+    if [[ "\$workers_ready" -eq 0 ]]; then
+      worker_units=\$(ray status 2>/dev/null | grep "worker_units" | awk -F'[/. ]' '{print \$4}' || echo 0)
+      echo "[INFO] Number of actors online: \$worker_units/$NUM_ACTORS"
+      if [[ "\$worker_units" -eq "$NUM_ACTORS" ]]; then
+        workers_ready=1
+        echo "All workers connected!"
+      fi
+    fi
+    if [[ "\$sandbox_ready" -eq 0 ]]; then
+      ready_count=\$(ls -1 "$SANDBOX_PORTS_DIR"/SANDBOX_READY_* 2>/dev/null | wc -l)
+      echo "[INFO] Sandbox ready on \$ready_count/$SLURM_JOB_NUM_NODES nodes..."
+      if [[ "\$ready_count" -ge "$SLURM_JOB_NUM_NODES" ]]; then
+        sandbox_ready=1
+        echo "[INFO] All $SLURM_JOB_NUM_NODES sandbox instances ready."
+      fi
+    fi
+    if [[ "\$workers_ready" -eq 1 ]] && [[ "\$sandbox_ready" -eq 1 ]]; then
+      break
+    fi
+    if [[ "\$sandbox_ready" -eq 0 ]] && (( SECONDS > SANDBOX_DEADLINE )); then
+      echo "[ERROR] Timed out waiting for sandbox (\$ready_count/$SLURM_JOB_NUM_NODES after 10 min)"
+      touch "$LOG_DIR/ENDED"
+      exit 1
+    fi
+    if [[ "\$workers_ready" -eq 0 ]] && (( SECONDS > WORKER_DEADLINE )); then
+      echo "[ERROR] Timed out waiting for all workers to connect (\$worker_units/$NUM_ACTORS after 30 min)"
+      touch "$LOG_DIR/ENDED"
+      exit 1
+    fi
+    sleep 5
+  done
+
+  set +e
+  bash "$DRIVER_COMMAND_FILE" > "$LOG_DIR/ray-driver.log" 2>&1
+  exit_code=\$?
+  set -e
+  exit \$exit_code
+else
+  # Interactive: keep the head container alive for user attachment via the attach
+  # helper (a separate overlapping srun). sleep infinity is invisible to the
+  # attached session.
+  sleep infinity
+fi
 EOF
 )
-srun $COMMON_SRUN_ARGS --container-name=ray-head --nodes=1 --ntasks=1 --cpus-per-task=$CPUS_PER_WORKER -w "$head_node" -o $LOG_DIR/ray-head.log bash -x -c "$head_cmd" &
-SRUN_PIDS["ray-head"]=$!
 
-NUM_ACTORS=$((GPUS_PER_NODE * SLURM_JOB_NUM_NODES))
-
-# Start Ray worker nodes
-# We want 1 Ray worker node per physical node (excluding the head node)
-# Worker nodes are started with ray start but without the --head flag
-# Start from node 1 since node 0 is running the head
-for ((i = 1; i < SLURM_JOB_NUM_NODES; i++)); do
-  node_i=${nodes_array[$i]}
-    
-  worker_cmd=$(cat <<EOF
+# Worker nodes connect to the head. They're launched with a single batched srun
+# below; each task discovers its identity at runtime via SLURM_PROCID/SLURMD_NODENAME.
+worker_cmd=$(cat <<EOF
 if [[ "\${RAY_SUB_DEBUG_ENV:-0}" == "1" ]]; then
   env | grep -viE '(WANDB_API_KEY|HF_TOKEN|API_KEY|TOKEN|SECRET|PASSWORD)=' || true
+fi
+echo "[INFO] Worker \$SLURM_PROCID on node \$SLURMD_NODENAME"
+
+# Fail fast if LOG_DIR is not actually shared with the submit host -- the worker
+# gates on STARTED_RAY_HEAD and other signal files that would otherwise never appear.
+if [[ ! -f "$LOG_DIR/.shared_fs_canary" ]]; then
+  echo "[ERROR] Worker \$SLURM_PROCID: $LOG_DIR/.shared_fs_canary not visible; LOG_DIR must be on a shared filesystem." >&2
+  exit 1
 fi
 
 exit-dramatically() {
@@ -458,18 +595,18 @@ log-sync-sidecar() {
     echo "RAY_LOG_SYNC_FREQUENCY is not set, skipping log sync sidecar"
     return
   fi
-  mkdir -p $LOG_DIR/ray/$node_i
+  mkdir -p "$LOG_DIR/ray/\$SLURMD_NODENAME"
   while true; do
     sleep $RAY_LOG_SYNC_FREQUENCY
     if ls /tmp/ray/session_[0-9]* > /dev/null 2>&1; then
       for session_dir in /tmp/ray/session_[0-9]*/; do
         if [[ -d "\$session_dir/logs" ]]; then
           session_name=\$(basename "\$session_dir")
-          mkdir -p "$LOG_DIR/ray/$node_i/\$session_name"
+          mkdir -p "$LOG_DIR/ray/\$SLURMD_NODENAME/\$session_name"
           if command -v rsync > /dev/null 2>&1; then
-            rsync -ahP "\$session_dir/logs/" $LOG_DIR/ray/$node_i/\$session_name/logs/ 2>/dev/null || true
+            rsync -ahP "\$session_dir/logs/" "$LOG_DIR/ray/\$SLURMD_NODENAME/\$session_name/logs/" 2>/dev/null || true
           else
-            cp -r "\$session_dir/logs" $LOG_DIR/ray/$node_i/\$session_name/
+            cp -r "\$session_dir/logs" "$LOG_DIR/ray/\$SLURMD_NODENAME/\$session_name/"
           fi
         fi
       done
@@ -487,7 +624,37 @@ sed -i 's/context\.py_executable = " "\.join(self\.nsight_cmd) + " python"/conte
 
 source $LOG_DIR/topology_probe.sh
 
-cat <<EOFINNER | tee /launch-worker.sh
+# Wait for the head to signal that its GCS is listening before connecting.
+echo "[INFO] Worker \$SLURM_PROCID: waiting for Ray head GCS to be ready..."
+while true; do
+  if [[ -f "$LOG_DIR/STARTED_RAY_HEAD" ]]; then
+    echo "[INFO] Worker \$SLURM_PROCID: Ray head GCS is ready, connecting."
+    break
+  fi
+  if [[ -f "$LOG_DIR/ENDED" ]]; then
+    echo "[ERROR] ENDED detected before head started, exiting."
+    exit 1
+  fi
+  sleep 5
+done
+
+# Workers retry more often and wait longer than the head. 'ray start --address'
+# fails until the head GCS is listening, so a worker may have to outlast a slow head
+# bringup: WORKER_NUM_RETRIES x 10s gives it ~200s. The head only retries a local
+# 'ray start --head' a few times.
+count=0
+while [[ \$count -lt $WORKER_NUM_RETRIES ]]; do
+  # Clean up stale Ray state before every attempt so a half-started raylet from a
+  # previous attempt doesn't block the next one.
+  ray stop || true
+  rm -rf /tmp/ray/session_* || true
+
+  if [[ -n "$SETUP_COMMAND_FILE" ]] && [[ -f "$SETUP_COMMAND_FILE" ]]; then
+    echo "[INFO] Running setup command from $SETUP_COMMAND_FILE..."
+    bash "$SETUP_COMMAND_FILE"
+  fi
+  echo "[INFO] Worker \$SLURM_PROCID: starting Ray worker (attempt \$((count+1))/$WORKER_NUM_RETRIES)..."
+  cat <<EOFINNER | bash
 ray start --address "$ip_head" \
           --disable-usage-stats \
           --resources="\$RAY_RESOURCES" \
@@ -502,44 +669,31 @@ ray start --address "$ip_head" \
           --metrics-export-port=${METRICS_EXPORT_PORT} \
           $RAY_DEBUGGER_ARGS \
           \
-          --block 
+          --block
 EOFINNER
-
-count=0
-while [[ \$count -lt $num_retries ]]; do
-  if [[ -n "$SETUP_COMMAND_FILE" ]] && [[ -f "$SETUP_COMMAND_FILE" ]]; then
-    echo "[INFO] Running setup command from $SETUP_COMMAND_FILE..."
-    bash "$SETUP_COMMAND_FILE"
-  fi
-  bash /launch-worker.sh
   count=\$((count+1))
-  echo "Worker failed \$count/$num_retries times, restarting in 5 seconds..."
-  sleep 5
+  echo "[WARN] Worker \$SLURM_PROCID failed \$count/$WORKER_NUM_RETRIES times, restarting in 10 seconds..."
+  sleep 10
 done
 touch $LOG_DIR/ENDED
 exit 1
 EOF
 )
-  srun $COMMON_SRUN_ARGS --container-name=ray-worker-$i --exact --nodes=1 --ntasks=1 --cpus-per-task=$CPUS_PER_WORKER -w "$node_i" -o $LOG_DIR/ray-worker-$i.log bash -x -c "$worker_cmd" &
-  SRUN_PIDS["ray-worker-$i"]=$!
-  sleep 3
-done
 
-# Then we wait here for the file to be created by the head node container
-while check_srun_processes && ! srun --overlap --nodes=1 --ntasks=1 -w $head_node test -f $LOG_DIR/STARTED_RAY_HEAD; do
-  echo "[INFO][$(date)] Waiting for head node container to start..."
-  sleep 2
-done
+# Validate the generated head/worker scripts before submitting them to the cluster.
+bash -n <(printf '%s' "$head_cmd") || { echo "[FATAL] Head script has syntax errors" >&2; exit 1; }
+bash -n <(printf '%s' "$worker_cmd") || { echo "[FATAL] Worker script has syntax errors" >&2; exit 1; }
 
 ########################################################
 # Optional sandbox sidecar for NeMo-Skills-backed Gym resources.
+# Launched first so it boots in parallel with the Ray head/workers. Each per-node
+# task starts the sandbox, polls its local port, and on success touches
+# SANDBOX_READY_<hostname> so the head can gate the driver on all instances.
 ########################################################
 export SLURM_MASTER_NODE=$(scontrol show hostnames $SLURM_JOB_NODELIST | head -n1)
+SANDBOX_PORT="${NEMO_SKILLS_SANDBOX_PORT:-6000}"
 
 if [[ -n "${SANDBOX_CONTAINER:-}" ]] && [[ -n "${SANDBOX_COMMAND:-}" ]]; then
-  SANDBOX_PORTS_DIR="$LOG_DIR/sandbox"
-  mkdir -p "$SANDBOX_PORTS_DIR"
-
   SANDBOX_MOUNTS="$SANDBOX_PORTS_DIR:$SANDBOX_PORTS_DIR"
   if [[ -n "${SANDBOX_EXTRA_MOUNTS:-}" ]]; then
     SANDBOX_MOUNTS="${SANDBOX_EXTRA_MOUNTS},${SANDBOX_MOUNTS}"
@@ -550,9 +704,9 @@ if [[ -n "${SANDBOX_CONTAINER:-}" ]] && [[ -n "${SANDBOX_COMMAND:-}" ]]; then
     SANDBOX_EXPORTS="${SANDBOX_EXPORTS},${SANDBOX_ENV_VARS}"
   fi
 
-  echo "[INFO] Starting sandbox sidecars on all allocated nodes (ports_dir=$SANDBOX_PORTS_DIR)..."
-  srun --output "$LOG_DIR/sandbox.log" \
-    --error "$LOG_DIR/sandbox.log" \
+  echo "[INFO] Starting sandbox sidecars on all allocated nodes (ports_dir=$SANDBOX_PORTS_DIR, port=$SANDBOX_PORT)..."
+  srun --output "$SANDBOX_PORTS_DIR/sandbox-%t.log" \
+    --error "$SANDBOX_PORTS_DIR/sandbox-%t.log" \
     --container-image="$SANDBOX_CONTAINER" \
     --container-mounts="$SANDBOX_MOUNTS" \
     --no-container-mount-home \
@@ -565,49 +719,112 @@ if [[ -n "${SANDBOX_CONTAINER:-}" ]] && [[ -n "${SANDBOX_COMMAND:-}" ]]; then
     --nodes="$SLURM_JOB_NUM_NODES" \
     --ntasks-per-node=1 \
     --export="$SANDBOX_EXPORTS" \
-    bash -c "$SANDBOX_COMMAND" &
+    bash -xc '
+      ('"$SANDBOX_COMMAND"') &
+      SANDBOX_PID=$!
+      deadline=$((SECONDS + 300))
+      while ! (echo > /dev/tcp/localhost/'"$SANDBOX_PORT"') 2>/dev/null; do
+        if ! kill -0 $SANDBOX_PID 2>/dev/null; then
+          echo "[ERROR] Sandbox process died before becoming ready on $(hostname)"
+          exit 1
+        fi
+        if (( SECONDS > deadline )); then
+          echo "[ERROR] Sandbox not ready on $(hostname) after 5 min"
+          exit 1
+        fi
+        sleep 2
+      done
+      touch '"$SANDBOX_PORTS_DIR"'/SANDBOX_READY_$(hostname)
+      echo "[INFO] Sandbox ready on $(hostname):'"$SANDBOX_PORT"'"
+      wait $SANDBOX_PID
+    ' &
   SRUN_PIDS["sandbox"]=$!
   echo "[INFO] Sandbox sidecar started in background (PID: ${SRUN_PIDS["sandbox"]})"
 else
   echo "[INFO] SANDBOX_CONTAINER or SANDBOX_COMMAND not defined, skipping sandbox startup"
 fi
 
-# At this stage the Ray cluster bringup has started on the physical nodes in the allocation
-# Before we launch a job on this cluster we need to make sure that the bringup is complete
-# We do so by querying the number of worker_units in the ray cluster and asserting = NUM_ACTORS
-extract_worker_units() {
-  status_output=$(srun --overlap --container-name=ray-head --nodes=1 --ntasks=1 -w "$head_node" ray status)
-  if echo "$status_output" | grep -q "worker_units"; then
-    worker_units=$(echo "$status_output" | grep "worker_units" | awk -F'[/. ]' '{print $4}')
-    echo $worker_units
-  else
-    echo 0
-  fi
-}
+# Start the Ray head.
+srun $COMMON_SRUN_ARGS --container-name=ray-head --nodes=1 --ntasks=1 --cpus-per-task=$CPUS_PER_WORKER -w "$head_node" -o $LOG_DIR/ray-head.log bash -x -c "$head_cmd" &
+SRUN_PIDS["ray-head"]=$!
 
-# Poll to make sure that all Ray worker nodes have connected to the head.
-# All workers have connected when number of GPUs in ray cluster
-# is equal to NUM_ACTORS. We use the utility function above
-# to check how many GPUs have come online in the ray cluster
-while true; do
-  worker_units=$(extract_worker_units)
-  echo "[INFO] Number of actors online: $worker_units/$NUM_ACTORS"
-  if [[ "$worker_units" -eq "$NUM_ACTORS" ]]; then
-    break
-  fi
-  check_srun_processes
+# Start the Ray workers (all nodes except the head) with a single batched srun, so
+# the number of srun/slurmctld RPCs stays constant regardless of node count. In
+# single-node mode there are no workers: the head already registers its GPUs as Ray
+# resources.
+_num_workers=$((SLURM_JOB_NUM_NODES - 1))
+if [[ $_num_workers -gt 0 ]]; then
+  # srun -o with %t produces per-task log files; zero-pad to the worker-count
+  # width so ray-worker-*.log filenames sort naturally (e.g. ray-worker-007.log).
+  _task_digits=${#_num_workers}
+  srun $COMMON_SRUN_ARGS --container-name=ray-worker --exact \
+    --nodes=$_num_workers \
+    --ntasks=$_num_workers \
+    --ntasks-per-node=1 \
+    --cpus-per-task=$CPUS_PER_WORKER \
+    --kill-on-bad-exit=0 \
+    --exclude="$head_node" \
+    -o "$LOG_DIR/ray-worker-%0${_task_digits}t.log" \
+    bash -x -c "$worker_cmd" &
+  SRUN_PIDS["ray-workers"]=$!
+else
+  echo "[INFO] Single-node mode: head node is the only compute node, no workers to launch"
+fi
+
+# Wait for the head container to report, via a shared-FS file, that the Ray head
+# GCS is ready.
+while check_srun_processes && ! test -f "$LOG_DIR/STARTED_RAY_HEAD"; do
+  echo "[INFO][$(date)] Waiting for Ray head GCS to be ready..."
   sleep 2
 done
 
-echo "All workers connected!"
-
-# We can now launch a job on this cluster
-# We do so by launching a driver process on the physical node that the head node is on
-# This driver process is responsible for launching a job on the Ray cluster
-CONTAINER_CWD=$(scontrol show job $SLURM_JOB_ID | grep -oP 'WorkDir=\K[^ ]+' | head -1)
 if [[ -n "$COMMAND" ]]; then
-  srun --no-container-mount-home --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "$head_node" -o $LOG_DIR/ray-driver.log bash -c "$COMMAND"
+  # Non-interactive: the head container polls for workers, gates on sandbox
+  # readiness, runs the driver (-> ray-driver.log), and exits with its status, which
+  # we propagate.
+  #
+  # While waiting on the head, also watch the worker/sandbox sruns: if one dies
+  # during bringup (e.g. a failed node), signal ENDED and stop promptly instead of
+  # stalling until the head's 30-min worker deadline. check_srun_processes isn't used
+  # here because it also watches the head, whose exit is the normal success path.
+  set +e
+  while kill -0 "${SRUN_PIDS["ray-head"]}" 2>/dev/null; do
+    for _name in ray-workers sandbox; do
+      _pid="${SRUN_PIDS[$_name]:-}"
+      if [[ -n "$_pid" ]] && ! kill -0 "$_pid" 2>/dev/null; then
+        echo "[ERROR] Background srun '$_name' (pid=$_pid) exited before the head; failing fast." >&2
+        touch "$LOG_DIR/ENDED"
+        break 2
+      fi
+    done
+    sleep 2
+  done
+  wait "${SRUN_PIDS["ray-head"]}"
+  exit_code=$?
+  set -e
+  exit $exit_code
 else
+  # Interactive: poll for workers from the submit host by reading the file the
+  # head's ray-status-sidecar publishes, then write the attach helper and idle.
+  RAY_STATUS_DEADLINE=$((SECONDS + 1800))
+  while true; do
+    worker_units=$(cat "$LOG_DIR/ray_worker_units" 2>/dev/null || echo -1)
+    echo "[INFO] Number of actors online: $worker_units/$NUM_ACTORS"
+    if [[ "$worker_units" -eq "$NUM_ACTORS" ]]; then
+      break
+    fi
+    check_srun_processes
+    if (( SECONDS > RAY_STATUS_DEADLINE )); then
+      echo "[ERROR] Timed out waiting for all workers to connect ($worker_units/$NUM_ACTORS after 30 min)"
+      touch "$LOG_DIR/ENDED"
+      exit 1
+    fi
+    sleep 5
+  done
+
+  echo "All workers connected!"
+
+  CONTAINER_CWD=$(scontrol show job $SLURM_JOB_ID | grep -oP 'WorkDir=\K[^ ]+' | head -1)
   echo "[INFO]: Ray Cluster is idled, run this on the slurm head node to get a shell to the head node:"
   cat <<EOF >$SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh
 # No args launches on the head node (node 0)
@@ -615,31 +832,36 @@ else
 # Optional: set COMMAND='...' to run non-interactively instead of opening an interactive shell
 WORKER_NUM=\${1:-}
 if [[ -z "\$WORKER_NUM" ]]; then
-  # Empty means we are on the head node
   if [[ -n "\${COMMAND:-}" ]]; then
     srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "$head_node" --jobid $SLURM_JOB_ID bash -c "\$COMMAND"
   else
     srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-head --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "$head_node" --jobid $SLURM_JOB_ID --pty bash
   fi
+elif [[ $SLURM_JOB_NUM_NODES -eq 1 ]]; then
+  echo "Error: Single-node mode — only the head node is available. Run without arguments."
+  exit 1
 else
-  # Worker numbers 1 through N-1 correspond to ray-worker-1 through ray-worker-(N-1)
-  # and use nodes_array[1] through nodes_array[N-1]
+  # All workers share the container name 'ray-worker'; target a specific one by node.
+  # Log files are 0-indexed: worker K maps to ray-worker-(K-1).log
   if [[ \$WORKER_NUM -lt 1 || \$WORKER_NUM -ge $SLURM_JOB_NUM_NODES ]]; then
     echo "Error: WORKER_NUM must be between 1 and $((SLURM_JOB_NUM_NODES-1))"
     exit 1
   fi
   nodes_array=($nodes)
+  node="\${nodes_array[\$WORKER_NUM]}"
   if [[ -n "\${COMMAND:-}" ]]; then
-    srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-worker-\$WORKER_NUM --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "\${nodes_array[\$WORKER_NUM]}" --jobid $SLURM_JOB_ID bash -c "\$COMMAND"
+    srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-worker --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "\$node" --jobid $SLURM_JOB_ID bash -c "\$COMMAND"
   else
-    srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-worker-\$WORKER_NUM --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "\${nodes_array[\$WORKER_NUM]}" --jobid $SLURM_JOB_ID --pty bash
+    srun --no-container-mount-home $GRES_ARG -A $SLURM_JOB_ACCOUNT -p $SLURM_JOB_PARTITION --overlap --container-name=ray-worker --container-workdir=$CONTAINER_CWD --nodes=1 --ntasks=1 -w "\$node" --jobid $SLURM_JOB_ID --pty bash
   fi
 fi
 EOF
   chmod +x $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh
   echo "     COMMAND='echo hello' bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh    # run a non-interactive command on head node"
   echo "     bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh    # to attach to head node (i.e., 'worker 0')"
-  echo "     bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh 1  # to attach to worker 1"
-  echo "     bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh 2  # to attach to worker 2, etc."
+  if [[ $SLURM_JOB_NUM_NODES -gt 1 ]]; then
+    echo "     bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh 1  # to attach to worker 1"
+    echo "     bash $SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh 2  # to attach to worker 2, etc."
+  fi
   sleep infinity
 fi


### PR DESCRIPTION
# What does this PR do ?

`ray.sub` previously scales srun/slurmctld RPCs with the node count: it launches one srun per worker (each followed by a 3s sleep), slept a fixed 120s before workers, polls head readiness via `srun --overlap test -f`, and polls cluster status via repeated `srun ... ray status`. For larger jobs, this dominates cluster bringup time and risks throttling slurmctld.

This PR replaces the per-node fan-out with shared-filesystem file signaling so srun calls stay constant relative to the node count:

1. Launch all workers with a single batched srun (--nodes/--ntasks=N-1, --ntasks-per-node=1, --exclude=head); workers self-identify via SLURM_PROCID / SLURMD_NODENAME. This change drops the per-worker loop, the 3s stagger, and the 120s sleep.
2.  Start the head without --block and touch STARTED_RAY_HEAD only after the GCS is listening, so workers connect on the first try; workers poll that file before `ray start --address` and retry the GCS connect.
3. A head-side ray-status sidecar publishes the live worker_units count to a file; the submit host reads it instead of issuing `srun ... ray status` RPCs.
4. The head container runs the driver inline (via a driver_command.sh file) and the submit host just waits on the head srun, removing the dedicated driver srun.
5. Sandbox readiness becomes a blocking gate: each per-node sandbox task polls its local port and touches `SANDBOX_READY_<host>`; the head waits for all instances before launching the driver. The `SANDBOX_PORTS_DIR` signal dir is always mounted and exported, independent of the `SANDBOX_EXTRA_MOUNTS` / `SANDBOX_ENV_VARS` knobs.

This change assumes that the LOG_DIR is on a shared filesystem visible across compute nodes.


This change also does the following:
1. cleans stale Ray session state inside the head and worker retry loops
2. Adds 0-indexed, zero-padded worker logs for natural sorting
3. Suffix LOG_DIR with SLURM_RESTART_COUNT so a requeue does not clobber the previous attempt's logs and signal files


# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
