### PR TITLE
fix: reduce NUM_MINUTES to match 04:00:00 CI walltime in 2 test scripts

### DIFF
--- a/tests/test_suites/llm/grpo-llama3.1-8b-instruct-4n8g-fsdp2tp1-long.v3.sh
+++ b/tests/test_suites/llm/grpo-llama3.1-8b-instruct-4n8g-fsdp2tp1-long.v3.sh
@@ -7,7 +7,7 @@ NUM_NODES=4
 STEPS_PER_RUN=190
 MAX_STEPS=500
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
-NUM_MINUTES=300
+NUM_MINUTES=240
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached


### PR DESCRIPTION
## Summary
- Both scripts had `NUM_MINUTES` exceeding the CI job walltime of `04:00:00` (240 min), causing `sbatch` to reject all job submissions (including all `NUM_RUNS` segments in the chain)
- `grpo-llama3.1-8b-instruct-4n8g-fsdp2tp1-long.v3.sh`: 300 → 240
- `dapo-deepseek-v3-64n8g.v2.sh`: 360 → 240

## Test plan
- [ ] Verify `llm_grpo_llama3_1_8b_instruct_4n8g_fsdp2tp1_long_v3` submits successfully
- [ ] Verify `llm_performance_dapo_deepseek_v3_64n8g_v2` submits successfully