### PR TITLE
ci: bump async-gym megatron test wall-clock budget to 120 min

### DIFF
--- a/tests/test_suites/llm/grpo-nanov3-30BA3B-2n8g-megatron_generation-async-gym.sh
+++ b/tests/test_suites/llm/grpo-nanov3-30BA3B-2n8g-megatron_generation-async-gym.sh
@@ -8,7 +8,11 @@ GPUS_PER_NODE=8
 STEPS_PER_RUN=8
 MAX_STEPS=8
 NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
-NUM_MINUTES=90
+# ~25 min startup (30B-MoE load + CUDA-graph warmup + nemo_gym servers) plus
+# ~63 min for 8 async steps left no headroom at 90 min, so the driver finished
+# but Slurm SIGKILLed teardown/metric-dump at the wall-clock limit (CI mislabels
+# the exit-137 as OOM). 120 min leaves margin for teardown + metrics.
+NUM_MINUTES=120
 # ===== END CONFIG =====
 
 exit_if_max_steps_reached


### PR DESCRIPTION
## Summary
- Bump `NUM_MINUTES` from 90 to 120 in `grpo-nanov3-30BA3B-2n8g-megatron_generation-async-gym.sh`.
- Job [364261521](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/364261521) completes all 8 async GRPO steps (`Async GRPO training complete!`) but is SIGKILLed at the 90-minute Slurm wall-clock limit during teardown, before `json_dump_tb_logs.py` / `check_metrics.py` run. nemo-ci classifies exit 137 as `Signal/OOM-Kill`; there is no CUDA OOM in the driver log.
- Wall-clock breakdown: ~25 min startup (30B-MoE load + CUDA-graph warmup + nemo_gym servers) + ~63 min for 8 steps leaves ~0 headroom at 90 min. PR #3150 already reduced steps 10→8 but kept the 90 min budget.

## Test plan
- [ ] `/ok to test <commit-sha>` on the MR
- [ ] Confirm `llm_grpo_nanov3_30BA3B_2n8g_megatron_generation_async_gym` finishes with `metrics.json` written on cw_dfw