### PR TITLE
fix(skills): make review-pr frontmatter Open-Plugin-valid (string fields)

### DIFF
--- a/.agents/contributor-skills/review-pr/SKILL.md
+++ b/.agents/contributor-skills/review-pr/SKILL.md
@@ -2,8 +2,8 @@
 name: review-pr
 description: Interactive code review for NVIDIA-NeMo/RL pull requests. Checks out PR locally, reads existing comments, applies coding guidelines from skills, previews findings, and posts review comments. Also supports reviewing the current branch locally.
 when_to_use: Reviewing a PR; '/review-pr <number>'; 'review this PR', 'check PR', 'code review for PR'.
-argument-hint: [<pr-number>] [update] [--deep]
-allowed-tools: [AskUserQuestion, Bash, Read, Glob, Grep, Agent, mcp__github__pull_request_read, mcp__github__pull_request_review_write, mcp__github__add_comment_to_pending_review, mcp__github__add_reply_to_pull_request_comment, mcp__github__add_issue_comment]
+argument-hint: "[<pr-number>] [update] [--deep]"
+allowed-tools: AskUserQuestion Bash Read Glob Grep Agent mcp__github__pull_request_read mcp__github__pull_request_review_write mcp__github__add_comment_to_pending_review mcp__github__add_reply_to_pull_request_comment mcp__github__add_issue_comment
 ---
 
 # Interactive PR Review — NVIDIA-NeMo/RL


### PR DESCRIPTION
## What

Make the `review-pr` skill's frontmatter valid for the **Regent Open Plugin** packaging. Two fields were YAML **flow-lists**; regent parses every packaged `SKILL.md` frontmatter at snapshot time, and either one fails the whole plugin:

```diff
- argument-hint: [<pr-number>] [update] [--deep]
+ argument-hint: "[<pr-number>] [update] [--deep]"
- allowed-tools: [AskUserQuestion, Bash, Read, …, mcp__github__…]
+ allowed-tools: AskUserQuestion Bash Read … mcp__github__…
```

- `argument-hint: [a] [b] [c]` is three flow sequences on one line → invalid YAML (`yaml.v3: "did not find expected key"`).
- `allowed-tools` as a list → Open Plugin requires it to be a **string** (`"allowed-tools must be a string"`).

## Why

This skill is packaged into the **`nemo-rl-skills`** Open Plugin consumed by the NeMo-CI `implement-issue` agents. The invalid frontmatter poisoned the whole plugin, so **every** AgentRun on it failed with `PluginSnapshotInvalid` — wedging live debug sessions.

Both fields now parse as strings (`yaml.safe_load` → `argument-hint` str, `allowed-tools` str). No behavior change to the skill; only the frontmatter encoding. The values are identical.

The CI plugin builder was also hardened to coerce either shape defensively (NeMo-CI-TF-States #353 for `argument-hint`, #355 for `allowed-tools`); this is the source-side fix so the skill is correct regardless of the builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
