### PR TITLE
Use JSON for vLLM env list parsing

### DIFF
--- a/nemo_rl/distributed/worker_groups.py
+++ b/nemo_rl/distributed/worker_groups.py
@@ -30,6 +30,7 @@ from nemo_rl.distributed.ray_actor_environment_registry import (
 )
 from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
 from nemo_rl.distributed.worker_group_utils import recursive_merge_options
+from nemo_rl.utils.env_var_serialization import encode_env_list
 from nemo_rl.utils.venvs import (
     create_local_venv_on_each_node,
 )
@@ -527,8 +528,8 @@ class RayWorkerGroup:
                         "MASTER_ADDR": self.master_address,
                         "MASTER_PORT": str(self.master_port),
                         "NODE_RANK": str(pg_idx),
-                        "AVAILABLE_ADDR_LIST": str(available_addresses),
-                        "AVAILABLE_PORT_LIST": str(available_ports),
+                        "AVAILABLE_ADDR_LIST": encode_env_list(available_addresses),
+                        "AVAILABLE_PORT_LIST": encode_env_list(available_ports),
                     }
                 )
                 # Remove Ray-specific environment variables, let the worker itself set them.

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -42,6 +42,10 @@ from nemo_rl.models.generation.vllm.utils import (
 )
 from nemo_rl.models.huggingface.common import ModelFlag
 from nemo_rl.models.policy.utils import is_vllm_v1_engine_enabled
+from nemo_rl.utils.env_var_serialization import (
+    decode_env_int_list,
+    decode_env_str_list,
+)
 from nemo_rl.utils.nsys import wrap_with_nvtx_name
 from nemo_rl.utils.nvml import log_gpu_memory_diagnostics
 
@@ -295,8 +299,12 @@ class BaseVllmGenerationWorker:
             os.environ["VLLM_DP_RANK_LOCAL"] = str((rank % 8) // model_parallel_size)
             # set vLLM DP address and port
             leader_rank = int(os.environ["RANK"]) // world_size * world_size
-            addr_list = eval(os.environ["AVAILABLE_ADDR_LIST"])
-            port_list = eval(os.environ["AVAILABLE_PORT_LIST"])
+            addr_list = decode_env_str_list(
+                os.environ["AVAILABLE_ADDR_LIST"], "AVAILABLE_ADDR_LIST"
+            )
+            port_list = decode_env_int_list(
+                os.environ["AVAILABLE_PORT_LIST"], "AVAILABLE_PORT_LIST"
+            )
             os.environ["VLLM_DP_MASTER_IP"] = addr_list[leader_rank]
             os.environ["VLLM_DP_MASTER_PORT"] = str(port_list[leader_rank])
 

--- a/nemo_rl/utils/env_var_serialization.py
+++ b/nemo_rl/utils/env_var_serialization.py
@@ -1,0 +1,34 @@
+import json
+
+
+def encode_env_list(values: list[str] | list[int]) -> str:
+    """Serialize an environment-variable list payload as JSON."""
+    return json.dumps(values)
+
+
+def decode_env_str_list(raw_value: str, env_var_name: str) -> list[str]:
+    """Parse a JSON-encoded environment variable as a list of strings."""
+    parsed = _decode_env_list(raw_value, env_var_name)
+    if not all(isinstance(item, str) for item in parsed):
+        raise ValueError(f"{env_var_name} must be a JSON list of strings")
+    return parsed
+
+
+def decode_env_int_list(raw_value: str, env_var_name: str) -> list[int]:
+    """Parse a JSON-encoded environment variable as a list of integers."""
+    parsed = _decode_env_list(raw_value, env_var_name)
+    if not all(type(item) is int for item in parsed):
+        raise ValueError(f"{env_var_name} must be a JSON list of integers")
+    return parsed
+
+
+def _decode_env_list(raw_value: str, env_var_name: str) -> list[object]:
+    try:
+        parsed = json.loads(raw_value)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{env_var_name} must be valid JSON") from exc
+
+    if not isinstance(parsed, list):
+        raise ValueError(f"{env_var_name} must be a JSON list")
+
+    return parsed

--- a/tests/test_env_var_serialization.py
+++ b/tests/test_env_var_serialization.py
@@ -1,0 +1,46 @@
+import pytest
+
+from nemo_rl.utils.env_var_serialization import (
+    decode_env_int_list,
+    decode_env_str_list,
+    encode_env_list,
+)
+
+
+def test_encode_env_list_uses_json():
+    assert encode_env_list(["10.0.0.1", "10.0.0.2"]) == '["10.0.0.1", "10.0.0.2"]'
+    assert encode_env_list([25001, 25002]) == "[25001, 25002]"
+
+
+def test_decode_env_lists_round_trip():
+    assert decode_env_str_list('["10.0.0.1", "10.0.0.2"]', "AVAILABLE_ADDR_LIST") == [
+        "10.0.0.1",
+        "10.0.0.2",
+    ]
+    assert decode_env_int_list("[25001, 25002]", "AVAILABLE_PORT_LIST") == [
+        25001,
+        25002,
+    ]
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "env_var_name"),
+    [
+        ('__import__("os").system("echo pwned")', "AVAILABLE_ADDR_LIST"),
+        ('{"addr": "10.0.0.1"}', "AVAILABLE_PORT_LIST"),
+    ],
+)
+def test_decode_env_list_rejects_non_list_json(raw_value, env_var_name):
+    with pytest.raises(ValueError, match=env_var_name):
+        if env_var_name == "AVAILABLE_ADDR_LIST":
+            decode_env_str_list(raw_value, env_var_name)
+        else:
+            decode_env_int_list(raw_value, env_var_name)
+
+
+def test_decode_env_list_rejects_wrong_element_types():
+    with pytest.raises(ValueError, match="AVAILABLE_ADDR_LIST"):
+        decode_env_str_list('["10.0.0.1", 2]', "AVAILABLE_ADDR_LIST")
+
+    with pytest.raises(ValueError, match="AVAILABLE_PORT_LIST"):
+        decode_env_int_list('[25001, "25002"]', "AVAILABLE_PORT_LIST")


### PR DESCRIPTION
# What does this PR do ?

Replaces unsafe `eval()` parsing for vLLM worker address/port environment variables with JSON serialization and strict decoding.

# Issues
List issues that this PR closes:

N/A

# Usage
* **You can potentially add a usage example below**

```python
os.environ["AVAILABLE_ADDR_LIST"] = '["10.0.0.1", "10.0.0.2"]'
os.environ["AVAILABLE_PORT_LIST"] = '[25001, 25002]'
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* Root cause: `nemo_rl/models/generation/vllm/vllm_worker.py` used `eval()` on `AVAILABLE_ADDR_LIST` and `AVAILABLE_PORT_LIST`, so malformed or attacker-controlled env vars could turn config parsing into arbitrary Python execution.
* Fix: serialize these env-var payloads as JSON in `nemo_rl/distributed/worker_groups.py`, decode them with `json.loads()` in the vLLM worker, and validate that the decoded values are lists of the expected element type.
* Regression coverage:
  * verifies the producer emits JSON-formatted list payloads
  * verifies valid string/int lists round-trip correctly
  * rejects non-JSON and non-list payloads, including a code-like `__import__(...)` string
  * rejects mixed or incorrect element types
* Validation:
  * `uv run --no-project --with pytest python -m pytest tests/test_env_var_serialization.py`
