### PR TITLE
perf(vllm): return token metadata with chat completions

### DIFF
--- a/nemo_rl/models/generation/vllm/utils.py
+++ b/nemo_rl/models/generation/vllm/utils.py
@@ -318,17 +318,105 @@ def attach_routed_experts_to_chat_response_choices(
     return response
 
 
+def attach_token_information_to_chat_response_choices(
+    response: Any,
+    final_request_output: Any,
+) -> Any:
+    """Attach engine-native token information to OpenAI chat response choices."""
+    prompt_token_ids = getattr(final_request_output, "prompt_token_ids", None)
+    if prompt_token_ids is None:
+        raise RuntimeError(
+            "vLLM was asked to return token information for the "
+            "OpenAI-compatible chat endpoint but the final request output did "
+            "not include prompt_token_ids."
+        )
+
+    outputs_by_index = {
+        output.index: output for output in getattr(final_request_output, "outputs", [])
+    }
+    choices = list(getattr(response, "choices", []))
+    choice_indices = [choice.index for choice in choices]
+    if len(outputs_by_index) != len(
+        getattr(final_request_output, "outputs", [])
+    ) or len(set(choice_indices)) != len(choice_indices):
+        raise RuntimeError(
+            "vLLM returned duplicate choice indices while attaching token "
+            "information to the OpenAI-compatible chat response."
+        )
+
+    missing_choice_indices = sorted(set(choice_indices) - outputs_by_index.keys())
+    if missing_choice_indices:
+        raise RuntimeError(
+            "vLLM was asked to return token information for the "
+            "OpenAI-compatible chat endpoint but response choices could not be "
+            "matched to generation outputs: "
+            f"missing_choice_indices={missing_choice_indices}."
+        )
+
+    for choice in choices:
+        generation_details = outputs_by_index[choice.index]
+        output_token_ids = getattr(generation_details, "token_ids", None)
+        if output_token_ids is None:
+            raise RuntimeError(
+                "vLLM was asked to return token information for the "
+                "OpenAI-compatible chat endpoint but generation output "
+                f"choice_idx={choice.index} did not include token_ids."
+            )
+        generation_token_ids = list(output_token_ids)
+
+        logprob_content = getattr(getattr(choice, "logprobs", None), "content", None)
+        if logprob_content is None:
+            if generation_token_ids:
+                raise RuntimeError(
+                    "vLLM was asked to return token information for the "
+                    "OpenAI-compatible chat endpoint but response "
+                    f"choice_idx={choice.index} did not include logprobs."
+                )
+            generation_log_probs = []
+        else:
+            if len(generation_token_ids) != len(logprob_content):
+                raise RuntimeError(
+                    "vLLM returned mismatched generation token IDs and log "
+                    "probabilities for the OpenAI-compatible chat endpoint: "
+                    f"choice_idx={choice.index}, "
+                    f"token_count={len(generation_token_ids)}, "
+                    f"logprob_count={len(logprob_content)}."
+                )
+            generation_log_probs = []
+            for token_id, logprob_entry in zip(generation_token_ids, logprob_content):
+                if logprob_entry.token != f"token_id:{token_id}":
+                    raise RuntimeError(
+                        "vLLM returned a log probability for an unexpected "
+                        "token while attaching token information to the "
+                        "OpenAI-compatible chat response: "
+                        f"choice_idx={choice.index}, token_id={token_id}, "
+                        f"logprob_token={logprob_entry.token!r}."
+                    )
+                generation_log_probs.append(float(logprob_entry.logprob))
+
+        choice.message.prompt_token_ids = list(prompt_token_ids)
+        choice.message.generation_token_ids = generation_token_ids
+        choice.message.generation_log_probs = generation_log_probs
+
+    return response
+
+
 def model_dump_chat_response_with_routed_experts(response: Any) -> dict[str, Any]:
-    """Dump a vLLM OpenAI chat response while preserving dynamic R3 fields."""
+    """Dump a vLLM OpenAI chat response while preserving dynamic message fields."""
     response_dict = response.model_dump()
     for choice, choice_dict in zip(
         getattr(response, "choices", []), response_dict.get("choices", [])
     ):
-        routed_experts = getattr(
-            getattr(choice, "message", None), "routed_experts", None
-        )
-        if routed_experts is not None:
-            choice_dict.setdefault("message", {})["routed_experts"] = routed_experts
+        message = getattr(choice, "message", None)
+        for field_name in (
+            "routed_experts",
+            "prompt_token_ids",
+            "generation_token_ids",
+            "generation_log_probs",
+        ):
+            field_value = getattr(message, field_name, None)
+            if field_value is not None:
+                choice_dict.setdefault("message", {})[field_name] = field_value
     return response_dict
 
 

--- a/nemo_rl/models/generation/vllm/utils.py
+++ b/nemo_rl/models/generation/vllm/utils.py
@@ -26,6 +26,7 @@ from nemo_rl.models.generation.interfaces import (
 from nemo_rl.utils.routed_experts_codec import encode_routed_experts
 
 R3_MISSING_ROUTE_SENTINEL = ROUTED_EXPERTS_MISSING_ROUTE_SENTINEL
+VLLM_LOGPROB_FLOOR = -9999.0
 
 # The expert-id range vs carry dtype is model-constant, so it is verified on the
 # first non-empty routed-experts tensor per process and skipped afterwards.
@@ -331,26 +332,34 @@ def attach_token_information_to_chat_response_choices(
             "not include prompt_token_ids."
         )
 
-    outputs_by_index = {
-        output.index: output for output in getattr(final_request_output, "outputs", [])
-    }
-    choices = list(getattr(response, "choices", []))
-    choice_indices = [choice.index for choice in choices]
-    if len(outputs_by_index) != len(
-        getattr(final_request_output, "outputs", [])
-    ) or len(set(choice_indices)) != len(choice_indices):
+    generation_outputs = list(getattr(final_request_output, "outputs", []))
+    generation_output_indices = [output.index for output in generation_outputs]
+    outputs_by_index = {output.index: output for output in generation_outputs}
+    if len(outputs_by_index) != len(generation_outputs):
         raise RuntimeError(
-            "vLLM returned duplicate choice indices while attaching token "
-            "information to the OpenAI-compatible chat response."
+            "vLLM returned duplicate generation output indices while attaching "
+            "token information to the OpenAI-compatible chat response."
         )
 
-    missing_choice_indices = sorted(set(choice_indices) - outputs_by_index.keys())
-    if missing_choice_indices:
+    choices = list(getattr(response, "choices", []))
+    choice_indices = [choice.index for choice in choices]
+    if len(set(choice_indices)) != len(choice_indices):
+        raise RuntimeError(
+            "vLLM returned duplicate response choice indices while attaching "
+            "token information to the OpenAI-compatible chat response."
+        )
+
+    choice_index_set = set(choice_indices)
+    output_index_set = set(generation_output_indices)
+    missing_choice_indices = sorted(choice_index_set - output_index_set)
+    unexpected_output_indices = sorted(output_index_set - choice_index_set)
+    if missing_choice_indices or unexpected_output_indices:
         raise RuntimeError(
             "vLLM was asked to return token information for the "
             "OpenAI-compatible chat endpoint but response choices could not be "
             "matched to generation outputs: "
-            f"missing_choice_indices={missing_choice_indices}."
+            f"missing_choice_indices={missing_choice_indices}, "
+            f"unexpected_output_indices={unexpected_output_indices}."
         )
 
     for choice in choices:
@@ -364,35 +373,39 @@ def attach_token_information_to_chat_response_choices(
             )
         generation_token_ids = list(output_token_ids)
 
-        logprob_content = getattr(getattr(choice, "logprobs", None), "content", None)
-        if logprob_content is None:
+        generation_logprob_details = getattr(generation_details, "logprobs", None)
+        if generation_logprob_details is None:
             if generation_token_ids:
                 raise RuntimeError(
                     "vLLM was asked to return token information for the "
-                    "OpenAI-compatible chat endpoint but response "
+                    "OpenAI-compatible chat endpoint but generation output "
                     f"choice_idx={choice.index} did not include logprobs."
                 )
             generation_log_probs = []
         else:
-            if len(generation_token_ids) != len(logprob_content):
+            if len(generation_token_ids) != len(generation_logprob_details):
                 raise RuntimeError(
                     "vLLM returned mismatched generation token IDs and log "
                     "probabilities for the OpenAI-compatible chat endpoint: "
                     f"choice_idx={choice.index}, "
                     f"token_count={len(generation_token_ids)}, "
-                    f"logprob_count={len(logprob_content)}."
+                    f"logprob_count={len(generation_logprob_details)}."
                 )
             generation_log_probs = []
-            for token_id, logprob_entry in zip(generation_token_ids, logprob_content):
-                if logprob_entry.token != f"token_id:{token_id}":
+            for token_id, position_logprobs in zip(
+                generation_token_ids, generation_logprob_details
+            ):
+                selected_token_logprob = position_logprobs.get(token_id)
+                if selected_token_logprob is None:
                     raise RuntimeError(
-                        "vLLM returned a log probability for an unexpected "
-                        "token while attaching token information to the "
-                        "OpenAI-compatible chat response: "
-                        f"choice_idx={choice.index}, token_id={token_id}, "
-                        f"logprob_token={logprob_entry.token!r}."
+                        "vLLM generation log probabilities did not include the "
+                        "selected token while attaching token information to "
+                        "the OpenAI-compatible chat response: "
+                        f"choice_idx={choice.index}, token_id={token_id}."
                     )
-                generation_log_probs.append(float(logprob_entry.logprob))
+                generation_log_probs.append(
+                    max(float(selected_token_logprob.logprob), VLLM_LOGPROB_FLOOR)
+                )
 
         choice.message.prompt_token_ids = list(prompt_token_ids)
         choice.message.generation_token_ids = generation_token_ids

--- a/nemo_rl/models/generation/vllm/utils.py
+++ b/nemo_rl/models/generation/vllm/utils.py
@@ -414,7 +414,9 @@ def attach_token_information_to_chat_response_choices(
     return response
 
 
-def model_dump_chat_response_with_routed_experts(response: Any) -> dict[str, Any]:
+def model_dump_chat_response_with_dynamic_message_fields(
+    response: Any,
+) -> dict[str, Any]:
     """Dump a vLLM OpenAI chat response while preserving dynamic message fields."""
     response_dict = response.model_dump()
     for choice, choice_dict in zip(

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -595,6 +595,22 @@ class VllmAsyncGenerationWorkerImpl(
                 *args,
                 **kwargs,
             ):
+                return_as_token_id = (
+                    request.return_tokens_as_token_ids
+                    if request.return_tokens_as_token_ids is not None
+                    else self.return_tokens_as_token_ids
+                )
+                if (
+                    request.logprobs
+                    and return_as_token_id
+                    and request.top_logprobs is None
+                ):
+                    raise VLLMValidationError(
+                        "`top_logprobs` must be set when requesting token "
+                        "information from the NeMo-RL chat endpoint.",
+                        parameter="top_logprobs",
+                    )
+
                 final_res = None
 
                 async def capture_result_generator():
@@ -615,7 +631,7 @@ class VllmAsyncGenerationWorkerImpl(
                 ):
                     return response
 
-                if request.logprobs and request.return_tokens_as_token_ids:
+                if request.logprobs and return_as_token_id:
                     response = attach_token_information_to_chat_response_choices(
                         response,
                         final_res,

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -45,6 +45,7 @@ from nemo_rl.models.generation.vllm.checkpoint_engine import (
 )
 from nemo_rl.models.generation.vllm.utils import (
     attach_routed_experts_to_chat_response_choices,
+    attach_token_information_to_chat_response_choices,
     format_prompt_for_vllm_generation,
     model_dump_chat_response_with_routed_experts,
     pad_and_align_routed_expert_indices,
@@ -609,19 +610,27 @@ class VllmAsyncGenerationWorkerImpl(
                     **kwargs,
                 )
                 if (
-                    not worker_self._return_routed_experts_enabled()
-                    or not isinstance(response, ChatCompletionResponse)
+                    not isinstance(response, ChatCompletionResponse)
                     or final_res is None
                 ):
                     return response
 
-                return attach_routed_experts_to_chat_response_choices(
-                    response,
-                    final_res,
-                    device=torch.device("cpu"),
-                    logger=LOGGER,
-                    routed_experts_dtype=worker_self.routed_experts_dtype,
-                )
+                if request.logprobs and request.return_tokens_as_token_ids:
+                    response = attach_token_information_to_chat_response_choices(
+                        response,
+                        final_res,
+                    )
+
+                if worker_self._return_routed_experts_enabled():
+                    response = attach_routed_experts_to_chat_response_choices(
+                        response,
+                        final_res,
+                        device=torch.device("cpu"),
+                        logger=LOGGER,
+                        routed_experts_dtype=worker_self.routed_experts_dtype,
+                    )
+
+                return response
 
         class NeMoRLOpenAIServingChat(NeMoRLOpenAIServingChatMixin, OpenAIServingChat):
             pass

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -47,7 +47,7 @@ from nemo_rl.models.generation.vllm.utils import (
     attach_routed_experts_to_chat_response_choices,
     attach_token_information_to_chat_response_choices,
     format_prompt_for_vllm_generation,
-    model_dump_chat_response_with_routed_experts,
+    model_dump_chat_response_with_dynamic_message_fields,
     pad_and_align_routed_expert_indices,
 )
 from nemo_rl.models.generation.vllm.vllm_worker import BaseVllmGenerationWorker
@@ -763,7 +763,9 @@ class VllmAsyncGenerationWorkerImpl(
 
             elif isinstance(generator, ChatCompletionResponse):
                 return JSONResponse(
-                    content=model_dump_chat_response_with_routed_experts(generator)
+                    content=model_dump_chat_response_with_dynamic_message_fields(
+                        generator
+                    )
                 )
 
             return StreamingResponse(content=generator, media_type="text/event-stream")

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -1696,7 +1696,6 @@ def test_vllm_http_server(cluster, tokenizer):
         top_p=generation_config["top_p"],
         # We want to test the actual train flow and how this is used. So we need to get logprobs here.
         logprobs=True,
-        return_tokens_as_token_ids=True,
         max_tokens=1,
     )
 
@@ -1796,6 +1795,17 @@ def test_vllm_http_server(cluster, tokenizer):
         actual_result["choices"][0]["logprobs"]["content"][0]["logprob"]
     ]
     assert _standardize(expected_result) == _standardize(actual_result)
+
+    # The server default requests token IDs, so top_logprobs=None cannot provide
+    # the log probabilities required by the training response contract.
+    response = requests.post(
+        url=f"{base_urls[0]}/chat/completions",
+        json=body | {"top_logprobs": None},
+    )
+    assert response.status_code == 400
+    error = response.json()["error"]
+    assert error["code"] == 400
+    assert "top_logprobs" in error["message"]
 
     # Check that tokenization route works
     response = requests.post(url=f"{base_urls[0]}/../tokenize", json=body)
@@ -2109,6 +2119,10 @@ async def test_vllm_http_server_correct_merged_tokens_matches_baseline(
         url=f"{base_urls[0]}/chat/completions", json=body_with_reference_token_ids
     )
     vllm_http_server_result = response.json()
+    assert (
+        vllm_http_server_result["choices"][0]["message"]["prompt_token_ids"]
+        == initial_tokenized_query_ids
+    )
     vllm_http_server_generated_token = vllm_http_server_result["choices"][0][
         "logprobs"
     ]["content"][0]

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -1706,6 +1706,21 @@ def test_vllm_http_server(cluster, tokenizer):
     response = requests.post(url=f"{base_urls[0]}/chat/completions", json=body)
     actual_result = response.json()
 
+    expected_prompt_token_ids = [
+        151644,
+        872,
+        198,
+        1830,
+        311,
+        220,
+        20,
+        151645,
+        198,
+        151644,
+        77091,
+        198,
+    ]
+
     # This result assumes this exact model. The expected result here is what the full result looks like before we standardize.
     expected_result = {
         "id": "chatcmpl-7b8c0cdeeab34fd58ad260cf44b1a408",
@@ -1725,6 +1740,8 @@ def test_vllm_http_server(cluster, tokenizer):
                     # vLLM 0.25 omits tool_calls when empty and dropped
                     # reasoning_content in favor of reasoning.
                     "reasoning": None,
+                    "prompt_token_ids": expected_prompt_token_ids,
+                    "generation_token_ids": [151667],
                 },
                 "logprobs": {
                     "content": [
@@ -1771,9 +1788,13 @@ def test_vllm_http_server(cluster, tokenizer):
         message = d["choices"][0]["message"]
         for key in ("reasoning", "reasoning_content"):
             message.pop(key, None)
+        message.pop("generation_log_probs", None)
 
         return d
 
+    assert actual_result["choices"][0]["message"]["generation_log_probs"] == [
+        actual_result["choices"][0]["logprobs"]["content"][0]["logprob"]
+    ]
     assert _standardize(expected_result) == _standardize(actual_result)
 
     # Check that tokenization route works
@@ -1782,20 +1803,7 @@ def test_vllm_http_server(cluster, tokenizer):
     expected_result = {
         "count": 12,
         "max_model_len": 1024,
-        "tokens": [
-            151644,
-            872,
-            198,
-            1830,
-            311,
-            220,
-            20,
-            151645,
-            198,
-            151644,
-            77091,
-            198,
-        ],
+        "tokens": expected_prompt_token_ids,
         "token_strs": None,
     }
     assert expected_result == actual_result

--- a/tests/unit/models/generation/test_vllm_utils.py
+++ b/tests/unit/models/generation/test_vllm_utils.py
@@ -563,8 +563,15 @@ def test_attach_token_information_to_chat_response_choices():
     final_res = SimpleNamespace(
         prompt_token_ids=[101, 102, 103],
         outputs=[
-            SimpleNamespace(index=1, token_ids=[]),
-            SimpleNamespace(index=0, token_ids=[201, 202]),
+            SimpleNamespace(index=1, token_ids=[], logprobs=[]),
+            SimpleNamespace(
+                index=0,
+                token_ids=[201, 202],
+                logprobs=[
+                    {201: SimpleNamespace(logprob=-0.1)},
+                    {202: SimpleNamespace(logprob=-10000.0)},
+                ],
+            ),
         ],
     )
     response = SimpleNamespace(
@@ -574,8 +581,8 @@ def test_attach_token_information_to_chat_response_choices():
                 message=SimpleNamespace(),
                 logprobs=SimpleNamespace(
                     content=[
-                        SimpleNamespace(token="token_id:201", logprob=-0.1),
-                        SimpleNamespace(token="token_id:202", logprob=-0.2),
+                        SimpleNamespace(token="decoded token", logprob=-10.0),
+                        SimpleNamespace(token="format is ignored", logprob=-20.0),
                     ]
                 ),
             ),
@@ -604,7 +611,7 @@ def test_attach_token_information_to_chat_response_choices():
     assert response_dict["choices"][0]["message"]["generation_token_ids"] == [201, 202]
     assert response_dict["choices"][0]["message"]["generation_log_probs"] == [
         -0.1,
-        -0.2,
+        -9999.0,
     ]
     assert response_dict["choices"][1]["message"]["prompt_token_ids"] == [
         101,
@@ -613,6 +620,36 @@ def test_attach_token_information_to_chat_response_choices():
     ]
     assert response_dict["choices"][1]["message"]["generation_token_ids"] == []
     assert response_dict["choices"][1]["message"]["generation_log_probs"] == []
+
+
+@pytest.mark.parametrize(
+    ("token_ids", "logprobs", "error_match"),
+    [
+        (
+            [201, 202],
+            [{201: SimpleNamespace(logprob=-0.1)}],
+            "mismatched generation token IDs and log probabilities",
+        ),
+        (
+            [201],
+            [{999: SimpleNamespace(logprob=-0.1)}],
+            "did not include the selected token",
+        ),
+    ],
+)
+def test_attach_token_information_to_chat_response_choices_rejects_invalid_logprobs(
+    token_ids, logprobs, error_match
+):
+    final_res = SimpleNamespace(
+        prompt_token_ids=[101, 102, 103],
+        outputs=[SimpleNamespace(index=0, token_ids=token_ids, logprobs=logprobs)],
+    )
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(index=0, message=SimpleNamespace())]
+    )
+
+    with pytest.raises(RuntimeError, match=error_match):
+        attach_token_information_to_chat_response_choices(response, final_res)
 
 
 def test_model_dump_chat_response_with_routed_experts_preserves_dynamic_field():

--- a/tests/unit/models/generation/test_vllm_utils.py
+++ b/tests/unit/models/generation/test_vllm_utils.py
@@ -563,7 +563,7 @@ def test_attach_token_information_to_chat_response_choices():
     final_res = SimpleNamespace(
         prompt_token_ids=[101, 102, 103],
         outputs=[
-            SimpleNamespace(index=1, token_ids=[], logprobs=[]),
+            SimpleNamespace(index=1, token_ids=[], logprobs=None),
             SimpleNamespace(
                 index=0,
                 token_ids=[201, 202],
@@ -646,6 +646,63 @@ def test_attach_token_information_to_chat_response_choices_rejects_invalid_logpr
     )
     response = SimpleNamespace(
         choices=[SimpleNamespace(index=0, message=SimpleNamespace())]
+    )
+
+    with pytest.raises(RuntimeError, match=error_match):
+        attach_token_information_to_chat_response_choices(response, final_res)
+
+
+@pytest.mark.parametrize(
+    ("prompt_token_ids", "outputs", "choice_indices", "error_match"),
+    [
+        (None, [], [], "did not include prompt_token_ids"),
+        (
+            [101],
+            [
+                SimpleNamespace(index=0, token_ids=[], logprobs=[]),
+                SimpleNamespace(index=0, token_ids=[], logprobs=[]),
+            ],
+            [0],
+            "duplicate generation output indices",
+        ),
+        (
+            [101],
+            [SimpleNamespace(index=0, token_ids=[], logprobs=[])],
+            [0, 0],
+            "duplicate response choice indices",
+        ),
+        (
+            [101],
+            [SimpleNamespace(index=1, token_ids=[], logprobs=[])],
+            [0],
+            "could not be matched to generation outputs",
+        ),
+        (
+            [101],
+            [SimpleNamespace(index=0, logprobs=[])],
+            [0],
+            "did not include token_ids",
+        ),
+        (
+            [101],
+            [SimpleNamespace(index=0, token_ids=[201], logprobs=None)],
+            [0],
+            "did not include logprobs",
+        ),
+    ],
+)
+def test_attach_token_information_to_chat_response_choices_rejects_invalid_structure(
+    prompt_token_ids, outputs, choice_indices, error_match
+):
+    final_res = SimpleNamespace(
+        prompt_token_ids=prompt_token_ids,
+        outputs=outputs,
+    )
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(index=choice_index, message=SimpleNamespace())
+            for choice_index in choice_indices
+        ]
     )
 
     with pytest.raises(RuntimeError, match=error_match):

--- a/tests/unit/models/generation/test_vllm_utils.py
+++ b/tests/unit/models/generation/test_vllm_utils.py
@@ -30,6 +30,7 @@ from nemo_rl.models.generation.vllm.utils import (
     R3_MISSING_ROUTE_SENTINEL,
     aggregate_spec_decode_counters,
     attach_routed_experts_to_chat_response_choices,
+    attach_token_information_to_chat_response_choices,
     compute_spec_decode_metrics,
     format_prompt_for_vllm_generation,
     model_dump_chat_response_with_routed_experts,
@@ -556,6 +557,62 @@ def test_attach_routed_experts_to_chat_response_choices_raises_for_unmatched_cho
             final_res,
             device=torch.device("cpu"),
         )
+
+
+def test_attach_token_information_to_chat_response_choices():
+    final_res = SimpleNamespace(
+        prompt_token_ids=[101, 102, 103],
+        outputs=[
+            SimpleNamespace(index=1, token_ids=[]),
+            SimpleNamespace(index=0, token_ids=[201, 202]),
+        ],
+    )
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                index=0,
+                message=SimpleNamespace(),
+                logprobs=SimpleNamespace(
+                    content=[
+                        SimpleNamespace(token="token_id:201", logprob=-0.1),
+                        SimpleNamespace(token="token_id:202", logprob=-0.2),
+                    ]
+                ),
+            ),
+            SimpleNamespace(
+                index=1,
+                message=SimpleNamespace(),
+                logprobs=SimpleNamespace(content=None),
+            ),
+        ],
+        model_dump=lambda: {
+            "choices": [
+                {"message": {"role": "assistant", "content": "first"}},
+                {"message": {"role": "assistant", "content": "second"}},
+            ]
+        },
+    )
+
+    attach_token_information_to_chat_response_choices(response, final_res)
+    response_dict = model_dump_chat_response_with_routed_experts(response)
+
+    assert response_dict["choices"][0]["message"]["prompt_token_ids"] == [
+        101,
+        102,
+        103,
+    ]
+    assert response_dict["choices"][0]["message"]["generation_token_ids"] == [201, 202]
+    assert response_dict["choices"][0]["message"]["generation_log_probs"] == [
+        -0.1,
+        -0.2,
+    ]
+    assert response_dict["choices"][1]["message"]["prompt_token_ids"] == [
+        101,
+        102,
+        103,
+    ]
+    assert response_dict["choices"][1]["message"]["generation_token_ids"] == []
+    assert response_dict["choices"][1]["message"]["generation_log_probs"] == []
 
 
 def test_model_dump_chat_response_with_routed_experts_preserves_dynamic_field():

--- a/tests/unit/models/generation/test_vllm_utils.py
+++ b/tests/unit/models/generation/test_vllm_utils.py
@@ -33,7 +33,7 @@ from nemo_rl.models.generation.vllm.utils import (
     attach_token_information_to_chat_response_choices,
     compute_spec_decode_metrics,
     format_prompt_for_vllm_generation,
-    model_dump_chat_response_with_routed_experts,
+    model_dump_chat_response_with_dynamic_message_fields,
     pad_and_align_routed_expert_indices,
 )
 from nemo_rl.utils.routed_experts_codec import decode_routed_experts
@@ -601,7 +601,7 @@ def test_attach_token_information_to_chat_response_choices():
     )
 
     attach_token_information_to_chat_response_choices(response, final_res)
-    response_dict = model_dump_chat_response_with_routed_experts(response)
+    response_dict = model_dump_chat_response_with_dynamic_message_fields(response)
 
     assert response_dict["choices"][0]["message"]["prompt_token_ids"] == [
         101,
@@ -709,13 +709,29 @@ def test_attach_token_information_to_chat_response_choices_rejects_invalid_struc
         attach_token_information_to_chat_response_choices(response, final_res)
 
 
-def test_model_dump_chat_response_with_routed_experts_preserves_dynamic_field():
-    routed_experts = [[[1]], [[2]]]
+def test_model_dump_chat_response_with_dynamic_message_fields_preserves_all_fields():
+    final_res = SimpleNamespace(
+        prompt_token_ids=[101, 102],
+        prompt_routed_experts=torch.tensor(
+            [[[10]]], dtype=ROUTED_EXPERTS_FALLBACK_DTYPE
+        ),
+        outputs=[
+            SimpleNamespace(
+                index=0,
+                token_ids=[201],
+                logprobs=[{201: SimpleNamespace(logprob=-0.1)}],
+                routed_experts=torch.tensor(
+                    [[[20]]], dtype=ROUTED_EXPERTS_FALLBACK_DTYPE
+                ),
+            )
+        ],
+    )
 
     class Response:
         choices = [
             SimpleNamespace(
-                message=SimpleNamespace(routed_experts=routed_experts),
+                index=0,
+                message=SimpleNamespace(),
             )
         ]
 
@@ -731,9 +747,20 @@ def test_model_dump_chat_response_with_routed_experts_preserves_dynamic_field():
                 ]
             }
 
-    response_dict = model_dump_chat_response_with_routed_experts(Response())
+    response = Response()
+    attach_token_information_to_chat_response_choices(response, final_res)
+    attach_routed_experts_to_chat_response_choices(
+        response,
+        final_res,
+        device=torch.device("cpu"),
+    )
+    response_dict = model_dump_chat_response_with_dynamic_message_fields(response)
 
-    assert response_dict["choices"][0]["message"]["routed_experts"] == routed_experts
+    message = response_dict["choices"][0]["message"]
+    assert message["routed_experts"] == response.choices[0].message.routed_experts
+    assert message["prompt_token_ids"] == [101, 102]
+    assert message["generation_token_ids"] == [201]
+    assert message["generation_log_probs"] == [-0.1]
 
 
 @pytest.mark.vllm


### PR DESCRIPTION
## Summary

This PR removes a redundant, awaited `/tokenize` round trip from every raw-vLLM model turn. Under a 64-concurrent multi-turn workload, that round trip was on the session critical path and accumulated into a significant model-serving bottleneck.

- attach exact prompt token IDs, generation token IDs, and selected-token log probabilities to raw-vLLM chat-completion messages
- match vLLM generation outputs to response choices by choice index and validate token/logprob alignment
- preserve the dynamic token metadata in the serialized OpenAI-compatible response
- retain Gym's existing `/tokenize` compatibility fallback unchanged

## Performance impact

In a matched vLLM 0.23.0 benchmark using Gym `eddd5e98`, this change:

- reduced summed model-request-wave span from **2,683.4s to 2,291.3s**: a **392.1s (14.6%) reduction**, or **1.17x speedup**
- eliminated `/tokenize` entirely across **18,078 successful model calls**
- brought raw vLLM to within **3.5% of Dynamo + vLLM** on model-request span
- closed **83% of the previously observed raw-vLLM-to-Dynamo serving gap**

Because Gym awaited `/tokenize` before starting the next turn, this was not background bookkeeping overhead: its latency directly serialized multi-turn sessions. Returning metadata already available in vLLM's final `RequestOutput` removes that critical-path work without changing generation behavior.

## Root cause

The raw-vLLM backend already had the exact prompt and generated token IDs in the final vLLM `RequestOutput`, but discarded them while serializing the chat-completion response. Gym therefore issued a separate awaited `/tokenize` request on every model turn to reconstruct prompt token IDs, adding inter-turn latency under concurrency.

## Gym compatibility

No paired Gym change or submodule bump is required. NeMo-RL's pinned Gym revision, `473f446`, already guards the compatibility fallback on the absence of native metadata:

```python
if self.config.return_token_id_information and "prompt_token_ids" not in choice_dict["message"]:
```

Both `client.create_tokenize(...)` and the subsequent `message_dict.update(...)` are inside that block. Because this PR serializes `prompt_token_ids` on `choice.message`, pinned Gym skips the entire fallback. The fallback remains available for other servers that do not return native token metadata.

## Validation

- focused utility suite: 34 passed
- Ruff check and format checks passed on all changed files
- matched benchmark:
  - 320/320 valid trajectories
  - zero `/tokenize` calls
  - contiguous per-session multi-turn call sequences

The whole-run first-request-to-last-response span was 3,290.9s because this run accumulated 999.6s of between-wave environment delay, dominated by one 1,008s OpenHands trajectory. The benchmark therefore supports model-serving parity, not environment-inclusive wall-time parity.

## Known Gym payload behavior

Gym's native-metadata path skips its compatibility cleanup, so the standard OpenAI `choice.logprobs` block remains alongside `choice.message.generation_log_probs`. NeMo-RL intentionally preserves `choice.logprobs` to maintain the endpoint's OpenAI response contract.
