### PR TITLE
Keep FP8 KV-cache rollout scales aligned with training

### DIFF
--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -26,9 +26,11 @@ from transformers import AutoConfig, AutoTokenizer
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
 from nemo_rl.algorithms.grpo import (
+    _raise_if_initial_validation_requires_kv_scale_sync,
     _should_log_nemo_gym_responses,
     _should_use_async_rollouts,
     _should_use_nemo_gym,
+    _validate_calibrated_fp8_kv_scales,
     aggregate_rollout_metrics,
     refit_policy_generation,
 )
@@ -69,6 +71,7 @@ from nemo_rl.models.generation.interfaces import (
     GenerationInterface,
 )
 from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration
+from nemo_rl.models.generation.vllm.utils import validate_vllm_fp8_kv_cache_config
 from nemo_rl.models.policy import PolicyConfig
 from nemo_rl.models.policy.interfaces import ColocatablePolicyInterface
 from nemo_rl.models.policy.lm_policy import Policy
@@ -217,6 +220,12 @@ def setup(
     assert generation_config is not None, (
         "A generation config in the PolicyConfig is required for distillation"
     )
+    if generation_config["backend"] == "vllm":
+        validate_vllm_fp8_kv_cache_config(
+            policy_config,
+            generation_config,
+            use_async_rollouts=_should_use_async_rollouts(master_config),
+        )
 
     # Disallow SP + packing for dtensor path
     for cfg, who in ((policy_config, "student"), (teacher_config, "teacher")):
@@ -663,6 +672,10 @@ def distillation_train(
         NEED_REFIT = False
     POLICY_GENERATION_STALE = True  # tracks if generation needs a refit before running
     assert student_generation is not None  # for mypy type check
+    sync_kv_scales = NEED_REFIT and bool(
+        getattr(student_generation, "requires_kv_scale_sync", False)
+    )
+    kv_scales_cache: Optional[dict[str, float]] = None
     use_nemo_gym = _should_use_nemo_gym(master_config)
     if use_nemo_gym:
         print("▶ Using NeMo-Gym rollouts for distillation", flush=True)
@@ -688,12 +701,21 @@ def distillation_train(
         "max_num_steps"
     ]  # max number of steps to train for
 
+    _raise_if_initial_validation_requires_kv_scale_sync(
+        val_at_start=val_at_start,
+        current_step=total_steps,
+        sync_kv_scales=sync_kv_scales,
+    )
+
     # Run validation at the start if configured
     if val_at_start and total_steps == 0:
         print("\n🔍 Running initial validation...", flush=True)
         if NEED_REFIT and POLICY_GENERATION_STALE:
             refit_policy_generation(
-                student_policy, student_generation, colocated_inference
+                student_policy,
+                student_generation,
+                colocated_inference,
+                kv_scales=kv_scales_cache if sync_kv_scales else None,
             )
             POLICY_GENERATION_STALE = False
         else:
@@ -748,11 +770,46 @@ def distillation_train(
                 )
                 with timer.time("prepare_for_generation"):
                     if NEED_REFIT and POLICY_GENERATION_STALE:
+                        if sync_kv_scales and kv_scales_cache is None:
+                            print("▶ Computing KV cache scales...", flush=True)
+                            student_policy.prepare_for_lp_inference()
+                            calib_flat, calib_input_lengths = (
+                                batched_message_log_to_flat_message(
+                                    repeated_batch["message_log"],
+                                    pad_value_dict={
+                                        "token_ids": tokenizer.pad_token_id
+                                    },
+                                    make_sequence_length_divisible_by=master_config.policy[
+                                        "make_sequence_length_divisible_by"
+                                    ],
+                                )
+                            )
+                            calibration_data = BatchedDataDict[
+                                DistillationLossDataDict
+                            ](
+                                {
+                                    "input_ids": calib_flat["token_ids"],
+                                    "input_lengths": calib_input_lengths,
+                                }
+                            )
+                            calibration_data.update(
+                                calib_flat.get_multimodal_dict(as_tensors=False)
+                            )
+                            calibration_data.to("cpu")
+                            kv_scales_cache = student_policy.calibrate_qkv_fp8_scales(
+                                calibration_data, include_q=True
+                            )["layers"]
+                            _validate_calibrated_fp8_kv_scales(
+                                kv_scales_cache,
+                                context="initial distillation rollout refit",
+                            )
+
                         refit_policy_generation(
                             student_policy,
                             student_generation,
                             colocated_inference,
                             timer=timer,
+                            kv_scales=kv_scales_cache if sync_kv_scales else None,
                         )
                         POLICY_GENERATION_STALE = False
                     else:
@@ -881,6 +938,21 @@ def distillation_train(
                         timer=timer,
                     )
 
+                if sync_kv_scales:
+                    with timer.time("recompute_kv_scales"):
+                        print(
+                            "▶ Recomputing KV cache scales after policy update...",
+                            flush=True,
+                        )
+                        kv_scales_cache = student_policy.calibrate_qkv_fp8_scales(
+                            train_data, include_q=True
+                        )["layers"]
+                        _validate_calibrated_fp8_kv_scales(
+                            kv_scales_cache,
+                            context="post-training distillation refit",
+                        )
+                        POLICY_GENERATION_STALE = True
+
                 is_last_step = (total_steps + 1 >= max_steps) or (
                     (current_epoch + 1 == max_epochs)
                     and (current_step + 1 == len(dataloader))
@@ -892,7 +964,10 @@ def distillation_train(
                 ):
                     if NEED_REFIT and POLICY_GENERATION_STALE:
                         refit_policy_generation(
-                            student_policy, student_generation, colocated_inference
+                            student_policy,
+                            student_generation,
+                            colocated_inference,
+                            kv_scales=kv_scales_cache if sync_kv_scales else None,
                         )
                         POLICY_GENERATION_STALE = False
                     else:

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import gc
+import math
 import os
 import time
 import warnings
@@ -91,6 +92,10 @@ from nemo_rl.models.generation.megatron import MegatronGeneration
 from nemo_rl.models.generation.sglang.config import SGLangConfig
 from nemo_rl.models.generation.sglang.sglang_generation import SGLangGeneration
 from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration
+from nemo_rl.models.generation.vllm.utils import (
+    can_sync_apply_fp8_kv,
+    validate_vllm_fp8_kv_cache_config,
+)
 from nemo_rl.models.megatron.router_replay import (
     configure_vllm_for_router_replay,
     router_replay_enabled,
@@ -999,22 +1004,11 @@ def setup(
             assert loss_config.use_importance_sampling_correction, (
                 "Importance sampling must be enabled for vLLM FP8 generation for good convergence!"
             )
-        if generation_config["vllm_cfg"]["kv_cache_dtype"].startswith("fp8"):
-            # FP8 KV cache requires FP8 model precision
-            assert generation_config["vllm_cfg"]["precision"] == "fp8", (
-                f"kv_cache_dtype='{generation_config['vllm_cfg']['kv_cache_dtype']}' requires precision='fp8'. "
-                "FP8 KV cache can only be used together with FP8 model weights."
-            )
-            # FP8 KV cache compatibility checks
-            assert policy_config["dtensor_cfg"]["enabled"] == False, (
-                "DTensor backend is not supported with kv cache fp8 enabled."
-            )
-            assert not _should_use_async_rollouts(master_config), (
-                "Async rollouts is not supported with kv cache fp8 enabled."
-            )
-            assert policy_config["megatron_cfg"]["pipeline_model_parallel_size"] == 1, (
-                "Currently when using FP8 KV cache in generation, then in megatron we only support pipeline_model_parallel_size=1. We will add more support in future."
-            )
+        validate_vllm_fp8_kv_cache_config(
+            policy_config,
+            generation_config,
+            use_async_rollouts=_should_use_async_rollouts(master_config),
+        )
 
         configure_vllm_for_router_replay(policy_config)
         vllm_kwargs = generation_config.setdefault("vllm_kwargs", {})
@@ -1892,7 +1886,8 @@ def refit_policy_generation(
             else:
                 # Original ZMQ IPC path for vLLM
                 futures_train = policy.stream_weights_via_ipc_zmq(
-                    buffer_size_bytes=buffer_size_bytes
+                    buffer_size_bytes=buffer_size_bytes,
+                    kv_scales=kv_scales,
                 )
                 futures_inference = policy_generation.update_weights_via_ipc_zmq()
                 # wait for all futures to complete
@@ -1934,9 +1929,88 @@ def refit_policy_generation(
     # Megatron non-colocated inference needs to enter inference mode after refit.
     if colocated_inference or isinstance(policy_generation, MegatronGeneration):
         policy_generation.prepare_for_generation(tags=["kv_cache"])
+        if (
+            kv_scales is not None
+            and not isinstance(policy_generation, MegatronGeneration)
+            and can_sync_apply_fp8_kv(getattr(policy_generation, "cfg", {}))
+            and hasattr(policy_generation, "apply_kv_cache_scales")
+        ):
+            policy_generation.apply_kv_cache_scales(kv_scales)
 
     if isinstance(policy_generation, MegatronGeneration):
         policy_generation.resume_after_refit()
+
+
+def _raise_if_initial_validation_requires_kv_scale_sync(
+    *,
+    val_at_start: bool,
+    current_step: int,
+    sync_kv_scales: bool,
+) -> None:
+    if not (val_at_start and current_step == 0 and sync_kv_scales):
+        return
+
+    raise ValueError(
+        "val_at_start=True is not supported when the generation backend requires "
+        "FP8 KV-cache scale synchronization. Initial validation happens before a "
+        "rollout/training batch has produced calibrated KV scales, so validating "
+        "after a refit would use unauthoritative KV scales. Set val_at_start=False "
+        "and use val_period/val_at_end validation after the first calibrated refit."
+    )
+
+
+def _summarize_fp8_kv_scales(kv_scales: dict[str, Any]) -> dict[str, Any]:
+    values = []
+    counts = {"q": 0, "k": 0, "v": 0, "unknown": 0}
+    for name, value in kv_scales.items():
+        scale = float(value)
+        values.append(scale)
+        if name.endswith(".q_scale"):
+            counts["q"] += 1
+        elif name.endswith(".k_scale"):
+            counts["k"] += 1
+        elif name.endswith(".v_scale"):
+            counts["v"] += 1
+        else:
+            counts["unknown"] += 1
+
+    non_default = sum(
+        not math.isclose(value, 1.0, rel_tol=0.0, abs_tol=1e-12) for value in values
+    )
+    return {
+        "total": len(values),
+        "counts": counts,
+        "min": min(values) if values else None,
+        "max": max(values) if values else None,
+        "non_default": non_default,
+        "zero_or_negative": sum(value <= 0.0 for value in values),
+        "non_finite": sum(not math.isfinite(value) for value in values),
+    }
+
+
+def _validate_calibrated_fp8_kv_scales(
+    kv_scales: dict[str, Any],
+    *,
+    context: str,
+) -> dict[str, Any]:
+    summary = _summarize_fp8_kv_scales(kv_scales)
+    print(f"FP8 KV scale summary ({context}): {summary}", flush=True)
+
+    if summary["total"] == 0:
+        raise RuntimeError(f"No FP8 KV cache scales were produced during {context}.")
+    if summary["non_finite"] > 0 or summary["zero_or_negative"] > 0:
+        raise RuntimeError(f"Invalid FP8 KV cache scales during {context}: {summary}")
+    counts = summary["counts"]
+    if counts["unknown"] > 0 or not (counts["q"] == counts["k"] == counts["v"]):
+        raise RuntimeError(
+            f"Incomplete FP8 Q/K/V cache scales during {context}: {summary}"
+        )
+    if summary["non_default"] == 0:
+        raise RuntimeError(
+            f"FP8 KV cache scales stayed at the default value 1.0 during {context}; "
+            "this means calibration did not produce authoritative scales."
+        )
+    return summary
 
 
 def _log_mixed_rewards_and_advantages_information(
@@ -2160,7 +2234,11 @@ def grpo_train(
     adv_estimator = _create_advantage_estimator(master_config)
 
     # Run validation at the start if configured
-    # TODO: Add validation with kv scales if needed
+    _raise_if_initial_validation_requires_kv_scale_sync(
+        val_at_start=val_at_start,
+        current_step=current_step,
+        sync_kv_scales=sync_kv_scales,
+    )
     if val_at_start and current_step == 0:
         print("\n🔍 Running initial validation...", flush=True)
         memory_tracker.snapshot_start_of_stage("Initial validation", dir())
@@ -2280,6 +2358,10 @@ def grpo_train(
                             kv_scales_cache = policy.calibrate_qkv_fp8_scales(
                                 calibration_data, include_q=True
                             )["layers"]
+                            _validate_calibrated_fp8_kv_scales(
+                                kv_scales_cache,
+                                context="initial rollout refit",
+                            )
 
                         refit_policy_generation(
                             policy,
@@ -2704,6 +2786,10 @@ def grpo_train(
                         kv_scales_cache = policy.calibrate_qkv_fp8_scales(
                             train_data, include_q=True
                         )["layers"]
+                        _validate_calibrated_fp8_kv_scales(
+                            kv_scales_cache,
+                            context="post-training refit",
+                        )
                         # Set generation as stale to force refit with new scales
                         POLICY_GENERATION_STALE = True
 

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -51,8 +51,10 @@ from nemo_rl.algorithms.grpo import (
     _clip_grpo_advantages,
     _create_advantage_estimator,
     _log_mixed_rewards_and_advantages_information,
+    _raise_if_initial_validation_requires_kv_scale_sync,
     _should_log_nemo_gym_responses,
     _should_use_nemo_gym,
+    _validate_calibrated_fp8_kv_scales,
     compute_and_apply_seq_logprob_error_masking,
     refit_policy_generation,
     scale_rewards,
@@ -432,6 +434,12 @@ def grpo_train_sync(
     val_period = master_config.grpo["val_period"]
     colocated_inference = master_config.policy["generation"]["colocated"]["enabled"]
 
+    _raise_if_initial_validation_requires_kv_scale_sync(
+        val_at_start=val_at_start,
+        current_step=current_step,
+        sync_kv_scales=sync_kv_scales,
+    )
+
     # ── Data-plane setup (mandatory in the sync trainer) ───────────────
     # Sync trainer requires a TQ-mediated policy. The TQPolicy actor
     # bootstraps the controller and attaches workers; ``policy.dp_cfg``
@@ -601,6 +609,10 @@ def grpo_train_sync(
                             kv_scales_cache = policy.calibrate_qkv_fp8_scales(
                                 calibration_data, include_q=True
                             )["layers"]
+                            _validate_calibrated_fp8_kv_scales(
+                                kv_scales_cache,
+                                context="initial rollout refit",
+                            )
 
                         refit_policy_generation(
                             policy,
@@ -924,6 +936,10 @@ def grpo_train_sync(
                             calibration_data,
                             include_q=True,
                         )["layers"]
+                        _validate_calibrated_fp8_kv_scales(
+                            kv_scales_cache,
+                            context="post-training refit",
+                        )
                         POLICY_GENERATION_STALE = True
 
                 # Stash input_ids and content before clear_samples so the

--- a/nemo_rl/algorithms/ppo.py
+++ b/nemo_rl/algorithms/ppo.py
@@ -31,6 +31,8 @@ from nemo_rl.algorithms.advantage_estimator import (
 )
 from nemo_rl.algorithms.grpo import (
     RewardScalingConfig,
+    _raise_if_initial_validation_requires_kv_scale_sync,
+    _validate_calibrated_fp8_kv_scales,
     _should_log_nemo_gym_responses,
     _should_use_async_rollouts,
     _should_use_nemo_gym,
@@ -71,6 +73,7 @@ from nemo_rl.models.generation.interfaces import GenerationInterface
 from nemo_rl.models.generation.sglang.config import SGLangConfig
 from nemo_rl.models.generation.sglang.sglang_generation import SGLangGeneration
 from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration
+from nemo_rl.models.generation.vllm.utils import validate_vllm_fp8_kv_cache_config
 from nemo_rl.models.policy import PolicyConfig
 from nemo_rl.models.policy.interfaces import ColocatablePolicyInterface
 from nemo_rl.models.policy.lm_policy import Policy
@@ -570,22 +573,11 @@ def setup(
             assert loss_config.use_importance_sampling_correction is True, (
                 "Importance sampling must be enabled for vLLM FP8 generation for good convergence!"
             )
-        if generation_config["vllm_cfg"]["kv_cache_dtype"].startswith("fp8"):
-            # FP8 KV cache requires FP8 model precision
-            assert generation_config["vllm_cfg"]["precision"] == "fp8", (
-                f"kv_cache_dtype='{generation_config['vllm_cfg']['kv_cache_dtype']}' requires precision='fp8'. "
-                "FP8 KV cache can only be used together with FP8 model weights."
-            )
-            # FP8 KV cache compatibility checks
-            assert policy_config["dtensor_cfg"]["enabled"] == False, (
-                "DTensor backend is not supported with kv cache fp8 enabled."
-            )
-            assert not _should_use_async_rollouts(master_config), (
-                "Async rollouts is not supported with kv cache fp8 enabled."
-            )
-            assert policy_config["megatron_cfg"]["pipeline_model_parallel_size"] == 1, (
-                "Currently when using FP8 KV cache in generation, then in megatron we only support pipeline_model_parallel_size=1. We will add more support in future."
-            )
+        validate_vllm_fp8_kv_cache_config(
+            policy_config,
+            generation_config,
+            use_async_rollouts=_should_use_async_rollouts(master_config),
+        )
 
         ## make vllm hf overrides match the training policy
         generation_config["vllm_kwargs"]["hf_overrides"] = policy_config.get(
@@ -934,6 +926,11 @@ def ppo_train(
     adv_estimator = _create_advantage_estimator(master_config)
 
     # Run validation at the start if configured
+    _raise_if_initial_validation_requires_kv_scale_sync(
+        val_at_start=val_at_start,
+        current_step=current_step,
+        sync_kv_scales=sync_kv_scales,
+    )
     if val_at_start and current_step == 0:
         print("\n🔍 Running initial validation...", flush=True)
         memory_tracker.snapshot_start_of_stage("Initial validation", dir())
@@ -1023,6 +1020,10 @@ def ppo_train(
                             kv_scales_cache = policy.calibrate_qkv_fp8_scales(
                                 calibration_data, include_q=True
                             )["layers"]
+                            _validate_calibrated_fp8_kv_scales(
+                                kv_scales_cache,
+                                context="initial rollout refit",
+                            )
 
                         refit_policy_generation(
                             policy,
@@ -1314,6 +1315,10 @@ def ppo_train(
                         kv_scales_cache = policy.calibrate_qkv_fp8_scales(
                             train_data, include_q=True
                         )["layers"]
+                        _validate_calibrated_fp8_kv_scales(
+                            kv_scales_cache,
+                            context="post-training refit",
+                        )
                         POLICY_GENERATION_STALE = True
 
                 is_last_step = (total_steps + 1 >= max_num_steps) or (

--- a/nemo_rl/modelopt/models/generation/vllm_quant_backend.py
+++ b/nemo_rl/modelopt/models/generation/vllm_quant_backend.py
@@ -44,6 +44,31 @@ class VllmQuantInternalWorkerExtension(VllmInternalWorkerExtension):
     def _is_real_quant_model(self) -> bool:
         return os.environ.get("VLLM_MODELOPT_REAL_QUANT", "0") == "1"
 
+    def _maybe_process_fp8_kv_cache(self) -> None:
+        if self._is_real_quant_model():
+            # Real-quant ModelOpt KV scales are streamed out of band and applied
+            # explicitly; vLLM's generic post-load hook also revisits dense
+            # ModelOpt layers, which is not safe after W4A16 refit.
+            return
+        return super()._maybe_process_fp8_kv_cache()
+
+    def _record_pending_kv_scales(
+        self, weights: list[tuple[str, torch.Tensor]]
+    ) -> list[tuple[str, torch.Tensor]]:
+        pending = dict(getattr(self, "_pending_kv_cache_scales", {}))
+        filtered = []
+        for name, weight in weights:
+            if self._parse_kv_scale_name(name) is None:
+                filtered.append((name, weight))
+                continue
+            if weight.numel() != 1:
+                raise ValueError(
+                    f"Only scalar FP8 KV scale refit is supported, got {name} with shape {tuple(weight.shape)}"
+                )
+            pending[name] = float(weight.detach().float().cpu().reshape(-1)[0].item())
+        self._pending_kv_cache_scales = pending
+        return filtered
+
     @contextmanager
     def _patch_named_parameters_to_include_buffers(self, model):
         """Temporarily patches model.named_parameters() to also yield input_quantizer buffers.
@@ -84,6 +109,7 @@ class VllmQuantInternalWorkerExtension(VllmInternalWorkerExtension):
         applied during export), so no fold_weight step is needed here.
         """
         if self._is_real_quant_model():
+            weights = self._record_pending_kv_scales(list(weights))
             quant_config = (
                 self.model_runner.vllm_config.model_config.hf_config.quantization_config
             )
@@ -200,6 +226,12 @@ class VllmQuantInternalWorkerExtension(VllmInternalWorkerExtension):
         result = super().update_weights_from_collective()
         if result:
             modelopt_process_weights_after_loading(self.model_runner.model)
+            # Base collective reload processes FP8 KV cache before ModelOpt's
+            # post-load hooks. Run it again here so vLLM rebuilds cache-scale
+            # state after ModelOpt has finalized the loaded weights.
+            self._maybe_process_fp8_kv_cache()
+            if getattr(self, "_pending_kv_cache_scales", None):
+                self.apply_kv_cache_scales()
         return result
 
     def get_weight_snapshot(self, name: str) -> torch.Tensor:

--- a/nemo_rl/modelopt/models/generation/vllm_quant_worker.py
+++ b/nemo_rl/modelopt/models/generation/vllm_quant_worker.py
@@ -53,6 +53,7 @@ def _configure_quant_engine_kwargs(
         hf_overrides = llm_kwargs.setdefault("hf_overrides", {})
         hf_overrides["quantization_config"] = build_vllm_modelopt_nvfp4_config(
             ignore=cfg.get("real_quant_ignore"),
+            kv_cache_dtype=cfg.get("vllm_cfg", {}).get("kv_cache_dtype"),
         )
         llm_kwargs["quantization"] = "modelopt"
     else:

--- a/nemo_rl/modelopt/models/policy/workers/megatron_quant_policy_worker.py
+++ b/nemo_rl/modelopt/models/policy/workers/megatron_quant_policy_worker.py
@@ -395,15 +395,7 @@ class MegatronQuantPolicyWorker(MegatronPolicyWorkerImpl):
         if not vllm_cfg.get("kv_cache_dtype", "").startswith("fp8"):
             return
 
-        from nemo_rl.models.generation.vllm.quantization.fp8_train_utils import (
-            get_vllm_qkv_scale_names,
-        )
-
-        keys: list[str] = []
-        for layer_idx in range(self.megatron_bridge.transformer_config.num_layers):
-            keys.extend(get_vllm_qkv_scale_names(layer_idx).values())
-
-        for param_name in keys:
+        for param_name in self._get_vllm_kv_scale_names(kv_scales):
             scale_value = (
                 kv_scales[param_name] if kv_scales and param_name in kv_scales else 1.0
             )

--- a/nemo_rl/modelopt/utils.py
+++ b/nemo_rl/modelopt/utils.py
@@ -72,6 +72,7 @@ def matches_quant_ignore_pattern(name: str, patterns: list[str]) -> bool:
 def build_vllm_modelopt_nvfp4_config(
     *,
     ignore: list[str] | None = None,
+    kv_cache_dtype: str | None = None,
 ) -> dict[str, Any]:
     """Build the HuggingFace quantization_config consumed by vLLM ModelOpt NVFP4.
 
@@ -79,7 +80,7 @@ def build_vllm_modelopt_nvfp4_config(
     ``mtq.quantize``. vLLM expects the deployment/export-side
     ``quantization_config`` shape instead.
     """
-    return {
+    config = {
         "quant_method": "modelopt",
         "config_groups": {
             "group_0": {
@@ -100,6 +101,13 @@ def build_vllm_modelopt_nvfp4_config(
         "group_size": 16,
         "producer": {"name": "modelopt"},
     }
+    if kv_cache_dtype is not None and kv_cache_dtype.startswith("fp8"):
+        config["kv_cache_scheme"] = {
+            "dynamic": False,
+            "num_bits": 8,
+            "type": "float",
+        }
+    return config
 
 
 def resolve_quant_cfg(quant_cfg: str) -> dict[str, Any]:

--- a/nemo_rl/models/generation/vllm/quantization/fp8_train_utils.py
+++ b/nemo_rl/models/generation/vllm/quantization/fp8_train_utils.py
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
+
+_ATTENTION_LAYER_RE = re.compile(
+    r"(?:^|\.)layers\.(?P<layer_idx>\d+)\.(?:self_attn|self_attention)\."
+)
+
 
 def get_vllm_qkv_scale_names(layer_idx: int) -> dict[str, str]:
     """Get vLLM-compatible parameter names for Q/K/V FP8 scales.
@@ -46,6 +53,29 @@ def get_vllm_qkv_scale_names(layer_idx: int) -> dict[str, str]:
         "k_scale": f"model.layers.{layer_idx}.self_attn.k_scale",
         "v_scale": f"model.layers.{layer_idx}.self_attn.v_scale",
     }
+
+
+def get_attention_layer_indices_from_param_names(param_names: list[str]) -> list[int]:
+    """Return attention-owning layer ids visible in exported/HF parameter names."""
+    layer_indices: set[int] = set()
+    for name in param_names:
+        match = _ATTENTION_LAYER_RE.search(name)
+        if match:
+            layer_indices.add(int(match.group("layer_idx")))
+    return sorted(layer_indices)
+
+
+def validate_vllm_qkv_scale_completeness(
+    expected_scale_names: list[str],
+    kv_scales: dict[str, float],
+) -> None:
+    """Require calibrated scales for every expected local attention component."""
+    missing = sorted(set(expected_scale_names) - set(kv_scales))
+    if missing:
+        raise RuntimeError(
+            "Calibrated FP8 KV scale payload is incomplete; missing "
+            f"expected attention scales: {missing[:8]}"
+        )
 
 
 def convert_calibration_to_vllm_format(

--- a/nemo_rl/models/generation/vllm/utils.py
+++ b/nemo_rl/models/generation/vllm/utils.py
@@ -23,6 +23,78 @@ from nemo_rl.models.generation.interfaces import GenerationDatumSpec
 R3_MISSING_ROUTE_SENTINEL = -1
 
 
+def is_modelopt_real_quant_fp8_kv(generation_config: dict[str, Any]) -> bool:
+    """Return whether FP8 KV is backed by ModelOpt real-quant vLLM rollout."""
+    vllm_cfg = generation_config.get("vllm_cfg", {})
+    kv_cache_dtype = vllm_cfg.get("kv_cache_dtype", "")
+    return (
+        generation_config.get("backend") == "vllm"
+        and bool(generation_config.get("real_quant"))
+        and generation_config.get("quant_cfg") is not None
+        and isinstance(kv_cache_dtype, str)
+        and kv_cache_dtype.startswith("fp8")
+    )
+
+
+def can_sync_apply_modelopt_real_quant_fp8_kv(
+    generation_config: dict[str, Any],
+) -> bool:
+    """Return whether sync worker RPCs can apply ModelOpt FP8 KV scales."""
+    return is_modelopt_real_quant_fp8_kv(generation_config) and can_sync_apply_fp8_kv(
+        generation_config
+    )
+
+
+def can_sync_apply_fp8_kv(generation_config: dict[str, Any]) -> bool:
+    """Return whether sync vLLM workers can apply FP8 KV scales."""
+    vllm_cfg = generation_config.get("vllm_cfg", {})
+    kv_cache_dtype = vllm_cfg.get("kv_cache_dtype", "")
+    return (
+        generation_config.get("backend") == "vllm"
+        and isinstance(kv_cache_dtype, str)
+        and kv_cache_dtype.startswith("fp8")
+        and not bool(vllm_cfg.get("async_engine", False))
+    )
+
+
+def is_modelopt_qarl_fp8_kv(
+    policy_config: dict[str, Any], generation_config: dict[str, Any]
+) -> bool:
+    """Return whether ModelOpt QARL can pair real-quant rollout with FP8 KV."""
+    return bool(policy_config.get("quant_cfg")) and is_modelopt_real_quant_fp8_kv(
+        generation_config
+    )
+
+
+def validate_vllm_fp8_kv_cache_config(
+    policy_config: dict[str, Any],
+    generation_config: dict[str, Any],
+    *,
+    use_async_rollouts: bool,
+) -> None:
+    """Validate vLLM FP8 KV-cache constraints shared by GRPO and PPO."""
+    vllm_cfg = generation_config.get("vllm_cfg", {})
+    kv_cache_dtype = vllm_cfg.get("kv_cache_dtype", "auto")
+    if not kv_cache_dtype.startswith("fp8"):
+        return
+
+    assert vllm_cfg["precision"] in {"bfloat16", "fp8"} or is_modelopt_qarl_fp8_kv(
+        policy_config, generation_config
+    ), (
+        f"kv_cache_dtype='{kv_cache_dtype}' requires bfloat16 or fp8 vLLM "
+        "weights, or ModelOpt real-quant rollout with policy.quant_cfg set."
+    )
+    assert not use_async_rollouts, (
+        "Async rollouts is not supported with kv cache fp8 enabled."
+    )
+    assert policy_config["dtensor_cfg"]["enabled"] == False, (
+        "DTensor backend is not supported with kv cache fp8 enabled."
+    )
+    assert policy_config["megatron_cfg"]["pipeline_model_parallel_size"] == 1, (
+        "Currently when using FP8 KV cache in generation, then in megatron we only support pipeline_model_parallel_size=1. We will add more support in future."
+    )
+
+
 def format_prompt_for_vllm_generation(
     data: BatchedDataDict[GenerationDatumSpec], sample_idx: Optional[int] = None
 ) -> list[dict[str, Any]]:

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import gc
+import math
 import re
 import traceback
 from typing import Any
@@ -92,6 +93,12 @@ def _read_mtp_layer_weights_from_checkpoint(
 
 
 class VllmInternalWorkerExtension:
+    _pending_kv_cache_scales: dict[str, float]
+    _KV_SCALE_RE = re.compile(
+        r"^(?P<prefix>.*\.(?:self_attn|self_attention))(?:(?:\.attn)?\.(?P<kind>q)_scale|\.(?P<kv_kind>[kv])_scale)$"
+    )
+    _Q_SCALE_UNSUPPORTED_BACKENDS = {"TRITON_ATTN", "ROCM_ATTN"}
+
     def init_collective(
         self,
         rank_prefix: int,
@@ -137,6 +144,198 @@ class VllmInternalWorkerExtension:
             )  # set timeout to 120 seconds
             self.zmq_socket.setsockopt(zmq.LINGER, 0)
             self.zmq_socket.connect(self.get_zmq_address())
+
+    @classmethod
+    def _parse_kv_scale_name(cls, name: str) -> tuple[str, str] | None:
+        match = cls._KV_SCALE_RE.match(name)
+        if match is None:
+            return None
+        kind = match.group("kind") or match.group("kv_kind")
+        return f"{match.group('prefix')}.attn", kind
+
+    @staticmethod
+    def _without_model_prefix(name: str) -> str:
+        return name.removeprefix("model.")
+
+    def _iter_attention_modules(self):
+        model = getattr(self.model_runner, "model", None)
+        if model is not None and hasattr(model, "named_modules"):
+            yield from model.named_modules()
+
+        vllm_config = getattr(self.model_runner, "vllm_config", None)
+        context = getattr(vllm_config, "compilation_config", None)
+        static_context = getattr(context, "static_forward_context", None)
+        if isinstance(static_context, dict) and static_context:
+            yield from static_context.items()
+
+    def _attention_module_map(self) -> dict[str, torch.nn.Module]:
+        modules: dict[str, torch.nn.Module] = {}
+        for name, module in self._iter_attention_modules():
+            if all(
+                hasattr(module, attr) for attr in ("_q_scale", "_k_scale", "_v_scale")
+            ):
+                modules[name] = module
+                modules[self._without_model_prefix(name)] = module
+        return modules
+
+    @staticmethod
+    def _get_attention_backend_name(module: torch.nn.Module) -> str:
+        get_attn_backend = getattr(module, "get_attn_backend", None)
+        if callable(get_attn_backend):
+            backend = get_attn_backend()
+            if hasattr(backend, "get_name"):
+                return str(backend.get_name())
+        backend = getattr(module, "attn_backend", None)
+        if hasattr(backend, "get_name"):
+            return str(backend.get_name())
+        backend = getattr(module, "backend", None)
+        if backend is not None:
+            return str(backend)
+        return module.impl.__class__.__name__ if hasattr(module, "impl") else "unknown"
+
+    @classmethod
+    def _q_scale_supported(cls, module: torch.nn.Module) -> bool:
+        backend_name = cls._get_attention_backend_name(module)
+        if backend_name in cls._Q_SCALE_UNSUPPORTED_BACKENDS:
+            return False
+        impl_module = getattr(getattr(module, "impl", None), "__module__", "")
+        return not (
+            impl_module.endswith(".triton_attn") or impl_module.endswith(".rocm_attn")
+        )
+
+    @staticmethod
+    def _platform_adjust_scale(value: float) -> float:
+        from vllm.platforms import current_platform
+
+        return value * 2 if current_platform.is_fp8_fnuz() else value
+
+    @staticmethod
+    def _set_scale(module: torch.nn.Module, kind: str, value: float) -> None:
+        attr = f"_{kind}_scale"
+        tensor = getattr(module, attr)
+        with torch.no_grad():
+            tensor.copy_(torch.tensor(value, dtype=tensor.dtype, device=tensor.device))
+        setattr(module, f"_{kind}_scale_float", float(value))
+
+    @staticmethod
+    def _invalidate_attention_scale_cache(module: torch.nn.Module) -> None:
+        impl = getattr(module, "impl", None)
+        if impl is not None:
+            for attr in ("bmm1_scale", "bmm2_scale", "o_sf_scale"):
+                if hasattr(impl, attr):
+                    setattr(impl, attr, None)
+        if hasattr(module, "_o_scale_float"):
+            setattr(module, "_o_scale_float", None)
+
+    def apply_kv_cache_scales(self, kv_scales: dict[str, float] | None = None) -> dict:
+        scales = (
+            kv_scales
+            if kv_scales is not None
+            else getattr(self, "_pending_kv_cache_scales", {})
+        )
+        modules = self._attention_module_map()
+        resolved = []
+        missing = []
+
+        for transport_name, raw_value in scales.items():
+            parsed = self._parse_kv_scale_name(transport_name)
+            if parsed is None:
+                missing.append(transport_name)
+                continue
+            module_name, kind = parsed
+            module = modules.get(module_name) or modules.get(
+                self._without_model_prefix(module_name)
+            )
+            if module is None:
+                missing.append(transport_name)
+                continue
+
+            raw_float = float(raw_value)
+            if kind == "q" and raw_float != 1.0 and not self._q_scale_supported(module):
+                backend_name = self._get_attention_backend_name(module)
+                raise RuntimeError(
+                    f"Attention backend {backend_name} does not support non-1.0 q_scale for {transport_name}."
+                )
+            value = self._platform_adjust_scale(raw_float)
+            resolved.append((module_name, module, kind, value))
+
+        if missing:
+            raise KeyError(
+                "Failed to apply FP8 KV cache scales for missing or malformed keys: "
+                f"{missing[:8]}"
+            )
+
+        applied = {"q": 0, "k": 0, "v": 0}
+        applied_values = []
+        backends = {}
+        for module_name, module, kind, value in resolved:
+            if not math.isfinite(value) or value <= 0.0:
+                raise ValueError(
+                    f"Invalid FP8 KV cache scale for {module_name}.{kind}: {value}"
+                )
+            self._set_scale(module, kind, value)
+            self._invalidate_attention_scale_cache(module)
+            applied[kind] += 1
+            applied_values.append(value)
+            backends[module_name] = self._get_attention_backend_name(module)
+
+        non_default = sum(
+            not math.isclose(value, 1.0, rel_tol=0.0, abs_tol=1e-12)
+            for value in applied_values
+        )
+        if applied_values and non_default == 0:
+            raise RuntimeError(
+                "FP8 KV cache scales are all 1.0; calibrated scales were not applied."
+            )
+        summary = {
+            "applied": applied,
+            "total": sum(applied.values()),
+            "min": min(applied_values) if applied_values else None,
+            "max": max(applied_values) if applied_values else None,
+            "non_default": non_default,
+            "backends": backends,
+        }
+        if kv_scales is None:
+            self._pending_kv_cache_scales = {}
+        print(
+            "FP8 KV cache scales applied: "
+            f"total={summary['total']}, applied={summary['applied']}, "
+            f"min={summary['min']}, max={summary['max']}, "
+            f"non_default={summary['non_default']}",
+            flush=True,
+        )
+        return summary
+
+    def get_kv_cache_scale_snapshot(self) -> dict[str, dict[str, float | str]]:
+        snapshot: dict[str, dict[str, float | str]] = {}
+        for module_name, module in self._attention_module_map().items():
+            if module_name.startswith("model."):
+                continue
+            transport_prefix = f"model.{module_name}"
+            if transport_prefix.endswith(".self_attn.attn"):
+                base = transport_prefix.removesuffix(".attn")
+                names = {
+                    "q": f"{transport_prefix}.q_scale",
+                    "k": f"{base}.k_scale",
+                    "v": f"{base}.v_scale",
+                }
+            else:
+                names = {
+                    "q": f"{transport_prefix}.q_scale",
+                    "k": f"{transport_prefix}.k_scale",
+                    "v": f"{transport_prefix}.v_scale",
+                }
+            backend = self._get_attention_backend_name(module)
+            for kind, key in names.items():
+                tensor = getattr(module, f"_{kind}_scale")
+                snapshot[key] = {
+                    "tensor": float(
+                        tensor.detach().float().cpu().reshape(-1)[0].item()
+                    ),
+                    "host": float(getattr(module, f"_{kind}_scale_float")),
+                    "backend": backend,
+                }
+        return snapshot
 
     def prepare_refit_info(self, state_dict_info: dict[str, Any]) -> None:
         """Prepare state dict metadata for weight refitting and IPC streaming.
@@ -326,6 +525,11 @@ class VllmInternalWorkerExtension:
             for idx, (key, weight) in enumerate(weights):
                 weights[idx] = (fix_gemma3_vision_weight_name(key), weight)
 
+        weights = [
+            (name, weight)
+            for name, weight in weights
+            if self._parse_kv_scale_name(name) is None
+        ]
         policy_weights, draft_weights = self._split_policy_and_draft_weights(weights)
         if fp8.is_fp8_model(self.model_runner.vllm_config):
             fp8.load_weights(policy_weights, self.model_runner)

--- a/nemo_rl/models/generation/vllm/vllm_generation.py
+++ b/nemo_rl/models/generation/vllm/vllm_generation.py
@@ -1076,6 +1076,33 @@ class VllmGeneration(GenerationInterface):
             print(f"Error invalidating vLLM caches: {e}")
             return False
 
+    def apply_kv_cache_scales(self, kv_scales: dict[str, float] | None = None) -> dict:
+        """Apply authoritative FP8 KV cache scales after colocated KV-cache wake."""
+        if self.cfg["vllm_cfg"].get("async_engine", False):
+            raise RuntimeError(
+                "apply_kv_cache_scales can only be used with async_engine=False."
+            )
+        futures = self.worker_group.run_all_workers_single_data(
+            "apply_kv_cache_scales",
+            run_rank_0_only_axes=["tensor_parallel", "pipeline_parallel"],
+            kv_scales=kv_scales,
+        )
+        results = ray.get(futures)
+        return {"workers": [result for result in results if result is not None]}
+
+    def get_kv_cache_scale_snapshot(self) -> dict:
+        """Return named FP8 KV cache scale snapshots from vLLM workers."""
+        if self.cfg["vllm_cfg"].get("async_engine", False):
+            raise RuntimeError(
+                "get_kv_cache_scale_snapshot can only be used with async_engine=False."
+            )
+        futures = self.worker_group.run_all_workers_single_data(
+            "get_kv_cache_scale_snapshot",
+            run_rank_0_only_axes=["tensor_parallel", "pipeline_parallel"],
+        )
+        results = ray.get(futures)
+        return {"workers": [result for result in results if result is not None]}
+
     @property
     def requires_kv_scale_sync(self) -> bool:
         """Check if KV cache scales should be synchronized during refit.

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -256,6 +256,7 @@ class BaseVllmGenerationWorker:
                 "please run at least once with the environment variable NRL_FORCE_REBUILD_VENVS=true set to force the rebuild of the environment."
             )
         vllm_kwargs: dict[str, Any] = copy.deepcopy(self.cfg.get("vllm_kwargs", {}))
+        vllm_kwargs["kv_cache_dtype"] = self.cfg["vllm_cfg"]["kv_cache_dtype"]
 
         # Calculate total parallel size (TP * PP)
         model_parallel_size = self.tensor_parallel_size * self.pipeline_parallel_size
@@ -917,6 +918,36 @@ class VllmGenerationWorkerImpl(BaseVllmGenerationWorker):
 
             traceback.print_exc()
             return False
+
+    def apply_kv_cache_scales(self, kv_scales: dict[str, float] | None = None) -> dict:
+        """Apply authoritative FP8 KV cache scales inside vLLM workers."""
+        assert self.llm is not None, (
+            "Attempting to apply KV cache scales with either an uninitialized vLLM or non-model-owner"
+        )
+        if self.cfg["vllm_cfg"]["async_engine"]:
+            raise RuntimeError(
+                "apply_kv_cache_scales can only be used with async_engine=False."
+            )
+        result_or_coro = self.llm.collective_rpc(
+            "apply_kv_cache_scales",
+            args=(kv_scales,),
+        )
+        return cast(dict, result_or_coro[0])
+
+    def get_kv_cache_scale_snapshot(self) -> dict:
+        """Return a named snapshot of vLLM FP8 KV cache scales."""
+        assert self.llm is not None, (
+            "Attempting to snapshot KV cache scales with either an uninitialized vLLM or non-model-owner"
+        )
+        if self.cfg["vllm_cfg"]["async_engine"]:
+            raise RuntimeError(
+                "get_kv_cache_scale_snapshot can only be used with async_engine=False."
+            )
+        result_or_coro = self.llm.collective_rpc(
+            "get_kv_cache_scale_snapshot",
+            args=tuple(),
+        )
+        return cast(dict, result_or_coro[0])
 
     def reset_prefix_cache(self):
         """Reset the prefix cache of vLLM engine."""

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -134,6 +134,10 @@ def _model_self_packs_for_cp(model: Any) -> bool:
     return any(isinstance(chunk, Qwen3VLModel) for chunk in chunks)
 
 
+def _is_self_attention_core_attention_module_name(name: str) -> bool:
+    return name.endswith("self_attention.core_attention")
+
+
 # Classes with @ray.remote can't be inherited from, so we split the implementation out.
 # This is useful when using worker extension classes.
 class MegatronPolicyWorkerImpl(
@@ -1275,10 +1279,6 @@ class MegatronPolicyWorkerImpl(
         This helper is used by both IPC-based streaming and collective broadcast
         so that the logic for adding KV scales stays consistent in one place.
         """
-        from nemo_rl.models.generation.vllm.quantization.fp8_train_utils import (
-            get_vllm_qkv_scale_names,
-        )
-
         base_iter = self.megatron_bridge.export_hf_weights(
             [self.model],
             show_progress=False,
@@ -1315,14 +1315,7 @@ class MegatronPolicyWorkerImpl(
         if not use_fp8_kv_cache:
             return
 
-        # Append KV (and potentially Q) scale entries to match metadata.
-        num_layers = self.megatron_bridge.transformer_config.num_layers
-        keys: list[str] = []
-        for layer_idx in range(num_layers):
-            scale_names = get_vllm_qkv_scale_names(layer_idx)
-            keys.extend(scale_names.values())
-
-        for param_name in keys:
+        for param_name in self._get_vllm_kv_scale_names(kv_scales):
             if kv_scales and param_name in kv_scales:
                 scale_value = kv_scales[param_name]
             else:
@@ -1331,6 +1324,65 @@ class MegatronPolicyWorkerImpl(
                 scale_value, dtype=torch.float32, device="cuda"
             ).reshape(1)
             yield param_name, scale_tensor
+
+    def _get_vllm_kv_scale_names(
+        self,
+        kv_scales: Optional[dict[str, float]] = None,
+    ) -> list[str]:
+        """Return vLLM transport keys for attention KV/Q scales."""
+        from nemo_rl.models.generation.vllm.quantization.fp8_train_utils import (
+            get_attention_layer_indices_from_param_names,
+            get_vllm_qkv_scale_names,
+            validate_vllm_qkv_scale_completeness,
+        )
+
+        param_names = []
+        for task in getattr(self, "refit_conversion_tasks", []):
+            mapping = getattr(task, "mapping", None)
+            hf_param = getattr(mapping, "hf_param", None)
+            if isinstance(hf_param, str):
+                param_names.append(hf_param)
+            param_name = getattr(task, "param_name", None)
+            if isinstance(param_name, str):
+                param_names.append(param_name)
+
+        layer_indices = get_attention_layer_indices_from_param_names(param_names)
+        if not layer_indices:
+            transformer_config = self.megatron_bridge.transformer_config
+            layer_types = getattr(transformer_config, "layers_block_type", None)
+            if layer_types is None:
+                layer_types = getattr(transformer_config, "layer_types", None)
+            if isinstance(layer_types, (list, tuple)):
+                layer_indices = [
+                    idx
+                    for idx, layer_type in enumerate(layer_types)
+                    if "attention" in str(layer_type).lower()
+                ]
+            elif layer_types is not None:
+                raise RuntimeError(
+                    "Unable to derive attention layer ids for FP8 KV scale emission "
+                    f"from layer metadata type {type(layer_types).__name__}."
+                )
+            else:
+                num_layers = getattr(transformer_config, "num_layers", None)
+                if isinstance(num_layers, int) and num_layers > 0:
+                    layer_indices = list(range(num_layers))
+
+        if not layer_indices:
+            raise RuntimeError(
+                "Unable to derive attention layer ids for FP8 KV scale emission. "
+                "Provide calibrated kv_scales or ensure refit conversion tasks include "
+                "HF attention parameter names."
+            )
+
+        keys: list[str] = []
+        for layer_idx in layer_indices:
+            keys.extend(get_vllm_qkv_scale_names(layer_idx).values())
+
+        if kv_scales is not None:
+            validate_vllm_qkv_scale_completeness(keys, kv_scales)
+            return list(kv_scales)
+        return keys
 
     @torch.no_grad()
     @wrap_with_nvtx_name("megatron_policy_worker/stream_weights_via_ipc_zmq")
@@ -1850,7 +1902,7 @@ class MegatronPolicyWorkerImpl(
         matched_modules = []
         # Try to register forward_pre_hook on core_attention first
         for name, module in self.model.named_modules():
-            if "self_attention.core_attention" in name:
+            if _is_self_attention_core_attention_module_name(name):
                 try:
                     handle = module.register_forward_pre_hook(
                         _pre_hook_builder_core_attention(name)

--- a/nemo_rl/weight_sync/interfaces.py
+++ b/nemo_rl/weight_sync/interfaces.py
@@ -84,9 +84,11 @@ class WeightSynchronizer(ABC):
         Args:
             timer: Optional Timer for profiling individual phases.
             kv_scales: Optional KV cache scales for FP8 quantization.
-                **Note**: Only honored by the NCCL collective transport,
-                which forwards them to ``policy.broadcast_weights_for_collective()``.
-                IPC and HTTP transports ignore this parameter.
+                The NCCL collective transport forwards them to
+                ``policy.broadcast_weights_for_collective()``. The IPC
+                transport forwards them to ``policy.stream_weights_via_ipc_zmq()``
+                and reapplies them after the colocated vLLM KV-cache wake.
+                HTTP transport ignores this parameter.
 
         Raises:
             RuntimeError: If the weight transfer fails.

--- a/nemo_rl/weight_sync/ipc_weight_synchronizer.py
+++ b/nemo_rl/weight_sync/ipc_weight_synchronizer.py
@@ -33,6 +33,9 @@ from typing import Any, Optional
 
 import ray
 
+from nemo_rl.models.generation.vllm.utils import (
+    can_sync_apply_fp8_kv,
+)
 from nemo_rl.utils.timer import Timer
 from nemo_rl.weight_sync.interfaces import WeightSynchronizer
 
@@ -83,7 +86,8 @@ class IPCWeightSynchronizer(WeightSynchronizer):
                 buffer_size_bytes = self._compute_buffer_size()
 
                 futures_train = self._policy.stream_weights_via_ipc_zmq(
-                    buffer_size_bytes=buffer_size_bytes
+                    buffer_size_bytes=buffer_size_bytes,
+                    kv_scales=kv_scales,
                 )
                 futures_inference = self._generation.update_weights_via_ipc_zmq()
 
@@ -100,6 +104,13 @@ class IPCWeightSynchronizer(WeightSynchronizer):
         finally:
             self._policy.offload_after_refit()
             self._generation.prepare_for_generation(tags=["kv_cache"])
+            if (
+                sync_succeeded
+                and kv_scales is not None
+                and can_sync_apply_fp8_kv(getattr(self._generation, "cfg", {}))
+                and hasattr(self._generation, "apply_kv_cache_scales")
+            ):
+                self._generation.apply_kv_cache_scales(kv_scales)
 
         self._stale = not sync_succeeded
 

--- a/tests/unit/algorithms/test_distillation.py
+++ b/tests/unit/algorithms/test_distillation.py
@@ -227,6 +227,82 @@ def test_distillation_train_max_steps(mock_components):
     assert mock_components["student_policy"].train.call_count == 5
 
 
+def test_distillation_rejects_initial_validation_before_fp8_kv_calibration(
+    mock_components,
+):
+    master_config = mock_components["master_config"]
+    master_config.distillation["max_num_steps"] = 0
+    master_config.distillation["val_at_start"] = True
+    student_generation = MagicMock()
+    student_generation.requires_kv_scale_sync = True
+
+    with pytest.raises(ValueError, match="val_at_start=True"):
+        distillation_train(
+            mock_components["student_policy"],
+            mock_components["teacher_policy"],
+            student_generation,
+            mock_components["train_dataloader"],
+            mock_components["val_dataloader"],
+            mock_components["tokenizer"],
+            mock_components["loss_fn"],
+            mock_components["task_to_env"],
+            mock_components["val_task_to_env"],
+            mock_components["logger"],
+            mock_components["checkpointer"],
+            _default_distillation_save_state(),
+            master_config,
+        )
+
+
+def test_distillation_calibrates_and_refits_fp8_kv_scales(mock_components):
+    master_config = mock_components["master_config"]
+    master_config.distillation["max_num_steps"] = 1
+    master_config.distillation["max_num_epochs"] = 1
+    master_config.distillation["val_period"] = 0
+    student_generation = MagicMock()
+    student_generation.requires_kv_scale_sync = True
+    kv_scales = {
+        "model.layers.0.self_attn.attn.q_scale": 0.001,
+        "model.layers.0.self_attn.k_scale": 0.002,
+        "model.layers.0.self_attn.v_scale": 0.003,
+    }
+    mock_components["student_policy"].calibrate_qkv_fp8_scales.return_value = {
+        "layers": kv_scales
+    }
+    rollout_batch = next(iter(mock_components["train_dataloader"]))
+
+    with (
+        patch(
+            "nemo_rl.algorithms.distillation.run_multi_turn_rollout",
+            return_value=(rollout_batch, {"mean_gen_tokens_per_sample": 3.0}),
+        ),
+        patch("nemo_rl.algorithms.distillation.refit_policy_generation") as mock_refit,
+    ):
+        distillation_train(
+            mock_components["student_policy"],
+            mock_components["teacher_policy"],
+            student_generation,
+            mock_components["train_dataloader"],
+            mock_components["val_dataloader"],
+            mock_components["tokenizer"],
+            mock_components["loss_fn"],
+            mock_components["task_to_env"],
+            mock_components["val_task_to_env"],
+            mock_components["logger"],
+            mock_components["checkpointer"],
+            _default_distillation_save_state(),
+            master_config,
+        )
+
+    assert mock_components["student_policy"].calibrate_qkv_fp8_scales.call_count == 2
+    for call in mock_components[
+        "student_policy"
+    ].calibrate_qkv_fp8_scales.call_args_list:
+        assert call.kwargs["include_q"] is True
+    mock_refit.assert_called_once()
+    assert mock_refit.call_args.kwargs["kv_scales"] == kv_scales
+
+
 def test_distillation_train_uses_nemo_gym_rollout_when_enabled(mock_components):
     master_config = mock_components["master_config"]
     master_config.distillation["max_num_steps"] = 1

--- a/tests/unit/algorithms/test_fp8_kv_initial_validation.py
+++ b/tests/unit/algorithms/test_fp8_kv_initial_validation.py
@@ -1,0 +1,328 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nemo_rl.algorithms.grpo import (
+    MasterConfig as GRPOMasterConfig,
+)
+from nemo_rl.algorithms.grpo import (
+    _default_grpo_save_state,
+    _validate_calibrated_fp8_kv_scales,
+    grpo_train,
+    refit_policy_generation,
+)
+from nemo_rl.algorithms.grpo_sync import grpo_train_sync
+from nemo_rl.algorithms.loss.loss_functions import (
+    ClippedPGLossConfig,
+    MseValueLossConfig,
+)
+from nemo_rl.algorithms.ppo import (
+    MasterConfig as PPOMasterConfig,
+)
+from nemo_rl.algorithms.ppo import (
+    _default_ppo_save_state,
+    ppo_train,
+)
+from nemo_rl.models.generation.vllm.utils import (
+    can_sync_apply_fp8_kv,
+    can_sync_apply_modelopt_real_quant_fp8_kv,
+    is_modelopt_qarl_fp8_kv,
+    is_modelopt_real_quant_fp8_kv,
+)
+
+
+def _kv_sync_policy_generation():
+    policy_generation = MagicMock()
+    policy_generation.requires_kv_scale_sync = True
+    return policy_generation
+
+
+def test_modelopt_real_quant_fp8_kv_detection():
+    sync_cfg = {
+        "backend": "vllm",
+        "quant_cfg": "NVFP4_DEFAULT_CFG",
+        "real_quant": True,
+        "vllm_cfg": {"kv_cache_dtype": "fp8_e4m3"},
+    }
+    async_cfg = {
+        **sync_cfg,
+        "vllm_cfg": {"kv_cache_dtype": "fp8_e4m3", "async_engine": True},
+    }
+
+    assert is_modelopt_real_quant_fp8_kv(sync_cfg)
+    assert can_sync_apply_fp8_kv(sync_cfg)
+    assert can_sync_apply_modelopt_real_quant_fp8_kv(sync_cfg)
+    assert is_modelopt_qarl_fp8_kv({"quant_cfg": "NVFP4_DEFAULT_CFG"}, sync_cfg)
+    assert not is_modelopt_qarl_fp8_kv({"quant_cfg": None}, sync_cfg)
+    assert is_modelopt_real_quant_fp8_kv(async_cfg)
+    assert not can_sync_apply_fp8_kv(async_cfg)
+    assert not can_sync_apply_modelopt_real_quant_fp8_kv(async_cfg)
+    assert can_sync_apply_fp8_kv(
+        {
+            "backend": "vllm",
+            "vllm_cfg": {"kv_cache_dtype": "fp8_e4m3", "async_engine": False},
+        }
+    )
+    assert not is_modelopt_real_quant_fp8_kv(
+        {
+            "backend": "vllm",
+            "quant_cfg": "NVFP4_DEFAULT_CFG",
+            "real_quant": False,
+            "vllm_cfg": {"kv_cache_dtype": "fp8_e4m3"},
+        }
+    )
+
+
+def test_validate_calibrated_fp8_kv_scales_accepts_positive_non_default_scales():
+    summary = _validate_calibrated_fp8_kv_scales(
+        {
+            "model.layers.0.self_attn.attn.q_scale": 0.001,
+            "model.layers.0.self_attn.k_scale": 0.002,
+            "model.layers.0.self_attn.v_scale": 0.003,
+        },
+        context="unit test",
+    )
+
+    assert summary["total"] == 3
+    assert summary["counts"] == {"q": 1, "k": 1, "v": 1, "unknown": 0}
+    assert summary["non_default"] == 3
+    assert summary["zero_or_negative"] == 0
+    assert summary["non_finite"] == 0
+
+
+@pytest.mark.parametrize(
+    "kv_scales",
+    [
+        {},
+        {"model.layers.0.self_attn.k_scale": 0.0},
+        {"model.layers.0.self_attn.k_scale": float("nan")},
+        {
+            "model.layers.0.self_attn.attn.q_scale": 1.0,
+            "model.layers.0.self_attn.k_scale": 1.0,
+            "model.layers.0.self_attn.v_scale": 1.0,
+        },
+        {
+            "model.layers.0.self_attn.attn.q_scale": 0.001,
+            "model.layers.0.self_attn.k_scale": 0.002,
+        },
+        {
+            "model.layers.0.self_attn.attn.q_scale": 0.001,
+            "model.layers.0.self_attn.k_scale": 0.002,
+            "model.layers.0.self_attn.v_scale": 0.003,
+            "model.layers.0.self_attn.extra_scale": 0.004,
+        },
+    ],
+)
+def test_validate_calibrated_fp8_kv_scales_rejects_invalid_or_incomplete_scales(
+    kv_scales,
+):
+    with pytest.raises(RuntimeError):
+        _validate_calibrated_fp8_kv_scales(kv_scales, context="unit test")
+
+
+@patch("nemo_rl.algorithms.grpo.ray")
+def test_refit_policy_generation_colocated_ipc_passes_and_applies_kv_scales(mock_ray):
+    mock_ray.get.side_effect = [None, [True]]
+    policy = MagicMock()
+    policy.stream_weights_via_ipc_zmq.return_value = ["train-future"]
+    policy_generation = MagicMock()
+    policy_generation.cfg = {
+        "backend": "vllm",
+        "vllm_cfg": {"kv_cache_dtype": "fp8_e4m3"},
+    }
+    policy_generation.update_weights_via_ipc_zmq.return_value = ["infer-future"]
+    kv_scales = {"model.layers.0.self_attn.k_scale": 2.0}
+
+    refit_policy_generation(
+        policy,
+        policy_generation,
+        colocated_inference=True,
+        _refit_buffer_size_gb=1,
+        kv_scales=kv_scales,
+    )
+
+    policy.stream_weights_via_ipc_zmq.assert_called_once()
+    assert policy.stream_weights_via_ipc_zmq.call_args.kwargs["kv_scales"] == kv_scales
+    policy_generation.prepare_for_generation.assert_any_call(tags=["weights"])
+    policy_generation.prepare_for_generation.assert_any_call(tags=["kv_cache"])
+    policy_generation.apply_kv_cache_scales.assert_called_once_with(kv_scales)
+
+
+@patch("nemo_rl.algorithms.grpo.ray")
+def test_refit_policy_generation_colocated_ipc_skips_sync_kv_apply_for_async_vllm(
+    mock_ray,
+):
+    mock_ray.get.side_effect = [None, [True]]
+    policy = MagicMock()
+    policy.stream_weights_via_ipc_zmq.return_value = ["train-future"]
+    policy_generation = MagicMock()
+    policy_generation.cfg = {
+        "backend": "vllm",
+        "quant_cfg": "NVFP4_DEFAULT_CFG",
+        "real_quant": True,
+        "vllm_cfg": {"kv_cache_dtype": "fp8_e4m3", "async_engine": True},
+    }
+    policy_generation.update_weights_via_ipc_zmq.return_value = ["infer-future"]
+    kv_scales = {"model.layers.0.self_attn.k_scale": 2.0}
+
+    refit_policy_generation(
+        policy,
+        policy_generation,
+        colocated_inference=True,
+        _refit_buffer_size_gb=1,
+        kv_scales=kv_scales,
+    )
+
+    assert policy.stream_weights_via_ipc_zmq.call_args.kwargs["kv_scales"] == kv_scales
+    policy_generation.prepare_for_generation.assert_any_call(tags=["kv_cache"])
+    policy_generation.apply_kv_cache_scales.assert_not_called()
+
+
+def test_grpo_train_rejects_initial_validation_with_kv_scale_sync():
+    master_config = GRPOMasterConfig.model_construct(
+        **{
+            "policy": {
+                "generation": {"colocated": {"enabled": True}},
+                "make_sequence_length_divisible_by": 1,
+            },
+            "loss_fn": ClippedPGLossConfig(),
+            "env": {},
+            "data": {"use_multiple_dataloader": False},
+            "grpo": {
+                "max_num_steps": 0,
+                "max_num_epochs": 1,
+                "val_at_start": True,
+                "val_at_end": False,
+                "val_period": 0,
+                "adv_estimator": {
+                    "name": "grpo",
+                    "normalize_rewards": False,
+                    "use_leave_one_out_baseline": False,
+                    "minus_baseline": True,
+                },
+            },
+            "logger": {"num_val_samples_to_print": 0},
+            "cluster": {},
+            "checkpointing": {"checkpoint_must_save_by": None},
+        }
+    )
+
+    with pytest.raises(ValueError, match="val_at_start=True"):
+        grpo_train(
+            policy=MagicMock(),
+            policy_generation=_kv_sync_policy_generation(),
+            wrapped_dataloader=MagicMock(),
+            val_dataloader=MagicMock(),
+            tokenizer=MagicMock(),
+            loss_fn=MagicMock(),
+            task_to_env={},
+            val_task_to_env={},
+            logger=MagicMock(),
+            checkpointer=MagicMock(),
+            grpo_save_state=_default_grpo_save_state(),
+            master_config=master_config,
+        )
+
+
+def test_grpo_sync_train_rejects_initial_validation_with_kv_scale_sync():
+    master_config = GRPOMasterConfig.model_construct(
+        **{
+            "policy": {
+                "generation": {"colocated": {"enabled": True}},
+                "make_sequence_length_divisible_by": 1,
+            },
+            "loss_fn": ClippedPGLossConfig(),
+            "env": {},
+            "data": {"use_multiple_dataloader": False},
+            "grpo": {
+                "max_num_steps": 0,
+                "max_num_epochs": 1,
+                "val_at_start": True,
+                "val_at_end": False,
+                "val_period": 0,
+            },
+            "logger": {"num_val_samples_to_print": 0},
+            "cluster": {},
+            "checkpointing": {"checkpoint_must_save_by": None},
+        }
+    )
+
+    with pytest.raises(ValueError, match="val_at_start=True"):
+        grpo_train_sync(
+            policy=MagicMock(),
+            policy_generation=_kv_sync_policy_generation(),
+            wrapped_dataloader=MagicMock(),
+            val_dataloader=MagicMock(),
+            tokenizer=MagicMock(),
+            loss_fn=MagicMock(),
+            task_to_env={},
+            val_task_to_env={},
+            logger=MagicMock(),
+            checkpointer=MagicMock(),
+            grpo_save_state=_default_grpo_save_state(),
+            master_config=master_config,
+        )
+
+
+def test_ppo_train_rejects_initial_validation_with_kv_scale_sync():
+    master_config = PPOMasterConfig.model_construct(
+        **{
+            "policy": {
+                "generation": {"colocated": {"enabled": True}},
+                "make_sequence_length_divisible_by": 1,
+            },
+            "value": {},
+            "loss_fn": ClippedPGLossConfig(),
+            "value_loss_fn": MseValueLossConfig(),
+            "env": {},
+            "data": {"use_multiple_dataloader": False},
+            "ppo": {
+                "max_num_steps": 0,
+                "max_num_epochs": 1,
+                "ppo_epochs": 1,
+                "policy_training_start_step": 0,
+                "val_at_start": True,
+                "val_at_end": False,
+                "val_period": 0,
+                "adv_estimator": {
+                    "name": "raw_reward",
+                    "normalize_advantages": False,
+                },
+            },
+            "logger": {"num_val_samples_to_print": 0},
+            "cluster": {},
+            "checkpointing": {"checkpoint_must_save_by": None},
+        }
+    )
+
+    with pytest.raises(ValueError, match="val_at_start=True"):
+        ppo_train(
+            policy=MagicMock(),
+            policy_generation=_kv_sync_policy_generation(),
+            value_model=MagicMock(),
+            dataloader=MagicMock(),
+            val_dataloader=MagicMock(),
+            tokenizer=MagicMock(),
+            loss_fn=MagicMock(),
+            value_loss_fn=MagicMock(),
+            task_to_env={},
+            val_task_to_env={},
+            logger=MagicMock(),
+            checkpointer=MagicMock(),
+            ppo_save_state=_default_ppo_save_state(),
+            master_config=master_config,
+        )

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -36,6 +36,7 @@ from nemo_rl.models.generation.interfaces import (
     GenerationDatumSpec,
 )
 from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration
+from nemo_rl.models.generation.vllm.utils import validate_vllm_fp8_kv_cache_config
 from nemo_rl.models.generation.vllm.vllm_worker import (
     _resolve_enable_prefix_caching,
 )
@@ -136,6 +137,65 @@ basic_dtensor_test_config: PolicyConfig = {
     "make_sequence_length_divisible_by": 1,
     "generation": deepcopy(basic_vllm_test_config),
 }
+
+
+def test_apply_kv_cache_scales_dispatches_rank0_collective_rpc(monkeypatch):
+    vllm_generation = object.__new__(VllmGeneration)
+    vllm_generation.cfg = {"vllm_cfg": {"async_engine": False}}
+    vllm_generation.worker_group = MagicMock()
+    vllm_generation.worker_group.run_all_workers_single_data.return_value = [
+        "worker-future",
+        None,
+    ]
+    monkeypatch.setattr(ray, "get", lambda futures: [{"applied": {"k": 1}}, None])
+
+    result = vllm_generation.apply_kv_cache_scales(
+        {"model.layers.0.self_attn.k_scale": 2.0}
+    )
+
+    vllm_generation.worker_group.run_all_workers_single_data.assert_called_once_with(
+        "apply_kv_cache_scales",
+        run_rank_0_only_axes=["tensor_parallel", "pipeline_parallel"],
+        kv_scales={"model.layers.0.self_attn.k_scale": 2.0},
+    )
+    assert result == {"workers": [{"applied": {"k": 1}}]}
+
+
+def test_apply_kv_cache_scales_rejects_async_engine():
+    vllm_generation = object.__new__(VllmGeneration)
+    vllm_generation.cfg = {"vllm_cfg": {"async_engine": True}}
+    vllm_generation.worker_group = MagicMock()
+
+    with pytest.raises(RuntimeError, match="async_engine=False"):
+        vllm_generation.apply_kv_cache_scales({})
+
+
+def test_get_kv_cache_scale_snapshot_dispatches_rank0_collective_rpc(monkeypatch):
+    vllm_generation = object.__new__(VllmGeneration)
+    vllm_generation.cfg = {"vllm_cfg": {"async_engine": False}}
+    vllm_generation.worker_group = MagicMock()
+    vllm_generation.worker_group.run_all_workers_single_data.return_value = [
+        "worker-future",
+        None,
+    ]
+    monkeypatch.setattr(ray, "get", lambda futures: [{"scale": 2.0}, None])
+
+    result = vllm_generation.get_kv_cache_scale_snapshot()
+
+    vllm_generation.worker_group.run_all_workers_single_data.assert_called_once_with(
+        "get_kv_cache_scale_snapshot",
+        run_rank_0_only_axes=["tensor_parallel", "pipeline_parallel"],
+    )
+    assert result == {"workers": [{"scale": 2.0}]}
+
+
+def test_get_kv_cache_scale_snapshot_rejects_async_engine():
+    vllm_generation = object.__new__(VllmGeneration)
+    vllm_generation.cfg = {"vllm_cfg": {"async_engine": True}}
+    vllm_generation.worker_group = MagicMock()
+
+    with pytest.raises(RuntimeError, match="async_engine=False"):
+        vllm_generation.get_kv_cache_scale_snapshot()
 
 
 def test_resolve_enable_prefix_caching_respects_explicit_config(monkeypatch):
@@ -2445,9 +2505,26 @@ def test_vllm_generation_with_megatron_training(
     if vllm_precision == "fp8":
         skip_fp8_known_failures()
 
-    # Skip invalid configurations: kv_cache_dtype=fp8 requires precision=fp8
-    if kv_cache_dtype == "fp8" and vllm_precision != "fp8":
-        pytest.skip("kv_cache_dtype='fp8' requires precision='fp8'")
+    try:
+        validate_vllm_fp8_kv_cache_config(
+            {
+                "quant_cfg": None,
+                "dtensor_cfg": {"enabled": False},
+                "megatron_cfg": {"pipeline_model_parallel_size": 1},
+            },
+            {
+                "backend": "vllm",
+                "real_quant": False,
+                "quant_cfg": None,
+                "vllm_cfg": {
+                    "precision": vllm_precision,
+                    "kv_cache_dtype": kv_cache_dtype or "auto",
+                },
+            },
+            use_async_rollouts=False,
+        )
+    except AssertionError as exc:
+        pytest.skip(str(exc))
 
     if cluster.num_gpus_per_node < tensor_parallel_size:
         pytest.skip(f"Need at least {tensor_parallel_size} GPUs for this test")

--- a/tests/unit/models/generation/test_vllm_modelopt_real_quant_config.py
+++ b/tests/unit/models/generation/test_vllm_modelopt_real_quant_config.py
@@ -94,6 +94,70 @@ def _install_fake_modelopt_tensor_quantizer(monkeypatch):
     ].tensor_quantizer = tensor_quantizer_module
 
 
+def _install_fake_vllm_platform(monkeypatch, *, fp8_fnuz=False):
+    platforms_module = types.ModuleType("vllm.platforms")
+    platforms_module.current_platform = types.SimpleNamespace(
+        is_fp8_fnuz=lambda: fp8_fnuz
+    )
+    monkeypatch.setitem(sys.modules, "vllm.platforms", platforms_module)
+
+
+class _FakeAttention(torch.nn.Module):
+    def __init__(self, backend_name="FLASHINFER"):
+        super().__init__()
+        self.register_buffer("_q_scale", torch.tensor(1.0))
+        self.register_buffer("_k_scale", torch.tensor(1.0))
+        self.register_buffer("_v_scale", torch.tensor(1.0))
+        self._q_scale_float = 1.0
+        self._k_scale_float = 1.0
+        self._v_scale_float = 1.0
+        self._o_scale_float = 7.0
+        self.impl = types.SimpleNamespace(
+            bmm1_scale=2.0,
+            bmm2_scale=3.0,
+            o_sf_scale=4.0,
+        )
+        self._backend = types.SimpleNamespace(get_name=lambda: backend_name)
+
+    def get_attn_backend(self):
+        return self._backend
+
+
+def _make_extension_with_attention(backend, attention):
+    extension = object.__new__(backend.VllmQuantInternalWorkerExtension)
+    model = torch.nn.Module()
+    extension.model_runner = types.SimpleNamespace(
+        model=model,
+        vllm_config=types.SimpleNamespace(
+            compilation_config=types.SimpleNamespace(
+                static_forward_context={"model.layers.0.self_attn.attn": attention}
+            ),
+            model_config=types.SimpleNamespace(
+                hf_config=types.SimpleNamespace(quantization_config={"ignore": []})
+            ),
+        ),
+    )
+    return extension
+
+
+def _make_extension_with_named_attention(
+    backend, attention, module_name="layers.0.self_attn.attn"
+):
+    extension = object.__new__(backend.VllmQuantInternalWorkerExtension)
+    model = types.SimpleNamespace(
+        named_modules=lambda: iter([(module_name, attention)])
+    )
+    extension.model_runner = types.SimpleNamespace(
+        model=model,
+        vllm_config=types.SimpleNamespace(
+            model_config=types.SimpleNamespace(
+                hf_config=types.SimpleNamespace(quantization_config={"ignore": []})
+            ),
+        ),
+    )
+    return extension
+
+
 def test_w4a16_real_quant_config_keeps_weight_only_default():
     cfg = build_vllm_modelopt_nvfp4_config()
 
@@ -119,6 +183,17 @@ def test_w4a16_real_quant_config_keeps_weight_only_default():
         "*self_attention*",
         "*self_attn*",
     ]
+    assert "kv_cache_scheme" not in cfg
+
+
+def test_w4a16_real_quant_config_adds_fp8_kv_scheme_when_requested():
+    cfg = build_vllm_modelopt_nvfp4_config(kv_cache_dtype="fp8_e4m3")
+
+    assert cfg["kv_cache_scheme"] == {
+        "dynamic": False,
+        "num_bits": 8,
+        "type": "float",
+    }
 
 
 def test_real_quant_config_allows_explicit_ignore_override():
@@ -211,6 +286,7 @@ def test_configure_quant_engine_kwargs_for_real_quant(monkeypatch):
             "quant_cfg": "examples/modelopt/quant_configs/nvfp4_a16_mlp_only.yaml",
             "real_quant": True,
             "real_quant_ignore": ["lm_head"],
+            "vllm_cfg": {"kv_cache_dtype": "fp8_e4m3"},
         },
         llm_kwargs,
     )
@@ -221,7 +297,7 @@ def test_configure_quant_engine_kwargs_for_real_quant(monkeypatch):
     assert "worker_cls" not in llm_kwargs
     assert llm_kwargs["quantization"] == "modelopt"
     assert llm_kwargs["hf_overrides"]["quantization_config"] == (
-        build_vllm_modelopt_nvfp4_config(ignore=["lm_head"])
+        build_vllm_modelopt_nvfp4_config(ignore=["lm_head"], kv_cache_dtype="fp8_e4m3")
     )
 
 
@@ -511,6 +587,252 @@ def test_real_quant_load_weights_forwards_ignored_shape_mismatch(monkeypatch):
     assert forwarded == [("lm_head.weight", mismatched)]
 
 
+def test_real_quant_load_weights_records_and_filters_kv_scales(monkeypatch):
+    backend = _import_vllm_quant_backend(monkeypatch)
+
+    attention = _FakeAttention()
+    extension = _make_extension_with_attention(backend, attention)
+    forwarded = []
+
+    monkeypatch.setattr(
+        backend.VllmQuantInternalWorkerExtension,
+        "_is_real_quant_model",
+        lambda self: True,
+    )
+    monkeypatch.setattr(
+        backend.VllmInternalWorkerExtension,
+        "_load_weights",
+        lambda self, weights: forwarded.extend(weights) or "loaded",
+    )
+
+    assert (
+        extension._load_weights(
+            [
+                ("model.layers.0.self_attn.k_scale", torch.tensor([2.0])),
+                ("model.layers.0.mlp.down_proj.weight", torch.ones(1)),
+            ]
+        )
+        == "loaded"
+    )
+
+    assert extension._pending_kv_cache_scales == {
+        "model.layers.0.self_attn.k_scale": 2.0
+    }
+    assert len(forwarded) == 1
+    assert forwarded[0][0] == "model.layers.0.mlp.down_proj.weight"
+    torch.testing.assert_close(forwarded[0][1], torch.ones(1))
+
+
+def test_real_quant_load_weights_rejects_non_scalar_kv_scale(monkeypatch):
+    backend = _import_vllm_quant_backend(monkeypatch)
+
+    attention = _FakeAttention()
+    extension = _make_extension_with_attention(backend, attention)
+
+    monkeypatch.setattr(
+        backend.VllmQuantInternalWorkerExtension,
+        "_is_real_quant_model",
+        lambda self: True,
+    )
+
+    with pytest.raises(ValueError, match="Only scalar FP8 KV scale refit"):
+        extension._load_weights([("model.layers.0.self_attn.k_scale", torch.ones(2))])
+
+
+def test_real_quant_load_weights_records_self_attention_kv_scales(monkeypatch):
+    backend = _import_vllm_quant_backend(monkeypatch)
+
+    attention = _FakeAttention()
+    extension = _make_extension_with_named_attention(
+        backend, attention, module_name="layers.0.self_attention.attn"
+    )
+    forwarded = []
+
+    monkeypatch.setattr(
+        backend.VllmQuantInternalWorkerExtension,
+        "_is_real_quant_model",
+        lambda self: True,
+    )
+    monkeypatch.setattr(
+        backend.VllmInternalWorkerExtension,
+        "_load_weights",
+        lambda self, weights: forwarded.extend(weights) or "loaded",
+    )
+
+    assert (
+        extension._load_weights(
+            [
+                ("model.layers.0.self_attention.k_scale", torch.tensor([2.0])),
+                ("model.layers.0.mlp.down_proj.weight", torch.ones(1)),
+            ]
+        )
+        == "loaded"
+    )
+
+    assert extension._pending_kv_cache_scales == {
+        "model.layers.0.self_attention.k_scale": 2.0
+    }
+    assert [name for name, _ in forwarded] == ["model.layers.0.mlp.down_proj.weight"]
+
+
+def test_apply_kv_cache_scales_updates_buffers_and_invalidates_cache(monkeypatch):
+    backend = _import_vllm_quant_backend(monkeypatch)
+    _install_fake_vllm_platform(monkeypatch)
+
+    attention = _FakeAttention()
+    extension = _make_extension_with_attention(backend, attention)
+
+    summary = extension.apply_kv_cache_scales(
+        {
+            "model.layers.0.self_attn.attn.q_scale": 1.0,
+            "model.layers.0.self_attn.k_scale": 2.0,
+            "model.layers.0.self_attn.v_scale": 3.0,
+        }
+    )
+
+    assert summary["applied"] == {"q": 1, "k": 1, "v": 1}
+    torch.testing.assert_close(attention._q_scale, torch.tensor(1.0))
+    torch.testing.assert_close(attention._k_scale, torch.tensor(2.0))
+    torch.testing.assert_close(attention._v_scale, torch.tensor(3.0))
+    assert attention._q_scale_float == 1.0
+    assert attention._k_scale_float == 2.0
+    assert attention._v_scale_float == 3.0
+    assert attention.impl.bmm1_scale is None
+    assert attention.impl.bmm2_scale is None
+    assert attention.impl.o_sf_scale is None
+    assert attention._o_scale_float is None
+
+    snapshot = extension.get_kv_cache_scale_snapshot()
+    assert snapshot["model.layers.0.self_attn.attn.q_scale"]["host"] == 1.0
+    assert snapshot["model.layers.0.self_attn.k_scale"]["host"] == 2.0
+    assert snapshot["model.layers.0.self_attn.v_scale"]["host"] == 3.0
+
+
+def test_apply_kv_cache_scales_uses_named_modules_fallback(monkeypatch):
+    backend = _import_vllm_quant_backend(monkeypatch)
+    _install_fake_vllm_platform(monkeypatch)
+
+    attention = _FakeAttention()
+    extension = _make_extension_with_named_attention(backend, attention)
+
+    summary = extension.apply_kv_cache_scales({"model.layers.0.self_attn.k_scale": 2.0})
+
+    assert summary["applied"] == {"q": 0, "k": 1, "v": 0}
+    torch.testing.assert_close(attention._k_scale, torch.tensor(2.0))
+
+
+def test_apply_kv_cache_scales_clears_pending_after_implicit_apply(monkeypatch):
+    backend = _import_vllm_quant_backend(monkeypatch)
+    _install_fake_vllm_platform(monkeypatch)
+
+    attention = _FakeAttention()
+    extension = _make_extension_with_attention(backend, attention)
+    extension._pending_kv_cache_scales = {"model.layers.0.self_attn.k_scale": 2.0}
+
+    summary = extension.apply_kv_cache_scales()
+
+    assert summary["applied"] == {"q": 0, "k": 1, "v": 0}
+    assert extension._pending_kv_cache_scales == {}
+    torch.testing.assert_close(attention._k_scale, torch.tensor(2.0))
+
+
+def test_apply_kv_cache_scales_accepts_self_attention_keys(monkeypatch):
+    backend = _import_vllm_quant_backend(monkeypatch)
+    _install_fake_vllm_platform(monkeypatch)
+
+    attention = _FakeAttention()
+    extension = _make_extension_with_named_attention(
+        backend, attention, module_name="layers.0.self_attention.attn"
+    )
+
+    summary = extension.apply_kv_cache_scales(
+        {"model.layers.0.self_attention.k_scale": 2.0}
+    )
+
+    assert summary["applied"] == {"q": 0, "k": 1, "v": 0}
+    torch.testing.assert_close(attention._k_scale, torch.tensor(2.0))
+
+
+def test_apply_kv_cache_scales_validates_before_mutating(monkeypatch):
+    backend = _import_vllm_quant_backend(monkeypatch)
+    _install_fake_vllm_platform(monkeypatch)
+
+    attention = _FakeAttention()
+    extension = _make_extension_with_attention(backend, attention)
+
+    with pytest.raises(KeyError, match="missing or malformed"):
+        extension.apply_kv_cache_scales(
+            {
+                "model.layers.0.self_attn.k_scale": 2.0,
+                "model.layers.99.self_attn.k_scale": 3.0,
+            }
+        )
+
+    torch.testing.assert_close(attention._k_scale, torch.tensor(1.0))
+
+
+def test_apply_kv_cache_scales_rejects_nonpositive_scale(monkeypatch):
+    backend = _import_vllm_quant_backend(monkeypatch)
+    _install_fake_vllm_platform(monkeypatch)
+
+    attention = _FakeAttention()
+    extension = _make_extension_with_attention(backend, attention)
+
+    with pytest.raises(ValueError, match="Invalid FP8 KV cache scale"):
+        extension.apply_kv_cache_scales({"model.layers.0.self_attn.k_scale": 0.0})
+
+    torch.testing.assert_close(attention._k_scale, torch.tensor(1.0))
+
+
+def test_apply_kv_cache_scales_rejects_all_default_scales(monkeypatch):
+    backend = _import_vllm_quant_backend(monkeypatch)
+    _install_fake_vllm_platform(monkeypatch)
+
+    attention = _FakeAttention()
+    extension = _make_extension_with_attention(backend, attention)
+
+    with pytest.raises(RuntimeError, match="all 1.0"):
+        extension.apply_kv_cache_scales(
+            {
+                "model.layers.0.self_attn.attn.q_scale": 1.0,
+                "model.layers.0.self_attn.k_scale": 1.0,
+                "model.layers.0.self_attn.v_scale": 1.0,
+            }
+        )
+
+
+def test_apply_kv_cache_scales_rejects_non_unit_q_scale_on_unsupported_backend(
+    monkeypatch,
+):
+    backend = _import_vllm_quant_backend(monkeypatch)
+    _install_fake_vllm_platform(monkeypatch)
+
+    attention = _FakeAttention(backend_name="TRITON_ATTN")
+    extension = _make_extension_with_attention(backend, attention)
+
+    with pytest.raises(RuntimeError, match="does not support non-1.0 q_scale"):
+        extension.apply_kv_cache_scales({"model.layers.0.self_attn.attn.q_scale": 2.0})
+
+
+def test_apply_kv_cache_scales_checks_logical_q_scale_before_fnuz_adjustment(
+    monkeypatch,
+):
+    backend = _import_vllm_quant_backend(monkeypatch)
+    _install_fake_vllm_platform(monkeypatch, fp8_fnuz=True)
+
+    attention = _FakeAttention(backend_name="TRITON_ATTN")
+    extension = _make_extension_with_attention(backend, attention)
+
+    extension.apply_kv_cache_scales({"model.layers.0.self_attn.attn.q_scale": 1.0})
+    torch.testing.assert_close(attention._q_scale, torch.tensor(2.0))
+
+    attention = _FakeAttention(backend_name="TRITON_ATTN")
+    extension = _make_extension_with_attention(backend, attention)
+    with pytest.raises(RuntimeError, match="does not support non-1.0 q_scale"):
+        extension.apply_kv_cache_scales({"model.layers.0.self_attn.attn.q_scale": 0.5})
+    torch.testing.assert_close(attention._q_scale, torch.tensor(1.0))
+
+
 def test_fake_quant_load_weights_exposes_input_quantizer_buffers(monkeypatch):
     backend = _import_vllm_quant_backend(monkeypatch)
 
@@ -579,17 +901,28 @@ def test_real_quant_collective_reload_runs_modelopt_hooks(monkeypatch):
         "modelopt_process_weights_after_loading",
         lambda model_arg: calls.append(("process", model_arg)),
     )
+
+    def fake_collective(self):
+        calls.append("collective")
+        self._pending_kv_cache_scales = {"model.layers.0.self_attn.k_scale": 2.0}
+        return True
+
     monkeypatch.setattr(
         backend.VllmInternalWorkerExtension,
         "update_weights_from_collective",
-        lambda self: True,
+        fake_collective,
     )
     extension.device = torch.device("cpu")
+    extension._maybe_process_fp8_kv_cache = lambda: calls.append("kv")
+    extension.apply_kv_cache_scales = lambda: calls.append("apply")
 
     assert extension.update_weights_from_collective() is True
     assert calls == [
         ("prepare", model, torch.device("cpu")),
+        "collective",
         ("process", model),
+        "kv",
+        "apply",
     ]
 
 
@@ -810,6 +1143,37 @@ def test_non_real_quant_ipc_delegates(monkeypatch):
     )
 
     assert extension.update_weights_via_ipc_zmq() == "delegated"
+
+
+def test_real_quant_fp8_kv_processing_skips_base_post_load(monkeypatch):
+    backend = _import_vllm_quant_backend(monkeypatch)
+
+    extension = object.__new__(backend.VllmQuantInternalWorkerExtension)
+    calls = []
+    monkeypatch.setattr(
+        backend.VllmInternalWorkerExtension,
+        "_maybe_process_fp8_kv_cache",
+        lambda self: calls.append("base"),
+    )
+    monkeypatch.setattr(
+        backend.VllmQuantInternalWorkerExtension,
+        "_is_real_quant_model",
+        lambda self: True,
+    )
+
+    extension._maybe_process_fp8_kv_cache()
+
+    assert calls == []
+
+    monkeypatch.setattr(
+        backend.VllmQuantInternalWorkerExtension,
+        "_is_real_quant_model",
+        lambda self: False,
+    )
+
+    extension._maybe_process_fp8_kv_cache()
+
+    assert calls == ["base"]
 
 
 def test_weight_snapshot_returns_cpu_clone_and_missing_name_raises(monkeypatch):

--- a/tests/unit/models/generation/test_vllm_utils.py
+++ b/tests/unit/models/generation/test_vllm_utils.py
@@ -18,12 +18,16 @@ import pytest
 import torch
 
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.models.generation.vllm.quantization.fp8_train_utils import (
+    validate_vllm_qkv_scale_completeness,
+)
 from nemo_rl.models.generation.vllm.utils import (
     R3_MISSING_ROUTE_SENTINEL,
     aggregate_spec_decode_counters,
     compute_spec_decode_metrics,
     format_prompt_for_vllm_generation,
     pad_and_align_routed_expert_indices,
+    validate_vllm_fp8_kv_cache_config,
 )
 
 
@@ -32,6 +36,120 @@ def _mk_inputs(batch_size: int = 2, seq_len: int = 5):
     # make second example shorter
     input_lengths = torch.tensor([seq_len, seq_len - 2])
     return input_ids, input_lengths
+
+
+def _fp8_kv_policy_generation_configs():
+    policy_config = {
+        "quant_cfg": None,
+        "dtensor_cfg": {"enabled": False},
+        "megatron_cfg": {"pipeline_model_parallel_size": 1},
+    }
+    generation_config = {
+        "backend": "vllm",
+        "real_quant": False,
+        "quant_cfg": None,
+        "vllm_cfg": {
+            "precision": "bfloat16",
+            "kv_cache_dtype": "fp8_e4m3",
+            "async_engine": False,
+        },
+    }
+    return policy_config, generation_config
+
+
+def test_validate_vllm_fp8_kv_cache_accepts_fp8_precision():
+    policy_config, generation_config = _fp8_kv_policy_generation_configs()
+    generation_config["vllm_cfg"]["precision"] = "fp8"
+
+    validate_vllm_fp8_kv_cache_config(
+        policy_config, generation_config, use_async_rollouts=False
+    )
+
+
+def test_validate_vllm_fp8_kv_cache_accepts_modelopt_qarl_bf16_precision():
+    policy_config, generation_config = _fp8_kv_policy_generation_configs()
+    policy_config["quant_cfg"] = "NVFP4_DEFAULT_CFG"
+    generation_config["real_quant"] = True
+    generation_config["quant_cfg"] = "NVFP4_DEFAULT_CFG"
+
+    validate_vllm_fp8_kv_cache_config(
+        policy_config, generation_config, use_async_rollouts=False
+    )
+
+
+def test_validate_vllm_fp8_kv_cache_accepts_bf16_weights_without_modelopt_quant():
+    policy_config, generation_config = _fp8_kv_policy_generation_configs()
+
+    validate_vllm_fp8_kv_cache_config(
+        policy_config, generation_config, use_async_rollouts=False
+    )
+
+
+def test_validate_vllm_fp8_kv_cache_rejects_unsupported_weight_precision():
+    policy_config, generation_config = _fp8_kv_policy_generation_configs()
+    generation_config["vllm_cfg"]["precision"] = "float16"
+
+    with pytest.raises(AssertionError, match="bfloat16 or fp8"):
+        validate_vllm_fp8_kv_cache_config(
+            policy_config, generation_config, use_async_rollouts=False
+        )
+
+
+def test_validate_vllm_fp8_kv_cache_rejects_async_rollouts():
+    policy_config, generation_config = _fp8_kv_policy_generation_configs()
+    policy_config["quant_cfg"] = "NVFP4_DEFAULT_CFG"
+    generation_config["real_quant"] = True
+    generation_config["quant_cfg"] = "NVFP4_DEFAULT_CFG"
+
+    with pytest.raises(AssertionError, match="Async rollouts"):
+        validate_vllm_fp8_kv_cache_config(
+            policy_config, generation_config, use_async_rollouts=True
+        )
+
+
+def test_validate_vllm_fp8_kv_cache_rejects_dtensor_policy():
+    policy_config, generation_config = _fp8_kv_policy_generation_configs()
+    generation_config["vllm_cfg"]["precision"] = "fp8"
+    policy_config["dtensor_cfg"]["enabled"] = True
+
+    with pytest.raises(AssertionError, match="DTensor backend"):
+        validate_vllm_fp8_kv_cache_config(
+            policy_config, generation_config, use_async_rollouts=False
+        )
+
+
+def test_validate_vllm_fp8_kv_cache_rejects_pipeline_parallel_policy():
+    policy_config, generation_config = _fp8_kv_policy_generation_configs()
+    generation_config["vllm_cfg"]["precision"] = "fp8"
+    policy_config["megatron_cfg"]["pipeline_model_parallel_size"] = 2
+
+    with pytest.raises(AssertionError, match="pipeline_model_parallel_size=1"):
+        validate_vllm_fp8_kv_cache_config(
+            policy_config, generation_config, use_async_rollouts=False
+        )
+
+
+def test_validate_vllm_qkv_scale_completeness_accepts_global_superset():
+    expected = [
+        "model.layers.0.self_attn.attn.q_scale",
+        "model.layers.0.self_attn.k_scale",
+        "model.layers.0.self_attn.v_scale",
+    ]
+    kv_scales = {name: 0.1 for name in [*expected, "model.layers.1.self_attn.k_scale"]}
+
+    validate_vllm_qkv_scale_completeness(expected, kv_scales)
+
+
+def test_validate_vllm_qkv_scale_completeness_rejects_missing_component():
+    expected = [
+        "model.layers.0.self_attn.attn.q_scale",
+        "model.layers.0.self_attn.k_scale",
+        "model.layers.0.self_attn.v_scale",
+    ]
+    kv_scales = {name: 0.1 for name in expected[:-1]}
+
+    with pytest.raises(RuntimeError, match="payload is incomplete"):
+        validate_vllm_qkv_scale_completeness(expected, kv_scales)
 
 
 def test_vllm_utils_regular_llm_path():

--- a/tests/unit/models/policy/test_megatron_quant_worker.py
+++ b/tests/unit/models/policy/test_megatron_quant_worker.py
@@ -95,7 +95,12 @@ def _make_real_quant_worker():
     }
     worker.model = object()
     worker.draft_model = None
-    worker.refit_conversion_tasks = ["task"]
+    worker.refit_conversion_tasks = [
+        SimpleNamespace(
+            param_name="decoder.layers.0.self_attention.linear_qkv.weight",
+            mapping=SimpleNamespace(hf_param="model.layers.0.self_attn.q_proj.weight"),
+        )
+    ]
     worker.megatron_bridge = _FakeModelOptBridge()
     worker.rank = 0
     return worker
@@ -186,10 +191,83 @@ def test_iter_params_with_optional_kv_scales_uses_real_quant_export(monkeypatch)
         lambda kv_scales=None: iter([("real.weight", torch.ones(1))]),
     )
 
-    output = list(worker._iter_params_with_optional_kv_scales({"scale": 1.0}))
+    kv_scales = {
+        "model.layers.0.self_attn.attn.q_scale": 1.0,
+        "model.layers.0.self_attn.k_scale": 2.0,
+        "model.layers.0.self_attn.v_scale": 3.0,
+    }
+    output = list(worker._iter_params_with_optional_kv_scales(kv_scales))
 
     assert output[0][0] == "real.weight"
     torch.testing.assert_close(output[0][1], torch.ones(1))
+
+
+@requires_weight_folding
+def test_get_vllm_kv_scale_names_uses_explicit_kv_scales():
+    worker = _make_real_quant_worker()
+    kv_scales = {
+        "model.layers.0.self_attn.attn.q_scale": 1.0,
+        "model.layers.0.self_attn.k_scale": 2.0,
+        "model.layers.0.self_attn.v_scale": 3.0,
+    }
+
+    assert worker._get_vllm_kv_scale_names(kv_scales) == list(kv_scales)
+
+
+@requires_weight_folding
+def test_get_vllm_kv_scale_names_derives_attention_layers_from_refit_tasks():
+    worker = _make_real_quant_worker()
+    worker.refit_conversion_tasks = [
+        SimpleNamespace(
+            param_name="decoder.layers.1.mixer.in_proj.weight",
+            mapping=SimpleNamespace(hf_param="model.layers.1.mamba.in_proj.weight"),
+        ),
+        SimpleNamespace(
+            param_name="decoder.layers.0.self_attention.linear_qkv.weight",
+            mapping=SimpleNamespace(hf_param="model.layers.0.self_attn.q_proj.weight"),
+        ),
+        SimpleNamespace(
+            param_name="decoder.layers.2.self_attention.linear_qkv.weight",
+            mapping=SimpleNamespace(hf_param="model.layers.2.self_attn.q_proj.weight"),
+        ),
+    ]
+
+    assert worker._get_vllm_kv_scale_names() == [
+        "model.layers.0.self_attn.attn.q_scale",
+        "model.layers.0.self_attn.k_scale",
+        "model.layers.0.self_attn.v_scale",
+        "model.layers.2.self_attn.attn.q_scale",
+        "model.layers.2.self_attn.k_scale",
+        "model.layers.2.self_attn.v_scale",
+    ]
+
+
+@requires_weight_folding
+def test_get_vllm_kv_scale_names_uses_hybrid_layer_type_fallback():
+    worker = _make_real_quant_worker()
+    worker.refit_conversion_tasks = []
+    worker.megatron_bridge.transformer_config = SimpleNamespace(
+        layers_block_type=["mamba", "attention", "mamba", "full_attention", "moe"]
+    )
+
+    assert worker._get_vllm_kv_scale_names() == [
+        "model.layers.1.self_attn.attn.q_scale",
+        "model.layers.1.self_attn.k_scale",
+        "model.layers.1.self_attn.v_scale",
+        "model.layers.3.self_attn.attn.q_scale",
+        "model.layers.3.self_attn.k_scale",
+        "model.layers.3.self_attn.v_scale",
+    ]
+
+
+@requires_weight_folding
+def test_get_vllm_kv_scale_names_raises_without_attention_source():
+    worker = _make_real_quant_worker()
+    worker.refit_conversion_tasks = []
+    worker.megatron_bridge.transformer_config = SimpleNamespace(num_layers=0)
+
+    with pytest.raises(RuntimeError, match="Unable to derive attention layer ids"):
+        worker._get_vllm_kv_scale_names()
 
 
 @requires_weight_folding

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -75,6 +75,40 @@ def test_megatron_prepare_for_training_restores_optimizer():
     assert restored_devices == ["cuda"]
 
 
+def test_core_attention_name_match_excludes_child_quantizers():
+    source_path = (
+        Path(__file__).parents[4]
+        / "nemo_rl/models/policy/workers/megatron_policy_worker.py"
+    )
+    tree = ast.parse(source_path.read_text())
+    helper_node = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_is_self_attention_core_attention_module_name"
+    )
+    module = ast.Module(body=[helper_node], type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace: dict[str, object] = {}
+    exec(compile(module, str(source_path), "exec"), namespace)
+    _is_self_attention_core_attention_module_name = namespace[
+        "_is_self_attention_core_attention_module_name"
+    ]
+
+    assert _is_self_attention_core_attention_module_name(
+        "module.module.decoder.layers.0.self_attention.core_attention"
+    )
+    assert not _is_self_attention_core_attention_module_name(
+        "module.module.decoder.layers.0.self_attention.core_attention.q_bmm_quantizer"
+    )
+    assert not _is_self_attention_core_attention_module_name(
+        "module.module.decoder.layers.0.self_attention.core_attention.k_bmm_quantizer"
+    )
+    assert not _is_self_attention_core_attention_module_name(
+        "module.module.decoder.layers.0.self_attention.core_attention.v_bmm_quantizer"
+    )
+
+
 def test_set_moe_grad_scale_func_sets_and_clears_on_model_config():
     """_set_moe_grad_scale_func should set/clear moe_grad_scale_func on the config."""
     from nemo_rl.models.policy.workers.megatron_policy_worker import (

--- a/tests/unit/weight_sync/test_weight_synchronizer.py
+++ b/tests/unit/weight_sync/test_weight_synchronizer.py
@@ -143,6 +143,45 @@ class TestIPCWeightSynchronizer:
         assert call_kwargs.kwargs["buffer_size_bytes"] == 2 * (1024**3)
 
     @patch("nemo_rl.weight_sync.ipc_weight_synchronizer.ray")
+    def test_sync_weights_passes_and_applies_kv_scales(self, mock_ray):
+        mock_ray.get.return_value = [True]
+        policy = _mock_policy()
+        gen = _mock_generation()
+        gen.cfg = {
+            "backend": "vllm",
+            "vllm_cfg": {"kv_cache_dtype": "fp8_e4m3"},
+        }
+        sync = IPCWeightSynchronizer(policy, gen)
+        kv_scales = {"model.layers.0.self_attn.k_scale": 2.0}
+
+        sync.sync_weights(kv_scales=kv_scales)
+
+        stream_kwargs = policy.stream_weights_via_ipc_zmq.call_args.kwargs
+        assert stream_kwargs["kv_scales"] == kv_scales
+        gen.prepare_for_generation.assert_any_call(tags=["kv_cache"])
+        gen.apply_kv_cache_scales.assert_called_once_with(kv_scales)
+
+    @patch("nemo_rl.weight_sync.ipc_weight_synchronizer.ray")
+    def test_sync_weights_skips_sync_kv_apply_for_async_vllm(self, mock_ray):
+        mock_ray.get.return_value = [True]
+        policy = _mock_policy()
+        gen = _mock_generation()
+        gen.cfg = {
+            "backend": "vllm",
+            "vllm_cfg": {"kv_cache_dtype": "fp8_e4m3", "async_engine": True},
+        }
+        sync = IPCWeightSynchronizer(policy, gen)
+        kv_scales = {"model.layers.0.self_attn.k_scale": 2.0}
+
+        sync.sync_weights(kv_scales=kv_scales)
+
+        assert (
+            policy.stream_weights_via_ipc_zmq.call_args.kwargs["kv_scales"] == kv_scales
+        )
+        gen.prepare_for_generation.assert_any_call(tags=["kv_cache"])
+        gen.apply_kv_cache_scales.assert_not_called()
+
+    @patch("nemo_rl.weight_sync.ipc_weight_synchronizer.ray")
     def test_dynamic_buffer_size(self, mock_ray, monkeypatch):
         monkeypatch.delenv("NRL_REFIT_BUFFER_MEMORY_RATIO", raising=False)
         mock_ray.get.return_value = [True]


### PR DESCRIPTION
** Purely a test PR**
Calibrate Q/K/V scales from the active policy, validate them before use, and apply them to native or ModelOpt vLLM workers after refit. Extend distillation, GRPO, GRPO-sync, and PPO so FP8 KV-cache rollouts cannot silently use default or stale scales.

Constraint: vLLM BF16-weight rollouts expose FP8 KV-cache buffers without ModelOpt weight quantization.

Rejected: Rely on vLLM weight loading for KV scales | plain BF16 vLLM models do not expose those scales as loadable parameters.

Confidence: high

Scope-risk: moderate

Directive: Keep initial validation disabled until the policy has produced calibrated non-default KV scales.

Tested: 148 targeted unit tests; Ruff; formatting; Pyrefly; Qwen3-0.6B native FP8 KV distillation smoke; same-model KV-only QAD smoke with loss 0.007508 and grad norm 2.8707.

Not-tested: Full-scale Nano3 hybrid Mamba/MoE training.

# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
