### PR TITLE
fix: pass tools through preference preprocessor

### DIFF
--- a/nemo_rl/data/processors.py
+++ b/nemo_rl/data/processors.py
@@ -265,10 +265,16 @@ def preference_preprocessor(
     messages_rejected = datum_dict["context"] + rejected_completion["completion"]
 
     message_log_chosen = get_formatted_message_log(
-        messages_chosen, tokenizer, task_data_spec
+        messages_chosen,
+        tokenizer,
+        task_data_spec,
+        tools=datum_dict.get("tools", None),  # Pass tools from data if present
     )
     message_log_rejected = get_formatted_message_log(
-        messages_rejected, tokenizer, task_data_spec
+        messages_rejected,
+        tokenizer,
+        task_data_spec,
+        tools=datum_dict.get("tools", None),  # Pass tools from data if present
     )
 
     length_chosen = sum(len(m["token_ids"]) for m in message_log_chosen)


### PR DESCRIPTION
# What does this PR do ?

Pass per-example tools from preference data into chat-template formatting for both chosen and rejected preference responses.

# Issues
N/A


# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
No new tests were added. This is a narrow parity change with the existing SFT processor behavior.

# Additional Information
* Mirrors the existing `sft_processor behavior by` passing `tools=datum_dict.get("tools", None)` to `get_formatted_message_log`.
