### PR TITLE
chore: loosen metric in cispo nightly

### DIFF
--- a/tests/test_suites/llm/grpo-cispo-mm1-async-lag1-highoffpolicy-qwen3-30ba3b-3n8g-megatron-cispo.sh
+++ b/tests/test_suites/llm/grpo-cispo-mm1-async-lag1-highoffpolicy-qwen3-30ba3b-3n8g-megatron-cispo.sh
@@ -36,6 +36,5 @@ if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | ma
     uv run tests/check_metrics.py $JSON_METRICS \
         'mean(data["train/reward"]) > 0.50' \
         'median(data["train/token_mult_prob_error"]) < 1.1' \
-        "data[\"train/token_mult_prob_error\"][\"${MAX_STEPS}\"] < 1.1" \
         'mean(data["timing/train/total_step_time"], -6, -1) < 300'
 fi


### PR DESCRIPTION
remove check at step 10 since flaky and still guard using `'median(data["train/token_mult_prob_error"]) < 1.1'`.

pink: the run when adding the feature (three weeks ago)
others: recent run
<img width="1720" height="307" alt="image" src="https://github.com/user-attachments/assets/5d827cba-471a-4d79-a64b-80429a6038a8" />