### PR TITLE
fix: fix single controller grad_norm

### DIFF
--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -1277,6 +1277,10 @@ class MegatronPolicyWorkerImpl(
             self.model.start_grad_sync()
         self.model.finish_grad_sync()
 
+        # Wait for the comm-stream reduce dispatched above before opt.step
+        # reads main_grad. Without this, grad_norm collapses to ~1/2.
+        torch.cuda.synchronize()
+
         # opt.step clips internally (clip_grad config); operates on the
         # already-rescaled grad. Returns (success, grad_norm, num_zeros).
         update_successful, grad_norm, num_zeros_in_grad = self.optimizer.step()


### PR DESCRIPTION
## Bug

SC (Single Controller) split-API path had `grad_norm` at ~1/2 of the sync path from step 2 onward on the Megatron backend; reward regressed correspondingly.

## Fix

Add `torch.cuda.synchronize()` between `finish_grad_sync()` and `optimizer.step()` in `_finish_train_step_body`, so the DP reduce dispatched on the comm stream completes before `optimizer.step` reads `main_grad`.

## Test Results
- baseline (old code path)
    - yellow: didn't enable validate and checkpointing to keep the same test settings.
    - purple: with `val_period=10`, **which will reset vLLM's prefix cache every 10 steps**.
- blue: before this PR, `grad_norm` is ~1/2x smaller and reward is a bit lower.
- red: after this PR.

**Note**: Only the purple one will reset vLLM's prefix cache every 10 steps, other runs didn't reset for the whole run.

<img width="2728" height="594" alt="image" src="https://github.com/user-attachments/assets/c7283531-deb1-4a71-a065-65a15e527e36" />
<img width="1822" height="618" alt="image" src="https://github.com/user-attachments/assets/f9c6f1b9-0e12-40ad-940c-331767c38289" />