### PR TITLE
feat: Add configurable vLLM thinking token budget

### DIFF
--- a/docs/guides/nemotron-3-nano-omni.md
+++ b/docs/guides/nemotron-3-nano-omni.md
@@ -47,6 +47,29 @@ uv run examples/run_vlm_grpo.py --config examples/configs/recipes/vlm/vlm_grpo-n
     cluster.gpus_per_node=8 cluster.num_nodes=1
 ```
 
+### Optional reasoning budget
+
+Nemotron 3 Nano Omni reasoning checkpoints may continue generating inside the
+`<think>` block for the full rollout length if no reasoning budget is applied.
+For vLLM rollouts, set `policy.generation.thinking_token_budget` to bound the
+number of thinking tokens. vLLM also requires a reasoning config so it can
+identify the model's reasoning start and end tokens:
+
+```bash
+uv run examples/run_vlm_grpo.py --config examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-clevr-1n8g-automodel-ep8.v1.yaml \
+    cluster.gpus_per_node=8 \
+    cluster.num_nodes=1 \
+    policy.generation.thinking_token_budget=1024 \
+    ++policy.generation.vllm_kwargs.reasoning_config.reasoning_parser=nemotron_v3 \
+    '++policy.generation.vllm_kwargs.reasoning_config.reasoning_start_str=<think>' \
+    '++policy.generation.vllm_kwargs.reasoning_config.reasoning_end_str=</think>'
+```
+
+`thinking_token_budget` is a hard vLLM generation limit for the reasoning
+segment. If the Hugging Face chat template also accepts a `reasoning_budget`
+argument, treat that as a prompt/template-level soft control rather than a
+replacement for the vLLM sampling parameter.
+
 ## Recipe 2 — MMPR-Tiny (4-node Slurm)
 
 The MMPR-Tiny recipe uses [`examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-mmpr-4n8g-automodel-ep8.v1.yaml`](../../examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-mmpr-4n8g-automodel-ep8.v1.yaml). Differences vs. the CLEVR recipe:

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -311,6 +311,7 @@ policy:
     port_range_high: 15000
     backend: "vllm"
     max_new_tokens: ${policy.max_total_sequence_length}
+    thinking_token_budget: null
     temperature: 1.0
     top_p: 1.0
     top_k: null

--- a/nemo_rl/models/generation/interfaces.py
+++ b/nemo_rl/models/generation/interfaces.py
@@ -120,6 +120,7 @@ class GenerationConfig(TypedDict):
 
     backend: str
     max_new_tokens: int
+    thinking_token_budget: NotRequired[int | None]
     temperature: float
     top_p: float
     top_k: int | None

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -456,17 +456,21 @@ class BaseVllmGenerationWorker:
             max_new_tokens if max_new_tokens is not None else self.cfg["max_new_tokens"]
         )
 
-        return self.SamplingParams(
-            temperature=temperature,
-            top_p=self.cfg["top_p"],
-            top_k=top_k_val,
-            max_tokens=max_tokens,
-            logprobs=0,
-            stop_token_ids=self.cfg["stop_token_ids"],
-            stop=stop_strings,
-            include_stop_str_in_output=True,
-            ignore_eos=self.cfg.get("ignore_eos", False),
-        )
+        sampling_kwargs = {
+            "temperature": temperature,
+            "top_p": self.cfg["top_p"],
+            "top_k": top_k_val,
+            "max_tokens": max_tokens,
+            "logprobs": 0,
+            "stop_token_ids": self.cfg["stop_token_ids"],
+            "stop": stop_strings,
+            "include_stop_str_in_output": True,
+            "ignore_eos": self.cfg.get("ignore_eos", False),
+        }
+        if self.cfg.get("thinking_token_budget") is not None:
+            sampling_kwargs["thinking_token_budget"] = self.cfg["thinking_token_budget"]
+
+        return self.SamplingParams(**sampling_kwargs)
 
     def start_gpu_profiling(self) -> None:
         """Start GPU profiling."""

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -775,6 +775,91 @@ def test_vllm_policy_generation(policy, test_input_data, tokenizer):
     )
 
 
+@pytest.mark.vllm
+def test_vllm_thinking_token_budget_inserts_reasoning_end(cluster, tokenizer):
+    """A short vLLM thinking budget should close Qwen3 reasoning early."""
+
+    def find_subsequence(sequence: list[int], subsequence: list[int]) -> int:
+        if not subsequence:
+            return 0
+        return next(
+            (
+                idx
+                for idx in range(len(sequence) - len(subsequence) + 1)
+                if sequence[idx : idx + len(subsequence)] == subsequence
+            ),
+            -1,
+        )
+
+    thinking_token_budget = 4
+    vllm_config = deepcopy(basic_vllm_test_config)
+    vllm_config["max_new_tokens"] = 32
+    vllm_config["thinking_token_budget"] = thinking_token_budget
+    vllm_config["vllm_cfg"]["use_tqdm"] = False
+    vllm_config["vllm_kwargs"] = {
+        "reasoning_config": {
+            "reasoning_parser": "qwen3",
+            "reasoning_start_str": "<think>",
+            "reasoning_end_str": "</think>",
+        }
+    }
+    vllm_config = configure_generation_config(vllm_config, tokenizer, is_eval=True)
+
+    prompt = tokenizer.apply_chat_template(
+        [{"role": "user", "content": "What is 17 + 25? Answer briefly."}],
+        tokenize=False,
+        add_generation_prompt=True,
+        enable_thinking=True,
+    )
+    input_ids = tokenizer(
+        prompt,
+        return_tensors="pt",
+        add_special_tokens=False,
+    )["input_ids"]
+    input_lengths = torch.tensor([input_ids.shape[1]], dtype=torch.int32)
+    input_data = BatchedDataDict(
+        {
+            "input_ids": input_ids,
+            "input_lengths": input_lengths,
+        }
+    )
+
+    vllm_generation = VllmGeneration(cluster, vllm_config)
+    try:
+        outputs = vllm_generation.generate(input_data, greedy=True)
+    finally:
+        vllm_generation.shutdown()
+
+    generated_length = outputs["generation_lengths"][0].item()
+    generated_ids = outputs["output_ids"][
+        0, input_lengths[0].item() : input_lengths[0].item() + generated_length
+    ].tolist()
+    generated_text = tokenizer.decode(generated_ids, skip_special_tokens=False)
+
+    reasoning_start_ids = tokenizer.encode("<think>", add_special_tokens=False)
+    reasoning_end_ids = tokenizer.encode("</think>", add_special_tokens=False)
+    reasoning_end_idx = find_subsequence(generated_ids, reasoning_end_ids)
+
+    assert reasoning_end_idx != -1, (
+        "Expected vLLM to inject </think> when thinking_token_budget is reached. "
+        f"Generated text: {generated_text!r}"
+    )
+
+    reasoning_ids = generated_ids[:reasoning_end_idx]
+    if reasoning_ids[: len(reasoning_start_ids)] == reasoning_start_ids:
+        reasoning_ids = reasoning_ids[len(reasoning_start_ids) :]
+
+    assert len(reasoning_ids) <= thinking_token_budget + 2, (
+        "Expected only a few generated reasoning tokens before </think>. "
+        f"Budget={thinking_token_budget}, reasoning_tokens={len(reasoning_ids)}, "
+        f"generated_text={generated_text!r}"
+    )
+    assert reasoning_end_idx + len(reasoning_end_ids) < len(generated_ids), (
+        "Expected generation to continue with answer content after </think>. "
+        f"Generated text: {generated_text!r}"
+    )
+
+
 async def _generate_async(vllm_policy, tokenizer, test_input_data, greedy=False):
     collected_indexed_outputs = []
     # generate_async is restricted to handle only single samples


### PR DESCRIPTION
# What does this PR do ?

Adds a `policy.generation.thinking_token_budget` config knob and forwards it to vLLM `SamplingParams` when set, so reasoning rollouts can cap the `<think>` segment.
https://docs.vllm.ai/en/latest/features/reasoning_outputs/#thinking-budget-control

This fix prevents the content length from becoming 0 due to cyclic thinking or thinking that exceeds the context length.

# Issues
Related to #2946

# Usage
* Example Nemotron Omni vLLM rollout configuration:

```bash
uv run examples/run_vlm_grpo.py --config examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-clevr-1n8g-automodel-ep8.v1.yaml \
    cluster.gpus_per_node=8 \
    cluster.num_nodes=1 \
    policy.generation.thinking_token_budget=1024 \
    ++policy.generation.vllm_kwargs.reasoning_config.reasoning_parser=nemotron_v3 \
    '++policy.generation.vllm_kwargs.reasoning_config.reasoning_start_str=<think>' \
    '++policy.generation.vllm_kwargs.reasoning_config.reasoning_end_str=</think>'
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* `thinking_token_budget` is only passed to vLLM when explicitly set, preserving existing behavior for configs that leave it unset or `null`.
* vLLM requires `reasoning_config` when using `thinking_token_budget`; the Nemotron Omni guide now shows the required `nemotron_v3` parser settings.

