### PR TITLE
fix(vllm): retry MessageQueue remote bind so node-spanning engines start

### DIFF
--- a/nemo_rl/models/generation/vllm/patches.py
+++ b/nemo_rl/models/generation/vllm/patches.py
@@ -327,6 +327,139 @@ def _patch_vllm_ray_executor_v2_tcpstore_port(logger) -> None:
         )
 
 
+def _patch_vllm_shm_broadcast_bind_retry(logger) -> None:
+    """Make MessageQueue's remote socket survive losing a port race.
+
+    ``MessageQueue.__init__`` picks the port for its remote (TCP) socket with
+    ``remote_subscribe_port = get_open_port()``, which *probes a port and
+    releases it*, and only binds it with ZMQ several statements later
+    (``shm_broadcast.py``: ``self.remote_socket.bind(socket_addr)``). The
+    window between the probe and the bind is a TOCTOU race.
+
+    On vLLM 0.25 that race is lost reliably, not occasionally. Every
+    ``RayWorkerProc`` on a **non-driver** node takes ``n_local_reader=0``
+    (``ray_executor_v2.py::_init_message_queues``), so every one of them needs
+    a real TCP port, and they all scan from the same ``VLLM_PORT`` -- 7000 for
+    a node-spanning engine. ``_init_message_queues`` runs immediately after
+    ``init_device()``, whose process-group setup is a collective barrier, so
+    all workers on the node arrive at the probe within microseconds of each
+    other, all see the same port free, and all but one die with::
+
+        zmq.error.ZMQError: Address already in use (addr='tcp://10.65.1.9:7000')
+
+    Workers on the driver node take ``n_local_reader=1`` and use an ``ipc://``
+    socket instead, which is why only node-spanning engines are affected --
+    and why no nightly test catches it (none runs an engine whose
+    ``tensor_parallel_size * pipeline_parallel_size`` exceeds
+    ``cluster.gpus_per_node``). See RL-1111.
+
+    Fix the race at the bind rather than the probe: retry, advancing past the
+    port that was lost. This is safe and terminating because a port a peer
+    already holds with ZMQ *is* visible to the next ``_get_open_port`` probe
+    (a plain ``bind(("", port))`` on it fails with ``EADDRINUSE``), so each
+    retry makes forward progress.
+
+    Deliberately keeps the search anchored at ``VLLM_PORT`` instead of letting
+    vLLM fall back to ``bind(("", 0))``: kernel-assigned ephemeral ports are
+    exactly the TOCTOU contention the reserved sub-ephemeral band exists to
+    prevent (#2380, #3103).
+
+    Patching the bind (rather than handing each worker a private start port)
+    also covers every other ``MessageQueue`` with a remote reader -- notably
+    the executor's own ``rpc_broadcast_mq`` -- instead of the one call site
+    that happens to be failing today.
+
+    Returns without raising when the snippet is missing, but logs at warning
+    level so a silent no-op is visible in worker logs.
+    """
+    try:
+        file_to_patch = _get_vllm_file(
+            "distributed/device_communicators/shm_broadcast.py"
+        )
+    except RuntimeError:
+        logger.warning(
+            "Could not locate shm_broadcast.py; MessageQueue bind-retry patch "
+            "NOT applied. Engines spanning nodes may fail with EADDRINUSE at "
+            "startup."
+        )
+        return
+
+    marker = "_nrl_bind_attempts"
+    old_snippet = (
+        '            socket_addr = f"tcp://{connect_ip}:{remote_subscribe_port}"\n'
+        "            self.remote_socket.bind(socket_addr)\n"
+    )
+    new_snippet = (
+        "            # NeMo-RL: get_open_port() above probed this port and then\n"
+        "            # released it; ZMQ only binds it for real here. Every worker\n"
+        "            # on a non-driver node builds its response queue at the same\n"
+        "            # instant (init_device()'s collective releases them together)\n"
+        "            # scanning from the same VLLM_PORT, so they all probe the same\n"
+        "            # free port and all but one die with EADDRINUSE. Retry around\n"
+        "            # the bind instead of trusting the probe: a port a peer already\n"
+        "            # holds IS visible to the next probe, so advancing past the\n"
+        "            # loser terminates. Ports stay in the reserved VLLM_PORT band\n"
+        "            # rather than falling back to kernel-ephemeral ones, which is\n"
+        "            # the contention that band exists to avoid (#2380, #3103).\n"
+        "            _nrl_bind_attempts = 64\n"
+        "            for _nrl_bind_attempt in range(_nrl_bind_attempts):\n"
+        '                socket_addr = f"tcp://{connect_ip}:{remote_subscribe_port}"\n'
+        "                try:\n"
+        "                    self.remote_socket.bind(socket_addr)\n"
+        "                    break\n"
+        "                except zmq.ZMQError:\n"
+        "                    if _nrl_bind_attempt == _nrl_bind_attempts - 1:\n"
+        "                        raise\n"
+        "                    from vllm.utils.network_utils import _get_open_port\n"
+        "\n"
+        "                    logger.info(\n"
+        '                        "Port %s was taken between probe and bind; '
+        'retrying.",\n'
+        "                        remote_subscribe_port,\n"
+        "                    )\n"
+        "                    remote_subscribe_port = (\n"
+        "                        _get_open_port(start_port=remote_subscribe_port + 1)\n"
+        "                        if envs.VLLM_PORT is not None\n"
+        "                        else get_open_port()\n"
+        "                    )\n"
+    )
+
+    with _locked_file_patch(file_to_patch) as (content, write_back):
+        if marker in content:
+            logger.info("vLLM MessageQueue bind-retry patch already applied.")
+            return
+
+        if old_snippet not in content:
+            logger.warning(
+                "Could not apply MessageQueue bind-retry patch: expected "
+                "snippet not found in %s. The vLLM version may have changed. "
+                "Engines spanning nodes may fail with EADDRINUSE at startup.",
+                file_to_patch,
+            )
+            return
+
+        content = content.replace(old_snippet, new_snippet, 1)
+        write_back(content)
+
+    # Read back so a patch that silently failed to land is not reported as
+    # applied; this is the failure mode that previously went unnoticed.
+    try:
+        with open(file_to_patch) as handle:
+            applied = marker in handle.read()
+    except OSError as error:
+        logger.warning("Could not verify MessageQueue bind-retry patch: %s", error)
+        return
+
+    if applied:
+        logger.info("Successfully patched vLLM MessageQueue remote socket bind.")
+    else:
+        logger.warning(
+            "MessageQueue bind-retry patch did not persist to %s. Engines "
+            "spanning nodes may fail with EADDRINUSE at startup.",
+            file_to_patch,
+        )
+
+
 def ensure_vllm_source_compat() -> None:
     """Apply interpreter-independent vLLM source-compat patches.
 
@@ -357,3 +490,4 @@ def _apply_vllm_patches(
     _patch_vllm_llama_eagle3_own_lm_head(patch_logger)
     _patch_vllm_tool_parser_namespace_tool(patch_logger)
     _patch_vllm_ray_executor_v2_tcpstore_port(patch_logger)
+    _patch_vllm_shm_broadcast_bind_retry(patch_logger)

--- a/tests/unit/models/generation/test_vllm_message_queue_port.py
+++ b/tests/unit/models/generation/test_vllm_message_queue_port.py
@@ -1,0 +1,237 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for the MessageQueue remote-socket bind patch (RL-1111).
+
+``MessageQueue.__init__`` picks the port for its remote (TCP) socket with
+``get_open_port()``, which binds a probe socket, *releases it*, and returns the
+number; ZMQ only binds the port for real several statements later. Every
+``RayWorkerProc`` on a non-driver node takes ``n_local_reader=0`` and so needs
+one of these TCP ports, and they all scan from the same ``VLLM_PORT``. Because
+``_init_message_queues`` runs immediately after ``init_device()`` -- whose
+process-group setup is a collective barrier -- the workers on a node arrive at
+the probe together, all see the same port free, and all but one die with
+``zmq.error.ZMQError: Address already in use``.
+
+Workers on the *driver* node use an ``ipc://`` socket instead and never take a
+TCP port, so only an engine spanning >= 2 nodes can hit this -- and no nightly
+test runs one (none has ``tensor_parallel_size * pipeline_parallel_size >
+cluster.gpus_per_node``). These tests reproduce the race with plain processes,
+so it is covered without a GPU or a second node.
+"""
+
+import ast
+import logging
+import multiprocessing as mp
+import shutil
+import socket
+from pathlib import Path
+
+import pytest
+
+from nemo_rl.models.generation.vllm import patches
+
+pytestmark = pytest.mark.vllm
+
+_VLLM_MQ_SOURCE = "distributed/device_communicators/shm_broadcast.py"
+_MARKER = "_nrl_bind_attempts"
+# Enough concurrent binders that a lost race is essentially certain: unpatched,
+# this leaves 6 of 8 workers dead.
+_RACERS = 8
+_LOOPBACK = "127.0.0.1"
+
+
+def _find_free_port_band(width: int) -> int:
+    """Return a base port with `width` consecutive bindable ports above it."""
+    for _ in range(100):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.bind(("", 0))
+            base = probe.getsockname()[1]
+        held = []
+        try:
+            for offset in range(width):
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.bind(("", base + offset))
+                held.append(sock)
+        except OSError:
+            continue
+        finally:
+            for sock in held:
+                sock.close()
+        return base
+    pytest.skip("could not find a free port band for the test")
+
+
+def _load_message_queue(source_path: Path):
+    """Import `source_path` as a standalone module and return its MessageQueue.
+
+    Loaded from the file rather than from ``vllm`` so the test exercises the
+    exact bytes the worker patches on disk. Every import inside the file is
+    absolute, so it loads cleanly under a private module name.
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        f"nrl_test_shm_broadcast_{source_path.parent.name}", source_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.MessageQueue
+
+
+def _bind_racer(message_queue_cls, ready, hold, results, index: int) -> None:
+    """One worker: build a remote-reader MessageQueue, then hold its port."""
+    ready.wait(timeout=120)  # stands in for the init_device() collective
+    try:
+        queue = message_queue_cls(n_reader=1, n_local_reader=0, connect_ip=_LOOPBACK)
+        results.put((index, queue.handle.remote_subscribe_addr))
+    except Exception as error:  # noqa: BLE001 - the failure under test
+        results.put((index, f"ERROR {type(error).__name__}: {error}"))
+        queue = None
+    # A real RayWorkerProc keeps its response queue for the engine's lifetime.
+    # Returning here would drop the socket and free the port mid-race, letting a
+    # straggler legitimately reuse it and masking a genuine collision.
+    try:
+        hold.wait(timeout=120)
+    except Exception:  # noqa: BLE001 - a crashed peer breaks the barrier
+        pass
+    del queue
+
+
+def _race(message_queue_cls, racers: int = _RACERS) -> list[str]:
+    """Build `racers` MessageQueues at once; return each one's result string."""
+    # fork so the children inherit the already-loaded module object under test;
+    # spawn would re-import vLLM per child and cannot carry it across.
+    ctx = mp.get_context("fork")
+    ready, hold = ctx.Barrier(racers), ctx.Barrier(racers)
+    results = ctx.Queue()
+
+    procs = [
+        ctx.Process(
+            target=_bind_racer, args=(message_queue_cls, ready, hold, results, index)
+        )
+        for index in range(racers)
+    ]
+    for proc in procs:
+        proc.start()
+    collected = dict(results.get(timeout=180) for _ in range(racers))
+    for proc in procs:
+        proc.join(timeout=180)
+    return [collected[index] for index in range(racers)]
+
+
+@pytest.fixture
+def pristine_source(tmp_path) -> Path:
+    """A copy of the installed vLLM shm_broadcast.py, unpatched."""
+    installed = Path(patches._get_vllm_file(_VLLM_MQ_SOURCE))
+    copied = tmp_path / "pristine" / "shm_broadcast.py"
+    copied.parent.mkdir()
+    shutil.copy(installed, copied)
+    return copied
+
+
+@pytest.fixture
+def patched_source(tmp_path, monkeypatch) -> Path:
+    """The same copy after the NeMo-RL MessageQueue bind patch is applied."""
+    installed = Path(patches._get_vllm_file(_VLLM_MQ_SOURCE))
+    copied = tmp_path / "patched" / "shm_broadcast.py"
+    copied.parent.mkdir()
+    shutil.copy(installed, copied)
+    monkeypatch.setattr(patches, "_get_vllm_file", lambda _relative: str(copied))
+    patches._patch_vllm_shm_broadcast_bind_retry(logging.getLogger(__name__))
+    return copied
+
+
+@pytest.fixture
+def reserved_band(monkeypatch) -> int:
+    """Point VLLM_PORT at a free band, as configure_worker does for an engine."""
+    import vllm.envs as envs
+
+    # Another test in this process may have frozen envs after a fake init.
+    if hasattr(envs, "disable_envs_cache"):
+        envs.disable_envs_cache()
+    base = _find_free_port_band(_RACERS * 2)
+    monkeypatch.setenv("VLLM_PORT", str(base))
+    return base
+
+
+def test_patch_anchor_still_matches_installed_vllm(patched_source):
+    """The patch is a source edit, so an upstream rename makes it a silent no-op."""
+    assert _MARKER in patched_source.read_text(), (
+        "the MessageQueue bind-retry patch did not apply to the installed vLLM; "
+        "its anchor snippet has probably changed upstream"
+    )
+    ast.parse(patched_source.read_text())  # the edit must leave valid Python
+
+
+def test_patch_is_idempotent(patched_source, monkeypatch):
+    """Every worker on a node runs the patch against the same file."""
+    before = patched_source.read_text()
+    monkeypatch.setattr(
+        patches, "_get_vllm_file", lambda _relative: str(patched_source)
+    )
+    patches._patch_vllm_shm_broadcast_bind_retry(logging.getLogger(__name__))
+    assert patched_source.read_text() == before
+
+
+def test_probe_releases_the_port_it_returns(reserved_band):
+    """The root cause, without a race: the probe does not hold what it hands out."""
+    from vllm.utils.network_utils import get_open_port
+
+    # Two independent callers -- i.e. two workers on the same node -- are handed
+    # the same port, because nothing is holding it between the calls.
+    assert get_open_port() == get_open_port() == reserved_band
+
+
+def test_unpatched_message_queue_loses_the_port_race(pristine_source, reserved_band):
+    """Documents the bug: concurrent workers collide on one port."""
+    outcomes = _race(_load_message_queue(pristine_source))
+    failures = [outcome for outcome in outcomes if outcome.startswith("ERROR")]
+    if not failures:
+        pytest.skip("the port race did not materialize on this machine")
+    assert any("Address already in use" in failure for failure in failures)
+
+
+def test_patched_message_queue_survives_the_port_race(patched_source, reserved_band):
+    """The fix: every worker binds, on its own port, inside the reserved band."""
+    from nemo_rl.distributed.virtual_cluster import DEFAULT_VLLM_PORTS_PER_ENGINE
+
+    outcomes = _race(_load_message_queue(patched_source))
+
+    assert not [outcome for outcome in outcomes if outcome.startswith("ERROR")], (
+        f"workers failed to bind their response queue: {outcomes}"
+    )
+    ports = [int(outcome.rsplit(":", 1)[1]) for outcome in outcomes]
+    assert len(set(ports)) == _RACERS, f"workers share a port: {sorted(ports)}"
+    # Ports must stay below the OS ephemeral floor (as low as 9000 on GB200);
+    # falling back to kernel-assigned ports is the contention #2380 fixed.
+    assert all(
+        reserved_band <= port < reserved_band + DEFAULT_VLLM_PORTS_PER_ENGINE
+        for port in ports
+    ), f"ports escaped the engine's reserved band: {sorted(ports)}"
+
+
+def test_patched_message_queue_still_works_without_vllm_port(
+    patched_source, monkeypatch
+):
+    """Without VLLM_PORT there is no reserved band; keep vLLM's own behaviour."""
+    import vllm.envs as envs
+
+    if hasattr(envs, "disable_envs_cache"):
+        envs.disable_envs_cache()
+    monkeypatch.delenv("VLLM_PORT", raising=False)
+
+    message_queue_cls = _load_message_queue(patched_source)
+    queue = message_queue_cls(n_reader=1, n_local_reader=0, connect_ip=_LOOPBACK)
+    assert queue.handle.remote_subscribe_addr.startswith(f"tcp://{_LOOPBACK}:")


### PR DESCRIPTION
Fixes [RL-1111](https://linear.app/nvidia/issue/RL-1111). Stacked on #3280 (the vLLM 0.25.1 bump) — base is `terryk/bump-vllm-0.25.1`, not `main`.

Follow-on to #3350 (RL-1104). That fix was a prerequisite for *seeing* this one: with the TCPStore collision gone, engine startup gets one step further and then hits this.

## The bug

Every non-driver-node worker of a node-spanning engine dies at startup:

```
zmq.error.ZMQError: Address already in use (addr='tcp://10.65.1.9:7000')
     [repeated 563x across cluster]
```

## Root cause

`MessageQueue.__init__` picks the port for its remote (TCP) socket by *probing and releasing* it, then binds it with ZMQ several statements later:

```python
remote_subscribe_port = get_open_port()   # binds ("", port), CLOSES it, returns the number
...
self.remote_socket.bind(f"tcp://{connect_ip}:{remote_subscribe_port}")   # binds for real
```

That gap is a TOCTOU race, and on a non-driver node it is lost *reliably* rather than occasionally:

- `RayWorkerProc._init_message_queues` gives workers on the **driver** node `n_local_reader=1` → an `ipc://` socket, **no TCP port**. Workers on **every other** node get `n_local_reader=0` → a **TCP port**.
- All of them scan upward from the same `$VLLM_PORT` (7000 for a node-spanning engine, via `configure_worker`'s node-local slot 0).
- `_init_message_queues` runs immediately after `init_device()`, whose process-group setup is a **collective barrier** — so every worker on the node reaches the probe within microseconds of the others, all see 7000 free, and all but one die.

Only engines with `tensor_parallel_size * pipeline_parallel_size > cluster.gpus_per_node` are affected, which is exactly why nothing caught it: **zero** of the 140 nightly tests run a node-spanning engine.

## The fix

Retry at the bind rather than trusting the probe, advancing past the port that was lost.

Two properties make this small and safe, both verified empirically rather than assumed:

1. A port a peer already holds with ZMQ **is** visible to the next `_get_open_port` probe (a plain `bind(("", port))` on it fails `EADDRINUSE`), so each retry makes forward progress and the loop terminates.
2. A ZMQ socket **is** re-bindable after a failed bind, so no fresh socket per attempt is needed.

Ports stay anchored at `VLLM_PORT` instead of falling back to `bind(("", 0))` — kernel-ephemeral ports are precisely the contention the reserved sub-ephemeral band exists to prevent (#2380, #3103).

Patching the bind rather than handing each worker a private start port also covers every other `MessageQueue` with a remote reader — including the executor's own `rpc_broadcast_mq`, the queue involved in RL-1104 — instead of only the call site failing today.

## Validation

The mechanism is pure port arithmetic, so it reproduces with plain processes against the **real vLLM 0.25.1 `MessageQueue`** — no GPU, no Ray, no second node. A `multiprocessing.Barrier` stands in for the `init_device()` collective.

| racers | unpatched | patched |
| -- | -- | -- |
| 8 | **6/8 die**, 3/3 runs | **8/8 bind**, ports 7000–7007, 16/16 runs |
| 32 | **30/32 die**, 3/3 runs | **32/32 bind**, ports 7000–7031, 3/3 runs |

Failure signature matches CI exactly: `ZMQError: Address already in use (addr='tcp://…:7000')` raised from the same line.

Checked in as `tests/unit/models/generation/test_vllm_message_queue_port.py` (6 tests, 6s, no GPU), giving node-spanning engine startup its first automated coverage. `test_unpatched_message_queue_loses_the_port_race` **passes rather than skips** in CI-like conditions, so the patched test is not vacuous. The neighbouring RL-1104 suite still passes (12/12 together).

## Does the patch reach non-driver nodes?

Yes — this was flagged as a genuine unknown in RL-1111, since #3350 only proved the mechanism reaches the *executor* process. Resolved by reading the code:

- `patches.py` rewrites vLLM **on disk**, in the node-local venv.
- `_apply_vllm_patches` runs in `VllmGenerationWorker.__init__` on **every** worker, including the non-model-owner secondaries that exist on every node the engine spans.
- `RayWorkerGroup` blocks on `ray.get` until **all** worker `__init__`s return, so every node's venv is patched before `_load_model`/`_post_init` creates the engine that spawns the `RayWorkerProc` actors.
- Those actors inherit the parent's `py_executable` runtime_env, so they import the patched venv.

## Not covered here

- **Not yet run on a real node-spanning recipe.** Expected next failure there is the pre-existing refit-buffer assertion (`embed_tokens.weight too large for buffer`), which also fails on `main` with vLLM 0.20 — so a green DSv3 run is not the success criterion for this PR.
- The code is **byte-identical on vLLM `main`**, so this is an upstream bug. An upstream PR is worth filing; this patch is the local fix regardless.
- Ports walk into the TCPStore window (`VLLM_PORT+32..+63`) only past 32 workers on one node. They cannot collide: the TCPStore binds on the **driver** node, and these response queues only exist on **non-driver** nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)