### PR TITLE
fix: Add missing variables in mopd nightly

### DIFF
--- a/tests/test_suites/llm/mopd-qwen3-1.7b-3n8g-megatron-pack.sh
+++ b/tests/test_suites/llm/mopd-qwen3-1.7b-3n8g-megatron-pack.sh
@@ -27,6 +27,8 @@ STEPS_PER_RUN=5
 MAX_STEPS=5
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
 NUM_MINUTES=15
+USES_SANDBOX=1
+USE_GYM_CONTAINER=true
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached


### PR DESCRIPTION
# What does this PR do ?

Adds a few missing variables needed for mopd nightly since it runs using nano-v3's Gym dataset.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
