### PR TITLE
fix: honor NeMo Gym's mask_sample in the Gym rollout path

### DIFF
--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -400,17 +400,36 @@ Output prompt token IDs: {output_item_dict["prompt_token_ids"]}
 
         if not nemo_rl_message_log:
             input_messages = nemo_gym_result["responses_create_params"]["input"]
-            prompt_token_ids = tokenizer.apply_chat_template(
-                input_messages, tokenize=True
-            )
-            raise ValueError(
-                f"NeMo Gym returned a result with no generation data. "
-                f"This typically means the prompt for the first turn already exceeds the vLLM max_model_len, "
-                f"so vLLM rejected the request before any tokens could be generated.\n"
-                f"  Prompt length: {len(prompt_token_ids)} tokens.\n"
-                f"  → Fix: increase `policy.max_total_sequence_length` and `policy.generation.vllm_cfg.max_model_len` "
-                f"to a value larger than {len(prompt_token_ids)}."
-            )
+            if nemo_gym_result.get("mask_sample"):
+                # A masked rollout (unreliable reward: agent/eval timeout, OOM
+                # kill, failed trace capture) may legitimately carry no
+                # token-annotated generations. Its loss multiplier is zeroed
+                # downstream, so emit a prompt-only message log to keep
+                # tensorization working instead of failing the batch.
+                prompt_token_ids = (
+                    tokenizer.apply_chat_template(input_messages, tokenize=True)
+                    if input_messages
+                    else []
+                ) or [tokenizer.eos_token_id or 0]
+                nemo_rl_message_log.append(
+                    {
+                        "role": "user",
+                        "content": "",
+                        "token_ids": torch.tensor(prompt_token_ids),
+                    }
+                )
+            else:
+                prompt_token_ids = tokenizer.apply_chat_template(
+                    input_messages, tokenize=True
+                )
+                raise ValueError(
+                    f"NeMo Gym returned a result with no generation data. "
+                    f"This typically means the prompt for the first turn already exceeds the vLLM max_model_len, "
+                    f"so vLLM rejected the request before any tokens could be generated.\n"
+                    f"  Prompt length: {len(prompt_token_ids)} tokens.\n"
+                    f"  → Fix: increase `policy.max_total_sequence_length` and `policy.generation.vllm_cfg.max_model_len` "
+                    f"to a value larger than {len(prompt_token_ids)}."
+                )
 
         return {
             "message_log": nemo_rl_message_log,

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -1394,6 +1394,16 @@ def run_async_nemo_gym_rollout(
     )
     input_ids = batched_flat["token_ids"]
 
+    # Honor NeMo Gym's sample mask: agent servers set `mask_sample` on the
+    # verify response when a rollout's reward is unreliable (agent/eval
+    # timeout, OOM-killed container, failed trace capture). Zero the loss
+    # multiplier so the sample drops out of the gradient, mirroring the
+    # truncated-sample handling.
+    loss_multiplier = input_batch["loss_multiplier"].clone()
+    masked_samples = [bool(r["full_result"].get("mask_sample")) for r in results]
+    if any(masked_samples):
+        loss_multiplier[torch.tensor(masked_samples, dtype=torch.bool)] = 0
+
     final_batch = BatchedDataDict[DatumSpec](
         {
             "agent_ref": [r["agent_ref"] for r in results],
@@ -1402,7 +1412,7 @@ def run_async_nemo_gym_rollout(
             "length": torch.tensor(
                 [len(r["input_message_log"][0]["token_ids"]) for r in results]
             ),
-            "loss_multiplier": input_batch["loss_multiplier"],
+            "loss_multiplier": loss_multiplier,
             # Unnecessary parts of the DatumSpec unused by the GRPO algorithm
             # extra_env_info: dict[str, Any]
             # idx: int

--- a/tests/unit/environments/test_nemo_gym.py
+++ b/tests/unit/environments/test_nemo_gym.py
@@ -223,6 +223,67 @@ def test_nemo_gym_postprocess_uses_batch_decode():
     assert nemo_gym_result["response"]["output"][1]["generation_str"] == "6 7"
 
 
+class _MaskTokenizer:
+    eos_token_id = 99
+
+    def batch_decode(self, batch):
+        return [" ".join(map(str, token_ids)) for token_ids in batch]
+
+    def apply_chat_template(self, messages, tokenize=True):
+        return [11, 12]
+
+
+def test_nemo_gym_postprocess_masked_rollout_without_generations():
+    """Masked rollouts (unreliable reward) may carry no token-annotated items —
+    e.g. a failed trace capture. They must convert to a prompt-only message log
+    instead of raising; the sample's loss multiplier is zeroed downstream."""
+
+    class _MockSelf:
+        cfg = {}
+
+    nemo_gym_result = {
+        "mask_sample": True,
+        "response": {"output": [{"type": "message"}]},
+        "responses_create_params": {"input": [{"role": "user", "content": "hi"}]},
+    }
+
+    result = (
+        NemoGym.__ray_metadata__.modified_class._postprocess_nemo_gym_to_nemo_rl_result(
+            _MockSelf(), nemo_gym_result, _MaskTokenizer()
+        )
+    )
+    assert [m["role"] for m in result["message_log"]] == ["user"]
+    assert result["message_log"][0]["token_ids"].tolist() == [11, 12]
+
+    # An empty input prompt still yields a non-empty token_ids tensor.
+    nemo_gym_result_empty_input = {
+        "mask_sample": True,
+        "response": {"output": []},
+        "responses_create_params": {"input": []},
+    }
+    result = (
+        NemoGym.__ray_metadata__.modified_class._postprocess_nemo_gym_to_nemo_rl_result(
+            _MockSelf(), nemo_gym_result_empty_input, _MaskTokenizer()
+        )
+    )
+    assert result["message_log"][0]["token_ids"].tolist() == [99]
+
+
+def test_nemo_gym_postprocess_unmasked_rollout_without_generations_raises():
+    class _MockSelf:
+        cfg = {}
+
+    nemo_gym_result = {
+        "response": {"output": []},
+        "responses_create_params": {"input": [{"role": "user", "content": "hi"}]},
+    }
+
+    with pytest.raises(ValueError, match="no generation data"):
+        NemoGym.__ray_metadata__.modified_class._postprocess_nemo_gym_to_nemo_rl_result(
+            _MockSelf(), nemo_gym_result, _MaskTokenizer()
+        )
+
+
 @pytest.mark.nemo_gym
 def test_nemo_gym_sanity(
     nemo_gym,


### PR DESCRIPTION
# What does this PR do ?

**Honors NeMo Gym's `mask_sample` signal in the Gym rollout path so rollouts with unreliable rewards are excluded from the gradient instead of trained on (or crashing the step).**

Gym agent servers (e.g. `swe_agents`, `anyterminal_agent`) set `mask_sample: true` on the verify response when a rollout's reward is unreliable — agent/eval timeout, OOM-killed container, failed token-trace capture — and document the contract as "downstream RL drops the gradient for this rollout." Nothing in NeMo RL consumed it, so today:

- masked rollouts **train anyway** with garbage rewards contaminating GRPO group advantages — the worst sub-case being `reward=1.0` accidental resolves (patch passed but the agent died on max-iteration/context-window) reinforced as positives;
- a masked rollout carrying **no token-annotated generations** (e.g. a failed trace capture on the Gym↔Switchyard path) raises `ValueError` in `_postprocess_nemo_gym_to_nemo_rl_result` and fails the whole rollout batch.

Changes (both mirror existing conventions):

- `run_async_nemo_gym_rollout` zeroes the sample's `loss_multiplier` when `full_result["mask_sample"]` is truthy — the same mechanism used for truncated samples (`loss_multiplier[truncated] = 0`).
- The converter emits a prompt-only message log for **masked** rollouts with no generations, so tensorization proceeds and the zeroed loss multiplier excludes the sample; **unmasked** empty rollouts still raise the existing actionable `ValueError`.

Producer side: NeMo Gym promotes `mask_sample` to a top-level `BaseVerifyResponse` field (NVIDIA-NeMo/Gym#2026), so it also lands in the per-agent auto-aggregated metrics (`rollouts.py` scalar aggregation) — masked-sample rates become visible in training metrics for free.

# Issues

None filed; found while validating the Gym↔Switchyard token-capture integration end-to-end (NVIDIA-NeMo/Gym#2026).

# Usage

No API change. Any Gym rollout whose verify response carries `mask_sample: true` is now excluded from the gradient:

```python
# Gym agent server (producer side)
return MyVerifyResponse(..., reward=reward, mask_sample=True)  # unreliable reward
# → NeMo RL zeroes that sample's loss_multiplier; no training signal from it.
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? (`test_nemo_gym_postprocess_masked_rollout_without_generations`, `test_nemo_gym_postprocess_unmasked_rollout_without_generations_raises`)
- [x] Did you run the unit tests and functional tests locally? (converter paths + loss-multiplier zeroing exercised directly on CPU; `ruff@0.9.9 check`/`format` clean)
- [ ] Did you add or update any necessary documentation?

# Additional Information

The end-to-end verification that surfaced this: Switchyard token capture → Gym rollout reconstruction → this converter → GRPO tensors, with the masked-sample and non-contiguous-token failure modes reproduced against real code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)