### PR TITLE
fix(grpo_sync): skip refit for colocated MegatronGeneration

### DIFF
--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -76,6 +76,7 @@ from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.experience.sync_rollout_actor import SyncRolloutActor
 from nemo_rl.models.generation.interfaces import GenerationInterface
+from nemo_rl.models.generation.megatron import MegatronGeneration
 from nemo_rl.models.policy.interfaces import ColocatablePolicyInterface
 from nemo_rl.utils.checkpoint import CheckpointManager
 from nemo_rl.utils.logger import Logger, print_message_log_samples
@@ -404,7 +405,10 @@ def grpo_train_sync(
 
     kv_scales_cache = None  # Cache reused for computed kv scales
 
-    NEED_REFIT = True
+    NEED_REFIT = not (
+        isinstance(policy_generation, MegatronGeneration)
+        and master_config.policy["generation"]["colocated"]["enabled"]
+    )
     # If policy_generation is None, use the policy as the generation interface (megatron framework backend)
     if policy_generation is None:
         policy_generation = policy  # type: ignore


### PR DESCRIPTION
closes https://github.com/NVIDIA-NeMo/RL/issues/2942.

## Summary
- In `grpo_train_sync`, `NEED_REFIT` was unconditionally `True` for any non-`None` `policy_generation`, so colocated `MegatronGeneration` ran `refit_policy_generation`, which dispatches to the IPC ZMQ path.
- `MegatronGeneration` only overrides `update_weights_from_collective`, so the colocated IPC ZMQ branch raised `NotImplementedError`.
- Mirror the legacy `grpo.py:2155-2158` guard so the sync and legacy trainers behave identically for this case.
- introduction of the failure: PR #2355 (48d13ec69) made MegatronGeneration a real worker and added a NEED_REFIT guard for colocated-megatron in grpo.py:1983-1986 — but missed the same guard in grpo_sync.py. With data_plane.enabled=true, the sync trainer runs and calls update_weights_via_ipc_zmq, which MegatronGeneration doesn't implement → NotImplementedError.

## Test plan
- [x] Run `vlm_grpo` with `policy_generation=MegatronGeneration` and `colocated.enabled=true` on `grpo_train_sync` and confirm it no longer raises `NotImplementedError` during refit.
- [x] Confirm non-colocated and non-Megatron generation paths still take the refit branch (loss/reward parity with legacy `grpo.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)