### PR TITLE
feat: fault-tolerance checkpoint retention (ft_save_period / ft_keep_latest_k)

### DIFF
--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -947,10 +947,15 @@ def distillation_train(
                 consumed_samples += master_config.distillation["num_prompts_per_step"]
                 timeout.mark_iteration()
 
+                ft_save_period = master_config.checkpointing.get("ft_save_period")
                 should_save_by_step = (
                     is_last_step
                     or (total_steps + 1) % master_config.checkpointing["save_period"]
                     == 0
+                    or (
+                        ft_save_period is not None
+                        and (total_steps + 1) % ft_save_period == 0
+                    )
                 )
                 # +1 because total_steps is 0-indexed
                 # Check if timeout-based checkpointing is enabled in config.

--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -714,6 +714,8 @@ def distillation_train(
     # Run distillation training (multi-epoch until reaching max_num_steps or max_num_epochs)
     batch: BatchedDataDict[DatumSpec]
 
+    ft_save_period = master_config.checkpointing.get("ft_save_period")
+
     while total_steps < max_steps and current_epoch < max_epochs:
         print(
             f"\n{'=' * 25} Epoch {current_epoch + 1}/{max_epochs} {'=' * 25}",
@@ -947,7 +949,6 @@ def distillation_train(
                 consumed_samples += master_config.distillation["num_prompts_per_step"]
                 timeout.mark_iteration()
 
-                ft_save_period = master_config.checkpointing.get("ft_save_period")
                 should_save_by_step = (
                     is_last_step
                     or (total_steps + 1) % master_config.checkpointing["save_period"]
@@ -1109,9 +1110,11 @@ def distillation_train(
             current_step += 1
             total_steps += 1
             if should_save_by_timeout:
+                checkpointer.shutdown()
                 print("Timeout has been reached, stopping training early", flush=True)
                 return
             if total_steps >= max_steps:
+                checkpointer.shutdown()
                 print(
                     "Max number of steps has been reached, stopping training early",
                     flush=True,
@@ -1121,6 +1124,13 @@ def distillation_train(
         # End of epoch
         current_epoch += 1
         current_step = 0  # Reset step counter for new epoch
+
+    # Flush the last checkpoint's background finalization on an epoch-bounded
+    # exit. Reaching max_epochs falls through the while loop and bypasses the
+    # inline shutdown() calls at the max_steps / timeout early returns, so
+    # without this the daemon finalization thread could be killed before the
+    # final tmp_step_N is renamed.
+    checkpointer.shutdown()
 
 
 def validate(

--- a/nemo_rl/algorithms/dpo.py
+++ b/nemo_rl/algorithms/dpo.py
@@ -570,6 +570,8 @@ def dpo_train(
 
     policy.prepare_for_training()
 
+    ft_save_period = master_config.checkpointing.get("ft_save_period")
+
     while (
         current_epoch < max_num_epochs and total_steps < master_config.dpo.max_num_steps
     ):
@@ -643,7 +645,6 @@ def dpo_train(
                 ]
                 timeout.mark_iteration()
 
-                ft_save_period = master_config.checkpointing.get("ft_save_period")
                 should_save_by_step = (
                     is_last_step
                     or (total_steps + 1) % master_config.checkpointing["save_period"]
@@ -792,9 +793,11 @@ def dpo_train(
             total_steps += 1
 
             if should_save_by_timeout:
+                checkpointer.shutdown()
                 print("Timeout has been reached, stopping training early", flush=True)
                 return
             if total_steps >= master_config.dpo.max_num_steps:
+                checkpointer.shutdown()
                 print(
                     "Max number of steps has been reached, stopping training early",
                     flush=True,
@@ -803,3 +806,10 @@ def dpo_train(
 
         current_epoch += 1
         current_step = 0  # Reset step counter for new epoch
+
+    # Flush the last checkpoint's background finalization on an epoch-bounded
+    # exit. Reaching max_num_epochs falls through the while loop and bypasses
+    # the inline shutdown() calls at the max_num_steps / timeout early returns,
+    # so without this the daemon finalization thread could be killed before the
+    # final tmp_step_N is renamed.
+    checkpointer.shutdown()

--- a/nemo_rl/algorithms/dpo.py
+++ b/nemo_rl/algorithms/dpo.py
@@ -643,10 +643,15 @@ def dpo_train(
                 ]
                 timeout.mark_iteration()
 
+                ft_save_period = master_config.checkpointing.get("ft_save_period")
                 should_save_by_step = (
                     is_last_step
                     or (total_steps + 1) % master_config.checkpointing["save_period"]
                     == 0
+                    or (
+                        ft_save_period is not None
+                        and (total_steps + 1) % ft_save_period == 0
+                    )
                 )
                 # +1 because step is 0-indexed
                 # Check if timeout-based checkpointing is enabled in config.

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -3022,12 +3022,17 @@ def grpo_train(
                 consumed_samples += master_config.grpo["num_prompts_per_step"]
                 timeout.mark_iteration()
 
+                # +1 because step is 0-indexed
+                ft_save_period = master_config.checkpointing.get("ft_save_period")
                 should_save_by_step = (
                     is_last_step
                     or (total_steps + 1) % master_config.checkpointing["save_period"]
                     == 0
+                    or (
+                        ft_save_period is not None
+                        and (total_steps + 1) % ft_save_period == 0
+                    )
                 )
-                # +1 because step is 0-indexed
                 # Check if timeout-based checkpointing is enabled in config.
                 should_save_by_timeout = timeout.check_save()
 
@@ -4375,11 +4380,13 @@ def async_grpo_train(
                 consumed_samples += master_config.grpo["num_prompts_per_step"]
                 timeout.mark_iteration()
 
+                # +1 because step is 0-indexed
+                ft_save_period = master_config.checkpointing.get("ft_save_period")
                 should_save_by_step = (
                     is_last_step
                     or (step + 1) % master_config.checkpointing["save_period"] == 0
+                    or (ft_save_period is not None and (step + 1) % ft_save_period == 0)
                 )
-                # +1 because step is 0-indexed
                 # Check if timeout-based checkpointing is enabled in config.
                 should_save_by_timeout = timeout.check_save()
 

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -2375,6 +2375,8 @@ def grpo_train(
             "See https://github.com/NVIDIA-NeMo/RL/blob/main/docs/guides/grpo.md#multiple-dataloaders for more details."
         )
 
+    ft_save_period = master_config.checkpointing.get("ft_save_period")
+
     while current_epoch < max_num_epochs and total_steps < max_num_steps:
         memory_tracker.snapshot_start_of_stage("Preparing batch", dir())
         print(f"\n{'=' * 25} Epoch {current_epoch + 1}/{max_num_epochs} {'=' * 25}")
@@ -3023,7 +3025,6 @@ def grpo_train(
                 timeout.mark_iteration()
 
                 # +1 because step is 0-indexed
-                ft_save_period = master_config.checkpointing.get("ft_save_period")
                 should_save_by_step = (
                     is_last_step
                     or (total_steps + 1) % master_config.checkpointing["save_period"]
@@ -3859,6 +3860,8 @@ def async_grpo_train(
     timer.stop("init/total")
     print(f"✅ Buffer ready for step {step}! Starting training loop...")
 
+    ft_save_period = master_config.checkpointing.get("ft_save_period")
+
     # Main training loop
     try:
         while step < master_config.grpo["max_num_steps"]:
@@ -4381,7 +4384,6 @@ def async_grpo_train(
                 timeout.mark_iteration()
 
                 # +1 because step is 0-indexed
-                ft_save_period = master_config.checkpointing.get("ft_save_period")
                 should_save_by_step = (
                     is_last_step
                     or (step + 1) % master_config.checkpointing["save_period"] == 0

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -1071,10 +1071,15 @@ def grpo_train_sync(
                 consumed_samples += master_config.grpo["num_prompts_per_step"]
                 timeout.mark_iteration()
 
+                ft_save_period = master_config.checkpointing.get("ft_save_period")
                 should_save_by_step = (
                     is_last_step
                     or (total_steps + 1) % master_config.checkpointing["save_period"]
                     == 0
+                    or (
+                        ft_save_period is not None
+                        and (total_steps + 1) % ft_save_period == 0
+                    )
                 )
                 should_save_by_timeout = timeout.check_save()
 

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -522,6 +522,8 @@ def grpo_train_sync(
             "As a result, grpo.max_num_epochs will be ignored, and only grpo.max_num_steps will be used."
         )
 
+    ft_save_period = master_config.checkpointing.get("ft_save_period")
+
     while current_epoch < max_num_epochs and total_steps < max_num_steps:
         memory_tracker.snapshot_start_of_stage("Preparing batch", dir())
         print(f"\n{'=' * 25} Epoch {current_epoch + 1}/{max_num_epochs} {'=' * 25}")
@@ -1071,7 +1073,6 @@ def grpo_train_sync(
                 consumed_samples += master_config.grpo["num_prompts_per_step"]
                 timeout.mark_iteration()
 
-                ft_save_period = master_config.checkpointing.get("ft_save_period")
                 should_save_by_step = (
                     is_last_step
                     or (total_steps + 1) % master_config.checkpointing["save_period"]
@@ -1316,10 +1317,12 @@ def grpo_train_sync(
             current_step += 1
             total_steps += 1
             if should_save_by_timeout:
+                checkpointer.shutdown()
                 memory_tracker.snapshot_start_of_stage("", dir())
                 print("Timeout has been reached, stopping training early", flush=True)
                 return
             if total_steps >= max_num_steps:
+                checkpointer.shutdown()
                 memory_tracker.snapshot_start_of_stage("", dir())
                 print(
                     "Max number of steps has been reached, stopping training early",
@@ -1329,3 +1332,10 @@ def grpo_train_sync(
 
         current_epoch += 1
         current_step = 0
+
+    # Flush the last checkpoint's background finalization on an epoch-bounded
+    # exit. Reaching max_num_epochs falls through the while loop and bypasses
+    # the inline shutdown() calls at the max_num_steps / timeout early returns,
+    # so without this the daemon finalization thread could be killed before the
+    # final tmp_step_N is renamed.
+    checkpointer.shutdown()

--- a/nemo_rl/algorithms/ppo.py
+++ b/nemo_rl/algorithms/ppo.py
@@ -1493,10 +1493,15 @@ def ppo_train(
                 consumed_samples += master_config.ppo["num_prompts_per_step"]
                 timeout.mark_iteration()
 
+                ft_save_period = master_config.checkpointing.get("ft_save_period")
                 should_save_by_step = (
                     is_last_step
                     or (total_steps + 1) % master_config.checkpointing["save_period"]
                     == 0
+                    or (
+                        ft_save_period is not None
+                        and (total_steps + 1) % ft_save_period == 0
+                    )
                 )
                 should_save_by_timeout = timeout.check_save()
 

--- a/nemo_rl/algorithms/ppo.py
+++ b/nemo_rl/algorithms/ppo.py
@@ -972,6 +972,8 @@ def ppo_train(
         logger.log_metrics(val_metrics, current_step, prefix="validation")
         logger.log_metrics(validation_timings, current_step, prefix="timing/validation")
 
+    ft_save_period = master_config.checkpointing.get("ft_save_period")
+
     while current_epoch < max_num_epochs and total_steps < max_num_steps:
         memory_tracker.snapshot_start_of_stage("Preparing batch", dir())
         print(f"\n{'=' * 25} Epoch {current_epoch + 1}/{max_num_epochs} {'=' * 25}")
@@ -1493,7 +1495,6 @@ def ppo_train(
                 consumed_samples += master_config.ppo["num_prompts_per_step"]
                 timeout.mark_iteration()
 
-                ft_save_period = master_config.checkpointing.get("ft_save_period")
                 should_save_by_step = (
                     is_last_step
                     or (total_steps + 1) % master_config.checkpointing["save_period"]
@@ -1694,10 +1695,12 @@ def ppo_train(
             current_step += 1
             total_steps += 1
             if should_save_by_timeout:
+                checkpointer.shutdown()
                 memory_tracker.snapshot_start_of_stage("", dir())
                 print("Timeout has been reached, stopping training early", flush=True)
                 return
             if total_steps >= max_num_steps:
+                checkpointer.shutdown()
                 memory_tracker.snapshot_start_of_stage("", dir())
                 print(
                     "Max number of steps has been reached, stopping training early",
@@ -1707,6 +1710,13 @@ def ppo_train(
 
         current_epoch += 1
         current_step = 0
+
+    # Flush the last checkpoint's background finalization on an epoch-bounded
+    # exit. Reaching max_num_epochs falls through the while loop and bypasses
+    # the inline shutdown() calls at the max_num_steps / timeout early returns,
+    # so without this the daemon finalization thread could be killed before the
+    # final tmp_step_N is renamed.
+    checkpointer.shutdown()
 
 
 def validate(

--- a/nemo_rl/algorithms/rm.py
+++ b/nemo_rl/algorithms/rm.py
@@ -508,6 +508,8 @@ def rm_train(
 
     policy.prepare_for_training()
 
+    ft_save_period = master_config.checkpointing.get("ft_save_period")
+
     while current_epoch < max_num_epochs and (
         master_config.rm.max_num_steps == -1
         or total_steps < master_config.rm.max_num_steps
@@ -579,7 +581,6 @@ def rm_train(
                     "train_global_batch_size"
                 ]
 
-                ft_save_period = master_config.checkpointing.get("ft_save_period")
                 should_save_by_step = (
                     is_last_step
                     or (total_steps + 1) % master_config.checkpointing["save_period"]
@@ -715,12 +716,14 @@ def rm_train(
             total_steps += 1
 
             if should_save_by_timeout:
+                checkpointer.shutdown()
                 print("Timeout has been reached, stopping training early", flush=True)
                 return
             if (
                 master_config.rm.max_num_steps != -1
                 and total_steps >= master_config.rm.max_num_steps
             ):
+                checkpointer.shutdown()
                 print(
                     "Max number of steps has been reached, stopping training early",
                     flush=True,
@@ -729,3 +732,10 @@ def rm_train(
 
         current_epoch += 1
         current_step = 0  # Reset step counter for new epoch
+
+    # Flush the last checkpoint's background finalization on an epoch-bounded
+    # exit. Reaching max_num_epochs falls through the while loop and bypasses
+    # the inline shutdown() calls at the max_num_steps / timeout early returns,
+    # so without this the daemon finalization thread could be killed before the
+    # final tmp_step_N is renamed.
+    checkpointer.shutdown()

--- a/nemo_rl/algorithms/rm.py
+++ b/nemo_rl/algorithms/rm.py
@@ -579,10 +579,15 @@ def rm_train(
                     "train_global_batch_size"
                 ]
 
+                ft_save_period = master_config.checkpointing.get("ft_save_period")
                 should_save_by_step = (
                     is_last_step
                     or (total_steps + 1) % master_config.checkpointing["save_period"]
                     == 0
+                    or (
+                        ft_save_period is not None
+                        and (total_steps + 1) % ft_save_period == 0
+                    )
                 )
                 should_save_by_timeout = timeout.check_save()
 

--- a/nemo_rl/algorithms/sft.py
+++ b/nemo_rl/algorithms/sft.py
@@ -520,10 +520,15 @@ def sft_train(
                     "train_global_batch_size"
                 ]
                 timeout.mark_iteration()
+                ft_save_period = master_config.checkpointing.get("ft_save_period")
                 should_save_by_step = (
                     is_last_step
                     or (total_steps + 1) % master_config.checkpointing["save_period"]
                     == 0
+                    or (
+                        ft_save_period is not None
+                        and (total_steps + 1) % ft_save_period == 0
+                    )
                 )
                 # +1 because step is 0-indexed
                 # Check if timeout-based checkpointing is enabled in config.

--- a/nemo_rl/algorithms/sft.py
+++ b/nemo_rl/algorithms/sft.py
@@ -422,6 +422,8 @@ def sft_train(
 
     policy.prepare_for_training()
 
+    ft_save_period = master_config.checkpointing.get("ft_save_period")
+
     while (
         current_epoch < max_num_epochs and total_steps < master_config.sft.max_num_steps
     ):
@@ -520,7 +522,6 @@ def sft_train(
                     "train_global_batch_size"
                 ]
                 timeout.mark_iteration()
-                ft_save_period = master_config.checkpointing.get("ft_save_period")
                 should_save_by_step = (
                     is_last_step
                     or (total_steps + 1) % master_config.checkpointing["save_period"]
@@ -652,9 +653,11 @@ def sft_train(
             total_steps += 1
 
             if should_save_by_timeout:
+                checkpointer.shutdown()
                 print("Timeout has been reached, stopping training early", flush=True)
                 return
             if total_steps >= master_config.sft.max_num_steps:
+                checkpointer.shutdown()
                 print(
                     "Max number of steps has been reached, stopping training early",
                     flush=True,
@@ -663,3 +666,10 @@ def sft_train(
 
         current_epoch += 1
         current_step = 0  # Reset step counter for new epoch
+
+    # Flush the last checkpoint's background finalization on an epoch-bounded
+    # exit. Reaching max_num_epochs falls through the while loop and bypasses
+    # the inline shutdown() calls at the max_num_steps / timeout early returns,
+    # so without this the daemon finalization thread could be killed before the
+    # final tmp_step_N is renamed.
+    checkpointer.shutdown()

--- a/nemo_rl/algorithms/xtoken_off_policy_distillation.py
+++ b/nemo_rl/algorithms/xtoken_off_policy_distillation.py
@@ -724,10 +724,15 @@ def xtoken_off_policy_distillation_train(
                 timeout.mark_iteration()
 
                 # ===== Checkpointing =====
+                ft_save_period = master_config.checkpointing.get("ft_save_period")
                 should_save_by_step = (
                     is_last_step
                     or (total_steps + 1) % master_config.checkpointing["save_period"]
                     == 0
+                    or (
+                        ft_save_period is not None
+                        and (total_steps + 1) % ft_save_period == 0
+                    )
                 )
                 should_save_by_timeout = timeout.check_save()
                 if master_config.checkpointing["enabled"] and (

--- a/nemo_rl/algorithms/xtoken_off_policy_distillation.py
+++ b/nemo_rl/algorithms/xtoken_off_policy_distillation.py
@@ -622,6 +622,8 @@ def xtoken_off_policy_distillation_train(
         logger.log_metrics(val_metrics, total_steps, prefix="validation")
         logger.log_metrics(val_timings, total_steps, prefix="timing/validation")
 
+    ft_save_period = master_config.checkpointing.get("ft_save_period")
+
     while total_steps < max_steps and current_epoch < max_epochs:
         print(
             f"\n{'=' * 25} Epoch {current_epoch + 1}/{max_epochs} {'=' * 25}",
@@ -724,7 +726,6 @@ def xtoken_off_policy_distillation_train(
                 timeout.mark_iteration()
 
                 # ===== Checkpointing =====
-                ft_save_period = master_config.checkpointing.get("ft_save_period")
                 should_save_by_step = (
                     is_last_step
                     or (total_steps + 1) % master_config.checkpointing["save_period"]
@@ -860,11 +861,13 @@ def xtoken_off_policy_distillation_train(
             total_steps += 1
 
             if should_save_by_timeout:
+                checkpointer.shutdown()
                 print("Timeout reached, stopping training early.", flush=True)
                 for teacher_policy in teacher_policies:
                     teacher_policy.release_ipc_buffer()
                 return
             if total_steps >= max_steps:
+                checkpointer.shutdown()
                 print("Max steps reached, stopping training.", flush=True)
                 for teacher_policy in teacher_policies:
                     teacher_policy.release_ipc_buffer()
@@ -872,6 +875,12 @@ def xtoken_off_policy_distillation_train(
 
         current_epoch += 1
         current_step = 0
+    # Flush the last checkpoint's background finalization on an epoch-bounded
+    # exit. Reaching max_epochs falls through the while loop and bypasses the
+    # inline shutdown() calls at the max_steps / timeout early returns, so
+    # without this the daemon finalization thread could be killed before the
+    # final tmp_step_N is renamed.
+    checkpointer.shutdown()
     for teacher_policy in teacher_policies:
         teacher_policy.release_ipc_buffer()
 

--- a/nemo_rl/utils/checkpoint.py
+++ b/nemo_rl/utils/checkpoint.py
@@ -23,6 +23,7 @@ import os
 import re
 import shutil
 import threading
+import time
 import warnings
 from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
@@ -90,6 +91,10 @@ class CheckpointingConfig(TypedDict):
         the metric should be taken from the validation or training metrics.
     higher_is_better (bool): Whether higher values of the metric indicate better performance.
     keep_top_k (Optional[int]): Number of best checkpoints to keep. If None, all checkpoints are kept.
+    ft_keep_latest_k (Optional[int]): Number of most recent checkpoints to keep for crash recovery.
+    ft_save_period (Optional[int]): How often to save fault-tolerance checkpoints, in steps.
+        When set, a checkpoint is saved every ft_save_period steps for crash recovery.
+        Requires ft_keep_latest_k to control how many of these are retained.
     model_save_format (str | None): Format for saving model (v2 allowed values: "torch_save" or "safetensors", v1 allowed values: None).
     save_consolidated (bool): Whether to save consolidated checkpoints (for HF compatibility).
     model_cache_dir (str): Directory for model cache (for safetensors format).
@@ -104,6 +109,8 @@ class CheckpointingConfig(TypedDict):
     higher_is_better: bool
     save_period: int
     keep_top_k: NotRequired[int]
+    ft_keep_latest_k: NotRequired[int | None]
+    ft_save_period: NotRequired[int]
     checkpoint_must_save_by: NotRequired[str | None]
     pretrained_checkpoint: NotRequired[PretrainedCheckpointConfig]
     save_optimizer: NotRequired[bool]  # Default: True
@@ -148,6 +155,8 @@ class CheckpointManager:
         self.metric_name: str | None = config["metric_name"]
         self.higher_is_better = config["higher_is_better"]
         self.keep_top_k = config["keep_top_k"]
+        self.save_period: int = config["save_period"]
+        self.ft_keep_latest_k: int | None = config.get("ft_keep_latest_k", None)
         self.save_optimizer = config["save_optimizer"]
 
         # Store nemo-automodel specific config options
@@ -226,8 +235,14 @@ class CheckpointManager:
         Returns:
             PathLike: Path to the temporary checkpoint directory.
         """
-        # create new step_{step} directory
         save_dir = self.checkpoint_dir / f"tmp_step_{step}"
+        # Remove a stale tmp_step_{step} left behind by an interrupted prior save
+        # so the new save starts clean.
+        if save_dir.exists():
+            t0 = time.monotonic()
+            shutil.rmtree(save_dir)
+            elapsed = time.monotonic() - t0
+            print(f"Removed stale {save_dir.name} in {elapsed:.2f}s")
         save_dir.mkdir(parents=True, exist_ok=True)
 
         # save training info
@@ -390,51 +405,77 @@ class CheckpointManager:
         return self._pending_checkpoint_path is not None
 
     def remove_old_checkpoints(self, exclude_latest: bool = True) -> None:
-        """Remove checkpoints that are not in the top-k or latest based on the (optional) metric.
+        """Remove checkpoints that exceed the configured retention limits.
 
-        If keep_top_k is set, this method removes all checkpoints except the top-k
-        best ones. The "best" checkpoints are determined by:
-        - If a metric is provided: the given metric value and the higher_is_better setting.
-          When multiple checkpoints have the same metric value, more recent checkpoints
-          (higher step numbers) are preferred.
-        - If no metric is provided: the step number. The most recent k checkpoints are kept.
+        Retention rules are applied as a union — a checkpoint survives if any
+        rule retains it:
+
+        Periodic retention: save_period-aligned checkpoints (step % save_period == 0)
+        are always retained. If keep_top_k is set, only the top-k best among them
+        are kept; otherwise all periodic checkpoints survive indefinitely.
+
+        keep_top_k: limits periodic checkpoint retention to the top-k best.
+        The "best" are determined by:
+        - If a metric is provided: the metric value and the higher_is_better setting.
+          When multiple checkpoints share the same metric value, more recent
+          checkpoints (higher step numbers) are preferred.
+        - If no metric is provided: recency. The most recent k are kept.
+
+        ft_keep_latest_k: retains the most recent k checkpoints for crash recovery.
+        Applied to all checkpoints regardless of save_period alignment.
+        Purely recency-based — metrics are not considered.
 
         Args:
-            exclude_latest (bool): Whether to exclude the latest checkpoint from deletion. (may result in K+1 checkpoints)
+            exclude_latest (bool): Whether to protect the most recent checkpoint
+                from deletion.
         """
-        if self.keep_top_k is None:
-            return
         checkpoint_history = _load_checkpoint_history(self.checkpoint_dir)
-        latest_step = (
-            max([step for step, _, _ in checkpoint_history])
-            if checkpoint_history
-            else None
-        )
+        if not checkpoint_history:
+            return
+        if self.keep_top_k is None and self.ft_keep_latest_k is None:
+            return
 
-        if self.metric_name is None:
-            checkpoint_history.sort(key=lambda x: x[0], reverse=True)
-        else:
-            # sort by metric value first, then by step number (for equal metrics, prefer more recent)
-            if self.higher_is_better:
-                # For higher_is_better=True: higher metric values first, then higher step numbers
-                checkpoint_history.sort(
-                    key=lambda x: (x[2].get(self.metric_name, -float("inf")), x[0]),
-                    reverse=True,
-                )
+        latest_step = max(step for step, _, _ in checkpoint_history)
+        protected_steps: set[int] = set()
+
+        if exclude_latest:
+            protected_steps.add(latest_step)
+
+        periodic_history = [
+            (s, p, m) for s, p, m in checkpoint_history if s % self.save_period == 0
+        ]
+
+        if self.keep_top_k is not None:
+            # keep_top_k limits which periodic checkpoints survive
+            if self.metric_name is None:
+                periodic_history.sort(key=lambda x: x[0], reverse=True)
             else:
-                # For higher_is_better=False: lower metric values first, then higher step numbers for equal values
-                checkpoint_history.sort(
-                    key=lambda x: (x[2].get(self.metric_name, float("inf")), -x[0])
-                )
+                # sort by metric value first, then by step number (for equal metrics, prefer more recent)
+                if self.higher_is_better:
+                    # For higher_is_better=True: higher metric values first, then higher step numbers
+                    periodic_history.sort(
+                        key=lambda x: (x[2].get(self.metric_name, -float("inf")), x[0]),
+                        reverse=True,
+                    )
+                else:
+                    # For higher_is_better=False: lower metric values first, then higher step numbers for equal values
+                    periodic_history.sort(
+                        key=lambda x: (x[2].get(self.metric_name, float("inf")), -x[0]),
+                    )
+            protected_steps.update(s for s, _, _ in periodic_history[: self.keep_top_k])
+        else:
+            # Without keep_top_k, all periodic checkpoints are retained
+            protected_steps.update(s for s, _, _ in periodic_history)
 
-        # remove checkpoints that are not in the top-k
-        for checkpoint in checkpoint_history[self.keep_top_k :]:
-            if exclude_latest and checkpoint[0] == latest_step:
-                continue
-            print(
-                f"Removing checkpoint {checkpoint[1]} due to being outside top-{self.keep_top_k}"
-            )
-            shutil.rmtree(checkpoint[1])
+        # ft_keep_latest_k: retain the most recent k checkpoints for crash recovery
+        if self.ft_keep_latest_k is not None:
+            by_step = sorted(checkpoint_history, key=lambda x: x[0], reverse=True)
+            protected_steps.update(s for s, _, _ in by_step[: self.ft_keep_latest_k])
+
+        for step, path, _ in checkpoint_history:
+            if step not in protected_steps:
+                print(f"Removing checkpoint {path} (step {step})")
+                shutil.rmtree(path)
 
     def get_best_checkpoint_path(self) -> Optional[str]:
         """Get the path to the best checkpoint based on the metric.

--- a/tests/unit/algorithms/test_distillation.py
+++ b/tests/unit/algorithms/test_distillation.py
@@ -227,6 +227,43 @@ def test_distillation_train_max_steps(mock_components):
     assert mock_components["student_policy"].train.call_count == 5
 
 
+def test_ft_save_period_triggers_periodic_saves(mock_components):
+    """ft_save_period triggers checkpoint saves independent of save_period."""
+    cfg = mock_components["master_config"]
+    cfg.distillation["max_num_steps"] = 5
+    cfg.distillation["val_period"] = 0
+    cfg.checkpointing["enabled"] = True
+    cfg.checkpointing["save_period"] = 100  # only the final step would save
+    cfg.checkpointing["ft_save_period"] = 2
+    cfg.checkpointing["metric_name"] = None
+
+    checkpointer = mock_components["checkpointer"]
+    checkpointer.init_tmp_checkpoint.return_value = "/tmp/ft_ckpt_test/tmp_step"
+
+    distillation_save_state = _default_distillation_save_state()
+
+    with patch("nemo_rl.algorithms.distillation.torch.save"):
+        distillation_train(
+            mock_components["student_policy"],
+            mock_components["teacher_policy"],
+            mock_components["student_generation"],
+            mock_components["train_dataloader"],
+            mock_components["val_dataloader"],
+            mock_components["tokenizer"],
+            mock_components["loss_fn"],
+            mock_components["task_to_env"],
+            mock_components["val_task_to_env"],
+            mock_components["logger"],
+            checkpointer,
+            distillation_save_state,
+            cfg,
+        )
+
+    # ft_save_period=2 -> steps 2, 4; save_period=100 contributes only the last step (5).
+    saved_steps = [c.args[0] for c in checkpointer.init_tmp_checkpoint.call_args_list]
+    assert saved_steps == [2, 4, 5]
+
+
 def test_distillation_train_uses_nemo_gym_rollout_when_enabled(mock_components):
     master_config = mock_components["master_config"]
     master_config.distillation["max_num_steps"] = 1

--- a/tests/unit/algorithms/test_dpo.py
+++ b/tests/unit/algorithms/test_dpo.py
@@ -323,3 +323,37 @@ def test_exit_on_timeout(mock_dpo_components, capsys):
             assert "Epoch" not in line or "Epoch 1/10" in line, (
                 f"Training continued to next epoch after timeout: {line}"
             )
+
+
+def test_ft_save_period_triggers_periodic_saves(mock_dpo_components):
+    """ft_save_period triggers checkpoint saves independent of save_period."""
+    cfg = mock_dpo_components["master_config"]
+    cfg.dpo.val_period = 0
+    cfg.dpo.max_num_steps = 5
+    cfg.dpo.max_num_epochs = 1
+    cfg.checkpointing["enabled"] = True
+    cfg.checkpointing["save_period"] = 100  # only the final step would save
+    cfg.checkpointing["ft_save_period"] = 2
+    cfg.checkpointing["metric_name"] = None
+
+    checkpointer = mock_dpo_components["checkpointer"]
+    checkpointer.init_tmp_checkpoint.return_value = "/tmp/ft_ckpt_test/tmp_step"
+
+    dpo_save_state = _initial_dpo_save_state()
+
+    with patch("nemo_rl.algorithms.dpo.torch.save"):
+        dpo_train(
+            mock_dpo_components["policy"],
+            mock_dpo_components["train_dataloader"],
+            mock_dpo_components["val_dataloader"],
+            mock_dpo_components["tokenizer"],
+            mock_dpo_components["loss_fn"],
+            cfg,
+            mock_dpo_components["logger"],
+            checkpointer,
+            dpo_save_state,
+        )
+
+    # ft_save_period=2 -> steps 2, 4; save_period=100 contributes only the last step (5).
+    saved_steps = [c.args[0] for c in checkpointer.init_tmp_checkpoint.call_args_list]
+    assert saved_steps == [2, 4, 5]

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -786,6 +786,17 @@ class StubAsyncTrajectoryCollector:
         mock.remote = MagicMock(return_value={})
         return mock
 
+    @property
+    def get_dataloader_state(self):
+        """Return a remote-callable mock yielding a checkpointable dataloader state.
+
+        Exercised by async_grpo_train's checkpoint-save path, which persists the
+        collector's dataloader state alongside the replay buffer.
+        """
+        mock = MagicMock()
+        mock.remote = MagicMock(return_value={})
+        return mock
+
 
 def mock_async_grpo_infrastructure(
     mock_batch, mock_rollout_metrics, seq_logprob_error_result=None
@@ -1884,6 +1895,97 @@ def test_grpo_train_shutdown_on_epoch_completion(mock_grpo_components, tmp_path)
 
     checkpointer.begin_finalization.assert_called_once()
     checkpointer.shutdown.assert_called_once()
+
+
+@pytest.mark.parametrize("train_func", [grpo_train, async_grpo_train])
+def test_grpo_ft_save_period_triggers_periodic_saves(
+    mock_grpo_components, train_func, tmp_path
+):
+    """ft_save_period triggers checkpoint saves independent of save_period.
+
+    Covers both GRPO training paths (grpo_train and async_grpo_train). With
+    save_period large enough to only fire on the final step, ft_save_period=2
+    must add saves at steps 2 and 4, and the last step (5) is saved as usual.
+    """
+    mock_batch = next(iter(mock_grpo_components["train_dataloader"]))
+    mock_rollout_metrics = {"mean_gen_tokens_per_sample": 2.0}
+    policy = mock_grpo_components["policy"]
+    checkpointer = mock_grpo_components["checkpointer"]
+
+    master_config = mock_grpo_components["master_config"]
+    master_config.grpo["max_num_steps"] = 5
+    master_config.grpo["max_num_epochs"] = 1
+    master_config.grpo["val_period"] = 0
+    master_config.grpo["val_at_start"] = False
+    master_config.grpo["val_at_end"] = False
+    master_config.grpo["use_dynamic_sampling"] = False
+    master_config.checkpointing["enabled"] = True
+    master_config.checkpointing["save_period"] = 100  # only the final step saves
+    master_config.checkpointing["ft_save_period"] = 2
+    master_config.checkpointing["metric_name"] = None
+
+    checkpointer.init_tmp_checkpoint.return_value = "/tmp/checkpoint"
+    # Both paths write latest_checkpoint_status.json under checkpoint_dir; give
+    # the mocked checkpointer a real directory so that write succeeds.
+    checkpointer.checkpoint_dir = tmp_path
+
+    if train_func == async_grpo_train:
+        master_config.policy["generation"]["colocated"]["enabled"] = False
+        with (
+            mock_async_grpo_infrastructure(mock_batch, mock_rollout_metrics),
+            _patched_logprob_phase(policy),
+            patch("nemo_rl.algorithms.grpo.torch.save"),
+        ):
+            train_func(
+                policy,
+                _mock_policy_generation(),
+                mock_grpo_components["train_dataloader"],
+                mock_grpo_components["val_dataloader"],
+                mock_grpo_components["tokenizer"],
+                mock_grpo_components["loss_fn"],
+                mock_grpo_components["task_to_env"],
+                mock_grpo_components["val_task_to_env"],
+                mock_grpo_components["logger"],
+                checkpointer,
+                _default_grpo_save_state(),
+                master_config,
+            )
+    else:
+        with (
+            _patched_logprob_phase(policy),
+            patch(
+                "nemo_rl.algorithms.grpo.run_multi_turn_rollout",
+                return_value=(mock_batch, mock_rollout_metrics),
+            ),
+            patch(
+                "nemo_rl.algorithms.grpo.run_async_multi_turn_rollout",
+                return_value=(mock_batch, mock_rollout_metrics),
+            ),
+            patch(
+                "nemo_rl.algorithms.grpo.compute_and_apply_seq_logprob_error_masking",
+                return_value=_mock_seq_logprob_error_result(),
+            ),
+            patch("nemo_rl.algorithms.grpo.torch.save"),
+        ):
+            train_func(
+                policy,
+                _mock_policy_generation(),
+                mock_grpo_components["train_dataloader"],
+                mock_grpo_components["val_dataloader"],
+                mock_grpo_components["tokenizer"],
+                mock_grpo_components["loss_fn"],
+                mock_grpo_components["task_to_env"],
+                mock_grpo_components["val_task_to_env"],
+                mock_grpo_components["logger"],
+                checkpointer,
+                _default_grpo_save_state(),
+                master_config,
+            )
+
+    # ft_save_period=2 -> steps 2, 4; save_period=100 contributes only the last
+    # step (5). Each save calls init_tmp_checkpoint(step, ...).
+    saved_steps = [c.args[0] for c in checkpointer.init_tmp_checkpoint.call_args_list]
+    assert saved_steps == [2, 4, 5]
 
 
 @pytest.mark.parametrize("train_func", [grpo_train, async_grpo_train])

--- a/tests/unit/algorithms/test_rm.py
+++ b/tests/unit/algorithms/test_rm.py
@@ -294,3 +294,37 @@ def test_exit_on_timeout(mock_components, capsys):
             assert "Epoch" not in line or "Epoch 1/10" in line, (
                 f"Training continued to next epoch after timeout: {line}"
             )
+
+
+def test_ft_save_period_triggers_periodic_saves(mock_components):
+    """ft_save_period triggers checkpoint saves independent of save_period."""
+    cfg = mock_components["master_config"]
+    cfg.rm.val_period = 0
+    cfg.rm.max_num_steps = 5
+    cfg.rm.max_num_epochs = 1
+    cfg.checkpointing["enabled"] = True
+    cfg.checkpointing["save_period"] = 100  # only the final step would save
+    cfg.checkpointing["ft_save_period"] = 2
+    cfg.checkpointing["metric_name"] = None
+
+    checkpointer = mock_components["checkpointer"]
+    checkpointer.init_tmp_checkpoint.return_value = "/tmp/ft_ckpt_test/tmp_step"
+
+    rm_save_state = _initial_rm_save_state()
+
+    with patch("nemo_rl.algorithms.rm.torch.save"):
+        rm_train(
+            mock_components["policy"],
+            mock_components["train_dataloader"],
+            mock_components["val_dataloader"],
+            mock_components["tokenizer"],
+            mock_components["loss_fn"],
+            cfg,
+            mock_components["logger"],
+            checkpointer,
+            rm_save_state,
+        )
+
+    # ft_save_period=2 -> steps 2, 4; save_period=100 contributes only the last step (5).
+    saved_steps = [c.args[0] for c in checkpointer.init_tmp_checkpoint.call_args_list]
+    assert saved_steps == [2, 4, 5]

--- a/tests/unit/algorithms/test_sft.py
+++ b/tests/unit/algorithms/test_sft.py
@@ -253,3 +253,38 @@ def test_training_with_negative_val_period(mock_components):
     )
 
     assert mock_components["policy"].train.call_count == 3
+
+
+def test_ft_save_period_triggers_periodic_saves(mock_components):
+    """ft_save_period triggers checkpoint saves independent of save_period."""
+    cfg = mock_components["master_config"]
+    cfg.sft.val_period = 0
+    cfg.sft.max_num_steps = 5
+    cfg.sft.max_num_epochs = 1
+    cfg.checkpointing["enabled"] = True
+    cfg.checkpointing["save_period"] = 100  # only the final step would save
+    cfg.checkpointing["ft_save_period"] = 2
+    cfg.checkpointing["metric_name"] = None
+
+    checkpointer = mock_components["checkpointer"]
+    checkpointer.init_tmp_checkpoint.return_value = "/tmp/ft_ckpt_test/tmp_step"
+
+    sft_save_state = _initial_sft_save_state()
+
+    with patch("nemo_rl.algorithms.sft.torch.save"):
+        sft_train(
+            mock_components["policy"],
+            mock_components["train_dataloader"],
+            None,
+            mock_components["tokenizer"],
+            mock_components["loss_fn"],
+            cfg,
+            mock_components["logger"],
+            checkpointer,
+            sft_save_state,
+        )
+
+    # ft_save_period=2 -> steps 2, 4; save_period=100 contributes only the last
+    # step (5). Each save calls init_tmp_checkpoint(step, ...).
+    saved_steps = [c.args[0] for c in checkpointer.init_tmp_checkpoint.call_args_list]
+    assert saved_steps == [2, 4, 5]

--- a/tests/unit/algorithms/x_token/test_xtoken_off_policy_distillation.py
+++ b/tests/unit/algorithms/x_token/test_xtoken_off_policy_distillation.py
@@ -469,6 +469,27 @@ def test_exit_on_max_steps(mock_xtoken_components):
     assert mock_xtoken_components.student_policy.train.call_count == 3
 
 
+def test_ft_save_period_triggers_periodic_saves(mock_xtoken_components):
+    """ft_save_period triggers checkpoint saves independent of save_period."""
+    c = mock_xtoken_components
+    c.master_config.distillation["max_num_steps"] = 5
+    c.master_config.distillation["max_num_epochs"] = 1
+    c.master_config.checkpointing["enabled"] = True
+    c.master_config.checkpointing["save_period"] = 100  # only the final step saves
+    c.master_config.checkpointing["ft_save_period"] = 2
+    c.master_config.checkpointing["metric_name"] = None
+    c.checkpointer.init_tmp_checkpoint.return_value = "/tmp/ft_ckpt_test/tmp_step"
+
+    with patch("nemo_rl.algorithms.xtoken_off_policy_distillation.torch.save"):
+        _run_train(c)
+
+    # ft_save_period=2 -> steps 2, 4; save_period=100 contributes only the last step (5).
+    saved_steps = [
+        call.args[0] for call in c.checkpointer.init_tmp_checkpoint.call_args_list
+    ]
+    assert saved_steps == [2, 4, 5]
+
+
 def test_exit_on_max_epochs(mock_xtoken_components):
     # max_num_steps high so it doesn't fire first; max_num_epochs caps the loop.
     mock_xtoken_components.master_config.distillation["max_num_steps"] = 10_000

--- a/tests/unit/utils/test_checkpoint.py
+++ b/tests/unit/utils/test_checkpoint.py
@@ -38,6 +38,7 @@ def checkpoint_config(checkpoint_dir):
         "checkpoint_dir": checkpoint_dir,
         "metric_name": "loss",
         "higher_is_better": False,
+        "save_period": 1,
         "keep_top_k": 3,
         "save_optimizer": True,
     }
@@ -333,6 +334,7 @@ def test_checkpoint_without_keep_top_k(tmp_path):
         "checkpoint_dir": str((tmp_path.resolve() / "checkpoints")),
         "metric_name": "loss",
         "higher_is_better": False,
+        "save_period": 1,
         "keep_top_k": None,
         "save_optimizer": True,
     }
@@ -433,6 +435,7 @@ def test_get_best_checkpoint_path_some_missing_metric(tmp_path):
         "checkpoint_dir": str((tmp_path.resolve() / "checkpoints")),
         "metric_name": "loss",
         "higher_is_better": False,
+        "save_period": 1,
         "keep_top_k": None,  # Keep all checkpoints
         "save_optimizer": True,
     }
@@ -477,6 +480,7 @@ def test_get_best_checkpoint_path_all_missing_metric(tmp_path):
         "checkpoint_dir": str((tmp_path.resolve() / "checkpoints")),
         "metric_name": "loss",
         "higher_is_better": False,
+        "save_period": 1,
         "keep_top_k": None,  # Keep all checkpoints
         "save_optimizer": True,
     }
@@ -519,6 +523,7 @@ def test_get_best_checkpoint_path_higher_is_better(tmp_path):
         "checkpoint_dir": str((tmp_path.resolve() / "checkpoints")),
         "metric_name": "accuracy",
         "higher_is_better": True,
+        "save_period": 1,
         "keep_top_k": None,  # Keep all
         "save_optimizer": True,
     }
@@ -549,6 +554,7 @@ def async_checkpoint_config(checkpoint_dir):
         "checkpoint_dir": checkpoint_dir,
         "metric_name": None,
         "higher_is_better": False,
+        "save_period": 1,
         "keep_top_k": None,
         "save_optimizer": True,
     }
@@ -673,6 +679,7 @@ class TestShutdown:
             "checkpoint_dir": checkpoint_dir,
             "metric_name": None,
             "higher_is_better": False,
+            "save_period": 1,
             "keep_top_k": 1,
             "save_optimizer": True,
         }
@@ -764,6 +771,7 @@ class TestDeletionSerialization:
             "checkpoint_dir": checkpoint_dir,
             "metric_name": None,
             "higher_is_better": False,
+            "save_period": 1,
             "keep_top_k": 2,
             "save_optimizer": True,
         }
@@ -789,6 +797,7 @@ class TestDeletionSerialization:
             "checkpoint_dir": checkpoint_dir,
             "metric_name": None,
             "higher_is_better": False,
+            "save_period": 1,
             "keep_top_k": 1,
             "save_optimizer": True,
         }
@@ -955,3 +964,232 @@ class TestRenameCheckpointSwap:
         assert not (step_dir / "stale_marker").exists()
         with open(step_dir / "training_info.json") as f:
             assert json.load(f)["loss"] == 0.2
+
+
+# ---------------------------------------------------------------------------
+# Fault tolerance (ft_keep_latest_k / ft_save_period) retention tests
+# ---------------------------------------------------------------------------
+
+
+class TestFTKeepLatestK:
+    """Tests for the ft_keep_latest_k / periodic union retention policy.
+
+    A checkpoint survives if ANY retention rule keeps it:
+    - periodic (save_period-aligned) checkpoints — all when keep_top_k is None,
+      else only the top-k best among them,
+    - ft_keep_latest_k most recent checkpoints (recency only),
+    - the latest checkpoint (when exclude_latest=True).
+    When both keep_top_k and ft_keep_latest_k are None, nothing is deleted.
+    """
+
+    def _make_manager(
+        self,
+        checkpoint_dir,
+        keep_top_k=None,
+        ft_keep_latest_k=None,
+        metric_name=None,
+        higher_is_better=False,
+        save_period=1,
+    ):
+        config = {
+            "enabled": True,
+            "checkpoint_dir": checkpoint_dir,
+            "metric_name": metric_name,
+            "higher_is_better": higher_is_better,
+            "save_period": save_period,
+            "keep_top_k": keep_top_k,
+            "ft_keep_latest_k": ft_keep_latest_k,
+            "save_optimizer": True,
+        }
+        return CheckpointManager(config)
+
+    @staticmethod
+    def _remaining_steps(checkpoint_dir):
+        return sorted(int(p.name.split("_")[1]) for p in checkpoint_dir.glob("step_*"))
+
+    def test_both_none_keeps_everything(self, checkpoint_dir):
+        """When both policies are None, no checkpoints are deleted."""
+        manager = self._make_manager(checkpoint_dir)
+        for step in range(1, 6):
+            tmp = manager.init_tmp_checkpoint(step, {"loss": float(step)})
+            manager.finalize_checkpoint(tmp)
+
+        assert self._remaining_steps(checkpoint_dir) == [1, 2, 3, 4, 5]
+
+    def test_ft_keep_1_only(self, checkpoint_dir):
+        """ft_keep_latest_k=1 with no periodic checkpoints keeps only the most recent."""
+        # save_period=100 so no steps in range are periodic — isolates ft behavior
+        manager = self._make_manager(
+            checkpoint_dir, ft_keep_latest_k=1, save_period=100
+        )
+        for step in range(1, 6):
+            tmp = manager.init_tmp_checkpoint(step, {"loss": float(step)})
+            manager.finalize_checkpoint(tmp)
+
+        assert self._remaining_steps(checkpoint_dir) == [5]
+
+    def test_ft_keep_2_only(self, checkpoint_dir):
+        """ft_keep_latest_k=2 with no periodic checkpoints keeps the two most recent."""
+        manager = self._make_manager(
+            checkpoint_dir, ft_keep_latest_k=2, save_period=100
+        )
+        for step in range(1, 8):
+            tmp = manager.init_tmp_checkpoint(step, {"loss": float(step)})
+            manager.finalize_checkpoint(tmp)
+
+        assert self._remaining_steps(checkpoint_dir) == [6, 7]
+
+    def test_keep_top_k_only(self, checkpoint_dir):
+        """keep_top_k=2 alone keeps the 2 most recent (no metric, save_period=1)."""
+        manager = self._make_manager(checkpoint_dir, keep_top_k=2)
+        for step in range(1, 6):
+            tmp = manager.init_tmp_checkpoint(step, {"loss": float(step)})
+            manager.finalize_checkpoint(tmp)
+
+        assert self._remaining_steps(checkpoint_dir) == [4, 5]
+
+    def test_union_of_both_policies(self, checkpoint_dir):
+        """A checkpoint survives if either policy retains it (here they overlap)."""
+        manager = self._make_manager(checkpoint_dir, keep_top_k=1, ft_keep_latest_k=1)
+        for step in range(1, 10):
+            tmp = manager.init_tmp_checkpoint(step, {"loss": float(step)})
+            manager.finalize_checkpoint(tmp)
+
+        assert self._remaining_steps(checkpoint_dir) == [9]
+
+    def test_union_with_metric_picks_different_sets(self, checkpoint_dir):
+        """Metric-based top-k and recency-based ft pick different checkpoints; union kept."""
+        manager = self._make_manager(
+            checkpoint_dir,
+            keep_top_k=1,
+            ft_keep_latest_k=1,
+            metric_name="reward",
+            higher_is_better=True,
+        )
+        data = [
+            (1, {"reward": 0.5}),
+            (2, {"reward": 0.9}),  # best by metric
+            (3, {"reward": 0.3}),
+            (4, {"reward": 0.1}),
+            (5, {"reward": 0.2}),
+            (6, {"reward": 0.4}),  # most recent
+        ]
+        for step, info in data:
+            tmp = manager.init_tmp_checkpoint(step, info)
+            manager.finalize_checkpoint(tmp)
+
+        # keep_top_k=1 by metric -> step 2; ft_keep_latest_k=1 / exclude_latest -> step 6
+        assert self._remaining_steps(checkpoint_dir) == [2, 6]
+
+    def test_union_with_overlap(self, checkpoint_dir):
+        """Overlapping protections are not double-counted."""
+        manager = self._make_manager(
+            checkpoint_dir,
+            keep_top_k=2,
+            ft_keep_latest_k=2,
+            metric_name="reward",
+            higher_is_better=True,
+        )
+        data = [
+            (1, {"reward": 0.1}),
+            (2, {"reward": 0.2}),
+            (3, {"reward": 0.3}),
+            (4, {"reward": 0.9}),  # top-2 by metric
+            (5, {"reward": 0.8}),  # top-2 by metric AND latest-2
+            (6, {"reward": 0.4}),  # latest-2 AND most recent
+        ]
+        for step, info in data:
+            tmp = manager.init_tmp_checkpoint(step, info)
+            manager.finalize_checkpoint(tmp)
+
+        # top-2 by metric -> {4, 5}; latest-2 -> {5, 6}; union -> {4, 5, 6}
+        assert self._remaining_steps(checkpoint_dir) == [4, 5, 6]
+
+    def test_periodic_retention_all_when_no_keep_top_k(self, checkpoint_dir):
+        """With keep_top_k=None, every save_period-aligned checkpoint is retained."""
+        # save_period=2, ft_keep_latest_k=1: periodic {2,4,6} plus latest {6}.
+        manager = self._make_manager(checkpoint_dir, ft_keep_latest_k=1, save_period=2)
+        for step in range(1, 7):
+            tmp = manager.init_tmp_checkpoint(step, {"loss": float(step)})
+            manager.finalize_checkpoint(tmp)
+
+        assert self._remaining_steps(checkpoint_dir) == [2, 4, 6]
+
+    def test_periodic_retention_limited_by_keep_top_k(self, checkpoint_dir):
+        """keep_top_k caps how many periodic checkpoints survive; ft adds recency."""
+        # save_period=2 -> periodic {2,4,6,8}; keep_top_k=1 (no metric) -> newest periodic {8};
+        # ft_keep_latest_k=1 -> {8}; latest -> {8}. Non-periodic never retained here.
+        manager = self._make_manager(
+            checkpoint_dir, keep_top_k=1, ft_keep_latest_k=1, save_period=2
+        )
+        for step in range(1, 9):
+            tmp = manager.init_tmp_checkpoint(step, {"loss": float(step)})
+            manager.finalize_checkpoint(tmp)
+
+        assert self._remaining_steps(checkpoint_dir) == [8]
+
+    def test_metric_topk_over_periodic_plus_ft(self, checkpoint_dir):
+        """Top-k by metric (over periodic checkpoints) is retained alongside ft.
+
+        Combines a periodic save_period, metric-based keep_top_k, and
+        ft_keep_latest_k for crash recovery. The best periodic checkpoint by
+        metric must survive even when it is not the most recent, in addition to
+        the ft recency checkpoint.
+        """
+        manager = self._make_manager(
+            checkpoint_dir,
+            keep_top_k=1,
+            ft_keep_latest_k=1,
+            metric_name="reward",
+            higher_is_better=True,
+            save_period=2,
+        )
+        # save_period=2 -> periodic {2, 4, 6, 8}. Step 4 is the best periodic by
+        # metric; the odd (non-periodic) steps have higher-looking values but are
+        # not eligible for metric top-k (only ft recency could keep them).
+        data = [
+            (1, {"reward": 0.95}),  # non-periodic, high metric -> NOT metric-eligible
+            (2, {"reward": 0.5}),
+            (3, {"reward": 0.99}),  # non-periodic, highest metric -> NOT eligible
+            (4, {"reward": 0.9}),  # best PERIODIC by metric
+            (5, {"reward": 0.2}),
+            (6, {"reward": 0.3}),
+            (7, {"reward": 0.25}),
+            (8, {"reward": 0.4}),  # most recent (periodic)
+        ]
+        for step, info in data:
+            tmp = manager.init_tmp_checkpoint(step, info)
+            manager.finalize_checkpoint(tmp)
+
+        # keep_top_k=1 by metric over periodic {2,4,6,8} -> step 4 (reward 0.9).
+        # ft_keep_latest_k=1 / exclude_latest -> step 8.
+        # The high-metric non-periodic steps (1, 3) are correctly NOT retained.
+        assert self._remaining_steps(checkpoint_dir) == [4, 8]
+
+    def test_metric_topk_with_ft_keeps_best_and_recent_disjoint(self, checkpoint_dir):
+        """save_period=1 (all periodic): top-k best by metric plus ft recency.
+
+        Ensures the best-by-metric checkpoints and the most-recent (ft) ones are
+        both retained when they are disjoint sets.
+        """
+        manager = self._make_manager(
+            checkpoint_dir,
+            keep_top_k=2,
+            ft_keep_latest_k=2,
+            metric_name="reward",
+            higher_is_better=True,
+        )
+        data = [
+            (1, {"reward": 0.9}),  # top-2 by metric
+            (2, {"reward": 0.8}),  # top-2 by metric
+            (3, {"reward": 0.1}),
+            (4, {"reward": 0.2}),
+            (5, {"reward": 0.3}),  # latest-2
+            (6, {"reward": 0.4}),  # latest-2 / most recent
+        ]
+        for step, info in data:
+            tmp = manager.init_tmp_checkpoint(step, info)
+            manager.finalize_checkpoint(tmp)
+
+        # top-2 by metric -> {1, 2}; ft latest-2 -> {5, 6}; union -> {1, 2, 5, 6}.
+        assert self._remaining_steps(checkpoint_dir) == [1, 2, 5, 6]


### PR DESCRIPTION
# What does this PR do ?

Adds two optional checkpointing knobs for crash recovery/resiliency, independent of the existing metric-based `keep_top_k` retention:

- **`ft_save_period`**: save a checkpoint every N steps for fault tolerance (separate from `save_period`).
- **`ft_keep_latest_k`**: retain the K most recent checkpoints (recency only, metric-agnostic).

This enables saving after each step for recovery purposes and subsequently clearing them without affecting checkpoints taken by `save_period` that are intended to be retained for downstream usage.

## Retention policy (`CheckpointManager.remove_old_checkpoints`)

Retention is now a union. A checkpoint survives if any rule keeps it:

- **Periodic**: `save_period`-aligned checkpoints. When `keep_top_k` is set, only the top-k best of these are kept (by metric if `metric_name` is set, else by recency); otherwise all periodic checkpoints are kept.
- **`ft_keep_latest_k`**: the K most recent checkpoints (pure recency), regardless of `save_period` alignment.
- The latest checkpoint (when `exclude_latest=True`).

`init_tmp_checkpoint` also clears a stale `tmp_step_N` left behind by an interrupted save so the next save starts clean.

## Driver wiring

`ft_save_period` is wired into the `should_save_by_step` gate of **every** training driver (grpo, grpo_sync, sft, dpo, rm, ppo, distillation, xtoken). `ft_keep_latest_k` retention is centralized in `CheckpointManager`, so it applies to all drivers automatically.

## Tests

- Extended the checkpoint-manager unit tests with the `ft_keep_latest_k` / periodic / metric-top-k union behaviors.
- Added per-driver tests asserting `ft_save_period` triggers saves at the expected cadence for sft, dpo, rm, distillation, and xtoken.

# Before your PR is "Ready for review"

**Pre checks**:

* [x] Make sure you read and followed Contributor guidelines
* [x] Did you write any new necessary tests?
* [ ] Did you add or update any necessary documentation?
* [x] Did you run the unit tests and functional tests locally?