### PR TITLE
refactor(vllm): defer HTTP server imports in async worker

### DIFF
--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -20,12 +20,14 @@ import threading
 import time
 import uuid
 import warnings
-from typing import Any, AsyncGenerator, Optional, cast
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Optional, cast
 
 import ray
 import torch
-import uvicorn
-from fastapi import FastAPI
+
+if TYPE_CHECKING:
+    import uvicorn
+    from fastapi import FastAPI
 
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.virtual_cluster import (
@@ -345,7 +347,7 @@ class VllmAsyncGenerationWorkerImpl(
         return self.base_url
 
     # ruff: noqa
-    def _setup_vllm_openai_api_server(self, app: FastAPI) -> FastAPI:
+    def _setup_vllm_openai_api_server(self, app: "FastAPI") -> "FastAPI":
         from copy import deepcopy
         from logging import Filter as LoggingFilter
         from logging import LogRecord


### PR DESCRIPTION
## What does this PR do?

Defers the direct `fastapi` and `uvicorn` imports in `vllm_worker_async.py` until the HTTP server is actually created.

This is a small import-layering cleanup, not a claim that `nemo_rl.algorithms.grpo` can run without those packages: other import paths still load them today. #3552 carries this change together with the broader fixes that produce the measurable GRPO import improvement.

## Testing

- Added a runtime regression that reloads the async worker and records its direct imports, failing if `fastapi` or `uvicorn` moves back to module scope
- `ruff`, formatting, and `git diff --check` pass

Superseded by #3552, so I am closing this focused version.

cc @RayenTian @yuki-97
