### PR TITLE
fix: sanitize non-finite logprobs in vllm async worker

### DIFF
--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -16,6 +16,7 @@ import asyncio
 import copy
 import gc
 import logging
+import math
 import threading
 import time
 import uuid
@@ -49,6 +50,23 @@ from nemo_rl.models.generation.vllm.utils import (
 from nemo_rl.models.generation.vllm.vllm_worker import BaseVllmGenerationWorker
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _replace_non_finite(obj: Any) -> Any:
+    """Recursively replace NaN/Inf floats with 0.0.
+
+    starlette's JSONResponse serializes with allow_nan=False, so a single
+    non-finite value raises ValueError and the request returns HTTP 500. vLLM
+    can return NaN/Inf logprobs (we hit this at long context), so sanitize the
+    response payload before serializing it.
+    """
+    if isinstance(obj, float):
+        return obj if math.isfinite(obj) else 0.0
+    if isinstance(obj, dict):
+        return {k: _replace_non_finite(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_replace_non_finite(v) for v in obj]
+    return obj
 
 
 def _replace_prefix_tokens(
@@ -803,8 +821,11 @@ class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
                 )
 
             elif isinstance(generator, ChatCompletionResponse):
+                # NaN/Inf logprobs would make JSONResponse (allow_nan=False) 500.
                 return JSONResponse(
-                    content=model_dump_chat_response_with_routed_experts(generator)
+                    content=_replace_non_finite(
+                        model_dump_chat_response_with_routed_experts(generator)
+                    )
                 )
 
             return StreamingResponse(content=generator, media_type="text/event-stream")

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -14,6 +14,7 @@
 
 import importlib.util
 import json
+import math
 import os
 import sys
 import types
@@ -41,6 +42,7 @@ from nemo_rl.models.generation.vllm.vllm_worker import (
 )
 from nemo_rl.models.generation.vllm.vllm_worker_async import (
     VllmAsyncGenerationWorkerImpl,
+    _replace_non_finite,
     _replace_prefix_tokens,
 )
 from nemo_rl.models.policy import LoRAConfig, PolicyConfig
@@ -1730,6 +1732,19 @@ def test_vllm_deferred_model_load(cluster, tokenizer):
 
     # Clean up
     vllm_generation.shutdown()
+
+
+def test_replace_non_finite():
+    assert _replace_non_finite(math.nan) == 0.0
+    assert _replace_non_finite(math.inf) == 0.0
+    assert _replace_non_finite(-math.inf) == 0.0
+    assert _replace_non_finite(1.5) == 1.5
+    assert _replace_non_finite({"a": [math.nan, 1.0], "b": {"c": math.inf}}) == {
+        "a": [0.0, 1.0],
+        "b": {"c": 0.0},
+    }
+    assert _replace_non_finite("x") == "x"
+    assert _replace_non_finite([{"lp": -math.inf}, 2, None]) == [{"lp": 0.0}, 2, None]
 
 
 def test_VllmAsyncGenerationWorker_replace_prefix_tokens(tokenizer):


### PR DESCRIPTION
vLLM can emit non-finite logprobs. We hit a NaN consistently around 49K context, and vLLM also uses `-inf` intentionally when sampling filters remove tokens. Starlette's `JSONResponse` serializes with `allow_nan=False`, so any remaining NaN or infinity raises `ValueError` and turns the chat-completion request into a 500.

This PR sanitizes the dumped response immediately before JSON serialization:

- recursively replaces NaN, `+inf`, and `-inf` floats with `0.0`;
- emits at most one warning per response with the number of replaced values, so numerical instability is visible rather than silently masked;
- wraps the current `model_dump_chat_response_with_dynamic_message_fields` result on `main`.

`0.0` is a conservative sentinel for the rollout importance ratio because the train-time logprob is recomputed. The warning/count is intended to preserve the signal needed to investigate genuine model or vLLM numerical failures.

The unit test covers nested dict/list values, all three non-finite forms, finite and non-float passthrough, replacement count, one-warning behavior, and the no-warning finite path. Ruff lint/format, syntax compilation, and DCO pass on the rebased head.

Recent bounded retry and exhausted-rollout handling reduce the blast radius of a 500, but they do not make this response serializable; a deterministic NaN can still fail every retry. This keeps the fix at the source boundary.

