### PR TITLE
fix: zero router aux loss in Qwen3.5 automodel recipes

### DIFF
--- a/examples/configs/recipes/llm/grpo-qwen3.5-35ba3b-2n8g-automodel-ep16.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen3.5-35ba3b-2n8g-automodel-ep16.yaml
@@ -3,6 +3,14 @@ checkpointing:
   checkpoint_dir: results/grpo-qwen3.5-35ba3b-2n8g-automodel-ep16
 policy:
   model_name: Qwen/Qwen3.5-35B-A3B-Base
+  hf_config_overrides:
+    text_config:
+      # Disable the MoE load-balancing aux loss for RL: Automodel otherwise
+      # injects router gradients that conflict with the policy objective and
+      # degrade accuracy. Keep as 0.0, not 0: Hugging Face strict config
+      # validation declares router_aux_loss_coef as float and rejects YAML's
+      # integer 0.
+      router_aux_loss_coef: 0.0
   train_micro_batch_size: 1
   logprob_batch_size: 1
   max_total_sequence_length: 4096

--- a/examples/configs/recipes/llm/grpo-qwen3.5-35ba3b-dapo-4n8g-automodel.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen3.5-35ba3b-dapo-4n8g-automodel.yaml
@@ -19,6 +19,14 @@ checkpointing:
   checkpoint_dir: results/grpo-qwen3.5-35ba3b-dapo-4n8g-automodel
 policy:
   model_name: Qwen/Qwen3.5-35B-A3B-Base
+  hf_config_overrides:
+    text_config:
+      # Disable the MoE load-balancing aux loss for RL: Automodel otherwise
+      # injects router gradients that conflict with the policy objective and
+      # degrade accuracy. Keep as 0.0, not 0: Hugging Face strict config
+      # validation declares router_aux_loss_coef as float and rejects YAML's
+      # integer 0.
+      router_aux_loss_coef: 0.0
   train_micro_batch_size: 1
   logprob_batch_size: 1
   max_total_sequence_length: 9216

--- a/examples/configs/recipes/vlm/vlm_grpo-qwen3.5-35ba3b-geo3k-2n8g-automodel-ep16.yaml
+++ b/examples/configs/recipes/vlm/vlm_grpo-qwen3.5-35ba3b-geo3k-2n8g-automodel-ep16.yaml
@@ -10,6 +10,14 @@ checkpointing:
   checkpoint_dir: results/vlm_grpo-qwen3.5-35ba3b-geo3k-2n8g-automodel-ep16
 policy:
   model_name: Qwen/Qwen3.5-35B-A3B-Base
+  hf_config_overrides:
+    text_config:
+      # Disable the MoE load-balancing aux loss for RL: Automodel otherwise
+      # injects router gradients that conflict with the policy objective and
+      # degrade accuracy. Keep as 0.0, not 0: Hugging Face strict config
+      # validation declares router_aux_loss_coef as float and rejects YAML's
+      # integer 0.
+      router_aux_loss_coef: 0.0
   train_global_batch_size: 512
   logprob_batch_size: 1
   max_total_sequence_length: 3072


### PR DESCRIPTION
## What does this PR do?

Adds `hf_config_overrides.text_config.router_aux_loss_coef: 0.0` to the three Qwen3.5 Automodel recipes:

- `examples/configs/recipes/llm/grpo-qwen3.5-35ba3b-dapo-4n8g-automodel.yaml`
- `examples/configs/recipes/llm/grpo-qwen3.5-35ba3b-2n8g-automodel-ep16.yaml`
- `examples/configs/recipes/vlm/vlm_grpo-qwen3.5-35ba3b-geo3k-2n8g-automodel-ep16.yaml`

Reran the above release test: https://wandb.ai/nvidia/nemorl-pr3196/runs/almaogtl

## Why

The Automodel backend reads `router_aux_loss_coef` from the HF config (Qwen3.5 default: **0.001**) and silently injects the MoE load-balancing aux-loss gradient into the router via `MoEAuxLossAutoScaler` during RL training. The load-balancing objective conflicts with the policy objective and severely degrades accuracy.

Verified on `grpo-qwen3.5-35ba3b-dapo-4n8g-automodel` with dynamic filtering=True (DAPOMathAIME2024 validation, otherwise identical runs):

- Red: original run
- Green: with `router_aux_loss_coef=0.0`

<img width="902" height="632" alt="截屏2026-07-13 09 56 09" src="https://github.com/user-attachments/assets/0680014f-5705-4708-a1b0-7940af8e01c6" />

Wandb Link: https://wandb.ai/nvidia/nemorl-pr3196

The run with aux loss active also shows ~10x larger grad norm at step 1 (1.88 vs ~0.1) and `token_mult_prob_error` spikes up to ~2.0.

All other MoE Automodel recipes (nanov3, minimax-m27, gpt-oss) already zero this coefficient; the Qwen3.5 recipes were the only ones missing it. Qwen3.5 nests the field under `text_config`, and the value must be `0.0` (float) because Hugging Face strict config validation rejects YAML's integer `0`.

## Issues

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)