### PR TITLE
fix(distillation): persist validation samples as JSONL

### DIFF
--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -673,6 +673,7 @@ def distillation_train(
             val_task_to_env,
             step=total_steps,
             master_config=master_config,
+            logger=logger,
         )
         student_generation.finish_generation()
         logger.log_metrics(val_metrics, total_steps, prefix="validation")
@@ -871,6 +872,7 @@ def distillation_train(
                         val_task_to_env,
                         step=total_steps + 1,
                         master_config=master_config,
+                        logger=logger,
                     )
                     student_generation.finish_generation()
                     logger.log_metrics(
@@ -1080,6 +1082,7 @@ def validate(
     val_task_to_env: Optional[dict[str, EnvironmentInterface]],
     step: int,
     master_config: MasterConfig,
+    logger: Optional[Logger] = None,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     """Run validation on the validation dataset."""
     if val_dataloader is None:
@@ -1214,6 +1217,14 @@ def validate(
     print("\n  ⏱️  Validation Timing:")
     validation_time = timing_metrics.get("total_validation_time", 0)
     print(f"    • Total validation time: {validation_time:.2f}s", flush=True)
+
+    # Log validation data to JSONL file
+    if logger is not None:
+        val_log_data = {
+            "content": all_message_logs,
+            "rewards": total_rewards,
+        }
+        logger.log_batched_dict_as_jsonl(val_log_data, f"val_data_step{step}.jsonl")
 
     # Make sure to reset the timer after validation
     timer.reset()

--- a/tests/unit/algorithms/test_distillation.py
+++ b/tests/unit/algorithms/test_distillation.py
@@ -341,6 +341,14 @@ def test_exit_on_timeout(mock_components, capsys):
 
 def test_validate_function(mock_components):
     """Test independent validation function to ensure validation logic correctness."""
+    logged_data = {}
+
+    def capture_log(data, filename):
+        logged_data["data"] = data
+        logged_data["filename"] = filename
+
+    mock_components["logger"].log_batched_dict_as_jsonl = MagicMock(side_effect=capture_log)
+
     # Run validation
     val_metrics, validation_timings = validate(
         mock_components["student_generation"],
@@ -349,14 +357,19 @@ def test_validate_function(mock_components):
         mock_components["val_task_to_env"],
         step=0,
         master_config=mock_components["master_config"],
+        logger=mock_components["logger"],
     )
 
     # Verify validation results
     assert isinstance(val_metrics, dict)
     assert isinstance(validation_timings, dict)
+    mock_components["logger"].log_batched_dict_as_jsonl.assert_called_once()
+    assert logged_data["filename"] == "val_data_step0.jsonl"
+    assert "content" in logged_data["data"]
+    assert "rewards" in logged_data["data"]
     # For distillation, we don't need environment interaction since max_rollout_turns=0
     # The validation focuses on generation and teacher-student knowledge transfer
-    # Note: validate() function itself doesn't call logger.log_metrics - that's done by the caller
+    # Note: validate() still doesn't call logger.log_metrics - that's done by the caller
 
 
 def test_validate_uses_nemo_gym_rollout_when_enabled(mock_components):

--- a/tests/unit/data/test_llm_message_utils.py
+++ b/tests/unit/data/test_llm_message_utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 import pytest
 import torch


### PR DESCRIPTION
Pass logger through distillation validation and write val_data_step{N}.jsonl so validation sample conversations and rewards are available after runs, matching GRPO behavior. Add a unit test assertion for the JSONL logging path.

# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues

https://github.com/NVIDIA-NeMo/RL/issues/2846