### PR TITLE
cp: `ci: Nemotron3-Super Perf Recipe (3207)` into `r0.7.0`

### DIFF
--- a/.github/workflows/config/.secrets.baseline
+++ b/.github/workflows/config/.secrets.baseline
@@ -161,6 +161,42 @@
         "line_number": 11
       }
     ],
+    "examples/configs/recipes/llm/performance/grpo-nemotron3-super-120BA12B-32n4g-async-1off.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "examples/configs/recipes/llm/performance/grpo-nemotron3-super-120BA12B-32n4g-async-1off.yaml",
+        "hashed_secret": "4702220fec9261c7d9b0c427aceeca118b66c702",
+        "is_verified": false,
+        "line_number": 21
+      }
+    ],
+    "examples/configs/recipes/llm/performance/grpo-nemotron3-super-120BA12B-32n4g.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "examples/configs/recipes/llm/performance/grpo-nemotron3-super-120BA12B-32n4g.yaml",
+        "hashed_secret": "4702220fec9261c7d9b0c427aceeca118b66c702",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ],
+    "examples/configs/recipes/llm/performance/grpo-nemotron3-super-120BA12B-32n8g-async-1off.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "examples/configs/recipes/llm/performance/grpo-nemotron3-super-120BA12B-32n8g-async-1off.yaml",
+        "hashed_secret": "4702220fec9261c7d9b0c427aceeca118b66c702",
+        "is_verified": false,
+        "line_number": 16
+      }
+    ],
+    "examples/configs/recipes/llm/performance/grpo-nemotron3-super-120BA12B-32n8g.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "examples/configs/recipes/llm/performance/grpo-nemotron3-super-120BA12B-32n8g.yaml",
+        "hashed_secret": "4702220fec9261c7d9b0c427aceeca118b66c702",
+        "is_verified": false,
+        "line_number": 11
+      }
+    ],
     "tests/unit/test_version_check.py": [
       {
         "type": "Hex High Entropy String",
@@ -171,5 +207,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-30T19:40:15Z"
+  "generated_at": "2026-07-15T20:07:55Z"
 }

--- a/examples/configs/recipes/llm/performance/grpo-nemotron3-super-120BA12B-32n4g-async-1off.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-nemotron3-super-120BA12B-32n4g-async-1off.yaml
@@ -1,0 +1,78 @@
+defaults: ../../../grpo_math_1B.yaml
+
+grpo:
+  num_prompts_per_step: 32
+  num_generations_per_prompt: 8
+
+  async_grpo:
+    enabled: true
+    max_trajectory_age_steps: 1
+    in_flight_weight_updates: true
+    recompute_kv_cache_after_weight_updates: false
+
+loss_fn:
+  use_importance_sampling_correction: true
+  force_on_policy_ratio: true
+
+checkpointing:
+  checkpoint_dir: results/grpo-nemotron3-super-120BA12B-32n4g-async-1off
+
+policy:
+  model_name: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+  tokenizer:
+    name: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+  train_global_batch_size: 256
+  train_micro_batch_size: 1
+  logprob_batch_size: 1
+  logprob_chunk_size: 2048
+  max_total_sequence_length: 8192
+  make_sequence_length_divisible_by: 8
+  dtensor_cfg:
+    enabled: false
+  megatron_cfg:
+    enabled: true
+    tensor_model_parallel_size: 2
+    expert_model_parallel_size: 16
+    sequence_parallel: true
+    activation_checkpointing: true
+    bias_activation_fusion: false
+    moe_router_dtype: fp32
+    moe_router_bias_update_rate: 0.001
+    moe_router_enable_expert_bias: true
+    defer_fp32_logits: true
+    env_vars:
+      PYTORCH_CUDA_ALLOC_CONF: expandable_segments:False
+      NRL_REFIT_BUFFER_MEMORY_RATIO: "0.005"
+      NRL_REFIT_NUM_BUFFERS: "1"
+    # # HybridEP settings. Currently disabled
+    # # due to incompatibility with sequence packing
+    # moe_token_dispatcher_type: flex
+    # moe_flex_dispatcher_backend: hybridep
+    # moe_hybridep_num_sms: 32
+    # MTP — disabled
+    mtp_num_layers: 0
+  generation:
+    colocated:
+      enabled: false
+      resources:
+        gpus_per_node: 4
+        num_nodes: 16
+    vllm_cfg:
+      async_engine: true
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.7
+      env_vars:
+        NRL_REFIT_BUFFER_MEMORY_RATIO: "0.005"
+        NRL_REFIT_NUM_BUFFERS: "1"
+
+logger:
+  wandb_enabled: true
+  tensorboard_enabled: true
+  wandb:
+    project: nemo-rl
+    name: grpo-nemotron3-super-120BA12B-32n4g-async-1off
+
+cluster:
+  gpus_per_node: 4
+  num_nodes: 32
+  segment_size: 8

--- a/examples/configs/recipes/llm/performance/grpo-nemotron3-super-120BA12B-32n4g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-nemotron3-super-120BA12B-32n4g.yaml
@@ -1,0 +1,67 @@
+defaults: ../../../grpo_math_1B.yaml
+
+grpo:
+  num_prompts_per_step: 32
+  num_generations_per_prompt: 8
+
+loss_fn:
+  use_importance_sampling_correction: true
+  force_on_policy_ratio: true
+
+checkpointing:
+  checkpoint_dir: results/grpo-nemotron3-super-120BA12B-32n4g
+
+policy:
+  model_name: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+  tokenizer:
+    name: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+  train_global_batch_size: 256
+  train_micro_batch_size: 1
+  logprob_batch_size: 1
+  logprob_chunk_size: 2048
+  max_total_sequence_length: 8192
+  make_sequence_length_divisible_by: 8
+  dtensor_cfg:
+    enabled: false
+  megatron_cfg:
+    enabled: true
+    tensor_model_parallel_size: 2
+    expert_model_parallel_size: 16
+    sequence_parallel: true
+    activation_checkpointing: true
+    bias_activation_fusion: false
+    moe_router_dtype: fp32
+    moe_router_bias_update_rate: 0.001
+    moe_router_enable_expert_bias: true
+    # # HybridEP settings. Currently disabled
+    # # due to incompatibility with sequence packing
+    # moe_token_dispatcher_type: flex
+    # moe_flex_dispatcher_backend: hybridep
+    # moe_hybridep_num_sms: 32
+    defer_fp32_logits: true
+    # MTP — disabled
+    mtp_num_layers: 0
+    env_vars:
+      PYTORCH_CUDA_ALLOC_CONF: expandable_segments:False
+      NRL_REFIT_BUFFER_MEMORY_RATIO: "0.005"
+      NRL_REFIT_NUM_BUFFERS: "1"
+  generation:
+    vllm_cfg:
+      async_engine: true
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.7
+      env_vars:
+        NRL_REFIT_BUFFER_MEMORY_RATIO: "0.005"
+        NRL_REFIT_NUM_BUFFERS: "1"
+
+logger:
+  wandb_enabled: true
+  tensorboard_enabled: true
+  wandb:
+    project: nemo-rl
+    name: grpo-nemotron3-super-120BA12B-32n4g
+
+cluster:
+  gpus_per_node: 4
+  num_nodes: 32
+  segment_size: 8

--- a/examples/configs/recipes/llm/performance/grpo-nemotron3-super-120BA12B-32n8g-async-1off.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-nemotron3-super-120BA12B-32n8g-async-1off.yaml
@@ -1,0 +1,62 @@
+defaults: ../../../grpo_math_1B.yaml
+grpo:
+  num_prompts_per_step: 32
+  num_generations_per_prompt: 8
+  async_grpo:
+    enabled: true
+    max_trajectory_age_steps: 1
+    in_flight_weight_updates: true
+    recompute_kv_cache_after_weight_updates: false
+loss_fn:
+  use_importance_sampling_correction: true
+  force_on_policy_ratio: true
+checkpointing:
+  checkpoint_dir: results/grpo-nemotron3-super-120BA12B-32n8g-async-1off
+policy:
+  model_name: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+  tokenizer:
+    name: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+  train_global_batch_size: 256
+  train_micro_batch_size: 1
+  logprob_batch_size: 1
+  logprob_chunk_size: 2048
+  max_total_sequence_length: 8192
+  make_sequence_length_divisible_by: 8
+  dtensor_cfg:
+    enabled: false
+  megatron_cfg:
+    enabled: true
+    tensor_model_parallel_size: 4
+    expert_model_parallel_size: 32
+    sequence_parallel: true
+    activation_checkpointing: true
+    bias_activation_fusion: false
+    moe_router_dtype: fp32
+    moe_router_bias_update_rate: 0.001
+    moe_router_enable_expert_bias: true
+    defer_fp32_logits: true
+    # MTP — disabled
+    mtp_num_layers: 0
+  generation:
+    colocated:
+      enabled: false
+      resources:
+        num_nodes: 24
+        gpus_per_node: 8
+    vllm_cfg:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.7
+      async_engine: true
+    # vllm_kwargs:
+    #   # vLLM 0.20's default FlashInfer TRTLLM MoE backend isn't refit-compatible,
+    #   # change to triton to keep same behavior as vLLM 0.17.
+    #   moe_backend: triton
+logger:
+  wandb_enabled: true
+  tensorboard_enabled: true
+  wandb:
+    project: nemo-rl
+    name: grpo-nemotron3-super-120BA12B-32n8g-async-1off
+cluster:
+  gpus_per_node: 8
+  num_nodes: 32

--- a/examples/configs/recipes/llm/performance/grpo-nemotron3-super-120BA12B-32n8g.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-nemotron3-super-120BA12B-32n8g.yaml
@@ -1,0 +1,52 @@
+defaults: ../../../grpo_math_1B.yaml
+grpo:
+  num_prompts_per_step: 32
+  num_generations_per_prompt: 8
+loss_fn:
+  force_on_policy_ratio: true
+  use_importance_sampling_correction: true
+checkpointing:
+  checkpoint_dir: results/grpo-nemotron3-super-120BA12B-32n8g
+policy:
+  model_name: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+  tokenizer:
+    name: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+  train_global_batch_size: 256
+  train_micro_batch_size: 1
+  logprob_batch_size: 1
+  logprob_chunk_size: 2048
+  max_total_sequence_length: 8192
+  make_sequence_length_divisible_by: 8
+  dtensor_cfg:
+    enabled: false
+  megatron_cfg:
+    enabled: true
+    tensor_model_parallel_size: 4
+    expert_model_parallel_size: 32
+    sequence_parallel: true
+    activation_checkpointing: true
+    bias_activation_fusion: false
+    moe_router_dtype: fp32
+    moe_router_bias_update_rate: 0.001
+    moe_router_enable_expert_bias: true
+    defer_fp32_logits: true
+    # MTP — disabled
+    mtp_num_layers: 0
+  generation:
+    vllm_cfg:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.7
+      async_engine: true
+    # vllm_kwargs:
+    #   # vLLM 0.20's default FlashInfer TRTLLM MoE backend isn't refit-compatible,
+    #   # change to triton to keep same behavior as vLLM 0.17.
+    #   moe_backend: triton
+logger:
+  wandb_enabled: true
+  tensorboard_enabled: true
+  wandb:
+    project: nemo-rl
+    name: grpo-nemotron3-super-120BA12B-32n8g
+cluster:
+  gpus_per_node: 8
+  num_nodes: 32

--- a/tests/test_suites/llm/performance/grpo-nemotron3-super-120BA12B-32n4g-async-1off.sh
+++ b/tests/test_suites/llm/performance/grpo-nemotron3-super-120BA12B-32n4g-async-1off.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $SCRIPT_DIR/common.env
+# disable NVLS to avoid OOM issue
+export NCCL_NVLS_ENABLE=0
+
+# ===== BEGIN CONFIG =====
+NUM_NODES=32
+GPUS_PER_NODE=4
+SEGMENT_SIZE=8     # nodes per NVLink-domain segment; tools/launch passes it as sbatch --segment. Matches cluster.segment_size in the yaml.
+STEPS_PER_RUN=10
+MAX_STEPS=10
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=100
+# ===== END CONFIG =====
+
+exit_if_max_steps_reached
+
+# Run the experiment
+cd $PROJECT_ROOT
+uv run examples/run_grpo.py \
+    --config $CONFIG_PATH \
+    grpo.max_num_steps=$MAX_STEPS \
+    logger.log_dir=$LOG_DIR \
+    logger.wandb_enabled=True \
+    logger.wandb.project=nemo-rl \
+    logger.wandb.name=$EXP_NAME \
+    logger.monitor_gpus=True \
+    logger.tensorboard_enabled=True \
+    checkpointing.enabled=True \
+    checkpointing.checkpoint_dir=$CKPT_DIR \
+    $@ \
+    2>&1 | tee $RUN_LOG
+
+# Convert tensorboard logs to json
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+
+# Only run metrics if the target step is reached
+if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
+    uv run tests/check_metrics.py $JSON_METRICS \
+        'median(data["train/token_mult_prob_error"]) < 1.1' \
+        'data["train/token_mult_prob_error"]["10"] < 1.1'
+
+    # Clean up checkpoint directory after successful run to save space.
+    rm -rf "$CKPT_DIR"
+fi

--- a/tests/test_suites/llm/performance/grpo-nemotron3-super-120BA12B-32n4g.sh
+++ b/tests/test_suites/llm/performance/grpo-nemotron3-super-120BA12B-32n4g.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $SCRIPT_DIR/common.env
+# disable NVLS to avoid OOM issue
+export NCCL_NVLS_ENABLE=0
+
+# ===== BEGIN CONFIG =====
+NUM_NODES=32
+GPUS_PER_NODE=4
+SEGMENT_SIZE=8     # nodes per NVLink-domain segment; tools/launch passes it as sbatch --segment. Matches cluster.segment_size in the yaml.
+STEPS_PER_RUN=10
+MAX_STEPS=10
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=100
+# ===== END CONFIG =====
+
+exit_if_max_steps_reached
+
+# Run the experiment
+cd $PROJECT_ROOT
+uv run examples/run_grpo.py \
+    --config $CONFIG_PATH \
+    grpo.max_num_steps=$MAX_STEPS \
+    logger.log_dir=$LOG_DIR \
+    logger.wandb_enabled=True \
+    logger.wandb.project=nemo-rl \
+    logger.wandb.name=$EXP_NAME \
+    logger.monitor_gpus=True \
+    logger.tensorboard_enabled=True \
+    checkpointing.enabled=True \
+    checkpointing.checkpoint_dir=$CKPT_DIR \
+    $@ \
+    2>&1 | tee $RUN_LOG
+
+# Convert tensorboard logs to json
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+
+# Only run metrics if the target step is reached
+if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
+    uv run tests/check_metrics.py $JSON_METRICS \
+        'median(data["train/token_mult_prob_error"]) < 1.1' \
+        'data["train/token_mult_prob_error"]["10"] < 1.1'
+
+    # Clean up checkpoint directory after successful run to save space.
+    rm -rf "$CKPT_DIR"
+fi

--- a/tests/test_suites/llm/performance/grpo-nemotron3-super-120BA12B-32n8g-async-1off.sh
+++ b/tests/test_suites/llm/performance/grpo-nemotron3-super-120BA12B-32n8g-async-1off.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $SCRIPT_DIR/common.env
+# disable NVLS to avoid OOM issue
+export NCCL_NVLS_ENABLE=0
+
+# ===== BEGIN CONFIG =====
+NUM_NODES=32
+GPUS_PER_NODE=8
+STEPS_PER_RUN=10
+MAX_STEPS=10
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=60
+# ===== END CONFIG =====
+
+exit_if_max_steps_reached
+
+# Run the experiment
+cd $PROJECT_ROOT
+uv run examples/run_grpo.py \
+    --config $CONFIG_PATH \
+    grpo.max_num_steps=$MAX_STEPS \
+    logger.log_dir=$LOG_DIR \
+    logger.wandb_enabled=True \
+    logger.wandb.project=nemo-rl \
+    logger.wandb.name=$EXP_NAME \
+    logger.monitor_gpus=True \
+    logger.tensorboard_enabled=True \
+    checkpointing.enabled=True \
+    checkpointing.checkpoint_dir=$CKPT_DIR \
+    $@ \
+    2>&1 | tee $RUN_LOG
+
+# Convert tensorboard logs to json
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+
+# Only run metrics if the target step is reached
+if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
+    uv run tests/check_metrics.py $JSON_METRICS \
+        'median(data["train/token_mult_prob_error"]) < 1.1'
+
+    # Clean up checkpoint directory after successful run to save space.
+    rm -rf "$CKPT_DIR"
+fi

--- a/tests/test_suites/llm/performance/grpo-nemotron3-super-120BA12B-32n8g.sh
+++ b/tests/test_suites/llm/performance/grpo-nemotron3-super-120BA12B-32n8g.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $SCRIPT_DIR/common.env
+# disable NVLS to avoid OOM issue
+export NCCL_NVLS_ENABLE=0
+
+# ===== BEGIN CONFIG =====
+NUM_NODES=32
+GPUS_PER_NODE=8
+STEPS_PER_RUN=10
+MAX_STEPS=10
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=60
+# ===== END CONFIG =====
+
+exit_if_max_steps_reached
+
+# Run the experiment
+cd $PROJECT_ROOT
+uv run examples/run_grpo.py \
+    --config $CONFIG_PATH \
+    grpo.max_num_steps=$MAX_STEPS \
+    logger.log_dir=$LOG_DIR \
+    logger.wandb_enabled=True \
+    logger.wandb.project=nemo-rl \
+    logger.wandb.name=$EXP_NAME \
+    logger.monitor_gpus=True \
+    logger.tensorboard_enabled=True \
+    checkpointing.enabled=True \
+    checkpointing.checkpoint_dir=$CKPT_DIR \
+    $@ \
+    2>&1 | tee $RUN_LOG
+
+# Convert tensorboard logs to json
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+
+# Only run metrics if the target step is reached
+if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
+    uv run tests/check_metrics.py $JSON_METRICS \
+        'median(data["train/token_mult_prob_error"]) < 1.1'
+
+    # Clean up checkpoint directory after successful run to save space.
+    rm -rf "$CKPT_DIR"
+fi

--- a/tests/test_suites/performance.txt
+++ b/tests/test_suites/performance.txt
@@ -14,6 +14,7 @@ tests/test_suites/llm/performance/grpo-qwen3-32b-4n8g.sh
 tests/test_suites/llm/performance/grpo-qwen3-235b-16n8g.sh
 tests/test_suites/llm/performance/grpo-qwen3-235b-32n8g.sh
 tests/test_suites/llm/performance/dapo-deepseek-v3-64n8g.v2.sh
+tests/test_suites/llm/performance/grpo-nemotron3-super-120BA12B-32n8g.sh
 
 ## ASYNC 1-off
 tests/test_suites/llm/performance/grpo-deepseek-v3-64n8g-async-1off.sh
@@ -21,6 +22,7 @@ tests/test_suites/llm/performance/grpo-llama3.1-8b-instruct-2n8g-async-1off.sh
 tests/test_suites/llm/performance/grpo-qwen3-32b-8n8g-async-1off.sh
 tests/test_suites/llm/performance/grpo-qwen3-235b-32n8g-async-1off.sh
 tests/test_suites/llm/performance/grpo-qwen3-30ba3b-4n8g-async-1off.sh
+tests/test_suites/llm/performance/grpo-nemotron3-super-120BA12B-32n8g-async-1off.sh
 
 ## ASYNC many-off
 tests/test_suites/llm/performance/grpo-qwen3-30ba3b-24n8g-async-8off.sh

--- a/tests/test_suites/performance_gb200.txt
+++ b/tests/test_suites/performance_gb200.txt
@@ -12,6 +12,7 @@ tests/test_suites/llm/performance/grpo-deepseek-v3-32n4g.sh
 tests/test_suites/llm/performance/grpo-deepseek-v3-64n4g.sh
 tests/test_suites/llm/performance/grpo-qwen3-235b-16n4g.sh
 tests/test_suites/llm/performance/grpo-qwen3-235b-32n4g.sh
+tests/test_suites/llm/performance/grpo-nemotron3-super-120BA12B-32n4g.sh
 
 ## ASYNC 1-off
 tests/test_suites/llm/performance/grpo-llama3.1-8b-instruct-2n4g-async-1off.sh
@@ -19,3 +20,4 @@ tests/test_suites/llm/performance/grpo-qwen3-32b-8n4g-async-1off.sh
 tests/test_suites/llm/performance/grpo-qwen3-30ba3b-4n4g-async-1off.sh
 tests/test_suites/llm/performance/grpo-deepseek-v3-64n4g-async-1off.sh
 tests/test_suites/llm/performance/grpo-qwen3-235b-32n4g-async-1off.sh
+tests/test_suites/llm/performance/grpo-nemotron3-super-120BA12B-32n4g-async-1off.sh


### PR DESCRIPTION
Cherry-pick of #3207 into `r0.7.0`.

Manual resolution required: conflict in `tests/test_suites/performance_gb200.txt` because `main` had a `# GB200 MXFP8` section that isn't in `r0.7.0`. Resolved by adding only the two new Nemotron3-Super entries and omitting the MXFP8 block.

cc @parthmannan