### PR TITLE
fix(grpo_sync): honor force_on_policy_ratio in TQ trainer

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -2373,30 +2373,26 @@ def _placeholder_seq_logprob_error_metrics() -> dict[str, float]:
     }
 
 
-def _resolve_logprob_skip_flags(
-    master_config: MasterConfig,
-) -> tuple[bool, Any, Optional[float]]:
-    """Return (skip_prev, skip_ref, seq_logprob_error_threshold); warn on incompatible combos."""
-    # Skip prev_logprobs computation when force_on_policy_ratio=True
-    # unless seq_logprob_error_threshold is set (which requires prev_logprobs)
-    seq_logprob_error_threshold = master_config.grpo.get(
-        "seq_logprob_error_threshold", None
-    )
-    skip_prev_logprobs = opd_module._skip_prev_logprobs(master_config)
+def _resolve_logprob_skip_flags(master_config: MasterConfig) -> tuple[bool, Any]:
+    """Return (skip_prev_logprobs, skip_reference_logprobs); warn on incompatible combos.
+
+    Skip prev_logprobs when force_on_policy_ratio=True unless
+    seq_logprob_error_threshold is set (which requires prev_logprobs).
+    Skip reference_policy_logprobs when
+    ``grpo.skip_reference_policy_logprobs_calculation`` is set.
+    """
     # todo @jiaqi: is there a better way to skip prev_logprobs computation while still computing the seq-level error metrics?
     if (
         master_config.loss_fn.force_on_policy_ratio
-        and seq_logprob_error_threshold is not None
+        and master_config.grpo.get("seq_logprob_error_threshold") is not None
     ):
         warnings.warn(
             "force_on_policy_ratio=True but seq_logprob_error_threshold is set. "
             "Computing prev_logprobs anyway for seq-level error masking."
         )
-    # Skip reference_policy_logprobs computation when skip_reference_policy_logprobs_calculation=True
     return (
-        skip_prev_logprobs,
+        opd_module._skip_prev_logprobs(master_config),
         master_config.grpo.get("skip_reference_policy_logprobs_calculation"),
-        seq_logprob_error_threshold,
     )
 
 
@@ -2993,11 +2989,12 @@ def grpo_train(
                     metrics_logging_data["content"] = flat_messages["content"]
 
                 memory_tracker.snapshot_start_of_stage("Computing logprobs", dir())
-                (
-                    skip_prev_logprobs,
-                    skip_reference_logprobs,
-                    seq_logprob_error_threshold,
-                ) = _resolve_logprob_skip_flags(master_config)
+                skip_prev_logprobs, skip_reference_logprobs = (
+                    _resolve_logprob_skip_flags(master_config)
+                )
+                seq_logprob_error_threshold = master_config.grpo.get(
+                    "seq_logprob_error_threshold", None
+                )
 
                 if not (skip_prev_logprobs and skip_reference_logprobs):
                     print("▶ Preparing for logprob inference...", flush=True)
@@ -4376,11 +4373,12 @@ def async_grpo_train(
                     train_data.to("cpu")
 
                 # Training phase (same as sync version)
-                (
-                    skip_prev_logprobs,
-                    skip_reference_logprobs,
-                    seq_logprob_error_threshold,
-                ) = _resolve_logprob_skip_flags(master_config)
+                skip_prev_logprobs, skip_reference_logprobs = (
+                    _resolve_logprob_skip_flags(master_config)
+                )
+                seq_logprob_error_threshold = master_config.grpo.get(
+                    "seq_logprob_error_threshold", None
+                )
 
                 if not (skip_prev_logprobs and skip_reference_logprobs):
                     print("▶ Preparing for logprob inference...", flush=True)

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -2131,7 +2131,8 @@ def _create_advantage_estimator(master_config: MasterConfig):
     loss_config = master_config.loss_fn
 
     assert not (
-        loss_config.use_kl_in_reward and opd_module._skip_prev_logprobs(master_config)
+        getattr(loss_config, "use_kl_in_reward", False)
+        and opd_module._skip_prev_logprobs(master_config)
     ), (
         "loss_fn.use_kl_in_reward requires real prev_logprobs but force_on_policy_ratio "
         "with no grpo.seq_logprob_error_threshold zeros them (KL would be computed against a zero placeholder)."

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -2359,6 +2359,20 @@ def _log_mixed_rewards_and_advantages_information(
     metrics["advantages/mean"] = advantages.float().mean().item()
 
 
+def _placeholder_seq_logprob_error_metrics() -> dict[str, float]:
+    """Zero-valued seq-level metrics used when the prev_logprobs forward is skipped."""
+    return {
+        "max_seq_mult_prob_error": 0.0,
+        "mean_seq_mult_prob_error": 0.0,
+        "min_seq_mult_prob_error": 0.0,
+        "max_seq_mult_prob_error_after_mask": 0.0,
+        "mean_seq_mult_prob_error_after_mask": 0.0,
+        "min_seq_mult_prob_error_after_mask": 0.0,
+        "num_masked_seqs_by_logprob_error": 0,
+        "masked_correct_pct": 0.0,
+    }
+
+
 def _resolve_logprob_skip_flags(
     master_config: MasterConfig,
 ) -> tuple[bool, Any, Optional[float]]:
@@ -3047,9 +3061,8 @@ def grpo_train(
 
                 # Seq-level logprob error metrics/masking require real prev_logprobs
                 if skip_prev_logprobs:
-                    # No valid measurements — leave the seq-level metrics
-                    # out of the emitted dict rather than pinning them to 0.
-                    seq_logprob_error_metrics: dict[str, Any] = {}
+                    # Cannot compute seq-level metrics with placeholder prev_logprobs
+                    seq_logprob_error_metrics = _placeholder_seq_logprob_error_metrics()
                 else:
                     seq_error_result = compute_and_apply_seq_logprob_error_masking(
                         train_data=train_data,
@@ -4403,9 +4416,8 @@ def async_grpo_train(
 
                 # Seq-level logprob error metrics/masking require real prev_logprobs
                 if skip_prev_logprobs:
-                    # No valid measurements — leave the seq-level metrics
-                    # out of the emitted dict rather than pinning them to 0.
-                    seq_logprob_error_metrics: dict[str, Any] = {}
+                    # Cannot compute seq-level metrics with placeholder prev_logprobs
+                    seq_logprob_error_metrics = _placeholder_seq_logprob_error_metrics()
                 else:
                     seq_error_result = compute_and_apply_seq_logprob_error_masking(
                         train_data=train_data,

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -2359,28 +2359,17 @@ def _log_mixed_rewards_and_advantages_information(
     metrics["advantages/mean"] = advantages.float().mean().item()
 
 
-def _placeholder_seq_logprob_error_metrics() -> dict[str, float]:
-    """Zero-valued seq-level metrics used when the prev_logprobs forward is skipped."""
-    return {
-        "max_seq_mult_prob_error": 0.0,
-        "mean_seq_mult_prob_error": 0.0,
-        "min_seq_mult_prob_error": 0.0,
-        "max_seq_mult_prob_error_after_mask": 0.0,
-        "mean_seq_mult_prob_error_after_mask": 0.0,
-        "min_seq_mult_prob_error_after_mask": 0.0,
-        "num_masked_seqs_by_logprob_error": 0,
-        "masked_correct_pct": 0.0,
-    }
-
-
 def _resolve_logprob_skip_flags(
     master_config: MasterConfig,
 ) -> tuple[bool, Any, Optional[float]]:
     """Return (skip_prev, skip_ref, seq_logprob_error_threshold); warn on incompatible combos."""
+    # Skip prev_logprobs computation when force_on_policy_ratio=True
+    # unless seq_logprob_error_threshold is set (which requires prev_logprobs)
     seq_logprob_error_threshold = master_config.grpo.get(
         "seq_logprob_error_threshold", None
     )
     skip_prev_logprobs = opd_module._skip_prev_logprobs(master_config)
+    # todo @jiaqi: is there a better way to skip prev_logprobs computation while still computing the seq-level error metrics?
     if (
         master_config.loss_fn.force_on_policy_ratio
         and seq_logprob_error_threshold is not None
@@ -2389,6 +2378,7 @@ def _resolve_logprob_skip_flags(
             "force_on_policy_ratio=True but seq_logprob_error_threshold is set. "
             "Computing prev_logprobs anyway for seq-level error masking."
         )
+    # Skip reference_policy_logprobs computation when skip_reference_policy_logprobs_calculation=True
     return (
         skip_prev_logprobs,
         master_config.grpo.get("skip_reference_policy_logprobs_calculation"),
@@ -3057,7 +3047,9 @@ def grpo_train(
 
                 # Seq-level logprob error metrics/masking require real prev_logprobs
                 if skip_prev_logprobs:
-                    seq_logprob_error_metrics = _placeholder_seq_logprob_error_metrics()
+                    # No valid measurements — leave the seq-level metrics
+                    # out of the emitted dict rather than pinning them to 0.
+                    seq_logprob_error_metrics: dict[str, Any] = {}
                 else:
                     seq_error_result = compute_and_apply_seq_logprob_error_masking(
                         train_data=train_data,
@@ -4411,7 +4403,9 @@ def async_grpo_train(
 
                 # Seq-level logprob error metrics/masking require real prev_logprobs
                 if skip_prev_logprobs:
-                    seq_logprob_error_metrics = _placeholder_seq_logprob_error_metrics()
+                    # No valid measurements — leave the seq-level metrics
+                    # out of the emitted dict rather than pinning them to 0.
+                    seq_logprob_error_metrics: dict[str, Any] = {}
                 else:
                     seq_error_result = compute_and_apply_seq_logprob_error_masking(
                         train_data=train_data,

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -578,6 +578,8 @@ def setup(
             "Reference policy logprob calculation will be skipped since `grpo.skip_reference_policy_logprobs_calculation` is set to True and `loss_fn.reference_policy_kl_penalty` is 0."
         )
 
+    _validate_use_kl_in_reward_compat(master_config)
+
     # ==========================
     #          Cluster
     # ==========================
@@ -2130,14 +2132,6 @@ def _create_advantage_estimator(master_config: MasterConfig):
     grpo_config = master_config.grpo
     loss_config = master_config.loss_fn
 
-    assert not (
-        getattr(loss_config, "use_kl_in_reward", False)
-        and opd_module._skip_prev_logprobs(master_config)
-    ), (
-        "loss_fn.use_kl_in_reward requires real prev_logprobs but force_on_policy_ratio "
-        "with no grpo.seq_logprob_error_threshold zeros them (KL would be computed against a zero placeholder)."
-    )
-
     # Provide backward-compatible defaults when adv_estimator is not in config.
     # Fall back to top-level grpo.normalize_rewards / grpo.use_leave_one_out_baseline
     # which older configs still use.
@@ -2381,7 +2375,29 @@ def _placeholder_seq_logprob_error_metrics() -> dict[str, float]:
     }
 
 
-def _resolve_logprob_skip_flags(master_config: MasterConfig) -> tuple[bool, Any]:
+def _validate_use_kl_in_reward_compat(master_config: MasterConfig) -> None:
+    """Reject ``use_kl_in_reward`` when the KL term would read zero placeholder logprobs.
+
+    ``force_on_policy_ratio`` (without ``seq_logprob_error_threshold``) skips
+    the prev_logprobs forward and passes a zero placeholder to the advantage
+    estimator; ``use_kl_in_reward`` then applies
+    ``kl_coef * calculate_kl(zeros, ref)`` which corrupts the advantage.
+    ``kl_coef=0`` (``reference_policy_kl_penalty=0``) zeros the term regardless,
+    so that case is allowed.
+    """
+    loss_config = master_config.loss_fn
+    if loss_config.use_kl_in_reward and loss_config.reference_policy_kl_penalty != 0:
+        assert not opd_module._skip_prev_logprobs(master_config), (
+            "loss_fn.use_kl_in_reward with nonzero loss_fn.reference_policy_kl_penalty "
+            "requires real prev_logprobs, but force_on_policy_ratio (without "
+            "grpo.seq_logprob_error_threshold) zeros them — KL would be computed "
+            "against a zero placeholder."
+        )
+
+
+def _resolve_logprob_skip_flags(
+    master_config: MasterConfig,
+) -> tuple[bool, bool | None]:
     """Return (skip_prev_logprobs, skip_reference_logprobs); warn on incompatible combos.
 
     Skip prev_logprobs when force_on_policy_ratio=True unless

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -2359,6 +2359,43 @@ def _log_mixed_rewards_and_advantages_information(
     metrics["advantages/mean"] = advantages.float().mean().item()
 
 
+def _placeholder_seq_logprob_error_metrics() -> dict[str, float]:
+    """Zero-valued seq-level metrics used when the prev_logprobs forward is skipped."""
+    return {
+        "max_seq_mult_prob_error": 0.0,
+        "mean_seq_mult_prob_error": 0.0,
+        "min_seq_mult_prob_error": 0.0,
+        "max_seq_mult_prob_error_after_mask": 0.0,
+        "mean_seq_mult_prob_error_after_mask": 0.0,
+        "min_seq_mult_prob_error_after_mask": 0.0,
+        "num_masked_seqs_by_logprob_error": 0,
+        "masked_correct_pct": 0.0,
+    }
+
+
+def _resolve_logprob_skip_flags(
+    master_config: MasterConfig,
+) -> tuple[bool, Any, Optional[float]]:
+    """Return (skip_prev, skip_ref, seq_logprob_error_threshold); warn on incompatible combos."""
+    seq_logprob_error_threshold = master_config.grpo.get(
+        "seq_logprob_error_threshold", None
+    )
+    skip_prev_logprobs = opd_module._skip_prev_logprobs(master_config)
+    if (
+        master_config.loss_fn.force_on_policy_ratio
+        and seq_logprob_error_threshold is not None
+    ):
+        warnings.warn(
+            "force_on_policy_ratio=True but seq_logprob_error_threshold is set. "
+            "Computing prev_logprobs anyway for seq-level error masking."
+        )
+    return (
+        skip_prev_logprobs,
+        master_config.grpo.get("skip_reference_policy_logprobs_calculation"),
+        seq_logprob_error_threshold,
+    )
+
+
 def compute_and_apply_seq_logprob_error_masking(
     train_data: BatchedDataDict,
     rewards: torch.Tensor,
@@ -2952,24 +2989,11 @@ def grpo_train(
                     metrics_logging_data["content"] = flat_messages["content"]
 
                 memory_tracker.snapshot_start_of_stage("Computing logprobs", dir())
-                # Skip prev_logprobs computation when force_on_policy_ratio=True
-                # unless seq_logprob_error_threshold is set (which requires prev_logprobs)
-                seq_logprob_error_threshold = master_config.grpo.get(
-                    "seq_logprob_error_threshold", None
-                )
-                force_on_policy_ratio = master_config.loss_fn.force_on_policy_ratio
-                skip_prev_logprobs = opd_module._skip_prev_logprobs(master_config)
-                # todo @jiaqi: is there a better way to skip prev_logprobs computation while still computing the seq-level error metrics?
-                if force_on_policy_ratio and seq_logprob_error_threshold is not None:
-                    warnings.warn(
-                        "force_on_policy_ratio=True but seq_logprob_error_threshold is set. "
-                        "Computing prev_logprobs anyway for seq-level error masking."
-                    )
-
-                # Skip reference_policy_logprobs computation when skip_reference_policy_logprobs_calculation=True
-                skip_reference_logprobs = master_config.grpo.get(
-                    "skip_reference_policy_logprobs_calculation"
-                )
+                (
+                    skip_prev_logprobs,
+                    skip_reference_logprobs,
+                    seq_logprob_error_threshold,
+                ) = _resolve_logprob_skip_flags(master_config)
 
                 if not (skip_prev_logprobs and skip_reference_logprobs):
                     print("▶ Preparing for logprob inference...", flush=True)
@@ -3033,17 +3057,7 @@ def grpo_train(
 
                 # Seq-level logprob error metrics/masking require real prev_logprobs
                 if skip_prev_logprobs:
-                    # Cannot compute seq-level metrics with placeholder prev_logprobs
-                    seq_logprob_error_metrics = {
-                        "max_seq_mult_prob_error": 0.0,
-                        "mean_seq_mult_prob_error": 0.0,
-                        "min_seq_mult_prob_error": 0.0,
-                        "max_seq_mult_prob_error_after_mask": 0.0,
-                        "mean_seq_mult_prob_error_after_mask": 0.0,
-                        "min_seq_mult_prob_error_after_mask": 0.0,
-                        "num_masked_seqs_by_logprob_error": 0,
-                        "masked_correct_pct": 0.0,
-                    }
+                    seq_logprob_error_metrics = _placeholder_seq_logprob_error_metrics()
                 else:
                     seq_error_result = compute_and_apply_seq_logprob_error_masking(
                         train_data=train_data,
@@ -4357,25 +4371,11 @@ def async_grpo_train(
                     train_data.to("cpu")
 
                 # Training phase (same as sync version)
-                # Skip prev_logprobs computation when force_on_policy_ratio=True
-                # unless seq_logprob_error_threshold is set (which requires prev_logprobs)
-                seq_logprob_error_threshold = master_config.grpo.get(
-                    "seq_logprob_error_threshold", None
-                )
-                force_on_policy_ratio = master_config.loss_fn.force_on_policy_ratio
-                skip_prev_logprobs = opd_module._skip_prev_logprobs(master_config)
-
-                # todo @jiaqi: is there a better way to skip prev_logprobs computation while still computing the seq-level error metrics?
-                if force_on_policy_ratio and seq_logprob_error_threshold is not None:
-                    warnings.warn(
-                        "force_on_policy_ratio=True but seq_logprob_error_threshold is set. "
-                        "Computing prev_logprobs anyway for seq-level error masking."
-                    )
-
-                # Skip reference_policy_logprobs computation when skip_reference_policy_logprobs_calculation=True
-                skip_reference_logprobs = master_config.grpo.get(
-                    "skip_reference_policy_logprobs_calculation"
-                )
+                (
+                    skip_prev_logprobs,
+                    skip_reference_logprobs,
+                    seq_logprob_error_threshold,
+                ) = _resolve_logprob_skip_flags(master_config)
 
                 if not (skip_prev_logprobs and skip_reference_logprobs):
                     print("▶ Preparing for logprob inference...", flush=True)
@@ -4411,17 +4411,7 @@ def async_grpo_train(
 
                 # Seq-level logprob error metrics/masking require real prev_logprobs
                 if skip_prev_logprobs:
-                    # Cannot compute seq-level metrics with placeholder prev_logprobs
-                    seq_logprob_error_metrics = {
-                        "max_seq_mult_prob_error": 0.0,
-                        "mean_seq_mult_prob_error": 0.0,
-                        "min_seq_mult_prob_error": 0.0,
-                        "max_seq_mult_prob_error_after_mask": 0.0,
-                        "mean_seq_mult_prob_error_after_mask": 0.0,
-                        "min_seq_mult_prob_error_after_mask": 0.0,
-                        "num_masked_seqs_by_logprob_error": 0,
-                        "masked_correct_pct": 0.0,
-                    }
+                    seq_logprob_error_metrics = _placeholder_seq_logprob_error_metrics()
                 else:
                     seq_error_result = compute_and_apply_seq_logprob_error_masking(
                         train_data=train_data,

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -2130,6 +2130,13 @@ def _create_advantage_estimator(master_config: MasterConfig):
     grpo_config = master_config.grpo
     loss_config = master_config.loss_fn
 
+    assert not (
+        loss_config.use_kl_in_reward and opd_module._skip_prev_logprobs(master_config)
+    ), (
+        "loss_fn.use_kl_in_reward requires real prev_logprobs but force_on_policy_ratio "
+        "with no grpo.seq_logprob_error_threshold zeros them (KL would be computed against a zero placeholder)."
+    )
+
     # Provide backward-compatible defaults when adv_estimator is not in config.
     # Fall back to top-level grpo.normalize_rewards / grpo.use_leave_one_out_baseline
     # which older configs still use.

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -837,8 +837,9 @@ def grpo_train_sync(
                     )
                     generation_logprobs = extras_bdd["generation_logprobs"]
                     token_mask = extras_bdd["token_mask"]
-                    # Placeholder zeros satisfying compute_advantage's
-                    # signature; not shipped to workers.
+                    # Unused placeholder for compute_advantage's
+                    # logprobs_policy arg — GRPO/Reinforce++ ignore it,
+                    # and OPD is forbidden here (asserted by opd module).
                     prev_logprobs = (
                         extras_bdd["prev_logprobs"]
                         if compute_prev

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -51,6 +51,8 @@ from nemo_rl.algorithms.grpo import (
     _clip_grpo_advantages,
     _create_advantage_estimator,
     _log_mixed_rewards_and_advantages_information,
+    _placeholder_seq_logprob_error_metrics,
+    _resolve_logprob_skip_flags,
     _should_log_nemo_gym_responses,
     _should_use_nemo_gym,
     compute_and_apply_seq_logprob_error_masking,
@@ -777,9 +779,16 @@ def grpo_train_sync(
                 baseline_for_log = baseline.clone()
 
                 memory_tracker.snapshot_start_of_stage("Computing logprobs", dir())
-                print("▶ Preparing for logprob inference...", flush=True)
-                with timer.time("logprob_inference_prep"):
-                    policy.prepare_for_lp_inference()
+                (
+                    skip_prev_logprobs,
+                    skip_reference_logprobs,
+                    seq_logprob_error_threshold,
+                ) = _resolve_logprob_skip_flags(master_config)
+
+                if not (skip_prev_logprobs and skip_reference_logprobs):
+                    print("▶ Preparing for logprob inference...", flush=True)
+                    with timer.time("logprob_inference_prep"):
+                        policy.prepare_for_lp_inference()
 
                 print("▶ Computing logprobs...", flush=True)
                 with timer.time("policy_and_reference_logprobs"):
@@ -791,11 +800,14 @@ def grpo_train_sync(
                     # batched fetch to avoid double-shipping the per-token
                     # tensor through Ray's plasma store on top of the TQ
                     # writeback.
-                    policy.get_logprobs_from_meta(meta, timer=timer)
-                    compute_ref = not master_config.grpo.get(
-                        "skip_reference_policy_logprobs_calculation"
-                    )
-                    if compute_ref:
+                    if not skip_prev_logprobs:
+                        policy.get_logprobs_from_meta(meta, timer=timer)
+                    else:
+                        print(
+                            "▶ Skipping prev_logprobs (force_on_policy_ratio=True)...",
+                            flush=True,
+                        )
+                    if not skip_reference_logprobs:
                         policy.get_reference_policy_logprobs_from_meta(
                             meta,
                             timer=timer,
@@ -805,23 +817,41 @@ def grpo_train_sync(
                     # for masking / advantage. Bulk (input_ids, multimodal,
                     # output_ids, attention_mask, position_ids) stays in
                     # TQ — workers will fetch it via ``train_presharded``.
+                    select_fields = ["generation_logprobs", "token_mask"]
+                    if not skip_prev_logprobs:
+                        select_fields.append("prev_logprobs")
+                    if not skip_reference_logprobs:
+                        select_fields.append("reference_policy_logprobs")
                     extras_bdd = policy.read_from_dataplane(
                         meta,
-                        select_fields=[
-                            "prev_logprobs",
-                            "generation_logprobs",
-                            "token_mask",
-                            *(["reference_policy_logprobs"] if compute_ref else []),
-                        ],
+                        select_fields=select_fields,
                         pad_value_dict=_pad_dict,
                     )
-                    prev_logprobs = extras_bdd["prev_logprobs"]
                     generation_logprobs = extras_bdd["generation_logprobs"]
                     token_mask = extras_bdd["token_mask"]
+                    if skip_prev_logprobs:
+                        # Train workers fetch prev_logprobs via
+                        # train_presharded (it's in DP_TRAIN_FIELDS), so the
+                        # column must exist in TQ even when the forward was
+                        # skipped.
+                        prev_logprobs = torch.zeros_like(generation_logprobs)
+                        policy.write_to_dataplane(
+                            meta,
+                            fields={"prev_logprobs": prev_logprobs},
+                        )
+                    else:
+                        prev_logprobs = extras_bdd["prev_logprobs"]
                     reference_policy_logprobs = (
-                        extras_bdd["reference_policy_logprobs"] if compute_ref else None
+                        extras_bdd["reference_policy_logprobs"]
+                        if not skip_reference_logprobs
+                        else None
                     )
 
+                # Seq-level logprob error metrics/masking require real prev_logprobs
+                if skip_prev_logprobs:
+                    sample_mask = loss_multiplier
+                    seq_logprob_error_metrics = _placeholder_seq_logprob_error_metrics()
+                else:
                     sample_mask, seq_logprob_error_metrics = (
                         _compute_seq_logprob_error_metrics(
                             token_mask=token_mask,
@@ -829,9 +859,7 @@ def grpo_train_sync(
                             prev_logprobs=prev_logprobs,
                             generation_logprobs=generation_logprobs,
                             rewards=rewards,
-                            seq_logprob_error_threshold=master_config.grpo[
-                                "seq_logprob_error_threshold"
-                            ],
+                            seq_logprob_error_threshold=seq_logprob_error_threshold,
                         )
                     )
 

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -51,6 +51,7 @@ from nemo_rl.algorithms.grpo import (
     _clip_grpo_advantages,
     _create_advantage_estimator,
     _log_mixed_rewards_and_advantages_information,
+    _placeholder_seq_logprob_error_metrics,
     _resolve_logprob_skip_flags,
     _should_log_nemo_gym_responses,
     _should_use_nemo_gym,
@@ -829,15 +830,13 @@ def grpo_train_sync(
                     generation_logprobs = extras_bdd["generation_logprobs"]
                     token_mask = extras_bdd["token_mask"]
                     if skip_prev_logprobs:
-                        # Train workers fetch prev_logprobs via
-                        # train_presharded (it's in DP_TRAIN_FIELDS), so the
-                        # column must exist in TQ even when the forward was
-                        # skipped.
+                        # Driver-local placeholder for the advantage-compute
+                        # call below; not written to TQ. Train workers drop
+                        # prev_logprobs from the fetch when
+                        # loss_fn.force_on_policy_ratio is True
+                        # (see TQPolicy.train_from_meta) and the loss then
+                        # uses curr_logprobs instead.
                         prev_logprobs = torch.zeros_like(generation_logprobs)
-                        policy.write_to_dataplane(
-                            meta,
-                            fields={"prev_logprobs": prev_logprobs},
-                        )
                     else:
                         prev_logprobs = extras_bdd["prev_logprobs"]
                     reference_policy_logprobs = (
@@ -849,9 +848,8 @@ def grpo_train_sync(
                 # Seq-level logprob error metrics/masking require real prev_logprobs
                 if skip_prev_logprobs:
                     sample_mask = loss_multiplier
-                    # No valid measurements — leave the seq-level metrics
-                    # out of the emitted dict rather than pinning them to 0.
-                    seq_logprob_error_metrics: dict[str, Any] = {}
+                    # Cannot compute seq-level metrics with placeholder prev_logprobs
+                    seq_logprob_error_metrics = _placeholder_seq_logprob_error_metrics()
                 else:
                     sample_mask, seq_logprob_error_metrics = (
                         _compute_seq_logprob_error_metrics(

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -838,7 +838,9 @@ def grpo_train_sync(
                     generation_logprobs = extras_bdd["generation_logprobs"]
                     token_mask = extras_bdd["token_mask"]
                     prev_logprobs = (
-                        extras_bdd["prev_logprobs"] if compute_prev else None
+                        extras_bdd["prev_logprobs"]
+                        if compute_prev
+                        else torch.zeros_like(generation_logprobs)
                     )
                     reference_policy_logprobs = (
                         extras_bdd["reference_policy_logprobs"] if compute_ref else None
@@ -1214,9 +1216,7 @@ def grpo_train_sync(
                 log_data["sample_loss_mask"] = sample_mask.tolist()
                 log_data["advantages"] = advantages.tolist()
                 log_data["generation_logprobs"] = generation_logprobs.tolist()
-                log_data["prev_logprobs"] = (
-                    prev_logprobs.tolist() if prev_logprobs is not None else None
-                )
+                log_data["prev_logprobs"] = prev_logprobs.tolist()
                 # input_ids was stashed before the step-end clear_samples (the
                 # keys are no longer in TQ at this point); ``_log_input_ids``
                 # is None when nemo_gym-responses logging path skipped the

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -51,7 +51,6 @@ from nemo_rl.algorithms.grpo import (
     _clip_grpo_advantages,
     _create_advantage_estimator,
     _log_mixed_rewards_and_advantages_information,
-    _placeholder_seq_logprob_error_metrics,
     _resolve_logprob_skip_flags,
     _should_log_nemo_gym_responses,
     _should_use_nemo_gym,
@@ -850,7 +849,9 @@ def grpo_train_sync(
                 # Seq-level logprob error metrics/masking require real prev_logprobs
                 if skip_prev_logprobs:
                     sample_mask = loss_multiplier
-                    seq_logprob_error_metrics = _placeholder_seq_logprob_error_metrics()
+                    # No valid measurements — leave the seq-level metrics
+                    # out of the emitted dict rather than pinning them to 0.
+                    seq_logprob_error_metrics: dict[str, Any] = {}
                 else:
                     sample_mask, seq_logprob_error_metrics = (
                         _compute_seq_logprob_error_metrics(

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -837,13 +837,8 @@ def grpo_train_sync(
                     )
                     generation_logprobs = extras_bdd["generation_logprobs"]
                     token_mask = extras_bdd["token_mask"]
-                    # Unused placeholder for compute_advantage's
-                    # logprobs_policy arg — GRPO/Reinforce++ ignore it,
-                    # and OPD is forbidden here (asserted by opd module).
                     prev_logprobs = (
-                        extras_bdd["prev_logprobs"]
-                        if compute_prev
-                        else torch.zeros_like(generation_logprobs)
+                        extras_bdd["prev_logprobs"] if compute_prev else None
                     )
                     reference_policy_logprobs = (
                         extras_bdd["reference_policy_logprobs"] if compute_ref else None

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -1214,7 +1214,9 @@ def grpo_train_sync(
                 log_data["sample_loss_mask"] = sample_mask.tolist()
                 log_data["advantages"] = advantages.tolist()
                 log_data["generation_logprobs"] = generation_logprobs.tolist()
-                log_data["prev_logprobs"] = prev_logprobs.tolist()
+                log_data["prev_logprobs"] = (
+                    prev_logprobs.tolist() if prev_logprobs is not None else None
+                )
                 # input_ids was stashed before the step-end clear_samples (the
                 # keys are no longer in TQ at this point); ``_log_input_ids``
                 # is None when nemo_gym-responses logging path skipped the

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -73,7 +73,7 @@ from nemo_rl.algorithms.utils import (
 from nemo_rl.data.interfaces import DatumSpec
 from nemo_rl.data.llm_message_utils import batched_message_log_to_flat_message
 from nemo_rl.data_plane.interfaces import KVBatchMeta
-from nemo_rl.data_plane.schema import DP_CALIB_INPUT_FIELDS
+from nemo_rl.data_plane.schema import DP_CALIB_INPUT_FIELDS, DP_TRAIN_FIELDS
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.experience.sync_rollout_actor import SyncRolloutActor
@@ -787,6 +787,13 @@ def grpo_train_sync(
                 seq_logprob_error_threshold = master_config.grpo.get(
                     "seq_logprob_error_threshold", None
                 )
+                # Effective field set for this step. Filtered once; both
+                # the driver-side read_from_dataplane and the workers'
+                # train_presharded fetch (via train_from_meta) consume it.
+                train_fields = tuple(
+                    f for f in DP_TRAIN_FIELDS
+                    if not (skip_prev_logprobs and f == "prev_logprobs")
+                )
 
                 if compute_prev or compute_ref:
                     print("▶ Preparing for logprob inference...", flush=True)
@@ -923,7 +930,7 @@ def grpo_train_sync(
                         meta,
                         loss_fn=loss_fn,
                         timer=timer,
-                        skip_prev_logprobs=skip_prev_logprobs,
+                        train_fields=train_fields,
                     )
 
                 if sync_kv_scales:

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -779,13 +779,16 @@ def grpo_train_sync(
                 baseline_for_log = baseline.clone()
 
                 memory_tracker.snapshot_start_of_stage("Computing logprobs", dir())
-                (
-                    skip_prev_logprobs,
-                    skip_reference_logprobs,
-                    seq_logprob_error_threshold,
-                ) = _resolve_logprob_skip_flags(master_config)
+                skip_prev_logprobs, skip_reference_logprobs = (
+                    _resolve_logprob_skip_flags(master_config)
+                )
+                compute_prev = not skip_prev_logprobs
+                compute_ref = not skip_reference_logprobs
+                seq_logprob_error_threshold = master_config.grpo.get(
+                    "seq_logprob_error_threshold", None
+                )
 
-                if not (skip_prev_logprobs and skip_reference_logprobs):
+                if compute_prev or compute_ref:
                     print("▶ Preparing for logprob inference...", flush=True)
                     with timer.time("logprob_inference_prep"):
                         policy.prepare_for_lp_inference()
@@ -800,28 +803,29 @@ def grpo_train_sync(
                     # batched fetch to avoid double-shipping the per-token
                     # tensor through Ray's plasma store on top of the TQ
                     # writeback.
-                    if not skip_prev_logprobs:
+                    #
+                    # Each ``compute_X`` guard doubles as the "add to
+                    # select_fields" gate — one flag, one branch.
+                    select_fields = ["generation_logprobs", "token_mask"]
+                    if compute_prev:
                         policy.get_logprobs_from_meta(meta, timer=timer)
+                        select_fields.append("prev_logprobs")
                     else:
                         print(
                             "▶ Skipping prev_logprobs (force_on_policy_ratio=True)...",
                             flush=True,
                         )
-                    if not skip_reference_logprobs:
+                    if compute_ref:
                         policy.get_reference_policy_logprobs_from_meta(
                             meta,
                             timer=timer,
                         )
+                        select_fields.append("reference_policy_logprobs")
 
                     # Driver pulls only the per-token columns it needs
                     # for masking / advantage. Bulk (input_ids, multimodal,
                     # output_ids, attention_mask, position_ids) stays in
                     # TQ — workers will fetch it via ``train_presharded``.
-                    select_fields = ["generation_logprobs", "token_mask"]
-                    if not skip_prev_logprobs:
-                        select_fields.append("prev_logprobs")
-                    if not skip_reference_logprobs:
-                        select_fields.append("reference_policy_logprobs")
                     extras_bdd = policy.read_from_dataplane(
                         meta,
                         select_fields=select_fields,
@@ -829,20 +833,15 @@ def grpo_train_sync(
                     )
                     generation_logprobs = extras_bdd["generation_logprobs"]
                     token_mask = extras_bdd["token_mask"]
-                    if skip_prev_logprobs:
-                        # Driver-local placeholder for the advantage-compute
-                        # call below; not written to TQ. Train workers drop
-                        # prev_logprobs from the fetch when
-                        # loss_fn.force_on_policy_ratio is True
-                        # (see TQPolicy.train_from_meta) and the loss then
-                        # uses curr_logprobs instead.
-                        prev_logprobs = torch.zeros_like(generation_logprobs)
-                    else:
-                        prev_logprobs = extras_bdd["prev_logprobs"]
+                    # Local zeros for compute_advantage below; workers skip
+                    # fetching prev_logprobs (see TQPolicy.train_from_meta).
+                    prev_logprobs = (
+                        extras_bdd["prev_logprobs"]
+                        if compute_prev
+                        else torch.zeros_like(generation_logprobs)
+                    )
                     reference_policy_logprobs = (
-                        extras_bdd["reference_policy_logprobs"]
-                        if not skip_reference_logprobs
-                        else None
+                        extras_bdd["reference_policy_logprobs"] if compute_ref else None
                     )
 
                 # Seq-level logprob error metrics/masking require real prev_logprobs

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -803,9 +803,6 @@ def grpo_train_sync(
                     # batched fetch to avoid double-shipping the per-token
                     # tensor through Ray's plasma store on top of the TQ
                     # writeback.
-                    #
-                    # Each ``compute_X`` guard doubles as the "add to
-                    # select_fields" gate — one flag, one branch.
                     select_fields = ["generation_logprobs", "token_mask"]
                     if compute_prev:
                         policy.get_logprobs_from_meta(meta, timer=timer)
@@ -833,8 +830,8 @@ def grpo_train_sync(
                     )
                     generation_logprobs = extras_bdd["generation_logprobs"]
                     token_mask = extras_bdd["token_mask"]
-                    # Local zeros for compute_advantage below; workers skip
-                    # fetching prev_logprobs (see TQPolicy.train_from_meta).
+                    # Placeholder zeros satisfying compute_advantage's
+                    # signature; not shipped to workers.
                     prev_logprobs = (
                         extras_bdd["prev_logprobs"]
                         if compute_prev
@@ -926,6 +923,7 @@ def grpo_train_sync(
                         meta,
                         loss_fn=loss_fn,
                         timer=timer,
+                        skip_prev_logprobs=skip_prev_logprobs,
                     )
 
                 if sync_kv_scales:

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -791,7 +791,8 @@ def grpo_train_sync(
                 # the driver-side read_from_dataplane and the workers'
                 # train_presharded fetch (via train_from_meta) consume it.
                 train_fields = tuple(
-                    f for f in DP_TRAIN_FIELDS
+                    f
+                    for f in DP_TRAIN_FIELDS
                     if not (skip_prev_logprobs and f == "prev_logprobs")
                 )
 

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -117,6 +117,13 @@ def _raise_if_message_level_advantage_penalties_enabled(
     )
 
 
+def _train_fields_for_step(skip_prev_logprobs: bool) -> tuple[str, ...]:
+    """Fields workers fetch this step; ``prev_logprobs`` is dropped when skipped."""
+    return tuple(
+        f for f in DP_TRAIN_FIELDS if not (skip_prev_logprobs and f == "prev_logprobs")
+    )
+
+
 # ── DAPO non-zero-std dynamic sampling, slice-only ─────────────────────
 # Slice-only formulation of nemo_rl.algorithms.grpo.dynamic_sampling: filter
 # on std != 0, accumulate survivors across iterations, slice on overflow.
@@ -787,15 +794,10 @@ def grpo_train_sync(
                 seq_logprob_error_threshold = master_config.grpo.get(
                     "seq_logprob_error_threshold", None
                 )
-                # Worker-side fetch schema for this step. Derived from the
-                # same skip decision as ``select_fields`` below, but consumed
-                # only by ``train_from_meta`` (the driver read uses
-                # ``select_fields``).
-                train_fields = tuple(
-                    f
-                    for f in DP_TRAIN_FIELDS
-                    if not (skip_prev_logprobs and f == "prev_logprobs")
-                )
+                # Worker-side fetch schema for this step. Same skip decision
+                # as ``select_fields`` below, but consumed only by
+                # ``train_from_meta`` (driver read uses ``select_fields``).
+                train_fields = _train_fields_for_step(skip_prev_logprobs)
 
                 if compute_prev or compute_ref:
                     print("▶ Preparing for logprob inference...", flush=True)

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -787,9 +787,10 @@ def grpo_train_sync(
                 seq_logprob_error_threshold = master_config.grpo.get(
                     "seq_logprob_error_threshold", None
                 )
-                # Effective field set for this step. Filtered once; both
-                # the driver-side read_from_dataplane and the workers'
-                # train_presharded fetch (via train_from_meta) consume it.
+                # Worker-side fetch schema for this step. Derived from the
+                # same skip decision as ``select_fields`` below, but consumed
+                # only by ``train_from_meta`` (the driver read uses
+                # ``select_fields``).
                 train_fields = tuple(
                     f
                     for f in DP_TRAIN_FIELDS

--- a/nemo_rl/models/policy/tq_policy.py
+++ b/nemo_rl/models/policy/tq_policy.py
@@ -364,7 +364,7 @@ class TQPolicy(Policy):
         gbs: Optional[int] = None,
         mbs: Optional[int] = None,
         timer: Optional[Timer] = None,
-        skip_prev_logprobs: bool = False,
+        train_fields: Optional[tuple[str, ...]] = None,
     ) -> dict[str, Any]:
         """1-hop counterpart to :meth:`train`.
 
@@ -393,12 +393,10 @@ class TQPolicy(Policy):
         # logprob deltas + advantages + sample_mask). Caller is responsible
         # for ensuring those columns have been written to TQ before this
         # call (workers + driver delta-writes).
-        # skip_prev_logprobs=True → loss uses curr_logprobs in place of
-        # prev_logprobs, so drop it from the fetch entirely (dp_client
-        # rejects unknown fields).
-        train_fields = DP_TRAIN_FIELDS
-        if skip_prev_logprobs:
-            train_fields = tuple(f for f in train_fields if f != "prev_logprobs")
+        # Caller may narrow the fetch schema (e.g. drop prev_logprobs
+        # when force_on_policy_ratio=True); default to DP_TRAIN_FIELDS.
+        if train_fields is None:
+            train_fields = DP_TRAIN_FIELDS
         train_meta = replace(
             meta,
             fields=fields_with_optional_routed_experts(

--- a/nemo_rl/models/policy/tq_policy.py
+++ b/nemo_rl/models/policy/tq_policy.py
@@ -392,11 +392,10 @@ class TQPolicy(Policy):
         # logprob deltas + advantages + sample_mask). Caller is responsible
         # for ensuring those columns have been written to TQ before this
         # call (workers + driver delta-writes).
-        # When force_on_policy_ratio=True the loss uses curr_logprobs in
-        # place of prev_logprobs (see ClippedPGLoss), so we drop it from
-        # the fetch instead of forcing the driver to write placeholder
-        # zeros back to TQ.
-        train_fields: tuple[str, ...] = DP_TRAIN_FIELDS
+        # force_on_policy_ratio=True → loss uses curr_logprobs in place
+        # of prev_logprobs, so drop it from the fetch entirely
+        # (dp_client rejects missing fields — see noop adapter).
+        train_fields = DP_TRAIN_FIELDS
         if getattr(loss_fn, "force_on_policy_ratio", False):
             train_fields = tuple(f for f in train_fields if f != "prev_logprobs")
         train_meta = replace(

--- a/nemo_rl/models/policy/tq_policy.py
+++ b/nemo_rl/models/policy/tq_policy.py
@@ -392,10 +392,17 @@ class TQPolicy(Policy):
         # logprob deltas + advantages + sample_mask). Caller is responsible
         # for ensuring those columns have been written to TQ before this
         # call (workers + driver delta-writes).
+        # When force_on_policy_ratio=True the loss uses curr_logprobs in
+        # place of prev_logprobs (see ClippedPGLoss), so we drop it from
+        # the fetch instead of forcing the driver to write placeholder
+        # zeros back to TQ.
+        train_fields: tuple[str, ...] = DP_TRAIN_FIELDS
+        if getattr(loss_fn, "force_on_policy_ratio", False):
+            train_fields = tuple(f for f in train_fields if f != "prev_logprobs")
         train_meta = replace(
             meta,
             fields=fields_with_optional_routed_experts(
-                DP_TRAIN_FIELDS, enabled=self._router_replay_enabled
+                train_fields, enabled=self._router_replay_enabled
             ),
             task_name="train",
         )

--- a/nemo_rl/models/policy/tq_policy.py
+++ b/nemo_rl/models/policy/tq_policy.py
@@ -364,6 +364,7 @@ class TQPolicy(Policy):
         gbs: Optional[int] = None,
         mbs: Optional[int] = None,
         timer: Optional[Timer] = None,
+        skip_prev_logprobs: bool = False,
     ) -> dict[str, Any]:
         """1-hop counterpart to :meth:`train`.
 
@@ -392,11 +393,11 @@ class TQPolicy(Policy):
         # logprob deltas + advantages + sample_mask). Caller is responsible
         # for ensuring those columns have been written to TQ before this
         # call (workers + driver delta-writes).
-        # force_on_policy_ratio=True → loss uses curr_logprobs in place
-        # of prev_logprobs, so drop it from the fetch entirely
-        # (dp_client rejects missing fields — see noop adapter).
+        # skip_prev_logprobs=True → loss uses curr_logprobs in place of
+        # prev_logprobs, so drop it from the fetch entirely (dp_client
+        # rejects unknown fields).
         train_fields = DP_TRAIN_FIELDS
-        if getattr(loss_fn, "force_on_policy_ratio", False):
+        if skip_prev_logprobs:
             train_fields = tuple(f for f in train_fields if f != "prev_logprobs")
         train_meta = replace(
             meta,

--- a/nemo_rl/models/policy/tq_policy.py
+++ b/nemo_rl/models/policy/tq_policy.py
@@ -364,7 +364,7 @@ class TQPolicy(Policy):
         gbs: Optional[int] = None,
         mbs: Optional[int] = None,
         timer: Optional[Timer] = None,
-        train_fields: Optional[tuple[str, ...]] = None,
+        train_fields: tuple[str, ...] = DP_TRAIN_FIELDS,
     ) -> dict[str, Any]:
         """1-hop counterpart to :meth:`train`.
 
@@ -394,9 +394,7 @@ class TQPolicy(Policy):
         # for ensuring those columns have been written to TQ before this
         # call (workers + driver delta-writes).
         # Caller may narrow the fetch schema (e.g. drop prev_logprobs
-        # when force_on_policy_ratio=True); default to DP_TRAIN_FIELDS.
-        if train_fields is None:
-            train_fields = DP_TRAIN_FIELDS
+        # when force_on_policy_ratio=True).
         train_meta = replace(
             meta,
             fields=fields_with_optional_routed_experts(

--- a/nemo_rl/models/policy/tq_policy.py
+++ b/nemo_rl/models/policy/tq_policy.py
@@ -393,8 +393,10 @@ class TQPolicy(Policy):
 
         self._stamp_pad_seqlen(meta)
         spa, dba = self._packing_args("train_mb_tokens")
-        # ``train_fields`` columns must already be in TQ (rollout + worker
-        # logprob deltas + driver advantage delta) before this call.
+        # ``train_fields`` (rollout + logprob deltas + advantages + sample_mask;
+        # default ``DP_TRAIN_FIELDS``) must be in TQ before this call — written
+        # by workers + driver delta-writes. Caller may narrow to drop columns
+        # skipped this step (e.g. ``prev_logprobs`` under force_on_policy_ratio).
         train_meta = replace(
             meta,
             fields=fields_with_optional_routed_experts(

--- a/nemo_rl/models/policy/tq_policy.py
+++ b/nemo_rl/models/policy/tq_policy.py
@@ -393,12 +393,8 @@ class TQPolicy(Policy):
 
         self._stamp_pad_seqlen(meta)
         spa, dba = self._packing_args("train_mb_tokens")
-        # Train workers fetch ``train_fields`` (rollout + logprob deltas +
-        # advantages + sample_mask), defaulting to the full DP_TRAIN_FIELDS
-        # schema. Caller is responsible for ensuring those columns have been
-        # written to TQ before this call (workers + driver delta-writes), and
-        # may narrow it to drop columns it skipped writing this step (e.g.
-        # prev_logprobs when force_on_policy_ratio=True).
+        # ``train_fields`` columns must already be in TQ (rollout + worker
+        # logprob deltas + driver advantage delta) before this call.
         train_meta = replace(
             meta,
             fields=fields_with_optional_routed_experts(

--- a/nemo_rl/models/policy/tq_policy.py
+++ b/nemo_rl/models/policy/tq_policy.py
@@ -380,6 +380,10 @@ class TQPolicy(Policy):
             gbs: Global batch size; defaults to ``cfg["train_global_batch_size"]``.
             mbs: Micro batch size; defaults to ``cfg["train_micro_batch_size"]``.
             timer: Optional timer for nested ``policy_training/*`` measurements.
+            train_fields: TQ columns workers fetch this step; defaults to the
+                full ``DP_TRAIN_FIELDS`` schema. Caller may narrow it to drop
+                columns it skipped writing (e.g. ``prev_logprobs`` when
+                ``force_on_policy_ratio=True``).
 
         Returns:
             Aggregated training-step output dict.
@@ -389,12 +393,12 @@ class TQPolicy(Policy):
 
         self._stamp_pad_seqlen(meta)
         spa, dba = self._packing_args("train_mb_tokens")
-        # Train workers fetch the full DP_TRAIN_FIELDS schema (rollout +
-        # logprob deltas + advantages + sample_mask). Caller is responsible
-        # for ensuring those columns have been written to TQ before this
-        # call (workers + driver delta-writes).
-        # Caller may narrow the fetch schema (e.g. drop prev_logprobs
-        # when force_on_policy_ratio=True).
+        # Train workers fetch ``train_fields`` (rollout + logprob deltas +
+        # advantages + sample_mask), defaulting to the full DP_TRAIN_FIELDS
+        # schema. Caller is responsible for ensuring those columns have been
+        # written to TQ before this call (workers + driver delta-writes), and
+        # may narrow it to drop columns it skipped writing this step (e.g.
+        # prev_logprobs when force_on_policy_ratio=True).
         train_meta = replace(
             meta,
             fields=fields_with_optional_routed_experts(

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -3634,16 +3634,14 @@ class TestAggregateRolloutMetrics:
 
 
 def _cfg(*, force=False, threshold=None, skip_ref=None, kl_reward=False):
-    from types import SimpleNamespace
-
-    return SimpleNamespace(
+    return MasterConfig.model_construct(
+        loss_fn=ClippedPGLossConfig(
+            force_on_policy_ratio=force, use_kl_in_reward=kl_reward
+        ),
         grpo={
             "seq_logprob_error_threshold": threshold,
             "skip_reference_policy_logprobs_calculation": skip_ref,
         },
-        loss_fn=SimpleNamespace(
-            force_on_policy_ratio=force, use_kl_in_reward=kl_reward
-        ),
     )
 
 

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -32,9 +32,11 @@ from nemo_rl.algorithms.grpo import (
     _apply_configured_message_level_advantage_penalties,
     _apply_mask_sample_filter,
     _apply_message_level_advantage_penalties,
+    _create_advantage_estimator,
     _default_grpo_save_state,
     _initial_policy_generation_stale,
     _raise_if_reward_penalties_enabled_without_nemo_gym,
+    _resolve_logprob_skip_flags,
     _resolve_message_level_advantage_penalties,
     _should_use_async_rollouts,
     aggregate_rollout_metrics,
@@ -3629,3 +3631,36 @@ class TestAggregateRolloutMetrics:
         assert result["total_turns"] == 45
         assert result["accuracy"] == pytest.approx(0.8)
         assert result["min_accuracy_rate"] == pytest.approx(0.2)
+
+
+def _cfg(*, force=False, threshold=None, skip_ref=None, kl_reward=False):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        grpo={
+            "seq_logprob_error_threshold": threshold,
+            "skip_reference_policy_logprobs_calculation": skip_ref,
+        },
+        loss_fn=SimpleNamespace(
+            force_on_policy_ratio=force, use_kl_in_reward=kl_reward
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "kw, expected",
+    [
+        ({}, (False, None)),
+        ({"force": True}, (True, None)),
+        ({"force": True, "threshold": 1.5}, (False, None)),  # threshold overrides skip
+        ({"skip_ref": True}, (False, True)),
+    ],
+    ids=["default", "force_on_policy", "force_plus_threshold", "skip_ref"],
+)
+def test_resolve_logprob_skip_flags(kw, expected):
+    assert _resolve_logprob_skip_flags(_cfg(**kw)) == expected
+
+
+def test_advantage_estimator_rejects_kl_reward_with_force_on_policy_ratio():
+    with pytest.raises(AssertionError, match="use_kl_in_reward"):
+        _create_advantage_estimator(_cfg(force=True, kl_reward=True))

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -47,6 +47,7 @@ from nemo_rl.algorithms.grpo import (
     refit_policy_generation,
     validate,
 )
+from nemo_rl.algorithms.grpo_sync import _train_fields_for_step
 from nemo_rl.algorithms.loss import ClippedPGLossConfig, ClippedPGLossFn
 from nemo_rl.algorithms.reward_functions import (
     RewardShapingConfig,
@@ -3676,3 +3677,13 @@ def test_validate_use_kl_in_reward_allows_zero_kl_penalty():
     # kl_coef=0 zeros the KL term regardless, so a zero-placeholder
     # prev_logprobs can't corrupt the advantage.
     _validate_use_kl_in_reward_compat(_cfg(force=True, kl_reward=True, kl_penalty=0.0))
+
+
+@pytest.mark.parametrize(
+    "skip_prev_logprobs, expect_prev",
+    [(False, True), (True, False)],
+    ids=["keep_prev_logprobs", "skip_prev_logprobs"],
+)
+def test_train_fields_for_step(skip_prev_logprobs, expect_prev):
+    fields = _train_fields_for_step(skip_prev_logprobs)
+    assert ("prev_logprobs" in fields) is expect_prev

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -32,13 +32,13 @@ from nemo_rl.algorithms.grpo import (
     _apply_configured_message_level_advantage_penalties,
     _apply_mask_sample_filter,
     _apply_message_level_advantage_penalties,
-    _create_advantage_estimator,
     _default_grpo_save_state,
     _initial_policy_generation_stale,
     _raise_if_reward_penalties_enabled_without_nemo_gym,
     _resolve_logprob_skip_flags,
     _resolve_message_level_advantage_penalties,
     _should_use_async_rollouts,
+    _validate_use_kl_in_reward_compat,
     aggregate_rollout_metrics,
     async_grpo_train,
     compute_and_apply_seq_logprob_error_masking,
@@ -3633,10 +3633,14 @@ class TestAggregateRolloutMetrics:
         assert result["min_accuracy_rate"] == pytest.approx(0.2)
 
 
-def _cfg(*, force=False, threshold=None, skip_ref=None, kl_reward=False):
+def _cfg(
+    *, force=False, threshold=None, skip_ref=None, kl_reward=False, kl_penalty=0.01
+):
     return MasterConfig.model_construct(
         loss_fn=ClippedPGLossConfig(
-            force_on_policy_ratio=force, use_kl_in_reward=kl_reward
+            force_on_policy_ratio=force,
+            use_kl_in_reward=kl_reward,
+            reference_policy_kl_penalty=kl_penalty,
         ),
         grpo={
             "seq_logprob_error_threshold": threshold,
@@ -3656,9 +3660,19 @@ def _cfg(*, force=False, threshold=None, skip_ref=None, kl_reward=False):
     ids=["default", "force_on_policy", "force_plus_threshold", "skip_ref"],
 )
 def test_resolve_logprob_skip_flags(kw, expected):
-    assert _resolve_logprob_skip_flags(_cfg(**kw)) == expected
+    if kw.get("force") and kw.get("threshold") is not None:
+        with pytest.warns(UserWarning, match="seq_logprob_error_threshold is set"):
+            assert _resolve_logprob_skip_flags(_cfg(**kw)) == expected
+    else:
+        assert _resolve_logprob_skip_flags(_cfg(**kw)) == expected
 
 
-def test_advantage_estimator_rejects_kl_reward_with_force_on_policy_ratio():
+def test_validate_use_kl_in_reward_rejects_force_on_policy_ratio():
     with pytest.raises(AssertionError, match="use_kl_in_reward"):
-        _create_advantage_estimator(_cfg(force=True, kl_reward=True))
+        _validate_use_kl_in_reward_compat(_cfg(force=True, kl_reward=True))
+
+
+def test_validate_use_kl_in_reward_allows_zero_kl_penalty():
+    # kl_coef=0 zeros the KL term regardless, so a zero-placeholder
+    # prev_logprobs can't corrupt the advantage.
+    _validate_use_kl_in_reward_compat(_cfg(force=True, kl_reward=True, kl_penalty=0.0))


### PR DESCRIPTION
## Summary

grpo_sync.py (TQ trainer) never honored loss_fn.force_on_policy_ratio, so it always ran the prev-logprob forward.

## Fix

- Guard `policy.get_logprobs_from_meta(meta, …)` on `not skip_prev_logprobs`.
- Populate `prev_logprobs` locally with `torch.zeros_like(generation_logprobs)` when skipping (mirroring legacy `train_data["prev_logprobs"] = torch.zeros_like(...)`).
- Skip `logprob_inference_prep` when both prev and ref are skipped.
- Emit placeholder seq-level metrics (zero-filled) when the forward is skipped — matches legacy for wandb continuity.

# e2e tests
Verified force_on_policy_ratio is honored in grpo-qwen3-235b-16n8g, 16n × 8G e2e run
* Pre-fix TQ: https://wandb.ai/nvidia/nemorl-dataplane-zhiyul/runs/ezjf3udt
* legacy: https://wandb.ai/nvidia/nemorl-dataplane-zhiyul/runs/8cv205eq
* post-fix: https://wandb.ai/nvidia/nemorl-dataplane-zhiyul/runs/yzohftac
