### PR TITLE
feat(ray): support a dedicated gpu-free head node

### DIFF
--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -150,6 +150,28 @@ sbatch ray.sub \
     allocation or to override detection.
 * - `GPUS_PER_NODE=8`
   - Number of GPUs each Ray worker node claims. To determine this, run `nvidia-smi` on a worker node.
+* - `DEDICATED_RAY_HEAD=0`
+  - Set to `1` to run the first allocated node as a GPU-free Ray head: it hosts
+    only the Ray control plane and the driver, advertises `--num-gpus=0`, and
+    carries neither `worker_units` nor the topology resources, so no GPU actor
+    or topology-constrained placement group can land on it. Use this when driver
+    or head-node memory pressure is destabilizing training.
+
+    **You must shrink the driver's node count yourself.** `ray.sub` cannot see
+    inside your `COMMAND`, so it only prints the effective GPU-node count. With
+    `--nodes=N` and `DEDICATED_RAY_HEAD=1`, `cluster.num_nodes` (plus
+    `env.nemo_gym.num_gpu_nodes` when set) must sum to `N - 1`. If you leave it
+    at `N`, cluster bringup still succeeds and the driver instead fails minutes
+    later with `Maximum number of retries reached (6). Cluster resources may be
+    insufficient...`.
+
+    **The head's GPUs are idled, not freed.** Under `#SBATCH --exclusive` the
+    head node is still allocated with `--gres`, so this costs one node's worth
+    of GPUs.
+
+    **Watch segment divisibility.** With topology-aware placement the allocation
+    becomes `--nodes=N+1`, which can trip the "`SEGMENT_SIZE` must evenly divide
+    `NUM_NODES`" check in `tools/launch`.
 * - `BASE_LOG_DIR=$SLURM_SUBMIT_DIR`
   - Base directory for storing Ray logs. Defaults to the Slurm submission directory ([SLURM_SUBMIT_DIR](https://slurm.schedmd.com/sbatch.html#OPT_SLURM_SUBMIT_DIR)).
 * - `NODE_MANAGER_PORT=1301`

--- a/ray.sub
+++ b/ray.sub
@@ -226,6 +226,14 @@ fi
 
 # Number of GPUs per worker node
 GPUS_PER_NODE=${GPUS_PER_NODE:-8}
+DEDICATED_RAY_HEAD=${DEDICATED_RAY_HEAD:-0}
+case "$DEDICATED_RAY_HEAD" in
+  0|1) ;;
+  *)
+    echo "Error: DEDICATED_RAY_HEAD must be 0 or 1, got '$DEDICATED_RAY_HEAD'." >&2
+    exit 1
+    ;;
+esac
 
 # Detect GRES support and set GRES_ARG
 log_phase "detecting GRES support (sinfo)"
@@ -367,8 +375,15 @@ export RAY_health_check_period_ms="${RAY_health_check_period_ms:-10000}"
 num_retries=3
 WORKER_NUM_RETRIES=20
 
-# Total Ray worker_units expected once every node has registered with the head.
-NUM_ACTORS=$((GPUS_PER_NODE * SLURM_JOB_NUM_NODES))
+# Total Ray worker_units expected once every schedulable GPU node has
+# registered. In dedicated-head mode the first physical node runs only the Ray
+# control plane and driver, and intentionally contributes no GPU worker units.
+NUM_RAY_GPU_NODES=$((SLURM_JOB_NUM_NODES - DEDICATED_RAY_HEAD))
+if (( NUM_RAY_GPU_NODES <= 0 )); then
+  echo "Error: dedicated Ray head requires at least one additional GPU worker node." >&2
+  exit 1
+fi
+NUM_ACTORS=$((GPUS_PER_NODE * NUM_RAY_GPU_NODES))
 
 # Track backgrounded srun client PIDs for head and workers
 declare -A SRUN_PIDS
@@ -665,6 +680,16 @@ sed -i 's/context\.py_executable = " "\.join(self\.nsight_cmd) + " python"/conte
 
 source $LOG_DIR/topology_probe.sh
 
+# Keep model, generation, teacher, and Gym GPU actors off the Ray head. Omitting
+# worker_units and topology resources also prevents topology-constrained
+# placement groups from selecting it as a compute node.
+HEAD_RAY_RESOURCE_ARGS=""
+if [[ "$DEDICATED_RAY_HEAD" == "1" ]]; then
+  RAY_RESOURCES='{\"slurm_managed_ray_cluster\": 1, \"ray_head\": 1}'
+  HEAD_RAY_RESOURCE_ARGS="--num-gpus=0"
+  echo "[INFO] Dedicated Ray head enabled: advertising zero GPUs"
+fi
+
 # Clear MPI/PMIx/SLURM env vars inherited from the srun launcher so TRT-LLM's
 # MPI_Init (in the ray daemon child process below) starts clean.
 # NOTE: keep this after topology_probe.sh, which reads SLURM_TOPOLOGY_ADDR/SLURM_PROCID.
@@ -693,6 +718,7 @@ while [[ \$count -lt $num_retries ]]; do
 ray start --head \
     --disable-usage-stats \
     --resources="\$RAY_RESOURCES" \
+    \$HEAD_RAY_RESOURCE_ARGS \
     --node-ip-address="$head_node_ip" \
     --port=${PORT} \
     --ray-client-server-port=${RAY_CLIENT_SERVER_PORT} \

--- a/ray.sub
+++ b/ray.sub
@@ -384,6 +384,10 @@ if (( NUM_RAY_GPU_NODES <= 0 )); then
   exit 1
 fi
 NUM_ACTORS=$((GPUS_PER_NODE * NUM_RAY_GPU_NODES))
+if (( DEDICATED_RAY_HEAD == 1 )); then
+  echo "[INFO] DEDICATED_RAY_HEAD=1: $NUM_RAY_GPU_NODES of $SLURM_JOB_NUM_NODES allocated nodes are GPU compute nodes."
+  echo "[INFO] Size your driver COMMAND to $NUM_RAY_GPU_NODES nodes (cluster.num_nodes, plus env.nemo_gym.num_gpu_nodes when set); ray.sub cannot validate this for you."
+fi
 
 # Track backgrounded srun client PIDs for head and workers
 declare -A SRUN_PIDS
@@ -556,12 +560,22 @@ fi
 # IMPORTANT: The key names "nvlink_domain_" and "topo_rank" below must stay in sync
 # with the constants NVLINK_DOMAIN_PREFIX and TOPO_RANK_KEY defined in
 # nemo_rl/distributed/virtual_cluster.py.
-RAY_RESOURCES='{\"worker_units\": '"$GPUS_PER_NODE"', \"slurm_managed_ray_cluster\": 1'
-if [[ -n "\$CLUSTER_UUID" ]]; then
-  RAY_RESOURCES+=', \"nvlink_domain_'\${CLUSTER_UUID}'\": 1'
-fi
-if [[ -n "\$TOPO_RANK" ]]; then
-  RAY_RESOURCES+=', \"topo_rank\": '\$TOPO_RANK
+# NRL_DEDICATED_RAY_HEAD=1 is exported only by the head under DEDICATED_RAY_HEAD=1.
+# That node runs the control plane and driver only, so it advertises no compute
+# resources: without worker_units and the topology keys, neither a GPU actor nor a
+# topology-constrained placement group can select it. Any new node-level key belongs
+# in the else branch unless the dedicated head should carry it too.
+RAY_RESOURCES='{\"slurm_managed_ray_cluster\": 1'
+if [[ "\${NRL_DEDICATED_RAY_HEAD:-0}" == "1" ]]; then
+  RAY_RESOURCES+=', \"ray_head\": 1'
+else
+  RAY_RESOURCES+=', \"worker_units\": '"$GPUS_PER_NODE"
+  if [[ -n "\$CLUSTER_UUID" ]]; then
+    RAY_RESOURCES+=', \"nvlink_domain_'\${CLUSTER_UUID}'\": 1'
+  fi
+  if [[ -n "\$TOPO_RANK" ]]; then
+    RAY_RESOURCES+=', \"topo_rank\": '\$TOPO_RANK
+  fi
 fi
 RAY_RESOURCES+='}'
 export RAY_RESOURCES
@@ -678,16 +692,17 @@ ray-status-sidecar &
 # Patch nsight.py before starting Ray head
 sed -i 's/context\.py_executable = " "\.join(self\.nsight_cmd) + " python"/context.py_executable = " ".join(self.nsight_cmd) + f" {context.py_executable}"/g' /opt/nemo_rl_venv/lib64/python*/site-packages/ray/_private/runtime_env/nsight.py
 
+# Keeps model, generation, teacher, and Gym GPU actors off the Ray head. The
+# resource JSON itself is built by topology_probe.sh so head and workers keep a
+# single construction site.
+export NRL_DEDICATED_RAY_HEAD=$DEDICATED_RAY_HEAD
+
 source $LOG_DIR/topology_probe.sh
 
-# Keep model, generation, teacher, and Gym GPU actors off the Ray head. Omitting
-# worker_units and topology resources also prevents topology-constrained
-# placement groups from selecting it as a compute node.
 HEAD_RAY_RESOURCE_ARGS=""
 if [[ "$DEDICATED_RAY_HEAD" == "1" ]]; then
-  RAY_RESOURCES='{\"slurm_managed_ray_cluster\": 1, \"ray_head\": 1}'
   HEAD_RAY_RESOURCE_ARGS="--num-gpus=0"
-  echo "[INFO] Dedicated Ray head enabled: advertising zero GPUs"
+  echo "[INFO] Dedicated Ray head enabled: advertising zero GPUs and no worker_units"
 fi
 
 # Clear MPI/PMIx/SLURM env vars inherited from the srun launcher so TRT-LLM's


### PR DESCRIPTION
# What does this PR do ?

Allow the Ray head to run as a control-plane-only node by advertising zero GPUs and excluding it from worker-unit accounting. Can be switched on setting `DEDICATED_RAY_HEAD=1` on in env.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
