### PR TITLE
docs: fix broken PyTorch CUDA notes links (redirect stub breaks linkcheck)

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,7 +733,7 @@ For detailed instructions on how to set up and launch NeMo RL on Slurm or Kubern
 
 - Large amounts of memory fragmentation might occur when running models without support for FlashAttention2.
   If OOM occurs after a few iterations of training, it may help to tweak the allocator settings to reduce memory fragmentation.
-  To do so, specify [`max_split_size_mb`](https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-alloc-conf)
+  To do so, specify [`max_split_size_mb`](https://docs.pytorch.org/docs/2.12/notes/cuda.html#optimizing-memory-usage-with-pytorch-alloc-conf)
   at **either** one of the following places:
   1. Launch training with:
   ```sh

--- a/docs/about/tips-and-tricks.md
+++ b/docs/about/tips-and-tricks.md
@@ -22,7 +22,7 @@ NRL_FORCE_REBUILD_VENVS=true uv run examples/run_grpo.py ...
 
 ## Memory Fragmentation
 
-Large amounts of memory fragmentation might occur when running models without support for FlashAttention2. If OOM occurs after a few iterations of training, it may help to tweak the allocator settings to reduce memory fragmentation. To do so, specify [`max_split_size_mb`](https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-alloc-conf) at **either** one of the following places:
+Large amounts of memory fragmentation might occur when running models without support for FlashAttention2. If OOM occurs after a few iterations of training, it may help to tweak the allocator settings to reduce memory fragmentation. To do so, specify [`max_split_size_mb`](https://docs.pytorch.org/docs/2.12/notes/cuda.html#optimizing-memory-usage-with-pytorch-alloc-conf) at **either** one of the following places:
 
 1. Launch training with:
 

--- a/docs/broken_links_false_positives.json
+++ b/docs/broken_links_false_positives.json
@@ -5,5 +5,3 @@
 {"uri": "https://huggingface.co/docs/transformers/en/chat_templating_writing"}
 {"uri": "https://huggingface.co/docs/transformers/en/model_doc/auto#transformers.AutoModelForCausalLM"}
 {"uri": "https://huggingface.co/docs/transformers/en/model_doc/auto#transformers.AutoModelForImageTextToText"}
-{"uri": "https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-alloc-conf"}
-{"uri": "https://docs.pytorch.org/docs/stable/notes/cuda.html#reduced-precision-reduction-in-bf16-gemms"}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -119,12 +119,6 @@ linkcheck_ignore = [
     ".*githubusercontent\\.com.*",
 ]
 
-# PyTorch docs anchor IDs change between stable versions; verify the page
-# loads but skip anchor validation to avoid spurious failures on redirects.
-linkcheck_anchors_ignore_for_url = [
-    "https://docs.pytorch.org/.*",
-]
-
 
 def _convert_gh_admonitions_inplace(contents: list[str]) -> None:
     """Mutate contents to convert GitHub blockquote admonitions to MyST.

--- a/docs/guides/dtensor-tp-accuracy.md
+++ b/docs/guides/dtensor-tp-accuracy.md
@@ -233,7 +233,7 @@ Figure 6 reports the KL divergence between the logits produced by the Hugging Fa
 The broader research community has proposed multiple strategies to mitigate these issues. We have referred to a list of publications:
 
 * [Defeating the Training-Inference Mismatch via FP16](https://arxiv.org/pdf/2510.26788)
-* [Accumulator accuracy](https://docs.pytorch.org/docs/stable/notes/cuda.html#reduced-precision-reduction-in-bf16-gemms)
+* [Accumulator accuracy](https://docs.pytorch.org/docs/2.12/notes/cuda.html#reduced-precision-reduction-in-bf16-gemms)
 * [Systematic Outliers in Large Language Models](https://arxiv.org/abs/2502.06415)
 * [Training-Inference Mismatch](https://yingru.notion.site/When-Speed-Kills-Stability-Demystifying-RL-Collapse-from-the-Training-Inference-Mismatch-271211a558b7808d8b12d403fd15edda)
 


### PR DESCRIPTION
## Summary

The `docs/broken_links_needing_review.json` exception in #2248 (and the existing entries in `docs/broken_links_false_positives.json` + `linkcheck_anchors_ignore_for_url` in `docs/conf.py`) all exist to paper over a genuinely broken docs link.

`https://docs.pytorch.org/docs/stable/notes/cuda.html` no longer serves the CUDA-semantics page — it now returns a 1.3 KB JS/meta-refresh **redirect stub** (`<title>Redirecting…</title>`) that points to the versioned `/docs/2.12/...` page. Sphinx `linkcheck` follows only HTTP-level redirects (not JS/meta), so it sees the stub (HTTP 200), then fails **anchor validation** because the stub contains none of the section anchors we reference:

- `#optimizing-memory-usage-with-pytorch-alloc-conf`
- `#reduced-precision-reduction-in-bf16-gemms`

These anchors are linked from `docs/about/tips-and-tricks.md`, `docs/guides/dtensor-tp-accuracy.md`, and `README.md`.

## Plan for this PR

1. **Reproduce (this first commit):** remove the `linkcheck_anchors_ignore_for_url` PyTorch entry and the two PyTorch entries from `broken_links_false_positives.json`, so CI surfaces the real failure.
2. **Fix (follow-up commit):** repoint the 6 links to the non-redirecting, real-content stable page so `linkcheck` validates the anchors directly — no exception entries or anchor-ignore needed.

This is docs-only (`CI:docs`).
