### PR TITLE
fix: validate_reward_components_match_scalar reads reward without

### DIFF
--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -587,6 +587,11 @@ def validate_reward_components_match_scalar(nemo_gym_results: List[dict]) -> Non
                 f"NeMo Gym verify result {idx} declares reward_components but "
                 "is missing the scalar reward field required for validation."
             )
+        if "reward" not in result:
+            raise ValueError(
+                f"NeMo Gym verify result {idx} declares reward_components but "
+                "is missing the scalar reward field required for validation."
+            )
         scalar_reward = float(result["reward"])
         component_sum = sum(components.values())
         if not math.isclose(scalar_reward, component_sum, rel_tol=1e-5, abs_tol=1e-6):

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -582,6 +582,11 @@ def validate_reward_components_match_scalar(nemo_gym_results: List[dict]) -> Non
         components = extract_reward_components(result)
         if components is None:
             continue
+        if "reward" not in result:
+            raise ValueError(
+                f"NeMo Gym verify result {idx} declares reward_components but "
+                "is missing the scalar reward field required for validation."
+            )
         scalar_reward = float(result["reward"])
         component_sum = sum(components.values())
         if not math.isclose(scalar_reward, component_sum, rel_tol=1e-5, abs_tol=1e-6):

--- a/tests/unit/environments/test_nemo_gym.py
+++ b/tests/unit/environments/test_nemo_gym.py
@@ -11,6 +11,31 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Unit tests for nemo_rl/environments/nemo_gym.py helpers."""
+
+import pytest
+
+from nemo_rl.environments.nemo_gym import validate_reward_components_match_scalar
+
+
+def test_validate_reward_components_match_scalar_missing_reward():
+    result = {"reward_components": {"a": 1.0}}
+    with pytest.raises(ValueError, match="missing the scalar reward field"):
+        validate_reward_components_match_scalar([result])
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import json
 import time
 from copy import deepcopy


### PR DESCRIPTION
This PR addresses the following issue in `nemo_rl/environments/nemo_gym.py`: validate_reward_components_match_scalar reads reward without.

## Changes
- `nemo_rl/environments/nemo_gym.py`: validate_reward_components_match_scalar reads reward without.

## Details
```diff
--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -1,1 +1,6 @@
-        scalar_reward = float(result["reward"])
+        if "reward" not in result:
+            raise ValueError(
+                f"NeMo Gym verify result {idx} declares reward_components but "
+                "is missing the scalar reward field required for validation."
+            )
+        scalar_reward = float(result["reward"])
```

## Tests
- `tests/unit/environments/test_nemo_gym.py`

```diff
--- /dev/null
+++ b/tests/unit/environments/test_nemo_gym.py
@@ -0,0 +1,35 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for nemo_rl/environments/nemo_gym.py helpers."""
+
+import pytest
+
+from nemo_rl.environments.nemo_gym import validate_reward_components_match_scalar
+
+
+def test_validate_reward_components_match_scalar_missing_reward():
+    result = {"reward_components": {"a": 1.0}}
+    with pytest.raises(ValueError, match="missing the scalar reward field"):
+        validate_reward_components_match_scalar([result])
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).