### PR TITLE
fix: fix flaky L1_Functional_Tests_Gym distillation_nemo_gym

### DIFF
--- a/tests/functional/distillation_nemo_gym.sh
+++ b/tests/functional/distillation_nemo_gym.sh
@@ -59,7 +59,7 @@ uv run coverage run -a --data-file=$PROJECT_ROOT/tests/.coverage --source=$PROJE
     cluster.gpus_per_node=2 \
     policy.dtensor_cfg.tensor_parallel_size=1 \
     policy.dtensor_cfg.context_parallel_size=2 \
-    policy.make_sequence_length_divisible_by=2 \
+    policy.make_sequence_length_divisible_by=4 \
     teacher.dtensor_cfg.tensor_parallel_size=2 \
     teacher.dtensor_cfg.context_parallel_size=1 \
     data.train.data_path=$TRAIN_PATH \


### PR DESCRIPTION
load balance CP needs `make_sequence_length_divisible_by=2*CP*TP`.
```
    policy.dtensor_cfg.tensor_parallel_size=1 \
    policy.dtensor_cfg.context_parallel_size=2 \
    policy.make_sequence_length_divisible_by=4 \  # previous is 2, fix it to 4.
```

fix flaky fail in:
1. https://github.com/NVIDIA-NeMo/RL/actions/runs/28112916550/job/83312372865?pr=2912
2. https://github.com/NVIDIA-NeMo/RL/actions/runs/28132580722/job/83325231817?pr=2898
3. https://github.com/NVIDIA-NeMo/RL/actions/runs/28163548298/job/83421101791?pr=2525

error log:
```
2026-06-25T11:42:41.5653554Z   File "/opt/ray_venvs/nemo_rl.models.policy.workers.dtensor_policy_worker_v2.DTensorPolicyWorkerV2/lib/python3.13/site-packages/torch/distributed/tensor/experimental/_context_parallel/_attention.py", line 1082, in _context_parallel_buffers
2026-06-25T11:42:41.5654553Z     load_balance_indices = load_balancer._generate_indices() if load_balancer else None
2026-06-25T11:42:41.5655104Z                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
2026-06-25T11:42:41.5655983Z   File "/opt/ray_venvs/nemo_rl.models.policy.workers.dtensor_policy_worker_v2.DTensorPolicyWorkerV2/lib/python3.13/site-packages/torch/distributed/tensor/experimental/_context_parallel/_load_balancer.py", line 148, in _generate_indices
2026-06-25T11:42:41.5656863Z     assert seq_length % (world_size * 2) == 0
```