### PR TITLE
fix: avoid nvidia-cutlass-dsl install race + fix dsv3 gb200 perf test

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -264,7 +264,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.9.1"
+          version: "0.11.18"
           enable-cache: true
           prune-cache: false
       # Faster than uv python install since it caches python alongside runner

--- a/examples/configs/recipes/llm/performance/grpo-deepseek-v3-32n4g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-deepseek-v3-32n4g.yaml
@@ -19,3 +19,4 @@ logger:
     name: grpo-deepseek-v3-32n4g
 cluster:
   gpus_per_node: 4
+  segment_size: 16

--- a/examples/configs/recipes/llm/performance/grpo-deepseek-v3-64n4g-async-1off.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-deepseek-v3-64n4g-async-1off.yaml
@@ -18,3 +18,4 @@ logger:
     name: grpo-deepseek-v3-64n4g-async-32T32G-1off
 cluster:
   gpus_per_node: 4
+  segment_size: 16

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -398,6 +398,13 @@ constraint-dependencies = [
   "diffusers>=0.38.0",
 ]
 
+# Workaround for https://github.com/NVIDIA/cutlass/issues/3259: libs-base
+# and libs-cu13 wheels overlap and race on shared paths. libs-cu13 is a
+# functional superset at 4.5.2, so drop libs-base to make installs deterministic.
+exclude-dependencies = [
+  "nvidia-cutlass-dsl-libs-base",
+]
+
 conflicts = [
   [
     { extra = "fsdp" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -401,9 +401,7 @@ constraint-dependencies = [
 # Workaround for https://github.com/NVIDIA/cutlass/issues/3259: libs-base
 # and libs-cu13 wheels overlap and race on shared paths. libs-cu13 is a
 # functional superset at 4.5.2, so drop libs-base to make installs deterministic.
-exclude-dependencies = [
-  "nvidia-cutlass-dsl-libs-base",
-]
+exclude-dependencies = ["nvidia-cutlass-dsl-libs-base"]
 
 conflicts = [
   [

--- a/uv.lock
+++ b/uv.lock
@@ -87,6 +87,7 @@ overrides = [
     { name = "transformer-engine", extras = ["pytorch", "core-cu13"], git = "https://github.com/NVIDIA/TransformerEngine.git?rev=release_v2.15" },
     { name = "xgrammar", specifier = "==0.1.33" },
 ]
+excludes = ["nvidia-cutlass-dsl-libs-base"]
 
 [[manifest.dependency-metadata]]
 name = "causal-conv1d"
@@ -3796,9 +3797,6 @@ wheels = [
 name = "nvidia-cutlass-dsl"
 version = "4.5.2"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-cutlass-dsl-libs-base", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/15/575d7df4fe2f3406f1cfc68be72aeff2834f8a696daf1cd5bee8017e4507/nvidia_cutlass_dsl-4.5.2-py3-none-any.whl", hash = "sha256:68ed1b63ca74aae87955012da9dfd7fdaae471329d0028b229b841c7192ccf52", size = 10179, upload-time = "2026-05-25T03:38:56.364Z" },
 ]
@@ -3809,27 +3807,12 @@ cu13 = [
 ]
 
 [[package]]
-name = "nvidia-cutlass-dsl-libs-base"
-version = "4.5.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cuda-python", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "numpy", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/f8/b192015e273ff023a35741d6d5e4a93e4819160dee3955fc5d3d53534450/nvidia_cutlass_dsl_libs_base-4.5.2-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:395bd77cf642aeef311313453e6582f11c9357a4b81fe620ea3daccd1fccab9b", size = 75645002, upload-time = "2026-05-25T03:48:01.887Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/6e/bfe256ac08e5a6dfb11444809e54c76c3a2f05fff38dd173e2e71b95e4d2/nvidia_cutlass_dsl_libs_base-4.5.2-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e59da7d89e5e4f8514c6530843f910f9d8734d8042dcaa079c9d9c5063eb3514", size = 74514312, upload-time = "2026-05-25T03:50:56.343Z" },
-]
-
-[[package]]
 name = "nvidia-cutlass-dsl-libs-cu13"
 version = "4.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-python", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "numpy", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cutlass-dsl-libs-base", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typing-extensions", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 wheels = [


### PR DESCRIPTION
thanks @youngeunkwon0405 found this is the root cause for dsv3 gb200 fail! related PR: https://github.com/NVIDIA-NeMo/RL/pull/2921.

## Issue
related to https://github.com/NVIDIA-NeMo/RL/issues/2579.

## Summary
Validated these perf tests could pass:
`grpo-deepseek-v3-32n4g`, `grpo-deepseek-v3-64n4g`, `grpo-deepseek-v3-64n4g-async-1off`

Stil fail test:
`grpo-dapomath17k-dsv3-32n4g-megatron` still failed, OOM at step 10 when saving ckpt.

## Changes
1. exclude `nvidia-cutlass-dsl-libs-base` to avoid nvidia-cutlass-dsl install race.
2. add `cluster.segment_size=16`.
3. update ci `uv` version to support `exclude` and match dockerfile.