### PR TITLE
ci: increase timeout for grpo-qwen2.5-32b-32n8g-fsdp2tp8-actckpt.v3 by 15 min

### DIFF
--- a/tests/test_suites/llm/grpo-qwen2.5-32b-32n8g-fsdp2tp8-actckpt.v3.sh
+++ b/tests/test_suites/llm/grpo-qwen2.5-32b-32n8g-fsdp2tp8-actckpt.v3.sh
@@ -7,7 +7,7 @@ NUM_NODES=32
 STEPS_PER_RUN=2  # step_time: [220, 310]
 MAX_STEPS=2
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
-NUM_MINUTES=60
+NUM_MINUTES=75
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached


### PR DESCRIPTION
## Summary
- Increases `NUM_MINUTES` from 60 → 75 for `llm_grpo_qwen2_5_32b_32n8g_fsdp2tp8_actckpt_v3`

## Test plan
- [ ] CI passes with the relaxed time limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)