### PR TITLE
fix(automodel): avoid fp32 weight load when optimizer holds master

### DIFF
--- a/nemo_rl/models/automodel/setup.py
+++ b/nemo_rl/models/automodel/setup.py
@@ -324,10 +324,20 @@ def validate_and_prepare_config(
         else ("sdpa" if cp_size_cfg > 1 else None)
     )
 
+    # Load weights in float32 so the optimizer can keep fp32 master weights.
+    # Exception: TE FusedAdam with master_weights=True keeps its own fp32 master
+    # internally (bf16 params + int16 remainder), so an fp32 load is redundant and
+    # roughly doubles both model- and master-weight memory. In that case load in the
+    # compute dtype instead. See https://github.com/NVIDIA-NeMo/RL/issues/2865.
+    optimizer_cfg = config.get("optimizer") or {}
+    optimizer_kwargs = optimizer_cfg.get("kwargs") or {}
+    optimizer_keeps_fp32_master = bool(optimizer_kwargs.get("master_weights", False))
+    model_load_dtype = dtype if optimizer_keeps_fp32_master else torch.float32
+
     # Load model config
     model_config = AutoConfig.from_pretrained(
         model_name,
-        torch_dtype=torch.float32,  # Always load in float32 for master weights
+        torch_dtype=model_load_dtype,
         trust_remote_code=True,
         attn_implementation="flash_attention_2" if enable_seq_packing else None,
         **hf_config_overrides,

--- a/tests/unit/models/automodel/test_automodel_setup.py
+++ b/tests/unit/models/automodel/test_automodel_setup.py
@@ -126,6 +126,73 @@ class TestValidateAndPrepareConfig:
     @patch("nemo_rl.models.automodel.setup.AutoConfig")
     @patch("nemo_rl.models.automodel.setup.resolve_model_class")
     @patch("nemo_rl.models.automodel.setup.configure_dynamo_cache")
+    def test_load_dtype_fp32_for_plain_adamw(
+        self,
+        mock_dynamo,
+        mock_resolve_class,
+        mock_autoconfig_class,
+        mock_config,
+        mock_autoconfig,
+    ):
+        """Optimizers without an internal master (e.g. AdamW) load weights in fp32."""
+        mock_autoconfig_class.from_pretrained.return_value = mock_autoconfig
+        mock_resolve_class.return_value = Mock
+
+        validate_and_prepare_config(config=mock_config, processor=None, rank=0)
+
+        call_kwargs = mock_autoconfig_class.from_pretrained.call_args.kwargs
+        assert call_kwargs["torch_dtype"] == torch.float32
+
+    @patch("nemo_rl.models.automodel.setup.AutoConfig")
+    @patch("nemo_rl.models.automodel.setup.resolve_model_class")
+    @patch("nemo_rl.models.automodel.setup.configure_dynamo_cache")
+    def test_load_dtype_compute_when_optimizer_holds_master(
+        self,
+        mock_dynamo,
+        mock_resolve_class,
+        mock_autoconfig_class,
+        mock_config,
+        mock_autoconfig,
+    ):
+        """TE FusedAdam with master_weights holds its own fp32 master, so weights
+        load in the compute dtype to avoid ~2x memory (issue #2865)."""
+        mock_autoconfig_class.from_pretrained.return_value = mock_autoconfig
+        mock_resolve_class.return_value = Mock
+        mock_config["optimizer"] = {
+            "name": "transformer_engine.pytorch.optimizers.fused_adam.FusedAdam",
+            "kwargs": {"lr": 1e-4, "master_weights": True},
+        }
+
+        validate_and_prepare_config(config=mock_config, processor=None, rank=0)
+
+        call_kwargs = mock_autoconfig_class.from_pretrained.call_args.kwargs
+        # mock_config precision is "bfloat16"
+        assert call_kwargs["torch_dtype"] == torch.bfloat16
+
+    @patch("nemo_rl.models.automodel.setup.AutoConfig")
+    @patch("nemo_rl.models.automodel.setup.resolve_model_class")
+    @patch("nemo_rl.models.automodel.setup.configure_dynamo_cache")
+    def test_load_dtype_fp32_when_optimizer_absent(
+        self,
+        mock_dynamo,
+        mock_resolve_class,
+        mock_autoconfig_class,
+        mock_config,
+        mock_autoconfig,
+    ):
+        """A missing optimizer config falls back to the fp32 load (no master)."""
+        mock_autoconfig_class.from_pretrained.return_value = mock_autoconfig
+        mock_resolve_class.return_value = Mock
+        mock_config.pop("optimizer", None)
+
+        validate_and_prepare_config(config=mock_config, processor=None, rank=0)
+
+        call_kwargs = mock_autoconfig_class.from_pretrained.call_args.kwargs
+        assert call_kwargs["torch_dtype"] == torch.float32
+
+    @patch("nemo_rl.models.automodel.setup.AutoConfig")
+    @patch("nemo_rl.models.automodel.setup.resolve_model_class")
+    @patch("nemo_rl.models.automodel.setup.configure_dynamo_cache")
     def test_precision_validation_invalid(
         self,
         mock_dynamo,


### PR DESCRIPTION
## What
The automodel (DTensor) backend hard-coded the model load dtype to `float32` in `nemo_rl/models/automodel/setup.py` so the optimizer could keep fp32 master weights. When the optimizer maintains its **own** fp32 master — TE `FusedAdam` with `master_weights=True` (bf16 params + int16 remainder) — that fp32 load is redundant and roughly **doubles** both model-weight and optimizer master-weight memory.

Fixes #2865.

## Change
Pick the load dtype from the optimizer config in `validate_and_prepare_config`:
- `master_weights=True` (optimizer holds the master) → load in the **compute dtype**.
- plain AdamW / no `master_weights` / no optimizer configured → keep the **fp32** load (unchanged behavior).

Only the load dtype changes; the FSDP mixed-precision policy and everything downstream are untouched.

## Impact
No behavior change for the exemplar configs (they use `torch.optim.AdamW`, which has no internal master → still fp32). The savings apply only to the FusedAdam+`master_weights` path the issue reports (~131GB → ~102GB optimizer state, ~67GB → ~36GB model params in the reporter's run).

## Test plan
- [x] New unit tests in `tests/unit/models/automodel/test_automodel_setup.py` asserting the `torch_dtype` passed to `AutoConfig.from_pretrained`:
  - plain AdamW → `float32`
  - FusedAdam + `master_weights=True` → compute dtype (bf16)
  - optimizer absent → `float32`
- [ ] CI (`/ok to test`)

_Note: local test run blocked by an unrelated `uv`/Python `mac_ver()` issue on the dev box; logic validated in isolation and syntax-checked. CI will exercise the full suite._