### PR TITLE
fix: FILEEXT2TYPE recreated on every load_dataset_from_path call

### DIFF
--- a/nemo_rl/data/datasets/utils.py
+++ b/nemo_rl/data/datasets/utils.py
@@ -38,6 +38,15 @@ from transformers import AutoProcessor, PreTrainedTokenizerBase
 
 TokenizerType = Union[PreTrainedTokenizerBase, AutoProcessor]
 
+FILEEXT2TYPE = {
+    ".arrow": "arrow",
+    ".csv": "csv",
+    ".json": "json",
+    ".jsonl": "json",
+    ".parquet": "parquet",
+    ".txt": "text",
+}
+
 
 def load_audio_from_file(path: str, sampling_rate: int = 16000) -> np.ndarray:
     """Decode an audio file (or the audio track of a video) as a 1-D float32 array."""
@@ -106,14 +115,6 @@ def load_dataset_from_path(
         data_subset: The subset to load from the dataset. Only supported for huggingface datasets.
         data_split: The split to load from the dataset.
     """
-    FILEEXT2TYPE = {
-        ".arrow": "arrow",
-        ".csv": "csv",
-        ".json": "json",
-        ".jsonl": "json",
-        ".parquet": "parquet",
-        ".txt": "text",
-    }
     suffix = os.path.splitext(data_path)[-1]
     # load from local file (not save_to_disk format)
     if dataset_type := FILEEXT2TYPE.get(suffix):


### PR DESCRIPTION
This PR addresses the following issue in `nemo_rl/data/datasets/utils.py`: FILEEXT2TYPE recreated on every load_dataset_from_path call.

## Changes
- `nemo_rl/data/datasets/utils.py`: FILEEXT2TYPE recreated on every load_dataset_from_path call.

## Details
```diff
--- a/nemo_rl/data/datasets/utils.py
+++ b/nemo_rl/data/datasets/utils.py
@@ -27,4 +27,13 @@ from transformers import AutoProcessor, PreTrainedTokenizerBase
 
 TokenizerType = Union[PreTrainedTokenizerBase, AutoProcessor]
 
+FILEEXT2TYPE = {
+    ".arrow": "arrow",
+    ".csv": "csv",
+    ".json": "json",
+    ".jsonl": "json",
+    ".parquet": "parquet",
+    ".txt": "text",
+}
+
 
 def load_audio_from_file(path: str, sampling_rate: int = 16000) -> np.ndarray:
     """Decode an audio file (or the audio track of a video) as a 1-D float32 array."""
@@ -73,21 +82,13 @@ def load_dataset_from_path(
     """Load a dataset from a local file, huggingface dataset, or Arrow dataset (saved with save_to_disk).
 
     Args:
         data_path: The path to the dataset.
         data_subset: The subset to load from the dataset. Only supported for huggingface datasets.
         data_split: The split to load from the dataset.
     """
-    FILEEXT2TYPE = {
-        ".arrow": "arrow",
-        ".csv": "csv",
-        ".json": "json",
-        ".jsonl": "json",
-        ".parquet": "parquet",
-        ".txt": "text",
-    }
     suffix = os.path.splitext(data_path)[-1]
```

## Tests
- `tests/data/test_datasets_utils.py`

```diff
--- /dev/null
+++ b/tests/data/test_datasets_utils.py
@@ -0,0 +1,9 @@
+from nemo_rl.data.datasets import utils
+
+
+def test_file_extension_type_lookup_is_module_level_constant():
+    assert hasattr(utils, "FILEEXT2TYPE")
+    assert utils.FILEEXT2TYPE[".jsonl"] == "json"
+    assert utils.FILEEXT2TYPE[".parquet"] == "parquet"
+    assert utils.FILEEXT2TYPE[".arrow"] == "arrow"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).