### PR TITLE
fix: cap dapo-deepseek-v3-64n8g perf test NUM_MINUTES at 240 (cluster limit)

### DIFF
--- a/tests/test_suites/llm/performance/dapo-deepseek-v3-64n8g.v2.sh
+++ b/tests/test_suites/llm/performance/dapo-deepseek-v3-64n8g.v2.sh
@@ -15,7 +15,7 @@ NUM_NODES=64
 STEPS_PER_RUN=10
 MAX_STEPS=10
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
-NUM_MINUTES=360
+NUM_MINUTES=240
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached


### PR DESCRIPTION
## Summary

`dapo-deepseek-v3-64n8g.v2.sh` had `NUM_MINUTES=360` on `r0.7.0`, which exceeds the Slurm partition maximum and causes the job to fail at submission:

```
sbatch: error: Batch job submission failed: Requested time limit is invalid (missing or exceeds some limit)
```

Reduces to 240 (cluster cap). Companion fix on `main`: #3052.

## Test plan
- [ ] Verify `llm_performance_dapo_deepseek_v3_64n8g_v2` submits and runs in next perf run off r0.7.0