### PR TITLE
perf: batch worker port discovery

### DIFF
--- a/nemo_rl/distributed/virtual_cluster.py
+++ b/nemo_rl/distributed/virtual_cluster.py
@@ -874,20 +874,42 @@ class RayVirtualCluster:
         Returns:
             Tuple of (address, port)
         """
-        # Get placement groups if not already created
-        if not self._node_placement_groups:
-            self.get_placement_groups()
+        results = self.get_available_addresses_and_ports_batch([(pg_idx, bundle_idx)])
+        return results[0]
 
-        # Get the placement group
+    def get_available_addresses_and_ports_batch(
+        self,
+        pg_bundle_pairs: list[tuple[int, int]],
+        batch_size: int = 256,
+    ) -> list[tuple[str, int]]:
+        """Discovers available addresses and ports for multiple bundles in parallel.
+
+        Fires all remote tasks up front, then collects results in batches via ray.wait()
+        to avoid putting too many objects into the Ray object
+        store at once.
+        See https://docs.ray.io/en/latest/ray-core/patterns/ray-get-too-many-objects.html
+
+        Args:
+            pg_bundle_pairs: List of ``(pg_idx, bundle_idx)`` pairs.
+            batch_size: Maximum number of ready futures to fetch at once.
+
+        Returns:
+            List of ``(address, port)`` tuples in the same order as ``pg_bundle_pairs``.
+        """
         placement_groups = self.get_placement_groups()
-        if len(placement_groups) == 1:
-            pg = placement_groups[0]
-        else:
-            pg = placement_groups[pg_idx]
+        refs: list[ray.ObjectRef] = []
+        for pg_idx, bundle_idx in pg_bundle_pairs:
+            pg = (
+                placement_groups[0]
+                if len(placement_groups) == 1
+                else placement_groups[pg_idx]
+            )
+            if not pg.bundle_specs:
+                raise RuntimeError(
+                    "No valid placement groups found to get available address and port"
+                )
 
-        if pg.bundle_specs:
-            # Launch port finder on the given bundle of this placement group
-            addr, port = ray.get(
+            refs.append(
                 _get_node_ip_and_free_port.options(
                     scheduling_strategy=PlacementGroupSchedulingStrategy(
                         placement_group=pg, placement_group_bundle_index=bundle_idx
@@ -896,11 +918,29 @@ class RayVirtualCluster:
                     num_cpus=0,
                 ).remote(self.port_range_low, self.port_range_high)
             )
-            return addr, port
 
-        raise RuntimeError(
-            "No valid placement groups found to get available address and port"
-        )
+        if len(refs) <= batch_size:
+            return ray.get(refs)
+
+        # ray.wait returns refs in completion order, so map each ref back to
+        # its input index to preserve worker-to-port ordering.
+        ref_to_idx = {ref: idx for idx, ref in enumerate(refs)}
+        results: list[Optional[tuple[str, int]]] = []
+        for _ in refs:
+            results.append(None)
+        remaining = list(refs)
+        while remaining:
+            ready, remaining = ray.wait(
+                remaining, num_returns=min(batch_size, len(remaining))
+            )
+            for ref, value in zip(ready, ray.get(ready)):
+                results[ref_to_idx[ref]] = value
+
+        ordered_results: list[tuple[str, int]] = []
+        for result in results:
+            assert result is not None
+            ordered_results.append(result)
+        return ordered_results
 
     def get_master_address_and_port(self) -> tuple[str, int]:
         """Gets the master address and port for the distributed training setup.

--- a/nemo_rl/distributed/worker_groups.py
+++ b/nemo_rl/distributed/worker_groups.py
@@ -474,15 +474,16 @@ class RayWorkerGroup:
         placement_groups = self.cluster.get_placement_groups()
 
         # Get available address and port for each worker
-        available_addresses = []
-        available_ports = []
-        for group_idx, (pg_idx, local_bundle_indices) in enumerate(bundle_indices_list):
-            for local_rank, bundle_idx in enumerate(local_bundle_indices):
-                addr, port = self.cluster.get_available_address_and_port(
-                    pg_idx, bundle_idx
-                )
-                available_addresses.append(addr)
-                available_ports.append(port)
+        pg_bundle_pairs = [
+            (pg_idx, bundle_idx)
+            for pg_idx, local_bundle_indices in bundle_indices_list
+            for bundle_idx in local_bundle_indices
+        ]
+        addr_port_results = self.cluster.get_available_addresses_and_ports_batch(
+            pg_bundle_pairs
+        )
+        available_addresses = [addr for addr, _ in addr_port_results]
+        available_ports = [port for _, port in addr_port_results]
 
         # Pool one IsolatedWorkerInitializer per unique pg_idx instead of one
         # per worker. All workers on a node share the same py_executable, so

--- a/tests/unit/distributed/test_virtual_cluster.py
+++ b/tests/unit/distributed/test_virtual_cluster.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import ray
 
+import nemo_rl.distributed.virtual_cluster as virtual_cluster
 from nemo_rl.distributed.virtual_cluster import (
     DEFAULT_MASTER_PORT_RANGE_HIGH,
     DEFAULT_MASTER_PORT_RANGE_LOW,
@@ -314,6 +315,101 @@ class TestGetFreePortLocal:
         }
         # With a range of 800 ports, 10 calls should very likely produce multiple unique ports
         assert len(ports) > 1
+
+
+class TestRayVirtualClusterBatchPorts:
+    """Tests for batched address and port discovery."""
+
+    class FakePortFinder:
+        def __init__(self):
+            self.refs = []
+
+        def options(self, **kwargs):
+            return self
+
+        def remote(self, port_range_low, port_range_high):
+            ref = f"ref-{len(self.refs)}"
+            self.refs.append((ref, port_range_low, port_range_high))
+            return ref
+
+    @staticmethod
+    def _make_cluster():
+        cluster = RayVirtualCluster(bundle_ct_per_node_list=[2, 1], use_gpus=False)
+        cluster._node_placement_groups = [
+            MagicMock(bundle_specs=[{"CPU": 1}]),
+            MagicMock(bundle_specs=[{"CPU": 1}]),
+        ]
+        return cluster
+
+    @staticmethod
+    def _patch_common_mocks(monkeypatch, port_finder, results_by_ref):
+        def fake_get(refs):
+            return [results_by_ref[ref] for ref in refs]
+
+        monkeypatch.setattr(virtual_cluster, "_get_node_ip_and_free_port", port_finder)
+        monkeypatch.setattr(
+            virtual_cluster,
+            "PlacementGroupSchedulingStrategy",
+            lambda **kwargs: kwargs,
+        )
+        monkeypatch.setattr(virtual_cluster.ray, "get", fake_get)
+
+    def test_default_batch_size_uses_ray_get_fast_path(self, monkeypatch):
+        cluster = self._make_cluster()
+        port_finder = self.FakePortFinder()
+        results_by_ref = {
+            "ref-0": ("node-a", 25001),
+            "ref-1": ("node-a", 25002),
+            "ref-2": ("node-b", 25003),
+        }
+        self._patch_common_mocks(monkeypatch, port_finder, results_by_ref)
+        wait_mock = MagicMock(
+            side_effect=AssertionError("fast path should not call ray.wait")
+        )
+        monkeypatch.setattr(virtual_cluster.ray, "wait", wait_mock)
+
+        results = cluster.get_available_addresses_and_ports_batch(
+            [(0, 0), (0, 1), (1, 0)]
+        )
+
+        assert results == [
+            ("node-a", 25001),
+            ("node-a", 25002),
+            ("node-b", 25003),
+        ]
+        assert wait_mock.call_count == 0
+
+    def test_preserves_input_order_when_refs_complete_out_of_order(self, monkeypatch):
+        cluster = self._make_cluster()
+        port_finder = self.FakePortFinder()
+        results_by_ref = {
+            "ref-0": ("node-a", 25001),
+            "ref-1": ("node-a", 25002),
+            "ref-2": ("node-b", 25003),
+        }
+
+        def fake_wait(remaining, num_returns):
+            ready = remaining[-num_returns:]
+            remaining = remaining[:-num_returns]
+            return ready, remaining
+
+        self._patch_common_mocks(monkeypatch, port_finder, results_by_ref)
+        monkeypatch.setattr(virtual_cluster.ray, "wait", fake_wait)
+
+        results = cluster.get_available_addresses_and_ports_batch(
+            [(0, 0), (0, 1), (1, 0)], batch_size=1
+        )
+
+        assert results == [
+            ("node-a", 25001),
+            ("node-a", 25002),
+            ("node-b", 25003),
+        ]
+        assert port_finder.refs == [
+            ("ref-0", cluster.port_range_low, cluster.port_range_high),
+            ("ref-1", cluster.port_range_low, cluster.port_range_high),
+            ("ref-2", cluster.port_range_low, cluster.port_range_high),
+        ]
 
 
 class TestRayVirtualClusterPortRange:

--- a/tests/unit/distributed/test_virtual_cluster.py
+++ b/tests/unit/distributed/test_virtual_cluster.py
@@ -20,7 +20,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 import ray
 
-import nemo_rl.distributed.virtual_cluster as virtual_cluster
 from nemo_rl.distributed.virtual_cluster import (
     DEFAULT_MASTER_PORT_RANGE_HIGH,
     DEFAULT_MASTER_PORT_RANGE_LOW,
@@ -315,101 +314,6 @@ class TestGetFreePortLocal:
         }
         # With a range of 800 ports, 10 calls should very likely produce multiple unique ports
         assert len(ports) > 1
-
-
-class TestRayVirtualClusterBatchPorts:
-    """Tests for batched address and port discovery."""
-
-    class FakePortFinder:
-        def __init__(self):
-            self.refs = []
-
-        def options(self, **kwargs):
-            return self
-
-        def remote(self, port_range_low, port_range_high):
-            ref = f"ref-{len(self.refs)}"
-            self.refs.append((ref, port_range_low, port_range_high))
-            return ref
-
-    @staticmethod
-    def _make_cluster():
-        cluster = RayVirtualCluster(bundle_ct_per_node_list=[2, 1], use_gpus=False)
-        cluster._node_placement_groups = [
-            MagicMock(bundle_specs=[{"CPU": 1}]),
-            MagicMock(bundle_specs=[{"CPU": 1}]),
-        ]
-        return cluster
-
-    @staticmethod
-    def _patch_common_mocks(monkeypatch, port_finder, results_by_ref):
-        def fake_get(refs):
-            return [results_by_ref[ref] for ref in refs]
-
-        monkeypatch.setattr(virtual_cluster, "_get_node_ip_and_free_port", port_finder)
-        monkeypatch.setattr(
-            virtual_cluster,
-            "PlacementGroupSchedulingStrategy",
-            lambda **kwargs: kwargs,
-        )
-        monkeypatch.setattr(virtual_cluster.ray, "get", fake_get)
-
-    def test_default_batch_size_uses_ray_get_fast_path(self, monkeypatch):
-        cluster = self._make_cluster()
-        port_finder = self.FakePortFinder()
-        results_by_ref = {
-            "ref-0": ("node-a", 25001),
-            "ref-1": ("node-a", 25002),
-            "ref-2": ("node-b", 25003),
-        }
-        self._patch_common_mocks(monkeypatch, port_finder, results_by_ref)
-        wait_mock = MagicMock(
-            side_effect=AssertionError("fast path should not call ray.wait")
-        )
-        monkeypatch.setattr(virtual_cluster.ray, "wait", wait_mock)
-
-        results = cluster.get_available_addresses_and_ports_batch(
-            [(0, 0), (0, 1), (1, 0)]
-        )
-
-        assert results == [
-            ("node-a", 25001),
-            ("node-a", 25002),
-            ("node-b", 25003),
-        ]
-        assert wait_mock.call_count == 0
-
-    def test_preserves_input_order_when_refs_complete_out_of_order(self, monkeypatch):
-        cluster = self._make_cluster()
-        port_finder = self.FakePortFinder()
-        results_by_ref = {
-            "ref-0": ("node-a", 25001),
-            "ref-1": ("node-a", 25002),
-            "ref-2": ("node-b", 25003),
-        }
-
-        def fake_wait(remaining, num_returns):
-            ready = remaining[-num_returns:]
-            remaining = remaining[:-num_returns]
-            return ready, remaining
-
-        self._patch_common_mocks(monkeypatch, port_finder, results_by_ref)
-        monkeypatch.setattr(virtual_cluster.ray, "wait", fake_wait)
-
-        results = cluster.get_available_addresses_and_ports_batch(
-            [(0, 0), (0, 1), (1, 0)], batch_size=1
-        )
-
-        assert results == [
-            ("node-a", 25001),
-            ("node-a", 25002),
-            ("node-b", 25003),
-        ]
-        assert port_finder.refs == [
-            ("ref-0", cluster.port_range_low, cluster.port_range_high),
-            ("ref-1", cluster.port_range_low, cluster.port_range_high),
-            ("ref-2", cluster.port_range_low, cluster.port_range_high),
-        ]
 
 
 class TestRayVirtualClusterPortRange:

--- a/tests/unit/distributed/test_virtual_cluster_batch_ports.py
+++ b/tests/unit/distributed/test_virtual_cluster_batch_ports.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest.mock import MagicMock
+
+import pytest
+
+import nemo_rl.distributed.virtual_cluster as virtual_cluster
+from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
+
+
+class TestRayVirtualClusterBatchPorts:
+    """Tests for batched address and port discovery."""
+
+    class FakePortFinder:
+        def __init__(self):
+            self.refs = []
+
+        def options(self, **kwargs):
+            return self
+
+        def remote(self, port_range_low, port_range_high):
+            ref = f"ref-{len(self.refs)}"
+            self.refs.append((ref, port_range_low, port_range_high))
+            return ref
+
+    @staticmethod
+    def _make_cluster():
+        cluster = RayVirtualCluster(bundle_ct_per_node_list=[2, 1], use_gpus=False)
+        cluster._node_placement_groups = [
+            MagicMock(bundle_specs=[{"CPU": 1}]),
+            MagicMock(bundle_specs=[{"CPU": 1}]),
+        ]
+        return cluster
+
+    @staticmethod
+    def _patch_common_mocks(monkeypatch, port_finder, results_by_ref):
+        def fake_get(refs):
+            return [results_by_ref[ref] for ref in refs]
+
+        ray_mock = MagicMock()
+        ray_mock.get.side_effect = fake_get
+        monkeypatch.setattr(virtual_cluster, "ray", ray_mock)
+        monkeypatch.setattr(virtual_cluster, "_get_node_ip_and_free_port", port_finder)
+        monkeypatch.setattr(
+            virtual_cluster,
+            "PlacementGroupSchedulingStrategy",
+            lambda **kwargs: kwargs,
+        )
+        return ray_mock
+
+    def test_get_available_address_and_port_delegates_to_batch(self):
+        cluster = self._make_cluster()
+        cluster.get_available_addresses_and_ports_batch = MagicMock(
+            return_value=[("node-a", 25001)]
+        )
+
+        result = cluster.get_available_address_and_port(1, 2)
+
+        assert result == ("node-a", 25001)
+        cluster.get_available_addresses_and_ports_batch.assert_called_once_with(
+            [(1, 2)]
+        )
+
+    def test_default_batch_size_uses_ray_get_fast_path(self, monkeypatch):
+        cluster = self._make_cluster()
+        port_finder = self.FakePortFinder()
+        results_by_ref = {
+            "ref-0": ("node-a", 25001),
+            "ref-1": ("node-a", 25002),
+            "ref-2": ("node-b", 25003),
+        }
+        ray_mock = self._patch_common_mocks(monkeypatch, port_finder, results_by_ref)
+        ray_mock.wait.side_effect = AssertionError("fast path should not call ray.wait")
+
+        results = cluster.get_available_addresses_and_ports_batch(
+            [(0, 0), (0, 1), (1, 0)]
+        )
+
+        assert results == [
+            ("node-a", 25001),
+            ("node-a", 25002),
+            ("node-b", 25003),
+        ]
+        ray_mock.wait.assert_not_called()
+
+    def test_single_placement_group_uses_each_bundle(self, monkeypatch):
+        cluster = self._make_cluster()
+        cluster._node_placement_groups = cluster._node_placement_groups[:1]
+        port_finder = self.FakePortFinder()
+        results_by_ref = {
+            "ref-0": ("node-a", 25001),
+            "ref-1": ("node-a", 25002),
+        }
+        self._patch_common_mocks(monkeypatch, port_finder, results_by_ref)
+
+        results = cluster.get_available_addresses_and_ports_batch([(0, 0), (0, 1)])
+
+        assert results == [("node-a", 25001), ("node-a", 25002)]
+
+    def test_raises_for_placement_group_without_bundles(self, monkeypatch):
+        cluster = self._make_cluster()
+        monkeypatch.setattr(
+            cluster,
+            "get_placement_groups",
+            lambda: [MagicMock(bundle_specs=[])],
+        )
+
+        with pytest.raises(RuntimeError, match="No valid placement groups"):
+            cluster.get_available_addresses_and_ports_batch([(0, 0)])
+
+    def test_preserves_input_order_when_refs_complete_out_of_order(self, monkeypatch):
+        cluster = self._make_cluster()
+        port_finder = self.FakePortFinder()
+        results_by_ref = {
+            "ref-0": ("node-a", 25001),
+            "ref-1": ("node-a", 25002),
+            "ref-2": ("node-b", 25003),
+        }
+
+        def fake_wait(remaining, num_returns):
+            ready = remaining[-num_returns:]
+            remaining = remaining[:-num_returns]
+            return ready, remaining
+
+        ray_mock = self._patch_common_mocks(monkeypatch, port_finder, results_by_ref)
+        ray_mock.wait.side_effect = fake_wait
+
+        results = cluster.get_available_addresses_and_ports_batch(
+            [(0, 0), (0, 1), (1, 0)], batch_size=1
+        )
+
+        assert results == [
+            ("node-a", 25001),
+            ("node-a", 25002),
+            ("node-b", 25003),
+        ]
+        assert port_finder.refs == [
+            ("ref-0", cluster.port_range_low, cluster.port_range_high),
+            ("ref-1", cluster.port_range_low, cluster.port_range_high),
+            ("ref-2", cluster.port_range_low, cluster.port_range_high),
+        ]


### PR DESCRIPTION
# What does this PR do ?

Submit per-bundle address/port probes together during RayWorkerGroup setup
instead of blocking on one ray.get call per worker.

Preserve worker ordering when collecting batched results and add unit coverage
for both the default ray.get fast path and the ray.wait batching path.

Part of commit: [487e01567405b0b8038391cdb45616f1ea64a228](https://gitlab-master.nvidia.com/terryk/nemo-rl-internal/-/commit/487e01567405b0b8038391cdb45616f1ea64a228)

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
