### PR TITLE
docs(ci-cd): add guide for adding tests and new suites to CI

### DIFF
--- a/.agents/contributor-skills/cicd/SKILL.md
+++ b/.agents/contributor-skills/cicd/SKILL.md
@@ -86,3 +86,41 @@ Common failure patterns:
 | `semantic-pull-request` fails | PR title doesn't follow Conventional Commits | Fix PR title; see `contributing` skill |
 | Linting fails | Style violation | Run `uv run ruff check --fix . && uv run ruff format .` |
 | Unit test failure | Code regression or missing dependency | Reproduce locally; see `testing` skill |
+
+---
+
+## Adding Tests to CI
+
+See `docs/ci-cd.md` → "Adding Tests to CI" for the full guide with code links.
+Key decision tree for common cases:
+
+### Adding a single test to an existing L1 suite
+
+1. Write `tests/functional/<scenario>.sh`
+2. Add `run_test [fast] uv run --no-sync bash ./tests/functional/<scenario>.sh` to the suite orchestrator `tests/functional/L1_Functional_Tests_<Suite>.sh`
+3. Use `run_test fast` to also include it in `Lfast`; plain `run_test` for L1 only
+
+Reference: [L1_Functional_Tests_SGLang.sh](https://github.com/NVIDIA-NeMo/RL/blob/main/tests/functional/L1_Functional_Tests_SGLang.sh)
+
+### Adding a single unit test to an existing L0 shard
+
+Add the test file to the appropriate `tests/unit/` subdirectory with the correct
+`@pytest.mark.<backend>` decorator. It is picked up automatically by the shard
+script that runs `--<backend>-only`.
+
+Reference: [tests/unit/models/generation/trtllm/](https://github.com/NVIDIA-NeMo/RL/tree/main/tests/unit/models/generation/trtllm)
+
+### Adding a brand-new suite (new backend)
+
+Eight touch-points, in order:
+
+1. **`tests/unit/conftest.py`** — add `--<backend>-only` option + filter block
+2. **`pyproject.toml`** — add marker under `[tool.pytest.ini_options] markers` and optional dep under `[project.optional-dependencies]`
+3. **Unit test files** — `tests/unit/models/generation/<backend>/` with `@pytest.mark.<backend>`
+4. **`tests/unit/L0_Unit_Tests_<Backend>.sh`** — sources `run_unit_shard_common.sh`, runs `uv run --extra <backend> ... --<backend>-only`
+5. **`tests/functional/<scenario>.sh`** files — individual functional scenarios
+6. **`tests/functional/L1_Functional_Tests_<Backend>.sh`** — suite orchestrator; add `run_test fast` for Lfast-eligible tests
+7. **`.github/workflows/cicd-main.yml`** — add to L0 unit matrix, L1 functional matrix (standard), and L1 functional matrix (GB200)
+8. **`examples/configs/`** — at least one exemplar YAML
+
+Reference suites: [TRT-LLM](https://github.com/NVIDIA-NeMo/RL/blob/main/tests/functional/L1_Functional_Tests_Trtllm.sh) · [SGLang](https://github.com/NVIDIA-NeMo/RL/blob/main/tests/functional/L1_Functional_Tests_SGLang.sh)

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -48,6 +48,162 @@ The main pipeline (`cicd-main.yml`) runs through these stages:
 4. **Coverage**: aggregated from doc-tests, unit-tests, and e2e; uploaded to Codecov
 5. **QA Gate**: aggregates all job results into a single pass/fail status
 
+## Adding Tests to CI
+
+### Adding a single test to an existing suite
+
+Each L1 suite has a corresponding orchestrator script in
+[`tests/functional/`](https://github.com/NVIDIA-NeMo/RL/tree/main/tests/functional/)
+that lists which scenario scripts to run. To add one test:
+
+1. **Write a scenario script** in `tests/functional/`, following the pattern of an
+   existing script in the same suite. For example,
+   [`tests/functional/grpo_sglang_sync.sh`](https://github.com/NVIDIA-NeMo/RL/blob/main/tests/functional/grpo_sglang_sync.sh)
+   is a scenario in the SGLang suite.
+
+2. **Register it in the suite orchestrator**. Open the suite's
+   `tests/functional/L1_Functional_Tests_<Suite>.sh` and add a `run_test` call:
+
+   ```bash
+   run_test      uv run --no-sync bash ./tests/functional/<your_scenario>.sh   # full L1 only
+   run_test fast uv run --no-sync bash ./tests/functional/<your_scenario>.sh   # also runs in Lfast
+   ```
+
+   Use `run_test fast` if the test is short enough to include in `Lfast` (reuses
+   the pre-built `main` container). Use plain `run_test` if it should run at L1
+   only. See
+   [`tests/functional/L1_Functional_Tests_SGLang.sh`](https://github.com/NVIDIA-NeMo/RL/blob/main/tests/functional/L1_Functional_Tests_SGLang.sh)
+   for an example with both.
+
+3. **For unit tests**: add the test file under
+   `tests/unit/models/generation/<backend>/` or the appropriate subdirectory,
+   decorate it with the backend's pytest marker (e.g. `@pytest.mark.vllm`), and
+   it will be picked up automatically by the existing shard script (e.g.
+   [`tests/unit/L0_Unit_Tests_Vllm_1.sh`](https://github.com/NVIDIA-NeMo/RL/blob/main/tests/unit/L0_Unit_Tests_Vllm_1.sh)).
+
+---
+
+### Adding a new test suite (e.g. a new backend)
+
+Adding a first-class suite (like the TRT-LLM or SGLang suites) requires changes
+in **eight places**. Use the TRT-LLM and SGLang suites as reference throughout.
+
+#### 1. pytest marker and filtering logic — `tests/unit/conftest.py`
+
+Register a `--<backend>-only` CLI flag and the corresponding
+filter in `collection_modifyitems`. Every new backend needs:
+
+- An `addoption` entry (see the existing
+  [`--trtllm-only`](https://github.com/NVIDIA-NeMo/RL/blob/main/tests/unit/conftest.py#L67)
+  and
+  [`--vllm-only`](https://github.com/NVIDIA-NeMo/RL/blob/main/tests/unit/conftest.py#L55)
+  entries).
+- A variable in `collection_modifyitems` and a filter block that
+  validates the import and selects/excludes tests by marker (see
+  [the trtllm block](https://github.com/NVIDIA-NeMo/RL/blob/main/tests/unit/conftest.py#L191)).
+
+By default, unmarked tests in the backend's own directory also run — your
+`--<backend>-only` flag handles the explicit pass; tests without any marker run
+in the baseline shard.
+
+#### 2. pytest marker declaration — `pyproject.toml`
+
+Add `<backend> = "..."` under `[tool.pytest.ini_options] markers` so pytest
+does not warn about an unknown marker.
+
+#### 3. Unit test files
+
+Place backend-specific tests under
+`tests/unit/models/generation/<backend>/` and decorate them with
+`@pytest.mark.<backend>`. See
+[`tests/unit/models/generation/trtllm/`](https://github.com/NVIDIA-NeMo/RL/tree/main/tests/unit/models/generation/trtllm)
+and
+[`tests/unit/models/generation/sglang/`](https://github.com/NVIDIA-NeMo/RL/tree/main/tests/unit/models/generation/sglang)
+for examples.
+
+#### 4. L0 unit shard script — `tests/unit/L0_Unit_Tests_<Backend>.sh`
+
+Source the shared boilerplate, then run the backend's tests via `uv run --extra <backend>`:
+
+```bash
+source "$(dirname "${BASH_SOURCE[0]}")/run_unit_shard_common.sh"
+
+uv run --extra <backend> bash -x ./tests/run_unit.sh \
+    "unit/" \
+    "${EXCLUDED_UNIT_TESTS[@]}" \
+    --cov=nemo_rl --cov-report=term-missing --cov-report=json \
+    --hf-gated \
+    --<backend>-only
+```
+
+See
+[`tests/unit/L0_Unit_Tests_Trtllm.sh`](https://github.com/NVIDIA-NeMo/RL/blob/main/tests/unit/L0_Unit_Tests_Trtllm.sh)
+and
+[`tests/unit/L0_Unit_Tests_Sglang.sh`](https://github.com/NVIDIA-NeMo/RL/blob/main/tests/unit/L0_Unit_Tests_Sglang.sh)
+for full examples. SGLang also does a separate pass on its own directory
+to catch tests without an explicit marker — follow that pattern if needed.
+
+#### 5. L1 functional suite orchestrator — `tests/functional/L1_Functional_Tests_<Backend>.sh`
+
+Create the suite orchestrator that calls each scenario script. Use
+`run_test fast` for tests short enough to include in `Lfast`:
+
+```bash
+run_test fast uv run --no-sync bash ./tests/functional/<scenario_a>.sh
+run_test      uv run --no-sync bash ./tests/functional/<scenario_b>.sh
+```
+
+See
+[`tests/functional/L1_Functional_Tests_SGLang.sh`](https://github.com/NVIDIA-NeMo/RL/blob/main/tests/functional/L1_Functional_Tests_SGLang.sh)
+(uses `run_test fast` for Lfast inclusion) and
+[`tests/functional/L1_Functional_Tests_Trtllm.sh`](https://github.com/NVIDIA-NeMo/RL/blob/main/tests/functional/L1_Functional_Tests_Trtllm.sh)
+(L1 only, no `run_test fast`).
+
+#### 6. CI matrix entries — `.github/workflows/cicd-main.yml`
+
+Add the new suite to **three places** in the workflow:
+
+| Location | What to add |
+|----------|-------------|
+| L0 unit matrix | `- script: L0_Unit_Tests_<Backend>` (see [existing entries](https://github.com/NVIDIA-NeMo/RL/blob/main/github/workflows/cicd-main.yml#L523-L567)) |
+| L1 functional matrix — standard runners | `- script: L1_Functional_Tests_<Backend>` with runner variable (see [line ~708](https://github.com/NVIDIA-NeMo/RL/blob/main/github/workflows/cicd-main.yml#L708)) |
+| L1 functional matrix — GB200 runners | Same script with `runner: ${{ vars.GB200_RUNNER }}` (see [line ~781](https://github.com/NVIDIA-NeMo/RL/blob/main/github/workflows/cicd-main.yml#L781)) |
+
+If your backend requires special build-time caches (like TRT-LLM's
+`trtllm-ccache-tag`), add those to the container build step as well.
+
+**Lfast guard (temporary)**: if the backend is not yet in the `main` container,
+add a conditional to skip the unit shard in Lfast:
+
+```yaml
+if: ${{ needs.pre-flight.outputs.test_level != 'Lfast' || matrix.script != 'L0_Unit_Tests_<Backend>' }}
+```
+
+Remove this guard once the backend ships on main. See
+[PR #3479](https://github.com/NVIDIA-NeMo/RL/pull/3479) which removed this
+guard for TRT-LLM once it landed.
+
+#### 7. uv optional extra — `pyproject.toml`
+
+Declare the backend as an optional dependency so `uv run --extra <backend>`
+resolves correctly:
+
+```toml
+[project.optional-dependencies]
+<backend> = ["<backend-package>>=<version>"]
+```
+
+#### 8. Example configs (optional but standard)
+
+Add at least one exemplar YAML under `examples/configs/` and a recipe under
+`examples/configs/recipes/`. See
+[`examples/configs/grpo_math_1B_trtllm.yaml`](https://github.com/NVIDIA-NeMo/RL/blob/main/examples/configs/grpo_math_1B_trtllm.yaml)
+and
+[`examples/configs/grpo_math_1B_sglang.yaml`](https://github.com/NVIDIA-NeMo/RL/blob/main/examples/configs/grpo_math_1B_sglang.yaml)
+as examples.
+
+---
+
 ## Code Review
 
 Commenting `/claude-review` on a PR triggers an AI-powered code review. This is restricted to org members.


### PR DESCRIPTION
## Summary

- Adds a new **"Adding Tests to CI"** section to `docs/ci-cd.md` covering two workflows: adding a single test to an existing suite and adding a brand-new backend suite (8 touch-points, with code links to TRT-LLM and SGLang as reference implementations)
- Enhances `.agents/contributor-skills/cicd/SKILL.md` with a condensed decision tree for the same two workflows, so agents can answer CI integration questions without requiring the user to explain the structure

## Test plan

- [ ] Docs render correctly (`uv run sphinx-build docs/ _build/html`)
- [ ] All links resolve to real files on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)