### PR TITLE
fix: Port contention issues between Ray/vLLM/Gym and sandbox workers

### DIFF
--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -152,36 +152,38 @@ sbatch ray.sub \
   - Number of GPUs each Ray worker node claims. To determine this, run `nvidia-smi` on a worker node.
 * - `BASE_LOG_DIR=$SLURM_SUBMIT_DIR`
   - Base directory for storing Ray logs. Defaults to the Slurm submission directory ([SLURM_SUBMIT_DIR](https://slurm.schedmd.com/sbatch.html#OPT_SLURM_SUBMIT_DIR)).
-* - `NODE_MANAGER_PORT=53001`
+* - `NODE_MANAGER_PORT=1301`
   - Port for the Ray node manager on worker nodes.
-* - `OBJECT_MANAGER_PORT=53003`
+* - `OBJECT_MANAGER_PORT=1303`
   - Port for the Ray object manager on worker nodes.
-* - `RUNTIME_ENV_AGENT_PORT=53005`
+* - `RUNTIME_ENV_AGENT_PORT=1305`
   - Port for the Ray runtime environment agent on worker nodes.
-* - `DASHBOARD_AGENT_GRPC_PORT=53007`
+* - `DASHBOARD_AGENT_GRPC_PORT=1307`
   - gRPC port for the Ray dashboard agent on worker nodes.
-* - `METRICS_EXPORT_PORT=53009`
+* - `METRICS_EXPORT_PORT=1309`
   - Port for exporting metrics from worker nodes.
-* - `PORT=6379`
+* - `PORT=1200`
   - Main port for the Ray head node.
-* - `RAY_CLIENT_SERVER_PORT=10001`
+* - `RAY_CLIENT_SERVER_PORT=1201`
   - Port for the Ray client server on the head node.
 * - `DASHBOARD_GRPC_PORT=52367`
   - gRPC port for the Ray dashboard on the head node.
 * - `DASHBOARD_PORT=8265`
   - Port for the Ray dashboard UI on the head node. This is also the port
     used by the Ray distributed debugger.
-* - `DASHBOARD_AGENT_LISTEN_PORT=52365`
+* - `DASHBOARD_AGENT_LISTEN_PORT=1311`
   - Listening port for the dashboard agent on the head node.
-* - `MIN_WORKER_PORT=54001`
+* - `MIN_WORKER_PORT=2000`
   - Minimum port in the range for Ray worker processes.
-* - `MAX_WORKER_PORT=54257`
+* - `MAX_WORKER_PORT=2999`
   - Maximum port in the range for Ray worker processes.
 ``````
 
 > [!NOTE]
 > For the most part, you will not need to change ports unless these
 > are already taken by some other service backgrounded on your cluster.
+> The defaults above are the source-of-truth port layout defined in `ray.sub`;
+> keep this table in sync with that block if the defaults ever change.
 
 ### Topology-Aware Placement for MoE (avoiding cross-rack stalls)
 

--- a/examples/configs/distillation_math.yaml
+++ b/examples/configs/distillation_math.yaml
@@ -190,8 +190,8 @@ policy: &POLICY_BASE
     generation:
         # Port range for vLLM HTTP servers, kept below the OS ephemeral range.
         # See ray.sub for the full port layout.
-        port_range_low: 11001
-        port_range_high: 15000
+        port_range_low: 3000
+        port_range_high: 4999
         backend: "vllm"
         max_new_tokens: ${..max_total_sequence_length} # refer to local policy/teacher config
         temperature: 1.0
@@ -280,6 +280,6 @@ logger:
 cluster:
     gpus_per_node: 8
     num_nodes: 1
-    master_port_range_low: 25000
-    master_port_range_high: 28000
+    master_port_range_low: 1400
+    master_port_range_high: 1999
     segment_size: null  # Nodes per NVLink domain segment for topology-aware alignment; null to disable

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -327,8 +327,8 @@ policy:
   generation:
     # Port range for vLLM HTTP servers, kept below the OS ephemeral range.
     # See ray.sub for the full port layout.
-    port_range_low: 11001
-    port_range_high: 15000
+    port_range_low: 3000
+    port_range_high: 4999
     backend: "vllm"
     max_new_tokens: ${policy.max_total_sequence_length}
     temperature: 1.0
@@ -461,8 +461,8 @@ cluster:
   # Port range for the distributed master address (TCPStore / NCCL rendezvous)
   # and per-worker available ports.  Kept below the OS ephemeral range
   # (32768-60999 on stock Linux).  See ray.sub for the full port layout.
-  master_port_range_low: 25000
-  master_port_range_high: 28000
+  master_port_range_low: 1400
+  master_port_range_high: 1999
   segment_size: null  # Nodes per NVLink domain segment for topology-aware alignment; null to disable
 
 # TransferQueue-mediated data plane for sync GRPO.

--- a/examples/nemo_gym/distillation_qwen3_0_6b.yaml
+++ b/examples/nemo_gym/distillation_qwen3_0_6b.yaml
@@ -94,8 +94,8 @@ env:
   should_use_nemo_gym: true
   should_log_nemo_gym_responses: false
   nemo_gym:
-    port_range_low: 15001
-    port_range_high: 20000
+    port_range_low: 5000
+    port_range_high: 5999
     config_paths:
       - responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
       - resources_servers/example_multi_step/configs/example_multi_step.yaml

--- a/examples/nemo_gym/grpo_nanov3.yaml
+++ b/examples/nemo_gym/grpo_nanov3.yaml
@@ -195,8 +195,8 @@ policy:
   generation:
     # Port range for vLLM HTTP servers, kept below the OS ephemeral range.
     # See ray.sub for the full port layout.
-    port_range_low: 11001
-    port_range_high: 15000
+    port_range_low: 3000
+    port_range_high: 4999
     backend: "vllm"
     max_new_tokens: ${policy.max_total_sequence_length}
     temperature: 1.0
@@ -304,10 +304,10 @@ env:
   should_log_nemo_gym_responses: true
   nemo_gym:
     # Port range for Gym HTTP servers, kept below the OS ephemeral range
-    # (32768-60999) and non-overlapping with NeMo RL (11001-15000) or
-    # vLLM (20001+). See ray.sub for the full port layout.
-    port_range_low: 15001
-    port_range_high: 20000
+    # (below the 9000 ephemeral floor on some GB200 nodes) and non-overlapping with NeMo
+    # RL (3000-4999) or vLLM (7000-8999). See ray.sub for the full port layout.
+    port_range_low: 5000
+    port_range_high: 5999
     # Optional substrings/tags used to flag malformed assistant turns for advantage
     # penalties (see grpo.invalid_tool_call_advantage / malformed_thinking_advantage).
     # Omit to use the built-in defaults (DEFAULT_INVALID_TOOL_CALL_PATTERNS / DEFAULT_THINKING_TAGS).
@@ -363,5 +363,5 @@ logger:
 cluster:
   gpus_per_node: 8
   num_nodes: 32
-  master_port_range_low: 25000
-  master_port_range_high: 28000
+  master_port_range_low: 1400
+  master_port_range_high: 1999

--- a/examples/nemo_gym/grpo_qwen3_30ba3b_thinking_swe1.yaml
+++ b/examples/nemo_gym/grpo_qwen3_30ba3b_thinking_swe1.yaml
@@ -90,8 +90,8 @@ policy:
       fp8_param: false
   make_sequence_length_divisible_by: 16
   generation:
-    port_range_low: 11001
-    port_range_high: 15000
+    port_range_low: 3000
+    port_range_high: 4999
     max_new_tokens: ${policy.max_total_sequence_length}
     vllm_cfg:
       enable_prefix_caching: true
@@ -219,8 +219,8 @@ env:
   should_log_nemo_gym_responses: false
   nemo_gym:
     skip_venv_if_present: true
-    port_range_low: 15001
-    port_range_high: 20000
+    port_range_low: 5000
+    port_range_high: 5999
     config_paths:
     - responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
     - resources_servers/single_step_tool_use_with_argument_comparison/configs/swe_pivot_single_step_tool_use_with_argument_comparison.yaml

--- a/examples/nemo_gym/grpo_qwen3_30ba3b_thinking_swe2.yaml
+++ b/examples/nemo_gym/grpo_qwen3_30ba3b_thinking_swe2.yaml
@@ -89,8 +89,8 @@ policy:
       fp8_param: false
   make_sequence_length_divisible_by: 32
   generation:
-    port_range_low: 11001
-    port_range_high: 15000
+    port_range_low: 3000
+    port_range_high: 4999
     max_new_tokens: ${policy.max_total_sequence_length}
     vllm_cfg:
       enable_prefix_caching: true
@@ -218,8 +218,8 @@ env:
   should_log_nemo_gym_responses: false
   nemo_gym:
     skip_venv_if_present: true
-    port_range_low: 15001
-    port_range_high: 20000
+    port_range_low: 5000
+    port_range_high: 5999
     config_paths:
     - responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
     - responses_api_agents/swe_agents/configs/swebench_openhands_training.yaml

--- a/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
+++ b/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
@@ -291,10 +291,10 @@ env:
   should_log_nemo_gym_responses: true
   nemo_gym:  # This is passed into NeMo-Gym as the initial_global_config_dict
     # Port range for Gym HTTP servers, kept below the OS ephemeral range
-    # (32768-60999) and non-overlapping with NeMo RL (11001-15000) or
-    # vLLM (20001+). See ray.sub for the full port layout.
-    port_range_low: 15001
-    port_range_high: 20000
+    # (below the 9000 ephemeral floor on some GB200 nodes) and non-overlapping with NeMo
+    # RL (3000-4999) or vLLM (7000-8999). See ray.sub for the full port layout.
+    port_range_low: 5000
+    port_range_high: 5999
     rollout_max_attempts_to_avoid_lp_nan: 1
     is_trajectory_collection: false  # Set this to true to enable trajectory collection (no training). You may also want to increase `policy.generation.vllm_cfg.gpu_memory_utilization`
     config_paths:

--- a/examples/nemo_gym/nemotron-3-super/stage1_rlvr.yaml
+++ b/examples/nemo_gym/nemotron-3-super/stage1_rlvr.yaml
@@ -214,8 +214,8 @@ policy:
   scheduler: null
 
   generation:
-    port_range_low: 11001
-    port_range_high: 15000
+    port_range_low: 3000
+    port_range_high: 4999
     backend: "vllm"
     max_new_tokens: ${policy.max_total_sequence_length}
     temperature: 1.0
@@ -284,8 +284,8 @@ env:
     uv_venv_dir: "${oc.env:PERSISTENT_CACHE}/gym_venvs"
     skip_venv_if_present: true
     num_gpu_nodes: 7
-    port_range_low: 15001
-    port_range_high: 20000
+    port_range_low: 5000
+    port_range_high: 5999
     invalid_tool_call_patterns:
       - "<tool_call>"
       - "</tool_call>"

--- a/examples/nemo_gym/nemotron-3-super/stage2_swe1.yaml
+++ b/examples/nemo_gym/nemotron-3-super/stage2_swe1.yaml
@@ -214,8 +214,8 @@ policy:
   scheduler: null
 
   generation:
-    port_range_low: 11001
-    port_range_high: 15000
+    port_range_low: 3000
+    port_range_high: 4999
     backend: "vllm"
     max_new_tokens: ${policy.max_total_sequence_length}
     temperature: 1.0
@@ -293,8 +293,8 @@ env:
     thinking_tags:
       - "<think>"
       - "</think>"
-    port_range_low: 15001
-    port_range_high: 20000
+    port_range_low: 5000
+    port_range_high: 5999
     config_paths:
     - responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
     - resources_servers/single_step_tool_use_with_argument_comparison/configs/swe_pivot_single_step_tool_use_with_argument_comparison.yaml

--- a/examples/nemo_gym/nemotron-3-super/stage2_swe2.yaml
+++ b/examples/nemo_gym/nemotron-3-super/stage2_swe2.yaml
@@ -207,8 +207,8 @@ policy:
   scheduler: null
 
   generation:
-    port_range_low: 11001
-    port_range_high: 15000
+    port_range_low: 3000
+    port_range_high: 4999
     backend: "vllm"
     max_new_tokens: ${policy.max_total_sequence_length}
     temperature: 1.0
@@ -289,8 +289,8 @@ env:
     thinking_tags:
       - "<think>"
       - "</think>"
-    port_range_low: 15001
-    port_range_high: 20000
+    port_range_low: 5000
+    port_range_high: 5999
     config_paths:
     - responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
     - responses_api_agents/swe_agents/configs/swebench_openhands_training.yaml

--- a/examples/nemo_gym/nemotron-3-super/stage3_rlhf.yaml
+++ b/examples/nemo_gym/nemotron-3-super/stage3_rlhf.yaml
@@ -214,8 +214,8 @@ policy:
   scheduler: null
 
   generation:
-    port_range_low: 11001
-    port_range_high: 15000
+    port_range_low: 3000
+    port_range_high: 4999
     backend: "vllm"
     max_new_tokens: ${policy.max_total_sequence_length}
     temperature: 1.0
@@ -285,8 +285,8 @@ env:
     uv_venv_dir: "${oc.env:PERSISTENT_CACHE}/gym_venvs"  # overridden by super_launch.sh to $GYM_VENV_DIR
     skip_venv_if_present: true
     num_gpu_nodes: 4
-    port_range_low: 15001
-    port_range_high: 20000
+    port_range_low: 5000
+    port_range_high: 5999
     invalid_tool_call_patterns:
       - "<tool_call>"
       - "</tool_call>"

--- a/examples/nemo_gym/prefetch_super_all_envs.yaml
+++ b/examples/nemo_gym/prefetch_super_all_envs.yaml
@@ -8,8 +8,8 @@ env:
   should_use_nemo_gym: true
   nemo_gym:
     skip_venv_if_present: true
-    port_range_low: 15001
-    port_range_high: 20000
+    port_range_low: 5000
+    port_range_high: 5999
 
     # Dummy interpolation values for the bundled configs (unused in the dry run).
     policy_model_name: dummy-model

--- a/nemo_rl/distributed/virtual_cluster.py
+++ b/nemo_rl/distributed/virtual_cluster.py
@@ -39,7 +39,7 @@ class ClusterConfig(TypedDict):
     # kept below the OS ephemeral range (32768-60999 on stock Linux) to avoid
     # TOCTOU collisions with kernel-assigned source ports.  When absent,
     # RayVirtualCluster falls back to DEFAULT_MASTER_PORT_RANGE_LOW/HIGH
-    # (25000-28000).  See ray.sub for the full port layout.
+    # (1400-1999).  See ray.sub for the full port layout.
     master_port_range_low: NotRequired[int]
     master_port_range_high: NotRequired[int]
     segment_size: NotRequired[
@@ -77,27 +77,27 @@ class PY_EXECUTABLES:
     SGLANG = f"uv run --locked --extra sglang --directory {git_root}"
 
 
-# Default port ranges — kept below the OS ephemeral range (32768-60999 on
-# stock Linux) to avoid TOCTOU collisions.  See ray.sub for the full layout
-# including Ray's own GCS / worker gRPC ports.
+# Default port ranges — kept below the OS ephemeral range.  On some DGX/GB200
+# nodes the ephemeral floor is as low as 9000 (32768 on stock Linux), so every
+# service port is pinned below 9000 to avoid TOCTOU collisions.  See ray.sub for
+# the full layout including Ray's own GCS / worker gRPC ports.
 #
-#   11001-15000  vLLM / SGLang HTTP servers  (policy.generation.port_range_low/high)
-#   15001-20000  NeMo Gym HTTP servers       (env.nemo_gym.port_range_low/high)
-#   20001+       vLLM TP/DP rendezvous       (VLLM_PORT env var, 100-port spacing)
-#   25000-28000  Master address / TCPStore    (cluster.master_port_range_low/high)
-DEFAULT_GENERATION_PORT_RANGE_LOW = 11001
-DEFAULT_GENERATION_PORT_RANGE_HIGH = 15000
-DEFAULT_GYM_PORT_RANGE_LOW = 15001
-DEFAULT_GYM_PORT_RANGE_HIGH = 20000
-# vLLM TP/DP rendezvous ports.  Each engine gets PORTS_PER_ENGINE ports
-# starting at LOW + engine_index * PORTS_PER_ENGINE.  The effective upper
-# bound is LOW + max_engines_per_node * PORTS_PER_ENGINE.  With 8 GPUs and
-# TP=1 (8 engines): 20001 + 8*100 = 20801.  There is no fixed ceiling —
-# ensure the range does not overlap with MASTER (25000+) on very large nodes.
-DEFAULT_VLLM_PORT_RANGE_LOW = 20001
+#   1400-1999    Master address / TCPStore       (cluster.master_port_range_low/high)
+#   3000-4999    NeMo RL generation HTTP servers (policy.generation.port_range_low/high)
+#   5000-5999    NeMo Gym HTTP servers           (env.nemo_gym.port_range_low/high)
+#   7000-8999    vLLM / SGLang engine rendezvous (VLLM_PORT env var / SGLang base_port)
+DEFAULT_GENERATION_PORT_RANGE_LOW = 3000
+DEFAULT_GENERATION_PORT_RANGE_HIGH = 4999
+DEFAULT_GYM_PORT_RANGE_LOW = 5000
+DEFAULT_GYM_PORT_RANGE_HIGH = 5999
+# vLLM TP/DP rendezvous ports.  Each engine gets PORTS_PER_ENGINE ports starting
+# at LOW + engine_index * PORTS_PER_ENGINE.  With 8 GPUs and TP=1 (8 engines):
+# 7000 + 8*100 = 7800, still below the 9000 ephemeral floor.
+DEFAULT_VLLM_PORT_RANGE_LOW = 7000
 DEFAULT_VLLM_PORTS_PER_ENGINE = 100
-DEFAULT_MASTER_PORT_RANGE_LOW = 25000
-DEFAULT_MASTER_PORT_RANGE_HIGH = 28000
+# Master address / TCPStore range, tucked below the Ray worker-gRPC band (2000+).
+DEFAULT_MASTER_PORT_RANGE_LOW = 1400
+DEFAULT_MASTER_PORT_RANGE_HIGH = 1999
 
 # ---------------------------------------------------------------------------
 # Topology resource keys

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -67,7 +67,7 @@ class NemoGymConfig(TypedDict):
     base_urls: List[str]
     initial_global_config_dict: Dict[str, Any]
     # Port range for Gym HTTP servers (head server + subprocess servers).
-    # Defaults to DEFAULT_GYM_PORT_RANGE_LOW/HIGH (15001-20000) from
+    # Defaults to DEFAULT_GYM_PORT_RANGE_LOW/HIGH (5000-5999) from
     # nemo_rl.distributed.virtual_cluster.  See the port layout there.
     port_range_low: NotRequired[int]
     port_range_high: NotRequired[int]

--- a/nemo_rl/models/generation/sglang/sglang_generation.py
+++ b/nemo_rl/models/generation/sglang/sglang_generation.py
@@ -249,7 +249,9 @@ class SGLangGeneration(GenerationInterface):
         if len(local_all_engines) == 0:
             return [], port_cursors
 
-        base_port = max(port_cursors.values()) if port_cursors else 15000
+        # SGLang engine ports live in the below-ephemeral-floor engine band
+        # (7000-8999), shared with vLLM; see virtual_cluster.py port layout.
+        base_port = max(port_cursors.values()) if port_cursors else 7000
         addr_and_ports, port_cursors = _allocate_rollout_engine_addr_and_ports_normal(
             gpus_per_node=self.num_gpus_per_node,
             sglang_cfg=self.sglang_cfg,

--- a/nemo_rl/models/generation/sglang/sglang_worker.py
+++ b/nemo_rl/models/generation/sglang/sglang_worker.py
@@ -162,7 +162,7 @@ class SGLangGenerationWorker:
         return response.json()
 
     @staticmethod
-    def _get_current_node_ip_and_free_port(start_port=10000, consecutive=1):
+    def _get_current_node_ip_and_free_port(start_port=7000, consecutive=1):
         return get_current_node_ip(), get_free_port(
             start_port=start_port, consecutive=consecutive
         )

--- a/nemo_rl/models/generation/sglang/utils/ip_port_utils.py
+++ b/nemo_rl/models/generation/sglang/utils/ip_port_utils.py
@@ -48,7 +48,7 @@ def _allocate_rollout_engine_addr_and_ports_normal(
     sglang_cfg,
     local_all_engines,
     rank_offset=0,
-    base_port=15000,
+    base_port=7000,
 ):
     # get ports
     # there are 4 ports we need to allocate
@@ -85,8 +85,10 @@ def _allocate_rollout_engine_addr_and_ports_normal(
         )
 
         def get_addr_and_ports(engine, node_idx):
-            # use small ports to prevent ephemeral port between 32768 and 65536.
-            # also, ray uses port 10002-19999, thus we avoid near-10002 to avoid racing condition
+            # Keep engine ports below the OS ephemeral floor (9000 on some GB200 nodes,
+            # 32768 on stock Linux) to avoid TOCTOU collisions. SGLang shares
+            # the vLLM engine rendezvous band (7000-8999); see the port layout
+            # in ray.sub / nemo_rl/distributed/virtual_cluster.py.
             start_port = node_port_cursor.get(node_idx, base_port)
 
             def port(consecutive=1):

--- a/nemo_rl/models/generation/sglang/utils/ray_utils.py
+++ b/nemo_rl/models/generation/sglang/utils/ray_utils.py
@@ -129,7 +129,7 @@ def get_current_node_ip():
     return address
 
 
-def get_free_port(start_port=10000, consecutive=1):
+def get_free_port(start_port=7000, consecutive=1):
     # find the port where port, port + 1, port + 2, ... port + consecutive - 1 are all available
     port = start_port
     while not all(is_port_available(port + i) for i in range(consecutive)):

--- a/ray.sub
+++ b/ray.sub
@@ -92,19 +92,18 @@ COMMAND=${COMMAND:-}  # This is a script relative to the SLURM_SUBMIT_DIR. If le
 SETUP_COMMAND=${SETUP_COMMAND:-}  # Setup commands to run on all nodes before starting Ray.
 ########################################################
 # Ports for all nodes (should be odd numbers since we place head/worker[0] on the same node) so all workers get the odd ports, but the head will get +1 the ports
-NODE_MANAGER_PORT=${NODE_MANAGER_PORT:-53001}
-OBJECT_MANAGER_PORT=${OBJECT_MANAGER_PORT:-53003}
-RUNTIME_ENV_AGENT_PORT=${RUNTIME_ENV_AGENT_PORT:-53005}
-DASHBOARD_AGENT_GRPC_PORT=${DASHBOARD_AGENT_GRPC_PORT:-53007}
-METRICS_EXPORT_PORT=${METRICS_EXPORT_PORT:-53009}
+NODE_MANAGER_PORT=${NODE_MANAGER_PORT:-1301}
+OBJECT_MANAGER_PORT=${OBJECT_MANAGER_PORT:-1303}
+RUNTIME_ENV_AGENT_PORT=${RUNTIME_ENV_AGENT_PORT:-1305}
+DASHBOARD_AGENT_GRPC_PORT=${DASHBOARD_AGENT_GRPC_PORT:-1307}
+METRICS_EXPORT_PORT=${METRICS_EXPORT_PORT:-1309}
 
-# Ports for the head node
-# GCS head port and client server port -- kept below ephemeral range (32768-60999).
-PORT=${PORT:-9900}
-RAY_CLIENT_SERVER_PORT=${RAY_CLIENT_SERVER_PORT:-9901}
+# Ports for the head node -- all below ephemeral floor (9000 on some GB200 nodes).
+PORT=${PORT:-1200}
+RAY_CLIENT_SERVER_PORT=${RAY_CLIENT_SERVER_PORT:-1201}
 #REDIT_SHARD_PORTS=${REDIT_SHARD_PORTS:-"random"} ??
 DASHBOARD_PORT=${DASHBOARD_PORT:-8265}  # Also used by debugger
-DASHBOARD_AGENT_LISTEN_PORT=${DASHBOARD_AGENT_LISTEN_PORT:-52365}
+DASHBOARD_AGENT_LISTEN_PORT=${DASHBOARD_AGENT_LISTEN_PORT:-1311}
 RAY_DEBUGGER_ARGS=
 if [ "${RAY_DEBUG:-}" = "legacy" ]; then
   RAY_DEBUGGER_ARGS="--ray-debugger-external"
@@ -125,22 +124,30 @@ elif [[ $(ulimit -Hn) != "unlimited" ]] && [[ $(ulimit -Hn) -lt 65535 ]]; then
   echo "[WARNING]: Cannot increase ulimit on file descriptors to 65535 according ray recommendation: https://docs.ray.io/en/latest/cluster/vms/user-guides/large-cluster-best-practices.html. Speak to cluster admins to increase, otherwise ray may crash unexpectedly."
 fi
 
-# Worker port range must NOT overlap with the OS ephemeral range (32768-60999)
-# to prevent TOCTOU collisions.  Ray's Raylet uses a probe-and-release pattern
+# Worker port range must NOT overlap with the OS ephemeral range to prevent
+# TOCTOU collisions.  Ray's Raylet uses a probe-and-release pattern
 # (CheckPortFree) that can leave a window where the port is unguarded.
 # If the range overlaps with the ephemeral range, the kernel can assign the same
 # port as an ephemeral source port for outgoing TCP traffic during that window,
 # causing EADDRINUSE when the worker tries to bind.
 #
-# Port layout (all below ephemeral range):
-#   9900-9901    Ray GCS / client server (PORT, RAY_CLIENT_SERVER_PORT above)
-#   10002-11000  Ray worker gRPC (this setting)
-#   11001-15000  vLLM HTTP servers (policy.generation.port_range_low/high)
-#   15001-20000  NeMo Gym HTTP servers (env.nemo_gym.port_range_low/high)
-#   20001+       vLLM TP/DP rendezvous (VLLM_PORT env var, 100-port spacing per engine)
-#   25000-28000  Master address / TCPStore (cluster.master_port_range_low/high)
-MIN_WORKER_PORT=${MIN_WORKER_PORT:-10002}
-MAX_WORKER_PORT=${MAX_WORKER_PORT:-11000}
+# The ephemeral range is 9000-65000 on some DGX/GB200 nodes (32768-60999 on
+# stock Linux).  All service ports are pinned below 9000 to stay clear of even
+# the lowest observed ephemeral floor.
+#
+# Port layout (all below ephemeral floor at 9000):
+#   1200-1201    Ray GCS + client server (head only)
+#   1301-1312    Ray management (node-mgr, obj-mgr, etc.; odd=worker, even=head)
+#   1400-1999    Master address / TCPStore (cluster.master_port_range_low/high)
+#   2000-2999    Ray worker gRPC (min/max-worker-port)
+#   3000-4999    NeMo RL generation HTTP servers (policy.generation.port_range_low/high)
+#   5000-5999    NeMo Gym HTTP servers (Gym global config port_range_low/high)
+#   6000         Sandbox Nginx (NEMO_SKILLS_SANDBOX_PORT)
+#   6001-6999    Sandbox uWSGI workers (SANDBOX_BASE_PORT)
+#   7000-8999    vLLM / SGLang engine rendezvous (VLLM_PORT in vllm_worker.py / SGLang base_port)
+#   8265         Ray Dashboard (DASHBOARD_PORT; reserved carve-out inside the 7000-8999 band)
+MIN_WORKER_PORT=${MIN_WORKER_PORT:-2000}
+MAX_WORKER_PORT=${MAX_WORKER_PORT:-2999}
 ########################################################
 # Number seconds to sync logs from /tmp/ray/session_*/logs to $LOG_DIR/ray/
 RAY_LOG_SYNC_FREQUENCY=${RAY_LOG_SYNC_FREQUENCY:-}
@@ -604,6 +611,8 @@ ray start --head \
     --dashboard-port=${DASHBOARD_PORT} \
     --dashboard-host="$head_node_ip" \
     --include-dashboard=True \
+    --min-worker-port=${MIN_WORKER_PORT} \
+    --max-worker-port=${MAX_WORKER_PORT} \
     \
     --node-manager-port=$((${NODE_MANAGER_PORT} + 1)) \
     --object-manager-port=$((${OBJECT_MANAGER_PORT} + 1)) \
@@ -832,18 +841,19 @@ bash -n <(printf '%s' "$worker_cmd") || { echo "[FATAL] Worker script has syntax
 export SLURM_MASTER_NODE=$(scontrol show hostnames $SLURM_JOB_NODELIST | head -n1)
 SANDBOX_PORT="${NEMO_SKILLS_SANDBOX_PORT:-6000}"
 
+SANDBOX_BASE_PORT="${SANDBOX_BASE_PORT:-6001}"
 if [[ -n "${SANDBOX_CONTAINER:-}" ]] && [[ -n "${SANDBOX_COMMAND:-}" ]]; then
   SANDBOX_MOUNTS="$SANDBOX_PORTS_DIR:$SANDBOX_PORTS_DIR"
   if [[ -n "${SANDBOX_EXTRA_MOUNTS:-}" ]]; then
     SANDBOX_MOUNTS="${SANDBOX_EXTRA_MOUNTS},${SANDBOX_MOUNTS}"
   fi
 
-  SANDBOX_EXPORTS="ALL,SANDBOX_PORTS_DIR=$SANDBOX_PORTS_DIR"
+  SANDBOX_EXPORTS="ALL,SANDBOX_PORTS_DIR=$SANDBOX_PORTS_DIR,SANDBOX_WORKER_BASE_PORT=$SANDBOX_BASE_PORT,NGINX_PORT=$SANDBOX_PORT"
   if [[ -n "${SANDBOX_ENV_VARS:-}" ]]; then
     SANDBOX_EXPORTS="${SANDBOX_EXPORTS},${SANDBOX_ENV_VARS}"
   fi
 
-  echo "[INFO] Starting sandbox sidecars on all allocated nodes (ports_dir=$SANDBOX_PORTS_DIR, port=$SANDBOX_PORT)..."
+  echo "[INFO] Starting sandbox sidecars on all allocated nodes (ports_dir=$SANDBOX_PORTS_DIR, port=$SANDBOX_PORT, base_port=$SANDBOX_BASE_PORT)..."
   srun --output "$SANDBOX_PORTS_DIR/sandbox-%t.log" \
     --error "$SANDBOX_PORTS_DIR/sandbox-%t.log" \
     --container-image="$SANDBOX_CONTAINER" \

--- a/tests/unit/distributed/test_virtual_cluster.py
+++ b/tests/unit/distributed/test_virtual_cluster.py
@@ -21,8 +21,14 @@ import pytest
 import ray
 
 from nemo_rl.distributed.virtual_cluster import (
+    DEFAULT_GENERATION_PORT_RANGE_HIGH,
+    DEFAULT_GENERATION_PORT_RANGE_LOW,
+    DEFAULT_GYM_PORT_RANGE_HIGH,
+    DEFAULT_GYM_PORT_RANGE_LOW,
     DEFAULT_MASTER_PORT_RANGE_HIGH,
     DEFAULT_MASTER_PORT_RANGE_LOW,
+    DEFAULT_VLLM_PORT_RANGE_LOW,
+    DEFAULT_VLLM_PORTS_PER_ENGINE,
     PY_EXECUTABLES,
     RayVirtualCluster,
     ResourceInsufficientError,
@@ -341,20 +347,20 @@ class TestVllmPortAssignment:
         "bundle_indices,expected_port",
         [
             # TP=1: single-bundle engines, engine_index = bundle index
-            ((0, [0]), 20001),
-            ((0, [1]), 20101),
-            ((0, [7]), 20701),
-            ((1, [0]), 20001),
-            ((1, [3]), 20301),
+            ((0, [0]), 7000),
+            ((0, [1]), 7100),
+            ((0, [7]), 7700),
+            ((1, [0]), 7000),
+            ((1, [3]), 7300),
             # TP=4: multi-bundle engine, engine_index = first_bundle // tp_size
-            ((0, [0, 1, 2, 3]), 20001),  # 0 // 4 = 0
-            ((0, [4, 5, 6, 7]), 20101),  # 4 // 4 = 1
+            ((0, [0, 1, 2, 3]), 7000),  # 0 // 4 = 0
+            ((0, [4, 5, 6, 7]), 7100),  # 4 // 4 = 1
             # TP=2: multi-bundle engine
-            ((0, [0, 1]), 20001),  # 0 // 2 = 0
-            ((0, [2, 3]), 20101),  # 2 // 2 = 1
-            ((0, [6, 7]), 20301),  # 6 // 2 = 3
+            ((0, [0, 1]), 7000),  # 0 // 2 = 0
+            ((0, [2, 3]), 7100),  # 2 // 2 = 1
+            ((0, [6, 7]), 7300),  # 6 // 2 = 3
             # TP=8: entire node is one engine
-            ((0, [0, 1, 2, 3, 4, 5, 6, 7]), 20001),  # 0 // 8 = 0
+            ((0, [0, 1, 2, 3, 4, 5, 6, 7]), 7000),  # 0 // 8 = 0
         ],
     )
     def test_vllm_port_assignment(self, bundle_indices, expected_port):
@@ -374,3 +380,22 @@ class TestVllmPortAssignment:
 
         _, env_vars, _, _ = BaseVllmGenerationWorker.configure_worker(num_gpus=1)
         assert "VLLM_PORT" not in env_vars
+
+
+def test_default_port_ranges_ordered_and_below_ephemeral_floor():
+    # Lowest observed ephemeral floor on some GB200 nodes; stock Linux is 32768.
+    EPHEMERAL_FLOOR = 9000
+    assert DEFAULT_MASTER_PORT_RANGE_LOW < DEFAULT_MASTER_PORT_RANGE_HIGH
+    assert DEFAULT_GENERATION_PORT_RANGE_LOW < DEFAULT_GENERATION_PORT_RANGE_HIGH
+    assert DEFAULT_GYM_PORT_RANGE_LOW < DEFAULT_GYM_PORT_RANGE_HIGH
+    # Ordered, non-overlapping bands: master < generation < gym < vllm.
+    assert DEFAULT_MASTER_PORT_RANGE_HIGH < DEFAULT_GENERATION_PORT_RANGE_LOW
+    assert DEFAULT_GENERATION_PORT_RANGE_HIGH < DEFAULT_GYM_PORT_RANGE_LOW
+    assert DEFAULT_GYM_PORT_RANGE_HIGH < DEFAULT_VLLM_PORT_RANGE_LOW
+    # Top vLLM engine (8 GPUs, TP=1) stays below the ephemeral floor.
+    assert (
+        DEFAULT_VLLM_PORT_RANGE_LOW + 8 * DEFAULT_VLLM_PORTS_PER_ENGINE
+        < EPHEMERAL_FLOOR
+    )
+    # Avoid privileged ports (<1024).
+    assert DEFAULT_MASTER_PORT_RANGE_LOW > 1024

--- a/tests/unit/reference_configs/distillation_math.yaml
+++ b/tests/unit/reference_configs/distillation_math.yaml
@@ -180,8 +180,8 @@ policy: &POLICY_BASE
         - milestones: [10]
 
     generation:
-        port_range_low: 11001
-        port_range_high: 15000
+        port_range_low: 3000
+        port_range_high: 4999
         backend: "vllm"
         max_new_tokens: ${..max_total_sequence_length} # refer to local policy/teacher config
         temperature: 1.0
@@ -270,6 +270,6 @@ logger:
 cluster:
     gpus_per_node: 8
     num_nodes: 1
-    master_port_range_low: 25000
-    master_port_range_high: 28000
+    master_port_range_low: 1400
+    master_port_range_high: 1999
     segment_size: null

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -320,8 +320,8 @@ policy:
     - milestones: [50]
 
   generation:
-    port_range_low: 11001
-    port_range_high: 15000
+    port_range_low: 3000
+    port_range_high: 4999
     backend: "vllm"
     max_new_tokens: ${policy.max_total_sequence_length}
     temperature: 1.0
@@ -451,8 +451,8 @@ logger:
 cluster:
   gpus_per_node: 1
   num_nodes: 1
-  master_port_range_low: 25000
-  master_port_range_high: 28000
+  master_port_range_low: 1400
+  master_port_range_high: 1999
   segment_size: null
 
 # TransferQueue-mediated data plane for sync GRPO.


### PR DESCRIPTION
# What does this PR do ?

Eliminates port contention between all NeMo RL services (Ray, vLLM, SGLang, Gym, Sandbox) and the kernel's ephemeral port range by pinning every service port below the observed ephemeral floor.

### Fix
Pin all service ports below 9000. Final layout (documented in `ray.sub` and `nemo_rl/distributed/virtual_cluster.py`):

- **Ray worker gRPC** moved to 2000-2999 (`MIN_WORKER_PORT`/`MAX_WORKER_PORT` in `ray.sub`), and `--min-worker-port`/`--max-worker-port` added to `ray start --head` so the head node is constrained to the same range as workers.
- **Ray GCS + management ports** moved below the floor: GCS/client 1200-1201, node/object/runtime-env/dashboard-agent/metrics ports to 1301-1312, dashboard-agent-listen to 1311.
- **Master address / TCPStore** moved to 1400-1999 (`DEFAULT_MASTER_PORT_RANGE_*` in `virtual_cluster.py`).
- **NeMo RL generation HTTP** moved to 3000-4999 (`port_range_low/high` in the example configs and `DEFAULT_GENERATION_PORT_RANGE_*` in `virtual_cluster.py`).
- **NeMo Gym HTTP** moved to 5000-5999 (example configs and `DEFAULT_GYM_PORT_RANGE_*`, referenced from `nemo_gym.py`).
- **Sandbox** Nginx stays at 6000; uWSGI workers moved to 6001+ by exporting `SANDBOX_WORKER_BASE_PORT=6001` and `NGINX_PORT=6000` into the sandbox srun (the container's `start-with-nginx.sh` already supports these env vars — no image change needed).
- **vLLM engine TP/DP rendezvous** moved from 20001 to 7000 (`DEFAULT_VLLM_PORT_RANGE_LOW` in `virtual_cluster.py`, consumed by `vllm_worker.py`).
- **SGLang engine ports** (server / nccl / dist_init) moved from 15000 to the same 7000-8999 band (vLLM and SGLang are mutually exclusive backends); free-port helper defaults lowered from 10000. The SGLang router HTTP port already allocated from 3000-4000 and is unchanged.
- Propagated the new bands to all example configs that hardcoded the old ranges, kept the frozen `tests/unit/reference_configs/*` copies in sync, and refreshed stale port-range comments.

# Issues

None

# Usage

None