### PR TITLE
fix: skip no-op TP collectives for world size one

### DIFF
--- a/nemo_rl/distributed/model_utils.py
+++ b/nemo_rl/distributed/model_utils.py
@@ -30,6 +30,22 @@ if TYPE_CHECKING:
     from megatron.core.models.gpt import GPTModel
 
 
+def _get_world_size_or_1(group: Optional[torch.distributed.ProcessGroup]) -> int:
+    """Return the process-group world size, defaulting to 1 before dist init.
+
+    Delegates to ``torch.distributed.get_world_size(group)``; ``group=None``
+    resolves to the default process group's size, matching the semantics of the
+    collectives being guarded.
+    """
+    if (
+        not torch.distributed.is_available()
+        or not torch.distributed.is_initialized()
+    ):
+        return 1
+
+    return torch.distributed.get_world_size(group)
+
+
 def _compute_distributed_log_softmax_with_grad(
     vocab_parallel_logits: torch.Tensor, group: torch.distributed.ProcessGroup
 ) -> torch.Tensor:
@@ -47,22 +63,25 @@ def _compute_distributed_log_softmax_with_grad(
             the all-reduces).
     """
     logits_max = torch.amax(vocab_parallel_logits, dim=-1, keepdim=True).detach()
-    torch.distributed.all_reduce(
-        logits_max,
-        op=torch.distributed.ReduceOp.MAX,
-        group=group,
-    )
+    world_size = _get_world_size_or_1(group)
+    if world_size > 1:
+        torch.distributed.all_reduce(
+            logits_max,
+            op=torch.distributed.ReduceOp.MAX,
+            group=group,
+        )
 
     # Subtract the maximum value.
     vocab_parallel_logits = vocab_parallel_logits - logits_max
 
     sum_exp_logits = vocab_parallel_logits.exp().sum(-1, keepdim=True).float()
 
-    sum_exp_logits = torch.distributed.nn.functional.all_reduce(
-        sum_exp_logits,
-        op=torch.distributed.ReduceOp.SUM,
-        group=group,
-    )
+    if world_size > 1:
+        sum_exp_logits = torch.distributed.nn.functional.all_reduce(
+            sum_exp_logits,
+            op=torch.distributed.ReduceOp.SUM,
+            group=group,
+        )
 
     return vocab_parallel_logits - sum_exp_logits.log().to(vocab_parallel_logits.dtype)
 
@@ -96,22 +115,25 @@ def _compute_distributed_softmax(
         torch.Tensor: Softmax output with the same shape as input, normalized across the full vocabulary.
     """
     logits_max = torch.amax(vocab_parallel_logits, dim=-1, keepdim=True)
-    torch.distributed.all_reduce(
-        logits_max,
-        op=torch.distributed.ReduceOp.MAX,
-        group=group,
-    )
+    world_size = _get_world_size_or_1(group)
+    if world_size > 1:
+        torch.distributed.all_reduce(
+            logits_max,
+            op=torch.distributed.ReduceOp.MAX,
+            group=group,
+        )
 
     vocab_parallel_logits = vocab_parallel_logits - logits_max
 
     exp_logits = vocab_parallel_logits.exp_()
 
     sum_exp_logits = exp_logits.sum(-1, keepdim=True)
-    torch.distributed.all_reduce(
-        sum_exp_logits,
-        op=torch.distributed.ReduceOp.SUM,
-        group=group,
-    )
+    if world_size > 1:
+        torch.distributed.all_reduce(
+            sum_exp_logits,
+            op=torch.distributed.ReduceOp.SUM,
+            group=group,
+        )
     exp_logits.div_(sum_exp_logits)
 
     return exp_logits
@@ -146,11 +168,12 @@ class DistributedLogprob(torch.autograd.Function):
         log_probs = torch.gather(log_probs, -1, masked_target.unsqueeze(-1)).squeeze(-1)
         log_probs[target_mask] = 0.0
 
-        torch.distributed.all_reduce(
-            log_probs,
-            op=torch.distributed.ReduceOp.SUM,
-            group=group,
-        )
+        if _get_world_size_or_1(group) > 1:
+            torch.distributed.all_reduce(
+                log_probs,
+                op=torch.distributed.ReduceOp.SUM,
+                group=group,
+            )
 
         if not inference_only:
             # only save for backward when we have inference only=False
@@ -233,11 +256,12 @@ class DistributedCrossEntropy(torch.autograd.Function):
         local_cross_entropy = torch.einsum(
             "...v,...v->...", target_probs, student_log_probs
         ).neg_()
-        torch.distributed.all_reduce(
-            local_cross_entropy,
-            op=torch.distributed.ReduceOp.SUM,
-            group=group,
-        )
+        if _get_world_size_or_1(group) > 1:
+            torch.distributed.all_reduce(
+                local_cross_entropy,
+                op=torch.distributed.ReduceOp.SUM,
+                group=group,
+            )
 
         if not inference_only:
             student_probs = student_log_probs.exp_()
@@ -287,6 +311,7 @@ class ChunkedDistributedLogprob(torch.autograd.Function):
 
         seq_size = int(vocab_parallel_logits.shape[1])
         num_chunks = (seq_size + chunk_size - 1) // chunk_size
+        tp_world_size = _get_world_size_or_1(tp_group)
         all_log_probs = []
 
         for chunk_idx in range(num_chunks):
@@ -306,11 +331,12 @@ class ChunkedDistributedLogprob(torch.autograd.Function):
             ).squeeze(-1)
             log_probs[target_mask[:, chunk_start:chunk_end]] = 0.0
 
-            torch.distributed.all_reduce(
-                log_probs,
-                op=torch.distributed.ReduceOp.SUM,
-                group=tp_group,
-            )
+            if tp_world_size > 1:
+                torch.distributed.all_reduce(
+                    log_probs,
+                    op=torch.distributed.ReduceOp.SUM,
+                    group=tp_group,
+                )
 
             all_log_probs.append(log_probs)
 
@@ -737,6 +763,7 @@ class ChunkedDistributedGatherLogprob(torch.autograd.Function):
     ) -> torch.Tensor:
         B, S, V_local = vocab_parallel_logits.shape
         num_chunks = (int(S) + chunk_size - 1) // chunk_size
+        tp_world_size = _get_world_size_or_1(tp_group)
         out_chunks: list[torch.Tensor] = []
 
         for chunk_idx in range(num_chunks):
@@ -754,9 +781,10 @@ class ChunkedDistributedGatherLogprob(torch.autograd.Function):
             local_vals = torch.gather(log_probs, dim=-1, index=li)
             local_vals = local_vals * in_range.to(dtype=local_vals.dtype)
 
-            torch.distributed.all_reduce(
-                local_vals, op=torch.distributed.ReduceOp.SUM, group=tp_group
-            )
+            if tp_world_size > 1:
+                torch.distributed.all_reduce(
+                    local_vals, op=torch.distributed.ReduceOp.SUM, group=tp_group
+                )
 
             out_chunks.append(local_vals)
 
@@ -1761,6 +1789,7 @@ def gather_logits_at_global_indices(
     B, S, V_local = vocab_parallel_logits.shape
     if chunk_size is None:
         chunk_size = S
+    tp_world_size = _get_world_size_or_1(tp_group) if tp_group is not None else 1
 
     out_chunks: list[torch.Tensor] = []
     for s0 in range(0, S, chunk_size):
@@ -1777,7 +1806,7 @@ def gather_logits_at_global_indices(
         local_vals = torch.gather(logits_chunk, dim=-1, index=li)
         local_vals = local_vals * in_range.to(dtype=local_vals.dtype)
 
-        if tp_group is not None:
+        if tp_world_size > 1:
             torch.distributed.all_reduce(
                 local_vals, op=torch.distributed.ReduceOp.SUM, group=tp_group
             )
@@ -1983,6 +2012,7 @@ class ChunkedDistributedEntropy(torch.autograd.Function):
     ) -> torch.Tensor:
         B, S, _ = vocab_parallel_logits.shape
         num_chunks = (int(S) + chunk_size - 1) // chunk_size
+        tp_world_size = _get_world_size_or_1(tp_group)
         out_chunks: list[torch.Tensor] = []
 
         for chunk_idx in range(num_chunks):
@@ -1993,9 +2023,10 @@ class ChunkedDistributedEntropy(torch.autograd.Function):
             log_probs = _compute_distributed_log_softmax(logits, group=tp_group)
             softmax_output = log_probs.exp()
             H_local = (softmax_output * log_probs).sum(dim=-1)  # [B, Sc]
-            torch.distributed.all_reduce(
-                H_local, op=torch.distributed.ReduceOp.SUM, group=tp_group
-            )
+            if tp_world_size > 1:
+                torch.distributed.all_reduce(
+                    H_local, op=torch.distributed.ReduceOp.SUM, group=tp_group
+                )
             out_chunks.append(H_local)
 
         H_all = torch.cat(out_chunks, dim=1) if len(out_chunks) > 1 else out_chunks[0]
@@ -2018,6 +2049,7 @@ class ChunkedDistributedEntropy(torch.autograd.Function):
 
         B, S, V_local = vocab_parallel_logits.shape
         num_chunks = (int(S) + chunk_size - 1) // chunk_size
+        tp_world_size = _get_world_size_or_1(tp_group)
 
         grad_input: torch.Tensor = torch.empty_like(
             vocab_parallel_logits, dtype=torch.float32
@@ -2031,9 +2063,10 @@ class ChunkedDistributedEntropy(torch.autograd.Function):
             log_probs = _compute_distributed_log_softmax(logits, group=tp_group)
             softmax_output = log_probs.exp()
             H_local = (softmax_output * log_probs).sum(dim=-1)
-            torch.distributed.all_reduce(
-                H_local, op=torch.distributed.ReduceOp.SUM, group=tp_group
-            )
+            if tp_world_size > 1:
+                torch.distributed.all_reduce(
+                    H_local, op=torch.distributed.ReduceOp.SUM, group=tp_group
+                )
 
             # Inplace index into the preallocated grad_input tensor
             grad_input_chunk = grad_input[:, s0:s1, :]
@@ -2099,7 +2132,7 @@ class ChunkedDistributedHiddenStatesToLogprobs(torch.autograd.Function):
         target_mask = (target < vocab_start_index) | (target >= vocab_end_index)
         masked_target = target - vocab_start_index
         masked_target[target_mask] = 0
-        tp_group_size = torch.distributed.get_world_size(tp_group)
+        tp_group_size = _get_world_size_or_1(tp_group)
         if tp_group_size > 1:
             original_tensor_parallel_hidden_states = (
                 tensor_parallel_hidden_states.clone()
@@ -2142,11 +2175,12 @@ class ChunkedDistributedHiddenStatesToLogprobs(torch.autograd.Function):
             all_log_probs.append(log_probs)
 
         log_probs = torch.cat(all_log_probs, dim=1)
-        torch.distributed.all_reduce(
-            log_probs,
-            op=torch.distributed.ReduceOp.SUM,
-            group=tp_group,
-        )
+        if tp_group_size > 1:
+            torch.distributed.all_reduce(
+                log_probs,
+                op=torch.distributed.ReduceOp.SUM,
+                group=tp_group,
+            )
         if not inference_only:
             # only save for backward when we have inference only=False
             # save tensor_parallel_hidden_states and the output_layer to the context
@@ -2174,7 +2208,7 @@ class ChunkedDistributedHiddenStatesToLogprobs(torch.autograd.Function):
             output_weight_layer,
         ) = ctx.saved_tensors
         tp_group = ctx.tp_group
-        tp_group_size = torch.distributed.get_world_size(tp_group)
+        tp_group_size = _get_world_size_or_1(tp_group)
         if tp_group_size > 1:
             all_hidden_states = [
                 torch.zeros_like(tensor_parallel_hidden_states)
@@ -2244,12 +2278,15 @@ class ChunkedDistributedHiddenStatesToLogprobs(torch.autograd.Function):
         grad_input_hidden_states_list = list(
             torch.chunk(grad_input_hidden_states, chunks=tp_group_size, dim=0)
         )
-        torch.distributed.reduce_scatter(
-            sharded_grad_hidden_states,
-            grad_input_hidden_states_list,
-            op=torch.distributed.ReduceOp.SUM,
-            group=tp_group,
-        )
+        if tp_group_size > 1:
+            torch.distributed.reduce_scatter(
+                sharded_grad_hidden_states,
+                grad_input_hidden_states_list,
+                op=torch.distributed.ReduceOp.SUM,
+                group=tp_group,
+            )
+        else:
+            sharded_grad_hidden_states.copy_(grad_input_hidden_states_list[0])
 
         return (
             sharded_grad_hidden_states,

--- a/nemo_rl/distributed/model_utils.py
+++ b/nemo_rl/distributed/model_utils.py
@@ -37,10 +37,7 @@ def _get_world_size_or_1(group: Optional[torch.distributed.ProcessGroup]) -> int
     resolves to the default process group's size, matching the semantics of the
     collectives being guarded.
     """
-    if (
-        not torch.distributed.is_available()
-        or not torch.distributed.is_initialized()
-    ):
+    if not torch.distributed.is_available() or not torch.distributed.is_initialized():
         return 1
 
     return torch.distributed.get_world_size(group)

--- a/tests/unit/distributed/test_model_utils_tp1_collectives.py
+++ b/tests/unit/distributed/test_model_utils_tp1_collectives.py
@@ -1,0 +1,281 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from nemo_rl.distributed.model_utils import (
+    ChunkedDistributedEntropy,
+    ChunkedDistributedGatherLogprob,
+    ChunkedDistributedLogprob,
+    ChunkedDistributedHiddenStatesToLogprobs,
+    DistributedCrossEntropy,
+    DistributedLogprob,
+    _compute_distributed_log_softmax_with_grad,
+    _compute_distributed_softmax,
+    _get_world_size_or_1,
+)
+
+
+def _mock_distributed_world_size(monkeypatch: pytest.MonkeyPatch, world_size: int):
+    monkeypatch.setattr(torch.distributed, "is_available", lambda: True)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(
+        torch.distributed, "get_world_size", lambda group=None: world_size
+    )
+
+
+def _raise_if_called(*args, **kwargs):
+    raise AssertionError("collective should not be called for world size 1")
+
+
+def _forbid_collectives(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(torch.distributed, "all_reduce", _raise_if_called)
+    monkeypatch.setattr(torch.distributed, "reduce_scatter", _raise_if_called)
+    monkeypatch.setattr(torch.distributed, "all_gather", _raise_if_called)
+    monkeypatch.setattr(
+        torch.distributed.nn.functional, "all_reduce", _raise_if_called
+    )
+
+
+def test_world_size_helper_passes_none_to_default_group(monkeypatch):
+    seen_groups = []
+
+    monkeypatch.setattr(torch.distributed, "is_available", lambda: True)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+
+    def get_world_size(group=None):
+        seen_groups.append(group)
+        return 1
+
+    monkeypatch.setattr(torch.distributed, "get_world_size", get_world_size)
+
+    assert _get_world_size_or_1(None) == 1
+    assert seen_groups == [None]
+
+
+def test_distributed_log_softmax_skips_collectives_for_world_size_one(monkeypatch):
+    _mock_distributed_world_size(monkeypatch, world_size=1)
+    _forbid_collectives(monkeypatch)
+
+    logits = torch.randn(2, 3, 5, requires_grad=True)
+
+    actual = _compute_distributed_log_softmax_with_grad(logits, group=None)
+    expected = torch.log_softmax(logits, dim=-1)
+
+    torch.testing.assert_close(actual, expected)
+    actual.sum().backward()
+    assert logits.grad is not None
+
+
+def test_distributed_log_softmax_keeps_collectives_for_larger_world_size(
+    monkeypatch,
+):
+    _mock_distributed_world_size(monkeypatch, world_size=2)
+    calls = {"all_reduce": 0, "functional_all_reduce": 0}
+
+    def all_reduce(tensor, op=None, group=None):
+        calls["all_reduce"] += 1
+
+    def functional_all_reduce(tensor, op=None, group=None):
+        calls["functional_all_reduce"] += 1
+        return tensor
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", all_reduce)
+    monkeypatch.setattr(
+        torch.distributed.nn.functional, "all_reduce", functional_all_reduce
+    )
+
+    logits = torch.randn(2, 3, 5, requires_grad=True)
+    _compute_distributed_log_softmax_with_grad(logits, group=object())
+
+    assert calls == {"all_reduce": 1, "functional_all_reduce": 1}
+
+
+def test_distributed_softmax_skips_collectives_for_world_size_one(monkeypatch):
+    _mock_distributed_world_size(monkeypatch, world_size=1)
+    _forbid_collectives(monkeypatch)
+
+    logits = torch.randn(2, 3, 5)
+
+    actual = _compute_distributed_softmax(logits.clone(), group=None)
+    expected = torch.softmax(logits.float(), dim=-1)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_selected_logprob_and_cross_entropy_skip_collectives_for_world_size_one(
+    monkeypatch,
+):
+    _mock_distributed_world_size(monkeypatch, world_size=1)
+    _forbid_collectives(monkeypatch)
+
+    logits = torch.randn(2, 3, 5)
+    target = torch.tensor([[0, 2, 4], [1, 3, 0]])
+
+    actual_logprobs = DistributedLogprob.apply(
+        logits, target, 0, logits.shape[-1], None, True
+    )
+    expected_logprobs = torch.gather(
+        torch.log_softmax(logits.float(), dim=-1), -1, target.unsqueeze(-1)
+    ).squeeze(-1)
+    torch.testing.assert_close(actual_logprobs, expected_logprobs)
+
+    student_logits = torch.randn(2, 3, 5)
+    target_logits = torch.randn(2, 3, 5)
+    actual_ce = DistributedCrossEntropy.apply(student_logits, target_logits, None, True)
+    expected_ce = -(
+        torch.softmax(target_logits.float(), dim=-1)
+        * torch.log_softmax(student_logits.float(), dim=-1)
+    ).sum(dim=-1)
+    torch.testing.assert_close(actual_ce, expected_ce)
+
+
+def test_chunked_distributed_logprob_skips_collectives_for_world_size_one(
+    monkeypatch,
+):
+    _mock_distributed_world_size(monkeypatch, world_size=1)
+    _forbid_collectives(monkeypatch)
+
+    logits = torch.randn(2, 4, 5, requires_grad=True)
+    target = torch.tensor([[0, 2, 4, 1], [1, 3, 0, 2]])
+
+    actual = ChunkedDistributedLogprob.apply(
+        logits, target, 0, logits.shape[-1], 2, None, False
+    )
+    expected = torch.gather(
+        torch.log_softmax(logits.float(), dim=-1), -1, target.unsqueeze(-1)
+    ).squeeze(-1)
+    torch.testing.assert_close(actual, expected)
+
+    actual.sum().backward()
+    assert logits.grad is not None
+
+
+def test_chunked_gather_and_entropy_skip_collectives_for_world_size_one(monkeypatch):
+    _mock_distributed_world_size(monkeypatch, world_size=1)
+    _forbid_collectives(monkeypatch)
+
+    logits = torch.randn(2, 4, 6, requires_grad=True)
+    global_indices = torch.tensor(
+        [
+            [[0, 2], [1, 3], [4, 5], [0, 1]],
+            [[5, 4], [3, 2], [1, 0], [2, 4]],
+        ]
+    )
+
+    gathered = ChunkedDistributedGatherLogprob.apply(
+        logits, global_indices, 0, logits.shape[-1], 2, None, True
+    )
+    expected_gathered = torch.gather(
+        torch.log_softmax(logits.float(), dim=-1), -1, global_indices
+    )
+    torch.testing.assert_close(gathered, expected_gathered)
+
+    entropy = ChunkedDistributedEntropy.apply(logits, 2, None, False)
+    log_probs = torch.log_softmax(logits.float(), dim=-1)
+    expected_entropy = (log_probs.exp() * log_probs).sum(dim=-1)
+    torch.testing.assert_close(entropy, expected_entropy)
+
+    entropy.sum().backward()
+    assert logits.grad is not None
+
+
+def test_hidden_state_logprob_skips_all_gather_all_reduce_and_reduce_scatter_tp1(
+    monkeypatch,
+):
+    _mock_distributed_world_size(monkeypatch, world_size=1)
+    _forbid_collectives(monkeypatch)
+
+    hidden_states = torch.randn(3, 2, 4, requires_grad=True)
+    output_weight = torch.randn(5, 4, requires_grad=True)
+    target = torch.tensor([[0, 2, 4], [1, 3, 0]])
+
+    actual = ChunkedDistributedHiddenStatesToLogprobs.apply(
+        hidden_states,
+        target,
+        output_weight,
+        0,
+        output_weight.shape[0],
+        2,
+        None,
+        False,
+    )
+    logits = torch.matmul(hidden_states, output_weight.T).float().transpose(0, 1)
+    expected = torch.gather(
+        torch.log_softmax(logits, dim=-1), -1, target.unsqueeze(-1)
+    ).squeeze(-1)
+    torch.testing.assert_close(actual, expected)
+
+    actual.sum().backward()
+
+    assert hidden_states.grad is not None
+    assert output_weight.grad is not None
+
+
+def test_hidden_state_logprob_keeps_collectives_for_world_size_two(monkeypatch):
+    _mock_distributed_world_size(monkeypatch, world_size=2)
+    calls = {
+        "all_gather": 0,
+        "all_reduce": 0,
+        "functional_all_reduce": 0,
+        "reduce_scatter": 0,
+    }
+
+    def all_gather(output_tensors, tensor, group=None):
+        for output_tensor in output_tensors:
+            output_tensor.copy_(tensor)
+        calls["all_gather"] += 1
+
+    def all_reduce(tensor, op=None, group=None):
+        calls["all_reduce"] += 1
+
+    def functional_all_reduce(tensor, op=None, group=None):
+        calls["functional_all_reduce"] += 1
+        return tensor
+
+    def reduce_scatter(output, input_list, op=None, group=None):
+        output.copy_(input_list[0])
+        calls["reduce_scatter"] += 1
+
+    monkeypatch.setattr(torch.distributed, "all_gather", all_gather)
+    monkeypatch.setattr(torch.distributed, "all_reduce", all_reduce)
+    monkeypatch.setattr(torch.distributed, "reduce_scatter", reduce_scatter)
+    monkeypatch.setattr(
+        torch.distributed.nn.functional, "all_reduce", functional_all_reduce
+    )
+
+    hidden_states = torch.randn(2, 2, 4, requires_grad=True)
+    output_weight = torch.randn(6, 4, requires_grad=True)
+    target = torch.tensor([[0, 2, 4, 1], [1, 3, 0, 2]])
+
+    actual = ChunkedDistributedHiddenStatesToLogprobs.apply(
+        hidden_states,
+        target,
+        output_weight,
+        0,
+        output_weight.shape[0],
+        2,
+        object(),
+        False,
+    )
+
+    actual.sum().backward()
+
+    assert hidden_states.grad is not None
+    assert output_weight.grad is not None
+    assert calls["all_gather"] == 2
+    assert calls["all_reduce"] >= 1
+    assert calls["functional_all_reduce"] >= 1
+    assert calls["reduce_scatter"] == 1

--- a/tests/unit/distributed/test_model_utils_tp1_collectives.py
+++ b/tests/unit/distributed/test_model_utils_tp1_collectives.py
@@ -18,8 +18,8 @@ import torch
 from nemo_rl.distributed.model_utils import (
     ChunkedDistributedEntropy,
     ChunkedDistributedGatherLogprob,
-    ChunkedDistributedLogprob,
     ChunkedDistributedHiddenStatesToLogprobs,
+    ChunkedDistributedLogprob,
     DistributedCrossEntropy,
     DistributedLogprob,
     _compute_distributed_log_softmax_with_grad,
@@ -44,9 +44,7 @@ def _forbid_collectives(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(torch.distributed, "all_reduce", _raise_if_called)
     monkeypatch.setattr(torch.distributed, "reduce_scatter", _raise_if_called)
     monkeypatch.setattr(torch.distributed, "all_gather", _raise_if_called)
-    monkeypatch.setattr(
-        torch.distributed.nn.functional, "all_reduce", _raise_if_called
-    )
+    monkeypatch.setattr(torch.distributed.nn.functional, "all_reduce", _raise_if_called)
 
 
 def test_world_size_helper_passes_none_to_default_group(monkeypatch):


### PR DESCRIPTION
## Summary

Skips tensor-parallel collectives when the tensor-parallel process group has world size 1.

## Motivation

For TP=1 runs, these collectives are mathematical no-ops. Guarding them avoids unnecessary distributed backend calls in common single-TP configurations while preserving existing behavior for TP>1.

## Changes

- Adds `_get_world_size_or_1()` to safely query process-group size, defaulting to 1 before distributed initialization.
- Skips no-op TP `all_reduce` calls in distributed log-softmax, softmax, selected logprob, cross-entropy, gather-logprob, entropy, and hidden-state logprob paths.
- Replaces the TP=1 `reduce_scatter` path in hidden-state logprob backward with a direct copy.
- Adds CPU-only mock tests for TP=1 skip behavior, `group=None` default-group handling, and TP>1 collective preservation on the highest-risk hidden-state path.

## Safety

The skipped collectives are identity operations when world size is 1. For `group=None`, the helper delegates to `torch.distributed.get_world_size(None)` after distributed initialization, preserving default process-group semantics.

The touched sites do not rely on TP=1 collectives as synchronization barriers; follow-up work is local tensor math or direct copies. TP>1 paths still call the same collectives as before.

## Testing

- `ruff check --fix nemo_rl/distributed/model_utils.py tests/unit/distributed/test_model_utils_tp1_collectives.py`
- `python -m pytest tests/unit/distributed/test_model_utils_tp1_collectives.py`

Result: `9 passed`.