### PR TITLE
fix: fix grpo-qwen2.5-1.5B-4n8g-megatron-yarn-256k

### DIFF
--- a/tests/test_suites/llm/grpo-qwen2.5-1.5B-4n8g-megatron-yarn-256k.sh
+++ b/tests/test_suites/llm/grpo-qwen2.5-1.5B-4n8g-megatron-yarn-256k.sh
@@ -7,7 +7,7 @@ NUM_NODES=4
 STEPS_PER_RUN=30
 MAX_STEPS=30
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
-NUM_MINUTES=60
+NUM_MINUTES=90
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached
@@ -34,8 +34,8 @@ uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
 if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
     uv run tests/check_metrics.py $JSON_METRICS \
         'mean(data["train/token_mult_prob_error"], ignore_top_p=0.05) < 1.05' \
-        'mean(data["train/reward"], -6, -1) > 0.0' \
-        'data["validation/accuracy"]["30"] > 0.18'
+        'data["train/reward"]["30"] > 0.5' \
+        'data["validation/accuracy"]["30"] > 0.1'
 
     # Clean up checkpoint directory after successful run to save space.
     rm -rf "$CKPT_DIR"

--- a/tests/test_suites/llm/grpo-qwen2.5-1.5B-4n8g-megatron-yarn-256k.sh
+++ b/tests/test_suites/llm/grpo-qwen2.5-1.5B-4n8g-megatron-yarn-256k.sh
@@ -7,7 +7,10 @@ NUM_NODES=4
 STEPS_PER_RUN=30
 MAX_STEPS=30
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
-NUM_MINUTES=90
+# Note: This test's runtime variance is large: it depends on how many steps have rollouts whose
+# seqlen actually reaches 256k. In practice runs finish within ~2 hours; the
+# 4-hour cap is a safety margin for the worst case.
+NUM_MINUTES=240
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached

--- a/tests/unit/test_recipes_and_test_suites.py
+++ b/tests/unit/test_recipes_and_test_suites.py
@@ -255,7 +255,7 @@ def test_all_recipe_yamls_accounted_for_in_test_suites(
     )
 
 
-def test_nightly_compute_stays_below_3310_hours(nightly_test_suite, tracker):
+def test_nightly_compute_stays_below_3390_hours(nightly_test_suite, tracker):
     command = f"DRYRUN=1 HF_HOME=... HF_DATASETS_CACHE=... CONTAINER= ACCOUNT= PARTITION= ./tools/launch {' '.join(nightly_test_suite)}"
 
     print(f"Running command: {command}")
@@ -287,8 +287,8 @@ def test_nightly_compute_stays_below_3310_hours(nightly_test_suite, tracker):
         f"Last line of output was not as expected: '{last_line}'"
     )
     total_gpu_hours = float(last_line.split(":")[-1].strip())
-    assert total_gpu_hours <= 3310, (
-        f"Total GPU hours exceeded 3310: {last_line}. We should revisit the test suites to reduce the total GPU hours."
+    assert total_gpu_hours <= 3390, (
+        f"Total GPU hours exceeded 3390: {last_line}. We should revisit the test suites to reduce the total GPU hours."
     )
     tracker.track("total_nightly_gpu_hours", total_gpu_hours)
 

--- a/tests/unit/test_recipes_and_test_suites.py
+++ b/tests/unit/test_recipes_and_test_suites.py
@@ -255,7 +255,7 @@ def test_all_recipe_yamls_accounted_for_in_test_suites(
     )
 
 
-def test_nightly_compute_stays_below_3270_hours(nightly_test_suite, tracker):
+def test_nightly_compute_stays_below_3310_hours(nightly_test_suite, tracker):
     command = f"DRYRUN=1 HF_HOME=... HF_DATASETS_CACHE=... CONTAINER= ACCOUNT= PARTITION= ./tools/launch {' '.join(nightly_test_suite)}"
 
     print(f"Running command: {command}")
@@ -287,8 +287,8 @@ def test_nightly_compute_stays_below_3270_hours(nightly_test_suite, tracker):
         f"Last line of output was not as expected: '{last_line}'"
     )
     total_gpu_hours = float(last_line.split(":")[-1].strip())
-    assert total_gpu_hours <= 3270, (
-        f"Total GPU hours exceeded 3270: {last_line}. We should revisit the test suites to reduce the total GPU hours."
+    assert total_gpu_hours <= 3310, (
+        f"Total GPU hours exceeded 3310: {last_line}. We should revisit the test suites to reduce the total GPU hours."
     )
     tracker.track("total_nightly_gpu_hours", total_gpu_hours)
 


### PR DESCRIPTION
1. previous metric is flaky, updated to `data["train/reward"]["30"] > 0.5` and loosen to `data["validation/accuracy"]["30"] > 0.1`.
    <img width="1356" height="638" alt="image" src="https://github.com/user-attachments/assets/d22a55bc-718e-4e8e-93f1-7e6b2646b5ec" />
2. run time for this test is random, increased to 240 to avoid flaky fail.
    <img width="2008" height="698" alt="image" src="https://github.com/user-attachments/assets/4b227ac6-4371-4f3d-92ce-3e0cb2738f08" />
    <img width="1350" height="624" alt="image" src="https://github.com/user-attachments/assets/29a26f80-7ea2-4f5e-91af-f83fcd62b08a" />