### PR TITLE
docs(ppo): clarify backend is config-selected, drop dup block

### DIFF
--- a/docs/about/algorithms/ppo.md
+++ b/docs/about/algorithms/ppo.md
@@ -21,17 +21,11 @@ uv run examples/run_ppo.py \
   logger.wandb.name="ppo-math"
 ```
 
-For Megatron-Core backend:
-
-```sh
-uv run examples/run_ppo.py \
-  --config examples/configs/ppo_math_1B_megatron.yaml \
-  policy.model_name="Qwen/Qwen2.5-1.5B" \
-  cluster.gpus_per_node=8 \
-  checkpointing.checkpoint_dir="results/ppo_megatron" \
-  logger.wandb_enabled=True \
-  logger.wandb.name="ppo-megatron"
-```
+> [!NOTE]
+> The training backend is selected by the config, not a command-line flag.
+> `ppo_math_1B_megatron.yaml` runs the Megatron-Core backend because it sets
+> `policy.megatron_cfg.enabled=true` (and `policy.dtensor_cfg.enabled=false`).
+> The value model currently only supports the Megatron-Core backend.
 
 ## PPO Multi-node
 


### PR DESCRIPTION
## Summary

The **PPO Single Node** section of `docs/about/algorithms/ppo.md` showed
two `run_ppo.py` commands. The second was introduced with the heading
"For Megatron-Core backend:", implying it selected a different backend
than the first. In reality both commands were byte-identical except for
`checkpointing.checkpoint_dir` / `logger.wandb.name`, and **both** used
`examples/configs/ppo_math_1B_megatron.yaml`. There was no backend
difference between them, so the second block was redundant and its
heading was misleading.

This PR removes the duplicate block and replaces it with a note that
explains how the backend is actually chosen.

```diff
-For Megatron-Core backend:
-
-```sh
-uv run examples/run_ppo.py \
-  --config examples/configs/ppo_math_1B_megatron.yaml \
-  policy.model_name="Qwen/Qwen2.5-1.5B" \
-  cluster.gpus_per_node=8 \
-  checkpointing.checkpoint_dir="results/ppo_megatron" \
-  logger.wandb_enabled=True \
-  logger.wandb.name="ppo-megatron"
-```
+> [!NOTE]
+> The training backend is selected by the config, not a command-line flag.
+> `ppo_math_1B_megatron.yaml` runs the Megatron-Core backend because it sets
+> `policy.megatron_cfg.enabled=true` (and `policy.dtensor_cfg.enabled=false`).
+> The value model currently only supports the Megatron-Core backend.
```

## Root cause

`docs/about/algorithms/ppo.md` (Single Node section). The backend in
NeMo-RL is determined by the config, not a CLI flag — specifically by
which of `policy.megatron_cfg.enabled` / `policy.dtensor_cfg.enabled`
(and the matching `value.*` keys) is `true`. The duplicated code block
and its "For Megatron-Core backend" heading suggested the backend was
chosen on the command line, which is incorrect.

Verified against the shipped config `examples/configs/ppo_math_1B_megatron.yaml`:

```
103:  dtensor_cfg:
105:    enabled: false
124:  megatron_cfg:
125:    enabled: true      # policy block -> Megatron-Core
...
270:  dtensor_cfg:
272:    enabled: false
291:  megatron_cfg:
292:    enabled: true      # value block -> Megatron-Core
```

So the file the doc points at unambiguously selects Megatron-Core via
config, confirming the note's wording.

## Test command

Docs-only change — no executable code paths touched, so there is no
functional/e2e test to run. Verification was a content/render check:

- Confirmed the two pre-existing code blocks were identical apart from
  `checkpoint_dir` / `wandb.name` and both referenced
  `ppo_math_1B_megatron.yaml`.
- Confirmed the `megatron_cfg.enabled` / `dtensor_cfg.enabled` keys and
  values cited in the note exist in `examples/configs/ppo_math_1B_megatron.yaml`
  for both the policy and value blocks (see Root cause).
- MyST `> [!NOTE]` admonition syntax matches the existing usage in the
  same file (PPO Multi-node section, line 60).

## Detected by

Manual doc review while authoring PPO POR tests against
`examples/run_ppo.py` + `ppo_math_1B_megatron.yaml`.

## Test plan
- [x] No executable lines changed — `codecov/patch` is exempt (comment/docs only)
- [x] Cited config keys verified present in the referenced YAML
- [x] Admonition syntax matches existing in-file usage
- [x] No behavior change
