### PR TITLE
docs(mopd): fix dataset override key data.val -> data.validation

### DIFF
--- a/docs/about/algorithms/mopd.md
+++ b/docs/about/algorithms/mopd.md
@@ -133,7 +133,7 @@ override them for your local data:
 uv run examples/nemo_gym/run_grpo_nemo_gym.py \
   --config examples/configs/recipes/llm/mopd-qwen3-1.7b-3n8g-megatron-pack.yaml \
   data.train.data_path=/path/to/train.jsonl \
-  data.val.data_path=/path/to/val.jsonl
+  data.validation.data_path=/path/to/val.jsonl
 ```
 
 The reference recipe self-distills `Qwen/Qwen3-1.7B` (student == teacher) across


### PR DESCRIPTION
## What

The MOPD quickstart CLI example in `docs/about/algorithms/mopd.md` overrides the validation dataset path with `data.val.data_path`, but the shipped recipe (`examples/configs/recipes/llm/mopd-qwen3-1.7b-3n8g-megatron-pack.yaml`) keys the validation block under `data.validation`:

```yaml
data:
  train:
    data_path: ...
  validation:        # <-- key is 'validation', not 'val'
    data_path: ...
```

Copy-pasting the documented command verbatim hits an OmegaConf "key not found" error.

## Fix

One-line doc change to align the example with the recipe:

```diff
-  data.val.data_path=/path/to/val.jsonl
+  data.validation.data_path=/path/to/val.jsonl
```

(`data.train.data_path` on the line above is already correct.)

## Verification

Found while authoring the RL POR e2e test for MOPD (#2780). Confirmed the recipe uses `data.validation` and the documented `data.val` would fail config resolution.