### PR TITLE
fix: synchronize packed broadcast streams before return

### DIFF
--- a/nemo_rl/utils/packed_tensor.py
+++ b/nemo_rl/utils/packed_tensor.py
@@ -101,6 +101,14 @@ def packed_broadcast_producer(iterator, group, src, post_iter_func):
                     group.broadcast(packed_tensors[buffer_idx], src=src)
                 break
 
+    # Drain the side streams before returning. The per-iteration synchronize
+    # above only waits on the buffer about to be REUSED; without this, the
+    # last buffer's pack + NCCL broadcast are still executing when the caller
+    # resumes and may mutate the source parameters mid-broadcast (torn
+    # weights sent to every consumer).
+    for stream in streams:
+        stream.synchronize()
+
 
 def packed_broadcast_consumer(iterator, group, src, post_unpack_func):
     """Consume a packed tensor and unpack it into a list of tensors.
@@ -208,3 +216,15 @@ def packed_broadcast_consumer(iterator, group, src, post_unpack_func):
                         )
                     )
                 break
+
+    # Drain the side streams before returning. The per-iteration synchronize
+    # above only waits on the buffer about to be REUSED, so when the loop
+    # exits the last buffer's NCCL recv + in-place param copies (including
+    # multi-phase weight_loader transforms like mamba's A := -exp(A_log))
+    # are still executing. Returning early lets the engine resume decoding
+    # concurrently with those writes — decode kernels then read torn or
+    # mid-transform weights, which poisons the persistent mamba SSM state
+    # (whole-tail NaN generations). The sibling IPC/ZMQ path already does
+    # this (vllm_backend.py: current_stream().synchronize() after load).
+    for stream in streams:
+        stream.synchronize()


### PR DESCRIPTION
# What does this PR do?

Drain the side CUDA streams before `packed_broadcast_producer` and `packed_broadcast_consumer` return.

These functions enqueue NCCL transfers and in-place parameter copies on side CUDA streams. The existing per-iteration synchronization only waits for a buffer before it is reused, so work on the final buffer can still be running when the functions return.

On the generation side, this causes the weight-update RPC to report completion while the final parameter copies are still executing. The vLLM engine can then resume decoding concurrently with the pending writes, allowing decode kernels to observe torn or mid-transform weights.

For Mamba models, this can poison the persistent SSM state for the remainder of the request. The corrupted state can also spread engine-wide through Mamba prefix-state caching.

This PR synchronizes every side stream before returning from both the producer and consumer, ensuring that all NCCL transfers and parameter updates have completed before their callers resume.

# Issues

None.

# Usage

No API or usage changes.

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed the Contributor guidelines.
- [x] No documentation changes are required.
- [x] Unit and functional tests were run.

# Additional Information

- Only `nemo_rl/utils/packed_tensor.py` is changed.