### PR TITLE
fix(topology): exclude unknown-NVLink-domain nodes from segment selection

### DIFF
--- a/nemo_rl/distributed/virtual_cluster.py
+++ b/nemo_rl/distributed/virtual_cluster.py
@@ -417,6 +417,15 @@ def select_segment_nodes(
 
     domain_nodes: dict[str, list[tuple[str, int]]] = {}
     for nid, (domain, topo_rank) in topology.items():
+        # Skip nodes with no NVLink-domain info. They all collapse into a single
+        # NVLINK_DOMAIN_UNKNOWN pseudo-domain with TOPO_RANK_UNKNOWN (-1), so they
+        # would sort first and be selected — but the resulting placement-group
+        # constraint {NVLINK_DOMAIN_UNKNOWN: 0.001} names a Ray resource that
+        # ray.sub never registers, so the bundle can never schedule. Excluding
+        # them here means we only ever pin to real, registered NVLink domains
+        # (and these nodes fall through to remaining_node_ids).
+        if domain == NVLINK_DOMAIN_UNKNOWN:
+            continue
         domain_nodes.setdefault(domain, []).append((nid, topo_rank))
     for domain in domain_nodes:
         domain_nodes[domain].sort(key=lambda x: x[1])

--- a/tests/unit/distributed/test_topology_placement.py
+++ b/tests/unit/distributed/test_topology_placement.py
@@ -323,6 +323,35 @@ class TestSelectSegmentNodes:
         assert set(selected) | set(remaining) == set(topo.keys())
         assert len(set(selected) & set(remaining)) == 0  # no overlap
 
+    def test_unknown_domain_nodes_excluded_from_selection(self):
+        # Regression: nodes with no NVLink-domain info (UNKNOWN, topo_rank -1)
+        # must never be selected. They sort first (rank -1), so a naive selection
+        # would pick them and emit a {"unknown": 0.001} placement-group constraint
+        # that ray.sub never registers as a resource -> unschedulable bundle.
+        # This happens on heterogeneous / partial-probe clusters (e.g. a GPU-less
+        # or unprobed head node).
+        topo = _make_topology(
+            {
+                NVLINK_DOMAIN_UNKNOWN: [TOPO_RANK_UNKNOWN, TOPO_RANK_UNKNOWN],
+                "domain_A": [0, 1],
+                "domain_B": [2, 3],
+            }
+        )
+        selected, remaining = select_segment_nodes(topo, segment_size=2, num_nodes=4)
+        selected_domains = {topo[n][0] for n in selected}
+        assert NVLINK_DOMAIN_UNKNOWN not in selected_domains
+        assert selected_domains == {"domain_A", "domain_B"}
+        # The unknown nodes (e.g. a GPU-less head) fall through to remaining.
+        assert {topo[n][0] for n in remaining} == {NVLINK_DOMAIN_UNKNOWN}
+        assert set(selected) | set(remaining) == set(topo.keys())
+
+    def test_unknown_domain_only_raises_instead_of_unschedulable_pg(self):
+        # If every node is UNKNOWN there is no real domain to pin to, so we must
+        # raise rather than emit an unschedulable {"unknown": ...} constraint.
+        topo = _make_topology({NVLINK_DOMAIN_UNKNOWN: [TOPO_RANK_UNKNOWN] * 4})
+        with pytest.raises(ResourceInsufficientError, match="Cannot form"):
+            select_segment_nodes(topo, segment_size=2, num_nodes=4)
+
 
 # ---------------------------------------------------------------------------
 # 5. The 40-node / 5-domain scenario: training + inference placement


### PR DESCRIPTION
# What does this PR do?

Fixes a placement bug in `select_segment_nodes` (topology-aware NVLink-domain placement, from #2612). Nodes with no NVLink-domain info — e.g. a GPU-less or unprobed Ray head node — collapse into a single `NVLINK_DOMAIN_UNKNOWN` pseudo-domain with `topo_rank = -1`, so they sort first and get selected once there are >= `segment_size` of them. The resulting placement-group constraint `{"unknown": 0.001}` names a Ray resource that `ray.sub` never registers, so the bundle can never schedule (retry loop / hard failure on heterogeneous or partial-probe clusters).

The fix skips unknown-domain nodes when building the candidate set, so we only ever pin to real, registered NVLink domains; skipped nodes fall through to `remaining_node_ids`. No-op on a homogeneous all-GPU cluster.

## Testing

**Unit tests** — added regression tests in `tests/unit/distributed/test_topology_placement.py::TestSelectSegmentNodes`:
- `test_unknown_domain_nodes_excluded_from_selection` and `test_unknown_domain_only_raises_instead_of_unschedulable_pg` — both **fail on the pre-fix code, pass after**.
- Full file: **32 passed** on a GB200 node (HEAD `e2b6b2a2`).

**Functional `--segment` run on GB200** — confirms the fix does not regress topology-aware placement on real hardware. `grpo-llama3.2-1b-instruct-1n8g-megatron.yaml`, **2 nodes × 4 GPU, `cluster.segment_size=2`**, 5 steps:
- Topology-aware placement engaged: `✓ Topology-aware allocation: 2 training nodes in 1 NVLink domains (segment_size=2)`
- Reached **Step 5/5**, exited cleanly (`---EXIT:0---`), with no unschedulable-PG / `ResourceInsufficientError`.

(The unknown-domain case itself cannot occur on a clean homogeneous GB200 rack — it is covered by the unit tests; this functional run verifies no regression to the normal placement path.)

## Stack
Bottom of a stack — **#2613 (feat: Numa aware binding)** stacks on top of this.

## Before your PR is "Ready for review"
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests locally?

