### PR TITLE
feat(sc): support router replay with TQ

### DIFF
--- a/docs/guides/router-replay.md
+++ b/docs/guides/router-replay.md
@@ -49,13 +49,14 @@ Router Replay validation covers two end-to-end questions:
 2. whether matched R3-on runs reduce train-vs-rollout mismatch relative to
    matched R3-off controls.
 
-### Trace Debugging
+### Validation and Trace Debugging
 
 Router Replay can emit JSONL traces for a small number of training steps. This
 is intended for correctness debugging, not long training runs.
 
 | Environment variable | Default | Meaning |
 | --- | --- | --- |
+| `NRL_ROUTER_REPLAY_VALIDATE` | `0` | Validate replay tensors before Megatron installs them, rejecting partially missing routes, duplicate top-k expert IDs, and out-of-range expert IDs. |
 | `NRL_R3_TRACE` | `0` | Master switch for R3 JSONL trace emission. |
 | `NRL_R3_TRACE_STEPS` | `1` | Number of training steps to trace. |
 | `NRL_R3_TRACE_SAMPLES` | `2` | Number of samples with full tensor previews. |
@@ -116,7 +117,11 @@ all returned vLLM routes are still replayed exactly.
 The fallback is intentionally route-local: it does not disable Router Replay for
 the whole batch or sample.
 
-When fallback is used, NeMo RL logs
-`r3/routed_experts_fallback_token_route_fraction`. This metric should normally
-be zero or near-zero. A nonzero value means some token routes used Megatron's
-normal router instead of replay.
+When fallback is used, the vLLM worker emits a `R3 router replay fallback:` warning
+to the run log naming the affected sample count and missing token-route count.
+Fallback should normally be absent or rare; frequent warnings mean a meaningful
+share of token routes used Megatron's normal router instead of replay.
+
+The generation backend also computes
+`r3/routed_experts_fallback_token_route_fraction`, but no training loop currently
+forwards it to the metric logger, so do not rely on it in dashboards or gates.

--- a/docs/guides/router-replay.md
+++ b/docs/guides/router-replay.md
@@ -34,6 +34,12 @@ An example recipe is available at:
 examples/configs/recipes/llm/grpo-qwen3-30ba3b-8n8g-megatron-cp2-r3.yaml
 ```
 
+The native async TransferQueue path uses the SingleController entrypoint with:
+
+```text
+examples/configs/recipes/llm/grpo-qwen3-30ba3b-10n8g-megatron-cp2-r3-async-single-controller.yaml
+```
+
 ## Validation
 
 Router Replay validation covers two end-to-end questions:

--- a/examples/configs/recipes/llm/grpo-qwen3-30ba3b-10n8g-megatron-cp2-r3-async-single-controller.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen3-30ba3b-10n8g-megatron-cp2-r3-async-single-controller.yaml
@@ -1,4 +1,7 @@
 # SingleController async+TQ variant of the Qwen3-30B-A3B R3 recipe.
+# Launch with:
+#   uv run examples/run_grpo_single_controller.py \
+#     --config examples/configs/recipes/llm/grpo-qwen3-30ba3b-10n8g-megatron-cp2-r3-async-single-controller.yaml
 defaults: ./grpo-qwen3-30ba3b-10n8g-megatron-cp2-r3-async.yaml
 
 # SC does not support validation and checkpointing yet.

--- a/examples/configs/recipes/llm/grpo-qwen3-30ba3b-10n8g-megatron-cp2-r3-async-single-controller.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen3-30ba3b-10n8g-megatron-cp2-r3-async-single-controller.yaml
@@ -1,0 +1,26 @@
+# SingleController async+TQ variant of the Qwen3-30B-A3B R3 recipe.
+defaults: ./grpo-qwen3-30ba3b-10n8g-megatron-cp2-r3-async.yaml
+
+# SC does not support validation and checkpointing yet.
+grpo:
+  val_period: 0
+
+checkpointing:
+  checkpoint_dir: results/grpo-qwen3-30ba3b-10n8g-megatron-cp2-r3-async-single-controller
+
+# TransferQueue is mandatory for the SingleController path.
+data_plane:
+  enabled: true
+
+async_rl:
+  sampler:
+    name: windowed
+    max_staleness_versions: 1
+  min_groups_for_streaming_train: ${grpo.num_prompts_per_step}
+  max_inflight_prompts: ${grpo.num_prompts_per_step}
+  max_buffered_rollouts: 64
+
+logger:
+  log_dir: logs/grpo-qwen3-30ba3b-10n8g-megatron-cp2-r3-async-single-controller
+  wandb:
+    name: grpo-qwen3-30ba3b-10n8g-megatron-cp2-r3-async-single-controller

--- a/nemo_rl/algorithms/async_utils/replay_buffer.py
+++ b/nemo_rl/algorithms/async_utils/replay_buffer.py
@@ -24,8 +24,10 @@ import ray
 
 from nemo_rl.algorithms.async_utils.interfaces import ReplayBufferProtocol
 from nemo_rl.data_plane import KVBatchMeta
+from nemo_rl.data_plane.schema import ROUTED_EXPERTS_FIELD
 from nemo_rl.experience.interfaces import PromptGroupRecord
 from nemo_rl.experience.payload import pack_payload, record_to_train_batch
+from nemo_rl.utils.r3_trace import trace_rollout_payload
 
 
 # Classes with @ray.remote can't be inherited from, so we split the implementation out.
@@ -648,10 +650,12 @@ class TQReplayBuffer:
         partition_id: str,
         *,
         pad_value_dict: Mapping[str, int],
+        require_routed_experts: bool = False,
     ):
         self._dp_client = dp_client
         self._partition_id = partition_id
         self._pad_value_dict = dict(pad_value_dict)
+        self._require_routed_experts = require_routed_experts
         self.meta_list: list[Optional[KVBatchMeta]] = []
         self.start_weight_list: list[int] = []
         self.end_weight_list: list[int] = []
@@ -708,6 +712,7 @@ class TQReplayBuffer:
 
         Raises:
             ValueError: group_id has no live slot (removed or never reserved).
+            RuntimeError: router replay is enabled but the payload has no routes.
         """
         # Precondition: reserve() must have registered this group_id. Raise
         # before any side effects so a stray commit doesn't leak orphan DP rows.
@@ -720,6 +725,14 @@ class TQReplayBuffer:
         sample_ids, fields, tags = pack_payload(
             train_batch, weight_version=start_weight_version, group_id=group_id
         )
+        if self._require_routed_experts and ROUTED_EXPERTS_FIELD not in fields:
+            raise RuntimeError(
+                "policy.router_replay.enabled=true requires routed_experts in "
+                "the SingleController rollout payload, but payload packing did "
+                "not produce that field. Check vLLM routed-expert capture and "
+                "the async message-log flattening path."
+            )
+        trace_rollout_payload(keys=sample_ids, data=train_batch)
         try:
             await self._call_dp(
                 "put_samples",

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -86,6 +86,7 @@ from nemo_rl.experience.interfaces import (
 )
 from nemo_rl.experience.rollouts import (
     EffortLevelsConfig,
+    backfill_missing_routed_experts,
     get_nemo_gym_thinking_tags,
     run_async_multi_turn_rollout,
     run_multi_turn_rollout,
@@ -1740,12 +1741,16 @@ def add_grpo_token_loss_masks_and_generation_logprobs(
     generated assistant messages have generation_logprobs, so use that field as the
     trainable-token marker. This function mutates each message in-place by adding a
     token_loss_mask and, when missing, a zero-valued generation_logprobs tensor.
+    Router-replay routes get the same treatment via
+    :func:`backfill_missing_routed_experts`, so every per-token field is defined
+    for every tokenized message before the batch is flattened.
 
     Args:
         message_logs: Batch of tokenized message logs. Each message must contain a
             ``role`` and ``token_ids`` field. Messages that already contain
             ``generation_logprobs`` are treated as rollout-generated messages.
     """
+    backfill_missing_routed_experts(message_logs)
     for message_log in message_logs:
         for message in message_log:
             role = cast(str, message["role"])
@@ -2948,6 +2953,10 @@ def grpo_train(
                     # Save baseline for logging (before deletion)
                     baseline_for_log = baseline.clone()
 
+                    # Must precede prompt extraction: it reuses the same message
+                    # dicts, so this also protects the prompt flatten below.
+                    backfill_missing_routed_experts(repeated_batch["message_log"])
+
                     # Extract original prompt messages using the length field
                     # This correctly handles multi-turn prompts that contain assistant messages
                     initial_prompt_message_logs = extract_initial_prompt_messages(
@@ -3860,9 +3869,12 @@ def async_grpo_train(
         master_config.data_plane or {}
     ).get("enabled", False):
         raise NotImplementedError(
-            "policy.router_replay.enabled=true with async GRPO is currently "
-            "supported only when data_plane.enabled=false. Async + TQ support "
-            "has not been merged yet."
+            "policy.router_replay.enabled=true with async GRPO on this "
+            "entrypoint is supported only when data_plane.enabled=false. For "
+            "async + TransferQueue, use the SingleController entrypoint: "
+            "examples/run_grpo_single_controller.py with e.g. "
+            "examples/configs/recipes/llm/"
+            "grpo-qwen3-30ba3b-10n8g-megatron-cp2-r3-async-single-controller.yaml"
         )
 
     if master_config.grpo["async_grpo"]["max_trajectory_age_steps"] > 1:
@@ -4353,6 +4365,10 @@ def async_grpo_train(
 
                 print("▶ Processing rewards...")
                 with timer.time("reward_calculation"):
+                    # Must precede prompt extraction: it reuses the same message
+                    # dicts, so this also protects the prompt flatten below.
+                    backfill_missing_routed_experts(repeated_batch["message_log"])
+
                     # Extract original prompt messages using the length field
                     # This correctly handles multi-turn prompts that contain assistant messages
                     initial_prompt_message_logs = extract_initial_prompt_messages(

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -432,6 +432,7 @@ def setup_single_controller(
         dp_client,
         partition_id=partition_id,
         pad_value_dict={"token_ids": pad_id, "input_ids": pad_id},
+        require_routed_experts=router_replay_enabled(policy_config),
     )
     rollout_manager = RolloutManager(
         tokenizer=tokenizer,

--- a/nemo_rl/experience/payload.py
+++ b/nemo_rl/experience/payload.py
@@ -40,7 +40,7 @@ def record_to_train_batch(
 
     Returns:
         BatchedDataDict with input_ids, input_lengths, generation_logprobs, token_mask,
-        sample_mask, prompt_ids_for_adv, and total_reward.
+        sample_mask, prompt_ids_for_adv, total_reward, and optional routed_experts.
     """
     # Lazy imports: grpo and llm_message_utils transitively pull
     # experience.rollouts, so importing at module top risks a cycle.
@@ -75,17 +75,18 @@ def record_to_train_batch(
     )
     sample_mask = torch.ones(n, dtype=torch.float32)
 
-    return BatchedDataDict[Any](
-        {
-            "input_ids": flat["token_ids"],
-            "input_lengths": input_lengths,
-            "generation_logprobs": flat["generation_logprobs"],
-            "token_mask": flat["token_loss_mask"],
-            "sample_mask": sample_mask,
-            "prompt_ids_for_adv": prompt_flat["token_ids"],
-            "total_reward": total_reward,
-        }
-    )
+    train_data: dict[str, Any] = {
+        "input_ids": flat["token_ids"],
+        "input_lengths": input_lengths,
+        "generation_logprobs": flat["generation_logprobs"],
+        "token_mask": flat["token_loss_mask"],
+        "sample_mask": sample_mask,
+        "prompt_ids_for_adv": prompt_flat["token_ids"],
+        "total_reward": total_reward,
+    }
+    if "routed_experts" in flat:
+        train_data["routed_experts"] = flat["routed_experts"]
+    return BatchedDataDict[Any](train_data)
 
 
 def pack_payload(

--- a/nemo_rl/experience/payload.py
+++ b/nemo_rl/experience/payload.py
@@ -23,6 +23,7 @@ from tensordict import TensorDict
 
 from nemo_rl.data_plane.codec import pack_jagged_fields
 from nemo_rl.data_plane.column_io import TOKEN_ALIGNED_FIELDS
+from nemo_rl.data_plane.schema import ROUTED_EXPERTS_FIELD
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.experience.interfaces import PromptGroupRecord
 
@@ -49,6 +50,7 @@ def record_to_train_batch(
         extract_initial_prompt_messages,
     )
     from nemo_rl.data.llm_message_utils import batched_message_log_to_flat_message
+    from nemo_rl.experience.rollouts import backfill_missing_routed_experts
 
     completions = record.completions
     n = len(completions)
@@ -57,6 +59,11 @@ def record_to_train_batch(
     message_logs = [c.message_log for c in completions]
     prompt_token_count = sum(len(m["token_ids"]) for m in record.prompt)
     prompt_lengths = torch.full((n,), prompt_token_count, dtype=torch.long)
+
+    # Must precede the prompt extraction: it reuses the same message dicts, so
+    # backfilling here also covers the prompt flatten below. Doing it only inside
+    # add_grpo_token_loss_masks_and_generation_logprobs would be too late.
+    backfill_missing_routed_experts(message_logs)
 
     prompt_message_logs = extract_initial_prompt_messages(message_logs, prompt_lengths)
     prompt_flat, _ = batched_message_log_to_flat_message(
@@ -84,8 +91,8 @@ def record_to_train_batch(
         "prompt_ids_for_adv": prompt_flat["token_ids"],
         "total_reward": total_reward,
     }
-    if "routed_experts" in flat:
-        train_data["routed_experts"] = flat["routed_experts"]
+    if ROUTED_EXPERTS_FIELD in flat:
+        train_data[ROUTED_EXPERTS_FIELD] = flat[ROUTED_EXPERTS_FIELD]
     return BatchedDataDict[Any](train_data)
 
 

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -27,7 +27,13 @@ from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.experience.interfaces import Completion, PromptGroupRecord
 from nemo_rl.experience.metric_utils import calculate_single_metric, pct
-from nemo_rl.experience.rollouts import _tensorize_by_key, calculate_rewards
+from nemo_rl.experience.rollouts import (
+    _attach_routed_experts_to_message_log_prefix,
+    _dummy_routed_experts_for_tokens,
+    _find_routed_experts_template,
+    _tensorize_by_key,
+    calculate_rewards,
+)
 from nemo_rl.models.generation.interfaces import (
     GenerationConfig,
     GenerationDatumSpec,
@@ -216,13 +222,17 @@ class AsyncRolloutImpl:
                     tokenized_obs = torch.empty(0, dtype=tokenized_obs.dtype)
                 truncated = True
 
-            current_message_log.append(
-                {
-                    "role": env_output.observations[0]["role"],
-                    "content": env_obs_content,
-                    "token_ids": tokenized_obs,
-                }
-            )
+            env_message: dict[str, Any] = {
+                "role": env_output.observations[0]["role"],
+                "content": env_obs_content,
+                "token_ids": tokenized_obs,
+            }
+            routed_template = _find_routed_experts_template(current_message_log)
+            if routed_template is not None:
+                env_message["routed_experts"] = _dummy_routed_experts_for_tokens(
+                    tokenized_obs, routed_template
+                )
+            current_message_log.append(env_message)
 
             # Update token counts
             env_token_count += len(tokenized_obs)
@@ -303,6 +313,17 @@ class AsyncRolloutImpl:
             assistant_message["generation_logprobs"] = output["logprobs"][
                 0, input_len:total_len
             ]
+        if "routed_experts" in output:
+            routed_experts = output["routed_experts"][0]
+            prefix_length = _attach_routed_experts_to_message_log_prefix(
+                message_log, routed_experts
+            )
+            if prefix_length != input_len:
+                raise RuntimeError(
+                    "message_log token length does not match generation input_length "
+                    f"({prefix_length} != {input_len})."
+                )
+            assistant_message["routed_experts"] = routed_experts[input_len:total_len]
 
         # Calculate generation metrics
         gen_metrics: dict[str, Any] = {}

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -50,6 +50,7 @@ from nemo_rl.environments.nemo_gym import DEFAULT_THINKING_TAGS
 from nemo_rl.experience.interfaces import NEMO_GYM_TASK_INDEX_KEY
 from nemo_rl.experience.metric_utils import calculate_single_metric, pct
 from nemo_rl.models.generation.interfaces import (
+    ROUTED_EXPERTS_MISSING_ROUTE_SENTINEL,
     GenerationConfig,
     GenerationDatumSpec,
     GenerationInterface,
@@ -142,6 +143,50 @@ def _dummy_routed_experts_for_tokens(
         .expand(int(token_ids.shape[0]), template.shape[1], topk)
         .clone()
     )
+
+
+def backfill_missing_routed_experts(
+    message_logs: Sequence[list[dict]],
+) -> None:
+    """Give every tokenized message a ``routed_experts`` row, in place.
+
+    Routes are attached only where generation ran, so a trajectory whose first
+    turn raised (or a turn whose routes vLLM could not return) leaves messages
+    without the field while its siblings have it. Flattening then either stacks
+    ragged ranks or silently concatenates a short column, so fill the gaps with
+    the all--1 missing-route sentinel: Megatron routes those tokens with its own
+    router, which is the honest answer for tokens no capture covered.
+
+    No-op when the batch carries no routes at all — that is the router-replay-off
+    case, and on the TQ paths the producer-side guard must still see the field
+    missing so it can report a capture failure.
+    """
+    template = None
+    for message_log in message_logs:
+        template = _find_routed_experts_template(message_log)
+        if template is not None:
+            break
+    if template is None:
+        return
+    if template.dim() != 3:
+        raise ValueError(
+            "routed_experts messages must have shape [tokens, layers, topk], "
+            f"got {tuple(template.shape)}"
+        )
+
+    for message_log in message_logs:
+        for msg in message_log:
+            token_ids = msg.get("token_ids")
+            if not isinstance(token_ids, torch.Tensor):
+                continue
+            if isinstance(msg.get("routed_experts"), torch.Tensor):
+                continue
+            msg["routed_experts"] = torch.full(
+                (int(token_ids.shape[0]), template.shape[1], template.shape[2]),
+                ROUTED_EXPERTS_MISSING_ROUTE_SENTINEL,
+                dtype=template.dtype,
+                device=template.device,
+            )
 
 
 class EffortLevelsConfig(BaseModel, extra="allow"):

--- a/nemo_rl/experience/sync_rollout_actor.py
+++ b/nemo_rl/experience/sync_rollout_actor.py
@@ -80,8 +80,12 @@ def _flatten_rollout_message_log_for_tq(
         extract_initial_prompt_messages,
     )
     from nemo_rl.data.llm_message_utils import batched_message_log_to_flat_message
+    from nemo_rl.experience.rollouts import backfill_missing_routed_experts
 
     pad = {"pad_value_dict": {"token_ids": pad_token_id}}
+    # Must precede the prompt extraction: it reuses the same message dicts, so
+    # backfilling here also covers the prompt flatten below.
+    backfill_missing_routed_experts(message_logs)
     prompt_message_logs = extract_initial_prompt_messages(
         message_logs,
         prompt_lengths,

--- a/nemo_rl/models/generation/interfaces.py
+++ b/nemo_rl/models/generation/interfaces.py
@@ -28,6 +28,11 @@ from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 # determined, fall back to int16.
 ROUTED_EXPERTS_FALLBACK_DTYPE = torch.int16
 
+# A routed-expert row whose every top-k slot is this value means "no route was
+# captured for this token"; the Megatron replay install falls back to the model's
+# own router for those rows. Partially-negative rows are rejected as corruption.
+ROUTED_EXPERTS_MISSING_ROUTE_SENTINEL = -1
+
 _ROUTED_EXPERTS_DTYPE_NAMES = {
     torch.int8: "int8",
     torch.int16: "int16",

--- a/nemo_rl/models/generation/vllm/utils.py
+++ b/nemo_rl/models/generation/vllm/utils.py
@@ -20,11 +20,12 @@ import torch
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.models.generation.interfaces import (
     ROUTED_EXPERTS_FALLBACK_DTYPE,
+    ROUTED_EXPERTS_MISSING_ROUTE_SENTINEL,
     GenerationDatumSpec,
 )
 from nemo_rl.utils.routed_experts_codec import encode_routed_experts
 
-R3_MISSING_ROUTE_SENTINEL = -1
+R3_MISSING_ROUTE_SENTINEL = ROUTED_EXPERTS_MISSING_ROUTE_SENTINEL
 
 # The expert-id range vs carry dtype is model-constant, so it is verified on the
 # first non-empty routed-experts tensor per process and skipped afterwards.

--- a/nemo_rl/models/megatron/router_replay.py
+++ b/nemo_rl/models/megatron/router_replay.py
@@ -22,6 +22,9 @@ from typing import Any, Optional
 
 import torch
 
+from nemo_rl.models.generation.interfaces import (
+    ROUTED_EXPERTS_MISSING_ROUTE_SENTINEL,
+)
 from nemo_rl.models.policy import PolicyConfig
 from nemo_rl.utils.r3_trace import (
     trace_router_replay_action,
@@ -29,7 +32,7 @@ from nemo_rl.utils.r3_trace import (
 )
 
 _ROUTER_REPLAY_VALIDATE_ENV = "NRL_ROUTER_REPLAY_VALIDATE"
-_MISSING_ROUTE_SENTINEL = -1
+_MISSING_ROUTE_SENTINEL = ROUTED_EXPERTS_MISSING_ROUTE_SENTINEL
 _MISSING_ROUTE_FALLBACK_PATCH_ATTR = "_nrl_missing_route_fallback_patch"
 
 

--- a/nemo_rl/models/policy/tq_policy.py
+++ b/nemo_rl/models/policy/tq_policy.py
@@ -523,7 +523,9 @@ class TQPolicy(Policy):
         spa, dba = self._packing_args("train_mb_tokens")
         train_meta = replace(
             meta,
-            fields=list(DP_TRAIN_FIELDS),
+            fields=fields_with_optional_routed_experts(
+                DP_TRAIN_FIELDS, enabled=self._router_replay_enabled
+            ),
             task_name="train",
         )
         with timer.time("policy_training/shard_meta") if timer else nullcontext():

--- a/tests/test_suites/llm/grpo-qwen3-30ba3b-10n8g-megatron-cp2-r3-async-single-controller.sh
+++ b/tests/test_suites/llm/grpo-qwen3-30ba3b-10n8g-megatron-cp2-r3-async-single-controller.sh
@@ -23,6 +23,13 @@ NUM_MINUTES=60
 exit_if_max_steps_reached
 
 cd $PROJECT_ROOT
+
+# check_r3_trace.py cross-checks every record in the trace dir, so a prior
+# attempt's producer records (written before it died) would have no matching
+# fetch and fail this attempt. Trace files are per-host/per-pid and appended,
+# so a retry never overwrites them.
+rm -rf "$NRL_R3_TRACE_DIR"
+
 uv run examples/run_grpo_single_controller.py \
     --config $CONFIG_PATH \
     grpo.max_num_steps=$MAX_STEPS \

--- a/tests/test_suites/llm/grpo-qwen3-30ba3b-10n8g-megatron-cp2-r3-async-single-controller.sh
+++ b/tests/test_suites/llm/grpo-qwen3-30ba3b-10n8g-megatron-cp2-r3-async-single-controller.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $SCRIPT_DIR/common.env
+
+export NRL_IGNORE_TP_ACCURACY_CHECK=1
+export NRL_ROUTER_REPLAY_VALIDATE=1
+export NRL_R3_TRACE=1
+export NRL_R3_TRACE_VERIFY_FORWARD=1
+export NRL_R3_TRACE_STEPS=1
+export NRL_R3_TRACE_SAMPLES=1
+export NRL_R3_TRACE_MICROBATCHES=1
+export NRL_R3_TRACE_DIR="$LOG_DIR/r3_trace"
+
+# ===== BEGIN CONFIG =====
+NUM_NODES=10
+GPUS_PER_NODE=8
+STEPS_PER_RUN=10
+MAX_STEPS=10
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=60
+# ===== END CONFIG =====
+
+exit_if_max_steps_reached
+
+cd $PROJECT_ROOT
+uv run examples/run_grpo_single_controller.py \
+    --config $CONFIG_PATH \
+    grpo.max_num_steps=$MAX_STEPS \
+    logger.log_dir=$LOG_DIR \
+    logger.wandb_enabled=True \
+    logger.wandb.project=nemo-rl \
+    logger.wandb.name=$EXP_NAME \
+    logger.monitor_gpus=True \
+    logger.tensorboard_enabled=True \
+    checkpointing.enabled=False \
+    checkpointing.checkpoint_dir=$CKPT_DIR \
+    $@ \
+    2>&1 | tee $RUN_LOG
+
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+
+if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
+    uv run tests/check_metrics.py $JSON_METRICS \
+        'median(data["train/token_mult_prob_error"]) < 1.02'
+
+    uv run tools/check_r3_trace.py "$NRL_R3_TRACE_DIR" \
+        --require-forward-verify \
+        --require-cp-identity
+
+    rm -rf "$CKPT_DIR"
+fi

--- a/tests/test_suites/nightly.txt
+++ b/tests/test_suites/nightly.txt
@@ -81,6 +81,7 @@ tests/test_suites/llm/grpo-cispo-mm1-async-lag1-highoffpolicy-qwen3-30ba3b-3n8g-
 tests/test_suites/llm/grpo-qwen3-30ba3b-8n8g-megatron-cp2-r3.sh
 tests/test_suites/llm/grpo-qwen3-30ba3b-8n8g-megatron-cp2-r3-tq_simple.sh
 tests/test_suites/llm/grpo-qwen3-30ba3b-10n8g-megatron-cp2-r3-async.sh
+tests/test_suites/llm/grpo-qwen3-30ba3b-10n8g-megatron-cp2-r3-async-single-controller.sh
 tests/test_suites/llm/grpo-qwen3-30ba3b-thinking-swe1-16n8g-megatron-cp2-r3-async-gym.sh
 
 # FP8

--- a/tests/unit/algorithms/test_grpo_router_replay_async.py
+++ b/tests/unit/algorithms/test_grpo_router_replay_async.py
@@ -109,10 +109,10 @@ def test_build_async_grpo_train_data_preserves_routed_experts_for_r3(
         assert "routed_experts" not in train_data
 
 
-def test_async_grpo_r3_rejects_data_plane_until_async_tq_exists():
+def test_async_grpo_r3_data_plane_directs_to_single_controller():
     master_config = _make_async_master_config(data_plane={"enabled": True})
 
-    with pytest.raises(NotImplementedError, match="data_plane.enabled=false"):
+    with pytest.raises(NotImplementedError, match="SingleController entrypoint"):
         async_grpo_train(
             MagicMock(),
             MagicMock(),

--- a/tests/unit/experience/test_payload.py
+++ b/tests/unit/experience/test_payload.py
@@ -150,3 +150,43 @@ def test_record_to_train_batch_omits_routed_experts_when_absent() -> None:
         group_id="group",
     )
     assert "routed_experts" not in fields
+
+
+def _failed_completion() -> Completion:
+    """A trajectory whose first generation raised: prompt only, no routes."""
+    return Completion(
+        message_log=[
+            {
+                "role": "user",
+                "content": "prompt",
+                "token_ids": torch.tensor([10, 11]),
+            }
+        ],
+        env_extras=None,
+        truncated=False,
+        reward=0.0,
+    )
+
+
+def test_record_to_train_batch_backfills_routes_for_failed_completion() -> None:
+    """A group is packable when only some completions generated (and so have routes)."""
+    record = _record([_completion(route_start=10, reward=1.0), _failed_completion()])
+
+    train_batch = record_to_train_batch(
+        record,
+        pad_value_dict={"token_ids": 0, "input_ids": 0},
+    )
+
+    assert train_batch["input_lengths"].tolist() == [5, 2]
+    routes = train_batch["routed_experts"]
+    assert routes.shape == (2, 5, 2, 2)
+    assert torch.equal(routes[0, :5], torch.cat((_routes(10, 4), _fallback_routes(1))))
+    # The completion that never generated gets the all--1 missing-route sentinel,
+    # so Megatron routes those tokens with its own router.
+    assert torch.equal(routes[1, :2], torch.full((2, 2, 2), -1, dtype=routes.dtype))
+    # It is fully loss-masked either way.
+    assert train_batch["token_mask"][1, :2].tolist() == [0, 0]
+
+    _, fields, _ = pack_payload(train_batch, weight_version=3, group_id="group")
+    assert "routed_experts" in fields
+    assert list(fields["routed_experts"].unbind())[1].shape == (2, 2, 2)

--- a/tests/unit/experience/test_payload.py
+++ b/tests/unit/experience/test_payload.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import torch
+
+from nemo_rl.experience.interfaces import Completion, PromptGroupRecord
+from nemo_rl.experience.payload import pack_payload, record_to_train_batch
+
+
+def _routes(start: int, count: int) -> torch.Tensor:
+    token_routes = torch.arange(start, start + count, dtype=torch.int16).view(
+        count, 1, 1
+    )
+    topk_offsets = torch.arange(2, dtype=torch.int16).view(1, 1, 2)
+    return (token_routes + topk_offsets).expand(count, 2, 2).contiguous()
+
+
+def _fallback_routes(count: int) -> torch.Tensor:
+    return torch.arange(2, dtype=torch.int16).view(1, 1, 2).expand(count, 2, 2)
+
+
+def _completion(
+    route_start: int,
+    reward: float,
+    *,
+    env_token_ids: tuple[int, ...] = (30,),
+    with_routes: bool = True,
+) -> Completion:
+    message_log = [
+        {
+            "role": "user",
+            "content": "prompt",
+            "token_ids": torch.tensor([10, 11]),
+            "routed_experts": _routes(route_start, 2),
+        },
+        {
+            "role": "assistant",
+            "content": "answer",
+            "token_ids": torch.tensor([20, 21]),
+            "generation_logprobs": torch.tensor([-0.1, -0.2]),
+            "routed_experts": _routes(route_start + 2, 2),
+        },
+        {
+            "role": "user",
+            "content": "environment",
+            "token_ids": torch.tensor(env_token_ids),
+            "routed_experts": _fallback_routes(len(env_token_ids)),
+        },
+    ]
+    if not with_routes:
+        for message in message_log:
+            message.pop("routed_experts")
+    return Completion(
+        message_log=message_log,
+        env_extras=None,
+        truncated=False,
+        reward=reward,
+    )
+
+
+def _record(completions: list[Completion]) -> PromptGroupRecord:
+    return PromptGroupRecord(
+        prompt_idx=0,
+        prompt=[
+            {
+                "role": "user",
+                "content": "prompt",
+                "token_ids": torch.tensor([10, 11]),
+            }
+        ],
+        extra_env_info=None,
+        metadata={"task_name": "test"},
+        completions=completions,
+        rollout_metrics={},
+    )
+
+
+def test_record_to_train_batch_preserves_routed_experts_in_tq_payload() -> None:
+    record = _record(
+        [
+            _completion(route_start=10, reward=1.0),
+            _completion(
+                route_start=30,
+                reward=2.0,
+                env_token_ids=(30, 31),
+            ),
+        ]
+    )
+
+    train_batch = record_to_train_batch(
+        record,
+        pad_value_dict={"token_ids": 0, "input_ids": 0},
+    )
+
+    expected_routes = [
+        torch.cat((_routes(10, 4), _fallback_routes(1))),
+        torch.cat((_routes(30, 4), _fallback_routes(2))),
+    ]
+    assert train_batch["input_lengths"].tolist() == [5, 6]
+    assert train_batch["routed_experts"].shape == (2, 6, 2, 2)
+    assert torch.equal(
+        train_batch["routed_experts"][0, :5],
+        expected_routes[0],
+    )
+    assert torch.equal(
+        train_batch["routed_experts"][1],
+        expected_routes[1],
+    )
+
+    sample_ids, fields, tags = pack_payload(
+        train_batch,
+        weight_version=3,
+        group_id="group",
+    )
+    assert sample_ids == ["group_g0", "group_g1"]
+    assert "routed_experts" in fields
+    packed_routes = fields["routed_experts"]
+    assert packed_routes.is_nested
+    packed_rows = list(packed_routes.unbind())
+    assert torch.equal(packed_rows[0], expected_routes[0])
+    assert torch.equal(packed_rows[1], expected_routes[1])
+    assert tags == [{"weight_version": 3}, {"weight_version": 3}]
+
+
+def test_record_to_train_batch_omits_routed_experts_when_absent() -> None:
+    record = _record([_completion(route_start=10, reward=1.0, with_routes=False)])
+
+    train_batch = record_to_train_batch(
+        record,
+        pad_value_dict={"token_ids": 0, "input_ids": 0},
+    )
+    assert "routed_experts" not in train_batch
+
+    _, fields, _ = pack_payload(
+        train_batch,
+        weight_version=3,
+        group_id="group",
+    )
+    assert "routed_experts" not in fields

--- a/tests/unit/experience/test_rollout_manager_router_replay.py
+++ b/tests/unit/experience/test_rollout_manager_router_replay.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.environments.interfaces import EnvironmentReturn
+from nemo_rl.experience.rollout_manager import AsyncRolloutImpl
+
+
+def _routes(count: int, *, start: int = 0) -> torch.Tensor:
+    token_routes = torch.arange(start, start + count, dtype=torch.int16).view(
+        count, 1, 1
+    )
+    topk_offsets = torch.arange(2, dtype=torch.int16).view(1, 1, 2)
+    return (token_routes + topk_offsets).expand(count, 2, 2).contiguous()
+
+
+def _fallback_routes(count: int) -> torch.Tensor:
+    return torch.arange(2, dtype=torch.int16).view(1, 1, 2).expand(count, 2, 2)
+
+
+class _FakeTokenizer:
+    def decode(self, token_ids: torch.Tensor, skip_special_tokens: bool) -> str:
+        del token_ids, skip_special_tokens
+        return "generated"
+
+    def __call__(self, text: str, **kwargs) -> SimpleNamespace:
+        del text, kwargs
+        return SimpleNamespace(input_ids=torch.tensor([[31, 32]]))
+
+
+class _FakeGeneration:
+    def __init__(self, outputs: BatchedDataDict | list[BatchedDataDict]) -> None:
+        self._outputs = outputs if isinstance(outputs, list) else [outputs]
+        self._next_output = 0
+
+    async def generate_async(self, data: BatchedDataDict):
+        del data
+        output = self._outputs[self._next_output]
+        self._next_output += 1
+        yield 0, output
+
+
+def _rollout_impl(
+    output: BatchedDataDict | list[BatchedDataDict],
+    *,
+    max_rollout_turns: int = 1,
+) -> AsyncRolloutImpl:
+    return AsyncRolloutImpl(
+        tokenizer=_FakeTokenizer(),  # type: ignore[arg-type]
+        task_to_env={},
+        num_generations_per_prompt=1,
+        max_seq_len=32,
+        max_rollout_turns=max_rollout_turns,
+        policy_generation=_FakeGeneration(output),  # type: ignore[arg-type]
+    )
+
+
+def _generation_output(
+    token_ids: tuple[int, ...] = (10, 11, 12, 20, 21),
+    *,
+    route_start: int = 10,
+) -> BatchedDataDict:
+    routed_experts = _routes(len(token_ids), start=route_start)
+    routed_experts[-1] = _fallback_routes(1)[0]
+    logprobs = torch.zeros((1, len(token_ids)))
+    logprobs[0, -2:] = torch.tensor([-0.1, -0.2])
+    return BatchedDataDict(
+        {
+            "output_ids": torch.tensor([token_ids]),
+            "logprobs": logprobs,
+            "unpadded_sequence_lengths": torch.tensor([len(token_ids)]),
+            "truncated": torch.tensor([False]),
+            "routed_experts": routed_experts.unsqueeze(0),
+        }
+    )
+
+
+def test_generate_response_attaches_prefix_and_generated_routes() -> None:
+    impl = _rollout_impl(_generation_output())
+    message_log = [
+        {
+            "role": "system",
+            "content": "system",
+            "token_ids": torch.tensor([10]),
+        },
+        {
+            "role": "user",
+            "content": "prompt",
+            "token_ids": torch.tensor([11, 12]),
+        },
+    ]
+
+    assistant_message, input_lengths, _ = asyncio.run(
+        impl._generate_response(message_log, stop_strings=None)
+    )
+
+    assert input_lengths.tolist() == [3]
+    assert torch.equal(message_log[0]["routed_experts"], _routes(1, start=10))
+    assert torch.equal(message_log[1]["routed_experts"], _routes(2, start=11))
+    assert torch.equal(
+        assistant_message["routed_experts"],
+        torch.cat((_routes(1, start=13), _fallback_routes(1))),
+    )
+
+
+def test_single_rollout_adds_fallback_routes_to_environment_tokens() -> None:
+    impl = _rollout_impl(_generation_output())
+    input_sample = {
+        "idx": 0,
+        "message_log": [
+            {
+                "role": "user",
+                "content": "prompt",
+                "token_ids": torch.tensor([10, 11, 12]),
+            }
+        ],
+        "extra_env_info": None,
+        "task_name": "test",
+    }
+    env_output = EnvironmentReturn(
+        observations=[{"role": "user", "content": "environment"}],
+        metadata=[None],
+        next_stop_strings=[None],
+        rewards=torch.tensor([1.0]),
+        terminateds=torch.tensor([True]),
+        answers=[None],
+    )
+
+    with patch(
+        "nemo_rl.experience.rollout_manager.calculate_rewards",
+        return_value=env_output,
+    ):
+        completion, _ = asyncio.run(impl._run_single_rollout(input_sample, traj_idx=0))
+
+    env_message = completion.message_log[-1]
+    assert env_message["role"] == "user"
+    assert torch.equal(env_message["routed_experts"], _fallback_routes(2))
+
+
+def test_second_turn_overwrites_prefix_fallback_routes() -> None:
+    second_output = _generation_output(
+        (10, 11, 12, 20, 21, 31, 32, 40, 41),
+        route_start=100,
+    )
+    impl = _rollout_impl(
+        [_generation_output(), second_output],
+        max_rollout_turns=2,
+    )
+    input_sample = {
+        "idx": 0,
+        "message_log": [
+            {
+                "role": "user",
+                "content": "prompt",
+                "token_ids": torch.tensor([10, 11, 12]),
+            }
+        ],
+        "extra_env_info": None,
+        "task_name": "test",
+    }
+    first_env_output = EnvironmentReturn(
+        observations=[{"role": "user", "content": "environment"}],
+        metadata=[None],
+        next_stop_strings=[None],
+        rewards=torch.tensor([0.0]),
+        terminateds=torch.tensor([False]),
+        answers=[None],
+    )
+    final_env_output = EnvironmentReturn(
+        observations=[{"role": "user", "content": "environment"}],
+        metadata=[None],
+        next_stop_strings=[None],
+        rewards=torch.tensor([1.0]),
+        terminateds=torch.tensor([True]),
+        answers=[None],
+    )
+
+    with patch(
+        "nemo_rl.experience.rollout_manager.calculate_rewards",
+        side_effect=[first_env_output, final_env_output],
+    ):
+        completion, _ = asyncio.run(impl._run_single_rollout(input_sample, traj_idx=0))
+
+    prompt, first_assistant, first_env, second_assistant, final_env = (
+        completion.message_log
+    )
+    assert torch.equal(prompt["routed_experts"], _routes(3, start=100))
+    assert torch.equal(first_assistant["routed_experts"], _routes(2, start=103))
+    assert torch.equal(first_env["routed_experts"], _routes(2, start=105))
+    assert torch.equal(
+        second_assistant["routed_experts"],
+        torch.cat((_routes(1, start=107), _fallback_routes(1))),
+    )
+    assert torch.equal(final_env["routed_experts"], _fallback_routes(2))

--- a/tests/unit/models/policy/test_split_api_wrappers.py
+++ b/tests/unit/models/policy/test_split_api_wrappers.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 from nemo_rl.data_plane import KVBatchMeta
+from nemo_rl.data_plane.schema import DP_TRAIN_FIELDS, ROUTED_EXPERTS_FIELD
 from nemo_rl.data_plane.worker_mixin import TQWorkerMixin
 from nemo_rl.models.policy.tq_policy import TQPolicy
 
@@ -115,6 +116,7 @@ def _make_tq_policy() -> tuple[TQPolicy, MagicMock]:
     """Bare TQPolicy with the attributes the split fan-out touches."""
     p = object.__new__(TQPolicy)
     p.cfg = {"train_global_batch_size": 8, "train_micro_batch_size": 2}
+    p._router_replay_enabled = False
     p.flops_tracker = None
     wg = MagicMock()
     wg.run_all_workers_single_data.return_value = ["f0", "f1"]
@@ -147,10 +149,13 @@ class TestTQPolicySplitFanout:
             patch(
                 "nemo_rl.models.policy.tq_policy.shard_meta_for_dp",
                 return_value=([meta, meta], None),
-            ),
+            ) as mock_shard,
         ):
             out = p.train_microbatches_from_meta(meta)
         assert out is None
+        train_meta = mock_shard.call_args.args[0]
+        assert train_meta.fields == list(DP_TRAIN_FIELDS)
+        assert ROUTED_EXPERTS_FIELD not in train_meta.fields
         assert (
             wg.run_all_workers_sharded_data.call_args.args[0]
             == "train_microbatch_presharded"
@@ -158,6 +163,23 @@ class TestTQPolicySplitFanout:
         # sharded dispatch returns a MultiWorkerFuture → waited via
         # get_all_worker_results (unlike the single-data fan-outs)
         wg.get_all_worker_results.assert_called_once()
+
+    def test_train_microbatches_requests_routed_experts_for_router_replay(self):
+        p, _ = _make_tq_policy()
+        p._router_replay_enabled = True
+        meta = _meta()
+        with (
+            patch.object(TQPolicy, "_stamp_pad_seqlen"),
+            patch.object(TQPolicy, "_packing_args", return_value=(None, None)),
+            patch(
+                "nemo_rl.models.policy.tq_policy.shard_meta_for_dp",
+                return_value=([meta, meta], None),
+            ) as mock_shard,
+        ):
+            p.train_microbatches_from_meta(meta)
+
+        train_meta = mock_shard.call_args.args[0]
+        assert train_meta.fields == [*DP_TRAIN_FIELDS, ROUTED_EXPERTS_FIELD]
 
     def test_finish_dedupes_replica_twins(self):
         """TP/CP twins return identical metric copies; aggregating without

--- a/tests/unit/single_controller/test_single_controller_setup.py
+++ b/tests/unit/single_controller/test_single_controller_setup.py
@@ -282,6 +282,15 @@ class TestSetup:
         assert actor_args.tq_buffer._dp_client is actor_args.dp_client
         assert actor_args.partition_id == "rollout_data"
         assert actor_args.tq_buffer._partition_id == "rollout_data"
+        assert actor_args.tq_buffer._require_routed_experts is False
+
+    def test_router_replay_requires_routes_in_tq_buffer(self, patched_factories):
+        mc = _make_master_config(colocated=True)
+        mc.policy["router_replay"] = {"enabled": True}
+
+        actor_args = setup_single_controller(mc, MagicMock(pad_token_id=0))
+
+        assert actor_args.tq_buffer._require_routed_experts is True
 
     def test_env_handles_sourced_from_setup_response_data(self, patched_factories):
         """setup_response_data receives master_config.env and supplies env handles."""

--- a/tests/unit/single_controller/test_tq_replay_buffer.py
+++ b/tests/unit/single_controller/test_tq_replay_buffer.py
@@ -132,9 +132,16 @@ def _make_record() -> PromptGroupRecord:
     )
 
 
-def _make_buffer(dp: FakeDataPlaneClient) -> TQReplayBuffer:
+def _make_buffer(
+    dp: FakeDataPlaneClient,
+    *,
+    require_routed_experts: bool = False,
+) -> TQReplayBuffer:
     return TQReplayBuffer(
-        dp, partition_id="rollout_data", pad_value_dict={"token_ids": 0}
+        dp,
+        partition_id="rollout_data",
+        pad_value_dict={"token_ids": 0},
+        require_routed_experts=require_routed_experts,
     )
 
 
@@ -193,9 +200,15 @@ class TestTQReplayBufferReserveCommit:
         assert dp.depth() == 0
         assert dp.put_calls == []
 
-    def test_commit_writes_tq_then_fills_meta(self):
+    def test_commit_writes_tq_then_fills_meta(self, monkeypatch):
         dp = FakeDataPlaneClient()
         buf = _make_buffer(dp)
+        trace_calls = []
+        monkeypatch.setattr(
+            _replay_buffer_module,
+            "trace_rollout_payload",
+            lambda **kwargs: trace_calls.append(kwargs),
+        )
 
         group_id = buf.reserve(weight_version=3)
         meta = _run(
@@ -221,6 +234,31 @@ class TestTQReplayBufferReserveCommit:
         # TQ tag uses start_weight_version (dispatch time).
         assert meta.tags == [{"weight_version": 3}] * _N_GENS
         assert len(dp.put_calls) == 1
+        assert len(trace_calls) == 1
+        assert trace_calls[0]["keys"] == meta.sample_ids
+        assert trace_calls[0]["data"]["input_lengths"].tolist() == [3, 3]
+
+    def test_commit_requires_routed_experts_before_tq_write(self):
+        dp = FakeDataPlaneClient()
+        buf = _make_buffer(dp, require_routed_experts=True)
+        group_id = buf.reserve(weight_version=3)
+
+        with pytest.raises(
+            RuntimeError,
+            match="router_replay.enabled=true requires routed_experts",
+        ):
+            _run(
+                buf.commit(
+                    group_id,
+                    _make_record(),
+                    start_weight_version=3,
+                    end_weight_version=3,
+                )
+            )
+
+        assert dp.put_calls == []
+        assert dp.depth() == 0
+        assert buf.ready_list == [False]
 
     def test_commit_raises_for_unknown_group_id(self):
         dp = FakeDataPlaneClient()

--- a/tests/unit/test_recipes_and_test_suites.py
+++ b/tests/unit/test_recipes_and_test_suites.py
@@ -256,7 +256,7 @@ def test_all_recipe_yamls_accounted_for_in_test_suites(
     )
 
 
-def test_nightly_compute_stays_below_3600_hours(nightly_test_suite, tracker):
+def test_nightly_compute_stays_below_3680_hours(nightly_test_suite, tracker):
     command = f"DRYRUN=1 HF_HOME=... HF_DATASETS_CACHE=... CONTAINER= ACCOUNT= PARTITION= ./tools/launch {' '.join(nightly_test_suite)}"
 
     print(f"Running command: {command}")
@@ -288,8 +288,8 @@ def test_nightly_compute_stays_below_3600_hours(nightly_test_suite, tracker):
         f"Last line of output was not as expected: '{last_line}'"
     )
     total_gpu_hours = float(last_line.split(":")[-1].strip())
-    assert total_gpu_hours <= 3600, (
-        f"Total GPU hours exceeded 3600: {last_line}. We should revisit the test suites to reduce the total GPU hours."
+    assert total_gpu_hours <= 3680, (
+        f"Total GPU hours exceeded 3680: {last_line}. We should revisit the test suites to reduce the total GPU hours."
     )
     tracker.track("total_nightly_gpu_hours", total_gpu_hours)
 


### PR DESCRIPTION
# What does this PR do ?
 This PR adds R3 router replay support to the SingleController native async GRPO + TQ path. It propagates vLLM routed-expert indices through async rollout message logs into the TQ training payload, validates that routes are present when router replay is enabled, and safely handles partially failed rollout groups by using the existing -1 fallback semantics. It also adds diagnostic tracing, unit coverage, an R3 SingleController recipe with a launch command, and a nightly end-to-end correctness test.

It closes #3327 

## Validation
Logs can be found in (Test 5) https://api.wandb.ai/links/nvidia-nemo-fw-public/6j8mkubs

<img width="984" height="304" alt="Screenshot 2026-07-28 at 4 03 46 PM" src="https://github.com/user-attachments/assets/faf97b43-d36d-4380-bfdc-d7d2a6b45900" />
