### PR TITLE
docs(ultra): remove obsolete v5->v4 checkpoint conversion section

### DIFF
--- a/docs/guides/nemotron-3-ultra.md
+++ b/docs/guides/nemotron-3-ultra.md
@@ -156,29 +156,6 @@ git clone --recursive -b main https://github.com/NVIDIA-NeMo/RL.git
 cd RL
 ```
 
-## Prepare the starting checkpoint
-
-If your starting checkpoint comes from Hugging Face or is the result of SFT with
-Megatron-Bridge, it is a **transformers v5** checkpoint. NeMo RL runs an older
-**transformers v4**, so convert the checkpoint to a v4-compatible version before
-using it as `MODEL_PATH`.
-
-The converter rewrites `config.json`, adds the v4 modeling files, and symlinks
-the weight shards back to the source checkpoint.
-
-```bash
-python examples/converters/ultra/convert_ultra_ckpt_t5_to_t4.py \
-  --source /path/to/ultra_sft_checkpoint_v5 \
-  --output /path/to/ultra_sft_checkpoint_v4 \
-  --force
-```
-
-Use the converted directory (`/path/to/ultra_sft_checkpoint_v4`) as `MODEL_PATH`
-in the launch commands below. The converter copies the bundled v4 NemotronH
-modeling files (`configuration_nemotron_h.py` / `modeling_nemotron_h.py` in `examples/converters/ultra/`) into the output
-automatically (the default `--runtime-source`); pass `--runtime-source <dir>` to
-override.
-
 ## Build the sandbox container
 
 Several [Gym](https://github.com/NVIDIA-NeMo/Gym) environments used during


### PR DESCRIPTION
# What does this PR do ?

Main now runs transformers v5, so the starting checkpoint no longer needs converting to v4 before use as MODEL_PATH. The section also referenced `examples/converters/ultra/convert_ultra_ckpt_t5_to_t4.py`, which does not exist on main.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
