### PR TITLE
fix: increase NUM_MINUTES for 5 tests hitting Slurm timeouts

### DIFF
--- a/tests/test_suites/llm/grpo-llama3.1-8b-instruct-4n8g-fsdp2tp1-long.v3.sh
+++ b/tests/test_suites/llm/grpo-llama3.1-8b-instruct-4n8g-fsdp2tp1-long.v3.sh
@@ -7,7 +7,7 @@ NUM_NODES=4
 STEPS_PER_RUN=190
 MAX_STEPS=500
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
-NUM_MINUTES=240
+NUM_MINUTES=300
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-nanov3-30BA3B-2n8g-fsdp2-lora.sh
+++ b/tests/test_suites/llm/grpo-nanov3-30BA3B-2n8g-fsdp2-lora.sh
@@ -8,7 +8,7 @@ GPUS_PER_NODE=8
 STEPS_PER_RUN=10
 MAX_STEPS=10
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
-NUM_MINUTES=50
+NUM_MINUTES=70
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/grpo-qwen2.5-32b-32n8g-fsdp2tp8-actckpt.v3.sh
+++ b/tests/test_suites/llm/grpo-qwen2.5-32b-32n8g-fsdp2tp8-actckpt.v3.sh
@@ -7,7 +7,7 @@ NUM_NODES=32
 STEPS_PER_RUN=2  # step_time: [220, 310]
 MAX_STEPS=2
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
-NUM_MINUTES=35
+NUM_MINUTES=60
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/performance/dapo-deepseek-v3-64n8g.v2.sh
+++ b/tests/test_suites/llm/performance/dapo-deepseek-v3-64n8g.v2.sh
@@ -15,7 +15,7 @@ NUM_NODES=64
 STEPS_PER_RUN=10
 MAX_STEPS=10
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
-NUM_MINUTES=240
+NUM_MINUTES=360
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/test_suites/llm/performance/grpo-qwen3-30ba3b-4n4g-async-1off.sh
+++ b/tests/test_suites/llm/performance/grpo-qwen3-30ba3b-4n4g-async-1off.sh
@@ -8,7 +8,7 @@ GPUS_PER_NODE=4
 STEPS_PER_RUN=10
 MAX_STEPS=10
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
-NUM_MINUTES=100
+NUM_MINUTES=200
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached


### PR DESCRIPTION
## Summary

Increases `NUM_MINUTES` for 5 test scripts that were timing out at the Slurm level, based on analysis of CI log timing data.

| Test | Old | New | Basis |
|------|-----|-----|-------|
| `grpo-nanov3-30BA3B-2n8g-fsdp2-lora` | 50 | 70 | ~30 min cold-cache startup + 25 min for 10 steps |
| `grpo-qwen2.5-32b-32n8g-fsdp2tp8-actckpt.v3` | 35 | 60 | 24 min startup + 2 steps × up to 310s each; 35 was still insufficient |
| `grpo-llama3.1-8b-instruct-4n8g-fsdp2tp1-long.v3` | 240 | 300 | Measured 191 steps taking ~248 min with checkpoint overhead; 300 gives ~20% buffer |
| `dapo-deepseek-v3-64n8g.v2` | 240 | 360 | ~10 min setup + 10 large-model steps; 50% headroom over prior limit |
| `grpo-qwen3-30ba3b-4n4g-async-1off` | 100 | 200 | Async replay buffer fill alone consumed 84 of 100 min on the first step |

🤖 Generated with [Claude Code](https://claude.com/claude-code)