### PR TITLE
fix: preserve runtime tools after arm64 Apptainer build

### DIFF
--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -116,6 +116,7 @@ runs:
           --env HF_DATASETS_CACHE=/home/TestData/nemo-rl/hf_datasets_cache \
           --env NEMO_RL_REPO_DIR=/opt/nemo-rl \
           --env HF_TOKEN \
+          --env BASH_ENV= \
           ${{ inputs.is_fork_pr == 'true' && '--env HF_HUB_OFFLINE=1' || '' }} \
           ${{ inputs.image-tag != '' && '--env FAST=1' || '' }} \
           --volume $(pwd)/${{ github.run_id }}/${{steps.uuid.outputs.id }}/nemo-rl:/opt/nemo-rl \

--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -116,7 +116,6 @@ runs:
           --env HF_DATASETS_CACHE=/home/TestData/nemo-rl/hf_datasets_cache \
           --env NEMO_RL_REPO_DIR=/opt/nemo-rl \
           --env HF_TOKEN \
-          --env BASH_ENV= \
           ${{ inputs.is_fork_pr == 'true' && '--env HF_HUB_OFFLINE=1' || '' }} \
           ${{ inputs.image-tag != '' && '--env FAST=1' || '' }} \
           --volume $(pwd)/${{ github.run_id }}/${{steps.uuid.outputs.id }}/nemo-rl:/opt/nemo-rl \

--- a/docker/install_apptainer.sh
+++ b/docker/install_apptainer.sh
@@ -45,7 +45,6 @@ install_arm64_from_source() {
     local build_packages=(
         autoconf
         automake
-        build-essential
         dh-apparmor
         libfuse3-dev
         liblzo2-dev
@@ -59,6 +58,7 @@ install_arm64_from_source() {
         zlib1g-dev
     )
     local runtime_packages=(
+        build-essential
         ca-certificates
         cryptsetup
         fakeroot
@@ -75,6 +75,13 @@ install_arm64_from_source() {
         uidmap
         zlib1g
     )
+    local new_build_packages=()
+
+    for package in "${build_packages[@]}"; do
+        if ! dpkg-query -W -f='${db:Status-Abbrev}' "${package}" 2>/dev/null | grep -q '^ii '; then
+            new_build_packages+=("${package}")
+        fi
+    done
 
     apt-get update
     apt-get install -y --no-install-recommends "${runtime_packages[@]}" "${build_packages[@]}"
@@ -98,7 +105,9 @@ install_arm64_from_source() {
     rm -rf "${build_dir}"
 
     apt-get install -y --no-install-recommends "${runtime_packages[@]}"
-    apt-get purge -y --auto-remove "${build_packages[@]}"
+    if ((${#new_build_packages[@]} > 0)); then
+        apt-get purge -y --auto-remove "${new_build_packages[@]}"
+    fi
     rm -rf /usr/local/go /root/go /root/.cache/go-build
 }
 

--- a/docker/install_apptainer.sh
+++ b/docker/install_apptainer.sh
@@ -41,13 +41,12 @@ install_arm64_from_source() {
     local build_dir="/tmp/apptainer-build"
     local source_tarball="/tmp/apptainer-${APPTAINER_VERSION}.tar.gz"
     local source_url="https://github.com/apptainer/apptainer/releases/download/v${APPTAINER_VERSION}/apptainer-${APPTAINER_VERSION}.tar.gz"
+    # curl, git, and wget are installed by docker/Dockerfile and must remain in the final image.
     local build_packages=(
         autoconf
         automake
         build-essential
-        curl
         dh-apparmor
-        git
         libfuse3-dev
         liblzo2-dev
         liblz4-dev
@@ -57,7 +56,6 @@ install_arm64_from_source() {
         libtool
         libzstd-dev
         pkg-config
-        wget
         zlib1g-dev
     )
     local runtime_packages=(


### PR DESCRIPTION
## Summary

- The arm64 Apptainer source-build path purged every package declared as a build dependency, including tools already supplied by the base image or installed by `docker/Dockerfile`.
- The initial cleanup removed `curl`, `git`, and `wget`, causing GB200 tests to fail at the first `git config` command.
- After preserving those tools, the image-build log showed that `build-essential` was also pre-installed. Purging it with `--auto-remove` removed GCC, G++, Make, and CUDA compiler packages, causing Triton JIT compilation to fail at runtime.
- Keep `build-essential` as an explicit runtime dependency, record which temporary build packages were absent before installation, and purge only that newly installed subset.
- Revert the earlier `BASH_ENV` workaround because it did not address the missing executables.

The amd64 Apptainer path installs a release package and does not use this source-build cleanup, which is why the corresponding H100 jobs were unaffected.

## Test plan

- [x] Run `bash -n docker/install_apptainer.sh`
- [x] Run `git diff --check`
- [ ] Confirm the GB200 image retains `git`, `curl`, `wget`, GCC, G++, Make, and the CUDA compiler packages
- [ ] Confirm GB200 functional tests proceed through Triton JIT compilation
- [ ] Confirm H100 functional tests remain unaffected