### PR TITLE
fix(vlm): clear CI env var for vLLM workers in qwen3-omni audiomcq recipe

### DIFF
--- a/examples/configs/recipes/vlm/vlm_grpo-qwen2.5-omni-7b-audiomcq-1n8g-megatron.v1.yaml
+++ b/examples/configs/recipes/vlm/vlm_grpo-qwen2.5-omni-7b-audiomcq-1n8g-megatron.v1.yaml
@@ -23,8 +23,6 @@ policy:
       skip_tokenizer_init: false
       tensor_parallel_size: 2
       gpu_memory_utilization: 0.55
-      env_vars:
-        CI: ""
     vllm_kwargs:
       mm_processor_cache_gb: 0
       limit_mm_per_prompt:

--- a/examples/configs/recipes/vlm/vlm_grpo-qwen2.5-omni-7b-audiomcq-1n8g-megatron.v1.yaml
+++ b/examples/configs/recipes/vlm/vlm_grpo-qwen2.5-omni-7b-audiomcq-1n8g-megatron.v1.yaml
@@ -23,6 +23,8 @@ policy:
       skip_tokenizer_init: false
       tensor_parallel_size: 2
       gpu_memory_utilization: 0.55
+      env_vars:
+        CI: ""
     vllm_kwargs:
       mm_processor_cache_gb: 0
       limit_mm_per_prompt:

--- a/examples/configs/recipes/vlm/vlm_grpo-qwen3-omni-30ba3b-audiomcq-4n8g-megatron.v1.yaml
+++ b/examples/configs/recipes/vlm/vlm_grpo-qwen3-omni-30ba3b-audiomcq-4n8g-megatron.v1.yaml
@@ -27,6 +27,8 @@ policy:
       tensor_parallel_size: 4
       expert_parallel_size: 8
       gpu_memory_utilization: 0.55
+      env_vars:
+        CI: ""
     vllm_kwargs:
       mm_processor_cache_gb: 0
       limit_mm_per_prompt:


### PR DESCRIPTION
## Summary

- PyTorch sets \`error_on_custom_op_aliasing=True\` when \`CI=true\` (via \`bool(os.getenv('CI'))\`), causing \`vllm::sequence_parallel_chunk_impl\` to raise \`RuntimeError\` on aliasing
- vLLM workers inherit \`CI\` from the Ray daemon (started by sbatch), so \`unset CI\` in the test script is insufficient — workers are spawned by the daemon before the test script runs
- Set \`vllm_cfg.env_vars: {CI: ""}\` in the qwen3-omni-30ba3b audiomcq recipe; \`vllm_generation.py\` already supports reading this and injecting it into Ray's \`runtime_env\` for vLLM workers only, scoped so it does not affect other test cases

## Test plan

- [x] nemo-ci pipeline  passes for \`vlm_vlm_grpo_qwen3_omni_30ba3b_audiomcq_4n8g_megatron_v1\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)