### PR TITLE
fix: rebuild async GRPO dataloaders inside Ray collectors

### DIFF
--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -18,7 +18,7 @@ import concurrent.futures
 import threading as _threading
 import time
 from collections import defaultdict
-from typing import Any, Optional
+from typing import Any, Optional, TypedDict
 
 import ray
 import torch
@@ -27,6 +27,7 @@ from transformers import PreTrainedTokenizerBase
 
 from nemo_rl.algorithms.grpo import MasterConfig
 from nemo_rl.algorithms.opd import resolve_reference_aliases, teacher_seq_pad_multiple
+from nemo_rl.data.collate_fn import rl_collate_fn
 from nemo_rl.data.interfaces import DatumSpec
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.environments.interfaces import EnvironmentInterface
@@ -36,6 +37,13 @@ from nemo_rl.experience.rollouts import (
 from nemo_rl.models.generation.interfaces import GenerationInterface
 
 TokenizerType = PreTrainedTokenizerBase
+
+
+class AsyncCollectorDataloaderConfig(TypedDict):
+    batch_size: int
+    shuffle: bool
+    drop_last: bool
+    num_workers: int
 
 
 @ray.remote  # pragma: no cover
@@ -233,10 +241,38 @@ class AsyncTrajectoryCollector:
         except Exception:
             return False
 
-    def start_collection(self, dataloader: StatefulDataLoader) -> None:
+    def _build_dataloader(
+        self,
+        raw_data: list[DatumSpec],
+        dataloader_config: AsyncCollectorDataloaderConfig,
+        dataloader_state: Optional[dict[str, Any]] = None,
+    ) -> StatefulDataLoader:
+        """Build the collector-local dataloader from Ray-serializable inputs."""
+        dataloader = StatefulDataLoader(
+            raw_data,
+            batch_size=dataloader_config["batch_size"],
+            shuffle=dataloader_config["shuffle"],
+            collate_fn=rl_collate_fn,
+            drop_last=dataloader_config["drop_last"],
+            num_workers=dataloader_config["num_workers"],
+        )
+        if dataloader_state is not None:
+            dataloader.load_state_dict(dataloader_state)
+        return dataloader
+
+    def start_collection(
+        self,
+        raw_data: list[DatumSpec],
+        dataloader_config: AsyncCollectorDataloaderConfig,
+        dataloader_state: Optional[dict[str, Any]] = None,
+    ) -> None:
         """Start collecting trajectories from dataloader."""
         self.running = True
-        self.dataloader = dataloader
+        self.dataloader = self._build_dataloader(
+            raw_data,
+            dataloader_config,
+            dataloader_state,
+        )
 
         print("Started continuous trajectory collection")
 

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -292,6 +292,52 @@ class MasterConfig(BaseModel, extra="allow"):
     on_policy_distillation: Optional[OnPolicyDistillationConfig] = None
 
 
+def _materialize_dataset_for_ray(dataset: Any) -> list[Any]:
+    """Materialize dataset rows before sending them to a Ray actor."""
+    return list(dataset)
+
+
+def _get_async_collector_dataloader_config(
+    dataloader: StatefulDataLoader,
+    master_config: MasterConfig,
+) -> dict[str, Any]:
+    """Mirror GRPO train dataloader kwargs for actor-side reconstruction."""
+    grpo_config = master_config.grpo
+    data_config = master_config.data
+
+    batch_size = int(grpo_config["num_prompts_per_step"])
+    if grpo_config["use_dynamic_sampling"]:
+        batch_size = int(batch_size * grpo_config["batch_multiplier"])
+    dataloader_batch_size = getattr(dataloader, "batch_size", None)
+    if dataloader_batch_size is not None:
+        batch_size = int(dataloader_batch_size)
+
+    return {
+        "batch_size": batch_size,
+        "shuffle": data_config["shuffle"],
+        "drop_last": True,
+        "num_workers": data_config["num_workers"],
+    }
+
+
+def _get_async_collector_dataloader_payload(
+    dataloader: StatefulDataLoader,
+    master_config: MasterConfig,
+) -> tuple[list[Any], dict[str, Any], dict[str, Any]]:
+    """Return Ray-serializable dataset rows, dataloader config, and state."""
+    if not isinstance(dataloader, StatefulDataLoader):
+        raise NotImplementedError(
+            "Async GRPO Ray-safe dataloader handoff currently supports plain "
+            "StatefulDataLoader only. MultipleDataloaderWrapper reconstruction "
+            "inside the collector actor is not implemented."
+        )
+    return (
+        _materialize_dataset_for_ray(dataloader.dataset),
+        _get_async_collector_dataloader_config(dataloader, master_config),
+        dataloader.state_dict(),
+    )
+
+
 # ===============================================================================
 # Setup & Initialization
 # ===============================================================================
@@ -3495,6 +3541,13 @@ def async_grpo_train(
             "has not been merged yet."
         )
 
+    if master_config.data["use_multiple_dataloader"]:
+        raise NotImplementedError(
+            "Async GRPO Ray-safe dataloader handoff currently supports a single "
+            "training dataloader. Multiple dataloaders require actor-side "
+            "MultipleDataloaderWrapper reconstruction."
+        )
+
     if master_config.grpo["async_grpo"]["max_trajectory_age_steps"] > 1:
         if not master_config.grpo["async_grpo"].get("in_flight_weight_updates", False):
             print(
@@ -3649,8 +3702,14 @@ def async_grpo_train(
         on_policy_distillation_cfg=opd_module._opd_cfg(master_config),
     )
 
+    raw_data, dataloader_config, dataloader_state = (
+        _get_async_collector_dataloader_payload(dataloader, master_config)
+    )
+
     # Start trajectory collection in background
-    collection_task = trajectory_collector.start_collection.remote(dataloader)
+    collection_task = trajectory_collector.start_collection.remote(
+        raw_data, dataloader_config, dataloader_state
+    )
 
     # Ensure collector knows initial weight version
     trajectory_collector.set_weight_version.remote(weight_version)

--- a/tests/unit/algorithms/test_async_utils.py
+++ b/tests/unit/algorithms/test_async_utils.py
@@ -1331,9 +1331,7 @@ class TestAsyncTrajectoryCollector:
         )
 
         assert dataloader.loaded_state is dataloader_state
-        assert (
-            dataloader.kwargs["collate_fn"] is trajectory_collector_mod.rl_collate_fn
-        )
+        assert dataloader.kwargs["collate_fn"] is trajectory_collector_mod.rl_collate_fn
 
     def test_get_dataloader_state_returns_rebuilt_dataloader_state(self, monkeypatch):
         """Checkpoint state comes from the dataloader rebuilt in the actor."""
@@ -1368,9 +1366,7 @@ class TestAsyncTrajectoryCollector:
             dataloader_state,
         )
 
-        assert collector.get_dataloader_state() == {
-            "loaded_state": dataloader_state
-        }
+        assert collector.get_dataloader_state() == {"loaded_state": dataloader_state}
 
     def test_maybe_release_target_waits_for_spawning_to_close(self):
         """Test fast workers do not release a target while spawning is open."""

--- a/tests/unit/algorithms/test_async_utils.py
+++ b/tests/unit/algorithms/test_async_utils.py
@@ -1262,6 +1262,116 @@ class TestAsyncTrajectoryCollector:
         ray.kill(buffer)
         ray.kill(mock_env)
 
+    def test_build_dataloader_from_serializable_records(self):
+        """Collector rebuilds a StatefulDataLoader from plain records."""
+        collector = self.create_local_collector()
+        raw_data = [
+            {
+                "message_log": [{"role": "user", "content": "a"}],
+                "length": 1,
+                "loss_multiplier": 1.0,
+                "extra_env_info": {"id": 0},
+                "task_name": "test",
+                "idx": 0,
+            },
+            {
+                "message_log": [{"role": "user", "content": "b"}],
+                "length": 2,
+                "loss_multiplier": 1.0,
+                "extra_env_info": {"id": 1},
+                "task_name": "test",
+                "idx": 1,
+            },
+        ]
+
+        dataloader = collector._build_dataloader(
+            raw_data,
+            {
+                "batch_size": 2,
+                "shuffle": False,
+                "drop_last": False,
+                "num_workers": 0,
+            },
+        )
+        batch = next(iter(dataloader))
+
+        assert batch["idx"] == [0, 1]
+        assert batch["task_name"] == ["test", "test"]
+        assert batch["length"].tolist() == [1, 2]
+
+    def test_build_dataloader_loads_initial_state(self, monkeypatch):
+        """Collector forwards the initial dataloader state when rebuilding."""
+
+        class RecordingLoader:
+            def __init__(self, dataset, **kwargs):
+                self.dataset = dataset
+                self.kwargs = kwargs
+                self.loaded_state = None
+
+            def load_state_dict(self, state):
+                self.loaded_state = state
+
+        monkeypatch.setattr(
+            trajectory_collector_mod,
+            "StatefulDataLoader",
+            RecordingLoader,
+        )
+        collector = self.create_local_collector()
+        dataloader_state = {"cursor": 3}
+
+        dataloader = collector._build_dataloader(
+            [{"idx": 0}],
+            {
+                "batch_size": 1,
+                "shuffle": False,
+                "drop_last": False,
+                "num_workers": 0,
+            },
+            dataloader_state,
+        )
+
+        assert dataloader.loaded_state is dataloader_state
+        assert (
+            dataloader.kwargs["collate_fn"] is trajectory_collector_mod.rl_collate_fn
+        )
+
+    def test_get_dataloader_state_returns_rebuilt_dataloader_state(self, monkeypatch):
+        """Checkpoint state comes from the dataloader rebuilt in the actor."""
+
+        class RecordingLoader:
+            def __init__(self, dataset, **kwargs):
+                self.dataset = dataset
+                self.kwargs = kwargs
+                self.loaded_state = None
+
+            def load_state_dict(self, state):
+                self.loaded_state = state
+
+            def state_dict(self):
+                return {"loaded_state": self.loaded_state}
+
+        monkeypatch.setattr(
+            trajectory_collector_mod,
+            "StatefulDataLoader",
+            RecordingLoader,
+        )
+        collector = self.create_local_collector()
+        dataloader_state = {"cursor": 5}
+        collector.dataloader = collector._build_dataloader(
+            [{"idx": 0}],
+            {
+                "batch_size": 1,
+                "shuffle": False,
+                "drop_last": False,
+                "num_workers": 0,
+            },
+            dataloader_state,
+        )
+
+        assert collector.get_dataloader_state() == {
+            "loaded_state": dataloader_state
+        }
+
     def test_maybe_release_target_waits_for_spawning_to_close(self):
         """Test fast workers do not release a target while spawning is open."""
         collector = self.create_local_collector()

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -1710,9 +1710,7 @@ def test_async_collector_dataloader_payload_materializes_dataset(
     dataloader = StatefulDataLoader(records, batch_size=4, shuffle=False)
 
     raw_data, dataloader_config, dataloader_state = (
-        grpo_mod._get_async_collector_dataloader_payload(
-            dataloader, master_config
-        )
+        grpo_mod._get_async_collector_dataloader_payload(dataloader, master_config)
     )
 
     assert raw_data == list(records)

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -48,6 +48,7 @@ from nemo_rl.algorithms.reward_functions import (
     apply_reward_shaping,
 )
 from nemo_rl.algorithms.utils import calculate_baseline_and_std_per_prompt
+from nemo_rl.data.dataloader import MultipleDataloaderWrapper
 from nemo_rl.data.interfaces import DatumSpec, LLMMessageLogType
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.environments.interfaces import (
@@ -1684,6 +1685,61 @@ def test_setup_auto_enables_skip_reference_policy_logprobs_when_kl_penalty_zero(
     grpo_mod.setup(master_config, tokenizer, dataset, None)
 
     assert master_config.grpo["skip_reference_policy_logprobs_calculation"] is True
+
+
+def test_async_collector_dataloader_payload_materializes_dataset(
+    mock_grpo_components,
+):
+    from nemo_rl.algorithms import grpo as grpo_mod
+
+    records = (
+        {
+            "message_log": [{"role": "user", "content": "a"}],
+            "length": 1,
+            "loss_multiplier": 1.0,
+            "extra_env_info": {},
+            "task_name": "test",
+            "idx": 0,
+        },
+    )
+
+    master_config = mock_grpo_components["master_config"]
+    master_config.data["shuffle"] = True
+    master_config.data["num_workers"] = 0
+    master_config.grpo["use_dynamic_sampling"] = False
+    dataloader = StatefulDataLoader(records, batch_size=4, shuffle=False)
+
+    raw_data, dataloader_config, dataloader_state = (
+        grpo_mod._get_async_collector_dataloader_payload(
+            dataloader, master_config
+        )
+    )
+
+    assert raw_data == list(records)
+    assert dataloader_config == {
+        "batch_size": 4,
+        "shuffle": True,
+        "drop_last": True,
+        "num_workers": 0,
+    }
+    assert isinstance(dataloader_state, dict)
+
+
+def test_async_collector_dataloader_payload_rejects_wrapped_dataloader(
+    mock_grpo_components,
+):
+    from nemo_rl.algorithms import grpo as grpo_mod
+
+    wrapped_dataloader = MagicMock(spec=MultipleDataloaderWrapper)
+    master_config = mock_grpo_components["master_config"]
+
+    with pytest.raises(
+        NotImplementedError,
+        match="MultipleDataloaderWrapper reconstruction",
+    ):
+        grpo_mod._get_async_collector_dataloader_payload(
+            wrapped_dataloader, master_config
+        )
 
 
 def test_grpo_train_collects_generation_logger_and_seq_metrics(


### PR DESCRIPTION
## Summary

This PR updates async GRPO trajectory collection so the Ray collector actor rebuilds its training `StatefulDataLoader` locally from serializable dataset records, dataloader config, and dataloader state.

## Motivation

Async GRPO runs trajectory collection inside a Ray actor. Passing a live `StatefulDataLoader` through Ray can also pass along dataset internals such as memory-mapped Arrow/Hugging Face state. Those handles are process-local and can fail or behave poorly after Ray serialization.

Instead, this PR sends plain dataset records plus the small set of dataloader settings needed to reconstruct the loader inside the collector actor.

## Changes

- Materializes the training dataset into Ray-serializable records before starting async collection.
- Passes dataloader config separately:
  - `batch_size`
  - `shuffle`
  - `drop_last`
  - `num_workers`
- Passes the current dataloader state so checkpoint/resume behavior is preserved.
- Rebuilds `StatefulDataLoader` inside `AsyncTrajectoryCollector` using `rl_collate_fn`.
- Keeps `get_dataloader_state()` returning the actor-local dataloader state for checkpointing.
- Adds an explicit `NotImplementedError` for multiple-dataloader async mode until actor-side `MultipleDataloaderWrapper` reconstruction is implemented.

## Testing

- `ruff check --fix nemo_rl/algorithms/grpo.py nemo_rl/algorithms/async_utils/trajectory_collector.py tests/unit/algorithms/test_grpo.py tests/unit/algorithms/test_async_utils.py`
- `python -m pytest tests/unit/algorithms/test_async_utils.py::TestAsyncTrajectoryCollector::test_build_dataloader_from_serializable_records tests/unit/algorithms/test_async_utils.py::TestAsyncTrajectoryCollector::test_build_dataloader_loads_initial_state tests/unit/algorithms/test_async_utils.py::TestAsyncTrajectoryCollector::test_get_dataloader_state_returns_rebuilt_dataloader_state tests/unit/algorithms/test_grpo.py::test_async_collector_dataloader_payload_materializes_dataset tests/unit/algorithms/test_grpo.py::test_async_collector_dataloader_payload_rejects_wrapped_dataloader -v`
  - `5 passed`