### PR TITLE
fix: stop scaling scontrol RPCs with node count in ray.sub CPU detection

### DIFF
--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -143,10 +143,11 @@ sbatch ray.sub \
     into the container and will override the container's default `UV_CACHE_DIR`.
 * - `CPUS_PER_WORKER`
   - CPUs each Ray worker node claims. If unset, `ray.sub` auto-detects this from
-    Slurm (the `CPUTot` of the allocated nodes) so that Ray sees every CPU on the
-    node. Detection asserts all allocated nodes report the same CPU count and
-    errors out otherwise; set this explicitly to override (e.g. for a
-    heterogeneous allocation).
+    Slurm (the `CPUTot` of the first allocated node) so that Ray sees every CPU
+    on the node. Detection assumes a homogeneous allocation (all nodes have the
+    same CPU count) and only queries a single node to avoid hammering the Slurm
+    controller with one RPC per node; set this explicitly for a heterogeneous
+    allocation or to override detection.
 * - `GPUS_PER_NODE=8`
   - Number of GPUs each Ray worker node claims. To determine this, run `nvidia-smi` on a worker node.
 * - `BASE_LOG_DIR=$SLURM_SUBMIT_DIR`

--- a/ray.sub
+++ b/ray.sub
@@ -49,33 +49,34 @@ maybe_gres_arg() {
 # Function to detect the number of CPUs per node from SLURM
 ########################################################
 detect_cpus_per_node() {
-  # Query SLURM for the total number of CPUs (CPUTot) on every allocated node.
-  # With --exclusive whole-node allocations (the default for this script) this
-  # is the full CPU count of the node, which is what we want to claim per worker
-  # so Ray sees every CPU. We assert that all allocated nodes report the same
-  # CPUTot: a heterogeneous allocation breaks the single CPUS_PER_WORKER
-  # assumption and is treated as a user error. On any failure we exit (no
-  # heuristic fallback); set CPUS_PER_WORKER explicitly to override.
-  local node raw cpus expected_cpus=""
-  for node in $(scontrol show hostnames "$SLURM_JOB_NODELIST"); do
-    # Parse "CPUTot=<n>" out of the single-line (`-o`) node description using
-    # pure bash parameter expansion (no grep/awk pipeline) so we don't trip
-    # `set -e`/`pipefail` on a non-matching or short-circuited pipe.
-    raw=$(scontrol show node "$node" -o 2>/dev/null || true)
-    cpus=${raw#*CPUTot=}
-    cpus=${cpus%% *}
-    if ! [[ "$cpus" =~ ^[0-9]+$ ]] || [[ "$cpus" -le 0 ]]; then
-      echo "Error: Could not determine CPUTot for node '$node' from SLURM. Set CPUS_PER_WORKER explicitly to override." >&2
-      exit 1
-    fi
-    if [[ -z "$expected_cpus" ]]; then
-      expected_cpus=$cpus
-    elif [[ "$cpus" -ne "$expected_cpus" ]]; then
-      echo "Error: Heterogeneous CPU counts across allocated nodes (node '$node' reports CPUTot=$cpus but expected $expected_cpus). NeMo-RL assumes a homogeneous allocation; set CPUS_PER_WORKER explicitly to override." >&2
-      exit 1
-    fi
-  done
-  echo "$expected_cpus"
+  # Query SLURM for the total number of CPUs (CPUTot) on the first allocated
+  # node. With --exclusive whole-node allocations (the default for this script)
+  # this is the full CPU count of the node, which is what we want to claim per
+  # worker so Ray sees every CPU.
+  #
+  # ASSUMPTION: all allocated nodes have the same CPU count (homogeneous
+  # allocation), so reading a single node is sufficient. We deliberately do
+  # NOT query every node: each `scontrol show node` is an RPC to the SLURM
+  # controller, and issuing one per node across many jobs launched in a burst
+  # (e.g. CI) can overwhelm the controller. If your allocation is
+  # heterogeneous, set CPUS_PER_WORKER explicitly instead. On any failure we
+  # exit (no heuristic fallback); set CPUS_PER_WORKER explicitly to override.
+  local nodelist first_node raw cpus
+  # `scontrol show hostnames` expands the compressed nodelist string locally
+  # (no controller RPC). Take the first line with parameter expansion (no
+  # head/grep pipeline, to avoid `set -e`/`pipefail` foot-guns).
+  nodelist=$(scontrol show hostnames "$SLURM_JOB_NODELIST")
+  first_node=${nodelist%%$'\n'*}
+  # Parse "CPUTot=<n>" out of the single-line (`-o`) node description using
+  # pure bash parameter expansion.
+  raw=$(scontrol show node "$first_node" -o 2>/dev/null || true)
+  cpus=${raw#*CPUTot=}
+  cpus=${cpus%% *}
+  if ! [[ "$cpus" =~ ^[0-9]+$ ]] || [[ "$cpus" -le 0 ]]; then
+    echo "Error: Could not determine CPUTot for node '$first_node' from SLURM. Set CPUS_PER_WORKER explicitly to override." >&2
+    exit 1
+  fi
+  echo "$cpus"
 }
 
 ########################################################

--- a/ray.sub
+++ b/ray.sub
@@ -215,13 +215,13 @@ COMMON_SRUN_ARGS+=" -A $SLURM_JOB_ACCOUNT"
 # Number of CPUs per worker node. If the user did not set CPUS_PER_WORKER
 # explicitly, auto-detect it from SLURM so we claim every CPU the node actually
 # has (instead of the old GPUS_PER_NODE * 16 heuristic, which under-claims on
-# nodes with more cores). Detection exits with an error if it cannot determine a
-# single consistent CPU count; set CPUS_PER_WORKER explicitly to override.
+# nodes with more cores). Detection queries a single node and assumes a
+# homogeneous allocation; set CPUS_PER_WORKER explicitly to override.
 if [[ -n "${CPUS_PER_WORKER:-}" ]]; then
   echo "[INFO] Using user-provided CPUS_PER_WORKER=$CPUS_PER_WORKER."
 else
   CPUS_PER_WORKER=$(detect_cpus_per_node)
-  echo "[INFO] Auto-detected CPUS_PER_WORKER=$CPUS_PER_WORKER from SLURM (CPUTot of allocated nodes)."
+  echo "[INFO] Auto-detected CPUS_PER_WORKER=$CPUS_PER_WORKER from SLURM (CPUTot of first allocated node)."
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What

Follow-up to #2943. `detect_cpus_per_node()` in `ray.sub` iterated over **all** allocated nodes and ran `scontrol show node` for each one. Every `scontrol show node` is an RPC to the Slurm controller, so the RPC count scaled linearly with the allocation size — and a burst of jobs launched simultaneously (e.g. CI) multiplied by N nodes each can hammer `slurmctld` hard enough to degrade or take down the controller.

# Details

- `detect_cpus_per_node()` now reads `CPUTot` from **only the first allocated node**, so detection issues exactly **one** controller RPC regardless of node count.
- The documented assumption (docstring + `docs/cluster.md`): the allocation is **homogeneous** — all nodes have the same CPU count — so reading one node is sufficient. Heterogeneous allocations should set `CPUS_PER_WORKER` explicitly (same escape hatch as before).
- The per-node homogeneity assert from #2943 is dropped; it was the reason for the O(nodes) loop.
- `scontrol show hostnames` (used to expand the compressed nodelist) is a local hostlist string operation, not a controller RPC. The first hostname is extracted with pure bash parameter expansion (no `head`/`grep` pipeline) to stay `set -e`/`pipefail`-safe, and this path is exercised against real bracket-compressed nodelists in testing below.

# Testing

## Controller RPC count no longer scales with node count

Ran both the old (main) and new `detect_cpus_per_node()` against a real 4-node bracket-compressed nodelist with a `scontrol` shim that logs every invocation:

| Node type | Test nodelist | Old: `scontrol show node` RPCs | New: `scontrol show node` RPCs | Detected CPUs |
|---|---|---|---|---|
| H100 | `pool0-[00001-00004]` | 4 (one per node) | **1** | 128 (old and new agree) |
| GB200 | `nvl72001-T[03-06]` | 4 (one per node) | **1** | 144 (old and new agree) |

The shim log for the new code shows exactly two `scontrol` invocations total — `show hostnames <list>` (local expansion, no controller RPC) and a single `show node <first-node> -o`:

```
show hostnames pool0-[00001-00004]
show node pool0-00001 -o
```

## End-to-end on real multi-node allocations

Ran `ray.sub` from this branch on real 2-node allocations on both node types (>1 node specifically to exercise the compressed-nodelist first-hostname extraction on a real `SLURM_JOB_NODELIST`, including a non-contiguous one):

| Node type | GPUs/node | Real `SLURM_JOB_NODELIST` | Detected `CPUS_PER_WORKER` | Ray node sruns launched with |
|---|---|---|---|---|
| H100 | gpu:8 | `pool0-[01639,01727]` (non-contiguous) | **128** ✓ | 2 × `--cpus-per-task=128` ✓ |
| GB200 | gpu:4 | `nvl72108-T[08-09]` | **144** ✓ | 2 × `--cpus-per-task=144` ✓ |

On H100 the cluster came up fully end-to-end. On GB200 the run failed *after* detection, at container start, due to a corrupt local squashfs image (`enroot: Invalid image format`) — unrelated infra; the detection line and `--cpus-per-task` sruns above are from that run's Slurm log.

There are no unit/functional tests that exercise `ray.sub` cluster bring-up, so `CI:docs` is sufficient here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
