### PR TITLE
fix(megatron): prefer nvrx strategy for HF import saves

### DIFF
--- a/nemo_rl/models/megatron/community_import.py
+++ b/nemo_rl/models/megatron/community_import.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+from contextlib import contextmanager
 from typing import Any, Callable, Optional
 
 import torch
@@ -38,6 +39,43 @@ def to_torch_dtype(dtype: str | torch.dtype) -> torch.dtype:
         if key in aliases:
             return aliases[key]
     raise ValueError(f"Unknown dtype: {dtype}")
+
+
+@contextmanager
+def _prefer_nvrx_for_dist_ckpt_save():
+    """Prefer NVRx async strategy for torch_dist save in HF->Megatron import.
+
+    Megatron-LM's torch_dist sync save currently routes through the MCore async
+    finalize path, which can fail when write results contain non-picklable
+    objects (e.g., code objects) during gather_object.
+    """
+    try:
+        from megatron.core.dist_checkpointing.strategies.torch import (
+            TorchDistSaveShardedStrategy,
+        )
+    except ImportError:
+        # If dist-checkpoint strategy cannot be imported, leave behavior unchanged.
+        yield
+        return
+
+    original_save = TorchDistSaveShardedStrategy.save
+
+    def _save_with_nvrx_fallback(self, sharded_state_dict, checkpoint_dir):
+        try:
+            async_request = self.async_save(
+                sharded_state_dict, checkpoint_dir, async_strategy="nvrx"
+            )
+            async_request.execute_sync()
+            del async_request
+        except (ImportError, ModuleNotFoundError):
+            # Keep backward compatibility on environments without nvrx.
+            original_save(self, sharded_state_dict, checkpoint_dir)
+
+    TorchDistSaveShardedStrategy.save = _save_with_nvrx_fallback
+    try:
+        yield
+    finally:
+        TorchDistSaveShardedStrategy.save = original_save
 
 
 def import_model_from_hf_name(
@@ -147,7 +185,8 @@ def import_model_from_hf_name(
     config.num_layers_in_last_pipeline_stage = orig_num_layers_in_last_pipeline_stage
     config.pipeline_dtype = orig_pipeline_dtype
 
-    bridge.save_megatron_model(megatron_model, output_path)
+    with _prefer_nvrx_for_dist_ckpt_save():
+        bridge.save_megatron_model(megatron_model, output_path)
 
     # resetting mcore state
     import megatron.core.rerun_state_machine

--- a/tests/unit/models/dtensor/test_parallelize.py
+++ b/tests/unit/models/dtensor/test_parallelize.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from itertools import product
 from unittest.mock import MagicMock
 
@@ -39,7 +40,7 @@ from nemo_rl.models.dtensor.parallelize import (
                 ("google/gemma-3-4b-it", _parallelize_gemma3),
                 # ("Qwen/Qwen2.5-1.5B", _parallelize_qwen), # TODO: qwen2 doesn't have q_norm and k_norm, which will cause this test to fail
                 ("Qwen/Qwen3-0.6B", _parallelize_qwen),
-                ("meta-llama/Llama-3.2-1B-Instruct", _parallelize_llama),
+                ("HuggingFaceH4/tiny-random-LlamaForCausalLM", _parallelize_llama),
             ],
             [True, False],
         )
@@ -47,7 +48,29 @@ from nemo_rl.models.dtensor.parallelize import (
 )
 def test_parallelize_plan_keys(model_name, parallelize_func, sequence_parallel):
     """Tests that the keys in the parallelization plans are valid by mocking parallel styles."""
-    model = AutoModelForCausalLM.from_pretrained(model_name)
+    hf_token = os.environ.get("HF_TOKEN")
+    try:
+        model = AutoModelForCausalLM.from_pretrained(
+            model_name, **({"token": hf_token} if hf_token else {})
+        )
+    except Exception as exc:
+        # Some hf_gated models require explicit access approvals. In CI, token
+        # scopes/approvals can vary across bots; skip these cases when auth
+        # does not allow access to the model.
+        msg = str(exc).lower()
+        is_auth_failure = (
+            "401" in msg
+            or "unauthorized" in msg
+            or "gated repo" in msg
+            or "access to model" in msg
+            or "you are trying to access a gated repo" in msg
+        )
+        if is_auth_failure:
+            pytest.skip(
+                f"Skipping {model_name}: missing HF auth or gated-model access."
+            )
+        raise
+
     parallel_plan = parallelize_func(model, sequence_parallel=sequence_parallel)
 
     applied_keys = set()

--- a/tests/unit/models/dtensor/test_parallelize.py
+++ b/tests/unit/models/dtensor/test_parallelize.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from itertools import product
 from unittest.mock import MagicMock
 
@@ -40,7 +39,7 @@ from nemo_rl.models.dtensor.parallelize import (
                 ("google/gemma-3-4b-it", _parallelize_gemma3),
                 # ("Qwen/Qwen2.5-1.5B", _parallelize_qwen), # TODO: qwen2 doesn't have q_norm and k_norm, which will cause this test to fail
                 ("Qwen/Qwen3-0.6B", _parallelize_qwen),
-                ("HuggingFaceH4/tiny-random-LlamaForCausalLM", _parallelize_llama),
+                ("meta-llama/Llama-3.2-1B-Instruct", _parallelize_llama),
             ],
             [True, False],
         )
@@ -48,29 +47,7 @@ from nemo_rl.models.dtensor.parallelize import (
 )
 def test_parallelize_plan_keys(model_name, parallelize_func, sequence_parallel):
     """Tests that the keys in the parallelization plans are valid by mocking parallel styles."""
-    hf_token = os.environ.get("HF_TOKEN")
-    try:
-        model = AutoModelForCausalLM.from_pretrained(
-            model_name, **({"token": hf_token} if hf_token else {})
-        )
-    except Exception as exc:
-        # Some hf_gated models require explicit access approvals. In CI, token
-        # scopes/approvals can vary across bots; skip these cases when auth
-        # does not allow access to the model.
-        msg = str(exc).lower()
-        is_auth_failure = (
-            "401" in msg
-            or "unauthorized" in msg
-            or "gated repo" in msg
-            or "access to model" in msg
-            or "you are trying to access a gated repo" in msg
-        )
-        if is_auth_failure:
-            pytest.skip(
-                f"Skipping {model_name}: missing HF auth or gated-model access."
-            )
-        raise
-
+    model = AutoModelForCausalLM.from_pretrained(model_name)
     parallel_plan = parallelize_func(model, sequence_parallel=sequence_parallel)
 
     applied_keys = set()

--- a/tests/unit/models/megatron/test_community_import.py
+++ b/tests/unit/models/megatron/test_community_import.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/models/megatron/test_community_import.py
+++ b/tests/unit/models/megatron/test_community_import.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Unit tests for community_import checkpoint-save strategy shim."""
 
 import importlib

--- a/tests/unit/models/megatron/test_community_import.py
+++ b/tests/unit/models/megatron/test_community_import.py
@@ -111,7 +111,11 @@ def _install_runtime_stubs_for_hf_import(monkeypatch):
 
 def test_prefer_nvrx_is_noop_when_strategy_import_fails(monkeypatch):
     module = _load_community_import_module(monkeypatch)
-    sys.modules.pop("megatron.core.dist_checkpointing.strategies.torch", None)
+    # Force this import to fail even if real megatron modules were preloaded by
+    # earlier tests in the same process.
+    monkeypatch.setitem(
+        sys.modules, "megatron.core.dist_checkpointing.strategies.torch", None
+    )
 
     # Should not raise when dist-checkpoint strategy is unavailable.
     with module._prefer_nvrx_for_dist_ckpt_save():

--- a/tests/unit/models/megatron/test_community_import.py
+++ b/tests/unit/models/megatron/test_community_import.py
@@ -1,0 +1,228 @@
+"""Unit tests for community_import checkpoint-save strategy shim."""
+
+import importlib
+import sys
+from types import ModuleType
+from types import SimpleNamespace
+
+
+def _ensure_package(monkeypatch, name: str) -> ModuleType:
+    """Create a minimal package module in sys.modules for import stubbing."""
+    module = sys.modules.get(name)
+    if module is None:
+        module = ModuleType(name)
+        module.__path__ = []
+        monkeypatch.setitem(sys.modules, name, module)
+
+    if "." in name:
+        parent_name, child_name = name.rsplit(".", 1)
+        parent_module = _ensure_package(monkeypatch, parent_name)
+        setattr(parent_module, child_name, module)
+
+    return module
+
+
+def _load_community_import_module(monkeypatch):
+    """Import community_import with lightweight dependency stubs."""
+    # Stub torch symbols used at import time/type annotations.
+    fake_torch = ModuleType("torch")
+    fake_torch.dtype = type("dtype", (), {})
+    fake_torch.float32 = object()
+    fake_torch.bfloat16 = object()
+    fake_torch.float16 = object()
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    # Stub megatron imports required by the module.
+    _ensure_package(monkeypatch, "megatron")
+    _ensure_package(monkeypatch, "megatron.core")
+    megatron_bridge = ModuleType("megatron.bridge")
+    megatron_bridge.AutoBridge = type("AutoBridge", (), {})
+    monkeypatch.setitem(sys.modules, "megatron.bridge", megatron_bridge)
+    megatron_transformer = ModuleType("megatron.core.transformer")
+    megatron_transformer.ModuleSpec = type("ModuleSpec", (), {})
+    monkeypatch.setitem(
+        sys.modules, "megatron.core.transformer", megatron_transformer
+    )
+
+    # Stub MegatronConfig type import.
+    nemo_policy = ModuleType("nemo_rl.models.policy")
+    nemo_policy.MegatronConfig = dict
+    monkeypatch.setitem(sys.modules, "nemo_rl.models.policy", nemo_policy)
+
+    module_name = "nemo_rl.models.megatron.community_import"
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
+
+
+def _install_torch_strategy_module(monkeypatch, strategy_cls):
+    """Install a fake dist-checkpoint strategy module for local import."""
+    _ensure_package(monkeypatch, "megatron")
+    _ensure_package(monkeypatch, "megatron.core")
+    _ensure_package(monkeypatch, "megatron.core.dist_checkpointing")
+    _ensure_package(monkeypatch, "megatron.core.dist_checkpointing.strategies")
+    strategy_module = ModuleType("megatron.core.dist_checkpointing.strategies.torch")
+    strategy_module.TorchDistSaveShardedStrategy = strategy_cls
+    monkeypatch.setitem(
+        sys.modules, "megatron.core.dist_checkpointing.strategies.torch", strategy_module
+    )
+
+
+def _install_runtime_stubs_for_hf_import(monkeypatch):
+    """Install minimal megatron-core stubs needed by import_model_from_hf_name."""
+    core_module = _ensure_package(monkeypatch, "megatron.core")
+
+    parallel_state = ModuleType("megatron.core.parallel_state")
+    parallel_state.model_parallel_is_initialized = lambda: False
+    monkeypatch.setitem(sys.modules, "megatron.core.parallel_state", parallel_state)
+    core_module.parallel_state = parallel_state
+
+    rerun_state_machine = ModuleType("megatron.core.rerun_state_machine")
+    rerun_state_machine.destroy_rerun_state_machine = lambda: None
+    monkeypatch.setitem(
+        sys.modules, "megatron.core.rerun_state_machine", rerun_state_machine
+    )
+    core_module.rerun_state_machine = rerun_state_machine
+
+    tensor_parallel = ModuleType("megatron.core.tensor_parallel")
+    tensor_parallel.model_parallel_cuda_manual_seed = lambda seed: None
+    tensor_parallel_random = ModuleType("megatron.core.tensor_parallel.random")
+    tensor_parallel_random._CUDA_RNG_STATE_TRACKER = "stale"
+    tensor_parallel_random._CUDA_RNG_STATE_TRACKER_INITIALIZED = True
+    tensor_parallel.random = tensor_parallel_random
+    monkeypatch.setitem(sys.modules, "megatron.core.tensor_parallel", tensor_parallel)
+    monkeypatch.setitem(
+        sys.modules, "megatron.core.tensor_parallel.random", tensor_parallel_random
+    )
+    core_module.tensor_parallel = tensor_parallel
+
+
+def test_prefer_nvrx_is_noop_when_strategy_import_fails(monkeypatch):
+    module = _load_community_import_module(monkeypatch)
+    sys.modules.pop("megatron.core.dist_checkpointing.strategies.torch", None)
+
+    # Should not raise when dist-checkpoint strategy is unavailable.
+    with module._prefer_nvrx_for_dist_ckpt_save():
+        pass
+
+
+def test_prefer_nvrx_uses_async_save_and_restores_original_save(monkeypatch):
+    module = _load_community_import_module(monkeypatch)
+
+    class FakeAsyncRequest:
+        def __init__(self, owner):
+            self.owner = owner
+
+        def execute_sync(self):
+            self.owner.execute_sync_calls += 1
+
+    class FakeStrategy:
+        def __init__(self):
+            self.original_save_calls = []
+            self.async_save_calls = []
+            self.execute_sync_calls = 0
+
+        def save(self, sharded_state_dict, checkpoint_dir):
+            self.original_save_calls.append((sharded_state_dict, checkpoint_dir))
+
+        def async_save(self, sharded_state_dict, checkpoint_dir, async_strategy):
+            self.async_save_calls.append(
+                (sharded_state_dict, checkpoint_dir, async_strategy)
+            )
+            return FakeAsyncRequest(self)
+
+    _install_torch_strategy_module(monkeypatch, FakeStrategy)
+    strategy = FakeStrategy()
+    original_save = FakeStrategy.save
+
+    with module._prefer_nvrx_for_dist_ckpt_save():
+        strategy.save({"x": 1}, "/tmp/ckpt")
+        assert FakeStrategy.save is not original_save
+
+    assert strategy.async_save_calls == [({"x": 1}, "/tmp/ckpt", "nvrx")]
+    assert strategy.execute_sync_calls == 1
+    assert strategy.original_save_calls == []
+    assert FakeStrategy.save is original_save
+
+
+def test_prefer_nvrx_falls_back_to_original_save_when_nvrx_missing(monkeypatch):
+    module = _load_community_import_module(monkeypatch)
+
+    class FakeStrategy:
+        def __init__(self):
+            self.original_save_calls = []
+            self.async_save_calls = []
+
+        def save(self, sharded_state_dict, checkpoint_dir):
+            self.original_save_calls.append((sharded_state_dict, checkpoint_dir))
+
+        def async_save(self, sharded_state_dict, checkpoint_dir, async_strategy):
+            self.async_save_calls.append(
+                (sharded_state_dict, checkpoint_dir, async_strategy)
+            )
+            raise ModuleNotFoundError("nvrx is unavailable")
+
+    _install_torch_strategy_module(monkeypatch, FakeStrategy)
+    strategy = FakeStrategy()
+
+    with module._prefer_nvrx_for_dist_ckpt_save():
+        strategy.save({"y": 2}, "/tmp/ckpt")
+
+    assert strategy.async_save_calls == [({"y": 2}, "/tmp/ckpt", "nvrx")]
+    assert strategy.original_save_calls == [({"y": 2}, "/tmp/ckpt")]
+
+
+def test_import_model_from_hf_name_calls_bridge_save(monkeypatch):
+    module = _load_community_import_module(monkeypatch)
+    _install_runtime_stubs_for_hf_import(monkeypatch)
+    sys.modules.pop("megatron.core.dist_checkpointing.strategies.torch", None)
+
+    class FakeProvider:
+        def __init__(self):
+            self.tensor_model_parallel_size = 1
+            self.pipeline_model_parallel_size = 1
+            self.context_parallel_size = 1
+            self.expert_model_parallel_size = 1
+            self.expert_tensor_parallel_size = 1
+            self.num_layers_in_first_pipeline_stage = None
+            self.num_layers_in_last_pipeline_stage = None
+            self.pipeline_dtype = "fp32"
+
+        def finalize(self):
+            pass
+
+        def initialize_model_parallel(self, seed):
+            self.seed = seed
+
+        def provide_distributed_model(self, wrap_with_ddp, post_wrap_hook):
+            config = SimpleNamespace()
+            return [SimpleNamespace(config=config)]
+
+    class FakeBridge:
+        def __init__(self):
+            self.provider = FakeProvider()
+            self.saved_model = None
+            self.saved_path = None
+
+        def to_megatron_provider(self, load_weights):
+            assert load_weights is True
+            return self.provider
+
+        def save_megatron_model(self, megatron_model, output_path):
+            self.saved_model = megatron_model
+            self.saved_path = output_path
+
+    fake_bridge = FakeBridge()
+
+    class FakeAutoBridge:
+        @staticmethod
+        def from_hf_pretrained(hf_model_name, trust_remote_code=True, **kwargs):
+            assert hf_model_name == "fake/hf-model"
+            assert trust_remote_code is True
+            return fake_bridge
+
+    monkeypatch.setattr(module, "AutoBridge", FakeAutoBridge)
+
+    module.import_model_from_hf_name("fake/hf-model", "/tmp/out")
+
+    assert fake_bridge.saved_model is not None
+    assert fake_bridge.saved_path == "/tmp/out"

--- a/tests/unit/models/megatron/test_community_import.py
+++ b/tests/unit/models/megatron/test_community_import.py
@@ -16,8 +16,7 @@
 
 import importlib
 import sys
-from types import ModuleType
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 
 def _ensure_package(monkeypatch, name: str) -> ModuleType:
@@ -54,9 +53,7 @@ def _load_community_import_module(monkeypatch):
     monkeypatch.setitem(sys.modules, "megatron.bridge", megatron_bridge)
     megatron_transformer = ModuleType("megatron.core.transformer")
     megatron_transformer.ModuleSpec = type("ModuleSpec", (), {})
-    monkeypatch.setitem(
-        sys.modules, "megatron.core.transformer", megatron_transformer
-    )
+    monkeypatch.setitem(sys.modules, "megatron.core.transformer", megatron_transformer)
 
     # Stub MegatronConfig type import.
     nemo_policy = ModuleType("nemo_rl.models.policy")
@@ -77,7 +74,9 @@ def _install_torch_strategy_module(monkeypatch, strategy_cls):
     strategy_module = ModuleType("megatron.core.dist_checkpointing.strategies.torch")
     strategy_module.TorchDistSaveShardedStrategy = strategy_cls
     monkeypatch.setitem(
-        sys.modules, "megatron.core.dist_checkpointing.strategies.torch", strategy_module
+        sys.modules,
+        "megatron.core.dist_checkpointing.strategies.torch",
+        strategy_module,
     )
 
 

--- a/tests/unit/models/megatron/test_community_import.py
+++ b/tests/unit/models/megatron/test_community_import.py
@@ -191,7 +191,11 @@ def test_prefer_nvrx_falls_back_to_original_save_when_nvrx_missing(monkeypatch):
 def test_import_model_from_hf_name_calls_bridge_save(monkeypatch):
     module = _load_community_import_module(monkeypatch)
     _install_runtime_stubs_for_hf_import(monkeypatch)
-    sys.modules.pop("megatron.core.dist_checkpointing.strategies.torch", None)
+    # Force this import path to stay unavailable even if real megatron modules
+    # were preloaded by earlier tests in the same process.
+    monkeypatch.setitem(
+        sys.modules, "megatron.core.dist_checkpointing.strategies.torch", None
+    )
 
     class FakeProvider:
         def __init__(self):
@@ -232,9 +236,9 @@ def test_import_model_from_hf_name_calls_bridge_save(monkeypatch):
 
     class FakeAutoBridge:
         @staticmethod
-        def from_hf_pretrained(hf_model_name, trust_remote_code=True, **kwargs):
+        def from_hf_pretrained(hf_model_name, *args, **kwargs):
+            # Keep this test focused on bridge-save flow, not HF API defaults.
             assert hf_model_name == "fake/hf-model"
-            assert trust_remote_code is True
             return fake_bridge
 
     monkeypatch.setattr(module, "AutoBridge", FakeAutoBridge)


### PR DESCRIPTION
## Summary
- Fixes a failure during HF->Megatron import in `import_model_from_hf_name`, where `bridge.save_megatron_model(...)` could crash with:
  - `TypeError: cannot pickle code objects`
- Root cause is in the torch DCP async finalize path (`gather_object(write_results)`), not in router-replay/R3 logic.
- Updates `nemo_rl/models/megatron/community_import.py` to wrap the save call with a scoped context manager that:
  - temporarily prefers `async_strategy="nvrx"` for `TorchDistSaveShardedStrategy`
  - falls back to the original save behavior when `nvrx` is unavailable
  - restores the original strategy immediately after save to avoid side effects
- Scope: applies to any workflow that triggers HF->Megatron conversion (including GRPO/PPO model setup paths that call this import path).
