### PR TITLE
fix(grpo): restore NeMo Gym response logging guard in async training

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -3730,6 +3730,11 @@ def async_grpo_train(
                             per_group_metrics.setdefault(k, []).append(v)
                     rollout_metrics = aggregate_rollout_metrics(per_group_metrics)
 
+                    if not _should_log_nemo_gym_responses(master_config):
+                        for key in list(rollout_metrics):
+                            if "full_result" in key:
+                                rollout_metrics.pop(key)
+
                 # Enforce fixed training batch: num_prompts_per_step * num_generations_per_prompt
                 expected_batch_size = (
                     master_config.grpo["num_prompts_per_step"]


### PR DESCRIPTION
# What does this PR do ?

Respect `env.should_log_nemo_gym_responses` in async GRPO so NeMo Gym `full_result` rollout payloads are not sent to configured loggers, including W&B, when response logging is disabled. This aligns the async path with the existing synchronous behavior.

# Issues

N/A

# Usage

Set `env.should_log_nemo_gym_responses: false`; async GRPO will retain normal rollout metrics while excluding `full_result` payloads from training metrics.

# Before your PR is "Ready for review"

- [x] Read and followed the contributor guidelines.
- [x] No new tests were added; this is a five-line parity fix using the existing synchronous guard.
- [ ] Unit and functional tests were not run locally because `uv` is unavailable in this workspace.
- [x] No documentation changes are needed.

# Additional Information

- `git diff --check` passes.
