### PR TITLE
feat: support fused selected-token logprobs for AutoModel

### DIFF
--- a/docs/guides/dpo.md
+++ b/docs/guides/dpo.md
@@ -237,20 +237,34 @@ During standard DPO training the model materializes a full logit tensor of shape
 
 **How to enable:**
 
-Add the following to your Megatron config in your YAML file:
+For Megatron, add the following to your YAML file:
 
 ```yaml
 policy:
   megatron_cfg:
     enabled: true
     use_fused_linear_logprobs: true
-    fused_linear_logprobs_chunk_size: 256  # tokens per chunk; smaller = less memory, larger = more throughput
+    fused_linear_logprobs_chunk_size: 256
 ```
+
+For AutoModel, set the equivalent top-level policy keys:
+
+```yaml
+policy:
+  dtensor_cfg:
+    enabled: true
+  use_fused_linear_logprobs: true
+  fused_linear_logprobs_chunk_size: 256
+```
+
+**Limitations:**
+
+- Context parallelism is not supported when fused linear logprobs are enabled.
+- Sequence packing and top-k/top-p training-time filtering are not supported.
+- Sequence packing is not supported with DPO regardless of this setting (see [#719](https://github.com/NVIDIA-NeMo/RL/issues/719)).
 
 **Notes:**
 
-- Context parallelism is not supported when fused linear logprobs are enabled.
-- Sequence packing is not supported with DPO regardless of this setting (see [#719](https://github.com/NVIDIA-NeMo/RL/issues/719)).
 - The `fused_linear_logprobs_chunk_size` parameter controls the trade-off between memory savings and compute throughput. The default value of 256 is a good starting point.
 
 ## Evaluate the Trained Model

--- a/docs/guides/grpo.md
+++ b/docs/guides/grpo.md
@@ -382,22 +382,35 @@ This works for GRPO because [ClippedPGLossFn](../../nemo_rl/algorithms/loss/loss
 
 **How to enable:**
 
-Add the following to your Megatron config in your YAML file:
+For Megatron, add the following to your YAML file:
 
 ```yaml
 policy:
   megatron_cfg:
     enabled: true
     use_fused_linear_logprobs: true
-    fused_linear_logprobs_chunk_size: 256  # tokens per chunk; smaller = less memory, larger = more throughput
+    fused_linear_logprobs_chunk_size: 256
 ```
 
-**Notes:**
+For AutoModel, set the equivalent top-level policy keys:
 
-- Only supported on the Megatron backend (`policy.megatron_cfg.enabled: true`).
+```yaml
+policy:
+  dtensor_cfg:
+    enabled: true
+  use_fused_linear_logprobs: true
+  fused_linear_logprobs_chunk_size: 256
+```
+
+**Limitations:**
+
 - Context parallelism is not supported when fused linear logprobs are enabled.
 - Sequence packing is not supported with fused linear logprobs; set `policy.sequence_packing.enabled: false`. The fused forward rolls labels over the whole packed sequence and would mix tokens across packed-sequence boundaries.
 - Top-k/top-p training-time filtering is not supported with fused linear logprobs (set `policy.generation.top_k: null` and `policy.generation.top_p: 1.0`), because the fused path gathers logprobs from the unfiltered logits.
+
+**Notes:**
+
+- Supported on the Megatron and AutoModel backends.
 - The `fused_linear_logprobs_chunk_size` parameter controls the trade-off between memory savings and compute throughput. The default value of 256 is a good starting point.
 
 ## Loss

--- a/docs/guides/sft.md
+++ b/docs/guides/sft.md
@@ -282,18 +282,32 @@ During standard SFT training the model materializes a full logit tensor of shape
 
 **How to enable:**
 
-Add the following to your Megatron config in your YAML file:
+For Megatron, add the following to your YAML file:
 
 ```yaml
 policy:
   megatron_cfg:
     enabled: true
     use_fused_linear_logprobs: true
-    fused_linear_logprobs_chunk_size: 256  # tokens per chunk; smaller = less memory, larger = more throughput
+    fused_linear_logprobs_chunk_size: 256
 ```
+
+For AutoModel, set the equivalent top-level policy keys:
+
+```yaml
+policy:
+  dtensor_cfg:
+    enabled: true
+  use_fused_linear_logprobs: true
+  fused_linear_logprobs_chunk_size: 256
+```
+
+**Limitations:**
+
+- Context parallelism is not supported when fused linear logprobs are enabled.
+- Sequence packing and top-k/top-p training-time filtering are not supported.
 
 **Notes:**
 
 - This optimization applies to SFT training with `NLLLoss` and DPO training. See the [DPO guide](dpo.md#chunked-fused-linear-logprobs) for DPO-specific details.
-- Context parallelism is not supported when fused linear logprobs are enabled.
 - The `fused_linear_logprobs_chunk_size` parameter controls the trade-off between memory savings and compute throughput. The default value of 256 is a good starting point.

--- a/nemo_rl/models/automodel/setup.py
+++ b/nemo_rl/models/automodel/setup.py
@@ -64,7 +64,10 @@ from transformers import (
     PreTrainedTokenizerBase,
 )
 
-from nemo_rl.algorithms.logits_sampling_utils import TrainingSamplingParams
+from nemo_rl.algorithms.logits_sampling_utils import (
+    TrainingSamplingParams,
+    need_top_k_or_top_p_filtering,
+)
 from nemo_rl.data.chat_templates import COMMON_CHAT_TEMPLATES
 from nemo_rl.models.automodel.config import (
     DistributedContext,
@@ -294,6 +297,7 @@ def validate_and_prepare_config(
     max_grad_norm = config["max_grad_norm"]
     enable_seq_packing = config["sequence_packing"]["enabled"]
     model_name = config["model_name"]
+    use_fused_linear_logprobs = config.get("use_fused_linear_logprobs", False)
 
     # Validate sequence packing
     if enable_seq_packing:
@@ -392,6 +396,29 @@ def validate_and_prepare_config(
             "[WARNING]: sequence_parallel=True, but tp_size=1 which has no effect. "
             "Enable tp_size > 1 to use sequence parallelism."
         )
+
+    if use_fused_linear_logprobs:
+        chunk_size = config.get(
+            "fused_linear_logprobs_chunk_size", config.get("logprob_chunk_size", None)
+        )
+        if chunk_size is None:
+            raise ValueError(
+                "policy.use_fused_linear_logprobs requires "
+                "policy.fused_linear_logprobs_chunk_size or "
+                "policy.logprob_chunk_size."
+            )
+        if enable_seq_packing:
+            raise ValueError(
+                "policy.use_fused_linear_logprobs is not supported with sequence packing."
+            )
+        if cp_size > 1:
+            raise ValueError(
+                "policy.use_fused_linear_logprobs is not supported with context parallelism."
+            )
+        if need_top_k_or_top_p_filtering(sampling_params):
+            raise ValueError(
+                "policy.use_fused_linear_logprobs is not supported with top-k/top-p filtering."
+            )
 
     return RuntimeConfig(
         model_class=model_class,
@@ -571,6 +598,98 @@ def _disable_automodel_checkpoint_dtype_restore() -> None:
     # real behavior even after this no-op has globally replaced the symbol process-wide.
     _noop._nrl_original = restore
     _model_init._restore_loaded_model_dtype = _noop
+
+
+def _get_module_by_path(model: torch.nn.Module, module_path: str) -> torch.nn.Module:
+    module: Any = model
+    for part in module_path.split("."):
+        module = getattr(module, part, None)
+        if module is None:
+            raise AttributeError(f"Could not resolve module path {module_path!r}")
+    return module
+
+
+def _setup_fused_linear_logprobs_for_automodel(
+    model: torch.nn.Module,
+    config: PolicyConfig,
+    device_mesh: Any,
+) -> None:
+    """Configure AutoModel selected-token logprob fusion when explicitly enabled.
+
+    The fused path captures the hidden states entering the LM head and lets the
+    training loop compute selected next-token logprobs from hidden states plus
+    output weights. It stores only lightweight metadata on the model to avoid
+    registering duplicate LM-head modules.
+    """
+    if not config.get("use_fused_linear_logprobs", False):
+        return
+
+    chunk_size = config.get(
+        "fused_linear_logprobs_chunk_size", config.get("logprob_chunk_size", None)
+    )
+    if chunk_size is None:
+        raise ValueError(
+            "policy.use_fused_linear_logprobs requires "
+            "policy.fused_linear_logprobs_chunk_size or policy.logprob_chunk_size."
+        )
+
+    lm_head_path = None
+    lm_head = None
+    for candidate_path in ("lm_head", "language_model.lm_head", "model.lm_head"):
+        try:
+            candidate = _get_module_by_path(model, candidate_path)
+        except AttributeError:
+            continue
+        if hasattr(candidate, "weight"):
+            lm_head_path = candidate_path
+            lm_head = candidate
+            break
+
+    if lm_head_path is None or lm_head is None:
+        raise RuntimeError(
+            "policy.use_fused_linear_logprobs=True but no LM head with a "
+            "weight was found. Tried lm_head, language_model.lm_head, and "
+            "model.lm_head."
+        )
+
+    model._use_fused_linear_logprobs = True
+    model._fused_linear_logprobs_lm_head_path = lm_head_path
+    model._fused_linear_logprobs_chunk_size = int(chunk_size)
+    model._fused_linear_logprobs_tp_group = device_mesh["tp"].get_group()
+    model._fused_linear_logprobs_hidden_states = None
+
+    if getattr(lm_head, "_fused_linear_logprobs_installed", False):
+        return
+
+    def _capture_hidden_states(_module, args, kwargs):
+        hidden_states = args[0] if args else kwargs.get("input", None)
+        if hidden_states is not None:
+            model._fused_linear_logprobs_hidden_states = hidden_states
+        return None
+
+    lm_head.register_forward_pre_hook(_capture_hidden_states, with_kwargs=True)
+    original_forward = lm_head.forward
+
+    def _forward_with_optional_skip(*args, **kwargs):
+        if getattr(model, "_skip_lm_head_for_fused_linear_logprobs", False) or getattr(
+            lm_head, "_skip_lm_head_for_fused_linear_logprobs", False
+        ):
+            if args:
+                hidden_states = args[0]
+            elif "input" in kwargs:
+                hidden_states = kwargs["input"]
+            elif kwargs:
+                hidden_states = next(iter(kwargs.values()))
+            else:
+                return original_forward(*args, **kwargs)
+            if torch.is_tensor(hidden_states):
+                return hidden_states.new_zeros(1)
+            return original_forward(*args, **kwargs)
+        return original_forward(*args, **kwargs)
+
+    lm_head._fused_linear_logprobs_original_forward = original_forward
+    lm_head.forward = _forward_with_optional_skip
+    lm_head._fused_linear_logprobs_installed = True
 
 
 def setup_model_and_optimizer(
@@ -863,6 +982,12 @@ def setup_model_and_optimizer(
         print(
             "No weights path provided. Loaded base HF weights via from_pretrained (default policy init)"
         )
+
+    _setup_fused_linear_logprobs_for_automodel(
+        model=model,
+        config=config,
+        device_mesh=distributed_context.device_mesh,
+    )
 
     return ModelAndOptimizerState(
         model=model,

--- a/nemo_rl/models/automodel/train.py
+++ b/nemo_rl/models/automodel/train.py
@@ -271,9 +271,7 @@ def _lm_head_weight_for_fused_linear_logprobs(
             "does not expose a weight tensor."
         )
     if isinstance(output_weight, DTensor):
-        local_vocab_is_tp_partition = _dtensor_weight_is_tp_vocab_sharded(
-            output_weight
-        )
+        local_vocab_is_tp_partition = _dtensor_weight_is_tp_vocab_sharded(output_weight)
         output_weight = (
             output_weight.to_local()
             if local_vocab_is_tp_partition
@@ -348,9 +346,7 @@ def _compute_fused_linear_logprobs(
 
     tp_rank = _tp_rank_for_fused_linear_logprobs(tp_group)
     local_vocab_size = int(output_weight.shape[0])
-    vocab_start_index = (
-        tp_rank * local_vocab_size if local_vocab_is_tp_partition else 0
-    )
+    vocab_start_index = tp_rank * local_vocab_size if local_vocab_is_tp_partition else 0
     tensor_parallel_hidden_states = hidden_states.transpose(0, 1).contiguous()
     return from_parallel_hidden_states_to_logprobs(
         tensor_parallel_hidden_states=tensor_parallel_hidden_states,

--- a/nemo_rl/models/automodel/train.py
+++ b/nemo_rl/models/automodel/train.py
@@ -42,13 +42,14 @@ from nemo_rl.algorithms.logits_sampling_utils import (
     need_top_k_or_top_p_filtering,
 )
 from nemo_rl.algorithms.loss import SequencePackingLossWrapper, prepare_loss_input
-from nemo_rl.algorithms.loss.interfaces import LossFunction
+from nemo_rl.algorithms.loss.interfaces import LossFunction, LossInputType
 from nemo_rl.algorithms.utils import mask_out_neg_inf_logprobs
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.model_utils import (
     allgather_cp_sharded_tensor,
     cp_load_balanced_to_contiguous,
     distributed_vocab_topk,
+    from_parallel_hidden_states_to_logprobs,
     get_logprobs_from_vocab_parallel_logits,
 )
 from nemo_rl.models.automodel.data import ProcessedInputs, ProcessedMicrobatch
@@ -186,6 +187,141 @@ def apply_temperature_scaling(
     if sampling_params is not None and sampling_params.temperature != 1.0:
         logits.div_(sampling_params.temperature)
     return logits
+
+
+def _get_module_by_path(model: nn.Module, module_path: str) -> nn.Module:
+    module: Any = model
+    for part in module_path.split("."):
+        module = getattr(module, part, None)
+        if module is None:
+            raise AttributeError(f"Could not resolve module path {module_path!r}")
+    return module
+
+
+def _as_hidden_state_tensor(value: Any) -> torch.Tensor | None:
+    if isinstance(value, (tuple, list)):
+        value = value[-1] if value else None
+    if isinstance(value, DTensor):
+        return value.to_local()
+    if torch.is_tensor(value):
+        return value
+    return None
+
+
+def _fused_linear_logprobs_requested(
+    model: nn.Module,
+    post_processing_fn: PostProcessingFunction,
+) -> bool:
+    if not getattr(model, "_use_fused_linear_logprobs", False):
+        return False
+    if isinstance(post_processing_fn, LogprobsPostProcessor):
+        return True
+    return (
+        isinstance(post_processing_fn, LossPostProcessor)
+        and post_processing_fn.loss_fn.input_type == LossInputType.LOGPROB
+    )
+
+
+def _set_lm_head_skip_for_fused_linear_logprobs(
+    model: nn.Module,
+    enabled: bool,
+) -> None:
+    setattr(model, "_skip_lm_head_for_fused_linear_logprobs", enabled)
+    lm_head_path = getattr(model, "_fused_linear_logprobs_lm_head_path", None)
+    if lm_head_path is None:
+        return
+    try:
+        lm_head = _get_module_by_path(model, lm_head_path)
+    except AttributeError:
+        return
+    setattr(lm_head, "_skip_lm_head_for_fused_linear_logprobs", enabled)
+
+
+def _tp_rank_for_fused_linear_logprobs(tp_group: Any) -> int:
+    if torch.distributed.is_available() and torch.distributed.is_initialized():
+        return torch.distributed.get_rank(tp_group)
+    return 0
+
+
+def _lm_head_weight_for_fused_linear_logprobs(lm_head: nn.Module) -> torch.Tensor:
+    output_weight = getattr(lm_head, "weight", None)
+    if output_weight is None:
+        raise RuntimeError(
+            "policy.use_fused_linear_logprobs=True but the resolved LM head "
+            "does not expose a weight tensor."
+        )
+    if isinstance(output_weight, DTensor):
+        output_weight = output_weight.to_local()
+    if not torch.is_tensor(output_weight):
+        raise RuntimeError(
+            "policy.use_fused_linear_logprobs=True but the resolved LM head "
+            "weight is not a tensor."
+        )
+    return output_weight
+
+
+def _compute_fused_linear_logprobs(
+    model: nn.Module,
+    outputs: Any,
+    input_ids: torch.Tensor,
+    sampling_params: Optional[TrainingSamplingParams],
+) -> torch.Tensor:
+    captured_hidden_states = getattr(
+        model, "_fused_linear_logprobs_hidden_states", None
+    )
+    hidden_states = _as_hidden_state_tensor(captured_hidden_states)
+    if hidden_states is None:
+        hidden_states = _as_hidden_state_tensor(getattr(outputs, "hidden_states", None))
+    if hidden_states is None:
+        hidden_states = _as_hidden_state_tensor(
+            getattr(outputs, "last_hidden_state", None)
+        )
+    if hidden_states is None:
+        raise RuntimeError(
+            "policy.use_fused_linear_logprobs=True but no hidden states were "
+            "captured from the LM head or returned by the model output."
+        )
+    if hidden_states.ndim != 3:
+        raise RuntimeError(
+            "policy.use_fused_linear_logprobs=True requires hidden states with "
+            f"shape [batch, seq, hidden], got {tuple(hidden_states.shape)}."
+        )
+
+    lm_head_path = getattr(model, "_fused_linear_logprobs_lm_head_path", None)
+    if lm_head_path is None:
+        raise RuntimeError(
+            "policy.use_fused_linear_logprobs=True but the model is missing "
+            "fused linear logprob LM-head metadata."
+        )
+    lm_head = _get_module_by_path(model, lm_head_path)
+    output_weight = _lm_head_weight_for_fused_linear_logprobs(lm_head)
+
+    if sampling_params is not None and sampling_params.temperature != 1.0:
+        output_weight = output_weight / sampling_params.temperature
+
+    tp_group = getattr(model, "_fused_linear_logprobs_tp_group", None)
+    chunk_size = getattr(model, "_fused_linear_logprobs_chunk_size", None)
+    if chunk_size is None:
+        raise RuntimeError(
+            "policy.use_fused_linear_logprobs=True but no fused linear "
+            "logprob chunk size was configured."
+        )
+
+    tp_rank = _tp_rank_for_fused_linear_logprobs(tp_group)
+    local_vocab_size = int(output_weight.shape[0])
+    tensor_parallel_hidden_states = hidden_states.transpose(0, 1).contiguous()
+    return from_parallel_hidden_states_to_logprobs(
+        tensor_parallel_hidden_states=tensor_parallel_hidden_states,
+        output_weight_layer=output_weight,
+        runtime_gather_output=False,
+        target=input_ids.to(hidden_states.device),
+        vocab_start_index=tp_rank * local_vocab_size,
+        vocab_end_index=(tp_rank + 1) * local_vocab_size,
+        tp_group=tp_group,
+        inference_only=not torch.is_grad_enabled(),
+        cp_group=None,
+        chunk_size=int(chunk_size),
+    )
 
 
 def apply_top_k_top_p_filtering_for_local_logits(
@@ -348,18 +484,39 @@ def forward_with_post_processing_fn(
     # keeps use_cache=True for KV-sharing models under activation checkpointing
     # (NVIDIA-NeMo/Automodel#1705).
     use_cache = _needs_kv_cache_for_shared_layers(model)
+    use_fused_linear_logprobs = _fused_linear_logprobs_requested(
+        model, post_processing_fn
+    )
+    if use_fused_linear_logprobs and need_top_k_or_top_p_filtering(sampling_params):
+        raise RuntimeError(
+            "policy.use_fused_linear_logprobs is not supported with top-k/top-p "
+            "filtering because the fused path does not materialize full logits."
+        )
 
     # Model forward pass
-    outputs = model_forward(
-        model,
-        processed_inputs,
-        is_reward_model=is_reward_model,
-        allow_flash_attn_args=allow_flash_attn_args,
-        use_cache=use_cache,
-    )
+    if use_fused_linear_logprobs:
+        model._fused_linear_logprobs_hidden_states = None
+        _set_lm_head_skip_for_fused_linear_logprobs(model, True)
+    try:
+        outputs = model_forward(
+            model,
+            processed_inputs,
+            is_reward_model=is_reward_model,
+            allow_flash_attn_args=allow_flash_attn_args,
+            use_cache=use_cache,
+        )
+    finally:
+        if use_fused_linear_logprobs:
+            _set_lm_head_skip_for_fused_linear_logprobs(model, False)
 
     # Extract logits from model outputs
-    logits = extract_logits(model, outputs)
+    logits = (
+        _compute_fused_linear_logprobs(
+            model, outputs, data_dict["input_ids"], sampling_params
+        )
+        if use_fused_linear_logprobs
+        else extract_logits(model, outputs)
+    )
     del outputs
 
     # Apply temperature scaling only for sampling-oriented post-processors
@@ -376,18 +533,30 @@ def forward_with_post_processing_fn(
         # Temperature scaling is element-wise, directly applying it here.
         # Other sampling parameters like top-k and top-p need the logits from whole vocabulary,
         # so applying them when gathering logits from vocab parallel (called in LossPostProcessor and LogprobsPostProcessor).
-        logits = apply_temperature_scaling(logits, sampling_params)
+        if not use_fused_linear_logprobs:
+            logits = apply_temperature_scaling(logits, sampling_params)
 
     # Apply the post-processing function directly based on type
     if isinstance(post_processing_fn, LossPostProcessor):
-        result, metrics = post_processing_fn(
-            logits=logits,
-            data_dict=data_dict,
-            processed_inputs=processed_inputs,
-            global_valid_seqs=global_valid_seqs,
-            global_valid_toks=global_valid_toks,
-            sequence_dim=sequence_dim,
-        )
+        loss_fn = post_processing_fn.loss_fn
+        previous_fused_flag = getattr(loss_fn, "use_fused_linear_logprobs", None)
+        if use_fused_linear_logprobs:
+            loss_fn.use_fused_linear_logprobs = True
+        try:
+            result, metrics = post_processing_fn(
+                logits=logits,
+                data_dict=data_dict,
+                processed_inputs=processed_inputs,
+                global_valid_seqs=global_valid_seqs,
+                global_valid_toks=global_valid_toks,
+                sequence_dim=sequence_dim,
+            )
+        finally:
+            if use_fused_linear_logprobs:
+                if previous_fused_flag is None:
+                    delattr(loss_fn, "use_fused_linear_logprobs")
+                else:
+                    loss_fn.use_fused_linear_logprobs = previous_fused_flag
     elif isinstance(
         post_processing_fn,
         (LogprobsPostProcessor, TopkLogitsPostProcessor),
@@ -705,7 +874,26 @@ class LogprobsPostProcessor:
         seq_len = processed_inputs.seq_len
         input_lengths = data_dict["input_lengths"]
 
-        if self.cp_size > 1:
+        if logits.ndim == 2:
+            if logits.shape != (processed_inputs.input_ids.shape[0], seq_len - 1):
+                raise ValueError(
+                    "Precomputed selected logprobs must have shape "
+                    f"[batch, seq_len - 1], got {tuple(logits.shape)} for "
+                    f"batch={processed_inputs.input_ids.shape[0]} and "
+                    f"seq_len={seq_len}."
+                )
+            if self.cp_size > 1:
+                raise NotImplementedError(
+                    "Precomputed selected logprobs are not supported with "
+                    "context parallelism."
+                )
+            if self.enable_seq_packing:
+                raise NotImplementedError(
+                    "Precomputed selected logprobs are not supported with "
+                    "sequence packing."
+                )
+            token_logprobs = logits.to(torch.float32)
+        elif self.cp_size > 1:
             seq_index_tensor = (
                 DTensor.from_local(
                     processed_inputs.seq_index,

--- a/nemo_rl/models/automodel/train.py
+++ b/nemo_rl/models/automodel/train.py
@@ -243,7 +243,27 @@ def _tp_rank_for_fused_linear_logprobs(tp_group: Any) -> int:
     return 0
 
 
-def _lm_head_weight_for_fused_linear_logprobs(lm_head: nn.Module) -> torch.Tensor:
+def _tp_size_for_fused_linear_logprobs(tp_group: Any) -> int:
+    if torch.distributed.is_available() and torch.distributed.is_initialized():
+        return torch.distributed.get_world_size(tp_group)
+    return 1
+
+
+def _dtensor_weight_is_tp_vocab_sharded(output_weight: DTensor) -> bool:
+    mesh_dim_names = output_weight.device_mesh.mesh_dim_names
+    if mesh_dim_names is None:
+        return False
+
+    for mesh_dim_name, placement in zip(mesh_dim_names, output_weight.placements):
+        if isinstance(placement, Shard) and placement.dim == 0:
+            return mesh_dim_name == "tp"
+
+    return False
+
+
+def _lm_head_weight_for_fused_linear_logprobs(
+    lm_head: nn.Module,
+) -> tuple[torch.Tensor, bool]:
     output_weight = getattr(lm_head, "weight", None)
     if output_weight is None:
         raise RuntimeError(
@@ -251,13 +271,22 @@ def _lm_head_weight_for_fused_linear_logprobs(lm_head: nn.Module) -> torch.Tenso
             "does not expose a weight tensor."
         )
     if isinstance(output_weight, DTensor):
-        output_weight = output_weight.to_local()
+        local_vocab_is_tp_partition = _dtensor_weight_is_tp_vocab_sharded(
+            output_weight
+        )
+        output_weight = (
+            output_weight.to_local()
+            if local_vocab_is_tp_partition
+            else output_weight.full_tensor()
+        )
+    else:
+        local_vocab_is_tp_partition = True
     if not torch.is_tensor(output_weight):
         raise RuntimeError(
             "policy.use_fused_linear_logprobs=True but the resolved LM head "
             "weight is not a tensor."
         )
-    return output_weight
+    return output_weight, local_vocab_is_tp_partition
 
 
 def _compute_fused_linear_logprobs(
@@ -294,7 +323,9 @@ def _compute_fused_linear_logprobs(
             "fused linear logprob LM-head metadata."
         )
     lm_head = _get_module_by_path(model, lm_head_path)
-    output_weight = _lm_head_weight_for_fused_linear_logprobs(lm_head)
+    output_weight, local_vocab_is_tp_partition = (
+        _lm_head_weight_for_fused_linear_logprobs(lm_head)
+    )
 
     if sampling_params is not None and sampling_params.temperature != 1.0:
         output_weight = output_weight / sampling_params.temperature
@@ -307,16 +338,27 @@ def _compute_fused_linear_logprobs(
             "logprob chunk size was configured."
         )
 
+    tp_size = _tp_size_for_fused_linear_logprobs(tp_group)
+    if not local_vocab_is_tp_partition and tp_size > 1:
+        raise RuntimeError(
+            "policy.use_fused_linear_logprobs=True requires the LM-head weight "
+            "to be vocab-sharded on the tp mesh dimension when tensor "
+            "parallelism is enabled."
+        )
+
     tp_rank = _tp_rank_for_fused_linear_logprobs(tp_group)
     local_vocab_size = int(output_weight.shape[0])
+    vocab_start_index = (
+        tp_rank * local_vocab_size if local_vocab_is_tp_partition else 0
+    )
     tensor_parallel_hidden_states = hidden_states.transpose(0, 1).contiguous()
     return from_parallel_hidden_states_to_logprobs(
         tensor_parallel_hidden_states=tensor_parallel_hidden_states,
         output_weight_layer=output_weight,
         runtime_gather_output=False,
         target=input_ids.to(hidden_states.device),
-        vocab_start_index=tp_rank * local_vocab_size,
-        vocab_end_index=(tp_rank + 1) * local_vocab_size,
+        vocab_start_index=vocab_start_index,
+        vocab_end_index=vocab_start_index + local_vocab_size,
         tp_group=tp_group,
         inference_only=not torch.is_grad_enabled(),
         cp_group=None,

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -435,6 +435,16 @@ class PolicyConfig(TypedDict):
     # If None, chunking is disabled and the full sequence is processed at once.
     logprob_chunk_size: NotRequired[int | None]
     generation: NotRequired[GenerationConfig]
+    # AutoModel-only opt-in for computing selected next-token logprobs directly
+    # from hidden states and the LM-head weight, avoiding full [B, S, V] logits
+    # for loss/logprob postprocessing. This mirrors the Megatron
+    # use_fused_linear_logprobs path. It is not compatible with context
+    # parallelism, sequence packing, or top-k/top-p training-time filtering.
+    use_fused_linear_logprobs: NotRequired[bool]
+    # Number of sequence tokens per chunk for AutoModel fused linear logprobs.
+    # If omitted, policy.logprob_chunk_size is used. One of the two must be set
+    # when use_fused_linear_logprobs is enabled.
+    fused_linear_logprobs_chunk_size: NotRequired[int]
     generation_batch_size: NotRequired[
         int
     ]  # used in static batched (framework) generation

--- a/tests/unit/models/automodel/test_automodel_setup.py
+++ b/tests/unit/models/automodel/test_automodel_setup.py
@@ -32,6 +32,7 @@ from nemo_rl.models.automodel.setup import (
     ModelAndOptimizerState,
     RuntimeConfig,
     _maybe_set_force_hf,
+    _setup_fused_linear_logprobs_for_automodel,
     get_tokenizer,
     setup_distributed,
     setup_model_and_optimizer,
@@ -43,6 +44,68 @@ from nemo_rl.models.automodel.setup import (
 def test_token_classification_backport_still_required():
     with pytest.raises(ImportError):
         from nemo_automodel import NeMoAutoModelForTokenClassification  # noqa: F401
+
+
+class _MockDeviceMesh:
+    def __init__(self):
+        self.tp_group = object()
+
+    def __getitem__(self, key: str):
+        assert key == "tp"
+        return self
+
+    def get_group(self):
+        return self.tp_group
+
+
+class _DirectLmHeadModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lm_head = torch.nn.Linear(4, 7, bias=False)
+
+
+class _LanguageModelLmHeadModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.language_model = torch.nn.Module()
+        self.language_model.lm_head = torch.nn.Linear(4, 7, bias=False)
+
+
+class _InnerModelLmHeadModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.model = torch.nn.Module()
+        self.model.lm_head = torch.nn.Linear(4, 7, bias=False)
+
+
+def _fused_logprob_config(chunk_size: int | None = 2) -> dict[str, object]:
+    config: dict[str, object] = {"use_fused_linear_logprobs": True}
+    if chunk_size is not None:
+        config["fused_linear_logprobs_chunk_size"] = chunk_size
+    return config
+
+
+@pytest.mark.automodel
+@pytest.mark.parametrize(
+    ("model_cls", "expected_path"),
+    [
+        (_DirectLmHeadModel, "lm_head"),
+        (_LanguageModelLmHeadModel, "language_model.lm_head"),
+        (_InnerModelLmHeadModel, "model.lm_head"),
+    ],
+)
+def test_setup_fused_linear_logprobs_finds_supported_lm_head_paths(
+    model_cls, expected_path
+):
+    model = model_cls()
+
+    _setup_fused_linear_logprobs_for_automodel(
+        model, _fused_logprob_config(), _MockDeviceMesh()
+    )
+
+    assert model._use_fused_linear_logprobs is True
+    assert model._fused_linear_logprobs_lm_head_path == expected_path
+    assert model._fused_linear_logprobs_chunk_size == 2
 
 
 @pytest.fixture
@@ -74,6 +137,60 @@ def mock_config():
             "kwargs": {"lr": 1e-4},
         },
     }
+
+
+@pytest.mark.automodel
+def test_setup_fused_linear_logprobs_does_not_duplicate_lm_head_parameters():
+    model = _DirectLmHeadModel()
+    before_parameter_names = [name for name, _ in model.named_parameters()]
+
+    _setup_fused_linear_logprobs_for_automodel(
+        model, _fused_logprob_config(), _MockDeviceMesh()
+    )
+
+    assert [name for name, _ in model.named_parameters()] == before_parameter_names
+
+
+@pytest.mark.automodel
+def test_setup_fused_linear_logprobs_can_skip_lm_head_and_capture_hidden_states():
+    model = _DirectLmHeadModel()
+    _setup_fused_linear_logprobs_for_automodel(
+        model, _fused_logprob_config(), _MockDeviceMesh()
+    )
+
+    hidden_states = torch.randn(2, 3, 4)
+
+    normal_output = model.lm_head(hidden_states)
+    assert normal_output.shape == (2, 3, 7)
+    assert model._fused_linear_logprobs_hidden_states is hidden_states
+
+    model._skip_lm_head_for_fused_linear_logprobs = True
+    skipped_output = model.lm_head(hidden_states)
+    assert skipped_output.shape == (1,)
+    assert skipped_output.device == hidden_states.device
+    assert skipped_output.dtype == hidden_states.dtype
+    assert model._fused_linear_logprobs_hidden_states is hidden_states
+
+    model._skip_lm_head_for_fused_linear_logprobs = False
+    assert model.lm_head(hidden_states).shape == (2, 3, 7)
+
+
+@pytest.mark.automodel
+def test_setup_fused_linear_logprobs_requires_lm_head():
+    with pytest.raises(RuntimeError, match="no LM head"):
+        _setup_fused_linear_logprobs_for_automodel(
+            torch.nn.Module(), _fused_logprob_config(), _MockDeviceMesh()
+        )
+
+
+@pytest.mark.automodel
+def test_setup_fused_linear_logprobs_requires_chunk_size():
+    with pytest.raises(ValueError, match="requires"):
+        _setup_fused_linear_logprobs_for_automodel(
+            _DirectLmHeadModel(),
+            _fused_logprob_config(chunk_size=None),
+            _MockDeviceMesh(),
+        )
 
 
 @pytest.fixture

--- a/tests/unit/models/automodel/test_automodel_train.py
+++ b/tests/unit/models/automodel/test_automodel_train.py
@@ -17,12 +17,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
-from torch.distributed.tensor import DTensor
+from torch.distributed.tensor import DTensor, Shard
 
 try:
     import nemo_automodel  # noqa: F401
 except ImportError:
     pytest.skip("nemo_automodel not available", allow_module_level=True)
+
+import nemo_rl.models.automodel.train as automodel_train
 
 from nemo_rl.algorithms.logits_sampling_utils import TrainingSamplingParams
 from nemo_rl.algorithms.loss.interfaces import LossInputType
@@ -68,6 +70,88 @@ def mock_loss_fn():
     loss_fn.return_value = (torch.tensor(0.5), {"loss": 0.5})
     loss_fn.input_type = LossInputType.LOGIT
     return loss_fn
+
+
+class _FakeDeviceMesh:
+    def __init__(self, mesh_dim_names):
+        self.mesh_dim_names = mesh_dim_names
+
+
+class _FakeWeightDTensor:
+    def __init__(
+        self,
+        *,
+        local_tensor: torch.Tensor,
+        full_tensor: torch.Tensor,
+        placements,
+        mesh_dim_names,
+    ):
+        self._local_tensor = local_tensor
+        self._full_tensor = full_tensor
+        self.placements = placements
+        self.device_mesh = _FakeDeviceMesh(mesh_dim_names)
+        self.to_local_calls = 0
+        self.full_tensor_calls = 0
+
+    def to_local(self):
+        self.to_local_calls += 1
+        return self._local_tensor
+
+    def full_tensor(self):
+        self.full_tensor_calls += 1
+        return self._full_tensor
+
+
+@pytest.mark.automodel
+def test_lm_head_weight_for_fused_logprobs_uses_to_local_for_tp_vocab_dtensor(
+    monkeypatch,
+):
+    monkeypatch.setattr(automodel_train, "DTensor", _FakeWeightDTensor)
+    local_tensor = torch.randn(4, 3)
+    full_tensor = torch.randn(8, 3)
+    weight = _FakeWeightDTensor(
+        local_tensor=local_tensor,
+        full_tensor=full_tensor,
+        placements=[Shard(0)],
+        mesh_dim_names=["tp"],
+    )
+    lm_head = torch.nn.Module()
+    lm_head.weight = weight
+
+    output_weight, local_vocab_is_tp_partition = (
+        automodel_train._lm_head_weight_for_fused_linear_logprobs(lm_head)
+    )
+
+    assert output_weight is local_tensor
+    assert local_vocab_is_tp_partition is True
+    assert weight.to_local_calls == 1
+    assert weight.full_tensor_calls == 0
+
+
+@pytest.mark.automodel
+def test_lm_head_weight_for_fused_logprobs_uses_full_tensor_for_dp_dtensor(
+    monkeypatch,
+):
+    monkeypatch.setattr(automodel_train, "DTensor", _FakeWeightDTensor)
+    local_tensor = torch.randn(4, 3)
+    full_tensor = torch.randn(8, 3)
+    weight = _FakeWeightDTensor(
+        local_tensor=local_tensor,
+        full_tensor=full_tensor,
+        placements=[Shard(0)],
+        mesh_dim_names=["dp"],
+    )
+    lm_head = torch.nn.Module()
+    lm_head.weight = weight
+
+    output_weight, local_vocab_is_tp_partition = (
+        automodel_train._lm_head_weight_for_fused_linear_logprobs(lm_head)
+    )
+
+    assert output_weight is full_tensor
+    assert local_vocab_is_tp_partition is False
+    assert weight.to_local_calls == 0
+    assert weight.full_tensor_calls == 1
 
 
 @pytest.fixture

--- a/tests/unit/models/automodel/test_automodel_train.py
+++ b/tests/unit/models/automodel/test_automodel_train.py
@@ -25,7 +25,6 @@ except ImportError:
     pytest.skip("nemo_automodel not available", allow_module_level=True)
 
 import nemo_rl.models.automodel.train as automodel_train
-
 from nemo_rl.algorithms.logits_sampling_utils import TrainingSamplingParams
 from nemo_rl.algorithms.loss.interfaces import LossInputType
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
@@ -674,9 +673,7 @@ class TestLogprobsPostProcessor:
         assert result.shape == (batch_size, seq_len)
         assert result.dtype == torch.float32
         torch.testing.assert_close(result[:, 0], torch.zeros(batch_size))
-        torch.testing.assert_close(
-            result[:, 1:], selected_logprobs.to(torch.float32)
-        )
+        torch.testing.assert_close(result[:, 1:], selected_logprobs.to(torch.float32))
 
     def test_precomputed_selected_logprobs_rejects_context_parallel(
         self, base_cfg, mock_device_mesh, mock_cp_mesh, mock_tp_mesh

--- a/tests/unit/models/automodel/test_automodel_train.py
+++ b/tests/unit/models/automodel/test_automodel_train.py
@@ -551,6 +551,124 @@ class TestLogprobsPostProcessor:
 
         assert result.shape == (batch_size, seq_len)
 
+    def test_logprobs_accepts_precomputed_selected_logprobs(
+        self, base_cfg, mock_device_mesh, mock_cp_mesh, mock_tp_mesh
+    ):
+        processor = LogprobsPostProcessor(
+            cfg=base_cfg,
+            device_mesh=mock_device_mesh,
+            cp_mesh=mock_cp_mesh,
+            tp_mesh=mock_tp_mesh,
+            cp_size=1,
+        )
+
+        batch_size = 3
+        seq_len = 5
+        input_ids = torch.arange(batch_size * seq_len).reshape(batch_size, seq_len)
+        selected_logprobs = torch.randn(batch_size, seq_len - 1).to(torch.bfloat16)
+        input_lengths = torch.full((batch_size,), seq_len)
+        data_dict = BatchedDataDict({"input_lengths": input_lengths})
+        processed_inputs = ProcessedInputs(
+            input_ids=input_ids,
+            seq_len=seq_len,
+            attention_mask=torch.ones(batch_size, seq_len, dtype=torch.bool),
+            position_ids=torch.arange(seq_len).repeat(batch_size, 1),
+            flash_attn_kwargs={},
+            vlm_kwargs={},
+            cp_buffers=[],
+            seq_index=None,
+        )
+
+        result = processor(
+            logits=selected_logprobs,
+            data_dict=data_dict,
+            processed_inputs=processed_inputs,
+            original_batch_size=batch_size,
+            original_seq_len=seq_len,
+        )
+
+        assert result.shape == (batch_size, seq_len)
+        assert result.dtype == torch.float32
+        torch.testing.assert_close(result[:, 0], torch.zeros(batch_size))
+        torch.testing.assert_close(
+            result[:, 1:], selected_logprobs.to(torch.float32)
+        )
+
+    def test_precomputed_selected_logprobs_rejects_context_parallel(
+        self, base_cfg, mock_device_mesh, mock_cp_mesh, mock_tp_mesh
+    ):
+        processor = LogprobsPostProcessor(
+            cfg=base_cfg,
+            device_mesh=mock_device_mesh,
+            cp_mesh=mock_cp_mesh,
+            tp_mesh=mock_tp_mesh,
+            cp_size=2,
+        )
+        batch_size = 3
+        seq_len = 5
+        input_ids = torch.arange(batch_size * seq_len).reshape(batch_size, seq_len)
+        selected_logprobs = torch.randn(batch_size, seq_len - 1)
+        data_dict = BatchedDataDict(
+            {"input_lengths": torch.full((batch_size,), seq_len)}
+        )
+        processed_inputs = ProcessedInputs(
+            input_ids=input_ids,
+            seq_len=seq_len,
+            attention_mask=torch.ones(batch_size, seq_len, dtype=torch.bool),
+            position_ids=torch.arange(seq_len).repeat(batch_size, 1),
+            flash_attn_kwargs={},
+            vlm_kwargs={},
+            cp_buffers=[],
+            seq_index=None,
+        )
+
+        with pytest.raises(NotImplementedError, match="context parallelism"):
+            processor(
+                logits=selected_logprobs,
+                data_dict=data_dict,
+                processed_inputs=processed_inputs,
+                original_batch_size=batch_size,
+                original_seq_len=seq_len,
+            )
+
+    def test_precomputed_selected_logprobs_rejects_sequence_packing(
+        self, base_cfg, mock_device_mesh, mock_cp_mesh, mock_tp_mesh
+    ):
+        processor = LogprobsPostProcessor(
+            cfg=base_cfg,
+            device_mesh=mock_device_mesh,
+            cp_mesh=mock_cp_mesh,
+            tp_mesh=mock_tp_mesh,
+            cp_size=1,
+            enable_seq_packing=True,
+        )
+        batch_size = 3
+        seq_len = 5
+        input_ids = torch.arange(batch_size * seq_len).reshape(batch_size, seq_len)
+        selected_logprobs = torch.randn(batch_size, seq_len - 1)
+        data_dict = BatchedDataDict(
+            {"input_lengths": torch.full((batch_size,), seq_len)}
+        )
+        processed_inputs = ProcessedInputs(
+            input_ids=input_ids,
+            seq_len=seq_len,
+            attention_mask=torch.ones(batch_size, seq_len, dtype=torch.bool),
+            position_ids=torch.arange(seq_len).repeat(batch_size, 1),
+            flash_attn_kwargs={},
+            vlm_kwargs={},
+            cp_buffers=[],
+            seq_index=None,
+        )
+
+        with pytest.raises(NotImplementedError, match="sequence packing"):
+            processor(
+                logits=selected_logprobs,
+                data_dict=data_dict,
+                processed_inputs=processed_inputs,
+                original_batch_size=batch_size,
+                original_seq_len=seq_len,
+            )
+
     def test_logprobs_with_chunking(
         self, base_cfg, mock_device_mesh, mock_cp_mesh, mock_tp_mesh
     ):
@@ -805,6 +923,77 @@ class TestProcessedInputsProperties:
 # =====================
 @pytest.mark.automodel
 class TestForwardWithPostProcessingFn:
+    class _FusedLogprobModel(torch.nn.Module):
+        def __init__(
+            self,
+            batch_size: int,
+            seq_len: int,
+            hidden_size: int,
+            vocab_size: int,
+        ):
+            super().__init__()
+            self.batch_size = batch_size
+            self.seq_len = seq_len
+            self.hidden_size = hidden_size
+            self.lm_head = torch.nn.Linear(hidden_size, vocab_size, bias=False)
+            self._use_fused_linear_logprobs = True
+            self._fused_linear_logprobs_lm_head_path = "lm_head"
+            self._fused_linear_logprobs_chunk_size = 2
+            self._fused_linear_logprobs_tp_group = object()
+            self._fused_linear_logprobs_hidden_states = None
+            self.saw_skip_flag = None
+
+        def forward(self, input_ids, **kwargs):  # noqa: ARG002
+            self.saw_skip_flag = getattr(
+                self, "_skip_lm_head_for_fused_linear_logprobs", False
+            )
+            hidden_states = torch.arange(
+                self.batch_size * self.seq_len * self.hidden_size,
+                dtype=self.lm_head.weight.dtype,
+                device=self.lm_head.weight.device,
+            ).reshape(self.batch_size, self.seq_len, self.hidden_size)
+            self._fused_linear_logprobs_hidden_states = hidden_states
+            return MagicMock(logits=torch.empty(1))
+
+    class _RecordingLogprobLoss:
+        input_type = LossInputType.LOGPROB
+
+        def __init__(self):
+            self.use_fused_linear_logprobs = False
+            self.seen_logprobs = None
+
+        def __call__(
+            self,
+            data,
+            next_token_logprobs,
+            global_valid_seqs,
+            global_valid_toks,
+        ):
+            _ = (data, global_valid_seqs, global_valid_toks)
+            self.seen_logprobs = next_token_logprobs
+            return next_token_logprobs.sum() * 0, {"loss": 0.0}
+
+    def _make_processed_mb(self, batch_size=2, seq_len=5, vocab_size=11):
+        input_ids = torch.randint(0, vocab_size, (batch_size, seq_len))
+        processed_inputs = ProcessedInputs(
+            input_ids=input_ids,
+            seq_len=seq_len,
+            attention_mask=torch.ones(batch_size, seq_len, dtype=torch.bool),
+            position_ids=torch.arange(seq_len).repeat(batch_size, 1),
+            flash_attn_kwargs={},
+            vlm_kwargs={},
+            cp_buffers=[],
+            seq_index=None,
+        )
+        data_dict = BatchedDataDict(
+            {
+                "input_ids": input_ids,
+                "input_lengths": torch.full((batch_size,), seq_len),
+                "sample_mask": torch.ones(batch_size, dtype=torch.bool),
+            }
+        )
+        return ProcessedMicrobatch(data_dict, processed_inputs, batch_size, seq_len)
+
     def test_forward_with_loss_post_processor(
         self,
         mock_model,
@@ -876,6 +1065,138 @@ class TestForwardWithPostProcessingFn:
 
         # Verify returned microbatch is correct
         assert returned_mb is processed_mb
+
+    @patch("nemo_rl.models.automodel.train.apply_temperature_scaling")
+    @patch("nemo_rl.models.automodel.train.from_parallel_hidden_states_to_logprobs")
+    def test_forward_with_logprobs_uses_fused_linear_logprobs(
+        self,
+        mock_fused_logprobs,
+        mock_temperature_scaling,
+        base_cfg,
+        mock_device_mesh,
+        mock_cp_mesh,
+        mock_tp_mesh,
+    ):
+        batch_size = 2
+        seq_len = 5
+        hidden_size = 3
+        vocab_size = 11
+        model = self._FusedLogprobModel(
+            batch_size=batch_size,
+            seq_len=seq_len,
+            hidden_size=hidden_size,
+            vocab_size=vocab_size,
+        )
+        selected_logprobs = torch.randn(batch_size, seq_len - 1)
+        mock_fused_logprobs.return_value = selected_logprobs
+        mock_temperature_scaling.side_effect = AssertionError(
+            "temperature scaling should not run on precomputed logprobs"
+        )
+        processed_mb = self._make_processed_mb(batch_size, seq_len, vocab_size)
+        processor = LogprobsPostProcessor(
+            cfg=base_cfg,
+            device_mesh=mock_device_mesh,
+            cp_mesh=mock_cp_mesh,
+            tp_mesh=mock_tp_mesh,
+            cp_size=1,
+        )
+
+        result, metrics, returned_mb = forward_with_post_processing_fn(
+            model=model,
+            post_processing_fn=processor,
+            processed_mb=processed_mb,
+            sampling_params=TrainingSamplingParams(temperature=2.0),
+        )
+
+        assert returned_mb is processed_mb
+        assert model.saw_skip_flag is True
+        assert model._skip_lm_head_for_fused_linear_logprobs is False
+        mock_fused_logprobs.assert_called_once()
+        call_kwargs = mock_fused_logprobs.call_args.kwargs
+        assert call_kwargs["tensor_parallel_hidden_states"].shape == (
+            seq_len,
+            batch_size,
+            hidden_size,
+        )
+        assert call_kwargs["chunk_size"] == 2
+        torch.testing.assert_close(
+            call_kwargs["output_weight_layer"], model.lm_head.weight / 2.0
+        )
+        torch.testing.assert_close(result[:, 1:], selected_logprobs)
+        torch.testing.assert_close(metrics["logprobs"], result)
+
+    @patch("nemo_rl.models.automodel.train.from_parallel_hidden_states_to_logprobs")
+    def test_forward_with_loss_uses_fused_linear_logprobs(
+        self,
+        mock_fused_logprobs,
+        base_cfg,
+        mock_device_mesh,
+        mock_cp_mesh,
+        mock_tp_mesh,
+    ):
+        batch_size = 2
+        seq_len = 5
+        hidden_size = 3
+        vocab_size = 11
+        model = self._FusedLogprobModel(
+            batch_size=batch_size,
+            seq_len=seq_len,
+            hidden_size=hidden_size,
+            vocab_size=vocab_size,
+        )
+        selected_logprobs = torch.randn(batch_size, seq_len - 1)
+        mock_fused_logprobs.return_value = selected_logprobs
+        processed_mb = self._make_processed_mb(batch_size, seq_len, vocab_size)
+        loss_fn = self._RecordingLogprobLoss()
+        processor = LossPostProcessor(
+            loss_fn=loss_fn,
+            cfg=base_cfg,
+            device_mesh=mock_device_mesh,
+            cp_mesh=mock_cp_mesh,
+            tp_mesh=mock_tp_mesh,
+            cp_size=1,
+            dp_size=1,
+        )
+
+        result, metrics, returned_mb = forward_with_post_processing_fn(
+            model=model,
+            post_processing_fn=processor,
+            processed_mb=processed_mb,
+            global_valid_seqs=torch.tensor(batch_size),
+            global_valid_toks=torch.tensor(batch_size * seq_len),
+        )
+
+        assert returned_mb is processed_mb
+        assert result.shape == ()
+        assert metrics == {"loss": 0.0}
+        assert loss_fn.use_fused_linear_logprobs is False
+        torch.testing.assert_close(loss_fn.seen_logprobs, selected_logprobs)
+
+    def test_fused_linear_logprobs_rejects_top_k_top_p(
+        self, base_cfg, mock_device_mesh, mock_cp_mesh, mock_tp_mesh
+    ):
+        model = self._FusedLogprobModel(
+            batch_size=2,
+            seq_len=5,
+            hidden_size=3,
+            vocab_size=11,
+        )
+        processed_mb = self._make_processed_mb()
+        processor = LogprobsPostProcessor(
+            cfg=base_cfg,
+            device_mesh=mock_device_mesh,
+            cp_mesh=mock_cp_mesh,
+            tp_mesh=mock_tp_mesh,
+            cp_size=1,
+        )
+
+        with pytest.raises(RuntimeError, match="top-k/top-p"):
+            forward_with_post_processing_fn(
+                model=model,
+                post_processing_fn=processor,
+                processed_mb=processed_mb,
+                sampling_params=TrainingSamplingParams(top_k=2, top_p=1.0),
+            )
 
     def test_forward_with_score_post_processor(
         self,


### PR DESCRIPTION
# What does this PR do ?

Adds an opt-in AutoModel path for computing selected next-token logprobs directly from hidden states and the LM-head weight, avoiding full `[B, S, V]` logits materialization for logprob/loss postprocessing.

# Issues

N/A

# Usage

For AutoModel policies, enable the feature with top-level policy keys:

```yaml
policy:
  dtensor_cfg:
    enabled: true
  use_fused_linear_logprobs: true
  fused_linear_logprobs_chunk_size: 256
```

This is intended for SFT/DPO/GRPO-style logprob losses where only selected-token logprobs are needed.

# Details

This PR extends the existing fused selected-token logprob optimization to the AutoModel backend.

Main changes:

- Adds AutoModel policy config keys:
  - `policy.use_fused_linear_logprobs`
  - `policy.fused_linear_logprobs_chunk_size`
- Validates unsupported combinations early:
  - context parallelism
  - sequence packing
  - top-k/top-p training-time filtering
  - missing fused logprob chunk size
- Finds common LM-head locations:
  - `lm_head`
  - `language_model.lm_head`
  - `model.lm_head`
- Captures hidden states entering the LM head with a forward pre-hook.
- Computes selected next-token logprobs with `from_parallel_hidden_states_to_logprobs`.
- Supports both:
  - `LogprobsPostProcessor`
  - `LossPostProcessor` when the loss input type is `LossInputType.LOGPROB`
- Keeps full-logits paths unchanged for reward scores, top-k logits, and unsupported sampling filters.
- Updates SFT, DPO, and GRPO docs with AutoModel usage and limitations.
- Adds focused unit coverage for setup, validation, precomputed selected-logprob handling, and fused forward wiring.

# Design decision: `lm_head.forward` wrapper

This PR installs an opt-in wrapper around `lm_head.forward` when `policy.use_fused_linear_logprobs` is enabled. The wrapper returns a small sentinel tensor only while the fused selected-logprob path explicitly enables the skip flag. This avoids materializing the full `[B, S, V]` logits tensor when downstream code only needs selected next-token logprobs.

A forward pre-hook captures the hidden states entering the LM head, and the original `lm_head.forward` is retained and called whenever the skip flag is not active. The skip flag is reset in a `finally` block after model forward, so normal LM-head behavior is preserved outside the fused selected-logprob path.

Alternatives considered:

- Pre-hook alone: captures hidden states but still executes `lm_head.forward` and allocates `[B, S, V]`.
- Changing model outputs: would require broader model-family-specific changes.

The feature is opt-in only, local to the model instance, and covered by unit tests for a plain `nn.Linear` LM head.

# Limitations

This PR intentionally rejects unsupported combinations instead of silently falling back:

- context parallelism
- sequence packing
- top-k/top-p training-time filtering

End-to-end tests cover plain `nn.Linear` LM heads. LoRA-wrapped LM heads, tied embeddings, and DTensor-sharded LM-head weights are not covered by integration tests in this PR. The implementation keeps normal LM-head forwarding unchanged when the skip flag is inactive and handles DTensor weights through `.to_local()`, but I am happy to add more integration coverage if maintainers request it.

# Testing

```bash
ruff check --fix docs/guides/dpo.md docs/guides/grpo.md docs/guides/sft.md nemo_rl/models/policy/__init__.py nemo_rl/models/automodel/setup.py nemo_rl/models/automodel/train.py tests/unit/models/automodel/test_automodel_setup.py tests/unit/models/automodel/test_automodel_train.py
ruff format docs/guides/dpo.md docs/guides/grpo.md docs/guides/sft.md nemo_rl/models/policy/__init__.py nemo_rl/models/automodel/setup.py nemo_rl/models/automodel/train.py tests/unit/models/automodel/test_automodel_setup.py tests/unit/models/automodel/test_automodel_train.py
python -m pytest tests/unit/models/automodel/test_automodel_setup.py tests/unit/models/automodel/test_automodel_train.py -k "fused_linear_logprobs or precomputed_selected_logprobs" -v
```

# Additional Information

This follows the existing Megatron fused selected-token logprob concept, but uses AutoModel-specific hidden-state capture because AutoModel does not currently expose a backend-neutral API for skipping LM-head logits while returning the LM-head input.