### PR TITLE
fix(async-grpo): starvation diagnostics, gym logging, and dataloader exhaustion

### DIFF
--- a/nemo_rl/algorithms/async_utils/replay_buffer.py
+++ b/nemo_rl/algorithms/async_utils/replay_buffer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import statistics
 import threading as _threading
 from collections import Counter
 from typing import Any, Iterable, Optional
@@ -40,6 +41,25 @@ class ReplayBufferImpl(ReplayBufferProtocol):
 
         self.last_target_weight_already_generated = -1
         self._lock = _threading.Lock()
+
+    @staticmethod
+    def _rollout_metrics_turn_count_for_diagnostics(
+        rm: dict[str, Any],
+    ) -> Optional[float]:
+        """One scalar turn-depth per buffered trajectory for starvation diagnostics.
+
+        Supports sync multi-turn rollouts (`max_turns_per_sample` / `avg_turns_per_sample`)
+        and NeMo Gym (`turns_per_sample/max` / `turns_per_sample/mean`).
+        """
+        if "max_turns_per_sample" in rm:
+            return float(rm["max_turns_per_sample"])
+        if "avg_turns_per_sample" in rm:
+            return float(rm["avg_turns_per_sample"])
+        if "turns_per_sample/max" in rm:
+            return float(rm["turns_per_sample/max"])
+        if "turns_per_sample/mean" in rm:
+            return float(rm["turns_per_sample/mean"])
+        return None
 
     def add(
         self,
@@ -71,12 +91,70 @@ class ReplayBufferImpl(ReplayBufferProtocol):
 
     def get_debug_info(self) -> dict:
         """Get debug information about buffer state."""
-        return {
+        info: dict[str, Any] = {
             "total_trajectories": len(self.trajectories),
             "trajectory_versions": self.trajectory_versions,
             "target_weight_versions": self.target_weight_versions,
             "max_size": self.max_size,
         }
+        if self.trajectories:
+            durations = []
+            max_gen_tokens_per_turn_list = []
+            turn_counts_list = []
+            for t in self.trajectories:
+                rm = t.get("rollout_metrics", {})
+                if "trajectory_duration_s" in rm:
+                    durations.append(rm["trajectory_duration_s"])
+                if "max_gen_tokens_per_turn/max" in rm:
+                    max_gen_tokens_per_turn_list.append(
+                        rm["max_gen_tokens_per_turn/max"]
+                    )
+                elif "max_gen_tokens_per_turn" in rm:
+                    max_gen_tokens_per_turn_list.append(rm["max_gen_tokens_per_turn"])
+                tc = self._rollout_metrics_turn_count_for_diagnostics(rm)
+                if tc is not None:
+                    turn_counts_list.append(tc)
+
+            def _pct(values: list[float], p: float) -> float:
+                if not values:
+                    return 0.0
+                sorted_v = sorted(values)
+                idx = min(int(len(sorted_v) * p / 100), len(sorted_v) - 1)
+                return float(sorted_v[idx])
+
+            info["starvation_diagnostics"] = {
+                "trajectory_duration_s": {
+                    "mean": sum(durations) / len(durations) if durations else 0,
+                    "median": statistics.median(durations) if durations else 0,
+                    "max": max(durations) if durations else 0,
+                    "p95": _pct(durations, 95),
+                },
+                "max_gen_tokens_per_turn_in_buffer": {
+                    "mean": sum(max_gen_tokens_per_turn_list)
+                    / len(max_gen_tokens_per_turn_list)
+                    if max_gen_tokens_per_turn_list
+                    else 0,
+                    "median": statistics.median(max_gen_tokens_per_turn_list)
+                    if max_gen_tokens_per_turn_list
+                    else 0,
+                    "max": max(max_gen_tokens_per_turn_list)
+                    if max_gen_tokens_per_turn_list
+                    else 0,
+                    "p95": _pct(max_gen_tokens_per_turn_list, 95),
+                },
+                "turns_per_sample_in_buffer": {
+                    "mean": sum(turn_counts_list) / len(turn_counts_list)
+                    if turn_counts_list
+                    else 0,
+                    "median": statistics.median(turn_counts_list)
+                    if turn_counts_list
+                    else 0,
+                    "max": max(turn_counts_list) if turn_counts_list else 0,
+                    "p95": _pct(turn_counts_list, 95),
+                },
+                "num_trajectories_sampled": len(self.trajectories),
+            }
+        return info
 
     def get_last_target_weight_already_generated(self) -> int:
         with self._lock:

--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -77,6 +77,9 @@ class AsyncTrajectoryCollector:
             k: _threading.Lock() for k in self.teacher_worker_groups
         }
         self.running = False
+        self.data_exhausted = False
+        self.collection_failed = False
+
         self._pg_lock: _threading.Lock = _threading.Lock()
 
         # Event for manual pause/resume control
@@ -249,8 +252,24 @@ class AsyncTrajectoryCollector:
 
         print("Collection thread started, start_collection returning")
 
+    def is_data_exhausted(self) -> bool:
+        """Check if collection stopped because the dataloader ran out of data."""
+        return self.data_exhausted
+
+    def get_status(self) -> dict:
+        """Return a snapshot of the collector's internal state for driver-side diagnostics."""
+        with self._threads_lock:
+            inflight_workers = len(self._inflight_threads)
+        return {
+            "running": self.running,
+            "data_exhausted": self.data_exhausted,
+            "errored": self.collection_failed,
+            "inflight_workers": inflight_workers,
+        }
+
     def _collection_loop(self):
         """Run the collection loop in background thread."""
+        dataloader_exhausted = False
         try:
             for batch in self.dataloader:
                 if not self.running:
@@ -298,14 +317,27 @@ class AsyncTrajectoryCollector:
                     break
 
                 self._process_batch(batch)
+            else:
+                # for-loop completed without break → dataloader iterator exhausted
+                dataloader_exhausted = True
+
         except Exception as e:
             print(f"❌ Error in trajectory collection: {e}")
             import traceback
 
             traceback.print_exc()
+            self.collection_failed = True
         finally:
             self.running = False
-            print("🛑 Trajectory collection stopped")
+            if dataloader_exhausted:
+                self.data_exhausted = True
+                print(
+                    "❌ Trajectory collection stopped: dataloader exhausted "
+                    "(max_num_epochs reached). No more data available for generation. "
+                    "Increase max_num_epochs or use a larger dataset."
+                )
+            else:
+                print("🛑 Trajectory collection stopped")
 
     def _process_batch(self, batch: BatchedDataDict[DatumSpec]) -> None:
         """Process a single batch and generate for one target weight."""
@@ -804,6 +836,11 @@ class AsyncTrajectoryCollector:
                     final_batch_cpu["teacher_reference_logprobs"] = teacher_logprobs
                     rollout_metrics = dict(rollout_metrics)
                     rollout_metrics["teacher_logprob_time"] = teacher_logprob_time
+
+            # Record per-trajectory wall-clock duration for buffer starvation diagnostics
+            trajectory_duration_s = time.perf_counter() - worker_start
+            rollout_metrics = dict(rollout_metrics)
+            rollout_metrics["trajectory_duration_s"] = trajectory_duration_s
 
             trajectory_group = {
                 "batch": final_batch_cpu,

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -3499,6 +3499,14 @@ def aggregate_rollout_metrics(
             aggregated[k] = max(v)
         elif k == "total_turns":
             aggregated[k] = sum(v)
+        elif k == "trajectory_duration_s":
+            sorted_v = sorted(v)
+            p95_idx = min(int(len(sorted_v) * 0.95), len(sorted_v) - 1)
+            aggregated[k] = sum(v) / len(v)
+            aggregated["trajectory_duration_s/max"] = max(v)
+            aggregated["trajectory_duration_s/p95"] = (
+                sorted_v[p95_idx] if sorted_v else 0
+            )
         else:
             aggregated[k] = sum(v) / len(v)
     return aggregated
@@ -3824,6 +3832,22 @@ def async_grpo_train(
                 f"trajectories for step {step}"
             )
 
+        collector_status = ray.get(trajectory_collector.get_status.remote())
+        if (
+            (
+                collector_status["data_exhausted"]
+                or collector_status.get("errored", False)
+            )
+            and not collector_status["running"]
+            and collector_status["inflight_workers"] == 0
+        ):
+            raise RuntimeError(
+                f"Trajectory collector stopped: dataloader exhausted while waiting for initial buffer fill at step={step}. "
+                f"The dataset ran out of data before training could start. "
+                f"Collector status: {collector_status}. "
+                f"Increase data.train.max_num_epochs or use a larger dataset."
+            )
+
         wait_iterations += 1
         time.sleep(1.0)
 
@@ -3883,6 +3907,50 @@ def async_grpo_train(
                             print(
                                 f"   Trajectory versions in buffer: {buffer_debug['trajectory_versions']}"
                             )
+                            diag = buffer_debug.get("starvation_diagnostics")
+                            if diag:
+                                print(
+                                    "   📊 Buffer starvation diagnostics (long-tail root cause):"
+                                )
+                                print(
+                                    f"      trajectory_duration_s: mean={diag['trajectory_duration_s']['mean']:.1f}s, "
+                                    f"median={diag['trajectory_duration_s']['median']:.1f}s, "
+                                    f"max={diag['trajectory_duration_s']['max']:.1f}s, "
+                                    f"p95={diag['trajectory_duration_s']['p95']:.1f}s"
+                                )
+                                print(
+                                    f"      max_gen_tokens_per_turn: mean={diag['max_gen_tokens_per_turn_in_buffer']['mean']:.0f}, "
+                                    f"median={diag['max_gen_tokens_per_turn_in_buffer']['median']:.0f}, "
+                                    f"max={diag['max_gen_tokens_per_turn_in_buffer']['max']:.0f}, "
+                                    f"p95={diag['max_gen_tokens_per_turn_in_buffer']['p95']:.0f} "
+                                    "(high = long single generations per turn)"
+                                )
+                                print(
+                                    f"      turns_per_sample: mean={diag['turns_per_sample_in_buffer']['mean']:.1f}, "
+                                    f"median={diag['turns_per_sample_in_buffer']['median']:.1f}, "
+                                    f"max={diag['turns_per_sample_in_buffer']['max']:.0f}, "
+                                    f"p95={diag['turns_per_sample_in_buffer']['p95']:.1f} "
+                                    "(high = many turns per trajectory)"
+                                )
+
+                        collector_status = ray.get(
+                            trajectory_collector.get_status.remote()
+                        )
+                        if (
+                            (
+                                collector_status["data_exhausted"]
+                                or collector_status.get("errored", False)
+                            )
+                            and not collector_status["running"]
+                            and collector_status["inflight_workers"] == 0
+                        ):
+                            raise RuntimeError(
+                                f"Trajectory collector stopped: dataloader exhausted at training_step={step}. "
+                                f"The dataset ran out of data before training could complete. "
+                                f"Collector status: {collector_status}. "
+                                f"Increase data.train.max_num_epochs or use a larger dataset."
+                            )
+
                         with timer.time("idle/buffer_starvation"):
                             time.sleep(0.5)
                         continue

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -1097,6 +1097,9 @@ async def run_sample_multi_turn_rollout(
         for name, acc in reward_acc_dict.items():
             final_sample_state[name] = torch.tensor(acc)
 
+    # max_gen_tokens_per_turn: Diagnostic for long single generations
+    max_gen_tokens_per_turn = max(turn_gen_tokens) if turn_gen_tokens else 0
+
     # Sample metrics
     sample_metrics = {
         "turn_count": turn_count,
@@ -1110,6 +1113,7 @@ async def run_sample_multi_turn_rollout(
         "turn_gen_tokens": turn_gen_tokens,
         "turn_input_tokens": turn_input_tokens,
         "turn_total_tokens": turn_total_tokens,
+        "max_gen_tokens_per_turn": max_gen_tokens_per_turn,
         # Pass-through per-worker per-turn accounting for aggregation at batch level
         "per_worker_token_counts": per_worker_token_counts,
     }
@@ -1244,13 +1248,27 @@ def run_async_multi_turn_rollout(
             if key not in final_batch:
                 final_batch[key] = input_batch[key]
 
+        # Helper for percentile (buffer starvation diagnostics)
+        def _pct(values: Sequence[float | int], p: float) -> float:
+            if not values:
+                return 0.0
+            sorted_v = sorted(values)
+            idx = min(int(len(sorted_v) * p / 100), len(sorted_v) - 1)
+            return float(sorted_v[idx])
+
+        turn_counts = [m["turn_count"] for m in all_sample_metrics]
+        max_gen_tokens_per_turn_values = [
+            m["max_gen_tokens_per_turn"] for m in all_sample_metrics
+        ]
+
         # Aggregate metrics across all samples
         rollout_metrics = {
             # Overall metrics
-            "total_turns": sum(m["turn_count"] for m in all_sample_metrics),
-            "avg_turns_per_sample": sum(m["turn_count"] for m in all_sample_metrics)
-            / batch_size,
-            "max_turns_per_sample": max(m["turn_count"] for m in all_sample_metrics),
+            "total_turns": sum(turn_counts),
+            "avg_turns_per_sample": sum(turn_counts) / batch_size,
+            "max_turns_per_sample": max(turn_counts),
+            "turns_per_sample/p95": _pct(turn_counts, 95),
+            "turns_per_sample/p99": _pct(turn_counts, 99),
             "natural_termination_rate": sum(m["terminated"] for m in all_sample_metrics)
             / batch_size,
             "truncation_rate": sum(m["truncated"] for m in all_sample_metrics)
@@ -1275,6 +1293,11 @@ def run_async_multi_turn_rollout(
                 m["env_tokens"] for m in all_sample_metrics
             )
             / batch_size,
+            # max_gen_tokens_per_turn: Diagnostic for long single generations
+            "max_gen_tokens_per_turn/max": max(max_gen_tokens_per_turn_values),
+            "max_gen_tokens_per_turn/mean": sum(max_gen_tokens_per_turn_values)
+            / batch_size,
+            "max_gen_tokens_per_turn/p95": _pct(max_gen_tokens_per_turn_values, 95),
             # Reward metrics
             "mean_total_reward": sum(m["total_reward"] for m in all_sample_metrics)
             / batch_size,
@@ -1860,19 +1883,42 @@ def run_async_nemo_gym_rollout(
                 "turn_count": sum(1 for m in r["message_log"] if m["role"] == "user"),
                 "hit_max_tokens": sum(len(m["token_ids"]) for m in r["message_log"])
                 == max_total_tokens_per_sample,
+                # max_gen_tokens_per_turn: Diagnostic for long single generations
+                "max_gen_tokens_per_turn": max(
+                    (
+                        len(m["token_ids"])
+                        for m in r["message_log"]
+                        if m["role"] == "assistant"
+                    ),
+                    default=0,
+                ),
             }
             for r in results
         ]
 
     # Aggregate metrics across all samples
     with timer.time(f"{timer_prefix}/aggregate_metrics"):
+        turn_counts = [m["turn_count"] for m in all_sample_metrics]
+        max_gen_tokens_per_turn_values = [
+            m["max_gen_tokens_per_turn"] for m in all_sample_metrics
+        ]
+
+        def _pct(values: Sequence[float | int], p: float) -> float:
+            if not values:
+                return 0.0
+            sorted_v = sorted(values)
+            idx = min(int(len(sorted_v) * p / 100), len(sorted_v) - 1)
+            return float(sorted_v[idx])
+
         rollout_metrics = {
             **rollout_loop_timing_metrics,
             **_calculate_single_metric(
-                [m["turn_count"] for m in all_sample_metrics],
+                turn_counts,
                 batch_size,
                 "turns_per_sample",
             ),
+            "turns_per_sample/p95": _pct(turn_counts, 95),
+            "turns_per_sample/p99": _pct(turn_counts, 99),
             **_calculate_single_metric(
                 [m["total_tokens"] for m in all_sample_metrics],
                 batch_size,
@@ -1883,6 +1929,12 @@ def run_async_nemo_gym_rollout(
                 batch_size,
                 "gen_tokens_per_sample",
             ),
+            **_calculate_single_metric(
+                max_gen_tokens_per_turn_values,
+                batch_size,
+                "max_gen_tokens_per_turn",
+            ),
+            "max_gen_tokens_per_turn/p95": _pct(max_gen_tokens_per_turn_values, 95),
             **_calculate_single_metric(
                 [m["total_reward"] for m in all_sample_metrics],
                 batch_size,

--- a/tests/unit/algorithms/test_async_utils.py
+++ b/tests/unit/algorithms/test_async_utils.py
@@ -249,6 +249,60 @@ class TestReplayBufferImplCheckpointing:
         assert sample_result["trajectories"][0]["batch"]["data"] == "valid"
         assert buffer.size() == 0
 
+    def test_local_debug_info_reports_starvation_diagnostics(self):
+        buffer = ReplayBufferImpl(max_size=10)
+        assert (
+            buffer.add(
+                {
+                    "batch": {"data": "a"},
+                    "rollout_metrics": {
+                        "trajectory_duration_s": 10.0,
+                        "max_gen_tokens_per_turn/max": 100,
+                        "turns_per_sample/max": 3.0,
+                    },
+                },
+                weight_version=0,
+                target_weight_version=1,
+            )
+            == "success"
+        )
+        assert (
+            buffer.add(
+                {
+                    "batch": {"data": "b"},
+                    "rollout_metrics": {
+                        "trajectory_duration_s": 20.0,
+                        "max_gen_tokens_per_turn": 200,
+                        "turns_per_sample/mean": 4.0,
+                    },
+                },
+                weight_version=0,
+                target_weight_version=1,
+            )
+            == "success"
+        )
+
+        diagnostics = buffer.get_debug_info()["starvation_diagnostics"]
+
+        duration = diagnostics["trajectory_duration_s"]
+        assert duration["mean"] == 15.0
+        assert duration["median"] == 15.0
+        assert duration["max"] == 20.0
+        assert duration["p95"] == 20.0
+
+        gen = diagnostics["max_gen_tokens_per_turn_in_buffer"]
+        assert gen["mean"] == 150.0
+        assert gen["median"] == 150.0
+        assert gen["max"] == 200
+        assert gen["p95"] == 200.0
+
+        turns = diagnostics["turns_per_sample_in_buffer"]
+        assert turns["mean"] == 3.5
+        assert turns["median"] == 3.5
+        assert turns["max"] == 4.0
+        assert turns["p95"] == 4.0
+        assert diagnostics["num_trajectories_sampled"] == 2
+
     def test_local_load_state_dict_validates_checkpoint_shape(self):
         buffer = ReplayBufferImpl(max_size=10)
 
@@ -449,6 +503,42 @@ class TestReplayBuffer:
         assert sample_result is not None
         assert ray.get(buffer.get_last_target_weight_already_generated.remote()) == 5
 
+        ray.kill(buffer)
+
+    def test_replay_buffer_starvation_diagnostics_nemo_gym_turn_keys(self):
+        """NeMo Gym uses turns_per_sample/* in rollout_metrics; diagnostics must read them."""
+        buffer = ReplayBuffer.remote(max_size=10)
+        t1 = {
+            "batch": {"data": "a"},
+            "rollout_metrics": {
+                "trajectory_duration_s": 10.0,
+                "max_gen_tokens_per_turn/max": 100,
+                "turns_per_sample/max": 3.0,
+                "turns_per_sample/mean": 2.5,
+            },
+        }
+        t2 = {
+            "batch": {"data": "b"},
+            "rollout_metrics": {
+                "trajectory_duration_s": 20.0,
+                "max_gen_tokens_per_turn/max": 200,
+                "turns_per_sample/max": 5.0,
+                "turns_per_sample/mean": 4.0,
+            },
+        }
+        ray.get(buffer.add.remote(t1, weight_version=0, target_weight_version=1))
+        ray.get(buffer.add.remote(t2, weight_version=0, target_weight_version=1))
+        debug_info = ray.get(buffer.get_debug_info.remote())
+        diag = debug_info["starvation_diagnostics"]["turns_per_sample_in_buffer"]
+        assert diag["max"] == 5.0
+        assert diag["mean"] == 4.0
+        assert diag["median"] == 4.0
+        assert diag["p95"] == 5.0
+        gen = debug_info["starvation_diagnostics"]["max_gen_tokens_per_turn_in_buffer"]
+        assert gen["max"] == 200
+        assert gen["mean"] == 150
+        assert gen["median"] == 150
+        assert gen["p95"] == 200
         ray.kill(buffer)
 
     def test_replay_buffer_age_filtering(self):
@@ -1095,6 +1185,76 @@ class TestAsyncTrajectoryCollector:
             replay_buffer=replay_buffer,
             start_step=0,
         )
+
+    def _prime_collection_loop(self, collector):
+        """Unblock every wait-event so _collection_loop() runs to completion."""
+        for attr in (
+            "_manual_pause_cleared",
+            "_refit_pause_cleared",
+            "_generation_limit_cleared",
+        ):
+            ev = threading.Event()
+            ev.set()
+            setattr(collector, attr, ev)
+        collector._should_pause_for_generation_limits = lambda: False
+        collector.running = True
+
+    def test_collection_loop_marks_data_exhausted_on_natural_completion(self):
+        """for...else path: iterator drains cleanly -> data_exhausted, not errored."""
+        collector = self.create_local_collector()
+        self._prime_collection_loop(collector)
+        processed = []
+        collector._process_batch = lambda batch: processed.append(batch)
+        collector.dataloader = [{"b": 0}, {"b": 1}]
+
+        collector._collection_loop()
+
+        assert processed == [{"b": 0}, {"b": 1}]
+        assert collector.data_exhausted is True
+        assert collector.collection_failed is False
+        status = collector.get_status()
+        assert status["data_exhausted"] is True
+        assert status["errored"] is False
+        assert status["running"] is False
+
+    def test_collection_loop_marks_errored_on_crash(self):
+        """A crash sets errored (not data_exhausted) so driver guards fail fast."""
+        collector = self.create_local_collector()
+        self._prime_collection_loop(collector)
+
+        def _boom(batch):
+            raise RuntimeError("collection blew up")
+
+        collector._process_batch = _boom
+        collector.dataloader = [{"b": 0}]
+
+        collector._collection_loop()
+
+        assert collector.collection_failed is True
+        assert collector.data_exhausted is False
+        status = collector.get_status()
+        assert status["errored"] is True
+        assert status["data_exhausted"] is False
+        assert status["running"] is False
+
+    def test_collection_loop_no_exhaustion_on_manual_stop(self):
+        """Breaking out (running=False) must not set data_exhausted/errored."""
+        collector = self.create_local_collector()
+        self._prime_collection_loop(collector)
+
+        def _stop_after_first(batch):
+            collector.running = False
+
+        collector._process_batch = _stop_after_first
+        collector.dataloader = [{"b": 0}, {"b": 1}, {"b": 2}]
+
+        collector._collection_loop()
+
+        assert collector.data_exhausted is False
+        assert collector.collection_failed is False
+        status = collector.get_status()
+        assert status["data_exhausted"] is False
+        assert status["errored"] is False
 
     def create_mock_config(self) -> MasterConfig:
         """Create a mock master config for testing."""
@@ -1819,3 +1979,23 @@ class TestPromptExtraction:
         )
         assert torch.equal(message_log[1]["token_loss_mask"], torch.tensor([0, 0]))
         assert torch.equal(message_log[2]["token_loss_mask"], torch.tensor([1, 1]))
+
+
+def test_turn_count_fallback_priority():
+    """_rollout_metrics_turn_count_for_diagnostics honors the documented key priority."""
+    f = ReplayBufferImpl._rollout_metrics_turn_count_for_diagnostics
+    assert (
+        f(
+            {
+                "max_turns_per_sample": 7,
+                "avg_turns_per_sample": 1,
+                "turns_per_sample/max": 2,
+                "turns_per_sample/mean": 3,
+            }
+        )
+        == 7.0
+    )
+    assert f({"avg_turns_per_sample": 4, "turns_per_sample/max": 2}) == 4.0
+    assert f({"turns_per_sample/max": 5, "turns_per_sample/mean": 3}) == 5.0
+    assert f({"turns_per_sample/mean": 6}) == 6.0
+    assert f({"reward": 1.0}) is None


### PR DESCRIPTION
# What does this PR do ?

Addresses async GRPO runs that appear hung during buffer fill or between steps: adds actionable diagnostics, reduces logging overhead, and fails fast when the dataloader is exhausted instead of spinning forever.

## Buffer starvation diagnostics
ReplayBuffer.get_debug_info() reports per-buffer stats: trajectory duration, max generation tokens per turn, and turn depth (mean/median/max/p95).
Rollout paths record max_gen_tokens_per_turn and turn-count percentiles for long multi-turn Gym trajectories.
Collector records trajectory_duration_s per buffered group.
Driver logs starvation context (buffer state + diagnostics) while waiting for trajectories.

## Gym logging cost
Skips writing train_data_step*.jsonl in async GRPO when env.should_log_nemo_gym_responses is true (NeMo Gym handles full response logging).
Avoids serializing very large Gym payloads every step when that flag is set.

## Dataloader exhaustion fix
Collector sets data_exhausted when the train iterator completes without an explicit stop.
Exposes get_status() for driver-side checks.
Driver raises RuntimeError with collector status during initial buffer fill and mid-training starvation waits, instead of an infinite loop when max_num_epochs is too low for the buffer size.


# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.


