### PR TITLE
fix: guard tokenizer save with rank 0 to avoid NFS deadlock

### DIFF
--- a/nemo_rl/models/automodel/checkpoint.py
+++ b/nemo_rl/models/automodel/checkpoint.py
@@ -36,6 +36,7 @@ from torch.distributed.device_mesh import DeviceMesh
 from transformers import AutoTokenizer
 
 from nemo_rl.utils.checkpoint import CheckpointingConfig
+from nemo_rl.utils.native_checkpoint import save_tokenizer_on_rank0
 
 
 def _patch_qwen_vl_vision_key_mapping() -> None:
@@ -325,8 +326,10 @@ class AutomodelCheckpointManager:
             )
 
         if tokenizer_path and tokenizer is not None:
-            print(f"Saving tokenizer (or processor) to {tokenizer_path}")
-            tokenizer.save_pretrained(tokenizer_path)
+            # Rank-0 guarded: passing tokenizer_path bypasses save_model()'s
+            # ConsolidatedHFAddon (we pass tokenizer=None above), which is where
+            # nemo_automodel applies its own rank-0 guard, so we must apply it here.
+            save_tokenizer_on_rank0(tokenizer, tokenizer_path)
 
     def load_checkpoint(
         self,

--- a/nemo_rl/utils/native_checkpoint.py
+++ b/nemo_rl/utils/native_checkpoint.py
@@ -30,6 +30,40 @@ from torch.distributed.checkpoint.stateful import Stateful
 from transformers import AutoConfig, AutoTokenizer
 
 
+def save_tokenizer_on_rank0(tokenizer: Any, tokenizer_path: str) -> None:
+    """Save a tokenizer (or processor) to ``tokenizer_path`` from rank 0 only.
+
+    Unlike model/optimizer state, the tokenizer is *replicated* rather than
+    sharded: every rank holds an identical copy, and ``save_pretrained`` writes
+    to the same rank-independent filenames (``tokenizer_config.json``, ...).
+    Letting all ranks write means N-1 redundant writes racing on the same file.
+    ``save_pretrained`` is not atomic (it opens with ``O_TRUNC``, writes, and may
+    read files back), so concurrent writers can deadlock on the inode lock. On a
+    ``hard``-mounted NFS share this manifests as ranks stuck indefinitely in
+    uninterruptible disk sleep, hanging the whole job at checkpoint time.
+
+    This mirrors the rank-0 guard nemo_automodel applies to the same artifacts in
+    ``nemo_automodel.components.checkpoint.addons.ConsolidatedHFAddon.pre_save``.
+
+    Note this must NOT be applied to ``dcp.save``-based model/optimizer saves:
+    those are collective calls whose output is already rank-disjoint, so guarding
+    them would deadlock and drop every non-zero rank's shard.
+
+    Args:
+        tokenizer: The tokenizer or processor to save.
+        tokenizer_path: Directory to save the tokenizer into.
+    """
+    is_distributed = torch.distributed.is_initialized()
+    if not is_distributed or torch.distributed.get_rank() == 0:
+        print(f"Saving tokenizer (or processor) to {tokenizer_path}")
+        tokenizer.save_pretrained(tokenizer_path)
+    if is_distributed:
+        # Keep non-zero ranks from returning while rank 0 is still writing, so
+        # that the tokenizer directory is complete for any caller that reads it
+        # right after save_checkpoint() returns.
+        torch.distributed.barrier()
+
+
 ## modified from pytorch tutorial https://pytorch.org/tutorials/recipes/distributed_checkpoint_recipe.html
 class ModelState(Stateful):
     """Helper class for tracking model state in distributed checkpointing.
@@ -171,8 +205,7 @@ def save_checkpoint(
             raise ValueError(
                 "tokenizer_path must be provided when saving tokenizer state"
             )
-        print(f"Saving tokenizer (or processor) to {tokenizer_path}")
-        tokenizer.save_pretrained(tokenizer_path)
+        save_tokenizer_on_rank0(tokenizer, tokenizer_path)
 
 
 def load_checkpoint(

--- a/tests/unit/models/automodel/test_automodel_checkpoint.py
+++ b/tests/unit/models/automodel/test_automodel_checkpoint.py
@@ -708,6 +708,61 @@ class TestSaveCheckpointFunctional:
             # Verify tokenizer.save_pretrained was called
             mock_tokenizer.save_pretrained.assert_called_once_with(tokenizer_path)
 
+    @patch("torch.distributed.barrier")
+    @patch("torch.distributed.is_initialized")
+    @patch("torch.distributed.get_rank")
+    @patch("nemo_rl.models.automodel.checkpoint.Checkpointer")
+    def test_save_with_tokenizer_skipped_on_non_zero_rank(
+        self,
+        mock_checkpointer_cls,
+        mock_get_rank,
+        mock_is_initialized,
+        mock_barrier,
+        mock_meshes,
+        mock_model,
+    ):
+        """Only rank 0 may write the tokenizer.
+
+        The tokenizer is replicated across ranks and save_pretrained() writes
+        rank-independent filenames, so 32 ranks writing the same path race on the
+        same inode and can hang the job on a hard-mounted NFS share. The model
+        save stays collective and must still run on every rank.
+        """
+        mock_is_initialized.return_value = True
+        mock_get_rank.return_value = 5
+        mock_dp_mesh, mock_tp_mesh = mock_meshes
+
+        mock_checkpointer = MagicMock()
+        mock_checkpointer_cls.return_value = mock_checkpointer
+
+        manager = AutomodelCheckpointManager(
+            dp_mesh=mock_dp_mesh,
+            tp_mesh=mock_tp_mesh,
+        )
+        manager.init_checkpointer()
+
+        with TemporaryDirectory() as tmp_dir:
+            weights_path = os.path.join(tmp_dir, "model", "weights")
+            tokenizer_path = os.path.join(tmp_dir, "tokenizer")
+            os.makedirs(tokenizer_path)
+
+            mock_tokenizer = MagicMock()
+
+            manager.save_checkpoint(
+                model=mock_model,
+                weights_path=weights_path,
+                tokenizer=mock_tokenizer,
+                tokenizer_path=tokenizer_path,
+                checkpointing_cfg={"enabled": True},
+            )
+
+            # Collective model save still happens on this rank.
+            mock_checkpointer.save_model.assert_called_once()
+            # Replicated tokenizer write is skipped off rank 0...
+            mock_tokenizer.save_pretrained.assert_not_called()
+            # ...but the rank still joins the barrier so rank 0 does not hang.
+            mock_barrier.assert_called_once()
+
 
 @pytest.mark.automodel
 class TestSaveLoadIntegration:

--- a/tests/unit/utils/test_native_checkpoint.py
+++ b/tests/unit/utils/test_native_checkpoint.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import os
 from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -28,6 +29,7 @@ from nemo_rl.utils.native_checkpoint import (
     convert_dcp_to_hf,
     load_checkpoint,
     save_checkpoint,
+    save_tokenizer_on_rank0,
 )
 from tests.unit.test_utils import SimpleLossFn
 
@@ -177,6 +179,68 @@ def assert_recursive_dict_different(dict1, dict2):
     except AssertionError:
         return
     raise AssertionError("Dictionaries are equal")
+
+
+class TestSaveTokenizerOnRank0:
+    """Tests for the rank-0 guard around tokenizer saving.
+
+    The tokenizer is replicated across ranks and ``save_pretrained`` writes
+    rank-independent filenames, so letting every rank write races on the same
+    file and can hang the job on a hard-mounted NFS share.
+    """
+
+    def test_saves_when_distributed_not_initialized(self):
+        tokenizer = MagicMock()
+        with patch("torch.distributed.is_initialized", return_value=False):
+            save_tokenizer_on_rank0(tokenizer, "/some/tokenizer/path")
+        tokenizer.save_pretrained.assert_called_once_with("/some/tokenizer/path")
+
+    def test_saves_on_rank0_and_barriers(self):
+        tokenizer = MagicMock()
+        with (
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch("torch.distributed.get_rank", return_value=0),
+            patch("torch.distributed.barrier") as mock_barrier,
+        ):
+            save_tokenizer_on_rank0(tokenizer, "/some/tokenizer/path")
+        tokenizer.save_pretrained.assert_called_once_with("/some/tokenizer/path")
+        mock_barrier.assert_called_once()
+
+    @pytest.mark.parametrize("rank", [1, 7, 31])
+    def test_skips_write_on_non_zero_ranks(self, rank):
+        tokenizer = MagicMock()
+        with (
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch("torch.distributed.get_rank", return_value=rank),
+            patch("torch.distributed.barrier") as mock_barrier,
+        ):
+            save_tokenizer_on_rank0(tokenizer, "/some/tokenizer/path")
+        # Non-zero ranks must not write: concurrent save_pretrained() calls on
+        # the same path are what deadlocked on the NFS inode lock.
+        tokenizer.save_pretrained.assert_not_called()
+        # ...but they must still reach the barrier, otherwise rank 0 hangs.
+        mock_barrier.assert_called_once()
+
+    def test_save_checkpoint_routes_tokenizer_through_guard(self, tmp_path):
+        """save_checkpoint() must not call save_pretrained() unguarded."""
+        model = torch.nn.Linear(4, 4)
+        tokenizer = MagicMock()
+        with (
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch("torch.distributed.get_rank", return_value=3),
+            patch("torch.distributed.barrier"),
+            patch("nemo_rl.utils.native_checkpoint.dcp.save") as mock_dcp_save,
+        ):
+            save_checkpoint(
+                model,
+                str(tmp_path / "weights"),
+                tokenizer=tokenizer,
+                tokenizer_path=str(tmp_path / "tokenizer"),
+            )
+        # Model save is collective and must run on every rank...
+        mock_dcp_save.assert_called_once()
+        # ...while the replicated tokenizer is skipped on rank 3.
+        tokenizer.save_pretrained.assert_not_called()
 
 
 def test_model_state(mock_experiment):

--- a/tests/unit/utils/test_native_checkpoint.py
+++ b/tests/unit/utils/test_native_checkpoint.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import os
 from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -28,6 +29,7 @@ from nemo_rl.utils.native_checkpoint import (
     convert_dcp_to_hf,
     load_checkpoint,
     save_checkpoint,
+    save_tokenizer_on_rank0,
 )
 from tests.unit.test_utils import SimpleLossFn
 
@@ -174,6 +176,68 @@ def assert_recursive_dict_different(dict1, dict2):
     except AssertionError:
         return
     raise AssertionError("Dictionaries are equal")
+
+
+class TestSaveTokenizerOnRank0:
+    """Tests for the rank-0 guard around tokenizer saving.
+
+    The tokenizer is replicated across ranks and ``save_pretrained`` writes
+    rank-independent filenames, so letting every rank write races on the same
+    file and can hang the job on a hard-mounted NFS share.
+    """
+
+    def test_saves_when_distributed_not_initialized(self):
+        tokenizer = MagicMock()
+        with patch("torch.distributed.is_initialized", return_value=False):
+            save_tokenizer_on_rank0(tokenizer, "/some/tokenizer/path")
+        tokenizer.save_pretrained.assert_called_once_with("/some/tokenizer/path")
+
+    def test_saves_on_rank0_and_barriers(self):
+        tokenizer = MagicMock()
+        with (
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch("torch.distributed.get_rank", return_value=0),
+            patch("torch.distributed.barrier") as mock_barrier,
+        ):
+            save_tokenizer_on_rank0(tokenizer, "/some/tokenizer/path")
+        tokenizer.save_pretrained.assert_called_once_with("/some/tokenizer/path")
+        mock_barrier.assert_called_once()
+
+    @pytest.mark.parametrize("rank", [1, 7, 31])
+    def test_skips_write_on_non_zero_ranks(self, rank):
+        tokenizer = MagicMock()
+        with (
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch("torch.distributed.get_rank", return_value=rank),
+            patch("torch.distributed.barrier") as mock_barrier,
+        ):
+            save_tokenizer_on_rank0(tokenizer, "/some/tokenizer/path")
+        # Non-zero ranks must not write: concurrent save_pretrained() calls on
+        # the same path are what deadlocked on the NFS inode lock.
+        tokenizer.save_pretrained.assert_not_called()
+        # ...but they must still reach the barrier, otherwise rank 0 hangs.
+        mock_barrier.assert_called_once()
+
+    def test_save_checkpoint_routes_tokenizer_through_guard(self, tmp_path):
+        """save_checkpoint() must not call save_pretrained() unguarded."""
+        model = torch.nn.Linear(4, 4)
+        tokenizer = MagicMock()
+        with (
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch("torch.distributed.get_rank", return_value=3),
+            patch("torch.distributed.barrier"),
+            patch("nemo_rl.utils.native_checkpoint.dcp.save") as mock_dcp_save,
+        ):
+            save_checkpoint(
+                model,
+                str(tmp_path / "weights"),
+                tokenizer=tokenizer,
+                tokenizer_path=str(tmp_path / "tokenizer"),
+            )
+        # Model save is collective and must run on every rank...
+        mock_dcp_save.assert_called_once()
+        # ...while the replicated tokenizer is skipped on rank 3.
+        tokenizer.save_pretrained.assert_not_called()
 
 
 def test_model_state(mock_experiment):


### PR DESCRIPTION
## What does this PR do ?

Adds a rank-0 guard around tokenizer saving so that only one process writes the tokenizer directory during checkpointing.

Every rank previously called `tokenizer.save_pretrained()` on the **same** `tokenizer_path`. Unlike model/optimizer state, the tokenizer is *replicated* rather than sharded, and `save_pretrained` writes rank-independent filenames (`tokenizer_config.json`, ...), so all ranks raced on the same files.

`save_pretrained` is not atomic: it opens with `O_TRUNC`, writes, and may read files back. Concurrent writers therefore contend on the inode lock. On a `hard`-mounted NFS share this **deadlocks**: one rank blocks in `do_truncate -> nfs_setattr` holding the inode write lock while the others block in `nfs_start_io_read -> down_read`, all in uninterruptible disk sleep (`D` state). Those ranks never return, so the driver waits forever in `ray.get()` and the whole job hangs at checkpoint time **with no error and no timeout**.

### Observed failure

On an 8-node / 32-rank DTensor v2 SFT run (gemma-4-31B-it), training went silent right after `Saving checkpoint for step 500...` for **35+ hours**. 31 ranks had finished and returned to Ray's `main_loop`; 4 ranks on a single node were stuck:

```
 PID  STAT WCHAN                    ELAPSED      COMMAND
1533  DNl  nfs_start_io_read      1-22:05:56  ray::DTensorPolicyWorkerV2.save_checkpoint
1535  DNl  rpc_wait_bit_killable  1-22:05:56  ray::DTensorPolicyWorkerV2.save_checkpoint
```

Kernel stacks (`/proc/PID/stack`) show the writer/reader interlock, all four on `tokenizer_config.json`:

```
# writer
rpc_wait_bit_killable [sunrpc] -> nfs4_do_setattr [nfsv4] -> nfs_setattr
  -> notify_change -> do_truncate -> handle_truncate -> do_open

# readers
down_read -> nfs_start_io_read [nfs] -> nfs_file_read -> vfs_read
```

`dmesg` confirms: `rwsem_down_read_slowpath`, `blocked for more than 245 seconds`.

### How the guard went missing

`nemo_automodel` already guards these artifacts on rank 0 in `ConsolidatedHFAddon.pre_save`. But `AutomodelCheckpointManager.save_checkpoint` passes `tokenizer=tokenizer if tokenizer_path is None else None` to `save_model()`, and callers (e.g. `sft.py`) **always** pass `tokenizer_path`. So the addon receives `tokenizer=None`, its rank-0 branch never runs, and control falls through to a locally implemented, unguarded `save_pretrained()`.

### Scope of the guard

Deliberately **tokenizer-only**. Model and optimizer saves go through `dcp.save`, which is collective and already writes rank-disjoint files (`shard-000NN-*`, `__N_0.distcp`). Guarding those would deadlock rank 0 in `all_gather` and drop every non-zero rank's shard.

The DTensor v2 value worker reuses `AutomodelCheckpointManager` and is covered by the same change. The v1 path in `native_checkpoint.save_checkpoint` had the same bug and is fixed too.

## Issues

Fixes a silent checkpoint hang on shared NFS storage. No linked issue.

## Usage

No API or config change. Existing checkpointing calls are unaffected; only the number of processes writing the tokenizer directory changes (N to 1).

## Before your PR is "Ready for review"

- [x] Make sure you read and followed the Contributor guidelines
- [x] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? (see note below)
- [x] Did you add or update any necessary documentation? (docstring explains the invariant and why it must not be applied to `dcp.save`)

## Additional Information

Tests added:

- `tests/unit/utils/test_native_checkpoint.py::TestSaveTokenizerOnRank0` covers: non-distributed writes; rank 0 writes and barriers; ranks 1/7/31 skip the write but still barrier; `save_checkpoint()` keeps `dcp.save` running on a non-zero rank while skipping the tokenizer.
- `tests/unit/models/automodel/test_automodel_checkpoint.py::test_save_with_tokenizer_skipped_on_non_zero_rank` pairs with the existing rank-0 test to cover the `AutomodelCheckpointManager` path.

Validation performed:

| Check | Result |
| :--- | :--- |
| New tests (9 cases, incl. `AutomodelCheckpointManager` on ranks 0/5/31) | passed |
| Regression value: reverted the guard and re-ran | **5 failed**, confirming the tests actually catch this bug |
| `ruff check` and `ruff format --check` | clean |

Note on local test runs: `uv run` currently fails to resolve dependencies in my environment for a reason unrelated to this change (`nemo-rl[mcore]` needs `megatron-bridge`, which pins `transformers<=5.3.0`, while `nemo-rl` requires `>=5.5.0`). The tests above were therefore executed against the real modules with a minimal stub for the optional `transformers` import. Please run the full suite in CI.
