### PR TITLE
feat(vlm): support configurable custom reward functions

### DIFF
--- a/docs/guides/environments.md
+++ b/docs/guides/environments.md
@@ -65,6 +65,64 @@ if multi_rewards is not None:
 ```
 For instance, when running `examples/configs/gdpo_math_1B.yaml`, the batch will contain `reward/correctness`, `reward/integer`, and `reward/format`. More details can be found in `HFMultiRewardVerifyWorker`. Users can implement their own multi-reward environments by returning a dict from `step()` with keys using the `reward/` prefix.
 
+## VLM Environment
+
+The VLM Environment combines one or more weighted reward functions. It includes
+the built-in `format`, `exact_alnum`, `math_expr`, `bbox_giou`, and `geo3k`
+rewards. Custom reward functions can also be loaded from an importable Python
+module or a Python file without modifying NeMo RL.
+
+A custom reward callable receives the ground truth and model response and returns
+`(score, is_correct)`. Set `is_correct` to `None` when the reward does not
+measure correctness. Keyword arguments configured under `reward_functions` are
+passed to the callable after the two positional arguments.
+
+```python
+# my_project/rewards.py
+def concise_answer_reward(
+    ground_truth: str,
+    response: str,
+    max_characters: int,
+) -> tuple[float, bool | None]:
+    del ground_truth
+    return float(len(response) <= max_characters), None
+```
+
+Register the callable under a unique name, then select it in the existing
+weighted `reward_functions` list:
+
+```yaml
+env:
+  my-vlm-task:
+    num_workers: 8
+    custom_reward_functions:
+    - name: concise_answer
+      module: my_project.rewards
+      function: concise_answer_reward
+    reward_functions:
+    - name: exact_alnum
+      weight: 0.8
+    - name: concise_answer
+      weight: 0.2
+      kwargs:
+        max_characters: 256
+```
+
+For a standalone script, replace `module` with `file`:
+
+```yaml
+    custom_reward_functions:
+    - name: concise_answer
+      file: /shared/research/rewards.py
+      function: concise_answer_reward
+```
+
+Set exactly one of `module` or `file` per custom reward. Custom names cannot
+replace built-in rewards or another custom reward. Because verification runs in
+Ray workers, modules and files—and any dependencies they import—must be available
+in the VLM worker environment on every node. On multi-node jobs, use an installed
+package or a shared absolute file path.
+
 ## Code Environment
 
 The Code Environment is designed for code generation and execution tasks. It provides a sandboxed environment for executing Python code and evaluating the results.

--- a/examples/configs/vlm_grpo_3B.yaml
+++ b/examples/configs/vlm_grpo_3B.yaml
@@ -46,6 +46,13 @@ data:
 env:
   clevr-cogent:
     num_workers: 8
+    # Optional user-defined reward callables. Each entry requires `name`,
+    # `function`, and exactly one of `module` or `file`. The selected source
+    # must be importable/readable by VLM verification workers on every node.
+    # custom_reward_functions:
+    # - name: custom_reward
+    #   module: my_project.rewards
+    #   function: score_response
     reward_functions:
     - name: format
       weight: 0.2

--- a/nemo_rl/environments/vlm_environment.py
+++ b/nemo_rl/environments/vlm_environment.py
@@ -12,13 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import contextlib
+import importlib
+import importlib.util
 import io
 import logging
+import sys
 from functools import partial
+from pathlib import Path
+from types import ModuleType
 from typing import Any, Callable, List, NotRequired, Optional, TypedDict
 
 import ray
 import torch
+from pydantic import BaseModel, Field, model_validator
 
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.virtual_cluster import PY_EXECUTABLES
@@ -40,10 +46,151 @@ from nemo_rl.environments.rewards import (
 from nemo_rl.environments.utils import chunk_list_to_workers
 
 
+class CustomRewardFunctionConfig(BaseModel, extra="forbid"):
+    """Import location for a user-defined VLM reward function."""
+
+    name: str = Field(min_length=1)
+    function: str = Field(min_length=1)
+    module: Optional[str] = None
+    file: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _require_exactly_one_source(self) -> "CustomRewardFunctionConfig":
+        if (self.module is None) == (self.file is None):
+            raise ValueError("exactly one of 'module' or 'file' must be set")
+        return self
+
+
 class VLMEnvConfig(TypedDict):
     num_workers: int
     stop_strings: NotRequired[Optional[list[str]]]  # Default stop strings for this env
     reward_functions: List[dict[str, Any]]  # list of reward functions and their weights
+    custom_reward_functions: NotRequired[list[CustomRewardFunctionConfig]]
+
+
+RewardFunction = Callable[[str, str], tuple[float, Optional[bool]]]
+
+_BUILTIN_REWARD_FUNCTIONS: dict[str, RewardFunction] = {
+    "format": format_reward,
+    "exact_alnum": exact_answer_alphanumeric_reward,
+    "math_expr": math_expression_reward,
+    "bbox_giou": bbox_giou_reward,
+    "geo3k": geo3k_reward,
+}
+
+
+def _load_reward_module(config: CustomRewardFunctionConfig) -> ModuleType:
+    """Load the module containing a configured custom reward function."""
+    if config.module is not None:
+        try:
+            return importlib.import_module(config.module)
+        except Exception as error:
+            raise ValueError(
+                f"Failed to import module '{config.module}' for custom reward "
+                f"function '{config.name}'"
+            ) from error
+
+    assert config.file is not None  # Enforced by CustomRewardFunctionConfig.
+    file_path = Path(config.file)
+    if not file_path.is_file():
+        raise ValueError(
+            f"Python file '{file_path}' for custom reward function "
+            f"'{config.name}' does not exist"
+        )
+
+    module_name = f"nemo_rl_custom_reward_{abs(hash(file_path.resolve()))}"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    if spec is None or spec.loader is None:
+        raise ValueError(
+            f"Could not create an import spec for custom reward file '{file_path}'"
+        )
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception as error:
+        sys.modules.pop(module_name, None)
+        raise ValueError(
+            f"Failed to load Python file '{file_path}' for custom reward "
+            f"function '{config.name}'"
+        ) from error
+    return module
+
+
+def _load_custom_reward_function(
+    raw_config: CustomRewardFunctionConfig | dict[str, Any],
+) -> tuple[str, RewardFunction]:
+    """Load and validate one custom reward function from user configuration."""
+    config = CustomRewardFunctionConfig.model_validate(raw_config)
+    module = _load_reward_module(config)
+
+    try:
+        reward_function = getattr(module, config.function)
+    except AttributeError as error:
+        source = config.module if config.module is not None else config.file
+        raise ValueError(
+            f"Custom reward source '{source}' has no attribute "
+            f"'{config.function}' for reward '{config.name}'"
+        ) from error
+
+    if not callable(reward_function):
+        raise ValueError(
+            f"Custom reward '{config.name}' resolves to non-callable attribute "
+            f"'{config.function}'"
+        )
+    return config.name, reward_function
+
+
+def _get_reward_function_registry(cfg: VLMEnvConfig) -> dict[str, RewardFunction]:
+    """Return built-in and configured custom VLM reward functions by name."""
+    registry = dict(_BUILTIN_REWARD_FUNCTIONS)
+    custom_reward_configs = cfg.get("custom_reward_functions")
+    if custom_reward_configs is None:
+        return registry
+
+    for raw_config in custom_reward_configs:
+        config = CustomRewardFunctionConfig.model_validate(raw_config)
+        if config.name in registry:
+            raise ValueError(
+                f"Reward function name '{config.name}' is already registered; custom "
+                "reward names must not replace built-in or previously configured functions"
+            )
+        name, reward_function = _load_custom_reward_function(config)
+        registry[name] = reward_function
+    return registry
+
+
+def _resolve_configured_reward_functions(
+    cfg: VLMEnvConfig,
+) -> list[tuple[RewardFunction, float]]:
+    """Resolve weighted reward functions selected by a VLM environment config."""
+    registry = _get_reward_function_registry(cfg)
+    reward_functions = []
+    for reward_func_cfg in cfg["reward_functions"]:
+        reward_func_name: str = reward_func_cfg["name"]
+        reward_func_weight: float = reward_func_cfg["weight"]
+        reward_func_kwargs: Optional[dict] = reward_func_cfg.get("kwargs", None)
+
+        try:
+            reward_func = registry[reward_func_name]
+        except KeyError as error:
+            available_names = ", ".join(sorted(registry))
+            raise ValueError(
+                f"Invalid reward function: {reward_func_name}. "
+                f"Available reward functions: {available_names}"
+            ) from error
+
+        if reward_func_kwargs is not None:
+            reward_func = partial(reward_func, **reward_func_kwargs)
+        reward_functions.append((reward_func, reward_func_weight))
+
+    if len(reward_functions) == 0:
+        raise ValueError("No reward functions provided")
+    return reward_functions
 
 
 @contextlib.contextmanager
@@ -60,38 +207,7 @@ def _mute_output():
 class VLMVerifyWorker:
     def __init__(self, cfg: VLMEnvConfig) -> None:
         logging.getLogger("vlm_worker").setLevel(logging.CRITICAL)
-        # this is a simple reward function that rewards the agent for correct answer and correct format
-        reward_functions = []
-        # loop over all configs
-        for reward_func_cfg in cfg["reward_functions"]:
-            # get name and weight
-            reward_func_name: str = reward_func_cfg["name"]
-            reward_func_weight: float = reward_func_cfg["weight"]
-            reward_func_kwargs: Optional[dict] = reward_func_cfg.get("kwargs", None)
-            reward_func: Callable[[str, str], tuple[float, Optional[bool]]]
-            if reward_func_name == "format":
-                reward_func = format_reward
-            elif reward_func_name == "exact_alnum":
-                reward_func = exact_answer_alphanumeric_reward
-            elif reward_func_name == "math_expr":
-                reward_func = math_expression_reward
-            elif reward_func_name == "bbox_giou":
-                reward_func = bbox_giou_reward
-            elif reward_func_name == "geo3k":
-                reward_func = geo3k_reward
-            else:
-                raise ValueError(f"Invalid reward function: {reward_func_name}")
-
-            # check for additional kwargs
-            if reward_func_kwargs is not None:
-                reward_func = partial(reward_func, **reward_func_kwargs)
-
-            reward_functions.append((reward_func, reward_func_weight))
-
-        if len(reward_functions) == 0:
-            raise ValueError("No reward functions provided")
-
-        # combine the reward functions
+        reward_functions = _resolve_configured_reward_functions(cfg)
         self.verify_func = combine_reward_functions(reward_functions)
 
     def verify(

--- a/tests/unit/environments/test_vlm_environment.py
+++ b/tests/unit/environments/test_vlm_environment.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import pytest
+
+from nemo_rl.environments.vlm_environment import (
+    _BUILTIN_REWARD_FUNCTIONS,
+    _get_reward_function_registry,
+    _resolve_configured_reward_functions,
+)
+
+
+_CUSTOM_REWARD_SOURCE = """
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class RewardOptions:
+    scale: float = 1.0
+
+
+def length_reward(ground_truth, response, scale=1.0):
+    return len(response) * scale, None
+
+not_a_reward = 123
+"""
+
+
+def _write_reward_module(path: Path) -> None:
+    path.write_text(_CUSTOM_REWARD_SOURCE)
+
+
+def test_builtin_reward_configuration_is_backward_compatible():
+    resolved = _resolve_configured_reward_functions(
+        {
+            "num_workers": 1,
+            "reward_functions": [{"name": "format", "weight": 0.25}],
+        }
+    )
+
+    assert resolved == [(_BUILTIN_REWARD_FUNCTIONS["format"], 0.25)]
+
+
+def test_loads_custom_reward_from_importable_module(tmp_path, monkeypatch):
+    _write_reward_module(tmp_path / "research_rewards.py")
+    monkeypatch.syspath_prepend(tmp_path)
+
+    resolved = _resolve_configured_reward_functions(
+        {
+            "num_workers": 1,
+            "custom_reward_functions": [
+                {
+                    "name": "length",
+                    "module": "research_rewards",
+                    "function": "length_reward",
+                }
+            ],
+            "reward_functions": [
+                {"name": "length", "weight": 1.0, "kwargs": {"scale": 0.5}}
+            ],
+        }
+    )
+
+    reward_function, weight = resolved[0]
+    assert reward_function("unused", "abcd") == (2.0, None)
+    assert weight == 1.0
+
+
+def test_loads_custom_reward_from_python_file(tmp_path):
+    reward_file = tmp_path / "research_rewards.py"
+    _write_reward_module(reward_file)
+
+    resolved = _resolve_configured_reward_functions(
+        {
+            "num_workers": 1,
+            "custom_reward_functions": [
+                {
+                    "name": "length",
+                    "file": str(reward_file),
+                    "function": "length_reward",
+                }
+            ],
+            "reward_functions": [{"name": "length", "weight": 1.0}],
+        }
+    )
+
+    reward_function, _ = resolved[0]
+    assert reward_function("unused", "abc") == (3.0, None)
+
+
+@pytest.mark.parametrize(
+    "custom_config",
+    [
+        {"name": "length", "function": "length_reward"},
+        {
+            "name": "length",
+            "module": "research_rewards",
+            "file": "/tmp/research_rewards.py",
+            "function": "length_reward",
+        },
+    ],
+)
+def test_custom_reward_requires_exactly_one_source(custom_config):
+    with pytest.raises(ValueError, match="exactly one of 'module' or 'file'"):
+        _get_reward_function_registry(
+            {
+                "num_workers": 1,
+                "custom_reward_functions": [custom_config],
+                "reward_functions": [{"name": "length", "weight": 1.0}],
+            }
+        )
+
+
+def test_custom_reward_cannot_replace_builtin(tmp_path):
+    reward_file = tmp_path / "research_rewards.py"
+    _write_reward_module(reward_file)
+
+    with pytest.raises(ValueError, match="'format' is already registered"):
+        _get_reward_function_registry(
+            {
+                "num_workers": 1,
+                "custom_reward_functions": [
+                    {
+                        "name": "format",
+                        "file": str(reward_file),
+                        "function": "length_reward",
+                    }
+                ],
+                "reward_functions": [{"name": "format", "weight": 1.0}],
+            }
+        )
+
+
+def test_custom_reward_attribute_must_be_callable(tmp_path):
+    reward_file = tmp_path / "research_rewards.py"
+    _write_reward_module(reward_file)
+
+    with pytest.raises(ValueError, match="resolves to non-callable attribute"):
+        _get_reward_function_registry(
+            {
+                "num_workers": 1,
+                "custom_reward_functions": [
+                    {
+                        "name": "broken",
+                        "file": str(reward_file),
+                        "function": "not_a_reward",
+                    }
+                ],
+                "reward_functions": [{"name": "broken", "weight": 1.0}],
+            }
+        )
+
+
+def test_unknown_reward_error_lists_custom_and_builtin_names(tmp_path):
+    reward_file = tmp_path / "research_rewards.py"
+    _write_reward_module(reward_file)
+
+    with pytest.raises(ValueError, match="Available reward functions:.*length"):
+        _resolve_configured_reward_functions(
+            {
+                "num_workers": 1,
+                "custom_reward_functions": [
+                    {
+                        "name": "length",
+                        "file": str(reward_file),
+                        "function": "length_reward",
+                    }
+                ],
+                "reward_functions": [{"name": "typo", "weight": 1.0}],
+            }
+        )


### PR DESCRIPTION
# What does this PR do?

Adds an opt-in, validated custom reward registry to `VLMEnvironment`, allowing applied-research reward functions to live outside the NeMo RL source tree.

## Problem

`VLMEnvironment` currently builds its reward registry from a fixed set of functions defined inside NeMo RL. A researcher who wants to evaluate a new vision-language behavior must modify the framework source, add another built-in name, and carry that patch while iterating.

That makes reward research—the central scoring signal in RL post-training—unnecessarily coupled to framework releases. The requested workflow in #1211 is to select project-owned reward code from configuration while retaining the existing weighted reward composition.

## Design

This PR adds an optional `custom_reward_functions` list to each VLM environment configuration. Every entry declares:

- A unique registry `name`.
- The exported callable's `function` name.
- Exactly one source: an importable `module` or a Python `file`.

At environment initialization, NeMo RL validates the configuration, loads each callable, and extends the per-environment reward registry. The existing `reward_functions` list then selects built-in and custom names uniformly, including the existing weights and per-reward kwargs.

## Callable contract

A custom reward receives the ground truth and model response as its first two arguments. Configured kwargs are forwarded after them:

```python
def concise_answer_reward(
    ground_truth: str,
    response: str,
    max_characters: int,
) -> tuple[float, bool | None]:
    del ground_truth
    return float(len(response) <= max_characters), None
```

The return value is `(score, is_correct)`. `is_correct` can be `None` for rewards that do not represent correctness.

## Validation and compatibility

- All existing built-in reward names and behavior remain unchanged.
- Omitting `custom_reward_functions` preserves the current configuration path.
- Pydantic rejects unknown configuration fields.
- Each entry must specify exactly one of `module` or `file`.
- Custom names cannot replace built-ins or another custom reward.
- Missing modules/files, missing attributes, and non-callable attributes fail during environment construction with actionable errors.
- File-backed modules are registered in `sys.modules` before execution and removed if execution fails. This supports dataclasses and postponed annotations and avoids inconsistent partial imports.

# Issues

Closes #1211.

# Usage

Load from an importable module:

```yaml
env:
  my-vlm-task:
    custom_reward_functions:
    - name: concise_answer
      module: my_project.rewards
      function: concise_answer_reward
    reward_functions:
    - name: exact_alnum
      weight: 0.8
    - name: concise_answer
      weight: 0.2
      kwargs:
        max_characters: 256
```

For a standalone script shared by every worker, replace `module` with `file`:

```yaml
    custom_reward_functions:
    - name: concise_answer
      file: /shared/research/rewards.py
      function: concise_answer_reward
```

# Distributed execution and security model

VLM verification runs in Ray workers. Modules, files, and their dependencies must therefore be importable or readable in the worker environment on every node. For multi-node jobs, use an installed package or a shared absolute file path.

Custom rewards are trusted executable Python code, like importing a project module directly. This mechanism is intended for code controlled by the job owner; it is not a sandbox for untrusted reward files.

# Testing

Added focused tests covering:

- Backward-compatible built-in rewards.
- Importable-module rewards.
- File-backed rewards using postponed annotations and a dataclass.
- Weighted composition and kwargs forwarding.
- Ambiguous source configuration.
- Name collisions.
- Missing attributes and non-callable exports.
- File/module loading failures.

Local validation completed:

- 8 focused unit tests passed.
- Ruff lint and format checks passed.
- `git diff --check` passed.

# Documentation

- Documents the callable contract, module and file forms, trusted-code boundary, and multi-node requirements.
- Adds a commented example to `examples/configs/vlm_grpo_3B.yaml`.

# Before this PR is ready to merge

- [x] Read and followed the contributor guidelines.
- [x] Added necessary tests.
- [x] Ran the focused unit tests locally.
- [x] Updated the necessary documentation and example configuration.
- [ ] Run the repository-selected CI suite.
