### PR TITLE
fix: [NemoRL] Disable expensive Gym logging to reduce inter-step inefficiency

### DIFF
--- a/examples/nemo_gym/grpo_nanov3.yaml
+++ b/examples/nemo_gym/grpo_nanov3.yaml
@@ -300,6 +300,8 @@ data:
 
 env:
   should_use_nemo_gym: true
+  # true: skip expensive train_data_step*.jsonl; false: write full jsonl.
+  should_log_nemo_gym_responses: true
   nemo_gym:
     # Port range for Gym HTTP servers, kept below the OS ephemeral range
     # (32768-60999) and non-overlapping with NeMo RL (11001-15000) or

--- a/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
+++ b/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
@@ -287,7 +287,8 @@ data:
 
 env:
   should_use_nemo_gym: true
-  should_log_nemo_gym_responses: true  # If you have low logging storage, set this to false
+  # true: skip expensive train_data_step*.jsonl; false: write jsonl (heavy). Prefer true if disk is tight.
+  should_log_nemo_gym_responses: true
   nemo_gym:  # This is passed into NeMo-Gym as the initial_global_config_dict
     # Port range for Gym HTTP servers, kept below the OS ephemeral range
     # (32768-60999) and non-overlapping with NeMo RL (11001-15000) or

--- a/examples/nemo_gym/nemotron-3-super/stage1_rlvr.yaml
+++ b/examples/nemo_gym/nemotron-3-super/stage1_rlvr.yaml
@@ -278,6 +278,8 @@ data:
 
 env:
   should_use_nemo_gym: true
+  # true: skip expensive train_data_step*.jsonl (recommended for large Gym runs); false: write full jsonl.
+  should_log_nemo_gym_responses: true
   nemo_gym:
     uv_venv_dir: "${oc.env:PERSISTENT_CACHE}/gym_venvs"
     skip_venv_if_present: true

--- a/examples/nemo_gym/nemotron-3-super/stage3_rlhf.yaml
+++ b/examples/nemo_gym/nemotron-3-super/stage3_rlhf.yaml
@@ -279,6 +279,8 @@ data:
 
 env:
   should_use_nemo_gym: true
+  # true: skip expensive train_data_step*.jsonl (recommended for large Gym runs); false: enable full jsonl.
+  should_log_nemo_gym_responses: true
   nemo_gym:
     uv_venv_dir: "${oc.env:PERSISTENT_CACHE}/gym_venvs"  # overridden by super_launch.sh to $GYM_VENV_DIR
     skip_venv_if_present: true

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1841,6 +1841,16 @@ def _should_use_nemo_gym(master_config: MasterConfig) -> bool:
 
 
 def _should_log_nemo_gym_responses(master_config: MasterConfig) -> bool:
+    """Whether NeMo Gym is responsible for full response logging (wandb/metrics paths).
+
+    When **True**, we **skip** the expensive per-step ``train_data_step*.jsonl`` dump and
+    **keep** ``full_result``-style keys in rollout metrics (large payloads).
+
+    When **False** (default if unset), we **strip** ``full_result`` from rollout metrics and
+    **write** the ``train_data_step*.jsonl`` file (can be very large for Gym).
+
+    Set via ``env.should_log_nemo_gym_responses`` in the master config.
+    """
     env_config = master_config.env
     should_log_nemo_gym_responses = bool(
         env_config.get("should_log_nemo_gym_responses")
@@ -4320,26 +4330,33 @@ def async_grpo_train(
                         checkpointer.finalize_checkpoint(checkpoint_path)
 
             # Logging
-            # Log training data (match sync GRPO logging payload for parity)
-            log_data = {}
-            if "agent_ref" in repeated_batch:
-                log_data["agent_ref"] = repeated_batch["agent_ref"]
-            log_data["content"] = flat_messages_content
-            log_data["rewards"] = rewards.tolist()
-            if master_config.grpo["use_dynamic_sampling"]:
-                # In dynamic sampling, `rewards` corresponds to filtered rewards
-                log_data["filtered_rewards"] = rewards.tolist()
-                log_data["rewards"] = repeated_batch["total_reward"].tolist()
-            log_data["input_lengths"] = input_lengths.tolist()
-            log_data["token_ids"] = train_data["input_ids"].tolist()
-            log_data["token_loss_mask"] = train_data["token_mask"].tolist()
-            log_data["sample_loss_mask"] = train_data["sample_mask"].tolist()
-            log_data["advantages"] = train_data["advantages"].tolist()
-            log_data["generation_logprobs"] = train_data["generation_logprobs"].tolist()
-            log_data["prev_logprobs"] = train_data["prev_logprobs"].tolist()
-            logger.log_batched_dict_as_jsonl(
-                log_data, f"train_data_step{step + 1}.jsonl"
-            )
+            # Log training data (match sync GRPO logging payload for parity).
+            # NeMo Gym responses can be very large and expensive to log; when
+            # env.should_log_nemo_gym_responses is true, skip this jsonl (see
+            # _should_log_nemo_gym_responses).
+            if not _should_log_nemo_gym_responses(master_config):
+                log_data = {}
+                if "agent_ref" in repeated_batch:
+                    log_data["agent_ref"] = repeated_batch["agent_ref"]
+                log_data["content"] = flat_messages_content
+                log_data["rewards"] = rewards.tolist()
+                if master_config.grpo["use_dynamic_sampling"]:
+                    # In dynamic sampling, `rewards` corresponds to filtered rewards
+                    log_data["filtered_rewards"] = rewards.tolist()
+                    log_data["rewards"] = repeated_batch["total_reward"].tolist()
+                log_data["input_lengths"] = input_lengths.tolist()
+                log_data["token_ids"] = train_data["input_ids"].tolist()
+                log_data["token_loss_mask"] = train_data["token_mask"].tolist()
+                log_data["sample_loss_mask"] = train_data["sample_mask"].tolist()
+                log_data["advantages"] = train_data["advantages"].tolist()
+                log_data["generation_logprobs"] = train_data[
+                    "generation_logprobs"
+                ].tolist()
+                log_data["prev_logprobs"] = train_data["prev_logprobs"].tolist()
+                logger.log_batched_dict_as_jsonl(
+                    log_data, f"train_data_step{step + 1}.jsonl"
+                )
+                del log_data
             del train_data
             del flat_messages_content
 


### PR DESCRIPTION
# What does this PR do ?

In our NeMo RL efficiency traces, we’re seeing non-trivial blocking time between two consecutive steps. At ~1K scale, this is consistently around 5-6 minutes time range and we are paying this cost at every step. I found that most of this time is due to heavy logging happening at the end of the step.

A whole bunch of training tensors are being serialized to JSON and logged. This block is expensive mainly because we're doing eager, full-batch .tolist() materialization of the tensors on the hot path, which drives GPU sync + huge Python allocations + JSON + disk/W&B. The memory snapshots and other performance logging add more on top.

Paying the time for logging which is ~25-30% of the average step length seems excessive.

# Issues

None

# Usage

None

# Before your PR is "Ready for review"

**Pre checks**:

* [x] Make sure you read and followed Contributor guidelines
* [x] Did you write any new necessary tests?
* [x] Did you run the unit tests and functional tests locally? Visit our Testing Guide for how to run tests
* [ ] Did you add or update any necessary documentation? Visit our Document Development Guide for how to write, build and test the docs.