### PR TITLE
feat: add phase timing markers to ray.sub for diagnosing startup stalls

### DIFF
--- a/ray.sub
+++ b/ray.sub
@@ -28,6 +28,28 @@ set -eoux pipefail
 export NRL_JOB_START_EPOCH=$(date +%s.%N)
 
 ########################################################
+# Diagnostic phase logging
+#
+# ray.sub makes several blocking calls that reach the SLURM controller
+# (sinfo/scontrol/srun) and imports a multi-GB container image before Ray is up.
+# When any of those stall -- e.g. an overloaded/DDoS'd controller, a slow prolog,
+# or contended shared storage -- a bare `set -x` trace has no timestamps, so it is
+# impossible to tell from the logs *where* the wall-clock actually went.
+#
+# `log_phase` stamps an ISO wall-clock time plus seconds-since-job-start at each
+# phase boundary so a slowdown can be localized after the fact. Subtract the
+# elapsed counters of two adjacent markers to get that phase's duration. Keep
+# these coarse (phase boundaries, not per-command) so the trace stays readable.
+########################################################
+log_phase() {
+  echo "[NRL_PHASE][$(date '+%Y-%m-%dT%H:%M:%S%z')][+$(( $(date +%s) - ${NRL_JOB_START_EPOCH%.*} ))s] $*"
+}
+# The gap between the job's SLURM StartTime (from `sacct`/`scontrol show job`) and
+# this first marker is time spent in prolog/allocation/node-prep *before* the
+# script ran -- i.e. not attributable to anything in ray.sub itself.
+log_phase "ray.sub entry (job=${SLURM_JOB_ID:-?} nodes=${SLURM_JOB_NUM_NODES:-?} partition=${SLURM_JOB_PARTITION:-?} node=$(hostname)); compare to SLURM StartTime to measure pre-script prolog/allocation overhead"
+
+########################################################
 # Function to detect if SLURM cluster uses GRES
 ########################################################
 maybe_gres_arg() {
@@ -209,6 +231,7 @@ fi
 GPUS_PER_NODE=${GPUS_PER_NODE:-8}
 
 # Detect GRES support and set GRES_ARG
+log_phase "detecting GRES support (sinfo -> SLURM controller RPC; can stall if the controller is overloaded)"
 GRES_ARG=$(maybe_gres_arg)
 if [[ -n "$GRES_ARG" ]]; then
   echo "[INFO] GRES support detected. Using: $GRES_ARG"
@@ -233,6 +256,7 @@ COMMON_SRUN_ARGS+=" -A $SLURM_JOB_ACCOUNT"
 if [[ -n "${CPUS_PER_WORKER:-}" ]]; then
   echo "[INFO] Using user-provided CPUS_PER_WORKER=$CPUS_PER_WORKER."
 else
+  log_phase "auto-detecting CPUs per node (scontrol show node -> SLURM controller RPC)"
   CPUS_PER_WORKER=$(detect_cpus_per_node)
   echo "[INFO] Auto-detected CPUS_PER_WORKER=$CPUS_PER_WORKER from SLURM (CPUTot of first allocated node)."
 fi
@@ -328,6 +352,7 @@ nodes=$(scontrol show hostnames "$SLURM_JOB_NODELIST")
 nodes_array=($nodes)
 ip_addresses_array=()
 
+log_phase "resolving ${#nodes_array[@]} node hostname(s) to IPs (DNS: host/getent/nslookup/ping)"
 for node in $nodes; do
     # Try multiple methods to get IP address - ENHANCED VERSION v2.0
     echo "[DEBUG] Resolving hostname: $node using enhanced resolution methods"
@@ -662,10 +687,10 @@ if [[ -n "$DRIVER_COMMAND_FILE" ]]; then
   while true; do
     if [[ "\$workers_ready" -eq 0 ]]; then
       worker_units=\$(ray status 2>/dev/null | grep "worker_units" | awk -F'[/. ]' '{print \$4}' || echo 0)
-      echo "[INFO] Number of actors online: \$worker_units/$NUM_ACTORS"
+      echo "[INFO][\$(date '+%Y-%m-%dT%H:%M:%S%z')] Number of actors online: \$worker_units/$NUM_ACTORS"
       if [[ "\$worker_units" -eq "$NUM_ACTORS" ]]; then
         workers_ready=1
-        echo "All workers connected!"
+        echo "[INFO][\$(date '+%Y-%m-%dT%H:%M:%S%z')] All workers connected!"
       fi
     fi
     if [[ "\$sandbox_ready" -eq 0 ]]; then
@@ -811,7 +836,7 @@ while [[ \$count -lt $WORKER_NUM_RETRIES ]]; do
     echo "[INFO] Running setup command from $SETUP_COMMAND_FILE..."
     bash "$SETUP_COMMAND_FILE"
   fi
-  echo "[INFO] Worker \$SLURM_PROCID: starting Ray worker (attempt \$((count+1))/$WORKER_NUM_RETRIES)..."
+  echo "[INFO][\$(date '+%Y-%m-%dT%H:%M:%S%z')] Worker \$SLURM_PROCID: starting Ray worker (attempt \$((count+1))/$WORKER_NUM_RETRIES)..."
   cat <<EOFINNER | bash
 ray start --address "$ip_head" \
           --disable-usage-stats \
@@ -904,6 +929,7 @@ else
 fi
 
 # Start the Ray head.
+log_phase "launching Ray head + worker sruns (first container use triggers the enroot image import on each node; a slow import shows up as a gap before the next marker / STARTED_RAY_HEAD)"
 srun $COMMON_SRUN_ARGS --container-name=ray-head --nodes=1 --ntasks=1 --cpus-per-task=$CPUS_PER_WORKER -w "$head_node" -o $LOG_DIR/ray-head.log bash -x -c "$head_cmd" &
 SRUN_PIDS["ray-head"]=$!
 
@@ -936,6 +962,7 @@ while check_srun_processes && ! test -f "$LOG_DIR/STARTED_RAY_HEAD"; do
   echo "[INFO][$(date)] Waiting for Ray head GCS to be ready..."
   sleep 2
 done
+log_phase "Ray head GCS is up (STARTED_RAY_HEAD observed); handing off to worker/driver wait"
 
 if [[ -n "$COMMAND" ]]; then
   # Non-interactive: the head container polls for workers, gates on sandbox

--- a/ray.sub
+++ b/ray.sub
@@ -27,34 +27,13 @@ set -eoux pipefail
 # Record job-start epoch so Python can measure pre-Python overhead
 export NRL_JOB_START_EPOCH=$(date +%s.%N)
 
-########################################################
-# Diagnostic phase logging
-#
-# ray.sub makes several blocking calls that reach the SLURM controller
-# (sinfo/scontrol/srun) and imports a multi-GB container image before Ray is up.
-# When any of those stall -- e.g. an overloaded/DDoS'd controller, a slow prolog,
-# or contended shared storage -- a bare `set -x` trace has no timestamps, so it is
-# impossible to tell from the logs *where* the wall-clock actually went.
-#
-# `log_phase` stamps an ISO wall-clock time plus seconds-since-job-start at each
-# phase boundary so a slowdown can be localized after the fact. Subtract the
-# elapsed counters of two adjacent markers to get that phase's duration. Keep
-# these coarse (phase boundaries, not per-command) so the trace stays readable.
-########################################################
+# Log a timestamped, seconds-since-job-start marker at each phase boundary.
 log_phase() {
   echo "[NRL_PHASE][$(date '+%Y-%m-%dT%H:%M:%S%z')][+$(( $(date +%s) - ${NRL_JOB_START_EPOCH%.*} ))s] $*"
 }
-# The gap between the job's SLURM StartTime (from `sacct`/`scontrol show job`) and
-# this first marker is time spent in prolog/allocation/node-prep *before* the
-# script ran -- i.e. not attributable to anything in ray.sub itself.
 log_phase "ray.sub started (job=${SLURM_JOB_ID:-?} nodes=${SLURM_JOB_NUM_NODES:-?} partition=${SLURM_JOB_PARTITION:-?} node=$(hostname))"
 
-# Bookend the script so post-script teardown (SLURM epilog, enroot container
-# cleanup, GPU reset) is measurable: (job SLURM EndTime - this final marker) is
-# the epilog/teardown overhead, symmetric to (first marker - StartTime) = prolog.
-# Trap TERM/HUP/INT as well as EXIT so a time-limit kill or `scancel` is stamped
-# too -- a bare EXIT trap does NOT fire on an uncaught signal. `trap - EXIT`
-# inside prevents a double log when the handler's own `exit` re-triggers EXIT.
+# Log a final marker on exit; trap TERM/HUP/INT too so a scancel/time-limit kill is still stamped.
 _nrl_log_exit() { local rc=$?; trap - EXIT; log_phase "ray.sub exiting (exit_code=$rc)"; exit $rc; }
 trap _nrl_log_exit EXIT TERM HUP INT
 
@@ -554,12 +533,8 @@ if [[ ! -f "$LOG_DIR/.shared_fs_canary" ]]; then
   exit 1
 fi
 
-# Diagnostic phase markers inside the head container. Reuse the job-start epoch
-# propagated from the submit host so the elapsed counter lines up with the
-# submit-side [NRL_PHASE] markers -- together they form one end-to-end timeline.
-# This first marker fires once the container is actually executing, so the gap
-# from the submit-side "launching Ray head + worker sruns" marker to here is the
-# enroot image import time.
+# Phase markers inside the container; reuse the propagated job-start epoch so the
+# elapsed counter shares the submit-side timeline.
 log_phase() { local t0="\${NRL_JOB_START_EPOCH:-0}"; echo "[NRL_PHASE][\$(date '+%Y-%m-%dT%H:%M:%S%z')][+\$(( \$(date +%s) - \${t0%.*} ))s] \$*"; }
 log_phase "head container started on \$(hostname)"
 
@@ -772,10 +747,7 @@ if [[ ! -f "$LOG_DIR/.shared_fs_canary" ]]; then
   exit 1
 fi
 
-# Diagnostic phase markers inside the worker container (see the head container for
-# the rationale). Reuses the propagated job-start epoch so the elapsed counter is
-# comparable to the submit-side and head-side [NRL_PHASE] markers. The gap from the
-# submit-side srun-launch marker to here is this worker's enroot image import time.
+# Phase markers inside the container (see head container).
 log_phase() { local t0="\${NRL_JOB_START_EPOCH:-0}"; echo "[NRL_PHASE][\$(date '+%Y-%m-%dT%H:%M:%S%z')][+\$(( \$(date +%s) - \${t0%.*} ))s] \$*"; }
 log_phase "worker \$SLURM_PROCID container started on \$(hostname)"
 

--- a/ray.sub
+++ b/ray.sub
@@ -544,6 +544,15 @@ if [[ ! -f "$LOG_DIR/.shared_fs_canary" ]]; then
   exit 1
 fi
 
+# Diagnostic phase markers inside the head container. Reuse the job-start epoch
+# propagated from the submit host so the elapsed counter lines up with the
+# submit-side [NRL_PHASE] markers -- together they form one end-to-end timeline.
+# This first marker fires once the container is actually executing, so the gap
+# from the submit-side "launching Ray head + worker sruns" marker to here is the
+# enroot image import time.
+log_phase() { local t0="\${NRL_JOB_START_EPOCH:-0}"; echo "[NRL_PHASE][\$(date '+%Y-%m-%dT%H:%M:%S%z')][+\$(( \$(date +%s) - \${t0%.*} ))s] \$*"; }
+log_phase "head container started on \$(hostname) (enroot image import complete)"
+
 exit-dramatically() {
     # Use SIGTERM to forcefully terminate the srun process
     pkill -P $$ || true
@@ -624,6 +633,7 @@ source $LOG_DIR/topology_probe.sh
 # GCS is listening, so we touch STARTED_RAY_HEAD only after the head is actually up.
 # Workers gate on that file, so they only try to connect once the GCS is accepting
 # connections.
+log_phase "head: starting Ray head (ray start --head)"
 count=0
 while [[ \$count -lt $num_retries ]]; do
   # Clean up stale Ray state before every attempt. A timed-out attempt leaves a
@@ -671,6 +681,7 @@ fi
 
 # Signal workers and the submit host that the Ray head GCS is now listening.
 touch $LOG_DIR/STARTED_RAY_HEAD
+log_phase "head: Ray GCS listening (STARTED_RAY_HEAD written)"
 
 if [[ -n "$DRIVER_COMMAND_FILE" ]]; then
   # Non-interactive: wait for all workers to connect and, if a sandbox is
@@ -721,6 +732,7 @@ if [[ -n "$DRIVER_COMMAND_FILE" ]]; then
   # and training process can measure post-ready initialization timing.
   export NRL_RAY_READY_EPOCH=\$(date +%s.%N)
 
+  log_phase "head: cluster ready, launching driver command"
   set +e
   bash "$DRIVER_COMMAND_FILE" > "$LOG_DIR/ray-driver.log" 2>&1
   exit_code=\$?
@@ -749,6 +761,13 @@ if [[ ! -f "$LOG_DIR/.shared_fs_canary" ]]; then
   echo "[ERROR] Worker \$SLURM_PROCID: $LOG_DIR/.shared_fs_canary not visible; LOG_DIR must be on a shared filesystem." >&2
   exit 1
 fi
+
+# Diagnostic phase markers inside the worker container (see the head container for
+# the rationale). Reuses the propagated job-start epoch so the elapsed counter is
+# comparable to the submit-side and head-side [NRL_PHASE] markers. The gap from the
+# submit-side srun-launch marker to here is this worker's enroot image import time.
+log_phase() { local t0="\${NRL_JOB_START_EPOCH:-0}"; echo "[NRL_PHASE][\$(date '+%Y-%m-%dT%H:%M:%S%z')][+\$(( \$(date +%s) - \${t0%.*} ))s] \$*"; }
+log_phase "worker \$SLURM_PROCID container started on \$(hostname) (enroot image import complete)"
 
 exit-dramatically() {
     # Use SIGTERM to forcefully terminate the srun process
@@ -811,7 +830,7 @@ source $LOG_DIR/topology_probe.sh
 echo "[INFO] Worker \$SLURM_PROCID: waiting for Ray head GCS to be ready..."
 while true; do
   if [[ -f "$LOG_DIR/STARTED_RAY_HEAD" ]]; then
-    echo "[INFO] Worker \$SLURM_PROCID: Ray head GCS is ready, connecting."
+    log_phase "worker \$SLURM_PROCID: head GCS ready (STARTED_RAY_HEAD observed), connecting"
     break
   fi
   if [[ -f "$LOG_DIR/ENDED" ]]; then

--- a/ray.sub
+++ b/ray.sub
@@ -47,7 +47,16 @@ log_phase() {
 # The gap between the job's SLURM StartTime (from `sacct`/`scontrol show job`) and
 # this first marker is time spent in prolog/allocation/node-prep *before* the
 # script ran -- i.e. not attributable to anything in ray.sub itself.
-log_phase "ray.sub entry (job=${SLURM_JOB_ID:-?} nodes=${SLURM_JOB_NUM_NODES:-?} partition=${SLURM_JOB_PARTITION:-?} node=$(hostname)); compare to SLURM StartTime to measure pre-script prolog/allocation overhead"
+log_phase "ray.sub started (job=${SLURM_JOB_ID:-?} nodes=${SLURM_JOB_NUM_NODES:-?} partition=${SLURM_JOB_PARTITION:-?} node=$(hostname))"
+
+# Bookend the script so post-script teardown (SLURM epilog, enroot container
+# cleanup, GPU reset) is measurable: (job SLURM EndTime - this final marker) is
+# the epilog/teardown overhead, symmetric to (first marker - StartTime) = prolog.
+# Trap TERM/HUP/INT as well as EXIT so a time-limit kill or `scancel` is stamped
+# too -- a bare EXIT trap does NOT fire on an uncaught signal. `trap - EXIT`
+# inside prevents a double log when the handler's own `exit` re-triggers EXIT.
+_nrl_log_exit() { local rc=$?; trap - EXIT; log_phase "ray.sub exiting (exit_code=$rc)"; exit $rc; }
+trap _nrl_log_exit EXIT TERM HUP INT
 
 ########################################################
 # Function to detect if SLURM cluster uses GRES
@@ -208,6 +217,7 @@ mkdir -p $LOG_DIR
 # containers check at startup: a node that can't see it isn't on the shared FS, so
 # we fail there immediately instead of hanging on signal files that never appear.
 echo "$SLURM_JOB_ID" > "$LOG_DIR/.shared_fs_canary"
+log_phase "shared-FS log dir ready ($LOG_DIR)"
 
 # Write setup commands to a file so they can be executed inside each container
 # without heredoc escaping surprises.
@@ -231,7 +241,7 @@ fi
 GPUS_PER_NODE=${GPUS_PER_NODE:-8}
 
 # Detect GRES support and set GRES_ARG
-log_phase "detecting GRES support (sinfo -> SLURM controller RPC; can stall if the controller is overloaded)"
+log_phase "detecting GRES support (sinfo)"
 GRES_ARG=$(maybe_gres_arg)
 if [[ -n "$GRES_ARG" ]]; then
   echo "[INFO] GRES support detected. Using: $GRES_ARG"
@@ -256,7 +266,7 @@ COMMON_SRUN_ARGS+=" -A $SLURM_JOB_ACCOUNT"
 if [[ -n "${CPUS_PER_WORKER:-}" ]]; then
   echo "[INFO] Using user-provided CPUS_PER_WORKER=$CPUS_PER_WORKER."
 else
-  log_phase "auto-detecting CPUs per node (scontrol show node -> SLURM controller RPC)"
+  log_phase "auto-detecting CPUs per node (scontrol show node)"
   CPUS_PER_WORKER=$(detect_cpus_per_node)
   echo "[INFO] Auto-detected CPUS_PER_WORKER=$CPUS_PER_WORKER from SLURM (CPUTot of first allocated node)."
 fi
@@ -352,7 +362,7 @@ nodes=$(scontrol show hostnames "$SLURM_JOB_NODELIST")
 nodes_array=($nodes)
 ip_addresses_array=()
 
-log_phase "resolving ${#nodes_array[@]} node hostname(s) to IPs (DNS: host/getent/nslookup/ping)"
+log_phase "resolving ${#nodes_array[@]} node hostname(s) to IPs"
 for node in $nodes; do
     # Try multiple methods to get IP address - ENHANCED VERSION v2.0
     echo "[DEBUG] Resolving hostname: $node using enhanced resolution methods"
@@ -551,7 +561,7 @@ fi
 # from the submit-side "launching Ray head + worker sruns" marker to here is the
 # enroot image import time.
 log_phase() { local t0="\${NRL_JOB_START_EPOCH:-0}"; echo "[NRL_PHASE][\$(date '+%Y-%m-%dT%H:%M:%S%z')][+\$(( \$(date +%s) - \${t0%.*} ))s] \$*"; }
-log_phase "head container started on \$(hostname) (enroot image import complete)"
+log_phase "head container started on \$(hostname)"
 
 exit-dramatically() {
     # Use SIGTERM to forcefully terminate the srun process
@@ -633,7 +643,7 @@ source $LOG_DIR/topology_probe.sh
 # GCS is listening, so we touch STARTED_RAY_HEAD only after the head is actually up.
 # Workers gate on that file, so they only try to connect once the GCS is accepting
 # connections.
-log_phase "head: starting Ray head (ray start --head)"
+log_phase "head: starting Ray head"
 count=0
 while [[ \$count -lt $num_retries ]]; do
   # Clean up stale Ray state before every attempt. A timed-out attempt leaves a
@@ -706,10 +716,10 @@ if [[ -n "$DRIVER_COMMAND_FILE" ]]; then
     fi
     if [[ "\$sandbox_ready" -eq 0 ]]; then
       ready_count=\$(ls -1 "$SANDBOX_PORTS_DIR"/SANDBOX_READY_* 2>/dev/null | wc -l)
-      echo "[INFO] Sandbox ready on \$ready_count/$SLURM_JOB_NUM_NODES nodes..."
+      echo "[INFO][\$(date '+%Y-%m-%dT%H:%M:%S%z')] Sandbox ready on \$ready_count/$SLURM_JOB_NUM_NODES nodes..."
       if [[ "\$ready_count" -ge "$SLURM_JOB_NUM_NODES" ]]; then
         sandbox_ready=1
-        echo "[INFO] All $SLURM_JOB_NUM_NODES sandbox instances ready."
+        echo "[INFO][\$(date '+%Y-%m-%dT%H:%M:%S%z')] All $SLURM_JOB_NUM_NODES sandbox instances ready."
       fi
     fi
     if [[ "\$workers_ready" -eq 1 ]] && [[ "\$sandbox_ready" -eq 1 ]]; then
@@ -732,7 +742,7 @@ if [[ -n "$DRIVER_COMMAND_FILE" ]]; then
   # and training process can measure post-ready initialization timing.
   export NRL_RAY_READY_EPOCH=\$(date +%s.%N)
 
-  log_phase "head: cluster ready, launching driver command"
+  log_phase "head: cluster ready, launching driver"
   set +e
   bash "$DRIVER_COMMAND_FILE" > "$LOG_DIR/ray-driver.log" 2>&1
   exit_code=\$?
@@ -767,7 +777,7 @@ fi
 # comparable to the submit-side and head-side [NRL_PHASE] markers. The gap from the
 # submit-side srun-launch marker to here is this worker's enroot image import time.
 log_phase() { local t0="\${NRL_JOB_START_EPOCH:-0}"; echo "[NRL_PHASE][\$(date '+%Y-%m-%dT%H:%M:%S%z')][+\$(( \$(date +%s) - \${t0%.*} ))s] \$*"; }
-log_phase "worker \$SLURM_PROCID container started on \$(hostname) (enroot image import complete)"
+log_phase "worker \$SLURM_PROCID container started on \$(hostname)"
 
 exit-dramatically() {
     # Use SIGTERM to forcefully terminate the srun process
@@ -830,7 +840,7 @@ source $LOG_DIR/topology_probe.sh
 echo "[INFO] Worker \$SLURM_PROCID: waiting for Ray head GCS to be ready..."
 while true; do
   if [[ -f "$LOG_DIR/STARTED_RAY_HEAD" ]]; then
-    log_phase "worker \$SLURM_PROCID: head GCS ready (STARTED_RAY_HEAD observed), connecting"
+    log_phase "worker \$SLURM_PROCID connecting to Ray head"
     break
   fi
   if [[ -f "$LOG_DIR/ENDED" ]]; then
@@ -948,7 +958,7 @@ else
 fi
 
 # Start the Ray head.
-log_phase "launching Ray head + worker sruns (first container use triggers the enroot image import on each node; a slow import shows up as a gap before the next marker / STARTED_RAY_HEAD)"
+log_phase "launching Ray head + worker sruns"
 srun $COMMON_SRUN_ARGS --container-name=ray-head --nodes=1 --ntasks=1 --cpus-per-task=$CPUS_PER_WORKER -w "$head_node" -o $LOG_DIR/ray-head.log bash -x -c "$head_cmd" &
 SRUN_PIDS["ray-head"]=$!
 
@@ -981,7 +991,7 @@ while check_srun_processes && ! test -f "$LOG_DIR/STARTED_RAY_HEAD"; do
   echo "[INFO][$(date)] Waiting for Ray head GCS to be ready..."
   sleep 2
 done
-log_phase "Ray head GCS is up (STARTED_RAY_HEAD observed); handing off to worker/driver wait"
+log_phase "Ray head GCS up (STARTED_RAY_HEAD observed)"
 
 if [[ -n "$COMMAND" ]]; then
   # Non-interactive: the head container polls for workers, gates on sandbox
@@ -1014,7 +1024,7 @@ else
   RAY_STATUS_DEADLINE=$((SECONDS + 1800))
   while true; do
     worker_units=$(cat "$LOG_DIR/ray_worker_units" 2>/dev/null || echo -1)
-    echo "[INFO] Number of actors online: $worker_units/$NUM_ACTORS"
+    echo "[INFO][$(date '+%Y-%m-%dT%H:%M:%S%z')] Number of actors online: $worker_units/$NUM_ACTORS"
     if [[ "$worker_units" -eq "$NUM_ACTORS" ]]; then
       break
     fi
@@ -1027,8 +1037,9 @@ else
     sleep 5
   done
 
-  echo "All workers connected!"
+  echo "[INFO][$(date '+%Y-%m-%dT%H:%M:%S%z')] All workers connected!"
 
+  log_phase "generating attach helper (scontrol show job)"
   CONTAINER_CWD=$(scontrol show job $SLURM_JOB_ID | grep -oP 'WorkDir=\K[^ ]+' | head -1)
   echo "[INFO]: Ray Cluster is idled, run this on the slurm head node to get a shell to the head node:"
   cat <<EOF >$SLURM_SUBMIT_DIR/${SLURM_JOB_ID}-attach.sh


### PR DESCRIPTION
# What does this PR do ?

Adds coarse, timestamped phase markers to `ray.sub` so that startup/teardown stalls (before Ray, and after the driver) can be localized from the job log.

Motivation: a recent run burned ~20 min of a fixed wall-clock budget *before* the training driver even started, and it was impossible to tell from the log where that time went — `ray.sub` runs with `set -x`, but the xtrace has no timestamps, and the slow region was a mix of pre-script SLURM launch (prolog/allocation), controller RPCs (`sinfo`/`scontrol`), DNS resolution, and container image import. None of those were individually attributable after the fact.

This adds a `log_phase` helper that stamps an ISO wall-clock time **plus seconds-since-job-start**, called at the key phase boundaries on the submit host and inside the head/worker containers. Subtract two adjacent markers' elapsed counters to get that phase's duration. The timeline is bookended so the two things `ray.sub` can't see itself are still measurable:

- **prolog/allocation** = `first marker − SLURM StartTime`
- **epilog/teardown** = `SLURM EndTime − last marker` (via a `trap … EXIT TERM HUP INT`, so a time-limit kill / `scancel` is stamped too — a bare `EXIT` trap doesn't fire on an uncaught signal)

Markers — submit host: `ray.sub started` · shared-FS log dir ready · GRES (`sinfo`) · CPU (`scontrol show node`) · node→IP resolution · `srun` launch · Ray head GCS up · attach-helper (`scontrol show job`, interactive path) · `ray.sub exiting` (trap).
Inside the containers (reuse the propagated `NRL_JOB_START_EPOCH` so all counters share one timeline): head — container started / starting ray head / GCS listening / cluster ready, launching driver / worker-join poll / sandbox-readiness poll. worker — container started / connecting / per-attempt ray start.

Kept deliberately coarse (phase boundaries, not per-command); the rationale (which op is a controller RPC, where image import happens, etc.) lives in code comments, not the runtime log lines.

# Issues

None.

# Usage

`ray.sub` runs under `set -x`, so grep the timestamped form (`[NRL_PHASE][2…`) to skip the xtrace/definition lines:

```bash
grep -hE '\[NRL_PHASE\]\[2' slurm-*.out <jobid>-logs/ray-*.log | sort -t+ -k2 -n
```

## Example (from live 2-node validation runs)

SLURM `StartTime` was `…:12:39`. Merged submit + head + worker markers (node names genericized):

```
[NRL_PHASE][…:13:11][+0s]  ray.sub started (job=<id> nodes=2 partition=batch node=node-a)
[NRL_PHASE][…:13:11][+0s]  shared-FS log dir ready (/…/<id>-logs)
[NRL_PHASE][…:13:11][+0s]  detecting GRES support (sinfo)
[NRL_PHASE][…:13:12][+1s]  auto-detecting CPUs per node (scontrol show node)
[NRL_PHASE][…:13:13][+2s]  resolving 2 node hostname(s) to IPs
[NRL_PHASE][…:13:13][+2s]  launching Ray head + worker sruns
[NRL_PHASE][…:14:18][+67s] head container started on node-a
[NRL_PHASE][…:14:21][+70s] head: starting Ray head
[NRL_PHASE][…:14:22][+71s] worker 0 container started on node-b
[NRL_PHASE][…:14:34][+83s] head: Ray GCS listening (STARTED_RAY_HEAD written)
[NRL_PHASE][…:14:35][+84s] Ray head GCS up (STARTED_RAY_HEAD observed)
[NRL_PHASE][…:14:35][+84s] worker 0 connecting to Ray head
[NRL_PHASE][…:14:47][+96s] head: cluster ready, launching driver
        …driver runs…
[NRL_PHASE][…exit ][+…s]   ray.sub exiting (exit_code=0)   # last marker; EndTime − this = epilog
```

Reading phase durations straight off the counters:

| Phase | How to compute | Measured |
| --- | --- | --- |
| **prolog / allocation** (pre-script) | first marker − SLURM `StartTime` | **32 s** |
| GRES + CPU + DNS | `+2s` − `+0s` | ~2 s |
| **enroot image import** | `+67s` (head started) − `+2s` (srun launch) | **~65 s** |
| ray head bringup | `+83s` − `+70s` | ~13 s |
| worker registration | `+96s` − `+84s` | ~12 s |
| **epilog / teardown** (post-script) | SLURM `EndTime` − last marker | **~4 s** (from a `scancel` test) |

The point: in the incident that motivated this, a ~20-min gap was unattributable. It now lands unambiguously as **either** a large `StartTime → started` gap (prolog), **or** a large `srun launch → container started` gap (image import), **or** a large `exiting → EndTime` gap (epilog) — separated instead of hidden in an untimestamped trace.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests? (N/A — diagnostic log lines; `bash -n` validated the outer script + the heredoc-generated head/worker scripts, the exit-trap was unit-tested to fire on SIGTERM, and the whole thing was exercised end-to-end on live 2-node runs including a `scancel` to confirm the epilog marker)
- [x] Did you run the unit tests and functional tests locally? Live 2-node bringup + cancel; markers confirmed on submit host + both containers + on teardown.
- [ ] Did you add or update any necessary documentation? (N/A)

# Additional Information

- Only `ray.sub` changes; purely additive `echo`/`log_phase` lines plus a logging-only exit trap — no change to the launch path's behavior.
- `log_phase` reuses `NRL_JOB_START_EPOCH`; the container copies read it from the propagated env so all markers share one timeline.
- Because `ray.sub` runs under `set -x`, each marker also appears once as a `+ echo …` xtrace line; grep the `[NRL_PHASE][2…` timestamped form to get just the markers.
