### PR TITLE
feat: add Mistral Medium 3.5 (128B) text-only DAPO support

### DIFF
--- a/examples/configs/recipes/llm/dapo-mistral-medium-3.5-128b-16n8g-fsdp2-automodel.yaml
+++ b/examples/configs/recipes/llm/dapo-mistral-medium-3.5-128b-16n8g-fsdp2-automodel.yaml
@@ -1,0 +1,101 @@
+defaults: ../../grpo_math_1B.yaml
+grpo:
+  batch_multiplier: 3
+  val_period: 15
+  max_val_samples: 960
+  val_batch_size: 960
+  use_leave_one_out_baseline: false
+  use_dynamic_sampling: true
+  reward_scaling:
+    enabled: true
+    target_min: -1.0
+  reward_shaping:
+    enabled: true
+    overlong_buffer_length: 384
+    max_response_length: 3072
+loss_fn:
+  reference_policy_kl_penalty: 0.0
+  use_importance_sampling_correction: true
+  truncated_importance_sampling_type: tis
+  truncated_importance_sampling_ratio: 2
+  ratio_clip_max: 0.28
+  ratio_clip_c: 10
+checkpointing:
+  checkpoint_dir: results/dapo-mistral-medium-3.5-128b-16n8g-fsdp2-automodel
+  save_period: 5
+policy:
+  model_name: mistralai/Mistral-Medium-3.5-128B
+  tokenizer:
+    name: mistralai/Mistral-Medium-3.5-128B
+  train_global_batch_size: 128
+  train_micro_batch_size: 1
+  logprob_batch_size: 1
+  max_total_sequence_length: 4096
+  logprob_chunk_size: 4096
+  offload_optimizer_for_logprob: true
+  optimizer:
+    name: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
+    kwargs:
+      lr: 3.0e-07
+      weight_decay: 0.1
+      master_weights: true
+      store_param_remainders: true
+      exp_avg_dtype: torch.bfloat16
+      exp_avg_sq_dtype: torch.bfloat16
+  scheduler:
+  - name: torch.optim.lr_scheduler.LinearLR
+    kwargs:
+      start_factor: 1.0e-08
+      end_factor: 1.0
+      total_iters: 10
+  - name: torch.optim.lr_scheduler.ConstantLR
+    kwargs:
+      factor: 1.0
+      total_iters: 10000000000
+  - milestones:
+    - 10
+  dtensor_cfg:
+    activation_checkpointing: true
+    env_vars:
+      PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    automodel_kwargs:
+      attn_implementation: eager
+      freeze_config:
+        freeze_vision_tower: true
+        freeze_audio_tower: true
+        freeze_language_model: false
+  sequence_packing:
+    enabled: false
+  dynamic_batching:
+    enabled: true
+  make_sequence_length_divisible_by: 1
+  generation:
+    max_new_tokens: 3072
+    vllm_cfg:
+      gpu_memory_utilization: 0.85
+      tensor_parallel_size: 8
+      enforce_eager: true
+    vllm_kwargs:
+      language_model_only: true
+data:
+  max_input_seq_length: 1024
+  train:
+    dataset_name: DAPOMath17K
+  validation:
+    dataset_name: DAPOMathAIME2024
+  default:
+    prompt_file: null
+env:
+  math:
+    num_workers: 16
+    math_verify_impl: dapo_math_verify
+logger:
+  log_dir: logs/dapo-mistral-medium-3.5-128b-16n8g-fsdp2-automodel
+  wandb_enabled: true
+  tensorboard_enabled: true
+  wandb:
+    project: nemo-rl
+    name: dapo-mistral-medium-3.5-128b-16n8g-fsdp2-automodel
+cluster:
+  gpus_per_node: 8
+  num_nodes: 16

--- a/nemo_rl/models/automodel/setup.py
+++ b/nemo_rl/models/automodel/setup.py
@@ -688,6 +688,21 @@ def setup_model_and_optimizer(
     if "use_liger_kernel" not in automodel_kwargs:
         automodel_kwargs["use_liger_kernel"] = False
 
+    # Recipe-level attn_implementation wins; pop it so it doesn't collide with
+    # the explicit attn_implementation kwarg passed to from_pretrained() below.
+    if "attn_implementation" in automodel_kwargs:
+        requested = automodel_kwargs.pop("attn_implementation")
+        # Sequence packing relies on flash_attention_2 to honor cu_seqlens; any
+        # other backend would silently run cross-document attention. Packing with
+        # cp_size > 1 is already rejected above (see the cp_size/enable_seq_packing
+        # check), so enable_seq_packing here implies cp_size == 1 -> flash_attention_2.
+        if runtime_config.enable_seq_packing and requested != "flash_attention_2":
+            raise ValueError(
+                "sequence_packing requires attn_implementation='flash_attention_2', "
+                f"but the recipe set automodel_kwargs.attn_implementation={requested!r}."
+            )
+        attn_impl = requested
+
     # Determine SDPA method for activation checkpointing and CP
     from torch.nn.attention import SDPBackend
 
@@ -736,11 +751,6 @@ def setup_model_and_optimizer(
     # Keep fp32 master weights: stop Automodel from restoring loaded params to the bf16
     # checkpoint dtype, which would break optimizer master-weight precision (see helper).
     _disable_automodel_checkpoint_dtype_restore()
-
-    # Recipe-level attn_implementation wins; pop it so it doesn't collide with
-    # the explicit attn_implementation kwarg passed to from_pretrained() below.
-    if "attn_implementation" in automodel_kwargs:
-        attn_impl = automodel_kwargs.pop("attn_implementation")
 
     # Create model via from_pretrained - handles meta device init, parallelization,
     # LoRA, and base weight loading internally

--- a/nemo_rl/models/automodel/setup.py
+++ b/nemo_rl/models/automodel/setup.py
@@ -737,6 +737,11 @@ def setup_model_and_optimizer(
     # checkpoint dtype, which would break optimizer master-weight precision (see helper).
     _disable_automodel_checkpoint_dtype_restore()
 
+    # Recipe-level attn_implementation wins; pop it so it doesn't collide with
+    # the explicit attn_implementation kwarg passed to from_pretrained() below.
+    if "attn_implementation" in automodel_kwargs:
+        attn_impl = automodel_kwargs.pop("attn_implementation")
+
     # Create model via from_pretrained - handles meta device init, parallelization,
     # LoRA, and base weight loading internally
     model = model_class.from_pretrained(

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -361,6 +361,7 @@ class BaseVllmGenerationWorker:
             for arch in (
                 "Gemma3ForConditionalGeneration",
                 "Gemma4ForConditionalGeneration",
+                "Mistral3ForConditionalGeneration",
                 "Qwen3_5ForConditionalGeneration",
                 "Qwen3_5MoeForConditionalGeneration",
             )
@@ -372,6 +373,7 @@ class BaseVllmGenerationWorker:
                 in (
                     "Gemma3ForConditionalGeneration",
                     "Gemma4ForConditionalGeneration",
+                    "Mistral3ForConditionalGeneration",
                     "Qwen3_5ForConditionalGeneration",
                     "Qwen3_5MoeForConditionalGeneration",
                 )
@@ -383,6 +385,30 @@ class BaseVllmGenerationWorker:
                     "See https://github.com/NVIDIA-NeMo/RL/issues/1681 for more details."
                 )
             self.cfg["vllm_cfg"]["skip_tokenizer_init"] = False
+
+        # Mistral 3.5 (Mistral3ForConditionalGeneration) integration.
+        if "Mistral3ForConditionalGeneration" in getattr(
+            hf_config, "architectures", []
+        ):
+            # Mistral 3.5 ships FP8 on disk, but NeMo-RL refits bf16 weights via
+            # ZMQ (load_format='dummy'). Clear the auto-detected quantization_config
+            # so vLLM allocates bf16 buffers instead of building Fp8Config.
+            if hasattr(hf_config, "quantization_config"):
+                assert load_format == "dummy", (
+                    "Loading FP8-quantized Mistral3 in vLLM is only supported "
+                    "with load_format='dummy' (NeMo-RL refits bf16 weights via "
+                    "ZMQ). Got load_format=%r." % load_format
+                )
+                vllm_kwargs["quantization"] = None
+                vllm_kwargs["hf_overrides"]["quantization_config"] = {}
+
+            # Force the HF config parser. Auto-detect picks Mistral-native format
+            # and remaps architectures to Pixtral, whose weight loader is
+            # incompatible with NeMo-RL's HF-format ZMQ refit keys.
+            vllm_kwargs["config_format"] = "hf"
+
+            # Text-only runs additionally set generation.vllm_kwargs.language_model_only
+            # in the recipe YAML to skip vLLM's multimodal preflight.
 
         llm_kwargs = dict(
             model=self.model_name,

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -399,6 +399,15 @@ class BaseVllmGenerationWorker:
                     "with load_format='dummy' (NeMo-RL refits bf16 weights via "
                     "ZMQ). Got load_format=%r." % load_format
                 )
+                # NeMo-RL refits bf16 weights, so we intentionally clear any fp8
+                # quantization here -- including the quantization="fp8" that
+                # init_fp8 set above when precision == "fp8". Warn so a
+                # precision: fp8 Mistral3 config isn't silently downgraded to bf16.
+                if self.cfg["vllm_cfg"]["precision"] == "fp8":
+                    print(
+                        "Mistral3 refits bf16 weights via ZMQ; ignoring "
+                        "precision='fp8' and running vLLM generation in bf16."
+                    )
                 vllm_kwargs["quantization"] = None
                 vllm_kwargs["hf_overrides"]["quantization_config"] = {}
 

--- a/nemo_rl/models/policy/utils.py
+++ b/nemo_rl/models/policy/utils.py
@@ -37,6 +37,14 @@ try:
         NeMoAutoModelForTextToWaveform,
     )
 
+    # Side-effect import: installs the resolver hook that routes FP8-native
+    # Mistral 3.5 configs to Mistral3FP8VLM. Without it, HF's stock FP8Linear
+    # path runs and produces 0-d weight_scale_inv params that FSDP2 rejects.
+    try:
+        import nemo_automodel.components.models.mistral3_vlm  # noqa: F401
+    except ImportError:
+        pass
+
     NEMO_AUTOMODEL_AVAILABLE = True
 except ImportError:
     # nemo_automodel is not installed, classes will be None

--- a/tests/test_suites/llm/dapo-mistral-medium-3.5-128b-16n8g-fsdp2-automodel.sh
+++ b/tests/test_suites/llm/dapo-mistral-medium-3.5-128b-16n8g-fsdp2-automodel.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $SCRIPT_DIR/common.env
+
+# ===== BEGIN CONFIG =====
+NUM_NODES=16
+STEPS_PER_RUN=20
+MAX_STEPS=20
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=240
+# ===== END CONFIG =====
+
+exit_if_max_steps_reached
+
+# Run the experiment
+cd $PROJECT_ROOT
+uv run examples/run_grpo.py \
+    --config $CONFIG_PATH \
+    grpo.max_num_steps=$MAX_STEPS \
+    logger.log_dir=$LOG_DIR \
+    logger.wandb_enabled=True \
+    logger.wandb.project=nemo-rl \
+    logger.wandb.name=$EXP_NAME \
+    logger.monitor_gpus=True \
+    logger.tensorboard_enabled=True \
+    checkpointing.enabled=True \
+    checkpointing.checkpoint_dir=$CKPT_DIR \
+    $@ \
+    2>&1 | tee $RUN_LOG
+
+# Convert tensorboard logs to json
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+
+# Only run metrics if the target step is reached
+if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
+    uv run tests/check_metrics.py $JSON_METRICS \
+        'median(data["train/token_mult_prob_error"]) < 1.1' \
+        'mean(data["train/gen_kl_error"]) < 0.002' \
+        'max(data["train/reward"]) > -0.5'
+
+    # Clean up checkpoint directory after successful run to save space.
+    rm -rf "$CKPT_DIR"
+fi

--- a/tests/test_suites/release.txt
+++ b/tests/test_suites/release.txt
@@ -33,6 +33,9 @@ tests/test_suites/llm/grpo-glm5.1-64n8g-megatron.sh
 tests/test_suites/llm/dapo-gemma4-26ba4b-it-4n8g-fsdp2-automodel.sh
 tests/test_suites/llm/dapo-gemma4-31b-it-4n8g-fsdp2-automodel.sh
 
+# Mistral Medium 3.5 (128B, FP8, text-only) DAPO run
+tests/test_suites/llm/dapo-mistral-medium-3.5-128b-16n8g-fsdp2-automodel.sh
+
 # Deepseek-V3 on DAPO dataset
 tests/test_suites/llm/grpo-dapomath17k-dsv3-megatron.sh
 


### PR DESCRIPTION
Add text-only DAPO/GRPO support for mistralai/Mistral-Medium-3.5-128B on the Automodel + vLLM path:

- generation/vllm/vllm_worker.py — Mistral 3.5 integration block:
  - Force config_format="hf" so vLLM uses the HF config parser instead of auto-detecting the Mistral-native format (which remaps the architecture to Pixtral, whose weight loader is incompatible with NeMo-RL's HF-format ZMQ refit keys).
  - Clear the auto-detected FP8 quantization_config (asserting load_format='dummy') so vLLM allocates bf16 buffers for the ZMQ refit.
  - Add the arch to the skip_tokenizer_init force-False list.
- policy/utils.py — side-effect import of nemo_automodel ... mistral3_vlm so the FP8 resolver hook routes the dense ministral3 + FP8 config to the FSDP2-safe Mistral3FP8VLM class instead of HF's stock FP8Linear path (which produces 0-d weight_scale_inv params that FSDP2 rejects).
- automodel/setup.py — pop attn_implementation from automodel_kwargs so a recipe-level setting doesn't collide with the explicit kwarg passed to from_pretrained() (duplicate-keyword TypeError).
- Recipe + release-suite driver — text-only DAPO (language_model_only=true), 16n8g, registered in tests/test_suites/release.txt.

Training curves of the `examples/configs/recipes/llm/dapo-mistral-medium-3.5-128b-16n8g-fsdp2-automodel.yaml` recipe: 
<img width="1100" height="318" alt="image" src="https://github.com/user-attachments/assets/3925a592-eddd-40e2-83ed-25aa425fd9cc" />

# What does this PR do ?

Add text-only DAPO/GRPO support for mistralai/Mistral-Medium-3.5-128B 

# Issues
Address: https://github.com/NVIDIA-NeMo/RL/issues/2542


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
