### PR TITLE
fix: use staged SWE1 data in nightly recipe

### DIFF
--- a/examples/configs/recipes/llm/grpo-qwen3-30ba3b-thinking-swe1-16n8g-megatron-cp2-r3-async-gym.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen3-30ba3b-thinking-swe1-16n8g-megatron-cp2-r3-async-gym.yaml
@@ -1,8 +1,6 @@
 defaults: ../../../nemo_gym/grpo_qwen3_30ba3b_thinking_swe1.yaml
 grpo:
   num_prompts_per_step: 16
-  max_val_samples: 32
-  val_batch_size: 32
 checkpointing:
   checkpoint_dir: results/grpo-qwen3-30ba3b-thinking-swe1-16n8g-megatron-cp2-r3-async-gym
   enabled: false
@@ -16,6 +14,25 @@ policy:
       enable_prefix_caching: false
     vllm_kwargs:
       enable_chunked_prefill: false
+data:
+  train:
+    data_path: "${oc.env:HF_HOME}/superv3_data/swe1/train-split.jsonl"
+  validation:
+    data_path: "${oc.env:HF_HOME}/superv3_data/swe1/val-split.jsonl"
+env:
+  nemo_gym:
+    # The staged SWE1 data uses this legacy agent name. Register it as an
+    # alias for the current SWE pivot server instead of rewriting the data.
+    single_step_tool_use_with_argument_comparison_swe:
+      responses_api_agents:
+        tool_simulation_agent:
+          entrypoint: app.py
+          resources_server:
+            type: resources_servers
+            name: swe_pivot_single_step_tool_use_with_argument_comparison_resources_server
+          model_server:
+            type: responses_api_models
+            name: policy_model
 logger:
   log_dir: logs/grpo-qwen3-30ba3b-thinking-swe1-16n8g-megatron-cp2-r3-async-gym
   wandb:

--- a/tests/test_suites/llm/grpo-qwen3-30ba3b-thinking-swe1-16n8g-megatron-cp2-r3-async-gym.sh
+++ b/tests/test_suites/llm/grpo-qwen3-30ba3b-thinking-swe1-16n8g-megatron-cp2-r3-async-gym.sh
@@ -17,25 +17,6 @@ exit_if_max_steps_reached
 
 cd $PROJECT_ROOT
 
-DATA_DIR=$EXP_DIR/data
-RAW_DATA_DIR=$DATA_DIR/raw
-TRAIN_PATH=$DATA_DIR/swe1_train.jsonl
-VALIDATION_PATH=$DATA_DIR/swe1_validation.jsonl
-mkdir -p $RAW_DATA_DIR
-
-if [[ ! -f $RAW_DATA_DIR/swe1.jsonl ]]; then
-    uv run hf download nvidia/Nemotron-RL-Super-Training-Blends swe1.jsonl \
-        --repo-type dataset \
-        --local-dir $RAW_DATA_DIR
-fi
-
-if [[ ! -f $TRAIN_PATH ]]; then
-    head -n 512 $RAW_DATA_DIR/swe1.jsonl > $TRAIN_PATH
-fi
-if [[ ! -f $VALIDATION_PATH ]]; then
-    tail -n 32 $RAW_DATA_DIR/swe1.jsonl > $VALIDATION_PATH
-fi
-
 uv run examples/nemo_gym/run_grpo_nemo_gym.py \
     --config $CONFIG_PATH \
     grpo.max_num_steps=$MAX_STEPS \
@@ -47,8 +28,6 @@ uv run examples/nemo_gym/run_grpo_nemo_gym.py \
     logger.tensorboard_enabled=True \
     checkpointing.enabled=True \
     checkpointing.checkpoint_dir=$CKPT_DIR \
-    data.train.data_path=$TRAIN_PATH \
-    data.validation.data_path=$VALIDATION_PATH \
     $@ \
     2>&1 | tee $RUN_LOG
 


### PR DESCRIPTION
# What does this PR do ?

This PR fixes the SWE1 async-Gym nightly by using pre-staged local SWE1 data in offline CI instead of attempting a runtime HuggingFace download.
