### PR TITLE
fix: fix grpo-gemma3-27b-it-8n4g-fsdp2tp4-actckpt-long

### DIFF
--- a/examples/configs/recipes/llm/grpo-gemma3-27b-it-8n4g-fsdp2tp4-actckpt-long.yaml
+++ b/examples/configs/recipes/llm/grpo-gemma3-27b-it-8n4g-fsdp2tp4-actckpt-long.yaml
@@ -14,4 +14,4 @@ logger:
     name: grpo-gemma3-27b-it-8n4g-fsdp2tp4-actckpt-long
 cluster:
   gpus_per_node: 4
-
+  segment_size: 8

--- a/tests/test_suites/llm/grpo-gemma3-27b-it-8n4g-fsdp2tp4-actckpt-long.sh
+++ b/tests/test_suites/llm/grpo-gemma3-27b-it-8n4g-fsdp2tp4-actckpt-long.sh
@@ -7,6 +7,7 @@ export NRL_IGNORE_TP_ACCURACY_CHECK=1
 # ===== BEGIN CONFIG =====
 NUM_NODES=8
 GPUS_PER_NODE=4
+SEGMENT_SIZE=8     # nodes per NVLink-domain segment; tools/launch passes it as sbatch --segment. Matches cluster.segment_size in the yaml.
 STEPS_PER_RUN=20
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up


### PR DESCRIPTION
same `segment_size` fix with the one in https://github.com/NVIDIA-NeMo/RL/pull/2986.

validated two times `grpo-gemma3-27b-it-8n4g-fsdp2tp4-actckpt-long` could pass.