### PR TITLE
fix: Qwen3.5-397B training stability and async-GRPO robustness

### DIFF
--- a/nemo_rl/algorithms/async_utils/replay_buffer.py
+++ b/nemo_rl/algorithms/async_utils/replay_buffer.py
@@ -186,10 +186,11 @@ class ReplayBufferImpl(ReplayBufferProtocol):
     ) -> Optional[dict[str, Any]]:
         """Sample per-prompt trajectory groups intended for the current training step.
 
-        Only returns trajectories with target_weight_version == current_weight_version.
-        If insufficient trajectories are available, returns None to stall training
-        until the remaining trajectories are generated. This ensures no trajectory
-        loses its last chance to be used for its intended training step.
+        Only returns trajectories with target_weight_version >= current_weight_version,
+        so trajectories staged for a future step may be consumed early instead of
+        stalling. If insufficient trajectories are available, returns None to stall
+        training until the remaining trajectories are generated. This ensures no
+        trajectory loses its last chance to be used for its intended training step.
 
         Returns:
             Dictionary with 'trajectories' and 'avg_trajectory_age' keys, or None if insufficient data
@@ -252,7 +253,7 @@ class ReplayBufferImpl(ReplayBufferProtocol):
             intended_indices = [
                 i
                 for i in valid_indices
-                if self.target_weight_versions[i] == current_weight_version
+                if self.target_weight_versions[i] >= current_weight_version
             ]
 
             print(
@@ -283,8 +284,10 @@ class ReplayBufferImpl(ReplayBufferProtocol):
                 f"✅ Selected counts by generation weight-version: {Counter(sampled_weights)}"
             )
             print(f"📊 Average trajectory age: {avg_trajectory_age:.2f} steps")
+            sampled_targets = Counter(self.target_weight_versions[i] for i in selected)
             print(
-                f"🎯 All selected trajectories target step {current_weight_version} (100% target match)"
+                f"🎯 Selected trajectory targets for step {current_weight_version}: "
+                f"{dict(sampled_targets)}"
             )
 
             # Remove selected items in reverse order to maintain correct indices

--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -792,6 +792,10 @@ class AsyncTrajectoryCollector:
                 greedy=False,
                 reward_penalty_config=self.master_config.reward_penalties,
                 thinking_tags=get_nemo_gym_thinking_tags(self.master_config.env),
+                mask_env_flagged_samples=self.master_config.grpo.get(
+                    "mask_env_flagged_samples"
+                )
+                is not False,
             ):
                 task_index = rollout_result.task_index
                 if task_index is None:

--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -281,43 +281,51 @@ class AsyncTrajectoryCollector:
                 if not self.running:
                     break
 
-                # Check if manually paused and wait
-                if not self._manual_pause_cleared.is_set() and self.running:
-                    self._manual_pause_cleared.wait()
+                # Wait until NO pause condition holds, re-checking every
+                # condition after each wake-up: sequential checks race with
+                # pause() at validation boundaries and let full batches launch
+                # into the validation window.
+                while self.running:
+                    if not self._manual_pause_cleared.is_set():
+                        self._manual_pause_cleared.wait()
+                        continue  # re-check all conditions after waking
 
-                # Check if refit is in progress and wait
-                if not self._refit_pause_cleared.is_set() and self.running:
-                    print("⏸️ Pausing collection for refit...")
-                    with self._efficiency_timer.time("idle/refit_event_wait"):
-                        self._refit_pause_cleared.wait()
-                    print("▶️ Refit completed, resuming collection")
+                    if not self._refit_pause_cleared.is_set():
+                        print("⏸️ Pausing collection for refit...")
+                        with self._efficiency_timer.time("idle/refit_event_wait"):
+                            self._refit_pause_cleared.wait()
+                        print("▶️ Refit completed, resuming collection")
+                        continue  # re-check all conditions after waking
 
-                # Check if generation limits require pausing collection
-                if self._should_pause_for_generation_limits() and self.running:
-                    # Only log warning once per weight version
-                    if self._last_limit_warning_version != self.current_weight_version:
-                        async_cfg = self.master_config.grpo.get("async_grpo", {})
-                        max_trajectory_age = async_cfg["max_trajectory_age_steps"]
-                        target_weights = [
-                            self.current_weight_version + i
-                            for i in range(max_trajectory_age)
-                        ]
+                    if self._should_pause_for_generation_limits():
+                        # Only log warning once per weight version
+                        if (
+                            self._last_limit_warning_version
+                            != self.current_weight_version
+                        ):
+                            async_cfg = self.master_config.grpo.get("async_grpo", {})
+                            max_trajectory_age = async_cfg["max_trajectory_age_steps"]
+                            target_weights = [
+                                self.current_weight_version + i
+                                for i in range(max_trajectory_age)
+                            ]
 
-                        print(
-                            f"⏸️ Pausing collection: all target weights {target_weights} for weight version {self.current_weight_version} "
-                            f"already exist in buffer. Waiting for weight update..."
-                        )
-                        self._last_limit_warning_version = self.current_weight_version
+                            print(
+                                f"⏸️ Pausing collection: all target weights {target_weights} for weight version {self.current_weight_version} "
+                                f"already exist in buffer. Waiting for weight update..."
+                            )
+                            self._last_limit_warning_version = (
+                                self.current_weight_version
+                            )
 
-                        self._generation_limit_cleared.clear()  # Clear the event to pause
+                            self._generation_limit_cleared.clear()  # Clear the event to pause
 
-                    # Efficiently wait for generation limits to be cleared (no polling!)
-                    with self._efficiency_timer.time("idle/generation_limit_pause"):
-                        self._generation_limit_cleared.wait()
+                        # Efficiently wait for generation limits to be cleared (no polling!)
+                        with self._efficiency_timer.time("idle/generation_limit_pause"):
+                            self._generation_limit_cleared.wait()
+                        continue  # re-check all conditions after waking
 
-                    # Double-check we're still running after being woken up
-                    if not self.running:
-                        break
+                    break  # nothing requires pausing; clear to launch
 
                 if not self.running:
                     break
@@ -415,6 +423,12 @@ class AsyncTrajectoryCollector:
             from nemo_rl.algorithms.grpo import _should_use_nemo_gym
 
             use_nemo_gym = _should_use_nemo_gym(self.master_config)
+
+            # Honor a manual pause (e.g. a validation boundary) before
+            # spawning, so the batch cannot launch into the val window.
+            if not self._manual_pause_cleared.is_set() and self.running:
+                print("⏸️ Manual pause before batch spawn: holding launch")
+                self._manual_pause_cleared.wait()
 
             if not self._refit_pause_cleared.is_set() and self.running:
                 with self._threads_lock:
@@ -550,6 +564,10 @@ class AsyncTrajectoryCollector:
         # Invalidate&recompute vLLM caches after the in-flight weight updates if
         # recompute_kv_cache_after_weight_updates is True (AREAL-style implementation).
         # Otherwise, keep using the stale KV caches (Magistral-style implementation).
+        # NOTE: for drained (non-in-flight) refits with prefix caching enabled,
+        # cache invalidation is handled unconditionally in
+        # refit_policy_generation (grpo.py), which also covers the
+        # pre-validation refit path that never reaches this method.
         async_cfg = self.master_config.grpo.get("async_grpo", {})
         if async_cfg.get("in_flight_weight_updates", False) and async_cfg.get(
             "recompute_kv_cache_after_weight_updates", False

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -322,6 +322,9 @@ class GRPOConfig(TypedDict):
     validation_generation: NotRequired[ValidationGenerationConfig | None]
     # Number of independent validation rollouts generated for each prompt.
     num_val_generations_per_prompt: NotRequired[int]
+    # Set false to keep env-driven mask_sample flags out of async NeMo-Gym
+    # rollout batches; absent/true keeps the upstream loss-masking behavior.
+    mask_env_flagged_samples: NotRequired[bool]
     skip_reference_policy_logprobs_calculation: NotRequired[bool]
     seed: int
     async_grpo: NotRequired[AsyncGRPOConfig]
@@ -2882,6 +2885,10 @@ def grpo_train(
                             effort_config=_get_effort_config(master_config),
                             reward_penalty_config=master_config.reward_penalties,
                             thinking_tags=get_nemo_gym_thinking_tags(master_config.env),
+                            mask_env_flagged_samples=master_config.grpo.get(
+                                "mask_env_flagged_samples"
+                            )
+                            is not False,
                         )
                         input_ids = nemo_gym_rollout_result.input_ids
                         repeated_batch = nemo_gym_rollout_result.final_batch
@@ -3846,6 +3853,10 @@ def validate(
                     reward_penalty_config=master_config.reward_penalties,
                     thinking_tags=get_nemo_gym_thinking_tags(master_config.env),
                     mark_validation_request=validation_generation_config is not None,
+                    mask_env_flagged_samples=master_config.grpo.get(
+                        "mask_env_flagged_samples"
+                    )
+                    is not False,
                 )
                 val_batch = nemo_gym_rollout_result.final_batch
                 gen_metrics = nemo_gym_rollout_result.rollout_metrics

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -18,7 +18,16 @@ import time
 import warnings
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import nullcontext
-from typing import Any, Callable, NotRequired, Optional, TypedDict, TypeVar, cast
+from typing import (
+    Any,
+    Callable,
+    NotRequired,
+    Optional,
+    Protocol,
+    TypedDict,
+    TypeVar,
+    cast,
+)
 
 import numpy as np
 import ray
@@ -245,6 +254,48 @@ _REWARD_PENALTY_FLAGS = (
 )
 
 
+class TrainTelemetryHooks(Protocol):
+    """Benchmark/telemetry hooks observed by the train loops.
+
+    Implementations are injected by launch stacks (e.g. MLPerf compliance
+    logging); the train loops only call these when a logger is provided.
+    """
+
+    target_reached: bool
+
+    def start_train_block(self, step: int) -> None: ...
+
+    def observe_metrics(
+        self, metrics: dict[str, Any], step: int, prefix: str = ""
+    ) -> None: ...
+
+    def start_eval(self, step: int) -> None: ...
+
+    def end_eval(
+        self,
+        step: int,
+        val_metrics: Optional[dict[str, Any]],
+        validation_timings: Optional[dict[str, Any]],
+    ) -> None: ...
+
+    def end_eval_with_error(self, step: int) -> None: ...
+
+    def log_init_stop_run_start(self) -> None: ...
+
+    def finalize(self) -> None: ...
+
+
+class ValidationGenerationConfig(TypedDict):
+    """Optional validation-only sampling parameters.
+
+    These fields override policy.generation only while validation rollouts are
+    being generated. Training rollouts continue to use policy.generation.
+    """
+
+    temperature: float
+    top_p: float
+
+
 class GRPOConfig(TypedDict):
     num_prompts_per_step: int
     num_generations_per_prompt: int
@@ -259,12 +310,18 @@ class GRPOConfig(TypedDict):
     advantage_clip_high: NotRequired[float | None]
     use_leave_one_out_baseline: bool
     val_period: int
+    # Earliest training step eligible for periodic validation.
+    # First step eligible for periodic validation; absent means no delay.
+    val_start_at: NotRequired[int]
     val_batch_size: int | None  # None for NeMo-Gym compatibility
     val_at_start: bool
     # Whether to run validation on the last training step. Setting this to True ensures the
     # final checkpoint has validation metrics, which is required for get_best_checkpoint_path().
     val_at_end: bool
     max_val_samples: int | None  # None for NeMo-Gym compatibility
+    validation_generation: NotRequired[ValidationGenerationConfig | None]
+    # Number of independent validation rollouts generated for each prompt.
+    num_val_generations_per_prompt: NotRequired[int]
     skip_reference_policy_logprobs_calculation: NotRequired[bool]
     seed: int
     async_grpo: NotRequired[AsyncGRPOConfig]
@@ -394,6 +451,10 @@ def setup(
     )
     if generation_config["backend"] == "vllm":
         normalize_vllm_refit_config(cast(VllmConfig, generation_config))
+
+    validation_generation_config = grpo_config.get("validation_generation", None)
+    if validation_generation_config is not None:
+        generation_config["_validation_generation"] = dict(validation_generation_config)
 
     # Set seed for all random number generators
     set_seed(grpo_config["seed"])
@@ -1688,6 +1749,25 @@ def scale_rewards(
     return repeated_batch
 
 
+def _stable_group_ids(prompt_ids_for_adv, num_generations_per_prompt):
+    """Stable per-prompt grouping key for GRPO advantage computation.
+
+    GRPO groups samples by prompt (torch.unique) to compute the leave-one-out baseline. The default
+    key is the rendered prompt token-ids, but for agentic gym rollouts each generation's first-turn
+    prompt tokenizes slightly differently (observed on Qwen3-Instruct + hermes: every generation
+    becomes its own singleton group -> leave-one-out baseline == reward -> advantage == 0 -> zero
+    gradient; Exp 26). The training batch is laid out as contiguous num_gen blocks per prompt
+    (async: BatchedDataDict.from_batches of per-prompt groups; sync: repeat_interleave), so the
+    correct, model-agnostic group id is positional: index // num_gen. Falls back to the original
+    token-id grouping if the batch is not an exact multiple of num_gen (e.g. dynamic sampling).
+    """
+    n = int(prompt_ids_for_adv.shape[0])
+    g = int(num_generations_per_prompt)
+    if g <= 0 or n % g != 0:
+        return prompt_ids_for_adv
+    return (torch.arange(n, device=prompt_ids_for_adv.device) // g).unsqueeze(1)
+
+
 def extract_initial_prompt_messages(
     message_logs: list,
     original_prompt_lengths: torch.Tensor,
@@ -2218,7 +2298,9 @@ def refit_policy_generation(
     """
     synchronizer = getattr(policy_generation, "weight_synchronizer", None)
     if synchronizer is not None:
-        return synchronizer.sync_weights(timer=timer, kv_scales=kv_scales) or {}
+        sync_metrics = synchronizer.sync_weights(timer=timer, kv_scales=kv_scales) or {}
+        _invalidate_prefix_cache_after_refit(policy_generation)
+        return sync_metrics
 
     # Megatron generation backend needs explicit suspend/resume around refits.
     if isinstance(policy_generation, MegatronGeneration):
@@ -2321,10 +2403,34 @@ def refit_policy_generation(
     if colocated_inference or isinstance(policy_generation, MegatronGeneration):
         policy_generation.prepare_for_generation(tags=["kv_cache"])
 
+    _invalidate_prefix_cache_after_refit(policy_generation)
+
     if isinstance(policy_generation, MegatronGeneration):
         policy_generation.resume_after_refit()
 
     return {}
+
+
+def _invalidate_prefix_cache_after_refit(
+    policy_generation: GenerationInterface,
+) -> None:
+    """Drop reusable KV blocks after a weight update.
+
+    vLLM prefix-cache blocks are keyed only by token ids, so blocks
+    prefilled under the old weights would be silently reused after refit
+    (stale KV -> train/gen logprob divergence). Called on every refit path;
+    backends without reusable caches inherit the no-op interface default.
+    """
+    generation_cfg = getattr(policy_generation, "cfg", None) or {}
+    vllm_cfg = generation_cfg.get("vllm_cfg") or {}
+    if vllm_cfg.get("enable_prefix_caching"):
+        if not policy_generation.invalidate_kv_cache():
+            raise RuntimeError(
+                "❌ Error: prefix caching is enabled but invalidating the "
+                "vLLM prefix/KV cache after refit failed; continuing would "
+                "sample rollouts against stale KV computed under the "
+                "pre-refit weights."
+            )
 
 
 def _initial_policy_generation_stale(
@@ -2450,6 +2556,30 @@ def compute_and_apply_seq_logprob_error_masking(
             )
             masked_correct_pct = masked_correct_count / num_masked_seqs
 
+            # [lp-mask-debug] one parseable line per step attributing train/gen
+            # logprob divergence; opt in via NRL_LP_MASK_DEBUG=1.
+            if os.environ.get("NRL_LP_MASK_DEBUG") == "1":
+                seq_lens = mask.sum(dim=-1)
+                masked_rows = [
+                    (
+                        int(seq_lens[i]),
+                        float(seq_mult_prob_error[i]),
+                        float(rewards.view(-1)[i]),
+                    )
+                    for i in torch.nonzero(diff_mask_bool).flatten().tolist()
+                ]
+                kept_bool = seq_error_mask.bool() & valid_seq_mask
+                kept_lens = seq_lens[kept_bool]
+                print(
+                    "[lp-mask-debug] masked(len,err,rew)="
+                    + ";".join(f"{l},{e:.2f},{r:.0f}" for l, e, r in masked_rows[:200])
+                    + f" | kept_len mean={float(kept_lens.float().mean()):.0f}"
+                    f" p90={float(kept_lens.float().quantile(0.9)):.0f}"
+                    f" max={int(kept_lens.max())}"
+                    f" | masked_len mean={sum(r[0] for r in masked_rows) / len(masked_rows):.0f}",
+                    flush=True,
+                )
+
         # Compute after-mask metrics (only for sequences that passed the threshold)
         kept_mask = seq_error_mask.bool() & valid_seq_mask
         if kept_mask.sum() > 0:
@@ -2507,6 +2637,7 @@ def grpo_train(
     checkpointer: CheckpointManager,
     grpo_save_state: GRPOSaveState,
     master_config: MasterConfig,
+    mlperf_logger: Optional[TrainTelemetryHooks] = None,
 ) -> None:
     """Run GRPO training algorithm."""
     timer = Timer(context={"worker": "driver"})
@@ -2551,11 +2682,15 @@ def grpo_train(
     val_at_start = master_config.grpo["val_at_start"]
     val_at_end = master_config.grpo["val_at_end"]
     val_period = master_config.grpo["val_period"]
+    val_start_at = master_config.grpo.get("val_start_at", None)
     colocated_inference = master_config.policy["generation"]["colocated"]["enabled"]
     refit_buffer_size_gb = master_config.policy.get("refit_buffer_size_gb")
 
     # Initialize advantage estimator
     adv_estimator = _create_advantage_estimator(master_config)
+
+    if mlperf_logger is not None:
+        mlperf_logger.log_init_stop_run_start()
 
     # Run validation at the start if configured
     # TODO: Add validation with kv scales if needed
@@ -2573,18 +2708,31 @@ def grpo_train(
             POLICY_GENERATION_STALE = False
         else:
             policy_generation.prepare_for_generation()
-        val_metrics, validation_timings = validate(
-            policy_generation,
-            val_dataloader,
-            tokenizer,
-            val_task_to_env,
-            step=0,
-            master_config=master_config,
-            logger=logger,
-        )
+        if mlperf_logger is not None:
+            mlperf_logger.start_eval(0)
+        try:
+            val_metrics, validation_timings = validate(
+                policy_generation,
+                val_dataloader,
+                tokenizer,
+                val_task_to_env,
+                step=0,
+                master_config=master_config,
+                logger=logger,
+            )
+        except Exception:
+            if mlperf_logger is not None:
+                mlperf_logger.end_eval_with_error(0)
+            raise
+        if mlperf_logger is not None:
+            mlperf_logger.end_eval(0, val_metrics, validation_timings)
         policy_generation.finish_generation()
         logger.log_metrics(val_metrics, current_step, prefix="validation")
         logger.log_metrics(validation_timings, current_step, prefix="timing/validation")
+        if mlperf_logger is not None and mlperf_logger.target_reached:
+            return
+    elif mlperf_logger is not None:
+        mlperf_logger.start_train_block(total_steps)
 
     if master_config.data["use_multiple_dataloader"]:
         warnings.warn(
@@ -2780,6 +2928,10 @@ def grpo_train(
                         rollout_metrics["mean_gen_tokens_per_sample"]
                     )
                     logger.log_metrics(rollout_metrics, total_steps + 1, prefix="train")
+                    if mlperf_logger is not None:
+                        mlperf_logger.observe_metrics(
+                            rollout_metrics, total_steps + 1, prefix="train"
+                        )
 
                 repeated_batch = scale_rewards(
                     repeated_batch, master_config.grpo["reward_scaling"]
@@ -3064,8 +3216,17 @@ def grpo_train(
                     sample_mask = train_data["sample_mask"]
                     mask = token_mask * sample_mask.unsqueeze(-1)
 
+                    # Positional grouping is only needed for agentic gym rollouts,
+                    # where per-generation prompt tokenization is non-deterministic;
+                    # keep main's token-id grouping for every other GRPO user.
+                    advantage_group_ids = prompt_ids_for_adv
+                    if _should_use_nemo_gym(master_config):
+                        advantage_group_ids = _stable_group_ids(
+                            prompt_ids_for_adv,
+                            master_config.grpo["num_generations_per_prompt"],
+                        )
                     train_data["advantages"] = adv_estimator.compute_advantage(
-                        prompt_ids=prompt_ids_for_adv,
+                        prompt_ids=advantage_group_ids,
                         rewards=rewards,
                         mask=mask,
                         repeated_batch=repeated_batch,
@@ -3130,9 +3291,11 @@ def grpo_train(
                     )
 
                 # Run validation if it's a validation step or last step with val_at_end
-                if (val_period > 0 and (total_steps + 1) % val_period == 0) or (
-                    val_at_end and is_last_step
-                ):
+                if (
+                    val_period > 0
+                    and (val_start_at is None or total_steps + 1 >= val_start_at)
+                    and (total_steps + 1) % val_period == 0
+                ) or (val_at_end and is_last_step):
                     memory_tracker.snapshot_start_of_stage("Validation", dir())
                     if NEED_REFIT and POLICY_GENERATION_STALE:
                         refit_metrics = refit_policy_generation(
@@ -3147,15 +3310,27 @@ def grpo_train(
                         if colocated_inference:
                             policy.offload_after_refit()  # unload optimizer to make space for generation
                         policy_generation.prepare_for_generation()
-                    val_metrics, validation_timings = validate(
-                        policy_generation,
-                        val_dataloader,
-                        tokenizer,
-                        val_task_to_env,
-                        step=total_steps + 1,
-                        master_config=master_config,
-                        logger=logger,
-                    )
+                    validation_step = total_steps + 1
+                    if mlperf_logger is not None:
+                        mlperf_logger.start_eval(validation_step)
+                    try:
+                        val_metrics, validation_timings = validate(
+                            policy_generation,
+                            val_dataloader,
+                            tokenizer,
+                            val_task_to_env,
+                            step=validation_step,
+                            master_config=master_config,
+                            logger=logger,
+                        )
+                    except Exception:
+                        if mlperf_logger is not None:
+                            mlperf_logger.end_eval_with_error(validation_step)
+                        raise
+                    if mlperf_logger is not None:
+                        mlperf_logger.end_eval(
+                            validation_step, val_metrics, validation_timings
+                        )
                     policy_generation.finish_generation()
                     logger.log_metrics(
                         validation_timings, total_steps + 1, prefix="timing/validation"
@@ -3163,6 +3338,8 @@ def grpo_train(
                     logger.log_metrics(
                         val_metrics, total_steps + 1, prefix="validation"
                     )
+                    if mlperf_logger is not None and mlperf_logger.target_reached:
+                        return
 
                 # Get flat advantages and token mask for masked metrics computation
                 flat_advantages = train_data["advantages"]
@@ -3490,6 +3667,8 @@ def grpo_train(
             if refit_metrics:
                 logger.log_metrics(refit_metrics, total_steps + 1, prefix="refit")
             logger.log_metrics(metrics, total_steps + 1, prefix="train")
+            if mlperf_logger is not None:
+                mlperf_logger.observe_metrics(metrics, total_steps + 1, prefix="train")
             logger.log_metrics(
                 performance_metrics, total_steps + 1, prefix="performance"
             )
@@ -3500,6 +3679,13 @@ def grpo_train(
                 prefix="timing/train",
                 step_finished=True,
             )
+            if mlperf_logger is not None:
+                mlperf_logger.observe_metrics(
+                    timing_metrics,
+                    total_steps + 1,
+                    prefix="timing/train",
+                    step_finished=True,
+                )
 
             # Reset the batch and set dynamic_sampling_num_gen_batches to 0
             batch_cache = None
@@ -3523,11 +3709,15 @@ def grpo_train(
             if should_save_by_timeout:
                 checkpointer.shutdown()
                 memory_tracker.snapshot_start_of_stage("", dir())
+                if mlperf_logger is not None:
+                    mlperf_logger.finalize()
                 print("Timeout has been reached, stopping training early", flush=True)
                 return
             if total_steps >= max_num_steps:
                 checkpointer.shutdown()
                 memory_tracker.snapshot_start_of_stage("", dir())
+                if mlperf_logger is not None:
+                    mlperf_logger.finalize()
                 print(
                     "Max number of steps has been reached, stopping training early",
                     flush=True,
@@ -3543,6 +3733,37 @@ def grpo_train(
     # so without this the daemon finalization thread would be killed before the
     # final tmp_step_N is renamed.
     checkpointer.shutdown()
+
+    if mlperf_logger is not None:
+        mlperf_logger.finalize()
+
+
+def _calculate_observed_pass_metrics(
+    total_rewards: list[float], num_generations_per_prompt: int
+) -> dict[str, float]:
+    """Calculate observed pass metrics from prompt-grouped validation rewards."""
+    assert num_generations_per_prompt >= 1, (
+        "grpo.num_val_generations_per_prompt must be >= 1"
+    )
+
+    metric_names = (
+        f"pass@{num_generations_per_prompt}",
+        f"pass^{num_generations_per_prompt}",
+        f"pass@1[avg-of-{num_generations_per_prompt}]",
+    )
+    if not total_rewards:
+        return dict.fromkeys(metric_names, 0.0)
+
+    rewards = torch.tensor(total_rewards, dtype=torch.float32)
+    assert rewards.numel() % num_generations_per_prompt == 0, (
+        "Validation rewards must be divisible by grpo.num_val_generations_per_prompt"
+    )
+    passed = rewards.view(-1, num_generations_per_prompt) > 0
+    return {
+        metric_names[0]: passed.any(dim=1).float().mean().item(),
+        metric_names[1]: passed.all(dim=1).float().mean().item(),
+        metric_names[2]: passed.float().mean().item(),
+    }
 
 
 def validate(
@@ -3565,25 +3786,49 @@ def validate(
     timer = Timer(context={"worker": "validator"})
     with timer.time("total_validation_time"):
         print(f"▶ Starting validation at step {step}...", flush=True)
+        num_val_generations_per_prompt = int(
+            master_config.grpo.get("num_val_generations_per_prompt", 1)
+        )
+        assert num_val_generations_per_prompt >= 1, (
+            "grpo.num_val_generations_per_prompt must be >= 1"
+        )
 
         total_rewards = []
         total_lengths = []
         all_message_logs = []  # Collect all message logs
+        additional_metrics_to_report = dict()
 
         max_batches = (
             master_config.grpo["max_val_samples"]
             // master_config.grpo["val_batch_size"]
         )
+        validation_generation_config = master_config.grpo.get("validation_generation")
+        assert validation_generation_config is None or _should_use_nemo_gym(
+            master_config
+        ), "grpo.validation_generation is only supported on the NeMo-Gym rollout path."
+        validation_generation_overrides = master_config.policy["generation"]
+        if validation_generation_config is not None:
+            # Validation-only sampling overrides (e.g. temperature 0.0 for
+            # deterministic validation). Training rollouts keep policy.generation.
+            validation_generation_overrides = dict(validation_generation_overrides)
+            validation_generation_overrides["temperature"] = (
+                validation_generation_config["temperature"]
+            )
+            validation_generation_overrides["top_p"] = validation_generation_config[
+                "top_p"
+            ]
         for batch_idx, val_batch in enumerate(val_dataloader):
             if batch_idx >= max_batches:
                 break
 
-            additional_metrics_to_report = dict()
+            if num_val_generations_per_prompt > 1:
+                val_batch = val_batch.repeat_interleave(num_val_generations_per_prompt)
+
             # Generate responses (updates the LLMMessageLogType in batch_with_msg_logs)
             # Use async rollouts when enabled by config/backend defaults.
             # We cascade NeMo-Gym first since NeMo-Gym also uses async rollouts.
             if _should_use_nemo_gym(master_config):
-                generation_config = master_config.policy["generation"]
+                generation_config = validation_generation_overrides
                 nemo_gym_rollout_result = run_nemo_gym_rollout_sync(
                     policy_generation=policy_generation,
                     input_batch=val_batch,
@@ -3600,6 +3845,7 @@ def validate(
                     effort_config=_get_effort_config(master_config),
                     reward_penalty_config=master_config.reward_penalties,
                     thinking_tags=get_nemo_gym_thinking_tags(master_config.env),
+                    mark_validation_request=validation_generation_config is not None,
                 )
                 val_batch = nemo_gym_rollout_result.final_batch
                 gen_metrics = nemo_gym_rollout_result.rollout_metrics
@@ -3638,9 +3884,17 @@ def validate(
 
             all_message_logs.extend(to_env)
 
-        # Calculate validation metrics
+        # For grouped validation, pass@k is the benchmark accuracy and MLPerf
+        # convergence metric. Retain pass^k and average pass@1 as diagnostics.
         num_samples = len(total_rewards)
-        if num_samples > 0:
+        observed_pass_metrics: dict[str, float] = {}
+        if num_val_generations_per_prompt > 1:
+            observed_pass_metrics = _calculate_observed_pass_metrics(
+                total_rewards,
+                num_val_generations_per_prompt,
+            )
+            accuracy = observed_pass_metrics[f"pass@{num_val_generations_per_prompt}"]
+        elif num_samples > 0:
             rewards_t = torch.tensor(total_rewards, dtype=torch.float32)
             accuracy = rewards_t.mean().item()
         else:
@@ -3653,8 +3907,9 @@ def validate(
         val_metrics = {
             "accuracy": accuracy,
             "avg_length": avg_length,
-            **additional_metrics_to_report,
+            **observed_pass_metrics,
         }
+        val_metrics.update(additional_metrics_to_report)
 
         # Print sample conversations only once at the end of validation
         try:
@@ -3677,7 +3932,15 @@ def validate(
 
     # Print summary of validation results
     print("\n📊 Validation Results:")
-    print(f"    • Accuracy: {accuracy:.4f}")
+    if num_val_generations_per_prompt > 1:
+        for metric_name in (
+            f"pass@{num_val_generations_per_prompt}",
+            f"pass^{num_val_generations_per_prompt}",
+            f"pass@1[avg-of-{num_val_generations_per_prompt}]",
+        ):
+            print(f"    • {metric_name}: {val_metrics[metric_name]:.4f}")
+    else:
+        print(f"    • Accuracy: {accuracy:.4f}")
     print(f"    • Average response length: {avg_length:.1f} tokens")
     print(f"    • Samples processed: {len(total_rewards)}", flush=True)
 
@@ -3761,6 +4024,7 @@ def async_grpo_train(
     max_trajectory_age_steps: int = 1,
     teacher_worker_groups: Optional[dict[str, Any]] = None,
     alias_to_group_alias: Optional[dict[str, str]] = None,
+    mlperf_logger: Optional[TrainTelemetryHooks] = None,
 ) -> None:
     """Run asynchronous GRPO training with replay buffer.
 
@@ -3778,6 +4042,7 @@ def async_grpo_train(
         grpo_save_state: Training state
         master_config: Master configuration
         max_trajectory_age_steps: Maximum age (in training steps) for trajectories to be used in training
+        mlperf_logger: Optional MLPerf GRPO logger
     """
     # Ensure we are running with a compatible async generation backend.
     # Async GRPO (with in-flight weight updates) supports vLLM, Megatron, and TRT-LLM;
@@ -3836,12 +4101,18 @@ def async_grpo_train(
         "total_valid_tokens", 0
     )  # Default to 0 for backward compatibility with older checkpoints
     val_period = master_config.grpo["val_period"]
+    val_start_at = master_config.grpo.get("val_start_at", None)
     val_at_start = master_config.grpo["val_at_start"]
     val_at_end = master_config.grpo["val_at_end"]
     colocated_inference = master_config.policy["generation"]["colocated"]["enabled"]
 
     # Initialize advantage estimator
     adv_estimator = _create_advantage_estimator(master_config)
+
+    if mlperf_logger is not None:
+        mlperf_logger.log_init_stop_run_start()
+        if not (val_at_start and step == 0):
+            mlperf_logger.start_train_block(step)
 
     assert not colocated_inference, (
         "Colocated inference is not supported for async GRPO. Please use non-colocated inference."
@@ -3972,14 +4243,6 @@ def async_grpo_train(
         next_nemo_gym_task_index=next_nemo_gym_task_index,
     )
 
-    # Start trajectory collection in background
-    collection_task = trajectory_collector.start_collection.remote(dataloader)
-
-    # Ensure collector knows initial weight version
-    trajectory_collector.set_weight_version.remote(weight_version)
-
-    print("📦 Started continuous background trajectory collection")
-
     print(
         f"🚀 Starting async GRPO training with buffer_size={optimal_buffer_size}, max_age={max_trajectory_age_steps} steps"
     )
@@ -3996,6 +4259,8 @@ def async_grpo_train(
             import traceback
 
             traceback.print_exc()
+            if mlperf_logger is not None:
+                mlperf_logger.finalize()
             return
     else:
         print("🔄 Preparing policy generation for inference...")
@@ -4007,7 +4272,20 @@ def async_grpo_train(
             import traceback
 
             traceback.print_exc()
+            if mlperf_logger is not None:
+                mlperf_logger.finalize()
             return
+
+    # Start trajectory collection only after generation holds real weights.
+    # The engines come up with load_format=dummy (weights arrive via the refit
+    # above); collecting before the refit fills the buffer with garbage
+    # rollouts sampled from randomly initialized weights.
+    collection_task = trajectory_collector.start_collection.remote(dataloader)  # noqa: F841
+
+    # Ensure collector knows initial weight version
+    trajectory_collector.set_weight_version.remote(weight_version)
+
+    print("📦 Started continuous background trajectory collection")
 
     print("✅ Policy generation setup complete, proceeding to validation...")
 
@@ -4017,7 +4295,10 @@ def async_grpo_train(
         # Pause trajectory collection during initial validation
         trajectory_collector.pause.remote()
 
+        initial_validation_error: Optional[Exception] = None
         try:
+            if mlperf_logger is not None:
+                mlperf_logger.start_eval(0)
             val_metrics, validation_timings = validate(
                 policy_generation,
                 val_dataloader,
@@ -4027,19 +4308,44 @@ def async_grpo_train(
                 master_config=master_config,
                 logger=logger,
             )
+            if mlperf_logger is not None:
+                mlperf_logger.end_eval(0, val_metrics, validation_timings)
             policy_generation.finish_generation()
             logger.log_metrics(val_metrics, step, prefix="validation")
             logger.log_metrics(validation_timings, step, prefix="timing/validation")
             print("✅ Initial validation completed successfully")
         except Exception as e:
-            print(f"❌ Initial validation failed: {e}")
-            import traceback
+            if mlperf_logger is not None:
+                # end_eval_with_error emits the terminal RUN_STOP; continuing to
+                # train would append events after it and could never log SUCCESS,
+                # so fail fast instead of treating validation as optional. The
+                # raise happens below, after actor cleanup.
+                mlperf_logger.end_eval_with_error(0)
+                initial_validation_error = e
+            else:
+                print(f"❌ Initial validation failed: {e}")
+                import traceback
 
-            traceback.print_exc()
-            # Continue anyway since validation is optional
+                traceback.print_exc()
+                # Continue anyway since validation is optional
         finally:
             # Resume trajectory collection after initial validation
             trajectory_collector.resume.remote()
+
+        if mlperf_logger is not None and (
+            mlperf_logger.target_reached or initial_validation_error is not None
+        ):
+            try:
+                ray.kill(trajectory_collector)
+            except Exception as e:
+                print(f"Error stopping trajectory collector: {e}")
+            try:
+                ray.kill(replay_buffer)
+            except Exception as e:
+                print(f"Error stopping replay buffer: {e}")
+            if initial_validation_error is not None:
+                raise initial_validation_error
+            return
 
     print("✅ All setup complete, starting buffer wait...")
     # Clear logger metrics at start of training
@@ -4448,8 +4754,17 @@ def async_grpo_train(
                     sample_mask = train_data["sample_mask"]
                     mask = token_mask * sample_mask.unsqueeze(-1)
 
+                    # Positional grouping is only needed for agentic gym rollouts,
+                    # where per-generation prompt tokenization is non-deterministic;
+                    # keep main's token-id grouping for every other GRPO user.
+                    advantage_group_ids = prompt_ids_for_adv
+                    if _should_use_nemo_gym(master_config):
+                        advantage_group_ids = _stable_group_ids(
+                            prompt_ids_for_adv,
+                            master_config.grpo["num_generations_per_prompt"],
+                        )
                     train_data["advantages"] = adv_estimator.compute_advantage(
-                        prompt_ids=prompt_ids_for_adv,
+                        prompt_ids=advantage_group_ids,
                         rewards=rewards,
                         mask=mask,
                         repeated_batch=repeated_batch,
@@ -4552,12 +4867,20 @@ def async_grpo_train(
                 is_last_step = step + 1 == master_config.grpo["max_num_steps"]
 
                 # Run validation if it's a validation step or last step with val_at_end
-                if (val_period > 0 and (step + 1) % val_period == 0) or (
-                    val_at_end and is_last_step
-                ):
+                if (
+                    val_period > 0
+                    and (val_start_at is None or step + 1 >= val_start_at)
+                    and (step + 1) % val_period == 0
+                ) or (val_at_end and is_last_step):
                     with timer.time("idle/validation"):
                         # Pause trajectory collection during validation to reduce memory pressure
                         trajectory_collector.pause.remote()
+                        # Drain in-flight rollouts too: pause only stops new
+                        # launches, and in-flight train rollouts sharing the
+                        # engines push val agents into timeout.
+                        ray.get(
+                            trajectory_collector.wait_for_pending_generations.remote()
+                        )
 
                         if NEED_REFIT and POLICY_GENERATION_STALE:
                             refit_metrics = refit_policy_generation(
@@ -4566,20 +4889,34 @@ def async_grpo_train(
                             POLICY_GENERATION_STALE = False
                         else:
                             policy_generation.prepare_for_generation()
-                        val_metrics, validation_timings = validate(
-                            policy_generation,
-                            val_dataloader,
-                            tokenizer,
-                            val_task_to_env,
-                            step=step + 1,
-                            master_config=master_config,
-                            logger=logger,
-                        )
+                        validation_step = step + 1
+                        if mlperf_logger is not None:
+                            mlperf_logger.start_eval(validation_step)
+                        try:
+                            val_metrics, validation_timings = validate(
+                                policy_generation,
+                                val_dataloader,
+                                tokenizer,
+                                val_task_to_env,
+                                step=validation_step,
+                                master_config=master_config,
+                                logger=logger,
+                            )
+                        except Exception:
+                            if mlperf_logger is not None:
+                                mlperf_logger.end_eval_with_error(validation_step)
+                            raise
+                        if mlperf_logger is not None:
+                            mlperf_logger.end_eval(
+                                validation_step, val_metrics, validation_timings
+                            )
                         policy_generation.finish_generation()
                         logger.log_metrics(
                             validation_timings, step + 1, prefix="timing/validation"
                         )
                         logger.log_metrics(val_metrics, step + 1, prefix="validation")
+                        if mlperf_logger is not None and mlperf_logger.target_reached:
+                            return
 
                         # Explicit GPU memory cleanup after validation in async mode
                         import gc
@@ -4904,6 +5241,8 @@ def async_grpo_train(
             logger.log_metrics(performance_metrics, step + 1, prefix="performance")
             logger.log_metrics(metrics, step + 1, prefix="train")
             logger.log_metrics(efficiency_loggable, step + 1, prefix="")
+            if mlperf_logger is not None:
+                mlperf_logger.observe_metrics(metrics, step + 1, prefix="train")
             # step_finished=True here since this is the final log of our current step.
             logger.log_metrics(
                 timing_metrics,
@@ -4911,6 +5250,13 @@ def async_grpo_train(
                 prefix="timing/train",
                 step_finished=True,
             )
+            if mlperf_logger is not None:
+                mlperf_logger.observe_metrics(
+                    timing_metrics,
+                    step + 1,
+                    prefix="timing/train",
+                    step_finished=True,
+                )
 
             timer.reset()
             step += 1
@@ -4938,6 +5284,8 @@ def async_grpo_train(
             checkpointer.shutdown()
         except Exception as e:
             print(f"Error finalizing pending checkpoint: {e}")
+        if mlperf_logger is not None:
+            mlperf_logger.finalize()
 
         # Clean up
         print("🛑 Stopping trajectory collection...")

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -434,6 +434,7 @@ def grpo_train_sync(
     val_at_start = master_config.grpo["val_at_start"]
     val_at_end = master_config.grpo["val_at_end"]
     val_period = master_config.grpo["val_period"]
+    val_start_at = master_config.grpo.get("val_start_at", None)
     colocated_inference = master_config.policy["generation"]["colocated"]["enabled"]
 
     # ── Data-plane setup (mandatory in the sync trainer) ───────────────
@@ -957,9 +958,11 @@ def grpo_train_sync(
                         and (current_step + 1 == len(wrapped_dataloader))
                     )
 
-                if (val_period > 0 and (total_steps + 1) % val_period == 0) or (
-                    val_at_end and is_last_step
-                ):
+                if (
+                    val_period > 0
+                    and (val_start_at is None or total_steps + 1 >= val_start_at)
+                    and (total_steps + 1) % val_period == 0
+                ) or (val_at_end and is_last_step):
                     memory_tracker.snapshot_start_of_stage("Validation", dir())
                     if NEED_REFIT and POLICY_GENERATION_STALE:
                         refit_policy_generation(

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -11,15 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import math
 import os
 import subprocess
 import sys
 from collections import Counter
 from collections.abc import AsyncGenerator
+
 from pathlib import Path
 from typing import Any, Dict, List, NotRequired, Optional, TypedDict
 
+import aiohttp
 import ray
 import torch
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
@@ -111,6 +114,12 @@ class NemoGymConfig(TypedDict):
     # Forwarded from policy.tokenizer.use_fastokens so rollout actors patch their
     # tokenizer consistently with the driver. Defaults to off when absent.
     use_fastokens: NotRequired[bool]
+    # When true, rollouts that fail (transport errors, NaN generation
+    # logprobs, malformed or empty generation data) are back-filled as
+    # zero-reward trajectories so the batch keeps its shape. Absent/false
+    # keeps the default fail-fast behavior (the whole batch raises); long
+    # multi-node benchmark runs enable it.
+    backfill_failed_rollouts: NotRequired[bool]
 
 
 def _detect_invalid_tool_call_and_malformed_thinking(
@@ -291,17 +300,47 @@ Depending on your data shape, you may want to change these values."""
 
         timer = Timer()
         counts_left = Counter(row["agent_ref"]["name"] for row in nemo_gym_examples)
+        backfill_failed_rollouts = bool(self.cfg.get("backfill_failed_rollouts"))
 
         timer.start("_run_rollouts_total")
         nemo_gym_result_iterator = self.rch.run_examples(
             examples=nemo_gym_examples, head_server_config=self.head_server_config
         )
 
+        def _final_timing_metrics() -> dict:
+            timer.stop("_run_rollouts_total")
+            final_metrics = timer.get_timing_metrics("sum")
+            total_time = final_metrics.pop("_run_rollouts_total")
+            # The postprocess timer label never fires when every rollout failed
+            # at `await task` and was back-filled, so default it to 0 rather
+            # than crash.
+            final_metrics[f"{timer_prefix}/postprocess_results_pct"] = (
+                100
+                * final_metrics.get(f"{timer_prefix}/postprocess_results", 0.0)
+                / total_time
+                if total_time
+                else 0.0
+            )
+            return final_metrics
+
         num_results = 0
+        seen_rowidxs: set[int] = set()
         for task in nemo_gym_result_iterator:
             with timer.time(label=f"{timer_prefix}/await_results"):
                 try:
                     nemo_gym_row, nemo_gym_result = await task
+                except (aiohttp.ClientError, asyncio.TimeoutError) as error:
+                    if not backfill_failed_rollouts:
+                        raise
+                    # Back-fill the missing row after the stream instead of
+                    # aborting the batch.
+                    print(
+                        f"  [nemo_gym] WARNING: rollout failed "
+                        f"({type(error).__name__}: {error}); will back-fill as "
+                        "a zero-reward trajectory instead of aborting the batch.",
+                        flush=True,
+                    )
+                    continue
                 except Exception as error:
                     if hasattr(error, "response_content"):
                         print(
@@ -312,23 +351,46 @@ Depending on your data shape, you may want to change these values."""
                     raise
 
             with timer.time(label=f"{timer_prefix}/postprocess_results"):
-                nemo_rl_result = self._postprocess_nemo_gym_to_nemo_rl_result(
-                    nemo_gym_result, tokenizer
-                )
+                try:
+                    nemo_rl_result = self._postprocess_nemo_gym_to_nemo_rl_result(
+                        nemo_gym_result, tokenizer
+                    )
+                except Exception as error:
+                    if not backfill_failed_rollouts:
+                        raise
+                    print(
+                        f"  [nemo_gym] WARNING: failed to postprocess rollout "
+                        f"{nemo_gym_row.get('_rowidx', '<unknown>')} "
+                        f"({type(error).__name__}: {error}); "
+                        "back-filling as a zero-reward trajectory.",
+                        flush=True,
+                    )
+                    nemo_rl_result = self._zero_reward_nemo_rl_result(
+                        tokenizer,
+                        nemo_gym_result if isinstance(nemo_gym_result, dict) else None,
+                        reason=f"postprocess_failed:{type(error).__name__}",
+                    )
                 if _has_nan_generation_logprobs(nemo_rl_result):
-                    raise RuntimeError("Generation logprobs contain NaN")
+                    if not backfill_failed_rollouts:
+                        raise RuntimeError("Generation logprobs contain NaN")
+                    print(
+                        f"  [nemo_gym] WARNING: rollout "
+                        f"{nemo_gym_row.get('_rowidx', '<unknown>')} returned NaN "
+                        "generation logprobs; back-filling as a zero-reward "
+                        "trajectory instead of aborting the batch.",
+                        flush=True,
+                    )
+                    nemo_rl_result = self._zero_reward_nemo_rl_result(
+                        tokenizer,
+                        nemo_gym_result if isinstance(nemo_gym_result, dict) else None,
+                        reason="nan_generation_logprobs",
+                    )
 
             num_results += 1
+            seen_rowidxs.add(nemo_gym_row["_rowidx"])
             timing_metrics = None
             if num_results == len(nemo_gym_examples):
-                timer.stop("_run_rollouts_total")
-                timing_metrics = timer.get_timing_metrics("sum")
-                total_time = timing_metrics.pop("_run_rollouts_total")
-                timing_metrics[f"{timer_prefix}/postprocess_results_pct"] = (
-                    100
-                    * timing_metrics[f"{timer_prefix}/postprocess_results"]
-                    / total_time
-                )
+                timing_metrics = _final_timing_metrics()
 
             agent_name = nemo_gym_row["agent_ref"]["name"]
             counts_left[agent_name] -= 1
@@ -348,6 +410,80 @@ Depending on your data shape, you may want to change these values."""
 
             yield nemo_gym_row["_rowidx"], nemo_rl_result, timing_metrics
 
+        # Preserve batch shape when rollouts were dropped at `await task`: the
+        # stream consumer expects exactly one result per input row, so emit the
+        # missing rows as zero-reward trajectories.
+        if not backfill_failed_rollouts:
+            return
+        missing_rowidxs = [
+            rowidx
+            for rowidx in range(len(nemo_gym_examples))
+            if rowidx not in seen_rowidxs
+        ]
+        if missing_rowidxs:
+            print(
+                f"  [nemo_gym] WARNING: back-filling "
+                f"{len(missing_rowidxs)}/{len(nemo_gym_examples)} failed "
+                "rollout(s) as zero-reward trajectories (batch counts preserved).",
+                flush=True,
+            )
+        for rowidx in missing_rowidxs:
+            num_results += 1
+            timing_metrics = (
+                _final_timing_metrics()
+                if num_results == len(nemo_gym_examples)
+                else None
+            )
+            yield (
+                rowidx,
+                self._zero_reward_nemo_rl_result(tokenizer, reason="rollout_failed"),
+                timing_metrics,
+            )
+
+    def _zero_reward_nemo_rl_result(
+        self,
+        tokenizer: PreTrainedTokenizerBase,
+        nemo_gym_result: dict | None = None,
+        reason: str | None = None,
+    ) -> dict:
+        fallback_token = (
+            tokenizer.pad_token_id
+            if tokenizer.pad_token_id is not None
+            else (tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 0)
+        )
+        if nemo_gym_result is None:
+            nemo_gym_result = {}
+
+        response = nemo_gym_result.get("response")
+        if not isinstance(response, dict):
+            response = {}
+            nemo_gym_result["response"] = response
+        if not isinstance(response.get("output"), list):
+            response["output"] = []
+        nemo_gym_result["reward"] = 0.0
+        if reason:
+            nemo_gym_result["nemo_rl_fallback_reason"] = reason
+
+        message_log = [
+            {
+                "role": "user",
+                "content": "",
+                "token_ids": torch.tensor(
+                    [fallback_token, fallback_token], dtype=torch.int64
+                ),
+            },
+            {
+                "role": "assistant",
+                "content": "",
+                "token_ids": torch.tensor([fallback_token], dtype=torch.int64),
+            },
+        ]
+        return {
+            "message_log": message_log,
+            "input_message_log": message_log[:1],
+            "full_result": nemo_gym_result,
+        }
+
     def _postprocess_nemo_gym_to_nemo_rl_result(
         self, nemo_gym_result: dict, tokenizer: PreTrainedTokenizerBase
     ) -> dict:
@@ -355,15 +491,31 @@ Depending on your data shape, you may want to change these values."""
             f"Hit a non-successful response when querying NeMo Gym for rollouts: {nemo_gym_result}"
         )
 
+        response = nemo_gym_result.get("response")
+        response_output = response.get("output") if isinstance(response, dict) else None
+        if not isinstance(response_output, list):
+            if not self.cfg.get("backfill_failed_rollouts"):
+                raise ValueError(
+                    "NeMo Gym returned a malformed response.output: "
+                    f"{type(response_output).__name__}"
+                )
+            return self._zero_reward_nemo_rl_result(
+                tokenizer,
+                nemo_gym_result,
+                reason=f"malformed_response_output:{type(response_output).__name__}",
+            )
+
         nemo_rl_message_log = []
         seen_token_ids: List[int] = []
         batch_decode_items = []
-        for output_item_dict in nemo_gym_result["response"]["output"]:
+        for output_item_dict in response_output:
             # Nemo RL really only has two types of messages: assistant and not assistant since that is all that it is concerned with (i.e. to train or not to train)
             # Here we map all the trainable messages to assistant and all the non-trainable messages to user.
             # Eventually we can maybe be smarter about this, but this is functional for now.
 
             # Note that NeMo-Gym will only return token ids on "assistant" messages and not other message types.
+            if not isinstance(output_item_dict, dict):
+                continue
             # Also skip if generation_token_ids is present but empty, e.g. all-EOS generation stripped to [] — torch.tensor([]) defaults to float32 and breaks batch dtype consistency.
             if (
                 "generation_token_ids" not in output_item_dict
@@ -479,20 +631,26 @@ Output prompt token IDs: {output_item_dict["prompt_token_ids"]}
                 output_item_dict["generation_str"] = generation_str
 
         if not nemo_rl_message_log:
-            input_messages = nemo_gym_result["responses_create_params"]["input"]
+            input_messages = nemo_gym_result.get("responses_create_params", {}).get(
+                "input"
+            )
             try:
-                prompt_token_ids = tokenizer.apply_chat_template(
-                    input_messages, tokenize=True
-                )
-                prompt_len_str = f"{len(prompt_token_ids)} tokens"
+                if input_messages is None:
+                    prompt_len_str = "<unknown>"
+                else:
+                    prompt_token_ids = tokenizer.apply_chat_template(
+                        input_messages, tokenize=True
+                    )
+                    prompt_len_str = f"{len(prompt_token_ids)} tokens"
             except Exception as e:
                 prompt_len_str = (
-                    f"<unknown — apply_chat_template failed: {type(e).__name__}: {e}>"
+                    f"<unknown - apply_chat_template failed: {type(e).__name__}: {e}>"
                 )
             output_item_types = [
-                o.get("type") for o in nemo_gym_result["response"]["output"]
+                o.get("type") if isinstance(o, dict) else type(o).__name__
+                for o in response_output
             ]
-            raise ValueError(
+            no_generation_message = (
                 f"NeMo Gym returned a result with no generation data. "
                 f"Possible causes: (1) the prompt for the first turn already exceeds the vLLM max_model_len, "
                 f"so vLLM rejected the request before any tokens could be generated; "
@@ -502,6 +660,16 @@ Output prompt token IDs: {output_item_dict["prompt_token_ids"]}
                 f"  → If (1): increase `policy.max_total_sequence_length` and `policy.generation.vllm_cfg.max_model_len` "
                 f"above the prompt length above.\n"
                 f"  → If (2): inspect why no assistant content was produced for this rollout."
+            )
+            if not self.cfg.get("backfill_failed_rollouts"):
+                raise ValueError(no_generation_message)
+            print(
+                no_generation_message
+                + "\n  Treating this rollout as a masked zero-reward trajectory instead of aborting the batch.",
+                flush=True,
+            )
+            return self._zero_reward_nemo_rl_result(
+                tokenizer, nemo_gym_result, reason="no_generation_data"
             )
 
         return {

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -59,6 +59,54 @@ from nemo_rl.utils.timer import Timer
 
 TokenizerType = PreTrainedTokenizerBase
 
+_NEMO_RL_REQUEST_TYPE_METADATA_KEY = "_nemo_rl_request_type"
+_NEMO_RL_VALIDATION_REQUEST_TYPE = "validation"
+_NEMO_GYM_CHAT_TEMPLATE_KWARGS_METADATA_KEY = "chat_template_kwargs"
+
+
+def _get_nemo_gym_chat_template_kwargs(metadata: dict[str, Any]) -> dict[str, Any]:
+    chat_template_kwargs_str = metadata.get(
+        _NEMO_GYM_CHAT_TEMPLATE_KWARGS_METADATA_KEY, "{}"
+    )
+    assert isinstance(chat_template_kwargs_str, str), (
+        "NeMo-Gym responses_create_params.metadata.chat_template_kwargs must be a JSON string."
+    )
+
+    chat_template_kwargs = json.loads(chat_template_kwargs_str)
+    assert isinstance(chat_template_kwargs, dict), (
+        "NeMo-Gym responses_create_params.metadata.chat_template_kwargs must decode to a dict."
+    )
+    return chat_template_kwargs
+
+
+def _set_nemo_rl_request_type(
+    responses_create_params: dict[str, Any], request_type: str | None
+) -> None:
+    metadata = responses_create_params.get("metadata") or {}
+    assert isinstance(metadata, dict), (
+        "NeMo-Gym responses_create_params.metadata must be a dict."
+    )
+    metadata = dict(metadata)
+    metadata.pop(_NEMO_RL_REQUEST_TYPE_METADATA_KEY, None)
+
+    chat_template_kwargs = _get_nemo_gym_chat_template_kwargs(metadata)
+    if request_type is None:
+        chat_template_kwargs.pop(_NEMO_RL_REQUEST_TYPE_METADATA_KEY, None)
+    else:
+        chat_template_kwargs[_NEMO_RL_REQUEST_TYPE_METADATA_KEY] = request_type
+
+    if chat_template_kwargs:
+        metadata[_NEMO_GYM_CHAT_TEMPLATE_KWARGS_METADATA_KEY] = json.dumps(
+            chat_template_kwargs
+        )
+    else:
+        metadata.pop(_NEMO_GYM_CHAT_TEMPLATE_KWARGS_METADATA_KEY, None)
+
+    if metadata:
+        responses_create_params["metadata"] = metadata
+    else:
+        responses_create_params.pop("metadata", None)
+
 
 def _add_r3_fallback_metrics(
     gen_metrics: dict[str, float | int],
@@ -1947,7 +1995,9 @@ def apply_reward_penalties(
 
 
 def _prepare_nemo_gym_rows(
-    rows: list[dict], generation_config: GenerationConfig
+    rows: list[dict],
+    generation_config: GenerationConfig,
+    mark_validation_request: bool = False,
 ) -> None:
     """Apply NeMo-RL sampling parameters and stable row indices in place."""
     for row_index, row in enumerate(rows):
@@ -1959,6 +2009,12 @@ def _prepare_nemo_gym_rows(
 
         responses_create_params["temperature"] = generation_config["temperature"]
         responses_create_params["top_p"] = generation_config["top_p"]
+        if mark_validation_request:
+            _set_nemo_rl_request_type(
+                responses_create_params, _NEMO_RL_VALIDATION_REQUEST_TYPE
+            )
+        else:
+            _set_nemo_rl_request_type(responses_create_params, None)
         configured_max_tokens = generation_config["max_new_tokens"]
         row_max_tokens = responses_create_params.get("max_output_tokens")
         responses_create_params["max_output_tokens"] = (
@@ -1997,6 +2053,7 @@ async def run_async_nemo_gym_rollout(
     effort_config: Optional[EffortLevelsConfig] = None,
     reward_penalty_config: dict[str, Any] | BaseModel | None = None,
     thinking_tags: list[str] | tuple[str, ...] | None = None,
+    mark_validation_request: bool = False,
     returns_entire_batch: bool = False,
 ) -> AsyncGenerator[NemoGymRolloutResult, None]:
     """Stream complete NeMo-Gym prompt groups in group-completion order.
@@ -2099,7 +2156,11 @@ async def run_async_nemo_gym_rollout(
     run_rollouts_timer_label = f"{timer_prefix}/run_rollouts"
 
     with timer.time(total_timer_label):
-        _prepare_nemo_gym_rows(nemo_gym_rows, generation_config)
+        _prepare_nemo_gym_rows(
+            nemo_gym_rows,
+            generation_config,
+            mark_validation_request=mark_validation_request,
+        )
         accumulator = _NemoGymStreamAccumulator(
             rows=nemo_gym_rows,
             num_generations=num_generations,
@@ -2184,6 +2245,7 @@ def run_nemo_gym_rollout_sync(
     effort_config: Optional[EffortLevelsConfig] = None,
     reward_penalty_config: dict[str, Any] | BaseModel | None = None,
     thinking_tags: list[str] | tuple[str, ...] | None = None,
+    mark_validation_request: bool = False,
 ) -> NemoGymRolloutResult:
     """Run and return one complete NeMo-Gym batch synchronously.
 
@@ -2206,6 +2268,9 @@ def run_nemo_gym_rollout_sync(
         effort_config: Optional configuration for effort-based reward shaping.
         reward_penalty_config: Optional reward-penalty configuration.
         thinking_tags: Optional opening and closing tags used by thinking penalties.
+        mark_validation_request: Whether to tag every row's request as a
+            validation request so the generation server exempts it from the
+            strict training sampling-parameter checks.
 
     Returns:
         The fully postprocessed NeMo-Gym rollout batch in input-row order.
@@ -2235,6 +2300,7 @@ def run_nemo_gym_rollout_sync(
             effort_config=effort_config,
             reward_penalty_config=reward_penalty_config,
             thinking_tags=thinking_tags,
+            mark_validation_request=mark_validation_request,
             returns_entire_batch=True,
         ):
             pass

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -2054,6 +2054,7 @@ async def run_async_nemo_gym_rollout(
     reward_penalty_config: dict[str, Any] | BaseModel | None = None,
     thinking_tags: list[str] | tuple[str, ...] | None = None,
     mark_validation_request: bool = False,
+    mask_env_flagged_samples: bool = True,
     returns_entire_batch: bool = False,
 ) -> AsyncGenerator[NemoGymRolloutResult, None]:
     """Stream complete NeMo-Gym prompt groups in group-completion order.
@@ -2209,6 +2210,7 @@ async def run_async_nemo_gym_rollout(
                         effort_config=effort_config,
                         reward_penalty_config=reward_penalty_config,
                         thinking_tags=thinking_tags,
+                        mask_env_flagged_samples=mask_env_flagged_samples,
                     )
                     if accumulator.is_complete:
                         final_rollout_result = rollout_result
@@ -2246,6 +2248,7 @@ def run_nemo_gym_rollout_sync(
     reward_penalty_config: dict[str, Any] | BaseModel | None = None,
     thinking_tags: list[str] | tuple[str, ...] | None = None,
     mark_validation_request: bool = False,
+    mask_env_flagged_samples: bool = True,
 ) -> NemoGymRolloutResult:
     """Run and return one complete NeMo-Gym batch synchronously.
 
@@ -2271,6 +2274,8 @@ def run_nemo_gym_rollout_sync(
         mark_validation_request: Whether to tag every row's request as a
             validation request so the generation server exempts it from the
             strict training sampling-parameter checks.
+        mask_env_flagged_samples: Whether to carry env-driven ``mask_sample``
+            flags in the rollout batch for loss masking (the upstream default).
 
     Returns:
         The fully postprocessed NeMo-Gym rollout batch in input-row order.
@@ -2301,6 +2306,7 @@ def run_nemo_gym_rollout_sync(
             reward_penalty_config=reward_penalty_config,
             thinking_tags=thinking_tags,
             mark_validation_request=mark_validation_request,
+            mask_env_flagged_samples=mask_env_flagged_samples,
             returns_entire_batch=True,
         ):
             pass
@@ -2323,6 +2329,7 @@ def _postprocess_single_nemo_gym_group(
     effort_config: Optional[EffortLevelsConfig] = None,
     reward_penalty_config: dict[str, Any] | BaseModel | None = None,
     thinking_tags: list[str] | tuple[str, ...] | None = None,
+    mask_env_flagged_samples: bool = True,
 ) -> NemoGymRolloutResult:
     """Postprocess one complete prompt group from the NeMo-Gym stream."""
     # Length-based reward shaping for low-effort prompts
@@ -2503,11 +2510,14 @@ def _postprocess_single_nemo_gym_group(
             "truncated": torch.tensor(
                 [m["hit_max_tokens"] for m in all_sample_metrics], dtype=torch.bool
             ),
-            # Agent/env-driven mask flag — True means this sample should be masked
-            # from the GRPO gradient (kept for advantage computation).
-            "mask_sample": _extract_mask_sample_flags(results),
         }
     )
+    # Env-driven loss masking is configurable (grpo.mask_env_flagged_samples):
+    # the mere presence of this [B]-bool key collapsed a large sequence-packed
+    # async run even with every flag False, so runs hitting that interaction
+    # can keep the key out of the batch entirely.
+    if mask_env_flagged_samples:
+        final_batch["mask_sample"] = _extract_mask_sample_flags(results)
 
     if length_rewards_low:
         rollout_metrics["mean_length_reward_low"] = sum(length_rewards_low) / len(

--- a/nemo_rl/models/generation/interfaces.py
+++ b/nemo_rl/models/generation/interfaces.py
@@ -203,8 +203,6 @@ class GenerationConfig(TypedDict):
     port_range_low: NotRequired[int]
     port_range_high: NotRequired[int]
     use_async_rollouts: NotRequired[bool]
-    # Optional request-level left-truncation limit for HTTP chat generation.
-    truncate_prompt_tokens: NotRequired[int | None]
     # This isn't meant to be passed by the user, but is populated by nemo_rl.models.generation.__init__.configure_generation_config
     _pad_token_id: NotRequired[int]
     # MTP draft weights arrive via refit if the trainer trains the MTP layer.

--- a/nemo_rl/models/generation/interfaces.py
+++ b/nemo_rl/models/generation/interfaces.py
@@ -203,10 +203,14 @@ class GenerationConfig(TypedDict):
     port_range_low: NotRequired[int]
     port_range_high: NotRequired[int]
     use_async_rollouts: NotRequired[bool]
+    # Optional request-level left-truncation limit for HTTP chat generation.
+    truncate_prompt_tokens: NotRequired[int | None]
     # This isn't meant to be passed by the user, but is populated by nemo_rl.models.generation.__init__.configure_generation_config
     _pad_token_id: NotRequired[int]
     # MTP draft weights arrive via refit if the trainer trains the MTP layer.
     _mtp_weights_from_refit: NotRequired[bool]
+    # Internal GRPO validation-only sampling config used by OpenAI-compatible generation servers.
+    _validation_generation: NotRequired[dict[str, float] | None]
 
 
 class GenerationDatumSpec(TypedDict):

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -525,14 +525,6 @@ class VllmAsyncGenerationWorkerImpl(
                         except TypeError:
                             message["content"] = []
 
-                truncate_prompt_tokens = worker_self.cfg.get("truncate_prompt_tokens")
-                if (
-                    truncate_prompt_tokens is not None
-                    and hasattr(request, "truncate_prompt_tokens")
-                    and request.truncate_prompt_tokens is None
-                ):
-                    request.truncate_prompt_tokens = truncate_prompt_tokens
-
                 # Temporarily set to 1 so vLLM's pre-tokenization length check passes;
                 # the actual value will be set through _clamp_max_tokens later.
                 actual_request_max_tokens = None

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -56,6 +56,51 @@ from nemo_rl.models.generation.openai_server_utils import (
 
 LOGGER = logging.getLogger(__name__)
 
+_NEMO_RL_REQUEST_TYPE_METADATA_KEY = "_nemo_rl_request_type"
+_NEMO_RL_VALIDATION_REQUEST_TYPE = "validation"
+_NEMO_RL_VALIDATION_GENERATION_CONFIG_KEY = "_validation_generation"
+
+
+def _pop_nemo_rl_request_type(request: Any) -> Optional[str]:
+    """Remove and return NeMo-RL-only metadata before template rendering."""
+    chat_template_kwargs = getattr(request, "chat_template_kwargs", None) or {}
+    assert isinstance(chat_template_kwargs, dict), (
+        "Chat completion request chat_template_kwargs must be a dict."
+    )
+    chat_template_kwargs = dict(chat_template_kwargs)
+    request_type = chat_template_kwargs.pop(_NEMO_RL_REQUEST_TYPE_METADATA_KEY, None)
+    if request_type is not None:
+        request.chat_template_kwargs = chat_template_kwargs
+    return request_type
+
+
+def _is_validation_request(request: Any, generation_config: dict[str, Any]) -> bool:
+    """Identify validation requests while keeping training checks strict."""
+    request_type = _pop_nemo_rl_request_type(request)
+    if request_type is not None:
+        assert request_type == _NEMO_RL_VALIDATION_REQUEST_TYPE, (
+            f"Unsupported NeMo RL request type: {request_type!r}."
+        )
+        return True
+
+    validation_generation = generation_config.get(
+        _NEMO_RL_VALIDATION_GENERATION_CONFIG_KEY
+    )
+    if validation_generation is None:
+        return False
+
+    if (
+        validation_generation["temperature"] == generation_config["temperature"]
+        and validation_generation["top_p"] == generation_config["top_p"]
+    ):
+        return False
+
+    request_top_p = 1.0 if request.top_p is None else request.top_p
+    return (
+        request.temperature == validation_generation["temperature"]
+        and request_top_p == validation_generation["top_p"]
+    )
+
 
 class VllmAsyncGenerationWorkerImpl(
     VllmAsyncCheckpointEngineRpcMixin, BaseVllmGenerationWorker
@@ -421,6 +466,11 @@ class VllmAsyncGenerationWorkerImpl(
 
                 return super().model_post_init(context)
 
+        # Bind the worker instance for use inside the serving mixins below:
+        # their methods run with `self` = the vLLM serving/render object, which
+        # has no `cfg` attribute.
+        worker_self = self
+
         class NeMoRLOpenAIServingMixin:
             @staticmethod
             def _set_max_tokens(request, max_tokens: int) -> None:
@@ -468,7 +518,20 @@ class VllmAsyncGenerationWorkerImpl(
                     if message.get("tool_calls"):
                         message["tool_calls"] = list(message["tool_calls"])
 
-                messages_for_replace_prefix_tokens = deepcopy(messages)
+                    content = message.get("content")
+                    if content is not None and not isinstance(content, (list, str)):
+                        try:
+                            message["content"] = list(content)
+                        except TypeError:
+                            message["content"] = []
+
+                truncate_prompt_tokens = worker_self.cfg.get("truncate_prompt_tokens")
+                if (
+                    truncate_prompt_tokens is not None
+                    and hasattr(request, "truncate_prompt_tokens")
+                    and request.truncate_prompt_tokens is None
+                ):
+                    request.truncate_prompt_tokens = truncate_prompt_tokens
 
                 # Temporarily set to 1 so vLLM's pre-tokenization length check passes;
                 # the actual value will be set through _clamp_max_tokens later.
@@ -517,6 +580,27 @@ class VllmAsyncGenerationWorkerImpl(
                             res[1][0]["prompt_token_ids"],
                         )
                     return res
+
+                # vLLM normalizes reasoning and tool-call message content during
+                # preprocessing.  Reuse that representation for the isolated
+                # prefix render, while removing NeMo-RL's token bookkeeping.
+                excluded_fields = {
+                    "prompt_token_ids",
+                    "generation_token_ids",
+                    "generation_log_probs",
+                }
+                messages_for_replace_prefix_tokens = []
+                for message in messages:
+                    if isinstance(message, dict):
+                        messages_for_replace_prefix_tokens.append(
+                            {
+                                key: deepcopy(value)
+                                for key, value in message.items()
+                                if key not in excluded_fields
+                            }
+                        )
+                    else:
+                        messages_for_replace_prefix_tokens.append(deepcopy(message))
 
                 last_assistant_message_idx = None
                 for i in reversed(range(len(messages_for_replace_prefix_tokens))):
@@ -587,8 +671,7 @@ class VllmAsyncGenerationWorkerImpl(
 
         # vLLM 0.20 routes both /v1/chat/completions and /tokenize through
         # OpenAIServingRender.preprocess_chat, so the prefix-token override
-        # belongs on the render subclass.
-        worker_self = self
+        # belongs on the render subclass (worker_self is bound above).
 
         class NeMoRLOpenAIServingChatMixin:
             async def chat_completion_full_generator(
@@ -678,10 +761,20 @@ class VllmAsyncGenerationWorkerImpl(
             )
             request.top_k = -1
 
-            # The request sampling params need to exactly match those as are set in NeMo RL.
-            # If they do not match, the inference will be off policy and destroy training stability.
-            assert request.temperature == generation_config["temperature"]
-            assert request.top_p == generation_config["top_p"]
+            # Training requests must match the NeMo RL policy config exactly —
+            # a mismatch means off-policy inference and destroys training stability.
+            # Validation requests are metric-only and may use validation_generation params.
+            if not _is_validation_request(request, generation_config):
+                expected_temperature = generation_config["temperature"]
+                expected_top_p = generation_config["top_p"]
+                assert request.temperature == expected_temperature, (
+                    f"policy request temperature mismatch: got {request.temperature}, "
+                    f"expected {expected_temperature}."
+                )
+                assert request.top_p == expected_top_p, (
+                    f"policy request top_p mismatch: got {request.top_p}, "
+                    f"expected {expected_top_p}."
+                )
 
             try:
                 generator = await openai_serving_chat.create_chat_completion(
@@ -1333,17 +1426,18 @@ class VllmAsyncGenerationWorkerImpl(
             worker_results = cast(list[bool], worker_results)
 
             if not worker_results or not all(worker_results):
-                print(
-                    f"Error: Worker failed to update weights. Results: {worker_results}"
+                # Weight-update failures must abort the step: silently continuing
+                # would train against stale generation weights (off-policy drift).
+                raise RuntimeError(
+                    f"Worker failed to update weights. Results: {worker_results}"
                 )
-                return False
             return True
         except Exception as e:
             print(f"Exception during collective_rpc for weight update: {e}")
             import traceback
 
             traceback.print_exc()
-            return False
+            raise
 
     async def update_weights_from_collective_async(self) -> bool:
         """Async version of update_weights_from_collective."""
@@ -1369,17 +1463,18 @@ class VllmAsyncGenerationWorkerImpl(
             worker_results = cast(list[bool], worker_results)
 
             if not worker_results or not all(worker_results):
-                print(
-                    f"Error: Worker failed to update weights. Results: {worker_results}"
+                # Weight-update failures must abort the step: silently continuing
+                # would train against stale generation weights (off-policy drift).
+                raise RuntimeError(
+                    f"Worker failed to update weights. Results: {worker_results}"
                 )
-                return False
             return True
         except Exception as e:
             print(f"Exception during collective_rpc for weight update: {e}")
             import traceback
 
             traceback.print_exc()
-            return False
+            raise
 
     async def reset_prefix_cache_async(self):
         """Async version of reset_prefix_cache."""

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
 import hashlib
 import json
 import os
@@ -300,14 +299,8 @@ def setup_distributed() -> None:
     configure_dynamo_cache()
     # Ensure clean slate before import
     destroy_parallel_state()
-    # Raise the 10-minute NCCL watchdog default: transient first-hit stalls
-    # (e.g. triton JIT on new packed shapes) SIGABRT healthy multi-node runs.
-    # Sub-groups inherit this timeout; SLURM walltime bounds true hangs.
-    timeout_minutes = int(os.environ.get("NRL_NCCL_TIMEOUT_MINUTES", "60"))
-    torch.distributed.init_process_group(
-        "nccl",
-        timeout=datetime.timedelta(minutes=timeout_minutes),
-    )
+    # Initialize process group
+    torch.distributed.init_process_group("nccl")
 
 
 def validate_and_set_config(
@@ -927,20 +920,6 @@ def _apply_performance_config(model_cfg: Any, config: PolicyConfig) -> None:
     model_cfg.use_fused_weighted_squared_relu = config["megatron_cfg"][
         "use_fused_weighted_squared_relu"
     ]
-    # Optional first/last-layer BF16 precision overrides (used by FP8 recipes to
-    # keep boundary layers in BF16).
-    if "first_last_layers_bf16" in config["megatron_cfg"]:
-        model_cfg.first_last_layers_bf16 = config["megatron_cfg"][
-            "first_last_layers_bf16"
-        ]
-    if "num_layers_at_start_in_bf16" in config["megatron_cfg"]:
-        model_cfg.num_layers_at_start_in_bf16 = config["megatron_cfg"][
-            "num_layers_at_start_in_bf16"
-        ]
-    if "num_layers_at_end_in_bf16" in config["megatron_cfg"]:
-        model_cfg.num_layers_at_end_in_bf16 = config["megatron_cfg"][
-            "num_layers_at_end_in_bf16"
-        ]
     # Optional explicit attention backend override for environments where
     # TE auto backend probing is unstable.
     attention_backend = config["megatron_cfg"].get("attention_backend")
@@ -1128,29 +1107,6 @@ def _validate_dtype_config(
         )
 
 
-def _normalize_optimizer_dtypes(optimizer_cfg: dict[str, Any]) -> dict[str, Any]:
-    """Convert serializable dtype names to torch.dtype at the MCore boundary."""
-    normalized = dict(optimizer_cfg)
-    dtype_map = {
-        "float32": torch.float32,
-        "fp32": torch.float32,
-        "bfloat16": torch.bfloat16,
-        "bf16": torch.bfloat16,
-        "float16": torch.float16,
-        "fp16": torch.float16,
-    }
-    for key in (
-        "main_params_dtype",
-        "main_grads_dtype",
-        "exp_avg_dtype",
-        "exp_avg_sq_dtype",
-    ):
-        value = normalized.get(key)
-        if isinstance(value, str):
-            normalized[key] = dtype_map[value.lower()]
-    return normalized
-
-
 def _create_megatron_config(
     model_cfg: Any,
     checkpoint_config: CheckpointConfig,
@@ -1172,7 +1128,7 @@ def _create_megatron_config(
         "overlap_param_gather"
     ]
     optimizer_kwargs = {
-        **_normalize_optimizer_dtypes(config["megatron_cfg"]["optimizer"]),
+        **config["megatron_cfg"]["optimizer"],
         "overlap_param_gather": overlap_param_gather,
         "reuse_grad_buf_for_mxfp8_param_ag": reuse_grad_buf_for_mxfp8_param_ag,
     }
@@ -1211,10 +1167,6 @@ def _create_megatron_config(
         ),
         optimizer=OptimizerConfig(**optimizer_kwargs),
         ddp=DistributedDataParallelConfig(
-            # check_grads does a per-bucket D2H sync inside the grad-ready
-            # hook, which can deadlock large multi-node MoE runs mid-backward
-            # (mcore's own default is False). NaN grads still surface via the
-            # optimizer's global grad norm.
             check_for_nan_in_grad=config["megatron_cfg"][
                 "distributed_data_parallel_config"
             ].get("check_for_nan_in_grad", True),
@@ -1359,16 +1311,6 @@ def setup_model_and_optimizer(
     state.initialize_async_checkpoint_worker()
 
     megatron_cfg.dist.external_gpu_device_mapping = True
-    # initialize_megatron creates TP/PP/EP/DP sub-groups with an explicit
-    # timeout (mcore default 10 min) that overrides the default-group value
-    # from setup_distributed() — keep both knobs on the same env var.
-    megatron_cfg.dist.distributed_timeout_minutes = int(
-        os.environ.get("NRL_NCCL_TIMEOUT_MINUTES", "60")
-    )
-    # If a collective still times out, dump the NCCL flight-recorder trace so
-    # the stalled rank/op is identifiable post-mortem (pair with
-    # TORCH_NCCL_DEBUG_INFO_TEMP_FILE on a mounted path).
-    megatron_cfg.dist.flight_recorder_dump_on_timeout = True
     initialize_megatron(
         cfg=megatron_cfg,
         get_embedding_ranks=get_embedding_ranks,

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import hashlib
 import json
 import os
@@ -299,8 +300,14 @@ def setup_distributed() -> None:
     configure_dynamo_cache()
     # Ensure clean slate before import
     destroy_parallel_state()
-    # Initialize process group
-    torch.distributed.init_process_group("nccl")
+    # Raise the 10-minute NCCL watchdog default: transient first-hit stalls
+    # (e.g. triton JIT on new packed shapes) SIGABRT healthy multi-node runs.
+    # Sub-groups inherit this timeout; SLURM walltime bounds true hangs.
+    timeout_minutes = int(os.environ.get("NRL_NCCL_TIMEOUT_MINUTES", "60"))
+    torch.distributed.init_process_group(
+        "nccl",
+        timeout=datetime.timedelta(minutes=timeout_minutes),
+    )
 
 
 def validate_and_set_config(
@@ -920,6 +927,20 @@ def _apply_performance_config(model_cfg: Any, config: PolicyConfig) -> None:
     model_cfg.use_fused_weighted_squared_relu = config["megatron_cfg"][
         "use_fused_weighted_squared_relu"
     ]
+    # Optional first/last-layer BF16 precision overrides (used by FP8 recipes to
+    # keep boundary layers in BF16).
+    if "first_last_layers_bf16" in config["megatron_cfg"]:
+        model_cfg.first_last_layers_bf16 = config["megatron_cfg"][
+            "first_last_layers_bf16"
+        ]
+    if "num_layers_at_start_in_bf16" in config["megatron_cfg"]:
+        model_cfg.num_layers_at_start_in_bf16 = config["megatron_cfg"][
+            "num_layers_at_start_in_bf16"
+        ]
+    if "num_layers_at_end_in_bf16" in config["megatron_cfg"]:
+        model_cfg.num_layers_at_end_in_bf16 = config["megatron_cfg"][
+            "num_layers_at_end_in_bf16"
+        ]
     # Optional explicit attention backend override for environments where
     # TE auto backend probing is unstable.
     attention_backend = config["megatron_cfg"].get("attention_backend")
@@ -1107,6 +1128,29 @@ def _validate_dtype_config(
         )
 
 
+def _normalize_optimizer_dtypes(optimizer_cfg: dict[str, Any]) -> dict[str, Any]:
+    """Convert serializable dtype names to torch.dtype at the MCore boundary."""
+    normalized = dict(optimizer_cfg)
+    dtype_map = {
+        "float32": torch.float32,
+        "fp32": torch.float32,
+        "bfloat16": torch.bfloat16,
+        "bf16": torch.bfloat16,
+        "float16": torch.float16,
+        "fp16": torch.float16,
+    }
+    for key in (
+        "main_params_dtype",
+        "main_grads_dtype",
+        "exp_avg_dtype",
+        "exp_avg_sq_dtype",
+    ):
+        value = normalized.get(key)
+        if isinstance(value, str):
+            normalized[key] = dtype_map[value.lower()]
+    return normalized
+
+
 def _create_megatron_config(
     model_cfg: Any,
     checkpoint_config: CheckpointConfig,
@@ -1128,7 +1172,7 @@ def _create_megatron_config(
         "overlap_param_gather"
     ]
     optimizer_kwargs = {
-        **config["megatron_cfg"]["optimizer"],
+        **_normalize_optimizer_dtypes(config["megatron_cfg"]["optimizer"]),
         "overlap_param_gather": overlap_param_gather,
         "reuse_grad_buf_for_mxfp8_param_ag": reuse_grad_buf_for_mxfp8_param_ag,
     }
@@ -1167,7 +1211,13 @@ def _create_megatron_config(
         ),
         optimizer=OptimizerConfig(**optimizer_kwargs),
         ddp=DistributedDataParallelConfig(
-            check_for_nan_in_grad=True,
+            # check_grads does a per-bucket D2H sync inside the grad-ready
+            # hook, which can deadlock large multi-node MoE runs mid-backward
+            # (mcore's own default is False). NaN grads still surface via the
+            # optimizer's global grad norm.
+            check_for_nan_in_grad=config["megatron_cfg"][
+                "distributed_data_parallel_config"
+            ].get("check_for_nan_in_grad", True),
             grad_reduce_in_fp32=config["megatron_cfg"][
                 "distributed_data_parallel_config"
             ]["grad_reduce_in_fp32"],
@@ -1309,6 +1359,16 @@ def setup_model_and_optimizer(
     state.initialize_async_checkpoint_worker()
 
     megatron_cfg.dist.external_gpu_device_mapping = True
+    # initialize_megatron creates TP/PP/EP/DP sub-groups with an explicit
+    # timeout (mcore default 10 min) that overrides the default-group value
+    # from setup_distributed() — keep both knobs on the same env var.
+    megatron_cfg.dist.distributed_timeout_minutes = int(
+        os.environ.get("NRL_NCCL_TIMEOUT_MINUTES", "60")
+    )
+    # If a collective still times out, dump the NCCL flight-recorder trace so
+    # the stalled rank/op is identifiable post-mortem (pair with
+    # TORCH_NCCL_DEBUG_INFO_TEMP_FILE on a mounted path).
+    megatron_cfg.dist.flight_recorder_dump_on_timeout = True
     initialize_megatron(
         cfg=megatron_cfg,
         get_embedding_ranks=get_embedding_ranks,

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -281,6 +281,10 @@ class MegatronDDPConfig(TypedDict):
     overlap_param_gather: bool
     use_custom_fsdp: bool
     data_parallel_sharding_strategy: str
+    # Validate per-bucket grads for NaNs in the grad-ready hook (a D2H sync
+    # mid-backward). Absent keeps the current default (true); set false for
+    # large multi-node MoE runs where the sync can deadlock collectives.
+    check_for_nan_in_grad: NotRequired[bool]
 
 
 class Fp8Config(TypedDict):
@@ -415,6 +419,11 @@ class MegatronConfig(TypedDict):
     gradient_accumulation_fusion: NotRequired[bool]
     # Enable fused weighted squared ReLU when the architecture supports it.
     use_fused_weighted_squared_relu: NotRequired[bool]
+    # Keep the first/last transformer layers in BF16 (used by FP8 recipes to
+    # preserve precision at the model boundaries).
+    first_last_layers_bf16: NotRequired[bool]
+    num_layers_at_start_in_bf16: NotRequired[int]
+    num_layers_at_end_in_bf16: NotRequired[int]
     # When True, computes per-token logprobs with a chunked linear cross-entropy
     # fusion kernel directly from hidden states, avoiding materialization of the
     # full [batch, seq_len, vocab_size] logit tensor. This significantly reduces

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -281,9 +281,6 @@ class MegatronDDPConfig(TypedDict):
     overlap_param_gather: bool
     use_custom_fsdp: bool
     data_parallel_sharding_strategy: str
-    # Validate per-bucket grads for NaNs in the grad-ready hook (a D2H sync
-    # mid-backward). Absent keeps the current default (true); set false for
-    # large multi-node MoE runs where the sync can deadlock collectives.
     check_for_nan_in_grad: NotRequired[bool]
 
 
@@ -419,11 +416,6 @@ class MegatronConfig(TypedDict):
     gradient_accumulation_fusion: NotRequired[bool]
     # Enable fused weighted squared ReLU when the architecture supports it.
     use_fused_weighted_squared_relu: NotRequired[bool]
-    # Keep the first/last transformer layers in BF16 (used by FP8 recipes to
-    # preserve precision at the model boundaries).
-    first_last_layers_bf16: NotRequired[bool]
-    num_layers_at_start_in_bf16: NotRequired[int]
-    num_layers_at_end_in_bf16: NotRequired[int]
     # When True, computes per-token logprobs with a chunked linear cross-entropy
     # fusion kernel directly from hidden states, avoiding materialization of the
     # full [batch, seq_len, vocab_size] logit tensor. This significantly reduces

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -695,6 +695,18 @@ class MegatronPolicyWorkerImpl(
                     mtp_scale = 1.0 / global_valid_toks.clamp(min=1).float()
                     self._set_mtp_grad_scale_func(lambda: mtp_scale)
 
+                    # Memory snapshot before the fwd/bwd peak; opt in via
+                    # NRL_MEM_DEBUG=1.
+                    if os.environ.get("NRL_MEM_DEBUG") == "1":
+                        _alloc = torch.cuda.memory_allocated() / (1024**3)
+                        _resv = torch.cuda.memory_reserved() / (1024**3)
+                        _free, _total = torch.cuda.mem_get_info()
+                        print(
+                            f"[mem-debug] rank={self.rank} before train fwd/bwd: "
+                            f"allocated={_alloc:.1f}GiB reserved={_resv:.1f}GiB "
+                            f"device_free={_free / (1024**3):.1f}GiB of {_total / (1024**3):.1f}GiB"
+                        )
+
                     # Forward pass.
                     draft_enabled = "draft" in self.cfg and self.cfg["draft"]["enabled"]
                     use_router_replay = _should_use_router_replay(
@@ -1940,9 +1952,36 @@ class MegatronPolicyWorkerImpl(
             conversion_tasks=self.refit_conversion_tasks,
         )
 
+        # Stacked 3D fused-expert exports ([num_experts, ...] gate_up_proj /
+        # down_proj) trip vLLM 0.20's fused FusedMoE load path for Qwen3.5
+        # ("shard_dim=0 is not a valid data dimension for a 3D tensor"), which
+        # kills the collective refit. Split them into per-expert 2D HF tensors
+        # (experts.{i}.{gate,up,down}_proj.weight), which vLLM loads through
+        # its standard per-expert mapping. Both prepare_refit_info and the
+        # broadcast use this same iterator, so metadata and payload agree.
+        # Disable with NRL_REFIT_SPLIT_FUSED_EXPERTS=0.
+        split_fused = os.environ.get("NRL_REFIT_SPLIT_FUSED_EXPERTS", "1") == "1"
+
+        def _maybe_split_fused_experts(name, tensor):
+            if not split_fused or tensor.ndim != 3:
+                yield name, tensor
+                return
+            if name.endswith(".mlp.experts.gate_up_proj"):
+                prefix = name[: -len("gate_up_proj")]
+                inter = tensor.shape[1] // 2
+                for e in range(tensor.shape[0]):
+                    yield f"{prefix}{e}.gate_proj.weight", tensor[e, :inter]
+                    yield f"{prefix}{e}.up_proj.weight", tensor[e, inter:]
+            elif name.endswith(".mlp.experts.down_proj"):
+                prefix = name[: -len("down_proj")]
+                for e in range(tensor.shape[0]):
+                    yield f"{prefix}{e}.down_proj.weight", tensor[e]
+            else:
+                yield name, tensor
+
         # Yield the original parameters first.
         for name, tensor in base_iter:
-            yield name, tensor
+            yield from _maybe_split_fused_experts(name, tensor)
 
         if self.draft_model is not None:
             from nemo_rl.models.megatron.draft import export_eagle_weights_to_hf
@@ -2013,9 +2052,27 @@ class MegatronPolicyWorkerImpl(
         self, kv_scales: Optional[dict[str, float]] = None
     ) -> None:
         """Broadcast the weights for collective communication."""
+
+        def _log_expert_shapes_once(iterator):
+            log_experts = not getattr(self, "_refit_expert_shapes_logged", False)
+            logged = 0
+            for name, tensor in iterator:
+                if log_experts and ".mlp.experts." in name and logged < 4:
+                    # A few representative tensors are enough to diagnose
+                    # layout mismatches on the vLLM side.
+                    logged += 1
+                    print(
+                        f"[refit-debug] sending '{name}' "
+                        f"shape={tuple(tensor.shape)} dtype={tensor.dtype}"
+                    )
+                yield name, tensor
+            self._refit_expert_shapes_logged = True
+
         # param_iterator will return (name, tensor), we only need tensor.
         packed_broadcast_producer(
-            iterator=self._iter_params_with_optional_kv_scales(kv_scales=kv_scales),
+            iterator=_log_expert_shapes_once(
+                self._iter_params_with_optional_kv_scales(kv_scales=kv_scales)
+            ),
             group=self.model_update_group,
             src=0,
             post_iter_func=lambda x: x[1],

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -695,18 +695,6 @@ class MegatronPolicyWorkerImpl(
                     mtp_scale = 1.0 / global_valid_toks.clamp(min=1).float()
                     self._set_mtp_grad_scale_func(lambda: mtp_scale)
 
-                    # Memory snapshot before the fwd/bwd peak; opt in via
-                    # NRL_MEM_DEBUG=1.
-                    if os.environ.get("NRL_MEM_DEBUG") == "1":
-                        _alloc = torch.cuda.memory_allocated() / (1024**3)
-                        _resv = torch.cuda.memory_reserved() / (1024**3)
-                        _free, _total = torch.cuda.mem_get_info()
-                        print(
-                            f"[mem-debug] rank={self.rank} before train fwd/bwd: "
-                            f"allocated={_alloc:.1f}GiB reserved={_resv:.1f}GiB "
-                            f"device_free={_free / (1024**3):.1f}GiB of {_total / (1024**3):.1f}GiB"
-                        )
-
                     # Forward pass.
                     draft_enabled = "draft" in self.cfg and self.cfg["draft"]["enabled"]
                     use_router_replay = _should_use_router_replay(
@@ -2052,27 +2040,9 @@ class MegatronPolicyWorkerImpl(
         self, kv_scales: Optional[dict[str, float]] = None
     ) -> None:
         """Broadcast the weights for collective communication."""
-
-        def _log_expert_shapes_once(iterator):
-            log_experts = not getattr(self, "_refit_expert_shapes_logged", False)
-            logged = 0
-            for name, tensor in iterator:
-                if log_experts and ".mlp.experts." in name and logged < 4:
-                    # A few representative tensors are enough to diagnose
-                    # layout mismatches on the vLLM side.
-                    logged += 1
-                    print(
-                        f"[refit-debug] sending '{name}' "
-                        f"shape={tuple(tensor.shape)} dtype={tensor.dtype}"
-                    )
-                yield name, tensor
-            self._refit_expert_shapes_logged = True
-
         # param_iterator will return (name, tensor), we only need tensor.
         packed_broadcast_producer(
-            iterator=_log_expert_shapes_once(
-                self._iter_params_with_optional_kv_scales(kv_scales=kv_scales)
-            ),
+            iterator=self._iter_params_with_optional_kv_scales(kv_scales=kv_scales),
             group=self.model_update_group,
             src=0,
             post_iter_func=lambda x: x[1],

--- a/tests/unit/algorithms/test_async_utils.py
+++ b/tests/unit/algorithms/test_async_utils.py
@@ -644,6 +644,31 @@ class TestReplayBuffer:
 
         ray.kill(buffer)
 
+    def test_replay_buffer_future_target_weight_matching(self):
+        """Test that sampling can use trajectories intended for a future step."""
+        buffer = ReplayBuffer.remote(max_size=10)
+
+        trajectory = {
+            "batch": {"data": "for_future_step"},
+            "rollout_metrics": {"reward": 1.0},
+        }
+        ray.get(
+            buffer.add.remote(trajectory, weight_version=1, target_weight_version=3)
+        )
+
+        sample_result = ray.get(
+            buffer.sample.remote(
+                num_prompt_groups=1,
+                current_weight_version=2,
+                max_age_steps=1,
+            )
+        )
+
+        assert sample_result is not None
+        assert sample_result["trajectories"][0]["batch"]["data"] == "for_future_step"
+
+        ray.kill(buffer)
+
     def test_replay_buffer_get_existing_target_weights(self):
         """Test getting existing target weight versions."""
         buffer = ReplayBuffer.remote(max_size=10)

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -29,6 +29,7 @@ from nemo_rl.algorithms.advantage_estimator import (
 from nemo_rl.algorithms.grpo import (
     MasterConfig,
     RewardPenaltyConfig,
+    _calculate_observed_pass_metrics,
     _apply_configured_message_level_advantage_penalties,
     _apply_mask_sample_filter,
     _apply_message_level_advantage_penalties,
@@ -37,10 +38,13 @@ from nemo_rl.algorithms.grpo import (
     _raise_if_reward_penalties_enabled_without_nemo_gym,
     _resolve_message_level_advantage_penalties,
     _should_use_async_rollouts,
+    _stable_group_ids,
+    add_grpo_token_loss_masks_and_generation_logprobs,
     aggregate_rollout_metrics,
     async_grpo_train,
     compute_and_apply_seq_logprob_error_masking,
     dynamic_sampling,
+    extract_initial_prompt_messages,
     grpo_train,
     refit_policy_generation,
     validate,
@@ -156,6 +160,29 @@ def test_initial_policy_generation_stale() -> None:
     assert _initial_policy_generation_stale(generation, completed_steps=0)
 
 
+def test_stable_group_ids_uses_contiguous_prompt_groups():
+    rendered_prompt_ids = torch.tensor(
+        [
+            [10, 11],
+            [10, 12],
+            [20, 21],
+            [20, 22],
+        ]
+    )
+
+    result = _stable_group_ids(rendered_prompt_ids, num_generations_per_prompt=2)
+
+    assert torch.equal(result, torch.tensor([[0], [0], [1], [1]]))
+
+
+def test_stable_group_ids_falls_back_for_incomplete_group():
+    rendered_prompt_ids = torch.tensor([[10], [11], [20]])
+
+    result = _stable_group_ids(rendered_prompt_ids, num_generations_per_prompt=2)
+
+    assert result is rendered_prompt_ids
+
+
 @pytest.fixture
 def mock_grpo_components():
     # Create mock components
@@ -260,6 +287,7 @@ def mock_grpo_components():
                 "num_generations_per_prompt": 1,
                 "max_rollout_turns": 1,
                 "val_period": 100,
+                "val_start_at": 0,
                 "val_batch_size": 1,
                 "val_at_start": False,
                 "val_at_end": False,
@@ -2443,6 +2471,80 @@ def test_grpo_train_skips_prev_logprobs_when_force_on_policy_ratio(
 
 
 @pytest.mark.parametrize("train_func", [grpo_train, async_grpo_train])
+@pytest.mark.parametrize(
+    ("val_at_end", "expected_validation_steps"),
+    [(False, [4]), (True, [4, 5])],
+)
+def test_periodic_validation_starts_at_configured_step(
+    mock_grpo_components, train_func, val_at_end, expected_validation_steps
+):
+    """Both trainers preserve cadence while honoring the validation lower bound."""
+    master_config = mock_grpo_components["master_config"]
+    master_config.grpo.update(
+        {
+            "max_num_steps": 5,
+            "val_period": 2,
+            "val_start_at": 3,
+            "val_at_end": val_at_end,
+        }
+    )
+    mock_batch = next(iter(mock_grpo_components["train_dataloader"]))
+    mock_rollout_metrics = {
+        "mean_gen_tokens_per_sample": 10.0,
+        "max_gen_tokens": 20,
+        "min_gen_tokens": 5,
+    }
+
+    with ExitStack() as stack:
+        if train_func == async_grpo_train:
+            master_config.policy["generation"]["colocated"]["enabled"] = False
+            stack.enter_context(
+                mock_async_grpo_infrastructure(mock_batch, mock_rollout_metrics)
+            )
+        else:
+            stack.enter_context(
+                patch(
+                    "nemo_rl.algorithms.grpo.run_multi_turn_rollout",
+                    return_value=(mock_batch, mock_rollout_metrics),
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "nemo_rl.algorithms.grpo.run_async_multi_turn_rollout",
+                    return_value=(mock_batch, mock_rollout_metrics),
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "nemo_rl.algorithms.grpo.compute_and_apply_seq_logprob_error_masking",
+                    return_value=_mock_seq_logprob_error_result(),
+                )
+            )
+
+        mock_validate = stack.enter_context(
+            patch("nemo_rl.algorithms.grpo.validate", return_value=({}, {}))
+        )
+        train_func(
+            mock_grpo_components["policy"],
+            _mock_policy_generation(),
+            mock_grpo_components["train_dataloader"],
+            mock_grpo_components["val_dataloader"],
+            mock_grpo_components["tokenizer"],
+            mock_grpo_components["loss_fn"],
+            mock_grpo_components["task_to_env"],
+            mock_grpo_components["val_task_to_env"],
+            mock_grpo_components["logger"],
+            mock_grpo_components["checkpointer"],
+            _default_grpo_save_state(),
+            master_config,
+        )
+
+    assert [call.kwargs["step"] for call in mock_validate.call_args_list] == (
+        expected_validation_steps
+    )
+
+
+@pytest.mark.parametrize("train_func", [grpo_train, async_grpo_train])
 def test_grpo_exit_on_max_steps(mock_grpo_components, train_func):
     """Test that GRPO training loop exits when max_num_steps is reached"""
     # Set max steps to 12
@@ -2994,6 +3096,34 @@ def test_reinforce_plus_plus_global_normalization():
 # ============================================================================
 
 
+def test_calculate_observed_pass_metrics():
+    metrics = _calculate_observed_pass_metrics(
+        [
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        ],
+        num_generations_per_prompt=4,
+    )
+
+    assert metrics == pytest.approx(
+        {
+            "pass@4": 2 / 3,
+            "pass^4": 1 / 3,
+            "pass@1[avg-of-4]": 5 / 12,
+        }
+    )
+
+
 class TestValidateFunction:
     """Tests for the validate() function."""
 
@@ -3169,6 +3299,66 @@ class TestValidateFunction:
         # Verify metrics are returned correctly
         assert "accuracy" in val_metrics
         assert "avg_length" in val_metrics
+
+    def test_grouped_validation_uses_pass_at_k_as_accuracy(self, mock_grpo_components):
+        mock_batch = BatchedDataDict[DatumSpec](
+            {
+                "message_log": [
+                    [{"role": "user", "content": "a", "token_ids": torch.tensor([1])}],
+                    [{"role": "user", "content": "b", "token_ids": torch.tensor([2])}],
+                ],
+                "task_name": ["math", "math"],
+                "extra_env_info": [{}, {}],
+                "loss_multiplier": torch.tensor([1.0, 1.0]),
+                "idx": torch.tensor([0, 1]),
+                "length": torch.tensor([1, 1]),
+                "total_reward": torch.tensor([0.0, 0.0]),
+            }
+        )
+        mock_dataloader = MagicMock(spec=StatefulDataLoader)
+        mock_dataloader.__iter__ = MagicMock(return_value=iter([mock_batch]))
+        mock_config = mock_grpo_components["master_config"]
+        mock_config.grpo.update(
+            {
+                "max_val_samples": 2,
+                "val_batch_size": 2,
+                "num_val_generations_per_prompt": 4,
+                "validation_generation": None,
+            }
+        )
+
+        def run_rollout(_policy, repeated_batch, *_args, **_kwargs):
+            assert repeated_batch["idx"].tolist() == [0, 0, 0, 0, 1, 1, 1, 1]
+            repeated_batch["total_reward"] = torch.tensor(
+                [1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0]
+            )
+            return repeated_batch, {"mean_gen_tokens_per_sample": 1.0}
+
+        with (
+            patch(
+                "nemo_rl.algorithms.grpo.run_multi_turn_rollout",
+                side_effect=run_rollout,
+            ),
+            patch("nemo_rl.algorithms.grpo._should_use_nemo_gym", return_value=False),
+            patch(
+                "nemo_rl.algorithms.grpo._should_use_async_rollouts",
+                return_value=False,
+            ),
+            patch("nemo_rl.algorithms.grpo.print_message_log_samples"),
+        ):
+            val_metrics, _ = validate(
+                MagicMock(),
+                mock_dataloader,
+                MagicMock(),
+                {"math": MagicMock(spec=EnvironmentInterface)},
+                step=0,
+                master_config=mock_config,
+            )
+
+        assert val_metrics["accuracy"] == pytest.approx(1.0)
+        assert val_metrics["pass@4"] == pytest.approx(1.0)
+        assert val_metrics["pass^4"] == pytest.approx(0.5)
+        assert val_metrics["pass@1[avg-of-4]"] == pytest.approx(5 / 8)
 
     def test_validate_returns_empty_when_no_dataloader(self, mock_grpo_components):
         """Test that validate returns empty dicts when no dataloader is provided."""
@@ -3629,3 +3819,138 @@ class TestAggregateRolloutMetrics:
         assert result["total_turns"] == 45
         assert result["accuracy"] == pytest.approx(0.8)
         assert result["min_accuracy_rate"] == pytest.approx(0.2)
+
+
+class TestMultiTurnPromptHelpers:
+    """Tests for GRPO multi-turn prompt extraction and loss masking."""
+
+    def test_prompt_extraction_with_multi_turn_history(self):
+        original_prompt_messages = [
+            {
+                "role": "user",
+                "content": "What is 2+2?",
+                "token_ids": torch.tensor([1, 2]),
+            },
+            {
+                "role": "assistant",
+                "content": "4",
+                "token_ids": torch.tensor([3, 4]),
+            },
+            {
+                "role": "user",
+                "content": "Now what is 3+3?",
+                "token_ids": torch.tensor([5, 6]),
+            },
+        ]
+        generated_message = {
+            "role": "assistant",
+            "content": "6",
+            "token_ids": torch.tensor([7, 8]),
+        }
+        full_message_log = original_prompt_messages + [generated_message]
+        original_prompt_length = sum(
+            len(message["token_ids"]) for message in original_prompt_messages
+        )
+
+        result = extract_initial_prompt_messages(
+            [full_message_log], torch.tensor([original_prompt_length])
+        )
+
+        assert [message["role"] for message in result[0]] == [
+            "user",
+            "assistant",
+            "user",
+        ]
+        assert generated_message not in result[0]
+
+    def test_prompt_extraction_with_system_message(self):
+        original_prompt_messages = [
+            {
+                "role": "system",
+                "content": "You are a math tutor.",
+                "token_ids": torch.tensor([1, 2, 3]),
+            },
+            {
+                "role": "user",
+                "content": "What is 2+2?",
+                "token_ids": torch.tensor([4, 5]),
+            },
+        ]
+        generated_message = {
+            "role": "assistant",
+            "content": "4",
+            "token_ids": torch.tensor([6, 7]),
+        }
+        full_message_log = original_prompt_messages + [generated_message]
+        original_prompt_length = sum(
+            len(message["token_ids"]) for message in original_prompt_messages
+        )
+
+        result = extract_initial_prompt_messages(
+            [full_message_log], torch.tensor([original_prompt_length])
+        )
+
+        assert [message["role"] for message in result[0]] == ["system", "user"]
+        assert generated_message not in result[0]
+
+    def test_grpo_loss_mask_excludes_assistant_prompt_history(self):
+        message_log = [
+            {
+                "role": "user",
+                "content": "What is 2+2?",
+                "token_ids": torch.tensor([1, 2]),
+            },
+            {
+                "role": "assistant",
+                "content": "4",
+                "token_ids": torch.tensor([3, 4]),
+            },
+            {
+                "role": "user",
+                "content": "Now what is 3+3?",
+                "token_ids": torch.tensor([5, 6]),
+            },
+            {
+                "role": "assistant",
+                "content": "6",
+                "token_ids": torch.tensor([7, 8]),
+                "generation_logprobs": torch.tensor([0.1, 0.2]),
+            },
+        ]
+
+        add_grpo_token_loss_masks_and_generation_logprobs([message_log])
+
+        assert torch.equal(message_log[0]["token_loss_mask"], torch.tensor([0, 0]))
+        assert torch.equal(message_log[1]["token_loss_mask"], torch.tensor([0, 0]))
+        assert torch.equal(message_log[2]["token_loss_mask"], torch.tensor([0, 0]))
+        assert torch.equal(message_log[3]["token_loss_mask"], torch.tensor([1, 1]))
+
+    def test_grpo_loss_mask_uses_generation_logprobs_marker(self):
+        message_log = [
+            {
+                "role": "assistant",
+                "content": "prompt history",
+                "token_ids": torch.tensor([1, 2]),
+            },
+            {
+                "role": "user",
+                "content": "next question",
+                "token_ids": torch.tensor([3, 4]),
+                "generation_logprobs": torch.tensor([0.3, 0.4]),
+            },
+            {
+                "role": "assistant",
+                "content": "generated response",
+                "token_ids": torch.tensor([5, 6]),
+                "generation_logprobs": torch.tensor([0.5, 0.6]),
+            },
+        ]
+
+        add_grpo_token_loss_masks_and_generation_logprobs([message_log])
+
+        assert torch.equal(message_log[0]["token_loss_mask"], torch.tensor([0, 0]))
+        assert torch.equal(
+            message_log[0]["generation_logprobs"], torch.tensor([0.0, 0.0])
+        )
+        assert torch.equal(message_log[1]["token_loss_mask"], torch.tensor([0, 0]))
+        assert torch.equal(message_log[2]["token_loss_mask"], torch.tensor([1, 1]))

--- a/tests/unit/environments/test_nemo_gym.py
+++ b/tests/unit/environments/test_nemo_gym.py
@@ -11,15 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import json
 import time
 from copy import deepcopy
 from pathlib import Path
+from types import MethodType
 
 import pytest
 import ray
 import requests
 import torch
+from aiohttp import ClientConnectionError
 from yaml import safe_load
 
 from nemo_rl.algorithms.grpo import MasterConfig
@@ -311,67 +314,192 @@ def test_nemo_gym_postprocess_uses_batch_decode():
     assert nemo_gym_result["response"]["output"][1]["generation_str"] == "6 7"
 
 
-def test_nemo_gym_postprocess_no_generation_data_raises():
-    """When no output item carries generation data, the postprocess should raise a
-    ValueError that reports the prompt length and the response.output item types."""
-
+def test_nemo_gym_postprocess_empty_generation_is_masked_zero_reward():
     class _Tokenizer:
-        def apply_chat_template(self, input_messages, tokenize=True):
-            # Pretend the prompt is 1234 tokens long.
-            return list(range(1234))
+        pad_token_id = 7
+        eos_token_id = 8
+
+        def apply_chat_template(self, messages, tokenize=True):
+            return [1, 2, 3]
+
+    class _MockSelf:
+        cfg = {"backfill_failed_rollouts": True}
 
     nemo_gym_result = {
-        "response": {
-            "output": [
-                {"type": "reasoning"},
-                {"type": "function_call"},
-            ]
-        },
-        "responses_create_params": {"input": [{"role": "user", "content": "hi"}]},
+        "response": {"output": []},
+        "responses_create_params": {"input": [{"role": "user", "content": "x"}]},
+        "reward": 1.0,
     }
+
+    mock_self = _MockSelf()
+    zero_reward = NemoGym.__ray_metadata__.modified_class._zero_reward_nemo_rl_result
+    mock_self._zero_reward_nemo_rl_result = MethodType(zero_reward, mock_self)
+    result = (
+        NemoGym.__ray_metadata__.modified_class._postprocess_nemo_gym_to_nemo_rl_result(
+            mock_self, nemo_gym_result, _Tokenizer()
+        )
+    )
+
+    assert result["full_result"]["reward"] == 0.0
+    assert result["message_log"][0]["token_ids"].tolist() == [7, 7]
+    assert result["message_log"][1]["token_ids"].tolist() == [7]
+    assert "generation_logprobs" not in result["message_log"][1]
+
+
+def _collect_rollout_stream(mock_self, rows, tokenizer):
+    """Drain the run_rollouts async generator and return the yielded items."""
+
+    async def _collect():
+        items = []
+        async for item in NemoGym.__ray_metadata__.modified_class.run_rollouts(
+            mock_self, rows, tokenizer, "timing/rollout"
+        ):
+            items.append(item)
+        return items
+
+    return asyncio.run(_collect())
+
+
+def test_nemo_gym_transport_failure_preserves_batch_shape():
+    async def failed_rollout():
+        raise ClientConnectionError("transient failure")
+
+    class _RolloutCollectionHelper:
+        def run_examples(self, examples, head_server_config):
+            return [failed_rollout()]
+
+    class _Tokenizer:
+        pad_token_id = 7
+        eos_token_id = 8
+
+    class _MockSelf:
+        cfg = {"backfill_failed_rollouts": True}
+        rch = _RolloutCollectionHelper()
+        head_server_config = object()
+
+    mock_self = _MockSelf()
+    modified_class = NemoGym.__ray_metadata__.modified_class
+    mock_self._postprocess_nemo_gym_to_nemo_rl_result = MethodType(
+        modified_class._postprocess_nemo_gym_to_nemo_rl_result, mock_self
+    )
+    mock_self._zero_reward_nemo_rl_result = MethodType(
+        modified_class._zero_reward_nemo_rl_result, mock_self
+    )
+
+    items = _collect_rollout_stream(
+        mock_self, [{"_rowidx": 0, "agent_ref": {"name": "agent"}}], _Tokenizer()
+    )
+
+    assert len(items) == 1
+    rowidx, result, timing_metrics = items[0]
+    assert rowidx == 0
+    assert result["full_result"]["reward"] == 0.0
+    assert result["full_result"]["nemo_rl_fallback_reason"] == "rollout_failed"
+    # The back-filled final row still carries the batch timing metrics.
+    assert timing_metrics is not None
+
+
+def test_nemo_gym_transport_failure_raises_by_default():
+    """Without backfill_failed_rollouts, rollout failures fail the batch."""
+
+    async def failed_rollout():
+        raise ClientConnectionError("transient failure")
+
+    class _RolloutCollectionHelper:
+        def run_examples(self, examples, head_server_config):
+            return [failed_rollout()]
+
+    class _Tokenizer:
+        pad_token_id = 7
+        eos_token_id = 8
 
     class _MockSelf:
         cfg = {}
+        rch = _RolloutCollectionHelper()
+        head_server_config = object()
 
-    with pytest.raises(ValueError) as excinfo:
-        NemoGym.__ray_metadata__.modified_class._postprocess_nemo_gym_to_nemo_rl_result(
-            _MockSelf(), nemo_gym_result, _Tokenizer()
+    with pytest.raises(ClientConnectionError):
+        _collect_rollout_stream(
+            _MockSelf(), [{"_rowidx": 0, "agent_ref": {"name": "agent"}}], _Tokenizer()
         )
 
-    msg = str(excinfo.value)
-    assert "no generation data" in msg
-    assert "1234 tokens" in msg
-    # The error surfaces the response.output item types to help diagnose case (2).
-    assert "['reasoning', 'function_call']" in msg
 
+def test_nemo_gym_postprocess_failure_preserves_batch_shape():
+    async def malformed_rollout():
+        return (
+            {"_rowidx": 0, "agent_ref": {"name": "agent"}},
+            {
+                "response": {
+                    "output": [
+                        {
+                            "generation_token_ids": [3],
+                            "generation_log_probs": [-0.1],
+                        }
+                    ]
+                },
+                "reward": 1.0,
+            },
+        )
 
-def test_nemo_gym_postprocess_no_generation_data_chat_template_failure():
-    """If apply_chat_template itself fails while building the error message, the
-    postprocess should still raise the original 'no generation data' ValueError with
-    the prompt length reported as unknown rather than masking it with a new error."""
+    class _RolloutCollectionHelper:
+        def run_examples(self, examples, head_server_config):
+            return [malformed_rollout()]
 
     class _Tokenizer:
-        def apply_chat_template(self, input_messages, tokenize=True):
-            raise RuntimeError("boom")
-
-    nemo_gym_result = {
-        "response": {"output": [{"type": "reasoning"}]},
-        "responses_create_params": {"input": [{"role": "user", "content": "hi"}]},
-    }
+        pad_token_id = 7
+        eos_token_id = 8
 
     class _MockSelf:
-        cfg = {}
+        cfg = {"backfill_failed_rollouts": True}
+        rch = _RolloutCollectionHelper()
+        head_server_config = object()
 
-    with pytest.raises(ValueError) as excinfo:
-        NemoGym.__ray_metadata__.modified_class._postprocess_nemo_gym_to_nemo_rl_result(
-            _MockSelf(), nemo_gym_result, _Tokenizer()
-        )
+    mock_self = _MockSelf()
+    modified_class = NemoGym.__ray_metadata__.modified_class
+    mock_self._postprocess_nemo_gym_to_nemo_rl_result = MethodType(
+        modified_class._postprocess_nemo_gym_to_nemo_rl_result, mock_self
+    )
+    mock_self._zero_reward_nemo_rl_result = MethodType(
+        modified_class._zero_reward_nemo_rl_result, mock_self
+    )
 
-    msg = str(excinfo.value)
-    assert "no generation data" in msg
-    assert "apply_chat_template failed" in msg
-    assert "RuntimeError" in msg
-    assert "['reasoning']" in msg
+    items = _collect_rollout_stream(
+        mock_self, [{"_rowidx": 0, "agent_ref": {"name": "agent"}}], _Tokenizer()
+    )
+
+    assert len(items) == 1
+    rowidx, result, _ = items[0]
+    assert rowidx == 0
+    assert result["full_result"]["reward"] == 0.0
+    assert result["full_result"]["nemo_rl_fallback_reason"].startswith(
+        "postprocess_failed:KeyError"
+    )
+
+
+def test_nemo_gym_malformed_response_is_masked_zero_reward():
+    class _Tokenizer:
+        pad_token_id = 7
+        eos_token_id = 8
+
+    class _MockSelf:
+        cfg = {"backfill_failed_rollouts": True}
+
+    mock_self = _MockSelf()
+    modified_class = NemoGym.__ray_metadata__.modified_class
+    mock_self._zero_reward_nemo_rl_result = MethodType(
+        modified_class._zero_reward_nemo_rl_result, mock_self
+    )
+
+    result = modified_class._postprocess_nemo_gym_to_nemo_rl_result(
+        mock_self,
+        {"response": {"output": None}, "reward": 1.0},
+        _Tokenizer(),
+    )
+
+    assert result["full_result"]["reward"] == 0.0
+    assert result["full_result"]["nemo_rl_fallback_reason"] == (
+        "malformed_response_output:NoneType"
+    )
 
 
 @pytest.mark.nemo_gym

--- a/tests/unit/experience/test_reward_penalties.py
+++ b/tests/unit/experience/test_reward_penalties.py
@@ -18,7 +18,6 @@ import pytest
 import torch
 
 from nemo_rl.experience.rollouts import (
-    _extract_mask_sample_flags,
     apply_reward_penalties,
     resolve_reward_penalty_config,
 )
@@ -84,24 +83,6 @@ class _FakeTokenizer:
     def encode(self, text, add_special_tokens=False):
         assert not add_special_tokens
         return self.token_map[text]
-
-
-class TestExtractMaskSampleFlags:
-    def test_reads_mask_sample_from_instance_config(self):
-        results = [
-            {"full_result": {"instance_config": {"mask_sample": True}}},
-            {"full_result": {"instance_config": {"mask_sample": False}}},
-            {"full_result": {"instance_config": {}}},
-            {"full_result": {}},
-            {"full_result": {"instance_config": None}},
-        ]
-
-        mask_sample = _extract_mask_sample_flags(results)
-
-        assert mask_sample.dtype == torch.bool
-        assert torch.equal(
-            mask_sample, torch.tensor([True, False, False, False, False])
-        )
 
 
 # =====================================================================

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -1576,7 +1576,6 @@ def test_run_async_nemo_gym_rollout(
             ],
             "length": torch.tensor([3080, 3048]),
             "loss_multiplier": torch.tensor([1.0, 1.0]),
-            "mask_sample": torch.tensor([False, False]),
             "total_reward": torch.tensor([0.0, 0.0]),
             "truncated": torch.tensor([False, False]),
         },

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -41,6 +41,8 @@ from nemo_rl.environments.games.sliding_puzzle import (
 from nemo_rl.experience.metric_utils import calculate_single_metric, pct
 from nemo_rl.experience.rollout_manager import AsyncNemoGymRolloutImpl
 from nemo_rl.experience.rollouts import (
+    _NEMO_RL_VALIDATION_REQUEST_TYPE,
+    _set_nemo_rl_request_type,
     generate_responses_async,
     run_async_multi_turn_rollout,
     run_async_multi_turn_rollout_groups,
@@ -68,6 +70,42 @@ from tests.unit.test_envs import (
 )
 
 MODEL_NAME = "Qwen/Qwen2.5-1.5B-Instruct"
+
+
+def test_set_nemo_rl_request_type_preserves_template_metadata():
+    params = {
+        "metadata": {
+            "chat_template_kwargs": json.dumps({"enable_thinking": False}),
+            "trace_id": "abc",
+        }
+    }
+
+    _set_nemo_rl_request_type(params, _NEMO_RL_VALIDATION_REQUEST_TYPE)
+
+    assert params["metadata"]["trace_id"] == "abc"
+    assert json.loads(params["metadata"]["chat_template_kwargs"]) == {
+        "enable_thinking": False,
+        "_nemo_rl_request_type": "validation",
+    }
+
+
+def test_set_nemo_rl_request_type_clears_stale_marker():
+    params = {
+        "metadata": {
+            "chat_template_kwargs": json.dumps(
+                {
+                    "enable_thinking": False,
+                    "_nemo_rl_request_type": "validation",
+                }
+            )
+        }
+    }
+
+    _set_nemo_rl_request_type(params, None)
+
+    assert json.loads(params["metadata"]["chat_template_kwargs"]) == {
+        "enable_thinking": False
+    }
 
 
 class TestCalculateSingleMetric:

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -1858,6 +1858,98 @@ def test_VllmAsyncGenerationWorker_replace_prefix_tokens(tokenizer):
     assert result == model_token_ids
 
 
+def test_replace_prefix_tokens_empty_model_prefix_returns_template():
+    class _T:
+        eos_token_id = 2
+
+    tokenizer = _T()
+    model_prefix_token_ids = []
+    template_prefix_token_ids = [9, 2]
+    template_token_ids = [9, 2, 33, 44]
+    result = replace_prefix_tokens(
+        tokenizer=tokenizer,
+        model_prefix_token_ids=model_prefix_token_ids,
+        template_prefix_token_ids=template_prefix_token_ids,
+        template_token_ids=template_token_ids,
+    )
+    assert result == template_token_ids
+
+
+def test_replace_prefix_tokens_missing_eos_in_template_prefix_raises():
+    class _T:
+        eos_token_id = 2
+
+        def decode(self, *args, **kwargs):
+            pass
+
+    tokenizer = _T()
+    model_prefix_token_ids = [7, 2]
+    template_prefix_token_ids = [9, 9, 9]  # no EOS inside prefix
+    template_token_ids = [9, 9, 9, 2, 10]
+    with pytest.raises(AssertionError):
+        replace_prefix_tokens(
+            tokenizer=tokenizer,
+            model_prefix_token_ids=model_prefix_token_ids,
+            template_prefix_token_ids=template_prefix_token_ids,
+            template_token_ids=template_token_ids,
+        )
+
+
+def test_replace_prefix_tokens_tokenizer_without_eos_raises():
+    class _T:
+        eos_token_id = None
+
+    tokenizer = _T()
+    with pytest.raises(AssertionError):
+        replace_prefix_tokens(
+            tokenizer=tokenizer,
+            model_prefix_token_ids=[1],
+            template_prefix_token_ids=[1, 2],
+            template_token_ids=[1, 2],
+        )
+
+
+def test_replace_prefix_tokens_uses_last_eos_in_template_prefix():
+    class _T:
+        eos_token_id = 2
+
+    tokenizer = _T()
+    model_prefix_token_ids = [100, 2]
+    template_prefix_token_ids = [9, 2, 9, 2]  # two EOS; last at idx=3
+    template_token_ids = [9, 2, 9, 2, 77, 88]
+    result = replace_prefix_tokens(
+        tokenizer=tokenizer,
+        model_prefix_token_ids=model_prefix_token_ids,
+        template_prefix_token_ids=template_prefix_token_ids,
+        template_token_ids=template_token_ids,
+    )
+    assert result == [100, 2, 77, 88]
+
+
+def test_replace_prefix_tokens_repairs_qwen_normalized_prefix():
+    """Qwen3.5 re-renders assistant history with normalized reasoning content.
+
+    The isolated prefix render differs token-wise from what the model produced;
+    EOS-count splicing must still keep the original generated tokens and resume
+    from the template after the boundary EOS.
+    """
+
+    class _T:
+        eos_token_id = 2
+
+    tokenizer = _T()
+    result = replace_prefix_tokens(
+        tokenizer=tokenizer,
+        model_prefix_token_ids=[10, 11, 2],
+        # Rendering the assistant prefix alone changed token 11 to token 99.
+        template_prefix_token_ids=[10, 99, 2],
+        # Two messages follow that assistant turn, then the generation marker.
+        template_token_ids=[10, 11, 2, 20, 2, 30, 2, 40],
+    )
+
+    assert result == [10, 11, 2, 20, 2, 30, 2, 40]
+
+
 @pytest.mark.asyncio
 async def test_vllm_http_server_correct_merged_tokens_matches_baseline(
     cluster, tokenizer


### PR DESCRIPTION
## What does this PR do?

Merges the Qwen3.5-397B reference training changes into `opt/dev`, rebased onto current `main` (branch is 0 commits behind `opt/dev`).

Included commits:
- **fix(megatron):** GB300 Qwen3.5-397B training stability knobs
- **fix(vllm):** Qwen3.5 MoE refit and async-server fixes
- **feat(grpo):** async-GRPO robustness for long-horizon SWE rollouts
- **feat(grpo):** make env-flagged sample masking optional

## Convergence data

**Setup**
64×GB300 (4 GPUs/node): 16 training nodes (Megatron TP4·PP2·EP32, sequence
packing @ 65 536 tokens, bf16) + 48 generation nodes (24 vLLM engines, TP8/EP8, async
engine). GBS 256 = 16 prompts × 16 generations/step, async GRPO lag-1, NeMo-Gym
OpenHands agents on R2E-Gym easy (curriculum-v2 train set), validation = 256 instances
× 4 generations @ temp 0.1 / top-p 0.95, seed 3978.

**Training reward (fraction of 256 rollouts solved, per step):**

| step | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 |
|---|---|---|---|---|---|---|---|---|---|---|
| reward | .406 | .441 | .406 | .434 | .520 | .387 | .410 | .457 | .629 | .598 |

| step | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | → eval@20 |
|---|---|---|---|---|---|---|---|---|---|---|
| reward | .602 | .461 | .617 | .586 | .637 | .613 | .648 | .574 | .605 | **0.789** |

<img width="458" height="447" alt="Screenshot 2026-07-28 at 15 57 50" src="https://github.com/user-attachments/assets/132956ee-ff50-4e71-ae98-59c852dad991" />

<img width="460" height="448" alt="Screenshot 2026-07-28 at 15 58 01" src="https://github.com/user-attachments/assets/4209fdf1-9eb7-46a7-99ab-6a278159d6d0" />

<img width="464" height="444" alt="Screenshot 2026-07-28 at 15 57 40" src="https://github.com/user-attachments/assets/64fd18a4-1a81-4fe2-aacd-a272673ab7ac" />

<img width="462" height="446" alt="Screenshot 2026-07-28 at 15 57 33" src="https://github.com/user-attachments/assets/9f4a57b9-ff5f-4b6a-8e8c-7ee522029952" />

<img width="462" height="446" alt="Screenshot 2026-07-28 at 15 56 55" src="https://github.com/user-attachments/assets/a09d62c5-dd53-4049-8899-a1bc33b0baf7" />

<img width="468" height="469" alt="Screenshot 2026-07-28 at 16 01 32" src="https://github.com/user-attachments/assets/2743eb36-fac5-4956-a862-202e88afe12d" />
