### PR TITLE
feat(vllm): route NeMo-Gym rollouts through vLLM Router

### DIFF
--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -544,7 +544,7 @@ def setup(
                     nemo_gym_dict.setdefault("uv_venv_dir", uv_venv_dir)
                 nemo_gym_cfg = NemoGymConfig(
                     model_name=generation_config["model_name"],
-                    base_urls=deferred_vllm.dp_openai_server_base_urls,
+                    base_urls=deferred_vllm.openai_server_base_urls(),
                     invalid_tool_call_patterns=invalid_tool_call_patterns,
                     thinking_tags=thinking_tags,
                     use_fastokens=bool(policy_config["tokenizer"].get("use_fastokens")),

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1211,7 +1211,7 @@ def setup(
             def init_nemo_gym():
                 """Spin up NeMo Gym servers with the pre-assigned vLLM URLs."""
                 return _spinup_nemo_gym(
-                    deferred_vllm.dp_openai_server_base_urls,
+                    deferred_vllm.openai_server_base_urls(),
                     generation_config["model_name"],
                 )
 

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -394,7 +394,7 @@ def setup_single_controller(
         )
         env_handles["nemo_gym"] = spinup_nemo_gym_actor(
             env_configs=master_config.env,
-            base_urls=generation.dp_openai_server_base_urls,
+            base_urls=generation.openai_server_base_urls(),
             model_name=generation_config["model_name"],
             enable_router_replay=enable_router_replay,
             routed_experts_dtype=routed_experts_dtype,

--- a/nemo_rl/models/generation/vllm/config.py
+++ b/nemo_rl/models/generation/vllm/config.py
@@ -43,7 +43,7 @@ class VllmSpecificArgs(TypedDict):
     use_tqdm: NotRequired[bool]
     # By default, NeMo RL only has a Python handle to the vllm.LLM generation engine. The expose_http_server flag here will expose that generation engine as an HTTP server.
     # Exposing vLLM as a server is useful in instances where the multi-turn rollout is performed with utilities outside of NeMo RL, but the user still wants to take advantage of the refit logic in NeMo RL that keeps the policy and generation up to date.
-    # Currently it will expose the /tokenize and /v1/chat/completions endpoints. Later on we may expose /v1/completions or /v1/responses.
+    # It exposes /tokenize, /v1/chat/completions, and /v1/completions.
     expose_http_server: NotRequired[bool]
     # Environment variable containing the internal refit API key.
     http_refit_api_key_env_var: NotRequired[str | None]
@@ -62,6 +62,10 @@ class VllmSpecificArgs(TypedDict):
     env_vars: NotRequired[dict[str, str]]
     # A filepath that can be imported to register a vLLM reasoning parser
     reasoning_parser_plugin: NotRequired[str]
+    # Optional external vLLM Router origin (or origin/v1). Ray still owns
+    # worker lifecycle/refit; rollout requests use this endpoint when set.
+    router_url: NotRequired[str]
+    router_request_id_header: NotRequired[str]
 
 
 class VllmDeltaCompressionConfig(BaseModel, extra="allow"):

--- a/nemo_rl/models/generation/vllm/vllm_generation.py
+++ b/nemo_rl/models/generation/vllm/vllm_generation.py
@@ -102,6 +102,7 @@ class VllmGeneration(GenerationInterface):
         """
         # Store config
         self.cfg = config
+        self.router_url = self.cfg["vllm_cfg"].get("router_url")
         self._defer_model_load = defer_model_load
         self.weight_synchronizer: WeightSynchronizer | None = None
         self.tp_size = self.cfg["vllm_cfg"]["tensor_parallel_size"]
@@ -274,6 +275,13 @@ class VllmGeneration(GenerationInterface):
             self.device_uuids = self._report_device_id()
 
         self._step_metrics_snapshot: dict[str | tuple[str, int], float] | None = None
+
+    def openai_server_base_urls(self) -> list[str | None]:
+        """Return the endpoint used by HTTP-based rollout environments."""
+        if self.router_url:
+            base_url = self.router_url.rstrip("/")
+            return [base_url if base_url.endswith("/v1") else f"{base_url}/v1"]
+        return self.dp_openai_server_base_urls
 
     def _get_tied_worker_bundle_indices(
         self, cluster: RayVirtualCluster


### PR DESCRIPTION
## Summary
- allow NeMo-Gym to use an external vLLM Router endpoint
- keep NeMo RL-owned Ray workers for lifecycle and refit/sync
- preserve the existing per-worker URL behavior when no router is configured

## Validation
- `git diff --check`
- `/home/inf-aoshen/vllm/.venv/bin/python -m compileall -q nemo_rl/models/generation/vllm nemo_rl/algorithms/single_controller_utils/setup.py nemo_rl/algorithms/distillation.py nemo_rl/algorithms/grpo.py`

This change is AI-assisted and has been reviewed locally. It is not a duplicate of the open NeMo-Gym or Responses API PRs: those do not route NeMo-Gym's vLLM backend through an external vLLM Router while retaining NeMo RL worker ownership.
