### PR TITLE
fix: unset CI in ray.sub and virtual_cluster to prevent vLLM aliasing errors

### DIFF
--- a/nemo_rl/distributed/virtual_cluster.py
+++ b/nemo_rl/distributed/virtual_cluster.py
@@ -245,6 +245,22 @@ def init_ray(log_dir: Optional[str] = None) -> None:
     # Set up runtime environment
     env_vars = dict(os.environ)
     env_vars.pop("RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES", None)
+    # CI=true causes PyTorch to set error_on_custom_op_aliasing=True (see
+    # torch/_functorch/config.py), which raises RuntimeError in vLLM custom ops
+    # such as sequence_parallel_chunk_impl. Strip it from the worker runtime_env
+    # so Ray actors see the same environment as a local non-CI run. ray.sub also
+    # unsets CI before starting the Ray daemons for the same reason.
+    if env_vars.pop("CI", None):
+        import warnings
+
+        warnings.warn(
+            "CI environment variable was detected and has been cleared for Ray workers. "
+            "PyTorch enables strict custom-op aliasing checks (error_on_custom_op_aliasing) "
+            "when CI=true, which can cause RuntimeError in some vLLM custom ops. "
+            "To suppress this warning, unset CI before launching (ray.sub already does this).",
+            UserWarning,
+            stacklevel=2,
+        )
     runtime_env = {
         "env_vars": env_vars,  # Pass thru all user environment variables
     }

--- a/ray.sub
+++ b/ray.sub
@@ -561,6 +561,11 @@ if [[ "\${RAY_SUB_DEBUG_ENV:-0}" == "1" ]]; then
   env | grep -viE '(WANDB_API_KEY|HF_TOKEN|API_KEY|TOKEN|SECRET|PASSWORD)=' || true
 fi
 
+# CI=true causes PyTorch to enable strict custom-op aliasing checks
+# (error_on_custom_op_aliasing), which raises RuntimeError in some vLLM custom ops.
+# Unset it so the Ray daemon and all workers it spawns behave like a local non-CI run.
+unset CI
+
 # Turn on pipefail here; it does not carry into this 'bash -c' subshell from the
 # submit host. Without it, 'ray status | grep worker_units | awk ...' exits 0 even
 # when grep matches nothing (awk's status wins), so the '|| echo 0' fallback never
@@ -781,6 +786,12 @@ worker_cmd=$(cat <<EOF
 if [[ "\${RAY_SUB_DEBUG_ENV:-0}" == "1" ]]; then
   env | grep -viE '(WANDB_API_KEY|HF_TOKEN|API_KEY|TOKEN|SECRET|PASSWORD)=' || true
 fi
+
+# CI=true causes PyTorch to enable strict custom-op aliasing checks
+# (error_on_custom_op_aliasing), which raises RuntimeError in some vLLM custom ops.
+# Unset it so the Ray daemon and all workers it spawns behave like a local non-CI run.
+unset CI
+
 echo "[INFO] Worker \$SLURM_PROCID on node \$SLURMD_NODENAME"
 
 # Fail fast if LOG_DIR is not actually shared with the submit host -- the worker


### PR DESCRIPTION
## Summary

- PyTorch sets \`error_on_custom_op_aliasing=True\` when \`CI=true\` (via \`bool(os.getenv("CI"))\` in \`torch/_functorch/config.py\`), causing \`RuntimeError\` in vLLM custom ops such as \`sequence_parallel_chunk_impl\`
- \`CI\` propagates to Ray workers via the Ray daemon environment (started by sbatch before any test script runs), so per-recipe \`vllm_cfg.env_vars\` or \`unset CI\` in test scripts alone are insufficient
- Fix at two levels so all launchers are covered:
  - **\`ray.sub\`**: \`unset CI\` in both \`head_cmd\` and \`worker_cmd\` before \`ray start\`, ensuring Ray daemons and all workers they spawn never see \`CI=true\`
  - **\`virtual_cluster.py\`**: strip \`CI\` from the \`runtime_env\` env_vars passed to \`ray.init\` and emit \`UserWarning\` so non-ray.sub launchers (e.g. k8s, local) also get the fix with visibility

## Test plan

- [ ] Nightly audiomcq tests pass without per-recipe \`vllm_cfg.env_vars: {CI: ""}\` workaround
- [ ] \`UserWarning\` appears in logs when \`CI\` is set at launch time

🤖 Generated with [Claude Code](https://claude.com/claude-code)