### PR TITLE
fix: add missing closing brace and default value for extra_head in conf.py (closes #2816)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,7 +99,7 @@ html_theme_options = {
         "json_url": "../versions1.json",
         "version_match": release,
     },
-    "extra_head": {
+    "extra_head": "",": {
         """
     <script src="https://assets.adobedtm.com/5d4962a43b79/c1061d2c5e7b/launch-191c2462b890.min.js" ></script>
     """


### PR DESCRIPTION
## What
The `html_theme_options` dictionary in `docs/conf.py` had a truncated key `"extra_head` without a closing quote, colon, or value. This caused a syntax error when Sphinx attempted to load the configuration, breaking release documentation builds.

## Fix
Added the missing closing quote, colon, and an empty string default value: `"extra_head": ""`.

Closes #2816