### PR TITLE
fix: tune small scale super configs for h100

### DIFF
--- a/examples/nemo_gym/nemotron-3-super/small_scale/stage1_rlvr_convergence_27node_h100.yaml
+++ b/examples/nemo_gym/nemotron-3-super/small_scale/stage1_rlvr_convergence_27node_h100.yaml
@@ -6,6 +6,9 @@ policy:
     colocated:
       resources:
         num_nodes: 12
+    vllm_cfg:
+      max_num_seqs: 16
+      gpu_memory_utilization: 0.70
 
   megatron_cfg:
     env_vars:

--- a/examples/nemo_gym/nemotron-3-super/small_scale/stage2_swe1_convergence_20node_h100.yaml
+++ b/examples/nemo_gym/nemotron-3-super/small_scale/stage2_swe1_convergence_20node_h100.yaml
@@ -6,6 +6,9 @@ policy:
     colocated:
       resources:
         num_nodes: 4            # 4 TP8 H100 gen replicas for the 1024-trajectory step
+    vllm_cfg:
+      max_num_seqs: 16
+      gpu_memory_utilization: 0.75
 
 cluster:
   num_nodes: 20   # 16 train (TP8*CP8*PP1=64 GPUs, DP2) + 4 gen (TP8). No judges -> SBATCH=20.

--- a/examples/nemo_gym/nemotron-3-super/small_scale/stage2_swe2_convergence_20node_h100.yaml
+++ b/examples/nemo_gym/nemotron-3-super/small_scale/stage2_swe2_convergence_20node_h100.yaml
@@ -5,6 +5,8 @@ policy:
     colocated:
       resources:
         num_nodes: 4
+    vllm_kwargs:
+      max_num_batched_tokens: 8480
 
 cluster:
   num_nodes: 20   # 16 train (TP8*CP8*PP1=64 GPUs, DP2) + 4 gen (TP8). No judges -> SBATCH=20.

--- a/examples/nemo_gym/nemotron-3-super/small_scale/stage3_rlhf_convergence_28node_h100.yaml
+++ b/examples/nemo_gym/nemotron-3-super/small_scale/stage3_rlhf_convergence_28node_h100.yaml
@@ -6,6 +6,9 @@ policy:
     colocated:
       resources:
         num_nodes: 8            # 8 TP8 H100 gen replicas for the 2048-trajectory step
+    vllm_cfg:
+      max_num_seqs: 16
+      gpu_memory_utilization: 0.75
 
 env:
   nemo_gym:

--- a/examples/nemo_gym/nemotron-3-super/stage1_rlvr.yaml
+++ b/examples/nemo_gym/nemotron-3-super/stage1_rlvr.yaml
@@ -242,6 +242,7 @@ policy:
 
     vllm_kwargs:
       mamba_ssm_cache_dtype: "float32"
+      mamba_cache_mode: align
       compilation_config:
         cudagraph_mode: PIECEWISE
         cudagraph_capture_sizes: [1,2,4,8,16,32,64]

--- a/examples/nemo_gym/nemotron-3-super/stage2_swe1.yaml
+++ b/examples/nemo_gym/nemotron-3-super/stage2_swe1.yaml
@@ -246,6 +246,7 @@ policy:
 
     vllm_kwargs:
       mamba_ssm_cache_dtype: "float32"
+      mamba_cache_mode: align
       compilation_config:
         cudagraph_mode: PIECEWISE
         cudagraph_capture_sizes: [1,2,4,8,16,32,64]

--- a/examples/nemo_gym/nemotron-3-super/stage2_swe2.yaml
+++ b/examples/nemo_gym/nemotron-3-super/stage2_swe2.yaml
@@ -246,6 +246,7 @@ policy:
 
     vllm_kwargs:
       mamba_ssm_cache_dtype: "float32"
+      mamba_cache_mode: align
       compilation_config:
         cudagraph_mode: PIECEWISE
         cudagraph_capture_sizes: [1,2,4,8,16,32,64]

--- a/examples/nemo_gym/nemotron-3-super/stage3_rlhf.yaml
+++ b/examples/nemo_gym/nemotron-3-super/stage3_rlhf.yaml
@@ -243,6 +243,7 @@ policy:
 
     vllm_kwargs:
       mamba_ssm_cache_dtype: "float32"
+      mamba_cache_mode: align
       compilation_config:
         cudagraph_mode: PIECEWISE
         cudagraph_capture_sizes: [1,2,4,8,16,32,64]


### PR DESCRIPTION
# What does this PR do ?

This updates the Nemotron-3 Super small-scale configs so they can run more reliably on H100 nodes.

Changes:
- Add explicit `max_num_seqs` and lower `gpu_memory_utilization` for the small-scale stage1, stage2_swe1, and stage3 H100 convergence configs.
- Add `mamba_cache_mode: align` to the shared stage defaults so all stages inherit the vLLM Mamba cache alignment setting (used for mtp inference only)
- Add `max_num_batched_tokens: 8480` to the small-scale stage2_swe2 H100 config.

These settings reduce vLLM scheduler/GEMM pressure and memory pressure for H100-scale runs while keeping the intended small-scale cluster shapes.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
