### PR TITLE
fix(async): Always honor recompute_kv_cache_after_weight_updates

### DIFF
--- a/docs/guides/async-grpo.md
+++ b/docs/guides/async-grpo.md
@@ -42,7 +42,7 @@ grpo:
     enabled: true
     max_trajectory_age_steps: 1  # Maximum age, in training steps, for trajectories
     in_flight_weight_updates: false  # Enable for faster weight synchronization
-    recompute_kv_cache_after_weight_updates: false # Invalidates kv cache after in-flight-weight-updates
+    recompute_kv_cache_after_weight_updates: false # Invalidates kv cache after weight-updates
 ```
 
 ### Complete Example Config
@@ -68,7 +68,7 @@ grpo:
     enabled: true
     max_trajectory_age_steps: 1
     in_flight_weight_updates: false  # Enable for faster weight synchronization
-    recompute_kv_cache_after_weight_updates: false # Invalidates kv cache after in-flight-weight-updates
+    recompute_kv_cache_after_weight_updates: false # Invalidates kv cache after weight-updates
 
 cluster:
   num_nodes: 2
@@ -189,8 +189,7 @@ If no `replay_buffer.pt` file is found in the latest checkpoint directory, train
 
 4. **In-Flight Weight Updates**: Enable `in_flight_weight_updates: true` when using `async_engine: true` for updating the weights of vLLM engine during generation. This prevents stalling training pipeline until longest generation finishes and provides significant performance benefits.
 
-5. **Recompute KV Cache After Weight Updates**: While using in-flight weight update, user can choose whether to recompute
-KV caches after weight udpate by configuring `recompute_kv_cache_after_weight_update` configuration.
+5. **Recompute KV Cache After Weight Updates**: A user can choose whether to invalidate and recompute KV caches after weight updates by setting the `recompute_kv_cache_after_weight_updates` configuration. This is applicable to async GRPO and independent of in-flight updates.
 
 ## Why Importance Sampling Correction Is Required for Async
 

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -50,7 +50,7 @@ grpo:
     # Max age (in training steps) for trajectories used in training
     max_trajectory_age_steps: 1
     in_flight_weight_updates: false # Set to true to enable in-flight weight updates
-    recompute_kv_cache_after_weight_updates: false # Set to true to recompute kv cache after in-flight-weight-updates
+    recompute_kv_cache_after_weight_updates: false # Set to true to recompute kv cache after weight updates
 
 # Reward-zeroing penalties applied to NeMo-Gym rollout results.
 reward_penalties:

--- a/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
+++ b/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
@@ -48,7 +48,7 @@ grpo:
     # Max age (in training steps) for trajectories used in training
     max_trajectory_age_steps: 1
     in_flight_weight_updates: false # Set to true to enable in-flight weight updates
-    recompute_kv_cache_after_weight_updates: false # Set to true to recompute kv cache after in-flight-weight-updates
+    recompute_kv_cache_after_weight_updates: false # Set to true to recompute kv cache after weight updates
 
 loss_fn:
   reference_policy_kl_penalty: 0

--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -554,16 +554,20 @@ class AsyncTrajectoryCollector:
         async_cfg = self.master_config.grpo.get("async_grpo", {})
         if async_cfg.get("recompute_kv_cache_after_weight_updates", False):
             try:
-                print("🔄 Invalidating vLLM prefix/KV caches after weight update")
+                print(
+                    "🔄 Invalidating generation backend KV caches after weight update"
+                )
                 invalidated = self.policy_generation.invalidate_kv_cache()
                 if invalidated:
-                    print("✅ Invalidated vLLM prefix/KV caches after weight update")
+                    print(
+                        "✅ Invalidated generation backend KV caches after weight update"
+                    )
                 else:
                     print(
-                        "⚠️ vLLM cache invalidation reported partial/unsuccessful on some workers"
+                        "⚠️ KV cache invalidation not supported or only partially applied by the generation backend"
                     )
             except Exception as e:
-                print(f"⚠️ Failed to invalidate vLLM caches: {e}")
+                print(f"⚠️ Failed to invalidate generation backend KV caches: {e}")
 
         self._refit_pause_cleared.set()
 

--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -547,13 +547,12 @@ class AsyncTrajectoryCollector:
         """Resume new generation starts after refit is complete."""
         print("🔄 Resuming generation starts after refit")
 
-        # Invalidate&recompute vLLM caches after the in-flight weight updates if
+        # Invalidate&recompute vLLM caches after the weight updates (in-flight or not) if
         # recompute_kv_cache_after_weight_updates is True (AREAL-style implementation).
         # Otherwise, keep using the stale KV caches (Magistral-style implementation).
+        # Not invalidating KV cache can result in compounding policy KL errors across steps.
         async_cfg = self.master_config.grpo.get("async_grpo", {})
-        if async_cfg.get("in_flight_weight_updates", False) and async_cfg.get(
-            "recompute_kv_cache_after_weight_updates", False
-        ):
+        if async_cfg.get("recompute_kv_cache_after_weight_updates", False):
             try:
                 print("🔄 Invalidating vLLM prefix/KV caches after weight update")
                 invalidated = self.policy_generation.invalidate_kv_cache()

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -180,7 +180,7 @@ class AsyncGRPOConfig(TypedDict):
     # Does the weight synchronization as soon as the training is done
     # without waiting for the pending generations to finish.
     in_flight_weight_updates: NotRequired[bool]
-    # Recomputes the KV cache after the in-flight weight updates.
+    # Recomputes the KV cache after weight updates.
     recompute_kv_cache_after_weight_updates: NotRequired[bool]
 
 

--- a/research/template_project/configs/grpo_math_1B.yaml
+++ b/research/template_project/configs/grpo_math_1B.yaml
@@ -44,7 +44,7 @@ grpo:
     # Max age (in training steps) for trajectories used in training
     max_trajectory_age_steps: 1
     in_flight_weight_updates: false # Set to true to enable in-flight weight updates
-    recompute_kv_cache_after_weight_updates: false # Set to true to recompute kv cache after in-flight-weight-updates
+    recompute_kv_cache_after_weight_updates: false # Set to true to recompute kv cache after weight updates
 
 loss_fn:
   reference_policy_kl_penalty: 0.01

--- a/tests/unit/algorithms/test_async_utils.py
+++ b/tests/unit/algorithms/test_async_utils.py
@@ -1341,6 +1341,30 @@ class TestAsyncTrajectoryCollector:
         ray.kill(buffer)
         ray.kill(mock_env)
 
+    def test_resume_after_refit_invalidates_cache_without_in_flight_updates(self):
+        """Test resume after refit invalidates cache without in-flight updates."""
+        collector = self.create_local_collector()
+        async_cfg = collector.master_config.grpo["async_grpo"]
+        async_cfg["in_flight_weight_updates"] = False
+        async_cfg["recompute_kv_cache_after_weight_updates"] = True
+        collector.policy_generation.invalidate_kv_cache = mock.Mock(return_value=True)
+
+        collector.resume_after_refit()
+
+        collector.policy_generation.invalidate_kv_cache.assert_called_once_with()
+
+    def test_resume_after_refit_skips_cache_invalidation_when_recompute_disabled(self):
+        """Test resume after refit skips cache invalidation when recompute is disabled."""
+        collector = self.create_local_collector()
+        async_cfg = collector.master_config.grpo["async_grpo"]
+        async_cfg["in_flight_weight_updates"] = True
+        async_cfg["recompute_kv_cache_after_weight_updates"] = False
+        collector.policy_generation.invalidate_kv_cache = mock.Mock(return_value=True)
+
+        collector.resume_after_refit()
+
+        collector.policy_generation.invalidate_kv_cache.assert_not_called()
+
     def test_calculate_target_weights(self):
         """Test target weight calculation logic."""
         buffer = ReplayBuffer.remote(max_size=10)

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -50,7 +50,7 @@ grpo:
     # Max age (in training steps) for trajectories used in training
     max_trajectory_age_steps: 1
     in_flight_weight_updates: false # Set to true to enable in-flight weight updates
-    recompute_kv_cache_after_weight_updates: false # Set to true to recompute kv cache after in-flight-weight-updates
+    recompute_kv_cache_after_weight_updates: false # Set to true to recompute kv cache after weight updates
 
 # Reward-zeroing penalties applied to NeMo-Gym rollout results.
 reward_penalties:


### PR DESCRIPTION
# What does this PR do ?

KV cache invalidation is not specific to in-flight updates. If KV cache (eg. same prompt) is reused across steps with different weights we can keep a stale KV cache around for a long time which can manifest as compounding policy KL divergence and logprob errors.

Make recompute_kv_cache_after_weight_updates evaluation independent of in_flight_weight_updates and honor it in async grpo.

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

Use this config:
```yaml
grpo:
   async_grpo:
     enabled: true
     max_trajectory_age_steps: 1
     in_flight_weight_updates: false
     recompute_kv_cache_after_weight_updates: true

```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
