### PR TITLE
feat(flops): add NemotronH MoE-aware FLOPs tracking for MFU

### DIFF
--- a/nemo_rl/models/megatron/common.py
+++ b/nemo_rl/models/megatron/common.py
@@ -125,6 +125,9 @@ def get_moe_metrics(
     loss_scale: float,
     total_loss_dict: Optional[dict] = None,
     per_layer_logging: bool = False,
+    num_layers: Optional[int] = None,
+    mtp_num_layers: Optional[int] = None,
+    track_names: Optional[list[str]] = None,
 ) -> dict[str, Any]:
     """Returns Mixture of Experts (MoE) auxiliary-loss metrics.
 
@@ -141,7 +144,40 @@ def get_moe_metrics(
         the mean value is returned under the same key (e.g., "load_balancing_loss").
         If per_layer_logging is True, per-layer values are returned under keys of the
         form "moe/{name}_layer_{i}".
+
+    Note:
+        num_layers/mtp_num_layers pre-initialize the aux-loss tracker so every
+        pipeline-parallel rank participates in the collective all_reduce below with
+        an equally-sized tensor, preventing a hang when some PP rank did not save an
+        aux loss this step (e.g. an MTP MoE layer that lives only on the last stage).
     """
+    # Pre-initialize the aux-loss tracker so every PP rank has the same set of
+    # named, equally-sized tensors BEFORE the collective all_reduce below.
+    #
+    # reduce_aux_losses_tracker_across_ranks() runs torch.distributed.all_reduce over
+    # the pipeline-parallel group for each name present in the *local* tracker. The
+    # tracker entry is created lazily (Megatron save_to_aux_losses_tracker only
+    # allocates torch.zeros(num_layers) the first time a rank saves a loss). If any PP
+    # rank did not save an aux loss this step, it skips the all_reduce for that name
+    # while other PP ranks perform it -> the collective mismatches participants and hangs.
+    #
+    # Mirror Megatron's own track_moe_metrics(force_initialize=True) guard: allocate a
+    # zero tensor of size (num_layers + mtp_num_layers) for each tracked name on every
+    # rank, matching the size the router uses in save_to_aux_losses_tracker.
+    if num_layers is not None:
+        if track_names is None:
+            track_names = ["load_balancing_loss"]
+        tracker_num_layers = num_layers + (mtp_num_layers or 0)
+        tracker = get_moe_layer_wise_logging_tracker()
+        for name in track_names:
+            if name not in tracker:
+                tracker[name] = {
+                    "values": torch.zeros(tracker_num_layers, device="cuda"),
+                    "reduce_group": None,
+                    "avg_group": None,
+                    "reduce_group_has_dp": False,
+                }
+
     reduce_aux_losses_tracker_across_ranks()
     tracker = get_moe_layer_wise_logging_tracker()
 

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -832,6 +832,11 @@ class MegatronPolicyWorkerImpl(
             moe_metrics = get_moe_metrics(
                 loss_scale=moe_loss_scale,
                 per_layer_logging=self.cfg["megatron_cfg"]["moe_per_layer_logging"],
+                # Pre-initialize the aux-loss tracker on every PP rank so the
+                # cross-PP all_reduce inside get_moe_metrics does not hang when a
+                # rank saved no aux loss this step (e.g. MTP MoE on the last stage).
+                num_layers=getattr(model_config, "num_layers", None),
+                mtp_num_layers=getattr(model_config, "mtp_num_layers", None),
             )
             if moe_metrics:
                 metrics["moe_metrics"] = moe_metrics

--- a/nemo_rl/models/value/workers/megatron_value_worker.py
+++ b/nemo_rl/models/value/workers/megatron_value_worker.py
@@ -629,6 +629,11 @@ class MegatronValueWorkerImpl(AbstractPolicyWorker):
                 per_layer_logging=self.cfg["megatron_cfg"].get(
                     "moe_per_layer_logging", False
                 ),
+                # Pre-initialize the aux-loss tracker on every PP rank so the
+                # cross-PP all_reduce inside get_moe_metrics does not hang when a
+                # rank saved no aux loss this step (e.g. MTP MoE on the last stage).
+                num_layers=getattr(model_config, "num_layers", None),
+                mtp_num_layers=getattr(model_config, "mtp_num_layers", None),
             )
             if moe_metrics:
                 metrics["moe_metrics"] = moe_metrics

--- a/nemo_rl/utils/flops_formulas.py
+++ b/nemo_rl/utils/flops_formulas.py
@@ -58,6 +58,8 @@ class FLOPSConfig:
     mamba_head_dim: Optional[int] = None
     mamba_num_groups: Optional[int] = None
     mamba_num_heads: Optional[int] = None
+    gated_linear_unit: Optional[bool] = None
+    moe_shared_expert_num: Optional[int] = None
 
 
 def gpt3(config: FLOPSConfig):
@@ -492,6 +494,30 @@ def _mlp_layer_flops(config: FLOPSConfig):
     )
 
 
+def _moe_layer_flops(config: FLOPSConfig):
+    """Model FLOPs for an MoE FFN layer (routed + shared experts).
+
+    Each token is routed to ``moe_router_topk`` experts (plus any always-on
+    shared experts), so the effective FFN width is
+    ``moe_ffn_hidden_size * (moe_router_topk + moe_shared_expert_num)``.
+    ``gated_linear_unit`` doubles the up-projection GEMM (SwiGLU-style); a
+    non-gated activation (e.g. ReLU^2 in NemotronH) keeps the factor at 1.
+    """
+    gated_multiplier = 2 if config.gated_linear_unit else 1
+    shared_expert_num = config.moe_shared_expert_num or 0
+    effective_ffn_hidden_size = config.moe_ffn_hidden_size * (
+        config.moe_router_topk + shared_expert_num
+    )
+    return (
+        6
+        * config.gbs
+        * config.enc_seq_len
+        * config.hs
+        * effective_ffn_hidden_size
+        * gated_multiplier
+    )
+
+
 def _non_mla_attn_layer_flops(config: FLOPSConfig):
     """Model FLOPs for attention layer."""
     return (
@@ -536,7 +562,10 @@ def _hybrid_model_flops(config: FLOPSConfig):
     assert config.is_hybrid_model == True
     assert config.hybrid_override_pattern is not None
 
-    num_attn_layers, num_mamba_layers, num_mlp_layers = 0, 0, 0
+    # NemotronH hybrid pattern legend:
+    #   "M" -> Mamba layer, "*" -> attention layer, "-" -> dense MLP layer,
+    #   "E" -> MoE FFN layer (routed + shared experts).
+    num_attn_layers, num_mamba_layers, num_mlp_layers, num_moe_layers = 0, 0, 0, 0
     for c in config.hybrid_override_pattern:
         if c == "M":
             num_mamba_layers += 1
@@ -544,10 +573,13 @@ def _hybrid_model_flops(config: FLOPSConfig):
             num_mlp_layers += 1
         elif c == "*":
             num_attn_layers += 1
+        elif c == "E":
+            num_moe_layers += 1
     return (
         num_attn_layers * _non_mla_attn_layer_flops(config)
         + num_mamba_layers * _mamba_layer_flops(config)
         + num_mlp_layers * _mlp_layer_flops(config)
+        + num_moe_layers * _moe_layer_flops(config)
         + 6 * config.gbs * config.enc_seq_len * config.hs * config.vocab_size
     )
 

--- a/nemo_rl/utils/flops_tracker.py
+++ b/nemo_rl/utils/flops_tracker.py
@@ -24,7 +24,14 @@ from transformers.models.qwen2.configuration_qwen2 import Qwen2Config
 from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
 from transformers.models.qwen3_moe.configuration_qwen3_moe import Qwen3MoeConfig
 
-from nemo_rl.utils.flops_formulas import FLOPSConfig, deepseekv3, llama, qwen2, qwen3
+from nemo_rl.utils.flops_formulas import (
+    FLOPSConfig,
+    deepseekv3,
+    llama,
+    nemotronh,
+    qwen2,
+    qwen3,
+)
 
 
 def get_default_hf_config(model_name: str) -> PretrainedConfig:
@@ -99,6 +106,36 @@ def convert_config_to_flops_config(
             mtp_num_layers=0,
             causal_self_attn=True,
         ), deepseekv3
+    elif config.__class__.model_type == "nemotron_h":
+        # NemotronH is a hybrid Mamba/attention/MLP(-or-MoE) model. The layer
+        # composition is described by ``hybrid_override_pattern`` (e.g.
+        # "M" = Mamba, "*" = attention, "-" = dense MLP, "E" = MoE FFN).
+        # ``mamba_num_heads`` and ``n_groups`` are optional in some configs.
+        return FLOPSConfig(
+            gbs=0,
+            hs=config.hidden_size,
+            layers=config.num_hidden_layers,
+            ffn_hs=config.intermediate_size,
+            attention_heads=config.num_attention_heads,
+            query_groups=getattr(
+                config, "num_key_value_heads", config.num_attention_heads
+            ),
+            vocab_size=config.vocab_size,
+            is_hybrid_model=True,
+            hybrid_override_pattern=config.hybrid_override_pattern,
+            mamba_state_dim=config.ssm_state_size,
+            mamba_head_dim=config.mamba_head_dim,
+            mamba_num_groups=config.n_groups,
+            mamba_num_heads=getattr(config, "mamba_num_heads", None),
+            # MoE ("E") layers: each token uses ``num_experts_per_tok`` routed
+            # experts plus ``n_shared_experts`` always-on shared experts, each of
+            # width ``moe_intermediate_size``. NemotronH uses a non-gated ReLU^2
+            # activation, so gated_linear_unit is False.
+            moe_router_topk=config.num_experts_per_tok,
+            moe_ffn_hidden_size=config.moe_intermediate_size,
+            moe_shared_expert_num=getattr(config, "n_shared_experts", 0),
+            gated_linear_unit=False,
+        ), nemotronh
     else:
         raise ValueError(f"Unsupported config type: {type(config)}")
 

--- a/tests/unit/utils/test_flops_tracker.py
+++ b/tests/unit/utils/test_flops_tracker.py
@@ -15,7 +15,12 @@
 import pytest
 import torch
 
-from nemo_rl.utils.flops_formulas import FLOPSConfig, qwen3
+from nemo_rl.utils.flops_formulas import (
+    FLOPSConfig,
+    _moe_layer_flops,
+    nemotronh,
+    qwen3,
+)
 from nemo_rl.utils.flops_tracker import get_theoretical_tflops, is_using_tf32
 
 
@@ -50,6 +55,59 @@ def test_qwen3_flops_wide_attention():
     standard = qwen3(_qwen3_flops_config(4096 // 64))  # head_dim=64 == hidden/num_heads
     wide = qwen3(_qwen3_flops_config(128))  # head_dim=128 (Qwen3-235B)
     assert wide > standard
+
+
+def _nemotronh_flops_config(pattern):
+    # Nemotron-3 Nano 30B-A3B-like shape (real hyperparameters, short pattern).
+    return FLOPSConfig(
+        gbs=1,
+        enc_seq_len=4096,
+        hs=2688,
+        ffn_hs=1856,
+        attention_heads=32,
+        query_groups=2,
+        vocab_size=131072,
+        is_hybrid_model=True,
+        hybrid_override_pattern=pattern,
+        mamba_state_dim=128,
+        mamba_head_dim=64,
+        mamba_num_groups=8,
+        mamba_num_heads=64,
+        moe_router_topk=6,
+        moe_ffn_hidden_size=1856,
+        moe_shared_expert_num=1,
+        gated_linear_unit=False,
+    )
+
+
+def test_nemotronh_counts_moe_layers():
+    """Each MoE ("E") layer must contribute FLOPs.
+
+    Nemotron-3 Nano V3's hybrid_override_pattern is dominated by "E" layers, so
+    a formula that ignores "E" (counting only M/*/-) would under-report the
+    dominant FFN cost. Adding one "E" layer must increase total FLOPs by exactly
+    one MoE layer's worth.
+    """
+    base = _nemotronh_flops_config("M*")
+    with_moe = _nemotronh_flops_config("M*E")
+    expected_delta = _moe_layer_flops(with_moe)
+    assert expected_delta > 0
+    assert nemotronh(with_moe) - nemotronh(base) == pytest.approx(expected_delta)
+
+
+def test_nemotronh_moe_accounts_for_shared_experts_and_topk():
+    """MoE FLOPs scale with (routed topk + shared experts) and are non-gated for ReLU^2."""
+    cfg = _nemotronh_flops_config("E")
+    # routed topk=6 plus 1 shared expert, non-gated (factor 1)
+    expected = (
+        6
+        * cfg.gbs
+        * cfg.enc_seq_len
+        * cfg.hs
+        * cfg.moe_ffn_hidden_size
+        * (cfg.moe_router_topk + cfg.moe_shared_expert_num)
+    )
+    assert _moe_layer_flops(cfg) == pytest.approx(expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this PR do ?

Add MoE-aware FLOPs tracking for **NemotronH** models (e.g. Nemotron-3 Nano V3) so that training runs report Training FLOPS and Model Floating Point Utilization (MFU).

NemotronH is a hybrid Mamba/attention/MLP model whose layer layout is given by `hybrid_override_pattern`, which for the MoE variants is dominated by `E` (MoE FFN) layers. The FLOPs tracker previously raised `ValueError` for `NemotronHConfig`, so `total_flops`/`theoretical_tflops` were never populated and no FLOPS/MFU line was logged.

This wires up a `nemotron_h` branch in `convert_config_to_flops_config` and extends `_hybrid_model_flops` to account for `E` layers via a new `_moe_layer_flops` helper (routed `topk` + shared experts, non-gated ReLU^2). Without the `E` handling the dominant FFN cost would be omitted and MFU would be severely under-reported.

Builds on #1971 (which only added the wiring, not MoE-layer FLOPs).

- `flops_formulas`: add `gated_linear_unit`/`moe_shared_expert_num` fields, `_moe_layer_flops`, and `E` handling in `_hybrid_model_flops`
- `flops_tracker`: import `nemotronh` and add `nemotron_h` config branch
- `tests`: cover MoE-layer counting and shared-expert/topk scaling

# Issues

n/a

# Usage

```python
from nemo_rl.utils.flops_tracker import FLOPTracker, get_default_hf_config

# Nemotron-3 Nano V3 (MoE hybrid) now returns a valid tracker instead of raising.
tracker = FLOPTracker.from_config(model_name, get_default_hf_config(model_name))
tracker.track_batch(input_lengths)          # per-sequence packed tokens
print(tracker.total_flops)                   # > 0, MoE 'E' layers included
```

With this, an SFT/GRPO run on a NemotronH model prints:

```
  • Training FLOPS: <x> TFLOPS (<x/ranks> per rank)
  • Training Model Floating Point Utilization: <MFU>%
```

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

* MoE FLOPs use `moe_ffn_hidden_size * (moe_router_topk + moe_shared_expert_num)` as the effective FFN width. NemotronH uses a non-gated ReLU^2 activation, so `gated_linear_unit=False` (factor 1); gated (SwiGLU-style) models would use factor 2.
* Validated against a first-principles `6 * N_active * tokens` estimate (formula/rule-of-thumb ratio ≈ 0.76, expected since the rule-of-thumb ignores attention/mamba sublinear terms) and confirmed each `E` in the pattern increases total FLOPs by exactly one `_moe_layer_flops`.
