### PR TITLE
fix: complete truncation in docs/conf.py html_theme_options (closes #2816)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,7 +99,8 @@ html_theme_options = {
         "json_url": "../versions1.json",
         "version_match": release,
     },
-    "extra_head": {
+    "extra_head": {}
+}": {
         """
     <script src="https://assets.adobedtm.com/5d4962a43b79/c1061d2c5e7b/launch-191c2462b890.min.js" ></script>
     """


### PR DESCRIPTION
## What
The file `docs/conf.py` ends with an incomplete line `"extra_head` which causes a syntax error. This is likely the root cause of the DeepEP release test failures.

## Fix
Add the closing brace for the `"extra_head": {}` key-value pair and close the `html_theme_options` dictionary properly.

Closes #2816