### PR TITLE
fix: port remaining opt/dev-backup fixes (nsys, rc22 parser, Gym venv)

### DIFF
--- a/examples/nemo_gym/prefetch_venvs.py
+++ b/examples/nemo_gym/prefetch_venvs.py
@@ -18,14 +18,25 @@ This complements nemo_rl/utils/prefetch_venvs.py (which prefetches Ray actor ven
 by also triggering NeMo Gym's own internal venv creation for its servers (code_gen,
 math, etc.). It reuses the real code path (NemoGym -> _spinup) with dry_run=True
 so no actual policy model is needed.
+
+Gym's per-server venvs are built as a side effect of ``NemoGym._spinup()`` into the
+node-local container filesystem, so a single actor only covers whichever node it
+happened to land on. Because the Gym runners are SPREAD-placed, any uncovered node
+fails every rollout it receives with ``broken py_executable`` -> HTTP 500 -> a
+zero-reward back-fill, which silently depresses reward instead of erroring out.
+We therefore spin up one NemoGym actor *per node* under a STRICT_SPREAD placement
+group, mirroring ``create_local_venv_on_each_node``, and assert coverage afterwards.
 """
 
 import argparse
+import glob
 import os
 import sys
 
 import ray
 from omegaconf import OmegaConf
+from ray.util.placement_group import placement_group
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 from nemo_rl.distributed.ray_actor_environment_registry import get_actor_python_env
 from nemo_rl.distributed.virtual_cluster import init_ray
@@ -39,6 +50,89 @@ from nemo_rl.utils.config import load_config
 from nemo_rl.utils.venvs import create_local_venv_on_each_node
 
 OmegaConf.register_new_resolver("mul", lambda a, b: a * b)
+
+
+def _alive_nodes() -> list[dict]:
+    """Ray nodes eligible to host a prefetch actor.
+
+    Skips nodes with 0 CPUs (e.g. unschedulable head nodes) — including them
+    makes the STRICT_SPREAD placement group infeasible. Same filter as
+    ``nemo_rl.utils.venvs.create_local_venv_on_each_node``.
+    """
+    return [
+        n
+        for n in ray.nodes()
+        if n.get("Alive", False) and n.get("Resources", {}).get("CPU", 0) > 0
+    ]
+
+
+def _gym_venv_root() -> str:
+    """Directory that Gym builds its per-server venvs under.
+
+    With NEMO_GYM_VENV_DIR set, Gym builds into that directory; otherwise it
+    builds in-tree next to each server. Both layouts nest the venv as
+    ``<root>/<category>/<server>/.venv`` (e.g. ``responses_api_agents/swe_agents``).
+    """
+    venv_dir = get_nemo_gym_venv_dir()
+    if venv_dir:
+        return venv_dir
+    # <repo>/examples/nemo_gym/prefetch_venvs.py -> <repo>/3rdparty/Gym-workspace/Gym
+    repo_root = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    )
+    return os.path.join(repo_root, "3rdparty", "Gym-workspace", "Gym")
+
+
+@ray.remote(num_cpus=1)
+def _list_gym_venvs(root: str) -> list[str]:
+    """Return the Gym server venvs that exist on the node running this task.
+
+    Matches both the nested ``<category>/<server>/.venv`` layout and a flat
+    ``<server>/.venv`` one, so this does not depend on which root applies.
+    """
+    found = set()
+    for pattern in ("*/.venv/bin/python", "*/*/.venv/bin/python"):
+        for p in glob.glob(os.path.join(root, pattern)):
+            found.add(os.path.relpath(p, root))
+    return sorted(found)
+
+
+def _assert_venvs_on_every_node(pg, num_nodes: int) -> None:
+    """Fail loudly unless every node ended up with the same, non-empty venv set.
+
+    Reported success with only partial coverage is the exact failure this guards:
+    it does not crash the run, it just silently turns half the rollouts into
+    zero-reward trajectories.
+    """
+    root = _gym_venv_root()
+    per_node = ray.get(
+        [
+            _list_gym_venvs.options(
+                scheduling_strategy=PlacementGroupSchedulingStrategy(
+                    placement_group=pg, placement_group_bundle_index=i
+                )
+            ).remote(root)
+            for i in range(num_nodes)
+        ]
+    )
+
+    print(f"\nGym venv coverage under {root}:")
+    for i, venvs in enumerate(per_node):
+        print(f"  node[{i}]: {venvs if venvs else '<NONE>'}")
+
+    empty = [i for i, v in enumerate(per_node) if not v]
+    if empty:
+        raise RuntimeError(
+            f"NeMo Gym venv prefetch left {len(empty)}/{num_nodes} node(s) with no venv "
+            f"under {root} (node indices {empty}). Rollouts scheduled onto those nodes "
+            "would fail with 'broken py_executable' and be back-filled as zero reward."
+        )
+
+    distinct = {tuple(v) for v in per_node}
+    if len(distinct) > 1:
+        raise RuntimeError(
+            f"NeMo Gym venv prefetch produced inconsistent venv sets across nodes: {distinct}"
+        )
 
 
 def prefetch_nemo_gym_venvs(config_paths: list[str]) -> None:
@@ -56,9 +150,49 @@ def prefetch_nemo_gym_venvs(config_paths: list[str]) -> None:
             nemo_gym_py_exec, "nemo_rl.environments.nemo_gym.NemoGym"
         )
 
+    nodes = _alive_nodes()
+    num_nodes = len(nodes)
+    if num_nodes == 0:
+        raise RuntimeError("No alive Ray nodes with CPUs available for venv prefetch.")
+    print(f"Prefetching NeMo Gym venvs on {num_nodes} node(s).")
+
+    # Reserve one CPU per node so each NemoGym actor is pinned to a distinct node.
+    pg = placement_group(bundles=[{"CPU": 1}] * num_nodes, strategy="STRICT_SPREAD")
+    ray.get(pg.ready())
+
     succeeded = []
     failed = []
 
+    try:
+        _prefetch_configs(
+            config_paths, nemo_gym_py_exec, pg, num_nodes, succeeded, failed
+        )
+    finally:
+        ray.util.remove_placement_group(pg)
+
+    print(f"\n{'=' * 60}")
+    print("NeMo Gym venv prefetch summary")
+    print("=" * 60)
+    print(f"  Succeeded: {len(succeeded)}")
+    for path in succeeded:
+        print(f"    - {path}")
+    if failed:
+        print(f"  Failed: {len(failed)}")
+        for path, err in failed:
+            print(f"    - {path}: {err}")
+
+    if failed:
+        sys.exit(1)
+
+
+def _prefetch_configs(
+    config_paths: list[str],
+    nemo_gym_py_exec: str,
+    pg,
+    num_nodes: int,
+    succeeded: list,
+    failed: list,
+) -> None:
     for config_path in config_paths:
         print(f"\n{'=' * 60}")
         print(f"Processing config: {config_path}")
@@ -67,6 +201,13 @@ def prefetch_nemo_gym_venvs(config_paths: list[str]) -> None:
         try:
             config = load_config(config_path)
             config = OmegaConf.to_container(config, resolve=True)
+
+            # Recipes pick up env.nemo_gym through their `defaults:` chain, so
+            # only the resolved config can answer this. Skipping here (rather
+            # than erroring) lets callers run this unconditionally for any recipe.
+            if "nemo_gym" not in (config.get("env") or {}):
+                print(f"No env.nemo_gym section; skipping {config_path}")
+                continue
 
             nemo_gym_dict = dict(config["env"]["nemo_gym"])
             nemo_gym_dict["dry_run"] = True
@@ -102,15 +243,30 @@ def prefetch_nemo_gym_venvs(config_paths: list[str]) -> None:
                 },
             }
 
-            print("Creating NeMo Gym environment (dry_run=True)...")
-            nemo_gym = NemoGym.options(**nemo_gym_opts).remote(nemo_gym_cfg)
+            print(
+                f"Creating {num_nodes} NeMo Gym environment(s) (dry_run=True), one per node..."
+            )
+            actors = [
+                NemoGym.options(
+                    **nemo_gym_opts,
+                    scheduling_strategy=PlacementGroupSchedulingStrategy(
+                        placement_group=pg, placement_group_bundle_index=i
+                    ),
+                ).remote(nemo_gym_cfg)
+                for i in range(num_nodes)
+            ]
 
-            print("Waiting for NeMo Gym to finish initialization...")
-            ray.get(nemo_gym._spinup.remote())
-            print("NeMo Gym initialized successfully.")
+            try:
+                print("Waiting for NeMo Gym to finish initialization on every node...")
+                # A build failure on any single node fails the whole prefetch.
+                ray.get([a._spinup.remote() for a in actors])
+                print("NeMo Gym initialized successfully on every node.")
+            finally:
+                print("Killing NeMo Gym actors...")
+                for a in actors:
+                    ray.kill(a)
 
-            print("Killing NeMo Gym actor...")
-            ray.kill(nemo_gym)
+            _assert_venvs_on_every_node(pg, num_nodes)
 
             succeeded.append(config_path)
             print(f"Done with config: {config_path}")
@@ -118,20 +274,6 @@ def prefetch_nemo_gym_venvs(config_paths: list[str]) -> None:
         except Exception as e:
             print(f"Error processing {config_path}: {e}")
             failed.append((config_path, str(e)))
-
-    print(f"\n{'=' * 60}")
-    print("NeMo Gym venv prefetch summary")
-    print("=" * 60)
-    print(f"  Succeeded: {len(succeeded)}")
-    for path in succeeded:
-        print(f"    - {path}")
-    if failed:
-        print(f"  Failed: {len(failed)}")
-        for path, err in failed:
-            print(f"    - {path}: {err}")
-
-    if failed:
-        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/nemo_rl/distributed/virtual_cluster.py
+++ b/nemo_rl/distributed/virtual_cluster.py
@@ -77,7 +77,15 @@ class PY_EXECUTABLES:
     SGLANG = f"uv run --locked --extra sglang --directory {git_root}"
 
     # Use NeMo-RL direct dependencies and TRT-LLM.
-    TRTLLM = f"uv run --locked --extra trtllm --directory {git_root}"
+    # The `trtllm` extra is built into the image (Dockerfile.trtllm: uv sync
+    # --extra trtllm); at runtime we point directly at that baked venv's python
+    # via NEMO_RL_PY_EXECUTABLES_TRTLLM (a python binary path, NOT a `uv run`
+    # string) so the worker skips uv venv creation. trtllm_worker_async.py takes
+    # os.path.dirname(PY_EXECUTABLES.TRTLLM), which requires a real binary path.
+    TRTLLM = os.environ.get(
+        "NEMO_RL_PY_EXECUTABLES_TRTLLM",
+        f"uv run --locked --extra trtllm --directory {git_root}",
+    )
 
 
 # Default port ranges — kept below the OS ephemeral range.  On some DGX/GB200

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -18,7 +18,6 @@ import subprocess
 import sys
 from collections import Counter
 from collections.abc import AsyncGenerator
-
 from pathlib import Path
 from typing import Any, Dict, List, NotRequired, Optional, TypedDict
 

--- a/nemo_rl/models/generation/trtllm/trtllm_generation.py
+++ b/nemo_rl/models/generation/trtllm/trtllm_generation.py
@@ -114,11 +114,12 @@ class TrtllmGeneration(GenerationInterface):
         )
 
         self.colocated_enabled = bool(self.cfg["colocated"]["enabled"])
+        self.async_engine = bool(self.cfg["trtllm_cfg"].get("async_engine", False))
         # The synchronous TRT-LLM engine path is no longer supported: only the
         # async worker wires up colocated sleep/wakeup, IPC-ZMQ refit, and
         # per-sample streaming. Fail loudly at setup rather than silently
         # running a half-supported path.
-        assert self.cfg["trtllm_cfg"].get("async_engine", False), (
+        assert self.async_engine, (
             "TRT-LLM backend requires trtllm_cfg.async_engine=true; the "
             "synchronous engine path (async_engine=false) is no longer supported."
         )

--- a/nemo_rl/models/generation/trtllm/trtllm_http_server.py
+++ b/nemo_rl/models/generation/trtllm/trtllm_http_server.py
@@ -139,7 +139,7 @@ def create_app(
         )
 
         try:
-            conversation, mm_coroutine, _ = parse_chat_messages_coroutines(
+            conversation, mm_coroutine, *_ = parse_chat_messages_coroutines(
                 messages, model_config
             )
             mm_data, mm_embeddings = await mm_coroutine

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -29,10 +29,10 @@ from nemo_rl.algorithms.advantage_estimator import (
 from nemo_rl.algorithms.grpo import (
     MasterConfig,
     RewardPenaltyConfig,
-    _calculate_observed_pass_metrics,
     _apply_configured_message_level_advantage_penalties,
     _apply_mask_sample_filter,
     _apply_message_level_advantage_penalties,
+    _calculate_observed_pass_metrics,
     _default_grpo_save_state,
     _initial_policy_generation_stale,
     _raise_if_reward_penalties_enabled_without_nemo_gym,

--- a/tests/unit/models/generation/trtllm/test_trtllm_http_server.py
+++ b/tests/unit/models/generation/trtllm/test_trtllm_http_server.py
@@ -129,7 +129,7 @@ def _tool_call_messages():
 def _parse_with_trtllm(messages):
     chat_utils = pytest.importorskip("tensorrt_llm.serve.chat_utils")
     transformers = pytest.importorskip("transformers")
-    conversation, mm_coroutine, _ = chat_utils.parse_chat_messages_coroutines(
+    conversation, mm_coroutine, *_ = chat_utils.parse_chat_messages_coroutines(
         messages, transformers.PretrainedConfig()
     )
     assert asyncio.run(mm_coroutine) == (None, None)


### PR DESCRIPTION
## Summary

`opt/dev-backup` is being retired. A commit-by-commit audit of the 104
backup-only commits classified them as **39 already in `opt/dev`**, **23 drop**,
**42 missing**.

Of those 42 missing commits, **38 are @michal2409's** and are covered by his own
PR #3364 (merged into `opt/dev` 2026-07-29) — his work is his to migrate, so all
of it is excluded here. Authorship over the 42: 38 `mfutrega@*`, 2 Erin Ho,
1 shuyixiong, 1 Yan Chunwei.

**This PR is therefore 3 commits, not 42.** All three fix live bugs in `opt/dev` today.

## Live bugs fixed

- **nsys profiling crashes the TRT-LLM backend** (143c1d784, Erin Ho) —
  `TrtllmGeneration.start/stop_gpu_profiling` read `self.async_engine`
  (`trtllm_generation.py:451,461`) but `__init__` never assigned it →
  `AttributeError` on any nsys run.
- **rc22 chat-parser breakage** (68a87ab84, Erin Ho) —
  `trtllm_http_server.py:142` (and its unit test) still 3-tuple-unpacked
  `parse_chat_messages_coroutines`, which silently breaks against TRT-LLM ≥ rc22.
  This matters more now that #3434 bumped TRT-LLM to rc23.
- **NeMo Gym venv prefetch missing** (ae3c7555c, #3409) — per-node Gym venv
  prefetch and the env-overridable `PY_EXECUTABLES.TRTLLM` were absent;
  `virtual_cluster.py` still hardcoded the TRT-LLM executable.

A fourth commit fixes pre-existing ruff import-sort violations in `nemo_gym.py`
and `test_grpo.py` so the repo-wide Lint check passes.

**Dropped since the first revision:** the editable TRT-LLM build support
(partial pick of shuyixiong's 548407608). @shuyixiong landed that work himself
in #3434 (`Support editable trtllm and bump trtllm to 1.3.0rc23`), which is now
in `opt/dev` — re-landing an author's own work behind him would only conflict.
This branch has been rebased onto that new `opt/dev` head; it no longer touches
`nemo_rl/utils/venvs.py` or `tools/`.

Each pick carries backup provenance (`-x`) and DCO sign-off (`-s`).

## Explicitly out of scope

Named so nothing is silently dropped — all @michal2409's, all deferred to him:

- The Qwen3.5-397B MLPerf recipe tree (34 commits): `qwen_35/`, `docker/mlperf/`,
  `examples/nemo_gym/launch_qwen35_*.sh`, `nemo_rl/algorithms/mlperf_grpo_logging.py`.
- `da8e1882c` (`ray.sub` IPv4-only), `4a910e9c6` + `d9c9d614a` + `b74096869`
  (`NRL_NCCL_TIMEOUT_MINUTES` / mcore sub-group timeout / flight-recorder dumps).
- All 23 `drop` commits and the 39 already landed.

The full 104-row ledger lives in the branch-status worknote memory
(`nemorl-dev-opt-branch-status.memory/tasks/task-1.md`).

## Known-red check: `Lint check`

`Lint check` fails on this PR, but **not on anything this PR touches**. The three
offending files are `nemo_rl/utils/venvs.py`, `pyproject.toml`, and
`3rdparty/TensorRT-LLM-workspace/pyproject.toml` — all byte-identical here to
`origin/opt/dev`. The violations arrived with #3434 and are present on `opt/dev`
itself; this branch neither introduces nor inherits responsibility for them.

Reproduce against the base alone, no PR content involved:

```bash
git show origin/opt/dev:nemo_rl/utils/venvs.py > /tmp/base_venvs.py
uvx ruff@0.9.9 format --check /tmp/base_venvs.py   # -> Would reformat
uvx ruff@0.9.9 check --select D205 /tmp/base_venvs.py  # -> 3 errors
```

Deliberately not fixed here: those files belong to @shuyixiong via #3434, and
patching them would re-add `venvs.py` to this diff — the exact overlap this
revision exists to remove. The lint fixup commit in this PR does clear the
violations that *are* in scope (`nemo_gym.py`, `test_grpo.py`); they no longer
appear in the lint output. `Lint check` needs a conscious waive by the reviewer,
or a separate fix on `opt/dev`, to go green.

## Test plan

- [ ] `uv run pytest tests/unit/models/generation/trtllm/test_trtllm_http_server.py`
- [ ] ruff / ruff-format clean on all touched files (verified locally)
- [ ] CI green (`/ok to test`)
- [ ] No cluster validation — this PR is not functionally exercised on hardware.
