### PR TITLE
perf: cherry-pick #3278 to r0.7.0 — increase Qwen3-235B async GPU memory util

### DIFF
--- a/examples/configs/recipes/llm/performance/grpo-qwen3-235b-32n8g-async-1off.yaml
+++ b/examples/configs/recipes/llm/performance/grpo-qwen3-235b-32n8g-async-1off.yaml
@@ -23,7 +23,7 @@ policy:
         gpus_per_node: 8
     vllm_cfg:
       tensor_parallel_size: 8
-      gpu_memory_utilization: 0.8
+      gpu_memory_utilization: 0.88
       async_engine: true
 logger:
   log_dir: logs/grpo-qwen3-235b-32n8g-16T16G-async-1off


### PR DESCRIPTION
## Summary

Cherry-pick of #3278 onto `r0.7.0`.

- Increases `policy.generation.vllm_cfg.gpu_memory_utilization` from `0.80` → `0.88` for the H100 `grpo-qwen3-235b-32n8g-async-1off` performance recipe
- Expands KV-cache capacity, reducing rollout buffer starvation (~11% E2E throughput improvement)
