### PR TITLE
feat: add multiple penalties for model behaviour

### DIFF
--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -58,9 +58,9 @@ reward_penalties:
   penalize_empty_final_answer: false
   penalize_eos_token: false
   penalize_malformed_think_tag: false
-  # Optional model/tokenizer-specific overrides. When null, EOS is inferred
-  # from tokenizer.eos_token_id and think tags are inferred only if each tag
-  # encodes to one token. Example: {eos: 2, think_open: 12, think_close: 13}
+  # Optional model/tokenizer-specific token IDs. eos is required when
+  # penalize_eos_token is true; think tags are inferred only if each tag encodes
+  # to one token. Example: {eos: 2, think_open: 12, think_close: 13}
   token_ids: null
 
 loss_fn:

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -52,6 +52,17 @@ grpo:
     in_flight_weight_updates: false # Set to true to enable in-flight weight updates
     recompute_kv_cache_after_weight_updates: false # Set to true to recompute kv cache after in-flight-weight-updates
 
+# Reward-zeroing penalties applied to NeMo-Gym rollout results.
+reward_penalties:
+  penalize_duplicated_reasoning: false
+  penalize_empty_final_answer: false
+  penalize_eos_token: false
+  penalize_malformed_think_tag: false
+  # Optional model/tokenizer-specific overrides. When null, EOS is inferred
+  # from tokenizer.eos_token_id and think tags are inferred only if each tag
+  # encodes to one token. Example: {eos: 2, think_open: 12, think_close: 13}
+  token_ids: null
+
 loss_fn:
   reference_policy_kl_penalty: 0.01
   # Can be set to k1, k2, k3

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -59,8 +59,8 @@ reward_penalties:
   penalize_unwanted_tokens: false
   penalize_malformed_think_tag: false
   # Optional model/tokenizer-specific token IDs. Add token IDs that should
-  # be penalized when emitted by the model under unwanted
-  # Think tags are inferred only if each tag encodes
+  # be penalized when emitted by the model. Unwanted token IDs must be
+  # specified explicitly; think-tag IDs are inferred when each tag encodes
   # to one token. Example: {unwanted: [2], think_open: 12, think_close: 13}
   token_ids: null
 

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -56,11 +56,12 @@ grpo:
 reward_penalties:
   penalize_duplicated_reasoning: false
   penalize_empty_final_answer: false
-  penalize_eos_token: false
+  penalize_unwanted_tokens: false
   penalize_malformed_think_tag: false
-  # Optional model/tokenizer-specific token IDs. eos is required when
-  # penalize_eos_token is true; think tags are inferred only if each tag encodes
-  # to one token. Example: {eos: 2, think_open: 12, think_close: 13}
+  # Optional model/tokenizer-specific token IDs. Add token IDs that should
+  # be penalized when emitted by the model under unwanted
+  # Think tags are inferred only if each tag encodes
+  # to one token. Example: {unwanted: [2], think_open: 12, think_close: 13}
   token_ids: null
 
 loss_fn:

--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -725,7 +725,10 @@ class AsyncTrajectoryCollector:
         try:
             # Import here to avoid circular dependency
             from nemo_rl.algorithms.grpo import _should_use_nemo_gym
-            from nemo_rl.experience.rollouts import run_async_nemo_gym_rollout
+            from nemo_rl.experience.rollouts import (
+                get_nemo_gym_thinking_tags,
+                run_async_nemo_gym_rollout,
+            )
 
             # Run rollout for this prompt group
             # Async engine supports concurrent generation; avoid locking
@@ -741,6 +744,8 @@ class AsyncTrajectoryCollector:
                     generation_config=generation_config,
                     max_rollout_turns=None,
                     greedy=False,
+                    reward_penalty_config=self.master_config.reward_penalties,
+                    thinking_tags=get_nemo_gym_thinking_tags(self.master_config.env),
                 )
                 final_batch = nemo_gym_rollout_result.final_batch
                 rollout_metrics = nemo_gym_rollout_result.rollout_metrics

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -161,7 +161,7 @@ class AdvEstimatorConfig(TypedDict):
 class RewardPenaltyTokenIdsConfig(BaseModel, extra="allow"):
     """Optional token IDs for reward penalties."""
 
-    eos: int | None = None
+    unwanted: list[int] | None = None
     think_open: int | None = None
     think_close: int | None = None
 
@@ -171,20 +171,21 @@ class RewardPenaltyConfig(BaseModel, extra="allow"):
 
     penalize_duplicated_reasoning: bool = False
     penalize_empty_final_answer: bool = False
-    penalize_eos_token: bool = False
+    penalize_unwanted_tokens: bool = False
     penalize_malformed_think_tag: bool = False
-    # Optional token IDs. eos is required when penalize_eos_token is true;
+    # Optional token IDs. token_ids.unwanted is required when
+    # penalize_unwanted_tokens is true;
     # think-tag IDs are inferred from configured tag strings when possible.
     token_ids: Optional[RewardPenaltyTokenIdsConfig] = None
 
     @model_validator(mode="after")
-    def _require_eos_token_id_when_penalized(self) -> "RewardPenaltyConfig":
-        if self.penalize_eos_token and (
-            self.token_ids is None or self.token_ids.eos is None
+    def _require_unwanted_token_ids_when_penalized(self) -> "RewardPenaltyConfig":
+        if self.penalize_unwanted_tokens and (
+            self.token_ids is None or not self.token_ids.unwanted
         ):
             raise ValueError(
-                "reward_penalties.token_ids.eos must be set when "
-                "reward_penalties.penalize_eos_token is true"
+                "reward_penalties.token_ids.unwanted must be set when "
+                "reward_penalties.penalize_unwanted_tokens is true"
             )
         return self
 

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -22,7 +22,7 @@ from typing import Any, Callable, NotRequired, Optional, TypedDict, TypeVar, cas
 import numpy as np
 import ray
 import torch
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import AutoProcessor
@@ -159,7 +159,7 @@ class AdvEstimatorConfig(TypedDict):
 
 
 class RewardPenaltyTokenIdsConfig(BaseModel, extra="allow"):
-    """Optional tokenizer-derived token ID overrides for reward penalties."""
+    """Optional token IDs for reward penalties."""
 
     eos: int | None = None
     think_open: int | None = None
@@ -173,8 +173,20 @@ class RewardPenaltyConfig(BaseModel, extra="allow"):
     penalize_empty_final_answer: bool = False
     penalize_eos_token: bool = False
     penalize_malformed_think_tag: bool = False
-    # Optional overrides; None infers from tokenizer when possible.
+    # Optional token IDs. eos is required when penalize_eos_token is true;
+    # think-tag IDs are inferred from configured tag strings when possible.
     token_ids: Optional[RewardPenaltyTokenIdsConfig] = None
+
+    @model_validator(mode="after")
+    def _require_eos_token_id_when_penalized(self) -> "RewardPenaltyConfig":
+        if self.penalize_eos_token and (
+            self.token_ids is None or self.token_ids.eos is None
+        ):
+            raise ValueError(
+                "reward_penalties.token_ids.eos must be set when "
+                "reward_penalties.penalize_eos_token is true"
+            )
+        return self
 
 
 class GRPOConfig(TypedDict):

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -22,7 +22,7 @@ from typing import Any, Callable, NotRequired, Optional, TypedDict, TypeVar, cas
 import numpy as np
 import ray
 import torch
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import AutoProcessor
@@ -82,6 +82,7 @@ from nemo_rl.environments.nemo_gym import (
 )
 from nemo_rl.experience.rollouts import (
     EffortLevelsConfig,
+    get_nemo_gym_thinking_tags,
     run_async_multi_turn_rollout,
     run_async_nemo_gym_rollout,
     run_multi_turn_rollout,
@@ -155,6 +156,25 @@ class AdvEstimatorConfig(TypedDict):
     use_leave_one_out_baseline: NotRequired[bool]
     # Reinforce++ specific
     minus_baseline: NotRequired[bool]
+
+
+class RewardPenaltyTokenIdsConfig(BaseModel, extra="allow"):
+    """Optional tokenizer-derived token ID overrides for reward penalties."""
+
+    eos: int | None = None
+    think_open: int | None = None
+    think_close: int | None = None
+
+
+class RewardPenaltyConfig(BaseModel, extra="allow"):
+    """Reward-zeroing penalties applied to NeMo-Gym rollout results."""
+
+    penalize_duplicated_reasoning: bool = False
+    penalize_empty_final_answer: bool = False
+    penalize_eos_token: bool = False
+    penalize_malformed_think_tag: bool = False
+    # Optional overrides; None infers from tokenizer when possible.
+    token_ids: Optional[RewardPenaltyTokenIdsConfig] = None
 
 
 class GRPOConfig(TypedDict):
@@ -242,6 +262,7 @@ class MasterConfig(BaseModel, extra="allow"):
     logger: GRPOLoggerConfig
     cluster: ClusterConfig
     checkpointing: CheckpointingConfig
+    reward_penalties: RewardPenaltyConfig = Field(default_factory=RewardPenaltyConfig)
     data_plane: Optional[DataPlaneConfig] = None
     on_policy_distillation: Optional[OnPolicyDistillationConfig] = None
 
@@ -476,7 +497,7 @@ def setup(
             nemo_gym_py_exec = create_local_venv_on_each_node(
                 nemo_gym_py_exec, "nemo_rl.environments.nemo_gym.NemoGym"
             )
-        nemo_gym_dict = env_configs["nemo_gym"]
+        nemo_gym_dict = dict(env_configs["nemo_gym"])
         # NeMo-RL-side detection knobs are top-level NemoGymConfig fields
         # (where the detector reads them), not part of Gym's global config.
         invalid_tool_call_patterns = nemo_gym_dict.pop(
@@ -2357,6 +2378,8 @@ def grpo_train(
                             max_rollout_turns=None,
                             greedy=False,
                             effort_config=_get_effort_config(master_config),
+                            reward_penalty_config=master_config.reward_penalties,
+                            thinking_tags=get_nemo_gym_thinking_tags(master_config.env),
                         )
                         input_ids = nemo_gym_rollout_result.input_ids
                         repeated_batch = nemo_gym_rollout_result.final_batch
@@ -3185,6 +3208,8 @@ def validate(
                     max_rollout_turns=None,
                     greedy=False,
                     effort_config=_get_effort_config(master_config),
+                    reward_penalty_config=master_config.reward_penalties,
+                    thinking_tags=get_nemo_gym_thinking_tags(master_config.env),
                 )
                 val_batch = nemo_gym_rollout_result.final_batch
                 gen_metrics = nemo_gym_rollout_result.rollout_metrics

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -190,6 +190,14 @@ class RewardPenaltyConfig(BaseModel, extra="allow"):
         return self
 
 
+_REWARD_PENALTY_FLAGS = (
+    "penalize_duplicated_reasoning",
+    "penalize_empty_final_answer",
+    "penalize_unwanted_tokens",
+    "penalize_malformed_think_tag",
+)
+
+
 class GRPOConfig(TypedDict):
     num_prompts_per_step: int
     num_generations_per_prompt: int
@@ -493,6 +501,9 @@ def setup(
     # NeMo Gym is initialized inside setup() (rather than by the caller) so its
     # spinup can overlap with vLLM model loading via deferred model load.
     enable_nemo_gym = _should_use_nemo_gym(master_config)
+    _raise_if_reward_penalties_enabled_without_nemo_gym(
+        master_config, enable_nemo_gym=enable_nemo_gym
+    )
     nemo_gym_actor = None
     if enable_nemo_gym:
         nemo_gym_num_nodes = env_configs.get("nemo_gym", {}).get("num_gpu_nodes", 0)
@@ -1541,12 +1552,34 @@ def _resolve_message_level_advantage_penalties(
     # The is_invalid_tool_call / has_malformed_thinking flags these penalties rely on
     # are only populated by the NeMo-Gym environment. Without that path the penalties
     # would silently no-op, so fail loudly instead.
-    assert _should_use_nemo_gym(master_config), (
-        "grpo.invalid_tool_call_advantage / grpo.malformed_thinking_advantage require "
-        "the NeMo-Gym path (env.should_use_nemo_gym=true); they are not supported with "
-        "the native generation path."
-    )
+    if not _should_use_nemo_gym(master_config):
+        raise ValueError(
+            "grpo.invalid_tool_call_advantage / grpo.malformed_thinking_advantage require "
+            "the NeMo-Gym path (env.should_use_nemo_gym=true); they are not supported with "
+            "the native generation path."
+        )
     return invalid_tool_call_advantage, malformed_thinking_advantage
+
+
+def _raise_if_reward_penalties_enabled_without_nemo_gym(
+    master_config: MasterConfig,
+    *,
+    enable_nemo_gym: bool,
+) -> None:
+    """Validate reward-zeroing penalties are only used with NeMo-Gym."""
+    if enable_nemo_gym:
+        return
+
+    if not any(
+        getattr(master_config.reward_penalties, flag) for flag in _REWARD_PENALTY_FLAGS
+    ):
+        return
+
+    raise ValueError(
+        "reward_penalties require the NeMo-Gym path "
+        "(env.should_use_nemo_gym=true); they are not supported with the native "
+        "generation path."
+    )
 
 
 def _apply_message_level_advantage_penalties(

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -1390,6 +1390,36 @@ def _get_required_reward_penalty_token_id(
     return value
 
 
+def _get_reward_penalty_token_ids(
+    reward_penalty_config: dict[str, Any] | BaseModel,
+    key: str,
+) -> list[int] | None:
+    token_ids = _get_reward_penalty_config_value(reward_penalty_config, "token_ids")
+    if token_ids is None:
+        return None
+
+    if isinstance(token_ids, dict):
+        value = token_ids.get(key)
+    else:
+        value = getattr(token_ids, key, None)
+
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return [int(value)]
+    return [int(token_id) for token_id in value]
+
+
+def _get_required_reward_penalty_token_ids(
+    reward_penalty_config: dict[str, Any] | BaseModel,
+    key: str,
+) -> list[int]:
+    values = _get_reward_penalty_token_ids(reward_penalty_config, key)
+    if not values:
+        raise ValueError(f"reward_penalties.token_ids.{key} must be set")
+    return values
+
+
 def _infer_single_token_id(tokenizer: Any, text: str) -> int | None:
     token_ids = tokenizer.encode(text, add_special_tokens=False)
     if len(token_ids) != 1:
@@ -1404,7 +1434,8 @@ def resolve_reward_penalty_config(
 ) -> dict[str, Any] | None:
     """Resolve tokenizer-derived reward penalty fields.
 
-    User config must explicitly provide EOS when penalize_eos_token is enabled.
+    User config must explicitly provide unwanted token IDs when
+    penalize_unwanted_tokens is enabled.
     Think-tag IDs are inferred only when each configured tag is exactly one
     token.
     """
@@ -1415,23 +1446,29 @@ def resolve_reward_penalty_config(
     for flag in (
         "penalize_duplicated_reasoning",
         "penalize_empty_final_answer",
-        "penalize_eos_token",
+        "penalize_unwanted_tokens",
         "penalize_malformed_think_tag",
     ):
         value = _get_reward_penalty_config_value(reward_penalty_config, flag)
         if value is not None:
             resolved[flag] = value
 
-    token_ids: dict[str, int] = {}
-    for key in ("eos", "think_open", "think_close"):
+    token_ids: dict[str, Any] = {}
+    unwanted_token_ids = _get_reward_penalty_token_ids(
+        reward_penalty_config, "unwanted"
+    )
+    if unwanted_token_ids is not None:
+        token_ids["unwanted"] = unwanted_token_ids
+
+    for key in ("think_open", "think_close"):
         value = _get_reward_penalty_token_id(reward_penalty_config, key)
         if value is not None:
             token_ids[key] = value
 
-    if resolved.get("penalize_eos_token") and "eos" not in token_ids:
+    if resolved.get("penalize_unwanted_tokens") and not token_ids.get("unwanted"):
         raise ValueError(
-            "reward_penalties.token_ids.eos must be set when "
-            "reward_penalties.penalize_eos_token is true"
+            "reward_penalties.token_ids.unwanted must be set when "
+            "reward_penalties.penalize_unwanted_tokens is true"
         )
 
     if resolved.get("penalize_malformed_think_tag"):
@@ -1493,11 +1530,11 @@ def apply_reward_penalties(
          function_call (model was mid-agentic-loop, not producing an empty answer).
          Data: full_result["response"]["output"] — message items have content[0]["text"].
 
-      3. penalize_eos_token (token-based)
-         The explicitly configured EOS token should never appear anywhere in an
-         assistant generation, including as the terminal token. A turn may
-         contain multiple EOS tokens, so the whole assistant token sequence is
-         checked rather than excluding the trailing position.
+      3. penalize_unwanted_tokens (token-based)
+         Currently checks that none of the explicitly configured unwanted
+         token IDs appear anywhere in an assistant generation, including as the terminal
+         token. A turn may contain multiple unwanted tokens, so the whole assistant
+         token sequence is checked rather than excluding the trailing position.
          Data: message_log[i]["token_ids"] where role == "assistant".
 
       4. penalize_malformed_think_tag (message flag + token/string fallback)
@@ -1522,7 +1559,7 @@ def apply_reward_penalties(
     counts = {
         "duplicated_reasoning": 0,
         "empty_final_answer": 0,
-        "eos_token": 0,
+        "unwanted_token": 0,
         "malformed_think_tag": 0,
     }
     if not reward_penalty_config or not results:
@@ -1535,7 +1572,7 @@ def apply_reward_penalties(
         for flag in (
             "penalize_duplicated_reasoning",
             "penalize_empty_final_answer",
-            "penalize_eos_token",
+            "penalize_unwanted_tokens",
             "penalize_malformed_think_tag",
         )
     )
@@ -1603,25 +1640,27 @@ def apply_reward_penalties(
 
                 counts["empty_final_answer"] += 1
 
-    # --- Penalty 3: EOS token in generation ---
-    if _get_reward_penalty_config_value(reward_penalty_config, "penalize_eos_token"):
-        eos_token_id = _get_required_reward_penalty_token_id(
-            reward_penalty_config, "eos"
+    # --- Penalty 3: unwanted token in generation ---
+    if _get_reward_penalty_config_value(
+        reward_penalty_config, "penalize_unwanted_tokens"
+    ):
+        unwanted_token_ids = _get_required_reward_penalty_token_ids(
+            reward_penalty_config, "unwanted"
         )
         for result in results:
-            has_eos = False
+            has_unwanted_token = False
             for msg in result["message_log"]:
                 if msg["role"] != "assistant":
                     continue
-                # Penalize any EOS token in the assistant generation, including
-                # the terminal position — a turn may emit multiple EOS tokens.
-                if eos_token_id in msg["token_ids"]:
-                    has_eos = True
+                # Penalize any configured unwanted token in the assistant generation,
+                # including the terminal position.
+                if any(token_id in msg["token_ids"] for token_id in unwanted_token_ids):
+                    has_unwanted_token = True
                     break
-            if has_eos:
+            if has_unwanted_token:
                 result["full_result"]["reward"] = 0.0
 
-                counts["eos_token"] += 1
+                counts["unwanted_token"] += 1
 
     # --- Penalty 4: Malformed think tags (existing flag + optional token ID + string) ---
     if _get_reward_penalty_config_value(
@@ -1982,7 +2021,7 @@ def run_async_nemo_gym_rollout(
             "penalize_empty_final_answer",
             "empty_final_answer_rate",
         ),
-        "eos_token": ("penalize_eos_token", "eos_token_rate"),
+        "unwanted_token": ("penalize_unwanted_tokens", "unwanted_token_rate"),
         "malformed_think_tag": (
             "penalize_malformed_think_tag",
             "malformed_think_tag_rate",

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -1494,10 +1494,10 @@ def apply_reward_penalties(
          Data: full_result["response"]["output"] — message items have content[0]["text"].
 
       3. penalize_eos_token (token-based)
-         The explicitly configured EOS token should never appear inside any
-         assistant generation. A final EOS token is allowed per assistant turn
-         because vLLM/Gym may include the terminal stop marker in
-         generation_token_ids.
+         The explicitly configured EOS token should never appear anywhere in an
+         assistant generation, including as the terminal token. A turn may
+         contain multiple EOS tokens, so the whole assistant token sequence is
+         checked rather than excluding the trailing position.
          Data: message_log[i]["token_ids"] where role == "assistant".
 
       4. penalize_malformed_think_tag (message flag + token/string fallback)
@@ -1613,9 +1613,9 @@ def apply_reward_penalties(
             for msg in result["message_log"]:
                 if msg["role"] != "assistant":
                     continue
-                # Allow a terminal EOS stop marker on each assistant turn, but
-                # penalize EOS emitted inside the assistant content.
-                if eos_token_id in msg["token_ids"][:-1]:
+                # Penalize any EOS token in the assistant generation, including
+                # the terminal position — a turn may emit multiple EOS tokens.
+                if eos_token_id in msg["token_ids"]:
                     has_eos = True
                     break
             if has_eos:

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -1404,9 +1404,9 @@ def resolve_reward_penalty_config(
 ) -> dict[str, Any] | None:
     """Resolve tokenizer-derived reward penalty fields.
 
-    User config can still override token IDs. When absent, infer EOS from the
-    tokenizer and infer think-tag IDs only when each configured tag is exactly
-    one token.
+    User config must explicitly provide EOS when penalize_eos_token is enabled.
+    Think-tag IDs are inferred only when each configured tag is exactly one
+    token.
     """
     if reward_penalty_config is None:
         return None
@@ -1429,9 +1429,10 @@ def resolve_reward_penalty_config(
             token_ids[key] = value
 
     if resolved.get("penalize_eos_token") and "eos" not in token_ids:
-        eos_token_id = getattr(tokenizer, "eos_token_id", None)
-        if eos_token_id is not None:
-            token_ids["eos"] = int(eos_token_id)
+        raise ValueError(
+            "reward_penalties.token_ids.eos must be set when "
+            "reward_penalties.penalize_eos_token is true"
+        )
 
     if resolved.get("penalize_malformed_think_tag"):
         configured_thinking_tags = _get_reward_penalty_config_value(
@@ -1493,10 +1494,10 @@ def apply_reward_penalties(
          Data: full_result["response"]["output"] — message items have content[0]["text"].
 
       3. penalize_eos_token (token-based)
-         The EOS token resolved from config override or tokenizer should never
-         appear inside any assistant generation. A final EOS token is allowed
-         per assistant turn because vLLM/Gym may include the terminal stop
-         marker in generation_token_ids.
+         The explicitly configured EOS token should never appear inside any
+         assistant generation. A final EOS token is allowed per assistant turn
+         because vLLM/Gym may include the terminal stop marker in
+         generation_token_ids.
          Data: message_log[i]["token_ids"] where role == "assistant".
 
       4. penalize_malformed_think_tag (message flag + token/string fallback)

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -1494,7 +1494,9 @@ def apply_reward_penalties(
 
       3. penalize_eos_token (token-based)
          The EOS token resolved from config override or tokenizer should never
-         appear in any assistant generation.
+         appear inside any assistant generation. A final EOS token is allowed
+         per assistant turn because vLLM/Gym may include the terminal stop
+         marker in generation_token_ids.
          Data: message_log[i]["token_ids"] where role == "assistant".
 
       4. penalize_malformed_think_tag (message flag + token/string fallback)
@@ -1608,7 +1610,11 @@ def apply_reward_penalties(
         for result in results:
             has_eos = False
             for msg in result["message_log"]:
-                if msg["role"] == "assistant" and eos_token_id in msg["token_ids"]:
+                if msg["role"] != "assistant":
+                    continue
+                # Allow a terminal EOS stop marker on each assistant turn, but
+                # penalize EOS emitted inside the assistant content.
+                if eos_token_id in msg["token_ids"][:-1]:
                     has_eos = True
                     break
             if has_eos:

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -1351,14 +1351,6 @@ def _get_reward_penalty_config_value(
     if isinstance(reward_penalty_config, dict):
         return reward_penalty_config.get(key)
 
-    model_extra = getattr(reward_penalty_config, "model_extra", None)
-    if isinstance(model_extra, dict) and key in model_extra:
-        return model_extra[key]
-
-    pydantic_extra = getattr(reward_penalty_config, "__pydantic_extra__", None)
-    if isinstance(pydantic_extra, dict) and key in pydantic_extra:
-        return pydantic_extra[key]
-
     return getattr(reward_penalty_config, key, None)
 
 
@@ -1367,14 +1359,7 @@ def _get_reward_penalty_token_id(
     key: str,
 ) -> int | None:
     token_ids = _get_reward_penalty_config_value(reward_penalty_config, "token_ids")
-    if token_ids is None:
-        return None
-
-    if isinstance(token_ids, dict):
-        value = token_ids.get(key)
-    else:
-        value = getattr(token_ids, key, None)
-
+    value = _get_reward_penalty_config_value(token_ids, key)
     if value is None:
         return None
     return int(value)
@@ -1395,14 +1380,7 @@ def _get_reward_penalty_token_ids(
     key: str,
 ) -> list[int] | None:
     token_ids = _get_reward_penalty_config_value(reward_penalty_config, "token_ids")
-    if token_ids is None:
-        return None
-
-    if isinstance(token_ids, dict):
-        value = token_ids.get(key)
-    else:
-        value = getattr(token_ids, key, None)
-
+    value = _get_reward_penalty_config_value(token_ids, key)
     if value is None:
         return None
     if isinstance(value, int):
@@ -1487,14 +1465,15 @@ def resolve_reward_penalty_config(
             if not explicit_close:
                 inferred_close = _infer_single_token_id(tokenizer, tags[1])
 
-            if explicit_open or explicit_close:
+            if (
+                explicit_open
+                or explicit_close
+                or (inferred_open is not None and inferred_close is not None)
+            ):
                 if inferred_open is not None:
                     token_ids["think_open"] = inferred_open
                 if inferred_close is not None:
                     token_ids["think_close"] = inferred_close
-            elif inferred_open is not None and inferred_close is not None:
-                token_ids["think_open"] = inferred_open
-                token_ids["think_close"] = inferred_close
 
     if token_ids:
         resolved["token_ids"] = token_ids

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -47,6 +47,7 @@ from nemo_rl.environments.interfaces import (
     EnvironmentInterface,
     EnvironmentReturn,
 )
+from nemo_rl.environments.nemo_gym import DEFAULT_THINKING_TAGS
 from nemo_rl.models.generation.interfaces import (
     GenerationConfig,
     GenerationDatumSpec,
@@ -1333,6 +1334,377 @@ def _calculate_single_metric(
     }
 
 
+def get_nemo_gym_thinking_tags(env_config: dict[str, Any]) -> list[str]:
+    """Return thinking tags used by the Gym-side detector."""
+    nemo_gym_config = env_config.get("nemo_gym")
+    if isinstance(nemo_gym_config, dict) and nemo_gym_config.get("thinking_tags"):
+        return list(nemo_gym_config["thinking_tags"])
+    return list(DEFAULT_THINKING_TAGS)
+
+
+def _get_reward_penalty_config_value(
+    reward_penalty_config: dict[str, Any] | BaseModel | None,
+    key: str,
+) -> Any:
+    if reward_penalty_config is None:
+        return None
+    if isinstance(reward_penalty_config, dict):
+        return reward_penalty_config.get(key)
+
+    model_extra = getattr(reward_penalty_config, "model_extra", None)
+    if isinstance(model_extra, dict) and key in model_extra:
+        return model_extra[key]
+
+    pydantic_extra = getattr(reward_penalty_config, "__pydantic_extra__", None)
+    if isinstance(pydantic_extra, dict) and key in pydantic_extra:
+        return pydantic_extra[key]
+
+    return getattr(reward_penalty_config, key, None)
+
+
+def _get_reward_penalty_token_id(
+    reward_penalty_config: dict[str, Any] | BaseModel,
+    key: str,
+) -> int | None:
+    token_ids = _get_reward_penalty_config_value(reward_penalty_config, "token_ids")
+    if token_ids is None:
+        return None
+
+    if isinstance(token_ids, dict):
+        value = token_ids.get(key)
+    else:
+        value = getattr(token_ids, key, None)
+
+    if value is None:
+        return None
+    return int(value)
+
+
+def _get_required_reward_penalty_token_id(
+    reward_penalty_config: dict[str, Any] | BaseModel,
+    key: str,
+) -> int:
+    value = _get_reward_penalty_token_id(reward_penalty_config, key)
+    if value is None:
+        raise ValueError(f"reward_penalties.token_ids.{key} must be set")
+    return value
+
+
+def _infer_single_token_id(tokenizer: Any, text: str) -> int | None:
+    token_ids = tokenizer.encode(text, add_special_tokens=False)
+    if len(token_ids) != 1:
+        return None
+    return int(token_ids[0])
+
+
+def resolve_reward_penalty_config(
+    reward_penalty_config: dict[str, Any] | BaseModel | None,
+    tokenizer: Any,
+    thinking_tags: list[str] | tuple[str, ...] | None = None,
+) -> dict[str, Any] | None:
+    """Resolve tokenizer-derived reward penalty fields.
+
+    User config can still override token IDs. When absent, infer EOS from the
+    tokenizer and infer think-tag IDs only when each configured tag is exactly
+    one token.
+    """
+    if reward_penalty_config is None:
+        return None
+
+    resolved: dict[str, Any] = {}
+    for flag in (
+        "penalize_duplicated_reasoning",
+        "penalize_empty_final_answer",
+        "penalize_eos_token",
+        "penalize_malformed_think_tag",
+    ):
+        value = _get_reward_penalty_config_value(reward_penalty_config, flag)
+        if value is not None:
+            resolved[flag] = value
+
+    token_ids: dict[str, int] = {}
+    for key in ("eos", "think_open", "think_close"):
+        value = _get_reward_penalty_token_id(reward_penalty_config, key)
+        if value is not None:
+            token_ids[key] = value
+
+    if resolved.get("penalize_eos_token") and "eos" not in token_ids:
+        eos_token_id = getattr(tokenizer, "eos_token_id", None)
+        if eos_token_id is not None:
+            token_ids["eos"] = int(eos_token_id)
+
+    if resolved.get("penalize_malformed_think_tag"):
+        configured_thinking_tags = _get_reward_penalty_config_value(
+            reward_penalty_config, "thinking_tags"
+        )
+        tags = tuple(thinking_tags or configured_thinking_tags or DEFAULT_THINKING_TAGS)
+        resolved["thinking_tags"] = tags
+        if len(tags) >= 2:
+            explicit_open = "think_open" in token_ids
+            explicit_close = "think_close" in token_ids
+            inferred_open = None
+            inferred_close = None
+            if not explicit_open:
+                inferred_open = _infer_single_token_id(tokenizer, tags[0])
+            if not explicit_close:
+                inferred_close = _infer_single_token_id(tokenizer, tags[1])
+
+            if explicit_open or explicit_close:
+                if inferred_open is not None:
+                    token_ids["think_open"] = inferred_open
+                if inferred_close is not None:
+                    token_ids["think_close"] = inferred_close
+            elif inferred_open is not None and inferred_close is not None:
+                token_ids["think_open"] = inferred_open
+                token_ids["think_close"] = inferred_close
+
+    if token_ids:
+        resolved["token_ids"] = token_ids
+
+    return resolved
+
+
+def apply_reward_penalties(
+    results: list[dict], reward_penalty_config: dict[str, Any] | BaseModel | None
+) -> dict[str, int]:
+    """Apply reward penalties to results, setting reward to 0.0 when triggered.
+
+    All penalties are gated by reward_penalty_config flags. Returns a dict of penalty
+    counts keyed by penalty name.
+
+    NOTE: These penalties assume Gym-path message_log structure where roles
+    strictly alternate "user" → "assistant". Tool responses are folded into
+    user prompt tokens by _postprocess_nemo_gym_to_nemo_rl_result and never
+    appear as separate message_log entries. Do not call from non-Gym rollout paths.
+
+    Penalties:
+      1. penalize_duplicated_reasoning (text-based)
+         Checks response["output"] items. If a "reasoning" item's summary text
+         exactly matches the next item's content text (after strip), the model
+         is copying its thinking into the final answer verbatim.
+         Data: full_result["response"]["output"] — reasoning has summary[0]["text"],
+         message has content[0]["text"].
+
+      2. penalize_empty_final_answer (text-based)
+         Walks response["output"] in reverse to find the last message-type item.
+         If no message item exists or its content text is empty, the model failed
+         to produce a final answer. Skipped when the last output item is a
+         function_call (model was mid-agentic-loop, not producing an empty answer).
+         Data: full_result["response"]["output"] — message items have content[0]["text"].
+
+      3. penalize_eos_token (token-based)
+         The EOS token resolved from config override or tokenizer should never
+         appear in any assistant generation.
+         Data: message_log[i]["token_ids"] where role == "assistant".
+
+      4. penalize_malformed_think_tag (message flag + token/string fallback)
+         Three complementary checks to catch malformed think tags:
+         a) Existing Gym flag: honors assistant message has_malformed_thinking.
+         b) Token ID check: when think tag IDs are resolved from config override
+            or single-token tokenizer encodings, infers thinking mode from
+            prompt token counts. If prompt has open==close:
+            enable_thinking=False, expect 0 open
+            and 0 close in generation. If prompt has open==close+1:
+            enable_thinking=True, expect 0 open and 1 close in generation.
+            Any other prompt pattern or mismatched generation counts is a violation.
+            This fallback is skipped when the tags do not resolve to one token
+            each.
+         c) String check: the model can spell out thinking tags with piecemeal
+            regular tokens (e.g. "<", "/", "thi", "nk", ">") that bypass special
+            token IDs. Checks generation_str (decoded generation text) per output
+            item: open-tag count must be 0 (always in prompt, never generated),
+            close-tag count must be 0 or 1.
+         Data: message_log pairs for token IDs, full_result output items for strings.
+    """
+    counts = {
+        "duplicated_reasoning": 0,
+        "empty_final_answer": 0,
+        "eos_token": 0,
+        "malformed_think_tag": 0,
+    }
+    if not reward_penalty_config or not results:
+        return counts
+
+    # Guard: penalties rely on Gym-path message_log (strictly alternating user/assistant roles).
+    # Non-Gym paths may have "environment", "tool", or "system" roles which these checks don't handle.
+    any_penalty_enabled = any(
+        _get_reward_penalty_config_value(reward_penalty_config, flag)
+        for flag in (
+            "penalize_duplicated_reasoning",
+            "penalize_empty_final_answer",
+            "penalize_eos_token",
+            "penalize_malformed_think_tag",
+        )
+    )
+    if any_penalty_enabled:
+        for result in results:
+            roles = {msg.get("role") for msg in result["message_log"]}
+            assert roles <= {"user", "assistant"}, (
+                f"apply_reward_penalties requires Gym-path message_log with only 'user' and 'assistant' roles, "
+                f"but found roles: {roles}. These penalties are not supported for non-Gym rollout paths."
+            )
+
+    # --- Penalty 1: Duplicated reasoning / final answer ---
+    if _get_reward_penalty_config_value(
+        reward_penalty_config, "penalize_duplicated_reasoning"
+    ):
+        for result in results:
+            output_items = result["full_result"].get("response", {}).get("output", [])
+            is_duplicated = False
+            for item1, item2 in zip(output_items, output_items[1:]):
+                if item1.get("type") != "reasoning":
+                    continue
+                summary = item1.get("summary", [])
+                if not summary or "text" not in summary[0]:
+                    continue
+                reasoning_text = summary[0]["text"].strip()
+                content = item2.get("content", "")
+                if isinstance(content, list) and content and "text" in content[0]:
+                    chat_text = content[0]["text"].strip()
+                elif isinstance(content, str):
+                    chat_text = content.strip()
+                else:
+                    continue
+                if reasoning_text and chat_text and reasoning_text == chat_text:
+                    is_duplicated = True
+                    break
+            if is_duplicated:
+                result["full_result"]["reward"] = 0.0
+
+                counts["duplicated_reasoning"] += 1
+
+    # --- Penalty 2: Empty final answer ---
+    if _get_reward_penalty_config_value(
+        reward_penalty_config, "penalize_empty_final_answer"
+    ):
+        for result in results:
+            output_items = result["full_result"].get("response", {}).get("output", [])
+            # Skip if the last output item is a function_call — it is legit for model to
+            # produce reasoning and then a function_call as the last output item in PivotRL
+            if output_items and output_items[-1].get("type") == "function_call":
+                continue
+            final_answer_text = None
+            for item in reversed(output_items):
+                # Skip items without content (function_call, function_call_output, etc.)
+                if "content" not in item:
+                    continue
+                content = item["content"]
+                if isinstance(content, list) and content and "text" in content[0]:
+                    final_answer_text = content[0]["text"].strip()
+                    break
+                elif isinstance(content, str):
+                    final_answer_text = content.strip()
+                    break
+            if final_answer_text is None or final_answer_text == "":
+                result["full_result"]["reward"] = 0.0
+
+                counts["empty_final_answer"] += 1
+
+    # --- Penalty 3: EOS token in generation ---
+    if _get_reward_penalty_config_value(reward_penalty_config, "penalize_eos_token"):
+        eos_token_id = _get_required_reward_penalty_token_id(
+            reward_penalty_config, "eos"
+        )
+        for result in results:
+            has_eos = False
+            for msg in result["message_log"]:
+                if msg["role"] == "assistant" and eos_token_id in msg["token_ids"]:
+                    has_eos = True
+                    break
+            if has_eos:
+                result["full_result"]["reward"] = 0.0
+
+                counts["eos_token"] += 1
+
+    # --- Penalty 4: Malformed think tags (existing flag + optional token ID + string) ---
+    if _get_reward_penalty_config_value(
+        reward_penalty_config, "penalize_malformed_think_tag"
+    ):
+        think_open_token_id = _get_reward_penalty_token_id(
+            reward_penalty_config, "think_open"
+        )
+        think_close_token_id = _get_reward_penalty_token_id(
+            reward_penalty_config, "think_close"
+        )
+        if (think_open_token_id is None) != (think_close_token_id is None):
+            raise ValueError(
+                "reward_penalties.token_ids.think_open and "
+                "reward_penalties.token_ids.think_close must both be set"
+            )
+        for result in results:
+            has_violation = any(
+                msg.get("role") == "assistant"
+                and msg.get("has_malformed_thinking", False)
+                for msg in result["message_log"]
+            )
+
+            # 4a) Token ID check per (user, assistant) turn pair.
+            # Infer thinking mode from prompt token counts:
+            #   enable_thinking=True:  prompt has open=close+1 (trailing <think>), expect asst: 0 open, 1 close
+            #   enable_thinking=False: prompt has open=close (balanced), expect asst: 0 open, 0 close
+            msgs = result["message_log"]
+            if (
+                not has_violation
+                and think_open_token_id is not None
+                and think_close_token_id is not None
+            ):
+                for i in range(len(msgs) - 1):
+                    if msgs[i]["role"] != "user" or msgs[i + 1]["role"] != "assistant":
+                        continue
+                    user_ids = msgs[i]["token_ids"]
+                    asst_ids = msgs[i + 1]["token_ids"]
+                    prompt_open = (user_ids == think_open_token_id).sum().item()
+                    prompt_close = (user_ids == think_close_token_id).sum().item()
+                    asst_open = (asst_ids == think_open_token_id).sum().item()
+                    asst_close = (asst_ids == think_close_token_id).sum().item()
+                    if prompt_open == prompt_close:
+                        # enable_thinking=False: both tags in prompt, none in generation
+                        expected_open, expected_close = 0, 0
+                    elif prompt_open == prompt_close + 1:
+                        # enable_thinking=True: trailing <think> in prompt, expect </think> in generation
+                        expected_open, expected_close = 0, 1
+                    else:
+                        # Unexpected prompt pattern - flag as violation
+                        has_violation = True
+                        break
+                    if asst_open != expected_open or asst_close != expected_close:
+                        has_violation = True
+                        break
+
+            # 4b) String check on generation_str per output item.
+            if not has_violation:
+                thinking_tags = (
+                    _get_reward_penalty_config_value(
+                        reward_penalty_config, "thinking_tags"
+                    )
+                    or DEFAULT_THINKING_TAGS
+                )
+                if len(thinking_tags) < 2:
+                    raise ValueError(
+                        "reward_penalties.thinking_tags must contain open and close tags"
+                    )
+                think_open_text, think_close_text = thinking_tags[:2]
+                output_items = (
+                    result["full_result"].get("response", {}).get("output", [])
+                )
+                for item in output_items:
+                    gen_str = item.get("generation_str", "")
+                    if not gen_str:
+                        continue
+                    if (
+                        gen_str.count(think_open_text) > 0
+                        or gen_str.count(think_close_text) > 1
+                    ):
+                        has_violation = True
+                        break
+            if has_violation:
+                result["full_result"]["reward"] = 0.0
+
+                counts["malformed_think_tag"] += 1
+
+    return counts
+
+
 def run_async_nemo_gym_rollout(
     policy_generation: GenerationInterface,
     input_batch: BatchedDataDict[DatumSpec],
@@ -1343,6 +1715,8 @@ def run_async_nemo_gym_rollout(
     max_rollout_turns: Optional[int] = None,
     greedy: bool = False,
     effort_config: Optional[EffortLevelsConfig] = None,
+    reward_penalty_config: dict[str, Any] | BaseModel | None = None,
+    thinking_tags: list[str] | tuple[str, ...] | None = None,
 ) -> AsyncNemoGymRolloutResult:
     """Run multi-turn rollouts with NeMo-Gym. Please refer to the `run_async_multi_turn_rollout` docs for more information on the parameters."""
     # We accept max_seq_len for API parity with the other rollout paths, but NeMo-Gym
@@ -1428,6 +1802,11 @@ def run_async_nemo_gym_rollout(
     rewards_low = shaping.rewards_low
     low_lengths = shaping.low_lengths
     high_lengths = shaping.high_lengths
+
+    resolved_reward_penalty_config = resolve_reward_penalty_config(
+        reward_penalty_config, tokenizer, thinking_tags=thinking_tags
+    )
+    penalty_counts = apply_reward_penalties(results, resolved_reward_penalty_config)
 
     # Prepare for the rollout metrics calculation below. Not strictly necessary here, but good to have parity with `run_async_multi_turn_rollout`
     with timer.time(f"{timer_prefix}/prepare_for_metrics_calculation"):
@@ -1585,6 +1964,27 @@ def run_async_nemo_gym_rollout(
     if high_lengths:
         rollout_metrics["mean_length_high"] = sum(high_lengths) / len(high_lengths)
         rollout_metrics["median_length_high"] = float(statistics.median(high_lengths))
+
+    # Penalty metrics — map count keys to (config flag, metric name)
+    _PENALTY_METRICS = {
+        "duplicated_reasoning": (
+            "penalize_duplicated_reasoning",
+            "reasoning_equal_to_final_answer_rate",
+        ),
+        "empty_final_answer": (
+            "penalize_empty_final_answer",
+            "empty_final_answer_rate",
+        ),
+        "eos_token": ("penalize_eos_token", "eos_token_rate"),
+        "malformed_think_tag": (
+            "penalize_malformed_think_tag",
+            "malformed_think_tag_rate",
+        ),
+    }
+    if resolved_reward_penalty_config and results:
+        for key, (flag, metric_name) in _PENALTY_METRICS.items():
+            if _get_reward_penalty_config_value(resolved_reward_penalty_config, flag):
+                rollout_metrics[metric_name] = penalty_counts[key] / len(results)
 
     return AsyncNemoGymRolloutResult(
         input_ids=input_ids,

--- a/nemo_rl/experience/sync_rollout_actor.py
+++ b/nemo_rl/experience/sync_rollout_actor.py
@@ -50,6 +50,7 @@ from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.experience.rollouts import (
     EffortLevelsConfig,
+    get_nemo_gym_thinking_tags,
     run_async_multi_turn_rollout,
     run_async_nemo_gym_rollout,
     run_multi_turn_rollout,
@@ -251,6 +252,8 @@ class SyncRolloutActor:
                 if "nemo_gym" in cfg.env
                 and cfg.env["nemo_gym"].get("effort_levels") is not None
                 else None,
+                reward_penalty_config=cfg.reward_penalties,
+                thinking_tags=get_nemo_gym_thinking_tags(cfg.env),
             )
             final_batch, rollout_metrics = r.final_batch, r.rollout_metrics
         else:

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from contextlib import contextmanager
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -27,9 +28,11 @@ from nemo_rl.algorithms.advantage_estimator import (
 )
 from nemo_rl.algorithms.grpo import (
     MasterConfig,
+    RewardPenaltyConfig,
     _apply_configured_message_level_advantage_penalties,
     _apply_message_level_advantage_penalties,
     _default_grpo_save_state,
+    _raise_if_reward_penalties_enabled_without_nemo_gym,
     _resolve_message_level_advantage_penalties,
     _should_use_async_rollouts,
     aggregate_rollout_metrics,
@@ -469,8 +472,57 @@ def test_resolve_message_level_advantage_penalties_requires_nemo_gym(
     master_config.grpo["invalid_tool_call_advantage"] = -5.0
 
     with patch("nemo_rl.algorithms.grpo._should_use_nemo_gym", return_value=False):
-        with pytest.raises(AssertionError, match="NeMo-Gym path"):
+        with pytest.raises(ValueError, match="NeMo-Gym path"):
             _resolve_message_level_advantage_penalties(master_config)
+
+
+def test_raise_if_reward_penalties_enabled_without_nemo_gym_noops_when_all_flags_false(
+    mock_grpo_components,
+):
+    master_config = mock_grpo_components["master_config"]
+    master_config.reward_penalties = RewardPenaltyConfig()
+
+    _raise_if_reward_penalties_enabled_without_nemo_gym(
+        master_config, enable_nemo_gym=False
+    )
+
+
+@pytest.mark.parametrize(
+    "penalty_flag",
+    [
+        "penalize_duplicated_reasoning",
+        "penalize_empty_final_answer",
+        "penalize_unwanted_tokens",
+        "penalize_malformed_think_tag",
+    ],
+)
+def test_raise_if_reward_penalties_enabled_without_nemo_gym_raises(
+    mock_grpo_components,
+    penalty_flag,
+):
+    master_config = mock_grpo_components["master_config"]
+    penalty_kwargs: dict[str, Any] = {penalty_flag: True}
+    if penalty_flag == "penalize_unwanted_tokens":
+        penalty_kwargs["token_ids"] = {"unwanted": [2]}
+    master_config.reward_penalties = RewardPenaltyConfig(**penalty_kwargs)
+
+    with pytest.raises(ValueError, match="reward_penalties require the NeMo-Gym path"):
+        _raise_if_reward_penalties_enabled_without_nemo_gym(
+            master_config, enable_nemo_gym=False
+        )
+
+
+def test_raise_if_reward_penalties_enabled_without_nemo_gym_allows_nemo_gym(
+    mock_grpo_components,
+):
+    master_config = mock_grpo_components["master_config"]
+    master_config.reward_penalties = RewardPenaltyConfig(
+        penalize_empty_final_answer=True
+    )
+
+    _raise_if_reward_penalties_enabled_without_nemo_gym(
+        master_config, enable_nemo_gym=True
+    )
 
 
 def test_raise_if_message_level_advantage_penalties_enabled_noops_when_unset(

--- a/tests/unit/experience/test_reward_penalties.py
+++ b/tests/unit/experience/test_reward_penalties.py
@@ -1,0 +1,837 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+import sys
+
+import pytest
+import torch
+
+# apply_reward_penalties only needs torch, but rollouts.py imports ray/vllm/zmq.
+# Extract and exec just the helper and function to avoid the heavy dependency chain.
+try:
+    from nemo_rl.experience.rollouts import (
+        apply_reward_penalties,
+        resolve_reward_penalty_config,
+    )
+except (ImportError, ModuleNotFoundError):
+    _rollouts_path = os.path.normpath(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "..",
+            "..",
+            "..",
+            "nemo_rl",
+            "experience",
+            "rollouts.py",
+        )
+    )
+    _src = open(_rollouts_path).read()
+    _match = re.search(
+        r"^(def _get_reward_penalty_config_value\(.+?)(?=\ndef run_async_nemo_gym_rollout)",
+        _src,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert _match, "Could not find apply_reward_penalties in rollouts.py"
+    exec("from typing import Any\nfrom pydantic import BaseModel\n" + _match.group(1))
+
+
+# ---- Helpers to build minimal result dicts ----
+
+
+def _make_result(
+    reward=1.0,
+    output_items=None,
+    message_log=None,
+):
+    """Build a minimal result dict matching the structure from nemo_gym."""
+    return {
+        "full_result": {
+            "reward": reward,
+            "response": {"output": output_items or []},
+        },
+        "message_log": message_log or [],
+    }
+
+
+def _reasoning_item(text, generation_str=None):
+    item = {"type": "reasoning", "summary": [{"text": text, "type": "summary_text"}]}
+    if generation_str is not None:
+        item["generation_str"] = generation_str
+    return item
+
+
+def _message_item(text, generation_str=None):
+    item = {
+        "type": "message",
+        "content": [{"text": text, "type": "output_text"}],
+        "role": "assistant",
+    }
+    if generation_str is not None:
+        item["generation_str"] = generation_str
+    return item
+
+
+def _function_call_item(name="tool", generation_str=None):
+    item = {"type": "function_call", "name": name, "arguments": "{}", "call_id": "c1"}
+    if generation_str is not None:
+        item["generation_str"] = generation_str
+    return item
+
+
+def _function_call_output_item(output="result"):
+    return {"type": "function_call_output", "output": output, "call_id": "c1"}
+
+
+def _msg(role, token_ids, **extra):
+    msg = {"role": role, "token_ids": torch.tensor(token_ids)}
+    msg.update(extra)
+    return msg
+
+
+class _FakeTokenizer:
+    def __init__(self, eos_token_id=2, token_map=None):
+        self.eos_token_id = eos_token_id
+        self.token_map = token_map or {"<think>": [12], "</think>": [13]}
+
+    def encode(self, text, add_special_tokens=False):
+        assert not add_special_tokens
+        return self.token_map[text]
+
+
+# =====================================================================
+# Penalty 1: penalize_duplicated_reasoning
+# =====================================================================
+
+
+class TestPenalizeDuplicatedReasoning:
+    CFG = {"penalize_duplicated_reasoning": True}
+
+    def test_exact_match_penalized(self):
+        result = _make_result(
+            reward=1.0,
+            output_items=[
+                _reasoning_item("The answer is 42"),
+                _message_item("The answer is 42"),
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 0.0
+        assert counts["duplicated_reasoning"] == 1
+
+    def test_different_text_not_penalized(self):
+        result = _make_result(
+            reward=1.0,
+            output_items=[
+                _reasoning_item("Let me think about this"),
+                _message_item("The answer is 42"),
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 1.0
+        assert counts["duplicated_reasoning"] == 0
+
+    def test_whitespace_stripped_before_compare(self):
+        result = _make_result(
+            reward=1.0,
+            output_items=[
+                _reasoning_item("  hello world  "),
+                _message_item("hello world"),
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 0.0
+
+    def test_empty_reasoning_not_penalized(self):
+        result = _make_result(
+            reward=1.0,
+            output_items=[
+                _reasoning_item(""),
+                _message_item(""),
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 1.0
+
+    def test_reasoning_followed_by_function_call_not_penalized(self):
+        result = _make_result(
+            reward=1.0,
+            output_items=[
+                _reasoning_item("I need to call a tool"),
+                _function_call_item(),
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 1.0
+
+    def test_no_reasoning_item_not_penalized(self):
+        result = _make_result(
+            reward=1.0,
+            output_items=[
+                _message_item("The answer is 42"),
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 1.0
+
+    def test_disabled_by_default(self):
+        result = _make_result(
+            reward=1.0,
+            output_items=[
+                _reasoning_item("same"),
+                _message_item("same"),
+            ],
+        )
+        counts = apply_reward_penalties([result], {})
+        assert result["full_result"]["reward"] == 1.0
+
+    def test_multi_turn_first_pair_matches(self):
+        """In multi-turn, if any reasoning/answer pair matches, penalize."""
+        result = _make_result(
+            reward=1.0,
+            output_items=[
+                _reasoning_item("duplicated"),
+                _message_item("duplicated"),
+                _function_call_item(),
+                _function_call_output_item(),
+                _reasoning_item("different thinking"),
+                _message_item("final answer"),
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 0.0
+
+
+# =====================================================================
+# Penalty 2: penalize_empty_final_answer
+# =====================================================================
+
+
+class TestPenalizeEmptyFinalAnswer:
+    CFG = {"penalize_empty_final_answer": True}
+
+    def test_empty_content_penalized(self):
+        result = _make_result(
+            reward=1.0,
+            output_items=[
+                _reasoning_item("thinking"),
+                _message_item(""),
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 0.0
+        assert counts["empty_final_answer"] == 1
+
+    def test_nonempty_content_not_penalized(self):
+        result = _make_result(
+            reward=1.0,
+            output_items=[
+                _reasoning_item("thinking"),
+                _message_item("The answer is 42"),
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 1.0
+
+    def test_no_message_item_penalized(self):
+        """Only reasoning + tool calls, no final message."""
+        result = _make_result(
+            reward=1.0,
+            output_items=[
+                _reasoning_item("thinking"),
+                _function_call_item(),
+                _function_call_output_item(),
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 0.0
+
+    def test_empty_output_items_penalized(self):
+        result = _make_result(reward=1.0, output_items=[])
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 0.0
+
+    def test_whitespace_only_penalized(self):
+        result = _make_result(
+            reward=1.0,
+            output_items=[
+                _message_item("   "),
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 0.0
+
+    def test_last_item_function_call_not_penalized(self):
+        """Model ended mid-agentic-loop with a function_call — not an empty answer."""
+        result = _make_result(
+            reward=1.0,
+            output_items=[
+                _reasoning_item("thinking"),
+                _function_call_item(),
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 1.0
+        assert counts["empty_final_answer"] == 0
+
+    def test_message_before_tool_call_uses_last_message(self):
+        """Last content-bearing item is the function_call_output (no content field),
+        but there's a message earlier. The reverse walk finds the message."""
+        result = _make_result(
+            reward=1.0,
+            output_items=[
+                _message_item("answer"),
+                _function_call_item(),
+                _function_call_output_item(),
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        # function_call_output has no "content", function_call has no "content",
+        # so reverse walk reaches the message item
+        assert result["full_result"]["reward"] == 1.0
+
+
+# =====================================================================
+# Penalty 3: penalize_eos_token
+# =====================================================================
+
+
+class TestPenalizeEosToken:
+    CFG = {"penalize_eos_token": True, "token_ids": {"eos": 2}}
+
+    def test_eos_in_generation_penalized(self):
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100, 200]),
+                _msg("assistant", [300, 2, 400]),  # token 2 = EOS
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 0.0
+        assert counts["eos_token"] == 1
+
+    def test_no_eos_not_penalized(self):
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100, 200]),
+                _msg("assistant", [300, 400, 500]),
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 1.0
+
+    def test_eos_in_user_not_penalized(self):
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100, 2, 200]),  # EOS in user prompt
+                _msg("assistant", [300, 400]),
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 1.0
+
+    def test_custom_eos_token_id(self):
+        cfg = {"penalize_eos_token": True, "token_ids": {"eos": 99}}
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100]),
+                _msg("assistant", [300, 99, 400]),
+            ],
+        )
+        counts = apply_reward_penalties([result], cfg)
+        assert result["full_result"]["reward"] == 0.0
+
+    def test_multi_turn_eos_in_second_turn(self):
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100]),
+                _msg("assistant", [300, 400]),  # turn 1 ok
+                _msg("user", [500]),
+                _msg("assistant", [600, 2]),  # turn 2 has EOS
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 0.0
+
+    def test_empty_generation_not_penalized(self):
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100]),
+                _msg("assistant", []),
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 1.0
+
+    def test_eos_token_id_inferred_from_tokenizer(self):
+        cfg = resolve_reward_penalty_config(
+            {"penalize_eos_token": True}, _FakeTokenizer(eos_token_id=2)
+        )
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100]),
+                _msg("assistant", [300, 2]),
+            ],
+        )
+        counts = apply_reward_penalties([result], cfg)
+        assert result["full_result"]["reward"] == 0.0
+        assert counts["eos_token"] == 1
+
+    def test_null_token_ids_uses_tokenizer_eos(self):
+        cfg = resolve_reward_penalty_config(
+            {"penalize_eos_token": True, "token_ids": None},
+            _FakeTokenizer(eos_token_id=2),
+        )
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100]),
+                _msg("assistant", [300, 2]),
+            ],
+        )
+        counts = apply_reward_penalties([result], cfg)
+        assert result["full_result"]["reward"] == 0.0
+        assert counts["eos_token"] == 1
+
+    def test_missing_eos_after_resolution_raises(self):
+        cfg = resolve_reward_penalty_config(
+            {"penalize_eos_token": True}, _FakeTokenizer(eos_token_id=None)
+        )
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100]),
+                _msg("assistant", [300, 2]),
+            ],
+        )
+        with pytest.raises(ValueError, match="reward_penalties.token_ids.eos"):
+            apply_reward_penalties([result], cfg)
+
+
+# =====================================================================
+# Penalty 4: penalize_malformed_think_tag
+# =====================================================================
+
+
+class TestPenalizeMultiEndThink:
+    CFG = {
+        "penalize_malformed_think_tag": True,
+        "token_ids": {"think_open": 12, "think_close": 13},
+    }
+
+    # --- 4a: Token ID checks ---
+
+    def test_enable_thinking_true_valid(self):
+        """enable_thinking=True: <think>(12) in user prompt, </think>(13) in gen."""
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100, 12, 200]),  # 1x <think> in prompt
+                _msg("assistant", [300, 13, 400]),  # 1x </think> in gen
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 1.0
+
+    def test_enable_thinking_false_valid(self):
+        """enable_thinking=False: <think>(12) and </think>(13) both in prompt."""
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100, 12, 13, 200]),  # both in prompt
+                _msg("assistant", [300, 400]),  # none in gen
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 1.0
+
+    def test_missing_think_open_penalized(self):
+        """No <think> token at all."""
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100, 200]),
+                _msg("assistant", [300, 13, 400]),  # only </think>
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 0.0
+        assert counts["malformed_think_tag"] == 1
+
+    def test_missing_think_close_penalized(self):
+        """No </think> token at all."""
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100, 12, 200]),
+                _msg("assistant", [300, 400]),  # no </think>
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 0.0
+
+    def test_double_think_close_penalized(self):
+        """Two </think> tokens in generation."""
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100, 12, 200]),
+                _msg("assistant", [300, 13, 400, 13]),  # 2x </think>
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 0.0
+
+    def test_double_think_open_penalized(self):
+        """Two <think> tokens."""
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100, 12, 12, 200]),  # 2x <think>
+                _msg("assistant", [300, 13, 400]),
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 0.0
+
+    def test_multi_turn_valid(self):
+        """Two valid turns, each with exactly 1 <think> and 1 </think>."""
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100, 12]),
+                _msg("assistant", [300, 13, 400]),
+                _msg("user", [500, 12]),
+                _msg("assistant", [600, 13, 700]),
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 1.0
+
+    def test_multi_turn_second_turn_invalid(self):
+        """First turn ok, second turn has double </think>."""
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100, 12]),
+                _msg("assistant", [300, 13, 400]),
+                _msg("user", [500, 12]),
+                _msg("assistant", [600, 13, 13, 700]),  # 2x </think>
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 0.0
+
+    def test_custom_token_ids(self):
+        cfg = {
+            "penalize_malformed_think_tag": True,
+            "token_ids": {"think_open": 50, "think_close": 51},
+        }
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100, 50]),
+                _msg("assistant", [300, 51, 400]),
+            ],
+        )
+        counts = apply_reward_penalties([result], cfg)
+        assert result["full_result"]["reward"] == 1.0
+
+    def test_think_token_ids_inferred_from_tokenizer(self):
+        cfg = resolve_reward_penalty_config(
+            {"penalize_malformed_think_tag": True}, _FakeTokenizer()
+        )
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100, 12]),
+                _msg("assistant", [300, 13, 400]),
+            ],
+        )
+        counts = apply_reward_penalties([result], cfg)
+        assert result["full_result"]["reward"] == 1.0
+
+    def test_custom_thinking_tags_used_for_inference_and_string_check(self):
+        cfg = resolve_reward_penalty_config(
+            {"penalize_malformed_think_tag": True},
+            _FakeTokenizer(token_map={"<thinking>": [50], "</thinking>": [51]}),
+            thinking_tags=["<thinking>", "</thinking>"],
+        )
+        valid_result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100, 50]),
+                _msg("assistant", [300, 51, 400]),
+            ],
+        )
+        counts = apply_reward_penalties([valid_result], cfg)
+        assert valid_result["full_result"]["reward"] == 1.0
+        assert counts["malformed_think_tag"] == 0
+
+        leaked_result = _make_result(
+            reward=1.0,
+            output_items=[
+                _message_item("answer", generation_str="leaked <thinking> hidden text")
+            ],
+            message_log=[
+                _msg("user", [100, 50]),
+                _msg("assistant", [300, 51, 400]),
+            ],
+        )
+        counts = apply_reward_penalties([leaked_result], cfg)
+        assert leaked_result["full_result"]["reward"] == 0.0
+        assert counts["malformed_think_tag"] == 1
+
+    def test_multitoken_think_tags_skip_token_count_fallback(self):
+        cfg = resolve_reward_penalty_config(
+            {"penalize_malformed_think_tag": True},
+            _FakeTokenizer(token_map={"<think>": [12, 98], "</think>": [13, 99]}),
+        )
+        assert cfg is not None
+        assert "token_ids" not in cfg
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100, 12]),
+                _msg("assistant", [300, 400]),
+            ],
+        )
+        counts = apply_reward_penalties([result], cfg)
+        assert result["full_result"]["reward"] == 1.0
+        assert counts["malformed_think_tag"] == 0
+
+    def test_multi_turn_history_think_tokens_valid(self):
+        """Prompt has many think tokens from history; only the delta matters."""
+        # Simulates a prompt with 5 <think> and 4 </think> from prior turns,
+        # plus a trailing <think> for the current turn = 5 open, 4 close -> thinking_on
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg(
+                    "user", [100, 12, 13, 12, 13, 12, 13, 12, 13, 12]
+                ),  # 5 open, 4 close
+                _msg("assistant", [300, 13, 400]),  # 0 open, 1 close
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 1.0
+
+    def test_thinking_off_with_think_in_generation_penalized(self):
+        """enable_thinking=False inferred (balanced), but model generates </think>."""
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100, 12, 13]),  # 1 open, 1 close -> thinking_off
+                _msg("assistant", [300, 13, 400]),  # unexpected </think>
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 0.0
+
+    def test_unexpected_prompt_pattern_penalized(self):
+        """More </think> than <think> in prompt — unexpected pattern."""
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100, 13, 13, 12]),  # 1 open, 2 close -> unexpected
+                _msg("assistant", [300, 400]),
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 0.0
+
+    def test_existing_has_malformed_thinking_flag_without_token_ids_penalized(self):
+        cfg = {"penalize_malformed_think_tag": True}
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100, 12]),
+                _msg("assistant", [300, 13, 400], has_malformed_thinking=True),
+            ],
+        )
+        counts = apply_reward_penalties([result], cfg)
+        assert result["full_result"]["reward"] == 0.0
+        assert counts["malformed_think_tag"] == 1
+
+    # --- 4b: String checks ---
+
+    def test_piecemeal_think_open_in_generation_penalized(self):
+        """Model spells out <think> with regular tokens in generation_str."""
+        result = _make_result(
+            reward=1.0,
+            output_items=[
+                _message_item(
+                    "answer", generation_str="some <think> text </think> answer"
+                )
+            ],
+            message_log=[
+                _msg("user", [100, 12]),
+                _msg("assistant", [300, 13, 400]),  # token IDs are fine
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 0.0
+
+    def test_piecemeal_double_think_close_in_generation_penalized(self):
+        """Model spells out </think> twice with regular tokens."""
+        result = _make_result(
+            reward=1.0,
+            output_items=[
+                _message_item("answer", generation_str="</think> text </think>")
+            ],
+            message_log=[
+                _msg("user", [100, 12]),
+                _msg("assistant", [300, 13, 400]),  # token IDs are fine
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 0.0
+
+    def test_single_think_close_in_generation_str_ok(self):
+        """One </think> in generation_str is normal for enable_thinking=True."""
+        result = _make_result(
+            reward=1.0,
+            output_items=[
+                _message_item("answer", generation_str="thinking </think> answer")
+            ],
+            message_log=[
+                _msg("user", [100, 12]),
+                _msg("assistant", [300, 13, 400]),
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 1.0
+
+    def test_no_generation_str_skipped(self):
+        """Output items without generation_str are skipped (not penalized)."""
+        result = _make_result(
+            reward=1.0,
+            output_items=[
+                _function_call_output_item(),  # no generation_str
+                _message_item("answer"),  # no generation_str
+            ],
+            message_log=[
+                _msg("user", [100, 12]),
+                _msg("assistant", [300, 13, 400]),
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 1.0
+
+
+# =====================================================================
+# Cross-cutting: multiple penalties, config gating, batch behavior
+# =====================================================================
+
+
+class TestCrossCutting:
+    def test_no_config_no_penalties(self):
+        result = _make_result(reward=1.0)
+        counts = apply_reward_penalties([result], None)
+        assert result["full_result"]["reward"] == 1.0
+        assert all(v == 0 for v in counts.values())
+
+    def test_empty_config_no_penalties(self):
+        result = _make_result(reward=1.0)
+        counts = apply_reward_penalties([result], {})
+        assert result["full_result"]["reward"] == 1.0
+
+    def test_empty_results_no_crash(self):
+        counts = apply_reward_penalties([], {"penalize_eos_token": True})
+        assert all(v == 0 for v in counts.values())
+
+    def test_multiple_penalties_stack(self):
+        """A result that triggers both duplicated reasoning and EOS penalty."""
+        cfg = {
+            "penalize_duplicated_reasoning": True,
+            "penalize_eos_token": True,
+            "token_ids": {"eos": 2},
+        }
+        result = _make_result(
+            reward=1.0,
+            output_items=[
+                _reasoning_item("same"),
+                _message_item("same"),
+            ],
+            message_log=[
+                _msg("user", [100]),
+                _msg("assistant", [300, 2]),  # EOS
+            ],
+        )
+        counts = apply_reward_penalties([result], cfg)
+        assert result["full_result"]["reward"] == 0.0
+        assert counts["duplicated_reasoning"] == 1
+        assert counts["eos_token"] == 1
+
+    def test_batch_of_results_mixed(self):
+        """Two results: first is fine, second has EOS."""
+        cfg = {"penalize_eos_token": True, "token_ids": {"eos": 2}}
+        r1 = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100]),
+                _msg("assistant", [300, 400]),
+            ],
+        )
+        r2 = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100]),
+                _msg("assistant", [300, 2]),
+            ],
+        )
+        counts = apply_reward_penalties([r1, r2], cfg)
+        assert r1["full_result"]["reward"] == 1.0
+        assert r2["full_result"]["reward"] == 0.0
+        assert counts["eos_token"] == 1
+
+
+if __name__ == "__main__":
+    import traceback
+
+    test_classes = [
+        TestPenalizeDuplicatedReasoning,
+        TestPenalizeEmptyFinalAnswer,
+        TestPenalizeEosToken,
+        TestPenalizeMultiEndThink,
+        TestCrossCutting,
+    ]
+
+    passed = 0
+    failed = 0
+    for cls in test_classes:
+        obj = cls()
+        for name in sorted(dir(obj)):
+            if not name.startswith("test_"):
+                continue
+            try:
+                getattr(obj, name)()
+                print(f"  PASS {cls.__name__}.{name}")
+                passed += 1
+            except Exception as e:
+                print(f"  FAIL {cls.__name__}.{name}: {e}")
+                traceback.print_exc()
+                failed += 1
+
+    print(f"\n{passed} passed, {failed} failed")
+    if failed:
+        sys.exit(1)

--- a/tests/unit/experience/test_reward_penalties.py
+++ b/tests/unit/experience/test_reward_penalties.py
@@ -12,40 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import re
 import sys
 
 import pytest
 import torch
 
-# apply_reward_penalties only needs torch, but rollouts.py imports ray/vllm/zmq.
-# Extract and exec just the helper and function to avoid the heavy dependency chain.
-try:
-    from nemo_rl.experience.rollouts import (
-        apply_reward_penalties,
-        resolve_reward_penalty_config,
-    )
-except (ImportError, ModuleNotFoundError):
-    _rollouts_path = os.path.normpath(
-        os.path.join(
-            os.path.dirname(os.path.abspath(__file__)),
-            "..",
-            "..",
-            "..",
-            "nemo_rl",
-            "experience",
-            "rollouts.py",
-        )
-    )
-    _src = open(_rollouts_path).read()
-    _match = re.search(
-        r"^(def _get_reward_penalty_config_value\(.+?)(?=\ndef run_async_nemo_gym_rollout)",
-        _src,
-        re.DOTALL | re.MULTILINE,
-    )
-    assert _match, "Could not find apply_reward_penalties in rollouts.py"
-    exec("from typing import Any\nfrom pydantic import BaseModel\n" + _match.group(1))
+from nemo_rl.experience.rollouts import (
+    apply_reward_penalties,
+    resolve_reward_penalty_config,
+)
 
 
 # ---- Helpers to build minimal result dicts ----
@@ -408,41 +383,20 @@ class TestPenalizeEosToken:
         counts = apply_reward_penalties([result], self.CFG)
         assert result["full_result"]["reward"] == 1.0
 
-    def test_eos_token_id_inferred_from_tokenizer(self):
-        cfg = resolve_reward_penalty_config(
-            {"penalize_eos_token": True}, _FakeTokenizer(eos_token_id=2)
-        )
-        result = _make_result(
-            reward=1.0,
-            message_log=[
-                _msg("user", [100]),
-                _msg("assistant", [300, 2, 400]),
-            ],
-        )
-        counts = apply_reward_penalties([result], cfg)
-        assert result["full_result"]["reward"] == 0.0
-        assert counts["eos_token"] == 1
+    def test_eos_token_id_must_be_explicit(self):
+        with pytest.raises(ValueError, match="reward_penalties.token_ids.eos"):
+            resolve_reward_penalty_config(
+                {"penalize_eos_token": True}, _FakeTokenizer(eos_token_id=2)
+            )
 
-    def test_null_token_ids_uses_tokenizer_eos(self):
-        cfg = resolve_reward_penalty_config(
-            {"penalize_eos_token": True, "token_ids": None},
-            _FakeTokenizer(eos_token_id=2),
-        )
-        result = _make_result(
-            reward=1.0,
-            message_log=[
-                _msg("user", [100]),
-                _msg("assistant", [300, 2, 400]),
-            ],
-        )
-        counts = apply_reward_penalties([result], cfg)
-        assert result["full_result"]["reward"] == 0.0
-        assert counts["eos_token"] == 1
+    def test_null_token_ids_requires_explicit_eos(self):
+        with pytest.raises(ValueError, match="reward_penalties.token_ids.eos"):
+            resolve_reward_penalty_config(
+                {"penalize_eos_token": True, "token_ids": None},
+                _FakeTokenizer(eos_token_id=2),
+            )
 
-    def test_missing_eos_after_resolution_raises(self):
-        cfg = resolve_reward_penalty_config(
-            {"penalize_eos_token": True}, _FakeTokenizer(eos_token_id=None)
-        )
+    def test_missing_eos_direct_apply_raises(self):
         result = _make_result(
             reward=1.0,
             message_log=[
@@ -451,7 +405,7 @@ class TestPenalizeEosToken:
             ],
         )
         with pytest.raises(ValueError, match="reward_penalties.token_ids.eos"):
-            apply_reward_penalties([result], cfg)
+            apply_reward_penalties([result], {"penalize_eos_token": True})
 
 
 # =====================================================================
@@ -801,7 +755,7 @@ class TestCrossCutting:
             ],
             message_log=[
                 _msg("user", [100]),
-                _msg("assistant", [300, 2]),  # EOS
+                _msg("assistant", [300, 2, 400]),  # EOS internal (not terminal)
             ],
         )
         counts = apply_reward_penalties([result], cfg)
@@ -823,7 +777,7 @@ class TestCrossCutting:
             reward=1.0,
             message_log=[
                 _msg("user", [100]),
-                _msg("assistant", [300, 2]),
+                _msg("assistant", [300, 2, 400]),  # EOS internal (not terminal)
             ],
         )
         counts = apply_reward_penalties([r1, r2], cfg)

--- a/tests/unit/experience/test_reward_penalties.py
+++ b/tests/unit/experience/test_reward_penalties.py
@@ -22,7 +22,6 @@ from nemo_rl.experience.rollouts import (
     resolve_reward_penalty_config,
 )
 
-
 # ---- Helpers to build minimal result dicts ----
 
 
@@ -309,7 +308,8 @@ class TestPenalizeEosToken:
         counts = apply_reward_penalties([result], self.CFG)
         assert result["full_result"]["reward"] == 1.0
 
-    def test_terminal_eos_not_penalized(self):
+    def test_terminal_eos_penalized(self):
+        # A trailing EOS is penalized too — the whole sequence is checked.
         result = _make_result(
             reward=1.0,
             message_log=[
@@ -318,8 +318,8 @@ class TestPenalizeEosToken:
             ],
         )
         counts = apply_reward_penalties([result], self.CFG)
-        assert result["full_result"]["reward"] == 1.0
-        assert counts["eos_token"] == 0
+        assert result["full_result"]["reward"] == 0.0
+        assert counts["eos_token"] == 1
 
     def test_eos_in_user_not_penalized(self):
         result = _make_result(
@@ -344,7 +344,8 @@ class TestPenalizeEosToken:
         counts = apply_reward_penalties([result], cfg)
         assert result["full_result"]["reward"] == 0.0
 
-    def test_multi_turn_terminal_eos_not_penalized(self):
+    def test_multi_turn_terminal_eos_penalized(self):
+        # Trailing EOS in any assistant turn is penalized.
         result = _make_result(
             reward=1.0,
             message_log=[
@@ -355,15 +356,15 @@ class TestPenalizeEosToken:
             ],
         )
         counts = apply_reward_penalties([result], self.CFG)
-        assert result["full_result"]["reward"] == 1.0
-        assert counts["eos_token"] == 0
+        assert result["full_result"]["reward"] == 0.0
+        assert counts["eos_token"] == 1
 
     def test_multi_turn_internal_eos_penalized(self):
         result = _make_result(
             reward=1.0,
             message_log=[
                 _msg("user", [100]),
-                _msg("assistant", [300, 2]),
+                _msg("assistant", [300, 400]),
                 _msg("user", [500]),
                 _msg("assistant", [600, 2, 700]),
             ],

--- a/tests/unit/experience/test_reward_penalties.py
+++ b/tests/unit/experience/test_reward_penalties.py
@@ -334,6 +334,18 @@ class TestPenalizeEosToken:
         counts = apply_reward_penalties([result], self.CFG)
         assert result["full_result"]["reward"] == 1.0
 
+    def test_terminal_eos_not_penalized(self):
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100, 200]),
+                _msg("assistant", [300, 400, 2]),
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 1.0
+        assert counts["eos_token"] == 0
+
     def test_eos_in_user_not_penalized(self):
         result = _make_result(
             reward=1.0,
@@ -357,18 +369,33 @@ class TestPenalizeEosToken:
         counts = apply_reward_penalties([result], cfg)
         assert result["full_result"]["reward"] == 0.0
 
-    def test_multi_turn_eos_in_second_turn(self):
+    def test_multi_turn_terminal_eos_not_penalized(self):
         result = _make_result(
             reward=1.0,
             message_log=[
                 _msg("user", [100]),
-                _msg("assistant", [300, 400]),  # turn 1 ok
+                _msg("assistant", [300, 2]),
                 _msg("user", [500]),
-                _msg("assistant", [600, 2]),  # turn 2 has EOS
+                _msg("assistant", [600, 2]),
+            ],
+        )
+        counts = apply_reward_penalties([result], self.CFG)
+        assert result["full_result"]["reward"] == 1.0
+        assert counts["eos_token"] == 0
+
+    def test_multi_turn_internal_eos_penalized(self):
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100]),
+                _msg("assistant", [300, 2]),
+                _msg("user", [500]),
+                _msg("assistant", [600, 2, 700]),
             ],
         )
         counts = apply_reward_penalties([result], self.CFG)
         assert result["full_result"]["reward"] == 0.0
+        assert counts["eos_token"] == 1
 
     def test_empty_generation_not_penalized(self):
         result = _make_result(
@@ -389,7 +416,7 @@ class TestPenalizeEosToken:
             reward=1.0,
             message_log=[
                 _msg("user", [100]),
-                _msg("assistant", [300, 2]),
+                _msg("assistant", [300, 2, 400]),
             ],
         )
         counts = apply_reward_penalties([result], cfg)
@@ -405,7 +432,7 @@ class TestPenalizeEosToken:
             reward=1.0,
             message_log=[
                 _msg("user", [100]),
-                _msg("assistant", [300, 2]),
+                _msg("assistant", [300, 2, 400]),
             ],
         )
         counts = apply_reward_penalties([result], cfg)

--- a/tests/unit/experience/test_reward_penalties.py
+++ b/tests/unit/experience/test_reward_penalties.py
@@ -278,12 +278,12 @@ class TestPenalizeEmptyFinalAnswer:
 
 
 # =====================================================================
-# Penalty 3: penalize_eos_token
+# Penalty 3: penalize_unwanted_tokens
 # =====================================================================
 
 
-class TestPenalizeEosToken:
-    CFG = {"penalize_eos_token": True, "token_ids": {"eos": 2}}
+class TestPenalizeUnwantedTokens:
+    CFG = {"penalize_unwanted_tokens": True, "token_ids": {"unwanted": [2]}}
 
     def test_eos_in_generation_penalized(self):
         result = _make_result(
@@ -295,7 +295,7 @@ class TestPenalizeEosToken:
         )
         counts = apply_reward_penalties([result], self.CFG)
         assert result["full_result"]["reward"] == 0.0
-        assert counts["eos_token"] == 1
+        assert counts["unwanted_token"] == 1
 
     def test_no_eos_not_penalized(self):
         result = _make_result(
@@ -319,7 +319,7 @@ class TestPenalizeEosToken:
         )
         counts = apply_reward_penalties([result], self.CFG)
         assert result["full_result"]["reward"] == 0.0
-        assert counts["eos_token"] == 1
+        assert counts["unwanted_token"] == 1
 
     def test_eos_in_user_not_penalized(self):
         result = _make_result(
@@ -333,7 +333,7 @@ class TestPenalizeEosToken:
         assert result["full_result"]["reward"] == 1.0
 
     def test_custom_eos_token_id(self):
-        cfg = {"penalize_eos_token": True, "token_ids": {"eos": 99}}
+        cfg = {"penalize_unwanted_tokens": True, "token_ids": {"unwanted": [99]}}
         result = _make_result(
             reward=1.0,
             message_log=[
@@ -343,6 +343,19 @@ class TestPenalizeEosToken:
         )
         counts = apply_reward_penalties([result], cfg)
         assert result["full_result"]["reward"] == 0.0
+
+    def test_multiple_unwanted_token_ids(self):
+        cfg = {"penalize_unwanted_tokens": True, "token_ids": {"unwanted": [98, 99]}}
+        result = _make_result(
+            reward=1.0,
+            message_log=[
+                _msg("user", [100]),
+                _msg("assistant", [300, 99, 400]),
+            ],
+        )
+        counts = apply_reward_penalties([result], cfg)
+        assert result["full_result"]["reward"] == 0.0
+        assert counts["unwanted_token"] == 1
 
     def test_multi_turn_terminal_eos_penalized(self):
         # Trailing EOS in any assistant turn is penalized.
@@ -357,7 +370,7 @@ class TestPenalizeEosToken:
         )
         counts = apply_reward_penalties([result], self.CFG)
         assert result["full_result"]["reward"] == 0.0
-        assert counts["eos_token"] == 1
+        assert counts["unwanted_token"] == 1
 
     def test_multi_turn_internal_eos_penalized(self):
         result = _make_result(
@@ -371,7 +384,7 @@ class TestPenalizeEosToken:
         )
         counts = apply_reward_penalties([result], self.CFG)
         assert result["full_result"]["reward"] == 0.0
-        assert counts["eos_token"] == 1
+        assert counts["unwanted_token"] == 1
 
     def test_empty_generation_not_penalized(self):
         result = _make_result(
@@ -384,20 +397,30 @@ class TestPenalizeEosToken:
         counts = apply_reward_penalties([result], self.CFG)
         assert result["full_result"]["reward"] == 1.0
 
-    def test_eos_token_id_must_be_explicit(self):
-        with pytest.raises(ValueError, match="reward_penalties.token_ids.eos"):
+    def test_unwanted_token_ids_must_be_explicit(self):
+        with pytest.raises(ValueError, match="reward_penalties.token_ids.unwanted"):
             resolve_reward_penalty_config(
-                {"penalize_eos_token": True}, _FakeTokenizer(eos_token_id=2)
+                {"penalize_unwanted_tokens": True}, _FakeTokenizer(eos_token_id=2)
             )
 
-    def test_null_token_ids_requires_explicit_eos(self):
-        with pytest.raises(ValueError, match="reward_penalties.token_ids.eos"):
+    def test_null_token_ids_requires_explicit_unwanted(self):
+        with pytest.raises(ValueError, match="reward_penalties.token_ids.unwanted"):
             resolve_reward_penalty_config(
-                {"penalize_eos_token": True, "token_ids": None},
+                {"penalize_unwanted_tokens": True, "token_ids": None},
                 _FakeTokenizer(eos_token_id=2),
             )
 
-    def test_missing_eos_direct_apply_raises(self):
+    def test_empty_unwanted_list_requires_explicit_unwanted(self):
+        with pytest.raises(ValueError, match="reward_penalties.token_ids.unwanted"):
+            resolve_reward_penalty_config(
+                {
+                    "penalize_unwanted_tokens": True,
+                    "token_ids": {"unwanted": []},
+                },
+                _FakeTokenizer(eos_token_id=2),
+            )
+
+    def test_missing_unwanted_direct_apply_raises(self):
         result = _make_result(
             reward=1.0,
             message_log=[
@@ -405,8 +428,8 @@ class TestPenalizeEosToken:
                 _msg("assistant", [300, 2]),
             ],
         )
-        with pytest.raises(ValueError, match="reward_penalties.token_ids.eos"):
-            apply_reward_penalties([result], {"penalize_eos_token": True})
+        with pytest.raises(ValueError, match="reward_penalties.token_ids.unwanted"):
+            apply_reward_penalties([result], {"penalize_unwanted_tokens": True})
 
 
 # =====================================================================
@@ -738,15 +761,15 @@ class TestCrossCutting:
         assert result["full_result"]["reward"] == 1.0
 
     def test_empty_results_no_crash(self):
-        counts = apply_reward_penalties([], {"penalize_eos_token": True})
+        counts = apply_reward_penalties([], {"penalize_unwanted_tokens": True})
         assert all(v == 0 for v in counts.values())
 
     def test_multiple_penalties_stack(self):
-        """A result that triggers both duplicated reasoning and EOS penalty."""
+        """A result that triggers both duplicated reasoning and unwanted-token penalty."""
         cfg = {
             "penalize_duplicated_reasoning": True,
-            "penalize_eos_token": True,
-            "token_ids": {"eos": 2},
+            "penalize_unwanted_tokens": True,
+            "token_ids": {"unwanted": [2]},
         }
         result = _make_result(
             reward=1.0,
@@ -762,11 +785,11 @@ class TestCrossCutting:
         counts = apply_reward_penalties([result], cfg)
         assert result["full_result"]["reward"] == 0.0
         assert counts["duplicated_reasoning"] == 1
-        assert counts["eos_token"] == 1
+        assert counts["unwanted_token"] == 1
 
     def test_batch_of_results_mixed(self):
         """Two results: first is fine, second has EOS."""
-        cfg = {"penalize_eos_token": True, "token_ids": {"eos": 2}}
+        cfg = {"penalize_unwanted_tokens": True, "token_ids": {"unwanted": [2]}}
         r1 = _make_result(
             reward=1.0,
             message_log=[
@@ -784,7 +807,7 @@ class TestCrossCutting:
         counts = apply_reward_penalties([r1, r2], cfg)
         assert r1["full_result"]["reward"] == 1.0
         assert r2["full_result"]["reward"] == 0.0
-        assert counts["eos_token"] == 1
+        assert counts["unwanted_token"] == 1
 
 
 if __name__ == "__main__":
@@ -793,7 +816,7 @@ if __name__ == "__main__":
     test_classes = [
         TestPenalizeDuplicatedReasoning,
         TestPenalizeEmptyFinalAnswer,
-        TestPenalizeEosToken,
+        TestPenalizeUnwantedTokens,
         TestPenalizeMultiEndThink,
         TestCrossCutting,
     ]

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -58,9 +58,9 @@ reward_penalties:
   penalize_empty_final_answer: false
   penalize_eos_token: false
   penalize_malformed_think_tag: false
-  # Optional model/tokenizer-specific overrides. When null, EOS is inferred
-  # from tokenizer.eos_token_id and think tags are inferred only if each tag
-  # encodes to one token. Example: {eos: 2, think_open: 12, think_close: 13}
+  # Optional model/tokenizer-specific token IDs. eos is required when
+  # penalize_eos_token is true; think tags are inferred only if each tag encodes
+  # to one token. Example: {eos: 2, think_open: 12, think_close: 13}
   token_ids: null
 
 loss_fn:

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -52,6 +52,17 @@ grpo:
     in_flight_weight_updates: false # Set to true to enable in-flight weight updates
     recompute_kv_cache_after_weight_updates: false # Set to true to recompute kv cache after in-flight-weight-updates
 
+# Reward-zeroing penalties applied to NeMo-Gym rollout results.
+reward_penalties:
+  penalize_duplicated_reasoning: false
+  penalize_empty_final_answer: false
+  penalize_eos_token: false
+  penalize_malformed_think_tag: false
+  # Optional model/tokenizer-specific overrides. When null, EOS is inferred
+  # from tokenizer.eos_token_id and think tags are inferred only if each tag
+  # encodes to one token. Example: {eos: 2, think_open: 12, think_close: 13}
+  token_ids: null
+
 loss_fn:
   reference_policy_kl_penalty: 0.01
   # Can be set to k1, k2, k3

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -59,8 +59,8 @@ reward_penalties:
   penalize_unwanted_tokens: false
   penalize_malformed_think_tag: false
   # Optional model/tokenizer-specific token IDs. Add token IDs that should
-  # be penalized when emitted by the model under unwanted, such as a
-  # Think tags are inferred only if each tag encodes
+  # be penalized when emitted by the model. Unwanted token IDs must be
+  # specified explicitly; think-tag IDs are inferred when each tag encodes
   # to one token. Example: {unwanted: [2], think_open: 12, think_close: 13}
   token_ids: null
 

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -56,11 +56,12 @@ grpo:
 reward_penalties:
   penalize_duplicated_reasoning: false
   penalize_empty_final_answer: false
-  penalize_eos_token: false
+  penalize_unwanted_tokens: false
   penalize_malformed_think_tag: false
-  # Optional model/tokenizer-specific token IDs. eos is required when
-  # penalize_eos_token is true; think tags are inferred only if each tag encodes
-  # to one token. Example: {eos: 2, think_open: 12, think_close: 13}
+  # Optional model/tokenizer-specific token IDs. Add token IDs that should
+  # be penalized when emitted by the model under unwanted, such as a
+  # Think tags are inferred only if each tag encodes
+  # to one token. Example: {unwanted: [2], think_open: 12, think_close: 13}
   token_ids: null
 
 loss_fn:

--- a/tests/unit/test_config_validation.py
+++ b/tests/unit/test_config_validation.py
@@ -25,6 +25,8 @@ from nemo_rl.algorithms.distillation import MasterConfig as DistillationMasterCo
 from nemo_rl.algorithms.dpo import MasterConfig as DPOMasterConfig
 from nemo_rl.algorithms.grpo import (
     MasterConfig as GRPOMasterConfig,
+)
+from nemo_rl.algorithms.grpo import (
     RewardPenaltyConfig,
 )
 from nemo_rl.algorithms.ppo import MasterConfig as PPOMasterConfig

--- a/tests/unit/test_config_validation.py
+++ b/tests/unit/test_config_validation.py
@@ -161,23 +161,30 @@ def test_all_config_files_have_required_keys(config_file):
     validate_config_section(config_dict, master_config_class, config_file)
 
 
-def test_reward_penalty_config_requires_explicit_eos_token_id():
-    """EOS penalty requires an explicit token id at config validation time."""
-    with pytest.raises(ValidationError, match="reward_penalties.token_ids.eos"):
-        RewardPenaltyConfig(penalize_eos_token=True)
+def test_reward_penalty_config_requires_explicit_unwanted_token_ids():
+    """Unwanted-token penalty requires explicit unwanted-token config.
 
-    with pytest.raises(ValidationError, match="reward_penalties.token_ids.eos"):
-        RewardPenaltyConfig(penalize_eos_token=True, token_ids=None)
+    Validates that token_ids.unwanted is present whenever penalize_unwanted_tokens
+    is enabled.
+    """
+    with pytest.raises(ValidationError, match="reward_penalties.token_ids.unwanted"):
+        RewardPenaltyConfig(penalize_unwanted_tokens=True)
 
-    with pytest.raises(ValidationError, match="reward_penalties.token_ids.eos"):
-        RewardPenaltyConfig(penalize_eos_token=True, token_ids={})
+    with pytest.raises(ValidationError, match="reward_penalties.token_ids.unwanted"):
+        RewardPenaltyConfig(penalize_unwanted_tokens=True, token_ids=None)
+
+    with pytest.raises(ValidationError, match="reward_penalties.token_ids.unwanted"):
+        RewardPenaltyConfig(penalize_unwanted_tokens=True, token_ids={})
+
+    with pytest.raises(ValidationError, match="reward_penalties.token_ids.unwanted"):
+        RewardPenaltyConfig(penalize_unwanted_tokens=True, token_ids={"unwanted": []})
 
     config = RewardPenaltyConfig(
-        penalize_eos_token=True,
-        token_ids={"eos": 2},
+        penalize_unwanted_tokens=True,
+        token_ids={"unwanted": [2]},
     )
     assert config.token_ids is not None
-    assert config.token_ids.eos == 2
+    assert config.token_ids.unwanted == [2]
 
 
 @pytest.mark.parametrize("config_file", config_files)

--- a/tests/unit/test_config_validation.py
+++ b/tests/unit/test_config_validation.py
@@ -23,7 +23,10 @@ from pydantic import TypeAdapter, ValidationError
 
 from nemo_rl.algorithms.distillation import MasterConfig as DistillationMasterConfig
 from nemo_rl.algorithms.dpo import MasterConfig as DPOMasterConfig
-from nemo_rl.algorithms.grpo import MasterConfig as GRPOMasterConfig
+from nemo_rl.algorithms.grpo import (
+    MasterConfig as GRPOMasterConfig,
+    RewardPenaltyConfig,
+)
 from nemo_rl.algorithms.ppo import MasterConfig as PPOMasterConfig
 from nemo_rl.algorithms.rm import MasterConfig as RMMasterConfig
 from nemo_rl.algorithms.sft import MasterConfig as SFTMasterConfig
@@ -154,6 +157,25 @@ def test_all_config_files_have_required_keys(config_file):
 
     # Validate the entire config using the appropriate MasterConfig
     validate_config_section(config_dict, master_config_class, config_file)
+
+
+def test_reward_penalty_config_requires_explicit_eos_token_id():
+    """EOS penalty requires an explicit token id at config validation time."""
+    with pytest.raises(ValidationError, match="reward_penalties.token_ids.eos"):
+        RewardPenaltyConfig(penalize_eos_token=True)
+
+    with pytest.raises(ValidationError, match="reward_penalties.token_ids.eos"):
+        RewardPenaltyConfig(penalize_eos_token=True, token_ids=None)
+
+    with pytest.raises(ValidationError, match="reward_penalties.token_ids.eos"):
+        RewardPenaltyConfig(penalize_eos_token=True, token_ids={})
+
+    config = RewardPenaltyConfig(
+        penalize_eos_token=True,
+        token_ids={"eos": 2},
+    )
+    assert config.token_ids is not None
+    assert config.token_ids.eos == 2
 
 
 @pytest.mark.parametrize("config_file", config_files)


### PR DESCRIPTION
(cherry picked from commit f57f6adc4798334005d81ec7514e34737ebc62eb)

# What does this PR do ?

Adds optional GRPO reward penalties for malformed or low-quality Gym responses:
- duplicated reasoning/final-answer items
- empty final answers
- unwanted tokens emitted inside assistant output
- malformed thinking tags

The penalty config is modeled as `RewardPenaltyConfig`. Unwanted tokens need to be explicitly specified in the config, and thinking-tag token IDs are inferred only when the configured tags encode to single tokens. Gym thinking tags are threaded from `env.nemo_gym.thinking_tags`, falling back to `DEFAULT_THINKING_TAGS`.

**NOTE 1**: The intention with `penalize_eos_token` was to discourage the model from emitting `</s>` which was the eos token during pretraining (`<|im_end|>` is eos for post-training). We generalized it to `penalize_unwanted_token` to penalize any user-desired tokens specified inside the config.

**NOTE 2**: The last token is **included** while comparing the presence of unwanted tokens.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
