### PR TITLE
fix: merge grouped-expert LoRA weights during DTensor refit

### DIFF
--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -102,7 +102,7 @@ def dtensor_params_generator(
     """
     module_map = dict(model.named_modules())
     for name, tensor in model.state_dict().items():
-        if name.endswith(".lora_A.weight") or name.endswith(".lora_B.weight"):
+        if _is_lora_adapter_tensor(name):
             continue
         full_tensor = tensor.full_tensor() if isinstance(tensor, DTensor) else tensor
         merged_tensor = _maybe_merge_lora_weight(module_map, name, full_tensor)
@@ -120,12 +120,66 @@ def dtensor_params_generator(
         del full_tensor
 
 
+# Automodel's grouped-expert LoRA (GroupedExpertsLoRA / GroupedExpertsDeepEPLoRA) keeps its
+# adapters as bare parameters on the expert module rather than as LinearLoRA submodules, so
+# neither the skip filters nor the merge below recognise them without these helpers. Without
+# them the adapters are streamed to the inference engine as unknown keys and the base expert
+# weights are refit unmerged, i.e. generation silently uses an unadapted policy.
+_GROUPED_EXPERT_LORA_ADAPTERS = (
+    "lora_gate_and_up_A",
+    "lora_gate_and_up_B",
+    "lora_down_A",
+    "lora_down_B",
+)
+_GROUPED_EXPERT_BASE_WEIGHTS = ("gate_and_up_projs", "down_projs")
+
+
+def _is_lora_adapter_tensor(fqn: str) -> bool:
+    """True for adapter tensors that must never be sent to the inference engine."""
+    if fqn.endswith(".lora_A.weight") or fqn.endswith(".lora_B.weight"):
+        return True
+    return fqn.rpartition(".")[2] in _GROUPED_EXPERT_LORA_ADAPTERS
+
+
+def _grouped_expert_lora_adapters(
+    module_map: dict[str, nn.Module], fqn: str
+) -> tuple[Optional[nn.Module], Optional[tuple[torch.Tensor, torch.Tensor]]]:
+    """Return (module, (A, B)) when `fqn` is a grouped-expert base weight carrying LoRA."""
+    parent_name, _, leaf = fqn.rpartition(".")
+    if leaf not in _GROUPED_EXPERT_BASE_WEIGHTS:
+        return None, None
+    module = module_map.get(parent_name)
+    if module is None or not hasattr(module, "lora_gate_and_up_A"):
+        return None, None
+    if leaf == "gate_and_up_projs":
+        return module, (module.lora_gate_and_up_A, module.lora_gate_and_up_B)
+    return module, (module.lora_down_A, module.lora_down_B)
+
+
 @torch.no_grad()
 def _maybe_merge_lora_weight(
     module_map: dict[str, nn.Module],
     fqn: str,
     tensor: torch.Tensor,
 ) -> torch.Tensor:
+    expert_module, expert_adapters = _grouped_expert_lora_adapters(module_map, fqn)
+    if expert_module is not None:
+        # GroupedExperts(DeepEP)LoRA computes `x @ W + (x @ A @ B) * scale` per expert, so
+        # the merge is a per-expert batched matmul in the same orientation as W -- no
+        # transpose. A/B are sharded over the expert dimension exactly as W is under expert
+        # parallelism, so full_tensor() gathers them in the same expert order.
+        lora_a, lora_b = (
+            adapter.full_tensor() if isinstance(adapter, DTensor) else adapter
+            for adapter in expert_adapters
+        )
+        delta = torch.bmm(
+            lora_a.to(device=tensor.device, dtype=tensor.dtype),
+            lora_b.to(device=tensor.device, dtype=tensor.dtype),
+        )
+        merged = tensor + delta * getattr(expert_module, "scale", 1.0)
+        del delta
+        return merged
+
     if not fqn.endswith(".weight"):
         return tensor
     module_name = fqn[: -len(".weight")]
@@ -1075,7 +1129,7 @@ class DTensorPolicyWorkerV2Impl(
         """Prepare state dict metadata for weight refitting and IPC streaming."""
         state_dict_info = {}
         for name, tensor in self.model.state_dict().items():
-            if name.endswith(".lora_A.weight") or name.endswith(".lora_B.weight"):
+            if _is_lora_adapter_tensor(name):
                 continue
             full_tensor = (
                 tensor.full_tensor() if isinstance(tensor, DTensor) else tensor

--- a/tests/unit/models/dtensor/test_lora_expert_refit.py
+++ b/tests/unit/models/dtensor/test_lora_expert_refit.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Refit-time handling of LoRA on Automodel's grouped MoE experts.
+
+Grouped-expert LoRA does not follow the LinearLoRA layout: the adapters are bare parameters
+on the expert module (`lora_gate_and_up_A`, ...) next to fused base weights
+(`gate_and_up_projs`, `down_projs`). These tests pin down that such adapters are merged into
+the base weights before refit, and are not themselves streamed to the inference engine.
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from nemo_rl.models.policy.workers.dtensor_policy_worker_v2 import (
+    _grouped_expert_lora_adapters,
+    _is_lora_adapter_tensor,
+    _maybe_merge_lora_weight,
+)
+
+N_EXPERTS = 3
+DIM = 8
+UP_DIM = 12
+RANK = 2
+ALPHA = 8
+
+
+class StubGroupedExpertsLoRA(nn.Module):
+    """Minimal stand-in for GroupedExperts(DeepEP)LoRA's parameter layout."""
+
+    def __init__(self, dtype=torch.float32):
+        super().__init__()
+        self.gate_and_up_projs = nn.Parameter(
+            torch.randn(N_EXPERTS, DIM, UP_DIM, dtype=dtype)
+        )
+        self.down_projs = nn.Parameter(torch.randn(N_EXPERTS, UP_DIM, DIM, dtype=dtype))
+        self.lora_gate_and_up_A = nn.Parameter(
+            torch.randn(N_EXPERTS, DIM, RANK, dtype=dtype)
+        )
+        self.lora_gate_and_up_B = nn.Parameter(
+            torch.randn(N_EXPERTS, RANK, UP_DIM, dtype=dtype)
+        )
+        self.lora_down_A = nn.Parameter(
+            torch.randn(N_EXPERTS, UP_DIM, RANK, dtype=dtype)
+        )
+        self.lora_down_B = nn.Parameter(torch.randn(N_EXPERTS, RANK, DIM, dtype=dtype))
+        self.scale = ALPHA / RANK
+
+
+@pytest.fixture
+def module_map():
+    module = StubGroupedExpertsLoRA()
+    return {"model.layers.0.moe.experts": module}, module
+
+
+@pytest.mark.parametrize(
+    "fqn,expected",
+    [
+        ("model.layers.0.self_attn.q_proj.lora_A.weight", True),
+        ("model.layers.0.self_attn.q_proj.lora_B.weight", True),
+        ("model.layers.0.moe.experts.lora_gate_and_up_A", True),
+        ("model.layers.0.moe.experts.lora_gate_and_up_B", True),
+        ("model.layers.0.moe.experts.lora_down_A", True),
+        ("model.layers.0.moe.experts.lora_down_B", True),
+        ("model.layers.0.moe.experts.gate_and_up_projs", False),
+        ("model.layers.0.moe.experts.down_projs", False),
+        ("model.layers.0.self_attn.q_proj.weight", False),
+    ],
+)
+def test_is_lora_adapter_tensor(fqn, expected):
+    """Adapter tensors of both layouts are recognised; base weights are not."""
+    assert _is_lora_adapter_tensor(fqn) is expected
+
+
+def test_grouped_expert_adapters_are_resolved(module_map):
+    mapping, module = module_map
+    for leaf, expected in (
+        ("gate_and_up_projs", (module.lora_gate_and_up_A, module.lora_gate_and_up_B)),
+        ("down_projs", (module.lora_down_A, module.lora_down_B)),
+    ):
+        found_module, adapters = _grouped_expert_lora_adapters(
+            mapping, f"model.layers.0.moe.experts.{leaf}"
+        )
+        assert found_module is module
+        assert adapters == expected
+
+
+def test_non_expert_fqn_resolves_to_nothing(module_map):
+    mapping, _ = module_map
+    assert _grouped_expert_lora_adapters(
+        mapping, "model.layers.0.moe.experts.something"
+    ) == (
+        None,
+        None,
+    )
+    assert _grouped_expert_lora_adapters(mapping, "model.lm_head.weight") == (
+        None,
+        None,
+    )
+
+
+@pytest.mark.parametrize(
+    "leaf,a_attr,b_attr",
+    [
+        ("gate_and_up_projs", "lora_gate_and_up_A", "lora_gate_and_up_B"),
+        ("down_projs", "lora_down_A", "lora_down_B"),
+    ],
+)
+def test_merge_adds_per_expert_delta(module_map, leaf, a_attr, b_attr):
+    """The merge must be per-expert `W + (A @ B) * scale`, in the base weight's orientation."""
+    mapping, module = module_map
+    base = getattr(module, leaf).detach()
+    merged = _maybe_merge_lora_weight(
+        mapping, f"model.layers.0.moe.experts.{leaf}", base
+    )
+
+    expected = (
+        base
+        + torch.bmm(getattr(module, a_attr), getattr(module, b_attr)) * module.scale
+    )
+    assert merged.shape == base.shape
+    torch.testing.assert_close(merged, expected)
+    # Each expert must get its own delta, not a shared one.
+    for expert in range(N_EXPERTS):
+        torch.testing.assert_close(merged[expert], expected[expert])
+
+
+def test_merge_is_out_of_place(module_map):
+    """The refit generator may hand over a parameter's own storage; it must not be mutated."""
+    mapping, module = module_map
+    base = module.gate_and_up_projs.detach()
+    before = base.clone()
+    _maybe_merge_lora_weight(
+        mapping, "model.layers.0.moe.experts.gate_and_up_projs", base
+    )
+    torch.testing.assert_close(base, before)
+
+
+def test_zero_initialised_b_is_a_no_op(module_map):
+    """LoRA B starts at zero, so a freshly adapted model must refit unchanged."""
+    mapping, module = module_map
+    with torch.no_grad():
+        module.lora_gate_and_up_B.zero_()
+    base = module.gate_and_up_projs.detach()
+    merged = _maybe_merge_lora_weight(
+        mapping, "model.layers.0.moe.experts.gate_and_up_projs", base
+    )
+    torch.testing.assert_close(merged, base)
+
+
+def test_module_without_adapters_passes_through():
+    """A plain grouped-expert module (no LoRA) must be returned untouched."""
+
+    class PlainExperts(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.gate_and_up_projs = nn.Parameter(torch.randn(N_EXPERTS, DIM, UP_DIM))
+
+    module = PlainExperts()
+    mapping = {"model.layers.0.moe.experts": module}
+    base = module.gate_and_up_projs.detach()
+    merged = _maybe_merge_lora_weight(
+        mapping, "model.layers.0.moe.experts.gate_and_up_projs", base
+    )
+    assert merged is base
+
+
+def test_merge_preserves_dtype(module_map):
+    """Adapters may be held in a different dtype than the base weights (fp32 masters)."""
+    mapping, module = module_map
+    with torch.no_grad():
+        module.gate_and_up_projs.data = module.gate_and_up_projs.data.to(torch.bfloat16)
+    base = module.gate_and_up_projs.detach()
+    merged = _maybe_merge_lora_weight(
+        mapping, "model.layers.0.moe.experts.gate_and_up_projs", base
+    )
+    assert merged.dtype == torch.bfloat16


### PR DESCRIPTION
# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

Merges LoRA adapters on Automodel's grouped MoE experts into the base expert weights during the
DTensor refit, so GRPO with expert adapters no longer breaks weight streaming into the
inference engine.

# Issues

List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

None filed — happy to open one first if you prefer that order.

# Details

`policy.dtensor_cfg.lora_cfg.target_modules` can match Automodel's grouped expert modules,
because `ModuleMatcher` matching is name-based rather than type-based, and
`apply_lora_to_linear_modules` then wraps them in `GroupedExpertsLoRA` /
`GroupedExpertsDeepEPLoRA`. Those keep their adapters as **bare parameters on the expert
module** — `lora_gate_and_up_A/B`, `lora_down_A/B` — next to fused base weights
`gate_and_up_projs` / `down_projs`, rather than as `LinearLoRA` submodules with
`.lora_A.weight`.

Three places in `dtensor_policy_worker_v2.py` assume the `LinearLoRA` layout:

| Location | Assumption | Consequence |
|---|---|---|
| `_maybe_merge_lora_weight` | `fqn.endswith(".weight")` and `isinstance(module, LinearLoRA)` | grouped-expert base weights refit **unmerged** |
| `dtensor_params_generator` skip filter | name ends `.lora_A.weight` / `.lora_B.weight` | adapter tensors are **streamed** to the engine |
| `prepare_refit_info` skip filter | same | adapter keys are **advertised** to the engine |

On a `google/gemma-4-26B-A4B-it` GRPO run (1 node × 8 B200, EP=8, `experts: gmm`,
`dispatcher: deepep`, `target_modules: ['*_proj', '*experts']`) the first refit fails:

```
KeyError: 'layers.0.moe.experts.lora_gate_and_up_A'
  (vLLM RayWorkerWrapper, during DTensorPolicyWorkerV2.stream_weights_via_ipc_zmq)
```

An engine that tolerated unknown keys would instead generate from unadapted experts while
training adapts them — a divergence that grows from zero as `lora_B` leaves its zero
initialisation, which is harder to notice.

**The merge.** The expert forward computes `x @ W + (x @ A @ B) * scale`, so the delta is a
per-expert batched matmul already in the base weight's orientation — no transpose. Under expert
parallelism `A`/`B` are sharded over the expert dimension exactly as `W` is, so `full_tensor()`
gathers them in matching expert order. Matching is by attribute presence rather than by
importing Automodel's classes, so it survives refactors on either side.

# Usage

```yaml
policy:
  dtensor_cfg:
    _v2: true
    lora_cfg:
      enabled: true
      match_all_linear: false
      # '*experts' reaches the grouped expert module; '*_proj' covers attention and the
      # shared expert while leaving the router (`moe.gate.proj`) and lm_head frozen.
      target_modules: ['*_proj', '*experts']
      dim: 8
      alpha: 32
```

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally?
- [ ] Did you add or update any necessary documentation?

`tests/unit/models/dtensor/test_lora_expert_refit.py` adds 17 CPU-only cases covering adapter
detection for both layouts, adapter resolution, the per-expert delta, out-of-place merging
(the generator may hand over a parameter's own storage), the zero-`lora_B` no-op, pass-through
for un-adapted modules, and dtype preservation.

Run against NeMo-RL `bbc58087` + Automodel `24b47e85`:

```
tests/unit/models/dtensor/test_lora_expert_refit.py ..  17 passed
tests/unit/models/dtensor/test_lora.py ..............   11 passed   (unchanged)
```

End-to-end on the run above: generation KL error 0.00068 / 0.00056 / 0.00052 over three GRPO
steps, matching a full fine-tune of the same model, i.e. the refit reproduces the training-side
computation. Adapter checkpoint 894 MB / 247 M parameters; steps 38–41 s versus 36 s with
attention-only LoRA.

I did not touch `docs/guides/lora.md`; happy to add a note there that reaching the experts
requires `target_modules` (since `match_all_linear` only matches `nn.Linear` and so silently
skips grouped experts) if you'd like that in the same PR.

# Additional Information

* **A submodule bump is also needed to exercise this path.** Reaching the refit requires the
  expert-LoRA dtype fix from Automodel PR #2789 (`_to_grouped_mm_operand`). `main` pins
  Automodel `24b47e856263d313b942f0ed666c63fff83306b4`, which predates it, so grouped-expert
  LoRA currently aborts earlier with
  `RuntimeError: Expected b.scalar_type() == torch::kBFloat16 to be true, but got false`.
  I left that out of this PR since bumping the submodule is your call; I tested with #2789
  backported locally.
* **Scope.** This affects every model on Automodel's grouped-expert path — 21 model packages at
  the pinned revision, including `qwen3_moe`, `qwen3_next`, `deepseek_v3`, `gpt_oss`,
  `glm4_moe`, `minimax_m2` and `nemotron_v3` — not just Gemma 4.
* This work was done with AI assistance; the code, tests and measurements were reviewed by me.