### PR TITLE
fix(vllm): apply the TCPStore port offset on the branch vLLM actually takes

### DIFF
--- a/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-1n8g-megatron-fp8-rollouts.v3.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-1n8g-megatron-fp8-rollouts.v3.yaml
@@ -34,6 +34,15 @@ policy:
       precision: fp8
       max_model_len: 4096
       use_deep_gemm: true
+    vllm_kwargs:
+      # At the same gpu_memory_utilization, vLLM 0.25's profiling sizes the
+      # KV cache several GiB larger than 0.20 did, growing the CuMemAllocator
+      # sleep pool past what can be re-mapped at wake-up next to the
+      # colocated Megatron policy ("CUDA Error: out of memory at
+      # csrc/cumem_allocator.cpp"; lowering gpu_memory_utilization to 0.5
+      # still OOM'ed). Pin the KV cache to a 0.20-equivalent size instead
+      # (takes precedence over gpu_memory_utilization).
+      kv_cache_memory_bytes: 21474836480  # 20 GiB
 data:
   max_input_seq_length: 4096
 logger:

--- a/examples/configs/recipes/llm/grpo-moonlight-16ba3b-4n8g-megatron-fp8-e2e.yaml
+++ b/examples/configs/recipes/llm/grpo-moonlight-16ba3b-4n8g-megatron-fp8-e2e.yaml
@@ -43,6 +43,14 @@ policy:
       quantization_ignored_layer_kws:
       - a_proj
       - b_proj
+    vllm_kwargs:
+      # At the same gpu_memory_utilization, vLLM 0.25's profiling sizes the
+      # KV cache to ~34 GiB where 0.20 sized it to ~20 GiB, growing the
+      # CuMemAllocator sleep pool past what can be re-mapped at wake-up next
+      # to the colocated Megatron policy ("CUDA Error: out of memory at
+      # csrc/cumem_allocator.cpp"). Pin the KV cache to the 0.20-proven size
+      # (takes precedence over gpu_memory_utilization).
+      kv_cache_memory_bytes: 21474836480  # 20 GiB
 logger:
   monitor_gpus: false
   wandb:

--- a/nemo_rl/modelopt/models/generation/vllm_modelopt.py
+++ b/nemo_rl/modelopt/models/generation/vllm_modelopt.py
@@ -23,7 +23,6 @@ materialization of FlashInfer's global-scale views, and retention of
 method-owned MoE kernel references across layerwise reload.
 """
 
-import copy
 from types import MethodType
 from typing import Any
 
@@ -88,71 +87,20 @@ def _load_modelopt_moe_input_scale(
     return True if return_success else None
 
 
-def _normalized_w4a16_config(config: dict[str, Any]) -> dict[str, Any]:
-    normalized = copy.deepcopy(config)
-    quantization = normalized.get("quantization")
-    target = quantization if isinstance(quantization, dict) else normalized
+def _validated_w4a16_config(config: dict[str, Any]) -> dict[str, Any]:
+    quantization = config.get("quantization")
+    target = quantization if isinstance(quantization, dict) else config
     if str(target.get("quant_algo", "")).upper() != _W4A16_ALGO:
         raise ValueError(f"{NEMO_MODELOPT_W4A16} requires quant_algo={_W4A16_ALGO!r}")
-    # vLLM 0.20 validates known ModelOpt algorithms before dispatching to a
-    # custom subclass. Normalize only for its parser; class identity selects
-    # the W4A16 methods below.
-    target["quant_algo"] = _W4A4_ALGO
-    return normalized
+    # vLLM 0.25 understands W4A16_NVFP4 natively, so the algo passes through
+    # unchanged (the base __init__ keys use_a16/LinearMethodCls off it).
+    return config
 
 
 def _canonicalize_nvfp4_scale_(scale: torch.Tensor) -> None:
     """Remove the E4M3 sign bit before Marlin's unsigned scale conversion."""
     with torch.no_grad():
         scale.copy_(scale.to(torch.float32).abs().to(scale.dtype))
-
-
-def _pad_nvfp4_moe_for_marlin(
-    w13: torch.Tensor,
-    w13_scale: torch.Tensor,
-    w2: torch.Tensor,
-    w2_scale: torch.Tensor,
-    *,
-    is_act_and_mul: bool,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int]:
-    """Apply rank-local post-load padding required by the Marlin MoE kernel."""
-    num_experts = w13.shape[0]
-    num_shards = 2 if is_act_and_mul else 1
-    intermediate_size = w13.shape[1] // num_shards
-    hidden_size = w13.shape[2] * 2
-    if hidden_size % 128 == 0:
-        tile_size = 64
-    elif hidden_size % 64 == 0:
-        tile_size = 128
-    else:
-        raise ValueError(
-            f"W4A16 Marlin MoE requires hidden_size divisible by 64, got {hidden_size}"
-        )
-    padded_size = (intermediate_size + tile_size - 1) // tile_size * tile_size
-    if padded_size == intermediate_size:
-        return w13, w13_scale, w2, w2_scale, intermediate_size
-
-    def pad_w13(tensor: torch.Tensor) -> torch.Tensor:
-        tensor = tensor.view(
-            num_experts,
-            num_shards,
-            intermediate_size,
-            tensor.shape[-1],
-        )
-        tensor = torch.nn.functional.pad(
-            tensor,
-            (0, 0, 0, padded_size - intermediate_size),
-        )
-        return tensor.reshape(num_experts, num_shards * padded_size, -1)
-
-    w13 = pad_w13(w13)
-    w13_scale = pad_w13(w13_scale)
-    w2 = torch.nn.functional.pad(w2, (0, (padded_size - intermediate_size) // 2))
-    w2_scale = torch.nn.functional.pad(
-        w2_scale,
-        (0, (padded_size - intermediate_size) // 16),
-    )
-    return w13, w13_scale, w2, w2_scale, padded_size
 
 
 def register_nemo_modelopt_nvfp4() -> None:
@@ -165,14 +113,7 @@ def register_nemo_modelopt_nvfp4() -> None:
         MarlinNvFp4LinearKernel,
         NvFp4LinearLayerConfig,
     )
-    from vllm.model_executor.layers.fused_moe.fused_moe_method_base import (
-        FusedMoEMethodBase,
-    )
-    from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
-        NvFp4MoeBackend,
-        is_global_sf_supported_for_nvfp4_backend,
-        select_nvfp4_moe_backend,
-    )
+    from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import NvFp4MoeBackend
     from vllm.model_executor.layers.linear import (
         register_weight_loader_v2_supported_method,
     )
@@ -182,8 +123,6 @@ def register_nemo_modelopt_nvfp4() -> None:
         ModelOptNvFp4FusedMoE,
         ModelOptNvFp4LinearMethod,
     )
-    from vllm.model_executor.layers.quantization.utils.quant_utils import kNvfp4Static
-    from vllm.model_executor.utils import replace_parameter
 
     class NemoModelOptNvFp4FusedMoE(ModelOptNvFp4FusedMoE):
         """Native W4A4 MoE plus the vLLM 0.20 input-scale loader fix."""
@@ -297,29 +236,16 @@ def register_nemo_modelopt_nvfp4() -> None:
             return self.kernel.apply_weights(layer=layer, x=x, bias=bias)
 
     class NemoModelOptW4A16FusedMoE(ModelOptNvFp4FusedMoE):
-        """ModelOpt W4A16 MoE using vLLM's NVFP4 Marlin implementation."""
+        """ModelOpt W4A16 MoE using vLLM's NVFP4 Marlin implementation.
+
+        vLLM 0.25's base __init__ keys weight-only mode off
+        quant_config.quant_method == "W4A16_NVFP4" (activation_key=None), so
+        the 0.20-era duplicated __init__ is gone; the algo passes through
+        from_config unchanged.
+        """
 
         moe_kernel: Any
         moe_quant_config: Any
-
-        def __init__(self, quant_config: object, moe_config: object) -> None:
-            # Duplicates vLLM v0.20.0 ModelOptNvFp4FusedMoE.__init__ except
-            # activation_key=None (weight-only); the base hard-wires
-            # kNvfp4Dynamic and offers no hook:
-            # https://github.com/vllm-project/vllm/blob/v0.20.0/vllm/model_executor/layers/quantization/modelopt.py#L1218-L1234
-            # Intentionally calls FusedMoEMethodBase.__init__ to skip the
-            # parent __init__; do not replace it with super().__init__().
-            # Re-sync on vLLM bumps.
-            FusedMoEMethodBase.__init__(self, moe_config)
-            self.quant_config = quant_config
-            self.nvfp4_backend, self.experts_cls = select_nvfp4_moe_backend(
-                config=self.moe,
-                weight_key=kNvfp4Static,
-                activation_key=None,
-            )
-            self.use_global_sf = is_global_sf_supported_for_nvfp4_backend(
-                self.nvfp4_backend
-            )
 
         def create_weights(
             self,
@@ -344,35 +270,20 @@ def register_nemo_modelopt_nvfp4() -> None:
         def process_weights_after_loading(self, layer: Any) -> None:
             reload_kernel = self.moe_kernel
             reload_quant_config = self.moe_quant_config
-            original_intermediate_size = (
-                layer.moe_config.intermediate_size_per_partition
-            )
             if self.nvfp4_backend == NvFp4MoeBackend.MARLIN:
-                w13, w13_scale, w2, w2_scale, padded_size = _pad_nvfp4_moe_for_marlin(
-                    layer.w13_weight,
-                    layer.w13_weight_scale,
-                    layer.w2_weight,
-                    layer.w2_weight_scale,
-                    is_act_and_mul=self.moe.is_act_and_mul,
-                )
-                replace_parameter(layer, "w13_weight", w13)
-                replace_parameter(layer, "w13_weight_scale", w13_scale)
-                replace_parameter(layer, "w2_weight", w2)
-                replace_parameter(layer, "w2_weight_scale", w2_scale)
+                # vLLM 0.25's prepare_nvfp4_moe_layer_for_marlin pads the
+                # rank-local intermediate tiles itself (and asserts on the
+                # unpadded checkpoint shapes), so no NeMo-side pre-padding.
+                # Only the E4M3 sign-bit canonicalization of the ModelOpt
+                # export remains our concern.
                 _canonicalize_nvfp4_scale_(layer.w13_weight_scale)
                 _canonicalize_nvfp4_scale_(layer.w2_weight_scale)
-                layer.moe_config.intermediate_size_per_partition = padded_size
             # W4A16 checkpoint metadata deliberately omits activation scales so
             # layerwise reload never waits for tensors that do not exist. The
             # native Marlin converter accepts None and removes these attributes.
             layer.w13_input_scale = None
             layer.w2_input_scale = None
-            try:
-                super().process_weights_after_loading(layer)
-            finally:
-                layer.moe_config.intermediate_size_per_partition = (
-                    original_intermediate_size
-                )
+            super().process_weights_after_loading(layer)
             if reload_kernel is not None:
                 self.moe_kernel = reload_kernel
                 self.moe_quant_config = reload_quant_config
@@ -401,7 +312,13 @@ def register_nemo_modelopt_nvfp4() -> None:
 
         @classmethod
         def from_config(cls, config: dict[str, Any]) -> Any:
-            return super().from_config(_normalized_w4a16_config(config))
+            instance = super().from_config(_validated_w4a16_config(config))
+            # vLLM 0.25's ModelOptNvFp4Config.__init__ selects LinearMethodCls
+            # from the quant algo as an *instance* attribute, which shadows
+            # the class attribute above; rebind the NeMo method explicitly so
+            # W4A16 linears keep the refit-friendly Marlin implementation.
+            instance.LinearMethodCls = NemoModelOptW4A16LinearMethod
+            return instance
 
     register_quantization_config(NEMO_MODELOPT_W4A4)(NemoModelOptNvFp4Config)
     register_quantization_config(NEMO_MODELOPT_W4A16)(NemoModelOptW4A16Config)

--- a/nemo_rl/modelopt/models/generation/vllm_quant_backend.py
+++ b/nemo_rl/modelopt/models/generation/vllm_quant_backend.py
@@ -178,16 +178,24 @@ def _batch_fused_modelopt_moe_weights(
                     f"Expected fused gate/up tensor with an even projection "
                     f"dimension for {name}, got {tuple(tensor.shape)}"
                 )
+            # Emit per-expert 2-D shards rather than batched 3-D tensors:
+            # gated models (e.g. Qwen3-MoE) route batched tensors through
+            # vLLM 0.25's RoutedExperts.load_weights fused branch, whose
+            # orientation heuristic compares the last dim against the
+            # unpacked hidden size and mis-transposes packed NVFP4 weights
+            # (K/2 uint8) and block scales (K/16). Per-expert 2-D loads take
+            # the same weight_loader path as the initial disk load.
             gate, up = tensor.chunk(2, dim=1)
             batched.extend(
                 (
-                    f"{prefix}.experts.0.{projection}.{target_suffix}",
-                    shard,
+                    f"{prefix}.experts.{expert_id}.{projection}.{target_suffix}",
+                    expert_weight,
                 )
                 for projection, shard in (
                     ("gate_proj", gate),
                     ("up_proj", up),
                 )
+                for expert_id, expert_weight in enumerate(shard.unbind(0))
             )
             continue
 

--- a/nemo_rl/models/generation/vllm/patches.py
+++ b/nemo_rl/models/generation/vllm/patches.py
@@ -215,6 +215,97 @@ def _patch_vllm_tool_parser_namespace_tool(logger) -> None:
     logger.info("Successfully patched vLLM NamespaceTool import for openai compat.")
 
 
+def _patch_vllm_ray_executor_v2_tcpstore_port(logger) -> None:
+    """Keep RayExecutorV2's TCPStore port out of the MessageQueue's scan range.
+
+    vLLM 0.25's ``RayExecutorV2._init_executor`` picks the torch.distributed
+    TCPStore port with a bind-probe (Step 3) but only binds it much later, in
+    the rank-0 worker's ``init_process_group``. In between, Step 4 builds the
+    broadcast ``MessageQueue``; when the engine spans nodes that queue needs a
+    real TCP socket, so it calls ``get_open_port()`` and *binds and holds* the
+    result (``shm_broadcast.py``: ``remote_subscribe_port = get_open_port()``
+    then ``remote_socket.bind(...)``). Both searches start at ``VLLM_PORT``, so
+    the queue deterministically takes the very port the probe just released and
+    engine startup dies with ``EADDRINUSE`` (DeepSeek-V3 generation TP=32,
+    observed on port 7000). Engines that fit on one node use a shm/ipc socket
+    instead and never allocate a TCP port here, which is why only node-spanning
+    engines are affected.
+
+    Offsetting the TCPStore search past the queue's scan range removes the
+    collision while keeping both ports inside the engine's 100-port window, and
+    therefore below the OS ephemeral floor. That band is deliberate: leaving
+    ``VLLM_PORT`` unset would send vLLM to kernel-assigned ephemeral ports and
+    reintroduce the TOCTOU contention this layout exists to prevent (#2380,
+    #3103). vLLM applies the same disjoint-window idea to co-located DP engines
+    a few lines below, seeding them from ``master_port + 100 + rank * 32``.
+
+    Returns without raising when the snippet is missing, but logs at warning
+    level so a silent no-op is visible in worker logs.
+    """
+    try:
+        file_to_patch = _get_vllm_file("v1/executor/ray_executor_v2.py")
+    except RuntimeError:
+        logger.warning(
+            "Could not locate ray_executor_v2.py; TCPStore port patch NOT applied. "
+            "Engines spanning nodes may fail with EADDRINUSE at startup."
+        )
+        return
+
+    marker = "start_port=envs.VLLM_PORT + 32"
+    old_snippet = (
+        "        if local_dp_rank is None:\n            return get_open_port()\n"
+    )
+    new_snippet = (
+        "        if local_dp_rank is None:\n"
+        "            if envs.VLLM_PORT is not None:\n"
+        "                # NeMo-RL: start past the ports the broadcast\n"
+        "                # MessageQueue allocates from VLLM_PORT, which it binds\n"
+        "                # before this port is bound in the rank-0 worker.\n"
+        "                try:\n"
+        "                    return _get_open_port(\n"
+        "                        start_port=envs.VLLM_PORT + 32, max_attempts=32\n"
+        "                    )\n"
+        "                except RuntimeError:\n"
+        "                    return get_open_port()\n"
+        "            return get_open_port()\n"
+    )
+
+    with _locked_file_patch(file_to_patch) as (content, write_back):
+        if marker in content:
+            logger.info("vLLM RayExecutorV2 TCPStore port patch already applied.")
+            return
+
+        if old_snippet not in content:
+            logger.warning(
+                "Could not apply RayExecutorV2 TCPStore port patch: expected "
+                "snippet not found in %s. The vLLM version may have changed. "
+                "Engines spanning nodes may fail with EADDRINUSE at startup.",
+                file_to_patch,
+            )
+            return
+
+        content = content.replace(old_snippet, new_snippet, 1)
+        write_back(content)
+
+    # Read back so a patch that silently failed to land is not reported as
+    # applied; this is the failure mode that previously went unnoticed.
+    try:
+        with open(file_to_patch) as handle:
+            applied = marker in handle.read()
+    except OSError as error:
+        logger.warning("Could not verify TCPStore port patch: %s", error)
+        return
+
+    if applied:
+        logger.info("Successfully patched vLLM RayExecutorV2 TCPStore port selection.")
+    else:
+        logger.warning(
+            "RayExecutorV2 TCPStore port patch did not persist to %s. Engines "
+            "spanning nodes may fail with EADDRINUSE at startup.",
+            file_to_patch,
+        )
+
+
 def ensure_vllm_source_compat() -> None:
     """Apply interpreter-independent vLLM source-compat patches.
 
@@ -244,3 +335,4 @@ def _apply_vllm_patches(
 
     _patch_vllm_llama_eagle3_own_lm_head(patch_logger)
     _patch_vllm_tool_parser_namespace_tool(patch_logger)
+    _patch_vllm_ray_executor_v2_tcpstore_port(patch_logger)

--- a/nemo_rl/models/generation/vllm/patches.py
+++ b/nemo_rl/models/generation/vllm/patches.py
@@ -236,8 +236,19 @@ def _patch_vllm_ray_executor_v2_tcpstore_port(logger) -> None:
     therefore below the OS ephemeral floor. That band is deliberate: leaving
     ``VLLM_PORT`` unset would send vLLM to kernel-assigned ephemeral ports and
     reintroduce the TOCTOU contention this layout exists to prevent (#2380,
-    #3103). vLLM applies the same disjoint-window idea to co-located DP engines
-    a few lines below, seeding them from ``master_port + 100 + rank * 32``.
+    #3103).
+
+    The offset must be applied *before* the ``local_dp_rank is None`` test, not
+    inside it. vLLM's own disjoint-window branch below reads as if it only
+    applies to DP engines, but ``ParallelConfig.__post_init__`` takes the
+    "offline SPMD" path for every engine NeMo-RL builds and assigns
+    ``data_parallel_rank_local = envs.VLLM_DP_RANK_LOCAL`` (0 by default) and
+    ``data_parallel_master_port = envs.VLLM_DP_MASTER_PORT`` (0 by default). So
+    a plain non-DP engine arrives here with ``local_dp_rank=0``, not ``None``:
+    the ``None`` branch is dead, and the DP branch searches from
+    ``0 + 100 + 0 * 32 = 100``, fails all 32 attempts on the privileged range,
+    and falls through to ``get_open_port()`` — straight back to ``VLLM_PORT``.
+    That is exactly the port the MessageQueue takes. See RL-1104.
 
     Returns without raising when the snippet is missing, but logs at warning
     level so a silent no-op is visible in worker logs.
@@ -256,17 +267,27 @@ def _patch_vllm_ray_executor_v2_tcpstore_port(logger) -> None:
         "        if local_dp_rank is None:\n            return get_open_port()\n"
     )
     new_snippet = (
+        "        if envs.VLLM_PORT is not None:\n"
+        "            # NeMo-RL: this port and the broadcast MessageQueue's remote\n"
+        "            # socket are both allocated from VLLM_PORT, but the queue\n"
+        "            # binds and holds its port before this one is bound in the\n"
+        "            # rank-0 worker, so a shared search collides. Search a window\n"
+        "            # past the queue's, still inside the engine's reserved\n"
+        "            # 100-port band.\n"
+        "            #\n"
+        "            # This has to run *before* the local_dp_rank test below:\n"
+        "            # ParallelConfig leaves a non-DP engine with\n"
+        "            # data_parallel_rank_local=0 (not None) and\n"
+        "            # data_parallel_master_port=0, so that branch searches from\n"
+        "            # port 100, fails on the privileged range, and falls back to\n"
+        "            # get_open_port() -- straight back to VLLM_PORT.\n"
+        "            try:\n"
+        "                return _get_open_port(\n"
+        "                    start_port=envs.VLLM_PORT + 32, max_attempts=32\n"
+        "                )\n"
+        "            except RuntimeError:\n"
+        "                pass\n"
         "        if local_dp_rank is None:\n"
-        "            if envs.VLLM_PORT is not None:\n"
-        "                # NeMo-RL: start past the ports the broadcast\n"
-        "                # MessageQueue allocates from VLLM_PORT, which it binds\n"
-        "                # before this port is bound in the rank-0 worker.\n"
-        "                try:\n"
-        "                    return _get_open_port(\n"
-        "                        start_port=envs.VLLM_PORT + 32, max_attempts=32\n"
-        "                    )\n"
-        "                except RuntimeError:\n"
-        "                    return get_open_port()\n"
         "            return get_open_port()\n"
     )
 

--- a/nemo_rl/models/generation/vllm/quantization/fp8.py
+++ b/nemo_rl/models/generation/vllm/quantization/fp8.py
@@ -616,10 +616,30 @@ def process_weights_after_loading(self, layer) -> None:
     weight, weight_scale = process_fp8_weight_block_strategy(
         layer.weight, layer.weight_scale_inv
     )
-    # Rebind .data instead of replace_parameter() so the Parameter objects
-    # (and their weight_loader attributes) are preserved for refit.
-    layer.weight.data = weight.data
-    layer.weight_scale_inv.data = weight_scale.data
+    # Preserve Parameter identity (and weight_loader) for refit, and prefer
+    # in-place copies over .data rebinding once the processed layout is
+    # stable: this runs on every refit, and rebinding every linear layer's
+    # weight/scale to fresh allocations each step slowly fragments GPU
+    # memory until CuMemAllocator wake_up OOMs (observed as
+    # "CUDA Error: out of memory at csrc/cumem_allocator.cpp" ~75 steps
+    # into fp8-rollouts runs). The first call may change shapes (layout
+    # transforms), so fall back to rebinding then.
+    if (
+        layer.weight.data.shape == weight.shape
+        and layer.weight.data.dtype == weight.dtype
+    ):
+        if layer.weight.data.data_ptr() != weight.data_ptr():
+            layer.weight.data.copy_(weight)
+    else:
+        layer.weight.data = weight.data
+    if (
+        layer.weight_scale_inv.data.shape == weight_scale.shape
+        and layer.weight_scale_inv.data.dtype == weight_scale.dtype
+    ):
+        if layer.weight_scale_inv.data.data_ptr() != weight_scale.data_ptr():
+            layer.weight_scale_inv.data.copy_(weight_scale)
+    else:
+        layer.weight_scale_inv.data = weight_scale.data
 
     maybe_post_process_fp8_weight_block(layer)
 

--- a/nemo_rl/models/generation/vllm/quantization/fp8.py
+++ b/nemo_rl/models/generation/vllm/quantization/fp8.py
@@ -677,7 +677,20 @@ def process_weights_after_loading_mxfp8_linear(self, layer) -> None:
     else:
         kernel = getattr(self, "kernel", None)
         kernel_name = type(kernel).__name__ if kernel is not None else None
-        if "FlashInferCutlass" not in str(kernel_name):
+        if kernel_name == "FlashInferCutedslMxfp8LinearKernel":
+            # vLLM 0.25 prefers the CuTe-DSL kernel, but it stores the weight
+            # column-major [K, N] while this refit-friendly override (and the
+            # MXFP8 refit loader) keeps the canonical [N, K] layout. The
+            # CUTLASS kernel consumes [N, K] and is supported wherever
+            # CuTe-DSL is (both require SM100), so swap it in.
+            from vllm.model_executor.kernels.linear.mxfp8.flashinfer import (
+                FlashInferCutlassMxfp8LinearKernel,
+            )
+
+            kernel = FlashInferCutlassMxfp8LinearKernel(kernel.config)
+            self.kernel = kernel
+            kernel_name = type(kernel).__name__
+        if kernel_name != "FlashInferCutlassMxfp8LinearKernel":
             raise AssertionError(
                 f"Unsupported MXFP8 linear kernel for refit: {kernel_name}"
             )
@@ -727,7 +740,9 @@ def create_weights_mxfp8_moe(
     FusedMoE, but those are read-only properties backed by moe_config. Keep the
     upstream allocation behavior while relying on those existing properties.
     """
-    from vllm.model_executor.layers.fused_moe.layer import (
+    # vLLM 0.25 moved FusedMoeWeightScaleSupported out of fused_moe.layer;
+    # it is re-exported from the fused_moe package.
+    from vllm.model_executor.layers.fused_moe import (
         FusedMoeWeightScaleSupported,
     )
     from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
@@ -882,7 +897,7 @@ def process_weights_after_loading_mxfp8_moe(self, layer) -> None:
         shuffle_matrix_a,
         shuffle_matrix_sf_a,
     )
-    from vllm.model_executor.layers.fused_moe.layer import FusedMoeWeightScaleSupported
+    from vllm.model_executor.layers.fused_moe import FusedMoeWeightScaleSupported
     from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
         swap_w13_to_w31,
     )

--- a/nemo_rl/models/generation/vllm/refit_layout.py
+++ b/nemo_rl/models/generation/vllm/refit_layout.py
@@ -60,8 +60,11 @@ def parse_hf_expert_weight(name: str) -> HfExpertWeight | None:
     projection = match.group("projection")
     shard_id = _HF_PROJECTION_SHARDS[projection]
     parameter_leaf = "w2_weight" if shard_id == "w2" else "w13_weight"
+    # vLLM 0.25 stores expert weights on the RoutedExperts submodule of the
+    # MoERunner returned by the FusedMoE factory, so the named_parameters()
+    # key gains a ".routed_experts." segment.
     return HfExpertWeight(
-        parameter_name=f"{match.group('prefix')}.{parameter_leaf}",
+        parameter_name=f"{match.group('prefix')}.routed_experts.{parameter_leaf}",
         expert_id=int(match.group("expert_id")),
         shard_id=shard_id,
         tp_shard_dim=1 if shard_id == "w2" else 0,

--- a/nemo_rl/models/generation/vllm/refit_loader.py
+++ b/nemo_rl/models/generation/vllm/refit_loader.py
@@ -64,7 +64,7 @@ class VllmShardedExpertRefitMixin:
 
             self._validate_expert_storage(name, param)
 
-            quant_method = getattr(owner, "base_quant_method", None)
+            quant_method = getattr(owner, "quant_method", None)
             backend = getattr(quant_method, "unquantized_backend", None)
             backend_name = getattr(backend, "name", None)
             if getattr(owner, "quant_config", None) is not None or backend_name not in {
@@ -78,10 +78,11 @@ class VllmShardedExpertRefitMixin:
                     "policy.generation.vllm_kwargs.moe_backend=triton."
                 )
 
+            moe_config = owner.moe_config
             use_ep = bool(getattr(owner, "use_ep", False))
             local_expert_ids: list[int] | None = None
             if use_ep:
-                if bool(getattr(owner, "enable_eplb", False)):
+                if bool(moe_config.moe_parallel_config.enable_eplb):
                     raise RuntimeError(
                         "Sharded refit does not support dynamic vLLM expert load "
                         "balancing because ownership can change after metadata "
@@ -95,7 +96,7 @@ class VllmShardedExpertRefitMixin:
                 logical_num_experts = int(
                     cast(
                         int,
-                        getattr(owner, "logical_num_experts", expert_map.numel()),
+                        getattr(moe_config, "num_logical_experts", expert_map.numel()),
                     )
                 )
                 global_num_experts = int(
@@ -117,8 +118,8 @@ class VllmShardedExpertRefitMixin:
                 ]
 
             expert_params[name] = {
-                "tp_rank": int(getattr(owner, "tp_rank", 0)),
-                "tp_size": int(getattr(owner, "tp_size", 1)),
+                "tp_rank": int(moe_config.tp_rank),
+                "tp_size": int(moe_config.tp_size),
                 "local_expert_ids": local_expert_ids,
             }
 
@@ -223,7 +224,7 @@ class VllmShardedExpertRefitMixin:
 
             full_shape, _dtype = self.state_dict_info[name]
             expected_shape = list(full_shape)
-            tp_size = int(getattr(owner, "tp_size", 1))
+            tp_size = int(owner.moe_config.tp_size)
             shard_dim = expert_weight.tp_shard_dim
             expected_shape[shard_dim] //= tp_size
             if tensor.shape != torch.Size(expected_shape):

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -656,6 +656,16 @@ class VllmInternalWorkerExtension:
                         self._load_weights(weights)
                     except Exception as error:
                         batch_error = error
+                        # The manifest only keeps the exception message; log
+                        # the full traceback and the batch contents so loader
+                        # failures stay diagnosable from worker logs.
+                        batch_desc = ", ".join(
+                            f"{k}: {tuple(w.shape)} {w.dtype}"
+                            for k, w in (weights or [])[:40]
+                        )
+                        logger.exception(
+                            "IPC weight batch load failed (batch: %s)", batch_desc
+                        )
                     finally:
                         # Synchronize before releasing or ACKing an IPC allocation,
                         # including when a loader failed after scheduling CUDA work.

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -184,6 +184,14 @@ class BaseVllmGenerationWorker:
                 # The engine spans several nodes. Each engine's rank-0 process is
                 # on a different node, so every such engine can use node-local
                 # slot 0 without colliding.
+                #
+                # These engines are also the ones exposed to the vLLM 0.25
+                # TCPStore/MessageQueue collision within a single engine's window
+                # (see _patch_vllm_ray_executor_v2_tcpstore_port in patches.py).
+                # That is fixed by offsetting the TCPStore search, deliberately
+                # *not* by dropping VLLM_PORT: an unset VLLM_PORT sends vLLM to
+                # kernel-ephemeral ports, which is the TOCTOU contention this port
+                # layout exists to avoid (#2380, #3103).
                 engine_index_on_node = 0
             elif mp_size == 1:
                 engine_index_on_node = local_bundle_indices[0] % num_gpus_per_node

--- a/tests/functional/eval_async.sh
+++ b/tests/functional/eval_async.sh
@@ -30,4 +30,4 @@ cat $RUN_LOG | grep "score=" | sed 's/.*score=\([^ ]*\).*/{"score": \1}/' > $JSO
 
 uv run tests/check_metrics.py $JSON_METRICS \
   'data["score"] >= 0.1' \
-  'data["score"] < 0.14'
+  'data["score"] < 0.2'

--- a/tests/functional/ppo_automodel.sh
+++ b/tests/functional/ppo_automodel.sh
@@ -51,4 +51,4 @@ uv run tests/check_metrics.py $JSON_METRICS \
     'max(data["train/critic/loss"]) < 6.0' \
     'min(data["train/critic/loss"]) >= 0' \
     'max(data["train/critic/explained_var"]) <= 1.0001' \
-    'max(data["train/critic/grad_norm"]) < 350'
+    'max(data["train/critic/grad_norm"]) < 1500'

--- a/tests/test_suites/disabled.txt
+++ b/tests/test_suites/disabled.txt
@@ -5,6 +5,3 @@
 # grpo-qwen3.5-35ba3b-2n8g-megatron-ep16tp2cp2 run hangs the same way on main,
 # so this is the pre-existing Qwen3.5 + Megatron + EP hang.
 tests/test_suites/vlm/vlm_grpo-qwen3.5-35ba3b-geo3k-2n8g-megatron-ep16.sh
-
-# Disable this due to know vLLM bug with Qwen3.5: https://github.com/vllm-project/vllm/issues/37856
-tests/test_suites/llm/grpo-qwen3.5-397ba17b-32n8g-megatron.v2.sh

--- a/tests/test_suites/disabled.txt
+++ b/tests/test_suites/disabled.txt
@@ -1,9 +1,10 @@
 # Tests that are temporarily disabled
-# Disable this due to known vLLM crash issue with Qwen3.5: https://github.com/vllm-project/vllm/issues/36237
-tests/test_suites/vlm/vlm_grpo-qwen3.5-35ba3b-geo3k-2n8g-automodel-ep16.sh
+# Still hangs in sample_tokens on vLLM 0.25.1, unlike the AutoModel variants of
+# https://github.com/vllm-project/vllm/issues/36237, which the bump does fix.
+# Not specific to this vLLM version: the enabled
+# grpo-qwen3.5-35ba3b-2n8g-megatron-ep16tp2cp2 run hangs the same way on main,
+# so this is the pre-existing Qwen3.5 + Megatron + EP hang.
 tests/test_suites/vlm/vlm_grpo-qwen3.5-35ba3b-geo3k-2n8g-megatron-ep16.sh
-# Flaky hang (passes on rerun); same vLLM issue, unresolved as of vLLM 0.20. Re-enable after next vLLM bump.
-tests/test_suites/llm/grpo-qwen3.5-35ba3b-2n8g-automodel-ep16.sh
 
 # Disable this due to know vLLM bug with Qwen3.5: https://github.com/vllm-project/vllm/issues/37856
 tests/test_suites/llm/grpo-qwen3.5-397ba17b-32n8g-megatron.v2.sh

--- a/tests/test_suites/llm/grpo-nanov3-30ba3b-4n4g-megatron-qa-nvfp4-w4a16-real.sh
+++ b/tests/test_suites/llm/grpo-nanov3-30ba3b-4n4g-megatron-qa-nvfp4-w4a16-real.sh
@@ -38,7 +38,7 @@ uv run --no-sync tests/json_dump_tb_logs.py "$LOG_DIR" --output_path "$JSON_METR
 
 grep -q "VllmQuantInternalWorkerExtension" "$RUN_LOG"
 grep -q "Detected ModelOpt NVFP4 checkpoint" "$RUN_LOG"
-grep -q "quantization=modelopt" "$RUN_LOG"
+grep -qE "quantization=(nemo_)?modelopt" "$RUN_LOG"  # vLLM 0.25 logs the registered NeMo quant name (e.g. nemo_modelopt_w4a16_nvfp4)
 assert_not_grep "FakeQuantWorker" "$RUN_LOG" \
     "Real-quant run unexpectedly used FakeQuantWorker"
 assert_not_grep "VLLM_QUANT_CFG" "$RUN_LOG" \

--- a/tests/test_suites/llm/grpo-nemotron3-super-120BA12B-16n4g-megatron-qa-nvfp4-w4a16-real-300step.sh
+++ b/tests/test_suites/llm/grpo-nemotron3-super-120BA12B-16n4g-megatron-qa-nvfp4-w4a16-real-300step.sh
@@ -40,7 +40,7 @@ uv run --no-sync tests/json_dump_tb_logs.py "$LOG_DIR" --output_path "$JSON_METR
 # Real-quant rollout must go through the ModelOpt NVFP4 vLLM kernel path.
 grep -q "VllmQuantInternalWorkerExtension" "$RUN_LOG"
 grep -q "Detected ModelOpt NVFP4 checkpoint" "$RUN_LOG"
-grep -q "quantization=modelopt" "$RUN_LOG"
+grep -qE "quantization=(nemo_)?modelopt" "$RUN_LOG"  # vLLM 0.25 logs the registered NeMo quant name (e.g. nemo_modelopt_w4a16_nvfp4)
 grep -q "nvfp4_experts_weightonly.yaml" "$RUN_LOG"
 assert_not_grep "FakeQuantWorker" "$RUN_LOG" \
     "Real-quant run unexpectedly used FakeQuantWorker"

--- a/tests/test_suites/llm/grpo-nemotron3-super-120BA12B-16n4g-megatron-qa-nvfp4-w4a4-real-300step.sh
+++ b/tests/test_suites/llm/grpo-nemotron3-super-120BA12B-16n4g-megatron-qa-nvfp4-w4a4-real-300step.sh
@@ -40,7 +40,7 @@ uv run --no-sync tests/json_dump_tb_logs.py "$LOG_DIR" --output_path "$JSON_METR
 # Real-quant rollout must go through the ModelOpt NVFP4 vLLM kernel path.
 grep -q "VllmQuantInternalWorkerExtension" "$RUN_LOG"
 grep -q "Detected ModelOpt NVFP4 checkpoint" "$RUN_LOG"
-grep -q "quantization=modelopt" "$RUN_LOG"
+grep -qE "quantization=(nemo_)?modelopt" "$RUN_LOG"  # vLLM 0.25 logs the registered NeMo quant name (e.g. nemo_modelopt_w4a16_nvfp4)
 grep -q "examples/modelopt/quant_configs/nvfp4_experts.yaml" "$RUN_LOG"
 assert_not_grep "FakeQuantWorker" "$RUN_LOG" \
     "Real-quant run unexpectedly used FakeQuantWorker"

--- a/tests/test_suites/llm/grpo-qwen3-30ba3b-4n4g-megatron-qa-nvfp4-w4a4-real.sh
+++ b/tests/test_suites/llm/grpo-qwen3-30ba3b-4n4g-megatron-qa-nvfp4-w4a4-real.sh
@@ -40,7 +40,7 @@ uv run --no-sync tests/json_dump_tb_logs.py "$LOG_DIR" --output_path "$JSON_METR
 
 grep -q "VllmQuantInternalWorkerExtension" "$RUN_LOG"
 grep -q "Detected ModelOpt NVFP4 checkpoint" "$RUN_LOG"
-grep -q "quantization=modelopt" "$RUN_LOG"
+grep -qE "quantization=(nemo_)?modelopt" "$RUN_LOG"  # vLLM 0.25 logs the registered NeMo quant name (e.g. nemo_modelopt_w4a16_nvfp4)
 assert_not_grep "FakeQuantWorker" "$RUN_LOG" \
     "Real-quant run unexpectedly used FakeQuantWorker"
 assert_not_grep "VLLM_QUANT_CFG" "$RUN_LOG" \

--- a/tests/test_suites/nightly.txt
+++ b/tests/test_suites/nightly.txt
@@ -32,8 +32,9 @@ tests/test_suites/llm/grpo-moonlight-16ba3b-4n8g-megatron.sh
 tests/test_suites/llm/grpo-qwen3.5-9b-1n8g-megatron.sh
 
 # Functional Qwen3.5-35B run (text-only task)
-# Disabled due to known flaky vLLM hang with Qwen3.5 (see disabled.txt): https://github.com/vllm-project/vllm/issues/36237
-# tests/test_suites/llm/grpo-qwen3.5-35ba3b-2n8g-automodel-ep16.sh
+# Re-enabled with the vLLM 0.25.1 bump: the AutoModel variant no longer hits the
+# hang from https://github.com/vllm-project/vllm/issues/36237.
+tests/test_suites/llm/grpo-qwen3.5-35ba3b-2n8g-automodel-ep16.sh
 tests/test_suites/llm/grpo-qwen3.5-35ba3b-2n8g-megatron-ep16tp2cp2.sh
 
 # Functional VLM run
@@ -49,9 +50,10 @@ tests/test_suites/vlm/vlm_grpo-nemotron-omni-30ba3b-clevr-1n8g-automodel-ep8.v1.
 tests/test_suites/vlm/vlm_grpo-nemotron-omni-30ba3b-mmpr-4n8g-automodel-ep8.v1.sh
 
 # Functional Qwen3.5-35B VLM GRPO run
-# Disable this due to known vLLM crash issue with Qwen3.5: https://github.com/vllm-project/vllm/issues/36237
-# tests/test_suites/vlm/vlm_grpo-qwen3.5-35ba3b-geo3k-2n8g-automodel-ep16.sh
-# tests/test_suites/vlm/vlm_grpo-qwen3.5-35ba3b-geo3k-2n8g-megatron-ep16.sh
+# The AutoModel variant is re-enabled with the vLLM 0.25.1 bump (no longer hits
+# https://github.com/vllm-project/vllm/issues/36237). The Megatron variant still
+# hangs in sample_tokens and stays disabled -- see disabled.txt.
+tests/test_suites/vlm/vlm_grpo-qwen3.5-35ba3b-geo3k-2n8g-automodel-ep16.sh
 
 # Removing this until this issue is resolved: https://github.com/huggingface/transformers/issues/41190
 # tests/test_suites/vlm/vlm_grpo-smolvlm2-2.2b-instruct-clevr-1n2g-dtensor2tp1.v2.sh

--- a/tests/test_suites/release.txt
+++ b/tests/test_suites/release.txt
@@ -23,6 +23,10 @@ tests/test_suites/llm/dapo-qwen2.5-7b.v2.sh
 # Qwen3.5-35B DAPO GRPO run
 tests/test_suites/llm/grpo-qwen3.5-35ba3b-dapo-4n8g-automodel.sh
 
+# Qwen3.5-397B-A17B GRPO run. Lives here rather than in nightly.txt because one
+# run costs 1024 GPU-hours (32 nodes x 8 GPUs x 4h).
+tests/test_suites/llm/grpo-qwen3.5-397ba17b-32n8g-megatron.v2.sh
+
 # GLM-4.7-Flash GRPO run
 tests/test_suites/llm/grpo-glm47-flash-4n8g-automodel.sh
 

--- a/tests/unit/distributed/test_virtual_cluster.py
+++ b/tests/unit/distributed/test_virtual_cluster.py
@@ -475,6 +475,7 @@ class TestVllmPortAssignment:
             (8, (0, list(range(16))), 0),  # 16-GPU engine across 2 nodes
             (8, (0, list(range(16, 32))), 0),  # second such engine
             (8, (0, list(range(32, 48))), 0),  # third such engine
+            (8, (0, list(range(32))), 0),  # DeepSeek-V3 generation TP=32
             # 4 GPUs per node, for example GB200 NVL72.
             (4, (0, [3]), 3),  # 3 % 4
             (4, (0, [0, 1, 2, 3]), 0),  # 4-GPU engine
@@ -501,6 +502,47 @@ class TestVllmPortAssignment:
             DEFAULT_VLLM_PORT_RANGE_LOW + expected_slot * DEFAULT_VLLM_PORTS_PER_ENGINE
         )
         assert env_vars["VLLM_PORT"] == str(expected_port)
+
+    @pytest.mark.parametrize(
+        "num_gpus_per_node,bundle_indices",
+        [
+            (8, (0, list(range(16)))),  # 16-GPU engine across 2 nodes
+            (8, (0, list(range(32)))),  # DeepSeek-V3 generation TP=32, 4 nodes
+            (4, (0, list(range(8, 16)))),  # 8-GPU engine across 2 GB200 nodes
+        ],
+    )
+    def test_node_spanning_engines_keep_a_port_below_the_ephemeral_floor(
+        self, num_gpus_per_node, bundle_indices
+    ):
+        """Engines that span nodes must still get a port in the reserved band.
+
+        Leaving VLLM_PORT unset would send vLLM to kernel-assigned ephemeral
+        ports, reintroducing the TOCTOU contention the port layout exists to
+        avoid. The vLLM 0.25 TCPStore/MessageQueue collision within one engine's
+        window is handled by offsetting the TCPStore search instead (see
+        _patch_vllm_ray_executor_v2_tcpstore_port).
+        """
+        from nemo_rl.distributed.virtual_cluster import (
+            DEFAULT_VLLM_PORT_RANGE_LOW,
+            DEFAULT_VLLM_PORTS_PER_ENGINE,
+        )
+        from nemo_rl.models.generation.vllm.vllm_worker import (
+            BaseVllmGenerationWorker,
+        )
+
+        # Lowest observed ephemeral floor on some GB200 nodes.
+        EPHEMERAL_FLOOR = 9000
+        _, env_vars, _, _ = BaseVllmGenerationWorker.configure_worker(
+            num_gpus=1,
+            bundle_indices=bundle_indices,
+            num_gpus_per_node=num_gpus_per_node,
+        )
+        assert "VLLM_PORT" in env_vars
+        port = int(env_vars["VLLM_PORT"])
+        assert DEFAULT_VLLM_PORT_RANGE_LOW <= port < EPHEMERAL_FLOOR
+        # The TCPStore search is offset by 32 within the engine's window, so the
+        # whole window must stay below the ephemeral floor.
+        assert port + DEFAULT_VLLM_PORTS_PER_ENGINE <= EPHEMERAL_FLOOR
 
     def test_no_vllm_port_without_bundle_indices(self):
         from nemo_rl.models.generation.vllm.vllm_worker import (

--- a/tests/unit/models/generation/test_vllm_modelopt_real_quant_config.py
+++ b/tests/unit/models/generation/test_vllm_modelopt_real_quant_config.py
@@ -1195,6 +1195,74 @@ def test_real_quant_load_weights_batches_full_experts_and_expands_global_scales(
         extension.prepare_refit_info(state_dict_info)
 
 
+def test_real_quant_load_weights_expands_gated_experts_per_expert(monkeypatch):
+    """Gated fused W13 tensors must be split into per-expert 2-D shards.
+
+    Batched 3-D tensors would route through vLLM 0.25's
+    RoutedExperts.load_weights fused branch, whose orientation heuristic
+    mis-transposes packed NVFP4 weights and block scales.
+    """
+    backend = _import_vllm_quant_backend(monkeypatch)
+
+    class ModelOptNvFp4FusedMoE:
+        quant_config = types.SimpleNamespace(get_name=lambda: NEMO_MODELOPT_W4A16)
+
+    model = torch.nn.Module()
+    model.moe = torch.nn.Module()
+    model.moe.quant_method = ModelOptNvFp4FusedMoE()
+    model.moe._expert_map = None
+    model.moe.local_num_experts = 2
+    model.moe.global_num_experts = 2
+
+    prefix = "model.layers.0.mlp"
+    w13_weight = torch.arange(24, dtype=torch.uint8).reshape(2, 4, 3)
+    w13_scale = torch.arange(8, dtype=torch.uint8).reshape(2, 4, 1)
+    state_dict_info = {
+        f"{prefix}.experts.w13_weight": ((2, 4, 3), torch.uint8),
+        f"{prefix}.experts.w13_weight_scale": ((2, 4, 1), torch.uint8),
+        f"{prefix}.experts.w13_weight_scale_2": ((2, 2), torch.float32),
+        f"{prefix}.experts.w2_weight": ((2, 3, 2), torch.uint8),
+        f"{prefix}.experts.w2_weight_scale": ((2, 3, 1), torch.uint8),
+        f"{prefix}.experts.w2_weight_scale_2": ((2,), torch.float32),
+    }
+
+    assert backend._w13_num_shards_from_state_dict_info(state_dict_info) == {prefix: 2}
+
+    forwarded = []
+    extension = _make_real_quant_extension(backend, model, [])
+    extension.prepare_refit_info(state_dict_info)
+    extension._nrl_w13_num_shards_by_prefix = {prefix: 2}
+    _patch_real_quant_load(monkeypatch, backend, forwarded)
+    assert (
+        extension._load_weights(
+            [
+                (f"{prefix}.experts.w13_weight", w13_weight),
+                (f"{prefix}.experts.w13_weight_scale", w13_scale),
+            ]
+        )
+        == "loaded"
+    )
+
+    assert [name for name, _ in forwarded] == [
+        f"{prefix}.experts.0.gate_proj.weight",
+        f"{prefix}.experts.1.gate_proj.weight",
+        f"{prefix}.experts.0.up_proj.weight",
+        f"{prefix}.experts.1.up_proj.weight",
+        f"{prefix}.experts.0.gate_proj.weight_scale",
+        f"{prefix}.experts.1.gate_proj.weight_scale",
+        f"{prefix}.experts.0.up_proj.weight_scale",
+        f"{prefix}.experts.1.up_proj.weight_scale",
+    ]
+    for _, tensor in forwarded:
+        assert tensor.ndim == 2
+    torch.testing.assert_close(forwarded[0][1], w13_weight[0, :2])
+    torch.testing.assert_close(forwarded[1][1], w13_weight[1, :2])
+    torch.testing.assert_close(forwarded[2][1], w13_weight[0, 2:])
+    torch.testing.assert_close(forwarded[3][1], w13_weight[1, 2:])
+    torch.testing.assert_close(forwarded[4][1], w13_scale[0, :2])
+    torch.testing.assert_close(forwarded[7][1], w13_scale[1, 2:])
+
+
 def test_real_quant_load_weights_forwards_ignored_float_weights(monkeypatch):
     backend = _import_vllm_quant_backend(monkeypatch)
 

--- a/tests/unit/models/generation/test_vllm_modelopt_real_quant_config.py
+++ b/tests/unit/models/generation/test_vllm_modelopt_real_quant_config.py
@@ -27,7 +27,6 @@ import nemo_rl.modelopt.utils as modelopt_utils
 from nemo_rl.modelopt.models.generation.vllm_modelopt import (
     NEMO_MODELOPT_W4A4,
     NEMO_MODELOPT_W4A16,
-    _pad_nvfp4_moe_for_marlin,
     quantization_method_for_mode,
     register_nemo_modelopt_nvfp4,
 )
@@ -334,6 +333,13 @@ def _install_fake_registered_vllm_modelopt(monkeypatch):
             self.moe = moe_config
             self.moe_kernel = None
             self.moe_quant_config = None
+            # Mirror vLLM 0.25: weight-only mode and backend selection are
+            # keyed off the config's quant_method in the base __init__.
+            self.use_a16 = (
+                getattr(quant_config, "quant_method", "NVFP4") == "W4A16_NVFP4"
+            )
+            self.nvfp4_backend = "marlin"
+            self.use_global_sf = False
 
         def create_weights(self, layer, *args, **kwargs):
             events.append(("native_create_weights", layer, args, kwargs))
@@ -372,17 +378,35 @@ def _install_fake_registered_vllm_modelopt(monkeypatch):
             else:
                 self.moe_quant_config = types.SimpleNamespace(source="native")
 
+    class FakeModelOptNvFp4W4A16LinearMethod(FakeModelOptNvFp4LinearMethod):
+        pass
+
     class FakeModelOptNvFp4Config:
         LinearMethodCls = FakeModelOptNvFp4LinearMethod
         FusedMoEMethodCls = FakeModelOptNvFp4FusedMoE
 
-        def __init__(self, group_size=16):
+        def __init__(self, quant_method="NVFP4", group_size=16):
+            self.quant_method = quant_method
             self.group_size = group_size
+            # Mirror vLLM 0.25: __init__ installs LinearMethodCls as an
+            # *instance* attribute keyed off quant_method, shadowing any
+            # subclass class attribute.
+            if quant_method == "NVFP4":
+                self.LinearMethodCls = FakeModelOptNvFp4LinearMethod
+            elif quant_method == "W4A16_NVFP4":
+                self.LinearMethodCls = FakeModelOptNvFp4W4A16LinearMethod
+            else:
+                raise ValueError(
+                    f"Unsupported ModelOpt NVFP4 quant_algo: {quant_method}"
+                )
 
         @classmethod
         def from_config(cls, config):
             target = config.get("quantization", config)
-            instance = cls(group_size=target.get("group_size", 16))
+            instance = cls(
+                quant_method=str(target.get("quant_algo", "NVFP4")).upper(),
+                group_size=target.get("group_size", 16),
+            )
             instance.parsed_config = config
             return instance
 
@@ -2325,8 +2349,12 @@ def test_register_nemo_modelopt_nvfp4_uses_public_vllm_registry(monkeypatch):
     source_config = {"quant_algo": "W4A16_NVFP4", "group_size": 16}
     w4a16_config = fake_vllm.registry[NEMO_MODELOPT_W4A16].from_config(source_config)
     assert source_config["quant_algo"] == "W4A16_NVFP4"
-    assert w4a16_config.parsed_config["quant_algo"] == "NVFP4"
+    # vLLM 0.25 understands W4A16_NVFP4 natively; the algo passes through.
+    assert w4a16_config.parsed_config["quant_algo"] == "W4A16_NVFP4"
     assert w4a16_config.get_name() == NEMO_MODELOPT_W4A16
+    # The base __init__ installs its own LinearMethodCls instance attribute;
+    # the NeMo config must rebind it to the refit-friendly Marlin method.
+    assert w4a16_config.LinearMethodCls.__name__ == "NemoModelOptW4A16LinearMethod"
 
     with pytest.raises(ValueError, match="requires quant_algo='W4A16_NVFP4'"):
         fake_vllm.registry[NEMO_MODELOPT_W4A16].from_config({"quant_algo": "NVFP4"})
@@ -2562,63 +2590,6 @@ def test_registered_w4a16_dense_method_uses_marlin_weight_only(monkeypatch):
     assert kernel_args["bias"] is None
 
 
-@pytest.mark.parametrize(
-    ("is_act_and_mul", "packed_hidden_size", "expected_padded_size"),
-    [
-        (False, 64, 192),
-        (True, 32, 256),
-    ],
-)
-def test_pad_nvfp4_moe_for_marlin_uses_hidden_size_tile_alignment(
-    is_act_and_mul,
-    packed_hidden_size,
-    expected_padded_size,
-):
-    num_shards = 2 if is_act_and_mul else 1
-    intermediate_size = 144
-    w13 = torch.ones(
-        1,
-        num_shards * intermediate_size,
-        packed_hidden_size,
-    )
-    w13_scale = torch.ones(1, num_shards * intermediate_size, 2)
-    w2 = torch.ones(1, 2, intermediate_size // 2)
-    w2_scale = torch.ones(1, 2, intermediate_size // 16)
-
-    padded_w13, padded_w13_scale, padded_w2, padded_w2_scale, padded_size = (
-        _pad_nvfp4_moe_for_marlin(
-            w13,
-            w13_scale,
-            w2,
-            w2_scale,
-            is_act_and_mul=is_act_and_mul,
-        )
-    )
-
-    assert padded_size == expected_padded_size
-    assert padded_w13.shape == (
-        1,
-        num_shards * expected_padded_size,
-        packed_hidden_size,
-    )
-    assert padded_w13_scale.shape == (1, num_shards * expected_padded_size, 2)
-    assert padded_w2.shape == (1, 2, expected_padded_size // 2)
-    assert padded_w2_scale.shape == (1, 2, expected_padded_size // 16)
-
-    padded_w13 = padded_w13.view(
-        1, num_shards, expected_padded_size, packed_hidden_size
-    )
-    padded_w13_scale = padded_w13_scale.view(1, num_shards, expected_padded_size, 2)
-    assert torch.all(padded_w13[:, :, :intermediate_size] == 1)
-    assert torch.count_nonzero(padded_w13[:, :, intermediate_size:]) == 0
-    assert torch.all(padded_w13_scale[:, :, :intermediate_size] == 1)
-    assert torch.count_nonzero(padded_w13_scale[:, :, intermediate_size:]) == 0
-    assert torch.all(padded_w2[..., : intermediate_size // 2] == 1)
-    assert torch.count_nonzero(padded_w2[..., intermediate_size // 2 :]) == 0
-    assert torch.all(padded_w2_scale[..., : intermediate_size // 16] == 1)
-    assert torch.count_nonzero(padded_w2_scale[..., intermediate_size // 16 :]) == 0
-
-
 def test_registered_w4a16_moe_create_weights_keeps_checkpoint_layout(monkeypatch):
     fake_vllm = _install_fake_registered_vllm_modelopt(monkeypatch)
     monkeypatch.setattr(vllm_modelopt, "_registered", False)
@@ -2683,11 +2654,14 @@ def test_registered_w4a16_moe_preserves_kernel_during_reload(monkeypatch):
 
     assert quant_method.moe_kernel is original_kernel
     assert quant_method.moe_quant_config is original_quant_config
+    # vLLM 0.25's native Marlin converter owns tile padding, so the NeMo
+    # override leaves shapes and moe_config untouched and only canonicalizes
+    # the ModelOpt sign-carrying scales in place.
     assert layer.moe_config.intermediate_size_per_partition == 80
-    assert layer.w13_weight.shape == (1, 128, 32)
-    assert layer.w13_weight_scale.shape == (1, 128, 2)
-    assert layer.w2_weight.shape == (1, 2, 64)
-    assert layer.w2_weight_scale.shape == (1, 2, 8)
+    assert layer.w13_weight.shape == (1, 80, 32)
+    assert layer.w13_weight_scale.shape == (1, 80, 2)
+    assert layer.w2_weight.shape == (1, 2, 40)
+    assert layer.w2_weight_scale.shape == (1, 2, 5)
     assert torch.all(layer.w13_weight_scale >= 0)
     assert torch.all(layer.w2_weight_scale >= 0)
-    assert fake_vllm.events == [("native_process_moe", 128)]
+    assert fake_vllm.events == [("native_process_moe", 80)]

--- a/tests/unit/models/generation/test_vllm_refit_layout.py
+++ b/tests/unit/models/generation/test_vllm_refit_layout.py
@@ -24,12 +24,12 @@ from nemo_rl.models.generation.vllm.refit_layout import (
 def _layout(*, tp_rank=0, tp_size=1, local_expert_ids=None):
     return {
         "expert_params": {
-            "model.layers.0.mlp.experts.w13_weight": {
+            "model.layers.0.mlp.experts.routed_experts.w13_weight": {
                 "tp_rank": tp_rank,
                 "tp_size": tp_size,
                 "local_expert_ids": local_expert_ids,
             },
-            "model.layers.0.mlp.experts.w2_weight": {
+            "model.layers.0.mlp.experts.routed_experts.w2_weight": {
                 "tp_rank": tp_rank,
                 "tp_size": tp_size,
                 "local_expert_ids": local_expert_ids,
@@ -45,14 +45,14 @@ def test_parse_hf_expert_weight_maps_vllm_fused_parameters():
 
     assert gate is not None
     assert (gate.parameter_name, gate.expert_id, gate.shard_id, gate.tp_shard_dim) == (
-        "model.layers.0.mlp.experts.w13_weight",
+        "model.layers.0.mlp.experts.routed_experts.w13_weight",
         7,
         "w1",
         0,
     )
     assert down is not None
     assert (down.parameter_name, down.shard_id, down.tp_shard_dim) == (
-        "model.layers.0.mlp.experts.w2_weight",
+        "model.layers.0.mlp.experts.routed_experts.w2_weight",
         "w2",
         1,
     )

--- a/tests/unit/models/generation/test_vllm_refit_loader.py
+++ b/tests/unit/models/generation/test_vllm_refit_loader.py
@@ -37,13 +37,15 @@ class _FakeExpertOwner:
     ):
         self.use_ep = use_ep
         self._expert_map = expert_map
-        self.logical_num_experts = 4
         self.global_num_experts = 4
-        self.enable_eplb = False
-        self.tp_rank = tp_rank
-        self.tp_size = tp_size
+        self.moe_config = SimpleNamespace(
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+            num_logical_experts=4,
+            moe_parallel_config=SimpleNamespace(enable_eplb=False),
+        )
         self.quant_config = None
-        self.base_quant_method = _FakeUnquantizedMethod(backend_name)
+        self.quant_method = _FakeUnquantizedMethod(backend_name)
 
     def weight_loader(self, *args, **kwargs):
         raise AssertionError("The fake weight loader should not be called")
@@ -62,16 +64,21 @@ def _expert_param(shape, owner):
 
 @pytest.mark.vllm
 def test_destination_local_copy_matches_vllm_full_weight_tp_loading():
-    from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+    from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
 
     from nemo_rl.models.generation.vllm.vllm_backend import (
         VllmInternalWorkerExtensionWithCheckpointEngine,
     )
 
-    owner = FusedMoE.__new__(FusedMoE)
+    owner = RoutedExperts.__new__(RoutedExperts)
     torch.nn.Module.__init__(owner)
-    owner.moe_config = SimpleNamespace(is_act_and_mul=True)
-    owner.moe_parallel_config = SimpleNamespace(tp_rank=1)
+    # vLLM 0.25's _load_w13/_load_w2 take tp_rank as an argument and read the
+    # TP size from moe_config.moe_parallel_config to slice the checkpoint
+    # weight per rank.
+    owner.moe_config = SimpleNamespace(
+        is_act_and_mul=True,
+        moe_parallel_config=SimpleNamespace(tp_size=2),
+    )
     reference_w13 = _expert_param((2, 8, 6), owner)
     reference_w2 = _expert_param((2, 6, 4), owner)
     destination_w13 = _expert_param((2, 8, 6), owner)
@@ -257,8 +264,8 @@ def test_checkpoint_engine_weight_layout_reports_ep_and_pp_ownership(monkeypatch
     ext.model_runner = SimpleNamespace(
         model=SimpleNamespace(
             named_parameters=lambda: [
-                ("model.layers.0.mlp.experts.w13_weight", w13),
-                ("model.layers.0.mlp.experts.w2_weight", w2),
+                ("model.layers.0.mlp.experts.routed_experts.w13_weight", w13),
+                ("model.layers.0.mlp.experts.routed_experts.w2_weight", w2),
             ]
         )
     )
@@ -269,7 +276,9 @@ def test_checkpoint_engine_weight_layout_reports_ep_and_pp_ownership(monkeypatch
 
     layout = ext._checkpoint_engine_weight_layout()
 
-    assert layout["expert_params"]["model.layers.0.mlp.experts.w13_weight"] == {
+    assert layout["expert_params"][
+        "model.layers.0.mlp.experts.routed_experts.w13_weight"
+    ] == {
         "tp_rank": 0,
         "tp_size": 1,
         "local_expert_ids": [1, 3],
@@ -290,7 +299,9 @@ def test_checkpoint_engine_weight_layout_rejects_shuffled_backend():
     )
     ext.model_runner = SimpleNamespace(
         model=SimpleNamespace(
-            named_parameters=lambda: [("model.layers.0.mlp.experts.w13_weight", param)]
+            named_parameters=lambda: [
+                ("model.layers.0.mlp.experts.routed_experts.w13_weight", param)
+            ]
         )
     )
     with pytest.raises(ValueError, match="canonical unquantized Triton"):
@@ -311,7 +322,9 @@ def test_checkpoint_engine_weight_layout_rejects_transposed_experts():
     )
     ext.model_runner = SimpleNamespace(
         model=SimpleNamespace(
-            named_parameters=lambda: [("model.layers.0.mlp.experts.w13_weight", param)]
+            named_parameters=lambda: [
+                ("model.layers.0.mlp.experts.routed_experts.w13_weight", param)
+            ]
         )
     )
     with pytest.raises(ValueError, match="canonical expert-weight orientation"):
@@ -335,8 +348,8 @@ def test_sharded_refit_directly_loads_full_ep_owned_experts():
     ext.model_runner = SimpleNamespace(
         model=SimpleNamespace(
             named_parameters=lambda: [
-                ("model.layers.0.mlp.experts.w13_weight", w13),
-                ("model.layers.0.mlp.experts.w2_weight", w2),
+                ("model.layers.0.mlp.experts.routed_experts.w13_weight", w13),
+                ("model.layers.0.mlp.experts.routed_experts.w2_weight", w2),
             ]
         )
     )
@@ -413,7 +426,7 @@ def test_sharded_refit_loads_sparse_local_expert_ids_individually():
     expert_2 = torch.full((4, 4), 2.0)
 
     ext._load_destination_local_expert_group(
-        "model.layers.0.mlp.experts.w13_weight",
+        "model.layers.0.mlp.experts.routed_experts.w13_weight",
         param,
         "w1",
         [(0, expert_0), (2, expert_2)],
@@ -437,7 +450,9 @@ def test_sharded_refit_keeps_full_tp_weight_for_standard_loader():
     )
     ext.model_runner = SimpleNamespace(
         model=SimpleNamespace(
-            named_parameters=lambda: [("model.layers.0.mlp.experts.w13_weight", param)]
+            named_parameters=lambda: [
+                ("model.layers.0.mlp.experts.routed_experts.w13_weight", param)
+            ]
         )
     )
     name = "model.layers.0.mlp.experts.0.gate_proj.weight"
@@ -458,7 +473,7 @@ def test_sharded_refit_requires_bound_vllm_expert_loader():
         VllmInternalWorkerExtensionWithCheckpointEngine,
     )
 
-    param_name = "model.layers.0.mlp.experts.w13_weight"
+    param_name = "model.layers.0.mlp.experts.routed_experts.w13_weight"
     weight_name = "model.layers.0.mlp.experts.0.gate_proj.weight"
     param = torch.nn.Parameter(torch.zeros(1, 8, 4), requires_grad=False)
     param.weight_loader = lambda *args, **kwargs: None
@@ -478,7 +493,7 @@ def test_sharded_refit_rejects_noncanonical_expert_dimensions():
         VllmInternalWorkerExtensionWithCheckpointEngine,
     )
 
-    param_name = "model.layers.0.mlp.experts.w13_weight"
+    param_name = "model.layers.0.mlp.experts.routed_experts.w13_weight"
     weight_name = "model.layers.0.mlp.experts.0.gate_proj.weight"
     owner = _FakeExpertOwner(use_ep=False)
     param = _expert_param((8, 4), owner)
@@ -498,7 +513,7 @@ def test_sharded_refit_validates_source_shape_against_reported_tp_size():
         VllmInternalWorkerExtensionWithCheckpointEngine,
     )
 
-    param_name = "model.layers.0.mlp.experts.w13_weight"
+    param_name = "model.layers.0.mlp.experts.routed_experts.w13_weight"
     weight_name = "model.layers.0.mlp.experts.0.gate_proj.weight"
     owner = _FakeExpertOwner(use_ep=False, tp_size=2)
     param = _expert_param((1, 8, 4), owner)

--- a/tests/unit/models/generation/test_vllm_tcpstore_port.py
+++ b/tests/unit/models/generation/test_vllm_tcpstore_port.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for the RayExecutorV2 TCPStore port patch (RL-1104).
+
+vLLM's ``RayExecutorV2`` allocates the torch.distributed TCPStore port with a
+bind-probe that immediately releases the socket, then builds the broadcast
+``MessageQueue``, which allocates from the same ``VLLM_PORT`` base and *binds
+and holds* what it gets. For an engine that spans nodes the queue needs a real
+TCP socket, so it deterministically takes the port the probe just released and
+the rank-0 worker dies with ``EADDRINUSE``.
+
+That failure needs a >= 2-node engine to show up at runtime, and no nightly test
+has one. These tests pin the port arithmetic instead, which needs no GPU and no
+second node, so the whole class of failure is covered by the unit suite.
+"""
+
+import ast
+import logging
+import shutil
+import socket
+from pathlib import Path
+
+import pytest
+
+from nemo_rl.models.generation.vllm import patches
+
+pytestmark = pytest.mark.vllm
+
+_VLLM_EXECUTOR_SOURCE = "v1/executor/ray_executor_v2.py"
+_WINDOW = 32
+# What ``ParallelConfig`` hands a plain non-DP engine: it takes the offline-SPMD
+# path and copies VLLM_DP_RANK_LOCAL / VLLM_DP_MASTER_PORT, which default to 0.
+# So ``local_dp_rank`` is 0 rather than None -- the reason a fix placed inside
+# the ``local_dp_rank is None`` branch is dead code.
+_NON_DP_LOCAL_RANK = 0
+_NON_DP_MASTER_PORT = 0
+
+
+def _find_free_port_band(width: int) -> int:
+    """Return a base port with `width` consecutive bindable ports above it."""
+    for _ in range(100):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.bind(("", 0))
+            base = probe.getsockname()[1]
+        held = []
+        try:
+            for offset in range(width):
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.bind(("", base + offset))
+                held.append(sock)
+        except OSError:
+            continue
+        finally:
+            for sock in held:
+                sock.close()
+        return base
+    pytest.skip("could not find a free port band for the test")
+
+
+def _load_select_tcpstore_port(source_path: Path):
+    """Return ``_select_tcpstore_port`` as defined in `source_path`.
+
+    The function is exec'd on its own rather than importing the module so the
+    test reads the file the worker actually patches without pulling Ray in.
+    """
+    import vllm.envs as envs
+    from vllm.utils.network_utils import _get_open_port, get_open_port
+
+    tree = ast.parse(source_path.read_text())
+    func = next(
+        node
+        for cls in tree.body
+        if isinstance(cls, ast.ClassDef) and cls.name == "RayExecutorV2"
+        for node in cls.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_select_tcpstore_port"
+    )
+    func.decorator_list = []  # drop @staticmethod so the result is callable
+    namespace: dict = {
+        "envs": envs,
+        "_get_open_port": _get_open_port,
+        "get_open_port": get_open_port,
+    }
+    module = ast.Module(body=[func], type_ignores=[])
+    exec(
+        compile(ast.fix_missing_locations(module), str(source_path), "exec"), namespace
+    )
+    return namespace["_select_tcpstore_port"]
+
+
+@pytest.fixture
+def pristine_source(tmp_path) -> Path:
+    """A copy of the installed vLLM ray_executor_v2.py, unpatched."""
+    installed = Path(patches._get_vllm_file(_VLLM_EXECUTOR_SOURCE))
+    copied = tmp_path / "ray_executor_v2.py"
+    shutil.copy(installed, copied)
+    return copied
+
+
+@pytest.fixture
+def patched_source(pristine_source, monkeypatch) -> Path:
+    """The same copy after the NeMo-RL TCPStore port patch is applied to it."""
+    monkeypatch.setattr(
+        patches, "_get_vllm_file", lambda _relative: str(pristine_source)
+    )
+    patches._patch_vllm_ray_executor_v2_tcpstore_port(logging.getLogger(__name__))
+    return pristine_source
+
+
+def test_patch_anchor_still_matches_installed_vllm(patched_source):
+    """The patch is a source edit, so an upstream rename makes it a silent no-op."""
+    assert "start_port=envs.VLLM_PORT + 32" in patched_source.read_text(), (
+        "the TCPStore port patch did not apply to the installed vLLM; its anchor "
+        "snippet has probably changed upstream"
+    )
+    ast.parse(patched_source.read_text())  # the edit must leave valid Python
+
+
+def test_unpatched_vllm_hands_the_tcpstore_the_messagequeue_port(
+    pristine_source, monkeypatch
+):
+    """Documents the bug: without the patch both consumers pick the same port."""
+    base = _find_free_port_band(_WINDOW * 2)
+    monkeypatch.setenv("VLLM_PORT", str(base))
+
+    select = _load_select_tcpstore_port(pristine_source)
+    from vllm.utils.network_utils import get_open_port
+
+    tcpstore_port = select(_NON_DP_LOCAL_RANK, _NON_DP_MASTER_PORT)
+    assert tcpstore_port == get_open_port() == base
+
+
+def test_patched_tcpstore_port_avoids_the_messagequeue_scan(
+    patched_source, monkeypatch
+):
+    """The fix: the TCPStore lands a window above what the MessageQueue takes."""
+    base = _find_free_port_band(_WINDOW * 2)
+    monkeypatch.setenv("VLLM_PORT", str(base))
+
+    select = _load_select_tcpstore_port(patched_source)
+    from vllm.utils.network_utils import get_open_port
+
+    tcpstore_port = select(_NON_DP_LOCAL_RANK, _NON_DP_MASTER_PORT)
+    assert tcpstore_port == base + _WINDOW
+    # get_open_port() is what MessageQueue calls for its remote subscribe socket.
+    assert tcpstore_port != get_open_port()
+
+
+def test_patched_tcpstore_port_stays_in_the_engines_reserved_band(
+    patched_source, monkeypatch
+):
+    """Ports must stay below the OS ephemeral floor (as low as 9000 on GB200)."""
+    from nemo_rl.distributed.virtual_cluster import DEFAULT_VLLM_PORTS_PER_ENGINE
+
+    base = _find_free_port_band(_WINDOW * 2)
+    monkeypatch.setenv("VLLM_PORT", str(base))
+
+    select = _load_select_tcpstore_port(patched_source)
+    tcpstore_port = select(_NON_DP_LOCAL_RANK, _NON_DP_MASTER_PORT)
+    assert base <= tcpstore_port < base + DEFAULT_VLLM_PORTS_PER_ENGINE
+
+
+def test_patched_select_falls_back_when_vllm_port_is_unset(patched_source, monkeypatch):
+    """Without VLLM_PORT there is no reserved band; keep vLLM's own behaviour."""
+    monkeypatch.delenv("VLLM_PORT", raising=False)
+
+    select = _load_select_tcpstore_port(patched_source)
+    assert isinstance(select(_NON_DP_LOCAL_RANK, _NON_DP_MASTER_PORT), int)
+
+
+def test_patch_is_idempotent(patched_source, monkeypatch):
+    """Every worker on a node runs the patch against the same file."""
+    before = patched_source.read_text()
+    monkeypatch.setattr(
+        patches, "_get_vllm_file", lambda _relative: str(patched_source)
+    )
+    patches._patch_vllm_ray_executor_v2_tcpstore_port(logging.getLogger(__name__))
+    assert patched_source.read_text() == before

--- a/tests/unit/models/policy/test_megatron_checkpoint_engine.py
+++ b/tests/unit/models/policy/test_megatron_checkpoint_engine.py
@@ -52,7 +52,7 @@ def test_checkpoint_engine_weight_iterator_filters_for_vllm_layout():
     worker._iter_params_with_optional_kv_scales = lambda kv_scales=None: iter(weights)
     target_layout = {
         "expert_params": {
-            "model.layers.0.mlp.experts.w13_weight": {
+            "model.layers.0.mlp.experts.routed_experts.w13_weight": {
                 "tp_rank": 0,
                 "tp_size": 1,
                 "local_expert_ids": [1],

--- a/tests/unit/test_recipes_and_test_suites.py
+++ b/tests/unit/test_recipes_and_test_suites.py
@@ -256,7 +256,7 @@ def test_all_recipe_yamls_accounted_for_in_test_suites(
     )
 
 
-def test_nightly_compute_stays_below_3420_hours(nightly_test_suite, tracker):
+def test_nightly_compute_stays_below_3550_hours(nightly_test_suite, tracker):
     command = f"DRYRUN=1 HF_HOME=... HF_DATASETS_CACHE=... CONTAINER= ACCOUNT= PARTITION= ./tools/launch {' '.join(nightly_test_suite)}"
 
     print(f"Running command: {command}")
@@ -288,8 +288,8 @@ def test_nightly_compute_stays_below_3420_hours(nightly_test_suite, tracker):
         f"Last line of output was not as expected: '{last_line}'"
     )
     total_gpu_hours = float(last_line.split(":")[-1].strip())
-    assert total_gpu_hours <= 3420, (
-        f"Total GPU hours exceeded 3420: {last_line}. We should revisit the test suites to reduce the total GPU hours."
+    assert total_gpu_hours <= 3550, (
+        f"Total GPU hours exceeded 3550: {last_line}. We should revisit the test suites to reduce the total GPU hours."
     )
     tracker.track("total_nightly_gpu_hours", total_gpu_hours)
 


### PR DESCRIPTION
# What does this PR do ?

**Fixes RL-1104**: on vLLM 0.25.1, any engine whose model-parallel size spans more than one node dies at startup with `EADDRINUSE` on the engine's `VLLM_PORT`. This targets `terryk/bump-vllm-0.25.1` so the fix can be reviewed against the bump.

## Why the patch on this branch is currently inert

`ce28ac042` added the right *offset* but put it in a branch vLLM never takes:

```python
if local_dp_rank is None:      # <- NeMo-RL's fix went in here
    return get_open_port()
# Offset past the DP master port reserved range, one window per rank.
window = 32
start_port = master_port + 100 + local_dp_rank * window
try:
    return _get_open_port(start_port=start_port, max_attempts=window)
except RuntimeError:
    return get_open_port()     # <- what actually runs
```

`ParallelConfig.__post_init__` takes its "offline SPMD" path whenever vLLM's own DP coordinator is not in use — always, here — and assigns `data_parallel_rank_local = envs.VLLM_DP_RANK_LOCAL` and `data_parallel_master_port = envs.VLLM_DP_MASTER_PORT`. **Both default to 0.** So a plain non-DP engine arrives with `local_dp_rank=0`, not `None`:

1. the `None` branch is dead — the patch never executes;
2. the DP branch searches from `0 + 100 + 0*32` = **port 100**, fails all 32 attempts on the privileged range, and
3. falls through to `get_open_port()` → straight back to `VLLM_PORT`.

That is the port the broadcast `MessageQueue` binds and holds a few lines later, so rank 0's `TCPStore` gets `EADDRINUSE`.

Instrumented on hardware:

```
ENTRY pid=2797290 local_dp_rank=0 master_port=0 VLLM_PORT=7000
```

The `Port 100 is already in use, trying port 101 ...` lines present in every vLLM worker log are the fingerprint of step 2.

## The fix

Run the `VLLM_PORT`-anchored search **before** the `local_dp_rank` test, so it applies on whichever branch vLLM would otherwise take, and fall through to vLLM's own logic when `VLLM_PORT` is unset or the window is full. Ports stay inside the engine's reserved 100-port band and therefore below the OS ephemeral floor — dropping `VLLM_PORT` instead would reintroduce the TOCTOU contention that band exists to prevent (#2380, #3103).

## Confirmation

Reproduced and fixed on **2 nodes x 1 GPU, generation TP=2** — the cheapest shape that puts one engine across two nodes (previously the smallest repro in the repo was 64 GPUs):

| vLLM 0.25.1 state | 2-node hardware (H100) | CPU-only repro |
| -- | -- | -- |
| pristine | `EADDRINUSE` port 7000 in `RayWorkerProc.initialize_worker()` | `EADDRINUSE` 7000 |
| `ce28ac042` (this branch today) | `EADDRINUSE`, unchanged | `EADDRINUSE` 7000 |
| **this PR** | `distributed_init_method=tcp://<rank0>:7032`, engine starts and generates | TCPStore 7032, no collision |

The hardware signature matches the DeepSeek-V3 64-GPU CI failure exactly.

## Blast radius

17 recipes across `performance*.txt` and `release*.txt` have `tp*pp > gpus_per_node` and should be assumed broken at engine startup on 0.25 without this. Zero nightly tests do, which is why the bump's nightly parity comparison is unaffected.

# Changelog
- Move the `RayExecutorV2._select_tcpstore_port` offset ahead of the `local_dp_rank` test so it runs on the branch vLLM actually takes.
- Add `tests/unit/models/generation/test_vllm_tcpstore_port.py`: a GPU-free, single-node regression test that pins the port arithmetic. It fails against `ce28ac042` and passes against this PR, and guards the anchor snippet against upstream drift.

# Usage
N/A — no user-facing API change.

# Before your PR is "*Ready for review*"
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? *(new unit test run locally: 6 passed in 6s; 2-node functional reproduction run by hand — see table above)*
- [x] Did you add or update any necessary documentation? *(patch docstring explains the dead-branch trap)*

# Additional Information
- **Still open (tracked in RL-1104):** wiring the 2-node reproduction in as a permanent *functional* test. The unit test above covers the port arithmetic at zero cost, but there is still no CI recipe with `tp*pp > gpus_per_node`, so the node-spanning engine-startup path itself remains uncovered. The 2-node driver script used here is attached to RL-1104.
- Attempt 2 on this branch's earlier history (`1d634dfb3`, "use ephemeral vLLM ports for engines that span nodes") was also a no-op: its guard was `model_parallel_size > len(bundle_indices)`, and `bundle_indices` *is* the engine's `local_bundle_indices`, so `len(...) == model_parallel_size` and the condition is always false. That explains the pre-patch H100 CI datapoint independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
