### PR TITLE
fix: fix grpo-deepscaler-1.5b-24K

### DIFF
--- a/examples/configs/recipes/llm/grpo-deepscaler-1.5b-24K.yaml
+++ b/examples/configs/recipes/llm/grpo-deepscaler-1.5b-24K.yaml
@@ -13,4 +13,3 @@ policy:
   generation:
     vllm_cfg:
       gpu_memory_utilization: 0.8
-      enforce_eager: true


### PR DESCRIPTION
## Summary
validated `grpo-deepscaler-1.5b-24K` pass without timeout.

1. `enforce_eager: true` first introduced in https://github.com/NVIDIA-NeMo/RL/pull/857 for 8K and 24K.
2. https://github.com/NVIDIA-NeMo/RL/pull/1014 use `use_inductor: False` and set back to `enforce_eager: False` in 8K, **but didn't set for 24K**.
3. https://github.com/NVIDIA-NeMo/RL/pull/1962 updated `use_inductor: False` to `backend: eager`.

so this PR just remove `enforce_eager: true` in 24K and let it inherit from 8K.

## Test
**Red**: ~last release. **Yellow**: before #2981. **Pink**: after #2981. **Green**: this PR.
<img width="1352" height="606" alt="image" src="https://github.com/user-attachments/assets/a36cd503-cb30-4115-960a-98704d6a11fa" />
<img width="1354" height="632" alt="image" src="https://github.com/user-attachments/assets/003d96f1-b85a-4184-825d-1f13f272ba62" />