### PR TITLE
ci: List bundled codecs

### DIFF
--- a/tools/list_codecs.sh
+++ b/tools/list_codecs.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Lists all bundled codecs in the current container environment.
+# For each library also shows: install path, and which package pulled it in.
 # Run inside the container: bash tools/list_codecs.sh
 
 set -euo pipefail
@@ -11,11 +12,57 @@ section() {
     echo "========================================"
 }
 
+# Print install path + reverse-dependency info for a Python package.
+# Usage: py_provenance <import_name> <pip_package_name>
+py_provenance() {
+    local import_name="$1"
+    local pip_name="$2"
+    python3 - <<PYEOF
+import importlib, subprocess, sys
+
+# File path
+try:
+    mod = importlib.import_module("$import_name")
+    path = getattr(mod, "__file__", None) or getattr(mod, "__path__", ["(namespace)"])[0]
+    print(f"  path:        {path}")
+except ImportError:
+    print("  (not importable)")
+    sys.exit(0)
+
+# pip show: Location + Required-by
+try:
+    out = subprocess.check_output(
+        [sys.executable, "-m", "pip", "show", "$pip_name"],
+        stderr=subprocess.DEVNULL, text=True
+    )
+    for line in out.splitlines():
+        if line.startswith("Location:") or line.startswith("Required-by:"):
+            print(f"  {line}")
+except Exception:
+    pass
+
+# pipdeptree reverse tree (if available)
+try:
+    tree = subprocess.check_output(
+        [sys.executable, "-m", "pipdeptree", "--reverse", "--packages", "$pip_name"],
+        stderr=subprocess.DEVNULL, text=True
+    ).strip()
+    if tree:
+        print("  reverse-dep tree:")
+        for l in tree.splitlines():
+            print(f"    {l}")
+except Exception:
+    pass
+PYEOF
+}
+
 # ---------------------------------------------------------------------------
 # 1. Video / Audio codecs (ffmpeg)
 # ---------------------------------------------------------------------------
 section "VIDEO/AUDIO CODECS (ffmpeg)"
 if command -v ffmpeg &>/dev/null; then
+    echo "  path: $(command -v ffmpeg)"
+    echo ""
     echo "--- All codecs ---"
     ffmpeg -codecs 2>/dev/null || true
     echo ""
@@ -36,6 +83,7 @@ fi
 # ---------------------------------------------------------------------------
 section "VIDEO/AUDIO CODECS (GStreamer)"
 if command -v gst-inspect-1.0 &>/dev/null; then
+    echo "  path: $(command -v gst-inspect-1.0)"
     gst-inspect-1.0 --print-all 2>/dev/null | grep -i codec || true
 else
     echo "gst-inspect-1.0 not found — skipping"
@@ -56,35 +104,76 @@ fi
 # ---------------------------------------------------------------------------
 section "COMPRESSION CODECS (Python stdlib)"
 python3 - <<'EOF'
-import sys
-codecs = []
+import sys, importlib
 for mod in ["zlib", "bz2", "lzma", "gzip", "zipfile"]:
     try:
-        __import__(mod)
-        codecs.append(mod)
+        m = importlib.import_module(mod)
+        path = getattr(m, "__file__", "(built-in)")
+        print(f"  {mod}: {path}")
     except ImportError:
-        pass
-print("Available:", ", ".join(codecs))
+        print(f"  {mod}: not available")
 EOF
 
 # ---------------------------------------------------------------------------
 # 5. Compression codecs — third-party Python
 # ---------------------------------------------------------------------------
 section "COMPRESSION CODECS (third-party Python)"
+
+echo "[blosc]"
 python3 - <<'EOF'
-checks = {
-    "blosc":     "import blosc; print('blosc compressors:', blosc.compressor_list())",
-    "numcodecs": "import numcodecs; print('numcodecs:', numcodecs.available_codecs())",
-    "pyarrow":   "import pyarrow; codecs=['lz4','zstd','snappy','brotli','gzip','bz2']; print('pyarrow available:', [c for c in codecs if pyarrow.Codec.is_available(c)])",
-    "zarr":      "import zarr; print('zarr codec registry:', list(zarr.codec_registry.keys()) if hasattr(zarr,'codec_registry') else 'N/A')",
-    "h5py":      "import h5py; print('h5py version:', h5py.__version__, '| HDF5:', h5py.version.hdf5_version)",
-}
-for lib, code in checks.items():
-    try:
-        exec(code)
-    except Exception as e:
-        print(f"{lib}: not available ({e})")
+try:
+    import blosc
+    print("  codecs:", blosc.compressor_list())
+except ImportError as e:
+    print(f"  not available ({e})")
 EOF
+py_provenance blosc blosc
+
+echo ""
+echo "[numcodecs]"
+python3 - <<'EOF'
+try:
+    import numcodecs
+    print("  codecs:", numcodecs.available_codecs())
+except ImportError as e:
+    print(f"  not available ({e})")
+EOF
+py_provenance numcodecs numcodecs
+
+echo ""
+echo "[pyarrow]"
+python3 - <<'EOF'
+try:
+    import pyarrow
+    supported = [c for c in ['lz4','zstd','snappy','brotli','gzip','bz2'] if pyarrow.Codec.is_available(c)]
+    print("  codecs:", supported)
+except ImportError as e:
+    print(f"  not available ({e})")
+EOF
+py_provenance pyarrow pyarrow
+
+echo ""
+echo "[zarr]"
+python3 - <<'EOF'
+try:
+    import zarr
+    reg = list(zarr.codec_registry.keys()) if hasattr(zarr, 'codec_registry') else 'N/A'
+    print("  codec registry:", reg)
+except ImportError as e:
+    print(f"  not available ({e})")
+EOF
+py_provenance zarr zarr
+
+echo ""
+echo "[h5py]"
+python3 - <<'EOF'
+try:
+    import h5py
+    print(f"  h5py {h5py.__version__} | HDF5 {h5py.version.hdf5_version}")
+except ImportError as e:
+    print(f"  not available ({e})")
+EOF
+py_provenance h5py h5py
 
 # ---------------------------------------------------------------------------
 # 6. Image codecs — Pillow
@@ -94,9 +183,10 @@ python3 - <<'EOF'
 try:
     from PIL import features
     features.pilinfo()
-except ImportError:
-    print("Pillow not installed")
+except ImportError as e:
+    print(f"not available ({e})")
 EOF
+py_provenance PIL Pillow
 
 # ---------------------------------------------------------------------------
 # 7. Image codecs — OpenCV
@@ -106,9 +196,10 @@ python3 - <<'EOF'
 try:
     import cv2
     print(cv2.getBuildInformation())
-except ImportError:
-    print("opencv-python not installed")
+except ImportError as e:
+    print(f"not available ({e})")
 EOF
+py_provenance cv2 opencv-python
 
 # ---------------------------------------------------------------------------
 # 8. Image codecs — imagecodecs
@@ -118,9 +209,10 @@ python3 - <<'EOF'
 try:
     import imagecodecs
     print(imagecodecs.available())
-except ImportError:
-    print("imagecodecs not installed")
+except ImportError as e:
+    print(f"not available ({e})")
 EOF
+py_provenance imagecodecs imagecodecs
 
 # ---------------------------------------------------------------------------
 # 9. Image codecs — imageio
@@ -130,9 +222,10 @@ python3 - <<'EOF'
 try:
     import imageio
     print(imageio.formats.show())
-except ImportError:
-    print("imageio not installed")
+except ImportError as e:
+    print(f"not available ({e})")
 EOF
+py_provenance imageio imageio
 
 # ---------------------------------------------------------------------------
 # 10. Video codecs — PyAV
@@ -141,10 +234,11 @@ section "VIDEO CODECS (PyAV)"
 python3 - <<'EOF'
 try:
     import av
-    print("PyAV available codecs:", sorted(av.codec.codecs_available))
-except ImportError:
-    print("PyAV not installed")
+    print("available codecs:", sorted(av.codec.codecs_available))
+except ImportError as e:
+    print(f"not available ({e})")
 EOF
+py_provenance av av
 
 # ---------------------------------------------------------------------------
 # 11. Video codecs — decord
@@ -153,22 +247,24 @@ section "VIDEO CODECS (decord)"
 python3 - <<'EOF'
 try:
     import decord
-    print("decord version:", decord.__version__)
-except ImportError:
-    print("decord not installed")
+    print("version:", decord.__version__)
+except ImportError as e:
+    print(f"not available ({e})")
 EOF
+py_provenance decord decord
 
 # ---------------------------------------------------------------------------
 # 12. TIFF codecs — tifffile
 # ---------------------------------------------------------------------------
-section "IMAGE CODECS (tifffile / TIFF compressions)"
+section "IMAGE CODECS (tifffile)"
 python3 - <<'EOF'
 try:
     import tifffile
     print("TIFF compressions:", list(tifffile.TIFF.COMPRESSION.__members__.keys()))
-except ImportError:
-    print("tifffile not installed")
+except ImportError as e:
+    print(f"not available ({e})")
 EOF
+py_provenance tifffile tifffile
 
 # ---------------------------------------------------------------------------
 # 13. System packages (apt/dpkg)

--- a/tools/list_codecs.sh
+++ b/tools/list_codecs.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 # Resolve python and ffmpeg — PATH is often minimal inside srun containers
 # ---------------------------------------------------------------------------
-PYTHON=/opt/nemo_rl_venv/bin/python3
+PYTHON=/opt/nemo_rl_venv/bin/python3.13
 echo "Using Python: $PYTHON"
 run_python() { "$PYTHON" "$@"; }
 

--- a/tools/list_codecs.sh
+++ b/tools/list_codecs.sh
@@ -5,6 +5,31 @@
 
 set -euo pipefail
 
+# ---------------------------------------------------------------------------
+# Resolve python and ffmpeg — PATH is often minimal inside srun containers
+# ---------------------------------------------------------------------------
+PYTHON=""
+for candidate in python3 python /usr/bin/python3 /usr/local/bin/python3 /opt/conda/bin/python3 /opt/conda/bin/python; do
+    if command -v "$candidate" &>/dev/null; then
+        PYTHON="$candidate"
+        break
+    fi
+done
+if [[ -z "$PYTHON" ]]; then
+    echo "ERROR: no Python interpreter found. Tried: python3 python /usr/bin/python3 /usr/local/bin/python3 /opt/conda/bin/python3"
+    exit 1
+fi
+echo "Using Python: $PYTHON ($(command -v "$PYTHON"))"
+
+FFMPEG=""
+for candidate in ffmpeg /usr/bin/ffmpeg /usr/local/bin/ffmpeg /opt/conda/bin/ffmpeg; do
+    if command -v "$candidate" &>/dev/null; then
+        FFMPEG="$candidate"
+        break
+    fi
+done
+[[ -z "$FFMPEG" ]] && echo "ffmpeg not found on PATH or common locations — video codec sections will be skipped"
+
 section() {
     echo ""
     echo "========================================"
@@ -17,7 +42,7 @@ section() {
 py_provenance() {
     local import_name="$1"
     local pip_name="$2"
-    python3 - <<PYEOF
+    "$PYTHON" - <<PYEOF
 import importlib, subprocess, sys
 
 # File path
@@ -60,20 +85,20 @@ PYEOF
 # 1. Video / Audio codecs (ffmpeg)
 # ---------------------------------------------------------------------------
 section "VIDEO/AUDIO CODECS (ffmpeg)"
-if command -v ffmpeg &>/dev/null; then
-    echo "  path: $(command -v ffmpeg)"
+if [[ -n "$FFMPEG" ]]; then
+    echo "  path: $FFMPEG"
     echo ""
     echo "--- All codecs ---"
-    ffmpeg -codecs 2>/dev/null || true
+    "$FFMPEG" -codecs 2>/dev/null || true
     echo ""
     echo "--- Encoders ---"
-    ffmpeg -encoders 2>/dev/null || true
+    "$FFMPEG" -encoders 2>/dev/null || true
     echo ""
     echo "--- Decoders ---"
-    ffmpeg -decoders 2>/dev/null || true
+    "$FFMPEG" -decoders 2>/dev/null || true
     echo ""
     echo "--- Container formats ---"
-    ffmpeg -formats 2>/dev/null || true
+    "$FFMPEG" -formats 2>/dev/null || true
 else
     echo "ffmpeg not found — skipping"
 fi
@@ -103,7 +128,7 @@ fi
 # 4. Compression codecs — Python stdlib
 # ---------------------------------------------------------------------------
 section "COMPRESSION CODECS (Python stdlib)"
-python3 - <<'EOF'
+"$PYTHON" - <<'EOF'
 import sys, importlib
 for mod in ["zlib", "bz2", "lzma", "gzip", "zipfile"]:
     try:
@@ -120,7 +145,7 @@ EOF
 section "COMPRESSION CODECS (third-party Python)"
 
 echo "[blosc]"
-python3 - <<'EOF'
+"$PYTHON" - <<'EOF'
 try:
     import blosc
     print("  codecs:", blosc.compressor_list())
@@ -131,7 +156,7 @@ py_provenance blosc blosc
 
 echo ""
 echo "[numcodecs]"
-python3 - <<'EOF'
+"$PYTHON" - <<'EOF'
 try:
     import numcodecs
     print("  codecs:", numcodecs.available_codecs())
@@ -142,7 +167,7 @@ py_provenance numcodecs numcodecs
 
 echo ""
 echo "[pyarrow]"
-python3 - <<'EOF'
+"$PYTHON" - <<'EOF'
 try:
     import pyarrow
     supported = [c for c in ['lz4','zstd','snappy','brotli','gzip','bz2'] if pyarrow.Codec.is_available(c)]
@@ -154,7 +179,7 @@ py_provenance pyarrow pyarrow
 
 echo ""
 echo "[zarr]"
-python3 - <<'EOF'
+"$PYTHON" - <<'EOF'
 try:
     import zarr
     reg = list(zarr.codec_registry.keys()) if hasattr(zarr, 'codec_registry') else 'N/A'
@@ -166,7 +191,7 @@ py_provenance zarr zarr
 
 echo ""
 echo "[h5py]"
-python3 - <<'EOF'
+"$PYTHON" - <<'EOF'
 try:
     import h5py
     print(f"  h5py {h5py.__version__} | HDF5 {h5py.version.hdf5_version}")
@@ -179,7 +204,7 @@ py_provenance h5py h5py
 # 6. Image codecs — Pillow
 # ---------------------------------------------------------------------------
 section "IMAGE CODECS (Pillow)"
-python3 - <<'EOF'
+"$PYTHON" - <<'EOF'
 try:
     from PIL import features
     features.pilinfo()
@@ -192,7 +217,7 @@ py_provenance PIL Pillow
 # 7. Image codecs — OpenCV
 # ---------------------------------------------------------------------------
 section "IMAGE CODECS (OpenCV)"
-python3 - <<'EOF'
+"$PYTHON" - <<'EOF'
 try:
     import cv2
     print(cv2.getBuildInformation())
@@ -205,7 +230,7 @@ py_provenance cv2 opencv-python
 # 8. Image codecs — imagecodecs
 # ---------------------------------------------------------------------------
 section "IMAGE CODECS (imagecodecs)"
-python3 - <<'EOF'
+"$PYTHON" - <<'EOF'
 try:
     import imagecodecs
     print(imagecodecs.available())
@@ -218,7 +243,7 @@ py_provenance imagecodecs imagecodecs
 # 9. Image codecs — imageio
 # ---------------------------------------------------------------------------
 section "IMAGE CODECS (imageio)"
-python3 - <<'EOF'
+"$PYTHON" - <<'EOF'
 try:
     import imageio
     print(imageio.formats.show())
@@ -231,7 +256,7 @@ py_provenance imageio imageio
 # 10. Video codecs — PyAV
 # ---------------------------------------------------------------------------
 section "VIDEO CODECS (PyAV)"
-python3 - <<'EOF'
+"$PYTHON" - <<'EOF'
 try:
     import av
     print("available codecs:", sorted(av.codec.codecs_available))
@@ -244,7 +269,7 @@ py_provenance av av
 # 11. Video codecs — decord
 # ---------------------------------------------------------------------------
 section "VIDEO CODECS (decord)"
-python3 - <<'EOF'
+"$PYTHON" - <<'EOF'
 try:
     import decord
     print("version:", decord.__version__)
@@ -257,7 +282,7 @@ py_provenance decord decord
 # 12. TIFF codecs — tifffile
 # ---------------------------------------------------------------------------
 section "IMAGE CODECS (tifffile)"
-python3 - <<'EOF'
+"$PYTHON" - <<'EOF'
 try:
     import tifffile
     print("TIFF compressions:", list(tifffile.TIFF.COMPRESSION.__members__.keys()))

--- a/tools/list_codecs.sh
+++ b/tools/list_codecs.sh
@@ -8,20 +8,22 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
-# Resolve python and ffmpeg — PATH is often minimal inside srun containers
+# Resolve uv and ffmpeg — PATH is often minimal inside srun containers
 # ---------------------------------------------------------------------------
-PYTHON=""
-for candidate in /opt/nemo_rl_venv/bin/python python3 python /usr/bin/python3 /usr/local/bin/python3 /opt/conda/bin/python3 /opt/conda/bin/python; do
+UV=""
+for candidate in uv /usr/local/bin/uv /opt/conda/bin/uv ~/.cargo/bin/uv; do
     if command -v "$candidate" &>/dev/null; then
-        PYTHON="$candidate"
+        UV="$candidate"
         break
     fi
 done
-if [[ -z "$PYTHON" ]]; then
-    echo "ERROR: no Python interpreter found. Tried: /opt/nemo_rl_venv/bin/python python3 python /usr/bin/python3 /usr/local/bin/python3 /opt/conda/bin/python3"
+if [[ -z "$UV" ]]; then
+    echo "ERROR: uv not found. Tried: uv /usr/local/bin/uv /opt/conda/bin/uv ~/.cargo/bin/uv"
     exit 1
 fi
-echo "Using Python: $PYTHON ($(command -v "$PYTHON"))"
+echo "Using uv: $UV ($(command -v "$UV"))"
+# Convenience wrapper — use run_python instead of "$PYTHON" throughout
+run_python() { "$UV" run python "$@"; }
 
 FFMPEG=""
 for candidate in ffmpeg /usr/bin/ffmpeg /usr/local/bin/ffmpeg /opt/conda/bin/ffmpeg; do
@@ -62,7 +64,7 @@ section() {
 py_provenance() {
     local import_name="$1"
     local pip_name="$2"
-    "$PYTHON" - <<PYEOF
+    run_python - <<PYEOF
 import importlib, subprocess, sys
 
 try:
@@ -152,7 +154,7 @@ fi
 # 4. Compression codecs — Python stdlib
 # ---------------------------------------------------------------------------
 section "COMPRESSION CODECS (Python stdlib)"
-"$PYTHON" - <<'EOF'
+run_python - <<'EOF'
 import sys, importlib
 for mod in ["zlib", "bz2", "lzma", "gzip", "zipfile"]:
     try:
@@ -169,7 +171,7 @@ EOF
 section "COMPRESSION CODECS (third-party Python)"
 
 echo "[blosc]"
-"$PYTHON" - <<'EOF'
+run_python - <<'EOF'
 try:
     import blosc
     print("  codecs:", blosc.compressor_list())
@@ -180,7 +182,7 @@ py_provenance blosc blosc
 
 echo ""
 echo "[numcodecs]"
-"$PYTHON" - <<'EOF'
+run_python - <<'EOF'
 try:
     import numcodecs
     print("  codecs:", numcodecs.available_codecs())
@@ -191,7 +193,7 @@ py_provenance numcodecs numcodecs
 
 echo ""
 echo "[pyarrow]"
-"$PYTHON" - <<'EOF'
+run_python - <<'EOF'
 try:
     import pyarrow
     supported = [c for c in ['lz4','zstd','snappy','brotli','gzip','bz2'] if pyarrow.Codec.is_available(c)]
@@ -203,7 +205,7 @@ py_provenance pyarrow pyarrow
 
 echo ""
 echo "[zarr]"
-"$PYTHON" - <<'EOF'
+run_python - <<'EOF'
 try:
     import zarr
     reg = list(zarr.codec_registry.keys()) if hasattr(zarr, 'codec_registry') else 'N/A'
@@ -215,7 +217,7 @@ py_provenance zarr zarr
 
 echo ""
 echo "[h5py]"
-"$PYTHON" - <<'EOF'
+run_python - <<'EOF'
 try:
     import h5py
     print(f"  h5py {h5py.__version__} | HDF5 {h5py.version.hdf5_version}")
@@ -228,7 +230,7 @@ py_provenance h5py h5py
 # 6. Image codecs — Pillow
 # ---------------------------------------------------------------------------
 section "IMAGE CODECS (Pillow)"
-"$PYTHON" - <<'EOF'
+run_python - <<'EOF'
 try:
     from PIL import features
     features.pilinfo()
@@ -241,7 +243,7 @@ py_provenance PIL Pillow
 # 7. Image codecs — OpenCV (highlights codec-relevant lines)
 # ---------------------------------------------------------------------------
 section "IMAGE CODECS (OpenCV)"
-CV2_OUT=$("$PYTHON" - <<'EOF'
+CV2_OUT=$(run_python - <<'EOF'
 try:
     import cv2
     print(cv2.getBuildInformation())
@@ -257,7 +259,7 @@ py_provenance cv2 opencv-python
 # 8. Image codecs — imagecodecs
 # ---------------------------------------------------------------------------
 section "IMAGE CODECS (imagecodecs)"
-"$PYTHON" - <<'EOF'
+run_python - <<'EOF'
 try:
     import imagecodecs
     print(imagecodecs.available())
@@ -270,7 +272,7 @@ py_provenance imagecodecs imagecodecs
 # 9. Image codecs — imageio
 # ---------------------------------------------------------------------------
 section "IMAGE CODECS (imageio)"
-"$PYTHON" - <<'EOF'
+run_python - <<'EOF'
 try:
     import imageio
     print(imageio.formats.show())
@@ -283,7 +285,7 @@ py_provenance imageio imageio
 # 10. Video codecs — PyAV
 # ---------------------------------------------------------------------------
 section "VIDEO CODECS (PyAV)"
-PYAV_OUT=$("$PYTHON" - <<'EOF'
+PYAV_OUT=$(run_python - <<'EOF'
 try:
     import av
     print("available codecs:", sorted(av.codec.codecs_available))
@@ -299,7 +301,7 @@ py_provenance av av
 # 11. Video codecs — decord
 # ---------------------------------------------------------------------------
 section "VIDEO CODECS (decord)"
-"$PYTHON" - <<'EOF'
+run_python - <<'EOF'
 try:
     import decord
     print("version:", decord.__version__)
@@ -312,7 +314,7 @@ py_provenance decord decord
 # 12. TIFF codecs — tifffile
 # ---------------------------------------------------------------------------
 section "IMAGE CODECS (tifffile)"
-"$PYTHON" - <<'EOF'
+run_python - <<'EOF'
 try:
     import tifffile
     print("TIFF compressions:", list(tifffile.TIFF.COMPRESSION.__members__.keys()))
@@ -342,7 +344,7 @@ fi
 #     e.g. av.libs/libx264-*.so, opencv_python.libs/libavcodec-*.so
 # ---------------------------------------------------------------------------
 section "BUNDLED .SO LIBS IN PYTHON WHEEL PACKAGES (auditwheel)"
-"$PYTHON" - <<'PYEOF'
+run_python - <<'PYEOF'
 import sys, os, re, subprocess
 
 site_dirs = [p for p in sys.path if "site-packages" in p and os.path.isdir(p)]
@@ -371,7 +373,7 @@ if not found_any:
 PYEOF
 
 # Flag royalty-bearing .so names specifically
-PYEOF_OUT=$("$PYTHON" - <<'PYEOF'
+PYEOF_OUT=$(run_python - <<'PYEOF'
 import sys, os
 
 site_dirs = [p for p in sys.path if "site-packages" in p and os.path.isdir(p)]

--- a/tools/list_codecs.sh
+++ b/tools/list_codecs.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# Lists all bundled codecs in the current container environment.
+# Run inside the container: bash tools/list_codecs.sh
+
+set -euo pipefail
+
+section() {
+    echo ""
+    echo "========================================"
+    echo "  $1"
+    echo "========================================"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Video / Audio codecs (ffmpeg)
+# ---------------------------------------------------------------------------
+section "VIDEO/AUDIO CODECS (ffmpeg)"
+if command -v ffmpeg &>/dev/null; then
+    echo "--- All codecs ---"
+    ffmpeg -codecs 2>/dev/null || true
+    echo ""
+    echo "--- Encoders ---"
+    ffmpeg -encoders 2>/dev/null || true
+    echo ""
+    echo "--- Decoders ---"
+    ffmpeg -decoders 2>/dev/null || true
+    echo ""
+    echo "--- Container formats ---"
+    ffmpeg -formats 2>/dev/null || true
+else
+    echo "ffmpeg not found — skipping"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. GStreamer
+# ---------------------------------------------------------------------------
+section "VIDEO/AUDIO CODECS (GStreamer)"
+if command -v gst-inspect-1.0 &>/dev/null; then
+    gst-inspect-1.0 --print-all 2>/dev/null | grep -i codec || true
+else
+    echo "gst-inspect-1.0 not found — skipping"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Compression codecs — system libraries
+# ---------------------------------------------------------------------------
+section "COMPRESSION CODECS (system libraries)"
+if command -v ldconfig &>/dev/null; then
+    ldconfig -p 2>/dev/null | grep -E 'lz4|zstd|snappy|brotli|lzma|zlib|bz2' || echo "none found"
+else
+    echo "ldconfig not available"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Compression codecs — Python stdlib
+# ---------------------------------------------------------------------------
+section "COMPRESSION CODECS (Python stdlib)"
+python3 - <<'EOF'
+import sys
+codecs = []
+for mod in ["zlib", "bz2", "lzma", "gzip", "zipfile"]:
+    try:
+        __import__(mod)
+        codecs.append(mod)
+    except ImportError:
+        pass
+print("Available:", ", ".join(codecs))
+EOF
+
+# ---------------------------------------------------------------------------
+# 5. Compression codecs — third-party Python
+# ---------------------------------------------------------------------------
+section "COMPRESSION CODECS (third-party Python)"
+python3 - <<'EOF'
+checks = {
+    "blosc":     "import blosc; print('blosc compressors:', blosc.compressor_list())",
+    "numcodecs": "import numcodecs; print('numcodecs:', numcodecs.available_codecs())",
+    "pyarrow":   "import pyarrow; codecs=['lz4','zstd','snappy','brotli','gzip','bz2']; print('pyarrow available:', [c for c in codecs if pyarrow.Codec.is_available(c)])",
+    "zarr":      "import zarr; print('zarr codec registry:', list(zarr.codec_registry.keys()) if hasattr(zarr,'codec_registry') else 'N/A')",
+    "h5py":      "import h5py; print('h5py version:', h5py.__version__, '| HDF5:', h5py.version.hdf5_version)",
+}
+for lib, code in checks.items():
+    try:
+        exec(code)
+    except Exception as e:
+        print(f"{lib}: not available ({e})")
+EOF
+
+# ---------------------------------------------------------------------------
+# 6. Image codecs — Pillow
+# ---------------------------------------------------------------------------
+section "IMAGE CODECS (Pillow)"
+python3 - <<'EOF'
+try:
+    from PIL import features
+    features.pilinfo()
+except ImportError:
+    print("Pillow not installed")
+EOF
+
+# ---------------------------------------------------------------------------
+# 7. Image codecs — OpenCV
+# ---------------------------------------------------------------------------
+section "IMAGE CODECS (OpenCV)"
+python3 - <<'EOF'
+try:
+    import cv2
+    print(cv2.getBuildInformation())
+except ImportError:
+    print("opencv-python not installed")
+EOF
+
+# ---------------------------------------------------------------------------
+# 8. Image codecs — imagecodecs
+# ---------------------------------------------------------------------------
+section "IMAGE CODECS (imagecodecs)"
+python3 - <<'EOF'
+try:
+    import imagecodecs
+    print(imagecodecs.available())
+except ImportError:
+    print("imagecodecs not installed")
+EOF
+
+# ---------------------------------------------------------------------------
+# 9. Image codecs — imageio
+# ---------------------------------------------------------------------------
+section "IMAGE CODECS (imageio)"
+python3 - <<'EOF'
+try:
+    import imageio
+    print(imageio.formats.show())
+except ImportError:
+    print("imageio not installed")
+EOF
+
+# ---------------------------------------------------------------------------
+# 10. Video codecs — PyAV
+# ---------------------------------------------------------------------------
+section "VIDEO CODECS (PyAV)"
+python3 - <<'EOF'
+try:
+    import av
+    print("PyAV available codecs:", sorted(av.codec.codecs_available))
+except ImportError:
+    print("PyAV not installed")
+EOF
+
+# ---------------------------------------------------------------------------
+# 11. Video codecs — decord
+# ---------------------------------------------------------------------------
+section "VIDEO CODECS (decord)"
+python3 - <<'EOF'
+try:
+    import decord
+    print("decord version:", decord.__version__)
+except ImportError:
+    print("decord not installed")
+EOF
+
+# ---------------------------------------------------------------------------
+# 12. TIFF codecs — tifffile
+# ---------------------------------------------------------------------------
+section "IMAGE CODECS (tifffile / TIFF compressions)"
+python3 - <<'EOF'
+try:
+    import tifffile
+    print("TIFF compressions:", list(tifffile.TIFF.COMPRESSION.__members__.keys()))
+except ImportError:
+    print("tifffile not installed")
+EOF
+
+# ---------------------------------------------------------------------------
+# 13. System packages (apt/dpkg)
+# ---------------------------------------------------------------------------
+section "SYSTEM PACKAGES (codec-related)"
+if command -v dpkg &>/dev/null; then
+    dpkg -l 2>/dev/null | grep -E 'ffmpeg|codec|libav|x264|x265|vpx|aom|opus|vorbis|theora|libde265|hevc' || echo "none found"
+else
+    echo "dpkg not available"
+fi
+
+echo ""
+echo "Done."

--- a/tools/list_codecs.sh
+++ b/tools/list_codecs.sh
@@ -10,17 +10,7 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 # Resolve python and ffmpeg — PATH is often minimal inside srun containers
 # ---------------------------------------------------------------------------
-PYTHON=""
-for candidate in /opt/nemo_rl_venv/bin/python3.13 /opt/nemo_rl_venv/bin/python /opt/nemo_rl_venv/bin/python3 python3 python /usr/bin/python3 /usr/local/bin/python3 /opt/conda/bin/python3 /opt/conda/bin/python; do
-    if [[ -x "$candidate" ]] || command -v "$candidate" &>/dev/null; then
-        PYTHON="$candidate"
-        break
-    fi
-done
-if [[ -z "$PYTHON" ]]; then
-    echo "ERROR: no Python interpreter found."
-    exit 1
-fi
+PYTHON=/opt/nemo_rl_venv/bin/python3
 echo "Using Python: $PYTHON"
 run_python() { "$PYTHON" "$@"; }
 

--- a/tools/list_codecs.sh
+++ b/tools/list_codecs.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # Resolve python and ffmpeg — PATH is often minimal inside srun containers
 # ---------------------------------------------------------------------------
 PYTHON=""
-for candidate in python3 python /usr/bin/python3 /usr/local/bin/python3 /opt/conda/bin/python3 /opt/conda/bin/python; do
+for candidate in /opt/nemo_rl_venv/bin/python python3 python /usr/bin/python3 /usr/local/bin/python3 /opt/conda/bin/python3 /opt/conda/bin/python; do
     if command -v "$candidate" &>/dev/null; then
         PYTHON="$candidate"
         break

--- a/tools/list_codecs.sh
+++ b/tools/list_codecs.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 # Resolve python and ffmpeg — PATH is often minimal inside srun containers
 # ---------------------------------------------------------------------------
 PYTHON=""
-for candidate in /opt/nemo_rl_venv/bin/python /opt/nemo_rl_venv/bin/python3 python3 python /usr/bin/python3 /usr/local/bin/python3 /opt/conda/bin/python3 /opt/conda/bin/python; do
+for candidate in /opt/nemo_rl_venv/bin/python3.13 /opt/nemo_rl_venv/bin/python /opt/nemo_rl_venv/bin/python3 python3 python /usr/bin/python3 /usr/local/bin/python3 /opt/conda/bin/python3 /opt/conda/bin/python; do
     if [[ -x "$candidate" ]] || command -v "$candidate" &>/dev/null; then
         PYTHON="$candidate"
         break

--- a/tools/list_codecs.sh
+++ b/tools/list_codecs.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Lists all bundled codecs in the current container environment.
-# For each library also shows: install path, and which package pulled it in.
+# For each library: install path, pip provenance, reverse-dep tree.
+# Scans auditwheel *.libs/ dirs for bundled .so files (e.g. libx264 inside PyAV).
+# Ends with a ROYALTY-BEARING CODEC SUMMARY for OSRB point 12.
 # Run inside the container: bash tools/list_codecs.sh
 
 set -euo pipefail
@@ -16,7 +18,7 @@ for candidate in /opt/nemo_rl_venv/bin/python python3 python /usr/bin/python3 /u
     fi
 done
 if [[ -z "$PYTHON" ]]; then
-    echo "ERROR: no Python interpreter found. Tried: python3 python /usr/bin/python3 /usr/local/bin/python3 /opt/conda/bin/python3"
+    echo "ERROR: no Python interpreter found. Tried: /opt/nemo_rl_venv/bin/python python3 python /usr/bin/python3 /usr/local/bin/python3 /opt/conda/bin/python3"
     exit 1
 fi
 echo "Using Python: $PYTHON ($(command -v "$PYTHON"))"
@@ -29,6 +31,24 @@ for candidate in ffmpeg /usr/bin/ffmpeg /usr/local/bin/ffmpeg /opt/conda/bin/ffm
     fi
 done
 [[ -z "$FFMPEG" ]] && echo "ffmpeg not found on PATH or common locations — video codec sections will be skipped"
+
+# Royalty-bearing codec pattern (AAC, H.264, H.265 and all variants)
+ROYALTY_PATTERN='libx264|libx265|libh264|libh265|libaac|libfaac|libfdk.aac|libopenh264|libde265|hevc|x264|x265|avc.*enc|h264.*enc|h265.*enc|hvec'
+
+# Accumulate royalty hits across all sections into this file
+ROYALTY_TMP=$(mktemp)
+trap 'rm -f "$ROYALTY_TMP"' EXIT
+
+flag_royalty() {
+    # flag_royalty <section_name> <text>
+    local section="$1"
+    local text="$2"
+    if echo "$text" | grep -iE "$ROYALTY_PATTERN" &>/dev/null; then
+        echo "$text" | grep -iE "$ROYALTY_PATTERN" | while IFS= read -r line; do
+            echo "  [$section] $line" >> "$ROYALTY_TMP"
+        done
+    fi
+}
 
 section() {
     echo ""
@@ -45,7 +65,6 @@ py_provenance() {
     "$PYTHON" - <<PYEOF
 import importlib, subprocess, sys
 
-# File path
 try:
     mod = importlib.import_module("$import_name")
     path = getattr(mod, "__file__", None) or getattr(mod, "__path__", ["(namespace)"])[0]
@@ -54,7 +73,6 @@ except ImportError:
     print("  (not importable)")
     sys.exit(0)
 
-# pip show: Location + Required-by
 try:
     out = subprocess.check_output(
         [sys.executable, "-m", "pip", "show", "$pip_name"],
@@ -66,7 +84,6 @@ try:
 except Exception:
     pass
 
-# pipdeptree reverse tree (if available)
 try:
     tree = subprocess.check_output(
         [sys.executable, "-m", "pipdeptree", "--reverse", "--packages", "$pip_name"],
@@ -88,8 +105,13 @@ section "VIDEO/AUDIO CODECS (ffmpeg)"
 if [[ -n "$FFMPEG" ]]; then
     echo "  path: $FFMPEG"
     echo ""
+    echo "--- Build configuration (configure flags) ---"
+    "$FFMPEG" -buildconf 2>/dev/null || true
+    echo ""
     echo "--- All codecs ---"
-    "$FFMPEG" -codecs 2>/dev/null || true
+    FFMPEG_CODECS=$("$FFMPEG" -codecs 2>/dev/null || true)
+    echo "$FFMPEG_CODECS"
+    flag_royalty "ffmpeg -codecs" "$FFMPEG_CODECS"
     echo ""
     echo "--- Encoders ---"
     "$FFMPEG" -encoders 2>/dev/null || true
@@ -109,7 +131,9 @@ fi
 section "VIDEO/AUDIO CODECS (GStreamer)"
 if command -v gst-inspect-1.0 &>/dev/null; then
     echo "  path: $(command -v gst-inspect-1.0)"
-    gst-inspect-1.0 --print-all 2>/dev/null | grep -i codec || true
+    GST_OUT=$(gst-inspect-1.0 --print-all 2>/dev/null | grep -i codec || true)
+    echo "$GST_OUT"
+    flag_royalty "GStreamer" "$GST_OUT"
 else
     echo "gst-inspect-1.0 not found — skipping"
 fi
@@ -214,16 +238,19 @@ EOF
 py_provenance PIL Pillow
 
 # ---------------------------------------------------------------------------
-# 7. Image codecs — OpenCV
+# 7. Image codecs — OpenCV (highlights codec-relevant lines)
 # ---------------------------------------------------------------------------
 section "IMAGE CODECS (OpenCV)"
-"$PYTHON" - <<'EOF'
+CV2_OUT=$("$PYTHON" - <<'EOF'
 try:
     import cv2
     print(cv2.getBuildInformation())
 except ImportError as e:
     print(f"not available ({e})")
 EOF
+)
+echo "$CV2_OUT"
+flag_royalty "OpenCV getBuildInformation" "$CV2_OUT"
 py_provenance cv2 opencv-python
 
 # ---------------------------------------------------------------------------
@@ -256,13 +283,16 @@ py_provenance imageio imageio
 # 10. Video codecs — PyAV
 # ---------------------------------------------------------------------------
 section "VIDEO CODECS (PyAV)"
-"$PYTHON" - <<'EOF'
+PYAV_OUT=$("$PYTHON" - <<'EOF'
 try:
     import av
     print("available codecs:", sorted(av.codec.codecs_available))
 except ImportError as e:
     print(f"not available ({e})")
 EOF
+)
+echo "$PYAV_OUT"
+flag_royalty "PyAV codecs" "$PYAV_OUT"
 py_provenance av av
 
 # ---------------------------------------------------------------------------
@@ -296,9 +326,95 @@ py_provenance tifffile tifffile
 # ---------------------------------------------------------------------------
 section "SYSTEM PACKAGES (codec-related)"
 if command -v dpkg &>/dev/null; then
-    dpkg -l 2>/dev/null | grep -E 'ffmpeg|codec|libav|x264|x265|vpx|aom|opus|vorbis|theora|libde265|hevc' || echo "none found"
+    DPKG_OUT=$(dpkg -l 2>/dev/null | grep -E 'ffmpeg|codec|libav|x264|x265|vpx|aom|opus|vorbis|theora|libde265|hevc' || true)
+    if [[ -n "$DPKG_OUT" ]]; then
+        echo "$DPKG_OUT"
+        flag_royalty "dpkg" "$DPKG_OUT"
+    else
+        echo "none found"
+    fi
 else
     echo "dpkg not available"
+fi
+
+# ---------------------------------------------------------------------------
+# 14. Bundled .so libs inside Python wheel *.libs/ dirs (auditwheel packages)
+#     e.g. av.libs/libx264-*.so, opencv_python.libs/libavcodec-*.so
+# ---------------------------------------------------------------------------
+section "BUNDLED .SO LIBS IN PYTHON WHEEL PACKAGES (auditwheel)"
+"$PYTHON" - <<'PYEOF'
+import sys, os, re, subprocess
+
+site_dirs = [p for p in sys.path if "site-packages" in p and os.path.isdir(p)]
+found_any = False
+
+for site in site_dirs:
+    for entry in sorted(os.listdir(site)):
+        libs_dir = os.path.join(site, entry, "libs") if "." not in entry else os.path.join(site, entry + ".libs")
+        # also handle e.g. av.libs as a direct dir under site-packages
+        alt_libs_dir = os.path.join(site, entry.replace("-", "_") + ".libs")
+        for d in [libs_dir, alt_libs_dir]:
+            if not os.path.isdir(d):
+                continue
+            sos = sorted(f for f in os.listdir(d) if f.endswith(".so") or ".so." in f)
+            if not sos:
+                continue
+            found_any = True
+            pkg = entry
+            print(f"\n  Package : {pkg}")
+            print(f"  libs dir: {d}")
+            for so in sos:
+                print(f"    {so}")
+
+if not found_any:
+    print("  No *.libs/ directories found under site-packages.")
+PYEOF
+
+# Flag royalty-bearing .so names specifically
+PYEOF_OUT=$("$PYTHON" - <<'PYEOF'
+import sys, os
+
+site_dirs = [p for p in sys.path if "site-packages" in p and os.path.isdir(p)]
+import re
+pattern = re.compile(r'libx264|libx265|libh264|libh265|libaac|libfaac|libfdk|libopenh264|libde265|libavcodec|libavformat|libavutil|libswscale', re.IGNORECASE)
+
+for site in site_dirs:
+    for entry in sorted(os.listdir(site)):
+        for suffix in [".libs", "/libs"]:
+            d = os.path.join(site, entry.replace("-","_") + ".libs") if suffix == ".libs" else os.path.join(site, entry, "libs")
+            if not os.path.isdir(d):
+                continue
+            for so in os.listdir(d):
+                if pattern.search(so):
+                    print(f"  [{entry}] {d}/{so}")
+PYEOF
+)
+if [[ -n "$PYEOF_OUT" ]]; then
+    echo ""
+    echo "  *** ROYALTY-RELEVANT .so files found inside wheel packages: ***"
+    echo "$PYEOF_OUT"
+    flag_royalty "auditwheel .so" "$PYEOF_OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# 15. ROYALTY-BEARING CODEC SUMMARY (for OSRB point 12)
+# ---------------------------------------------------------------------------
+section "ROYALTY-BEARING CODEC SUMMARY (OSRB point 12)"
+echo "  Codecs matching royalty pattern: AAC, H.264/x264, H.265/x265/HEVC and variants"
+echo ""
+if [[ -s "$ROYALTY_TMP" ]]; then
+    echo "  *** ACTION REQUIRED — the following royalty-bearing codecs were detected: ***"
+    echo ""
+    sort -u "$ROYALTY_TMP"
+    echo ""
+    echo "  Per NVIDIA OSRB policy:"
+    echo "    - Remove unused codecs, OR"
+    echo "    - Replace with HW codecs (NVENC/NVDEC), OR"
+    echo "    - Obtain org3 management approval before distribution"
+    echo "    - Disclose all findings in OSRB submission point 12"
+else
+    echo "  No royalty-bearing codecs detected."
+    echo "  (Still verify manually — this script may not catch statically linked codecs.)"
 fi
 
 echo ""

--- a/tools/list_codecs.sh
+++ b/tools/list_codecs.sh
@@ -8,22 +8,21 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
-# Resolve uv and ffmpeg — PATH is often minimal inside srun containers
+# Resolve python and ffmpeg — PATH is often minimal inside srun containers
 # ---------------------------------------------------------------------------
-UV=""
-for candidate in uv /usr/local/bin/uv /opt/conda/bin/uv ~/.cargo/bin/uv; do
-    if command -v "$candidate" &>/dev/null; then
-        UV="$candidate"
+PYTHON=""
+for candidate in /opt/nemo_rl_venv/bin/python /opt/nemo_rl_venv/bin/python3 python3 python /usr/bin/python3 /usr/local/bin/python3 /opt/conda/bin/python3 /opt/conda/bin/python; do
+    if [[ -x "$candidate" ]] || command -v "$candidate" &>/dev/null; then
+        PYTHON="$candidate"
         break
     fi
 done
-if [[ -z "$UV" ]]; then
-    echo "ERROR: uv not found. Tried: uv /usr/local/bin/uv /opt/conda/bin/uv ~/.cargo/bin/uv"
+if [[ -z "$PYTHON" ]]; then
+    echo "ERROR: no Python interpreter found."
     exit 1
 fi
-echo "Using uv: $UV ($(command -v "$UV"))"
-# Convenience wrapper — use run_python instead of "$PYTHON" throughout
-run_python() { "$UV" run python "$@"; }
+echo "Using Python: $PYTHON"
+run_python() { "$PYTHON" "$@"; }
 
 FFMPEG=""
 for candidate in ffmpeg /usr/bin/ffmpeg /usr/local/bin/ffmpeg /opt/conda/bin/ffmpeg; do


### PR DESCRIPTION
# What does this PR do ?

tools: add list_codecs.sh to enumerate all bundled codecs

## Summary
- Adds `tools/list_codecs.sh` to enumerate all bundled codecs in the container
- Covers video/audio (ffmpeg, GStreamer), compression (stdlib, blosc, numcodecs, pyarrow, zarr, h5py), and image/video (Pillow, OpenCV, imagecodecs, imageio, PyAV, decord, tifffile)
- For each library: shows install path, pip location, and reverse-dependency tree (which package pulled it in)



## Test plan
- [ ] Run `bash tools/list_codecs.sh` inside the RL container