### PR TITLE
fix: router-replay startup validation and NeMo-Gym trace alignment

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -104,6 +104,7 @@ from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration
 from nemo_rl.models.megatron.router_replay import (
     configure_vllm_for_router_replay,
     router_replay_enabled,
+    validate_router_replay_startup,
 )
 from nemo_rl.models.policy import PolicyConfig
 from nemo_rl.models.policy.interfaces import ColocatablePolicyInterface
@@ -1116,6 +1117,14 @@ def setup(
                 "Currently when using FP8 KV cache in generation, then in megatron we only support pipeline_model_parallel_size=1. We will add more support in future."
             )
 
+        validate_router_replay_startup(
+            policy_config,
+            data_plane_enabled=bool(
+                (master_config.data_plane or {}).get("enabled", False)
+            ),
+            using_nemo_gym=enable_nemo_gym,
+            async_rollouts=_should_use_async_rollouts(master_config),
+        )
         configure_vllm_for_router_replay(policy_config)
         vllm_kwargs = generation_config.setdefault("vllm_kwargs", {})
 

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -14,7 +14,7 @@
 import os
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, List, NotRequired, TypedDict
+from typing import Any, Dict, List, NotRequired, Optional, TypedDict
 
 import ray
 import torch
@@ -337,6 +337,8 @@ Depending on your data shape, you may want to change these values."""
 
         nemo_rl_message_log = []
         seen_token_ids: List[int] = []
+        prev_assistant_routed_experts: Optional[torch.Tensor] = None
+        prev_assistant_final_pos: Optional[int] = None
         batch_decode_items = []
         for output_item_dict in nemo_gym_result["response"]["output"]:
             # Nemo RL really only has two types of messages: assistant and not assistant since that is all that it is concerned with (i.e. to train or not to train)
@@ -383,6 +385,30 @@ Output prompt token IDs: {output_item_dict["prompt_token_ids"]}
                         f"routes={routed_experts.shape[0]}, expected_at_least="
                         f"{expected_tokens}."
                     )
+                # At most one surplus row is legal (the final-token route, when
+                # the backend returns it); anything beyond that means the row
+                # count comes from a different token sequence than reported and
+                # every route after the divergence would be misaligned.
+                if routed_experts.shape[0] > expected_tokens + 1:
+                    raise ValueError(
+                        "NeMo Gym returned too many routed_experts rows for a "
+                        "trainable output item: "
+                        f"routes={routed_experts.shape[0]}, "
+                        f"expected={expected_tokens} (+1 surplus final-token "
+                        "route allowed)."
+                    )
+                # Splice: vLLM never routes the final sampled token of a
+                # request, so the previous assistant turn's last route row is a
+                # placeholder — but this turn's prompt re-forwards that token,
+                # giving its real route at the same global position.
+                if (
+                    prev_assistant_routed_experts is not None
+                    and prev_assistant_final_pos is not None
+                    and prev_assistant_final_pos < routed_experts.shape[0]
+                ):
+                    prev_assistant_routed_experts[-1] = routed_experts[
+                        prev_assistant_final_pos
+                    ]
             elif self.cfg.get("require_routed_experts", False):
                 raise ValueError(
                     "policy.router_replay.enabled=true requires NeMo Gym output "
@@ -434,6 +460,8 @@ Output prompt token IDs: {output_item_dict["prompt_token_ids"]}
 
             seen_token_ids.extend(new_prompt_token_ids)
             seen_token_ids.extend(generation_token_ids)
+            prev_assistant_routed_experts = assistant_message.get("routed_experts")
+            prev_assistant_final_pos = len(seen_token_ids) - 1
 
             # We pop to remove larger tensors from logging.
             batch_decode_items.append(

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -29,6 +29,11 @@ from nemo_rl.distributed.virtual_cluster import (
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.utils.timer import Timer
 
+# Local copy of the R3 missing-route sentinel (canonical def in
+# nemo_rl.models.generation.vllm.utils) — kept local so the Gym actor stays free
+# of generation-module imports. Must stay -1 to match Megatron's replay fallback.
+_R3_MISSING_ROUTE_SENTINEL = -1
+
 # Kept local (not imported from models.generation) so the gym actor stays free of
 # generation-module imports. Must cover every name resolve_routed_experts_dtype
 # can produce.
@@ -340,6 +345,24 @@ Depending on your data shape, you may want to change these values."""
         prev_assistant_routed_experts: Optional[torch.Tensor] = None
         prev_assistant_final_pos: Optional[int] = None
         batch_decode_items = []
+
+        # A missing-routes item (e.g. Gym's error-recovery dummy) is sentinel-filled
+        # so Megatron's fallback handles it instead of crashing the run — but that
+        # needs the [num_moe_layers, topk] shape, which only a sibling item that DID
+        # carry routes can provide. Scan for one up front; if none exists the whole
+        # batch is trace-less, a genuine misconfiguration that still raises below.
+        routed_experts_layer_topk: Optional[tuple[int, int]] = None
+        for _scan_item in nemo_gym_result["response"]["output"]:
+            _scan_routes = _scan_item.get("routed_experts")
+            if _scan_routes is not None:
+                _scan_tensor = torch.as_tensor(_scan_routes, dtype=torch.int32)
+                if _scan_tensor.dim() == 3:
+                    routed_experts_layer_topk = (
+                        int(_scan_tensor.shape[1]),
+                        int(_scan_tensor.shape[2]),
+                    )
+                    break
+
         for output_item_dict in nemo_gym_result["response"]["output"]:
             # Nemo RL really only has two types of messages: assistant and not assistant since that is all that it is concerned with (i.e. to train or not to train)
             # Here we map all the trainable messages to assistant and all the non-trainable messages to user.
@@ -377,25 +400,17 @@ Output prompt token IDs: {output_item_dict["prompt_token_ids"]}
                         "Expected [tokens, num_moe_layers, topk], got "
                         f"{tuple(routed_experts.shape)}."
                     )
+                # The route array is engine-derived and already padded to the full
+                # prompt+generation length, so it must match the (independently
+                # tokenize-derived) token count exactly. Any difference means the
+                # two came from different token sequences and every route after
+                # the divergence — and the splice below — would be misaligned.
                 expected_tokens = len(prompt_token_ids) + len(generation_token_ids)
-                if routed_experts.shape[0] < expected_tokens:
+                if routed_experts.shape[0] != expected_tokens:
                     raise ValueError(
-                        "NeMo Gym returned too few routed_experts rows for a "
-                        "trainable output item: "
-                        f"routes={routed_experts.shape[0]}, expected_at_least="
-                        f"{expected_tokens}."
-                    )
-                # At most one surplus row is legal (the final-token route, when
-                # the backend returns it); anything beyond that means the row
-                # count comes from a different token sequence than reported and
-                # every route after the divergence would be misaligned.
-                if routed_experts.shape[0] > expected_tokens + 1:
-                    raise ValueError(
-                        "NeMo Gym returned too many routed_experts rows for a "
-                        "trainable output item: "
-                        f"routes={routed_experts.shape[0]}, "
-                        f"expected={expected_tokens} (+1 surplus final-token "
-                        "route allowed)."
+                        "NeMo Gym routed_experts row count does not match the "
+                        "trainable output item's token count: "
+                        f"routes={routed_experts.shape[0]}, expected={expected_tokens}."
                     )
                 # Splice: vLLM never routes the final sampled token of a
                 # request, so the previous assistant turn's last route row is a
@@ -410,12 +425,37 @@ Output prompt token IDs: {output_item_dict["prompt_token_ids"]}
                         prev_assistant_final_pos
                     ]
             elif self.cfg.get("require_routed_experts", False):
-                raise ValueError(
-                    "policy.router_replay.enabled=true requires NeMo Gym output "
-                    "items to include routed_experts, but the field was missing. "
-                    "Make sure the Gym repo includes routed_experts propagation "
-                    "and the NeMo-RL vLLM OpenAI-compatible server is configured "
-                    "with enable_return_routed_experts."
+                # A single trace-less item (e.g. Gym's error-recovery dummy for a
+                # rollout that ended without a valid assistant message) should not
+                # kill the whole run. Sentinel-fill it so Megatron's missing-route
+                # fallback replays natural routing for these tokens, and surface it
+                # via r3/train_fallback_token_route_fraction. Only a fully
+                # trace-less batch (no sibling shape to fill from) is a real
+                # misconfiguration and still raises.
+                if routed_experts_layer_topk is None:
+                    raise ValueError(
+                        "policy.router_replay.enabled=true requires NeMo Gym "
+                        "output items to include routed_experts, but no item in "
+                        "the batch carried them. Make sure the Gym repo includes "
+                        "routed_experts propagation and the NeMo-RL vLLM "
+                        "OpenAI-compatible server is configured with "
+                        "enable_return_routed_experts."
+                    )
+                num_layers, topk = routed_experts_layer_topk
+                # Must match the dtype the sibling (real) routes are cast to above
+                # so the sentinel-filled and real tensors concatenate/replay
+                # identically — resolved the same way as the real-route branch.
+                sentinel_dtype = _ROUTED_EXPERTS_DTYPES[
+                    self.cfg.get("routed_experts_dtype", "int16")
+                ]
+                routed_experts = torch.full(
+                    (
+                        len(prompt_token_ids) + len(generation_token_ids),
+                        num_layers,
+                        topk,
+                    ),
+                    _R3_MISSING_ROUTE_SENTINEL,
+                    dtype=sentinel_dtype,
                 )
 
             prompt_start = len(seen_token_ids)

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -349,19 +349,24 @@ Depending on your data shape, you may want to change these values."""
         # A missing-routes item (e.g. Gym's error-recovery dummy) is sentinel-filled
         # so Megatron's fallback handles it instead of crashing the run — but that
         # needs the [num_moe_layers, topk] shape, which only a sibling item that DID
-        # carry routes can provide. Scan for one up front; if none exists the whole
-        # batch is trace-less, a genuine misconfiguration that still raises below.
+        # carry routes can provide. Read it from the raw [tokens][layers][topk]
+        # nested-list structure (cheap ``len``s — do NOT tensor-convert the whole
+        # array here, it is re-converted per item below). If no item carries
+        # routes the batch is trace-less, a misconfiguration that still raises.
         routed_experts_layer_topk: Optional[tuple[int, int]] = None
         for _scan_item in nemo_gym_result["response"]["output"]:
             _scan_routes = _scan_item.get("routed_experts")
-            if _scan_routes is not None:
-                _scan_tensor = torch.as_tensor(_scan_routes, dtype=torch.int32)
-                if _scan_tensor.dim() == 3:
-                    routed_experts_layer_topk = (
-                        int(_scan_tensor.shape[1]),
-                        int(_scan_tensor.shape[2]),
-                    )
-                    break
+            if (
+                _scan_routes
+                and isinstance(_scan_routes[0], list)
+                and _scan_routes[0]
+                and isinstance(_scan_routes[0][0], list)
+            ):
+                routed_experts_layer_topk = (
+                    len(_scan_routes[0]),
+                    len(_scan_routes[0][0]),
+                )
+                break
 
         for output_item_dict in nemo_gym_result["response"]["output"]:
             # Nemo RL really only has two types of messages: assistant and not assistant since that is all that it is concerned with (i.e. to train or not to train)

--- a/nemo_rl/models/megatron/router_replay.py
+++ b/nemo_rl/models/megatron/router_replay.py
@@ -67,6 +67,86 @@ def validate_router_replay_config(config: PolicyConfig) -> None:
     _install_missing_route_fallback_patch()
 
 
+def validate_router_replay_startup(
+    policy_config: PolicyConfig,
+    *,
+    data_plane_enabled: bool = False,
+    using_nemo_gym: bool = False,
+    async_rollouts: bool = False,
+) -> None:
+    """Fail-fast, driver-side router-replay validation (config only, no mcore).
+
+    validate_router_replay_config runs only inside the Megatron worker setup, so
+    configurations that never reach it fail silently or deep into the run. This
+    catches them at startup instead:
+      - a non-Megatron policy backend captures and transports routes but never
+        replays them (silent no-op R3 at full cost);
+      - MTP inner routers reuse main-model layer numbers and would silently
+        receive main-layer replay payloads;
+      - NeMo-Gym over the sync TQ dataplane is an untested route transport;
+      - a dense (non-MoE) model can never produce routed experts and previously
+        only failed at first generation.
+    """
+    if not router_replay_enabled(policy_config):
+        return
+
+    generation = policy_config.get("generation") or {}
+    megatron_cfg = policy_config.get("megatron_cfg") or {}
+    dtensor_cfg = policy_config.get("dtensor_cfg") or {}
+
+    if generation.get("backend") != "vllm":
+        raise ValueError("router_replay.enabled requires vLLM generation.")
+    if dtensor_cfg.get("enabled", False) or not megatron_cfg.get("enabled", False):
+        raise ValueError(
+            "router_replay.enabled requires the Megatron policy backend. With the "
+            "DTensor/automodel backend, routed experts are captured and "
+            "transported but never replayed, so R3 silently does nothing while "
+            "paying its full cost."
+        )
+    if int(megatron_cfg.get("mtp_num_layers") or 0) > 0:
+        raise ValueError(
+            "router_replay.enabled does not support MTP (mtp_num_layers>0): MTP "
+            "inner routers reuse main-model layer numbers and would silently "
+            "replay main-layer routes."
+        )
+    if using_nemo_gym and data_plane_enabled and not async_rollouts:
+        raise NotImplementedError(
+            "router_replay.enabled with NeMo-Gym over the sync TQ dataplane "
+            "(data_plane.enabled=true) is not a tested transport for routed "
+            "experts. Use data_plane.enabled=false with NeMo-Gym."
+        )
+    _validate_model_is_moe(policy_config)
+
+
+def _validate_model_is_moe(policy_config: PolicyConfig) -> None:
+    """Raise if the policy model config is loadable and clearly has no routed experts."""
+    model_name = policy_config.get("model_name")
+    if not model_name:
+        return
+    # Deferred import: transformers config loading is only needed for this check.
+    from transformers import AutoConfig
+
+    try:
+        hf_config = AutoConfig.from_pretrained(model_name, trust_remote_code=True)
+    except (OSError, ValueError):
+        # Best-effort check: an unloadable config here will fail loudly later in
+        # model setup, with better context than we could add now.
+        return
+    for owner in (hf_config, getattr(hf_config, "text_config", None)):
+        if owner is None:
+            continue
+        for attr in ("num_experts", "n_routed_experts", "num_local_experts"):
+            value = getattr(owner, attr, None)
+            if isinstance(value, int) and value > 0:
+                return
+    raise ValueError(
+        f"router_replay.enabled requires a MoE model, but '{model_name}' has no "
+        "routed-expert count in its config (checked num_experts, "
+        "n_routed_experts, num_local_experts). Disable policy.router_replay for "
+        "dense models."
+    )
+
+
 def _iter_model_modules(model: Any) -> Iterable[Any]:
     if isinstance(model, (list, tuple)):
         for item in model:

--- a/tests/unit/environments/test_nemo_gym_router_replay.py
+++ b/tests/unit/environments/test_nemo_gym_router_replay.py
@@ -182,15 +182,39 @@ def test_single_turn_final_token_route_unchanged():
     assert message_log[1]["routed_experts"].tolist() == _routes_from(3, 0)[2:3]
 
 
-def test_surplus_final_token_route_is_accepted():
+def test_surplus_route_rows_raise():
+    # expected tokens for turn 2 = 7; any surplus is an exact-count mismatch.
     result = _two_turn_result()
-    # expected tokens for turn 2 = 7; one surplus row is the legal final-token route
     result["response"]["output"][1]["routed_experts"] = _routes_from(8, 1000)
-    _postprocess(result)
+    with pytest.raises(ValueError, match="row count does not match"):
+        _postprocess(result)
 
 
-def test_more_than_one_surplus_route_row_raises():
+def test_too_few_route_rows_raise():
     result = _two_turn_result()
-    result["response"]["output"][1]["routed_experts"] = _routes_from(9, 1000)
-    with pytest.raises(ValueError, match="too many routed_experts rows"):
+    result["response"]["output"][1]["routed_experts"] = _routes_from(6, 1000)
+    with pytest.raises(ValueError, match="row count does not match"):
+        _postprocess(result)
+
+
+def test_missing_routes_on_one_item_are_sentinel_filled_not_fatal():
+    # One healthy item (provides the [layers, topk] shape) plus one trace-less
+    # item (Gym's error-recovery dummy). The dummy must be sentinel-filled, not
+    # crash the run.
+    result = _two_turn_result()
+    result["response"]["output"][1].pop("routed_experts")
+    message_log = _postprocess(result)["message_log"]
+    # turn-2 (dummy) assistant message: routes are all the -1 sentinel.
+    dummy_assistant = message_log[3]
+    routes = dummy_assistant["routed_experts"]
+    assert (routes == -1).all()
+    # shape borrowed from the healthy sibling: [layers=1, topk=2] per _routes_from.
+    assert routes.shape[1:] == (1, 2)
+
+
+def test_all_items_missing_routes_still_raises():
+    result = _two_turn_result()
+    for item in result["response"]["output"]:
+        item.pop("routed_experts")
+    with pytest.raises(ValueError, match="no item in the batch carried them"):
         _postprocess(result)

--- a/tests/unit/environments/test_nemo_gym_router_replay.py
+++ b/tests/unit/environments/test_nemo_gym_router_replay.py
@@ -119,3 +119,78 @@ def test_nemo_gym_postprocess_casts_routed_experts_to_configured_dtype():
     for message in result["message_log"]:
         if "routed_experts" in message:
             assert message["routed_experts"].dtype == torch.int8
+
+
+def _routes_from(num_tokens: int, base: int) -> list[list[list[int]]]:
+    return [
+        [[base + token_idx, base + token_idx + 100]] for token_idx in range(num_tokens)
+    ]
+
+
+def _two_turn_result() -> dict:
+    return {
+        "response": {
+            "output": [
+                {
+                    "prompt_token_ids": [1, 2],
+                    "generation_token_ids": [3],
+                    "generation_log_probs": [-0.1],
+                    "routed_experts": _routes_from(3, 0),
+                },
+                {
+                    "prompt_token_ids": [1, 2, 3, 4, 5],
+                    "generation_token_ids": [6, 7],
+                    "generation_log_probs": [-0.2, -0.3],
+                    "routed_experts": _routes_from(7, 1000),
+                },
+            ]
+        },
+        "responses_create_params": {"input": []},
+    }
+
+
+class _R3MockSelf:
+    cfg = {"require_routed_experts": True}
+
+
+def _postprocess(result):
+    return (
+        NemoGym.__ray_metadata__.modified_class._postprocess_nemo_gym_to_nemo_rl_result(
+            _R3MockSelf(), result, _Tokenizer()
+        )
+    )
+
+
+def test_prev_turn_final_token_route_spliced_from_next_turn_prefill():
+    message_log = _postprocess(_two_turn_result())["message_log"]
+
+    turn1_assistant = message_log[1]
+    # Turn-1 assistant covers global position 2 only (token id 3). Its route row
+    # was the placeholder from turn 1; the splice must replace it with turn 2's
+    # real prefill row at global position 2.
+    assert turn1_assistant["routed_experts"].tolist() == _routes_from(7, 1000)[2:3]
+    # Turn-2 assistant (final turn) keeps its own rows untouched — the last
+    # position placeholder is unavoidable for the final turn.
+    turn2_assistant = message_log[3]
+    assert turn2_assistant["routed_experts"].tolist() == _routes_from(7, 1000)[5:7]
+
+
+def test_single_turn_final_token_route_unchanged():
+    result = _two_turn_result()
+    result["response"]["output"] = result["response"]["output"][:1]
+    message_log = _postprocess(result)["message_log"]
+    assert message_log[1]["routed_experts"].tolist() == _routes_from(3, 0)[2:3]
+
+
+def test_surplus_final_token_route_is_accepted():
+    result = _two_turn_result()
+    # expected tokens for turn 2 = 7; one surplus row is the legal final-token route
+    result["response"]["output"][1]["routed_experts"] = _routes_from(8, 1000)
+    _postprocess(result)
+
+
+def test_more_than_one_surplus_route_row_raises():
+    result = _two_turn_result()
+    result["response"]["output"][1]["routed_experts"] = _routes_from(9, 1000)
+    with pytest.raises(ValueError, match="too many routed_experts rows"):
+        _postprocess(result)

--- a/tests/unit/models/megatron/test_router_replay_startup_validation.py
+++ b/tests/unit/models/megatron/test_router_replay_startup_validation.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Startup-validation matrix for router replay, against the real exemplar YAMLs.
+
+These tests intentionally load the shipped configs (with inheritance) rather
+than hand-built dicts, so key-path assumptions in the validator are exercised
+against the true config shape.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from omegaconf import OmegaConf
+
+from nemo_rl.models.megatron.router_replay import validate_router_replay_startup
+from nemo_rl.utils.config import load_config
+
+REPO_ROOT = Path(__file__).parents[4]
+QWEN30B_MEGATRON_YAML = REPO_ROOT / "examples/configs/grpo_math_qwen30ba3b_megatron.yaml"
+
+MOE_HF_CONFIG = SimpleNamespace(num_experts=128)
+DENSE_HF_CONFIG = SimpleNamespace()
+
+
+@pytest.fixture()
+def moe_model_config(monkeypatch):
+    monkeypatch.setattr(
+        "transformers.AutoConfig.from_pretrained",
+        lambda *args, **kwargs: MOE_HF_CONFIG,
+    )
+
+
+@pytest.fixture()
+def qwen30b_policy():
+    cfg = load_config(QWEN30B_MEGATRON_YAML)
+    policy = OmegaConf.to_container(cfg, resolve=True)["policy"]
+    policy["router_replay"] = {"enabled": True}
+    return policy
+
+
+def test_exemplar_megatron_config_with_r3_passes(qwen30b_policy, moe_model_config):
+    validate_router_replay_startup(qwen30b_policy)
+
+
+def test_r3_disabled_skips_all_checks(qwen30b_policy):
+    qwen30b_policy["router_replay"] = {"enabled": False}
+    # DTensor on + megatron off would raise if checks ran.
+    qwen30b_policy["dtensor_cfg"]["enabled"] = True
+    qwen30b_policy["megatron_cfg"]["enabled"] = False
+    validate_router_replay_startup(qwen30b_policy)
+
+
+def test_r3_with_dtensor_backend_raises(qwen30b_policy, moe_model_config):
+    qwen30b_policy["dtensor_cfg"]["enabled"] = True
+    qwen30b_policy["megatron_cfg"]["enabled"] = False
+    with pytest.raises(ValueError, match="Megatron policy backend"):
+        validate_router_replay_startup(qwen30b_policy)
+
+
+def test_r3_with_mtp_raises(qwen30b_policy, moe_model_config):
+    qwen30b_policy["megatron_cfg"]["mtp_num_layers"] = 2
+    with pytest.raises(ValueError, match="MTP"):
+        validate_router_replay_startup(qwen30b_policy)
+
+
+def test_r3_with_gym_over_sync_dataplane_raises(qwen30b_policy, moe_model_config):
+    with pytest.raises(NotImplementedError, match="sync TQ dataplane"):
+        validate_router_replay_startup(
+            qwen30b_policy,
+            data_plane_enabled=True,
+            using_nemo_gym=True,
+            async_rollouts=False,
+        )
+
+
+def test_r3_with_gym_without_dataplane_passes(qwen30b_policy, moe_model_config):
+    validate_router_replay_startup(
+        qwen30b_policy,
+        data_plane_enabled=False,
+        using_nemo_gym=True,
+        async_rollouts=False,
+    )
+
+
+def test_r3_with_sync_dataplane_without_gym_passes(qwen30b_policy, moe_model_config):
+    validate_router_replay_startup(
+        qwen30b_policy,
+        data_plane_enabled=True,
+        using_nemo_gym=False,
+        async_rollouts=False,
+    )
+
+
+def test_r3_on_dense_model_raises(qwen30b_policy, monkeypatch):
+    monkeypatch.setattr(
+        "transformers.AutoConfig.from_pretrained",
+        lambda *args, **kwargs: DENSE_HF_CONFIG,
+    )
+    with pytest.raises(ValueError, match="MoE model"):
+        validate_router_replay_startup(qwen30b_policy)
+
+
+def test_r3_with_unloadable_model_config_defers_to_model_setup(
+    qwen30b_policy, monkeypatch
+):
+    def _raise(*args, **kwargs):
+        raise OSError("no such model")
+
+    monkeypatch.setattr("transformers.AutoConfig.from_pretrained", _raise)
+    validate_router_replay_startup(qwen30b_policy)

--- a/tests/unit/models/megatron/test_router_replay_startup_validation.py
+++ b/tests/unit/models/megatron/test_router_replay_startup_validation.py
@@ -25,7 +25,9 @@ import pytest
 from omegaconf import OmegaConf
 
 from nemo_rl.models.megatron.router_replay import validate_router_replay_startup
-from nemo_rl.utils.config import load_config
+from nemo_rl.utils.config import load_config, register_omegaconf_resolvers
+
+register_omegaconf_resolvers()
 
 REPO_ROOT = Path(__file__).parents[4]
 QWEN30B_MEGATRON_YAML = REPO_ROOT / "examples/configs/grpo_math_qwen30ba3b_megatron.yaml"

--- a/tests/unit/models/megatron/test_router_replay_startup_validation.py
+++ b/tests/unit/models/megatron/test_router_replay_startup_validation.py
@@ -30,7 +30,9 @@ from nemo_rl.utils.config import load_config, register_omegaconf_resolvers
 register_omegaconf_resolvers()
 
 REPO_ROOT = Path(__file__).parents[4]
-QWEN30B_MEGATRON_YAML = REPO_ROOT / "examples/configs/grpo_math_qwen30ba3b_megatron.yaml"
+QWEN30B_MEGATRON_YAML = (
+    REPO_ROOT / "examples/configs/grpo_math_qwen30ba3b_megatron.yaml"
+)
 
 MOE_HF_CONFIG = SimpleNamespace(num_experts=128)
 DENSE_HF_CONFIG = SimpleNamespace()


### PR DESCRIPTION
# What does this PR do ?

**Startup validation** (`router_replay.py`, `grpo.py`) — new `validate_router_replay_startup(...)` in `grpo.setup()` rejects, up front, configs that previously no-op'd or crashed mid-run: non-Megatron backend (routes captured but never replayed), MTP, NeMo-Gym over sync-TQ, and dense (non-MoE) models.

**NeMo-Gym trace alignment** (`nemo_gym.py`) — exact route-row count check (`<`→`!=`); splice each turn's real final-token route from the next turn's re-forward (vLLM leaves it a placeholder); sentinel-fill a single trace-less rollout instead of killing the run (only a fully trace-less batch raises); read the sentinel shape via `len()` instead of a redundant tensor conversion.
# Validation

We didn't observe any regression.

<img width="2043" height="326" alt="Screenshot 2026-07-09 at 4 08 36 PM" src="https://github.com/user-attachments/assets/3fdb5841-f654-49b8-b37c-f22e1f602f5d" />
