### PR TITLE
fix: revert max_concurrency and label fast

### DIFF
--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -2568,13 +2568,7 @@ class MegatronPolicyWorkerImpl(
 
 
 @ray.remote(
-    runtime_env=get_runtime_env_for_policy_worker("megatron_policy_worker"),
-    # max_concurrency=1 is load-bearing: the split-API state machine
-    # (_train_step_state mutations in begin/microbatch/finish/abort) is not
-    # thread-safe. SingleController submits train_microbatches_from_meta
-    # without awaiting and relies on actor-mailbox serialization. Do not
-    # change without auditing _train_step_state mutation sites.
-    max_concurrency=1,
+    runtime_env=get_runtime_env_for_policy_worker("megatron_policy_worker")
 )  # pragma: no cover
 class MegatronPolicyWorker(MegatronPolicyWorkerImpl):
     pass

--- a/tests/functional/L1_Functional_Tests_Megatron_4.sh
+++ b/tests/functional/L1_Functional_Tests_Megatron_4.sh
@@ -49,14 +49,14 @@ megatron_generation_supported() {
 }
 
 if megatron_generation_supported; then
-    run_test uv run --no-sync bash ./tests/functional/grpo_megatron_generation.sh
-    run_test uv run --no-sync bash ./tests/functional/grpo_megatron_generation_non_colocated.sh
-    run_test uv run --no-sync bash ./tests/functional/grpo_megatron_generation_async.sh
-    run_test uv run --no-sync bash ./tests/functional/grpo_megatron_generation_colocated_async.sh
-    run_test uv run --no-sync bash ./tests/functional/grpo_megatron_generation_async_gym.sh
+    run_test      uv run --no-sync bash ./tests/functional/grpo_megatron_generation.sh
+    run_test      uv run --no-sync bash ./tests/functional/grpo_megatron_generation_non_colocated.sh
+    run_test      uv run --no-sync bash ./tests/functional/grpo_megatron_generation_async.sh
+    run_test fast uv run --no-sync bash ./tests/functional/grpo_megatron_generation_colocated_async.sh
+    run_test      uv run --no-sync bash ./tests/functional/grpo_megatron_generation_async_gym.sh
     # DISABLED: Megatron Inference returns unmasked logprobs
-    # run_test uv run --no-sync bash ./tests/functional/grpo_megatron_generation_topp_topk.sh
-    run_test uv run --no-sync bash ./tests/functional/grpo_megatron_generation_multiturn.sh
+    # run_test      uv run --no-sync bash ./tests/functional/grpo_megatron_generation_topp_topk.sh
+    run_test      uv run --no-sync bash ./tests/functional/grpo_megatron_generation_multiturn.sh
 fi
 
 cd ${PROJECT_ROOT}/tests


### PR DESCRIPTION
revert `max_concurrency` in #2700, this will cause [L1_Functional_Tests_Megatron_4](https://github.com/NVIDIA-NeMo/RL/actions/runs/29396129210/job/87346884483?pr=3212#logs) fail.

each step in the `train_pump` is sequential, so don't need `max_concurrency=1` to guard.