### PR TITLE
feat: ThreadSafeTimer, container init timing, and Ray telemetry

### DIFF
--- a/examples/nemo_gym/run_grpo_nemo_gym.py
+++ b/examples/nemo_gym/run_grpo_nemo_gym.py
@@ -15,6 +15,7 @@
 import argparse
 import os
 import pprint
+import time
 
 # Increase the W&B single object size warning threshold. Initially 100_000 (100 KB) -> 10_000_000 (10 MB)
 import wandb.util
@@ -50,7 +51,8 @@ from nemo_rl.utils.config import (
     parse_hydra_overrides,
     register_omegaconf_resolvers,
 )
-from nemo_rl.utils.logger import get_next_experiment_dir
+from nemo_rl.utils.logger import get_next_experiment_dir, log_container_init_timing
+from nemo_rl.utils.timer import Timer
 
 
 def parse_args() -> tuple[argparse.Namespace, list[str]]:
@@ -116,7 +118,10 @@ def collect_trajectories(
 
 def main() -> None:
     """Main entry point."""
-    # Parse arguments
+    main_start = time.perf_counter()
+    log_container_init_timing()
+    rl_init_timer = Timer(context={"worker": "driver"})
+
     register_omegaconf_resolvers()
     args, overrides = parse_args()
 
@@ -126,16 +131,17 @@ def main() -> None:
             "grpo_workplace_assistant_nemotron_nano_v2_9b.yaml",
         )
 
-    config = load_config(args.config)
-    print(f"Loaded configuration from: {args.config}")
+    with rl_init_timer.time("config"):
+        config = load_config(args.config)
+        print(f"Loaded configuration from: {args.config}")
 
-    if overrides:
-        print(f"Overrides: {overrides}")
-        config = parse_hydra_overrides(config, overrides)
+        if overrides:
+            print(f"Overrides: {overrides}")
+            config = parse_hydra_overrides(config, overrides)
 
-    config = OmegaConf.to_container(config, resolve=True)
-    config = MasterConfig(**config)
-    print("Applied CLI overrides")
+        config = OmegaConf.to_container(config, resolve=True)
+        config = MasterConfig(**config)
+        print("Applied CLI overrides")
 
     # Get the next experiment directory with incremented ID
     config.logger["log_dir"] = get_next_experiment_dir(config.logger["log_dir"])
@@ -145,26 +151,27 @@ def main() -> None:
             f"📊 Using checkpoint directory: {config.checkpointing['checkpoint_dir']}"
         )
 
-    # setup tokenizer
-    tokenizer = get_tokenizer(config.policy["tokenizer"])
-    assert config.policy["generation"] is not None, (
-        "A generation config is required for GRPO"
-    )
-    config.policy["generation"] = configure_generation_config(
-        config.policy["generation"], tokenizer
-    )
+    with rl_init_timer.time("tokenizer"):
+        tokenizer = get_tokenizer(config.policy["tokenizer"])
+        assert config.policy["generation"] is not None, (
+            "A generation config is required for GRPO"
+        )
+        config.policy["generation"] = configure_generation_config(
+            config.policy["generation"], tokenizer
+        )
 
-    # NeMo-Gym specific config setup.
-    setup_nemo_gym_config(config, tokenizer)
+        # NeMo-Gym specific config setup.
+        setup_nemo_gym_config(config, tokenizer)
 
     # We assert here since this is right after the final config has been materialized.
     assert _should_use_nemo_gym(config)
 
     # NeMo-Gym environment needs to get dp_openai_server_base_urls from policy_generation, so we don't setup env here.
-    print("\n▶ Setting up data...")
-    train_dataset, val_dataset = setup_response_data(
-        tokenizer, config.data, env_configs=None
-    )
+    with rl_init_timer.time("data"):
+        print("\n▶ Setting up data...")
+        train_dataset, val_dataset = setup_response_data(
+            tokenizer, config.data, env_configs=None
+        )
 
     # Validation dataset config setup.
     if config.grpo["max_val_samples"] is not None:
@@ -187,7 +194,8 @@ The validation set you pass in will directly be used for validation with no addi
     print("Final config:")
     pprint.pprint(config)
 
-    init_ray()
+    with rl_init_timer.time("ray_connect"):
+        init_ray()
 
     # `is_trajectory_collection` is a NeMo-RL-side control-flow knob; pop it
     # before setup() so it is not forwarded into NeMo-Gym's global config (the
@@ -196,21 +204,31 @@ The validation set you pass in will directly be used for validation with no addi
         config.env["nemo_gym"].pop("is_trajectory_collection", False) or False
     )
 
-    (
-        policy,
-        policy_generation,
-        nemo_gym,
-        cluster,
-        dataloader,
-        val_dataloader,
-        loss_fn,
-        logger,
-        checkpointer,
-        grpo_state,
-        master_config,
-        teacher_worker_groups,
-        alias_to_group_alias,
-    ) = setup(config, tokenizer, train_dataset, val_dataset)
+    with rl_init_timer.time("setup"):
+        (
+            policy,
+            policy_generation,
+            nemo_gym,
+            cluster,
+            dataloader,
+            val_dataloader,
+            loss_fn,
+            logger,
+            checkpointer,
+            grpo_state,
+            master_config,
+            teacher_worker_groups,
+            alias_to_group_alias,
+        ) = setup(config, tokenizer, train_dataset, val_dataset)
+
+    rl_init_timer.record("total", time.perf_counter() - main_start)
+    rl_init_metrics = rl_init_timer.get_timing_metrics(reduction_op="sum")
+    print("\n" + "=" * 60)
+    print(" " * 14 + "RL INIT TIMING BREAKDOWN")
+    for label, value in sorted(rl_init_metrics.items()):
+        if isinstance(value, (int, float)):
+            print(f"  {label}: {value:.1f}s")
+    print("=" * 60 + "\n", flush=True)
 
     # NeMo-Gym is spun up inside setup() (overlapped with vLLM model load).
     # Bind task_to_env and val_task_to_env for the nemo_gym env.

--- a/examples/run_grpo.py
+++ b/examples/run_grpo.py
@@ -15,6 +15,7 @@
 import argparse
 import os
 import pprint
+import time
 
 from omegaconf import OmegaConf
 
@@ -28,7 +29,8 @@ from nemo_rl.utils.config import (
     parse_hydra_overrides,
     register_omegaconf_resolvers,
 )
-from nemo_rl.utils.logger import get_next_experiment_dir
+from nemo_rl.utils.logger import get_next_experiment_dir, log_container_init_timing
+from nemo_rl.utils.timer import Timer
 
 
 def _select_trainer(master_config: MasterConfig):
@@ -62,6 +64,11 @@ def parse_args() -> tuple[argparse.Namespace, list[str]]:
 
 def main() -> None:
     """Main entry point."""
+    main_start = time.perf_counter()
+    log_container_init_timing()
+
+    rl_init_timer = Timer(context={"worker": "driver"})
+
     # Parse arguments
     register_omegaconf_resolvers()
     args, overrides = parse_args()
@@ -71,16 +78,17 @@ def main() -> None:
             os.path.dirname(__file__), "configs", "grpo_math_1B.yaml"
         )
 
-    config = load_config(args.config)
-    print(f"Loaded configuration from: {args.config}")
+    with rl_init_timer.time("config"):
+        config = load_config(args.config)
+        print(f"Loaded configuration from: {args.config}")
 
-    if overrides:
-        print(f"Overrides: {overrides}")
-        config = parse_hydra_overrides(config, overrides)
+        if overrides:
+            print(f"Overrides: {overrides}")
+            config = parse_hydra_overrides(config, overrides)
 
-    config = OmegaConf.to_container(config, resolve=True)
-    config = MasterConfig(**config)
-    print("Applied CLI overrides")
+        config = OmegaConf.to_container(config, resolve=True)
+        config = MasterConfig(**config)
+        print("Applied CLI overrides")
 
     # Print config
     print("Final config:")
@@ -94,30 +102,30 @@ def main() -> None:
             f"📊 Using checkpoint directory: {config.checkpointing['checkpoint_dir']}"
         )
 
-    init_ray()
+    with rl_init_timer.time("ray_connect"):
+        init_ray()
 
     # setup tokenizer
-    tokenizer = get_tokenizer(config.policy["tokenizer"])
-    assert config.policy["generation"] is not None, (
-        "A generation config is required for GRPO"
-    )
-    has_refit_draft_weights = bool(config.policy["draft"]["enabled"])
-    megatron_cfg = config.policy.get("megatron_cfg") or {}
-    trains_mtp = bool(megatron_cfg.get("mtp_num_layers"))
-    config.policy["generation"] = configure_generation_config(
-        config.policy["generation"],
-        tokenizer,
-        has_refit_draft_weights=has_refit_draft_weights,
-        trains_mtp=trains_mtp,
-    )
+    with rl_init_timer.time("tokenizer"):
+        tokenizer = get_tokenizer(config.policy["tokenizer"])
+        assert config.policy["generation"] is not None, (
+            "A generation config is required for GRPO"
+        )
+        has_refit_draft_weights = bool(config.policy["draft"]["enabled"])
+        megatron_cfg = config.policy.get("megatron_cfg") or {}
+        trains_mtp = bool(megatron_cfg.get("mtp_num_layers"))
+        config.policy["generation"] = configure_generation_config(
+            config.policy["generation"],
+            tokenizer,
+            has_refit_draft_weights=has_refit_draft_weights,
+            trains_mtp=trains_mtp,
+        )
 
     # setup data
-    (
-        dataset,
-        val_dataset,
-        task_to_env,
-        val_task_to_env,
-    ) = setup_response_data(tokenizer, config.data, config.env)
+    with rl_init_timer.time("data"):
+        dataset, val_dataset, task_to_env, val_task_to_env = setup_response_data(
+            tokenizer, config.data, config.env
+        )
 
     # Pick the policy factory at the launcher level so the legacy trainer
     # stays data-plane-agnostic (architectural invariant — see
@@ -133,27 +141,38 @@ def main() -> None:
     else:
         _policy_factory = None  # setup() defaults to plain Policy
 
-    (
-        policy,
-        policy_generation,
-        _nemo_gym,
-        cluster,
-        dataloader,
-        val_dataloader,
-        loss_fn,
-        logger,
-        checkpointer,
-        grpo_state,
-        master_config,
-        teacher_worker_groups,
-        alias_to_group_alias,
-    ) = setup(
-        config,
-        tokenizer,
-        dataset,
-        val_dataset,
-        policy_factory=_policy_factory,
-    )
+    with rl_init_timer.time("setup"):
+        (
+            policy,
+            policy_generation,
+            _nemo_gym,
+            cluster,
+            dataloader,
+            val_dataloader,
+            loss_fn,
+            logger,
+            checkpointer,
+            grpo_state,
+            master_config,
+            teacher_worker_groups,
+            alias_to_group_alias,
+        ) = setup(
+            config,
+            tokenizer,
+            dataset,
+            val_dataset,
+            policy_factory=_policy_factory,
+        )
+
+    rl_init_timer.record("total", time.perf_counter() - main_start)
+
+    rl_init_metrics = rl_init_timer.get_timing_metrics(reduction_op="sum")
+    print("\n" + "=" * 60)
+    print(" " * 14 + "RL INIT TIMING BREAKDOWN")
+    for label, value in sorted(rl_init_metrics.items()):
+        if isinstance(value, (int, float)):
+            print(f"  {label}: {value:.1f}s")
+    print("=" * 60 + "\n", flush=True)
 
     # Check if async mode is enabled
     if "async_grpo" in config.grpo and config.grpo["async_grpo"]["enabled"]:

--- a/examples/run_grpo_sliding_puzzle.py
+++ b/examples/run_grpo_sliding_puzzle.py
@@ -17,6 +17,7 @@ import itertools
 import os
 import pprint
 import random
+import time
 from typing import Any, Iterator, Mapping
 
 from omegaconf import OmegaConf
@@ -39,7 +40,8 @@ from nemo_rl.utils.config import (
     parse_hydra_overrides,
     register_omegaconf_resolvers,
 )
-from nemo_rl.utils.logger import get_next_experiment_dir
+from nemo_rl.utils.logger import get_next_experiment_dir, log_container_init_timing
+from nemo_rl.utils.timer import Timer
 
 
 def parse_args():
@@ -193,7 +195,10 @@ def setup_puzzle_data(
 
 def main():
     """Main entry point."""
-    # Parse arguments
+    main_start = time.perf_counter()
+    log_container_init_timing()
+    rl_init_timer = Timer(context={"worker": "driver"})
+
     register_omegaconf_resolvers()
     args, overrides = parse_args()
 
@@ -202,16 +207,17 @@ def main():
             os.path.dirname(__file__), "configs", "grpo_sliding_puzzle.yaml"
         )
 
-    config = load_config(args.config)
-    print(f"Loaded configuration from: {args.config}")
+    with rl_init_timer.time("config"):
+        config = load_config(args.config)
+        print(f"Loaded configuration from: {args.config}")
 
-    if overrides:
-        print(f"Overrides: {overrides}")
-        config = parse_hydra_overrides(config, overrides)
+        if overrides:
+            print(f"Overrides: {overrides}")
+            config = parse_hydra_overrides(config, overrides)
 
-    config = OmegaConf.to_container(config, resolve=True)
-    config = MasterConfig(**config)
-    print("Applied CLI overrides")
+        config = OmegaConf.to_container(config, resolve=True)
+        config = MasterConfig(**config)
+        print("Applied CLI overrides")
 
     # Print config
     print("Final config:")
@@ -225,46 +231,57 @@ def main():
             f"📊 Using checkpoint directory: {config.checkpointing['checkpoint_dir']}"
         )
 
-    init_ray()
+    with rl_init_timer.time("ray_connect"):
+        init_ray()
 
     set_seed(config.grpo["seed"])
 
-    # setup tokenizer
-    tokenizer = get_tokenizer(config.policy["tokenizer"])
+    with rl_init_timer.time("tokenizer"):
+        tokenizer = get_tokenizer(config.policy["tokenizer"])
     config.policy["generation"] = configure_generation_config(
         config.policy["generation"], tokenizer
     )
 
-    # setup data & env map
-    ds_length = (
-        config.grpo["num_prompts_per_step"]
-        * config.grpo["num_generations_per_prompt"]
-        * config.grpo["max_num_steps"]
-    )
-    dataset, val_dataset, task_to_env, val_task_to_env = setup_puzzle_data(
-        tokenizer=tokenizer,
-        env_cfg=config.env,
-        task_name="sliding_puzzle_game",
-        length=ds_length,
-        val_length=config.grpo["max_val_samples"],
-        add_system_prompt=config.data["add_system_prompt"],
-    )
+    with rl_init_timer.time("data"):
+        ds_length = (
+            config.grpo["num_prompts_per_step"]
+            * config.grpo["num_generations_per_prompt"]
+            * config.grpo["max_num_steps"]
+        )
+        dataset, val_dataset, task_to_env, val_task_to_env = setup_puzzle_data(
+            tokenizer=tokenizer,
+            env_cfg=config.env,
+            task_name="sliding_puzzle_game",
+            length=ds_length,
+            val_length=config.grpo["max_val_samples"],
+            add_system_prompt=config.data["add_system_prompt"],
+        )
 
-    (
-        policy,
-        policy_generation,
-        _nemo_gym,
-        cluster,
-        dataloader,
-        val_dataloader,
-        loss_fn,
-        logger,
-        checkpointer,
-        grpo_state,
-        master_config,
-        _teacher_worker_groups,
-        _alias_to_group_alias,
-    ) = setup(config, tokenizer, dataset, val_dataset)
+    with rl_init_timer.time("setup"):
+        (
+            policy,
+            policy_generation,
+            _nemo_gym,
+            cluster,
+            dataloader,
+            val_dataloader,
+            loss_fn,
+            logger,
+            checkpointer,
+            grpo_state,
+            master_config,
+            _teacher_worker_groups,
+            _alias_to_group_alias,
+        ) = setup(config, tokenizer, dataset, val_dataset)
+
+    rl_init_timer.record("total", time.perf_counter() - main_start)
+    rl_init_metrics = rl_init_timer.get_timing_metrics(reduction_op="sum")
+    print("\n" + "=" * 60)
+    print(" " * 14 + "RL INIT TIMING BREAKDOWN")
+    for label, value in sorted(rl_init_metrics.items()):
+        if isinstance(value, (int, float)):
+            print(f"  {label}: {value:.1f}s")
+    print("=" * 60 + "\n", flush=True)
 
     grpo_train(
         policy,

--- a/examples/run_vlm_grpo.py
+++ b/examples/run_vlm_grpo.py
@@ -15,6 +15,7 @@
 import argparse
 import os
 import pprint
+import time
 
 from omegaconf import OmegaConf
 
@@ -28,7 +29,8 @@ from nemo_rl.utils.config import (
     parse_hydra_overrides,
     register_omegaconf_resolvers,
 )
-from nemo_rl.utils.logger import get_next_experiment_dir
+from nemo_rl.utils.logger import get_next_experiment_dir, log_container_init_timing
+from nemo_rl.utils.timer import Timer
 
 
 def parse_args() -> tuple[argparse.Namespace, list[str]]:
@@ -44,7 +46,10 @@ def parse_args() -> tuple[argparse.Namespace, list[str]]:
 
 def main() -> None:
     """Main entry point."""
-    # Parse arguments
+    main_start = time.perf_counter()
+    log_container_init_timing()
+    rl_init_timer = Timer(context={"worker": "driver"})
+
     register_omegaconf_resolvers()
     args, overrides = parse_args()
 
@@ -53,16 +58,17 @@ def main() -> None:
             os.path.dirname(__file__), "configs", "vlm_grpo_3B.yaml"
         )
 
-    config = load_config(args.config)
-    print(f"Loaded configuration from: {args.config}")
+    with rl_init_timer.time("config"):
+        config = load_config(args.config)
+        print(f"Loaded configuration from: {args.config}")
 
-    if overrides:
-        print(f"Overrides: {overrides}")
-        config = parse_hydra_overrides(config, overrides)
+        if overrides:
+            print(f"Overrides: {overrides}")
+            config = parse_hydra_overrides(config, overrides)
 
-    config = OmegaConf.to_container(config, resolve=True)
-    config = MasterConfig(**config)
-    print("Applied CLI overrides")
+        config = OmegaConf.to_container(config, resolve=True)
+        config = MasterConfig(**config)
+        print("Applied CLI overrides")
 
     # Print config
     print("Final config:")
@@ -76,10 +82,11 @@ def main() -> None:
             f"📊 Using checkpoint directory: {config.checkpointing['checkpoint_dir']}"
         )
 
-    init_ray()
+    with rl_init_timer.time("ray_connect"):
+        init_ray()
 
-    # init processor
-    processor = get_tokenizer(config.policy["tokenizer"], get_processor=True)
+    with rl_init_timer.time("tokenizer"):
+        processor = get_tokenizer(config.policy["tokenizer"], get_processor=True)
     tokenizer = processor.tokenizer
 
     assert config.policy["generation"] is not None, (
@@ -95,30 +102,36 @@ def main() -> None:
             "VLMs require tokenizer to be initialized before generation, so skip_tokenizer_init must be set to False."
         )
 
-    # setup data
-    # this function is local to this script, and can be extended to other VLM datasets
-    (
-        dataset,
-        val_dataset,
-        task_to_env,
-        val_task_to_env,
-    ) = setup_response_data(processor, config.data, config.env, is_vlm=True)
+    with rl_init_timer.time("data"):
+        dataset, val_dataset, task_to_env, val_task_to_env = setup_response_data(
+            processor, config.data, config.env, is_vlm=True
+        )
 
-    (
-        policy,
-        policy_generation,
-        _nemo_gym,
-        cluster,
-        dataloader,
-        val_dataloader,
-        loss_fn,
-        logger,
-        checkpointer,
-        grpo_state,
-        master_config,
-        _teacher_worker_groups,
-        _alias_to_group_alias,
-    ) = setup(config, tokenizer, dataset, val_dataset, processor=processor)
+    with rl_init_timer.time("setup"):
+        (
+            policy,
+            policy_generation,
+            _nemo_gym,
+            cluster,
+            dataloader,
+            val_dataloader,
+            loss_fn,
+            logger,
+            checkpointer,
+            grpo_state,
+            master_config,
+            _teacher_worker_groups,
+            _alias_to_group_alias,
+        ) = setup(config, tokenizer, dataset, val_dataset, processor=processor)
+
+    rl_init_timer.record("total", time.perf_counter() - main_start)
+    rl_init_metrics = rl_init_timer.get_timing_metrics(reduction_op="sum")
+    print("\n" + "=" * 60)
+    print(" " * 14 + "RL INIT TIMING BREAKDOWN")
+    for label, value in sorted(rl_init_metrics.items()):
+        if isinstance(value, (int, float)):
+            print(f"  {label}: {value:.1f}s")
+    print("=" * 60 + "\n", flush=True)
 
     grpo_train(
         policy,

--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -34,6 +34,7 @@ from nemo_rl.experience.rollouts import (
     run_async_multi_turn_rollout,
 )
 from nemo_rl.models.generation.interfaces import GenerationInterface
+from nemo_rl.utils.timer import ThreadSafeTimer
 
 TokenizerType = PreTrainedTokenizerBase
 
@@ -76,7 +77,6 @@ class AsyncTrajectoryCollector:
             k: _threading.Lock() for k in self.teacher_worker_groups
         }
         self.running = False
-
         self._pg_lock: _threading.Lock = _threading.Lock()
 
         # Event for manual pause/resume control
@@ -118,6 +118,9 @@ class AsyncTrajectoryCollector:
         self._completed_per_target: dict[int, int] = {}
         self._spawning_targets: set[int] = set()
         self._counter_lock: _threading.Lock = _threading.Lock()
+
+        # Timer for efficiency metrics
+        self._efficiency_timer = ThreadSafeTimer(context={"worker": "collector"})
 
     def _calculate_target_weights(self, generation_weight_version: int) -> list[int]:
         """Calculate target weight versions for given generation weight version.
@@ -260,7 +263,8 @@ class AsyncTrajectoryCollector:
                 # Check if refit is in progress and wait
                 if not self._refit_pause_cleared.is_set() and self.running:
                     print("⏸️ Pausing collection for refit...")
-                    self._refit_pause_cleared.wait()
+                    with self._efficiency_timer.time("idle/refit_event_wait"):
+                        self._refit_pause_cleared.wait()
                     print("▶️ Refit completed, resuming collection")
 
                 # Check if generation limits require pausing collection
@@ -283,7 +287,8 @@ class AsyncTrajectoryCollector:
                         self._generation_limit_cleared.clear()  # Clear the event to pause
 
                     # Efficiently wait for generation limits to be cleared (no polling!)
-                    self._generation_limit_cleared.wait()
+                    with self._efficiency_timer.time("idle/generation_limit_pause"):
+                        self._generation_limit_cleared.wait()
 
                     # Double-check we're still running after being woken up
                     if not self.running:
@@ -293,7 +298,6 @@ class AsyncTrajectoryCollector:
                     break
 
                 self._process_batch(batch)
-
         except Exception as e:
             print(f"❌ Error in trajectory collection: {e}")
             import traceback
@@ -369,7 +373,8 @@ class AsyncTrajectoryCollector:
                         print(
                             "   Note: With vLLM V1 async engine, active threads can complete during weight update"
                         )
-                        self._refit_pause_cleared.wait()
+                        with self._efficiency_timer.time("idle/refit_event_wait"):
+                            self._refit_pause_cleared.wait()
 
                         # After refit finishes if weight version has updated, reflect that in the new trajectories
                         generation_weight_version = self.current_weight_version
@@ -565,6 +570,13 @@ class AsyncTrajectoryCollector:
             return self.dataloader.state_dict()
         return {}
 
+    def get_efficiency_metrics(self) -> dict[str, float]:
+        """Return accumulated efficiency metrics (sum of durations per category).
+
+        Called by the driver process each step to merge collector-side metrics.
+        """
+        return self._efficiency_timer.get_timing_metrics(reduction_op="sum")
+
     def _cleanup_finished_threads(self) -> None:
         with self._threads_lock:
             finished = {t for t in self._inflight_threads if not t.is_alive()}
@@ -722,6 +734,7 @@ class AsyncTrajectoryCollector:
         target_weight_version: int,
         prompt_idx: int,
     ) -> None:
+        worker_start = time.perf_counter()
         try:
             # Import here to avoid circular dependency
             from nemo_rl.algorithms.grpo import _should_use_nemo_gym
@@ -801,6 +814,7 @@ class AsyncTrajectoryCollector:
             # Use exponential backoff when buffer is full
             try:
                 backoff_delay = 0.01
+                backoff_start = None
                 while self.running:
                     status = ray.get(
                         self.replay_buffer.add.remote(
@@ -821,6 +835,11 @@ class AsyncTrajectoryCollector:
                             spawned_count = self._spawned_per_target.get(
                                 target_weight_version, 0
                             )
+                        if backoff_start is not None:
+                            self._efficiency_timer.record(
+                                "idle/buffer_full_backoff",
+                                time.perf_counter() - backoff_start,
+                            )
                         print(
                             f"📦 Buffered per-prompt group (prompt_idx {prompt_idx}, "
                             f"target_weight {target_weight_version}) "
@@ -828,6 +847,8 @@ class AsyncTrajectoryCollector:
                         )
                         break
                     elif status == "full":
+                        if backoff_start is None:
+                            backoff_start = time.perf_counter()
                         # Exponential backoff up to 0.5 second
                         time.sleep(min(backoff_delay, 0.5))
                         backoff_delay *= 1.5
@@ -836,11 +857,19 @@ class AsyncTrajectoryCollector:
                         time.sleep(0.01)
             except Exception as e:
                 print(f"❌ Failed to enqueue per-prompt group to buffer: {e}")
+                if backoff_start is not None:
+                    self._efficiency_timer.record(
+                        "idle/buffer_full_backoff",
+                        time.perf_counter() - backoff_start,
+                    )
                 import traceback
 
                 traceback.print_exc()
         except Exception as e:
             print(f"❌ Error in prompt group worker: {e}")
+            self._efficiency_timer.record(
+                "wasted/failed_trajectory", time.perf_counter() - worker_start
+            )
             import traceback
 
             traceback.print_exc()

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import gc
+import json
 import os
 import time
 import warnings
@@ -54,6 +55,7 @@ from nemo_rl.algorithms.utils import (
     calculate_baseline_and_std_per_prompt,
     get_gdpo_reward_component_keys,
     log_generation_metrics_to_wandb,
+    print_efficiency_summary,
     print_performance_metrics,
     set_seed,
 )
@@ -1859,6 +1861,33 @@ def _should_log_nemo_gym_responses(master_config: MasterConfig) -> bool:
     return should_log_nemo_gym_responses
 
 
+def _write_latest_checkpoint_status(
+    checkpointer: CheckpointManager, last_checkpoint_step: int
+) -> None:
+    """Write a lightweight, top-level ``latest_checkpoint_status.json`` for monitoring.
+
+    Records the wall-clock time and step of the most recent successful checkpoint
+    save so an out-of-band watchdog can poll checkpoint progress on long runs.
+
+    Intentionally distinct from ``CheckpointManager``'s per-step
+    ``step_{N}/training_info.json`` (the resume state): different schema, written
+    at the checkpoint-dir root. There is no in-repo consumer yet. The read is
+    deliberately unguarded so a corrupt file surfaces loudly (signalling
+    corruption) instead of being silently masked.
+    """
+    status_path = os.path.join(
+        str(checkpointer.checkpoint_dir), "latest_checkpoint_status.json"
+    )
+    status: dict[str, Any] = {}
+    if os.path.exists(status_path):
+        with open(status_path) as f:
+            status = json.load(f)
+    status["last_successful_ckpt_save_completion"] = time.time()
+    status["last_checkpoint_step"] = last_checkpoint_step
+    with open(status_path, "w") as f:
+        json.dump(status, f)
+
+
 def _get_effort_config(master_config: MasterConfig) -> Optional[EffortLevelsConfig]:
     """Return the effort-levels reward-shaping config from env.nemo_gym, if set."""
     if "nemo_gym" not in master_config.env:
@@ -2264,7 +2293,7 @@ def grpo_train(
     master_config: MasterConfig,
 ) -> None:
     """Run GRPO training algorithm."""
-    timer = Timer()
+    timer = Timer(context={"worker": "driver"})
     timeout = TimeoutChecker(
         timeout=master_config.checkpointing["checkpoint_must_save_by"],
         fit_last_save_time=True,
@@ -3089,6 +3118,13 @@ def grpo_train(
                             )
                         checkpointer.finalize_checkpoint(checkpoint_path)
 
+                        # Record last-successful-checkpoint time/step for external
+                        # monitoring (parity with async_grpo_train; see
+                        # _write_latest_checkpoint_status).
+                        _write_latest_checkpoint_status(
+                            checkpointer, last_checkpoint_step=total_steps + 1
+                        )
+
             # Logging
             # Log training data
             memory_tracker.snapshot_start_of_stage("Logging", dir())
@@ -3276,7 +3312,7 @@ def validate(
         print("  ⚠️ No validation dataloader provided, skipping validation", flush=True)
         return {}, {}
 
-    timer = Timer()
+    timer = Timer(context={"worker": "validator"})
     with timer.time("total_validation_time"):
         print(f"▶ Starting validation at step {step}...", flush=True)
 
@@ -3515,7 +3551,8 @@ def async_grpo_train(
     # Import async utilities only when needed
     from nemo_rl.algorithms.async_utils import AsyncTrajectoryCollector, ReplayBuffer
 
-    timer = Timer()
+    timer = Timer(context={"worker": "driver"})
+    training_wall_start = time.perf_counter()
     timeout = TimeoutChecker(
         timeout=master_config.checkpointing["checkpoint_must_save_by"],
         fit_last_save_time=True,
@@ -3737,6 +3774,7 @@ def async_grpo_train(
     print(
         f"⏳ Waiting for replay buffer to have sufficient trajectories for step {step}..."
     )
+    timer.start("init/total")
     wait_iterations = 0
     while True:
         buffer_size_current = ray.get(replay_buffer.size.remote())
@@ -3768,6 +3806,7 @@ def async_grpo_train(
         wait_iterations += 1
         time.sleep(1.0)
 
+    timer.stop("init/total")
     print(f"✅ Buffer ready for step {step}! Starting training loop...")
 
     # Main training loop
@@ -3823,8 +3862,8 @@ def async_grpo_train(
                             print(
                                 f"   Trajectory versions in buffer: {buffer_debug['trajectory_versions']}"
                             )
-
-                        time.sleep(0.5)
+                        with timer.time("idle/buffer_starvation"):
+                            time.sleep(0.5)
                         continue
 
                     # Extract trajectories and metadata from sample result
@@ -4097,6 +4136,8 @@ def async_grpo_train(
                 print("🔄 Synchronizing policy weights to trajectory collector…")
                 generation_logger_metrics = None
                 if NEED_REFIT:
+                    timer.start("idle/refit_bubble")
+
                     # Measure pending-generation wait as exposed_generation time
                     print("🔄 Coordinating with trajectory collector before refit...")
                     with timer.time("exposed_generation"):
@@ -4124,6 +4165,8 @@ def async_grpo_train(
                         trajectory_collector.set_weight_version.remote(weight_version)
                         trajectory_collector.resume_after_refit.remote()
 
+                    timer.stop("idle/refit_bubble")
+
                 # Clear logger metrics after each refit (weight sync), starting a new logging cycle
                 if policy_generation is not None:
                     policy_generation.clear_logger_metrics()
@@ -4136,39 +4179,40 @@ def async_grpo_train(
                 if (val_period > 0 and (step + 1) % val_period == 0) or (
                     val_at_end and is_last_step
                 ):
-                    # Pause trajectory collection during validation to reduce memory pressure
-                    trajectory_collector.pause.remote()
+                    with timer.time("idle/validation"):
+                        # Pause trajectory collection during validation to reduce memory pressure
+                        trajectory_collector.pause.remote()
 
-                    if NEED_REFIT and POLICY_GENERATION_STALE:
-                        refit_policy_generation(
-                            policy, policy_generation, colocated_inference
+                        if NEED_REFIT and POLICY_GENERATION_STALE:
+                            refit_policy_generation(
+                                policy, policy_generation, colocated_inference
+                            )
+                            POLICY_GENERATION_STALE = False
+                        else:
+                            policy_generation.prepare_for_generation()
+                        val_metrics, validation_timings = validate(
+                            policy_generation,
+                            val_dataloader,
+                            tokenizer,
+                            val_task_to_env,
+                            step=step + 1,
+                            master_config=master_config,
+                            logger=logger,
                         )
-                        POLICY_GENERATION_STALE = False
-                    else:
-                        policy_generation.prepare_for_generation()
-                    val_metrics, validation_timings = validate(
-                        policy_generation,
-                        val_dataloader,
-                        tokenizer,
-                        val_task_to_env,
-                        step=step + 1,
-                        master_config=master_config,
-                        logger=logger,
-                    )
-                    policy_generation.finish_generation()
-                    logger.log_metrics(
-                        validation_timings, step + 1, prefix="timing/validation"
-                    )
-                    logger.log_metrics(val_metrics, step + 1, prefix="validation")
+                        policy_generation.finish_generation()
+                        logger.log_metrics(
+                            validation_timings, step + 1, prefix="timing/validation"
+                        )
+                        logger.log_metrics(val_metrics, step + 1, prefix="validation")
 
-                    # Explicit GPU memory cleanup after validation in async mode
-                    import gc
+                        # Explicit GPU memory cleanup after validation in async mode
+                        import gc
 
-                    gc.collect()
-                    torch.cuda.empty_cache()
+                        gc.collect()
+                        torch.cuda.empty_cache()
 
-                    # Resume trajectory collection after validation
-                    trajectory_collector.resume.remote()
+                        # Resume trajectory collection after validation
+                        trajectory_collector.resume.remote()
                 # Get flat advantages and token mask for masked metrics computation
                 flat_advantages = train_data["advantages"]
                 flat_token_mask = flat_messages["token_loss_mask"]
@@ -4329,6 +4373,12 @@ def async_grpo_train(
                         )
                         checkpointer.finalize_checkpoint(checkpoint_path)
 
+                        # Record last-successful-checkpoint time/step for external
+                        # monitoring (see _write_latest_checkpoint_status).
+                        _write_latest_checkpoint_status(
+                            checkpointer, last_checkpoint_step=step + 1
+                        )
+
             # Logging
             # Log training data (match sync GRPO logging payload for parity).
             # NeMo Gym responses can be very large and expensive to log; when
@@ -4428,8 +4478,31 @@ def async_grpo_train(
                 train_results, metrics, timing_metrics, master_config
             )
 
+            collector_efficiency = ray.get(
+                trajectory_collector.get_efficiency_metrics.remote()
+            )
+            driver_efficiency = {
+                cat: timer.reduce(cat, "sum")
+                for cat in [
+                    "init/total",
+                    "idle/buffer_starvation",
+                    "idle/refit_bubble",
+                    "idle/validation",
+                ]
+                if cat in timer._timers
+            }
+            merged_efficiency = {**driver_efficiency}
+            for cat, dur in collector_efficiency.items():
+                merged_efficiency[cat] = merged_efficiency.get(cat, 0.0) + dur
+
+            total_wall_time = time.perf_counter() - training_wall_start
+            efficiency_loggable = print_efficiency_summary(
+                merged_efficiency, total_wall_time, step + 1
+            )
+
             logger.log_metrics(performance_metrics, step + 1, prefix="performance")
             logger.log_metrics(metrics, step + 1, prefix="train")
+            logger.log_metrics(efficiency_loggable, step + 1, prefix="")
             # step_finished=True here since this is the final log of our current step.
             logger.log_metrics(
                 timing_metrics,

--- a/nemo_rl/algorithms/utils.py
+++ b/nemo_rl/algorithms/utils.py
@@ -930,3 +930,95 @@ def log_generation_metrics_to_wandb(
             name=generation_metric,
             timeline_interval=timeline_interval,
         )
+
+
+WALL_CLOCK_EFFICIENCY_CATEGORIES = [
+    "init/total",
+    "idle/buffer_starvation",
+    "idle/refit_bubble",
+    "idle/validation",
+]
+
+THREAD_ACCUMULATED_EFFICIENCY_CATEGORIES = [
+    "idle/buffer_full_backoff",
+    "idle/generation_limit_pause",
+    "idle/refit_event_wait",
+    "wasted/failed_trajectory",
+]
+
+EFFICIENCY_CATEGORIES = (
+    WALL_CLOCK_EFFICIENCY_CATEGORIES + THREAD_ACCUMULATED_EFFICIENCY_CATEGORIES
+)
+
+
+def print_efficiency_summary(
+    efficiency_metrics: dict[str, float],
+    total_wall_time_s: float,
+    step: int,
+) -> dict[str, float]:
+    """Print a summary table of efficiency metrics and return loggable dict.
+
+    Wall-clock categories (driver-side idle) are used for the efficiency
+    percentage.  Collector-side categories are summed across concurrent
+    threads and reported separately as thread-seconds so they are not
+    compared directly against a single wall-clock denominator.
+
+    Args:
+        efficiency_metrics: Dict mapping category labels to total seconds spent.
+        total_wall_time_s: Total wall-clock time in seconds since training began.
+        step: Current training step number.
+
+    Returns:
+        Dict of metrics suitable for logging to WandB/TensorBoard, including
+        per-category seconds and percentages, total waste, and efficiency_pct.
+    """
+    print(f"\n📊 Efficiency Summary (Step {step}):")
+    print(f"  {'Category':<35} {'Time (s)':>10} {'% of Wall':>10}")
+    print(f"  {'─' * 57}")
+
+    loggable: dict[str, float] = {}
+
+    for category in WALL_CLOCK_EFFICIENCY_CATEGORIES:
+        duration = efficiency_metrics.get(category, 0.0)
+        pct = (duration / total_wall_time_s * 100) if total_wall_time_s > 0 else 0.0
+        print(f"  {category:<35} {duration:>10.2f} {pct:>9.2f}%")
+        loggable[f"efficiency/{category}_s"] = duration
+        loggable[f"efficiency/{category}_pct"] = pct
+
+    thread_seconds_total = 0.0
+    for category in THREAD_ACCUMULATED_EFFICIENCY_CATEGORIES:
+        duration = efficiency_metrics.get(category, 0.0)
+        thread_seconds_total += duration
+        print(f"  {category + ' (thread-s)':<35} {duration:>10.2f} {'n/a':>10}")
+        loggable[f"efficiency/{category}_s"] = duration
+
+    wall_waste = sum(
+        efficiency_metrics.get(cat, 0.0) for cat in WALL_CLOCK_EFFICIENCY_CATEGORIES
+    )
+    if total_wall_time_s > 0 and wall_waste > total_wall_time_s:
+        wall_waste = total_wall_time_s
+
+    productive = max(0.0, total_wall_time_s - wall_waste)
+    efficiency_pct = (
+        (productive / total_wall_time_s * 100) if total_wall_time_s > 0 else 100.0
+    )
+    efficiency_pct = min(100.0, max(0.0, efficiency_pct))
+    waste_pct = (wall_waste / total_wall_time_s * 100) if total_wall_time_s > 0 else 0.0
+    waste_pct = min(100.0, max(0.0, waste_pct))
+
+    print(f"  {'─' * 57}")
+    print(
+        f"  {'Collector thread-seconds (info)':<35} "
+        f"{thread_seconds_total:>10.2f} {'n/a':>10}"
+    )
+    print(f"  {'Wall-clock waste':<35} {wall_waste:>10.2f} {waste_pct:>9.2f}%")
+    print(f"  {'Productive time':<35} {productive:>10.2f} {efficiency_pct:>9.2f}%")
+    print(f"  {'Efficiency':<35} {'':>10} {efficiency_pct:>9.2f}%")
+
+    loggable["efficiency/thread_seconds_total_s"] = thread_seconds_total
+    loggable["efficiency/total_waste_s"] = wall_waste
+    loggable["efficiency/productive_time_s"] = productive
+    loggable["efficiency/efficiency_pct"] = efficiency_pct
+    loggable["efficiency/total_wall_time_s"] = total_wall_time_s
+
+    return loggable

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -94,6 +94,7 @@ from nemo_rl.utils.native_checkpoint import (
 )
 from nemo_rl.utils.nsys import wrap_with_nvtx_name
 from nemo_rl.utils.packed_tensor import packed_broadcast_producer
+from nemo_rl.utils.timer import Timer
 
 
 def _attach_context_parallel_hooks(model: nn.Module) -> None:
@@ -233,6 +234,7 @@ class DTensorPolicyWorkerImpl(
         # torch distributed init. Envars for rank, world_size, and master_addr and master_port are set from the ray remote call
         torch.distributed.init_process_group(backend="nccl")
         self.rank = torch.distributed.get_rank()
+        self.timer = Timer(context={"worker": "dtensor_policy", "rank": self.rank})
         world_size = torch.distributed.get_world_size()
         model_name = self.cfg["model_name"]
 
@@ -579,6 +581,7 @@ class DTensorPolicyWorkerImpl(
         check_dim_skip_keys: Optional[Iterable[str]] = None,
     ) -> dict[str, Any]:
         """Train the policy on a batch of data with a given loss function."""
+        self.timer.start("train")
         if gbs is None:
             gbs = self.cfg["train_global_batch_size"]
         if mbs is None:
@@ -981,6 +984,7 @@ class DTensorPolicyWorkerImpl(
                 "all_mb_metrics": dict(mb_metrics),
             }
 
+            self.timer.stop("train")
             return metrics
 
     # TODO @Rayen Tian: Related Issue: Refactor shared logic between score() and get_logprobs() (https://github.com/NVIDIA-NeMo/RL/issues/1094)
@@ -1000,6 +1004,7 @@ class DTensorPolicyWorkerImpl(
           We use the convention that the logprob of the first token is 0 so that the sequence length is maintained.
           The logprob of input token i is specified at position i in the output logprobs tensor.
         """
+        self.timer.start("get_logprobs")
         logprob_batch_size = (
             micro_batch_size
             if micro_batch_size is not None
@@ -1302,6 +1307,7 @@ class DTensorPolicyWorkerImpl(
             )
 
         return_data["logprobs"] = token_logprobs.cpu()
+        self.timer.stop("get_logprobs")
         return return_data
 
     # TODO @Rayen Tian: Related Issue: Refactor shared logic between score() and get_logprobs() (https://github.com/NVIDIA-NeMo/RL/issues/1094)
@@ -1449,6 +1455,7 @@ class DTensorPolicyWorkerImpl(
         - Supports context parallelism with proper CP gather.
         - Otherwise, computes local top-k on full-vocab tensor.
         """
+        self.timer.start("get_topk_logits")
         topk_batch_size = (
             micro_batch_size
             if micro_batch_size is not None
@@ -1728,6 +1735,7 @@ class DTensorPolicyWorkerImpl(
             if len(all_topk_idx_padded) > 1
             else all_topk_idx_padded[0]
         ).cpu()
+        self.timer.stop("get_topk_logits")
         return ret
 
     @contextmanager
@@ -1739,6 +1747,7 @@ class DTensorPolicyWorkerImpl(
                   is different from the current policy, making filtered logprobs incompatible.
         On exit: Restores original references and re-flips cuda/cpu, restores sampling_params.
         """
+        self.timer.start("use_reference_model")
         with torch.no_grad():
             # Save train model state_dict
             curr_state_dict = get_cpu_state_dict(
@@ -1776,6 +1785,7 @@ class DTensorPolicyWorkerImpl(
             for k, v in self.model.state_dict().items():
                 val = to_local_if_dtensor(v)
                 val.copy_(curr_state_dict[k])
+            self.timer.stop("use_reference_model")
 
     def _add_noise_to_weights(self) -> None:
         """Add small Gaussian noise to the weights of the model. Note that this is used for testing purposes only."""
@@ -1945,17 +1955,20 @@ class DTensorPolicyWorkerImpl(
     @wrap_with_nvtx_name("dtensor_policy_worker/offload_before_refit")
     def offload_before_refit(self) -> None:
         """Offload the optimizer to the CPU."""
+        self.timer.start("offload_before_refit")
         torch.randn(1).cuda()  # wake up torch allocator
         if self.optimizer is not None:
             self.move_optimizer_to_device("cpu")
 
         gc.collect()
         torch.cuda.empty_cache()
+        self.timer.stop("offload_before_refit")
 
     @torch.no_grad()
     @wrap_with_nvtx_name("dtensor_policy_worker/offload_after_refit")
     def offload_after_refit(self) -> None:
         """Offload as much as possible on the CPU."""
+        self.timer.start("offload_after_refit")
         self.model = self.move_to_cpu(self.model)
         self.model.eval()
         torch.randn(1).cuda()  # wake up torch allocator
@@ -1967,6 +1980,7 @@ class DTensorPolicyWorkerImpl(
         print(
             f"GPU Memory after optimizer offload: {allocated:.2f}GB allocated, {reserved:.2f}GB reserved"
         )
+        self.timer.stop("offload_after_refit")
 
     def move_optimizer_to_device(self, device: str | torch.device) -> None:
         for state in self.optimizer.state.values():
@@ -2009,6 +2023,7 @@ class DTensorPolicyWorkerImpl(
 
         the optimizer states are saved only if `optimizer` and `optimizer_path` are provided.
         """
+        self.timer.start("save_checkpoint")
         save_checkpoint(
             model=self.model,
             weights_path=weights_path,
@@ -2018,6 +2033,7 @@ class DTensorPolicyWorkerImpl(
             tokenizer=self.tokenizer if tokenizer_path else None,
             tokenizer_path=tokenizer_path,
         )
+        self.timer.stop("save_checkpoint")
 
     def load_checkpoint(
         self, weights_path: str, optimizer_path: Optional[str] = None

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -79,6 +79,7 @@ from nemo_rl.utils.checkpoint import CheckpointingConfig
 from nemo_rl.utils.grad_norm import warn_if_inf_grad_norm
 from nemo_rl.utils.nsys import wrap_with_nvtx_name
 from nemo_rl.utils.packed_tensor import packed_broadcast_producer
+from nemo_rl.utils.timer import Timer
 
 
 def dtensor_params_generator(
@@ -281,6 +282,7 @@ class DTensorPolicyWorkerV2Impl(
         )
         # Set instance attributes from distributed context
         self.rank = torch.distributed.get_rank()
+        self.timer = Timer(context={"worker": "dtensor_policy_v2", "rank": self.rank})
         self.device_mesh = distributed_context.device_mesh
         self.dp_cp_mesh = self.device_mesh["dp_cp"]
         self.dp_mesh = self.device_mesh["dp"]
@@ -389,6 +391,7 @@ class DTensorPolicyWorkerV2Impl(
         check_dim_skip_keys: Optional[Iterable[str]] = None,
     ) -> dict[str, Any]:
         """Train the policy on a batch of data with a given loss function."""
+        self.timer.start("train")
         if gbs is None:
             gbs = self.cfg["train_global_batch_size"]
         if mbs is None:
@@ -562,6 +565,7 @@ class DTensorPolicyWorkerV2Impl(
                 dtype=self.dtype,
             )
 
+            self.timer.stop("train")
             return metrics
 
     @wrap_with_nvtx_name("dtensor_policy_worker_v2/get_logprobs")
@@ -580,6 +584,7 @@ class DTensorPolicyWorkerV2Impl(
           We use the convention that the logprob of the first token is 0 so that the sequence length is maintained.
           The logprob of input token i is specified at position i in the output logprobs tensor.
         """
+        self.timer.start("get_logprobs")
         logprob_batch_size = (
             micro_batch_size
             if micro_batch_size is not None
@@ -656,6 +661,7 @@ class DTensorPolicyWorkerV2Impl(
             all_log_probs_padded.append(lp)
         return_data["logprobs"] = torch.cat(all_log_probs_padded, dim=0).cpu()
 
+        self.timer.stop("get_logprobs")
         return return_data
 
     @wrap_with_nvtx_name("dtensor_policy_worker_v2/score")

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -97,6 +97,7 @@ from nemo_rl.utils.nsys import wrap_with_nvtx_name
 from nemo_rl.utils.nvml import log_gpu_memory_diagnostics
 from nemo_rl.utils.packed_tensor import packed_broadcast_producer
 from nemo_rl.utils.r3_trace import maybe_r3_trace_stage
+from nemo_rl.utils.timer import Timer
 
 TokenizerType = TypeVar("TokenizerType", bound=PreTrainedTokenizerBase)
 
@@ -282,6 +283,7 @@ class MegatronPolicyWorkerImpl(
 
         # Set rank for non-collocated to check which ranks to broadcast from
         self.rank = get_rank_safe()
+        self.timer = Timer(context={"worker": "megatron_policy", "rank": self.rank})
 
         # Step 1: Setup distributed
         setup_distributed()
@@ -544,6 +546,7 @@ class MegatronPolicyWorkerImpl(
             "check_dim_skip_keys is only supported by the v2 DTensor worker; "
             "Megatron does not run cross-tokenizer distillation."
         )
+        self.timer.start("train")
         # Note: zero_grad_buffer is called at the start of each global batch iteration
         # in the loop below, so we don't need to call it here.
         if hasattr(self.model, "inference_params"):
@@ -827,6 +830,7 @@ class MegatronPolicyWorkerImpl(
         # Collect MTP metrics (kept out of train()'s body so cloudpickle does not
         # pull an unpicklable torch ConfigModuleInstance into the worker actor).
         self._collect_mtp_metrics(metrics)
+        self.timer.stop("train")
         return metrics
 
     def _compute_moe_grad_scale(self, global_valid_toks):
@@ -1373,6 +1377,7 @@ class MegatronPolicyWorkerImpl(
           We use the convention that the logprob of the first token is 0 so that the sequence length is maintained.
           The logprob of input token i is specified at position i in the output logprobs tensor.
         """
+        self.timer.start("get_logprobs")
         no_grad = torch.no_grad()
         no_grad.__enter__()
         logprob_batch_size = (
@@ -1447,6 +1452,7 @@ class MegatronPolicyWorkerImpl(
         logprobs = broadcast_tensors_from_last_stage(tensors)["logprobs"]
 
         no_grad.__exit__(None, None, None)
+        self.timer.stop("get_logprobs")
         return BatchedDataDict[LogprobOutputSpec](logprobs=logprobs).to("cpu")
 
     def _apply_state_dict_to_model(

--- a/nemo_rl/utils/logger.py
+++ b/nemo_rl/utils/logger.py
@@ -1616,3 +1616,43 @@ def get_next_experiment_dir(base_log_dir: str) -> str:
     os.makedirs(new_log_dir, exist_ok=True)
 
     return new_log_dir
+
+
+def log_container_init_timing() -> None:
+    """Log pre-Python container timing from environment variables.
+
+    Reads epoch timestamps set by the launch script (ray.sub) and prints
+    the Container Init breakdown.  Missing variables are silently skipped
+    so this is safe to call in any environment.
+    """
+    now = time.time()
+    slurm_start = os.environ.get("SLURM_JOB_START_TIME")
+    job_start = os.environ.get("NRL_JOB_START_EPOCH")
+    ray_ready = os.environ.get("NRL_RAY_READY_EPOCH")
+
+    if not job_start:
+        logging.warning(
+            "Cannot detect container startup time: NRL_JOB_START_EPOCH not set. "
+            "Ensure the launch script exports this variable for init timing."
+        )
+        return
+
+    job_start_f = float(job_start)
+    total = now - job_start_f
+
+    print("\n" + "=" * 60)
+    print(" " * 14 + "CONTAINER INIT TIMING")
+
+    if slurm_start:
+        prologue = job_start_f - float(slurm_start)
+        print(f"  slurm_prologue: {prologue:.1f}s")
+        total = now - float(slurm_start)
+
+    if ray_ready:
+        ray_ready_f = float(ray_ready)
+        cluster = ray_ready_f - job_start_f
+        driver_startup = now - ray_ready_f
+        print(f"  cluster_startup (orchestrator+container+ray): {cluster:.1f}s")
+        print(f"  driver_startup (launch+python+imports): {driver_startup:.1f}s")
+    print(f"  total: {total:.1f}s")
+    print("=" * 60 + "\n", flush=True)

--- a/nemo_rl/utils/timer.py
+++ b/nemo_rl/utils/timer.py
@@ -11,12 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import datetime
+import logging
 import sys
+import threading
 import time
 from contextlib import contextmanager
 from typing import Callable, Generator, Optional, Sequence, Union
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 
 class Timer:
@@ -68,21 +73,44 @@ class Timer:
         "count": len,
     }
 
-    def __init__(self) -> None:
-        # Dictionary mapping labels to lists of elapsed times
-        # We store a list of times for each label rather than a single value
-        # to support multiple timing runs with the same label (e.g., in loops)
-        # This allows calculating reductions like mean, min, max, and std dev
+    def __init__(self, context: Optional[dict[str, object]] = None) -> None:
+        """Initialize the timer.
+
+        Args:
+            context: Arbitrary key-value pairs identifying this timer instance.
+                     Included in DEBUG log messages emitted on every
+                     start/stop/record/mark call.
+                     Typical keys: rank, worker, node, job_id.
+                     Example: {"rank": 3, "worker": "collector", "node": "gpu-05"}
+        """
         self._timers: dict[str, list[float]] = {}
         self._start_times: dict[str, float] = {}
+        self._markers: dict[str, list[tuple[float, Optional[dict]]]] = {}
+        self._context = context or {}
+        if "hostname" not in self._context:
+            import socket
 
-    def start(self, label: str) -> None:
+            self._context["hostname"] = socket.gethostname()
+
+    def _fmt(self, label: str, event: str) -> str:
+        """Build a log message string, prepending context prefix and appending UTC timestamp."""
+        ts = datetime.datetime.now(datetime.timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%S.%fZ"
+        )
+        if self._context:
+            prefix = " ".join(f"{k}={v}" for k, v in self._context.items())
+            return f"[{prefix}] {label} {event} ts={ts}"
+        return f"{label} {event} ts={ts}"
+
+    def start(self, label: str, should_log: bool = True) -> None:
         """Start timing for the given label."""
         if label in self._start_times:
             raise ValueError(f"Timer '{label}' is already running")
         self._start_times[label] = time.perf_counter()
+        if should_log:
+            logger.debug(self._fmt(label, "start"))
 
-    def stop(self, label: str) -> float:
+    def stop(self, label: str, should_log: bool = True) -> float:
         """Stop timing for the given label and return the elapsed time.
 
         Args:
@@ -104,10 +132,68 @@ class Timer:
             self._timers[label] = []
         self._timers[label].append(elapsed)
         del self._start_times[label]
+        if should_log:
+            logger.debug(self._fmt(label, f"end elapsed={elapsed:.4f}s"))
         return elapsed
 
+    def record(self, label: str, elapsed: float) -> None:
+        """Append a pre-measured duration without start/stop.
+
+        Useful when the caller has already measured the elapsed time
+        (e.g., across a try/except boundary) and wants to record it directly.
+
+        Args:
+            label: The timing label to record under
+            elapsed: The elapsed time in seconds
+        """
+        if label not in self._timers:
+            self._timers[label] = []
+        self._timers[label].append(elapsed)
+        logger.debug(self._fmt(label, f"record elapsed={elapsed:.4f}s"))
+
+    def mark(self, label: str, metadata: Optional[dict] = None) -> float:
+        """Record a point-in-time event at the current Unix epoch.
+
+        Unlike start/stop/record which measure durations, this captures
+        a standalone timestamp for events like failures, state transitions,
+        or any moment worth noting on a timeline.
+
+        Uses time.time() (not perf_counter) so timestamps are correlatable
+        across processes and Ray actors.
+
+        Args:
+            label: The event label (e.g., "vllm/worker_crashed")
+            metadata: Optional context dict (e.g., {"worker_id": 3, "error": "OOM"})
+
+        Returns:
+            The recorded timestamp (Unix epoch seconds).
+        """
+        ts = time.time()
+        if label not in self._markers:
+            self._markers[label] = []
+        self._markers[label].append((ts, metadata))
+        event = f"mark meta={metadata}" if metadata else "mark"
+        logger.debug(self._fmt(label, event))
+        return ts
+
+    def get_markers(
+        self, label: Optional[str] = None
+    ) -> dict[str, list[tuple[float, Optional[dict]]]]:
+        """Get recorded markers, optionally filtered by label.
+
+        Args:
+            label: If provided, return markers for this label only.
+                   If None, return all markers.
+
+        Returns:
+            Dict mapping labels to lists of (timestamp, metadata) tuples.
+        """
+        if label is not None:
+            return {label: list(self._markers.get(label, []))}
+        return {k: list(v) for k, v in self._markers.items()}
+
     @contextmanager
-    def time(self, label: str) -> Generator[None, None, None]:
+    def time(self, label: str, should_log: bool = True) -> Generator[None, None, None]:
         """Context manager for timing a block of code.
 
         Args:
@@ -116,11 +202,11 @@ class Timer:
         Yields:
             None
         """
-        self.start(label)
+        self.start(label, should_log)
         try:
             yield
         finally:
-            self.stop(label)
+            self.stop(label, should_log)
 
     def get_elapsed(self, label: str) -> list[float]:
         """Get all elapsed time measurements for a specific label.
@@ -233,19 +319,88 @@ class Timer:
         return results
 
     def reset(self, label: Optional[str] = None) -> None:
-        """Reset timings for the specified label or all labels.
+        """Reset timings and markers for the specified label or all labels.
 
         Args:
-            label: Optional label to reset. If None, resets all timers.
+            label: Optional label to reset. If None, resets all timers and markers.
         """
         if label:
             if label in self._timers:
                 del self._timers[label]
             if label in self._start_times:
                 del self._start_times[label]
+            if label in self._markers:
+                del self._markers[label]
         else:
             self._timers = {}
             self._start_times = {}
+            self._markers = {}
+
+
+class ThreadSafeTimer(Timer):
+    """Thread-safe extension of Timer for use in multi-threaded contexts.
+
+    Wraps all mutating and reading operations with a lock so that
+    concurrent threads can safely record timings to the same instance.
+    """
+
+    def __init__(self, context: Optional[dict[str, object]] = None) -> None:
+        super().__init__(context=context)
+        self._lock = threading.RLock()
+
+    def start(self, label: str, should_log: bool = True) -> None:
+        with self._lock:
+            super().start(label, should_log)
+
+    def stop(self, label: str, should_log: bool = True) -> float:
+        with self._lock:
+            return super().stop(label, should_log)
+
+    def record(self, label: str, elapsed: float) -> None:
+        with self._lock:
+            super().record(label, elapsed)
+
+    def mark(self, label: str, metadata: Optional[dict] = None) -> float:
+        with self._lock:
+            return super().mark(label, metadata)
+
+    def get_markers(
+        self, label: Optional[str] = None
+    ) -> dict[str, list[tuple[float, Optional[dict]]]]:
+        with self._lock:
+            return super().get_markers(label)
+
+    @contextmanager
+    def time(self, label: str, should_log: bool = True) -> Generator[None, None, None]:
+        # start/stop are individually locked; no need to hold the lock
+        # across the yielded block (that would serialize all timed code).
+        self.start(label, should_log)
+        try:
+            yield
+        finally:
+            self.stop(label, should_log)
+
+    def get_elapsed(self, label: str) -> list[float]:
+        with self._lock:
+            return super().get_elapsed(label)
+
+    def get_latest_elapsed(self, label: str) -> float:
+        with self._lock:
+            return super().get_latest_elapsed(label)
+
+    def reduce(self, label: str, operation: str = "mean") -> float:
+        with self._lock:
+            return super().reduce(label, operation)
+
+    def get_timing_metrics(
+        self, reduction_op: Union[str, dict[str, str]] = "mean"
+    ) -> dict[str, float | list[float]]:
+        with self._lock:
+            return super().get_timing_metrics(reduction_op)
+
+    def reset(self, label: Optional[str] = None) -> None:
+        with self._lock:
+            super().reset(label)
 
 
 def convert_to_seconds(time_string: str) -> int:

--- a/ray.sub
+++ b/ray.sub
@@ -24,6 +24,9 @@
 
 set -eoux pipefail
 
+# Record job-start epoch so Python can measure pre-Python overhead
+export NRL_JOB_START_EPOCH=$(date +%s.%N)
+
 ########################################################
 # Function to detect if SLURM cluster uses GRES
 ########################################################
@@ -640,6 +643,10 @@ if [[ -n "$DRIVER_COMMAND_FILE" ]]; then
     fi
     sleep 5
   done
+
+  # Record the wall-clock epoch when the Ray cluster became ready so the driver
+  # and training process can measure post-ready initialization timing.
+  export NRL_RAY_READY_EPOCH=\$(date +%s.%N)
 
   set +e
   bash "$DRIVER_COMMAND_FILE" > "$LOG_DIR/ray-driver.log" 2>&1

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -775,6 +775,17 @@ class StubAsyncTrajectoryCollector:
         mock.remote = MagicMock(return_value=MagicMock())
         return mock
 
+    @property
+    def get_efficiency_metrics(self):
+        """Get efficiency metrics - returns a remote-callable mock.
+
+        Returns an empty dict so the driver's efficiency-summary aggregation
+        (which iterates ``.items()``) is exercised without real collector timing.
+        """
+        mock = MagicMock()
+        mock.remote = MagicMock(return_value={})
+        return mock
+
 
 def mock_async_grpo_infrastructure(
     mock_batch, mock_rollout_metrics, seq_logprob_error_result=None

--- a/tests/unit/algorithms/test_utils.py
+++ b/tests/unit/algorithms/test_utils.py
@@ -20,9 +20,12 @@ import torch
 
 from nemo_rl.algorithms.grpo import MasterConfig
 from nemo_rl.algorithms.utils import (
+    EFFICIENCY_CATEGORIES,
+    WALL_CLOCK_EFFICIENCY_CATEGORIES,
     calculate_baseline_and_std_per_prompt,
     get_tokenizer,
     maybe_pad_last_batch,
+    print_efficiency_summary,
     print_performance_metrics,
 )
 from nemo_rl.data.chat_templates import COMMON_CHAT_TEMPLATES
@@ -622,3 +625,79 @@ def test_calculate_baseline_and_std_per_prompt_numerical_precision():
     # Std values should be finite and not NaN
     assert torch.isfinite(std).all()
     assert not torch.isnan(std).any()
+
+
+class TestPrintEfficiencySummary:
+    def test_basic_efficiency_calculation(self, capsys):
+        """Test that efficiency is computed correctly from metrics."""
+        metrics = {
+            "init/total": 10.0,
+            "idle/buffer_starvation": 5.0,
+            "idle/refit_bubble": 3.0,
+            "idle/validation": 2.0,
+        }
+        total_wall = 100.0
+
+        result = print_efficiency_summary(metrics, total_wall, step=1)
+
+        assert result["efficiency/total_waste_s"] == 20.0
+        assert result["efficiency/productive_time_s"] == 80.0
+        assert result["efficiency/efficiency_pct"] == pytest.approx(80.0)
+        assert result["efficiency/total_wall_time_s"] == 100.0
+
+        assert result["efficiency/init/total_s"] == 10.0
+        assert result["efficiency/init/total_pct"] == pytest.approx(10.0)
+        assert result["efficiency/idle/buffer_starvation_s"] == 5.0
+
+        assert result["efficiency/idle/buffer_full_backoff_s"] == 0.0
+        assert result["efficiency/wasted/failed_trajectory_s"] == 0.0
+
+        captured = capsys.readouterr()
+        assert "Efficiency Summary (Step 1)" in captured.out
+        assert "80.00%" in captured.out
+
+    def test_zero_wall_time(self):
+        """Test that zero wall time produces 100% efficiency."""
+        result = print_efficiency_summary({}, total_wall_time_s=0.0, step=0)
+        assert result["efficiency/efficiency_pct"] == 100.0
+        assert result["efficiency/total_waste_s"] == 0.0
+
+    def test_all_categories_present(self):
+        """Test that all EFFICIENCY_CATEGORIES appear in the output."""
+        metrics = {cat: 1.0 for cat in EFFICIENCY_CATEGORIES}
+        result = print_efficiency_summary(metrics, total_wall_time_s=100.0, step=5)
+
+        for cat in EFFICIENCY_CATEGORIES:
+            assert f"efficiency/{cat}_s" in result
+            assert result[f"efficiency/{cat}_s"] == 1.0
+            if cat in WALL_CLOCK_EFFICIENCY_CATEGORIES:
+                assert f"efficiency/{cat}_pct" in result
+
+        # total_waste_s reflects wall-clock categories only (4 x 1.0); collector
+        # thread-seconds are reported separately, not folded into wall waste.
+        assert result["efficiency/total_waste_s"] == 4.0
+        assert result["efficiency/efficiency_pct"] == pytest.approx(96.0)
+
+    def test_efficiency_with_collector_metrics_merge(self):
+        """Test merging driver and collector metrics before computing efficiency."""
+        driver = {"init/total": 5.0, "idle/refit_bubble": 3.0}
+        collector = {"idle/buffer_full_backoff": 2.0, "wasted/failed_trajectory": 1.0}
+
+        merged = {**driver}
+        for cat, dur in collector.items():
+            merged[cat] = merged.get(cat, 0.0) + dur
+
+        result = print_efficiency_summary(merged, total_wall_time_s=50.0, step=3)
+
+        assert result["efficiency/total_waste_s"] == 8.0
+        assert result["efficiency/thread_seconds_total_s"] == 3.0
+        assert result["efficiency/efficiency_pct"] == pytest.approx(84.0)
+
+    def test_wall_waste_clamped_to_wall_time(self):
+        """Wall-clock waste is capped so efficiency stays in [0, 100]."""
+        metrics = {cat: 30.0 for cat in WALL_CLOCK_EFFICIENCY_CATEGORIES}
+        result = print_efficiency_summary(metrics, total_wall_time_s=60.0, step=2)
+
+        assert result["efficiency/total_waste_s"] == 60.0
+        assert result["efficiency/productive_time_s"] == 0.0
+        assert result["efficiency/efficiency_pct"] == 0.0

--- a/tests/unit/utils/test_logger.py
+++ b/tests/unit/utils/test_logger.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import shutil
 import tempfile
 from unittest.mock import MagicMock, call, patch
@@ -27,6 +28,7 @@ from nemo_rl.utils.logger import (
     TensorboardLogger,
     WandbLogger,
     flatten_dict,
+    log_container_init_timing,
     print_message_log_samples,
 )
 
@@ -2056,6 +2058,35 @@ class TestLogger:
 
         mock_subplots.assert_not_called()
         backend_logger.log_plot.assert_not_called()
+
+
+class TestLogContainerInitTiming:
+    def test_warns_when_job_start_unset(self, monkeypatch, caplog, capsys):
+        monkeypatch.delenv("NRL_JOB_START_EPOCH", raising=False)
+        with caplog.at_level(logging.WARNING):
+            log_container_init_timing()
+        assert "NRL_JOB_START_EPOCH not set" in caplog.text
+        assert "CONTAINER INIT TIMING" not in capsys.readouterr().out
+
+    def test_prints_total_only(self, monkeypatch, capsys):
+        monkeypatch.delenv("SLURM_JOB_START_TIME", raising=False)
+        monkeypatch.delenv("NRL_RAY_READY_EPOCH", raising=False)
+        monkeypatch.setenv("NRL_JOB_START_EPOCH", "1.0")
+        log_container_init_timing()
+        out = capsys.readouterr().out
+        assert "CONTAINER INIT TIMING" in out and "total:" in out
+        assert "slurm_prologue" not in out and "cluster_startup" not in out
+
+    def test_prints_full_breakdown(self, monkeypatch, capsys):
+        monkeypatch.setenv("SLURM_JOB_START_TIME", "1.0")
+        monkeypatch.setenv("NRL_JOB_START_EPOCH", "2.0")
+        monkeypatch.setenv("NRL_RAY_READY_EPOCH", "3.0")
+        log_container_init_timing()
+        out = capsys.readouterr().out
+        assert "slurm_prologue: 1.0s" in out
+        assert "cluster_startup (orchestrator+container+ray): 1.0s" in out
+        assert "driver_startup (launch+python+imports):" in out
+        assert "total:" in out
 
 
 def test_print_message_log_samples(capsys):

--- a/tests/unit/utils/test_timer.py
+++ b/tests/unit/utils/test_timer.py
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+import threading
 import time
 from unittest.mock import patch
 
 import numpy as np
 import pytest
 
-from nemo_rl.utils.timer import TimeoutChecker, Timer
+from nemo_rl.utils.timer import ThreadSafeTimer, TimeoutChecker, Timer
 
 
 class TestTimer:
@@ -188,6 +190,422 @@ class TestTimer:
         # Check the elapsed time
         assert elapsed == 5.0
         assert timer._timers["precise_test"][0] == 5.0
+
+    def test_record(self, timer):
+        """Test the record() method for appending pre-measured durations."""
+        timer.record("manual", 1.5)
+        timer.record("manual", 2.5)
+        timer.record("manual", 3.0)
+
+        assert timer._timers["manual"] == [1.5, 2.5, 3.0]
+        assert timer.reduce("manual", "sum") == 7.0
+        assert timer.reduce("manual", "mean") == pytest.approx(7.0 / 3)
+
+    def test_record_mixed_with_start_stop(self, timer):
+        """Test that record() works alongside start/stop."""
+        timer.record("mixed", 1.0)
+        timer.start("mixed")
+        time.sleep(0.01)
+        timer.stop("mixed")
+        timer.record("mixed", 2.0)
+
+        assert len(timer._timers["mixed"]) == 3
+        assert timer._timers["mixed"][0] == 1.0
+        assert timer._timers["mixed"][1] > 0  # from start/stop
+        assert timer._timers["mixed"][2] == 2.0
+
+    def test_get_latest_elapsed(self, timer):
+        """Test get_latest_elapsed returns the most recent measurement."""
+        timer._timers["latest"] = [1.0, 2.0, 3.0]
+        assert timer.get_latest_elapsed("latest") == 3.0
+
+    def test_get_latest_elapsed_nonexistent(self, timer):
+        """Test get_latest_elapsed raises KeyError for missing label."""
+        with pytest.raises(KeyError):
+            timer.get_latest_elapsed("missing")
+
+    def test_get_timing_metrics_sum(self, timer):
+        """Test get_timing_metrics with sum reduction."""
+        timer._timers["a"] = [1.0, 2.0]
+        timer._timers["b"] = [3.0, 4.0]
+
+        metrics = timer.get_timing_metrics(reduction_op="sum")
+        assert metrics["a"] == 3.0
+        assert metrics["b"] == 7.0
+
+    def test_mark_basic(self, timer):
+        """Test basic mark() records a Unix epoch timestamp."""
+        before = time.time()
+        ts = timer.mark("event/test")
+        after = time.time()
+
+        assert before <= ts <= after
+        assert "event/test" in timer._markers
+        assert len(timer._markers["event/test"]) == 1
+        assert timer._markers["event/test"][0] == (ts, None)
+
+    def test_mark_with_metadata(self, timer):
+        """Test mark() with metadata dict."""
+        meta = {"worker_id": 3, "error": "OOM"}
+        ts = timer.mark("vllm/worker_crashed", metadata=meta)
+
+        markers = timer.get_markers("vllm/worker_crashed")
+        assert len(markers["vllm/worker_crashed"]) == 1
+        recorded_ts, recorded_meta = markers["vllm/worker_crashed"][0]
+        assert recorded_ts == ts
+        assert recorded_meta == {"worker_id": 3, "error": "OOM"}
+
+    def test_mark_multiple(self, timer):
+        """Test multiple marks under the same label."""
+        timer.mark("crash", metadata={"id": 1})
+        timer.mark("crash", metadata={"id": 2})
+        timer.mark("crash", metadata={"id": 3})
+
+        markers = timer.get_markers("crash")
+        assert len(markers["crash"]) == 3
+        # Timestamps should be non-decreasing
+        timestamps = [m[0] for m in markers["crash"]]
+        assert timestamps == sorted(timestamps)
+        # Metadata preserved
+        ids = [m[1]["id"] for m in markers["crash"]]
+        assert ids == [1, 2, 3]
+
+    def test_get_markers_all(self, timer):
+        """Test get_markers() with no label returns all markers."""
+        timer.mark("a")
+        timer.mark("b", metadata={"x": 1})
+
+        all_markers = timer.get_markers()
+        assert "a" in all_markers
+        assert "b" in all_markers
+        assert len(all_markers["a"]) == 1
+        assert len(all_markers["b"]) == 1
+
+    def test_get_markers_nonexistent(self, timer):
+        """Test get_markers() for a label with no markers returns empty list."""
+        markers = timer.get_markers("missing")
+        assert markers == {"missing": []}
+
+    def test_get_markers_returns_copy(self, timer):
+        """Test that get_markers returns a copy, not a reference."""
+        timer.mark("x")
+        markers = timer.get_markers("x")
+        markers["x"].clear()
+        assert len(timer._markers["x"]) == 1  # original unaffected
+
+    def test_reset_clears_markers(self, timer):
+        """Test that reset() clears markers too."""
+        timer.mark("event")
+        timer.record("duration", 1.0)
+        timer.reset()
+        assert len(timer._markers) == 0
+        assert len(timer._timers) == 0
+
+    def test_reset_specific_label_clears_markers(self, timer):
+        """Test that reset(label) clears markers for that label."""
+        timer.mark("a")
+        timer.mark("b")
+        timer.reset("a")
+        assert "a" not in timer._markers
+        assert "b" in timer._markers
+
+
+class TestTimerLogging:
+    """Tests for DEBUG-level log messages emitted by Timer."""
+
+    def test_start_stop_logs(self, caplog):
+        timer = Timer(context={"rank": 2, "worker": "policy"})
+        with caplog.at_level(logging.DEBUG, logger="nemo_rl.utils.timer"):
+            timer.start("idle/refit_bubble")
+            timer.stop("idle/refit_bubble")
+
+        assert len(caplog.records) == 2
+        assert "rank=2" in caplog.records[0].message
+        assert "worker=policy" in caplog.records[0].message
+        assert "hostname=" in caplog.records[0].message
+        assert "idle/refit_bubble start ts=" in caplog.records[0].message
+        assert "idle/refit_bubble end elapsed=" in caplog.records[1].message
+        assert " ts=" in caplog.records[1].message
+
+    def test_record_logs(self, caplog):
+        timer = Timer(context={"rank": 0, "worker": "generation"})
+        with caplog.at_level(logging.DEBUG, logger="nemo_rl.utils.timer"):
+            timer.record("wasted/failed_trajectory", 3.14)
+
+        assert len(caplog.records) == 1
+        assert "rank=0" in caplog.records[0].message
+        assert "worker=generation" in caplog.records[0].message
+        assert (
+            "wasted/failed_trajectory record elapsed=3.1400s ts="
+            in caplog.records[0].message
+        )
+
+    def test_mark_logs(self, caplog):
+        timer = Timer(context={"rank": 5, "worker": "generation"})
+        with caplog.at_level(logging.DEBUG, logger="nemo_rl.utils.timer"):
+            timer.mark("vllm/worker_crashed", metadata={"error": "OOM"})
+
+        assert len(caplog.records) == 1
+        assert "rank=5" in caplog.records[0].message
+        assert "worker=generation" in caplog.records[0].message
+        assert "vllm/worker_crashed mark meta=" in caplog.records[0].message
+        assert "'error': 'OOM'" in caplog.records[0].message
+        assert " ts=" in caplog.records[0].message
+
+    def test_mark_without_metadata_logs(self, caplog):
+        timer = Timer(context={"worker": "collector"})
+        with caplog.at_level(logging.DEBUG, logger="nemo_rl.utils.timer"):
+            timer.mark("heartbeat")
+
+        assert len(caplog.records) == 1
+        assert "worker=collector" in caplog.records[0].message
+        assert "heartbeat mark ts=" in caplog.records[0].message
+        assert "meta=" not in caplog.records[0].message
+
+    def test_no_context_still_logs(self, caplog):
+        """Without explicit context, log messages still contain hostname, label, event, and UTC timestamp."""
+        timer = Timer()
+        with caplog.at_level(logging.DEBUG, logger="nemo_rl.utils.timer"):
+            timer.start("x")
+            timer.stop("x")
+            timer.record("y", 1.0)
+            timer.mark("z")
+
+        assert len(caplog.records) == 4
+        assert "hostname=" in caplog.records[0].message
+        assert "x start ts=" in caplog.records[0].message
+        assert "x end elapsed=" in caplog.records[1].message
+        assert " ts=" in caplog.records[1].message
+        assert "y record elapsed=1.0000s ts=" in caplog.records[2].message
+        assert "z mark ts=" in caplog.records[3].message
+
+    def test_no_logs_at_warning_level(self, caplog):
+        """At default WARNING level, no timer messages should appear."""
+        timer = Timer(context={"rank": 0, "worker": "test"})
+        with caplog.at_level(logging.WARNING, logger="nemo_rl.utils.timer"):
+            timer.start("x")
+            timer.stop("x")
+            timer.record("y", 1.0)
+            timer.mark("z")
+
+        assert len(caplog.records) == 0
+
+    def test_context_manager_logs_start_end(self, caplog):
+        timer = Timer(context={"rank": 1, "worker": "policy"})
+        with caplog.at_level(logging.DEBUG, logger="nemo_rl.utils.timer"):
+            with timer.time("idle/validation"):
+                pass
+
+        assert len(caplog.records) == 2
+        assert "start" in caplog.records[0].message
+        assert "end elapsed=" in caplog.records[1].message
+
+    def test_context_with_extra_fields(self, caplog):
+        """Context can hold arbitrary keys beyond rank/worker."""
+        timer = Timer(
+            context={
+                "rank": 0,
+                "worker": "collector",
+                "node": "gpu-05",
+                "job_id": "slurm-123",
+            }
+        )
+        with caplog.at_level(logging.DEBUG, logger="nemo_rl.utils.timer"):
+            timer.mark("event")
+
+        msg = caplog.records[0].message
+        assert "rank=0" in msg
+        assert "worker=collector" in msg
+        assert "node=gpu-05" in msg
+        assert "job_id=slurm-123" in msg
+        assert "hostname=" in msg
+
+    def test_utc_timestamp_format(self, caplog):
+        """Verify the ts= field contains a valid ISO 8601 UTC timestamp."""
+        import re
+
+        timer = Timer(context={"worker": "test"})
+        with caplog.at_level(logging.DEBUG, logger="nemo_rl.utils.timer"):
+            timer.start("op")
+            timer.stop("op")
+
+        iso_pattern = re.compile(r"ts=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z")
+        for record in caplog.records:
+            assert iso_pattern.search(record.message), (
+                f"Expected ISO 8601 UTC timestamp in: {record.message}"
+            )
+
+    def test_hostname_auto_injected(self):
+        """Hostname is automatically added to context when not provided."""
+        import socket
+
+        timer = Timer()
+        assert "hostname" in timer._context
+        assert timer._context["hostname"] == socket.gethostname()
+
+        timer_with_context = Timer(context={"worker": "test"})
+        assert "hostname" in timer_with_context._context
+        assert timer_with_context._context["worker"] == "test"
+        assert timer_with_context._context["hostname"] == socket.gethostname()
+
+    def test_hostname_override(self, caplog):
+        """Caller-provided hostname is preserved (not overwritten)."""
+        timer = Timer(context={"worker": "test", "hostname": "custom-host"})
+        assert timer._context["hostname"] == "custom-host"
+
+        with caplog.at_level(logging.DEBUG, logger="nemo_rl.utils.timer"):
+            timer.start("op")
+        assert "hostname=custom-host" in caplog.records[0].message
+
+    def test_thread_safe_timer_logs(self, caplog):
+        """ThreadSafeTimer delegates to super() which has the logging calls."""
+        timer = ThreadSafeTimer(context={"rank": 3, "worker": "collector"})
+        with caplog.at_level(logging.DEBUG, logger="nemo_rl.utils.timer"):
+            timer.record("idle/buffer_full_backoff", 1.23)
+
+        assert len(caplog.records) == 1
+        assert "rank=3" in caplog.records[0].message
+        assert "worker=collector" in caplog.records[0].message
+        assert (
+            "idle/buffer_full_backoff record elapsed=1.2300s ts="
+            in caplog.records[0].message
+        )
+
+
+class TestThreadSafeTimer:
+    @pytest.fixture
+    def timer(self):
+        return ThreadSafeTimer()
+
+    def test_thread_safe_timer_should_log(self, caplog):
+        """ThreadSafeTimer forwards should_log to the base Timer."""
+        timer = ThreadSafeTimer()
+        with caplog.at_level(logging.DEBUG, logger="nemo_rl.utils.timer"):
+            timer.start("quiet", should_log=False)
+            timer.stop("quiet", should_log=False)
+        assert caplog.records == []
+
+    def test_basic_operations(self, timer):
+        """Test that ThreadSafeTimer has the same API as Timer."""
+        timer.start("test")
+        time.sleep(0.01)
+        elapsed = timer.stop("test")
+        assert elapsed > 0
+
+        timer.record("manual", 5.0)
+        assert timer.reduce("manual", "sum") == 5.0
+
+        with timer.time("ctx"):
+            time.sleep(0.01)
+        assert timer.reduce("ctx", "sum") > 0
+
+    def test_concurrent_record(self, timer):
+        """Test that concurrent record() calls don't lose data."""
+        num_threads = 10
+        records_per_thread = 100
+        barrier = threading.Barrier(num_threads)
+
+        def worker():
+            barrier.wait()
+            for _ in range(records_per_thread):
+                timer.record("concurrent", 1.0)
+
+        threads = [threading.Thread(target=worker) for _ in range(num_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        expected_total = num_threads * records_per_thread
+        assert len(timer._timers["concurrent"]) == expected_total
+        assert timer.reduce("concurrent", "sum") == pytest.approx(float(expected_total))
+
+    def test_concurrent_start_stop(self, timer):
+        """Test concurrent start/stop with distinct labels."""
+        num_threads = 10
+        barrier = threading.Barrier(num_threads)
+
+        def worker(thread_id):
+            barrier.wait()
+            label = f"thread_{thread_id}"
+            timer.start(label)
+            time.sleep(0.01)
+            timer.stop(label)
+
+        threads = [
+            threading.Thread(target=worker, args=(i,)) for i in range(num_threads)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        for i in range(num_threads):
+            assert f"thread_{i}" in timer._timers
+            assert len(timer._timers[f"thread_{i}"]) == 1
+            assert timer._timers[f"thread_{i}"][0] > 0
+
+    def test_get_timing_metrics_thread_safe(self, timer):
+        """Test that get_timing_metrics is safe to call during concurrent writes."""
+        stop_event = threading.Event()
+
+        def writer():
+            i = 0
+            while not stop_event.is_set():
+                timer.record("bg", float(i))
+                i += 1
+                time.sleep(0.001)
+
+        writer_thread = threading.Thread(target=writer)
+        writer_thread.start()
+
+        # Read metrics multiple times while writer is active
+        for _ in range(10):
+            metrics = timer.get_timing_metrics(reduction_op="sum")
+            if "bg" in metrics:
+                assert metrics["bg"] >= 0
+            time.sleep(0.005)
+
+        stop_event.set()
+        writer_thread.join()
+
+    def test_concurrent_mark(self, timer):
+        """Test that concurrent mark() calls don't lose data."""
+        num_threads = 10
+        marks_per_thread = 100
+        barrier = threading.Barrier(num_threads)
+
+        def worker(thread_id):
+            barrier.wait()
+            for i in range(marks_per_thread):
+                timer.mark("event", metadata={"thread": thread_id, "i": i})
+
+        threads = [
+            threading.Thread(target=worker, args=(tid,)) for tid in range(num_threads)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        markers = timer.get_markers("event")
+        assert len(markers["event"]) == num_threads * marks_per_thread
+
+    def test_mark_basic(self, timer):
+        """Test mark() works on ThreadSafeTimer."""
+        ts = timer.mark("test_event", metadata={"key": "val"})
+        markers = timer.get_markers("test_event")
+        assert len(markers["test_event"]) == 1
+        assert markers["test_event"][0] == (ts, {"key": "val"})
+
+    def test_reset(self, timer):
+        """Test reset clears all data including markers."""
+        timer.record("a", 1.0)
+        timer.record("b", 2.0)
+        timer.mark("event")
+        timer.reset()
+        assert len(timer._timers) == 0
+        assert len(timer._markers) == 0
 
 
 class TestTimeoutChecker:


### PR DESCRIPTION
# What does this PR do ?
Improves observability for large-scale Slurm/Ray GRPO runs

## Timer infrastructure
Extends Timer with optional context labels (rank, worker, hostname) and structured start/stop/record/mark logging for timeline debugging.
Adds ThreadSafeTimer for concurrent use in AsyncTrajectoryCollector (refit waits, generation-limit pauses, buffer-full backoff, failed trajectories).
Adds mark() for point-in-time events (e.g. worker crashes) correlatable across Ray actors.
## Container init breakdown
ray.sub records NRL_JOB_START_EPOCH at job submit and NRL_RAY_READY_EPOCH when Ray is ready on the head node.
Fixes propagation of NRL_RAY_READY_EPOCH into the driver container so the driver sees the same timestamp.
Adds log_container_init_timing(), called at the start of GRPO entrypoints, printing:
Slurm prologue (optional)
Cluster startup (orchestrator + container + Ray)
Driver startup (launch + Python imports)
Total wall time to first training code
## Async GRPO efficiency accounting
Driver and collector track idle categories: init/total, idle/buffer_starvation, idle/buffer_full_backoff, idle/refit_bubble, idle/refit_event_wait, idle/generation_limit_pause, idle/validation, wasted/failed_trajectory.
Each step prints and logs an efficiency summary (% wall time productive vs wasted) to stdout and WandB.
Policy workers emit timer spans around refit/prepare paths.
Safe when env vars are unset: init timing is skipped with a warning; timer behavior is unchanged for sync training.
# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
