### PR TITLE
Fix setuptools package discovery for nemo_rl subpackages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 requires = ["setuptools>=42", "wheel>=0.46.2"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = ["nemo_rl"]
+[tool.setuptools.packages.find]
+include = ["nemo_rl*"]
 
 [tool.setuptools.dynamic]
 version = { attr = "nemo_rl.__version__" }                      # any module attribute compatible with ast.literal_eval

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import tomllib
+
+from setuptools import find_packages
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_setuptools_package_discovery_includes_nemo_rl_subpackages():
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    package_find = pyproject["tool"]["setuptools"]["packages"]["find"]
+
+    assert package_find["include"] == ["nemo_rl*"]
+
+    discovered = set(find_packages(where=str(REPO_ROOT), include=package_find["include"]))
+    expected = {
+        "nemo_rl",
+        "nemo_rl.algorithms",
+        "nemo_rl.data",
+        "nemo_rl.environments",
+        "nemo_rl.models",
+    }
+
+    assert expected.issubset(discovered)


### PR DESCRIPTION
# What does this PR do ?

Fixes wheel packaging so setuptools discovers the full `nemo_rl` package tree instead of shipping only the top-level package.

# Issues
List issues that this PR closes:

N/A

# Usage
* **You can potentially add a usage example below**

```python
from nemo_rl.algorithms import ppo
from nemo_rl.data import dataloader
from nemo_rl.models import policy
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* Root cause: `[tool.setuptools] packages = ["nemo_rl"]` only packaged the top-level module, so wheel builds omitted importable subpackages such as `nemo_rl.algorithms`, `nemo_rl.data`, `nemo_rl.models`, and `nemo_rl.environments`.
* Fix: switch to setuptools package discovery with `include = ["nemo_rl*"]` and add a regression test that verifies the packaging config still discovers key `nemo_rl` subpackages.
* Validation:
  * `uv run --no-project --with pytest --with setuptools python -m pytest tests/test_packaging.py`
  * `uv run --no-project --with build --with setuptools --with wheel python -m build --wheel --no-isolation`
  * Before the change, the built wheel only contained `nemo_rl/__init__.py` and `nemo_rl/package_info.py`. After the change, the wheel includes subpackages across `nemo_rl.algorithms`, `nemo_rl.data`, `nemo_rl.data_plane`, `nemo_rl.environments`, `nemo_rl.models`, and more.
