### PR TITLE
fix: Per-node NeMo Gym venv prefetch + env-overridable PY_EXECUTABLES.TRTLLM

### DIFF
--- a/examples/nemo_gym/prefetch_venvs.py
+++ b/examples/nemo_gym/prefetch_venvs.py
@@ -18,14 +18,25 @@ This complements nemo_rl/utils/prefetch_venvs.py (which prefetches Ray actor ven
 by also triggering NeMo Gym's own internal venv creation for its servers (code_gen,
 math, etc.). It reuses the real code path (NemoGym -> _spinup) with dry_run=True
 so no actual policy model is needed.
+
+Gym's per-server venvs are built as a side effect of ``NemoGym._spinup()`` into the
+node-local container filesystem, so a single actor only covers whichever node it
+happened to land on. Because the Gym runners are SPREAD-placed, any uncovered node
+fails every rollout it receives with ``broken py_executable`` -> HTTP 500 -> a
+zero-reward back-fill, which silently depresses reward instead of erroring out.
+We therefore spin up one NemoGym actor *per node* under a STRICT_SPREAD placement
+group, mirroring ``create_local_venv_on_each_node``, and assert coverage afterwards.
 """
 
 import argparse
+import glob
 import os
 import sys
 
 import ray
 from omegaconf import OmegaConf
+from ray.util.placement_group import placement_group
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 from nemo_rl.distributed.ray_actor_environment_registry import get_actor_python_env
 from nemo_rl.distributed.virtual_cluster import init_ray
@@ -39,6 +50,89 @@ from nemo_rl.utils.config import load_config
 from nemo_rl.utils.venvs import create_local_venv_on_each_node
 
 OmegaConf.register_new_resolver("mul", lambda a, b: a * b)
+
+
+def _alive_nodes() -> list[dict]:
+    """Ray nodes eligible to host a prefetch actor.
+
+    Skips nodes with 0 CPUs (e.g. unschedulable head nodes) — including them
+    makes the STRICT_SPREAD placement group infeasible. Same filter as
+    ``nemo_rl.utils.venvs.create_local_venv_on_each_node``.
+    """
+    return [
+        n
+        for n in ray.nodes()
+        if n.get("Alive", False) and n.get("Resources", {}).get("CPU", 0) > 0
+    ]
+
+
+def _gym_venv_root() -> str:
+    """Directory that Gym builds its per-server venvs under.
+
+    With NEMO_GYM_VENV_DIR set, Gym builds into that directory; otherwise it
+    builds in-tree next to each server. Both layouts nest the venv as
+    ``<root>/<category>/<server>/.venv`` (e.g. ``responses_api_agents/swe_agents``).
+    """
+    venv_dir = get_nemo_gym_venv_dir()
+    if venv_dir:
+        return venv_dir
+    # <repo>/examples/nemo_gym/prefetch_venvs.py -> <repo>/3rdparty/Gym-workspace/Gym
+    repo_root = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    )
+    return os.path.join(repo_root, "3rdparty", "Gym-workspace", "Gym")
+
+
+@ray.remote(num_cpus=1)
+def _list_gym_venvs(root: str) -> list[str]:
+    """Return the Gym server venvs that exist on the node running this task.
+
+    Matches both the nested ``<category>/<server>/.venv`` layout and a flat
+    ``<server>/.venv`` one, so this does not depend on which root applies.
+    """
+    found = set()
+    for pattern in ("*/.venv/bin/python", "*/*/.venv/bin/python"):
+        for p in glob.glob(os.path.join(root, pattern)):
+            found.add(os.path.relpath(p, root))
+    return sorted(found)
+
+
+def _assert_venvs_on_every_node(pg, num_nodes: int) -> None:
+    """Fail loudly unless every node ended up with the same, non-empty venv set.
+
+    Reported success with only partial coverage is the exact failure this guards:
+    it does not crash the run, it just silently turns half the rollouts into
+    zero-reward trajectories.
+    """
+    root = _gym_venv_root()
+    per_node = ray.get(
+        [
+            _list_gym_venvs.options(
+                scheduling_strategy=PlacementGroupSchedulingStrategy(
+                    placement_group=pg, placement_group_bundle_index=i
+                )
+            ).remote(root)
+            for i in range(num_nodes)
+        ]
+    )
+
+    print(f"\nGym venv coverage under {root}:")
+    for i, venvs in enumerate(per_node):
+        print(f"  node[{i}]: {venvs if venvs else '<NONE>'}")
+
+    empty = [i for i, v in enumerate(per_node) if not v]
+    if empty:
+        raise RuntimeError(
+            f"NeMo Gym venv prefetch left {len(empty)}/{num_nodes} node(s) with no venv "
+            f"under {root} (node indices {empty}). Rollouts scheduled onto those nodes "
+            "would fail with 'broken py_executable' and be back-filled as zero reward."
+        )
+
+    distinct = {tuple(v) for v in per_node}
+    if len(distinct) > 1:
+        raise RuntimeError(
+            f"NeMo Gym venv prefetch produced inconsistent venv sets across nodes: {distinct}"
+        )
 
 
 def prefetch_nemo_gym_venvs(config_paths: list[str]) -> None:
@@ -56,9 +150,49 @@ def prefetch_nemo_gym_venvs(config_paths: list[str]) -> None:
             nemo_gym_py_exec, "nemo_rl.environments.nemo_gym.NemoGym"
         )
 
+    nodes = _alive_nodes()
+    num_nodes = len(nodes)
+    if num_nodes == 0:
+        raise RuntimeError("No alive Ray nodes with CPUs available for venv prefetch.")
+    print(f"Prefetching NeMo Gym venvs on {num_nodes} node(s).")
+
+    # Reserve one CPU per node so each NemoGym actor is pinned to a distinct node.
+    pg = placement_group(bundles=[{"CPU": 1}] * num_nodes, strategy="STRICT_SPREAD")
+    ray.get(pg.ready())
+
     succeeded = []
     failed = []
 
+    try:
+        _prefetch_configs(
+            config_paths, nemo_gym_py_exec, pg, num_nodes, succeeded, failed
+        )
+    finally:
+        ray.util.remove_placement_group(pg)
+
+    print(f"\n{'=' * 60}")
+    print("NeMo Gym venv prefetch summary")
+    print("=" * 60)
+    print(f"  Succeeded: {len(succeeded)}")
+    for path in succeeded:
+        print(f"    - {path}")
+    if failed:
+        print(f"  Failed: {len(failed)}")
+        for path, err in failed:
+            print(f"    - {path}: {err}")
+
+    if failed:
+        sys.exit(1)
+
+
+def _prefetch_configs(
+    config_paths: list[str],
+    nemo_gym_py_exec: str,
+    pg,
+    num_nodes: int,
+    succeeded: list,
+    failed: list,
+) -> None:
     for config_path in config_paths:
         print(f"\n{'=' * 60}")
         print(f"Processing config: {config_path}")
@@ -67,6 +201,13 @@ def prefetch_nemo_gym_venvs(config_paths: list[str]) -> None:
         try:
             config = load_config(config_path)
             config = OmegaConf.to_container(config, resolve=True)
+
+            # Recipes pick up env.nemo_gym through their `defaults:` chain, so
+            # only the resolved config can answer this. Skipping here (rather
+            # than erroring) lets callers run this unconditionally for any recipe.
+            if "nemo_gym" not in (config.get("env") or {}):
+                print(f"No env.nemo_gym section; skipping {config_path}")
+                continue
 
             nemo_gym_dict = dict(config["env"]["nemo_gym"])
             nemo_gym_dict["dry_run"] = True
@@ -102,15 +243,30 @@ def prefetch_nemo_gym_venvs(config_paths: list[str]) -> None:
                 },
             }
 
-            print("Creating NeMo Gym environment (dry_run=True)...")
-            nemo_gym = NemoGym.options(**nemo_gym_opts).remote(nemo_gym_cfg)
+            print(
+                f"Creating {num_nodes} NeMo Gym environment(s) (dry_run=True), one per node..."
+            )
+            actors = [
+                NemoGym.options(
+                    **nemo_gym_opts,
+                    scheduling_strategy=PlacementGroupSchedulingStrategy(
+                        placement_group=pg, placement_group_bundle_index=i
+                    ),
+                ).remote(nemo_gym_cfg)
+                for i in range(num_nodes)
+            ]
 
-            print("Waiting for NeMo Gym to finish initialization...")
-            ray.get(nemo_gym._spinup.remote())
-            print("NeMo Gym initialized successfully.")
+            try:
+                print("Waiting for NeMo Gym to finish initialization on every node...")
+                # A build failure on any single node fails the whole prefetch.
+                ray.get([a._spinup.remote() for a in actors])
+                print("NeMo Gym initialized successfully on every node.")
+            finally:
+                print("Killing NeMo Gym actors...")
+                for a in actors:
+                    ray.kill(a)
 
-            print("Killing NeMo Gym actor...")
-            ray.kill(nemo_gym)
+            _assert_venvs_on_every_node(pg, num_nodes)
 
             succeeded.append(config_path)
             print(f"Done with config: {config_path}")
@@ -118,20 +274,6 @@ def prefetch_nemo_gym_venvs(config_paths: list[str]) -> None:
         except Exception as e:
             print(f"Error processing {config_path}: {e}")
             failed.append((config_path, str(e)))
-
-    print(f"\n{'=' * 60}")
-    print("NeMo Gym venv prefetch summary")
-    print("=" * 60)
-    print(f"  Succeeded: {len(succeeded)}")
-    for path in succeeded:
-        print(f"    - {path}")
-    if failed:
-        print(f"  Failed: {len(failed)}")
-        for path, err in failed:
-            print(f"    - {path}: {err}")
-
-    if failed:
-        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/nemo_rl/distributed/virtual_cluster.py
+++ b/nemo_rl/distributed/virtual_cluster.py
@@ -77,7 +77,15 @@ class PY_EXECUTABLES:
     SGLANG = f"uv run --locked --extra sglang --directory {git_root}"
 
     # Use NeMo-RL direct dependencies and TRT-LLM.
-    TRTLLM = f"uv run --locked --extra trtllm --directory {git_root}"
+    # The `trtllm` extra is built into the image (Dockerfile.trtllm: uv sync
+    # --extra trtllm); at runtime we point directly at that baked venv's python
+    # via NEMO_RL_PY_EXECUTABLES_TRTLLM (a python binary path, NOT a `uv run`
+    # string) so the worker skips uv venv creation. trtllm_worker_async.py takes
+    # os.path.dirname(PY_EXECUTABLES.TRTLLM), which requires a real binary path.
+    TRTLLM = os.environ.get(
+        "NEMO_RL_PY_EXECUTABLES_TRTLLM",
+        f"uv run --locked --extra trtllm --directory {git_root}",
+    )
 
 
 # Default port ranges — kept below the OS ephemeral range (32768-60999 on


### PR DESCRIPTION
## Summary

Two fixes carried in the MLPerf `qwen35_397b_grpo` submission kit as out-of-tree patches
against this exact pin (`640cdc1c`), sent upstream so they don't have to be maintained
downstream.

### 1. `examples/nemo_gym/prefetch_venvs.py` — prefetch venvs on every node

`NemoGym._spinup()` builds each server's venv into the *node-local* container filesystem
as a side effect. The prefetch script ran a single `NemoGym` actor, so only that actor's
node got the venvs — while still reporting `Succeeded: 1`.

With SPREAD-placed runners, any rollout landing on an uncovered node hit a broken
`py_executable`, returned HTTP 500, and was back-filled with a zero reward — silently
depressing measured reward. On a 4-node run only 2/4 nodes were covered, matching the
observed `back-filling 8/16 failed rollout(s)`.

Fix: launch one `NemoGym` actor per node under a STRICT_SPREAD placement group, mirroring
`nemo_rl/utils/venvs.py:create_local_venv_on_each_node`, and assert afterwards that every
node reported the same non-empty venv set.

### 2. `nemo_rl/distributed/virtual_cluster.py` — `PY_EXECUTABLES.TRTLLM` from env

Honour `NEMO_RL_PY_EXECUTABLES_TRTLLM` (a real python binary path) so TRT-LLM workers can
use a prebuilt/baked venv.

`nemo_rl/distributed/worker_groups.py:449` only creates a venv when the py_executable
string `startswith("uv")`. With the default `uv run --locked --extra trtllm …` the worker
runs `uv sync --extra trtllm`, and `pyproject.toml:265` routes `tensorrt-llm` through a
custom PEP 517 backend whose `build_wheel` triggers the ~60-minute TRT-LLM compile —
observed as a hang (0% CPU in `futex_do_wait`, no venv ever produced). Making the constant
a path falsifies the `startswith("uv")` gate.

It also fixes `trtllm_worker_async.py:67` (`os.path.dirname(PY_EXECUTABLES.TRTLLM)`), which
yields a garbage `PATH` entry when the constant is a command string.

**Backwards compatible:** opt-in via env var; default behaviour is unchanged when unset.

## Test plan / validation

- [x] Both changes were validated in the MLPerf submission kit against this pin, not
      re-run as fresh upstream CI here.
- [x] SLURM job 2525439: ~68 minutes of fault-free 4×GB200 generation with change (2) as
      the sole runtime patch.
- [x] Change (1)'s per-node coverage assert reproduces/guards the 2/4-node gap that caused
      the zero-reward back-fill.
- [ ] Upstream CI.