### PR TITLE
feat: log reward component metrics

### DIFF
--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -26,6 +26,7 @@ from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.experience.interfaces import Completion, PromptGroupRecord
 from nemo_rl.experience.rollouts import (
+    _calculate_agent_result_metrics,
     _calculate_single_metric,
     _tensorize_by_key,
     calculate_rewards,
@@ -561,16 +562,9 @@ class AsyncNemoGymRolloutImpl:
 
         # Agent-level metrics.
         agent_extras = [c.env_extras for c in completions]
-        for key in agent_extras[0].keys():
-            values = [
-                float(r[key])  # type: ignore
-                for r in agent_extras
-                if isinstance(r.get(key), (bool, int, float))
-            ]
-            if values:
-                rollout_metrics.update(
-                    _calculate_single_metric(values, n, f"{agent_name}/{key}")
-                )
+        rollout_metrics.update(
+            _calculate_agent_result_metrics(agent_extras, agent_name)
+        )
         rollout_metrics[f"{agent_name}/full_result"] = Table(
             data=[[json.dumps(r, separators=(",", ":"))] for r in agent_extras],
             columns=["Full result"],

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -1334,6 +1334,50 @@ def _calculate_single_metric(
     }
 
 
+def _calculate_agent_result_metrics(
+    agent_results: Sequence[dict[str, Any]], agent_name: str
+) -> dict:
+    metrics = {}
+    for key in agent_results[0].keys():
+        values = [
+            float(r[key])
+            for r in agent_results
+            if isinstance(r.get(key), (bool, int, float))
+        ]
+        if values:
+            metrics.update(
+                _calculate_single_metric(
+                    values, len(agent_results), f"{agent_name}/{key}"
+                )
+            )
+
+    reward_component_keys: set[str] = set()
+    for result in agent_results:
+        reward_components = result.get("reward_components")
+        if isinstance(reward_components, dict):
+            reward_component_keys.update(
+                key
+                for key, value in reward_components.items()
+                if isinstance(key, str) and isinstance(value, (bool, int, float))
+            )
+
+    for key in sorted(reward_component_keys):
+        values = []
+        for result in agent_results:
+            reward_components = result.get("reward_components")
+            if isinstance(reward_components, dict) and isinstance(
+                reward_components.get(key), (bool, int, float)
+            ):
+                values.append(float(reward_components[key]))
+        metrics.update(
+            _calculate_single_metric(
+                values, len(agent_results), f"{agent_name}/reward_components/{key}"
+            )
+        )
+
+    return metrics
+
+
 def get_nemo_gym_thinking_tags(env_config: dict[str, Any]) -> list[str]:
     """Return thinking tags used by the Gym-side detector."""
     nemo_gym_config = env_config.get("nemo_gym")
@@ -1913,19 +1957,9 @@ def run_async_nemo_gym_rollout(
 
         per_agent_metrics = {}
         for agent_name, agent_results in agent_to_results.items():
-            keys = agent_results[0].keys()
-            for key in keys:
-                values = [
-                    float(r[key])
-                    for r in agent_results
-                    if isinstance(r.get(key), (bool, int, float))
-                ]
-                if values:
-                    per_agent_metrics.update(
-                        _calculate_single_metric(
-                            values, len(agent_results), f"{agent_name}/{key}"
-                        )
-                    )
+            per_agent_metrics.update(
+                _calculate_agent_result_metrics(agent_results, agent_name)
+            )
 
             # Log the full result
             to_log = [[json.dumps(r, separators=((",", ":")))] for r in agent_results]

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -40,6 +40,7 @@ from nemo_rl.environments.games.sliding_puzzle import (
 from nemo_rl.experience.interfaces import Completion, PromptGroupRecord
 from nemo_rl.experience.rollout_manager import RolloutManager
 from nemo_rl.experience.rollouts import (
+    _calculate_agent_result_metrics,
     _calculate_single_metric,
     generate_responses_async,
     run_async_multi_turn_rollout,
@@ -102,6 +103,37 @@ class TestCalculateSingleMetric:
         result = _calculate_single_metric([5.0, 5.0], batch_size=2, key_name="test")
 
         assert result["test/stddev"] == 0.0
+
+
+def test_calculate_agent_result_metrics_flattens_reward_components():
+    metrics = _calculate_agent_result_metrics(
+        [
+            {
+                "reward": 1.0,
+                "reward_components": {
+                    "correctness": 0.5,
+                    "format": 0.2,
+                    "details": {"reason": "ignored"},
+                    "note": "ignored",
+                },
+            },
+            {
+                "reward": 0.0,
+                "reward_components": {
+                    "correctness": 1.0,
+                    "format": 0.4,
+                },
+            },
+        ],
+        "test_agent",
+    )
+
+    assert metrics["test_agent/reward/mean"] == 0.5
+    assert metrics["test_agent/reward_components/correctness/mean"] == 0.75
+    assert metrics["test_agent/reward_components/format/mean"] == pytest.approx(0.3)
+    assert "test_agent/reward_components/mean" not in metrics
+    assert "test_agent/reward_components/details/mean" not in metrics
+    assert "test_agent/reward_components/note/mean" not in metrics
 
 
 class _DummyTokenizer:


### PR DESCRIPTION
## Summary
Flatten scalar values under Gym `reward_components` into rollout metrics.
Keep existing top-level scalar metrics and `full_result` table logging behavior.
Reuse the same extraction helper in the legacy rollout path and rollout manager path.

## Validation
`.venv/bin/ruff format nemo_rl/experience/rollouts.py nemo_rl/experience/rollout_manager.py tests/unit/experience/test_rollouts.py`
`.venv/bin/ruff check nemo_rl/experience/rollouts.py nemo_rl/experience/rollout_manager.py tests/unit/experience/test_rollouts.py`
`.venv/bin/pytest tests/unit/experience/test_rollouts.py -k reward_components -q`
