### PR TITLE
fix(perf): fix CUDA OOM in grpo-qwen3-30ba3b-4n8g performance test

### DIFF
--- a/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n8g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n8g.yaml
@@ -10,6 +10,7 @@ policy:
   train_micro_batch_size: 1
   logprob_batch_size: 4
   max_total_sequence_length: 4096
+  logprob_chunk_size: 512
   sequence_packing:
     fuse_loss: true
   dtensor_cfg:
@@ -20,6 +21,7 @@ policy:
   megatron_cfg:
     enabled: true
     empty_unused_memory_level: 1
+    defer_fp32_logits: true
     tensor_model_parallel_size: 1
     pipeline_model_parallel_size: 1
     expert_model_parallel_size: 8
@@ -32,7 +34,7 @@ policy:
       lr_warmup_iters: 50
       lr_warmup_init: 3.0e-08
     env_vars:
-      PYTORCH_CUDA_ALLOC_CONF: expandable_segments:False
+      PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
   generation:
     vllm_cfg:
       tensor_parallel_size: 2


### PR DESCRIPTION
  Fixes #2811
                                                                                                                                                                                    
  ## Root cause
  `logprob_chunk_size` was unset, causing logprob computation to cast the full                                                                                                      
  `[logprob_batch_size, max_seq_len, vocab_size]` tensor to fp32 in one shot: 4 × 4096 × 151936 × 4 bytes = **9.27 GiB** — exactly matching the OOM.                                                                                                
                                                                                                                                                                                    
  ## Fix (grpo-qwen3-30ba3b-4n8g.yaml)                                                                                                                                              
  - `logprob_chunk_size: 512` — chunked computation, peak fp32 drops from 9.27 GiB → 1.16 GiB (~88% reduction)                                                                      
  - `defer_fp32_logits: true` — required by assertion when `logprob_chunk_size` is set                                                                                              
  - `PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True` — allows PyTorch to reclaim fragmented reserved memory
                                                                                                                                                                                    
  ## Validation   
  4-node 32-GPU Slurm job: 3 training steps completed without OOM ✓                                                                     