### PR TITLE
fix: add vLLM config context during collective refit

### DIFF
--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -465,9 +465,12 @@ class VllmInternalWorkerExtension:
                 process_weights_after_loading,
             )
 
-            process_weights_after_loading(
-                self.model_runner.model, self.model_config, self.device
-            )
+            from vllm.config import set_current_vllm_config
+
+            with set_current_vllm_config(self.model_runner.vllm_config):
+                process_weights_after_loading(
+                    self.model_runner.model, self.model_config, self.device
+                )
             self._maybe_process_fp8_kv_cache()
 
         except Exception as e:

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -461,11 +461,10 @@ class VllmInternalWorkerExtension:
             )
 
             # Process weights after loading
+            from vllm.config import set_current_vllm_config
             from vllm.model_executor.model_loader.utils import (
                 process_weights_after_loading,
             )
-
-            from vllm.config import set_current_vllm_config
 
             with set_current_vllm_config(self.model_runner.vllm_config):
                 process_weights_after_loading(

--- a/tests/unit/models/generation/test_vllm_backend.py
+++ b/tests/unit/models/generation/test_vllm_backend.py
@@ -33,7 +33,7 @@ def _make_collective_update_extension(backend):
     state_info = object()
     ext.state_dict_info = {"model.weight": state_info}
     ext.model_update_group = object()
-    ext.model_runner = SimpleNamespace(model=object())
+    ext.model_runner = SimpleNamespace(model=object(), vllm_config=object())
     ext.model_config = object()
     ext.device = object()
     return ext, state_info

--- a/tests/unit/models/generation/test_vllm_backend.py
+++ b/tests/unit/models/generation/test_vllm_backend.py
@@ -113,9 +113,7 @@ def test_update_weights_from_collective_processes_weights_after_loading(monkeypa
         finally:
             call_order.append("config_exit")
 
-    monkeypatch.setattr(
-        "vllm.config.set_current_vllm_config", set_current_vllm_config
-    )
+    monkeypatch.setattr("vllm.config.set_current_vllm_config", set_current_vllm_config)
 
     def load_weights(weights):
         call_order.append("load")

--- a/tests/unit/models/generation/test_vllm_backend.py
+++ b/tests/unit/models/generation/test_vllm_backend.py
@@ -104,6 +104,19 @@ def test_update_weights_from_collective_processes_weights_after_loading(monkeypa
     )
     ext, expected_state_info = _make_collective_update_extension(vllm_backend)
 
+    @contextlib.contextmanager
+    def set_current_vllm_config(config):
+        assert config is ext.model_runner.vllm_config
+        call_order.append("config_enter")
+        try:
+            yield
+        finally:
+            call_order.append("config_exit")
+
+    monkeypatch.setattr(
+        "vllm.config.set_current_vllm_config", set_current_vllm_config
+    )
+
     def load_weights(weights):
         call_order.append("load")
         assert weights == [("model.weight", "weight-value")]
@@ -130,7 +143,16 @@ def test_update_weights_from_collective_processes_weights_after_loading(monkeypa
     assert ext.update_weights_from_collective() is True
 
     assert process_calls == [(ext.model_runner.model, ext.model_config, ext.device)]
-    assert call_order == ["broadcast", "load", "process", "kv", "gc", "empty_cache"]
+    assert call_order == [
+        "broadcast",
+        "load",
+        "config_enter",
+        "process",
+        "config_exit",
+        "kv",
+        "gc",
+        "empty_cache",
+    ]
 
 
 @pytest.mark.vllm


### PR DESCRIPTION
## What changed

Wrap the collective-refit call to `process_weights_after_loading()` in
`set_current_vllm_config(self.model_runner.vllm_config)`.

Extend the focused unit test to verify that post-load processing runs inside
that context and that the context exits before FP8 KV-cache post-processing.

## Why

A Nano-v3 async GRPO run using current `main` (`ad23de8da`) and NeMo RL's latest
nightly container initialized all 256 Ray actors, both 128-worker model groups,
and all 13 NeMo Gym servers. The initial policy-to-generation refit then failed
on every vLLM worker with:

```
Current vLLM config is not set.
```

This originates from `process_weights_after_loading()`, which newer vLLM
versions require to execute under `set_current_vllm_config()`. Other post-load
paths in the same extension already establish this context; the collective
refit path did not.

Reproduction:

- Slurm job: `13777880`
- W&B: https://wandb.ai/nvidia/grpo-dev-wenweng/runs/88atirl1
- Runtime error: `Updating weights for the generation policy failed during refit`

## Impact

Collective Megatron-to-vLLM weight synchronization can complete with newer
vLLM containers instead of returning `False` from every generation worker
before the first rollout.

## Validation

- `git diff --check`
- `python -m py_compile nemo_rl/models/generation/vllm/vllm_backend.py tests/unit/models/generation/test_vllm_backend.py`
- Focused test updated to assert config-context enter/process/exit ordering.
- The prescribed vLLM test invocation was attempted, but dependency resolution
  is currently blocked by HTTP 403 while fetching metadata for the pinned
  FlashAttention aarch64 wheel:
  `flash_attn-2.8.1+cu13torch2.10cxx11abiTRUE-cp313-cp313-linux_aarch64.whl`.
