### PR TITLE
DRAT: fix: run Nemotron Nano v2 workplace assistant recipe

### DIFF
--- a/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
+++ b/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
@@ -235,7 +235,7 @@ policy:
       kv_cache_dtype: "auto"
       expose_http_server: true
       skip_tokenizer_init: false
-      # tool_parser_plugin: ???  # This is set to the path for Nemotron Nano v2
+      tool_parser_plugin: nemo_rl/models/generation/vllm/tool_parsers/nemotron_json.py
       http_server_serving_chat_kwargs:
         # Workplace assistant uses 26 tools, so we enable auto_tools.
         # For Nemotron Nano v2, we use the dedicated `nemotron_json` tool parser

--- a/nemo_rl/models/generation/vllm/tool_parsers/nemotron_json.py
+++ b/nemo_rl/models/generation/vllm/tool_parsers/nemotron_json.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import re
+from collections.abc import Sequence
+from typing import Any
+
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    DeltaMessage,
+    FunctionCall,
+    ToolCall,
+)
+from vllm.logger import init_logger
+from vllm.tool_parsers.abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+    ToolParserManager,
+)
+
+logger = init_logger(__name__)
+
+
+@ToolParserManager.register_module("nemotron_json")
+class NemotronJSONToolParser(ToolParser):
+    """Nemotron Nano v2 non-streaming tool parser for vLLM."""
+
+    def __init__(self, tokenizer: Any, tools: Any | None = None) -> None:
+        try:
+            super().__init__(tokenizer, tools)
+        except TypeError:
+            super().__init__(tokenizer)
+        self.tool_call_start_token = "<TOOLCALL>"
+        self.tool_call_end_token = "</TOOLCALL>"
+        self.tool_call_regex = re.compile(r"<TOOLCALL>(.*?)</TOOLCALL>", re.DOTALL)
+
+    def extract_tool_calls(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest,
+    ) -> ExtractedToolCallInformation:
+        if self.tool_call_start_token not in model_output:
+            return ExtractedToolCallInformation(
+                tools_called=False,
+                tool_calls=[],
+                content=model_output,
+            )
+
+        tool_call_matches = self.tool_call_regex.findall(model_output)
+        if not tool_call_matches:
+            return ExtractedToolCallInformation(
+                tools_called=False,
+                tool_calls=[],
+                content=model_output,
+            )
+
+        try:
+            str_tool_calls = tool_call_matches[0].strip()
+            if not str_tool_calls.startswith("["):
+                str_tool_calls = "[" + str_tool_calls
+            if not str_tool_calls.endswith("]"):
+                str_tool_calls += "]"
+
+            tool_calls = []
+            for tool_call in json.loads(str_tool_calls):
+                try:
+                    arguments = tool_call["arguments"]
+                    if isinstance(arguments, dict):
+                        arguments = json.dumps(arguments, ensure_ascii=False)
+                    tool_calls.append(
+                        ToolCall(
+                            type="function",
+                            function=FunctionCall(
+                                name=tool_call["name"],
+                                arguments=arguments,
+                            ),
+                        )
+                    )
+                except (KeyError, TypeError):
+                    continue
+
+            if not tool_calls:
+                return ExtractedToolCallInformation(
+                    tools_called=False,
+                    tool_calls=[],
+                    content=model_output,
+                )
+
+            content = model_output[: model_output.rfind(self.tool_call_start_token)]
+            return ExtractedToolCallInformation(
+                tools_called=True,
+                tool_calls=tool_calls,
+                content=content or None,
+            )
+        except (json.JSONDecodeError, TypeError):
+            logger.debug("Failed to parse Nemotron tool call.", exc_info=True)
+            return ExtractedToolCallInformation(
+                tools_called=False,
+                tool_calls=[],
+                content=model_output,
+            )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+        request: ChatCompletionRequest,
+    ) -> DeltaMessage | None:
+        raise NotImplementedError("Tool calling is not supported in streaming mode.")

--- a/tests/unit/models/generation/vllm/test_nemotron_json_tool_parser.py
+++ b/tests/unit/models/generation/vllm/test_nemotron_json_tool_parser.py
@@ -1,0 +1,147 @@
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+def _load_nemotron_json_tool_parser(monkeypatch, tool_parser_cls):
+    registered_tool_parsers = {}
+
+    for module_name in (
+        "vllm",
+        "vllm.entrypoints",
+        "vllm.entrypoints.openai",
+        "vllm.entrypoints.openai.chat_completion",
+        "vllm.logger",
+        "vllm.tool_parsers",
+    ):
+        monkeypatch.setitem(sys.modules, module_name, types.ModuleType(module_name))
+
+    class FunctionCall:
+        def __init__(self, name, arguments):
+            self.name = name
+            self.arguments = arguments
+
+    class ToolCall:
+        def __init__(self, type, function):
+            self.type = type
+            self.function = function
+
+    class ExtractedToolCallInformation:
+        def __init__(self, tools_called, tool_calls, content):
+            self.tools_called = tools_called
+            self.tool_calls = tool_calls
+            self.content = content
+
+    class ToolParserManager:
+        @staticmethod
+        def register_module(name):
+            def decorator(parser_cls):
+                registered_tool_parsers[name] = parser_cls
+                return parser_cls
+
+            return decorator
+
+    protocol_module = types.ModuleType(
+        "vllm.entrypoints.openai.chat_completion.protocol"
+    )
+    protocol_module.ChatCompletionRequest = type("ChatCompletionRequest", (), {})
+    protocol_module.DeltaMessage = type("DeltaMessage", (), {})
+    protocol_module.FunctionCall = FunctionCall
+    protocol_module.ToolCall = ToolCall
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.entrypoints.openai.chat_completion.protocol",
+        protocol_module,
+    )
+
+    logger_module = types.ModuleType("vllm.logger")
+    logger_module.init_logger = lambda name: MagicMock()
+    monkeypatch.setitem(sys.modules, "vllm.logger", logger_module)
+
+    abstract_tool_parser_module = types.ModuleType(
+        "vllm.tool_parsers.abstract_tool_parser"
+    )
+    abstract_tool_parser_module.ExtractedToolCallInformation = (
+        ExtractedToolCallInformation
+    )
+    abstract_tool_parser_module.ToolParser = tool_parser_cls
+    abstract_tool_parser_module.ToolParserManager = ToolParserManager
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.tool_parsers.abstract_tool_parser",
+        abstract_tool_parser_module,
+    )
+
+    repo_root = Path(__file__).resolve().parents[5]
+    parser_path = (
+        repo_root / "nemo_rl/models/generation/vllm/tool_parsers/nemotron_json.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "test_nemotron_json_tool_parser",
+        parser_path,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    parser_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(parser_module)
+
+    return parser_module, registered_tool_parsers
+
+
+def test_nemotron_json_tool_parser_extracts_tool_calls(monkeypatch):
+    class ToolParser:
+        def __init__(self, tokenizer, tools):
+            self.tokenizer = tokenizer
+            self.tools = tools
+
+    parser_module, registered_tool_parsers = _load_nemotron_json_tool_parser(
+        monkeypatch,
+        ToolParser,
+    )
+
+    assert (
+        registered_tool_parsers["nemotron_json"]
+        is parser_module.NemotronJSONToolParser
+    )
+    parser = parser_module.NemotronJSONToolParser(tokenizer=object(), tools=[])
+
+    result = parser.extract_tool_calls(
+        (
+            "assistant text"
+            '<TOOLCALL>{"name": "email_search_emails", '
+            '"arguments": {"query": "status"}}</TOOLCALL>'
+        ),
+        request=object(),
+    )
+
+    assert result.tools_called is True
+    assert result.content == "assistant text"
+    assert len(result.tool_calls) == 1
+    tool_call = result.tool_calls[0]
+    assert tool_call.type == "function"
+    assert tool_call.function.name == "email_search_emails"
+    assert json.loads(tool_call.function.arguments) == {"query": "status"}
+
+
+def test_nemotron_json_tool_parser_ignores_malformed_tool_calls(monkeypatch):
+    class ToolParser:
+        def __init__(self, tokenizer):
+            self.tokenizer = tokenizer
+
+    parser_module, registered_tool_parsers = _load_nemotron_json_tool_parser(
+        monkeypatch,
+        ToolParser,
+    )
+
+    assert "nemotron_json" in registered_tool_parsers
+    parser = parser_module.NemotronJSONToolParser(tokenizer=object(), tools=[])
+    malformed_output = 'prefix<TOOLCALL>{"name": "broken"'
+
+    result = parser.extract_tool_calls(malformed_output, request=object())
+
+    assert result.tools_called is False
+    assert result.tool_calls == []
+    assert result.content == malformed_output


### PR DESCRIPTION
The PR makes the Nemotron Nano v2 workplace-assistant NeMo-Gym recipe runnable with the current vLLM stack.

  It fixes three concrete issues we hit:

  1. Missing/invalid vLLM tool parser
     The recipe was configured to use tool_parser: nemotron_json, but no working local parser plugin was wired in. The model’s HF-cache parser was also incompatible with the installed
     vLLM package paths.
     The PR adds nemo_rl/models/generation/vllm/tool_parsers/nemotron_json.py and points the recipe at it.

  2. vLLM parser constructor mismatch
     Current vLLM instantiates tool parsers as parser_cls(tokenizer, request.tools). The previous shim only accepted tokenizer, causing:
     TypeError: __init__() takes 2 positional arguments but 3 were given
     The new parser accepts both signatures, so it works with current vLLM and remains tolerant of older base parser constructors.

 

  also makes malformed model tool-call output non-fatal and quieter: malformed <TOOLCALL>...</TOOLCALL> generations fall back to normal content instead of crashing request handling
  or spamming exception tracebacks.



# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
