### PR TITLE
fix: bump FW-CI-templates claude review to v1.8.1

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   claude-review:
     if: github.event.issue.pull_request != null && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@v1.7.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@v1.8.1
     with:
       model: ${{ vars.CLAUDE_MODEL }}
       prompt: |


### PR DESCRIPTION
## Summary
- Bumps `_claude_review.yml` from `@v1.7.0` to `@v1.8.1`
- v1.8.1 replaces `Bash(gh pr *:*)` patterns with built-in `Read`/`Glob`/`Grep` tools and adds a dual-checkout security model
- Fixes silent review failures where Claude hit a permission denial mid-run and exited without posting anything

## Test plan
- Trigger `/claude review` on any open PR and verify a review comment appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)