### PR TITLE
feat(rollout): add stable partial-rollout lineage

### DIFF
--- a/examples/configs/grpo_math_1B_megatron_single_controller.yaml
+++ b/examples/configs/grpo_math_1B_megatron_single_controller.yaml
@@ -24,6 +24,48 @@ async_rl:
   # Enable per-rollout diagnostic prints (prompt content / completion previews).
   diagnostics: false
 
+  # ── Resiliency ─────────────────────────────────────────────────────────────
+  # What happens to a prompt whose rollout fails. Infrastructure failures are
+  # re-dispatched (the retry re-enters shard selection, so it lands elsewhere);
+  # deterministic per-prompt failures get a much smaller budget because another
+  # shard would fail identically.
+  #
+  # The budgets here govern BOTH rollout paths -- the retry loop sits above the
+  # native/NeMo-Gym split. Anything path-specific lives in the sub-blocks below,
+  # so the structure says which knob applies where. Filling in the block for the
+  # path a run is not taking is rejected at setup rather than silently ignored.
+  rollout_failure:
+    max_infra_attempts_per_prompt: 5  # infra budget; exhausting it fails the run
+    max_data_attempts_per_prompt: 2   # data budget; 1 retry separates transient from deterministic
+    backoff_base_s: 1.0
+    max_backoff_s: 30.0
+    # Prompts allowed to exhaust their data budget and be dropped. 0 fails the run
+    # on the first one, propagating the original error. The two budgets above are
+    # INDEPENDENT counters, so one prompt can consume up to their sum minus one.
+    max_skipped_prompts: 0
+
+    # Deadlines. null disables, which is the default and reproduces the historical
+    # behaviour of waiting forever. Set them in any run that matters: without one a
+    # wedged generation engine parks a rollout permanently, holding a
+    # max_inflight_prompts slot for the rest of the job.
+    native:                           # AsyncRolloutImpl only
+      generation_timeout_s: null      # one generate_async turn
+      env_timeout_s: null             # one environment step
+    nemo_gym:                         # AsyncNemoGymRolloutImpl only
+      rollout_timeout_s: null         # the whole prompt-group rollout, retries included
+      # Re-send just the rows that never arrived before retrying the whole group.
+      # Gym's stream dies on its first failing row, so one bad row loses every later
+      # one; recovering those individually beats redoing all N.
+      max_row_attempts: 3
+
+  # Last-resort stall detection. stall_timeout_s must exceed interval_s and every
+  # deadline above, so a merely-slow rollout is not reported as a stall.
+  watchdog:
+    interval_s: 30.0
+    stall_timeout_s: 600.0
+    stall_action: warn                # warn | abort
+    gym_subprocess_check: true        # polls NeMo-Gym's RunHelper for dead servers
+
 checkpointing:
   enabled: false
   checkpoint_dir: results/grpo-single-controller

--- a/nemo_rl/algorithms/async_utils/replay_buffer.py
+++ b/nemo_rl/algorithms/async_utils/replay_buffer.py
@@ -849,6 +849,11 @@ class TQReplayBuffer:
             raise RuntimeError("data-plane checkpoint barrier is already configured")
         self._data_plane_checkpoint_barrier = barrier
 
+    @property
+    def group_ids(self) -> tuple[str, ...]:
+        """Return a stable snapshot of controller-local replay ownership."""
+        return tuple(self._group_ids)
+
     def reserve(
         self,
         *,
@@ -1011,6 +1016,29 @@ class TQReplayBuffer:
             except ValueError as error:
                 raise ValueError(f"unknown group_id={group_id!r}") from error
             return await self._remove_unlocked([idx], clear_data_plane=remove_in_dp)
+
+    async def clear_staging_keys(self, staging_keys: list[str]) -> None:
+        """Clear known token-capture staging rows under the checkpoint barrier."""
+        if not staging_keys:
+            return
+        if self._staging_partition_id is None:
+            raise RuntimeError(
+                "cannot clear token-capture staging keys without a staging partition"
+            )
+        if self._data_plane_checkpoint_barrier is None:
+            raise RuntimeError(
+                "TQReplayBuffer must be bound to the controller data-plane "
+                "checkpoint barrier before clearing staging samples"
+            )
+        unique_keys = list(dict.fromkeys(staging_keys))
+        async with self._data_plane_checkpoint_barrier.mutation():
+            await call_data_plane(
+                self._dp_client,
+                "clear_samples",
+                offload_sync=True,
+                sample_ids=unique_keys,
+                partition_id=self._staging_partition_id,
+            )
 
     async def commit_finalized(
         self,

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -853,45 +853,15 @@ class SingleControllerActor:
                 f"contains {len(group_ids)} group IDs"
             )
 
-        # Existing TQ-only checkpoints predate the lineage sidecar. Adopt their
-        # finalized rows lazily so completed-rollout recovery keeps working while
-        # the next stacked change adds persisted ledger restoration.
-        for group_id in group_ids:
-            if group_id in ledger:
-                continue
-            indices = [
-                index
-                for index, sample_id in enumerate(meta.sample_ids)
-                if sample_id.rsplit("_g", 1)[0] == group_id
-            ]
-            group_meta = KVBatchMeta(
-                partition_id=meta.partition_id,
-                task_name=meta.task_name,
-                sample_ids=[meta.sample_ids[index] for index in indices],
-                fields=list(meta.fields) if meta.fields is not None else None,
-                sequence_lengths=(
-                    [meta.sequence_lengths[index] for index in indices]
-                    if meta.sequence_lengths is not None
-                    else None
-                ),
-                extra_info=dict(meta.extra_info),
-                tags=(
-                    [dict(meta.tags[index]) for index in indices]
-                    if meta.tags is not None
-                    else None
-                ),
-            )
-            weights = [
-                int(tag["weight_version"])
-                for tag in group_meta.tags or []
-                if "weight_version" in tag
-            ]
-            fallback_weight = self._trainer_version
-            ledger.adopt_finalized_group(
-                group_id=group_id,
-                meta=group_meta,
-                start_weight_version=min(weights, default=fallback_weight),
-                end_weight_version=max(weights, default=fallback_weight),
+        missing_group_ids = [
+            group_id for group_id in group_ids if group_id not in ledger
+        ]
+        if missing_group_ids:
+            raise RuntimeError(
+                "sampler selected canonical rollout group(s) missing from the "
+                "rollout recovery ledger: "
+                f"{missing_group_ids!r}. Restore TQ, replay metadata, and rollout "
+                "lineage from the same checkpoint."
             )
         ledger.claim_groups_for_training(
             group_ids,

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -143,6 +143,7 @@ class SingleControllerActor:
         self._loss_fn = actor_args.loss_fn
         self._buffer = actor_args.tq_buffer
         self._rollout_manager = actor_args.rollout_manager
+        self._rollout_recovery_ledger = self._rollout_manager.recovery_ledger
         # Direct access, deliberately. A getattr default here reads as defensive but
         # buys a silent failure mode: rename or drop the field and
         # watchdog.gym_subprocess_check: true degrades to a health check that iterates
@@ -154,6 +155,10 @@ class SingleControllerActor:
         # when Ray deserializes rollout_manager and tq_buffer separately.
         self._rollout_manager._tq_buffer = self._buffer
         self._finalizer_actors = list(actor_args.finalizer_actors)
+        if self._finalizer_actors and self._rollout_recovery_ledger is None:
+            raise RuntimeError(
+                "token-capture finalizer actors require a rollout recovery ledger"
+            )
         self._available_finalizers: asyncio.Queue[Any] = asyncio.Queue()
         for actor in self._finalizer_actors:
             self._available_finalizers.put_nowait(actor)
@@ -491,14 +496,15 @@ class SingleControllerActor:
         try:
             await self._call_dp(
                 "clear_samples",
-                sample_ids=list(request.rollout_ids),
+                sample_ids=list(request.canonical_sample_ids),
                 partition_id=self._partition_id,
             )
         except Exception as error:
             errors.append(
                 RuntimeError(
                     "pre-publication canonical cleanup failed for "
-                    f"group={request.group_id!r}, ids={request.rollout_ids!r}"
+                    f"group={request.group_id!r}, "
+                    f"ids={request.canonical_sample_ids!r}"
                 )
             )
             errors[-1].__cause__ = error
@@ -524,6 +530,11 @@ class SingleControllerActor:
                 errors,
             )
         self._buffer.abort(request.group_id)
+        if (
+            self._rollout_recovery_ledger is not None
+            and request.group_id in self._rollout_recovery_ledger
+        ):
+            self._rollout_recovery_ledger.discard_group(request.group_id)
 
     async def _cleanup_known_finalization_request(
         self, request: "FinalizationRequest"
@@ -560,11 +571,15 @@ class SingleControllerActor:
             # observes either the complete group or neither half of it while
             # tensor payloads remain outside the SingleController process.
             async with self._data_plane_checkpoint_barrier.mutation():
+                ledger = self._rollout_recovery_ledger
+                assert ledger is not None
+                ledger.mark_finalization_started(request.group_id)
                 try:
                     rpc_submitted = True
                     finalized = await actor.finalize.remote(request)
                 except BaseException:
                     self._finalizer_unknown_outcomes += 1
+                    ledger.mark_finalization_unknown(request.group_id)
                     print(
                         "FATAL: finalizer actor RPC failed after submission; canonical "
                         f"publication outcome is unknown for group {request.group_id}. "
@@ -617,6 +632,12 @@ class SingleControllerActor:
                             [commit_error, cleanup_error],
                         )
                     raise
+                ledger.mark_group_finalized(
+                    request.group_id,
+                    meta=finalized.meta,
+                    group_min_weight_version=finalized.group_min_wv,
+                    group_max_weight_version=finalized.group_max_wv,
+                )
         finally:
             self._active_finalizers -= 1
             # Cancellation before RPC submission leaves the actor untouched;
@@ -803,6 +824,83 @@ class SingleControllerActor:
             flush=True,
         )
 
+    @staticmethod
+    def _group_ids_from_meta(meta: KVBatchMeta) -> list[str]:
+        """Return stable prompt-group IDs in their canonical sample order."""
+        group_ids: list[str] = []
+        for sample_id in meta.sample_ids:
+            if "_g" not in sample_id:
+                raise ValueError(
+                    f"canonical rollout sample ID has no generation suffix: "
+                    f"{sample_id!r}"
+                )
+            group_id, generation_index = sample_id.rsplit("_g", 1)
+            if not group_id or not generation_index.isdigit():
+                raise ValueError(f"invalid canonical rollout sample ID: {sample_id!r}")
+            if not group_ids or group_ids[-1] != group_id:
+                group_ids.append(group_id)
+        return group_ids
+
+    def _claim_train_meta(self, meta: KVBatchMeta, *, num_groups: int) -> list[str]:
+        """Bind a sampler selection to the ledger's current optimizer step."""
+        ledger = self._rollout_recovery_ledger
+        if ledger is None:
+            return self._group_ids_from_meta(meta)
+        group_ids = self._group_ids_from_meta(meta)
+        if len(group_ids) != num_groups:
+            raise ValueError(
+                f"sampler selected {num_groups} groups but canonical metadata "
+                f"contains {len(group_ids)} group IDs"
+            )
+
+        # Existing TQ-only checkpoints predate the lineage sidecar. Adopt their
+        # finalized rows lazily so completed-rollout recovery keeps working while
+        # the next stacked change adds persisted ledger restoration.
+        for group_id in group_ids:
+            if group_id in ledger:
+                continue
+            indices = [
+                index
+                for index, sample_id in enumerate(meta.sample_ids)
+                if sample_id.rsplit("_g", 1)[0] == group_id
+            ]
+            group_meta = KVBatchMeta(
+                partition_id=meta.partition_id,
+                task_name=meta.task_name,
+                sample_ids=[meta.sample_ids[index] for index in indices],
+                fields=list(meta.fields) if meta.fields is not None else None,
+                sequence_lengths=(
+                    [meta.sequence_lengths[index] for index in indices]
+                    if meta.sequence_lengths is not None
+                    else None
+                ),
+                extra_info=dict(meta.extra_info),
+                tags=(
+                    [dict(meta.tags[index]) for index in indices]
+                    if meta.tags is not None
+                    else None
+                ),
+            )
+            weights = [
+                int(tag["weight_version"])
+                for tag in group_meta.tags or []
+                if "weight_version" in tag
+            ]
+            fallback_weight = self._trainer_version
+            ledger.adopt_finalized_group(
+                group_id=group_id,
+                meta=group_meta,
+                start_weight_version=min(weights, default=fallback_weight),
+                end_weight_version=max(weights, default=fallback_weight),
+            )
+        ledger.claim_groups_for_training(
+            group_ids,
+            train_step=self._train_steps,
+            trainer_version=self._trainer_version,
+            expected_group_count=self._master_config.grpo.num_prompts_per_step,
+        )
+        return group_ids
+
     # ── the three pumps + the inline advantage stage ───────────────────────
 
     async def _rollout_pump(self) -> None:
@@ -841,12 +939,16 @@ class SingleControllerActor:
                         target_step=target_step,
                         inflight_registry=self._inflight_by_group_id,
                     )
-                    self._inflight_rollouts -= 1
-                    inflight_count_released = True
-                    sem.release()
-                    generation_permit_released = True
-                    await self._finalize_with_actor(request)
-                    outcome = RolloutOutcome.COMMITTED
+                    if request is None:
+                        outcome = RolloutOutcome.SKIPPED
+                    else:
+                        self._inflight_rollouts -= 1
+                        inflight_count_released = True
+                        sem.release()
+                        generation_permit_released = True
+                        await self._finalize_with_actor(request)
+                        self._rollout_manager.stats.committed += 1
+                        outcome = RolloutOutcome.COMMITTED
                 else:
                     outcome = await self._rollout_manager.generate_and_push(
                         prompt,
@@ -980,9 +1082,24 @@ class SingleControllerActor:
                         await asyncio.sleep(0)
 
                         # Evict stale groups
-                        evicted = await self._sampler.evict(
-                            current_train_weight=self._trainer_version,
-                        )
+                        if self._rollout_recovery_ledger is None:
+                            evicted = await self._sampler.evict(
+                                current_train_weight=self._trainer_version,
+                            )
+                        else:
+                            async with self._data_plane_checkpoint_barrier.mutation():
+                                group_ids_before_evict = set(self._buffer.group_ids)
+                                evicted = await self._sampler.evict(
+                                    current_train_weight=self._trainer_version,
+                                )
+                                evicted_group_ids = group_ids_before_evict - set(
+                                    self._buffer.group_ids
+                                )
+                                for group_id in evicted_group_ids:
+                                    if group_id in self._rollout_recovery_ledger:
+                                        self._rollout_recovery_ledger.discard_group(
+                                            group_id
+                                        )
                         evicted_stale_prompt_groups += evicted
                         if evicted:
                             print(
@@ -1000,11 +1117,26 @@ class SingleControllerActor:
                             self._async_cfg.min_groups_for_streaming_train,
                             max_prompt_groups,
                         )
-                        train_meta, num_groups = await self._sampler.select(
-                            current_train_weight=self._trainer_version,
-                            min_prompt_groups=min_prompt_groups,
-                            max_prompt_groups=max_prompt_groups,
-                        )
+                        if self._rollout_recovery_ledger is None:
+                            train_meta, num_groups = await self._sampler.select(
+                                current_train_weight=self._trainer_version,
+                                min_prompt_groups=min_prompt_groups,
+                                max_prompt_groups=max_prompt_groups,
+                            )
+                        else:
+                            # Selection removes local replay ownership. Keep that
+                            # removal and the matching ledger claim in one mutation
+                            # boundary so a later periodic checkpoint cannot split them.
+                            async with self._data_plane_checkpoint_barrier.mutation():
+                                train_meta, num_groups = await self._sampler.select(
+                                    current_train_weight=self._trainer_version,
+                                    min_prompt_groups=min_prompt_groups,
+                                    max_prompt_groups=max_prompt_groups,
+                                )
+                                if train_meta is not None:
+                                    self._claim_train_meta(
+                                        train_meta, num_groups=num_groups
+                                    )
 
                         # If no batch is selectable, sleep and retry
                         if train_meta is None:
@@ -1030,10 +1162,7 @@ class SingleControllerActor:
 
                         consumed_metas.append(train_meta)
                         consumed_group_count += num_groups
-                        selected_group_ids = {
-                            sample_id.rsplit("_g", 1)[0]
-                            for sample_id in train_meta.sample_ids
-                        }
+                        selected_group_ids = self._group_ids_from_meta(train_meta)
                         for group_id in selected_group_ids:
                             for name, value in self._finalizer_metrics_by_group.pop(
                                 group_id, {}
@@ -1117,7 +1246,16 @@ class SingleControllerActor:
                 with self._timer.time("policy_training"):
                     result = await asyncio.to_thread(self._trainer.finish_train_step)
 
-                await self._cleanup_consumed_metas(consumed_metas)
+                if self._rollout_recovery_ledger is not None:
+                    self._rollout_recovery_ledger.mark_train_step_applied(
+                        self._train_steps
+                    )
+                async with self._data_plane_checkpoint_barrier.mutation():
+                    await self._cleanup_consumed_metas(consumed_metas)
+                    if self._rollout_recovery_ledger is not None:
+                        self._rollout_recovery_ledger.release_applied_train_step(
+                            self._train_steps
+                        )
                 for _ in range(consumed_group_count):
                     self._buffer_capacity.release()
 

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -14,9 +14,9 @@
 
 """SingleController: asyncio orchestrator for the RL training loop.
 
-CPU-only Ray actor that runs two concurrent pumps and coordinates the
-other actors via lightweight RPCs. SC sends control signals and reads
-metadata only — model tensors still move through DataPlane or NCCL.
+CPU-only Ray actor that runs two concurrent pumps plus a watchdog, and
+coordinates the other actors via lightweight RPCs. SC sends control signals
+and reads metadata only — model tensors still move through DataPlane or NCCL.
 
 Data flow:
   _rollout_pump  → gen.generate_and_push(prompt, dp_client) ← RPC to GenWorker
@@ -75,6 +75,8 @@ from nemo_rl.data_plane.async_utils import call_data_plane
 from nemo_rl.data_plane.schema import DP_CALIB_INPUT_FIELDS
 from nemo_rl.data_plane.schema import ROUTE_PLAN_TAG
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.experience.failures import RolloutStall
+from nemo_rl.experience.rollout_manager import RolloutOutcome
 from nemo_rl.experience.route_plan import decode_route_plan
 from nemo_rl.models.generation.sglang.sglang_generation import SGLangGeneration
 from nemo_rl.models.generation.vllm import VllmGeneration
@@ -93,11 +95,14 @@ Generation = Union[VllmGeneration, SGLangGeneration]
 class SingleControllerActor:
     """CPU-only Ray actor that orchestrates the RL training loop.
 
-    Owns two concurrent asyncio tasks:
-      - _rollout_pump: dispatches prompts to GenerationWorkerActor
-      - _train_pump:   claims DataPlane meta, trains, clears consumed rows,
-                       then runs _sync_weights (drain gate + weight
-                       synchronization) inline after each optimizer step
+    Owns three concurrent asyncio tasks:
+      - _rollout_pump:  dispatches prompts to GenerationWorkerActor
+      - _train_pump:    claims DataPlane meta, trains, clears consumed rows,
+                        then runs _sync_weights (drain gate + weight
+                        synchronization) inline after each optimizer step
+      - _watchdog_pump: publishes rollout counters and reports stalls or
+                        unhealthy environments, which are the failures that
+                        otherwise produce no signal at all
 
     All other actors are passive — they expose methods and wait to be called.
     """
@@ -138,6 +143,13 @@ class SingleControllerActor:
         self._loss_fn = actor_args.loss_fn
         self._buffer = actor_args.tq_buffer
         self._rollout_manager = actor_args.rollout_manager
+        # Direct access, deliberately. A getattr default here reads as defensive but
+        # buys a silent failure mode: rename or drop the field and
+        # watchdog.gym_subprocess_check: true degrades to a health check that iterates
+        # nothing and reports nothing -- the exact class of silent failure this work
+        # exists to remove. A missing field should break loudly at construction, where
+        # it costs five minutes, not quietly at hour three of a run.
+        self._env_handles = actor_args.env_handles
         # Rebind so writer and sampler share one buffer instance even
         # when Ray deserializes rollout_manager and tq_buffer separately.
         self._rollout_manager._tq_buffer = self._buffer
@@ -274,30 +286,42 @@ class SingleControllerActor:
 
         await self._maybe_restore_replay_buffer()
 
-        # Start the rollout and train pumps
+        # Start the rollout and train pumps, plus the watchdog
         rollout_task = asyncio.create_task(self._rollout_pump())
         train_task = asyncio.create_task(self._train_pump())
+        watchdog_task = asyncio.create_task(self._watchdog_pump())
+        tasks = (rollout_task, train_task, watchdog_task)
         try:
             done, _ = await asyncio.wait(
-                {rollout_task, train_task}, return_when=asyncio.FIRST_COMPLETED
+                set(tasks), return_when=asyncio.FIRST_COMPLETED
             )
+            if watchdog_task in done:
+                # The watchdog loops forever, so finishing at all means it raised --
+                # a stall or an unhealthy environment. Surface that ahead of the
+                # pumps, whose own symptom would just be "waiting".
+                await watchdog_task
             if rollout_task in done:
                 # Propagate rollout failures immediately. A normally exhausted
                 # rollout pump leaves the train pump to drain committed groups.
                 await rollout_task
             await train_task
         finally:
-            rollout_task.cancel()
-            train_task.cancel()
-            await asyncio.gather(rollout_task, train_task, return_exceptions=True)
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
             for actor in self._finalizer_actors:
                 try:
                     ray.kill(actor, no_restart=True)
                 except Exception as error:
                     print(f"finalizer actor termination failed: {error}", flush=True)
-            self._logger.finish()
-            # Flush the last checkpoint's background finalization before exit.
-            await asyncio.to_thread(self._checkpointer.shutdown)
+            try:
+                self._weight_synchronizer.shutdown()
+            except Exception as e:  # teardown must not mask the original failure
+                print(f"Error during weight-synchronizer shutdown: {e}", flush=True)
+            finally:
+                self._logger.finish()
+                # Flush the last checkpoint's background finalization before exit.
+                await asyncio.to_thread(self._checkpointer.shutdown)
 
         return {
             "train_steps": self._train_steps,
@@ -822,8 +846,9 @@ class SingleControllerActor:
                     sem.release()
                     generation_permit_released = True
                     await self._finalize_with_actor(request)
+                    outcome = RolloutOutcome.COMMITTED
                 else:
-                    await self._rollout_manager.generate_and_push(
+                    outcome = await self._rollout_manager.generate_and_push(
                         prompt,
                         target_step=target_step,
                         inflight_registry=self._inflight_by_group_id,
@@ -840,6 +865,12 @@ class SingleControllerActor:
                     self._inflight_rollouts -= 1
                 if not generation_permit_released:
                     sem.release()
+
+            if outcome is RolloutOutcome.SKIPPED:
+                # Nothing was committed, so the train pump will never see this group
+                # and never release its permit on our behalf.
+                self._buffer_capacity.release()
+                return
 
             if self._async_cfg.diagnostics:
                 content = ""
@@ -1200,6 +1231,110 @@ class SingleControllerActor:
             if should_save_by_timeout:
                 print("Timeout has been reached, stopping training early", flush=True)
                 break
+
+    async def _watchdog_pump(self) -> None:
+        """Report rollout health, and detect stalls nothing else catches.
+
+        Progress is the pair (committed groups, completed train steps) rather than a
+        timestamp: both counters already exist, and "neither has moved" is the property
+        that actually matters.
+
+        Deliberately *not* conditioned on rollouts being in flight. An earlier version
+        required that, on the reasoning that an idle controller has legitimately no
+        work -- and a fault-injection run walked straight through the gap. Killing a
+        generation worker wedged the loop with zero rollouts in flight and zero
+        failures recorded: the rollout pump was blocked on backpressure behind a train
+        pump that could no longer finish a step, so nothing was in flight to count.
+        The watchdog observed six minutes of idleness and said nothing.
+
+        What separates a real stall from an idle gap is whether work remains, so that
+        is what is checked instead.
+        """
+        watchdog_cfg = self._async_cfg.watchdog
+        max_num_steps = self._master_config.grpo.max_num_steps
+        last_progress = (-1, -1)
+        last_progress_at = time.monotonic()
+
+        while True:
+            await asyncio.sleep(watchdog_cfg.interval_s)
+            now = time.monotonic()
+
+            stats = self._rollout_manager.stats
+            progress = (stats.committed, self._train_steps)
+            if progress != last_progress:
+                last_progress = progress
+                last_progress_at = now
+            idle_s = now - last_progress_at
+
+            metrics = dict(stats.as_metrics())
+            metrics["rollout/inflight"] = float(self._inflight_rollouts)
+            metrics["rollout/idle_s"] = idle_s
+            metrics["rollout/train_steps"] = float(self._train_steps)
+            self._logger.log_metrics(metrics, step=self._train_steps)
+
+            if watchdog_cfg.gym_subprocess_check:
+                # Bounded by one tick so a wedged environment cannot stop the pump, and
+                # routed through stall_action so "warn" means warn -- see
+                # _check_env_health.
+                problems = await self._check_env_health(watchdog_cfg.interval_s)
+                if problems:
+                    detail = "; ".join(problems)
+                    if watchdog_cfg.stall_action == "abort":
+                        raise RuntimeError(
+                            f"environment health check failed -- {detail}"
+                        )
+                    print(f"WARNING: environment health -- {detail}", flush=True)
+
+            work_remains = self._train_steps < max_num_steps
+            if work_remains and idle_s > watchdog_cfg.stall_timeout_s:
+                message = (
+                    f"no rollout committed and no train step completed in "
+                    f"{idle_s:.0f}s ({self._inflight_rollouts} rollouts in flight, "
+                    f"{stats.committed} groups committed, step "
+                    f"{self._train_steps}/{max_num_steps}, "
+                    f"stall_timeout_s={watchdog_cfg.stall_timeout_s})"
+                )
+                if watchdog_cfg.stall_action == "abort":
+                    raise RolloutStall(message)
+                print(f"WARNING: rollout stall -- {message}", flush=True)
+
+    async def _check_env_health(self, timeout_s: float) -> list[str]:
+        """Ask each environment actor that exposes a health check whether it is whole.
+
+        Returns the problems found, empty when everything is well. It *reports* rather
+        than raises so the caller can route the verdict through ``stall_action``, the
+        same way the stall path does. Raising here bypassed ``stall_action`` entirely:
+        under the documented default (``"warn"``, which promises to "only report"), and
+        with ``gym_subprocess_check`` defaulting to true, an unhealthy environment killed
+        the run -- a run-ending path switched on by default, in a feature whose whole
+        posture is inert-by-default.
+
+        Each probe is bounded. ``NemoGym`` is an asyncio actor, so a *wedged* environment
+        -- precisely the case this check exists to catch -- left the await hanging
+        forever, the pump never ticked again, and stall detection was dead exactly when
+        it was needed. A probe that does not answer within one tick IS the unhealthy
+        signal; it is not a reason to stop watching.
+
+        Environments without the method are skipped rather than treated as unhealthy;
+        only NeMo-Gym has subprocess servers to lose.
+        """
+        problems: list[str] = []
+        for env_name, handle in self._env_handles.items():
+            health_check = getattr(handle, "health_check", None)
+            if health_check is None:
+                continue
+            try:
+                await asyncio.wait_for(
+                    self._ray_get(health_check.remote()), timeout=timeout_s
+                )
+            except asyncio.TimeoutError:
+                problems.append(
+                    f"environment {env_name!r} did not answer its health check within "
+                    f"{timeout_s}s"
+                )
+            except Exception as error:
+                problems.append(f"environment {env_name!r} reported unhealthy: {error}")
+        return problems
 
     async def _abort_stale_inflight(self) -> int:
         """Abort in-flight rollouts that the sampler can no longer select."""

--- a/nemo_rl/algorithms/single_controller_utils/__init__.py
+++ b/nemo_rl/algorithms/single_controller_utils/__init__.py
@@ -18,6 +18,8 @@ from nemo_rl.algorithms.single_controller_utils.config import (
     AdvantageConfig,
     AsyncRLConfig,
     MasterConfig,
+    RolloutFailureConfig,
+    WatchdogConfig,
 )
 from nemo_rl.algorithms.single_controller_utils.setup import (
     SingleControllerActorArgs,
@@ -28,6 +30,8 @@ __all__ = [
     "AdvantageConfig",
     "AsyncRLConfig",
     "MasterConfig",
+    "RolloutFailureConfig",
     "SingleControllerActorArgs",
+    "WatchdogConfig",
     "setup_single_controller",
 ]

--- a/nemo_rl/algorithms/single_controller_utils/config.py
+++ b/nemo_rl/algorithms/single_controller_utils/config.py
@@ -18,7 +18,14 @@ import warnings
 from dataclasses import dataclass, field
 from typing import Any, Literal, Optional
 
-from pydantic import BaseModel, Field, PositiveInt
+from pydantic import (
+    BaseModel,
+    Field,
+    NonNegativeInt,
+    PositiveFloat,
+    PositiveInt,
+    model_validator,
+)
 
 from nemo_rl.algorithms.async_utils.staleness_sampler import (
     InOrderSamplerConfig,
@@ -36,11 +43,148 @@ from nemo_rl.utils.checkpoint import CheckpointingConfig
 # ── User-facing SingleController configs ────────────────────────────────────
 
 
+class NativeRolloutFTConfig(BaseModel, extra="allow"):
+    """Fault-tolerance knobs read only by ``AsyncRolloutImpl`` (the native GRPO path).
+
+    Setting these on a NeMo-Gym run does nothing; ``validate_single_controller_config``
+    rejects that rather than letting it pass silently.
+    """
+
+    # Deadline for a single generate_async turn. None disables.
+    generation_timeout_s: Optional[PositiveFloat] = None
+    # Deadline for one environment step. None disables.
+    env_timeout_s: Optional[PositiveFloat] = None
+
+
+class NemoGymRolloutFTConfig(BaseModel, extra="allow"):
+    """Fault-tolerance knobs read only by ``AsyncNemoGymRolloutImpl``.
+
+    Setting these on a native run does nothing; ``validate_single_controller_config``
+    rejects that rather than letting it pass silently.
+    """
+
+    # Deadline for one whole prompt-group rollout, re-dispatches included. It spans the
+    # entire stream rather than each await: Gym yields rows as they finish, so a
+    # per-await budget would reset every time a fast row landed and never fire for the
+    # slow row actually holding the group up. None disables.
+    rollout_timeout_s: Optional[PositiveFloat] = None
+    # Attempts to re-dispatch just the rows that never arrived, before falling back to
+    # retrying the whole prompt group. Gym's stream dies on its first failing row, so one
+    # bad row takes every later row with it; recovering those individually is much
+    # cheaper than redoing all num_generations_per_prompt of them.
+    max_row_attempts: PositiveInt = 3
+
+
+class RolloutFailureConfig(BaseModel, extra="allow"):
+    """Fault tolerance for a rollout that fails.
+
+    The budgets at the top level are consumed by ``generate_and_push``, which sits above
+    the native/NeMo-Gym split, so they govern **both** paths. Everything path-specific
+    lives in the ``native`` and ``nemo_gym`` sub-blocks, so the structure itself says
+    which knob applies where -- these used to dangle on ``async_rl`` among unrelated
+    pump and buffer settings, where a native-path operator could set the most
+    generic-sounding one (``rollout_timeout_s``) and silently get no deadline at all.
+
+    Infrastructure failures re-dispatch the prompt onto a different generation shard;
+    data failures are deterministic, so their budget is small and exhausting it is
+    reported rather than absorbed. Nothing here ever discards a prompt silently.
+    """
+
+    # ── shared: consumed by generate_and_push, above the impl split ──
+    # Attempts for infrastructure failures (timeout, dead shard, transport). Each retry
+    # re-enters shard selection, so it lands elsewhere. Exhausting this means the fleet
+    # is broken rather than the prompt, and the run fails.
+    #
+    # Named for the failure class it bounds, not "per prompt": this budget and the data
+    # budget below are INDEPENDENT counters, not a total and a sub-total. Worst case for
+    # one prompt is their sum minus one -- 6 attempts under the defaults below.
+    max_infra_attempts_per_prompt: PositiveInt = 5
+    # Attempts for deterministic, prompt-specific failures. One retry separates a
+    # transient empty response from a genuinely bad prompt; a second identical failure
+    # confirms the prompt is at fault.
+    max_data_attempts_per_prompt: PositiveInt = 2
+    # First infra-retry delay, doubled per attempt.
+    backoff_base_s: PositiveFloat = 1.0
+    # Ceiling on the exponential backoff, so a long outage retries at a steady rate.
+    max_backoff_s: PositiveFloat = 30.0
+    # Distinct prompts that may exhaust their data budget and be dropped before the run
+    # fails anyway. 0 (the default) fails on the first one, propagating the original
+    # error. One knob rather than two: an enum plus a count could express "skip, but
+    # never actually skip anything", which meant a validator existed purely to reject
+    # that one combination. At 0 the name reads as its own documentation.
+    max_skipped_prompts: NonNegativeInt = 0
+    # ── path-specific ──
+    native: NativeRolloutFTConfig = Field(default_factory=NativeRolloutFTConfig)
+    nemo_gym: NemoGymRolloutFTConfig = Field(default_factory=NemoGymRolloutFTConfig)
+
+    @model_validator(mode="after")
+    def _check_consistent(self) -> "RolloutFailureConfig":
+        if self.max_backoff_s < self.backoff_base_s:
+            raise ValueError(
+                f"async_rl.rollout_failure.max_backoff_s ({self.max_backoff_s}) must be "
+                f">= backoff_base_s ({self.backoff_base_s})"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _reject_renamed_keys(self) -> "RolloutFailureConfig":
+        """Fail loudly on the previous key names rather than ignoring them.
+
+        ``extra="allow"`` means an old key parses fine and then does nothing. For
+        ``on_data_exhausted: skip`` that is a behaviour change -- prompts that used to be
+        skipped now fail the run -- arriving with no diagnostic at all.
+        """
+        renamed = {
+            "max_attempts_per_prompt": "max_infra_attempts_per_prompt",
+            "on_data_exhausted": "max_skipped_prompts (0 = the old 'fail_fast')",
+            "max_gym_row_attempts": "nemo_gym.max_row_attempts",
+        }
+        stale = [
+            f"  async_rl.rollout_failure.{old} -> async_rl.rollout_failure.{new}"
+            for old, new in renamed.items()
+            if getattr(self, old, None) is not None
+        ]
+        if stale:
+            raise ValueError(
+                "async_rl.rollout_failure keys have been renamed:\n" + "\n".join(stale)
+            )
+        return self
+
+
+class WatchdogConfig(BaseModel, extra="allow"):
+    """Last-resort detection for stalls that no other layer catches."""
+
+    # How often the watchdog task runs its checks.
+    interval_s: PositiveFloat = 30.0
+    # Rollouts in flight but none committed for this long counts as a stall.
+    stall_timeout_s: PositiveFloat = 600.0
+    # Whether a detected stall only reports, or ends the run.
+    stall_action: Literal["warn", "abort"] = "warn"
+    # Poll NeMo-Gym's own RunHelper for dead subprocess servers each tick.
+    gym_subprocess_check: bool = True
+
+    @model_validator(mode="after")
+    def _check_consistent(self) -> "WatchdogConfig":
+        if self.stall_timeout_s <= self.interval_s:
+            raise ValueError(
+                f"async_rl.watchdog.stall_timeout_s ({self.stall_timeout_s}) must be "
+                f"> interval_s ({self.interval_s}); otherwise the watchdog reports a "
+                "stall before it has had a chance to observe one."
+            )
+        return self
+
+
 class AsyncRLConfig(BaseModel, extra="allow"):
     # Staleness policy shared by the rollout and train pumps.
     sampler: SamplerConfig = Field(
         default_factory=InOrderSamplerConfig,
     )
+    # Fault tolerance for failed rollouts: shared budgets plus per-path deadlines.
+    rollout_failure: RolloutFailureConfig = Field(
+        default_factory=RolloutFailureConfig,
+    )
+    # Stall detection.
+    watchdog: WatchdogConfig = Field(default_factory=WatchdogConfig)
     # Recompute generation KV caches after each weight update.
     recompute_kv_cache_after_weight_updates: bool = False
     # Min ready groups the streaming trainer waits for before dispatching a batch.
@@ -51,6 +195,66 @@ class AsyncRLConfig(BaseModel, extra="allow"):
     max_buffered_rollouts: int = 64
     # Enable per-rollout diagnostic prints (prompt content / completion previews).
     diagnostics: bool = False
+
+    @model_validator(mode="after")
+    def _check_watchdog_outlasts_rollouts(self) -> "AsyncRLConfig":
+        # A rollout that is merely slow already has its own deadline; the watchdog must
+        # give it a chance to fire first, or every long rollout reads as a stall.
+        #
+        # Checks EVERY deadline, not just the NeMo-Gym one. This previously compared
+        # against rollout_timeout_s alone, so the invariant it advertises went unchecked
+        # on the native path -- where generation_timeout_s and env_timeout_s are the
+        # deadlines, and where a stall_timeout_s below either produces exactly the false
+        # stall reports this guard exists to prevent.
+        deadlines = (
+            (
+                "rollout_failure.nemo_gym.rollout_timeout_s",
+                self.rollout_failure.nemo_gym.rollout_timeout_s,
+            ),
+            (
+                "rollout_failure.native.generation_timeout_s",
+                self.rollout_failure.native.generation_timeout_s,
+            ),
+            (
+                "rollout_failure.native.env_timeout_s",
+                self.rollout_failure.native.env_timeout_s,
+            ),
+        )
+        for name, deadline in deadlines:
+            if deadline is not None and self.watchdog.stall_timeout_s <= deadline:
+                raise ValueError(
+                    f"async_rl.watchdog.stall_timeout_s "
+                    f"({self.watchdog.stall_timeout_s}) must be > async_rl.{name} "
+                    f"({deadline}); otherwise the watchdog reports a stall for rollouts "
+                    "that are merely slow and would have timed out on their own."
+                )
+        return self
+
+    @model_validator(mode="after")
+    def _reject_relocated_keys(self) -> "AsyncRLConfig":
+        """Fail loudly on keys that moved, instead of ignoring them.
+
+        These models are ``extra="allow"``, so a config written against the previous
+        layout keeps parsing and its fault-tolerance settings simply stop taking effect.
+        A silently ignored ``rollout_timeout_s: 900`` is precisely the failure mode the
+        restructure was meant to remove, so the move must not create one on its way out.
+        """
+        moved = {
+            "rollout_timeout_s": "rollout_failure.nemo_gym.rollout_timeout_s",
+            "generation_timeout_s": "rollout_failure.native.generation_timeout_s",
+            "env_timeout_s": "rollout_failure.native.env_timeout_s",
+        }
+        stale = [
+            f"  async_rl.{old} -> async_rl.{new}"
+            for old, new in moved.items()
+            if getattr(self, old, None) is not None
+        ]
+        if stale:
+            raise ValueError(
+                "async_rl fault-tolerance keys have moved into rollout_failure:\n"
+                + "\n".join(stale)
+            )
+        return self
 
 
 class TokenCaptureConfig(BaseModel, extra="allow"):
@@ -217,6 +421,38 @@ def validate_single_controller_config(master_config: MasterConfig) -> None:
             "grpo.skip_reference_policy_logprobs_calculation=false, or set "
             "loss_fn.reference_policy_kl_penalty=0."
         )
+
+    # Nesting says which knob applies to which path, but nothing stops an operator
+    # filling in the block for the path this run is not taking -- and a populated
+    # wrong-path block is still a silent no-op, which is the failure this whole
+    # restructure exists to remove. Only a check at setup actually closes it.
+    #
+    # ``env`` is a required field, so a run built the production way -- through
+    # MasterConfig(**cfg), which validates -- always carries it. model_construct
+    # skips validation and only fills fields that have defaults, so a config
+    # assembled that way can genuinely lack the attribute, and without it the
+    # rollout path is unknowable. This check only reads it to decide which half of
+    # the block is inert, so skip rather than fail a construction over it.
+    env_config = getattr(master_config, "env", None)
+    if env_config is not None:
+        use_nemo_gym = bool(env_config.get("should_use_nemo_gym"))
+        unused_name = "native" if use_nemo_gym else "nemo_gym"
+        unused_block = getattr(async_config.rollout_failure, unused_name)
+        unused_defaults = type(unused_block)()
+        populated = [
+            f"  async_rl.rollout_failure.{unused_name}.{field}="
+            f"{getattr(unused_block, field)!r}"
+            for field in type(unused_block).model_fields
+            if getattr(unused_block, field) != getattr(unused_defaults, field)
+        ]
+        if populated:
+            active = "nemo_gym" if use_nemo_gym else "native"
+            raise ValueError(
+                f"this run uses the {active} rollout path, so these "
+                f"{unused_name}-only settings would be silently ignored:\n"
+                + "\n".join(populated)
+                + f"\nMove them under async_rl.rollout_failure.{active}, or remove them."
+            )
 
 
 # ── Internal SingleController configs ────────────────────────────────────

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -71,7 +71,11 @@ from nemo_rl.data_plane import (
 from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.environments.nemo_gym import spinup_nemo_gym_actor
-from nemo_rl.experience.rollout_manager import RolloutManager
+from nemo_rl.experience.rollout_manager import (
+    RolloutManager,
+    RolloutRetryPolicy,
+    RolloutTimeouts,
+)
 from nemo_rl.experience.rollouts import should_mask_flagged_samples
 from nemo_rl.models.generation.interfaces import (
     resolve_routed_experts_dtype_name_for_model,
@@ -462,6 +466,19 @@ def _maybe_inject_megatron_train_iters(master_config: MasterConfig) -> None:
         return
     grpo_config = master_config.grpo
     policy_config["megatron_cfg"]["train_iters"] = grpo_config.max_num_steps
+
+
+def _build_retry_policy(master_config: MasterConfig) -> RolloutRetryPolicy:
+    """Translate ``async_rl.rollout_failure`` into the rollout layer's policy object."""
+    failure_config = master_config.async_rl.rollout_failure
+    return RolloutRetryPolicy(
+        max_infra_attempts=failure_config.max_infra_attempts_per_prompt,
+        max_data_attempts=failure_config.max_data_attempts_per_prompt,
+        backoff_base_s=failure_config.backoff_base_s,
+        max_backoff_s=failure_config.max_backoff_s,
+        max_skipped_prompts=failure_config.max_skipped_prompts,
+        max_gym_row_attempts=failure_config.nemo_gym.max_row_attempts,
+    )
 
 
 def setup_single_controller(
@@ -900,6 +917,12 @@ def setup_single_controller(
         use_nemo_gym=use_nemo_gym,
         mask_env_flagged_samples=should_mask_flagged_samples(master_config.env),
         tq_buffer=tq_buffer,
+        timeouts=RolloutTimeouts(
+            rollout_s=master_config.async_rl.rollout_failure.nemo_gym.rollout_timeout_s,
+            generation_s=master_config.async_rl.rollout_failure.native.generation_timeout_s,
+            env_s=master_config.async_rl.rollout_failure.native.env_timeout_s,
+        ),
+        retry_policy=_build_retry_policy(master_config),
     )
 
     # Print setup timing metrics

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -887,6 +887,7 @@ def setup_single_controller(
         ),
     )
     finalizer_actors: list[Any] = []
+    recovery_ledger = None
     if token_capture_cfg.enabled:
         from nemo_rl.experience.finalizer_actor import (
             FinalizerActorConfig,
@@ -906,6 +907,9 @@ def setup_single_controller(
             ),
             num_workers=token_capture_cfg.num_finalizer_workers,
         )
+        from nemo_rl.experience.rollout_recovery import RolloutRecoveryLedger
+
+        recovery_ledger = RolloutRecoveryLedger()
     rollout_manager = RolloutManager(
         tokenizer=tokenizer,
         task_to_env=env_handles,
@@ -923,6 +927,7 @@ def setup_single_controller(
             env_s=master_config.async_rl.rollout_failure.native.env_timeout_s,
         ),
         retry_policy=_build_retry_policy(master_config),
+        recovery_ledger=recovery_ledger,
     )
 
     # Print setup timing metrics

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -789,8 +789,7 @@ Depending on your data shape, you may want to change these values."""
         try:
             manifest = await self._control(
                 "GET",
-                f"{_TOKEN_CAPTURE_CONTROL_PREFIX}"
-                f"/rollouts/{rollout_id}/manifest",
+                f"{_TOKEN_CAPTURE_CONTROL_PREFIX}/rollouts/{rollout_id}/manifest",
             )
             receipt = self._assemble_receipt(
                 rollout_id,
@@ -871,10 +870,7 @@ Depending on your data shape, you may want to change these values."""
 
             try:
                 selection = select_terminal_call(
-                    [
-                        CallRecord.model_validate(record)
-                        for record in deduped.values()
-                    ]
+                    [CallRecord.model_validate(record) for record in deduped.values()]
                 )
             except ValueError:
                 selection_reason = "invalid_manifest_row"
@@ -890,7 +886,9 @@ Depending on your data shape, you may want to change these values."""
         ]
         failure_reason = None
         if poisoning_failures:
-            failure_reason = str(poisoning_failures[0].get("reason") or "capture_failed")
+            failure_reason = str(
+                poisoning_failures[0].get("reason") or "capture_failed"
+            )
         elif terminal_record is None:
             failure_reason = selection_reason or "missing_terminal_row"
         return {

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -44,6 +44,11 @@ from nemo_rl.distributed.virtual_cluster import (
     _get_node_ip_local,
 )
 from nemo_rl.environments.interfaces import EnvironmentInterface
+from nemo_rl.experience.failures import (
+    GymTransportError,
+    RolloutDataFailure,
+    http_status_is_infra,
+)
 from nemo_rl.models.policy import TokenizerConfig
 from nemo_rl.utils.routed_experts_codec import decode_routed_experts
 from nemo_rl.utils.timer import Timer
@@ -74,6 +79,39 @@ def _has_nan_generation_logprobs(result: dict) -> bool:
         and torch.isnan(message["generation_logprobs"]).any()
         for message in result["message_log"]
     )
+
+
+def _typed_gym_failure(error: Exception) -> Optional[Exception]:
+    """Map a NeMo-Gym HTTP failure onto a typed, PICKLABLE failure, or None if not one.
+
+    Classification has to happen here, on the raising side, because ``run_rollouts`` runs
+    inside the ``NemoGym`` Ray actor and the exception must survive the actor boundary to
+    reach the retry policy on the driver.
+
+    It does not survive. aiohttp's ``raise_for_status`` passes ``headers=self.headers``,
+    and those are a ``CIMultiDictProxy``, which cloudpickle cannot serialize -- so Ray
+    drops the cause and the driver receives a bare ``RayTaskError`` with no type and no
+    ``.status``. Every gym HTTP failure then classified DATA, capping the gym path at
+    ``max_data_attempts_per_prompt`` (2) and leaving ``max_attempts_per_prompt`` (5)
+    unreachable on the very path whose dead-endpoint scenario motivates it. Two things
+    made that the dominant case rather than a corner: Gym's middleware turns inner-server
+    failures into 500 -- exactly the status the INFRA branch is for -- and its transport
+    layer retries disconnects in an uncapped loop, so those never arrive at all.
+
+    ``GymTransportError`` and ``RolloutDataFailure`` take a single str, so they pickle
+    cleanly and ``classify_rollout_failure``'s explicit-class fast path wins on the far
+    side.
+
+    Returns None when the exception carries no HTTP status, leaving the caller to
+    re-raise it untouched.
+    """
+    status = getattr(error, "status", None)
+    if not isinstance(status, int):
+        return None
+    detail = f"NeMo-Gym /run failed with HTTP {status}: {error}"
+    if http_status_is_infra(status):
+        return GymTransportError(detail)
+    return RolloutDataFailure(detail)
 
 
 def get_nemo_gym_uv_cache_dir() -> str | None:
@@ -375,6 +413,15 @@ class NemoGym(EnvironmentInterface):
 
     def __init__(self, cfg: NemoGymConfig):
         self.cfg = cfg
+        # Populated by _spinup. Declared here so a restarted actor -- Ray recreates it
+        # through __init__, which does not start the Gym servers -- reports what
+        # actually happened instead of an AttributeError from deep inside a rollout.
+        self.rh: Any = None
+        self.rch: Any = None
+        self.head_server_config: Any = None
+        self.node_ip: Optional[str] = None
+        self.head_server_port: Optional[int] = None
+        self._pad_dynamic_image_shapes = bool(cfg.get("pad_dynamic_image_shapes"))
         # Reconstruct the processor inside the actor (rather than serializing it
         # per rollout call) for full-trajectory multimodal postprocessing.
         self._processor: Optional[Any] = None
@@ -393,6 +440,27 @@ class NemoGym(EnvironmentInterface):
                 f"got {type(self._processor).__name__}. Update "
                 "_attach_multimodal_data_to_user_message before enabling."
             )
+
+    def _require_spinup(self) -> None:
+        """Raise a diagnosable error if this instance never ran :meth:`_spinup`."""
+        if self.rh is None:
+            raise RuntimeError(
+                "NeMo-Gym actor has no running servers: _spinup() was never called on "
+                "this instance. Ray recreates a restarted actor through __init__ only, "
+                "so an actor that died and came back reaches this state and cannot "
+                "serve rollouts until it is spun up again."
+            )
+
+    def health_check(self) -> None:
+        """Raise if the Gym head server or any subprocess server has died.
+
+        Thin wrapper over NeMo-Gym's own ``RunHelper.poll``, which is what ``gym env
+        start`` calls every 60s from ``run_forever``. NeMo-RL only calls ``rh.start``,
+        so without this the check Gym already implements never runs and a dead tool
+        server surfaces as unexplained rollout timeouts instead of a named process.
+        """
+        self._require_spinup()
+        self.rh.poll()
 
     def _spinup(self) -> None:
         """Start the NeMo-Gym head server and rollout collection helper.
@@ -597,6 +665,7 @@ Depending on your data shape, you may want to change these values."""
         deduplicate_multimodal_data: bool = False,
     ) -> AsyncGenerator[tuple[int, dict, dict | None], None]:
         """Stream postprocessed rollouts as NeMo-Gym tasks complete."""
+        self._require_spinup()
         if not nemo_gym_examples:
             raise ValueError("NeMo-Gym rollout batch must not be empty")
 
@@ -638,6 +707,12 @@ Depending on your data shape, you may want to change these values."""
                             error.response_content,
                             file=sys.stderr,
                         )
+                    typed = _typed_gym_failure(error)
+                    if typed is not None:
+                        # `from None`, deliberately: chaining the original would put the
+                        # unpicklable exception back on the wire as __cause__ and undo
+                        # the whole point. The status and message are already in `detail`.
+                        raise typed from None
                     raise
 
             with timer.time(label=f"{timer_prefix}/postprocess_results"):
@@ -1106,6 +1181,10 @@ output prompt token ids till seen: {output_item_dict["prompt_token_ids"][: len(s
         return result
 
     def shutdown(self) -> None:
+        # Teardown runs in a finally block, so it must not turn a real training error
+        # into a confusing AttributeError from a never-spun-up (e.g. restarted) actor.
+        if self.rh is None:
+            return
         self.rh.shutdown()
 
     def step(self, message_log_batch, metadata):

--- a/nemo_rl/experience/blackbox_finalizer.py
+++ b/nemo_rl/experience/blackbox_finalizer.py
@@ -505,6 +505,7 @@ class BlackboxFinalizer:
         rewards: list[float],
         *,
         fallback_weight_version: int,
+        canonical_sample_ids: Optional[list[str]] = None,
     ) -> FinalizedGroup:
         """Publish exactly N canonical rows for one prompt group.
 
@@ -515,6 +516,11 @@ class BlackboxFinalizer:
         """
         assert len(rollout_ids) == len(receipts) == len(rewards), (
             "rollout_ids, receipts, and rewards must be parallel"
+        )
+        if canonical_sample_ids is None:
+            canonical_sample_ids = rollout_ids
+        assert len(canonical_sample_ids) == len(rollout_ids), (
+            "canonical_sample_ids must be one per rollout"
         )
         _group_t0 = time.perf_counter()
         rows = [
@@ -699,9 +705,9 @@ class BlackboxFinalizer:
             train_batch=train_batch,
             weight_version=group_min_wv,
         )
-        assert sample_ids == rollout_ids, (
-            "canonical sample ids must equal the ledger-registered rollout ids: "
-            f"{sample_ids} != {rollout_ids}"
+        assert sample_ids == canonical_sample_ids, (
+            "canonical sample ids must equal the stable logical rollout ids: "
+            f"{sample_ids} != {canonical_sample_ids}"
         )
         _tensorize_ms = (time.perf_counter() - _tensorize_t0) * 1000.0
         _put_t0 = time.perf_counter()

--- a/nemo_rl/experience/blackbox_finalizer.py
+++ b/nemo_rl/experience/blackbox_finalizer.py
@@ -221,16 +221,24 @@ class BlackboxFinalizer:
         rewards: list[float],
         *,
         fallback_weight_version: int,
+        canonical_sample_ids: Optional[list[str]] = None,
     ) -> FinalizedGroup:
         """Build exactly N canonical rows for one prompt group.
 
         Blocking (TQ round trips); run via ``asyncio.to_thread`` from the
         dispatch task. ``fallback_weight_version`` stamps a group none of
         whose rollouts produced a valid row (placeholder-only groups still
-        need a staleness tag).
+        need a staleness tag). ``rollout_ids`` are physical gate attempt IDs;
+        ``canonical_sample_ids`` are stable logical sibling IDs. They are the
+        same on the legacy first-attempt path.
         """
         assert len(rollout_ids) == len(receipts) == len(rewards), (
             "rollout_ids, receipts, and rewards must be parallel"
+        )
+        if canonical_sample_ids is None:
+            canonical_sample_ids = rollout_ids
+        assert len(canonical_sample_ids) == len(rollout_ids), (
+            "canonical_sample_ids must be one per rollout"
         )
         rows = [
             self.finalize_rollout(rollout_id, receipt, reward=reward)
@@ -320,9 +328,9 @@ class BlackboxFinalizer:
             train_batch=train_batch,
             weight_version=group_min_wv,
         )
-        assert sample_ids == rollout_ids, (
-            "canonical sample ids must equal the gate-registered rollout ids: "
-            f"{sample_ids} != {rollout_ids}"
+        assert sample_ids == canonical_sample_ids, (
+            "canonical sample ids must equal the stable logical rollout ids: "
+            f"{sample_ids} != {canonical_sample_ids}"
         )
         meta = KVBatchMeta(
             partition_id=self._partition_id,

--- a/nemo_rl/experience/failures.py
+++ b/nemo_rl/experience/failures.py
@@ -1,0 +1,264 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rollout failure taxonomy for the SingleController path.
+
+A failed rollout attempt is one of exactly two things, and the distinction drives
+the whole retry policy:
+
+  - **Infra** (:class:`RolloutInfraFailure`) — the prompt is fine, the fleet is not.
+    A dead generation shard, a timeout, a dropped connection. Re-dispatching the same
+    prompt is expected to succeed because the retry lands on a different shard.
+  - **Data** (:class:`RolloutDataFailure`) — deterministic and prompt-specific. A prompt
+    longer than the engine's ``max_model_len``, non-contiguous tokens after tokenization.
+    Another shard fails the same way, so the retry budget is small and exhausting it is
+    reported rather than absorbed.
+
+:func:`classify_rollout_failure` maps an arbitrary exception onto that split. Anything
+not recognized as infrastructure is treated as data — an unrecognized exception is more
+likely a real bug than a transient blip, and the data path surfaces it loudly instead of
+retrying it into silence.
+
+**Classify where the information still exists.** An exception that crosses a Ray actor
+boundary arrives stripped: Ray pickles the cause, and anything unpicklable (aiohttp's
+``CIMultiDictProxy`` headers, for one) is replaced by a bare error carrying neither type
+nor ``.status``. Driver-side classification is then guessing. So failures raised inside
+an actor are converted to a picklable member of this taxonomy *before* they cross —
+:func:`http_status_is_infra` exists to keep that decision identical on both sides. See
+``_typed_gym_failure`` in ``nemo_rl/environments/nemo_gym.py``.
+"""
+
+from __future__ import annotations
+
+import enum
+from typing import Final, Optional
+
+import ray.exceptions
+
+# aiohttp is not a declared NeMo-RL dependency -- it arrives transitively with ray and
+# vllm. It is present in every supported environment, but the import is guarded so this
+# module stays usable if that ever stops being true; _INFRA_TYPE_NAMES below is the
+# fallback.
+_AIOHTTP_INFRA_TYPES: tuple[type[BaseException], ...]
+_CLIENT_RESPONSE_ERROR: Optional[type[BaseException]]
+try:
+    from aiohttp import (
+        ClientConnectionError as _ClientConnectionError,
+    )
+    from aiohttp import (
+        ClientPayloadError as _ClientPayloadError,
+    )
+    from aiohttp import (
+        ClientResponseError as _ClientResponseError,
+    )
+except ImportError:  # pragma: no cover - aiohttp ships with ray in supported images
+    _AIOHTTP_INFRA_TYPES = ()
+    _CLIENT_RESPONSE_ERROR = None
+else:
+    # ClientConnectionError is the transport-failure root: it covers ClientOSError,
+    # ClientConnectorError, ServerDisconnectedError and ServerTimeoutError. Deliberately
+    # NOT the broader ClientError, whose other branch (ClientResponseError) carries HTTP
+    # status codes and is classified by status instead -- see _http_status.
+    _AIOHTTP_INFRA_TYPES = (_ClientConnectionError, _ClientPayloadError)
+    _CLIENT_RESPONSE_ERROR = _ClientResponseError
+
+# Maximum ``__cause__`` links followed by :func:`classify_rollout_failure`. Bounded so a
+# self-referential or pathologically deep chain cannot spin.
+_MAX_CAUSE_DEPTH: Final[int] = 8
+
+# Sub-500 HTTP statuses that still mean "try again", not "this prompt is bad".
+_RETRIABLE_HTTP_STATUSES: Final[frozenset[int]] = frozenset({408, 429})
+
+
+class RolloutFailure(Exception):
+    """Base class for failures that terminate a single rollout attempt."""
+
+
+class RolloutInfraFailure(RolloutFailure):
+    """The generation or environment infrastructure could not serve this rollout.
+
+    The prompt is not implicated. Re-dispatching it is expected to succeed once a
+    healthy shard is selected.
+    """
+
+
+class RolloutTimeout(RolloutInfraFailure):
+    """A rollout, generation turn, or environment step exceeded its deadline."""
+
+
+class GenerationUnavailable(RolloutInfraFailure):
+    """The selected generation shard could not serve the request."""
+
+
+class NoHealthyShards(RolloutInfraFailure):
+    """No generation shard is currently eligible to serve traffic."""
+
+
+class GymTransportError(RolloutInfraFailure):
+    """NeMo-Gym failed at the transport layer rather than returning a rollout."""
+
+
+class RolloutDataFailure(RolloutFailure):
+    """This prompt cannot be rolled out, and another shard would fail identically.
+
+    Usually a configuration problem — most often ``policy.max_total_sequence_length``
+    exceeding the generation engine's ``max_model_len``.
+    """
+
+
+class RolloutRedispatchExhausted(RuntimeError):
+    """A prompt exhausted its infrastructure retry budget.
+
+    Deliberately not a :class:`RolloutFailure`: it is terminal for the run rather than
+    for one attempt, so the per-attempt retry loop must not catch it. Reaching it means
+    the prompt failed across repeated shard selections, which indicates fleet-wide
+    failure rather than a bad prompt.
+    """
+
+
+class RolloutStall(RuntimeError):
+    """Rollouts are in flight but none has committed within the watchdog deadline."""
+
+
+class FailureClass(str, enum.Enum):
+    """Retry policy bucket for a failed rollout attempt."""
+
+    INFRA = "infra"
+    DATA = "data"
+
+
+# Exception types that always indicate infrastructure failure. Ray's actor/node/RPC
+# errors mean a worker or its host went away; the stdlib entries cover the timeout and
+# connection paths the rollout code raises directly.
+_INFRA_TYPES: Final[tuple[type[BaseException], ...]] = (
+    RolloutInfraFailure,
+    TimeoutError,  # asyncio.TimeoutError is an alias for this on Python 3.11+
+    ConnectionError,
+    ray.exceptions.RayActorError,  # parent of ActorDiedError
+    ray.exceptions.ActorUnavailableError,
+    ray.exceptions.ActorUnschedulableError,
+    ray.exceptions.TaskUnschedulableError,
+    ray.exceptions.WorkerCrashedError,
+    ray.exceptions.NodeDiedError,
+    ray.exceptions.LocalRayletDiedError,
+    ray.exceptions.OwnerDiedError,
+    ray.exceptions.RpcError,
+    ray.exceptions.GetTimeoutError,
+    ray.exceptions.ObjectFetchTimedOutError,
+    # Cluster-resource and object-store failures. None of these say anything about the
+    # prompt, and all of them were previously falling through to DATA -- which meant a
+    # node running out of memory got two attempts and killed the run, while the bounded,
+    # backed-off infra budget built for exactly that sat unused.
+    # ObjectLostError is the parent of OwnerDiedError/ObjectFetchTimedOutError above;
+    # both are kept listed because being explicit about what we have considered is worth
+    # more here than a shorter tuple.
+    ray.exceptions.ObjectLostError,
+    ray.exceptions.OutOfMemoryError,
+    ray.exceptions.ObjectStoreFullError,
+    ray.exceptions.RaySystemError,
+    *_AIOHTTP_INFRA_TYPES,
+)
+
+# Fallback for environments without aiohttp, matched against every class name in the
+# exception's MRO. These are the transport errors NeMo-Gym surfaces when a vLLM endpoint
+# dies mid-request or refuses a connection. Note ``ClientOSError`` derives from
+# ``OSError`` but *not* from ``ConnectionError``, so the isinstance table above would
+# not catch it on its own. ``ClientError`` and ``ClientResponseError`` are deliberately
+# absent: they cover HTTP responses, which _http_status classifies by status code.
+_INFRA_TYPE_NAMES: Final[frozenset[str]] = frozenset(
+    {
+        "ClientConnectionError",
+        "ClientConnectorError",
+        "ClientOSError",
+        "ClientPayloadError",
+        "ServerConnectionError",
+        "ServerDisconnectedError",
+        "ServerTimeoutError",
+    }
+)
+
+
+def http_status_is_infra(status: int) -> bool:
+    """Whether an HTTP status means the endpoint is unwell rather than the request bad.
+
+    5xx and the retriable 4xx are infrastructure; any other 4xx describes the request
+    itself, so another shard would answer it identically.
+
+    Public because NeMo-Gym has to make this same call on the *raising* side of a Ray
+    actor boundary (see ``nemo_rl/environments/nemo_gym.py``), and the two copies of the
+    decision must not drift apart.
+    """
+    return status >= 500 or status in _RETRIABLE_HTTP_STATUSES
+
+
+def _http_status(exc: BaseException) -> Optional[int]:
+    """Return the HTTP status carried by an aiohttp response error, if this is one."""
+    if _CLIENT_RESPONSE_ERROR is not None:
+        if not isinstance(exc, _CLIENT_RESPONSE_ERROR):
+            return None
+    elif not any(
+        cls.__name__ == "ClientResponseError" for cls in type(exc).__mro__
+    ):  # pragma: no cover - only reachable without aiohttp
+        return None
+    status = getattr(exc, "status", None)
+    return status if isinstance(status, int) else None
+
+
+def _is_infra(exc: BaseException) -> bool:
+    """Return whether this single exception (ignoring its cause chain) is infra."""
+    if isinstance(exc, RolloutDataFailure):
+        return False
+
+    # An HTTP error is classified by status, not by type. A 4xx from the generation
+    # engine describes the request -- "This model's maximum context length is ..." comes
+    # back as a 400 -- so retrying it on another shard would fail identically. 5xx and
+    # the retriable 4xx mean the endpoint is unwell, which another shard can serve.
+    status = _http_status(exc)
+    if status is not None:
+        return http_status_is_infra(status)
+
+    if isinstance(exc, _INFRA_TYPES):
+        return True
+    return any(cls.__name__ in _INFRA_TYPE_NAMES for cls in type(exc).__mro__)
+
+
+def classify_rollout_failure(exc: BaseException) -> FailureClass:
+    """Bucket a rollout exception into ``INFRA`` or ``DATA``.
+
+    An explicit :class:`RolloutDataFailure` always wins, so callers that know a failure
+    is prompt-specific can say so and not have it re-read as infrastructure. Otherwise
+    the exception and its ``__cause__`` chain are checked against the infrastructure
+    table; anything unrecognized is ``DATA`` so that unexpected exceptions fail loudly
+    instead of being retried into silence.
+
+    Args:
+        exc: The exception raised by a rollout attempt.
+
+    Returns:
+        The :class:`FailureClass` governing this failure's retry budget.
+    """
+    if isinstance(exc, RolloutDataFailure):
+        return FailureClass.DATA
+
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    for _ in range(_MAX_CAUSE_DEPTH):
+        if current is None or id(current) in seen:
+            break
+        seen.add(id(current))
+        if _is_infra(current):
+            return FailureClass.INFRA
+        current = current.__cause__
+
+    return FailureClass.DATA

--- a/nemo_rl/experience/finalizer_actor.py
+++ b/nemo_rl/experience/finalizer_actor.py
@@ -46,6 +46,7 @@ class FinalizationRequest:
 
     group_id: str
     rollout_ids: tuple[str, ...]
+    canonical_sample_ids: tuple[str, ...]
     receipts: tuple[Optional[dict[str, Any]], ...]
     rewards: tuple[float, ...]
     fallback_weight_version: int
@@ -123,10 +124,14 @@ class FinalizerActor:  # pragma: no cover
         """Finalize one request without allowing tensor payloads across Ray RPC."""
         assert_metadata_only(request)
         if not (
-            len(request.rollout_ids) == len(request.receipts) == len(request.rewards)
+            len(request.rollout_ids)
+            == len(request.canonical_sample_ids)
+            == len(request.receipts)
+            == len(request.rewards)
         ):
             raise ValueError(
-                "finalizer request rollout_ids, receipts, and rewards must be parallel"
+                "finalizer request rollout_ids, canonical_sample_ids, receipts, "
+                "and rewards must be parallel"
             )
         result = self._finalizer.finalize_group(
             request.group_id,
@@ -134,6 +139,7 @@ class FinalizerActor:  # pragma: no cover
             list(request.receipts),
             list(request.rewards),
             fallback_weight_version=request.fallback_weight_version,
+            canonical_sample_ids=list(request.canonical_sample_ids),
         )
         assert_metadata_only(result)
         return result

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -1478,7 +1478,7 @@ class RolloutManager:
         *,
         target_step: Optional[int] = None,
         inflight_registry: Optional[dict[str, tuple[asyncio.Task[None], int]]] = None,
-    ) -> "FinalizationRequest":
+    ) -> Optional["FinalizationRequest"]:
         """Run capture generation and return a metadata-only actor request.
 
         The replay-buffer slot remains reserved and unready. Logical sibling

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -14,10 +14,13 @@
 
 import asyncio
 import copy
+import enum
 import json
 import uuid
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Optional
 
+import ray.exceptions
 import torch
 from transformers import PreTrainedTokenizerBase
 from wandb import Table
@@ -26,6 +29,16 @@ from nemo_rl.algorithms.async_utils.replay_buffer import TQReplayBuffer
 from nemo_rl.data.interfaces import DatumSpec, LLMMessageLogType
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.environments.interfaces import EnvironmentInterface
+from nemo_rl.experience.failures import (
+    FailureClass,
+    GenerationUnavailable,
+    GymTransportError,
+    RolloutDataFailure,
+    RolloutFailure,
+    RolloutRedispatchExhausted,
+    RolloutTimeout,
+    classify_rollout_failure,
+)
 from nemo_rl.experience.interfaces import Completion, PromptGroupRecord
 from nemo_rl.experience.metric_utils import calculate_single_metric, pct
 from nemo_rl.experience.rollouts import (
@@ -48,6 +61,265 @@ if TYPE_CHECKING:
     from nemo_rl.experience.finalizer_actor import FinalizationRequest
 
 
+class RolloutOutcome(str, enum.Enum):
+    """How :meth:`RolloutManager.generate_and_push` finished for one prompt."""
+
+    # The prompt group reached the replay buffer.
+    COMMITTED = "committed"
+    # The prompt exhausted its data-failure budget within max_skipped_prompts.
+    # No group was committed, so the caller owns releasing its backpressure permit.
+    SKIPPED = "skipped"
+
+
+@dataclass(frozen=True)
+class RolloutRetryPolicy:
+    """Retry budgets for one prompt, resolved from ``async_rl.rollout_failure``.
+
+    The attempt budgets are **required**. They previously defaulted to 1/1/1, which
+    contradicted ``RolloutFailureConfig``'s 5/2/3 and put a second set of defaults in
+    the codebase -- a reader here came away believing the shipped budget was 1. The only
+    place a retry default lives is ``RolloutFailureConfig``; callers that need the
+    historical no-retry behaviour ask for it by name via :meth:`single_attempt`.
+    """
+
+    # Attempts for infrastructure failures. 1 means no retry.
+    max_infra_attempts: int
+    # Attempts for deterministic, prompt-specific failures. 1 means no retry.
+    max_data_attempts: int
+    # Attempts to re-dispatch only the NeMo-Gym rows that never arrived, before the
+    # whole prompt group is retried. 1 means no row-level retry.
+    max_gym_row_attempts: int
+    # These three do not contradict RolloutFailureConfig, so they keep their defaults.
+    backoff_base_s: float = 1.0
+    max_backoff_s: float = 30.0
+    # Run-wide cap on prompts that may exhaust their data budget and be dropped,
+    # enforced across every generate_and_push call. 0 means none may be: the first
+    # exhaustion propagates the original failure.
+    max_skipped_prompts: int = 0
+
+    @classmethod
+    def single_attempt(cls, **overrides: Any) -> "RolloutRetryPolicy":
+        """The historical no-retry policy, with optional overrides.
+
+        An explicit choice for callers constructing a ``RolloutManager`` directly, who
+        must not silently gain retries -- not a second set of defaults.
+        """
+        budgets: dict[str, Any] = {
+            "max_infra_attempts": 1,
+            "max_data_attempts": 1,
+            "max_gym_row_attempts": 1,
+        }
+        budgets.update(overrides)
+        return cls(**budgets)
+
+    def __post_init__(self) -> None:
+        # A zero budget would mean "never attempt the rollout at all", which no caller
+        # wants and which would leave the retry loop with nothing to report.
+        if (
+            self.max_infra_attempts < 1
+            or self.max_data_attempts < 1
+            or self.max_gym_row_attempts < 1
+        ):
+            raise ValueError(
+                "RolloutRetryPolicy attempt budgets must be >= 1; got "
+                f"max_infra_attempts={self.max_infra_attempts}, "
+                f"max_data_attempts={self.max_data_attempts}, "
+                f"max_gym_row_attempts={self.max_gym_row_attempts}"
+            )
+
+    def backoff_for(self, attempt: int) -> float:
+        """Return the delay before infra attempt ``attempt`` + 1 (1-based attempts)."""
+        return min(self.backoff_base_s * 2 ** (attempt - 1), self.max_backoff_s)
+
+
+@dataclass
+class RolloutStats:
+    """Counters describing what the retry policy has been doing.
+
+    Read by the SingleController for logging. A stall or a rising redispatch count is
+    the only externally visible sign that the fleet is degrading, so these are not
+    optional bookkeeping.
+    """
+
+    committed: int = 0
+    skipped: int = 0
+    # Infra re-dispatches: the fleet is degrading. Kept apart from data retries because
+    # conflating them defeats the whole point of the two-budget split -- an operator
+    # watching redispatch_total climb needs to know whether the cluster is sick or the
+    # dataset is.
+    redispatches_by_reason: dict[str, int] = field(default_factory=dict)
+    # Retries of a deterministic, prompt-specific failure.
+    data_retries_by_reason: dict[str, int] = field(default_factory=dict)
+    # Prompts that ran out of data budget entirely.
+    data_failures_by_reason: dict[str, int] = field(default_factory=dict)
+    # NeMo-Gym row-level re-dispatches. These recover a partial prompt group without
+    # redoing the whole thing, so they never reached the counters above and gym could
+    # retry rows all run with redispatch_total sitting flat.
+    gym_row_redispatches: int = 0
+
+    def record_redispatch(self, reason: str) -> None:
+        self.redispatches_by_reason[reason] = (
+            self.redispatches_by_reason.get(reason, 0) + 1
+        )
+
+    def record_data_retry(self, reason: str) -> None:
+        self.data_retries_by_reason[reason] = (
+            self.data_retries_by_reason.get(reason, 0) + 1
+        )
+
+    def record_data_failure(self, reason: str) -> None:
+        self.data_failures_by_reason[reason] = (
+            self.data_failures_by_reason.get(reason, 0) + 1
+        )
+
+    def record_gym_row_redispatch(self, rows: int = 1) -> None:
+        self.gym_row_redispatches += rows
+
+    def as_metrics(self) -> dict[str, float]:
+        """Flatten into a metric dict for the SingleController logger."""
+        # Every family gets an aggregate, not just per-exception series: alerting on
+        # "any data failure" should not require knowing the exception names up front.
+        metrics: dict[str, float] = {
+            "rollout/committed_total": float(self.committed),
+            "rollout/skipped_total": float(self.skipped),
+            "rollout/redispatch_total": float(
+                sum(self.redispatches_by_reason.values())
+            ),
+            "rollout/data_retry_total": float(
+                sum(self.data_retries_by_reason.values())
+            ),
+            "rollout/data_failures_total": float(
+                sum(self.data_failures_by_reason.values())
+            ),
+            "rollout/gym_row_redispatch_total": float(self.gym_row_redispatches),
+        }
+        for reason, count in self.redispatches_by_reason.items():
+            metrics[f"rollout/redispatch_total/{reason}"] = float(count)
+        for reason, count in self.data_retries_by_reason.items():
+            metrics[f"rollout/data_retry_total/{reason}"] = float(count)
+        for reason, count in self.data_failures_by_reason.items():
+            metrics[f"rollout/data_failures_total/{reason}"] = float(count)
+        return metrics
+
+
+@dataclass(frozen=True)
+class RolloutTimeouts:
+    """Deadlines for the blocking waits inside one rollout.
+
+    Resolved from ``async_rl.rollout_failure.nemo_gym.rollout_timeout_s`` and
+    ``async_rl.rollout_failure.native.{generation,env}_timeout_s``, which own the
+    user-facing defaults. ``None`` means no deadline,
+    reproducing the historical behaviour of waiting indefinitely.
+    """
+
+    rollout_s: Optional[float] = None
+    generation_s: Optional[float] = None
+    env_s: Optional[float] = None
+
+
+def _classify_generation_failure(
+    exc: Exception, *, prompt_idx: Any, traj_idx: int
+) -> RolloutFailure:
+    """Wrap a generation error in the typed failure its class implies.
+
+    The original exception is preserved as ``__cause__``; the prompt and trajectory
+    coordinates are attached because a raw generation traceback does not say which
+    rollout it belonged to.
+
+    Any Ray-boundary error is infrastructure *here*, by context. An exception raised
+    inside a still-living generation worker -- vLLM ``EngineDeadError``, a CUDA OOM --
+    arrives as a bare ``RayTaskError`` whose cause the boundary degraded, so
+    ``classify_rollout_failure`` can only fall through to DATA and the prompt gets two
+    attempts instead of the five the fleet-failure path is built for.
+
+    Scoped to this call site rather than widened in ``classify_rollout_failure``,
+    deliberately. Globally, "unrecognized means DATA" is the right default: it is about
+    exceptions we can inspect and do not recognize, and flipping it would retry genuine
+    bugs everywhere. Here we have information the classifier does not -- this exception
+    came from a *generation* RPC, so "that shard could not serve it" is the correct
+    reading whatever the destroyed cause was, and re-dispatching to another shard is
+    exactly the right response. A real bug in the worker still surfaces, chained, once
+    the bounded infra budget runs out.
+
+    This also makes the two paths agree: part 2/4's ``_generate_on_shard`` already maps
+    ``ray.exceptions.RayError`` to ``GenerationUnavailable``, so without this the same
+    exception classified INFRA there and DATA here.
+
+    Args:
+        exc: The exception raised while generating a turn.
+        prompt_idx: Index of the prompt whose rollout failed.
+        traj_idx: Index of the failing generation within the prompt group.
+
+    Returns:
+        ``GenerationUnavailable`` for infrastructure failures (retriable on another
+        shard), ``RolloutDataFailure`` otherwise.
+    """
+    detail = f"prompt_idx={prompt_idx} traj_idx={traj_idx}: {type(exc).__name__}: {exc}"
+    if (
+        isinstance(exc, ray.exceptions.RayError)
+        or classify_rollout_failure(exc) is FailureClass.INFRA
+    ):
+        return GenerationUnavailable(f"generation unavailable for {detail}")
+    return RolloutDataFailure(f"generation failed for {detail}")
+
+
+async def _gather_cancelling_siblings(coros: list[Any]) -> list[Any]:
+    """Gather coroutines, cancelling the remainder as soon as one fails.
+
+    ``asyncio.gather`` propagates the first exception but leaves the other awaitables
+    running detached. On the rollout path those keep occupying generation capacity for
+    a prompt group whose result is already being discarded, so they are cancelled and
+    drained before unwinding.
+
+    Args:
+        coros: Coroutines to run concurrently.
+
+    Returns:
+        Their results, in input order.
+    """
+    tasks = [asyncio.ensure_future(coro) for coro in coros]
+    try:
+        return list(await asyncio.gather(*tasks))
+    except BaseException:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
+
+
+class _Deadline:
+    """``asyncio.timeout`` that reports expiry as a typed :class:`RolloutTimeout`.
+
+    A bare ``asyncio.timeout`` surfaces expiry as ``TimeoutError``, which is
+    indistinguishable from a ``TimeoutError`` raised by the wrapped code itself. This
+    consults ``expired()`` so only a real deadline breach is relabelled, and anything
+    else propagates untouched.
+
+    ``seconds=None`` disables the deadline, matching ``asyncio.timeout`` semantics.
+    """
+
+    def __init__(self, seconds: Optional[float], description: str) -> None:
+        self._seconds = seconds
+        self._description = description
+        self._timeout: Optional[asyncio.Timeout] = None
+
+    async def __aenter__(self) -> "_Deadline":
+        self._timeout = asyncio.timeout(self._seconds)
+        await self._timeout.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> Optional[bool]:
+        assert self._timeout is not None
+        try:
+            return await self._timeout.__aexit__(exc_type, exc, tb)
+        except TimeoutError as timeout_error:
+            if not self._timeout.expired():
+                raise
+            raise RolloutTimeout(
+                f"{self._description} exceeded {self._seconds}s"
+            ) from timeout_error
+
+
 class AsyncRolloutImpl:
     """Manages per-prompt multi-turn rollouts, producing a PromptGroupRecord per call.
 
@@ -63,6 +335,7 @@ class AsyncRolloutImpl:
         max_seq_len: int,
         max_rollout_turns: int,
         policy_generation: GenerationInterface,
+        timeouts: RolloutTimeouts = RolloutTimeouts(),
         **kwargs: Any,
     ) -> None:
         self._tokenizer = tokenizer
@@ -71,6 +344,7 @@ class AsyncRolloutImpl:
         self._max_seq_len = max_seq_len
         self._max_rollout_turns = max_rollout_turns
         self._policy_generation = policy_generation
+        self._timeouts = timeouts
 
     async def run_rollout(
         self, input_sample: DatumSpec, *, rollout_ids: Optional[list[str]] = None
@@ -92,13 +366,11 @@ class AsyncRolloutImpl:
         timer.start(f"{timer_prefix}/total")
 
         with timer.time(f"{timer_prefix}/run_rollouts"):
-            results = list(
-                await asyncio.gather(
-                    *[
-                        self._run_single_rollout(input_sample, traj_idx)
-                        for traj_idx in range(self._num_generations_per_prompt)
-                    ]
-                )
+            results = await _gather_cancelling_siblings(
+                [
+                    self._run_single_rollout(input_sample, traj_idx)
+                    for traj_idx in range(self._num_generations_per_prompt)
+                ]
             )
             completions = [c for c, _ in results]
             all_sample_metrics = [m for _, m in results]
@@ -153,7 +425,10 @@ class AsyncRolloutImpl:
 
             turn_count += 1
 
-            # Generate response for this sample using async generation
+            # Generate response for this sample using async generation.
+            # A failure here must not be absorbed: returning a partial completion
+            # would commit a zero-reward row that still counts toward this prompt
+            # group's GRPO baseline, silently biasing every sibling's advantage.
             try:
                 (
                     assistant_message,
@@ -163,32 +438,31 @@ class AsyncRolloutImpl:
                     current_message_log,
                     current_stop_strings,
                 )
-                current_message_log.append(assistant_message)
-
-                # Check if response was truncated (hit max_tokens without stop token)
-                response_truncated = gen_metrics.pop("_response_truncated", None)
-                if response_truncated is not None and response_truncated[0]:
-                    truncated = True
-
-                # Update token counts
-                gen_token_count = len(assistant_message["token_ids"])
-                assistant_token_count += gen_token_count
-                total_token_count += gen_token_count
-                turn_gen_tokens.append(gen_token_count)
-                turn_input_tokens.append(int(input_lengths))
-                turn_total_tokens.append(int(input_lengths) + gen_token_count)
-                # Per-worker load accounting
-                if "gen_leader_worker_idx" in gen_metrics:
-                    worker_idx = int(gen_metrics["gen_leader_worker_idx"])
-                    per_worker_token_counts[worker_idx] = (
-                        per_worker_token_counts.get(worker_idx, 0) + gen_token_count
-                    )
-
             except Exception as e:
-                print(
-                    f"Error generating response for prompt_idx {input_sample['idx']}, traj_idx {traj_idx}: {e}"
+                raise _classify_generation_failure(
+                    e, prompt_idx=input_sample["idx"], traj_idx=traj_idx
+                ) from e
+
+            current_message_log.append(assistant_message)
+
+            # Check if response was truncated (hit max_tokens without stop token)
+            response_truncated = gen_metrics.pop("_response_truncated", None)
+            if response_truncated is not None and response_truncated[0]:
+                truncated = True
+
+            # Update token counts
+            gen_token_count = len(assistant_message["token_ids"])
+            assistant_token_count += gen_token_count
+            total_token_count += gen_token_count
+            turn_gen_tokens.append(gen_token_count)
+            turn_input_tokens.append(int(input_lengths))
+            turn_total_tokens.append(int(input_lengths) + gen_token_count)
+            # Per-worker load accounting
+            if "gen_leader_worker_idx" in gen_metrics:
+                worker_idx = int(gen_metrics["gen_leader_worker_idx"])
+                per_worker_token_counts[worker_idx] = (
+                    per_worker_token_counts.get(worker_idx, 0) + gen_token_count
                 )
-                break
 
             # Create single-sample batch for environment interaction
             sample_batch = BatchedDataDict[DatumSpec](
@@ -204,9 +478,15 @@ class AsyncRolloutImpl:
             # blocks every other in-flight rollout coroutine for the entire env
             # step. In this case, need to wrap with asyncio.to_thread to make
             # this function yieldable.
-            env_output = await asyncio.to_thread(
-                calculate_rewards, sample_batch, self._task_to_env
-            )
+            #
+            # The deadline frees this rollout, not the thread: Python cannot kill a
+            # running thread, so a hung env call keeps occupying a thread-pool slot
+            # until its own ray.get returns. Unblocking the rollout is still what
+            # matters -- otherwise it holds a max_inflight_prompts permit forever.
+            async with _Deadline(self._timeouts.env_s, "environment step"):
+                env_output = await asyncio.to_thread(
+                    calculate_rewards, sample_batch, self._task_to_env
+                )
 
             # Update reward and termination statistics
             # Multi-reward isn't supported in RolloutManager now, see
@@ -303,10 +583,11 @@ class AsyncRolloutImpl:
         # Generate response
         # TODO: update generate_async to return a single item directly
         output = None
-        async for _idx, output in self._policy_generation.generate_async(
-            generation_input_data
-        ):
-            pass
+        async with _Deadline(self._timeouts.generation_s, "generation turn"):
+            async for _idx, output in self._policy_generation.generate_async(
+                generation_input_data
+            ):
+                pass
 
         # Build assistant message
         input_len = int(input_lengths[0].item())
@@ -343,7 +624,9 @@ class AsyncRolloutImpl:
                 gen_metrics["gen_leader_worker_idx"] = (
                     int(v[0]) if isinstance(v, list) else int(v)
                 )
-            except Exception as e:
+            except (IndexError, TypeError, ValueError) as e:
+                # Load-accounting metric only -- a malformed value must not fail the
+                # rollout, but the catch stays narrow so a real error still surfaces.
                 print(f"Error extracting gen_leader_worker_idx: {e}")
         if "truncated" in output:
             gen_metrics["_response_truncated"] = output["truncated"]
@@ -437,6 +720,13 @@ class AsyncNemoGymRolloutImpl:
         max_rollout_turns: int,
         generation_config: GenerationConfig,
         mask_env_flagged_samples: bool = True,
+        # Optional so direct construction does not have to carry the resiliency wiring;
+        # RolloutManager always passes both explicitly.
+        timeouts: Optional[RolloutTimeouts] = None,
+        retry_policy: Optional[RolloutRetryPolicy] = None,
+        # Shared with the owning RolloutManager so row-level re-dispatches are visible
+        # in the same counters as everything else. None when constructed directly.
+        stats: Optional[RolloutStats] = None,
         **kwargs: Any,
     ) -> None:
         self._tokenizer = tokenizer
@@ -446,6 +736,13 @@ class AsyncNemoGymRolloutImpl:
         self._max_rollout_turns = max_rollout_turns
         self._generation_config = generation_config
         self._mask_env_flagged_samples = mask_env_flagged_samples
+        self._timeouts = timeouts if timeouts is not None else RolloutTimeouts()
+        self._max_gym_row_attempts = (
+            retry_policy
+            if retry_policy is not None
+            else RolloutRetryPolicy.single_attempt()
+        ).max_gym_row_attempts
+        self._stats = stats
 
         self._validate_init_params()
 
@@ -538,37 +835,142 @@ class AsyncNemoGymRolloutImpl:
             rows.append(row)
         return rows
 
+    async def _stream_rows(
+        self,
+        nemo_gym_env: Any,
+        pending: list[dict],
+        results: list[Optional[dict]],
+        total_rows: int,
+        timer_prefix: str,
+    ) -> Optional[dict[str, Any]]:
+        """Dispatch ``pending`` rows and fill their slots in ``results`` as they land.
+
+        Args:
+            nemo_gym_env: The NeMo-Gym environment actor handle.
+            pending: Rows still awaiting a result; each carries its original ``_rowidx``.
+            results: Full-length result list, mutated in place.
+            total_rows: Size of the original prompt group, used to validate row indices.
+            timer_prefix: Timer namespace forwarded to the environment.
+
+        Returns:
+            The environment's timing metrics, or None if the stream ended without them.
+        """
+        dispatched = {row["_rowidx"] for row in pending}
+        received: set[int] = set()
+        env_timing_metrics: Optional[dict[str, Any]] = None
+
+        async for result_ref in nemo_gym_env.run_rollouts.options(
+            num_returns="streaming"
+        ).remote(pending, self._tokenizer, timer_prefix):
+            rowidx, result, timing_metrics = await result_ref
+            # Validated against the original group, not the pending subset: on a
+            # re-dispatch the row keeps its original index so results stay ordered.
+            if not isinstance(rowidx, int) or not 0 <= rowidx < total_rows:
+                raise ValueError(
+                    f"NeMo-Gym returned invalid row index {rowidx!r} for "
+                    f"{total_rows} inputs"
+                )
+            if rowidx not in dispatched:
+                raise ValueError(
+                    f"NeMo-Gym returned row index {rowidx}, which was not dispatched "
+                    f"in this attempt ({sorted(dispatched)})"
+                )
+            if rowidx in received:
+                raise ValueError(f"NeMo-Gym returned duplicate row index {rowidx}")
+            received.add(rowidx)
+            results[rowidx] = result
+            if timing_metrics is not None:
+                env_timing_metrics = timing_metrics
+
+        return env_timing_metrics
+
     async def _run_rollouts(
         self, inputs: list[dict], timer: Timer, timer_prefix: str
     ) -> tuple[list[Completion], LLMMessageLogType, dict[str, Any]]:
-        """Dispatch rows to NeMo-Gym; return completions, prompt, and metrics."""
+        """Dispatch rows to NeMo-Gym; return completions, prompt, and metrics.
+
+        Rows that never arrive are re-dispatched on their own rather than by redoing the
+        whole group. NeMo-Gym's stream dies on the first failing row, so one bad row
+        takes every later row with it; at num_generations_per_prompt=16 a naive whole
+        group retry pays 16 generations to recover one. Completed rows are kept across
+        attempts, which is the same shape as the legacy collector's pending-group retry.
+        """
         nemo_gym_env = self._task_to_env["nemo_gym"]
+        total_rows = len(inputs)
+        # Re-dispatch maps NeMo-Gym's echoed _rowidx back onto the original group, so
+        # the rows must carry the index _build_inputs stamped on them. Checked here
+        # because the alternative is a KeyError several frames deeper.
+        for position, row in enumerate(inputs):
+            if row.get("_rowidx") != position:
+                raise ValueError(
+                    f"NeMo-Gym input row {position} carries _rowidx="
+                    f"{row.get('_rowidx')!r}; rows must be stamped with their own "
+                    "position for re-dispatch to preserve ordering"
+                )
 
         # Run generation and restore input order as results stream back.
         with timer.time(f"{timer_prefix}/run_rollouts"):
             results: list[dict | None] = [None for _ in inputs]
-            received_row_indices: set[int] = set()
             env_timing_metrics: dict[str, Any] = {}
-            async for result_ref in nemo_gym_env.run_rollouts.options(
-                num_returns="streaming"
-            ).remote(inputs, self._tokenizer, timer_prefix):
-                rowidx, result, timing_metrics = await result_ref
-                if not isinstance(rowidx, int) or not 0 <= rowidx < len(inputs):
-                    raise ValueError(
-                        f"NeMo-Gym returned invalid row index {rowidx!r} for "
-                        f"{len(inputs)} inputs"
-                    )
-                if rowidx in received_row_indices:
-                    raise ValueError(f"NeMo-Gym returned duplicate row index {rowidx}")
-                received_row_indices.add(rowidx)
-                results[rowidx] = result
-                if timing_metrics is not None:
-                    env_timing_metrics = timing_metrics
+            # One deadline for the whole prompt group, re-dispatches included -- it is
+            # the group that has a budget, not each attempt. It also spans the stream
+            # rather than each await: NeMo-Gym yields rows as they finish, so a
+            # per-await budget would reset every time a fast row landed and never fire
+            # for the slow one holding the group up.
+            # Kept across attempts so the failure below can name the transport error that
+            # actually lost the rows. An intermediate attempt can absorb an INFRA error
+            # and a later one end the stream cleanly-but-short, and without this the
+            # operator reads "rows missing" with no cause attached at exactly the moment
+            # they need one.
+            # Exception, not BaseException: the only writer is the `except Exception`
+            # below, and a wider annotation makes the `raise ... from last_error` at the
+            # end unverifiable.
+            last_error: Optional[Exception] = None
+            async with _Deadline(self._timeouts.rollout_s, "NeMo-Gym prompt group"):
+                for attempt in range(1, self._max_gym_row_attempts + 1):
+                    pending = [row for row in inputs if results[row["_rowidx"]] is None]
+                    if not pending:
+                        break
+                    if attempt > 1:
+                        print(
+                            f"NeMo-Gym: re-dispatching {len(pending)}/{total_rows} "
+                            f"row(s) (attempt {attempt}/{self._max_gym_row_attempts})",
+                            flush=True,
+                        )
+                        # Row re-dispatches are invisible in redispatch_total -- they
+                        # recover a partial group instead of retrying the prompt -- so
+                        # gym could retry rows all run with every counter flat.
+                        if self._stats is not None:
+                            self._stats.record_gym_row_redispatch(len(pending))
+                    try:
+                        timing_metrics = await self._stream_rows(
+                            nemo_gym_env, pending, results, total_rows, timer_prefix
+                        )
+                    except Exception as error:
+                        last_error = error
+                        # Only transport-shaped failures are worth another dispatch; a
+                        # prompt NeMo-Gym cannot serve fails the same way every time.
+                        if (
+                            classify_rollout_failure(error) is not FailureClass.INFRA
+                            or attempt == self._max_gym_row_attempts
+                        ):
+                            raise
+                    else:
+                        if timing_metrics is not None:
+                            env_timing_metrics = timing_metrics
 
-            if any(result is None for result in results):
-                raise RuntimeError(
-                    "NeMo-Gym rollout stream ended before all rows arrived"
+            missing = [i for i, result in enumerate(results) if result is None]
+            if missing:
+                failure = GymTransportError(
+                    "NeMo-Gym rollout stream ended before all rows arrived; missing "
+                    f"rows {missing} of {total_rows} after "
+                    f"{self._max_gym_row_attempts} attempt(s)"
                 )
+                # Narrowed before the raise: pyrefly rejects an Optional in a `from`
+                # clause, even though `raise ... from None` is legal at runtime.
+                if last_error is None:
+                    raise failure
+                raise failure from last_error
 
             completed_results = [result for result in results if result is not None]
             # All N rollouts share the same input prompt; tensorize one copy.
@@ -754,10 +1156,21 @@ class RolloutManager:
         use_nemo_gym: bool = False,
         mask_env_flagged_samples: bool = True,
         tq_buffer: Optional[TQReplayBuffer] = None,
+        timeouts: Optional[RolloutTimeouts] = None,
+        retry_policy: Optional[RolloutRetryPolicy] = None,
     ) -> None:
         assert num_generations_per_prompt >= 1, (
             "num_generations_per_prompt must be >= 1"
         )
+        # Resolved before the impl is built: the NeMo-Gym impl reads its row-retry
+        # budget out of it at construction time, and shares the counters so its
+        # row-level re-dispatches land in the same place as everything else.
+        self._retry_policy = (
+            retry_policy
+            if retry_policy is not None
+            else RolloutRetryPolicy.single_attempt()
+        )
+        self._stats = RolloutStats()
         if not use_nemo_gym:
             rollout_cls = AsyncRolloutImpl
             assert policy_generation is not None, (
@@ -779,12 +1192,26 @@ class RolloutManager:
             generation_config=generation_config,
             # Only used by AsyncNemoGymRolloutImpl; AsyncRolloutImpl ignores it.
             mask_env_flagged_samples=mask_env_flagged_samples,
+            # None means "no deadlines", which is what async_rl's own defaults resolve
+            # to; callers that have a config pass the resolved values in.
+            timeouts=timeouts if timeouts is not None else RolloutTimeouts(),
+            # Only the NeMo-Gym impl reads these; the native impl absorbs them via kwargs.
+            retry_policy=self._retry_policy,
+            stats=self._stats,
         )
         self._tokenizer = tokenizer
         self._num_generations_per_prompt = num_generations_per_prompt
         self._tq_buffer = tq_buffer
         self._env_handles = task_to_env
         self._weight_version: int = 0
+        # Run-wide, shared across concurrent generate_and_push calls. Safe as a plain
+        # int: every caller runs on the SingleController's single event loop.
+        self._skipped_prompts: int = 0
+
+    @property
+    def stats(self) -> RolloutStats:
+        """Counters describing retry/skip activity so far."""
+        return self._stats
 
     def set_weight_version(self, version: int) -> None:
         """Set the weight_version used for rollout tags.
@@ -808,51 +1235,157 @@ class RolloutManager:
         *,
         target_step: Optional[int] = None,
         inflight_registry: Optional[dict[str, tuple[asyncio.Task[None], int]]] = None,
-    ) -> None:
-        """Reserve a buffer slot, run one prompt's rollout, then commit the slot.
+    ) -> RolloutOutcome:
+        """Roll out one prompt and commit it, re-dispatching on infrastructure failure.
+
+        No prompt is discarded for infrastructure reasons. An infra failure means the
+        fleet is unwell, not the prompt, so the attempt is retried -- and because each
+        retry re-enters generation-shard selection, it naturally lands somewhere else
+        without this method needing to know anything about shard health. Exhausting the
+        infra budget therefore means the failure follows the prompt across the whole
+        fleet, which is reported as fleet-wide failure rather than absorbed.
+
+        Deterministic failures get their own, much smaller budget: another shard would
+        reject the prompt identically, so retrying mostly burns time. One retry is still
+        worth taking because a shard under memory pressure can return an empty
+        generation that looks deterministic and is not.
 
         Args:
             input_sample: A single prompt (one DatumSpec entry).
             target_step: Training step this rollout targets; stamped on the buffer slot for StalenessSampler.force_in_order.
             inflight_registry: Optional controller-owned mapping from group ID to
                 its dispatch task and start weight version.
+
+        Returns:
+            ``COMMITTED`` when the group reached the buffer, ``SKIPPED`` when the prompt
+            exhausted its data budget within ``max_skipped_prompts``.
+
+        Raises:
+            RolloutRedispatchExhausted: The infra budget ran out.
+            RolloutDataFailure: The data budget ran out under ``fail_fast``.
         """
         assert self._tq_buffer is not None, (
             "generate_and_push requires tq_buffer to be set at __init__"
         )
-        start_version = self._weight_version
-        group_id = self._tq_buffer.reserve(
-            weight_version=start_version, target_step=target_step
-        )
-        try:
-            if inflight_registry is not None:
-                current_task = asyncio.current_task()
-                assert current_task is not None
-                inflight_registry[group_id] = (current_task, start_version)
-            # Unregister before commit so cancellation cannot interrupt it.
-            try:
-                record = await self.run_rollout(input_sample)
-            finally:
-                if inflight_registry is not None:
-                    inflight_registry.pop(group_id, None)
-            end_version = self._weight_version
-            await self._tq_buffer.commit(
-                group_id,
-                record,
-                start_weight_version=start_version,
-                end_weight_version=end_version,
+        policy = self._retry_policy
+        infra_attempts = 0
+        data_attempts = 0
+        last_infra_error: Optional[Exception] = None
+
+        # The loop condition is the infrastructure budget, so running out of it exits
+        # here rather than raising from inside the handler. The data budget is tracked
+        # separately and terminates from within, since exhausting it is a statement
+        # about the prompt rather than about the fleet.
+        while infra_attempts < policy.max_infra_attempts:
+            start_version = self._weight_version
+            # Reserved inside the loop so each attempt owns a fresh group_id: rows a
+            # failed attempt may have written cannot then collide with the retry's.
+            group_id = self._tq_buffer.reserve(
+                weight_version=start_version, target_step=target_step
             )
-        except BaseException:
-            # A failed rollout must not leave an unready slot that can block an
-            # in-order sampler. commit() rolls back any DataPlane rows it wrote.
             try:
-                await self._tq_buffer.remove_group(group_id)
-            except Exception as cleanup_exc:
-                print(
-                    f"  warn: remove_group({group_id}) cleanup failed: {cleanup_exc!r}",
-                    flush=True,
+                # Registered per ATTEMPT, not per prompt: each retry reserves a fresh
+                # group_id, so the controller's registry must follow the attempt that
+                # actually owns the slot it might abort.
+                if inflight_registry is not None:
+                    current_task = asyncio.current_task()
+                    assert current_task is not None
+                    inflight_registry[group_id] = (current_task, start_version)
+                # Unregister before commit so cancellation cannot interrupt it.
+                try:
+                    record = await self.run_rollout(input_sample)
+                finally:
+                    if inflight_registry is not None:
+                        inflight_registry.pop(group_id, None)
+                end_version = self._weight_version
+                await self._tq_buffer.commit(
+                    group_id,
+                    record,
+                    start_weight_version=start_version,
+                    end_weight_version=end_version,
                 )
-            raise
+            except Exception as error:
+                # A failed rollout must not leave an unready slot that can block an
+                # in-order sampler. commit() rolls back any DataPlane rows it wrote.
+                # Cleanup failure must not mask the error that caused it.
+                try:
+                    await self._tq_buffer.remove_group(group_id)
+                except Exception as cleanup_exc:
+                    print(
+                        f"  warn: remove_group({group_id}) cleanup failed: {cleanup_exc!r}",
+                        flush=True,
+                    )
+                reason = type(error).__name__
+
+                if classify_rollout_failure(error) is FailureClass.INFRA:
+                    infra_attempts += 1
+                    last_infra_error = error
+                    if infra_attempts >= policy.max_infra_attempts:
+                        break
+                    self._stats.record_redispatch(reason)
+                    # The backpressure permit is held across this sleep, so the wait is
+                    # capped by max_backoff_s rather than growing without bound.
+                    await asyncio.sleep(policy.backoff_for(infra_attempts))
+                    continue
+
+                data_attempts += 1
+                if data_attempts >= policy.max_data_attempts:
+                    self._stats.record_data_failure(reason)
+                    if self._skipped_prompts >= policy.max_skipped_prompts:
+                        # At the default of 0 this fires on the first exhaustion and the
+                        # original failure propagates unchanged -- one knob, and its
+                        # zero value is the old "fail_fast" without a second key to
+                        # contradict it.
+                        if policy.max_skipped_prompts == 0:
+                            raise
+                        raise RolloutDataFailure(
+                            f"skipped {self._skipped_prompts} prompts and this one also "
+                            f"exhausted its data budget, exceeding max_skipped_prompts="
+                            f"{policy.max_skipped_prompts}; the dataset or "
+                            "sequence-length configuration is likely wrong"
+                        ) from error
+                    self._skipped_prompts += 1
+                    print(
+                        f"skipping prompt idx={input_sample['idx']} after "
+                        f"{data_attempts} deterministic failure(s) ({reason}: {error})",
+                        flush=True,
+                    )
+                    self._stats.skipped += 1
+                    return RolloutOutcome.SKIPPED
+                # A data retry, NOT a re-dispatch: the fleet is fine, this prompt is
+                # suspect. Recording it as a re-dispatch made rollout/redispatch_total --
+                # documented above as the sign the fleet is degrading -- climb for bad
+                # data, which is the one distinction the two budgets exist to draw.
+                self._stats.record_data_retry(reason)
+                continue
+            except BaseException:
+                # Cancellation and other non-Exception exits: clean up, never retry.
+                try:
+                    await self._tq_buffer.remove_group(group_id)
+                except Exception as cleanup_exc:
+                    print(
+                        f"  warn: remove_group({group_id}) cleanup failed: {cleanup_exc!r}",
+                        flush=True,
+                    )
+                raise
+
+            self._stats.committed += 1
+            return RolloutOutcome.COMMITTED
+
+        # The infrastructure budget ran out. The same failure followed the prompt across
+        # repeated shard selections, which says the fleet is broken rather than the
+        # prompt, so this is reported rather than absorbed.
+        #
+        # The budget is >= 1 (enforced in RolloutRetryPolicy), so the loop ran at least
+        # once and can only have exited through the infra branch's break.
+        assert last_infra_error is not None
+        raise RolloutRedispatchExhausted(
+            f"prompt idx={input_sample['idx']} exhausted its infrastructure retry "
+            f"budget after {infra_attempts} attempt(s) "
+            f"(max_infra_attempts_per_prompt="
+            f"{policy.max_infra_attempts}); last failure was "
+            f"{type(last_infra_error).__name__}: {last_infra_error}"
+        ) from last_infra_error
 
     async def generate_for_finalization(
         self,
@@ -863,9 +1396,9 @@ class RolloutManager:
     ) -> "FinalizationRequest":
         """Run capture generation and return a metadata-only actor request.
 
-        The replay-buffer slot remains reserved and unready. The caller owns
-        finalizer submission and must either commit the returned group or stop
-        the validation run on an unknown publication outcome.
+        Canonical sibling IDs are stable logical row names. Gate rollout IDs
+        identify the physical capture attempts and are kept separate so later
+        retry/recovery layers can replace an attempt without changing its row.
         """
         from nemo_rl.experience.finalizer_actor import FinalizationRequest
 
@@ -874,8 +1407,11 @@ class RolloutManager:
         )
         start_version = self._weight_version
         group_id = str(uuid.uuid4())
-        rollout_ids = tuple(
+        canonical_sample_ids = tuple(
             f"{group_id}_g{i}" for i in range(self._num_generations_per_prompt)
+        )
+        rollout_ids = tuple(
+            f"{sample_id}_a{uuid.uuid4().hex}" for sample_id in canonical_sample_ids
         )
         self._tq_buffer.reserve(
             weight_version=start_version,
@@ -901,6 +1437,7 @@ class RolloutManager:
             request = FinalizationRequest(
                 group_id=group_id,
                 rollout_ids=rollout_ids,
+                canonical_sample_ids=canonical_sample_ids,
                 receipts=receipts,
                 rewards=rewards,
                 fallback_weight_version=start_version,
@@ -910,10 +1447,5 @@ class RolloutManager:
             assert_metadata_only(request)
             return request
         except BaseException:
-            # Abandoned dispatch: no receipt will name these rollouts' staged
-            # rows, so they leak until the staging partition is torn down at
-            # run end (there is no prefix-clear primitive in the data plane
-            # yet). Their ledger files are inert — failure rows or missing
-            # terminal rows keep any later read fail-closed.
             self._tq_buffer.abort(group_id)
             raise

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -16,7 +16,7 @@ import asyncio
 import copy
 import enum
 import json
-import uuid
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -41,6 +41,11 @@ from nemo_rl.experience.failures import (
 )
 from nemo_rl.experience.interfaces import Completion, PromptGroupRecord
 from nemo_rl.experience.metric_utils import calculate_single_metric, pct
+from nemo_rl.experience.rollout_recovery import (
+    PromptGroupStatus,
+    RolloutAttemptStatus,
+    RolloutRecoveryLedger,
+)
 from nemo_rl.experience.rollouts import (
     _attach_routed_experts_to_message_log_prefix,
     _dummy_routed_experts_for_tokens,
@@ -56,6 +61,7 @@ from nemo_rl.models.generation.interfaces import (
 from nemo_rl.utils.timer import Timer
 
 TokenizerType = PreTrainedTokenizerBase
+RolloutCompletionCallback = Callable[[int, Completion], Awaitable[None]]
 
 if TYPE_CHECKING:
     from nemo_rl.experience.finalizer_actor import FinalizationRequest
@@ -347,7 +353,12 @@ class AsyncRolloutImpl:
         self._timeouts = timeouts
 
     async def run_rollout(
-        self, input_sample: DatumSpec, *, rollout_ids: Optional[list[str]] = None
+        self,
+        input_sample: DatumSpec,
+        *,
+        rollout_ids: Optional[list[str]] = None,
+        generation_indices: Optional[list[int]] = None,
+        on_completion: Optional[RolloutCompletionCallback] = None,
     ) -> PromptGroupRecord:
         """Run num_generations_per_prompt rollouts for one prompt.
 
@@ -360,6 +371,12 @@ class AsyncRolloutImpl:
         """
         assert rollout_ids is None, (
             "token capture (rollout_ids) is only supported on the NeMo-Gym path"
+        )
+        assert generation_indices is None, (
+            "partial sibling dispatch is only supported on the NeMo-Gym path"
+        )
+        assert on_completion is None, (
+            "streamed completion callbacks are only supported on the NeMo-Gym path"
         )
         timer = Timer()
         timer_prefix = "timing/rollout"
@@ -747,7 +764,12 @@ class AsyncNemoGymRolloutImpl:
         self._validate_init_params()
 
     async def run_rollout(
-        self, input_sample: DatumSpec, *, rollout_ids: Optional[list[str]] = None
+        self,
+        input_sample: DatumSpec,
+        *,
+        rollout_ids: Optional[list[str]] = None,
+        generation_indices: Optional[list[int]] = None,
+        on_completion: Optional[RolloutCompletionCallback] = None,
     ) -> PromptGroupRecord:
         """Run num_generations_per_prompt rollouts for one prompt.
 
@@ -765,9 +787,16 @@ class AsyncNemoGymRolloutImpl:
         timer_prefix = "timing/rollout"
         timer.start(f"{timer_prefix}/total")
 
-        rollout_inputs = self._build_inputs(input_sample, rollout_ids=rollout_ids)
+        rollout_inputs = self._build_inputs(
+            input_sample,
+            rollout_ids=rollout_ids,
+            generation_indices=generation_indices,
+        )
         completions, prompt_message_log, rollout_metrics = await self._run_rollouts(
-            rollout_inputs, timer, timer_prefix
+            rollout_inputs,
+            timer,
+            timer_prefix,
+            on_completion=on_completion,
         )
 
         timer.stop(f"{timer_prefix}/total")
@@ -797,7 +826,11 @@ class AsyncNemoGymRolloutImpl:
         )
 
     def _build_inputs(
-        self, input_sample: DatumSpec, *, rollout_ids: Optional[list[str]] = None
+        self,
+        input_sample: DatumSpec,
+        *,
+        rollout_ids: Optional[list[str]] = None,
+        generation_indices: Optional[list[int]] = None,
     ) -> list[dict]:
         """Build N row dicts from input_sample, applying generation config params."""
         # Build a template row from the input_sample's extra_env_info, applying generation params.
@@ -823,8 +856,19 @@ class AsyncNemoGymRolloutImpl:
             assert len(rollout_ids) == self._num_generations_per_prompt, (
                 "token-capture rollout ids must be one per generation"
             )
+        indices = (
+            list(range(self._num_generations_per_prompt))
+            if generation_indices is None
+            else list(generation_indices)
+        )
+        if len(indices) != len(set(indices)) or any(
+            not 0 <= index < self._num_generations_per_prompt for index in indices
+        ):
+            raise ValueError(
+                "generation_indices must be unique and within the prompt group"
+            )
         rows = []
-        for i in range(self._num_generations_per_prompt):
+        for i in indices:
             row = copy.deepcopy(template_row)
             row["_rowidx"] = i
             if rollout_ids is not None:
@@ -842,6 +886,7 @@ class AsyncNemoGymRolloutImpl:
         results: list[Optional[dict]],
         total_rows: int,
         timer_prefix: str,
+        on_completion: Optional[RolloutCompletionCallback] = None,
     ) -> Optional[dict[str, Any]]:
         """Dispatch ``pending`` rows and fill their slots in ``results`` as they land.
 
@@ -879,13 +924,20 @@ class AsyncNemoGymRolloutImpl:
                 raise ValueError(f"NeMo-Gym returned duplicate row index {rowidx}")
             received.add(rowidx)
             results[rowidx] = result
+            if on_completion is not None:
+                await on_completion(rowidx, self._result_to_completion(result))
             if timing_metrics is not None:
                 env_timing_metrics = timing_metrics
 
         return env_timing_metrics
 
     async def _run_rollouts(
-        self, inputs: list[dict], timer: Timer, timer_prefix: str
+        self,
+        inputs: list[dict],
+        timer: Timer,
+        timer_prefix: str,
+        *,
+        on_completion: Optional[RolloutCompletionCallback] = None,
     ) -> tuple[list[Completion], LLMMessageLogType, dict[str, Any]]:
         """Dispatch rows to NeMo-Gym; return completions, prompt, and metrics.
 
@@ -896,21 +948,26 @@ class AsyncNemoGymRolloutImpl:
         attempts, which is the same shape as the legacy collector's pending-group retry.
         """
         nemo_gym_env = self._task_to_env["nemo_gym"]
-        total_rows = len(inputs)
+        if not inputs:
+            raise ValueError("NeMo-Gym rollout dispatch requires at least one row")
+        total_rows = self._num_generations_per_prompt
         # Re-dispatch maps NeMo-Gym's echoed _rowidx back onto the original group, so
         # the rows must carry the index _build_inputs stamped on them. Checked here
         # because the alternative is a KeyError several frames deeper.
-        for position, row in enumerate(inputs):
-            if row.get("_rowidx") != position:
+        for row in inputs:
+            rowidx = row.get("_rowidx")
+            if not isinstance(rowidx, int) or not 0 <= rowidx < total_rows:
                 raise ValueError(
-                    f"NeMo-Gym input row {position} carries _rowidx="
-                    f"{row.get('_rowidx')!r}; rows must be stamped with their own "
-                    "position for re-dispatch to preserve ordering"
+                    f"NeMo-Gym input row carries invalid _rowidx={rowidx!r}; "
+                    f"expected an index within {total_rows} generations"
                 )
+        expected_indices = [row["_rowidx"] for row in inputs]
+        if len(expected_indices) != len(set(expected_indices)):
+            raise ValueError("NeMo-Gym input rows contain duplicate _rowidx values")
 
         # Run generation and restore input order as results stream back.
         with timer.time(f"{timer_prefix}/run_rollouts"):
-            results: list[dict | None] = [None for _ in inputs]
+            results: list[dict | None] = [None for _ in range(total_rows)]
             env_timing_metrics: dict[str, Any] = {}
             # One deadline for the whole prompt group, re-dispatches included -- it is
             # the group that has a budget, not each attempt. It also spans the stream
@@ -944,7 +1001,12 @@ class AsyncNemoGymRolloutImpl:
                             self._stats.record_gym_row_redispatch(len(pending))
                     try:
                         timing_metrics = await self._stream_rows(
-                            nemo_gym_env, pending, results, total_rows, timer_prefix
+                            nemo_gym_env,
+                            pending,
+                            results,
+                            total_rows,
+                            timer_prefix,
+                            on_completion=on_completion,
                         )
                     except Exception as error:
                         last_error = error
@@ -959,7 +1021,7 @@ class AsyncNemoGymRolloutImpl:
                         if timing_metrics is not None:
                             env_timing_metrics = timing_metrics
 
-            missing = [i for i, result in enumerate(results) if result is None]
+            missing = [index for index in expected_indices if results[index] is None]
             if missing:
                 failure = GymTransportError(
                     "NeMo-Gym rollout stream ended before all rows arrived; missing "
@@ -972,7 +1034,11 @@ class AsyncNemoGymRolloutImpl:
                     raise failure
                 raise failure from last_error
 
-            completed_results = [result for result in results if result is not None]
+            completed_results: list[dict] = []
+            for index in expected_indices:
+                result = results[index]
+                assert result is not None
+                completed_results.append(result)
             # All N rollouts share the same input prompt; tensorize one copy.
             prompt_message_log = completed_results[0]["input_message_log"]
             _tensorize_by_key(prompt_message_log, "token_ids")
@@ -1158,6 +1224,7 @@ class RolloutManager:
         tq_buffer: Optional[TQReplayBuffer] = None,
         timeouts: Optional[RolloutTimeouts] = None,
         retry_policy: Optional[RolloutRetryPolicy] = None,
+        recovery_ledger: Optional[RolloutRecoveryLedger] = None,
     ) -> None:
         assert num_generations_per_prompt >= 1, (
             "num_generations_per_prompt must be >= 1"
@@ -1202,7 +1269,7 @@ class RolloutManager:
         self._tokenizer = tokenizer
         self._num_generations_per_prompt = num_generations_per_prompt
         self._tq_buffer = tq_buffer
-        self._env_handles = task_to_env
+        self._recovery_ledger = recovery_ledger
         self._weight_version: int = 0
         # Run-wide, shared across concurrent generate_and_push calls. Safe as a plain
         # int: every caller runs on the SingleController's single event loop.
@@ -1213,6 +1280,11 @@ class RolloutManager:
         """Counters describing retry/skip activity so far."""
         return self._stats
 
+    @property
+    def recovery_ledger(self) -> Optional[RolloutRecoveryLedger]:
+        """Return the controller-owned token-capture lineage ledger."""
+        return self._recovery_ledger
+
     def set_weight_version(self, version: int) -> None:
         """Set the weight_version used for rollout tags.
 
@@ -1222,12 +1294,24 @@ class RolloutManager:
         self._weight_version = int(version)
 
     async def run_rollout(
-        self, input_sample: DatumSpec, *, rollout_ids: Optional[list[str]] = None
+        self,
+        input_sample: DatumSpec,
+        *,
+        rollout_ids: Optional[list[str]] = None,
+        generation_indices: Optional[list[int]] = None,
+        on_completion: Optional[RolloutCompletionCallback] = None,
     ) -> PromptGroupRecord:
         if rollout_ids is None:
+            assert generation_indices is None
+            assert on_completion is None
             # Legacy path: keep the impl call signature byte-identical.
             return await self._impl.run_rollout(input_sample)
-        return await self._impl.run_rollout(input_sample, rollout_ids=rollout_ids)
+        return await self._impl.run_rollout(
+            input_sample,
+            rollout_ids=rollout_ids,
+            generation_indices=generation_indices,
+            on_completion=on_completion,
+        )
 
     async def generate_and_push(
         self,
@@ -1396,50 +1480,177 @@ class RolloutManager:
     ) -> "FinalizationRequest":
         """Run capture generation and return a metadata-only actor request.
 
-        Canonical sibling IDs are stable logical row names. Gate rollout IDs
-        identify the physical capture attempts and are kept separate so later
-        retry/recovery layers can replace an attempt without changing its row.
-        """
-        from nemo_rl.experience.finalizer_actor import FinalizationRequest
+        The replay-buffer slot remains reserved and unready. Logical sibling
+        IDs remain stable across retries; only unfinished siblings receive new
+        physical Gate attempt IDs. Sealed sibling receipts are therefore reused
+        instead of paying for the whole GRPO group again.
 
+        Returns:
+            A metadata-only finalizer request after successful generation, or
+            ``None`` when a deterministic prompt failure exhausts its budget
+            within ``max_skipped_prompts``.
+        """
         assert self._tq_buffer is not None, (
             "generate_for_finalization requires tq_buffer to be set at __init__"
         )
-        start_version = self._weight_version
-        group_id = str(uuid.uuid4())
-        canonical_sample_ids = tuple(
-            f"{group_id}_g{i}" for i in range(self._num_generations_per_prompt)
+        if self._recovery_ledger is None:
+            raise RuntimeError(
+                "generate_for_finalization requires a rollout recovery ledger"
+            )
+        recovery_group = self._recovery_ledger.reserve_group(
+            prompt_id=str(input_sample["idx"]),
+            prompt_payload=input_sample,
+            expected_generations=self._num_generations_per_prompt,
+            target_step=target_step,
+            start_weight_version=self._weight_version,
         )
-        rollout_ids = tuple(
-            f"{sample_id}_a{uuid.uuid4().hex}" for sample_id in canonical_sample_ids
-        )
+        recovery_group_id = recovery_group.group_id
+        policy = self._retry_policy
+        infra_attempts = 0
+        data_attempts = 0
+        last_infra_error: Optional[Exception] = None
+
+        while infra_attempts < policy.max_infra_attempts:
+            try:
+                return await self._generate_for_finalization_attempt(
+                    input_sample,
+                    recovery_group_id=recovery_group_id,
+                    inflight_registry=inflight_registry,
+                )
+            except Exception as error:
+                reason = type(error).__name__
+                if classify_rollout_failure(error) is FailureClass.INFRA:
+                    infra_attempts += 1
+                    last_infra_error = error
+                    if infra_attempts >= policy.max_infra_attempts:
+                        break
+                    self._stats.record_redispatch(reason)
+                    await asyncio.sleep(policy.backoff_for(infra_attempts))
+                    continue
+
+                data_attempts += 1
+                if data_attempts >= policy.max_data_attempts:
+                    self._stats.record_data_failure(reason)
+                    if self._skipped_prompts >= policy.max_skipped_prompts:
+                        if policy.max_skipped_prompts == 0:
+                            raise
+                        raise RolloutDataFailure(
+                            f"skipped {self._skipped_prompts} prompts and this one "
+                            "also exhausted its data budget, exceeding "
+                            f"max_skipped_prompts={policy.max_skipped_prompts}; "
+                            "the dataset or sequence-length configuration is likely "
+                            "wrong"
+                        ) from error
+                    self._skipped_prompts += 1
+                    await self._discard_recovery_group(recovery_group_id)
+                    print(
+                        f"skipping prompt idx={input_sample['idx']} after "
+                        f"{data_attempts} deterministic failure(s) "
+                        f"({reason}: {error})",
+                        flush=True,
+                    )
+                    self._stats.skipped += 1
+                    return None
+                self._stats.record_data_retry(reason)
+
+        assert last_infra_error is not None
+        raise RolloutRedispatchExhausted(
+            f"prompt idx={input_sample['idx']} exhausted its infrastructure retry "
+            f"budget after {infra_attempts} attempt(s) "
+            f"(max_infra_attempts_per_prompt={policy.max_infra_attempts}); "
+            f"last failure was {type(last_infra_error).__name__}: "
+            f"{last_infra_error}"
+        ) from last_infra_error
+
+    async def _generate_for_finalization_attempt(
+        self,
+        input_sample: DatumSpec,
+        *,
+        recovery_group_id: str,
+        inflight_registry: Optional[dict[str, tuple[asyncio.Task[None], int]]],
+    ) -> "FinalizationRequest":
+        """Dispatch only unfinished siblings and leave one reserved slot unready."""
+        from nemo_rl.experience.finalizer_actor import FinalizationRequest
+
+        assert self._tq_buffer is not None
+        assert self._recovery_ledger is not None
+        recovery_group = self._recovery_ledger.get_group(recovery_group_id)
+        if recovery_group.status == PromptGroupStatus.GENERATING:
+            recovery_group = self._recovery_ledger.prepare_incomplete_retry(
+                recovery_group_id
+            )
+        pending_indices = [
+            sibling.generation_index
+            for sibling in recovery_group.siblings
+            if sibling.current_attempt.status != RolloutAttemptStatus.SEALED
+        ]
+        group_id = recovery_group.group_id
+        start_version = recovery_group.start_weight_version
+        rollout_ids = tuple(recovery_group.gate_rollout_ids)
         self._tq_buffer.reserve(
             weight_version=start_version,
-            target_step=target_step,
+            target_step=recovery_group.target_step,
             group_id=group_id,
             rollout_ids=list(rollout_ids),
         )
+
+        async def _record_streamed_completion(
+            generation_index: int, completion: Completion
+        ) -> None:
+            env_extras = completion.env_extras
+            if env_extras is None:
+                raise ValueError(
+                    "token-capture completion must contain environment extras"
+                )
+            receipt = env_extras.get("ng_receipt")
+            gate_rollout_id = env_extras.get("ng_rollout_id")
+            if not isinstance(receipt, dict):
+                raise ValueError(
+                    "token-capture completion must contain a receipt mapping"
+                )
+            if not isinstance(gate_rollout_id, str):
+                raise ValueError(
+                    "token-capture completion must contain its Gate rollout ID"
+                )
+            self._recovery_ledger.mark_sibling_sealed(
+                group_id,
+                generation_index=generation_index,
+                gate_rollout_id=gate_rollout_id,
+                receipt=receipt,
+                reward=completion.reward,
+            )
+
         try:
             if inflight_registry is not None:
                 current_task = asyncio.current_task()
                 assert current_task is not None
                 inflight_registry[group_id] = (current_task, start_version)
             try:
-                record = await self.run_rollout(
-                    input_sample,
-                    rollout_ids=list(rollout_ids),
-                )
+                if pending_indices:
+                    self._recovery_ledger.mark_group_dispatched(
+                        group_id, generation_indices=pending_indices
+                    )
+                    await self.run_rollout(
+                        input_sample,
+                        rollout_ids=list(rollout_ids),
+                        generation_indices=pending_indices,
+                        on_completion=_record_streamed_completion,
+                    )
             finally:
                 if inflight_registry is not None:
                     inflight_registry.pop(group_id, None)
-            receipts = tuple(c.env_extras.get("ng_receipt") for c in record.completions)
-            rewards = tuple(float(c.reward) for c in record.completions)
+            (
+                physical_rollout_ids,
+                canonical_sample_ids,
+                receipts,
+                rewards,
+            ) = self._recovery_ledger.finalization_inputs(group_id)
             request = FinalizationRequest(
                 group_id=group_id,
-                rollout_ids=rollout_ids,
-                canonical_sample_ids=canonical_sample_ids,
-                receipts=receipts,
-                rewards=rewards,
+                rollout_ids=tuple(physical_rollout_ids),
+                canonical_sample_ids=tuple(canonical_sample_ids),
+                receipts=tuple(receipts),
+                rewards=tuple(rewards),
                 fallback_weight_version=start_version,
             )
             from nemo_rl.experience.finalizer_actor import assert_metadata_only
@@ -1448,4 +1659,21 @@ class RolloutManager:
             return request
         except BaseException:
             self._tq_buffer.abort(group_id)
+            self._recovery_ledger.abandon_unsealed(group_id)
+            # The capture ledger has no per-rollout fail endpoint. Rows from
+            # abandoned attempts are unreferenced and are swept with the
+            # staging partition at run teardown.
             raise
+
+    async def _discard_recovery_group(self, group_id: str) -> None:
+        """Clean known staged rows before intentionally dropping lineage."""
+        assert self._tq_buffer is not None
+        assert self._recovery_ledger is not None
+        group = self._recovery_ledger.get_group(group_id)
+        staging_keys = [
+            key
+            for sibling in group.siblings
+            for key in sibling.current_attempt.staging_keys
+        ]
+        await self._tq_buffer.clear_staging_keys(staging_keys)
+        self._recovery_ledger.discard_group(group_id)

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -42,6 +42,7 @@ from nemo_rl.experience.failures import (
 from nemo_rl.experience.interfaces import Completion, PromptGroupRecord
 from nemo_rl.experience.metric_utils import calculate_single_metric, pct
 from nemo_rl.experience.rollout_recovery import (
+    PromptRef,
     PromptGroupStatus,
     RolloutAttemptStatus,
     RolloutRecoveryLedger,
@@ -1499,6 +1500,10 @@ class RolloutManager:
             )
         recovery_group = self._recovery_ledger.reserve_group(
             prompt_id=str(input_sample["idx"]),
+            prompt_ref=PromptRef(
+                sample_id=str(input_sample["idx"]),
+                task_name=input_sample.get("task_name"),
+            ),
             prompt_payload=input_sample,
             expected_generations=self._num_generations_per_prompt,
             target_step=target_step,

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -15,6 +15,7 @@
 import asyncio
 import copy
 import json
+from collections.abc import Awaitable, Callable
 from typing import Any, Optional
 
 import torch
@@ -27,7 +28,10 @@ from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.experience.interfaces import Completion, PromptGroupRecord
 from nemo_rl.experience.metric_utils import calculate_single_metric, pct
-from nemo_rl.experience.rollout_recovery import RolloutRecoveryLedger
+from nemo_rl.experience.rollout_recovery import (
+    RolloutAttemptStatus,
+    RolloutRecoveryLedger,
+)
 from nemo_rl.experience.rollouts import _tensorize_by_key, calculate_rewards
 from nemo_rl.models.generation.interfaces import (
     GenerationConfig,
@@ -37,6 +41,7 @@ from nemo_rl.models.generation.interfaces import (
 from nemo_rl.utils.timer import Timer
 
 TokenizerType = PreTrainedTokenizerBase
+RolloutCompletionCallback = Callable[[int, Completion], Awaitable[None]]
 
 
 class AsyncRolloutImpl:
@@ -64,19 +69,28 @@ class AsyncRolloutImpl:
         self._policy_generation = policy_generation
 
     async def run_rollout(
-        self, input_sample: DatumSpec, *, rollout_ids: Optional[list[str]] = None
+        self,
+        input_sample: DatumSpec,
+        *,
+        rollout_ids: Optional[list[str]] = None,
+        on_completion: Optional[RolloutCompletionCallback] = None,
     ) -> PromptGroupRecord:
         """Run num_generations_per_prompt rollouts for one prompt.
 
         Args:
             input_sample: A single prompt (one DatumSpec entry).
             rollout_ids: Unsupported here — token capture is NeMo-Gym only.
+            on_completion: Unsupported here — streamed sibling receipts are
+                available only on the NeMo-Gym path.
 
         Returns:
             PromptGroupRecord with num_generations_per_prompt completions.
         """
         assert rollout_ids is None, (
             "token capture (rollout_ids) is only supported on the NeMo-Gym path"
+        )
+        assert on_completion is None, (
+            "streamed completion callbacks are only supported on the NeMo-Gym path"
         )
         timer = Timer()
         timer_prefix = "timing/rollout"
@@ -424,7 +438,11 @@ class AsyncNemoGymRolloutImpl:
         self._validate_init_params()
 
     async def run_rollout(
-        self, input_sample: DatumSpec, *, rollout_ids: Optional[list[str]] = None
+        self,
+        input_sample: DatumSpec,
+        *,
+        rollout_ids: Optional[list[str]] = None,
+        on_completion: Optional[RolloutCompletionCallback] = None,
     ) -> PromptGroupRecord:
         """Run num_generations_per_prompt rollouts for one prompt.
 
@@ -434,6 +452,8 @@ class AsyncNemoGymRolloutImpl:
                 per generation, riding each row's run body as the opaque
                 ``_ng_rollout_id`` key (agents stamp /ng-rollout/<id> from it;
                 zero agent changes).
+            on_completion: Optional async callback invoked as soon as one
+                streamed sibling result has been converted to a completion.
 
         Returns:
             PromptGroupRecord with num_generations_per_prompt completions.
@@ -444,7 +464,10 @@ class AsyncNemoGymRolloutImpl:
 
         rollout_inputs = self._build_inputs(input_sample, rollout_ids=rollout_ids)
         completions, prompt_message_log, rollout_metrics = await self._run_rollouts(
-            rollout_inputs, timer, timer_prefix
+            rollout_inputs,
+            timer,
+            timer_prefix,
+            on_completion=on_completion,
         )
 
         timer.stop(f"{timer_prefix}/total")
@@ -513,7 +536,12 @@ class AsyncNemoGymRolloutImpl:
         return rows
 
     async def _run_rollouts(
-        self, inputs: list[dict], timer: Timer, timer_prefix: str
+        self,
+        inputs: list[dict],
+        timer: Timer,
+        timer_prefix: str,
+        *,
+        on_completion: Optional[RolloutCompletionCallback] = None,
     ) -> tuple[list[Completion], LLMMessageLogType, dict[str, Any]]:
         """Dispatch rows to NeMo-Gym; return completions, prompt, and metrics."""
         nemo_gym_env = self._task_to_env["nemo_gym"]
@@ -521,6 +549,7 @@ class AsyncNemoGymRolloutImpl:
         # Run generation and restore input order as results stream back.
         with timer.time(f"{timer_prefix}/run_rollouts"):
             results: list[dict | None] = [None for _ in inputs]
+            streamed_completions: list[Completion | None] = [None for _ in inputs]
             received_row_indices: set[int] = set()
             env_timing_metrics: dict[str, Any] = {}
             async for result_ref in nemo_gym_env.run_rollouts.options(
@@ -536,10 +565,16 @@ class AsyncNemoGymRolloutImpl:
                     raise ValueError(f"NeMo-Gym returned duplicate row index {rowidx}")
                 received_row_indices.add(rowidx)
                 results[rowidx] = result
+                completion = self._result_to_completion(result)
+                if on_completion is not None:
+                    await on_completion(rowidx, completion)
+                streamed_completions[rowidx] = completion
                 if timing_metrics is not None:
                     env_timing_metrics = timing_metrics
 
-            if any(result is None for result in results):
+            if any(result is None for result in results) or any(
+                completion is None for completion in streamed_completions
+            ):
                 raise RuntimeError(
                     "NeMo-Gym rollout stream ended before all rows arrived"
                 )
@@ -548,9 +583,10 @@ class AsyncNemoGymRolloutImpl:
             # All N rollouts share the same input prompt; tensorize one copy.
             prompt_message_log = completed_results[0]["input_message_log"]
             _tensorize_by_key(prompt_message_log, "token_ids")
-            # Convert results to completions.
             completions = [
-                self._result_to_completion(result) for result in completed_results
+                completion
+                for completion in streamed_completions
+                if completion is not None
             ]
 
         # Compute rollout metrics.
@@ -798,12 +834,23 @@ class RolloutManager:
         return await env.gate_metrics.remote()
 
     async def run_rollout(
-        self, input_sample: DatumSpec, *, rollout_ids: Optional[list[str]] = None
+        self,
+        input_sample: DatumSpec,
+        *,
+        rollout_ids: Optional[list[str]] = None,
+        on_completion: Optional[RolloutCompletionCallback] = None,
     ) -> PromptGroupRecord:
         if rollout_ids is None:
+            assert on_completion is None, (
+                "completion callback requires token-capture rollout IDs"
+            )
             # Legacy path: keep the impl call signature byte-identical.
             return await self._impl.run_rollout(input_sample)
-        return await self._impl.run_rollout(input_sample, rollout_ids=rollout_ids)
+        return await self._impl.run_rollout(
+            input_sample,
+            rollout_ids=rollout_ids,
+            on_completion=on_completion,
+        )
 
     async def generate_and_push(
         self, input_sample: DatumSpec, *, target_step: Optional[int] = None
@@ -861,6 +908,34 @@ class RolloutManager:
         group_id = recovery_group.group_id
         logical_rollout_ids = recovery_group.logical_rollout_ids
         gate_rollout_ids = recovery_group.gate_rollout_ids
+        discard_recovery_group = False
+
+        async def _record_streamed_completion(
+            generation_index: int, completion: Completion
+        ) -> None:
+            env_extras = completion.env_extras
+            if env_extras is None:
+                raise ValueError(
+                    "token-capture completion must contain environment extras"
+                )
+            receipt = env_extras.get("ng_receipt")
+            gate_rollout_id = env_extras.get("ng_rollout_id")
+            if not isinstance(receipt, dict):
+                raise ValueError(
+                    "token-capture completion must contain a receipt mapping"
+                )
+            if not isinstance(gate_rollout_id, str):
+                raise ValueError(
+                    "token-capture completion must contain its gate rollout ID"
+                )
+            self._recovery_ledger.mark_sibling_sealed(
+                group_id,
+                generation_index=generation_index,
+                gate_rollout_id=gate_rollout_id,
+                receipt=receipt,
+                reward=completion.reward,
+            )
+
         try:
             self._tq_buffer.reserve(
                 weight_version=start_version,
@@ -869,7 +944,11 @@ class RolloutManager:
                 rollout_ids=gate_rollout_ids,
             )
             self._recovery_ledger.mark_group_dispatched(group_id)
-            record = await self.run_rollout(input_sample, rollout_ids=gate_rollout_ids)
+            record = await self.run_rollout(
+                input_sample,
+                rollout_ids=gate_rollout_ids,
+                on_completion=_record_streamed_completion,
+            )
             receipts = [c.env_extras.get("ng_receipt") for c in record.completions]
             rewards = [float(c.reward) for c in record.completions]
             finalized = await asyncio.to_thread(
@@ -888,6 +967,9 @@ class RolloutManager:
                 await self._tq_buffer.abort_finalized(
                     group_id, staging_keys=finalized.staging_keys
                 )
+                # Only discard the lineage once cleanup succeeds. If cleanup
+                # fails, retain sealed receipts so recovery can retry it.
+                discard_recovery_group = True
                 raise RuntimeError(
                     f"token capture: group {group_id} dropped "
                     "(min_valid_fraction_per_group)"
@@ -904,13 +986,28 @@ class RolloutManager:
             )
         except BaseException:
             self._tq_buffer.abort(group_id)
-            self._recovery_ledger.abandon_group(group_id)
-            # Best-effort gate cleanup: no receipt will ever seal these ids.
+            if discard_recovery_group:
+                self._recovery_ledger.discard_group(group_id)
+                gate_ids_to_fail = gate_rollout_ids
+            else:
+                self._recovery_ledger.abandon_group(group_id)
+                recovery_group = self._recovery_ledger.get_group(group_id)
+                gate_ids_to_fail = [
+                    sibling.current_attempt.gate_rollout_id
+                    for sibling in recovery_group.siblings
+                    if sibling.current_attempt.status
+                    not in {
+                        RolloutAttemptStatus.SEALED,
+                        RolloutAttemptStatus.FINALIZED,
+                    }
+                ]
+            # Best-effort gate cleanup for attempts with no reusable receipt.
+            # Sealed siblings must remain intact for partial-group recovery.
             nemo_gym_env = self._env_handles.get("nemo_gym")
-            if nemo_gym_env is not None:
+            if nemo_gym_env is not None and gate_ids_to_fail:
                 try:
                     await nemo_gym_env.fail_rollouts.remote(
-                        gate_rollout_ids, reason="dispatch_failed"
+                        gate_ids_to_fail, reason="dispatch_failed"
                     )
                 except Exception as error:  # noqa: BLE001 — TTL is the backstop
                     print(f"fail_rollouts({group_id}) failed: {error}", flush=True)

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -15,7 +15,6 @@
 import asyncio
 import copy
 import json
-import uuid
 from typing import Any, Optional
 
 import torch
@@ -28,6 +27,7 @@ from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.experience.interfaces import Completion, PromptGroupRecord
 from nemo_rl.experience.metric_utils import calculate_single_metric, pct
+from nemo_rl.experience.rollout_recovery import RolloutRecoveryLedger
 from nemo_rl.experience.rollouts import _tensorize_by_key, calculate_rewards
 from nemo_rl.models.generation.interfaces import (
     GenerationConfig,
@@ -721,6 +721,7 @@ class RolloutManager:
         use_nemo_gym: bool = False,
         tq_buffer: Optional[TQReplayBuffer] = None,
         finalizer: Optional[Any] = None,
+        recovery_ledger: Optional[RolloutRecoveryLedger] = None,
     ) -> None:
         assert num_generations_per_prompt >= 1, (
             "num_generations_per_prompt must be >= 1"
@@ -728,6 +729,10 @@ class RolloutManager:
         if finalizer is not None:
             assert use_nemo_gym, (
                 "token capture (finalizer) is only supported on the NeMo-Gym path"
+            )
+        if recovery_ledger is not None and finalizer is None:
+            raise ValueError(
+                "rollout recovery ledger is only supported with token capture"
             )
 
         if not use_nemo_gym:
@@ -754,10 +759,22 @@ class RolloutManager:
         self._num_generations_per_prompt = num_generations_per_prompt
         self._tq_buffer = tq_buffer
         self._finalizer = finalizer
+        self._recovery_ledger = (
+            recovery_ledger
+            if recovery_ledger is not None
+            else RolloutRecoveryLedger()
+            if finalizer is not None
+            else None
+        )
         # The NeMo-Gym env handle doubles as the gate control-plane proxy
         # (gate_metrics / fail_rollouts) on the capture path.
         self._env_handles = task_to_env
         self._weight_version: int = 0
+
+    @property
+    def recovery_ledger(self) -> Optional[RolloutRecoveryLedger]:
+        """Return the controller-local token-capture recovery ledger."""
+        return self._recovery_ledger
 
     def set_weight_version(self, version: int) -> None:
         """Set the weight_version used for rollout tags.
@@ -827,34 +844,42 @@ class RolloutManager:
     ) -> None:
         """Token-capture dispatch: receipts in, canonical rows via the finalizer.
 
-        Mints the group's rollout ids up front — sample ids and gate-registered
-        rollout ids are the same strings (``{group_id}_g{i}``) — reserves the
-        slot with them so cleanup can name what it owns before a receipt
-        exists, and commits via ``commit_finalized`` with the group's
-        min/max call weight versions.
+        The recovery ledger mints stable canonical sibling IDs plus a distinct
+        physical gate ID for each execution attempt. The buffer records the
+        physical IDs so cleanup can name what it owns before a receipt exists;
+        the finalizer maps those attempts back to stable canonical rows.
         """
+        assert self._recovery_ledger is not None
         start_version = self._weight_version
-        group_id = str(uuid.uuid4())
-        rollout_ids = [
-            f"{group_id}_g{i}" for i in range(self._num_generations_per_prompt)
-        ]
-        self._tq_buffer.reserve(
-            weight_version=start_version,
+        recovery_group = self._recovery_ledger.reserve_group(
+            prompt_id=str(input_sample["idx"]),
+            prompt_payload=input_sample,
+            expected_generations=self._num_generations_per_prompt,
             target_step=target_step,
-            group_id=group_id,
-            rollout_ids=rollout_ids,
+            start_weight_version=start_version,
         )
+        group_id = recovery_group.group_id
+        logical_rollout_ids = recovery_group.logical_rollout_ids
+        gate_rollout_ids = recovery_group.gate_rollout_ids
         try:
-            record = await self.run_rollout(input_sample, rollout_ids=rollout_ids)
+            self._tq_buffer.reserve(
+                weight_version=start_version,
+                target_step=target_step,
+                group_id=group_id,
+                rollout_ids=gate_rollout_ids,
+            )
+            self._recovery_ledger.mark_group_dispatched(group_id)
+            record = await self.run_rollout(input_sample, rollout_ids=gate_rollout_ids)
             receipts = [c.env_extras.get("ng_receipt") for c in record.completions]
             rewards = [float(c.reward) for c in record.completions]
             finalized = await asyncio.to_thread(
                 self._finalizer.finalize_group,
                 group_id,
-                rollout_ids,
+                gate_rollout_ids,
                 receipts,
                 rewards,
                 fallback_weight_version=start_version,
+                canonical_sample_ids=logical_rollout_ids,
             )
             record.rollout_metrics.update(finalized.metrics)
             if finalized.dropped:
@@ -879,13 +904,20 @@ class RolloutManager:
             )
         except BaseException:
             self._tq_buffer.abort(group_id)
+            self._recovery_ledger.abandon_group(group_id)
             # Best-effort gate cleanup: no receipt will ever seal these ids.
             nemo_gym_env = self._env_handles.get("nemo_gym")
             if nemo_gym_env is not None:
                 try:
                     await nemo_gym_env.fail_rollouts.remote(
-                        rollout_ids, reason="dispatch_failed"
+                        gate_rollout_ids, reason="dispatch_failed"
                     )
                 except Exception as error:  # noqa: BLE001 — TTL is the backstop
                     print(f"fail_rollouts({group_id}) failed: {error}", flush=True)
             raise
+        else:
+            # Completed groups are recovered through canonical TQ rows plus
+            # replay metadata. Retaining their prompt payload here would grow
+            # controller memory without improving recovery.
+            self._recovery_ledger.mark_group_finalized(group_id)
+            self._recovery_ledger.release_finalized_group(group_id)

--- a/nemo_rl/experience/rollout_recovery.py
+++ b/nemo_rl/experience/rollout_recovery.py
@@ -733,12 +733,13 @@ class RolloutRecoveryLedger:
                 f"recovery group {group_id!r} must contain "
                 f"{expected_generations} siblings"
             )
+        raw_status = raw_group.get("status")
+        if not isinstance(raw_status, str):
+            raise ValueError(f"invalid prompt group status={raw_status!r}")
         try:
-            status = PromptGroupStatus(raw_group.get("status"))
+            status = PromptGroupStatus(raw_status)
         except ValueError as error:
-            raise ValueError(
-                f"invalid prompt group status={raw_group.get('status')!r}"
-            ) from error
+            raise ValueError(f"invalid prompt group status={raw_status!r}") from error
 
         siblings: list[RolloutSiblingRecord] = []
         for generation_index, sibling_state in enumerate(siblings_state):
@@ -765,10 +766,17 @@ class RolloutRecoveryLedger:
                     raise ValueError("duplicate rollout attempt identity")
                 seen_attempt_uuids.add(attempt_uuid)
                 gate_id = f"{logical_id}_a{attempt_uuid.hex}"
+                raw_attempt_status = attempt_state.get("status")
+                if not isinstance(raw_attempt_status, str):
+                    raise ValueError(
+                        f"invalid rollout attempt status={raw_attempt_status!r}"
+                    )
                 try:
-                    attempt_status = RolloutAttemptStatus(attempt_state.get("status"))
+                    attempt_status = RolloutAttemptStatus(raw_attempt_status)
                 except ValueError as error:
-                    raise ValueError("invalid rollout attempt status") from error
+                    raise ValueError(
+                        f"invalid rollout attempt status={raw_attempt_status!r}"
+                    ) from error
                 receipt = attempt_state.get("receipt")
                 reward = attempt_state.get("reward")
                 staging_keys = attempt_state.get("staging_keys")

--- a/nemo_rl/experience/rollout_recovery.py
+++ b/nemo_rl/experience/rollout_recovery.py
@@ -1,0 +1,955 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Controller-owned lineage for recoverable token-capture prompt groups.
+
+The ledger deliberately contains control-plane metadata only. Token tensors and
+router-replay payloads remain in TQ. Persistence is added by a later change; the
+versioned ``state_dict`` boundary lives here so that change does not have to
+invent a second lifecycle model.
+"""
+
+from __future__ import annotations
+
+import copy
+import uuid
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any, Optional, Self, cast
+
+from nemo_rl.data_plane import KVBatchMeta
+
+if TYPE_CHECKING:
+    from nemo_rl.data.interfaces import DatumSpec
+
+ROLLOUT_RECOVERY_SCHEMA_VERSION = 1
+
+
+class RolloutAttemptStatus(StrEnum):
+    """Lifecycle of one physical Gate execution attempt."""
+
+    RESERVED = "reserved"
+    DISPATCHED = "dispatched"
+    SEALED = "sealed"
+    FAILED = "failed"
+    ABANDONED = "abandoned"
+
+
+class PromptGroupStatus(StrEnum):
+    """Ownership lifecycle of one logical prompt group."""
+
+    GENERATING = "generating"
+    READY_TO_FINALIZE = "ready_to_finalize"
+    FINALIZING = "finalizing"
+    FINALIZATION_UNKNOWN = "finalization_unknown"
+    FINALIZED = "finalized"
+    CLAIMED_FOR_TRAINING = "claimed_for_training"
+    APPLIED_UNCHECKPOINTED = "applied_uncheckpointed"
+
+
+class TrainStepStatus(StrEnum):
+    """State of the one optimizer step the SingleController may have open."""
+
+    OPEN = "open"
+    APPLIED_UNCHECKPOINTED = "applied_uncheckpointed"
+
+
+@dataclass
+class RolloutAttemptRecord:
+    """One physical attempt for a stable logical sibling."""
+
+    attempt_id: str
+    gate_rollout_id: str
+    status: RolloutAttemptStatus
+    receipt: Optional[dict[str, Any]] = None
+    reward: Optional[float] = None
+    staging_keys: list[str] = field(default_factory=list)
+
+
+@dataclass
+class RolloutSiblingRecord:
+    """One stable GRPO generation slot and its physical attempts."""
+
+    generation_index: int
+    logical_rollout_id: str
+    attempts: list[RolloutAttemptRecord]
+
+    @property
+    def current_attempt(self) -> RolloutAttemptRecord:
+        if not self.attempts:
+            raise RuntimeError(
+                f"logical rollout {self.logical_rollout_id!r} has no attempts"
+            )
+        return self.attempts[-1]
+
+
+@dataclass
+class PromptGroupRecoveryRecord:
+    """Lineage and ownership for one logical prompt group."""
+
+    group_id: str
+    prompt_id: str
+    prompt_payload: Optional[DatumSpec]
+    expected_generations: int
+    target_step: Optional[int]
+    start_weight_version: int
+    siblings: list[RolloutSiblingRecord]
+    status: PromptGroupStatus = PromptGroupStatus.GENERATING
+    canonical_meta: Optional[KVBatchMeta] = None
+    group_min_weight_version: Optional[int] = None
+    group_max_weight_version: Optional[int] = None
+    claimed_train_step: Optional[int] = None
+
+    @property
+    def logical_rollout_ids(self) -> list[str]:
+        return [sibling.logical_rollout_id for sibling in self.siblings]
+
+    @property
+    def gate_rollout_ids(self) -> list[str]:
+        return [sibling.current_attempt.gate_rollout_id for sibling in self.siblings]
+
+    @property
+    def sealed_generation_indices(self) -> list[int]:
+        return [
+            sibling.generation_index
+            for sibling in self.siblings
+            if sibling.current_attempt.status == RolloutAttemptStatus.SEALED
+        ]
+
+
+@dataclass
+class OpenTrainStepRecord:
+    """Groups contributing to the current, not-yet-durable optimizer step."""
+
+    train_step: int
+    trainer_version: int
+    expected_group_count: int
+    group_ids: list[str] = field(default_factory=list)
+    status: TrainStepStatus = TrainStepStatus.OPEN
+
+
+def _new_attempt(logical_rollout_id: str) -> RolloutAttemptRecord:
+    attempt_id = str(uuid.uuid4())
+    return RolloutAttemptRecord(
+        attempt_id=attempt_id,
+        gate_rollout_id=f"{logical_rollout_id}_a{attempt_id}",
+        status=RolloutAttemptStatus.RESERVED,
+    )
+
+
+def _receipt_staging_keys(receipt: dict[str, Any]) -> list[str]:
+    """Validate a sealed Gate receipt and return its ordered staging keys."""
+    manifest = receipt.get("manifest")
+    if not isinstance(manifest, list):
+        raise ValueError("sealed rollout receipt must contain a manifest list")
+    staging_keys: list[str] = []
+    for entry in manifest:
+        if not isinstance(entry, dict) or not isinstance(entry.get("staging_key"), str):
+            raise ValueError(
+                "sealed rollout receipt manifest entries must contain string "
+                "staging_key values"
+            )
+        staging_keys.append(entry["staging_key"])
+    return staging_keys
+
+
+class RolloutRecoveryLedger:
+    """In-memory source of truth for token-capture rollout ownership."""
+
+    def __init__(self) -> None:
+        self._groups: dict[str, PromptGroupRecoveryRecord] = {}
+        self._open_train_step: Optional[OpenTrainStepRecord] = None
+
+    @property
+    def open_train_step(self) -> Optional[OpenTrainStepRecord]:
+        return copy.deepcopy(self._open_train_step)
+
+    def groups(self) -> list[PromptGroupRecoveryRecord]:
+        return [self._copy_group(group) for group in self._groups.values()]
+
+    def reserve_group(
+        self,
+        *,
+        prompt_id: str,
+        prompt_payload: DatumSpec,
+        expected_generations: int,
+        target_step: Optional[int],
+        start_weight_version: int,
+        group_id: Optional[str] = None,
+    ) -> PromptGroupRecoveryRecord:
+        """Create one logical group and its first physical sibling attempts."""
+        if not prompt_id:
+            raise ValueError("prompt_id must not be empty")
+        if expected_generations < 1:
+            raise ValueError("expected_generations must be at least one")
+        group_id = group_id or str(uuid.uuid4())
+        if group_id in self._groups:
+            raise ValueError(f"duplicate recovery group_id={group_id!r}")
+
+        siblings = []
+        for generation_index in range(expected_generations):
+            logical_rollout_id = f"{group_id}_g{generation_index}"
+            siblings.append(
+                RolloutSiblingRecord(
+                    generation_index=generation_index,
+                    logical_rollout_id=logical_rollout_id,
+                    attempts=[_new_attempt(logical_rollout_id)],
+                )
+            )
+        record = PromptGroupRecoveryRecord(
+            group_id=group_id,
+            prompt_id=prompt_id,
+            # Retain the immutable dataloader sample by reference instead of copying
+            # a potentially 131k-token payload. It is released as soon as canonical
+            # rows take over recovery ownership.
+            prompt_payload=prompt_payload,
+            expected_generations=expected_generations,
+            target_step=target_step,
+            start_weight_version=start_weight_version,
+            siblings=siblings,
+        )
+        self._groups[group_id] = record
+        return self._copy_group(record)
+
+    def prepare_incomplete_retry(self, group_id: str) -> PromptGroupRecoveryRecord:
+        """Mint fresh physical attempts only for siblings that are not sealed."""
+        record = self._require_group(group_id)
+        if record.status != PromptGroupStatus.GENERATING:
+            raise ValueError(
+                f"cannot retry group {group_id!r} from status {record.status.value!r}"
+            )
+        for sibling in record.siblings:
+            attempt = sibling.current_attempt
+            if attempt.status == RolloutAttemptStatus.SEALED:
+                continue
+            if attempt.status == RolloutAttemptStatus.RESERVED:
+                continue
+            if attempt.status not in {
+                RolloutAttemptStatus.ABANDONED,
+                RolloutAttemptStatus.FAILED,
+            }:
+                raise ValueError(
+                    f"cannot retry logical rollout {sibling.logical_rollout_id!r} "
+                    f"from status {attempt.status.value!r}"
+                )
+            sibling.attempts.append(_new_attempt(sibling.logical_rollout_id))
+        return self._copy_group(record)
+
+    def mark_group_dispatched(
+        self, group_id: str, *, generation_indices: Optional[list[int]] = None
+    ) -> None:
+        """Move the selected current sibling attempts to dispatched."""
+        record = self._require_group(group_id)
+        if record.status != PromptGroupStatus.GENERATING:
+            raise ValueError(
+                f"cannot dispatch group {group_id!r} from {record.status.value!r}"
+            )
+        indices = (
+            generation_indices
+            if generation_indices is not None
+            else list(range(record.expected_generations))
+        )
+        attempts = [
+            self._require_sibling(record, index).current_attempt for index in indices
+        ]
+        if any(attempt.status != RolloutAttemptStatus.RESERVED for attempt in attempts):
+            raise ValueError("only reserved rollout attempts may be dispatched")
+        for attempt in attempts:
+            attempt.status = RolloutAttemptStatus.DISPATCHED
+
+    def mark_sibling_sealed(
+        self,
+        group_id: str,
+        *,
+        generation_index: int,
+        gate_rollout_id: str,
+        receipt: dict[str, Any],
+        reward: float,
+    ) -> None:
+        """Record one streamed sibling receipt as soon as the row arrives."""
+        record = self._require_group(group_id)
+        sibling = self._require_sibling(record, generation_index)
+        attempt = sibling.current_attempt
+        staging_keys = _receipt_staging_keys(receipt)
+        if gate_rollout_id != attempt.gate_rollout_id:
+            raise ValueError(
+                "streamed rollout identity mismatch: "
+                f"result={gate_rollout_id!r}, expected={attempt.gate_rollout_id!r}"
+            )
+        if receipt.get("rollout_id") != gate_rollout_id:
+            raise ValueError(
+                "receipt rollout identity mismatch: "
+                f"receipt={receipt.get('rollout_id')!r}, expected={gate_rollout_id!r}"
+            )
+        if attempt.status == RolloutAttemptStatus.SEALED:
+            if (
+                attempt.receipt == receipt
+                and attempt.reward == float(reward)
+                and attempt.staging_keys == staging_keys
+            ):
+                return
+            raise ValueError(
+                f"conflicting duplicate seal for {sibling.logical_rollout_id!r}"
+            )
+        if attempt.status != RolloutAttemptStatus.DISPATCHED:
+            raise ValueError(
+                f"cannot seal logical rollout {sibling.logical_rollout_id!r} "
+                f"from status {attempt.status.value!r}"
+            )
+
+        attempt.receipt = copy.deepcopy(receipt)
+        attempt.reward = float(reward)
+        attempt.staging_keys = staging_keys
+        attempt.status = RolloutAttemptStatus.SEALED
+        if all(
+            item.current_attempt.status == RolloutAttemptStatus.SEALED
+            for item in record.siblings
+        ):
+            record.status = PromptGroupStatus.READY_TO_FINALIZE
+
+    def abandon_unsealed(self, group_id: str) -> None:
+        """Abandon failed attempts without destroying reusable sealed receipts."""
+        record = self._require_group(group_id)
+        if record.status not in {
+            PromptGroupStatus.GENERATING,
+            PromptGroupStatus.READY_TO_FINALIZE,
+        }:
+            raise ValueError(
+                f"cannot abandon group {group_id!r} from {record.status.value!r}"
+            )
+        for sibling in record.siblings:
+            attempt = sibling.current_attempt
+            if attempt.status == RolloutAttemptStatus.SEALED:
+                continue
+            attempt.status = RolloutAttemptStatus.ABANDONED
+        record.status = (
+            PromptGroupStatus.READY_TO_FINALIZE
+            if all(
+                sibling.current_attempt.status == RolloutAttemptStatus.SEALED
+                for sibling in record.siblings
+            )
+            else PromptGroupStatus.GENERATING
+        )
+
+    def finalization_inputs(
+        self, group_id: str
+    ) -> tuple[list[str], list[str], list[dict[str, Any]], list[float]]:
+        """Return physical IDs, canonical IDs, receipts and rewards in sibling order."""
+        record = self._require_group(group_id)
+        if record.status != PromptGroupStatus.READY_TO_FINALIZE:
+            raise ValueError(
+                f"group {group_id!r} is not ready to finalize: {record.status.value!r}"
+            )
+        receipts: list[dict[str, Any]] = []
+        rewards: list[float] = []
+        for sibling in record.siblings:
+            attempt = sibling.current_attempt
+            if (
+                attempt.status != RolloutAttemptStatus.SEALED
+                or attempt.receipt is None
+                or attempt.reward is None
+            ):
+                raise ValueError(
+                    f"logical rollout {sibling.logical_rollout_id!r} is not sealed"
+                )
+            receipts.append(copy.deepcopy(attempt.receipt))
+            rewards.append(attempt.reward)
+        return (
+            record.gate_rollout_ids,
+            record.logical_rollout_ids,
+            receipts,
+            rewards,
+        )
+
+    def mark_finalization_started(self, group_id: str) -> None:
+        record = self._require_group(group_id)
+        self._require_group_status(
+            record,
+            allowed={PromptGroupStatus.READY_TO_FINALIZE},
+            transition="start finalization",
+        )
+        record.status = PromptGroupStatus.FINALIZING
+
+    def mark_finalization_unknown(self, group_id: str) -> None:
+        record = self._require_group(group_id)
+        self._require_group_status(
+            record,
+            allowed={PromptGroupStatus.FINALIZING},
+            transition="mark finalization unknown",
+        )
+        record.status = PromptGroupStatus.FINALIZATION_UNKNOWN
+
+    def mark_group_finalized(
+        self,
+        group_id: str,
+        *,
+        meta: KVBatchMeta,
+        group_min_weight_version: int,
+        group_max_weight_version: int,
+    ) -> None:
+        """Transfer recovery ownership from staged receipts to canonical TQ rows."""
+        record = self._require_group(group_id)
+        self._require_group_status(
+            record,
+            allowed={PromptGroupStatus.FINALIZING},
+            transition="finalize",
+        )
+        if list(meta.sample_ids) != record.logical_rollout_ids:
+            raise ValueError(
+                "finalized sample IDs do not match stable logical rollout IDs: "
+                f"{meta.sample_ids!r} != {record.logical_rollout_ids!r}"
+            )
+        record.canonical_meta = copy.deepcopy(meta)
+        record.group_min_weight_version = int(group_min_weight_version)
+        record.group_max_weight_version = int(group_max_weight_version)
+        record.prompt_payload = None
+        record.status = PromptGroupStatus.FINALIZED
+
+    def adopt_finalized_group(
+        self,
+        *,
+        group_id: str,
+        meta: KVBatchMeta,
+        start_weight_version: int,
+        end_weight_version: int,
+        target_step: Optional[int] = None,
+    ) -> None:
+        """Adopt a canonical-only group restored by the existing TQ checkpoint.
+
+        Older completed-rollout checkpoints have canonical rows and replay metadata
+        but no partial lineage sidecar. They remain trainable during the transition
+        to persisted lineage; synthetic abandoned attempts represent the fact that
+        their physical Gate history is no longer needed.
+        """
+        if group_id in self._groups:
+            raise ValueError(f"duplicate recovery group_id={group_id!r}")
+        expected_ids = [f"{group_id}_g{i}" for i in range(len(meta.sample_ids))]
+        if list(meta.sample_ids) != expected_ids:
+            raise ValueError(
+                "restored canonical sample IDs do not form one logical group: "
+                f"{meta.sample_ids!r}"
+            )
+        siblings = []
+        for generation_index, logical_id in enumerate(expected_ids):
+            attempt = _new_attempt(logical_id)
+            attempt.status = RolloutAttemptStatus.ABANDONED
+            siblings.append(
+                RolloutSiblingRecord(
+                    generation_index=generation_index,
+                    logical_rollout_id=logical_id,
+                    attempts=[attempt],
+                )
+            )
+        self._groups[group_id] = PromptGroupRecoveryRecord(
+            group_id=group_id,
+            prompt_id=group_id,
+            prompt_payload=None,
+            expected_generations=len(expected_ids),
+            target_step=target_step,
+            start_weight_version=int(start_weight_version),
+            siblings=siblings,
+            status=PromptGroupStatus.FINALIZED,
+            canonical_meta=copy.deepcopy(meta),
+            group_min_weight_version=int(start_weight_version),
+            group_max_weight_version=int(end_weight_version),
+        )
+
+    def claim_groups_for_training(
+        self,
+        group_ids: list[str],
+        *,
+        train_step: int,
+        trainer_version: int,
+        expected_group_count: int,
+    ) -> None:
+        """Move finalized groups into the controller's one open optimizer step."""
+        if not group_ids:
+            raise ValueError("training claim must contain at least one group")
+        if len(group_ids) != len(set(group_ids)):
+            raise ValueError("training claim contains duplicate group IDs")
+        if self._open_train_step is None:
+            self._open_train_step = OpenTrainStepRecord(
+                train_step=train_step,
+                trainer_version=trainer_version,
+                expected_group_count=expected_group_count,
+            )
+        open_step = self._open_train_step
+        if (
+            open_step.train_step != train_step
+            or open_step.trainer_version != trainer_version
+            or open_step.expected_group_count != expected_group_count
+            or open_step.status != TrainStepStatus.OPEN
+        ):
+            raise ValueError(
+                "training claim does not match the existing open train step"
+            )
+        records = [self._require_group(group_id) for group_id in group_ids]
+        for record in records:
+            if record.status != PromptGroupStatus.FINALIZED:
+                raise ValueError(
+                    f"cannot claim group {record.group_id!r} from "
+                    f"{record.status.value!r}"
+                )
+        if len(open_step.group_ids) + len(group_ids) > expected_group_count:
+            raise ValueError("training claim exceeds the step's expected group count")
+        for record in records:
+            record.status = PromptGroupStatus.CLAIMED_FOR_TRAINING
+            record.claimed_train_step = train_step
+            open_step.group_ids.append(record.group_id)
+
+    def mark_train_step_applied(self, train_step: int) -> None:
+        """Record optimizer success while rows are still not checkpoint-covered."""
+        open_step = self._require_open_train_step(train_step)
+        if open_step.status != TrainStepStatus.OPEN:
+            raise ValueError(
+                f"train step {train_step} is already {open_step.status.value!r}"
+            )
+        if len(open_step.group_ids) != open_step.expected_group_count:
+            raise ValueError(
+                f"train step {train_step} has {len(open_step.group_ids)} claimed "
+                f"groups; expected {open_step.expected_group_count}"
+            )
+        for group_id in open_step.group_ids:
+            record = self._require_group(group_id)
+            if record.status != PromptGroupStatus.CLAIMED_FOR_TRAINING:
+                raise ValueError(
+                    f"train step {train_step} owns group {group_id!r} in state "
+                    f"{record.status.value!r}"
+                )
+        for group_id in open_step.group_ids:
+            self._groups[group_id].status = PromptGroupStatus.APPLIED_UNCHECKPOINTED
+        open_step.status = TrainStepStatus.APPLIED_UNCHECKPOINTED
+
+    def release_applied_train_step(self, train_step: int) -> None:
+        """Drop group metadata after the caller has cleared all owned TQ rows.
+
+        The current controller clears immediately after optimizer success. A later
+        persistence change will delay this call until a trainer checkpoint covers
+        the applied update.
+        """
+        open_step = self._require_open_train_step(train_step)
+        if open_step.status != TrainStepStatus.APPLIED_UNCHECKPOINTED:
+            raise ValueError(
+                f"cannot release train step {train_step} from "
+                f"{open_step.status.value!r}"
+            )
+        for group_id in open_step.group_ids:
+            del self._groups[group_id]
+        self._open_train_step = None
+
+    def rollback_open_train_step(self, train_step: int) -> None:
+        """Return an uncheckpointed step's groups to finalized ownership."""
+        open_step = self._require_open_train_step(train_step)
+        for group_id in open_step.group_ids:
+            record = self._require_group(group_id)
+            if record.status not in {
+                PromptGroupStatus.CLAIMED_FOR_TRAINING,
+                PromptGroupStatus.APPLIED_UNCHECKPOINTED,
+            }:
+                raise ValueError(
+                    f"cannot roll back group {group_id!r} from {record.status.value!r}"
+                )
+            record.status = PromptGroupStatus.FINALIZED
+            record.claimed_train_step = None
+        self._open_train_step = None
+
+    def discard_group(self, group_id: str) -> None:
+        """Drop a group only after its external TQ/Gate ownership is cleaned."""
+        record = self._require_group(group_id)
+        if record.claimed_train_step is not None:
+            raise ValueError(f"cannot discard training-owned group {group_id!r}")
+        del self._groups[group_id]
+
+    def get_group(self, group_id: str) -> PromptGroupRecoveryRecord:
+        return self._copy_group(self._require_group(group_id))
+
+    def __len__(self) -> int:
+        return len(self._groups)
+
+    def __contains__(self, group_id: object) -> bool:
+        return isinstance(group_id, str) and group_id in self._groups
+
+    def state_dict(self) -> dict[str, Any]:
+        """Return the versioned metadata envelope used by later persistence."""
+        groups = []
+        for record in self._groups.values():
+            groups.append(
+                {
+                    "group_id": record.group_id,
+                    "prompt_id": record.prompt_id,
+                    "prompt_payload": copy.deepcopy(record.prompt_payload),
+                    "expected_generations": record.expected_generations,
+                    "target_step": record.target_step,
+                    "start_weight_version": record.start_weight_version,
+                    "status": record.status.value,
+                    "canonical_meta": copy.deepcopy(record.canonical_meta),
+                    "group_min_weight_version": record.group_min_weight_version,
+                    "group_max_weight_version": record.group_max_weight_version,
+                    "claimed_train_step": record.claimed_train_step,
+                    "siblings": [
+                        {
+                            "generation_index": sibling.generation_index,
+                            "logical_rollout_id": sibling.logical_rollout_id,
+                            "attempts": [
+                                {
+                                    "attempt_id": attempt.attempt_id,
+                                    "gate_rollout_id": attempt.gate_rollout_id,
+                                    "status": attempt.status.value,
+                                    "receipt": copy.deepcopy(attempt.receipt),
+                                    "reward": attempt.reward,
+                                    "staging_keys": list(attempt.staging_keys),
+                                }
+                                for attempt in sibling.attempts
+                            ],
+                        }
+                        for sibling in record.siblings
+                    ],
+                }
+            )
+        open_step = self._open_train_step
+        return {
+            "schema_version": ROLLOUT_RECOVERY_SCHEMA_VERSION,
+            "groups": groups,
+            "open_train_step": (
+                None
+                if open_step is None
+                else {
+                    "train_step": open_step.train_step,
+                    "trainer_version": open_step.trainer_version,
+                    "expected_group_count": open_step.expected_group_count,
+                    "group_ids": list(open_step.group_ids),
+                    "status": open_step.status.value,
+                }
+            ),
+        }
+
+    @classmethod
+    def from_state_dict(cls, state: dict[str, Any]) -> Self:
+        """Restore and validate a ledger metadata envelope."""
+        if state.get("schema_version") != ROLLOUT_RECOVERY_SCHEMA_VERSION:
+            raise ValueError(
+                "Unsupported rollout-recovery schema version: "
+                f"{state.get('schema_version')!r}"
+            )
+        raw_groups = state.get("groups")
+        if not isinstance(raw_groups, list):
+            raise ValueError("rollout-recovery state must contain a groups list")
+
+        ledger = cls()
+        seen_logical_ids: set[str] = set()
+        seen_attempt_ids: set[str] = set()
+        seen_gate_ids: set[str] = set()
+        for raw_group in raw_groups:
+            record = cls._group_from_state(
+                raw_group,
+                seen_logical_ids=seen_logical_ids,
+                seen_attempt_ids=seen_attempt_ids,
+                seen_gate_ids=seen_gate_ids,
+            )
+            if record.group_id in ledger._groups:
+                raise ValueError(f"duplicate recovery group_id={record.group_id!r}")
+            ledger._groups[record.group_id] = record
+
+        raw_open_step = state.get("open_train_step")
+        if raw_open_step is not None:
+            if not isinstance(raw_open_step, dict):
+                raise ValueError("open_train_step must be a mapping or None")
+            try:
+                open_step = OpenTrainStepRecord(
+                    train_step=int(raw_open_step["train_step"]),
+                    trainer_version=int(raw_open_step["trainer_version"]),
+                    expected_group_count=int(raw_open_step["expected_group_count"]),
+                    group_ids=list(raw_open_step["group_ids"]),
+                    status=TrainStepStatus(raw_open_step["status"]),
+                )
+            except (KeyError, TypeError, ValueError) as error:
+                raise ValueError("invalid open_train_step state") from error
+            if not all(isinstance(group_id, str) for group_id in open_step.group_ids):
+                raise ValueError("open_train_step group_ids must be strings")
+            if len(open_step.group_ids) != len(set(open_step.group_ids)):
+                raise ValueError("open_train_step contains duplicate group IDs")
+            if len(open_step.group_ids) > open_step.expected_group_count:
+                raise ValueError("open_train_step exceeds expected_group_count")
+            expected_group_status = (
+                PromptGroupStatus.CLAIMED_FOR_TRAINING
+                if open_step.status == TrainStepStatus.OPEN
+                else PromptGroupStatus.APPLIED_UNCHECKPOINTED
+            )
+            for group_id in open_step.group_ids:
+                record = ledger._require_group(group_id)
+                if (
+                    record.claimed_train_step != open_step.train_step
+                    or record.status != expected_group_status
+                ):
+                    raise ValueError(
+                        f"open_train_step ownership mismatch for group {group_id!r}"
+                    )
+            claimed_group_ids = {
+                record.group_id
+                for record in ledger._groups.values()
+                if record.claimed_train_step is not None
+            }
+            if claimed_group_ids != set(open_step.group_ids):
+                raise ValueError(
+                    "open_train_step does not list every training-owned group"
+                )
+            ledger._open_train_step = open_step
+        elif any(
+            record.claimed_train_step is not None for record in ledger._groups.values()
+        ):
+            raise ValueError("claimed groups require an open_train_step record")
+        return ledger
+
+    @classmethod
+    def _group_from_state(
+        cls,
+        raw_group: Any,
+        *,
+        seen_logical_ids: set[str],
+        seen_attempt_ids: set[str],
+        seen_gate_ids: set[str],
+    ) -> PromptGroupRecoveryRecord:
+        if not isinstance(raw_group, dict):
+            raise ValueError("rollout-recovery group must be a mapping")
+        group_id = raw_group.get("group_id")
+        prompt_id = raw_group.get("prompt_id")
+        expected_generations = raw_group.get("expected_generations")
+        siblings_state = raw_group.get("siblings")
+        if not isinstance(group_id, str) or not group_id:
+            raise ValueError("group_id must be a non-empty string")
+        if not isinstance(prompt_id, str) or not prompt_id:
+            raise ValueError("prompt_id must be a non-empty string")
+        if not isinstance(expected_generations, int) or expected_generations < 1:
+            raise ValueError("expected_generations must be a positive integer")
+        if (
+            not isinstance(siblings_state, list)
+            or len(siblings_state) != expected_generations
+        ):
+            raise ValueError(
+                f"recovery group {group_id!r} must contain "
+                f"{expected_generations} siblings"
+            )
+        try:
+            status = PromptGroupStatus(raw_group.get("status"))
+        except ValueError as error:
+            raise ValueError(
+                f"invalid prompt group status={raw_group.get('status')!r}"
+            ) from error
+
+        siblings: list[RolloutSiblingRecord] = []
+        for generation_index, sibling_state in enumerate(siblings_state):
+            if not isinstance(sibling_state, dict):
+                raise ValueError("rollout-recovery sibling must be a mapping")
+            if sibling_state.get("generation_index") != generation_index:
+                raise ValueError("generation indices must be contiguous")
+            logical_id = sibling_state.get("logical_rollout_id")
+            expected_logical_id = f"{group_id}_g{generation_index}"
+            if (
+                not isinstance(logical_id, str)
+                or logical_id != expected_logical_id
+                or logical_id in seen_logical_ids
+            ):
+                raise ValueError(
+                    f"logical rollout ID mismatch or duplicate: {logical_id!r}"
+                )
+            seen_logical_ids.add(logical_id)
+            attempts_state = sibling_state.get("attempts")
+            if not isinstance(attempts_state, list) or not attempts_state:
+                raise ValueError(f"logical rollout {logical_id!r} has no attempts")
+            attempts: list[RolloutAttemptRecord] = []
+            for attempt_state in attempts_state:
+                if not isinstance(attempt_state, dict):
+                    raise ValueError("rollout-recovery attempt must be a mapping")
+                attempt_id = attempt_state.get("attempt_id")
+                gate_id = attempt_state.get("gate_rollout_id")
+                if not isinstance(attempt_id, str) or not attempt_id:
+                    raise ValueError("attempt_id must be a non-empty string")
+                if not isinstance(gate_id, str) or gate_id != (
+                    f"{logical_id}_a{attempt_id}"
+                ):
+                    raise ValueError("gate rollout ID does not match attempt identity")
+                if attempt_id in seen_attempt_ids or gate_id in seen_gate_ids:
+                    raise ValueError("duplicate rollout attempt identity")
+                seen_attempt_ids.add(attempt_id)
+                seen_gate_ids.add(gate_id)
+                try:
+                    attempt_status = RolloutAttemptStatus(attempt_state.get("status"))
+                except ValueError as error:
+                    raise ValueError("invalid rollout attempt status") from error
+                receipt = attempt_state.get("receipt")
+                reward = attempt_state.get("reward")
+                staging_keys = attempt_state.get("staging_keys")
+                if not isinstance(staging_keys, list) or not all(
+                    isinstance(key, str) for key in staging_keys
+                ):
+                    raise ValueError("staging_keys must be a list of strings")
+                if attempt_status == RolloutAttemptStatus.SEALED:
+                    if not isinstance(receipt, dict) or not isinstance(
+                        reward, (int, float)
+                    ):
+                        raise ValueError("sealed attempts require receipt and reward")
+                    if receipt.get("rollout_id") != gate_id:
+                        raise ValueError("sealed receipt identity mismatch")
+                    if _receipt_staging_keys(receipt) != staging_keys:
+                        raise ValueError("sealed receipt staging manifest mismatch")
+                elif receipt is not None or reward is not None or staging_keys:
+                    raise ValueError("only sealed attempts may retain receipt data")
+                attempts.append(
+                    RolloutAttemptRecord(
+                        attempt_id=attempt_id,
+                        gate_rollout_id=gate_id,
+                        status=attempt_status,
+                        receipt=copy.deepcopy(receipt),
+                        reward=float(reward) if reward is not None else None,
+                        staging_keys=list(staging_keys),
+                    )
+                )
+            siblings.append(
+                RolloutSiblingRecord(
+                    generation_index=generation_index,
+                    logical_rollout_id=logical_id,
+                    attempts=attempts,
+                )
+            )
+
+        prompt_payload = raw_group.get("prompt_payload")
+        if prompt_payload is not None and not isinstance(prompt_payload, dict):
+            raise ValueError("prompt_payload must be a mapping or None")
+        canonical_meta = raw_group.get("canonical_meta")
+        if canonical_meta is not None and not isinstance(canonical_meta, KVBatchMeta):
+            raise ValueError("canonical_meta must be KVBatchMeta or None")
+        target_step = raw_group.get("target_step")
+        claimed_train_step = raw_group.get("claimed_train_step")
+        if target_step is not None and not isinstance(target_step, int):
+            raise ValueError("target_step must be an integer or None")
+        if claimed_train_step is not None and not isinstance(claimed_train_step, int):
+            raise ValueError("claimed_train_step must be an integer or None")
+        start_weight = raw_group.get("start_weight_version")
+        if not isinstance(start_weight, int):
+            raise ValueError("start_weight_version must be an integer")
+        min_weight = raw_group.get("group_min_weight_version")
+        max_weight = raw_group.get("group_max_weight_version")
+        if min_weight is not None and not isinstance(min_weight, int):
+            raise ValueError("group_min_weight_version must be an integer or None")
+        if max_weight is not None and not isinstance(max_weight, int):
+            raise ValueError("group_max_weight_version must be an integer or None")
+
+        finalized_states = {
+            PromptGroupStatus.FINALIZED,
+            PromptGroupStatus.CLAIMED_FOR_TRAINING,
+            PromptGroupStatus.APPLIED_UNCHECKPOINTED,
+        }
+        prefinalization_sealed_states = {
+            PromptGroupStatus.READY_TO_FINALIZE,
+            PromptGroupStatus.FINALIZING,
+            PromptGroupStatus.FINALIZATION_UNKNOWN,
+        }
+        all_current_attempts_sealed = all(
+            sibling.current_attempt.status == RolloutAttemptStatus.SEALED
+            for sibling in siblings
+        )
+        if status in prefinalization_sealed_states and not all_current_attempts_sealed:
+            raise ValueError(
+                f"group state {status.value!r} requires every sibling to be sealed"
+            )
+        if status in finalized_states:
+            if canonical_meta is None or min_weight is None or max_weight is None:
+                raise ValueError("finalized group state requires canonical metadata")
+            if list(canonical_meta.sample_ids) != [
+                s.logical_rollout_id for s in siblings
+            ]:
+                raise ValueError("canonical sample IDs do not match logical lineage")
+        elif canonical_meta is not None:
+            raise ValueError("unfinished group cannot contain canonical metadata")
+        claimed_states = {
+            PromptGroupStatus.CLAIMED_FOR_TRAINING,
+            PromptGroupStatus.APPLIED_UNCHECKPOINTED,
+        }
+        if (status in claimed_states) != (claimed_train_step is not None):
+            raise ValueError(
+                "claimed_train_step must be present exactly for training-owned groups"
+            )
+
+        return PromptGroupRecoveryRecord(
+            group_id=group_id,
+            prompt_id=prompt_id,
+            prompt_payload=(
+                copy.deepcopy(cast("DatumSpec", prompt_payload))
+                if prompt_payload is not None
+                else None
+            ),
+            expected_generations=expected_generations,
+            target_step=target_step,
+            start_weight_version=start_weight,
+            siblings=siblings,
+            status=status,
+            canonical_meta=copy.deepcopy(canonical_meta),
+            group_min_weight_version=min_weight,
+            group_max_weight_version=max_weight,
+            claimed_train_step=claimed_train_step,
+        )
+
+    def _require_group(self, group_id: str) -> PromptGroupRecoveryRecord:
+        try:
+            return self._groups[group_id]
+        except KeyError as error:
+            raise ValueError(f"unknown recovery group_id={group_id!r}") from error
+
+    @staticmethod
+    def _copy_group(record: PromptGroupRecoveryRecord) -> PromptGroupRecoveryRecord:
+        """Copy mutable lineage metadata without duplicating the prompt payload."""
+        return PromptGroupRecoveryRecord(
+            group_id=record.group_id,
+            prompt_id=record.prompt_id,
+            prompt_payload=record.prompt_payload,
+            expected_generations=record.expected_generations,
+            target_step=record.target_step,
+            start_weight_version=record.start_weight_version,
+            siblings=copy.deepcopy(record.siblings),
+            status=record.status,
+            canonical_meta=copy.deepcopy(record.canonical_meta),
+            group_min_weight_version=record.group_min_weight_version,
+            group_max_weight_version=record.group_max_weight_version,
+            claimed_train_step=record.claimed_train_step,
+        )
+
+    @staticmethod
+    def _require_sibling(
+        record: PromptGroupRecoveryRecord, generation_index: int
+    ) -> RolloutSiblingRecord:
+        if not 0 <= generation_index < len(record.siblings):
+            raise ValueError(
+                f"generation_index={generation_index} is outside group "
+                f"{record.group_id!r}"
+            )
+        return record.siblings[generation_index]
+
+    @staticmethod
+    def _require_group_status(
+        record: PromptGroupRecoveryRecord,
+        *,
+        allowed: set[PromptGroupStatus],
+        transition: str,
+    ) -> None:
+        if record.status not in allowed:
+            raise ValueError(
+                f"cannot {transition} group {record.group_id!r} from "
+                f"{record.status.value!r}"
+            )
+
+    def _require_open_train_step(self, train_step: int) -> OpenTrainStepRecord:
+        open_step = self._open_train_step
+        if open_step is None or open_step.train_step != train_step:
+            raise ValueError(f"train step {train_step} is not open")
+        return open_step

--- a/nemo_rl/experience/rollout_recovery.py
+++ b/nemo_rl/experience/rollout_recovery.py
@@ -26,14 +26,14 @@ import copy
 import uuid
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, Optional, Self, cast
+from typing import TYPE_CHECKING, Any, Optional, Self
 
 from nemo_rl.data_plane import KVBatchMeta
 
 if TYPE_CHECKING:
     from nemo_rl.data.interfaces import DatumSpec
 
-ROLLOUT_RECOVERY_SCHEMA_VERSION = 1
+ROLLOUT_RECOVERY_SCHEMA_VERSION = 2
 
 
 class RolloutAttemptStatus(StrEnum):
@@ -65,16 +65,37 @@ class TrainStepStatus(StrEnum):
     APPLIED_UNCHECKPOINTED = "applied_uncheckpointed"
 
 
+@dataclass(frozen=True)
+class PromptRef:
+    """Small durable locator for a prompt owned by the input dataset.
+
+    The persistence layer will resolve this reference and validate the dataset
+    identity before redispatch. The full ``DatumSpec`` is runtime-only state and
+    is deliberately excluded from the serialized ledger.
+    """
+
+    sample_id: str
+    task_name: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not self.sample_id:
+            raise ValueError("prompt sample_id must not be empty")
+
+
 @dataclass
 class RolloutAttemptRecord:
     """One physical attempt for a stable logical sibling."""
 
-    attempt_id: str
-    gate_rollout_id: str
+    attempt_uuid: uuid.UUID
     status: RolloutAttemptStatus
     receipt: Optional[dict[str, Any]] = None
     reward: Optional[float] = None
     staging_keys: list[str] = field(default_factory=list)
+
+    @property
+    def attempt_id(self) -> str:
+        """Return the compact external representation of this attempt UUID."""
+        return self.attempt_uuid.hex
 
 
 @dataclass
@@ -82,14 +103,13 @@ class RolloutSiblingRecord:
     """One stable GRPO generation slot and its physical attempts."""
 
     generation_index: int
-    logical_rollout_id: str
     attempts: list[RolloutAttemptRecord]
 
     @property
     def current_attempt(self) -> RolloutAttemptRecord:
         if not self.attempts:
             raise RuntimeError(
-                f"logical rollout {self.logical_rollout_id!r} has no attempts"
+                f"generation index {self.generation_index} has no attempts"
             )
         return self.attempts[-1]
 
@@ -100,7 +120,8 @@ class PromptGroupRecoveryRecord:
 
     group_id: str
     prompt_id: str
-    prompt_payload: Optional[DatumSpec]
+    prompt_ref: PromptRef
+    runtime_prompt_payload: Optional[DatumSpec]
     expected_generations: int
     target_step: Optional[int]
     start_weight_version: int
@@ -113,11 +134,28 @@ class PromptGroupRecoveryRecord:
 
     @property
     def logical_rollout_ids(self) -> list[str]:
-        return [sibling.logical_rollout_id for sibling in self.siblings]
+        return [
+            self.logical_rollout_id(sibling.generation_index)
+            for sibling in self.siblings
+        ]
 
     @property
     def gate_rollout_ids(self) -> list[str]:
-        return [sibling.current_attempt.gate_rollout_id for sibling in self.siblings]
+        return [
+            self.gate_rollout_id(sibling.generation_index) for sibling in self.siblings
+        ]
+
+    def logical_rollout_id(self, generation_index: int) -> str:
+        """Derive the stable sibling ID instead of storing another UUID string."""
+        return f"{self.group_id}_g{generation_index}"
+
+    def gate_rollout_id(self, generation_index: int) -> str:
+        """Derive the physical Gate ID from group, sibling, and attempt UUID."""
+        sibling = self.siblings[generation_index]
+        return (
+            f"{self.logical_rollout_id(generation_index)}"
+            f"_a{sibling.current_attempt.attempt_id}"
+        )
 
     @property
     def sealed_generation_indices(self) -> list[int]:
@@ -139,11 +177,9 @@ class OpenTrainStepRecord:
     status: TrainStepStatus = TrainStepStatus.OPEN
 
 
-def _new_attempt(logical_rollout_id: str) -> RolloutAttemptRecord:
-    attempt_id = str(uuid.uuid4())
+def _new_attempt() -> RolloutAttemptRecord:
     return RolloutAttemptRecord(
-        attempt_id=attempt_id,
-        gate_rollout_id=f"{logical_rollout_id}_a{attempt_id}",
+        attempt_uuid=uuid.uuid4(),
         status=RolloutAttemptStatus.RESERVED,
     )
 
@@ -182,6 +218,7 @@ class RolloutRecoveryLedger:
         self,
         *,
         prompt_id: str,
+        prompt_ref: PromptRef,
         prompt_payload: DatumSpec,
         expected_generations: int,
         target_step: Optional[int],
@@ -191,6 +228,11 @@ class RolloutRecoveryLedger:
         """Create one logical group and its first physical sibling attempts."""
         if not prompt_id:
             raise ValueError("prompt_id must not be empty")
+        if prompt_ref.sample_id != prompt_id:
+            raise ValueError(
+                "dataset prompt reference must match prompt_id: "
+                f"{prompt_ref.sample_id!r} != {prompt_id!r}"
+            )
         if expected_generations < 1:
             raise ValueError("expected_generations must be at least one")
         group_id = group_id or str(uuid.uuid4())
@@ -199,21 +241,20 @@ class RolloutRecoveryLedger:
 
         siblings = []
         for generation_index in range(expected_generations):
-            logical_rollout_id = f"{group_id}_g{generation_index}"
             siblings.append(
                 RolloutSiblingRecord(
                     generation_index=generation_index,
-                    logical_rollout_id=logical_rollout_id,
-                    attempts=[_new_attempt(logical_rollout_id)],
+                    attempts=[_new_attempt()],
                 )
             )
         record = PromptGroupRecoveryRecord(
             group_id=group_id,
             prompt_id=prompt_id,
+            prompt_ref=prompt_ref,
             # Retain the immutable dataloader sample by reference instead of copying
-            # a potentially 131k-token payload. It is released as soon as canonical
-            # rows take over recovery ownership.
-            prompt_payload=prompt_payload,
+            # a potentially 131k-token payload. This cache is never serialized and
+            # is released as soon as canonical rows take over recovery ownership.
+            runtime_prompt_payload=prompt_payload,
             expected_generations=expected_generations,
             target_step=target_step,
             start_weight_version=start_weight_version,
@@ -240,10 +281,11 @@ class RolloutRecoveryLedger:
                 RolloutAttemptStatus.FAILED,
             }:
                 raise ValueError(
-                    f"cannot retry logical rollout {sibling.logical_rollout_id!r} "
+                    "cannot retry logical rollout "
+                    f"{record.logical_rollout_id(sibling.generation_index)!r} "
                     f"from status {attempt.status.value!r}"
                 )
-            sibling.attempts.append(_new_attempt(sibling.logical_rollout_id))
+            sibling.attempts.append(_new_attempt())
         return self._copy_group(record)
 
     def mark_group_dispatched(
@@ -281,11 +323,12 @@ class RolloutRecoveryLedger:
         record = self._require_group(group_id)
         sibling = self._require_sibling(record, generation_index)
         attempt = sibling.current_attempt
+        expected_gate_rollout_id = record.gate_rollout_id(generation_index)
         staging_keys = _receipt_staging_keys(receipt)
-        if gate_rollout_id != attempt.gate_rollout_id:
+        if gate_rollout_id != expected_gate_rollout_id:
             raise ValueError(
                 "streamed rollout identity mismatch: "
-                f"result={gate_rollout_id!r}, expected={attempt.gate_rollout_id!r}"
+                f"result={gate_rollout_id!r}, expected={expected_gate_rollout_id!r}"
             )
         if receipt.get("rollout_id") != gate_rollout_id:
             raise ValueError(
@@ -300,11 +343,13 @@ class RolloutRecoveryLedger:
             ):
                 return
             raise ValueError(
-                f"conflicting duplicate seal for {sibling.logical_rollout_id!r}"
+                "conflicting duplicate seal for "
+                f"{record.logical_rollout_id(generation_index)!r}"
             )
         if attempt.status != RolloutAttemptStatus.DISPATCHED:
             raise ValueError(
-                f"cannot seal logical rollout {sibling.logical_rollout_id!r} "
+                "cannot seal logical rollout "
+                f"{record.logical_rollout_id(generation_index)!r} "
                 f"from status {attempt.status.value!r}"
             )
 
@@ -361,7 +406,9 @@ class RolloutRecoveryLedger:
                 or attempt.reward is None
             ):
                 raise ValueError(
-                    f"logical rollout {sibling.logical_rollout_id!r} is not sealed"
+                    "logical rollout "
+                    f"{record.logical_rollout_id(sibling.generation_index)!r} "
+                    "is not sealed"
                 )
             receipts.append(copy.deepcopy(attempt.receipt))
             rewards.append(attempt.reward)
@@ -413,57 +460,8 @@ class RolloutRecoveryLedger:
         record.canonical_meta = copy.deepcopy(meta)
         record.group_min_weight_version = int(group_min_weight_version)
         record.group_max_weight_version = int(group_max_weight_version)
-        record.prompt_payload = None
+        record.runtime_prompt_payload = None
         record.status = PromptGroupStatus.FINALIZED
-
-    def adopt_finalized_group(
-        self,
-        *,
-        group_id: str,
-        meta: KVBatchMeta,
-        start_weight_version: int,
-        end_weight_version: int,
-        target_step: Optional[int] = None,
-    ) -> None:
-        """Adopt a canonical-only group restored by the existing TQ checkpoint.
-
-        Older completed-rollout checkpoints have canonical rows and replay metadata
-        but no partial lineage sidecar. They remain trainable during the transition
-        to persisted lineage; synthetic abandoned attempts represent the fact that
-        their physical Gate history is no longer needed.
-        """
-        if group_id in self._groups:
-            raise ValueError(f"duplicate recovery group_id={group_id!r}")
-        expected_ids = [f"{group_id}_g{i}" for i in range(len(meta.sample_ids))]
-        if list(meta.sample_ids) != expected_ids:
-            raise ValueError(
-                "restored canonical sample IDs do not form one logical group: "
-                f"{meta.sample_ids!r}"
-            )
-        siblings = []
-        for generation_index, logical_id in enumerate(expected_ids):
-            attempt = _new_attempt(logical_id)
-            attempt.status = RolloutAttemptStatus.ABANDONED
-            siblings.append(
-                RolloutSiblingRecord(
-                    generation_index=generation_index,
-                    logical_rollout_id=logical_id,
-                    attempts=[attempt],
-                )
-            )
-        self._groups[group_id] = PromptGroupRecoveryRecord(
-            group_id=group_id,
-            prompt_id=group_id,
-            prompt_payload=None,
-            expected_generations=len(expected_ids),
-            target_step=target_step,
-            start_weight_version=int(start_weight_version),
-            siblings=siblings,
-            status=PromptGroupStatus.FINALIZED,
-            canonical_meta=copy.deepcopy(meta),
-            group_min_weight_version=int(start_weight_version),
-            group_max_weight_version=int(end_weight_version),
-        )
 
     def claim_groups_for_training(
         self,
@@ -588,7 +586,10 @@ class RolloutRecoveryLedger:
                 {
                     "group_id": record.group_id,
                     "prompt_id": record.prompt_id,
-                    "prompt_payload": copy.deepcopy(record.prompt_payload),
+                    "prompt_ref": {
+                        "sample_id": record.prompt_ref.sample_id,
+                        "task_name": record.prompt_ref.task_name,
+                    },
                     "expected_generations": record.expected_generations,
                     "target_step": record.target_step,
                     "start_weight_version": record.start_weight_version,
@@ -600,11 +601,9 @@ class RolloutRecoveryLedger:
                     "siblings": [
                         {
                             "generation_index": sibling.generation_index,
-                            "logical_rollout_id": sibling.logical_rollout_id,
                             "attempts": [
                                 {
-                                    "attempt_id": attempt.attempt_id,
-                                    "gate_rollout_id": attempt.gate_rollout_id,
+                                    "attempt_uuid": attempt.attempt_uuid.bytes,
                                     "status": attempt.status.value,
                                     "receipt": copy.deepcopy(attempt.receipt),
                                     "reward": attempt.reward,
@@ -647,15 +646,11 @@ class RolloutRecoveryLedger:
             raise ValueError("rollout-recovery state must contain a groups list")
 
         ledger = cls()
-        seen_logical_ids: set[str] = set()
-        seen_attempt_ids: set[str] = set()
-        seen_gate_ids: set[str] = set()
+        seen_attempt_uuids: set[uuid.UUID] = set()
         for raw_group in raw_groups:
             record = cls._group_from_state(
                 raw_group,
-                seen_logical_ids=seen_logical_ids,
-                seen_attempt_ids=seen_attempt_ids,
-                seen_gate_ids=seen_gate_ids,
+                seen_attempt_uuids=seen_attempt_uuids,
             )
             if record.group_id in ledger._groups:
                 raise ValueError(f"duplicate recovery group_id={record.group_id!r}")
@@ -716,9 +711,7 @@ class RolloutRecoveryLedger:
         cls,
         raw_group: Any,
         *,
-        seen_logical_ids: set[str],
-        seen_attempt_ids: set[str],
-        seen_gate_ids: set[str],
+        seen_attempt_uuids: set[uuid.UUID],
     ) -> PromptGroupRecoveryRecord:
         if not isinstance(raw_group, dict):
             raise ValueError("rollout-recovery group must be a mapping")
@@ -753,17 +746,7 @@ class RolloutRecoveryLedger:
                 raise ValueError("rollout-recovery sibling must be a mapping")
             if sibling_state.get("generation_index") != generation_index:
                 raise ValueError("generation indices must be contiguous")
-            logical_id = sibling_state.get("logical_rollout_id")
-            expected_logical_id = f"{group_id}_g{generation_index}"
-            if (
-                not isinstance(logical_id, str)
-                or logical_id != expected_logical_id
-                or logical_id in seen_logical_ids
-            ):
-                raise ValueError(
-                    f"logical rollout ID mismatch or duplicate: {logical_id!r}"
-                )
-            seen_logical_ids.add(logical_id)
+            logical_id = f"{group_id}_g{generation_index}"
             attempts_state = sibling_state.get("attempts")
             if not isinstance(attempts_state, list) or not attempts_state:
                 raise ValueError(f"logical rollout {logical_id!r} has no attempts")
@@ -771,18 +754,17 @@ class RolloutRecoveryLedger:
             for attempt_state in attempts_state:
                 if not isinstance(attempt_state, dict):
                     raise ValueError("rollout-recovery attempt must be a mapping")
-                attempt_id = attempt_state.get("attempt_id")
-                gate_id = attempt_state.get("gate_rollout_id")
-                if not isinstance(attempt_id, str) or not attempt_id:
-                    raise ValueError("attempt_id must be a non-empty string")
-                if not isinstance(gate_id, str) or gate_id != (
-                    f"{logical_id}_a{attempt_id}"
+                raw_attempt_uuid = attempt_state.get("attempt_uuid")
+                if (
+                    not isinstance(raw_attempt_uuid, bytes)
+                    or len(raw_attempt_uuid) != 16
                 ):
-                    raise ValueError("gate rollout ID does not match attempt identity")
-                if attempt_id in seen_attempt_ids or gate_id in seen_gate_ids:
+                    raise ValueError("attempt_uuid must contain exactly 16 bytes")
+                attempt_uuid = uuid.UUID(bytes=raw_attempt_uuid)
+                if attempt_uuid in seen_attempt_uuids:
                     raise ValueError("duplicate rollout attempt identity")
-                seen_attempt_ids.add(attempt_id)
-                seen_gate_ids.add(gate_id)
+                seen_attempt_uuids.add(attempt_uuid)
+                gate_id = f"{logical_id}_a{attempt_uuid.hex}"
                 try:
                     attempt_status = RolloutAttemptStatus(attempt_state.get("status"))
                 except ValueError as error:
@@ -807,8 +789,7 @@ class RolloutRecoveryLedger:
                     raise ValueError("only sealed attempts may retain receipt data")
                 attempts.append(
                     RolloutAttemptRecord(
-                        attempt_id=attempt_id,
-                        gate_rollout_id=gate_id,
+                        attempt_uuid=attempt_uuid,
                         status=attempt_status,
                         receipt=copy.deepcopy(receipt),
                         reward=float(reward) if reward is not None else None,
@@ -818,14 +799,21 @@ class RolloutRecoveryLedger:
             siblings.append(
                 RolloutSiblingRecord(
                     generation_index=generation_index,
-                    logical_rollout_id=logical_id,
                     attempts=attempts,
                 )
             )
 
-        prompt_payload = raw_group.get("prompt_payload")
-        if prompt_payload is not None and not isinstance(prompt_payload, dict):
-            raise ValueError("prompt_payload must be a mapping or None")
+        raw_prompt_ref = raw_group.get("prompt_ref")
+        if not isinstance(raw_prompt_ref, dict):
+            raise ValueError("prompt_ref must be a mapping")
+        sample_id = raw_prompt_ref.get("sample_id")
+        task_name = raw_prompt_ref.get("task_name")
+        if not isinstance(sample_id, str) or not sample_id:
+            raise ValueError("prompt_ref sample_id must be a non-empty string")
+        if task_name is not None and not isinstance(task_name, str):
+            raise ValueError("prompt_ref task_name must be a string or None")
+        if sample_id != prompt_id:
+            raise ValueError("prompt_ref sample_id must match prompt_id")
         canonical_meta = raw_group.get("canonical_meta")
         if canonical_meta is not None and not isinstance(canonical_meta, KVBatchMeta):
             raise ValueError("canonical_meta must be KVBatchMeta or None")
@@ -867,7 +855,7 @@ class RolloutRecoveryLedger:
             if canonical_meta is None or min_weight is None or max_weight is None:
                 raise ValueError("finalized group state requires canonical metadata")
             if list(canonical_meta.sample_ids) != [
-                s.logical_rollout_id for s in siblings
+                f"{group_id}_g{s.generation_index}" for s in siblings
             ]:
                 raise ValueError("canonical sample IDs do not match logical lineage")
         elif canonical_meta is not None:
@@ -884,11 +872,8 @@ class RolloutRecoveryLedger:
         return PromptGroupRecoveryRecord(
             group_id=group_id,
             prompt_id=prompt_id,
-            prompt_payload=(
-                copy.deepcopy(cast("DatumSpec", prompt_payload))
-                if prompt_payload is not None
-                else None
-            ),
+            prompt_ref=PromptRef(sample_id=sample_id, task_name=task_name),
+            runtime_prompt_payload=None,
             expected_generations=expected_generations,
             target_step=target_step,
             start_weight_version=start_weight,
@@ -912,7 +897,8 @@ class RolloutRecoveryLedger:
         return PromptGroupRecoveryRecord(
             group_id=record.group_id,
             prompt_id=record.prompt_id,
-            prompt_payload=record.prompt_payload,
+            prompt_ref=record.prompt_ref,
+            runtime_prompt_payload=record.runtime_prompt_payload,
             expected_generations=record.expected_generations,
             target_step=record.target_step,
             start_weight_version=record.start_weight_version,

--- a/nemo_rl/experience/rollout_recovery.py
+++ b/nemo_rl/experience/rollout_recovery.py
@@ -1,0 +1,460 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""In-memory identity and lineage state for recoverable prompt groups."""
+
+from __future__ import annotations
+
+import copy
+import uuid
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any, Self, TypedDict, cast
+
+if TYPE_CHECKING:
+    from nemo_rl.data.interfaces import DatumSpec
+
+ROLLOUT_RECOVERY_SCHEMA_VERSION = 1
+
+
+class RolloutAttemptStatus(StrEnum):
+    """Lifecycle state of one physical execution attempt."""
+
+    RESERVED = "reserved"
+    DISPATCHED = "dispatched"
+    SEALED = "sealed"
+    FINALIZED = "finalized"
+    FAILED = "failed"
+    ABANDONED = "abandoned"
+
+
+class RolloutAttemptState(TypedDict):
+    """Serializable state for one execution attempt."""
+
+    attempt_id: str
+    gate_rollout_id: str
+    status: str
+
+
+class RolloutSiblingState(TypedDict):
+    """Serializable state for one logical generation slot."""
+
+    generation_index: int
+    logical_rollout_id: str
+    attempts: list[RolloutAttemptState]
+
+
+class PromptGroupRecoveryState(TypedDict):
+    """Serializable state for one prompt group."""
+
+    group_id: str
+    prompt_id: str
+    prompt_payload: DatumSpec
+    expected_generations: int
+    target_step: int | None
+    start_weight_version: int
+    siblings: list[RolloutSiblingState]
+
+
+class RolloutRecoveryState(TypedDict):
+    """Versioned envelope for the complete in-memory ledger."""
+
+    schema_version: int
+    groups: list[PromptGroupRecoveryState]
+
+
+@dataclass
+class RolloutAttemptRecord:
+    """One physical attempt for a stable logical sibling."""
+
+    attempt_id: str
+    gate_rollout_id: str
+    status: RolloutAttemptStatus
+
+
+@dataclass
+class RolloutSiblingRecord:
+    """One stable generation slot and all of its execution attempts."""
+
+    generation_index: int
+    logical_rollout_id: str
+    attempts: list[RolloutAttemptRecord]
+
+    @property
+    def current_attempt(self) -> RolloutAttemptRecord:
+        """Return the newest execution attempt."""
+        if not self.attempts:
+            raise RuntimeError(
+                f"logical rollout {self.logical_rollout_id!r} has no attempts"
+            )
+        return self.attempts[-1]
+
+
+@dataclass
+class PromptGroupRecoveryRecord:
+    """Prompt identity and sibling lineage retained across dispatch."""
+
+    group_id: str
+    prompt_id: str
+    prompt_payload: DatumSpec
+    expected_generations: int
+    target_step: int | None
+    start_weight_version: int
+    siblings: list[RolloutSiblingRecord]
+
+    @property
+    def logical_rollout_ids(self) -> list[str]:
+        """Return stable canonical sample IDs in generation order."""
+        return [sibling.logical_rollout_id for sibling in self.siblings]
+
+    @property
+    def gate_rollout_ids(self) -> list[str]:
+        """Return current physical gate IDs in generation order."""
+        return [sibling.current_attempt.gate_rollout_id for sibling in self.siblings]
+
+
+def _new_attempt(logical_rollout_id: str) -> RolloutAttemptRecord:
+    attempt_id = str(uuid.uuid4())
+    return RolloutAttemptRecord(
+        attempt_id=attempt_id,
+        gate_rollout_id=f"{logical_rollout_id}_a{attempt_id}",
+        status=RolloutAttemptStatus.RESERVED,
+    )
+
+
+class RolloutRecoveryLedger:
+    """Controller-owned prompt-to-attempt lineage for token-capture rollouts.
+
+    This first implementation is deliberately in-memory. ``state_dict`` and
+    ``from_state_dict`` define the versioned boundary that a later checkpoint
+    change will persist alongside the native TQ snapshot.
+    """
+
+    def __init__(self) -> None:
+        self._groups: dict[str, PromptGroupRecoveryRecord] = {}
+
+    def reserve_group(
+        self,
+        *,
+        prompt_id: str,
+        prompt_payload: DatumSpec,
+        expected_generations: int,
+        target_step: int | None,
+        start_weight_version: int,
+        group_id: str | None = None,
+    ) -> PromptGroupRecoveryRecord:
+        """Create one logical group and its first physical attempts."""
+        if not prompt_id:
+            raise ValueError("prompt_id must not be empty")
+        if expected_generations < 1:
+            raise ValueError("expected_generations must be at least one")
+        group_id = group_id or str(uuid.uuid4())
+        if group_id in self._groups:
+            raise ValueError(f"duplicate recovery group_id={group_id!r}")
+
+        siblings = []
+        for generation_index in range(expected_generations):
+            logical_rollout_id = f"{group_id}_g{generation_index}"
+            siblings.append(
+                RolloutSiblingRecord(
+                    generation_index=generation_index,
+                    logical_rollout_id=logical_rollout_id,
+                    attempts=[_new_attempt(logical_rollout_id)],
+                )
+            )
+        record = PromptGroupRecoveryRecord(
+            group_id=group_id,
+            prompt_id=prompt_id,
+            prompt_payload=copy.deepcopy(prompt_payload),
+            expected_generations=expected_generations,
+            target_step=target_step,
+            start_weight_version=start_weight_version,
+            siblings=siblings,
+        )
+        self._groups[group_id] = record
+        return copy.deepcopy(record)
+
+    def mark_group_dispatched(self, group_id: str) -> None:
+        """Move every current attempt from reserved to dispatched."""
+        record = self._require_group(group_id)
+        attempts = [sibling.current_attempt for sibling in record.siblings]
+        self._require_statuses(
+            attempts,
+            allowed={RolloutAttemptStatus.RESERVED},
+            transition="dispatch",
+        )
+        for attempt in attempts:
+            attempt.status = RolloutAttemptStatus.DISPATCHED
+
+    def mark_group_finalized(self, group_id: str) -> None:
+        """Mark all logical siblings canonical after the TQ commit succeeds."""
+        record = self._require_group(group_id)
+        attempts = [sibling.current_attempt for sibling in record.siblings]
+        self._require_statuses(
+            attempts,
+            allowed={
+                RolloutAttemptStatus.DISPATCHED,
+                RolloutAttemptStatus.SEALED,
+            },
+            transition="finalize",
+        )
+        for attempt in attempts:
+            attempt.status = RolloutAttemptStatus.FINALIZED
+
+    def release_finalized_group(self, group_id: str) -> None:
+        """Drop a group after canonical replay metadata owns its recovery."""
+        record = self._require_group(group_id)
+        if any(
+            sibling.current_attempt.status != RolloutAttemptStatus.FINALIZED
+            for sibling in record.siblings
+        ):
+            raise ValueError(
+                f"cannot release unfinished recovery group_id={group_id!r}"
+            )
+        del self._groups[group_id]
+
+    def abandon_group(self, group_id: str) -> None:
+        """Mark unfinished attempts abandoned after dispatch cleanup."""
+        record = self._require_group(group_id)
+        for sibling in record.siblings:
+            attempt = sibling.current_attempt
+            if attempt.status == RolloutAttemptStatus.FINALIZED:
+                continue
+            attempt.status = RolloutAttemptStatus.ABANDONED
+
+    def retry_sibling(
+        self, group_id: str, *, generation_index: int
+    ) -> RolloutAttemptRecord:
+        """Create a new attempt while preserving the sibling's logical ID."""
+        record = self._require_group(group_id)
+        if not 0 <= generation_index < len(record.siblings):
+            raise ValueError(
+                f"generation_index={generation_index} is outside group {group_id!r}"
+            )
+        sibling = record.siblings[generation_index]
+        if sibling.current_attempt.status not in {
+            RolloutAttemptStatus.ABANDONED,
+            RolloutAttemptStatus.FAILED,
+        }:
+            raise ValueError(
+                f"cannot retry logical rollout {sibling.logical_rollout_id!r} "
+                f"from status {sibling.current_attempt.status.value!r}"
+            )
+        attempt = _new_attempt(sibling.logical_rollout_id)
+        sibling.attempts.append(attempt)
+        return copy.deepcopy(attempt)
+
+    def get_group(self, group_id: str) -> PromptGroupRecoveryRecord:
+        """Return a defensive copy of one group."""
+        return copy.deepcopy(self._require_group(group_id))
+
+    def __len__(self) -> int:
+        """Return the number of unfinished or retryable prompt groups."""
+        return len(self._groups)
+
+    def state_dict(self) -> RolloutRecoveryState:
+        """Return a versioned, tensor-compatible checkpoint envelope."""
+        groups: list[PromptGroupRecoveryState] = []
+        for record in self._groups.values():
+            groups.append(
+                {
+                    "group_id": record.group_id,
+                    "prompt_id": record.prompt_id,
+                    "prompt_payload": copy.deepcopy(record.prompt_payload),
+                    "expected_generations": record.expected_generations,
+                    "target_step": record.target_step,
+                    "start_weight_version": record.start_weight_version,
+                    "siblings": [
+                        {
+                            "generation_index": sibling.generation_index,
+                            "logical_rollout_id": sibling.logical_rollout_id,
+                            "attempts": [
+                                {
+                                    "attempt_id": attempt.attempt_id,
+                                    "gate_rollout_id": attempt.gate_rollout_id,
+                                    "status": attempt.status.value,
+                                }
+                                for attempt in sibling.attempts
+                            ],
+                        }
+                        for sibling in record.siblings
+                    ],
+                }
+            )
+        return {
+            "schema_version": ROLLOUT_RECOVERY_SCHEMA_VERSION,
+            "groups": groups,
+        }
+
+    @classmethod
+    def from_state_dict(cls, state: dict[str, Any]) -> Self:
+        """Validate and restore a ledger checkpoint into a fresh instance."""
+        if state.get("schema_version") != ROLLOUT_RECOVERY_SCHEMA_VERSION:
+            raise ValueError(
+                "Unsupported rollout-recovery schema version: "
+                f"{state.get('schema_version')!r}"
+            )
+        raw_groups = state.get("groups")
+        if not isinstance(raw_groups, list):
+            raise ValueError("rollout-recovery state must contain a groups list")
+
+        ledger = cls()
+        seen_logical_ids: set[str] = set()
+        seen_attempt_ids: set[str] = set()
+        seen_gate_ids: set[str] = set()
+        for raw_group in raw_groups:
+            if not isinstance(raw_group, dict):
+                raise ValueError("rollout-recovery group must be a mapping")
+            group_id = raw_group.get("group_id")
+            prompt_id = raw_group.get("prompt_id")
+            expected_generations = raw_group.get("expected_generations")
+            siblings_state = raw_group.get("siblings")
+            if not isinstance(group_id, str) or not group_id:
+                raise ValueError("rollout-recovery group_id must be a non-empty string")
+            if group_id in ledger._groups:
+                raise ValueError(f"duplicate recovery group_id={group_id!r}")
+            if not isinstance(prompt_id, str) or not prompt_id:
+                raise ValueError(
+                    "rollout-recovery prompt_id must be a non-empty string"
+                )
+            if not isinstance(expected_generations, int) or expected_generations < 1:
+                raise ValueError(
+                    "rollout-recovery expected_generations must be a positive integer"
+                )
+            if (
+                not isinstance(siblings_state, list)
+                or len(siblings_state) != expected_generations
+            ):
+                raise ValueError(
+                    f"recovery group {group_id!r} has {len(siblings_state) if isinstance(siblings_state, list) else 'invalid'} "
+                    f"siblings; expected {expected_generations}"
+                )
+
+            siblings: list[RolloutSiblingRecord] = []
+            for generation_index, sibling_state in enumerate(siblings_state):
+                if not isinstance(sibling_state, dict):
+                    raise ValueError("rollout-recovery sibling must be a mapping")
+                if sibling_state.get("generation_index") != generation_index:
+                    raise ValueError(
+                        f"recovery group {group_id!r} has non-contiguous generation indices"
+                    )
+                logical_rollout_id = sibling_state.get("logical_rollout_id")
+                expected_logical_id = f"{group_id}_g{generation_index}"
+                if (
+                    not isinstance(logical_rollout_id, str)
+                    or logical_rollout_id != expected_logical_id
+                ):
+                    raise ValueError(
+                        f"logical rollout ID mismatch: {logical_rollout_id!r} != "
+                        f"{expected_logical_id!r}"
+                    )
+                if logical_rollout_id in seen_logical_ids:
+                    raise ValueError(
+                        f"duplicate logical_rollout_id={logical_rollout_id!r}"
+                    )
+                seen_logical_ids.add(logical_rollout_id)
+
+                attempts_state = sibling_state.get("attempts")
+                if not isinstance(attempts_state, list) or not attempts_state:
+                    raise ValueError(
+                        f"logical rollout {logical_rollout_id!r} has no attempts"
+                    )
+                attempts: list[RolloutAttemptRecord] = []
+                for attempt_state in attempts_state:
+                    if not isinstance(attempt_state, dict):
+                        raise ValueError("rollout-recovery attempt must be a mapping")
+                    attempt_id = attempt_state.get("attempt_id")
+                    gate_rollout_id = attempt_state.get("gate_rollout_id")
+                    if not isinstance(attempt_id, str) or not attempt_id:
+                        raise ValueError("attempt_id must be a non-empty string")
+                    expected_gate_id = f"{logical_rollout_id}_a{attempt_id}"
+                    if (
+                        not isinstance(gate_rollout_id, str)
+                        or gate_rollout_id != expected_gate_id
+                    ):
+                        raise ValueError(
+                            f"gate rollout ID mismatch: {gate_rollout_id!r} != "
+                            f"{expected_gate_id!r}"
+                        )
+                    if attempt_id in seen_attempt_ids:
+                        raise ValueError(f"duplicate attempt_id={attempt_id!r}")
+                    if gate_rollout_id in seen_gate_ids:
+                        raise ValueError(
+                            f"duplicate gate_rollout_id={gate_rollout_id!r}"
+                        )
+                    seen_attempt_ids.add(attempt_id)
+                    seen_gate_ids.add(gate_rollout_id)
+                    try:
+                        status = RolloutAttemptStatus(attempt_state.get("status"))
+                    except ValueError as error:
+                        raise ValueError(
+                            f"invalid rollout attempt status={attempt_state.get('status')!r}"
+                        ) from error
+                    attempts.append(
+                        RolloutAttemptRecord(
+                            attempt_id=attempt_id,
+                            gate_rollout_id=gate_rollout_id,
+                            status=status,
+                        )
+                    )
+                siblings.append(
+                    RolloutSiblingRecord(
+                        generation_index=generation_index,
+                        logical_rollout_id=logical_rollout_id,
+                        attempts=attempts,
+                    )
+                )
+
+            target_step = raw_group.get("target_step")
+            start_weight_version = raw_group.get("start_weight_version")
+            if target_step is not None and not isinstance(target_step, int):
+                raise ValueError("target_step must be an integer or None")
+            if not isinstance(start_weight_version, int):
+                raise ValueError("start_weight_version must be an integer")
+            prompt_payload = raw_group.get("prompt_payload")
+            if not isinstance(prompt_payload, dict):
+                raise ValueError("prompt_payload must be a mapping")
+            ledger._groups[group_id] = PromptGroupRecoveryRecord(
+                group_id=group_id,
+                prompt_id=prompt_id,
+                prompt_payload=copy.deepcopy(cast("DatumSpec", prompt_payload)),
+                expected_generations=expected_generations,
+                target_step=target_step,
+                start_weight_version=start_weight_version,
+                siblings=siblings,
+            )
+        return ledger
+
+    def _require_group(self, group_id: str) -> PromptGroupRecoveryRecord:
+        try:
+            return self._groups[group_id]
+        except KeyError as error:
+            raise ValueError(f"unknown recovery group_id={group_id!r}") from error
+
+    @staticmethod
+    def _require_statuses(
+        attempts: list[RolloutAttemptRecord],
+        *,
+        allowed: set[RolloutAttemptStatus],
+        transition: str,
+    ) -> None:
+        invalid = [
+            attempt.gate_rollout_id
+            for attempt in attempts
+            if attempt.status not in allowed
+        ]
+        if invalid:
+            raise ValueError(
+                f"cannot {transition} rollout attempts in their current states: {invalid}"
+            )

--- a/nemo_rl/experience/rollout_recovery.py
+++ b/nemo_rl/experience/rollout_recovery.py
@@ -18,14 +18,14 @@ from __future__ import annotations
 
 import copy
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Self, TypedDict, cast
 
 if TYPE_CHECKING:
     from nemo_rl.data.interfaces import DatumSpec
 
-ROLLOUT_RECOVERY_SCHEMA_VERSION = 1
+ROLLOUT_RECOVERY_SCHEMA_VERSION = 2
 
 
 class RolloutAttemptStatus(StrEnum):
@@ -45,6 +45,9 @@ class RolloutAttemptState(TypedDict):
     attempt_id: str
     gate_rollout_id: str
     status: str
+    receipt: dict[str, Any] | None
+    reward: float | None
+    staging_keys: list[str]
 
 
 class RolloutSiblingState(TypedDict):
@@ -81,6 +84,9 @@ class RolloutAttemptRecord:
     attempt_id: str
     gate_rollout_id: str
     status: RolloutAttemptStatus
+    receipt: dict[str, Any] | None = None
+    reward: float | None = None
+    staging_keys: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -131,6 +137,22 @@ def _new_attempt(logical_rollout_id: str) -> RolloutAttemptRecord:
         gate_rollout_id=f"{logical_rollout_id}_a{attempt_id}",
         status=RolloutAttemptStatus.RESERVED,
     )
+
+
+def _receipt_staging_keys(receipt: dict[str, Any]) -> list[str]:
+    """Validate a sealed receipt and return its ordered staging keys."""
+    manifest = receipt.get("manifest")
+    if not isinstance(manifest, list):
+        raise ValueError("sealed rollout receipt must contain a manifest list")
+    staging_keys: list[str] = []
+    for entry in manifest:
+        if not isinstance(entry, dict) or not isinstance(entry.get("staging_key"), str):
+            raise ValueError(
+                "sealed rollout receipt manifest entries must contain "
+                "string staging_key values"
+            )
+        staging_keys.append(entry["staging_key"])
+    return staging_keys
 
 
 class RolloutRecoveryLedger:
@@ -203,14 +225,51 @@ class RolloutRecoveryLedger:
         attempts = [sibling.current_attempt for sibling in record.siblings]
         self._require_statuses(
             attempts,
-            allowed={
-                RolloutAttemptStatus.DISPATCHED,
-                RolloutAttemptStatus.SEALED,
-            },
+            allowed={RolloutAttemptStatus.SEALED},
             transition="finalize",
         )
         for attempt in attempts:
             attempt.status = RolloutAttemptStatus.FINALIZED
+
+    def mark_sibling_sealed(
+        self,
+        group_id: str,
+        *,
+        generation_index: int,
+        gate_rollout_id: str,
+        receipt: dict[str, Any],
+        reward: float,
+    ) -> None:
+        """Record one streamed sibling receipt before the group completes."""
+        record = self._require_group(group_id)
+        if not 0 <= generation_index < len(record.siblings):
+            raise ValueError(
+                f"generation_index={generation_index} is outside group {group_id!r}"
+            )
+        sibling = record.siblings[generation_index]
+        attempt = sibling.current_attempt
+        if attempt.status != RolloutAttemptStatus.DISPATCHED:
+            raise ValueError(
+                f"cannot seal logical rollout {sibling.logical_rollout_id!r} "
+                f"from status {attempt.status.value!r}"
+            )
+        if gate_rollout_id != attempt.gate_rollout_id:
+            raise ValueError(
+                "streamed rollout identity mismatch: "
+                f"result={gate_rollout_id!r}, expected={attempt.gate_rollout_id!r}"
+            )
+        if receipt.get("rollout_id") != gate_rollout_id:
+            raise ValueError(
+                "receipt rollout identity mismatch: "
+                f"receipt={receipt.get('rollout_id')!r}, "
+                f"expected={gate_rollout_id!r}"
+            )
+        staging_keys = _receipt_staging_keys(receipt)
+
+        attempt.receipt = copy.deepcopy(receipt)
+        attempt.reward = float(reward)
+        attempt.staging_keys = staging_keys
+        attempt.status = RolloutAttemptStatus.SEALED
 
     def release_finalized_group(self, group_id: str) -> None:
         """Drop a group after canonical replay metadata owns its recovery."""
@@ -225,13 +284,21 @@ class RolloutRecoveryLedger:
         del self._groups[group_id]
 
     def abandon_group(self, group_id: str) -> None:
-        """Mark unfinished attempts abandoned after dispatch cleanup."""
+        """Abandon unfinished attempts while preserving sealed siblings."""
         record = self._require_group(group_id)
         for sibling in record.siblings:
             attempt = sibling.current_attempt
-            if attempt.status == RolloutAttemptStatus.FINALIZED:
+            if attempt.status in {
+                RolloutAttemptStatus.SEALED,
+                RolloutAttemptStatus.FINALIZED,
+            }:
                 continue
             attempt.status = RolloutAttemptStatus.ABANDONED
+
+    def discard_group(self, group_id: str) -> None:
+        """Drop a group that policy deliberately rejected after finalization."""
+        self._require_group(group_id)
+        del self._groups[group_id]
 
     def retry_sibling(
         self, group_id: str, *, generation_index: int
@@ -284,6 +351,9 @@ class RolloutRecoveryLedger:
                                     "attempt_id": attempt.attempt_id,
                                     "gate_rollout_id": attempt.gate_rollout_id,
                                     "status": attempt.status.value,
+                                    "receipt": copy.deepcopy(attempt.receipt),
+                                    "reward": attempt.reward,
+                                    "staging_keys": list(attempt.staging_keys),
                                 }
                                 for attempt in sibling.attempts
                             ],
@@ -401,11 +471,45 @@ class RolloutRecoveryLedger:
                         raise ValueError(
                             f"invalid rollout attempt status={attempt_state.get('status')!r}"
                         ) from error
+                    receipt = attempt_state.get("receipt")
+                    reward = attempt_state.get("reward")
+                    staging_keys = attempt_state.get("staging_keys")
+                    if receipt is not None and not isinstance(receipt, dict):
+                        raise ValueError("rollout receipt must be a mapping or None")
+                    if reward is not None and not isinstance(reward, (int, float)):
+                        raise ValueError("rollout reward must be numeric or None")
+                    if not isinstance(staging_keys, list) or not all(
+                        isinstance(key, str) for key in staging_keys
+                    ):
+                        raise ValueError("staging_keys must be a list of strings")
+                    if status in {
+                        RolloutAttemptStatus.SEALED,
+                        RolloutAttemptStatus.FINALIZED,
+                    }:
+                        if receipt is None or reward is None:
+                            raise ValueError(
+                                f"{status.value} rollout attempt must retain its "
+                                "receipt and reward"
+                            )
+                        if receipt.get("rollout_id") != gate_rollout_id:
+                            raise ValueError(
+                                "restored receipt rollout identity does not match "
+                                "its gate_rollout_id"
+                            )
+                        receipt_staging_keys = _receipt_staging_keys(receipt)
+                        if staging_keys != receipt_staging_keys:
+                            raise ValueError(
+                                "restored staging_keys do not match the receipt "
+                                "manifest"
+                            )
                     attempts.append(
                         RolloutAttemptRecord(
                             attempt_id=attempt_id,
                             gate_rollout_id=gate_rollout_id,
                             status=status,
+                            receipt=copy.deepcopy(receipt),
+                            reward=float(reward) if reward is not None else None,
+                            staging_keys=list(staging_keys),
                         )
                     )
                 siblings.append(

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -154,6 +154,7 @@ project-includes = [
   "nemo_rl/experience/metric_utils.py",
   "nemo_rl/experience/payload.py",
   "nemo_rl/experience/rollout_manager.py",
+  "nemo_rl/experience/rollout_recovery.py",
   "nemo_rl/experience/rollouts.py",
   "nemo_rl/experience/route_plan.py",
   "nemo_rl/modelopt/__init__.py",

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -149,6 +149,7 @@ project-includes = [
   "nemo_rl/experience/blackbox_finalizer.py",
   "nemo_rl/experience/finalizer_actor.py",
   "nemo_rl/experience/row_dump.py",
+  "nemo_rl/experience/failures.py",
   "nemo_rl/experience/interfaces.py",
   "nemo_rl/experience/metric_utils.py",
   "nemo_rl/experience/payload.py",

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -150,6 +150,7 @@ project-includes = [
   "nemo_rl/experience/metric_utils.py",
   "nemo_rl/experience/payload.py",
   "nemo_rl/experience/rollout_manager.py",
+  "nemo_rl/experience/rollout_recovery.py",
   "nemo_rl/experience/rollouts.py",
   "nemo_rl/modelopt/__init__.py",
   "nemo_rl/modelopt/models/__init__.py",

--- a/tests/functional/_find_generation_actors.py
+++ b/tests/functional/_find_generation_actors.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Print the pid of every live generation actor, one per line, on stdout.
+
+Everything else goes to stderr, so callers can do `$(... 2>/dev/null)`.
+
+Used by the chaos and recovery functional tests to pick a victim.
+
+WHY NOT `ps`/`pgrep`. Both tests originally matched Ray's process *title*
+(``ray::VllmAsyncGenerationWorker``), set via setproctitle. That worked on a 2-GPU
+workstation and found zero actors on a GB200 cluster. Titles are a runtime implementation
+detail; the GCS actor table is the runtime's own record of which pid is which actor.
+
+WHY NOT ``ray.util.state.list_actors``. It goes through the dashboard HTTP state server,
+which is not reachable in every configuration. ``ray._private.state.actors()`` reads the
+GCS directly.
+
+WHY IT PRINTS SO MUCH TO STDERR. On job 5866390 this returned zero pids and said nothing,
+which left no way to tell "no actors" from "wrong field name" from "wrong state string".
+It now always reports what the actor table actually contained, so one run answers that.
+"""
+
+import os
+import sys
+
+DEFAULT_MATCH = "GenerationWorker"
+
+
+def _err(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)
+
+
+def _address_from_session(tmp: str = "") -> str:
+    """Rebuild ip:port for the live cluster from Ray's session directory.
+
+    ``address="auto"`` reads a marker file that a driver-managed cluster does not always
+    leave behind, but every session records the GCS port. Pairing that with the recorded
+    node ip gives an address that can be connected to directly.
+    """
+    import glob
+    import json
+
+    if not tmp:
+        try:
+            from ray._private.utils import get_ray_temp_dir
+
+            tmp = get_ray_temp_dir()
+        except Exception:  # noqa: BLE001
+            tmp = "/tmp/ray"
+    session = os.path.join(tmp, "session_latest")
+    if not os.path.isdir(session):
+        return ""
+    ports = sorted(glob.glob(os.path.join(session, "gcs_server_port_*")))
+    if not ports:
+        return ""
+    try:
+        with open(ports[-1]) as fh:
+            port = fh.read().strip()
+        ip = ""
+        node_ip = os.path.join(session, "node_ip_address.json")
+        if os.path.exists(node_ip):
+            with open(node_ip) as fh:
+                ip = json.load(fh).get("node_ip_address", "")
+        if not ip:
+            import socket
+
+            ip = socket.gethostbyname(socket.gethostname())
+        return f"{ip}:{port}" if port else ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _report_attach_failure(address: str, exc: Exception) -> None:
+    import glob
+
+    _err(f"[actors] could not attach to Ray at address={address!r}: {exc}")
+    for var in ("RAY_ADDRESS", "RAY_TMPDIR", "TMPDIR"):
+        _err(f"[actors]   env {var}={os.environ.get(var, '<unset>')!r}")
+    try:
+        from ray._private.utils import get_ray_temp_dir
+
+        tmp = get_ray_temp_dir()
+    except Exception:  # noqa: BLE001
+        tmp = "/tmp/ray"
+    _err(f"[actors]   ray temp dir: {tmp} (exists={os.path.isdir(tmp)})")
+    if os.path.isdir(tmp):
+        _err(f"[actors]   contents: {sorted(os.listdir(tmp))[:10]}")
+    _err(f"[actors]   rebuilt-from-session: {_address_from_session(tmp)!r}")
+    for cand in sorted(glob.glob("/tmp/ray*"))[:5]:
+        _err(f"[actors]   /tmp glob: {cand}")
+
+
+def main() -> int:
+    match = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_MATCH
+
+    import ray
+
+    address = os.environ.get("RAY_ADDRESS") or "auto"
+    try:
+        ray.init(address=address, log_to_driver=False, include_dashboard=False)
+    except Exception as first_exc:  # noqa: BLE001
+        # "auto" resolves through a marker that is not always written -- on the GB200
+        # cluster it failed while the training job's cluster was demonstrably up. The
+        # session directory always records the GCS port, so rebuild the address from it.
+        rebuilt = _address_from_session()
+        if rebuilt:
+            _err(f"[actors] address={address!r} failed; retrying with {rebuilt!r}")
+            try:
+                ray.init(address=rebuilt, log_to_driver=False, include_dashboard=False)
+                address = rebuilt
+            except Exception as exc:  # noqa: BLE001
+                _report_attach_failure(address, exc)
+                return 1
+        else:
+            _report_attach_failure(address, first_exc)
+            return 1
+    try:
+        import ray._private.state as rstate
+
+        table = rstate.actors()
+        _err(f"[actors] GCS actor table: {len(table)} entries")
+
+        rows = []
+        for rec in table.values():
+            rows.append(
+                (
+                    rec.get("ActorClassName", "<no ActorClassName>"),
+                    rec.get("State", "<no State>"),
+                    rec.get("Pid", 0),
+                    rec.get("Name", "") or "",
+                )
+            )
+
+        # Always dump the table. The whole point is to stop guessing at field values.
+        for cls, state, pid, name in sorted(rows):
+            _err(f"[actors]   class={cls!r} state={state!r} pid={pid} name={name!r}")
+
+        matched = [
+            (cls, state, pid)
+            for cls, state, pid in ((r[0], r[1], r[2]) for r in rows)
+            if match in cls
+        ]
+        _err(f"[actors] {len(matched)} entries match {match!r}")
+
+        # Deliberately permissive about State: a shard that is RESTARTING or PENDING is
+        # still a real process worth reporting, and over-filtering here is exactly what
+        # produced a silent empty result before. Pid 0 means Ray has no process for it,
+        # so those cannot be killed and are excluded, but they are reported above.
+        pids = sorted({pid for _cls, _state, pid in matched if pid})
+        if not pids:
+            _err(f"[actors] no killable pid for any actor matching {match!r}")
+    finally:
+        ray.shutdown()
+
+    for pid in pids:
+        print(pid)
+    return 0 if pids else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/functional/grpo_dp_single_controller_chaos.sh
+++ b/tests/functional/grpo_dp_single_controller_chaos.sh
@@ -1,0 +1,376 @@
+#!/bin/bash
+# Chaos variant of grpo_dp_single_controller.sh: SIGKILL a vLLM generation worker
+# mid-run and assert the job fails fast and loudly instead of wedging.
+#
+# This is the scenario the whole SC resiliency effort exists for. Before the P0
+# work, a dead generation endpoint left rollouts parked forever -- each holding a
+# max_inflight_prompts permit -- until the rollout pump blocked and the train pump
+# spun, with no exception raised anywhere. The pass condition here is therefore not
+# "training succeeds"; it is "the job stops, quickly, with an attributable error".
+#
+# Registered in the SingleController L1 lane (full mode). It was originally kept out as
+# "timing-sensitive", but that no longer justifies exclusion: the death deadline is now
+# 600s against an observed 222s, and the victim selection is asserted rather than assumed.
+# (The shard-recovery harness added in part 3/4 of this series kills processes the same
+# way, from the same lane.) Leaving it out meant
+# the containment behaviour had no end-to-end coverage at all -- and a wedge is precisely
+# the failure that no other test can detect, because it raises nothing.
+#
+# Usage: bash tests/functional/grpo_dp_single_controller_chaos.sh
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+PROJECT_ROOT=$(realpath "$SCRIPT_DIR"/../..)
+git config --global --add safe.directory "$PROJECT_ROOT"
+
+set -eou pipefail
+
+# Suffixed with the victim state because BOTH lane entries run this script, and it opens
+# with `rm -rf "$EXP_DIR"` -- so a shared EXP_NAME meant the serving run deleted the idle
+# run's run.log and tensorboard artifacts. When serving then failed in CI, the idle
+# evidence you would compare it against was already gone.
+# VICTIM_STATE is not assigned until below, hence repeating its default here.
+EXP_NAME=$(basename "$0" .sh)-${VICTIM_STATE:-idle}
+EXP_DIR=$SCRIPT_DIR/$EXP_NAME
+LOG_DIR=$EXP_DIR/logs
+RUN_LOG=$EXP_DIR/run.log
+export PYTHONPATH=${PROJECT_ROOT}:${PYTHONPATH:-}
+
+# How long to wait for the job to die after the kill. The point of the test is that
+# this is bounded at all: pre-P0 the job would still be sitting here at any deadline.
+# 600s, not 300s: an observed run took 222s to die (5 re-dispatch attempts with capped
+# exponential backoff, which is the designed containment behaviour). 300s left only 26%
+# headroom, and CI is slower than this workstation -- a deadline that tight turns into a
+# flaky "wedge" report.
+DEATH_DEADLINE_S=${DEATH_DEADLINE_S:-600}
+# Which generation worker to kill, and in which state.
+#
+# Ray retitles a worker with setproctitle for the exact duration of a call, so a single
+# actor cycles through several titles. Observed over one run (378 samples):
+#
+#   /opt/ray_venvs/...VllmAsyncGenerationWorker/bin/python   a CHILD process, not the actor
+#   bash -c exec /opt/ray_venvs/...GenerationWorker...       the launcher shell
+#   ray::VllmAsyncGenerationWorker                           the actor, between calls
+#   ray::vllm_policy-0-0:VllmAsyncGenerationWorker.__init__  the actor, constructing
+#   ray::VllmAsyncGenerationWorker.generate_async            the actor, serving a rollout
+#   ray::VllmAsyncGenerationWorker.init_collective_async     the actor, setting up refit
+#   ray::VllmAsyncGenerationWorker.shutdown                  the actor, tearing down
+#
+# A loose `[Gg]enerationWorker` substring matches every one of those -- three distinct
+# processes across five states -- and `head -1` then picked whichever had the lowest pid.
+# So the test silently chose a different scenario from run to run. It never failed, because
+# every scenario does end in a bounded attributable failure, which is all it asserted; the
+# difference only showed up as wildly different wall-clock times across branches (7s vs
+# 222s). A `*GenerationWorker*` check on the victim does not help either: the launcher
+# shell and the venv child both satisfy it.
+#
+# So select the ACTOR structurally (`ray::` prefix, optional `name:` infix) and pin the
+# state:
+#   idle    -- title has no method suffix. Nothing is in flight, so the loss must be
+#              *detected*: by a health probe, or by the stall detector. This exercises the
+#              resiliency machinery, so it is the default.
+#   serving -- title is `.generate_async`. An in-flight rollout RPC dies with the worker
+#              and the failure surfaces immediately, without detection doing any work.
+#
+# Deliberately not "any method suffix": killing during __init__, init_collective_async or
+# shutdown are three further distinct scenarios, and lumping them in would reintroduce
+# exactly the ambiguity this replaces.
+VICTIM_STATE=${VICTIM_STATE:-idle}
+# How long to wait for the worker to be observed in that state. Generous because `serving`
+# is a narrow window -- generate_async was only ~2% of samples, against ~34% for idle.
+VICTIM_WAIT_S=${VICTIM_WAIT_S:-300}
+# Separate budget for finding the actors at all, before any state is considered.
+# Generation takes a while to come up, and conflating the two made 'no actors' and
+# 'actors never reached the state' indistinguishable in the log.
+ACTOR_WAIT_S=${ACTOR_WAIT_S:-300}
+# Hard bound on ONE discovery attempt: an unbounded Ray actor-table query against a GCS
+# that is itself unwell hangs the harness rather than the run it is watching.
+ACTOR_QUERY_TIMEOUT_S=${ACTOR_QUERY_TIMEOUT_S:-20}
+# GPUs this test pins itself to, independent of how many the host has. One shard of
+# generation and one trainer: killing the shard leaves the fleet empty, which is the
+# scenario -- a bounded failure with nothing to fall back to. Defined once because the
+# pre-flight check below has to agree with it.
+GPUS=2
+# How long to wait for device memory to come back: on entry, because the previous test in
+# the lane may still be releasing it, and on exit, so this test cannot poison the next one.
+GPU_WAIT_S=${GPU_WAIT_S:-120}
+GPU_SETTLE_S=${GPU_SETTLE_S:-60}
+
+# GPUs whose used memory is low enough to place a worker on.
+free_gpu_count() {
+    nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits \
+        | awk -v lim=1024 '$1 <= lim' | wc -l
+}
+
+# Waits up to $1 seconds for $GPUS of them; non-zero if the budget runs out.
+#
+# Sampling once is wrong, because SIGKILL does not free device memory synchronously: the
+# driver tears the context down, and a worker holding tens of GB stays visible to
+# nvidia-smi for seconds after it dies. The lane runs tests back to back -- run_test is
+# just `time "$@"` -- so a single sample reads the previous test's corpse. That is exactly
+# what broke GitHub CI: chaos-idle passed at 19:51:42, its cleanup killed the
+# VLLM::EngineCore it had orphaned on purpose, and chaos-serving sampled 280ms later,
+# found GPU 0 still holding 50470MiB, and refused to start without running a single line
+# of product code. It had always passed on the cluster only because submit-ci.sh sleeps 5s
+# between tests -- and that hygiene belongs here, in the test that makes the mess, not in
+# one particular driver that happens to run it.
+wait_for_free_gpus() {
+    local budget_s=$1 free
+    for _ in $(seq 1 "$budget_s"); do
+        free=$(free_gpu_count) || free=0
+        if (( free >= GPUS )); then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
+
+# Refuse to start on a dirty machine rather than misreport a leftover allocation as a
+# failure of the code under test.
+#
+# Counts how many GPUs are free and requires enough of them, rather than requiring that
+# EVERY GPU on the host is free. The latter is an OR that gets likelier to trip the bigger
+# the machine: this test pins itself to $GPUS GPUs, so on an 8-GPU CI runner one unrelated
+# process on one GPU would abort it with six sitting idle -- a false failure that says
+# nothing about the code. It still catches the case it was written for, a previous test in
+# the lane leaking a VLLM::EngineCore, because that drops the free count below $GPUS.
+#
+# This runs BEFORE the training launch. It used to run after, which meant a refusal was
+# not a refusal: the driver was already up, the EXIT trap shot it back down, and the log
+# carried a bare "line 129: <pid> Killed" from bash job control on top of the real message.
+if command -v nvidia-smi >/dev/null 2>&1 && ! wait_for_free_gpus "$GPU_WAIT_S"; then
+    echo "[chaos] FAIL: need $GPUS free GPUs, still $(free_gpu_count) after ${GPU_WAIT_S}s; clean up before running"
+    nvidia-smi --query-gpu=index,memory.used --format=csv
+    nvidia-smi --query-compute-apps=pid,used_memory --format=csv
+    exit 1
+fi
+
+rm -rf "$EXP_DIR"
+mkdir -p "$EXP_DIR" "$LOG_DIR"
+
+cd "$PROJECT_ROOT"
+
+# Enough steps that the run is still going when the kill lands.
+# PYTHONUNBUFFERED: the harness detects progress by grepping RUN_LOG, and that only
+# works if the driver actually writes to it. The actor prints with flush=True, but
+# that just reaches the DRIVER -- Ray forwards actor output there, and the driver's
+# own stdout is a redirected file, so Python block-buffers it. Job 5892910 wrote
+# "train step 3/24" at 10:40:38 and the harness did not see it until 10:48:21, by
+# which time the run had finished and there was nothing left to kill.
+PYTHONUNBUFFERED=1 uv run "$PROJECT_ROOT"/examples/run_grpo_single_controller.py \
+    policy.model_name=Qwen/Qwen3-0.6B \
+    grpo.num_prompts_per_step=2 \
+    grpo.num_generations_per_prompt=4 \
+    policy.train_global_batch_size=8 \
+    policy.train_micro_batch_size=1 \
+    cluster.gpus_per_node=$GPUS \
+    grpo.max_num_steps=50 \
+    logger.tensorboard_enabled=true \
+    logger.log_dir="$LOG_DIR" \
+    logger.wandb_enabled=false \
+    logger.monitor_gpus=false \
+    checkpointing.enabled=false \
+    data_plane.enabled=true \
+    data_plane.impl=transfer_queue \
+    data_plane.backend=simple \
+    async_rl.sampler.name=in_order \
+    async_rl.sampler.max_lookahead_versions=0 \
+    async_rl.min_groups_for_streaming_train=2 \
+    async_rl.max_inflight_prompts=2 \
+    async_rl.max_buffered_rollouts=2 \
+    ++async_rl.rollout_failure.native.generation_timeout_s=60 \
+    ++async_rl.rollout_failure.max_infra_attempts_per_prompt=3 \
+    ++async_rl.watchdog.interval_s=10 \
+    ++async_rl.watchdog.stall_timeout_s=180 \
+    ++async_rl.watchdog.stall_action=abort \
+    > "$RUN_LOG" 2>&1 &
+TRAIN_PID=$!
+
+cleanup() {
+    kill -9 $TRAIN_PID 2>/dev/null || true
+    # Killing the driver is not enough. Ray actors outlive it, and vLLM's engine
+    # runs in a VLLM::EngineCore child that survives its parent actor being killed
+    # -- which is exactly what this test does on purpose. Left behind, it holds
+    # tens of GB of device memory and the next run fails to place its placement
+    # groups, which looks like an unrelated bug.
+    ray stop --force >/dev/null 2>&1 || true
+    pkill -9 -f "VLLM::EngineCore" 2>/dev/null || true
+    pkill -9 -f "megatron_policy_worker" 2>/dev/null || true
+    # Signalling is not reclaiming: wait for the memory to actually come back before
+    # handing the machine to the next test, which starts with no gap at all.
+    if command -v nvidia-smi >/dev/null 2>&1 && ! wait_for_free_gpus "$GPU_SETTLE_S"; then
+        echo "[chaos] WARN: ${GPU_SETTLE_S}s after cleanup, fewer than $GPUS GPUs are free:"
+        nvidia-smi --query-compute-apps=pid,used_memory --format=csv
+    fi
+}
+trap cleanup EXIT
+
+echo "[chaos] training pid=$TRAIN_PID, waiting for the first train step..."
+for _ in $(seq 1 120); do
+    grep -q "train step 1/" "$RUN_LOG" 2>/dev/null && break
+    kill -0 $TRAIN_PID 2>/dev/null || { echo "[chaos] FAIL: job died before the kill"; tail -40 "$RUN_LOG"; exit 1; }
+    sleep 5
+done
+grep -q "train step 1/" "$RUN_LOG" || { echo "[chaos] FAIL: never reached a train step"; tail -40 "$RUN_LOG"; exit 1; }
+
+# Which processes are the generation actors? Ask Ray, not ps.
+#
+# Anchored `ray::` title matching worked on a workstation and found ZERO actors on a GB200
+# cluster (job 5861743) -- both chaos variants reported "job died before the kill" because
+# the poll below never matched anything, and the run simply finished. Titles are a runtime
+# implementation detail; the GCS actor table is authoritative.
+#
+# The STATE (idle vs serving) still comes from the title, because Ray only exposes the
+# running method through the dashboard state API and init_ray disables the dashboard. So:
+# discover actors authoritatively, then refine by title when titles are available, and say
+# plainly when they are not rather than silently killing an arbitrary one.
+ACTOR_RE='^ray::([A-Za-z0-9_.:-]+:)?[A-Za-z_]*GenerationWorker'
+case "$VICTIM_STATE" in
+    idle)    STATE_RE="${ACTOR_RE}\$" ;;
+    serving) STATE_RE="${ACTOR_RE}\.generate_async\$" ;;
+    any)     STATE_RE="" ;;
+    *) echo "[chaos] FAIL: VICTIM_STATE must be idle, serving or any; got '$VICTIM_STATE'"; exit 1 ;;
+esac
+
+# Discover the actors ONCE, then poll their titles.
+#
+# Not once per 0.2s tick: each helper call is a full ray.init/shutdown of about three
+# seconds, so polling it at tick rate would make VICTIM_WAIT_S=300 mean roughly 60 checks
+# instead of 1500, and burn the budget on Ray handshakes rather than on watching for the
+# state. The actor SET is stable once generation is up; only the STATE changes.
+echo "[chaos] discovering generation actors (up to ${ACTOR_WAIT_S}s)..."
+ACTORS=()
+ATTEMPT=0
+for _ in $(seq 1 $((ACTOR_WAIT_S / 3))); do
+    kill -0 $TRAIN_PID 2>/dev/null || { echo "[chaos] FAIL: job died before any actor appeared"; break; }
+    # Keep stderr: discarding it cost three debugging rounds, because a failed discovery
+    # is indistinguishable from an empty fleet once the reason is thrown away.
+    # stderr inline, into this log -- a separate artifact twice failed to survive to be
+    # read. stdout (the pids) to a temp file, stderr to a variable.
+    : > "$EXP_DIR/pids.tmp"
+    ACTORS_ERR=$(timeout "$ACTOR_QUERY_TIMEOUT_S" uv run --no-sync python \
+        "$SCRIPT_DIR/_find_generation_actors.py" 2>&1 >"$EXP_DIR/pids.tmp" || true)
+    mapfile -t ACTORS < <(sort -n < "$EXP_DIR/pids.tmp")
+    ATTEMPT=$((ATTEMPT + 1))
+    if (( ${#ACTORS[@]} == 0 )) && [[ -n "$ACTORS_ERR" && $ATTEMPT -le 2 ]]; then
+        echo "[chaos] discovery attempt $ATTEMPT found no actors; helper said:"
+        echo "$ACTORS_ERR" | tail -25 | sed 's/^/[chaos]   /'
+    fi
+    (( ${#ACTORS[@]} > 0 )) && break
+    sleep 3
+done
+
+if (( ${#ACTORS[@]} == 0 )); then
+    echo "[chaos] FAIL: no generation actors found in ${ACTOR_WAIT_S}s"
+    echo "[chaos] --- helper stderr from the LAST in-loop attempt (job was alive) ---"
+    echo "${ACTORS_ERR:-<no attempt completed>}" | tail -25 | sed 's/^/[chaos]   /'
+    echo "[chaos] --- what Ray reports now (job may already be gone) ---"
+    uv run --no-sync python "$SCRIPT_DIR/_find_generation_actors.py" || true
+    echo "[chaos] --- every process with 'eneration' in its command line ---"
+    ps -eo pid=,args= 2>/dev/null | sed -E 's/^ *//' | grep -i "eneration" | grep -v grep | head -20
+    echo "[chaos] --- last 60 lines of the training log ---"
+    # "job died before any actor appeared" is ambiguous between a crash and simply
+    # finishing all the steps, and those need opposite fixes. The log settles it.
+    tail -60 "$RUN_LOG"
+    exit 1
+fi
+echo "[chaos] generation actors: ${ACTORS[*]}"
+
+echo "[chaos] waiting up to ${VICTIM_WAIT_S}s for one in state '$VICTIM_STATE'..."
+VICTIM=""
+TITLES_SEEN=0
+for _ in $(seq 1 $((VICTIM_WAIT_S * 5))); do
+    kill -0 $TRAIN_PID 2>/dev/null || { echo "[chaos] FAIL: job died before the kill"; break; }
+    for pid in "${ACTORS[@]}"; do
+        [[ -z "$pid" ]] && continue
+        title=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null | sed -E 's/ +$//')
+        [[ "$title" =~ ^ray:: ]] && TITLES_SEEN=1
+        if [[ -z "$STATE_RE" || "$title" =~ $STATE_RE ]]; then
+            VICTIM=$pid; VICTIM_CMD=$title; break 2
+        fi
+    done
+    sleep 0.2
+done
+
+if [[ -z "$VICTIM" ]]; then
+    echo "[chaos] FAIL: no generation actor reached state '$VICTIM_STATE' in ${VICTIM_WAIT_S}s"
+    echo "[chaos] --- what Ray reports ---"
+    uv run --no-sync python "$SCRIPT_DIR/_find_generation_actors.py" || true
+    if (( TITLES_SEEN == 0 )); then
+        echo "[chaos] No actor ever presented a 'ray::' process title, so idle-vs-serving"
+        echo "[chaos] cannot be distinguished on this platform. Re-run with VICTIM_STATE=any"
+        echo "[chaos] to kill a generation actor without pinning the state -- the test still"
+        echo "[chaos] asserts a bounded, attributable failure, it just stops distinguishing"
+        echo "[chaos] the detection path from the in-flight-RPC path."
+    fi
+    echo "[chaos] --- every process with 'eneration' in its command line ---"
+    # Unfiltered: the previous diagnostic grepped 'ray::' and so printed nothing exactly
+    # when the ray:: assumption was itself the problem.
+    ps -eo pid=,args= 2>/dev/null | sed -E 's/^ *//' | grep -i "eneration" | grep -v grep | head -20
+    exit 1
+fi
+
+NOW_CMD=$(tr '\0' ' ' < "/proc/$VICTIM/cmdline" 2>/dev/null | sed -E 's/ +$//')
+if [[ -n "$STATE_RE" && ! "$NOW_CMD" =~ $STATE_RE ]]; then
+    echo "[chaos] FAIL: pid $VICTIM left state '$VICTIM_STATE' before the kill"
+    echo "[chaos]   was: $VICTIM_CMD"
+    echo "[chaos]   now: $NOW_CMD"
+    exit 1
+fi
+echo "[chaos] killing generation actor pid=$VICTIM in state '$VICTIM_STATE'"
+echo "[chaos]   cmdline: ${NOW_CMD:-<unavailable>}"
+kill -9 "$VICTIM"
+KILLED_AT=$(date +%s)
+sleep 2
+if kill -0 "$VICTIM" 2>/dev/null; then
+    echo "[chaos] FAIL: victim $VICTIM survived SIGKILL; nothing was actually killed"
+    exit 1
+fi
+
+echo "[chaos] waiting up to ${DEATH_DEADLINE_S}s for the job to stop..."
+DIED=0
+for _ in $(seq 1 $((DEATH_DEADLINE_S / 5))); do
+    if ! kill -0 $TRAIN_PID 2>/dev/null; then DIED=1; break; fi
+    sleep 5
+done
+
+ELAPSED=$(( $(date +%s) - KILLED_AT ))
+if [[ $DIED -ne 1 ]]; then
+    echo "[chaos] FAIL: still running ${ELAPSED}s after the kill -- this is the wedge."
+    # A wedge is only actionable if you can see where it is wedged. Dump the
+    # controller's stacks before tearing anything down; "it hung" on its own has
+    # already cost one debugging cycle here.
+    SC_PID=$(pgrep -f "ray::SingleControllerActor" | head -1 || true)
+    if [[ -n "${SC_PID:-}" ]] && command -v py-spy >/dev/null 2>&1; then
+        echo "[chaos] --- py-spy dump of SingleControllerActor pid=$SC_PID ---"
+        py-spy dump --pid "$SC_PID" --locals 2>&1 | head -80 || true
+    fi
+    for name in MegatronPolicyWorker VllmAsyncGenerationWorker; do
+        pid=$(pgrep -f "ray::${name}" | head -1 || true)
+        if [[ -n "${pid:-}" ]] && command -v py-spy >/dev/null 2>&1; then
+            echo "[chaos] --- py-spy dump of ${name} pid=${pid} ---"
+            py-spy dump --pid "$pid" 2>&1 | head -40 || true
+        fi
+    done
+    tail -40 "$RUN_LOG"
+    exit 1
+fi
+
+wait $TRAIN_PID && EXIT_CODE=0 || EXIT_CODE=$?
+echo "[chaos] job stopped after ${ELAPSED}s with exit code ${EXIT_CODE}"
+
+if [[ $EXIT_CODE -eq 0 ]]; then
+    echo "[chaos] FAIL: job exited 0 -- a killed generation worker must not look like success"
+    exit 1
+fi
+
+# The failure must name the rollout path, not surface as a bare Ray traceback.
+if grep -qE "RolloutRedispatchExhausted|GenerationUnavailable|RolloutStall|RolloutTimeout" "$RUN_LOG"; then
+    echo "[chaos] PASS: bounded, attributable failure ${ELAPSED}s after the kill"
+    grep -oE "RolloutRedispatchExhausted|GenerationUnavailable|RolloutStall|RolloutTimeout" "$RUN_LOG" | sort | uniq -c
+    exit 0
+fi
+
+echo "[chaos] FAIL: job stopped but no typed rollout failure was reported"
+tail -40 "$RUN_LOG"
+exit 1

--- a/tests/unit/data_plane/test_blackbox_finalizer.py
+++ b/tests/unit/data_plane/test_blackbox_finalizer.py
@@ -245,6 +245,33 @@ def test_finalize_group_publishes_n_rows_with_placeholder(tq_client, partitions)
         finalizer._source.fetch([receipt["manifest"][0]["staging_key"]])
 
 
+def test_finalize_group_maps_physical_attempt_to_stable_canonical_id(
+    tq_client, partitions
+):
+    group_id = "stable"
+    physical_id = f"{group_id}_g0_aattempt"
+    canonical_id = f"{group_id}_g0"
+    receipt, _ = _stage_fixture(
+        tq_client,
+        "worked_example",
+        rollout_id=physical_id,
+    )
+    receipt["rollout_id"] = physical_id
+
+    finalized = _finalizer(tq_client).finalize_group(
+        group_id,
+        [physical_id],
+        [receipt],
+        [1.0],
+        fallback_weight_version=4,
+        canonical_sample_ids=[canonical_id],
+    )
+
+    assert finalized.meta is not None
+    assert finalized.meta.sample_ids == [canonical_id]
+    assert _fetch_rows(tq_client, [canonical_id])["input_ids"] is not None
+
+
 def test_finalize_group_min_valid_fraction_drops(tq_client, partitions):
     group_id = "grp2"
     rollout_ids = [f"{group_id}_g0", f"{group_id}_g1"]

--- a/tests/unit/data_plane/test_blackbox_finalizer.py
+++ b/tests/unit/data_plane/test_blackbox_finalizer.py
@@ -185,11 +185,12 @@ def _fetch_rows(tq_client, sample_ids):
 
 def test_finalize_group_builds_n_rows_with_placeholder(tq_client, partitions):
     group_id = "grp1"
+    canonical_sample_ids = [f"{group_id}_g0", f"{group_id}_g1"]
+    rollout_ids = [f"{sample_id}_aattempt-1" for sample_id in canonical_sample_ids]
     receipt, expected = _stage_fixture(
-        tq_client, "worked_example", rollout_id=f"{group_id}_g0"
+        tq_client, "worked_example", rollout_id=rollout_ids[0]
     )
-    receipt["rollout_id"] = f"{group_id}_g0"
-    rollout_ids = [f"{group_id}_g0", f"{group_id}_g1"]
+    receipt["rollout_id"] = rollout_ids[0]
 
     finalizer = _finalizer(tq_client)
     finalized = finalizer.finalize_group(
@@ -198,11 +199,12 @@ def test_finalize_group_builds_n_rows_with_placeholder(tq_client, partitions):
         [receipt, None],  # second rollout lost its receipt -> placeholder
         [1.0, 0.0],
         fallback_weight_version=9,
+        canonical_sample_ids=canonical_sample_ids,
     )
     assert not finalized.dropped
     assert finalized.meta is not None
     assert finalized.fields is not None
-    assert finalized.meta.sample_ids == rollout_ids
+    assert finalized.meta.sample_ids == canonical_sample_ids
     # Group staleness comes from the valid rollout's calls (wv 4), not the fallback.
     assert (finalized.group_min_wv, finalized.group_max_wv) == (4, 4)
     assert finalized.metrics["finalize/invalid_row_rate"] == 0.5
@@ -228,7 +230,7 @@ def test_finalize_group_builds_n_rows_with_placeholder(tq_client, partitions):
     assert finalized.staging_keys == [receipt["manifest"][0]["staging_key"]]
     assert finalizer._source.fetch(finalized.staging_keys)
     with pytest.raises((KeyError, RuntimeError, ValueError)):
-        _fetch_rows(tq_client, rollout_ids)
+        _fetch_rows(tq_client, canonical_sample_ids)
 
 
 def test_finalize_group_min_valid_fraction_drops(tq_client, partitions):

--- a/tests/unit/environments/test_nemo_gym_health.py
+++ b/tests/unit/environments/test_nemo_gym_health.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NemoGym liveness surface.
+
+Two things are covered. First, health_check forwards to NeMo-Gym's own RunHelper.poll --
+the check Gym already implements and calls every 60s from `gym env start`, but which
+NeMo-RL never ran because it only calls rh.start. Without it a dead tool server shows up
+as unexplained rollout timeouts instead of a named process.
+
+Second, an actor that never spun up says so. Ray recreates a restarted actor through
+__init__ only, which does not start the Gym servers, so a restarted NemoGym reaches that
+state and previously surfaced it as an AttributeError from deep inside a rollout.
+"""
+
+import pytest
+
+from nemo_rl.environments.nemo_gym import NemoGym
+
+# NemoGym is a Ray actor; grab the plain class so these run without a cluster.
+NemoGymClass = NemoGym.__ray_metadata__.modified_class
+
+
+def _unspun() -> NemoGymClass:
+    """A NemoGym exactly as Ray would recreate it after a restart."""
+    return NemoGymClass(
+        {"model_name": "m", "base_urls": [], "initial_global_config_dict": {}}
+    )
+
+
+class _FakeRunHelper:
+    def __init__(self, error: BaseException | None = None) -> None:
+        self.error = error
+        self.polls = 0
+        self.shutdowns = 0
+
+    def poll(self) -> None:
+        self.polls += 1
+        if self.error is not None:
+            raise self.error
+
+    def shutdown(self) -> None:
+        self.shutdowns += 1
+
+
+class TestHealthCheck:
+    def test_a_healthy_gym_polls_the_run_helper(self):
+        env = _unspun()
+        env.rh = _FakeRunHelper()
+        env.health_check()
+        assert env.rh.polls == 1
+
+    def test_a_dead_subprocess_server_propagates_with_its_name(self):
+        env = _unspun()
+        env.rh = _FakeRunHelper(
+            RuntimeError("Process `workplace_assistant` finished unexpectedly!")
+        )
+        with pytest.raises(RuntimeError, match="workplace_assistant"):
+            env.health_check()
+
+
+class TestUnspunActor:
+    def test_health_check_explains_the_restarted_actor_state(self):
+        with pytest.raises(RuntimeError, match="_spinup\\(\\) was never called"):
+            _unspun().health_check()
+
+    def test_run_rollouts_refuses_rather_than_raising_attribute_error(self):
+        env = _unspun()
+        with pytest.raises(RuntimeError, match="_spinup\\(\\) was never called"):
+            # run_rollouts is an async generator, so the guard fires on first advance.
+            gen = env.run_rollouts([{"agent_ref": {"name": "a"}}], None, "timing/x")
+            import asyncio
+
+            asyncio.run(anext(gen))
+
+    def test_shutdown_is_a_noop_so_teardown_does_not_mask_the_real_error(self):
+        """shutdown() runs in a finally block; it must not raise over a training error."""
+        _unspun().shutdown()
+
+    def test_shutdown_still_forwards_when_spun_up(self):
+        env = _unspun()
+        env.rh = _FakeRunHelper()
+        env.shutdown()
+        assert env.rh.shutdowns == 1

--- a/tests/unit/experience/test_failures.py
+++ b/tests/unit/experience/test_failures.py
@@ -1,0 +1,284 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the rollout failure taxonomy.
+
+The split these tests pin down is load-bearing: an infra failure re-dispatches the
+prompt onto another shard, a data failure does not. Misclassifying data as infra
+retries a doomed prompt; misclassifying infra as data fails a recoverable run.
+"""
+
+import asyncio
+
+import aiohttp
+import pytest
+import ray.exceptions
+from multidict import CIMultiDict, CIMultiDictProxy
+from ray import cloudpickle as ray_cloudpickle
+from yarl import URL
+
+from nemo_rl.environments.nemo_gym import _typed_gym_failure
+from nemo_rl.experience.failures import (
+    FailureClass,
+    GenerationUnavailable,
+    GymTransportError,
+    NoHealthyShards,
+    RolloutDataFailure,
+    RolloutFailure,
+    RolloutInfraFailure,
+    RolloutRedispatchExhausted,
+    RolloutStall,
+    RolloutTimeout,
+    classify_rollout_failure,
+    http_status_is_infra,
+)
+
+
+class ClientOSError(OSError):
+    """A look-alike for aiohttp's ClientOSError, used to exercise the name fallback.
+
+    Named exactly as aiohttp names it, because the fallback path matches on MRO class
+    name for environments where aiohttp cannot be imported. The shape matters too:
+    aiohttp's ClientOSError derives from OSError but *not* from ConnectionError, so an
+    isinstance-only table would miss it.
+    """
+
+
+def _response_error(status: int) -> aiohttp.ClientResponseError:
+    return aiohttp.ClientResponseError(
+        None, (), status=status, message=f"synthetic {status}"
+    )
+
+
+INFRA_CASES = [
+    pytest.param(RolloutInfraFailure("x"), id="infra-base"),
+    pytest.param(RolloutTimeout("x"), id="timeout"),
+    pytest.param(GenerationUnavailable("x"), id="generation-unavailable"),
+    pytest.param(NoHealthyShards("x"), id="no-healthy-shards"),
+    pytest.param(GymTransportError("x"), id="gym-transport"),
+    pytest.param(TimeoutError("x"), id="builtin-timeout"),
+    pytest.param(asyncio.TimeoutError("x"), id="asyncio-timeout"),
+    pytest.param(ConnectionRefusedError("x"), id="connection-refused"),
+    pytest.param(ConnectionResetError("x"), id="connection-reset"),
+    pytest.param(ray.exceptions.RayActorError(), id="ray-actor-error"),
+    pytest.param(ray.exceptions.ActorDiedError(), id="ray-actor-died"),
+    pytest.param(ray.exceptions.WorkerCrashedError(), id="ray-worker-crashed"),
+    pytest.param(ray.exceptions.LocalRayletDiedError(), id="ray-raylet-died"),
+    pytest.param(ray.exceptions.GetTimeoutError(), id="ray-get-timeout"),
+    pytest.param(ray.exceptions.RpcError("boom"), id="ray-rpc-error"),
+    pytest.param(ray.exceptions.NodeDiedError("boom"), id="ray-node-died"),
+    pytest.param(ClientOSError("x"), id="client-os-error-by-name-fallback"),
+    # Real aiohttp transport errors -- the ones a dying vLLM endpoint produces.
+    pytest.param(
+        aiohttp.ClientConnectorError(None, OSError("refused")),
+        id="aiohttp-connector-error",
+    ),
+    pytest.param(aiohttp.ServerDisconnectedError(), id="aiohttp-server-disconnected"),
+    pytest.param(aiohttp.ServerTimeoutError(), id="aiohttp-server-timeout"),
+    pytest.param(aiohttp.ClientPayloadError("truncated"), id="aiohttp-payload-error"),
+]
+
+DATA_CASES = [
+    pytest.param(RolloutDataFailure("x"), id="data-base"),
+    pytest.param(ValueError("prompt too long"), id="value-error"),
+    pytest.param(AssertionError("non-contiguous tokens"), id="assertion-error"),
+    pytest.param(KeyError("reward"), id="key-error"),
+    pytest.param(RuntimeError("generation logprobs contain NaN"), id="runtime-error"),
+]
+
+
+@pytest.mark.parametrize("exc", INFRA_CASES)
+def test_infra_exceptions_classify_as_infra(exc):
+    assert classify_rollout_failure(exc) is FailureClass.INFRA
+
+
+@pytest.mark.parametrize("exc", DATA_CASES)
+def test_unrecognized_and_data_exceptions_classify_as_data(exc):
+    assert classify_rollout_failure(exc) is FailureClass.DATA
+
+
+@pytest.mark.parametrize("status", [500, 502, 503, 504, 520, 408, 429])
+def test_server_side_and_retriable_http_statuses_are_infra(status):
+    assert classify_rollout_failure(_response_error(status)) is FailureClass.INFRA
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404, 413, 422])
+def test_client_side_http_statuses_are_data(status):
+    """A 4xx describes the request, so another shard would reject it identically.
+
+    The motivating case is real: vLLM answers an over-long prompt with
+    ``400 {"message": "This model's maximum context length is ..."}``. Re-dispatching
+    that burns the infra budget on a prompt no shard can serve.
+    """
+    assert classify_rollout_failure(_response_error(status)) is FailureClass.DATA
+
+
+def test_every_status_nemo_gym_retries_is_classified_infra():
+    """Stay consistent with NeMo-Gym's own retry set.
+
+    Gym retries RETRY_ERROR_CODES = [429, 502, 503, 504, 520] + [500] internally
+    (nemo_gym/openai_utils.py). Anything Gym considers worth retrying must not be
+    treated here as a permanent property of the prompt.
+    """
+    for status in (429, 500, 502, 503, 504, 520):
+        assert classify_rollout_failure(_response_error(status)) is FailureClass.INFRA
+
+
+def test_infra_cause_promotes_an_otherwise_unrecognized_exception():
+    """A wrapper around a dead actor is still an infrastructure failure."""
+    exc = RuntimeError("rollout failed")
+    exc.__cause__ = ray.exceptions.RayActorError()
+    assert classify_rollout_failure(exc) is FailureClass.INFRA
+
+
+def test_explicit_data_failure_wins_over_an_infra_cause():
+    """Callers that know a failure is prompt-specific must not be second-guessed.
+
+    A data failure can legitimately be raised while some infra error sits in the cause
+    chain (e.g. a shard hiccup surfaced as an empty generation that the prompt would
+    reproduce anyway). The explicit classification is authoritative.
+    """
+    exc = RolloutDataFailure("prompt exceeds max_model_len")
+    exc.__cause__ = ConnectionResetError("x")
+    assert classify_rollout_failure(exc) is FailureClass.DATA
+
+
+def test_cause_chain_is_walked_more_than_one_level():
+    outer = RuntimeError("outer")
+    middle = RuntimeError("middle")
+    middle.__cause__ = TimeoutError("inner")
+    outer.__cause__ = middle
+    assert classify_rollout_failure(outer) is FailureClass.INFRA
+
+
+def test_cyclic_cause_chain_terminates():
+    """A self-referential chain must not spin the classifier."""
+    a = RuntimeError("a")
+    b = RuntimeError("b")
+    a.__cause__ = b
+    b.__cause__ = a
+    assert classify_rollout_failure(a) is FailureClass.DATA
+
+
+def test_cause_chain_deeper_than_the_bound_terminates():
+    head = RuntimeError("0")
+    node = head
+    for i in range(1, 50):
+        nxt = RuntimeError(str(i))
+        node.__cause__ = nxt
+        node = nxt
+    # The infra marker sits past the bound, so it is not reached -- but the call must
+    # still return rather than walk 50 links.
+    node.__cause__ = TimeoutError("deep")
+    assert classify_rollout_failure(head) is FailureClass.DATA
+
+
+def test_context_is_not_followed():
+    """Only __cause__ (explicit `raise ... from`) counts, not incidental __context__.
+
+    __context__ is set by any exception raised inside an except block, so following it
+    would let an unrelated earlier error silently reclassify this one.
+    """
+    exc = ValueError("bad prompt")
+    exc.__context__ = ray.exceptions.RayActorError()
+    assert classify_rollout_failure(exc) is FailureClass.DATA
+
+
+def test_redispatch_exhausted_is_not_catchable_as_a_rollout_failure():
+    """The per-attempt retry loop catches RolloutFailure; this must escape it."""
+    assert not issubclass(RolloutRedispatchExhausted, RolloutFailure)
+    assert not issubclass(RolloutStall, RolloutFailure)
+
+
+def test_infra_and_data_are_disjoint_branches_of_one_base():
+    assert issubclass(RolloutInfraFailure, RolloutFailure)
+    assert issubclass(RolloutDataFailure, RolloutFailure)
+    assert not issubclass(RolloutInfraFailure, RolloutDataFailure)
+    assert not issubclass(RolloutDataFailure, RolloutInfraFailure)
+
+
+class TestTheRayActorBoundary:
+    """The Ray actor boundary is where classification information goes to die.
+
+    Every NeMo-Gym HTTP failure is raised inside the ``NemoGym`` actor and has to cross
+    back to the driver to reach the retry policy. ``_response_error`` above -- and every
+    other case in this file -- builds a *headerless* ``ClientResponseError``, which
+    pickles cleanly. Production never produces that shape: aiohttp's
+    ``raise_for_status`` passes ``headers=self.headers``, a ``CIMultiDictProxy``, which
+    cloudpickle cannot serialize. Ray then drops the cause and the driver receives a bare
+    error carrying neither type nor ``.status`` -- so the status split below classified
+    every gym failure DATA, capping the gym path at 2 attempts and leaving the 5-attempt
+    infra budget unreachable on the path it was built for.
+
+    These pin the real shape so that cannot silently come back.
+    """
+
+    @staticmethod
+    def _realistic_response_error(status: int) -> aiohttp.ClientResponseError:
+        """Built the way aiohttp's ``raise_for_status`` builds it -- with real headers."""
+        headers = CIMultiDictProxy(CIMultiDict({"Content-Type": "application/json"}))
+        request_info = aiohttp.RequestInfo(
+            URL("http://gym/run"), "POST", headers, URL("http://gym")
+        )
+        return aiohttp.ClientResponseError(
+            request_info,
+            (),
+            status=status,
+            message=f"synthetic {status}",
+            headers=headers,
+        )
+
+    def test_the_realistic_error_cannot_survive_pickling(self):
+        """The premise of the fix. If this ever passes, _typed_gym_failure is dead weight."""
+        with pytest.raises(Exception):
+            ray_cloudpickle.dumps(self._realistic_response_error(503))
+
+    def test_the_headerless_shape_pickles_which_is_why_the_other_tests_missed_this(
+        self,
+    ):
+        ray_cloudpickle.dumps(_response_error(503))
+
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [
+            (500, FailureClass.INFRA),  # what Gym's middleware turns inner errors into
+            (503, FailureClass.INFRA),
+            (408, FailureClass.INFRA),
+            (429, FailureClass.INFRA),
+            (400, FailureClass.DATA),  # context-length overflow and friends
+            (404, FailureClass.DATA),
+        ],
+    )
+    def test_what_nemo_gym_raises_survives_the_boundary_and_still_classifies(
+        self, status, expected
+    ):
+        typed = _typed_gym_failure(self._realistic_response_error(status))
+        assert typed is not None, f"HTTP {status} should have been classified at source"
+        # The boundary itself.
+        restored = ray_cloudpickle.loads(ray_cloudpickle.dumps(typed))
+        assert classify_rollout_failure(restored) is expected
+        assert str(status) in str(restored), "the status must survive for the operator"
+
+    def test_an_exception_without_a_status_is_left_untouched(self):
+        """No status means no HTTP verdict to make; the caller re-raises as-is."""
+        assert _typed_gym_failure(RuntimeError("not an HTTP failure")) is None
+
+    def test_both_sides_of_the_boundary_share_one_status_policy(self):
+        """nemo_gym classifies at source, failures.py on the driver -- one rule, not two."""
+        for status in (400, 404, 408, 429, 500, 503):
+            at_source = isinstance(
+                _typed_gym_failure(self._realistic_response_error(status)),
+                GymTransportError,
+            )
+            assert at_source is http_status_is_infra(status)

--- a/tests/unit/experience/test_finalizer_actor.py
+++ b/tests/unit/experience/test_finalizer_actor.py
@@ -30,6 +30,7 @@ def _request() -> FinalizationRequest:
     return FinalizationRequest(
         group_id="group",
         rollout_ids=("group_g0",),
+        canonical_sample_ids=("group_g0",),
         receipts=(
             {
                 "rollout_id": "group_g0",

--- a/tests/unit/experience/test_rollout_generation_failures.py
+++ b/tests/unit/experience/test_rollout_generation_failures.py
@@ -1,0 +1,804 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generation failures on the native GRPO rollout path must never reach training.
+
+The regression these tests guard is subtle and silent. `_run_single_rollout` used to
+catch every exception from `_generate_response`, print it, and `break` out of the turn
+loop. Execution then fell through to build a Completion holding only the prompt, with
+`reward=0.0`, which `generate_and_push` committed as a training row.
+
+It did not even crash downstream: `add_grpo_token_loss_masks_and_generation_logprobs`
+zero-fills a missing `generation_logprobs` and sets `token_loss_mask=0`, so the row is
+well formed. It contributes no gradient -- but its zero reward *does* enter the
+per-prompt GRPO baseline, so with `use_leave_one_out_baseline` one dead vLLM worker
+silently shifts the advantage of every sibling in the group.
+"""
+
+import asyncio
+import uuid
+
+import pytest
+import ray.exceptions
+import torch
+
+from nemo_rl.environments.interfaces import EnvironmentReturn
+from nemo_rl.experience.failures import (
+    FailureClass,
+    GenerationUnavailable,
+    GymTransportError,
+    RolloutDataFailure,
+    RolloutFailure,
+    RolloutRedispatchExhausted,
+    RolloutTimeout,
+    classify_rollout_failure,
+)
+from nemo_rl.experience.rollout_manager import (
+    AsyncRolloutImpl,
+    RolloutManager,
+    RolloutRetryPolicy,
+    RolloutStats,
+    RolloutTimeouts,
+    _classify_generation_failure,
+    _Deadline,
+    _gather_cancelling_siblings,
+)
+from nemo_rl.utils.timer import Timer
+
+
+@pytest.fixture
+def terminating_env(monkeypatch):
+    """Make calculate_rewards return a terminated, zero-reward step.
+
+    Lets the success-path tests exercise a whole rollout turn without standing up a
+    real environment actor.
+    """
+
+    def _fake(sample_batch, task_to_env):
+        del sample_batch, task_to_env
+        return EnvironmentReturn(
+            observations=[{"role": "environment", "content": ""}],
+            metadata=[None],
+            next_stop_strings=[None],
+            rewards=torch.tensor([0.0]),
+            terminateds=torch.tensor([True]),
+            answers=[None],
+        )
+
+    monkeypatch.setattr(
+        "nemo_rl.experience.rollout_manager.calculate_rewards", _fake, raising=True
+    )
+    return _fake
+
+
+class _TokenizedText:
+    def __init__(self, input_ids: torch.Tensor) -> None:
+        self.input_ids = input_ids
+
+
+class _FakeTokenizer:
+    def decode(self, ids, skip_special_tokens=True):
+        del skip_special_tokens
+        return f"<{len(ids)} tokens>"
+
+    def __call__(self, text, return_tensors=None, add_special_tokens=True):
+        """Tokenize an environment observation to one id per character."""
+        del return_tensors, add_special_tokens
+        return _TokenizedText(torch.tensor([[7] * len(text)], dtype=torch.long))
+
+
+class _FakeGeneration:
+    """Generation stub whose behaviour is chosen per call.
+
+    `behaviours` is consumed in call order; each entry is either an exception to raise
+    or the string "hang" / "ok".
+    """
+
+    def __init__(self, behaviours):
+        self._behaviours = list(behaviours)
+        self.calls = 0
+        self.cancelled = 0
+
+    async def generate_async(self, data):
+        del data
+        index = min(self.calls, len(self._behaviours) - 1)
+        behaviour = self._behaviours[index]
+        self.calls += 1
+
+        if isinstance(behaviour, BaseException):
+            raise behaviour
+        if behaviour == "hang":
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                self.cancelled += 1
+                raise
+        if behaviour == "slow":
+            await asyncio.sleep(0.05)
+        yield (
+            0,
+            {
+                "output_ids": torch.tensor([[1, 2, 3, 4]]),
+                "unpadded_sequence_lengths": torch.tensor([4]),
+            },
+        )
+
+
+def _make_impl(
+    generation, *, num_generations=1, max_turns=1, timeouts=None
+) -> AsyncRolloutImpl:
+    """Build an AsyncRolloutImpl without firing its real __init__."""
+    impl = object.__new__(AsyncRolloutImpl)
+    impl._tokenizer = _FakeTokenizer()
+    impl._task_to_env = {}
+    impl._num_generations_per_prompt = num_generations
+    impl._max_seq_len = 128
+    impl._max_rollout_turns = max_turns
+    impl._policy_generation = generation
+    impl._timeouts = timeouts if timeouts is not None else RolloutTimeouts()
+    return impl
+
+
+def _sample(idx=7):
+    return {
+        "idx": idx,
+        "message_log": [
+            {"role": "user", "content": "hi", "token_ids": torch.tensor([1, 2])}
+        ],
+        "extra_env_info": {},
+        "task_name": "calc",
+        "stop_strings": None,
+    }
+
+
+def _make_manager(buffer, impl, retry_policy=None) -> RolloutManager:
+    """Build a RolloutManager without firing the real __init__."""
+    manager = object.__new__(RolloutManager)
+    manager._impl = impl
+    manager._tokenizer = None
+    manager._num_generations_per_prompt = 1
+    manager._tq_buffer = buffer
+    manager._weight_version = 0
+    manager._retry_policy = (
+        retry_policy
+        if retry_policy is not None
+        else RolloutRetryPolicy.single_attempt()
+    )
+    manager._stats = RolloutStats()
+    manager._skipped_prompts = 0
+    return manager
+
+
+class _RecordingBuffer:
+    """TQReplayBuffer stand-in that records whether anything was ever committed."""
+
+    def __init__(self) -> None:
+        self.commits: list[str] = []
+        self.removals: list[str] = []
+
+    def reserve(self, *, weight_version, target_step=None, group_id=None) -> str:
+        del weight_version, target_step
+        return group_id or str(uuid.uuid4())
+
+    async def commit(self, group_id, record, start_weight_version, end_weight_version):
+        del start_weight_version, end_weight_version
+        self.commits.append(group_id)
+        return record
+
+    async def remove_group(self, group_id, *, remove_in_dp: bool = False) -> int:
+        del remove_in_dp
+        self.removals.append(group_id)
+        return 1
+
+
+class TestGenerationFailureIsClassifiedAndRaised:
+    def test_dead_worker_becomes_generation_unavailable(self):
+        impl = _make_impl(_FakeGeneration([ray.exceptions.RayActorError()]))
+        with pytest.raises(GenerationUnavailable) as excinfo:
+            asyncio.run(impl._run_single_rollout(_sample(), traj_idx=3))
+        assert isinstance(excinfo.value.__cause__, ray.exceptions.RayActorError)
+
+    def test_failure_message_names_the_prompt_and_trajectory(self):
+        impl = _make_impl(_FakeGeneration([ray.exceptions.RayActorError()]))
+        with pytest.raises(GenerationUnavailable, match=r"prompt_idx=7 traj_idx=3"):
+            asyncio.run(impl._run_single_rollout(_sample(idx=7), traj_idx=3))
+
+    def test_deterministic_error_becomes_a_data_failure(self):
+        impl = _make_impl(_FakeGeneration([ValueError("prompt too long")]))
+        with pytest.raises(RolloutDataFailure) as excinfo:
+            asyncio.run(impl._run_single_rollout(_sample(), traj_idx=0))
+        assert isinstance(excinfo.value.__cause__, ValueError)
+
+    def test_cancellation_is_not_reclassified_as_a_rollout_failure(self):
+        """CancelledError derives from BaseException, so `except Exception` must miss it.
+
+        Reclassifying it would turn a shutdown into a data failure and, once retries
+        exist, retry a rollout the controller is deliberately tearing down.
+        """
+        impl = _make_impl(_FakeGeneration([asyncio.CancelledError()]))
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(impl._run_single_rollout(_sample(), traj_idx=0))
+
+
+class TestNoPartialCompletionSurvives:
+    def test_run_rollout_raises_instead_of_returning_a_zero_reward_record(self):
+        """The core regression guard: a failed generation yields no record at all."""
+        impl = _make_impl(_FakeGeneration([ray.exceptions.RayActorError()]))
+        with pytest.raises(RolloutFailure):
+            asyncio.run(impl.run_rollout(_sample()))
+
+    def test_generate_and_push_never_commits_a_failed_rollout(self):
+        """End of the chain: nothing reaches the replay buffer, so nothing reaches training."""
+        buffer = _RecordingBuffer()
+        impl = _make_impl(_FakeGeneration([ray.exceptions.RayActorError()]))
+
+        manager = _make_manager(buffer, impl)
+
+        # A dead worker is an infra failure, so the single-attempt default budget is
+        # exhausted immediately and surfaces as RolloutRedispatchExhausted.
+        with pytest.raises(RolloutRedispatchExhausted):
+            asyncio.run(manager.generate_and_push(_sample()))
+
+        assert buffer.commits == [], "a failed generation must not be committed"
+        assert len(buffer.removals) == 1, "the reserved slot must be released"
+
+
+class TestSiblingCancellation:
+    def test_one_failure_cancels_the_other_generations_in_the_group(self):
+        """Siblings must not keep occupying generation capacity for a discarded group.
+
+        asyncio.gather propagates the first exception but leaves the rest running
+        detached; on this path that means N-1 generations still queued against the
+        fleet for a prompt whose result is already being thrown away.
+        """
+        # First call fails, every later call hangs until cancelled.
+        generation = _FakeGeneration([ray.exceptions.RayActorError(), "hang"])
+        impl = _make_impl(generation, num_generations=4)
+
+        with pytest.raises(RolloutFailure):
+            asyncio.run(impl.run_rollout(_sample()))
+
+        assert generation.calls == 4, "all four generations should have started"
+        assert generation.cancelled == 3, (
+            "the three surviving siblings must be cancelled"
+        )
+
+
+class TestGatherCancellingSiblings:
+    def test_returns_results_in_input_order(self):
+        async def _value(i):
+            await asyncio.sleep((5 - i) * 0.001)
+            return i
+
+        result = asyncio.run(
+            _gather_cancelling_siblings([_value(0), _value(1), _value(2)])
+        )
+        assert result == [0, 1, 2]
+
+    def test_propagates_the_original_exception_type(self):
+        async def _boom():
+            raise ray.exceptions.RayActorError()
+
+        async def _hang():
+            await asyncio.Event().wait()
+
+        with pytest.raises(ray.exceptions.RayActorError):
+            asyncio.run(_gather_cancelling_siblings([_boom(), _hang()]))
+
+    def test_drains_cancelled_siblings_before_unwinding(self):
+        """The helper must not leave tasks pending when it returns control."""
+        started = []
+        finished = []
+
+        async def _boom():
+            await asyncio.sleep(0.01)
+            raise ValueError("x")
+
+        async def _slow():
+            started.append(1)
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                finished.append(1)
+                raise
+
+        async def _main():
+            with pytest.raises(ValueError):
+                await _gather_cancelling_siblings([_boom(), _slow()])
+            # If the helper returned before draining, this would still be 0.
+            assert finished == [1]
+            assert not [
+                t for t in asyncio.all_tasks() if t is not asyncio.current_task()
+            ]
+
+        asyncio.run(_main())
+
+
+class TestGenerationDeadline:
+    def test_a_hung_generation_raises_rollout_timeout(self):
+        """The wedge this exists to prevent: a generation that never returns."""
+        impl = _make_impl(
+            _FakeGeneration(["hang"]),
+            timeouts=RolloutTimeouts(generation_s=0.05),
+        )
+        with pytest.raises(GenerationUnavailable) as excinfo:
+            asyncio.run(impl._run_single_rollout(_sample(), traj_idx=0))
+        # Classified as infra, so the retry policy will re-dispatch it.
+        assert isinstance(excinfo.value.__cause__, RolloutTimeout)
+
+    def test_the_hung_generation_is_cancelled_not_abandoned(self):
+        generation = _FakeGeneration(["hang"])
+        impl = _make_impl(generation, timeouts=RolloutTimeouts(generation_s=0.05))
+        with pytest.raises(GenerationUnavailable):
+            asyncio.run(impl._run_single_rollout(_sample(), traj_idx=0))
+        assert generation.cancelled == 1
+
+    def test_no_deadline_configured_means_no_timeout(self, terminating_env):
+        """Default config must behave exactly as before: wait indefinitely."""
+        impl = _make_impl(
+            _FakeGeneration(["slow"]), timeouts=RolloutTimeouts(generation_s=None)
+        )
+        completion, _ = asyncio.run(impl._run_single_rollout(_sample(), traj_idx=0))
+        assert completion.reward == 0.0
+
+    def test_slow_but_healthy_generation_does_not_trip_the_deadline(
+        self, terminating_env
+    ):
+        """Guards against over-tightening: a slow success must still succeed."""
+        impl = _make_impl(
+            _FakeGeneration(["slow"]), timeouts=RolloutTimeouts(generation_s=5.0)
+        )
+        completion, metrics = asyncio.run(
+            impl._run_single_rollout(_sample(), traj_idx=0)
+        )
+        assert metrics["turn_count"] == 1
+        assert any(m["role"] == "assistant" for m in completion.message_log)
+
+    def test_the_environment_step_has_its_own_deadline(self, monkeypatch):
+        """A hung env actor leaks a rollout permit exactly like a hung generation.
+
+        The sleep is deliberately short. calculate_rewards runs under asyncio.to_thread
+        and Python cannot kill a running thread, so the deadline frees the rollout while
+        the thread keeps its pool slot -- and asyncio.run waits for the default executor
+        on the way out. A long sleep here would stall the test for exactly that reason,
+        which is itself the documented caveat.
+        """
+
+        def _hang(sample_batch, task_to_env):
+            del sample_batch, task_to_env
+            import time
+
+            time.sleep(1.0)
+
+        monkeypatch.setattr(
+            "nemo_rl.experience.rollout_manager.calculate_rewards", _hang, raising=True
+        )
+        impl = _make_impl(_FakeGeneration(["ok"]), timeouts=RolloutTimeouts(env_s=0.05))
+        with pytest.raises(RolloutTimeout, match="environment step"):
+            asyncio.run(impl._run_single_rollout(_sample(), traj_idx=0))
+
+
+class TestDeadlineHelper:
+    def test_expiry_is_reported_as_rollout_timeout(self):
+        async def _main():
+            async with _Deadline(0.01, "unit under test"):
+                await asyncio.sleep(10)
+
+        with pytest.raises(RolloutTimeout, match="unit under test exceeded 0.01s"):
+            asyncio.run(_main())
+
+    def test_an_inner_timeout_error_is_not_relabelled(self):
+        """A TimeoutError from the wrapped code must not read as a deadline breach.
+
+        Otherwise a genuine downstream timeout would be reported with our deadline's
+        duration, sending anyone debugging it to the wrong knob.
+        """
+
+        async def _main():
+            async with _Deadline(30.0, "unit under test"):
+                raise TimeoutError("something downstream timed out")
+
+        with pytest.raises(TimeoutError) as excinfo:
+            asyncio.run(_main())
+        assert not isinstance(excinfo.value, RolloutTimeout)
+
+    def test_none_disables_the_deadline(self):
+        async def _main():
+            async with _Deadline(None, "unit under test"):
+                await asyncio.sleep(0.01)
+            return "completed"
+
+        assert asyncio.run(_main()) == "completed"
+
+    def test_outer_cancellation_still_propagates_as_cancellation(self):
+        """Tearing down the controller must not look like a rollout timeout."""
+
+        async def _main():
+            async def _body():
+                async with _Deadline(30.0, "unit under test"):
+                    await asyncio.Event().wait()
+
+            task = asyncio.ensure_future(_body())
+            await asyncio.sleep(0.01)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        asyncio.run(_main())
+
+
+def _gym_rows(count: int) -> list[dict]:
+    """Rows shaped the way _build_inputs stamps them: each carries its own index."""
+    return [{"_rowidx": i, "agent_ref": {"name": "agent"}} for i in range(count)]
+
+
+class _PartialGymMethod:
+    """Gym stream that fails partway through, then succeeds on re-dispatch.
+
+    Reproduces the shape that matters: NeMo-Gym's stream dies on its first failing row,
+    so every later row is lost with it even though nothing was wrong with them.
+    """
+
+    def __init__(self, fail_after_rows: int, failures_before_success: int) -> None:
+        self._fail_after_rows = fail_after_rows
+        self._failures_before_success = failures_before_success
+        self.attempts = 0
+        self.dispatched: list[list[int]] = []
+
+    def options(self, **kwargs):
+        del kwargs
+        return self
+
+    def remote(self, inputs, tokenizer, timer_prefix):
+        del tokenizer, timer_prefix
+        self.dispatched.append([row["_rowidx"] for row in inputs])
+        attempt = self.attempts
+        self.attempts += 1
+        return self._stream(inputs, attempt)
+
+    async def _stream(self, inputs, attempt):
+        should_fail = attempt < self._failures_before_success
+        for position, row in enumerate(inputs):
+            if should_fail and position >= self._fail_after_rows:
+                raise ConnectionResetError("gym stream died mid-flight")
+            yield _row_result(row["_rowidx"])
+
+
+async def _row_result(rowidx: int):
+    """A minimally complete NeMo-Gym result, enough to build a Completion."""
+    return (
+        rowidx,
+        {
+            "input_message_log": [{"role": "user", "token_ids": [1]}],
+            "message_log": [{"role": "assistant", "token_ids": [2]}],
+            "full_result": {"reward": 1.0},
+        },
+        None,
+    )
+
+
+class _FakeGymMethod:
+    """Mimics `env.run_rollouts.options(...).remote(...)` returning a result stream."""
+
+    def __init__(self, rows_to_yield, hang_after) -> None:
+        self._rows_to_yield = rows_to_yield
+        self._hang_after = hang_after
+        self.cancelled = 0
+
+    def options(self, **kwargs):
+        del kwargs
+        return self
+
+    def remote(self, inputs, tokenizer, timer_prefix):
+        del tokenizer, timer_prefix
+        return self._stream(len(inputs))
+
+    async def _stream(self, num_inputs):
+        async def _result(rowidx):
+            return rowidx, {"input_message_log": [], "message_log": []}, None
+
+        for rowidx in range(min(self._rows_to_yield, num_inputs)):
+            yield _result(rowidx)
+        if self._hang_after:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                self.cancelled += 1
+                raise
+
+
+def _make_gym_impl(
+    gym_method, *, num_generations=2, timeouts=None, row_attempts=1, stats=None
+):
+    from nemo_rl.experience.rollout_manager import AsyncNemoGymRolloutImpl
+
+    impl = object.__new__(AsyncNemoGymRolloutImpl)
+    impl._tokenizer = _FakeTokenizer()
+    impl._task_to_env = {"nemo_gym": type("Env", (), {"run_rollouts": gym_method})()}
+    impl._num_generations_per_prompt = num_generations
+    impl._max_seq_len = 128
+    impl._max_rollout_turns = 1
+    impl._timeouts = timeouts if timeouts is not None else RolloutTimeouts()
+    impl._max_gym_row_attempts = row_attempts
+    # Real counters by default so row-level re-dispatches are observable; production
+    # shares the owning RolloutManager's instance.
+    impl._stats = stats if stats is not None else RolloutStats()
+    # Upstream default; this fixture is about re-dispatch, not sample masking.
+    impl._mask_env_flagged_samples = True
+    return impl
+
+
+class TestGymRolloutDeadline:
+    """The gym path is where the silent wedge described in the resiliency report lives.
+
+    NeMo-Gym retries a dead vLLM endpoint forever with no HTTP timeout, so without a
+    deadline here the rollout never returns and permanently holds a
+    max_inflight_prompts permit.
+    """
+
+    def test_a_hung_gym_stream_raises_rollout_timeout(self):
+        method = _FakeGymMethod(rows_to_yield=0, hang_after=True)
+        impl = _make_gym_impl(method, timeouts=RolloutTimeouts(rollout_s=0.05))
+        with pytest.raises(RolloutTimeout, match="NeMo-Gym prompt group"):
+            asyncio.run(impl._run_rollouts(_gym_rows(2), Timer(), "timing/rollout"))
+        assert method.cancelled == 1, "the hung stream must be cancelled"
+
+    def test_the_deadline_spans_the_whole_stream_not_each_row(self):
+        """A steady drip of fast rows must not keep resetting the budget.
+
+        One slow row holding the group up is exactly the case that has to fire, and a
+        per-await deadline would never see it.
+        """
+        method = _FakeGymMethod(rows_to_yield=1, hang_after=True)
+        impl = _make_gym_impl(method, timeouts=RolloutTimeouts(rollout_s=0.05))
+        with pytest.raises(RolloutTimeout):
+            asyncio.run(impl._run_rollouts(_gym_rows(2), Timer(), "timing/rollout"))
+
+    def test_a_truncated_stream_is_an_infra_failure_not_a_bare_runtime_error(self):
+        """Rows going missing is a transport problem, so it must be retriable."""
+        method = _FakeGymMethod(rows_to_yield=1, hang_after=False)
+        impl = _make_gym_impl(method)
+        with pytest.raises(GymTransportError, match=r"missing rows \[1\] of 2"):
+            asyncio.run(impl._run_rollouts(_gym_rows(2), Timer(), "timing/rollout"))
+
+    def test_no_deadline_configured_leaves_the_stream_unbounded(self):
+        """Default config must not introduce a deadline where there was none."""
+        method = _FakeGymMethod(rows_to_yield=1, hang_after=False)
+        impl = _make_gym_impl(method, timeouts=RolloutTimeouts(rollout_s=None))
+        # Reaches the missing-rows check rather than timing out first.
+        with pytest.raises(GymTransportError):
+            asyncio.run(impl._run_rollouts(_gym_rows(2), Timer(), "timing/rollout"))
+
+
+class TestPartialGymRedispatch:
+    """Only the rows that never arrived are re-sent.
+
+    At num_generations_per_prompt=16, one bad row killing the stream costs 16
+    regenerations if the whole group is redone. It should cost the rows that were lost.
+    """
+
+    def test_only_the_missing_rows_are_re_dispatched(self):
+        # Rows 0-1 land, then the stream dies; the retry should carry rows 2-3 only.
+        method = _PartialGymMethod(fail_after_rows=2, failures_before_success=1)
+        impl = _make_gym_impl(method, num_generations=4, row_attempts=3)
+
+        completions, _, _ = asyncio.run(
+            impl._run_rollouts(_gym_rows(4), Timer(), "timing/rollout")
+        )
+
+        assert method.dispatched == [[0, 1, 2, 3], [2, 3]]
+        assert len(completions) == 4
+
+    def test_completed_rows_survive_across_attempts(self):
+        """The point of the exercise: work already done is not thrown away.
+
+        Attempt 1 lands rows 0-2 before the stream dies. Only 3-4 are re-sent, and the
+        group finishes there -- 7 row-generations instead of the 10 a whole-group retry
+        would have cost.
+        """
+        method = _PartialGymMethod(fail_after_rows=3, failures_before_success=2)
+        impl = _make_gym_impl(method, num_generations=5, row_attempts=3)
+
+        completions, _, _ = asyncio.run(
+            impl._run_rollouts(_gym_rows(5), Timer(), "timing/rollout")
+        )
+
+        assert method.dispatched == [[0, 1, 2, 3, 4], [3, 4]]
+        assert len(completions) == 5
+        assert sum(len(d) for d in method.dispatched) == 7
+
+    def test_a_stale_echo_of_a_landed_row_is_rejected(self):
+        """Re-dispatch narrows the stream; an echo of an already-landed row must not win.
+
+        Attempt 1 lands row 0 then dies. Attempt 2 carries only the rows that never
+        arrived, so a stream replaying row 0 is echoing stale work -- and silently
+        accepting it would overwrite a good result with an older one. This guard had no
+        test at all: deleting the two lines it lives in left the suite green.
+        """
+
+        class _EchoingMethod(_PartialGymMethod):
+            def __init__(self) -> None:
+                super().__init__(fail_after_rows=1, failures_before_success=1)
+
+            async def _stream(self, inputs, attempt):
+                if attempt == 0:
+                    yield _row_result(0)
+                    raise ConnectionResetError("stream died after row 0")
+                # Handed rows 1..n-1, but answers with row 0 all the same.
+                yield _row_result(0)
+
+        impl = _make_gym_impl(_EchoingMethod(), num_generations=3, row_attempts=3)
+
+        with pytest.raises(ValueError, match="which was not dispatched"):
+            asyncio.run(impl._run_rollouts(_gym_rows(3), Timer(), "timing/rollout"))
+
+    def test_row_redispatches_are_counted(self):
+        """Otherwise gym retries rows all run with every visible counter flat."""
+        stats = RolloutStats()
+        method = _PartialGymMethod(fail_after_rows=2, failures_before_success=1)
+        impl = _make_gym_impl(method, num_generations=4, row_attempts=3, stats=stats)
+
+        asyncio.run(impl._run_rollouts(_gym_rows(4), Timer(), "timing/rollout"))
+
+        # Attempt 2 re-sent exactly the two rows that never arrived.
+        assert method.dispatched == [[0, 1, 2, 3], [2, 3]]
+        assert stats.gym_row_redispatches == 2
+        assert stats.as_metrics()["rollout/gym_row_redispatch_total"] == 2.0
+
+    def test_the_transport_error_that_lost_the_rows_is_chained(self):
+        """A short-but-clean final stream otherwise reports missing rows with no cause.
+
+        Attempt 1 dies with a transport error; attempt 2 ends cleanly without supplying
+        the rest. Without the chain the operator reads "rows missing" at exactly the
+        moment they need to know why.
+        """
+
+        class _ShortSecondAttempt(_PartialGymMethod):
+            def __init__(self) -> None:
+                super().__init__(fail_after_rows=1, failures_before_success=1)
+
+            async def _stream(self, inputs, attempt):
+                if attempt == 0:
+                    yield _row_result(0)
+                    raise ConnectionResetError("the transport error to blame")
+                return
+                yield  # unreachable; keeps this an async generator
+
+        impl = _make_gym_impl(_ShortSecondAttempt(), num_generations=3, row_attempts=2)
+
+        with pytest.raises(GymTransportError) as exc_info:
+            asyncio.run(impl._run_rollouts(_gym_rows(3), Timer(), "timing/rollout"))
+        cause = exc_info.value.__cause__
+        assert isinstance(cause, ConnectionResetError)
+        assert "the transport error to blame" in str(cause)
+
+    def test_exhausting_the_row_budget_reports_a_transport_failure(self):
+        method = _PartialGymMethod(fail_after_rows=1, failures_before_success=99)
+        impl = _make_gym_impl(method, num_generations=4, row_attempts=2)
+
+        with pytest.raises(ConnectionResetError):
+            asyncio.run(impl._run_rollouts(_gym_rows(4), Timer(), "timing/rollout"))
+        assert method.attempts == 2, "the budget bounds the re-dispatches"
+
+    def test_a_data_failure_is_not_re_dispatched(self):
+        """Another dispatch cannot help a prompt NeMo-Gym is unable to serve."""
+
+        class _DataFailingMethod(_PartialGymMethod):
+            async def _stream(self, inputs, attempt):
+                del attempt
+                yield _row_result(inputs[0]["_rowidx"])
+                raise ValueError("NeMo Gym returned a result with no generation data")
+
+        method = _DataFailingMethod(fail_after_rows=1, failures_before_success=99)
+        impl = _make_gym_impl(method, num_generations=4, row_attempts=5)
+
+        with pytest.raises(ValueError, match="no generation data"):
+            asyncio.run(impl._run_rollouts(_gym_rows(4), Timer(), "timing/rollout"))
+        assert method.attempts == 1, "a deterministic failure must not be retried"
+
+    def test_a_single_attempt_budget_reproduces_the_old_behaviour(self):
+        method = _PartialGymMethod(fail_after_rows=2, failures_before_success=1)
+        impl = _make_gym_impl(method, num_generations=4, row_attempts=1)
+
+        with pytest.raises(ConnectionResetError):
+            asyncio.run(impl._run_rollouts(_gym_rows(4), Timer(), "timing/rollout"))
+        assert method.attempts == 1
+
+    def test_rows_must_carry_their_own_index(self):
+        """Re-dispatch maps Gym's echoed _rowidx back onto the group, so this is a contract."""
+        method = _PartialGymMethod(fail_after_rows=99, failures_before_success=0)
+        impl = _make_gym_impl(method, num_generations=2, row_attempts=2)
+
+        with pytest.raises(ValueError, match="must be stamped with their own position"):
+            asyncio.run(
+                impl._run_rollouts(
+                    [{"agent_ref": {"name": "a"}}], Timer(), "timing/rollout"
+                )
+            )
+
+    def test_the_group_deadline_spans_re_dispatches(self):
+        """The budget belongs to the prompt group, not to each attempt.
+
+        Otherwise N attempts silently multiply rollout_timeout_s by N.
+        """
+
+        class _SlowThenHang(_PartialGymMethod):
+            async def _stream(self, inputs, attempt):
+                if attempt == 0:
+                    yield _row_result(inputs[0]["_rowidx"])
+                    raise ConnectionResetError("died")
+                await asyncio.Event().wait()
+                yield _row_result(inputs[0]["_rowidx"])  # pragma: no cover
+
+        method = _SlowThenHang(fail_after_rows=1, failures_before_success=1)
+        impl = _make_gym_impl(
+            method,
+            num_generations=2,
+            row_attempts=5,
+            timeouts=RolloutTimeouts(rollout_s=0.1),
+        )
+        with pytest.raises(RolloutTimeout, match="NeMo-Gym prompt group"):
+            asyncio.run(impl._run_rollouts(_gym_rows(2), Timer(), "timing/rollout"))
+
+
+class TestClassifyGenerationFailure:
+    def test_infra_maps_to_generation_unavailable(self):
+        out = _classify_generation_failure(
+            ConnectionResetError("x"), prompt_idx=1, traj_idx=2
+        )
+        assert isinstance(out, GenerationUnavailable)
+
+    def test_data_maps_to_rollout_data_failure(self):
+        out = _classify_generation_failure(
+            AssertionError("non-contiguous"), prompt_idx=1, traj_idx=2
+        )
+        assert isinstance(out, RolloutDataFailure)
+
+    @pytest.mark.parametrize(
+        "cause",
+        [
+            RuntimeError("EngineDeadError"),  # vLLM, worker still alive
+            RuntimeError("CUDA out of memory"),
+            ValueError("something we have never seen"),
+        ],
+    )
+    def test_a_ray_boundary_error_from_generation_is_infrastructure(self, cause):
+        """The boundary destroys the cause, so classify by the call site instead.
+
+        An exception raised inside a still-LIVING generation worker arrives as a bare
+        RayTaskError -- not a RayActorError, and not in _INFRA_TYPES -- so the generic
+        classifier can only fall through to DATA, and the prompt got 2 attempts instead
+        of the 5 the fleet-failure path exists for.
+
+        Scoped to this call site on purpose: globally, unrecognized-means-DATA is still
+        the right default. Here we know the RPC was a generation, so "that shard could
+        not serve it" is the correct reading whatever the cause was.
+        """
+        exc = ray.exceptions.RayTaskError("gen", "traceback", cause)
+        out = _classify_generation_failure(exc, prompt_idx=1, traj_idx=2)
+        assert isinstance(out, GenerationUnavailable)
+        assert classify_rollout_failure(out) is FailureClass.INFRA
+
+    def test_a_plain_data_error_is_still_data(self):
+        """The widening is Ray-boundary-only; ordinary bad prompts are unaffected."""
+        out = _classify_generation_failure(
+            ValueError("token ids are not contiguous"), prompt_idx=1, traj_idx=2
+        )
+        assert isinstance(out, RolloutDataFailure)
+        assert classify_rollout_failure(out) is FailureClass.DATA
+
+    def test_both_branches_are_rollout_failures(self):
+        for exc in (ConnectionResetError("x"), AssertionError("y")):
+            out = _classify_generation_failure(exc, prompt_idx=0, traj_idx=0)
+            assert isinstance(out, RolloutFailure)

--- a/tests/unit/experience/test_rollout_manager.py
+++ b/tests/unit/experience/test_rollout_manager.py
@@ -38,6 +38,7 @@ from nemo_rl.data.datasets.response_datasets import NemoGymDataset
 from nemo_rl.data.interfaces import DatumSpec
 from nemo_rl.data.processors import nemo_gym_data_processor
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.experience.failures import GenerationUnavailable
 from nemo_rl.experience.interfaces import Completion, PromptGroupRecord
 from nemo_rl.experience.rollout_manager import (
     AsyncNemoGymRolloutImpl,
@@ -45,6 +46,7 @@ from nemo_rl.experience.rollout_manager import (
     RolloutRetryPolicy,
     RolloutStats,
 )
+from nemo_rl.experience.rollout_recovery import RolloutRecoveryLedger
 from nemo_rl.experience.rollouts import (
     run_async_multi_turn_rollout,
     run_async_nemo_gym_rollout,
@@ -150,7 +152,6 @@ def _make_manager(
     mgr._tokenizer = None
     mgr._num_generations_per_prompt = 1
     mgr._tq_buffer = buffer
-    mgr._env_handles = {}
     mgr._weight_version = 0
     mgr._retry_policy = (
         retry_policy
@@ -1016,6 +1017,9 @@ class _FakeCaptureBuffer(_FakeBuffer):
             rollout_ids=rollout_ids,
         )
 
+    async def clear_staging_keys(self, staging_keys):
+        del staging_keys
+
 
 def _receipt_record(rollout_ids, receipts):
     completions = [
@@ -1042,20 +1046,41 @@ def _make_capture_manager(buf, *, on_run=None, num_generations=2):
     mgr._tokenizer = None
     mgr._num_generations_per_prompt = num_generations
     mgr._tq_buffer = buf
-    mgr._env_handles = {}
     mgr._weight_version = 7
+    mgr._retry_policy = RolloutRetryPolicy.single_attempt()
+    mgr._stats = RolloutStats()
+    mgr._skipped_prompts = 0
+    mgr._recovery_ledger = RolloutRecoveryLedger()
 
     class _CaptureImpl:
         def __init__(self):
             self.seen_rollout_ids = None
 
-        async def run_rollout(self, _sample, *, rollout_ids=None):
+        async def run_rollout(
+            self,
+            _sample,
+            *,
+            rollout_ids=None,
+            generation_indices=None,
+            on_completion=None,
+        ):
             self.seen_rollout_ids = rollout_ids
             if on_run is not None:
                 await on_run(_sample)
-            return _receipt_record(
-                rollout_ids, [{"rollout_id": rid} for rid in rollout_ids]
-            )
+            indices = generation_indices or list(range(len(rollout_ids)))
+            selected_ids = [rollout_ids[index] for index in indices]
+            receipts = [
+                {
+                    "rollout_id": rollout_id,
+                    "manifest": [{"staging_key": f"{rollout_id}/call"}],
+                }
+                for rollout_id in selected_ids
+            ]
+            record = _receipt_record(selected_ids, receipts)
+            if on_completion is not None:
+                for generation_index, completion in zip(indices, record.completions):
+                    await on_completion(generation_index, completion)
+            return record
 
     mgr._impl = _CaptureImpl()
     return mgr
@@ -1066,24 +1091,33 @@ class TestGenerateForFinalizationFlow:
         buf = _FakeCaptureBuffer()
         mgr = _make_capture_manager(buf)
 
-        request = _run(mgr.generate_for_finalization({"prompt": "p"}, target_step=5))
+        request = _run(
+            mgr.generate_for_finalization({"prompt": "p", "idx": 0}, target_step=5)
+        )
+        assert request is not None
 
         # Rollout ids were minted from the reserved group id and threaded
         # end to end: reserve -> impl -> metadata-only actor request.
         (group_id,) = buf._slots
-        expected_ids = [f"{group_id}_g0", f"{group_id}_g1"]
-        assert buf.reserve_rollout_ids == [expected_ids]
-        assert mgr._impl.seen_rollout_ids == expected_ids
+        canonical_ids = [f"{group_id}_g0", f"{group_id}_g1"]
+        attempt_ids = buf.reserve_rollout_ids[0]
+        assert attempt_ids is not None
+        assert all(
+            attempt_id.startswith(f"{canonical_id}_a")
+            for attempt_id, canonical_id in zip(attempt_ids, canonical_ids)
+        )
+        assert mgr._impl.seen_rollout_ids == attempt_ids
         assert request.group_id == group_id
-        assert request.rollout_ids == tuple(expected_ids)
-        assert [r["rollout_id"] for r in request.receipts] == expected_ids
+        assert request.rollout_ids == tuple(attempt_ids)
+        assert request.canonical_sample_ids == tuple(canonical_ids)
+        assert [r["rollout_id"] for r in request.receipts] == attempt_ids
         assert request.rewards == (0.5, 0.5)
         assert request.fallback_weight_version == 7
         # Finalization and commit are exclusively owned by the controller's
         # actor-pool path; the manager leaves the reservation unready.
         assert buf.commit_calls == []
 
-    def test_failed_dispatch_aborts_the_reservation(self):
+    def test_failed_dispatch_aborts_replay_reservation(self):
         buf = _FakeCaptureBuffer()
 
         async def _boom(_sample):
@@ -1091,7 +1125,91 @@ class TestGenerateForFinalizationFlow:
 
         mgr = _make_capture_manager(buf, on_run=_boom)
         with pytest.raises(RuntimeError, match="rollout exploded"):
-            _run(mgr.generate_for_finalization({"prompt": "p"}))
-        # The slot is released; abandoned staged rows are swept with the
-        # staging partition at run end (no per-rollout control-plane call).
+            _run(mgr.generate_for_finalization({"prompt": "p", "idx": 0}))
         assert len(buf.abort_calls) == 1
+
+    def test_retries_infrastructure_failure_with_stable_logical_ids(self):
+        buf = _FakeCaptureBuffer()
+        attempts = 0
+
+        async def _fail_once(_sample):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise GenerationUnavailable("worker disappeared")
+
+        mgr = _make_capture_manager(buf, on_run=_fail_once)
+        mgr._retry_policy = RolloutRetryPolicy.single_attempt(
+            max_infra_attempts=2,
+            backoff_base_s=0.0,
+        )
+
+        request = _run(mgr.generate_for_finalization({"prompt": "p", "idx": 4}))
+
+        assert request is not None
+        assert attempts == 2
+        assert len(buf.reserve_rollout_ids) == 2
+        assert buf.reserve_rollout_ids[0] != buf.reserve_rollout_ids[1]
+        assert len(buf.abort_calls) == 1
+        assert buf.abort_calls[0] == request.group_id
+        assert request.canonical_sample_ids == (
+            f"{request.group_id}_g0",
+            f"{request.group_id}_g1",
+        )
+        assert mgr.stats.as_metrics()["rollout/redispatch_total"] == 1.0
+
+    def test_reuses_sealed_sibling_and_redispatches_only_incomplete_one(self):
+        buf = _FakeCaptureBuffer()
+        mgr = _make_capture_manager(buf)
+        mgr._retry_policy = RolloutRetryPolicy.single_attempt(
+            max_infra_attempts=2,
+            backoff_base_s=0.0,
+        )
+
+        class _PartialCaptureImpl:
+            def __init__(self):
+                self.generation_indices: list[list[int]] = []
+
+            async def run_rollout(
+                self,
+                _sample,
+                *,
+                rollout_ids=None,
+                generation_indices=None,
+                on_completion=None,
+            ):
+                indices = list(generation_indices)
+                self.generation_indices.append(indices)
+                completions = []
+                for generation_index in indices:
+                    rollout_id = rollout_ids[generation_index]
+                    receipt = {
+                        "rollout_id": rollout_id,
+                        "manifest": [{"staging_key": f"{rollout_id}/call"}],
+                    }
+                    completion = _receipt_record([rollout_id], [receipt]).completions[0]
+                    completions.append(completion)
+                    await on_completion(generation_index, completion)
+                    if len(self.generation_indices) == 1:
+                        raise GenerationUnavailable("worker disappeared")
+                return PromptGroupRecord(
+                    prompt_idx=0,
+                    prompt=[],
+                    extra_env_info={},
+                    metadata={"task_name": "nemo_gym"},
+                    completions=completions,
+                    rollout_metrics={},
+                )
+
+        impl = _PartialCaptureImpl()
+        mgr._impl = impl
+
+        request = _run(mgr.generate_for_finalization({"prompt": "p", "idx": 9}))
+
+        assert request is not None
+        assert impl.generation_indices == [[0, 1], [1]]
+        first_ids, second_ids = buf.reserve_rollout_ids
+        assert first_ids is not None and second_ids is not None
+        assert second_ids[0] == first_ids[0]
+        assert second_ids[1] != first_ids[1]
+        assert request.rollout_ids == (second_ids[0], second_ids[1])

--- a/tests/unit/experience/test_rollout_manager.py
+++ b/tests/unit/experience/test_rollout_manager.py
@@ -42,6 +42,8 @@ from nemo_rl.experience.interfaces import Completion, PromptGroupRecord
 from nemo_rl.experience.rollout_manager import (
     AsyncNemoGymRolloutImpl,
     RolloutManager,
+    RolloutRetryPolicy,
+    RolloutStats,
 )
 from nemo_rl.experience.rollouts import (
     run_async_multi_turn_rollout,
@@ -135,8 +137,14 @@ class _FakeImpl:
         return self._record
 
 
-def _make_manager(buffer: _FakeBuffer, impl: _FakeImpl) -> RolloutManager:
-    """Build a RolloutManager without firing the real __init__."""
+def _make_manager(
+    buffer: _FakeBuffer, impl: _FakeImpl, retry_policy: RolloutRetryPolicy | None = None
+) -> RolloutManager:
+    """Build a RolloutManager without firing the real __init__.
+
+    The default policy is single-attempt, matching RolloutRetryPolicy's own default, so
+    these tests keep exercising the no-retry path unless they ask for otherwise.
+    """
     mgr = object.__new__(RolloutManager)
     mgr._impl = impl
     mgr._tokenizer = None
@@ -144,6 +152,13 @@ def _make_manager(buffer: _FakeBuffer, impl: _FakeImpl) -> RolloutManager:
     mgr._tq_buffer = buffer
     mgr._env_handles = {}
     mgr._weight_version = 0
+    mgr._retry_policy = (
+        retry_policy
+        if retry_policy is not None
+        else RolloutRetryPolicy.single_attempt()
+    )
+    mgr._stats = RolloutStats()
+    mgr._skipped_prompts = 0
     return mgr
 
 
@@ -300,13 +315,9 @@ class TestGenerateAndPushFlow:
 
         first_mgr = _make_manager(buf, first_impl)
         # Share buffer across two managers (mimics two dispatches from one pump).
-        second_mgr = object.__new__(RolloutManager)
-        second_mgr._impl = second_impl
-        second_mgr._tokenizer = None
-        second_mgr._num_generations_per_prompt = 1
-        second_mgr._tq_buffer = buf
-        second_mgr._env_handles = {}
-        second_mgr._weight_version = 0
+        # Built through the shared helper so new RolloutManager attributes only have to
+        # be added in one place.
+        second_mgr = _make_manager(buf, second_impl)
 
         async def _drive():
             t1 = asyncio.create_task(first_mgr.generate_and_push({"prompt": "p1"}))

--- a/tests/unit/experience/test_rollout_manager.py
+++ b/tests/unit/experience/test_rollout_manager.py
@@ -40,6 +40,10 @@ from nemo_rl.data.processors import nemo_gym_data_processor
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.experience.interfaces import Completion, PromptGroupRecord
 from nemo_rl.experience.rollout_manager import RolloutManager
+from nemo_rl.experience.rollout_recovery import (
+    RolloutAttemptStatus,
+    RolloutRecoveryLedger,
+)
 from nemo_rl.experience.rollouts import (
     run_async_multi_turn_rollout,
     run_async_nemo_gym_rollout,
@@ -140,6 +144,7 @@ def _make_manager(buffer: _FakeBuffer, impl: _FakeImpl) -> RolloutManager:
     mgr._num_generations_per_prompt = 1
     mgr._tq_buffer = buffer
     mgr._finalizer = None
+    mgr._recovery_ledger = None
     mgr._env_handles = {}
     mgr._weight_version = 0
     return mgr
@@ -901,10 +906,24 @@ class _FakeFinalizer:
         self._dropped = dropped
 
     def finalize_group(
-        self, group_id, rollout_ids, receipts, rewards, *, fallback_weight_version
+        self,
+        group_id,
+        rollout_ids,
+        receipts,
+        rewards,
+        *,
+        fallback_weight_version,
+        canonical_sample_ids=None,
     ):
         self.calls.append(
-            (group_id, rollout_ids, receipts, rewards, fallback_weight_version)
+            (
+                group_id,
+                rollout_ids,
+                receipts,
+                rewards,
+                fallback_weight_version,
+                canonical_sample_ids,
+            )
         )
         return _FakeFinalizedGroup(dropped=self._dropped)
 
@@ -992,6 +1011,7 @@ def _make_capture_manager(buf, finalizer, *, on_run=None, num_generations=2):
     mgr._num_generations_per_prompt = num_generations
     mgr._tq_buffer = buf
     mgr._finalizer = finalizer
+    mgr._recovery_ledger = RolloutRecoveryLedger()
     mgr._env_handles = {"nemo_gym": _FakeGymEnvHandle()}
     mgr._weight_version = 7
 
@@ -1011,24 +1031,54 @@ def _make_capture_manager(buf, finalizer, *, on_run=None, num_generations=2):
     return mgr
 
 
+def _capture_sample():
+    return {
+        "idx": 42,
+        "message_log": [],
+        "extra_env_info": {},
+        "task_name": "nemo_gym",
+    }
+
+
 class TestGenerateAndFinalizeFlow:
     def test_mints_ids_finalizes_and_commits(self):
         buf = _FakeCaptureBuffer()
         finalizer = _FakeFinalizer()
-        mgr = _make_capture_manager(buf, finalizer)
+        observed_recovery_groups = []
 
-        _run(mgr.generate_and_push({"prompt": "p"}, target_step=5))
+        async def _observe_dispatched_group(_sample):
+            observed_recovery_groups.append(
+                mgr.recovery_ledger.get_group(buf._slots[0])
+            )
 
-        # Rollout ids were minted from the reserved group id and threaded
-        # end to end: reserve -> impl -> finalizer.
+        mgr = _make_capture_manager(buf, finalizer, on_run=_observe_dispatched_group)
+
+        _run(mgr.generate_and_push(_capture_sample(), target_step=5))
+
+        # Canonical IDs are stable logical siblings. Physical gate IDs carry
+        # an attempt suffix and are threaded reserve -> impl -> finalizer.
         (group_id,) = buf._slots
-        expected_ids = [f"{group_id}_g0", f"{group_id}_g1"]
-        assert buf.reserve_rollout_ids == [expected_ids]
-        assert mgr._impl.seen_rollout_ids == expected_ids
-        (fin_group_id, fin_ids, receipts, rewards, fallback_wv) = finalizer.calls[0]
+        logical_ids = [f"{group_id}_g0", f"{group_id}_g1"]
+        (gate_ids,) = buf.reserve_rollout_ids
+        assert gate_ids is not None
+        assert all(
+            gate_id.startswith(f"{logical_id}_a")
+            for gate_id, logical_id in zip(gate_ids, logical_ids)
+        )
+        assert len(set(gate_ids)) == 2
+        assert mgr._impl.seen_rollout_ids == gate_ids
+        (
+            fin_group_id,
+            fin_ids,
+            receipts,
+            rewards,
+            fallback_wv,
+            canonical_ids,
+        ) = finalizer.calls[0]
         assert fin_group_id == group_id
-        assert fin_ids == expected_ids
-        assert [r["rollout_id"] for r in receipts] == expected_ids
+        assert fin_ids == gate_ids
+        assert canonical_ids == logical_ids
+        assert [r["rollout_id"] for r in receipts] == gate_ids
         assert rewards == [0.5, 0.5]
         assert fallback_wv == 7
         # commit_finalized carried the group's min/max call versions.
@@ -1045,12 +1095,21 @@ class TestGenerateAndFinalizeFlow:
         # The legacy commit path was not used and nothing failed at the gate.
         assert buf.commit_calls == []
         assert mgr._env_handles["nemo_gym"].failed == []
+        (recovery_group,) = observed_recovery_groups
+        assert recovery_group.prompt_id == "42"
+        assert recovery_group.target_step == 5
+        assert recovery_group.logical_rollout_ids == logical_ids
+        assert all(
+            sibling.current_attempt.status == RolloutAttemptStatus.DISPATCHED
+            for sibling in recovery_group.siblings
+        )
+        assert len(mgr.recovery_ledger) == 0
 
     def test_dropped_group_aborts_slot(self):
         buf = _FakeCaptureBuffer()
         mgr = _make_capture_manager(buf, _FakeFinalizer(dropped=True))
         with pytest.raises(RuntimeError, match="min_valid_fraction"):
-            _run(mgr.generate_and_push({"prompt": "p"}))
+            _run(mgr.generate_and_push(_capture_sample()))
         assert buf.commit_finalized_calls == []
         assert len(buf.abort_finalized_calls) == 1
         assert len(buf.abort_calls) >= 1
@@ -1063,10 +1122,18 @@ class TestGenerateAndFinalizeFlow:
 
         mgr = _make_capture_manager(buf, _FakeFinalizer(), on_run=_boom)
         with pytest.raises(RuntimeError, match="rollout exploded"):
-            _run(mgr.generate_and_push({"prompt": "p"}))
+            _run(mgr.generate_and_push(_capture_sample()))
         assert buf.commit_finalized_calls == []
         assert len(buf.abort_calls) == 1
         (failed_ids, reason) = mgr._env_handles["nemo_gym"].failed[0]
         (group_id,) = [buf.abort_calls[0]]
-        assert failed_ids == [f"{group_id}_g0", f"{group_id}_g1"]
+        assert all(
+            gate_id.startswith(f"{group_id}_g{generation_index}_a")
+            for generation_index, gate_id in enumerate(failed_ids)
+        )
         assert reason == "dispatch_failed"
+        recovery_group = mgr.recovery_ledger.get_group(group_id)
+        assert all(
+            sibling.current_attempt.status == RolloutAttemptStatus.ABANDONED
+            for sibling in recovery_group.siblings
+        )

--- a/tests/unit/experience/test_rollout_manager.py
+++ b/tests/unit/experience/test_rollout_manager.py
@@ -39,7 +39,7 @@ from nemo_rl.data.interfaces import DatumSpec
 from nemo_rl.data.processors import nemo_gym_data_processor
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.experience.interfaces import Completion, PromptGroupRecord
-from nemo_rl.experience.rollout_manager import RolloutManager
+from nemo_rl.experience.rollout_manager import AsyncNemoGymRolloutImpl, RolloutManager
 from nemo_rl.experience.rollout_recovery import (
     RolloutAttemptStatus,
     RolloutRecoveryLedger,
@@ -48,6 +48,7 @@ from nemo_rl.experience.rollouts import (
     run_async_multi_turn_rollout,
     run_async_nemo_gym_rollout,
 )
+from nemo_rl.utils.timer import Timer
 
 # Fixtures shared with the heavyweight rollout tests.
 from tests.unit.environments.test_nemo_gym import (
@@ -69,6 +70,74 @@ from tests.unit.test_envs import MultiStepCalcMetadata
 
 def _run(coro):
     return asyncio.run(coro)
+
+
+class _StreamingGymEnv:
+    """Ray-style streaming actor stub that yields results out of order."""
+
+    def __init__(self, results):
+        self._results = results
+        self.run_rollouts = self
+
+    def options(self, *, num_returns):
+        assert num_returns == "streaming"
+        return self
+
+    def remote(self, _inputs, _tokenizer, _timer_prefix):
+        async def _stream():
+            for result in self._results:
+
+                async def _result_ref(value=result):
+                    return value
+
+                yield _result_ref()
+
+        return _stream()
+
+
+def test_nemo_gym_stream_callback_runs_before_group_completion() -> None:
+    def _result(rowidx: int) -> tuple[int, dict, None]:
+        rollout_id = f"rollout-{rowidx}"
+        return (
+            rowidx,
+            {
+                "receipt": {"rollout_id": rollout_id, "manifest": []},
+                "rollout_id": rollout_id,
+                "full_result": {"reward": float(rowidx)},
+                "message_log": [],
+                "input_message_log": [],
+            },
+            None,
+        )
+
+    impl = object.__new__(AsyncNemoGymRolloutImpl)
+    impl._task_to_env = {"nemo_gym": _StreamingGymEnv([_result(1), _result(0)])}
+    impl._tokenizer = None
+    impl._compute_rollout_metrics = lambda _completions, _agent_name: {}
+    callback_order: list[int] = []
+
+    async def _record(rowidx: int, _completion: Completion) -> None:
+        callback_order.append(rowidx)
+        if rowidx == 1:
+            assert len(callback_order) == 1
+
+    completions, _, _ = _run(
+        impl._run_rollouts(
+            [
+                {"agent_ref": {"name": "agent"}},
+                {"agent_ref": {"name": "agent"}},
+            ],
+            Timer(),
+            "timing/test",
+            on_completion=_record,
+        )
+    )
+
+    assert callback_order == [1, 0]
+    assert [completion.env_extras["ng_rollout_id"] for completion in completions] == [
+        "rollout-0",
+        "rollout-1",
+    ]
 
 
 class _FakeBuffer:
@@ -1005,7 +1074,14 @@ def _receipt_record(rollout_ids, receipts):
     )
 
 
-def _make_capture_manager(buf, finalizer, *, on_run=None, num_generations=2):
+def _make_capture_manager(
+    buf,
+    finalizer,
+    *,
+    on_run=None,
+    num_generations=2,
+    fail_after_completions=None,
+):
     mgr = object.__new__(RolloutManager)
     mgr._tokenizer = None
     mgr._num_generations_per_prompt = num_generations
@@ -1018,14 +1094,29 @@ def _make_capture_manager(buf, finalizer, *, on_run=None, num_generations=2):
     class _CaptureImpl:
         def __init__(self):
             self.seen_rollout_ids = None
+            self.streamed_recovery_groups = []
 
-        async def run_rollout(self, _sample, *, rollout_ids=None):
+        async def run_rollout(self, _sample, *, rollout_ids=None, on_completion=None):
             self.seen_rollout_ids = rollout_ids
             if on_run is not None:
                 await on_run(_sample)
-            return _receipt_record(
-                rollout_ids, [{"rollout_id": rid} for rid in rollout_ids]
-            )
+            receipts = [
+                {
+                    "rollout_id": rollout_id,
+                    "manifest": [{"staging_key": f"stage-{generation_index}"}],
+                }
+                for generation_index, rollout_id in enumerate(rollout_ids)
+            ]
+            record = _receipt_record(rollout_ids, receipts)
+            for generation_index, completion in enumerate(record.completions):
+                if on_completion is not None:
+                    await on_completion(generation_index, completion)
+                    self.streamed_recovery_groups.append(
+                        mgr.recovery_ledger.get_group(buf._slots[0])
+                    )
+                if fail_after_completions == generation_index + 1:
+                    raise RuntimeError("stream interrupted")
+            return record
 
     mgr._impl = _CaptureImpl()
     return mgr
@@ -1103,6 +1194,14 @@ class TestGenerateAndFinalizeFlow:
             sibling.current_attempt.status == RolloutAttemptStatus.DISPATCHED
             for sibling in recovery_group.siblings
         )
+        streamed_group = mgr._impl.streamed_recovery_groups[-1]
+        assert all(
+            sibling.current_attempt.status == RolloutAttemptStatus.SEALED
+            for sibling in streamed_group.siblings
+        )
+        assert [
+            sibling.current_attempt.staging_keys for sibling in streamed_group.siblings
+        ] == [["stage-0"], ["stage-1"]]
         assert len(mgr.recovery_ledger) == 0
 
     def test_dropped_group_aborts_slot(self):
@@ -1113,6 +1212,27 @@ class TestGenerateAndFinalizeFlow:
         assert buf.commit_finalized_calls == []
         assert len(buf.abort_finalized_calls) == 1
         assert len(buf.abort_calls) >= 1
+        assert len(mgr.recovery_ledger) == 0
+
+    def test_dropped_group_preserves_sealed_receipts_when_cleanup_fails(self):
+        class _FailingCleanupBuffer(_FakeCaptureBuffer):
+            async def abort_finalized(self, group_id, *, staging_keys):
+                self.abort_finalized_calls.append((group_id, list(staging_keys)))
+                raise RuntimeError("staging cleanup failed")
+
+        buf = _FailingCleanupBuffer()
+        mgr = _make_capture_manager(buf, _FakeFinalizer(dropped=True))
+
+        with pytest.raises(RuntimeError, match="staging cleanup failed"):
+            _run(mgr.generate_and_push(_capture_sample()))
+
+        (group_id,) = buf.abort_calls
+        recovery_group = mgr.recovery_ledger.get_group(group_id)
+        assert all(
+            sibling.current_attempt.status == RolloutAttemptStatus.SEALED
+            for sibling in recovery_group.siblings
+        )
+        assert mgr._env_handles["nemo_gym"].failed == []
 
     def test_failed_dispatch_aborts_and_fails_gate_rollouts(self):
         buf = _FakeCaptureBuffer()
@@ -1137,3 +1257,35 @@ class TestGenerateAndFinalizeFlow:
             sibling.current_attempt.status == RolloutAttemptStatus.ABANDONED
             for sibling in recovery_group.siblings
         )
+
+    def test_stream_failure_preserves_completed_siblings(self):
+        buf = _FakeCaptureBuffer()
+        mgr = _make_capture_manager(
+            buf,
+            _FakeFinalizer(),
+            num_generations=3,
+            fail_after_completions=2,
+        )
+
+        with pytest.raises(RuntimeError, match="stream interrupted"):
+            _run(mgr.generate_and_push(_capture_sample()))
+
+        (group_id,) = buf.abort_calls
+        recovery_group = mgr.recovery_ledger.get_group(group_id)
+        assert [
+            sibling.current_attempt.status for sibling in recovery_group.siblings
+        ] == [
+            RolloutAttemptStatus.SEALED,
+            RolloutAttemptStatus.SEALED,
+            RolloutAttemptStatus.ABANDONED,
+        ]
+        assert [
+            sibling.current_attempt.staging_keys
+            for sibling in recovery_group.siblings[:2]
+        ] == [["stage-0"], ["stage-1"]]
+        (failed_ids, reason) = mgr._env_handles["nemo_gym"].failed[0]
+        assert failed_ids == [
+            recovery_group.siblings[2].current_attempt.gate_rollout_id
+        ]
+        assert reason == "dispatch_failed"
+        assert buf.commit_finalized_calls == []

--- a/tests/unit/experience/test_rollout_recovery.py
+++ b/tests/unit/experience/test_rollout_recovery.py
@@ -1,0 +1,229 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from nemo_rl.data_plane import KVBatchMeta
+from nemo_rl.experience.rollout_recovery import (
+    PromptGroupStatus,
+    RolloutAttemptStatus,
+    RolloutRecoveryLedger,
+    TrainStepStatus,
+)
+
+
+def _prompt() -> dict:
+    return {
+        "idx": 17,
+        "message_log": [{"role": "user", "content": "solve"}],
+        "extra_env_info": {"task": "math"},
+        "task_name": "nemo_gym",
+    }
+
+
+def _reserve(ledger: RolloutRecoveryLedger, *, group_id: str = "group-1"):
+    return ledger.reserve_group(
+        group_id=group_id,
+        prompt_id="17",
+        prompt_payload=_prompt(),  # type: ignore[arg-type]
+        expected_generations=2,
+        target_step=8,
+        start_weight_version=7,
+    )
+
+
+def _receipt(gate_rollout_id: str) -> dict:
+    return {
+        "rollout_id": gate_rollout_id,
+        "manifest": [{"staging_key": f"{gate_rollout_id}/call"}],
+    }
+
+
+def _seal(ledger: RolloutRecoveryLedger, group_id: str, generation_index: int) -> None:
+    group = ledger.get_group(group_id)
+    gate_id = group.siblings[generation_index].current_attempt.gate_rollout_id
+    ledger.mark_sibling_sealed(
+        group_id,
+        generation_index=generation_index,
+        gate_rollout_id=gate_id,
+        receipt=_receipt(gate_id),
+        reward=float(generation_index),
+    )
+
+
+def _finalize(ledger: RolloutRecoveryLedger, group_id: str) -> KVBatchMeta:
+    group = ledger.get_group(group_id)
+    meta = KVBatchMeta(
+        partition_id="rollout",
+        task_name="train",
+        sample_ids=group.logical_rollout_ids,
+        fields=["input_ids"],
+        sequence_lengths=[4, 5],
+        tags=[{"weight_version": 7}, {"weight_version": 7}],
+    )
+    ledger.mark_finalization_started(group_id)
+    ledger.mark_group_finalized(
+        group_id,
+        meta=meta,
+        group_min_weight_version=7,
+        group_max_weight_version=8,
+    )
+    return meta
+
+
+def test_retry_preserves_logical_id_and_reuses_sealed_sibling() -> None:
+    ledger = RolloutRecoveryLedger()
+    group = _reserve(ledger)
+    first_gate_ids = group.gate_rollout_ids
+    ledger.mark_group_dispatched(group.group_id)
+    _seal(ledger, group.group_id, 0)
+    ledger.abandon_unsealed(group.group_id)
+
+    retried = ledger.prepare_incomplete_retry(group.group_id)
+
+    assert retried.logical_rollout_ids == ["group-1_g0", "group-1_g1"]
+    assert retried.gate_rollout_ids[0] == first_gate_ids[0]
+    assert retried.gate_rollout_ids[1] != first_gate_ids[1]
+    assert retried.siblings[0].current_attempt.status == RolloutAttemptStatus.SEALED
+    assert retried.siblings[1].current_attempt.status == RolloutAttemptStatus.RESERVED
+
+
+def test_all_siblings_must_be_sealed_before_finalization() -> None:
+    ledger = RolloutRecoveryLedger()
+    group = _reserve(ledger)
+    ledger.mark_group_dispatched(group.group_id)
+    _seal(ledger, group.group_id, 0)
+
+    with pytest.raises(ValueError, match="not ready to finalize"):
+        ledger.finalization_inputs(group.group_id)
+
+    _seal(ledger, group.group_id, 1)
+    physical_ids, canonical_ids, receipts, rewards = ledger.finalization_inputs(
+        group.group_id
+    )
+    assert canonical_ids == ["group-1_g0", "group-1_g1"]
+    assert [receipt["rollout_id"] for receipt in receipts] == physical_ids
+    assert rewards == [0.0, 1.0]
+
+
+def test_finalized_group_remains_until_training_cleanup() -> None:
+    ledger = RolloutRecoveryLedger()
+    group = _reserve(ledger)
+    ledger.mark_group_dispatched(group.group_id)
+    _seal(ledger, group.group_id, 0)
+    _seal(ledger, group.group_id, 1)
+    _finalize(ledger, group.group_id)
+
+    finalized = ledger.get_group(group.group_id)
+    assert finalized.status == PromptGroupStatus.FINALIZED
+    assert finalized.prompt_payload is None
+    assert len(ledger) == 1
+
+    ledger.claim_groups_for_training(
+        [group.group_id],
+        train_step=3,
+        trainer_version=3,
+        expected_group_count=1,
+    )
+    assert (
+        ledger.get_group(group.group_id).status
+        == PromptGroupStatus.CLAIMED_FOR_TRAINING
+    )
+    assert ledger.open_train_step is not None
+    assert ledger.open_train_step.status == TrainStepStatus.OPEN
+
+    ledger.mark_train_step_applied(3)
+    assert (
+        ledger.get_group(group.group_id).status
+        == PromptGroupStatus.APPLIED_UNCHECKPOINTED
+    )
+    ledger.release_applied_train_step(3)
+    assert len(ledger) == 0
+    assert ledger.open_train_step is None
+
+
+def test_open_train_step_rolls_back_as_one_unit() -> None:
+    ledger = RolloutRecoveryLedger()
+    group_ids = []
+    for index in range(2):
+        group = _reserve(ledger, group_id=f"group-{index}")
+        ledger.mark_group_dispatched(group.group_id)
+        _seal(ledger, group.group_id, 0)
+        _seal(ledger, group.group_id, 1)
+        _finalize(ledger, group.group_id)
+        group_ids.append(group.group_id)
+    ledger.claim_groups_for_training(
+        [group_ids[0]],
+        train_step=4,
+        trainer_version=4,
+        expected_group_count=2,
+    )
+    ledger.claim_groups_for_training(
+        [group_ids[1]],
+        train_step=4,
+        trainer_version=4,
+        expected_group_count=2,
+    )
+
+    ledger.rollback_open_train_step(4)
+
+    assert ledger.open_train_step is None
+    assert all(
+        ledger.get_group(group_id).status == PromptGroupStatus.FINALIZED
+        for group_id in group_ids
+    )
+
+
+def test_state_dict_round_trip_preserves_partial_and_claimed_lineage() -> None:
+    ledger = RolloutRecoveryLedger()
+    partial = _reserve(ledger, group_id="partial")
+    ledger.mark_group_dispatched(partial.group_id)
+    _seal(ledger, partial.group_id, 0)
+    ledger.abandon_unsealed(partial.group_id)
+
+    finalized = _reserve(ledger, group_id="finalized")
+    ledger.mark_group_dispatched(finalized.group_id)
+    _seal(ledger, finalized.group_id, 0)
+    _seal(ledger, finalized.group_id, 1)
+    _finalize(ledger, finalized.group_id)
+    ledger.claim_groups_for_training(
+        [finalized.group_id],
+        train_step=5,
+        trainer_version=5,
+        expected_group_count=2,
+    )
+
+    state = ledger.state_dict()
+    restored = RolloutRecoveryLedger.from_state_dict(deepcopy(state))
+
+    assert restored.state_dict() == state
+    assert restored.open_train_step is not None
+    assert restored.open_train_step.group_ids == ["finalized"]
+
+
+def test_finalizer_unknown_outcome_is_terminal() -> None:
+    ledger = RolloutRecoveryLedger()
+    group = _reserve(ledger)
+    ledger.mark_group_dispatched(group.group_id)
+    _seal(ledger, group.group_id, 0)
+    _seal(ledger, group.group_id, 1)
+    ledger.mark_finalization_started(group.group_id)
+    ledger.mark_finalization_unknown(group.group_id)
+
+    with pytest.raises(ValueError, match="cannot retry"):
+        ledger.prepare_incomplete_retry(group.group_id)

--- a/tests/unit/experience/test_rollout_recovery.py
+++ b/tests/unit/experience/test_rollout_recovery.py
@@ -257,6 +257,23 @@ def test_state_dict_excludes_runtime_prompt_payload() -> None:
     assert state["groups"][0]["prompt_ref"]["sample_id"] == "17"
 
 
+@pytest.mark.parametrize("missing_status", ["group", "attempt"])
+def test_state_dict_rejects_missing_status_with_context(missing_status: str) -> None:
+    ledger = RolloutRecoveryLedger()
+    _reserve(ledger)
+    state = ledger.state_dict()
+    group_state = state["groups"][0]
+    if missing_status == "group":
+        group_state.pop("status")
+        expected_message = "invalid prompt group status=None"
+    else:
+        group_state["siblings"][0]["attempts"][0].pop("status")
+        expected_message = "invalid rollout attempt status=None"
+
+    with pytest.raises(ValueError, match=expected_message):
+        RolloutRecoveryLedger.from_state_dict(state)
+
+
 def test_finalizer_unknown_outcome_is_terminal() -> None:
     ledger = RolloutRecoveryLedger()
     group = _reserve(ledger)

--- a/tests/unit/experience/test_rollout_recovery.py
+++ b/tests/unit/experience/test_rollout_recovery.py
@@ -20,6 +20,7 @@ import pytest
 
 from nemo_rl.data_plane import KVBatchMeta
 from nemo_rl.experience.rollout_recovery import (
+    PromptRef,
     PromptGroupStatus,
     RolloutAttemptStatus,
     RolloutRecoveryLedger,
@@ -36,10 +37,16 @@ def _prompt() -> dict:
     }
 
 
+class _NoDeepcopy:
+    def __deepcopy__(self, memo):
+        raise AssertionError("runtime prompt payload must not be deep-copied")
+
+
 def _reserve(ledger: RolloutRecoveryLedger, *, group_id: str = "group-1"):
     return ledger.reserve_group(
         group_id=group_id,
         prompt_id="17",
+        prompt_ref=PromptRef(sample_id="17", task_name="nemo_gym"),
         prompt_payload=_prompt(),  # type: ignore[arg-type]
         expected_generations=2,
         target_step=8,
@@ -56,7 +63,7 @@ def _receipt(gate_rollout_id: str) -> dict:
 
 def _seal(ledger: RolloutRecoveryLedger, group_id: str, generation_index: int) -> None:
     group = ledger.get_group(group_id)
-    gate_id = group.siblings[generation_index].current_attempt.gate_rollout_id
+    gate_id = group.gate_rollout_ids[generation_index]
     ledger.mark_sibling_sealed(
         group_id,
         generation_index=generation_index,
@@ -131,7 +138,7 @@ def test_finalized_group_remains_until_training_cleanup() -> None:
 
     finalized = ledger.get_group(group.group_id)
     assert finalized.status == PromptGroupStatus.FINALIZED
-    assert finalized.prompt_payload is None
+    assert finalized.runtime_prompt_payload is None
     assert len(ledger) == 1
 
     ledger.claim_groups_for_training(
@@ -209,11 +216,45 @@ def test_state_dict_round_trip_preserves_partial_and_claimed_lineage() -> None:
     )
 
     state = ledger.state_dict()
+    assert all("prompt_payload" not in group for group in state["groups"])
+    partial_state = next(
+        group for group in state["groups"] if group["group_id"] == "partial"
+    )
+    assert partial_state["prompt_ref"] == {
+        "sample_id": "17",
+        "task_name": "nemo_gym",
+    }
+    sibling_state = partial_state["siblings"][0]
+    assert "logical_rollout_id" not in sibling_state
+    attempt_state = sibling_state["attempts"][0]
+    assert set(attempt_state).isdisjoint({"attempt_id", "gate_rollout_id"})
+    assert len(attempt_state["attempt_uuid"]) == 16
     restored = RolloutRecoveryLedger.from_state_dict(deepcopy(state))
 
     assert restored.state_dict() == state
     assert restored.open_train_step is not None
     assert restored.open_train_step.group_ids == ["finalized"]
+    assert restored.get_group("partial").runtime_prompt_payload is None
+
+
+def test_state_dict_excludes_runtime_prompt_payload() -> None:
+    ledger = RolloutRecoveryLedger()
+    prompt = _prompt()
+    prompt["__extra__"] = _NoDeepcopy()
+    ledger.reserve_group(
+        group_id="partial",
+        prompt_id="17",
+        prompt_ref=PromptRef(sample_id="17", task_name="nemo_gym"),
+        prompt_payload=prompt,  # type: ignore[arg-type]
+        expected_generations=2,
+        target_step=8,
+        start_weight_version=7,
+    )
+
+    state = ledger.state_dict()
+
+    assert "prompt_payload" not in state["groups"][0]
+    assert state["groups"][0]["prompt_ref"]["sample_id"] == "17"
 
 
 def test_finalizer_unknown_outcome_is_terminal() -> None:

--- a/tests/unit/experience/test_rollout_recovery.py
+++ b/tests/unit/experience/test_rollout_recovery.py
@@ -31,6 +31,26 @@ def _reserve(ledger: RolloutRecoveryLedger, *, group_id: str = "group-1"):
     )
 
 
+def _receipt(gate_rollout_id: str, generation_index: int) -> dict:
+    return {
+        "rollout_id": gate_rollout_id,
+        "manifest": [{"staging_key": f"stage-{generation_index}"}],
+    }
+
+
+def _seal_all(ledger: RolloutRecoveryLedger, group_id: str) -> None:
+    group = ledger.get_group(group_id)
+    for sibling in group.siblings:
+        gate_rollout_id = sibling.current_attempt.gate_rollout_id
+        ledger.mark_sibling_sealed(
+            group_id,
+            generation_index=sibling.generation_index,
+            gate_rollout_id=gate_rollout_id,
+            receipt=_receipt(gate_rollout_id, sibling.generation_index),
+            reward=float(sibling.generation_index),
+        )
+
+
 def test_reserve_separates_logical_ids_from_attempt_ids() -> None:
     ledger = RolloutRecoveryLedger()
     group = _reserve(ledger)
@@ -93,15 +113,29 @@ def test_state_dict_round_trip_preserves_lineage() -> None:
     ledger = RolloutRecoveryLedger()
     group = _reserve(ledger)
     ledger.mark_group_dispatched(group.group_id)
+    gate_rollout_id = group.siblings[0].current_attempt.gate_rollout_id
+    ledger.mark_sibling_sealed(
+        group.group_id,
+        generation_index=0,
+        gate_rollout_id=gate_rollout_id,
+        receipt=_receipt(gate_rollout_id, 0),
+        reward=0.5,
+    )
     state = ledger.state_dict()
 
     restored = RolloutRecoveryLedger.from_state_dict(deepcopy(state))
 
     assert state["schema_version"] == ROLLOUT_RECOVERY_SCHEMA_VERSION
     assert restored.state_dict() == state
+    restored_group = restored.get_group(group.group_id)
+    sealed_attempt = restored_group.siblings[0].current_attempt
+    assert sealed_attempt.status == RolloutAttemptStatus.SEALED
+    assert sealed_attempt.reward == 0.5
+    assert sealed_attempt.staging_keys == ["stage-0"]
+    assert sealed_attempt.receipt == _receipt(gate_rollout_id, 0)
     assert all(
         sibling.current_attempt.status == RolloutAttemptStatus.DISPATCHED
-        for sibling in restored.get_group(group.group_id).siblings
+        for sibling in restored_group.siblings[1:]
     )
 
 
@@ -126,9 +160,64 @@ def test_release_requires_finalized_group() -> None:
         ledger.release_finalized_group(group.group_id)
 
     ledger.mark_group_dispatched(group.group_id)
+    _seal_all(ledger, group.group_id)
     ledger.mark_group_finalized(group.group_id)
     ledger.release_finalized_group(group.group_id)
     assert len(ledger) == 0
+
+
+def test_streamed_seal_preserves_completed_sibling_on_group_abort() -> None:
+    ledger = RolloutRecoveryLedger()
+    group = _reserve(ledger)
+    ledger.mark_group_dispatched(group.group_id)
+    gate_rollout_id = group.siblings[1].current_attempt.gate_rollout_id
+    receipt = _receipt(gate_rollout_id, 1)
+
+    ledger.mark_sibling_sealed(
+        group.group_id,
+        generation_index=1,
+        gate_rollout_id=gate_rollout_id,
+        receipt=receipt,
+        reward=2.5,
+    )
+    receipt["manifest"][0]["staging_key"] = "mutated"
+    ledger.abandon_group(group.group_id)
+
+    restored_group = ledger.get_group(group.group_id)
+    assert (
+        restored_group.siblings[0].current_attempt.status
+        == RolloutAttemptStatus.ABANDONED
+    )
+    sealed_attempt = restored_group.siblings[1].current_attempt
+    assert sealed_attempt.status == RolloutAttemptStatus.SEALED
+    assert sealed_attempt.receipt == _receipt(gate_rollout_id, 1)
+    assert sealed_attempt.reward == 2.5
+    assert sealed_attempt.staging_keys == ["stage-1"]
+    assert (
+        restored_group.siblings[2].current_attempt.status
+        == RolloutAttemptStatus.ABANDONED
+    )
+
+
+def test_streamed_seal_rejects_receipt_identity_mismatch() -> None:
+    ledger = RolloutRecoveryLedger()
+    group = _reserve(ledger)
+    ledger.mark_group_dispatched(group.group_id)
+    gate_rollout_id = group.siblings[0].current_attempt.gate_rollout_id
+
+    with pytest.raises(ValueError, match="receipt rollout identity mismatch"):
+        ledger.mark_sibling_sealed(
+            group.group_id,
+            generation_index=0,
+            gate_rollout_id=gate_rollout_id,
+            receipt=_receipt("wrong-attempt", 0),
+            reward=0.0,
+        )
+
+    assert (
+        ledger.get_group(group.group_id).siblings[0].current_attempt.status
+        == RolloutAttemptStatus.DISPATCHED
+    )
 
 
 def test_restore_rejects_identity_mismatch() -> None:
@@ -138,6 +227,25 @@ def test_restore_rejects_identity_mismatch() -> None:
     state["groups"][0]["siblings"][0]["logical_rollout_id"] = "wrong"
 
     with pytest.raises(ValueError, match="logical rollout ID mismatch"):
+        RolloutRecoveryLedger.from_state_dict(state)
+
+
+def test_restore_rejects_staging_keys_that_disagree_with_receipt() -> None:
+    ledger = RolloutRecoveryLedger()
+    group = _reserve(ledger)
+    ledger.mark_group_dispatched(group.group_id)
+    gate_rollout_id = group.siblings[0].current_attempt.gate_rollout_id
+    ledger.mark_sibling_sealed(
+        group.group_id,
+        generation_index=0,
+        gate_rollout_id=gate_rollout_id,
+        receipt=_receipt(gate_rollout_id, 0),
+        reward=0.5,
+    )
+    state = ledger.state_dict()
+    state["groups"][0]["siblings"][0]["attempts"][0]["staging_keys"] = ["wrong-stage"]
+
+    with pytest.raises(ValueError, match="do not match the receipt manifest"):
         RolloutRecoveryLedger.from_state_dict(state)
 
 

--- a/tests/unit/experience/test_rollout_recovery.py
+++ b/tests/unit/experience/test_rollout_recovery.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+
 from __future__ import annotations
 
 from copy import deepcopy

--- a/tests/unit/experience/test_rollout_recovery.py
+++ b/tests/unit/experience/test_rollout_recovery.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from nemo_rl.experience.rollout_recovery import (
+    ROLLOUT_RECOVERY_SCHEMA_VERSION,
+    RolloutAttemptStatus,
+    RolloutRecoveryLedger,
+)
+
+
+def _prompt() -> dict:
+    return {
+        "idx": 17,
+        "message_log": [{"role": "user", "content": "solve"}],
+        "extra_env_info": {"task": "math"},
+        "task_name": "nemo_gym",
+    }
+
+
+def _reserve(ledger: RolloutRecoveryLedger, *, group_id: str = "group-1"):
+    return ledger.reserve_group(
+        group_id=group_id,
+        prompt_id="17",
+        prompt_payload=_prompt(),  # type: ignore[arg-type]
+        expected_generations=3,
+        target_step=8,
+        start_weight_version=7,
+    )
+
+
+def test_reserve_separates_logical_ids_from_attempt_ids() -> None:
+    ledger = RolloutRecoveryLedger()
+    group = _reserve(ledger)
+
+    assert group.logical_rollout_ids == [
+        "group-1_g0",
+        "group-1_g1",
+        "group-1_g2",
+    ]
+    assert len(set(group.gate_rollout_ids)) == 3
+    assert all(
+        gate_id.startswith(f"{logical_id}_a")
+        for gate_id, logical_id in zip(
+            group.gate_rollout_ids, group.logical_rollout_ids
+        )
+    )
+    assert all(
+        sibling.current_attempt.status == RolloutAttemptStatus.RESERVED
+        for sibling in group.siblings
+    )
+
+
+def test_retry_preserves_logical_id_and_changes_attempt_identity() -> None:
+    ledger = RolloutRecoveryLedger()
+    group = _reserve(ledger)
+    first_attempt = group.siblings[1].current_attempt
+
+    ledger.mark_group_dispatched(group.group_id)
+    ledger.abandon_group(group.group_id)
+    retry = ledger.retry_sibling(group.group_id, generation_index=1)
+    restored_group = ledger.get_group(group.group_id)
+
+    assert restored_group.siblings[1].logical_rollout_id == "group-1_g1"
+    assert retry.attempt_id != first_attempt.attempt_id
+    assert retry.gate_rollout_id != first_attempt.gate_rollout_id
+    assert retry.gate_rollout_id.startswith("group-1_g1_a")
+    assert retry.status == RolloutAttemptStatus.RESERVED
+
+
+def test_prompt_payload_is_snapshotted_defensively() -> None:
+    prompt = _prompt()
+    ledger = RolloutRecoveryLedger()
+    group = ledger.reserve_group(
+        group_id="group-1",
+        prompt_id="17",
+        prompt_payload=prompt,  # type: ignore[arg-type]
+        expected_generations=1,
+        target_step=None,
+        start_weight_version=0,
+    )
+    prompt["extra_env_info"]["task"] = "mutated"
+
+    assert group.prompt_payload["extra_env_info"]["task"] == "math"
+    assert (
+        ledger.get_group("group-1").prompt_payload["extra_env_info"]["task"] == "math"
+    )
+
+
+def test_state_dict_round_trip_preserves_lineage() -> None:
+    ledger = RolloutRecoveryLedger()
+    group = _reserve(ledger)
+    ledger.mark_group_dispatched(group.group_id)
+    state = ledger.state_dict()
+
+    restored = RolloutRecoveryLedger.from_state_dict(deepcopy(state))
+
+    assert state["schema_version"] == ROLLOUT_RECOVERY_SCHEMA_VERSION
+    assert restored.state_dict() == state
+    assert all(
+        sibling.current_attempt.status == RolloutAttemptStatus.DISPATCHED
+        for sibling in restored.get_group(group.group_id).siblings
+    )
+
+
+def test_invalid_state_transition_fails_without_partial_mutation() -> None:
+    ledger = RolloutRecoveryLedger()
+    group = _reserve(ledger)
+
+    with pytest.raises(ValueError, match="cannot finalize"):
+        ledger.mark_group_finalized(group.group_id)
+
+    assert all(
+        sibling.current_attempt.status == RolloutAttemptStatus.RESERVED
+        for sibling in ledger.get_group(group.group_id).siblings
+    )
+
+
+def test_release_requires_finalized_group() -> None:
+    ledger = RolloutRecoveryLedger()
+    group = _reserve(ledger)
+
+    with pytest.raises(ValueError, match="cannot release unfinished"):
+        ledger.release_finalized_group(group.group_id)
+
+    ledger.mark_group_dispatched(group.group_id)
+    ledger.mark_group_finalized(group.group_id)
+    ledger.release_finalized_group(group.group_id)
+    assert len(ledger) == 0
+
+
+def test_restore_rejects_identity_mismatch() -> None:
+    ledger = RolloutRecoveryLedger()
+    _reserve(ledger)
+    state = ledger.state_dict()
+    state["groups"][0]["siblings"][0]["logical_rollout_id"] = "wrong"
+
+    with pytest.raises(ValueError, match="logical rollout ID mismatch"):
+        RolloutRecoveryLedger.from_state_dict(state)
+
+
+def test_restore_rejects_unknown_schema() -> None:
+    with pytest.raises(ValueError, match="Unsupported rollout-recovery schema"):
+        RolloutRecoveryLedger.from_state_dict({"schema_version": 999, "groups": []})

--- a/tests/unit/experience/test_rollout_redispatch.py
+++ b/tests/unit/experience/test_rollout_redispatch.py
@@ -1,0 +1,345 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Re-dispatch policy: no prompt is discarded for infrastructure reasons.
+
+An infra failure means the fleet is unwell, not the prompt, so the attempt is retried.
+The retry re-enters generation-shard selection, which is what makes it land somewhere
+else -- generate_and_push itself knows nothing about shard health. Deterministic
+failures get a much smaller budget because another shard rejects the prompt identically.
+
+The invariants every test here upholds:
+  - nothing is committed unless the rollout actually succeeded
+  - every reserved slot is released, whatever the outcome
+  - each attempt gets a fresh group_id, so a failed attempt's rows cannot collide
+    with the retry's
+  - cancellation is never retried
+"""
+
+import asyncio
+import uuid
+
+import pytest
+import ray.exceptions
+
+from nemo_rl.experience.failures import (
+    GenerationUnavailable,
+    RolloutDataFailure,
+    RolloutRedispatchExhausted,
+)
+from nemo_rl.experience.rollout_manager import (
+    RolloutManager,
+    RolloutOutcome,
+    RolloutRetryPolicy,
+    RolloutStats,
+)
+
+
+class _Buffer:
+    """TQReplayBuffer stand-in recording the reserve/commit/remove sequence."""
+
+    def __init__(self) -> None:
+        self.reserved: list[str] = []
+        self.commits: list[str] = []
+        self.removals: list[str] = []
+
+    def reserve(self, *, weight_version, target_step=None, group_id=None) -> str:
+        del weight_version, target_step
+        group_id = group_id or str(uuid.uuid4())
+        self.reserved.append(group_id)
+        return group_id
+
+    async def commit(self, group_id, record, start_weight_version, end_weight_version):
+        del start_weight_version, end_weight_version
+        self.commits.append(group_id)
+        return record
+
+    async def remove_group(self, group_id, *, remove_in_dp: bool = False) -> int:
+        del remove_in_dp
+        self.removals.append(group_id)
+        return 1
+
+
+class _ScriptedImpl:
+    """Rollout impl that raises a scripted sequence of failures, then succeeds."""
+
+    def __init__(self, failures) -> None:
+        self._failures = list(failures)
+        self.attempts = 0
+
+    async def run_rollout(self, input_sample):
+        del input_sample
+        index = self.attempts
+        self.attempts += 1
+        if index < len(self._failures):
+            failure = self._failures[index]
+            if failure is not None:
+                raise failure
+        return f"record-{index}"
+
+
+def _make_manager(buffer, impl, policy) -> RolloutManager:
+    manager = object.__new__(RolloutManager)
+    manager._impl = impl
+    manager._tokenizer = None
+    manager._num_generations_per_prompt = 1
+    manager._tq_buffer = buffer
+    manager._weight_version = 0
+    manager._retry_policy = policy
+    manager._stats = RolloutStats()
+    manager._skipped_prompts = 0
+    return manager
+
+
+def _sample(idx=3):
+    return {"idx": idx}
+
+
+@pytest.fixture
+def no_sleep(monkeypatch):
+    """Record backoff delays instead of waiting them out."""
+    delays: list[float] = []
+    real_sleep = asyncio.sleep
+
+    async def _fake(seconds, *args, **kwargs):
+        delays.append(seconds)
+        await real_sleep(0, *args, **kwargs)
+
+    monkeypatch.setattr("nemo_rl.experience.rollout_manager.asyncio.sleep", _fake)
+    return delays
+
+
+class TestInfraRedispatch:
+    def test_a_transient_infra_failure_is_retried_and_the_prompt_survives(
+        self, no_sleep
+    ):
+        buffer = _Buffer()
+        impl = _ScriptedImpl([GenerationUnavailable("shard down")])
+        manager = _make_manager(
+            buffer, impl, RolloutRetryPolicy.single_attempt(max_infra_attempts=3)
+        )
+
+        outcome = asyncio.run(manager.generate_and_push(_sample()))
+
+        assert outcome is RolloutOutcome.COMMITTED
+        assert impl.attempts == 2, "one failure, then one successful retry"
+        assert len(buffer.commits) == 1
+
+    def test_each_attempt_reserves_a_fresh_group_id(self, no_sleep):
+        """A failed attempt's rows must not be able to collide with the retry's."""
+        buffer = _Buffer()
+        impl = _ScriptedImpl([GenerationUnavailable("x"), GenerationUnavailable("y")])
+        manager = _make_manager(
+            buffer, impl, RolloutRetryPolicy.single_attempt(max_infra_attempts=5)
+        )
+
+        asyncio.run(manager.generate_and_push(_sample()))
+
+        assert len(buffer.reserved) == 3
+        assert len(set(buffer.reserved)) == 3, "group ids must all differ"
+        # The two failed attempts released their slots; the third committed.
+        assert buffer.removals == buffer.reserved[:2]
+        assert buffer.commits == buffer.reserved[2:]
+
+    def test_exhausting_the_infra_budget_reports_fleet_wide_failure(self, no_sleep):
+        buffer = _Buffer()
+        impl = _ScriptedImpl([ray.exceptions.RayActorError()] * 10)
+        manager = _make_manager(
+            buffer, impl, RolloutRetryPolicy.single_attempt(max_infra_attempts=3)
+        )
+
+        with pytest.raises(RolloutRedispatchExhausted, match="after 3 attempt"):
+            asyncio.run(manager.generate_and_push(_sample()))
+
+        assert impl.attempts == 3
+        assert buffer.commits == []
+        assert len(buffer.removals) == 3, "every reserved slot released"
+
+    def test_backoff_is_exponential_and_capped(self, no_sleep):
+        buffer = _Buffer()
+        impl = _ScriptedImpl([GenerationUnavailable("x")] * 10)
+        manager = _make_manager(
+            buffer,
+            impl,
+            RolloutRetryPolicy.single_attempt(
+                max_infra_attempts=6, backoff_base_s=1.0, max_backoff_s=4.0
+            ),
+        )
+
+        with pytest.raises(RolloutRedispatchExhausted):
+            asyncio.run(manager.generate_and_push(_sample()))
+
+        # 5 sleeps between 6 attempts, doubling until the ceiling bites.
+        assert no_sleep == [1.0, 2.0, 4.0, 4.0, 4.0]
+
+    def test_single_attempt_policy_reproduces_no_retry(self, no_sleep):
+        buffer = _Buffer()
+        impl = _ScriptedImpl([GenerationUnavailable("x")] * 3)
+        manager = _make_manager(
+            buffer, impl, RolloutRetryPolicy.single_attempt(max_infra_attempts=1)
+        )
+
+        with pytest.raises(RolloutRedispatchExhausted):
+            asyncio.run(manager.generate_and_push(_sample()))
+
+        assert impl.attempts == 1
+        assert no_sleep == [], "no backoff when there is no retry"
+
+
+class TestDataFailures:
+    def test_one_retry_separates_transient_from_deterministic(self, no_sleep):
+        """A shard under pressure can return an empty generation that is not the prompt."""
+        buffer = _Buffer()
+        impl = _ScriptedImpl([RolloutDataFailure("no generation data")])
+        manager = _make_manager(
+            buffer, impl, RolloutRetryPolicy.single_attempt(max_data_attempts=2)
+        )
+
+        outcome = asyncio.run(manager.generate_and_push(_sample()))
+
+        assert outcome is RolloutOutcome.COMMITTED
+        assert impl.attempts == 2
+
+    def test_a_genuinely_bad_prompt_fails_the_run_by_default(self, no_sleep):
+        buffer = _Buffer()
+        impl = _ScriptedImpl([RolloutDataFailure("prompt too long")] * 5)
+        manager = _make_manager(
+            buffer, impl, RolloutRetryPolicy.single_attempt(max_data_attempts=2)
+        )
+
+        with pytest.raises(RolloutDataFailure, match="prompt too long"):
+            asyncio.run(manager.generate_and_push(_sample()))
+
+        assert impl.attempts == 2, "budget spent, then the original failure propagates"
+        assert buffer.commits == []
+        assert len(buffer.removals) == 2
+
+    def test_data_failures_do_not_back_off(self, no_sleep):
+        """Waiting cannot help a deterministic failure, so it should not cost time."""
+        buffer = _Buffer()
+        impl = _ScriptedImpl([RolloutDataFailure("x")] * 5)
+        manager = _make_manager(
+            buffer, impl, RolloutRetryPolicy.single_attempt(max_data_attempts=3)
+        )
+
+        with pytest.raises(RolloutDataFailure):
+            asyncio.run(manager.generate_and_push(_sample()))
+        assert no_sleep == []
+
+    def test_skip_returns_a_typed_outcome_rather_than_committing(self, no_sleep):
+        buffer = _Buffer()
+        impl = _ScriptedImpl([RolloutDataFailure("bad row")] * 5)
+        manager = _make_manager(
+            buffer,
+            impl,
+            RolloutRetryPolicy.single_attempt(
+                max_data_attempts=2, max_skipped_prompts=5
+            ),
+        )
+
+        outcome = asyncio.run(manager.generate_and_push(_sample()))
+
+        assert outcome is RolloutOutcome.SKIPPED
+        assert buffer.commits == [], "a skipped prompt must never reach training"
+        assert len(buffer.removals) == 2
+
+    def test_the_skip_budget_is_run_wide_not_per_prompt(self, no_sleep):
+        """Otherwise a systematically broken dataset would skip forever."""
+        buffer = _Buffer()
+        policy = RolloutRetryPolicy.single_attempt(
+            max_data_attempts=1, max_skipped_prompts=2
+        )
+        impl = _ScriptedImpl([RolloutDataFailure("x")] * 50)
+        manager = _make_manager(buffer, impl, policy)
+
+        async def _drive():
+            assert await manager.generate_and_push(_sample(1)) is RolloutOutcome.SKIPPED
+            assert await manager.generate_and_push(_sample(2)) is RolloutOutcome.SKIPPED
+            with pytest.raises(RolloutDataFailure, match="max_skipped_prompts=2"):
+                await manager.generate_and_push(_sample(3))
+
+        asyncio.run(_drive())
+
+
+class TestCancellationIsNeverRetried:
+    def test_cancellation_propagates_and_releases_the_slot(self, no_sleep):
+        buffer = _Buffer()
+        impl = _ScriptedImpl([asyncio.CancelledError()])
+        manager = _make_manager(
+            buffer, impl, RolloutRetryPolicy.single_attempt(max_infra_attempts=5)
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(manager.generate_and_push(_sample()))
+
+        assert impl.attempts == 1, "a cancelled rollout must not be re-dispatched"
+        assert len(buffer.removals) == 1
+
+
+class TestPolicyValidation:
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"max_infra_attempts": 0},
+            {"max_data_attempts": 0},
+            {"max_infra_attempts": -1},
+        ],
+    )
+    def test_zero_attempt_budgets_are_rejected(self, kwargs):
+        """A zero budget means "never attempt the rollout", which no caller wants."""
+        with pytest.raises(ValueError, match="must be >= 1"):
+            RolloutRetryPolicy.single_attempt(**kwargs)
+
+    def test_single_attempt_is_the_no_retry_policy(self):
+        """The attempt budgets are required, so no-retry has to be asked for by name."""
+        policy = RolloutRetryPolicy.single_attempt()
+        assert policy.max_infra_attempts == 1
+        assert policy.max_data_attempts == 1
+        # 0 skips allowed: the first data-budget exhaustion propagates the original
+        # failure, which is what the retired on_data_exhausted="fail_fast" meant.
+        assert policy.max_skipped_prompts == 0
+
+
+class TestStats:
+    def test_redispatches_and_commits_are_counted(self, no_sleep):
+        buffer = _Buffer()
+        impl = _ScriptedImpl([GenerationUnavailable("x")])
+        manager = _make_manager(
+            buffer, impl, RolloutRetryPolicy.single_attempt(max_infra_attempts=3)
+        )
+
+        asyncio.run(manager.generate_and_push(_sample()))
+
+        metrics = manager.stats.as_metrics()
+        assert metrics["rollout/committed_total"] == 1.0
+        assert metrics["rollout/redispatch_total"] == 1.0
+        assert metrics["rollout/redispatch_total/GenerationUnavailable"] == 1.0
+
+    def test_skips_are_counted_separately_from_commits(self, no_sleep):
+        buffer = _Buffer()
+        impl = _ScriptedImpl([RolloutDataFailure("x")] * 5)
+        manager = _make_manager(
+            buffer,
+            impl,
+            RolloutRetryPolicy.single_attempt(
+                max_data_attempts=1, max_skipped_prompts=5
+            ),
+        )
+
+        asyncio.run(manager.generate_and_push(_sample()))
+
+        metrics = manager.stats.as_metrics()
+        assert metrics["rollout/skipped_total"] == 1.0
+        assert metrics["rollout/committed_total"] == 0.0
+        assert metrics["rollout/data_failures_total/RolloutDataFailure"] == 1.0

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -46,7 +46,10 @@ from nemo_rl.environments.games.sliding_puzzle import (
 )
 from nemo_rl.environments.interfaces import EnvironmentReturn
 from nemo_rl.experience.metric_utils import calculate_single_metric, pct
-from nemo_rl.experience.rollout_manager import AsyncNemoGymRolloutImpl
+from nemo_rl.experience.rollout_manager import (
+    AsyncNemoGymRolloutImpl,
+    RolloutTimeouts,
+)
 from nemo_rl.experience.rollouts import (
     _add_multimodal_generation_payload,
     _reattach_original_multimodal_payloads,
@@ -2148,6 +2151,9 @@ def test_rollout_manager_consumes_stream_and_restores_input_order():
             return _Stream()
 
     manager = object.__new__(AsyncNemoGymRolloutImpl)
+    # These tests cover stream ordering/dedup, not deadlines or re-dispatch.
+    manager._timeouts = RolloutTimeouts()
+    manager._max_gym_row_attempts = 1
     manager._task_to_env = {
         "nemo_gym": type("_Environment", (), {"run_rollouts": _RunRolloutsRemote()})()
     }
@@ -2161,8 +2167,8 @@ def test_rollout_manager_consumes_stream_and_restores_input_order():
     completions, prompt_message_log, metrics = asyncio.run(
         manager._run_rollouts(
             inputs=[
-                {"agent_ref": {"name": "agent"}},
-                {"agent_ref": {"name": "agent"}},
+                {"_rowidx": 0, "agent_ref": {"name": "agent"}},
+                {"_rowidx": 1, "agent_ref": {"name": "agent"}},
             ],
             timer=rollouts_mod.Timer(),
             timer_prefix="timing/test",
@@ -2218,6 +2224,9 @@ def test_rollout_manager_rejects_duplicate_stream_rows():
             return _DuplicateStream()
 
     manager = object.__new__(AsyncNemoGymRolloutImpl)
+    # These tests cover stream ordering/dedup, not deadlines or re-dispatch.
+    manager._timeouts = RolloutTimeouts()
+    manager._max_gym_row_attempts = 1
     manager._task_to_env = {
         "nemo_gym": type("_Environment", (), {"run_rollouts": _RunRolloutsRemote()})()
     }
@@ -2227,8 +2236,8 @@ def test_rollout_manager_rejects_duplicate_stream_rows():
         asyncio.run(
             manager._run_rollouts(
                 inputs=[
-                    {"agent_ref": {"name": "agent"}},
-                    {"agent_ref": {"name": "agent"}},
+                    {"_rowidx": 0, "agent_ref": {"name": "agent"}},
+                    {"_rowidx": 1, "agent_ref": {"name": "agent"}},
                 ],
                 timer=rollouts_mod.Timer(),
                 timer_prefix="timing/test",

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -2151,6 +2151,7 @@ def test_rollout_manager_consumes_stream_and_restores_input_order():
             return _Stream()
 
     manager = object.__new__(AsyncNemoGymRolloutImpl)
+    manager._num_generations_per_prompt = 2
     # These tests cover stream ordering/dedup, not deadlines or re-dispatch.
     manager._timeouts = RolloutTimeouts()
     manager._max_gym_row_attempts = 1
@@ -2224,6 +2225,7 @@ def test_rollout_manager_rejects_duplicate_stream_rows():
             return _DuplicateStream()
 
     manager = object.__new__(AsyncNemoGymRolloutImpl)
+    manager._num_generations_per_prompt = 2
     # These tests cover stream ordering/dedup, not deadlines or re-dispatch.
     manager._timeouts = RolloutTimeouts()
     manager._max_gym_row_attempts = 1

--- a/tests/unit/single_controller/test_finalizer_lifecycle.py
+++ b/tests/unit/single_controller/test_finalizer_lifecycle.py
@@ -92,6 +92,7 @@ def _request() -> FinalizationRequest:
     return FinalizationRequest(
         group_id="group",
         rollout_ids=("group_g0",),
+        canonical_sample_ids=("group_g0",),
         receipts=(
             {
                 "manifest": [

--- a/tests/unit/single_controller/test_finalizer_lifecycle.py
+++ b/tests/unit/single_controller/test_finalizer_lifecycle.py
@@ -30,6 +30,7 @@ from nemo_rl.data_plane.schema import ROUTE_PLAN_TAG
 from nemo_rl.experience.blackbox_finalizer import FinalizedGroup
 from nemo_rl.experience.finalizer_actor import FinalizationRequest
 from nemo_rl.experience.rollout_recovery import (
+    PromptRef,
     PromptGroupStatus,
     RolloutRecoveryLedger,
 )
@@ -334,11 +335,33 @@ def test_train_selection_transfers_finalized_group_to_open_step() -> None:
     )
     ctrl = _controller(SimpleNamespace())
     ledger = RolloutRecoveryLedger()
-    ledger.adopt_finalized_group(
+    group = ledger.reserve_group(
         group_id="group",
-        meta=meta,
+        prompt_id="17",
+        prompt_ref=PromptRef(sample_id="17", task_name="nemo_gym"),
+        prompt_payload={"idx": 17},  # type: ignore[arg-type]
+        expected_generations=1,
+        target_step=None,
         start_weight_version=3,
-        end_weight_version=3,
+    )
+    ledger.mark_group_dispatched(group.group_id)
+    gate_id = group.gate_rollout_ids[0]
+    ledger.mark_sibling_sealed(
+        group.group_id,
+        generation_index=0,
+        gate_rollout_id=gate_id,
+        receipt={
+            "rollout_id": gate_id,
+            "manifest": [{"staging_key": f"{gate_id}/call"}],
+        },
+        reward=1.0,
+    )
+    ledger.mark_finalization_started(group.group_id)
+    ledger.mark_group_finalized(
+        group.group_id,
+        meta=meta,
+        group_min_weight_version=3,
+        group_max_weight_version=3,
     )
     ctrl._rollout_recovery_ledger = ledger
 
@@ -348,3 +371,19 @@ def test_train_selection_transfers_finalized_group_to_open_step() -> None:
     assert ledger.get_group("group").status == PromptGroupStatus.CLAIMED_FOR_TRAINING
     assert ledger.open_train_step is not None
     assert ledger.open_train_step.group_ids == ["group"]
+
+
+def test_train_selection_rejects_group_missing_from_lineage() -> None:
+    meta = KVBatchMeta(
+        partition_id="canonical",
+        task_name="train",
+        sample_ids=["group_g0"],
+        fields=["input_ids"],
+        sequence_lengths=[3],
+        tags=[{"weight_version": 3}],
+    )
+    ctrl = _controller(SimpleNamespace())
+    ctrl._rollout_recovery_ledger = RolloutRecoveryLedger()
+
+    with pytest.raises(RuntimeError, match="missing from the rollout recovery ledger"):
+        ctrl._claim_train_meta(meta, num_groups=1)

--- a/tests/unit/single_controller/test_finalizer_lifecycle.py
+++ b/tests/unit/single_controller/test_finalizer_lifecycle.py
@@ -29,6 +29,10 @@ from nemo_rl.data_plane import KVBatchMeta
 from nemo_rl.data_plane.schema import ROUTE_PLAN_TAG
 from nemo_rl.experience.blackbox_finalizer import FinalizedGroup
 from nemo_rl.experience.finalizer_actor import FinalizationRequest
+from nemo_rl.experience.rollout_recovery import (
+    PromptGroupStatus,
+    RolloutRecoveryLedger,
+)
 from nemo_rl.experience.route_plan import (
     ROUTE_PLAN_SCHEMA_VERSION,
     RouteAssemblyPlan,
@@ -115,14 +119,19 @@ def _controller(actor: object) -> Any:
     ctrl._finalizer_waiters = 0
     ctrl._finalizer_unknown_outcomes = 0
     ctrl._finalizer_metrics_by_group = {}
+    ctrl._rollout_recovery_ledger = MagicMock()
+    ctrl._rollout_recovery_ledger.__contains__.return_value = False
     ctrl._data_plane_checkpoint_barrier = DataPlaneCheckpointBarrier()
     ctrl._buffer = MagicMock()
     ctrl._buffer.commit_finalized = AsyncMock()
     ctrl._dp_client = _DataPlaneClient()
     ctrl._partition_id = "canonical"
     ctrl._master_config = SimpleNamespace(
-        token_capture=SimpleNamespace(staging_partition="staging")
+        token_capture=SimpleNamespace(staging_partition="staging"),
+        grpo=SimpleNamespace(num_prompts_per_step=1),
     )
+    ctrl._trainer_version = 3
+    ctrl._train_steps = 3
     return ctrl
 
 
@@ -312,3 +321,30 @@ def test_post_train_cleanup_clears_canonical_rows_and_route_plan_staging_keys() 
             "partition_id": "staging",
         },
     ]
+
+
+def test_train_selection_transfers_finalized_group_to_open_step() -> None:
+    meta = KVBatchMeta(
+        partition_id="canonical",
+        task_name="train",
+        sample_ids=["group_g0"],
+        fields=["input_ids"],
+        sequence_lengths=[3],
+        tags=[{"weight_version": 3}],
+    )
+    ctrl = _controller(SimpleNamespace())
+    ledger = RolloutRecoveryLedger()
+    ledger.adopt_finalized_group(
+        group_id="group",
+        meta=meta,
+        start_weight_version=3,
+        end_weight_version=3,
+    )
+    ctrl._rollout_recovery_ledger = ledger
+
+    selected = ctrl._claim_train_meta(meta, num_groups=1)
+
+    assert selected == ["group"]
+    assert ledger.get_group("group").status == PromptGroupStatus.CLAIMED_FOR_TRAINING
+    assert ledger.open_train_step is not None
+    assert ledger.open_train_step.group_ids == ["group"]

--- a/tests/unit/single_controller/test_resiliency_config.py
+++ b/tests/unit/single_controller/test_resiliency_config.py
@@ -1,0 +1,276 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the SingleController resiliency config blocks.
+
+Two things are pinned here. First, every default is inert: a config that does not
+mention these fields must behave exactly as it did before they existed. Second, the
+combinations that would silently do nothing are rejected at load time rather than at
+hour three of a run.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+from nemo_rl.algorithms.grpo import GRPOConfig
+from nemo_rl.algorithms.single_controller_utils.config import (
+    AsyncRLConfig,
+    MasterConfig,
+    RolloutFailureConfig,
+    WatchdogConfig,
+    validate_single_controller_config,
+)
+
+
+class TestDefaultsAreInert:
+    def test_timeouts_default_to_disabled(self):
+        cfg = AsyncRLConfig()
+        assert cfg.rollout_failure.nemo_gym.rollout_timeout_s is None
+        assert cfg.rollout_failure.native.generation_timeout_s is None
+        assert cfg.rollout_failure.native.env_timeout_s is None
+
+    def test_retry_budgets_have_documented_defaults(self):
+        cfg = AsyncRLConfig().rollout_failure
+        assert cfg.max_infra_attempts_per_prompt == 5
+        assert cfg.max_data_attempts_per_prompt == 2
+        assert cfg.backoff_base_s == 1.0
+        assert cfg.max_backoff_s == 30.0
+        assert cfg.max_skipped_prompts == 0
+        assert cfg.nemo_gym.max_row_attempts == 3
+
+    def test_watchdog_has_documented_defaults(self):
+        cfg = AsyncRLConfig().watchdog
+        assert cfg.interval_s == 30.0
+        assert cfg.stall_timeout_s == 600.0
+        assert cfg.stall_action == "warn"
+        assert cfg.gym_subprocess_check is True
+
+    def test_pre_existing_configs_still_load(self):
+        """A config written before these fields existed must be unaffected."""
+        cfg = AsyncRLConfig(
+            **{
+                "sampler": {"name": "in_order", "max_lookahead_versions": 0},
+                "min_groups_for_streaming_train": 4,
+                "max_inflight_prompts": 4,
+                "max_buffered_rollouts": 4,
+            }
+        )
+        assert cfg.rollout_failure.nemo_gym.rollout_timeout_s is None
+        assert cfg.rollout_failure.max_infra_attempts_per_prompt == 5
+
+
+class TestRolloutFailureValidation:
+    def test_backoff_ceiling_below_base_is_rejected(self):
+        with pytest.raises(ValidationError, match="max_backoff_s"):
+            RolloutFailureConfig(backoff_base_s=10.0, max_backoff_s=1.0)
+
+    def test_equal_backoff_bounds_are_allowed(self):
+        cfg = RolloutFailureConfig(backoff_base_s=5.0, max_backoff_s=5.0)
+        assert cfg.max_backoff_s == 5.0
+
+    def test_a_skip_budget_is_accepted(self):
+        cfg = RolloutFailureConfig(max_skipped_prompts=10)
+        assert cfg.max_skipped_prompts == 10
+
+    def test_zero_is_the_default_and_means_fail_on_the_first_one(self):
+        """One knob: the illegal "skip, but never skip anything" state is unrepresentable.
+
+        It used to take an enum plus a count, which could contradict each other, and a
+        validator existed purely to reject that one combination.
+        """
+        assert RolloutFailureConfig().max_skipped_prompts == 0
+
+    @pytest.mark.parametrize("attempts", [0, -1])
+    def test_non_positive_attempt_budgets_are_rejected(self, attempts):
+        with pytest.raises(ValidationError):
+            RolloutFailureConfig(max_infra_attempts_per_prompt=attempts)
+        with pytest.raises(ValidationError):
+            RolloutFailureConfig(max_data_attempts_per_prompt=attempts)
+
+    @pytest.mark.parametrize(
+        ("old", "value"),
+        [
+            ("max_attempts_per_prompt", 5),
+            ("on_data_exhausted", "skip"),
+            ("max_gym_row_attempts", 3),
+        ],
+    )
+    def test_the_previous_key_names_are_rejected_not_ignored(self, old, value):
+        """extra="allow" would let an old key parse and quietly do nothing.
+
+        For on_data_exhausted="skip" that is a behaviour change -- prompts that used to
+        be skipped start failing the run -- delivered with no diagnostic at all.
+        """
+        with pytest.raises(ValidationError, match="renamed"):
+            RolloutFailureConfig(**{old: value})
+
+    @pytest.mark.parametrize(
+        "old", ["rollout_timeout_s", "generation_timeout_s", "env_timeout_s"]
+    )
+    def test_the_relocated_timeout_keys_are_rejected_not_ignored(self, old):
+        """Same reasoning one level up: these moved into rollout_failure sub-blocks."""
+        with pytest.raises(ValidationError, match="moved"):
+            AsyncRLConfig(**{old: 60.0})
+
+
+class TestWatchdogValidation:
+    def test_stall_timeout_must_exceed_the_tick(self):
+        with pytest.raises(ValidationError, match="stall_timeout_s"):
+            WatchdogConfig(interval_s=30.0, stall_timeout_s=30.0)
+
+    def test_stall_timeout_below_the_tick_is_rejected(self):
+        with pytest.raises(ValidationError, match="stall_timeout_s"):
+            WatchdogConfig(interval_s=30.0, stall_timeout_s=5.0)
+
+    def test_unknown_action_is_rejected(self):
+        with pytest.raises(ValidationError):
+            WatchdogConfig(stall_action="explode")
+
+
+class TestWatchdogVersusRolloutTimeout:
+    """The watchdog must outlast EVERY deadline, not just the NeMo-Gym one.
+
+    This guard used to compare stall_timeout_s against rollout_timeout_s alone, so on
+    the native path -- where generation_timeout_s and env_timeout_s are the deadlines --
+    the invariant it advertises went unchecked, and a stall_timeout_s below either
+    produced exactly the false stall reports it exists to prevent.
+    """
+
+    # (sub-block, key) for each deadline the watchdog has to outlast.
+    DEADLINES = [
+        ("nemo_gym", "rollout_timeout_s"),
+        ("native", "generation_timeout_s"),
+        ("native", "env_timeout_s"),
+    ]
+
+    @staticmethod
+    def _cfg(block, key, deadline, stall_timeout_s):
+        return AsyncRLConfig(
+            rollout_failure={block: {key: deadline}},
+            watchdog={"interval_s": 30.0, "stall_timeout_s": stall_timeout_s},
+        )
+
+    @pytest.mark.parametrize(("block", "key"), DEADLINES)
+    def test_watchdog_must_outlast_every_deadline(self, block, key):
+        with pytest.raises(ValidationError, match="stall_timeout_s"):
+            self._cfg(block, key, 900.0, 600.0)
+
+    @pytest.mark.parametrize(("block", "key"), DEADLINES)
+    def test_equal_deadlines_are_rejected(self, block, key):
+        with pytest.raises(ValidationError, match="stall_timeout_s"):
+            self._cfg(block, key, 600.0, 600.0)
+
+    @pytest.mark.parametrize(("block", "key"), DEADLINES)
+    def test_a_longer_watchdog_is_accepted(self, block, key):
+        assert self._cfg(block, key, 900.0, 1200.0).watchdog.stall_timeout_s == 1200.0
+
+    @pytest.mark.parametrize(("block", "key"), DEADLINES)
+    def test_a_disabled_deadline_imposes_no_constraint(self, block, key):
+        assert self._cfg(block, key, None, 60.0).watchdog.stall_timeout_s == 60.0
+
+    @pytest.mark.parametrize(("block", "key"), DEADLINES)
+    @pytest.mark.parametrize("value", [0.0, -1.0])
+    def test_non_positive_timeouts_are_rejected(self, block, key, value):
+        with pytest.raises(ValidationError):
+            AsyncRLConfig(rollout_failure={block: {key: value}})
+
+
+class TestWrongPathFaultToleranceIsRejected:
+    """Nesting shows which knob applies where; only a setup check enforces it.
+
+    A populated sub-block for the path a run is not taking parses fine and then does
+    nothing -- the silent no-op the restructure exists to remove. The chaos harness was
+    itself guilty of this: it set the gym-only rollout_timeout_s on a native run.
+    """
+
+    @staticmethod
+    def _master_config(*, use_nemo_gym: bool, rollout_failure: dict) -> MasterConfig:
+        return MasterConfig.model_construct(
+            async_rl=AsyncRLConfig(
+                min_groups_for_streaming_train=2,
+                max_inflight_prompts=2,
+                rollout_failure=rollout_failure,
+            ),
+            grpo=GRPOConfig.model_construct(
+                num_prompts_per_step=2,
+                num_generations_per_prompt=4,
+                skip_reference_policy_logprobs_calculation=False,
+            ),
+            policy={"train_global_batch_size": 8},
+            loss_fn=SimpleNamespace(reference_policy_kl_penalty=0),
+            env={"should_use_nemo_gym": use_nemo_gym},
+            # Read by the metric_name check upstream #3429 added to this same
+            # validator, which runs before the wrong-path check under test.
+            checkpointing={"enabled": False, "metric_name": None},
+        )
+
+    def test_gym_only_knobs_on_a_native_run_are_rejected(self):
+        cfg = self._master_config(
+            use_nemo_gym=False,
+            rollout_failure={"nemo_gym": {"rollout_timeout_s": 60.0}},
+        )
+        with pytest.raises(ValueError, match="silently ignored"):
+            validate_single_controller_config(cfg)
+
+    def test_native_only_knobs_on_a_gym_run_are_rejected(self):
+        cfg = self._master_config(
+            use_nemo_gym=True,
+            rollout_failure={"native": {"generation_timeout_s": 60.0}},
+        )
+        with pytest.raises(ValueError, match="silently ignored"):
+            validate_single_controller_config(cfg)
+
+    def test_the_row_attempt_budget_counts_as_gym_only(self):
+        """It is not a deadline, but it is just as inert on the native path."""
+        cfg = self._master_config(
+            use_nemo_gym=False, rollout_failure={"nemo_gym": {"max_row_attempts": 7}}
+        )
+        with pytest.raises(ValueError, match="max_row_attempts"):
+            validate_single_controller_config(cfg)
+
+    def test_the_applicable_block_is_accepted_on_each_path(self):
+        validate_single_controller_config(
+            self._master_config(
+                use_nemo_gym=False,
+                rollout_failure={"native": {"generation_timeout_s": 60.0}},
+            )
+        )
+        validate_single_controller_config(
+            self._master_config(
+                use_nemo_gym=True,
+                rollout_failure={"nemo_gym": {"rollout_timeout_s": 60.0}},
+            )
+        )
+
+    @pytest.mark.parametrize("use_nemo_gym", [True, False])
+    def test_defaults_are_accepted_on_both_paths(self, use_nemo_gym):
+        """Inert by default: an untouched config must never trip this."""
+        validate_single_controller_config(
+            self._master_config(use_nemo_gym=use_nemo_gym, rollout_failure={})
+        )
+
+    def test_a_config_without_env_is_skipped_not_crashed(self):
+        """`env` is required, so model_construct leaves it absent entirely.
+
+        Reading it unguarded raised AttributeError from inside
+        SingleControllerActor.__init__ and killed the actor -- for a check that only
+        needs it to pick which half of the block is inert. Caught by an upstream
+        vLLM test that builds its config this way, not by this suite.
+        """
+        cfg = self._master_config(use_nemo_gym=False, rollout_failure={})
+        del cfg.env
+        assert not hasattr(cfg, "env")
+        validate_single_controller_config(cfg)

--- a/tests/unit/single_controller/test_rollout_pump.py
+++ b/tests/unit/single_controller/test_rollout_pump.py
@@ -41,7 +41,7 @@ from nemo_rl.algorithms.single_controller_utils.config import (
 )
 from nemo_rl.algorithms.single_controller_utils.setup import SingleControllerActorArgs
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
-from nemo_rl.experience.rollout_manager import RolloutManager
+from nemo_rl.experience.rollout_manager import RolloutManager, RolloutOutcome
 
 # Reuse fixtures from the experience tests; same shape as test_async_rollout_manager.
 from tests.unit.experience.test_rollout_manager import (
@@ -137,6 +137,61 @@ def test_rollout_pump_stamps_target_steps(
 
     assert buffer.target_step_list == expected_target_steps
     assert ctrl._rollout_exhausted.is_set()
+
+
+@pytest.mark.parametrize(
+    ("outcome", "expect_permit_released"),
+    [
+        # A committed group transfers permit ownership to the train pump, which
+        # releases it after consuming the group.
+        (RolloutOutcome.COMMITTED, False),
+        # A skipped prompt never reaches the buffer, so the train pump will never
+        # see it and the dispatcher must release the permit itself. Getting this
+        # wrong leaks one backpressure slot per skipped prompt until the pump wedges.
+        (RolloutOutcome.SKIPPED, True),
+    ],
+)
+def test_rollout_pump_releases_capacity_only_for_uncommitted_prompts(
+    outcome: RolloutOutcome, expect_permit_released: bool
+) -> None:
+    class _OutcomeRolloutManager:
+        async def generate_and_push(
+            self,
+            prompt: Any,
+            *,
+            target_step: int | None = None,
+            inflight_registry: dict[str, Any] | None = None,
+        ) -> RolloutOutcome:
+            del prompt, target_step, inflight_registry
+            return outcome
+
+    controller_cls = SingleControllerActor.__ray_metadata__.modified_class
+    ctrl = object.__new__(controller_cls)
+    ctrl._async_cfg = SimpleNamespace(max_inflight_prompts=2, diagnostics=False)
+    ctrl._master_config = SimpleNamespace(
+        grpo=GRPOConfig.model_construct(max_num_epochs=1)
+    )
+    ctrl._rollout_manager = _OutcomeRolloutManager()
+    ctrl._sampler = WindowedSampler(None, max_staleness_versions=1)
+    ctrl._dataloader = [
+        BatchedDataDict({"message_log": [[{"role": "user", "content": "prompt"}]]})
+    ]
+    ctrl._rollout_permitted = asyncio.Event()
+    ctrl._rollout_permitted.set()
+    ctrl._rollout_exhausted = asyncio.Event()
+    ctrl._buffer_capacity = asyncio.Semaphore(2)
+    ctrl._inflight_rollouts = 0
+    ctrl._dispatched_rollouts = set()
+    ctrl._trainer_version = 0
+    ctrl._current_epoch = 0
+    ctrl._inflight_by_group_id = {}
+
+    asyncio.run(ctrl._rollout_pump())
+
+    # One prompt was dispatched out of a semaphore sized 2.
+    expected = 2 if expect_permit_released else 1
+    assert ctrl._buffer_capacity._value == expected
+    assert ctrl._inflight_rollouts == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/single_controller/test_sc_checkpointing.py
+++ b/tests/unit/single_controller/test_sc_checkpointing.py
@@ -332,6 +332,7 @@ class _FakeRolloutManager:
     def __init__(self) -> None:
         self.weight_versions: list[int] = []
         self._tq_buffer = None
+        self.recovery_ledger = None
 
     def set_weight_version(self, version: int) -> None:
         self.weight_versions.append(version)
@@ -359,6 +360,10 @@ class _FakeTQBuffer:
         self.metadata_state_dict_calls: list[int] = []
         self.load_calls: list[dict[str, Any]] = []
         self.checkpoint_barrier: Optional[DataPlaneCheckpointBarrier] = None
+
+    @property
+    def group_ids(self) -> tuple[str, ...]:
+        return ()
 
     def set_data_plane_checkpoint_barrier(
         self, barrier: DataPlaneCheckpointBarrier

--- a/tests/unit/single_controller/test_single_controller.py
+++ b/tests/unit/single_controller/test_single_controller.py
@@ -65,6 +65,7 @@ def test_rejects_multiple_optimizer_steps_per_rl_step(monkeypatch) -> None:
         ),
         async_rl=AsyncRLConfig(min_groups_for_streaming_train=1),
         logger={},
+        env={},
     )
     actor_args = SimpleNamespace(
         partition_id="rollout_data",
@@ -77,6 +78,7 @@ def test_rejects_multiple_optimizer_steps_per_rl_step(monkeypatch) -> None:
         loss_fn=None,
         tq_buffer=None,
         rollout_manager=SimpleNamespace(_tq_buffer=None),
+        env_handles={},
         train_cluster=None,
         inference_cluster=None,
     )
@@ -115,6 +117,7 @@ def test_logs_hyperparameters_and_concrete_weight_synchronizer(
             max_buffered_rollouts=4,
         ),
         logger={},
+        env={},
         # __init__ builds a CheckpointManager + TimeoutChecker from this block.
         checkpointing=_checkpointing_config(tmp_path),
     )
@@ -129,6 +132,7 @@ def test_logs_hyperparameters_and_concrete_weight_synchronizer(
         loss_fn=None,
         tq_buffer=None,
         rollout_manager=SimpleNamespace(_tq_buffer=None),
+        env_handles={},
         train_cluster=None,
         inference_cluster=None,
         save_state=_initial_grpo_save_state(),
@@ -165,6 +169,7 @@ def test_logs_setup_timing_metrics(monkeypatch, tmp_path) -> None:
             max_buffered_rollouts=4,
         ),
         logger={},
+        env={},
         # __init__ builds a CheckpointManager + TimeoutChecker from this block.
         checkpointing=_checkpointing_config(tmp_path),
     )
@@ -184,6 +189,10 @@ def test_logs_setup_timing_metrics(monkeypatch, tmp_path) -> None:
         rollout_manager=SimpleNamespace(_tq_buffer=None),
         train_cluster=None,
         inference_cluster=None,
+        # A real field of SingleControllerActorArgs. Read directly rather than via a
+        # getattr default, so omitting it breaks here instead of silently degrading
+        # watchdog.gym_subprocess_check into a no-op at runtime.
+        env_handles={},
         save_state=_initial_grpo_save_state(),
         last_checkpoint_path=None,
         data_plane_checkpoint_metadata=None,

--- a/tests/unit/single_controller/test_single_controller.py
+++ b/tests/unit/single_controller/test_single_controller.py
@@ -77,7 +77,7 @@ def test_rejects_multiple_optimizer_steps_per_rl_step(monkeypatch) -> None:
         advantage_estimator=None,
         loss_fn=None,
         tq_buffer=None,
-        rollout_manager=SimpleNamespace(_tq_buffer=None),
+        rollout_manager=SimpleNamespace(_tq_buffer=None, recovery_ledger=None),
         env_handles={},
         train_cluster=None,
         inference_cluster=None,
@@ -131,7 +131,7 @@ def test_logs_hyperparameters_and_concrete_weight_synchronizer(
         advantage_estimator=None,
         loss_fn=None,
         tq_buffer=None,
-        rollout_manager=SimpleNamespace(_tq_buffer=None),
+        rollout_manager=SimpleNamespace(_tq_buffer=None, recovery_ledger=None),
         env_handles={},
         train_cluster=None,
         inference_cluster=None,
@@ -186,7 +186,7 @@ def test_logs_setup_timing_metrics(monkeypatch, tmp_path) -> None:
         advantage_estimator=None,
         loss_fn=None,
         tq_buffer=None,
-        rollout_manager=SimpleNamespace(_tq_buffer=None),
+        rollout_manager=SimpleNamespace(_tq_buffer=None, recovery_ledger=None),
         train_cluster=None,
         inference_cluster=None,
         # A real field of SingleControllerActorArgs. Read directly rather than via a
@@ -382,6 +382,7 @@ def _train_pump_controller(*, sampler) -> object:
     ctrl._trainer_version = 0
     ctrl._train_steps = 0
     ctrl._data_plane_checkpoint_barrier = DataPlaneCheckpointBarrier()
+    ctrl._rollout_recovery_ledger = None
     ctrl._step_log_dict = {
         "rewards": [],
         "masked_advantages": [],

--- a/tests/unit/single_controller/test_watchdog_pump.py
+++ b/tests/unit/single_controller/test_watchdog_pump.py
@@ -1,0 +1,340 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Watchdog: the last line of defence for failures nothing else catches.
+
+Every other guard in this phase reacts to something raising. The wedge described in the
+resiliency report raises nothing at all -- rollouts sit in NeMo-Gym's uncapped retry loop
+while the train pump spins -- so the only way to see it is to notice that committed
+groups stopped moving while rollouts are still in flight.
+
+Progress is measured by the committed counter rather than a timestamp because that is the
+property that matters: "no group has landed" is the symptom, whatever the cause.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from nemo_rl.algorithms.grpo import GRPOConfig
+from nemo_rl.algorithms.single_controller import SingleControllerActor
+from nemo_rl.experience.failures import RolloutStall
+from nemo_rl.experience.rollout_manager import RolloutStats
+
+
+class _RecordingLogger:
+    def __init__(self) -> None:
+        self.metrics: list[dict] = []
+
+    def log_metrics(self, metrics, step=0, prefix="", **kwargs) -> None:
+        del step, prefix, kwargs
+        self.metrics.append(dict(metrics))
+
+
+def _make_controller(
+    *,
+    stats: RolloutStats,
+    inflight: int,
+    stall_timeout_s: float,
+    stall_action: str = "warn",
+    gym_subprocess_check: bool = False,
+    env_handles=None,
+    train_steps: int = 0,
+    max_num_steps: int = 100,
+):
+    controller_cls = SingleControllerActor.__ray_metadata__.modified_class
+    ctrl = object.__new__(controller_cls)
+    ctrl._async_cfg = SimpleNamespace(
+        watchdog=SimpleNamespace(
+            # Tiny tick so the loop runs immediately; the stall threshold is what the
+            # tests actually vary.
+            interval_s=0.001,
+            stall_timeout_s=stall_timeout_s,
+            stall_action=stall_action,
+            gym_subprocess_check=gym_subprocess_check,
+        )
+    )
+    ctrl._master_config = SimpleNamespace(
+        grpo=GRPOConfig.model_construct(max_num_steps=max_num_steps)
+    )
+    ctrl._rollout_manager = SimpleNamespace(stats=stats)
+    ctrl._inflight_rollouts = inflight
+    ctrl._train_steps = train_steps
+    ctrl._logger = _RecordingLogger()
+    ctrl._env_handles = env_handles if env_handles is not None else {}
+    return ctrl
+
+
+async def _run_ticks(ctrl, ticks: int):
+    """Run the watchdog for a bounded number of ticks, then cancel it."""
+    task = asyncio.ensure_future(ctrl._watchdog_pump())
+    # Each tick sleeps interval_s (1ms); give it room for `ticks` of them.
+    await asyncio.sleep(0.005 * ticks)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    return task
+
+
+class TestStallDetection:
+    def test_no_stall_is_reported_while_groups_keep_landing(self):
+        stats = RolloutStats()
+
+        async def _main():
+            ctrl = _make_controller(stats=stats, inflight=4, stall_timeout_s=0.0)
+            task = asyncio.ensure_future(ctrl._watchdog_pump())
+            for _ in range(5):
+                await asyncio.sleep(0.003)
+                stats.committed += 1  # progress on every tick
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        # stall_timeout_s=0 would fire instantly if progress were not being seen.
+        asyncio.run(_main())
+
+    def test_no_progress_while_work_remains_aborts_when_configured(self):
+        stats = RolloutStats()
+        ctrl = _make_controller(
+            stats=stats, inflight=8, stall_timeout_s=0.0, stall_action="abort"
+        )
+        with pytest.raises(RolloutStall, match="8 rollouts in flight"):
+            asyncio.run(ctrl._watchdog_pump())
+
+    def test_a_wedge_with_nothing_in_flight_is_still_a_stall(self):
+        """Regression guard for the gap a fault-injection run walked straight through.
+
+        Killing a generation worker wedged the loop with zero rollouts in flight and
+        zero failures recorded: the rollout pump sat on backpressure behind a train
+        pump that could no longer finish a step, so there was nothing in flight to
+        count. The earlier `inflight > 0` condition meant the watchdog watched six
+        minutes of idleness and said nothing.
+        """
+        stats = RolloutStats()
+        stats.committed = 10  # groups landed before the wedge, then stopped
+        ctrl = _make_controller(
+            stats=stats,
+            inflight=0,
+            stall_timeout_s=0.0,
+            stall_action="abort",
+            train_steps=4,
+            max_num_steps=50,
+        )
+        with pytest.raises(RolloutStall, match="0 rollouts in flight"):
+            asyncio.run(ctrl._watchdog_pump())
+
+    def test_warn_mode_reports_without_ending_the_run(self, capsys):
+        stats = RolloutStats()
+        ctrl = _make_controller(
+            stats=stats, inflight=3, stall_timeout_s=0.0, stall_action="warn"
+        )
+        asyncio.run(_run_ticks(ctrl, 3))
+        assert "rollout stall" in capsys.readouterr().out
+
+    def test_a_finished_run_is_not_a_stall(self):
+        """With every step done there is nothing left to wait for."""
+        stats = RolloutStats()
+        ctrl = _make_controller(
+            stats=stats,
+            inflight=0,
+            stall_timeout_s=0.0,
+            stall_action="abort",
+            train_steps=50,
+            max_num_steps=50,
+        )
+        asyncio.run(_run_ticks(ctrl, 3))
+
+    def test_train_step_progress_counts_even_without_new_commits(self):
+        """A step draining already-buffered groups is progress, not a stall."""
+        stats = RolloutStats()
+
+        async def _main():
+            # Threshold comfortably above the progress cadence below, so only a real
+            # gap in progress can trip it.
+            ctrl = _make_controller(
+                stats=stats,
+                inflight=0,
+                stall_timeout_s=0.05,
+                stall_action="abort",
+                max_num_steps=100,
+            )
+            task = asyncio.ensure_future(ctrl._watchdog_pump())
+            for _ in range(5):
+                await asyncio.sleep(0.003)
+                ctrl._train_steps += 1  # commits frozen, steps advancing
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        asyncio.run(_main())
+
+
+class TestMetrics:
+    def test_rollout_counters_and_inflight_are_published(self):
+        stats = RolloutStats()
+        stats.committed = 7
+        stats.record_redispatch("GenerationUnavailable")
+        ctrl = _make_controller(stats=stats, inflight=2, stall_timeout_s=1000.0)
+
+        asyncio.run(_run_ticks(ctrl, 2))
+
+        assert ctrl._logger.metrics, "the watchdog must publish something"
+        published = ctrl._logger.metrics[-1]
+        assert published["rollout/committed_total"] == 7.0
+        assert published["rollout/redispatch_total"] == 1.0
+        assert published["rollout/inflight"] == 2.0
+        # The leading indicator: idle time rises before a wedge becomes a stall.
+        assert "rollout/idle_s" in published
+
+
+class TestEnvHealthCheck:
+    def test_a_healthy_environment_passes(self):
+        calls = []
+
+        class _Handle:
+            health_check = SimpleNamespace(
+                remote=lambda: _completed(calls.append("checked"))
+            )
+
+        ctrl = _make_controller(
+            stats=RolloutStats(),
+            inflight=0,
+            stall_timeout_s=1000.0,
+            gym_subprocess_check=True,
+            env_handles={"nemo_gym": _Handle()},
+        )
+        asyncio.run(_run_ticks(ctrl, 2))
+        assert calls, "health_check should have been polled"
+
+    def test_an_unhealthy_environment_is_named_in_the_error(self):
+        """Gym's poll() names the dead process; the env name says which actor it was."""
+
+        class _Handle:
+            health_check = SimpleNamespace(
+                remote=lambda: _failed(
+                    RuntimeError("Process `workplace_assistant` finished unexpectedly!")
+                )
+            )
+
+        ctrl = _make_controller(
+            stats=RolloutStats(),
+            inflight=0,
+            stall_timeout_s=1000.0,
+            stall_action="abort",
+            gym_subprocess_check=True,
+            env_handles={"nemo_gym": _Handle()},
+        )
+        with pytest.raises(RuntimeError, match="'nemo_gym' reported unhealthy"):
+            asyncio.run(ctrl._watchdog_pump())
+
+    def test_an_unhealthy_environment_only_warns_under_the_default_action(self, capsys):
+        """stall_action="warn" promises to "only report". It has to mean that here too.
+
+        This path raised unconditionally, so with gym_subprocess_check defaulting to
+        true, an unhealthy environment ended the run under the documented default -- a
+        run-killing path switched on by default in a feature that is meant to be
+        inert until configured.
+        """
+
+        class _Handle:
+            health_check = SimpleNamespace(
+                remote=lambda: _failed(RuntimeError("subprocess died"))
+            )
+
+        ctrl = _make_controller(
+            stats=RolloutStats(),
+            inflight=0,
+            stall_timeout_s=1000.0,
+            stall_action="warn",
+            gym_subprocess_check=True,
+            env_handles={"nemo_gym": _Handle()},
+        )
+        # Must complete its ticks rather than blowing up.
+        asyncio.run(_run_ticks(ctrl, 2))
+        out = capsys.readouterr().out
+        assert "environment health" in out
+        assert "nemo_gym" in out
+
+    def test_a_wedged_environment_does_not_stop_the_pump(self):
+        """The failure this whole check exists for must not disable the check.
+
+        NemoGym is an asyncio actor: a wedged one never answers, and an unbounded await
+        meant the pump stopped ticking and stall detection died exactly when it was
+        needed. A probe that does not answer within a tick IS the unhealthy signal.
+        """
+        never_resolves: list[asyncio.Future] = []
+
+        def _hang():
+            future: asyncio.Future = asyncio.get_event_loop().create_future()
+            never_resolves.append(future)
+            return future
+
+        class _Handle:
+            health_check = SimpleNamespace(remote=_hang)
+
+        ctrl = _make_controller(
+            stats=RolloutStats(),
+            inflight=0,
+            stall_timeout_s=1000.0,
+            stall_action="warn",
+            gym_subprocess_check=True,
+            env_handles={"nemo_gym": _Handle()},
+        )
+        asyncio.run(_run_ticks(ctrl, 4))
+        # The pump kept ticking despite the environment never answering.
+        assert len(ctrl._logger.metrics) >= 2, (
+            "watchdog stopped ticking while an environment was wedged"
+        )
+        assert never_resolves, "the health check was never actually polled"
+
+    def test_environments_without_a_health_check_are_skipped(self):
+        """Only NeMo-Gym has subprocess servers to lose; math envs must not trip this."""
+        ctrl = _make_controller(
+            stats=RolloutStats(),
+            inflight=0,
+            stall_timeout_s=1000.0,
+            gym_subprocess_check=True,
+            env_handles={"math": SimpleNamespace()},
+        )
+        asyncio.run(_run_ticks(ctrl, 2))
+
+    def test_the_check_can_be_disabled(self):
+        class _Handle:
+            health_check = SimpleNamespace(
+                remote=lambda: _failed(RuntimeError("would fail if polled"))
+            )
+
+        ctrl = _make_controller(
+            stats=RolloutStats(),
+            inflight=0,
+            stall_timeout_s=1000.0,
+            gym_subprocess_check=False,
+            env_handles={"nemo_gym": _Handle()},
+        )
+        asyncio.run(_run_ticks(ctrl, 2))
+
+
+def _completed(_value=None):
+    future: asyncio.Future = asyncio.get_event_loop().create_future()
+    future.set_result(None)
+    return future
+
+
+def _failed(error: BaseException):
+    future: asyncio.Future = asyncio.get_event_loop().create_future()
+    future.set_exception(error)
+    return future


### PR DESCRIPTION
# What does this PR do?

Adds the durable identity and in-memory lineage foundation for recovering partially completed NeMo-Gym prompt groups.

- Gives each prompt group and GRPO sibling a stable logical identity.
- Tracks physical Gym/Gate attempts separately, so redispatch can create a new attempt without changing canonical training-row identity.
- Records sibling receipts, rewards, and TQ staging keys as soon as Gym seals them.
- Models ownership through generation, finalization, training claim, and uncheckpointed application.
- Preserves sealed siblings when another sibling fails and abandons only unfinished attempts.
- Stores compact attempt UUIDs and small `PromptRef` values while excluding full runtime prompts from serialized lineage.
- Validates the versioned serialized state and rejects unsupported or invalid statuses.

This layer intentionally does not persist or restore the ledger. Persistence and selective redispatch are added by #3507.

## Stack

- Layer 1 of 4.
- Base: `amahishi/sc-tq-token-capture-recovery`, refreshed with the current capture/recovery integration.
- Next: #3507.

## Scope

This is internal plumbing for the existing `token_capture.enabled=true` Single Controller NeMo-Gym path. It adds no user-facing configuration.

Tensor payloads remain in TQ. The controller ledger contains identity, ownership state, compact prompt references, receipts, rewards, and storage references.

## Validation

- Unit coverage is included for identity, lineage transitions, retries, finalization ownership, training claims, serialization, and invalid persisted states.
- The PR remains draft while the refreshed focused suite, recovery functionals, and full CI are rerun.
