### PR TITLE
feat(algorithms): AReaL decoupled-PPO async training on the SingleController

### DIFF
--- a/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-2n4g-areal-single-controller.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-2n4g-areal-single-controller.yaml
@@ -1,0 +1,59 @@
+# AReaL decoupled-PPO end-to-end recipe on the SingleController path, sized for
+# the GB200 2n4g cluster (2 nodes x 4 GPUs = 8 GPUs total; non-colocated:
+# 1 node/4 GPUs vLLM async inference + 1 node/4 GPUs Megatron training, TP=1/PP=1).
+#
+# Built on the proven 2n4g async-1off non-colocated performance recipe, then
+# overlaid with the SingleController data plane + async-RL dispatch knobs and the
+# AReaL decoupled-PPO objective + interruptible-refit knob (AREAL.md §2, §6, §9 P5).
+# Mirrors grpo-llama3.1-8b-instruct-2n8g-areal-single-controller.yaml, retargeted
+# from 2n8g -> 2n4g. Launch with examples/run_grpo_areal.py (SingleControllerArealActor).
+#
+# Recipes under recipes/llm/ have no reference_configs entry (test_config_v2.py
+# globs only tests/unit/reference_configs/*.yaml), matching the SC convention.
+defaults: ./performance/grpo-llama3.1-8b-instruct-2n4g-async-1off.yaml
+
+logger:
+  log_dir: logs/grpo-llama3.1-8b-instruct-2n4g-areal-sc
+  wandb:
+    project: areal
+    name: grpo-llama3.1-8b-instruct-2n4g-areal-sc
+
+checkpointing:
+  checkpoint_dir: results/grpo-llama3.1-8b-instruct-2n4g-areal-sc
+
+# TransferQueue data plane is mandatory for the SingleController path.
+data_plane:
+  enabled: true
+
+# Keep M = num_minibatches = 1 for this smoke run: rl_step_samples
+# (num_prompts_per_step * num_generations_per_prompt = 64 * 32 = 2048) divided by
+# train_global_batch_size == 1. M>1 exercises the still-open LR-tick / throughput
+# deltas (AREAL.md §7.2/§7.6), out of scope for a "does it run end-to-end" test.
+# DP world = 4 train GPUs; 2048 % 4 == 0.
+policy:
+  train_global_batch_size: 2048
+
+# ── AReaL decoupled-PPO loss (AREAL.md §2b, §6) ──────────────────────────────
+# clip ratio = pi_theta / pi_prox (prev_logprobs := frozen pi_prox); NO KL term
+# (AReaL's KL is a reward penalty, math recipes set it 0); always-on pi_prox/pi_behav
+# importance-sampling reweight (the startup assert in single_controller_areal.py
+# requires use_importance_sampling_correction=true).
+loss_fn:
+  ratio_clip_min: 0.2
+  ratio_clip_max: 0.2
+  reference_policy_kl_penalty: 0.0
+  use_importance_sampling_correction: true
+
+# ── SingleController async-RL dispatch + AReaL refit knobs (AREAL.md §2a) ─────
+async_rl:
+  max_weight_staleness_versions: 1            # eta (matches async-1off max_trajectory_age_steps=1)
+  min_prompt_groups_per_batch: 64             # = grpo.num_prompts_per_step
+  batch_selection_strategy: staleness_window
+  max_inflight_prompts: ${grpo.num_prompts_per_step}
+  max_buffered_rollouts: 128                  # 64 * (eta + 1); controller re-derives + overrides anyway
+  over_sampling: false
+  force_in_order: true
+  # AReaL interruptible refit: after the weight swap, invalidate the KV cache with
+  # reset_running_requests=True so vLLM preempts in-flight requests and reprefills
+  # them under the new weights (P4).
+  refit_invalidate_kv_cache: true

--- a/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-2n4g-async-1off-single-controller.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-2n4g-async-1off-single-controller.yaml
@@ -1,0 +1,41 @@
+# SingleController variant of grpo-llama3.1-8b-instruct-2n4g-async-1off.yaml.
+# Same training topology (2 nodes x 4 GPUs, non-colocated) and async-1off
+# strategy; the SC path routes everything through the TransferQueue data plane
+# + SingleControllerActor. staleness_window + over_sampling=false replicate the
+# per-version dispatch quota of the original async-grpo path.
+defaults: ./performance/grpo-llama3.1-8b-instruct-2n4g-async-1off.yaml
+
+logger:
+  log_dir: logs/grpo-llama3.1-8b-instruct-2n4g-async-1off-sc
+  wandb:
+    project: areal
+    name: grpo-llama3.1-8b-instruct-2n4g-async-1off-sc
+
+checkpointing:
+  checkpoint_dir: results/grpo-llama3.1-8b-instruct-2n4g-async-1off-sc
+
+policy:
+  # The SC/AReaL controller asserts num_prompts_per_step * num_generations_per_prompt
+  # (64 * 32 = 2048) == train_global_batch_size, so each RL-step batch is one
+  # minibatch / one optimizer.step. The 2n4g base leaves train_global_batch_size at
+  # the grpo_math_1B default (512), so set it explicitly here. 2048 % dp_world(=4)==0.
+  train_global_batch_size: 2048
+
+# TransferQueue data plane is mandatory for the SingleController path.
+data_plane:
+  enabled: true
+
+# SC async-RL runtime knobs.
+async_rl:
+  # Matches grpo.async_grpo.max_trajectory_age_steps=1.
+  max_weight_staleness_versions: 1
+  # One training step consumes grpo.num_prompts_per_step (=64) prompt groups.
+  min_prompt_groups_per_batch: 64
+  batch_selection_strategy: staleness_window
+  max_inflight_prompts: ${grpo.num_prompts_per_step}  # match grpo-llama3.1-8b-instruct-2n4g-async-1off
+  # over_sampling=false requires
+  #   max_buffered_rollouts == target_prompt_groups_per_step * (max_weight_staleness_versions + 1)
+  #   64 * (1 + 1) = 128
+  max_buffered_rollouts: 128
+  over_sampling: false
+  force_in_order: true

--- a/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-2n8g-areal-single-controller.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-2n8g-areal-single-controller.yaml
@@ -50,10 +50,6 @@ loss_fn:
 
 # ── AReaL minibatch / refit knobs (AREAL.md §2a) ─────────────────────────────
 async_rl:
-  # == AReaL ppo_n_minibatches: split the full batch into this many minibatches,
-  # ONE optimizer step per minibatch (single pass, each sample used once).
-  # gsm8k uses 1, boba 4. num_minibatches=1 == one optimizer step per train step.
-  num_minibatches: 1
   # AReaL-style interruptible refit: after the weight swap, invalidate the KV
   # cache with reset_running_requests=True so vLLM preempts in-flight requests
   # and reprefills them under the new weights (P4). False keeps stale KV

--- a/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-2n8g-areal-single-controller.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-2n8g-areal-single-controller.yaml
@@ -1,0 +1,61 @@
+# AReaL decoupled-PPO exemplar on the SingleController path.
+#
+# Inherits the canonical SC async-1off recipe (same training topology, async
+# staleness-window dispatch, TransferQueue data plane) and overlays the AReaL
+# decoupled-PPO objective + minibatch / refit knobs (AREAL.md §2, §6).
+#
+# AReaL collapses onto existing NeMo-RL machinery (AREAL.md §0): pi_prox is the
+# frozen `prev_logprobs` snapshot, the decoupled loss is
+# ClippedPGLossFn(use_importance_sampling_correction=True,
+# reference_policy_kl_penalty=0). Only the controller loop is new (P1/P2/P4);
+# the loss needs no new code, just this config.
+#
+# NOTE: the two-phase train loop, minibatch split, and interruptible refit are
+# implemented incrementally (P1/P2/P4) on SingleControllerArealActor. At P0 the
+# controller behaves identically to the base SC controller (num_minibatches=1);
+# this recipe documents the target configuration.
+#
+# reference_configs coverage: tests/unit/test_config_v2.py globs only
+# tests/unit/reference_configs/*.yaml and resolves each to a REAL config by
+# basename at examples/configs/<basename> (top level) — it does NOT descend into
+# recipes/ subdirs. Every SingleController recipe under recipes/llm/ (this file
+# and its parent grpo-llama3.1-8b-instruct-2n8g-async-1off-single-controller.yaml)
+# therefore has no reference_configs entry, and adding one would BREAK the test
+# (the basename would resolve to a non-existent top-level real config). This
+# recipe is consistent with that convention; test_config_v2.py is green without
+# an entry (AREAL.md §9 P0).
+defaults: ./grpo-llama3.1-8b-instruct-2n8g-async-1off-single-controller.yaml
+
+logger:
+  log_dir: logs/grpo-llama3.1-8b-instruct-2n8g-areal-sc
+  wandb:
+    name: grpo-llama3.1-8b-instruct-2n8g-areal-sc
+
+checkpointing:
+  checkpoint_dir: results/grpo-llama3.1-8b-instruct-2n8g-areal-sc
+
+# ── AReaL decoupled-PPO loss (AREAL.md §2b, §6) ──────────────────────────────
+# Core mechanism: clip ratio = pi_theta / pi_prox  (prev_logprobs := frozen
+# pi_prox). The decoupled loss has NO KL term — AReaL's KL is a *reward* penalty
+# and its math recipes set it to 0. Staleness reweighting pi_prox / pi_behav is
+# the always-on importance-sampling correction.
+loss_fn:
+  ratio_clip_min: 0.2                          # eps clip (AReaL gsm8k eps_clip=0.4; tune)
+  ratio_clip_max: 0.2
+  reference_policy_kl_penalty: 0.0             # no KL term in the decoupled loss
+  use_importance_sampling_correction: true     # always-on pi_prox/pi_behav reweight
+  # Optional AReaL safety knob (behav_imp_weight_cap; recipe=5.0, default off):
+  # mask tokens whose IS weight exceeds the cap. Left off to match the paper;
+  # realize via NeMo's truncated-IS knob if desired (AREAL.md §6, §10).
+
+# ── AReaL minibatch / refit knobs (AREAL.md §2a) ─────────────────────────────
+async_rl:
+  # == AReaL ppo_n_minibatches: split the full batch into this many minibatches,
+  # ONE optimizer step per minibatch (single pass, each sample used once).
+  # gsm8k uses 1, boba 4. num_minibatches=1 == one optimizer step per train step.
+  num_minibatches: 1
+  # AReaL-style interruptible refit: after the weight swap, invalidate the KV
+  # cache with reset_running_requests=True so vLLM preempts in-flight requests
+  # and reprefills them under the new weights (P4). False keeps stale KV
+  # (Magistral-style, cheaper).
+  refit_invalidate_kv_cache: true

--- a/examples/nemo_gym/grpo_nanov3_8n8g.yaml
+++ b/examples/nemo_gym/grpo_nanov3_8n8g.yaml
@@ -1,0 +1,247 @@
+grpo:
+  num_prompts_per_step: 64
+  num_generations_per_prompt: 16
+  num_val_generations_per_prompt: 4
+  max_rollout_turns: 1
+  max_num_epochs: 1
+  max_num_steps: 1000000
+  normalize_rewards: true
+  use_leave_one_out_baseline: true
+  val_period: -1 # 5
+  val_at_start: false
+  val_at_end: false
+  overlong_filtering: true
+  max_val_samples: null
+  val_batch_size: 256
+  seed: 42
+  async_grpo:
+    enabled: true
+    max_trajectory_age_steps: 1
+  batch_multiplier: 1
+  use_dynamic_sampling: false
+  reward_shaping:
+    enabled: false
+  reward_scaling:
+    enabled: false
+  seq_logprob_error_threshold: 2
+  skip_reference_policy_logprobs_calculation: false
+loss_fn:
+  reference_policy_kl_penalty: 0
+  reference_policy_kl_type: k3
+  kl_input_clamp_value: 20.0
+  kl_output_clamp_value: 10.0
+  ratio_clip_min: 0.2
+  ratio_clip_max: 0.2
+  ratio_clip_c: null
+  use_on_policy_kl_approximation: false
+  use_importance_sampling_correction: true
+  sequence_level_importance_ratios: true
+  token_level_loss: false
+  truncated_importance_sampling_ratio: 3.0
+  truncated_importance_sampling_ratio_min: null
+  truncated_importance_sampling_type: tis
+  force_on_policy_ratio: false
+  use_kl_in_reward: false
+checkpointing:
+  enabled: false
+  checkpoint_dir: results/grpo
+  metric_name: val:total_reward/mean
+  higher_is_better: true
+  keep_top_k: 1000000
+  save_period: 10
+  checkpoint_must_save_by: 00:03:40:00
+  save_optimizer: true
+policy:
+  model_name: /lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_nemorl/users/rohitkumarj/data/nano-v3-12b-hf
+  tokenizer:
+    name: /lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_nemorl/users/rohitkumarj/data/nano-v3-12b-hf
+  train_global_batch_size: 1024
+  train_micro_batch_size: 1
+  generation_batch_size: 64
+  logprob_batch_size: 1
+  max_total_sequence_length: 49152
+  precision: bfloat16
+  logprob_chunk_size: 2048
+  dtensor_cfg:
+    _v2: true
+    enabled: false
+    cpu_offload: false
+    sequence_parallel: false
+    activation_checkpointing: false
+    tensor_parallel_size: 1
+    context_parallel_size: 1
+    custom_parallel_plan: null
+  megatron_cfg:
+    use_fused_weighted_squared_relu: false
+    enabled: true
+    empty_unused_memory_level: 1
+    activation_checkpointing: false
+    bias_activation_fusion: false
+    tensor_model_parallel_size: 2
+    expert_tensor_parallel_size: 1
+    expert_model_parallel_size: 8
+    pipeline_model_parallel_size: 2
+    num_layers_in_first_pipeline_stage: null
+    num_layers_in_last_pipeline_stage: null
+    context_parallel_size: 8
+    pipeline_dtype: bfloat16
+    sequence_parallel: true
+    freeze_moe_router: true
+    moe_router_dtype: fp32
+    moe_router_load_balancing_type: none
+    moe_router_bias_update_rate: 0.001
+    moe_permute_fusion: true
+    moe_enable_deepep: false
+    moe_token_dispatcher_type: alltoall
+    moe_aux_loss_coeff: 0.0
+    moe_router_enable_expert_bias: true
+    apply_rope_fusion: true
+    defer_fp32_logits: true
+    track_moe_metrics: true
+    moe_per_layer_logging: true
+    moe_shared_expert_overlap: false
+    gradient_accumulation_fusion: false
+    optimizer:
+      optimizer: adam
+      lr: 3.0e-06
+      min_lr: 3.0e-06
+      weight_decay: 0.0
+      bf16: true
+      fp16: false
+      params_dtype: float32
+      adam_beta1: 0.9
+      adam_beta2: 0.999
+      adam_eps: 1.0e-08
+      sgd_momentum: 0.9
+      clip_grad: 1.0
+      use_distributed_optimizer: true
+      use_precision_aware_optimizer: true
+      optimizer_cpu_offload: false
+      optimizer_offload_fraction: 0
+    scheduler:
+      start_weight_decay: 0.0
+      end_weight_decay: 0.0
+      weight_decay_incr_style: constant
+      lr_decay_style: constant
+      lr_decay_iters: null
+      lr_warmup_iters: 10
+      lr_warmup_init: 3.0e-07
+    distributed_data_parallel_config:
+      grad_reduce_in_fp32: false
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+      average_in_collective: false
+      use_custom_fsdp: false
+      data_parallel_sharding_strategy: optim_grads_params
+    env_vars: null
+  dynamic_batching:
+    enabled: false
+    train_mb_tokens: 49152
+    logprob_mb_tokens: 49152
+    sequence_length_round: 64
+  sequence_packing:
+    enabled: true
+    train_mb_tokens: 49152
+    logprob_mb_tokens: 49152
+    algorithm: modified_first_fit_decreasing
+    sequence_length_round: 64
+  make_sequence_length_divisible_by: 32
+  max_grad_norm: 1.0
+  optimizer: null
+  scheduler: null
+  offload_optimizer_for_logprob: false
+  generation:
+    backend: vllm
+    max_new_tokens: 49152
+    temperature: 1.0
+    top_p: 1.0
+    top_k: null
+    stop_token_ids: null
+    stop_strings: null
+    vllm_cfg:
+      async_engine: true
+      kv_cache_dtype: auto
+      precision: bfloat16
+      tensor_parallel_size: 4
+      pipeline_parallel_size: 1
+      expert_parallel_size: 1
+      gpu_memory_utilization: 0.5
+      max_model_len: 49152
+      enforce_eager: false
+      use_deep_gemm: false
+      num_last_layers_in_bf16: 0
+      num_first_layers_in_bf16: 0
+      expose_http_server: true
+      http_server_serving_chat_kwargs:
+        enable_auto_tools: true
+        tool_parser: qwen3_coder
+        reasoning_parser: deepseek_r1
+    vllm_kwargs:
+      mamba_ssm_cache_dtype: float32
+      compilation_config:
+        backend: eager
+    colocated:
+      enabled: false
+      resources:
+        gpus_per_node: 8
+        num_nodes: 4
+data:
+  max_input_seq_length: null
+  shuffle: false
+  num_workers: 1
+  use_multiple_dataloader: false
+  train:
+    data_path: /lustre/fsw/portfolios/coreai/users/haitianj/data/nanov3/train-split.jsonl
+  validation:
+    data_path: /lustre/fsw/portfolios/coreai/users/haitianj/data/nanov3/val-split.jsonl
+  default:
+    dataset_name: NemoGymDataset
+    env_name: nemo_gym
+    prompt_file: null
+    system_prompt_file: null
+    processor: nemo_gym_data_processor
+env:
+  should_use_nemo_gym: true
+  nemo_gym:
+    config_paths:
+    - responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
+    - resources_servers/math_with_judge/configs/math_with_judge.yaml
+    - resources_servers/code_gen/configs/code_gen.yaml
+    - resources_servers/workplace_assistant/configs/workplace_assistant.yaml
+    - resources_servers/mcqa/configs/mcqa.yaml
+    - resources_servers/instruction_following/configs/instruction_following.yaml
+    - resources_servers/structured_outputs/configs/structured_outputs_json.yaml
+    math_with_judge:
+      resources_servers:
+        math_with_judge:
+          judge_model_server:
+            name: policy_model
+          should_use_judge: false
+    code_gen:
+      resources_servers:
+        code_gen:
+          num_processes: 1024
+          unit_test_timeout_secs: 10
+          debug: false
+    skip_venv_if_present: true
+logger:
+  log_dir: logs
+  num_val_samples_to_print: 0
+  wandb_enabled: true
+  tensorboard_enabled: false
+  mlflow_enabled: false
+  monitor_gpus: true
+  swanlab_enabled: false
+  wandb:
+    project: grpo-dev
+    name: grpo-nanov3-32nodes-logger
+  tensorboard: {}
+  mlflow:
+    experiment_name: grpo-dev
+    run_name: grpo-dev-logger
+  gpu_monitoring:
+    collection_interval: 10
+    flush_interval: 10
+cluster:
+  gpus_per_node: 8
+  num_nodes: 8

--- a/examples/nemo_gym/grpo_nanov3_8n8g.yaml
+++ b/examples/nemo_gym/grpo_nanov3_8n8g.yaml
@@ -134,6 +134,12 @@ policy:
       use_custom_fsdp: false
       data_parallel_sharding_strategy: optim_grads_params
     env_vars: null
+  draft:
+    enabled: false
+    model_name: null
+    loss_weight: 0.1
+    num_layers: null
+    aux_layer_indices: null
   dynamic_batching:
     enabled: false
     train_mb_tokens: 49152
@@ -245,3 +251,22 @@ logger:
 cluster:
   gpus_per_node: 8
   num_nodes: 8
+
+data_plane:
+  enabled: true
+  impl: transfer_queue
+  backend: "simple"
+  storage_capacity: 1000000
+  num_storage_units: 2
+  claim_meta_poll_interval_s: 0.5
+  global_segment_size: 549755813888
+  local_buffer_size: 68719476736
+
+async_rl:
+  batch_selection_strategy: staleness_window
+  max_weight_staleness_versions: 1     # η — matches the legacy async_grpo.max_trajectory_age_steps: 1
+  max_inflight_prompts: 64             # = grpo.num_prompts_per_step
+  max_buffered_rollouts: 128           # 64 * (η+1); controller re-derives anyway
+  over_sampling: false
+  force_in_order: true
+  refit_invalidate_kv_cache: true      # AReaL interruptible refit

--- a/examples/nemo_gym/grpo_nanov3_8n8g.yaml
+++ b/examples/nemo_gym/grpo_nanov3_8n8g.yaml
@@ -16,7 +16,8 @@ grpo:
   seed: 42
   async_grpo:
     enabled: true
-    max_trajectory_age_steps: 1
+    max_trajectory_age_steps: 4
+    in_flight_weight_updates: true
   batch_multiplier: 1
   use_dynamic_sampling: false
   reward_shaping:
@@ -53,6 +54,7 @@ checkpointing:
   save_optimizer: true
 policy:
   model_name: /lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_nemorl/users/rohitkumarj/data/nano-v3-12b-hf
+  # model_name: Qwen/Qwen3-8B
   tokenizer:
     name: /lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_nemorl/users/rohitkumarj/data/nano-v3-12b-hf
   train_global_batch_size: 1024
@@ -83,7 +85,7 @@ policy:
     pipeline_model_parallel_size: 2
     num_layers_in_first_pipeline_stage: null
     num_layers_in_last_pipeline_stage: null
-    context_parallel_size: 8
+    context_parallel_size: 4
     pipeline_dtype: bfloat16
     sequence_parallel: true
     freeze_moe_router: true
@@ -184,13 +186,15 @@ policy:
         reasoning_parser: deepseek_r1
     vllm_kwargs:
       mamba_ssm_cache_dtype: float32
+      mamba_cache_mode: align
       compilation_config:
         backend: eager
+        cudagraph_mode: PIECEWISE
     colocated:
       enabled: false
       resources:
         gpus_per_node: 8
-        num_nodes: 4
+        num_nodes: 6
 data:
   max_input_seq_length: null
   shuffle: false
@@ -264,9 +268,12 @@ data_plane:
 
 async_rl:
   batch_selection_strategy: staleness_window
-  max_weight_staleness_versions: 1     # η — matches the legacy async_grpo.max_trajectory_age_steps: 1
-  max_inflight_prompts: 64             # = grpo.num_prompts_per_step
-  max_buffered_rollouts: 128           # 64 * (η+1); controller re-derives anyway
-  over_sampling: false
-  force_in_order: true
+  max_weight_staleness_versions: 4     # η — matches the legacy async_grpo.max_trajectory_age_steps: 1
+  max_inflight_prompts: 320             # = grpo.num_prompts_per_step
+  max_buffered_rollouts: 320           # floor = 64 * (η+1); with over_sampling values above the floor add failure/straggler headroom
+  over_sampling: true
+  # AReaL-native consumption (mixed-version, oldest-first) has no per-batch
+  # target_step — the controller raises if this is true.
+  force_in_order: false
   refit_invalidate_kv_cache: true      # AReaL interruptible refit
+  evict_stale_samples: false

--- a/examples/nemo_gym/launch_areal_nemo_gym_multinode_training.sh
+++ b/examples/nemo_gym/launch_areal_nemo_gym_multinode_training.sh
@@ -22,7 +22,7 @@
 # ----- PARAMETERS -----
 # WANDB_API_KEY, HF_TOKEN, EXP_NAME, NUM_ACTOR_NODES, NUM_SLURM_NODES (optional), REPO_LOCATION, CONTAINER_IMAGE_PATH, SLURM_ACCOUNT, SLURM_PARTITION
 
-REPO_LOCATION=/home/haitianj/repos/nemo-RL
+REPO_LOCATION=/lustre/fsw/portfolios/coreai/users/haitianj/repos/nemo-RL
 
 HF_HOME=/lustre/fsw/portfolios/coreai/users/haitianj/hf_cache
 EXP_NAME=${EXP_NAME:-grpo-nanov3-12B-8n8g-gym-areal}

--- a/examples/nemo_gym/launch_areal_nemo_gym_multinode_training.sh
+++ b/examples/nemo_gym/launch_areal_nemo_gym_multinode_training.sh
@@ -20,22 +20,31 @@
 # (8 nodes: 4 vLLM async generation + 4 megatron training).
 
 # ----- PARAMETERS -----
-# WANDB_API_KEY, HF_TOKEN, EXP_NAME, NUM_ACTOR_NODES, NUM_SLURM_NODES (optional), REPO_LOCATION, CONTAINER_IMAGE_PATH, SLURM_ACCOUNT, SLURM_PARTITION
+# WANDB_API_KEY, HF_TOKEN, EXP_NAME, NUM_ACTOR_NODES, NUM_SLURM_NODES (optional), TRAINING_SCRIPT, REPO_LOCATION, CONTAINER_IMAGE_PATH, SLURM_ACCOUNT, SLURM_PARTITION
 
-REPO_LOCATION=/lustre/fsw/portfolios/coreai/users/haitianj/repos/nemo-RL
 
-HF_HOME=/lustre/fsw/portfolios/coreai/users/haitianj/hf_cache
 EXP_NAME=${EXP_NAME:-grpo-nanov3-12B-8n8g-gym-areal}
-NUM_ACTOR_NODES=8
-NUM_SLURM_NODES=8
+NUM_ACTOR_NODES=${NUM_ACTOR_NODES:-8}
+NUM_SLURM_NODES=${NUM_SLURM_NODES:-8}
+TRAINING_SCRIPT=${TRAINING_SCRIPT:-examples/run_grpo_areal.py}
+REPO_LOCATION=${REPO_LOCATION:-/lustre/fsw/portfolios/coreai/users/haitianj/repos/nemo-RL-areal}
 CONTAINER_IMAGE_PATH=/lustre/fsw/portfolios/coreai/users/yukih/enroot-images/nvcr.io/nvidian/nemo-rl:29fc948-55351550.squashfs
 SLURM_ACCOUNT=coreai_dlalgo_nemorl
 SLURM_PARTITION=batch
 # Checkpoints are large (12B Megatron + optimizer state); keep them on lustre, not $HOME.
 # (SC-path checkpointing is not wired yet; the override is inert until it is.)
-CHECKPOINT_DIR=/lustre/fsw/portfolios/coreai/users/haitianj/results/$EXP_NAME
+LUSTRE_USER_DIR=/lustre/fsw/portfolios/coreai/users/haitianj
+CHECKPOINT_DIR=$LUSTRE_USER_DIR/results/$EXP_NAME
+UV_CACHE_DIR_OVERRIDE=$LUSTRE_USER_DIR/uv_cache
+HF_HOME=$LUSTRE_USER_DIR/hf_cache
 # policy.model_name / policy.tokenizer.name in the config live under this path,
 # which is outside the default mounts.
+NEMO_GYM_VENV_DIR=$LUSTRE_USER_DIR/gym_venvs
+# Training data dumps (train_data_step*.jsonl, hundreds of MB per step),
+# W&B local files (wandb.init(dir=log_dir)), and GPU monitoring logs.
+RESULTS_DIR=$LUSTRE_USER_DIR/results/$EXP_NAME
+# ray-driver/head/worker logs (ray.sub BASE_LOG_DIR) and sbatch stdout.
+RUN_LOGS_DIR=$LUSTRE_USER_DIR/run-logs
 MODEL_DIR=/lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_nemorl/users/rohitkumarj/data/nano-v3-12b-hf
 
 
@@ -47,15 +56,15 @@ read -r -d '' COMMAND <<EOF
 cd ${REPO_LOCATION}
 
 HF_HOME=$HF_HOME \
-HF_TOKEN=$HF_TOKEN \
-WANDB_API_KEY=$WANDB_API_KEY \
-NEMO_GYM_VENV_DIR=/lustre/fsw/portfolios/coreai/users/haitianj/gym_venvs \
+HF_TOKEN=\$HF_TOKEN \
+WANDB_API_KEY=\$WANDB_API_KEY \
+NEMO_GYM_VENV_DIR=$NEMO_GYM_VENV_DIR \
 NRL_TQ_SKIP_ACTOR_RUNTIME_ENV=1 \
-uv run python examples/run_grpo_areal.py \
+uv run python $TRAINING_SCRIPT \
     --config examples/nemo_gym/grpo_nanov3_8n8g.yaml \
     ++cluster.num_nodes=$NUM_ACTOR_NODES \
     ++logger.wandb.name=$EXP_NAME \
-    ++logger.log_dir=results/$EXP_NAME \
+    ++logger.log_dir=$RESULTS_DIR/logs \
     ++checkpointing.checkpoint_dir=$CHECKPOINT_DIR \
     ++logger.wandb_enabled=True \
     ++logger.wandb.project=areal \
@@ -72,12 +81,19 @@ FINAL_NUM_SLURM_NODES="${NUM_SLURM_NODES:-$NUM_ACTOR_NODES}"
 # TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD: torch>=2.6 DCP load of our own trusted megatron
 # shards fails under weights_only=True (belt and suspenders with the monkeypatch in
 # nemo_rl/__init__.py).
+# REPO_LOCATION (/lustre/fsw/...) is a symlink alias of the /lustre/fs1/...
+# physical path; sbatch records the job cwd as the RESOLVED physical path, so
+# pyxis chdir fails inside the container unless the physical path is mounted too.
+REPO_PHYSICAL=$(readlink -f "$REPO_LOCATION")
+
 COMMAND=$COMMAND \
 CONTAINER=$CONTAINER_IMAGE_PATH \
-MOUNTS="$REPO_LOCATION:$REPO_LOCATION,/lustre/fsw/portfolios/coreai/users/haitianj:/lustre/fsw/portfolios/coreai/users/haitianj,$MODEL_DIR:$MODEL_DIR" \
+MOUNTS="$REPO_LOCATION:$REPO_LOCATION,$REPO_PHYSICAL:$REPO_PHYSICAL,$LUSTRE_USER_DIR:$LUSTRE_USER_DIR,$MODEL_DIR:$MODEL_DIR" \
+BASE_LOG_DIR=$RUN_LOGS_DIR \
 NRL_IGNORE_VERSION_MISMATCH=1 \
 TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 \
 HF_HOME=$HF_HOME \
+UV_CACHE_DIR_OVERRIDE=$UV_CACHE_DIR_OVERRIDE \
 sbatch \
     --nodes=$FINAL_NUM_SLURM_NODES \
     --account=$SLURM_ACCOUNT \
@@ -85,4 +101,6 @@ sbatch \
     --time=4:0:0 \
     --job-name=$EXP_NAME \
     --gres=gpu:8 \
+    --output=$RUN_LOGS_DIR/slurm-%j.out \
+    --error=$RUN_LOGS_DIR/slurm-%j.out \
     ray.sub

--- a/examples/nemo_gym/launch_areal_nemo_gym_multinode_training.sh
+++ b/examples/nemo_gym/launch_areal_nemo_gym_multinode_training.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,37 +13,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# AReaL variant of launch_nemo_gym_multinode_training.sh: same Slurm/ray.sub
+# flow, but the entrypoint is examples/run_grpo_areal.py
+# (SingleControllerArealActor: two-phase decoupled-PPO + interruptible refit)
+# with the SC/AReaL config examples/nemo_gym/grpo_nanov3_8n8g.yaml
+# (8 nodes: 4 vLLM async generation + 4 megatron training).
 
 # ----- PARAMETERS -----
+# WANDB_API_KEY, HF_TOKEN, EXP_NAME, NUM_ACTOR_NODES, NUM_SLURM_NODES (optional), REPO_LOCATION, CONTAINER_IMAGE_PATH, SLURM_ACCOUNT, SLURM_PARTITION
 
-EXP_NAME=${EXP_NAME:-grpo-nanov3-12B-8n8g-async-gym}
-NUM_ACTOR_NODES=${NUM_ACTOR_NODES:-8}
-NUM_SLURM_NODES=${NUM_SLURM_NODES:-8}
 REPO_LOCATION=/home/haitianj/repos/nemo-RL
+
+HF_HOME=/lustre/fsw/portfolios/coreai/users/haitianj/hf_cache
+EXP_NAME=${EXP_NAME:-grpo-nanov3-12B-8n8g-gym-areal}
+NUM_ACTOR_NODES=8
+NUM_SLURM_NODES=8
 CONTAINER_IMAGE_PATH=/lustre/fsw/portfolios/coreai/users/yukih/enroot-images/nvcr.io/nvidian/nemo-rl:29fc948-55351550.squashfs
 SLURM_ACCOUNT=coreai_dlalgo_nemorl
 SLURM_PARTITION=batch
-
-# Lustre locations (everything the job writes at runtime).
-LUSTRE_USER_DIR=/lustre/fsw/portfolios/coreai/users/haitianj
-CHECKPOINT_DIR=$LUSTRE_USER_DIR/results/$EXP_NAME
-UV_CACHE_DIR_OVERRIDE=$LUSTRE_USER_DIR/uv_cache
-HF_HOME=$LUSTRE_USER_DIR/hf_cache
-# Shared gym server venvs: must be on a filesystem visible from every node,
-# because code_gen's unit-test Ray tasks (SPREAD + py_executable) start
-# workers with this venv's python on arbitrary nodes. Pre-built serially —
-# see repair_gym_venvs.sh on lustre (parallel setup on lustre corrupts venvs).
-NEMO_GYM_VENV_DIR=$LUSTRE_USER_DIR/gym_venvs
-# Training data dumps (train_data_step*.jsonl, hundreds of MB per step),
-# W&B local files (wandb.init(dir=log_dir)), and GPU monitoring logs.
-RESULTS_DIR=$LUSTRE_USER_DIR/results/$EXP_NAME
-# ray-driver/head/worker logs (ray.sub BASE_LOG_DIR) and sbatch stdout.
-RUN_LOGS_DIR=$LUSTRE_USER_DIR/run-logs
-# policy.model_name / policy.tokenizer.name in the config live here, outside
-# the default mounts.
+# Checkpoints are large (12B Megatron + optimizer state); keep them on lustre, not $HOME.
+# (SC-path checkpointing is not wired yet; the override is inert until it is.)
+CHECKPOINT_DIR=/lustre/fsw/portfolios/coreai/users/haitianj/results/$EXP_NAME
+# policy.model_name / policy.tokenizer.name in the config live under this path,
+# which is outside the default mounts.
 MODEL_DIR=/lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_nemorl/users/rohitkumarj/data/nano-v3-12b-hf
 
-mkdir -p "$RUN_LOGS_DIR"
 
 # ray.sub needs to be launched from the NeMo-RL root directory
 cd $REPO_LOCATION
@@ -55,13 +49,14 @@ cd ${REPO_LOCATION}
 HF_HOME=$HF_HOME \
 HF_TOKEN=$HF_TOKEN \
 WANDB_API_KEY=$WANDB_API_KEY \
-NEMO_GYM_VENV_DIR=$NEMO_GYM_VENV_DIR \
-uv run python examples/nemo_gym/run_grpo_nemo_gym.py \
+NEMO_GYM_VENV_DIR=/lustre/fsw/portfolios/coreai/users/haitianj/gym_venvs \
+NRL_TQ_SKIP_ACTOR_RUNTIME_ENV=1 \
+uv run python examples/run_grpo_areal.py \
     --config examples/nemo_gym/grpo_nanov3_8n8g.yaml \
     ++cluster.num_nodes=$NUM_ACTOR_NODES \
     ++logger.wandb.name=$EXP_NAME \
-    ++logger.log_dir=$RESULTS_DIR/logs \
-    ++checkpointing.checkpoint_dir=$RESULTS_DIR \
+    ++logger.log_dir=results/$EXP_NAME \
+    ++checkpointing.checkpoint_dir=$CHECKPOINT_DIR \
     ++logger.wandb_enabled=True \
     ++logger.wandb.project=areal \
     ++logger.wandb.entity=joc \
@@ -77,16 +72,12 @@ FINAL_NUM_SLURM_NODES="${NUM_SLURM_NODES:-$NUM_ACTOR_NODES}"
 # TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD: torch>=2.6 DCP load of our own trusted megatron
 # shards fails under weights_only=True (belt and suspenders with the monkeypatch in
 # nemo_rl/__init__.py).
-# BASE_LOG_DIR + --output/--error: ray and slurm logs go to lustre; ray.sub uses
-# set -e, so an unwritable stdout kills the job within seconds.
 COMMAND=$COMMAND \
 CONTAINER=$CONTAINER_IMAGE_PATH \
-MOUNTS="$REPO_LOCATION:$REPO_LOCATION,$LUSTRE_USER_DIR:$LUSTRE_USER_DIR,$MODEL_DIR:$MODEL_DIR" \
-BASE_LOG_DIR=$RUN_LOGS_DIR \
+MOUNTS="$REPO_LOCATION:$REPO_LOCATION,/lustre/fsw/portfolios/coreai/users/haitianj:/lustre/fsw/portfolios/coreai/users/haitianj,$MODEL_DIR:$MODEL_DIR" \
 NRL_IGNORE_VERSION_MISMATCH=1 \
 TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 \
 HF_HOME=$HF_HOME \
-UV_CACHE_DIR_OVERRIDE=$UV_CACHE_DIR_OVERRIDE \
 sbatch \
     --nodes=$FINAL_NUM_SLURM_NODES \
     --account=$SLURM_ACCOUNT \
@@ -94,6 +85,4 @@ sbatch \
     --time=4:0:0 \
     --job-name=$EXP_NAME \
     --gres=gpu:8 \
-    --output=$RUN_LOGS_DIR/slurm-%j.out \
-    --error=$RUN_LOGS_DIR/slurm-%j.out \
     ray.sub

--- a/examples/nemo_gym/launch_nemo_gym_multinode_training_lustre.sh
+++ b/examples/nemo_gym/launch_nemo_gym_multinode_training_lustre.sh
@@ -19,7 +19,7 @@
 EXP_NAME=${EXP_NAME:-grpo-nanov3-12B-8n8g-async-gym}
 NUM_ACTOR_NODES=${NUM_ACTOR_NODES:-8}
 NUM_SLURM_NODES=${NUM_SLURM_NODES:-8}
-REPO_LOCATION=/home/haitianj/repos/nemo-RL
+REPO_LOCATION=/lustre/fsw/portfolios/coreai/users/haitianj/repos/nemo-RL
 CONTAINER_IMAGE_PATH=/lustre/fsw/portfolios/coreai/users/yukih/enroot-images/nvcr.io/nvidian/nemo-rl:29fc948-55351550.squashfs
 SLURM_ACCOUNT=coreai_dlalgo_nemorl
 SLURM_PARTITION=batch

--- a/examples/nemo_gym/launch_nemo_gym_multinode_training_lustre.sh
+++ b/examples/nemo_gym/launch_nemo_gym_multinode_training_lustre.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# ----- PARAMETERS -----
+
+EXP_NAME=grpo-nanov3-12B-8n8g-async-gym
+NUM_ACTOR_NODES=8
+NUM_SLURM_NODES=8
+REPO_LOCATION=/home/haitianj/repos/nemo-RL
+CONTAINER_IMAGE_PATH=/lustre/fsw/portfolios/coreai/users/yukih/enroot-images/nvcr.io/nvidian/nemo-rl:29fc948-55351550.squashfs
+SLURM_ACCOUNT=coreai_dlalgo_nemorl
+SLURM_PARTITION=batch
+
+# Lustre locations (everything the job writes at runtime).
+LUSTRE_USER_DIR=/lustre/fsw/portfolios/coreai/users/haitianj
+CHECKPOINT_DIR=$LUSTRE_USER_DIR/results/$EXP_NAME
+UV_CACHE_DIR_OVERRIDE=$LUSTRE_USER_DIR/uv_cache
+HF_HOME=$LUSTRE_USER_DIR/hf_cache
+# Shared gym server venvs: must be on a filesystem visible from every node,
+# because code_gen's unit-test Ray tasks (SPREAD + py_executable) start
+# workers with this venv's python on arbitrary nodes. Pre-built serially —
+# see repair_gym_venvs.sh on lustre (parallel setup on lustre corrupts venvs).
+NEMO_GYM_VENV_DIR=$LUSTRE_USER_DIR/gym_venvs
+# Training data dumps (train_data_step*.jsonl, hundreds of MB per step),
+# W&B local files (wandb.init(dir=log_dir)), and GPU monitoring logs.
+RESULTS_DIR=$LUSTRE_USER_DIR/results/$EXP_NAME
+# ray-driver/head/worker logs (ray.sub BASE_LOG_DIR) and sbatch stdout.
+RUN_LOGS_DIR=$LUSTRE_USER_DIR/run-logs
+# policy.model_name / policy.tokenizer.name in the config live here, outside
+# the default mounts.
+MODEL_DIR=/lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_nemorl/users/rohitkumarj/data/nano-v3-12b-hf
+
+mkdir -p "$RUN_LOGS_DIR"
+
+# ray.sub needs to be launched from the NeMo-RL root directory
+cd $REPO_LOCATION
+
+# Construct the command
+read -r -d '' COMMAND <<EOF
+cd ${REPO_LOCATION}
+
+HF_HOME=$HF_HOME \
+HF_TOKEN=$HF_TOKEN \
+WANDB_API_KEY=$WANDB_API_KEY \
+NEMO_GYM_VENV_DIR=$NEMO_GYM_VENV_DIR \
+uv run python examples/nemo_gym/run_grpo_nemo_gym.py \
+    --config examples/nemo_gym/rohit_nanov3.yaml \
+    ++cluster.num_nodes=$NUM_ACTOR_NODES \
+    ++logger.wandb.name=$EXP_NAME \
+    ++logger.log_dir=$RESULTS_DIR/logs \
+    ++checkpointing.checkpoint_dir=$RESULTS_DIR \
+    ++logger.wandb_enabled=True \
+    ++logger.wandb.project=areal \
+    ++logger.wandb.entity=joc \
+    $@
+EOF
+
+echo -e "Running command:\n$COMMAND"
+
+FINAL_NUM_SLURM_NODES="${NUM_SLURM_NODES:-$NUM_ACTOR_NODES}"
+
+# NRL_IGNORE_VERSION_MISMATCH: mounted dev repo vs baked container pyproject/uv.lock
+# drift is a fatal RuntimeError otherwise.
+# TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD: torch>=2.6 DCP load of our own trusted megatron
+# shards fails under weights_only=True (belt and suspenders with the monkeypatch in
+# nemo_rl/__init__.py).
+# BASE_LOG_DIR + --output/--error: ray and slurm logs go to lustre; ray.sub uses
+# set -e, so an unwritable stdout kills the job within seconds.
+COMMAND=$COMMAND \
+CONTAINER=$CONTAINER_IMAGE_PATH \
+MOUNTS="$REPO_LOCATION:$REPO_LOCATION,$LUSTRE_USER_DIR:$LUSTRE_USER_DIR,$MODEL_DIR:$MODEL_DIR" \
+BASE_LOG_DIR=$RUN_LOGS_DIR \
+NRL_IGNORE_VERSION_MISMATCH=1 \
+TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 \
+HF_HOME=$HF_HOME \
+UV_CACHE_DIR_OVERRIDE=$UV_CACHE_DIR_OVERRIDE \
+sbatch \
+    --nodes=$FINAL_NUM_SLURM_NODES \
+    --account=$SLURM_ACCOUNT \
+    --partition=$SLURM_PARTITION \
+    --time=4:0:0 \
+    --job-name=$EXP_NAME \
+    --gres=gpu:8 \
+    --output=$RUN_LOGS_DIR/slurm-%j.out \
+    --error=$RUN_LOGS_DIR/slurm-%j.out \
+    ray.sub

--- a/examples/run_grpo_areal.py
+++ b/examples/run_grpo_areal.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AReaL decoupled-PPO GRPO launcher driven by SingleControllerArealActor.
+
+Identical wiring to run_grpo_single_controller.py (same config loading,
+setup_single_controller bundle, data_plane.enabled=true requirement); it only
+swaps the orchestrator to SingleControllerArealActor, which runs the AReaL
+two-phase decoupled-PPO train loop + interruptible refit (AREAL.md §9 P0-P4).
+Pair it with an AReaL recipe (use_importance_sampling_correction=true, the
+startup assert in single_controller_areal.py requires it).
+"""
+
+import argparse
+import os
+import pprint
+
+import ray
+from omegaconf import OmegaConf
+
+from nemo_rl.algorithms.single_controller_areal import SingleControllerArealActor
+from nemo_rl.algorithms.single_controller_utils import (
+    MasterConfig,
+    setup_single_controller,
+)
+from nemo_rl.algorithms.utils import get_tokenizer
+from nemo_rl.distributed.virtual_cluster import init_ray
+from nemo_rl.models.generation import configure_generation_config
+from nemo_rl.utils.config import (
+    load_config,
+    parse_hydra_overrides,
+    register_omegaconf_resolvers,
+)
+from nemo_rl.utils.logger import get_next_experiment_dir
+
+
+def parse_args() -> tuple[argparse.Namespace, list[str]]:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Run AReaL decoupled-PPO GRPO training via SingleControllerArealActor"
+    )
+    parser.add_argument(
+        "--config", type=str, default=None, help="Path to YAML config file"
+    )
+    args, overrides = parser.parse_known_args()
+    return args, overrides
+
+
+def main() -> None:
+    """Main entry point."""
+    register_omegaconf_resolvers()
+    args, overrides = parse_args()
+
+    if not args.config:
+        args.config = os.path.join(
+            os.path.dirname(__file__),
+            "configs",
+            "recipes",
+            "llm",
+            "grpo-llama3.1-8b-instruct-2n4g-areal-single-controller.yaml",
+        )
+
+    config = load_config(args.config)
+    print(f"Loaded configuration from: {args.config}")
+
+    if overrides:
+        print(f"Overrides: {overrides}")
+        config = parse_hydra_overrides(config, overrides)
+
+    config = OmegaConf.to_container(config, resolve=True)
+    config = MasterConfig(**config)
+    print("Applied CLI overrides")
+
+    dp_cfg = config.data_plane
+    if not dp_cfg.get("enabled", False):
+        raise ValueError(
+            "run_grpo_areal requires data_plane.enabled=true. "
+            "Use examples/run_grpo.py for the legacy / sync paths."
+        )
+
+    print("Final config:")
+    pprint.pprint(config)
+
+    config.logger["log_dir"] = get_next_experiment_dir(config.logger["log_dir"])
+    print(f"📊 Using log directory: {config.logger['log_dir']}")
+    if config.checkpointing["enabled"]:
+        print(
+            f"📊 Using checkpoint directory: {config.checkpointing['checkpoint_dir']}"
+        )
+
+    init_ray()
+
+    tokenizer = get_tokenizer(config.policy["tokenizer"])
+    assert config.policy["generation"] is not None, (
+        "A generation config is required for SC-driven AReaL GRPO"
+    )
+    has_refit_draft_weights = bool(config.policy["draft"]["enabled"])
+    config.policy["generation"] = configure_generation_config(
+        config.policy["generation"],
+        tokenizer,
+        has_refit_draft_weights=has_refit_draft_weights,
+    )
+
+    bundle = setup_single_controller(config, tokenizer)
+
+    print("🚀 Launching SingleControllerArealActor")
+    sc = SingleControllerArealActor.remote(master_config=config, bundle=bundle)
+    result = ray.get(sc.run.remote())
+    print(f"AReaL SC run complete: {result}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/run_grpo_areal.py
+++ b/examples/run_grpo_areal.py
@@ -15,8 +15,9 @@
 """AReaL decoupled-PPO GRPO launcher driven by SingleControllerArealActor.
 
 Identical wiring to run_grpo_single_controller.py (same config loading,
-setup_single_controller bundle, data_plane.enabled=true requirement); it only
-swaps the orchestrator to SingleControllerArealActor, which runs the AReaL
+setup_single_controller bundle, data_plane.enabled=true requirement,
+NeMo-Gym support via env.should_use_nemo_gym); it only swaps the
+orchestrator to SingleControllerArealActor, which runs the AReaL
 two-phase decoupled-PPO train loop + interruptible refit (AREAL.md §9 P0-P4).
 Pair it with an AReaL recipe (use_importance_sampling_correction=true, the
 startup assert in single_controller_areal.py requires it).
@@ -25,6 +26,7 @@ startup assert in single_controller_areal.py requires it).
 import argparse
 import os
 import pprint
+import sys
 
 import ray
 from omegaconf import OmegaConf
@@ -36,6 +38,7 @@ from nemo_rl.algorithms.single_controller_utils import (
 )
 from nemo_rl.algorithms.utils import get_tokenizer
 from nemo_rl.distributed.virtual_cluster import init_ray
+from nemo_rl.environments.nemo_gym import setup_nemo_gym_config
 from nemo_rl.models.generation import configure_generation_config
 from nemo_rl.utils.config import (
     load_config,
@@ -43,6 +46,12 @@ from nemo_rl.utils.config import (
     register_omegaconf_resolvers,
 )
 from nemo_rl.utils.logger import get_next_experiment_dir
+
+# Drop examples/ from sys.path so examples/nemo_gym/ (no __init__.py) doesn't
+# shadow the real nemo_gym package as a namespace package.
+current_dir = os.path.dirname(os.path.abspath(__file__))
+while current_dir in sys.path:
+    sys.path.remove(current_dir)
 
 
 def parse_args() -> tuple[argparse.Namespace, list[str]]:
@@ -112,12 +121,21 @@ def main() -> None:
         has_refit_draft_weights=has_refit_draft_weights,
     )
 
+    # NeMo-Gym specific config setup.
+    if bool(config.env.get("should_use_nemo_gym")):
+        setup_nemo_gym_config(config, tokenizer)
+
     bundle = setup_single_controller(config, tokenizer)
 
     print("🚀 Launching SingleControllerArealActor")
     sc = SingleControllerArealActor.remote(master_config=config, bundle=bundle)
     result = ray.get(sc.run.remote())
     print(f"AReaL SC run complete: {result}")
+
+    # Drain env actors before vLLM shutdown to avoid race-condition 500s on
+    # in-flight requests.
+    for handle in bundle.env_handles.values():
+        ray.get(handle.shutdown.remote())
 
 
 if __name__ == "__main__":

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -862,8 +862,16 @@ def setup(
 
         # When the user opts into recompute-after-refit on the megatron side,
         # override mcore's kv_cache_management_mode to "recompute" directly.
-        if "async_grpo" in grpo_config and grpo_config["async_grpo"].get(
-            "recompute_kv_cache_after_weight_updates", False
+        # Megatron GENERATION backend only (mirrors the backend guard at the
+        # init_collective site below): on vllm generation the recompute is
+        # handled by the trajectory collector's invalidate_kv_cache path, and
+        # mcore_generation_config does not exist in the config.
+        if (
+            policy_config["generation"]["backend"] == "megatron"
+            and "async_grpo" in grpo_config
+            and grpo_config["async_grpo"].get(
+                "recompute_kv_cache_after_weight_updates", False
+            )
         ):
             mcore_cfg = policy_config["generation"]["mcore_generation_config"]
             prior_mode = mcore_cfg.get("kv_cache_management_mode", "persist")

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -257,6 +257,7 @@ class SingleControllerActor:
             "rewards": [],
             "masked_advantages": [],
             "sequence_lengths": [],
+            "staleness": [],
         }
 
         print(
@@ -667,11 +668,18 @@ class SingleControllerActor:
                             int(s) for s in train_meta.sequence_lengths
                         )
 
-                    # Refresh min_sample_version
-                    curr_min_sample_version = min(
+                    # Per-sample staleness = version gap at consumption;
+                    # _trainer_version stays fixed until the step closes below.
+                    sample_versions = [
                         t["weight_version"]
                         for t in train_meta.tags  # type: ignore
+                    ]
+                    self._step_log_dict["staleness"].extend(
+                        self._trainer_version - v for v in sample_versions
                     )
+
+                    # Refresh min_sample_version
+                    curr_min_sample_version = min(sample_versions)
                     if min_sample_version is not None:
                         min_sample_version = min(
                             min_sample_version, curr_min_sample_version

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -104,6 +104,26 @@ class SingleControllerActor:
 
         self._master_config = master_config
         self._async_cfg = master_config.async_rl
+
+        # No reference model is built when reference_policy_kl_penalty == 0
+        # (setup.py's init_reference_model = reference_policy_kl_penalty > 0).
+        # AdvantageConfig defaults reference_logprobs_field to a non-None string,
+        # so the train loop would call get_reference_policy_logprobs_from_meta ->
+        # use_reference_model -> AttributeError('reference_state_dict'). Null the
+        # field so every `reference_logprobs_field is not None` gate (compute in
+        # run(), plus the field-collection sites) skips it consistently. Mirrors
+        # the non-SC grpo path, which already skips reference logprobs when
+        # kl_penalty == 0. (Fixes the SC-only crash flagged by the TODO at the
+        # compute_reference_logprobs assignment.)
+        _lf = master_config.loss_fn
+        _kl_penalty = (
+            _lf["reference_policy_kl_penalty"]
+            if isinstance(_lf, dict)
+            else getattr(_lf, "reference_policy_kl_penalty", 0)
+        )
+        if not (_kl_penalty and _kl_penalty > 0):
+            self._advantage_cfg.reference_logprobs_field = None
+
         self._dp_client = bundle.dp_client
         self._gen: Generation = bundle.gen_handle
         self._trainer: TQPolicy = bundle.trainer_handle

--- a/nemo_rl/algorithms/single_controller_areal.py
+++ b/nemo_rl/algorithms/single_controller_areal.py
@@ -23,12 +23,14 @@ Data flow:
                      → TQReplayBuffer.reserve claims a slot at dispatch time;
                        run_rollout runs; TQReplayBuffer.commit tensorizes the
                        record, writes N training rows to TQ, and marks ready.
-  _train_pump    → sampler.evict → buffer.remove (stale groups, with DP clear).
-                 → sampler.select → drops chosen groups from buffer, returns
-                   KVBatchMeta of K groups (or None); meta is already trainable.
-                 → _advantage_pump (get → compute → put).
-                 → trainer.train_on_meta.
-                 → dp_client.clear_samples (trained groups; buffer already dropped).
+  _train_pump    → PHASE 1 (once): _collect_full_batch (evict/select barrier);
+                     freeze π_prox via get_logprobs_from_meta over the whole batch;
+                     _advantage_pump (get → compute → put).
+                 → PHASE 2 (single pass): per minibatch from _iter_minibatches,
+                     begin_train_step → train_microbatch_from_meta →
+                     finish_train_step (one optimizer.step each).
+                 → PUBLISH (once): dp_client.clear_samples; bump trainer_version;
+                     WeightSynchronizer.sync_weights via _sync_weights.
   _sync_weights  → drain _inflight_rollouts → WeightSynchronizer.sync_weights.
 """
 
@@ -127,18 +129,34 @@ class SingleControllerArealActor:
         self._train_cluster = bundle.train_cluster
         self._inference_cluster = bundle.inference_cluster
 
-        if self._async_cfg.target_prompt_groups_per_step is None:
-            self._async_cfg.target_prompt_groups_per_step = (
-                self._async_cfg.min_prompt_groups_per_batch
-            )
-        if (
-            self._async_cfg.target_prompt_groups_per_step
-            < self._async_cfg.min_prompt_groups_per_batch
-        ):
+        # AReaL batch sizing. Each RL step consumes the FULL batch of
+        # num_prompts_per_step prompt groups = rl_step_samples sequences
+        # (rl_step_samples = num_prompts_per_step * num_generations_per_prompt),
+        # split into minibatches of train_global_batch_size, ONE optimizer.step
+        # each (num_minibatches = rl_step_samples // train_global_batch_size).
+        # AReaL collects exactly num_prompts_per_step groups per step; the streaming
+        # knobs target_prompt_groups_per_step / min_prompt_groups_per_batch are NOT
+        # used on this path.
+        self._num_prompt_groups_per_step: int = self._master_config.grpo[
+            "num_prompts_per_step"
+        ]
+        rl_step_samples = (
+            self._num_prompt_groups_per_step
+            * self._master_config.grpo["num_generations_per_prompt"]
+        )
+        train_gbs = self._master_config.policy["train_global_batch_size"]
+        if train_gbs <= 0 or rl_step_samples % train_gbs != 0:
             raise ValueError(
-                f"target_prompt_groups_per_step ({self._async_cfg.target_prompt_groups_per_step}) "
-                f"must be >= min_prompt_groups_per_batch ({self._async_cfg.min_prompt_groups_per_batch})"
+                f"num_prompts_per_step * num_generations_per_prompt "
+                f"({rl_step_samples}) must be a positive multiple of "
+                f"policy.train_global_batch_size ({train_gbs}): each RL step's batch "
+                f"is split into rl_step_samples // train_global_batch_size minibatches "
+                f"of train_global_batch_size, one optimizer.step each."
             )
+        self._train_minibatch_size: int = train_gbs
+        # num_minibatches is DERIVED (not a config knob): how many
+        # train_global_batch_size optimizer steps tile one RL-step batch.
+        self._num_minibatches: int = rl_step_samples // train_gbs
 
         if self._async_cfg.batch_selection_strategy == "strict_on_policy":
             self._async_cfg.max_weight_staleness_versions = 0
@@ -152,25 +170,24 @@ class SingleControllerArealActor:
         # staleness window (η) + the decoupled-PPO π_prox/π_behav reweighting, NOT
         # by over-producing and discarding stragglers that age out (an orthogonal
         # async strategy AReaL avoids). Validate + derive the buffer size from η.
-        self._validate_buffer_config(self._async_cfg)
+        self._validate_buffer_config(
+            self._async_cfg, self._num_prompt_groups_per_step
+        )
         # force_in_order needs over_sampling=False, which _validate_buffer_config
         # now guarantees for the AReaL path, so no separate check is needed.
 
-        # SC split path does one optimizer.step per RL step.
-        # TODO: support multi-mini-step (legacy train() does gbs-sized
-        # mini-steps with shared prev_logprobs).
-        rl_step_samples = (
-            self._master_config.grpo["num_prompts_per_step"]
-            * self._master_config.grpo["num_generations_per_prompt"]
+        # Each minibatch is one train_global_batch_size, DP-sharded independently by
+        # train_microbatch_from_meta -> shard_by_batch_size, which requires
+        # minibatch.size % dp_world == 0. Read the REAL data-parallel size from the
+        # driver-side trainer's existing sharding annotations (no new trainer API).
+        self._dp_world: int = self._trainer.sharding_annotations.get_axis_size(
+            "data_parallel"
         )
-        train_gbs = self._master_config.policy["train_global_batch_size"]
-        if rl_step_samples != train_gbs:
+        if self._dp_world <= 0 or train_gbs % self._dp_world != 0:
             raise ValueError(
-                f"num_prompts_per_step * num_generations_per_prompt "
-                f"({rl_step_samples}) must equal policy.train_global_batch_size "
-                f"({train_gbs}) so that one RL step maps to exactly one "
-                f"optimizer.step. Multi-mini-step inside a single RL step is "
-                f"not supported on the SC split path."
+                f"train_global_batch_size ({train_gbs}) must be a multiple of the "
+                f"data_parallel size ({self._dp_world}); each minibatch is DP-sharded "
+                f"and shard_by_batch_size requires minibatch.size % dp_world == 0."
             )
 
         self._sampler = StalenessSampler(
@@ -223,7 +240,7 @@ class SingleControllerArealActor:
             f"buffer={self._async_cfg.max_buffered_rollouts} "
             f"inflight={self._async_cfg.max_inflight_prompts} "
             f"over_sampling={self._async_cfg.over_sampling} "
-            f"num_minibatches={self._async_cfg.num_minibatches} "
+            f"num_minibatches={self._num_minibatches} "
             f"refit_invalidate_kv_cache={self._async_cfg.refit_invalidate_kv_cache} "
             f"transport={self._weight_sync_cfg.transport}",
             flush=True,
@@ -287,6 +304,8 @@ class SingleControllerArealActor:
         if asyncio.iscoroutine(result):
             return await result
         return result
+
+    # ── the three pumps + advantage helper ────────────────────────────────
 
     async def _rollout_pump(self) -> None:
         """Continuously dispatch rollout tasks until cancellation.
@@ -371,141 +390,145 @@ class SingleControllerArealActor:
         print(f"rollout_pump: completed {epoch} epoch(s)", flush=True)
 
     async def _train_pump(self) -> None:
-        """Drain stale groups, sample, train, drop.
+        """AReaL decoupled-PPO two-phase loop. One pass, each sample used once.
 
         Per step:
-          1. sampler.evict drops stale groups from the buffer and clears their TQ rows.
-          2. sampler.select returns K prompt groups (or None) and drops them from the
-             buffer; DP rows survive so the trainer can read them. Already trainable —
-             buffer wrote training-shaped rows at rollout time.
-          3. _advantage_pump(train_meta).
-          4. trainer.train_microbatch_from_meta + finish_train_step.
-          5. dp_client.clear_samples on consumed sample_ids; release _buffer_capacity
-             per dropped group, then sync.
+          PHASE 1 — full-batch barrier (ONCE):
+            1. ``_collect_full_batch`` accumulates+merges whole prompt groups until
+               the target batch is in hand (or returns None on rollout exhaustion).
+            2. Freeze π_prox over the WHOLE batch: ``prepare_for_lp_inference`` then
+               ``get_logprobs_from_meta`` writes ``prev_logprobs``. Nothing rewrites
+               that field until the next step, so the snapshot stays frozen across
+               every minibatch — this is the decoupled loss's trust-region center.
+            3. GRPO advantages over the full batch via ``_advantage_pump``.
+          PHASE 2 — per-MINIBATCH optimizer steps (single pass):
+            4. For each ``_iter_minibatches`` slice, one ``begin_train_step →
+               train_microbatch_from_meta → finish_train_step`` cycle = one
+               ``optimizer.step``. M minibatches ⇒ exactly M optimizer steps; at
+               ``num_minibatches=1`` that is one step over the whole batch.
+          PUBLISH — ONCE per step, AFTER the minibatch loop:
+            5. ``clear_samples`` frees the DP rows; reduce the M finish results via
+               the EXISTING ``aggregate_step_metrics``; bump ``_trainer_version`` +
+               ``_train_steps``; ``_sync_weights``.
 
-        P0 note: this is a verbatim fork of the base controller loop with the
-        AReaL ``step_results`` scaffolding added — each ``finish_train_step``
-        result is collected into ``step_results`` and reduced through the EXISTING
-        ``aggregate_step_metrics`` helper. At ``num_minibatches=1`` there is a
-        single optimizer step per training step, so ``step_results`` holds exactly
-        one result and the reduced metrics are byte-for-byte identical to the base
-        controller (no behavior change at defaults). P2 replaces this single-step
-        body with the two-phase Phase-1 barrier + per-minibatch Phase-2 loop that
-        appends one result per minibatch to the SAME ``step_results`` list.
+        π_prox = ``prev_logprobs`` (reuse ``get_logprobs_from_meta``), π_behav =
+        ``generation_logprobs``, π_θ = the fresh forward inside ``train_microbatch``.
+        The Phase-1 freeze runs UNCONDITIONALLY (not gated on
+        ``adv_cfg.policy_logprobs_field``) because the decoupled loss always needs
+        π_prox present for the full batch (§3).
         """
         adv_cfg = self._advantage_cfg
         grpo_cfg = self._master_config.grpo
 
-        # TODO: fix the compute_prev_logprobs and compute_reference_logprobs logic
-        compute_prev_logprobs = adv_cfg.policy_logprobs_field is not None
+        # Reference logprobs stay optional/gated; π_prox (prev_logprobs) is always
+        # frozen in Phase 1 below regardless of the advantage config.
         compute_reference_logprobs = adv_cfg.reference_logprobs_field is not None
 
         while self._train_steps < grpo_cfg["max_num_steps"]:
             step_id = f"sc-step-{self._train_steps:06d}"
-            # __init__ coerces None → min_prompt_groups_per_batch (int);
-            # the assert narrows the Optional[int] type for pyrefly.
-            assert self._async_cfg.target_prompt_groups_per_step is not None
-            target_groups: int = self._async_cfg.target_prompt_groups_per_step
-            groups_dispatched = 0
-            step_open = False
-            # AReaL scaffolding: one finish_train_step result per optimizer step.
-            # P0 (num_minibatches=1) appends exactly one; P2's minibatch loop
-            # appends one per minibatch. Reduced via the existing helper below.
+            # AReaL scaffolding: one finish_train_step result per optimizer step,
+            # i.e. one per minibatch. Reduced via the existing helper at step end.
             step_results: list[dict[str, Any]] = []
 
             with self._timer.time("total_step_time"):
-                while groups_dispatched < target_groups:
-                    await asyncio.sleep(0)
-
-                    # evict stale groups
-                    evicted = await self._sampler.evict(
-                        current_train_weight=self._trainer_version,
-                    )
-                    if evicted:
-                        print(f"  evicted {evicted} stale prompt group(s)", flush=True)
-                        for _ in range(evicted):
-                            self._buffer_capacity.release()
-
-                    # TODO @yukih: wait train pump merged, now always return min_prompt_groups_per_batch
-                    # need to add a max_prompt_groups_per_batch
-                    with self._timer.time("exposed_generation"):
-                        train_meta, num_groups = await self._sampler.select(
-                            current_train_weight=self._trainer_version,
-                            min_prompt_groups=self._async_cfg.min_prompt_groups_per_batch,
-                        )
-
-                    if train_meta is None:
-                        await asyncio.sleep(0.05)
-                        continue
-
-                    for _ in range(num_groups):
-                        self._buffer_capacity.release()
-
-                    # Compute prev_logprobs / ref_logprobs
-                    with self._timer.time("logprob_inference_prep"):
-                        await asyncio.to_thread(self._trainer.prepare_for_lp_inference)
-                    with self._timer.time("policy_and_reference_logprobs"):
-                        if compute_prev_logprobs:
-                            await asyncio.to_thread(
-                                self._trainer.get_logprobs_from_meta, train_meta
-                            )
-                        if compute_reference_logprobs:
-                            await asyncio.to_thread(
-                                self._trainer.get_reference_policy_logprobs_from_meta,
-                                train_meta,
-                            )
-
-                    with self._timer.time("advantage_calculation"):
-                        train_meta = await self._advantage_pump(train_meta)
-
-                    # Train
-                    with self._timer.time("training_prep"):
-                        await asyncio.to_thread(self._trainer.prepare_for_training)
-                    with self._timer.time("policy_training"):
-                        if not step_open:
-                            await asyncio.to_thread(
-                                self._trainer.begin_train_step,
-                                step_id,
-                                loss_fn=self._loss_fn,
-                            )
-                            step_open = True
-                        await asyncio.to_thread(
-                            self._trainer.train_microbatch_from_meta,
-                            step_id,
-                            train_meta,
-                        )
-
-                    groups_dispatched += num_groups
-                    self._step_consumed_sample_ids.extend(train_meta.sample_ids)
-                    if train_meta.sequence_lengths:
-                        self._step_log_dict["sequence_lengths"].extend(
-                            int(s) for s in train_meta.sequence_lengths
-                        )
-
-                if not step_open:
+                # ══════════ PHASE 1 — accumulate full batch, freeze π_prox ════════
+                with self._timer.time("exposed_generation"):
+                    batch_meta = await self._collect_full_batch()
+                if batch_meta is None:
                     print(
                         "train_pump: rollout exhausted before any group ready",
                         flush=True,
                     )
                     break
 
-                with self._timer.time("policy_training"):
-                    result = await asyncio.to_thread(
-                        self._trainer.finish_train_step, step_id
+                # π_prox ← current θ: ONE no-grad forward over the WHOLE batch,
+                # writing prev_logprobs (frozen for the entire step). Runs
+                # unconditionally — the decoupled loss requires it.
+                with self._timer.time("logprob_inference_prep"):
+                    await asyncio.to_thread(self._trainer.prepare_for_lp_inference)
+                with self._timer.time("policy_and_reference_logprobs"):
+                    await asyncio.to_thread(
+                        self._trainer.get_logprobs_from_meta, batch_meta
                     )
-                step_results.append(result)
-                consumed_ids = list(self._step_consumed_sample_ids)
-                self._step_consumed_sample_ids = []
+                    if compute_reference_logprobs:
+                        await asyncio.to_thread(
+                            self._trainer.get_reference_policy_logprobs_from_meta,
+                            batch_meta,
+                        )
+
+                # GRPO group-normalized advantages over the full batch.
+                with self._timer.time("advantage_calculation"):
+                    batch_meta = await self._advantage_pump(batch_meta)
+
+                if batch_meta.sequence_lengths:
+                    self._step_log_dict["sequence_lengths"].extend(
+                        int(s) for s in batch_meta.sequence_lengths
+                    )
+
+                # Drop a tail remainder if the collected batch is not a whole
+                # number of train_global_batch_size minibatches (the target%min
+                # over-claim edge; the common case is already exact). Advantages
+                # above were computed over the full batch, so dropped rows just get
+                # no optimizer step; clear_samples below still frees them
+                # (consumed_ids uses the full batch_meta.sample_ids).
+                train_meta, dropped = self._dp_align_batch(
+                    batch_meta, self._train_minibatch_size
+                )
+                if dropped:
+                    print(
+                        f"train_pump: dropped {dropped} tail sample(s) so the batch "
+                        f"is a whole number of {self._train_minibatch_size}-sample "
+                        f"minibatches",
+                        flush=True,
+                    )
+
+                # ══════════ PHASE 2 — per-MINIBATCH optimizer steps (single pass) ══
+                with self._timer.time("training_prep"):
+                    await asyncio.to_thread(self._trainer.prepare_for_training)
+                with self._timer.time("policy_training"):
+                    for j, minibatch_meta in enumerate(
+                        self._iter_minibatches(train_meta)
+                    ):
+                        ep = f"{step_id}-mb{j:03d}"  # ONE optimizer step
+                        # gbs == minibatch size == train_global_batch_size, so
+                        # finish_train_step's scheduler.step(increment=gbs) advances
+                        # the sample-based LR schedule by one train_global_batch_size
+                        # per optimizer step — num_minibatches ticks per RL step.
+                        # At num_minibatches==1 this matches the base controller.
+                        await asyncio.to_thread(
+                            self._trainer.begin_train_step,
+                            ep,
+                            loss_fn=self._loss_fn,
+                            gbs=minibatch_meta.size,
+                        )
+                        try:
+                            await asyncio.to_thread(
+                                self._trainer.train_microbatch_from_meta,
+                                ep,
+                                minibatch_meta,
+                            )
+                            result = await asyncio.to_thread(
+                                self._trainer.finish_train_step, ep
+                            )
+                        except Exception:
+                            await asyncio.to_thread(
+                                self._trainer.abort_train_step, ep
+                            )
+                            raise
+                        step_results.append(result)
+
+                # ══════════ publish (ONCE per training step, after the loop) ═══════
+                consumed_ids = list(batch_meta.sample_ids)
                 await self._call_dp(
                     "clear_samples",
-                    sample_ids=list(consumed_ids),
+                    sample_ids=consumed_ids,
                     partition_id=self._partition_id,
                 )
 
-                # Reduce the per-optimizer-step finish results through the EXISTING
-                # metrics path (no new helper). At num_minibatches=1 step_results
-                # holds one result, so aggregate_step_metrics(step_results[-1])
-                # reproduces the base controller exactly. P2 reduces all M results.
+                # Reduce the per-minibatch finish results through the EXISTING
+                # metrics path (no new helper). The last minibatch's metrics carry
+                # the step-level scalars (lr/wd after the final scheduler.step,
+                # global valid seqs/toks); aggregate_step_metrics flattens them.
                 step_metrics = aggregate_step_metrics(step_results[-1])
                 step_metrics.update(
                     reduce_advantage_pump_metrics(**self._step_log_dict)
@@ -555,12 +578,16 @@ class SingleControllerArealActor:
 
             # min sample version refers to the version each consumed sample was
             # generated with; lag = current trainer version - oldest sample version.
-            min_sample_version = min(t["weight_version"] for t in train_meta.tags)  # type: ignore
-            lag = self._trainer_version - min_sample_version
+            staleness = "n/a"
+            if batch_meta.tags:
+                min_sample_version = min(
+                    t["weight_version"] for t in batch_meta.tags
+                )
+                staleness = self._trainer_version - min_sample_version
             print(
                 f"train step {self._train_steps}/{grpo_cfg['max_num_steps']}  "
                 f"trainer_v={self._trainer_version}  "
-                f"lag={lag}  "
+                f"staleness={staleness}  "
                 f"batch_size={len(consumed_ids)}",
                 flush=True,
             )
@@ -568,7 +595,9 @@ class SingleControllerArealActor:
     # ── AReaL helpers ──────────────────────────────────────────────────────
 
     @staticmethod
-    def _validate_buffer_config(async_cfg: AsyncRLConfig) -> None:
+    def _validate_buffer_config(
+        async_cfg: AsyncRLConfig, num_prompt_groups_per_step: int
+    ) -> None:
         """Require over_sampling=False and DERIVE the buffer size from the window.
 
         AReaL controls off-policyness through the staleness window (η) plus the
@@ -578,23 +607,22 @@ class SingleControllerArealActor:
         is scoped to ``over_sampling=False``.
 
         With ``over_sampling=False`` the buffer size is fully derivable: at most
-        one in-window batch per live weight version, i.e.
+        one full RL-step batch per live weight version, i.e.
 
-            max_buffered_rollouts = target_prompt_groups_per_step
+            max_buffered_rollouts = num_prompt_groups_per_step
                                     * (max_weight_staleness_versions + 1)
 
-        rather than a user knob to set and assert against. This method computes
-        that value and writes it back onto ``async_cfg.max_buffered_rollouts`` so
-        the ``_buffer_capacity`` semaphore and the startup banner both use the
-        derived (auditable) number. If the user also set a conflicting value, we
-        log a one-line note and use the derived value — we do NOT error.
-
-        ``target_prompt_groups_per_step`` must already be coerced from ``None``.
+        (``num_prompt_groups_per_step`` == grpo.num_prompts_per_step — the AReaL
+        path collects exactly that many groups per step and does NOT use the
+        streaming knobs target_prompt_groups_per_step / min_prompt_groups_per_batch).
+        This method computes the value and writes it back onto
+        ``async_cfg.max_buffered_rollouts`` so the ``_buffer_capacity`` semaphore
+        and the startup banner both use the derived (auditable) number. A
+        conflicting configured value is logged and ignored — we do NOT error.
 
         Raises:
             ValueError: if ``over_sampling`` is True (unsupported for AReaL).
         """
-        assert async_cfg.target_prompt_groups_per_step is not None
         if async_cfg.over_sampling:
             raise ValueError(
                 "AReaL controls off-policyness via the staleness window (η) + "
@@ -602,32 +630,50 @@ class SingleControllerArealActor:
                 "async_rl.over_sampling=false."
             )
 
-        derived_buffer = async_cfg.target_prompt_groups_per_step * (
+        derived_buffer = num_prompt_groups_per_step * (
             async_cfg.max_weight_staleness_versions + 1
         )
         if async_cfg.max_buffered_rollouts != derived_buffer:
             print(
                 f"AReaL: deriving max_buffered_rollouts={derived_buffer} "
-                f"(= target_prompt_groups_per_step * "
-                f"(max_weight_staleness_versions + 1)); ignoring the configured "
-                f"value {async_cfg.max_buffered_rollouts}.",
+                f"(= num_prompts_per_step * (max_weight_staleness_versions + 1)); "
+                f"ignoring the configured value {async_cfg.max_buffered_rollouts}.",
                 flush=True,
             )
         async_cfg.max_buffered_rollouts = derived_buffer
 
+    @staticmethod
+    def _dp_align_batch(
+        batch_meta: "KVBatchMeta", minibatch_size: int
+    ) -> "tuple[KVBatchMeta, int]":
+        """Trim a tail remainder so the batch is a whole number of minibatches.
+
+        The full batch is normally exactly ``rl_step_samples == k * minibatch_size``
+        (``minibatch_size == train_global_batch_size``), but the
+        ``target_prompt_groups_per_step % min_prompt_groups_per_batch`` over-claim
+        edge can leave a smaller tail; trim to the largest multiple of
+        ``minibatch_size``. Each kept minibatch is then exactly ``minibatch_size``,
+        which ``__init__`` already verified is a DP multiple. Returns
+        ``(meta_to_train, dropped)``; the dropped tail rows already had advantages
+        computed over the full batch (Phase 1) and are still freed by
+        ``clear_samples`` — they simply receive no optimizer update.
+        """
+        size = minibatch_size
+        usable = (batch_meta.size // size) * size if size > 0 else batch_meta.size
+        dropped = batch_meta.size - usable
+        if dropped <= 0 or usable <= 0:
+            return batch_meta, 0
+        return batch_meta.slice(0, usable), dropped
+
     async def _collect_full_batch(self) -> "KVBatchMeta | None":
         """Phase-1 barrier: drain the staleness sampler until the full batch is claimed.
 
-        Accumulates whole prompt groups until ``target_prompt_groups_per_step``
-        groups are in hand, then merges them into a single ``KVBatchMeta``. This
-        is the structural difference from the base controller's interleaved
+        Accumulates whole prompt groups until ``num_prompts_per_step`` groups are
+        in hand (the full RL-step batch), then merges them into one ``KVBatchMeta``.
+        This is the structural difference from the base controller's interleaved
         loop: the *whole* batch is gathered before any training so that π_prox
         (``get_logprobs_from_meta``) and the GRPO advantages can be defined over
-        a single, consistent batch (§3, §4).
-
-        ACCUMULATE + MERGE ONLY — this method performs no training, no logprob
-        inference, and no advantage computation. P2 wires the call site in
-        ``_train_pump`` and adds those phases around it.
+        a single, consistent batch.
 
         Each loop iteration yields to ``_rollout_pump`` (``asyncio.sleep(0)``) so
         generation of batches i+1..i+η keeps streaming in the background — that
@@ -637,10 +683,10 @@ class SingleControllerArealActor:
 
         Buffer-capacity slots are released as groups leave the buffer (per evicted
         group and per claimed group) so the rollout pump keeps producing during
-        Phase 2; the DataPlane rows stay alive until ``clear_samples`` at step end
-        (§7.4), so the frozen π_prox/advantages survive the whole minibatch loop.
+        Phase 2; the DataPlane rows stay alive until ``clear_samples`` at step end,
+        so the frozen π_prox/advantages survive the whole minibatch loop.
 
-        Exhaustion is tail-safe (§7.10): ``select`` returning ``None`` only ends
+        Exhaustion is tail-safe: ``select`` returning ``None`` only ends
         the loop when the dispatch loop is done (``_rollout_done``) AND nothing is
         still in flight (``_dispatched_rollouts`` empty) — otherwise the last
         in-flight rollouts would be dropped.
@@ -649,10 +695,10 @@ class SingleControllerArealActor:
             The merged full-batch ``KVBatchMeta`` (concat of all claimed groups),
             or ``None`` if rollout is exhausted with nothing left to train.
         """
-        # __init__ coerces None → min_prompt_groups_per_batch (int); the assert
-        # narrows the Optional[int] type for pyrefly.
-        assert self._async_cfg.target_prompt_groups_per_step is not None
-        target: int = self._async_cfg.target_prompt_groups_per_step
+        # AReaL collects exactly num_prompts_per_step groups (the full RL-step
+        # batch) before training; it does NOT use the streaming knobs
+        # target_prompt_groups_per_step / min_prompt_groups_per_batch.
+        target: int = self._num_prompt_groups_per_step
         claimed: list[KVBatchMeta] = []
         n = 0
         while n < target:
@@ -669,7 +715,7 @@ class SingleControllerArealActor:
             # Claim in-window groups (lag ≤ η). select() returns (meta|None, num).
             train_meta, num = await self._sampler.select(
                 current_train_weight=self._trainer_version,
-                min_prompt_groups=self._async_cfg.min_prompt_groups_per_batch,
+                min_prompt_groups=self._num_prompt_groups_per_step,
             )
 
             if train_meta is None:
@@ -694,35 +740,27 @@ class SingleControllerArealActor:
     def _iter_minibatches(
         self, batch_meta: "KVBatchMeta"
     ) -> Iterator["KVBatchMeta"]:
-        """Yield ``num_minibatches`` contiguous slices of the batch, in order.
+        """Yield contiguous minibatches of ``train_global_batch_size`` sequences.
 
-        Each yielded meta is ONE optimizer step (one begin/train_microbatch/
-        finish cycle in Phase 2). Deterministic, no shuffle — matches AReaL,
-        which splits the flat batch into ``ppo_n_minibatches`` in order (single
-        pass, each sample used exactly once). The split is even; the leading
-        minibatches absorb the remainder. ``num_minibatches=1`` yields the whole
-        batch unchanged (one optimizer step per training step).
+        Each yielded meta is ONE optimizer step. The full RL-step batch 
+        (``rl_step_samples``) splits into ``rl_step_samples // train_global_batch_size`` 
+        minibatches — deterministic, in order, no shuffle, each sample used exactly once.
+        A trailing remainder smaller than one minibatch is NOT yielded; 
+        ``_dp_align_batch`` normally trims it first, so in practice there is no remainder.
 
         Args:
             batch_meta: the frozen full-batch ``KVBatchMeta`` (Phase 1 output).
 
         Yields:
-            Contiguous, non-overlapping ``KVBatchMeta`` slices whose union is the
-            full batch. Empty slices (when ``num_minibatches > batch size``) are
-            skipped.
+            Contiguous, non-overlapping ``KVBatchMeta`` slices of
+            ``train_global_batch_size`` sequences each.
         """
-        n = batch_meta.size  # total sequences in the batch
-        m = self._async_cfg.num_minibatches
-        if m < 1:
-            raise ValueError(f"num_minibatches must be >= 1, got {m}")
-        # Even split; the first (n % m) minibatches each take one extra sample.
-        sizes = [n // m + (1 if i < n % m else 0) for i in range(m)]
+        size = self._train_minibatch_size  # one optimizer step == train_gbs
+        n = batch_meta.size  # total sequences in the (full) batch
         start = 0
-        for sz in sizes:
-            if sz == 0:
-                continue
-            yield batch_meta.slice(start, start + sz)
-            start += sz
+        while start + size <= n:
+            yield batch_meta.slice(start, start + size)
+            start += size
 
 
     async def _sync_weights(self) -> None:

--- a/nemo_rl/algorithms/single_controller_areal.py
+++ b/nemo_rl/algorithms/single_controller_areal.py
@@ -44,6 +44,7 @@ import torch
 from nemo_rl.algorithms.async_utils.staleness_sampler import StalenessSampler
 from nemo_rl.algorithms.single_controller_utils.config import (
     AdvantageConfig,
+    AsyncRLConfig,
     MasterConfig,
     WeightSyncConfig,
 )
@@ -147,23 +148,13 @@ class SingleControllerArealActor:
                 flush=True,
             )
 
-        if not self._async_cfg.over_sampling:
-            expected_buffer = self._async_cfg.target_prompt_groups_per_step * (
-                self._async_cfg.max_weight_staleness_versions + 1
-            )
-            if self._async_cfg.max_buffered_rollouts != expected_buffer:
-                raise ValueError(
-                    f"over_sampling=False requires max_buffered_rollouts "
-                    f"({self._async_cfg.max_buffered_rollouts}) == "
-                    f"target_prompt_groups_per_step * (max_weight_staleness_versions + 1) "
-                    f"({expected_buffer})"
-                )
-
-        if self._async_cfg.force_in_order and self._async_cfg.over_sampling:
-            raise ValueError(
-                "force_in_order=True requires over_sampling=False so that each "
-                "dispatched batch corresponds to exactly one target training step."
-            )
+        # AReaL is over_sampling=False ONLY. Off-policyness is controlled by the
+        # staleness window (η) + the decoupled-PPO π_prox/π_behav reweighting, NOT
+        # by over-producing and discarding stragglers that age out (an orthogonal
+        # async strategy AReaL avoids). Validate + derive the buffer size from η.
+        self._validate_buffer_config(self._async_cfg)
+        # force_in_order needs over_sampling=False, which _validate_buffer_config
+        # now guarantees for the AReaL path, so no separate check is needed.
 
         # SC split path does one optimizer.step per RL step.
         # TODO: support multi-mini-step (legacy train() does gbs-sized
@@ -199,6 +190,12 @@ class SingleControllerArealActor:
 
         # Cancellation handles for in-flight rollout dispatches.
         self._dispatched_rollouts: set[asyncio.Task[None]] = set()
+
+        # Set True by _rollout_pump when its epoch loop completes. Makes
+        # _collect_full_batch tail-safe (§4, §7.10): exhaustion is only declared
+        # once the dispatch loop is done AND no rollouts are still in flight, so
+        # the last in-flight rollouts are trained rather than dropped.
+        self._rollout_done: bool = False
 
         # over_sampling=False batch gate: farthest trainer_version covered by
         # already-dispatched batches.
@@ -368,6 +365,9 @@ class SingleControllerArealActor:
                     task.add_done_callback(self._dispatched_rollouts.discard)
             epoch += 1
 
+        # Mark dispatch loop exhausted so _collect_full_batch can declare the
+        # tail batch ready once the remaining in-flight rollouts commit (§7.10).
+        self._rollout_done = True
         print(f"rollout_pump: completed {epoch} epoch(s)", flush=True)
 
     async def _train_pump(self) -> None:
@@ -566,6 +566,130 @@ class SingleControllerArealActor:
             )
 
     # ── AReaL helpers ──────────────────────────────────────────────────────
+
+    @staticmethod
+    def _validate_buffer_config(async_cfg: AsyncRLConfig) -> None:
+        """Require over_sampling=False and DERIVE the buffer size from the window.
+
+        AReaL controls off-policyness through the staleness window (η) plus the
+        decoupled-PPO π_prox/π_behav reweighting — NOT through over_sampling
+        ("over-generate and waste stragglers that age out"), which is an
+        orthogonal async strategy AReaL deliberately avoids. So this controller
+        is scoped to ``over_sampling=False``.
+
+        With ``over_sampling=False`` the buffer size is fully derivable: at most
+        one in-window batch per live weight version, i.e.
+
+            max_buffered_rollouts = target_prompt_groups_per_step
+                                    * (max_weight_staleness_versions + 1)
+
+        rather than a user knob to set and assert against. This method computes
+        that value and writes it back onto ``async_cfg.max_buffered_rollouts`` so
+        the ``_buffer_capacity`` semaphore and the startup banner both use the
+        derived (auditable) number. If the user also set a conflicting value, we
+        log a one-line note and use the derived value — we do NOT error.
+
+        ``target_prompt_groups_per_step`` must already be coerced from ``None``.
+
+        Raises:
+            ValueError: if ``over_sampling`` is True (unsupported for AReaL).
+        """
+        assert async_cfg.target_prompt_groups_per_step is not None
+        if async_cfg.over_sampling:
+            raise ValueError(
+                "AReaL controls off-policyness via the staleness window (η) + "
+                "decoupled-PPO reweighting, not over_sampling; set "
+                "async_rl.over_sampling=false."
+            )
+
+        derived_buffer = async_cfg.target_prompt_groups_per_step * (
+            async_cfg.max_weight_staleness_versions + 1
+        )
+        if async_cfg.max_buffered_rollouts != derived_buffer:
+            print(
+                f"AReaL: deriving max_buffered_rollouts={derived_buffer} "
+                f"(= target_prompt_groups_per_step * "
+                f"(max_weight_staleness_versions + 1)); ignoring the configured "
+                f"value {async_cfg.max_buffered_rollouts}.",
+                flush=True,
+            )
+        async_cfg.max_buffered_rollouts = derived_buffer
+
+    async def _collect_full_batch(self) -> "KVBatchMeta | None":
+        """Phase-1 barrier: drain the staleness sampler until the full batch is claimed.
+
+        Accumulates whole prompt groups until ``target_prompt_groups_per_step``
+        groups are in hand, then merges them into a single ``KVBatchMeta``. This
+        is the structural difference from the base controller's interleaved
+        loop: the *whole* batch is gathered before any training so that π_prox
+        (``get_logprobs_from_meta``) and the GRPO advantages can be defined over
+        a single, consistent batch (§3, §4).
+
+        ACCUMULATE + MERGE ONLY — this method performs no training, no logprob
+        inference, and no advantage computation. P2 wires the call site in
+        ``_train_pump`` and adds those phases around it.
+
+        Each loop iteration yields to ``_rollout_pump`` (``asyncio.sleep(0)``) so
+        generation of batches i+1..i+η keeps streaming in the background — that
+        overlap is exactly what η buys. Staleness is enforced entirely by the
+        ``StalenessSampler`` window ``[v-η, v]`` via ``evict``/``select`` (no
+        hand-rolled lag check) and there is NO in-flight drain.
+
+        Buffer-capacity slots are released as groups leave the buffer (per evicted
+        group and per claimed group) so the rollout pump keeps producing during
+        Phase 2; the DataPlane rows stay alive until ``clear_samples`` at step end
+        (§7.4), so the frozen π_prox/advantages survive the whole minibatch loop.
+
+        Exhaustion is tail-safe (§7.10): ``select`` returning ``None`` only ends
+        the loop when the dispatch loop is done (``_rollout_done``) AND nothing is
+        still in flight (``_dispatched_rollouts`` empty) — otherwise the last
+        in-flight rollouts would be dropped.
+
+        Returns:
+            The merged full-batch ``KVBatchMeta`` (concat of all claimed groups),
+            or ``None`` if rollout is exhausted with nothing left to train.
+        """
+        # __init__ coerces None → min_prompt_groups_per_batch (int); the assert
+        # narrows the Optional[int] type for pyrefly.
+        assert self._async_cfg.target_prompt_groups_per_step is not None
+        target: int = self._async_cfg.target_prompt_groups_per_step
+        claimed: list[KVBatchMeta] = []
+        n = 0
+        while n < target:
+            await asyncio.sleep(0)  # yield to _rollout_pump
+
+            # Drop groups that aged past the staleness window [v-η, v]; free
+            # their buffer slots so the rollout pump can keep producing.
+            evicted = await self._sampler.evict(
+                current_train_weight=self._trainer_version,
+            )
+            for _ in range(evicted):
+                self._buffer_capacity.release()
+
+            # Claim in-window groups (lag ≤ η). select() returns (meta|None, num).
+            train_meta, num = await self._sampler.select(
+                current_train_weight=self._trainer_version,
+                min_prompt_groups=self._async_cfg.min_prompt_groups_per_batch,
+            )
+
+            if train_meta is None:
+                # True exhaustion = dispatch loop done AND nothing still in
+                # flight; otherwise the last in-flight rollouts would be dropped.
+                if self._rollout_done and not self._dispatched_rollouts:
+                    break
+                await asyncio.sleep(0.05)
+                continue
+
+            # Free buffer slots for the claimed groups (decoupled from the DP-row
+            # clear, which happens at step end).
+            for _ in range(num):
+                self._buffer_capacity.release()
+            claimed.append(train_meta)
+            n += num
+
+        if not claimed:
+            return None
+        return claimed[0].concat(*claimed[1:])
 
     def _iter_minibatches(
         self, batch_meta: "KVBatchMeta"

--- a/nemo_rl/algorithms/single_controller_areal.py
+++ b/nemo_rl/algorithms/single_controller_areal.py
@@ -31,7 +31,10 @@ Data flow:
                      finish_train_step (one optimizer.step each).
                  → PUBLISH (once): dp_client.clear_samples; bump trainer_version;
                      WeightSynchronizer.sync_weights via _sync_weights.
-  _sync_weights  → drain _inflight_rollouts → WeightSynchronizer.sync_weights.
+  _sync_weights  → AReaL interruptible refit (NO drain): pause _rollout_permitted
+                   → WeightSynchronizer.sync_weights (in-place) → invalidate_kv_cache(
+                   reset_running_requests=True) when refit_invalidate_kv_cache →
+                   set_weight_version → resume.
 """
 
 from __future__ import annotations
@@ -83,7 +86,8 @@ class SingleControllerArealActor:
       - _rollout_pump: dispatches prompts via RolloutManager; reserve+commit in
         TQReplayBuffer preserves dispatch order
       - _train_pump:   evicts stale groups, samples a batch, trains, drops it
-      - _sync_weights: drain gate + weight synchronization
+      - _sync_weights: AReaL interruptible refit (pause→swap→invalidate KV→resume),
+        no in-flight drain
 
     All other actors are passive — they expose methods and wait to be called.
     """
@@ -157,6 +161,25 @@ class SingleControllerArealActor:
         # num_minibatches is DERIVED (not a config knob): how many
         # train_global_batch_size optimizer steps tile one RL-step batch.
         self._num_minibatches: int = rl_step_samples // train_gbs
+
+        # AReaL decoupled-PPO REQUIRES the always-on π_prox/π_behav importance-
+        # sampling reweight (AReaL's unconditional `pg_loss *= behav_imp_weight`,
+        # §6/§11). In NeMo that is loss_fn.use_importance_sampling_correction=True,
+        # and with prev_logprobs := frozen π_prox the loss reproduces AReaL's
+        # decoupled objective exactly. With it False the IS weight is silently
+        # dropped and the loss degrades to a plain clip against prev_logprobs —
+        # NOT the decoupled-PPO objective — which diverges on the off-policy/stale
+        # samples this whole design exists to consume. Fail LOUD here (mirrors the
+        # legacy async entrypoint grpo.py:3062) rather than train a wrong objective.
+        if self._master_config.loss_fn.use_importance_sampling_correction is not True:
+            raise ValueError(
+                "AReaL decoupled-PPO requires "
+                "loss_fn.use_importance_sampling_correction=true: the always-on "
+                "π_prox/π_behav importance-sampling reweight is the decoupled "
+                "objective's staleness correction. With it off the loss degrades "
+                "to plain clip-against-prev_logprobs and diverges on the "
+                "off-policy/stale samples this controller is built to consume."
+            )
 
         if self._async_cfg.batch_selection_strategy == "strict_on_policy":
             self._async_cfg.max_weight_staleness_versions = 0
@@ -422,7 +445,23 @@ class SingleControllerArealActor:
 
         # Reference logprobs stay optional/gated; π_prox (prev_logprobs) is always
         # frozen in Phase 1 below regardless of the advantage config.
-        compute_reference_logprobs = adv_cfg.reference_logprobs_field is not None
+        # Gate on the reference model ACTUALLY existing: setup only builds it when
+        # reference_policy_kl_penalty > 0 (single_controller_utils/setup.py:180).
+        # AReaL's decoupled loss uses KL=0, so the reference forward is skipped
+        # (π_prox = prev_logprobs is the trust-region anchor, not a separate
+        # reference policy). Without the KL gate, reference_logprobs_field defaults
+        # non-None and get_reference_policy_logprobs_from_meta would hit
+        # `MegatronPolicyWorker has no attribute 'reference_state_dict'`.
+        compute_reference_logprobs = (
+            adv_cfg.reference_logprobs_field is not None
+            and self._master_config.loss_fn.reference_policy_kl_penalty > 0
+        )
+        if not compute_reference_logprobs:
+            # Keep the advantage stage consistent: with no reference model the
+            # reference_logprobs field is never written, so _advantage_pump and
+            # _advantage_input_fields must not try to read it (they gate on this
+            # field being None). One source of truth for "no reference logprobs".
+            adv_cfg.reference_logprobs_field = None
 
         while self._train_steps < grpo_cfg["max_num_steps"]:
             step_id = f"sc-step-{self._train_steps:06d}"
@@ -764,40 +803,55 @@ class SingleControllerArealActor:
 
 
     async def _sync_weights(self) -> None:
-        """Drain in-flight rollouts then synchronize weights.
+        """AReaL-style interruptible refit, native to the controller.
 
-        SC owns the drain gate (when to sync); WeightSynchronizer owns how.
+        Idea borrowed from the legacy prepare/resume_after_refit; the code is our
+        own. No per-request abort and NO in-flight drain: pause NEW generation
+        starts, update weights in place while in-flight decode keeps running,
+        optionally invalidate KV so ongoing requests reprefill under the new
+        weights, then resume. Staleness is bounded by the #2819 StalenessSampler
+        at consumption, not by gating production on a drain.
 
         Flow:
-          1. _rollout_permitted.clear()  — no new dispatches
-          2. drain _inflight_rollouts → 0  (5ms poll)
-          3. weight_synchronizer.sync_weights(trainer_version)
-          4. _rollout_permitted.set()   — resume
+          1. _rollout_permitted.clear()           — pause NEW generation starts
+          2. weight_synchronizer.sync_weights     — update_weights_* in place
+          3. invalidate_kv_cache(reset_running_requests=True) when configured
+             — vLLM preempts running requests, frees old-weight KV, reschedules
+               them so they reprefill under the new weights (scheduler.py:2147).
+               Without the flag the reset is a no-op while requests hold KV
+               (block_pool.py:665), leaving stale KV (Magistral-style).
+          4. set_weight_version(trainer_version)
+          5. _rollout_permitted.set()             — resume NEW starts
         """
+        # 1. Pause NEW generation starts. In-flight generate_async() coroutines
+        #    keep decoding with current KV while the weights swap underneath them
+        #    — we do NOT wait for any _inflight_rollouts counter (no drain).
         self._rollout_permitted.clear()
+        try:
+            # 2. In-place weight update. to_thread because the synchronizer fans out
+            #    + ray.gets internally and must stay off the event loop so in-flight
+            #    generate_async() coroutines keep progressing during refit.
+            t0 = time.monotonic()
+            await asyncio.to_thread(self._weight_synchronizer.sync_weights)
+            elapsed = time.monotonic() - t0
+            print(f"  _sync_weights: sync done in {elapsed:.3f}s", flush=True)
 
-        # TODO: currently sync_weights is not implemented, comment out for now
-        # # Drain: wait for all in-flight rollouts to complete before NCCL
-        # # Critical: if GenWorker has queued calls when NCCL init is dispatched,
-        # # the init sits behind them — trainer blocks in rendezvous → deadlock
-        # drain_start = time.monotonic()
-        # while self._inflight_rollouts > 0:
-        #     await asyncio.sleep(0.005)
+            # 3. AReaL-style recompute: reset_running_requests=True makes vLLM PREEMPT
+            #    the running requests, free their old-weight KV, and reschedule them
+            #    -> they REPREFILL under the new weights and resume. invalidate_kv_cache
+            #    is on self._gen (the generation backend handle), NOT the rollout manager.
+            if self._async_cfg.refit_invalidate_kv_cache:
+                await asyncio.to_thread(
+                    self._gen.invalidate_kv_cache, reset_running_requests=True
+                )
 
-        # drain_elapsed = time.monotonic() - drain_start
-        # print(
-        #     f"  _sync_weights: drained in {drain_elapsed:.3f}s, "
-        #     f"syncing weights v{self._trainer_version}",
-        #     flush=True,
-        # )
-
-        t0 = time.monotonic()
-        await asyncio.to_thread(self._weight_synchronizer.sync_weights)
-        elapsed = time.monotonic() - t0
-
-        print(f"  _sync_weights: sync done in {elapsed:.3f}s", flush=True)
-        self._rollout_manager.set_weight_version(self._trainer_version)
-        self._rollout_permitted.set()
+            # 4. Publish the new weight version.
+            self._rollout_manager.set_weight_version(self._trainer_version)
+        finally:
+            # 5. ALWAYS resume NEW starts — even if sync_weights/invalidate_kv_cache
+            #    raised — so the rollout pump can never be left parked forever at
+            #    `await self._rollout_permitted.wait()` (which would hang shutdown).
+            self._rollout_permitted.set()
 
     async def _advantage_pump(self, meta: KVBatchMeta) -> KVBatchMeta:
         """Fetch advantage inputs, compute advantages, and write them back.

--- a/nemo_rl/algorithms/single_controller_areal.py
+++ b/nemo_rl/algorithms/single_controller_areal.py
@@ -1,0 +1,728 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SingleController: asyncio orchestrator for the RL training loop.
+
+CPU-only Ray actor that runs three concurrent pumps and coordinates the
+other actors via lightweight RPCs. SC sends control signals and reads
+metadata only — model tensors still move through DataPlane or NCCL.
+
+Data flow:
+  _rollout_pump  → rollout_manager.generate_and_push(prompt)
+                     → TQReplayBuffer.reserve claims a slot at dispatch time;
+                       run_rollout runs; TQReplayBuffer.commit tensorizes the
+                       record, writes N training rows to TQ, and marks ready.
+  _train_pump    → sampler.evict → buffer.remove (stale groups, with DP clear).
+                 → sampler.select → drops chosen groups from buffer, returns
+                   KVBatchMeta of K groups (or None); meta is already trainable.
+                 → _advantage_pump (get → compute → put).
+                 → trainer.train_on_meta.
+                 → dp_client.clear_samples (trained groups; buffer already dropped).
+  _sync_weights  → drain _inflight_rollouts → WeightSynchronizer.sync_weights.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Iterator, Optional, Union
+
+import ray
+import torch
+
+from nemo_rl.algorithms.async_utils.staleness_sampler import StalenessSampler
+from nemo_rl.algorithms.single_controller_utils.config import (
+    AdvantageConfig,
+    MasterConfig,
+    WeightSyncConfig,
+)
+from nemo_rl.algorithms.single_controller_utils.setup import SingleControllerBundle
+from nemo_rl.algorithms.single_controller_utils.utils import (
+    aggregate_step_metrics,
+    fields_for_put,
+    reduce_advantage_pump_metrics,
+    squeeze_trailing_unit_dim,
+    tensor_field,
+)
+from nemo_rl.data.interfaces import DatumSpec
+from nemo_rl.data_plane import KVBatchMeta
+from nemo_rl.models.generation.sglang import SGLangGeneration
+from nemo_rl.models.generation.vllm import VllmGeneration
+from nemo_rl.models.policy.tq_policy import TQPolicy
+from nemo_rl.utils.logger import Logger
+from nemo_rl.utils.timer import Timer
+
+Generation = Union[VllmGeneration, SGLangGeneration]
+
+
+@ray.remote(num_cpus=1, num_gpus=0)  # pragma: no cover
+class SingleControllerArealActor:
+    """CPU-only Ray actor that orchestrates the AReaL decoupled-PPO loop.
+
+    Standalone fork of :class:`SingleControllerActor` (no inheritance / mixin):
+    the base controller's machinery is copied verbatim so the AReaL two-phase
+    train loop and interruptible refit can diverge without modifying the base. 
+    At defaults (``num_minibatches=1``) this actor behaves identically to the 
+    base controller.
+
+    Owns three concurrent asyncio tasks:
+      - _rollout_pump: dispatches prompts via RolloutManager; reserve+commit in
+        TQReplayBuffer preserves dispatch order
+      - _train_pump:   evicts stale groups, samples a batch, trains, drops it
+      - _sync_weights: drain gate + weight synchronization
+
+    All other actors are passive — they expose methods and wait to be called.
+    """
+
+    def __init__(
+        self,
+        master_config: MasterConfig,
+        bundle: SingleControllerBundle,
+    ) -> None:
+        """Initialize the SingleController actor.
+
+        Args:
+            master_config: SC MasterConfig.
+            bundle: Pre-built bundle from setup_single_controller. Tests can
+                construct a bundle by hand (or with fakes) to bypass the real factories.
+        """
+        self._advantage_cfg = AdvantageConfig()
+        self._weight_sync_cfg = WeightSyncConfig()
+        self._partition_id: str = bundle.partition_id
+        self._diagnostics: bool = False
+
+        self._master_config = master_config
+        self._async_cfg = master_config.async_rl
+        self._dp_client = bundle.dp_client
+        self._gen: Generation = bundle.gen_handle
+        self._trainer: TQPolicy = bundle.trainer_handle
+        self._dataloader = bundle.dataloader
+        self._weight_synchronizer = bundle.weight_synchronizer
+        self._advantage_estimator = bundle.advantage_estimator
+        self._loss_fn = bundle.loss_fn
+        self._buffer = bundle.tq_buffer
+        self._rollout_manager = bundle.rollout_manager
+        # Rebind so writer and sampler share one buffer instance even
+        # when Ray deserializes rollout_manager and tq_buffer separately.
+        self._rollout_manager._tq_buffer = self._buffer
+
+        # Built here, not on the driver: Logger backends (wandb/tb/...) hold
+        # _thread.lock that Ray can't cloudpickle into the actor.
+        self._logger = Logger(master_config.logger)  # type: ignore
+        self._timer = Timer()
+
+        # Pin clusters so RayVirtualCluster.__del__ doesn't remove the PGs.
+        self._train_cluster = bundle.train_cluster
+        self._inference_cluster = bundle.inference_cluster
+
+        if self._async_cfg.target_prompt_groups_per_step is None:
+            self._async_cfg.target_prompt_groups_per_step = (
+                self._async_cfg.min_prompt_groups_per_batch
+            )
+        if (
+            self._async_cfg.target_prompt_groups_per_step
+            < self._async_cfg.min_prompt_groups_per_batch
+        ):
+            raise ValueError(
+                f"target_prompt_groups_per_step ({self._async_cfg.target_prompt_groups_per_step}) "
+                f"must be >= min_prompt_groups_per_batch ({self._async_cfg.min_prompt_groups_per_batch})"
+            )
+
+        if self._async_cfg.batch_selection_strategy == "strict_on_policy":
+            self._async_cfg.max_weight_staleness_versions = 0
+            self._async_cfg.over_sampling = False
+            print(
+                "Using strict_on_policy, auto setting max_weight_staleness_versions to 0 and over_sampling to False.",
+                flush=True,
+            )
+
+        if not self._async_cfg.over_sampling:
+            expected_buffer = self._async_cfg.target_prompt_groups_per_step * (
+                self._async_cfg.max_weight_staleness_versions + 1
+            )
+            if self._async_cfg.max_buffered_rollouts != expected_buffer:
+                raise ValueError(
+                    f"over_sampling=False requires max_buffered_rollouts "
+                    f"({self._async_cfg.max_buffered_rollouts}) == "
+                    f"target_prompt_groups_per_step * (max_weight_staleness_versions + 1) "
+                    f"({expected_buffer})"
+                )
+
+        if self._async_cfg.force_in_order and self._async_cfg.over_sampling:
+            raise ValueError(
+                "force_in_order=True requires over_sampling=False so that each "
+                "dispatched batch corresponds to exactly one target training step."
+            )
+
+        # SC split path does one optimizer.step per RL step.
+        # TODO: support multi-mini-step (legacy train() does gbs-sized
+        # mini-steps with shared prev_logprobs).
+        rl_step_samples = (
+            self._master_config.grpo["num_prompts_per_step"]
+            * self._master_config.grpo["num_generations_per_prompt"]
+        )
+        train_gbs = self._master_config.policy["train_global_batch_size"]
+        if rl_step_samples != train_gbs:
+            raise ValueError(
+                f"num_prompts_per_step * num_generations_per_prompt "
+                f"({rl_step_samples}) must equal policy.train_global_batch_size "
+                f"({train_gbs}) so that one RL step maps to exactly one "
+                f"optimizer.step. Multi-mini-step inside a single RL step is "
+                f"not supported on the SC split path."
+            )
+
+        self._sampler = StalenessSampler(
+            self._buffer,
+            max_staleness_versions=self._async_cfg.max_weight_staleness_versions,
+            require_order=not self._async_cfg.over_sampling,
+            force_in_order=self._async_cfg.force_in_order,
+        )
+
+        # ── asyncio state ──────────────────────────────────────────────────
+        # Gate: cleared during _sync_weights, set when generation may proceed
+        self._rollout_permitted: asyncio.Event = asyncio.Event()
+        self._rollout_permitted.set()
+
+        # Count of in-flight generate_and_push calls
+        self._inflight_rollouts: int = 0
+
+        # Cancellation handles for in-flight rollout dispatches.
+        self._dispatched_rollouts: set[asyncio.Task[None]] = set()
+
+        # over_sampling=False batch gate: farthest trainer_version covered by
+        # already-dispatched batches.
+        self._max_rollout_version: int = -1
+
+        # Backpressure valve: max unconsumed rollout groups allowed in DataPlane.
+        # Acquired before each rollout dispatch; released when the buffer
+        # drops a group (sampler.evict or post-train buffer.remove).
+        self._buffer_capacity: asyncio.Semaphore = asyncio.Semaphore(
+            self._async_cfg.max_buffered_rollouts
+        )
+
+        self._trainer_version: int = 0
+        self._train_steps: int = 0
+        self._step_consumed_sample_ids: list[str] = []
+        self._step_log_dict: dict[str, list] = {
+            "rewards": [],
+            "masked_advantages": [],
+            "sequence_lengths": [],
+        }
+
+        print(
+            f"SingleControllerArealActor: "
+            f"staleness_cap={self._async_cfg.max_weight_staleness_versions} "
+            f"buffer={self._async_cfg.max_buffered_rollouts} "
+            f"inflight={self._async_cfg.max_inflight_prompts} "
+            f"over_sampling={self._async_cfg.over_sampling} "
+            f"num_minibatches={self._async_cfg.num_minibatches} "
+            f"refit_invalidate_kv_cache={self._async_cfg.refit_invalidate_kv_cache} "
+            f"transport={self._weight_sync_cfg.transport}",
+            flush=True,
+        )
+
+    # ── public API ─────────────────────────────────────────────────────────
+
+    async def run(self) -> dict[str, Any]:
+        """Main entry point. Runs until max_train_steps is reached."""
+        # Synchronize weights before starting the pumps
+        await self._sync_weights()
+
+        # Start the rollout and train pumps
+        rollout_task = asyncio.create_task(self._rollout_pump())
+        train_task = asyncio.create_task(self._train_pump())
+
+        # Wait until the train pump is done
+        await train_task
+        self._logger.finish()
+
+        # Cancel the rollout pump and any in-flight dispatches so we exit immediately.
+        rollout_task.cancel()
+        try:
+            await rollout_task
+        except asyncio.CancelledError:
+            pass
+        inflight = list(self._dispatched_rollouts)
+        for task in inflight:
+            task.cancel()
+        if inflight:
+            await asyncio.gather(*inflight, return_exceptions=True)
+
+        return {
+            "train_steps": self._train_steps,
+            "trainer_version": self._trainer_version,
+        }
+
+    async def ping(self) -> dict[str, Any]:
+        """Liveness check — returns immediately if event loop is running."""
+        return {
+            "alive": True,
+            "trainer_version": self._trainer_version,
+            "train_steps": self._train_steps,
+            "inflight_rollouts": self._inflight_rollouts,
+            "rollout_permitted": self._rollout_permitted.is_set(),
+        }
+
+    # ── internal helpers ───────────────────────────────────────────────────
+
+    async def _ray_get(self, obj_ref: Any) -> Any:
+        """Await a Ray ObjectRef without blocking the asyncio event loop."""
+        return await obj_ref
+
+    async def _call_dp(self, method_name: str, **kwargs) -> Any:
+        """Call a DataPlaneClient method or a Ray actor exposing that method."""
+        method = getattr(self._dp_client, method_name)
+        remote = getattr(method, "remote", None)
+        if remote is not None:
+            return await self._ray_get(remote(**kwargs))
+        result = method(**kwargs)
+        if asyncio.iscoroutine(result):
+            return await result
+        return result
+
+    async def _rollout_pump(self) -> None:
+        """Continuously dispatch rollout tasks until cancellation.
+
+        Per batch (over_sampling=False):
+          0. Wait while _max_rollout_version >= trainer_version + max_staleness,
+             then claim the next step by incrementing _max_rollout_version.
+
+        Per prompt:
+          1. Acquire _buffer_capacity slot (backpressure)
+          2. Acquire sem (cap concurrent in-flight rollouts)
+          3. Wait for _rollout_permitted (paused during weight sync)
+          4. Call rollout_manager.generate_and_push(prompt) — local async
+             RolloutManager reserves a slot, runs the rollout, then commits the
+             group via TQReplayBuffer (→ dp_client.put_samples + mark ready)
+          5. Decrement _inflight_rollouts
+        """
+        sem = asyncio.Semaphore(self._async_cfg.max_inflight_prompts)
+        over_sampling = self._async_cfg.over_sampling
+        max_staleness = self._async_cfg.max_weight_staleness_versions
+        force_in_order = self._async_cfg.force_in_order
+        print("rollout_pump: starting", flush=True)
+
+        async def _dispatch_one_prompt(
+            prompt: DatumSpec, target_step: Optional[int]
+        ) -> None:
+            self._inflight_rollouts += 1
+            try:
+                await self._rollout_manager.generate_and_push(
+                    prompt, target_step=target_step
+                )
+                if self._diagnostics:
+                    content = ""
+                    for i in range(len(prompt["message_log"])):
+                        if prompt["message_log"][i]["role"] == "user":
+                            content = prompt["message_log"][i]["content"]
+                            break
+                    print(f"  rollout done for prompt='{content[:20]}...'", flush=True)
+            finally:
+                self._inflight_rollouts -= 1
+                sem.release()
+
+        max_epochs = self._master_config.grpo["max_num_epochs"]
+        epoch = 0
+        while max_epochs is None or epoch < max_epochs:
+            for prompt_batch in self._dataloader:
+                # over_sampling=False: batch-level gate on max_rollout_version.
+                if not over_sampling:
+                    while (
+                        self._max_rollout_version
+                        >= self._trainer_version + max_staleness
+                    ):
+                        await asyncio.sleep(0.005)
+                    self._max_rollout_version += 1
+
+                # target_step = batch dispatch index when force_in_order is on.
+                target_step = self._max_rollout_version if force_in_order else None
+
+                for prompt_idx in range(prompt_batch.size):
+                    prompt: DatumSpec = {  # type: ignore
+                        k: v[prompt_idx] for k, v in prompt_batch.items()
+                    }
+
+                    # check if buffer is full
+                    await self._buffer_capacity.acquire()
+                    # check if inflight rollouts is full
+                    await sem.acquire()
+                    # wait for rollout to be permitted
+                    await self._rollout_permitted.wait()
+
+                    # dispatch rollout
+                    task = asyncio.create_task(
+                        _dispatch_one_prompt(prompt, target_step)
+                    )
+                    self._dispatched_rollouts.add(task)
+                    task.add_done_callback(self._dispatched_rollouts.discard)
+            epoch += 1
+
+        print(f"rollout_pump: completed {epoch} epoch(s)", flush=True)
+
+    async def _train_pump(self) -> None:
+        """Drain stale groups, sample, train, drop.
+
+        Per step:
+          1. sampler.evict drops stale groups from the buffer and clears their TQ rows.
+          2. sampler.select returns K prompt groups (or None) and drops them from the
+             buffer; DP rows survive so the trainer can read them. Already trainable —
+             buffer wrote training-shaped rows at rollout time.
+          3. _advantage_pump(train_meta).
+          4. trainer.train_microbatch_from_meta + finish_train_step.
+          5. dp_client.clear_samples on consumed sample_ids; release _buffer_capacity
+             per dropped group, then sync.
+
+        P0 note: this is a verbatim fork of the base controller loop with the
+        AReaL ``step_results`` scaffolding added — each ``finish_train_step``
+        result is collected into ``step_results`` and reduced through the EXISTING
+        ``aggregate_step_metrics`` helper. At ``num_minibatches=1`` there is a
+        single optimizer step per training step, so ``step_results`` holds exactly
+        one result and the reduced metrics are byte-for-byte identical to the base
+        controller (no behavior change at defaults). P2 replaces this single-step
+        body with the two-phase Phase-1 barrier + per-minibatch Phase-2 loop that
+        appends one result per minibatch to the SAME ``step_results`` list.
+        """
+        adv_cfg = self._advantage_cfg
+        grpo_cfg = self._master_config.grpo
+
+        # TODO: fix the compute_prev_logprobs and compute_reference_logprobs logic
+        compute_prev_logprobs = adv_cfg.policy_logprobs_field is not None
+        compute_reference_logprobs = adv_cfg.reference_logprobs_field is not None
+
+        while self._train_steps < grpo_cfg["max_num_steps"]:
+            step_id = f"sc-step-{self._train_steps:06d}"
+            # __init__ coerces None → min_prompt_groups_per_batch (int);
+            # the assert narrows the Optional[int] type for pyrefly.
+            assert self._async_cfg.target_prompt_groups_per_step is not None
+            target_groups: int = self._async_cfg.target_prompt_groups_per_step
+            groups_dispatched = 0
+            step_open = False
+            # AReaL scaffolding: one finish_train_step result per optimizer step.
+            # P0 (num_minibatches=1) appends exactly one; P2's minibatch loop
+            # appends one per minibatch. Reduced via the existing helper below.
+            step_results: list[dict[str, Any]] = []
+
+            with self._timer.time("total_step_time"):
+                while groups_dispatched < target_groups:
+                    await asyncio.sleep(0)
+
+                    # evict stale groups
+                    evicted = await self._sampler.evict(
+                        current_train_weight=self._trainer_version,
+                    )
+                    if evicted:
+                        print(f"  evicted {evicted} stale prompt group(s)", flush=True)
+                        for _ in range(evicted):
+                            self._buffer_capacity.release()
+
+                    # TODO @yukih: wait train pump merged, now always return min_prompt_groups_per_batch
+                    # need to add a max_prompt_groups_per_batch
+                    with self._timer.time("exposed_generation"):
+                        train_meta, num_groups = await self._sampler.select(
+                            current_train_weight=self._trainer_version,
+                            min_prompt_groups=self._async_cfg.min_prompt_groups_per_batch,
+                        )
+
+                    if train_meta is None:
+                        await asyncio.sleep(0.05)
+                        continue
+
+                    for _ in range(num_groups):
+                        self._buffer_capacity.release()
+
+                    # Compute prev_logprobs / ref_logprobs
+                    with self._timer.time("logprob_inference_prep"):
+                        await asyncio.to_thread(self._trainer.prepare_for_lp_inference)
+                    with self._timer.time("policy_and_reference_logprobs"):
+                        if compute_prev_logprobs:
+                            await asyncio.to_thread(
+                                self._trainer.get_logprobs_from_meta, train_meta
+                            )
+                        if compute_reference_logprobs:
+                            await asyncio.to_thread(
+                                self._trainer.get_reference_policy_logprobs_from_meta,
+                                train_meta,
+                            )
+
+                    with self._timer.time("advantage_calculation"):
+                        train_meta = await self._advantage_pump(train_meta)
+
+                    # Train
+                    with self._timer.time("training_prep"):
+                        await asyncio.to_thread(self._trainer.prepare_for_training)
+                    with self._timer.time("policy_training"):
+                        if not step_open:
+                            await asyncio.to_thread(
+                                self._trainer.begin_train_step,
+                                step_id,
+                                loss_fn=self._loss_fn,
+                            )
+                            step_open = True
+                        await asyncio.to_thread(
+                            self._trainer.train_microbatch_from_meta,
+                            step_id,
+                            train_meta,
+                        )
+
+                    groups_dispatched += num_groups
+                    self._step_consumed_sample_ids.extend(train_meta.sample_ids)
+                    if train_meta.sequence_lengths:
+                        self._step_log_dict["sequence_lengths"].extend(
+                            int(s) for s in train_meta.sequence_lengths
+                        )
+
+                if not step_open:
+                    print(
+                        "train_pump: rollout exhausted before any group ready",
+                        flush=True,
+                    )
+                    break
+
+                with self._timer.time("policy_training"):
+                    result = await asyncio.to_thread(
+                        self._trainer.finish_train_step, step_id
+                    )
+                step_results.append(result)
+                consumed_ids = list(self._step_consumed_sample_ids)
+                self._step_consumed_sample_ids = []
+                await self._call_dp(
+                    "clear_samples",
+                    sample_ids=list(consumed_ids),
+                    partition_id=self._partition_id,
+                )
+
+                # Reduce the per-optimizer-step finish results through the EXISTING
+                # metrics path (no new helper). At num_minibatches=1 step_results
+                # holds one result, so aggregate_step_metrics(step_results[-1])
+                # reproduces the base controller exactly. P2 reduces all M results.
+                step_metrics = aggregate_step_metrics(step_results[-1])
+                step_metrics.update(
+                    reduce_advantage_pump_metrics(**self._step_log_dict)
+                )
+                self._step_log_dict = {k: [] for k in self._step_log_dict}
+
+                self._trainer_version += 1
+                self._train_steps += 1
+                with self._timer.time("weight_sync"):
+                    await self._sync_weights()
+
+            timing_metrics: dict[str, float] = self._timer.get_timing_metrics(
+                reduction_op="sum"
+            )  # type: ignore
+
+            total_time = timing_metrics.get("total_step_time", 0.0)
+            cluster_cfg = self._master_config.cluster
+            total_num_gpus = cluster_cfg["num_nodes"] * cluster_cfg["gpus_per_node"]
+            if total_time > 0 and "global_valid_toks" in step_metrics:
+                timing_metrics["valid_tokens_per_sec_per_gpu"] = (
+                    step_metrics["global_valid_toks"] / total_time / total_num_gpus
+                )
+
+            print("\n⏱️  Timing:")
+            print(f"  • Total step time: {total_time:.2f}s")
+            for k, v in sorted(
+                timing_metrics.items(), key=lambda item: item[1], reverse=True
+            ):
+                if k == "total_step_time":
+                    continue
+                percent = (v / total_time * 100) if total_time > 0 else 0.0
+                print(f"  • {k}: {v:.2f}s ({percent:.1f}%)")
+
+            # TODO: checkpointing (save_period/top-k metric_name,
+            #   policy.save_checkpoint, dataloader state, TQReplayBuffer state).
+            # TODO: per-step train_data jsonl dump, vllm metrics logger,
+            #   histogram log, rollout_metrics, seq_logprob_error_metrics,
+            #   pretty-print "Training Results" block, print_performance_metrics.
+            print(f"step_metrics={step_metrics}", flush=True)
+            self._logger.log_metrics(
+                step_metrics, step=self._train_steps, prefix="train"
+            )
+            self._logger.log_metrics(
+                timing_metrics, step=self._train_steps, prefix="timing/train"
+            )
+            self._timer.reset()
+
+            # min sample version refers to the version each consumed sample was
+            # generated with; lag = current trainer version - oldest sample version.
+            min_sample_version = min(t["weight_version"] for t in train_meta.tags)  # type: ignore
+            lag = self._trainer_version - min_sample_version
+            print(
+                f"train step {self._train_steps}/{grpo_cfg['max_num_steps']}  "
+                f"trainer_v={self._trainer_version}  "
+                f"lag={lag}  "
+                f"batch_size={len(consumed_ids)}",
+                flush=True,
+            )
+
+    # ── AReaL helpers ──────────────────────────────────────────────────────
+
+    def _iter_minibatches(
+        self, batch_meta: "KVBatchMeta"
+    ) -> Iterator["KVBatchMeta"]:
+        """Yield ``num_minibatches`` contiguous slices of the batch, in order.
+
+        Each yielded meta is ONE optimizer step (one begin/train_microbatch/
+        finish cycle in Phase 2). Deterministic, no shuffle — matches AReaL,
+        which splits the flat batch into ``ppo_n_minibatches`` in order (single
+        pass, each sample used exactly once). The split is even; the leading
+        minibatches absorb the remainder. ``num_minibatches=1`` yields the whole
+        batch unchanged (one optimizer step per training step).
+
+        Args:
+            batch_meta: the frozen full-batch ``KVBatchMeta`` (Phase 1 output).
+
+        Yields:
+            Contiguous, non-overlapping ``KVBatchMeta`` slices whose union is the
+            full batch. Empty slices (when ``num_minibatches > batch size``) are
+            skipped.
+        """
+        n = batch_meta.size  # total sequences in the batch
+        m = self._async_cfg.num_minibatches
+        if m < 1:
+            raise ValueError(f"num_minibatches must be >= 1, got {m}")
+        # Even split; the first (n % m) minibatches each take one extra sample.
+        sizes = [n // m + (1 if i < n % m else 0) for i in range(m)]
+        start = 0
+        for sz in sizes:
+            if sz == 0:
+                continue
+            yield batch_meta.slice(start, start + sz)
+            start += sz
+
+
+    async def _sync_weights(self) -> None:
+        """Drain in-flight rollouts then synchronize weights.
+
+        SC owns the drain gate (when to sync); WeightSynchronizer owns how.
+
+        Flow:
+          1. _rollout_permitted.clear()  — no new dispatches
+          2. drain _inflight_rollouts → 0  (5ms poll)
+          3. weight_synchronizer.sync_weights(trainer_version)
+          4. _rollout_permitted.set()   — resume
+        """
+        self._rollout_permitted.clear()
+
+        # TODO: currently sync_weights is not implemented, comment out for now
+        # # Drain: wait for all in-flight rollouts to complete before NCCL
+        # # Critical: if GenWorker has queued calls when NCCL init is dispatched,
+        # # the init sits behind them — trainer blocks in rendezvous → deadlock
+        # drain_start = time.monotonic()
+        # while self._inflight_rollouts > 0:
+        #     await asyncio.sleep(0.005)
+
+        # drain_elapsed = time.monotonic() - drain_start
+        # print(
+        #     f"  _sync_weights: drained in {drain_elapsed:.3f}s, "
+        #     f"syncing weights v{self._trainer_version}",
+        #     flush=True,
+        # )
+
+        t0 = time.monotonic()
+        await asyncio.to_thread(self._weight_synchronizer.sync_weights)
+        elapsed = time.monotonic() - t0
+
+        print(f"  _sync_weights: sync done in {elapsed:.3f}s", flush=True)
+        self._rollout_manager.set_weight_version(self._trainer_version)
+        self._rollout_permitted.set()
+
+    async def _advantage_pump(self, meta: KVBatchMeta) -> KVBatchMeta:
+        """Fetch advantage inputs, compute advantages, and write them back.
+
+        SC owns the prompt-group-scoped advantage stage because the selected
+        ``KVBatchMeta`` still contains complete prompt groups before trainer
+        DP sharding. Tensor payloads still move through DataPlane: SC fetches
+        only the configured advantage input columns and writes the computed
+        ``advantages`` column back under the same ``sample_ids``.
+        """
+        if self._advantage_estimator is None:
+            return meta
+        adv_cfg = self._advantage_cfg
+
+        data = await self._call_dp(
+            "get_samples",
+            sample_ids=meta.sample_ids,
+            partition_id=meta.partition_id,
+            select_fields=self._advantage_input_fields(),
+        )
+
+        prompt_ids = tensor_field(data, adv_cfg.prompt_ids_field)
+        rewards = squeeze_trailing_unit_dim(
+            tensor_field(data, adv_cfg.reward_field)
+        ).float()
+        self._step_log_dict["rewards"].append(rewards.detach())
+        token_mask = tensor_field(data, adv_cfg.token_mask_field).float()
+        sample_mask = squeeze_trailing_unit_dim(
+            tensor_field(data, adv_cfg.sample_mask_field)
+        ).float()
+        mask = token_mask * sample_mask.unsqueeze(-1)
+
+        repeated_batch: dict[str, torch.Tensor] = {
+            "total_reward": rewards,
+        }
+        for field_name in adv_cfg.repeated_batch_fields:
+            repeated_batch[field_name] = squeeze_trailing_unit_dim(
+                tensor_field(data, field_name)
+            )
+
+        kwargs: dict[str, torch.Tensor] = {}
+        if adv_cfg.policy_logprobs_field is not None:
+            kwargs["logprobs_policy"] = tensor_field(
+                data,
+                adv_cfg.policy_logprobs_field,
+            )
+        if adv_cfg.reference_logprobs_field is not None:
+            kwargs["logprobs_reference"] = tensor_field(
+                data,
+                adv_cfg.reference_logprobs_field,
+            )
+
+        advantages = self._advantage_estimator.compute_advantage(
+            prompt_ids=prompt_ids,
+            rewards=rewards,
+            mask=mask,
+            repeated_batch=repeated_batch,
+            **kwargs,
+        )
+        self._step_log_dict["masked_advantages"].append(
+            torch.masked_select(advantages.detach(), mask.bool())
+        )
+
+        await self._call_dp(
+            "put_samples",
+            sample_ids=meta.sample_ids,
+            partition_id=meta.partition_id,
+            fields=fields_for_put(
+                meta,
+                {adv_cfg.output_field: advantages},
+            ),
+        )
+        return meta.with_fields([adv_cfg.output_field])
+
+    # ── utility helpers ────────────────────────────────────────────────────
+
+    def _advantage_input_fields(self) -> list[str]:
+        adv_cfg = self._advantage_cfg
+        fields = [
+            adv_cfg.prompt_ids_field,
+            adv_cfg.reward_field,
+            adv_cfg.token_mask_field,
+            adv_cfg.sample_mask_field,
+            *adv_cfg.repeated_batch_fields,
+        ]
+        if adv_cfg.policy_logprobs_field is not None:
+            fields.append(adv_cfg.policy_logprobs_field)
+        if adv_cfg.reference_logprobs_field is not None:
+            fields.append(adv_cfg.reference_logprobs_field)
+        return list(dict.fromkeys(fields))

--- a/nemo_rl/algorithms/single_controller_areal.py
+++ b/nemo_rl/algorithms/single_controller_areal.py
@@ -63,7 +63,7 @@ from nemo_rl.algorithms.single_controller_utils.utils import (
 )
 from nemo_rl.data.interfaces import DatumSpec
 from nemo_rl.data_plane import KVBatchMeta
-from nemo_rl.models.generation.sglang import SGLangGeneration
+from nemo_rl.models.generation.sglang.sglang_generation import SGLangGeneration
 from nemo_rl.models.generation.vllm import VllmGeneration
 from nemo_rl.models.policy.tq_policy import TQPolicy
 from nemo_rl.utils.logger import Logger
@@ -139,8 +139,7 @@ class SingleControllerArealActor:
         # split into minibatches of train_global_batch_size, ONE optimizer.step
         # each (num_minibatches = rl_step_samples // train_global_batch_size).
         # AReaL collects exactly num_prompts_per_step groups per step; the streaming
-        # knobs target_prompt_groups_per_step / min_prompt_groups_per_batch are NOT
-        # used on this path.
+        # knob min_prompt_groups_per_batch is NOT used on this path.
         self._num_prompt_groups_per_step: int = self._master_config.grpo[
             "num_prompts_per_step"
         ]
@@ -255,6 +254,7 @@ class SingleControllerArealActor:
             "rewards": [],
             "masked_advantages": [],
             "sequence_lengths": [],
+            "gen_tokens_per_sample": [],
         }
 
         print(
@@ -653,7 +653,7 @@ class SingleControllerArealActor:
 
         (``num_prompt_groups_per_step`` == grpo.num_prompts_per_step — the AReaL
         path collects exactly that many groups per step and does NOT use the
-        streaming knobs target_prompt_groups_per_step / min_prompt_groups_per_batch).
+        streaming knob min_prompt_groups_per_batch).
         This method computes the value and writes it back onto
         ``async_cfg.max_buffered_rollouts`` so the ``_buffer_capacity`` semaphore
         and the startup banner both use the derived (auditable) number. A
@@ -688,9 +688,8 @@ class SingleControllerArealActor:
         """Trim a tail remainder so the batch is a whole number of minibatches.
 
         The full batch is normally exactly ``rl_step_samples == k * minibatch_size``
-        (``minibatch_size == train_global_batch_size``), but the
-        ``target_prompt_groups_per_step % min_prompt_groups_per_batch`` over-claim
-        edge can leave a smaller tail; trim to the largest multiple of
+        (``minibatch_size == train_global_batch_size``), but if a claim ever
+        leaves a smaller tail, trim to the largest multiple of
         ``minibatch_size``. Each kept minibatch is then exactly ``minibatch_size``,
         which ``__init__`` already verified is a DP multiple. Returns
         ``(meta_to_train, dropped)``; the dropped tail rows already had advantages
@@ -735,8 +734,8 @@ class SingleControllerArealActor:
             or ``None`` if rollout is exhausted with nothing left to train.
         """
         # AReaL collects exactly num_prompts_per_step groups (the full RL-step
-        # batch) before training; it does NOT use the streaming knobs
-        # target_prompt_groups_per_step / min_prompt_groups_per_batch.
+        # batch) before training; it does NOT use the streaming knob
+        # min_prompt_groups_per_batch.
         target: int = self._num_prompt_groups_per_step
         claimed: list[KVBatchMeta] = []
         n = 0
@@ -752,9 +751,11 @@ class SingleControllerArealActor:
                 self._buffer_capacity.release()
 
             # Claim in-window groups (lag ≤ η). select() returns (meta|None, num).
+            # min == max == the full step: one all-or-nothing claim.
             train_meta, num = await self._sampler.select(
                 current_train_weight=self._trainer_version,
                 min_prompt_groups=self._num_prompt_groups_per_step,
+                max_prompt_groups=self._num_prompt_groups_per_step,
             )
 
             if train_meta is None:
@@ -883,6 +884,15 @@ class SingleControllerArealActor:
             tensor_field(data, adv_cfg.sample_mask_field)
         ).float()
         mask = token_mask * sample_mask.unsqueeze(-1)
+
+        # Per-row generated-token counts: token_mask marks the trained
+        # (assistant) tokens, so its row sum is the generation length on the
+        # gym path. Reduced at step end into the legacy-named
+        # gen_tokens_per_sample/* metrics so wandb charts line up across the
+        # legacy and SC paths.
+        self._step_log_dict["gen_tokens_per_sample"].extend(
+            token_mask.sum(dim=-1).tolist()
+        )
 
         repeated_batch: dict[str, torch.Tensor] = {
             "total_reward": rewards,

--- a/nemo_rl/algorithms/single_controller_areal.py
+++ b/nemo_rl/algorithms/single_controller_areal.py
@@ -55,7 +55,7 @@ from nemo_rl.algorithms.single_controller_utils.config import (
 )
 from nemo_rl.algorithms.single_controller_utils.setup import SingleControllerBundle
 from nemo_rl.algorithms.single_controller_utils.utils import (
-    aggregate_step_metrics,
+    aggregate_step_metrics_multi_minibatch,
     fields_for_put,
     reduce_advantage_pump_metrics,
     squeeze_trailing_unit_dim,
@@ -564,11 +564,10 @@ class SingleControllerArealActor:
                     partition_id=self._partition_id,
                 )
 
-                # Reduce the per-minibatch finish results through the EXISTING
-                # metrics path (no new helper). The last minibatch's metrics carry
-                # the step-level scalars (lr/wd after the final scheduler.step,
-                # global valid seqs/toks); aggregate_step_metrics flattens them.
-                step_metrics = aggregate_step_metrics(step_results[-1])
+                # Reduce every per-minibatch finish result into one RL-step view.
+                # LR/WD come from the final optimizer result; token counts and
+                # FLOPs span the whole list for correct throughput accounting.
+                step_metrics = aggregate_step_metrics_multi_minibatch(step_results)
                 step_metrics.update(
                     reduce_advantage_pump_metrics(**self._step_log_dict)
                 )

--- a/nemo_rl/algorithms/single_controller_areal.py
+++ b/nemo_rl/algorithms/single_controller_areal.py
@@ -255,6 +255,7 @@ class SingleControllerArealActor:
             "masked_advantages": [],
             "sequence_lengths": [],
             "gen_tokens_per_sample": [],
+            "staleness": [],
         }
 
         print(
@@ -520,6 +521,17 @@ class SingleControllerArealActor:
                         f"minibatches",
                         flush=True,
                     )
+
+                # Per-sample staleness = version gap at consumption. The
+                # weight_version tag is pinned to the rollout's start version,
+                # so refits during generation do not change this value.
+                sample_versions = [
+                    t["weight_version"]
+                    for t in train_meta.tags  # type: ignore
+                ]
+                self._step_log_dict["staleness"].extend(
+                    self._trainer_version - v for v in sample_versions
+                )
 
                 # ══════════ PHASE 2 — per-MINIBATCH optimizer steps (single pass) ══
                 with self._timer.time("training_prep"):

--- a/nemo_rl/algorithms/single_controller_areal.py
+++ b/nemo_rl/algorithms/single_controller_areal.py
@@ -215,7 +215,7 @@ class SingleControllerArealActor:
         self._sampler = StalenessSampler(
             self._buffer,
             max_staleness_versions=self._async_cfg.max_weight_staleness_versions,
-            require_order=not self._async_cfg.over_sampling,
+            require_order=False,  # AReaL will consume whatever is ready
             force_in_order=self._async_cfg.force_in_order,
         )
 
@@ -743,11 +743,12 @@ class SingleControllerArealActor:
 
             # Drop groups that aged past the staleness window [v-η, v]; free
             # their buffer slots so the rollout pump can keep producing.
-            evicted = await self._sampler.evict(
-                current_train_weight=self._trainer_version,
-            )
-            for _ in range(evicted):
-                self._buffer_capacity.release()
+            if self._async_cfg.get("evict_stale_samples", True):  # AReaL does not evict
+                evicted = await self._sampler.evict(
+                    current_train_weight=self._trainer_version,
+                )
+                for _ in range(evicted):
+                    self._buffer_capacity.release()
 
             # Claim in-window groups (lag ≤ η). select() returns (meta|None, num).
             # min == max == the full step: one all-or-nothing claim.

--- a/nemo_rl/algorithms/single_controller_utils/config.py
+++ b/nemo_rl/algorithms/single_controller_utils/config.py
@@ -57,6 +57,7 @@ class AsyncRLConfig(BaseModel, extra="allow"):
     # in-flight requests and reprefills them under the new weights;
     # False keeps stale KV (Magistral-style, cheaper).
     refit_invalidate_kv_cache: bool = True
+    evict_stale_samples: bool = True
 
 
 class MasterConfig(BaseModel, extra="allow"):

--- a/nemo_rl/algorithms/single_controller_utils/config.py
+++ b/nemo_rl/algorithms/single_controller_utils/config.py
@@ -50,12 +50,6 @@ class AsyncRLConfig(BaseModel, extra="allow"):
     force_in_order: bool = False
 
     # ── AReaL decoupled-PPO ────────────────────────────────────────────────
-    # == AReaL `ppo_n_minibatches`: split the full batch into this many
-    # minibatches; ONE optimizer step per minibatch (gsm8k recipe uses 1,
-    # boba 4). Split is deterministic / in-order, like AReaL — no shuffle
-    # (single pass, each sample used once). num_minibatches=1 reproduces
-    # today's "one optimizer step per training step".
-    num_minibatches: int = 1
     # ── refit / interruptible generation (idea borrowed from the legacy
     #    trajectory_collector prepare/resume_after_refit; implemented natively) ──
     # AReaL-style: after the weight swap, call

--- a/nemo_rl/algorithms/single_controller_utils/config.py
+++ b/nemo_rl/algorithms/single_controller_utils/config.py
@@ -49,6 +49,21 @@ class AsyncRLConfig(BaseModel, extra="allow"):
     # over_sampling=False.
     force_in_order: bool = False
 
+    # ── AReaL decoupled-PPO ────────────────────────────────────────────────
+    # == AReaL `ppo_n_minibatches`: split the full batch into this many
+    # minibatches; ONE optimizer step per minibatch (gsm8k recipe uses 1,
+    # boba 4). Split is deterministic / in-order, like AReaL — no shuffle
+    # (single pass, each sample used once). num_minibatches=1 reproduces
+    # today's "one optimizer step per training step".
+    num_minibatches: int = 1
+    # ── refit / interruptible generation (idea borrowed from the legacy
+    #    trajectory_collector prepare/resume_after_refit; implemented natively) ──
+    # AReaL-style: after the weight swap, call
+    # invalidate_kv_cache(reset_running_requests=True) so vLLM preempts
+    # in-flight requests and reprefills them under the new weights;
+    # False keeps stale KV (Magistral-style, cheaper).
+    refit_invalidate_kv_cache: bool = True
+
 
 class MasterConfig(BaseModel, extra="allow"):
     policy: PolicyConfig

--- a/nemo_rl/algorithms/single_controller_utils/utils.py
+++ b/nemo_rl/algorithms/single_controller_utils/utils.py
@@ -91,6 +91,142 @@ def aggregate_step_metrics(train_result: dict[str, Any]) -> dict[str, Any]:
     return metrics
 
 
+def _metric_values(value: Any) -> list[Any]:
+    """Normalize a metric payload so results can be concatenated by key."""
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    return [value]
+
+
+def _collect_reducible_metrics(
+    train_result: dict[str, Any],
+) -> dict[str, list[Any]]:
+    """Collect one finish result's metrics that share GRPO reductions."""
+    mb: dict[str, list[Any]] = {}
+    if "moe_metrics" in train_result:
+        mb.update(
+            {
+                f"moe/{k}": _metric_values(v)
+                for k, v in train_result["moe_metrics"].items()
+            }
+        )
+    if "mtp_metrics" in train_result:
+        mb.update(
+            {
+                f"mtp/{k}": _metric_values(v)
+                for k, v in train_result["mtp_metrics"].items()
+            }
+        )
+    mb.update(
+        {
+            k: _metric_values(v)
+            for k, v in train_result.get("all_mb_metrics", {}).items()
+        }
+    )
+    return mb
+
+
+def _reduce_mb_metrics(mb: dict[str, list[Any]]) -> dict[str, float]:
+    """Apply the legacy GRPO per-microbatch reduction rules."""
+    metrics: dict[str, float] = {}
+    for k, v in mb.items():
+        if k in _MB_METRIC_MIN:
+            valid = [x for x in v if not np.isinf(x)]
+            metrics[k] = float(np.min(valid)) if valid else -1.0
+        elif k in _MB_METRIC_MAX:
+            valid = [x for x in v if not np.isinf(x)]
+            metrics[k] = float(np.max(valid)) if valid else -1.0
+        elif k in _MB_METRIC_MEAN:
+            metrics[k] = float(np.mean(v))
+        else:
+            metrics[k] = float(np.sum(v))
+    return metrics
+
+
+def aggregate_step_metrics_multi_minibatch(
+    train_results: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Reduce an AReaL RL step's optimizer results into logging scalars.
+
+    Per-microbatch metric lists are concatenated before applying the existing
+    GRPO reductions; summed keys are then rescaled by 1/M because each finish
+    result's lists are already normalized within that minibatch (a result's
+    list sums to its minibatch mean). Metrics that describe one optimizer
+    result retain their natural cross-result semantics: loss and grad norm are
+    averaged, FLOPs and valid counts are summed, and the final optimizer
+    result supplies LR/WD.
+
+    Args:
+        train_results: Ordered ``finish_train_step`` outputs, one per AReaL
+            training minibatch.
+
+    Returns:
+        Flat dict of RL-step scalars ready for logging.
+
+    Raises:
+        ValueError: If no optimizer results are provided.
+    """
+    if not train_results:
+        raise ValueError(
+            "aggregate_step_metrics_multi_minibatch requires at least one train "
+            "result"
+        )
+    if len(train_results) == 1:
+        return aggregate_step_metrics(train_results[0])
+
+    per_result = [aggregate_step_metrics(result) for result in train_results]
+    merged_mb: dict[str, list[Any]] = {}
+    for result in train_results:
+        for key, values in _collect_reducible_metrics(result).items():
+            merged_mb.setdefault(key, []).extend(values)
+    metrics: dict[str, Any] = _reduce_mb_metrics(merged_mb)
+
+    # Each finish result's non-min/max lists are normalized within that
+    # minibatch (the worker rescales by its own 1/N, so a result's list sums
+    # to the minibatch MEAN — mirroring the sync path where the worker
+    # pre-divides by num_global_batches). Summing the concatenation therefore
+    # yields M× the per-step value; rescale summed keys back to the mean over
+    # minibatches. Min/max/mean rules need no correction, and the step-level
+    # keys below (valid counts, lr/wd) are overwritten explicitly anyway.
+    for key in merged_mb:
+        if (
+            key not in _MB_METRIC_MIN
+            and key not in _MB_METRIC_MAX
+            and key not in _MB_METRIC_MEAN
+        ):
+            metrics[key] /= len(train_results)
+
+    # These fields describe a whole optimizer result, not an individual inner
+    # microbatch. Reduce them across optimizer-step boundaries explicitly.
+    for key in ("loss", "grad_norm"):
+        values = [result[key] for result in per_result if key in result]
+        if values:
+            metrics[key] = float(np.mean(values))
+
+    # A finish result repeats its global count for each inner microbatch. The
+    # single-result reducer removes that duplication; the RL step then needs the
+    # sum across its separate optimizer steps for correct throughput metrics.
+    for key in ("total_flops", "global_valid_seqs", "global_valid_toks"):
+        values = [result[key] for result in per_result if key in result]
+        if values:
+            metrics[key] = float(np.sum(values))
+
+    num_ranks = [result["num_ranks"] for result in per_result if "num_ranks" in result]
+    if num_ranks:
+        metrics["num_ranks"] = num_ranks[-1]
+
+    # LR/WD are repeated within a finish result and change between optimizer
+    # steps. Log the values used by the final optimizer step.
+    for key in ("lr", "wd"):
+        if key in per_result[-1]:
+            metrics[key] = per_result[-1][key]
+        else:
+            metrics.pop(key, None)
+    return metrics
+
+
 def reduce_advantage_pump_metrics(
     rewards: list[torch.Tensor],
     masked_advantages: list[torch.Tensor],

--- a/nemo_rl/algorithms/single_controller_utils/utils.py
+++ b/nemo_rl/algorithms/single_controller_utils/utils.py
@@ -23,6 +23,7 @@ import torch
 from tensordict import TensorDict
 
 from nemo_rl.data_plane import KVBatchMeta
+from nemo_rl.experience.rollouts import _calculate_single_metric
 
 # Reduction rules for all_mb_metrics. Mirror grpo.py / grpo_sync.py.
 _MB_METRIC_MIN: frozenset[str] = frozenset(
@@ -94,16 +95,25 @@ def reduce_advantage_pump_metrics(
     rewards: list[torch.Tensor],
     masked_advantages: list[torch.Tensor],
     sequence_lengths: list[int],
-) -> dict[str, float]:
+    gen_tokens_per_sample: list[float] | None = None,
+) -> dict[str, Any]:
     """Reduce per-step accumulators from _advantage_pump into step scalars.
 
     Args:
         rewards: One tensor per advantage_pump call; each row a sample reward.
         masked_advantages: Token-masked advantages, one tensor per call.
         sequence_lengths: All input_lengths trained on this step.
+        gen_tokens_per_sample: Per-row generated-token counts (token_mask sums),
+            when the controller collects them. Emitted under the SAME metric
+            names as the legacy NeMo-Gym rollout path
+            (``gen_tokens_per_sample/*``, ``total_tokens_per_sample/*``,
+            ``mean_gen_tokens_per_sample``) so wandb charts line up across the
+            legacy and SC paths.
 
     Returns:
-        Dict with reward, advantages/{mean,max,min}, total_num_tokens.
+        Dict with reward, advantages/{mean,max,min}, total_num_tokens, and —
+        when ``gen_tokens_per_sample`` is provided — the legacy-named length
+        metrics above.
     """
     out: dict[str, float] = {}
     if rewards:
@@ -120,6 +130,24 @@ def reduce_advantage_pump_metrics(
             out["advantages/min"] = 0.0
     if sequence_lengths:
         out["total_num_tokens"] = float(sum(sequence_lengths))
+    if gen_tokens_per_sample:
+        out.update(
+            _calculate_single_metric(
+                gen_tokens_per_sample,
+                len(gen_tokens_per_sample),
+                "gen_tokens_per_sample",
+            )
+        )
+        # Alias kept for parity with the legacy path's downstream logging.
+        out["mean_gen_tokens_per_sample"] = out["gen_tokens_per_sample/mean"]
+        if sequence_lengths:
+            out.update(
+                _calculate_single_metric(
+                    sequence_lengths,
+                    len(sequence_lengths),
+                    "total_tokens_per_sample",
+                )
+            )
     return out
 
 

--- a/nemo_rl/algorithms/single_controller_utils/utils.py
+++ b/nemo_rl/algorithms/single_controller_utils/utils.py
@@ -232,6 +232,7 @@ def reduce_advantage_pump_metrics(
     masked_advantages: list[torch.Tensor],
     sequence_lengths: list[int],
     gen_tokens_per_sample: list[float] | None = None,
+    staleness: list[int] | None = None,
 ) -> dict[str, Any]:
     """Reduce per-step accumulators from _advantage_pump into step scalars.
 
@@ -245,11 +246,15 @@ def reduce_advantage_pump_metrics(
             (``gen_tokens_per_sample/*``, ``total_tokens_per_sample/*``,
             ``mean_gen_tokens_per_sample``) so wandb charts line up across the
             legacy and SC paths.
+        staleness: Per-sample weight-version lag (trainer version at
+            consumption minus the sample's generation version) for every
+            sample trained on this step.
 
     Returns:
         Dict with reward, advantages/{mean,max,min}, total_num_tokens, and —
         when ``gen_tokens_per_sample`` is provided — the legacy-named length
-        metrics above.
+        metrics above, and — when ``staleness`` is provided —
+        staleness/{mean,max,min}.
     """
     out: dict[str, float] = {}
     if rewards:
@@ -284,6 +289,10 @@ def reduce_advantage_pump_metrics(
                     "total_tokens_per_sample",
                 )
             )
+    if staleness:
+        out["staleness/mean"] = float(np.mean(staleness))
+        out["staleness/max"] = float(max(staleness))
+        out["staleness/min"] = float(min(staleness))
     return out
 
 

--- a/nemo_rl/algorithms/single_controller_utils/utils.py
+++ b/nemo_rl/algorithms/single_controller_utils/utils.py
@@ -23,7 +23,7 @@ import torch
 from tensordict import TensorDict
 
 from nemo_rl.data_plane import KVBatchMeta
-from nemo_rl.experience.rollouts import _calculate_single_metric
+from nemo_rl.experience.metric_utils import calculate_single_metric
 
 # Reduction rules for all_mb_metrics. Mirror grpo.py / grpo_sync.py.
 _MB_METRIC_MIN: frozenset[str] = frozenset(
@@ -268,7 +268,7 @@ def reduce_advantage_pump_metrics(
         out["total_num_tokens"] = float(sum(sequence_lengths))
     if gen_tokens_per_sample:
         out.update(
-            _calculate_single_metric(
+            calculate_single_metric(
                 gen_tokens_per_sample,
                 len(gen_tokens_per_sample),
                 "gen_tokens_per_sample",
@@ -278,7 +278,7 @@ def reduce_advantage_pump_metrics(
         out["mean_gen_tokens_per_sample"] = out["gen_tokens_per_sample/mean"]
         if sequence_lengths:
             out.update(
-                _calculate_single_metric(
+                calculate_single_metric(
                     sequence_lengths,
                     len(sequence_lengths),
                     "total_tokens_per_sample",

--- a/nemo_rl/data_plane/adapters/transfer_queue.py
+++ b/nemo_rl/data_plane/adapters/transfer_queue.py
@@ -157,7 +157,21 @@ def _patch_tq_actor_runtime_env() -> None:
     if _TQ_RUNTIME_ENV_PATCHED:
         return
 
-    runtime_env = {"pip": [_resolve_tq_pin()]}
+    # Escape hatch for images that already bake transfer_queue into the base
+    # env on every node (the exact end-state the TODO above describes): the
+    # pip injection is then pure overhead, and on multi-node cold starts the
+    # per-node pip install can exceed Ray's runtime_env setup timeout and
+    # kill the job (observed: 8-node run, RuntimeEnvSetupError after 600s).
+    if os.environ.get("NRL_TQ_SKIP_ACTOR_RUNTIME_ENV") == "1":
+        _TQ_RUNTIME_ENV_PATCHED = True
+        return
+
+    runtime_env = {
+        "pip": [_resolve_tq_pin()],
+        # Multi-node cold-start pip installs (one per node, concurrently,
+        # through the cluster's PyPI egress) can exceed Ray's 600s default.
+        "config": {"setup_timeout_seconds": 1800},
+    }
 
     def _install(cls) -> bool:
         if not hasattr(cls, "options"):

--- a/nemo_rl/models/generation/vllm/vllm_generation.py
+++ b/nemo_rl/models/generation/vllm/vllm_generation.py
@@ -1057,11 +1057,18 @@ class VllmGeneration(GenerationInterface):
         """
         self.shutdown()
 
-    def invalidate_kv_cache(self) -> bool:
+    def invalidate_kv_cache(self, reset_running_requests: bool = False) -> bool:
         """Invalidate reusable caches in vLLM (e.g., prefix/KV cache) after weight updates.
 
         For async_engine, calls reset_prefix_cache_async on workers. For sync, calls reset_prefix_cache.
         Returns True if all workers report success.
+
+        Args:
+            reset_running_requests: AReaL interruptible refit. When True, vLLM
+                preempts in-flight requests, frees their old-weight KV, and
+                reschedules them so they reprefill under the new weights. When
+                False (default), the reset is a no-op while requests hold KV
+                blocks, leaving stale KV (Magistral-style).
         """
         try:
             method_name = (
@@ -1072,6 +1079,7 @@ class VllmGeneration(GenerationInterface):
             futures = self.worker_group.run_all_workers_single_data(
                 method_name,
                 run_rank_0_only_axes=["tensor_parallel", "pipeline_parallel"],
+                reset_running_requests=reset_running_requests,
             )
             results = ray.get(futures)
             return all(result for result in results if result is not None)

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -987,8 +987,19 @@ class VllmGenerationWorkerImpl(BaseVllmGenerationWorker):
             traceback.print_exc()
             return False
 
-    def reset_prefix_cache(self):
-        """Reset the prefix cache of vLLM engine."""
+    def reset_prefix_cache(self, reset_running_requests: bool = False):
+        """Reset the prefix cache of vLLM engine.
+
+        Args:
+            reset_running_requests: AReaL interruptible refit. On the ASYNC
+                engine (``reset_prefix_cache_async``), True makes vLLM preempt
+                in-flight requests and reschedule them to reprefill under the
+                new weights. This SYNC path accepts the param only for signature
+                parity with the async version and does NOT forward it: the sync
+                vLLM ``LLMEngine.reset_prefix_cache()`` takes no
+                ``reset_running_requests`` argument (passing it would raise). The
+                SC/AReaL recipe is async-only, so this sync path is parity-only.
+        """
         assert self.llm is not None, (
             "Attempting to reset prefix cache with either an uninitialized vLLM or non-model-owner"
         )

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -1472,8 +1472,15 @@ class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
             traceback.print_exc()
             return False
 
-    async def reset_prefix_cache_async(self):
-        """Async version of reset_prefix_cache."""
+    async def reset_prefix_cache_async(self, reset_running_requests: bool = False):
+        """Async version of reset_prefix_cache.
+
+        Args:
+            reset_running_requests: AReaL interruptible refit. When True, vLLM
+                preempts in-flight requests and reschedules them so they
+                reprefill under the new weights; when False the reset is a
+                no-op while requests hold KV blocks.
+        """
         assert self.llm is not None, (
             "Attempting to reset prefix cache with either an uninitialized vLLM or non-model-owner"
         )
@@ -1483,7 +1490,9 @@ class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
                 "reset_prefix_cache_async can only be used with async_engine=True. Use reset_prefix_cache instead."
             )
 
-        await self.llm.reset_prefix_cache()
+        await self.llm.reset_prefix_cache(
+            reset_running_requests=reset_running_requests
+        )
         gc.collect()
         torch.cuda.empty_cache()
 

--- a/nemo_rl/utils/packed_tensor.py
+++ b/nemo_rl/utils/packed_tensor.py
@@ -101,6 +101,14 @@ def packed_broadcast_producer(iterator, group, src, post_iter_func):
                     group.broadcast(packed_tensors[buffer_idx], src=src)
                 break
 
+    # Drain the side streams before returning. The per-iteration synchronize
+    # above only waits on the buffer about to be REUSED; without this, the
+    # last buffer's pack + NCCL broadcast are still executing when the caller
+    # resumes and may mutate the source parameters mid-broadcast (torn
+    # weights sent to every consumer).
+    for stream in streams:
+        stream.synchronize()
+
 
 def packed_broadcast_consumer(iterator, group, src, post_unpack_func):
     """Consume a packed tensor and unpack it into a list of tensors.
@@ -208,3 +216,15 @@ def packed_broadcast_consumer(iterator, group, src, post_unpack_func):
                         )
                     )
                 break
+
+    # Drain the side streams before returning. The per-iteration synchronize
+    # above only waits on the buffer about to be REUSED, so when the loop
+    # exits the last buffer's NCCL recv + in-place param copies (including
+    # multi-phase weight_loader transforms like mamba's A := -exp(A_log))
+    # are still executing. Returning early lets the engine resume decoding
+    # concurrently with those writes — decode kernels then read torn or
+    # mid-transform weights, which poisons the persistent mamba SSM state
+    # (whole-tail NaN generations). The sibling IPC/ZMQ path already does
+    # this (vllm_backend.py: current_stream().synchronize() after load).
+    for stream in streams:
+        stream.synchronize()

--- a/tests/unit/models/generation/test_areal_invalidate_kv_cache.py
+++ b/tests/unit/models/generation/test_areal_invalidate_kv_cache.py
@@ -1,0 +1,239 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""P4 real-engine plumbing test: ``invalidate_kv_cache(reset_running_requests=...)``.
+
+Layer: REAL vLLM async engine + tiny model on a real GPU (NOT a mock). Per
+AREAL.md §9 (P4): "interruptible generation cannot be faked. A mock engine would
+only assert we *called* a method; the property under test ... is a behavior of
+the real vLLM async engine." This file is the "real-engine plumbing test (the
+actual proof of the fix)": it submits an **in-flight** async generation, then
+calls ``invalidate_kv_cache(reset_running_requests=True)`` MID-DECODE while the
+request holds KV blocks, and asserts the engine preempts/reschedules and the
+generation still completes (resumes under the swapped cache, not dropped, no
+hang) — vs the default ``False``, which no-ops while requests hold KV
+(``block_pool.py:665``).
+
+NOTE on the observable (verified against the real plumbing, not assumed):
+``invalidate_kv_cache`` returns ``all(r for r in results if r is not None)``,
+but the worker hops (``reset_prefix_cache_async`` / ``reset_prefix_cache``) do
+NOT return the bool from vLLM's ``reset_prefix_cache`` — they fall off the end
+returning ``None``. So ``invalidate_kv_cache`` returns ``True`` vacuously for
+BOTH flag values; the boolean return therefore does NOT distinguish
+preempt-vs-no-op. The robust observable is BEHAVIORAL: the call must (a) return
+without raising and (b) leave the in-flight decode able to complete with valid
+output. That is exactly the guarantee the AReaL refit needs (an in-flight
+rollout interrupts and resumes rather than hanging or being dropped) and is what
+a fake cannot prove because the preempt/reschedule lives in vLLM's scheduler.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+
+import pytest
+import torch
+
+from nemo_rl.algorithms.grpo import refit_policy_generation
+from nemo_rl.algorithms.utils import get_tokenizer
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
+from nemo_rl.models.generation import configure_generation_config
+from nemo_rl.models.generation.vllm import VllmGeneration
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="real vLLM async engine requires a GPU",
+)
+
+_MODEL = "Qwen/Qwen3-0.6B"
+
+_BASE_CFG = {
+    "backend": "vllm",
+    "model_name": _MODEL,
+    "tokenizer": {"name": _MODEL},
+    "dtype": "bfloat16",
+    # Long enough that the request is genuinely still decoding when we fire the
+    # invalidate mid-flight (so it is a RUNNING request holding KV blocks).
+    "max_new_tokens": 256,
+    "temperature": 1.0,
+    "top_p": 1.0,
+    "top_k": None,
+    "stop_token_ids": None,
+    "stop_strings": None,
+    "vllm_cfg": {
+        "precision": "bfloat16",
+        "tensor_parallel_size": 1,
+        "pipeline_parallel_size": 1,
+        "expert_parallel_size": 1,
+        "gpu_memory_utilization": 0.6,
+        "max_model_len": 1024,
+        "async_engine": True,  # the AReaL path is scoped to vLLM async
+        "skip_tokenizer_init": False,
+        "load_format": "auto",
+        "enforce_eager": "False",
+        "kv_cache_dtype": "auto",
+        # Prefix caching must be on for reset_prefix_cache to be meaningful.
+        "enable_prefix_caching": True,
+    },
+    "colocated": {
+        "enabled": True,
+        "resources": {"gpus_per_node": None, "num_nodes": None},
+    },
+    "vllm_kwargs": {},
+}
+
+
+@pytest.fixture(scope="function")
+def tokenizer():
+    return get_tokenizer(_BASE_CFG["tokenizer"])
+
+
+@pytest.fixture(scope="function")
+def cluster():
+    vc = RayVirtualCluster(
+        bundle_ct_per_node_list=[1],
+        use_gpus=True,
+        max_colocated_worker_groups=1,
+        num_gpus_per_node=1,
+        name="areal-invalidate-kv-cache-cluster",
+    )
+    yield vc
+    vc.shutdown()
+
+
+@pytest.fixture(scope="function")
+def async_gen(cluster, tokenizer):
+    """A REAL vLLM async-engine generation handle with real weights loaded."""
+    cfg = configure_generation_config(deepcopy(_BASE_CFG), tokenizer)
+    gen = VllmGeneration(cluster, cfg)
+    # Load real weights so generation actually decodes (refit from the policy is
+    # heavy; here we just need a running engine — load_format="auto" already
+    # loads the HF checkpoint at init, so no separate refit is required).
+    gen.prepare_for_generation()
+    yield gen
+    try:
+        gen.shutdown()
+        import gc
+
+        gc.collect()
+        torch.cuda.empty_cache()
+    except Exception as e:  # pragma: no cover - cleanup best effort
+        print(f"async_gen cleanup error: {e}")
+
+
+def _one_prompt(tokenizer) -> BatchedDataDict:
+    enc = tokenizer(
+        ["Write a long story about a robot learning to paint:"],
+        padding="max_length",
+        max_length=16,
+        truncation=True,
+        return_tensors="pt",
+        padding_side="right",
+    )
+    return BatchedDataDict(
+        {
+            "input_ids": enc["input_ids"],
+            "input_lengths": enc["attention_mask"].sum(dim=1).to(torch.int32),
+        }
+    )
+
+
+async def _drive(async_gen, tokenizer, *, reset_running_requests: bool):
+    """Submit one in-flight async generation, fire invalidate_kv_cache MID-DECODE,
+    and let the generation complete. Returns (invalidate_ok, output)."""
+    data = _one_prompt(tokenizer)
+    collected: list = []
+
+    async def _consume():
+        async for idx, out in async_gen.generate_async(data, greedy=False):
+            collected.append((idx, out))
+
+    gen_task = asyncio.create_task(_consume())
+
+    # Let the request reach the RUNNING state (prefill done, actively decoding) so
+    # the invalidate genuinely hits an in-flight request holding KV blocks.
+    await asyncio.sleep(1.0)
+    assert not gen_task.done(), (
+        "generation finished before we could invalidate mid-decode; "
+        "increase max_new_tokens"
+    )
+
+    # invalidate_kv_cache is a blocking (ray.get) call -> off the event loop so the
+    # in-flight decode keeps progressing, exactly as _sync_weights does it.
+    invalidate_ok = await asyncio.to_thread(
+        async_gen.invalidate_kv_cache,
+        reset_running_requests=reset_running_requests,
+    )
+
+    # The in-flight generation must RESUME and finish (not hang, not be dropped).
+    await asyncio.wait_for(gen_task, timeout=120.0)
+    assert len(collected) == 1
+    return invalidate_ok, collected[0][1]
+
+
+@pytest.mark.asyncio
+async def test_invalidate_with_reset_running_requests_true_preempts_and_resumes(
+    async_gen, tokenizer
+):
+    """reset_running_requests=True mid-decode: vLLM preempts the running request,
+    frees its old-weight KV, reschedules it -> it reprefills and RESUMES. We assert
+    the call returns without raising and the in-flight generation still completes
+    with valid output. (A fake engine cannot exhibit preempt/reschedule.)"""
+    invalidate_ok, out = await _drive(
+        async_gen, tokenizer, reset_running_requests=True
+    )
+
+    # Plumbing returned cleanly (note: bool is vacuously True on the async path —
+    # see module docstring; the real proof is the behavioral resume below).
+    assert invalidate_ok is True
+
+    # The preempted request resumed and produced real tokens.
+    assert "output_ids" in out
+    assert "generation_lengths" in out
+    gen_len = int(out["generation_lengths"].reshape(-1)[0].item())
+    assert gen_len > 0, "preempted request produced no tokens (dropped, not resumed)"
+    text = tokenizer.batch_decode(out["output_ids"], skip_special_tokens=True)[0]
+    assert len(text) > 0
+
+
+@pytest.mark.asyncio
+async def test_invalidate_with_reset_running_requests_false_is_noop_but_safe(
+    async_gen, tokenizer
+):
+    """Default reset_running_requests=False mid-decode: the reset is a no-op while
+    the request holds KV blocks (block_pool.py:665, Magistral-style). The in-flight
+    generation is untouched and completes normally. This is the control proving the
+    flag is the thing that changes behavior — and that the default path stays safe."""
+    invalidate_ok, out = await _drive(
+        async_gen, tokenizer, reset_running_requests=False
+    )
+
+    assert invalidate_ok is True
+    gen_len = int(out["generation_lengths"].reshape(-1)[0].item())
+    assert gen_len > 0
+    text = tokenizer.batch_decode(out["output_ids"], skip_special_tokens=True)[0]
+    assert len(text) > 0
+
+
+@pytest.mark.asyncio
+async def test_invalidate_idle_engine_succeeds_both_flags(async_gen, tokenizer):
+    """Sanity: with NO in-flight request, invalidate_kv_cache returns cleanly for
+    both flag values (the no-running-request path that grpo.py refit uses)."""
+    for flag in (False, True):
+        ok = await asyncio.to_thread(
+            async_gen.invalidate_kv_cache, reset_running_requests=flag
+        )
+        assert ok is True

--- a/tests/unit/single_controller/test_areal_train_pump.py
+++ b/tests/unit/single_controller/test_areal_train_pump.py
@@ -1,0 +1,756 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""P2 unit tests: AReaL two-phase ``_train_pump`` (call-order dry run).
+
+Layer: pure-Python / asyncio unit (no Ray actor, no GPU). Per AREAL.md §9 (P2)
+the test is a "dry-run streaming loop with a MOCK trainer recording call order".
+``_train_pump`` orchestrates collaborators it does not own — the trainer split
+API (``prepare_for_lp_inference`` / ``get_logprobs_from_meta`` /
+``prepare_for_training`` / ``begin_train_step`` / ``train_microbatch_from_meta`` /
+``finish_train_step`` / ``abort_train_step``), the data plane (``clear_samples``),
+``_collect_full_batch`` (P1, tested separately), ``_advantage_pump``, and
+``_sync_weights`` (P4, left as-is) — so the unit under test IS the orchestration:
+the two-phase ordering and the once-per-step publish. A MOCK trainer is the
+correct (and only) tool here because the assertion is about *call order and
+counts*, not numerics: numeric equivalence is P3, and real GPU training is the
+end-to-end recipe. Nothing about the loop structure is faked; only the GPU/Ray
+collaborators are recorded.
+
+SIZE-BASED model (corrected): each RL step consumes the FULL batch
+``rl_step_samples`` and splits it into minibatches of ``train_global_batch_size``
+sequences each — one ``optimizer.step`` per minibatch. ``num_minibatches`` is
+DERIVED (``rl_step_samples // train_global_batch_size``), NOT a config knob, and
+``_train_pump`` no longer reads ``self._async_cfg.num_minibatches`` or
+``self._dp_world``. It reads ``self._train_minibatch_size`` (== train_gbs),
+trims a tail remainder via the real ``_dp_align_batch``, then iterates the real
+size-based ``_iter_minibatches``. So we parametrize ``(full_batch_size,
+minibatch_size)`` and assert ``finish_train_step`` count ==
+``full_batch_size // minibatch_size``.
+
+We exercise the REAL forked ``_train_pump``, ``_iter_minibatches`` and
+``_dp_align_batch`` (and the REAL ``aggregate_step_metrics`` /
+``reduce_advantage_pump_metrics`` / ``Timer``), feeding REAL ``KVBatchMeta``
+batches. The surrounding ``@ray.remote`` actor and its bundle-heavy ``__init__``
+are bypassed via ``SingleControllerArealActor.__ray_actor_class__`` (the
+undecorated class behind the wrapper), with the methods bound to a tiny stub
+holding exactly the state the loop reads.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from nemo_rl.algorithms.single_controller_areal import SingleControllerArealActor
+from nemo_rl.data_plane import KVBatchMeta
+from nemo_rl.utils.timer import Timer
+
+_PARTITION_ID = "rollout_data"
+
+# The original (undecorated) class behind the @ray.remote wrapper.
+_ArealClass = SingleControllerArealActor.__ray_actor_class__
+
+
+def _make_batch(n: int) -> KVBatchMeta:
+    """Real full-batch KVBatchMeta with ``n`` rows. ``tags`` carry a
+    ``weight_version`` so the loop's lag log path is exercised."""
+    return KVBatchMeta(
+        partition_id=_PARTITION_ID,
+        task_name="train",
+        sample_ids=[f"s{i}" for i in range(n)],
+        sequence_lengths=[i + 1 for i in range(n)],
+        tags=[{"row": i, "weight_version": 0} for i in range(n)],
+    )
+
+
+class _RecordingTrainer:
+    """Mock trainer: records the ORDER of every split-API call.
+
+    Each call appends a tuple to the shared ``events`` log. The episode id passed
+    to the per-minibatch calls is recorded so we can assert begin/train/finish are
+    paired and ordered. ``finish_train_step`` returns an empty dict, which
+    ``aggregate_step_metrics`` handles (all ``.get`` defaults) — keeping the test
+    free of numerics.
+    """
+
+    def __init__(self, events: list) -> None:
+        self.events = events
+
+    def prepare_for_lp_inference(self) -> None:
+        self.events.append(("prepare_for_lp_inference",))
+
+    def get_logprobs_from_meta(self, meta) -> None:
+        self.events.append(("get_logprobs_from_meta",))
+
+    def get_reference_policy_logprobs_from_meta(self, meta) -> None:
+        self.events.append(("get_reference_policy_logprobs_from_meta",))
+
+    def prepare_for_training(self) -> None:
+        self.events.append(("prepare_for_training",))
+
+    def begin_train_step(self, ep, *, loss_fn=None, gbs=None) -> None:
+        self.events.append(("begin_train_step", ep, gbs))
+
+    def train_microbatch_from_meta(self, ep, minibatch_meta) -> None:
+        self.events.append(("train_microbatch_from_meta", ep, minibatch_meta.size))
+
+    def finish_train_step(self, ep) -> dict:
+        self.events.append(("finish_train_step", ep))
+        return {}
+
+    def abort_train_step(self, ep) -> None:
+        self.events.append(("abort_train_step", ep))
+
+
+class _FailingTrainer(_RecordingTrainer):
+    """Like ``_RecordingTrainer`` but ``train_microbatch_from_meta`` raises on the
+    minibatch index ``fail_on`` — exercises the abort-then-reraise path."""
+
+    def __init__(self, events: list, fail_on: int) -> None:
+        super().__init__(events)
+        self._fail_on = fail_on
+        self._mb_count = 0
+
+    def train_microbatch_from_meta(self, ep, minibatch_meta) -> None:
+        super().train_microbatch_from_meta(ep, minibatch_meta)
+        if self._mb_count == self._fail_on:
+            self._mb_count += 1
+            raise RuntimeError("boom in train_microbatch")
+        self._mb_count += 1
+
+
+class _NullLogger:
+    def log_metrics(self, *args, **kwargs) -> None:
+        pass
+
+
+class _ArealHelper:
+    """Minimal stub carrying exactly the state ``_train_pump`` reads.
+
+    Binds the genuine forked ``_train_pump``, ``_iter_minibatches`` and
+    ``_dp_align_batch`` so the REAL two-phase loop + size-based split arithmetic +
+    tail-trim are exercised. ``_collect_full_batch``, ``_advantage_pump``,
+    ``_sync_weights`` and ``_call_dp`` are recorded shims so the test stays
+    pure-asyncio (P1 / P3 / P4 cover those bodies). The Ray actor wrapper and its
+    bundle-heavy __init__ are bypassed.
+
+    SIZE-BASED: the loop reads ``self._train_minibatch_size`` (the new attr) — it
+    no longer reads ``self._async_cfg.num_minibatches`` or ``self._dp_world``.
+    """
+
+    def __init__(
+        self,
+        *,
+        minibatch_size: int,
+        max_num_steps: int,
+        batches: list,
+        trainer,
+        events: list,
+        reference_logprobs_field=None,
+    ) -> None:
+        self._master_config = _MasterCfg(max_num_steps)
+        self._trainer = trainer
+        self._events = events
+        self._loss_fn = object()  # opaque; only passed through to begin_train_step
+        self._partition_id = _PARTITION_ID
+        self._logger = _NullLogger()
+        self._timer = Timer()
+        # The new size-based knob the loop + _iter_minibatches read.
+        self._train_minibatch_size = minibatch_size
+        # advantage config knob the loop reads (reference logprobs gating).
+        self._advantage_cfg = _AdvCfg(reference_logprobs_field)
+        # Phase-1 batch source: pop one per step; None ⇒ exhaustion (clean break).
+        self._batches = list(batches)
+        # The metrics accumulator the loop reads + resets each step.
+        self._step_log_dict = {
+            "rewards": [],
+            "masked_advantages": [],
+            "sequence_lengths": [],
+        }
+        self._trainer_version = 0
+        self._train_steps = 0
+        # Observable publish-side counters.
+        self.collect_calls = 0
+        self.advantage_calls = 0
+        self.clear_samples_calls: list[dict] = []
+        self.sync_weights_calls = 0
+        self.trainer_versions_at_sync: list[int] = []
+
+    # Genuine forked implementations under test.
+    _train_pump = _ArealClass._train_pump
+    _iter_minibatches = _ArealClass._iter_minibatches
+    _dp_align_batch = staticmethod(_ArealClass._dp_align_batch)
+
+    # ── recorded collaborators (bodies are P1/P3/P4 scope) ──────────────────
+
+    async def _collect_full_batch(self):
+        self.collect_calls += 1
+        self._events.append(("collect_full_batch",))
+        if not self._batches:
+            return None
+        return self._batches.pop(0)
+
+    async def _advantage_pump(self, meta):
+        self.advantage_calls += 1
+        self._events.append(("advantage_pump",))
+        return meta
+
+    async def _call_dp(self, method_name, **kwargs):
+        self._events.append(("call_dp", method_name))
+        if method_name == "clear_samples":
+            self.clear_samples_calls.append(kwargs)
+        return None
+
+    async def _sync_weights(self):
+        self.sync_weights_calls += 1
+        self.trainer_versions_at_sync.append(self._trainer_version)
+        self._events.append(("sync_weights",))
+
+
+class _MasterCfg:
+    """Just the two MasterConfig sub-dicts the loop reads."""
+
+    def __init__(self, max_num_steps: int) -> None:
+        self.grpo = {"max_num_steps": max_num_steps, "max_num_epochs": None}
+        self.cluster = {"num_nodes": 1, "gpus_per_node": 1}
+
+
+class _AdvCfg:
+    """Just the advantage-config field the loop gates reference logprobs on."""
+
+    def __init__(self, reference_logprobs_field) -> None:
+        self.reference_logprobs_field = reference_logprobs_field
+
+
+def _run(helper: _ArealHelper) -> None:
+    asyncio.run(helper._train_pump())
+
+
+def _ep_index(events, name):
+    return [i for i, e in enumerate(events) if e[0] == name]
+
+
+# ── sanity: the bound methods are the real ones ─────────────────────────────
+
+
+def test_methods_are_the_real_implementations():
+    assert _ArealHelper._train_pump is _ArealClass._train_pump
+    assert _ArealHelper._iter_minibatches is _ArealClass._iter_minibatches
+    # _dp_align_batch is a @staticmethod; compare the underlying function.
+    assert (
+        _ArealHelper.__dict__["_dp_align_batch"].__func__
+        is _ArealClass.__dict__["_dp_align_batch"].__func__
+    )
+
+
+def test_loop_does_not_read_removed_attrs():
+    """The SIZE-based loop must drive entirely off ``_train_minibatch_size``; it
+    must NOT touch the removed ``_async_cfg.num_minibatches`` or ``_dp_world``.
+    The stub deliberately defines neither — a clean full run is proof the real
+    ``_train_pump`` never reads them (an AttributeError would surface otherwise)."""
+    events: list = []
+    helper = _ArealHelper(
+        minibatch_size=4,  # 8 / 4 -> 2 minibatches
+        max_num_steps=1,
+        batches=[_make_batch(8)],
+        trainer=_RecordingTrainer(events),
+        events=events,
+    )
+    # The stub has the new knob and NOT the removed ones.
+    assert hasattr(helper, "_train_minibatch_size")
+    assert not hasattr(helper, "_dp_world")
+    assert not hasattr(helper, "_async_cfg")
+    _run(helper)
+    # Ran to completion (2 optimizer steps) without touching removed attrs.
+    assert len(_ep_index(events, "finish_train_step")) == 2
+
+
+# ── get_logprobs_from_meta: exactly once per step, BEFORE any begin ──────────
+
+
+def test_get_logprobs_once_per_step_before_any_begin():
+    events: list = []
+    helper = _ArealHelper(
+        minibatch_size=3,  # 12 / 3 -> 4 minibatches
+        max_num_steps=1,
+        batches=[_make_batch(12)],
+        trainer=_RecordingTrainer(events),
+        events=events,
+    )
+    _run(helper)
+
+    lp = _ep_index(events, "get_logprobs_from_meta")
+    begins = _ep_index(events, "begin_train_step")
+    # exactly once.
+    assert len(lp) == 1
+    # before EVERY begin_train_step (π_prox frozen over the whole batch first).
+    assert begins, "expected begin_train_step calls"
+    assert lp[0] < begins[0]
+    assert all(lp[0] < b for b in begins)
+
+
+def test_get_logprobs_runs_unconditionally_without_reference_field():
+    """π_prox freeze is NOT gated on the advantage config; it runs even when no
+    reference logprobs field is configured (decoupled loss always needs it)."""
+    events: list = []
+    helper = _ArealHelper(
+        minibatch_size=4,  # 8 / 4 -> 2 minibatches
+        max_num_steps=1,
+        batches=[_make_batch(8)],
+        trainer=_RecordingTrainer(events),
+        events=events,
+        reference_logprobs_field=None,
+    )
+    _run(helper)
+
+    assert len(_ep_index(events, "get_logprobs_from_meta")) == 1
+    # reference logprobs stay gated -> NOT called when field is None.
+    assert _ep_index(events, "get_reference_policy_logprobs_from_meta") == []
+
+
+def test_reference_logprobs_called_when_field_configured():
+    """When a reference logprobs field IS configured, the gated reference forward
+    runs once per step, after get_logprobs_from_meta, before any begin."""
+    events: list = []
+    helper = _ArealHelper(
+        minibatch_size=4,  # 8 / 4 -> 2 minibatches
+        max_num_steps=1,
+        batches=[_make_batch(8)],
+        trainer=_RecordingTrainer(events),
+        events=events,
+        reference_logprobs_field="reference_policy_logprobs",
+    )
+    _run(helper)
+
+    ref = _ep_index(events, "get_reference_policy_logprobs_from_meta")
+    lp = _ep_index(events, "get_logprobs_from_meta")
+    begins = _ep_index(events, "begin_train_step")
+    assert len(ref) == 1
+    assert lp[0] < ref[0] < begins[0]
+
+
+# ── finish_train_step count == full_batch // minibatch (SIZE-BASED) ─────────
+
+
+@pytest.mark.parametrize(
+    "full_batch_size,minibatch_size",
+    [
+        (16, 16),  # 1 minibatch (== whole batch)
+        (16, 8),  # 2 minibatches
+        (16, 4),  # 4 minibatches
+        (16, 2),  # 8 minibatches
+        (12, 3),  # 4 minibatches
+        (512, 256),  # 2 minibatches (recipe-scale)
+    ],
+)
+def test_finish_count_equals_full_batch_over_minibatch(
+    full_batch_size, minibatch_size
+):
+    """Exactly ``full_batch // minibatch`` optimizer steps per training step:
+    that many begin/train/finish triples, each with gbs == minibatch_size, and
+    Σ gbs == (full_batch // minibatch) * minibatch."""
+    events: list = []
+    expected = full_batch_size // minibatch_size
+    helper = _ArealHelper(
+        minibatch_size=minibatch_size,
+        max_num_steps=1,
+        batches=[_make_batch(full_batch_size)],
+        trainer=_RecordingTrainer(events),
+        events=events,
+    )
+    _run(helper)
+
+    assert len(_ep_index(events, "begin_train_step")) == expected
+    assert len(_ep_index(events, "train_microbatch_from_meta")) == expected
+    assert len(_ep_index(events, "finish_train_step")) == expected
+
+    # every begin gets gbs == minibatch_size; train sizes match.
+    gbs_values = [e[2] for e in events if e[0] == "begin_train_step"]
+    train_sizes = [e[2] for e in events if e[0] == "train_microbatch_from_meta"]
+    assert gbs_values == [minibatch_size] * expected
+    assert train_sizes == [minibatch_size] * expected
+    # Σ gbs == the whole (aligned) batch.
+    assert sum(gbs_values) == expected * minibatch_size
+
+
+def test_single_optimizer_step_when_minibatch_equals_full_batch():
+    """minibatch_size == full_batch_size ⇒ exactly one begin/train/finish over the
+    whole batch (the num_minibatches==1 / base-controller case)."""
+    events: list = []
+    n = 10
+    helper = _ArealHelper(
+        minibatch_size=n,
+        max_num_steps=1,
+        batches=[_make_batch(n)],
+        trainer=_RecordingTrainer(events),
+        events=events,
+    )
+    _run(helper)
+
+    begins = [e for e in events if e[0] == "begin_train_step"]
+    trains = [e for e in events if e[0] == "train_microbatch_from_meta"]
+    finishes = [e for e in events if e[0] == "finish_train_step"]
+    assert len(begins) == len(trains) == len(finishes) == 1
+    # the single minibatch is the whole batch.
+    assert trains[0][2] == n
+    # gbs at this single step == whole batch size.
+    assert begins[0][2] == n
+
+
+# ── tail-drop: full batch NOT a multiple of minibatch_size ──────────────────
+
+
+@pytest.mark.parametrize(
+    "full_batch_size,minibatch_size,expected_finishes",
+    [
+        (10, 3, 3),  # usable 9, drop 1
+        (7, 3, 2),  # usable 6, drop 1
+        (520, 256, 2),  # usable 512, drop 8
+        (5, 3, 1),  # usable 3, drop 2
+    ],
+)
+def test_tail_remainder_dropped_finish_count(
+    full_batch_size, minibatch_size, expected_finishes
+):
+    """A full batch NOT a whole number of minibatches: _dp_align_batch trims the
+    tail, so finish count == full_batch // minibatch (tail dropped) and every
+    trained minibatch is exactly minibatch_size."""
+    events: list = []
+    helper = _ArealHelper(
+        minibatch_size=minibatch_size,
+        max_num_steps=1,
+        batches=[_make_batch(full_batch_size)],
+        trainer=_RecordingTrainer(events),
+        events=events,
+    )
+    _run(helper)
+
+    assert expected_finishes == full_batch_size // minibatch_size
+    assert len(_ep_index(events, "finish_train_step")) == expected_finishes
+    # no minibatch carries the dropped tail: each trained one is exactly the size.
+    train_sizes = [e[2] for e in events if e[0] == "train_microbatch_from_meta"]
+    assert train_sizes == [minibatch_size] * expected_finishes
+
+
+def test_tail_drop_clear_samples_uses_full_unaligned_batch_ids():
+    """The dropped tail rows are not trained, but ``clear_samples`` still frees the
+    FULL (un-aligned) batch: consumed_ids = batch_meta.sample_ids, not the trimmed
+    train_meta. Here 10 rows / minibatch 3 -> train 9 rows over 3 minibatches but
+    clear all 10."""
+    events: list = []
+    full = _make_batch(10)
+    helper = _ArealHelper(
+        minibatch_size=3,
+        max_num_steps=1,
+        batches=[full],
+        trainer=_RecordingTrainer(events),
+        events=events,
+    )
+    _run(helper)
+
+    # 3 minibatches trained (s0..s8); s9 dropped from training.
+    train_sizes = [e[2] for e in events if e[0] == "train_microbatch_from_meta"]
+    assert train_sizes == [3, 3, 3]  # 9 rows trained, s9 dropped
+
+    # clear_samples frees the FULL batch — all 10 ids, including the dropped tail.
+    assert len(helper.clear_samples_calls) == 1
+    assert helper.clear_samples_calls[0]["sample_ids"] == full.sample_ids
+    assert len(helper.clear_samples_calls[0]["sample_ids"]) == 10
+
+
+# NOTE (intentionally NOT tested here): a collected batch SMALLER than one
+# minibatch is trimmed to zero by ``_dp_align_batch``, leaving ``step_results``
+# empty; the publish path then evaluates ``aggregate_step_metrics(step_results[-1])``
+# (single_controller_areal.py:544), which raises IndexError on an empty list.
+# This is a latent edge in the controller, not a property to assert as "graceful";
+# in production ``train_global_batch_size`` divides ``rl_step_samples`` so the
+# common path is exact and this never trips. Flagged in the report, not encoded
+# as an expectation. Tail-drop with a surviving minibatch is covered above.
+
+
+# ── per-minibatch begin → train → finish ordering & pairing ─────────────────
+
+
+def test_each_minibatch_is_begin_train_finish_in_order():
+    """Per minibatch: begin then train then finish, all with the SAME episode id,
+    and minibatches run in index order (single pass, no shuffle)."""
+    events: list = []
+    minibatch_size = 3
+    n = 9  # -> 3 minibatches
+    m = n // minibatch_size
+    helper = _ArealHelper(
+        minibatch_size=minibatch_size,
+        max_num_steps=1,
+        batches=[_make_batch(n)],
+        trainer=_RecordingTrainer(events),
+        events=events,
+    )
+    _run(helper)
+
+    # collapse to the per-minibatch triples in event order.
+    triples = [
+        e
+        for e in events
+        if e[0]
+        in (
+            "begin_train_step",
+            "train_microbatch_from_meta",
+            "finish_train_step",
+        )
+    ]
+    assert [e[0] for e in triples] == (
+        ["begin_train_step", "train_microbatch_from_meta", "finish_train_step"] * m
+    )
+    # episode ids derived from step id, indexed, in order.
+    eps = [e[1] for e in triples]
+    expected_eps = []
+    for j in range(m):
+        ep = f"sc-step-000000-mb{j:03d}"
+        expected_eps += [ep, ep, ep]
+    assert eps == expected_eps
+
+
+def test_gbs_per_minibatch_is_constant_and_sums_to_aligned_batch():
+    """Per-minibatch gbs == train_global_batch_size (constant), so Σ gbs == the
+    aligned batch and the LR schedule advances by one global batch per step."""
+    events: list = []
+    minibatch_size = 4
+    n = 16  # exact multiple -> 4 minibatches, no tail
+    m = n // minibatch_size
+    helper = _ArealHelper(
+        minibatch_size=minibatch_size,
+        max_num_steps=1,
+        batches=[_make_batch(n)],
+        trainer=_RecordingTrainer(events),
+        events=events,
+    )
+    _run(helper)
+
+    gbs_values = [e[2] for e in events if e[0] == "begin_train_step"]
+    train_sizes = [e[2] for e in events if e[0] == "train_microbatch_from_meta"]
+    # every minibatch is exactly train_gbs (size-based; never a ragged tail).
+    assert gbs_values == [minibatch_size] * m
+    assert sum(gbs_values) == n
+    # gbs matches the minibatch the optimizer step trains on.
+    assert gbs_values == train_sizes
+
+
+# ── publish: clear_samples + version bump + sync ONCE per step, after loop ───
+
+
+def test_publish_happens_once_after_minibatch_loop():
+    events: list = []
+    minibatch_size = 3
+    n = 12  # -> 4 minibatches
+    helper = _ArealHelper(
+        minibatch_size=minibatch_size,
+        max_num_steps=1,
+        batches=[_make_batch(n)],
+        trainer=_RecordingTrainer(events),
+        events=events,
+    )
+    _run(helper)
+
+    # clear_samples and sync_weights happen exactly once.
+    assert len(helper.clear_samples_calls) == 1
+    assert helper.sync_weights_calls == 1
+    # version bumped once.
+    assert helper._trainer_version == 1
+    assert helper._train_steps == 1
+
+    # ordering: every finish_train_step precedes clear_samples, which precedes
+    # sync_weights.
+    finishes = _ep_index(events, "finish_train_step")
+    clear = [i for i, e in enumerate(events) if e == ("call_dp", "clear_samples")]
+    sync = _ep_index(events, "sync_weights")
+    assert len(clear) == 1 and len(sync) == 1
+    assert max(finishes) < clear[0] < sync[0]
+
+
+def test_clear_samples_uses_full_batch_sample_ids():
+    """clear_samples frees exactly the batch's DP rows, with the controller's
+    partition id — once, after the minibatch loop."""
+    events: list = []
+    batch = _make_batch(12)
+    helper = _ArealHelper(
+        minibatch_size=3,  # 12 / 3 -> 4 minibatches
+        max_num_steps=1,
+        batches=[batch],
+        trainer=_RecordingTrainer(events),
+        events=events,
+    )
+    _run(helper)
+
+    assert len(helper.clear_samples_calls) == 1
+    call = helper.clear_samples_calls[0]
+    assert call["sample_ids"] == batch.sample_ids
+    assert call["partition_id"] == _PARTITION_ID
+
+
+def test_version_bump_before_sync_weights():
+    """_trainer_version is incremented BEFORE _sync_weights publishes it (AReaL
+    i ← i+1 then signal refit)."""
+    events: list = []
+    helper = _ArealHelper(
+        minibatch_size=4,  # 8 / 4 -> 2 minibatches
+        max_num_steps=1,
+        batches=[_make_batch(8)],
+        trainer=_RecordingTrainer(events),
+        events=events,
+    )
+    _run(helper)
+
+    # sync saw the bumped version (1), not the pre-bump 0.
+    assert helper.trainer_versions_at_sync == [1]
+
+
+# ── multi-step: phases repeat once per step, in the right order ──────────────
+
+
+def test_multi_step_phase_order_and_counts():
+    """Three steps: each is collect -> get_logprobs(once) -> advantage ->
+    M finishes -> clear -> sync. Counts scale by step count."""
+    events: list = []
+    minibatch_size = 4
+    n = 8  # -> 2 minibatches per step
+    m = n // minibatch_size
+    steps = 3
+    helper = _ArealHelper(
+        minibatch_size=minibatch_size,
+        max_num_steps=steps,
+        batches=[_make_batch(n) for _ in range(steps)],
+        trainer=_RecordingTrainer(events),
+        events=events,
+    )
+    _run(helper)
+
+    assert len(_ep_index(events, "get_logprobs_from_meta")) == steps
+    assert len(_ep_index(events, "finish_train_step")) == steps * m
+    assert helper.sync_weights_calls == steps
+    assert len(helper.clear_samples_calls) == steps
+    assert helper._train_steps == steps
+    assert helper._trainer_version == steps
+
+    # Per-step structure: get_logprobs before that step's begins, and exactly one
+    # sync between consecutive steps' collects.
+    collects = _ep_index(events, "collect_full_batch")
+    syncs = _ep_index(events, "sync_weights")
+    assert len(collects) == steps
+    assert len(syncs) == steps
+    # each sync comes after its step's collect and before the next collect.
+    for i in range(steps):
+        assert collects[i] < syncs[i]
+        if i + 1 < steps:
+            assert syncs[i] < collects[i + 1]
+
+
+# ── clean break on rollout exhaustion (collect returns None) ────────────────
+
+
+def test_clean_break_on_exhaustion_no_training():
+    """When _collect_full_batch returns None the loop breaks cleanly: no
+    get_logprobs, no begin/finish, no clear/sync, version unchanged."""
+    events: list = []
+    helper = _ArealHelper(
+        minibatch_size=4,
+        max_num_steps=5,
+        batches=[],  # collect returns None immediately
+        trainer=_RecordingTrainer(events),
+        events=events,
+    )
+    _run(helper)
+
+    assert _ep_index(events, "get_logprobs_from_meta") == []
+    assert _ep_index(events, "begin_train_step") == []
+    assert _ep_index(events, "finish_train_step") == []
+    assert helper.clear_samples_calls == []
+    assert helper.sync_weights_calls == 0
+    assert helper._train_steps == 0
+    assert helper._trainer_version == 0
+
+
+def test_exhaustion_after_some_steps_stops_cleanly():
+    """Two batches then exhaustion (within a 10-step cap): trains 2 steps then
+    breaks; no publish for the empty 3rd collect."""
+    events: list = []
+    minibatch_size = 4
+    n = 8  # -> 2 minibatches per step
+    m = n // minibatch_size
+    helper = _ArealHelper(
+        minibatch_size=minibatch_size,
+        max_num_steps=10,
+        batches=[_make_batch(n), _make_batch(n)],
+        trainer=_RecordingTrainer(events),
+        events=events,
+    )
+    _run(helper)
+
+    assert helper._train_steps == 2
+    assert helper.sync_weights_calls == 2
+    assert len(_ep_index(events, "finish_train_step")) == 2 * m
+    # 3 collects: 2 productive + 1 that returned None (then break).
+    assert helper.collect_calls == 3
+
+
+def test_max_num_steps_caps_training():
+    """The loop stops at max_num_steps even with batches still available."""
+    events: list = []
+    helper = _ArealHelper(
+        minibatch_size=4,  # 4 / 4 -> 1 minibatch
+        max_num_steps=2,
+        batches=[_make_batch(4) for _ in range(5)],
+        trainer=_RecordingTrainer(events),
+        events=events,
+    )
+    _run(helper)
+
+    assert helper._train_steps == 2
+    assert helper.sync_weights_calls == 2
+    # only 2 collects consumed (cap hit before the 3rd).
+    assert helper.collect_calls == 2
+
+
+# ── exception path: abort then reraise, no publish ──────────────────────────
+
+
+def test_minibatch_exception_aborts_and_reraises_no_publish():
+    """If train_microbatch_from_meta raises, abort_train_step fires for that
+    episode and the error propagates — no finish for that minibatch, no clear, no
+    sync, no version bump."""
+    events: list = []
+    helper = _ArealHelper(
+        minibatch_size=3,  # 12 / 3 -> 4 minibatches
+        max_num_steps=1,
+        batches=[_make_batch(12)],
+        trainer=_FailingTrainer(events, fail_on=1),  # second minibatch fails
+        events=events,
+    )
+
+    with pytest.raises(RuntimeError, match="boom in train_microbatch"):
+        _run(helper)
+
+    aborts = [e for e in events if e[0] == "abort_train_step"]
+    finishes = [e for e in events if e[0] == "finish_train_step"]
+    # the failing (2nd) minibatch aborted; the first one finished before it.
+    assert len(aborts) == 1
+    assert aborts[0][1] == "sc-step-000000-mb001"
+    assert len(finishes) == 1
+    assert finishes[0][1] == "sc-step-000000-mb000"
+    # publish did NOT run.
+    assert helper.clear_samples_calls == []
+    assert helper.sync_weights_calls == 0
+    assert helper._trainer_version == 0
+    assert helper._train_steps == 0

--- a/tests/unit/single_controller/test_areal_train_pump.py
+++ b/tests/unit/single_controller/test_areal_train_pump.py
@@ -132,9 +132,29 @@ class _FailingTrainer(_RecordingTrainer):
         self._mb_count += 1
 
 
+class _MetricTrainer(_RecordingTrainer):
+    """Return a distinct metric payload for each finished minibatch."""
+
+    def __init__(self, events: list, results: list[dict]) -> None:
+        super().__init__(events)
+        self._results = list(results)
+
+    def finish_train_step(self, ep) -> dict:
+        self.events.append(("finish_train_step", ep))
+        return self._results.pop(0)
+
+
 class _NullLogger:
     def log_metrics(self, *args, **kwargs) -> None:
         pass
+
+
+class _RecordingLogger:
+    def __init__(self) -> None:
+        self.calls: list[tuple[dict, dict]] = []
+
+    def log_metrics(self, metrics, **kwargs) -> None:
+        self.calls.append((dict(metrics), kwargs))
 
 
 class _ArealHelper:
@@ -473,8 +493,8 @@ def test_tail_drop_clear_samples_uses_full_unaligned_batch_ids():
 
 # NOTE (intentionally NOT tested here): a collected batch SMALLER than one
 # minibatch is trimmed to zero by ``_dp_align_batch``, leaving ``step_results``
-# empty; the publish path then evaluates ``aggregate_step_metrics(step_results[-1])``
-# (single_controller_areal.py:544), which raises IndexError on an empty list.
+# empty; the publish path then passes that empty list to
+# ``aggregate_step_metrics_multi_minibatch``, which raises ``ValueError``.
 # This is a latent edge in the controller, not a property to assert as "graceful";
 # in production ``train_global_batch_size`` divides ``rl_step_samples`` so the
 # common path is exact and this never trips. Flagged in the report, not encoded
@@ -578,6 +598,62 @@ def test_publish_happens_once_after_minibatch_loop():
     sync = _ep_index(events, "sync_weights")
     assert len(clear) == 1 and len(sync) == 1
     assert max(finishes) < clear[0] < sync[0]
+
+
+def test_publish_aggregates_metrics_from_every_minibatch():
+    """The publish path must pass all finish results to the shared reducer."""
+    events: list = []
+    trainer = _MetricTrainer(
+        events,
+        results=[
+            {
+                "loss": 2.0,
+                "grad_norm": 4.0,
+                "total_flops": 10.0,
+                "all_mb_metrics": {
+                    "lr": [1.0e-4],
+                    "wd": [0.01],
+                    "global_valid_toks": [100.0],
+                    "custom_sum": [1.0],
+                },
+            },
+            {
+                "loss": 6.0,
+                "grad_norm": 8.0,
+                "total_flops": 20.0,
+                "all_mb_metrics": {
+                    "lr": [2.0e-4],
+                    "wd": [0.02],
+                    "global_valid_toks": [200.0],
+                    "custom_sum": [2.0],
+                },
+            },
+        ],
+    )
+    helper = _ArealHelper(
+        minibatch_size=4,
+        max_num_steps=1,
+        batches=[_make_batch(8)],
+        trainer=trainer,
+        events=events,
+    )
+    logger = _RecordingLogger()
+    helper._logger = logger
+
+    _run(helper)
+
+    train_metrics = next(
+        metrics for metrics, kwargs in logger.calls if kwargs["prefix"] == "train"
+    )
+    assert train_metrics["loss"] == pytest.approx(4.0)
+    assert train_metrics["grad_norm"] == pytest.approx(6.0)
+    assert train_metrics["total_flops"] == pytest.approx(30.0)
+    assert train_metrics["global_valid_toks"] == pytest.approx(300.0)
+    # Summed mb keys rescale by 1/M in aggregate_step_metrics_multi_minibatch
+    # (each result's list already sums to its own minibatch's mean).
+    assert train_metrics["custom_sum"] == pytest.approx((1.0 + 2.0) / 2)
+    assert train_metrics["lr"] == pytest.approx(2.0e-4)
+    assert train_metrics["wd"] == pytest.approx(0.02)
 
 
 def test_clear_samples_uses_full_batch_sample_ids():

--- a/tests/unit/single_controller/test_areal_train_pump.py
+++ b/tests/unit/single_controller/test_areal_train_pump.py
@@ -64,15 +64,18 @@ _PARTITION_ID = "rollout_data"
 _ArealClass = SingleControllerArealActor.__ray_actor_class__
 
 
-def _make_batch(n: int) -> KVBatchMeta:
+def _make_batch(n: int, *, weight_versions: list[int] | None = None) -> KVBatchMeta:
     """Real full-batch KVBatchMeta with ``n`` rows. ``tags`` carry a
     ``weight_version`` so the loop's lag log path is exercised."""
+    if weight_versions is None:
+        weight_versions = [0] * n
+    assert len(weight_versions) == n
     return KVBatchMeta(
         partition_id=_PARTITION_ID,
         task_name="train",
         sample_ids=[f"s{i}" for i in range(n)],
         sequence_lengths=[i + 1 for i in range(n)],
-        tags=[{"row": i, "weight_version": 0} for i in range(n)],
+        tags=[{"row": i, "weight_version": weight_versions[i]} for i in range(n)],
     )
 
 
@@ -199,6 +202,7 @@ class _ArealHelper:
             "rewards": [],
             "masked_advantages": [],
             "sequence_lengths": [],
+            "staleness": [],
         }
         self._trainer_version = 0
         self._train_steps = 0
@@ -654,6 +658,34 @@ def test_publish_aggregates_metrics_from_every_minibatch():
     assert train_metrics["custom_sum"] == pytest.approx((1.0 + 2.0) / 2)
     assert train_metrics["lr"] == pytest.approx(2.0e-4)
     assert train_metrics["wd"] == pytest.approx(0.02)
+
+
+def test_publish_logs_rollout_start_weight_staleness():
+    """Staleness uses each consumed row's rollout-start weight version."""
+    events: list = []
+    batch = _make_batch(
+        8,
+        weight_versions=[0, 0, 1, 1, 2, 2, 3, 3],
+    )
+    helper = _ArealHelper(
+        minibatch_size=4,
+        max_num_steps=1,
+        batches=[batch],
+        trainer=_RecordingTrainer(events),
+        events=events,
+    )
+    helper._trainer_version = 3
+    logger = _RecordingLogger()
+    helper._logger = logger
+
+    _run(helper)
+
+    train_metrics = next(
+        metrics for metrics, kwargs in logger.calls if kwargs["prefix"] == "train"
+    )
+    assert train_metrics["staleness/mean"] == pytest.approx(1.5)
+    assert train_metrics["staleness/max"] == pytest.approx(3.0)
+    assert train_metrics["staleness/min"] == pytest.approx(0.0)
 
 
 def test_clear_samples_uses_full_batch_sample_ids():

--- a/tests/unit/single_controller/test_single_controller_utils.py
+++ b/tests/unit/single_controller/test_single_controller_utils.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from nemo_rl.algorithms.single_controller_utils.utils import (
+    aggregate_step_metrics,
+    aggregate_step_metrics_multi_minibatch,
+)
+
+
+def test_aggregate_step_metrics_single_result_list_is_compatible():
+    result = {
+        "loss": torch.tensor([1.0, 2.0]),
+        "grad_norm": torch.tensor([3.0, 5.0]),
+        "total_flops": 10.0,
+        "num_ranks": 8,
+        "moe_metrics": {"load_balancing_loss": 0.25},
+        "mtp_metrics": {"mtp_1_loss": 0.5},
+        "all_mb_metrics": {
+            "probs_ratio_min": [math.inf, 0.8],
+            "probs_ratio_max": [1.1, math.inf],
+            "reward": [1.0, 3.0],
+            "lr": [1.0e-4, 1.0e-4],
+            "wd": [0.01, 0.01],
+            "global_valid_seqs": [4.0, 4.0],
+            "global_valid_toks": [100.0, 100.0],
+            "custom_sum": [2.0, 3.0],
+        },
+    }
+
+    expected = aggregate_step_metrics(result)
+
+    assert aggregate_step_metrics_multi_minibatch([result]) == expected
+    assert expected["loss"] == pytest.approx(1.5)
+    assert expected["grad_norm"] == pytest.approx(4.0)
+    assert expected["probs_ratio_min"] == pytest.approx(0.8)
+    assert expected["probs_ratio_max"] == pytest.approx(1.1)
+    assert expected["reward"] == pytest.approx(2.0)
+    assert expected["custom_sum"] == pytest.approx(5.0)
+
+
+def test_aggregate_step_metrics_combines_all_optimizer_results():
+    results = [
+        {
+            "loss": torch.tensor([2.0]),
+            "grad_norm": torch.tensor([4.0]),
+            "total_flops": 10.0,
+            "num_ranks": 8,
+            "moe_metrics": {"load_balancing_loss": 0.1},
+            "mtp_metrics": {"mtp_1_loss": 0.4},
+            "all_mb_metrics": {
+                "probs_ratio_min": [math.inf, 0.8],
+                "probs_ratio_max": [1.2, math.inf],
+                "probs_ratio_clamped_min": [math.inf],
+                "probs_ratio_clamped_max": [math.inf],
+                "reward": [1.0, 3.0],
+                "lr": [1.0e-4, 1.0e-4],
+                "wd": [0.01, 0.01],
+                "global_valid_seqs": [2.0, 2.0],
+                "global_valid_toks": [100.0, 100.0],
+                "custom_sum": [1.0, 2.0],
+            },
+        },
+        {
+            "loss": 6.0,
+            "grad_norm": 8.0,
+            "total_flops": 20.0,
+            "num_ranks": 8,
+            "moe_metrics": {"load_balancing_loss": 0.2},
+            "mtp_metrics": {"mtp_1_loss": 0.6},
+            "all_mb_metrics": {
+                "probs_ratio_min": [0.7],
+                "probs_ratio_max": [1.5],
+                "probs_ratio_clamped_min": [math.inf],
+                "probs_ratio_clamped_max": [math.inf],
+                "reward": [5.0],
+                "lr": [2.0e-4],
+                "wd": [0.02],
+                "global_valid_seqs": [3.0],
+                "global_valid_toks": [200.0],
+                "custom_sum": [4.0],
+            },
+        },
+    ]
+
+    metrics = aggregate_step_metrics_multi_minibatch(results)
+
+    assert metrics["loss"] == pytest.approx(4.0)
+    assert metrics["grad_norm"] == pytest.approx(6.0)
+    assert metrics["total_flops"] == pytest.approx(30.0)
+    assert metrics["num_ranks"] == 8
+    assert metrics["probs_ratio_min"] == pytest.approx(0.7)
+    assert metrics["probs_ratio_max"] == pytest.approx(1.5)
+    assert metrics["probs_ratio_clamped_min"] == -1.0
+    assert metrics["probs_ratio_clamped_max"] == -1.0
+    assert metrics["reward"] == pytest.approx(3.0)
+    # Summed keys are normalized within one finish result (a result's list
+    # sums to that minibatch's mean), so the step value is the mean of the
+    # per-result sums — not the raw concatenated sum, which would inflate
+    # these metrics by the minibatch count relative to legacy GRPO.
+    assert metrics["custom_sum"] == pytest.approx((1.0 + 2.0 + 4.0) / 2)
+    assert metrics["moe/load_balancing_loss"] == pytest.approx((0.1 + 0.2) / 2)
+    assert metrics["mtp/mtp_1_loss"] == pytest.approx((0.4 + 0.6) / 2)
+
+    # Counts are repeated within one finish result, then summed across the two
+    # optimizer steps. A raw mean over the concatenated values would be wrong.
+    assert metrics["global_valid_seqs"] == pytest.approx(5.0)
+    assert metrics["global_valid_toks"] == pytest.approx(300.0)
+
+    # The last finish result reports the LR/WD used by the final optimizer step.
+    assert metrics["lr"] == pytest.approx(2.0e-4)
+    assert metrics["wd"] == pytest.approx(0.02)
+
+
+def test_aggregate_step_metrics_rejects_empty_result_list():
+    with pytest.raises(ValueError, match="at least one train result"):
+        aggregate_step_metrics_multi_minibatch([])

--- a/tests/unit/single_controller/test_single_controller_utils.py
+++ b/tests/unit/single_controller/test_single_controller_utils.py
@@ -22,6 +22,7 @@ import torch
 from nemo_rl.algorithms.single_controller_utils.utils import (
     aggregate_step_metrics,
     aggregate_step_metrics_multi_minibatch,
+    reduce_advantage_pump_metrics,
 )
 
 
@@ -132,3 +133,26 @@ def test_aggregate_step_metrics_combines_all_optimizer_results():
 def test_aggregate_step_metrics_rejects_empty_result_list():
     with pytest.raises(ValueError, match="at least one train result"):
         aggregate_step_metrics_multi_minibatch([])
+
+
+def test_reduce_advantage_pump_metrics_staleness_stats():
+    out = reduce_advantage_pump_metrics(
+        rewards=[torch.tensor([1.0, 0.0])],
+        masked_advantages=[torch.tensor([0.5, -0.5])],
+        sequence_lengths=[3, 4],
+        staleness=[0, 1, 3],
+    )
+
+    assert out["staleness/mean"] == pytest.approx(4.0 / 3.0)
+    assert out["staleness/max"] == pytest.approx(3.0)
+    assert out["staleness/min"] == pytest.approx(0.0)
+
+
+def test_reduce_advantage_pump_metrics_omits_staleness_when_absent():
+    out = reduce_advantage_pump_metrics(
+        rewards=[torch.tensor([1.0])],
+        masked_advantages=[torch.tensor([0.5])],
+        sequence_lengths=[2],
+    )
+
+    assert not any(key.startswith("staleness/") for key in out)


### PR DESCRIPTION
# What does this PR do ?
  
Adds an AReaL-style decoupled-PPO async-RL training path on the SingleController — a standalone SingleControllerArealActor with a two-phase train loop (full-batch barrier → frozen π_prox → per-minibatch optimizer steps) on top of the TransferQueue data plane.

# Usage

The AReaL decoupled-PPO objective reuses existing machinery — it is ClippedPGLossFn with the always-on importance-sampling correction (π_prox/π_behav) and no KL term; the only new runtime logic is the controller's two-phase loop. Launch via the SC entrypoint + the AReaL recipe:

```    
uv run examples/run_grpo_single_controller.py \
    --config examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-2n8g-areal-single-controller.yaml
```

# Before your PR is "Ready for review"

**Pre checks:**
  - [x] Make sure you read and followed Contributor guidelines
  - [x] Did you write any new necessary tests? — AReaL unit tests across tests/unit/single_controller/test_areal_train_pump.py, plus
  nightly functional entries. 
  - [x] Did you run the unit tests and functional tests locally? — 67/67 AReaL unit tests pass in the nemo-rl
  container; functional recipe added to tests/test_suites/nightly.txt.
  - [ ] Did you add or update any necessary documentation? — in-code docstrings cover the controller. (No docs/ site change.)
