### PR TITLE
feat(sc): add checkpoint save/restore to SingleController

### DIFF
--- a/nemo_rl/algorithms/async_utils/replay_buffer.py
+++ b/nemo_rl/algorithms/async_utils/replay_buffer.py
@@ -701,6 +701,194 @@ class TQReplayBuffer:
 
         return len(drop_idxs)
 
+    async def state_dict(self, *, saved_capacity: int) -> dict[str, Any]:
+        """Serialize ready groups (meta + DataPlane payloads) for checkpointing.
+
+        Snapshots the ready slots synchronously on the event loop first, then
+        fetches each group's rows from the DataPlane. Unready reservations are
+        in-flight rollouts and are dropped, matching legacy semantics. The
+        snapshot stays consistent during the async fetch: concurrent commits
+        only append/flip *other* slots, and the train pump — the only
+        remover — is the caller itself; groups committed mid-save land in the
+        next checkpoint.
+
+        Args:
+            saved_capacity: max_buffered_rollouts at save time, recorded so
+                load_state_dict can report capacity changes across restarts.
+
+        Returns:
+            Envelope: ``{"partition_id": ..., "saved_capacity": ...,
+            "groups": [{"meta", "start_weight", "end_weight", "target_step",
+            "group_id", "fields_data"}, ...]}``.
+        """
+        snapshot: list[tuple[KVBatchMeta, int, int, Optional[int], str]] = []
+        for i, ready in enumerate(self.ready_list):
+            if not ready:
+                continue
+            meta = self.meta_list[i]
+            assert meta is not None  # commit sets meta before ready=True
+            snapshot.append(
+                (
+                    meta,
+                    self.start_weight_list[i],
+                    self.end_weight_list[i],
+                    self.target_step_list[i],
+                    self._group_ids[i],
+                )
+            )
+
+        groups: list[dict[str, Any]] = []
+        for meta, start_weight, end_weight, target_step, group_id in snapshot:
+            fields_data = await self._call_dp(
+                "get_samples",
+                sample_ids=meta.sample_ids,
+                partition_id=self._partition_id,
+                select_fields=meta.fields,
+            )
+            groups.append(
+                {
+                    "meta": meta,
+                    "start_weight": start_weight,
+                    "end_weight": end_weight,
+                    "target_step": target_step,
+                    "group_id": group_id,
+                    "fields_data": fields_data,
+                }
+            )
+        return {
+            "partition_id": self._partition_id,
+            "saved_capacity": saved_capacity,
+            "groups": groups,
+        }
+
+    async def load_state_dict(
+        self,
+        state: dict[str, Any],
+        *,
+        max_groups: int,
+        expected_partition_id: str,
+        expected_group_size: int,
+    ) -> int:
+        """Validate and re-put checkpointed groups into the buffer.
+
+        The preflight runs entirely before any DataPlane write (legacy
+        precedent: validate, then truncate):
+          1. Validate the envelope and raise ValueError on malformed state.
+          2. Truncate to ``max_groups``, keeping the freshest groups, so the
+             restored count can never exceed the buffer's capacity.
+
+        Staleness is intentionally NOT handled here — load only loads. The
+        train pump's first ``StalenessSampler.evict`` drops any restored
+        group that is outside the staleness window and releases its capacity
+        permit, keeping eviction in one place.
+
+        Args:
+            state: Envelope produced by ``state_dict``.
+            max_groups: Current max_buffered_rollouts; the restored count
+                never exceeds it.
+            expected_partition_id: Partition this buffer writes to; must
+                match the envelope.
+            expected_group_size: num_generations_per_prompt; every group must
+                hold exactly this many rows (a changed group size silently
+                breaks the group-relative baseline).
+
+        Returns:
+            Number of groups restored into the buffer.
+
+        Raises:
+            ValueError: If the envelope is malformed (missing keys, partition
+                mismatch, misaligned or wrongly sized groups, duplicate
+                sample_ids).
+        """
+        required_keys = {"partition_id", "saved_capacity", "groups"}
+        missing_keys = required_keys - set(state)
+        if missing_keys:
+            raise ValueError(
+                f"Replay buffer checkpoint missing required keys: {missing_keys}"
+            )
+        if state["partition_id"] != expected_partition_id:
+            raise ValueError(
+                "Replay buffer checkpoint partition_id mismatch: "
+                f"checkpoint={state['partition_id']!r}, "
+                f"expected={expected_partition_id!r}"
+            )
+
+        groups = list(state["groups"])
+        group_keys = {
+            "meta",
+            "start_weight",
+            "end_weight",
+            "target_step",
+            "group_id",
+            "fields_data",
+        }
+        seen_sample_ids: set[str] = set()
+        for group in groups:
+            missing_group_keys = group_keys - set(group)
+            if missing_group_keys:
+                raise ValueError(
+                    f"Replay buffer checkpoint group missing keys: {missing_group_keys}"
+                )
+            meta = group["meta"]
+            num_tags = len(meta.tags) if meta.tags is not None else -1
+            num_lengths = (
+                len(meta.sequence_lengths) if meta.sequence_lengths is not None else -1
+            )
+            if not (
+                len(meta.sample_ids) == num_tags == num_lengths == expected_group_size
+            ):
+                raise ValueError(
+                    "Replay buffer checkpoint group misaligned: "
+                    f"sample_ids={len(meta.sample_ids)}, tags={num_tags}, "
+                    f"sequence_lengths={num_lengths}, "
+                    f"expected_group_size={expected_group_size}"
+                )
+            for sid in meta.sample_ids:
+                if sid in seen_sample_ids:
+                    raise ValueError(
+                        f"Replay buffer checkpoint has duplicate sample_id: {sid!r}"
+                    )
+                seen_sample_ids.add(sid)
+
+        if state["saved_capacity"] != max_groups:
+            print(
+                "TQReplayBuffer capacity changed: "
+                f"checkpoint={state['saved_capacity']}, current={max_groups}. "
+                "Using current config value."
+            )
+        num_truncated = 0
+        if len(groups) > max_groups:
+            num_truncated = len(groups) - max_groups
+            # Keep the freshest max_groups groups, preserving original order.
+            prioritized = sorted(
+                range(len(groups)),
+                key=lambda i: (groups[i]["start_weight"], i),
+            )
+            indices_to_keep = sorted(prioritized[num_truncated:])
+            groups = [groups[i] for i in indices_to_keep]
+
+        for group in groups:
+            meta = group["meta"]
+            await self._call_dp(
+                "put_samples",
+                sample_ids=list(meta.sample_ids),
+                partition_id=self._partition_id,
+                fields=group["fields_data"],
+                tags=[dict(t) for t in meta.tags],
+            )
+            self.meta_list.append(meta)
+            self.start_weight_list.append(group["start_weight"])
+            self.end_weight_list.append(group["end_weight"])
+            self.target_step_list.append(group["target_step"])
+            self.ready_list.append(True)
+            self._group_ids.append(group["group_id"])
+
+        summary = f"📦 Restored {len(groups)} replay group(s) from checkpoint"
+        if num_truncated:
+            summary += f"; truncated {num_truncated} group(s) over capacity"
+        print(summary, flush=True)
+        return len(groups)
+
     def size(self) -> int:
         """Return the number of prompt-group entries currently held."""
         return len(self.meta_list)

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -130,10 +130,11 @@ class SingleControllerActor:
         )
         self._timeout.start_iterations()
 
-        # Loaded (or default) GRPOSaveState; keys SC does not own yet
-        # (current_epoch, ...) pass through to saved checkpoints untouched.
+        # Loaded (or default) GRPOSaveState; keys SC does not own
+        # (val_reward, ...) pass through to saved checkpoints untouched.
         self._save_state: GRPOSaveState = bundle.save_state
         self._consumed_samples: int = bundle.save_state["consumed_samples"]
+        self._current_epoch: int = bundle.save_state["current_epoch"]
         self._total_valid_tokens: int = bundle.save_state.get(
             "total_valid_tokens", 0
         )  # Default to 0 for backward compatibility with older checkpoints
@@ -345,8 +346,7 @@ class SingleControllerActor:
                 sem.release()
 
         max_epochs = self._master_config.grpo["max_num_epochs"]
-        epoch = 0
-        while max_epochs is None or epoch < max_epochs:
+        while max_epochs is None or self._current_epoch < max_epochs:
             for prompt_batch in self._dataloader:
                 # over_sampling=False: batch-level gate on max_rollout_version.
                 if not over_sampling:
@@ -378,9 +378,9 @@ class SingleControllerActor:
                     )
                     self._dispatched_rollouts.add(task)
                     task.add_done_callback(self._dispatched_rollouts.discard)
-            epoch += 1
+            self._current_epoch += 1
 
-        print(f"rollout_pump: completed {epoch} epoch(s)", flush=True)
+        print(f"rollout_pump: completed {self._current_epoch} epoch(s)", flush=True)
 
     async def _train_pump(self) -> None:
         """Drain stale groups, sample, train, drop.
@@ -553,8 +553,15 @@ class SingleControllerActor:
                     save_state = self._save_state
                     save_state["current_step"] = self._train_steps
                     save_state["total_steps"] = self._train_steps
+                    save_state["current_epoch"] = self._current_epoch
                     save_state["consumed_samples"] = self._consumed_samples
                     save_state["total_valid_tokens"] = self._total_valid_tokens
+                    # Snapshot synchronously — no await between the save
+                    # decision and here — so it cannot interleave with
+                    # _rollout_pump iterating this same dataloader (asyncio
+                    # single-threading makes the snapshot race-free); the
+                    # slow torch.save happens off-loop below.
+                    dataloader_state = self._dataloader.state_dict()
                     # SC has no validation loop yet; keep the legacy shape so
                     # wiring it in later only replaces this None.
                     val_metrics: Optional[dict[str, Any]] = None
@@ -615,6 +622,11 @@ class SingleControllerActor:
                                 checkpoint_path, "policy", "tokenizer"
                             ),
                             checkpointing_cfg=self._master_config.checkpointing,
+                        )
+                        await asyncio.to_thread(
+                            torch.save,
+                            dataloader_state,
+                            os.path.join(checkpoint_path, "train_dataloader.pt"),
                         )
                         await asyncio.to_thread(
                             self._checkpointer.finalize_checkpoint, checkpoint_path

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -35,13 +35,16 @@ Data flow:
 from __future__ import annotations
 
 import asyncio
+import os
 import time
+import warnings
 from typing import Any, Optional, Union
 
 import ray
 import torch
 
 from nemo_rl.algorithms.async_utils.staleness_sampler import StalenessSampler
+from nemo_rl.algorithms.grpo import GRPOSaveState
 from nemo_rl.algorithms.single_controller_utils.config import (
     AdvantageConfig,
     MasterConfig,
@@ -60,8 +63,9 @@ from nemo_rl.data_plane import KVBatchMeta
 from nemo_rl.models.generation.sglang.sglang_generation import SGLangGeneration
 from nemo_rl.models.generation.vllm import VllmGeneration
 from nemo_rl.models.policy.tq_policy import TQPolicy
+from nemo_rl.utils.checkpoint import CheckpointManager
 from nemo_rl.utils.logger import Logger
-from nemo_rl.utils.timer import Timer
+from nemo_rl.utils.timer import TimeoutChecker, Timer
 
 Generation = Union[VllmGeneration, SGLangGeneration]
 
@@ -115,6 +119,24 @@ class SingleControllerActor:
         # _thread.lock that Ray can't cloudpickle into the actor.
         self._logger = Logger(master_config.logger)  # type: ignore
         self._timer = Timer()
+
+        # Built here, not on the driver: TimeoutChecker must capture wall-clock
+        # start times inside the actor, not at driver setup time. The bundle
+        # only carries the driver-side restore product (save_state).
+        self._checkpointer = CheckpointManager(master_config.checkpointing)
+        self._timeout = TimeoutChecker(
+            timeout=master_config.checkpointing["checkpoint_must_save_by"],
+            fit_last_save_time=True,
+        )
+        self._timeout.start_iterations()
+
+        # Loaded (or default) GRPOSaveState; keys SC does not own yet
+        # (current_epoch, ...) pass through to saved checkpoints untouched.
+        self._save_state: GRPOSaveState = bundle.save_state
+        self._consumed_samples: int = bundle.save_state["consumed_samples"]
+        self._total_valid_tokens: int = bundle.save_state.get(
+            "total_valid_tokens", 0
+        )  # Default to 0 for backward compatibility with older checkpoints
 
         # Pin clusters so RayVirtualCluster.__del__ doesn't remove the PGs.
         self._train_cluster = bundle.train_cluster
@@ -190,8 +212,10 @@ class SingleControllerActor:
         self._dispatched_rollouts: set[asyncio.Task[None]] = set()
 
         # over_sampling=False batch gate: farthest trainer_version covered by
-        # already-dispatched batches.
-        self._max_rollout_version: int = -1
+        # already-dispatched batches. Restored as current_step - 1 to preserve
+        # the fresh-start invariant _max_rollout_version == _trainer_version - 1
+        # (the quota gate and force_in_order target_step matching rely on it).
+        self._max_rollout_version: int = bundle.save_state["current_step"] - 1
 
         # Backpressure valve: max unconsumed rollout groups allowed in DataPlane.
         # Acquired before each rollout dispatch; released when the buffer
@@ -200,8 +224,8 @@ class SingleControllerActor:
             self._async_cfg.max_buffered_rollouts
         )
 
-        self._trainer_version: int = 0
-        self._train_steps: int = 0
+        self._trainer_version: int = bundle.save_state["current_step"]
+        self._train_steps: int = bundle.save_state["current_step"]
         self._step_log_dict: dict[str, list] = {
             "rewards": [],
             "masked_advantages": [],
@@ -509,6 +533,93 @@ class SingleControllerActor:
                 with self._timer.time("weight_sync"):
                     await self._sync_weights()
 
+                # Checkpointing (ported from the legacy async loop).
+                self._consumed_samples += grpo_cfg["num_prompts_per_step"]
+                self._total_valid_tokens += step_metrics.get("global_valid_toks", 0)
+                self._timeout.mark_iteration()
+
+                is_last_step = self._train_steps >= grpo_cfg["max_num_steps"]
+                save_period = self._master_config.checkpointing["save_period"]
+                # _train_steps was already incremented above, so it equals the
+                # legacy loop's 1-indexed `step + 1`.
+                should_save_by_step = (
+                    is_last_step or self._train_steps % save_period == 0
+                )
+                should_save_by_timeout = self._timeout.check_save()
+
+                if self._master_config.checkpointing["enabled"] and (
+                    should_save_by_step or should_save_by_timeout
+                ):
+                    save_state = self._save_state
+                    save_state["current_step"] = self._train_steps
+                    save_state["total_steps"] = self._train_steps
+                    save_state["consumed_samples"] = self._consumed_samples
+                    save_state["total_valid_tokens"] = self._total_valid_tokens
+                    # SC has no validation loop yet; keep the legacy shape so
+                    # wiring it in later only replaces this None.
+                    val_metrics: Optional[dict[str, Any]] = None
+                    if val_metrics is not None:
+                        save_state["val_reward"] = val_metrics["accuracy"]
+                    elif "val_reward" in save_state:
+                        del save_state["val_reward"]
+
+                    full_metric_name = self._master_config.checkpointing[
+                        "metric_name"
+                    ]
+                    if full_metric_name is not None:
+                        assert full_metric_name.startswith(
+                            "train:"
+                        ) or full_metric_name.startswith("val:"), (
+                            f"metric_name={full_metric_name} must start with 'val:' or 'train:',\n"
+                            f'followed by the corresponding name in the "val" or "train" metrics dictionary.'
+                            f"  If you are using an old config, please updated checkpointing.metric_name to the new format, "
+                            f" e.g. 'val_reward --> 'val:accuracy'"
+                        )
+                        prefix, metric_name = full_metric_name.split(":", 1)
+                        metrics_source = (
+                            step_metrics if prefix == "train" else val_metrics
+                        )
+                        if not metrics_source:
+                            warnings.warn(
+                                f"You asked to save checkpoints based on {metric_name} but no {prefix} metrics were collected. "
+                                "This checkpoint will not be saved as top-k.",
+                                stacklevel=2,
+                            )
+                            if full_metric_name in save_state:
+                                del save_state[full_metric_name]
+                        elif metric_name not in metrics_source:
+                            raise ValueError(
+                                f"Metric {metric_name} not found in {prefix} metrics"
+                            )
+                        else:
+                            save_state[full_metric_name] = metrics_source[
+                                metric_name
+                            ]
+
+                    with self._timer.time("checkpointing"):
+                        print(f"Saving checkpoint for step {self._train_steps}...")
+                        checkpoint_path = self._checkpointer.init_tmp_checkpoint(
+                            self._train_steps, save_state, self._master_config
+                        )
+                        await asyncio.to_thread(
+                            self._trainer.save_checkpoint,
+                            weights_path=os.path.join(
+                                checkpoint_path, "policy", "weights"
+                            ),
+                            optimizer_path=os.path.join(
+                                checkpoint_path, "policy", "optimizer"
+                            )
+                            if self._checkpointer.save_optimizer
+                            else None,
+                            tokenizer_path=os.path.join(
+                                checkpoint_path, "policy", "tokenizer"
+                            ),
+                            checkpointing_cfg=self._master_config.checkpointing,
+                        )
+                        await asyncio.to_thread(
+                            self._checkpointer.finalize_checkpoint, checkpoint_path
+                        )
+
             timing_metrics: dict[str, float] = self._timer.get_timing_metrics(
                 reduction_op="sum"
             )  # type: ignore
@@ -531,8 +642,6 @@ class SingleControllerActor:
                 percent = (v / total_time * 100) if total_time > 0 else 0.0
                 print(f"  • {k}: {v:.2f}s ({percent:.1f}%)")
 
-            # TODO: checkpointing (save_period/top-k metric_name,
-            #   policy.save_checkpoint, dataloader state, TQReplayBuffer state).
             # TODO: per-step train_data jsonl dump, vllm metrics logger,
             #   histogram log, rollout_metrics, seq_logprob_error_metrics,
             #   pretty-print "Training Results" block, print_performance_metrics.
@@ -554,6 +663,10 @@ class SingleControllerActor:
                 f"lag={lag}  ",
                 flush=True,
             )
+
+            if should_save_by_timeout:
+                print("Timeout has been reached, stopping training early", flush=True)
+                break
 
     async def _sync_weights(self) -> None:
         """Drain in-flight rollouts then synchronize weights.

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -122,7 +122,8 @@ class SingleControllerActor:
 
         # Built here, not on the driver: TimeoutChecker must capture wall-clock
         # start times inside the actor, not at driver setup time. The bundle
-        # only carries the driver-side restore product (save_state).
+        # only carries the driver-side restore products (save_state,
+        # last_checkpoint_path).
         self._checkpointer = CheckpointManager(master_config.checkpointing)
         self._timeout = TimeoutChecker(
             timeout=master_config.checkpointing["checkpoint_must_save_by"],
@@ -133,6 +134,7 @@ class SingleControllerActor:
         # Loaded (or default) GRPOSaveState; keys SC does not own
         # (val_reward, ...) pass through to saved checkpoints untouched.
         self._save_state: GRPOSaveState = bundle.save_state
+        self._last_checkpoint_path: Optional[str] = bundle.last_checkpoint_path
         self._consumed_samples: int = bundle.save_state["consumed_samples"]
         self._current_epoch: int = bundle.save_state["current_epoch"]
         self._total_valid_tokens: int = bundle.save_state.get(
@@ -249,6 +251,42 @@ class SingleControllerActor:
         """Main entry point. Runs until max_train_steps is reached."""
         # Synchronize weights before starting the pumps
         await self._sync_weights()
+
+        # Restore committed rollout groups from the previous run. Only when
+        # over_sampling=True — with the strict quota the restored window can
+        # never be completed (see the checkpointing plan's design note).
+        if self._async_cfg.over_sampling and self._last_checkpoint_path is not None:
+            buffer_path = os.path.join(self._last_checkpoint_path, "replay_buffer.pt")
+            if os.path.exists(buffer_path):
+                print(f"📦 Restoring replay buffer from checkpoint: {buffer_path}")
+                # weights_only=False: groups hold pickled KVBatchMeta/TensorDicts,
+                # not plain tensors. The checkpoint is a trusted same-job artifact.
+                buffer_state = await asyncio.to_thread(
+                    torch.load, buffer_path, weights_only=False
+                )
+                restored = await self._buffer.load_state_dict(
+                    buffer_state,
+                    max_groups=self._async_cfg.max_buffered_rollouts,
+                    expected_partition_id=self._partition_id,
+                    expected_group_size=self._master_config.grpo[
+                        "num_generations_per_prompt"
+                    ],
+                )
+                # Each buffered group holds one _buffer_capacity permit. The
+                # load truncation guarantees restored <= capacity, so these
+                # acquisitions never wait — blocking here would hang run()
+                # forever (no pump is running yet to release permits). Any
+                # restored group now outside the staleness window is dropped
+                # by the train pump's first sampler.evict, which releases its
+                # permit — load does not stale-filter.
+                assert restored <= self._async_cfg.max_buffered_rollouts
+                for _ in range(restored):
+                    await self._buffer_capacity.acquire()
+            else:
+                print(
+                    f"⚠️ No replay buffer checkpoint found at {buffer_path}. "
+                    "Starting with an empty replay buffer."
+                )
 
         # Start the rollout and train pumps
         rollout_task = asyncio.create_task(self._rollout_pump())
@@ -628,6 +666,15 @@ class SingleControllerActor:
                             dataloader_state,
                             os.path.join(checkpoint_path, "train_dataloader.pt"),
                         )
+                        if self._async_cfg.over_sampling:
+                            buffer_state = await self._buffer.state_dict(
+                                saved_capacity=self._async_cfg.max_buffered_rollouts
+                            )
+                            await asyncio.to_thread(
+                                torch.save,
+                                buffer_state,
+                                os.path.join(checkpoint_path, "replay_buffer.pt"),
+                            )
                         await asyncio.to_thread(
                             self._checkpointer.finalize_checkpoint, checkpoint_path
                         )

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -23,14 +23,20 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
-from typing import Any, Optional
+from pathlib import Path
+from typing import Any, Optional, cast
 
 from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import AutoProcessor
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
 from nemo_rl.algorithms.async_utils.replay_buffer import TQReplayBuffer
-from nemo_rl.algorithms.grpo import _create_advantage_estimator, _should_use_nemo_gym
+from nemo_rl.algorithms.grpo import (
+    GRPOSaveState,
+    _create_advantage_estimator,
+    _default_grpo_save_state,
+    _should_use_nemo_gym,
+)
 from nemo_rl.algorithms.loss import ClippedPGLossFn
 from nemo_rl.algorithms.loss.interfaces import LossFunction
 from nemo_rl.algorithms.single_controller_utils.config import MasterConfig
@@ -45,6 +51,7 @@ from nemo_rl.experience.rollout_manager import RolloutManager
 from nemo_rl.models.generation.sglang.sglang_generation import SGLangGeneration
 from nemo_rl.models.generation.vllm import VllmGeneration
 from nemo_rl.models.policy.tq_policy import TQPolicy
+from nemo_rl.utils.checkpoint import CheckpointManager
 from nemo_rl.weight_sync import WeightSynchronizer, create_weight_synchronizer
 
 
@@ -69,6 +76,7 @@ class SingleControllerBundle:
     rollout_manager: RolloutManager
     tq_buffer: TQReplayBuffer
     partition_id: str
+    save_state: GRPOSaveState
 
 
 def _build_clusters(
@@ -169,6 +177,9 @@ def _build_trainer(
     master_config: MasterConfig,
     tokenizer,
     processor,
+    *,
+    weights_path: Optional[Path],
+    optimizer_path: Optional[Path],
 ):
     """Build the TQ-mediated trainer (driver-side TQPolicy).
 
@@ -184,8 +195,8 @@ def _build_trainer(
         config=master_config.policy,
         tokenizer=tokenizer,
         processor=processor,
-        weights_path=None,
-        optimizer_path=None,
+        weights_path=weights_path,
+        optimizer_path=optimizer_path,
         init_optimizer=True,
         init_reference_model=init_reference_model,
         dp_cfg=master_config.data_plane,
@@ -270,6 +281,10 @@ def setup_single_controller(
         "single_controller_utils.setup requires policy.generation in master_config"
     )
 
+    checkpointing_pretrained = master_config.checkpointing.get("pretrained_checkpoint")
+    if checkpointing_pretrained is not None:
+        master_config.policy["pretrained_checkpoint"] = checkpointing_pretrained
+
     if data_config["use_multiple_dataloader"]:
         raise NotImplementedError(
             "single_controller_utils does not support "
@@ -277,6 +292,18 @@ def setup_single_controller(
         )
 
     set_seed(grpo_config["seed"])
+
+    # ==========================
+    # Checkpointing
+    # ==========================
+    checkpointer = CheckpointManager(master_config.checkpointing)
+    last_checkpoint_path = checkpointer.get_latest_checkpoint_path()
+    save_state = cast(
+        Optional[GRPOSaveState], checkpointer.load_training_info(last_checkpoint_path)
+    )
+    if save_state is None:
+        save_state = _default_grpo_save_state()
+    weights_path, optimizer_path = checkpointer.get_resume_paths(last_checkpoint_path)
 
     # ==========================
     # Setup Dataset & Environments
@@ -315,7 +342,14 @@ def setup_single_controller(
         # Colocated: vLLM prefers a clean GPU at load time, so generation
         # comes up before the policy.
         generation = _build_generation(inference_cluster, master_config)
-        policy = _build_trainer(train_cluster, master_config, tokenizer, processor)
+        policy = _build_trainer(
+            train_cluster,
+            master_config,
+            tokenizer,
+            processor,
+            weights_path=weights_path,
+            optimizer_path=optimizer_path,
+        )
     else:
         # Non-colocated: generation + policy run on disjoint GPUs, so
         # bring them up in parallel.
@@ -324,7 +358,13 @@ def setup_single_controller(
                 _build_generation, inference_cluster, master_config
             )
             policy_future = executor.submit(
-                _build_trainer, train_cluster, master_config, tokenizer, processor
+                _build_trainer,
+                train_cluster,
+                master_config,
+                tokenizer,
+                processor,
+                weights_path=weights_path,
+                optimizer_path=optimizer_path,
             )
             generation = gen_future.result()
             policy = policy_future.result()
@@ -399,4 +439,5 @@ def setup_single_controller(
         rollout_manager=rollout_manager,
         tq_buffer=tq_buffer,
         partition_id=partition_id,
+        save_state=save_state,
     )

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -78,6 +78,7 @@ class SingleControllerBundle:
     tq_buffer: TQReplayBuffer
     partition_id: str
     save_state: GRPOSaveState
+    last_checkpoint_path: Optional[str]
 
 
 def _build_clusters(
@@ -456,4 +457,5 @@ def setup_single_controller(
         tq_buffer=tq_buffer,
         partition_id=partition_id,
         save_state=save_state,
+        last_checkpoint_path=last_checkpoint_path,
     )

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -21,6 +21,7 @@ runtime_envs and breaks Ray's resource resolution (see the PR #2692 follow-up).
 
 from __future__ import annotations
 
+import os
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
@@ -42,7 +43,7 @@ from nemo_rl.algorithms.loss.interfaces import LossFunction
 from nemo_rl.algorithms.single_controller_utils.config import MasterConfig
 from nemo_rl.algorithms.utils import set_seed
 from nemo_rl.data.collate_fn import rl_collate_fn
-from nemo_rl.data.utils import setup_response_data
+from nemo_rl.data.utils import load_dataloader_state, setup_response_data
 from nemo_rl.data_plane import build_data_plane_client
 from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
 from nemo_rl.environments.interfaces import EnvironmentInterface
@@ -329,6 +330,21 @@ def setup_single_controller(
         drop_last=True,
         num_workers=data_config["num_workers"],
     )
+    if last_checkpoint_path is not None:
+        dataloader_state_path = os.path.join(
+            last_checkpoint_path, "train_dataloader.pt"
+        )
+        if os.path.exists(dataloader_state_path):
+            print(
+                f"📦 Restoring dataloader state from checkpoint: {dataloader_state_path}"
+            )
+            load_dataloader_state(dataloader, last_checkpoint_path, data_config)
+        else:
+            # Pre-Phase-2 checkpoints have no dataloader state.
+            print(
+                f"⚠️ No dataloader state found at {dataloader_state_path}. "
+                "Starting with a fresh dataloader position."
+            )
 
     _clamp_max_num_steps(master_config, dataloader)
     _maybe_inject_megatron_train_iters(master_config, dataloader)

--- a/tests/functional/grpo_checkpoint_single_controller.sh
+++ b/tests/functional/grpo_checkpoint_single_controller.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Verifies that the SingleController (SC) path saves and restores a full
+# checkpoint across a training restart: model weights/optimizer + training
+# state (phase 1), dataloader position (phase 2), and the replay buffer
+# (phase 3, over_sampling=True). Two runs share one checkpoint_dir: run 1
+# trains 2 steps and checkpoints; run 2 resumes and trains 2 more.
+# Same shape as grpo_dp_single_controller.sh (Qwen3-0.6B, 2 GPUs) with the
+# two-run structure of grpo_async_replay_buffer_checkpoint.sh.
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+PROJECT_ROOT=$(realpath $SCRIPT_DIR/../..)
+# Mark the current repo as safe, since wandb fetches metadata about the repo
+git config --global --add safe.directory $PROJECT_ROOT
+
+set -eou pipefail
+
+EXP_NAME=$(basename $0 .sh)
+EXP_DIR=$SCRIPT_DIR/$EXP_NAME
+LOG_DIR=$EXP_DIR/logs
+CKPT_DIR=$EXP_DIR/ckpts
+export PYTHONPATH=${PROJECT_ROOT}:${PYTHONPATH:-}
+
+rm -rf $EXP_DIR
+mkdir -p $EXP_DIR $LOG_DIR $CKPT_DIR
+
+# over_sampling=True (via staleness_window) so replay_buffer.pt is exercised;
+# strict_on_policy would force over_sampling=False and skip it.
+TRAIN_CMD=(
+    uv run coverage run -a --data-file=$PROJECT_ROOT/tests/.coverage --source=$PROJECT_ROOT/nemo_rl
+    $PROJECT_ROOT/examples/run_grpo_single_controller.py
+    policy.model_name=Qwen/Qwen3-0.6B
+    grpo.num_prompts_per_step=2
+    grpo.num_generations_per_prompt=4
+    policy.train_global_batch_size=8
+    policy.train_micro_batch_size=1
+    cluster.gpus_per_node=2
+    logger.tensorboard_enabled=false
+    logger.wandb_enabled=false
+    logger.monitor_gpus=false
+    checkpointing.enabled=true
+    checkpointing.checkpoint_dir=$CKPT_DIR
+    checkpointing.save_period=2
+    # The two runs use different max_num_steps (2 then 4), so the Megatron
+    # backend derives a different train_iters each run (via
+    # _maybe_inject_megatron_train_iters), which changes the optimizer
+    # scheduler's wd_incr_steps/lr_decay_iters. Megatron-LM's
+    # OptimizerParamScheduler.load_state_dict asserts the saved horizon
+    # matches the freshly-built one, so resuming with a longer horizon fails.
+    # override_opt_param_scheduler=true keeps the (new) class schedule on
+    # restore instead of asserting — correct for a resumed RL run that
+    # extends training, and unrelated to the SC checkpoint save/restore under
+    # test (the SC checkpoint itself loads fine). use_checkpoint_...=false is
+    # required alongside override (SchedulerConfig.finalize forbids both true).
+    # These scheduler keys are not in the YAML schema (struct-locked), so
+    # Hydra needs the '+' append prefix to add them.
+    +policy.megatron_cfg.scheduler.override_opt_param_scheduler=true
+    +policy.megatron_cfg.scheduler.use_checkpoint_opt_param_scheduler=false
+    data_plane.enabled=true
+    data_plane.impl=transfer_queue
+    data_plane.backend=simple
+    async_rl.batch_selection_strategy=staleness_window
+    async_rl.max_weight_staleness_versions=1
+    async_rl.min_prompt_groups_per_batch=2
+    async_rl.max_inflight_prompts=4
+    async_rl.max_buffered_rollouts=4
+    async_rl.over_sampling=true
+)
+
+cd $PROJECT_ROOT
+
+# --- Run 1: train 2 steps and checkpoint ---
+echo "=== Run 1: steps 1-2 ==="
+"${TRAIN_CMD[@]}" \
+    grpo.max_num_steps=2 \
+    logger.log_dir=$LOG_DIR/run1 \
+    $@ \
+    2>&1 | tee $EXP_DIR/run1.log
+
+STEP2=$CKPT_DIR/step_2
+for artifact in \
+    "$STEP2/training_info.json" \
+    "$STEP2/config.yaml" \
+    "$STEP2/policy/weights" \
+    "$STEP2/train_dataloader.pt" \
+    "$STEP2/replay_buffer.pt"; do
+    if [[ ! -e "$artifact" ]]; then
+        echo "FAIL: expected checkpoint artifact missing: $artifact"
+        exit 1
+    fi
+done
+echo "✅ step_2 checkpoint artifacts present (weights, dataloader, replay buffer)"
+
+if ! grep -q '"current_step": 2' "$STEP2/training_info.json"; then
+    echo "FAIL: training_info.json does not record current_step=2"
+    cat "$STEP2/training_info.json"
+    exit 1
+fi
+echo "✅ training_info.json records current_step=2"
+
+# --- Run 2: resume from checkpoint and train 2 more steps ---
+echo "=== Run 2: resuming, steps 3-4 ==="
+"${TRAIN_CMD[@]}" \
+    grpo.max_num_steps=4 \
+    logger.log_dir=$LOG_DIR/run2 \
+    $@ \
+    2>&1 | tee $EXP_DIR/run2.log
+
+if ! grep -q "Restoring dataloader state from checkpoint" $EXP_DIR/run2.log; then
+    echo "FAIL: dataloader restore log line not found in run2 output"
+    exit 1
+fi
+echo "✅ dataloader state restored from checkpoint"
+
+if ! grep -q "Restoring replay buffer from checkpoint" $EXP_DIR/run2.log; then
+    echo "FAIL: replay buffer restore log line not found in run2 output"
+    exit 1
+fi
+if ! grep -qF "replay group(s) from checkpoint" $EXP_DIR/run2.log; then
+    echo "FAIL: replay buffer restored-count summary line not found in run2 output"
+    exit 1
+fi
+echo "✅ replay buffer restored from checkpoint"
+
+if [[ ! -e "$CKPT_DIR/step_4" ]]; then
+    echo "FAIL: run2 did not produce step_4 (resume did not reach step 4)"
+    exit 1
+fi
+echo "✅ grpo_sc_checkpoint passed"

--- a/tests/unit/single_controller/test_rollout_pump.py
+++ b/tests/unit/single_controller/test_rollout_pump.py
@@ -24,6 +24,7 @@ import torch
 from tensordict import TensorDict
 
 from nemo_rl.algorithms.async_utils.replay_buffer import TQReplayBuffer
+from nemo_rl.algorithms.grpo import _default_grpo_save_state
 from nemo_rl.algorithms.single_controller import SingleControllerActor
 from nemo_rl.algorithms.single_controller_utils import (
     AsyncRLConfig,
@@ -156,6 +157,7 @@ class _SyncDPAdapter:
 def test_rollout_pump_writes_expected_tq_data(
     multi_step_setup_vllm_async,  # noqa: F811
     single_multi_step_calculator_input_sample,  # noqa: F811
+    tmp_path,
 ):
     """SC._rollout_pump writes max_rollout_prompts * num_generations rows to TQ with the expected fields and tags."""
     vllm_generation, tokenizer, env_handles, _, _ = multi_step_setup_vllm_async
@@ -177,10 +179,35 @@ def test_rollout_pump_writes_expected_tq_data(
     dp_adapter = _SyncDPAdapter(tq_actor)
 
     mc = MasterConfig.model_construct(
+        policy={
+            # __init__'s one-optimizer-step check: prompts * generations == gbs.
+            "train_global_batch_size": max_rollout_prompts * num_generations,
+        },
         grpo={
             "max_num_steps": 1,
             "max_num_epochs": None,
+            # strict_on_policy (over_sampling=False, staleness 0) requires
+            # max_buffered_rollouts == num_prompts_per_step.
+            "num_prompts_per_step": max_rollout_prompts,
             "num_generations_per_prompt": num_generations,
+        },
+        logger={
+            "log_dir": str(tmp_path / "logs"),
+            "wandb_enabled": False,
+            "swanlab_enabled": False,
+            "tensorboard_enabled": False,
+            "mlflow_enabled": False,
+            "monitor_gpus": False,
+        },
+        checkpointing={
+            "enabled": False,
+            "checkpoint_dir": str(tmp_path / "checkpoints"),
+            "metric_name": None,
+            "higher_is_better": False,
+            "keep_top_k": None,
+            "save_period": 10_000,
+            "save_optimizer": False,
+            "checkpoint_must_save_by": None,
         },
         async_rl=AsyncRLConfig(
             batch_selection_strategy="strict_on_policy",
@@ -223,6 +250,7 @@ def test_rollout_pump_writes_expected_tq_data(
         rollout_manager=rollout_manager,
         tq_buffer=tq_buffer,
         partition_id=_PARTITION_ID,
+        save_state=_default_grpo_save_state(),
     )
     ctrl = SingleControllerActor.remote(master_config=mc, bundle=bundle)
 

--- a/tests/unit/single_controller/test_rollout_pump.py
+++ b/tests/unit/single_controller/test_rollout_pump.py
@@ -251,6 +251,7 @@ def test_rollout_pump_writes_expected_tq_data(
         tq_buffer=tq_buffer,
         partition_id=_PARTITION_ID,
         save_state=_default_grpo_save_state(),
+        last_checkpoint_path=None,
     )
     ctrl = SingleControllerActor.remote(master_config=mc, bundle=bundle)
 

--- a/tests/unit/single_controller/test_sc_checkpointing.py
+++ b/tests/unit/single_controller/test_sc_checkpointing.py
@@ -12,14 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for Phase 1 SC checkpointing.
+"""Unit tests for SC checkpointing.
 
-Covers (checkpointing-plan.md, Phase 1 "Testing"):
+Covers (weight and dataloader testing):
   - counter restore from save_state (train_steps / trainer_version /
-    max_rollout_version invariant);
+    max_rollout_version invariant, current_epoch);
   - save trigger + write path through _train_pump with fakes (period
     boundary, last step, timeout, disabled);
   - metric_name behavior (val:* warn-and-save, train:* value recorded);
+  - dataloader state: train_dataloader.pt written at save, position
+    round-trip through a real StatefulDataLoader, dataset-swap guard,
+    setup restore wiring + missing-file fresh-position fallback;
   - setup_single_controller resume-path wiring (get_resume_paths forwarded
     to the trainer factory, save_state loaded from training_info.json).
 """
@@ -34,6 +37,9 @@ from typing import Any, Optional
 from unittest.mock import MagicMock
 
 import pytest
+import torch
+import yaml
+from torchdata.stateful_dataloader import StatefulDataLoader
 
 from nemo_rl.algorithms.grpo import _default_grpo_save_state
 from nemo_rl.algorithms.loss import ClippedPGLossConfig
@@ -44,6 +50,7 @@ from nemo_rl.algorithms.single_controller_utils import (
     SingleControllerBundle,
     setup_single_controller,
 )
+from nemo_rl.data.utils import load_dataloader_state
 from nemo_rl.data_plane import KVBatchMeta
 from nemo_rl.utils.checkpoint import CheckpointManager
 
@@ -168,6 +175,26 @@ class _FakeRolloutManager:
         self.weight_versions.append(version)
 
 
+# Default position sentinel the fake dataloader reports via state_dict().
+_SENTINEL_DL_STATE = {"fake_position": 42}
+
+
+class _FakeDataloader(list):
+    """List-backed dataloader with the StatefulDataLoader state_dict surface.
+
+    The save block snapshots ``self._dataloader.state_dict()``; return a
+    sentinel dict so tests can assert the exact object written to
+    train_dataloader.pt.
+    """
+
+    def __init__(self, batches: Any = (), state: Optional[dict[str, Any]] = None):
+        super().__init__(batches)
+        self._state = dict(state) if state is not None else dict(_SENTINEL_DL_STATE)
+
+    def state_dict(self) -> dict[str, Any]:
+        return dict(self._state)
+
+
 # ── builders ─────────────────────────────────────────────────────────────────
 
 
@@ -237,6 +264,7 @@ def _make_bundle(
     *,
     trainer: Optional[_FakeTrainer] = None,
     save_state: Optional[dict[str, Any]] = None,
+    dataloader: Optional[_FakeDataloader] = None,
 ) -> SingleControllerBundle:
     return SingleControllerBundle(
         gen_handle=object(),
@@ -245,7 +273,7 @@ def _make_bundle(
         train_cluster=None,
         inference_cluster=None,
         dp_client=_FakeDPClient(),
-        dataloader=[],
+        dataloader=dataloader if dataloader is not None else _FakeDataloader(),
         weight_synchronizer=_FakeWeightSynchronizer(),
         advantage_estimator=None,
         loss_fn=object(),
@@ -288,6 +316,7 @@ class TestCounterRestore:
     def test_restore_from_step_n(self, tmp_path):
         save_state = _default_grpo_save_state()
         save_state["current_step"] = 7
+        save_state["current_epoch"] = 2
         save_state["consumed_samples"] = 42
         save_state["total_valid_tokens"] = 1234
 
@@ -298,6 +327,7 @@ class TestCounterRestore:
         # Fresh-start invariant: _max_rollout_version == _trainer_version - 1.
         assert actor._max_rollout_version == 6
         assert actor._consumed_samples == 42
+        assert actor._current_epoch == 2
         assert actor._total_valid_tokens == 1234
 
     def test_fresh_start_defaults(self, tmp_path):
@@ -307,6 +337,7 @@ class TestCounterRestore:
         assert actor._trainer_version == 0
         assert actor._max_rollout_version == -1
         assert actor._consumed_samples == 0
+        assert actor._current_epoch == 0
         assert actor._total_valid_tokens == 0
 
     def test_old_checkpoint_without_total_valid_tokens(self, tmp_path):
@@ -490,6 +521,8 @@ def _write_checkpoint(
     save_state: dict[str, Any],
     *,
     with_optimizer: bool = True,
+    dataloader_state: Optional[dict[str, Any]] = None,
+    config: Optional[dict[str, Any]] = None,
 ) -> Path:
     step_dir = ckpt_dir / f"step_{step}"
     (step_dir / "policy" / "weights").mkdir(parents=True)
@@ -497,6 +530,11 @@ def _write_checkpoint(
         (step_dir / "policy" / "optimizer").mkdir(parents=True)
     with open(step_dir / "training_info.json", "w") as f:
         json.dump(save_state, f)
+    if dataloader_state is not None:
+        torch.save(dataloader_state, step_dir / "train_dataloader.pt")
+    if config is not None:
+        with open(step_dir / "config.yaml", "w") as f:
+            yaml.safe_dump(config, f)
     return step_dir
 
 
@@ -574,7 +612,11 @@ class TestGetResumePaths:
 
 
 class TestSetupResumeWiring:
-    def test_setup_forwards_latest_resume_paths(self, patched_factories, tmp_path):
+    def test_setup_forwards_latest_resume_paths(
+        self,
+        patched_factories,  # noqa: F811
+        tmp_path,
+    ):
         ckpt_dir = tmp_path / "ckpts"
         _write_checkpoint(ckpt_dir, 1, {**_STEP_3_SAVE_STATE, "current_step": 1})
         step_3 = _write_checkpoint(ckpt_dir, 3, _STEP_3_SAVE_STATE)
@@ -589,7 +631,11 @@ class TestSetupResumeWiring:
         # training_info.json is loaded into the bundle for the actor.
         assert bundle.save_state == _STEP_3_SAVE_STATE
 
-    def test_setup_fresh_start_passes_none_paths(self, patched_factories, tmp_path):
+    def test_setup_fresh_start_passes_none_paths(
+        self,
+        patched_factories,  # noqa: F811
+        tmp_path,
+    ):
         ckpt_dir = tmp_path / "empty_ckpts"
         ckpt_dir.mkdir()
         mc = _setup_master_config(str(ckpt_dir))
@@ -601,7 +647,11 @@ class TestSetupResumeWiring:
         assert trainer_kwargs["optimizer_path"] is None
         assert bundle.save_state == _default_grpo_save_state()
 
-    def test_setup_forwards_pretrained_checkpoint(self, patched_factories, tmp_path):
+    def test_setup_forwards_pretrained_checkpoint(
+        self,
+        patched_factories,  # noqa: F811
+        tmp_path,
+    ):
         mc = _setup_master_config(str(tmp_path / "ckpts"))
         pretrained = {"path": "/some/ckpt", "format": "megatron_bridge"}
         mc.checkpointing["pretrained_checkpoint"] = pretrained
@@ -609,3 +659,116 @@ class TestSetupResumeWiring:
         setup_single_controller(mc, MagicMock(pad_token_id=0))
 
         assert mc.policy["pretrained_checkpoint"] == pretrained
+
+
+def _make_int_dataloader() -> StatefulDataLoader:
+    """8 ints, batch_size=2 → batches [0,1], [2,3], [4,5], [6,7]."""
+    return StatefulDataLoader(
+        list(range(8)),
+        batch_size=2,
+        shuffle=False,
+        drop_last=True,
+        num_workers=0,
+    )
+
+
+class TestDataloaderState:
+    def test_save_writes_dataloader_state(self, tmp_path):
+        mc = _actor_master_config(tmp_path, max_num_steps=2, save_period=2)
+        save_state = _default_grpo_save_state()
+        save_state["current_epoch"] = 3
+        dataloader = _FakeDataloader(state={"fake_position": 7})
+
+        _run_train_pump(mc, _make_bundle(save_state=save_state, dataloader=dataloader))
+
+        ckpt_dir = tmp_path / "checkpoints"
+        dl_state_path = ckpt_dir / "step_2" / "train_dataloader.pt"
+        assert dl_state_path.exists()
+        # The snapshot taken at save time round-trips through torch.save.
+        assert torch.load(dl_state_path) == {"fake_position": 7}
+        # current_epoch flows save_state → actor → training_info.json.
+        assert _training_info(ckpt_dir, 2)["current_epoch"] == 3
+
+    def test_stateful_dataloader_position_roundtrip(self, tmp_path):
+        data_config = {"train": [{"dataset_name": "math_train"}]}
+        dataloader = _make_int_dataloader()
+        it = iter(dataloader)
+        assert [next(it).tolist() for _ in range(2)] == [[0, 1], [2, 3]]
+
+        step_dir = _write_checkpoint(
+            tmp_path,
+            5,
+            _default_grpo_save_state(),
+            dataloader_state=dataloader.state_dict(),
+            config={"data": {"train": [{"dataset_name": "math_train"}]}},
+        )
+
+        restored = _make_int_dataloader()
+        load_dataloader_state(restored, str(step_dir), data_config)
+
+        # Resumes at batch k+1, not from the top.
+        assert next(iter(restored)).tolist() == [4, 5]
+
+    def test_dataset_swap_skips_restore(self, tmp_path):
+        dataloader = _make_int_dataloader()
+        it = iter(dataloader)
+        assert [next(it).tolist() for _ in range(2)] == [[0, 1], [2, 3]]
+
+        step_dir = _write_checkpoint(
+            tmp_path,
+            5,
+            _default_grpo_save_state(),
+            dataloader_state=dataloader.state_dict(),
+            config={"data": {"train": [{"dataset_name": "old_dataset"}]}},
+        )
+
+        restored = _make_int_dataloader()
+        load_dataloader_state(
+            restored, str(step_dir), {"train": [{"dataset_name": "new_dataset"}]}
+        )
+
+        # Restore skipped on dataset swap: the new dataset starts from index 0.
+        assert next(iter(restored)).tolist() == [0, 1]
+
+    def test_setup_restores_dataloader_state(
+        self,
+        patched_factories,  # noqa: F811
+        tmp_path,
+    ):
+        ckpt_dir = tmp_path / "ckpts"
+        sentinel = {"fake_position": 123}
+        _write_checkpoint(ckpt_dir, 3, _STEP_3_SAVE_STATE, dataloader_state=sentinel)
+        mc = _setup_master_config(str(ckpt_dir))
+
+        setup_single_controller(mc, MagicMock(pad_token_id=0))
+
+        fake_dataloader = patched_factories["dataloader"]
+        fake_dataloader.load_state_dict.assert_called_once()
+        assert fake_dataloader.load_state_dict.call_args.args[0] == sentinel
+
+    def test_setup_missing_dataloader_state_starts_fresh(
+        self,
+        patched_factories,  # noqa: F811
+        tmp_path,
+        monkeypatch,
+    ):
+        # Pre-Phase-2 checkpoint: training_info.json + policy/ but no
+        # train_dataloader.pt. Setup must warn and keep the fresh position
+        # while still forwarding the weight resume paths.
+        ckpt_dir = tmp_path / "ckpts"
+        step_3 = _write_checkpoint(ckpt_dir, 3, _STEP_3_SAVE_STATE)
+        mc = _setup_master_config(str(ckpt_dir))
+        printed: list[str] = []
+        # Repo addopts run pytest with -s, so capsys sees nothing; record
+        # print calls instead.
+        monkeypatch.setattr(
+            "builtins.print",
+            lambda *args, **kwargs: printed.append(" ".join(str(a) for a in args)),
+        )
+
+        setup_single_controller(mc, MagicMock(pad_token_id=0))
+
+        patched_factories["dataloader"].load_state_dict.assert_not_called()
+        assert any("No dataloader state found" in line for line in printed)
+        trainer_kwargs = patched_factories["_build_trainer"].call_args.kwargs
+        assert trainer_kwargs["weights_path"] == step_3 / "policy" / "weights"

--- a/tests/unit/single_controller/test_sc_checkpointing.py
+++ b/tests/unit/single_controller/test_sc_checkpointing.py
@@ -1,0 +1,611 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Phase 1 SC checkpointing.
+
+Covers (checkpointing-plan.md, Phase 1 "Testing"):
+  - counter restore from save_state (train_steps / trainer_version /
+    max_rollout_version invariant);
+  - save trigger + write path through _train_pump with fakes (period
+    boundary, last step, timeout, disabled);
+  - metric_name behavior (val:* warn-and-save, train:* value recorded);
+  - setup_single_controller resume-path wiring (get_resume_paths forwarded
+    to the trainer factory, save_state loaded from training_info.json).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from typing import Any, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from nemo_rl.algorithms.grpo import _default_grpo_save_state
+from nemo_rl.algorithms.loss import ClippedPGLossConfig
+from nemo_rl.algorithms.single_controller import SingleControllerActor
+from nemo_rl.algorithms.single_controller_utils import (
+    AsyncRLConfig,
+    MasterConfig,
+    SingleControllerBundle,
+    setup_single_controller,
+)
+from nemo_rl.data_plane import KVBatchMeta
+from nemo_rl.utils.checkpoint import CheckpointManager
+
+# Reuse the factory patches from the setup tests (same cross-module fixture
+# import pattern as test_rollout_pump.py).
+from tests.unit.single_controller.test_single_controller_setup import (
+    patched_factories,  # noqa: F401
+)
+
+# Instantiate the underlying class in-process (same pattern as
+# tests/unit/algorithms/test_async_utils.py for AsyncTrajectoryCollector).
+_ACTOR_CLS = SingleControllerActor.__ray_metadata__.modified_class
+
+_PARTITION_ID = "rollout_data"
+
+
+# ── fakes ────────────────────────────────────────────────────────────────────
+
+
+class _FakeTrainer:
+    """TQPolicy stand-in: train methods are no-ops, save_checkpoint records calls."""
+
+    def __init__(self, step_metrics: Optional[dict[str, Any]] = None) -> None:
+        self._step_metrics = dict(step_metrics or {})
+        self.save_calls: list[dict[str, Any]] = []
+
+    def prepare_for_lp_inference(self) -> None:
+        pass
+
+    def get_logprobs_from_meta(self, meta: KVBatchMeta) -> None:
+        pass
+
+    def get_reference_policy_logprobs_from_meta(self, meta: KVBatchMeta) -> None:
+        pass
+
+    def prepare_for_training(self) -> None:
+        pass
+
+    def begin_train_step(self, step_id: str, loss_fn: Any = None) -> None:
+        pass
+
+    def train_microbatch_from_meta(self, step_id: str, meta: KVBatchMeta) -> None:
+        pass
+
+    def finish_train_step(self, step_id: str) -> dict[str, Any]:
+        return dict(self._step_metrics)
+
+    def save_checkpoint(
+        self,
+        *,
+        weights_path: str,
+        optimizer_path: Optional[str],
+        tokenizer_path: str,
+        checkpointing_cfg: dict[str, Any],
+    ) -> None:
+        self.save_calls.append(
+            {
+                "weights_path": weights_path,
+                "optimizer_path": optimizer_path,
+                "tokenizer_path": tokenizer_path,
+                "checkpointing_cfg": checkpointing_cfg,
+            }
+        )
+        # Mimic the real Policy: materialize the checkpoint subdirs.
+        os.makedirs(weights_path, exist_ok=True)
+        if optimizer_path is not None:
+            os.makedirs(optimizer_path, exist_ok=True)
+        os.makedirs(tokenizer_path, exist_ok=True)
+
+
+class _FakeSampler:
+    """StalenessSampler stand-in: always returns a full, fresh batch."""
+
+    def __init__(self, partition_id: str = _PARTITION_ID) -> None:
+        self._partition_id = partition_id
+        self._step = 0
+
+    async def evict(self, current_train_weight: int) -> int:
+        return 0
+
+    async def select(
+        self,
+        *,
+        current_train_weight: int,
+        min_prompt_groups: int,
+        max_prompt_groups: int,
+    ) -> tuple[KVBatchMeta, int]:
+        n = max_prompt_groups
+        sample_ids = [f"s{self._step}-{i}" for i in range(n)]
+        self._step += 1
+        meta = KVBatchMeta(
+            partition_id=self._partition_id,
+            task_name=None,
+            sample_ids=sample_ids,
+            sequence_lengths=[16] * n,
+            tags=[{"weight_version": current_train_weight}] * n,
+        )
+        return meta, n
+
+
+class _FakeDPClient:
+    def __init__(self) -> None:
+        self.clear_calls: list[tuple[list[str], str]] = []
+
+    def clear_samples(self, sample_ids: list[str], partition_id: str) -> None:
+        self.clear_calls.append((list(sample_ids), partition_id))
+
+
+class _FakeWeightSynchronizer:
+    def __init__(self) -> None:
+        self.sync_count = 0
+
+    def sync_weights(self) -> None:
+        self.sync_count += 1
+
+
+class _FakeRolloutManager:
+    def __init__(self) -> None:
+        self.weight_versions: list[int] = []
+
+    def set_weight_version(self, version: int) -> None:
+        self.weight_versions.append(version)
+
+
+# ── builders ─────────────────────────────────────────────────────────────────
+
+
+def _actor_master_config(
+    tmp_path: Path,
+    *,
+    max_num_steps: int = 4,
+    save_period: int = 2,
+    enabled: bool = True,
+    metric_name: Optional[str] = None,
+    save_optimizer: bool = True,
+    checkpoint_must_save_by: Optional[str] = None,
+    num_prompts_per_step: int = 2,
+) -> MasterConfig:
+    """MasterConfig for in-process SingleControllerActor tests.
+
+    All fields are populated (init_tmp_checkpoint dumps the whole config to
+    config.yaml); values satisfy __init__'s quota/batch-size validation.
+    """
+    return MasterConfig.model_construct(
+        policy={
+            # One optimizer.step per RL step: prompts * generations == gbs.
+            "train_global_batch_size": num_prompts_per_step * 2,
+        },
+        loss_fn=ClippedPGLossConfig(),
+        env={},
+        data={"shuffle": False, "num_workers": 0},
+        grpo={
+            "max_num_steps": max_num_steps,
+            "max_num_epochs": 1,
+            "num_prompts_per_step": num_prompts_per_step,
+            "num_generations_per_prompt": 2,
+            "seed": 42,
+        },
+        logger={
+            "log_dir": str(tmp_path / "logs"),
+            "wandb_enabled": False,
+            "swanlab_enabled": False,
+            "tensorboard_enabled": False,
+            "mlflow_enabled": False,
+            "monitor_gpus": False,
+        },
+        cluster={"num_nodes": 1, "gpus_per_node": 1},
+        checkpointing={
+            "enabled": enabled,
+            "checkpoint_dir": str(tmp_path / "checkpoints"),
+            "metric_name": metric_name,
+            "higher_is_better": True,
+            "keep_top_k": None,
+            "save_period": save_period,
+            "save_optimizer": save_optimizer,
+            "checkpoint_must_save_by": checkpoint_must_save_by,
+        },
+        data_plane={"enabled": True, "impl": "transfer_queue"},
+        async_rl=AsyncRLConfig(
+            batch_selection_strategy="staleness_window",
+            max_weight_staleness_versions=1,
+            min_prompt_groups_per_batch=1,
+            max_inflight_prompts=4,
+            max_buffered_rollouts=4,
+            over_sampling=True,
+        ),
+    )
+
+
+def _make_bundle(
+    *,
+    trainer: Optional[_FakeTrainer] = None,
+    save_state: Optional[dict[str, Any]] = None,
+) -> SingleControllerBundle:
+    return SingleControllerBundle(
+        gen_handle=object(),
+        trainer_handle=trainer if trainer is not None else _FakeTrainer(),
+        env_handles={},
+        train_cluster=None,
+        inference_cluster=None,
+        dp_client=_FakeDPClient(),
+        dataloader=[],
+        weight_synchronizer=_FakeWeightSynchronizer(),
+        advantage_estimator=None,
+        loss_fn=object(),
+        rollout_manager=_FakeRolloutManager(),
+        tq_buffer=object(),
+        partition_id=_PARTITION_ID,
+        save_state=(
+            save_state if save_state is not None else _default_grpo_save_state()
+        ),
+    )
+
+
+def _run_train_pump(mc: MasterConfig, bundle: SingleControllerBundle):
+    """Construct the actor in-process and drive _train_pump to completion."""
+
+    async def _main():
+        actor = _ACTOR_CLS(mc, bundle)
+        actor._sampler = _FakeSampler()
+        await actor._train_pump()
+        return actor
+
+    return asyncio.run(_main())
+
+
+def _step_dir_names(ckpt_dir: Path) -> set[str]:
+    if not ckpt_dir.exists():
+        return set()
+    return {p.name for p in ckpt_dir.iterdir()}
+
+
+def _training_info(ckpt_dir: Path, step: int) -> dict[str, Any]:
+    with open(ckpt_dir / f"step_{step}" / "training_info.json") as f:
+        return json.load(f)
+
+
+# ── counter restore ──────────────────────────────────────────────────────────
+
+
+class TestCounterRestore:
+    def test_restore_from_step_n(self, tmp_path):
+        save_state = _default_grpo_save_state()
+        save_state["current_step"] = 7
+        save_state["consumed_samples"] = 42
+        save_state["total_valid_tokens"] = 1234
+
+        actor = _ACTOR_CLS(_actor_master_config(tmp_path), _make_bundle(save_state=save_state))
+
+        assert actor._train_steps == 7
+        assert actor._trainer_version == 7
+        # Fresh-start invariant: _max_rollout_version == _trainer_version - 1.
+        assert actor._max_rollout_version == 6
+        assert actor._consumed_samples == 42
+        assert actor._total_valid_tokens == 1234
+
+    def test_fresh_start_defaults(self, tmp_path):
+        actor = _ACTOR_CLS(_actor_master_config(tmp_path), _make_bundle())
+
+        assert actor._train_steps == 0
+        assert actor._trainer_version == 0
+        assert actor._max_rollout_version == -1
+        assert actor._consumed_samples == 0
+        assert actor._total_valid_tokens == 0
+
+    def test_old_checkpoint_without_total_valid_tokens(self, tmp_path):
+        # Older checkpoints may predate the total_valid_tokens key.
+        save_state = {
+            "consumed_samples": 10,
+            "current_step": 5,
+            "current_epoch": 0,
+            "total_steps": 5,
+        }
+
+        actor = _ACTOR_CLS(_actor_master_config(tmp_path), _make_bundle(save_state=save_state))
+
+        assert actor._train_steps == 5
+        assert actor._max_rollout_version == 4
+        assert actor._total_valid_tokens == 0
+
+
+# ── save trigger + write path ────────────────────────────────────────────────
+
+
+class TestSaveTrigger:
+    def test_saves_on_period_boundary_and_last_step(self, tmp_path):
+        mc = _actor_master_config(tmp_path, max_num_steps=4, save_period=2)
+        trainer = _FakeTrainer()
+
+        actor = _run_train_pump(mc, _make_bundle(trainer=trainer))
+
+        assert actor._train_steps == 4
+        ckpt_dir = tmp_path / "checkpoints"
+        # Finalized exactly at steps 2 and 4; no tmp_step_* leftovers.
+        assert _step_dir_names(ckpt_dir) == {"step_2", "step_4"}
+
+        info_2 = _training_info(ckpt_dir, 2)
+        assert info_2["current_step"] == 2
+        assert info_2["total_steps"] == 2
+        assert info_2["consumed_samples"] == 4  # 2 prompts/step * 2 steps
+        # No validation ran, so the default val_reward is dropped.
+        assert "val_reward" not in info_2
+
+        info_4 = _training_info(ckpt_dir, 4)
+        assert info_4["current_step"] == 4
+        assert info_4["consumed_samples"] == 8
+
+        # config.yaml is dumped next to training_info.json.
+        assert (ckpt_dir / "step_2" / "config.yaml").exists()
+
+        # save_checkpoint was called into the tmp dir with all three paths.
+        assert len(trainer.save_calls) == 2
+        first = trainer.save_calls[0]
+        assert first["weights_path"] == str(
+            ckpt_dir / "tmp_step_2" / "policy" / "weights"
+        )
+        assert first["optimizer_path"] == str(
+            ckpt_dir / "tmp_step_2" / "policy" / "optimizer"
+        )
+        assert first["tokenizer_path"] == str(
+            ckpt_dir / "tmp_step_2" / "policy" / "tokenizer"
+        )
+        assert first["checkpointing_cfg"] is mc.checkpointing
+        assert trainer.save_calls[1]["weights_path"] == str(
+            ckpt_dir / "tmp_step_4" / "policy" / "weights"
+        )
+
+        # The tmp dirs were finalized: policy/* survive under step_*.
+        assert (ckpt_dir / "step_2" / "policy" / "weights").is_dir()
+        assert (ckpt_dir / "step_2" / "policy" / "optimizer").is_dir()
+        assert (ckpt_dir / "step_4" / "policy" / "tokenizer").is_dir()
+
+    def test_last_step_saves_off_period_boundary(self, tmp_path):
+        mc = _actor_master_config(tmp_path, max_num_steps=3, save_period=2)
+
+        _run_train_pump(mc, _make_bundle())
+
+        # step 2 (boundary) + step 3 (last step), no step_1.
+        assert _step_dir_names(tmp_path / "checkpoints") == {"step_2", "step_3"}
+
+    def test_save_optimizer_false_gates_optimizer_path(self, tmp_path):
+        mc = _actor_master_config(
+            tmp_path, max_num_steps=2, save_period=2, save_optimizer=False
+        )
+        trainer = _FakeTrainer()
+
+        _run_train_pump(mc, _make_bundle(trainer=trainer))
+
+        assert len(trainer.save_calls) == 1
+        assert trainer.save_calls[0]["optimizer_path"] is None
+        ckpt_dir = tmp_path / "checkpoints"
+        assert (ckpt_dir / "step_2" / "policy" / "weights").is_dir()
+        assert not (ckpt_dir / "step_2" / "policy" / "optimizer").exists()
+
+    def test_no_save_when_disabled(self, tmp_path):
+        mc = _actor_master_config(
+            tmp_path, max_num_steps=2, save_period=1, enabled=False
+        )
+        trainer = _FakeTrainer()
+
+        actor = _run_train_pump(mc, _make_bundle(trainer=trainer))
+
+        assert actor._train_steps == 2
+        assert trainer.save_calls == []
+        assert _step_dir_names(tmp_path / "checkpoints") == set()
+
+    def test_timeout_saves_and_stops_training_early(self, tmp_path):
+        # 0-second budget: the first check_save() fires; the pump must save
+        # at step 1 (off the period boundary) and break out of the loop.
+        mc = _actor_master_config(
+            tmp_path,
+            max_num_steps=4,
+            save_period=100,
+            checkpoint_must_save_by="00:00:00:00",
+        )
+        trainer = _FakeTrainer()
+
+        actor = _run_train_pump(mc, _make_bundle(trainer=trainer))
+
+        assert actor._train_steps == 1
+        assert len(trainer.save_calls) == 1
+        assert _step_dir_names(tmp_path / "checkpoints") == {"step_1"}
+
+
+# ── metric_name behavior ─────────────────────────────────────────────────────
+
+
+class TestMetricName:
+    def test_val_metric_without_validation_warns_and_still_saves(self, tmp_path):
+        mc = _actor_master_config(
+            tmp_path, max_num_steps=2, save_period=2, metric_name="val:accuracy"
+        )
+
+        with pytest.warns(UserWarning, match="no val metrics were collected"):
+            _run_train_pump(mc, _make_bundle())
+
+        ckpt_dir = tmp_path / "checkpoints"
+        assert _step_dir_names(ckpt_dir) == {"step_2"}
+        assert "val:accuracy" not in _training_info(ckpt_dir, 2)
+
+    def test_train_metric_lands_in_training_info(self, tmp_path):
+        mc = _actor_master_config(
+            tmp_path, max_num_steps=2, save_period=2, metric_name="train:loss"
+        )
+        trainer = _FakeTrainer(step_metrics={"loss": 0.5})
+
+        _run_train_pump(mc, _make_bundle(trainer=trainer))
+
+        info = _training_info(tmp_path / "checkpoints", 2)
+        assert info["train:loss"] == 0.5
+
+    def test_train_metric_missing_key_raises(self, tmp_path):
+        mc = _actor_master_config(
+            tmp_path, max_num_steps=2, save_period=2, metric_name="train:not_a_metric"
+        )
+
+        with pytest.raises(ValueError, match="not found in train metrics"):
+            _run_train_pump(mc, _make_bundle())
+
+    def test_metric_name_requires_train_or_val_prefix(self, tmp_path):
+        mc = _actor_master_config(
+            tmp_path, max_num_steps=2, save_period=2, metric_name="reward"
+        )
+
+        with pytest.raises(AssertionError, match="must start with"):
+            _run_train_pump(mc, _make_bundle())
+
+
+# ── setup resume-path wiring ─────────────────────────────────────────────────
+
+
+_STEP_3_SAVE_STATE = {
+    "consumed_samples": 24,
+    "current_step": 3,
+    "current_epoch": 1,
+    "total_steps": 3,
+    "total_valid_tokens": 999,
+}
+
+
+def _write_checkpoint(
+    ckpt_dir: Path,
+    step: int,
+    save_state: dict[str, Any],
+    *,
+    with_optimizer: bool = True,
+) -> Path:
+    step_dir = ckpt_dir / f"step_{step}"
+    (step_dir / "policy" / "weights").mkdir(parents=True)
+    if with_optimizer:
+        (step_dir / "policy" / "optimizer").mkdir(parents=True)
+    with open(step_dir / "training_info.json", "w") as f:
+        json.dump(save_state, f)
+    return step_dir
+
+
+def _setup_master_config(checkpoint_dir: str) -> MasterConfig:
+    """Partially-populated MasterConfig for setup_single_controller tests.
+
+    Same shape as test_single_controller_setup._make_master_config, plus the
+    checkpointing block setup now reads.
+    """
+    return MasterConfig.model_construct(
+        data_plane={"enabled": True, "impl": "transfer_queue"},
+        data={
+            "use_multiple_dataloader": False,
+            "shuffle": False,
+            "num_workers": 0,
+            "train": [{"env_name": "math"}],
+        },
+        grpo={
+            "max_num_steps": 100,
+            "max_num_epochs": 1,
+            "num_prompts_per_step": 4,
+            "num_generations_per_prompt": 2,
+            "max_rollout_turns": 1,
+            "seed": 42,
+        },
+        policy={
+            "max_total_sequence_length": 32,
+            "megatron_cfg": {"enabled": False},
+            "generation": {
+                "backend": "vllm",
+                "colocated": {"enabled": True, "resources": {}},
+            },
+        },
+        loss_fn=ClippedPGLossConfig(),
+        env={},
+        checkpointing={
+            "enabled": True,
+            "checkpoint_dir": checkpoint_dir,
+            "metric_name": None,
+            "higher_is_better": True,
+            "keep_top_k": None,
+            "save_period": 2,
+            "save_optimizer": True,
+            "checkpoint_must_save_by": None,
+        },
+    )
+
+
+class TestGetResumePaths:
+    def test_resume_paths_from_fixture_layout(self, tmp_path):
+        step_dir = _write_checkpoint(tmp_path, 3, _STEP_3_SAVE_STATE)
+
+        weights_path, optimizer_path = CheckpointManager.get_resume_paths(
+            str(step_dir)
+        )
+
+        assert weights_path == step_dir / "policy" / "weights"
+        assert optimizer_path == step_dir / "policy" / "optimizer"
+
+    def test_resume_paths_without_optimizer_state(self, tmp_path):
+        step_dir = _write_checkpoint(
+            tmp_path, 3, _STEP_3_SAVE_STATE, with_optimizer=False
+        )
+
+        with pytest.warns(UserWarning, match="Optimizer state not found"):
+            weights_path, optimizer_path = CheckpointManager.get_resume_paths(
+                str(step_dir)
+            )
+
+        assert weights_path == step_dir / "policy" / "weights"
+        assert optimizer_path is None
+
+    def test_no_checkpoint_gives_none(self):
+        assert CheckpointManager.get_resume_paths(None) == (None, None)
+
+
+class TestSetupResumeWiring:
+    def test_setup_forwards_latest_resume_paths(self, patched_factories, tmp_path):
+        ckpt_dir = tmp_path / "ckpts"
+        _write_checkpoint(ckpt_dir, 1, {**_STEP_3_SAVE_STATE, "current_step": 1})
+        step_3 = _write_checkpoint(ckpt_dir, 3, _STEP_3_SAVE_STATE)
+        mc = _setup_master_config(str(ckpt_dir))
+
+        bundle = setup_single_controller(mc, MagicMock(pad_token_id=0))
+
+        # Latest checkpoint (step_3) wins; its paths reach the trainer factory.
+        trainer_kwargs = patched_factories["_build_trainer"].call_args.kwargs
+        assert trainer_kwargs["weights_path"] == step_3 / "policy" / "weights"
+        assert trainer_kwargs["optimizer_path"] == step_3 / "policy" / "optimizer"
+        # training_info.json is loaded into the bundle for the actor.
+        assert bundle.save_state == _STEP_3_SAVE_STATE
+
+    def test_setup_fresh_start_passes_none_paths(self, patched_factories, tmp_path):
+        ckpt_dir = tmp_path / "empty_ckpts"
+        ckpt_dir.mkdir()
+        mc = _setup_master_config(str(ckpt_dir))
+
+        bundle = setup_single_controller(mc, MagicMock(pad_token_id=0))
+
+        trainer_kwargs = patched_factories["_build_trainer"].call_args.kwargs
+        assert trainer_kwargs["weights_path"] is None
+        assert trainer_kwargs["optimizer_path"] is None
+        assert bundle.save_state == _default_grpo_save_state()
+
+    def test_setup_forwards_pretrained_checkpoint(self, patched_factories, tmp_path):
+        mc = _setup_master_config(str(tmp_path / "ckpts"))
+        pretrained = {"path": "/some/ckpt", "format": "megatron_bridge"}
+        mc.checkpointing["pretrained_checkpoint"] = pretrained
+
+        setup_single_controller(mc, MagicMock(pad_token_id=0))
+
+        assert mc.policy["pretrained_checkpoint"] == pretrained

--- a/tests/unit/single_controller/test_sc_checkpointing.py
+++ b/tests/unit/single_controller/test_sc_checkpointing.py
@@ -175,6 +175,42 @@ class _FakeRolloutManager:
         self.weight_versions.append(version)
 
 
+class _FakeTQBuffer:
+    """TQReplayBuffer stand-in for the SC save/restore integration tests."""
+
+    def __init__(
+        self,
+        state: Optional[dict[str, Any]] = None,
+        load_return: int = 0,
+    ) -> None:
+        self._state = state if state is not None else {"fake_buffer_envelope": 1}
+        self.load_return = load_return
+        self.state_dict_calls: list[int] = []
+        self.load_calls: list[dict[str, Any]] = []
+
+    async def state_dict(self, *, saved_capacity: int) -> dict[str, Any]:
+        self.state_dict_calls.append(saved_capacity)
+        return dict(self._state)
+
+    async def load_state_dict(
+        self,
+        state: dict[str, Any],
+        *,
+        max_groups: int,
+        expected_partition_id: str,
+        expected_group_size: int,
+    ) -> int:
+        self.load_calls.append(
+            {
+                "state": state,
+                "max_groups": max_groups,
+                "expected_partition_id": expected_partition_id,
+                "expected_group_size": expected_group_size,
+            }
+        )
+        return self.load_return
+
+
 # Default position sentinel the fake dataloader reports via state_dict().
 _SENTINEL_DL_STATE = {"fake_position": 42}
 
@@ -208,6 +244,8 @@ def _actor_master_config(
     save_optimizer: bool = True,
     checkpoint_must_save_by: Optional[str] = None,
     num_prompts_per_step: int = 2,
+    max_num_epochs: int = 1,
+    over_sampling: bool = True,
 ) -> MasterConfig:
     """MasterConfig for in-process SingleControllerActor tests.
 
@@ -224,7 +262,7 @@ def _actor_master_config(
         data={"shuffle": False, "num_workers": 0},
         grpo={
             "max_num_steps": max_num_steps,
-            "max_num_epochs": 1,
+            "max_num_epochs": max_num_epochs,
             "num_prompts_per_step": num_prompts_per_step,
             "num_generations_per_prompt": 2,
             "seed": 42,
@@ -249,13 +287,15 @@ def _actor_master_config(
             "checkpoint_must_save_by": checkpoint_must_save_by,
         },
         data_plane={"enabled": True, "impl": "transfer_queue"},
+        # over_sampling=False keeps __init__'s strict-quota check satisfied:
+        # max_buffered_rollouts == num_prompts_per_step * (staleness + 1) == 4.
         async_rl=AsyncRLConfig(
             batch_selection_strategy="staleness_window",
             max_weight_staleness_versions=1,
             min_prompt_groups_per_batch=1,
             max_inflight_prompts=4,
             max_buffered_rollouts=4,
-            over_sampling=True,
+            over_sampling=over_sampling,
         ),
     )
 
@@ -265,6 +305,8 @@ def _make_bundle(
     trainer: Optional[_FakeTrainer] = None,
     save_state: Optional[dict[str, Any]] = None,
     dataloader: Optional[_FakeDataloader] = None,
+    tq_buffer: Optional[_FakeTQBuffer] = None,
+    last_checkpoint_path: Optional[str] = None,
 ) -> SingleControllerBundle:
     return SingleControllerBundle(
         gen_handle=object(),
@@ -278,11 +320,12 @@ def _make_bundle(
         advantage_estimator=None,
         loss_fn=object(),
         rollout_manager=_FakeRolloutManager(),
-        tq_buffer=object(),
+        tq_buffer=tq_buffer if tq_buffer is not None else _FakeTQBuffer(),
         partition_id=_PARTITION_ID,
         save_state=(
             save_state if save_state is not None else _default_grpo_save_state()
         ),
+        last_checkpoint_path=last_checkpoint_path,
     )
 
 
@@ -772,3 +815,132 @@ class TestDataloaderState:
         assert any("No dataloader state found" in line for line in printed)
         trainer_kwargs = patched_factories["_build_trainer"].call_args.kwargs
         assert trainer_kwargs["weights_path"] == step_3 / "policy" / "weights"
+
+
+# ── replay buffer persistence (Phase 3) ──────────────────────────────────────
+
+
+def _run_actor_run(mc: MasterConfig, bundle: SingleControllerBundle):
+    """Construct the actor in-process and drive run() to completion.
+
+    max_num_steps=0 makes _train_pump exit immediately, so run() executes
+    only the restore block + pump startup/teardown. The wait_for bounds the
+    would-be-deadlock cases (an over-capacity permit acquisition would hang
+    run() forever).
+    """
+
+    async def _main():
+        actor = _ACTOR_CLS(mc, bundle)
+        result = await asyncio.wait_for(actor.run(), timeout=60.0)
+        return actor, result
+
+    return asyncio.run(_main())
+
+
+class TestReplayBufferPersistence:
+    def test_save_writes_replay_buffer_when_over_sampling(self, tmp_path):
+        mc = _actor_master_config(tmp_path, max_num_steps=2, save_period=2)
+        envelope = {"groups": [], "sentinel": "abc"}
+        buffer = _FakeTQBuffer(state=envelope)
+
+        _run_train_pump(mc, _make_bundle(tq_buffer=buffer))
+
+        ckpt_dir = tmp_path / "checkpoints"
+        buffer_path = ckpt_dir / "step_2" / "replay_buffer.pt"
+        assert buffer_path.exists()
+        assert torch.load(buffer_path, weights_only=False) == envelope
+        # state_dict is stamped with the capacity at save time.
+        assert buffer.state_dict_calls == [4]
+
+    def test_no_replay_buffer_when_not_over_sampling(self, tmp_path):
+        mc = _actor_master_config(
+            tmp_path, max_num_steps=2, save_period=2, over_sampling=False
+        )
+        buffer = _FakeTQBuffer()
+
+        _run_train_pump(mc, _make_bundle(tq_buffer=buffer))
+
+        ckpt_dir = tmp_path / "checkpoints"
+        assert (ckpt_dir / "step_2" / "training_info.json").exists()
+        assert not (ckpt_dir / "step_2" / "replay_buffer.pt").exists()
+        assert buffer.state_dict_calls == []
+
+    def test_run_restores_replay_buffer_and_permits(self, tmp_path):
+        ckpt_dir = tmp_path / "resume_ckpt"
+        ckpt_dir.mkdir()
+        envelope = {"groups": ["g0", "g1", "g2"]}
+        torch.save(envelope, ckpt_dir / "replay_buffer.pt")
+        mc = _actor_master_config(tmp_path, max_num_steps=0)
+        buffer = _FakeTQBuffer(load_return=3)
+
+        actor, result = _run_actor_run(
+            mc,
+            _make_bundle(tq_buffer=buffer, last_checkpoint_path=str(ckpt_dir)),
+        )
+
+        assert buffer.load_calls == [
+            {
+                "state": envelope,
+                "max_groups": 4,
+                "expected_partition_id": _PARTITION_ID,
+                "expected_group_size": 2,
+            }
+        ]
+        # Each restored group holds one _buffer_capacity permit.
+        assert actor._buffer_capacity._value == 4 - 3
+        assert result["train_steps"] == 0
+
+    def test_run_restore_at_full_capacity_does_not_hang(self, tmp_path):
+        # K == max_buffered_rollouts: the acquisitions must all complete
+        # without waiting (no pump is running yet to release permits).
+        ckpt_dir = tmp_path / "resume_ckpt"
+        ckpt_dir.mkdir()
+        torch.save({"groups": []}, ckpt_dir / "replay_buffer.pt")
+        mc = _actor_master_config(tmp_path, max_num_steps=0)
+        buffer = _FakeTQBuffer(load_return=4)
+
+        actor, result = _run_actor_run(
+            mc,
+            _make_bundle(tq_buffer=buffer, last_checkpoint_path=str(ckpt_dir)),
+        )
+
+        assert len(buffer.load_calls) == 1
+        assert actor._buffer_capacity._value == 0
+        assert result["train_steps"] == 0
+
+    def test_run_missing_replay_buffer_file_starts_empty(self, tmp_path, monkeypatch):
+        # Resuming from a pre-Phase-3 checkpoint: no replay_buffer.pt.
+        ckpt_dir = tmp_path / "resume_ckpt"
+        ckpt_dir.mkdir()
+        mc = _actor_master_config(tmp_path, max_num_steps=0)
+        buffer = _FakeTQBuffer()
+        printed: list[str] = []
+        monkeypatch.setattr(
+            "builtins.print",
+            lambda *args, **kwargs: printed.append(" ".join(str(a) for a in args)),
+        )
+
+        actor, _ = _run_actor_run(
+            mc,
+            _make_bundle(tq_buffer=buffer, last_checkpoint_path=str(ckpt_dir)),
+        )
+
+        assert buffer.load_calls == []
+        assert actor._buffer_capacity._value == 4  # zero permits consumed
+        assert any("No replay buffer checkpoint found" in line for line in printed)
+
+    def test_run_no_restore_when_not_over_sampling(self, tmp_path):
+        # File present but over_sampling=False: nothing is restored.
+        ckpt_dir = tmp_path / "resume_ckpt"
+        ckpt_dir.mkdir()
+        torch.save({"groups": []}, ckpt_dir / "replay_buffer.pt")
+        mc = _actor_master_config(tmp_path, max_num_steps=0, over_sampling=False)
+        buffer = _FakeTQBuffer(load_return=2)
+
+        actor, _ = _run_actor_run(
+            mc,
+            _make_bundle(tq_buffer=buffer, last_checkpoint_path=str(ckpt_dir)),
+        )
+
+        assert buffer.load_calls == []
+        assert actor._buffer_capacity._value == 4

--- a/tests/unit/single_controller/test_single_controller_setup.py
+++ b/tests/unit/single_controller/test_single_controller_setup.py
@@ -40,12 +40,14 @@ def _make_master_config(
     max_num_steps: int = 100,
     max_num_epochs: int = 1,
     num_prompts_per_step: int = 4,
+    checkpoint_dir: str = "/nonexistent/nemo-rl-sc-test-checkpoints",
 ) -> MasterConfig:
     """Build a partially-populated MasterConfig for unit tests.
 
-    Cross-cutting components (cluster/checkpointing/...) are required by pydantic for
+    Cross-cutting components (cluster/logger/...) are required by pydantic for
     normal load but unused here — model_construct skips validation, and we hand-fill
-    only the dict-shaped fields setup reads.
+    only the dict-shaped fields setup reads (including checkpointing; the default
+    checkpoint_dir never exists, so setup takes the fresh-start path).
     """
     return MasterConfig.model_construct(
         data_plane={"enabled": dp_enabled, "impl": "transfer_queue"},
@@ -61,6 +63,17 @@ def _make_master_config(
             "num_prompts_per_step": num_prompts_per_step,
             "num_generations_per_prompt": 2,
             "max_rollout_turns": 1,
+            "seed": 42,
+        },
+        checkpointing={
+            "enabled": False,
+            "checkpoint_dir": checkpoint_dir,
+            "metric_name": None,
+            "higher_is_better": True,
+            "keep_top_k": None,
+            "save_period": 10,
+            "save_optimizer": True,
+            "checkpoint_must_save_by": None,
         },
         policy={
             "max_total_sequence_length": 32,

--- a/tests/unit/single_controller/test_tq_replay_buffer.py
+++ b/tests/unit/single_controller/test_tq_replay_buffer.py
@@ -63,6 +63,7 @@ class FakeDataPlaneClient:
         self._rows: dict[str, dict[str, Any]] = {}
         self.put_calls: list[dict[str, Any]] = []
         self.clear_calls: list[list[str]] = []
+        self.get_calls: list[dict[str, Any]] = []
 
     def put_samples(
         self,
@@ -97,6 +98,24 @@ class FakeDataPlaneClient:
         self.clear_calls.append(list(ids))
         for sid in ids:
             self._rows.pop(sid, None)
+
+    def get_samples(
+        self,
+        sample_ids: list[str],
+        partition_id: str,
+        select_fields: list[str] | None = None,
+    ) -> dict[str, Any]:
+        assert partition_id == self._partition_id
+        self.get_calls.append(
+            {
+                "sample_ids": list(sample_ids),
+                "select_fields": (
+                    list(select_fields) if select_fields is not None else None
+                ),
+            }
+        )
+        # Opaque per-group payload; load_state_dict must re-put it verbatim.
+        return {"payload_for": list(sample_ids)}
 
     def depth(self) -> int:
         return len(self._rows)
@@ -322,3 +341,200 @@ class TestTQReplayBufferSize:
         _run(buf.remove([0], remove_in_dp=True))
         assert buf.size() == 1
         assert len(buf) == 1
+
+
+# ── state_dict / load_state_dict (Phase 3 checkpointing) ─────────────────────
+
+
+def _group_id_of(meta: KVBatchMeta) -> str:
+    head, _, _ = meta.sample_ids[0].rpartition("_g")
+    return head
+
+
+def _make_group_entry(
+    group_id: str,
+    weight: int,
+    *,
+    n: int = _N_GENS,
+    target_step: int | None = None,
+    sample_ids: list[str] | None = None,
+    sequence_lengths: list[int] | None = None,
+    partition_id: str = "rollout_data",
+) -> dict[str, Any]:
+    """Hand-built envelope group (bypasses commit) for preflight tests."""
+    sids = (
+        list(sample_ids)
+        if sample_ids is not None
+        else [f"{group_id}_g{i}" for i in range(n)]
+    )
+    meta = KVBatchMeta(
+        partition_id=partition_id,
+        task_name="train",
+        sample_ids=sids,
+        fields=["input_ids", "input_lengths", "total_reward"],
+        sequence_lengths=(
+            sequence_lengths if sequence_lengths is not None else [3] * len(sids)
+        ),
+        tags=[{"weight_version": weight}] * len(sids),
+    )
+    return {
+        "meta": meta,
+        "start_weight": weight,
+        "end_weight": weight,
+        "target_step": target_step,
+        "group_id": group_id,
+        "fields_data": {"payload_for": sids},
+    }
+
+
+def _make_envelope(
+    groups: list[dict[str, Any]],
+    *,
+    partition_id: str = "rollout_data",
+    saved_capacity: int = 8,
+) -> dict[str, Any]:
+    return {
+        "partition_id": partition_id,
+        "saved_capacity": saved_capacity,
+        "groups": list(groups),
+    }
+
+
+def _load(
+    buf: TQReplayBuffer,
+    state: dict[str, Any],
+    *,
+    max_groups: int = 8,
+    expected_partition_id: str = "rollout_data",
+    expected_group_size: int = _N_GENS,
+) -> int:
+    return _run(
+        buf.load_state_dict(
+            state,
+            max_groups=max_groups,
+            expected_partition_id=expected_partition_id,
+            expected_group_size=expected_group_size,
+        )
+    )
+
+
+class TestTQReplayBufferStateDict:
+    def test_state_dict_serializes_ready_and_skips_unready(self):
+        dp = FakeDataPlaneClient()
+        buf = _make_buffer(dp)
+        metas = [_add_group(buf, weight=w) for w in (1, 2)]
+        buf.reserve(weight_version=3)  # in-flight: must be excluded
+
+        state = _run(buf.state_dict(saved_capacity=8))
+
+        assert state["partition_id"] == "rollout_data"
+        assert state["saved_capacity"] == 8
+        assert len(state["groups"]) == 2
+        assert [g["start_weight"] for g in state["groups"]] == [1, 2]
+        assert [g["end_weight"] for g in state["groups"]] == [1, 2]
+        assert [g["target_step"] for g in state["groups"]] == [None, None]
+        assert [g["group_id"] for g in state["groups"]] == [
+            _group_id_of(metas[0]),
+            _group_id_of(metas[1]),
+        ]
+        # Payloads are fetched from the DataPlane rows of each group.
+        assert [c["sample_ids"] for c in dp.get_calls] == [
+            list(metas[0].sample_ids),
+            list(metas[1].sample_ids),
+        ]
+        assert dp.get_calls[0]["select_fields"] == list(metas[0].fields)
+        assert state["groups"][0]["fields_data"] == {
+            "payload_for": list(metas[0].sample_ids)
+        }
+
+    def test_round_trip_restores_lists_and_rows(self):
+        dp = FakeDataPlaneClient()
+        buf = _make_buffer(dp)
+        metas = [_add_group(buf, weight=w) for w in (1, 2)]
+        state = _run(buf.state_dict(saved_capacity=8))
+
+        dp2 = FakeDataPlaneClient()
+        buf2 = _make_buffer(dp2)
+        restored = _load(buf2, state)
+
+        assert restored == 2
+        assert buf2.size() == 2
+        # Parallel lists rebuilt in order, all ready.
+        assert buf2.start_weight_list == [1, 2]
+        assert buf2.end_weight_list == [1, 2]
+        assert buf2.target_step_list == [None, None]
+        assert buf2.ready_list == [True, True]
+        assert buf2._group_ids == [_group_id_of(m) for m in metas]
+        assert [m.sample_ids for m in buf2.meta_list] == [
+            list(metas[0].sample_ids),
+            list(metas[1].sample_ids),
+        ]
+        # Rows re-put with identical sample_ids / fields payload / tags.
+        assert len(dp2.put_calls) == 2
+        for put, meta in zip(dp2.put_calls, metas):
+            assert put["sample_ids"] == list(meta.sample_ids)
+            assert put["fields"] == {"payload_for": list(meta.sample_ids)}
+            assert put["tags"] == [dict(t) for t in meta.tags]
+
+
+class TestTQReplayBufferLoadPreflight:
+    """Malformed envelopes raise ValueError before any DataPlane write."""
+
+    def _assert_rejected(self, state: dict[str, Any], match: str, **load_kwargs):
+        dp = FakeDataPlaneClient()
+        buf = _make_buffer(dp)
+        with pytest.raises(ValueError, match=match):
+            _load(buf, state, **load_kwargs)
+        assert dp.put_calls == []
+        assert buf.size() == 0
+
+    def test_missing_envelope_keys(self):
+        self._assert_rejected({"groups": []}, match="missing required keys")
+
+    def test_partition_id_mismatch(self):
+        state = _make_envelope([], partition_id="other_partition")
+        self._assert_rejected(state, match="partition_id mismatch")
+
+    def test_group_missing_keys(self):
+        group = _make_group_entry("g0", weight=1)
+        del group["fields_data"]
+        self._assert_rejected(_make_envelope([group]), match="group missing keys")
+
+    def test_group_misaligned_sequence_lengths(self):
+        group = _make_group_entry("g0", weight=1, sequence_lengths=[3])
+        self._assert_rejected(_make_envelope([group]), match="misaligned")
+
+    def test_group_size_mismatch(self):
+        state = _make_envelope([_make_group_entry("g0", weight=1, n=2)])
+        self._assert_rejected(state, match="misaligned", expected_group_size=3)
+
+    def test_duplicate_sample_ids_across_groups(self):
+        g0 = _make_group_entry("g0", weight=1)
+        g1 = _make_group_entry(
+            "g1", weight=2, sample_ids=["g0_g0", "g1_g1"]
+        )  # g0_g0 collides
+        self._assert_rejected(_make_envelope([g0, g1]), match="duplicate sample_id")
+
+
+class TestTQReplayBufferLoadTruncation:
+    def test_capacity_change_truncates_to_freshest(self, monkeypatch):
+        state = _make_envelope(
+            [_make_group_entry(f"g{w}", weight=w) for w in (1, 2, 3)],
+            saved_capacity=8,
+        )
+        dp = FakeDataPlaneClient()
+        buf = _make_buffer(dp)
+        printed: list[str] = []
+        monkeypatch.setattr(
+            "builtins.print",
+            lambda *args, **kwargs: printed.append(" ".join(str(a) for a in args)),
+        )
+
+        restored = _load(buf, state, max_groups=2)
+
+        assert restored == 2
+        # The freshest max_groups groups survive, original order preserved.
+        assert buf.start_weight_list == [2, 3]
+        put_sample_ids = [sid for c in dp.put_calls for sid in c["sample_ids"]]
+        assert "g1_g0" not in put_sample_ids and "g1_g1" not in put_sample_ids
+        assert any("capacity changed" in line for line in printed)


### PR DESCRIPTION
## What does this PR do?

Adds checkpoint save/restore to the single-controller (SC) RL loop, so a run can
resume from the latest checkpoint instead of starting over. It reuses the legacy
GRPO checkpoint machinery (`CheckpointManager`, `GRPOSaveState`,
`load_dataloader_state`) and keeps the same on-disk layout, extending it to the
state SC owns:

- **Model weights + optimizer + training state**: setup builds a
  `CheckpointManager`, loads the latest `GRPOSaveState` (or defaults),
  propagates `pretrained_checkpoint`, and passes the weights/optimizer resume
  paths into `_build_trainer`. The actor restores
  `_trainer_version`/`_train_steps`/`_max_rollout_version` and
  `consumed_samples`/`total_valid_tokens`, and after each train step saves on
  `save_period`, the last step, or a `checkpoint_must_save_by` timeout (top-k
  `metric_name` supported), stopping early on timeout.
- **Dataloader position + epoch**: `train_dataloader.pt` is written on save and
  restored via `load_dataloader_state` on setup; `current_epoch` is persisted
  and restored.
- **Replay buffer** (`TQReplayBuffer`): `state_dict` fetches each ready group's
  rows from the DataPlane into an envelope; `load_state_dict` validates and
  truncates to the current capacity before any DataPlane write, then re-puts
  each group. `run()` restores it before the pumps start.

## Notable design points

- **The replay buffer is saved only when `over_sampling=True`.** Under the
  strict quota (`over_sampling=False`) each weight version gets exactly one
  dispatched batch and the pump never re-dispatches. A checkpoint can only hold
  *committed* groups, so a partially-committed window could never be completed
  on resume — the train pump would wait forever for groups that will never
  arrive (an immediate stall under `force_in_order`). Instead, resume restores
  `_max_rollout_version = current_step - 1` and regenerates the whole window
  from the restored dataloader position. With `over_sampling=True` there is no
  quota: restored groups are surplus, missing ones are regenerated by the
  free-running pump, and stale ones are evicted — so persisting the buffer is
  safe and saves wasted generation.
- **Restore never blocks.** `run()` acquires one `_buffer_capacity` permit per
  restored group before the pumps start; if the restored count exceeded
  capacity, that acquisition would hang `run()` forever (no pump is running yet
  to release a permit). `load_state_dict`'s truncation to the current
  `max_buffered_rollouts` guarantees `K <= capacity`, asserted before acquiring
  — this closes a resume deadlock when resuming onto a smaller-capacity config.
- **The `state_dict` snapshot is taken synchronously on the event loop** before
  any `await`, so it cannot be torn by the rollout pump committing into the same
  buffer concurrently.
- **In-flight rollouts are not persisted** (reserved-but-uncommitted slots),
  matching legacy — they are regenerated on resume.
- **Backward compatible**: a checkpoint written before dataloader / replay-buffer
  support (missing `train_dataloader.pt` / `replay_buffer.pt`) resumes with a
  fresh dataloader position / empty buffer and a warning, not a crash.

## Testing

- **Unit**: `test_sc_checkpointing.py` + `test_tq_replay_buffer.py` — counter
  restore, save triggers, dataloader position round-trip, and replay-buffer
  round-trip / preflight validation / permit accounting (incl. the
  `K == capacity` no-hang case).
- **Functional**: `tests/functional/grpo_checkpoint_single_controller.sh` — a
  two-run save→restart on 2 GPUs (Qwen3-0.6B, Megatron), verifying
  weights/dataloader/replay-buffer restore and resume at the correct step
  (step 2 → resume → step 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
