### PR TITLE
fix: KL backward when clamping is active

### DIFF
--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -427,16 +427,13 @@ class ClippedPGLossFn(LossFunction):
             )
 
             # Compute KL loss
-            kl = (
-                kl_importance_weights
-                * self.reference_policy_kl_penalty
-                * calculate_kl(
-                    logprobs=curr_logprobs_unfiltered,
-                    logprobs_reference=reference_policy_logprobs,
-                    kl_type=self.reference_policy_kl_type,
-                    input_clamp_value=self.kl_input_clamp_value,
-                    output_clamp_value=self.kl_output_clamp_value,
-                )
+            kl = self.reference_policy_kl_penalty * calculate_kl(
+                logprobs=curr_logprobs_unfiltered,
+                logprobs_reference=reference_policy_logprobs,
+                kl_type=self.reference_policy_kl_type,
+                input_clamp_value=self.kl_input_clamp_value,
+                output_clamp_value=self.kl_output_clamp_value,
+                importance_sampling_weights=kl_importance_weights,
             )
 
             # Reduce KL loss

--- a/nemo_rl/algorithms/utils.py
+++ b/nemo_rl/algorithms/utils.py
@@ -44,6 +44,7 @@ def calculate_kl(
     kl_type: str = "k3",
     input_clamp_value: float | None = 20.0,
     output_clamp_value: float | None = 10.0,
+    importance_sampling_weights: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Calculates a per-token estimate of the KL Divergence between two logprobs.
 
@@ -57,13 +58,26 @@ def calculate_kl(
                            If None, no clamping is applied.
         output_clamp_value: Optional clamping value for kl to prevent numerical instability.
                            If None, no clamping is applied.
+        importance_sampling_weights: Optional per-token importance weights. When
+                                     provided, weights are multiplied into the KL
+                                     before output clamping. If input clamping
+                                     applies to a token, the corresponding weight
+                                     is detached so the clamp suppresses both KL
+                                     and sampling-weight gradients.
 
     Returns:
         torch.Tensor: Per-token KL penalty values (b, s)
     """
     logr = logprobs_reference - logprobs
     if input_clamp_value is not None:
-        logr = logr.clamp(min=-input_clamp_value, max=input_clamp_value)
+        logr_clamped = logr.clamp(min=-input_clamp_value, max=input_clamp_value)
+        if importance_sampling_weights is not None:
+            importance_sampling_weights = torch.where(
+                logr == logr_clamped,
+                importance_sampling_weights,
+                importance_sampling_weights.detach(),
+            )
+        logr = logr_clamped
 
     if kl_type == "k1":
         kl = -logr
@@ -76,6 +90,9 @@ def calculate_kl(
 
     else:
         raise ValueError(f"Invalid KL type: {kl_type}")
+
+    if importance_sampling_weights is not None:
+        kl = importance_sampling_weights * kl
 
     if output_clamp_value is not None:
         kl = kl.clamp(min=-output_clamp_value, max=output_clamp_value)

--- a/tests/unit/algorithms/test_loss_functions.py
+++ b/tests/unit/algorithms/test_loss_functions.py
@@ -872,6 +872,61 @@ def test_calculate_kl(kl_type):
     assert torch.allclose(kl_clamped, expected_kl_clamped[kl_type], rtol=1e-3)
 
 
+def test_calculate_kl_detaches_importance_sampling_when_input_clamped():
+    """Input-clamped KL terms should not keep score-function gradients alive."""
+    logprobs = torch.tensor([[-3.0, -1.0]], requires_grad=True)
+    logprobs_reference = torch.zeros_like(logprobs)
+    importance_sampling_weights = torch.exp(logprobs - logprobs.detach())
+
+    kl = calculate_kl(
+        logprobs=logprobs,
+        logprobs_reference=logprobs_reference,
+        kl_type="k3",
+        input_clamp_value=2.0,
+        output_clamp_value=None,
+        importance_sampling_weights=importance_sampling_weights,
+    )
+
+    expected_kl = torch.tensor([[4.389056, 0.7182818]])
+    torch.testing.assert_close(kl.detach(), expected_kl)
+
+    kl.sum().backward()
+
+    torch.testing.assert_close(
+        logprobs.grad,
+        torch.tensor([[0.0, -1.0]]),
+        atol=1e-6,
+        rtol=1e-6,
+    )
+
+
+def test_calculate_kl_output_clamp_includes_importance_sampling_weight():
+    """Output clamping should apply after IS weighting and block IS gradients."""
+    logprobs = torch.tensor([[-1.0]], requires_grad=True)
+    logprobs_reference = torch.zeros_like(logprobs)
+    importance_sampling_weights = 100.0 * torch.exp(logprobs - logprobs.detach())
+
+    kl = calculate_kl(
+        logprobs=logprobs,
+        logprobs_reference=logprobs_reference,
+        kl_type="k3",
+        input_clamp_value=None,
+        output_clamp_value=1.0,
+        importance_sampling_weights=importance_sampling_weights,
+    )
+
+    torch.testing.assert_close(kl.detach(), torch.tensor([[1.0]]))
+
+    kl.sum().backward()
+
+    torch.testing.assert_close(
+        logprobs.grad,
+        torch.zeros_like(logprobs),
+        atol=1e-6,
+        rtol=1e-6,
+    )
+
+
 # Simplified KL Penalty Test using original Loss
 def test_clipped_pg_loss_kl_penalty():
     """Tests KL penalty calculations directly."""


### PR DESCRIPTION
# What does this PR do ?

When kl is clapmed, the importance ratios still carry gradients, so the kl backward becomes incorrect. We fix this by deactivating gradients for importance ratios when clamping is active.

This fixes some numerical instability observed in one of the test cases:
<img width="1319" height="318" alt="Screenshot 2026-06-26 at 10 05 15 AM" src="https://github.com/user-attachments/assets/8221dcae-1309-4f56-8bcd-39453fa018f8" />


# Issues

# Usage

Same as before

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information