### PR TITLE
Avoid leaking env vars across Ray worker groups

### DIFF
--- a/nemo_rl/distributed/worker_groups.py
+++ b/nemo_rl/distributed/worker_groups.py
@@ -333,7 +333,7 @@ class RayWorkerGroup:
         name_prefix: str = "",
         bundle_indices_list: Optional[list[tuple[int, list[int]]]] = None,
         sharding_annotations: Optional[NamedSharding] = None,
-        env_vars: dict[str, str] = {},
+        env_vars: Optional[dict[str, str]] = None,
     ):
         """Initialize a group of distributed Ray workers.
 
@@ -426,7 +426,7 @@ class RayWorkerGroup:
         self,
         remote_worker_builder: RayWorkerBuilder,
         bundle_indices_list: list[tuple[int, list[int]]],
-        env_vars: dict[str, str] = {},
+        env_vars: Optional[dict[str, str]] = None,
     ) -> None:
         """Create workers based on explicit bundle indices for tied worker groups.
 
@@ -440,6 +440,9 @@ class RayWorkerGroup:
         self.master_address, self.master_port = (
             self.cluster.get_master_address_and_port()
         )
+
+        # Copy user-supplied env vars so worker creation never mutates caller state.
+        env_vars = dict(env_vars or {})
 
         # Update env_vars with the current environment variables
         for k, v in os.environ.items():

--- a/tests/test_worker_group_env_vars.py
+++ b/tests/test_worker_group_env_vars.py
@@ -1,0 +1,104 @@
+import os
+
+import pytest
+import ray
+
+from nemo_rl.distributed.ray_actor_environment_registry import (
+    ACTOR_ENVIRONMENT_REGISTRY,
+    PY_EXECUTABLES,
+)
+from nemo_rl.distributed.virtual_cluster import RayVirtualCluster, init_ray
+from nemo_rl.distributed.worker_groups import RayWorkerBuilder, RayWorkerGroup
+
+
+@ray.remote
+class EnvCaptureActor:
+    def __init__(self):
+        self.env_vars = dict(os.environ)
+
+    def get_env_var(self, var_name):
+        return self.env_vars.get(var_name)
+
+
+ENV_CAPTURE_ACTOR_FQN = f"{EnvCaptureActor.__module__}.EnvCaptureActor"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ray_cluster():
+    init_ray()
+    yield
+    ray.shutdown()
+
+
+@pytest.fixture
+def register_env_capture_actor():
+    original_registry_value = ACTOR_ENVIRONMENT_REGISTRY.get(ENV_CAPTURE_ACTOR_FQN)
+    ACTOR_ENVIRONMENT_REGISTRY[ENV_CAPTURE_ACTOR_FQN] = PY_EXECUTABLES.SYSTEM
+
+    yield ENV_CAPTURE_ACTOR_FQN
+
+    if ENV_CAPTURE_ACTOR_FQN in ACTOR_ENVIRONMENT_REGISTRY:
+        if original_registry_value is None:
+            del ACTOR_ENVIRONMENT_REGISTRY[ENV_CAPTURE_ACTOR_FQN]
+        else:
+            ACTOR_ENVIRONMENT_REGISTRY[ENV_CAPTURE_ACTOR_FQN] = original_registry_value
+
+
+@pytest.fixture
+def virtual_cluster():
+    cluster = RayVirtualCluster(bundle_ct_per_node_list=[2], use_gpus=False)
+    yield cluster
+    cluster.shutdown()
+
+
+def test_default_environment_variables_do_not_leak_between_worker_groups(
+    register_env_capture_actor, virtual_cluster, monkeypatch
+):
+    builder = RayWorkerBuilder(register_env_capture_actor)
+    leak_var = "NRL_TEST_LEAKED_ENV_VAR"
+
+    monkeypatch.setenv(leak_var, "first-launch-only")
+    first_worker_group = RayWorkerGroup(
+        cluster=virtual_cluster,
+        remote_worker_builder=builder,
+        workers_per_node=1,
+    )
+
+    assert (
+        ray.get(first_worker_group.workers[0].get_env_var.remote(leak_var))
+        == "first-launch-only"
+    )
+    first_worker_group.shutdown(force=True)
+
+    monkeypatch.delenv(leak_var, raising=False)
+    second_worker_group = RayWorkerGroup(
+        cluster=virtual_cluster,
+        remote_worker_builder=builder,
+        workers_per_node=1,
+    )
+
+    assert ray.get(second_worker_group.workers[0].get_env_var.remote(leak_var)) is None
+    second_worker_group.shutdown(force=True)
+
+
+def test_custom_env_vars_input_is_not_mutated(
+    register_env_capture_actor, virtual_cluster, monkeypatch
+):
+    builder = RayWorkerBuilder(register_env_capture_actor)
+
+    monkeypatch.setenv("NRL_TEST_SYSTEM_ENV_ONLY", "system-value")
+    custom_env_vars = {"NRL_TEST_CUSTOM_ENV": "custom-value"}
+
+    worker_group = RayWorkerGroup(
+        cluster=virtual_cluster,
+        remote_worker_builder=builder,
+        workers_per_node=1,
+        env_vars=custom_env_vars,
+    )
+
+    worker = worker_group.workers[0]
+    assert ray.get(worker.get_env_var.remote("NRL_TEST_CUSTOM_ENV")) == "custom-value"
+    assert ray.get(worker.get_env_var.remote("NRL_TEST_SYSTEM_ENV_ONLY")) == "system-value"
+    assert custom_env_vars == {"NRL_TEST_CUSTOM_ENV": "custom-value"}
+
+    worker_group.shutdown(force=True)


### PR DESCRIPTION
# What does this PR do ?

Avoids mutating and reusing shared `env_vars` state when creating `RayWorkerGroup` workers.

# Issues
List issues that this PR closes:

N/A

# Usage
* **You can potentially add a usage example below**

```python
worker_group = RayWorkerGroup(
    cluster=cluster,
    remote_worker_builder=builder,
    env_vars={"HF_HOME": "/shared/cache"},
)
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* Root cause: both `RayWorkerGroup.__init__` and `_create_workers_from_bundle_indices` used a mutable default `env_vars={}`. The helper then merged `os.environ` into that dict in place, so later worker-group launches could inherit stale environment variables from earlier launches. The same mutation also polluted caller-supplied `env_vars` dictionaries.
* Fix: change both defaults to `None`, then copy `env_vars` locally before merging the current process environment.
* Regression coverage:
  * `test_default_environment_variables_do_not_leak_between_worker_groups` proves a second default-launched worker group no longer inherits a variable removed from the parent environment after the first launch.
  * `test_custom_env_vars_input_is_not_mutated` proves caller-provided `env_vars` keep their original contents after worker creation.
* Validation:
  * `uv run --no-project --with pytest --with 'ray[default]' --with tqdm --with numpy --with rich --with torch python -m pytest tests/test_worker_group_env_vars.py`
