### PR TITLE
fix(skills): quote review-pr argument-hint so SKILL.md frontmatter parses

### DIFF
--- a/.agents/contributor-skills/review-pr/SKILL.md
+++ b/.agents/contributor-skills/review-pr/SKILL.md
@@ -2,7 +2,7 @@
 name: review-pr
 description: Interactive code review for NVIDIA-NeMo/RL pull requests. Checks out PR locally, reads existing comments, applies coding guidelines from skills, previews findings, and posts review comments. Also supports reviewing the current branch locally.
 when_to_use: Reviewing a PR; '/review-pr <number>'; 'review this PR', 'check PR', 'code review for PR'.
-argument-hint: [<pr-number>] [update] [--deep]
+argument-hint: "[<pr-number>] [update] [--deep]"
 allowed-tools: [AskUserQuestion, Bash, Read, Glob, Grep, Agent, mcp__github__pull_request_read, mcp__github__pull_request_review_write, mcp__github__add_comment_to_pending_review, mcp__github__add_reply_to_pull_request_comment, mcp__github__add_issue_comment]
 ---
 


### PR DESCRIPTION
## Background / motivation

- The `nemo-rl-skills` Regent Plugin (packaged from this repo's `.agents/contributor-skills/`) is snapshotted into every author-agent AgentRun.
- Snapshotting fails hard:
  ```
  invalid AgentRun template Plugins: snapshot Plugins: Plugin regent-nemo-ci/nemo-rl-skills
  is not usable: InvalidPlugin: Skill package "skills/review-pr": parse SKILL.md frontmatter:
  yaml: line 3: did not find expected key.
  ```
- Because one bad skill invalidates the whole Plugin, **every** AgentRun that references it (author-agent, etc.) fails — not just `/review-pr`.

## What changed

- Quote the `argument-hint` value in `.agents/contributor-skills/review-pr/SKILL.md` so the frontmatter is valid YAML.

## Details

- `argument-hint: [<pr-number>] [update] [--deep]` is **three separate bracket groups**, not a single valid YAML flow sequence. After `[<pr-number>]` closes the sequence, the trailing ` [update] [--deep]` is a syntax error.
- `yaml.v3` (the parser Regent uses) reports it as `line 3: did not find expected key` — it points at the line *before* the real offender, which is why this looked like a `when_to_use` problem. Empirically, quoting only `when_to_use` does **not** fix it; quoting `argument-hint` does.
- Fix: `argument-hint: "[<pr-number>] [update] [--deep]"` — parses as a plain string, value unchanged.

## Tested

- Reproduced the exact error against `gopkg.in/yaml.v3@v3.0.1`:
  - before → `PARSE ERROR: yaml: line 3: did not find expected key`
  - after  → `PARSED OK` (keys: name, description, when_to_use, argument-hint, allowed-tools)
- Verified every other `.agents/contributor-skills/*/SKILL.md` and `skills/*/SKILL.md` on `main` already parse cleanly — `review-pr` was the only offender.

> After merge, the OCI-builder cron republishes the `nemo-rl-skills` Plugin and the snapshot becomes usable again.
