### PR TITLE
chore: update NCCL to 2.30.4 via uv override

### DIFF
--- a/3rdparty/TensorRT-LLM-workspace/pyproject.toml
+++ b/3rdparty/TensorRT-LLM-workspace/pyproject.toml
@@ -31,7 +31,9 @@ dependencies = [
   "torch>=2.11.0",
   "torchvision",
   "nvidia-modelopt>=0.37.0",
-  "nvidia-nccl-cu13>=2.28.9,<=2.29.7",
+  # Ceiling raised from upstream's <=2.29.7 (which tracks what NGC rel-26-04 ships,
+  # not a tested incompatibility) so it matches the nvidia-nccl-cu13==2.30.4 override.
+  "nvidia-nccl-cu13>=2.28.9,<=2.30.4",
   "nvidia-cuda-nvrtc",
   "nvidia-cutlass-dsl[cu13]==4.5.0",
   "nvidia-ml-py>=13",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@
 #   --build-arg SKIP_SGLANG_BUILD=1  # Skip SGLang dependencies
 #   --build-arg SKIP_TRTLLM_BUILD=1  # Skip TRT-LLM dependencies
 
-ARG BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:26.03-cuda13.2-devel-ubuntu24.04
+ARG BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:26.05-cuda13.2-devel-ubuntu24.04
 FROM scratch AS nemo-rl
 ARG NRL_GIT_REF=main
 ADD --keep-git-dir=true https://github.com/NVIDIA-NeMo/RL.git#${NRL_GIT_REF} /

--- a/examples/nemo_gym/nemotron-3-ultra/ifbench_teacher.yaml
+++ b/examples/nemo_gym/nemotron-3-ultra/ifbench_teacher.yaml
@@ -56,6 +56,7 @@ grpo:
   advantage_clip_low: -20
   advantage_clip_high: 20
   val_period: 10000
+  val_start_at: -1
   val_at_start: false
   val_at_end: false
   overlong_filtering: false

--- a/examples/nemo_gym/nemotron-3-ultra/mopd.yaml
+++ b/examples/nemo_gym/nemotron-3-ultra/mopd.yaml
@@ -71,6 +71,7 @@ grpo:
   advantage_clip_low: -20
   advantage_clip_high: 20
   val_period: -1
+  val_start_at: -1
   val_at_start: false
   val_at_end: false
   overlong_filtering: false

--- a/examples/nemo_gym/nemotron-3-ultra/reasoning_teacher.yaml
+++ b/examples/nemo_gym/nemotron-3-ultra/reasoning_teacher.yaml
@@ -60,6 +60,7 @@ grpo:
   advantage_clip_low: -20
   advantage_clip_high: 20
   val_period: 10000
+  val_start_at: -1
   val_at_start: false
   val_at_end: false
   overlong_filtering: false

--- a/examples/nemo_gym/nemotron-3-ultra/rlhf_teacher.yaml
+++ b/examples/nemo_gym/nemotron-3-ultra/rlhf_teacher.yaml
@@ -57,6 +57,7 @@ grpo:
   advantage_clip_low: -20
   advantage_clip_high: 20
   val_period: 10000
+  val_start_at: -1
   val_at_start: false
   val_at_end: false
   overlong_filtering: false

--- a/examples/nemo_gym/nemotron-3-ultra/student_rlvr1.yaml
+++ b/examples/nemo_gym/nemotron-3-ultra/student_rlvr1.yaml
@@ -53,6 +53,7 @@ grpo:
   advantage_clip_low: -20
   advantage_clip_high: 20
   val_period: 10000
+  val_start_at: -1
   val_at_start: false
   val_at_end: false
   overlong_filtering: false

--- a/examples/nemo_gym/nemotron-3-ultra/student_rlvr2.yaml
+++ b/examples/nemo_gym/nemotron-3-ultra/student_rlvr2.yaml
@@ -54,6 +54,7 @@ grpo:
   advantage_clip_low: -20
   advantage_clip_high: 20
   val_period: 10000
+  val_start_at: -1
   val_at_start: false
   val_at_end: false
   overlong_filtering: false

--- a/examples/nemo_gym/nemotron-3-ultra/swe_teacher.yaml
+++ b/examples/nemo_gym/nemotron-3-ultra/swe_teacher.yaml
@@ -76,6 +76,7 @@ grpo:
   advantage_clip_low: -100
   advantage_clip_high: 100
   val_period: 10000
+  val_start_at: -1
   val_at_start: false
   val_at_end: false
   overlong_filtering: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -354,6 +354,9 @@ override-dependencies = [
   "nvidia-cublas==13.5.1.27; sys_platform != 'darwin'",
   "nvidia-cudnn-cu13==9.20.0.48; sys_platform != 'darwin'",
   "nvidia-cudnn-frontend==1.23.0",
+  # NCCL 2.30.4 fixes a context-parallel hang on GB200 when GPUs are non-contiguous.
+  # An override is required because torch 2.11.0+cu130 pins nvidia-nccl-cu13==2.28.9.
+  "nvidia-nccl-cu13==2.30.4",
   "nvidia-nvshmem-cu13>=3.6.5; sys_platform != 'darwin'",
   "opencv-python-headless; sys_platform == 'never'",
   "timm<=1.0.22",

--- a/uv.lock
+++ b/uv.lock
@@ -93,6 +93,7 @@ overrides = [
     { name = "nvidia-cudnn-cu13", marker = "sys_platform != 'darwin'", specifier = "==9.20.0.48" },
     { name = "nvidia-cudnn-frontend", specifier = "==1.23.0" },
     { name = "nvidia-modelopt", extras = ["torch"], git = "https://github.com/NVIDIA/Model-Optimizer?rev=c3b913b9cc1d82d5a0af9fa77b4db87829e6f158" },
+    { name = "nvidia-nccl-cu13", specifier = "==2.30.4" },
     { name = "nvidia-nvshmem-cu13", marker = "sys_platform != 'darwin'", specifier = ">=3.6.5" },
     { name = "opencv-python-headless", marker = "sys_platform == 'never'" },
     { name = "opentelemetry-api", specifier = ">=1.33.1" },
@@ -4998,11 +4999,11 @@ dependencies = [
 
 [[package]]
 name = "nvidia-nccl-cu13"
-version = "2.28.9"
+version = "2.30.4"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/55/1920646a2e43ffd4fc958536b276197ed740e9e0c54105b4bb3521591fc7/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:01c873ba1626b54caa12272ed228dc5b2781545e0ae8ba3f432a8ef1c6d78643", size = 196561677, upload-time = "2025-11-18T05:49:03.45Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/b4/878fefaad5b2bcc6fcf8d474a25e3e3774bc5133e4b58adff4d0bca238bc/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:e4553a30f34195f3fa1da02a6da3d6337d28f2003943aa0a3d247bbc25fefc42", size = 196493177, upload-time = "2025-11-18T05:49:17.677Z" },
+    { url = "https://files.pythonhosted.org/packages/65/32/ff4e28cbed87f99fed63df446ef1986e0617842258a3535eaa2ee92d6226/nvidia_nccl_cu13-2.30.4-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:e99308a3a89fba78918d50886e81072a6c8b0b4199feb02c3903e63713a6525a", size = 212898082, upload-time = "2026-04-23T03:22:28.608Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/93/6d020a69fc37e57fae8a96ab0c53102d96538db256e933e914d100e5a430/nvidia_nccl_cu13-2.30.4-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:534dbf3058cadb625f08ab0d17f1dffad3b961a2bfa360d66633fcf21be53f57", size = 212855427, upload-time = "2026-04-23T03:22:47.436Z" },
 ]
 
 [[package]]
@@ -7641,7 +7642,7 @@ requires-dist = [
     { name = "nvidia-cutlass-dsl", extras = ["cu13"], specifier = "==4.5.0" },
     { name = "nvidia-ml-py", specifier = ">=13" },
     { name = "nvidia-modelopt", specifier = ">=0.37.0" },
-    { name = "nvidia-nccl-cu13", specifier = ">=2.28.9,<=2.29.7" },
+    { name = "nvidia-nccl-cu13", specifier = ">=2.28.9,<=2.30.4" },
     { name = "nvtx" },
     { name = "omegaconf" },
     { name = "onnx", specifier = ">=1.21.0" },


### PR DESCRIPTION
# What does this PR do ?

NCCL 2.30.4 fixes a context-parallel hang on GB200 when GPUs are non-contiguous.

torch 2.11.0+cu130 pins nvidia-nccl-cu13==2.28.9, so a plain version bump is unresolvable ("No solution found"). Use [tool.uv] override-dependencies, the same mechanism already used for nvidia-cublas, nvidia-cudnn-cu13 and nvidia-nvshmem-cu13.

Also raise the ceiling in the vendored TensorRT-LLM workspace from <=2.29.7 to <=2.30.4 so the declared constraint matches what is installed rather than being silently overridden. Upstream's ceiling tracks what NGC rel-26-04 ships and is not a tested incompatibility; nothing in the TRT-LLM build path references NCCL.

Unlike excluding the wheel in the Dockerfile, this covers non-container `uv sync` users and worker venvs built at runtime, and pins the version reproducibly in uv.lock instead of inheriting whatever the base image ships.

Thanks to @cspades @ZhiyuLi-Nvidia @macandro96 for identifying the root cause and testing.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
