### PR TITLE
fix: add validation for make_sequence_length_divisible_by

### DIFF
--- a/nemo_rl/models/automodel/setup.py
+++ b/nemo_rl/models/automodel/setup.py
@@ -72,7 +72,11 @@ from nemo_rl.models.automodel.config import (
     RuntimeConfig,
 )
 from nemo_rl.models.policy import PolicyConfig, TokenizerConfig
-from nemo_rl.models.policy.utils import configure_dynamo_cache, resolve_model_class
+from nemo_rl.models.policy.utils import (
+    configure_dynamo_cache,
+    resolve_model_class,
+    validate_sequence_length_divisibility,
+)
 
 STRING_TO_DTYPE = {
     "float32": torch.float32,
@@ -314,14 +318,30 @@ def validate_and_prepare_config(
         "Please use the Megatron backend (policy.megatron_cfg.enabled=True) for YaRN."
     )
 
+    tp_size = config["dtensor_cfg"].get("tensor_parallel_size", 1)
+    cp_size = config["dtensor_cfg"].get("context_parallel_size", 1)
+    sequence_parallel_enabled = config["dtensor_cfg"]["sequence_parallel"]
+
+    if cp_size > 1 and enable_seq_packing:
+        raise ValueError(
+            "Context parallel is not supported for sequence packing. "
+            "Refer to https://github.com/NVIDIA-NeMo/RL/blob/main/docs/model-quirks.md#context-parallel-with-fsdp2 for more details."
+        )
+
+    validate_sequence_length_divisibility(
+        config["make_sequence_length_divisible_by"],
+        context_parallel_size=cp_size,
+        tensor_parallel_size=tp_size,
+        sequence_parallel=sequence_parallel_enabled,
+    )
+
     # NeMoAutoModelForCausalLM uses flash_attention_2 by default
     # so we need to set it to None if sequence packing is disabled
     # See https://github.com/NVIDIA-NeMo/Automodel/blob/7e748be260651349307862426c0c168cebdeeec3/nemo_automodel/components/_transformers/auto_model.py#L180
-    cp_size_cfg = config["dtensor_cfg"]["context_parallel_size"]
     attn_impl = (
         "flash_attention_2"
-        if (enable_seq_packing and cp_size_cfg == 1)
-        else ("sdpa" if cp_size_cfg > 1 else None)
+        if (enable_seq_packing and cp_size == 1)
+        else ("sdpa" if cp_size > 1 else None)
     )
 
     # Load model config
@@ -374,18 +394,6 @@ def validate_and_prepare_config(
             raise ValueError(f"Unknown reward model type: {rm_type}")
     else:
         model_class = resolve_model_class(model_config.model_type)
-
-    # Get parallelization sizes
-    tp_size = config["dtensor_cfg"].get("tensor_parallel_size", 1)
-    cp_size = config["dtensor_cfg"].get("context_parallel_size", 1)
-    sequence_parallel_enabled = config["dtensor_cfg"]["sequence_parallel"]
-
-    # Validate parallelization configuration
-    if cp_size > 1 and enable_seq_packing:
-        raise ValueError(
-            "Context parallel is not supported for sequence packing. "
-            "Refer to https://github.com/NVIDIA/NeMo-RL/blob/main/docs/model-quirks.md#context-parallel-with-fsdp2 for more details."
-        )
 
     if sequence_parallel_enabled and tp_size == 1:
         print(

--- a/nemo_rl/models/policy/utils.py
+++ b/nemo_rl/models/policy/utils.py
@@ -220,6 +220,37 @@ def configure_dynamo_cache() -> None:
     torch._inductor.config.autotune_local_cache = False
 
 
+def validate_sequence_length_divisibility(
+    make_sequence_length_divisible_by: int,
+    *,
+    context_parallel_size: int,
+    tensor_parallel_size: int,
+    sequence_parallel: bool,
+) -> None:
+    """Validate the sequence-padding multiple required by CP and TP+SP."""
+    minimum_pad_factor = 1
+    if context_parallel_size > 1:
+        minimum_pad_factor *= 2 * context_parallel_size
+    if tensor_parallel_size > 1 and sequence_parallel:
+        minimum_pad_factor *= tensor_parallel_size
+
+    if (
+        make_sequence_length_divisible_by <= 0
+        or make_sequence_length_divisible_by % minimum_pad_factor != 0
+    ):
+        raise ValueError(
+            "make_sequence_length_divisible_by "
+            f"({make_sequence_length_divisible_by}) must be a positive multiple "
+            f"of the minimum pad factor ({minimum_pad_factor}).\n"
+            f"Please set policy.make_sequence_length_divisible_by to a positive "
+            f"multiple of {minimum_pad_factor}.\n"
+            "    - CP requires `2 * context_parallel_size`.\n"
+            "    - TP requires `tensor_parallel_size` only when sequence parallel "
+            "is enabled.\n"
+            "    - When both constraints apply, their factors are multiplied."
+        )
+
+
 def get_runtime_env_for_policy_worker(policy_worker_name: str) -> dict[str, Any]:
     """Get runtime environment configuration for policy workers.
 

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -85,6 +85,7 @@ from nemo_rl.models.policy.utils import (
     configure_dynamo_cache,
     get_runtime_env_for_policy_worker,
     resolve_model_class,
+    validate_sequence_length_divisibility,
 )
 from nemo_rl.models.policy.workers.base_policy_worker import AbstractPolicyWorker
 from nemo_rl.models.policy.workers.checkpoint_engine import (
@@ -257,6 +258,16 @@ class DTensorPolicyWorkerImpl(
         configure_dynamo_cache()
 
         self.cfg = config
+        tp_size = self.cfg["dtensor_cfg"]["tensor_parallel_size"]
+        cp_size = self.cfg["dtensor_cfg"]["context_parallel_size"]
+        sequence_parallel_enabled = self.cfg["dtensor_cfg"]["sequence_parallel"]
+        validate_sequence_length_divisibility(
+            self.cfg["make_sequence_length_divisible_by"],
+            context_parallel_size=cp_size,
+            tensor_parallel_size=tp_size,
+            sequence_parallel=sequence_parallel_enabled,
+        )
+
         # torch distributed init. Envars for rank, world_size, and master_addr and master_port are set from the ray remote call
         torch.distributed.init_process_group(backend="nccl")
         self.rank = torch.distributed.get_rank()
@@ -287,6 +298,11 @@ class DTensorPolicyWorkerImpl(
                 f"[Rank {self.rank}] Sequence packing is enabled for model {model_name}"
             )
             print(f"[Rank {self.rank}] Using FlashAttention2 for sequence packing")
+
+        if cp_size > 1 and self.enable_seq_packing:
+            raise ValueError(
+                "Context parallel is not supported for sequence packing. Refer to https://github.com/NVIDIA-NeMo/RL/blob/main/docs/model-quirks.md#context-parallel-with-fsdp2 for more details."
+            )
 
         hf_config_overrides = self.cfg.get("hf_config_overrides", {}) or {}
 
@@ -362,14 +378,7 @@ class DTensorPolicyWorkerImpl(
         if getattr(self.model.config, "pad_token_id", None) is None:
             self.model.config.pad_token_id = tokenizer.pad_token_id
 
-        tp_size = self.cfg["dtensor_cfg"]["tensor_parallel_size"]
-        cp_size = self.cfg["dtensor_cfg"]["context_parallel_size"]
-        if cp_size > 1 and self.enable_seq_packing:
-            raise ValueError(
-                "Context parallel is not supported for sequence packing. Refer to https://github.com/NVIDIA/NeMo-RL/blob/main/docs/model-quirks.md#context-parallel-with-fsdp2 for more details."
-            )
         dp_size = world_size // tp_size // cp_size
-        sequence_parallel_enabled = self.cfg["dtensor_cfg"]["sequence_parallel"]
         assert world_size == dp_size * tp_size * cp_size, (
             f"World size({world_size}) must equal to dp_size({dp_size}) * tp_size({tp_size}) * cp_size({cp_size}) to use DTensor"
         )

--- a/tests/unit/environments/test_reward_model_environment.py
+++ b/tests/unit/environments/test_reward_model_environment.py
@@ -57,6 +57,7 @@ basic_env_config: RewardModelEnvironmentConfig = {
     "dynamic_batching": {"enabled": False},
     "sequence_packing": {"enabled": False},
     "max_grad_norm": None,
+    "make_sequence_length_divisible_by": 1,
 }
 
 

--- a/tests/unit/models/automodel/test_automodel_setup.py
+++ b/tests/unit/models/automodel/test_automodel_setup.py
@@ -54,6 +54,7 @@ def mock_config():
         "max_grad_norm": 1.0,
         "offload_optimizer_for_logprob": False,
         "sequence_packing": {"enabled": False},
+        "make_sequence_length_divisible_by": 1,
         "dtensor_cfg": {
             "cpu_offload": False,
             "tensor_parallel_size": 1,
@@ -260,6 +261,26 @@ class TestValidateAndPrepareConfig:
     @patch("nemo_rl.models.automodel.setup.AutoConfig")
     @patch("nemo_rl.models.automodel.setup.resolve_model_class")
     @patch("nemo_rl.models.automodel.setup.configure_dynamo_cache")
+    def test_make_sequence_length_divisible_by_rejects_invalid_cp_multiple(
+        self,
+        mock_dynamo,
+        mock_resolve_class,
+        mock_autoconfig_class,
+        mock_config,
+    ):
+        mock_config["dtensor_cfg"]["context_parallel_size"] = 2
+        mock_config["make_sequence_length_divisible_by"] = 2
+
+        with pytest.raises(ValueError, match=r"minimum pad factor \(4\)"):
+            validate_and_prepare_config(
+                config=mock_config,
+                processor=None,
+                rank=0,
+            )
+
+    @patch("nemo_rl.models.automodel.setup.AutoConfig")
+    @patch("nemo_rl.models.automodel.setup.resolve_model_class")
+    @patch("nemo_rl.models.automodel.setup.configure_dynamo_cache")
     def test_attention_implementation_selection(
         self,
         mock_dynamo,
@@ -281,11 +302,13 @@ class TestValidateAndPrepareConfig:
         # Test SDPA for cp > 1
         mock_config["sequence_packing"]["enabled"] = False
         mock_config["dtensor_cfg"]["context_parallel_size"] = 2
+        mock_config["make_sequence_length_divisible_by"] = 4
         result = validate_and_prepare_config(mock_config, None, 0)
         assert result.attn_impl == "sdpa"
 
         # Test None for cp=1 without sequence packing
         mock_config["dtensor_cfg"]["context_parallel_size"] = 1
+        mock_config["make_sequence_length_divisible_by"] = 1
         result = validate_and_prepare_config(mock_config, None, 0)
         assert result.attn_impl is None
 

--- a/tests/unit/models/policy/test_dtensor_worker.py
+++ b/tests/unit/models/policy/test_dtensor_worker.py
@@ -149,6 +149,9 @@ def create_test_config(
             },
         },
         "max_grad_norm": 1.0,
+        "make_sequence_length_divisible_by": (
+            (2 * cp if cp > 1 else 1) * (tp if tp > 1 and sp else 1)
+        ),
     }
 
 

--- a/tests/unit/models/policy/test_dtensor_worker_v2.py
+++ b/tests/unit/models/policy/test_dtensor_worker_v2.py
@@ -178,6 +178,9 @@ def create_test_config(
             },
         },
         "max_grad_norm": 1.0,
+        "make_sequence_length_divisible_by": (
+            (2 * cp if cp > 1 else 1) * (tp if tp > 1 and sp else 1)
+        ),
     }
     if automodel_kwargs is not None:
         config["dtensor_cfg"]["automodel_kwargs"] = automodel_kwargs

--- a/tests/unit/models/policy/test_policy_validation.py
+++ b/tests/unit/models/policy/test_policy_validation.py
@@ -108,6 +108,7 @@ def create_dtensor_config(
         "sequence_packing": {
             "enabled": False,
         },
+        "make_sequence_length_divisible_by": 2 * cp if cp > 1 else 1,
         "optimizer": {
             "name": "torch.optim.AdamW",
             "lr": 5e-6,

--- a/tests/unit/models/policy/test_utils.py
+++ b/tests/unit/models/policy/test_utils.py
@@ -32,7 +32,71 @@ from nemo_rl.models.policy.utils import (
     get_megatron_checkpoint_dir,
     rebuild_cuda_tensor_from_ipc,
     stream_weights_via_ipc_zmq_impl,
+    validate_sequence_length_divisibility,
 )
+
+
+@pytest.mark.parametrize(
+    (
+        "make_sequence_length_divisible_by",
+        "context_parallel_size",
+        "tensor_parallel_size",
+        "sequence_parallel",
+    ),
+    [
+        (1, 1, 1, False),
+        (4, 2, 1, False),
+        (4, 1, 4, True),
+        (16, 2, 4, True),
+    ],
+)
+def test_validate_sequence_length_divisibility_accepts_valid_multiples(
+    make_sequence_length_divisible_by,
+    context_parallel_size,
+    tensor_parallel_size,
+    sequence_parallel,
+):
+    validate_sequence_length_divisibility(
+        make_sequence_length_divisible_by,
+        context_parallel_size=context_parallel_size,
+        tensor_parallel_size=tensor_parallel_size,
+        sequence_parallel=sequence_parallel,
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        "make_sequence_length_divisible_by",
+        "context_parallel_size",
+        "tensor_parallel_size",
+        "sequence_parallel",
+        "minimum_pad_factor",
+    ),
+    [
+        (0, 1, 1, False, 1),
+        (2, 2, 1, False, 4),
+        (2, 1, 4, True, 4),
+        # This distinguishes the product requirement (16) from an LCM (4).
+        (8, 2, 4, True, 16),
+    ],
+)
+def test_validate_sequence_length_divisibility_rejects_invalid_multiples(
+    make_sequence_length_divisible_by,
+    context_parallel_size,
+    tensor_parallel_size,
+    sequence_parallel,
+    minimum_pad_factor,
+):
+    with pytest.raises(
+        ValueError,
+        match=rf"positive multiple of the minimum pad factor \({minimum_pad_factor}\)",
+    ):
+        validate_sequence_length_divisibility(
+            make_sequence_length_divisible_by,
+            context_parallel_size=context_parallel_size,
+            tensor_parallel_size=tensor_parallel_size,
+            sequence_parallel=sequence_parallel,
+        )
 
 
 class TestGetMegatronCheckpointDir:

--- a/tests/unit/utils/test_native_checkpoint.py
+++ b/tests/unit/utils/test_native_checkpoint.py
@@ -69,6 +69,7 @@ simple_policy_config = {
         "enabled": False,
     },
     "max_grad_norm": 1.0,
+    "make_sequence_length_divisible_by": 1,
     "generation": {
         "temperature": 1.0,
         "top_p": 1.0,


### PR DESCRIPTION
## Summary

PR #2933 fixed a flaky `distillation_nemo_gym` CI test by hardcoding
`make_sequence_length_divisible_by=4`. This PR adds an early, actionable
validation for the underlying DTensor sequence-length constraint.

### Confirmed constraint

- Context parallel load balancing requires a multiple of
  `2 * context_parallel_size`.
- Tensor parallelism adds a `tensor_parallel_size` factor only when sequence
  parallelism is enabled.
- If both constraints apply, the required factor is their product, not their
  least common multiple.
- NeMo RL currently rejects DTensor CP together with TP+SP, so supported
  configurations effectively use either the CP factor or the TP+SP factor.

### Changes

- Add one shared `validate_sequence_length_divisibility` helper.
- Call it from both the DTensor V1 worker and the Automodel/DTensor V2 setup
  before model loading.
- Raise a clear `ValueError` that reports the required minimum pad factor.
- Add unit coverage for valid and invalid CP, TP+SP, positivity, and the
  product-vs-LCM case.
- Keep example and reference YAML recipes unchanged, per the earlier design
  discussion.

## Testing

- `8 passed` for the focused sequence-divisibility unit tests.
- Ruff 0.9.9 lint, import sorting, and format checks pass on every changed
  Python file.
