### PR TITLE
fix: missing input validation for dataset_name in

### DIFF
--- a/nemo_rl/data/datasets/preference_datasets/__init__.py
+++ b/nemo_rl/data/datasets/preference_datasets/__init__.py
@@ -48,6 +48,10 @@ def load_preference_dataset(data_config: PreferenceDatasetConfig):
        without editing ``nemo_rl``.
     3. Otherwise, raise ``ValueError`` with a helpful message.
     """
+    if "dataset_name" not in data_config:
+        raise ValueError(
+            "PreferenceDatasetConfig must contain a 'dataset_name' key."
+        )
     dataset_name = data_config["dataset_name"]
 
     # load dataset

--- a/nemo_rl/data/datasets/preference_datasets/__init__.py
+++ b/nemo_rl/data/datasets/preference_datasets/__init__.py
@@ -52,6 +52,10 @@ def load_preference_dataset(data_config: PreferenceDatasetConfig):
         raise ValueError(
             "PreferenceDatasetConfig must contain a 'dataset_name' key."
         )
+    if "dataset_name" not in data_config:
+        raise ValueError(
+            "PreferenceDatasetConfig must contain a 'dataset_name' key."
+        )
     dataset_name = data_config["dataset_name"]
 
     # load dataset

--- a/nemo_rl/data/datasets/preference_datasets/__init__.py
+++ b/nemo_rl/data/datasets/preference_datasets/__init__.py
@@ -56,6 +56,10 @@ def load_preference_dataset(data_config: PreferenceDatasetConfig):
         raise ValueError(
             "PreferenceDatasetConfig must contain a 'dataset_name' key."
         )
+    if "dataset_name" not in data_config:
+        raise ValueError(
+            "PreferenceDatasetConfig must contain a 'dataset_name' key."
+        )
     dataset_name = data_config["dataset_name"]
 
     # load dataset

--- a/tests/test_preference_datasets_init.py
+++ b/tests/test_preference_datasets_init.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from nemo_rl.data.datasets.preference_datasets import load_preference_dataset
+
+
+class TestLoadPreferenceDataset(unittest.TestCase):
+    def test_missing_dataset_name_raises_valueerror(self):
+        """A missing dataset_name must raise a clear ValueError, not KeyError."""
+        with self.assertRaisesRegex(ValueError, "dataset_name"):
+            load_preference_dataset({})
+
+

--- a/tests/test_preference_datasets_init.py
+++ b/tests/test_preference_datasets_init.py
@@ -24,3 +24,31 @@ class TestLoadPreferenceDataset(unittest.TestCase):
             load_preference_dataset({})
 
 
+if __name__ == "__main__":
+    unittest.main()
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from nemo_rl.data.datasets.preference_datasets import load_preference_dataset
+
+
+class TestLoadPreferenceDataset(unittest.TestCase):
+    def test_missing_dataset_name_raises_valueerror(self):
+        """A missing dataset_name must raise a clear ValueError, not KeyError."""
+        with self.assertRaisesRegex(ValueError, "dataset_name"):
+            load_preference_dataset({})
+
+

--- a/tests/test_preference_datasets_init.py
+++ b/tests/test_preference_datasets_init.py
@@ -52,3 +52,31 @@ class TestLoadPreferenceDataset(unittest.TestCase):
             load_preference_dataset({})
 
 
+if __name__ == "__main__":
+    unittest.main()
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from nemo_rl.data.datasets.preference_datasets import load_preference_dataset
+
+
+class TestLoadPreferenceDataset(unittest.TestCase):
+    def test_missing_dataset_name_raises_valueerror(self):
+        """A missing dataset_name must raise a clear ValueError, not KeyError."""
+        with self.assertRaisesRegex(ValueError, "dataset_name"):
+            load_preference_dataset({})
+
+


### PR DESCRIPTION
This PR addresses the following issue in `nemo_rl/data/datasets/preference_datasets/__init__.py`: missing input validation for dataset_name in.

## Changes
- `nemo_rl/data/datasets/preference_datasets/__init__.py`: missing input validation for dataset_name in.

## Details
```diff
--- a/nemo_rl/data/datasets/preference_datasets/__init__.py
+++ b/nemo_rl/data/datasets/preference_datasets/__init__.py
@@ -1,1 +1,5 @@
-    dataset_name = data_config["dataset_name"]
+    if "dataset_name" not in data_config:
+        raise ValueError(
+            "PreferenceDatasetConfig must contain a 'dataset_name' key."
+        )
+    dataset_name = data_config["dataset_name"]
```

## Tests
- `tests/test_preference_datasets_init.py`

```diff
--- /dev/null
+++ b/tests/test_preference_datasets_init.py
@@ -0,0 +1,26 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from nemo_rl.data.datasets.preference_datasets import load_preference_dataset
+
+
+class TestLoadPreferenceDataset(unittest.TestCase):
+    def test_missing_dataset_name_raises_valueerror(self):
+        """A missing dataset_name must raise a clear ValueError, not KeyError."""
+        with self.assertRaisesRegex(ValueError, "dataset_name"):
+            load_preference_dataset({})
+
+
+if __name__ == "__main__":
+    unittest.main()
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).