### PR TITLE
fix: handle inflated packed sequence lengths in input-id packing

### DIFF
--- a/nemo_rl/algorithms/loss/utils.py
+++ b/nemo_rl/algorithms/loss/utils.py
@@ -246,7 +246,12 @@ def _pack_input_ids(
         padded_len = int((cu_seqlens_q_padded[i + 1] - cu_seqlens_q_padded[i]).item())
         packed_start = int(cu_seqlens_q_padded[i].item())
         seq = torch.zeros(padded_len, dtype=input_ids.dtype, device=input_ids.device)
-        seq[:actual_len] = input_ids[i, :actual_len]
+        # The packer absorbs bin-level alignment padding into the last
+        # sequence's effective length (see _get_pack_sequence_parameters_for_megatron),
+        # so cu_seqlens can exceed the unpacked row width. Copy only real
+        # tokens; the tail stays zero and is excluded from the loss by token_mask.
+        copy_len = min(actual_len, input_ids.shape[1])
+        seq[:copy_len] = input_ids[i, :copy_len]
         if roll_shift != 0:
             seq = seq.roll(shifts=roll_shift, dims=0)
         sharded = _get_tokens_on_this_cp_rank(seq, cp_rank, cp_size, seq_dim=0)

--- a/tests/unit/algorithms/test_sequence_packing_fusion.py
+++ b/tests/unit/algorithms/test_sequence_packing_fusion.py
@@ -414,3 +414,95 @@ def test_sequence_packing_fusion_vs_baseline_with_sampling_params(
         tp_size=tp_size,
     )
     distributed_test_runner(test_fn, world_size=world_size)
+
+
+# ---------------------------------------------------------------------------
+# _pack_input_ids: bin-fill padding regression tests
+#
+# The Megatron packer rounds each packed bin's total length up to a kernel
+# alignment (e.g. 128 * cp*2 * tp for hybridep) and absorbs the deficit into
+# the LAST sequence's effective length in cu_seqlens. Those phantom positions
+# exceed the unpacked [B, S] row width; _pack_input_ids must copy only real
+# tokens and leave the tail zero (it is masked at the loss by token_mask).
+# Regression test for the tiny-Ultra smoke crash:
+#   RuntimeError: The expanded size of the tensor (9472) must match the
+#   existing size (7040) at non-singleton dimension 0.
+# ---------------------------------------------------------------------------
+
+
+def _rolled_padded_seq(row, actual_len, padded_len, roll_shift):
+    seq = torch.zeros(padded_len, dtype=row.dtype)
+    seq[:actual_len] = row[:actual_len]
+    if roll_shift != 0:
+        seq = seq.roll(shifts=roll_shift, dims=0)
+    return seq
+
+
+def test_pack_input_ids_last_seq_inflated_beyond_row_width():
+    """cu_seqlens' last entry exceeds input_ids width (bin-fill deficit)."""
+    from nemo_rl.algorithms.loss.utils import _pack_input_ids
+
+    row_width = 7040
+    inflated_len = 9472  # 7040 real tokens + 2432 bin-fill deficit
+    input_ids = torch.arange(2 * row_width).reshape(2, row_width)
+    cu = torch.tensor([0, row_width, row_width + inflated_len])
+
+    packed = _pack_input_ids(input_ids, cu, cu, cp_rank=0, cp_size=1, roll_shift=-1)
+
+    assert packed.shape == (1, row_width + inflated_len)
+    expected_seq0 = _rolled_padded_seq(input_ids[0], row_width, row_width, -1)
+    expected_seq1 = _rolled_padded_seq(input_ids[1], row_width, inflated_len, -1)
+    assert torch.equal(packed[0, :row_width], expected_seq0)
+    assert torch.equal(packed[0, row_width:], expected_seq1)
+    # Phantom bin-fill tail (rolled by -1) must stay zero.
+    assert packed[0, row_width + row_width : -1].eq(0).all()
+
+
+@pytest.mark.parametrize("cp_size", [2, 8])
+def test_pack_input_ids_inflated_last_seq_cp_sharded(cp_size):
+    """CP sharding of the inflated last sequence conserves the real tokens."""
+    from nemo_rl.algorithms.loss.utils import _pack_input_ids
+
+    row_width = 64
+    inflated_len = 96  # deficit of 32 absorbed into the last sequence
+    input_ids = torch.arange(1, 2 * row_width + 1).reshape(2, row_width)
+    cu = torch.tensor([0, row_width, row_width + inflated_len])
+    total = row_width + inflated_len
+
+    shards = [
+        _pack_input_ids(input_ids, cu, cu, cp_rank=r, cp_size=cp_size, roll_shift=0)
+        for r in range(cp_size)
+    ]
+    for shard in shards:
+        assert shard.shape == (1, total // cp_size)
+
+    # Union of all CP shards holds exactly the real tokens plus zeros for the
+    # phantom tail, regardless of chunk placement.
+    all_tokens = torch.cat([s[0] for s in shards]).sort().values
+    expected = (
+        torch.cat(
+            [
+                input_ids.flatten(),
+                torch.zeros(inflated_len - row_width, dtype=input_ids.dtype),
+            ]
+        )
+        .sort()
+        .values
+    )
+    assert torch.equal(all_tokens, expected)
+
+
+def test_pack_input_ids_in_bounds_lengths_unchanged():
+    """Sequences within the row width behave as before the clamp."""
+    from nemo_rl.algorithms.loss.utils import _pack_input_ids
+
+    input_ids = torch.arange(2 * 64).reshape(2, 64)
+    cu_q = torch.tensor([0, 40, 40 + 64])  # real lengths 40, 64
+    cu_qp = torch.tensor([0, 48, 48 + 64])  # per-seq alignment padding only
+
+    packed = _pack_input_ids(input_ids, cu_q, cu_qp, cp_rank=0, cp_size=1, roll_shift=0)
+
+    assert packed.shape == (1, 48 + 64)
+    assert torch.equal(packed[0, :40], input_ids[0, :40])
+    assert packed[0, 40:48].eq(0).all()
+    assert torch.equal(packed[0, 48:], input_ids[1])


### PR DESCRIPTION
# What does this PR do ?

## What

Fix `_pack_input_ids` to handle packed sequence metadata where the final sequence in a packed bin has an effective length larger than the original `input_ids` row width.

The packer can absorb bin-level alignment padding into the last sequence's `cu_seqlens` span. In that case, `_pack_input_ids` should copy only real tokens from `input_ids` and leave the phantom padded tail as zeros.

## Why

This prevents shape mismatch crashes like:

```text
RuntimeError: The expanded size of the tensor (...) must match the existing size (...)
```

Reference impl. in ultra-v3 branch [here](https://github.com/NVIDIA-NeMo/RL/blob/ultra-v3/nemo_rl/algorithms/loss_functions.py#L1152)

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
