### PR TITLE
feat(vllm): expose Responses API from async workers

### DIFF
--- a/docs/design-docs/nemo-gym-integration.md
+++ b/docs/design-docs/nemo-gym-integration.md
@@ -121,10 +121,17 @@ The flow is:
 |--------|---------------------|----------------------|
 | **Engine** | Runs actual vLLM `AsyncLLM` | No engine - HTTP proxy only |
 | **GPU** | Holds model weights | No GPU required |
-| **Endpoints** | `/v1/chat/completions`, `/tokenize` | `/v1/responses` |
+| **Endpoints** | `/v1/chat/completions`, `/v1/responses`, `/tokenize` | `/v1/responses` |
 | **Role** | Inference | API translation, forwards requests |
 
 Data parallel vLLM workers each expose their own HTTP server. NeMo Gym's Model Server load-balances requests across them.
+
+The vLLM worker mounts vLLM's native Responses API, including create,
+retrieve, and cancel routes. The default NeMo Gym training path still translates
+Responses requests to Chat Completions because its on-policy correction contract
+requires selected-token logprobs. In vLLM 0.20, GPT-OSS Responses requests do not
+support output logprobs, so native GPT-OSS Responses serving cannot yet provide
+the complete token-ID and logprob payload required for GRPO training.
 
 ## Initialization Sequence
 

--- a/nemo_rl/models/generation/vllm/config.py
+++ b/nemo_rl/models/generation/vllm/config.py
@@ -37,7 +37,7 @@ class VllmSpecificArgs(TypedDict):
     use_tqdm: NotRequired[bool]
     # By default, NeMo RL only has a Python handle to the vllm.LLM generation engine. The expose_http_server flag here will expose that generation engine as an HTTP server.
     # Exposing vLLM as a server is useful in instances where the multi-turn rollout is performed with utilities outside of NeMo RL, but the user still wants to take advantage of the refit logic in NeMo RL that keeps the policy and generation up to date.
-    # Currently it will expose the /tokenize and /v1/chat/completions endpoints. Later on we may expose /v1/completions or /v1/responses.
+    # Currently it exposes the /tokenize, /v1/chat/completions, and /v1/responses endpoints. Later on we may expose /v1/completions.
     expose_http_server: NotRequired[bool]
     # These kwargs are passed to the vllm.LLM HTTP server Chat Completions endpoint config. Typically this will include things like tool parser, chat template, etc
     http_server_serving_chat_kwargs: NotRequired[dict[str, Any]]

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -458,6 +458,10 @@ class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
         from vllm.entrypoints.openai.engine.protocol import ErrorResponse
         from vllm.entrypoints.openai.models.protocol import BaseModelPath
         from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+        from vllm.entrypoints.openai.responses.api_router import (
+            attach_router as attach_responses_router,
+        )
+        from vllm.entrypoints.openai.responses.serving import OpenAIServingResponses
         from vllm.entrypoints.serve.tokenize.protocol import (
             TokenizeChatRequest,
             TokenizeCompletionRequest,
@@ -808,6 +812,45 @@ class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
                 )
 
             return StreamingResponse(content=generator, media_type="text/event-stream")
+
+        ########################################
+        # /v1/responses endpoints
+        ########################################
+
+        class NeMoRLOpenAIServingResponses(OpenAIServingResponses):
+            async def create_responses(self, request, raw_request=None):
+                # Match BaseVllmGenerationWorker._build_sampling_params and the
+                # Chat Completions endpoint above. Divergent sampling parameters
+                # make rollouts off-policy and can destabilize training.
+                assert request.top_k in (None, -1), (
+                    "Top k sampling parameter must be unset, empty, or -1. "
+                    f"Got `{request.top_k}`"
+                )
+                request.top_k = -1
+                assert request.temperature == generation_config["temperature"]
+                assert request.top_p == generation_config["top_p"]
+
+                return await super().create_responses(request, raw_request)
+
+        serving_responses_kwargs = dict(
+            engine_client=engine_client,
+            models=openai_serving_models,
+            openai_serving_render=openai_serving_render,
+            request_logger=serving_chat_kwargs["request_logger"],
+            chat_template=serving_chat_kwargs["chat_template"],
+            chat_template_content_format=serving_chat_kwargs[
+                "chat_template_content_format"
+            ],
+            return_tokens_as_token_ids=True,
+            reasoning_parser=serving_chat_kwargs.get("reasoning_parser") or "",
+            enable_auto_tools=serving_chat_kwargs["enable_auto_tools"],
+            tool_parser=serving_chat_kwargs.get("tool_parser"),
+        )
+        openai_serving_responses = NeMoRLOpenAIServingResponses(
+            **serving_responses_kwargs
+        )
+        app.state.openai_serving_responses = openai_serving_responses
+        attach_responses_router(app)
 
         ########################################
         # /tokenize endpoint

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -192,6 +192,7 @@ def _install_fake_vllm_openai_modules(monkeypatch):
         "vllm.entrypoints.openai.chat_completion",
         "vllm.entrypoints.openai.engine",
         "vllm.entrypoints.openai.models",
+        "vllm.entrypoints.openai.responses",
         "vllm.entrypoints.serve",
         "vllm.entrypoints.serve.render",
         "vllm.entrypoints.serve.tokenize",
@@ -229,6 +230,18 @@ def _install_fake_vllm_openai_modules(monkeypatch):
         def __init__(self, **kwargs):
             self.kwargs = kwargs
             self.instances.append(self)
+
+    class OpenAIServingResponses:
+        instances = []
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.last_request = None
+            self.instances.append(self)
+
+        async def create_responses(self, request, raw_request=None):
+            self.last_request = request
+            return "responses-result"
 
     class OpenAIServingTokenization:
         instances = []
@@ -268,6 +281,16 @@ def _install_fake_vllm_openai_modules(monkeypatch):
         OpenAIServingModels=OpenAIServingModels,
     )
     make_module(
+        "vllm.entrypoints.openai.responses.api_router",
+        attach_router=MagicMock(
+            side_effect=lambda app: app.include_router("responses-router")
+        ),
+    )
+    make_module(
+        "vllm.entrypoints.openai.responses.serving",
+        OpenAIServingResponses=OpenAIServingResponses,
+    )
+    make_module(
         "vllm.entrypoints.serve.tokenize.protocol",
         TokenizeChatRequest=type("TokenizeChatRequest", (), {}),
         TokenizeCompletionRequest=type("TokenizeCompletionRequest", (), {}),
@@ -291,12 +314,19 @@ def _install_fake_vllm_openai_modules(monkeypatch):
         ToolParserManager=ToolParserManager,
     )
     make_module("vllm.v1.engine.async_llm", logger=MagicMock())
-    return ToolParserManager, ReasoningParserManager, OpenAIServingChat
+    return (
+        ToolParserManager,
+        ReasoningParserManager,
+        OpenAIServingChat,
+        OpenAIServingResponses,
+    )
 
 
 class _FakeFastAPIApp:
     def __init__(self):
         self.routes = []
+        self.included_routers = []
+        self.state = types.SimpleNamespace()
 
     def post(self, path):
         def decorator(func):
@@ -305,12 +335,17 @@ class _FakeFastAPIApp:
 
         return decorator
 
+    def include_router(self, router):
+        self.included_routers.append(router)
 
-def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch):
+
+@pytest.mark.asyncio
+async def test_vllm_async_http_server_loads_parsers_and_responses_api(monkeypatch):
     (
         tool_parser_manager,
         reasoning_parser_manager,
         openai_serving_chat,
+        openai_serving_responses,
     ) = _install_fake_vllm_openai_modules(monkeypatch)
 
     worker = VllmAsyncGenerationWorkerImpl.__new__(VllmAsyncGenerationWorkerImpl)
@@ -342,6 +377,20 @@ def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch):
     assert openai_serving_chat.instances[0].kwargs["reasoning_parser"] == "nano_v3"
     # make sure that the config attribute does not leak into `http_server_serving_chat_kwargs`
     assert "reasoning_parser_plugin" not in openai_serving_chat.instances[0].kwargs
+
+    responses_handler = openai_serving_responses.instances[0]
+    assert responses_handler.kwargs["reasoning_parser"] == "nano_v3"
+    assert responses_handler.kwargs["return_tokens_as_token_ids"] is True
+    assert app.state.openai_serving_responses is responses_handler
+    assert app.included_routers == ["responses-router"]
+
+    request = types.SimpleNamespace(top_k=None, temperature=1.0, top_p=1.0)
+    assert await responses_handler.create_responses(request) == "responses-result"
+    assert request.top_k == -1
+
+    mismatched_request = types.SimpleNamespace(top_k=None, temperature=0.5, top_p=1.0)
+    with pytest.raises(AssertionError):
+        await responses_handler.create_responses(mismatched_request)
 
 
 def test_nano_v3_reasoning_parser_swaps_reasoning_when_thinking_disabled(
@@ -1605,6 +1654,29 @@ def test_vllm_http_server(cluster, tokenizer):
         return d
 
     assert _standardize(expected_result) == _standardize(actual_result)
+
+    # Check that the Responses API is backed by the same engine and sampling
+    # configuration as the Chat Completions endpoint.
+    responses_body = dict(
+        model=generation_config["model_name"],
+        input="count to 5",
+        temperature=generation_config["temperature"],
+        top_p=generation_config["top_p"],
+        max_output_tokens=1,
+        store=False,
+        enable_response_messages=True,
+    )
+    response = requests.post(url=f"{base_urls[0]}/responses", json=responses_body)
+    assert response.status_code == 200, response.text
+    responses_result = response.json()
+    assert responses_result["object"] == "response"
+    assert responses_result["model"] == generation_config["model_name"]
+    assert responses_result["usage"]["output_tokens"] == 1
+    assert responses_result["output"]
+    assert responses_result["input_messages"][0]["type"] == "raw_message_tokens"
+    assert responses_result["input_messages"][0]["tokens"]
+    assert responses_result["output_messages"][0]["type"] == "raw_message_tokens"
+    assert responses_result["output_messages"][0]["tokens"]
 
     # Check that tokenization route works
     response = requests.post(url=f"{base_urls[0]}/../tokenize", json=body)


### PR DESCRIPTION
# What does this PR do?

Exposes vLLM 0.20's native Responses API from NeMo RL async vLLM workers when `expose_http_server` is enabled.

## Problem

The async vLLM worker already hosts the model engine and manually exposes Chat Completions and tokenization routes. It does not initialize vLLM's Responses serving object or mount the official Responses router, so clients using `/v1/responses` need a separate translation proxy even though the worker already owns the relevant engine, model registry, templates, and parsers.

For post-training, exposing another generation route also requires preserving the rollout sampling contract. If a client silently changes `top_k`, temperature, or `top_p`, the generated trajectories no longer match the policy configuration and can become off-policy training data.

## Implementation

- Initializes `OpenAIServingResponses` with the existing async engine, model registry, rendering configuration, request logger, chat template, reasoning parser, and tool parser.
- Mounts vLLM's official create, retrieve, and cancel Responses routes through its `attach_router` helper instead of duplicating endpoint implementations in NeMo RL.
- Stores the serving object on `app.state`, following vLLM's expected router integration.
- Enables raw response token messages with `return_tokens_as_token_ids=True` so callers can recover exact input and output token IDs.
- Applies the same sampling-alignment safeguards as NeMo RL's Chat Completions endpoint:
  - `top_k` must be unset or `-1` and is normalized to `-1`.
  - `temperature` must equal the configured generation temperature.
  - `top_p` must equal the configured generation `top_p`.
- Updates the HTTP-server configuration comments and the NeMo Gym integration design document.

The existing Chat Completions and `/tokenize` behavior is unchanged.

# Issues

Addresses #1923.

This intentionally uses `Addresses` rather than an auto-closing keyword because of the GPT-OSS limitation described below.

# Usage

With `expose_http_server: true`, the worker accepts native Responses API requests:

```bash
curl http://<worker-host>:<port>/v1/responses \
  -H 'Content-Type: application/json' \
  -d '{"model":"<model>","input":"Solve 2 + 2.","temperature":1.0,"top_p":1.0}'
```

The requested temperature and `top_p` must match the worker's generation configuration.

# Testing

Added unit coverage that installs mocked vLLM 0.20 modules and verifies:

- The official Responses router is mounted.
- The Responses serving object reuses the expected engine/render/parser configuration.
- Raw token messages are enabled.
- An aligned request succeeds and normalizes `top_k`.
- A mismatched sampling request is rejected.

Extended the existing GPU HTTP integration test to send a real `/v1/responses` request and validate the response object, usage, and raw input/output token messages.

Local validation completed:

- Ruff lint and format checks.
- Python syntax/compile checks.
- Mocked route-wiring and sampling-contract exercise.
- `git diff --check`.

The GPU HTTP integration test requires a supported CUDA/vLLM environment and is left for NVIDIA CI.

# Compatibility and current limitation

In vLLM 0.20, GPT-OSS Responses requests reject output-logprob requests. NeMo RL's default GRPO correction path requires selected-token logprobs, so this PR exposes native Responses serving and exact token IDs but does not claim complete native GPT-OSS GRPO support yet. The documentation calls out that boundary explicitly.

# Before this PR is ready to merge

- [x] Read and followed the contributor guidelines.
- [x] Added necessary tests.
- [x] Updated the necessary documentation.
- [x] Ran available local lint, formatting, syntax, and mocked unit validation.
- [ ] Run the GPU HTTP integration coverage in NVIDIA CI.
