### PR TITLE
fix: missing test: unsupported dataset_name raises ValueError

### DIFF
--- a/test_preference_datasets_init.py
+++ b/test_preference_datasets_init.py
@@ -1,0 +1,16 @@
+"""Regression tests for nemo_rl.data.datasets.preference_datasets."""
+
+from __future__ import annotations
+
+import pytest
+
+from nemo_rl.data.datasets.preference_datasets import load_preference_dataset
+
+
+def test_load_preference_dataset_raises_for_unsupported_name():
+    config = {"dataset_name": "UnknownDataset"}
+    with pytest.raises(
+        ValueError,
+        match="Unsupported dataset_name='UnknownDataset'",
+    ):
+        load_preference_dataset(config)


### PR DESCRIPTION
This PR addresses the following issue in `nemo_rl/data/datasets/preference_datasets/__init__.py`: missing test: unsupported dataset_name raises ValueError.

## Changes
- `nemo_rl/data/datasets/preference_datasets/__init__.py`: missing test: unsupported dataset_name raises ValueError.

## Details
```diff
--- /dev/null
+++ b/tests/test_preference_datasets_init.py
@@ -0,0 +1,16 @@
+"""Regression tests for nemo_rl.data.datasets.preference_datasets."""
+
+from __future__ import annotations
+
+import pytest
+
+from nemo_rl.data.datasets.preference_datasets import load_preference_dataset
+
+
+def test_load_preference_dataset_raises_for_unsupported_name():
+    config = {"dataset_name": "UnknownDataset"}
+    with pytest.raises(
+        ValueError,
+        match="Unsupported dataset_name='UnknownDataset'",
+    ):
+        load_preference_dataset(config)
```

## Tests
- `tests/test_preference_datasets_init.py`

```diff
--- /dev/null
+++ b/tests/test_preference_datasets_init.py
@@ -0,0 +1,16 @@
+"""Regression tests for nemo_rl.data.datasets.preference_datasets."""
+
+from __future__ import annotations
+
+import pytest
+
+from nemo_rl.data.datasets.preference_datasets import load_preference_dataset
+
+
+def test_load_preference_dataset_raises_for_unsupported_name():
+    config = {"dataset_name": "UnknownDataset"}
+    with pytest.raises(
+        ValueError,
+        match="Unsupported dataset_name='UnknownDataset'",
+    ):
+        load_preference_dataset(config)
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).