### PR TITLE
ci: increase sft-nanov3-30BA3B-2n8g-fsdp2-lora timeout to 45min

### DIFF
--- a/tests/test_suites/llm/sft-nanov3-30BA3B-2n8g-fsdp2-lora.sh
+++ b/tests/test_suites/llm/sft-nanov3-30BA3B-2n8g-fsdp2-lora.sh
@@ -7,7 +7,7 @@ NUM_NODES=2
 STEPS_PER_RUN=20  # step_time ~ 10sec
 MAX_STEPS=20
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
-NUM_MINUTES=35 # Usually 15 minutes is enough for 20 steps, but we add a buffer of 3 minutes in metrics check (30min to buffer for initial ckpt download)
+NUM_MINUTES=45 # Usually 15 minutes is enough for 20 steps, but we add a buffer of 3 minutes in metrics check (45min to buffer for initial ckpt download)
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached


### PR DESCRIPTION
## Summary
- Bumps `NUM_MINUTES` from 35 → 45 for `sft-nanov3-30BA3B-2n8g-fsdp2-lora` nightly test
- Addresses spurious timeout failures observed in CI (run 58094611)
