### PR TITLE
chore: update deepscaler nightly metric to avoid flaky

### DIFF
--- a/tests/test_suites/llm/grpo-deepscaler-1.5b-16K.sh
+++ b/tests/test_suites/llm/grpo-deepscaler-1.5b-16K.sh
@@ -42,7 +42,7 @@ uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
 if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
     uv run tests/check_metrics.py $JSON_METRICS \
         'median(data["train/token_mult_prob_error"]) < 1.05' \
-        "data['train/token_mult_prob_error']['$MAX_STEPS'] < 1.05"
+        "max(data['train/gen_kl_error']) < 0.0004"
 fi
 
 # Convert 16k checkpoint

--- a/tests/test_suites/llm/grpo-deepscaler-1.5b-1n4g-8K.sh
+++ b/tests/test_suites/llm/grpo-deepscaler-1.5b-1n4g-8K.sh
@@ -36,7 +36,7 @@ uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
 if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
     uv run tests/check_metrics.py $JSON_METRICS \
         'median(data["train/token_mult_prob_error"]) < 1.05' \
-        "data['train/token_mult_prob_error']['$MAX_STEPS'] < 1.05"
+        "max(data['train/gen_kl_error']) < 0.0005"
 fi
 
 # Convert 8k checkpoint

--- a/tests/test_suites/llm/grpo-deepscaler-1.5b-24K.sh
+++ b/tests/test_suites/llm/grpo-deepscaler-1.5b-24K.sh
@@ -42,7 +42,7 @@ uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
 if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
     uv run tests/check_metrics.py $JSON_METRICS \
         'median(data["train/token_mult_prob_error"]) < 1.05' \
-        "data['train/token_mult_prob_error']['$MAX_STEPS'] < 1.05"
+        "max(data['train/gen_kl_error']) < 0.0004"
 fi
 
 # Convert 24k checkpoint

--- a/tests/test_suites/llm/grpo-deepscaler-1.5b-8K.sh
+++ b/tests/test_suites/llm/grpo-deepscaler-1.5b-8K.sh
@@ -35,7 +35,6 @@ uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
 if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
     uv run tests/check_metrics.py $JSON_METRICS \
         'median(data["train/token_mult_prob_error"]) < 1.05' \
-        "data['train/token_mult_prob_error']['$MAX_STEPS'] < 1.05" \
         "max(data['train/gen_kl_error']) < 0.0005"
 fi
 

--- a/tests/test_suites/llm/grpo-gspo-deepscaler-1.5b-8K.sh
+++ b/tests/test_suites/llm/grpo-gspo-deepscaler-1.5b-8K.sh
@@ -37,7 +37,6 @@ uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
 if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
     uv run tests/check_metrics.py $JSON_METRICS \
         'median(data["train/token_mult_prob_error"]) < 1.05' \
-        "data['train/token_mult_prob_error']['$MAX_STEPS'] < 1.05" \
         "max(data['train/gen_kl_error']) < 0.0005"
 
     # Clean up checkpoint directory after successful run to save space.


### PR DESCRIPTION
## Changes
1. remove `token_mult_prob_error` check at max step.
2. add `gen_kl_error` check.

## Reference (Red is before rotary_embedding fix in https://github.com/NVIDIA-NeMo/RL/pull/2981)
**8K**
<img width="1947" height="311" alt="image" src="https://github.com/user-attachments/assets/aa1b43bf-e8a6-4306-9b1a-d0b958cee1d5" />

**16K**
<img width="1951" height="309" alt="image" src="https://github.com/user-attachments/assets/befff20a-50e4-4af0-a9a4-84e4b8b11366" />

**24K**
<img width="1950" height="311" alt="image" src="https://github.com/user-attachments/assets/00c5881a-5e2b-486d-8bfc-35db66f20094" />