### PR TITLE
feat(vllm): route native async rollouts through vLLM Router

### DIFF
--- a/nemo_rl/models/generation/vllm/config.py
+++ b/nemo_rl/models/generation/vllm/config.py
@@ -43,7 +43,7 @@ class VllmSpecificArgs(TypedDict):
     use_tqdm: NotRequired[bool]
     # By default, NeMo RL only has a Python handle to the vllm.LLM generation engine. The expose_http_server flag here will expose that generation engine as an HTTP server.
     # Exposing vLLM as a server is useful in instances where the multi-turn rollout is performed with utilities outside of NeMo RL, but the user still wants to take advantage of the refit logic in NeMo RL that keeps the policy and generation up to date.
-    # Currently it will expose the /tokenize and /v1/chat/completions endpoints. Later on we may expose /v1/completions or /v1/responses.
+    # It exposes /tokenize, /v1/chat/completions, and /v1/completions.
     expose_http_server: NotRequired[bool]
     # Environment variable containing the internal refit API key.
     http_refit_api_key_env_var: NotRequired[str | None]
@@ -62,6 +62,10 @@ class VllmSpecificArgs(TypedDict):
     env_vars: NotRequired[dict[str, str]]
     # A filepath that can be imported to register a vLLM reasoning parser
     reasoning_parser_plugin: NotRequired[str]
+    # Optional external vLLM Router origin (or origin/v1). Ray still owns
+    # worker lifecycle/refit; rollout requests use this endpoint when set.
+    router_url: NotRequired[str]
+    router_request_id_header: NotRequired[str]
 
 
 class VllmDeltaCompressionConfig(BaseModel, extra="allow"):

--- a/nemo_rl/models/generation/vllm/vllm_generation.py
+++ b/nemo_rl/models/generation/vllm/vllm_generation.py
@@ -13,8 +13,11 @@
 # limitations under the License.
 
 import asyncio
+import base64
+import io
 import logging
 import os
+import uuid
 import warnings
 from collections import defaultdict
 from typing import (
@@ -102,6 +105,10 @@ class VllmGeneration(GenerationInterface):
         """
         # Store config
         self.cfg = config
+        self.router_url = self.cfg["vllm_cfg"].get("router_url")
+        self.router_request_id_header = self.cfg["vllm_cfg"].get(
+            "router_request_id_header", "x-request-id"
+        )
         self._defer_model_load = defer_model_load
         self.weight_synchronizer: WeightSynchronizer | None = None
         self.tp_size = self.cfg["vllm_cfg"]["tensor_parallel_size"]
@@ -274,6 +281,17 @@ class VllmGeneration(GenerationInterface):
             self.device_uuids = self._report_device_id()
 
         self._step_metrics_snapshot: dict[str | tuple[str, int], float] | None = None
+
+    def openai_server_base_urls(self) -> list[str | None]:
+        """Return the endpoint used by HTTP-based rollout environments."""
+        if self.router_url:
+            return [self._router_base_url()]
+        return self.dp_openai_server_base_urls
+
+    def _router_base_url(self) -> str:
+        """Return the router's OpenAI-compatible ``/v1`` base URL."""
+        base_url = self.router_url.rstrip("/")
+        return base_url if base_url.endswith("/v1") else f"{base_url}/v1"
 
     def _get_tied_worker_bundle_indices(
         self, cluster: RayVirtualCluster
@@ -754,6 +772,10 @@ class VllmGeneration(GenerationInterface):
             f"outside this method."
         )
 
+        if self.router_url:
+            yield await self._generate_one_via_router(data, greedy=greedy)
+            return
+
         # Determine the leader worker for the current data parallel shard
         leader_worker_idx = self.worker_group.get_dp_leader_worker_idx(
             self.current_generate_dp_shard_idx
@@ -804,6 +826,118 @@ class VllmGeneration(GenerationInterface):
         original_idx, result_batch = sample_result
         result_batch["gen_leader_worker_idx"] = [int(leader_worker_idx)]
         yield (original_idx, result_batch)
+
+    async def _generate_one_via_router(
+        self, data: BatchedDataDict[GenerationDatumSpec], *, greedy: bool
+    ) -> tuple[int, BatchedDataDict[GenerationOutputSpec]]:
+        """Generate one token-id prompt through an external vLLM Router."""
+        import aiohttp
+
+        input_ids = data["input_ids"][0]
+        input_length = int(data["input_lengths"][0].item())
+        prompt_token_ids = input_ids[:input_length].detach().cpu().tolist()
+        stop_strings = data.get("stop_strings", [None])[0]
+        remaining = self.cfg["vllm_cfg"]["max_model_len"] - input_length
+        max_tokens = max(0, min(self.cfg["max_new_tokens"], remaining))
+        if max_tokens == 0:
+            return 0, BatchedDataDict(
+                {
+                    "output_ids": input_ids[:input_length].unsqueeze(0),
+                    "logprobs": torch.zeros(
+                        (1, input_length), dtype=torch.float32, device=input_ids.device
+                    ),
+                    "generation_lengths": torch.zeros(1, dtype=torch.long),
+                    "unpadded_sequence_lengths": torch.tensor(
+                        [input_length], dtype=torch.long
+                    ),
+                    "truncated": torch.zeros(1, dtype=torch.bool),
+                }
+            )
+
+        request_id = data.get("router_request_id") or str(uuid.uuid4())
+        headers = {
+            self.router_request_id_header: str(request_id),
+            "content-type": "application/json",
+        }
+        body = {
+            "model": self.cfg["model_name"],
+            "prompt": prompt_token_ids,
+            "max_tokens": max_tokens,
+            "temperature": 0.0 if greedy else self.cfg["temperature"],
+            "top_p": self.cfg["top_p"],
+            "top_k": 1 if greedy else (self.cfg["top_k"] or -1),
+            "stop": stop_strings,
+            "stop_token_ids": self.cfg["stop_token_ids"],
+            "include_stop_str_in_output": True,
+            "ignore_eos": self.cfg.get("ignore_eos", False),
+            "logprobs": 0,
+            "return_token_ids": True,
+            "request_id": str(request_id),
+        }
+        timeout = aiohttp.ClientTimeout(
+            total=float(os.environ.get("NRL_VLLM_ASYNC_TIMEOUT_SECONDS", "900"))
+        )
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(
+                f"{self._router_base_url()}/completions",
+                json=body,
+                headers=headers,
+            ) as response:
+                payload = await response.json()
+                if response.status >= 400:
+                    raise RuntimeError(
+                        f"vLLM Router generation failed ({response.status}): {payload}"
+                    )
+
+        choice = payload["choices"][0]
+        returned_prompt = choice.get("prompt_token_ids")
+        if returned_prompt is not None and returned_prompt != prompt_token_ids:
+            raise RuntimeError(
+                "Router backend changed the prompt token IDs; refusing an "
+                "off-policy native rollout."
+            )
+        generated_token_ids = choice.get("token_ids")
+        if generated_token_ids is None:
+            raise RuntimeError(
+                "Router completion response did not include token_ids; "
+                "set return_token_ids on every backend."
+            )
+        generated_token_ids = [int(token_id) for token_id in generated_token_ids]
+        output_ids = torch.tensor(
+            [prompt_token_ids + generated_token_ids],
+            dtype=input_ids.dtype,
+            device=input_ids.device,
+        )
+        token_logprobs = (choice.get("logprobs") or {}).get("token_logprobs") or []
+        logprobs = torch.zeros(
+            output_ids.shape, dtype=torch.float32, device=input_ids.device
+        )
+        for idx, value in enumerate(token_logprobs[: len(generated_token_ids)]):
+            if value is not None:
+                logprobs[0, input_length + idx] = float(value)
+        result = BatchedDataDict(
+            {
+                "output_ids": output_ids,
+                "logprobs": logprobs,
+                "generation_lengths": torch.tensor(
+                    [len(generated_token_ids)], dtype=torch.long
+                ),
+                "unpadded_sequence_lengths": torch.tensor(
+                    [output_ids.shape[1]], dtype=torch.long
+                ),
+                "truncated": torch.tensor(
+                    [choice.get("finish_reason") == "length"], dtype=torch.bool
+                ),
+            }
+        )
+        routed_experts_b64 = choice.get("routed_experts")
+        if routed_experts_b64:
+            with io.BytesIO(base64.b64decode(routed_experts_b64)) as buffer:
+                routed = torch.from_numpy(np.load(buffer, allow_pickle=False)).to(
+                    device=input_ids.device
+                )
+            result["routed_experts"] = routed.unsqueeze(0)
+        return 0, result
 
     async def generate_text_async(
         self, data: BatchedDataDict[GenerationDatumSpec], greedy: bool = False

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -357,6 +357,13 @@ class VllmAsyncGenerationWorkerImpl(
             ChatCompletionRequest,
             ChatCompletionResponse,
         )
+        from vllm.entrypoints.openai.completion.protocol import (
+            CompletionRequest,
+            CompletionResponse,
+        )
+        from vllm.entrypoints.openai.completion.serving import (
+            OpenAIServingCompletion,
+        )
         from vllm.entrypoints.openai.chat_completion.serving import (
             OpenAIServingChat,
         )
@@ -662,8 +669,40 @@ class VllmAsyncGenerationWorkerImpl(
             )
         )
         openai_serving_chat = NeMoRLOpenAIServingChat(**serving_chat_kwargs)
+        openai_serving_completion = OpenAIServingCompletion(
+            engine_client=engine_client,
+            models=openai_serving_models,
+            online_renderer=engine_client.renderer,
+            request_logger=serving_chat_kwargs["request_logger"],
+            return_tokens_as_token_ids=True,
+            enable_prompt_tokens_details=True,
+        )
 
         generation_config = self.cfg
+
+        @app.post("/v1/completions")
+        async def create_completion(
+            request: CompletionRequest, raw_request: Request
+        ):
+            # This endpoint is for native NeMo-RL router transport.  It keeps
+            # the prompt pre-tokenized and returns token IDs/logprobs instead
+            # of forcing a text round-trip through a chat template.
+            assert request.top_k in (None, -1), (
+                f"Top k must be unset, empty, or -1; got {request.top_k}"
+            )
+            request.top_k = -1
+            assert request.temperature == generation_config["temperature"]
+            assert request.top_p == generation_config["top_p"]
+            generator = await openai_serving_completion.create_completion(
+                request, raw_request
+            )
+            if isinstance(generator, ErrorResponse):
+                return JSONResponse(
+                    content=generator.model_dump(), status_code=generator.error.code
+                )
+            if isinstance(generator, CompletionResponse):
+                return JSONResponse(content=generator.model_dump())
+            return StreamingResponse(content=generator, media_type="text/event-stream")
 
         # The create_chat_completion and tokenize methods are taken from vllm/entrypoints/openai/api_server.py
         @app.post("/v1/chat/completions")


### PR DESCRIPTION
## Summary
- add an HTTP `/v1/completions` path for NeMo RL native async rollouts
- send pre-tokenized prompts through an external vLLM Router
- preserve prompt/token IDs, logprobs, truncation, and optional routed-expert metadata
- keep Ray workers responsible for lifecycle and weight refit/sync

## Validation
- `git diff --check`
- `/home/inf-aoshen/vllm/.venv/bin/python -m compileall -q nemo_rl/models/generation/vllm`

This change is AI-assisted and has been reviewed locally. It is separate from the open NeMo-Gym/Responses API work: it implements the native async generation transport and token-preserving completion response required by NeMo RL.
