### PR TITLE
ci: demonstrate the pyrefly baseline gate

### DIFF
--- a/nemo_rl/_pyrefly_baseline_demo.py
+++ b/nemo_rl/_pyrefly_baseline_demo.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Demonstration of the pyrefly baseline gate — NOT for merge.
+
+This file is added by a demo PR to show that `pyrefly check --baseline
+pyrefly-baseline.json` fails on a NEW type error (one not present in the
+committed baseline snapshot), both in pre-commit and in CI. The follow-up
+commit fixes the error so the check goes green again.
+"""
+
+
+def add_one(x: int) -> str:
+    # Intentional bug for the demo: this returns an int, but the signature
+    # promises str. pyrefly flags this as a new error (not in the baseline).
+    return x + 1


### PR DESCRIPTION
**Demo only — do not merge.** Stacked on #3080 (base is `typecheck/pyrefly-baseline`), so this diff shows only the demo.

Demonstrates that the pyrefly **baseline gate** from #3080 catches a *new* type error (one not in `pyrefly-baseline.json`) in both pre-commit and CI, and that fixing it turns the check green.

### Commit 1 — introduce the error → gate FLAGS it
Adds `nemo_rl/_pyrefly_baseline_demo.py` with a deliberate `bad-return` (returns `int`, annotated `str`). Local run of the exact command CI/pre-commit use:

```
$ pyrefly check --baseline pyrefly-baseline.json nemo_rl/_pyrefly_baseline_demo.py
ERROR Returned type `int` is not assignable to declared return type `str` [bad-return]
 INFO 1 error
```

Committing it required `--no-verify` because the pre-commit `pyrefly check --baseline` hook **blocked the commit** — that's the pre-commit flag working.

### Commit 2 — fix it → gate goes GREEN
Corrects the return type; `pyrefly check --baseline` then reports 0 errors, so pre-commit and CI pass. The PR head is green/mergeable (though this is a demo and should be closed, not merged).

This proves the baseline gates **new** errors while ignoring the ~1.3k pre-existing ones already snapshotted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)