### PR TITLE
fix(test): increase NUM_MINUTES for timing-out tests

### DIFF
--- a/tests/test_suites/llm/grpo-llama3.1-8b-instruct-4n8g-fsdp2tp1-long.v3.sh
+++ b/tests/test_suites/llm/grpo-llama3.1-8b-instruct-4n8g-fsdp2tp1-long.v3.sh
@@ -7,7 +7,7 @@ NUM_NODES=4
 STEPS_PER_RUN=190
 MAX_STEPS=500
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
-NUM_MINUTES=240
+NUM_MINUTES=265
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/performance/grpo-qwen3-30ba3b-4n4g-async-1off.sh
+++ b/tests/test_suites/llm/performance/grpo-qwen3-30ba3b-4n4g-async-1off.sh
@@ -8,7 +8,7 @@ GPUS_PER_NODE=4
 STEPS_PER_RUN=10
 MAX_STEPS=10
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
-NUM_MINUTES=100
+NUM_MINUTES=120
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached


### PR DESCRIPTION
## Summary
- `grpo-qwen3-30ba3b-4n4g-async-1off`: `NUM_MINUTES` 100 → 120 (+20%)
- `grpo-llama3.1-8b-instruct-4n8g-fsdp2tp1-long.v3`: `NUM_MINUTES` 240 → 265 (+10% buffer over observed 192/500 step timeout rate)

## Test plan
- [ ] Verify `llm_performance_grpo_qwen3_30ba3b_4n4g_async_1off` completes within new 120-min budget
- [ ] Verify `llm_grpo_llama3_1_8b_instruct_4n8g_fsdp2tp1_long_v3` advances past step 192 within new 265-min budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)