### PR TITLE
fix(nemo-gym): define actor failure and teardown ownership

### DIFF
--- a/examples/nemo_gym/run_grpo_nemo_gym.py
+++ b/examples/nemo_gym/run_grpo_nemo_gym.py
@@ -36,7 +36,6 @@ from nemo_rl.algorithms.grpo import (
     grpo_train,
     refit_policy_generation,
     setup,
-    shutdown_environments,
 )
 from nemo_rl.algorithms.utils import get_tokenizer
 from nemo_rl.data.utils import setup_response_data
@@ -46,6 +45,7 @@ from nemo_rl.environments.nemo_gym import (
     setup_nemo_gym_config,
     should_use_nemo_gym,
 )
+from nemo_rl.environments.utils import shutdown_environments
 from nemo_rl.experience.rollouts import run_nemo_gym_rollout_sync
 from nemo_rl.models.generation import configure_generation_config
 from nemo_rl.models.generation.vllm.config import materialize_vllm_video_config
@@ -274,6 +274,7 @@ The validation set you pass in will directly be used for validation with no addi
     task_to_env = {"nemo_gym": nemo_gym}
     val_task_to_env = task_to_env
 
+    trainer_owns_environment_shutdown = False
     try:
         if is_trajectory_collection:
             collect_trajectories(
@@ -334,6 +335,7 @@ The validation set you pass in will directly be used for validation with no addi
             print("🚀 Running synchronous GRPO training")
 
             # Run standard GRPO training
+            trainer_owns_environment_shutdown = True
             grpo_train(
                 policy,
                 policy_generation,
@@ -350,7 +352,8 @@ The validation set you pass in will directly be used for validation with no addi
                 processor=processor,
             )
     finally:
-        shutdown_environments(task_to_env, val_task_to_env)
+        if not trainer_owns_environment_shutdown:
+            shutdown_environments(task_to_env, val_task_to_env)
         try:
             policy_generation.shutdown()
         except Exception as error:

--- a/examples/run_grpo.py
+++ b/examples/run_grpo.py
@@ -21,8 +21,8 @@ from omegaconf import OmegaConf
 
 from nemo_rl.algorithms.grpo import (
     MasterConfig,
+    grpo_train,
     setup,
-    shutdown_environments,
 )
 from nemo_rl.algorithms.utils import get_tokenizer
 from nemo_rl.data.utils import setup_response_data
@@ -32,6 +32,7 @@ from nemo_rl.data_plane.factory import (
     select_sync_trainer,
 )
 from nemo_rl.distributed.virtual_cluster import init_ray
+from nemo_rl.environments.utils import shutdown_environments
 from nemo_rl.models.generation import configure_generation_config
 from nemo_rl.telemetry.setup import init_telemetry_driver, shutdown_telemetry
 from nemo_rl.utils.config import (
@@ -162,6 +163,7 @@ def main() -> None:
                 print(f"  {label}: {value:.1f}s")
         print("=" * 60 + "\n", flush=True)
 
+        trainer_owns_environment_shutdown = False
         try:
             # Check if async mode is enabled
             if config.grpo.async_grpo.enabled:
@@ -211,6 +213,7 @@ def main() -> None:
                 # Two parallel synchronous trainers (verl-style — main_ppo.py vs
                 # main_ppo_sync.py). data_plane.enabled selects which one runs.
                 trainer = select_sync_trainer(master_config)
+                trainer_owns_environment_shutdown = trainer is grpo_train
                 # grpo_train_sync defers checkpoint finalization to the checkpointer's
                 # background threads; the context manager guarantees they are flushed on
                 # exit. (grpo_train also flushes internally; shutdown() is idempotent.)
@@ -230,7 +233,8 @@ def main() -> None:
                         master_config,
                     )
         finally:
-            shutdown_environments(task_to_env, val_task_to_env)
+            if not trainer_owns_environment_shutdown:
+                shutdown_environments(task_to_env, val_task_to_env)
             try:
                 policy_generation.shutdown()
             except Exception as error:

--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -52,6 +52,7 @@ from nemo_rl.environments.nemo_gym import (
     should_use_nemo_gym,
     spinup_nemo_gym_actor,
 )
+from nemo_rl.environments.utils import shutdown_environments
 from nemo_rl.experience.rollouts import (
     run_async_multi_turn_rollout,
     run_multi_turn_rollout,
@@ -638,8 +639,7 @@ def setup(
 # ===============================================================================
 
 
-@trace_fn(RLSpanGroup.JOB, "rl.distillation.job")
-def distillation_train(
+def _distillation_train_impl(
     student_policy: ColocatablePolicyInterface,
     teacher_policy: ColocatablePolicyInterface,
     student_generation: Optional[GenerationInterface],
@@ -1181,6 +1181,43 @@ def distillation_train(
     # without this the daemon finalization thread could be killed before the
     # final tmp_step_N is renamed.
     checkpointer.shutdown()
+
+
+@trace_fn(RLSpanGroup.JOB, "rl.distillation.job")
+def distillation_train(
+    student_policy: ColocatablePolicyInterface,
+    teacher_policy: ColocatablePolicyInterface,
+    student_generation: Optional[GenerationInterface],
+    dataloader: StatefulDataLoader,
+    val_dataloader: Optional[StatefulDataLoader],
+    tokenizer: TokenizerType,
+    loss_fn: DistillationLossFn,
+    task_to_env: dict[str, EnvironmentInterface],
+    val_task_to_env: Optional[dict[str, EnvironmentInterface]],
+    logger: Logger,
+    checkpointer: CheckpointManager,
+    distillation_save_state: DistillationSaveState,
+    master_config: MasterConfig,
+) -> None:
+    """Run distillation training and always tear down its environments."""
+    try:
+        _distillation_train_impl(
+            student_policy=student_policy,
+            teacher_policy=teacher_policy,
+            student_generation=student_generation,
+            dataloader=dataloader,
+            val_dataloader=val_dataloader,
+            tokenizer=tokenizer,
+            loss_fn=loss_fn,
+            task_to_env=task_to_env,
+            val_task_to_env=val_task_to_env,
+            logger=logger,
+            checkpointer=checkpointer,
+            distillation_save_state=distillation_save_state,
+            master_config=master_config,
+        )
+    finally:
+        shutdown_environments(task_to_env, val_task_to_env)
 
 
 def validate(

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -80,6 +80,7 @@ from nemo_rl.distributed.virtual_cluster import (
 )
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.environments.nemo_gym import spinup_nemo_gym_actor
+from nemo_rl.environments.utils import shutdown_environments
 from nemo_rl.experience.interfaces import (
     NEMO_GYM_TASK_INDEX_KEY,
     NEXT_NEMO_GYM_TASK_INDEX_KEY,
@@ -3465,11 +3466,13 @@ def grpo_train(
             total_steps += 1
             if should_save_by_timeout:
                 checkpointer.shutdown()
+                shutdown_environments(task_to_env, val_task_to_env)
                 memory_tracker.snapshot_start_of_stage("", dir())
                 print("Timeout has been reached, stopping training early", flush=True)
                 return
             if total_steps >= max_num_steps:
                 checkpointer.shutdown()
+                shutdown_environments(task_to_env, val_task_to_env)
                 memory_tracker.snapshot_start_of_stage("", dir())
                 print(
                     "Max number of steps has been reached, stopping training early",
@@ -3486,6 +3489,10 @@ def grpo_train(
     # so without this the daemon finalization thread would be killed before the
     # final tmp_step_N is renamed.
     checkpointer.shutdown()
+    # Environments own long-lived server subprocesses (NeMo-Gym runs ~60 per
+    # actor), so they have to be stopped on every exit from the synchronous
+    # trainer too, not just the async one.
+    shutdown_environments(task_to_env, val_task_to_env)
 
 
 def validate(
@@ -4894,21 +4901,7 @@ def async_grpo_train(
         except Exception as e:
             print(f"Error stopping replay buffer: {e}")
 
-        # Environments must be shut down before generation workers because
-        # they may have in-flight HTTP requests to vLLM HTTP endpoints.
-        # Killing generation first leaves environments retrying dead connections.
-        for env_dict in (task_to_env, val_task_to_env):
-            if env_dict is None:
-                continue
-            for task_name, env in env_dict.items():
-                print(f"🛑 Shutting down environment {task_name}...")
-                try:
-                    ray.get(env.shutdown.remote(), timeout=10)
-                except Exception:
-                    try:
-                        ray.kill(env)
-                    except Exception as e:
-                        print(f"Error shutting down environment {task_name}: {e}")
+        shutdown_environments(task_to_env, val_task_to_env)
 
         print("🛑 Shutting down generation workers...")
         try:

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -2868,8 +2868,7 @@ def _validation_early_stop_message(
     )
 
 
-@trace_fn(RLSpanGroup.JOB, "rl.grpo.job")
-def grpo_train(
+def _grpo_train_impl(
     policy: ColocatablePolicyInterface,
     policy_generation: Optional[GenerationInterface],
     wrapped_dataloader: StatefulDataLoader | MultipleDataloaderWrapper,
@@ -4040,13 +4039,11 @@ def grpo_train(
                 return
             if should_save_by_timeout:
                 checkpointer.shutdown()
-                shutdown_environments(task_to_env, val_task_to_env)
                 memory_tracker.snapshot_start_of_stage("", dir())
                 print("Timeout has been reached, stopping training early", flush=True)
                 return
             if total_steps >= max_num_steps:
                 checkpointer.shutdown()
-                shutdown_environments(task_to_env, val_task_to_env)
                 memory_tracker.snapshot_start_of_stage("", dir())
                 print(
                     "Max number of steps has been reached, stopping training early",
@@ -4063,10 +4060,43 @@ def grpo_train(
     # so without this the daemon finalization thread would be killed before the
     # final tmp_step_N is renamed.
     checkpointer.shutdown()
-    # Environments own long-lived server subprocesses (NeMo-Gym runs ~60 per
-    # actor), so they have to be stopped on every exit from the synchronous
-    # trainer too, not just the async one.
-    shutdown_environments(task_to_env, val_task_to_env)
+
+
+@trace_fn(RLSpanGroup.JOB, "rl.grpo.job")
+def grpo_train(
+    policy: ColocatablePolicyInterface,
+    policy_generation: Optional[GenerationInterface],
+    wrapped_dataloader: StatefulDataLoader | MultipleDataloaderWrapper,
+    val_dataloader: Optional[StatefulDataLoader],
+    tokenizer: TokenizerType,
+    loss_fn: LossFunction,
+    task_to_env: dict[str, EnvironmentInterface],
+    val_task_to_env: Optional[dict[str, EnvironmentInterface]],
+    logger: Logger,
+    checkpointer: CheckpointManager,
+    grpo_save_state: GRPOSaveState,
+    master_config: MasterConfig,
+    processor: Optional[AutoProcessor] = None,
+) -> None:
+    """Run GRPO training and always tear down its environments."""
+    try:
+        _grpo_train_impl(
+            policy=policy,
+            policy_generation=policy_generation,
+            wrapped_dataloader=wrapped_dataloader,
+            val_dataloader=val_dataloader,
+            tokenizer=tokenizer,
+            loss_fn=loss_fn,
+            task_to_env=task_to_env,
+            val_task_to_env=val_task_to_env,
+            logger=logger,
+            checkpointer=checkpointer,
+            grpo_save_state=grpo_save_state,
+            master_config=master_config,
+            processor=processor,
+        )
+    finally:
+        shutdown_environments(task_to_env, val_task_to_env)
 
 
 def validate(

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -86,6 +86,7 @@ from nemo_rl.distributed.virtual_cluster import (
 )
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.environments.nemo_gym import should_use_nemo_gym, spinup_nemo_gym_actor
+from nemo_rl.environments.utils import shutdown_environments
 from nemo_rl.experience.interfaces import (
     FRONTIER_ORDINAL_KEY,
     NEMO_GYM_TASK_INDEX_KEY,
@@ -490,35 +491,6 @@ def _needs_hf_refit_handshake(
     if generation_backend == "megatron":
         return False
     return not (nccl_reshard_refit_enabled and not colocated_inference)
-
-
-def shutdown_environments(
-    task_to_env: dict[str, EnvironmentInterface] | None,
-    val_task_to_env: dict[str, EnvironmentInterface] | None,
-) -> None:
-    """Shut down each unique environment actor before generation stops."""
-    seen_environment_handles: set[int] = set()
-    for environment_map in (task_to_env, val_task_to_env):
-        if environment_map is None:
-            continue
-        for task_name, environment in environment_map.items():
-            handle_id = id(environment)
-            if handle_id in seen_environment_handles:
-                continue
-            seen_environment_handles.add(handle_id)
-
-            print(f"🛑 Shutting down environment {task_name}...")
-            try:
-                ray.get(environment.shutdown.remote(), timeout=10)
-            except Exception as shutdown_error:
-                print(
-                    f"Environment {task_name} graceful shutdown failed: "
-                    f"{shutdown_error}"
-                )
-                try:
-                    ray.kill(environment)
-                except Exception as kill_error:
-                    print(f"Error stopping environment {task_name}: {kill_error}")
 
 
 def setup(
@@ -4068,11 +4040,13 @@ def grpo_train(
                 return
             if should_save_by_timeout:
                 checkpointer.shutdown()
+                shutdown_environments(task_to_env, val_task_to_env)
                 memory_tracker.snapshot_start_of_stage("", dir())
                 print("Timeout has been reached, stopping training early", flush=True)
                 return
             if total_steps >= max_num_steps:
                 checkpointer.shutdown()
+                shutdown_environments(task_to_env, val_task_to_env)
                 memory_tracker.snapshot_start_of_stage("", dir())
                 print(
                     "Max number of steps has been reached, stopping training early",
@@ -4089,6 +4063,10 @@ def grpo_train(
     # so without this the daemon finalization thread would be killed before the
     # final tmp_step_N is renamed.
     checkpointer.shutdown()
+    # Environments own long-lived server subprocesses (NeMo-Gym runs ~60 per
+    # actor), so they have to be stopped on every exit from the synchronous
+    # trainer too, not just the async one.
+    shutdown_environments(task_to_env, val_task_to_env)
 
 
 def validate(

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -174,12 +174,17 @@ def _detect_invalid_tool_call_and_malformed_thinking(
     return is_invalid_tool_call, has_malformed_thinking
 
 
-@ray.remote(max_restarts=-1, max_task_retries=-1)  # pragma: no cover
+# Fail fast rather than restart. The servers this actor owns are started in
+# _spinup, which Ray does not re-run after a restart, so a restarted actor is
+# permanently broken: every later call raises AttributeError on self.rch and
+# the caller never sees the RayActorError it is waiting for.
+@ray.remote(max_restarts=0, max_task_retries=0)  # pragma: no cover
 class NemoGym(EnvironmentInterface):
     """This environment class isn't really used for training. It's really meant as an integration wrapper around NeMo-Gym that hooks into the existing NeMo RL resource management via ray. So there is still one source of truth for resource management in NeMo RL."""
 
     def __init__(self, cfg: NemoGymConfig):
         self.cfg = cfg
+        self.rh = None
 
     def _spinup(self) -> None:
         """Start the NeMo-Gym head server and rollout collection helper.
@@ -512,7 +517,16 @@ Output prompt token IDs: {output_item_dict["prompt_token_ids"]}
         }
 
     def shutdown(self) -> None:
-        self.rh.shutdown()
+        """Stop the Gym servers. Safe to call more than once, and before spinup.
+
+        Callers routinely hold the same actor under both the train and the
+        validation environment map, so this is reached twice on a normal exit.
+        The underlying RunHelper.shutdown() raises on a second call, which used
+        to escalate an otherwise graceful teardown into a ray.kill().
+        """
+        rh, self.rh = self.rh, None
+        if rh is not None:
+            rh.shutdown()
 
     def step(self, message_log_batch, metadata):
         # This is not used since NeMo-Gym will handle the rollouts entirely.

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -326,7 +326,7 @@ def get_pad_dynamic_image_shapes(env_config: Mapping[str, Any]) -> bool:
 
 # Fail fast rather than restart. The servers this actor owns are started in
 # _spinup, which Ray does not re-run after a restart, so a restarted actor is
-# permanently broken: every later call raises AttributeError on self.rch and
+# permanently broken: _require_spinup() rejects every later rollout call, and
 # the caller never sees the RayActorError it is waiting for.
 @ray.remote(max_restarts=0, max_task_retries=0)  # pragma: no cover
 class NemoGym(EnvironmentInterface):
@@ -1151,13 +1151,10 @@ output prompt token ids till seen: {output_item_dict["prompt_token_ids"][: len(s
     def shutdown(self) -> None:
         """Stop the Gym servers. Safe to call more than once, and before spinup.
 
-        Callers routinely hold the same actor under both the train and the
-        validation environment map, so this is reached twice on a normal exit.
-        The underlying RunHelper.shutdown() raises on a second call, which used
-        to escalate an otherwise graceful teardown into a ray.kill(). Teardown
-        also runs in a finally block, so it must not turn a real training error
-        into a confusing AttributeError from a never-spun-up (e.g. restarted)
-        actor.
+        Teardown runs in a finally block and may be requested more than once.
+        RunHelper.shutdown() is not idempotent, so the handle is cleared before
+        it is used. A failure therefore cannot leave a live handle that a later
+        cleanup attempt invokes again.
         """
         rh, self.rh = self.rh, None
         if rh is not None:

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -324,7 +324,11 @@ def get_pad_dynamic_image_shapes(env_config: Mapping[str, Any]) -> bool:
     return bool(nemo_gym_config.get("pad_dynamic_image_shapes"))
 
 
-@ray.remote(max_restarts=-1, max_task_retries=-1)  # pragma: no cover
+# Fail fast rather than restart. The servers this actor owns are started in
+# _spinup, which Ray does not re-run after a restart, so a restarted actor is
+# permanently broken: every later call raises AttributeError on self.rch and
+# the caller never sees the RayActorError it is waiting for.
+@ray.remote(max_restarts=0, max_task_retries=0)  # pragma: no cover
 class NemoGym(EnvironmentInterface):
     """This environment class isn't really used for training. It's really meant as an integration wrapper around NeMo-Gym that hooks into the existing NeMo RL resource management via ray. So there is still one source of truth for resource management in NeMo RL."""
 
@@ -1145,13 +1149,19 @@ output prompt token ids till seen: {output_item_dict["prompt_token_ids"][: len(s
         return result
 
     def shutdown(self) -> None:
-        # Teardown runs in a finally block, so it must not turn a real training error
-        # into a confusing AttributeError from a never-spun-up (e.g. restarted) actor.
-        if self.rh is None:
-            return
-        run_helper = self.rh
-        self.rh = None
-        run_helper.shutdown()
+        """Stop the Gym servers. Safe to call more than once, and before spinup.
+
+        Callers routinely hold the same actor under both the train and the
+        validation environment map, so this is reached twice on a normal exit.
+        The underlying RunHelper.shutdown() raises on a second call, which used
+        to escalate an otherwise graceful teardown into a ray.kill(). Teardown
+        also runs in a finally block, so it must not turn a real training error
+        into a confusing AttributeError from a never-spun-up (e.g. restarted)
+        actor.
+        """
+        rh, self.rh = self.rh, None
+        if rh is not None:
+            rh.shutdown()
 
     def step(self, message_log_batch, metadata):
         # This is not used since NeMo-Gym will handle the rollouts entirely.

--- a/nemo_rl/environments/utils.py
+++ b/nemo_rl/environments/utils.py
@@ -149,16 +149,16 @@ def shutdown_environments(
     """Gracefully shut down every distinct environment actor in the given maps.
 
     Runners commonly bind the same actor — often the very same mapping — to
-    both training and validation, so handles are deduped before teardown.
-    Without that, the second shutdown of an already-stopped actor fails and
-    escalates a graceful exit into a ``ray.kill``.
+    both training and validation, so each handle is asked to stop once no
+    matter how many maps contain it.
 
     Environments must be torn down before generation workers: they may have
     in-flight HTTP requests to the vLLM endpoints, and killing generation first
     leaves them retrying dead connections.
 
     Args:
-        env_maps: Task-name to environment mappings. ``None`` entries are skipped.
+        env_maps: Task-name to environment mappings. ``None`` and empty
+            mappings are skipped.
         timeout: Seconds to wait for each actor's ``shutdown()`` before killing it.
     """
     seen: set[int] = set()

--- a/nemo_rl/environments/utils.py
+++ b/nemo_rl/environments/utils.py
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from typing import Any, Dict, NotRequired, TypedDict
+from typing import Any, Dict, NotRequired, Optional, TypedDict
 
+import ray
 from hydra.utils import get_object
 
 from nemo_rl.distributed.ray_actor_environment_registry import get_actor_python_env
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.utils.venvs import create_local_venv_on_each_node
+
+DEFAULT_ENV_SHUTDOWN_TIMEOUT_SECONDS = 10.0
 
 
 # Environment registry entry schema.
@@ -137,3 +140,43 @@ def register_env(env_name: str, actor_class_fqn: str) -> None:
         raise ValueError(f"Env name {env_name} already registered")
 
     ENV_REGISTRY[env_name] = {"actor_class_fqn": actor_class_fqn}
+
+
+def shutdown_environments(
+    *env_maps: Optional[Dict[str, EnvironmentInterface]],
+    timeout: float = DEFAULT_ENV_SHUTDOWN_TIMEOUT_SECONDS,
+) -> None:
+    """Gracefully shut down every distinct environment actor in the given maps.
+
+    Runners commonly bind the same actor — often the very same mapping — to
+    both training and validation, so handles are deduped before teardown.
+    Without that, the second shutdown of an already-stopped actor fails and
+    escalates a graceful exit into a ``ray.kill``.
+
+    Environments must be torn down before generation workers: they may have
+    in-flight HTTP requests to the vLLM endpoints, and killing generation first
+    leaves them retrying dead connections.
+
+    Args:
+        env_maps: Task-name to environment mappings. ``None`` entries are skipped.
+        timeout: Seconds to wait for each actor's ``shutdown()`` before killing it.
+    """
+    seen: set[int] = set()
+    for env_map in env_maps:
+        if not env_map:
+            continue
+        for task_name, env in env_map.items():
+            if id(env) in seen:
+                continue
+            seen.add(id(env))
+            print(f"🛑 Shutting down environment {task_name}...")
+            try:
+                ray.get(env.shutdown.remote(), timeout=timeout)
+            except Exception as e:
+                print(f"Graceful shutdown of environment {task_name} failed: {e}")
+                try:
+                    ray.kill(env)
+                except Exception as kill_error:
+                    print(
+                        f"Error killing environment {task_name}: {kill_error}",
+                    )

--- a/tests/unit/algorithms/test_distillation.py
+++ b/tests/unit/algorithms/test_distillation.py
@@ -917,6 +917,64 @@ def test_noncolocated_inference_requires_explicit_gpus_per_node_single_node():
         setup(master_config, tokenizer, dataset, None)
 
 
+def test_distillation_train_shuts_down_environments_after_failure():
+    task_to_env = {"nemo_gym": MagicMock()}
+    val_task_to_env = task_to_env
+
+    with (
+        patch.object(
+            distil_mod,
+            "_distillation_train_impl",
+            side_effect=RuntimeError("rollout failed"),
+        ),
+        patch.object(distil_mod, "shutdown_environments") as shutdown,
+        pytest.raises(RuntimeError, match="rollout failed"),
+    ):
+        distillation_train(
+            student_policy=MagicMock(),
+            teacher_policy=MagicMock(),
+            student_generation=MagicMock(),
+            dataloader=MagicMock(),
+            val_dataloader=None,
+            tokenizer=MagicMock(),
+            loss_fn=MagicMock(),
+            task_to_env=task_to_env,
+            val_task_to_env=val_task_to_env,
+            logger=MagicMock(),
+            checkpointer=MagicMock(),
+            distillation_save_state=MagicMock(),
+            master_config=MagicMock(),
+        )
+
+    shutdown.assert_called_once_with(task_to_env, val_task_to_env)
+
+
+def test_distillation_train_shuts_down_environments_after_success():
+    task_to_env = {"nemo_gym": MagicMock()}
+
+    with (
+        patch.object(distil_mod, "_distillation_train_impl"),
+        patch.object(distil_mod, "shutdown_environments") as shutdown,
+    ):
+        distillation_train(
+            student_policy=MagicMock(),
+            teacher_policy=MagicMock(),
+            student_generation=MagicMock(),
+            dataloader=MagicMock(),
+            val_dataloader=None,
+            tokenizer=MagicMock(),
+            loss_fn=MagicMock(),
+            task_to_env=task_to_env,
+            val_task_to_env=task_to_env,
+            logger=MagicMock(),
+            checkpointer=MagicMock(),
+            distillation_save_state=MagicMock(),
+            master_config=MagicMock(),
+        )
+
+    shutdown.assert_called_once_with(task_to_env, task_to_env)
+
+
 @pytest.mark.parametrize("refit_transport", [None, "nixl"])
 def test_distillation_setup_non_colocated_smoke(monkeypatch, refit_transport):
     """Smoke test: calling setup with a non-colocated config should succeed."""

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -60,7 +60,6 @@ from nemo_rl.algorithms.grpo import (
     grpo_train,
     refit_policy_generation,
     setup,
-    shutdown_environments,
     validate,
 )
 from nemo_rl.algorithms.grpo_sync import _train_fields_for_step, grpo_train_sync
@@ -1974,35 +1973,6 @@ def test_async_grpo_awaits_resume_after_refit_failure(mock_grpo_components) -> N
             _initial_grpo_save_state(),
             master_config,
         )
-
-
-def test_shutdown_environments_drains_unique_actors_before_kill() -> None:
-    shared_environment = MagicMock()
-    failing_environment = MagicMock()
-    shared_shutdown_ref = object()
-    failing_shutdown_ref = object()
-    shared_environment.shutdown.remote.return_value = shared_shutdown_ref
-    failing_environment.shutdown.remote.return_value = failing_shutdown_ref
-
-    def get_or_fail(ref, timeout=None):
-        assert timeout == 10
-        if ref is failing_shutdown_ref:
-            raise RuntimeError("environment shutdown failed")
-        assert ref is shared_shutdown_ref
-        return True
-
-    with (
-        patch("nemo_rl.algorithms.grpo.ray.get", side_effect=get_or_fail),
-        patch("nemo_rl.algorithms.grpo.ray.kill") as ray_kill,
-    ):
-        shutdown_environments(
-            {"train": shared_environment, "failing": failing_environment},
-            {"validation": shared_environment},
-        )
-
-    shared_environment.shutdown.remote.assert_called_once_with()
-    failing_environment.shutdown.remote.assert_called_once_with()
-    ray_kill.assert_called_once_with(failing_environment)
 
 
 def test_should_use_nemo_gym_requires_dynamo_token_wrapper() -> None:
@@ -6111,3 +6081,58 @@ def test_train_fields_for_step(skip_prev_logprobs, expect_prev):
 )
 def test_needs_hf_refit_handshake(backend, nccl_reshard, colocated, expected):
     assert _needs_hf_refit_handshake(backend, nccl_reshard, colocated) is expected
+
+
+def test_grpo_train_shuts_down_environments_after_failure():
+    task_to_env = {"nemo_gym": MagicMock()}
+    val_task_to_env = task_to_env
+
+    with (
+        patch(
+            "nemo_rl.algorithms.grpo._grpo_train_impl",
+            side_effect=RuntimeError("rollout failed"),
+        ),
+        patch("nemo_rl.algorithms.grpo.shutdown_environments") as shutdown,
+        pytest.raises(RuntimeError, match="rollout failed"),
+    ):
+        grpo_train(
+            policy=MagicMock(),
+            policy_generation=MagicMock(),
+            wrapped_dataloader=MagicMock(),
+            val_dataloader=None,
+            tokenizer=MagicMock(),
+            loss_fn=MagicMock(),
+            task_to_env=task_to_env,
+            val_task_to_env=val_task_to_env,
+            logger=MagicMock(),
+            checkpointer=MagicMock(),
+            grpo_save_state=MagicMock(),
+            master_config=MagicMock(),
+        )
+
+    shutdown.assert_called_once_with(task_to_env, val_task_to_env)
+
+
+def test_grpo_train_shuts_down_environments_after_success():
+    task_to_env = {"nemo_gym": MagicMock()}
+
+    with (
+        patch("nemo_rl.algorithms.grpo._grpo_train_impl"),
+        patch("nemo_rl.algorithms.grpo.shutdown_environments") as shutdown,
+    ):
+        grpo_train(
+            policy=MagicMock(),
+            policy_generation=MagicMock(),
+            wrapped_dataloader=MagicMock(),
+            val_dataloader=None,
+            tokenizer=MagicMock(),
+            loss_fn=MagicMock(),
+            task_to_env=task_to_env,
+            val_task_to_env=task_to_env,
+            logger=MagicMock(),
+            checkpointer=MagicMock(),
+            grpo_save_state=MagicMock(),
+            master_config=MagicMock(),
+        )
+
+    shutdown.assert_called_once_with(task_to_env, task_to_env)

--- a/tests/unit/environments/test_environment_utils.py
+++ b/tests/unit/environments/test_environment_utils.py
@@ -11,9 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest.mock import MagicMock, patch
+
 import pytest
 
-from nemo_rl.environments.utils import ENV_REGISTRY, register_env
+from nemo_rl.environments.utils import (
+    ENV_REGISTRY,
+    register_env,
+    shutdown_environments,
+)
 
 
 def test_register_new_env_success():
@@ -50,3 +56,61 @@ def test_register_env_duplicate_raises_error():
         # Restore original registry state
         ENV_REGISTRY.clear()
         ENV_REGISTRY.update(original_registry)
+
+
+def _fake_env(name):
+    env = MagicMock(name=name)
+    env.shutdown.remote.return_value = f"{name}-ref"
+    return env
+
+
+def test_shutdown_environments_dedupes_shared_handles():
+    """Runners bind the same actor to train and val; it must be stopped once.
+
+    Shutting an already-stopped NeMo-Gym actor down a second time raises and
+    would escalate a graceful teardown into a ray.kill.
+    """
+    env = _fake_env("gym")
+    task_to_env = {"nemo_gym": env}
+    val_task_to_env = task_to_env  # the aliasing real runners use
+
+    with patch("nemo_rl.environments.utils.ray") as mock_ray:
+        shutdown_environments(task_to_env, val_task_to_env)
+
+    env.shutdown.remote.assert_called_once_with()
+    mock_ray.get.assert_called_once_with("gym-ref", timeout=10.0)
+    mock_ray.kill.assert_not_called()
+
+
+def test_shutdown_environments_stops_each_distinct_actor():
+    train_env, val_env = _fake_env("train"), _fake_env("val")
+
+    with patch("nemo_rl.environments.utils.ray") as mock_ray:
+        shutdown_environments({"a": train_env}, {"a": val_env}, None)
+
+    train_env.shutdown.remote.assert_called_once_with()
+    val_env.shutdown.remote.assert_called_once_with()
+    assert mock_ray.get.call_count == 2
+    mock_ray.kill.assert_not_called()
+
+
+def test_shutdown_environments_kills_only_on_failure():
+    healthy, wedged = _fake_env("healthy"), _fake_env("wedged")
+
+    with patch("nemo_rl.environments.utils.ray") as mock_ray:
+        mock_ray.get.side_effect = (
+            lambda ref, timeout: None
+            if ref == "healthy-ref"
+            else (_ for _ in ()).throw(TimeoutError("no response"))
+        )
+        shutdown_environments({"healthy": healthy, "wedged": wedged})
+
+    mock_ray.kill.assert_called_once_with(wedged)
+
+
+def test_shutdown_environments_tolerates_empty_input():
+    with patch("nemo_rl.environments.utils.ray") as mock_ray:
+        shutdown_environments(None, {})
+
+    mock_ray.get.assert_not_called()
+    mock_ray.kill.assert_not_called()

--- a/tests/unit/environments/test_environment_utils.py
+++ b/tests/unit/environments/test_environment_utils.py
@@ -65,11 +65,7 @@ def _fake_env(name):
 
 
 def test_shutdown_environments_dedupes_shared_handles():
-    """Runners bind the same actor to train and val; it must be stopped once.
-
-    Shutting an already-stopped NeMo-Gym actor down a second time raises and
-    would escalate a graceful teardown into a ray.kill.
-    """
+    """Runners can bind one actor to train and val; it must be stopped once."""
     env = _fake_env("gym")
     task_to_env = {"nemo_gym": env}
     val_task_to_env = task_to_env  # the aliasing real runners use
@@ -94,8 +90,8 @@ def test_shutdown_environments_stops_each_distinct_actor():
     mock_ray.kill.assert_not_called()
 
 
-def test_shutdown_environments_kills_only_on_failure():
-    healthy, wedged = _fake_env("healthy"), _fake_env("wedged")
+def test_shutdown_environments_continues_after_a_failure():
+    wedged, healthy = _fake_env("wedged"), _fake_env("healthy")
 
     with patch("nemo_rl.environments.utils.ray") as mock_ray:
         mock_ray.get.side_effect = (
@@ -103,9 +99,26 @@ def test_shutdown_environments_kills_only_on_failure():
             if ref == "healthy-ref"
             else (_ for _ in ()).throw(TimeoutError("no response"))
         )
-        shutdown_environments({"healthy": healthy, "wedged": wedged})
+        shutdown_environments({"wedged": wedged, "healthy": healthy})
 
     mock_ray.kill.assert_called_once_with(wedged)
+    healthy.shutdown.remote.assert_called_once_with()
+
+
+def test_shutdown_environments_continues_after_a_failed_kill():
+    wedged, healthy = _fake_env("wedged"), _fake_env("healthy")
+
+    with patch("nemo_rl.environments.utils.ray") as mock_ray:
+        mock_ray.get.side_effect = (
+            lambda ref, timeout: None
+            if ref == "healthy-ref"
+            else (_ for _ in ()).throw(TimeoutError("no response"))
+        )
+        mock_ray.kill.side_effect = RuntimeError("already gone")
+        shutdown_environments({"wedged": wedged, "healthy": healthy})
+
+    mock_ray.kill.assert_called_once_with(wedged)
+    healthy.shutdown.remote.assert_called_once_with()
 
 
 def test_shutdown_environments_tolerates_empty_input():

--- a/tests/unit/environments/test_nemo_gym_utils.py
+++ b/tests/unit/environments/test_nemo_gym_utils.py
@@ -241,3 +241,36 @@ def test_spinup_nemo_gym_actor(detected_uv_dirs, num_gpu_nodes):
     # Spinup is deferred from __init__, so the factory must await it.
     actor._spinup.remote.assert_called_once_with()
     mock_ray.get.assert_called_once_with("spinup-ref")
+
+
+def test_nemo_gym_fails_fast_instead_of_restarting():
+    """A restarted actor would be permanently broken.
+
+    __init__ only stores cfg; the Gym servers are created in _spinup, which Ray
+    does not re-run after a restart. Restarting would raise AttributeError on
+    every later call instead of surfacing RayActorError to the caller.
+    """
+    metadata = nemo_gym_mod.NemoGym.__ray_metadata__
+    assert metadata.max_restarts == 0
+    assert metadata.max_task_retries == 0
+
+
+def test_nemo_gym_shutdown_is_idempotent():
+    actor = nemo_gym_mod.NemoGym.__ray_metadata__.modified_class.__new__(
+        nemo_gym_mod.NemoGym.__ray_metadata__.modified_class
+    )
+    actor.rh = MagicMock()
+    run_helper = actor.rh
+
+    actor.shutdown()
+    actor.shutdown()
+
+    run_helper.shutdown.assert_called_once_with()
+
+
+def test_nemo_gym_shutdown_before_spinup_is_a_noop():
+    cls = nemo_gym_mod.NemoGym.__ray_metadata__.modified_class
+    actor = cls.__new__(cls)
+    actor.__init__({})
+
+    actor.shutdown()  # must not raise

--- a/tests/unit/environments/test_nemo_gym_utils.py
+++ b/tests/unit/environments/test_nemo_gym_utils.py
@@ -376,8 +376,8 @@ def test_nemo_gym_fails_fast_instead_of_restarting():
     """A restarted actor would be permanently broken.
 
     __init__ only stores cfg; the Gym servers are created in _spinup, which Ray
-    does not re-run after a restart. Restarting would raise AttributeError on
-    every later call instead of surfacing RayActorError to the caller.
+    does not re-run after a restart. _require_spinup() would reject every later
+    call instead of surfacing RayActorError to the caller.
     """
     metadata = nemo_gym_mod.NemoGym.__ray_metadata__
     assert metadata.max_restarts == 0

--- a/tests/unit/environments/test_nemo_gym_utils.py
+++ b/tests/unit/environments/test_nemo_gym_utils.py
@@ -370,3 +370,36 @@ def test_spinup_nemo_gym_actor_preserves_startup_error_when_cleanup_fails(
     assert exc_info.value is startup_error
     actor.shutdown.remote.assert_called_once_with()
     mock_ray.kill.assert_called_once_with(actor)
+
+
+def test_nemo_gym_fails_fast_instead_of_restarting():
+    """A restarted actor would be permanently broken.
+
+    __init__ only stores cfg; the Gym servers are created in _spinup, which Ray
+    does not re-run after a restart. Restarting would raise AttributeError on
+    every later call instead of surfacing RayActorError to the caller.
+    """
+    metadata = nemo_gym_mod.NemoGym.__ray_metadata__
+    assert metadata.max_restarts == 0
+    assert metadata.max_task_retries == 0
+
+
+def test_nemo_gym_shutdown_is_idempotent():
+    actor = nemo_gym_mod.NemoGym.__ray_metadata__.modified_class.__new__(
+        nemo_gym_mod.NemoGym.__ray_metadata__.modified_class
+    )
+    actor.rh = MagicMock()
+    run_helper = actor.rh
+
+    actor.shutdown()
+    actor.shutdown()
+
+    run_helper.shutdown.assert_called_once_with()
+
+
+def test_nemo_gym_shutdown_before_spinup_is_a_noop():
+    cls = nemo_gym_mod.NemoGym.__ray_metadata__.modified_class
+    actor = cls.__new__(cls)
+    actor.__init__({})
+
+    actor.shutdown()  # must not raise


### PR DESCRIPTION
## Summary

Defines clear ownership and failure behavior for `NemoGym` before one job starts multiple actors.

- Configures actors with `max_restarts=0` and `max_task_retries=0`. Ray reruns `__init__` after an actor restart but does not rerun the deferred `_spinup()` method that creates the Gym servers, so a replacement actor cannot serve rollouts.
- Clears the `RunHelper` handle before invoking its non-idempotent shutdown method. Repeated cleanup and cleanup before spinup remain safe.
- Adds `shutdown_environments()`. It deduplicates aliased train and validation handles, waits for graceful shutdown under a bounded timeout, and kills actors that do not stop.
- Runs environment shutdown from `finally` blocks in synchronous GRPO and distillation.
- Keeps one shutdown owner on each GRPO path. The training function owns legacy synchronous and asynchronous training cleanup. The runner retains cleanup for TransferQueue synchronous training and trajectory-only collection.

These guarantees apply to the existing single-actor path and prevent sharding from multiplying leaked actors or leaving restarted actors without Gym server processes.

## Stack

This PR depends on #3367. Resolved-config introspection follows in #3633.