### PR TITLE
feat: warn when UV_CACHE_DIR is set

### DIFF
--- a/nemo_rl/__init__.py
+++ b/nemo_rl/__init__.py
@@ -76,8 +76,7 @@ def _warn_if_uv_cache_dir_set():
         "holding NeMo RL's prebuilt wheels (causing slow reinstalls even with a prebuilt "
         "container), and a cache on a persistent/shared filesystem can be corrupted by "
         "concurrent jobs. Recommended: `unset UV_CACHE_DIR` and let uv use its default, "
-        "whether in a container or on baremetal. With ray.sub, use UV_CACHE_DIR_OVERRIDE "
-        "instead (see docs/cluster.md)."
+        "whether in a container or on baremetal."
     )
 
 

--- a/nemo_rl/__init__.py
+++ b/nemo_rl/__init__.py
@@ -59,6 +59,31 @@ os.environ["RAY_USAGE_STATS_ENABLED"] = "0"
 os.environ["RAY_ENABLE_UV_RUN_RUNTIME_ENV"] = "0"
 
 
+def _warn_if_uv_cache_dir_set():
+    """Warn if UV_CACHE_DIR is set, since the default is almost always the right choice.
+
+    Pointing uv at a non-default cache bypasses the cache that holds NeMo RL's
+    prebuilt wheels (e.g. the one baked into the container), and a cache placed on
+    a persistent/shared filesystem has been observed to corrupt when several jobs
+    use it concurrently.
+    """
+    uv_cache_dir = os.environ.get("UV_CACHE_DIR")
+    if not uv_cache_dir:
+        return
+
+    logging.warning(
+        f"UV_CACHE_DIR is set to '{uv_cache_dir}'. This bypasses the default uv cache "
+        "holding NeMo RL's prebuilt wheels (causing slow reinstalls even with a prebuilt "
+        "container), and a cache on a persistent/shared filesystem can be corrupted by "
+        "concurrent jobs. Recommended: `unset UV_CACHE_DIR` and let uv use its default, "
+        "whether in a container or on baremetal. With ray.sub, use UV_CACHE_DIR_OVERRIDE "
+        "instead (see docs/cluster.md)."
+    )
+
+
+_warn_if_uv_cache_dir_set()
+
+
 def _is_build_isolation():
     """Detect if we're running in a uv build isolation environment.
 

--- a/tests/unit/test_uv_cache_dir_warning.py
+++ b/tests/unit/test_uv_cache_dir_warning.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the UV_CACHE_DIR warning emitted on import of nemo_rl."""
+
+import logging
+import os
+from unittest.mock import patch
+
+from nemo_rl import _warn_if_uv_cache_dir_set
+
+
+class TestWarnIfUvCacheDirSet:
+    """Test cases for the _warn_if_uv_cache_dir_set function."""
+
+    def test_no_warning_when_unset(self, caplog):
+        with patch.dict(os.environ, {}, clear=True):
+            with caplog.at_level(logging.WARNING):
+                _warn_if_uv_cache_dir_set()
+
+        assert caplog.records == []
+
+    def test_no_warning_when_empty(self, caplog):
+        with patch.dict(os.environ, {"UV_CACHE_DIR": ""}):
+            with caplog.at_level(logging.WARNING):
+                _warn_if_uv_cache_dir_set()
+
+        assert caplog.records == []
+
+    def test_warns_with_path_and_remedy(self, caplog):
+        with patch.dict(os.environ, {"UV_CACHE_DIR": "/shared/fs/uv"}):
+            with caplog.at_level(logging.WARNING):
+                _warn_if_uv_cache_dir_set()
+
+        assert len(caplog.records) == 1
+        message = caplog.records[0].message
+        assert "/shared/fs/uv" in message
+        assert "unset UV_CACHE_DIR" in message


### PR DESCRIPTION
# What does this PR do ?

**Warns on `import nemo_rl` when `UV_CACHE_DIR` is set, since overriding the default uv cache is almost always unintentional and harmful.**

Two failure modes have been observed in the wild:

1. **Unnecessary reinstalls / very long install times.** Setting `UV_CACHE_DIR` points uv away from the cache that holds NeMo RL's prebuilt wheels (e.g. the one baked into the container), so venv creation re-downloads and re-builds packages. If you see long install times despite using a prebuilt container, this env var is sometimes the culprit.
2. **Cache corruption.** When `UV_CACHE_DIR` points somewhere persistent outside the container, the cache has been observed to get corrupted when multiple jobs access it simultaneously.

The default is the right choice both in a container and on baremetal, so the warning's only recommendation is to unset the variable.

# Issues

N/A

# Usage

```console
$ UV_CACHE_DIR=/lustre/shared/uv python -c "import nemo_rl"
WARNING:root:__init__.py:79: UV_CACHE_DIR is set to '/lustre/shared/uv'. This bypasses the
default uv cache holding NeMo RL's prebuilt wheels (causing slow reinstalls even with a
prebuilt container), and a cache on a persistent/shared filesystem can be corrupted by
concurrent jobs. Recommended: `unset UV_CACHE_DIR` and let uv use its default, whether in a
container or on baremetal.
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

* Warning only — nothing is unset or mutated on the user's behalf, so existing setups keep working.
* New unit test `tests/unit/test_uv_cache_dir_warning.py` (picked up by the `L0_Unit_Tests_Other` shard) covers unset / empty / set cases.
