### PR TITLE
feat(sc): overlap NeMo-Gym spinup with deferred vLLM load

### DIFF
--- a/examples/run_grpo_single_controller.py
+++ b/examples/run_grpo_single_controller.py
@@ -122,10 +122,14 @@ def main() -> None:
     if bool(config.env.get("should_use_nemo_gym")):
         setup_nemo_gym_config(config, tokenizer)
 
-    actor_args = setup_single_controller(config, tokenizer)
+    actor_args, setup_timing_metrics = setup_single_controller(config, tokenizer)
 
     print("🚀 Launching SingleControllerActor")
-    sc = SingleControllerActor.remote(master_config=config, actor_args=actor_args)
+    sc = SingleControllerActor.remote(
+        master_config=config,
+        actor_args=actor_args,
+        setup_timing_metrics=setup_timing_metrics,
+    )
     try:
         result = ray.get(sc.run.remote())
         print(f"SC run complete: {result}")

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1134,7 +1134,7 @@ def setup(
             worker_init_timing_metrics[init_time_key] = generation_time
             worker_init_timing_metrics["policy_init_time_s"] = policy_time
             worker_init_timing_metrics["parallel_wall_time_s"] = parallel_wall_time
-            worker_init_timing_metrics["parallel_init_enabled"] = True
+            worker_init_timing_metrics["parallel_init_enabled"] = 1.0
 
         else:
             # Sequential initialization: colocated mode (GPU memory requires generation engine first)

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -1237,11 +1237,13 @@ def setup(
                 "  ⚡ Deferred model load: reserving vLLM ports for overlapped NeMo Gym init",
                 flush=True,
             )
+            vllm_reserve_t0 = time.perf_counter()
             deferred_vllm = VllmGeneration(
                 cluster=inference_cluster,
                 config=generation_config,
                 defer_model_load=True,
             )
+            vllm_reserve_time = time.perf_counter() - vllm_reserve_t0
             print(
                 f"  ✓ Reserved {len(deferred_vllm.dp_openai_server_base_urls)} vLLM server URLs: "
                 f"{deferred_vllm.dp_openai_server_base_urls}",
@@ -1286,14 +1288,14 @@ def setup(
                 results = {k: f.result() for k, f in submitted.items()}
 
             if colocated_inference:
-                policy_generation, vllm_time, policy, policy_time = results[
+                policy_generation, vllm_load_time, policy, policy_time = results[
                     "vllm_policy"
                 ]
             else:
-                policy_generation, vllm_time = results["vllm"]
+                policy_generation, vllm_load_time = results["vllm"]
                 policy, policy_time = results["policy"]
             nemo_gym_actor, nemo_gym_time = results["nemo_gym"]
-            setup_timing_metrics.vllm_init_time_s = vllm_time
+            setup_timing_metrics.vllm_init_time_s = vllm_reserve_time + vllm_load_time
             setup_timing_metrics.policy_init_time_s = policy_time
             setup_timing_metrics.nemo_gym_init_time_s = nemo_gym_time
         else:

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -47,6 +47,10 @@ from nemo_rl.algorithms.loss import (
     ClippedPGLossFn,
 )
 from nemo_rl.algorithms.loss.interfaces import LossFunction
+from nemo_rl.algorithms.metric_utils import (
+    SetupTimingMetrics,
+    print_setup_timing_summary,
+)
 from nemo_rl.algorithms.opd import OnPolicyDistillationConfig
 from nemo_rl.algorithms.reward_functions import (
     RewardShapingConfig,
@@ -978,18 +982,21 @@ def setup(
 
     # vllm model loading prefers clean environment, initialize policy_generation before policy in colocated mode
     backend = generation_config["backend"]
+    gen_init_time_key = (
+        "megatron_generation_init_time_s"
+        if backend == "megatron"
+        else f"{backend}_init_time_s"
+    )
     generation_config["model_name"] = policy_config["model_name"]  # Needed for vLLM
     remote_transport = None
     remote_synchronizer_cls = None
     remote_baseline_init_refs: list[Any] = []
     checkpoint_engine_config = None
 
-    # Dictionary to store worker initialization timing stats for logging
-    worker_init_timing_metrics = {}
+    # Worker initialization timing stats — populated as each phase completes.
+    setup_timing_metrics = SetupTimingMetrics()
     if teacher_reservation_time:
-        worker_init_timing_metrics["teacher_reservation_time_s"] = (
-            teacher_reservation_time
-        )
+        setup_timing_metrics.teacher_reservation_time_s = teacher_reservation_time
 
     weights_path, optimizer_path = checkpointer.get_resume_paths(last_checkpoint_path)
 
@@ -1094,22 +1101,18 @@ def setup(
 
     def initialize_generation_with_policy(
         init_generation_fn,
-        generation_name: str,
-        init_time_key: str,
         colocated_inference: bool,
-        worker_init_timing_metrics: dict,
+        setup_timing_metrics: SetupTimingMetrics,
     ):
-        """Generic function to initialize a generation engine (vLLM or SGLang) along with policy.
+        """Initialize a generation engine along with policy, sequentially or in parallel.
 
         Args:
-            init_generation_fn: Function that initializes the generation engine (init_vllm or init_sglang)
-            generation_name: Name of the generation engine ("vLLM" or "SGLang")
-            init_time_key: Key name for storing initialization time in metrics ("vllm_init_time_s" or "sglang_init_time_s")
-            colocated_inference: Whether inference is colocated with training
-            worker_init_timing_metrics: Dictionary to store timing metrics
+            init_generation_fn: Function that initializes the generation engine (init_vllm, ...).
+            colocated_inference: Whether inference is colocated with training.
+            setup_timing_metrics: SetupTimingMetrics to store timings on.
 
         Returns:
-            Tuple of (policy_generation, policy)
+            Tuple of (policy_generation, policy).
         """
         # Determine if parallel initialization is possible (non-colocated mode)
         use_parallel_init = not colocated_inference
@@ -1131,10 +1134,10 @@ def setup(
             parallel_wall_time = time.perf_counter() - parallel_start_time
 
             # Store timing metrics
-            worker_init_timing_metrics[init_time_key] = generation_time
-            worker_init_timing_metrics["policy_init_time_s"] = policy_time
-            worker_init_timing_metrics["parallel_wall_time_s"] = parallel_wall_time
-            worker_init_timing_metrics["parallel_init_enabled"] = 1.0
+            setattr(setup_timing_metrics, gen_init_time_key, generation_time)
+            setup_timing_metrics.policy_init_time_s = policy_time
+            setup_timing_metrics.parallel_wall_time_s = parallel_wall_time
+            setup_timing_metrics.parallel_init_enabled = 1.0
 
         else:
             # Sequential initialization: colocated mode (GPU memory requires generation engine first)
@@ -1145,11 +1148,11 @@ def setup(
 
             # Initialize generation engine first (clean GPU memory), then policy
             policy_generation, generation_time = init_generation_fn()
-            worker_init_timing_metrics[init_time_key] = generation_time
+            setattr(setup_timing_metrics, gen_init_time_key, generation_time)
 
             policy, policy_time = init_policy()
-            worker_init_timing_metrics["policy_init_time_s"] = policy_time
-            worker_init_timing_metrics["parallel_init_enabled"] = 0.0
+            setup_timing_metrics.policy_init_time_s = policy_time
+            setup_timing_metrics.parallel_init_enabled = 0.0
 
         return policy_generation, policy
 
@@ -1157,13 +1160,11 @@ def setup(
     if backend == "megatron":
         # Initialize training first so checkpoint conversion completes before inference starts.
         policy, policy_time = init_policy()
-        worker_init_timing_metrics["policy_init_time_s"] = policy_time
+        setup_timing_metrics.policy_init_time_s = policy_time
 
         # Colocated wraps the training policy; non-colocated builds a dedicated inference policy.
         policy_generation, megatron_gen_time = init_megatron_generation(policy)
-        worker_init_timing_metrics["megatron_generation_init_time_s"] = (
-            megatron_gen_time
-        )
+        setup_timing_metrics.megatron_generation_init_time_s = megatron_gen_time
 
         if enable_nemo_gym:
             # The Megatron inference engine must be up before its server URLs exist.
@@ -1171,7 +1172,7 @@ def setup(
                 policy_generation.dp_openai_server_base_urls,
                 generation_config["model_name"],
             )
-            worker_init_timing_metrics["nemo_gym_init_time_s"] = nemo_gym_time
+            setup_timing_metrics.nemo_gym_init_time_s = nemo_gym_time
 
         print(
             f"  ✓ Using {backend} backend for generation with {policy_config['model_name']}",
@@ -1292,16 +1293,14 @@ def setup(
                 policy_generation, vllm_time = results["vllm"]
                 policy, policy_time = results["policy"]
             nemo_gym_actor, nemo_gym_time = results["nemo_gym"]
-            worker_init_timing_metrics["vllm_init_time_s"] = vllm_time
-            worker_init_timing_metrics["policy_init_time_s"] = policy_time
-            worker_init_timing_metrics["nemo_gym_init_time_s"] = nemo_gym_time
+            setup_timing_metrics.vllm_init_time_s = vllm_time
+            setup_timing_metrics.policy_init_time_s = policy_time
+            setup_timing_metrics.nemo_gym_init_time_s = nemo_gym_time
         else:
             policy_generation, policy = initialize_generation_with_policy(
                 init_generation_fn=init_vllm,
-                generation_name="vLLM",
-                init_time_key="vllm_init_time_s",
                 colocated_inference=colocated_inference,
-                worker_init_timing_metrics=worker_init_timing_metrics,
+                setup_timing_metrics=setup_timing_metrics,
             )
 
         print(
@@ -1318,10 +1317,8 @@ def setup(
 
         policy_generation, policy = initialize_generation_with_policy(
             init_generation_fn=init_sglang,
-            generation_name="SGLang",
-            init_time_key="sglang_init_time_s",
             colocated_inference=colocated_inference,
-            worker_init_timing_metrics=worker_init_timing_metrics,
+            setup_timing_metrics=setup_timing_metrics,
         )
 
         # Capture rollout TP size on the policy once; refit calls no longer need it.
@@ -1344,10 +1341,8 @@ def setup(
 
         policy_generation, policy = initialize_generation_with_policy(
             init_generation_fn=init_trtllm,
-            generation_name="TRT-LLM",
-            init_time_key="trtllm_init_time_s",
             colocated_inference=colocated_inference,
-            worker_init_timing_metrics=worker_init_timing_metrics,
+            setup_timing_metrics=setup_timing_metrics,
         )
 
         print(
@@ -1360,7 +1355,7 @@ def setup(
                 policy_generation.dp_openai_server_base_urls,
                 generation_config["model_name"],
             )
-            worker_init_timing_metrics["nemo_gym_init_time_s"] = nemo_gym_time
+            setup_timing_metrics.nemo_gym_init_time_s = nemo_gym_time
 
     # Record when worker initialization completes (for calculating other setup time)
     worker_init_complete_time = time.perf_counter() - setup_start_time
@@ -1439,7 +1434,8 @@ def setup(
                 ip, port, world_size, train_world_size=train_world_size
             )  # type: ignore
             ray.get(futures_train + futures_inference)
-        worker_init_timing_metrics["collective_init_time_s"] = time.perf_counter() - t0
+        setup_timing_metrics.collective_init_time_s = time.perf_counter() - t0
+
     if remote_transport is not None:
         t0 = time.perf_counter()
         assert isinstance(policy_generation, VllmGeneration)
@@ -1457,7 +1453,7 @@ def setup(
             baseline_init_refs=remote_baseline_init_refs,
         )
         policy_generation.weight_synchronizer.init_communicator()
-        worker_init_timing_metrics[f"vllm_{remote_transport}_sparse_init_time_s"] = (
+        setup_timing_metrics.extras[f"vllm_{remote_transport}_sparse_init_time_s"] = (
             time.perf_counter() - t0
         )
     elif checkpoint_engine_config is not None:
@@ -1472,7 +1468,7 @@ def setup(
             inference_cluster=inference_cluster,
         )
         policy_generation.weight_synchronizer.init_communicator()
-        worker_init_timing_metrics["vllm_checkpoint_engine_init_time_s"] = (
+        setup_timing_metrics.vllm_checkpoint_engine_init_time_s = (
             time.perf_counter() - t0
         )
         print(
@@ -1502,46 +1498,25 @@ def setup(
             )
         )
         teacher_model_init_time = time.perf_counter() - t0
-        worker_init_timing_metrics["teacher_model_init_time_s"] = (
-            teacher_model_init_time
-        )
+        setup_timing_metrics.teacher_model_init_time_s = teacher_model_init_time
         # Preserve the existing metric's end-to-end meaning while exposing the
         # newly separated reservation and model-initialization phases.
-        worker_init_timing_metrics["teacher_init_time_s"] = (
+        setup_timing_metrics.teacher_init_time_s = (
             teacher_reservation_time + teacher_model_init_time
         )
 
     # Calculate total setup time
     total_setup_time = time.perf_counter() - setup_start_time
-    worker_init_timing_metrics["total_setup_time_s"] = total_setup_time
+    setup_timing_metrics.total_setup_time_s = total_setup_time
+    setup_timing_metrics.other_setup_time_s = (
+        total_setup_time - worker_init_complete_time
+    )
 
     # Log worker initialization timing metrics to logger
-    if worker_init_timing_metrics:
-        print("\n▶ Worker Initialization Timing:")
-
-        vllm_time = worker_init_timing_metrics.get("vllm_init_time_s", 0)
-        policy_time = worker_init_timing_metrics.get("policy_init_time_s", 0)
-        total_setup = worker_init_timing_metrics.get("total_setup_time_s", 0)
-
-        if vllm_time:
-            print(f"  vLLM init: {vllm_time:.1f}s")
-
-        if policy_time:
-            print(f"  Policy init: {policy_time:.1f}s")
-
-        teacher_time = worker_init_timing_metrics.get("teacher_init_time_s", 0)
-        if teacher_time:
-            print(f"  Teacher init: {teacher_time:.1f}s")
-
-        # Calculate "other" time (time after worker init completes)
-        other_time = total_setup - worker_init_complete_time
-        worker_init_timing_metrics["other_setup_time_s"] = other_time
-        print(f"  Other setup: {other_time:.1f}s")
-
-        print(f"  Total setup: {total_setup:.1f}s")
-
-        # Log all metrics to the logger for analysis
-        logger.log_metrics(worker_init_timing_metrics, step=0, prefix="timing/setup")
+    print_setup_timing_summary(setup_timing_metrics, gen_init_time_key)
+    logger.log_metrics(
+        setup_timing_metrics.to_metrics_dict(), step=0, prefix="timing/setup"
+    )
 
     print("\n" + "=" * 60)
     print(" " * 18 + "SETUP COMPLETE")

--- a/nemo_rl/algorithms/metric_utils.py
+++ b/nemo_rl/algorithms/metric_utils.py
@@ -22,11 +22,16 @@ from typing import Any, Optional
 class SetupTimingMetrics:
     """Driver-side per-phase timings collected during setup."""
 
-    # Generation-backend init (exactly one populated per run).
+    # grpo.py only: generation-backend init (exactly one populated per run).
     vllm_init_time_s: Optional[float] = None
     sglang_init_time_s: Optional[float] = None
     trtllm_init_time_s: Optional[float] = None
     megatron_generation_init_time_s: Optional[float] = None
+
+    # SC only: generation init (reserve + load).
+    generation_init_time_s: Optional[float] = None
+    generation_init_reserve_time_s: Optional[float] = None
+    generation_init_load_time_s: Optional[float] = None
 
     policy_init_time_s: Optional[float] = None
     nemo_gym_init_time_s: Optional[float] = None
@@ -60,12 +65,34 @@ class SetupTimingMetrics:
 
 
 def print_setup_timing_summary(
-    metrics: SetupTimingMetrics, gen_init_time_key: str
+    metrics: SetupTimingMetrics, gen_init_time_key: Optional[str] = None
 ) -> None:
-    """Print the setup-phase summary block."""
+    """Print the setup-phase summary block.
+
+    Args:
+        metrics: Populated timing metrics.
+        gen_init_time_key: grpo.py passes the backend-specific field name
+            (e.g. "vllm_init_time_s"); SC leaves it None and the summary
+            reads generation_init_time_s (+ optional reserve/load split).
+    """
     print("\n▶ Worker Initialization Timing:")
 
-    print(f"  Generation init: {getattr(metrics, gen_init_time_key):.1f}s")
+    if metrics.generation_init_reserve_time_s:
+        # SC + gym-on path
+        print(
+            f"  Generation init: {metrics.generation_init_time_s:.1f}s"
+            f" (reserve {metrics.generation_init_reserve_time_s:.1f}s"
+            f" + load {metrics.generation_init_load_time_s:.1f}s)"
+        )
+    elif gen_init_time_key is None:
+        # SC + gym-off path
+        assert metrics.generation_init_time_s is not None
+        print(f"  Generation init: {metrics.generation_init_time_s:.1f}s")
+    else:
+        # grpo.py path
+        assert metrics.generation_init_time_s is None
+        print(f"  Generation init: {getattr(metrics, gen_init_time_key):.1f}s")
+
     print(f"  Policy init: {metrics.policy_init_time_s:.1f}s")
 
     if metrics.nemo_gym_init_time_s:

--- a/nemo_rl/algorithms/metric_utils.py
+++ b/nemo_rl/algorithms/metric_utils.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Optional
+
+
+@dataclass
+class SetupTimingMetrics:
+    """Driver-side per-phase timings collected during setup."""
+
+    # Generation-backend init (exactly one populated per run).
+    vllm_init_time_s: Optional[float] = None
+    sglang_init_time_s: Optional[float] = None
+    trtllm_init_time_s: Optional[float] = None
+    megatron_generation_init_time_s: Optional[float] = None
+
+    policy_init_time_s: Optional[float] = None
+    nemo_gym_init_time_s: Optional[float] = None
+    collective_init_time_s: Optional[float] = None
+
+    # Non-colocated only.
+    parallel_wall_time_s: Optional[float] = None
+    # 0.0 = sequential, 1.0 = parallel.
+    parallel_init_enabled: Optional[float] = None
+
+    # grpo-only phases (non-colocated OPD teachers, sparse refit, checkpoint-engine).
+    teacher_reservation_time_s: Optional[float] = None
+    teacher_model_init_time_s: Optional[float] = None
+    teacher_init_time_s: Optional[float] = None
+    vllm_checkpoint_engine_init_time_s: Optional[float] = None
+
+    total_setup_time_s: Optional[float] = None
+    other_setup_time_s: Optional[float] = None
+
+    # Overflow bucket for dynamic-keyed metrics (e.g. one entry per active
+    # sparse refit transport: vllm_<transport>_sparse_init_time_s).
+    extras: dict[str, float] = field(default_factory=dict)
+
+    def to_metrics_dict(self) -> dict[str, Any]:
+        """Serialize for Logger.log_metrics; drops unset (None) fields."""
+        base = {
+            k: v for k, v in asdict(self).items() if k != "extras" and v is not None
+        }
+        base.update(self.extras)
+        return base
+
+
+def print_setup_timing_summary(
+    metrics: SetupTimingMetrics, gen_init_time_key: str
+) -> None:
+    """Print the setup-phase summary block."""
+    print("\n▶ Worker Initialization Timing:")
+
+    print(f"  Generation init: {getattr(metrics, gen_init_time_key):.1f}s")
+    print(f"  Policy init: {metrics.policy_init_time_s:.1f}s")
+
+    if metrics.nemo_gym_init_time_s:
+        print(f"  NeMo-Gym init: {metrics.nemo_gym_init_time_s:.1f}s")
+
+    if metrics.teacher_init_time_s:
+        print(f"  Teacher init: {metrics.teacher_init_time_s:.1f}s")
+
+    print(f"  Other setup: {metrics.other_setup_time_s:.1f}s")
+    print(f"  Total setup: {metrics.total_setup_time_s:.1f}s", flush=True)

--- a/nemo_rl/algorithms/metric_utils.py
+++ b/nemo_rl/algorithms/metric_utils.py
@@ -32,9 +32,8 @@ class SetupTimingMetrics:
     nemo_gym_init_time_s: Optional[float] = None
     collective_init_time_s: Optional[float] = None
 
-    # Non-colocated only.
+    # Non-colocated only. (grpo.py only)
     parallel_wall_time_s: Optional[float] = None
-    # 0.0 = sequential, 1.0 = parallel.
     parallel_init_enabled: Optional[float] = None
 
     # grpo-only phases (non-colocated OPD teachers, sparse refit, checkpoint-engine).
@@ -44,6 +43,7 @@ class SetupTimingMetrics:
     vllm_checkpoint_engine_init_time_s: Optional[float] = None
 
     total_setup_time_s: Optional[float] = None
+    worker_setup_time_s: Optional[float] = None
     other_setup_time_s: Optional[float] = None
 
     # Overflow bucket for dynamic-keyed metrics (e.g. one entry per active

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -95,9 +95,7 @@ class SingleControllerActor:
         Args:
             master_config: SC MasterConfig.
             actor_args: Pre-built actor args from setup_single_controller.
-            setup_timing_metrics: Per-phase timings collected on the driver in
-                setup_single_controller; logged here because Logger backends
-                can't be cloudpickled into the actor.
+            setup_timing_metrics: Driver-side setup timings; logged here (Logger isn't cloudpickleable).
         """
         validate_single_controller_config(master_config)
 

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -87,12 +87,16 @@ class SingleControllerActor:
         self,
         master_config: MasterConfig,
         actor_args: SingleControllerActorArgs,
+        setup_timing_metrics: dict[str, Any],
     ) -> None:
         """Initialize the SingleController actor.
 
         Args:
             master_config: SC MasterConfig.
             actor_args: Pre-built actor args from setup_single_controller.
+            setup_timing_metrics: Per-phase timings collected on the driver in
+                setup_single_controller; logged here because Logger backends
+                can't be cloudpickled into the actor.
         """
         validate_single_controller_config(master_config)
 
@@ -125,6 +129,7 @@ class SingleControllerActor:
         # _thread.lock that Ray can't cloudpickle into the actor.
         self._logger = Logger(master_config.logger)  # type: ignore
         self._logger.log_hyperparams(master_config.model_dump())
+        self._logger.log_metrics(setup_timing_metrics, step=0, prefix="timing/setup")
         self._timer = Timer()
 
         # Pin clusters so RayVirtualCluster.__del__ doesn't remove the PGs.

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -43,6 +43,7 @@ import ray
 import torch
 
 from nemo_rl.algorithms.async_utils.staleness_sampler import create_sampler
+from nemo_rl.algorithms.metric_utils import SetupTimingMetrics
 from nemo_rl.algorithms.single_controller_utils.config import (
     AdvantageConfig,
     MasterConfig,
@@ -87,7 +88,7 @@ class SingleControllerActor:
         self,
         master_config: MasterConfig,
         actor_args: SingleControllerActorArgs,
-        setup_timing_metrics: dict[str, Any],
+        setup_timing_metrics: SetupTimingMetrics,
     ) -> None:
         """Initialize the SingleController actor.
 
@@ -129,7 +130,9 @@ class SingleControllerActor:
         # _thread.lock that Ray can't cloudpickle into the actor.
         self._logger = Logger(master_config.logger)  # type: ignore
         self._logger.log_hyperparams(master_config.model_dump())
-        self._logger.log_metrics(setup_timing_metrics, step=0, prefix="timing/setup")
+        self._logger.log_metrics(
+            setup_timing_metrics.to_metrics_dict(), step=0, prefix="timing/setup"
+        )
         self._timer = Timer()
 
         # Pin clusters so RayVirtualCluster.__del__ doesn't remove the PGs.

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -455,6 +455,12 @@ def setup_single_controller(
     train_cluster, inference_cluster = _build_clusters(master_config)
     colocated = generation_config["colocated"]["enabled"]
 
+    # Create build tasks for generation / trainer / (nemo-gym) workers
+    build_tasks: dict[str, Callable[[], Any]] = {}
+    generation = None
+    defer_generation_model_load = False
+    gen_reserve_time = 0.0
+
     def _build_generation_then_trainer(
         defer_generation_model_load: bool, generation=None
     ) -> tuple[Any, Any, dict[str, float]]:
@@ -488,13 +494,9 @@ def setup_single_controller(
 
         return generation, trainer, time_metrics
 
-    # Create build tasks for generation / trainer / (nemo-gym) workers
-    build_tasks: dict[str, Callable[[], Any]] = {}
-    generation = None
-    defer_generation_model_load = False
     if use_nemo_gym:
         # defer generation, only get base_urls for nemo_gym spinup
-        generation, _ = _build_generation(
+        generation, gen_reserve_time = _build_generation(
             inference_cluster,
             master_config=master_config,
             defer_model_load=True,
@@ -546,12 +548,18 @@ def setup_single_controller(
 
     if colocated:
         generation, trainer, time_metrics = results["generation_trainer"]
-        setattr(setup_timing_metrics, gen_init_time_key, time_metrics["gen_time"])
+        setattr(
+            setup_timing_metrics,
+            gen_init_time_key,
+            time_metrics["gen_time"] + gen_reserve_time,
+        )
         setup_timing_metrics.policy_init_time_s = time_metrics["trainer_time"]
     else:
-        generation, gen_time = results["generation"]
+        generation, gen_load_time = results["generation"]
         trainer, trainer_time = results["trainer"]
-        setattr(setup_timing_metrics, gen_init_time_key, gen_time)
+        setattr(
+            setup_timing_metrics, gen_init_time_key, gen_load_time + gen_reserve_time
+        )
         setup_timing_metrics.policy_init_time_s = trainer_time
 
     worker_setup_time = time.perf_counter() - setup_start_time

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -464,7 +464,8 @@ def setup_single_controller(
         """Build generation then trainer serially.
 
         Args:
-            defer_generation_model_load: If True, `generation` is a pre-reserved handle and this call finishes its model load; if False, builds generation from scratch.
+            defer_generation_model_load: If True, generation is a pre-reserved handle and this call
+                finishes its model load; if False, builds generation from scratch.
             generation: Pre-reserved generation handle when defer_generation_model_load=True; None otherwise.
 
         Returns:
@@ -534,6 +535,8 @@ def setup_single_controller(
             _build_trainer,
             train_cluster=train_cluster,
             master_config=master_config,
+            tokenizer=tokenizer,
+            processor=processor,
         )
 
     # Submit build tasks and get results

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -25,7 +25,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Optional, cast
+from typing import Any, Callable, Optional, cast
 
 from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import AutoProcessor
@@ -492,7 +492,7 @@ def setup_single_controller(
         return generation, trainer, time_metrics
 
     # Create build tasks for generation / trainer / (nemo-gym) workers
-    build_tasks = {}
+    build_tasks: dict[str, Callable[[], Any]] = {}
     generation = None
     defer_generation_model_load = False
     if use_nemo_gym:

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -181,8 +181,8 @@ def _build_generation(
         defer_model_load: If True (for the NeMo-Gym flow), reserve OpenAI server URLs without loading weights; caller runs gen.load_and_start() later.
 
     Returns:
-        gen: The generation object (VllmGeneration or SGLangGeneration).
-        elapsed_s: Wall time spent in this call.
+        A tuple of (generation object, wall time spent in this call). The
+        generation object is a VllmGeneration or SGLangGeneration.
     """
     t0 = time.perf_counter()
     generation_config = master_config.policy["generation"]
@@ -232,8 +232,7 @@ def _finish_deferred_generation(generation: Any) -> tuple[Any, float]:
         generation: The deferred generation object.
 
     Returns:
-        generation: The finished generation object.
-        elapsed_s: Wall time spent in this call.
+        A tuple of (finished generation object, wall time spent in this call).
     """
     t0 = time.perf_counter()
     generation.load_and_start()
@@ -256,8 +255,7 @@ def _build_trainer(
         processor: Optional AutoProcessor for VLM paths.
 
     Returns:
-        trainer: The TQPolicy trainer.
-        elapsed_s: Wall time spent in this call.
+        A tuple of (TQPolicy trainer, wall time spent in this call).
     """
     t0 = time.perf_counter()
     loss_config = master_config.loss_fn
@@ -284,8 +282,7 @@ def _spinup_gym(master_config: MasterConfig, base_urls: list[str]) -> tuple[Any,
         base_urls: Reserved vLLM OpenAI server URLs.
 
     Returns:
-        actor: The NeMo-Gym actor.
-        elapsed_s: Wall time spent in this call.
+        A tuple of (NeMo-Gym actor, wall time spent in this call).
     """
     t0 = time.perf_counter()
     policy_config = master_config.policy
@@ -363,8 +360,8 @@ def setup_single_controller(
         partition_id: TQ partition the rollout writer + sampler share.
 
     Returns:
-        actor_args: Pre-built SC actor args.
-        setup_timing_metrics: Driver-side per-phase timings, logged by the SC actor.
+        A tuple of (pre-built SC actor args, driver-side per-phase timings
+        logged by the SC actor).
     """
     validate_single_controller_config(master_config)
 
@@ -469,9 +466,8 @@ def setup_single_controller(
             generation: Pre-reserved generation handle when defer_generation_model_load=True; None otherwise.
 
         Returns:
-            generation: The finalized generation object.
-            trainer: The TQPolicy trainer.
-            time_metrics: Per-phase wall times keyed as "gen_time" and "trainer_time".
+            A tuple of (finalized generation object, TQPolicy trainer,
+            per-phase wall times keyed as "gen_time" and "trainer_time").
         """
         time_metrics = {}
 

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -446,7 +446,13 @@ def setup_single_controller(
     setup_start_time = time.perf_counter()
     setup_timing_metrics = SetupTimingMetrics()
     gen_backend = generation_config["backend"]
-    gen_init_time_key = f"{gen_backend}_init_time_s"
+    # TODO: SC doesn't support megatron generation yet; the megatron branch is
+    # defensive — mirrors grpo.py so the metric key stays valid if we add it.
+    gen_init_time_key = (
+        "megatron_generation_init_time_s"
+        if gen_backend == "megatron"
+        else f"{gen_backend}_init_time_s"
+    )
 
     # Create clusters
     train_cluster, inference_cluster = _build_clusters(master_config)
@@ -562,7 +568,7 @@ def setup_single_controller(
     weight_synchronizer = create_weight_synchronizer(
         policy=trainer,
         generation=generation,
-        gen_backend=gen_backend,
+        generation_backend=gen_backend,
         colocated=colocated,
         train_cluster=train_cluster,
         inference_cluster=inference_cluster,

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -38,6 +38,10 @@ from nemo_rl.algorithms.grpo import (
 )
 from nemo_rl.algorithms.loss import ClippedPGLossFn
 from nemo_rl.algorithms.loss.interfaces import LossFunction
+from nemo_rl.algorithms.metric_utils import (
+    SetupTimingMetrics,
+    print_setup_timing_summary,
+)
 from nemo_rl.algorithms.single_controller_utils.config import (
     MasterConfig,
     validate_single_controller_config,
@@ -268,7 +272,7 @@ def setup_single_controller(
     *,
     processor: Optional[AutoProcessor] = None,
     partition_id: str = "rollout_data",
-) -> tuple[SingleControllerActorArgs, dict[str, Any]]:
+) -> tuple[SingleControllerActorArgs, SetupTimingMetrics]:
     """Build the full SC actor args driver-side.
 
     Args:
@@ -359,7 +363,7 @@ def setup_single_controller(
     # Setup Clusters & Workers
     # ==========================
     setup_start_time = time.perf_counter()
-    setup_timing_metrics: dict[str, Any] = {}
+    setup_timing_metrics = SetupTimingMetrics()
     gen_backend = generation_config["backend"]
     gen_init_time_key = f"{gen_backend}_init_time_s"
 
@@ -381,9 +385,9 @@ def setup_single_controller(
         # comes up before the policy.
         generation, gen_time = _timed_build_generation()
         policy, policy_time = _timed_build_trainer()
-        setup_timing_metrics[gen_init_time_key] = gen_time
-        setup_timing_metrics["policy_init_time_s"] = policy_time
-        setup_timing_metrics["parallel_init_enabled"] = 0.0
+        setattr(setup_timing_metrics, gen_init_time_key, gen_time)
+        setup_timing_metrics.policy_init_time_s = policy_time
+        setup_timing_metrics.parallel_init_enabled = 0.0
     else:
         # Non-colocated: generation + policy run on disjoint GPUs, so
         # bring them up in parallel.
@@ -393,12 +397,12 @@ def setup_single_controller(
             policy_future = executor.submit(_timed_build_trainer)
             generation, gen_time = gen_future.result()
             policy, policy_time = policy_future.result()
-        setup_timing_metrics[gen_init_time_key] = gen_time
-        setup_timing_metrics["policy_init_time_s"] = policy_time
-        setup_timing_metrics["parallel_wall_time_s"] = (
+        setattr(setup_timing_metrics, gen_init_time_key, gen_time)
+        setup_timing_metrics.policy_init_time_s = policy_time
+        setup_timing_metrics.parallel_wall_time_s = (
             time.perf_counter() - parallel_start_time
         )
-        setup_timing_metrics["parallel_init_enabled"] = 1.0
+        setup_timing_metrics.parallel_init_enabled = 1.0
 
     # ==========================
     # NeMo-Gym actor (after generation is up so OpenAI URLs are available)
@@ -421,7 +425,7 @@ def setup_single_controller(
             routed_experts_dtype=routed_experts_dtype,
             use_fastokens=bool(policy_config["tokenizer"].get("use_fastokens")),
         )
-        setup_timing_metrics["nemo_gym_init_time_s"] = time.perf_counter() - t0
+        setup_timing_metrics.nemo_gym_init_time_s = time.perf_counter() - t0
 
     worker_init_complete_time = time.perf_counter() - setup_start_time
 
@@ -442,7 +446,7 @@ def setup_single_controller(
         refit_buffer_size_gb=policy_config.get("refit_buffer_size_gb"),
     )
     weight_synchronizer.init_communicator()
-    setup_timing_metrics["collective_init_time_s"] = time.perf_counter() - t0
+    setup_timing_metrics.collective_init_time_s = time.perf_counter() - t0
 
     # ==========================
     # Setup Algorithm + Rollout Wiring
@@ -474,11 +478,11 @@ def setup_single_controller(
 
     # Print setup timing metrics
     total_setup_time = time.perf_counter() - setup_start_time
-    setup_timing_metrics["total_setup_time_s"] = total_setup_time
-    setup_timing_metrics["other_setup_time_s"] = (
+    setup_timing_metrics.total_setup_time_s = total_setup_time
+    setup_timing_metrics.other_setup_time_s = (
         total_setup_time - worker_init_complete_time
     )
-    _print_setup_timing_summary(setup_timing_metrics, gen_init_time_key)
+    print_setup_timing_summary(setup_timing_metrics, gen_init_time_key)
 
     # Build actor args and return
     actor_args = SingleControllerActorArgs(
@@ -497,24 +501,3 @@ def setup_single_controller(
         partition_id=partition_id,
     )
     return actor_args, setup_timing_metrics
-
-
-def _print_setup_timing_summary(
-    metrics: dict[str, Any], gen_init_time_key: str
-) -> None:
-    """Log-style summary of setup-phase timings; mirrors grpo.py's block."""
-    print("\n▶ Worker Initialization Timing:")
-    gen_time = metrics.get(gen_init_time_key, 0)
-    if gen_time:
-        print(
-            f"  {gen_init_time_key.removesuffix('_init_time_s')} init: {gen_time:.1f}s"
-        )
-    policy_time = metrics.get("policy_init_time_s", 0)
-    if policy_time:
-        print(f"  Policy init: {policy_time:.1f}s")
-    nemo_gym_time = metrics.get("nemo_gym_init_time_s", 0)
-    if nemo_gym_time:
-        print(f"  NeMo-Gym init: {nemo_gym_time:.1f}s")
-    other_time = metrics.get("other_setup_time_s", 0)
-    print(f"  Other setup: {other_time:.1f}s")
-    print(f"  Total setup: {metrics.get('total_setup_time_s', 0):.1f}s", flush=True)

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -442,14 +442,6 @@ def setup_single_controller(
     # ==========================
     setup_start_time = time.perf_counter()
     setup_timing_metrics = SetupTimingMetrics()
-    gen_backend = generation_config["backend"]
-    # TODO: SC doesn't support megatron generation yet; the megatron branch is
-    # defensive — mirrors grpo.py so the metric key stays valid if we add it.
-    gen_init_time_key = (
-        "megatron_generation_init_time_s"
-        if gen_backend == "megatron"
-        else f"{gen_backend}_init_time_s"
-    )
 
     # Create clusters
     train_cluster, inference_cluster = _build_clusters(master_config)
@@ -542,25 +534,22 @@ def setup_single_controller(
         submitted = {k: executor.submit(fn) for k, fn in build_tasks.items()}
         results = {k: f.result() for k, f in submitted.items()}
 
-    if use_nemo_gym:
-        env_handles["nemo_gym"], gym_time = results["nemo_gym"]
-        setup_timing_metrics.nemo_gym_init_time_s = gym_time
-
     if colocated:
         generation, trainer, time_metrics = results["generation_trainer"]
-        setattr(
-            setup_timing_metrics,
-            gen_init_time_key,
-            time_metrics["gen_time"] + gen_reserve_time,
-        )
+        gen_load_time = time_metrics["gen_time"]
         setup_timing_metrics.policy_init_time_s = time_metrics["trainer_time"]
     else:
         generation, gen_load_time = results["generation"]
         trainer, trainer_time = results["trainer"]
-        setattr(
-            setup_timing_metrics, gen_init_time_key, gen_load_time + gen_reserve_time
-        )
         setup_timing_metrics.policy_init_time_s = trainer_time
+    setup_timing_metrics.generation_init_time_s = gen_reserve_time + gen_load_time
+
+    if use_nemo_gym:
+        env_handles["nemo_gym"], gym_time = results["nemo_gym"]
+        setup_timing_metrics.nemo_gym_init_time_s = gym_time
+        # the two fields are only meaningful when use_nemo_gym enabled
+        setup_timing_metrics.generation_init_reserve_time_s = gen_reserve_time
+        setup_timing_metrics.generation_init_load_time_s = gen_load_time
 
     worker_setup_time = time.perf_counter() - setup_start_time
     setup_timing_metrics.worker_setup_time_s = worker_setup_time
@@ -575,7 +564,7 @@ def setup_single_controller(
     weight_synchronizer = create_weight_synchronizer(
         policy=trainer,
         generation=generation,
-        generation_backend=gen_backend,
+        generation_backend=generation_config["backend"],
         colocated=colocated,
         train_cluster=train_cluster,
         inference_cluster=inference_cluster,
@@ -616,7 +605,7 @@ def setup_single_controller(
     total_setup_time = time.perf_counter() - setup_start_time
     setup_timing_metrics.total_setup_time_s = total_setup_time
     setup_timing_metrics.other_setup_time_s = total_setup_time - worker_setup_time
-    print_setup_timing_summary(setup_timing_metrics, gen_init_time_key)
+    print_setup_timing_summary(setup_timing_metrics)
 
     # Build actor args and return
     actor_args = SingleControllerActorArgs(

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -21,6 +21,7 @@ runtime_envs and breaks Ray's resource resolution (see the PR #2692 follow-up).
 
 from __future__ import annotations
 
+import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any, Optional, cast
@@ -267,7 +268,7 @@ def setup_single_controller(
     *,
     processor: Optional[AutoProcessor] = None,
     partition_id: str = "rollout_data",
-) -> SingleControllerActorArgs:
+) -> tuple[SingleControllerActorArgs, dict[str, Any]]:
     """Build the full SC actor args driver-side.
 
     Args:
@@ -277,7 +278,8 @@ def setup_single_controller(
         partition_id: TQ partition the rollout writer + sampler share.
 
     Returns:
-        SingleControllerActorArgs ready to be passed to SingleControllerActor.
+        actor_args: Pre-built SC actor args.
+        setup_timing_metrics: Driver-side per-phase timings, logged by the SC actor.
     """
     validate_single_controller_config(master_config)
 
@@ -356,25 +358,47 @@ def setup_single_controller(
     # ==========================
     # Setup Clusters & Workers
     # ==========================
+    setup_start_time = time.perf_counter()
+    setup_timing_metrics: dict[str, Any] = {}
+    gen_backend = generation_config["backend"]
+    gen_init_time_key = f"{gen_backend}_init_time_s"
+
     train_cluster, inference_cluster = _build_clusters(master_config)
     colocated = generation_config["colocated"]["enabled"]
+
+    def _timed_build_generation() -> tuple[Any, float]:
+        t0 = time.perf_counter()
+        gen = _build_generation(inference_cluster, master_config)
+        return gen, time.perf_counter() - t0
+
+    def _timed_build_trainer() -> tuple[Any, float]:
+        t0 = time.perf_counter()
+        p = _build_trainer(train_cluster, master_config, tokenizer, processor)
+        return p, time.perf_counter() - t0
+
     if colocated:
         # Colocated: vLLM prefers a clean GPU at load time, so generation
         # comes up before the policy.
-        generation = _build_generation(inference_cluster, master_config)
-        policy = _build_trainer(train_cluster, master_config, tokenizer, processor)
+        generation, gen_time = _timed_build_generation()
+        policy, policy_time = _timed_build_trainer()
+        setup_timing_metrics[gen_init_time_key] = gen_time
+        setup_timing_metrics["policy_init_time_s"] = policy_time
+        setup_timing_metrics["parallel_init_enabled"] = 0.0
     else:
         # Non-colocated: generation + policy run on disjoint GPUs, so
         # bring them up in parallel.
+        parallel_start_time = time.perf_counter()
         with ThreadPoolExecutor(max_workers=2) as executor:
-            gen_future = executor.submit(
-                _build_generation, inference_cluster, master_config
-            )
-            policy_future = executor.submit(
-                _build_trainer, train_cluster, master_config, tokenizer, processor
-            )
-            generation = gen_future.result()
-            policy = policy_future.result()
+            gen_future = executor.submit(_timed_build_generation)
+            policy_future = executor.submit(_timed_build_trainer)
+            generation, gen_time = gen_future.result()
+            policy, policy_time = policy_future.result()
+        setup_timing_metrics[gen_init_time_key] = gen_time
+        setup_timing_metrics["policy_init_time_s"] = policy_time
+        setup_timing_metrics["parallel_wall_time_s"] = (
+            time.perf_counter() - parallel_start_time
+        )
+        setup_timing_metrics["parallel_init_enabled"] = 1.0
 
     # ==========================
     # NeMo-Gym actor (after generation is up so OpenAI URLs are available)
@@ -388,6 +412,7 @@ def setup_single_controller(
             if enable_router_replay
             else "int16"
         )
+        t0 = time.perf_counter()
         env_handles["nemo_gym"] = spinup_nemo_gym_actor(
             env_configs=master_config.env,
             base_urls=generation.dp_openai_server_base_urls,
@@ -396,6 +421,9 @@ def setup_single_controller(
             routed_experts_dtype=routed_experts_dtype,
             use_fastokens=bool(policy_config["tokenizer"].get("use_fastokens")),
         )
+        setup_timing_metrics["nemo_gym_init_time_s"] = time.perf_counter() - t0
+
+    worker_init_complete_time = time.perf_counter() - setup_start_time
 
     # ==========================
     # Setup Data Plane Client & Weight Sync
@@ -403,17 +431,18 @@ def setup_single_controller(
     # Connect-only DP client; TQPolicy already bootstrapped the controller.
     dp_client = build_data_plane_client(dp_config, bootstrap=False)
 
-    backend = generation_config["backend"]
+    t0 = time.perf_counter()
     weight_synchronizer = create_weight_synchronizer(
         policy=policy,
         generation=generation,
-        generation_backend=backend,
+        gen_backend=gen_backend,
         colocated=colocated,
         train_cluster=train_cluster,
         inference_cluster=inference_cluster,
         refit_buffer_size_gb=policy_config.get("refit_buffer_size_gb"),
     )
     weight_synchronizer.init_communicator()
+    setup_timing_metrics["collective_init_time_s"] = time.perf_counter() - t0
 
     # ==========================
     # Setup Algorithm + Rollout Wiring
@@ -443,7 +472,16 @@ def setup_single_controller(
         tq_buffer=tq_buffer,
     )
 
-    return SingleControllerActorArgs(
+    # Print setup timing metrics
+    total_setup_time = time.perf_counter() - setup_start_time
+    setup_timing_metrics["total_setup_time_s"] = total_setup_time
+    setup_timing_metrics["other_setup_time_s"] = (
+        total_setup_time - worker_init_complete_time
+    )
+    _print_setup_timing_summary(setup_timing_metrics, gen_init_time_key)
+
+    # Build actor args and return
+    actor_args = SingleControllerActorArgs(
         gen_handle=generation,
         trainer_handle=policy,
         env_handles=env_handles,
@@ -458,3 +496,25 @@ def setup_single_controller(
         tq_buffer=tq_buffer,
         partition_id=partition_id,
     )
+    return actor_args, setup_timing_metrics
+
+
+def _print_setup_timing_summary(
+    metrics: dict[str, Any], gen_init_time_key: str
+) -> None:
+    """Log-style summary of setup-phase timings; mirrors grpo.py's block."""
+    print("\n▶ Worker Initialization Timing:")
+    gen_time = metrics.get(gen_init_time_key, 0)
+    if gen_time:
+        print(
+            f"  {gen_init_time_key.removesuffix('_init_time_s')} init: {gen_time:.1f}s"
+        )
+    policy_time = metrics.get("policy_init_time_s", 0)
+    if policy_time:
+        print(f"  Policy init: {policy_time:.1f}s")
+    nemo_gym_time = metrics.get("nemo_gym_init_time_s", 0)
+    if nemo_gym_time:
+        print(f"  NeMo-Gym init: {nemo_gym_time:.1f}s")
+    other_time = metrics.get("other_setup_time_s", 0)
+    print(f"  Other setup: {other_time:.1f}s")
+    print(f"  Total setup: {metrics.get('total_setup_time_s', 0):.1f}s", flush=True)

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from functools import partial
 from typing import Any, Optional, cast
 
 from torchdata.stateful_dataloader import StatefulDataLoader
@@ -169,19 +170,41 @@ def _build_clusters(
 def _build_generation(
     inference_cluster: RayVirtualCluster,
     master_config: MasterConfig,
-):
-    """Spin up the generation backend (vLLM or SGLang)."""
+    *,
+    defer_model_load: bool = False,
+) -> tuple[Any, float]:
+    """Spin up the generation backend (vLLM or SGLang).
+
+    Args:
+        inference_cluster: Ray virtual cluster the generation workers run on.
+        master_config: SC MasterConfig.
+        defer_model_load: If True (for the NeMo-Gym flow), reserve OpenAI server URLs without loading weights; caller runs gen.load_and_start() later.
+
+    Returns:
+        gen: The generation object (VllmGeneration or SGLangGeneration).
+        elapsed_s: Wall time spent in this call.
+    """
+    t0 = time.perf_counter()
     generation_config = master_config.policy["generation"]
     generation_config["model_name"] = master_config.policy["model_name"]
     backend = generation_config["backend"]
+
     if backend == "vllm":
         vllm_config = cast(VllmConfig, generation_config)
         vllm_config.setdefault("vllm_kwargs", {})["hf_overrides"] = (
             master_config.policy.get("hf_config_overrides", {})
         )
         configure_vllm_for_router_replay(master_config.policy)
-        gen = VllmGeneration(cluster=inference_cluster, config=vllm_config)
+        gen = VllmGeneration(
+            cluster=inference_cluster,
+            config=vllm_config,
+            defer_model_load=defer_model_load,
+        )
+
     elif backend == "sglang":
+        assert not defer_model_load, (
+            "defer_model_load is only supported for the vllm backend"
+        )
         sglang_config = cast(SGLangConfig, generation_config)
         sglang_config["sglang_cfg"].setdefault(
             "model_path", master_config.policy["model_name"]
@@ -190,12 +213,32 @@ def _build_generation(
             cluster=inference_cluster,
             sglang_cfg=sglang_config,
         )
+
     else:
         raise ValueError(
             f"single_controller_utils.setup only supports vllm or sglang generation; got {backend!r}"
         )
-    gen.finish_generation()
-    return gen
+
+    if not defer_model_load:
+        gen.finish_generation()
+
+    return gen, time.perf_counter() - t0
+
+
+def _finish_deferred_generation(generation: Any) -> tuple[Any, float]:
+    """Finish loading and starting the deferred generation.
+
+    Args:
+        generation: The deferred generation object.
+
+    Returns:
+        generation: The finished generation object.
+        elapsed_s: Wall time spent in this call.
+    """
+    t0 = time.perf_counter()
+    generation.load_and_start()
+    generation.finish_generation()
+    return generation, time.perf_counter() - t0
 
 
 def _build_trainer(
@@ -203,17 +246,23 @@ def _build_trainer(
     master_config: MasterConfig,
     tokenizer,
     processor,
-):
+) -> tuple[Any, float]:
     """Build the TQ-mediated trainer (driver-side TQPolicy).
 
-    Driver-side on purpose: instantiating TQPolicy inside another Ray
-    actor nests runtime_envs and triggers Ray's
-    get_accelerator_ids_for_accelerator_resource IndexError. Keep this
-    here until PolicyTrainerActor (PR #2692) lands.
+    Args:
+        train_cluster: Ray virtual cluster the trainer workers run on.
+        master_config: SC MasterConfig.
+        tokenizer: Tokenizer used by the policy.
+        processor: Optional AutoProcessor for VLM paths.
+
+    Returns:
+        trainer: The TQPolicy trainer.
+        elapsed_s: Wall time spent in this call.
     """
+    t0 = time.perf_counter()
     loss_config = master_config.loss_fn
     init_reference_model = loss_config.reference_policy_kl_penalty > 0
-    return TQPolicy(
+    trainer = TQPolicy(
         cluster=train_cluster,
         config=master_config.policy,
         tokenizer=tokenizer,
@@ -224,6 +273,38 @@ def _build_trainer(
         init_reference_model=init_reference_model,
         dp_cfg=master_config.data_plane,
     )
+    return trainer, time.perf_counter() - t0
+
+
+def _spinup_gym(master_config: MasterConfig, base_urls: list[str]) -> tuple[Any, float]:
+    """Spin up the NeMo-Gym actor against the reserved vLLM URLs.
+
+    Args:
+        master_config: SC MasterConfig.
+        base_urls: Reserved vLLM OpenAI server URLs.
+
+    Returns:
+        actor: The NeMo-Gym actor.
+        elapsed_s: Wall time spent in this call.
+    """
+    t0 = time.perf_counter()
+    policy_config = master_config.policy
+    generation_config = policy_config["generation"]
+    enable_router_replay = router_replay_enabled(policy_config)
+    routed_experts_dtype = (
+        resolve_routed_experts_dtype_name_for_model(generation_config["model_name"])
+        if enable_router_replay
+        else "int16"
+    )
+    actor = spinup_nemo_gym_actor(
+        env_configs=master_config.env,
+        base_urls=base_urls,
+        model_name=generation_config["model_name"],
+        enable_router_replay=enable_router_replay,
+        routed_experts_dtype=routed_experts_dtype,
+        use_fastokens=bool(policy_config["tokenizer"].get("use_fastokens")),
+    )
+    return actor, time.perf_counter() - t0
 
 
 def _generation_max_seq_len(generation_config) -> int:
@@ -367,67 +448,109 @@ def setup_single_controller(
     gen_backend = generation_config["backend"]
     gen_init_time_key = f"{gen_backend}_init_time_s"
 
+    # Create clusters
     train_cluster, inference_cluster = _build_clusters(master_config)
     colocated = generation_config["colocated"]["enabled"]
 
-    def _timed_build_generation() -> tuple[Any, float]:
-        t0 = time.perf_counter()
-        gen = _build_generation(inference_cluster, master_config)
-        return gen, time.perf_counter() - t0
+    def _build_generation_then_trainer(
+        defer_generation_model_load: bool, generation=None
+    ) -> tuple[Any, Any, dict[str, float]]:
+        """Build generation then trainer serially.
 
-    def _timed_build_trainer() -> tuple[Any, float]:
-        t0 = time.perf_counter()
-        p = _build_trainer(train_cluster, master_config, tokenizer, processor)
-        return p, time.perf_counter() - t0
+        Args:
+            defer_generation_model_load: If True, `generation` is a pre-reserved handle and this call finishes its model load; if False, builds generation from scratch.
+            generation: Pre-reserved generation handle when defer_generation_model_load=True; None otherwise.
+
+        Returns:
+            generation: The finalized generation object.
+            trainer: The TQPolicy trainer.
+            time_metrics: Per-phase wall times keyed as "gen_time" and "trainer_time".
+        """
+        time_metrics = {}
+
+        # generation
+        if defer_generation_model_load:
+            generation, time_metrics["gen_time"] = _finish_deferred_generation(
+                generation
+            )
+        else:
+            generation, time_metrics["gen_time"] = _build_generation(
+                inference_cluster, master_config
+            )
+
+        # trainer
+        trainer, time_metrics["trainer_time"] = _build_trainer(
+            train_cluster, master_config, tokenizer, processor
+        )
+
+        return generation, trainer, time_metrics
+
+    # Create build tasks for generation / trainer / (nemo-gym) workers
+    build_tasks = {}
+    generation = None
+    defer_generation_model_load = False
+    if use_nemo_gym:
+        # defer generation, only get base_urls for nemo_gym spinup
+        generation, _ = _build_generation(
+            inference_cluster,
+            master_config=master_config,
+            defer_model_load=True,
+        )
+        defer_generation_model_load = True
+        # add nemo_gym spinup task
+        build_tasks["nemo_gym"] = partial(
+            _spinup_gym,
+            master_config=master_config,
+            base_urls=generation.dp_openai_server_base_urls,
+        )
 
     if colocated:
-        # Colocated: vLLM prefers a clean GPU at load time, so generation
-        # comes up before the policy.
-        generation, gen_time = _timed_build_generation()
-        policy, policy_time = _timed_build_trainer()
-        setattr(setup_timing_metrics, gen_init_time_key, gen_time)
-        setup_timing_metrics.policy_init_time_s = policy_time
-        setup_timing_metrics.parallel_init_enabled = 0.0
+        # Colocated: vLLM prefers a clean GPU at load time, so generation comes up before the trainer.
+        build_tasks["generation_trainer"] = partial(
+            _build_generation_then_trainer,
+            defer_generation_model_load=defer_generation_model_load,
+            generation=generation,
+        )
     else:
-        # Non-colocated: generation + policy run on disjoint GPUs, so
-        # bring them up in parallel.
-        parallel_start_time = time.perf_counter()
-        with ThreadPoolExecutor(max_workers=2) as executor:
-            gen_future = executor.submit(_timed_build_generation)
-            policy_future = executor.submit(_timed_build_trainer)
-            generation, gen_time = gen_future.result()
-            policy, policy_time = policy_future.result()
-        setattr(setup_timing_metrics, gen_init_time_key, gen_time)
-        setup_timing_metrics.policy_init_time_s = policy_time
-        setup_timing_metrics.parallel_wall_time_s = (
-            time.perf_counter() - parallel_start_time
+        # Non-colocated: generation + trainer run on disjoint GPUs, so bring them up in parallel.
+        if defer_generation_model_load:
+            build_tasks["generation"] = partial(
+                _finish_deferred_generation,
+                generation=generation,
+            )
+        else:
+            build_tasks["generation"] = partial(
+                _build_generation,
+                inference_cluster=inference_cluster,
+                master_config=master_config,
+            )
+        build_tasks["trainer"] = partial(
+            _build_trainer,
+            train_cluster=train_cluster,
+            master_config=master_config,
         )
-        setup_timing_metrics.parallel_init_enabled = 1.0
 
-    # ==========================
-    # NeMo-Gym actor (after generation is up so OpenAI URLs are available)
-    # ==========================
+    # Submit build tasks and get results
+    with ThreadPoolExecutor(max_workers=len(build_tasks)) as executor:
+        submitted = {k: executor.submit(fn) for k, fn in build_tasks.items()}
+        results = {k: f.result() for k, f in submitted.items()}
+
     if use_nemo_gym:
-        # TODO(#2625): Mirror GRPO's deferred vLLM load so NeMo-Gym spinup
-        # overlaps model loading instead of running serially afterward.
-        enable_router_replay = router_replay_enabled(policy_config)
-        routed_experts_dtype = (
-            resolve_routed_experts_dtype_name_for_model(generation_config["model_name"])
-            if enable_router_replay
-            else "int16"
-        )
-        t0 = time.perf_counter()
-        env_handles["nemo_gym"] = spinup_nemo_gym_actor(
-            env_configs=master_config.env,
-            base_urls=generation.dp_openai_server_base_urls,
-            model_name=generation_config["model_name"],
-            enable_router_replay=enable_router_replay,
-            routed_experts_dtype=routed_experts_dtype,
-            use_fastokens=bool(policy_config["tokenizer"].get("use_fastokens")),
-        )
-        setup_timing_metrics.nemo_gym_init_time_s = time.perf_counter() - t0
+        env_handles["nemo_gym"], gym_time = results["nemo_gym"]
+        setup_timing_metrics.nemo_gym_init_time_s = gym_time
 
-    worker_init_complete_time = time.perf_counter() - setup_start_time
+    if colocated:
+        generation, trainer, time_metrics = results["generation_trainer"]
+        setattr(setup_timing_metrics, gen_init_time_key, time_metrics["gen_time"])
+        setup_timing_metrics.policy_init_time_s = time_metrics["trainer_time"]
+    else:
+        generation, gen_time = results["generation"]
+        trainer, trainer_time = results["trainer"]
+        setattr(setup_timing_metrics, gen_init_time_key, gen_time)
+        setup_timing_metrics.policy_init_time_s = trainer_time
+
+    worker_setup_time = time.perf_counter() - setup_start_time
+    setup_timing_metrics.worker_setup_time_s = worker_setup_time
 
     # ==========================
     # Setup Data Plane Client & Weight Sync
@@ -437,7 +560,7 @@ def setup_single_controller(
 
     t0 = time.perf_counter()
     weight_synchronizer = create_weight_synchronizer(
-        policy=policy,
+        policy=trainer,
         generation=generation,
         gen_backend=gen_backend,
         colocated=colocated,
@@ -479,15 +602,13 @@ def setup_single_controller(
     # Print setup timing metrics
     total_setup_time = time.perf_counter() - setup_start_time
     setup_timing_metrics.total_setup_time_s = total_setup_time
-    setup_timing_metrics.other_setup_time_s = (
-        total_setup_time - worker_init_complete_time
-    )
+    setup_timing_metrics.other_setup_time_s = total_setup_time - worker_setup_time
     print_setup_timing_summary(setup_timing_metrics, gen_init_time_key)
 
     # Build actor args and return
     actor_args = SingleControllerActorArgs(
         gen_handle=generation,
-        trainer_handle=policy,
+        trainer_handle=trainer,
         env_handles=env_handles,
         train_cluster=train_cluster,
         inference_cluster=inference_cluster,

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -18,7 +18,7 @@ import sys
 from collections import Counter
 from collections.abc import AsyncGenerator
 from pathlib import Path
-from typing import Any, Dict, List, NotRequired, TypedDict
+from typing import Any, Dict, List, NotRequired, Optional, TypedDict
 
 import ray
 import torch

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -18,7 +18,7 @@ import sys
 from collections import Counter
 from collections.abc import AsyncGenerator
 from pathlib import Path
-from typing import Any, Dict, List, NotRequired, Optional, TypedDict
+from typing import Any, Dict, List, NotRequired, TypedDict
 
 import ray
 import torch
@@ -850,7 +850,7 @@ def setup_nemo_gym_config(config, tokenizer) -> None:
 
 def spinup_nemo_gym_actor(
     env_configs: dict[str, Any],
-    base_urls: list[Optional[str]],
+    base_urls: list[str],
     model_name: str,
     *,
     enable_router_replay: bool,

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -55,6 +55,7 @@ project-includes = [
   "nemo_rl/algorithms/loss/__init__.py",
   "nemo_rl/algorithms/loss/interfaces.py",
   "nemo_rl/algorithms/loss/utils.py",
+  "nemo_rl/algorithms/metric_utils.py",
   "nemo_rl/algorithms/opd.py",
   "nemo_rl/algorithms/reward_functions.py",
   "nemo_rl/algorithms/single_controller.py",

--- a/tests/test_suites/llm/grpo-llama3.1-8b-instruct-2n8g-async-1off-single-controller-streaming2.sh
+++ b/tests/test_suites/llm/grpo-llama3.1-8b-instruct-2n8g-async-1off-single-controller-streaming2.sh
@@ -36,7 +36,7 @@ if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | ma
     uv run tests/check_metrics.py $JSON_METRICS \
         'median(data["train/token_mult_prob_error"]) < 1.1' \
         'data["train/token_mult_prob_error"]["10"] < 1.1' \
-        'mean(data["train/grad_norm"], 2, 0) > 0.10'
+        'mean(data["train/grad_norm"], 2, 0) > 0.06'
 
     # Clean up checkpoint directory after successful run to save space.
     rm -rf "$CKPT_DIR"

--- a/tests/unit/algorithms/test_metric_utils.py
+++ b/tests/unit/algorithms/test_metric_utils.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for SetupTimingMetrics + print_setup_timing_summary."""
+
+from __future__ import annotations
+
+import pytest
+
+from nemo_rl.algorithms.metric_utils import (
+    SetupTimingMetrics,
+    print_setup_timing_summary,
+)
+
+
+class TestPrintSetupTimingSummary:
+    """print_setup_timing_summary has three code paths with assertions."""
+
+    @staticmethod
+    def _common_setup(**overrides) -> SetupTimingMetrics:
+        base = {
+            "policy_init_time_s": 20.0,
+            "other_setup_time_s": 1.0,
+            "total_setup_time_s": 25.0,
+        }
+        base.update(overrides)
+        return SetupTimingMetrics(**base)
+
+    def test_sc_gym_on_prints_reserve_load_split(self, capsys):
+        """SC + gym-on renders the '(reserve X.Xs + load Y.Ys)' suffix."""
+        metrics = self._common_setup(
+            generation_init_time_s=15.0,
+            generation_init_reserve_time_s=3.0,
+            generation_init_load_time_s=12.0,
+        )
+        print_setup_timing_summary(metrics)
+        out = capsys.readouterr().out
+        assert "Generation init: 15.0s (reserve 3.0s + load 12.0s)" in out
+
+    def test_sc_gym_off_prints_plain_generation_init(self, capsys):
+        """SC + gym-off renders only the top-level generation_init_time_s."""
+        metrics = self._common_setup(generation_init_time_s=15.0)
+        print_setup_timing_summary(metrics)
+        out = capsys.readouterr().out
+        assert "Generation init: 15.0s\n" in out
+        # no reserve/load suffix on this path.
+        assert "reserve" not in out
+        assert "load" not in out
+
+    def test_sc_gym_off_asserts_generation_init_time_populated(self):
+        """SC path with gen_init_time_key=None must have generation_init_time_s set."""
+        metrics = self._common_setup()
+        with pytest.raises(AssertionError):
+            print_setup_timing_summary(metrics)
+
+    def test_grpo_uses_backend_specific_key(self, capsys):
+        """grpo.py path reads the field named by gen_init_time_key."""
+        metrics = self._common_setup(vllm_init_time_s=15.0)
+        print_setup_timing_summary(metrics, gen_init_time_key="vllm_init_time_s")
+        out = capsys.readouterr().out
+        assert "Generation init: 15.0s" in out
+        assert "reserve" not in out
+
+    def test_grpo_asserts_generation_init_time_unset(self):
+        """grpo.py path forbids generation_init_time_s from being populated."""
+        metrics = self._common_setup(
+            generation_init_time_s=15.0,
+            vllm_init_time_s=15.0,
+        )
+        with pytest.raises(AssertionError):
+            print_setup_timing_summary(metrics, gen_init_time_key="vllm_init_time_s")
+
+    def test_reserve_load_split_takes_precedence_over_gen_key(self, capsys):
+        """If reserve_time_s is set, the SC+gym-on branch wins even if a key is passed."""
+        metrics = self._common_setup(
+            generation_init_time_s=15.0,
+            generation_init_reserve_time_s=3.0,
+            generation_init_load_time_s=12.0,
+        )
+        print_setup_timing_summary(metrics, gen_init_time_key="vllm_init_time_s")
+        out = capsys.readouterr().out
+        assert "Generation init: 15.0s (reserve 3.0s + load 12.0s)" in out
+
+    def test_optional_nemo_gym_and_teacher_lines(self, capsys):
+        """nemo_gym_init_time_s and teacher_init_time_s only print when populated."""
+        metrics = self._common_setup(
+            generation_init_time_s=15.0,
+            nemo_gym_init_time_s=8.0,
+            teacher_init_time_s=6.0,
+        )
+        print_setup_timing_summary(metrics)
+        out = capsys.readouterr().out
+        assert "NeMo-Gym init: 8.0s" in out
+        assert "Teacher init: 6.0s" in out
+
+
+class TestSetupTimingMetricsToDict:
+    """to_metrics_dict serializes into a dict for Logger.log_metrics."""
+
+    def test_drops_none_fields(self):
+        """Unset (None) fields are dropped."""
+        metrics = SetupTimingMetrics(generation_init_time_s=1.5)
+        d = metrics.to_metrics_dict()
+        assert d == {"generation_init_time_s": 1.5}
+
+    def test_zero_is_kept(self):
+        """Zero survives the None-drop (the filter is 'is not None', not 'truthy')."""
+        metrics = SetupTimingMetrics(generation_init_time_s=0.0, policy_init_time_s=0.0)
+        d = metrics.to_metrics_dict()
+        assert d == {"generation_init_time_s": 0.0, "policy_init_time_s": 0.0}
+
+    def test_extras_merged_into_top_level(self):
+        """extras dict entries appear as top-level keys, not nested."""
+        metrics = SetupTimingMetrics(generation_init_time_s=1.0)
+        metrics.extras["vllm_nccl_sparse_init_time_s"] = 2.5
+        d = metrics.to_metrics_dict()
+        assert d == {
+            "generation_init_time_s": 1.0,
+            "vllm_nccl_sparse_init_time_s": 2.5,
+        }
+        # extras itself is not exposed as a nested key.
+        assert "extras" not in d
+
+    def test_reserve_load_split_serialized(self):
+        """Reserve/load split fields are included when populated."""
+        metrics = SetupTimingMetrics(
+            generation_init_time_s=15.0,
+            generation_init_reserve_time_s=3.0,
+            generation_init_load_time_s=12.0,
+        )
+        d = metrics.to_metrics_dict()
+        assert d["generation_init_reserve_time_s"] == 3.0
+        assert d["generation_init_load_time_s"] == 12.0

--- a/tests/unit/single_controller/test_rollout_pump.py
+++ b/tests/unit/single_controller/test_rollout_pump.py
@@ -353,7 +353,9 @@ def test_rollout_pump_writes_expected_tq_data(
         partition_id=_PARTITION_ID,
     )
     ctrl = SingleControllerActor.remote(
-        master_config=master_config, actor_args=actor_args
+        master_config=master_config,
+        actor_args=actor_args,
+        setup_timing_metrics={},
     )
 
     vllm_generation.prepare_for_generation()

--- a/tests/unit/single_controller/test_rollout_pump.py
+++ b/tests/unit/single_controller/test_rollout_pump.py
@@ -33,6 +33,7 @@ from nemo_rl.algorithms.async_utils.staleness_sampler import (
 )
 from nemo_rl.algorithms.grpo import GRPOConfig
 from nemo_rl.algorithms.loss import ClippedPGLossConfig
+from nemo_rl.algorithms.metric_utils import SetupTimingMetrics
 from nemo_rl.algorithms.single_controller import SingleControllerActor
 from nemo_rl.algorithms.single_controller_utils.config import (
     AsyncRLConfig,
@@ -355,7 +356,7 @@ def test_rollout_pump_writes_expected_tq_data(
     ctrl = SingleControllerActor.remote(
         master_config=master_config,
         actor_args=actor_args,
-        setup_timing_metrics={},
+        setup_timing_metrics=SetupTimingMetrics(),
     )
 
     vllm_generation.prepare_for_generation()

--- a/tests/unit/single_controller/test_run_grpo_single_controller.py
+++ b/tests/unit/single_controller/test_run_grpo_single_controller.py
@@ -77,7 +77,7 @@ def main_context(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
     monkeypatch.setattr(
         run_grpo_single_controller,
         "setup_single_controller",
-        lambda *_args: actor_args,
+        lambda *_args: (actor_args, {}),
     )
     monkeypatch.setattr(
         run_grpo_single_controller.SingleControllerActor,

--- a/tests/unit/single_controller/test_run_grpo_single_controller.py
+++ b/tests/unit/single_controller/test_run_grpo_single_controller.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from examples import run_grpo_single_controller
+from nemo_rl.algorithms.metric_utils import SetupTimingMetrics
 
 
 @pytest.fixture
@@ -77,7 +78,7 @@ def main_context(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
     monkeypatch.setattr(
         run_grpo_single_controller,
         "setup_single_controller",
-        lambda *_args: (actor_args, {}),
+        lambda *_args: (actor_args, SetupTimingMetrics()),
     )
     monkeypatch.setattr(
         run_grpo_single_controller.SingleControllerActor,

--- a/tests/unit/single_controller/test_single_controller.py
+++ b/tests/unit/single_controller/test_single_controller.py
@@ -76,6 +76,7 @@ def test_rejects_multiple_optimizer_steps_per_rl_step(monkeypatch) -> None:
         controller_cls(
             master_config=master_config,
             actor_args=actor_args,
+            setup_timing_metrics={},
         )
 
 
@@ -117,12 +118,58 @@ def test_logs_hyperparameters_and_concrete_weight_synchronizer(
     controller_cls(
         master_config=master_config,
         actor_args=actor_args,
+        setup_timing_metrics={},
     )
 
     logger.log_hyperparams.assert_called_once_with(master_config.model_dump())
     output = capsys.readouterr().out
     assert "weight_sync=FakeWeightSynchronizer" in output
     assert "transport=stub" not in output
+
+
+def test_logs_setup_timing_metrics(monkeypatch) -> None:
+    """setup_timing_metrics is forwarded to Logger.log_metrics under timing/setup."""
+    logger = MagicMock()
+    monkeypatch.setattr(single_controller, "Logger", lambda _: logger)
+    master_config = MasterConfig.model_construct(
+        policy={"train_global_batch_size": 8},
+        grpo=GRPOConfig.model_construct(
+            num_prompts_per_step=2,
+            num_generations_per_prompt=4,
+        ),
+        loss_fn=ClippedPGLossConfig(force_on_policy_ratio=False),
+        async_rl=AsyncRLConfig(
+            min_groups_for_streaming_train=1,
+            max_buffered_rollouts=4,
+        ),
+        logger={},
+    )
+    setup_metrics = {"vllm_init_time_s": 1.5, "policy_init_time_s": 2.5}
+    actor_args = SimpleNamespace(
+        partition_id="rollout_data",
+        dp_client=None,
+        gen_handle=None,
+        trainer_handle=None,
+        dataloader=None,
+        weight_synchronizer=FakeWeightSynchronizer(),
+        advantage_estimator=None,
+        loss_fn=None,
+        tq_buffer=None,
+        rollout_manager=SimpleNamespace(_tq_buffer=None),
+        train_cluster=None,
+        inference_cluster=None,
+    )
+    controller_cls = SingleControllerActor.__ray_metadata__.modified_class
+
+    controller_cls(
+        master_config=master_config,
+        actor_args=actor_args,
+        setup_timing_metrics=setup_metrics,
+    )
+
+    logger.log_metrics.assert_called_once_with(
+        setup_metrics, step=0, prefix="timing/setup"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/single_controller/test_single_controller.py
+++ b/tests/unit/single_controller/test_single_controller.py
@@ -145,7 +145,9 @@ def test_logs_setup_timing_metrics(monkeypatch) -> None:
         ),
         logger={},
     )
-    setup_metrics = SetupTimingMetrics(vllm_init_time_s=1.5, policy_init_time_s=2.5)
+    setup_metrics = SetupTimingMetrics(
+        generation_init_time_s=1.5, policy_init_time_s=2.5
+    )
     actor_args = SimpleNamespace(
         partition_id="rollout_data",
         dp_client=None,

--- a/tests/unit/single_controller/test_single_controller.py
+++ b/tests/unit/single_controller/test_single_controller.py
@@ -24,6 +24,7 @@ import torch
 import nemo_rl.algorithms.single_controller as single_controller
 from nemo_rl.algorithms.grpo import GRPOConfig
 from nemo_rl.algorithms.loss import ClippedPGLossConfig
+from nemo_rl.algorithms.metric_utils import SetupTimingMetrics
 from nemo_rl.algorithms.single_controller import SingleControllerActor
 from nemo_rl.algorithms.single_controller_utils.config import (
     AdvantageConfig,
@@ -76,7 +77,7 @@ def test_rejects_multiple_optimizer_steps_per_rl_step(monkeypatch) -> None:
         controller_cls(
             master_config=master_config,
             actor_args=actor_args,
-            setup_timing_metrics={},
+            setup_timing_metrics=SetupTimingMetrics(),
         )
 
 
@@ -118,7 +119,7 @@ def test_logs_hyperparameters_and_concrete_weight_synchronizer(
     controller_cls(
         master_config=master_config,
         actor_args=actor_args,
-        setup_timing_metrics={},
+        setup_timing_metrics=SetupTimingMetrics(),
     )
 
     logger.log_hyperparams.assert_called_once_with(master_config.model_dump())
@@ -144,7 +145,7 @@ def test_logs_setup_timing_metrics(monkeypatch) -> None:
         ),
         logger={},
     )
-    setup_metrics = {"vllm_init_time_s": 1.5, "policy_init_time_s": 2.5}
+    setup_metrics = SetupTimingMetrics(vllm_init_time_s=1.5, policy_init_time_s=2.5)
     actor_args = SimpleNamespace(
         partition_id="rollout_data",
         dp_client=None,
@@ -168,7 +169,7 @@ def test_logs_setup_timing_metrics(monkeypatch) -> None:
     )
 
     logger.log_metrics.assert_called_once_with(
-        setup_metrics, step=0, prefix="timing/setup"
+        setup_metrics.to_metrics_dict(), step=0, prefix="timing/setup"
     )
 
 

--- a/tests/unit/single_controller/test_single_controller_setup.py
+++ b/tests/unit/single_controller/test_single_controller_setup.py
@@ -438,24 +438,23 @@ class TestSetup:
         assert actor_args.env_handles["nemo_gym"] is fake_gym_actor
 
     def test_setup_timing_populated_for_colocated_vllm(self, patched_factories):
-        """Colocated vLLM records vllm+policy+collective+total keys, parallel disabled."""
+        """Colocated vLLM records vllm+policy+collective+total fields, parallel disabled."""
         mc = _make_master_config(colocated=True, backend="vllm")
 
         _, metrics = setup_single_controller(mc, MagicMock(pad_token_id=0))
 
-        for key in (
+        for field in (
             "vllm_init_time_s",
             "policy_init_time_s",
             "collective_init_time_s",
             "total_setup_time_s",
             "other_setup_time_s",
         ):
-            assert key in metrics, f"missing {key} in {metrics}"
-            assert metrics[key] >= 0
-        assert metrics["parallel_init_enabled"] == 0.0
-        assert "parallel_wall_time_s" not in metrics
-        # Order-of-phases sanity: worker_init_complete <= total.
-        assert metrics["other_setup_time_s"] >= 0
+            value = getattr(metrics, field)
+            assert value is not None, f"missing {field} on {metrics}"
+            assert value >= 0
+        assert metrics.parallel_init_enabled == 0.0
+        assert metrics.parallel_wall_time_s is None
 
     def test_setup_timing_populated_for_noncolocated_vllm(self, patched_factories):
         """Non-colocated vLLM records parallel_wall_time_s and parallel_init_enabled=1.0."""
@@ -463,20 +462,20 @@ class TestSetup:
 
         _, metrics = setup_single_controller(mc, MagicMock(pad_token_id=0))
 
-        assert metrics["parallel_init_enabled"] == 1.0
-        assert "parallel_wall_time_s" in metrics
-        assert metrics["parallel_wall_time_s"] >= 0
-        assert "vllm_init_time_s" in metrics
-        assert "policy_init_time_s" in metrics
+        assert metrics.parallel_init_enabled == 1.0
+        assert metrics.parallel_wall_time_s is not None
+        assert metrics.parallel_wall_time_s >= 0
+        assert metrics.vllm_init_time_s is not None
+        assert metrics.policy_init_time_s is not None
 
     def test_setup_timing_uses_sglang_key_for_sglang_backend(self, patched_factories):
-        """Generation-init key follows the backend name (sglang_init_time_s)."""
+        """Generation-init field follows the backend name (sglang_init_time_s)."""
         mc = _make_master_config(colocated=True, backend="sglang")
 
         _, metrics = setup_single_controller(mc, MagicMock(pad_token_id=0))
 
-        assert "sglang_init_time_s" in metrics
-        assert "vllm_init_time_s" not in metrics
+        assert metrics.sglang_init_time_s is not None
+        assert metrics.vllm_init_time_s is None
 
     def test_setup_timing_includes_nemo_gym_when_enabled(self, patched_factories):
         """nemo_gym_init_time_s appears when NeMo-Gym is spun up."""
@@ -496,7 +495,7 @@ class TestSetup:
         ):
             _, metrics = setup_single_controller(mc, MagicMock(pad_token_id=0))
 
-        assert "nemo_gym_init_time_s" in metrics
+        assert metrics.nemo_gym_init_time_s is not None
 
     @pytest.mark.parametrize("backend", ["sglang", "megatron"])
     def test_nemo_gym_rejects_non_vllm_backend(self, patched_factories, backend):

--- a/tests/unit/single_controller/test_single_controller_setup.py
+++ b/tests/unit/single_controller/test_single_controller_setup.py
@@ -178,7 +178,7 @@ def test_build_generation_passes_sglang_config():
     inference_cluster = MagicMock(name="inference_cluster")
 
     with patch.object(sc_setup_mod, "SGLangGeneration") as mock_sglang:
-        generation = sc_setup_mod._build_generation(
+        generation, _ = sc_setup_mod._build_generation(
             inference_cluster,
             master_config,
         )
@@ -314,7 +314,7 @@ class TestSetup:
         _, factory_kwargs = patched_factories["create_weight_synchronizer"].call_args
         assert factory_kwargs["policy"] is patched_factories["fake_policy"]
         assert factory_kwargs["generation"] is patched_factories["fake_gen"]
-        assert factory_kwargs["gen_backend"] == "vllm"
+        assert factory_kwargs["generation_backend"] == "vllm"
         assert factory_kwargs["colocated"] is False
 
     def test_custom_partition_id(self, patched_factories):

--- a/tests/unit/single_controller/test_single_controller_setup.py
+++ b/tests/unit/single_controller/test_single_controller_setup.py
@@ -431,13 +431,13 @@ class TestSetup:
         assert actor_args.env_handles["nemo_gym"] is fake_gym_actor
 
     def test_setup_timing_populated_for_colocated_vllm(self, patched_factories):
-        """Colocated vLLM records vllm+policy+collective+total+worker fields."""
+        """Colocated vLLM records gen+policy+collective+total+worker fields."""
         mc = _make_master_config(colocated=True, backend="vllm")
 
         _, metrics = setup_single_controller(mc, MagicMock(pad_token_id=0))
 
         for field in (
-            "vllm_init_time_s",
+            "generation_init_time_s",
             "policy_init_time_s",
             "collective_init_time_s",
             "worker_setup_time_s",
@@ -451,6 +451,9 @@ class TestSetup:
         # shared SetupTimingMetrics — SC does not emit them.
         assert metrics.parallel_wall_time_s is None
         assert metrics.parallel_init_enabled is None
+        # Reserve/load split is populated on the gym-on path only.
+        assert metrics.generation_init_reserve_time_s is None
+        assert metrics.generation_init_load_time_s is None
 
     def test_setup_timing_populated_for_noncolocated_vllm(self, patched_factories):
         """Non-colocated vLLM records the same per-phase fields as colocated."""
@@ -458,21 +461,26 @@ class TestSetup:
 
         _, metrics = setup_single_controller(mc, MagicMock(pad_token_id=0))
 
-        assert metrics.vllm_init_time_s is not None
+        assert metrics.generation_init_time_s is not None
         assert metrics.policy_init_time_s is not None
         assert metrics.worker_setup_time_s is not None
         # parallel_wall_time_s / parallel_init_enabled are grpo.py-only.
         assert metrics.parallel_wall_time_s is None
         assert metrics.parallel_init_enabled is None
+        # Reserve/load split is populated on the gym-on path only.
+        assert metrics.generation_init_reserve_time_s is None
+        assert metrics.generation_init_load_time_s is None
 
-    def test_setup_timing_uses_sglang_key_for_sglang_backend(self, patched_factories):
-        """Generation-init field follows the backend name (sglang_init_time_s)."""
+    def test_setup_timing_backend_agnostic_for_sglang(self, patched_factories):
+        """SC uses the backend-agnostic generation_init_time_s regardless of backend."""
         mc = _make_master_config(colocated=True, backend="sglang")
 
         _, metrics = setup_single_controller(mc, MagicMock(pad_token_id=0))
 
-        assert metrics.sglang_init_time_s is not None
+        assert metrics.generation_init_time_s is not None
+        # Backend-specific fields are grpo.py-only; SC does not populate them.
         assert metrics.vllm_init_time_s is None
+        assert metrics.sglang_init_time_s is None
 
     def test_nemo_gym_uses_deferred_vllm_load(self, patched_factories):
         """NeMo-Gym path reserves vLLM ports up-front and finishes the load afterwards."""
@@ -519,7 +527,7 @@ class TestSetup:
             _, metrics = setup_single_controller(mc, MagicMock(pad_token_id=0))
 
         assert metrics.nemo_gym_init_time_s is not None
-        assert metrics.vllm_init_time_s is not None
+        assert metrics.generation_init_time_s is not None
         assert metrics.policy_init_time_s is not None
         assert metrics.worker_setup_time_s is not None
         # parallel_wall_time_s / parallel_init_enabled are grpo.py-only.
@@ -552,19 +560,20 @@ class TestSetup:
         patched_factories["fake_gen"].load_and_start.assert_called_once_with()
         assert actor_args.gen_handle is patched_factories["fake_gen"]
         assert metrics.nemo_gym_init_time_s is not None
-        assert metrics.vllm_init_time_s is not None
+        assert metrics.generation_init_time_s is not None
         assert metrics.policy_init_time_s is not None
 
     @pytest.mark.parametrize("colocated", [True, False])
-    def test_nemo_gym_vllm_init_time_includes_reserve_time(
+    def test_nemo_gym_generation_init_time_includes_reserve_time(
         self, patched_factories, colocated
     ):
-        """vllm_init_time_s folds in the deferred-VllmGeneration reserve time.
+        """generation_init_time_s folds in the deferred-VllmGeneration reserve time.
 
         With gym on, _build_generation(defer_model_load=True) does worker-group
         spawn + port bind (no weight load). That elapsed time has to end up in
-        vllm_init_time_s alongside the deferred-load elapsed; otherwise gym-on
-        runs undercount vLLM setup by the worker-group span.
+        generation_init_time_s alongside the deferred-load elapsed; otherwise
+        gym-on runs undercount generation setup by the worker-group span. The
+        reserve/load split is also exposed for overlap analysis.
         """
         mc = _make_master_config(colocated=colocated, backend="vllm")
         mc.policy["generation"]["model_name"] = "test-model"
@@ -590,7 +599,9 @@ class TestSetup:
 
         # gen_load_time (from _finish_deferred_generation, unpatched) is ~0 in
         # the test — the reserve time dominates and must be present.
-        assert metrics.vllm_init_time_s >= 3.0
+        assert metrics.generation_init_time_s >= 3.0
+        assert metrics.generation_init_reserve_time_s == 3.0
+        assert metrics.generation_init_load_time_s is not None
 
     @pytest.mark.parametrize("backend", ["sglang", "megatron"])
     def test_nemo_gym_rejects_non_vllm_backend(self, patched_factories, backend):

--- a/tests/unit/single_controller/test_single_controller_setup.py
+++ b/tests/unit/single_controller/test_single_controller_setup.py
@@ -526,9 +526,9 @@ class TestSetup:
         assert metrics.parallel_wall_time_s is None
         assert metrics.parallel_init_enabled is None
 
-    def test_setup_timing_includes_nemo_gym_when_enabled(self, patched_factories):
-        """nemo_gym_init_time_s appears when NeMo-Gym is spun up."""
-        mc = _make_master_config(colocated=True, backend="vllm")
+    def test_nemo_gym_noncolocated_finishes_deferred_load(self, patched_factories):
+        """Non-colocated + gym fans out gym / deferred-load / trainer together."""
+        mc = _make_master_config(colocated=False, backend="vllm")
         mc.policy["generation"]["model_name"] = "test-model"
         mc.policy["generation"]["stop_strings"] = None
         mc.policy["generation"]["stop_token_ids"] = None
@@ -542,9 +542,55 @@ class TestSetup:
             ),
             patch.object(sc_setup_mod, "router_replay_enabled", return_value=False),
         ):
+            actor_args, metrics = setup_single_controller(mc, MagicMock(pad_token_id=0))
+
+        # _build_generation runs once (URL reservation only); the load is finished
+        # by _finish_deferred_generation inside the executor.
+        patched_factories["_build_generation"].assert_called_once()
+        _, gen_kwargs = patched_factories["_build_generation"].call_args
+        assert gen_kwargs.get("defer_model_load") is True
+        patched_factories["fake_gen"].load_and_start.assert_called_once_with()
+        assert actor_args.gen_handle is patched_factories["fake_gen"]
+        assert metrics.nemo_gym_init_time_s is not None
+        assert metrics.vllm_init_time_s is not None
+        assert metrics.policy_init_time_s is not None
+
+    @pytest.mark.parametrize("colocated", [True, False])
+    def test_nemo_gym_vllm_init_time_includes_reserve_time(
+        self, patched_factories, colocated
+    ):
+        """vllm_init_time_s folds in the deferred-VllmGeneration reserve time.
+
+        With gym on, _build_generation(defer_model_load=True) does worker-group
+        spawn + port bind (no weight load). That elapsed time has to end up in
+        vllm_init_time_s alongside the deferred-load elapsed; otherwise gym-on
+        runs undercount vLLM setup by the worker-group span.
+        """
+        mc = _make_master_config(colocated=colocated, backend="vllm")
+        mc.policy["generation"]["model_name"] = "test-model"
+        mc.policy["generation"]["stop_strings"] = None
+        mc.policy["generation"]["stop_token_ids"] = None
+        mc.policy["generation"]["top_k"] = None
+        patched_factories["setup_response_data"].return_value = (list(range(8)), None)
+        # Deferred _build_generation returns 3.0s of reserve time; _build_generation
+        # is only called once (for reservation), so this is the reserve span.
+        patched_factories["_build_generation"].return_value = (
+            patched_factories["fake_gen"],
+            3.0,
+        )
+
+        with (
+            patch.object(sc_setup_mod, "_should_use_nemo_gym", return_value=True),
+            patch.object(
+                sc_setup_mod, "spinup_nemo_gym_actor", return_value=MagicMock()
+            ),
+            patch.object(sc_setup_mod, "router_replay_enabled", return_value=False),
+        ):
             _, metrics = setup_single_controller(mc, MagicMock(pad_token_id=0))
 
-        assert metrics.nemo_gym_init_time_s is not None
+        # gen_load_time (from _finish_deferred_generation, unpatched) is ~0 in
+        # the test — the reserve time dominates and must be present.
+        assert metrics.vllm_init_time_s >= 3.0
 
     @pytest.mark.parametrize("backend", ["sglang", "megatron"])
     def test_nemo_gym_rejects_non_vllm_backend(self, patched_factories, backend):

--- a/tests/unit/single_controller/test_single_controller_setup.py
+++ b/tests/unit/single_controller/test_single_controller_setup.py
@@ -100,6 +100,9 @@ def patched_factories():
     # len(dataloader) used by the Megatron train_iters injection.
     fake_dataloader.__len__ = MagicMock(return_value=4)
     fake_env_handles = {"math": MagicMock(name="math_env")}
+    # Real return objects; _build_generation and _build_trainer return (obj, elapsed_s) tuples.
+    fake_gen = MagicMock(name="gen")
+    fake_policy = MagicMock(name="policy")
 
     with (
         patch.object(
@@ -121,10 +124,10 @@ def patched_factories():
             ),
         ) as mock_clusters,
         patch.object(
-            sc_setup_mod, "_build_generation", return_value=MagicMock(name="gen")
+            sc_setup_mod, "_build_generation", return_value=(fake_gen, 0.0)
         ) as mock_gen,
         patch.object(
-            sc_setup_mod, "_build_trainer", return_value=MagicMock(name="policy")
+            sc_setup_mod, "_build_trainer", return_value=(fake_policy, 0.0)
         ) as mock_trainer,
         patch.object(
             sc_setup_mod,
@@ -162,6 +165,8 @@ def patched_factories():
             "ClippedPGLossFn": mock_loss,
             "dataloader": fake_dataloader,
             "env_handles": fake_env_handles,
+            "fake_gen": fake_gen,
+            "fake_policy": fake_policy,
         }
 
 
@@ -252,13 +257,8 @@ class TestSetup:
         actor_args, _ = setup_single_controller(mc, tokenizer)
 
         assert isinstance(actor_args, SingleControllerActorArgs)
-        assert (
-            actor_args.gen_handle is patched_factories["_build_generation"].return_value
-        )
-        assert (
-            actor_args.trainer_handle
-            is patched_factories["_build_trainer"].return_value
-        )
+        assert actor_args.gen_handle is patched_factories["fake_gen"]
+        assert actor_args.trainer_handle is patched_factories["fake_policy"]
         assert actor_args.env_handles is patched_factories["env_handles"]
         assert (
             actor_args.dp_client
@@ -312,14 +312,9 @@ class TestSetup:
         setup_single_controller(mc, tokenizer)
 
         _, factory_kwargs = patched_factories["create_weight_synchronizer"].call_args
-        assert (
-            factory_kwargs["policy"] is patched_factories["_build_trainer"].return_value
-        )
-        assert (
-            factory_kwargs["generation"]
-            is patched_factories["_build_generation"].return_value
-        )
-        assert factory_kwargs["generation_backend"] == "vllm"
+        assert factory_kwargs["policy"] is patched_factories["fake_policy"]
+        assert factory_kwargs["generation"] is patched_factories["fake_gen"]
+        assert factory_kwargs["gen_backend"] == "vllm"
         assert factory_kwargs["colocated"] is False
 
     def test_custom_partition_id(self, patched_factories):
@@ -427,9 +422,7 @@ class TestSetup:
 
         mock_spinup.assert_called_once_with(
             env_configs=mc.env,
-            base_urls=patched_factories[
-                "_build_generation"
-            ].return_value.dp_openai_server_base_urls,
+            base_urls=patched_factories["fake_gen"].dp_openai_server_base_urls,
             model_name="test-model",
             enable_router_replay=False,
             routed_experts_dtype="int16",
@@ -438,7 +431,7 @@ class TestSetup:
         assert actor_args.env_handles["nemo_gym"] is fake_gym_actor
 
     def test_setup_timing_populated_for_colocated_vllm(self, patched_factories):
-        """Colocated vLLM records vllm+policy+collective+total fields, parallel disabled."""
+        """Colocated vLLM records vllm+policy+collective+total+worker fields."""
         mc = _make_master_config(colocated=True, backend="vllm")
 
         _, metrics = setup_single_controller(mc, MagicMock(pad_token_id=0))
@@ -447,26 +440,30 @@ class TestSetup:
             "vllm_init_time_s",
             "policy_init_time_s",
             "collective_init_time_s",
+            "worker_setup_time_s",
             "total_setup_time_s",
             "other_setup_time_s",
         ):
             value = getattr(metrics, field)
             assert value is not None, f"missing {field} on {metrics}"
             assert value >= 0
-        assert metrics.parallel_init_enabled == 0.0
+        # parallel_wall_time_s / parallel_init_enabled are grpo.py-only in the
+        # shared SetupTimingMetrics — SC does not emit them.
         assert metrics.parallel_wall_time_s is None
+        assert metrics.parallel_init_enabled is None
 
     def test_setup_timing_populated_for_noncolocated_vllm(self, patched_factories):
-        """Non-colocated vLLM records parallel_wall_time_s and parallel_init_enabled=1.0."""
+        """Non-colocated vLLM records the same per-phase fields as colocated."""
         mc = _make_master_config(colocated=False, backend="vllm")
 
         _, metrics = setup_single_controller(mc, MagicMock(pad_token_id=0))
 
-        assert metrics.parallel_init_enabled == 1.0
-        assert metrics.parallel_wall_time_s is not None
-        assert metrics.parallel_wall_time_s >= 0
         assert metrics.vllm_init_time_s is not None
         assert metrics.policy_init_time_s is not None
+        assert metrics.worker_setup_time_s is not None
+        # parallel_wall_time_s / parallel_init_enabled are grpo.py-only.
+        assert metrics.parallel_wall_time_s is None
+        assert metrics.parallel_init_enabled is None
 
     def test_setup_timing_uses_sglang_key_for_sglang_backend(self, patched_factories):
         """Generation-init field follows the backend name (sglang_init_time_s)."""
@@ -476,6 +473,58 @@ class TestSetup:
 
         assert metrics.sglang_init_time_s is not None
         assert metrics.vllm_init_time_s is None
+
+    def test_nemo_gym_uses_deferred_vllm_load(self, patched_factories):
+        """NeMo-Gym path reserves vLLM ports up-front and finishes the load afterwards."""
+        mc = _make_master_config(colocated=True, backend="vllm")
+        mc.policy["generation"]["model_name"] = "test-model"
+        mc.policy["generation"]["stop_strings"] = None
+        mc.policy["generation"]["stop_token_ids"] = None
+        mc.policy["generation"]["top_k"] = None
+        patched_factories["setup_response_data"].return_value = (list(range(8)), None)
+
+        with (
+            patch.object(sc_setup_mod, "_should_use_nemo_gym", return_value=True),
+            patch.object(
+                sc_setup_mod, "spinup_nemo_gym_actor", return_value=MagicMock()
+            ),
+            patch.object(sc_setup_mod, "router_replay_enabled", return_value=False),
+        ):
+            setup_single_controller(mc, MagicMock(pad_token_id=0))
+
+        # _build_generation must be called with defer_model_load=True so the workers
+        # only reserve URLs; load_and_start()+finish_generation() run afterwards.
+        _, gen_kwargs = patched_factories["_build_generation"].call_args
+        assert gen_kwargs.get("defer_model_load") is True
+        deferred_vllm = patched_factories["fake_gen"]
+        deferred_vllm.load_and_start.assert_called_once_with()
+        deferred_vllm.finish_generation.assert_called_once_with()
+
+    def test_nemo_gym_records_timing_metrics(self, patched_factories):
+        """NeMo-Gym path records per-phase timings (vllm/policy/gym/worker)."""
+        mc = _make_master_config(colocated=True, backend="vllm")
+        mc.policy["generation"]["model_name"] = "test-model"
+        mc.policy["generation"]["stop_strings"] = None
+        mc.policy["generation"]["stop_token_ids"] = None
+        mc.policy["generation"]["top_k"] = None
+        patched_factories["setup_response_data"].return_value = (list(range(8)), None)
+
+        with (
+            patch.object(sc_setup_mod, "_should_use_nemo_gym", return_value=True),
+            patch.object(
+                sc_setup_mod, "spinup_nemo_gym_actor", return_value=MagicMock()
+            ),
+            patch.object(sc_setup_mod, "router_replay_enabled", return_value=False),
+        ):
+            _, metrics = setup_single_controller(mc, MagicMock(pad_token_id=0))
+
+        assert metrics.nemo_gym_init_time_s is not None
+        assert metrics.vllm_init_time_s is not None
+        assert metrics.policy_init_time_s is not None
+        assert metrics.worker_setup_time_s is not None
+        # parallel_wall_time_s / parallel_init_enabled are grpo.py-only.
+        assert metrics.parallel_wall_time_s is None
+        assert metrics.parallel_init_enabled is None
 
     def test_setup_timing_includes_nemo_gym_when_enabled(self, patched_factories):
         """nemo_gym_init_time_s appears when NeMo-Gym is spun up."""

--- a/tests/unit/single_controller/test_single_controller_setup.py
+++ b/tests/unit/single_controller/test_single_controller_setup.py
@@ -249,7 +249,7 @@ class TestSetup:
         mc = _make_master_config(colocated=True)
         tokenizer = MagicMock(pad_token_id=0)
 
-        actor_args = setup_single_controller(mc, tokenizer)
+        actor_args, _ = setup_single_controller(mc, tokenizer)
 
         assert isinstance(actor_args, SingleControllerActorArgs)
         assert (
@@ -289,7 +289,7 @@ class TestSetup:
         mc = _make_master_config(colocated=True)
         mc.policy["router_replay"] = {"enabled": True}
 
-        actor_args = setup_single_controller(mc, MagicMock(pad_token_id=0))
+        actor_args, _ = setup_single_controller(mc, MagicMock(pad_token_id=0))
 
         assert actor_args.tq_buffer._require_routed_experts is True
 
@@ -298,7 +298,7 @@ class TestSetup:
         math_env_cfg = {"some": "value"}
         mc = _make_master_config(env={"math": math_env_cfg})
 
-        actor_args = setup_single_controller(mc, MagicMock(pad_token_id=0))
+        actor_args, _ = setup_single_controller(mc, MagicMock(pad_token_id=0))
 
         _, call_kwargs = patched_factories["setup_response_data"].call_args
         assert call_kwargs["env_configs"] == {"math": math_env_cfg}
@@ -326,7 +326,7 @@ class TestSetup:
         mc = _make_master_config()
         tokenizer = MagicMock(pad_token_id=7)
 
-        actor_args = setup_single_controller(
+        actor_args, _ = setup_single_controller(
             mc, tokenizer, partition_id="custom_partition"
         )
 
@@ -423,7 +423,7 @@ class TestSetup:
             ) as mock_spinup,
             patch.object(sc_setup_mod, "router_replay_enabled", return_value=False),
         ):
-            actor_args = setup_single_controller(mc, MagicMock(pad_token_id=0))
+            actor_args, _ = setup_single_controller(mc, MagicMock(pad_token_id=0))
 
         mock_spinup.assert_called_once_with(
             env_configs=mc.env,
@@ -436,6 +436,67 @@ class TestSetup:
             use_fastokens=False,
         )
         assert actor_args.env_handles["nemo_gym"] is fake_gym_actor
+
+    def test_setup_timing_populated_for_colocated_vllm(self, patched_factories):
+        """Colocated vLLM records vllm+policy+collective+total keys, parallel disabled."""
+        mc = _make_master_config(colocated=True, backend="vllm")
+
+        _, metrics = setup_single_controller(mc, MagicMock(pad_token_id=0))
+
+        for key in (
+            "vllm_init_time_s",
+            "policy_init_time_s",
+            "collective_init_time_s",
+            "total_setup_time_s",
+            "other_setup_time_s",
+        ):
+            assert key in metrics, f"missing {key} in {metrics}"
+            assert metrics[key] >= 0
+        assert metrics["parallel_init_enabled"] == 0.0
+        assert "parallel_wall_time_s" not in metrics
+        # Order-of-phases sanity: worker_init_complete <= total.
+        assert metrics["other_setup_time_s"] >= 0
+
+    def test_setup_timing_populated_for_noncolocated_vllm(self, patched_factories):
+        """Non-colocated vLLM records parallel_wall_time_s and parallel_init_enabled=1.0."""
+        mc = _make_master_config(colocated=False, backend="vllm")
+
+        _, metrics = setup_single_controller(mc, MagicMock(pad_token_id=0))
+
+        assert metrics["parallel_init_enabled"] == 1.0
+        assert "parallel_wall_time_s" in metrics
+        assert metrics["parallel_wall_time_s"] >= 0
+        assert "vllm_init_time_s" in metrics
+        assert "policy_init_time_s" in metrics
+
+    def test_setup_timing_uses_sglang_key_for_sglang_backend(self, patched_factories):
+        """Generation-init key follows the backend name (sglang_init_time_s)."""
+        mc = _make_master_config(colocated=True, backend="sglang")
+
+        _, metrics = setup_single_controller(mc, MagicMock(pad_token_id=0))
+
+        assert "sglang_init_time_s" in metrics
+        assert "vllm_init_time_s" not in metrics
+
+    def test_setup_timing_includes_nemo_gym_when_enabled(self, patched_factories):
+        """nemo_gym_init_time_s appears when NeMo-Gym is spun up."""
+        mc = _make_master_config(colocated=True, backend="vllm")
+        mc.policy["generation"]["model_name"] = "test-model"
+        mc.policy["generation"]["stop_strings"] = None
+        mc.policy["generation"]["stop_token_ids"] = None
+        mc.policy["generation"]["top_k"] = None
+        patched_factories["setup_response_data"].return_value = (list(range(8)), None)
+
+        with (
+            patch.object(sc_setup_mod, "_should_use_nemo_gym", return_value=True),
+            patch.object(
+                sc_setup_mod, "spinup_nemo_gym_actor", return_value=MagicMock()
+            ),
+            patch.object(sc_setup_mod, "router_replay_enabled", return_value=False),
+        ):
+            _, metrics = setup_single_controller(mc, MagicMock(pad_token_id=0))
+
+        assert "nemo_gym_init_time_s" in metrics
 
     @pytest.mark.parametrize("backend", ["sglang", "megatron"])
     def test_nemo_gym_rejects_non_vllm_backend(self, patched_factories, backend):

--- a/tests/unit/single_controller/test_train_pump.py
+++ b/tests/unit/single_controller/test_train_pump.py
@@ -30,6 +30,7 @@ from nemo_rl.algorithms.async_utils.replay_buffer import TQReplayBuffer
 from nemo_rl.algorithms.async_utils.staleness_sampler import WindowedSamplerConfig
 from nemo_rl.algorithms.grpo import GRPOConfig
 from nemo_rl.algorithms.loss import ClippedPGLossConfig
+from nemo_rl.algorithms.metric_utils import SetupTimingMetrics
 from nemo_rl.algorithms.single_controller import SingleControllerActor
 from nemo_rl.algorithms.single_controller_utils.config import (
     AsyncRLConfig,
@@ -343,7 +344,7 @@ def test_train_pump_drives_mcore_training_step(
             metric_log_handle=log,
             master_config=master_config,
             actor_args=actor_args,
-            setup_timing_metrics={},
+            setup_timing_metrics=SetupTimingMetrics(),
         )
 
         # train_steps outer steps, each: sampler.select → advantage stage → begin/microbatches/finish → sync.

--- a/tests/unit/single_controller/test_train_pump.py
+++ b/tests/unit/single_controller/test_train_pump.py
@@ -343,6 +343,7 @@ def test_train_pump_drives_mcore_training_step(
             metric_log_handle=log,
             master_config=master_config,
             actor_args=actor_args,
+            setup_timing_metrics={},
         )
 
         # train_steps outer steps, each: sampler.select → advantage stage → begin/microbatches/finish → sync.

--- a/tools/refit_verifier.py
+++ b/tools/refit_verifier.py
@@ -651,7 +651,7 @@ def initialize_generation_with_policy(
         worker_init_timing_metrics[init_time_key] = generation_time
         worker_init_timing_metrics["policy_init_time_s"] = policy_time
         worker_init_timing_metrics["parallel_wall_time_s"] = parallel_wall_time
-        worker_init_timing_metrics["parallel_init_enabled"] = True
+        worker_init_timing_metrics["parallel_init_enabled"] = 1.0
     else:
         print(
             "  ⚙️  Using sequential worker initialization (colocated mode)",


### PR DESCRIPTION
## Summary
- Parallel NeMo-Gym init on the SC path, mirroring grpo.py: reserve vLLM URLs up-front (via `defer_model_load=True`) so NeMo-Gym spins up in parallel with the vLLM weight load and trainer build.
- Extract `SetupTimingMetrics` dataclass + `print_setup_timing_summary` into `nemo_rl.algorithms.metric_utils`, shared by SC and grpo.
- SC uses backend-agnostic `generation_init_time_s` (with `generation_init_reserve_time_s` / `generation_init_load_time_s` split populated when the NeMo-Gym overlap path runs); `print_setup_timing_summary` renders the split as `Generation init: X.Xs (reserve X.Xs + load X.Xs)`. grpo.py keeps the existing per-backend `<backend>_init_time_s` fields.
- SC now emits `worker_setup_time_s` and drops `parallel_wall_time_s` / `parallel_init_enabled` (grpo-only).
- Fix `vllm_init_time_s` under-count on grpo.py's NeMo-Gym path: the deferred `VllmGeneration.__init__` elapsed (worker-group spawn + port bind, no weight load) was previously discarded, so `vllm_init_time_s` on gym-on runs only counted `load_and_start`. Now folded in.
- Update `grpo-llama3.1-8b-instruct-2n8g-async-1off-single-controller-streaming2`'s threshold since that value was tested by non-streaming instead of streaming 2 by mistake in https://github.com/NVIDIA-NeMo/RL/pull/3266. w/ the fix in https://github.com/NVIDIA-NeMo/RL/pull/3282, `mean(data["train/grad_norm"], 2, 0)` is `0.07307618069979879`; w/o the fix, it's `0.04454974799106518`, so update to `> 0.06`.

## Test plan
- [x] `uv run pytest -q tests/unit/single_controller/`
- [x] SC nightlies:
  - `grpo-llama3.1-8b-instruct-2n8g-async-1off-single-controller-streaming2`
  - `grpo-qwen2.5-math-1.5b-instruct-1n8g-megatron-single-controller-sync`
- [x] `tests/functional/grpo_async_gym_single_controller.sh`

## Worker Initialization Timing (before / after)

From `tests/functional/grpo_async_gym_single_controller.sh`. Current `main` doesn't print the SC setup-timing summary at all, so the baseline is captured on [`90fa6c06d`](https://github.com/NVIDIA-NeMo/RL/commit/90fa6c06da00e26b10335166a8bad9e0e86f3389) (the earliest commit that had SC timing metrics but not this PR's deferred-vLLM overlap) with a small typo fix on top, not `main` HEAD.

**Baseline (`90fa6c06d` + typo fix):**
```
▶ Worker Initialization Timing:
  vllm init: 32.4s
  Policy init: 38.2s
  NeMo-Gym init: 11.8s
  Other setup: 1.9s
  Total setup: 51.9s
```

**Branch (`yukih/sc-parallel-init`):**
```
▶ Worker Initialization Timing:
  Generation init: 32.9s (reserve 11.0s + load 21.9s)
  Policy init: 36.3s
  NeMo-Gym init: 11.9s
  Other setup: 1.7s
  Total setup: 49.0s
```

On this smoke config total wall-time is 51.9s → 49.0s (~3s), and the new `reserve/load` split makes the regime visible: `reserve_time (11.0s) ≈ nemo_gym_init (11.9s)`. Reserve is serial by design (need vLLM URLs before spinning gym), so once gym is only that long the parallel executor has essentially nothing to absorb; the delta here is at the noise level. Reassuring that `reserve + load (32.9s) ≈ baseline vllm init (32.4s)`, so the deferred flow adds no measurable overhead. Once NeMo-Gym init grows in heavier setups (multi-resource-server / agent+tool prefetch / large dataset warmup) so gym > reserve, the parallel-init win becomes visible; this smoke just doesn't exercise that regime.