### PR TITLE
fix: skip RayVirtualCluster.shutdown when Ray already torn down

### DIFF
--- a/nemo_rl/distributed/virtual_cluster.py
+++ b/nemo_rl/distributed/virtual_cluster.py
@@ -1018,6 +1018,11 @@ class RayVirtualCluster:
 
         This method is idempotent and can be safely called multiple times.
         """
+        # Skip if Ray is already gone (typically from __del__ during _Py_Finalize
+        # after Ray's atexit teardown). Any Ray API call would trigger a fatal
+        # core_worker_process.cc:88 CHECK. Placement groups die with Ray.
+        if not ray.is_initialized():
+            return True
         if self._node_placement_groups is not None:
             # Remove all placement groups
             for pg in self._node_placement_groups:


### PR DESCRIPTION
## Issue

MOPD nightly (`llm_mopd_qwen3_1_7b_3n8g_megatron_pack`) exits 1 after training completes cleanly:

```
[C] core_worker_process.cc:88: Check failed: !core_worker_process
```

Ray's atexit tears down `CoreWorker` first, then Python's GC runs `__del__` on `RayVirtualCluster` instances, which call `remove_placement_group` on the dead runtime — CoreWorker re-init fails the CHECK and the process aborts.

## Fix

Return early from `RayVirtualCluster.shutdown()` when `ray.is_initialized()` is False. The guard only fires from `__del__` during `_Py_Finalize`; placement groups are already gone with Ray at that point.

**5 lines, 1 file.** No new imports, no semantic change when Ray is alive, no reference retention.

Verified twice end-to-end on the `mopd-qwen3-1.7b-3n8g-megatron-pack` nightly recipe:

🤖 Generated with [Claude Code](https://claude.com/claude-code)