### PR TITLE
fix: fix dapo-deepseek-v3-64n8g.v2 and dsv3 tokenizer

### DIFF
--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -55,13 +55,34 @@ def _patch_transformers_tokenizer_class_set():
         "Check if the upstream fix now applies and remove this patch if so."
     )
 
+    from transformers import AutoTokenizer
     from transformers.models.auto.tokenization_auto import (
         MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS,
         TOKENIZER_MAPPING_NAMES,
     )
 
-    MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS.discard("deepseek_v3")
-    TOKENIZER_MAPPING_NAMES.pop("deepseek_v3", None)
+    _original_from_pretrained = AutoTokenizer.from_pretrained
+
+    def _patched_from_pretrained(pretrained_model_name_or_path, *args, **kwargs):
+        try:
+            # DSV3 goes here: the transformers blocklist routes its
+            # tokenizer.json around LlamaTokenizerFast.__init__'s Llama-specific
+            # post-processing, which would corrupt DSV3 special tokens.
+            return _original_from_pretrained(
+                pretrained_model_name_or_path, *args, **kwargs
+            )
+        except Exception:
+            # Moonlight goes here: it ships no tokenizer.json (only
+            # tiktoken.model + remote-code TikTokenTokenizer), so the blocklist
+            # prevents loading. Strip deepseek_v3 from the registries so
+            # trust_remote_code / auto_map takes over.
+            MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS.discard("deepseek_v3")
+            TOKENIZER_MAPPING_NAMES.pop("deepseek_v3", None)
+            return _original_from_pretrained(
+                pretrained_model_name_or_path, *args, **kwargs
+            )
+
+    AutoTokenizer.from_pretrained = _patched_from_pretrained
 
 
 _patch_transformers_tokenizer_class_set()

--- a/tests/test_suites/llm/performance/dapo-deepseek-v3-64n8g.v2.sh
+++ b/tests/test_suites/llm/performance/dapo-deepseek-v3-64n8g.v2.sh
@@ -24,8 +24,8 @@ exit_if_max_steps_reached
 cd $PROJECT_ROOT
 uv run examples/run_grpo.py \
     --config $CONFIG_PATH \
-    grpo.num_prompts_per_step=64 \
-    grpo.num_generations_per_prompt=8 \
+    grpo.num_prompts_per_step=32 \
+    grpo.num_generations_per_prompt=16 \
     grpo.max_num_steps=$MAX_STEPS \
     policy.model_name=$NRL_DEEPSEEK_V3_BF16_CKPT \
     policy.tokenizer.name=$NRL_DEEPSEEK_V3_BF16_CKPT \


### PR DESCRIPTION
## 1. Fix `dapo-deepseek-v3-64n8g.v2`

Update `num_prompts_per_step * num_generations_per_prompt` from 64 * 8 to 32 * 16.

The dynamic-sampling fix in #2478 filters more samples than before. With `num_generations_per_prompt=8`, samples are easily filtered and most runs approach the max allowed number of batches (10), triggering the 4h timeout. Some runs also fail with:

```
ValueError: Dynamic sampling has reached the maximum allowed number of batches (10). Consider evaluating the complexity of your data or adjusting the num_prompts_per_step or num_generations_per_prompt parameters to enhance the diversity of the samples.
```

Raising `num_generations_per_prompt` to 16 gives enough within-group diversity.

## 2. Fix DSV3 tokenizer

The Moonlight tokenizer fix in #3116 breaks DSV3. Narrow the scope of the Moonlight patch so it only kicks in when the default `AutoTokenizer.from_pretrained` path fails.

## Tests
Validated below tests passed.
- `dapo-deepseek-v3-64n8g.v2`
- `grpo-moonlight-16b-automodel-1n8g-ep8`

## Note
`dapo-deepseek-v3-64n8g.v2` is fixed in `r0.7.0` branch, but will easily meet the below error in main branch. tracked in https://github.com/NVIDIA-NeMo/RL/issues/3155.

`(MegatronPolicyWorker pid=1391870) [2026-07-10 06:19:36] pool0-00008:1391870:1393239 [7] init.cc:904 NCCL WARN Duplicate GPU detected : rank 15 and rank 7 both on CUDA device e4000`