### PR TITLE
fix: missing test: dotted-path dataset class resolution

### DIFF
--- a/tests/test_preference_datasets_init.py
+++ b/tests/test_preference_datasets_init.py
@@ -1,0 +1,23 @@
+"""Regression tests for custom preference dataset resolution."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nemo_rl.data.datasets.preference_datasets import load_preference_dataset
+
+
+def test_load_preference_dataset_resolves_external_dotted_path(monkeypatch):
+    config = {"dataset_name": "my_module.MyDataset", "data_path": "dummy.jsonl"}
+    mock_cls = MagicMock()
+    monkeypatch.setattr(
+        "nemo_rl.data.datasets.preference_datasets.resolve_external_dataset_class",
+        lambda name: mock_cls,
+    )
+
+    dataset = load_preference_dataset(config)
+
+    mock_cls.assert_called_once_with(**config)
+    mock_cls.return_value.set_task_spec.assert_called_once_with(config)


### PR DESCRIPTION
This PR addresses the following issue in `nemo_rl/data/datasets/preference_datasets/__init__.py`: missing test: dotted-path dataset class resolution.

## Changes
- `nemo_rl/data/datasets/preference_datasets/__init__.py`: missing test: dotted-path dataset class resolution.

## Details
```diff
--- /dev/null
+++ b/tests/test_preference_datasets_init.py
@@ -0,0 +1,23 @@
+"""Regression tests for custom preference dataset resolution."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nemo_rl.data.datasets.preference_datasets import load_preference_dataset
+
+
+def test_load_preference_dataset_resolves_external_dotted_path(monkeypatch):
+    config = {"dataset_name": "my_module.MyDataset", "data_path": "dummy.jsonl"}
+    mock_cls = MagicMock()
+    monkeypatch.setattr(
+        "nemo_rl.data.datasets.preference_datasets.resolve_external_dataset_class",
+        lambda name: mock_cls,
+    )
+
+    dataset = load_preference_dataset(config)
+
+    mock_cls.assert_called_once_with(**config)
+    mock_cls.return_value.set_task_spec.assert_called_once_with(config)
+    assert dataset == mock_cls.return_value
```

## Tests
- `tests/test_preference_datasets_init.py`

```diff
--- /dev/null
+++ b/tests/test_preference_datasets_init.py
@@ -0,0 +1,23 @@
+"""Regression tests for custom preference dataset resolution."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nemo_rl.data.datasets.preference_datasets import load_preference_dataset
+
+
+def test_load_preference_dataset_resolves_external_dotted_path(monkeypatch):
+    config = {"dataset_name": "my_module.MyDataset", "data_path": "dummy.jsonl"}
+    mock_cls = MagicMock()
+    monkeypatch.setattr(
+        "nemo_rl.data.datasets.preference_datasets.resolve_external_dataset_class",
+        lambda name: mock_cls,
+    )
+
+    dataset = load_preference_dataset(config)
+
+    mock_cls.assert_called_once_with(**config)
+    mock_cls.return_value.set_task_spec.assert_called_once_with(config)
+    assert dataset == mock_cls.return_value
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).