### PR TITLE
test(grpo): reproduce masked samples affecting group stats

### DIFF
--- a/tests/unit/algorithms/test_grpo_sample_mask.py
+++ b/tests/unit/algorithms/test_grpo_sample_mask.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from nemo_rl.algorithms.advantage_estimator import GRPOAdvantageEstimator
+from nemo_rl.algorithms.loss import ClippedPGLossConfig
+
+
+@pytest.mark.parametrize(
+    ("use_leave_one_out_baseline", "normalize_rewards", "expected"),
+    [
+        pytest.param(
+            False,
+            False,
+            [0.6666667, -0.3333333, -0.3333333],
+            id="group-mean",
+        ),
+        pytest.param(
+            False,
+            True,
+            [1.1546985, -0.5773493, -0.5773493],
+            id="group-mean-normalized",
+        ),
+        pytest.param(True, False, [1.0, -0.5, -0.5], id="leave-one-out"),
+        pytest.param(
+            True,
+            True,
+            [1.0, -0.7071058, -0.7071058],
+            id="leave-one-out-normalized",
+        ),
+    ],
+)
+def test_grpo_stats_exclude_samples_removed_by_sample_mask(
+    use_leave_one_out_baseline: bool,
+    normalize_rewards: bool,
+    expected: list[float],
+) -> None:
+    """Masked responses must not affect per-prompt baselines or normalization."""
+    estimator = GRPOAdvantageEstimator(
+        {
+            "use_leave_one_out_baseline": use_leave_one_out_baseline,
+            "normalize_rewards": normalize_rewards,
+        },
+        ClippedPGLossConfig(),
+    )
+    prompt_ids = torch.tensor([[7], [7], [7], [7]], dtype=torch.long)
+    rewards = torch.tensor([1.0, 1.0, 0.0, 0.0])
+    sample_mask = torch.tensor([1.0, 0.0, 1.0, 1.0])
+    token_mask = torch.ones((4, 1), dtype=torch.float32)
+
+    advantages = estimator.compute_advantage(
+        prompt_ids=prompt_ids,
+        rewards=rewards,
+        mask=token_mask * sample_mask.unsqueeze(-1),
+    )[:, 0]
+
+    actual = advantages[sample_mask.bool()]
+    assert torch.allclose(
+        actual,
+        torch.tensor(expected),
+        atol=1e-6,
+        rtol=0.0,
+    ), (
+        "masked sample changed the per-prompt population: "
+        f"expected valid advantages {expected}, observed {actual.tolist()}"
+    )


### PR DESCRIPTION
# What does this PR do ?

Adds a focused regression test showing that GRPO per-prompt statistics include responses whose entire token mask is zero.

The test covers ordinary group-mean and leave-one-out baselines, both with and without reward normalization. It is intentionally failing on current `main`, so this PR is opened as a draft until the estimator is corrected.

# Issues

No public issue.

# Usage

Not applicable; this is a regression test.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? The focused regression cases were run on Linux and fail as expected; the full suite was not run for this intentionally red draft.
- [x] Did you add or update any necessary documentation? No documentation changes are needed for this test-only PR.

# Additional Information

For rewards `[1, 1, 0, 0]`, where the second response is fully masked:

| Baseline | Normalize | Expected valid advantages | Current `main` |
| --- | --- | --- | --- |
| Group mean | No | `[0.667, -0.333, -0.333]` | `[0.5, -0.5, -0.5]` |
| Group mean | Yes | `[1.155, -0.577, -0.577]` | `[0.866, -0.866, -0.866]` |
| Leave one out | No | `[1, -0.5, -0.5]` | `[0.667, -0.667, -0.667]` |
| Leave one out | Yes | `[1, -0.707, -0.707]` | `[1.155, -1.155, -1.155]` |

The reproducer supplies only the existing token-level `mask`; it does not rely on an extra `sample_mask` keyword that some GRPO call paths do not provide.

Static checks completed:

- `ruff check tests/unit/algorithms/test_grpo_sample_mask.py`
- `ruff format --check tests/unit/algorithms/test_grpo_sample_mask.py`
- `git diff --check`
