### PR TITLE
fix: stale function name in no-BOS tokenizer message

### DIFF
--- a/nemo_rl/data/datasets/utils.py
+++ b/nemo_rl/data/datasets/utils.py
@@ -75,7 +75,7 @@ def assert_no_double_bos(token_ids: torch.Tensor, tokenizer: TokenizerType) -> N
             ), "Found double BOS token in the first two positions of the message."
     else:
         name = getattr(_tok, "name_or_path", str(type(_tok).__name__))
-        print(f"skip assert_start_single_bos since Tokenizer {name} has no BOS token")
+        print(f"skip assert_no_double_bos since Tokenizer {name} has no BOS token")
 
 
 def pil_to_base64(image: Image.Image, format: str = "PNG") -> str:

--- a/tests/data/test_assert_no_double_bos.py
+++ b/tests/data/test_assert_no_double_bos.py
@@ -1,0 +1,21 @@
+import io
+from unittest.mock import patch
+
+from nemo_rl.data.datasets.utils import assert_no_double_bos
+
+
+def test_assert_no_double_bos_message_uses_correct_function_name():
+    tokenizer = type(
+        "Tokenizer",
+        (),
+        {
+            "tokenizer": type(
+                "InnerTokenizer", (), {"bos_token_id": None, "name_or_path": "dummy"}
+            )()
+        },
+    )()
+    token_ids = type("Tensor", (), {"tolist": lambda self: [1, 2]})()
+
+    with patch("sys.stdout", new_callable=io.StringIO) as captured:
+        assert_no_double_bos(token_ids, tokenizer)
+


### PR DESCRIPTION
This PR addresses the following issue in `nemo_rl/data/datasets/utils.py`: stale function name in no-BOS tokenizer message.

## Changes
- `nemo_rl/data/datasets/utils.py`: stale function name in no-BOS tokenizer message.

## Details
```diff
--- a/nemo_rl/data/datasets/utils.py
+++ b/nemo_rl/data/datasets/utils.py
@@ -1,3 +1,3 @@
-    else:
-        name = getattr(_tok, "name_or_path", str(type(_tok).__name__))
-        print(f"skip assert_start_single_bos since Tokenizer {name} has no BOS token")
+    else:
+        name = getattr(_tok, "name_or_path", str(type(_tok).__name__))
+        print(f"skip assert_no_double_bos since Tokenizer {name} has no BOS token")
```

## Tests
- `tests/data/test_assert_no_double_bos.py`

```diff
--- /dev/null
+++ b/tests/data/test_assert_no_double_bos.py
@@ -0,0 +1,21 @@
+import io
+from unittest.mock import patch
+
+from nemo_rl.data.datasets.utils import assert_no_double_bos
+
+
+def test_assert_no_double_bos_message_uses_correct_function_name():
+    tokenizer = type(
+        "Tokenizer",
+        (),
+        {
+            "tokenizer": type(
+                "InnerTokenizer", (), {"bos_token_id": None, "name_or_path": "dummy"}
+            )()
+        },
+    )()
+    token_ids = type("Tensor", (), {"tolist": lambda self: [1, 2]})()
+
+    with patch("sys.stdout", new_callable=io.StringIO) as captured:
+        assert_no_double_bos(token_ids, tokenizer)
+
+    assert "assert_no_double_bos" in captured.getvalue()
+    assert "assert_start_single_bos" not in captured.getvalue()
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).