### PR TITLE
fix: pil_to_base64 hardcodes PNG MIME type regardless of format

### DIFF
--- a/nemo_rl/data/datasets/utils.py
+++ b/nemo_rl/data/datasets/utils.py
@@ -91,7 +91,8 @@ def pil_to_base64(image: Image.Image, format: str = "PNG") -> str:
     buffered = io.BytesIO()
     image.save(buffered, format=format)
     img_str = base64.b64encode(buffered.getvalue()).decode("utf-8")
-    return f"data:image/png;base64,{img_str}"
+    mime_type = format.lower() if format else "png"
+    return f"data:image/{mime_type};base64,{img_str}"
 
 
 def load_dataset_from_path(

--- a/tests/test_pil_to_base64.py
+++ b/tests/test_pil_to_base64.py
@@ -1,0 +1,17 @@
+import pytest
+from PIL import Image
+
+from nemo_rl.data.datasets.utils import pil_to_base64
+
+
+def test_pil_to_base64_mime_type_matches_format():
+    """The data URI MIME type must match the requested image format."""
+    img = Image.new("RGB", (2, 2), color="red")
+
+    bmp_uri = pil_to_base64(img, "BMP")
+    assert bmp_uri.startswith("data:image/bmp;base64,"), bmp_uri
+
+    png_uri = pil_to_base64(img, "PNG")
+    assert png_uri.startswith("data:image/png;base64,"), png_uri
+
+    jpeg_uri = pil_to_base64(img, "JPEG")


### PR DESCRIPTION
This PR addresses the following issue in `nemo_rl/data/datasets/utils.py`: pil_to_base64 hardcodes PNG MIME type regardless of format.

## Changes
- `nemo_rl/data/datasets/utils.py`: pil_to_base64 hardcodes PNG MIME type regardless of format.

## Details
```diff
--- a/nemo_rl/data/datasets/utils.py
+++ b/nemo_rl/data/datasets/utils.py
@@ -1,2 +1,3 @@
-    img_str = base64.b64encode(buffered.getvalue()).decode("utf-8")
-    return f"data:image/png;base64,{img_str}"
+    img_str = base64.b64encode(buffered.getvalue()).decode("utf-8")
+    mime_type = format.lower() if format else "png"
+    return f"data:image/{mime_type};base64,{img_str}"
```

## Tests
- `tests/test_pil_to_base64.py`

```diff
--- /dev/null
+++ b/tests/test_pil_to_base64.py
@@ -0,0 +1,17 @@
+import pytest
+from PIL import Image
+
+from nemo_rl.data.datasets.utils import pil_to_base64
+
+
+def test_pil_to_base64_mime_type_matches_format():
+    """The data URI MIME type must match the requested image format."""
+    img = Image.new("RGB", (2, 2), color="red")
+
+    bmp_uri = pil_to_base64(img, "BMP")
+    assert bmp_uri.startswith("data:image/bmp;base64,"), bmp_uri
+
+    png_uri = pil_to_base64(img, "PNG")
+    assert png_uri.startswith("data:image/png;base64,"), png_uri
+
+    jpeg_uri = pil_to_base64(img, "JPEG")
+    assert jpeg_uri.startswith("data:image/jpeg;base64,"), jpeg_uri
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).