### PR TITLE
docs: strengthen contributor review/style skill guidelines

### DIFF
--- a/.agents/contributor-skills/config-conventions/SKILL.md
+++ b/.agents/contributor-skills/config-conventions/SKILL.md
@@ -174,4 +174,35 @@ if "milestones" in scheduler_cfg:
     configure_milestones(scheduler_cfg["milestones"])
 ```
 
+## Avoid `dict[str, Any]` for Known-Field Config
+
+If a config block has a known set of fields, model it as a `BaseModel` (or, pre-migration, a `TypedDict`) —
+do not type it as `dict[str, Any]` and read keys with `.get(k, default)`. A bare `dict[str, Any]` both loses
+type-safety and pushes per-key defaults to the call site (the Forbidden Pattern above).
+
+If the block must also pass arbitrary keys through to another system, use `BaseModel(extra="allow")`: the known
+fields get types + centralized defaults, and unknown keys still come through (`model_extra`).
+
+**Don't:**
+```python
+class NonColocatedTeachersConfig(BaseModel, extra="allow"):
+    default_teacher_cfg: dict[str, Any] = Field(default_factory=dict)   # known fields hidden behind Any
+
+# ...so defaults end up scattered at the call site:
+tp = cfg.get("tensor_model_parallel_size", 1)
+precision = cfg.get("precision", "bf16")
+```
+
+**Do:**
+```python
+class TeacherResourceConfig(BaseModel, extra="allow"):  # extra="allow" keeps the passthrough escape hatch
+    tensor_model_parallel_size: int = 1
+    precision: str = "bf16"
+    micro_batch_size: int = 4
+    # ...
+
+class NonColocatedTeachersConfig(BaseModel, extra="allow"):
+    default_teacher_cfg: TeacherResourceConfig = Field(default_factory=TeacherResourceConfig)
+```
+
 See also: @docs/design-docs/design-and-philosophy.md (Configuration Schema: BaseModel, dataclass, and TypedDict section).

--- a/.agents/contributor-skills/error-handling/SKILL.md
+++ b/.agents/contributor-skills/error-handling/SKILL.md
@@ -25,3 +25,19 @@ try:
 except FileNotFoundError:
     print("Failed to open file")
 ```
+
+## Fail Loud, Not Silent
+
+When adding a config option or branch, ask: what does the worst plausible misconfiguration do? If it silently
+produces *wrong results* rather than an error, add a setup-time `assert`/`raise` so it fails loudly at startup
+instead of corrupting a run.
+
+**Examples of silent-wrong worth guarding:**
+- An advantage estimator that needs a real `prev_logprobs` while a loss flag zeroes it (advantage degrades to
+  garbage with no error).
+- An agent routed to a teacher alias that has no worker group (cryptic `KeyError` mid-run instead of a
+  setup-time check).
+- A backend/quantization setting silently ignored for a sub-component.
+
+Prefer failing at `setup()` time over a deep-in-the-loop crash; prefer a crash over silent garbage. If you
+truly can't validate, surface a logged warning rather than nothing.

--- a/.agents/contributor-skills/linting-and-formatting/SKILL.md
+++ b/.agents/contributor-skills/linting-and-formatting/SKILL.md
@@ -101,3 +101,22 @@ def make_complex(*args):
 def make_complex(x, y):
     return {'x': x, 'y': y}
 ```
+
+## Type Annotations
+
+Annotate new functions and methods — both parameters and return type. When you add a parameter to an
+existing signature, type it, and **match the type already used at the call site** (don't leave a new arg
+untyped while the caller already declares it, e.g. `def __init__(self, teacher_worker_groups=None)` when the
+caller passes `teacher_worker_groups: Optional[dict[str, Any]]`).
+
+When you add a new module under a type-checked area, **add it to `pyrefly.toml` `project-includes`**.
+`pyrefly` checks an explicit allow-list of files, so a new file that isn't listed silently escapes
+type-checking and its annotations are never verified.
+
+## Imports
+
+Put imports at module top. Defer an `import` into a function body ONLY to break a circular import or to avoid
+loading a heavy/optional dependency in a path that shouldn't need it — and when you do, add a one-line comment
+saying which. An in-function `import` with no such reason should move to the top. In particular, deferring
+stdlib (`concurrent.futures`, `collections`, …) or a module that is *already* imported at module top buys
+nothing — hoist it.

--- a/.agents/contributor-skills/review-pr/SKILL.md
+++ b/.agents/contributor-skills/review-pr/SKILL.md
@@ -100,6 +100,7 @@ After all subagents return: merge results and deduplicate (same file+line+issue 
 - Analyze the diff against all guideline skills
 - For each changed file, read surrounding context locally using `Read` and `Grep` to understand the change in context
 - Cross-reference existing review comments (PR mode only, from step 4) to avoid duplicating points already raised by other reviewers
+- Compare any new component to its nearest existing analog in the repo (a new worker group ↔ `lm_policy.py`, a new advantage estimator ↔ the existing estimators, a new config block ↔ `MasterConfig`) and flag missing affordances: backend dispatch, override hooks (e.g. `resolve_policy_worker_cls`), guards/validation, type annotations, return-shape consistency. "It works for the shipped recipe" is not enough if it silently diverges from the sibling's contract
 - Also apply any patterns from review memory files
 - Categorize findings:
   - **[BUG]** — Logic errors, null refs, race conditions, syntax errors

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,10 +31,12 @@ Use `/review-pr <pr-number>` for interactive local PR review.
 
 When reviewing code, follow these principles:
 
-- **Be concise and actionable.** Focus on bugs, logic errors, missing tests, outdated docs, and guideline violations.
-- **Do NOT flag:** style/formatting (linters handle it), minor naming suggestions, architectural opinions, or performance unless there is a clear measurable issue.
-- **High confidence only.** Only flag issues you are confident about. If unsure, skip it.
+- **Be concise and actionable.** Focus on bugs, logic errors, missing tests, outdated docs, and guideline violations. Lead with the issue, then a concrete suggested fix (name the file/function; give the snippet/schema when known).
+- **Do NOT flag:** style/formatting (linters handle it), minor naming suggestions, *subjective* architecture debates, or performance unless there is a clear measurable issue.
+- **DO flag concrete maintainability smells that have a clear fix** (these are not "architectural opinions"): side-channel/out-of-band state (e.g. setting an attribute the caller reads via `hasattr`), `dict[str, Any]` for known-field configs, inconsistent return types across siblings, and silent-on-misconfiguration paths. Raise them as low-severity suggestions.
+- **High confidence only — but verify the premise.** Only flag issues you are confident about; if unsure, skip it. When a finding hinges on how an external tool/API/env-var behaves, verify it against source/docs (with a permalink) before flagging — don't inflate confidence on an unverified premise.
 - **Verify upstream API usage.** When code calls into megatron-bridge, megatron-lm, automodel, or gym APIs, look up the actual API to verify correct usage. Evaluate each such call with scrutiny — don't assume the author got the signature, return type, or semantics right.
+- **Compare new components to their nearest internal analog.** A new worker group, estimator, or config block should mirror the established pattern (backend dispatch, override hooks, guards, typing, return shape) or justify diverging.
 - It is perfectly acceptable to have nothing to comment on. Say "LGTM" if so.
 
 ## Kubernetes / nrl-k8s


### PR DESCRIPTION
## What does this PR do?

Strengthens the contributor-facing review/style skills (`.agents/contributor-skills/`) and the Code Review section of `AGENTS.md`/`CLAUDE.md` with rules that recurred as manual review feedback during the PR #2780 (MOPD) review. The goal is for these to be caught by guidelines/CI rather than human back-and-forth.

## Changes

- **`linting-and-formatting`**
  - **Type annotations**: annotate new functions/methods (params + return); match the type already used at the call site.
  - **pyrefly**: add new modules to `pyrefly.toml` `project-includes` — `pyrefly` checks an allow-list, so unlisted new files silently escape type-checking.
  - **Imports**: imports at module top; defer into a function only to break a circular import or avoid a heavy/optional dependency, with a one-line comment saying why.
- **`config-conventions`**: don't type a known-field config as `dict[str, Any]` — model it as a `BaseModel` (use `extra="allow"` when arbitrary passthrough is needed). Complements the existing no-hidden-defaults rule.
- **`error-handling`**: *fail loud, not silent* — if the worst plausible misconfiguration of a new option/branch yields wrong results instead of an error, add a setup-time `assert`/`raise`.
- **`review-pr`** and **`AGENTS.md` (Code Review)**: compare a new component to its nearest internal analog (worker group ↔ `lm_policy.py`, estimator ↔ existing estimators, config ↔ `MasterConfig`) and flag missing affordances; recalibrate "don't flag architectural opinions" to still flag concrete maintainability smells (side-channels, `dict[str,Any]` configs, inconsistent return types, silent-on-misconfig); verify a finding's external-behavior premise before flagging.

Docs-only; no code changes.

## Usage

N/A — guideline/skill docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
