### PR TITLE
fix: forward calibrated KV cache scales on colocated ZMQ IPC refit path

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -2222,7 +2222,8 @@ def refit_policy_generation(
             else:
                 # Original ZMQ IPC path for vLLM
                 futures_train = policy.stream_weights_via_ipc_zmq(
-                    buffer_size_bytes=buffer_size_bytes
+                    buffer_size_bytes=buffer_size_bytes,
+                    kv_scales=kv_scales,
                 )
                 futures_inference = policy_generation.update_weights_via_ipc_zmq()
                 # wait for all futures to complete

--- a/nemo_rl/models/policy/interfaces.py
+++ b/nemo_rl/models/policy/interfaces.py
@@ -187,7 +187,9 @@ class ColocatablePolicyInterface(PolicyInterface):
 
     @abstractmethod
     def stream_weights_via_ipc_zmq(
-        self, *args: Any, **kwargs: Any
+        self,
+        buffer_size_bytes: int,
+        kv_scales: Optional[dict[str, float]] = None,
     ) -> list[ray.ObjectRef]:
         pass
 

--- a/nemo_rl/weight_sync/http_weight_synchronizer.py
+++ b/nemo_rl/weight_sync/http_weight_synchronizer.py
@@ -66,6 +66,12 @@ class HTTPWeightSynchronizer(WeightSynchronizer):
         timer: Optional[Timer] = None,
         kv_scales: Optional[dict[str, float]] = None,
     ) -> None:
+        assert kv_scales is None, (
+            "HTTP transport (SGLang) does not support FP8 KV cache scale sync. "
+            "`kv_scales` is accepted only for interface uniformity; if this "
+            "assertion fires, calibrated scales were routed through a path that "
+            "would otherwise silently ignore them."
+        )
         self._policy.offload_before_refit()
         self._generation.prepare_for_generation(tags=["weights"])
 

--- a/nemo_rl/weight_sync/interfaces.py
+++ b/nemo_rl/weight_sync/interfaces.py
@@ -85,9 +85,8 @@ class WeightSynchronizer(ABC):
         Args:
             timer: Optional Timer for profiling individual phases.
             kv_scales: Optional KV cache scales for FP8 quantization.
-                **Note**: Only honored by the NCCL collective transport,
-                which forwards them to ``policy.broadcast_weights_for_collective()``.
-                IPC and HTTP transports ignore this parameter.
+                Honored by the IPC/ZMQ and NCCL collective transports. The
+                HTTP transport ignores this parameter.
 
         Returns:
             Optional transport-specific scalar metrics for the current sync.

--- a/nemo_rl/weight_sync/ipc_weight_synchronizer.py
+++ b/nemo_rl/weight_sync/ipc_weight_synchronizer.py
@@ -83,7 +83,8 @@ class IPCWeightSynchronizer(WeightSynchronizer):
                 buffer_size_bytes = self._compute_buffer_size()
 
                 futures_train = self._policy.stream_weights_via_ipc_zmq(
-                    buffer_size_bytes=buffer_size_bytes
+                    buffer_size_bytes=buffer_size_bytes,
+                    kv_scales=kv_scales,
                 )
                 futures_inference = self._generation.update_weights_via_ipc_zmq()
 

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -42,6 +42,7 @@ from nemo_rl.algorithms.grpo import (
     compute_and_apply_seq_logprob_error_masking,
     dynamic_sampling,
     grpo_train,
+    refit_policy_generation,
     validate,
 )
 from nemo_rl.algorithms.loss import ClippedPGLossConfig, ClippedPGLossFn
@@ -71,6 +72,33 @@ def _mock_policy_generation() -> MagicMock:
     policy_generation.requires_kv_scale_sync = False
     policy_generation.get_logger_metrics.return_value = {}
     return policy_generation
+
+
+@patch("nemo_rl.algorithms.grpo.ray")
+def test_refit_policy_generation_forwards_kv_scales_on_colocated_ipc(
+    mock_ray: MagicMock,
+) -> None:
+    mock_ray.get.return_value = [True]
+    policy = MagicMock()
+    policy_generation = MagicMock()
+    # Match VllmGeneration's default; a bare MagicMock would auto-create a truthy
+    # weight_synchronizer and refit_policy_generation would delegate to it instead
+    # of taking the colocated IPC path under test.
+    policy_generation.weight_synchronizer = None
+    kv_scales = {"layer.0": 0.5}
+
+    refit_policy_generation(
+        policy,
+        policy_generation,
+        colocated_inference=True,
+        _refit_buffer_size_gb=1.0,
+        kv_scales=kv_scales,
+    )
+
+    policy.stream_weights_via_ipc_zmq.assert_called_once_with(
+        buffer_size_bytes=1024**3,
+        kv_scales=kv_scales,
+    )
 
 
 class TestMaskSampleFilter:

--- a/tests/unit/weight_sync/test_weight_synchronizer.py
+++ b/tests/unit/weight_sync/test_weight_synchronizer.py
@@ -120,6 +120,19 @@ class TestIPCWeightSynchronizer:
         gen.prepare_for_generation.assert_any_call(tags=["kv_cache"])
 
     @patch("nemo_rl.weight_sync.ipc_weight_synchronizer.ray")
+    def test_sync_weights_passes_kv_scales(self, mock_ray: MagicMock) -> None:
+        mock_ray.get.return_value = [True]
+        policy = _mock_policy()
+        gen = _mock_generation()
+        sync = IPCWeightSynchronizer(policy, gen)
+        kv_scales = {"layer.0": 0.5}
+
+        sync.sync_weights(kv_scales=kv_scales)
+
+        call_kwargs = policy.stream_weights_via_ipc_zmq.call_args
+        assert call_kwargs.kwargs["kv_scales"] == kv_scales
+
+    @patch("nemo_rl.weight_sync.ipc_weight_synchronizer.ray")
     def test_sync_weights_raises_on_failure(self, mock_ray):
         mock_ray.get.side_effect = [
             None,  # futures_train
@@ -223,6 +236,17 @@ class TestIPCWeightSynchronizer:
 
 
 class TestHTTPWeightSynchronizer:
+    def test_sync_weights_rejects_kv_scales(self):
+        policy = _mock_policy()
+        gen = _mock_generation()
+        sync = HTTPWeightSynchronizer(policy, gen)
+
+        with pytest.raises(AssertionError, match="does not support"):
+            sync.sync_weights(kv_scales={"layer.0": 0.5})
+
+        policy.offload_before_refit.assert_not_called()
+        gen.prepare_for_generation.assert_not_called()
+
     @patch("nemo_rl.weight_sync.http_weight_synchronizer.ray")
     def test_sync_weights_calls_full_lifecycle(self, mock_ray):
         mock_ray.get.return_value = [True]


### PR DESCRIPTION
Fixes NVIDIA-NeMo/RL#3225

## What

Forward the trainer-calibrated per-tensor FP8 KV cache scales (`kv_scales`)<br>on the **colocated ZMQ-IPC** refit path, so they actually reach the generation<br>worker.

## Why

`calibrate_qkv_fp8_scales` computes per-tensor K/V scales every step, but they<br>were only forwarded on the **non-colocated NCCL** path<br>(`broadcast_weights_for_collective(kv_scales=...)`). The colocated ZMQ-IPC path<br>called `stream_weights_via_ipc_zmq(buffer_size_bytes=...)` **without**<br>`kv_scales`, so `_iter_params_with_optional_kv_scales` received `None` and<br>defaulted every per-tensor K/V scale to **1.0**<br>(`megatron_policy_worker.py`, `scale_value = 1.0`).

Net effect: in the common **colocated** GRPO/PPO setup, FP8 KV cache runs<br>silently used scale 1.0 instead of the calibrated values. The calibration ran<br>each step but its output was discarded at the refit call site — no error, just<br>uncalibrated KV cache.

## Change

Two one-line additions, passing `kv_scales` on both colocated IPC call sites so<br>they match the collective path:

* `nemo_rl/algorithms/grpo.py` — `refit_policy_generation`, the ZMQ IPC branch.
* `nemo_rl/weight_sync/ipc_weight_synchronizer.py` — `IPCWeightSynchronizer.sync_weights`<br>(the method already accepted `kv_scales` but dropped it at the call).

No new machinery; precision-independent; the receiving<br>`stream_weights_via_ipc_zmq` → `_iter_params_with_optional_kv_scales` chain<br>already threads `kv_scales` end-to-end.

## Verification

On a colocated run, the streamed `kv_scales` now populate the worker's<br>per-tensor scales each step (calibrated, non-1.0, drifting with activations)<br>instead of defaulting to 1.0.