### PR TITLE
test: disable flaky grpo-qwen3.5-35ba3b-2n8g-automodel-ep16 nightly

### DIFF
--- a/tests/test_suites/disabled.txt
+++ b/tests/test_suites/disabled.txt
@@ -2,6 +2,8 @@
 # Disable this due to known vLLM crash issue with Qwen3.5: https://github.com/vllm-project/vllm/issues/36237
 tests/test_suites/vlm/vlm_grpo-qwen3.5-35ba3b-geo3k-2n8g-automodel-ep16.sh
 tests/test_suites/vlm/vlm_grpo-qwen3.5-35ba3b-geo3k-2n8g-megatron-ep16.sh
+# Flaky hang (passes on rerun); same vLLM issue, unresolved as of vLLM 0.20. Re-enable after next vLLM bump.
+tests/test_suites/llm/grpo-qwen3.5-35ba3b-2n8g-automodel-ep16.sh
 
 # Disable this due to know vLLM bug with Qwen3.5: https://github.com/vllm-project/vllm/issues/37856
 tests/test_suites/llm/grpo-qwen3.5-397ba17b-32n8g-megatron.v2.sh

--- a/tests/test_suites/nightly.txt
+++ b/tests/test_suites/nightly.txt
@@ -32,7 +32,8 @@ tests/test_suites/llm/grpo-moonlight-16ba3b-4n8g-megatron.sh
 tests/test_suites/llm/grpo-qwen3.5-9b-1n8g-megatron.sh
 
 # Functional Qwen3.5-35B run (text-only task)
-tests/test_suites/llm/grpo-qwen3.5-35ba3b-2n8g-automodel-ep16.sh
+# Disabled due to known flaky vLLM hang with Qwen3.5 (see disabled.txt): https://github.com/vllm-project/vllm/issues/36237
+# tests/test_suites/llm/grpo-qwen3.5-35ba3b-2n8g-automodel-ep16.sh
 tests/test_suites/llm/grpo-qwen3.5-35ba3b-2n8g-megatron-ep16tp2cp2.sh
 
 # Functional VLM run


### PR DESCRIPTION
Known flaky vLLM hang with Qwen3.5 (generation hangs until RAY_CGRAPH_get_timeout), unresolved as of vLLM 0.20. Passes on rerun. Move the recipe to disabled.txt (same vLLM issue already tracked for the Qwen3.5 VLM recipes) and comment it out in nightly.txt with a breadcrumb. Re-enable after the next vLLM bump.

Ref: https://github.com/vllm-project/vllm/issues/36237

# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
