### PR TITLE
feat: add grpo-smoke recipe for quick install validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ uv venv</code></pre>
 > [!TIP]
 > **Smoke test:** to validate your install end-to-end more quickly, run the smoke recipe — it switches to GSM8K and caps the run at 10 steps:
 > ```sh
-> uv run examples/run_grpo.py --config examples/configs/recipes/llm/grpo-smoke.yaml
+> uv run examples/run_grpo.py --config examples/configs/grpo-smoke.yaml
 > ```
 
 ## Prerequisites

--- a/README.md
+++ b/README.md
@@ -198,6 +198,12 @@ uv venv</code></pre>
   </tbody>
 </table>
 
+> [!TIP]
+> **Smoke test:** to validate your install end-to-end more quickly, run the smoke recipe — it switches to GSM8K and caps the run at 10 steps:
+> ```sh
+> uv run examples/run_grpo.py --config examples/configs/recipes/llm/grpo-smoke.yaml
+> ```
+
 ## Prerequisites
 
 Clone **NeMo RL**.

--- a/docs/about/quick-start.md
+++ b/docs/about/quick-start.md
@@ -38,3 +38,12 @@ uv run examples/run_grpo.py \
   --config examples/configs/grpo_math_1B_megatron.yaml
 ```
 
+### Smoke Test
+
+To validate your install end-to-end more quickly, use the smoke recipe — it switches to GSM8K and caps the run at 10 optimizer steps:
+
+```sh
+uv run examples/run_grpo.py \
+  --config examples/configs/recipes/llm/grpo-smoke.yaml
+```
+

--- a/docs/about/quick-start.md
+++ b/docs/about/quick-start.md
@@ -44,6 +44,6 @@ To validate your install end-to-end more quickly, use the smoke recipe — it sw
 
 ```sh
 uv run examples/run_grpo.py \
-  --config examples/configs/recipes/llm/grpo-smoke.yaml
+  --config examples/configs/grpo-smoke.yaml
 ```
 

--- a/examples/configs/grpo-smoke.yaml
+++ b/examples/configs/grpo-smoke.yaml
@@ -2,8 +2,8 @@
 # 10 steps so users can validate their install end-to-end more quickly.
 #
 # Usage:
-#   uv run examples/run_grpo.py --config examples/configs/recipes/llm/grpo-smoke.yaml
-defaults: ../../grpo_math_1B.yaml
+#   uv run examples/run_grpo.py --config examples/configs/grpo-smoke.yaml
+defaults: grpo_math_1B.yaml
 grpo:
   num_prompts_per_step: 2
   num_generations_per_prompt: 4

--- a/examples/configs/recipes/llm/grpo-smoke.yaml
+++ b/examples/configs/recipes/llm/grpo-smoke.yaml
@@ -1,0 +1,25 @@
+# Smoke-test recipe layered on grpo_math_1B.yaml — switches to GSM8K and runs
+# 10 steps so users can validate their install end-to-end more quickly.
+#
+# Usage:
+#   uv run examples/run_grpo.py --config examples/configs/recipes/llm/grpo-smoke.yaml
+defaults: ../../grpo_math_1B.yaml
+grpo:
+  num_prompts_per_step: 2
+  num_generations_per_prompt: 4
+  max_num_steps: 10
+  val_period: -1
+  val_at_start: false
+  val_at_end: false
+checkpointing:
+  enabled: false
+policy:
+  model_name: Qwen/Qwen3-0.6B
+  train_global_batch_size: 8
+  train_micro_batch_size: 8
+data:
+  train:
+    dataset_name: gsm8k
+cluster:
+  gpus_per_node: 1
+  num_nodes: 1

--- a/examples/configs/recipes/llm/grpo-smoke.yaml
+++ b/examples/configs/recipes/llm/grpo-smoke.yaml
@@ -9,8 +9,6 @@ grpo:
   num_generations_per_prompt: 4
   max_num_steps: 10
   val_period: -1
-  val_at_start: false
-  val_at_end: false
 checkpointing:
   enabled: false
 policy:
@@ -20,6 +18,3 @@ policy:
 data:
   train:
     dataset_name: gsm8k
-cluster:
-  gpus_per_node: 1
-  num_nodes: 1


### PR DESCRIPTION
## Summary

Add `examples/configs/grpo-smoke.yaml`, a thin recipe layered on `grpo_math_1B.yaml` that switches to GSM8K and runs 10 steps so users can validate their install end-to-end more quickly. Linked from `README.md` and `docs/about/quick-start.md`.

Closes #2726.

## Timings (1 GPU, Qwen3-0.6B)

First run:
```
▶ Worker Initialization Timing:
  vLLM init: 58.4s
  Policy init: 19.4s
  Other setup: 13.7s
  Total setup: 91.5s

total time for init + 10 steps: 3m13.322s
```

Second run (warm cache):
```
▶ Worker Initialization Timing:
  vLLM init: 28.4s
  Policy init: 8.0s
  Other setup: 10.5s
  Total setup: 46.9s

total time for init + 10 steps: 2m7.525s
```

Dataset preparation takes almost no time.
```
main/train-00000-of-00001.parquet: 100%|███████████████████████████████████████████████████████████████| 2.31M/2.31M [00:01<00:00, 1.49MB/s]
main/test-00000-of-00001.parquet: 100%|██████████████████████████████████████████████████████████████████| 419k/419k [00:00<00:00, 1.52MB/s]
Generating train split: 100%|████████████████████████████████████████████████████████████████| 7473/7473 [00:00<00:00, 686556.14 examples/s]
Generating test split: 100%|█████████████████████████████████████████████████████████████████| 1319/1319 [00:00<00:00, 524785.33 examples/s]
Map: 100%|████████████████████████████████████████████████████████████████████████████████████| 7473/7473 [00:00<00:00, 52552.39 examples/s]
```

## Test plan
- [x] `uv run examples/run_grpo.py --config examples/configs/grpo-smoke.yaml` completes on 1 GPU.
