### PR TITLE
feat(eval): NeMo Gym rollout benchmark — gen-only eval of GRPO recipes + per-rollout telemetry

### DIFF
--- a/docs/design-docs/nemo-gym-integration.md
+++ b/docs/design-docs/nemo-gym-integration.md
@@ -4,13 +4,13 @@ This document describes how NeMo RL integrates with [NeMo Gym](https://docs.nvid
 
 ## Overview
 
-NeMo Gym provides HTTP-based training environments for LLMs. **NeMo Gym is CPU-only**—it runs no inference engines and holds no GPU memory. NeMo RL exposes its vLLM generation engine as an OpenAI-compatible HTTP server, which NeMo Gym calls during rollouts, enabling:
+NeMo Gym provides HTTP-based training and evaluation environments for LLMs. **NeMo Gym is CPU-only**—it runs no inference engines and holds no GPU memory. NeMo RL exposes its vLLM generation engine as an OpenAI-compatible HTTP server, which NeMo Gym calls during rollouts, enabling:
 
 - **Decoupled architecture**: Environments don't need direct access to model internals
 - **Multi-step/multi-turn support**: Agents can orchestrate complex interactions with tools
 - **Refit compatibility**: NeMo RL's weight synchronization works transparently
 
-The same NeMo Gym rollout path is used by GRPO and on-policy distillation when `env.should_use_nemo_gym` is enabled. Distillation uses the generated NeMo Gym conversations as the student on-policy samples before computing teacher logits and the distillation loss.
+The same NeMo Gym rollout path is used by GRPO, on-policy distillation, and standalone evaluation when `env.should_use_nemo_gym` is enabled. Distillation uses the generated NeMo Gym conversations as the student on-policy samples before computing teacher logits and the distillation loss.
 
 For on-policy distillation, NeMo Gym controls the rollout turn count from its environment and agent configuration. The standard distillation `distillation.max_rollout_turns` setting is not used by the NeMo Gym rollout path.
 
@@ -48,6 +48,59 @@ rollout metrics are unaffected. Set the flag to `true` only when the complete
 Gym result payloads are needed for a short debugging run.
 
 For complete examples, see `examples/nemo_gym/run_grpo_nemo_gym.py`, `examples/nemo_gym/run_distillation_nemo_gym.py`, and their associated configs under `examples/nemo_gym/`.
+
+### Rollout Benchmark Through the Eval Flow
+
+Use the dedicated converter entrypoint to run an existing GRPO NeMo Gym recipe
+as a rollout-only benchmark:
+
+```bash
+uv run examples/nemo_gym/run_grpo_rollout_benchmark.py \
+  --config examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
+```
+
+The entrypoint validates the source as a GRPO config, converts it to the
+standard eval schema, and then calls the same eval implementation as
+`examples/run_eval.py`. The GRPO recipe remains the only source of rollout
+sampling configuration:
+
+- `grpo.num_generations_per_prompt` controls trajectories per prompt.
+- `grpo.num_prompts_per_step` controls prompts in each 1-based `eval_step`.
+- `policy.generation` supplies `max_new_tokens`, `temperature`, `top_p`,
+  `top_k`, stop settings, and the vLLM configuration.
+
+The converter also flattens `data.default` plus `data.validation`, copies the
+NeMo Gym, logger, cluster, tokenizer, and full policy configuration, and removes
+legacy trajectory-collection control fields before Gym starts. Do not add an
+`eval` block or a second generation block to the GRPO recipe. Results and
+telemetry use the normal eval outputs: `nemo_gym_eval_results.jsonl`,
+`generation_metrics.jsonl`, W&B `eval_step`, rollout metrics, generation
+metrics, and Ray system metrics.
+
+### Standalone Evaluation
+
+`examples/run_eval.py` supports NeMo Gym datasets and agents through the same
+`env.should_use_nemo_gym` switch. A complete configuration is available at
+`examples/nemo_gym/eval_workplace_assistant_nemotron_nano_v2_9b.yaml`:
+
+```bash
+uv run examples/run_eval.py \
+  --config examples/nemo_gym/eval_workplace_assistant_nemotron_nano_v2_9b.yaml
+```
+
+The example uses Gym's checked-in workplace-assistant split. Gym eval supports
+`mean_reward` and `pass@k`; use `eval.num_tests_per_prompt` for multiple
+trajectories per prompt. It uses the HTTP-serving vLLM or Megatron rollout
+engine selected by `generation.backend`.
+
+Each completed batch is a 1-based W&B `eval_step`. Eval, rollout, generation,
+and (when `logger.monitor_gpus=true`) Ray system metrics share that axis. Raw
+results and generation time series are written to
+`nemo_gym_eval_results.jsonl` and `generation_metrics.jsonl`.
+
+Standard eval can construct vLLM, SGLang, or Megatron from
+`generation.backend`. NeMo Gym eval supports the same HTTP rollout engines as
+the GRPO Gym flow: vLLM and Megatron.
 
 ### Version Requirements
 

--- a/examples/configs/evals/eval.yaml
+++ b/examples/configs/evals/eval.yaml
@@ -52,6 +52,25 @@ env:
   math:
     num_workers: 8
 
+logger:
+  log_dir: "logs/eval"
+  wandb_enabled: false
+  tensorboard_enabled: false
+  mlflow_enabled: false
+  swanlab_enabled: false
+  monitor_gpus: false # set true to log cluster GPU/host-memory metrics at eval_step
+  wandb:
+    project: "nemo-rl-eval"
+    name: "eval"
+  tensorboard: {}
+  swanlab:
+    project: "nemo-rl-eval"
+    name: "eval"
+  mlflow: {}
+  gpu_monitoring:
+    collection_interval: 10
+    flush_interval: 10
+
 cluster:
   gpus_per_node: 1
   num_nodes: 1

--- a/examples/nemo_gym/eval_workplace_assistant_nemotron_nano_v2_9b.yaml
+++ b/examples/nemo_gym/eval_workplace_assistant_nemotron_nano_v2_9b.yaml
@@ -1,0 +1,70 @@
+defaults: ../configs/evals/eval.yaml
+
+eval:
+  metric: "mean_reward"
+  num_tests_per_prompt: 1
+  save_path: "results/eval-workplace-assistant-nemotron-nano-v2-9b"
+
+generation:
+  max_new_tokens: 8192
+  model_name: "nvidia/NVIDIA-Nemotron-Nano-9B-v2"
+  top_k: null
+  num_prompts_per_step: 32
+  vllm_cfg:
+    async_engine: true
+    expose_http_server: true
+    enable_vllm_metrics_logger: true
+    vllm_metrics_logger_interval: 0.5
+    tensor_parallel_size: 1
+    gpu_memory_utilization: 0.8
+    max_model_len: 8192
+    skip_tokenizer_init: false
+    http_server_serving_chat_kwargs:
+      enable_auto_tools: true
+      tool_parser: nemotron_json
+  vllm_kwargs:
+    compilation_config:
+      backend: eager
+    mamba_ssm_cache_dtype: "float32"
+
+tokenizer:
+  name: ${generation.model_name}
+
+data:
+  max_input_seq_length: null
+  dataset_name: "NemoGymDataset"
+  # The checked-in example split makes this recipe runnable after submodule init.
+  # Override with resources_servers/workplace_assistant/data/validation.jsonl
+  # after downloading the full validation artifact through NeMo Gym.
+  data_path: "3rdparty/Gym-workspace/Gym/resources_servers/workplace_assistant/data/example.jsonl"
+  processor: "nemo_gym_data_processor"
+  env_name: "nemo_gym"
+  repeat: 1
+
+env:
+  should_use_nemo_gym: true
+  nemo_gym:
+    port_range_low: 5000
+    port_range_high: 5999
+    rollout_max_attempts_to_avoid_lp_nan: 1
+    config_paths:
+      - responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
+      - resources_servers/workplace_assistant/configs/workplace_assistant.yaml
+    policy_model:
+      responses_api_models:
+        vllm_model:
+          uses_reasoning_parser: false
+          extra_body:
+            chat_template_kwargs:
+              enable_thinking: false
+
+logger:
+  log_dir: "logs/eval-workplace-assistant-nemotron-nano-v2-9b"
+  wandb_enabled: true
+  wandb:
+    project: "nemo-rl-eval"
+    name: "workplace-assistant-nemotron-nano-v2-9b"
+
+cluster:
+  gpus_per_node: 8
+  num_nodes: 1

--- a/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
+++ b/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
@@ -305,6 +305,7 @@ env:
     port_range_low: 5000
     port_range_high: 5999
     is_trajectory_collection: false  # Set this to true to enable trajectory collection (no training). You may also want to increase `policy.generation.vllm_cfg.gpu_memory_utilization`
+    trajectory_collection_batch_size: null  # Optional positive integer; null collects the validation set in one batch
     config_paths:
     - responses_api_models/vllm_model/configs/vllm_model_for_training.yaml  # Required! And it must be *for_training
     - resources_servers/workplace_assistant/configs/workplace_assistant.yaml

--- a/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
+++ b/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
@@ -130,6 +130,7 @@ policy:
     #gives ~20% training perf speedup with sequence packing
     apply_rope_fusion: True
     defer_fp32_logits: false
+    moe_per_layer_logging: false
     moe_permute_fusion: true
     moe_enable_deepep: false
     moe_token_dispatcher_type: "alltoall"

--- a/examples/nemo_gym/run_grpo_nemo_gym.py
+++ b/examples/nemo_gym/run_grpo_nemo_gym.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import argparse
+import json
 import os
 import pprint
 import time
@@ -38,7 +39,7 @@ from nemo_rl.algorithms.grpo import (
     refit_policy_generation,
     setup,
 )
-from nemo_rl.algorithms.utils import get_tokenizer
+from nemo_rl.algorithms.utils import get_tokenizer, log_generation_metrics_to_wandb
 from nemo_rl.data.utils import setup_response_data
 from nemo_rl.distributed.virtual_cluster import init_ray
 from nemo_rl.environments.nemo_gym import setup_nemo_gym_config
@@ -66,6 +67,34 @@ def parse_args() -> tuple[argparse.Namespace, list[str]]:
     return args, overrides
 
 
+def _pop_trajectory_collection_settings(
+    nemo_gym_config: dict[str, object],
+) -> tuple[bool, int | None]:
+    """Remove and validate NeMo-RL trajectory-collection settings."""
+    is_trajectory_collection = bool(
+        nemo_gym_config.pop("is_trajectory_collection", False)
+    )
+    batch_size = nemo_gym_config.pop("trajectory_collection_batch_size", None)
+    if batch_size is None:
+        return is_trajectory_collection, None
+
+    if not is_trajectory_collection:
+        raise ValueError(
+            "env.nemo_gym.trajectory_collection_batch_size requires "
+            "env.nemo_gym.is_trajectory_collection=true"
+        )
+    if (
+        isinstance(batch_size, bool)
+        or not isinstance(batch_size, int)
+        or batch_size <= 0
+    ):
+        raise ValueError(
+            "env.nemo_gym.trajectory_collection_batch_size must be a positive integer"
+        )
+
+    return is_trajectory_collection, batch_size
+
+
 # These types are directly imported from grpo_train since if something about the architecture changes we want to immediately fail.
 def collect_trajectories(
     policy: ColocatablePolicyInterface,
@@ -76,7 +105,13 @@ def collect_trajectories(
     logger: Logger,
     master_config: MasterConfig,
 ) -> None:
-    """Run trajectory collection."""
+    """Run trajectory collection and persist every completed batch."""
+    expected_trajectories = master_config.grpo["max_val_samples"]
+    if expected_trajectories is None or expected_trajectories <= 0:
+        raise ValueError(
+            "Trajectory collection requires a non-empty validation dataset"
+        )
+
     # common config/state items
     colocated_inference = master_config.policy["generation"]["colocated"]["enabled"]
     refit_policy_generation(policy, policy_generation, colocated_inference)
@@ -85,35 +120,110 @@ def collect_trajectories(
 
     print("\n🔍 Running trajectory collection...", flush=True)
     generation_config = master_config.policy["generation"]
-    for val_batch in val_dataloader:
-        nemo_gym_rollout_result = run_nemo_gym_rollout_sync(
-            policy_generation=policy_generation,
-            input_batch=val_batch,
-            tokenizer=tokenizer,
-            task_to_env=val_task_to_env,
-            max_seq_len=master_config.policy["max_total_sequence_length"],
-            generation_config=generation_config,
-            # This utility consumes the Tables below to write its trajectory JSONL.
-            log_full_result_tables=True,
-            max_rollout_turns=None,
-            greedy=False,
+    vllm_config = generation_config.get("vllm_cfg", {})
+    should_log_generation_metrics = (
+        vllm_config.get("enable_vllm_metrics_logger", False)
+        and vllm_config.get("async_engine", False)
+        and master_config.logger["wandb_enabled"]
+    )
+    collected_trajectories = 0
+    total_reward = 0.0
+
+    try:
+        for batch_idx, val_batch in enumerate(val_dataloader):
+            batch_step = batch_idx + 1
+            if should_log_generation_metrics:
+                policy_generation.clear_logger_metrics()
+
+            nemo_gym_rollout_result = run_nemo_gym_rollout_sync(
+                policy_generation=policy_generation,
+                input_batch=val_batch,
+                tokenizer=tokenizer,
+                task_to_env=val_task_to_env,
+                max_seq_len=master_config.policy["max_total_sequence_length"],
+                generation_config=generation_config,
+                # This utility consumes the Tables below to write its trajectory JSONL.
+                log_full_result_tables=True,
+                max_rollout_turns=None,
+                greedy=False,
+            )
+            if should_log_generation_metrics:
+                generation_logger_metrics = policy_generation.get_logger_metrics()
+
+            rows_to_log: list[str] = []
+            for key, value in nemo_gym_rollout_result.rollout_metrics.items():
+                if "full_result" not in key:
+                    continue
+
+                value: Table
+                data: list[list[str]] = value.data  # (n, 1)
+                rows_to_log.extend(v[0] for v in data)
+
+            if not rows_to_log:
+                raise RuntimeError(
+                    f"Trajectory batch {batch_idx} did not contain any full Gym results"
+                )
+
+            attributed_rows: list[str] = []
+            batch_size = len(rows_to_log)
+            batch_reward = 0.0
+            for batch_position, serialized_result in enumerate(rows_to_log):
+                result = json.loads(serialized_result)
+                result["trajectory_collection_batch_index"] = batch_idx
+                result["trajectory_collection_batch_position"] = batch_position
+                result["trajectory_collection_batch_size"] = batch_size
+                batch_reward += float(result["reward"])
+                attributed_rows.append(json.dumps(result, separators=(",", ":")))
+
+            # Append after every completed batch so earlier trajectories survive a later
+            # batch or worker failure during a long collection run.
+            logger.log_string_list_as_jsonl(attributed_rows, log_filename)
+            collected_trajectories += batch_size
+            total_reward += batch_reward
+
+            batch_rollout_metrics = {
+                key: value
+                for key, value in nemo_gym_rollout_result.rollout_metrics.items()
+                if "full_result" not in key
+            }
+            # Match the training prefix so rollout-only and GRPO runs expose the same
+            # timing and rollout metric names for direct comparison.
+            logger.log_metrics(batch_rollout_metrics, batch_step, prefix="train")
+            if should_log_generation_metrics:
+                log_generation_metrics_to_wandb(
+                    generation_logger_metrics,
+                    batch_step,
+                    vllm_config["vllm_metrics_logger_interval"],
+                    logger,
+                )
+            logger.log_metrics(
+                {
+                    "mean_reward": total_reward / collected_trajectories,
+                    "num_trajectories": collected_trajectories,
+                },
+                batch_step,
+                prefix="trajectory_collection",
+                step_finished=True,
+            )
+            print(
+                f"Collected {collected_trajectories}/{expected_trajectories} "
+                f"trajectories after batch {batch_idx + 1}",
+                flush=True,
+            )
+    finally:
+        policy_generation.finish_generation()
+
+    if collected_trajectories != expected_trajectories:
+        raise RuntimeError(
+            "Trajectory collection was incomplete: "
+            f"expected {expected_trajectories}, got {collected_trajectories}"
         )
 
-        rows_to_log: list[str] = []
-        for key, value in nemo_gym_rollout_result.rollout_metrics.items():
-            if "full_result" not in key:
-                continue
-
-            value: Table
-            data: list[list[str]] = value.data  # (n, 1)
-            rows_to_log.extend(v[0] for v in data)
-
-        logger.log_string_list_as_jsonl(rows_to_log, log_filename)
-
-        # TODO: eventually as trajectory collection use cases exceed 4 hours, we can leverage the dataloader save functionality to resume
-        # And also leverage the TimeoutChecker functionality as well
-
-    policy_generation.finish_generation()
+    print(
+        f"Trajectory collection complete: {collected_trajectories} trajectories, "
+        f"mean reward {total_reward / collected_trajectories:.6f}",
+        flush=True,
+    )
 
 
 def main() -> None:
@@ -175,6 +285,12 @@ def main() -> None:
         # NeMo-Gym specific config setup.
         setup_nemo_gym_config(config, tokenizer)
 
+        # These are NeMo-RL control-flow settings, not NeMo-Gym global config.
+        (
+            is_trajectory_collection,
+            trajectory_collection_batch_size,
+        ) = _pop_trajectory_collection_settings(config.env["nemo_gym"])
+
     # We assert here since this is right after the final config has been materialized.
     assert _should_use_nemo_gym(config)
 
@@ -196,11 +312,15 @@ The validation set you pass in will directly be used for validation with no addi
         )
 
     if val_dataset is not None:
+        val_batch_size = len(val_dataset)
+        if trajectory_collection_batch_size is not None:
+            val_batch_size = min(trajectory_collection_batch_size, len(val_dataset))
         print(
-            f"Setting `grpo.max_val_samples` and `grpo.val_batch_size` to the length of the validation dataset, which is {len(val_dataset)}"
+            f"Setting `grpo.max_val_samples` to {len(val_dataset)} and "
+            f"`grpo.val_batch_size` to {val_batch_size}"
         )
         config.grpo.max_val_samples = len(val_dataset)
-        config.grpo.val_batch_size = config.grpo.max_val_samples
+        config.grpo.val_batch_size = val_batch_size
 
     # Print config
     print("Final config:")
@@ -208,13 +328,6 @@ The validation set you pass in will directly be used for validation with no addi
 
     with rl_init_timer.time("ray_connect"):
         init_ray()
-
-    # `is_trajectory_collection` is a NeMo-RL-side control-flow knob; pop it
-    # before setup() so it is not forwarded into NeMo-Gym's global config (the
-    # gym actor is now created inside setup()).
-    is_trajectory_collection = (
-        config.env["nemo_gym"].pop("is_trajectory_collection", False) or False
-    )
 
     with rl_init_timer.time("setup"):
         (

--- a/examples/nemo_gym/run_grpo_rollout_benchmark.py
+++ b/examples/nemo_gym/run_grpo_rollout_benchmark.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+from copy import deepcopy
+from typing import Any, cast
+
+from omegaconf import OmegaConf
+
+from examples.run_eval import run_eval
+from nemo_rl.algorithms.grpo import MasterConfig as GRPOMasterConfig
+from nemo_rl.evals.eval import MasterConfig as EvalMasterConfig
+from nemo_rl.models.generation.interfaces import GenerationConfig
+from nemo_rl.utils.config import (
+    load_config,
+    parse_hydra_overrides,
+    register_omegaconf_resolvers,
+)
+
+ROLLOUT_BENCHMARK_METRIC = "mean_reward"
+ROLLOUT_BENCHMARK_K_VALUE = 1
+
+
+def parse_args() -> tuple[argparse.Namespace, list[str]]:
+    """Parse an RL recipe path and overrides applied before conversion."""
+    parser = argparse.ArgumentParser(
+        description="Run an RL recipe as a rollout benchmark through eval"
+    )
+    parser.add_argument(
+        "--config", type=str, default=None, help="Path to the source GRPO YAML"
+    )
+    args, overrides = parser.parse_known_args()
+    return args, overrides
+
+
+def load_grpo_config(config_path: str, overrides: list[str]) -> GRPOMasterConfig:
+    """Load and validate the source GRPO recipe before converting it."""
+    config = load_config(config_path)
+    if overrides:
+        config = parse_hydra_overrides(config, overrides)
+    resolved_config = OmegaConf.to_container(config, resolve=True)
+    if not isinstance(resolved_config, dict):
+        raise TypeError("The GRPO recipe must resolve to a mapping")
+    return GRPOMasterConfig.model_validate(resolved_config)
+
+
+def _convert_validation_data(grpo_config: GRPOMasterConfig) -> dict[str, Any]:
+    """Merge RL validation data with its defaults into eval's flat data block."""
+    validation_config = grpo_config.data.get("validation")
+    if validation_config is None:
+        raise ValueError("Rollout benchmark requires data.validation")
+    if isinstance(validation_config, list):
+        raise ValueError(
+            "Rollout benchmark requires exactly one data.validation dataset"
+        )
+
+    default_config = grpo_config.data.get("default")
+    if default_config is None:
+        raise ValueError("Rollout benchmark requires data.default")
+
+    data_config = cast(dict[str, Any], deepcopy(default_config))
+    data_config.update(cast(dict[str, Any], deepcopy(validation_config)))
+    data_config["max_input_seq_length"] = grpo_config.data["max_input_seq_length"]
+    if data_config.get("dataset_name") != "NemoGymDataset":
+        raise ValueError(
+            "NeMo Gym rollout benchmark requires "
+            "data.default.dataset_name=NemoGymDataset"
+        )
+    return data_config
+
+
+def convert_grpo_to_eval_config(
+    grpo_config: GRPOMasterConfig,
+) -> EvalMasterConfig:
+    """Convert an RL recipe into the standard eval configuration schema."""
+    if not grpo_config.env.get("should_use_nemo_gym"):
+        raise ValueError(
+            "NeMo Gym rollout benchmark requires env.should_use_nemo_gym=true"
+        )
+    nemo_gym_config = grpo_config.env.get("nemo_gym")
+    if not isinstance(nemo_gym_config, dict):
+        raise ValueError("NeMo Gym rollout benchmark requires env.nemo_gym")
+
+    source_generation_config = grpo_config.policy.get("generation")
+    if source_generation_config is None:
+        raise ValueError("Rollout benchmark requires policy.generation")
+    generation_config = cast(dict[str, Any], deepcopy(source_generation_config))
+    generation_config["model_name"] = grpo_config.policy["model_name"]
+    generation_config["num_prompts_per_step"] = grpo_config.grpo["num_prompts_per_step"]
+    if generation_config["backend"] == "vllm":
+        vllm_config = generation_config["vllm_cfg"]
+        vllm_config.setdefault("enable_vllm_metrics_logger", True)
+        vllm_config.setdefault("vllm_metrics_logger_interval", 0.5)
+
+    converted_nemo_gym_config = deepcopy(nemo_gym_config)
+    # These select the legacy collect_trajectories path in the source entrypoint;
+    # benchmark batching is derived exclusively from the GRPO step configuration.
+    converted_nemo_gym_config.pop("is_trajectory_collection", None)
+    converted_nemo_gym_config.pop("trajectory_collection_batch_size", None)
+
+    policy_config = deepcopy(grpo_config.policy)
+    policy_config["generation"] = cast(GenerationConfig, generation_config)
+    converted_config: dict[str, Any] = {
+        "eval": {
+            "metric": ROLLOUT_BENCHMARK_METRIC,
+            "num_tests_per_prompt": grpo_config.grpo["num_generations_per_prompt"],
+            "seed": grpo_config.grpo["seed"],
+            "k_value": ROLLOUT_BENCHMARK_K_VALUE,
+            "save_path": None,
+        },
+        "generation": generation_config,
+        "tokenizer": deepcopy(grpo_config.policy["tokenizer"]),
+        "data": _convert_validation_data(grpo_config),
+        "env": {
+            "should_use_nemo_gym": True,
+            "nemo_gym": converted_nemo_gym_config,
+        },
+        "logger": deepcopy(grpo_config.logger),
+        "cluster": deepcopy(grpo_config.cluster),
+        "policy": policy_config,
+    }
+    return EvalMasterConfig.model_validate(converted_config)
+
+
+def main() -> None:
+    """Convert an RL recipe and run it through the standard eval entrypoint."""
+    register_omegaconf_resolvers()
+    args, overrides = parse_args()
+    if args.config is None:
+        args.config = os.path.join(
+            os.path.dirname(__file__),
+            "grpo_workplace_assistant_nemotron_nano_v2_9b.yaml",
+        )
+
+    grpo_config = load_grpo_config(args.config, overrides)
+    eval_config = convert_grpo_to_eval_config(grpo_config)
+    print(f"Loaded GRPO configuration from: {args.config}")
+    print("Converted GRPO configuration to the standard eval schema")
+    run_eval(eval_config)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/nemo_gym/run_grpo_rollout_benchmark.py
+++ b/examples/nemo_gym/run_grpo_rollout_benchmark.py
@@ -120,6 +120,37 @@ def convert_grpo_to_eval_config(
 
     policy_config = deepcopy(grpo_config.policy)
     policy_config["generation"] = cast(GenerationConfig, generation_config)
+
+    # The benchmark is generation-only, so the eval "cluster" IS the generation
+    # cluster. Size it to the generation's own (non-colocated) resources rather than
+    # the full training cluster: otherwise EVERY allocated node becomes a generation
+    # replica (dp_size == cluster.num_nodes), so a node the launcher reserved for
+    # training silently becomes an extra replica and dilutes per-replica concurrency
+    # to GBS / cluster.num_nodes (e.g. R=2 requested but 3 nodes allocated → 3
+    # replicas at GBS/3). Fall back to the training cluster when generation is
+    # colocated or declares no explicit resources.
+    eval_cluster = cast(dict[str, Any], deepcopy(grpo_config.cluster))
+    gen_colocated = cast(dict[str, Any], generation_config.get("colocated") or {})
+    if not gen_colocated.get("enabled", False):
+        gen_resources = cast(dict[str, Any], gen_colocated.get("resources") or {})
+        gen_num_nodes = gen_resources.get("num_nodes")
+        if gen_num_nodes:
+            if gen_num_nodes != eval_cluster.get("num_nodes"):
+                print(
+                    f"Rollout benchmark: sizing the generation cluster to "
+                    f"{gen_num_nodes} node(s) from policy.generation.colocated.resources "
+                    f"(training cluster has {eval_cluster.get('num_nodes')}); "
+                    f"per-replica concurrency = GBS / {gen_num_nodes}."
+                )
+            eval_cluster["num_nodes"] = gen_num_nodes
+            gen_gpus_per_node = gen_resources.get("gpus_per_node")
+            if gen_gpus_per_node:
+                eval_cluster["gpus_per_node"] = gen_gpus_per_node
+            # Keep the cluster valid: segment_size must divide num_nodes.
+            segment_size = eval_cluster.get("segment_size")
+            if segment_size and gen_num_nodes % segment_size != 0:
+                eval_cluster["segment_size"] = 1
+
     converted_config: dict[str, Any] = {
         "eval": {
             "metric": ROLLOUT_BENCHMARK_METRIC,
@@ -136,7 +167,7 @@ def convert_grpo_to_eval_config(
             "nemo_gym": converted_nemo_gym_config,
         },
         "logger": deepcopy(grpo_config.logger),
-        "cluster": deepcopy(grpo_config.cluster),
+        "cluster": eval_cluster,
         "policy": policy_config,
     }
     return EvalMasterConfig.model_validate(converted_config)

--- a/examples/nemo_gym/run_grpo_rollout_benchmark.py
+++ b/examples/nemo_gym/run_grpo_rollout_benchmark.py
@@ -14,8 +14,16 @@
 
 import argparse
 import os
+import sys
 from copy import deepcopy
 from typing import Any, cast
+
+# Allow running this file directly (e.g. `uv run examples/nemo_gym/run_grpo_rollout_benchmark.py`):
+# put the repo root on sys.path so the `from examples...` / `from nemo_rl...` imports below resolve
+# even when Python placed this file's own directory on sys.path[0] instead of the repo root.
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
 
 from omegaconf import OmegaConf
 

--- a/examples/run_eval.py
+++ b/examples/run_eval.py
@@ -26,10 +26,20 @@ from nemo_rl.data.datasets import AllTaskProcessedDataset, load_eval_dataset
 from nemo_rl.data.datasets.eval_datasets import _is_multimodal_dataset
 from nemo_rl.data.datasets.response_datasets import load_response_dataset
 from nemo_rl.distributed.virtual_cluster import init_ray
+from nemo_rl.environments.nemo_gym import setup_nemo_gym_generation_config
 from nemo_rl.environments.utils import create_env
-from nemo_rl.evals.eval import MasterConfig, run_env_eval, setup
+from nemo_rl.evals.eval import (
+    EvalRunResult,
+    MasterConfig,
+    NemoGymEvalDataConfig,
+    run_env_eval,
+    setup,
+    setup_nemo_gym_environment,
+    should_use_nemo_gym,
+)
 from nemo_rl.models.generation import configure_generation_config
 from nemo_rl.utils.config import load_config
+from nemo_rl.utils.logger import Logger
 
 
 def parse_args():
@@ -50,6 +60,18 @@ def parse_args():
 
 def setup_data(tokenizer, data_config, env_configs, is_multimodal=False):
     print("Setting up data...")
+
+    if isinstance(data_config, NemoGymEvalDataConfig):
+        base_dataset = load_response_dataset(data_config.model_dump())
+        dataset = AllTaskProcessedDataset(
+            dataset=base_dataset.dataset,
+            tokenizer=tokenizer,
+            default_task_data_spec=base_dataset.task_spec,
+            task_data_processors=base_dataset.processor,
+            task_data_preprocessors=base_dataset.preprocessor,
+            max_seq_length=data_config.max_input_seq_length,
+        )
+        return dataset, None, tokenizer
 
     # load dataset
     # TODO(#2840): consolidate onto load_response_dataset. Migration is in
@@ -83,9 +105,65 @@ def setup_data(tokenizer, data_config, env_configs, is_multimodal=False):
     return dataset, env, tokenizer
 
 
-def main():
-    """Main entry point."""
-    # Parse arguments
+def run_eval(config: MasterConfig) -> EvalRunResult:
+    """Run evaluation from an already validated eval configuration."""
+    # Print config
+    print("Final config:")
+    pprint.pprint(config)
+
+    # Init ray
+    init_ray()
+
+    # Setup tokenizer — get_tokenizer handles both text-only and multimodal
+    is_multimodal = not should_use_nemo_gym(config) and _is_multimodal_dataset(
+        config.data["dataset_name"]
+    )
+    tokenizer = get_tokenizer(config.tokenizer, get_processor=is_multimodal)
+    config.generation = configure_generation_config(
+        config.generation, tokenizer, is_eval=True
+    )
+    if should_use_nemo_gym(config):
+        setup_nemo_gym_generation_config(config.generation)
+
+    # Setup data
+    (
+        dataset,
+        env,
+        tokenizer,
+    ) = setup_data(tokenizer, config.data, config.env, is_multimodal=is_multimodal)
+
+    # Setup
+    (
+        vllm_generation,
+        dataloader,
+        master_config,
+    ) = setup(config, tokenizer, dataset)
+
+    if should_use_nemo_gym(master_config):
+        env = setup_nemo_gym_environment(vllm_generation, master_config)
+
+    logger = Logger(master_config.logger) if master_config.logger is not None else None
+    if logger is not None:
+        logger.log_hyperparams(master_config.model_dump())
+
+    # Run evaluation
+    try:
+        result = run_env_eval(
+            vllm_generation,
+            dataloader,
+            env,
+            master_config,
+            tokenizer=tokenizer,
+            logger=logger,
+        )
+    finally:
+        if logger is not None:
+            logger.close()
+    return result
+
+
+def main() -> None:
+    """Load a standard eval YAML and run evaluation."""
     args, overrides = parse_args()
 
     if not args.config:
@@ -102,44 +180,9 @@ def main():
         config = OmegaConf.merge(config, override_conf)
 
     config = OmegaConf.to_container(config, resolve=True)
-    config = MasterConfig(**config)
+    master_config = MasterConfig(**config)
     print("Applied CLI overrides")
-
-    # Print config
-    print("Final config:")
-    pprint.pprint(config)
-
-    # Init ray
-    init_ray()
-
-    # Setup tokenizer — get_tokenizer handles both text-only and multimodal
-    is_multimodal = _is_multimodal_dataset(config.data["dataset_name"])
-    tokenizer = get_tokenizer(config.tokenizer, get_processor=is_multimodal)
-    config.generation = configure_generation_config(
-        config.generation, tokenizer, is_eval=True
-    )
-
-    # Setup data
-    (
-        dataset,
-        env,
-        tokenizer,
-    ) = setup_data(tokenizer, config.data, config.env, is_multimodal=is_multimodal)
-
-    # Setup
-    (
-        vllm_generation,
-        dataloader,
-        master_config,
-    ) = setup(config, tokenizer, dataset)
-
-    # Run evaluation
-    run_env_eval(
-        vllm_generation,
-        dataloader,
-        env,
-        master_config,
-    )
+    run_eval(master_config)
 
 
 if __name__ == "__main__":

--- a/examples/run_eval.py
+++ b/examples/run_eval.py
@@ -158,7 +158,7 @@ def run_eval(config: MasterConfig) -> EvalRunResult:
         )
     finally:
         if logger is not None:
-            logger.close()
+            logger.finish()
     return result
 
 

--- a/nemo_rl/algorithms/utils.py
+++ b/nemo_rl/algorithms/utils.py
@@ -925,6 +925,7 @@ def log_generation_metrics_to_wandb(
     step: int,
     timeline_interval: float,
     logger: Logger,
+    step_metric: str | None = None,
 ) -> None:
     """Log generation metrics to wandb.
 
@@ -933,6 +934,7 @@ def log_generation_metrics_to_wandb(
         step: Global step value
         timeline_interval: Interval between timeline points (in seconds)
         logger: Logger instance
+        step_metric: Optional custom step field for batch-driven eval logging
     """
     for generation_metric in generation_logger_metrics.keys():
         logger.log_plot_per_worker_timeline_metrics(
@@ -941,6 +943,7 @@ def log_generation_metrics_to_wandb(
             prefix="generation_metrics",
             name=generation_metric,
             timeline_interval=timeline_interval,
+            step_metric=step_metric,
         )
 
 

--- a/nemo_rl/data/collate_fn.py
+++ b/nemo_rl/data/collate_fn.py
@@ -79,7 +79,8 @@ def eval_collate_fn(data_batch: list[DatumSpec]) -> BatchedDataDict[Any]:
     """Collate function for evaluation.
 
     Takes a list of data samples and combines them into a single batched dictionary
-    for model evaluation.
+    for model evaluation. ``loss_multiplier`` is retained because agent-backed
+    evaluation reuses the rollout result assembly path, which expects this field.
 
     Args:
         data_batch: List of data samples with message_log, extra_env_info, and idx fields.
@@ -118,6 +119,9 @@ def eval_collate_fn(data_batch: list[DatumSpec]) -> BatchedDataDict[Any]:
     extra_env_info = [datum_spec["extra_env_info"] for datum_spec in data_batch]
     idx = [datum_spec["idx"] for datum_spec in data_batch]
     task_names = [datum_spec.get("task_name", None) for datum_spec in data_batch]
+    loss_multiplier = torch.tensor(
+        [datum_spec.get("loss_multiplier", 1.0) for datum_spec in data_batch]
+    )
 
     # Check if any of the data batch has vllm content (multimodal data)
     extra_args = {}
@@ -142,6 +146,7 @@ def eval_collate_fn(data_batch: list[DatumSpec]) -> BatchedDataDict[Any]:
         extra_env_info=extra_env_info,
         idx=idx,
         task_name=task_names,
+        loss_multiplier=loss_multiplier,
         **extra_args,
     )
     return output

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -32,7 +32,6 @@ from nemo_rl.distributed.virtual_cluster import (
     _get_free_port_local,
     _get_node_ip_local,
 )
-from nemo_rl.distributed.ray_actor_environment_registry import get_actor_python_env
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.utils.routed_experts_codec import decode_routed_experts
 from nemo_rl.utils.timer import Timer
@@ -592,62 +591,6 @@ def validate_reward_components_match_scalar(nemo_gym_results: List[dict]) -> Non
                 "verifier must set reward = sum(reward_components.values()) so single-reward "
                 "(GRPO) consumers and GDPO read the same aggregate."
             )
-
-
-def create_nemo_gym_actor(
-    *,
-    model_name: str,
-    base_urls: list[str],
-    nemo_gym_config: dict[str, Any],
-) -> Any:
-    """Create and start a NeMo Gym actor connected to generation endpoints.
-
-    Args:
-        model_name: Model name advertised to NeMo Gym.
-        base_urls: OpenAI-compatible generation server base URLs.
-        nemo_gym_config: NeMo Gym global configuration.
-
-    Returns:
-        A started ``NemoGym`` Ray actor handle.
-    """
-    nemo_gym_py_exec = get_actor_python_env("nemo_rl.environments.nemo_gym.NemoGym")
-    if nemo_gym_py_exec.startswith("uv"):
-        nemo_gym_py_exec = create_local_venv_on_each_node(
-            nemo_gym_py_exec, "nemo_rl.environments.nemo_gym.NemoGym"
-        )
-
-    initial_global_config_dict = dict(nemo_gym_config)
-    invalid_tool_call_patterns = initial_global_config_dict.pop(
-        "invalid_tool_call_patterns", None
-    )
-    thinking_tags = initial_global_config_dict.pop("thinking_tags", None)
-
-    uv_cache_dir = get_nemo_gym_uv_cache_dir()
-    if uv_cache_dir is not None:
-        initial_global_config_dict.setdefault("uv_cache_dir", uv_cache_dir)
-    uv_venv_dir = get_nemo_gym_venv_dir()
-    if uv_venv_dir is not None:
-        initial_global_config_dict.setdefault("uv_venv_dir", uv_venv_dir)
-
-    nemo_gym_cfg = NemoGymConfig(
-        model_name=model_name,
-        base_urls=base_urls,
-        invalid_tool_call_patterns=invalid_tool_call_patterns,
-        thinking_tags=thinking_tags,
-        require_routed_experts=False,
-        initial_global_config_dict=initial_global_config_dict,
-    )
-    runtime_env = {
-        "py_executable": nemo_gym_py_exec,
-        "env_vars": {
-            **os.environ,
-            "VIRTUAL_ENV": nemo_gym_py_exec,
-            "UV_PROJECT_ENVIRONMENT": nemo_gym_py_exec,
-        },
-    }
-    actor = NemoGym.options(runtime_env=runtime_env).remote(nemo_gym_cfg)
-    ray.get(actor._spinup.remote())
-    return actor
 
 
 ########################################

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -32,6 +32,7 @@ from nemo_rl.distributed.virtual_cluster import (
     _get_free_port_local,
     _get_node_ip_local,
 )
+from nemo_rl.distributed.ray_actor_environment_registry import get_actor_python_env
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.utils.routed_experts_codec import decode_routed_experts
 from nemo_rl.utils.timer import Timer
@@ -593,17 +594,82 @@ def validate_reward_components_match_scalar(nemo_gym_results: List[dict]) -> Non
             )
 
 
+def create_nemo_gym_actor(
+    *,
+    model_name: str,
+    base_urls: list[str],
+    nemo_gym_config: dict[str, Any],
+) -> Any:
+    """Create and start a NeMo Gym actor connected to generation endpoints.
+
+    Args:
+        model_name: Model name advertised to NeMo Gym.
+        base_urls: OpenAI-compatible generation server base URLs.
+        nemo_gym_config: NeMo Gym global configuration.
+
+    Returns:
+        A started ``NemoGym`` Ray actor handle.
+    """
+    nemo_gym_py_exec = get_actor_python_env("nemo_rl.environments.nemo_gym.NemoGym")
+    if nemo_gym_py_exec.startswith("uv"):
+        nemo_gym_py_exec = create_local_venv_on_each_node(
+            nemo_gym_py_exec, "nemo_rl.environments.nemo_gym.NemoGym"
+        )
+
+    initial_global_config_dict = dict(nemo_gym_config)
+    invalid_tool_call_patterns = initial_global_config_dict.pop(
+        "invalid_tool_call_patterns", None
+    )
+    thinking_tags = initial_global_config_dict.pop("thinking_tags", None)
+
+    uv_cache_dir = get_nemo_gym_uv_cache_dir()
+    if uv_cache_dir is not None:
+        initial_global_config_dict.setdefault("uv_cache_dir", uv_cache_dir)
+    uv_venv_dir = get_nemo_gym_venv_dir()
+    if uv_venv_dir is not None:
+        initial_global_config_dict.setdefault("uv_venv_dir", uv_venv_dir)
+
+    nemo_gym_cfg = NemoGymConfig(
+        model_name=model_name,
+        base_urls=base_urls,
+        invalid_tool_call_patterns=invalid_tool_call_patterns,
+        thinking_tags=thinking_tags,
+        require_routed_experts=False,
+        initial_global_config_dict=initial_global_config_dict,
+    )
+    runtime_env = {
+        "py_executable": nemo_gym_py_exec,
+        "env_vars": {
+            **os.environ,
+            "VIRTUAL_ENV": nemo_gym_py_exec,
+            "UV_PROJECT_ENVIRONMENT": nemo_gym_py_exec,
+        },
+    }
+    actor = NemoGym.options(runtime_env=runtime_env).remote(nemo_gym_cfg)
+    ray.get(actor._spinup.remote())
+    return actor
+
+
 ########################################
 # Global config utils
 ########################################
 
 
-def setup_nemo_gym_config(config, tokenizer) -> None:
-    generation_config = config.policy["generation"]
+def setup_nemo_gym_generation_config(generation_config: dict[str, Any]) -> None:
+    """Configure a generation backend for NeMo Gym HTTP rollouts."""
+    backend = generation_config.get("backend")
+    if backend == "vllm":
+        backend_config = generation_config["vllm_cfg"]
+    elif backend == "megatron":
+        backend_config = generation_config["mcore_generation_config"]
+    else:
+        raise ValueError(
+            "NeMo Gym HTTP rollouts require backend=vllm or backend=megatron"
+        )
 
-    # Enable the http server. Requires both async engine and the expose_http_server flag
-    generation_config["vllm_cfg"]["async_engine"] = True
-    generation_config["vllm_cfg"]["expose_http_server"] = True
+    # Gym calls the rollout engine through its OpenAI-compatible HTTP server.
+    backend_config["async_engine"] = True
+    backend_config["expose_http_server"] = True
 
     # Stop strings or token ids are not supported
     generation_config["stop_strings"] = None
@@ -691,3 +757,8 @@ def spinup_nemo_gym_actor(
     actor = NemoGym.options(**nemo_gym_opts).remote(nemo_gym_cfg)
     ray.get(actor._spinup.remote())
     return actor
+
+
+def setup_nemo_gym_config(config, tokenizer) -> None:
+    """Configure a training config for NeMo Gym rollouts."""
+    setup_nemo_gym_generation_config(config.policy["generation"])

--- a/nemo_rl/evals/eval.py
+++ b/nemo_rl/evals/eval.py
@@ -16,16 +16,20 @@ import asyncio
 import json
 import os
 from collections import Counter
+from dataclasses import dataclass
 from itertools import combinations
-from typing import NotRequired, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 
+import numpy as np
 import ray
 import torch
 from pydantic import BaseModel
+from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import DataLoader
 from transformers import AutoTokenizer
+from wandb import Table
 
-from nemo_rl.algorithms.utils import set_seed
+from nemo_rl.algorithms.utils import log_generation_metrics_to_wandb, set_seed
 from nemo_rl.data import EvalDataConfigType
 from nemo_rl.data.collate_fn import eval_collate_fn
 from nemo_rl.data.datasets import AllTaskProcessedDataset
@@ -33,10 +37,22 @@ from nemo_rl.data.llm_message_utils import get_keys_from_message_log
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.virtual_cluster import ClusterConfig, RayVirtualCluster
 from nemo_rl.environments.math_environment import MathEnvConfig
+from nemo_rl.environments.nemo_gym import (
+    DEFAULT_GYM_PORT_RANGE_HIGH,
+    DEFAULT_GYM_PORT_RANGE_LOW,
+    create_nemo_gym_actor,
+)
 from nemo_rl.environments.vlm_environment import VLMEnvConfig
-from nemo_rl.models.generation.interfaces import GenerationConfig
+from nemo_rl.experience.rollouts import run_async_nemo_gym_rollout
+from nemo_rl.models.generation.interfaces import GenerationConfig, GenerationInterface
+from nemo_rl.models.generation.megatron import MegatronGeneration
+from nemo_rl.models.generation.sglang.sglang_generation import SGLangGeneration
 from nemo_rl.models.generation.vllm import VllmGeneration
-from nemo_rl.models.policy import TokenizerConfig
+from nemo_rl.models.policy import PolicyConfig, TokenizerConfig
+from nemo_rl.utils.logger import Logger, LoggerConfig
+
+EVAL_STEP_METRIC = "eval_step"
+EVAL_STEP_PATTERNS = ("eval/*", "generation_metrics/*", "ray/*")
 
 # ===============================================================================
 # Configuration
@@ -51,19 +67,67 @@ class EvalConfig(TypedDict):
     save_path: str | None
 
 
+class NemoGymEvalDataConfig(BaseModel, extra="allow"):
+    """Dataset configuration for NeMo Gym evaluation."""
+
+    dataset_name: Literal["NemoGymDataset"]
+    data_path: str
+    processor: Literal["nemo_gym_data_processor"]
+    env_name: Literal["nemo_gym"]
+    max_input_seq_length: int | None = None
+    repeat: int = 1
+    prompt_file: str | None = None
+    system_prompt_file: str | None = None
+
+
+class NemoGymEvalEnvConfig(BaseModel, extra="allow"):
+    """NeMo RL control fields plus pass-through NeMo Gym configuration."""
+
+    config_paths: list[str]
+    port_range_low: int = DEFAULT_GYM_PORT_RANGE_LOW
+    port_range_high: int = DEFAULT_GYM_PORT_RANGE_HIGH
+    rollout_max_attempts_to_avoid_lp_nan: int = 1
+    invalid_tool_call_patterns: list[str] | None = None
+    thinking_tags: list[str] | None = None
+
+
 # TODO: this should updated, but is left to avoid breaking changes
 class _PassThroughEnvConfig(TypedDict):
     math: NotRequired[MathEnvConfig]
     mmau: NotRequired[VLMEnvConfig]
+    should_use_nemo_gym: NotRequired[bool]
+    nemo_gym: NotRequired[NemoGymEvalEnvConfig]
 
 
 class MasterConfig(BaseModel, extra="allow"):
     eval: EvalConfig
     generation: GenerationConfig  # Fixed: was 'generate'
     tokenizer: TokenizerConfig  # Added missing tokenizer key
-    data: EvalDataConfigType
+    data: NemoGymEvalDataConfig | EvalDataConfigType
     env: _PassThroughEnvConfig
+    logger: LoggerConfig | None = None
     cluster: ClusterConfig
+    policy: PolicyConfig | None = None
+
+
+@dataclass
+class EvalRunResult:
+    """Programmatic result returned by an evaluation run."""
+
+    average_score: float
+    num_samples: int
+    generation_metrics: list[dict[str, Any]]
+    rollout_metrics: list[dict[str, Any]]
+
+
+def _get_num_generations_per_prompt(eval_config: EvalConfig) -> int:
+    """Validate and return the number of eval samples per prompt."""
+    value = eval_config.get("num_tests_per_prompt")
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise ValueError(
+            "eval.num_tests_per_prompt must be an integer greater than or equal to 1"
+        )
+    return value
 
 
 # ===============================================================================
@@ -71,12 +135,111 @@ class MasterConfig(BaseModel, extra="allow"):
 # ===============================================================================
 
 
+def should_use_nemo_gym(master_config: MasterConfig) -> bool:
+    """Return whether the evaluation should use NeMo Gym rollouts."""
+    return bool(master_config.env.get("should_use_nemo_gym"))
+
+
+def _validate_nemo_gym_generation_config(
+    generation_config: GenerationConfig,
+) -> None:
+    """Validate generation settings shared by all NeMo Gym eval callers."""
+    if generation_config["top_k"] is not None:
+        raise ValueError("NeMo Gym evaluation requires generation.top_k=null")
+    if generation_config["stop_strings"] or generation_config["stop_token_ids"]:
+        raise ValueError(
+            "NeMo Gym evaluation does not support stop strings or stop token IDs"
+        )
+
+    backend = generation_config["backend"]
+    if backend == "vllm":
+        backend_config = generation_config["vllm_cfg"]
+        config_path = "generation.vllm_cfg"
+    elif backend == "megatron":
+        backend_config = generation_config["mcore_generation_config"]
+        config_path = "generation.mcore_generation_config"
+    else:
+        raise ValueError(
+            "NeMo Gym evaluation supports the vLLM and Megatron rollout backends"
+        )
+    if not backend_config["async_engine"] or not backend_config.get(
+        "expose_http_server"
+    ):
+        raise ValueError(
+            f"NeMo Gym evaluation requires {config_path}.async_engine=true "
+            "and expose_http_server=true"
+        )
+
+    if backend == "vllm" and backend_config.get("enable_vllm_metrics_logger"):
+        metrics_interval = backend_config.get("vllm_metrics_logger_interval")
+        if not isinstance(metrics_interval, (int, float)) or metrics_interval <= 0:
+            raise ValueError(
+                "generation.vllm_cfg.vllm_metrics_logger_interval must be "
+                "positive when vLLM metrics logging is enabled"
+            )
+
+
+def _validate_nemo_gym_eval_config(master_config: MasterConfig) -> None:
+    """Fail early when a NeMo Gym evaluation cannot produce valid metrics."""
+    use_nemo_gym = should_use_nemo_gym(master_config)
+    if isinstance(master_config.data, NemoGymEvalDataConfig) and not use_nemo_gym:
+        raise ValueError(
+            "data.dataset_name=NemoGymDataset requires env.should_use_nemo_gym=true"
+        )
+    if not use_nemo_gym:
+        return
+
+    if "nemo_gym" not in master_config.env:
+        raise ValueError(
+            "env.should_use_nemo_gym=true requires an env.nemo_gym config block"
+        )
+    if not isinstance(master_config.data, NemoGymEvalDataConfig):
+        raise ValueError(
+            "NeMo Gym evaluation requires data.dataset_name=NemoGymDataset"
+        )
+    if master_config.logger is None:
+        raise ValueError(
+            "NeMo Gym evaluation requires a logger config to persist generation metrics"
+        )
+    if master_config.eval["metric"] == "cons@k":
+        raise ValueError(
+            "cons@k is not supported for NeMo Gym evaluation because Gym does "
+            "not expose a uniform extracted-answer field; use mean_reward or pass@k"
+        )
+    if master_config.eval["metric"] not in {"mean_reward", "pass@k"}:
+        raise ValueError(
+            "NeMo Gym evaluation supports only mean_reward and pass@k metrics"
+        )
+
+    _validate_nemo_gym_generation_config(master_config.generation)
+
+
+def setup_nemo_gym_environment(
+    vllm_generation: GenerationInterface,
+    master_config: MasterConfig,
+) -> Any:
+    """Start NeMo Gym against the eval generation server endpoints."""
+    _validate_nemo_gym_eval_config(master_config)
+    base_urls = getattr(vllm_generation, "dp_openai_server_base_urls", None)
+    if not isinstance(base_urls, list) or not base_urls:
+        raise RuntimeError(
+            f"The {master_config.generation['backend']} rollout engine did not "
+            "expose any OpenAI server endpoints for NeMo Gym"
+        )
+    nemo_gym_config = master_config.env["nemo_gym"].model_dump(exclude_none=True)
+    return create_nemo_gym_actor(
+        model_name=master_config.generation["model_name"],
+        base_urls=base_urls,
+        nemo_gym_config=nemo_gym_config,
+    )
+
+
 def setup(
     master_config: MasterConfig,
     tokenizer: AutoTokenizer,
     dataset: AllTaskProcessedDataset,
 ) -> tuple[
-    VllmGeneration,
+    GenerationInterface,
     DataLoader,
     MasterConfig,
 ]:
@@ -96,26 +259,28 @@ def setup(
     generation_config = master_config.generation
     cluster_config = master_config.cluster
 
+    _validate_nemo_gym_eval_config(master_config)
+
     # Set seed for reproducibility
     set_seed(eval_config["seed"])
 
     # Check settings
     metric = eval_config["metric"]
     k_value = eval_config["k_value"]
-    num_tests_per_prompt = eval_config["num_tests_per_prompt"]
+    num_generations_per_prompt = _get_num_generations_per_prompt(eval_config)
     temperature = generation_config["temperature"]
     top_k = generation_config["top_k"]
 
     # Validate metrics
-    assert metric in ["pass@k", "cons@k"], f"Invalid metric: {metric}"
-    if num_tests_per_prompt > 1:
+    assert metric in ["mean_reward", "pass@k", "cons@k"], f"Invalid metric: {metric}"
+    if num_generations_per_prompt > 1:
         assert temperature > 0 and top_k != 1, (
             "temperature > 0 and top_k != 1 are required for multiple samples"
         )
 
     assert k_value >= 1, "k_value must be greater than or equal to 1"
-    assert num_tests_per_prompt >= k_value, (
-        "num_tests_per_prompt must be greater than or equal to k_value "
+    assert num_generations_per_prompt >= k_value, (
+        "num_generations_per_prompt must be greater than or equal to k_value "
     )
 
     # ==========================
@@ -149,14 +314,36 @@ def setup(
     #           Model
     # ==========================
     print("\n▶ Setting up model...")
-    # check backend
+    # Initialize the configured rollout engine.
     backend = generation_config["backend"]
-    assert backend == "vllm", "Only vLLM backend is supported for evaluation"
-
-    # initialize vllm generation
-    vllm_generation = VllmGeneration(cluster=cluster, config=generation_config)
+    if backend == "vllm":
+        policy_generation: GenerationInterface = VllmGeneration(
+            cluster=cluster, config=generation_config
+        )
+    elif backend == "sglang":
+        sglang_config = generation_config["sglang_cfg"]
+        if "model_path" not in sglang_config:
+            sglang_config["model_path"] = generation_config["model_name"]
+        policy_generation = SGLangGeneration(
+            cluster=cluster, sglang_cfg=generation_config
+        )
+    elif backend == "megatron":
+        if master_config.policy is None:
+            raise ValueError(
+                "Megatron evaluation requires the full policy config; use the "
+                "GRPO-to-eval entrypoint or provide eval.policy"
+            )
+        master_config.policy["generation"] = generation_config
+        policy_generation = MegatronGeneration(
+            cluster=cluster,
+            config=master_config.policy,
+            tokenizer=tokenizer,
+        )
+    else:
+        raise ValueError(f"Unsupported evaluation generation backend: {backend}")
     print(
-        f"  ✓ Using vLLM backend for generation with {generation_config['model_name']}"
+        f"  ✓ Using {backend} backend for generation with "
+        f"{generation_config['model_name']}"
     )
 
     print("\n" + "=" * 60)
@@ -164,7 +351,7 @@ def setup(
     print("=" * 60 + "\n")
 
     return (
-        vllm_generation,
+        policy_generation,
         dataloader,
         master_config,
     )
@@ -277,7 +464,15 @@ def eval_cons_k(
     return cons_k_score
 
 
-def run_env_eval(vllm_generation, dataloader, env, master_config):
+def run_env_eval(
+    vllm_generation: GenerationInterface,
+    dataloader: DataLoader,
+    env: Any,
+    master_config: MasterConfig,
+    *,
+    tokenizer: AutoTokenizer | None = None,
+    logger: Logger | None = None,
+) -> EvalRunResult:
     """Main entry point for running evaluation using environment.
 
     Generates model responses and evaluates them by env.
@@ -288,6 +483,26 @@ def run_env_eval(vllm_generation, dataloader, env, master_config):
         env: Environment that scores responses.
         master_config: Configuration settings.
     """
+    if should_use_nemo_gym(master_config):
+        if tokenizer is None:
+            raise ValueError("NeMo Gym evaluation requires a tokenizer")
+        if logger is None:
+            raise ValueError(
+                "NeMo Gym evaluation requires a logger to persist generation metrics"
+            )
+        _validate_nemo_gym_eval_config(master_config)
+        logger.use_batch_steps(EVAL_STEP_METRIC, EVAL_STEP_PATTERNS)
+        return _run_nemo_gym_eval_impl(
+            vllm_generation=vllm_generation,
+            dataloader=dataloader,
+            nemo_gym=env,
+            tokenizer=tokenizer,
+            master_config=master_config,
+            logger=logger,
+        )
+
+    if logger is not None:
+        logger.use_batch_steps(EVAL_STEP_METRIC, EVAL_STEP_PATTERNS)
     generation_config = master_config.generation
     backend = generation_config.get("backend", "")
     if backend == "sglang":
@@ -296,35 +511,387 @@ def run_env_eval(vllm_generation, dataloader, env, master_config):
         use_async = bool(
             generation_config.get("vllm_cfg", {}).get("async_engine", False)
         )
+    elif backend == "megatron":
+        use_async = bool(
+            generation_config.get("mcore_generation_config", {}).get(
+                "async_engine", False
+            )
+        )
     else:
         use_async = False
-    asyncio.run(
+    return asyncio.run(
         _run_env_eval_impl(
-            vllm_generation, dataloader, env, master_config, use_async=use_async
+            vllm_generation,
+            dataloader,
+            env,
+            master_config,
+            use_async=use_async,
+            tokenizer=tokenizer,
+            logger=logger,
         )
     )
 
 
+def _log_generation_metrics(
+    *,
+    generation_metrics: dict[str, Any],
+    step: int,
+    generation_config: GenerationConfig,
+    logger_config: LoggerConfig | None,
+    require_numeric_metrics: bool,
+    logger: Logger | None,
+) -> None:
+    """Persist raw generation metrics and log batch-step summaries and plots."""
+    if logger is None or logger_config is None:
+        return
+
+    summary = _summarize_generation_metrics(generation_metrics)
+    if not summary:
+        if require_numeric_metrics:
+            raise RuntimeError(
+                f"NeMo Gym eval batch step {step} did not produce any numeric "
+                "generation metrics"
+            )
+        return
+    logger.log_string_list_as_jsonl(
+        [json.dumps({"step": step, "metrics": generation_metrics})],
+        "generation_metrics.jsonl",
+    )
+    logger.log_metrics(
+        {EVAL_STEP_METRIC: step, **summary},
+        step,
+        prefix="generation_metrics",
+        step_metric=EVAL_STEP_METRIC,
+    )
+    if generation_metrics and logger_config["wandb_enabled"]:
+        timeline_interval = 1.0
+        if generation_config["backend"] == "vllm":
+            timeline_interval = generation_config["vllm_cfg"].get(
+                "vllm_metrics_logger_interval", timeline_interval
+            )
+        log_generation_metrics_to_wandb(
+            generation_metrics,
+            step,
+            timeline_interval,
+            logger,
+            step_metric=EVAL_STEP_METRIC,
+        )
+
+
+def _summarize_generation_metrics(
+    generation_metrics: dict[str, Any],
+) -> dict[str, float]:
+    """Reduce per-worker time series to bounded scalar metrics for one batch."""
+    summary: dict[str, float] = {}
+    for metric_name, per_worker in generation_metrics.items():
+        worker_series = (
+            per_worker.values() if isinstance(per_worker, dict) else [per_worker]
+        )
+        all_values: list[float] = []
+        worker_last_values: list[float] = []
+        for series in worker_series:
+            values = series if isinstance(series, (list, tuple)) else [series]
+            numeric_values = [
+                float(value)
+                for value in values
+                if isinstance(value, (int, float, np.integer, np.floating))
+                and not isinstance(value, bool)
+                and np.isfinite(value)
+            ]
+            if numeric_values:
+                all_values.extend(numeric_values)
+                worker_last_values.append(numeric_values[-1])
+
+        if not all_values:
+            continue
+        summary[f"{metric_name}/mean"] = float(np.mean(all_values))
+        summary[f"{metric_name}/max"] = float(np.max(all_values))
+        summary[f"{metric_name}/last_mean"] = float(np.mean(worker_last_values))
+        summary[f"{metric_name}/last_sum"] = float(np.sum(worker_last_values))
+    return summary
+
+
+def _ensure_nemo_gym_generation_metrics(
+    generation_metrics: dict[str, Any],
+    rollout_metrics: dict[str, Any],
+    num_generations: int,
+) -> dict[str, Any]:
+    """Use backend telemetry when available, otherwise derive batch telemetry."""
+    if _summarize_generation_metrics(generation_metrics):
+        return generation_metrics
+
+    fallback_metrics: dict[str, Any] = {
+        "completed_generations": {0: [float(num_generations)]}
+    }
+    mean_tokens = rollout_metrics.get("gen_tokens_per_sample/mean")
+    if isinstance(mean_tokens, (int, float)) and np.isfinite(mean_tokens):
+        fallback_metrics["generated_tokens_per_sample"] = {0: [float(mean_tokens)]}
+        fallback_metrics["generated_tokens"] = {
+            0: [float(mean_tokens * num_generations)]
+        }
+
+    rollout_seconds = rollout_metrics.get("timing/rollout/total")
+    if isinstance(rollout_seconds, (int, float)) and np.isfinite(rollout_seconds):
+        fallback_metrics["rollout_seconds"] = {0: [float(rollout_seconds)]}
+        if rollout_seconds > 0 and isinstance(mean_tokens, (int, float)):
+            fallback_metrics["generated_tokens_per_rollout_second"] = {
+                0: [float(mean_tokens * num_generations / rollout_seconds)]
+            }
+    return fallback_metrics
+
+
+def _log_eval_batch_metrics(
+    logger: Logger | None,
+    *,
+    step: int,
+    metrics: dict[str, int | float],
+) -> None:
+    """Commit generation, rollout, and system metrics at one eval batch step."""
+    if logger is None:
+        return
+    logger.flush_system_metrics(step)
+    logger.log_metrics(
+        {EVAL_STEP_METRIC: step, **metrics},
+        step,
+        prefix="eval",
+        step_metric=EVAL_STEP_METRIC,
+        step_finished=True,
+    )
+
+
+def _run_nemo_gym_eval_impl(
+    *,
+    vllm_generation: GenerationInterface,
+    dataloader: DataLoader,
+    nemo_gym: Any,
+    tokenizer: AutoTokenizer,
+    master_config: MasterConfig,
+    logger: Logger,
+) -> EvalRunResult:
+    """Run NeMo Gym rollouts and aggregate eval and generation metrics."""
+    _validate_nemo_gym_eval_config(master_config)
+    generation_config = master_config.generation
+    metric = master_config.eval["metric"]
+    num_generations_per_prompt = _get_num_generations_per_prompt(master_config.eval)
+    num_prompts_per_step = generation_config["num_prompts_per_step"]
+    k_value = master_config.eval["k_value"]
+
+    score = 0.0
+    evaluation_data: list[dict[str, Any]] = []
+    generation_metrics: list[dict[str, Any]] = []
+    rollout_metrics: list[dict[str, Any]] = []
+    dataset_size = len(dataloader.dataset)
+    expected_results = dataset_size * num_generations_per_prompt
+    processed_prompts = 0
+
+    try:
+        if expected_results <= 0:
+            raise ValueError("NeMo Gym evaluation requires a non-empty dataset")
+
+        for batch_idx, batch in enumerate(dataloader):
+            batch_step = batch_idx + 1
+            if num_generations_per_prompt > 1:
+                batch = batch.repeat_interleave(num_generations_per_prompt)
+
+            vllm_generation.clear_logger_metrics()
+            rollout_result = run_async_nemo_gym_rollout(
+                policy_generation=vllm_generation,
+                input_batch=batch,
+                tokenizer=tokenizer,
+                task_to_env={"nemo_gym": nemo_gym},
+                generation_config=generation_config,
+                max_seq_len=None,
+                max_rollout_turns=None,
+                greedy=False,
+            )
+            rewards = rollout_result.final_batch["total_reward"]
+            batch_generation_metrics = _ensure_nemo_gym_generation_metrics(
+                vllm_generation.get_logger_metrics(),
+                rollout_result.rollout_metrics,
+                rewards.numel(),
+            )
+            generation_metrics.append(
+                {"step": batch_step, "metrics": batch_generation_metrics}
+            )
+            _log_generation_metrics(
+                generation_metrics=batch_generation_metrics,
+                step=batch_step,
+                generation_config=generation_config,
+                logger_config=master_config.logger,
+                require_numeric_metrics=True,
+                logger=logger,
+            )
+
+            if rewards.numel() % num_generations_per_prompt != 0:
+                raise RuntimeError(
+                    f"NeMo Gym eval batch {batch_idx} returned {rewards.numel()} "
+                    "rewards, which is not divisible by "
+                    f"num_generations_per_prompt={num_generations_per_prompt}"
+                )
+            if metric == "mean_reward":
+                batch_score = rewards.sum().item() / num_generations_per_prompt
+            else:
+                batch_score = eval_pass_k(rewards, num_generations_per_prompt, k_value)
+            score += batch_score
+            batch_num_prompts = rewards.numel() // num_generations_per_prompt
+            if batch_num_prompts > num_prompts_per_step:
+                raise RuntimeError(
+                    f"NeMo Gym eval batch {batch_idx} returned {batch_num_prompts} "
+                    "prompts, which exceeds "
+                    f"num_prompts_per_step={num_prompts_per_step}"
+                )
+            if (
+                batch_step < len(dataloader)
+                and batch_num_prompts != num_prompts_per_step
+            ):
+                raise RuntimeError(
+                    f"NeMo Gym eval batch {batch_idx} returned {batch_num_prompts} "
+                    "prompts before the final batch; expected "
+                    f"num_prompts_per_step={num_prompts_per_step}"
+                )
+            prompt_index_offset = processed_prompts
+            processed_prompts += batch_num_prompts
+
+            scalar_rollout_metrics = {
+                key: value
+                for key, value in rollout_result.rollout_metrics.items()
+                if isinstance(value, (bool, int, float))
+            }
+            rollout_metrics.append(scalar_rollout_metrics)
+            logger.log_metrics(
+                {EVAL_STEP_METRIC: batch_step, **scalar_rollout_metrics},
+                batch_step,
+                prefix="eval/rollout",
+                step_metric=EVAL_STEP_METRIC,
+            )
+
+            serialized_results: list[str] = []
+            for key, value in rollout_result.rollout_metrics.items():
+                if "full_result" not in key or not isinstance(value, Table):
+                    continue
+                serialized_results.extend(row[0] for row in value.data)
+
+            if len(serialized_results) != rewards.numel():
+                raise RuntimeError(
+                    f"NeMo Gym eval batch {batch_idx} returned "
+                    f"{len(serialized_results)} full results for "
+                    f"{rewards.numel()} rewards"
+                )
+
+            attributed_results: list[str] = []
+            for batch_position, serialized_result in enumerate(serialized_results):
+                full_result = json.loads(serialized_result)
+                prompt_position = batch_position // num_generations_per_prompt
+                sample = {
+                    "full_result": full_result,
+                    "reward": float(full_result["reward"]),
+                    "sample_index": len(evaluation_data),
+                    "prompt_index": prompt_index_offset + prompt_position,
+                    "generation_index": (batch_position % num_generations_per_prompt),
+                    "num_generations_per_prompt": num_generations_per_prompt,
+                    "eval_batch_index": batch_idx,
+                    "eval_step": batch_step,
+                    "eval_batch_position": batch_position,
+                    "eval_batch_size": len(serialized_results),
+                }
+                evaluation_data.append(sample)
+                attributed_results.append(json.dumps(sample, separators=(",", ":")))
+
+            if not attributed_results:
+                raise RuntimeError(
+                    f"NeMo Gym eval batch {batch_idx} did not contain any full results"
+                )
+            logger.log_string_list_as_jsonl(
+                attributed_results, "nemo_gym_eval_results.jsonl"
+            )
+            batch_metrics: dict[str, int | float] = {
+                "batch/reward_mean": float(rewards.float().mean().item()),
+                "batch/reward_sum": float(rewards.sum().item()),
+                "batch/score": float(batch_score / batch_num_prompts),
+                "batch/num_prompts": batch_num_prompts,
+                "batch/num_generations": rewards.numel(),
+                "batch/num_generations_per_prompt": num_generations_per_prompt,
+                "num_prompts_total": processed_prompts,
+                "score_running": float(score / processed_prompts),
+            }
+            if batch_step == len(dataloader):
+                batch_metrics["score"] = float(score / dataset_size)
+            _log_eval_batch_metrics(
+                logger,
+                step=batch_step,
+                metrics=batch_metrics,
+            )
+    finally:
+        try:
+            ray.get(nemo_gym.shutdown.remote())
+        finally:
+            vllm_generation.shutdown()
+
+    if len(evaluation_data) != expected_results:
+        raise RuntimeError(
+            "NeMo Gym evaluation was incomplete: "
+            f"expected {expected_results} full results, got {len(evaluation_data)}"
+        )
+
+    save_path = master_config.eval.get("save_path")
+    if evaluation_data and save_path is not None:
+        _save_evaluation_data_to_json(
+            evaluation_data,
+            _master_config_data(master_config),
+            save_path,
+        )
+
+    _print_results(
+        generation_config,
+        score,
+        dataset_size,
+        metric,
+        k_value,
+        num_generations_per_prompt,
+        dataset_name=_master_config_dataset_name(master_config),
+        seed=master_config.eval["seed"],
+    )
+    average_score = score / dataset_size
+    return EvalRunResult(
+        average_score=average_score,
+        num_samples=dataset_size,
+        generation_metrics=generation_metrics,
+        rollout_metrics=rollout_metrics,
+    )
+
+
 async def _run_env_eval_impl(
-    vllm_generation, dataloader, env, master_config, use_async=False
-):
+    vllm_generation: GenerationInterface,
+    dataloader: DataLoader,
+    env: Any,
+    master_config: MasterConfig,
+    use_async: bool = False,
+    tokenizer: AutoTokenizer | None = None,
+    logger: Logger | None = None,
+) -> EvalRunResult:
     """Unified implementation for both sync and async evaluation."""
     # Extract for easier access
     generation_config = master_config.generation
     eval_config = master_config.eval
     metric = eval_config["metric"]
-    num_tests_per_prompt = eval_config["num_tests_per_prompt"]
+    num_generations_per_prompt = _get_num_generations_per_prompt(eval_config)
     k_value = eval_config["k_value"]
 
     # List to collect evaluation data for parquet file
     evaluation_data = []
+    generation_metrics: list[dict[str, Any]] = []
+    processed_prompts = 0
 
     # Run evaluation loop
     score = 0.0
-    for batch in dataloader:
+    for batch_idx, batch in enumerate(dataloader):
+        batch_step = batch_idx + 1
+        batch_num_prompts = len(batch["message_log"])
+        vllm_generation.clear_logger_metrics()
+
         # measure multiple samples
-        if num_tests_per_prompt > 1:
-            batch = batch.repeat_interleave(num_tests_per_prompt)
+        if num_generations_per_prompt > 1:
+            batch = batch.repeat_interleave(num_generations_per_prompt)
 
         # get input prompt from message_log
         is_multimodal = "vllm_content" in batch
@@ -367,7 +934,26 @@ async def _run_env_eval_impl(
 
         # generate by vllm
         inputs = BatchedDataDict({"prompts": prompts})
-        outputs = await _generate_texts(vllm_generation, inputs, use_async)
+        outputs = await _generate_texts(
+            vllm_generation,
+            inputs,
+            use_async,
+            backend=generation_config["backend"],
+            batch=batch,
+            tokenizer=tokenizer,
+        )
+        batch_generation_metrics = vllm_generation.get_logger_metrics()
+        generation_metrics.append(
+            {"step": batch_step, "metrics": batch_generation_metrics}
+        )
+        _log_generation_metrics(
+            generation_metrics=batch_generation_metrics,
+            step=batch_step,
+            generation_config=generation_config,
+            logger_config=master_config.logger,
+            require_numeric_metrics=False,
+            logger=logger,
+        )
 
         # append to message_log
         for idx, output in enumerate(outputs):
@@ -405,19 +991,45 @@ async def _run_env_eval_impl(
                     "message_log": message_log,
                     "extra_env_info": extra_info,
                     "sample_index": len(evaluation_data),
+                    "prompt_index": processed_prompts + i // num_generations_per_prompt,
+                    "generation_index": i % num_generations_per_prompt,
+                    "num_generations_per_prompt": num_generations_per_prompt,
+                    "eval_batch_index": batch_idx,
+                    "eval_step": batch_step,
                 }
             )
 
         # update stats
-        if metric == "pass@k":
-            score += eval_pass_k(rewards, num_tests_per_prompt, k_value)
+        if metric == "mean_reward":
+            batch_score = rewards.sum().item() / num_generations_per_prompt
+        elif metric == "pass@k":
+            batch_score = eval_pass_k(rewards, num_generations_per_prompt, k_value)
         elif metric == "cons@k":
             extracted_answers = env_return.answers
-            score += eval_cons_k(
-                rewards, num_tests_per_prompt, k_value, extracted_answers
+            batch_score = eval_cons_k(
+                rewards, num_generations_per_prompt, k_value, extracted_answers
             )
         else:
             raise ValueError(f"Invalid metric: {metric}")
+        score += batch_score
+        processed_prompts += batch_num_prompts
+        batch_metrics = {
+            "batch/reward_mean": float(rewards.float().mean().item()),
+            "batch/reward_sum": float(rewards.sum().item()),
+            "batch/score": float(batch_score / batch_num_prompts),
+            "batch/num_prompts": batch_num_prompts,
+            "batch/num_generations": rewards.numel(),
+            "batch/num_generations_per_prompt": num_generations_per_prompt,
+            "num_prompts_total": processed_prompts,
+            "score_running": float(score / processed_prompts),
+        }
+        if batch_step == len(dataloader):
+            batch_metrics["score"] = float(score / len(dataloader.dataset))
+        _log_eval_batch_metrics(
+            logger,
+            step=batch_step,
+            metrics=batch_metrics,
+        )
 
     # Cleanup before printing results
     ray.get(env.shutdown.remote())
@@ -426,62 +1038,172 @@ async def _run_env_eval_impl(
     # Save evaluation data to JSON file if save_path is specified
     save_path = eval_config.get("save_path")
     if evaluation_data and save_path is not None:
-        _save_evaluation_data_to_json(evaluation_data, master_config, save_path)
+        _save_evaluation_data_to_json(
+            evaluation_data,
+            _master_config_data(master_config),
+            save_path,
+        )
 
     # Print results
     _print_results(
-        master_config,
         generation_config,
         score,
         len(dataloader.dataset),
         metric,
         k_value,
-        num_tests_per_prompt,
+        num_generations_per_prompt,
+        dataset_name=_master_config_dataset_name(master_config),
+        seed=master_config.eval["seed"],
+    )
+    dataset_size = len(dataloader.dataset)
+    return EvalRunResult(
+        average_score=score / dataset_size,
+        num_samples=dataset_size,
+        generation_metrics=generation_metrics,
+        rollout_metrics=[],
     )
 
 
-async def _generate_texts(vllm_generation, inputs, use_async):
-    """Generate texts using either sync or async method."""
+def _build_generation_inputs(
+    batch: BatchedDataDict,
+    tokenizer: AutoTokenizer,
+) -> BatchedDataDict:
+    """Build backend-neutral token inputs from an eval message-log batch."""
+    input_ids = []
+    for sample_idx, message_log in enumerate(batch["message_log"]):
+        token_ids = [message.get("token_ids") for message in message_log]
+        if not token_ids or any(
+            not isinstance(tokens, torch.Tensor) for tokens in token_ids
+        ):
+            raise ValueError(
+                "Non-vLLM evaluation requires token_ids on every message; "
+                f"sample {sample_idx} is missing them"
+            )
+        input_ids.append(torch.cat(token_ids))
+
+    input_lengths = torch.tensor(
+        [tokens.numel() for tokens in input_ids], dtype=torch.int32
+    )
+    return BatchedDataDict(
+        {
+            "input_ids": pad_sequence(
+                input_ids,
+                batch_first=True,
+                padding_value=tokenizer.pad_token_id,
+            ),
+            "input_lengths": input_lengths,
+        }
+    )
+
+
+def _decode_generation_outputs(
+    outputs: BatchedDataDict,
+    input_lengths: torch.Tensor,
+    tokenizer: AutoTokenizer,
+) -> list[str]:
+    """Decode only newly generated tokens from GenerationInterface outputs."""
+    texts = []
+    for sample_idx, input_length in enumerate(input_lengths.tolist()):
+        total_length = int(outputs["unpadded_sequence_lengths"][sample_idx].item())
+        generated_ids = outputs["output_ids"][
+            sample_idx, int(input_length) : total_length
+        ]
+        texts.append(tokenizer.decode(generated_ids, skip_special_tokens=True))
+    return texts
+
+
+async def _generate_texts(
+    vllm_generation: GenerationInterface,
+    inputs: BatchedDataDict,
+    use_async: bool,
+    *,
+    backend: str,
+    batch: BatchedDataDict,
+    tokenizer: AutoTokenizer | None,
+) -> list[str]:
+    """Generate text through vLLM's text API or the common engine interface."""
+    if backend == "vllm" and isinstance(vllm_generation, VllmGeneration):
+        if use_async:
+            # generate_text_async accepts one sample per call; fan out and gather.
+            async def _generate_single_sample(i):
+                single = inputs.slice(i, i + 1)
+                async for _, result in vllm_generation.generate_text_async(single):
+                    return (i, result["texts"][0])
+                raise RuntimeError(f"No output produced for sample {i}")
+
+            results = await asyncio.gather(
+                *(_generate_single_sample(i) for i in range(inputs.size))
+            )
+            results.sort(key=lambda x: x[0])
+            return [text for _, text in results]
+        return vllm_generation.generate_text(inputs)["texts"]
+
+    if tokenizer is None:
+        raise ValueError(f"{backend} evaluation requires a tokenizer")
+    generation_inputs = _build_generation_inputs(batch, tokenizer)
     if use_async:
-        # generate_text_async accepts one sample per call; fan out and gather.
-        async def _generate_single_sample(i):
-            single = inputs.slice(i, i + 1)
-            async for _, result in vllm_generation.generate_text_async(single):
-                return (i, result["texts"][0])
+        # GenerationInterface async methods accept one sample per call.
+        async def _generate_single_sample(i: int) -> tuple[int, str]:
+            single = generation_inputs.slice(i, i + 1)
+            async for _, result in vllm_generation.generate_async(single, greedy=False):
+                return (
+                    i,
+                    _decode_generation_outputs(
+                        result, single["input_lengths"], tokenizer
+                    )[0],
+                )
             raise RuntimeError(f"No output produced for sample {i}")
 
         results = await asyncio.gather(
-            *(_generate_single_sample(i) for i in range(inputs.size))
+            *(_generate_single_sample(i) for i in range(generation_inputs.size))
         )
-        # Sort by index to maintain order
         results.sort(key=lambda x: x[0])
         return [text for _, text in results]
-    else:
-        # Use sync generation
-        return vllm_generation.generate_text(inputs)["texts"]
+
+    outputs = vllm_generation.generate(generation_inputs, greedy=False)
+    return _decode_generation_outputs(
+        outputs, generation_inputs["input_lengths"], tokenizer
+    )
 
 
-def _save_evaluation_data_to_json(evaluation_data, master_config, save_path):
-    """Save evaluation data to a JSON file.
+def _master_config_dataset_name(master_config: MasterConfig) -> str:
+    """Return the configured dataset name for output metadata."""
+    return (
+        master_config.data.dataset_name
+        if isinstance(master_config.data, NemoGymEvalDataConfig)
+        else master_config.data["dataset_name"]
+    )
 
-    Args:
-        evaluation_data: List of evaluation samples
-        master_config: Configuration dictionary
-        save_path: Path to save evaluation results. Set to null to disable saving.
-                  Example: "results/eval_output" or "/path/to/evaluation_results"
-    """
-    # Extract configuration information
-    config_data = {
+
+def _master_config_data(master_config: MasterConfig) -> dict[str, Any]:
+    """Build serializable output metadata for a standalone eval config."""
+    return {
         "model_name": master_config.generation["model_name"],
-        "dataset_name": master_config.data["dataset_name"],
+        "dataset_name": _master_config_dataset_name(master_config),
         "metric": master_config.eval["metric"],
         "k_value": master_config.eval["k_value"],
-        "num_tests_per_prompt": master_config.eval["num_tests_per_prompt"],
+        "num_generations_per_prompt": _get_num_generations_per_prompt(
+            master_config.eval
+        ),
         "temperature": master_config.generation["temperature"],
         "top_p": master_config.generation["top_p"],
         "top_k": master_config.generation["top_k"],
     }
 
+
+def _save_evaluation_data_to_json(
+    evaluation_data: list[dict[str, Any]],
+    config_data: dict[str, Any],
+    save_path: str,
+) -> None:
+    """Save evaluation data to a JSON file.
+
+    Args:
+        evaluation_data: List of evaluation samples
+        config_data: Resolved configuration metadata to persist.
+        save_path: Path to save evaluation results. Set to null to disable saving.
+                  Example: "results/eval_output" or "/path/to/evaluation_results"
+    """
     # Create directory if it doesn't exist
     save_dir = save_path
     if not os.path.exists(save_dir):
@@ -504,8 +1226,10 @@ def _save_evaluation_data_to_json(evaluation_data, master_config, save_path):
     for sample in evaluation_data:
         processed_sample = sample.copy()
         # Convert non-serializable objects to strings
-        processed_sample["message_log"] = str(sample["message_log"])
-        processed_sample["extra_env_info"] = str(sample["extra_env_info"])
+        if "message_log" in sample:
+            processed_sample["message_log"] = str(sample["message_log"])
+        if "extra_env_info" in sample:
+            processed_sample["extra_env_info"] = str(sample["extra_env_info"])
         processed_data.append(processed_sample)
 
     # Update data to save with processed version
@@ -521,19 +1245,20 @@ def _save_evaluation_data_to_json(evaluation_data, master_config, save_path):
 
 
 def _print_results(
-    master_config,
-    generation_config,
-    score,
-    dataset_size,
-    metric,
-    k_value,
-    num_tests_per_prompt,
-):
+    generation_config: GenerationConfig,
+    score: float,
+    dataset_size: int,
+    metric: str,
+    k_value: int,
+    num_generations_per_prompt: int,
+    *,
+    dataset_name: str,
+    seed: int,
+) -> None:
     """Print evaluation results."""
-    dataset_name = os.path.basename(master_config.data["dataset_name"])
+    dataset_name = os.path.basename(dataset_name)
     model_name = os.path.basename(generation_config["model_name"])
-    max_new_tokens = generation_config["vllm_cfg"]["max_model_len"]
-    seed = master_config.eval["seed"]
+    max_new_tokens = generation_config["max_new_tokens"]
     temperature = generation_config["temperature"]
     top_p = generation_config["top_p"]
     top_k = generation_config["top_k"]
@@ -542,6 +1267,7 @@ def _print_results(
     print("\n" + "=" * 60)
     print(f"{model_name=} {dataset_name=}")
     print(f"{max_new_tokens=} {temperature=} {top_p=} {top_k=} {seed=}\n")
-    print(f"metric={metric[:-1]}{k_value} {num_tests_per_prompt=}\n")
+    metric_name = f"{metric[:-1]}{k_value}" if metric.endswith("@k") else metric
+    print(f"metric={metric_name} {num_generations_per_prompt=}\n")
     print(f"score={average_score:.4f} ({score}/{dataset_size})")
     print("=" * 60 + "\n")

--- a/nemo_rl/evals/eval.py
+++ b/nemo_rl/evals/eval.py
@@ -40,7 +40,7 @@ from nemo_rl.environments.math_environment import MathEnvConfig
 from nemo_rl.environments.nemo_gym import (
     DEFAULT_GYM_PORT_RANGE_HIGH,
     DEFAULT_GYM_PORT_RANGE_LOW,
-    create_nemo_gym_actor,
+    spinup_nemo_gym_actor,
 )
 from nemo_rl.environments.vlm_environment import VLMEnvConfig
 from nemo_rl.experience.rollouts import run_async_nemo_gym_rollout
@@ -226,11 +226,13 @@ def setup_nemo_gym_environment(
             f"The {master_config.generation['backend']} rollout engine did not "
             "expose any OpenAI server endpoints for NeMo Gym"
         )
-    nemo_gym_config = master_config.env["nemo_gym"].model_dump(exclude_none=True)
-    return create_nemo_gym_actor(
-        model_name=master_config.generation["model_name"],
+    return spinup_nemo_gym_actor(
+        env_configs={
+            "nemo_gym": master_config.env["nemo_gym"].model_dump(exclude_none=True)
+        },
         base_urls=base_urls,
-        nemo_gym_config=nemo_gym_config,
+        model_name=master_config.generation["model_name"],
+        enable_router_replay=False,
     )
 
 

--- a/nemo_rl/evals/eval.py
+++ b/nemo_rl/evals/eval.py
@@ -43,7 +43,7 @@ from nemo_rl.environments.nemo_gym import (
     spinup_nemo_gym_actor,
 )
 from nemo_rl.environments.vlm_environment import VLMEnvConfig
-from nemo_rl.experience.rollouts import run_async_nemo_gym_rollout
+from nemo_rl.experience.rollouts import run_nemo_gym_rollout_sync
 from nemo_rl.models.generation.interfaces import GenerationConfig, GenerationInterface
 from nemo_rl.models.generation.megatron import MegatronGeneration
 from nemo_rl.models.generation.sglang.sglang_generation import SGLangGeneration
@@ -233,6 +233,8 @@ def setup_nemo_gym_environment(
         base_urls=base_urls,
         model_name=master_config.generation["model_name"],
         enable_router_replay=False,
+        routed_experts_dtype="int16",
+        use_fastokens=bool(master_config.tokenizer.get("use_fastokens")),
     )
 
 
@@ -696,12 +698,13 @@ def _run_nemo_gym_eval_impl(
                 batch = batch.repeat_interleave(num_generations_per_prompt)
 
             vllm_generation.clear_logger_metrics()
-            rollout_result = run_async_nemo_gym_rollout(
+            rollout_result = run_nemo_gym_rollout_sync(
                 policy_generation=vllm_generation,
                 input_batch=batch,
                 tokenizer=tokenizer,
                 task_to_env={"nemo_gym": nemo_gym},
                 generation_config=generation_config,
+                log_full_result_tables=True,
                 max_seq_len=None,
                 max_rollout_turns=None,
                 greedy=False,

--- a/nemo_rl/models/generation/interfaces.py
+++ b/nemo_rl/models/generation/interfaces.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import ABC, abstractmethod
-from typing import Any, NotRequired, Optional, TypedDict, Union
+from typing import Any, AsyncGenerator, NotRequired, Optional, TypedDict, Union
 
 import ray
 import torch
@@ -321,6 +321,12 @@ class GenerationInterface(ABC):
         self, data: BatchedDataDict["GenerationDatumSpec"], greedy: bool
     ) -> BatchedDataDict["GenerationOutputSpec"]:
         pass
+
+    def generate_async(
+        self, data: BatchedDataDict["GenerationDatumSpec"], greedy: bool = False
+    ) -> AsyncGenerator[tuple[int, BatchedDataDict["GenerationOutputSpec"]], None]:
+        """Generate one sample asynchronously."""
+        raise NotImplementedError
 
     @abstractmethod
     def prepare_for_generation(self, *args: Any, **kwargs: Any) -> bool:

--- a/nemo_rl/models/generation/vllm/config.py
+++ b/nemo_rl/models/generation/vllm/config.py
@@ -51,6 +51,9 @@ class VllmSpecificArgs(TypedDict):
     http_refit_server_port: NotRequired[int | None]
     # Fixed ZeroMQ relay port for stable Kubernetes targetPorts.
     zmq_refit_server_port: NotRequired[int | None]
+    # Periodically sample vLLM engine telemetry for rollout performance reporting.
+    enable_vllm_metrics_logger: NotRequired[bool]
+    vllm_metrics_logger_interval: NotRequired[int | float]
     # These kwargs are passed to the vllm.LLM HTTP server Chat Completions endpoint config. Typically this will include things like tool parser, chat template, etc
     http_server_serving_chat_kwargs: NotRequired[dict[str, Any]]
     # Miscellaneous top level vLLM HTTP server arguments.

--- a/nemo_rl/utils/logger.py
+++ b/nemo_rl/utils/logger.py
@@ -54,6 +54,8 @@ class WandbConfig(TypedDict):
     # Log complete NeMo Gym result payloads as W&B Tables. These payloads can be
     # very large, so the recommended default is false.
     log_nemo_gym_full_result_tables: NotRequired[bool]
+    id: NotRequired[str]
+    resume: NotRequired[str | bool]
 
 
 class SwanlabConfig(TypedDict):
@@ -380,8 +382,9 @@ class WandbLogger(LoggerInterface):
 
         # If step_metric is provided, use the corresponding value from metrics as step
         if step_metric and step_metric in metrics:
-            # commit=False so the step does not get incremented
-            self.run.log(metrics, commit=False)
+            # Multiple metrics from one logical step can be accumulated with
+            # commit=False and committed together by the final batch log.
+            self.run.log(metrics, commit=step_finished)
         elif step_finished:
             # Commit param defaults to None. By default if step is set, then commit defaults to False
             # Here, we have an explicit fork for commit in case W&B ever decides to change their default logic.
@@ -397,14 +400,25 @@ class WandbLogger(LoggerInterface):
         """
         self.run.config.update(params, allow_val_change=True)
 
-    def log_plot(self, figure: plt.Figure, step: int, name: str) -> None:
+    def log_plot(
+        self,
+        figure: plt.Figure,
+        step: int,
+        name: str,
+        *,
+        step_metric: Optional[str] = None,
+        step_finished: bool = False,
+    ) -> None:
         """Log a plot to wandb.
 
         Args:
             figure: Matplotlib figure to log
             step: Global step value
         """
-        self.run.log({name: figure}, step=step)
+        if step_metric:
+            self.run.log({step_metric: step, name: figure}, commit=step_finished)
+        else:
+            self.run.log({name: figure}, step=step)
 
     def finish(self) -> None:
         """Flush queued metrics and close the wandb service.
@@ -530,6 +544,11 @@ class RayGpuMonitorLogger:
         self.collection_thread: Optional[threading.Thread] = None
         self.lock = threading.Lock()
         self.start_time: float = float("-inf")
+        self.batch_step_metric: Optional[str] = None
+
+    def use_batch_steps(self, step_metric: str) -> None:
+        """Buffer samples until the caller flushes them at a batch step."""
+        self.batch_step_metric = step_metric
 
     def start(self) -> None:
         """Start the GPU monitoring thread."""
@@ -558,8 +577,14 @@ class RayGpuMonitorLogger:
         if self.collection_thread:
             self.collection_thread.join(timeout=self.collection_interval * 2)
 
-        # Final flush
-        self.flush()
+        # Wall-clock mode preserves the historical final flush. In batch mode,
+        # samples collected after the final batch have no valid batch step and
+        # must not create a second, time-based axis.
+        if self.batch_step_metric is None:
+            self.flush()
+        else:
+            with self.lock:
+                self.metrics_buffer = []
         print("GPU monitoring stopped")
 
     def _collection_loop(self) -> None:
@@ -584,7 +609,10 @@ class RayGpuMonitorLogger:
 
                 # Check if it's time to flush
                 current_time = time.time()
-                if current_time - self.last_flush_time >= self.flush_interval:
+                if (
+                    self.batch_step_metric is None
+                    and current_time - self.last_flush_time >= self.flush_interval
+                ):
                     self.flush()
                     self.last_flush_time = current_time
 
@@ -764,27 +792,63 @@ class RayGpuMonitorLogger:
             print(f"Error fetching metrics from {metric_address}: {e}")
             return {}
 
-    def flush(self) -> None:
-        """Flush collected metrics to the parent logger."""
+    def flush(self, step: Optional[int] = None) -> None:
+        """Flush metrics using wall-clock samples or one aggregated batch step."""
         with self.lock:
             if not self.metrics_buffer:
                 return
 
             if self.parent_logger:
-                # Log each set of metrics with its original step
-                for entry in self.metrics_buffer:
-                    step = entry["step"]
-                    metrics = entry["metrics"]
+                if step is None:
+                    # Historical training behavior: one point per collection
+                    # time, using seconds since monitor startup as the step.
+                    for entry in self.metrics_buffer:
+                        entry_step = entry["step"]
+                        metrics = dict(entry["metrics"])
+                        metrics[self.step_metric] = entry_step
+                        self.parent_logger.log_metrics(
+                            metrics,
+                            step=entry_step,
+                            prefix=self.metric_prefix,
+                            step_metric=self.step_metric,
+                        )
+                else:
+                    # Eval has no meaningful optimizer/global step. Aggregate
+                    # every sample observed during the batch and attach it to
+                    # the batch index supplied by the eval loop.
+                    values_by_name: dict[str, list[float]] = {}
+                    latest_by_name: dict[str, Any] = {}
+                    for entry in self.metrics_buffer:
+                        for name, value in entry["metrics"].items():
+                            if isinstance(
+                                value, (int, float, np.integer, np.floating)
+                            ) and not isinstance(value, bool):
+                                if np.isfinite(value):
+                                    latest_by_name[name] = value
+                                    values_by_name.setdefault(name, []).append(
+                                        float(value)
+                                    )
+                            else:
+                                latest_by_name[name] = value
 
-                    # Add the step metric directly to metrics for use as step_metric
-                    metrics[self.step_metric] = step
+                    metrics: dict[str, Any] = {
+                        "samples": len(self.metrics_buffer),
+                    }
+                    for name, values in values_by_name.items():
+                        metrics[f"{name}/mean"] = float(np.mean(values))
+                        metrics[f"{name}/max"] = float(np.max(values))
+                        metrics[f"{name}/last"] = float(values[-1])
+                    for name, value in latest_by_name.items():
+                        if name not in values_by_name:
+                            metrics[f"{name}/last"] = value
 
-                    # Pass step_metric as the step_metric to use it as the step value in wandb
+                    step_metric = self.batch_step_metric or self.step_metric
+                    metrics[step_metric] = step
                     self.parent_logger.log_metrics(
                         metrics,
                         step=step,
                         prefix=self.metric_prefix,
-                        step_metric=self.step_metric,
+                        step_metric=step_metric,
                     )
 
             # Clear buffer after logging
@@ -976,8 +1040,9 @@ class Logger(LoggerInterface):
                 - "gpu_monitoring": dict with "collection_interval" and "flush_interval" when GPU monitoring is enabled.
         """
         self.loggers: list[LoggerInterface] = []
-        self.wandb_logger = None
-        self.swanlab_logger = None
+        self.wandb_logger: Optional[WandbLogger] = None
+        self.swanlab_logger: Optional[SwanlabLogger] = None
+        self.gpu_monitor: Optional[RayGpuMonitorLogger] = None
 
         self.base_log_dir = cfg["log_dir"]
         os.makedirs(self.base_log_dir, exist_ok=True)
@@ -1011,7 +1076,6 @@ class Logger(LoggerInterface):
             self.loggers.append(mlflow_logger)
 
         # Initialize GPU monitoring if requested
-        self.gpu_monitor = None
         if cfg["monitor_gpus"]:
             metric_prefix = "ray"
             step_metric = f"{metric_prefix}/ray_step"
@@ -1068,6 +1132,17 @@ class Logger(LoggerInterface):
             if callable(finish):
                 finish()
 
+    def use_batch_steps(
+        self, step_metric: str, metric_patterns: tuple[str, ...]
+    ) -> None:
+        """Configure existing backends and system monitoring for batch steps."""
+        if self.wandb_logger is not None:
+            self.wandb_logger.define_metric(step_metric)
+            for pattern in metric_patterns:
+                self.wandb_logger.define_metric(pattern, step_metric=step_metric)
+        if self.gpu_monitor is not None:
+            self.gpu_monitor.use_batch_steps(step_metric)
+
     def log_batched_dict_as_jsonl(
         self, to_log: BatchedDataDict[Any] | dict[str, Any], filename: str
     ) -> None:
@@ -1122,6 +1197,7 @@ class Logger(LoggerInterface):
         prefix: str,
         name: str,
         timeline_interval: float,
+        step_metric: Optional[str] = None,
     ) -> None:
         """Log a plot of per-worker timeline metrics.
 
@@ -1174,7 +1250,12 @@ class Logger(LoggerInterface):
         ax.grid(True, alpha=0.2)
         fig.tight_layout()
 
-        self.log_plot(fig, step, f"{prefix}/per_worker_{name}")
+        self.log_plot(
+            fig,
+            step,
+            f"{prefix}/per_worker_{name}",
+            step_metric=step_metric,
+        )
         plt.close(fig)
 
         # Plot the average of the metrics
@@ -1191,7 +1272,12 @@ class Logger(LoggerInterface):
         ax.set_title(name)
         ax.grid(True, alpha=0.2)
         fig.tight_layout()
-        self.log_plot(fig, step, f"{prefix}/average_{name}")
+        self.log_plot(
+            fig,
+            step,
+            f"{prefix}/average_{name}",
+            step_metric=step_metric,
+        )
         plt.close(fig)
 
     def log_histogram(self, histogram: list[Any], step: int, name: str) -> None:
@@ -1205,7 +1291,15 @@ class Logger(LoggerInterface):
         for logger in self.loggers:
             logger.log_histogram(histogram, step, name)
 
-    def log_plot(self, figure: plt.Figure, step: int, name: str) -> None:
+    def log_plot(
+        self,
+        figure: plt.Figure,
+        step: int,
+        name: str,
+        *,
+        step_metric: Optional[str] = None,
+        step_finished: bool = False,
+    ) -> None:
         """Log a matplotlib figure to all backends.
 
         Args:
@@ -1213,8 +1307,36 @@ class Logger(LoggerInterface):
             step: Global step value
             name: Name of the plot
         """
+        wandb_logger = getattr(self, "wandb_logger", None)
         for logger in self.loggers:
-            logger.log_plot(figure, step, name)
+            if (
+                wandb_logger is not None
+                and logger is wandb_logger
+                and (step_metric is not None or step_finished)
+            ):
+                wandb_logger.log_plot(
+                    figure,
+                    step,
+                    name,
+                    step_metric=step_metric,
+                    step_finished=step_finished,
+                )
+            else:
+                logger.log_plot(figure, step, name)
+
+    def flush_system_metrics(self, step: int) -> None:
+        """Attach buffered Ray system metrics to a caller-defined batch step."""
+        if self.gpu_monitor is not None:
+            self.gpu_monitor.flush(step=step)
+
+    def close(self) -> None:
+        """Stop background monitoring and finish remote logging backends."""
+        if self.gpu_monitor is not None:
+            self.gpu_monitor.stop()
+            self.gpu_monitor = None
+        if self.wandb_logger is not None:
+            self.wandb_logger.finish()
+            self.wandb_logger = None
 
     def log_plot_token_mult_prob_error(
         self, data: dict[str, Any], step: int, name: str
@@ -1317,8 +1439,9 @@ class Logger(LoggerInterface):
 
     def __del__(self) -> None:
         """Clean up resources when the logger is destroyed."""
-        if self.gpu_monitor:
-            self.gpu_monitor.stop()
+        gpu_monitor = getattr(self, "gpu_monitor", None)
+        if gpu_monitor is not None:
+            gpu_monitor.stop()
 
 
 def flatten_dict(

--- a/nemo_rl/utils/logger.py
+++ b/nemo_rl/utils/logger.py
@@ -1043,6 +1043,7 @@ class Logger(LoggerInterface):
         self.wandb_logger: Optional[WandbLogger] = None
         self.swanlab_logger: Optional[SwanlabLogger] = None
         self.gpu_monitor: Optional[RayGpuMonitorLogger] = None
+        self._finished = False
 
         self.base_log_dir = cfg["log_dir"]
         os.makedirs(self.base_log_dir, exist_ok=True)
@@ -1126,11 +1127,18 @@ class Logger(LoggerInterface):
             logger.log_hyperparams(params)
 
     def finish(self) -> None:
-        """Flush and close backends that need explicit teardown (e.g. wandb)."""
+        """Stop system monitoring and finish backends exactly once."""
+        if self._finished:
+            return
+        if self.gpu_monitor is not None:
+            self.gpu_monitor.stop()
+            self.gpu_monitor = None
         for logger in self.loggers:
             finish = getattr(logger, "finish", None)
             if callable(finish):
                 finish()
+        self.wandb_logger = None
+        self._finished = True
 
     def use_batch_steps(
         self, step_metric: str, metric_patterns: tuple[str, ...]
@@ -1328,15 +1336,6 @@ class Logger(LoggerInterface):
         """Attach buffered Ray system metrics to a caller-defined batch step."""
         if self.gpu_monitor is not None:
             self.gpu_monitor.flush(step=step)
-
-    def close(self) -> None:
-        """Stop background monitoring and finish remote logging backends."""
-        if self.gpu_monitor is not None:
-            self.gpu_monitor.stop()
-            self.gpu_monitor = None
-        if self.wandb_logger is not None:
-            self.wandb_logger.finish()
-            self.wandb_logger = None
 
     def log_plot_token_mult_prob_error(
         self, data: dict[str, Any], step: int, name: str

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -44,6 +44,7 @@ project-includes = [
   "examples/custom_parallel/custom_parallel.py",
   "examples/custom_parallel/llama_nemotron_super_49b_custom_plan.py",
   "examples/modelopt/export_quantized_to_hf.py",
+  "examples/nemo_gym/run_grpo_rollout_benchmark.py",
   "nemo_rl/algorithms/__init__.py",
   "nemo_rl/algorithms/advantage_estimator.py",
   "nemo_rl/algorithms/async_utils/__init__.py",

--- a/tests/unit/data/datasets/test_eval_dataset.py
+++ b/tests/unit/data/datasets/test_eval_dataset.py
@@ -11,14 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
+from omegaconf import OmegaConf
 from transformers import AutoTokenizer
 
 from examples import run_eval
 from nemo_rl.data.datasets import load_eval_dataset
+from nemo_rl.evals.eval import (
+    MasterConfig,
+    NemoGymEvalDataConfig,
+    _validate_nemo_gym_eval_config,
+)
+from nemo_rl.utils.config import load_config
 
 
 @pytest.mark.parametrize(
@@ -56,6 +64,50 @@ def test_setup_data_uses_response_loader_only_for_migrated_eval_datasets(
     else:
         eval_loader.assert_called_once_with(data_config)
         response_loader.assert_not_called()
+
+
+def test_setup_data_uses_response_loader_without_native_env_for_nemo_gym(
+    monkeypatch,
+) -> None:
+    data_config = NemoGymEvalDataConfig(
+        dataset_name="NemoGymDataset",
+        data_path="eval.jsonl",
+        processor="nemo_gym_data_processor",
+        env_name="nemo_gym",
+    )
+    response_dataset = SimpleNamespace(
+        dataset=object(), task_spec=object(), processor=object(), preprocessor=None
+    )
+    response_loader = Mock(return_value=response_dataset)
+    create_env = Mock()
+
+    monkeypatch.setattr(run_eval, "load_response_dataset", response_loader)
+    monkeypatch.setattr(run_eval, "create_env", create_env)
+    monkeypatch.setattr(run_eval, "AllTaskProcessedDataset", Mock())
+
+    _, env, _ = run_eval.setup_data(object(), data_config, {"nemo_gym": {}})
+
+    response_loader.assert_called_once_with(data_config.model_dump())
+    create_env.assert_not_called()
+    assert env is None
+
+
+def test_nemo_gym_eval_example_config_references_checked_in_assets() -> None:
+    repo_root = Path(__file__).parents[4]
+    config_path = (
+        repo_root
+        / "examples/nemo_gym/eval_workplace_assistant_nemotron_nano_v2_9b.yaml"
+    )
+    raw_config = OmegaConf.to_container(load_config(str(config_path)), resolve=True)
+    config = MasterConfig(**raw_config)
+
+    _validate_nemo_gym_eval_config(config)
+
+    assert isinstance(config.data, NemoGymEvalDataConfig)
+    assert (repo_root / config.data.data_path).is_file()
+    gym_root = repo_root / "3rdparty/Gym-workspace/Gym"
+    for gym_config_path in config.env["nemo_gym"].config_paths:
+        assert (gym_root / gym_config_path).is_file()
 
 
 @pytest.mark.skip(reason="dataset download is flaky")

--- a/tests/unit/data/test_collate_fn.py
+++ b/tests/unit/data/test_collate_fn.py
@@ -16,9 +16,30 @@ from unittest.mock import MagicMock
 
 import torch
 
-from nemo_rl.data.collate_fn import preference_collate_fn
+from nemo_rl.data.collate_fn import eval_collate_fn, preference_collate_fn
 from nemo_rl.data.interfaces import DatumSpec
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+
+
+def test_eval_collate_fn_retains_loss_multiplier():
+    data_batch = [
+        DatumSpec(
+            message_log=[],
+            extra_env_info={"instance_id": "one"},
+            loss_multiplier=0.25,
+            idx=0,
+        ),
+        DatumSpec(
+            message_log=[],
+            extra_env_info={"instance_id": "two"},
+            loss_multiplier=1.0,
+            idx=1,
+        ),
+    ]
+
+    batch = eval_collate_fn(data_batch)
+
+    assert torch.equal(batch["loss_multiplier"], torch.tensor([0.25, 1.0]))
 
 
 def test_preference_collate_fn():

--- a/tests/unit/environments/test_nemo_gym_utils.py
+++ b/tests/unit/environments/test_nemo_gym_utils.py
@@ -17,14 +17,93 @@ These run in the default L0 suite. Keep this module free of heavy imports
 (e.g. vllm) so the fast detector tests are not gated behind the nemo_gym extra.
 """
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from nemo_rl.environments import nemo_gym as nemo_gym_mod
 from nemo_rl.environments.nemo_gym import (
     _detect_invalid_tool_call_and_malformed_thinking,
+    create_nemo_gym_actor,
     get_nemo_gym_uv_cache_dir,
     get_nemo_gym_venv_dir,
+    setup_nemo_gym_generation_config,
 )
+
+
+def test_create_nemo_gym_actor_starts_with_generation_endpoints(monkeypatch) -> None:
+    actor = MagicMock()
+    actor._spinup.remote.return_value = "started"
+    actor_class = MagicMock()
+    actor_class.options.return_value.remote.return_value = actor
+
+    monkeypatch.setattr(nemo_gym_mod, "NemoGym", actor_class)
+    monkeypatch.setattr(nemo_gym_mod, "get_actor_python_env", lambda _: "/gym/python")
+    monkeypatch.setattr(nemo_gym_mod, "get_nemo_gym_uv_cache_dir", lambda: None)
+    monkeypatch.setattr(nemo_gym_mod, "get_nemo_gym_venv_dir", lambda: None)
+    ray_get = MagicMock(return_value=None)
+    monkeypatch.setattr(nemo_gym_mod.ray, "get", ray_get)
+
+    result = create_nemo_gym_actor(
+        model_name="test-model",
+        base_urls=["http://worker-0:8000/v1"],
+        nemo_gym_config={
+            "config_paths": ["gym.yaml"],
+            "invalid_tool_call_patterns": ["<bad>"],
+        },
+    )
+
+    assert result is actor
+    actor_options = actor_class.options.call_args.kwargs
+    assert actor_options["runtime_env"]["py_executable"] == "/gym/python"
+    nemo_gym_config = actor_class.options.return_value.remote.call_args.args[0]
+    assert nemo_gym_config["model_name"] == "test-model"
+    assert nemo_gym_config["base_urls"] == ["http://worker-0:8000/v1"]
+    assert nemo_gym_config["invalid_tool_call_patterns"] == ["<bad>"]
+    assert nemo_gym_config["initial_global_config_dict"] == {
+        "config_paths": ["gym.yaml"]
+    }
+    ray_get.assert_called_once_with("started")
+
+
+def test_setup_nemo_gym_generation_config_enables_http_rollouts() -> None:
+    generation_config = {
+        "backend": "vllm",
+        "stop_strings": ["stop"],
+        "stop_token_ids": [1],
+        "vllm_cfg": {"async_engine": False, "expose_http_server": False},
+    }
+
+    setup_nemo_gym_generation_config(generation_config)
+
+    assert generation_config["vllm_cfg"]["async_engine"] is True
+    assert generation_config["vllm_cfg"]["expose_http_server"] is True
+    assert generation_config["stop_strings"] is None
+    assert generation_config["stop_token_ids"] is None
+
+
+def test_setup_nemo_gym_generation_config_enables_megatron_http_rollouts() -> None:
+    generation_config = {
+        "backend": "megatron",
+        "stop_strings": ["stop"],
+        "stop_token_ids": [1],
+        "mcore_generation_config": {
+            "async_engine": False,
+            "expose_http_server": False,
+        },
+    }
+
+    setup_nemo_gym_generation_config(generation_config)
+
+    assert generation_config["mcore_generation_config"]["async_engine"] is True
+    assert generation_config["mcore_generation_config"]["expose_http_server"] is True
+    assert generation_config["stop_strings"] is None
+    assert generation_config["stop_token_ids"] is None
+
+
+def test_setup_nemo_gym_generation_config_rejects_unsupported_backend() -> None:
+    with pytest.raises(ValueError, match="backend=vllm or backend=megatron"):
+        setup_nemo_gym_generation_config({"backend": "sglang"})
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/environments/test_nemo_gym_utils.py
+++ b/tests/unit/environments/test_nemo_gym_utils.py
@@ -17,53 +17,15 @@ These run in the default L0 suite. Keep this module free of heavy imports
 (e.g. vllm) so the fast detector tests are not gated behind the nemo_gym extra.
 """
 
-from unittest.mock import MagicMock
-
 import pytest
 
 from nemo_rl.environments import nemo_gym as nemo_gym_mod
 from nemo_rl.environments.nemo_gym import (
     _detect_invalid_tool_call_and_malformed_thinking,
-    create_nemo_gym_actor,
     get_nemo_gym_uv_cache_dir,
     get_nemo_gym_venv_dir,
     setup_nemo_gym_generation_config,
 )
-
-
-def test_create_nemo_gym_actor_starts_with_generation_endpoints(monkeypatch) -> None:
-    actor = MagicMock()
-    actor._spinup.remote.return_value = "started"
-    actor_class = MagicMock()
-    actor_class.options.return_value.remote.return_value = actor
-
-    monkeypatch.setattr(nemo_gym_mod, "NemoGym", actor_class)
-    monkeypatch.setattr(nemo_gym_mod, "get_actor_python_env", lambda _: "/gym/python")
-    monkeypatch.setattr(nemo_gym_mod, "get_nemo_gym_uv_cache_dir", lambda: None)
-    monkeypatch.setattr(nemo_gym_mod, "get_nemo_gym_venv_dir", lambda: None)
-    ray_get = MagicMock(return_value=None)
-    monkeypatch.setattr(nemo_gym_mod.ray, "get", ray_get)
-
-    result = create_nemo_gym_actor(
-        model_name="test-model",
-        base_urls=["http://worker-0:8000/v1"],
-        nemo_gym_config={
-            "config_paths": ["gym.yaml"],
-            "invalid_tool_call_patterns": ["<bad>"],
-        },
-    )
-
-    assert result is actor
-    actor_options = actor_class.options.call_args.kwargs
-    assert actor_options["runtime_env"]["py_executable"] == "/gym/python"
-    nemo_gym_config = actor_class.options.return_value.remote.call_args.args[0]
-    assert nemo_gym_config["model_name"] == "test-model"
-    assert nemo_gym_config["base_urls"] == ["http://worker-0:8000/v1"]
-    assert nemo_gym_config["invalid_tool_call_patterns"] == ["<bad>"]
-    assert nemo_gym_config["initial_global_config_dict"] == {
-        "config_paths": ["gym.yaml"]
-    }
-    ray_get.assert_called_once_with("started")
 
 
 def test_setup_nemo_gym_generation_config_enables_http_rollouts() -> None:

--- a/tests/unit/evals/test_eval.py
+++ b/tests/unit/evals/test_eval.py
@@ -12,17 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import asyncio
+import json
 from types import SimpleNamespace
+from unittest.mock import MagicMock, call
 
 import pytest
 import torch
+from wandb import Table
 
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.evals.eval import (
+    EVAL_STEP_METRIC,
+    NemoGymEvalDataConfig,
+    _ensure_nemo_gym_generation_metrics,
+    _get_num_generations_per_prompt,
+    _generate_texts,
+    _log_generation_metrics,
+    _run_nemo_gym_eval_impl,
+    _summarize_generation_metrics,
+    _validate_nemo_gym_eval_config,
     eval_cons_k,
     eval_pass_k,
     run_env_eval,
+    setup,
+    setup_nemo_gym_environment,
 )
+from nemo_rl.utils.logger import Logger
 
 
 def test_eval_pass_k_basic():
@@ -54,7 +70,13 @@ def test_run_env_eval_selects_backend_specific_async_path(
     captured = {}
 
     async def fake_run_env_eval_impl(
-        vllm_generation, dataloader, env, master_config, use_async=False
+        vllm_generation,
+        dataloader,
+        env,
+        master_config,
+        use_async=False,
+        tokenizer=None,
+        logger=None,
     ):
         captured["use_async"] = use_async
 
@@ -64,10 +86,555 @@ def test_run_env_eval_selects_backend_specific_async_path(
         vllm_generation=object(),
         dataloader=object(),
         env=object(),
-        master_config=SimpleNamespace(generation=generation_config),
+        master_config=SimpleNamespace(generation=generation_config, env={}),
     )
 
     assert captured["use_async"] is expected_use_async
+
+
+def test_generate_texts_uses_generation_interface_for_sglang() -> None:
+    generation = MagicMock()
+    generation.generate.return_value = BatchedDataDict(
+        {
+            "output_ids": torch.tensor([[10, 11, 20, 21], [12, 30, 0, 0]]),
+            "unpadded_sequence_lengths": torch.tensor([4, 2]),
+        }
+    )
+    batch = BatchedDataDict(
+        {
+            "message_log": [
+                [{"role": "user", "content": "a", "token_ids": torch.tensor([10, 11])}],
+                [{"role": "user", "content": "b", "token_ids": torch.tensor([12])}],
+            ]
+        }
+    )
+    tokenizer = MagicMock()
+    tokenizer.pad_token_id = 0
+    tokenizer.decode.side_effect = lambda tokens, **_: ",".join(
+        str(token) for token in tokens.tolist()
+    )
+
+    texts = asyncio.run(
+        _generate_texts(
+            generation,
+            BatchedDataDict({"prompts": ["a", "b"]}),
+            False,
+            backend="sglang",
+            batch=batch,
+            tokenizer=tokenizer,
+        )
+    )
+
+    assert texts == ["20,21", "30"]
+    generation.generate.assert_called_once()
+    generation_inputs = generation.generate.call_args.args[0]
+    assert generation_inputs["input_ids"].tolist() == [[10, 11], [12, 0]]
+    assert generation_inputs["input_lengths"].tolist() == [2, 1]
+    assert generation.generate.call_args.kwargs == {"greedy": False}
+
+
+def test_setup_dispatches_to_sglang_rollout_engine(monkeypatch) -> None:
+    cluster = MagicMock()
+    monkeypatch.setattr(
+        "nemo_rl.evals.eval.RayVirtualCluster", MagicMock(return_value=cluster)
+    )
+    generation = MagicMock()
+    sglang_generation = MagicMock(return_value=generation)
+    monkeypatch.setattr("nemo_rl.evals.eval.SGLangGeneration", sglang_generation)
+    config = SimpleNamespace(
+        eval={
+            "metric": "mean_reward",
+            "num_tests_per_prompt": 1,
+            "seed": 42,
+            "k_value": 1,
+        },
+        generation={
+            "backend": "sglang",
+            "model_name": "test-model",
+            "temperature": 0.0,
+            "top_k": None,
+            "num_prompts_per_step": 2,
+            "sglang_cfg": {},
+        },
+        cluster={"gpus_per_node": 2, "num_nodes": 1},
+        env={},
+        data={"dataset_name": "AIME2024"},
+        policy=None,
+    )
+
+    configured_generation, dataloader, returned_config = setup(
+        config, MagicMock(), [object(), object(), object()]
+    )
+
+    assert configured_generation is generation
+    assert len(dataloader) == 2
+    assert returned_config is config
+    assert config.generation["sglang_cfg"]["model_path"] == "test-model"
+    sglang_generation.assert_called_once_with(
+        cluster=cluster, sglang_cfg=config.generation
+    )
+
+
+def _nemo_gym_eval_config(
+    *,
+    metrics_enabled: bool = True,
+    num_generations_per_prompt: int = 1,
+    num_prompts_per_step: int = 2,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        eval={
+            "metric": "mean_reward",
+            "num_tests_per_prompt": num_generations_per_prompt,
+            "k_value": 1,
+            "seed": 42,
+            "save_path": None,
+        },
+        generation={
+            "backend": "vllm",
+            "model_name": "test-model",
+            "max_new_tokens": 128,
+            "temperature": 1.0 if num_generations_per_prompt > 1 else 0.0,
+            "top_p": 1.0,
+            "top_k": None,
+            "num_prompts_per_step": num_prompts_per_step,
+            "stop_strings": None,
+            "stop_token_ids": None,
+            "vllm_cfg": {
+                "async_engine": True,
+                "expose_http_server": True,
+                "enable_vllm_metrics_logger": metrics_enabled,
+                "vllm_metrics_logger_interval": 0.5,
+            },
+        },
+        data=NemoGymEvalDataConfig(
+            dataset_name="NemoGymDataset",
+            data_path="eval.jsonl",
+            processor="nemo_gym_data_processor",
+            env_name="nemo_gym",
+        ),
+        env={"should_use_nemo_gym": True, "nemo_gym": {}},
+        logger={"wandb_enabled": True},
+    )
+
+
+def test_nemo_gym_eval_can_derive_metrics_without_backend_telemetry() -> None:
+    _validate_nemo_gym_eval_config(_nemo_gym_eval_config(metrics_enabled=False))
+
+
+def test_nemo_gym_eval_accepts_megatron_rollout_engine() -> None:
+    config = _nemo_gym_eval_config()
+    config.generation = {
+        **config.generation,
+        "backend": "megatron",
+        "mcore_generation_config": {
+            "async_engine": True,
+            "expose_http_server": True,
+        },
+    }
+
+    _validate_nemo_gym_eval_config(config)
+
+
+def test_setup_nemo_gym_environment_uses_rollout_engine_endpoints(monkeypatch) -> None:
+    create_actor = MagicMock(return_value=object())
+    monkeypatch.setattr("nemo_rl.evals.eval.create_nemo_gym_actor", create_actor)
+    config = _nemo_gym_eval_config()
+    config.env["nemo_gym"] = MagicMock()
+    config.env["nemo_gym"].model_dump.return_value = {}
+    generation = SimpleNamespace(dp_openai_server_base_urls=["http://worker-0:8000/v1"])
+
+    result = setup_nemo_gym_environment(generation, config)
+
+    assert result is create_actor.return_value
+    create_actor.assert_called_once_with(
+        model_name="test-model",
+        base_urls=["http://worker-0:8000/v1"],
+        nemo_gym_config={},
+    )
+
+
+def test_eval_generation_count_uses_num_tests_per_prompt() -> None:
+    assert _get_num_generations_per_prompt({"num_tests_per_prompt": 2}) == 2
+
+
+@pytest.mark.parametrize("value", [None, 0, -1, True])
+def test_eval_generation_count_must_be_positive_integer(value) -> None:
+    with pytest.raises(ValueError, match="must be an integer"):
+        _get_num_generations_per_prompt({"num_tests_per_prompt": value})
+
+
+def test_nemo_gym_eval_requires_matching_dataset_switch() -> None:
+    config = _nemo_gym_eval_config()
+    config.env["should_use_nemo_gym"] = False
+
+    with pytest.raises(ValueError, match="env.should_use_nemo_gym=true"):
+        _validate_nemo_gym_eval_config(config)
+
+
+def test_nemo_gym_eval_requires_null_top_k() -> None:
+    config = _nemo_gym_eval_config()
+    config.generation["top_k"] = 0
+
+    with pytest.raises(ValueError, match="generation.top_k=null"):
+        _validate_nemo_gym_eval_config(config)
+
+
+def test_run_env_eval_dispatches_to_nemo_gym_rollout(monkeypatch) -> None:
+    expected_result = object()
+    run_nemo_gym_eval = MagicMock(return_value=expected_result)
+    monkeypatch.setattr("nemo_rl.evals.eval._run_nemo_gym_eval_impl", run_nemo_gym_eval)
+
+    vllm_generation = object()
+    dataloader = object()
+    nemo_gym = object()
+    tokenizer = MagicMock()
+    logger = MagicMock()
+    config = _nemo_gym_eval_config()
+
+    result = run_env_eval(
+        vllm_generation=vllm_generation,
+        dataloader=dataloader,
+        env=nemo_gym,
+        master_config=config,
+        tokenizer=tokenizer,
+        logger=logger,
+    )
+
+    assert result is expected_result
+    logger.use_batch_steps.assert_called_once_with(
+        EVAL_STEP_METRIC, ("eval/*", "generation_metrics/*", "ray/*")
+    )
+    run_nemo_gym_eval.assert_called_once()
+    call_kwargs = run_nemo_gym_eval.call_args.kwargs
+    assert call_kwargs["vllm_generation"] is vllm_generation
+    assert call_kwargs["dataloader"] is dataloader
+    assert call_kwargs["nemo_gym"] is nemo_gym
+    assert call_kwargs["tokenizer"] is tokenizer
+    assert call_kwargs["logger"] is logger
+    assert call_kwargs["master_config"] is config
+
+
+def test_run_env_eval_requires_runtime_logger_for_nemo_gym() -> None:
+    with pytest.raises(
+        ValueError,
+        match="requires a logger to persist generation metrics",
+    ):
+        run_env_eval(
+            vllm_generation=object(),
+            dataloader=object(),
+            env=object(),
+            master_config=_nemo_gym_eval_config(),
+            tokenizer=MagicMock(),
+        )
+
+
+def test_nemo_gym_eval_persists_raw_generation_metrics(tmp_path) -> None:
+    config = _nemo_gym_eval_config()
+    config.logger = {
+        "log_dir": str(tmp_path),
+        "wandb_enabled": False,
+        "tensorboard_enabled": False,
+        "mlflow_enabled": False,
+        "swanlab_enabled": False,
+        "monitor_gpus": False,
+        "wandb": {},
+        "tensorboard": {},
+        "mlflow": {},
+        "swanlab": {},
+        "gpu_monitoring": {"collection_interval": 10, "flush_interval": 10},
+    }
+    metrics = {"inflight_batch_sizes": {0: [2, 1, 0]}}
+
+    _log_generation_metrics(
+        generation_metrics=metrics,
+        step=3,
+        generation_config=config.generation,
+        logger_config=config.logger,
+        require_numeric_metrics=True,
+        logger=Logger(config.logger),
+    )
+
+    rows = (tmp_path / "generation_metrics.jsonl").read_text().splitlines()
+    assert [json.loads(row) for row in rows] == [
+        {
+            "step": 3,
+            "metrics": {"inflight_batch_sizes": {"0": [2, 1, 0]}},
+        }
+    ]
+
+
+def test_nemo_gym_eval_rejects_empty_generation_metrics() -> None:
+    with pytest.raises(
+        RuntimeError,
+        match="did not produce any numeric generation metrics",
+    ):
+        _log_generation_metrics(
+            generation_metrics={},
+            step=1,
+            generation_config=_nemo_gym_eval_config().generation,
+            logger_config=_nemo_gym_eval_config().logger,
+            require_numeric_metrics=True,
+            logger=MagicMock(),
+        )
+
+
+def test_eval_summarizes_generation_metrics_per_batch() -> None:
+    metrics = {
+        "generation_tokens": {0: [1, 3], 1: [2, 6]},
+        "kv_cache_usage_perc": {0: [0.1, 0.2], 1: []},
+        "non_numeric": {0: ["ignored"]},
+    }
+
+    assert _summarize_generation_metrics(metrics) == pytest.approx(
+        {
+            "generation_tokens/mean": 3.0,
+            "generation_tokens/max": 6.0,
+            "generation_tokens/last_mean": 4.5,
+            "generation_tokens/last_sum": 9.0,
+            "kv_cache_usage_perc/mean": 0.15,
+            "kv_cache_usage_perc/max": 0.2,
+            "kv_cache_usage_perc/last_mean": 0.2,
+            "kv_cache_usage_perc/last_sum": 0.2,
+        }
+    )
+
+
+def test_nemo_gym_eval_derives_backend_neutral_generation_metrics() -> None:
+    assert _ensure_nemo_gym_generation_metrics(
+        {},
+        {
+            "gen_tokens_per_sample/mean": 12.5,
+            "timing/rollout/total": 2.0,
+        },
+        4,
+    ) == {
+        "completed_generations": {0: [4.0]},
+        "generated_tokens_per_sample": {0: [12.5]},
+        "generated_tokens": {0: [50.0]},
+        "rollout_seconds": {0: [2.0]},
+        "generated_tokens_per_rollout_second": {0: [25.0]},
+    }
+
+
+def test_nemo_gym_eval_logs_results_and_generation_metrics(monkeypatch) -> None:
+    rollout_results = [
+        SimpleNamespace(
+            final_batch={"total_reward": torch.tensor([1.0, 0.0])},
+            rollout_metrics={
+                "timing/rollout/total": 2.0,
+                "agent/full_result": Table(
+                    columns=["Full result"],
+                    data=[
+                        [json.dumps({"reward": 1.0})],
+                        [json.dumps({"reward": 0.0})],
+                    ],
+                ),
+            },
+        ),
+        SimpleNamespace(
+            final_batch={"total_reward": torch.tensor([0.5])},
+            rollout_metrics={
+                "timing/rollout/total": 1.0,
+                "agent/full_result": Table(
+                    columns=["Full result"],
+                    data=[[json.dumps({"reward": 0.5})]],
+                ),
+            },
+        ),
+    ]
+    run_rollout = MagicMock(side_effect=rollout_results)
+    monkeypatch.setattr("nemo_rl.evals.eval.run_async_nemo_gym_rollout", run_rollout)
+    monkeypatch.setattr("nemo_rl.evals.eval._print_results", MagicMock())
+    monkeypatch.setattr("nemo_rl.evals.eval.ray.get", lambda value: value)
+    log_generation_metrics = MagicMock()
+    monkeypatch.setattr(
+        "nemo_rl.evals.eval.log_generation_metrics_to_wandb",
+        log_generation_metrics,
+    )
+
+    vllm_generation = MagicMock()
+    per_batch_generation_metrics = [
+        {"inflight_batch_sizes": {0: [1, 0]}},
+        {"inflight_batch_sizes": {0: [2, 0]}},
+    ]
+    vllm_generation.get_logger_metrics.side_effect = per_batch_generation_metrics
+    dataloader = MagicMock()
+    dataloader.__iter__.return_value = iter([object(), object()])
+    dataloader.__len__.return_value = 2
+    dataloader.dataset = [object(), object(), object()]
+    nemo_gym = MagicMock()
+    logger = MagicMock()
+
+    result = _run_nemo_gym_eval_impl(
+        vllm_generation=vllm_generation,
+        dataloader=dataloader,
+        nemo_gym=nemo_gym,
+        tokenizer=MagicMock(),
+        master_config=_nemo_gym_eval_config(),
+        logger=logger,
+    )
+
+    assert result.average_score == pytest.approx(0.5)
+    assert result.num_samples == 3
+    assert result.generation_metrics == [
+        {"step": 1, "metrics": per_batch_generation_metrics[0]},
+        {"step": 2, "metrics": per_batch_generation_metrics[1]},
+    ]
+    assert vllm_generation.clear_logger_metrics.call_count == 2
+    assert vllm_generation.get_logger_metrics.call_count == 2
+    vllm_generation.shutdown.assert_called_once_with()
+    nemo_gym.shutdown.remote.assert_called_once_with()
+    assert log_generation_metrics.call_args_list == [
+        call(
+            per_batch_generation_metrics[0],
+            1,
+            0.5,
+            logger,
+            step_metric=EVAL_STEP_METRIC,
+        ),
+        call(
+            per_batch_generation_metrics[1],
+            2,
+            0.5,
+            logger,
+            step_metric=EVAL_STEP_METRIC,
+        ),
+    ]
+    assert logger.flush_system_metrics.call_args_list == [call(1), call(2)]
+    committed_batch_logs = [
+        log_call
+        for log_call in logger.log_metrics.call_args_list
+        if log_call.kwargs.get("step_finished")
+    ]
+    assert [
+        log_call.args[0][EVAL_STEP_METRIC] for log_call in committed_batch_logs
+    ] == [
+        1,
+        2,
+    ]
+    assert committed_batch_logs[-1].args[0]["score"] == pytest.approx(0.5)
+
+    generation_jsonl_calls = [
+        log_call
+        for log_call in logger.log_string_list_as_jsonl.call_args_list
+        if log_call.args[1] == "generation_metrics.jsonl"
+    ]
+    result_jsonl_calls = [
+        log_call
+        for log_call in logger.log_string_list_as_jsonl.call_args_list
+        if log_call.args[1] == "nemo_gym_eval_results.jsonl"
+    ]
+    assert len(generation_jsonl_calls) == 2
+    assert len(result_jsonl_calls) == 2
+    assert [
+        (json.loads(row)["eval_batch_index"], json.loads(row)["eval_step"])
+        for log_call in result_jsonl_calls
+        for row in log_call.args[0]
+    ] == [(0, 1), (0, 1), (1, 2)]
+
+
+def test_nemo_gym_eval_tracks_multiple_generations_per_prompt(monkeypatch) -> None:
+    rewards = [0.0, 1.0, 0.5, 1.0]
+    rollout_result = SimpleNamespace(
+        final_batch={"total_reward": torch.tensor(rewards)},
+        rollout_metrics={
+            "agent/full_result": Table(
+                columns=["Full result"],
+                data=[[json.dumps({"reward": reward})] for reward in rewards],
+            ),
+        },
+    )
+    run_rollout = MagicMock(return_value=rollout_result)
+    monkeypatch.setattr("nemo_rl.evals.eval.run_async_nemo_gym_rollout", run_rollout)
+    monkeypatch.setattr("nemo_rl.evals.eval._print_results", MagicMock())
+    monkeypatch.setattr("nemo_rl.evals.eval.ray.get", lambda value: value)
+
+    vllm_generation = MagicMock()
+    vllm_generation.get_logger_metrics.return_value = {
+        "inflight_batch_sizes": {0: [4, 0]}
+    }
+    original_batch = MagicMock()
+    repeated_batch = MagicMock()
+    original_batch.repeat_interleave.return_value = repeated_batch
+    dataloader = MagicMock()
+    dataloader.__iter__.return_value = iter([original_batch])
+    dataloader.__len__.return_value = 1
+    dataloader.dataset = [object()]
+    nemo_gym = MagicMock()
+    logger = MagicMock()
+
+    result = _run_nemo_gym_eval_impl(
+        vllm_generation=vllm_generation,
+        dataloader=dataloader,
+        nemo_gym=nemo_gym,
+        tokenizer=MagicMock(),
+        master_config=_nemo_gym_eval_config(
+            num_generations_per_prompt=4,
+            num_prompts_per_step=1,
+        ),
+        logger=logger,
+    )
+
+    assert result.average_score == pytest.approx(0.625)
+    original_batch.repeat_interleave.assert_called_once_with(4)
+    assert run_rollout.call_args.kwargs["input_batch"] is repeated_batch
+    result_jsonl_call = next(
+        log_call
+        for log_call in logger.log_string_list_as_jsonl.call_args_list
+        if log_call.args[1] == "nemo_gym_eval_results.jsonl"
+    )
+    result_rows = [json.loads(row) for row in result_jsonl_call.args[0]]
+    assert [row["prompt_index"] for row in result_rows] == [0, 0, 0, 0]
+    assert [row["generation_index"] for row in result_rows] == [0, 1, 2, 3]
+    assert all(row["num_generations_per_prompt"] == 4 for row in result_rows)
+    committed_batch_log = next(
+        log_call
+        for log_call in logger.log_metrics.call_args_list
+        if log_call.kwargs.get("step_finished")
+    )
+    assert committed_batch_log.args[0]["batch/num_generations_per_prompt"] == 4
+
+
+def test_nemo_gym_eval_rejects_incomplete_full_results(monkeypatch) -> None:
+    rollout_result = SimpleNamespace(
+        final_batch={"total_reward": torch.tensor([1.0, 0.0])},
+        rollout_metrics={
+            "agent/full_result": Table(
+                columns=["Full result"],
+                data=[[json.dumps({"reward": 1.0})]],
+            ),
+        },
+    )
+    monkeypatch.setattr(
+        "nemo_rl.evals.eval.run_async_nemo_gym_rollout",
+        MagicMock(return_value=rollout_result),
+    )
+    monkeypatch.setattr("nemo_rl.evals.eval.ray.get", lambda value: value)
+
+    vllm_generation = MagicMock()
+    vllm_generation.get_logger_metrics.return_value = {
+        "inflight_batch_sizes": {0: [1, 0]}
+    }
+    dataloader = MagicMock()
+    dataloader.__iter__.return_value = iter([object()])
+    dataloader.dataset = [object(), object()]
+    nemo_gym = MagicMock()
+
+    with pytest.raises(
+        RuntimeError,
+        match="batch 0 returned 1 full results for 2 rewards",
+    ):
+        _run_nemo_gym_eval_impl(
+            vllm_generation=vllm_generation,
+            dataloader=dataloader,
+            nemo_gym=nemo_gym,
+            tokenizer=MagicMock(),
+            master_config=_nemo_gym_eval_config(),
+            logger=MagicMock(),
+        )
+
+    vllm_generation.shutdown.assert_called_once_with()
+    nemo_gym.shutdown.remote.assert_called_once_with()
 
 
 def test_eval_pass_k_all_correct():

--- a/tests/unit/evals/test_eval.py
+++ b/tests/unit/evals/test_eval.py
@@ -236,8 +236,8 @@ def test_nemo_gym_eval_accepts_megatron_rollout_engine() -> None:
 
 
 def test_setup_nemo_gym_environment_uses_rollout_engine_endpoints(monkeypatch) -> None:
-    create_actor = MagicMock(return_value=object())
-    monkeypatch.setattr("nemo_rl.evals.eval.create_nemo_gym_actor", create_actor)
+    spinup_actor = MagicMock(return_value=object())
+    monkeypatch.setattr("nemo_rl.evals.eval.spinup_nemo_gym_actor", spinup_actor)
     config = _nemo_gym_eval_config()
     config.env["nemo_gym"] = MagicMock()
     config.env["nemo_gym"].model_dump.return_value = {}
@@ -245,11 +245,12 @@ def test_setup_nemo_gym_environment_uses_rollout_engine_endpoints(monkeypatch) -
 
     result = setup_nemo_gym_environment(generation, config)
 
-    assert result is create_actor.return_value
-    create_actor.assert_called_once_with(
-        model_name="test-model",
+    assert result is spinup_actor.return_value
+    spinup_actor.assert_called_once_with(
+        env_configs={"nemo_gym": {}},
         base_urls=["http://worker-0:8000/v1"],
-        nemo_gym_config={},
+        model_name="test-model",
+        enable_router_replay=False,
     )
 
 

--- a/tests/unit/evals/test_eval.py
+++ b/tests/unit/evals/test_eval.py
@@ -206,6 +206,7 @@ def _nemo_gym_eval_config(
                 "vllm_metrics_logger_interval": 0.5,
             },
         },
+        tokenizer={"name": "test-tokenizer"},
         data=NemoGymEvalDataConfig(
             dataset_name="NemoGymDataset",
             data_path="eval.jsonl",
@@ -251,6 +252,8 @@ def test_setup_nemo_gym_environment_uses_rollout_engine_endpoints(monkeypatch) -
         base_urls=["http://worker-0:8000/v1"],
         model_name="test-model",
         enable_router_replay=False,
+        routed_experts_dtype="int16",
+        use_fastokens=False,
     )
 
 
@@ -444,7 +447,7 @@ def test_nemo_gym_eval_logs_results_and_generation_metrics(monkeypatch) -> None:
         ),
     ]
     run_rollout = MagicMock(side_effect=rollout_results)
-    monkeypatch.setattr("nemo_rl.evals.eval.run_async_nemo_gym_rollout", run_rollout)
+    monkeypatch.setattr("nemo_rl.evals.eval.run_nemo_gym_rollout_sync", run_rollout)
     monkeypatch.setattr("nemo_rl.evals.eval._print_results", MagicMock())
     monkeypatch.setattr("nemo_rl.evals.eval.ray.get", lambda value: value)
     log_generation_metrics = MagicMock()
@@ -546,7 +549,7 @@ def test_nemo_gym_eval_tracks_multiple_generations_per_prompt(monkeypatch) -> No
         },
     )
     run_rollout = MagicMock(return_value=rollout_result)
-    monkeypatch.setattr("nemo_rl.evals.eval.run_async_nemo_gym_rollout", run_rollout)
+    monkeypatch.setattr("nemo_rl.evals.eval.run_nemo_gym_rollout_sync", run_rollout)
     monkeypatch.setattr("nemo_rl.evals.eval._print_results", MagicMock())
     monkeypatch.setattr("nemo_rl.evals.eval.ray.get", lambda value: value)
 
@@ -607,7 +610,7 @@ def test_nemo_gym_eval_rejects_incomplete_full_results(monkeypatch) -> None:
         },
     )
     monkeypatch.setattr(
-        "nemo_rl.evals.eval.run_async_nemo_gym_rollout",
+        "nemo_rl.evals.eval.run_nemo_gym_rollout_sync",
         MagicMock(return_value=rollout_result),
     )
     monkeypatch.setattr("nemo_rl.evals.eval.ray.get", lambda value: value)

--- a/tests/unit/evals/test_run_eval.py
+++ b/tests/unit/evals/test_run_eval.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from omegaconf import OmegaConf
+
+from examples import run_eval
+from nemo_rl.utils.config import load_config
+
+
+def test_main_wires_nemo_gym_rollout_only_eval(monkeypatch) -> None:
+    repo_root = Path(__file__).parents[3]
+    config_path = (
+        repo_root
+        / "examples/nemo_gym/eval_workplace_assistant_nemotron_nano_v2_9b.yaml"
+    )
+    loaded_config = load_config(str(config_path))
+    monkeypatch.setattr(
+        run_eval,
+        "parse_args",
+        lambda: (SimpleNamespace(config=str(config_path)), OmegaConf.create({})),
+    )
+    monkeypatch.setattr(run_eval, "load_config", lambda _: loaded_config)
+    monkeypatch.setattr(run_eval, "init_ray", MagicMock())
+
+    tokenizer = MagicMock()
+    tokenizer.pad_token_id = 0
+    tokenizer.eos_token_id = 1
+    monkeypatch.setattr(run_eval, "get_tokenizer", MagicMock(return_value=tokenizer))
+
+    dataset = object()
+    monkeypatch.setattr(
+        run_eval,
+        "setup_data",
+        MagicMock(return_value=(dataset, None, tokenizer)),
+    )
+    generation = object()
+    dataloader = object()
+    captured = {}
+
+    def fake_setup(config, configured_tokenizer, configured_dataset):
+        captured["config"] = config
+        assert configured_tokenizer is tokenizer
+        assert configured_dataset is dataset
+        return generation, dataloader, config
+
+    monkeypatch.setattr(run_eval, "setup", fake_setup)
+    nemo_gym = object()
+    setup_nemo_gym = MagicMock(return_value=nemo_gym)
+    monkeypatch.setattr(run_eval, "setup_nemo_gym_environment", setup_nemo_gym)
+
+    logger = MagicMock()
+    logger_class = MagicMock(return_value=logger)
+    monkeypatch.setattr(run_eval, "Logger", logger_class)
+    run_env_eval = MagicMock()
+    monkeypatch.setattr(run_eval, "run_env_eval", run_env_eval)
+
+    run_eval.main()
+
+    config = captured["config"]
+    assert config.generation["vllm_cfg"]["async_engine"] is True
+    assert config.generation["vllm_cfg"]["expose_http_server"] is True
+    assert config.generation["vllm_cfg"]["enable_vllm_metrics_logger"] is True
+    assert config.generation["stop_strings"] is None
+    assert config.generation["stop_token_ids"] is None
+    setup_nemo_gym.assert_called_once_with(generation, config)
+    logger_class.assert_called_once_with(config.logger)
+    logger.log_hyperparams.assert_called_once_with(config.model_dump())
+    run_env_eval.assert_called_once_with(
+        generation,
+        dataloader,
+        nemo_gym,
+        config,
+        tokenizer=tokenizer,
+        logger=logger,
+    )
+    logger.close.assert_called_once_with()

--- a/tests/unit/evals/test_run_eval.py
+++ b/tests/unit/evals/test_run_eval.py
@@ -88,4 +88,4 @@ def test_main_wires_nemo_gym_rollout_only_eval(monkeypatch) -> None:
         tokenizer=tokenizer,
         logger=logger,
     )
-    logger.close.assert_called_once_with()
+    logger.finish.assert_called_once_with()

--- a/tests/unit/reference_configs/eval.yaml
+++ b/tests/unit/reference_configs/eval.yaml
@@ -34,6 +34,7 @@ generation:
       gpus_per_node: null # Decides num gpus to be dedicated to generation when there is one node in the cluster i.e cluster.num_nodes == 1
       num_nodes: null # Decides number of nodes to be dedicated to generation
 
+policy: null
 
 tokenizer:
   name: ${generation.model_name} ## specify if you'd like to use a tokenizer different from the model's default
@@ -51,6 +52,25 @@ data:
 env:
   math:
     num_workers: 8
+
+logger:
+  log_dir: "logs/eval"
+  wandb_enabled: false
+  tensorboard_enabled: false
+  mlflow_enabled: false
+  swanlab_enabled: false
+  monitor_gpus: false # set true to log cluster GPU/host-memory metrics at eval_step
+  wandb:
+    project: "nemo-rl-eval"
+    name: "eval"
+  tensorboard: {}
+  swanlab:
+    project: "nemo-rl-eval"
+    name: "eval"
+  mlflow: {}
+  gpu_monitoring:
+    collection_interval: 10
+    flush_interval: 10
 
 cluster:
   gpus_per_node: 1

--- a/tests/unit/test_run_grpo_nemo_gym.py
+++ b/tests/unit/test_run_grpo_nemo_gym.py
@@ -1,0 +1,288 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from examples.nemo_gym import run_grpo_nemo_gym
+
+
+def _rollout_result(
+    rewards: list[float],
+    rollout_time: float,
+) -> SimpleNamespace:
+    full_results = [json.dumps({"reward": reward}) for reward in rewards]
+    return SimpleNamespace(
+        rollout_metrics={
+            "timing/rollout/total": rollout_time,
+            "timing/rollout/run_rollouts": rollout_time - 1,
+            "mean_gen_tokens_per_sample": 4.0,
+            "test_agent/full_result": SimpleNamespace(
+                data=[[result] for result in full_results]
+            ),
+        }
+    )
+
+
+def _master_config(
+    *, expected_trajectories: int, wandb_enabled: bool = True
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        policy={
+            "generation": {
+                "colocated": {"enabled": False},
+                "vllm_cfg": {
+                    "async_engine": True,
+                    "enable_vllm_metrics_logger": True,
+                    "vllm_metrics_logger_interval": 0.5,
+                },
+            },
+            "max_total_sequence_length": 4096,
+        },
+        grpo={"max_val_samples": expected_trajectories},
+        logger={"wandb_enabled": wandb_enabled},
+    )
+
+
+def test_pop_trajectory_collection_settings() -> None:
+    nemo_gym_config = {
+        "is_trajectory_collection": True,
+        "trajectory_collection_batch_size": 16,
+        "config_paths": ["gym.yaml"],
+    }
+
+    settings = run_grpo_nemo_gym._pop_trajectory_collection_settings(nemo_gym_config)
+
+    assert settings == (True, 16)
+    assert nemo_gym_config == {"config_paths": ["gym.yaml"]}
+
+
+@pytest.mark.parametrize("batch_size", [True, 0, -1, 1.5, "16"])
+def test_pop_trajectory_collection_settings_rejects_invalid_batch_size(
+    batch_size: object,
+) -> None:
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        run_grpo_nemo_gym._pop_trajectory_collection_settings(
+            {
+                "is_trajectory_collection": True,
+                "trajectory_collection_batch_size": batch_size,
+            }
+        )
+
+
+def test_pop_trajectory_collection_settings_requires_collection_mode() -> None:
+    with pytest.raises(ValueError, match="requires"):
+        run_grpo_nemo_gym._pop_trajectory_collection_settings(
+            {
+                "is_trajectory_collection": False,
+                "trajectory_collection_batch_size": 16,
+            }
+        )
+
+
+def test_collect_trajectories_logs_each_batch_and_generation_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    refit_policy_generation = MagicMock()
+    run_rollout = MagicMock(
+        side_effect=[
+            _rollout_result([1.0, 0.0], rollout_time=12.0),
+            _rollout_result([0.5], rollout_time=18.0),
+        ]
+    )
+    log_generation_metrics = MagicMock()
+    monkeypatch.setattr(
+        run_grpo_nemo_gym, "refit_policy_generation", refit_policy_generation
+    )
+    monkeypatch.setattr(run_grpo_nemo_gym, "run_nemo_gym_rollout_sync", run_rollout)
+    monkeypatch.setattr(
+        run_grpo_nemo_gym,
+        "log_generation_metrics_to_wandb",
+        log_generation_metrics,
+    )
+
+    generation_metrics = [
+        {"inflight_batch_sizes": {0: [1, 0]}},
+        {"inflight_batch_sizes": {0: [2, 0]}},
+    ]
+    policy_generation = MagicMock()
+    policy_generation.get_logger_metrics.side_effect = generation_metrics
+    logger = MagicMock()
+
+    run_grpo_nemo_gym.collect_trajectories(
+        policy=MagicMock(),
+        policy_generation=policy_generation,
+        val_dataloader=[object(), object()],
+        tokenizer=MagicMock(),
+        val_task_to_env={"nemo_gym": MagicMock()},
+        logger=logger,
+        master_config=_master_config(expected_trajectories=3),
+    )
+
+    refit_policy_generation.assert_called_once()
+    assert policy_generation.clear_logger_metrics.call_count == 2
+    assert policy_generation.get_logger_metrics.call_count == 2
+    policy_generation.finish_generation.assert_called_once_with()
+    assert all(
+        rollout_call.kwargs["log_full_result_tables"] is True
+        for rollout_call in run_rollout.call_args_list
+    )
+
+    assert logger.log_string_list_as_jsonl.call_count == 2
+    logged_batches = [
+        [json.loads(row) for row in log_call.args[0]]
+        for log_call in logger.log_string_list_as_jsonl.call_args_list
+    ]
+    assert [
+        result["trajectory_collection_batch_index"]
+        for batch in logged_batches
+        for result in batch
+    ] == [0, 0, 1]
+    assert [
+        result["trajectory_collection_batch_position"]
+        for batch in logged_batches
+        for result in batch
+    ] == [0, 1, 0]
+    assert [
+        result["trajectory_collection_batch_size"]
+        for batch in logged_batches
+        for result in batch
+    ] == [2, 2, 1]
+
+    rollout_log_calls = [
+        log_call
+        for log_call in logger.log_metrics.call_args_list
+        if log_call.kwargs.get("prefix") == "train"
+    ]
+    assert [
+        log_call.args[0]["timing/rollout/total"] for log_call in rollout_log_calls
+    ] == [12.0, 18.0]
+    assert [log_call.args[1] for log_call in rollout_log_calls] == [1, 2]
+    assert all(
+        "full_result" not in key
+        for log_call in rollout_log_calls
+        for key in log_call.args[0]
+    )
+
+    assert log_generation_metrics.call_args_list == [
+        call(generation_metrics[0], 1, 0.5, logger),
+        call(generation_metrics[1], 2, 0.5, logger),
+    ]
+    collection_log_calls = [
+        log_call
+        for log_call in logger.log_metrics.call_args_list
+        if log_call.kwargs.get("prefix") == "trajectory_collection"
+    ]
+    assert collection_log_calls[-1].args[0] == {
+        "mean_reward": 0.5,
+        "num_trajectories": 3,
+    }
+    assert collection_log_calls[-1].args[1] == 2
+    assert collection_log_calls[-1].kwargs["step_finished"] is True
+
+
+def test_collect_trajectories_rejects_empty_validation_dataset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    refit_policy_generation = MagicMock()
+    monkeypatch.setattr(
+        run_grpo_nemo_gym, "refit_policy_generation", refit_policy_generation
+    )
+
+    with pytest.raises(ValueError, match="non-empty validation dataset"):
+        run_grpo_nemo_gym.collect_trajectories(
+            policy=MagicMock(),
+            policy_generation=MagicMock(),
+            val_dataloader=[],
+            tokenizer=MagicMock(),
+            val_task_to_env={"nemo_gym": MagicMock()},
+            logger=MagicMock(),
+            master_config=_master_config(expected_trajectories=0),
+        )
+
+    refit_policy_generation.assert_not_called()
+
+
+def test_collect_trajectories_skips_generation_metrics_without_wandb(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(run_grpo_nemo_gym, "refit_policy_generation", MagicMock())
+    monkeypatch.setattr(
+        run_grpo_nemo_gym,
+        "run_nemo_gym_rollout_sync",
+        MagicMock(return_value=_rollout_result([1.0], rollout_time=12.0)),
+    )
+    log_generation_metrics = MagicMock()
+    monkeypatch.setattr(
+        run_grpo_nemo_gym,
+        "log_generation_metrics_to_wandb",
+        log_generation_metrics,
+    )
+    policy_generation = MagicMock()
+
+    run_grpo_nemo_gym.collect_trajectories(
+        policy=MagicMock(),
+        policy_generation=policy_generation,
+        val_dataloader=[object()],
+        tokenizer=MagicMock(),
+        val_task_to_env={"nemo_gym": MagicMock()},
+        logger=MagicMock(),
+        master_config=_master_config(expected_trajectories=1, wandb_enabled=False),
+    )
+
+    policy_generation.clear_logger_metrics.assert_not_called()
+    policy_generation.get_logger_metrics.assert_not_called()
+    log_generation_metrics.assert_not_called()
+    policy_generation.finish_generation.assert_called_once_with()
+
+
+def test_collect_trajectories_preserves_completed_batches_before_incomplete_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(run_grpo_nemo_gym, "refit_policy_generation", MagicMock())
+    monkeypatch.setattr(
+        run_grpo_nemo_gym,
+        "run_nemo_gym_rollout_sync",
+        MagicMock(return_value=_rollout_result([1.0], rollout_time=12.0)),
+    )
+    policy_generation = MagicMock()
+    logger = MagicMock()
+
+    with pytest.raises(RuntimeError, match="expected 2, got 1"):
+        run_grpo_nemo_gym.collect_trajectories(
+            policy=MagicMock(),
+            policy_generation=policy_generation,
+            val_dataloader=[object()],
+            tokenizer=MagicMock(),
+            val_task_to_env={"nemo_gym": MagicMock()},
+            logger=logger,
+            master_config=_master_config(expected_trajectories=2),
+        )
+
+    logger.log_string_list_as_jsonl.assert_called_once()
+    policy_generation.finish_generation.assert_called_once_with()
+
+
+def test_collect_trajectories_finishes_generation_after_rollout_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(run_grpo_nemo_gym, "refit_policy_generation", MagicMock())
+    monkeypatch.setattr(
+        run_grpo_nemo_gym,
+        "run_nemo_gym_rollout_sync",
+        MagicMock(side_effect=RuntimeError("rollout failed")),
+    )
+    policy_generation = MagicMock()
+
+    with pytest.raises(RuntimeError, match="rollout failed"):
+        run_grpo_nemo_gym.collect_trajectories(
+            policy=MagicMock(),
+            policy_generation=policy_generation,
+            val_dataloader=[object()],
+            tokenizer=MagicMock(),
+            val_task_to_env={"nemo_gym": MagicMock()},
+            logger=MagicMock(),
+            master_config=_master_config(expected_trajectories=1),
+        )
+
+    policy_generation.finish_generation.assert_called_once_with()

--- a/tests/unit/test_run_grpo_rollout_benchmark.py
+++ b/tests/unit/test_run_grpo_rollout_benchmark.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from examples.nemo_gym import run_grpo_rollout_benchmark
+from nemo_rl.utils.config import register_omegaconf_resolvers
+
+
+def _load_workplace_config():
+    register_omegaconf_resolvers()
+    repo_root = Path(__file__).parents[2]
+    config_path = (
+        repo_root
+        / "examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml"
+    )
+    return run_grpo_rollout_benchmark.load_grpo_config(str(config_path), [])
+
+
+def test_convert_grpo_to_eval_config_inherits_rollout_settings() -> None:
+    grpo_config = _load_workplace_config()
+    grpo_config.grpo["num_generations_per_prompt"] = 4
+    grpo_config.grpo["num_prompts_per_step"] = 4
+    grpo_config.grpo["seed"] = 123
+    grpo_config.policy["generation"]["temperature"] = 0.7
+    grpo_config.policy["generation"]["top_p"] = 0.9
+
+    eval_config = run_grpo_rollout_benchmark.convert_grpo_to_eval_config(grpo_config)
+
+    assert eval_config.eval == {
+        "metric": "mean_reward",
+        "num_tests_per_prompt": 4,
+        "seed": 123,
+        "k_value": 1,
+        "save_path": None,
+    }
+    assert (
+        eval_config.generation["backend"] == grpo_config.policy["generation"]["backend"]
+    )
+    assert eval_config.generation["model_name"] == grpo_config.policy["model_name"]
+    assert eval_config.generation["num_prompts_per_step"] == 4
+    assert eval_config.generation["temperature"] == 0.7
+    assert eval_config.generation["top_p"] == 0.9
+    assert eval_config.generation["top_k"] is None
+    for key, value in grpo_config.policy["generation"]["vllm_cfg"].items():
+        assert eval_config.generation["vllm_cfg"][key] == value
+    assert eval_config.generation["vllm_cfg"]["enable_vllm_metrics_logger"] is True
+    assert eval_config.generation["vllm_cfg"]["vllm_metrics_logger_interval"] == 0.5
+    assert eval_config.data.dataset_name == "NemoGymDataset"
+    assert eval_config.data.data_path == grpo_config.data["validation"]["data_path"]
+    assert eval_config.env["should_use_nemo_gym"] is True
+    converted_gym_config = eval_config.env["nemo_gym"].model_dump()
+    assert "is_trajectory_collection" not in converted_gym_config
+    assert "trajectory_collection_batch_size" not in converted_gym_config
+    assert eval_config.logger["wandb"] == grpo_config.logger["wandb"]
+    assert eval_config.cluster == grpo_config.cluster
+    assert eval_config.policy is not None
+    assert eval_config.policy["generation"] == eval_config.generation
+
+
+def test_convert_grpo_to_eval_config_requires_one_validation_dataset() -> None:
+    grpo_config = _load_workplace_config()
+    grpo_config.data["validation"] = None
+    with pytest.raises(ValueError, match="requires data.validation"):
+        run_grpo_rollout_benchmark.convert_grpo_to_eval_config(grpo_config)
+
+    grpo_config = _load_workplace_config()
+    grpo_config.data["validation"] = [{"data_path": "a"}, {"data_path": "b"}]
+    with pytest.raises(ValueError, match="exactly one"):
+        run_grpo_rollout_benchmark.convert_grpo_to_eval_config(grpo_config)
+
+
+def test_convert_grpo_to_eval_config_preserves_megatron_backend() -> None:
+    grpo_config = _load_workplace_config()
+    grpo_config.policy["generation"]["backend"] = "megatron"
+    grpo_config.policy["generation"]["mcore_generation_config"] = {
+        "async_engine": True,
+        "expose_http_server": True,
+    }
+
+    eval_config = run_grpo_rollout_benchmark.convert_grpo_to_eval_config(grpo_config)
+
+    assert eval_config.generation["backend"] == "megatron"
+    assert eval_config.generation["mcore_generation_config"] == {
+        "async_engine": True,
+        "expose_http_server": True,
+    }
+    assert eval_config.policy is not None
+    assert eval_config.policy["generation"] == eval_config.generation
+
+
+def test_main_converts_then_runs_standard_eval(monkeypatch: pytest.MonkeyPatch) -> None:
+    grpo_config = object()
+    eval_config = object()
+    load_grpo_config = MagicMock(return_value=grpo_config)
+    convert_config = MagicMock(return_value=eval_config)
+    run_eval = MagicMock()
+    monkeypatch.setattr(
+        run_grpo_rollout_benchmark,
+        "parse_args",
+        lambda: (SimpleNamespace(config="source.yaml"), ["grpo.seed=7"]),
+    )
+    monkeypatch.setattr(
+        run_grpo_rollout_benchmark, "load_grpo_config", load_grpo_config
+    )
+    monkeypatch.setattr(
+        run_grpo_rollout_benchmark, "convert_grpo_to_eval_config", convert_config
+    )
+    monkeypatch.setattr(run_grpo_rollout_benchmark, "run_eval", run_eval)
+
+    run_grpo_rollout_benchmark.main()
+
+    load_grpo_config.assert_called_once_with("source.yaml", ["grpo.seed=7"])
+    convert_config.assert_called_once_with(grpo_config)
+    run_eval.assert_called_once_with(eval_config)

--- a/tests/unit/utils/test_logger.py
+++ b/tests/unit/utils/test_logger.py
@@ -392,6 +392,38 @@ class TestWandbLogger:
         mock_run.log.assert_called_once_with(metrics, commit=False)
 
     @patch("nemo_rl.utils.logger.wandb")
+    def test_log_metrics_commits_finished_custom_step(self, mock_wandb):
+        """The final log for a batch commits all custom-step metrics together."""
+        logger = WandbLogger({})
+        metrics = {"eval_step": 2, "score": 0.5}
+
+        logger.log_metrics(
+            metrics,
+            step=2,
+            step_metric="eval_step",
+            step_finished=True,
+        )
+
+        mock_wandb.init.return_value.log.assert_called_once_with(metrics, commit=True)
+
+    @patch("nemo_rl.utils.logger.wandb")
+    def test_log_plot_with_custom_step(self, mock_wandb):
+        logger = WandbLogger({})
+        figure = MagicMock()
+
+        logger.log_plot(
+            figure,
+            step=3,
+            name="generation_metrics/tokens",
+            step_metric="eval_step",
+        )
+
+        mock_wandb.init.return_value.log.assert_called_once_with(
+            {"eval_step": 3, "generation_metrics/tokens": figure},
+            commit=False,
+        )
+
+    @patch("nemo_rl.utils.logger.wandb")
     def test_log_metrics_with_prefix_and_step_metric(self, mock_wandb):
         """Test logging metrics with both prefix and step metric."""
         cfg = {}
@@ -1324,6 +1356,53 @@ ray_node_gram_used{{GpuIndex="0",GpuDeviceName="NVIDIA Test GPU"}} {80.0 * 1024}
         assert mock_parent_logger.logged_step_metrics[0] == custom_step_metric
 
     @patch("nemo_rl.utils.logger.ray")
+    def test_flush_aggregates_system_metrics_at_batch_step(
+        self, mock_ray, mock_parent_logger
+    ):
+        """Eval flushes all system samples once using its batch-defined step."""
+        mock_ray.is_initialized.return_value = True
+        monitor = RayGpuMonitorLogger(
+            collection_interval=10.0,
+            flush_interval=60.0,
+            metric_prefix="ray",
+            step_metric="ray/ray_step",
+            parent_logger=mock_parent_logger,
+        )
+        monitor.use_batch_steps("eval_step")
+        monitor.metrics_buffer = [
+            {
+                "step": 10,
+                "metrics": {"node.0.gpu.0.util": 50.0, "node.0.mem_gb": 100.0},
+            },
+            {
+                "step": 20,
+                "metrics": {
+                    "node.0.gpu.0.util": 90.0,
+                    "node.0.mem_gb": 120.0,
+                    "node.0.invalid": float("inf"),
+                },
+            },
+        ]
+
+        monitor.flush(step=4)
+
+        assert len(mock_parent_logger.logged_metrics) == 1
+        assert mock_parent_logger.logged_metrics[0] == {
+            "samples": 2,
+            "node.0.gpu.0.util/mean": 70.0,
+            "node.0.gpu.0.util/max": 90.0,
+            "node.0.gpu.0.util/last": 90.0,
+            "node.0.mem_gb/mean": 110.0,
+            "node.0.mem_gb/max": 120.0,
+            "node.0.mem_gb/last": 120.0,
+            "eval_step": 4,
+        }
+        assert mock_parent_logger.logged_steps == [4]
+        assert mock_parent_logger.logged_prefixes == ["ray"]
+        assert mock_parent_logger.logged_step_metrics == ["eval_step"]
+        assert monitor.metrics_buffer == []
+
+    @patch("nemo_rl.utils.logger.ray")
     @patch("nemo_rl.utils.logger.time")
     def test_collection_loop(self, mock_time, mock_ray):
         """Test _collection_loop method (one iteration)."""
@@ -1426,6 +1505,47 @@ ray_node_gram_used{{GpuIndex="0",GpuDeviceName="NVIDIA Test GPU"}} {80.0 * 1024}
         mock_wandb_instance = mock_wandb_logger.return_value
         mock_wandb_instance.define_metric.assert_called_once_with(
             "ray/*", step_metric="ray/ray_step"
+        )
+
+    @patch("nemo_rl.utils.logger.WandbLogger")
+    @patch("nemo_rl.utils.logger.TensorboardLogger")
+    @patch("nemo_rl.utils.logger.RayGpuMonitorLogger")
+    def test_use_batch_steps_with_gpu_monitoring(
+        self, mock_gpu_monitor, mock_tb_logger, mock_wandb_logger, temp_dir
+    ):
+        """Eval switches Ray and W&B to the caller's batch step."""
+        cfg = {
+            "wandb_enabled": True,
+            "tensorboard_enabled": False,
+            "mlflow_enabled": False,
+            "swanlab_enabled": False,
+            "monitor_gpus": True,
+            "gpu_monitoring": {
+                "collection_interval": 10.0,
+                "flush_interval": 60.0,
+            },
+            "wandb": {"project": "test-project"},
+            "log_dir": temp_dir,
+        }
+
+        logger = Logger(cfg)
+        logger.use_batch_steps("eval_step", ("eval/*", "generation_metrics/*", "ray/*"))
+
+        gpu_monitor = mock_gpu_monitor.return_value
+        gpu_monitor.use_batch_steps.assert_called_once_with("eval_step")
+        gpu_monitor.start.assert_called_once_with()
+        wandb_logger = mock_wandb_logger.return_value
+        wandb_logger.define_metric.assert_has_calls(
+            [
+                call("eval_step"),
+                call("eval/*", step_metric="eval_step"),
+                call("generation_metrics/*", step_metric="eval_step"),
+                call("ray/*", step_metric="eval_step"),
+            ],
+            any_order=True,
+        )
+        assert call("ray/*", step_metric="ray/ray_step") in (
+            wandb_logger.define_metric.call_args_list
         )
 
     @patch("nemo_rl.utils.logger.WandbLogger")

--- a/tests/unit/utils/test_logger.py
+++ b/tests/unit/utils/test_logger.py
@@ -1637,6 +1637,29 @@ ray_node_gram_used{{GpuIndex="0",GpuDeviceName="NVIDIA Test GPU"}} {80.0 * 1024}
 class TestLogger:
     """Test the main Logger class."""
 
+    def test_finish_stops_monitor_before_backends_and_is_idempotent(self):
+        """Logger teardown uses one ordered, idempotent lifecycle entry point."""
+        events = []
+        gpu_monitor = MagicMock()
+        gpu_monitor.stop.side_effect = lambda: events.append("monitor")
+        backend = MagicMock()
+        backend.finish.side_effect = lambda: events.append("backend")
+
+        logger = Logger.__new__(Logger)
+        logger.loggers = [backend]
+        logger.wandb_logger = backend
+        logger.gpu_monitor = gpu_monitor
+        logger._finished = False
+
+        logger.finish()
+        logger.finish()
+
+        assert events == ["monitor", "backend"]
+        gpu_monitor.stop.assert_called_once_with()
+        backend.finish.assert_called_once_with()
+        assert logger.gpu_monitor is None
+        assert logger.wandb_logger is None
+
     @pytest.fixture
     def temp_dir(self):
         """Create a temporary directory for logs."""


### PR DESCRIPTION
# What does this PR do?

Adds a **NeMo Gym rollout benchmark**: run an existing **GRPO recipe** through the **eval** path (generation-only — no training / optimizer step) to measure a policy's *agentic task-solve accuracy* — e.g. SWE-bench-Verified via NeMo Gym SWE agents — and emit **per-rollout telemetry**.

**What's added / changed**
- **New entrypoint** `examples/nemo_gym/run_grpo_rollout_benchmark.py`: loads a GRPO recipe, converts it to the eval config schema, and runs it via `run_eval`. The per-step batch is derived from the recipe's `grpo.num_prompts_per_step × num_generations_per_prompt`. Runnable directly (`uv run examples/nemo_gym/run_grpo_rollout_benchmark.py --config <recipe>`).
- **Eval drives NeMo Gym environments** (`nemo_rl/evals/eval.py`, `examples/run_eval.py`, `nemo_rl/environments/nemo_gym.py`): multi-turn agentic rollouts inside the eval loop, alongside the existing static-dataset eval.
- **Per-rollout telemetry** (`nemo_rl/utils/logger.py`, `nemo_rl/models/generation/*`): vLLM metrics logging (`enable_vllm_metrics_logger`) and per-rollout results (`nemo_gym_eval_results.jsonl` — reward, full agent response, per-trajectory timers).
- Config plumbing (`interfaces.py`, `vllm/config.py`), `docs/design-docs/nemo-gym-integration.md`, and unit tests.

# Usage
```bash
uv run examples/nemo_gym/run_grpo_rollout_benchmark.py \
  --config <grpo_recipe>.yaml \
  data.validation.data_path=<val_subset>.jsonl \
  grpo.num_prompts_per_step=<N>
```
- Reuses the recipe's model / generation / gym config; runs generation-only (no optimizer step).
- **Eval "steps" = val_subset_size / num_prompts_per_step** — size the val subset to control the step count.
- Designed for **reproducible measurement** on a fixed val subset (low run-to-run reward variance), so it can gate accuracy regressions of the policy or the rollout stack.

# Issues
_List issues this PR closes, if any._

# Before your PR is "Ready for review"
- [ ] Read and followed the [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Added new tests (`tests/unit/test_run_grpo_rollout_benchmark.py`, `tests/unit/evals/test_run_eval.py`, eval/logger tests)
- [ ] Ran unit + functional tests locally
- [x] Updated docs (`docs/design-docs/nemo-gym-integration.md`)

# Additional Information
* Post-hoc analysis tooling for benchmark runs lives on a separate scripts-only branch (`joyang/rollout-bench-analysis`), kept out of this PR.
