### PR TITLE
feat: add NCCL timeout config, stale ZMQ socket cleanup, OmegaConfig resolvers

### DIFF
--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import hashlib
 import json
 import os
@@ -159,8 +160,16 @@ def setup_distributed() -> None:
     destroy_parallel_state()
     # Pin the communicator to the correct GPU explicitly.
     local_rank = int(os.environ["LOCAL_RANK"])
+    # Provision to raise the default NCCL collective timeout: the HF->Megatron distcp reshard and the
+    # policy->vLLM refit can do very large cross-node collectives that can exceed the default timeout,
+    # especially over the slower Socket NCCL fallback (NCCL_NET=Socket). This sets _DEFAULT_PG_TIMEOUT,
+    # which later new_group() calls (megatron TP/PP/DP/EP/CP groups) inherit. Override via
+    # NRL_DIST_TIMEOUT_MINUTES (default 10 mins).
+    dist_timeout_min = int(os.environ.get("NRL_DIST_TIMEOUT_MINUTES", "10"))
     torch.distributed.init_process_group(
-        "nccl", device_id=torch.device(f"cuda:{local_rank}")
+        "nccl",
+        device_id=torch.device(f"cuda:{local_rank}"),
+        timeout=datetime.timedelta(minutes=dist_timeout_min),
     )
 
 

--- a/nemo_rl/models/policy/workers/base_policy_worker.py
+++ b/nemo_rl/models/policy/workers/base_policy_worker.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 from typing import Any, Optional
 
 import ray
@@ -87,7 +88,18 @@ class AbstractPolicyWorker:
                 zmq.RCVTIMEO, 120000
             )  # set timeout to 120 seconds
             self.zmq_socket.setsockopt(zmq.LINGER, 0)
-            self.zmq_socket.bind(self.get_zmq_address())
+            addr = self.get_zmq_address()
+            # Self-heal stale IPC sockets: an unclean exit (crash, kill -9, OOM) can skip
+            # shutdown(), so the prior run's ipc:// socket file can be left on disk and the
+            # bind below would fail with EADDRINUSE. The address is keyed by GPU UUID and
+            # each GPU maps to exactly one worker, so any existing file is a stale leftover
+            # (never a live binder) and is safe to remove. Runs per-worker, so it self-heals
+            # every node in a multinode run.
+            if addr.startswith("ipc://"):
+                stale_socket_path = addr[len("ipc://") :]
+                if os.path.exists(stale_socket_path):
+                    os.unlink(stale_socket_path)
+            self.zmq_socket.bind(addr)
 
     def get_free_memory_bytes(self) -> int:
         """Get the available free memory."""

--- a/nemo_rl/utils/config.py
+++ b/nemo_rl/utils/config.py
@@ -190,6 +190,10 @@ def parse_hydra_overrides(cfg: DictConfig, overrides: list[str]) -> DictConfig:
 
 def register_omegaconf_resolvers() -> None:
     """Register shared OmegaConf resolvers used in configs."""
+    if not OmegaConf.has_resolver("add"):
+        OmegaConf.register_new_resolver("add", lambda a, b: a + b)
+    if not OmegaConf.has_resolver("sub"):
+        OmegaConf.register_new_resolver("sub", lambda a, b: a - b)
     if not OmegaConf.has_resolver("mul"):
         OmegaConf.register_new_resolver("mul", lambda a, b: a * b)
     if not OmegaConf.has_resolver("div"):


### PR DESCRIPTION
# What does this PR do ?

- Add configurable NCCL collective timeout via NRL_DIST_TIMEOUT_MINUTES env var (default 10 mins) to handle slow cross-node collectives during HF->Megatron reshard and policy->vLLM refit.
- Self-heal stale IPC socket files in maybe_init_zmq() to prevent EADDRINUSE errors after unclean exits (crash, kill -9, OOM).
- Register "add" and "sub" OmegaConf resolvers for use in config files. Helps to have below auto calculations in config files for agent harnesses.
max_input_tokens: ${sub:${policy.generation.vllm_cfg.max_model_len}, ${policy.generation.max_new_tokens}}
max_output_tokens: ${policy.generation.max_new_tokens}

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
New tests not required.

/review-pr comments below:
Files changed: 3                                                                                                                                                          
                                                                                                                                                                            
  Findings (scored ≥80)                                                                                                                                                     
                                                                                                                                                                            
  None. LGTM.                                                                                                                                                               
                                                                                                                                                                            
  Filtered (scored <80)                                                                                                                                                     
                                                                                                                                                                            
  All candidates were either consistent with codebase conventions (env var ValueError — 92% confidence it's a non-issue) or pre-existing gaps (missing resolver tests). No  
  new bugs or guideline violations introduced by this diff.
                                                                                                                                                                            
  The changes are clean and ready. 
