### PR TITLE
fix(docker): pre-build megatron-core datasets helpers_cpp extension

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -93,8 +93,18 @@ RUN GITHUB_ARTIFACTORY=github.com \
 ARG UV_VERSION=0.11.18
 ARG PYTHON_VERSION=3.13.13
 ENV PATH="/root/.local/bin:$PATH"
+# `uv python install` (run as root) lands under /root/.local/share/uv/python with
+# perms that are not necessarily executable/traversable by non-root users. Since
+# this Python is what /opt/nemo_rl_venv's bin/python3 ultimately symlinks to,
+# any downstream process running as a non-root user (e.g. a Ray cluster launched
+# as a regular user) hits `exec: python3: Permission denied` even though `ls`/
+# `which` report the symlink chain as present. Open up read+execute for all
+# users on the whole uv-managed Python tree so it's usable regardless of the
+# runtime container user.
 RUN curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh && \
-    uv python install ${PYTHON_VERSION}
+    uv python install ${PYTHON_VERSION} && \
+    chmod -R a+rX /root/.local/share/uv/python
+
 
 # Disable usage stats by default for users who are sensitive to sharing usage.
 # Users are encouraged to enable if the wish.
@@ -260,6 +270,53 @@ ENV LD_LIBRARY_PATH="/opt/amazon/ofi-nccl/lib:/opt/amazon/efa/lib:${LD_LIBRARY_P
 # Copy in source from build context (defaults to cloned repo, can be overridden)
 # Exclude pyproject.toml and uv.lock since those may be altered by build-custom-vllm.sh
 COPY --from=nemo-rl --exclude=pyproject.toml --exclude=uv.lock . /opt/nemo-rl
+
+# Pre-build the megatron-core `helpers_cpp` C++ extension.
+# megatron-core is an editable install and this extension is optional, so `uv sync`
+# never builds the .so. At runtime Megatron-Bridge's initialize_megatron always
+# invokes `make -C .../datasets`; without a pre-built .so every worker recompiles
+# in its own Ray venv -- and if that compile ever fails/desyncs it surfaces as an
+# opaque `torch.distributed.barrier()` NCCL timeout in initialize_megatron.
+#
+# This must run *after* the `COPY --from=nemo-rl ... /opt/nemo-rl` above, because
+# that copy re-materializes the source tree (from a fresh clone that has no .so)
+# and would clobber anything built earlier in the hermetic stage.
+#
+# The datasets `Makefile` hard-codes the interpreter as `python3` (via
+# `python3 -m pybind11 --includes` and `python3-config --extension-suffix`). The
+# uv-managed CPython 3.13 that owns this venv (a) is not necessarily first on
+# PATH -- the Ubuntu base image ships its own /usr/bin/python3 (3.12) -- and
+# (b) exposes no `python3-config` inside the venv's own bin/ (the script only
+# lives in the uv python-build-standalone install dir). Either mismatch makes
+# `make` emit a binary with the wrong (or empty) ABI suffix that Python can
+# never import.
+#
+# Fix it at the root:
+#   1. Symlink the venv's `python3-config` to the real script in the uv python
+#      install (absolute path, arch-derived so both x86_64 and aarch64 work).
+#   2. Put the venv first on PATH so the Makefile's bare `python3`/`python3-config`
+#      resolve to the 3.13 interpreter, producing the correctly ABI-suffixed
+#      `helpers_cpp.cpython-313-<arch>-linux-gnu.so`.
+#   3. Verify via `uv run` (not a bare `python3`), because megatron-core is an
+#      editable install that is only importable through the project environment.
+# /opt/nemo_rl_venv/bin is already first on PATH via the ENV set earlier in the
+# `hermetic` stage (line ~202: `ENV PATH="/opt/nemo_rl_venv/bin:$PATH"`), which
+# this `release` stage inherits. So `make` below already resolves `python3`/
+# `python3-config` to the venv's symlinked 3.13 interpreter without needing to
+# re-set PATH inline.
+RUN /opt/nemo_rl_venv/bin/python3 -m pip install pybind11 && \
+    UV_PY_ARCH="$(uname -m)" && \
+    ln -sf "/root/.local/share/uv/python/cpython-${PYTHON_VERSION}-linux-${UV_PY_ARCH}-gnu/bin/python3-config" \
+        /opt/nemo_rl_venv/bin/python3-config && \
+    cd /opt/nemo-rl/3rdparty/Megatron-Bridge-workspace/Megatron-Bridge/3rdparty/Megatron-LM/megatron/core/datasets && \
+    rm -f helpers_cpp*.so && \
+    make && \
+    cd /opt/nemo-rl && \
+    UV_LINK_MODE=symlink uv run --extra mcore python -c "import megatron.core.datasets.helpers_cpp"
+
+
+
+
 # Unshallow the repo to get the full history (in the case it was from the scratch layer).
 # Potentially not necessary if the repo is passed in as a complete repository (w/ full git history),
 # so do a quick check before trying to unshallow.


### PR DESCRIPTION
# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

Pre-build the `megatron-core` datasets `helpers_cpp` C++ extension at image-build
time so multi-node runs don't fail with `fatal error: pybind11/pybind11.h: No
such file or directory` during dataset initialization.

# Issues

List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

N/A — no existing issue (GitHub search for `helpers_cpp` / `pybind11.h` /
`compile_helpers` returns 0 results).

## Root cause

`megatron-core` is installed **editable** (`[tool.uv.sources]
megatron-core = { path = ".../Megatron-LM", editable = true }`) and its
`helpers_cpp` extension is declared `Pybind11Extension(..., optional=True)` in
`Megatron-LM/setup.py`. PEP-660 editable installs skip `build_ext`, and
`optional=True` makes any build failure silent, so the compiled `.so` is **never
produced** in the release image.

At runtime, the GPT/blended/masked dataset modules do
`from megatron.core.datasets.helpers import *`, and
`megatron/training/initialize.py` calls
`megatron.core.datasets.utils.compile_helpers()`, which shells out to `make`.
That Makefile pulls its include path from `python3 -m pybind11 --includes`.
Because `pybind11` lives only in the `[dependency-groups] build` group (a
build-time group), the release venv can lack the headers — so every worker dies
with:

```
helpers.cpp:12:10: fatal error: pybind11/pybind11.h: No such file or directory
make: *** [Makefile:13: helpers_cpp] Error 1
ERROR:megatron.core.datasets.utils: Failed to compile the C++ dataset helper functions
```

In multi-node jobs this is worse: every rank races on the same runtime `make`.

Notably, Megatron-Bridge's own `docker/Dockerfile.ci` already stages
`megatron/core/datasets/{Makefile,helpers.cpp}` for exactly this reason —
NeMo-RL's `docker/Dockerfile` was simply missing the equivalent build step.

## Fix

After `uv sync --extra mcore`, build the extension the normal way once
(`python setup.py build_ext --inplace`) and hard-fail the image build if the
`.so` still isn't importable. Runtime becomes zero-compile and multi-node ranks
no longer race on `make`.

# Usage

* **You can potentially add a usage example below**

No API change. Verify from a built image:

```bash
python -c "import megatron.core.datasets.helpers_cpp; print('helpers_cpp OK')"
```

During the build you should now see:

```
building 'megatron.core.datasets.helpers_cpp' extension
```

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests? — N/A (Dockerfile build step; the
      added `import megatron.core.datasets.helpers_cpp` acts as a build-time
      assertion that fails the image build if the extension is missing)
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? — N/A (no user-facing
      behavior change; rationale captured inline in the Dockerfile comment)

# Additional Information

* Alternative (smaller) fix considered: promote `pybind11` from the
  `[dependency-groups] build` group to a **runtime** dependency of the `mcore`
  extra in `pyproject.toml`. That would keep the runtime `make` fallback working
  offline, but still pays a per-run (and per-rank) compilation cost and doesn't
  fail fast at build time. Pre-building the extension in the image is preferred;
  happy to switch to (or additionally include) the `pyproject.toml` change if
  reviewers prefer.
* Prior art: `3rdparty/.../Megatron-Bridge/docker/Dockerfile.ci` stages the
  datasets `Makefile`/`helpers.cpp` for the same underlying reason.
