### PR TITLE
feat(nemo-gym): create actors for configured shards

### DIFF
--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -17,12 +17,17 @@ import subprocess
 import sys
 from collections import Counter
 from collections.abc import AsyncGenerator
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, NotRequired, Optional, TypedDict
 
 import ray
 import torch
-from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+from ray.util.placement_group import placement_group, remove_placement_group
+from ray.util.scheduling_strategies import (
+    NodeAffinitySchedulingStrategy,
+    PlacementGroupSchedulingStrategy,
+)
 from transformers import PreTrainedTokenizerBase
 
 from nemo_rl.distributed.virtual_cluster import (
@@ -35,8 +40,15 @@ from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.environments.nemo_gym_shards import (
     SHARDING_CONFIG_KEYS,
     ShardConfigError,
+    ShardPlan,
+    ShardSetupError,
+    ShardSpec,
+    apply_shard_log_dir,
+    apply_shard_overlay,
+    build_agent_shard_map,
     parse_shard_plan,
 )
+from nemo_rl.environments.utils import shutdown_environments
 from nemo_rl.utils.timer import Timer
 from nemo_rl.utils.venvs import make_actor_runtime_env
 
@@ -50,6 +62,26 @@ GYM_SERVER_TYPE_KEYS = (
     "responses_api_models",
     "resources_servers",
 )
+
+# Shard name used when the job is unsharded, so a single actor and a sharded
+# set have the same shape and callers need only one code path.
+DEFAULT_SHARD_NAME = "nemo_gym"
+
+# Logical CPUs reserved per shard bundle. This is a scheduling reservation, not
+# a limit: it decides whether a node can host a shard and steers Ray away from
+# stacking other CPU work there. Gym's subprocesses are not metered against it,
+# so a shard can use more than it reserves. Override per shard for known-heavy
+# stacks (e.g. code_gen and its sandbox pool).
+DEFAULT_SHARD_CPUS = 8
+
+# Waiting for STRICT_SPREAD bundles. Failing here means the allocation has
+# fewer usable nodes than the plan needs, which is worth reporting quickly.
+DEFAULT_SHARD_PG_READY_TIMEOUT_SECONDS = 180.0
+
+# Waiting for a shard to finish _spinup. Generous because a node that has never
+# run Gym builds every server's venv first; with venvs baked into the image
+# this is far shorter.
+DEFAULT_SHARD_SPINUP_TIMEOUT_SECONDS = 1800.0
 
 # Kept local (not imported from models.generation) so the gym actor stays free of
 # generation-module imports. Must cover every name resolve_routed_experts_dtype
@@ -679,7 +711,7 @@ def build_nemo_gym_config(
     enable_router_replay: bool = False,
     use_fastokens: bool = False,
 ) -> NemoGymConfig:
-    """Build the ``NemoGymConfig`` for a NeMo-Gym actor.
+    """Build the ``NemoGymConfig`` for a single, unsharded NeMo-Gym actor.
 
     Splits ``env_configs["nemo_gym"]`` into the NeMo-RL-side fields the actor
     reads directly and the remainder, which is forwarded verbatim as NeMo-Gym's
@@ -696,20 +728,44 @@ def build_nemo_gym_config(
             routed-experts carry dtype for the model.
         use_fastokens: Forwarded from ``policy.tokenizer.use_fastokens`` so the
             actor patches its tokenizer the same way the driver does.
+
+    Raises:
+        ShardConfigError: The config is sharded. One config cannot describe
+            several shards; use :func:`build_nemo_gym_actors`.
     """
     nemo_gym_dict = dict(env_configs["nemo_gym"])
 
-    # Validate the shards block even though only single-actor creation is wired
-    # up so far, so a malformed or premature sharded config fails at setup with
-    # a precise message instead of silently running unsharded.
     shard_plan = parse_shard_plan(nemo_gym_dict)
     if shard_plan is not None:
         raise ShardConfigError(
             f"env.nemo_gym.shards defines {len(shard_plan.shards)} shards "
-            f"({', '.join(s.name for s in shard_plan.shards)}), but multi-actor "
-            f"creation is not wired up yet. Remove 'shards' and use "
-            f"'config_paths' to run this job on a single actor."
+            f"({', '.join(s.name for s in shard_plan.shards)}), so it does not "
+            f"describe a single actor. Use build_nemo_gym_actors() instead."
         )
+
+    return _build_gym_actor_config(
+        nemo_gym_dict,
+        base_urls=base_urls,
+        model_name=model_name,
+        enable_router_replay=enable_router_replay,
+        use_fastokens=use_fastokens,
+    )
+
+
+def _build_gym_actor_config(
+    nemo_gym_dict: dict[str, Any],
+    *,
+    base_urls: list[Optional[str]],
+    model_name: str,
+    enable_router_replay: bool,
+    use_fastokens: bool,
+) -> NemoGymConfig:
+    """Turn one already-resolved Gym config mapping into a ``NemoGymConfig``.
+
+    Shared by the unsharded path and by each shard, so every actor gets the
+    same treatment of NeMo-RL-side keys regardless of how it was composed.
+    """
+    nemo_gym_dict = dict(nemo_gym_dict)
 
     # NeMo-RL-only keys are consumed here and must never reach Gym: the merged
     # config is serialized into every Gym child process, and unrecognized
@@ -752,6 +808,289 @@ def build_nemo_gym_config(
     )
 
 
+@dataclass
+class NemoGymShardSet:
+    """The live actors behind one NeMo-Gym stack, sharded or not.
+
+    An unsharded job is the one-shard, one-replica case, so callers do not need
+    a separate code path for it.
+
+    Attributes:
+        handles: Shard name to its replica handles, in replica order.
+        agent_to_shard: Agent entry name to the shard hosting it. Empty when
+            unsharded, where every row goes to the only actor anyway.
+        placement_group: The STRICT_SPREAD group pinning shards to distinct
+            nodes, or None when unsharded.
+    """
+
+    handles: Dict[str, List[Any]]
+    agent_to_shard: Dict[str, str] = field(default_factory=dict)
+    placement_group: Any = None
+
+    @property
+    def is_sharded(self) -> bool:
+        return self.placement_group is not None
+
+    @property
+    def all_handles(self) -> List[Any]:
+        return [handle for replicas in self.handles.values() for handle in replicas]
+
+    def sole_handle(self) -> Any:
+        """The only actor, for callers that predate routing.
+
+        Raises:
+            ShardSetupError: There is more than one actor, so picking one would
+                silently drop the rest.
+        """
+        handles = self.all_handles
+        if len(handles) != 1:
+            raise ShardSetupError(
+                f"Expected a single NeMo-Gym actor but this set has "
+                f"{len(handles)} across shards {sorted(self.handles)}. The "
+                f"caller needs the shard-aware rollout router."
+            )
+        return handles[0]
+
+    def shutdown(self) -> None:
+        """Stop every actor, then release the bundles they were pinned to."""
+        shutdown_environments(
+            {
+                f"nemo_gym[{shard}][{replica}]": handle
+                for shard, replicas in self.handles.items()
+                for replica, handle in enumerate(replicas)
+            }
+        )
+        if self.placement_group is not None:
+            try:
+                remove_placement_group(self.placement_group)
+            except Exception as error:
+                print(f"Failed to release the NeMo-Gym placement group: {error}")
+            self.placement_group = None
+
+
+def _shard_instances(plan: ShardPlan) -> List[tuple[ShardSpec, int]]:
+    """Expand shards into one (shard, replica_index) entry per actor."""
+    return [
+        (shard, replica) for shard in plan.shards for replica in range(shard.replicas)
+    ]
+
+
+def build_nemo_gym_actors(
+    env_configs: dict[str, Any],
+    *,
+    base_urls: list[Optional[str]],
+    model_name: str,
+    enable_router_replay: bool = False,
+    use_fastokens: bool = False,
+    pg_ready_timeout: float = DEFAULT_SHARD_PG_READY_TIMEOUT_SECONDS,
+    spinup_timeout: float = DEFAULT_SHARD_SPINUP_TIMEOUT_SECONDS,
+) -> NemoGymShardSet:
+    """Create and spin up every NeMo-Gym actor this job needs.
+
+    Without ``shards`` this makes exactly one actor, scheduled as before. With
+    ``shards`` it makes one actor per replica, each pinned by a STRICT_SPREAD
+    placement group to a distinct node, each holding its own complete Gym
+    stack. Actors are spun up concurrently, so the wall-clock cost is roughly
+    the slowest shard rather than the sum.
+
+    Returns:
+        A :class:`NemoGymShardSet` whose actors are all running and validated.
+
+    Raises:
+        ShardSetupError: The bundles could not be placed, a shard failed to
+            start, or the shards' entries did not pass the startup checks. Any
+            actors already created are torn down first.
+    """
+    nemo_gym_dict = dict(env_configs["nemo_gym"])
+    plan = parse_shard_plan(nemo_gym_dict)
+
+    if plan is None:
+        return _build_single_gym_actor(
+            nemo_gym_dict,
+            base_urls=base_urls,
+            model_name=model_name,
+            enable_router_replay=enable_router_replay,
+            use_fastokens=use_fastokens,
+        )
+
+    return _build_sharded_gym_actors(
+        nemo_gym_dict,
+        plan,
+        base_urls=base_urls,
+        model_name=model_name,
+        enable_router_replay=enable_router_replay,
+        use_fastokens=use_fastokens,
+        pg_ready_timeout=pg_ready_timeout,
+        spinup_timeout=spinup_timeout,
+    )
+
+
+def _build_single_gym_actor(
+    nemo_gym_dict: dict[str, Any],
+    *,
+    base_urls: list[Optional[str]],
+    model_name: str,
+    enable_router_replay: bool,
+    use_fastokens: bool,
+) -> NemoGymShardSet:
+    """The pre-sharding path: one actor, no placement group, no discovery.
+
+    Discovery is skipped rather than merely unused. Its checks compare entry
+    names *between* shards, so with one shard there is nothing they could find.
+    """
+    actor_config = _build_gym_actor_config(
+        nemo_gym_dict,
+        base_urls=base_urls,
+        model_name=model_name,
+        enable_router_replay=enable_router_replay,
+        use_fastokens=use_fastokens,
+    )
+
+    actor_options: dict[str, Any] = {
+        "runtime_env": make_actor_runtime_env(NEMO_GYM_ACTOR_FQN)
+    }
+    if nemo_gym_dict.get("num_gpu_nodes", 0):
+        actor_options["scheduling_strategy"] = NodeAffinitySchedulingStrategy(
+            node_id=ray.get_runtime_context().get_node_id(),
+            soft=True,
+        )
+
+    actor = NemoGym.options(**actor_options).remote(actor_config)
+    ray.get(actor._spinup.remote())
+    return NemoGymShardSet(handles={DEFAULT_SHARD_NAME: [actor]})
+
+
+def _build_sharded_gym_actors(
+    nemo_gym_dict: dict[str, Any],
+    plan: ShardPlan,
+    *,
+    base_urls: list[Optional[str]],
+    model_name: str,
+    enable_router_replay: bool,
+    use_fastokens: bool,
+    pg_ready_timeout: float,
+    spinup_timeout: float,
+) -> NemoGymShardSet:
+    instances = _shard_instances(plan)
+
+    # num_gpu_nodes normally pins the single actor to the driver node. Under
+    # sharding that is the opposite of what we want, so the placement group
+    # wins; num_gpu_nodes keeps its other job of sizing the allocation.
+    if nemo_gym_dict.get("num_gpu_nodes", 0):
+        print(
+            "env.nemo_gym.shards is set, so the num_gpu_nodes affinity hint is "
+            "superseded by STRICT_SPREAD placement across "
+            f"{len(instances)} nodes."
+        )
+
+    base_gym_dict = {
+        key: value
+        for key, value in nemo_gym_dict.items()
+        if key not in SHARDING_CONFIG_KEYS
+    }
+    # One merge per shard; replicas are identical stamps of it apart from the
+    # log directory, so they must not re-run the merge.
+    merged_by_shard = {
+        shard.name: apply_shard_overlay(base_gym_dict, plan, shard)
+        for shard in plan.shards
+    }
+
+    pg = placement_group(
+        bundles=[
+            {"CPU": float(shard.actor_cpus or DEFAULT_SHARD_CPUS)}
+            for shard, _ in instances
+        ],
+        strategy="STRICT_SPREAD",
+    )
+    try:
+        ray.get(pg.ready(), timeout=pg_ready_timeout)
+    except BaseException as error:
+        remove_placement_group(pg)
+        raise ShardSetupError(
+            f"Could not place {len(instances)} NeMo-Gym shard instances on "
+            f"distinct nodes within {pg_ready_timeout}s. STRICT_SPREAD needs "
+            f"one node per instance with the requested CPUs free; the "
+            f"allocation may be too small or its nodes too busy."
+        ) from error
+
+    shard_set = NemoGymShardSet(handles={}, placement_group=pg)
+    try:
+        for bundle_index, (shard, replica) in enumerate(instances):
+            instance_gym_dict = apply_shard_log_dir(
+                merged_by_shard[shard.name],
+                shard.name,
+                replica_index=replica if shard.replicas > 1 else None,
+            )
+            actor = NemoGym.options(
+                runtime_env=make_actor_runtime_env(NEMO_GYM_ACTOR_FQN),
+                scheduling_strategy=PlacementGroupSchedulingStrategy(
+                    placement_group=pg,
+                    placement_group_bundle_index=bundle_index,
+                ),
+            ).remote(
+                _build_gym_actor_config(
+                    instance_gym_dict,
+                    base_urls=base_urls,
+                    model_name=model_name,
+                    enable_router_replay=enable_router_replay,
+                    use_fastokens=use_fastokens,
+                )
+            )
+            shard_set.handles.setdefault(shard.name, []).append(actor)
+
+        _spinup_shards_concurrently(shard_set, spinup_timeout)
+        shard_set.agent_to_shard = _discover_agent_shard_map(shard_set, plan)
+    except BaseException:
+        # A ray.get timeout does not cancel the actor-side work, so a
+        # half-started stack would keep running with nothing left to stop it.
+        shard_set.shutdown()
+        raise
+
+    print(f"NeMo-Gym shard map (agent -> shard): {shard_set.agent_to_shard}")
+    return shard_set
+
+
+def _spinup_shards_concurrently(
+    shard_set: NemoGymShardSet, spinup_timeout: float
+) -> None:
+    """Start every shard at once, naming the shard behind any failure.
+
+    Config faults surface inside ``_spinup`` -- a server ref pointing at an
+    entry that is missing from *this* shard's slice raises Gym's
+    ``ServerRefNotFoundError`` there. Gym names the entry and field but has no
+    concept of a shard, so the shard name is added here.
+    """
+    pending = {
+        (shard_name, replica): handle._spinup.remote()
+        for shard_name, replicas in shard_set.handles.items()
+        for replica, handle in enumerate(replicas)
+    }
+    for (shard_name, replica), reference in pending.items():
+        try:
+            ray.get(reference, timeout=spinup_timeout)
+        except BaseException as error:
+            raise ShardSetupError(
+                f"NeMo-Gym shard '{shard_name}' (replica {replica}) failed to "
+                f"start. A reference to an entry that is not in this shard's "
+                f"config_paths is the usual cause: {error}"
+            ) from error
+
+
+def _discover_agent_shard_map(
+    shard_set: NemoGymShardSet, plan: ShardPlan
+) -> Dict[str, str]:
+    """Ask one replica per shard what it spawned, then validate across shards.
+
+    Replicas of a shard are stamped from one merge, so they host identical
+    entries and only the first needs to be asked.
+    """
+    entries_by_shard = {
+        shard.name: ray.get(shard_set.handles[shard.name][0].list_entries.remote())
+        for shard in plan.shards
+    }
+    return build_agent_shard_map(entries_by_shard, plan.allowed_duplicate_entries)
+
+
 def spinup_nemo_gym_actor(
     env_configs: dict[str, Any],
     *,
@@ -760,7 +1099,7 @@ def spinup_nemo_gym_actor(
     enable_router_replay: bool = False,
     use_fastokens: bool = False,
 ) -> Any:
-    """Spin up the NeMo-Gym actor against the given generation server URLs.
+    """Spin up a single NeMo-Gym actor against the given generation server URLs.
 
     When ``env_configs["nemo_gym"]["num_gpu_nodes"] > 0``, the actor is
     scheduled with soft NodeAffinity to the caller's Ray node so its colocated
@@ -768,24 +1107,24 @@ def spinup_nemo_gym_actor(
 
     Returns:
         The spun-up ``NemoGym`` Ray actor handle (``_spinup`` already awaited).
+
+    Raises:
+        ShardConfigError: The config is sharded. Callers that dispatch to a
+            single handle cannot serve several shards; they need the router.
     """
-    nemo_gym_cfg = build_nemo_gym_config(
+    plan = parse_shard_plan(dict(env_configs["nemo_gym"]))
+    if plan is not None:
+        raise ShardConfigError(
+            f"env.nemo_gym.shards defines {len(plan.shards)} shards "
+            f"({', '.join(shard.name for shard in plan.shards)}), but this "
+            f"entrypoint dispatches rollouts to one actor handle. Shard-aware "
+            f"rollout routing is not wired up yet."
+        )
+
+    return build_nemo_gym_actors(
         env_configs,
         base_urls=base_urls,
         model_name=model_name,
         enable_router_replay=enable_router_replay,
         use_fastokens=use_fastokens,
-    )
-
-    nemo_gym_opts: dict[str, Any] = {
-        "runtime_env": make_actor_runtime_env(NEMO_GYM_ACTOR_FQN)
-    }
-    if env_configs["nemo_gym"].get("num_gpu_nodes", 0):
-        nemo_gym_opts["scheduling_strategy"] = NodeAffinitySchedulingStrategy(
-            node_id=ray.get_runtime_context().get_node_id(),
-            soft=True,
-        )
-
-    actor = NemoGym.options(**nemo_gym_opts).remote(nemo_gym_cfg)
-    ray.get(actor._spinup.remote())
-    return actor
+    ).sole_handle()

--- a/nemo_rl/environments/nemo_gym_shards.py
+++ b/nemo_rl/environments/nemo_gym_shards.py
@@ -60,6 +60,10 @@ class ShardConfigError(ValueError):
     """Raised for a malformed ``env.nemo_gym.shards`` block."""
 
 
+class ShardSetupError(RuntimeError):
+    """Raised when a sharded stack fails to start or fails its startup checks."""
+
+
 @dataclass(frozen=True)
 class ShardSpec:
     """One shard: a slice of the Gym config that gets its own actor.
@@ -264,6 +268,56 @@ def apply_shard_overlay(
         merged["port_range_low"] = shard.port_range_low
         merged["port_range_high"] = shard.port_range_high
     return merged
+
+
+def build_agent_shard_map(
+    entries_by_shard: Mapping[str, Mapping[str, list[str]]],
+    allowed_duplicate_entries: frozenset[str] | set[str] = frozenset(),
+) -> dict[str, str]:
+    """Map each agent entry to its shard, rejecting duplicates across shards.
+
+    Takes what each shard reported from ``NemoGym.list_entries()`` and returns
+    ``{agent_entry_name: shard_name}``, the lookup the router dispatches on.
+
+    Two failures are caught here rather than at first dispatch. An agent hosted
+    by two shards is always an error: rows naming it could go to either, so
+    routing would be silently nondeterministic. Any other entry in two shards
+    has to be allowlisted, because duplication is usually accidental — a shared
+    YAML dropped into two shards' path lists quietly brings its judge along and
+    doubles that judge's GPU claim.
+
+    Only names are compared. What an entry means is Gym's business.
+    """
+    agent_to_shard: dict[str, str] = {}
+    for shard_name, entries in entries_by_shard.items():
+        for entry, types in entries.items():
+            if "responses_api_agents" not in types:
+                continue
+            if entry in agent_to_shard:
+                raise ShardSetupError(
+                    f"Agent '{entry}' is hosted by both shard "
+                    f"'{agent_to_shard[entry]}' and shard '{shard_name}'. An "
+                    f"agent must live in exactly one shard so rows naming it "
+                    f"have one destination."
+                )
+            agent_to_shard[entry] = shard_name
+
+    hosting_shard: dict[str, str] = {}
+    for shard_name, entries in entries_by_shard.items():
+        for entry in entries:
+            if entry in agent_to_shard:
+                continue
+            if entry in hosting_shard and entry not in allowed_duplicate_entries:
+                raise ShardSetupError(
+                    f"Config entry '{entry}' appears in shard "
+                    f"'{hosting_shard[entry]}' and shard '{shard_name}' but is "
+                    f"not listed in allowed_duplicate_entries. If this entry "
+                    f"starts a model engine, duplicating it doubles its GPU "
+                    f"claim; if the duplication is intended, allowlist it."
+                )
+            hosting_shard.setdefault(entry, shard_name)
+
+    return agent_to_shard
 
 
 def apply_shard_log_dir(

--- a/tests/unit/environments/test_nemo_gym_shards.py
+++ b/tests/unit/environments/test_nemo_gym_shards.py
@@ -20,9 +20,11 @@ from nemo_rl.environments.nemo_gym_shards import (
     GYM_LOG_DIR_KEY,
     ShardConfigError,
     ShardPlan,
+    ShardSetupError,
     ShardSpec,
     apply_shard_log_dir,
     apply_shard_overlay,
+    build_agent_shard_map,
     find_gym_config_entries,
     parse_shard_plan,
 )
@@ -192,6 +194,75 @@ def test_apply_shard_overlay_keeps_global_ports_by_default():
     )
 
     assert (merged["port_range_low"], merged["port_range_high"]) == (5000, 5999)
+
+
+def test_build_agent_shard_map_routes_each_agent_to_its_shard():
+    agent_to_shard = build_agent_shard_map(
+        {
+            "judged": {
+                "math_agent": ["responses_api_agents"],
+                "math_env": ["resources_servers"],
+            },
+            "tools": {
+                "bash_agent": ["responses_api_agents"],
+                "bash_tools": ["resources_servers"],
+            },
+        }
+    )
+
+    assert agent_to_shard == {"math_agent": "judged", "bash_agent": "tools"}
+
+
+def test_build_agent_shard_map_rejects_an_agent_in_two_shards():
+    """Rows naming the agent could go to either shard, so routing is undefined."""
+    with pytest.raises(ShardSetupError, match="hosted by both shard"):
+        build_agent_shard_map(
+            {
+                "judged": {"math_agent": ["responses_api_agents"]},
+                "tools": {"math_agent": ["responses_api_agents"]},
+            }
+        )
+
+
+def test_agents_are_never_allowlisted_for_duplication():
+    """The allowlist covers shared support entries, not routing ambiguity."""
+    with pytest.raises(ShardSetupError, match="hosted by both shard"):
+        build_agent_shard_map(
+            {
+                "a": {"math_agent": ["responses_api_agents"]},
+                "b": {"math_agent": ["responses_api_agents"]},
+            },
+            allowed_duplicate_entries={"math_agent"},
+        )
+
+
+def test_build_agent_shard_map_rejects_an_unlisted_duplicate_entry():
+    with pytest.raises(ShardSetupError, match="allowed_duplicate_entries"):
+        build_agent_shard_map(
+            {
+                "judged": {"shared_judge": ["responses_api_models"]},
+                "tools": {"shared_judge": ["responses_api_models"]},
+            }
+        )
+
+
+def test_build_agent_shard_map_allows_a_listed_duplicate_entry():
+    """Policy proxies are copied into every shard on purpose."""
+    agent_to_shard = build_agent_shard_map(
+        {
+            "judged": {
+                "math_agent": ["responses_api_agents"],
+                "policy_model": ["responses_api_models"],
+            },
+            "tools": {
+                "bash_agent": ["responses_api_agents"],
+                "policy_model": ["responses_api_models"],
+            },
+        },
+        allowed_duplicate_entries={"policy_model"},
+    )
+
+    assert agent_to_shard == {"math_agent": "judged", "bash_agent": "tools"}
 
 
 def test_apply_shard_log_dir_gives_each_shard_its_own_directory():

--- a/tests/unit/environments/test_nemo_gym_utils.py
+++ b/tests/unit/environments/test_nemo_gym_utils.py
@@ -349,3 +349,312 @@ def test_list_entries_before_spinup_raises():
 
     with pytest.raises(RuntimeError, match="call _spinup"):
         actor.list_entries()
+
+
+class _FakeGymCluster:
+    """Stands in for Ray while the factory creates, starts and queries actors.
+
+    Each actor returns tagged sentinels from ``.remote()`` so ``ray.get`` can
+    tell spinups from entry queries and fail whichever the test asks it to.
+    """
+
+    def __init__(
+        self, *, entries_by_index=None, spinup_failures=None, pg_ready_error=None
+    ):
+        self.entries_by_index = entries_by_index or {}
+        self.spinup_failures = spinup_failures or {}
+        self.pg_ready_error = pg_ready_error
+        self.actors = []
+        self.actor_options = []
+        self.actor_configs = []
+        self.removed_placement_groups = []
+        self.placement_group_calls = []
+        self.placement_group = MagicMock(name="placement_group")
+        self.placement_group.ready.return_value = "pg-ready"
+
+    def make_placement_group(self, **kwargs):
+        self.placement_group_calls.append(kwargs)
+        return self.placement_group
+
+    def remove_placement_group(self, pg):
+        self.removed_placement_groups.append(pg)
+
+    def make_actor_class(self):
+        actor_class = MagicMock(name="NemoGym")
+
+        def options(**option_kwargs):
+            holder = MagicMock()
+
+            def remote(config):
+                index = len(self.actors)
+                actor = MagicMock(name=f"gym-actor-{index}")
+                actor._spinup.remote.return_value = ("spinup", index)
+                actor.list_entries.remote.return_value = ("entries", index)
+                self.actors.append(actor)
+                self.actor_options.append(option_kwargs)
+                self.actor_configs.append(config)
+                return actor
+
+            holder.remote = remote
+            return holder
+
+        actor_class.options = options
+        return actor_class
+
+    def ray_get(self, reference, timeout=None):
+        if reference == "pg-ready":
+            if self.pg_ready_error is not None:
+                raise self.pg_ready_error
+            return None
+        kind, index = reference
+        if kind == "spinup":
+            failure = self.spinup_failures.get(index)
+            if failure is not None:
+                raise failure
+            return None
+        return self.entries_by_index.get(index, {})
+
+
+@contextmanager
+def _patched_cluster(cluster):
+    with (
+        patch.object(nemo_gym_mod, "NemoGym", cluster.make_actor_class()),
+        patch.object(
+            nemo_gym_mod, "make_actor_runtime_env", return_value={"py_executable": "p"}
+        ),
+        patch.object(
+            nemo_gym_mod, "placement_group", side_effect=cluster.make_placement_group
+        ),
+        patch.object(
+            nemo_gym_mod,
+            "remove_placement_group",
+            side_effect=cluster.remove_placement_group,
+        ),
+        patch.object(nemo_gym_mod, "shutdown_environments") as shutdown,
+        patch.object(nemo_gym_mod, "ray") as mock_ray,
+    ):
+        mock_ray.get.side_effect = cluster.ray_get
+        mock_ray.get_runtime_context.return_value.get_node_id.return_value = "a" * 56
+        cluster.shutdown_environments = shutdown
+        yield cluster
+
+
+def _shard_env_configs(**overrides):
+    nemo_gym = {
+        "num_gpu_nodes": 1,
+        "shards": [
+            {"name": "judged", "config_paths": ["judge.yaml"]},
+            {"name": "tools", "config_paths": ["tools.yaml"], "replicas": 2},
+        ],
+        "allowed_duplicate_entries": ["policy_model"],
+        "nemo_gym_log_dir": "/logs/gym",
+    }
+    nemo_gym.update(overrides)
+    return {"nemo_gym": nemo_gym}
+
+
+def test_build_nemo_gym_actors_unsharded_makes_exactly_one_actor(detected_uv_dirs):
+    """The pre-sharding path must stay identical: one actor, no placement group."""
+    cluster = _FakeGymCluster()
+
+    with _patched_cluster(cluster):
+        shard_set = nemo_gym_mod.build_nemo_gym_actors(
+            _env_configs(),
+            base_urls=["http://vllm-0"],
+            model_name="test-model",
+        )
+
+    assert not shard_set.is_sharded
+    assert shard_set.sole_handle() is cluster.actors[0]
+    assert cluster.placement_group_calls == []
+    # Node affinity still applies when the actor has colocated GPUs.
+    assert isinstance(
+        cluster.actor_options[0]["scheduling_strategy"],
+        nemo_gym_mod.NodeAffinitySchedulingStrategy,
+    )
+
+
+def test_build_nemo_gym_actors_spreads_every_replica_onto_its_own_node(
+    detected_uv_dirs,
+):
+    cluster = _FakeGymCluster(
+        entries_by_index={
+            0: {"math_agent": ["responses_api_agents"]},
+            1: {"bash_agent": ["responses_api_agents"]},
+        }
+    )
+
+    with _patched_cluster(cluster):
+        shard_set = nemo_gym_mod.build_nemo_gym_actors(
+            _shard_env_configs(),
+            base_urls=["http://vllm-0"],
+            model_name="test-model",
+        )
+
+    # Two shards, one with replicas: 2, so three actors on three nodes.
+    assert len(cluster.actors) == 3
+    assert [len(replicas) for replicas in shard_set.handles.values()] == [1, 2]
+
+    (pg_kwargs,) = cluster.placement_group_calls
+    assert pg_kwargs["strategy"] == "STRICT_SPREAD"
+    assert pg_kwargs["bundles"] == [
+        {"CPU": float(nemo_gym_mod.DEFAULT_SHARD_CPUS)} for _ in range(3)
+    ]
+
+    # Each actor is pinned to its own bundle.
+    bundle_indices = [
+        options["scheduling_strategy"].placement_group_bundle_index
+        for options in cluster.actor_options
+    ]
+    assert bundle_indices == [0, 1, 2]
+    assert shard_set.agent_to_shard == {"math_agent": "judged", "bash_agent": "tools"}
+
+
+def test_shards_get_their_own_config_paths_and_log_directories(detected_uv_dirs):
+    cluster = _FakeGymCluster()
+
+    with _patched_cluster(cluster):
+        nemo_gym_mod.build_nemo_gym_actors(
+            _shard_env_configs(),
+            base_urls=["http://vllm-0"],
+            model_name="test-model",
+        )
+
+    gym_configs = [
+        config["initial_global_config_dict"] for config in cluster.actor_configs
+    ]
+    assert [config["config_paths"] for config in gym_configs] == [
+        ["judge.yaml"],
+        ["tools.yaml"],
+        ["tools.yaml"],
+    ]
+    # A single-replica shard needs no replica component; replicas of one shard
+    # must not share a directory, since they spawn identical server names.
+    assert [config["nemo_gym_log_dir"] for config in gym_configs] == [
+        "/logs/gym/judged",
+        "/logs/gym/tools/0",
+        "/logs/gym/tools/1",
+    ]
+    # NeMo-RL-only keys must never reach Gym.
+    for config in gym_configs:
+        assert "shards" not in config
+        assert "allowed_duplicate_entries" not in config
+
+
+def test_actor_cpus_override_sizes_that_shards_bundle(detected_uv_dirs):
+    cluster = _FakeGymCluster()
+    env_configs = _shard_env_configs(
+        shards=[
+            {"name": "code_gen", "config_paths": ["code.yaml"], "actor_cpus": 64},
+            {"name": "tools", "config_paths": ["tools.yaml"]},
+        ]
+    )
+
+    with _patched_cluster(cluster):
+        nemo_gym_mod.build_nemo_gym_actors(
+            env_configs, base_urls=["http://vllm-0"], model_name="test-model"
+        )
+
+    (pg_kwargs,) = cluster.placement_group_calls
+    assert pg_kwargs["bundles"] == [
+        {"CPU": 64.0},
+        {"CPU": float(nemo_gym_mod.DEFAULT_SHARD_CPUS)},
+    ]
+
+
+def test_a_shard_that_fails_to_start_names_itself_and_tears_everything_down(
+    detected_uv_dirs,
+):
+    """A ray.get timeout does not stop the actor, so cleanup must be explicit."""
+    cluster = _FakeGymCluster(
+        spinup_failures={1: RuntimeError("ServerRefNotFoundError: judge_model")}
+    )
+
+    with _patched_cluster(cluster):
+        with pytest.raises(
+            nemo_gym_mod.ShardSetupError, match="shard 'tools' \\(replica 0\\)"
+        ) as excinfo:
+            nemo_gym_mod.build_nemo_gym_actors(
+                _shard_env_configs(),
+                base_urls=["http://vllm-0"],
+                model_name="test-model",
+            )
+
+    # Gym names the offending entry; we add the shard it belongs to.
+    assert "ServerRefNotFoundError" in str(excinfo.value)
+    cluster.shutdown_environments.assert_called_once()
+    torn_down = cluster.shutdown_environments.call_args.args[0]
+    assert len(torn_down) == 3
+    assert cluster.removed_placement_groups == [cluster.placement_group]
+
+
+def test_unplaceable_bundles_fail_fast_and_release_the_group(detected_uv_dirs):
+    cluster = _FakeGymCluster(pg_ready_error=TimeoutError("no nodes"))
+
+    with _patched_cluster(cluster):
+        with pytest.raises(nemo_gym_mod.ShardSetupError, match="distinct nodes"):
+            nemo_gym_mod.build_nemo_gym_actors(
+                _shard_env_configs(),
+                base_urls=["http://vllm-0"],
+                model_name="test-model",
+            )
+
+    assert cluster.actors == []
+    assert cluster.removed_placement_groups == [cluster.placement_group]
+
+
+def test_duplicate_agent_across_shards_tears_the_set_down(detected_uv_dirs):
+    cluster = _FakeGymCluster(
+        entries_by_index={
+            0: {"math_agent": ["responses_api_agents"]},
+            1: {"math_agent": ["responses_api_agents"]},
+        }
+    )
+
+    with _patched_cluster(cluster):
+        with pytest.raises(nemo_gym_mod.ShardSetupError, match="hosted by both shard"):
+            nemo_gym_mod.build_nemo_gym_actors(
+                _shard_env_configs(),
+                base_urls=["http://vllm-0"],
+                model_name="test-model",
+            )
+
+    cluster.shutdown_environments.assert_called_once()
+    assert cluster.removed_placement_groups == [cluster.placement_group]
+
+
+def test_spinup_nemo_gym_actor_rejects_a_sharded_config(detected_uv_dirs):
+    """Single-handle callers cannot serve several shards; say so up front."""
+    with pytest.raises(nemo_gym_mod.ShardConfigError, match="not wired up yet"):
+        spinup_nemo_gym_actor(
+            _shard_env_configs(),
+            base_urls=["http://vllm-0"],
+            model_name="test-model",
+        )
+
+
+def test_sole_handle_refuses_to_pick_one_of_many():
+    shard_set = nemo_gym_mod.NemoGymShardSet(
+        handles={"a": [MagicMock()], "b": [MagicMock()]}
+    )
+
+    with pytest.raises(nemo_gym_mod.ShardSetupError, match="2 across shards"):
+        shard_set.sole_handle()
+
+
+def test_shard_set_shutdown_releases_the_placement_group_once():
+    pg = MagicMock()
+    shard_set = nemo_gym_mod.NemoGymShardSet(
+        handles={"tools": [MagicMock(), MagicMock()]}, placement_group=pg
+    )
+
+    with (
+        patch.object(nemo_gym_mod, "shutdown_environments") as shutdown,
+        patch.object(nemo_gym_mod, "remove_placement_group") as remove,
+    ):
+        shard_set.shutdown()
+        shard_set.shutdown()
+
+    assert shutdown.call_count == 2
+    # Releasing a group twice raises; the second shutdown must not try.
+    remove.assert_called_once_with(pg)


### PR DESCRIPTION
## Summary

Adds the factory that creates one `NemoGym` actor for every configured shard instance.

For a sharded configuration, `build_nemo_gym_actors()`:

- Expands each shard's replica count into physical actor instances.
- Materializes the actor runtime environment before reserving shard CPUs. The runtime-environment builder may temporarily reserve one CPU on every node while it creates virtual environments.
- Creates one placement-group bundle per instance and uses `STRICT_SPREAD` by default.
- Composes each actor's Gym configuration and assigns a separate log directory.
- Starts all actors under one shared deadline, then installs the tokenizer on each actor.
- Reads resolved entries through `NemoGym.list_entries()` and builds the agent-to-shard map.
- Rejects ambiguous duplicate agents and entries.
- Waits for in-progress startup calls to leave `RunHelper.start()` before cleanup. It then shuts down every actor and removes the placement group without killing an actor while it still owns Gym subprocesses.

The unsharded path uses the same cleanup guarantee if startup or tokenizer installation fails. Errors identify the shard that failed instead of exposing only the underlying Ray or Gym exception.

This PR provides actor creation and discovery. Rollout routing is added in the next layer.

## Dependency

This PR targets `main`. [PR #3372](https://github.com/NVIDIA-NeMo/RL/pull/3372) builds on this branch.