### PR TITLE
perf(logprob): skip the softmax materialization on the inference path

### DIFF
--- a/nemo_rl/distributed/model_utils.py
+++ b/nemo_rl/distributed/model_utils.py
@@ -140,10 +140,13 @@ class DistributedLogprob(torch.autograd.Function):
 
         vocab_parallel_logits = vocab_parallel_logits.to(dtype=torch.float32)
 
-        log_probs = _compute_distributed_log_softmax(vocab_parallel_logits, group=group)
-        softmax_output = log_probs.exp()
+        full_log_probs = _compute_distributed_log_softmax(
+            vocab_parallel_logits, group=group
+        )
 
-        log_probs = torch.gather(log_probs, -1, masked_target.unsqueeze(-1)).squeeze(-1)
+        log_probs = torch.gather(
+            full_log_probs, -1, masked_target.unsqueeze(-1)
+        ).squeeze(-1)
         log_probs[target_mask] = 0.0
 
         torch.distributed.all_reduce(
@@ -153,8 +156,11 @@ class DistributedLogprob(torch.autograd.Function):
         )
 
         if not inference_only:
-            # only save for backward when we have inference only=False
-            ctx.save_for_backward(softmax_output, target_mask, masked_target)
+            # only save for backward when we have inference only=False. The
+            # softmax is materialized here rather than next to the log_softmax
+            # so the inference path does not pay for a [B, S, V_local] tensor
+            # it never reads (same placement as ChunkedDistributedLogprob).
+            ctx.save_for_backward(full_log_probs.exp(), target_mask, masked_target)
 
         return log_probs
 


### PR DESCRIPTION
## What does this PR do ?

`DistributedLogprob.forward` builds the full-vocab softmax unconditionally:

```python
log_probs = _compute_distributed_log_softmax(vocab_parallel_logits, group=group)
softmax_output = log_probs.exp()          # always
...
if not inference_only:
    ctx.save_for_backward(softmax_output, target_mask, masked_target)   # only consumer
```

`softmax_output` is referenced in exactly two places — where it is created, and inside the `if not inference_only:` guard. So on the inference path the `[B, S, V_local]` fp32 tensor is materialized and immediately discarded.

That path is the common one, not an edge case: `from_parallel_logits_to_logprobs` passes `inference_only=not torch.is_grad_enabled()`, so every logprob computation under `no_grad` (reference-policy logprobs, rollout logprobs) hits it, plus two explicit `inference_only=True` call sites in `models/megatron/train.py`.

This moves the `.exp()` inside the guard — the placement `ChunkedDistributedLogprob` already uses a few hundred lines down in the same file:

```python
if not inference_only:
    # Save softmax and mask for backward
    softmax_output = log_probs.exp()
    ctx.save_for_backward(softmax_output, target_local, keep_mask)
```

## Correctness

Bit-identical, and the one subtlety is worth naming: `log_probs` is rebound by the `torch.gather`, and `log_probs[target_mask] = 0.0` then writes in place. That write lands on the gathered `[B, S]` tensor, not on the full-vocab one, so taking `.exp()` after the gather saves exactly the same values as before. Verified directly — forward output and the saved softmax are both `torch.equal` to the previous ordering (max abs diff 0.0).

Only this call site had the pattern. The sibling guards in the same file are already correct: `ChunkedDistributedLogprob` recomputes from `vocab_parallel_logits` in backward, the KL variant's `.exp_()` is already inside its guard, and the entropy kernel's `softmax_output` genuinely feeds `H_local`.

## Measured

Reference-logprob shape `B*S=2048`, `V_local=18992` (V=151,936 at TP=8), fp32:

| | forward | fp32 tensor allocated |
|---|---|---|
| main | 23.3 ms | 148 MiB |
| this PR | 10.9 ms | — |

## Before your PR is "Ready for review"

- [x] Tests: no new test — this is a pure code-motion change with no behavioral surface, and `tests/unit/distributed/test_distributed_logprob.py` already covers both the `inference_only` and training paths. Happy to add an explicit assertion that nothing is saved when `inference_only=True` if you'd like one.
- [x] Validation: equivalence checked directly (forward and saved-softmax both bit-identical); `ruff check` / `format --check` clean; `pyrefly==0.24.2` reports 34 errors before and after on this file — unchanged, and it is not in `project-includes`.
- [x] Docs: N/A.

Follow-up to #3314, same class of change.

cc @yuki-97 @RayenTian
