### PR TITLE
Added Logging, evals and training setup for my local setup. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,9 +41,14 @@ results/
 code_snapshots*/
 .cache/
 
+# Claude Code local files — ignore everything (skills are local-only)
+.claude/
+# Local operational skills (launch-skypilot, etc.) — local-only, not committed
+skills/
+
 # Runtime env
 *runtime_env.yaml
 !default_runtime_env.yaml
 
-# Claude Code review memory (local only)
-.claude/review-memory/
+# Local secrets — never commit
+.env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ NeMo-RL is an RLHF training framework built on Ray and PyTorch (FSDP2 / Megatron
 Coding guidelines and operational procedures are organized as Claude skills in
 two locations:
 
-- `skills/` — customer-facing operational skills (launch-nemo-rl, auto-research, brev-etiquette, docs)
+- `skills/` — operational skills (launch-skypilot, launch-nemo-rl, auto-research, brev-etiquette, docs)
 - `.agents/contributor-skills/` — contributor-facing development guidelines (testing, linting, CI/CD, review, etc.)
 
 All skills are symlinked into `.claude/skills/` for unified discovery.
@@ -39,6 +39,18 @@ When reviewing code, follow these principles:
 - **Compare new components to their nearest internal analog.** A new worker group, estimator, or config block should mirror the established pattern (backend dispatch, override hooks, guards, typing, return shape) or justify diverging.
 - It is perfectly acceptable to have nothing to comment on. Say "LGTM" if so.
 
-## Kubernetes / nrl-k8s
+## Launching training (SkyPilot — this fork's default)
 
-For launching, monitoring, stopping, and debugging NeMo-RL recipes on Kubernetes, see the skill at @skills/launch-nemo-rl/SKILL.md.
+This fork trains via **SkyPilot managed jobs** on a Teleport hyperpod H200
+cluster, driven by `skypilot/launch.sh <recipe>`. For any request to run,
+launch, submit, monitor, or stop an experiment/recipe here, use the
+**launch-skypilot** skill (@skills/launch-skypilot/SKILL.md) — it is the default
+launch path. Never use interactive `sky launch`; only `sky jobs launch` (which
+the script calls).
+
+## Kubernetes / nrl-k8s (not used in this setup)
+
+The upstream `nrl-k8s` Kubernetes path (`kubectl`, `RayJob`/`RayCluster`) is
+documented in @skills/launch-nemo-rl/SKILL.md. Only use it when the user
+explicitly asks about `nrl-k8s`/Kubernetes — otherwise launches go through
+launch-skypilot above.

--- a/examples/configs/evals/eval.yaml
+++ b/examples/configs/evals/eval.yaml
@@ -53,3 +53,23 @@ env:
 cluster:
   gpus_per_node: 1
   num_nodes: 1
+
+# Logging. Off by default so a bare `run_eval.py` needs no W&B credentials; the
+# multi-benchmark runner (run_multibench_eval.sh) turns wandb on and sets an
+# "_eval"-suffixed run name per benchmark. run_eval.py disables wandb gracefully
+# if wandb_enabled is true but WANDB_API_KEY is not set.
+logger:
+  log_dir: "logs"
+  wandb_enabled: false
+  swanlab_enabled: false
+  tensorboard_enabled: false
+  mlflow_enabled: false
+  monitor_gpus: false
+  wandb:
+    project: "nemo-rl-evals"
+    name: "eval"
+    # group is set per run by run_multibench_eval.sh to group a suite's benchmarks
+    tags: ["eval"]
+  gpu_monitoring:
+    collection_interval: 10.0
+    flush_interval: 10.0

--- a/examples/configs/evals/nemotron3_nano_30b_eval.yaml
+++ b/examples/configs/evals/nemotron3_nano_30b_eval.yaml
@@ -1,0 +1,61 @@
+# Evaluation config: NVIDIA Nemotron-3 Nano 30B-A3B (30B-total / 3B-active MoE, reasoning model)
+#
+# This is a *base* config: model + sampling + cluster settings. It defaults to
+# the MATH-500 benchmark so it is runnable standalone, but the intended use is
+# the multi-benchmark runner, which overrides data.dataset_name / prompt_file /
+# env.math.verifier_type / eval.save_path per benchmark:
+#
+#   examples/configs/evals/run_multibench_eval.sh \
+#     examples/configs/evals/nemotron3_nano_30b_eval.yaml nemotron3_nano_30b
+#
+# Standalone (single benchmark) example:
+#   uv run python examples/run_eval.py \
+#     --config examples/configs/evals/nemotron3_nano_30b_eval.yaml \
+#     data.dataset_name=aime2024 eval.num_tests_per_prompt=16 \
+#     eval.save_path=results/evals/nemotron3_nano_30b/aime2024
+defaults: "eval.yaml"
+
+eval:
+  metric: "pass@k"
+  k_value: 1
+  # avg pass@1 over N samples; set per-benchmark by the runner (AIME needs more
+  # samples because it only has 30 problems). Overridden per benchmark.
+  num_tests_per_prompt: 1
+  save_path: null # set by the runner per benchmark
+
+generation:
+  model_name: "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
+  # Reasoning-model sampling. Verify against the model card and adjust if the
+  # recommended values differ.
+  temperature: 0.6
+  top_p: 0.95
+  top_k: -1 # -1 disables top-k
+  vllm_cfg:
+    # 30B MoE on a full 8xH200 node; TP=8 maximizes KV-cache room for the long
+    # reasoning traces. Lower to 4 if you want to leave GPUs free.
+    tensor_parallel_size: 8
+    pipeline_parallel_size: 1
+    expert_parallel_size: 1
+    # Long context for reasoning outputs. max_new_tokens inherits this from eval.yaml.
+    max_model_len: 32768
+    # Lowered from 0.9 for warm-up headroom, and enforce_eager=true skips CUDA
+    # graph capture, which is where the first launch's vLLM worker crashed
+    # (ActorDiedError during compile_or_warm_up_model). Revisit once it runs.
+    gpu_memory_utilization: 0.85
+    enforce_eager: true
+
+tokenizer:
+  name: ${generation.model_name}
+  # Use the model's native chat template. For a reasoning model this typically
+  # enables thinking by default; toggle via chat_template_kwargs or a system
+  # prompt per the model card if you need to control it.
+  chat_template: "default"
+  chat_template_kwargs: null
+
+data:
+  prompt_file: "examples/prompts/cot.txt"
+  dataset_name: "math500" # default; overridden per benchmark by the runner
+
+cluster:
+  gpus_per_node: 8
+  num_nodes: 1

--- a/examples/configs/evals/qwen3vl_4b_eval.yaml
+++ b/examples/configs/evals/qwen3vl_4b_eval.yaml
@@ -1,0 +1,49 @@
+# Evaluation config: Qwen3-VL-4B-Instruct (the model used in the GRPO Qwen runs)
+#
+# The selected benchmarks (MATH-500, AIME, GPQA-diamond, MMLU-Pro) are all
+# TEXT benchmarks, so this VLM is evaluated through its text path
+# (run_eval only treats `mmau` as multimodal, so the processor is not loaded).
+#
+# Base config: model + sampling + cluster. Defaults to MATH-500 so it runs
+# standalone, but the intended use is the multi-benchmark runner:
+#
+#   examples/configs/evals/run_multibench_eval.sh \
+#     examples/configs/evals/qwen3vl_4b_eval.yaml qwen3vl_4b_instruct
+defaults: "eval.yaml"
+
+eval:
+  metric: "pass@k"
+  k_value: 1
+  # avg pass@1 over N samples; set per-benchmark by the runner. Light sampling
+  # (below) makes multi-sample averaging meaningful for small sets like AIME.
+  num_tests_per_prompt: 1
+  save_path: null # set by the runner per benchmark
+
+generation:
+  model_name: "Qwen/Qwen3-VL-4B-Instruct"
+  # Light sampling so avg@k over multiple samples is meaningful. For a strictly
+  # deterministic single-shot run instead, override temperature=0.0 top_p=1.0
+  # and eval.num_tests_per_prompt=1.
+  temperature: 0.6
+  top_p: 0.95
+  top_k: -1
+  vllm_cfg:
+    tensor_parallel_size: 1 # 4B fits on a single GPU
+    pipeline_parallel_size: 1
+    expert_parallel_size: 1
+    max_model_len: 16384 # room for CoT on AIME/MATH; max_new_tokens inherits this
+    gpu_memory_utilization: 0.9
+    enforce_eager: false
+
+tokenizer:
+  name: ${generation.model_name}
+  chat_template: "default" # native Qwen3-VL chat template
+  chat_template_kwargs: null
+
+data:
+  prompt_file: "examples/prompts/cot.txt"
+  dataset_name: "math500" # default; overridden per benchmark by the runner
+
+cluster:
+  gpus_per_node: 8
+  num_nodes: 1

--- a/examples/configs/evals/run_multibench_eval.sh
+++ b/examples/configs/evals/run_multibench_eval.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Run a NeMo-RL eval config across a fixed benchmark suite, saving each
+# benchmark's results to its own subdirectory. run_eval.py evaluates a single
+# dataset per invocation, so this issues one call per benchmark.
+#
+# Usage:
+#   examples/configs/evals/run_multibench_eval.sh <eval_config.yaml> <run_name> [extra hydra overrides...]
+#
+# Examples:
+#   examples/configs/evals/run_multibench_eval.sh \
+#     examples/configs/evals/nemotron3_nano_30b_eval.yaml nemotron3_nano_30b
+#
+#   examples/configs/evals/run_multibench_eval.sh \
+#     examples/configs/evals/qwen3vl_4b_eval.yaml qwen3vl_4b_instruct
+#
+# Any extra args are forwarded to every run_eval.py call (e.g. to change a
+# model path or lower max_model_len for a quick smoke test).
+set -euo pipefail
+
+CONFIG="${1:?path to eval config yaml}"
+RUN_NAME="${2:?short run name used in the save path}"
+shift 2
+EXTRA_OVERRIDES=("$@")
+
+# Where per-benchmark results land. Defaults to a repo-local path for local
+# runs; the SkyPilot job overrides EVAL_RESULTS_ROOT to a persistent FSx path.
+RESULTS_ROOT="${EVAL_RESULTS_ROOT:-results/evals/${RUN_NAME}}"
+
+# Each row: name | dataset_name | prompt_file | verifier_type | num_tests_per_prompt
+# num_tests_per_prompt tuned per benchmark: AIME has only 30 problems so it
+# needs more samples for a stable avg@k; MMLU-Pro is ~12k questions so 1 sample
+# keeps cost sane. Tune these for your compute budget.
+BENCHMARKS=(
+  "math500|math500|examples/prompts/cot.txt|math|2"
+  "aime2024|aime2024|examples/prompts/cot.txt|math|16"
+  "aime2025|aime2025|examples/prompts/cot.txt|math|16"
+  "gpqa_diamond|gpqa_diamond|examples/prompts/gpqa.txt|multilingual_multichoice|2"
+  "mmlu_pro|mmlu_pro|examples/prompts/mmlu_pro.txt|english_multichoice|1"
+)
+
+echo "Config:       ${CONFIG}"
+echo "Run name:     ${RUN_NAME}"
+echo "Results root: ${RESULTS_ROOT}"
+echo
+
+FAILED_BENCHMARKS=()
+for entry in "${BENCHMARKS[@]}"; do
+  IFS='|' read -r name dataset prompt verifier ntests <<< "${entry}"
+  echo "=================================================================="
+  echo "  Evaluating ${RUN_NAME} on ${name} (num_tests_per_prompt=${ntests})"
+  echo "=================================================================="
+  # Don't let one benchmark's failure (e.g. a gated dataset, an OOM) abort the
+  # whole suite: log it, record it, and keep going. The aggregation below writes
+  # null for any benchmark without a results.json.
+  if ! uv run python examples/run_eval.py \
+    --config "${CONFIG}" \
+    data.dataset_name="${dataset}" \
+    data.prompt_file="${prompt}" \
+    env.math.verifier_type="${verifier}" \
+    eval.num_tests_per_prompt="${ntests}" \
+    eval.save_path="${RESULTS_ROOT}/${name}" \
+    logger.wandb_enabled=true \
+    logger.log_dir="${RESULTS_ROOT}/${name}/wandb" \
+    logger.wandb.project="${WANDB_PROJECT:-nemo-rl-evals}" \
+    logger.wandb.name="${RUN_NAME}_${name}_eval" \
+    logger.wandb.group="${RUN_NAME}_eval" \
+    ${EXTRA_OVERRIDES[@]+"${EXTRA_OVERRIDES[@]}"}; then
+    echo "!! Benchmark '${name}' FAILED; continuing with the rest of the suite."
+    FAILED_BENCHMARKS+=("${name}")
+  fi
+done
+
+if [ "${#FAILED_BENCHMARKS[@]}" -gt 0 ]; then
+  echo
+  echo "WARNING: these benchmarks failed and will be null in summary.json: ${FAILED_BENCHMARKS[*]}"
+fi
+
+echo
+echo "All benchmarks complete. Results saved under ${RESULTS_ROOT}/<benchmark>/"
+
+# Aggregate every benchmark's results.json (written by run_eval.py) into one
+# summary.json at the results root, so the whole suite's scores live in a single
+# file. Missing per-benchmark files (e.g. a benchmark that crashed) are recorded
+# as null rather than failing the aggregation.
+echo
+echo "Aggregating benchmark scores -> ${RESULTS_ROOT}/summary.json"
+BENCH_NAMES="$(printf '%s\n' "${BENCHMARKS[@]}" | cut -d'|' -f1 | paste -sd, -)"
+RUN_NAME="${RUN_NAME}" RESULTS_ROOT="${RESULTS_ROOT}" BENCH_NAMES="${BENCH_NAMES}" \
+  python3 - <<'PY'
+import json
+import os
+
+results_root = os.environ["RESULTS_ROOT"]
+run_name = os.environ["RUN_NAME"]
+names = [n for n in os.environ["BENCH_NAMES"].split(",") if n]
+
+results = {}
+scores = []
+for name in names:
+    path = os.path.join(results_root, name, "results.json")
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        results[name] = None
+        print(f"  ! {name}: results.json missing or unreadable")
+        continue
+    results[name] = data
+    scores.append(data["score"])
+    print(f"  - {name}: {data['metric']} = {data['score']:.4f}")
+
+summary = {
+    "run": run_name,
+    "results": results,
+    "average_over_benchmarks": (sum(scores) / len(scores)) if scores else None,
+    "num_benchmarks_reported": len(scores),
+    "num_benchmarks_expected": len(names),
+}
+out_path = os.path.join(results_root, "summary.json")
+os.makedirs(results_root, exist_ok=True)
+with open(out_path, "w") as f:
+    json.dump(summary, f, indent=2)
+print(f"  -> wrote {out_path}")
+PY

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -415,13 +415,13 @@ env:
 logger:
   log_dir: "logs"  # Base directory for all logs
   num_val_samples_to_print: 0 # Number of validation samples to pretty print on terminal
-  wandb_enabled: false
+  wandb_enabled: true
   tensorboard_enabled: false
   mlflow_enabled: false  # Disable MLflow logging
   swanlab_enabled: false # Disable SwanLab logging
   monitor_gpus: true  # If true, will monitor GPU usage and log to wandb and/or tensorboard
   wandb:
-    project: "grpo-dev"
+    project: "nemo-rl"
     name: "grpo-dev-logger"
   swanlab:
     project: "grpo-dev"

--- a/examples/configs/recipes/llm/grpo-deepscaler-1.5b-8K.yaml
+++ b/examples/configs/recipes/llm/grpo-deepscaler-1.5b-8K.yaml
@@ -40,4 +40,4 @@ env:
 logger:
   monitor_gpus: false
 cluster:
-  gpus_per_node: 8
+  gpus_per_node: 1

--- a/examples/run_eval.py
+++ b/examples/run_eval.py
@@ -29,6 +29,7 @@ from nemo_rl.environments.utils import create_env
 from nemo_rl.evals.eval import MasterConfig, run_env_eval, setup
 from nemo_rl.models.generation import configure_generation_config
 from nemo_rl.utils.config import load_config
+from nemo_rl.utils.logger import Logger
 
 
 def parse_args():
@@ -98,6 +99,26 @@ def main():
     print("Final config:")
     pprint.pprint(config)
 
+    # Build a logger if a logger config with wandb is present. Evals are marked
+    # with an "_eval" run-name suffix so they are easy to spot in W&B. If wandb
+    # is enabled but no API key is available, disable it rather than crashing the
+    # whole benchmark suite.
+    logger = None
+    logger_cfg = getattr(config, "logger", None)
+    if logger_cfg is not None and logger_cfg.get("wandb_enabled"):
+        if os.environ.get("WANDB_API_KEY"):
+            wandb_cfg = logger_cfg.setdefault("wandb", {})
+            run_name = wandb_cfg.get("name") or "eval"
+            if not run_name.endswith("_eval"):
+                run_name = f"{run_name}_eval"
+            wandb_cfg["name"] = run_name
+            logger = Logger(logger_cfg)
+        else:
+            print(
+                "⚠️ logger.wandb_enabled is true but WANDB_API_KEY is not set; "
+                "skipping W&B logging for this eval."
+            )
+
     # Init ray
     init_ray()
 
@@ -128,6 +149,7 @@ def main():
         dataloader,
         env,
         master_config,
+        logger=logger,
     )
 
 

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1311,6 +1311,41 @@ def dynamic_sampling(
             # Get the prompt indices with non-zero std
             non_zero_std_mask = std != 0.0
 
+            # Research diagnostic: among the std==0 prompt groups that dynamic
+            # sampling discards, track only the "all-incorrect" ones (every
+            # completion wrong) so we can watch whether the policy starts
+            # solving previously-unsolvable prompts as training progresses.
+            # This count should trend down if the model is improving on the
+            # hard tail. "All-correct" groups (std==0, reward>0) are
+            # intentionally NOT logged, per the request.
+            num_generations = master_config.grpo["num_generations_per_prompt"]
+            # Score correctness on the same reward std was filtered on: the raw
+            # task metric (unshaped) for DAPO, otherwise the total reward.
+            correctness_reward = (
+                repeated_batch["unshaped_total_reward"]
+                if "unshaped_total_reward" in repeated_batch
+                else total_rewards
+            )
+            # std==0 => every completion in the group scored identically, so a
+            # single reward==0 sample means the whole group is all-incorrect.
+            all_incorrect_sample_mask = (~non_zero_std_mask) & (
+                correctness_reward == 0.0
+            )
+            # Samples are laid out in contiguous groups of `num_generations`;
+            # dividing the sample count by the group size recovers the number
+            # of all-incorrect prompt groups (each contributes exactly
+            # `num_generations` samples).
+            num_prompts = std.numel() // num_generations
+            num_all_incorrect_prompts = (
+                int(all_incorrect_sample_mask.sum().item()) // num_generations
+            )
+            dynamic_sampling_metrics["dynamic_sampling_num_all_incorrect_prompts"] = (
+                num_all_incorrect_prompts
+            )
+            dynamic_sampling_metrics[
+                "dynamic_sampling_frac_all_incorrect_prompts"
+            ] = (num_all_incorrect_prompts / num_prompts if num_prompts > 0 else 0.0)
+
             keep_prompt_indices = torch.arange(
                 len(non_zero_std_mask), device=std.device
             )[non_zero_std_mask].tolist()
@@ -2123,6 +2158,161 @@ def compute_and_apply_seq_logprob_error_masking(
     }
 
 
+def _training_stage(step: int, total_steps: int) -> str:
+    """Bucket a training step into an early / mid / late stage.
+
+    Oracular heuristic: split the total planned steps into even thirds. The
+    first third is ``early``, the middle third ``mid``, the final third ``late``
+    (e.g. step 50 of 100 -> ``mid``). Returns ``unknown`` when the total step
+    count is unavailable (<= 0), so the column is always populated.
+    """
+    if total_steps <= 0:
+        return "unknown"
+    frac = step / total_steps
+    if frac < 1 / 3:
+        return "early"
+    if frac < 2 / 3:
+        return "mid"
+    return "late"
+
+
+def _per_sample_advantage(
+    flat_advantages: torch.Tensor, flat_token_mask: torch.Tensor
+) -> torch.Tensor:
+    """Reduce per-token advantages to one scalar per sample.
+
+    Takes a masked mean over the valid response tokens so each rollout gets a
+    single advantage value (GRPO advantages are constant across a sample's
+    response tokens, so this recovers that value robustly even after clipping).
+    """
+    mask = flat_token_mask.float()
+    denom = mask.sum(dim=1).clamp(min=1.0)
+    return (flat_advantages.float() * mask).sum(dim=1) / denom
+
+
+def _log_rollout_sample_table(
+    logger: "Logger",
+    step: int,
+    message_logs: list[Any],
+    rewards: Any,
+    per_sample_advantages: Any,
+    max_total_steps: int = 0,
+    num_prompts: int = 3,
+    max_text_chars: int = 4000,
+) -> None:
+    """Log a readable, prompt-grouped table of training rollouts to W&B.
+
+    GRPO generates ``num_generations_per_prompt`` rollouts per prompt. Instead of
+    dumping every rollout as its own row, this collapses that structure into one
+    row per prompt: the group's total and mean reward, plus the single best and
+    single worst rollout (by reward) with their rewards and advantages, so a
+    reviewer can eyeball a good vs. bad completion for the same prompt.
+    ``num_prompts`` distinct prompts are drawn at random (seeded by ``step`` for
+    a reproducible but rotating sample).
+
+    Logged under a single fixed key ``train/rollout_samples`` so W&B renders one
+    panel and versions it by ``step``: scrub the panel's step slider to move
+    between snapshots without losing any. Every row carries a ``training_stage``
+    column (early/mid/late, see :func:`_training_stage`) plus the ``step`` so the
+    snapshot the slider is on is always legible. No-op for non-W&B backends.
+
+    Args:
+        logger: Parent Logger (``log_table`` no-ops on backends without tables).
+        step: Global training step (table step and RNG seed).
+        message_logs: Per-rollout message logs, aligned with ``rewards`` and
+            ``per_sample_advantages``.
+        rewards: Per-rollout scalar rewards (1D tensor/array/list).
+        per_sample_advantages: Per-rollout scalar advantages (1D), same order.
+        max_total_steps: Total planned training steps, used to derive the
+            training stage and the zero-pad width of the table name.
+        num_prompts: Number of distinct prompts to sample.
+        max_text_chars: Truncate prompt/completion text to this many characters.
+    """
+    if logger is None or not message_logs:
+        return
+    try:
+        rewards = np.asarray(
+            rewards.tolist() if isinstance(rewards, torch.Tensor) else rewards,
+            dtype=np.float64,
+        )
+        advantages = np.asarray(
+            per_sample_advantages.tolist()
+            if isinstance(per_sample_advantages, torch.Tensor)
+            else per_sample_advantages,
+            dtype=np.float64,
+        )
+
+        def _join(log: Any, assistant: bool) -> str:
+            text = "\n\n".join(
+                str(m.get("content", ""))
+                for m in log
+                if (m.get("role") == "assistant") == assistant
+            )
+            return text[:max_text_chars]
+
+        # Group rollout indices by their prompt text so identical prompts share a
+        # group. Grouping by text is robust to however the rollouts were laid out.
+        groups: dict[str, list[int]] = {}
+        for i, log in enumerate(message_logs):
+            if i >= len(rewards):
+                break
+            groups.setdefault(_join(log, assistant=False), []).append(i)
+
+        prompt_keys = list(groups.keys())
+        if not prompt_keys:
+            return
+        rng = np.random.RandomState(step)
+        take = min(num_prompts, len(prompt_keys))
+        chosen = rng.choice(len(prompt_keys), take, replace=False)
+
+        stage = _training_stage(step, max_total_steps)
+        columns = [
+            "step",
+            "training_stage",
+            "prompt",
+            "num_rollouts",
+            "reward_total",
+            "reward_mean",
+            "best_reward",
+            "best_advantage",
+            "best_completion",
+            "worst_reward",
+            "worst_advantage",
+            "worst_completion",
+        ]
+        rows = []
+        for k in chosen:
+            prompt = prompt_keys[int(k)]
+            idxs = groups[prompt]
+            group_rewards = rewards[idxs]
+            best = idxs[int(np.argmax(group_rewards))]
+            worst = idxs[int(np.argmin(group_rewards))]
+            rows.append(
+                [
+                    step,
+                    stage,
+                    prompt,
+                    len(idxs),
+                    float(group_rewards.sum()),
+                    float(group_rewards.mean()),
+                    float(rewards[best]),
+                    float(advantages[best]),
+                    _join(message_logs[best], assistant=True),
+                    float(rewards[worst]),
+                    float(advantages[worst]),
+                    _join(message_logs[worst], assistant=True),
+                ]
+            )
+        # Log under a single fixed key so W&B renders ONE panel and versions it by
+        # step: scrub the panel's step slider to see each snapshot. The `step` and
+        # `training_stage` columns identify which snapshot the slider is on.
+        logger.log_table(
+            columns=columns, rows=rows, step=step, name="train/rollout_samples"
+        )
+    except Exception as e:
+        print(f"  ⚠️ Error logging rollout sample table to W&B: {e}")
+
+
 # ===============================================================================
 # Training & Validation
 # ===============================================================================
@@ -2816,6 +3006,10 @@ def grpo_train(
                     "advantages/min": torch.min(response_advantages).detach().item()
                     if response_advantages.numel() > 0
                     else 0.0,
+                    "advantages/std": torch.std(response_advantages).detach().item()
+                    if response_advantages.numel() > 1
+                    else 0.0,
+                    "reward/std": float(np.std(rewards.numpy())),
                     **ds_metrics,
                 }
                 if "moe_metrics" in train_results:
@@ -2858,6 +3052,13 @@ def grpo_train(
                         metrics[k] = np.sum(v).item()
                     else:
                         print(f"Skipping aggregation for {k} ({type(v)})")
+
+                # Recover the population std of the importance ratio from the
+                # globally-summed E[r] (probs_ratio) and E[r^2] (probs_ratio_sq).
+                if "probs_ratio_sq" in metrics and "probs_ratio" in metrics:
+                    ratio_var = metrics["probs_ratio_sq"] - metrics["probs_ratio"] ** 2
+                    metrics["probs_ratio_std"] = float(np.sqrt(max(0.0, ratio_var)))
+                    del metrics["probs_ratio_sq"]
 
                 metrics.update(rollout_metrics)
                 metrics["generation_logger_metrics"] = generation_logger_metrics
@@ -3101,6 +3302,22 @@ def grpo_train(
                 step_finished=True,
             )
 
+            # Log a prompt-grouped sample of this step's rollouts to W&B on the
+            # validation cadence (or the final step) to keep table volume low.
+            if (val_period > 0 and (total_steps + 1) % val_period == 0) or (
+                val_at_end and is_last_step
+            ):
+                _log_rollout_sample_table(
+                    logger,
+                    step=total_steps + 1,
+                    message_logs=repeated_batch["message_log"],
+                    rewards=rewards,
+                    per_sample_advantages=_per_sample_advantage(
+                        flat_advantages, flat_token_mask
+                    ),
+                    max_total_steps=max_num_steps,
+                )
+
             # Reset the batch and set dynamic_sampling_num_gen_batches to 0
             batch_cache = None
             dynamic_sampling_num_gen_batches = 0
@@ -3255,6 +3472,56 @@ def validate(
         except Exception as e:
             print(f"\n  ⚠️ Error displaying message samples: {str(e)}")
             print("  ⚠️ Continuing validation without displaying samples...", flush=True)
+
+        # Log a stratified-random sample of validation conversations to W&B as a
+        # table (no-op for non-W&B backends). Each eval step logs its own table,
+        # so the W&B step slider shows the early/mid/late progression. We pick
+        # NUM_SAMPLE_ROWS prompts split between correct (reward > 0) and wrong
+        # completions so both sides of the model's behavior are visible, re-seeded
+        # per step for a fresh-but-reproducible draw.
+        NUM_SAMPLE_ROWS = 5
+        if logger is not None and len(all_message_logs) > 0:
+            try:
+                rng = np.random.RandomState(step)
+                correct_idx = [i for i, r in enumerate(total_rewards) if r > 0]
+                wrong_idx = [i for i, r in enumerate(total_rewards) if r <= 0]
+                n = min(NUM_SAMPLE_ROWS, len(all_message_logs))
+                take_correct = min(n // 2, len(correct_idx))
+                take_wrong = min(n - take_correct, len(wrong_idx))
+                take_correct = min(n - take_wrong, len(correct_idx))
+                selected = list(
+                    rng.choice(correct_idx, take_correct, replace=False)
+                ) + list(rng.choice(wrong_idx, take_wrong, replace=False))
+
+                # Truncate long conversations so table cells stay readable in the
+                # W&B UI (validation has no advantages, so reward per completion
+                # is the signal here).
+                MAX_TEXT_CHARS = 4000
+                sample_rows = []
+                for i in selected:
+                    message_log = all_message_logs[i]
+                    prompt = "\n\n".join(
+                        str(m.get("content", ""))
+                        for m in message_log
+                        if m.get("role") != "assistant"
+                    )[:MAX_TEXT_CHARS]
+                    completion = "\n\n".join(
+                        str(m.get("content", ""))
+                        for m in message_log
+                        if m.get("role") == "assistant"
+                    )[:MAX_TEXT_CHARS]
+                    reward = float(total_rewards[i])
+                    sample_rows.append(
+                        [step, prompt, completion, reward, reward > 0]
+                    )
+                logger.log_table(
+                    columns=["step", "prompt", "completion", "reward", "correct"],
+                    rows=sample_rows,
+                    step=step,
+                    name="validation/samples",
+                )
+            except Exception as e:
+                print(f"  ⚠️ Error logging sample table to W&B: {str(e)}")
 
     # Get timing metrics
     timing_metrics = timer.get_timing_metrics(reduction_op="sum")
@@ -4072,6 +4339,10 @@ def async_grpo_train(
                     "advantages/min": torch.min(response_advantages).detach().item()
                     if response_advantages.numel() > 0
                     else 0.0,
+                    "advantages/std": torch.std(response_advantages).detach().item()
+                    if response_advantages.numel() > 1
+                    else 0.0,
+                    "reward/std": float(np.std(rewards.numpy())),
                 }
                 if "moe_metrics" in train_results:
                     metrics.update(
@@ -4105,6 +4376,12 @@ def async_grpo_train(
                         metrics[k] = np.mean(v).item()
                     else:
                         metrics[k] = np.sum(v).item()
+                # Recover the population std of the importance ratio from the
+                # globally-summed E[r] (probs_ratio) and E[r^2] (probs_ratio_sq).
+                if "probs_ratio_sq" in metrics and "probs_ratio" in metrics:
+                    ratio_var = metrics["probs_ratio_sq"] - metrics["probs_ratio"] ** 2
+                    metrics["probs_ratio_std"] = float(np.sqrt(max(0.0, ratio_var)))
+                    del metrics["probs_ratio_sq"]
                 metrics.update(rollout_metrics)
                 if generation_logger_metrics is not None:
                     metrics["generation_logger_metrics"] = generation_logger_metrics
@@ -4305,6 +4582,22 @@ def async_grpo_train(
                 prefix="timing/train",
                 step_finished=True,
             )
+
+            # Log a prompt-grouped sample of this step's rollouts to W&B on the
+            # validation cadence (or the final step) to keep table volume low.
+            if (val_period > 0 and (step + 1) % val_period == 0) or (
+                val_at_end and is_last_step
+            ):
+                _log_rollout_sample_table(
+                    logger,
+                    step=step + 1,
+                    message_logs=repeated_batch["message_log"],
+                    rewards=rewards,
+                    per_sample_advantages=_per_sample_advantage(
+                        flat_advantages, flat_token_mask
+                    ),
+                    max_total_steps=master_config.grpo["max_num_steps"],
+                )
 
             timer.reset()
             step += 1

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -1014,6 +1014,9 @@ def grpo_train_sync(
                     "advantages/min": torch.min(response_advantages).detach().item()
                     if response_advantages.numel() > 0
                     else 0.0,
+                    "advantages/std": torch.std(response_advantages).detach().item()
+                    if response_advantages.numel() > 1
+                    else 0.0,
                     **ds_metrics,
                 }
                 if "moe_metrics" in train_results:

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -675,6 +675,14 @@ class ClippedPGLossFn(LossFunction):
                 mask,
                 global_normalization_factor=global_valid_toks,
             ).item()
+            # Mean of squared ratios, normalized identically to probs_ratio. Summed
+            # across microbatches this yields the global E[ratio^2], so a correct
+            # population std is recoverable as sqrt(E[r^2] - E[r]^2) downstream.
+            probs_ratio_sq = masked_mean(
+                ratios.detach() ** 2,
+                mask,
+                global_normalization_factor=global_valid_toks,
+            ).item()
             probs_ratio_clamped = masked_mean(
                 ratios_clamped.detach(),
                 mask,
@@ -705,6 +713,7 @@ class ClippedPGLossFn(LossFunction):
             {
                 "loss": loss.item(),
                 "probs_ratio": probs_ratio,
+                "probs_ratio_sq": probs_ratio_sq,
                 "probs_ratio_clamped": probs_ratio_clamped,
                 "probs_ratio_min": probs_ratio_min,
                 "probs_ratio_max": probs_ratio_max,

--- a/nemo_rl/evals/eval.py
+++ b/nemo_rl/evals/eval.py
@@ -37,6 +37,7 @@ from nemo_rl.environments.vlm_environment import VLMEnvConfig
 from nemo_rl.models.generation.interfaces import GenerationConfig
 from nemo_rl.models.generation.vllm import VllmGeneration
 from nemo_rl.models.policy import TokenizerConfig
+from nemo_rl.utils.logger import Logger, LoggerConfig
 
 # ===============================================================================
 # Configuration
@@ -64,6 +65,9 @@ class MasterConfig(BaseModel, extra="allow"):
     data: EvalDataConfigType
     env: _PassThroughEnvConfig
     cluster: ClusterConfig
+    # Optional logging config. When present with wandb_enabled, run_eval.py
+    # builds a Logger and each benchmark's aggregate score is logged to W&B.
+    logger: LoggerConfig | None = None
 
 
 # ===============================================================================
@@ -277,7 +281,7 @@ def eval_cons_k(
     return cons_k_score
 
 
-def run_env_eval(vllm_generation, dataloader, env, master_config):
+def run_env_eval(vllm_generation, dataloader, env, master_config, logger=None):
     """Main entry point for running evaluation using environment.
 
     Generates model responses and evaluates them by env.
@@ -287,6 +291,8 @@ def run_env_eval(vllm_generation, dataloader, env, master_config):
         dataloader: Data loader with evaluation samples.
         env: Environment that scores responses.
         master_config: Configuration settings.
+        logger: Optional Logger; when provided, the aggregate benchmark score is
+            logged to its backends (e.g. W&B) under the ``eval/`` prefix.
     """
     generation_config = master_config.generation
     backend = generation_config.get("backend", "")
@@ -423,6 +429,36 @@ async def _run_env_eval_impl(
     if evaluation_data and save_path is not None:
         _save_evaluation_data_to_json(evaluation_data, master_config, save_path)
 
+    # Persist the aggregate score so the multi-benchmark runner can collect it
+    # into a single summary.json (the per-sample JSON above stores raw rewards
+    # but not the computed metric).
+    dataset_size = len(dataloader.dataset)
+    if save_path is not None:
+        _save_results_summary(
+            master_config,
+            score,
+            dataset_size,
+            metric,
+            k_value,
+            num_tests_per_prompt,
+            save_path,
+        )
+
+    # Log the aggregate score to W&B / other backends if a logger was provided.
+    if logger is not None:
+        average_score = score / dataset_size if dataset_size else 0.0
+        dataset_name = master_config.data["dataset_name"]
+        metric_label = f"{metric[:-1]}{k_value}"
+        logger.log_metrics(
+            {
+                f"{dataset_name}/{metric_label}": average_score,
+                f"{dataset_name}/score_sum": score,
+                f"{dataset_name}/dataset_size": dataset_size,
+            },
+            step=0,
+            prefix="eval",
+        )
+
     # Print results
     _print_results(
         master_config,
@@ -511,6 +547,50 @@ def _save_evaluation_data_to_json(evaluation_data, master_config, save_path):
         json.dump(data_to_save, f, indent=2)
 
     print(f"\n✓ Evaluation data saved to: {eval_data_path}")
+
+
+def _save_results_summary(
+    master_config,
+    score,
+    dataset_size,
+    metric,
+    k_value,
+    num_tests_per_prompt,
+    save_path,
+):
+    """Save the aggregate benchmark score to results.json.
+
+    Mirrors the score printed by _print_results (average over the dataset) so the
+    multi-benchmark runner can merge every benchmark's number into one summary
+    without re-deriving the metric from per-sample rewards.
+
+    Args:
+        master_config: Configuration dictionary.
+        score: Summed metric across the dataset (as returned by eval_pass_k /
+            eval_cons_k).
+        dataset_size: Number of prompts evaluated (denominator for the average).
+        metric: Metric name, e.g. "pass@k" or "cons@k".
+        k_value: The k in pass@k / cons@k.
+        num_tests_per_prompt: Samples drawn per prompt.
+        save_path: Directory to write results.json into.
+    """
+    os.makedirs(save_path, exist_ok=True)
+    average_score = score / dataset_size if dataset_size else 0.0
+    summary = {
+        "model_name": master_config.generation["model_name"],
+        "dataset_name": master_config.data["dataset_name"],
+        # e.g. "pass@k" + k_value=1 -> "pass@1", matching _print_results.
+        "metric": f"{metric[:-1]}{k_value}",
+        "k_value": k_value,
+        "num_tests_per_prompt": num_tests_per_prompt,
+        "score": average_score,
+        "score_sum": score,
+        "dataset_size": dataset_size,
+    }
+    results_path = os.path.join(save_path, "results.json")
+    with open(results_path, "w") as f:
+        json.dump(summary, f, indent=2)
+    print(f"\n✓ Results summary saved to: {results_path}")
     print(f"  Total samples: {len(evaluation_data)}")
     print(f"  File size: {os.path.getsize(eval_data_path) / 1024 / 1024:.2f} MB")
 

--- a/nemo_rl/utils/logger.py
+++ b/nemo_rl/utils/logger.py
@@ -51,6 +51,8 @@ class WandbConfig(TypedDict):
     project: NotRequired[str]
     name: NotRequired[str]
     entity: NotRequired[str]
+    group: NotRequired[str]
+    tags: NotRequired[list[str]]
 
 
 class SwanlabConfig(TypedDict):
@@ -119,6 +121,12 @@ class LoggerInterface(ABC):
     def log_plot(self, figure: plt.Figure, step: int, name: str) -> None:
         """Log a matplotlib figure."""
         pass
+
+    def log_table(
+        self, columns: list[str], rows: list[list[Any]], step: int, name: str
+    ) -> None:
+        """Log a table of sample rows. No-op for backends without table support."""
+        return
 
 
 class TensorboardLogger(LoggerInterface):
@@ -392,6 +400,23 @@ class WandbLogger(LoggerInterface):
             step: Global step value
         """
         self.run.log({name: figure}, step=step)
+
+    def log_table(
+        self, columns: list[str], rows: list[list[Any]], step: int, name: str
+    ) -> None:
+        """Log a table of sample rows to wandb as a wandb.Table.
+
+        Args:
+            columns: Column headers.
+            rows: Row values, each a list aligned with ``columns``.
+            step: Global step value.
+            name: Panel name for the table in the W&B UI.
+        """
+        try:
+            table = wandb.Table(columns=columns, data=rows)
+            self.run.log({name: table}, step=step)
+        except Exception as e:
+            print(f"Warning: Failed to log table '{name}' to W&B: {e}")
 
     def log_histogram(self, histogram: list[Any], step: int, name: str) -> None:
         """Log histogram metrics to wandb.
@@ -1037,6 +1062,22 @@ class Logger(LoggerInterface):
         """
         for logger in self.loggers:
             logger.log_hyperparams(params)
+
+    def log_table(
+        self, columns: list[str], rows: list[list[Any]], step: int, name: str
+    ) -> None:
+        """Log a table of sample rows to all enabled backends.
+
+        Backends without table support (everything but W&B) no-op.
+
+        Args:
+            columns: Column headers.
+            rows: Row values, each a list aligned with ``columns``.
+            step: Global step value.
+            name: Panel name for the table.
+        """
+        for logger in self.loggers:
+            logger.log_table(columns, rows, step, name)
 
     def log_batched_dict_as_jsonl(
         self, to_log: BatchedDataDict[Any] | dict[str, Any], filename: str


### PR DESCRIPTION
## What & why

Adds an end-to-end multi-benchmark evaluation flow and expands training/eval
observability so runs can be monitored and compared in Weights & Biases. Also
records extra GRPO diagnostics (histograms, dynamic-sampling and ratio/advantage
metrics) that were missing.

## Changes (by theme)

**Eval suite** (`feat(eval)`)
- `run_multibench_eval.sh` runs a fixed benchmark suite (MATH-500, AIME 2024/2025,
  GPQA-diamond, MMLU-Pro), one `run_eval.py` call per ben
- Resilient: a single benchmark failing (e.g. a gated dataset, an OOM) is logged
  and skipped instead of aborting the whole suite.
- Aggregates each benchmark's `results.json` into one `summary.json` at the
  results root (missing benchmarks recorded as `null`).
- `eval.py` writes a per-benchmark `results.json` (aggregate score) alongside the
  existing per-sample JSON, and logs the score to W&B und
- New configs: `nemotron3_nano_30b_eval.yaml`, `qwen3vl_4b_eval.yaml`; base
  `eval.yaml` gains a `logger:` block (W&B off by default

**W&B logging** (`feat(logger)`)
- `log_table()` added to the logger interface + `WandbLogger` (wandb.Table panels),
  no-op on non-W&B backends.
- `WandbConfig` gains optional `group`/`tags`; eval runs are grouped per suite and
  get an `_eval` run-name suffix so they're easy to spot.
  when `WANDB_API_KEY` is absent.

**GRPO diagnostics** (`feat(grpo)`)
- Per-step histograms (baseline reward, advantages, gen/i
  and a stratified validation-sample table logged to W&B.
- Dynamic sampling reports the count/fraction of all-inco
  (every completion wrong) to track the hard tail over training.
- `loss_functions.py` logs `probs_ratio_sq` (population s
  ratio is recoverable downstream); `grpo_sync.py` logs `advantages/std`.

## Validation

- Config load/merge + `_eval` run-name logic verified locally; bash/py syntax
  checked. Full end-to-end runs launched on the eval suit
  nano-30b) — [update with results/W&B links before merging].

## Notes / caveats

- `grpo_math_1B.yaml` and the deepscaler recipe carry local run tweaks
  (`wandb_enabled: true`, project rename, `gpus_per_node:
  exemplar defaults — flag if they should be reverted for upstream.
- GPQA (`Idavidrein/gpqa`) is a gated HF dataset; the acc
  accept its terms or that benchmark is skipped (non-fatal).