### PR TITLE
refactor(nemo-gym): centralize actor construction

### DIFF
--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -21,7 +21,6 @@ import numpy as np
 import ray
 import torch
 from pydantic import BaseModel
-from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import AutoConfig, AutoTokenizer
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
@@ -50,11 +49,8 @@ from nemo_rl.distributed.virtual_cluster import (
 )
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.environments.nemo_gym import (
-    NemoGym,
-    NemoGymConfig,
-    get_nemo_gym_uv_cache_dir,
-    get_nemo_gym_venv_dir,
     should_use_nemo_gym,
+    spinup_nemo_gym_actor,
 )
 from nemo_rl.experience.rollouts import (
     run_async_multi_turn_rollout,
@@ -86,7 +82,6 @@ from nemo_rl.utils.logger import (
 )
 from nemo_rl.utils.nsys import maybe_gpu_profile_step
 from nemo_rl.utils.timer import TimeoutChecker, Timer
-from nemo_rl.utils.venvs import make_actor_runtime_env
 from nemo_rl.weight_sync.checkpoint_engine_config import (
     checkpoint_engine_refit_config,
 )
@@ -341,12 +336,6 @@ def setup(
     colocated_inference = generation_config["colocated"]["enabled"]
     enable_nemo_gym = bool(env_configs) and should_use_nemo_gym(master_config)
     nemo_gym_actor: Optional[EnvironmentInterface] = None
-    if enable_nemo_gym:
-        nemo_gym_num_nodes = env_configs.get("nemo_gym", {}).get("num_gpu_nodes", 0)
-        ray_cur_node_id = ray.get_runtime_context().get_node_id()
-    else:
-        nemo_gym_num_nodes = 0
-        ray_cur_node_id = None
     segment_size = cluster_config.get("segment_size")
 
     if colocated_inference:
@@ -529,45 +518,15 @@ def setup(
                 return deferred_vllm
 
             def init_nemo_gym():
-                nemo_gym_dict = dict(env_configs["nemo_gym"])
-                # These are NeMo-RL-side fields consumed by NemoGymConfig, not
-                # NeMo-Gym global config entries.
-                invalid_tool_call_patterns = nemo_gym_dict.pop(
-                    "invalid_tool_call_patterns", None
-                )
-                thinking_tags = nemo_gym_dict.pop("thinking_tags", None)
-                # Pass prebuilt cache + venv dirs through the global config so the
-                # gym reuses image-baked venvs instead of rebuilding them.
-                uv_cache_dir = get_nemo_gym_uv_cache_dir()
-                if uv_cache_dir is not None:
-                    nemo_gym_dict.setdefault("uv_cache_dir", uv_cache_dir)
-                uv_venv_dir = get_nemo_gym_venv_dir()
-                if uv_venv_dir is not None:
-                    nemo_gym_dict.setdefault("uv_venv_dir", uv_venv_dir)
-                nemo_gym_cfg = NemoGymConfig(
-                    model_name=generation_config["model_name"],
+                # Distillation does not configure vLLM for router replay, so the
+                # actor must not require routed experts on its output items.
+                return spinup_nemo_gym_actor(
+                    env_configs,
                     base_urls=deferred_vllm.dp_openai_server_base_urls,
-                    invalid_tool_call_patterns=invalid_tool_call_patterns,
-                    thinking_tags=thinking_tags,
+                    model_name=generation_config["model_name"],
+                    tokenizer=tokenizer,
                     use_fastokens=bool(policy_config["tokenizer"].get("use_fastokens")),
-                    initial_global_config_dict=nemo_gym_dict,
                 )
-                nemo_gym_opts = {
-                    "runtime_env": make_actor_runtime_env(
-                        "nemo_rl.environments.nemo_gym.NemoGym"
-                    )
-                }
-                if nemo_gym_num_nodes:
-                    nemo_gym_opts["scheduling_strategy"] = (
-                        NodeAffinitySchedulingStrategy(
-                            node_id=ray_cur_node_id,
-                            soft=True,
-                        )
-                    )
-                actor = NemoGym.options(**nemo_gym_opts).remote(nemo_gym_cfg)
-                ray.get(actor._spinup.remote())
-                ray.get(actor.set_tokenizer.remote(tokenizer))
-                return actor
 
             init_tasks = {
                 "vllm": init_vllm_deferred,

--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -518,13 +518,13 @@ def setup(
                 return deferred_vllm
 
             def init_nemo_gym():
-                # Distillation does not configure vLLM for router replay, so the
-                # actor must not require routed experts on its output items.
                 return spinup_nemo_gym_actor(
                     env_configs,
-                    base_urls=deferred_vllm.dp_openai_server_base_urls,
+                    base_urls=cast(list[str], deferred_vllm.dp_openai_server_base_urls),
                     model_name=generation_config["model_name"],
                     tokenizer=tokenizer,
+                    # Distillation does not configure vLLM for router replay.
+                    enable_router_replay=False,
                     use_fastokens=bool(policy_config["tokenizer"].get("use_fastokens")),
                 )
 

--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -20,7 +20,6 @@ import numpy as np
 import ray
 import torch
 from pydantic import BaseModel
-from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import AutoConfig, AutoTokenizer
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
@@ -53,12 +52,7 @@ from nemo_rl.distributed.virtual_cluster import (
     prepare_segment_topology,
 )
 from nemo_rl.environments.interfaces import EnvironmentInterface
-from nemo_rl.environments.nemo_gym import (
-    NemoGym,
-    NemoGymConfig,
-    get_nemo_gym_uv_cache_dir,
-    get_nemo_gym_venv_dir,
-)
+from nemo_rl.environments.nemo_gym import spinup_nemo_gym_actor
 from nemo_rl.experience.rollouts import (
     run_async_multi_turn_rollout,
     run_multi_turn_rollout,
@@ -84,7 +78,6 @@ from nemo_rl.utils.logger import (
 )
 from nemo_rl.utils.nsys import maybe_gpu_profile_step
 from nemo_rl.utils.timer import TimeoutChecker, Timer
-from nemo_rl.utils.venvs import make_actor_runtime_env
 from nemo_rl.weight_sync.checkpoint_engine_config import (
     checkpoint_engine_refit_config,
 )
@@ -328,12 +321,6 @@ def setup(
     colocated_inference = generation_config["colocated"]["enabled"]
     enable_nemo_gym = bool(env_configs) and _should_use_nemo_gym(master_config)
     nemo_gym_actor: Optional[EnvironmentInterface] = None
-    if enable_nemo_gym:
-        nemo_gym_num_nodes = env_configs.get("nemo_gym", {}).get("num_gpu_nodes", 0)
-        ray_cur_node_id = ray.get_runtime_context().get_node_id()
-    else:
-        nemo_gym_num_nodes = 0
-        ray_cur_node_id = None
     segment_size = cluster_config.get("segment_size")
 
     if colocated_inference:
@@ -516,44 +503,14 @@ def setup(
                 return deferred_vllm
 
             def init_nemo_gym():
-                nemo_gym_dict = dict(env_configs["nemo_gym"])
-                # These are NeMo-RL-side fields consumed by NemoGymConfig, not
-                # NeMo-Gym global config entries.
-                invalid_tool_call_patterns = nemo_gym_dict.pop(
-                    "invalid_tool_call_patterns", None
-                )
-                thinking_tags = nemo_gym_dict.pop("thinking_tags", None)
-                # Pass prebuilt cache + venv dirs through the global config so the
-                # gym reuses image-baked venvs instead of rebuilding them.
-                uv_cache_dir = get_nemo_gym_uv_cache_dir()
-                if uv_cache_dir is not None:
-                    nemo_gym_dict.setdefault("uv_cache_dir", uv_cache_dir)
-                uv_venv_dir = get_nemo_gym_venv_dir()
-                if uv_venv_dir is not None:
-                    nemo_gym_dict.setdefault("uv_venv_dir", uv_venv_dir)
-                nemo_gym_cfg = NemoGymConfig(
-                    model_name=generation_config["model_name"],
+                # Distillation does not configure vLLM for router replay, so the
+                # actor must not require routed experts on its output items.
+                return spinup_nemo_gym_actor(
+                    env_configs,
                     base_urls=deferred_vllm.dp_openai_server_base_urls,
-                    invalid_tool_call_patterns=invalid_tool_call_patterns,
-                    thinking_tags=thinking_tags,
+                    model_name=generation_config["model_name"],
                     use_fastokens=bool(policy_config["tokenizer"].get("use_fastokens")),
-                    initial_global_config_dict=nemo_gym_dict,
                 )
-                nemo_gym_opts = {
-                    "runtime_env": make_actor_runtime_env(
-                        "nemo_rl.environments.nemo_gym.NemoGym"
-                    )
-                }
-                if nemo_gym_num_nodes:
-                    nemo_gym_opts["scheduling_strategy"] = (
-                        NodeAffinitySchedulingStrategy(
-                            node_id=ray_cur_node_id,
-                            soft=True,
-                        )
-                    )
-                actor = NemoGym.options(**nemo_gym_opts).remote(nemo_gym_cfg)
-                ray.get(actor._spinup.remote())
-                return actor
 
             init_tasks = {
                 "vllm": init_vllm_deferred,

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -111,7 +111,6 @@ from nemo_rl.models.generation.interfaces import (
     GenerationConfig,
     GenerationInterface,
     GenerationSamplingParams,
-    resolve_routed_experts_dtype_name_for_model,
     should_use_async_rollouts,
 )
 from nemo_rl.models.generation.megatron import MegatronGeneration
@@ -816,19 +815,12 @@ def setup(
     def _spinup_nemo_gym(base_urls, model_name):
         """Spin up the NeMo Gym actor against the given generation server URLs."""
         t0 = time.perf_counter()
-        enable_router_replay = router_replay_enabled(policy_config)
-        routed_experts_dtype = (
-            resolve_routed_experts_dtype_name_for_model(model_name)
-            if enable_router_replay
-            else "int16"
-        )
         actor = spinup_nemo_gym_actor(
-            env_configs=env_configs,
+            env_configs,
             base_urls=base_urls,
             model_name=model_name,
             tokenizer=tokenizer,
-            enable_router_replay=enable_router_replay,
-            routed_experts_dtype=routed_experts_dtype,
+            enable_router_replay=router_replay_enabled(policy_config),
             use_fastokens=bool(policy_config["tokenizer"].get("use_fastokens")),
         )
         return actor, time.perf_counter() - t0

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -24,7 +24,6 @@ import numpy as np
 import ray
 import torch
 from pydantic import BaseModel, Field, model_validator
-from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import AutoProcessor
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
@@ -80,12 +79,7 @@ from nemo_rl.distributed.virtual_cluster import (
     prepare_segment_topology,
 )
 from nemo_rl.environments.interfaces import EnvironmentInterface
-from nemo_rl.environments.nemo_gym import (
-    NemoGym,
-    NemoGymConfig,
-    get_nemo_gym_uv_cache_dir,
-    get_nemo_gym_venv_dir,
-)
+from nemo_rl.environments.nemo_gym import spinup_nemo_gym_actor
 from nemo_rl.experience.interfaces import (
     NEMO_GYM_TASK_INDEX_KEY,
     NEXT_NEMO_GYM_TASK_INDEX_KEY,
@@ -100,7 +94,6 @@ from nemo_rl.experience.rollouts import (
 from nemo_rl.models.generation.interfaces import (
     GenerationConfig,
     GenerationInterface,
-    resolve_routed_experts_dtype_name_for_model,
 )
 from nemo_rl.models.generation.megatron import MegatronGeneration
 from nemo_rl.models.generation.sglang.config import SGLangConfig
@@ -594,67 +587,17 @@ def setup(
         master_config, enable_nemo_gym=enable_nemo_gym
     )
     nemo_gym_actor = None
-    if enable_nemo_gym:
-        nemo_gym_num_nodes = env_configs.get("nemo_gym", {}).get("num_gpu_nodes", 0)
-        ray_runtime_ctx = ray.get_runtime_context()
-        ray_cur_node_id = ray_runtime_ctx.get_node_id()
-    else:
-        nemo_gym_num_nodes = 0
-        ray_cur_node_id = None
 
     def _spinup_nemo_gym(base_urls, model_name):
         """Spin up the NeMo Gym actor against the given generation server URLs."""
         t0 = time.perf_counter()
-        nemo_gym_py_exec = get_actor_python_env("nemo_rl.environments.nemo_gym.NemoGym")
-        if nemo_gym_py_exec.startswith("uv"):
-            nemo_gym_py_exec = create_local_venv_on_each_node(
-                nemo_gym_py_exec, "nemo_rl.environments.nemo_gym.NemoGym"
-            )
-        nemo_gym_dict = dict(env_configs["nemo_gym"])
-        # NeMo-RL-side detection knobs are top-level NemoGymConfig fields
-        # (where the detector reads them), not part of Gym's global config.
-        invalid_tool_call_patterns = nemo_gym_dict.pop(
-            "invalid_tool_call_patterns", None
-        )
-        thinking_tags = nemo_gym_dict.pop("thinking_tags", None)
-        # Pass prebuilt cache + venv dirs through the global config so the gym reuses
-        # image-baked venvs instead of rebuilding them.
-        uv_cache_dir = get_nemo_gym_uv_cache_dir()
-        if uv_cache_dir is not None:
-            nemo_gym_dict.setdefault("uv_cache_dir", uv_cache_dir)
-        uv_venv_dir = get_nemo_gym_venv_dir()
-        if uv_venv_dir is not None:
-            nemo_gym_dict.setdefault("uv_venv_dir", uv_venv_dir)
-        nemo_gym_cfg = NemoGymConfig(
-            model_name=model_name,
+        actor = spinup_nemo_gym_actor(
+            env_configs,
             base_urls=base_urls,
-            invalid_tool_call_patterns=invalid_tool_call_patterns,
-            thinking_tags=thinking_tags,
-            require_routed_experts=router_replay_enabled(policy_config),
-            routed_experts_dtype=(
-                resolve_routed_experts_dtype_name_for_model(model_name)
-                if router_replay_enabled(policy_config)
-                else "int16"
-            ),
+            model_name=model_name,
+            enable_router_replay=router_replay_enabled(policy_config),
             use_fastokens=bool(policy_config["tokenizer"].get("use_fastokens")),
-            initial_global_config_dict=nemo_gym_dict,
         )
-        nemo_gym_opts = {}
-        if nemo_gym_num_nodes:
-            nemo_gym_opts["scheduling_strategy"] = NodeAffinitySchedulingStrategy(
-                node_id=ray_cur_node_id,
-                soft=True,
-            )
-        nemo_gym_opts["runtime_env"] = {
-            "py_executable": nemo_gym_py_exec,
-            "env_vars": {
-                **os.environ,
-                "VIRTUAL_ENV": nemo_gym_py_exec,
-                "UV_PROJECT_ENVIRONMENT": nemo_gym_py_exec,
-            },
-        }
-        actor = NemoGym.options(**nemo_gym_opts).remote(nemo_gym_cfg)
-        ray.get(actor._spinup.remote())
         return actor, time.perf_counter() - t0
 
     total_nodes = cluster_config["num_nodes"]

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -642,7 +642,7 @@ def _build_value(
 
 def _spinup_gym(
     master_config: MasterConfig,
-    base_urls: list[str],
+    base_urls: list[Optional[str]],
     tokenizer: PreTrainedTokenizerBase,
 ) -> tuple[Any, float]:
     """Spin up the NeMo-Gym actor against the reserved vLLM URLs.

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -108,9 +108,6 @@ from nemo_rl.models.generation.generation_router import (
     GenerationRouterActor,
     GenerationRouterImpl,
 )
-from nemo_rl.models.generation.interfaces import (
-    resolve_routed_experts_dtype_name_for_model,
-)
 from nemo_rl.models.generation.megatron.megatron_generation import MegatronGeneration
 from nemo_rl.models.generation.sglang.config import SGLangConfig
 from nemo_rl.models.generation.sglang.sglang_generation import SGLangGeneration
@@ -663,18 +660,12 @@ def _spinup_gym(
     policy_config = master_config.policy
     generation_config = policy_config["generation"]
     enable_router_replay = router_replay_enabled(policy_config)
-    routed_experts_dtype = (
-        resolve_routed_experts_dtype_name_for_model(generation_config["model_name"])
-        if enable_router_replay
-        else "int16"
-    )
     actor = spinup_nemo_gym_actor(
         env_configs=master_config.env,
         base_urls=base_urls,
         model_name=generation_config["model_name"],
         tokenizer=tokenizer,
         enable_router_replay=enable_router_replay,
-        routed_experts_dtype=routed_experts_dtype,
         use_fastokens=bool(policy_config["tokenizer"].get("use_fastokens")),
     )
     return actor, time.perf_counter() - t0

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -642,7 +642,7 @@ def _build_value(
 
 def _spinup_gym(
     master_config: MasterConfig,
-    base_urls: list[Optional[str]],
+    base_urls: list[str],
     tokenizer: PreTrainedTokenizerBase,
 ) -> tuple[Any, float]:
     """Spin up the NeMo-Gym actor against the reserved vLLM URLs.
@@ -1224,7 +1224,7 @@ def setup_single_controller(
         build_tasks["nemo_gym"] = partial(
             _spinup_gym,
             master_config=master_config,
-            base_urls=gym_spinup_base_urls,
+            base_urls=cast(list[str], gym_spinup_base_urls),
             tokenizer=tokenizer,
         )
 

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -384,12 +384,12 @@ def setup_single_controller(
     if use_nemo_gym:
         # TODO(#2625): Mirror GRPO's deferred vLLM load so NeMo-Gym spinup
         # overlaps model loading instead of running serially afterward.
-        enable_router_replay = router_replay_enabled(master_config.policy)
         env_handles["nemo_gym"] = spinup_nemo_gym_actor(
-            env_configs=master_config.env,
+            master_config.env,
             base_urls=generation.dp_openai_server_base_urls,
             model_name=generation_config["model_name"],
-            enable_router_replay=enable_router_replay,
+            enable_router_replay=router_replay_enabled(master_config.policy),
+            use_fastokens=bool(master_config.policy["tokenizer"].get("use_fastokens")),
         )
 
     # ==========================

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -31,7 +31,6 @@ from nemo_rl.data.multimodal_utils import (
     media_sources_equal,
     uses_image_placeholder,
 )
-from nemo_rl.distributed.ray_actor_environment_registry import get_actor_python_env
 from nemo_rl.distributed.virtual_cluster import (
     DEFAULT_GYM_PORT_RANGE_HIGH,
     DEFAULT_GYM_PORT_RANGE_LOW,
@@ -54,7 +53,9 @@ from nemo_rl.models.generation.interfaces import should_use_async_rollouts
 from nemo_rl.models.policy import PolicyConfig, TokenizerConfig
 from nemo_rl.utils.routed_experts_codec import decode_routed_experts
 from nemo_rl.utils.timer import Timer
-from nemo_rl.utils.venvs import create_local_venv_on_each_node
+from nemo_rl.utils.venvs import make_actor_runtime_env
+
+NEMO_GYM_ACTOR_FQN = "nemo_rl.environments.nemo_gym.NemoGym"
 
 # Kept local so the Gym actor does not depend on model-config dtype resolution.
 # Must cover every name resolve_routed_experts_dtype can produce.
@@ -961,21 +962,19 @@ def setup_nemo_gym_config(config, tokenizer) -> None:
         env_cfg.setdefault("tokenizer_config", dict(config.policy["tokenizer"]))
 
 
-def spinup_nemo_gym_actor(
+def build_nemo_gym_config(
     env_configs: dict[str, Any],
-    base_urls: list[str],
-    model_name: str,
     *,
-    tokenizer: PreTrainedTokenizerBase,
-    enable_router_replay: bool,
-    routed_experts_dtype: str,
-    use_fastokens: bool,
-) -> Any:
-    """Spin up the NeMo-Gym actor against the given generation server URLs.
+    base_urls: list[Optional[str]],
+    model_name: str,
+    enable_router_replay: bool = False,
+    use_fastokens: bool = False,
+) -> NemoGymConfig:
+    """Build the ``NemoGymConfig`` for a NeMo-Gym actor.
 
-    When env_configs["nemo_gym"]["num_gpu_nodes"] > 0, the actor is scheduled
-    with soft NodeAffinity to the current Ray node so its colocated GPU
-    resources land where the caller expects.
+    Splits ``env_configs["nemo_gym"]`` into the NeMo-RL-side fields the actor
+    reads directly and the remainder, which is forwarded verbatim as NeMo-Gym's
+    initial global config.
 
     Args:
         env_configs: The master_config.env mapping; env_configs["nemo_gym"] supplies
@@ -983,17 +982,10 @@ def spinup_nemo_gym_actor(
             thinking_tags, num_gpu_nodes).
         base_urls: Per-DP-rank OpenAI-compatible server base URLs from the generation backend.
         model_name: Served model name the Gym rollouts should target.
-        tokenizer: Installed on the actor once, here, rather than passed per
-            rollout call. See NemoGym.set_tokenizer for why that distinction is
-            the difference between a working run and a stalled one.
-        enable_router_replay: Sets require_routed_experts on the NemoGymConfig.
-        routed_experts_dtype: Dtype name for R3 routed_experts tensors ("int8"/"int16"/"int32"),
-            resolved by the caller from the model's expert count.
-        use_fastokens: Forwarded from policy.tokenizer.use_fastokens so the rollout actor
-            patches its tokenizer consistently with the driver.
-
-    Returns:
-        The spun-up NemoGym Ray actor handle (_spinup already awaited).
+        enable_router_replay: Sets ``require_routed_experts`` and selects the
+            routed-experts carry dtype ("int8"/"int16"/"int32") for the model.
+        use_fastokens: Forwarded from ``policy.tokenizer.use_fastokens`` so the
+            actor patches its tokenizer the same way the driver does.
     """
     nemo_gym_dict = dict(env_configs["nemo_gym"])
 
@@ -1020,7 +1012,16 @@ def spinup_nemo_gym_actor(
     if uv_venv_dir is not None:
         nemo_gym_dict.setdefault("uv_venv_dir", uv_venv_dir)
 
-    nemo_gym_cfg = NemoGymConfig(
+    routed_experts_dtype = "int16"
+    if enable_router_replay:
+        # Deferred so the actor module stays free of generation-package imports.
+        from nemo_rl.models.generation.interfaces import (
+            resolve_routed_experts_dtype_name_for_model,
+        )
+
+        routed_experts_dtype = resolve_routed_experts_dtype_name_for_model(model_name)
+
+    return NemoGymConfig(
         model_name=model_name,
         base_urls=base_urls,
         invalid_tool_call_patterns=invalid_tool_call_patterns,
@@ -1033,26 +1034,47 @@ def spinup_nemo_gym_actor(
         **multimodal_flags,
     )
 
-    nemo_gym_py_exec = get_actor_python_env("nemo_rl.environments.nemo_gym.NemoGym")
-    if nemo_gym_py_exec.startswith("uv"):
-        nemo_gym_py_exec = create_local_venv_on_each_node(
-            nemo_gym_py_exec, "nemo_rl.environments.nemo_gym.NemoGym"
-        )
 
-    nemo_gym_opts: dict[str, Any] = {}
-    if nemo_gym_dict.get("num_gpu_nodes", 0):
+def spinup_nemo_gym_actor(
+    env_configs: dict[str, Any],
+    *,
+    base_urls: list[Optional[str]],
+    model_name: str,
+    tokenizer: PreTrainedTokenizerBase,
+    enable_router_replay: bool = False,
+    use_fastokens: bool = False,
+) -> Any:
+    """Spin up the NeMo-Gym actor against the given generation server URLs.
+
+    When ``env_configs["nemo_gym"]["num_gpu_nodes"] > 0``, the actor is
+    scheduled with soft NodeAffinity to the caller's Ray node so its colocated
+    GPU resources land where the caller expects.
+
+    Args:
+        tokenizer: Installed on the actor once, here, rather than passed per
+            rollout call. See ``NemoGym.set_tokenizer`` for why that
+            distinction is the difference between a working run and a stalled
+            one.
+
+    Returns:
+        The spun-up ``NemoGym`` Ray actor handle (``_spinup`` already awaited).
+    """
+    nemo_gym_cfg = build_nemo_gym_config(
+        env_configs,
+        base_urls=base_urls,
+        model_name=model_name,
+        enable_router_replay=enable_router_replay,
+        use_fastokens=use_fastokens,
+    )
+
+    nemo_gym_opts: dict[str, Any] = {
+        "runtime_env": make_actor_runtime_env(NEMO_GYM_ACTOR_FQN)
+    }
+    if env_configs["nemo_gym"].get("num_gpu_nodes", 0):
         nemo_gym_opts["scheduling_strategy"] = NodeAffinitySchedulingStrategy(
             node_id=ray.get_runtime_context().get_node_id(),
             soft=True,
         )
-    nemo_gym_opts["runtime_env"] = {
-        "py_executable": nemo_gym_py_exec,
-        "env_vars": {
-            **os.environ,
-            "VIRTUAL_ENV": nemo_gym_py_exec,
-            "UV_PROJECT_ENVIRONMENT": nemo_gym_py_exec,
-        },
-    }
 
     actor = NemoGym.options(**nemo_gym_opts).remote(nemo_gym_cfg)
     ray.get(actor._spinup.remote())

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -49,7 +49,10 @@ from nemo_rl.experience.failures import (
     RolloutDataFailure,
     http_status_is_infra,
 )
-from nemo_rl.models.generation.interfaces import should_use_async_rollouts
+from nemo_rl.models.generation.interfaces import (
+    resolve_routed_experts_dtype_name_for_model,
+    should_use_async_rollouts,
+)
 from nemo_rl.models.policy import PolicyConfig, TokenizerConfig
 from nemo_rl.utils.routed_experts_codec import decode_routed_experts
 from nemo_rl.utils.timer import Timer
@@ -965,10 +968,10 @@ def setup_nemo_gym_config(config, tokenizer) -> None:
 def build_nemo_gym_config(
     env_configs: dict[str, Any],
     *,
-    base_urls: list[Optional[str]],
+    base_urls: list[str],
     model_name: str,
-    enable_router_replay: bool = False,
-    use_fastokens: bool = False,
+    enable_router_replay: bool,
+    use_fastokens: bool,
 ) -> NemoGymConfig:
     """Build the ``NemoGymConfig`` for a NeMo-Gym actor.
 
@@ -986,6 +989,11 @@ def build_nemo_gym_config(
             routed-experts carry dtype ("int8"/"int16"/"int32") for the model.
         use_fastokens: Forwarded from ``policy.tokenizer.use_fastokens`` so the
             actor patches its tokenizer the same way the driver does.
+
+    Returns:
+        A ``NemoGymConfig`` with NeMo-RL fields at the top level and the
+        remaining ``env_configs["nemo_gym"]`` keys under
+        ``initial_global_config_dict``. The caller's ``env_configs`` is not mutated.
     """
     nemo_gym_dict = dict(env_configs["nemo_gym"])
 
@@ -1012,14 +1020,11 @@ def build_nemo_gym_config(
     if uv_venv_dir is not None:
         nemo_gym_dict.setdefault("uv_venv_dir", uv_venv_dir)
 
-    routed_experts_dtype = "int16"
-    if enable_router_replay:
-        # Deferred so the actor module stays free of generation-package imports.
-        from nemo_rl.models.generation.interfaces import (
-            resolve_routed_experts_dtype_name_for_model,
-        )
-
-        routed_experts_dtype = resolve_routed_experts_dtype_name_for_model(model_name)
+    routed_experts_dtype = (
+        resolve_routed_experts_dtype_name_for_model(model_name)
+        if enable_router_replay
+        else "int16"
+    )
 
     return NemoGymConfig(
         model_name=model_name,
@@ -1038,11 +1043,11 @@ def build_nemo_gym_config(
 def spinup_nemo_gym_actor(
     env_configs: dict[str, Any],
     *,
-    base_urls: list[Optional[str]],
+    base_urls: list[str],
     model_name: str,
     tokenizer: PreTrainedTokenizerBase,
-    enable_router_replay: bool = False,
-    use_fastokens: bool = False,
+    enable_router_replay: bool,
+    use_fastokens: bool,
 ) -> Any:
     """Spin up the NeMo-Gym actor against the given generation server URLs.
 

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -25,7 +25,6 @@ import torch
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 from transformers import PreTrainedTokenizerBase
 
-from nemo_rl.distributed.ray_actor_environment_registry import get_actor_python_env
 from nemo_rl.distributed.virtual_cluster import (
     DEFAULT_GYM_PORT_RANGE_HIGH,
     DEFAULT_GYM_PORT_RANGE_LOW,
@@ -34,7 +33,9 @@ from nemo_rl.distributed.virtual_cluster import (
 )
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.utils.timer import Timer
-from nemo_rl.utils.venvs import create_local_venv_on_each_node
+from nemo_rl.utils.venvs import make_actor_runtime_env
+
+NEMO_GYM_ACTOR_FQN = "nemo_rl.environments.nemo_gym.NemoGym"
 
 # Kept local (not imported from models.generation) so the gym actor stays free of
 # generation-module imports. Must cover every name resolve_routed_experts_dtype
@@ -609,17 +610,19 @@ def setup_nemo_gym_config(config, tokenizer) -> None:
     generation_config["stop_token_ids"] = None
 
 
-def spinup_nemo_gym_actor(
+def build_nemo_gym_config(
     env_configs: dict[str, Any],
+    *,
     base_urls: list[Optional[str]],
     model_name: str,
-    enable_router_replay: bool,
-) -> Any:
-    """Spin up the NeMo-Gym actor against the given generation server URLs.
+    enable_router_replay: bool = False,
+    use_fastokens: bool = False,
+) -> NemoGymConfig:
+    """Build the ``NemoGymConfig`` for a NeMo-Gym actor.
 
-    When ``env_configs["nemo_gym"]["num_gpu_nodes"] > 0``, the actor is
-    scheduled with soft NodeAffinity to the current Ray node so its colocated
-    GPU resources land where the caller expects.
+    Splits ``env_configs["nemo_gym"]`` into the NeMo-RL-side fields the actor
+    reads directly and the remainder, which is forwarded verbatim as NeMo-Gym's
+    initial global config.
 
     Args:
         env_configs: The ``master_config.env`` mapping; ``env_configs["nemo_gym"]``
@@ -628,11 +631,10 @@ def spinup_nemo_gym_actor(
         base_urls: Per-DP-rank OpenAI-compatible server base URLs from the
             generation backend.
         model_name: Served model name the Gym rollouts should target.
-        enable_router_replay: Sets ``require_routed_experts`` on the
-            ``NemoGymConfig``.
-
-    Returns:
-        The spun-up ``NemoGym`` Ray actor handle (``_spinup`` already awaited).
+        enable_router_replay: Sets ``require_routed_experts`` and selects the
+            routed-experts carry dtype for the model.
+        use_fastokens: Forwarded from ``policy.tokenizer.use_fastokens`` so the
+            actor patches its tokenizer the same way the driver does.
     """
     nemo_gym_dict = dict(env_configs["nemo_gym"])
 
@@ -650,35 +652,60 @@ def spinup_nemo_gym_actor(
     if uv_venv_dir is not None:
         nemo_gym_dict.setdefault("uv_venv_dir", uv_venv_dir)
 
-    nemo_gym_cfg = NemoGymConfig(
+    routed_experts_dtype = "int16"
+    if enable_router_replay:
+        # Deferred so the actor module stays free of generation-package imports.
+        from nemo_rl.models.generation.interfaces import (
+            resolve_routed_experts_dtype_name_for_model,
+        )
+
+        routed_experts_dtype = resolve_routed_experts_dtype_name_for_model(model_name)
+
+    return NemoGymConfig(
         model_name=model_name,
         base_urls=base_urls,
         invalid_tool_call_patterns=invalid_tool_call_patterns,
         thinking_tags=thinking_tags,
         require_routed_experts=enable_router_replay,
+        routed_experts_dtype=routed_experts_dtype,
+        use_fastokens=use_fastokens,
         initial_global_config_dict=nemo_gym_dict,
     )
 
-    nemo_gym_py_exec = get_actor_python_env("nemo_rl.environments.nemo_gym.NemoGym")
-    if nemo_gym_py_exec.startswith("uv"):
-        nemo_gym_py_exec = create_local_venv_on_each_node(
-            nemo_gym_py_exec, "nemo_rl.environments.nemo_gym.NemoGym"
-        )
 
-    nemo_gym_opts: dict[str, Any] = {}
-    if nemo_gym_dict.get("num_gpu_nodes", 0):
+def spinup_nemo_gym_actor(
+    env_configs: dict[str, Any],
+    *,
+    base_urls: list[Optional[str]],
+    model_name: str,
+    enable_router_replay: bool = False,
+    use_fastokens: bool = False,
+) -> Any:
+    """Spin up the NeMo-Gym actor against the given generation server URLs.
+
+    When ``env_configs["nemo_gym"]["num_gpu_nodes"] > 0``, the actor is
+    scheduled with soft NodeAffinity to the caller's Ray node so its colocated
+    GPU resources land where the caller expects.
+
+    Returns:
+        The spun-up ``NemoGym`` Ray actor handle (``_spinup`` already awaited).
+    """
+    nemo_gym_cfg = build_nemo_gym_config(
+        env_configs,
+        base_urls=base_urls,
+        model_name=model_name,
+        enable_router_replay=enable_router_replay,
+        use_fastokens=use_fastokens,
+    )
+
+    nemo_gym_opts: dict[str, Any] = {
+        "runtime_env": make_actor_runtime_env(NEMO_GYM_ACTOR_FQN)
+    }
+    if env_configs["nemo_gym"].get("num_gpu_nodes", 0):
         nemo_gym_opts["scheduling_strategy"] = NodeAffinitySchedulingStrategy(
             node_id=ray.get_runtime_context().get_node_id(),
             soft=True,
         )
-    nemo_gym_opts["runtime_env"] = {
-        "py_executable": nemo_gym_py_exec,
-        "env_vars": {
-            **os.environ,
-            "VIRTUAL_ENV": nemo_gym_py_exec,
-            "UV_PROJECT_ENVIRONMENT": nemo_gym_py_exec,
-        },
-    }
 
     actor = NemoGym.options(**nemo_gym_opts).remote(nemo_gym_cfg)
     ray.get(actor._spinup.remote())

--- a/tests/unit/algorithms/test_distillation.py
+++ b/tests/unit/algorithms/test_distillation.py
@@ -14,7 +14,7 @@
 
 import copy
 from types import SimpleNamespace
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -1041,8 +1041,7 @@ def test_distillation_setup_non_colocated_smoke(monkeypatch, refit_transport):
         patch.object(
             distil_mod, "create_weight_synchronizer"
         ) as mock_create_synchronizer,
-        patch.object(distil_mod, "get_nemo_gym_uv_cache_dir") as mock_uv_cache_dir,
-        patch.object(distil_mod, "get_nemo_gym_venv_dir") as mock_uv_venv_dir,
+        patch.object(distil_mod, "spinup_nemo_gym_actor") as mock_spinup_nemo_gym,
         patch.object(distil_mod, "ray") as mock_ray,
     ):
         mock_ckpt_mgr.return_value.get_latest_checkpoint_path.return_value = None
@@ -1055,8 +1054,7 @@ def test_distillation_setup_non_colocated_smoke(monkeypatch, refit_transport):
         # Basic shape check of returned tuple
         assert isinstance(result, tuple)
         assert result[3] is None
-        mock_uv_cache_dir.assert_not_called()
-        mock_uv_venv_dir.assert_not_called()
+        mock_spinup_nemo_gym.assert_not_called()
         if refit_transport == "nixl":
             mock_create_synchronizer.assert_called_once()
             mock_create_synchronizer.return_value.init_communicator.assert_called_once()
@@ -1068,35 +1066,7 @@ def test_distillation_setup_non_colocated_smoke(monkeypatch, refit_transport):
             assert DummyVllmGeneration.collective_calls
 
 
-@pytest.mark.parametrize(
-    (
-        "configured_uv_cache_dir",
-        "configured_uv_venv_dir",
-        "expected_uv_cache_dir",
-        "expected_uv_venv_dir",
-    ),
-    [
-        (
-            None,
-            None,
-            "/opt/nemo-gym/.uv-cache",
-            "/opt/nemo-gym/venvs",
-        ),
-        (
-            "/custom/cache",
-            "/custom/venvs",
-            "/custom/cache",
-            "/custom/venvs",
-        ),
-    ],
-)
-def test_distillation_setup_nemo_gym_uses_deferred_vllm(
-    monkeypatch,
-    configured_uv_cache_dir,
-    configured_uv_venv_dir,
-    expected_uv_cache_dir,
-    expected_uv_venv_dir,
-):
+def test_distillation_setup_nemo_gym_uses_deferred_vllm(monkeypatch):
     import nemo_rl.algorithms.distillation as distil_mod
 
     nemo_gym_config = {
@@ -1105,10 +1075,6 @@ def test_distillation_setup_nemo_gym_uses_deferred_vllm(
         "thinking_tags": ["<think>"],
         "config_paths": ["gym.yaml"],
     }
-    if configured_uv_cache_dir is not None:
-        nemo_gym_config["uv_cache_dir"] = configured_uv_cache_dir
-    if configured_uv_venv_dir is not None:
-        nemo_gym_config["uv_venv_dir"] = configured_uv_venv_dir
 
     master_config = MasterConfig.model_construct(
         **{
@@ -1210,16 +1176,6 @@ def test_distillation_setup_nemo_gym_uses_deferred_vllm(
             self.prepare_refit_info_called = True
 
     nemo_gym_actor = MagicMock()
-    nemo_gym_actor._spinup.remote.return_value = "spinup-ref"
-    nemo_gym_cls = MagicMock()
-    nemo_gym_cls.options.return_value.remote.return_value = nemo_gym_actor
-    runtime_env = {
-        "py_executable": "/venv/bin/python",
-        "env_vars": {
-            "VIRTUAL_ENV": "/venv",
-            "UV_PROJECT_ENVIRONMENT": "/venv",
-        },
-    }
 
     with (
         patch.object(distil_mod, "RayVirtualCluster", DummyCluster),
@@ -1228,22 +1184,9 @@ def test_distillation_setup_nemo_gym_uses_deferred_vllm(
         patch.object(distil_mod, "StatefulDataLoader"),
         patch.object(distil_mod, "Policy", DummyPolicy),
         patch.object(distil_mod, "VllmGeneration", DummyVllmGeneration),
-        patch.object(distil_mod, "NemoGym", nemo_gym_cls),
         patch.object(
-            distil_mod,
-            "make_actor_runtime_env",
-            return_value=runtime_env,
-        ) as mock_runtime_env,
-        patch.object(
-            distil_mod,
-            "get_nemo_gym_uv_cache_dir",
-            return_value="/opt/nemo-gym/.uv-cache",
-        ),
-        patch.object(
-            distil_mod,
-            "get_nemo_gym_venv_dir",
-            return_value="/opt/nemo-gym/venvs",
-        ),
+            distil_mod, "spinup_nemo_gym_actor", return_value=nemo_gym_actor
+        ) as mock_spinup_nemo_gym,
         patch.object(distil_mod, "ray") as mock_ray,
     ):
         mock_ckpt_mgr.return_value.get_latest_checkpoint_path.return_value = None
@@ -1261,33 +1204,18 @@ def test_distillation_setup_nemo_gym_uses_deferred_vllm(
     assert result[2] is created_vllm[0]
     assert result[3] is nemo_gym_actor
 
-    mock_runtime_env.assert_called_once_with("nemo_rl.environments.nemo_gym.NemoGym")
-    nemo_gym_options_kwargs = nemo_gym_cls.options.call_args.kwargs
-    assert nemo_gym_options_kwargs["runtime_env"] == runtime_env
-    assert isinstance(
-        nemo_gym_options_kwargs["scheduling_strategy"],
-        distil_mod.NodeAffinitySchedulingStrategy,
+    # The gym actor must target the deferred vLLM's servers, and distillation
+    # must not require routed experts (it never configures vLLM to emit them).
+    # The tokenizer is installed on the actor at spinup, inside the factory,
+    # rather than passed per rollout call.
+    mock_spinup_nemo_gym.assert_called_once_with(
+        master_config.env,
+        base_urls=["http://reserved-vllm"],
+        model_name="test-policy",
+        tokenizer=tokenizer,
+        use_fastokens=False,
     )
-    nemo_gym_cfg = nemo_gym_cls.options.return_value.remote.call_args.args[0]
-    assert nemo_gym_cfg["model_name"] == "test-policy"
-    assert nemo_gym_cfg["base_urls"] == ["http://reserved-vllm"]
-    assert nemo_gym_cfg["invalid_tool_call_patterns"] == ["bad_call"]
-    assert nemo_gym_cfg["thinking_tags"] == ["<think>"]
-    assert nemo_gym_cfg["initial_global_config_dict"] == {
-        "num_gpu_nodes": 1,
-        "config_paths": ["gym.yaml"],
-        "uv_cache_dir": expected_uv_cache_dir,
-        "uv_venv_dir": expected_uv_venv_dir,
-    }
     assert master_config.env["nemo_gym"] == nemo_gym_env_before
-    nemo_gym_actor._spinup.remote.assert_called_once_with()
-    # Two waits, in order: the spinup, then the tokenizer install. Distillation
-    # builds its actor inline rather than through spinup_nemo_gym_actor, so it
-    # is the one call site that has to set the tokenizer itself -- passing it
-    # per rollout is what made the actor deserialize it once per prompt.
-    assert mock_ray.get.call_args_list[0] == call("spinup-ref")
-    assert mock_ray.get.call_count == 2
-    nemo_gym_actor.set_tokenizer.remote.assert_called_once_with(tokenizer)
 
 
 def test_nemo_gym_distillation_runner_uses_setup_actor():

--- a/tests/unit/algorithms/test_distillation.py
+++ b/tests/unit/algorithms/test_distillation.py
@@ -1213,6 +1213,7 @@ def test_distillation_setup_nemo_gym_uses_deferred_vllm(monkeypatch):
         base_urls=["http://reserved-vllm"],
         model_name="test-policy",
         tokenizer=tokenizer,
+        enable_router_replay=False,
         use_fastokens=False,
     )
     assert master_config.env["nemo_gym"] == nemo_gym_env_before

--- a/tests/unit/algorithms/test_distillation.py
+++ b/tests/unit/algorithms/test_distillation.py
@@ -984,8 +984,7 @@ def test_distillation_setup_non_colocated_smoke(monkeypatch, refit_transport):
         patch.object(
             distil_mod, "create_weight_synchronizer"
         ) as mock_create_synchronizer,
-        patch.object(distil_mod, "get_nemo_gym_uv_cache_dir") as mock_uv_cache_dir,
-        patch.object(distil_mod, "get_nemo_gym_venv_dir") as mock_uv_venv_dir,
+        patch.object(distil_mod, "spinup_nemo_gym_actor") as mock_spinup_nemo_gym,
         patch.object(distil_mod, "ray") as mock_ray,
     ):
         mock_ckpt_mgr.return_value.get_latest_checkpoint_path.return_value = None
@@ -998,8 +997,7 @@ def test_distillation_setup_non_colocated_smoke(monkeypatch, refit_transport):
         # Basic shape check of returned tuple
         assert isinstance(result, tuple)
         assert result[3] is None
-        mock_uv_cache_dir.assert_not_called()
-        mock_uv_venv_dir.assert_not_called()
+        mock_spinup_nemo_gym.assert_not_called()
         if refit_transport == "nixl":
             mock_create_synchronizer.assert_called_once()
             mock_create_synchronizer.return_value.init_communicator.assert_called_once()
@@ -1011,35 +1009,7 @@ def test_distillation_setup_non_colocated_smoke(monkeypatch, refit_transport):
             assert DummyVllmGeneration.collective_calls
 
 
-@pytest.mark.parametrize(
-    (
-        "configured_uv_cache_dir",
-        "configured_uv_venv_dir",
-        "expected_uv_cache_dir",
-        "expected_uv_venv_dir",
-    ),
-    [
-        (
-            None,
-            None,
-            "/opt/nemo-gym/.uv-cache",
-            "/opt/nemo-gym/venvs",
-        ),
-        (
-            "/custom/cache",
-            "/custom/venvs",
-            "/custom/cache",
-            "/custom/venvs",
-        ),
-    ],
-)
-def test_distillation_setup_nemo_gym_uses_deferred_vllm(
-    monkeypatch,
-    configured_uv_cache_dir,
-    configured_uv_venv_dir,
-    expected_uv_cache_dir,
-    expected_uv_venv_dir,
-):
+def test_distillation_setup_nemo_gym_uses_deferred_vllm(monkeypatch):
     import nemo_rl.algorithms.distillation as distil_mod
 
     nemo_gym_config = {
@@ -1048,10 +1018,6 @@ def test_distillation_setup_nemo_gym_uses_deferred_vllm(
         "thinking_tags": ["<think>"],
         "config_paths": ["gym.yaml"],
     }
-    if configured_uv_cache_dir is not None:
-        nemo_gym_config["uv_cache_dir"] = configured_uv_cache_dir
-    if configured_uv_venv_dir is not None:
-        nemo_gym_config["uv_venv_dir"] = configured_uv_venv_dir
 
     master_config = MasterConfig.model_construct(
         **{
@@ -1150,16 +1116,6 @@ def test_distillation_setup_nemo_gym_uses_deferred_vllm(
             self.prepare_refit_info_called = True
 
     nemo_gym_actor = MagicMock()
-    nemo_gym_actor._spinup.remote.return_value = "spinup-ref"
-    nemo_gym_cls = MagicMock()
-    nemo_gym_cls.options.return_value.remote.return_value = nemo_gym_actor
-    runtime_env = {
-        "py_executable": "/venv/bin/python",
-        "env_vars": {
-            "VIRTUAL_ENV": "/venv",
-            "UV_PROJECT_ENVIRONMENT": "/venv",
-        },
-    }
 
     with (
         patch.object(distil_mod, "RayVirtualCluster", DummyCluster),
@@ -1168,22 +1124,9 @@ def test_distillation_setup_nemo_gym_uses_deferred_vllm(
         patch.object(distil_mod, "StatefulDataLoader"),
         patch.object(distil_mod, "Policy", DummyPolicy),
         patch.object(distil_mod, "VllmGeneration", DummyVllmGeneration),
-        patch.object(distil_mod, "NemoGym", nemo_gym_cls),
         patch.object(
-            distil_mod,
-            "make_actor_runtime_env",
-            return_value=runtime_env,
-        ) as mock_runtime_env,
-        patch.object(
-            distil_mod,
-            "get_nemo_gym_uv_cache_dir",
-            return_value="/opt/nemo-gym/.uv-cache",
-        ),
-        patch.object(
-            distil_mod,
-            "get_nemo_gym_venv_dir",
-            return_value="/opt/nemo-gym/venvs",
-        ),
+            distil_mod, "spinup_nemo_gym_actor", return_value=nemo_gym_actor
+        ) as mock_spinup_nemo_gym,
         patch.object(distil_mod, "ray") as mock_ray,
     ):
         mock_ckpt_mgr.return_value.get_latest_checkpoint_path.return_value = None
@@ -1201,27 +1144,15 @@ def test_distillation_setup_nemo_gym_uses_deferred_vllm(
     assert result[2] is created_vllm[0]
     assert result[3] is nemo_gym_actor
 
-    mock_runtime_env.assert_called_once_with("nemo_rl.environments.nemo_gym.NemoGym")
-    nemo_gym_options_kwargs = nemo_gym_cls.options.call_args.kwargs
-    assert nemo_gym_options_kwargs["runtime_env"] == runtime_env
-    assert isinstance(
-        nemo_gym_options_kwargs["scheduling_strategy"],
-        distil_mod.NodeAffinitySchedulingStrategy,
+    # The gym actor must target the deferred vLLM's servers, and distillation
+    # must not require routed experts (it never configures vLLM to emit them).
+    mock_spinup_nemo_gym.assert_called_once_with(
+        master_config.env,
+        base_urls=["http://reserved-vllm"],
+        model_name="test-policy",
+        use_fastokens=False,
     )
-    nemo_gym_cfg = nemo_gym_cls.options.return_value.remote.call_args.args[0]
-    assert nemo_gym_cfg["model_name"] == "test-policy"
-    assert nemo_gym_cfg["base_urls"] == ["http://reserved-vllm"]
-    assert nemo_gym_cfg["invalid_tool_call_patterns"] == ["bad_call"]
-    assert nemo_gym_cfg["thinking_tags"] == ["<think>"]
-    assert nemo_gym_cfg["initial_global_config_dict"] == {
-        "num_gpu_nodes": 1,
-        "config_paths": ["gym.yaml"],
-        "uv_cache_dir": expected_uv_cache_dir,
-        "uv_venv_dir": expected_uv_venv_dir,
-    }
     assert master_config.env["nemo_gym"] == nemo_gym_env_before
-    nemo_gym_actor._spinup.remote.assert_called_once_with()
-    mock_ray.get.assert_called_once_with("spinup-ref")
 
 
 def test_nemo_gym_distillation_runner_uses_setup_actor():

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -2986,12 +2986,11 @@ def test_setup_initializes_noncolocated_dynamo_with_nemo_gym(monkeypatch) -> Non
     assert DynamoConfig.model_validate(dynamo_config).engine_world_size == 4
     synchronizer.init_communicator.assert_called_once_with()
     spinup_nemo_gym_actor.assert_called_once_with(
-        env_configs=master_config.env,
+        master_config.env,
         base_urls=["http://dynamo-wrapper.example/v1"],
         model_name=master_config.policy["model_name"],
         tokenizer=tokenizer,
         enable_router_replay=False,
-        routed_experts_dtype="int16",
         use_fastokens=False,
     )
 
@@ -3360,12 +3359,11 @@ def test_setup_starts_nemo_gym_for_trtllm(monkeypatch, mock_grpo_components):
 
     assert result[2] is nemo_gym_actor
     spinup_nemo_gym_actor.assert_called_once_with(
-        env_configs=master_config.env,
+        master_config.env,
         base_urls=["http://trtllm.example/v1"],
         model_name="test-model",
         tokenizer=tokenizer,
         enable_router_replay=False,
-        routed_experts_dtype="int16",
         use_fastokens=False,
     )
 

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -3407,7 +3407,7 @@ def test_setup_refits_noncolocated_megatron_while_nemo_gym_waits(
     synchronizer.sync_weights.side_effect = sync_weights
     nemo_gym_actor = object()
 
-    def spinup_nemo_gym_actor(**kwargs):
+    def spinup_nemo_gym_actor(_env_configs, **kwargs):
         assert kwargs["base_urls"] == [reserved_url]
         events.append("gym_started")
         gym_started.set()

--- a/tests/unit/environments/test_nemo_gym_utils.py
+++ b/tests/unit/environments/test_nemo_gym_utils.py
@@ -18,7 +18,7 @@ These run in the default L0 suite. Keep this module free of heavy imports
 """
 
 import copy
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -207,6 +207,8 @@ def test_spinup_nemo_gym_actor(detected_uv_dirs, num_gpu_nodes):
     has colocated GPUs to land next to."""
     actor = MagicMock()
     actor._spinup.remote.return_value = "spinup-ref"
+    actor.set_tokenizer.remote.return_value = "tokenizer-ref"
+    tokenizer = MagicMock()
     runtime_env = {"py_executable": "/venv/bin/python"}
 
     with (
@@ -223,6 +225,7 @@ def test_spinup_nemo_gym_actor(detected_uv_dirs, num_gpu_nodes):
             _env_configs(num_gpu_nodes=num_gpu_nodes),
             base_urls=["http://vllm-0"],
             model_name="test-model",
+            tokenizer=tokenizer,
             use_fastokens=True,
         )
 
@@ -245,4 +248,5 @@ def test_spinup_nemo_gym_actor(detected_uv_dirs, num_gpu_nodes):
 
     # Spinup is deferred from __init__, so the factory must await it.
     actor._spinup.remote.assert_called_once_with()
-    mock_ray.get.assert_called_once_with("spinup-ref")
+    actor.set_tokenizer.remote.assert_called_once_with(tokenizer)
+    assert mock_ray.get.call_args_list == [call("spinup-ref"), call("tokenizer-ref")]

--- a/tests/unit/environments/test_nemo_gym_utils.py
+++ b/tests/unit/environments/test_nemo_gym_utils.py
@@ -17,13 +17,19 @@ These run in the default L0 suite. Keep this module free of heavy imports
 (e.g. vllm) so the fast detector tests are not gated behind the nemo_gym extra.
 """
 
+import copy
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from nemo_rl.environments import nemo_gym as nemo_gym_mod
 from nemo_rl.environments.nemo_gym import (
+    NEMO_GYM_ACTOR_FQN,
     _detect_invalid_tool_call_and_malformed_thinking,
+    build_nemo_gym_config,
     get_nemo_gym_uv_cache_dir,
     get_nemo_gym_venv_dir,
+    spinup_nemo_gym_actor,
 )
 
 
@@ -102,3 +108,141 @@ def test_get_nemo_gym_uv_cache_dir_uses_uv_inside_container(monkeypatch):
         lambda *args, **kwargs: b"  /root/.cache/uv\n",
     )
     assert get_nemo_gym_uv_cache_dir() == "/root/.cache/uv"
+
+
+def _env_configs(**overrides):
+    nemo_gym = {
+        "num_gpu_nodes": 1,
+        "invalid_tool_call_patterns": ["bad_call"],
+        "thinking_tags": ["<think>"],
+        "config_paths": ["gym.yaml"],
+    }
+    nemo_gym.update(overrides)
+    return {"nemo_gym": nemo_gym}
+
+
+@pytest.fixture
+def detected_uv_dirs(monkeypatch):
+    """Pretend we are in a container with image-baked uv cache + venv dirs."""
+    monkeypatch.setattr(
+        nemo_gym_mod, "get_nemo_gym_uv_cache_dir", lambda: "/opt/nemo-gym/.uv-cache"
+    )
+    monkeypatch.setattr(
+        nemo_gym_mod, "get_nemo_gym_venv_dir", lambda: "/opt/nemo-gym/venvs"
+    )
+
+
+def test_build_nemo_gym_config_splits_nemo_rl_keys(detected_uv_dirs):
+    """NeMo-RL-only knobs become top-level fields; the rest is Gym's global config."""
+    env_configs = _env_configs()
+    env_configs_before = copy.deepcopy(env_configs)
+
+    cfg = build_nemo_gym_config(
+        env_configs,
+        base_urls=["http://vllm-0"],
+        model_name="test-model",
+    )
+
+    assert cfg["model_name"] == "test-model"
+    assert cfg["base_urls"] == ["http://vllm-0"]
+    assert cfg["invalid_tool_call_patterns"] == ["bad_call"]
+    assert cfg["thinking_tags"] == ["<think>"]
+    assert cfg["initial_global_config_dict"] == {
+        "num_gpu_nodes": 1,
+        "config_paths": ["gym.yaml"],
+        "uv_cache_dir": "/opt/nemo-gym/.uv-cache",
+        "uv_venv_dir": "/opt/nemo-gym/venvs",
+    }
+    # The caller's master_config.env must survive untouched.
+    assert env_configs == env_configs_before
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        ({}, ("/opt/nemo-gym/.uv-cache", "/opt/nemo-gym/venvs")),
+        (
+            {"uv_cache_dir": "/custom/cache", "uv_venv_dir": "/custom/venvs"},
+            ("/custom/cache", "/custom/venvs"),
+        ),
+    ],
+    ids=["detected", "explicit-wins"],
+)
+def test_build_nemo_gym_config_uv_dirs(detected_uv_dirs, configured, expected):
+    cfg = build_nemo_gym_config(
+        _env_configs(**configured),
+        base_urls=[],
+        model_name="test-model",
+    )
+    global_config = cfg["initial_global_config_dict"]
+    assert (global_config["uv_cache_dir"], global_config["uv_venv_dir"]) == expected
+
+
+def test_build_nemo_gym_config_router_replay_off_uses_default_dtype(detected_uv_dirs):
+    cfg = build_nemo_gym_config(_env_configs(), base_urls=[], model_name="test-model")
+    assert cfg["require_routed_experts"] is False
+    assert cfg["routed_experts_dtype"] == "int16"
+
+
+def test_build_nemo_gym_config_router_replay_resolves_dtype(detected_uv_dirs):
+    with patch(
+        "nemo_rl.models.generation.interfaces.resolve_routed_experts_dtype_name_for_model",
+        return_value="int8",
+    ) as mock_resolve:
+        cfg = build_nemo_gym_config(
+            _env_configs(),
+            base_urls=[],
+            model_name="test-model",
+            enable_router_replay=True,
+        )
+
+    mock_resolve.assert_called_once_with("test-model")
+    assert cfg["require_routed_experts"] is True
+    assert cfg["routed_experts_dtype"] == "int8"
+
+
+@pytest.mark.parametrize("num_gpu_nodes", [0, 1], ids=["no-gpus", "colocated-gpus"])
+def test_spinup_nemo_gym_actor(detected_uv_dirs, num_gpu_nodes):
+    """The actor gets the registry runtime_env, and node affinity only when it
+    has colocated GPUs to land next to."""
+    actor = MagicMock()
+    actor._spinup.remote.return_value = "spinup-ref"
+    runtime_env = {"py_executable": "/venv/bin/python"}
+
+    with (
+        patch.object(
+            nemo_gym_mod, "make_actor_runtime_env", return_value=runtime_env
+        ) as mock_runtime_env,
+        patch.object(nemo_gym_mod, "NemoGym") as mock_cls,
+        patch.object(nemo_gym_mod, "ray") as mock_ray,
+    ):
+        mock_cls.options.return_value.remote.return_value = actor
+        mock_ray.get_runtime_context.return_value.get_node_id.return_value = "a" * 56
+
+        result = spinup_nemo_gym_actor(
+            _env_configs(num_gpu_nodes=num_gpu_nodes),
+            base_urls=["http://vllm-0"],
+            model_name="test-model",
+            use_fastokens=True,
+        )
+
+    assert result is actor
+    mock_runtime_env.assert_called_once_with(NEMO_GYM_ACTOR_FQN)
+
+    options_kwargs = mock_cls.options.call_args.kwargs
+    assert options_kwargs["runtime_env"] is runtime_env
+    if num_gpu_nodes:
+        assert isinstance(
+            options_kwargs["scheduling_strategy"],
+            nemo_gym_mod.NodeAffinitySchedulingStrategy,
+        )
+        assert options_kwargs["scheduling_strategy"].node_id == "a" * 56
+    else:
+        assert "scheduling_strategy" not in options_kwargs
+
+    cfg = mock_cls.options.return_value.remote.call_args.args[0]
+    assert cfg["use_fastokens"] is True
+
+    # Spinup is deferred from __init__, so the factory must await it.
+    actor._spinup.remote.assert_called_once_with()
+    mock_ray.get.assert_called_once_with("spinup-ref")

--- a/tests/unit/environments/test_nemo_gym_utils.py
+++ b/tests/unit/environments/test_nemo_gym_utils.py
@@ -115,6 +115,8 @@ def _env_configs(**overrides):
         "num_gpu_nodes": 1,
         "invalid_tool_call_patterns": ["bad_call"],
         "thinking_tags": ["<think>"],
+        "tokenizer_config": {"name": "test-tokenizer"},
+        "pad_dynamic_image_shapes": True,
         "config_paths": ["gym.yaml"],
     }
     nemo_gym.update(overrides)
@@ -141,12 +143,16 @@ def test_build_nemo_gym_config_splits_nemo_rl_keys(detected_uv_dirs):
         env_configs,
         base_urls=["http://vllm-0"],
         model_name="test-model",
+        enable_router_replay=False,
+        use_fastokens=False,
     )
 
     assert cfg["model_name"] == "test-model"
     assert cfg["base_urls"] == ["http://vllm-0"]
     assert cfg["invalid_tool_call_patterns"] == ["bad_call"]
     assert cfg["thinking_tags"] == ["<think>"]
+    assert cfg["tokenizer_config"] == {"name": "test-tokenizer"}
+    assert cfg["pad_dynamic_image_shapes"] is True
     assert cfg["initial_global_config_dict"] == {
         "num_gpu_nodes": 1,
         "config_paths": ["gym.yaml"],
@@ -173,20 +179,29 @@ def test_build_nemo_gym_config_uv_dirs(detected_uv_dirs, configured, expected):
         _env_configs(**configured),
         base_urls=[],
         model_name="test-model",
+        enable_router_replay=False,
+        use_fastokens=False,
     )
     global_config = cfg["initial_global_config_dict"]
     assert (global_config["uv_cache_dir"], global_config["uv_venv_dir"]) == expected
 
 
 def test_build_nemo_gym_config_router_replay_off_uses_default_dtype(detected_uv_dirs):
-    cfg = build_nemo_gym_config(_env_configs(), base_urls=[], model_name="test-model")
+    cfg = build_nemo_gym_config(
+        _env_configs(),
+        base_urls=[],
+        model_name="test-model",
+        enable_router_replay=False,
+        use_fastokens=False,
+    )
     assert cfg["require_routed_experts"] is False
     assert cfg["routed_experts_dtype"] == "int16"
 
 
 def test_build_nemo_gym_config_router_replay_resolves_dtype(detected_uv_dirs):
-    with patch(
-        "nemo_rl.models.generation.interfaces.resolve_routed_experts_dtype_name_for_model",
+    with patch.object(
+        nemo_gym_mod,
+        "resolve_routed_experts_dtype_name_for_model",
         return_value="int8",
     ) as mock_resolve:
         cfg = build_nemo_gym_config(
@@ -194,6 +209,7 @@ def test_build_nemo_gym_config_router_replay_resolves_dtype(detected_uv_dirs):
             base_urls=[],
             model_name="test-model",
             enable_router_replay=True,
+            use_fastokens=False,
         )
 
     mock_resolve.assert_called_once_with("test-model")
@@ -226,6 +242,7 @@ def test_spinup_nemo_gym_actor(detected_uv_dirs, num_gpu_nodes):
             base_urls=["http://vllm-0"],
             model_name="test-model",
             tokenizer=tokenizer,
+            enable_router_replay=False,
             use_fastokens=True,
         )
 

--- a/tests/unit/environments/test_nemo_gym_utils.py
+++ b/tests/unit/environments/test_nemo_gym_utils.py
@@ -17,13 +17,19 @@ These run in the default L0 suite. Keep this module free of heavy imports
 (e.g. vllm) so the fast detector tests are not gated behind the nemo_gym extra.
 """
 
+import copy
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from nemo_rl.environments import nemo_gym as nemo_gym_mod
 from nemo_rl.environments.nemo_gym import (
+    NEMO_GYM_ACTOR_FQN,
     _detect_invalid_tool_call_and_malformed_thinking,
+    build_nemo_gym_config,
     get_nemo_gym_uv_cache_dir,
     get_nemo_gym_venv_dir,
+    spinup_nemo_gym_actor,
 )
 
 
@@ -97,3 +103,141 @@ def test_get_nemo_gym_uv_cache_dir_uses_uv_inside_container(monkeypatch):
         lambda *args, **kwargs: b"  /root/.cache/uv\n",
     )
     assert get_nemo_gym_uv_cache_dir() == "/root/.cache/uv"
+
+
+def _env_configs(**overrides):
+    nemo_gym = {
+        "num_gpu_nodes": 1,
+        "invalid_tool_call_patterns": ["bad_call"],
+        "thinking_tags": ["<think>"],
+        "config_paths": ["gym.yaml"],
+    }
+    nemo_gym.update(overrides)
+    return {"nemo_gym": nemo_gym}
+
+
+@pytest.fixture
+def detected_uv_dirs(monkeypatch):
+    """Pretend we are in a container with image-baked uv cache + venv dirs."""
+    monkeypatch.setattr(
+        nemo_gym_mod, "get_nemo_gym_uv_cache_dir", lambda: "/opt/nemo-gym/.uv-cache"
+    )
+    monkeypatch.setattr(
+        nemo_gym_mod, "get_nemo_gym_venv_dir", lambda: "/opt/nemo-gym/venvs"
+    )
+
+
+def test_build_nemo_gym_config_splits_nemo_rl_keys(detected_uv_dirs):
+    """NeMo-RL-only knobs become top-level fields; the rest is Gym's global config."""
+    env_configs = _env_configs()
+    env_configs_before = copy.deepcopy(env_configs)
+
+    cfg = build_nemo_gym_config(
+        env_configs,
+        base_urls=["http://vllm-0"],
+        model_name="test-model",
+    )
+
+    assert cfg["model_name"] == "test-model"
+    assert cfg["base_urls"] == ["http://vllm-0"]
+    assert cfg["invalid_tool_call_patterns"] == ["bad_call"]
+    assert cfg["thinking_tags"] == ["<think>"]
+    assert cfg["initial_global_config_dict"] == {
+        "num_gpu_nodes": 1,
+        "config_paths": ["gym.yaml"],
+        "uv_cache_dir": "/opt/nemo-gym/.uv-cache",
+        "uv_venv_dir": "/opt/nemo-gym/venvs",
+    }
+    # The caller's master_config.env must survive untouched.
+    assert env_configs == env_configs_before
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        ({}, ("/opt/nemo-gym/.uv-cache", "/opt/nemo-gym/venvs")),
+        (
+            {"uv_cache_dir": "/custom/cache", "uv_venv_dir": "/custom/venvs"},
+            ("/custom/cache", "/custom/venvs"),
+        ),
+    ],
+    ids=["detected", "explicit-wins"],
+)
+def test_build_nemo_gym_config_uv_dirs(detected_uv_dirs, configured, expected):
+    cfg = build_nemo_gym_config(
+        _env_configs(**configured),
+        base_urls=[],
+        model_name="test-model",
+    )
+    global_config = cfg["initial_global_config_dict"]
+    assert (global_config["uv_cache_dir"], global_config["uv_venv_dir"]) == expected
+
+
+def test_build_nemo_gym_config_router_replay_off_uses_default_dtype(detected_uv_dirs):
+    cfg = build_nemo_gym_config(_env_configs(), base_urls=[], model_name="test-model")
+    assert cfg["require_routed_experts"] is False
+    assert cfg["routed_experts_dtype"] == "int16"
+
+
+def test_build_nemo_gym_config_router_replay_resolves_dtype(detected_uv_dirs):
+    with patch(
+        "nemo_rl.models.generation.interfaces.resolve_routed_experts_dtype_name_for_model",
+        return_value="int8",
+    ) as mock_resolve:
+        cfg = build_nemo_gym_config(
+            _env_configs(),
+            base_urls=[],
+            model_name="test-model",
+            enable_router_replay=True,
+        )
+
+    mock_resolve.assert_called_once_with("test-model")
+    assert cfg["require_routed_experts"] is True
+    assert cfg["routed_experts_dtype"] == "int8"
+
+
+@pytest.mark.parametrize("num_gpu_nodes", [0, 1], ids=["no-gpus", "colocated-gpus"])
+def test_spinup_nemo_gym_actor(detected_uv_dirs, num_gpu_nodes):
+    """The actor gets the registry runtime_env, and node affinity only when it
+    has colocated GPUs to land next to."""
+    actor = MagicMock()
+    actor._spinup.remote.return_value = "spinup-ref"
+    runtime_env = {"py_executable": "/venv/bin/python"}
+
+    with (
+        patch.object(
+            nemo_gym_mod, "make_actor_runtime_env", return_value=runtime_env
+        ) as mock_runtime_env,
+        patch.object(nemo_gym_mod, "NemoGym") as mock_cls,
+        patch.object(nemo_gym_mod, "ray") as mock_ray,
+    ):
+        mock_cls.options.return_value.remote.return_value = actor
+        mock_ray.get_runtime_context.return_value.get_node_id.return_value = "a" * 56
+
+        result = spinup_nemo_gym_actor(
+            _env_configs(num_gpu_nodes=num_gpu_nodes),
+            base_urls=["http://vllm-0"],
+            model_name="test-model",
+            use_fastokens=True,
+        )
+
+    assert result is actor
+    mock_runtime_env.assert_called_once_with(NEMO_GYM_ACTOR_FQN)
+
+    options_kwargs = mock_cls.options.call_args.kwargs
+    assert options_kwargs["runtime_env"] is runtime_env
+    if num_gpu_nodes:
+        assert isinstance(
+            options_kwargs["scheduling_strategy"],
+            nemo_gym_mod.NodeAffinitySchedulingStrategy,
+        )
+        assert options_kwargs["scheduling_strategy"].node_id == "a" * 56
+    else:
+        assert "scheduling_strategy" not in options_kwargs
+
+    cfg = mock_cls.options.return_value.remote.call_args.args[0]
+    assert cfg["use_fastokens"] is True
+
+    # Spinup is deferred from __init__, so the factory must await it.
+    actor._spinup.remote.assert_called_once_with()
+    mock_ray.get.assert_called_once_with("spinup-ref")

--- a/tests/unit/single_controller/test_setup.py
+++ b/tests/unit/single_controller/test_setup.py
@@ -1153,7 +1153,6 @@ class TestSetup:
             # run_rollouts call.
             tokenizer=tokenizer,
             enable_router_replay=False,
-            routed_experts_dtype="int16",
             use_fastokens=False,
         )
         assert actor_args.env_handles["nemo_gym"] is fake_gym_actor

--- a/tests/unit/single_controller/test_single_controller_setup.py
+++ b/tests/unit/single_controller/test_single_controller_setup.py
@@ -71,6 +71,7 @@ def _make_master_config(
             "train_global_batch_size": num_prompts_per_step * 2,
             "max_total_sequence_length": 32,
             "megatron_cfg": {"enabled": megatron_enabled},
+            "tokenizer": {},
             "generation": {
                 "backend": backend,
                 "colocated": {"enabled": colocated, "resources": {}},
@@ -415,12 +416,13 @@ class TestSetup:
             actor_args = setup_single_controller(mc, MagicMock(pad_token_id=0))
 
         mock_spinup.assert_called_once_with(
-            env_configs=mc.env,
+            mc.env,
             base_urls=patched_factories[
                 "_build_generation"
             ].return_value.dp_openai_server_base_urls,
             model_name="test-model",
             enable_router_replay=False,
+            use_fastokens=False,
         )
         assert actor_args.env_handles["nemo_gym"] is fake_gym_actor
 


### PR DESCRIPTION
## Summary

Centralizes construction of the `NemoGym` Ray actor in `nemo_rl/environments/nemo_gym.py`.

`grpo.py`, `distillation.py`, and `single_controller_utils/setup.py` previously assembled the actor configuration independently. Those paths could diverge in how they handled NeMo RL integration keys, uv directories, router replay, routed-expert dtype, and `use_fastokens`.

The shared implementation now separates those responsibilities:

- `build_nemo_gym_config()` removes NeMo RL integration settings from the configuration forwarded to Gym and applies model-dependent rollout settings.
- `spinup_nemo_gym_actor()` creates the actor runtime environment, preserves existing placement behavior, starts Gym, and installs the tokenizer.
- SingleController accepts deferred model-server URLs while generation starts concurrently.
- GRPO and SingleController now set `VIRTUAL_ENV` and `UV_PROJECT_ENVIRONMENT` to the virtual-environment root through `make_actor_runtime_env()`, matching the directory values already used by distillation.
- Distillation now promotes `tokenizer_config` and `pad_dynamic_image_shapes` into the top-level `NemoGymConfig` fields consumed by the actor. This enables the VLM distillation path, although no current in-tree distillation recipe sets `is_vlm: true`.

## Stack

This is the first PR in the NeMo-Gym actor-sharding stack. Actor lifetime fixes follow in #3368.