### PR TITLE
feat: router replay unified wrapper

### DIFF
--- a/nemo_rl/models/megatron/router_replay.py
+++ b/nemo_rl/models/megatron/router_replay.py
@@ -17,20 +17,22 @@ from __future__ import annotations
 import inspect
 import os
 from collections.abc import Iterable
-from functools import wraps
 from typing import Any, Optional
 
 import torch
 
 from nemo_rl.models.policy import PolicyConfig
 from nemo_rl.utils.r3_trace import (
+    replay_topk_record,
+    replay_topk_snapshot,
     trace_router_replay_action,
     trace_router_replay_assignment,
 )
 
 _ROUTER_REPLAY_VALIDATE_ENV = "NRL_ROUTER_REPLAY_VALIDATE"
 _MISSING_ROUTE_SENTINEL = -1
-_MISSING_ROUTE_FALLBACK_PATCH_ATTR = "_nrl_missing_route_fallback_patch"
+
+_original_get_replay_topk: Optional[Any] = None
 
 
 def router_replay_enabled(config: PolicyConfig) -> bool:
@@ -64,7 +66,7 @@ def validate_router_replay_config(config: PolicyConfig) -> None:
         raise ValueError(
             "router_replay.enabled does not support virtual pipeline parallelism yet."
         )
-    _install_missing_route_fallback_patch()
+    _install_get_replay_topk_wrapper()
 
 
 def _iter_model_modules(model: Any) -> Iterable[Any]:
@@ -249,16 +251,102 @@ def _validate_replay_tensor(
         )
 
 
-def _install_missing_route_fallback_patch() -> None:
-    from megatron.core.transformer.moe.router_replay import (
-        RouterReplay,
-        RouterReplayAction,
-    )
+def _compute_get_replay_topk(
+    replay_instance: Any,
+    scores: torch.Tensor,
+    topk: int,
+    num_groups: Optional[int],
+    group_topk: Optional[int],
+    default_compute_topk: Optional[Any],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply the missing-route fallback, else delegate to upstream get_replay_topk."""
+    from megatron.core.transformer.moe.router_replay import RouterReplayAction
 
-    if getattr(RouterReplay.get_replay_topk, _MISSING_ROUTE_FALLBACK_PATCH_ATTR, False):
+    assert _original_get_replay_topk is not None
+
+    action = getattr(replay_instance, "router_replay_action", None)
+    if action not in {
+        RouterReplayAction.REPLAY_FORWARD,
+        RouterReplayAction.REPLAY_BACKWARD,
+    }:
+        return _original_get_replay_topk(
+            replay_instance, scores, topk,
+            num_groups, group_topk, default_compute_topk,
+        )
+
+    if action == RouterReplayAction.REPLAY_FORWARD:
+        target_topk_idx = getattr(replay_instance, "target_topk_idx", None)
+    else:
+        replay_backward_list = getattr(replay_instance, "replay_backward_list", [])
+        target_topk_idx = replay_backward_list[0] if replay_backward_list else None
+
+    if target_topk_idx is None:
+        return _original_get_replay_topk(
+            replay_instance, scores, topk,
+            num_groups, group_topk, default_compute_topk,
+        )
+
+    target_topk_idx = target_topk_idx.to(scores.device)
+    fallback_mask = target_topk_idx.eq(_MISSING_ROUTE_SENTINEL).all(dim=-1)
+    if not bool(fallback_mask.any().item()):
+        return _original_get_replay_topk(
+            replay_instance, scores, topk,
+            num_groups, group_topk, default_compute_topk,
+        )
+
+    if default_compute_topk is None:
+        raise RuntimeError(
+            "RouterReplay missing-route fallback requires default_compute_topk."
+        )
+
+    _, default_indices = default_compute_topk(
+        scores, topk, num_groups=num_groups, group_topk=group_topk,
+    )
+    effective_topk_idx = target_topk_idx.clone()
+    effective_topk_idx[fallback_mask] = default_indices[fallback_mask]
+    probs = scores.gather(1, effective_topk_idx)
+
+    if action == RouterReplayAction.REPLAY_FORWARD:
+        replay_backward_list = getattr(replay_instance, "replay_backward_list", [])
+        if replay_backward_list:
+            replay_backward_list[-1] = effective_topk_idx.detach()
+    else:
+        getattr(replay_instance, "replay_backward_list").pop(0)
+
+    return probs, effective_topk_idx
+
+
+def _wrapped_get_replay_topk(
+    replay_instance: Any,
+    scores: torch.Tensor,
+    topk: int,
+    num_groups: Optional[int] = None,
+    group_topk: Optional[int] = None,
+    default_compute_topk: Optional[Any] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Permanent replacement for Megatron's RouterReplay.get_replay_topk.
+
+    Applies NeMo RL's missing-route fallback and feeds the r3_trace forward
+    verifier in a single pass. Both responsibilities live here so there is no
+    cross-module patch composition.
+    """
+    trace_ctx = replay_topk_snapshot(replay_instance)
+    probs, top_indices = _compute_get_replay_topk(
+        replay_instance, scores, topk,
+        num_groups, group_topk, default_compute_topk,
+    )
+    replay_topk_record(replay_instance, scores, topk, trace_ctx, top_indices)
+    return probs, top_indices
+
+
+def _install_get_replay_topk_wrapper() -> None:
+    """Install the unified RouterReplay.get_replay_topk wrapper. Idempotent."""
+    global _original_get_replay_topk
+    if _original_get_replay_topk is not None:
         return
 
-    original_get_replay_topk = RouterReplay.get_replay_topk
+    from megatron.core.transformer.moe.router_replay import RouterReplay
+
     expected_non_receiver_params = [
         "scores",
         "topk",
@@ -266,96 +354,31 @@ def _install_missing_route_fallback_patch() -> None:
         "group_topk",
         "default_compute_topk",
     ]
-    actual_params = list(inspect.signature(original_get_replay_topk).parameters)
-    # Wrapper receiver names are arbitrary; guard only Megatron's callable API.
-    actual_non_receiver_params = actual_params[1:]
-    if actual_non_receiver_params != expected_non_receiver_params:
+    actual_params = list(inspect.signature(RouterReplay.get_replay_topk).parameters)
+    # Receiver names are arbitrary; guard only Megatron's callable API (see #2963).
+    if actual_params[1:] != expected_non_receiver_params:
         raise RuntimeError(
             "Unsupported Megatron RouterReplay.get_replay_topk signature for "
-            "NeMo RL missing-route fallback patch: "
+            "NeMo RL router replay wrapper: "
             f"expected_non_receiver_params={expected_non_receiver_params}, "
             f"actual={actual_params}. "
             "Update nemo_rl.models.megatron.router_replay before enabling "
             "policy.router_replay.enabled."
         )
 
-    @wraps(original_get_replay_topk)
-    def wrapped_get_replay_topk(
-        replay_instance: Any,
-        scores: torch.Tensor,
-        topk: int,
-        num_groups: Optional[int] = None,
-        group_topk: Optional[int] = None,
-        default_compute_topk: Optional[Any] = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        action = getattr(replay_instance, "router_replay_action", None)
-        if action not in {
-            RouterReplayAction.REPLAY_FORWARD,
-            RouterReplayAction.REPLAY_BACKWARD,
-        }:
-            return original_get_replay_topk(
-                replay_instance,
-                scores,
-                topk,
-                num_groups,
-                group_topk,
-                default_compute_topk,
-            )
+    _original_get_replay_topk = RouterReplay.get_replay_topk
+    RouterReplay.get_replay_topk = _wrapped_get_replay_topk
 
-        if action == RouterReplayAction.REPLAY_FORWARD:
-            target_topk_idx = getattr(replay_instance, "target_topk_idx", None)
-        else:
-            replay_backward_list = getattr(replay_instance, "replay_backward_list", [])
-            target_topk_idx = replay_backward_list[0] if replay_backward_list else None
 
-        if target_topk_idx is None:
-            return original_get_replay_topk(
-                replay_instance,
-                scores,
-                topk,
-                num_groups,
-                group_topk,
-                default_compute_topk,
-            )
+def _reset_router_replay_wrapper_for_tests() -> None:
+    """Test-only: restore upstream RouterReplay.get_replay_topk. Not for production."""
+    global _original_get_replay_topk
+    if _original_get_replay_topk is None:
+        return
+    from megatron.core.transformer.moe.router_replay import RouterReplay
 
-        target_topk_idx = target_topk_idx.to(scores.device)
-        fallback_mask = target_topk_idx.eq(_MISSING_ROUTE_SENTINEL).all(dim=-1)
-        if not bool(fallback_mask.any().item()):
-            return original_get_replay_topk(
-                replay_instance,
-                scores,
-                topk,
-                num_groups,
-                group_topk,
-                default_compute_topk,
-            )
-
-        if default_compute_topk is None:
-            raise RuntimeError(
-                "RouterReplay missing-route fallback requires default_compute_topk."
-            )
-
-        _, default_indices = default_compute_topk(
-            scores,
-            topk,
-            num_groups=num_groups,
-            group_topk=group_topk,
-        )
-        effective_topk_idx = target_topk_idx.clone()
-        effective_topk_idx[fallback_mask] = default_indices[fallback_mask]
-        probs = scores.gather(1, effective_topk_idx)
-
-        if action == RouterReplayAction.REPLAY_FORWARD:
-            replay_backward_list = getattr(replay_instance, "replay_backward_list", [])
-            if replay_backward_list:
-                replay_backward_list[-1] = effective_topk_idx.detach()
-        else:
-            getattr(replay_instance, "replay_backward_list").pop(0)
-
-        return probs, effective_topk_idx
-
-    setattr(wrapped_get_replay_topk, _MISSING_ROUTE_FALLBACK_PATCH_ATTR, True)
-    RouterReplay.get_replay_topk = wrapped_get_replay_topk
+    RouterReplay.get_replay_topk = _original_get_replay_topk
+    _original_get_replay_topk = None
 
 
 def _get_tensor_model_parallel_world_size() -> int:
@@ -479,7 +502,7 @@ def build_router_replay_assignments(
 def set_router_replay_forward(model: Any, routed_experts: torch.Tensor) -> None:
     from megatron.core.transformer.moe.router_replay import RouterReplayAction
 
-    _install_missing_route_fallback_patch()
+    _install_get_replay_topk_wrapper()
     for replay_instance, replay_tensor in build_router_replay_assignments(
         model, routed_experts
     ):

--- a/nemo_rl/models/megatron/router_replay.py
+++ b/nemo_rl/models/megatron/router_replay.py
@@ -251,6 +251,30 @@ def _validate_replay_tensor(
         )
 
 
+# Per-process fallback accounting for the training-side replay forward. Drained
+# once per train step by the Megatron worker into
+# r3/train_fallback_token_route_fraction (the train-side mirror of the
+# generation-side fallback metrics, which a transport-side trace desync would
+# never show).
+G_REPLAY_FALLBACK_ROWS = 0
+G_REPLAY_TOTAL_ROWS = 0
+
+
+def _note_replay_fallback(fallback_rows: int, total_rows: int) -> None:
+    global G_REPLAY_FALLBACK_ROWS, G_REPLAY_TOTAL_ROWS
+    G_REPLAY_FALLBACK_ROWS += fallback_rows
+    G_REPLAY_TOTAL_ROWS += total_rows
+
+
+def consume_replay_fallback_stats() -> tuple[int, int]:
+    """Return and reset (fallback_rows, total_rows) accumulated since last call."""
+    global G_REPLAY_FALLBACK_ROWS, G_REPLAY_TOTAL_ROWS
+    stats = (G_REPLAY_FALLBACK_ROWS, G_REPLAY_TOTAL_ROWS)
+    G_REPLAY_FALLBACK_ROWS = 0
+    G_REPLAY_TOTAL_ROWS = 0
+    return stats
+
+
 def _compute_get_replay_topk(
     replay_instance: Any,
     scores: torch.Tensor,
@@ -270,8 +294,12 @@ def _compute_get_replay_topk(
         RouterReplayAction.REPLAY_BACKWARD,
     }:
         return _original_get_replay_topk(
-            replay_instance, scores, topk,
-            num_groups, group_topk, default_compute_topk,
+            replay_instance,
+            scores,
+            topk,
+            num_groups,
+            group_topk,
+            default_compute_topk,
         )
 
     if action == RouterReplayAction.REPLAY_FORWARD:
@@ -282,16 +310,27 @@ def _compute_get_replay_topk(
 
     if target_topk_idx is None:
         return _original_get_replay_topk(
-            replay_instance, scores, topk,
-            num_groups, group_topk, default_compute_topk,
+            replay_instance,
+            scores,
+            topk,
+            num_groups,
+            group_topk,
+            default_compute_topk,
         )
 
     target_topk_idx = target_topk_idx.to(scores.device)
     fallback_mask = target_topk_idx.eq(_MISSING_ROUTE_SENTINEL).all(dim=-1)
-    if not bool(fallback_mask.any().item()):
+    fallback_rows = int(fallback_mask.sum().item())
+    if action == RouterReplayAction.REPLAY_FORWARD:
+        _note_replay_fallback(fallback_rows, int(target_topk_idx.shape[0]))
+    if fallback_rows == 0:
         return _original_get_replay_topk(
-            replay_instance, scores, topk,
-            num_groups, group_topk, default_compute_topk,
+            replay_instance,
+            scores,
+            topk,
+            num_groups,
+            group_topk,
+            default_compute_topk,
         )
 
     if default_compute_topk is None:
@@ -300,7 +339,10 @@ def _compute_get_replay_topk(
         )
 
     _, default_indices = default_compute_topk(
-        scores, topk, num_groups=num_groups, group_topk=group_topk,
+        scores,
+        topk,
+        num_groups=num_groups,
+        group_topk=group_topk,
     )
     effective_topk_idx = target_topk_idx.clone()
     effective_topk_idx[fallback_mask] = default_indices[fallback_mask]
@@ -332,8 +374,12 @@ def _wrapped_get_replay_topk(
     """
     trace_ctx = replay_topk_snapshot(replay_instance)
     probs, top_indices = _compute_get_replay_topk(
-        replay_instance, scores, topk,
-        num_groups, group_topk, default_compute_topk,
+        replay_instance,
+        scores,
+        topk,
+        num_groups,
+        group_topk,
+        default_compute_topk,
     )
     replay_topk_record(replay_instance, scores, topk, trace_ctx, top_indices)
     return probs, top_indices

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -67,7 +67,10 @@ from nemo_rl.models.megatron.pipeline_parallel import (
     broadcast_obj_from_pp_rank,
     broadcast_tensors_from_last_stage,
 )
-from nemo_rl.models.megatron.router_replay import router_replay_enabled
+from nemo_rl.models.megatron.router_replay import (
+    consume_replay_fallback_stats,
+    router_replay_enabled,
+)
 from nemo_rl.models.megatron.setup import (
     finalize_megatron_setup,
     handle_model_import,
@@ -838,6 +841,12 @@ class MegatronPolicyWorkerImpl(
             losses=losses,
             data_parallel_group=parallel_state.get_data_parallel_group(),
         )
+
+        if self._router_replay_enabled:
+            fallback_rows, total_rows = consume_replay_fallback_stats()
+            mb_metrics["r3/train_fallback_token_route_fraction"] = [
+                fallback_rows / total_rows if total_rows else 0.0
+            ]
 
         metrics = {
             "global_loss": global_loss.cpu(),

--- a/nemo_rl/utils/r3_trace.py
+++ b/nemo_rl/utils/r3_trace.py
@@ -24,7 +24,6 @@ import time
 from collections import defaultdict
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager, nullcontext
-from functools import wraps
 from pathlib import Path
 from typing import Any, Optional
 
@@ -41,9 +40,6 @@ _DEFAULT_TRACE_SAMPLES = 2
 _DEFAULT_TRACE_MICROBATCHES = 2
 
 _write_lock = threading.Lock()
-_patch_lock = threading.Lock()
-_router_replay_patch_depth = 0
-_original_get_replay_topk: Optional[Any] = None
 _event_counts: dict[str, int] = defaultdict(int)
 _context: contextvars.ContextVar[Optional[dict[str, Any]]] = contextvars.ContextVar(
     "nrl_r3_trace_context",
@@ -284,84 +280,53 @@ def _trace_router_replay_topk_use(
         )
 
 
-@contextmanager
-def _verify_router_replay_forward_context() -> Iterator[None]:
-    global _original_get_replay_topk, _router_replay_patch_depth
+def replay_topk_snapshot(replay_instance: Any) -> Optional[tuple[Any, Any, int]]:
+    """Pre-call hook for the RouterReplay.get_replay_topk wrapper.
 
-    if not r3_trace_verify_forward_enabled():
-        yield
+    Returns (action, expected, backward_len_before) when verification is active,
+    else None. The wrapper in nemo_rl.models.megatron.router_replay calls this
+    before computing the result, then passes the returned ctx to
+    replay_topk_record.
+    """
+    if not r3_trace_verify_forward_enabled() or _current_context() is None:
+        return None
+
+    from megatron.core.transformer.moe.router_replay import RouterReplayAction
+
+    action = getattr(replay_instance, "router_replay_action", None)
+    backward_list = getattr(replay_instance, "replay_backward_list", [])
+    if action == RouterReplayAction.REPLAY_FORWARD:
+        expected = getattr(replay_instance, "target_topk_idx", None)
+    elif action == RouterReplayAction.REPLAY_BACKWARD:
+        expected = backward_list[0] if backward_list else None
+    else:
+        return None
+    return action, expected, len(backward_list)
+
+
+def replay_topk_record(
+    replay_instance: Any,
+    scores: Any,
+    topk: int,
+    ctx: Optional[tuple[Any, Any, int]],
+    actual: Any,
+) -> None:
+    """Post-call hook for the RouterReplay.get_replay_topk wrapper. No-ops when ctx is None."""
+    if ctx is None:
         return
-
-    from megatron.core.transformer.moe.router_replay import (
-        RouterReplay,
-        RouterReplayAction,
+    action, expected, before = ctx
+    _trace_router_replay_topk_use(
+        replay_instance=replay_instance,
+        action=action,
+        scores=scores,
+        topk=topk,
+        expected=expected,
+        actual=actual,
+        backward_list_len_before=before,
+        backward_list_len_after=len(
+            getattr(replay_instance, "replay_backward_list", [])
+        ),
     )
-
-    with _patch_lock:
-        if _router_replay_patch_depth == 0:
-            original_get_replay_topk = RouterReplay.get_replay_topk
-            _original_get_replay_topk = original_get_replay_topk
-
-            @wraps(original_get_replay_topk)
-            def wrapped_get_replay_topk(
-                replay_instance: Any,
-                scores: Any,
-                topk: int,
-                num_groups: Optional[int] = None,
-                group_topk: Optional[int] = None,
-                default_compute_topk: Optional[Any] = None,
-            ) -> tuple[Any, Any]:
-                action = getattr(replay_instance, "router_replay_action", None)
-                backward_list = getattr(replay_instance, "replay_backward_list", [])
-                backward_len_before = len(backward_list)
-                expected = None
-                if action == RouterReplayAction.REPLAY_FORWARD:
-                    expected = getattr(replay_instance, "target_topk_idx", None)
-                elif action == RouterReplayAction.REPLAY_BACKWARD:
-                    expected = backward_list[0] if backward_list else None
-
-                assert _original_get_replay_topk is not None
-                probs, top_indices = _original_get_replay_topk(
-                    replay_instance,
-                    scores,
-                    topk,
-                    num_groups,
-                    group_topk,
-                    default_compute_topk,
-                )
-
-                if action in {
-                    RouterReplayAction.REPLAY_FORWARD,
-                    RouterReplayAction.REPLAY_BACKWARD,
-                }:
-                    _trace_router_replay_topk_use(
-                        replay_instance=replay_instance,
-                        action=action,
-                        scores=scores,
-                        topk=topk,
-                        expected=expected,
-                        actual=top_indices,
-                        backward_list_len_before=backward_len_before,
-                        backward_list_len_after=len(
-                            getattr(replay_instance, "replay_backward_list", [])
-                        ),
-                    )
-                return probs, top_indices
-
-            RouterReplay.get_replay_topk = wrapped_get_replay_topk
-        _router_replay_patch_depth += 1
-
-    try:
-        yield
-    finally:
-        with _patch_lock:
-            _router_replay_patch_depth -= 1
-            if (
-                _router_replay_patch_depth == 0
-                and _original_get_replay_topk is not None
-            ):
-                RouterReplay.get_replay_topk = _original_get_replay_topk
-                _original_get_replay_topk = None
 
 
 def trace_rollout_payload(
@@ -460,8 +425,7 @@ def r3_trace_stage(stage: str) -> Iterator[None]:
         }
     )
     try:
-        with _verify_router_replay_forward_context():
-            yield
+        yield
     finally:
         _context.reset(token)
 

--- a/tests/unit/models/megatron/test_router_replay.py
+++ b/tests/unit/models/megatron/test_router_replay.py
@@ -603,9 +603,12 @@ def test_r3_trace_forward_verifier_records_actual_replayed_topk(tmp_path, monkey
 
 
 @pytest.mark.mcore
-def test_missing_route_fallback_patch_is_idempotent_inside_r3_trace_verifier(
+def test_unified_wrapper_install_is_idempotent_inside_r3_trace_verifier(
     tmp_path, monkeypatch
 ):
+    """Ported from the #2963 regression test: installing the wrapper while a trace
+    verifier stage is active must be a no-op, and the installed wrapper must stay
+    the unified one (the old two-patch composition bug cannot recur by design)."""
     from megatron.core.transformer.moe.router_replay import RouterReplay
 
     from nemo_rl.models.megatron import router_replay
@@ -617,20 +620,15 @@ def test_missing_route_fallback_patch_is_idempotent_inside_r3_trace_verifier(
     RouterReplay.clear_global_router_replay_instances()
 
     try:
-        router_replay._install_missing_route_fallback_patch()
-        assert getattr(
-            RouterReplay.get_replay_topk,
-            router_replay._MISSING_ROUTE_FALLBACK_PATCH_ATTR,
-            False,
-        )
+        router_replay._install_get_replay_topk_wrapper()
+        assert RouterReplay.get_replay_topk is router_replay._wrapped_get_replay_topk
 
         with r3_trace_stage("unit-forward"):
-            assert getattr(
-                RouterReplay.get_replay_topk,
-                router_replay._MISSING_ROUTE_FALLBACK_PATCH_ATTR,
-                False,
+            router_replay._install_get_replay_topk_wrapper()
+            assert (
+                RouterReplay.get_replay_topk
+                is router_replay._wrapped_get_replay_topk
             )
-            router_replay._install_missing_route_fallback_patch()
     finally:
         RouterReplay.clear_global_router_replay_instances()
 
@@ -924,7 +922,7 @@ def test_router_replay_missing_route_sentinel_uses_megatron_topk():
     )
 
     from nemo_rl.models.megatron.router_replay import (
-        _install_missing_route_fallback_patch,
+        _install_get_replay_topk_wrapper,
     )
 
     RouterReplay.clear_global_router_replay_instances()
@@ -945,7 +943,7 @@ def test_router_replay_missing_route_sentinel_uses_megatron_topk():
         expected_default = torch.topk(scores, k=2, dim=1).indices
         expected_mixed = torch.stack([target[0], expected_default[1]])
 
-        _install_missing_route_fallback_patch()
+        _install_get_replay_topk_wrapper()
         replay.set_target_indices(target)
         replay.set_router_replay_action(RouterReplayAction.REPLAY_FORWARD)
         _, forward_indices = replay.get_replay_topk(
@@ -974,7 +972,7 @@ def test_router_replay_backward_queue_is_fifo_across_replayed_microbatches():
     )
 
     from nemo_rl.models.megatron.router_replay import (
-        _install_missing_route_fallback_patch,
+        _install_get_replay_topk_wrapper,
     )
 
     RouterReplay.clear_global_router_replay_instances()
@@ -983,7 +981,7 @@ def test_router_replay_backward_queue_is_fifo_across_replayed_microbatches():
         return torch.topk(scores, k=topk, dim=1)
 
     try:
-        _install_missing_route_fallback_patch()
+        _install_get_replay_topk_wrapper()
         replay = RouterReplay()
         scores_0 = torch.tensor(
             [
@@ -1076,4 +1074,41 @@ def test_clear_global_router_replay_instances_clears_registry():
 
         assert RouterReplay.global_router_replay_instances == []
     finally:
+        RouterReplay.clear_global_router_replay_instances()
+
+
+@pytest.mark.mcore
+def test_get_replay_topk_wrapper_is_idempotent_and_survives_r3_trace_stage(
+    tmp_path, monkeypatch
+):
+    from megatron.core.transformer.moe.router_replay import RouterReplay
+
+    from nemo_rl.models.megatron.router_replay import (
+        _install_get_replay_topk_wrapper,
+        _reset_router_replay_wrapper_for_tests,
+        _wrapped_get_replay_topk,
+    )
+    from nemo_rl.utils.r3_trace import r3_trace_stage
+
+    monkeypatch.setenv("NRL_R3_TRACE", "1")
+    monkeypatch.setenv("NRL_R3_TRACE_VERIFY_FORWARD", "1")
+    monkeypatch.setenv("NRL_R3_TRACE_DIR", str(tmp_path))
+    RouterReplay.clear_global_router_replay_instances()
+    _reset_router_replay_wrapper_for_tests()
+
+    try:
+        _install_get_replay_topk_wrapper()
+        assert RouterReplay.get_replay_topk is _wrapped_get_replay_topk
+
+        _install_get_replay_topk_wrapper()
+        assert RouterReplay.get_replay_topk is _wrapped_get_replay_topk
+
+        with r3_trace_stage("unit-forward"):
+            assert RouterReplay.get_replay_topk is _wrapped_get_replay_topk
+            _install_get_replay_topk_wrapper()
+            assert RouterReplay.get_replay_topk is _wrapped_get_replay_topk
+
+        assert RouterReplay.get_replay_topk is _wrapped_get_replay_topk
+    finally:
+        _reset_router_replay_wrapper_for_tests()
         RouterReplay.clear_global_router_replay_instances()

--- a/tests/unit/models/megatron/test_router_replay.py
+++ b/tests/unit/models/megatron/test_router_replay.py
@@ -626,8 +626,7 @@ def test_unified_wrapper_install_is_idempotent_inside_r3_trace_verifier(
         with r3_trace_stage("unit-forward"):
             router_replay._install_get_replay_topk_wrapper()
             assert (
-                RouterReplay.get_replay_topk
-                is router_replay._wrapped_get_replay_topk
+                RouterReplay.get_replay_topk is router_replay._wrapped_get_replay_topk
             )
     finally:
         RouterReplay.clear_global_router_replay_instances()
@@ -1112,3 +1111,38 @@ def test_get_replay_topk_wrapper_is_idempotent_and_survives_r3_trace_stage(
     finally:
         _reset_router_replay_wrapper_for_tests()
         RouterReplay.clear_global_router_replay_instances()
+
+
+@pytest.mark.mcore
+def test_replay_fallback_stats_accumulate_and_reset(monkeypatch):
+    from types import SimpleNamespace
+
+    from megatron.core.transformer.moe.router_replay import RouterReplayAction
+
+    from nemo_rl.models.megatron import router_replay
+
+    monkeypatch.setattr(router_replay, "G_REPLAY_FALLBACK_ROWS", 0)
+    monkeypatch.setattr(router_replay, "G_REPLAY_TOTAL_ROWS", 0)
+    router_replay._install_get_replay_topk_wrapper()
+
+    scores = torch.rand(4, 8)
+    target = torch.tensor([[0, 1], [-1, -1], [2, 3], [-1, -1]])
+    replay_instance = SimpleNamespace(
+        router_replay_action=RouterReplayAction.REPLAY_FORWARD,
+        target_topk_idx=target,
+        replay_backward_list=[target],
+    )
+
+    def default_compute_topk(scores, topk, num_groups=None, group_topk=None):
+        values, indices = torch.topk(scores, k=topk, dim=-1)
+        return values, indices
+
+    probs, indices = router_replay._wrapped_get_replay_topk(
+        replay_instance, scores, 2, None, None, default_compute_topk
+    )
+
+    assert indices.shape == (4, 2)
+    assert not indices.eq(-1).any()
+    assert router_replay.consume_replay_fallback_stats() == (2, 4)
+    # drained -> second read is zeroed
+    assert router_replay.consume_replay_fallback_stats() == (0, 0)


### PR DESCRIPTION
# What does this PR do ?
Router replay injects two NeMo-RL behaviors into Megatron's RouterReplay.get_replay_topk by monkey-patching it: the missing-route fallback (compute routing normally where the recorded route is the all--1 sentinel) and the trace forward-verifier (record replay-vs-expected for check_r3_trace). Today these are two independent patches from two modules, so r3_trace.py needs machinery to keep them from colliding — _patch_lock, _router_replay_patch_depth, _original_get_replay_topk. 

There is only ever one method to replace, so this PR replaces it once. router_replay.py installs a single permanent wrapper doing both jobs; r3_trace.py stops patching and exposes passive hooks the wrapper calls. Result: _patch_lock and _router_replay_patch_depth are deleted, the install is idempotent and never restored mid-run,.

# Validation
We didn't observe any regression after changing this. 
<img width="1198" height="324" alt="Screenshot 2026-07-08 at 2 23 49 PM" src="https://github.com/user-attachments/assets/c7b8bc45-b14c-4558-bce3-c31f91beeb38" />
