### PR TITLE
fix(check_metrics): force console width to prevent CI log truncation

### DIFF
--- a/tests/check_metrics.py
+++ b/tests/check_metrics.py
@@ -208,8 +208,8 @@ def main():
     with open(args.json_file, "r") as f:
         data = json.load(f)
 
-    # Initialize rich console
-    console = Console()
+    # Initialize rich console — force wide output so CI logs never truncate columns.
+    console = Console(width=args.table_width or 300)
 
     table = Table(title="Metric Checks", min_width=220, width=args.table_width)
     table.add_column("Status", style="bold")


### PR DESCRIPTION
# What does this PR do ?

Force console width to 300 in check_metrics.py so CI log output is never truncated.

Rich defaults to terminal width (often 80–120 in CI), causing the Check column to wrap across continuation rows that nemo-ci's error extractor cannot reconstruct.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
