### PR TITLE
ci: use NVIDIA inference for Claude review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,8 +13,9 @@ permissions:
 jobs:
   claude-review:
     if: github.event.issue.pull_request != null && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@v0.79.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@v1.7.0
     with:
+      model: ${{ vars.CLAUDE_MODEL }}
       prompt: |
         Mandatory workflow — never skip or reorder:
         1. Read the PR diff first.
@@ -44,4 +45,5 @@ jobs:
         It's perfectly acceptable to not have anything to comment on.
         If you do not have anything to comment on, post "LGTM".
     secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      NVIDIA_INFERENCE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
+      NVIDIA_INFERENCE_KEY: ${{ secrets.NVIDIA_INFERENCE_KEY }}


### PR DESCRIPTION
# What does this PR do ?

Updates the Claude review workflow to use the released FW-CI-templates `v1.7.0` NVIDIA inference configuration.

# Issues

Linear: AUT-644

# Usage

N/A. CI workflow configuration only.

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Did you write any new necessary tests? N/A, workflow secret/tag update only.
- [x] Did you run the unit tests and functional tests locally? N/A; validated workflow YAML parsing.
- [x] Did you add or update any necessary documentation? N/A.

# Additional Information

- Bumps `_claude_review.yml` to `v1.7.0`.
- Passes `vars.CLAUDE_MODEL`, `secrets.NVIDIA_INFERENCE_URL`, and `secrets.NVIDIA_INFERENCE_KEY`.