### PR TITLE
fix: empty pattern list falls back to defaults instead of disabling

### DIFF
--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -131,9 +131,13 @@ def _detect_invalid_tool_call_and_malformed_thinking(
         (is_invalid_tool_call, has_malformed_thinking).
     """
     invalid_tool_call_patterns = (
-        invalid_tool_call_patterns or DEFAULT_INVALID_TOOL_CALL_PATTERNS
+        DEFAULT_INVALID_TOOL_CALL_PATTERNS
+        if invalid_tool_call_patterns is None
+        else invalid_tool_call_patterns
     )
-    thinking_tags = thinking_tags or DEFAULT_THINKING_TAGS
+    thinking_tags = (
+        DEFAULT_THINKING_TAGS if thinking_tags is None else thinking_tags
+    )
 
     is_output_message = (
         "content" in output_item_dict


### PR DESCRIPTION
This PR addresses the following issue in `nemo_rl/environments/nemo_gym.py`: empty pattern list falls back to defaults instead of disabling.

## Changes
- `nemo_rl/environments/nemo_gym.py`: empty pattern list falls back to defaults instead of disabling.

## Details
```diff
--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -1,4 +1,8 @@
-    invalid_tool_call_patterns = (
-        invalid_tool_call_patterns or DEFAULT_INVALID_TOOL_CALL_PATTERNS
-    )
-    thinking_tags = thinking_tags or DEFAULT_THINKING_TAGS
+    invalid_tool_call_patterns = (
+        DEFAULT_INVALID_TOOL_CALL_PATTERNS
+        if invalid_tool_call_patterns is None
+        else invalid_tool_call_patterns
+    )
+    thinking_tags = (
+        DEFAULT_THINKING_TAGS if thinking_tags is None else thinking_tags
+    )
```

## Tests
- `tests/unit/environments/test_nemo_gym.py`

```diff
--- /dev/null
+++ b/tests/unit/environments/test_nemo_gym.py
@@ -0,0 +1,45 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for nemo_rl.environments.nemo_gym helpers."""
+
+import pytest
+
+from nemo_rl.environments.nemo_gym import (
+    DEFAULT_INVALID_TOOL_CALL_PATTERNS,
+    DEFAULT_THINKING_TAGS,
+    _detect_invalid_tool_call_and_malformed_thinking,
+)
+
+
+def test_explicit_empty_invalid_tool_call_patterns_disable_detection():
+    pattern = DEFAULT_INVALID_TOOL_CALL_PATTERNS[0]
+    output_item = {"content": [{"text": f"hello {pattern} world"}]}
+    with_defaults, _ = _detect_invalid_tool_call_and_malformed_thinking(
+        output_item,
+        invalid_tool_call_patterns=DEFAULT_INVALID_TOOL_CALL_PATTERNS,
+        thinking_tags=[],
+    )
+    assert with_defaults is True
+    with_empty, _ = _detect_invalid_tool_call_and_malformed_thinking(
+        output_item, invalid_tool_call_patterns=[], thinking_tags=[]
+    )
+    assert with_empty is False
+
+
+def test_explicit_empty_thinking_tags_disable_malformed_thinking_detection():
+    tag = DEFAULT_THINKING_TAGS[0]
+    output_item = {"content": [{"text": f"hello {tag} world"}]}
+    _, with_defaults = _detect_invalid_tool_call_and_malformed_thinking(
+        output_item,
+        invalid_tool_call_patterns=[],
+        thinking_tags=DEFAULT_THINKING_TAGS,
+    )
+    assert with_defaults is True
+    _, with_empty = _detect_invalid_tool_call_and_malformed_thinking(
+        output_item, invalid_tool_call_patterns=[], thinking_tags=[]
+    )
+    assert with_empty is False
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).