### PR TITLE
fix: harden multimodal Gym training lifecycle

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -295,7 +295,7 @@ if [[ -n "${NEMO_GYM_PREFETCH_CONFIGS:-}" ]]; then
         "${NEMO_GYM_VLLM_VERSION}" "${NEMO_GYM_VLLM_VERSION}" "${WHEEL_ARCH}" > "${GYM_VLLM_OVERRIDE}"
     UV_TORCH_BACKEND="${NEMO_GYM_CUDA}" \
     UV_OVERRIDE="${GYM_VLLM_OVERRIDE}" \
-    UV_LINK_MODE=symlink uv run python examples/nemo_gym/prefetch_venvs.py $NEMO_GYM_PREFETCH_CONFIGS
+    UV_LINK_MODE=copy uv run python examples/nemo_gym/prefetch_venvs.py $NEMO_GYM_PREFETCH_CONFIGS
     rm -f "${GYM_VLLM_OVERRIDE}"
 fi
 EOF

--- a/nemo_rl/models/generation/vllm/utils.py
+++ b/nemo_rl/models/generation/vllm/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from collections import defaultdict
+import math
 from typing import Any, Optional
 
 import torch
@@ -272,6 +273,23 @@ def attach_routed_experts_to_chat_response_choices(
     return response
 
 
+def _find_non_finite_float_paths(value: Any, path: str = "$") -> list[str]:
+    """Return JSON-style paths for non-finite float values without mutating them."""
+    if isinstance(value, float):
+        return [] if math.isfinite(value) else [f"{path}={value!r}"]
+    if isinstance(value, dict):
+        paths = []
+        for key, item in value.items():
+            paths.extend(_find_non_finite_float_paths(item, f"{path}.{key}"))
+        return paths
+    if isinstance(value, (list, tuple)):
+        paths = []
+        for index, item in enumerate(value):
+            paths.extend(_find_non_finite_float_paths(item, f"{path}[{index}]"))
+        return paths
+    return []
+
+
 def model_dump_chat_response_with_routed_experts(response: Any) -> dict[str, Any]:
     """Dump a vLLM OpenAI chat response while preserving dynamic R3 fields."""
     response_dict = response.model_dump()
@@ -283,6 +301,15 @@ def model_dump_chat_response_with_routed_experts(response: Any) -> dict[str, Any
         )
         if routed_experts is not None:
             choice_dict.setdefault("message", {})["routed_experts"] = routed_experts
+
+    non_finite_paths = _find_non_finite_float_paths(response_dict)
+    if non_finite_paths:
+        preview = ", ".join(non_finite_paths[:16])
+        omitted = len(non_finite_paths) - 16
+        suffix = f", ... and {omitted} more" if omitted > 0 else ""
+        raise ValueError(
+            f"vLLM chat response contains non-finite float values at {preview}{suffix}"
+        )
     return response_dict
 
 

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -494,11 +494,6 @@ class BaseVllmGenerationWorker:
         )
 
         self._create_engine(llm_kwargs)
-        # Nemotron Omni checkpoints fold RADIO LayerScale into adjacent weights,
-        # while stock vLLM still allocates ls1/ls2 parameters. Initialize those
-        # parameters before colocated level-1 sleep releases their CUDA storage;
-        # mutating them later from prepare_refit_info corrupts sleep/wake state.
-        self.llm.collective_rpc("_initialize_nemotron_omni_radio_layerscale")
         log_gpu_memory_diagnostics(
             label="after_engine_create", worker_type="VllmGenerationWorker", device_id=0
         )
@@ -646,6 +641,13 @@ class VllmGenerationWorkerImpl(BaseVllmGenerationWorker):
 
     def post_init(self):
         if self.llm is not None:
+            # Nemotron Omni checkpoints fold RADIO LayerScale into adjacent
+            # weights, while stock vLLM still allocates ls1/ls2 parameters.
+            # Initialize them after engine creation but before any refit or
+            # colocated level-1 sleep releases their CUDA storage.
+            self.llm.collective_rpc(
+                "_initialize_nemotron_omni_radio_layerscale", args=tuple()
+            )
             self.llm.collective_rpc("bind_numa", args=tuple())
         self.vllm_device_ids = self.report_device_id()
         if self._mtp_load_from_disk:

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -423,6 +423,11 @@ class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
 
     async def post_init_async(self):
         if self.llm is not None:
+            # AsyncLLM.collective_rpc returns a coroutine. Keep this hook in
+            # post-init so it is explicitly awaited before refit or sleep.
+            await self.llm.collective_rpc(
+                "_initialize_nemotron_omni_radio_layerscale", args=tuple()
+            )
             await self.llm.collective_rpc("bind_numa", args=tuple())
         self.vllm_device_ids = await self.report_device_id_async()
         if self._mtp_load_from_disk:
@@ -448,6 +453,7 @@ class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
 
         from fastapi import Request
         from fastapi.responses import JSONResponse, StreamingResponse
+        from vllm.entrypoints.chat_utils import load_chat_template
         from vllm.entrypoints.openai.chat_completion.protocol import (
             ChatCompletionRequest,
             ChatCompletionResponse,
@@ -745,6 +751,14 @@ class VllmAsyncGenerationWorkerImpl(BaseVllmGenerationWorker):
         # instead of silently defaulting.
         default_chat_template_kwargs: dict[str, Any] = (
             serving_chat_kwargs.pop("chat_template_kwargs", None) or {}
+        )
+        # The stock vLLM API server resolves a configured template path before
+        # constructing OpenAIServingRender. NeMo-RL builds these serving
+        # objects directly, so it must perform the same step; otherwise
+        # Transformers treats the path itself as literal Jinja and the rendered
+        # prompt loses multimodal markers such as ``<image>``.
+        serving_chat_kwargs["chat_template"] = load_chat_template(
+            serving_chat_kwargs["chat_template"]
         )
         openai_serving_render = NeMoRLOpenAIServingRender(
             model_config=engine_client.model_config,

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -495,9 +495,22 @@ def validate_model_paths(config: PolicyConfig) -> tuple[str, str, bool]:
         overrides_hash = _get_hf_config_overrides_hash(hf_config_overrides)
         hf_model_subdir = f"{hf_model_subdir}__hfovr_{overrides_hash}"
     pretrained_path = os.path.join(get_megatron_checkpoint_dir(), hf_model_subdir)
-    pt_checkpoint_exists = os.path.exists(pretrained_path) and os.path.exists(
-        os.path.join(pretrained_path, "iter_0000000")
+    # A previous conversion can leave the iteration directory and large distcp
+    # shards behind before Bridge writes its completion metadata. Treating that
+    # directory alone as a cache hit makes every policy rank skip the HF import,
+    # only to fail later while loading run_config.yaml. A completed Bridge
+    # conversion has its config and train state plus metadata for either the
+    # MCore torch_dist or PyTorch DCP checkpoint format.
+    iter_path = os.path.join(pretrained_path, "iter_0000000")
+    bridge_files_exist = all(
+        os.path.isfile(os.path.join(iter_path, filename))
+        for filename in ("run_config.yaml", "train_state.pt")
     )
+    checkpoint_metadata_exists = any(
+        os.path.isfile(os.path.join(iter_path, filename))
+        for filename in ("metadata.json", ".metadata")
+    )
+    pt_checkpoint_exists = bridge_files_exist and checkpoint_metadata_exists
     return hf_model_name, pretrained_path, pt_checkpoint_exists
 
 

--- a/nemo_rl/utils/packed_tensor.py
+++ b/nemo_rl/utils/packed_tensor.py
@@ -20,14 +20,43 @@ from typing import Any, List, Tuple
 import torch
 
 
+_MAX_PACKED_TENSOR_SIZE_BYTES = 5 * 1024**3
+
+
 @lru_cache(maxsize=1)
-def get_target_packed_tensor_size():
+def get_target_packed_tensor_size() -> int:
+    """Return one packed-buffer size shared by every collective rank.
+
+    The ratio-based fallback is retained for homogeneous deployments.  A
+    heterogeneous collective must set ``NRL_REFIT_BUFFER_SIZE_BYTES`` because
+    deriving the size from each rank's local GPU memory can produce different
+    broadcast counts and tensor sizes (for example, B300 producers paired with
+    A100 consumers).
+    """
+    explicit_size = os.getenv("NRL_REFIT_BUFFER_SIZE_BYTES")
+    if explicit_size is not None:
+        try:
+            size_bytes = int(explicit_size)
+        except ValueError as exc:
+            raise ValueError(
+                f"NRL_REFIT_BUFFER_SIZE_BYTES must be an integer, got {explicit_size!r}"
+            ) from exc
+        if not 0 < size_bytes <= _MAX_PACKED_TENSOR_SIZE_BYTES:
+            raise ValueError(
+                "NRL_REFIT_BUFFER_SIZE_BYTES must be in the range "
+                f"[1, {_MAX_PACKED_TENSOR_SIZE_BYTES}], got {size_bytes}"
+            )
+        return size_bytes
+
     memory_ratio = os.getenv("NRL_REFIT_BUFFER_MEMORY_RATIO", "0.02")
     device = torch.device("cuda")
     props = torch.cuda.get_device_properties(device)
     total_memory_bytes = props.total_memory
     # max size is 5GB
-    target_size = min(int(total_memory_bytes * float(memory_ratio)), 5 * 1024**3)
+    target_size = min(
+        int(total_memory_bytes * float(memory_ratio)),
+        _MAX_PACKED_TENSOR_SIZE_BYTES,
+    )
     return target_size
 
 
@@ -102,6 +131,12 @@ def packed_broadcast_producer(iterator, group, src, post_iter_func):
                     )
                     group.broadcast(packed_tensors[buffer_idx], src=src)
                 break
+
+    # The broadcasts run on private streams.  Do not let the packed buffers go
+    # out of scope, or report the Ray method complete, until every collective
+    # has actually finished.
+    for stream in streams:
+        stream.synchronize()
 
 
 def packed_broadcast_consumer(iterator, group, src, post_unpack_func):
@@ -214,3 +249,8 @@ def packed_broadcast_consumer(iterator, group, src, post_unpack_func):
                         )
                     )
                 break
+
+    # Keep receive buffers alive through the final asynchronous collectives
+    # and finish weight loading before callers run allocator cleanup.
+    for stream in streams:
+        stream.synchronize()

--- a/tests/unit/environments/test_nemo_gym.py
+++ b/tests/unit/environments/test_nemo_gym.py
@@ -206,7 +206,7 @@ def test_nemo_gym_postprocess_uses_batch_decode():
 
     result = (
         NemoGym.__ray_metadata__.modified_class._postprocess_nemo_gym_to_nemo_rl_result(
-            _MockSelf(), nemo_gym_result, tokenizer
+            _MockSelf(), {}, nemo_gym_result, tokenizer
         )
     )
 

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -49,6 +49,54 @@ from nemo_rl.models.policy import LoRAConfig, PolicyConfig
 from nemo_rl.models.policy.lm_policy import Policy
 
 model_name = "Qwen/Qwen3-0.6B"
+
+
+def test_vllm_post_init_initializes_radio_layerscale_before_other_collectives():
+    calls = []
+
+    class FakeLLM:
+        def collective_rpc(self, method, args=tuple()):
+            calls.append((method, args))
+
+    worker = VllmGenerationWorkerImpl.__new__(VllmGenerationWorkerImpl)
+    worker.llm = FakeLLM()
+    worker._mtp_load_from_disk = False
+    worker.report_device_id = lambda: ["gpu-0"]
+
+    worker.post_init()
+
+    assert calls == [
+        ("_initialize_nemotron_omni_radio_layerscale", tuple()),
+        ("bind_numa", tuple()),
+    ]
+    assert worker.vllm_device_ids == ["gpu-0"]
+
+
+@pytest.mark.asyncio
+async def test_vllm_async_post_init_awaits_radio_layerscale_initialization():
+    calls = []
+
+    class FakeAsyncLLM:
+        async def collective_rpc(self, method, args=tuple()):
+            calls.append((method, args))
+
+    async def report_device_id_async():
+        return ["gpu-0"]
+
+    worker = VllmAsyncGenerationWorkerImpl.__new__(VllmAsyncGenerationWorkerImpl)
+    worker.llm = FakeAsyncLLM()
+    worker._mtp_load_from_disk = False
+    worker.report_device_id_async = report_device_id_async
+
+    await worker.post_init_async()
+
+    assert calls == [
+        ("_initialize_nemotron_omni_radio_layerscale", tuple()),
+        ("bind_numa", tuple()),
+    ]
+    assert worker.vllm_device_ids == ["gpu-0"]
+
+
 # Define basic vLLM test config
 basic_vllm_test_config: VllmConfig = {
     "backend": "vllm",
@@ -294,6 +342,15 @@ def _install_fake_vllm_openai_modules(monkeypatch):
     class ReasoningParserManager:
         import_reasoning_parser = MagicMock()
 
+    load_chat_template = MagicMock(
+        side_effect=lambda value: None if value is None else f"resolved:{value}"
+    )
+
+    make_module(
+        "vllm.entrypoints.chat_utils",
+        load_chat_template=load_chat_template,
+    )
+
     make_module(
         "vllm.entrypoints.openai.chat_completion.protocol",
         ChatCompletionRequest=type("ChatCompletionRequest", (), {}),
@@ -339,7 +396,12 @@ def _install_fake_vllm_openai_modules(monkeypatch):
         ToolParserManager=ToolParserManager,
     )
     make_module("vllm.v1.engine.async_llm", logger=MagicMock())
-    return ToolParserManager, ReasoningParserManager, OpenAIServingChat
+    return (
+        ToolParserManager,
+        ReasoningParserManager,
+        OpenAIServingChat,
+        load_chat_template,
+    )
 
 
 class _FakeFastAPIApp:
@@ -359,6 +421,7 @@ def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch):
         tool_parser_manager,
         reasoning_parser_manager,
         openai_serving_chat,
+        load_chat_template,
     ) = _install_fake_vllm_openai_modules(monkeypatch)
 
     worker = VllmAsyncGenerationWorkerImpl.__new__(VllmAsyncGenerationWorkerImpl)
@@ -370,6 +433,7 @@ def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch):
             "reasoning_parser_plugin": "/plugins/reasoning_parser.py",
             "http_server_serving_chat_kwargs": {
                 "reasoning_parser": "nano_v3",
+                "chat_template": "/templates/omni.jinja",
             },
         },
     }
@@ -387,7 +451,12 @@ def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch):
     reasoning_parser_manager.import_reasoning_parser.assert_called_once_with(
         "/plugins/reasoning_parser.py"
     )
+    load_chat_template.assert_called_once_with("/templates/omni.jinja")
     assert openai_serving_chat.instances[0].kwargs["reasoning_parser"] == "nano_v3"
+    assert (
+        openai_serving_chat.instances[0].kwargs["chat_template"]
+        == "resolved:/templates/omni.jinja"
+    )
     # make sure that the config attribute does not leak into `http_server_serving_chat_kwargs`
     assert "reasoning_parser_plugin" not in openai_serving_chat.instances[0].kwargs
 

--- a/tests/unit/models/generation/test_vllm_utils.py
+++ b/tests/unit/models/generation/test_vllm_utils.py
@@ -539,6 +539,24 @@ def test_model_dump_chat_response_with_routed_experts_preserves_dynamic_field():
     assert response_dict["choices"][0]["message"]["routed_experts"] == routed_experts
 
 
+def test_model_dump_chat_response_reports_non_finite_field_path():
+    class Response:
+        choices = [SimpleNamespace(message=SimpleNamespace(routed_experts=None))]
+
+        def model_dump(self):
+            return {
+                "choices": [
+                    {"logprobs": {"content": [{"token": "x", "logprob": float("nan")}]}}
+                ]
+            }
+
+    with pytest.raises(
+        ValueError,
+        match=r"\$\.choices\[0\]\.logprobs\.content\[0\]\.logprob=nan",
+    ):
+        model_dump_chat_response_with_routed_experts(Response())
+
+
 @pytest.mark.vllm
 def test_vllm_speculative_decoding_patch_removed():
     # The speculative decoding patch was fixed upstream in vLLM >= 0.14.0:

--- a/tests/unit/models/megatron/test_megatron_setup.py
+++ b/tests/unit/models/megatron/test_megatron_setup.py
@@ -134,7 +134,8 @@ class TestValidateModelPaths:
         assert "model_" in pretrained_path
         assert pt_checkpoint_exists is False
 
-    def test_checkpoint_exists(self, tmp_path):
+    @pytest.mark.parametrize("metadata_file", ["metadata.json", ".metadata"])
+    def test_checkpoint_exists(self, tmp_path, metadata_file):
         """Test when a Megatron checkpoint already exists."""
         from nemo_rl.models.megatron.setup import validate_model_paths
 
@@ -142,6 +143,8 @@ class TestValidateModelPaths:
         checkpoint_dir = tmp_path / "checkpoints" / "test-model"
         iter_dir = checkpoint_dir / "iter_0000000"
         iter_dir.mkdir(parents=True)
+        for required_file in ("run_config.yaml", "train_state.pt", metadata_file):
+            (iter_dir / required_file).touch()
 
         config = {"model_name": "test-model"}
 
@@ -155,6 +158,26 @@ class TestValidateModelPaths:
 
         assert hf_model_name == "test-model"
         assert pt_checkpoint_exists is True
+
+    def test_incomplete_automatic_hf_conversion_is_not_a_cache_hit(self, tmp_path):
+        """Partial distcp shards must not suppress a fresh HF conversion."""
+        from nemo_rl.models.megatron.setup import validate_model_paths
+
+        checkpoint_dir = tmp_path / "checkpoints" / "test-model"
+        iter_dir = checkpoint_dir / "iter_0000000"
+        iter_dir.mkdir(parents=True)
+        (iter_dir / "__0_0.distcp").touch()
+
+        with patch(
+            "nemo_rl.models.megatron.setup.get_megatron_checkpoint_dir",
+            return_value=str(tmp_path / "checkpoints"),
+        ):
+            _, pretrained_path, pt_checkpoint_exists = validate_model_paths(
+                {"model_name": "test-model"}
+            )
+
+        assert pretrained_path == str(checkpoint_dir)
+        assert pt_checkpoint_exists is False
 
     def test_hf_config_overrides_change_hashed_pretrained_path(self, tmp_path):
         """Test that different hf_config_overrides map to different hashed paths."""

--- a/tests/unit/utils/test_packed_tensor.py
+++ b/tests/unit/utils/test_packed_tensor.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from contextlib import nullcontext
 from unittest.mock import patch
 
 import pytest
 import torch
 
+import nemo_rl.utils.packed_tensor as packed_tensor
 from nemo_rl.utils.packed_tensor import (
+    get_target_packed_tensor_size,
     packed_broadcast_consumer,
     packed_broadcast_producer,
 )
@@ -66,6 +69,75 @@ def create_mock_model_params():
 def create_mock_state_dict_info(params):
     """Create state dict info (name -> (shape, dtype)) from params."""
     return {name: (tensor.shape, tensor.dtype) for name, tensor in params}
+
+
+def test_explicit_packed_tensor_size_does_not_depend_on_local_gpu(monkeypatch):
+    """A fixed size is safe for collectives spanning heterogeneous GPUs."""
+    get_target_packed_tensor_size.cache_clear()
+    monkeypatch.setenv("NRL_REFIT_BUFFER_SIZE_BYTES", "536870912")
+    try:
+        assert get_target_packed_tensor_size() == 512 * 1024**2
+    finally:
+        get_target_packed_tensor_size.cache_clear()
+
+
+@pytest.mark.parametrize("value", ["not-an-int", "0", "-1", str(5 * 1024**3 + 1)])
+def test_explicit_packed_tensor_size_rejects_invalid_values(monkeypatch, value):
+    get_target_packed_tensor_size.cache_clear()
+    monkeypatch.setenv("NRL_REFIT_BUFFER_SIZE_BYTES", value)
+    try:
+        with pytest.raises(ValueError, match="NRL_REFIT_BUFFER_SIZE_BYTES"):
+            get_target_packed_tensor_size()
+    finally:
+        get_target_packed_tensor_size.cache_clear()
+
+
+@pytest.mark.parametrize("role", ["producer", "consumer"])
+def test_packed_broadcast_synchronizes_every_stream_before_return(
+    monkeypatch: pytest.MonkeyPatch, role: str
+) -> None:
+    class FakeStream:
+        def __init__(self) -> None:
+            self.synchronize_calls = 0
+
+        def synchronize(self) -> None:
+            self.synchronize_calls += 1
+
+    streams: list[FakeStream] = []
+
+    def make_stream() -> FakeStream:
+        stream = FakeStream()
+        streams.append(stream)
+        return stream
+
+    monkeypatch.setattr(packed_tensor, "get_num_buffers", lambda: 2)
+    monkeypatch.setattr(packed_tensor, "get_target_packed_tensor_size", lambda: 1)
+    monkeypatch.setattr(packed_tensor.torch.cuda, "Stream", make_stream)
+    monkeypatch.setattr(
+        packed_tensor.torch.cuda, "stream", lambda _stream: nullcontext()
+    )
+    monkeypatch.setattr(
+        packed_tensor.torch, "empty", lambda *_args, **_kwargs: object()
+    )
+
+    if role == "producer":
+        packed_broadcast_producer(
+            iterator=iter(()),
+            group=object(),
+            src=0,
+            post_iter_func=lambda tensor: tensor,
+        )
+    else:
+        packed_broadcast_consumer(
+            iterator=iter(()),
+            group=object(),
+            src=0,
+            post_unpack_func=lambda tensors: tensors,
+        )
+
+    # The first loop iteration reuses stream 1, so it synchronizes once before
+    # work and once at shutdown. Stream 0 is reached only by the shutdown loop.
+    assert [stream.synchronize_calls for stream in streams] == [1, 2]
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")


### PR DESCRIPTION
# What does this PR do?

Hardens the multimodal NeMo Gym training path discovered while running the
`rohit/gymv-mm-integration` branch across separate generation and policy GPU
classes.

The changes:

- make Docker-prefetched Gym virtual environments self-contained instead of
  leaving links into uv's build cache;
- resolve a configured vLLM chat-template path before constructing the serving
  objects, matching the stock vLLM API server;
- initialize the existing Nemotron Omni RADIO LayerScale hook from the sync
  and async post-init paths, awaiting the async collective explicitly;
- fail loudly on non-finite vLLM response fields and report their exact JSON
  paths instead of silently changing logprob values;
- reject incomplete automatic HF-to-Megatron conversion directories as cache
  hits; and
- allow a common packed-refit buffer size across heterogeneous GPUs and wait
  for all private CUDA streams before returning.

Focused regression tests cover each behavior. The branch also updates one
integration-branch test call for the existing `nemo_gym_row` argument.

# Issues

No linked issue.

# Usage

For a refit collective whose ranks have different GPU memory capacities, set
the same explicit buffer size in every process:

```bash
export NRL_REFIT_BUFFER_SIZE_BYTES=536870912
```

Homogeneous deployments retain the existing
`NRL_REFIT_BUFFER_MEMORY_RATIO` fallback.

# Provenance and related work

This PR is based on
`rohit/gymv-mm-integration@71717873240c99fd1ede2db17480818205766848`.
The Gym/MM/Nemotron Omni implementation already present in that branch,
including the LayerScale hook introduced through #3290, is baseline work and
is not claimed here. This PR only changes when and how that existing hook is
invoked.

The following related changes are intentionally distinguished:

- #2918 already fixed empty-generation attribution on `main`; the duplicate
  local implementation was removed from this PR.
- #2962 proposes replacing non-finite values with `0.0`. This PR instead
  preserves response semantics by rejecting the response and identifying the
  exact offending fields.
- #2771 introduced Gym venv prefetching with symlink mode. This PR is a
  follow-up that makes the baked venv relocatable/self-contained.
- #2742 redesigns refit prefetching. This PR addresses correctness in the
  current packed-transfer implementation and does not include that redesign.

No OSWorld provider code, Gym submodule changes, experiment recipes, internal
registry references, host configuration, scheduler jobs, proxy configuration,
or deployment assets are included.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added focused regression tests.
- [x] Ran Ruff over all changed Python files.
- [x] Ran Python compilation and `git diff --check`.
- [x] Previously validated the candidate behaviors with focused tests in the
  project Linux container; GitHub CI is expected to run the submission branch.
- [x] No user-facing documentation change is required; the new environment
  variable is documented in code and in this PR.

# Additional Information

The commits are separated by concern and carry `Signed-off-by` trailers so the
follow-up work can be reviewed independently from the integration branch's
existing commits.
