### PR TITLE
fix: WAR for Perf test failing with NCCL error

### DIFF
--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -178,6 +178,73 @@ sbatch ray.sub \
 > For the most part, you will not need to change ports unless these
 > are already taken by some other service backgrounded on your cluster.
 
+### Topology-Aware Placement for MoE (avoiding cross-rack stalls)
+
+On clusters where one NVLink domain spans a fixed set of nodes (e.g. a GB200
+NVL72 rack = 18 nodes = one fabric domain), a MoE job's expert-parallel (EP)
+`all_to_all` can intermittently stall under sustained load when an EP group is
+split across two NVLink domains (two racks). The fix is to keep every EP group
+inside a single NVLink domain. This requires **two coordinated knobs**, both
+sized to the EP group's node span:
+
+```
+segment_size (nodes) = expert_model_parallel_size / gpus_per_node
+```
+
+For example `expert_model_parallel_size=8` on a 4-GPU/node cluster spans 2
+nodes, so the segment size is `2`.
+
+* **`cluster.segment_size`** (recipe YAML) — application/Ray side. After the
+  Slurm allocation exists, NeMo RL selects topology-aligned nodes (complete
+  `segment_size`-node segments per NVLink domain) and orders global ranks so
+  each EP group lands on one segment. It is a *post-allocation selector*: it
+  cannot change what Slurm allocated, and raises `ResourceInsufficientError` if
+  the allocated nodes cannot form complete segments. The requested node count
+  must be evenly divisible by `segment_size`.
+
+  ```yaml
+  cluster:
+    gpus_per_node: 4
+    segment_size: 2   # = EP group node span; keeps each EP group intra-rack
+  ```
+
+* **`sbatch --segment=<size>`** (Slurm side, block topology) — allocation side.
+  Tells Slurm to allocate nodes in segments of `<size>` nodes, each segment
+  guaranteed within a single topology block (rack); segments themselves may
+  span blocks. This makes the physical allocation match what
+  `cluster.segment_size` expects (and forces an even node count per rack, so
+  odd splits like 5+3 cannot occur). The node count must be evenly divisible by
+  the segment size.
+
+  ```sh
+  ... \
+  sbatch --nodes=8 --segment=2 ray.sub \
+     ...
+  ```
+
+> [!NOTE]
+> Set both to the same value. `--segment` alone guarantees the physical layout
+> but not the rank→node mapping; `cluster.segment_size` alone aligns ranks but
+> can fail (or silently fall back) if Slurm hands you a layout that cannot form
+> complete segments. The guarantee also relies on EP being the contiguous
+> (inner) parallel dimension in the global rank order, which is the default for
+> `tp-...-ep-dp-pp` layouts with TP/PP not interleaving EP.
+
+For nightly/release tests launched with `tools/launch`, you do not pass
+`--segment` by hand: add `SEGMENT_SIZE=<size>` to the script's
+`# ===== BEGIN CONFIG =====` block (mirroring `cluster.segment_size` in the
+recipe) and `tools/launch` validates divisibility and appends
+`--segment=<size>` to the `sbatch` invocation automatically.
+
+```sh
+# ===== BEGIN CONFIG =====
+NUM_NODES=8
+GPUS_PER_NODE=4
+SEGMENT_SIZE=2     # nodes per NVLink-domain segment; -> sbatch --segment
+...
+# ===== END CONFIG =====
+```
+
 ## Kubernetes
 
 This guide outlines the process of migrating NemoRL training jobs from a Slurm environment to a Kubernetes cluster utilizing Ray orchestration and NVIDIA GPUs.

--- a/examples/configs/recipes/llm/grpo-gptoss-20b-8n4g-megatron.yaml
+++ b/examples/configs/recipes/llm/grpo-gptoss-20b-8n4g-megatron.yaml
@@ -14,3 +14,4 @@ policy:
       attention_backend: TRITON_ATTN
 cluster:
   gpus_per_node: 4
+  segment_size: 8

--- a/examples/configs/recipes/llm/grpo-gptoss-20b-8n4g-megatron.yaml
+++ b/examples/configs/recipes/llm/grpo-gptoss-20b-8n4g-megatron.yaml
@@ -14,4 +14,6 @@ policy:
       attention_backend: TRITON_ATTN
 cluster:
   gpus_per_node: 4
-  segment_size: 8
+  # EP=8, 4 GPU/node => each EP group spans 2 nodes. segment_size=2 aligns each
+  # EP group to a single NVL72 rack so the MoE EP all_to_all never crosses racks
+  segment_size: 2

--- a/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n4g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n4g.yaml
@@ -33,6 +33,7 @@ policy:
       lr_warmup_init: 3.0e-08
     env_vars:
       PYTORCH_CUDA_ALLOC_CONF: expandable_segments:False
+      NCCL_P2P_PXN_LEVEL: "0"
   generation:
     vllm_cfg:
       tensor_parallel_size: 1

--- a/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n4g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n4g.yaml
@@ -33,7 +33,6 @@ policy:
       lr_warmup_init: 3.0e-08
     env_vars:
       PYTORCH_CUDA_ALLOC_CONF: expandable_segments:False
-      NCCL_P2P_PXN_LEVEL: "0"
   generation:
     vllm_cfg:
       tensor_parallel_size: 1
@@ -51,4 +50,5 @@ logger:
 cluster:
   gpus_per_node: 4
   num_nodes: 4
+  segment_size: 4
 

--- a/tests/test_suites/llm/grpo-gptoss-20b-8n4g-megatron.sh
+++ b/tests/test_suites/llm/grpo-gptoss-20b-8n4g-megatron.sh
@@ -5,6 +5,7 @@ source $SCRIPT_DIR/common.env
 # ===== BEGIN CONFIG =====
 NUM_NODES=8
 GPUS_PER_NODE=4
+SEGMENT_SIZE=2     # nodes per NVLink-domain segment; tools/launch passes it as sbatch --segment (keeps MoE EP intra-rack, #2937). Matches cluster.segment_size in the yaml.
 STEPS_PER_RUN=60
 MAX_STEPS=60
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up

--- a/tests/test_suites/llm/grpo-qwen3-30ba3b-4n4g-megatron-qa-nvfp4.sh
+++ b/tests/test_suites/llm/grpo-qwen3-30ba3b-4n4g-megatron-qa-nvfp4.sh
@@ -9,6 +9,7 @@ source $SCRIPT_DIR/common.env
 # ===== BEGIN CONFIG =====
 NUM_NODES=4
 GPUS_PER_NODE=4
+SEGMENT_SIZE=4     # nodes per NVLink-domain segment; tools/launch passes it as sbatch --segment (keeps MoE EP intra-rack, #2937). Matches cluster.segment_size in the yaml.
 STEPS_PER_RUN=1
 MAX_STEPS=1
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up

--- a/tests/test_suites/llm/performance/grpo-deepseek-v3-32n4g.sh
+++ b/tests/test_suites/llm/performance/grpo-deepseek-v3-32n4g.sh
@@ -13,6 +13,7 @@ fi
 # ===== BEGIN CONFIG =====
 NUM_NODES=32
 GPUS_PER_NODE=4
+SEGMENT_SIZE=16    # nodes per NVLink-domain segment; tools/launch passes it as sbatch --segment (keeps MoE EP intra-rack, #2937). Matches cluster.segment_size in the yaml.
 STEPS_PER_RUN=10
 MAX_STEPS=10
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up

--- a/tests/test_suites/llm/performance/grpo-deepseek-v3-64n4g-async-1off.sh
+++ b/tests/test_suites/llm/performance/grpo-deepseek-v3-64n4g-async-1off.sh
@@ -13,6 +13,7 @@ fi
 # ===== BEGIN CONFIG =====
 NUM_NODES=64
 GPUS_PER_NODE=4
+SEGMENT_SIZE=16    # nodes per NVLink-domain segment; tools/launch passes it as sbatch --segment (keeps MoE EP intra-rack, #2937). Matches cluster.segment_size in the yaml.
 STEPS_PER_RUN=10
 MAX_STEPS=10
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up

--- a/tests/test_suites/llm/performance/grpo-deepseek-v3-64n4g.sh
+++ b/tests/test_suites/llm/performance/grpo-deepseek-v3-64n4g.sh
@@ -13,6 +13,7 @@ fi
 # ===== BEGIN CONFIG =====
 NUM_NODES=64
 GPUS_PER_NODE=4
+SEGMENT_SIZE=16    # nodes per NVLink-domain segment; tools/launch passes it as sbatch --segment (keeps MoE EP intra-rack, #2937). Matches cluster.segment_size in the yaml.
 STEPS_PER_RUN=10
 MAX_STEPS=10
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up

--- a/tests/test_suites/llm/performance/grpo-qwen3-30ba3b-4n4g-async-1off.sh
+++ b/tests/test_suites/llm/performance/grpo-qwen3-30ba3b-4n4g-async-1off.sh
@@ -5,6 +5,7 @@ source $SCRIPT_DIR/common.env
 # ===== BEGIN CONFIG =====
 NUM_NODES=4
 GPUS_PER_NODE=4
+SEGMENT_SIZE=4     # nodes per NVLink-domain segment; tools/launch passes it as sbatch --segment (keeps MoE EP intra-rack, #2937). Matches cluster.segment_size in the yaml.
 STEPS_PER_RUN=10
 MAX_STEPS=10
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up

--- a/tests/test_suites/llm/performance/grpo-qwen3-30ba3b-4n4g.sh
+++ b/tests/test_suites/llm/performance/grpo-qwen3-30ba3b-4n4g.sh
@@ -5,6 +5,7 @@ source $SCRIPT_DIR/common.env
 # ===== BEGIN CONFIG =====
 NUM_NODES=4
 GPUS_PER_NODE=4
+SEGMENT_SIZE=4     # nodes per NVLink-domain segment; tools/launch passes it as sbatch --segment (keeps MoE EP intra-rack, #2937). Matches cluster.segment_size in the yaml.
 STEPS_PER_RUN=10
 MAX_STEPS=10
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up

--- a/tools/launch
+++ b/tools/launch
@@ -120,10 +120,27 @@ for SCRIPT in $SCRIPTS; do
         # Error message is already printed by extract_config
         exit 1
     fi
+    # Reset optional per-script config vars so a value from a previous script in
+    # the loop does not leak into a script that omits it.
+    SEGMENT_SIZE=""
     eval "$config"
 
     # Default GPUS_PER_NODE to 8 if not specified in config (H100 default)
     export GPUS_PER_NODE=${GPUS_PER_NODE:-8}
+
+    # Optional topology-aware allocation: if the script's CONFIG defines
+    # SEGMENT_SIZE (mirrors cluster.segment_size in the recipe yaml), ask Slurm
+    # to allocate nodes in segments of that many nodes, each kept within a single
+    # topology block (rack), so MoE expert-parallel groups never span racks
+    # (#2937). Must evenly divide NUM_NODES. Empty => no --segment (default).
+    SEGMENT_ARG=""
+    if [[ -n "${SEGMENT_SIZE:-}" ]]; then
+        if (( NUM_NODES % SEGMENT_SIZE != 0 )); then
+            echo "[ERROR]: SEGMENT_SIZE=$SEGMENT_SIZE must evenly divide NUM_NODES=$NUM_NODES (in $SCRIPT)" >&2
+            exit 1
+        fi
+        SEGMENT_ARG="--segment=$SEGMENT_SIZE "
+    fi
 
     # NUM_RUNS * NUM_NODES * NUM_GPUS * (NUM_MINUTES / 60)
     gpu_hours=$((NUM_RUNS * NUM_NODES * GPUS_PER_NODE * NUM_MINUTES / 60))
@@ -180,7 +197,7 @@ SANDBOX_CONTAINER="${SANDBOX_CONTAINER:-}" \\
 SANDBOX_COMMAND="${SANDBOX_COMMAND:-}" \\
 SANDBOX_ENV_VARS="${SANDBOX_ENV_VARS:-}" \\
 sbatch \\
-    --nodes=$NUM_NODES \\
+    --nodes=$NUM_NODES ${SEGMENT_ARG}\\
     --account=$ACCOUNT \\
     --job-name=$ACCOUNT:${JOB_NAME}${SLURM_JOB_SUFFIX:-} \\
     --partition=$PARTITION \\


### PR DESCRIPTION
# What does this PR do ?

#2937 (cross-rack NCCL stall) only happens when a MoE job's expert-parallel
(EP) `all_to_all` group spans two NVLink domains (two NVL72 racks). Under
sustained load NCCL's cross-rack transport intermittently stalls on that
`all_to_all` and trips the 600s ProcessGroupNCCL watchdog — so it looks flaky,
surfacing only when the scheduler spreads a job across racks. The fix in this
PR is **topology-aware placement**: keep every EP group inside a single rack.

## Two approaches considered

1. **`NCCL_P2P_PXN_LEVEL=0` (NCCL workaround)** — disables PXN for the p2p path
   the `all_to_all` uses.
   - Fixes `llm_performance_grpo_qwen3_30ba3b_4n4g` and `..._async_1off`.
   - `llm_grpo_gptoss_20b_8n4g_megatron` still hangs (~step 45/60) even with the
     broad `NCCL_PXN_DISABLE=1` — insufficient for the larger/longer EP
     `all_to_all`.
   - ~16% perf drop (250 → 290 s/step on `grpo_qwen3_30ba3b_4n4g`).

2. **Topology-aware placement (this PR)** — keep each EP group inside one rack;
   no perf drop.

## What this PR does (approach 2, end-to-end)

Two coordinated knobs, both sized to the EP group's node span
(`segment_size = expert_model_parallel_size / gpus_per_node`):

- **`cluster.segment_size` (recipe YAML)** — Ray side. After the allocation
  exists, NeMo RL selects topology-aligned nodes (complete `segment_size`-node
  segments per NVLink domain) and orders ranks so each EP group lands on one
  segment.
- **`sbatch --segment=<n>` (Slurm side, block topology)** — allocation side.
  Each `<n>`-node segment is allocated within a single rack (segments may span
  racks). This closes the gap noted earlier ("no good way to control
  `--segment` from the framework"):
  - `tools/launch` now reads an optional `SEGMENT_SIZE` from a test script's
    `# ===== BEGIN CONFIG =====` block, validates it evenly divides
    `NUM_NODES`, and appends `--segment=<n>` to the `sbatch` invocation
    automatically.
  - Added `SEGMENT_SIZE` to the CONFIG block of the MoE recipes whose YAML sets
    `cluster.segment_size` (gptoss=2, qwen3-30ba3b=4, deepseek-v3=16).
- **Docs** — `docs/cluster.md` documents topology-aware placement (both knobs,
  why both are needed, the EP-contiguity caveat) and the `tools/launch`
  `SEGMENT_SIZE` usage.

Set both: `--segment` guarantees the physical layout but not the rank→node
mapping; `cluster.segment_size` aligns ranks but can fail (or silently fall
back) if Slurm hands it a layout that cannot form complete segments. The
guarantee also relies on EP being the contiguous (inner) parallel dimension,
which is the default for `tp-...-ep-dp-pp` layouts.

## Validation

`grpo-gptoss-20b-8n4g-megatron` with `cluster.segment_size: 2` on a genuine
cross-rack 6+2 allocation (2 NVLink domains) reaches **step 60/60, watchdog=0**,
all check_metrics pass:
- `mean(train/gen_kl_error) = 0.0012 < 0.002`
- `train/reward["60"] = 0.663 > 0.60`
- `mean(timing/train/total_step_time, -6, -1) = 108.8s < 150`

# Issues

closes https://github.com/NVIDIA-NeMo/RL/issues/2937

# Usage

`tools/launch` reads `SEGMENT_SIZE` from the test script's CONFIG block and
passes it as `sbatch --segment`, so launching a cross-rack MoE test keeps each
EP group within one rack automatically:

```bash
CONTAINER=... ACCOUNT=... PARTITION=... \
  ./tools/launch tests/test_suites/llm/grpo-gptoss-20b-8n4g-megatron.sh
# -> sbatch --nodes=8 --segment=2 ... ray.sub
```

Recipe knob (already set in this PR):

```yaml
cluster:
  gpus_per_node: 4
  segment_size: 2   # = EP group node span; keeps each EP group intra-rack
```

# Acknowledge
Thanks a lot @ashors1, @youngeunkwon0405 and @yuki-97 for helping investigate.

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? — `docs/cluster.md` (Topology-Aware Placement for MoE)

# Additional Information
- `segment_size` is in **nodes** and must evenly divide `num_nodes`.
  Recommended value = EP node span = `expert_model_parallel_size / gpus_per_node`
  (e.g. EP=8 on 4 GPU/node → 2).
- `cluster.segment_size` is a *post-allocation* selector: on a layout it cannot
  segment it raises `ResourceInsufficientError` (fast fail) rather than hanging.
