### PR TITLE
fix: reject activation_checkpointing with DeepEP MoE dispatcher

### DIFF
--- a/nemo_rl/models/automodel/setup.py
+++ b/nemo_rl/models/automodel/setup.py
@@ -81,6 +81,90 @@ STRING_TO_DTYPE = {
 }
 
 
+def _resolve_effective_dispatcher(automodel_kwargs: dict) -> Optional[str]:
+    """Return the effective MoE token dispatcher implied by ``automodel_kwargs``.
+
+    Mirrors the resolution logic in ``nemo_automodel``'s ``BackendConfig``:
+    an explicit ``dispatcher`` wins; the deprecated ``enable_deepep`` flag maps
+    to ``"deepep"``/``"torch"``; otherwise the default is ``"deepep"`` when
+    the ``deep_ep`` package is importable, else ``"torch"``.
+
+    Returns ``None`` if a backend was supplied but its type cannot be
+    interpreted (e.g. a fully-constructed object without dispatcher attrs).
+    """
+    backend = (automodel_kwargs or {}).get("backend")
+
+    if backend is None:
+        backend_fields: dict = {}
+    elif isinstance(backend, dict):
+        backend_fields = backend
+    else:
+        # Object form (already-constructed BackendConfig). Read attrs directly.
+        dispatcher_attr = getattr(backend, "dispatcher", None)
+        enable_deepep_attr = getattr(backend, "enable_deepep", None)
+        if dispatcher_attr is not None:
+            return str(dispatcher_attr)
+        if enable_deepep_attr is True:
+            return "deepep"
+        if enable_deepep_attr is False:
+            return "torch"
+        backend_fields = {}
+
+    dispatcher = backend_fields.get("dispatcher")
+    if dispatcher is not None:
+        return str(dispatcher)
+
+    enable_deepep = backend_fields.get("enable_deepep")
+    if enable_deepep is True:
+        return "deepep"
+    if enable_deepep is False:
+        return "torch"
+
+    # Neither key set: mirror BackendConfig's default (deepep when importable).
+    try:
+        import deep_ep  # noqa: F401
+    except ImportError:
+        return "torch"
+    return "deepep"
+
+
+def _raise_if_deepep_with_activation_checkpointing(
+    config: PolicyConfig, rank: int = 0
+) -> None:
+    """Reject the unsupported ``activation_checkpointing`` + DeepEP dispatcher combo.
+
+    Wrapping the whole MoE block in a single reentrant checkpoint region
+    (see ``nemo_automodel/components/distributed/parallelizer.py``) means the
+    router + DeepEP dispatch re-run during backward. DeepEP's dispatch is
+    not guaranteed to produce the same per-expert token count on recompute,
+    which yields a shape mismatch inside TE's ``moe_unpermute_mask_map``
+    backward and crashes with a ``torch.utils.checkpoint.CheckpointError``.
+    Fail here with a clear message instead of blowing up in autograd.
+    """
+    dtensor_cfg = config.get("dtensor_cfg", {})
+    if not dtensor_cfg.get("activation_checkpointing"):
+        return
+    if dtensor_cfg.get("expert_parallel_size", 1) <= 1:
+        return
+
+    automodel_kwargs = dtensor_cfg.get("automodel_kwargs", {}) or {}
+    dispatcher = _resolve_effective_dispatcher(automodel_kwargs)
+    if dispatcher != "deepep":
+        return
+
+    raise ValueError(
+        "activation_checkpointing=True is not supported with the DeepEP MoE "
+        "token dispatcher: DeepEP's dispatch is nondeterministic across the "
+        "activation-checkpoint recompute, which causes a shape mismatch in "
+        "TransformerEngine's moe_unpermute backward (CheckpointError). "
+        "Workaround: set "
+        "policy.dtensor_cfg.automodel_kwargs.backend.dispatcher=torch "
+        "(or backend.enable_deepep=false), or disable activation "
+        "checkpointing. See "
+        "https://github.com/NVIDIA-NeMo/Automodel for the upstream fix."
+    )
+
+
 def _maybe_set_force_hf(automodel_kwargs: dict, model_config) -> None:
     """Validate and maybe auto-set force_hf based on adapter compatibility.
 
@@ -392,6 +476,8 @@ def validate_and_prepare_config(
             "[WARNING]: sequence_parallel=True, but tp_size=1 which has no effect. "
             "Enable tp_size > 1 to use sequence parallelism."
         )
+
+    _raise_if_deepep_with_activation_checkpointing(config, rank)
 
     return RuntimeConfig(
         model_class=model_class,

--- a/tests/unit/models/automodel/test_automodel_setup.py
+++ b/tests/unit/models/automodel/test_automodel_setup.py
@@ -32,6 +32,8 @@ from nemo_rl.models.automodel.setup import (
     ModelAndOptimizerState,
     RuntimeConfig,
     _maybe_set_force_hf,
+    _raise_if_deepep_with_activation_checkpointing,
+    _resolve_effective_dispatcher,
     get_tokenizer,
     setup_distributed,
     setup_model_and_optimizer,
@@ -2210,3 +2212,98 @@ def test_automodel_dtype_restore_workaround_still_needed(monkeypatch):
         "_disable_automodel_checkpoint_dtype_restore() workaround in setup.py is obsolete - "
         "remove it and this test."
     )
+
+
+class TestResolveEffectiveDispatcher:
+    """Tests for _resolve_effective_dispatcher backend resolution."""
+
+    def test_explicit_dispatcher_wins(self):
+        assert (
+            _resolve_effective_dispatcher(
+                {"backend": {"dispatcher": "torch", "enable_deepep": True}}
+            )
+            == "torch"
+        )
+
+    def test_enable_deepep_true_maps_to_deepep(self):
+        assert (
+            _resolve_effective_dispatcher({"backend": {"enable_deepep": True}})
+            == "deepep"
+        )
+
+    def test_enable_deepep_false_maps_to_torch(self):
+        assert (
+            _resolve_effective_dispatcher({"backend": {"enable_deepep": False}})
+            == "torch"
+        )
+
+    def test_object_form_dispatcher_attr(self):
+        backend = Mock(spec=["dispatcher", "enable_deepep"])
+        backend.dispatcher = "deepep"
+        backend.enable_deepep = None
+        assert _resolve_effective_dispatcher({"backend": backend}) == "deepep"
+
+    def test_defaulted_uses_deepep_when_importable(self):
+        # Backend with _target_ but no dispatcher / enable_deepep -> defaulted.
+        with patch.dict("sys.modules", {"deep_ep": Mock()}):
+            assert _resolve_effective_dispatcher({"backend": {}}) == "deepep"
+
+    def test_defaulted_falls_back_to_torch_without_deepep(self):
+        with patch.dict("sys.modules", {"deep_ep": None}):
+            assert _resolve_effective_dispatcher({"backend": {}}) == "torch"
+
+    def test_no_backend_defaults_via_deepep_import(self):
+        with patch.dict("sys.modules", {"deep_ep": Mock()}):
+            assert _resolve_effective_dispatcher({}) == "deepep"
+
+
+class TestRaiseIfDeepEPWithActivationCheckpointing:
+    """Guard for the unsupported AC + DeepEP dispatcher combo."""
+
+    def _cfg(self, *, ac: bool, ep: int, backend=None) -> dict:
+        dtensor: dict = {
+            "activation_checkpointing": ac,
+            "expert_parallel_size": ep,
+        }
+        if backend is not None:
+            dtensor["automodel_kwargs"] = {"backend": backend}
+        return {"dtensor_cfg": dtensor}
+
+    def test_raises_on_ac_plus_dispatcher_deepep(self):
+        cfg = self._cfg(ac=True, ep=8, backend={"dispatcher": "deepep"})
+        with pytest.raises(ValueError, match="DeepEP"):
+            _raise_if_deepep_with_activation_checkpointing(cfg)
+
+    def test_raises_on_ac_plus_enable_deepep_true(self):
+        cfg = self._cfg(ac=True, ep=8, backend={"enable_deepep": True})
+        with pytest.raises(ValueError, match="DeepEP"):
+            _raise_if_deepep_with_activation_checkpointing(cfg)
+
+    def test_raises_on_ac_plus_defaulted_when_deepep_importable(self):
+        # Recipe omits dispatcher / enable_deepep; BackendConfig defaults to deepep.
+        cfg = self._cfg(ac=True, ep=8, backend={})
+        with patch.dict("sys.modules", {"deep_ep": Mock()}):
+            with pytest.raises(ValueError, match="DeepEP"):
+                _raise_if_deepep_with_activation_checkpointing(cfg)
+
+    def test_passes_when_dispatcher_is_torch(self):
+        cfg = self._cfg(ac=True, ep=8, backend={"dispatcher": "torch"})
+        _raise_if_deepep_with_activation_checkpointing(cfg)  # no raise
+
+    def test_passes_when_enable_deepep_false(self):
+        cfg = self._cfg(ac=True, ep=8, backend={"enable_deepep": False})
+        _raise_if_deepep_with_activation_checkpointing(cfg)  # no raise
+
+    def test_passes_when_ac_disabled(self):
+        cfg = self._cfg(ac=False, ep=8, backend={"dispatcher": "deepep"})
+        _raise_if_deepep_with_activation_checkpointing(cfg)  # no raise
+
+    def test_passes_when_ep_size_one(self):
+        # No EP -> DeepEP isn't dispatching, guard is inapplicable.
+        cfg = self._cfg(ac=True, ep=1, backend={"dispatcher": "deepep"})
+        _raise_if_deepep_with_activation_checkpointing(cfg)  # no raise
+
+    def test_passes_when_defaulted_but_deepep_unavailable(self):
+        cfg = self._cfg(ac=True, ep=8, backend={})
+        with patch.dict("sys.modules", {"deep_ep": None}):
+            _raise_if_deepep_with_activation_checkpointing(cfg)  # no raise


### PR DESCRIPTION

# What does this PR do?

The DeepEP token dispatcher is nondeterministic across activation- checkpoint recompute: the router + DeepEP dispatch re-run during backward can produce a per-expert token count that differs by 1 from the forward, which then trips a shape mismatch inside TransformerEngine's moe_unpermute_mask_map backward and surfaces as an opaque `torch.utils.checkpoint.CheckpointError` deep in autograd.

Add a config-time guard in validate_and_prepare_config that raises a clear `ValueError` when `policy.dtensor_cfg.activation_checkpointing` is on, `expert_parallel_size > 1`, and the effective dispatcher resolves to "deepep" (explicit, via the deprecated `enable_deepep`, or by `BackendConfig` default when deep_ep is importable). The message points to the workaround (dispatcher=torch / enable_deepep=false) so users can unblock without disabling AC.

Unit-tested in `tests/unit/models/automodel/test_automodel_setup.py`.

Command to reproduce the error that this PR fixes:
`uv run /opt/nemo-rl/examples/run_dpo.py   --config /opt/nemo-rl/examples/configs/recipes/llm/dpo-nanov3-30B3AB-1n8g-fsdp8ep8-automodel.yaml   dpo.max_num_steps=15   logger.log_dir=<LOG_DIR>   logger.wandb_enabled=false   logger.tensorboard_enabled=true   logger.monitor_gpus=true   checkpointing.enabled=true   checkpointing.checkpoint_dir=<CKPT_DIR>`


# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
