### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -14,14 +14,14 @@ docker buildx build -f docker/Dockerfile \
 
 # Self-contained build (specific git ref):
 docker buildx build -f docker/Dockerfile \
-    --build-arg NRL_GIT_REF=r0.6.0 \
-    --tag <registry>/nemo-rl:r0.6.0 \
+    --build-arg NRL_GIT_REF=r0.7.0 \
+    --tag <registry>/nemo-rl:r0.7.0 \
     --push .
 
 # Self-contained build (remote NeMo RL source; no need for a local clone of NeMo RL):
 docker buildx build -f docker/Dockerfile \
-    --build-arg NRL_GIT_REF=r0.6.0 \
-    --tag <registry>/nemo-rl:r0.6.0 \
+    --build-arg NRL_GIT_REF=r0.7.0 \
+    --tag <registry>/nemo-rl:r0.7.0 \
     --push https://github.com/NVIDIA-NeMo/RL.git
 
 # Local NeMo RL source override:

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -4,10 +4,14 @@
         "url": "https://docs.nvidia.com/nemo/rl/nightly/"
     },
     {
-        "name": "0.6.0 (latest)",
-        "version": "0.6.0",
+        "name": "0.7.0 (latest)",
+        "version": "0.7.0",
         "url": "https://docs.nvidia.com/nemo/rl/latest/",
         "preferred": true
+    },
+    {
+        "version": "0.6.0",
+        "url": "https://docs.nvidia.com/nemo/rl/0.6.0/"
     },
     {
         "version": "0.5.0",

--- a/nemo_rl/package_info.py
+++ b/nemo_rl/package_info.py
@@ -14,7 +14,7 @@
 
 
 MAJOR = 0
-MINOR = 6
+MINOR = 7
 PATCH = 0
 PRE_RELEASE = ""
 


### PR DESCRIPTION
## Summary
- Bump `MINOR` from 6 → 7 in `nemo_rl/package_info.py` (version becomes 0.7.0, no RC tag)
- Add 0.7.0 as latest in `docs/versions1.json`, demote 0.6.0 to its versioned URL
- Update Docker example refs from `r0.6.0` → `r0.7.0` in `docs/docker.md`
