### PR TITLE
fix: ensure unique TOPO_RANK per node

### DIFF
--- a/nemo_rl/distributed/virtual_cluster.py
+++ b/nemo_rl/distributed/virtual_cluster.py
@@ -122,7 +122,9 @@ Nodes sharing the same key belong to the same NVLink switch fabric (e.g. one GB2
 TOPO_RANK_KEY = "topo_rank"
 """Ray resource key for the SLURM topological rank.
 Derived from ``SLURM_TOPOLOGY_ADDR`` (when ``SLURM_TOPOLOGY_ADDR_PATTERN=block.node``),
-falling back to ``SLURM_PROCID`` or hostname digits.
+falling back to ``SLURM_PROCID + 2`` on worker nodes (head node is pinned to ``1``),
+then to hostname digits when SLURM is unavailable. Values are always ``>= 1`` so that
+Ray does not drop the custom resource (Ray drops value-0 custom resources).
 Used to sort nodes within and across NVLink domains so rank assignment follows physical topology."""
 
 NVLINK_DOMAIN_UNKNOWN = "unknown"

--- a/ray.sub
+++ b/ray.sub
@@ -399,7 +399,7 @@ ip_head=$head_node_ip:$PORT
 # TOPO_RANK: Topology-aware infrastructure rank.
 #   Fallback chain:
 #   1. SLURM_TOPOLOGY_ADDR (block.node format) -> block_num * 10^10 + node_num
-#   2. SLURM_PROCID (SLURM without topology plugin)
+#   2. SLURM_PROCID + 2 on workers, head pinned to 1 (SLURM without topology plugin)
 #   3. Hostname digits (non-SLURM fallback)
 #
 # TODO(ansubramania): Harden the SLURM_TOPOLOGY_ADDR digit-extraction logic for open source.

--- a/ray.sub
+++ b/ray.sub
@@ -426,7 +426,14 @@ if [[ -n "\${SLURM_TOPOLOGY_ADDR:-}" && "\${SLURM_TOPOLOGY_ADDR_PATTERN:-}" == "
     TOPO_RANK=\$(( 10#\$_block_digits * 10000000000 + 10#\$_node_digits ))
   fi
 elif [[ -n "\${SLURM_PROCID:-}" ]]; then
-  TOPO_RANK=\$(( 10#\$SLURM_PROCID ))
+  # Head srun and worker srun each start their own SLURM_PROCID counter at 0.
+  # Head hardcoded to 1; workers get +2 so worker[0]=2, worker[62]=64 -- keeps
+  # all nodes at unique values >=1 (Ray drops value-0 custom resources).
+  if [[ "\$SLURMD_NODENAME" == "$head_node" ]]; then
+    TOPO_RANK=1
+  else
+    TOPO_RANK=\$(( 10#\$SLURM_PROCID + 2 ))
+  fi
 else
   _hostname_digits=\$(hostname | tr -dc '0-9')
   if [[ -n "\$_hostname_digits" ]]; then

--- a/tests/unit/distributed/test_topology_placement.py
+++ b/tests/unit/distributed/test_topology_placement.py
@@ -118,9 +118,10 @@ class TestTopoRankValues:
     """Ray stores resource values as floats; int(float) must round-trip correctly."""
 
     def test_slurm_procid_value_as_float(self):
-        # SLURM_PROCID fallback: $(( 10#7 )) -> TOPO_RANK=7, stored as 7.0 by Ray
-        topo_rank = int(7.0)
-        assert topo_rank == 7
+        # SLURM_PROCID fallback (worker): $(( 10#7 + 2 )) -> TOPO_RANK=9, stored as 9.0 by Ray
+        # (head node is pinned to TOPO_RANK=1)
+        topo_rank = int(9.0)
+        assert topo_rank == 9
 
     def test_hostname_digits_value_as_float(self):
         # hostname node007 -> $(( 10#007 )) -> 7, stored as 7.0 by Ray
@@ -133,15 +134,15 @@ class TestTopoRankValues:
         assert topo_rank == 20000000015
 
     def test_sorting_with_slurm_procid_ranks(self):
-        # Nodes labelled by SLURM_PROCID (0..7) across two domains
+        # Nodes labelled by SLURM_PROCID (1..8) across two domains
         bundle_data = _make_bundle_data(
             {
-                "nvlink_domain_A": [4, 5, 6, 7],  # higher SLURM_PROCID
-                "nvlink_domain_B": [0, 1, 2, 3],  # lower SLURM_PROCID
+                "nvlink_domain_A": [5, 6, 7, 8],  # higher TOPO_RANK
+                "nvlink_domain_B": [1, 2, 3, 4],  # lower TOPO_RANK
             }
         )
         result = _sort_bundle_indices_by_topology(bundle_data)
-        # Domain B min rank=0 < domain A min rank=4 → B comes first
+        # Domain B min rank=1 < domain A min rank=5 → B comes first
         node_ids = [bundle_data[i][3] for i in result]
         # First 4 nodes should all be from domain B (nodes 4..7 in bundle_data list)
         for node_id in node_ids[:4]:


### PR DESCRIPTION
## Issue
closes #3155

## Summary
Under Slurm, the head srun and the batched worker srun each start their own `SLURM_PROCID` counter at 0, so the head node and worker[0] both computed `TOPO_RANK=0`. **Ray silently drops value-0 custom resources**, so those two nodes lost their `topo_rank` and collapsed into `virtual_cluster.py`'s UNKNOWN topology bucket.

**This latent bug was invisible until #2827.** The pre-#2827 worker srun started workers serially (with a `sleep 3` stagger), so bundles landed on the alive-nodes in a blocked order and Megatron's rank→node mapping happened to be per-node blocked. After #2827 workers register with Ray in parallel; on the two UNKNOWN nodes the unified-PG placement path now produces an **interleaved** bundle→node mapping, and Megatron-based recipes with cross-node model parallelism (e.g. DAPO DSV3 64n8g) crash at NCCL init with `Duplicate GPU detected`.

## `topo_rank` in the Ray node dump

| Node | Before (crashed) | After (this fix) |
|---|---|---|
| head | **None** (Ray dropped value=0) | 1 |
| worker[0] | **None** (Ray dropped value=0) | 2 |
| worker[1..62] | 1..62 | 3..64 |

## Consequence on rank→node mapping (before fix)

On the **two nodes that both lost their `topo_rank`** (head + worker[0]), the unified PG placed bundles in an interleaved order, so the ranks Megatron assigned to those two physical machines were striped like this:

| Physical node | Ranks landed on it |
|---|---|
| Node A | 0, 2, 4, 6, 8, 10, 12, 14 |
| Node B | 1, 3, 5, 7, 9, 11, 13, 15 |

Every rank *R* and rank *R+8* in the same NCCL comm ends up on the same physical machine, and NCCL reports them on the same physical GPU → `Duplicate GPU detected: rank R and rank R+8` at NCCL init.

After the fix all 64 nodes have distinct `topo_rank` → `virtual_cluster` sees a full topology → blocked mapping (ranks 0-7 on one node, 8-15 on next, ...) → no collision.

## Fix
`ray.sub` `topology_probe.sh`: nest a `SLURMD_NODENAME == $head_node` check inside the `SLURM_PROCID` fallback branch. Head hardcodes to 1; workers get `SLURM_PROCID + 2`. `$head_node` is submit-time interpolated into the generated script; `SLURMD_NODENAME` is runtime.
