### PR TITLE
fix: fix several tests by pin triton moe backend

### DIFF
--- a/examples/configs/grpo_math_qwen30ba3b_megatron.yaml
+++ b/examples/configs/grpo_math_qwen30ba3b_megatron.yaml
@@ -73,6 +73,10 @@ policy:
       gpu_memory_utilization: 0.7
       enforce_eager: false
       max_model_len: ${policy.max_total_sequence_length}
+    vllm_kwargs:
+      # vLLM 0.20's default FlashInfer TRTLLM MoE backend isn't refit-compatible,
+      # change to triton to keep same behavior as vLLM 0.17.
+      moe_backend: triton
 
 cluster:
   gpus_per_node: 8

--- a/examples/configs/recipes/llm/grpo-dapomath17k-dsv3-megatron.yaml
+++ b/examples/configs/recipes/llm/grpo-dapomath17k-dsv3-megatron.yaml
@@ -40,6 +40,10 @@ policy:
     vllm_cfg:
       async_engine: true
       tensor_parallel_size: 32
+    vllm_kwargs:
+      # vLLM 0.20's default FlashInfer TRTLLM MoE backend isn't refit-compatible,
+      # change to triton to keep same behavior as vLLM 0.17.
+      moe_backend: triton
 data:
   train:
     dataset_name: DAPOMath17K

--- a/examples/configs/recipes/llm/grpo-gptoss-20b-8n8g-megatron.yaml
+++ b/examples/configs/recipes/llm/grpo-gptoss-20b-8n8g-megatron.yaml
@@ -22,6 +22,8 @@ policy:
     vllm_cfg:
       tensor_parallel_size: 2
     vllm_kwargs:
+      # vLLM 0.20's default FlashInfer TRTLLM MoE backend isn't refit-compatible,
+      # change to triton to keep same behavior as vLLM 0.17.
       moe_backend: triton
 cluster:
   num_nodes: 8

--- a/examples/configs/recipes/llm/grpo-math-qwen3-30ba3b-megatron-tp4-32k.yaml
+++ b/examples/configs/recipes/llm/grpo-math-qwen3-30ba3b-megatron-tp4-32k.yaml
@@ -38,6 +38,10 @@ policy:
     vllm_cfg:
       tensor_parallel_size: 4
       enforce_eager: true
+    vllm_kwargs:
+      # vLLM 0.20's default FlashInfer TRTLLM MoE backend isn't refit-compatible,
+      # change to triton to keep same behavior as vLLM 0.17.
+      moe_backend: triton
 logger:
   log_dir: logs/grpo-math-qwen3-30ba3b-megatron-tp4-32k
   wandb_enabled: true

--- a/examples/configs/recipes/llm/grpo-qwen3-30ba3b-8n8g-megatron-cp2-r3.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen3-30ba3b-8n8g-megatron-cp2-r3.yaml
@@ -27,7 +27,6 @@ policy:
       enable_prefix_caching: false
     vllm_kwargs:
       enable_chunked_prefill: false
-      moe_backend: triton
 data:
   max_input_seq_length: 2048
 data_plane:

--- a/examples/configs/recipes/llm/grpo-qwen3-30ba3b-8n8g-megatron.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen3-30ba3b-8n8g-megatron.yaml
@@ -36,6 +36,10 @@ policy:
     vllm_cfg:
       tensor_parallel_size: 4
       gpu_memory_utilization: 0.7
+    vllm_kwargs:
+      # vLLM 0.20's default FlashInfer TRTLLM MoE backend isn't refit-compatible,
+      # change to triton to keep same behavior as vLLM 0.17.
+      moe_backend: triton
 logger:
   log_dir: logs/grpo-qwen3-30ba3b-8n8g-megatron
   wandb_enabled: true

--- a/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n4g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n4g.yaml
@@ -36,6 +36,10 @@ policy:
   generation:
     vllm_cfg:
       tensor_parallel_size: 1
+    vllm_kwargs:
+      # vLLM 0.20's default FlashInfer TRTLLM MoE backend isn't refit-compatible,
+      # change to triton to keep same behavior as vLLM 0.17.
+      moe_backend: triton
 logger:
   log_dir: logs/grpo-qwen3-30ba3b-4n4g
   wandb_enabled: true

--- a/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n8g-40K.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n8g-40K.yaml
@@ -39,6 +39,10 @@ policy:
   generation:
     vllm_cfg:
       tensor_parallel_size: 2
+    vllm_kwargs:
+      # vLLM 0.20's default FlashInfer TRTLLM MoE backend isn't refit-compatible,
+      # change to triton to keep same behavior as vLLM 0.17.
+      moe_backend: triton
 logger:
   log_dir: logs/grpo-qwen3-30ba3b-4n8g
   wandb_enabled: true

--- a/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n8g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n8g.yaml
@@ -36,6 +36,10 @@ policy:
   generation:
     vllm_cfg:
       tensor_parallel_size: 2
+    vllm_kwargs:
+      # vLLM 0.20's default FlashInfer TRTLLM MoE backend isn't refit-compatible,
+      # change to triton to keep same behavior as vLLM 0.17.
+      moe_backend: triton
 logger:
   log_dir: logs/grpo-qwen3-30ba3b-4n8g
   wandb_enabled: true


### PR DESCRIPTION
## Issues
closes #2809, closes #2810, closes #2814, closes #2817
related to #2618

## Summary

### Fixed tests
- **H100**: `grpo-qwen3-30ba3b-8n8g-megatron`, `grpo-qwen3-30ba3b-4n8g-40K`, `grpo-qwen3-30ba3b-4n8g-async-1off`, `grpo-qwen3-30ba3b-24n8g-async-8off`, `grpo-math-qwen3-30ba3b-megatron-tp4-32k`, `grpo-dapomath17k-dsv3-megatron`
- **GB200**: `grpo-qwen3-30ba3b-8n4g-megatron`

### Still failed tests
- **H100**: `grpo-qwen3-30ba3b-4n8g` (OOM #2811)
- **GB200**:  `grpo-qwen3-30ba3b-4n4g`, `grpo-qwen3-30ba3b-4n4g-async-1off`, `grpo-dapomath17k-dsv3-32n4g-megatron`