### PR TITLE
docs: bump version to 0.7.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,7 +35,7 @@ from sphinx.application import Sphinx
 project = "NeMo-RL"
 copyright = "2026, NVIDIA Corporation"
 author = "NVIDIA Corporation"
-release = "nightly"
+release = "0.7.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -14,14 +14,14 @@ docker buildx build -f docker/Dockerfile \
 
 # Self-contained build (specific git ref):
 docker buildx build -f docker/Dockerfile \
-    --build-arg NRL_GIT_REF=r0.6.0 \
-    --tag <registry>/nemo-rl:r0.6.0 \
+    --build-arg NRL_GIT_REF=r0.7.0 \
+    --tag <registry>/nemo-rl:r0.7.0 \
     --push .
 
 # Self-contained build (remote NeMo RL source; no need for a local clone of NeMo RL):
 docker buildx build -f docker/Dockerfile \
-    --build-arg NRL_GIT_REF=r0.6.0 \
-    --tag <registry>/nemo-rl:r0.6.0 \
+    --build-arg NRL_GIT_REF=r0.7.0 \
+    --tag <registry>/nemo-rl:r0.7.0 \
     --push https://github.com/NVIDIA-NeMo/RL.git
 
 # Local NeMo RL source override:

--- a/docs/project.json
+++ b/docs/project.json
@@ -1,1 +1,1 @@
-{"name": "nemo-rl", "version": "nightly"}
+{"name": "nemo-rl", "version": "0.7.0"}

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -4,10 +4,14 @@
         "url": "https://docs.nvidia.com/nemo/rl/nightly/"
     },
     {
-        "name": "0.6.0 (latest)",
-        "version": "0.6.0",
+        "name": "0.7.0 (latest)",
+        "version": "0.7.0",
         "url": "https://docs.nvidia.com/nemo/rl/latest/",
         "preferred": true
+    },
+    {
+        "version": "0.6.0",
+        "url": "https://docs.nvidia.com/nemo/rl/0.6.0/"
     },
     {
         "version": "0.5.0",

--- a/nemo_rl/package_info.py
+++ b/nemo_rl/package_info.py
@@ -14,7 +14,7 @@
 
 
 MAJOR = 0
-MINOR = 6
+MINOR = 7
 PATCH = 0
 PRE_RELEASE = ""
 


### PR DESCRIPTION
## Summary
- `nemo_rl/package_info.py`: MINOR 6 → 7 (version becomes 0.7.0, no RC tag)
- `docs/conf.py`: `release = "nightly"` → `"0.7.0"`
- `docs/project.json`: version `"nightly"` → `"0.7.0"`
- `docs/versions1.json`: add 0.7.0 as latest, demote 0.6.0 to its versioned URL
- `docs/docker.md`: update example git refs from `r0.6.0` → `r0.7.0`
