### PR TITLE
feat: Llama true-on-policy mode

### DIFF
--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -110,6 +110,10 @@ policy:
   logprob_batch_size: ${policy.train_micro_batch_size}
   max_total_sequence_length: 512
   precision: "bfloat16"
+  # Enable BF16 true-on-policy numeric matching. This enables Megatron
+  # batch-invariant mode and BF16 parity patches for supported generation
+  # backends. Recommended default: false.
+  bf16_true_on_policy: false
   logprob_chunk_size: null
   offload_optimizer_for_logprob: false # Only useful for non-colocated generation since colocated generation will always offload optimizer to cuda before refit
 

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -246,6 +246,49 @@ class MasterConfig(BaseModel, extra="allow"):
     on_policy_distillation: Optional[OnPolicyDistillationConfig] = None
 
 
+def _configure_vllm_for_bf16_true_on_policy(generation_config: VllmConfig) -> None:
+    """Validate and configure vLLM for BF16 true-on-policy parity."""
+    if generation_config["vllm_cfg"]["async_engine"]:
+        raise ValueError(
+            "policy.bf16_true_on_policy=True requires "
+            "policy.generation.vllm_cfg.async_engine=false."
+        )
+    if generation_config["vllm_cfg"]["precision"] != "bfloat16":
+        raise ValueError(
+            "policy.bf16_true_on_policy=True requires "
+            "policy.generation.vllm_cfg.precision=bfloat16."
+        )
+    if generation_config["vllm_cfg"].get("enforce_eager") is True:
+        print(
+            "  ✓ Using vLLM eager mode for policy.bf16_true_on_policy "
+            "because policy.generation.vllm_cfg.enforce_eager=true",
+            flush=True,
+        )
+        return
+
+    vllm_kwargs = generation_config.setdefault("vllm_kwargs", {})
+    compilation_config = vllm_kwargs.get("compilation_config", None)
+    if compilation_config is None:
+        compilation_config = {}
+        vllm_kwargs["compilation_config"] = compilation_config
+    elif not isinstance(compilation_config, dict):
+        raise TypeError(
+            "policy.generation.vllm_kwargs.compilation_config must "
+            "be a dict when policy.bf16_true_on_policy=true, got "
+            f"{type(compilation_config)}."
+        )
+
+    compilation_config["mode"] = 0
+    compilation_config["cudagraph_mode"] = "FULL_DECODE_ONLY"
+    compilation_config["splitting_ops"] = []
+    print(
+        "  ✓ Configured vLLM CUDA graph-only mode for "
+        "policy.bf16_true_on_policy "
+        "(torch compile disabled, decode CUDA graphs enabled)",
+        flush=True,
+    )
+
+
 # ===============================================================================
 # Setup & Initialization
 # ===============================================================================
@@ -853,6 +896,7 @@ def setup(
     # Policy subclass without this shared setup needing to know the data
     # plane exists. Default is the plain Policy class — legacy behavior.
     _make_policy = policy_factory if policy_factory is not None else Policy
+    bf16_true_on_policy = policy_config.get("bf16_true_on_policy") is True
 
     def init_policy():
         """Initialize policy training workers."""
@@ -872,9 +916,27 @@ def setup(
     def init_vllm():
         """Initialize vLLM generation workers."""
         t0 = time.perf_counter()
-        pg = VllmGeneration(cluster=inference_cluster, config=generation_config)
+        pg = VllmGeneration(
+            cluster=inference_cluster,
+            config=generation_config,
+            bf16_true_on_policy=bf16_true_on_policy,
+        )
+        install_vllm_true_on_policy_patches(pg)
         pg.finish_generation()
         return pg, time.perf_counter() - t0
+
+    def install_vllm_true_on_policy_patches(pg: VllmGeneration) -> None:
+        """Install vLLM BF16 true-on-policy patches when requested."""
+        if not bf16_true_on_policy:
+            return
+
+        patch_info = pg.install_true_on_policy_patches(
+            bf16_true_on_policy=bf16_true_on_policy,
+        )
+        print(
+            f"  ✓ Installed vLLM true-on-policy patches: {patch_info}",
+            flush=True,
+        )
 
     def init_sglang():
         """Initialize SGLang generation workers."""
@@ -995,6 +1057,8 @@ def setup(
     elif backend == "vllm":
         # vLLM generation: setup config, then initialize with policy
         generation_config = cast(VllmConfig, generation_config)
+        if bf16_true_on_policy:
+            _configure_vllm_for_bf16_true_on_policy(generation_config)
         if generation_config["vllm_cfg"]["precision"] == "fp8":
             assert loss_config.use_importance_sampling_correction, (
                 "Importance sampling must be enabled for vLLM FP8 generation for good convergence!"
@@ -1033,6 +1097,7 @@ def setup(
                 cluster=inference_cluster,
                 config=generation_config,
                 defer_model_load=True,
+                bf16_true_on_policy=bf16_true_on_policy,
             )
             print(
                 f"  ✓ Reserved {len(deferred_vllm.dp_openai_server_base_urls)} vLLM server URLs: "
@@ -1044,6 +1109,7 @@ def setup(
                 """Complete the deferred vLLM model load started above."""
                 t0 = time.perf_counter()
                 deferred_vllm.load_and_start()
+                install_vllm_true_on_policy_patches(deferred_vllm)
                 deferred_vllm.finish_generation()
                 return deferred_vllm, time.perf_counter() - t0
 

--- a/nemo_rl/models/generation/vllm/batch_invariant.py
+++ b/nemo_rl/models/generation/vllm/batch_invariant.py
@@ -1,0 +1,418 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""vLLM BF16 true-on-policy runtime patches used by generation workers."""
+
+from __future__ import annotations
+
+import math
+import os
+from typing import Any
+
+import torch
+
+G_PATCH_MARKER_ATTR = "_nemo_rl_megatron_style_rmsnorm_patch"
+G_ORIGINAL_FORWARD_ATTR = "_nemo_rl_original_forward_cuda"
+G_MEGATRON_ROPE_PATCH_MARKER_ATTR = "_nemo_rl_megatron_style_rope_patch"
+G_MEGATRON_SWIGLU_PATCH_MARKER_ATTR = "_nemo_rl_megatron_style_swiglu_patch"
+G_MEGATRON_ROPE_CACHE_ATTR = "_nemo_rl_megatron_style_cos_sin_cache"
+G_TRUE_ON_POLICY_COMPONENTS_ENV = "NEMO_RL_VLLM_TRUE_ON_POLICY_PATCH_COMPONENTS"
+G_TRUE_ON_POLICY_BF16_PATCH_COMPONENTS = ("rmsnorm", "rope", "swiglu")
+G_TRUE_ON_POLICY_BF16_PATCH_COMPONENT_SET = frozenset(
+    G_TRUE_ON_POLICY_BF16_PATCH_COMPONENTS
+)
+
+
+def _rebind_custom_op_forward_methods(
+    model: torch.nn.Module,
+    target_cls: type,
+) -> int:
+    rebound_count = 0
+    for module in model.modules():
+        if isinstance(module, target_cls):
+            # CustomOp binds _forward_method at construction, so a class-level
+            # patch needs to be rebound onto existing module instances.
+            module._forward_method = module.forward_cuda
+            rebound_count += 1
+    return rebound_count
+
+
+def install_megatron_style_rmsnorm_patch(
+    model: torch.nn.Module,
+) -> dict[str, Any]:
+    """Route vLLM RMSNorm through Megatron's BI RMSNorm implementation."""
+    from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
+        BatchInvariantRMSNormFn,
+    )
+    from vllm.model_executor.layers.layernorm import RMSNorm
+
+    current_forward = RMSNorm.forward_cuda
+    original_forward = getattr(
+        current_forward,
+        G_ORIGINAL_FORWARD_ATTR,
+        current_forward,
+    )
+    already_installed = bool(getattr(current_forward, G_PATCH_MARKER_ATTR, False))
+
+    if not already_installed:
+
+        def patched_forward_cuda(self, x, residual=None):
+            if self.variance_size_override is not None or not getattr(
+                self, "has_weight", True
+            ):
+                return original_forward(self, x, residual)
+
+            if residual is not None:
+                residual_out = x + residual
+                return (
+                    BatchInvariantRMSNormFn.apply(
+                        residual_out,
+                        self.weight.data,
+                        self.variance_epsilon,
+                        False,
+                    ),
+                    residual_out,
+                )
+
+            return BatchInvariantRMSNormFn.apply(
+                x,
+                self.weight.data,
+                self.variance_epsilon,
+                False,
+            )
+
+        setattr(patched_forward_cuda, G_PATCH_MARKER_ATTR, True)
+        setattr(patched_forward_cuda, G_ORIGINAL_FORWARD_ATTR, original_forward)
+        RMSNorm.forward_cuda = patched_forward_cuda
+
+    rebound_count = _rebind_custom_op_forward_methods(model, RMSNorm)
+
+    return {
+        "already_installed": already_installed,
+        "rebound_count": rebound_count,
+    }
+
+
+def _megatron_style_rotate_half(
+    x: torch.Tensor,
+    *,
+    rotary_interleaved: bool,
+) -> torch.Tensor:
+    if not rotary_interleaved:
+        x1, x2 = torch.chunk(x, 2, dim=-1)
+        return torch.cat((-x2, x1), dim=-1)
+
+    x1 = x[..., ::2]
+    x2 = x[..., 1::2]
+    x_new = torch.stack((-x2, x1), dim=-1)
+    return x_new.flatten(-2)
+
+
+def _megatron_style_duplicate_freqs(
+    values: torch.Tensor,
+    *,
+    rotary_interleaved: bool,
+) -> torch.Tensor:
+    if not rotary_interleaved:
+        return torch.cat((values, values), dim=-1)
+    return torch.stack((values, values), dim=-1).flatten(-2)
+
+
+def _get_megatron_style_cos_sin_cache(module, device: torch.device) -> torch.Tensor:
+    cache = getattr(module, G_MEGATRON_ROPE_CACHE_ATTR, None)
+    if cache is None or cache.device != device:
+        cache = module._compute_cos_sin_cache().to(device=device)
+        setattr(module, G_MEGATRON_ROPE_CACHE_ATTR, cache)
+    return cache
+
+
+def _get_megatron_style_inv_freq_from_module_attrs(
+    module,
+    device: torch.device,
+) -> torch.Tensor | None:
+    base = getattr(module, "base", None)
+    rotary_dim = getattr(module, "rotary_dim", None)
+    if base is None or rotary_dim is None:
+        return None
+
+    inv_freq = 1.0 / (
+        float(base)
+        ** (
+            torch.arange(0, int(rotary_dim), 2, dtype=torch.float32, device=device)
+            / int(rotary_dim)
+        )
+    )
+
+    class_name = type(module).__name__
+    is_llama3_rope = class_name == "Llama3RotaryEmbedding" or all(
+        hasattr(module, attr)
+        for attr in (
+            "scaling_factor",
+            "low_freq_factor",
+            "high_freq_factor",
+            "old_context_len",
+        )
+    )
+    if not is_llama3_rope:
+        return inv_freq
+
+    factor = float(getattr(module, "scaling_factor", 8.0))
+    low_freq_factor = float(getattr(module, "low_freq_factor", 1.0))
+    high_freq_factor = float(getattr(module, "high_freq_factor", 4.0))
+    old_context_len = float(getattr(module, "old_context_len", 8192.0))
+
+    low_freq_wavelen = old_context_len / low_freq_factor
+    high_freq_wavelen = old_context_len / high_freq_factor
+    wavelen = 2 * math.pi / inv_freq
+
+    scaled_inv_freq = torch.where(
+        wavelen > low_freq_wavelen, inv_freq / factor, inv_freq
+    )
+    smooth_factor = (old_context_len / wavelen - low_freq_factor) / (
+        high_freq_factor - low_freq_factor
+    )
+    smoothed_inv_freq = (
+        1 - smooth_factor
+    ) * scaled_inv_freq / factor + smooth_factor * scaled_inv_freq
+    is_medium_freq = ~(wavelen < high_freq_wavelen) * ~(wavelen > low_freq_wavelen)
+    return torch.where(is_medium_freq, smoothed_inv_freq, scaled_inv_freq)
+
+
+def _get_megatron_style_inv_freq(module, device: torch.device) -> torch.Tensor | None:
+    inv_freq = _get_megatron_style_inv_freq_from_module_attrs(module, device)
+    if inv_freq is not None:
+        return inv_freq
+
+    compute_inv_freq = getattr(module, "_compute_inv_freq", None)
+    base = getattr(module, "base", None)
+    inv_freq = None
+    if callable(compute_inv_freq) and base is not None:
+        try:
+            inv_freq = compute_inv_freq(base)
+        except TypeError:
+            inv_freq = compute_inv_freq()
+
+    if inv_freq is None:
+        inv_freq = getattr(module, "inv_freq", None)
+    if inv_freq is None:
+        return None
+    return inv_freq.to(device=device)
+
+
+def _get_megatron_style_freqs_half(
+    *,
+    module,
+    positions: torch.Tensor,
+    device: torch.device,
+) -> torch.Tensor | None:
+    inv_freq = _get_megatron_style_inv_freq(module, device)
+    if inv_freq is None:
+        return None
+
+    positions = positions.to(device=device, dtype=inv_freq.dtype)
+    class_name = type(module).__name__
+    if class_name == "LinearScalingRotaryEmbedding" and hasattr(
+        module, "scaling_factor"
+    ):
+        positions = positions / module.scaling_factor
+
+    return torch.outer(positions, inv_freq)
+
+
+def _apply_megatron_style_rope(
+    *,
+    module,
+    positions: torch.Tensor,
+    tensor: torch.Tensor,
+) -> torch.Tensor:
+    original_shape = tensor.shape
+    positions = positions.flatten()
+    num_tokens = positions.shape[0]
+    tensor = tensor.view(num_tokens, -1, module.head_size)
+    tensor_rot = tensor[..., : module.rotary_dim]
+    tensor_pass = tensor[..., module.rotary_dim :]
+
+    rotary_interleaved = not module.is_neox_style
+    freqs_half = _get_megatron_style_freqs_half(
+        module=module,
+        positions=positions,
+        device=tensor.device,
+    )
+    if freqs_half is None:
+        cos_sin_cache = _get_megatron_style_cos_sin_cache(module, tensor.device)
+        cos_sin = cos_sin_cache.index_select(0, positions.to(device=tensor.device))
+        cos_half, sin_half = cos_sin.chunk(2, dim=-1)
+        cos = _megatron_style_duplicate_freqs(
+            cos_half,
+            rotary_interleaved=rotary_interleaved,
+        ).to(tensor_rot.dtype)
+        sin = _megatron_style_duplicate_freqs(
+            sin_half,
+            rotary_interleaved=rotary_interleaved,
+        ).to(tensor_rot.dtype)
+    else:
+        freqs = _megatron_style_duplicate_freqs(
+            freqs_half,
+            rotary_interleaved=rotary_interleaved,
+        )
+        cos = torch.cos(freqs).to(tensor_rot.dtype)
+        sin = torch.sin(freqs).to(tensor_rot.dtype)
+    cos = cos.unsqueeze(-2)
+    sin = sin.unsqueeze(-2)
+
+    tensor_rot = (tensor_rot * cos) + (
+        _megatron_style_rotate_half(
+            tensor_rot,
+            rotary_interleaved=rotary_interleaved,
+        )
+        * sin
+    )
+    return torch.cat((tensor_rot, tensor_pass), dim=-1).reshape(original_shape)
+
+
+def install_megatron_style_rope_patch(model: torch.nn.Module) -> dict[str, Any]:
+    """Route vLLM base RoPE through Megatron's unfused RoPE formula."""
+    from vllm.model_executor.layers.rotary_embedding.base import RotaryEmbedding
+
+    current_forward = RotaryEmbedding.forward_cuda
+    original_forward = getattr(
+        current_forward,
+        G_ORIGINAL_FORWARD_ATTR,
+        current_forward,
+    )
+    already_installed = bool(
+        getattr(current_forward, G_MEGATRON_ROPE_PATCH_MARKER_ATTR, False)
+    )
+
+    if not already_installed:
+
+        def patched_forward_cuda(self, positions, query, key=None):
+            if self.use_flashinfer:
+                return original_forward(self, positions, query, key)
+
+            query = _apply_megatron_style_rope(
+                module=self,
+                positions=positions,
+                tensor=query,
+            )
+            if key is not None:
+                key = _apply_megatron_style_rope(
+                    module=self,
+                    positions=positions,
+                    tensor=key,
+                )
+            return query, key
+
+        setattr(patched_forward_cuda, G_MEGATRON_ROPE_PATCH_MARKER_ATTR, True)
+        setattr(patched_forward_cuda, G_ORIGINAL_FORWARD_ATTR, original_forward)
+        RotaryEmbedding.forward_cuda = patched_forward_cuda
+
+    rebound_count = _rebind_custom_op_forward_methods(model, RotaryEmbedding)
+
+    return {
+        "already_installed": already_installed,
+        "rebound_count": rebound_count,
+    }
+
+
+def install_megatron_style_swiglu_patch(model: torch.nn.Module) -> dict[str, Any]:
+    """Route vLLM ``SiluAndMul`` through Megatron's unfused SwiGLU path."""
+    import torch.nn.functional as F
+    from vllm.model_executor.layers.activation import SiluAndMul
+
+    current_forward = SiluAndMul.forward_cuda
+    original_forward = getattr(
+        current_forward,
+        G_ORIGINAL_FORWARD_ATTR,
+        current_forward,
+    )
+    already_installed = bool(
+        getattr(current_forward, G_MEGATRON_SWIGLU_PATCH_MARKER_ATTR, False)
+    )
+
+    if not already_installed:
+
+        def patched_forward_cuda(self, x):
+            x_glu, x_linear = torch.chunk(x, 2, dim=-1)
+            return F.silu(x_glu) * x_linear
+
+        setattr(patched_forward_cuda, G_MEGATRON_SWIGLU_PATCH_MARKER_ATTR, True)
+        setattr(patched_forward_cuda, G_ORIGINAL_FORWARD_ATTR, original_forward)
+        SiluAndMul.forward_cuda = patched_forward_cuda
+
+    rebound_count = _rebind_custom_op_forward_methods(model, SiluAndMul)
+
+    return {
+        "already_installed": already_installed,
+        "rebound_count": rebound_count,
+    }
+
+
+def install_true_on_policy_patch_components(
+    model: torch.nn.Module,
+    components: tuple[str, ...],
+) -> dict[str, Any]:
+    """Install selected BF16 true-on-policy vLLM patches for diagnostics."""
+    requested_components = set(components)
+    unknown_components = (
+        requested_components - G_TRUE_ON_POLICY_BF16_PATCH_COMPONENT_SET
+    )
+    if unknown_components:
+        raise ValueError(
+            "Unknown vLLM true-on-policy patch components: "
+            f"{sorted(unknown_components)}. Expected subset of "
+            f"{list(G_TRUE_ON_POLICY_BF16_PATCH_COMPONENTS)}."
+        )
+
+    results: dict[str, Any] = {}
+    if "rmsnorm" in requested_components:
+        results["megatron_style_rmsnorm"] = install_megatron_style_rmsnorm_patch(model)
+    if "rope" in requested_components:
+        results["megatron_style_rope"] = install_megatron_style_rope_patch(model)
+    if "swiglu" in requested_components:
+        results["megatron_style_swiglu"] = install_megatron_style_swiglu_patch(model)
+    return results
+
+
+def _get_requested_true_on_policy_components() -> tuple[str, ...]:
+    raw_components = os.environ.get(G_TRUE_ON_POLICY_COMPONENTS_ENV)
+    if raw_components is None:
+        return G_TRUE_ON_POLICY_BF16_PATCH_COMPONENTS
+    if raw_components.strip() == "":
+        return ()
+    return tuple(
+        component.strip().lower()
+        for component in raw_components.split(",")
+        if component.strip()
+    )
+
+
+def install_true_on_policy_patches(
+    model: torch.nn.Module,
+    *,
+    bf16_true_on_policy: bool,
+) -> dict[str, Any]:
+    """Install vLLM BF16 true-on-policy patches controlled by policy flags."""
+    if not bf16_true_on_policy:
+        return {}
+
+    components = _get_requested_true_on_policy_components()
+    results: dict[str, Any] = {"bf16_components": components}
+    results.update(
+        install_true_on_policy_patch_components(
+            model,
+            components,
+        )
+    )
+    return results

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -92,6 +92,34 @@ def _read_mtp_layer_weights_from_checkpoint(
 
 
 class VllmInternalWorkerExtension:
+    def install_true_on_policy_patches(
+        self,
+        bf16_true_on_policy: bool,
+    ) -> dict[str, Any]:
+        """Install vLLM BF16 true-on-policy patches."""
+        from nemo_rl.models.generation.vllm.batch_invariant import (
+            install_true_on_policy_patches,
+        )
+
+        return install_true_on_policy_patches(
+            self.model_runner.model,
+            bf16_true_on_policy=bf16_true_on_policy,
+        )
+
+    def install_true_on_policy_patch_components(
+        self,
+        components: tuple[str, ...],
+    ) -> dict[str, Any]:
+        """Install selected BF16 true-on-policy patches on vLLM."""
+        from nemo_rl.models.generation.vllm.batch_invariant import (
+            install_true_on_policy_patch_components,
+        )
+
+        return install_true_on_policy_patch_components(
+            self.model_runner.model,
+            components=components,
+        )
+
     def init_collective(
         self,
         rank_prefix: int,

--- a/nemo_rl/models/generation/vllm/vllm_generation.py
+++ b/nemo_rl/models/generation/vllm/vllm_generation.py
@@ -46,6 +46,12 @@ from nemo_rl.models.generation.vllm.utils import (
 
 logger = logging.getLogger(__name__)
 
+G_VLLM_TRUE_ON_POLICY_FORWARDED_ENV_VARS = (
+    "NEMO_RL_VLLM_TRUE_ON_POLICY_PATCH_COMPONENTS",
+    "VLLM_BATCH_INVARIANT",
+    "NEMO_RL_VLLM_PREINIT_TRUE_ON_POLICY_PATCHES",
+)
+
 
 class VllmGeneration(GenerationInterface):
     @staticmethod
@@ -84,6 +90,7 @@ class VllmGeneration(GenerationInterface):
         name_prefix: str = "vllm_policy",
         workers_per_node: Optional[Union[int, list[int]]] = None,
         defer_model_load: bool = False,
+        bf16_true_on_policy: bool = False,
     ):
         """Initialize a vLLM policy with distributed workers.
 
@@ -98,10 +105,13 @@ class VllmGeneration(GenerationInterface):
             name_prefix: Prefix for Ray actor names
             workers_per_node: Workers per node override
             defer_model_load: If True, defer model loading for overlapped init
+            bf16_true_on_policy: If True, enable BF16 true-on-policy parity
+                patches in vLLM.
         """
         # Store config
         self.cfg = config
         self._defer_model_load = defer_model_load
+        self.bf16_true_on_policy = bf16_true_on_policy
         self.tp_size = self.cfg["vllm_cfg"]["tensor_parallel_size"]
         self.pp_size = self.cfg["vllm_cfg"]["pipeline_parallel_size"]
         self.ep_size = self.cfg["vllm_cfg"]["expert_parallel_size"]
@@ -192,12 +202,24 @@ class VllmGeneration(GenerationInterface):
                 "nemo_rl.models.generation.vllm.vllm_worker.VllmGenerationWorker"
             )
         worker_cls = resolve_generation_worker_cls(worker_cls, self.cfg)
+        worker_builder_kwargs: dict[str, Any] = {}
+        if self.bf16_true_on_policy:
+            worker_builder_kwargs["extra_env_vars"] = list(
+                G_VLLM_TRUE_ON_POLICY_FORWARDED_ENV_VARS
+            )
         if self.cfg["vllm_cfg"]["async_engine"]:
+            worker_builder_kwargs["defer_model_load"] = defer_model_load
             worker_builder = RayWorkerBuilder(
-                worker_cls, config, defer_model_load=defer_model_load
+                worker_cls,
+                config,
+                **worker_builder_kwargs,
             )
         else:
-            worker_builder = RayWorkerBuilder(worker_cls, config)
+            worker_builder = RayWorkerBuilder(
+                worker_cls,
+                config,
+                **worker_builder_kwargs,
+            )
 
         # It's necessary to set env_vars here to ensure that vllm non-leader workers also have these env_vars
         env_vars = {}
@@ -205,6 +227,16 @@ class VllmGeneration(GenerationInterface):
         # Scoped to this generation config so it does not impact other test cases.
         for k, v in self.cfg["vllm_cfg"].get("env_vars", {}).items():
             env_vars[str(k)] = str(v)
+        if self.bf16_true_on_policy:
+            top_components = os.environ.get(
+                "NEMO_RL_VLLM_TRUE_ON_POLICY_PATCH_COMPONENTS"
+            )
+            if top_components is not None:
+                env_vars["NEMO_RL_VLLM_TRUE_ON_POLICY_PATCH_COMPONENTS"] = (
+                    top_components
+                )
+            env_vars["VLLM_BATCH_INVARIANT"] = "1"
+            env_vars["NEMO_RL_VLLM_PREINIT_TRUE_ON_POLICY_PATCHES"] = "1"
         # Explicitly set NCCL_CUMEM_ENABLE to 1 to avoid the P2P initialization error for PyNCCLCommunicator.
         # See https://github.com/NVIDIA-NeMo/RL/issues/564 for more details.
         if not self.cfg["colocated"]["enabled"]:
@@ -525,6 +557,19 @@ class VllmGeneration(GenerationInterface):
         # Wait for all futures to complete
         results = ray.get(futures)
         return results
+
+    def install_true_on_policy_patches(
+        self,
+        *,
+        bf16_true_on_policy: bool,
+    ) -> list[dict[str, Any]]:
+        """Install BF16 true-on-policy patches on vLLM model workers."""
+        futures = self.worker_group.run_all_workers_single_data(
+            "install_true_on_policy_patches",
+            bf16_true_on_policy=bf16_true_on_policy,
+            run_rank_0_only_axes=["tensor_parallel", "pipeline_parallel"],
+        )
+        return ray.get(futures)
 
     def _get_raw_spec_counters(self) -> dict[str | tuple[str, int], float]:
         """Collect raw spec decode counters from workers."""

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -48,6 +48,27 @@ from nemo_rl.utils.nvml import log_gpu_memory_diagnostics
 logger = logging.getLogger(__name__)
 
 
+def _maybe_install_preinit_true_on_policy_patches() -> None:
+    if os.environ.get("NEMO_RL_VLLM_PREINIT_TRUE_ON_POLICY_PATCHES") != "1":
+        return
+
+    from nemo_rl.models.generation.vllm.batch_invariant import (
+        install_true_on_policy_patches,
+    )
+
+    # vLLM CustomOp instances bind forward methods during module construction,
+    # and CUDA graphs are captured during engine init. Install class-level
+    # patches before LLM construction so captured graphs see the patched path.
+    patch_info = install_true_on_policy_patches(
+        torch.nn.Module(),
+        bf16_true_on_policy=True,
+    )
+    print(
+        f"  ✓ Pre-installed vLLM true-on-policy class patches: {patch_info}",
+        flush=True,
+    )
+
+
 def _resolve_enable_prefix_caching(vllm_cfg: dict[str, Any]) -> bool:
     enable_prefix_caching = vllm_cfg.get("enable_prefix_caching", None)
     if enable_prefix_caching is None:
@@ -255,6 +276,7 @@ class BaseVllmGenerationWorker:
                 "This error can also happen if the venv creation was aborted or errored out in the middle. In that case, "
                 "please run at least once with the environment variable NRL_FORCE_REBUILD_VENVS=true set to force the rebuild of the environment."
             )
+        _maybe_install_preinit_true_on_policy_patches()
         vllm_kwargs: dict[str, Any] = copy.deepcopy(self.cfg.get("vllm_kwargs", {}))
 
         # Calculate total parallel size (TP * PP)
@@ -514,6 +536,24 @@ class BaseVllmGenerationWorker:
         torch.cuda.profiler.stop()
         if self.llm is not None:
             self.llm.collective_rpc("stop_gpu_profiling", args=tuple())
+
+    def install_true_on_policy_patches(
+        self,
+        bf16_true_on_policy: bool,
+    ) -> list[dict[str, Any]]:
+        """Install vLLM BF16 true-on-policy patches."""
+        if self.llm is None:
+            return []
+        if self.cfg["vllm_cfg"]["async_engine"]:
+            raise RuntimeError(
+                "True-on-policy vLLM patches are currently supported only "
+                "with sync vLLM. Set policy.generation.vllm_cfg.async_engine=false."
+            )
+        results = self.llm.collective_rpc(
+            "install_true_on_policy_patches",
+            args=(bf16_true_on_policy,),
+        )
+        return cast(list[dict[str, Any]], results)
 
     @staticmethod
     def _patch_vllm_nsight_config() -> None:

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -500,6 +500,8 @@ def setup_model_config(
     # Apply performance settings
     _apply_performance_config(model_cfg, config)
 
+    model_cfg.batch_invariant_mode = config.get("bf16_true_on_policy") is True
+
     # Validate optimizer configuration
     _validate_optimizer_config(config)
 
@@ -1102,6 +1104,13 @@ def setup_model_and_optimizer(
         get_embedding_ranks=get_embedding_ranks,
         get_position_embedding_ranks=get_position_embedding_ranks,
     )
+
+    if getattr(megatron_cfg.model, "batch_invariant_mode", False) is True:
+        from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
+            enable_batch_invariant_mode,
+        )
+
+        enable_batch_invariant_mode()
 
     if megatron_cfg.ft and megatron_cfg.ft.enable_ft_package:
         fault_tolerance.setup(megatron_cfg, state)

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -446,6 +446,10 @@ class PolicyConfig(TypedDict):
     sequence_packing: NotRequired[SequencePackingConfig | SequencePackingConfigDisabled]
     make_sequence_length_divisible_by: int
     max_total_sequence_length: int
+    # When True, enable BF16 true-on-policy numeric matching. This enables
+    # Megatron batch-invariant mode and BF16 parity patches for supported
+    # generation backends. Recommended default: false.
+    bf16_true_on_policy: NotRequired[bool]
     # This sets the clipping norm for the DTensorPolicyWorkers (Megatron's is called clip_grad)
     max_grad_norm: NotRequired[float | int | None]
     refit_buffer_size_gb: NotRequired[float]

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -29,6 +29,7 @@ from nemo_rl.algorithms.grpo import (
     MasterConfig,
     _apply_configured_message_level_advantage_penalties,
     _apply_message_level_advantage_penalties,
+    _configure_vllm_for_bf16_true_on_policy,
     _default_grpo_save_state,
     _resolve_message_level_advantage_penalties,
     _should_use_async_rollouts,
@@ -65,6 +66,73 @@ def _mock_policy_generation() -> MagicMock:
     policy_generation.requires_kv_scale_sync = False
     policy_generation.get_logger_metrics.return_value = {}
     return policy_generation
+
+
+def test_configure_vllm_for_bf16_true_on_policy_sets_graph_only_compile():
+    generation_config = {
+        "vllm_cfg": {
+            "async_engine": False,
+            "precision": "bfloat16",
+            "enforce_eager": False,
+        },
+        "vllm_kwargs": {"compilation_config": {"existing": "kept"}},
+    }
+
+    _configure_vllm_for_bf16_true_on_policy(generation_config)
+
+    assert generation_config["vllm_kwargs"]["compilation_config"] == {
+        "existing": "kept",
+        "mode": 0,
+        "cudagraph_mode": "FULL_DECODE_ONLY",
+        "splitting_ops": [],
+    }
+
+
+def test_configure_vllm_for_bf16_true_on_policy_keeps_eager_mode():
+    generation_config = {
+        "vllm_cfg": {
+            "async_engine": False,
+            "precision": "bfloat16",
+            "enforce_eager": True,
+        },
+        "vllm_kwargs": {},
+    }
+
+    _configure_vllm_for_bf16_true_on_policy(generation_config)
+
+    assert generation_config["vllm_kwargs"] == {}
+
+
+@pytest.mark.parametrize(
+    ("vllm_cfg", "message"),
+    [
+        (
+            {"async_engine": True, "precision": "bfloat16"},
+            "async_engine=false",
+        ),
+        (
+            {"async_engine": False, "precision": "fp8"},
+            "precision=bfloat16",
+        ),
+    ],
+)
+def test_configure_vllm_for_bf16_true_on_policy_rejects_unsupported_vllm_cfg(
+    vllm_cfg, message
+):
+    generation_config = {"vllm_cfg": vllm_cfg, "vllm_kwargs": {}}
+
+    with pytest.raises(ValueError, match=message):
+        _configure_vllm_for_bf16_true_on_policy(generation_config)
+
+
+def test_configure_vllm_for_bf16_true_on_policy_rejects_non_dict_compile_config():
+    generation_config = {
+        "vllm_cfg": {"async_engine": False, "precision": "bfloat16"},
+        "vllm_kwargs": {"compilation_config": "invalid"},
+    }
+
+    with pytest.raises(TypeError, match="compilation_config must be a dict"):
+        _configure_vllm_for_bf16_true_on_policy(generation_config)
 
 
 @pytest.fixture

--- a/tests/unit/models/generation/test_vllm_batch_invariant.py
+++ b/tests/unit/models/generation/test_vllm_batch_invariant.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from nemo_rl.models.generation.vllm import batch_invariant
+
+
+def test_true_on_policy_patches_disabled():
+    result = batch_invariant.install_true_on_policy_patches(
+        torch.nn.Module(),
+        bf16_true_on_policy=False,
+    )
+
+    assert result == {}
+
+
+def test_true_on_policy_patches_install_requested_components(monkeypatch):
+    calls = []
+
+    def _patch_result(name):
+        def _installer(model):
+            calls.append((name, model))
+            return {"patched": name}
+
+        return _installer
+
+    monkeypatch.setattr(
+        batch_invariant,
+        "install_megatron_style_rmsnorm_patch",
+        _patch_result("rmsnorm"),
+    )
+    monkeypatch.setattr(
+        batch_invariant,
+        "install_megatron_style_rope_patch",
+        _patch_result("rope"),
+    )
+    monkeypatch.setattr(
+        batch_invariant,
+        "install_megatron_style_swiglu_patch",
+        _patch_result("swiglu"),
+    )
+    monkeypatch.setenv(
+        batch_invariant.G_TRUE_ON_POLICY_COMPONENTS_ENV,
+        "rmsnorm, swiglu",
+    )
+
+    model = torch.nn.Module()
+    result = batch_invariant.install_true_on_policy_patches(
+        model,
+        bf16_true_on_policy=True,
+    )
+
+    assert calls == [("rmsnorm", model), ("swiglu", model)]
+    assert result == {
+        "bf16_components": ("rmsnorm", "swiglu"),
+        "megatron_style_rmsnorm": {"patched": "rmsnorm"},
+        "megatron_style_swiglu": {"patched": "swiglu"},
+    }
+
+
+def test_true_on_policy_patches_default_to_all_components(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(
+        batch_invariant,
+        "install_megatron_style_rmsnorm_patch",
+        lambda model: calls.append("rmsnorm") or {"patched": "rmsnorm"},
+    )
+    monkeypatch.setattr(
+        batch_invariant,
+        "install_megatron_style_rope_patch",
+        lambda model: calls.append("rope") or {"patched": "rope"},
+    )
+    monkeypatch.setattr(
+        batch_invariant,
+        "install_megatron_style_swiglu_patch",
+        lambda model: calls.append("swiglu") or {"patched": "swiglu"},
+    )
+    monkeypatch.delenv(batch_invariant.G_TRUE_ON_POLICY_COMPONENTS_ENV, raising=False)
+
+    result = batch_invariant.install_true_on_policy_patches(
+        torch.nn.Module(),
+        bf16_true_on_policy=True,
+    )
+
+    assert calls == ["rmsnorm", "rope", "swiglu"]
+    assert result["bf16_components"] == ("rmsnorm", "rope", "swiglu")
+
+
+def test_true_on_policy_patches_reject_unknown_component(monkeypatch):
+    monkeypatch.setenv(
+        batch_invariant.G_TRUE_ON_POLICY_COMPONENTS_ENV,
+        "rmsnorm,not_a_patch",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Unknown vLLM true-on-policy patch components",
+    ):
+        batch_invariant.install_true_on_policy_patches(
+            torch.nn.Module(),
+            bf16_true_on_policy=True,
+        )

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -37,6 +37,7 @@ from nemo_rl.models.generation.interfaces import (
 )
 from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration
 from nemo_rl.models.generation.vllm.vllm_worker import (
+    VllmGenerationWorkerImpl,
     _resolve_enable_prefix_caching,
 )
 from nemo_rl.models.generation.vllm.vllm_worker_async import (
@@ -171,6 +172,38 @@ basic_lora_test_config: LoRAConfig = {
     "lora_A_init": "xavier",
     "use_triton": False,
 }
+
+
+def test_vllm_generation_install_true_on_policy_patches(monkeypatch):
+    vllm_generation = VllmGeneration.__new__(VllmGeneration)
+    vllm_generation.worker_group = MagicMock()
+    vllm_generation.worker_group.run_all_workers_single_data.return_value = [
+        "worker_future"
+    ]
+    monkeypatch.setattr(
+        "nemo_rl.models.generation.vllm.vllm_generation.ray.get",
+        lambda futures: [{"megatron_style_rmsnorm": {"patched": True}}],
+    )
+
+    result = vllm_generation.install_true_on_policy_patches(
+        bf16_true_on_policy=True,
+    )
+
+    assert result == [{"megatron_style_rmsnorm": {"patched": True}}]
+    vllm_generation.worker_group.run_all_workers_single_data.assert_called_once_with(
+        "install_true_on_policy_patches",
+        bf16_true_on_policy=True,
+        run_rank_0_only_axes=["tensor_parallel", "pipeline_parallel"],
+    )
+
+
+def test_vllm_worker_install_true_on_policy_patches_rejects_async():
+    worker = VllmGenerationWorkerImpl.__new__(VllmGenerationWorkerImpl)
+    worker.cfg = {"vllm_cfg": {"async_engine": True}}
+    worker.llm = MagicMock()
+
+    with pytest.raises(RuntimeError, match="sync vLLM"):
+        worker.install_true_on_policy_patches(bf16_true_on_policy=True)
 
 
 def skip_fp8_known_failures() -> None:

--- a/tests/unit/models/megatron/test_megatron_setup.py
+++ b/tests/unit/models/megatron/test_megatron_setup.py
@@ -25,7 +25,8 @@ nemo_rl.models.megatron.setup, focusing on:
 """
 
 import os
-from types import SimpleNamespace
+import sys
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1761,6 +1762,44 @@ class TestSetupModelConfig:
 
         mock_ac.assert_called_once_with("test-model", trust_remote_code=True)
 
+    @pytest.mark.parametrize(
+        ("flag_value", "expected_batch_invariant_mode"),
+        [(True, True), (False, False), (None, False)],
+    )
+    def test_bf16_true_on_policy_controls_batch_invariant_mode(
+        self, request, flag_value, expected_batch_invariant_mode
+    ):
+        """bf16_true_on_policy should be the single policy flag for Megatron BI mode."""
+        from nemo_rl.models.megatron.setup import setup_model_config
+
+        self._apply_patches(request)
+
+        mock_model_cfg = self._make_model_cfg_mock()
+        mock_provider = MagicMock()
+        mock_provider.to_megatron_provider.return_value = mock_model_cfg
+
+        config = {
+            "pretrained_checkpoint": {"format": "megatron_lm", "path": "/ckpt"},
+            "megatron_cfg": {},
+        }
+        if flag_value is not None:
+            config["bf16_true_on_policy"] = flag_value
+
+        with (
+            patch("transformers.AutoConfig.from_pretrained"),
+            patch("nemo_rl.models.megatron.setup.AutoBridge") as mock_ab,
+        ):
+            mock_ab.from_hf_config.return_value = mock_provider
+            setup_model_config(
+                config,
+                rank=0,
+                dtype=torch.bfloat16,
+                hf_model_name="test-model",
+                pretrained_path="/ckpt/iter_0005000",
+            )
+
+        assert mock_model_cfg.batch_invariant_mode is expected_batch_invariant_mode
+
     def test_megatron_bridge_with_hf_config_overrides_warns(self, tmp_path, request):
         """hf_config_overrides set with megatron_bridge format must emit a UserWarning."""
         from nemo_rl.models.megatron.setup import setup_model_config
@@ -2037,6 +2076,88 @@ class TestSetupModelAndOptimizer:
         assert len(call_kwargs.get("pre_wrap_hook", [])) > 0
 
         assert result.param_sync_func == mock_model_chunk.start_param_sync
+
+    @patch("nemo_rl.models.megatron.setup.ProcessGroupCollection")
+    @patch("nemo_rl.models.megatron.setup.GlobalState")
+    @patch("nemo_rl.models.megatron.setup.initialize_megatron")
+    @patch("nemo_rl.models.megatron.setup.set_jit_fusion_options")
+    @patch("nemo_rl.models.megatron.setup.init_checkpointing_context")
+    @patch("nemo_rl.models.megatron.setup.build_tokenizer")
+    @patch("nemo_rl.models.megatron.setup.get_model")
+    @patch("nemo_rl.models.megatron.setup.setup_optimizer")
+    @patch("nemo_rl.models.megatron.setup.checkpoint_exists")
+    @patch("nemo_rl.models.megatron.setup.get_attached_draft_model")
+    @patch("torch.distributed.all_reduce")
+    @patch("torch.distributed.barrier")
+    @patch("torch.tensor")
+    def test_setup_enables_megatron_batch_invariant_mode(
+        self,
+        mock_tensor,
+        mock_barrier,
+        mock_all_reduce,
+        mock_get_attached_draft_model,
+        mock_checkpoint_exists,
+        mock_setup_optimizer,
+        mock_get_model,
+        mock_build_tokenizer,
+        mock_init_ckpt_context,
+        mock_set_jit,
+        mock_init_megatron,
+        mock_global_state,
+        mock_pg_collection,
+    ):
+        """setup_model_and_optimizer should enable Megatron BI kernels when configured."""
+        from nemo_rl.models.megatron.setup import setup_model_and_optimizer
+
+        mock_state = MagicMock()
+        mock_state.start_time = 0.0
+        mock_global_state.return_value = mock_state
+
+        mock_megatron_cfg = MagicMock()
+        mock_megatron_cfg.ft = None
+        mock_megatron_cfg.model.batch_invariant_mode = True
+        mock_megatron_cfg.model.vocab_size = 32000
+        mock_megatron_cfg.model.make_vocab_size_divisible_by = 128
+        mock_megatron_cfg.model.tensor_model_parallel_size = 1
+        mock_megatron_cfg.tokenizer.hf_tokenizer_kwargs = None
+        mock_megatron_cfg.checkpoint.load = None
+        mock_megatron_cfg.checkpoint.pretrained_checkpoint = None
+        mock_megatron_cfg.ddp.overlap_param_gather = False
+        mock_megatron_cfg.ddp.align_param_gather = False
+        mock_megatron_cfg.dist.use_torch_fsdp2 = False
+
+        mock_model = [MagicMock()]
+        mock_get_model.return_value = mock_model
+        mock_get_attached_draft_model.return_value = None
+        mock_tensor_instance = MagicMock()
+        mock_tensor_instance.item.return_value = 0.0
+        mock_tensor.return_value = mock_tensor_instance
+        mock_checkpoint_exists.return_value = False
+
+        fake_bi_module = ModuleType(
+            "megatron.core.transformer.custom_layers.batch_invariant_kernels"
+        )
+        fake_bi_module.enable_batch_invariant_mode = MagicMock()
+
+        policy_cfg = {
+            "megatron_cfg": {
+                "freeze_moe_router": False,
+            }
+        }
+
+        with patch.dict(
+            sys.modules,
+            {
+                "megatron.core.transformer.custom_layers.batch_invariant_kernels": fake_bi_module
+            },
+        ):
+            setup_model_and_optimizer(
+                policy_cfg=policy_cfg,
+                megatron_cfg=mock_megatron_cfg,
+                load_optimizer=False,
+            )
+
+        fake_bi_module.enable_batch_invariant_mode.assert_called_once_with()
 
 
 @pytest.mark.mcore

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -110,6 +110,10 @@ policy:
   logprob_batch_size: ${policy.train_micro_batch_size}
   max_total_sequence_length: 512
   precision: "bfloat16"
+  # Enable BF16 true-on-policy numeric matching. This enables Megatron
+  # batch-invariant mode and BF16 parity patches for supported generation
+  # backends. Recommended default: false.
+  bf16_true_on_policy: false
   logprob_chunk_size: null
   offload_optimizer_for_logprob: false # Only useful for non-colocated generation since colocated generation will always offload optimizer to cuda before refit
 


### PR DESCRIPTION
# What does this PR do ?

This branch adds BF16-only true-on-policy parity support across Megatron training and vLLM generation, controlled by `policy.bf16_true_on_policy`. It intentionally excludes MXFP8 rollout support and vLLM MXFP8 batch-invariant kernel support.

Compared against `main` at `28da2e00`.

## Commits

- `0c155459` `feat(megatron): enable BF16 true-on-policy batch-invariant mode`
- `4f4c1a3a` `feat(vllm): add BF16-only true-on-policy parity patches`

## Changes

### Megatron BF16 Batch-Invariant Mode

- Adds `policy.bf16_true_on_policy` to policy config typing and exemplar configs.
- Maps `policy.bf16_true_on_policy=True` to Megatron model `batch_invariant_mode`.
- Calls Megatron-Core `enable_batch_invariant_mode()` during setup when enabled.
- Adds unit coverage for config propagation and gated Megatron BI enablement.

### GRPO Setup and Validation

- Wires `bf16_true_on_policy` into vLLM generation setup.
- Rejects unsupported vLLM true-on-policy combinations:
  - `async_engine=true`
  - non-`bfloat16` vLLM precision
- Configures vLLM graph behavior for BF16 parity when not running eager:
  - disables torch compile via `compilation_config.mode = 0`
  - keeps decode CUDA graphs via `cudagraph_mode = "FULL_DECODE_ONLY"`
  - clears `splitting_ops`
- Adds unit coverage for validation and vLLM compilation config mutation.

### vLLM BF16 True-On-Policy Parity Patches

- Adds BF16-only vLLM patch module for:
  - Megatron-style RMSNorm
  - Megatron-style RoPE
  - Megatron-style SwiGLU
- Supports component selection through `NEMO_RL_VLLM_TRUE_ON_POLICY_PATCH_COMPONENTS`.
- Installs class-level patches before vLLM engine construction so captured graphs see patched implementations.
- Adds runtime collective installation/rebinding through the aggregate `install_true_on_policy_patches()` path.
- Forwards required true-on-policy env vars into vLLM worker processes.
- Does not add MXFP8 matmul patching or vLLM MXFP8 batch-invariant kernel support.

## Tests Added

- Megatron setup tests for `bf16_true_on_policy` config and BI enablement.
- GRPO tests for BF16 vLLM validation and compilation config setup.
- vLLM patch component tests for default components, selected components, disabled mode, and invalid components.
- vLLM generation/worker tests for aggregate true-on-policy patch RPC behavior.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
