### PR TITLE
chore: temporary skip SGLang L1 tests

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -701,6 +701,8 @@ jobs:
             runner: ${{ needs.org-member-pre-flight.outputs.runner_prefix }}
           - script: L1_Functional_Tests_AutoModel
             runner: ${{ needs.org-member-pre-flight.outputs.runner_prefix }}
+          - script: L1_Functional_Tests_SGLang
+            runner: ${{ needs.org-member-pre-flight.outputs.runner_prefix }}
           - script: L1_Functional_Tests_Gym
             runner: ${{ needs.org-member-pre-flight.outputs.runner_prefix }}
           - script: L1_Functional_Tests_GRPO_1
@@ -767,6 +769,8 @@ jobs:
           - script: L1_Functional_Tests_Megatron_4
             runner: ${{ vars.GB200_RUNNER }}
           - script: L1_Functional_Tests_AutoModel
+            runner: ${{ vars.GB200_RUNNER }}
+          - script: L1_Functional_Tests_SGLang
             runner: ${{ vars.GB200_RUNNER }}
           - script: L1_Functional_Tests_Gym
             runner: ${{ vars.GB200_RUNNER }}

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -701,8 +701,6 @@ jobs:
             runner: ${{ needs.org-member-pre-flight.outputs.runner_prefix }}
           - script: L1_Functional_Tests_AutoModel
             runner: ${{ needs.org-member-pre-flight.outputs.runner_prefix }}
-          - script: L1_Functional_Tests_SGLang
-            runner: ${{ needs.org-member-pre-flight.outputs.runner_prefix }}
           - script: L1_Functional_Tests_Gym
             runner: ${{ needs.org-member-pre-flight.outputs.runner_prefix }}
           - script: L1_Functional_Tests_GRPO_1
@@ -769,8 +767,6 @@ jobs:
           - script: L1_Functional_Tests_Megatron_4
             runner: ${{ vars.GB200_RUNNER }}
           - script: L1_Functional_Tests_AutoModel
-            runner: ${{ vars.GB200_RUNNER }}
-          - script: L1_Functional_Tests_SGLang
             runner: ${{ vars.GB200_RUNNER }}
           - script: L1_Functional_Tests_Gym
             runner: ${{ vars.GB200_RUNNER }}

--- a/tests/functional/L1_Functional_Tests_SGLang.sh
+++ b/tests/functional/L1_Functional_Tests_SGLang.sh
@@ -34,8 +34,8 @@ run_test() {
     fi
 }
 
-run_test      uv run --no-sync bash ./tests/functional/grpo_sglang_sync.sh
-run_test      uv run --no-sync bash ./tests/functional/grpo_sglang_async.sh
+# run_test      uv run --no-sync bash ./tests/functional/grpo_sglang_sync.sh
+# run_test      uv run --no-sync bash ./tests/functional/grpo_sglang_async.sh
 
 cd ${PROJECT_ROOT}/tests
 if compgen -G ".coverage*" > /dev/null; then


### PR DESCRIPTION
temporary skip SGLang L1 tests before it fixed.

passed in https://github.com/NVIDIA-NeMo/RL/pull/2267: https://github.com/NVIDIA-NeMo/RL/actions/runs/27807146738/job/82310056257
but always failed in main branch: https://github.com/NVIDIA-NeMo/RL/actions/runs/27867771177/job/82545844973