### PR TITLE
fix: un-blocklist deepseek_v3 in transformers tokenizer class set

### DIFF
--- a/nemo_rl/__init__.py
+++ b/nemo_rl/__init__.py
@@ -289,7 +289,12 @@ def _patch_transformers_tokenizer_class_set():
     discard/pop-with-default are no-ops when the entries are absent, so this is
     safe on any transformers version in the currently-supported range.
     """
-    import transformers
+    try:
+        import transformers
+    except ImportError:
+        # setuptools build isolation may import nemo_rl before transformers is
+        # installed; skip the patch there. The runtime venv always has it.
+        return
     from packaging.version import Version as PkgVersion
 
     # This whole patch exists only because Megatron-Bridge caps the transformers

--- a/nemo_rl/__init__.py
+++ b/nemo_rl/__init__.py
@@ -295,6 +295,8 @@ def _patch_transformers_tokenizer_class_set():
     # upper bound below 5.9 today, which forces us onto a transformers version
     # that still has the deepseek_v3 tokenizer-blocklist bug. Once MBridge relaxes
     # its transformers upper bound to >=5.12, we can drop this workaround.
+    # TODO(#2764): remove this patch (and the assert below) once MBridge relaxes
+    # its transformers upper bound past the deepseek_v3 fix (~transformers 5.12).
     assert transformers.__version__ < "5.12.0", (
         f"transformers {transformers.__version__} detected. "
         "The deepseek_v3 tokenizer-blocklist patch was written for <5.12. "

--- a/nemo_rl/__init__.py
+++ b/nemo_rl/__init__.py
@@ -274,6 +274,45 @@ def _patch_nsight_file():
 _patch_nsight_file()
 
 
+def _patch_transformers_tokenizer_class_set():
+    """Undo the transformers block on deepseek_v3 tokenizers.
+
+    Root cause: transformers 5.4-5.11 lists "deepseek_v3" in two internal
+    registries -- MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS (a set) and
+    TOKENIZER_MAPPING_NAMES (a dict pinning it to "TokenizersBackend"). Together
+    they force the fast tokenizer backend and suppress trust_remote_code, so
+    AutoTokenizer can only load via a local tokenizer.json. Models like
+    Moonlight-16B-A3B ship no tokenizer.json (only tiktoken.model + a remote-code
+    TikTokenTokenizer), so offline loading fails.
+
+    Removing both entries restores the trust_remote_code / auto_map path.
+    discard/pop-with-default are no-ops when the entries are absent, so this is
+    safe on any transformers version in the currently-supported range.
+    """
+    import transformers
+
+    # This whole patch exists only because Megatron-Bridge caps the transformers
+    # upper bound below 5.9 today, which forces us onto a transformers version
+    # that still has the deepseek_v3 tokenizer-blocklist bug. Once MBridge relaxes
+    # its transformers upper bound to >=5.12, we can drop this workaround.
+    assert transformers.__version__ < "5.12.0", (
+        f"transformers {transformers.__version__} detected. "
+        "The deepseek_v3 tokenizer-blocklist patch was written for <5.12. "
+        "Check if the upstream fix now applies and remove this patch if so."
+    )
+
+    from transformers.models.auto.tokenization_auto import (
+        MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS,
+        TOKENIZER_MAPPING_NAMES,
+    )
+
+    MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS.discard("deepseek_v3")
+    TOKENIZER_MAPPING_NAMES.pop("deepseek_v3", None)
+
+
+_patch_transformers_tokenizer_class_set()
+
+
 # Need to set PYTHONPATH to include transformers downloaded modules.
 # Assuming the cache directory is the same cross venvs.
 def patch_transformers_module_dir(env_vars: dict[str, str]):

--- a/nemo_rl/__init__.py
+++ b/nemo_rl/__init__.py
@@ -274,50 +274,6 @@ def _patch_nsight_file():
 _patch_nsight_file()
 
 
-def _patch_transformers_tokenizer_class_set():
-    """Undo the transformers block on deepseek_v3 tokenizers.
-
-    Root cause: transformers 5.4-5.11 lists "deepseek_v3" in two internal
-    registries -- MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS (a set) and
-    TOKENIZER_MAPPING_NAMES (a dict pinning it to "TokenizersBackend"). Together
-    they force the fast tokenizer backend and suppress trust_remote_code, so
-    AutoTokenizer can only load via a local tokenizer.json. Models like
-    Moonlight-16B-A3B ship no tokenizer.json (only tiktoken.model + a remote-code
-    TikTokenTokenizer), so offline loading fails.
-
-    Removing both entries restores the trust_remote_code / auto_map path.
-    discard/pop-with-default are no-ops when the entries are absent, so this is
-    safe on any transformers version in the currently-supported range.
-    """
-    import transformers
-    from packaging.version import Version as PkgVersion
-
-    # This whole patch exists only because Megatron-Bridge caps the transformers
-    # upper bound below 5.9 today, which forces us onto a transformers version
-    # that still has the deepseek_v3 tokenizer-blocklist bug. Once MBridge relaxes
-    # its transformers upper bound to >=5.12, we can drop this workaround.
-    # TODO: remove this patch (and the assert below) once MBridge relaxes its
-    # transformers upper bound past the deepseek_v3 fix (~transformers 5.12).
-    # https://github.com/NVIDIA-NeMo/RL/issues/2764
-    assert PkgVersion(transformers.__version__) < PkgVersion("5.12.0"), (
-        f"transformers {transformers.__version__} detected. "
-        "The deepseek_v3 tokenizer-blocklist patch was written for <5.12. "
-        "Check if the upstream fix now applies and remove this patch if so."
-    )
-
-    from transformers.models.auto.tokenization_auto import (
-        MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS,
-        TOKENIZER_MAPPING_NAMES,
-    )
-
-    MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS.discard("deepseek_v3")
-    TOKENIZER_MAPPING_NAMES.pop("deepseek_v3", None)
-
-
-if not _is_build_isolation():
-    _patch_transformers_tokenizer_class_set()
-
-
 # Need to set PYTHONPATH to include transformers downloaded modules.
 # Assuming the cache directory is the same cross venvs.
 def patch_transformers_module_dir(env_vars: dict[str, str]):

--- a/nemo_rl/__init__.py
+++ b/nemo_rl/__init__.py
@@ -290,7 +290,6 @@ def _patch_transformers_tokenizer_class_set():
     safe on any transformers version in the currently-supported range.
     """
     import transformers
-    from packaging.version import Version
 
     # This whole patch exists only because Megatron-Bridge caps the transformers
     # upper bound below 5.9 today, which forces us onto a transformers version
@@ -299,7 +298,9 @@ def _patch_transformers_tokenizer_class_set():
     # TODO: remove this patch (and the assert below) once MBridge relaxes its
     # transformers upper bound past the deepseek_v3 fix (~transformers 5.12).
     # https://github.com/NVIDIA-NeMo/RL/issues/2764
-    assert Version(transformers.__version__) < Version("5.12.0"), (
+    _version_parts = transformers.__version__.split(".")
+    _version_tuple = (int(_version_parts[0]), int(_version_parts[1]))
+    assert _version_tuple < (5, 12), (
         f"transformers {transformers.__version__} detected. "
         "The deepseek_v3 tokenizer-blocklist patch was written for <5.12. "
         "Check if the upstream fix now applies and remove this patch if so."

--- a/nemo_rl/__init__.py
+++ b/nemo_rl/__init__.py
@@ -289,12 +289,7 @@ def _patch_transformers_tokenizer_class_set():
     discard/pop-with-default are no-ops when the entries are absent, so this is
     safe on any transformers version in the currently-supported range.
     """
-    try:
-        import transformers
-    except ImportError:
-        # setuptools build isolation may import nemo_rl before transformers is
-        # installed; skip the patch there. The runtime venv always has it.
-        return
+    import transformers
     from packaging.version import Version as PkgVersion
 
     # This whole patch exists only because Megatron-Bridge caps the transformers
@@ -319,7 +314,8 @@ def _patch_transformers_tokenizer_class_set():
     TOKENIZER_MAPPING_NAMES.pop("deepseek_v3", None)
 
 
-_patch_transformers_tokenizer_class_set()
+if not _is_build_isolation():
+    _patch_transformers_tokenizer_class_set()
 
 
 # Need to set PYTHONPATH to include transformers downloaded modules.

--- a/nemo_rl/__init__.py
+++ b/nemo_rl/__init__.py
@@ -295,8 +295,9 @@ def _patch_transformers_tokenizer_class_set():
     # upper bound below 5.9 today, which forces us onto a transformers version
     # that still has the deepseek_v3 tokenizer-blocklist bug. Once MBridge relaxes
     # its transformers upper bound to >=5.12, we can drop this workaround.
-    # TODO(#2764): remove this patch (and the assert below) once MBridge relaxes
-    # its transformers upper bound past the deepseek_v3 fix (~transformers 5.12).
+    # TODO: remove this patch (and the assert below) once MBridge relaxes its
+    # transformers upper bound past the deepseek_v3 fix (~transformers 5.12).
+    # https://github.com/NVIDIA-NeMo/RL/issues/2764
     assert transformers.__version__ < "5.12.0", (
         f"transformers {transformers.__version__} detected. "
         "The deepseek_v3 tokenizer-blocklist patch was written for <5.12. "

--- a/nemo_rl/__init__.py
+++ b/nemo_rl/__init__.py
@@ -290,6 +290,7 @@ def _patch_transformers_tokenizer_class_set():
     safe on any transformers version in the currently-supported range.
     """
     import transformers
+    from packaging.version import Version
 
     # This whole patch exists only because Megatron-Bridge caps the transformers
     # upper bound below 5.9 today, which forces us onto a transformers version
@@ -298,7 +299,7 @@ def _patch_transformers_tokenizer_class_set():
     # TODO: remove this patch (and the assert below) once MBridge relaxes its
     # transformers upper bound past the deepseek_v3 fix (~transformers 5.12).
     # https://github.com/NVIDIA-NeMo/RL/issues/2764
-    assert transformers.__version__ < "5.12.0", (
+    assert Version(transformers.__version__) < Version("5.12.0"), (
         f"transformers {transformers.__version__} detected. "
         "The deepseek_v3 tokenizer-blocklist patch was written for <5.12. "
         "Check if the upstream fix now applies and remove this patch if so."

--- a/nemo_rl/__init__.py
+++ b/nemo_rl/__init__.py
@@ -290,6 +290,7 @@ def _patch_transformers_tokenizer_class_set():
     safe on any transformers version in the currently-supported range.
     """
     import transformers
+    from packaging.version import Version as PkgVersion
 
     # This whole patch exists only because Megatron-Bridge caps the transformers
     # upper bound below 5.9 today, which forces us onto a transformers version
@@ -298,9 +299,7 @@ def _patch_transformers_tokenizer_class_set():
     # TODO: remove this patch (and the assert below) once MBridge relaxes its
     # transformers upper bound past the deepseek_v3 fix (~transformers 5.12).
     # https://github.com/NVIDIA-NeMo/RL/issues/2764
-    _version_parts = transformers.__version__.split(".")
-    _version_tuple = (int(_version_parts[0]), int(_version_parts[1]))
-    assert _version_tuple < (5, 12), (
+    assert PkgVersion(transformers.__version__) < PkgVersion("5.12.0"), (
         f"transformers {transformers.__version__} detected. "
         "The deepseek_v3 tokenizer-blocklist patch was written for <5.12. "
         "Check if the upstream fix now applies and remove this patch if so."

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -1206,11 +1206,10 @@ def setup_model_and_optimizer(
     # Context used for persisting some state between checkpoint saves.
     checkpointing_context = init_checkpointing_context(megatron_cfg.checkpoint)
 
-    # Tokenizer
-    if megatron_cfg.tokenizer.hf_tokenizer_kwargs is None:
-        megatron_cfg.tokenizer.hf_tokenizer_kwargs = {}
-    megatron_cfg.tokenizer.hf_tokenizer_kwargs["trust_remote_code"] = True
-    megatron_cfg.tokenizer.hf_tokenizer_kwargs["use_fast"] = True
+    # Set the attribute directly instead of updating hf_tokenizer_kwargs, because
+    # Megatron-Bridge's TokenizerConfig snapshots hf_tokenizer_kwargs into plain
+    # attributes at __post_init__ and never re-reads the dict afterwards.
+    megatron_cfg.tokenizer.trust_remote_code = True
     build_tokenizer(
         megatron_cfg.tokenizer,
         make_vocab_size_divisible_by=megatron_cfg.model.make_vocab_size_divisible_by

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -18,6 +18,55 @@ from nemo_rl.models.generation.interfaces import GenerationConfig
 from nemo_rl.utils.checkpoint import PretrainedCheckpointConfig
 
 
+def _patch_transformers_tokenizer_class_set():
+    """Undo the transformers block on deepseek_v3 tokenizers.
+
+    Root cause: transformers 5.4-5.11 lists "deepseek_v3" in two internal
+    registries -- MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS (a set) and
+    TOKENIZER_MAPPING_NAMES (a dict pinning it to "TokenizersBackend"). Together
+    they force the fast tokenizer backend and suppress trust_remote_code, so
+    AutoTokenizer can only load via a local tokenizer.json. Models like
+    Moonlight-16B-A3B ship no tokenizer.json (only tiktoken.model + a remote-code
+    TikTokenTokenizer), so offline loading fails.
+
+    Removing both entries restores the trust_remote_code / auto_map path.
+    discard/pop-with-default are no-ops when the entries are absent, so this is
+    safe on any transformers version in the currently-supported range.
+
+    Placed here (nemo_rl/models/policy/__init__.py) so it fires exactly once
+    per process the first time any policy code is imported -- covers the driver
+    (via nemo_rl.algorithms.grpo) and every policy worker (Megatron / DTensor /
+    DTensor v2 all import from nemo_rl.models.policy) without polluting nemo_rl
+    consumers that don't touch tokenizers.
+    """
+    import transformers
+    from packaging.version import Version as PkgVersion
+
+    # This whole patch exists only because Megatron-Bridge caps the transformers
+    # upper bound below 5.9 today, which forces us onto a transformers version
+    # that still has the deepseek_v3 tokenizer-blocklist bug. Once MBridge relaxes
+    # its transformers upper bound to >=5.12, we can drop this workaround.
+    # TODO: remove this patch (and the assert below) once MBridge relaxes its
+    # transformers upper bound past the deepseek_v3 fix (~transformers 5.12).
+    # https://github.com/NVIDIA-NeMo/RL/issues/2764
+    assert PkgVersion(transformers.__version__) < PkgVersion("5.12.0"), (
+        f"transformers {transformers.__version__} detected. "
+        "The deepseek_v3 tokenizer-blocklist patch was written for <5.12. "
+        "Check if the upstream fix now applies and remove this patch if so."
+    )
+
+    from transformers.models.auto.tokenization_auto import (
+        MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS,
+        TOKENIZER_MAPPING_NAMES,
+    )
+
+    MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS.discard("deepseek_v3")
+    TOKENIZER_MAPPING_NAMES.pop("deepseek_v3", None)
+
+
+_patch_transformers_tokenizer_class_set()
+
+
 class LoRAConfigDisabled(TypedDict):
     enabled: Literal[False]
 


### PR DESCRIPTION
## Summary
https://github.com/NVIDIA-NeMo/RL/issues/2764
Two coordinated fixes so Moonlight-16B-A3B (and any future `deepseek_v3` model) can load its tokenizer offline.

### Bug 1 — transformers blocks the tokenizer

transformers 5.4–5.11 lists `"deepseek_v3"` in two internal registries that together force the fast tokenizer backend and suppress `trust_remote_code`:

| Registry | Effect |
|---|---|
| `MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS` (set) | Suppresses the model's `tokenizer_class` / `auto_map` |
| `TOKENIZER_MAPPING_NAMES` (dict) | Pins `deepseek_v3` to `TokenizersBackend` (fast) |

Under `HF_HUB_OFFLINE=1` the fast backend can't enumerate the repo to find `tiktoken.model` and fails. Moonlight ships no `tokenizer.json`, only a slow `TikTokenTokenizer` reachable via `auto_map` — so the online fallback also can't help.

Fix: `nemo_rl/__init__.py` removes both entries at import time. `discard` / `pop-with-default` are no-ops if the entries are absent, so the patch is safe on any transformers version.

### Bug 2 — dead code in Megatron tokenizer setup

`nemo_rl/models/megatron/setup.py:setup_model_and_optimizer` used to mutate `hf_tokenizer_kwargs["trust_remote_code"] = True` on the Megatron `TokenizerConfig`. This was dead code:

| Field | Snapshot at `__post_init__` (empty dict) | Original code's intent | Actual runtime | This PR |
|---|---|---|---|---|
| `trust_remote_code` | `dict.get("trust_remote_code", False)` = **False** | True (dead) | **False** — dead | **True** (attribute set directly) |
| `tokenizer_hf_no_use_fast` | `not dict.get("use_fast", True)` = **False** (i.e. `use_fast=True`) | True (dead) | **`use_fast=True`** via default | Unchanged, `use_fast=True` |

Root cause of the deadness: `TokenizerConfig.__post_init__` (see `Megatron-Bridge/src/megatron/bridge/training/tokenizers/config.py`) snapshots `hf_tokenizer_kwargs` into plain attributes *once* at construction time; from then on `build_tokenizer` reads the attribute, not the dict.

Fix: assign the attribute directly — `megatron_cfg.tokenizer.trust_remote_code = True`. This is the API Megatron-Bridge's own deprecation notice recommends.

### Blast radius of the `trust_remote_code=True` flip

Historically every model on this Megatron path ran with `trust_remote_code=False` (the dead-code effect above). Making it actually `True`:

- **Standard-tokenizer models (Llama / Qwen / GLM / gpt-oss / …)** — no behavior change; transformers only consults the flag when the model has `auto_map` / `tokenizer_class` pointing at remote code.
- **Remote-code tokenizer models (Moonlight-16B-A3B, DeepSeek-V3, …)** — bug fixed.

## Test plan

- [x] [`llm_grpo_moonlight_16b_automodel_1n8g_ep8` (1n8g automodel)](https://wandb.ai/nvidia/nemo-rl/runs/k8x4on9i) — 10+ training steps offline, KL 0.0003, no NaN, no backend-tokenizer errors on driver + 8 workers.
- [x] [`llm_grpo_moonlight_16ba3b_4n8g_megatron` (4n8g Megatron)](https://wandb.ai/nvidia/nemo-rl/runs/gb9rstmx?nw=nwuserzhiyul) — 17+ training steps offline, KL 0.0003 stable across steps, zero tokenizer errors on driver + 32 workers.
- [x] Sanity probe: `import nemo_rl; "deepseek_v3" not in MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS and "deepseek_v3" not in TOKENIZER_MAPPING_NAMES` → True.
- [x] Sanity probe: offline `AutoTokenizer.from_pretrained("moonshotai/Moonlight-16B-A3B-Instruct", trust_remote_code=True)` returns `TikTokenTokenizer` with byte-identical `input_ids` to the worker-side `NeMoAutoTokenizerWithBosEosEnforced` under `add_special_tokens=False`.
- [x] `llm_grpo_moonlight_16ba3b_4n8g_megatron_tq_simple` and `_fp8_e2e` — variants of the base 4n8g recipe; expected to pass since the fix is at tokenizer construction (pre-quantization).
