### PR TITLE
feat: support router replay (R3) without the dataplane

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -83,7 +83,10 @@ from nemo_rl.experience.rollouts import (
 from nemo_rl.models.generation.interfaces import GenerationInterface
 from nemo_rl.models.generation.sglang import SGLangConfig, SGLangGeneration
 from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration
-from nemo_rl.models.megatron.router_replay import configure_vllm_for_router_replay
+from nemo_rl.models.megatron.router_replay import (
+    configure_vllm_for_router_replay,
+    router_replay_enabled,
+)
 from nemo_rl.models.policy import PolicyConfig
 from nemo_rl.models.policy.interfaces import ColocatablePolicyInterface
 from nemo_rl.models.policy.lm_policy import Policy
@@ -2152,6 +2155,18 @@ def grpo_train(
                         as_tensors=False
                     )
                     train_data.update(extra_multimodal_data)
+                    # Router replay (R3) on the legacy data_plane.enabled=false
+                    # driver path: routed_experts already rides flat_messages
+                    # (attached to message_log during rollout, then batched into
+                    # a [B, S, L, K] tensor by batched_message_log_to_flat_message),
+                    # but the train_data whitelist above drops it. Copy it back so
+                    # the Megatron worker's train-stage router-replay guard finds
+                    # it. Mirrors the TQ producer (sync_rollout_actor.py).
+                    if (
+                        router_replay_enabled(master_config.policy)
+                        and "routed_experts" in flat_messages
+                    ):
+                        train_data["routed_experts"] = flat_messages["routed_experts"]
                     train_data.to("cpu")
 
                     metrics_logging_data["content"] = flat_messages["content"]
@@ -2195,6 +2210,18 @@ def grpo_train(
                             **extra_multimodal_data,
                         }
                     )
+                    # Router replay (R3): the prev-logprobs forward replays the
+                    # recorded routed_experts, so logprob_data must carry the
+                    # field too (it is a separate whitelist from train_data). The
+                    # reference-policy logprobs call reuses logprob_data but
+                    # intentionally ignores routed_experts (require_router_replay
+                    # =False short-circuits before the field is read), so a
+                    # present-but-unused field here is safe.
+                    if (
+                        router_replay_enabled(master_config.policy)
+                        and "routed_experts" in flat_messages
+                    ):
+                        logprob_data["routed_experts"] = flat_messages["routed_experts"]
 
                     if not skip_prev_logprobs:
                         train_data["prev_logprobs"] = policy.get_logprobs(

--- a/tests/unit/data/test_llm_message_utils.py
+++ b/tests/unit/data/test_llm_message_utils.py
@@ -378,6 +378,81 @@ def test_batch_pad_message_log_custom_pad_value(
     )
 
 
+@pytest.mark.parametrize("make_sequence_length_divisible_by", [1, 8])
+def test_batched_message_log_to_flat_message_carries_routed_experts(
+    make_sequence_length_divisible_by: int,
+) -> None:
+    """Router replay (R3): a per-message ``routed_experts`` tensor must survive
+    the flat-message batching as a 4D ``[B, S, L, K]`` tensor, right-padded and
+    row-aligned to ``token_ids``.
+
+    This is the precondition the ``data_plane.enabled=false`` R3 path depends on:
+    ``grpo_train`` copies ``flat_messages["routed_experts"]`` into
+    ``train_data`` / ``logprob_data`` (gated on ``router_replay_enabled``), and
+    the Megatron worker expects exactly a 4D ``[batch, seq, num_moe_layers,
+    topk]`` tensor (``nemo_rl/models/megatron/data.py``). If the key were dropped
+    or reshaped here, the dp-off copy would silently no-op and training would
+    fail late in the worker's router-replay guard.
+    """
+    num_layers, topk = 2, 4
+
+    def routes(start: int, n: int) -> torch.Tensor:
+        # Row i is the constant value (start + i) across all [L, K] entries, so
+        # padding (which is 0) is distinguishable from real routes.
+        vals = torch.arange(start, start + n, dtype=torch.long)
+        return vals.view(n, 1, 1).expand(n, num_layers, topk).contiguous()
+
+    message_log_batch: list[LLMMessageLogType] = [
+        [  # sample 0: 2 tokens, single message (shorter -> gets right-padded)
+            {
+                "role": "user",
+                "token_ids": torch.tensor([1, 2]),
+                "routed_experts": routes(10, 2),
+            },
+        ],
+        [  # sample 1: 3 tokens spread across two messages -> concatenated
+            {
+                "role": "user",
+                "token_ids": torch.tensor([3, 4]),
+                "routed_experts": routes(20, 2),
+            },
+            {
+                "role": "assistant",
+                "token_ids": torch.tensor([5]),
+                "routed_experts": routes(30, 1),
+            },
+        ],
+    ]
+
+    flat, input_lengths = batched_message_log_to_flat_message(
+        message_log_batch,
+        make_sequence_length_divisible_by=make_sequence_length_divisible_by,
+    )
+
+    # The key survives batching and is a 4D [B, S, L, K] tensor whose seq dim
+    # matches token_ids (so DP-sharding applies one permutation to both).
+    assert "routed_experts" in flat
+    routed = flat["routed_experts"]
+    token_ids = flat["token_ids"]
+    batch_size, seq_len = token_ids.shape
+    assert batch_size == 2
+    assert seq_len % make_sequence_length_divisible_by == 0
+    assert routed.shape == (batch_size, seq_len, num_layers, topk)
+    assert routed.dim() == 4
+    assert input_lengths.tolist() == [2, 3]
+
+    # Valid prefix rows match the per-message concat, in token order...
+    assert torch.equal(routed[0, 0], routes(10, 1)[0])
+    assert torch.equal(routed[0, 1], routes(11, 1)[0])
+    assert torch.equal(routed[1, 0], routes(20, 1)[0])
+    assert torch.equal(routed[1, 1], routes(21, 1)[0])
+    assert torch.equal(routed[1, 2], routes(30, 1)[0])
+    # ...and the tail is right-padded with zeros (the worker repairs these pad
+    # rows to a valid route, arange(K), before feeding mcore).
+    assert torch.all(routed[0, 2:] == 0)
+    assert torch.all(routed[1, 3:] == 0)
+
+
 @pytest.mark.parametrize(
     "model_id, chat_log_transform",
     [


### PR DESCRIPTION
# What does this PR do ?


grpo_train (the legacy in-memory driver path, data_plane.enabled=false) built train_data and logprob_data from a fixed key allowlist and dropped routed_experts, so R3 only worked with the dataplane. Thread routed_experts from flat_messages into both train_data (for policy.train) and logprob_data (for the prev-logprob get_logprobs), gated on router_replay_enabled + key presence. The Megatron worker's require=True guards (train + prev-logprob) then find routed_experts on the driver path.
