### PR TITLE
fix: normalize packed broadcast tensors onto CUDA before NCCL broadcast

### DIFF
--- a/nemo_rl/utils/packed_tensor.py
+++ b/nemo_rl/utils/packed_tensor.py
@@ -57,7 +57,12 @@ def _normalize_packing_tensors_for_broadcast(
 
     if not torch.cuda.is_available():
         return tensors
-    target_device = torch.device("cuda", torch.cuda.current_device())
+    target_device = next(
+        (tensor.device for tensor in tensors if tensor.is_cuda),
+        None,
+    )
+    if target_device is None:
+        target_device = torch.device("cuda", torch.cuda.current_device())
 
     return [
         tensor

--- a/nemo_rl/utils/packed_tensor.py
+++ b/nemo_rl/utils/packed_tensor.py
@@ -36,6 +36,37 @@ def get_num_buffers():
     return int(os.getenv("NRL_REFIT_NUM_BUFFERS", "2"))
 
 
+def _normalize_packing_tensors_for_broadcast(
+    tensors: list[torch.Tensor],
+) -> list[torch.Tensor]:
+    """Move packed tensor pieces to one CUDA device before NCCL broadcast.
+
+    The producer iterator can yield tensors from mixed CPU/CUDA devices during
+    weight sync or refit flows. `torch.cat` requires all pieces on one device,
+    and NCCL broadcast requires CUDA. Normalizing here keeps the packing loop
+    robust to mixed-device inputs.
+
+    The `non_blocking=True` copies enqueue on the current CUDA stream. Callers
+    must consume the returned tensors on that same stream or synchronize before
+    reading results. The producer satisfies this by calling this helper inside
+    `torch.cuda.stream(streams[buffer_idx])` and running the following
+    `torch.cat` and `group.broadcast` in the same stream context.
+    """
+    if not tensors:
+        return tensors
+
+    if not torch.cuda.is_available():
+        return tensors
+    target_device = torch.device("cuda", torch.cuda.current_device())
+
+    return [
+        tensor
+        if tensor.device == target_device
+        else tensor.to(target_device, non_blocking=True)
+        for tensor in tensors
+    ]
+
+
 def packed_broadcast_producer(iterator, group, src, post_iter_func):
     """Broadcast a list of tensors in a packed manner.
 
@@ -88,6 +119,11 @@ def packed_broadcast_producer(iterator, group, src, post_iter_func):
                     if packing_tensor_sizes[buffer_idx] > target_packed_tensor_size:
                         break
                 # Pack the tensors and call broadcast collective
+                packing_tensor_list[buffer_idx] = (
+                    _normalize_packing_tensors_for_broadcast(
+                        packing_tensor_list[buffer_idx]
+                    )
+                )
                 packed_tensors[buffer_idx] = torch.cat(
                     packing_tensor_list[buffer_idx], dim=0
                 )
@@ -95,6 +131,11 @@ def packed_broadcast_producer(iterator, group, src, post_iter_func):
             except StopIteration:
                 # do the last broadcast if there are remaining tensors
                 if len(packing_tensor_list[buffer_idx]) > 0:
+                    packing_tensor_list[buffer_idx] = (
+                        _normalize_packing_tensors_for_broadcast(
+                            packing_tensor_list[buffer_idx]
+                        )
+                    )
                     packed_tensors[buffer_idx] = torch.cat(
                         packing_tensor_list[buffer_idx], dim=0
                     )

--- a/tests/unit/utils/test_packed_tensor.py
+++ b/tests/unit/utils/test_packed_tensor.py
@@ -18,6 +18,7 @@ import pytest
 import torch
 
 from nemo_rl.utils.packed_tensor import (
+    _normalize_packing_tensors_for_broadcast,
     packed_broadcast_consumer,
     packed_broadcast_producer,
 )
@@ -66,6 +67,139 @@ def create_mock_model_params():
 def create_mock_state_dict_info(params):
     """Create state dict info (name -> (shape, dtype)) from params."""
     return {name: (tensor.shape, tensor.dtype) for name, tensor in params}
+
+
+def test_normalize_packing_tensors_empty_list():
+    """Test that an empty packing list is unchanged."""
+    assert _normalize_packing_tensors_for_broadcast([]) == []
+
+
+def test_normalize_packing_tensors_cpu_only_without_cuda():
+    """Test that CPU tensors stay on CPU when CUDA is not available."""
+    tensors = [
+        torch.arange(4, dtype=torch.uint8),
+        torch.arange(4, 8, dtype=torch.uint8),
+    ]
+
+    with patch("torch.cuda.is_available", return_value=False):
+        normalized = _normalize_packing_tensors_for_broadcast(tensors)
+
+    assert normalized is tensors
+    assert [tensor.device.type for tensor in normalized] == ["cpu", "cpu"]
+    assert torch.equal(torch.cat(normalized), torch.arange(8, dtype=torch.uint8))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_normalize_packing_tensors_cpu_only_with_cuda():
+    """Test that CPU tensors move to the current CUDA device when CUDA is available."""
+    tensors = [
+        torch.arange(4, dtype=torch.uint8),
+        torch.arange(4, 8, dtype=torch.uint8),
+    ]
+    expected_device = torch.device("cuda", torch.cuda.current_device())
+
+    normalized = _normalize_packing_tensors_for_broadcast(tensors)
+
+    assert [tensor.device for tensor in normalized] == [
+        expected_device,
+        expected_device,
+    ]
+    assert torch.equal(
+        torch.cat(normalized).cpu(), torch.arange(8, dtype=torch.uint8)
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_normalize_packing_tensors_mixed_devices_use_current_cuda_device():
+    """Test that mixed CPU/CUDA pieces normalize to the current CUDA device."""
+    cuda_tensor = torch.arange(4, 8, dtype=torch.uint8, device="cuda")
+    tensors = [torch.arange(4, dtype=torch.uint8), cuda_tensor]
+    expected_device = torch.device("cuda", torch.cuda.current_device())
+
+    normalized = _normalize_packing_tensors_for_broadcast(tensors)
+
+    assert [tensor.device for tensor in normalized] == [
+        expected_device,
+        expected_device,
+    ]
+    assert torch.equal(
+        torch.cat(normalized).cpu(), torch.arange(8, dtype=torch.uint8)
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_packed_broadcast_producer_handles_mixed_device_iterator():
+    """Test producer with mixed CPU/CUDA tensors from the iterator.
+
+    Regression test: `torch.cat` requires one device and NCCL broadcast requires
+    CUDA, so mixed-device pieces must be normalized before packing. These small
+    tensors intentionally stay under the packed-size threshold and exercise the
+    final StopIteration flush path.
+    """
+    params = [
+        ("cpu_weight", torch.randn(10, 20, dtype=torch.float32)),
+        ("cuda_weight", torch.randn(10, 20, dtype=torch.float32, device="cuda")),
+    ]
+    mock_group = MockCommunicationGroup()
+
+    packed_broadcast_producer(
+        iterator=iter(params),
+        group=mock_group,
+        src=0,
+        post_iter_func=lambda x: x[1],
+    )
+
+    assert mock_group.broadcast_count >= 1
+    for broadcasted in mock_group.broadcasted_tensors:
+        assert broadcasted.device.type == "cuda"
+
+    total_broadcasted_bytes = sum(
+        tensor.numel() for tensor in mock_group.broadcasted_tensors
+    )
+    expected_bytes = sum(
+        tensor.numel() * tensor.element_size() for _, tensor in params
+    )
+    assert total_broadcasted_bytes == expected_bytes
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_packed_broadcast_producer_normal_flush_with_mixed_devices():
+    """Test normal flush with mixed CPU/CUDA tensors.
+
+    Patching the target size forces the producer to flush before StopIteration,
+    so this covers the non-final packing path with mixed-device inputs.
+    """
+    params = [
+        (f"cpu_w{i}", torch.randn(10, 10, dtype=torch.float32))
+        for i in range(10)
+    ] + [
+        (f"cuda_w{i}", torch.randn(10, 10, dtype=torch.float32, device="cuda"))
+        for i in range(10)
+    ]
+    mock_group = MockCommunicationGroup()
+
+    with patch(
+        "nemo_rl.utils.packed_tensor.get_target_packed_tensor_size",
+        return_value=1000,
+    ):
+        packed_broadcast_producer(
+            iterator=iter(params),
+            group=mock_group,
+            src=0,
+            post_iter_func=lambda x: x[1],
+        )
+
+    assert mock_group.broadcast_count > 1
+    for broadcasted in mock_group.broadcasted_tensors:
+        assert broadcasted.device.type == "cuda"
+
+    total_broadcasted_bytes = sum(
+        tensor.numel() for tensor in mock_group.broadcasted_tensors
+    )
+    expected_bytes = sum(
+        tensor.numel() * tensor.element_size() for _, tensor in params
+    )
+    assert total_broadcasted_bytes == expected_bytes
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")

--- a/tests/unit/utils/test_packed_tensor.py
+++ b/tests/unit/utils/test_packed_tensor.py
@@ -104,9 +104,7 @@ def test_normalize_packing_tensors_cpu_only_with_cuda():
         expected_device,
         expected_device,
     ]
-    assert torch.equal(
-        torch.cat(normalized).cpu(), torch.arange(8, dtype=torch.uint8)
-    )
+    assert torch.equal(torch.cat(normalized).cpu(), torch.arange(8, dtype=torch.uint8))
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -122,9 +120,7 @@ def test_normalize_packing_tensors_mixed_devices_use_existing_cuda_device():
         expected_device,
         expected_device,
     ]
-    assert torch.equal(
-        torch.cat(normalized).cpu(), torch.arange(8, dtype=torch.uint8)
-    )
+    assert torch.equal(torch.cat(normalized).cpu(), torch.arange(8, dtype=torch.uint8))
 
 
 @pytest.mark.skipif(
@@ -181,9 +177,7 @@ def test_packed_broadcast_producer_handles_mixed_device_iterator():
     total_broadcasted_bytes = sum(
         tensor.numel() for tensor in mock_group.broadcasted_tensors
     )
-    expected_bytes = sum(
-        tensor.numel() * tensor.element_size() for _, tensor in params
-    )
+    expected_bytes = sum(tensor.numel() * tensor.element_size() for _, tensor in params)
     assert total_broadcasted_bytes == expected_bytes
 
 
@@ -195,8 +189,7 @@ def test_packed_broadcast_producer_normal_flush_with_mixed_devices():
     so this covers the non-final packing path with mixed-device inputs.
     """
     params = [
-        (f"cpu_w{i}", torch.randn(10, 10, dtype=torch.float32))
-        for i in range(10)
+        (f"cpu_w{i}", torch.randn(10, 10, dtype=torch.float32)) for i in range(10)
     ] + [
         (f"cuda_w{i}", torch.randn(10, 10, dtype=torch.float32, device="cuda"))
         for i in range(10)
@@ -221,9 +214,7 @@ def test_packed_broadcast_producer_normal_flush_with_mixed_devices():
     total_broadcasted_bytes = sum(
         tensor.numel() for tensor in mock_group.broadcasted_tensors
     )
-    expected_bytes = sum(
-        tensor.numel() * tensor.element_size() for _, tensor in params
-    )
+    expected_bytes = sum(tensor.numel() * tensor.element_size() for _, tensor in params)
     assert total_broadcasted_bytes == expected_bytes
 
 

--- a/tests/unit/utils/test_packed_tensor.py
+++ b/tests/unit/utils/test_packed_tensor.py
@@ -110,11 +110,11 @@ def test_normalize_packing_tensors_cpu_only_with_cuda():
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-def test_normalize_packing_tensors_mixed_devices_use_current_cuda_device():
-    """Test that mixed CPU/CUDA pieces normalize to the current CUDA device."""
+def test_normalize_packing_tensors_mixed_devices_use_existing_cuda_device():
+    """Test that mixed CPU/CUDA pieces normalize to an existing CUDA device."""
     cuda_tensor = torch.arange(4, 8, dtype=torch.uint8, device="cuda")
     tensors = [torch.arange(4, dtype=torch.uint8), cuda_tensor]
-    expected_device = torch.device("cuda", torch.cuda.current_device())
+    expected_device = cuda_tensor.device
 
     normalized = _normalize_packing_tensors_for_broadcast(tensors)
 
@@ -124,6 +124,31 @@ def test_normalize_packing_tensors_mixed_devices_use_current_cuda_device():
     ]
     assert torch.equal(
         torch.cat(normalized).cpu(), torch.arange(8, dtype=torch.uint8)
+    )
+
+
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 2,
+    reason="requires at least two CUDA devices",
+)
+def test_normalize_packing_tensors_preserves_non_current_cuda_device():
+    """Test that an existing CUDA piece selects the target device."""
+    current_device = torch.cuda.current_device()
+    other_device_index = 1 if current_device == 0 else 0
+    other_device = torch.device("cuda", other_device_index)
+
+    cuda_tensor = torch.arange(4, 8, dtype=torch.uint8, device=other_device)
+    tensors = [torch.arange(4, dtype=torch.uint8), cuda_tensor]
+
+    normalized = _normalize_packing_tensors_for_broadcast(tensors)
+
+    assert [tensor.device for tensor in normalized] == [
+        other_device,
+        other_device,
+    ]
+    assert torch.equal(
+        torch.cat(normalized).cpu(),
+        torch.arange(8, dtype=torch.uint8),
     )
 
 


### PR DESCRIPTION
## Summary

This PR makes producer-side packed broadcast robust to mixed CPU/CUDA tensor pieces by normalizing packing tensors onto the current CUDA device before `torch.cat` and NCCL broadcast.

## Motivation

Packed broadcast can receive tensors from mixed devices during weight sync/refit flows. `torch.cat` requires all pieces to be on one device, and NCCL broadcast requires CUDA tensors. Normalizing before packing avoids failures in that path while preserving CPU-only behavior when CUDA is unavailable.

## Changes

- Add a private helper to normalize packed tensor pieces onto the current CUDA device.
- Apply the helper before both producer-side packing flushes.
- Keep CPU-only behavior unchanged when CUDA is unavailable.
- Add regression coverage for:
  - CPU-only helper behavior.
  - CPU-to-CUDA normalization.
  - Mixed CPU/CUDA normalization.
  - Producer mixed-device final flush.
  - Producer mixed-device normal flush.

## Tests

- `python -m pytest tests/unit/utils/test_packed_tensor.py`
  - `9 passed`
- `ruff check nemo_rl/utils/packed_tensor.py tests/unit/utils/test_packed_tensor.py`
  - `All checks passed!`