### PR TITLE
fix(vllm): assign node-local VLLM_PORT for cross-node model parallelism

### DIFF
--- a/nemo_rl/distributed/worker_groups.py
+++ b/nemo_rl/distributed/worker_groups.py
@@ -143,6 +143,7 @@ class RayWorkerBuilder:
             placement_group_bundle_index: int,
             num_gpus: int,
             bundle_indices: Optional[tuple] = None,
+            num_gpus_per_node: Optional[int] = None,
             **extra_options: Optional[dict[str, Any]],
         ):
             """Create a Ray worker with the specified configuration.
@@ -160,6 +161,11 @@ class RayWorkerBuilder:
                 placement_group_bundle_index: Index of the bundle in the placement group
                 num_gpus: Number of GPUs to allocate to this worker
                 bundle_indices: Tuple of (node_idx, local_bundle_indices) for tensor parallelism (if applicable)
+                num_gpus_per_node: Number of GPUs per node in the cluster. Passed to
+                    configure_worker so it can map a bundle id to a node-local index,
+                    for example when assigning ports to model-parallel engines that
+                    span more than one node. None when the caller does not supply
+                    cluster topology.
                 extra_options: Additional options to pass to the Ray actor (may be overridden by actor's configure_worker(...) method)
 
             Returns:
@@ -181,6 +187,7 @@ class RayWorkerBuilder:
                     worker_class.configure_worker(
                         num_gpus=num_gpus,
                         bundle_indices=bundle_indices,
+                        num_gpus_per_node=num_gpus_per_node,
                     )
                 )
 
@@ -581,6 +588,7 @@ class RayWorkerGroup:
                     bundle_idx,
                     num_gpus,
                     worker_bundle_indices,
+                    num_gpus_per_node=self.cluster.num_gpus_per_node,
                     **extra_options,
                 )
 

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -83,7 +83,9 @@ class BaseVllmGenerationWorker:
 
     @staticmethod
     def configure_worker(
-        num_gpus: int | float, bundle_indices: Optional[tuple[int, list[int]]] = None
+        num_gpus: int | float,
+        bundle_indices: Optional[tuple[int, list[int]]] = None,
+        num_gpus_per_node: Optional[int] = None,
     ) -> tuple[dict[str, Any], dict[str, str], dict[str, Any], dict[str, Any]]:
         """Provides complete worker configuration for vLLM tensor and pipeline parallelism.
 
@@ -93,6 +95,9 @@ class BaseVllmGenerationWorker:
         Args:
             num_gpus: Original GPU allocation for this worker based on the placement group
             bundle_indices: Tuple of (node_idx, local_bundle_indices) for parallelism (if applicable)
+            num_gpus_per_node: Number of GPUs per node in the cluster. Used to map a
+                bundle id to a node-local engine slot when deriving VLLM_PORT. When
+                None, the original per-engine index is used unchanged.
 
         Returns:
             tuple with complete worker configuration:
@@ -136,16 +141,40 @@ class BaseVllmGenerationWorker:
                 + f"_{seed}"
             )
 
-            # Give each vLLM engine a deterministic starting port for TP/DP
-            # rendezvous.  vLLM's _get_open_port() reads VLLM_PORT and
-            # auto-increments on collision, so the per-engine spacing
-            # provides headroom.  See the port layout in virtual_cluster.py.
-            if len(local_bundle_indices) == 1:
-                engine_index_on_node = local_bundle_indices[0]
-            else:
-                engine_index_on_node = local_bundle_indices[0] // len(
-                    local_bundle_indices
+            # Give each vLLM engine a deterministic starting VLLM_PORT for the
+            # TP/DP rendezvous. vLLM's _get_open_port() reads VLLM_PORT and
+            # increments it on collision, so spacing engines by
+            # DEFAULT_VLLM_PORTS_PER_ENGINE leaves headroom. See the port layout
+            # in virtual_cluster.py.
+            #
+            # The port offset must be a node-local slot. The first entry of
+            # local_bundle_indices is a bundle id within the placement group.
+            # When a single engine spans more than one node (model parallel size
+            # larger than the per-node GPU count), that id can exceed the per-node
+            # GPU count, so dividing it by mp_size gives an offset that grows with
+            # the number of engines and can push VLLM_PORT into the OS ephemeral
+            # range, causing address-in-use errors. When num_gpus_per_node is
+            # known, reduce the id modulo the per-node GPU count to get a
+            # node-local slot. When it is not provided, use the original index,
+            # which is correct for engines that fit within one node.
+            mp_size = len(local_bundle_indices)
+            if num_gpus_per_node is None:
+                engine_index_on_node = (
+                    local_bundle_indices[0]
+                    if mp_size == 1
+                    else local_bundle_indices[0] // mp_size
                 )
+            elif mp_size > num_gpus_per_node:
+                # The engine spans several nodes. Each engine's rank-0 process is
+                # on a different node, so every such engine can use node-local
+                # slot 0 without colliding.
+                engine_index_on_node = 0
+            elif mp_size == 1:
+                engine_index_on_node = local_bundle_indices[0] % num_gpus_per_node
+            else:
+                engine_index_on_node = (
+                    local_bundle_indices[0] % num_gpus_per_node
+                ) // mp_size
             env_vars["VLLM_PORT"] = str(
                 DEFAULT_VLLM_PORT_RANGE_LOW
                 + engine_index_on_node * DEFAULT_VLLM_PORTS_PER_ENGINE

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -228,6 +228,7 @@ class MegatronPolicyWorkerImpl(
     def configure_worker(
         num_gpus: int | float,
         bundle_indices: Optional[tuple[int, list[int]]] = None,
+        num_gpus_per_node: Optional[int] = None,
     ) -> tuple[dict[str, Any], dict[str, str], dict[str, Any], dict[str, Any]]:
         """Worker-controlled Ray actor configuration.
 
@@ -236,6 +237,8 @@ class MegatronPolicyWorkerImpl(
         Args:
             num_gpus: Original GPU allocation for this worker based on the placement group
             bundle_indices: Tuple of (node_idx, local_bundle_indices) for this server
+            num_gpus_per_node: Per-node GPU count (unused here; part of the shared
+                configure_worker contract).
 
         Returns:
             tuple with complete worker configuration:
@@ -245,6 +248,7 @@ class MegatronPolicyWorkerImpl(
               - 'runtime_env': Additional runtime_env options (e.g., nsight config)
         """
         del bundle_indices  # one GPU per worker; no per-bundle seeding needed
+        del num_gpus_per_node  # not needed; one GPU per worker
         resources: dict[str, Any] = {"num_gpus": num_gpus}
         env_vars: dict[str, str] = {"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1"}
         init_kwargs: dict[str, Any] = {}

--- a/nemo_rl/models/value/workers/megatron_value_worker.py
+++ b/nemo_rl/models/value/workers/megatron_value_worker.py
@@ -239,6 +239,7 @@ class MegatronValueWorkerImpl(AbstractPolicyWorker):
     def configure_worker(
         num_gpus: int | float,
         bundle_indices: Optional[tuple[int, list[int]]] = None,
+        num_gpus_per_node: Optional[int] = None,
     ) -> tuple[dict[str, Any], dict[str, str], dict[str, Any], dict[str, Any]]:
         """Worker-controlled Ray actor configuration.
 
@@ -247,6 +248,8 @@ class MegatronValueWorkerImpl(AbstractPolicyWorker):
         Args:
             num_gpus: Original GPU allocation for this worker based on the placement group
             bundle_indices: Tuple of (node_idx, local_bundle_indices) for this server
+            num_gpus_per_node: Per-node GPU count (unused here; part of the shared
+                configure_worker contract).
 
         Returns:
             tuple with complete worker configuration:
@@ -256,6 +259,7 @@ class MegatronValueWorkerImpl(AbstractPolicyWorker):
               - 'runtime_env': Additional runtime_env options (e.g., nsight config)
         """
         del bundle_indices  # one GPU per worker; no per-bundle seeding needed
+        del num_gpus_per_node  # not needed; one GPU per worker
         resources: dict[str, Any] = {"num_gpus": num_gpus}
         env_vars: dict[str, str] = {"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1"}
         init_kwargs: dict[str, Any] = {}

--- a/tests/unit/distributed/test_virtual_cluster.py
+++ b/tests/unit/distributed/test_virtual_cluster.py
@@ -358,7 +358,6 @@ class TestVllmPortAssignment:
         ],
     )
     def test_vllm_port_assignment(self, bundle_indices, expected_port):
-        """num_gpus_per_node not supplied, so the original per-engine index is used."""
         from nemo_rl.models.generation.vllm.vllm_worker import (
             BaseVllmGenerationWorker,
         )
@@ -369,32 +368,41 @@ class TestVllmPortAssignment:
         assert env_vars["VLLM_PORT"] == str(expected_port)
 
     @pytest.mark.parametrize(
-        "num_gpus_per_node,bundle_indices,expected_port",
+        "num_gpus_per_node,bundle_indices,expected_slot",
         [
+            # expected_slot is the node-local engine index; the port is
+            # DEFAULT_VLLM_PORT_RANGE_LOW + slot * DEFAULT_VLLM_PORTS_PER_ENGINE.
+            # Deriving it from the constants keeps this test correct if the base
+            # of the vLLM port band changes.
+            #
             # With 8 GPUs per node, engines that fit on one node give the same
-            # result as the original index, since the bundle id modulo 8 is
+            # slot as the original index, since the bundle id modulo 8 is
             # unchanged within a node.
-            (8, (0, [0]), 20001),
-            (8, (0, [7]), 20701),
-            (8, (0, [4, 5, 6, 7]), 20101),  # (4 % 8) // 4 = 1
-            (8, (0, [0, 1, 2, 3, 4, 5, 6, 7]), 20001),  # 8-GPU engine, slot 0
+            (8, (0, [0]), 0),
+            (8, (0, [7]), 7),
+            (8, (0, [4, 5, 6, 7]), 1),  # (4 % 8) // 4
+            (8, (0, [0, 1, 2, 3, 4, 5, 6, 7]), 0),  # 8-GPU engine
             # A model-parallel size larger than the per-node GPU count means the
             # engine spans several nodes. Each engine's rank-0 process is on a
             # different node, so they all use node-local slot 0. The original
-            # index would instead give the second engine 16 // 16 = 1 (port
-            # 20101) and keep climbing.
-            (8, (0, list(range(16))), 20001),  # 16-GPU engine across 2 nodes
-            (8, (0, list(range(16, 32))), 20001),  # second such engine
-            (8, (0, list(range(32, 48))), 20001),  # third such engine
+            # index would instead climb (the second engine gives 16 // 16 = 1,
+            # and so on).
+            (8, (0, list(range(16))), 0),  # 16-GPU engine across 2 nodes
+            (8, (0, list(range(16, 32))), 0),  # second such engine
+            (8, (0, list(range(32, 48))), 0),  # third such engine
             # 4 GPUs per node, for example GB200 NVL72.
-            (4, (0, [3]), 20301),  # 3 % 4 = 3
-            (4, (0, [0, 1, 2, 3]), 20001),  # 4-GPU engine, slot 0
-            (4, (0, list(range(8, 16))), 20001),  # 8-GPU engine across 2 nodes
+            (4, (0, [3]), 3),  # 3 % 4
+            (4, (0, [0, 1, 2, 3]), 0),  # 4-GPU engine
+            (4, (0, list(range(8, 16))), 0),  # 8-GPU engine across 2 nodes
         ],
     )
     def test_vllm_port_assignment_respects_num_gpus_per_node(
-        self, num_gpus_per_node, bundle_indices, expected_port
+        self, num_gpus_per_node, bundle_indices, expected_slot
     ):
+        from nemo_rl.distributed.virtual_cluster import (
+            DEFAULT_VLLM_PORT_RANGE_LOW,
+            DEFAULT_VLLM_PORTS_PER_ENGINE,
+        )
         from nemo_rl.models.generation.vllm.vllm_worker import (
             BaseVllmGenerationWorker,
         )
@@ -403,6 +411,9 @@ class TestVllmPortAssignment:
             num_gpus=1,
             bundle_indices=bundle_indices,
             num_gpus_per_node=num_gpus_per_node,
+        )
+        expected_port = (
+            DEFAULT_VLLM_PORT_RANGE_LOW + expected_slot * DEFAULT_VLLM_PORTS_PER_ENGINE
         )
         assert env_vars["VLLM_PORT"] == str(expected_port)
 

--- a/tests/unit/distributed/test_virtual_cluster.py
+++ b/tests/unit/distributed/test_virtual_cluster.py
@@ -358,12 +358,51 @@ class TestVllmPortAssignment:
         ],
     )
     def test_vllm_port_assignment(self, bundle_indices, expected_port):
+        """num_gpus_per_node not supplied, so the original per-engine index is used."""
         from nemo_rl.models.generation.vllm.vllm_worker import (
             BaseVllmGenerationWorker,
         )
 
         _, env_vars, _, _ = BaseVllmGenerationWorker.configure_worker(
             num_gpus=1, bundle_indices=bundle_indices
+        )
+        assert env_vars["VLLM_PORT"] == str(expected_port)
+
+    @pytest.mark.parametrize(
+        "num_gpus_per_node,bundle_indices,expected_port",
+        [
+            # With 8 GPUs per node, engines that fit on one node give the same
+            # result as the original index, since the bundle id modulo 8 is
+            # unchanged within a node.
+            (8, (0, [0]), 20001),
+            (8, (0, [7]), 20701),
+            (8, (0, [4, 5, 6, 7]), 20101),  # (4 % 8) // 4 = 1
+            (8, (0, [0, 1, 2, 3, 4, 5, 6, 7]), 20001),  # 8-GPU engine, slot 0
+            # A model-parallel size larger than the per-node GPU count means the
+            # engine spans several nodes. Each engine's rank-0 process is on a
+            # different node, so they all use node-local slot 0. The original
+            # index would instead give the second engine 16 // 16 = 1 (port
+            # 20101) and keep climbing.
+            (8, (0, list(range(16))), 20001),  # 16-GPU engine across 2 nodes
+            (8, (0, list(range(16, 32))), 20001),  # second such engine
+            (8, (0, list(range(32, 48))), 20001),  # third such engine
+            # 4 GPUs per node, for example GB200 NVL72.
+            (4, (0, [3]), 20301),  # 3 % 4 = 3
+            (4, (0, [0, 1, 2, 3]), 20001),  # 4-GPU engine, slot 0
+            (4, (0, list(range(8, 16))), 20001),  # 8-GPU engine across 2 nodes
+        ],
+    )
+    def test_vllm_port_assignment_respects_num_gpus_per_node(
+        self, num_gpus_per_node, bundle_indices, expected_port
+    ):
+        from nemo_rl.models.generation.vllm.vllm_worker import (
+            BaseVllmGenerationWorker,
+        )
+
+        _, env_vars, _, _ = BaseVllmGenerationWorker.configure_worker(
+            num_gpus=1,
+            bundle_indices=bundle_indices,
+            num_gpus_per_node=num_gpus_per_node,
         )
         assert env_vars["VLLM_PORT"] == str(expected_port)
 

--- a/tests/unit/distributed/test_worker_groups.py
+++ b/tests/unit/distributed/test_worker_groups.py
@@ -94,7 +94,7 @@ class MyTestActor:
         self.call_count = 0
 
     @staticmethod
-    def configure_worker(num_gpus, bundle_indices):
+    def configure_worker(num_gpus, bundle_indices, num_gpus_per_node=None):
         init_kwargs_update = {
             "configured_gpus": num_gpus,
             "bundle_indices_seen_in_init": bundle_indices is not None,
@@ -130,7 +130,7 @@ class PrecedenceActor:
         return dict(self.env_vars)
 
     @classmethod
-    def configure_worker(cls, num_gpus, bundle_indices=None):
+    def configure_worker(cls, num_gpus, bundle_indices=None, num_gpus_per_node=None):
         return (
             {"num_gpus": num_gpus},  # resources
             {

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -969,9 +969,11 @@ def test_vllm_worker_seed_behavior(cluster, tokenizer):
         original_configure_worker = VllmGenerationWorker.configure_worker
 
         # Override the configure_worker method to always use the same seed
-        def configure_worker_fixed_seed(num_gpus, bundle_indices=None):
+        def configure_worker_fixed_seed(
+            num_gpus, bundle_indices=None, num_gpus_per_node=None
+        ):
             resources, env_vars, init_kwargs, runtime_env = original_configure_worker(
-                num_gpus, bundle_indices
+                num_gpus, bundle_indices, num_gpus_per_node
             )
             # Override with fixed seed
             init_kwargs["seed"] = 42


### PR DESCRIPTION
# What does this PR do ?

Problem:

When a vLLM engine's model-parallel size exceeds the per-node GPU count, the engine spans multiple nodes, and the first bundle id can be larger than the per-node GPU count. Dividing that id by the model-parallel size then produced a port offset that grew with the number of engines and could push `VLLM_PORT` into the OS ephemeral range, causing address-in-use errors during the TP/DP rendezvous.

Fix: 

Thread the cluster's per-node GPU count into configure_worker and use it to reduce the bundle id to a node-local slot. Engines that span several nodes each have their rank-0 process on a distinct node, so they all use node-local slot 0 without colliding. When the per-node GPU count is not supplied, the original per-engine index is used, which is correct for engines that fit within a single node.

`num_gpus_per_node` is added to the shared configure_worker contract. The Megatron policy and value workers accept and ignore it.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
