### PR TITLE
fix: serialize uv installs to avoid nvidia-cutlass-dsl install race

### DIFF
--- a/nemo_rl/utils/venvs.py
+++ b/nemo_rl/utils/venvs.py
@@ -87,6 +87,10 @@ def create_local_venv(
     #  context.
     #  https://docs.astral.sh/uv/concepts/projects/config/#project-environment-path
     env["UV_PROJECT_ENVIRONMENT"] = venv_path
+    # Serialize installs to avoid the nvidia-cutlass-dsl parallel-install race
+    # (its -libs-base / -libs-cu13 wheels ship overlapping files), which can
+    # corrupt the cutlass.cute import that vLLM's FA4/MLA path relies on.
+    env.setdefault("UV_CONCURRENT_INSTALLS", "1")
 
     # Split the py_executable into command and arguments
     exec_cmd = shlex.split(py_executable)

--- a/nemo_rl/utils/venvs.py
+++ b/nemo_rl/utils/venvs.py
@@ -87,10 +87,11 @@ def create_local_venv(
     #  context.
     #  https://docs.astral.sh/uv/concepts/projects/config/#project-environment-path
     env["UV_PROJECT_ENVIRONMENT"] = venv_path
-    # Serialize installs to avoid the nvidia-cutlass-dsl parallel-install race
-    # (its -libs-base / -libs-cu13 wheels ship overlapping files), which can
-    # corrupt the cutlass.cute import that vLLM's FA4/MLA path relies on.
-    env.setdefault("UV_CONCURRENT_INSTALLS", "1")
+    if force_rebuild:
+        # Serialize installs to avoid the nvidia-cutlass-dsl parallel-install race
+        # (its -libs-base / -libs-cu13 wheels ship overlapping files), which can
+        # corrupt the cutlass.cute import that vLLM's FA4/MLA path relies on.
+        env.setdefault("UV_CONCURRENT_INSTALLS", "1")
 
     # Split the py_executable into command and arguments
     exec_cmd = shlex.split(py_executable)


### PR DESCRIPTION
# What does this PR do ?

Serialize `uv` package installation during venv builds (`UV_CONCURRENT_INSTALLS=1`)
to avoid a parallel-install race that corrupts the `nvidia-cutlass-dsl` package and
crashes vLLM 0.20's FA4/CuTe-DSL MLA path (e.g. DeepSeek-V3 on GB200) on the first generation.

## TL;DR

DSV3 run on the GB200 cluster has been failing.
nvidia-cutlass-dsl requires both `nvidia-cutlass-dsl-libs-base` and `nvidia-cutlass-dsl-libs-cu13`. UV concurrent install makes race during installation (agent says both do writes to the same file (e.g, `lib/libcuda_dialect_runtime_static.a`)).
@terrykong, is there a better way than just serializing it? 


## Additional information (AI-generated)
Root cause. vLLM 0.20 selects the FA4 (CuTe-DSL) attention backend for MLA on
Blackwell, which lazily does import cutlass.cute. That pulls in
nvidia-cutlass-dsl (4.5.2), whose native libs are split across the
-libs-base and -libs-cu13 wheels -- both shipping overlapping files
(e.g. lib/libcuda_dialect_runtime_static.a). uv installs packages in parallel by
default, so the two wheels race on those shared files and leave a corrupt cutlass
install. import cutlass.cute then fails with a run-varying ImportError
(TmaTrait / increment_coord / VoteSyncKind / cvt_f4e2m1_f16_intrinsic),
killing the vLLM engine-core workers on the first rollout. Non-MLA models (e.g.
GQA Qwen3) never take this path and are unaffected.

Fix. Set UV_CONCURRENT_INSTALLS=1 for the venv build so the conflicting wheels
can't interleave-write their shared files. This only serializes the install/link
phase; downloads and source builds still run in parallel, so the build-time cost is
minimal.

Validation. grpo-deepseek-v3-32n4g previously crashed on the first generation
with the cutlass ImportError; with this change it completes 10/10 steps with zero
cutlass errors (validated across two independent runs).

Note. The corruption is an intermittent timing race that we could not reproduce in
isolation; serialization matches uv's documented remedy for the "install race
condition" warning it emits for these wheels. uv still prints that warning every build
(it's emitted at plan time regardless of concurrency)  -- the signal that matters is the
absence of the ImportError, not the warning.


# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
