### PR TITLE
test: increase NUM_MINUTES to 85 for grpo-nanov3-30BA3B-2n8g-fsdp2-lora

### DIFF
--- a/tests/test_suites/llm/grpo-nanov3-30BA3B-2n8g-fsdp2-lora.sh
+++ b/tests/test_suites/llm/grpo-nanov3-30BA3B-2n8g-fsdp2-lora.sh
@@ -8,7 +8,7 @@ GPUS_PER_NODE=8
 STEPS_PER_RUN=10
 MAX_STEPS=10
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
-NUM_MINUTES=70
+NUM_MINUTES=85
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached


### PR DESCRIPTION
## Summary
- Increases `NUM_MINUTES` from 70 → 85 in the GRPO NanoV3 30B/3B 2-node 8-GPU FSDP2 LoRA test to give the job more time to complete.
