### PR TITLE
perf: reduce Qwen3 logprob batch size

### DIFF
--- a/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n8g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-qwen3-30ba3b-4n8g.yaml
@@ -8,7 +8,7 @@ checkpointing:
 policy:
   model_name: Qwen/Qwen3-30B-A3B
   train_micro_batch_size: 1
-  logprob_batch_size: 4
+  logprob_batch_size: 2
   max_total_sequence_length: 4096
   sequence_packing:
     fuse_loss: true


### PR DESCRIPTION
## Summary

- Reduce `policy.logprob_batch_size` from 4 to 2 in the `grpo-qwen3-30ba3b-4n8g` performance recipe.
- Leave every other model and runtime setting unchanged.

## Why

The current logprob batch size of 4 can leave insufficient GPU memory headroom and trigger CUDA OOMs. Reducing the logprob microbatch to 2 lowers the peak working set while retaining better throughput than batch size 1.

Fixes #2811