### PR TITLE
refactor(sglang): allocate ports from reserved ranges

### DIFF
--- a/nemo_rl/distributed/virtual_cluster.py
+++ b/nemo_rl/distributed/virtual_cluster.py
@@ -83,9 +83,14 @@ class PY_EXECUTABLES:
 # the full layout including Ray's own GCS / worker gRPC ports.
 #
 #   1400-1999    Master address / TCPStore       (cluster.master_port_range_low/high)
-#   3000-4999    NeMo RL generation HTTP servers (policy.generation.port_range_low/high)
+#   3000-4999    NeMo RL generation HTTP servers + SGLang engine NCCL/dist_init
+#                                                 (policy.generation.port_range_low/high)
 #   5000-5999    NeMo Gym HTTP servers           (env.nemo_gym.port_range_low/high)
-#   7000-8999    vLLM / SGLang engine rendezvous (VLLM_PORT env var / SGLang base_port)
+#   7000-8999    vLLM engine rendezvous          (VLLM_PORT env var, 100-port spacing)
+#   8600-8799    SGLang router                   (DEFAULT_SGLANG_ROUTER_PORT_RANGE_*, hard-coded;
+#                                                 carved out of the vLLM band — only one rollout
+#                                                 backend runs at a time)
+#   8800-8999    SGLang Prometheus metrics       (DEFAULT_SGLANG_PROMETHEUS_PORT_RANGE_*, hard-coded)
 DEFAULT_GENERATION_PORT_RANGE_LOW = 3000
 DEFAULT_GENERATION_PORT_RANGE_HIGH = 4999
 DEFAULT_GYM_PORT_RANGE_LOW = 5000
@@ -95,6 +100,14 @@ DEFAULT_GYM_PORT_RANGE_HIGH = 5999
 # 7000 + 8*100 = 7800, still below the 9000 ephemeral floor.
 DEFAULT_VLLM_PORT_RANGE_LOW = 7000
 DEFAULT_VLLM_PORTS_PER_ENGINE = 100
+# SGLang control-plane ports, carved out of the top of the vLLM rendezvous band —
+# safe because only one rollout backend runs at a time, and a vLLM run only
+# climbs past 8600 with >=16 engines on a single node.  Both bands also steer
+# clear of the Ray dashboard carve-out at 8265 (see ray.sub).
+DEFAULT_SGLANG_ROUTER_PORT_RANGE_LOW = 8600
+DEFAULT_SGLANG_ROUTER_PORT_RANGE_HIGH = 8799
+DEFAULT_SGLANG_PROMETHEUS_PORT_RANGE_LOW = 8800
+DEFAULT_SGLANG_PROMETHEUS_PORT_RANGE_HIGH = 8999
 # Master address / TCPStore range, tucked below the Ray worker-gRPC band (2000+).
 DEFAULT_MASTER_PORT_RANGE_LOW = 1400
 DEFAULT_MASTER_PORT_RANGE_HIGH = 1999
@@ -181,6 +194,40 @@ def _get_free_port_local(
         s.listen(1)
 
     return port
+
+
+def _get_free_consecutive_ports_local(
+    port_range_low: int,
+    port_range_high: int,
+    consecutive: int = 1,
+    start_port: Optional[int] = None,
+) -> int:
+    """Find ``consecutive`` contiguous bindable ports and return the base.
+
+    Scans upward from *start_port* within [port_range_low, port_range_high).
+    *start_port* lets a caller thread a per-node cursor so successive blocks do
+    not overlap. Raises ``RuntimeError`` if no such block exists in the range.
+    """
+    assert consecutive >= 1, f"consecutive must be >= 1, got {consecutive}"
+    base = port_range_low if start_port is None else max(start_port, port_range_low)
+    while base + consecutive - 1 < port_range_high:
+        socks: list[socket.socket] = []
+        try:
+            for offset in range(consecutive):
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                s.bind(("", base + offset))
+                s.listen(1)
+                socks.append(s)
+            return base
+        except OSError:
+            base += 1
+        finally:
+            for s in socks:
+                s.close()
+    raise RuntimeError(
+        f"Could not find {consecutive} consecutive free ports in "
+        f"[{port_range_low}, {port_range_high})."
+    )
 
 
 def init_ray(log_dir: Optional[str] = None) -> None:

--- a/nemo_rl/models/generation/sglang/sglang_generation.py
+++ b/nemo_rl/models/generation/sglang/sglang_generation.py
@@ -23,6 +23,8 @@ from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.virtual_cluster import (
+    DEFAULT_GENERATION_PORT_RANGE_HIGH,
+    DEFAULT_GENERATION_PORT_RANGE_LOW,
     RayVirtualCluster,
     get_reordered_bundle,
 )
@@ -163,7 +165,6 @@ class SGLangGeneration(GenerationInterface):
         """
         if port_cursors is None:
             port_cursors = {}
-
         num_gpu_per_engine = min(self.num_gpus_per_engine, self.num_gpus_per_node)
         pg = self.pg
         reordered_bundle_indices = self.pg_reordered_bundle_indices
@@ -249,15 +250,23 @@ class SGLangGeneration(GenerationInterface):
         if len(local_all_engines) == 0:
             return [], port_cursors
 
-        # SGLang engine ports live in the below-ephemeral-floor engine band
-        # (7000-8999), shared with vLLM; see virtual_cluster.py port layout.
-        base_port = max(port_cursors.values()) if port_cursors else 7000
+        # SGLang engine server/NCCL/dist_init ports come from the reserved
+        # generation band (3000-4999 by default), below the ephemeral floor;
+        # see the port layout in virtual_cluster.py.
+        gen_port_low = self.sglang_cfg.get("port_range_low")
+        if gen_port_low is None:
+            gen_port_low = DEFAULT_GENERATION_PORT_RANGE_LOW
+        gen_port_high = self.sglang_cfg.get("port_range_high")
+        if gen_port_high is None:
+            gen_port_high = DEFAULT_GENERATION_PORT_RANGE_HIGH
         addr_and_ports, port_cursors = _allocate_rollout_engine_addr_and_ports_normal(
             gpus_per_node=self.num_gpus_per_node,
             sglang_cfg=self.sglang_cfg,
             local_all_engines=local_all_engines,
             rank_offset=self.rank_offset,
-            base_port=base_port,
+            port_range_low=gen_port_low,
+            port_range_high=gen_port_high,
+            node_port_cursor=port_cursors,
         )
 
         init_handles = [

--- a/nemo_rl/models/generation/sglang/sglang_router.py
+++ b/nemo_rl/models/generation/sglang/sglang_router.py
@@ -14,17 +14,20 @@
 
 import logging
 import multiprocessing
-import random
 import time
 
 import ray
 
+from nemo_rl.distributed.virtual_cluster import (
+    DEFAULT_SGLANG_PROMETHEUS_PORT_RANGE_HIGH,
+    DEFAULT_SGLANG_PROMETHEUS_PORT_RANGE_LOW,
+    DEFAULT_SGLANG_ROUTER_PORT_RANGE_HIGH,
+    DEFAULT_SGLANG_ROUTER_PORT_RANGE_LOW,
+    _get_free_port_local,
+)
 from nemo_rl.models.generation.sglang.config import SGLangRouterConfig
 from nemo_rl.models.generation.sglang.utils.ip_port_utils import _wrap_ipv6
-from nemo_rl.models.generation.sglang.utils.ray_utils import (
-    find_available_port,
-    get_host_info,
-)
+from nemo_rl.models.generation.sglang.utils.ray_utils import get_host_info
 from nemo_rl.utils.venvs import make_actor_runtime_env
 
 logger = logging.getLogger(__name__)
@@ -51,14 +54,20 @@ class RouterActor:
         router_ip = _wrap_ipv6(get_host_info()[1])
         router_port = router_cfg.get("sglang_router_port")
         if router_port is None:
-            router_port = find_available_port(random.randint(3000, 4000))
+            router_port = _get_free_port_local(
+                DEFAULT_SGLANG_ROUTER_PORT_RANGE_LOW,
+                DEFAULT_SGLANG_ROUTER_PORT_RANGE_HIGH,
+            )
 
         router_args = RouterArgs()
         router_args.host = router_ip
         router_args.port = router_port
         if router_cfg.get("router_policy") is not None:
             router_args.router_policy = router_cfg["router_policy"]
-        router_args.prometheus_port = find_available_port(random.randint(4000, 5000))
+        router_args.prometheus_port = _get_free_port_local(
+            DEFAULT_SGLANG_PROMETHEUS_PORT_RANGE_LOW,
+            DEFAULT_SGLANG_PROMETHEUS_PORT_RANGE_HIGH,
+        )
         router_args.log_level = "warn"
         request_timeout_secs = router_cfg.get("sglang_router_request_timeout_secs")
         if request_timeout_secs is not None:

--- a/nemo_rl/models/generation/sglang/sglang_worker.py
+++ b/nemo_rl/models/generation/sglang/sglang_worker.py
@@ -21,12 +21,14 @@ from collections.abc import Callable
 import ray
 import requests
 
+from nemo_rl.distributed.virtual_cluster import (
+    DEFAULT_GENERATION_PORT_RANGE_HIGH,
+    DEFAULT_GENERATION_PORT_RANGE_LOW,
+    _get_free_consecutive_ports_local,
+)
 from nemo_rl.models.generation.sglang.utils.ip_port_utils import _format_v6_uri
 from nemo_rl.models.generation.sglang.utils.patches import _apply_sglang_compat_patches
-from nemo_rl.models.generation.sglang.utils.ray_utils import (
-    get_current_node_ip,
-    get_free_port,
-)
+from nemo_rl.models.generation.sglang.utils.ray_utils import get_current_node_ip
 
 logger = logging.getLogger(__name__)
 
@@ -162,10 +164,22 @@ class SGLangGenerationWorker:
         return response.json()
 
     @staticmethod
-    def _get_current_node_ip_and_free_port(start_port=7000, consecutive=1):
-        return get_current_node_ip(), get_free_port(
-            start_port=start_port, consecutive=consecutive
+    def _get_current_free_port(
+        port_range_low=DEFAULT_GENERATION_PORT_RANGE_LOW,
+        port_range_high=DEFAULT_GENERATION_PORT_RANGE_HIGH,
+        consecutive=1,
+        start_port=None,
+    ):
+        return _get_free_consecutive_ports_local(
+            port_range_low=port_range_low,
+            port_range_high=port_range_high,
+            consecutive=consecutive,
+            start_port=start_port,
         )
+
+    @staticmethod
+    def _get_current_node_ip():
+        return get_current_node_ip()
 
     def health_generate(self, timeout: float = 5.0) -> bool:
         """Run /health_generate on the underlying SGLang HTTP server.

--- a/nemo_rl/models/generation/sglang/utils/ip_port_utils.py
+++ b/nemo_rl/models/generation/sglang/utils/ip_port_utils.py
@@ -17,6 +17,10 @@ import logging
 
 import ray
 
+from nemo_rl.distributed.virtual_cluster import (
+    DEFAULT_GENERATION_PORT_RANGE_HIGH,
+    DEFAULT_GENERATION_PORT_RANGE_LOW,
+)
 from nemo_rl.models.generation.sglang.utils.ray_utils import get_host_info
 
 logger = logging.getLogger(__name__)
@@ -48,14 +52,18 @@ def _allocate_rollout_engine_addr_and_ports_normal(
     sglang_cfg,
     local_all_engines,
     rank_offset=0,
-    base_port=7000,
+    port_range_low: int = DEFAULT_GENERATION_PORT_RANGE_LOW,
+    port_range_high: int = DEFAULT_GENERATION_PORT_RANGE_HIGH,
+    node_port_cursor: dict[int, int] | None = None,
 ):
     # get ports
     # there are 4 ports we need to allocate
     # 1. server port
     # 2. nccl port
     # 3. dist_init_addr port
-    # 4. other ports for dp_attention, which is of size 4 + dp_size
+    # 4. other ports for dp_attention, which is of size 30 + dp_size
+    if node_port_cursor is None:
+        node_port_cursor = {}
 
     sglang_dp_size = sglang_cfg["sglang_cfg"]["dp_size"]
     num_gpus_per_engine = sglang_cfg["sglang_cfg"]["sglang_server_config"][
@@ -66,10 +74,6 @@ def _allocate_rollout_engine_addr_and_ports_normal(
     _gpus_per_engine = num_gpus_per_engine
     num_engines_per_node = max(1, num_gpus_per_node // _gpus_per_engine)
     addr_and_ports: dict[int, dict] = {}
-
-    # Track per-node port cursors so that different server groups (called
-    # sequentially) never race for the same ports on a given node.
-    node_port_cursor: dict[int, int] = {}
 
     visited_nodes = set()
     for rank, engine in local_all_engines:
@@ -85,18 +89,19 @@ def _allocate_rollout_engine_addr_and_ports_normal(
         )
 
         def get_addr_and_ports(engine, node_idx):
-            # Keep engine ports below the OS ephemeral floor (9000 on some GB200 nodes,
-            # 32768 on stock Linux) to avoid TOCTOU collisions. SGLang shares
-            # the vLLM engine rendezvous band (7000-8999); see the port layout
-            # in ray.sub / nemo_rl/distributed/virtual_cluster.py.
-            start_port = node_port_cursor.get(node_idx, base_port)
+            # Allocate from the reserved generation band (below the ephemeral
+            # floor; see virtual_cluster.py), advancing a per-node cursor so
+            # blocks never overlap on a given node.
+            start_port = node_port_cursor.get(node_idx, port_range_low)
 
             def port(consecutive=1):
                 nonlocal start_port
-                _, port = ray.get(
-                    engine._get_current_node_ip_and_free_port.remote(
-                        start_port=start_port,
+                port = ray.get(
+                    engine._get_current_free_port.remote(
+                        port_range_low=port_range_low,
+                        port_range_high=port_range_high,
                         consecutive=consecutive,
+                        start_port=start_port,
                     )
                 )
                 start_port = port + consecutive
@@ -104,7 +109,7 @@ def _allocate_rollout_engine_addr_and_ports_normal(
                 return port
 
             def addr():
-                addr, _ = ray.get(engine._get_current_node_ip_and_free_port.remote())
+                addr = ray.get(engine._get_current_node_ip.remote())
                 if addr is None:
                     addr = get_host_info()[1]
                 return addr

--- a/nemo_rl/models/generation/sglang/utils/patches.py
+++ b/nemo_rl/models/generation/sglang/utils/patches.py
@@ -207,70 +207,11 @@ def _patch_sglang_custom_all_reduce_v2_tms_cudagraph() -> None:
     """Backport sglang#27948 for colocated TMS CUDA graph capture.
 
     With ``SGLANG_MEMORY_SAVER_CUDA_GRAPH=true``, custom all-reduce v2 must
-    avoid registering captured IPC addresses. TMS will otherwise replace those
-    addresses during capture and custom_all_reduce.cuh can fail at replay time.
+    not flag the kernel as capturing. TMS replaces the IPC addresses during
+    capture, so the addresses registered while ``set_cuda_graph_capture`` is
+    on become stale and custom_all_reduce.cuh can fail at replay time. Passing
+    ``not self.tms_cudagraph`` keeps the capture flag off in that mode.
     """
-    _patch_sglang_file_replacements(
-        "jit_kernel/all_reduce.py",
-        (
-            (
-                "        def set_cuda_graph_register_inputs(self, register_inputs: bool) -> None: ...\n",
-                "        def set_cuda_graph_capture(self, is_capturing: bool) -> None: ...\n",
-                "        def set_cuda_graph_capture(self, is_capturing: bool) -> None: ...\n"
-                "        def set_cuda_graph_register_inputs(self, register_inputs: bool) -> None: ...\n",
-            ),
-        ),
-        "custom all-reduce type stub graph-input registration toggle",
-    )
-    _patch_sglang_file_replacements(
-        "jit_kernel/csrc/distributed/custom_all_reduce_base.cuh",
-        (
-            (
-                '      .def("set_cuda_graph_register_inputs", &Class::set_cuda_graph_register_inputs)\n',
-                '      .def("set_cuda_graph_capture", &Class::set_cuda_graph_capture)\n',
-                '      .def("set_cuda_graph_capture", &Class::set_cuda_graph_capture)\n'
-                '      .def("set_cuda_graph_register_inputs", &Class::set_cuda_graph_register_inputs)\n',
-            ),
-        ),
-        "custom all-reduce C++ binding graph-input registration toggle",
-    )
-    _patch_sglang_file_replacements(
-        "jit_kernel/include/sgl_kernel/distributed/custom_all_reduce.cuh",
-        (
-            (
-                "  void set_cuda_graph_register_inputs(bool enabled) {\n",
-                "  void set_cuda_graph_capture(bool enabled) {\n"
-                "    m_is_graph_capturing = enabled;\n"
-                "  }\n\n",
-                "  void set_cuda_graph_capture(bool enabled) {\n"
-                "    m_is_graph_capturing = enabled;\n"
-                "  }\n\n"
-                "  void set_cuda_graph_register_inputs(bool enabled) {\n"
-                "    m_register_graph_inputs = enabled;\n"
-                "  }\n\n",
-            ),
-            (
-                "  bool m_register_graph_inputs = true;\n",
-                "  bool m_is_graph_capturing = false;\n"
-                "  int64_t m_cum_registered_count = 0;\n",
-                "  bool m_is_graph_capturing = false;\n"
-                "  bool m_register_graph_inputs = true;\n"
-                "  int64_t m_cum_registered_count = 0;\n",
-            ),
-        ),
-        "custom all-reduce graph-input registration flag",
-    )
-    _patch_sglang_file_replacements(
-        "jit_kernel/csrc/distributed/custom_all_reduce_pull.cuh",
-        (
-            (
-                "    if (check_capturing() && m_register_graph_inputs) {\n",
-                "    if (check_capturing()) {\n",
-                "    if (check_capturing() && m_register_graph_inputs) {\n",
-            ),
-        ),
-        "custom all-reduce pull graph-input registration gate",
-    )
     _patch_sglang_file_replacements(
         "srt/distributed/device_communicators/custom_all_reduce_v2.py",
         (
@@ -282,33 +223,24 @@ def _patch_sglang_custom_all_reduce_v2_tms_cudagraph() -> None:
             ),
             (
                 "        self.tms_cudagraph = envs.SGLANG_MEMORY_SAVER_CUDA_GRAPH.get()\n",
-                "        self.override_shot(None)  # set default config based on world size\n"
                 "        self.override_algo: Optional[AllReduceAlgo] = None\n"
                 "        self.obj = get_custom_all_reduce_cls()(\n",
-                "        self.override_shot(None)  # set default config based on world size\n"
                 "        self.override_algo: Optional[AllReduceAlgo] = None\n"
                 "        self.tms_cudagraph = envs.SGLANG_MEMORY_SAVER_CUDA_GRAPH.get()\n"
                 "        self.obj = get_custom_all_reduce_cls()(\n",
             ),
             (
-                '            log_info_on_rank0(logger, "Registering 0 cuda graph addresses because tms is used")\n',
+                "            self.obj.set_cuda_graph_capture(not self.tms_cudagraph)\n",
+                "        try:\n            self.obj.set_cuda_graph_capture(True)\n",
                 "        try:\n"
-                "            self.obj.set_cuda_graph_capture(True)\n"
-                "            yield\n"
-                "        finally:\n"
-                "            self.obj.set_cuda_graph_capture(False)\n"
-                "        # cannot call when graph is capturing\n",
-                "        try:\n"
-                "            self.obj.set_cuda_graph_register_inputs(not self.tms_cudagraph)\n"
-                "            self.obj.set_cuda_graph_capture(True)\n"
-                "            yield\n"
-                "        finally:\n"
-                "            self.obj.set_cuda_graph_capture(False)\n"
-                "            self.obj.set_cuda_graph_register_inputs(True)\n"
-                "        if self.tms_cudagraph:\n"
-                '            log_info_on_rank0(logger, "Registering 0 cuda graph addresses because tms is used")\n'
-                "            return\n"
-                "        # cannot call when graph is capturing\n",
+                "            self.obj.set_cuda_graph_capture(not self.tms_cudagraph)\n",
+            ),
+            (
+                "                self.obj.set_cuda_graph_capture(not self.tms_cudagraph)\n",
+                "            finally:\n"
+                "                self.obj.set_cuda_graph_capture(True)\n",
+                "            finally:\n"
+                "                self.obj.set_cuda_graph_capture(not self.tms_cudagraph)\n",
             ),
         ),
         "custom all-reduce v2 TMS CUDA graph capture path",

--- a/nemo_rl/models/generation/sglang/utils/ray_utils.py
+++ b/nemo_rl/models/generation/sglang/utils/ray_utils.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 import os
-import random
 import socket
 
-import ray
+from nemo_rl.distributed.virtual_cluster import _get_node_ip_local
 
 # Env vars Ray uses to gate its visible-device manipulation. Setting any of
 # these to "1" tells Ray not to override the corresponding *_VISIBLE_DEVICES
@@ -31,31 +30,6 @@ NOSET_VISIBLE_DEVICES_ENV_VARS_LIST = [
     "RAY_EXPERIMENTAL_NOSET_TPU_VISIBLE_CHIPS",
     "RAY_EXPERIMENTAL_NOSET_ONEAPI_DEVICE_SELECTOR",
 ]
-
-
-def find_available_port(base_port: int):
-    port = base_port + random.randint(100, 1000)
-    while True:
-        if is_port_available(port):
-            return port
-        if port < 60000:
-            port += 42
-        else:
-            port -= 43
-
-
-def is_port_available(port):
-    """Return whether a port is available."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        try:
-            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            s.bind(("", port))
-            s.listen(1)
-            return True
-        except OSError:
-            return False
-        except OverflowError:
-            return False
 
 
 def get_host_info():
@@ -123,15 +97,6 @@ def get_host_info():
 
 
 def get_current_node_ip():
-    address = ray._private.services.get_node_ip_address()
-    # strip ipv6 address
-    address = address.strip("[]")
-    return address
-
-
-def get_free_port(start_port=7000, consecutive=1):
-    # find the port where port, port + 1, port + 2, ... port + consecutive - 1 are all available
-    port = start_port
-    while not all(is_port_available(port + i) for i in range(consecutive)):
-        port += 1
-    return port
+    ip = _get_node_ip_local()
+    # strip ipv6 brackets so callers get a bare ip
+    return ip.strip("[]") if ip is not None else None

--- a/ray.sub
+++ b/ray.sub
@@ -140,12 +140,15 @@ fi
 #   1301-1312    Ray management (node-mgr, obj-mgr, etc.; odd=worker, even=head)
 #   1400-1999    Master address / TCPStore (cluster.master_port_range_low/high)
 #   2000-2999    Ray worker gRPC (min/max-worker-port)
-#   3000-4999    NeMo RL generation HTTP servers (policy.generation.port_range_low/high)
+#   3000-4999    NeMo RL generation HTTP servers + SGLang engine NCCL/dist_init
+#                (policy.generation.port_range_low/high)
 #   5000-5999    NeMo Gym HTTP servers (Gym global config port_range_low/high)
 #   6000         Sandbox Nginx (NEMO_SKILLS_SANDBOX_PORT)
 #   6001-6999    Sandbox uWSGI workers (SANDBOX_BASE_PORT)
-#   7000-8999    vLLM / SGLang engine rendezvous (VLLM_PORT in vllm_worker.py / SGLang base_port)
+#   7000-8999    vLLM engine rendezvous (VLLM_PORT in vllm_worker.py)
 #   8265         Ray Dashboard (DASHBOARD_PORT; reserved carve-out inside the 7000-8999 band)
+#   8600-8799    SGLang router (carve-out inside the 7000-8999 band; only one rollout backend runs)
+#   8800-8999    SGLang Prometheus metrics (carve-out inside the 7000-8999 band)
 MIN_WORKER_PORT=${MIN_WORKER_PORT:-2000}
 MAX_WORKER_PORT=${MAX_WORKER_PORT:-2999}
 ########################################################

--- a/tests/unit/distributed/test_virtual_cluster.py
+++ b/tests/unit/distributed/test_virtual_cluster.py
@@ -27,12 +27,17 @@ from nemo_rl.distributed.virtual_cluster import (
     DEFAULT_GYM_PORT_RANGE_LOW,
     DEFAULT_MASTER_PORT_RANGE_HIGH,
     DEFAULT_MASTER_PORT_RANGE_LOW,
+    DEFAULT_SGLANG_PROMETHEUS_PORT_RANGE_HIGH,
+    DEFAULT_SGLANG_PROMETHEUS_PORT_RANGE_LOW,
+    DEFAULT_SGLANG_ROUTER_PORT_RANGE_HIGH,
+    DEFAULT_SGLANG_ROUTER_PORT_RANGE_LOW,
     DEFAULT_VLLM_PORT_RANGE_LOW,
     DEFAULT_VLLM_PORTS_PER_ENGINE,
     PY_EXECUTABLES,
     RayVirtualCluster,
     ResourceInsufficientError,
     _bind_socket_in_range,
+    _get_free_consecutive_ports_local,
     _get_free_port_local,
     _get_node_ip_and_free_port,
 )
@@ -322,6 +327,80 @@ class TestGetFreePortLocal:
         assert len(ports) > 1
 
 
+class TestGetFreeConsecutivePortsLocal:
+    """Tests for _get_free_consecutive_ports_local()."""
+
+    def test_single_port_in_range(self):
+        port = _get_free_consecutive_ports_local(14000, 14100, consecutive=1)
+        assert 14000 <= port < 14100
+
+    def test_returns_bindable_contiguous_block(self):
+        n = 5
+        base = _get_free_consecutive_ports_local(14100, 14300, consecutive=n)
+        assert 14100 <= base
+        assert base + n - 1 < 14300
+        # All n ports are simultaneously bindable.
+        socks = []
+        try:
+            for offset in range(n):
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                s.bind(("", base + offset))
+                socks.append(s)
+        finally:
+            for s in socks:
+                s.close()
+
+    def test_start_port_below_low_is_clamped(self):
+        base = _get_free_consecutive_ports_local(
+            14300, 14400, consecutive=1, start_port=1000
+        )
+        assert base >= 14300
+
+    def test_cursor_advance_yields_non_overlapping_blocks(self):
+        n = 3
+        first = _get_free_consecutive_ports_local(14400, 14600, consecutive=n)
+        second = _get_free_consecutive_ports_local(
+            14400, 14600, consecutive=n, start_port=first + n
+        )
+        assert second >= first + n
+
+    def test_raises_when_range_exhausted(self):
+        # A 3-wide range cannot fit a block of 5.
+        with pytest.raises(RuntimeError, match="consecutive free ports"):
+            _get_free_consecutive_ports_local(14600, 14603, consecutive=5)
+
+    def test_port_is_reusable_after_return(self):
+        base = _get_free_consecutive_ports_local(14700, 14800, consecutive=2)
+        # Sockets are closed before return, so the block can be re-bound.
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("", base))
+
+    def test_raises_when_start_port_at_or_above_high(self):
+        with pytest.raises(RuntimeError, match="consecutive free ports"):
+            _get_free_consecutive_ports_local(
+                14850, 14900, consecutive=1, start_port=15000
+            )
+
+    def test_block_fits_exactly_against_high_boundary(self):
+        # high is exclusive: a block whose last port is high-1 must still fit.
+        n = 4
+        base = _get_free_consecutive_ports_local(14900, 14900 + n, consecutive=n)
+        assert base == 14900
+        socks = []
+        try:
+            for offset in range(n):
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                s.bind(("", base + offset))
+                socks.append(s)
+        finally:
+            for s in socks:
+                s.close()
+
+    def test_rejects_non_positive_consecutive(self):
+        with pytest.raises(AssertionError, match="consecutive must be >= 1"):
+            _get_free_consecutive_ports_local(14950, 15000, consecutive=0)
+
+
 class TestRayVirtualClusterPortRange:
     """Tests for port range propagation in RayVirtualCluster."""
 
@@ -397,5 +476,22 @@ def test_default_port_ranges_ordered_and_below_ephemeral_floor():
         DEFAULT_VLLM_PORT_RANGE_LOW + 8 * DEFAULT_VLLM_PORTS_PER_ENGINE
         < EPHEMERAL_FLOOR
     )
+    # SGLang router / Prometheus carve-outs live inside the vLLM band (only one
+    # rollout backend runs at a time), stay above the 8-engine vLLM high-water
+    # mark and the Ray dashboard (8265), and sit below the ephemeral floor.
+    assert (
+        DEFAULT_VLLM_PORT_RANGE_LOW + 8 * DEFAULT_VLLM_PORTS_PER_ENGINE
+        < DEFAULT_SGLANG_ROUTER_PORT_RANGE_LOW
+    )
+    assert 8265 < DEFAULT_SGLANG_ROUTER_PORT_RANGE_LOW
+    assert DEFAULT_SGLANG_ROUTER_PORT_RANGE_LOW < DEFAULT_SGLANG_ROUTER_PORT_RANGE_HIGH
+    assert (
+        DEFAULT_SGLANG_ROUTER_PORT_RANGE_HIGH < DEFAULT_SGLANG_PROMETHEUS_PORT_RANGE_LOW
+    )
+    assert (
+        DEFAULT_SGLANG_PROMETHEUS_PORT_RANGE_LOW
+        < DEFAULT_SGLANG_PROMETHEUS_PORT_RANGE_HIGH
+    )
+    assert DEFAULT_SGLANG_PROMETHEUS_PORT_RANGE_HIGH < EPHEMERAL_FLOOR
     # Avoid privileged ports (<1024).
     assert DEFAULT_MASTER_PORT_RANGE_LOW > 1024

--- a/tests/unit/models/generation/sglang/helpers.py
+++ b/tests/unit/models/generation/sglang/helpers.py
@@ -34,10 +34,13 @@ os.environ.setdefault("SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK", "false")
 
 import ray
 
+from nemo_rl.distributed.virtual_cluster import (
+    DEFAULT_GENERATION_PORT_RANGE_LOW,
+    _get_free_port_local,
+)
 from nemo_rl.models.generation.sglang.sglang_worker import SGLangGenerationWorker
 from nemo_rl.models.generation.sglang.utils.ray_utils import (
     NOSET_VISIBLE_DEVICES_ENV_VARS_LIST,
-    find_available_port,
     get_host_info,
 )
 from nemo_rl.utils.venvs import make_actor_runtime_env
@@ -141,9 +144,10 @@ def create_worker(router_info, base_gpu_id=0, tp_size=1, rank=0):
     )
 
     host_ip = get_host_info()[1]
-    port = find_available_port(30000 + rank * 1000)
-    nccl_port = find_available_port(40000 + rank * 1000)
-    dist_init_port = find_available_port(50000 + rank * 1000)
+    band_low = DEFAULT_GENERATION_PORT_RANGE_LOW + rank * 1000
+    port = _get_free_port_local(band_low, band_low + 300)
+    nccl_port = _get_free_port_local(band_low + 300, band_low + 600)
+    dist_init_port = _get_free_port_local(band_low + 600, band_low + 1000)
 
     ray.get(
         worker.init.remote(

--- a/tests/unit/models/generation/sglang/test_sglang_router.py
+++ b/tests/unit/models/generation/sglang/test_sglang_router.py
@@ -22,8 +22,8 @@ import pytest
 import ray
 import requests
 
+from nemo_rl.distributed.virtual_cluster import _get_free_port_local
 from nemo_rl.models.generation.sglang.sglang_router import RouterActor, _start_router
-from nemo_rl.models.generation.sglang.utils.ray_utils import find_available_port
 
 from . import (
     helpers,  # noqa: F401  — installs env vars + module stubs before nemo_rl imports
@@ -68,7 +68,7 @@ def test_start_returns_ip_and_port(ray_cluster):
 
 def test_start_uses_configured_port(ray_cluster):
     """When sglang_router_port is set, the router uses that exact port."""
-    configured_port = find_available_port(9000)
+    configured_port = _get_free_port_local(9000, 10000)
     actor = RouterActor.remote()
     try:
         ip, port = _start_and_cleanup(actor, {"sglang_router_port": configured_port})

--- a/tests/unit/models/generation/sglang/test_utils_smoke.py
+++ b/tests/unit/models/generation/sglang/test_utils_smoke.py
@@ -27,11 +27,7 @@ from . import (
 pytestmark = pytest.mark.sglang
 
 from nemo_rl.models.generation.sglang.utils.ip_port_utils import _wrap_ipv6
-from nemo_rl.models.generation.sglang.utils.ray_utils import (
-    find_available_port,
-    get_host_info,
-    is_port_available,
-)
+from nemo_rl.models.generation.sglang.utils.ray_utils import get_host_info
 from nemo_rl.models.generation.sglang.utils.train_utils import (
     MultiprocessingSerializer,
 )
@@ -40,14 +36,6 @@ from nemo_rl.models.generation.sglang.utils.train_utils import (
 # ---------------------------------------------------------------------------
 # ray_utils
 # ---------------------------------------------------------------------------
-def test_find_available_port():
-    """find_available_port returns a port that passes is_port_available."""
-    port = find_available_port(20000)
-    assert isinstance(port, int)
-    assert port > 0
-    assert is_port_available(port)
-
-
 def test_wrap_ipv6_noop_for_ipv4():
     """IPv4 addresses are returned unchanged by _wrap_ipv6."""
     assert _wrap_ipv6("192.168.1.1") == "192.168.1.1"

--- a/tests/unit/models/generation/sglang/test_weight_update_real.py
+++ b/tests/unit/models/generation/sglang/test_weight_update_real.py
@@ -35,12 +35,14 @@ import ray
 import torch
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
-from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
-from nemo_rl.models.generation.sglang.sglang_generation import SGLangGeneration
-from nemo_rl.models.generation.sglang.utils.ray_utils import (
-    find_available_port,
-    get_host_info,
+from nemo_rl.distributed.virtual_cluster import (
+    DEFAULT_MASTER_PORT_RANGE_HIGH,
+    DEFAULT_MASTER_PORT_RANGE_LOW,
+    RayVirtualCluster,
+    _get_free_port_local,
 )
+from nemo_rl.models.generation.sglang.sglang_generation import SGLangGeneration
+from nemo_rl.models.generation.sglang.utils.ray_utils import get_host_info
 from tests.unit.models.generation.sglang.weight_update_actor import MockFSDPWorker
 
 from .helpers import make_actor_env_vars, post_and_assert_200
@@ -160,7 +162,9 @@ def mock_trainer(ray_cluster, sglang_gen):
     fit both worker groups.
     """
     host_ip = get_host_info()[1]
-    master_port = find_available_port(29500)
+    master_port = _get_free_port_local(
+        DEFAULT_MASTER_PORT_RANGE_LOW, DEFAULT_MASTER_PORT_RANGE_HIGH
+    )
     env_vars = make_actor_env_vars()
 
     pg = sglang_gen.cluster.get_placement_groups()[0]


### PR DESCRIPTION
## Summary

The SGLang backend allocated ports with its own helpers (`find_available_port`,
`is_port_available`, `get_free_port`) that probe OS-ephemeral ports, instead of
the shared range-based primitives in `virtual_cluster.py` already used by vLLM
and NeMo-Gym. This re-introduced the TOCTOU-prone allocation that #2380 removed,
just in a different place.

This PR rebases SGLang onto the shared helpers and reserved port map, while
keeping the SGLang-specific bits the shared helpers don't cover (contiguous
dp_attention port blocks, a per-node cursor, IPv6 bracketing, non-Ray host lookup).

Closes #2874



## What changed

- **`virtual_cluster.py`**: added `_get_free_consecutive_ports_local()` (returns a
  contiguous block of bindable ports in a reserved range — the one capability the
  existing helpers lacked) and a dedicated router/Prometheus band (28001–30000).
- **`ray_utils.py`**: removed `find_available_port` / `is_port_available` /
  `get_free_port`; `get_current_node_ip` now delegates to `_get_node_ip_local()`.
  `get_host_info` and the NOSET env list are unchanged.
- **`ip_port_utils.py` / `sglang_worker.py`**: allocate through the shared helper
  with `port_range_low/high` + a per-node cursor instead of a hard-coded `base_port=15000`.
- **`sglang_generation.py`**: reads `port_range_low/high` from the generation config.
- **`sglang_router.py`**: router/Prometheus ports from `_get_free_port_local` over their band.
- **Tests**: added `TestGetFreeConsecutivePortsLocal`; updated SGLang tests/helpers
  that used the removed functions.
- **patch**: This patch rebases `_patch_sglang_custom_all_reduce_v2_tms_cudagraph` onto the final form of [sgl-project/sglang#27948](https://github.com/sgl-project/sglang/pull/27948) (tracking [radixark/miles#1176](https://github.com/radixark/miles/issues/1176)): instead of the earlier revision's `set_cuda_graph_register_inputs` toggle threaded through five files, it applies the upstream Python-only fix to `custom_all_reduce_v2.py` — adding the `envs` import and `self.tms_cudagraph` flag, and gating both `set_cuda_graph_capture(True)` calls on `not self.tms_cudagraph` — so the kernel's capture flag stays off under TMS and we no longer touch the fragile jit_kernel C++/`.cuh` sources.


## Port layout

| Port class | Band |
|---|---|
| HTTP server + NCCL/dist_init | 11001–15000 (per-node cursor) |
| Router / Prometheus | 28001–29000 / 29000–30000 |

## Testing
- `pytest tests/unit/distributed/test_virtual_cluster.py::TestGetFreeConsecutivePortsLocal`
- `pytest -m sglang tests/unit/models/generation/sglang/`
