### PR TITLE
fix(vllm): record logprob for the sampled token

### DIFF
--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -814,12 +814,15 @@ class VllmGenerationWorkerImpl(BaseVllmGenerationWorker):
             full_logprobs = torch.zeros(total_length, dtype=torch.float32)
             if hasattr(generation, "logprobs") and generation.logprobs:
                 try:
-                    for idx, logprob_dict in enumerate(generation.logprobs):
+                    for idx, (token_id, logprob_dict) in enumerate(
+                        zip(generated_tokens, generation.logprobs)
+                    ):
                         if logprob_dict:
-                            position = sequence_length + idx
-                            full_logprobs[position] = next(iter(logprob_dict.items()))[
-                                1
-                            ].logprob
+                            sampled_logprob = logprob_dict.get(token_id)
+                            if sampled_logprob is not None:
+                                full_logprobs[sequence_length + idx] = (
+                                    sampled_logprob.logprob
+                                )
                 except Exception:
                     import traceback
 

--- a/tests/unit/models/generation/test_vllm_logprobs_mode.py
+++ b/tests/unit/models/generation/test_vllm_logprobs_mode.py
@@ -12,10 +12,80 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test vLLM logprobs_mode functionality to verify processed_logprobs matches expectations."""
+"""Tests for vLLM generation log probabilities."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 import torch
+
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+
+
+@pytest.mark.vllm
+def test_worker_generate_records_sampled_token_logprob(monkeypatch):
+    from nemo_rl.models.generation.vllm import vllm_worker
+
+    sampled_token_id = 880
+    generation = SimpleNamespace(
+        token_ids=[sampled_token_id],
+        logprobs=[
+            {
+                512: SimpleNamespace(logprob=-0.10, rank=1),
+                sampled_token_id: SimpleNamespace(logprob=-2.30, rank=2),
+            }
+        ],
+        finish_reason="stop",
+    )
+    raw_output = SimpleNamespace(outputs=[generation])
+
+    worker = vllm_worker.VllmGenerationWorkerImpl.__new__(
+        vllm_worker.VllmGenerationWorkerImpl
+    )
+    worker.cfg = {
+        "_pad_token_id": 0,
+        "vllm_cfg": {"use_tqdm": False},
+        "vllm_kwargs": {},
+    }
+    worker.routed_experts_dtype = torch.int32
+    worker.llm = SimpleNamespace(
+        generate=MagicMock(return_value=[raw_output]),
+        llm_engine=SimpleNamespace(
+            model_config=SimpleNamespace(max_model_len=16, model="test-model")
+        ),
+    )
+    worker._merge_stop_strings = lambda _stop_strings: []
+    worker._build_sampling_params = lambda **_kwargs: object()
+
+    monkeypatch.setattr(
+        vllm_worker, "verify_right_padding", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        vllm_worker,
+        "format_prompt_for_vllm_generation",
+        lambda _data: ["prompt"],
+    )
+    monkeypatch.setattr(
+        vllm_worker,
+        "pad_and_align_routed_expert_indices",
+        lambda *_args, **_kwargs: (
+            None,
+            {"missing_routes": 0, "expected_routes": 0, "actual_routes": 0},
+        ),
+    )
+
+    result = worker.generate(
+        BatchedDataDict(
+            {
+                "input_ids": torch.tensor([[101, 102, 0]]),
+                "input_lengths": torch.tensor([2]),
+            }
+        )
+    )
+
+    assert result["output_ids"][0].tolist() == [101, 102, sampled_token_id, 0]
+    assert result["logprobs"][0].tolist() == pytest.approx([0.0, 0.0, -2.30, 0.0])
 
 
 @pytest.mark.vllm


### PR DESCRIPTION
# What does this PR do ?

Record logprob for the sampled token

# Issues

https://github.com/NVIDIA-NeMo/RL/pull/2608#discussion_r3612313374

Fix vLLM generation output processing to record the log probability of the token actually sampled, rather than relying on the first entry in the per-position logprob dictionary.

vLLM returns each generated position as a mapping from token ID to logprob metadata. When that mapping contains multiple tokens, the first entry is not guaranteed to be the sampled token.

For example, if token 880 was sampled:

```bash
{
    512: Logprob(logprob=-0.10, rank=1),
    880: Logprob(logprob=-2.30, rank=2),
}
```

The previous implementation recorded -0.10 by taking the first dictionary entry. The correct value for the generated token is -2.30.

So Pair each generated token ID with its corresponding logprob dictionary and look up the logprob by that token ID.

The behavior is unchanged when vLLM returns only the sampled token.

# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [X] Did you write any new necessary tests?
- [X] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
