### PR TITLE
cp: cherry-pick #3194 - fix: Fix mtp metrics scale and mtp grad norm logging

### DIFF
--- a/nemo_rl/models/megatron/common.py
+++ b/nemo_rl/models/megatron/common.py
@@ -167,10 +167,17 @@ def get_moe_metrics(
     return metrics
 
 
-def get_mtp_metrics() -> dict[str, Any]:
+def get_mtp_metrics(loss_scale: float = 1.0) -> dict[str, Any]:
     """Returns Multi-Token Prediction (MTP) loss and acceptance rate metrics.
 
     This function reduces MTP metrics across ranks and returns a dictionary of metrics.
+
+    Args:
+        loss_scale: Scale factor applied to each MTP layer's loss (e.g., 1/num_microbatches).
+            ``MTPLossLoggingHelper`` accumulates the per-microbatch loss across microbatches
+            without dividing, so callers must pass 1/num_microbatches to recover the mean
+            (mirroring ``get_moe_metrics``). Acceptance rate is a ratio of counts and is not
+            scaled. Defaults to 1.0.
 
     Returns:
         dict[str, Any]: A flat dict of metrics. Each MTP layer's loss is returned
@@ -182,7 +189,7 @@ def get_mtp_metrics() -> dict[str, Any]:
 
     metrics: dict[str, Any] = {}
     if "loss_values" in tracker:
-        mtp_losses = tracker["loss_values"].float()
+        mtp_losses = tracker["loss_values"].float() * loss_scale
         mtp_corrects = tracker.get("correct_values", torch.zeros_like(mtp_losses))
         mtp_totals = tracker.get("total_values", torch.ones_like(mtp_losses))
         mtp_num_layers = mtp_losses.shape[0]

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -702,8 +702,15 @@ class MegatronPolicyWorkerImpl(
                     update_successful, grad_norm, num_zeros_in_grad = (
                         self.optimizer.step()
                     )
+                    # Megatron-LM PR #4116 replaced the optimizer.mtp_grad_norm attribute
+                    # with a per-group dict populated during gradient clipping. Value is
+                    # None when clip_grad == 0 or this rank owns no MTP-tagged params
+                    # (MTP params are tagged only when mtp_detach_heads=True, on the last
+                    # pipeline stage). grad_norms_by_group always exists after step().
+                    mtp_grad_norm = self.optimizer.grad_norms_by_group.get("mtp")
                 else:
                     update_successful, grad_norm, num_zeros_in_grad = (True, 0.0, 0.0)
+                    mtp_grad_norm = None
 
                 pg_collection = get_pg_collection(self.model)
 
@@ -719,6 +726,11 @@ class MegatronPolicyWorkerImpl(
                 )
                 num_zeros_in_grad: float = reduce_max_stat_across_model_parallel_group(
                     num_zeros_in_grad, mp_group=pg_collection.mp
+                )
+                # Max-reduce across the model-parallel group so every rank (including
+                # non-last-PP-stage ranks, where it is None) has the MTP grad norm.
+                mtp_grad_norm = reduce_max_stat_across_model_parallel_group(
+                    mtp_grad_norm, mp_group=pg_collection.mp
                 )
                 if (
                     not eval_mode
@@ -815,7 +827,7 @@ class MegatronPolicyWorkerImpl(
                 metrics["moe_metrics"] = moe_metrics
         # Collect MTP metrics (kept out of train()'s body so cloudpickle does not
         # pull an unpicklable torch ConfigModuleInstance into the worker actor).
-        self._collect_mtp_metrics(metrics)
+        self._collect_mtp_metrics(metrics, total_num_microbatches, mtp_grad_norm)
         return metrics
 
     def _compute_moe_grad_scale(self, global_valid_toks):
@@ -1177,12 +1189,26 @@ class MegatronPolicyWorkerImpl(
 
         return refit_param_info_hf
 
-    def _collect_mtp_metrics(self, metrics: dict[str, Any]) -> None:
+    def _collect_mtp_metrics(
+        self,
+        metrics: dict[str, Any],
+        total_num_microbatches: int,
+        mtp_grad_norm: Optional[float],
+    ) -> None:
         """Add Multi-Token Prediction metrics to ``metrics`` when MTP is enabled.
 
         get_mtp_metrics is imported lazily (not a module global) so cloudpickle
         does not pull an unpicklable torch ConfigModuleInstance into the worker
         actor's serialization.
+
+        Args:
+            metrics: Metrics dict to populate with MTP metrics (under "mtp_metrics").
+            total_num_microbatches: Microbatches accumulated this step. The MTP loss
+                logging helper sums the per-microbatch loss without dividing, so we pass
+                1/total_num_microbatches to recover the mean (mirroring the MoE path).
+            mtp_grad_norm: The MTP parameter group's gradient norm, already reduced across
+                the model-parallel group, or None when unavailable (e.g. clip_grad == 0 or
+                mtp_detach_heads=False). Logged under "mtp_metrics" as "grad_norm".
         """
         mtp_num_layers = getattr(self.model.config, "mtp_num_layers", None)
         if mtp_num_layers is not None and mtp_num_layers > 0:
@@ -1191,8 +1217,13 @@ class MegatronPolicyWorkerImpl(
             # MTP layers live only on the last pipeline stage, so the tracker is
             # populated there alone. Broadcast to all stages so downstream metric
             # aggregation (which reads rank 0's results) sees them when PP > 1.
-            mtp_metrics = get_mtp_metrics()
+            mtp_loss_scale = 1.0 / max(1, total_num_microbatches)
+            mtp_metrics = get_mtp_metrics(loss_scale=mtp_loss_scale)
             mtp_metrics = broadcast_loss_metrics_from_last_stage(mtp_metrics)
+            # mtp_grad_norm is already MP-reduced (same value on every rank); expose it
+            # under the "mtp/" namespace so it logs as train/mtp/grad_norm.
+            if mtp_grad_norm is not None:
+                mtp_metrics["grad_norm"] = float(mtp_grad_norm)
             if mtp_metrics:
                 metrics["mtp_metrics"] = mtp_metrics
 

--- a/tests/unit/models/megatron/test_mtp_metrics.py
+++ b/tests/unit/models/megatron/test_mtp_metrics.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from types import SimpleNamespace
+
 import pytest
 import torch
 
@@ -76,3 +78,142 @@ def test_get_mtp_metrics_defaults_when_only_loss_tracked(monkeypatch):
     metrics = get_mtp_metrics()
     assert metrics["mtp_1_loss"] == pytest.approx(1.5)
     assert metrics["mtp_1_acceptance_rate"] == pytest.approx(0.0)
+
+
+@pytest.mark.mcore
+def test_get_mtp_metrics_applies_loss_scale(monkeypatch):
+    """loss_scale multiplies each layer's loss; acceptance (a count ratio) is unscaled.
+
+    The MTPLossLoggingHelper accumulates the per-microbatch loss across microbatches
+    without dividing, so the worker passes loss_scale=1/num_microbatches to recover the
+    mean (mirroring get_moe_metrics). Acceptance rate must stay independent of loss_scale.
+    """
+    from nemo_rl.models.megatron.common import get_mtp_metrics
+
+    tracker = {
+        "loss_values": torch.tensor([2.0, 4.0]),
+        "correct_values": torch.tensor([1.0, 3.0]),
+        "total_values": torch.tensor([2.0, 6.0]),
+    }
+    _seed_tracker(monkeypatch, tracker)
+
+    # e.g. 4 microbatches accumulated -> loss_scale = 1/4.
+    metrics = get_mtp_metrics(loss_scale=0.25)
+
+    assert metrics["mtp_1_loss"] == pytest.approx(0.5)  # 2.0 * 0.25
+    assert metrics["mtp_2_loss"] == pytest.approx(1.0)  # 4.0 * 0.25
+    assert metrics["mtp_1_acceptance_rate"] == pytest.approx(50.0)
+    assert metrics["mtp_2_acceptance_rate"] == pytest.approx(50.0)
+
+
+@pytest.mark.mcore
+def test_get_mtp_metrics_loss_scale_recovers_mean_over_microbatches(monkeypatch):
+    """loss_scale=1/num_microbatches turns the accumulated loss sum into the mean.
+
+    loss_values here stands in for the sum of 4 per-microbatch losses of 2.0 each.
+    """
+    from nemo_rl.models.megatron.common import get_mtp_metrics
+
+    num_microbatches = 4
+    _seed_tracker(monkeypatch, {"loss_values": torch.tensor([8.0])})  # 4 * 2.0
+
+    metrics = get_mtp_metrics(loss_scale=1.0 / num_microbatches)
+    assert metrics["mtp_1_loss"] == pytest.approx(2.0)
+
+
+@pytest.mark.mcore
+def test_get_mtp_metrics_default_loss_scale_is_identity(monkeypatch):
+    """Omitting loss_scale (default 1.0) leaves the loss unchanged (backward compatible)."""
+    from nemo_rl.models.megatron.common import get_mtp_metrics
+
+    _seed_tracker(monkeypatch, {"loss_values": torch.tensor([3.0])})
+    assert get_mtp_metrics()["mtp_1_loss"] == pytest.approx(3.0)
+
+
+def _fake_worker(mtp_num_layers):
+    """A minimal stand-in for MegatronPolicyWorkerImpl for calling _collect_mtp_metrics."""
+    return SimpleNamespace(
+        model=SimpleNamespace(config=SimpleNamespace(mtp_num_layers=mtp_num_layers))
+    )
+
+
+@pytest.mark.mcore
+def test_collect_mtp_metrics_scales_loss_and_adds_grad_norm(monkeypatch):
+    """_collect_mtp_metrics passes loss_scale=1/num_microbatches and surfaces the MTP grad norm.
+
+    The grad norm is placed inside the mtp_metrics dict as "grad_norm" so grpo.py flattens it
+    to mtp/grad_norm (logged as train/mtp/grad_norm).
+    """
+    from nemo_rl.models.policy.workers import megatron_policy_worker as mpw
+
+    captured = {}
+
+    def fake_get_mtp_metrics(loss_scale=1.0):
+        captured["loss_scale"] = loss_scale
+        return {"mtp_1_loss": 0.5, "mtp_1_acceptance_rate": 40.0}
+
+    # get_mtp_metrics is imported lazily inside the method, so patch it on its source module.
+    monkeypatch.setattr(
+        "nemo_rl.models.megatron.common.get_mtp_metrics", fake_get_mtp_metrics
+    )
+    # Single-process test: the last-stage broadcast is an identity passthrough.
+    monkeypatch.setattr(mpw, "broadcast_loss_metrics_from_last_stage", lambda d: d)
+
+    metrics: dict = {}
+    mpw.MegatronPolicyWorkerImpl._collect_mtp_metrics(
+        _fake_worker(mtp_num_layers=1),
+        metrics,
+        total_num_microbatches=8,
+        mtp_grad_norm=1.25,
+    )
+
+    assert captured["loss_scale"] == pytest.approx(1.0 / 8)
+    assert metrics["mtp_metrics"]["mtp_1_loss"] == pytest.approx(0.5)
+    assert metrics["mtp_metrics"]["grad_norm"] == pytest.approx(1.25)
+
+
+@pytest.mark.mcore
+def test_collect_mtp_metrics_omits_grad_norm_when_none(monkeypatch):
+    """A None MTP grad norm (e.g. clip_grad==0 or mtp_detach_heads=False) is not logged."""
+    from nemo_rl.models.policy.workers import megatron_policy_worker as mpw
+
+    monkeypatch.setattr(
+        "nemo_rl.models.megatron.common.get_mtp_metrics",
+        lambda loss_scale=1.0: {"mtp_1_loss": 0.5},
+    )
+    monkeypatch.setattr(mpw, "broadcast_loss_metrics_from_last_stage", lambda d: d)
+
+    metrics: dict = {}
+    mpw.MegatronPolicyWorkerImpl._collect_mtp_metrics(
+        _fake_worker(mtp_num_layers=1),
+        metrics,
+        total_num_microbatches=4,
+        mtp_grad_norm=None,
+    )
+    assert "grad_norm" not in metrics["mtp_metrics"]
+
+
+@pytest.mark.mcore
+def test_collect_mtp_metrics_noop_when_mtp_disabled(monkeypatch):
+    """MTP disabled (mtp_num_layers=0) -> nothing added and get_mtp_metrics is not called."""
+    from nemo_rl.models.policy.workers import megatron_policy_worker as mpw
+
+    called = {"get_mtp_metrics": False}
+
+    def fake_get_mtp_metrics(loss_scale=1.0):
+        called["get_mtp_metrics"] = True
+        return {}
+
+    monkeypatch.setattr(
+        "nemo_rl.models.megatron.common.get_mtp_metrics", fake_get_mtp_metrics
+    )
+
+    metrics: dict = {}
+    mpw.MegatronPolicyWorkerImpl._collect_mtp_metrics(
+        _fake_worker(mtp_num_layers=0),
+        metrics,
+        total_num_microbatches=4,
+        mtp_grad_norm=1.0,
+    )
+    assert "mtp_metrics" not in metrics
+    assert not called["get_mtp_metrics"]


### PR DESCRIPTION
manually cp since conflict at around `self._collect_mtp_metrics(metrics, total_num_microbatches, mtp_grad_norm)` in `nemo_rl/models/policy/workers/megatron_policy_worker.py`.