### PR TITLE
fix: express sbatch --time as HH:MM:SS to fix invalid time limit on long tests

### DIFF
--- a/tools/launch
+++ b/tools/launch
@@ -182,6 +182,9 @@ for SCRIPT in $SCRIPTS; do
             GRES_ARG=""
         fi
 
+        SLURM_HOURS=$((NUM_MINUTES / 60))
+        SLURM_MINS=$((NUM_MINUTES % 60))
+
         cat <<EOF >$SNAPSHOT_DIR/continue.sh
 #!/bin/bash
 SCRIPT_DIR=\$( cd -- "\$( dirname -- "\${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
@@ -201,7 +204,7 @@ sbatch \\
     --account=$ACCOUNT \\
     --job-name=$ACCOUNT:${JOB_NAME}${SLURM_JOB_SUFFIX:-} \\
     --partition=$PARTITION \\
-    --time=0:${NUM_MINUTES}:0 ${GRES_ARG}\\
+    --time=${SLURM_HOURS}:${SLURM_MINS}:0 ${GRES_ARG}\\
     --output=slurm-${NOW}-%j-${JOB_NAME}-${i}.${NUM_RUNS}.out \\
     ray.sub
 EOF


### PR DESCRIPTION
## Summary

`tools/launch` was generating `--time=0:${NUM_MINUTES}:0` for sbatch. For tests with `NUM_MINUTES >= 60`, this produces values like `0:240:0` where the minutes field exceeds 59 — which Slurm considers invalid:

```
sbatch: error: Batch job submission failed: Requested time limit is invalid (missing or exceeds some limit)
```

Repro: `grpo-llama3.1-8b-instruct-4n8g-fsdp2tp1-long.v3` (`NUM_MINUTES=240`) hitting this on cw_dfw.

**Fix:** compute `HH` and `MM` before writing `continue.sh` so the time is expressed correctly:
- 240 min → `4:0:0` ✓
- 72 min → `1:12:0` ✓
- 18 min → `0:18:0` ✓

`NUM_MINUTES` stays at 240 — this is purely a formatting fix.

## Test plan
- [ ] Verify `grpo-llama3.1-8b-instruct-4n8g-fsdp2tp1-long.v3` submits successfully in next release run