### PR TITLE
feat(rollout): persist and recover partial rollout groups

### DIFF
--- a/nemo_rl/algorithms/async_utils/replay_buffer.py
+++ b/nemo_rl/algorithms/async_utils/replay_buffer.py
@@ -158,16 +158,33 @@ class DataPlaneCheckpointBarrier:
         self._condition = asyncio.Condition()
         self._checkpoint_active = False
         self._active_mutations = 0
+        self._mutation_depth_by_task: dict[asyncio.Task[Any], int] = {}
 
     @asynccontextmanager
     async def mutation(self) -> AsyncIterator[None]:
         """Enter a commit/clear section, waiting only for an active checkpoint."""
+        task = asyncio.current_task()
+        if task is None:
+            raise RuntimeError("data-plane mutation must run inside an asyncio task")
+        depth = self._mutation_depth_by_task.get(task, 0)
+        if depth:
+            # Replay-buffer helpers may join a controller-owned mutation. Do not
+            # wait behind a checkpoint that is already waiting for this outer
+            # mutation, or the two tasks deadlock.
+            self._mutation_depth_by_task[task] = depth + 1
+            try:
+                yield
+            finally:
+                self._mutation_depth_by_task[task] -= 1
+            return
         async with self._condition:
             await self._condition.wait_for(lambda: not self._checkpoint_active)
             self._active_mutations += 1
+            self._mutation_depth_by_task[task] = 1
         try:
             yield
         finally:
+            del self._mutation_depth_by_task[task]
             async with self._condition:
                 self._active_mutations -= 1
                 if self._active_mutations == 0:

--- a/nemo_rl/algorithms/async_utils/staleness_sampler.py
+++ b/nemo_rl/algorithms/async_utils/staleness_sampler.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 import abc
 import asyncio
 import importlib
+from collections import Counter
 from typing import (
     Annotated,
     Callable,
@@ -120,6 +121,19 @@ class PromptGroupSampler(Protocol):
     def set_dispatch_index(self, resume_from_trainer_version: int) -> None:
         """Seed the dispatch cursor when resuming from a checkpoint."""
         ...
+
+
+@runtime_checkable
+class CheckpointDispatchSampler(Protocol):
+    """Sampler that can reconstruct dispatch state from restored groups."""
+
+    def restore_dispatch_state(
+        self,
+        *,
+        current_train_weight: int,
+        restored_target_steps: list[Optional[int]],
+        groups_per_step: int,
+    ) -> None: ...
 
 
 class BaseSampler(abc.ABC):
@@ -204,6 +218,19 @@ class BaseSampler(abc.ABC):
 
     def required_buffer_capacity(self, groups_per_step: int) -> Optional[int]:
         return None
+
+    def restore_dispatch_state(
+        self,
+        *,
+        current_train_weight: int,
+        restored_target_steps: list[Optional[int]],
+        groups_per_step: int,
+    ) -> None:
+        """Validate the default unstamped checkpoint representation."""
+        if any(target is not None for target in restored_target_steps):
+            raise ValueError(
+                f"{type(self).__name__} cannot restore stamped target steps"
+            )
 
     # ── shared helpers ───────────────────────────────────────────────────
     def _eviction_window(self) -> int:
@@ -414,6 +441,62 @@ class InOrderSampler(_GatedSampler):
 
     def _stamp(self) -> Optional[int]:
         return self._dispatch_index
+
+    supports_buffer_checkpoint: ClassVar[bool] = True
+
+    def restore_dispatch_state(
+        self,
+        *,
+        current_train_weight: int,
+        restored_target_steps: list[Optional[int]],
+        groups_per_step: int,
+    ) -> None:
+        """Resume admission after the highest target restored from the cut."""
+        if groups_per_step < 1:
+            raise ValueError(f"groups_per_step must be positive, got {groups_per_step}")
+        if not restored_target_steps:
+            return
+        if any(target is None for target in restored_target_steps):
+            raise ValueError("restored InOrder groups must have target_step values")
+
+        target_steps = [
+            target for target in restored_target_steps if target is not None
+        ]
+        counts: Counter[int] = Counter(target_steps)
+        oldest_target = min(counts)
+        newest_target = max(counts)
+        if oldest_target < current_train_weight:
+            raise ValueError(
+                "restored InOrder target is older than the trainer: "
+                f"oldest_target={oldest_target}, "
+                f"trainer_version={current_train_weight}"
+            )
+        max_allowed_target = current_train_weight + self.max_lookahead_versions
+        if newest_target > max_allowed_target:
+            raise ValueError(
+                "restored InOrder target exceeds the configured lookahead: "
+                f"newest_target={newest_target}, "
+                f"max_allowed_target={max_allowed_target}"
+            )
+        expected_targets = set(range(current_train_weight, newest_target + 1))
+        if set(counts) != expected_targets:
+            raise ValueError(
+                "restored InOrder targets are not contiguous from the current "
+                f"trainer version: restored={sorted(counts)}, "
+                f"expected={sorted(expected_targets)}"
+            )
+        invalid_counts = {
+            target: count
+            for target, count in counts.items()
+            if count != groups_per_step
+        }
+        if invalid_counts:
+            raise ValueError(
+                "restored InOrder target batches do not contain exactly "
+                f"grpo.num_prompts_per_step={groups_per_step} groups: "
+                f"counts={dict(sorted(counts.items()))}"
+            )
+        self._dispatch_index = newest_target
 
     async def select(
         self,

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -264,6 +264,10 @@ class SingleControllerActor:
         # dispatched tasks finish successfully. Rollout failures propagate
         # through run() instead of being reported as normal exhaustion.
         self._rollout_exhausted: asyncio.Event = asyncio.Event()
+        # Restored groups run beside the normal pumps. Dataloader exhaustion is
+        # not terminal until this source has also drained.
+        self._rollout_recovery_complete: asyncio.Event = asyncio.Event()
+        self._rollout_recovery_complete.set()
 
         # Count of in-flight generate_and_push calls
         self._inflight_rollouts: int = 0
@@ -278,6 +282,12 @@ class SingleControllerActor:
         # drops a group (sampler.evict or post-train buffer.remove).
         self._buffer_capacity: asyncio.Semaphore = asyncio.Semaphore(
             self._async_cfg.max_buffered_rollouts
+        )
+        # Recovery and fresh dispatch share one generation budget. Restored
+        # groups reserve buffer ownership first, then compete for worker slots
+        # without blocking genuinely spare capacity from serving fresh prompts.
+        self._rollout_slots: asyncio.Semaphore = asyncio.Semaphore(
+            self._async_cfg.max_inflight_prompts
         )
 
         self._trainer_version: int = restored_trainer_version
@@ -306,29 +316,42 @@ class SingleControllerActor:
         await self._sync_weights()
 
         restored_replay_groups = await self._maybe_restore_replay_buffer()
-        await self._maybe_restore_rollout_recovery(
+        recovery_groups = await self._prepare_rollout_recovery(
             restored_replay_groups=restored_replay_groups
         )
 
-        # Start the rollout and train pumps, plus the watchdog
+        # Start restored work and normal pumps together. Preparation above has
+        # already reconstructed sampler state and reserved restored capacity,
+        # so fresh dispatch can use only genuine headroom.
+        recovery_task = (
+            asyncio.create_task(self._recover_prepared_rollout_groups(recovery_groups))
+            if recovery_groups
+            else None
+        )
         rollout_task = asyncio.create_task(self._rollout_pump())
         train_task = asyncio.create_task(self._train_pump())
         watchdog_task = asyncio.create_task(self._watchdog_pump())
-        tasks = (rollout_task, train_task, watchdog_task)
+        tasks = {rollout_task, train_task, watchdog_task}
+        if recovery_task is not None:
+            tasks.add(recovery_task)
         try:
-            done, _ = await asyncio.wait(
-                set(tasks), return_when=asyncio.FIRST_COMPLETED
-            )
-            if watchdog_task in done:
-                # The watchdog loops forever, so finishing at all means it raised --
-                # a stall or an unhealthy environment. Surface that ahead of the
-                # pumps, whose own symptom would just be "waiting".
-                await watchdog_task
-            if rollout_task in done:
-                # Propagate rollout failures immediately. A normally exhausted
-                # rollout pump leaves the train pump to drain committed groups.
-                await rollout_task
-            await train_task
+            pending = set(tasks)
+            while pending:
+                done, pending = await asyncio.wait(
+                    pending, return_when=asyncio.FIRST_COMPLETED
+                )
+                for task in done:
+                    # Propagate recovery, rollout, training, and watchdog
+                    # failures as soon as their owning task reports them.
+                    await task
+                if train_task in done:
+                    # A max-step exit can happen before recovery drains. Do not
+                    # leave restored lineage half-mutated merely because enough
+                    # other groups completed the requested training steps.
+                    if recovery_task is not None and not recovery_task.done():
+                        rollout_task.cancel()
+                        await recovery_task
+                    break
         finally:
             for task in tasks:
                 task.cancel()
@@ -812,16 +835,17 @@ class SingleControllerActor:
             flush=True,
         )
 
-    async def _maybe_restore_rollout_recovery(
+    async def _prepare_rollout_recovery(
         self, *, restored_replay_groups: int
-    ) -> None:
-        """Complete restored unfinished groups before starting either SC pump."""
+    ) -> list[PromptGroupRecoverySummary]:
+        """Validate restored lineage and reclaim its durable buffer permits."""
+        self._rollout_recovery_complete.set()
         metadata = self._data_plane_checkpoint_metadata or {}
         if "rollout_recovery_payload_sha256" not in metadata:
             self._restore_sampler_dispatch_state(
                 [], restored_replay_groups=restored_replay_groups
             )
-            return
+            return []
         ledger = self._rollout_recovery_ledger
         if ledger is None:
             raise RuntimeError(
@@ -885,25 +909,119 @@ class SingleControllerActor:
                 f"capacity={self._async_cfg.max_buffered_rollouts}"
             )
 
-        for group in unfinished:
-            await self._buffer_capacity.acquire()
-            try:
-                request = await self._rollout_manager.recover_for_finalization(
-                    group.group_id,
-                    inflight_registry=self._inflight_by_group_id,
-                )
-                if request is None:
-                    self._buffer_capacity.release()
-                    continue
-                await self._finalize_with_actor(request)
-            except BaseException:
+        # Reclaim all saved permits before fresh dataloader work can run. The
+        # capacity check above makes these acquisitions immediate and prevents
+        # new work from stealing ownership represented by the durable ledger.
+        acquired = 0
+        try:
+            for _ in unfinished:
+                await self._buffer_capacity.acquire()
+                acquired += 1
+        except BaseException:
+            for _ in range(acquired):
                 self._buffer_capacity.release()
-                raise
+            raise
+
         if unfinished:
+            self._rollout_recovery_complete.clear()
+        return unfinished
+
+    @staticmethod
+    def _release_recovery_permit_if_task_not_started(
+        _: asyncio.Task[Any],
+        *,
+        task_started_event: asyncio.Event,
+        buffer_capacity: asyncio.Semaphore,
+    ) -> None:
+        """Return preclaimed capacity if cancellation beats coroutine startup."""
+        if not task_started_event.is_set():
+            buffer_capacity.release()
+
+    async def _recover_one_prepared_group(
+        self,
+        group: PromptGroupRecoverySummary,
+        *,
+        task_started_event: asyncio.Event,
+    ) -> bool:
+        """Recover one capacity-owned group through the shared worker budget."""
+        task_started_event.set()
+        buffer_permit_owned = True
+        rollout_slot_owned = False
+        counted_inflight = False
+        try:
+            await self._rollout_slots.acquire()
+            rollout_slot_owned = True
+            await self._rollout_permitted.wait()
+            self._inflight_rollouts += 1
+            counted_inflight = True
+
+            request = await self._rollout_manager.recover_for_finalization(
+                group.group_id,
+                inflight_registry=self._inflight_by_group_id,
+            )
+
+            # Generation capacity protects vLLM/Gym work, not the independent
+            # finalizer pool. Release it as soon as token capture is complete.
+            self._inflight_rollouts -= 1
+            counted_inflight = False
+            self._rollout_slots.release()
+            rollout_slot_owned = False
+
+            if request is None:
+                return False
+            await self._finalize_with_actor(request)
+            buffer_permit_owned = False
+            return True
+        finally:
+            if counted_inflight:
+                self._inflight_rollouts -= 1
+            if rollout_slot_owned:
+                self._rollout_slots.release()
+            if buffer_permit_owned:
+                self._buffer_capacity.release()
+
+    async def _recover_prepared_rollout_groups(
+        self, groups: list[PromptGroupRecoverySummary]
+    ) -> None:
+        """Recover restored groups concurrently beside fresh rollout dispatch."""
+        recovery_tasks: list[asyncio.Task[bool]] = []
+        try:
+            async with asyncio.TaskGroup() as task_group:
+                for group in groups:
+                    task_started_event = asyncio.Event()
+                    task = task_group.create_task(
+                        self._recover_one_prepared_group(
+                            group,
+                            task_started_event=task_started_event,
+                        )
+                    )
+                    task.add_done_callback(
+                        partial(
+                            self._release_recovery_permit_if_task_not_started,
+                            task_started_event=task_started_event,
+                            buffer_capacity=self._buffer_capacity,
+                        )
+                    )
+                    recovery_tasks.append(task)
+
+            completed = sum(task.result() for task in recovery_tasks)
             print(
-                f"📦 Rollout recovery completed: groups={len(unfinished)}",
+                "📦 Rollout recovery completed: "
+                f"groups={len(groups)}, finalized={completed}, "
+                f"dropped={len(groups) - completed}",
                 flush=True,
             )
+        finally:
+            self._rollout_recovery_complete.set()
+
+    async def _maybe_restore_rollout_recovery(
+        self, *, restored_replay_groups: int
+    ) -> None:
+        """Compatibility helper for focused recovery callers and tests."""
+        groups = await self._prepare_rollout_recovery(
+            restored_replay_groups=restored_replay_groups
+        )
+        await self._recover_prepared_rollout_groups(groups)
 
     def _restore_sampler_dispatch_state(
         self,
@@ -1100,13 +1218,12 @@ class SingleControllerActor:
 
         Per prompt:
           1. Acquire _buffer_capacity slot (backpressure)
-          2. Acquire sem (cap concurrent in-flight rollouts)
+          2. Acquire _rollout_slots shared with startup recovery
           3. Wait for _rollout_permitted (paused during weight sync)
           4. Run the rollout, then either commit it directly or submit its
              metadata-only request to the finalizer actor pool.
           5. Decrement _inflight_rollouts
         """
-        sem = asyncio.Semaphore(self._async_cfg.max_inflight_prompts)
         self._rollout_exhausted.clear()
         print("rollout_pump: starting", flush=True)
 
@@ -1114,13 +1231,21 @@ class SingleControllerActor:
             prompt: DatumSpec,
             target_step: Optional[int],
             task_started_event: asyncio.Event,
+            dispatch_admitted_event: asyncio.Event,
         ) -> None:
             task_started_event.set()
-            self._inflight_rollouts += 1
             generation_permit_released = False
             inflight_count_released = False
+            counted_inflight = False
             ownership_transferred = False
+            rollout_slot_owned = False
             try:
+                await self._rollout_slots.acquire()
+                rollout_slot_owned = True
+                await self._rollout_permitted.wait()
+                dispatch_admitted_event.set()
+                self._inflight_rollouts += 1
+                counted_inflight = True
                 if self._finalizer_actors:
                     request = await self._rollout_manager.generate_for_finalization(
                         prompt,
@@ -1132,7 +1257,8 @@ class SingleControllerActor:
                     else:
                         self._inflight_rollouts -= 1
                         inflight_count_released = True
-                        sem.release()
+                        self._rollout_slots.release()
+                        rollout_slot_owned = False
                         generation_permit_released = True
                         await self._finalize_with_actor(request)
                         self._rollout_manager.stats.committed += 1
@@ -1151,10 +1277,13 @@ class SingleControllerActor:
                     self._buffer_capacity.release()
                 raise
             finally:
-                if not inflight_count_released:
+                # Never leave the producer waiting if this task fails or is
+                # cancelled before it passes the generation gates.
+                dispatch_admitted_event.set()
+                if counted_inflight and not inflight_count_released:
                     self._inflight_rollouts -= 1
-                if not generation_permit_released:
-                    sem.release()
+                if not generation_permit_released and rollout_slot_owned:
+                    self._rollout_slots.release()
 
             if outcome is RolloutOutcome.SKIPPED:
                 # Nothing was committed, so the train pump will never see this group
@@ -1170,14 +1299,15 @@ class SingleControllerActor:
                         break
                 print(f"  rollout done for prompt='{content[:20]}...'", flush=True)
 
-        def _release_permits_if_task_not_started(
+        def _release_buffer_if_task_not_started(
             _: asyncio.Task[Any],
             *,
             task_started_event: asyncio.Event,
+            dispatch_admitted_event: asyncio.Event,
         ) -> None:
             if not task_started_event.is_set():
                 self._buffer_capacity.release()
-                sem.release()
+                dispatch_admitted_event.set()
 
         max_epochs = self._master_config.grpo.max_num_epochs
         async with asyncio.TaskGroup() as rollout_tasks:
@@ -1206,26 +1336,31 @@ class SingleControllerActor:
 
                         # check if buffer is full
                         await self._buffer_capacity.acquire()
-                        # check if inflight rollouts is full
-                        await sem.acquire()
-                        # wait for rollout to be permitted
-                        await self._rollout_permitted.wait()
 
                         task_started_event = asyncio.Event()
+                        dispatch_admitted_event = asyncio.Event()
                         # dispatch rollout
                         task = rollout_tasks.create_task(
                             _dispatch_one_prompt(
-                                prompt, target_step, task_started_event
+                                prompt,
+                                target_step,
+                                task_started_event,
+                                dispatch_admitted_event,
                             )
                         )
                         self._dispatched_rollouts.add(task)
                         task.add_done_callback(self._dispatched_rollouts.discard)
                         task.add_done_callback(
                             partial(
-                                _release_permits_if_task_not_started,
+                                _release_buffer_if_task_not_started,
                                 task_started_event=task_started_event,
+                                dispatch_admitted_event=dispatch_admitted_event,
                             )
                         )
+                        # Keep dataloader production bounded by actual worker
+                        # admission instead of filling the buffer with tasks
+                        # queued behind recovery.
+                        await dispatch_admitted_event.wait()
 
                 self._current_epoch += 1
 
@@ -1328,7 +1463,10 @@ class SingleControllerActor:
 
                         # If no batch is selectable, sleep and retry
                         if train_meta is None:
-                            if self._rollout_exhausted.is_set():
+                            if (
+                                self._rollout_exhausted.is_set()
+                                and self._rollout_recovery_complete.is_set()
+                            ):
                                 buffered_groups = len(self._buffer)
                                 if groups_dispatched == 0 and buffered_groups == 0:
                                     print(
@@ -1484,7 +1622,9 @@ class SingleControllerActor:
                 self._timeout.mark_iteration()
 
                 is_last_step = self._train_steps >= grpo_cfg.max_num_steps or (
-                    self._rollout_exhausted.is_set() and len(self._buffer) == 0
+                    self._rollout_exhausted.is_set()
+                    and self._rollout_recovery_complete.is_set()
+                    and len(self._buffer) == 0
                 )
                 ft_save_period = self._master_config.checkpointing.get("ft_save_period")
                 # _train_steps was already incremented above, so it equals

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -798,7 +798,7 @@ class SingleControllerActor:
     async def _validate_rollout_recovery_inventory(
         self, *, clear_unreferenced: bool
     ) -> None:
-        """Require every sealed receipt to retain its staged TQ rows."""
+        """Require every unfinished receipt or deferred route to retain staging."""
         ledger = self._rollout_recovery_ledger
         if ledger is None:
             return
@@ -813,8 +813,8 @@ class SingleControllerActor:
         missing = sorted(expected_staging_keys - actual_staging_keys)
         if missing:
             raise RuntimeError(
-                "rollout-recovery receipts reference staging rows missing from "
-                f"the native TQ checkpoint: missing={missing[:10]!r} "
+                "rollout-recovery ownership references staging rows missing "
+                f"from live TQ state: missing={missing[:10]!r} "
                 f"(total={len(missing)})"
             )
         unreferenced = sorted(actual_staging_keys - expected_staging_keys)

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -35,10 +35,13 @@ Data flow:
 from __future__ import annotations
 
 import asyncio
-import statistics
+import hashlib
+import io
 import os
+import statistics
 import time
 from functools import partial
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 import ray
@@ -52,7 +55,10 @@ from nemo_rl.algorithms.async_utils.replay_buffer import (
     DataPlaneCheckpointBarrier,
     TQReplayMetadataState,
 )
-from nemo_rl.algorithms.async_utils.staleness_sampler import create_sampler
+from nemo_rl.algorithms.async_utils.staleness_sampler import (
+    CheckpointDispatchSampler,
+    create_sampler,
+)
 from nemo_rl.algorithms.grpo import GRPOSaveState, _write_latest_checkpoint_status
 from nemo_rl.algorithms.metric_utils import SetupTimingMetrics
 from nemo_rl.algorithms.single_controller_utils.config import (
@@ -77,6 +83,12 @@ from nemo_rl.data_plane.schema import ROUTE_PLAN_TAG
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.experience.failures import RolloutStall
 from nemo_rl.experience.rollout_manager import RolloutOutcome
+from nemo_rl.experience.rollout_recovery import (
+    ROLLOUT_RECOVERY_SCHEMA_VERSION,
+    ROLLOUT_RECOVERY_STATE_FILENAME,
+    PromptGroupRecoverySummary,
+    PromptGroupStatus,
+)
 from nemo_rl.experience.route_plan import decode_route_plan
 from nemo_rl.models.generation.sglang.sglang_generation import SGLangGeneration
 from nemo_rl.models.generation.vllm import VllmGeneration
@@ -239,6 +251,10 @@ class SingleControllerActor:
             self._buffer.set_data_plane_checkpoint_barrier(
                 self._data_plane_checkpoint_barrier
             )
+        if self._rollout_recovery_ledger is not None:
+            self._rollout_manager.set_data_plane_checkpoint_barrier(
+                self._data_plane_checkpoint_barrier
+            )
 
         # Gate: cleared during _sync_weights, set when generation may proceed
         self._rollout_permitted: asyncio.Event = asyncio.Event()
@@ -289,7 +305,10 @@ class SingleControllerActor:
         # Synchronize weights before starting the pumps
         await self._sync_weights()
 
-        await self._maybe_restore_replay_buffer()
+        restored_replay_groups = await self._maybe_restore_replay_buffer()
+        await self._maybe_restore_rollout_recovery(
+            restored_replay_groups=restored_replay_groups
+        )
 
         # Start the rollout and train pumps, plus the watchdog
         rollout_task = asyncio.create_task(self._rollout_pump())
@@ -350,7 +369,7 @@ class SingleControllerActor:
 
     # ── internal helpers ───────────────────────────────────────────────────
 
-    async def _maybe_restore_replay_buffer(self) -> None:
+    async def _maybe_restore_replay_buffer(self) -> int:
         """Restore the local replay index for the native TQ checkpoint.
 
         Recovery is authoritative only for samplers that explicitly support
@@ -358,7 +377,7 @@ class SingleControllerActor:
         must both be present and agree on their manifest and group count.
         """
         if self._last_checkpoint_path is None:
-            return
+            return 0
         metadata_path = os.path.join(
             self._last_checkpoint_path, REPLAY_BUFFER_METADATA_FILENAME
         )
@@ -372,7 +391,7 @@ class SingleControllerActor:
                 "replay-buffer recovery"
             )
         if not self._sampler.supports_buffer_checkpoint:
-            return
+            return 0
         if not os.path.exists(metadata_path):
             legacy_path = os.path.join(
                 self._last_checkpoint_path, LEGACY_REPLAY_BUFFER_FILENAME
@@ -389,7 +408,7 @@ class SingleControllerActor:
                 "Starting with an empty replay buffer.",
                 flush=True,
             )
-            return
+            return 0
         print(f"📦 Restoring replay buffer metadata: {metadata_path}")
         # weights_only=False: the metadata sidecar contains pickled KVBatchMeta
         # objects but no rollout tensor payloads. It is a trusted same-job artifact.
@@ -435,6 +454,7 @@ class SingleControllerActor:
         assert restored <= self._async_cfg.max_buffered_rollouts
         for _ in range(restored):
             await self._buffer_capacity.acquire()
+        return restored
 
     async def _ray_get(self, obj_ref: Any) -> Any:
         """Await a Ray ObjectRef without blocking the asyncio event loop."""
@@ -444,7 +464,7 @@ class SingleControllerActor:
         self,
         method_name: str,
         *,
-        offload_sync: bool = False,
+        offload_sync: bool = True,
         **kwargs: Any,
     ) -> Any:
         """Call a local DataPlaneClient or a Ray actor exposing its methods.
@@ -752,6 +772,176 @@ class SingleControllerActor:
             flush=True,
         )
 
+    async def _validate_rollout_recovery_inventory(
+        self, *, clear_unreferenced: bool
+    ) -> None:
+        """Require every sealed receipt to retain its staged TQ rows."""
+        ledger = self._rollout_recovery_ledger
+        if ledger is None:
+            return
+        expected_staging_keys = ledger.expected_staging_keys()
+        staging_partition = self._master_config.token_capture.staging_partition
+        actual_staging_keys = set(
+            await self._call_dp(
+                "list_sample_ids",
+                partition_id=staging_partition,
+            )
+        )
+        missing = sorted(expected_staging_keys - actual_staging_keys)
+        if missing:
+            raise RuntimeError(
+                "rollout-recovery receipts reference staging rows missing from "
+                f"the native TQ checkpoint: missing={missing[:10]!r} "
+                f"(total={len(missing)})"
+            )
+        unreferenced = sorted(actual_staging_keys - expected_staging_keys)
+        if clear_unreferenced and unreferenced:
+            await self._call_dp(
+                "clear_samples",
+                sample_ids=unreferenced,
+                partition_id=staging_partition,
+            )
+            print(
+                "rollout recovery cleared unreferenced staging rows: "
+                f"count={len(unreferenced)}",
+                flush=True,
+            )
+        print(
+            "📦 Rollout-recovery staging inventory validated: "
+            f"referenced={len(expected_staging_keys)}",
+            flush=True,
+        )
+
+    async def _maybe_restore_rollout_recovery(
+        self, *, restored_replay_groups: int
+    ) -> None:
+        """Complete restored unfinished groups before starting either SC pump."""
+        metadata = self._data_plane_checkpoint_metadata or {}
+        if "rollout_recovery_payload_sha256" not in metadata:
+            self._restore_sampler_dispatch_state(
+                [], restored_replay_groups=restored_replay_groups
+            )
+            return
+        ledger = self._rollout_recovery_ledger
+        if ledger is None:
+            raise RuntimeError(
+                "native TQ checkpoint advertises rollout recovery, but token "
+                "capture did not construct a recovery ledger"
+            )
+        ledger.prepare_for_restart()
+        groups = ledger.summaries()
+        unfinished = [
+            group
+            for group in groups
+            if group.status
+            in {PromptGroupStatus.GENERATING, PromptGroupStatus.READY_TO_FINALIZE}
+        ]
+        finalized_group_ids = {
+            group.group_id
+            for group in groups
+            if group.status == PromptGroupStatus.FINALIZED
+        }
+        restored_group_ids = set(self._buffer.group_ids)
+        if restored_group_ids != finalized_group_ids:
+            raise RuntimeError(
+                "restored replay groups do not match finalized rollout lineage: "
+                f"replay_only={sorted(restored_group_ids - finalized_group_ids)!r}, "
+                f"lineage_only={sorted(finalized_group_ids - restored_group_ids)!r}"
+            )
+        self._restore_sampler_dispatch_state(
+            unfinished,
+            restored_replay_groups=restored_replay_groups,
+        )
+        await self._validate_rollout_recovery_inventory(clear_unreferenced=True)
+        stale_unfinished = [
+            group
+            for group in unfinished
+            if self._sampler.should_abort_inflight(
+                start_weight_version=group.start_weight_version,
+                current_train_weight=self._trainer_version,
+            )
+        ]
+        stale_group_ids = {group.group_id for group in stale_unfinished}
+        for group in stale_unfinished:
+            await self._rollout_manager.discard_recovery_group(group.group_id)
+        if stale_unfinished:
+            print(
+                "📦 Rollout recovery dropped stale unfinished groups: "
+                f"count={len(stale_unfinished)}",
+                flush=True,
+            )
+        unfinished = [
+            group for group in unfinished if group.group_id not in stale_group_ids
+        ]
+        if (
+            restored_replay_groups + len(unfinished)
+            > self._async_cfg.max_buffered_rollouts
+        ):
+            raise RuntimeError(
+                "restored canonical and unfinished rollout groups exceed current "
+                "buffer capacity: "
+                f"canonical={restored_replay_groups}, "
+                f"unfinished={len(unfinished)}, "
+                f"capacity={self._async_cfg.max_buffered_rollouts}"
+            )
+
+        for group in unfinished:
+            await self._buffer_capacity.acquire()
+            try:
+                request = await self._rollout_manager.recover_for_finalization(
+                    group.group_id,
+                    inflight_registry=self._inflight_by_group_id,
+                )
+                if request is None:
+                    self._buffer_capacity.release()
+                    continue
+                await self._finalize_with_actor(request)
+            except BaseException:
+                self._buffer_capacity.release()
+                raise
+        if unfinished:
+            print(
+                f"📦 Rollout recovery completed: groups={len(unfinished)}",
+                flush=True,
+            )
+
+    def _restore_sampler_dispatch_state(
+        self,
+        unfinished_groups: list[PromptGroupRecoverySummary],
+        *,
+        restored_replay_groups: int,
+    ) -> None:
+        """Reconstruct gated admission from canonical and unfinished groups."""
+        if not self._sampler.supports_buffer_checkpoint:
+            return
+        if not isinstance(self._sampler, CheckpointDispatchSampler):
+            raise RuntimeError(
+                f"checkpoint-capable sampler {type(self._sampler).__name__} "
+                "does not implement dispatch-state recovery"
+            )
+        restored_target_steps = list(self._buffer.target_step_list)
+        if len(restored_target_steps) != restored_replay_groups:
+            raise RuntimeError(
+                "restored replay group count does not match the sampler target "
+                f"index: groups={restored_replay_groups}, "
+                f"targets={len(restored_target_steps)}"
+            )
+        restored_target_steps.extend(group.target_step for group in unfinished_groups)
+        self._sampler.restore_dispatch_state(
+            current_train_weight=self._trainer_version,
+            restored_target_steps=restored_target_steps,
+            groups_per_step=self._master_config.grpo.num_prompts_per_step,
+        )
+        stamped_targets = [
+            target for target in restored_target_steps if target is not None
+        ]
+        if stamped_targets:
+            print(
+                "📦 Restored sampler dispatch state: "
+                f"highest_target_step={max(stamped_targets)}",
+                flush=True,
+            )
+
     async def _clear_data_plane_samples(self, sample_ids: list[str]) -> None:
         """Clear consumed rows without overlapping a data-plane checkpoint."""
         async with self._data_plane_checkpoint_barrier.mutation():
@@ -765,8 +955,11 @@ class SingleControllerActor:
 
     async def _save_data_plane_checkpoint(
         self,
-        checkpoint_path: str,
+        checkpoint_path: PathLike,
+        *,
         replay_metadata: Optional[TQReplayMetadataState] = None,
+        rollout_recovery_payload_sha256: Optional[str] = None,
+        rollout_recovery_group_count: Optional[int] = None,
     ) -> None:
         """Save a required TQ snapshot inside an SC checkpoint bundle.
 
@@ -789,7 +982,12 @@ class SingleControllerActor:
             "single_controller_epoch": self._current_epoch,
             "partition_id": self._partition_id,
             "sampler_name": self._async_cfg.sampler.name,
-            "mode": "authoritative" if replay_metadata is not None else "shadow",
+            "mode": (
+                "authoritative"
+                if replay_metadata is not None
+                or rollout_recovery_payload_sha256 is not None
+                else "shadow"
+            ),
         }
         if replay_metadata is not None:
             metadata.update(
@@ -800,6 +998,26 @@ class SingleControllerActor:
                     "replay_manifest_digest": replay_metadata["manifest_digest"],
                     "replay_group_count": len(replay_metadata["groups"]),
                 }
+            )
+        if rollout_recovery_payload_sha256 is not None:
+            if rollout_recovery_group_count is None:
+                raise ValueError(
+                    "rollout recovery group count is required with its digest"
+                )
+            metadata.update(
+                {
+                    "rollout_recovery_schema_version": (
+                        ROLLOUT_RECOVERY_SCHEMA_VERSION
+                    ),
+                    "rollout_recovery_payload_sha256": (
+                        rollout_recovery_payload_sha256
+                    ),
+                    "rollout_recovery_group_count": rollout_recovery_group_count,
+                }
+            )
+        elif rollout_recovery_group_count is not None:
+            raise ValueError(
+                "rollout recovery payload digest is required with its group count"
             )
         started = time.monotonic()
         print(f"data-plane checkpoint save started: {checkpoint_dir}", flush=True)
@@ -1216,11 +1434,11 @@ class SingleControllerActor:
                 with self._timer.time("policy_training"):
                     result = await asyncio.to_thread(self._trainer.finish_train_step)
 
-                if self._rollout_recovery_ledger is not None:
-                    self._rollout_recovery_ledger.mark_train_step_applied(
-                        self._train_steps
-                    )
                 async with self._data_plane_checkpoint_barrier.mutation():
+                    if self._rollout_recovery_ledger is not None:
+                        self._rollout_recovery_ledger.mark_train_step_applied(
+                            self._train_steps
+                        )
                     await self._cleanup_consumed_metas(consumed_metas)
                     if self._rollout_recovery_ledger is not None:
                         self._rollout_recovery_ledger.release_applied_train_step(
@@ -1538,6 +1756,9 @@ class SingleControllerActor:
             os.path.join(checkpoint_path, "train_dataloader.pt"),
         )
         replay_metadata: Optional[TQReplayMetadataState] = None
+        rollout_recovery_payload: Optional[bytes] = None
+        rollout_recovery_digest: Optional[str] = None
+        rollout_recovery_group_count: Optional[int] = None
         if self._master_config.data_plane.get("checkpointing_enabled"):
             if self._finalizer_unknown_outcomes:
                 raise RuntimeError(
@@ -1553,16 +1774,41 @@ class SingleControllerActor:
                     replay_metadata = self._buffer.metadata_state_dict(
                         saved_capacity=self._async_cfg.max_buffered_rollouts
                     )
+                if self._rollout_recovery_ledger is not None:
+                    self._rollout_recovery_ledger.assert_full_step_checkpoint_safe()
+                    rollout_recovery_state = self._rollout_recovery_ledger.state_dict()
+                    payload_buffer = io.BytesIO()
+                    torch.save(rollout_recovery_state, payload_buffer)
+                    rollout_recovery_payload = payload_buffer.getvalue()
+                    rollout_recovery_digest = hashlib.sha256(
+                        rollout_recovery_payload
+                    ).hexdigest()
+                    rollout_recovery_group_count = len(rollout_recovery_state["groups"])
                 if replay_metadata is not None:
                     await self._validate_replay_inventory(replay_metadata)
+                if rollout_recovery_payload is not None:
+                    await self._validate_rollout_recovery_inventory(
+                        clear_unreferenced=False
+                    )
                 await self._save_data_plane_checkpoint(
-                    checkpoint_path, replay_metadata=replay_metadata
+                    checkpoint_path,
+                    replay_metadata=replay_metadata,
+                    rollout_recovery_payload_sha256=rollout_recovery_digest,
+                    rollout_recovery_group_count=rollout_recovery_group_count,
                 )
         if replay_metadata is not None:
             await asyncio.to_thread(
                 torch.save,
                 replay_metadata,
                 os.path.join(checkpoint_path, REPLAY_BUFFER_METADATA_FILENAME),
+            )
+        if rollout_recovery_payload is not None:
+            recovery_path = os.path.join(
+                checkpoint_path, ROLLOUT_RECOVERY_STATE_FILENAME
+            )
+            await asyncio.to_thread(
+                Path(recovery_path).write_bytes,
+                rollout_recovery_payload,
             )
         # Rename happens in the background once the async weight writes
         # finish; flushed at the next save or on exit.

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -35,11 +35,14 @@ Data flow:
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import io
 import os
 import sys
 import time
 import warnings
 from functools import partial
+from pathlib import Path
 from typing import Any, Optional, Union
 
 import ray
@@ -75,6 +78,12 @@ from nemo_rl.data_plane import KVBatchMeta
 from nemo_rl.data_plane.async_utils import call_data_plane
 from nemo_rl.data_plane.schema import DP_CALIB_INPUT_FIELDS
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.experience.rollout_recovery import (
+    ROLLOUT_RECOVERY_SCHEMA_VERSION,
+    ROLLOUT_RECOVERY_STATE_FILENAME,
+    RolloutAttemptStatus,
+    RolloutRecoveryState,
+)
 from nemo_rl.models.generation.sglang.sglang_generation import SGLangGeneration
 from nemo_rl.models.generation.vllm import VllmGeneration
 from nemo_rl.models.policy.tq_policy import TQPolicy
@@ -83,6 +92,7 @@ from nemo_rl.utils.logger import Logger
 from nemo_rl.utils.timer import TimeoutChecker, Timer
 
 Generation = Union[VllmGeneration, SGLangGeneration]
+
 
 @ray.remote(num_cpus=1, num_gpus=0)  # pragma: no cover
 class SingleControllerActor:
@@ -205,6 +215,10 @@ class SingleControllerActor:
             self._buffer.set_data_plane_checkpoint_barrier(
                 self._data_plane_checkpoint_barrier
             )
+        if self._master_config.token_capture.enabled:
+            self._rollout_manager.set_data_plane_checkpoint_barrier(
+                self._data_plane_checkpoint_barrier
+            )
 
         # Gate: cleared during _sync_weights, set when generation may proceed
         self._rollout_permitted: asyncio.Event = asyncio.Event()
@@ -255,7 +269,10 @@ class SingleControllerActor:
         # Synchronize weights before starting the pumps
         await self._sync_weights()
 
-        await self._maybe_restore_replay_buffer()
+        restored_replay_groups = await self._maybe_restore_replay_buffer()
+        await self._maybe_restore_rollout_recovery(
+            restored_replay_groups=restored_replay_groups
+        )
 
         # Start the rollout and train pumps
         rollout_task = asyncio.create_task(self._rollout_pump())
@@ -307,13 +324,16 @@ class SingleControllerActor:
 
     # ── internal helpers ───────────────────────────────────────────────────
 
-    async def _maybe_restore_replay_buffer(self) -> None:
+    async def _maybe_restore_replay_buffer(self) -> int:
         """Restore replay-buffer groups from the previous run's checkpoint.
 
         No-op unless the sampler supports_buffer_checkpoint (ungated only).
+
+        Returns:
+            Number of canonical replay groups restored.
         """
         if self._last_checkpoint_path is None:
-            return
+            return 0
         metadata_path = os.path.join(
             self._last_checkpoint_path, REPLAY_BUFFER_METADATA_FILENAME
         )
@@ -327,7 +347,7 @@ class SingleControllerActor:
                 "replay-buffer recovery"
             )
         if not self._sampler.supports_buffer_checkpoint:
-            return
+            return 0
         if not os.path.exists(metadata_path):
             legacy_path = os.path.join(
                 self._last_checkpoint_path, LEGACY_REPLAY_BUFFER_FILENAME
@@ -344,7 +364,7 @@ class SingleControllerActor:
                 "Starting with an empty replay buffer.",
                 flush=True,
             )
-            return
+            return 0
         print(f"📦 Restoring replay buffer metadata: {metadata_path}")
         # weights_only=False: the metadata sidecar contains pickled KVBatchMeta
         # objects but no rollout tensor payloads. It is a trusted same-job artifact.
@@ -390,6 +410,19 @@ class SingleControllerActor:
         assert restored <= self._async_cfg.max_buffered_rollouts
         for _ in range(restored):
             await self._buffer_capacity.acquire()
+        recovery_ledger = self._rollout_manager.recovery_ledger
+        if recovery_ledger is not None:
+            canonical_group_ids = {
+                group["group_id"] for group in buffer_state["groups"]
+            }
+            discarded = recovery_ledger.discard_canonical_groups(canonical_group_ids)
+            if discarded:
+                print(
+                    "rollout recovery reconciled canonical groups: "
+                    f"discarded={discarded}",
+                    flush=True,
+                )
+        return restored
 
     async def _validate_replay_inventory(
         self, replay_metadata: TQReplayMetadataState
@@ -425,6 +458,106 @@ class SingleControllerActor:
             flush=True,
         )
 
+    async def _validate_rollout_recovery_inventory(
+        self,
+        *,
+        clear_unreferenced: bool,
+        recovery_state: Optional[RolloutRecoveryState] = None,
+    ) -> None:
+        """Require every sealed receipt to retain its staged TQ rows."""
+        recovery_ledger = self._rollout_manager.recovery_ledger
+        if recovery_ledger is None:
+            return
+        staging_partition = self._master_config.token_capture.staging_partition
+        if recovery_state is None:
+            expected_staging_keys = recovery_ledger.expected_staging_keys()
+        else:
+            expected_staging_keys = {
+                staging_key
+                for group in recovery_state["groups"]
+                for sibling in group["siblings"]
+                for attempt in sibling["attempts"][-1:]
+                if attempt["status"] == RolloutAttemptStatus.SEALED.value
+                for staging_key in attempt["staging_keys"]
+            }
+        actual_staging_keys = set(
+            await call_data_plane(
+                self._dp_client,
+                "list_sample_ids",
+                offload_sync=True,
+                partition_id=staging_partition,
+            )
+        )
+        missing_staging_keys = sorted(expected_staging_keys - actual_staging_keys)
+        if missing_staging_keys:
+            raise RuntimeError(
+                "Rollout-recovery receipts reference staging rows missing from "
+                "the native TQ checkpoint: "
+                f"missing={missing_staging_keys[:10]!r} "
+                f"(total={len(missing_staging_keys)})"
+            )
+
+        unreferenced_staging_keys = sorted(actual_staging_keys - expected_staging_keys)
+        if clear_unreferenced and unreferenced_staging_keys:
+            await call_data_plane(
+                self._dp_client,
+                "clear_samples",
+                offload_sync=True,
+                sample_ids=unreferenced_staging_keys,
+                partition_id=staging_partition,
+            )
+            print(
+                "rollout recovery cleared unreferenced staging rows: "
+                f"count={len(unreferenced_staging_keys)}",
+                flush=True,
+            )
+        print(
+            "rollout recovery staging inventory validated: "
+            f"referenced={len(expected_staging_keys)}",
+            flush=True,
+        )
+
+    async def _maybe_restore_rollout_recovery(
+        self, *, restored_replay_groups: int
+    ) -> None:
+        """Recover sealed and partial groups before starting either SC pump."""
+        metadata = self._data_plane_checkpoint_metadata or {}
+        if "rollout_recovery_payload_sha256" not in metadata:
+            return
+        recovery_ledger = self._rollout_manager.recovery_ledger
+        if recovery_ledger is None:
+            raise RuntimeError(
+                "Native TQ checkpoint advertises rollout recovery, but token "
+                "capture did not construct a recovery ledger"
+            )
+
+        recovery_ledger.prepare_for_restart()
+        groups = recovery_ledger.groups()
+        await self._validate_rollout_recovery_inventory(clear_unreferenced=True)
+        if restored_replay_groups + len(groups) > self._async_cfg.max_buffered_rollouts:
+            raise RuntimeError(
+                "Restored canonical and unfinished rollout groups exceed current "
+                "buffer capacity: "
+                f"canonical={restored_replay_groups}, unfinished={len(groups)}, "
+                f"capacity={self._async_cfg.max_buffered_rollouts}"
+            )
+
+        for group in groups:
+            await self._buffer_capacity.acquire()
+            try:
+                committed = await self._rollout_manager.recover_group(group.group_id)
+            except BaseException:
+                self._buffer_capacity.release()
+                raise
+            if not committed:
+                self._buffer_capacity.release()
+
+        if groups:
+            print(
+                f"rollout recovery replay completed: groups={len(groups)}",
+                flush=True,
+            )
+
     async def _clear_data_plane_samples(self, sample_ids: list[str]) -> None:
         """Clear consumed rows without overlapping a data-plane checkpoint."""
         async with self._data_plane_checkpoint_barrier.mutation():
@@ -438,8 +571,11 @@ class SingleControllerActor:
 
     async def _save_data_plane_checkpoint(
         self,
-        checkpoint_path: str,
+        checkpoint_path: os.PathLike[str] | str,
+        *,
         replay_metadata: Optional[TQReplayMetadataState] = None,
+        rollout_recovery_payload_sha256: Optional[str] = None,
+        rollout_recovery_group_count: Optional[int] = None,
     ) -> None:
         """Save a required TQ snapshot inside an SC checkpoint bundle.
 
@@ -462,7 +598,12 @@ class SingleControllerActor:
             "single_controller_epoch": self._current_epoch,
             "partition_id": self._partition_id,
             "sampler_name": self._async_cfg.sampler.name,
-            "mode": "authoritative" if replay_metadata is not None else "shadow",
+            "mode": (
+                "authoritative"
+                if replay_metadata is not None
+                or rollout_recovery_payload_sha256 is not None
+                else "shadow"
+            ),
         }
         if replay_metadata is not None:
             metadata.update(
@@ -473,6 +614,26 @@ class SingleControllerActor:
                     "replay_manifest_digest": replay_metadata["manifest_digest"],
                     "replay_group_count": len(replay_metadata["groups"]),
                 }
+            )
+        if rollout_recovery_payload_sha256 is not None:
+            if rollout_recovery_group_count is None:
+                raise ValueError(
+                    "rollout recovery group count is required with its payload digest"
+                )
+            metadata.update(
+                {
+                    "rollout_recovery_schema_version": (
+                        ROLLOUT_RECOVERY_SCHEMA_VERSION
+                    ),
+                    "rollout_recovery_payload_sha256": (
+                        rollout_recovery_payload_sha256
+                    ),
+                    "rollout_recovery_group_count": rollout_recovery_group_count,
+                }
+            )
+        elif rollout_recovery_group_count is not None:
+            raise ValueError(
+                "rollout recovery payload digest is required with its group count"
             )
         started = time.monotonic()
         print(f"data-plane checkpoint save started: {checkpoint_dir}", flush=True)
@@ -522,14 +683,22 @@ class SingleControllerActor:
         async def _dispatch_one_prompt(
             prompt: DatumSpec,
             target_step: Optional[int],
+            recovery_group_id: Optional[str],
             task_started_event: asyncio.Event,
         ) -> None:
             task_started_event.set()
             self._inflight_rollouts += 1
             try:
-                await self._rollout_manager.generate_and_push(
-                    prompt, target_step=target_step
-                )
+                if recovery_group_id is None:
+                    await self._rollout_manager.generate_and_push(
+                        prompt, target_step=target_step
+                    )
+                else:
+                    await self._rollout_manager.generate_and_push(
+                        prompt,
+                        target_step=target_step,
+                        recovery_group_id=recovery_group_id,
+                    )
             except BaseException:
                 # On success ownership transfers to the train pump, which
                 # releases this permit after consuming the committed group.
@@ -557,18 +726,66 @@ class SingleControllerActor:
                 sem.release()
 
         max_epochs = self._master_config.grpo["max_num_epochs"]
+        token_capture_enabled = bool(
+            getattr(
+                getattr(self._master_config, "token_capture", None),
+                "enabled",
+                False,
+            )
+        )
         async with asyncio.TaskGroup() as rollout_tasks:
             while max_epochs is None or self._current_epoch < max_epochs:
-                for prompt_batch in self._dataloader:
-                    target_step = await self._sampler.admit(
-                        trainer_version_fn=lambda: self._trainer_version
-                    )
+                dataloader_iterator = iter(self._dataloader)
+                while True:
+                    if token_capture_enabled:
+                        # Advancing the dataloader and reserving every prompt
+                        # in that batch is one checkpoint mutation. A snapshot
+                        # therefore sees either neither operation or both,
+                        # preventing skipped/duplicated prompts after restart.
+                        async with self._data_plane_checkpoint_barrier.mutation():
+                            try:
+                                prompt_batch = next(dataloader_iterator)
+                            except StopIteration:
+                                self._current_epoch += 1
+                                break
+                            target_step = await self._sampler.admit(
+                                trainer_version_fn=lambda: self._trainer_version
+                            )
+                            prompt_dispatches: list[
+                                tuple[DatumSpec, Optional[str]]
+                            ] = []
+                            for prompt_idx in range(prompt_batch.size):
+                                prompt: DatumSpec = {  # type: ignore
+                                    k: v[prompt_idx] for k, v in prompt_batch.items()
+                                }
+                                recovery_group_id = (
+                                    self._rollout_manager.reserve_prompt_group(
+                                        prompt, target_step=target_step
+                                    )
+                                )
+                                if recovery_group_id is None:
+                                    raise RuntimeError(
+                                        "token-capture dispatch must reserve "
+                                        "durable prompt-group lineage"
+                                    )
+                                prompt_dispatches.append((prompt, recovery_group_id))
+                    else:
+                        try:
+                            prompt_batch = next(dataloader_iterator)
+                        except StopIteration:
+                            self._current_epoch += 1
+                            break
+                        target_step = await self._sampler.admit(
+                            trainer_version_fn=lambda: self._trainer_version
+                        )
+                        prompt_dispatches = []
+                        for prompt_idx in range(prompt_batch.size):
+                            prompt = {  # type: ignore
+                                k: v[prompt_idx] for k, v in prompt_batch.items()
+                            }
+                            prompt_dispatches.append((prompt, None))
 
-                    for prompt_idx in range(prompt_batch.size):
-                        prompt: DatumSpec = {  # type: ignore
-                            k: v[prompt_idx] for k, v in prompt_batch.items()
-                        }
-
+                    for prompt, recovery_group_id in prompt_dispatches:
                         # check if buffer is full
                         await self._buffer_capacity.acquire()
                         # check if inflight rollouts is full
@@ -580,7 +797,10 @@ class SingleControllerActor:
                         # dispatch rollout
                         task = rollout_tasks.create_task(
                             _dispatch_one_prompt(
-                                prompt, target_step, task_started_event
+                                prompt,
+                                target_step,
+                                recovery_group_id,
+                                task_started_event,
                             )
                         )
                         self._dispatched_rollouts.add(task)
@@ -591,8 +811,6 @@ class SingleControllerActor:
                                 task_started_event=task_started_event,
                             )
                         )
-
-                self._current_epoch += 1
 
         # Drain in-flight so return implies "all rollouts in TQ".
         inflight = list(self._dispatched_rollouts)
@@ -858,20 +1076,18 @@ class SingleControllerActor:
     ) -> None:
         """Write a full checkpoint for the just-finished train step.
 
-        Everything except the (possibly async) policy weight write must be
-        on disk before begin_finalization; rollouts keep running throughout.
-        val_metrics stays None until SC grows a validation loop.
+        Everything except the (possibly async) policy weight write must be on
+        disk before begin_finalization. In-flight generation continues, while
+        the short dataloader/ledger/TQ cut blocks new batch reservation and
+        completed-row publication. ``val_metrics`` stays None until SC grows a
+        validation loop.
         """
         save_state = self._save_state
         save_state["current_step"] = self._train_steps
         save_state["total_steps"] = self._train_steps
         save_state["trainer_version"] = self._trainer_version
-        save_state["current_epoch"] = self._current_epoch
         save_state["consumed_samples"] = self._consumed_samples
         save_state["total_valid_tokens"] = self._total_valid_tokens
-        # Snapshot before any await so it can't interleave with
-        # _rollout_pump iterating this same dataloader.
-        dataloader_state = self._dataloader.state_dict()
         if val_metrics is not None:
             save_state["val_reward"] = val_metrics["accuracy"]
         elif "val_reward" in save_state:
@@ -907,14 +1123,76 @@ class SingleControllerActor:
         await asyncio.to_thread(self._checkpointer.finalize_pending)
 
         print(f"Saving checkpoint for step {self._train_steps}...")
-        checkpoint_path = await asyncio.to_thread(
-            self._checkpointer.init_tmp_checkpoint,
-            self._train_steps,
-            save_state,
-            self._master_config,
-        )
+        replay_metadata: Optional[TQReplayMetadataState] = None
+        rollout_recovery_state: Optional[RolloutRecoveryState] = None
+        rollout_recovery_payload: Optional[bytes] = None
+        rollout_recovery_payload_sha256: Optional[str] = None
+        # The rollout pump advances the dataloader and reserves durable lineage
+        # under the mutation side of this barrier. Capturing the cursor, ledger,
+        # and TQ under the exclusive side makes them one restart-consistent cut.
+        async with self._data_plane_checkpoint_barrier.checkpoint():
+            save_state["current_epoch"] = self._current_epoch
+            dataloader_state = self._dataloader.state_dict()
+            checkpoint_path = await asyncio.to_thread(
+                self._checkpointer.init_tmp_checkpoint,
+                self._train_steps,
+                save_state,
+                self._master_config,
+            )
+            if self._master_config.data_plane.get("checkpointing_enabled"):
+                if self._sampler.supports_buffer_checkpoint:
+                    replay_metadata = self._buffer.metadata_state_dict(
+                        saved_capacity=self._async_cfg.max_buffered_rollouts
+                    )
+                if self._master_config.token_capture.enabled:
+                    recovery_ledger = self._rollout_manager.recovery_ledger
+                    if recovery_ledger is None:
+                        raise RuntimeError(
+                            "token capture checkpointing requires a rollout "
+                            "recovery ledger"
+                        )
+                    rollout_recovery_state = recovery_ledger.state_dict()
+                    if replay_metadata is not None:
+                        # A canonical commit and the following ledger release
+                        # straddle one event-loop yield. Canonical replay wins
+                        # if a checkpoint lands in that narrow interval.
+                        canonical_group_ids = {
+                            group["group_id"] for group in replay_metadata["groups"]
+                        }
+                        rollout_recovery_state = {
+                            "schema_version": rollout_recovery_state["schema_version"],
+                            "groups": [
+                                group
+                                for group in rollout_recovery_state["groups"]
+                                if group["group_id"] not in canonical_group_ids
+                            ],
+                        }
+                    payload_buffer = io.BytesIO()
+                    torch.save(rollout_recovery_state, payload_buffer)
+                    rollout_recovery_payload = payload_buffer.getvalue()
+                    rollout_recovery_payload_sha256 = hashlib.sha256(
+                        rollout_recovery_payload
+                    ).hexdigest()
+                    await self._validate_rollout_recovery_inventory(
+                        clear_unreferenced=False,
+                        recovery_state=rollout_recovery_state,
+                    )
+                await self._save_data_plane_checkpoint(
+                    checkpoint_path,
+                    replay_metadata=replay_metadata,
+                    rollout_recovery_payload_sha256=(rollout_recovery_payload_sha256),
+                    rollout_recovery_group_count=(
+                        len(rollout_recovery_state["groups"])
+                        if rollout_recovery_state is not None
+                        else None
+                    ),
+                )
+                if replay_metadata is not None:
+                    await self._validate_replay_inventory(replay_metadata)
+
         # With async_save this returns after D2H staging; disk writes finish
-        # in the background.
+        # in the background. New rollout dispatch may resume after the durable
+        # data-plane cut because the trainer is not mutated during this save.
         await asyncio.to_thread(
             self._trainer.save_checkpoint,
             weights_path=os.path.join(checkpoint_path, "policy", "weights"),
@@ -929,27 +1207,19 @@ class SingleControllerActor:
             dataloader_state,
             os.path.join(checkpoint_path, "train_dataloader.pt"),
         )
-        replay_metadata: Optional[TQReplayMetadataState] = None
-        if self._master_config.data_plane.get("checkpointing_enabled"):
-            # Commits and destructive clears take the same barrier. Generation
-            # may continue while a snapshot is written, but completed groups
-            # wait at commit, so TQ and the metadata sidecar describe exactly
-            # the same set of training-ready groups.
-            async with self._data_plane_checkpoint_barrier.checkpoint():
-                if self._sampler.supports_buffer_checkpoint:
-                    replay_metadata = self._buffer.metadata_state_dict(
-                        saved_capacity=self._async_cfg.max_buffered_rollouts
-                    )
-                await self._save_data_plane_checkpoint(
-                    checkpoint_path, replay_metadata=replay_metadata
-                )
-                if replay_metadata is not None:
-                    await self._validate_replay_inventory(replay_metadata)
         if replay_metadata is not None:
             await asyncio.to_thread(
                 torch.save,
                 replay_metadata,
                 os.path.join(checkpoint_path, REPLAY_BUFFER_METADATA_FILENAME),
+            )
+        if rollout_recovery_payload is not None:
+            await asyncio.to_thread(
+                Path(
+                    checkpoint_path,
+                    ROLLOUT_RECOVERY_STATE_FILENAME,
+                ).write_bytes,
+                rollout_recovery_payload,
             )
         # Rename happens in the background once the async weight writes
         # finish; flushed at the next save or on exit.

--- a/nemo_rl/algorithms/single_controller_utils/config.py
+++ b/nemo_rl/algorithms/single_controller_utils/config.py
@@ -342,6 +342,14 @@ def validate_single_controller_config(master_config: MasterConfig) -> None:
             f"must be >= async_rl.min_groups_for_streaming_train "
             f"({async_config.min_groups_for_streaming_train})"
         )
+    if async_config.max_buffered_rollouts < async_config.min_groups_for_streaming_train:
+        raise ValueError(
+            "async_rl.max_buffered_rollouts "
+            f"({async_config.max_buffered_rollouts}) must be >= "
+            f"async_rl.min_groups_for_streaming_train "
+            f"({async_config.min_groups_for_streaming_train}); otherwise the rollout "
+            "pump can fill every buffer slot while the trainer waits for more groups."
+        )
 
     rl_step_samples = (
         num_prompts_per_step * master_config.grpo.num_generations_per_prompt

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -21,6 +21,8 @@ runtime_envs and breaks Ray's resource resolution (see the PR #2692 follow-up).
 
 from __future__ import annotations
 
+import hashlib
+import io
 import os
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -29,6 +31,7 @@ from functools import partial
 from pathlib import Path
 from typing import Any, Callable, Optional, cast
 
+import torch
 from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import AutoProcessor
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
@@ -75,6 +78,12 @@ from nemo_rl.experience.rollout_manager import (
     RolloutManager,
     RolloutRetryPolicy,
     RolloutTimeouts,
+)
+from nemo_rl.experience.rollout_recovery import (
+    ROLLOUT_RECOVERY_SCHEMA_VERSION,
+    ROLLOUT_RECOVERY_STATE_FILENAME,
+    PromptGroupStatus,
+    RolloutRecoveryLedger,
 )
 from nemo_rl.experience.rollouts import should_mask_flagged_samples
 from nemo_rl.models.generation.interfaces import (
@@ -130,17 +139,18 @@ def _maybe_restore_native_data_plane_checkpoint(
 ) -> Optional[dict[str, Any]]:
     """Load and validate an authoritative native TQ checkpoint when present.
 
-    The metadata-only replay sidecar is the format marker. Checkpoints without
-    any replay artifact resume trainer state with an empty replay buffer;
-    legacy tensor-bearing replay files are rejected rather than silently
-    ignored. Rollout tensors are never serialized into a controller-side
-    replay checkpoint.
+    Replay metadata or the rollout-lineage sidecar marks an authoritative
+    native snapshot. Tensor-bearing legacy replay files are rejected rather
+    than silently ignored.
     """
     if last_checkpoint_path is None:
         return None
     checkpoint_path = Path(last_checkpoint_path)
     replay_metadata_path = checkpoint_path / REPLAY_BUFFER_METADATA_FILENAME
-    if not replay_metadata_path.is_file():
+    rollout_recovery_path = checkpoint_path / ROLLOUT_RECOVERY_STATE_FILENAME
+    has_replay_metadata = replay_metadata_path.is_file()
+    has_rollout_recovery = rollout_recovery_path.is_file()
+    if not has_replay_metadata and not has_rollout_recovery:
         legacy_replay_path = checkpoint_path / LEGACY_REPLAY_BUFFER_FILENAME
         if legacy_replay_path.is_file():
             raise RuntimeError(
@@ -177,8 +187,15 @@ def _maybe_restore_native_data_plane_checkpoint(
         "partition_id": partition_id,
         "sampler_name": sampler_name,
         "mode": "authoritative",
-        "replay_metadata_schema_version": REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
     }
+    if has_replay_metadata:
+        expected_values["replay_metadata_schema_version"] = (
+            REPLAY_BUFFER_METADATA_SCHEMA_VERSION
+        )
+    if has_rollout_recovery:
+        expected_values["rollout_recovery_schema_version"] = (
+            ROLLOUT_RECOVERY_SCHEMA_VERSION
+        )
     mismatches = {
         key: {"checkpoint": metadata.get(key), "expected": expected}
         for key, expected in expected_values.items()
@@ -189,22 +206,148 @@ def _maybe_restore_native_data_plane_checkpoint(
             "Native TQ checkpoint metadata does not match the trainer "
             f"checkpoint: {mismatches}"
         )
-    manifest_digest = metadata.get("replay_manifest_digest")
-    if not isinstance(manifest_digest, str) or not manifest_digest:
-        raise ValueError(
-            "Native TQ checkpoint metadata is missing replay_manifest_digest"
+    replay_group_count = 0
+    if has_replay_metadata:
+        manifest_digest = metadata.get("replay_manifest_digest")
+        if not isinstance(manifest_digest, str) or not manifest_digest:
+            raise ValueError(
+                "Native TQ checkpoint metadata is missing replay_manifest_digest"
+            )
+        replay_group_count = metadata.get("replay_group_count")
+        if not isinstance(replay_group_count, int) or replay_group_count < 0:
+            raise ValueError(
+                "Native TQ checkpoint metadata has invalid replay_group_count: "
+                f"{replay_group_count!r}"
+            )
+    elif any(
+        key in metadata
+        for key in (
+            "replay_metadata_schema_version",
+            "replay_manifest_digest",
+            "replay_group_count",
         )
-    group_count = metadata.get("replay_group_count")
-    if not isinstance(group_count, int) or group_count < 0:
-        raise ValueError(
-            "Native TQ checkpoint metadata has invalid replay_group_count: "
-            f"{group_count!r}"
+    ):
+        raise FileNotFoundError(
+            "Native TQ checkpoint advertises replay metadata, but its sidecar "
+            f"is missing at {replay_metadata_path}"
+        )
+
+    recovery_group_count = 0
+    if has_rollout_recovery:
+        recovery_digest = metadata.get("rollout_recovery_payload_sha256")
+        if not isinstance(recovery_digest, str) or not recovery_digest:
+            raise ValueError(
+                "Native TQ checkpoint metadata is missing "
+                "rollout_recovery_payload_sha256"
+            )
+        recovery_group_count = metadata.get("rollout_recovery_group_count")
+        if not isinstance(recovery_group_count, int) or recovery_group_count < 0:
+            raise ValueError(
+                "Native TQ checkpoint metadata has invalid "
+                f"rollout_recovery_group_count: {recovery_group_count!r}"
+            )
+    elif any(
+        key in metadata
+        for key in (
+            "rollout_recovery_schema_version",
+            "rollout_recovery_payload_sha256",
+            "rollout_recovery_group_count",
+        )
+    ):
+        raise FileNotFoundError(
+            "Native TQ checkpoint advertises rollout recovery, but its sidecar "
+            f"is missing at {rollout_recovery_path}"
         )
     print(
-        f"📦 Native TQ checkpoint restored and validated: groups={group_count}",
+        "📦 Native TQ checkpoint restored and validated: "
+        f"replay_groups={replay_group_count}, "
+        f"lineage_groups={recovery_group_count}",
         flush=True,
     )
     return metadata
+
+
+def _maybe_restore_rollout_recovery_ledger(
+    *,
+    last_checkpoint_path: Optional[str],
+    data_plane_checkpoint_metadata: Optional[dict[str, Any]],
+    token_capture_enabled: bool,
+) -> Optional[RolloutRecoveryLedger]:
+    """Load the compact lineage sidecar and validate its TQ-bound digest."""
+    if not token_capture_enabled:
+        if (
+            last_checkpoint_path is not None
+            and (Path(last_checkpoint_path) / ROLLOUT_RECOVERY_STATE_FILENAME).is_file()
+        ):
+            raise RuntimeError(
+                "checkpoint contains rollout recovery state, but "
+                "token_capture.enabled=false"
+            )
+        return None
+    if last_checkpoint_path is None:
+        return RolloutRecoveryLedger()
+    recovery_path = Path(last_checkpoint_path) / ROLLOUT_RECOVERY_STATE_FILENAME
+    if not recovery_path.is_file():
+        if data_plane_checkpoint_metadata is not None:
+            raise FileNotFoundError(
+                "token-capture resume requires rollout lineage from the same "
+                "native TQ checkpoint; older checkpoints without "
+                f"{ROLLOUT_RECOVERY_STATE_FILENAME} are not supported"
+            )
+        return RolloutRecoveryLedger()
+    if data_plane_checkpoint_metadata is None:
+        raise RuntimeError(
+            "rollout recovery sidecar requires a matching native TQ checkpoint"
+        )
+    payload = recovery_path.read_bytes()
+    actual_digest = hashlib.sha256(payload).hexdigest()
+    expected_digest = data_plane_checkpoint_metadata.get(
+        "rollout_recovery_payload_sha256"
+    )
+    if actual_digest != expected_digest:
+        raise ValueError(
+            "rollout recovery sidecar digest does not match the native TQ "
+            f"checkpoint: actual={actual_digest!r}, expected={expected_digest!r}"
+        )
+    state = torch.load(io.BytesIO(payload), weights_only=False)
+    if not isinstance(state, dict):
+        raise TypeError("rollout recovery sidecar must contain a state mapping")
+    ledger = RolloutRecoveryLedger.from_state_dict(state)
+    expected_group_count = data_plane_checkpoint_metadata.get(
+        "rollout_recovery_group_count"
+    )
+    if not isinstance(expected_group_count, int) or len(ledger) != expected_group_count:
+        raise ValueError(
+            "rollout recovery group count does not match native TQ metadata: "
+            f"sidecar={len(ledger)}, expected={expected_group_count!r}"
+        )
+    return ledger
+
+
+def _rehydrate_rollout_recovery_prompts(
+    ledger: Optional[RolloutRecoveryLedger], dataset: Any
+) -> None:
+    """Resolve unfinished static prompts from the restored dataset by index."""
+    if ledger is None:
+        return
+    for group in ledger.summaries():
+        if group.status != PromptGroupStatus.GENERATING:
+            continue
+        try:
+            dataset_index = int(group.prompt_ref.sample_id)
+        except ValueError as error:
+            raise ValueError(
+                "rollout recovery currently requires numeric dataset sample IDs: "
+                f"{group.prompt_ref.sample_id!r}"
+            ) from error
+        try:
+            prompt = dataset[dataset_index]
+        except (IndexError, KeyError) as error:
+            raise ValueError(
+                "rollout recovery prompt reference is absent from the current "
+                f"dataset: sample_id={group.prompt_ref.sample_id!r}"
+            ) from error
+        ledger.bind_runtime_prompt(group.group_id, prompt)
 
 
 def _build_clusters(
@@ -536,6 +679,25 @@ def setup_single_controller(
             "sampler requires data_plane.checkpointing_enabled=true so "
             "completed, unconsumed rollouts are recoverable."
         )
+    if (
+        master_config.checkpointing["enabled"]
+        and master_config.token_capture.enabled
+        and not dp_config.get("checkpointing_enabled")
+    ):
+        raise ValueError(
+            "token-capture checkpointing requires "
+            "data_plane.checkpointing_enabled=true so staged partial rollouts "
+            "and their lineage are restored together"
+        )
+    if (
+        master_config.checkpointing["enabled"]
+        and master_config.token_capture.enabled
+        and not sampler_supports_buffer_checkpoint(master_config.async_rl.sampler)
+    ):
+        raise ValueError(
+            "token-capture checkpointing requires a sampler that supports "
+            "replay-buffer recovery; supported built-ins are windowed and in_order"
+        )
 
     assert generation_config is not None, (
         "single_controller_utils.setup requires policy.generation in master_config"
@@ -773,6 +935,12 @@ def setup_single_controller(
         partition_id=partition_id,
         sampler_name=master_config.async_rl.sampler.name,
     )
+    recovery_ledger = _maybe_restore_rollout_recovery_ledger(
+        last_checkpoint_path=last_checkpoint_path,
+        data_plane_checkpoint_metadata=data_plane_checkpoint_metadata,
+        token_capture_enabled=token_capture_cfg.enabled,
+    )
+    _rehydrate_rollout_recovery_prompts(recovery_ledger, dataset)
 
     if use_nemo_gym:
         env_handles["nemo_gym"], gym_time = results["nemo_gym"]
@@ -887,7 +1055,6 @@ def setup_single_controller(
         ),
     )
     finalizer_actors: list[Any] = []
-    recovery_ledger = None
     if token_capture_cfg.enabled:
         from nemo_rl.experience.finalizer_actor import (
             FinalizerActorConfig,
@@ -907,9 +1074,7 @@ def setup_single_controller(
             ),
             num_workers=token_capture_cfg.num_finalizer_workers,
         )
-        from nemo_rl.experience.rollout_recovery import RolloutRecoveryLedger
-
-        recovery_ledger = RolloutRecoveryLedger()
+        assert recovery_ledger is not None
     rollout_manager = RolloutManager(
         tokenizer=tokenizer,
         task_to_env=env_handles,

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -21,12 +21,15 @@ runtime_envs and breaks Ray's resource resolution (see the PR #2692 follow-up).
 
 from __future__ import annotations
 
+import hashlib
+import io
 import os
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional, cast
 
+import torch
 from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import AutoProcessor
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
@@ -60,6 +63,11 @@ from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
 from nemo_rl.environments.interfaces import EnvironmentInterface
 from nemo_rl.environments.nemo_gym import spinup_nemo_gym_actor
 from nemo_rl.experience.rollout_manager import RolloutManager
+from nemo_rl.experience.rollout_recovery import (
+    ROLLOUT_RECOVERY_SCHEMA_VERSION,
+    ROLLOUT_RECOVERY_STATE_FILENAME,
+    RolloutRecoveryLedger,
+)
 from nemo_rl.models.generation.sglang.config import SGLangConfig
 from nemo_rl.models.generation.sglang.sglang_generation import SGLangGeneration
 from nemo_rl.models.generation.vllm import VllmGeneration
@@ -109,17 +117,20 @@ def _maybe_restore_native_data_plane_checkpoint(
 ) -> Optional[dict[str, Any]]:
     """Load and validate an authoritative native TQ checkpoint when present.
 
-    The metadata-only replay sidecar is the format marker. Checkpoints without
-    any replay artifact resume trainer state with an empty replay buffer;
-    legacy tensor-bearing replay files are rejected rather than silently
-    ignored. Rollout tensors are never serialized into a controller-side
-    replay checkpoint.
+    A replay-metadata or rollout-recovery sidecar is the authoritative format
+    marker. Checkpoints without either artifact resume trainer state with an
+    empty replay buffer; legacy tensor-bearing replay files are rejected
+    rather than silently ignored. Rollout tensors are never serialized into a
+    controller-side checkpoint.
     """
     if last_checkpoint_path is None:
         return None
     checkpoint_path = Path(last_checkpoint_path)
     replay_metadata_path = checkpoint_path / REPLAY_BUFFER_METADATA_FILENAME
-    if not replay_metadata_path.is_file():
+    rollout_recovery_path = checkpoint_path / ROLLOUT_RECOVERY_STATE_FILENAME
+    has_replay_metadata = replay_metadata_path.is_file()
+    has_rollout_recovery = rollout_recovery_path.is_file()
+    if not has_replay_metadata and not has_rollout_recovery:
         legacy_replay_path = checkpoint_path / LEGACY_REPLAY_BUFFER_FILENAME
         if legacy_replay_path.is_file():
             raise RuntimeError(
@@ -145,9 +156,7 @@ def _maybe_restore_native_data_plane_checkpoint(
             f"got {type(metadata).__name__}"
         )
     expected_values: dict[str, Any] = {
-        "data_plane_checkpoint_schema_version": (
-            DATA_PLANE_CHECKPOINT_SCHEMA_VERSION
-        ),
+        "data_plane_checkpoint_schema_version": (DATA_PLANE_CHECKPOINT_SCHEMA_VERSION),
         "single_controller_train_steps": save_state["current_step"],
         "single_controller_trainer_version": save_state.get(
             "trainer_version", save_state["current_step"]
@@ -156,8 +165,15 @@ def _maybe_restore_native_data_plane_checkpoint(
         "partition_id": partition_id,
         "sampler_name": sampler_name,
         "mode": "authoritative",
-        "replay_metadata_schema_version": REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
     }
+    if has_replay_metadata:
+        expected_values["replay_metadata_schema_version"] = (
+            REPLAY_BUFFER_METADATA_SCHEMA_VERSION
+        )
+    if has_rollout_recovery:
+        expected_values["rollout_recovery_schema_version"] = (
+            ROLLOUT_RECOVERY_SCHEMA_VERSION
+        )
     mismatches = {
         key: {"checkpoint": metadata.get(key), "expected": expected}
         for key, expected in expected_values.items()
@@ -168,23 +184,119 @@ def _maybe_restore_native_data_plane_checkpoint(
             "Native TQ checkpoint metadata does not match the trainer "
             f"checkpoint: {mismatches}"
         )
-    manifest_digest = metadata.get("replay_manifest_digest")
-    if not isinstance(manifest_digest, str) or not manifest_digest:
-        raise ValueError(
-            "Native TQ checkpoint metadata is missing replay_manifest_digest"
+    group_count = 0
+    if has_replay_metadata:
+        manifest_digest = metadata.get("replay_manifest_digest")
+        if not isinstance(manifest_digest, str) or not manifest_digest:
+            raise ValueError(
+                "Native TQ checkpoint metadata is missing replay_manifest_digest"
+            )
+        group_count = metadata.get("replay_group_count")
+        if not isinstance(group_count, int) or group_count < 0:
+            raise ValueError(
+                "Native TQ checkpoint metadata has invalid replay_group_count: "
+                f"{group_count!r}"
+            )
+    elif any(
+        key in metadata
+        for key in (
+            "replay_metadata_schema_version",
+            "replay_manifest_digest",
+            "replay_group_count",
         )
-    group_count = metadata.get("replay_group_count")
-    if not isinstance(group_count, int) or group_count < 0:
-        raise ValueError(
-            "Native TQ checkpoint metadata has invalid replay_group_count: "
-            f"{group_count!r}"
+    ):
+        raise FileNotFoundError(
+            "Native TQ checkpoint advertises replay metadata, but its sidecar "
+            f"is missing at {replay_metadata_path}"
+        )
+
+    if has_rollout_recovery:
+        recovery_digest = metadata.get("rollout_recovery_payload_sha256")
+        if not isinstance(recovery_digest, str) or not recovery_digest:
+            raise ValueError(
+                "Native TQ checkpoint metadata is missing "
+                "rollout_recovery_payload_sha256"
+            )
+        recovery_group_count = metadata.get("rollout_recovery_group_count")
+        if not isinstance(recovery_group_count, int) or recovery_group_count < 0:
+            raise ValueError(
+                "Native TQ checkpoint metadata has invalid "
+                f"rollout_recovery_group_count: {recovery_group_count!r}"
+            )
+    elif any(
+        key in metadata
+        for key in (
+            "rollout_recovery_schema_version",
+            "rollout_recovery_payload_sha256",
+            "rollout_recovery_group_count",
+        )
+    ):
+        raise FileNotFoundError(
+            "Native TQ checkpoint advertises rollout recovery, but its "
+            f"sidecar is missing at {rollout_recovery_path}"
         )
     print(
-        "📦 Native TQ checkpoint restored and validated: "
-        f"groups={group_count}",
+        f"📦 Native TQ checkpoint restored and validated: groups={group_count}",
         flush=True,
     )
     return metadata
+
+
+def _maybe_restore_rollout_recovery_ledger(
+    *,
+    last_checkpoint_path: Optional[str],
+    data_plane_checkpoint_metadata: Optional[dict[str, Any]],
+    token_capture_enabled: bool,
+) -> Optional[RolloutRecoveryLedger]:
+    """Load and bind the rollout-recovery sidecar to the restored TQ cut."""
+    if last_checkpoint_path is None:
+        return None
+    recovery_path = Path(last_checkpoint_path) / ROLLOUT_RECOVERY_STATE_FILENAME
+    if not recovery_path.is_file():
+        return None
+    if not token_capture_enabled:
+        raise RuntimeError(
+            "Checkpoint contains rollout-recovery state, but token capture is disabled"
+        )
+    if data_plane_checkpoint_metadata is None:
+        raise RuntimeError(
+            "Rollout-recovery sidecar requires a matching restored native TQ checkpoint"
+        )
+
+    payload = recovery_path.read_bytes()
+    actual_digest = hashlib.sha256(payload).hexdigest()
+    expected_digest = data_plane_checkpoint_metadata.get(
+        "rollout_recovery_payload_sha256"
+    )
+    if actual_digest != expected_digest:
+        raise ValueError(
+            "Rollout-recovery sidecar digest does not match the native TQ "
+            f"checkpoint metadata: actual={actual_digest!r}, "
+            f"expected={expected_digest!r}"
+        )
+    # weights_only=False: the trusted same-job sidecar may contain DatumSpec
+    # values unsupported by torch's restricted weights-only unpickler.
+    state = torch.load(io.BytesIO(payload), weights_only=False)
+    if not isinstance(state, dict):
+        raise TypeError(
+            "Rollout-recovery sidecar must contain a state dictionary, "
+            f"got {type(state).__name__}"
+        )
+    ledger = RolloutRecoveryLedger.from_state_dict(state)
+    expected_group_count = data_plane_checkpoint_metadata.get(
+        "rollout_recovery_group_count"
+    )
+    if len(ledger) != expected_group_count:
+        raise ValueError(
+            "Rollout-recovery sidecar group count does not match the native "
+            f"TQ checkpoint metadata: sidecar={len(ledger)}, "
+            f"checkpoint={expected_group_count!r}"
+        )
+    print(
+        f"📦 Restored rollout recovery ledger: groups={len(ledger)}",
+        flush=True,
+    )
+    return ledger
 
 
 def _build_clusters(
@@ -437,6 +549,23 @@ def setup_single_controller(
     # worker hosts Gym's capture core + adapter in-process).
     token_capture_cfg = master_config.token_capture
     if token_capture_cfg.enabled:
+        if master_config.checkpointing["enabled"] and not dp_config.get(
+            "checkpointing_enabled"
+        ):
+            raise ValueError(
+                "SingleController token-capture checkpointing requires "
+                "data_plane.checkpointing_enabled=true so receipts and their "
+                "TQ staging rows share one durable checkpoint cut."
+            )
+        if (
+            master_config.checkpointing["enabled"]
+            and master_config.async_rl.sampler.supports_buffer_checkpoint is not True
+        ):
+            raise NotImplementedError(
+                "Token-capture checkpoint recovery currently requires a "
+                "replay-checkpoint-capable sampler (windowed); restoring the "
+                "dispatch/readiness state of gated samplers is not implemented yet."
+            )
         if not _should_use_nemo_gym(master_config):
             raise ValueError(
                 "token_capture.enabled requires the NeMo-Gym rollout path "
@@ -605,6 +734,11 @@ def setup_single_controller(
         partition_id=partition_id,
         sampler_name=master_config.async_rl.sampler.name,
     )
+    recovery_ledger = _maybe_restore_rollout_recovery_ledger(
+        last_checkpoint_path=last_checkpoint_path,
+        data_plane_checkpoint_metadata=data_plane_checkpoint_metadata,
+        token_capture_enabled=token_capture_cfg.enabled,
+    )
 
     # ==========================
     # NeMo-Gym actor (after generation is up so OpenAI URLs are available)
@@ -732,6 +866,7 @@ def setup_single_controller(
         use_nemo_gym=use_nemo_gym,
         tq_buffer=tq_buffer,
         finalizer=finalizer,
+        recovery_ledger=recovery_ledger,
     )
 
     return SingleControllerActorArgs(

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -1761,6 +1761,9 @@ class RolloutManager:
             self._tq_buffer.abort(group_id)
             async with self._recovery_mutation():
                 self._recovery_ledger.abandon_unsealed(group_id)
+            # A failure after the last sibling sealed leaves the group ready to
+            # finalize; an earlier failure leaves it generating. The outer retry
+            # loop deliberately supports both entry states.
             # The capture ledger has no per-rollout fail endpoint. Rows from
             # abandoned attempts are unreferenced and are swept with the
             # staging partition at run teardown.

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -16,7 +16,8 @@ import asyncio
 import copy
 import enum
 import json
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -25,7 +26,10 @@ import torch
 from transformers import PreTrainedTokenizerBase
 from wandb import Table
 
-from nemo_rl.algorithms.async_utils.replay_buffer import TQReplayBuffer
+from nemo_rl.algorithms.async_utils.replay_buffer import (
+    DataPlaneCheckpointBarrier,
+    TQReplayBuffer,
+)
 from nemo_rl.data.interfaces import DatumSpec, LLMMessageLogType
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.environments.interfaces import EnvironmentInterface
@@ -1271,6 +1275,7 @@ class RolloutManager:
         self._num_generations_per_prompt = num_generations_per_prompt
         self._tq_buffer = tq_buffer
         self._recovery_ledger = recovery_ledger
+        self._data_plane_checkpoint_barrier: Optional[DataPlaneCheckpointBarrier] = None
         self._weight_version: int = 0
         # Run-wide, shared across concurrent generate_and_push calls. Safe as a plain
         # int: every caller runs on the SingleController's single event loop.
@@ -1285,6 +1290,22 @@ class RolloutManager:
     def recovery_ledger(self) -> Optional[RolloutRecoveryLedger]:
         """Return the controller-owned token-capture lineage ledger."""
         return self._recovery_ledger
+
+    def set_data_plane_checkpoint_barrier(
+        self, barrier: DataPlaneCheckpointBarrier
+    ) -> None:
+        """Join streamed receipt transitions to the SC snapshot barrier."""
+        self._data_plane_checkpoint_barrier = barrier
+
+    @asynccontextmanager
+    async def _recovery_mutation(self) -> AsyncIterator[None]:
+        """Serialize short lineage transitions with native TQ snapshots."""
+        barrier = self._data_plane_checkpoint_barrier
+        if barrier is None:
+            yield
+            return
+        async with barrier.mutation():
+            yield
 
     def set_weight_version(self, version: int) -> None:
         """Set the weight_version used for rollout tags.
@@ -1498,18 +1519,65 @@ class RolloutManager:
             raise RuntimeError(
                 "generate_for_finalization requires a rollout recovery ledger"
             )
-        recovery_group = self._recovery_ledger.reserve_group(
-            prompt_id=str(input_sample["idx"]),
-            prompt_ref=PromptRef(
-                sample_id=str(input_sample["idx"]),
-                task_name=input_sample.get("task_name"),
-            ),
-            prompt_payload=input_sample,
-            expected_generations=self._num_generations_per_prompt,
-            target_step=target_step,
-            start_weight_version=self._weight_version,
-        )
+        async with self._recovery_mutation():
+            recovery_group = self._recovery_ledger.reserve_group(
+                prompt_id=str(input_sample["idx"]),
+                prompt_ref=PromptRef(
+                    sample_id=str(input_sample["idx"]),
+                    task_name=input_sample.get("task_name"),
+                ),
+                prompt_payload=input_sample,
+                expected_generations=self._num_generations_per_prompt,
+                target_step=target_step,
+                start_weight_version=self._weight_version,
+            )
         recovery_group_id = recovery_group.group_id
+        return await self._run_finalization_with_retries(
+            input_sample,
+            recovery_group_id=recovery_group_id,
+            inflight_registry=inflight_registry,
+        )
+
+    async def recover_for_finalization(
+        self,
+        group_id: str,
+        *,
+        inflight_registry: Optional[dict[str, tuple[asyncio.Task[None], int]]] = None,
+    ) -> Optional["FinalizationRequest"]:
+        """Redispatch only missing siblings from one restored prompt group."""
+        if self._recovery_ledger is None:
+            raise RuntimeError("rollout recovery requires a lineage ledger")
+        group = self._recovery_ledger.get_group(group_id)
+        if group.status == PromptGroupStatus.READY_TO_FINALIZE:
+            input_sample = None
+        elif group.status == PromptGroupStatus.GENERATING:
+            input_sample = group.runtime_prompt_payload
+            if input_sample is None:
+                raise RuntimeError(
+                    f"recovery group {group_id!r} has no reconstructed prompt"
+                )
+        else:
+            raise ValueError(
+                f"cannot recover group {group_id!r} from {group.status.value!r}"
+            )
+        return await self._run_finalization_with_retries(
+            input_sample,
+            recovery_group_id=group_id,
+            inflight_registry=inflight_registry,
+        )
+
+    async def discard_recovery_group(self, group_id: str) -> None:
+        """Drop restored lineage that the active sampler can no longer consume."""
+        await self._discard_recovery_group(group_id)
+
+    async def _run_finalization_with_retries(
+        self,
+        input_sample: Optional[DatumSpec],
+        *,
+        recovery_group_id: str,
+        inflight_registry: Optional[dict[str, tuple[asyncio.Task[None], int]]],
+    ) -> Optional["FinalizationRequest"]:
+        """Apply the normal retry policy to new or restored capture groups."""
         policy = self._retry_policy
         infra_attempts = 0
         data_attempts = 0
@@ -1548,8 +1616,13 @@ class RolloutManager:
                         ) from error
                     self._skipped_prompts += 1
                     await self._discard_recovery_group(recovery_group_id)
+                    prompt_id = (
+                        input_sample["idx"]
+                        if input_sample is not None
+                        else recovery_group_id
+                    )
                     print(
-                        f"skipping prompt idx={input_sample['idx']} after "
+                        f"skipping prompt idx={prompt_id} after "
                         f"{data_attempts} deterministic failure(s) "
                         f"({reason}: {error})",
                         flush=True,
@@ -1559,8 +1632,11 @@ class RolloutManager:
                 self._stats.record_data_retry(reason)
 
         assert last_infra_error is not None
+        prompt_id = (
+            input_sample["idx"] if input_sample is not None else recovery_group_id
+        )
         raise RolloutRedispatchExhausted(
-            f"prompt idx={input_sample['idx']} exhausted its infrastructure retry "
+            f"prompt idx={prompt_id} exhausted its infrastructure retry "
             f"budget after {infra_attempts} attempt(s) "
             f"(max_infra_attempts_per_prompt={policy.max_infra_attempts}); "
             f"last failure was {type(last_infra_error).__name__}: "
@@ -1569,7 +1645,7 @@ class RolloutManager:
 
     async def _generate_for_finalization_attempt(
         self,
-        input_sample: DatumSpec,
+        input_sample: Optional[DatumSpec],
         *,
         recovery_group_id: str,
         inflight_registry: Optional[dict[str, tuple[asyncio.Task[None], int]]],
@@ -1579,11 +1655,12 @@ class RolloutManager:
 
         assert self._tq_buffer is not None
         assert self._recovery_ledger is not None
-        recovery_group = self._recovery_ledger.get_group(recovery_group_id)
-        if recovery_group.status == PromptGroupStatus.GENERATING:
-            recovery_group = self._recovery_ledger.prepare_incomplete_retry(
-                recovery_group_id
-            )
+        async with self._recovery_mutation():
+            recovery_group = self._recovery_ledger.get_group(recovery_group_id)
+            if recovery_group.status == PromptGroupStatus.GENERATING:
+                recovery_group = self._recovery_ledger.prepare_incomplete_retry(
+                    recovery_group_id
+                )
         pending_indices = [
             sibling.generation_index
             for sibling in recovery_group.siblings
@@ -1617,13 +1694,24 @@ class RolloutManager:
                 raise ValueError(
                     "token-capture completion must contain its Gate rollout ID"
                 )
-            self._recovery_ledger.mark_sibling_sealed(
-                group_id,
-                generation_index=generation_index,
-                gate_rollout_id=gate_rollout_id,
-                receipt=receipt,
-                reward=completion.reward,
-            )
+            barrier = self._data_plane_checkpoint_barrier
+            if barrier is None:
+                self._recovery_ledger.mark_sibling_sealed(
+                    group_id,
+                    generation_index=generation_index,
+                    gate_rollout_id=gate_rollout_id,
+                    receipt=receipt,
+                    reward=completion.reward,
+                )
+            else:
+                async with barrier.mutation():
+                    self._recovery_ledger.mark_sibling_sealed(
+                        group_id,
+                        generation_index=generation_index,
+                        gate_rollout_id=gate_rollout_id,
+                        receipt=receipt,
+                        reward=completion.reward,
+                    )
 
         try:
             if inflight_registry is not None:
@@ -1632,9 +1720,15 @@ class RolloutManager:
                 inflight_registry[group_id] = (current_task, start_version)
             try:
                 if pending_indices:
-                    self._recovery_ledger.mark_group_dispatched(
-                        group_id, generation_indices=pending_indices
-                    )
+                    if input_sample is None:
+                        raise RuntimeError(
+                            f"recovery group {group_id!r} needs a prompt for "
+                            "unfinished sibling generation"
+                        )
+                    async with self._recovery_mutation():
+                        self._recovery_ledger.mark_group_dispatched(
+                            group_id, generation_indices=pending_indices
+                        )
                     await self.run_rollout(
                         input_sample,
                         rollout_ids=list(rollout_ids),
@@ -1644,12 +1738,13 @@ class RolloutManager:
             finally:
                 if inflight_registry is not None:
                     inflight_registry.pop(group_id, None)
-            (
-                physical_rollout_ids,
-                canonical_sample_ids,
-                receipts,
-                rewards,
-            ) = self._recovery_ledger.finalization_inputs(group_id)
+            async with self._recovery_mutation():
+                (
+                    physical_rollout_ids,
+                    canonical_sample_ids,
+                    receipts,
+                    rewards,
+                ) = self._recovery_ledger.finalization_inputs(group_id)
             request = FinalizationRequest(
                 group_id=group_id,
                 rollout_ids=tuple(physical_rollout_ids),
@@ -1664,7 +1759,8 @@ class RolloutManager:
             return request
         except BaseException:
             self._tq_buffer.abort(group_id)
-            self._recovery_ledger.abandon_unsealed(group_id)
+            async with self._recovery_mutation():
+                self._recovery_ledger.abandon_unsealed(group_id)
             # The capture ledger has no per-rollout fail endpoint. Rows from
             # abandoned attempts are unreferenced and are swept with the
             # staging partition at run teardown.
@@ -1680,5 +1776,6 @@ class RolloutManager:
             for sibling in group.siblings
             for key in sibling.current_attempt.staging_keys
         ]
-        await self._tq_buffer.clear_staging_keys(staging_keys)
-        self._recovery_ledger.discard_group(group_id)
+        async with self._recovery_mutation():
+            await self._tq_buffer.clear_staging_keys(staging_keys)
+            self._recovery_ledger.discard_group(group_id)

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -22,7 +22,10 @@ import torch
 from transformers import PreTrainedTokenizerBase
 from wandb import Table
 
-from nemo_rl.algorithms.async_utils.replay_buffer import TQReplayBuffer
+from nemo_rl.algorithms.async_utils.replay_buffer import (
+    DataPlaneCheckpointBarrier,
+    TQReplayBuffer,
+)
 from nemo_rl.data.interfaces import DatumSpec, LLMMessageLogType
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.environments.interfaces import EnvironmentInterface
@@ -84,7 +87,7 @@ class AsyncRolloutImpl:
                 available only on the NeMo-Gym path.
 
         Returns:
-            PromptGroupRecord with num_generations_per_prompt completions.
+            PromptGroupRecord containing each requested generation.
         """
         assert rollout_ids is None, (
             "token capture (rollout_ids) is only supported on the NeMo-Gym path"
@@ -442,6 +445,7 @@ class AsyncNemoGymRolloutImpl:
         input_sample: DatumSpec,
         *,
         rollout_ids: Optional[list[str]] = None,
+        generation_indices: Optional[list[int]] = None,
         on_completion: Optional[RolloutCompletionCallback] = None,
     ) -> PromptGroupRecord:
         """Run num_generations_per_prompt rollouts for one prompt.
@@ -452,6 +456,9 @@ class AsyncNemoGymRolloutImpl:
                 per generation, riding each row's run body as the opaque
                 ``_ng_rollout_id`` key (agents stamp /ng-rollout/<id> from it;
                 zero agent changes).
+            generation_indices: Logical sibling indices represented by
+                ``rollout_ids``. Recovery uses a strict subset so already
+                sealed siblings are not generated again.
             on_completion: Optional async callback invoked as soon as one
                 streamed sibling result has been converted to a completion.
 
@@ -462,12 +469,42 @@ class AsyncNemoGymRolloutImpl:
         timer_prefix = "timing/rollout"
         timer.start(f"{timer_prefix}/total")
 
-        rollout_inputs = self._build_inputs(input_sample, rollout_ids=rollout_ids)
+        if generation_indices is None:
+            generation_indices = list(range(self._num_generations_per_prompt))
+        if not generation_indices:
+            raise ValueError("generation_indices must not be empty")
+        if len(set(generation_indices)) != len(generation_indices) or any(
+            index < 0 or index >= self._num_generations_per_prompt
+            for index in generation_indices
+        ):
+            raise ValueError(
+                "generation_indices must contain unique logical sibling "
+                "indices within the configured group size"
+            )
+        if rollout_ids is None and generation_indices != list(
+            range(self._num_generations_per_prompt)
+        ):
+            raise ValueError("subset generation requires token-capture rollout IDs")
+
+        rollout_inputs = self._build_inputs(
+            input_sample,
+            rollout_ids=rollout_ids,
+            num_generations=len(generation_indices),
+        )
+
+        async def _map_completion_index(
+            local_index: int, completion: Completion
+        ) -> None:
+            if on_completion is not None:
+                await on_completion(generation_indices[local_index], completion)
+
         completions, prompt_message_log, rollout_metrics = await self._run_rollouts(
             rollout_inputs,
             timer,
             timer_prefix,
-            on_completion=on_completion,
+            on_completion=(
+                _map_completion_index if on_completion is not None else None
+            ),
         )
 
         timer.stop(f"{timer_prefix}/total")
@@ -497,9 +534,15 @@ class AsyncNemoGymRolloutImpl:
         )
 
     def _build_inputs(
-        self, input_sample: DatumSpec, *, rollout_ids: Optional[list[str]] = None
+        self,
+        input_sample: DatumSpec,
+        *,
+        rollout_ids: Optional[list[str]] = None,
+        num_generations: Optional[int] = None,
     ) -> list[dict]:
         """Build N row dicts from input_sample, applying generation config params."""
+        if num_generations is None:
+            num_generations = self._num_generations_per_prompt
         # Build a template row from the input_sample's extra_env_info, applying generation params.
         template_row: dict = copy.deepcopy(input_sample["extra_env_info"])  # type: ignore
 
@@ -520,11 +563,11 @@ class AsyncNemoGymRolloutImpl:
 
         # Build N rows with distinct rowidxs so run_rollouts can sort them correctly.
         if rollout_ids is not None:
-            assert len(rollout_ids) == self._num_generations_per_prompt, (
-                "token-capture rollout ids must be one per generation"
+            assert len(rollout_ids) == num_generations, (
+                "token-capture rollout ids must be one per requested generation"
             )
         rows = []
-        for i in range(self._num_generations_per_prompt):
+        for i in range(num_generations):
             row = copy.deepcopy(template_row)
             row["_rowidx"] = i
             if rollout_ids is not None:
@@ -802,6 +845,7 @@ class RolloutManager:
             if finalizer is not None
             else None
         )
+        self._data_plane_checkpoint_barrier: Optional[DataPlaneCheckpointBarrier] = None
         # The NeMo-Gym env handle doubles as the gate control-plane proxy
         # (gate_metrics / fail_rollouts) on the capture path.
         self._env_handles = task_to_env
@@ -812,6 +856,16 @@ class RolloutManager:
         """Return the controller-local token-capture recovery ledger."""
         return self._recovery_ledger
 
+    def set_data_plane_checkpoint_barrier(
+        self, barrier: DataPlaneCheckpointBarrier
+    ) -> None:
+        """Bind the SC checkpoint barrier to streamed ledger mutations."""
+        if self._data_plane_checkpoint_barrier is not None:
+            raise RuntimeError(
+                "rollout-manager checkpoint barrier is already configured"
+            )
+        self._data_plane_checkpoint_barrier = barrier
+
     def set_weight_version(self, version: int) -> None:
         """Set the weight_version used for rollout tags.
 
@@ -819,6 +873,27 @@ class RolloutManager:
             version: Trainer weight version to stamp on future rollout tags.
         """
         self._weight_version = int(version)
+
+    def reserve_prompt_group(
+        self, input_sample: DatumSpec, *, target_step: Optional[int] = None
+    ) -> Optional[str]:
+        """Reserve durable lineage before advancing past a dataloader batch.
+
+        The native rollout path returns ``None`` because its completed-only
+        replay recovery does not retain partial generation state.
+        """
+        if self._finalizer is None:
+            return None
+        if self._recovery_ledger is None:
+            raise RuntimeError("token capture requires a rollout recovery ledger")
+        group = self._recovery_ledger.reserve_group(
+            prompt_id=str(input_sample["idx"]),
+            prompt_payload=input_sample,
+            expected_generations=self._num_generations_per_prompt,
+            target_step=target_step,
+            start_weight_version=self._weight_version,
+        )
+        return group.group_id
 
     async def gate_metrics(self) -> Optional[dict[str, int]]:
         """Fetch the capture gate's § 8 counters, or None off the capture path.
@@ -838,22 +913,39 @@ class RolloutManager:
         input_sample: DatumSpec,
         *,
         rollout_ids: Optional[list[str]] = None,
+        generation_indices: Optional[list[int]] = None,
         on_completion: Optional[RolloutCompletionCallback] = None,
     ) -> PromptGroupRecord:
         if rollout_ids is None:
             assert on_completion is None, (
                 "completion callback requires token-capture rollout IDs"
             )
+            assert generation_indices is None, (
+                "generation subset requires token-capture rollout IDs"
+            )
             # Legacy path: keep the impl call signature byte-identical.
             return await self._impl.run_rollout(input_sample)
+        if generation_indices is None:
+            return await self._impl.run_rollout(
+                input_sample,
+                rollout_ids=rollout_ids,
+                on_completion=on_completion,
+            )
+        if not isinstance(self._impl, AsyncNemoGymRolloutImpl):
+            raise RuntimeError("generation subset requires the NeMo-Gym rollout path")
         return await self._impl.run_rollout(
             input_sample,
             rollout_ids=rollout_ids,
+            generation_indices=generation_indices,
             on_completion=on_completion,
         )
 
     async def generate_and_push(
-        self, input_sample: DatumSpec, *, target_step: Optional[int] = None
+        self,
+        input_sample: DatumSpec,
+        *,
+        target_step: Optional[int] = None,
+        recovery_group_id: Optional[str] = None,
     ) -> None:
         """Reserve a buffer slot, run one prompt's rollout, then commit the slot.
 
@@ -865,8 +957,16 @@ class RolloutManager:
             "generate_and_push requires tq_buffer to be set at __init__"
         )
         if self._finalizer is not None:
-            await self._generate_and_finalize(input_sample, target_step=target_step)
+            await self._generate_and_finalize(
+                input_sample,
+                target_step=target_step,
+                recovery_group_id=recovery_group_id,
+            )
             return
+        if recovery_group_id is not None:
+            raise ValueError(
+                "recovery_group_id is only supported for token-capture rollouts"
+            )
         start_version = self._weight_version
         group_id = self._tq_buffer.reserve(
             weight_version=start_version, target_step=target_step
@@ -887,7 +987,11 @@ class RolloutManager:
             raise
 
     async def _generate_and_finalize(
-        self, input_sample: DatumSpec, *, target_step: Optional[int] = None
+        self,
+        input_sample: DatumSpec,
+        *,
+        target_step: Optional[int] = None,
+        recovery_group_id: Optional[str] = None,
     ) -> None:
         """Token-capture dispatch: receipts in, canonical rows via the finalizer.
 
@@ -897,14 +1001,25 @@ class RolloutManager:
         the finalizer maps those attempts back to stable canonical rows.
         """
         assert self._recovery_ledger is not None
-        start_version = self._weight_version
-        recovery_group = self._recovery_ledger.reserve_group(
-            prompt_id=str(input_sample["idx"]),
-            prompt_payload=input_sample,
-            expected_generations=self._num_generations_per_prompt,
-            target_step=target_step,
-            start_weight_version=start_version,
-        )
+        if recovery_group_id is None:
+            recovery_group_id = self.reserve_prompt_group(
+                input_sample, target_step=target_step
+            )
+            assert recovery_group_id is not None
+        recovery_group = self._recovery_ledger.get_group(recovery_group_id)
+        if recovery_group.prompt_id != str(input_sample["idx"]):
+            raise ValueError(
+                "pre-reserved recovery group belongs to a different prompt: "
+                f"group={recovery_group.prompt_id!r}, "
+                f"input={str(input_sample['idx'])!r}"
+            )
+        if recovery_group.target_step != target_step:
+            raise ValueError(
+                "pre-reserved recovery group target step does not match its "
+                f"dispatch: group={recovery_group.target_step!r}, "
+                f"dispatch={target_step!r}"
+            )
+        start_version = recovery_group.start_weight_version
         group_id = recovery_group.group_id
         logical_rollout_ids = recovery_group.logical_rollout_ids
         gate_rollout_ids = recovery_group.gate_rollout_ids
@@ -928,13 +1043,22 @@ class RolloutManager:
                 raise ValueError(
                     "token-capture completion must contain its gate rollout ID"
                 )
-            self._recovery_ledger.mark_sibling_sealed(
-                group_id,
-                generation_index=generation_index,
-                gate_rollout_id=gate_rollout_id,
-                receipt=receipt,
-                reward=completion.reward,
-            )
+            if self._data_plane_checkpoint_barrier is None:
+                raise RuntimeError(
+                    "token-capture recovery requires the SC data-plane "
+                    "checkpoint barrier"
+                )
+            # The worker staged every key in the receipt before the gate
+            # returned it. Joining the mutation side here prevents a ledger
+            # snapshot from naming rows omitted by the matching TQ snapshot.
+            async with self._data_plane_checkpoint_barrier.mutation():
+                self._recovery_ledger.mark_sibling_sealed(
+                    group_id,
+                    generation_index=generation_index,
+                    gate_rollout_id=gate_rollout_id,
+                    receipt=receipt,
+                    reward=completion.reward,
+                )
 
         try:
             self._tq_buffer.reserve(
@@ -1018,3 +1142,171 @@ class RolloutManager:
             # controller memory without improving recovery.
             self._recovery_ledger.mark_group_finalized(group_id)
             self._recovery_ledger.release_finalized_group(group_id)
+
+    async def recover_group(self, group_id: str) -> bool:
+        """Redispatch missing siblings and publish one restored prompt group.
+
+        Returns:
+            True when canonical rows were committed. False when finalizer
+            policy deliberately dropped the restored group.
+        """
+        if self._recovery_ledger is None or self._finalizer is None:
+            raise RuntimeError("prompt-group recovery requires token capture")
+        if self._tq_buffer is None:
+            raise RuntimeError("prompt-group recovery requires a TQ replay buffer")
+
+        group = self._recovery_ledger.get_group(group_id)
+        generation_indices = self._recovery_ledger.retryable_generation_indices(
+            group_id
+        )
+        for generation_index in generation_indices:
+            self._recovery_ledger.retry_sibling(
+                group_id, generation_index=generation_index
+            )
+        if generation_indices:
+            self._recovery_ledger.mark_siblings_dispatched(
+                group_id, generation_indices=generation_indices
+            )
+        group = self._recovery_ledger.get_group(group_id)
+        allowed_statuses = {
+            RolloutAttemptStatus.SEALED,
+            RolloutAttemptStatus.DISPATCHED,
+        }
+        if any(
+            sibling.current_attempt.status not in allowed_statuses
+            for sibling in group.siblings
+        ):
+            raise ValueError(
+                f"recovery group {group_id!r} contains attempts that are "
+                "neither reusable nor retryable"
+            )
+
+        async def _record_retried_completion(
+            generation_index: int, completion: Completion
+        ) -> None:
+            env_extras = completion.env_extras
+            if env_extras is None:
+                raise ValueError(
+                    "token-capture completion must contain environment extras"
+                )
+            receipt = env_extras.get("ng_receipt")
+            gate_rollout_id = env_extras.get("ng_rollout_id")
+            if not isinstance(receipt, dict) or not isinstance(gate_rollout_id, str):
+                raise ValueError(
+                    "retried token-capture completion must contain its receipt "
+                    "and gate rollout ID"
+                )
+            if self._data_plane_checkpoint_barrier is None:
+                raise RuntimeError(
+                    "token-capture recovery requires the SC data-plane "
+                    "checkpoint barrier"
+                )
+            async with self._data_plane_checkpoint_barrier.mutation():
+                self._recovery_ledger.mark_sibling_sealed(
+                    group_id,
+                    generation_index=generation_index,
+                    gate_rollout_id=gate_rollout_id,
+                    receipt=receipt,
+                    reward=completion.reward,
+                )
+
+        try:
+            self._tq_buffer.reserve(
+                weight_version=group.start_weight_version,
+                target_step=group.target_step,
+                group_id=group.group_id,
+                rollout_ids=group.gate_rollout_ids,
+            )
+            if generation_indices:
+                retry_rollout_ids = [
+                    group.siblings[generation_index].current_attempt.gate_rollout_id
+                    for generation_index in generation_indices
+                ]
+                await self.run_rollout(
+                    group.prompt_payload,
+                    rollout_ids=retry_rollout_ids,
+                    generation_indices=generation_indices,
+                    on_completion=_record_retried_completion,
+                )
+
+            group = self._recovery_ledger.get_group(group_id)
+            attempts = [sibling.current_attempt for sibling in group.siblings]
+            if any(
+                attempt.status != RolloutAttemptStatus.SEALED for attempt in attempts
+            ):
+                raise RuntimeError(
+                    f"recovery group {group_id!r} did not seal every sibling"
+                )
+            receipts: list[dict[str, Any]] = []
+            rewards: list[float] = []
+            for attempt in attempts:
+                if attempt.receipt is None or attempt.reward is None:
+                    raise RuntimeError(
+                        f"sealed attempt {attempt.gate_rollout_id!r} lost its "
+                        "receipt or reward"
+                    )
+                receipts.append(attempt.receipt)
+                rewards.append(attempt.reward)
+
+            finalized = await asyncio.to_thread(
+                self._finalizer.finalize_group,
+                group.group_id,
+                group.gate_rollout_ids,
+                receipts,
+                rewards,
+                fallback_weight_version=group.start_weight_version,
+                canonical_sample_ids=group.logical_rollout_ids,
+            )
+            if finalized.dropped:
+                await self._tq_buffer.abort_finalized(
+                    group.group_id, staging_keys=finalized.staging_keys
+                )
+                self._recovery_ledger.discard_group(group.group_id)
+                print(
+                    f"rollout recovery dropped group: group={group.group_id}",
+                    flush=True,
+                )
+                return False
+            assert finalized.meta is not None
+            assert finalized.fields is not None
+            await self._tq_buffer.commit_finalized(
+                group.group_id,
+                finalized.meta,
+                finalized.fields,
+                finalized.group_min_wv,
+                finalized.group_max_wv,
+                staging_keys=finalized.staging_keys,
+            )
+        except BaseException:
+            self._tq_buffer.abort(group.group_id)
+            self._recovery_ledger.abandon_group(group.group_id)
+            recovery_group = self._recovery_ledger.get_group(group.group_id)
+            gate_ids_to_fail = [
+                sibling.current_attempt.gate_rollout_id
+                for sibling in recovery_group.siblings
+                if sibling.current_attempt.status
+                not in {
+                    RolloutAttemptStatus.SEALED,
+                    RolloutAttemptStatus.FINALIZED,
+                }
+            ]
+            nemo_gym_env = self._env_handles.get("nemo_gym")
+            if nemo_gym_env is not None and gate_ids_to_fail:
+                try:
+                    await nemo_gym_env.fail_rollouts.remote(
+                        gate_ids_to_fail, reason="recovery_failed"
+                    )
+                except Exception as error:  # noqa: BLE001 — TTL is the backstop
+                    print(f"fail_rollouts({group_id}) failed: {error}", flush=True)
+            raise
+        else:
+            self._recovery_ledger.mark_group_finalized(group.group_id)
+            self._recovery_ledger.release_finalized_group(group.group_id)
+            print(
+                "rollout recovery finalized group: "
+                f"group={group.group_id} reused="
+                f"{group.expected_generations - len(generation_indices)} "
+                f"redispatched={len(generation_indices)}",
+                flush=True,
+            )
+            return True

--- a/nemo_rl/experience/rollout_recovery.py
+++ b/nemo_rl/experience/rollout_recovery.py
@@ -15,9 +15,8 @@
 """Controller-owned lineage for recoverable token-capture prompt groups.
 
 The ledger deliberately contains control-plane metadata only. Token tensors and
-router-replay payloads remain in TQ. Persistence is added by a later change; the
-versioned ``state_dict`` boundary lives here so that change does not have to
-invent a second lifecycle model.
+router-replay payloads remain in TQ. The versioned ``state_dict`` boundary is
+persisted beside the native TQ snapshot.
 """
 
 from __future__ import annotations
@@ -34,6 +33,7 @@ if TYPE_CHECKING:
     from nemo_rl.data.interfaces import DatumSpec
 
 ROLLOUT_RECOVERY_SCHEMA_VERSION = 2
+ROLLOUT_RECOVERY_STATE_FILENAME = "rollout_recovery.pt"
 
 
 class RolloutAttemptStatus(StrEnum):
@@ -166,6 +166,17 @@ class PromptGroupRecoveryRecord:
         ]
 
 
+@dataclass(frozen=True)
+class PromptGroupRecoverySummary:
+    """Small immutable view used for restore planning at large group counts."""
+
+    group_id: str
+    prompt_ref: PromptRef
+    target_step: Optional[int]
+    start_weight_version: int
+    status: PromptGroupStatus
+
+
 @dataclass
 class OpenTrainStepRecord:
     """Groups contributing to the current, not-yet-durable optimizer step."""
@@ -213,6 +224,92 @@ class RolloutRecoveryLedger:
 
     def groups(self) -> list[PromptGroupRecoveryRecord]:
         return [self._copy_group(group) for group in self._groups.values()]
+
+    def summaries(self) -> list[PromptGroupRecoverySummary]:
+        """Return restore-planning fields without copying receipts or metadata."""
+        return [
+            PromptGroupRecoverySummary(
+                group_id=record.group_id,
+                prompt_ref=record.prompt_ref,
+                target_step=record.target_step,
+                start_weight_version=record.start_weight_version,
+                status=record.status,
+            )
+            for record in self._groups.values()
+        ]
+
+    def bind_runtime_prompt(self, group_id: str, prompt_payload: DatumSpec) -> None:
+        """Attach a dataset-reconstructed prompt without serializing it.
+
+        Only unfinished generation needs the prompt body. Finalization and
+        training consume durable TQ rows referenced by the ledger instead.
+        """
+        record = self._require_group(group_id)
+        if record.status != PromptGroupStatus.GENERATING:
+            raise ValueError(
+                f"cannot bind a prompt to group {group_id!r} in "
+                f"state {record.status.value!r}"
+            )
+        sample_id = str(prompt_payload.get("idx"))
+        task_name = prompt_payload.get("task_name")
+        if sample_id != record.prompt_ref.sample_id:
+            raise ValueError(
+                "reconstructed prompt does not match its durable sample reference: "
+                f"sample={sample_id!r}, expected={record.prompt_ref.sample_id!r}"
+            )
+        if task_name != record.prompt_ref.task_name:
+            raise ValueError(
+                "reconstructed prompt task does not match its durable reference: "
+                f"task={task_name!r}, expected={record.prompt_ref.task_name!r}"
+            )
+        record.runtime_prompt_payload = prompt_payload
+
+    def prepare_for_restart(self) -> None:
+        """Convert crash-interrupted attempts into retryable ledger state.
+
+        A valid full-step checkpoint cannot contain an open optimizer step or
+        an in-progress/unknown finalizer publication. Those states need the
+        periodic-checkpoint protocol and are rejected rather than guessed at.
+        """
+        self.assert_full_step_checkpoint_safe()
+        for record in self._groups.values():
+            if record.status == PromptGroupStatus.GENERATING:
+                self.abandon_unsealed(record.group_id)
+
+    def assert_full_step_checkpoint_safe(self) -> None:
+        """Reject states that require the periodic mid-step protocol."""
+        if self._open_train_step is not None:
+            raise RuntimeError(
+                "rollout recovery contains an open optimizer step; restoring "
+                "mid-step snapshots is not supported by full-step recovery"
+            )
+        unsupported = [
+            record.group_id
+            for record in self._groups.values()
+            if record.status
+            in {
+                PromptGroupStatus.FINALIZING,
+                PromptGroupStatus.FINALIZATION_UNKNOWN,
+                PromptGroupStatus.CLAIMED_FOR_TRAINING,
+                PromptGroupStatus.APPLIED_UNCHECKPOINTED,
+            }
+        ]
+        if unsupported:
+            raise RuntimeError(
+                "rollout recovery contains checkpoint-unsafe group states: "
+                f"groups={unsupported!r}"
+            )
+
+    def expected_staging_keys(self) -> set[str]:
+        """Return every durable staging row still owned by the ledger."""
+        return {
+            staging_key
+            for record in self._groups.values()
+            for sibling in record.siblings
+            for attempt in sibling.attempts[-1:]
+            if attempt.status == RolloutAttemptStatus.SEALED
+            for staging_key in attempt.staging_keys
+        }
 
     def reserve_group(
         self,
@@ -855,11 +952,15 @@ class RolloutRecoveryLedger:
             sibling.current_attempt.status == RolloutAttemptStatus.SEALED
             for sibling in siblings
         )
+        if status == PromptGroupStatus.GENERATING and all_current_attempts_sealed:
+            raise ValueError("generating group must retain an unfinished sibling")
         if status in prefinalization_sealed_states and not all_current_attempts_sealed:
             raise ValueError(
                 f"group state {status.value!r} requires every sibling to be sealed"
             )
         if status in finalized_states:
+            if not all_current_attempts_sealed:
+                raise ValueError("finalized group state requires sealed siblings")
             if canonical_meta is None or min_weight is None or max_weight is None:
                 raise ValueError("finalized group state requires canonical metadata")
             if list(canonical_meta.sample_ids) != [

--- a/nemo_rl/experience/rollout_recovery.py
+++ b/nemo_rl/experience/rollout_recovery.py
@@ -28,6 +28,8 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Optional, Self
 
 from nemo_rl.data_plane import KVBatchMeta
+from nemo_rl.data_plane.schema import ROUTE_PLAN_TAG
+from nemo_rl.experience.route_plan import decode_route_plan
 
 if TYPE_CHECKING:
     from nemo_rl.data.interfaces import DatumSpec
@@ -301,15 +303,32 @@ class RolloutRecoveryLedger:
             )
 
     def expected_staging_keys(self) -> set[str]:
-        """Return every durable staging row still owned by the ledger."""
-        return {
-            staging_key
-            for record in self._groups.values()
-            for sibling in record.siblings
-            for attempt in sibling.attempts[-1:]
-            if attempt.status == RolloutAttemptStatus.SEALED
-            for staging_key in attempt.staging_keys
-        }
+        """Return every staging row required to restore the current ownership.
+
+        Before canonical publication, sealed receipts own their staged token
+        rows. Finalization transfers that ownership to canonical TQ rows and
+        normally clears staging. Deferred router replay is the exception: its
+        canonical metadata carries route plans naming the staged rows that the
+        policy still needs.
+        """
+        expected: set[str] = set()
+        for record in self._groups.values():
+            if record.canonical_meta is None:
+                expected.update(
+                    staging_key
+                    for sibling in record.siblings
+                    for attempt in sibling.attempts[-1:]
+                    if attempt.status == RolloutAttemptStatus.SEALED
+                    for staging_key in attempt.staging_keys
+                )
+                continue
+            for tag in record.canonical_meta.tags or []:
+                encoded_plan = tag.get(ROUTE_PLAN_TAG)
+                if encoded_plan is not None:
+                    expected.update(
+                        decode_route_plan(encoded_plan).cleanup_staging_keys
+                    )
+        return expected
 
     def reserve_group(
         self,

--- a/nemo_rl/experience/rollout_recovery.py
+++ b/nemo_rl/experience/rollout_recovery.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from nemo_rl.data.interfaces import DatumSpec
 
 ROLLOUT_RECOVERY_SCHEMA_VERSION = 2
+ROLLOUT_RECOVERY_STATE_FILENAME = "rollout_recovery.pt"
 
 
 class RolloutAttemptStatus(StrEnum):
@@ -158,9 +159,9 @@ def _receipt_staging_keys(receipt: dict[str, Any]) -> list[str]:
 class RolloutRecoveryLedger:
     """Controller-owned prompt-to-attempt lineage for token-capture rollouts.
 
-    This first implementation is deliberately in-memory. ``state_dict`` and
-    ``from_state_dict`` define the versioned boundary that a later checkpoint
-    change will persist alongside the native TQ snapshot.
+    ``state_dict`` and ``from_state_dict`` define the versioned sidecar stored
+    alongside the native TQ snapshot. The sidecar contains lineage and
+    receipts only; token payloads remain in TQ's staging partition.
     """
 
     def __init__(self) -> None:
@@ -210,7 +211,32 @@ class RolloutRecoveryLedger:
     def mark_group_dispatched(self, group_id: str) -> None:
         """Move every current attempt from reserved to dispatched."""
         record = self._require_group(group_id)
-        attempts = [sibling.current_attempt for sibling in record.siblings]
+        self.mark_siblings_dispatched(
+            group_id,
+            generation_indices=[
+                sibling.generation_index for sibling in record.siblings
+            ],
+        )
+
+    def mark_siblings_dispatched(
+        self, group_id: str, *, generation_indices: list[int]
+    ) -> None:
+        """Move selected current attempts from reserved to dispatched."""
+        record = self._require_group(group_id)
+        if not generation_indices or len(set(generation_indices)) != len(
+            generation_indices
+        ):
+            raise ValueError("generation_indices must be non-empty and unique")
+        if any(
+            index < 0 or index >= len(record.siblings) for index in generation_indices
+        ):
+            raise ValueError(
+                f"generation_indices are outside recovery group {group_id!r}"
+            )
+        attempts = [
+            record.siblings[generation_index].current_attempt
+            for generation_index in generation_indices
+        ]
         self._require_statuses(
             attempts,
             allowed={RolloutAttemptStatus.RESERVED},
@@ -325,6 +351,53 @@ class RolloutRecoveryLedger:
     def get_group(self, group_id: str) -> PromptGroupRecoveryRecord:
         """Return a defensive copy of one group."""
         return copy.deepcopy(self._require_group(group_id))
+
+    def groups(self) -> list[PromptGroupRecoveryRecord]:
+        """Return defensive copies of all groups in checkpoint order."""
+        return copy.deepcopy(list(self._groups.values()))
+
+    def discard_canonical_groups(self, group_ids: set[str]) -> int:
+        """Drop groups already represented by canonical replay metadata."""
+        discarded = 0
+        for group_id in group_ids:
+            if group_id in self._groups:
+                del self._groups[group_id]
+                discarded += 1
+        return discarded
+
+    def prepare_for_restart(self) -> None:
+        """Mark physical attempts that cannot survive a process restart abandoned."""
+        for record in self._groups.values():
+            for sibling in record.siblings:
+                attempt = sibling.current_attempt
+                if attempt.status in {
+                    RolloutAttemptStatus.RESERVED,
+                    RolloutAttemptStatus.DISPATCHED,
+                }:
+                    attempt.status = RolloutAttemptStatus.ABANDONED
+
+    def expected_staging_keys(self) -> set[str]:
+        """Return staging rows referenced by reusable sealed receipts."""
+        return {
+            staging_key
+            for record in self._groups.values()
+            for sibling in record.siblings
+            if sibling.current_attempt.status == RolloutAttemptStatus.SEALED
+            for staging_key in sibling.current_attempt.staging_keys
+        }
+
+    def retryable_generation_indices(self, group_id: str) -> list[int]:
+        """Return logical siblings that require a new physical attempt."""
+        record = self._require_group(group_id)
+        return [
+            sibling.generation_index
+            for sibling in record.siblings
+            if sibling.current_attempt.status
+            in {
+                RolloutAttemptStatus.ABANDONED,
+                RolloutAttemptStatus.FAILED,
+            }
+        ]
 
     def __len__(self) -> int:
         """Return the number of unfinished or retryable prompt groups."""

--- a/tests/unit/experience/test_rollout_manager.py
+++ b/tests/unit/experience/test_rollout_manager.py
@@ -46,7 +46,7 @@ from nemo_rl.experience.rollout_manager import (
     RolloutRetryPolicy,
     RolloutStats,
 )
-from nemo_rl.experience.rollout_recovery import RolloutRecoveryLedger
+from nemo_rl.experience.rollout_recovery import PromptRef, RolloutRecoveryLedger
 from nemo_rl.experience.rollouts import (
     run_async_multi_turn_rollout,
     run_async_nemo_gym_rollout,
@@ -1051,6 +1051,7 @@ def _make_capture_manager(buf, *, on_run=None, num_generations=2):
     mgr._stats = RolloutStats()
     mgr._skipped_prompts = 0
     mgr._recovery_ledger = RolloutRecoveryLedger()
+    mgr._data_plane_checkpoint_barrier = None
 
     class _CaptureImpl:
         def __init__(self):
@@ -1213,3 +1214,46 @@ class TestGenerateForFinalizationFlow:
         assert second_ids[0] == first_ids[0]
         assert second_ids[1] != first_ids[1]
         assert request.rollout_ids == (second_ids[0], second_ids[1])
+
+    def test_recovery_redispatches_only_sibling_missing_from_snapshot(self):
+        buf = _FakeCaptureBuffer()
+        mgr = _make_capture_manager(buf)
+        prompt = {"prompt": "p", "idx": 12, "task_name": "nemo_gym"}
+        group = mgr._recovery_ledger.reserve_group(
+            group_id="restored-group",
+            prompt_id="12",
+            prompt_ref=PromptRef(sample_id="12", task_name="nemo_gym"),
+            prompt_payload=prompt,
+            expected_generations=2,
+            target_step=6,
+            start_weight_version=7,
+        )
+        mgr._recovery_ledger.mark_group_dispatched(group.group_id)
+        first_rollout_id = group.gate_rollout_ids[0]
+        mgr._recovery_ledger.mark_sibling_sealed(
+            group.group_id,
+            generation_index=0,
+            gate_rollout_id=first_rollout_id,
+            receipt={
+                "rollout_id": first_rollout_id,
+                "manifest": [{"staging_key": f"{first_rollout_id}/call"}],
+            },
+            reward=0.5,
+        )
+        restored = RolloutRecoveryLedger.from_state_dict(
+            mgr._recovery_ledger.state_dict()
+        )
+        restored.prepare_for_restart()
+        restored.bind_runtime_prompt(group.group_id, prompt)
+        mgr._recovery_ledger = restored
+
+        request = _run(mgr.recover_for_finalization(group.group_id))
+
+        assert request is not None
+        assert mgr._impl.seen_rollout_ids is not None
+        assert buf.reserve_rollout_ids[-1] is not None
+        restored_ids = buf.reserve_rollout_ids[-1]
+        assert restored_ids is not None
+        assert restored_ids[0] == first_rollout_id
+        assert restored_ids[1] != group.gate_rollout_ids[1]
+        assert request.rollout_ids == tuple(restored_ids)

--- a/tests/unit/experience/test_rollout_manager.py
+++ b/tests/unit/experience/test_rollout_manager.py
@@ -33,6 +33,7 @@ from copy import deepcopy
 import pytest
 import torch
 
+from nemo_rl.algorithms.async_utils.replay_buffer import DataPlaneCheckpointBarrier
 from nemo_rl.data.collate_fn import rl_collate_fn
 from nemo_rl.data.datasets.response_datasets import NemoGymDataset
 from nemo_rl.data.interfaces import DatumSpec
@@ -77,13 +78,16 @@ class _StreamingGymEnv:
 
     def __init__(self, results):
         self._results = results
+        self.inputs = None
         self.run_rollouts = self
 
     def options(self, *, num_returns):
         assert num_returns == "streaming"
         return self
 
-    def remote(self, _inputs, _tokenizer, _timer_prefix):
+    def remote(self, inputs, _tokenizer, _timer_prefix):
+        self.inputs = inputs
+
         async def _stream():
             for result in self._results:
 
@@ -138,6 +142,59 @@ def test_nemo_gym_stream_callback_runs_before_group_completion() -> None:
         "rollout-0",
         "rollout-1",
     ]
+
+
+def test_nemo_gym_subset_maps_local_rows_to_logical_siblings() -> None:
+    def _result(rowidx: int, rollout_id: str) -> tuple[int, dict, None]:
+        return (
+            rowidx,
+            {
+                "receipt": {"rollout_id": rollout_id, "manifest": []},
+                "rollout_id": rollout_id,
+                "full_result": {"reward": float(rowidx)},
+                "message_log": [],
+                "input_message_log": [],
+            },
+            None,
+        )
+
+    env = _StreamingGymEnv([_result(1, "retry-4"), _result(0, "retry-1")])
+    impl = object.__new__(AsyncNemoGymRolloutImpl)
+    impl._task_to_env = {"nemo_gym": env}
+    impl._tokenizer = None
+    impl._num_generations_per_prompt = 5
+    impl._generation_config = {
+        "temperature": 1.0,
+        "top_p": 1.0,
+        "max_new_tokens": 32,
+    }
+    impl._compute_rollout_metrics = lambda _completions, _agent_name: {}
+    callback_order: list[int] = []
+
+    async def _record(generation_index: int, _completion: Completion) -> None:
+        callback_order.append(generation_index)
+
+    record = _run(
+        impl.run_rollout(
+            {
+                "idx": 9,
+                "message_log": [],
+                "extra_env_info": {
+                    "agent_ref": {"name": "agent"},
+                    "responses_create_params": {},
+                },
+                "task_name": "nemo_gym",
+            },
+            rollout_ids=["retry-1", "retry-4"],
+            generation_indices=[1, 4],
+            on_completion=_record,
+        )
+    )
+
+    assert callback_order == [4, 1]
+    assert [row["_rowidx"] for row in env.inputs] == [0, 1]
+    assert [row["_ng_rollout_id"] for row in env.inputs] == ["retry-1", "retry-4"]
+    assert len(record.completions) == 2
 
 
 class _FakeBuffer:
@@ -1088,33 +1145,44 @@ def _make_capture_manager(
     mgr._tq_buffer = buf
     mgr._finalizer = finalizer
     mgr._recovery_ledger = RolloutRecoveryLedger()
+    mgr._data_plane_checkpoint_barrier = DataPlaneCheckpointBarrier()
     mgr._env_handles = {"nemo_gym": _FakeGymEnvHandle()}
     mgr._weight_version = 7
 
-    class _CaptureImpl:
+    class _CaptureImpl(AsyncNemoGymRolloutImpl):
         def __init__(self):
             self.seen_rollout_ids = None
+            self.seen_generation_indices = None
             self.streamed_recovery_groups = []
 
-        async def run_rollout(self, _sample, *, rollout_ids=None, on_completion=None):
+        async def run_rollout(
+            self,
+            _sample,
+            *,
+            rollout_ids=None,
+            generation_indices=None,
+            on_completion=None,
+        ):
             self.seen_rollout_ids = rollout_ids
+            self.seen_generation_indices = generation_indices
             if on_run is not None:
                 await on_run(_sample)
+            logical_indices = generation_indices or list(range(len(rollout_ids)))
             receipts = [
                 {
                     "rollout_id": rollout_id,
-                    "manifest": [{"staging_key": f"stage-{generation_index}"}],
+                    "manifest": [{"staging_key": f"stage-{logical_index}"}],
                 }
-                for generation_index, rollout_id in enumerate(rollout_ids)
+                for logical_index, rollout_id in zip(logical_indices, rollout_ids)
             ]
             record = _receipt_record(rollout_ids, receipts)
-            for generation_index, completion in enumerate(record.completions):
+            for local_index, completion in enumerate(record.completions):
                 if on_completion is not None:
-                    await on_completion(generation_index, completion)
+                    await on_completion(logical_indices[local_index], completion)
                     self.streamed_recovery_groups.append(
                         mgr.recovery_ledger.get_group(buf._slots[0])
                     )
-                if fail_after_completions == generation_index + 1:
+                if fail_after_completions == local_index + 1:
                     raise RuntimeError("stream interrupted")
             return record
 
@@ -1132,6 +1200,157 @@ def _capture_sample():
 
 
 class TestGenerateAndFinalizeFlow:
+    def test_dispatch_uses_pre_reserved_dataloader_lineage(self):
+        buf = _FakeCaptureBuffer()
+        mgr = _make_capture_manager(buf, _FakeFinalizer())
+        group_id = mgr.reserve_prompt_group(_capture_sample(), target_step=5)
+
+        assert group_id is not None
+        _run(
+            mgr.generate_and_push(
+                _capture_sample(),
+                target_step=5,
+                recovery_group_id=group_id,
+            )
+        )
+
+        assert buf._slots == [group_id]
+        assert len(mgr.recovery_ledger) == 0
+
+    def test_recover_sealed_group_replays_finalizer_without_generation(self):
+        buf = _FakeCaptureBuffer()
+        finalizer = _FakeFinalizer()
+        mgr = _make_capture_manager(buf, finalizer)
+        group = mgr.recovery_ledger.reserve_group(
+            group_id="recovery-g0",
+            prompt_id="42",
+            prompt_payload=_capture_sample(),
+            expected_generations=2,
+            target_step=None,
+            start_weight_version=7,
+        )
+        mgr.recovery_ledger.mark_group_dispatched(group.group_id)
+        for sibling in group.siblings:
+            rollout_id = sibling.current_attempt.gate_rollout_id
+            mgr.recovery_ledger.mark_sibling_sealed(
+                group.group_id,
+                generation_index=sibling.generation_index,
+                gate_rollout_id=rollout_id,
+                receipt={
+                    "rollout_id": rollout_id,
+                    "manifest": [{"staging_key": f"stage-{sibling.generation_index}"}],
+                },
+                reward=0.5,
+            )
+
+        committed = _run(mgr.recover_group(group.group_id))
+
+        assert committed is True
+        assert mgr._impl.seen_rollout_ids is None
+        assert len(finalizer.calls) == 1
+        assert buf.commit_finalized_calls == [
+            (
+                group.group_id,
+                "meta-sentinel",
+                "fields-sentinel",
+                3,
+                4,
+                ["stage-0"],
+            )
+        ]
+        assert len(mgr.recovery_ledger) == 0
+
+    def test_recover_partial_group_redispatches_only_missing_siblings(self):
+        buf = _FakeCaptureBuffer()
+        finalizer = _FakeFinalizer()
+        mgr = _make_capture_manager(buf, finalizer, num_generations=3)
+        group = mgr.recovery_ledger.reserve_group(
+            group_id="recovery-g0",
+            prompt_id="42",
+            prompt_payload=_capture_sample(),
+            expected_generations=3,
+            target_step=None,
+            start_weight_version=7,
+        )
+        mgr.recovery_ledger.mark_group_dispatched(group.group_id)
+        for generation_index in (0, 2):
+            attempt = group.siblings[generation_index].current_attempt
+            mgr.recovery_ledger.mark_sibling_sealed(
+                group.group_id,
+                generation_index=generation_index,
+                gate_rollout_id=attempt.gate_rollout_id,
+                receipt={
+                    "rollout_id": attempt.gate_rollout_id,
+                    "manifest": [{"staging_key": f"stage-{generation_index}"}],
+                },
+                reward=float(generation_index),
+            )
+        mgr.recovery_ledger.prepare_for_restart()
+        old_missing_attempt = group.siblings[1].current_attempt
+
+        committed = _run(mgr.recover_group(group.group_id))
+
+        assert committed is True
+        assert mgr._impl.seen_generation_indices == [1]
+        assert len(mgr._impl.seen_rollout_ids) == 1
+        assert mgr._impl.seen_rollout_ids[0] != old_missing_attempt.gate_rollout_id
+        (_, finalizer_ids, receipts, rewards, _, canonical_ids) = finalizer.calls[0]
+        assert canonical_ids == [
+            "recovery-g0_g0",
+            "recovery-g0_g1",
+            "recovery-g0_g2",
+        ]
+        assert finalizer_ids[0] == group.siblings[0].current_attempt.gate_rollout_id
+        assert finalizer_ids[2] == group.siblings[2].current_attempt.gate_rollout_id
+        assert finalizer_ids[1] == mgr._impl.seen_rollout_ids[0]
+        assert [receipt["rollout_id"] for receipt in receipts] == finalizer_ids
+        assert rewards == [0.0, 0.5, 2.0]
+        assert len(mgr.recovery_ledger) == 0
+
+    def test_recovery_failure_preserves_old_and_newly_sealed_siblings(self):
+        buf = _FakeCaptureBuffer()
+        mgr = _make_capture_manager(
+            buf,
+            _FakeFinalizer(),
+            num_generations=3,
+            fail_after_completions=1,
+        )
+        group = mgr.recovery_ledger.reserve_group(
+            group_id="recovery-g0",
+            prompt_id="42",
+            prompt_payload=_capture_sample(),
+            expected_generations=3,
+            target_step=None,
+            start_weight_version=7,
+        )
+        mgr.recovery_ledger.mark_group_dispatched(group.group_id)
+        attempt = group.siblings[0].current_attempt
+        mgr.recovery_ledger.mark_sibling_sealed(
+            group.group_id,
+            generation_index=0,
+            gate_rollout_id=attempt.gate_rollout_id,
+            receipt={
+                "rollout_id": attempt.gate_rollout_id,
+                "manifest": [{"staging_key": "stage-0"}],
+            },
+            reward=0.0,
+        )
+        mgr.recovery_ledger.prepare_for_restart()
+
+        with pytest.raises(RuntimeError, match="stream interrupted"):
+            _run(mgr.recover_group(group.group_id))
+
+        recovered = mgr.recovery_ledger.get_group(group.group_id)
+        assert [sibling.current_attempt.status for sibling in recovered.siblings] == [
+            RolloutAttemptStatus.SEALED,
+            RolloutAttemptStatus.SEALED,
+            RolloutAttemptStatus.ABANDONED,
+        ]
+        assert mgr._impl.seen_generation_indices == [1, 2]
+        (failed_ids, reason) = mgr._env_handles["nemo_gym"].failed[-1]
+        assert failed_ids == [recovered.siblings[2].current_attempt.gate_rollout_id]
+        assert reason == "recovery_failed"
+
     def test_mints_ids_finalizes_and_commits(self):
         buf = _FakeCaptureBuffer()
         finalizer = _FakeFinalizer()

--- a/tests/unit/experience/test_rollout_recovery.py
+++ b/tests/unit/experience/test_rollout_recovery.py
@@ -274,6 +274,83 @@ def test_state_dict_rejects_missing_status_with_context(missing_status: str) -> 
         RolloutRecoveryLedger.from_state_dict(state)
 
 
+def test_restored_partial_group_rebinds_runtime_prompt_by_reference() -> None:
+    ledger = RolloutRecoveryLedger()
+    group = _reserve(ledger, group_id="partial")
+    ledger.mark_group_dispatched(group.group_id)
+    _seal(ledger, group.group_id, 0)
+
+    restored = RolloutRecoveryLedger.from_state_dict(ledger.state_dict())
+    assert restored.get_group(group.group_id).runtime_prompt_payload is None
+
+    prompt = _prompt()
+    restored.bind_runtime_prompt(group.group_id, prompt)  # type: ignore[arg-type]
+
+    rebound = restored.get_group(group.group_id)
+    assert rebound.runtime_prompt_payload is prompt
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        {**_prompt(), "idx": 18},
+        {**_prompt(), "task_name": "different-task"},
+    ],
+)
+def test_runtime_prompt_reference_mismatch_is_rejected(prompt: dict) -> None:
+    ledger = RolloutRecoveryLedger()
+    group = _reserve(ledger)
+
+    with pytest.raises(ValueError, match="durable|task"):
+        ledger.bind_runtime_prompt(group.group_id, prompt)  # type: ignore[arg-type]
+
+
+def test_prepare_for_restart_preserves_sealed_and_abandons_inflight() -> None:
+    ledger = RolloutRecoveryLedger()
+    group = _reserve(ledger)
+    ledger.mark_group_dispatched(group.group_id)
+    _seal(ledger, group.group_id, 0)
+
+    ledger.prepare_for_restart()
+
+    restored = ledger.get_group(group.group_id)
+    assert restored.status == PromptGroupStatus.GENERATING
+    assert restored.siblings[0].current_attempt.status == RolloutAttemptStatus.SEALED
+    assert restored.siblings[1].current_attempt.status == RolloutAttemptStatus.ABANDONED
+    assert ledger.expected_staging_keys() == {f"{restored.gate_rollout_ids[0]}/call"}
+
+
+def test_full_step_checkpoint_rejects_open_train_step() -> None:
+    ledger = RolloutRecoveryLedger()
+    group = _reserve(ledger)
+    ledger.mark_group_dispatched(group.group_id)
+    _seal(ledger, group.group_id, 0)
+    _seal(ledger, group.group_id, 1)
+    _finalize(ledger, group.group_id)
+    ledger.claim_groups_for_training(
+        [group.group_id],
+        train_step=3,
+        trainer_version=3,
+        expected_group_count=1,
+    )
+
+    with pytest.raises(RuntimeError, match="open optimizer step"):
+        ledger.assert_full_step_checkpoint_safe()
+
+
+def test_full_step_checkpoint_rejects_unknown_finalizer_outcome() -> None:
+    ledger = RolloutRecoveryLedger()
+    group = _reserve(ledger)
+    ledger.mark_group_dispatched(group.group_id)
+    _seal(ledger, group.group_id, 0)
+    _seal(ledger, group.group_id, 1)
+    ledger.mark_finalization_started(group.group_id)
+    ledger.mark_finalization_unknown(group.group_id)
+
+    with pytest.raises(RuntimeError, match="checkpoint-unsafe"):
+        ledger.assert_full_step_checkpoint_safe()
+
+
 def test_finalizer_unknown_outcome_is_terminal() -> None:
     ledger = RolloutRecoveryLedger()
     group = _reserve(ledger)

--- a/tests/unit/experience/test_rollout_recovery.py
+++ b/tests/unit/experience/test_rollout_recovery.py
@@ -19,6 +19,12 @@ from copy import deepcopy
 import pytest
 
 from nemo_rl.data_plane import KVBatchMeta
+from nemo_rl.data_plane.schema import ROUTE_PLAN_TAG
+from nemo_rl.experience.route_plan import (
+    ROUTE_PLAN_SCHEMA_VERSION,
+    RouteAssemblyPlan,
+    encode_route_plan,
+)
 from nemo_rl.experience.rollout_recovery import (
     PromptRef,
     PromptGroupStatus,
@@ -318,6 +324,58 @@ def test_prepare_for_restart_preserves_sealed_and_abandons_inflight() -> None:
     assert restored.siblings[0].current_attempt.status == RolloutAttemptStatus.SEALED
     assert restored.siblings[1].current_attempt.status == RolloutAttemptStatus.ABANDONED
     assert ledger.expected_staging_keys() == {f"{restored.gate_rollout_ids[0]}/call"}
+
+
+def test_finalized_group_does_not_require_cleared_staging_rows() -> None:
+    ledger = RolloutRecoveryLedger()
+    group = _reserve(ledger)
+    ledger.mark_group_dispatched(group.group_id)
+    _seal(ledger, group.group_id, 0)
+    _seal(ledger, group.group_id, 1)
+
+    _finalize(ledger, group.group_id)
+
+    assert ledger.expected_staging_keys() == set()
+
+
+def test_finalized_group_retains_deferred_router_staging_ownership() -> None:
+    ledger = RolloutRecoveryLedger()
+    group = _reserve(ledger)
+    ledger.mark_group_dispatched(group.group_id)
+    _seal(ledger, group.group_id, 0)
+    _seal(ledger, group.group_id, 1)
+    staging_keys = [f"{gate_id}/call" for gate_id in group.gate_rollout_ids]
+    meta = KVBatchMeta(
+        partition_id="rollout",
+        task_name="train",
+        sample_ids=group.logical_rollout_ids,
+        fields=["input_ids"],
+        sequence_lengths=[4, 5],
+        tags=[
+            {
+                "weight_version": 7,
+                ROUTE_PLAN_TAG: encode_route_plan(
+                    RouteAssemblyPlan(
+                        schema_version=ROUTE_PLAN_SCHEMA_VERSION,
+                        staging_partition="rollout_staging",
+                        spans=(),
+                        cleanup_staging_keys=(staging_key,),
+                        expected_token_length=sequence_length,
+                    )
+                ),
+            }
+            for staging_key, sequence_length in zip(staging_keys, [4, 5])
+        ],
+    )
+    ledger.mark_finalization_started(group.group_id)
+    ledger.mark_group_finalized(
+        group.group_id,
+        meta=meta,
+        group_min_weight_version=7,
+        group_max_weight_version=8,
+    )
+
+    assert ledger.expected_staging_keys() == set(staging_keys)
 
 
 def test_full_step_checkpoint_rejects_open_train_step() -> None:

--- a/tests/unit/experience/test_rollout_recovery.py
+++ b/tests/unit/experience/test_rollout_recovery.py
@@ -92,6 +92,34 @@ def test_retry_preserves_logical_id_and_changes_attempt_identity() -> None:
     assert retry.status == RolloutAttemptStatus.RESERVED
 
 
+def test_partial_retry_dispatches_only_missing_sibling() -> None:
+    ledger = RolloutRecoveryLedger()
+    group = _reserve(ledger)
+    ledger.mark_group_dispatched(group.group_id)
+    for generation_index in (0, 2):
+        attempt = group.siblings[generation_index].current_attempt
+        ledger.mark_sibling_sealed(
+            group.group_id,
+            generation_index=generation_index,
+            gate_rollout_id=attempt.gate_rollout_id,
+            receipt=_receipt(attempt.gate_rollout_id, generation_index),
+            reward=float(generation_index),
+        )
+    ledger.prepare_for_restart()
+
+    assert ledger.retryable_generation_indices(group.group_id) == [1]
+    retry = ledger.retry_sibling(group.group_id, generation_index=1)
+    ledger.mark_siblings_dispatched(group.group_id, generation_indices=[1])
+
+    restored = ledger.get_group(group.group_id)
+    assert restored.siblings[0].current_attempt.status == RolloutAttemptStatus.SEALED
+    assert (
+        restored.siblings[1].current_attempt.status == RolloutAttemptStatus.DISPATCHED
+    )
+    assert restored.siblings[1].current_attempt.gate_rollout_id == retry.gate_rollout_id
+    assert restored.siblings[2].current_attempt.status == RolloutAttemptStatus.SEALED
+
+
 def test_prompt_payload_is_snapshotted_defensively() -> None:
     prompt = _prompt()
     ledger = RolloutRecoveryLedger()
@@ -139,6 +167,39 @@ def test_state_dict_round_trip_preserves_lineage() -> None:
         sibling.current_attempt.status == RolloutAttemptStatus.DISPATCHED
         for sibling in restored_group.siblings[1:]
     )
+
+
+def test_prepare_for_restart_preserves_only_reusable_sealed_attempts() -> None:
+    ledger = RolloutRecoveryLedger()
+    group = _reserve(ledger)
+    ledger.mark_group_dispatched(group.group_id)
+    gate_rollout_id = group.siblings[1].current_attempt.gate_rollout_id
+    ledger.mark_sibling_sealed(
+        group.group_id,
+        generation_index=1,
+        gate_rollout_id=gate_rollout_id,
+        receipt=_receipt(gate_rollout_id, 1),
+        reward=1.0,
+    )
+
+    ledger.prepare_for_restart()
+
+    restored_group = ledger.get_group(group.group_id)
+    assert [sibling.current_attempt.status for sibling in restored_group.siblings] == [
+        RolloutAttemptStatus.ABANDONED,
+        RolloutAttemptStatus.SEALED,
+        RolloutAttemptStatus.ABANDONED,
+    ]
+    assert ledger.expected_staging_keys() == {"stage-1"}
+
+
+def test_discard_canonical_groups_reconciles_checkpoint_overlap() -> None:
+    ledger = RolloutRecoveryLedger()
+    _reserve(ledger, group_id="canonical")
+    _reserve(ledger, group_id="unfinished")
+
+    assert ledger.discard_canonical_groups({"canonical", "missing"}) == 1
+    assert [group.group_id for group in ledger.groups()] == ["unfinished"]
 
 
 def test_invalid_state_transition_fails_without_partial_mutation() -> None:

--- a/tests/unit/single_controller/test_rollout_pump.py
+++ b/tests/unit/single_controller/test_rollout_pump.py
@@ -41,7 +41,11 @@ from nemo_rl.algorithms.single_controller_utils.config import (
 )
 from nemo_rl.algorithms.single_controller_utils.setup import SingleControllerActorArgs
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
-from nemo_rl.experience.rollout_manager import RolloutManager, RolloutOutcome
+from nemo_rl.experience.rollout_manager import (
+    RolloutManager,
+    RolloutOutcome,
+    RolloutStats,
+)
 
 # Reuse fixtures from the experience tests; same shape as test_async_rollout_manager.
 from tests.unit.experience.test_rollout_manager import (
@@ -127,6 +131,7 @@ def test_rollout_pump_stamps_target_steps(
     ctrl._rollout_permitted.set()
     ctrl._rollout_exhausted = asyncio.Event()
     ctrl._buffer_capacity = asyncio.Semaphore(2)
+    ctrl._rollout_slots = asyncio.Semaphore(2)
     ctrl._inflight_rollouts = 0
     ctrl._inflight_by_group_id = {}
     ctrl._dispatched_rollouts = set()
@@ -180,6 +185,7 @@ def test_rollout_pump_releases_capacity_only_for_uncommitted_prompts(
     ctrl._rollout_permitted.set()
     ctrl._rollout_exhausted = asyncio.Event()
     ctrl._buffer_capacity = asyncio.Semaphore(2)
+    ctrl._rollout_slots = asyncio.Semaphore(2)
     ctrl._inflight_rollouts = 0
     ctrl._dispatched_rollouts = set()
     ctrl._trainer_version = 0
@@ -192,6 +198,51 @@ def test_rollout_pump_releases_capacity_only_for_uncommitted_prompts(
     expected = 2 if expect_permit_released else 1
     assert ctrl._buffer_capacity._value == expected
     assert ctrl._inflight_rollouts == 0
+
+
+def test_actor_path_releases_capacity_when_capture_generation_is_skipped() -> None:
+    class _SkippedCaptureManager:
+        def __init__(self) -> None:
+            self.stats = RolloutStats(skipped=1)
+
+        async def generate_for_finalization(
+            self,
+            prompt: Any,
+            *,
+            target_step: int | None = None,
+            inflight_registry: dict[str, Any] | None = None,
+        ) -> None:
+            del prompt, target_step, inflight_registry
+            return None
+
+    controller_cls = SingleControllerActor.__ray_metadata__.modified_class
+    ctrl = object.__new__(controller_cls)
+    ctrl._async_cfg = SimpleNamespace(max_inflight_prompts=1, diagnostics=False)
+    ctrl._master_config = SimpleNamespace(
+        grpo=GRPOConfig.model_construct(max_num_epochs=1)
+    )
+    ctrl._rollout_manager = _SkippedCaptureManager()
+    ctrl._finalizer_actors = [object()]
+    ctrl._sampler = WindowedSampler(None, max_staleness_versions=1)
+    ctrl._dataloader = [
+        BatchedDataDict({"message_log": [[{"role": "user", "content": "prompt"}]]})
+    ]
+    ctrl._rollout_permitted = asyncio.Event()
+    ctrl._rollout_permitted.set()
+    ctrl._rollout_exhausted = asyncio.Event()
+    ctrl._buffer_capacity = asyncio.Semaphore(1)
+    ctrl._rollout_slots = asyncio.Semaphore(1)
+    ctrl._inflight_rollouts = 0
+    ctrl._inflight_by_group_id = {}
+    ctrl._dispatched_rollouts = set()
+    ctrl._trainer_version = 0
+    ctrl._current_epoch = 0
+
+    asyncio.run(ctrl._rollout_pump())
+
+    assert ctrl._buffer_capacity._value == 1
+    assert ctrl._inflight_rollouts == 0
+    assert ctrl._rollout_exhausted.is_set()
 
 
 @pytest.mark.parametrize(
@@ -239,6 +290,7 @@ def test_rollout_pump_tops_up_restored_target_step(
     ctrl._rollout_permitted.set()
     ctrl._rollout_exhausted = asyncio.Event()
     ctrl._buffer_capacity = asyncio.Semaphore(4)
+    ctrl._rollout_slots = asyncio.Semaphore(2)
     ctrl._inflight_rollouts = 0
     ctrl._inflight_by_group_id = {}
     ctrl._dispatched_rollouts = set()
@@ -365,6 +417,7 @@ def test_rollout_pump_failure_cancels_sibling_and_releases_capacity() -> None:
         ctrl._rollout_permitted.set()
         ctrl._rollout_exhausted = asyncio.Event()
         ctrl._buffer_capacity = asyncio.Semaphore(2)
+        ctrl._rollout_slots = asyncio.Semaphore(2)
         ctrl._inflight_rollouts = 0
         ctrl._inflight_by_group_id = {}
         ctrl._dispatched_rollouts = set()
@@ -414,14 +467,6 @@ def test_rollout_pump_releases_permits_when_child_never_starts(monkeypatch) -> N
             return task
 
     real_semaphore = asyncio.Semaphore
-    created_semaphores: list[asyncio.Semaphore] = []
-
-    def _recording_semaphore(value: int) -> asyncio.Semaphore:
-        semaphore = real_semaphore(value)
-        created_semaphores.append(semaphore)
-        return semaphore
-
-    monkeypatch.setattr(asyncio, "Semaphore", _recording_semaphore)
     monkeypatch.setattr(asyncio, "TaskGroup", _CancelBeforeStartTaskGroup)
 
     async def _main() -> None:
@@ -445,6 +490,7 @@ def test_rollout_pump_releases_permits_when_child_never_starts(monkeypatch) -> N
         ctrl._rollout_permitted.set()
         ctrl._rollout_exhausted = asyncio.Event()
         ctrl._buffer_capacity = real_semaphore(1)
+        ctrl._rollout_slots = real_semaphore(1)
         ctrl._inflight_rollouts = 0
         ctrl._inflight_by_group_id = {}
         ctrl._dispatched_rollouts = set()
@@ -455,7 +501,7 @@ def test_rollout_pump_releases_permits_when_child_never_starts(monkeypatch) -> N
         await asyncio.sleep(0)
 
         assert ctrl._buffer_capacity._value == 1
-        assert created_semaphores[0]._value == 1
+        assert ctrl._rollout_slots._value == 1
         assert ctrl._inflight_rollouts == 0
         assert ctrl._dispatched_rollouts == set()
         assert ctrl._rollout_exhausted.is_set()
@@ -517,6 +563,7 @@ def test_actor_path_releases_generation_permit_before_finalization() -> None:
         ctrl._rollout_permitted.set()
         ctrl._rollout_exhausted = asyncio.Event()
         ctrl._buffer_capacity = asyncio.Semaphore(2)
+        ctrl._rollout_slots = asyncio.Semaphore(1)
         ctrl._inflight_rollouts = 0
         ctrl._inflight_by_group_id = {}
         ctrl._dispatched_rollouts = set()

--- a/tests/unit/single_controller/test_rollout_pump.py
+++ b/tests/unit/single_controller/test_rollout_pump.py
@@ -24,7 +24,10 @@ import pytest
 import ray
 import torch
 
-from nemo_rl.algorithms.async_utils.replay_buffer import TQReplayBuffer
+from nemo_rl.algorithms.async_utils.replay_buffer import (
+    DataPlaneCheckpointBarrier,
+    TQReplayBuffer,
+)
 from nemo_rl.algorithms.async_utils.staleness_sampler import (
     InOrderSampler,
     WeightFifoSampler,
@@ -260,6 +263,68 @@ def test_rollout_pump_releases_permits_when_child_never_starts(monkeypatch) -> N
         assert ctrl._rollout_exhausted.is_set()
 
     asyncio.run(_main())
+
+
+def test_token_capture_reserves_entire_batch_before_dispatch() -> None:
+    events: list[str] = []
+
+    class _RecordingRolloutManager:
+        def reserve_prompt_group(
+            self, prompt: Any, *, target_step: int | None = None
+        ) -> str:
+            del target_step
+            prompt_id = prompt["idx"]
+            events.append(f"reserve-{prompt_id}")
+            return f"group-{prompt_id}"
+
+        async def generate_and_push(
+            self,
+            prompt: Any,
+            *,
+            target_step: int | None = None,
+            recovery_group_id: str | None = None,
+        ) -> None:
+            del target_step
+            events.append(f"dispatch-{prompt['idx']}-{recovery_group_id}")
+
+    controller_cls = SingleControllerActor.__ray_metadata__.modified_class
+    ctrl = object.__new__(controller_cls)
+    ctrl._async_cfg = SimpleNamespace(max_inflight_prompts=2, diagnostics=False)
+    ctrl._master_config = SimpleNamespace(
+        grpo={"max_num_epochs": 1},
+        token_capture=SimpleNamespace(enabled=True),
+    )
+    ctrl._rollout_manager = _RecordingRolloutManager()
+    ctrl._sampler = WindowedSampler(None, max_staleness_versions=1)
+    ctrl._dataloader = [
+        BatchedDataDict(
+            {
+                "idx": [10, 11],
+                "message_log": [
+                    [{"role": "user", "content": "a"}],
+                    [{"role": "user", "content": "b"}],
+                ],
+            }
+        )
+    ]
+    ctrl._data_plane_checkpoint_barrier = DataPlaneCheckpointBarrier()
+    ctrl._rollout_permitted = asyncio.Event()
+    ctrl._rollout_permitted.set()
+    ctrl._rollout_exhausted = asyncio.Event()
+    ctrl._buffer_capacity = asyncio.Semaphore(2)
+    ctrl._inflight_rollouts = 0
+    ctrl._dispatched_rollouts = set()
+    ctrl._trainer_version = 0
+    ctrl._current_epoch = 0
+
+    asyncio.run(ctrl._rollout_pump())
+
+    assert events == [
+        "reserve-10",
+        "reserve-11",
+        "dispatch-10-group-10",
+        "dispatch-11-group-11",
+    ]
 
 
 @pytest.mark.vllm

--- a/tests/unit/single_controller/test_sampler_interface.py
+++ b/tests/unit/single_controller/test_sampler_interface.py
@@ -159,7 +159,7 @@ class TestFactory:
         [
             (WindowedSamplerConfig(), True),
             (WeightFifoSamplerConfig(), False),
-            (InOrderSamplerConfig(), False),
+            (InOrderSamplerConfig(), True),
             (
                 CustomSamplerConfig(target=f"{__name__}:EchoSampler"),
                 False,
@@ -389,6 +389,38 @@ class TestDispatchCursorRestore:
         )
         s.set_dispatch_index(6)
         assert _run(s.admit(trainer_version_fn=lambda: 6)) == 6
+
+    def test_in_order_restores_after_highest_complete_target(self):
+        s = InOrderSampler(FakeBuffer(), max_lookahead_versions=2)
+
+        s.restore_dispatch_state(
+            current_train_weight=4,
+            restored_target_steps=[4, 4, 5, 5],
+            groups_per_step=2,
+        )
+
+        assert _run(s.admit(trainer_version_fn=lambda: 4)) == 6
+
+    @pytest.mark.parametrize(
+        ("targets", "error_fragment"),
+        [
+            ([3, 3], "older than the trainer"),
+            ([4, 4, 6, 6], "not contiguous"),
+            ([4], "exactly grpo.num_prompts_per_step"),
+            ([4, 4, 7, 7], "configured lookahead"),
+        ],
+    )
+    def test_in_order_rejects_inconsistent_restored_targets(
+        self, targets, error_fragment
+    ):
+        s = InOrderSampler(FakeBuffer(), max_lookahead_versions=2)
+
+        with pytest.raises(ValueError, match=error_fragment):
+            s.restore_dispatch_state(
+                current_train_weight=4,
+                restored_target_steps=targets,
+                groups_per_step=2,
+            )
 
 
 class TestInflightAbortPolicy:

--- a/tests/unit/single_controller/test_sc_checkpointing.py
+++ b/tests/unit/single_controller/test_sc_checkpointing.py
@@ -35,6 +35,7 @@ Covers:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import os
 import threading
@@ -55,7 +56,7 @@ from nemo_rl.algorithms.async_utils.replay_buffer import (
     DataPlaneCheckpointBarrier,
 )
 from nemo_rl.algorithms.async_utils.staleness_sampler import (
-    InOrderSamplerConfig,
+    WeightFifoSamplerConfig,
     WindowedSamplerConfig,
 )
 from nemo_rl.algorithms.grpo import (
@@ -75,6 +76,12 @@ from nemo_rl.algorithms.single_controller_utils import (
 from nemo_rl.algorithms.single_controller_utils.setup import SingleControllerActorArgs
 from nemo_rl.data.utils import load_dataloader_state
 from nemo_rl.data_plane import DATA_PLANE_CHECKPOINT_SCHEMA_VERSION, KVBatchMeta
+from nemo_rl.experience.rollout_recovery import (
+    ROLLOUT_RECOVERY_SCHEMA_VERSION,
+    ROLLOUT_RECOVERY_STATE_FILENAME,
+    PromptRef,
+    RolloutRecoveryLedger,
+)
 from nemo_rl.utils.checkpoint import CheckpointManager
 
 # Reuse the factory patches from the setup tests (same cross-module fixture
@@ -329,13 +336,31 @@ class _FakeWeightSynchronizer:
 
 
 class _FakeRolloutManager:
-    def __init__(self) -> None:
+    def __init__(self, recovery_ledger: Optional[RolloutRecoveryLedger] = None) -> None:
         self.weight_versions: list[int] = []
         self._tq_buffer = None
-        self.recovery_ledger = None
+        self.recovery_ledger = recovery_ledger
+        self.checkpoint_barrier: Optional[DataPlaneCheckpointBarrier] = None
+        self.recovery_calls: list[str] = []
+        self.discard_calls: list[str] = []
 
     def set_weight_version(self, version: int) -> None:
         self.weight_versions.append(version)
+
+    def set_data_plane_checkpoint_barrier(
+        self, barrier: DataPlaneCheckpointBarrier
+    ) -> None:
+        self.checkpoint_barrier = barrier
+
+    async def recover_for_finalization(self, group_id: str, **_: Any) -> None:
+        self.recovery_calls.append(group_id)
+        assert self.recovery_ledger is not None
+        self.recovery_ledger.discard_group(group_id)
+
+    async def discard_recovery_group(self, group_id: str) -> None:
+        self.discard_calls.append(group_id)
+        assert self.recovery_ledger is not None
+        self.recovery_ledger.discard_group(group_id)
 
 
 class _FakeTQBuffer:
@@ -357,13 +382,19 @@ class _FakeTQBuffer:
             "groups": [],
         }
         self.load_return = load_return
+        self._group_ids: tuple[str, ...] = ()
+        self._target_step_list: list[Optional[int]] = []
         self.metadata_state_dict_calls: list[int] = []
         self.load_calls: list[dict[str, Any]] = []
         self.checkpoint_barrier: Optional[DataPlaneCheckpointBarrier] = None
 
     @property
     def group_ids(self) -> tuple[str, ...]:
-        return ()
+        return self._group_ids
+
+    @property
+    def target_step_list(self) -> tuple[Optional[int], ...]:
+        return tuple(self._target_step_list)
 
     def set_data_plane_checkpoint_barrier(
         self, barrier: DataPlaneCheckpointBarrier
@@ -392,6 +423,10 @@ class _FakeTQBuffer:
                 "expected_manifest_digest": expected_manifest_digest,
             }
         )
+        groups = state.get("groups", [])
+        self._group_ids = tuple(group["group_id"] for group in groups)
+        self._target_step_list = [group.get("target_step") for group in groups]
+        self._num_groups = self.load_return
         return self.load_return
 
     def __len__(self) -> int:
@@ -444,7 +479,7 @@ def _actor_master_config(
     sampler_cfg = (
         WindowedSamplerConfig(max_staleness_versions=1)
         if buffer_checkpoint
-        else InOrderSamplerConfig(max_lookahead_versions=1)
+        else WeightFifoSamplerConfig(max_staleness_versions=1)
     )
     return MasterConfig.model_construct(
         policy={
@@ -505,6 +540,7 @@ def _make_actor_args(
     dp_client: Optional[_FakeDPClient] = None,
     last_checkpoint_path: Optional[str] = None,
     data_plane_checkpoint_metadata: Optional[dict[str, Any]] = None,
+    rollout_manager: Optional[_FakeRolloutManager] = None,
 ) -> SingleControllerActorArgs:
     return SingleControllerActorArgs(
         gen_handle=object(),
@@ -517,7 +553,9 @@ def _make_actor_args(
         weight_synchronizer=_FakeWeightSynchronizer(),  # type: ignore[arg-type]
         advantage_estimator=None,
         loss_fn=object(),  # type: ignore[arg-type]
-        rollout_manager=_FakeRolloutManager(),  # type: ignore[arg-type]
+        rollout_manager=(
+            rollout_manager if rollout_manager is not None else _FakeRolloutManager()
+        ),  # type: ignore[arg-type]
         tq_buffer=tq_buffer if tq_buffer is not None else _FakeTQBuffer(),  # type: ignore[arg-type]
         partition_id=_PARTITION_ID,
         finalizer_actors=[],
@@ -856,6 +894,66 @@ class TestSaveTrigger:
 
 
 class TestDataPlaneCheckpoint:
+    def test_saves_digest_bound_rollout_lineage_without_prompt_payload(self, tmp_path):
+        mc = _actor_master_config(
+            tmp_path,
+            max_num_steps=1,
+            save_period=1,
+            buffer_checkpoint=True,
+            data_plane_checkpoint=True,
+        )
+        mc.token_capture.enabled = True
+        ledger = RolloutRecoveryLedger()
+        ledger.reserve_group(
+            group_id="partial-group",
+            prompt_id="17",
+            prompt_ref=PromptRef(sample_id="17", task_name="nemo_gym"),
+            prompt_payload={
+                "idx": 17,
+                "task_name": "nemo_gym",
+                "message_log": [{"role": "user", "content": "solve"}],
+            },
+            expected_generations=2,
+            target_step=None,
+            start_weight_version=0,
+        )
+        manager = _FakeRolloutManager(ledger)
+        dp_client = _FakeDPClient()
+
+        async def _main() -> None:
+            actor = _ACTOR_CLS(
+                mc,
+                _make_actor_args(
+                    dp_client=dp_client,
+                    rollout_manager=manager,
+                ),
+                SetupTimingMetrics(),
+            )
+            actor._train_steps = 1
+            actor._trainer_version = 1
+            await actor._save_checkpoint({})
+            actor._checkpointer.shutdown()
+
+        asyncio.run(_main())
+
+        step_dir = tmp_path / "checkpoints" / "step_1"
+        payload = (step_dir / ROLLOUT_RECOVERY_STATE_FILENAME).read_bytes()
+        metadata = dp_client.save_calls[0]["metadata"]
+        assert metadata["rollout_recovery_schema_version"] == (
+            ROLLOUT_RECOVERY_SCHEMA_VERSION
+        )
+        assert metadata["rollout_recovery_group_count"] == 1
+        assert (
+            metadata["rollout_recovery_payload_sha256"]
+            == hashlib.sha256(payload).hexdigest()
+        )
+        state = torch.load(
+            step_dir / ROLLOUT_RECOVERY_STATE_FILENAME, weights_only=False
+        )
+        assert state["groups"][0]["group_id"] == "partial-group"
+        assert "prompt_payload" not in state["groups"][0]
+        assert manager.checkpoint_barrier is not None
+
     def test_saves_authoritative_tq_state_and_metadata_only_replay_index(
         self, tmp_path
     ):
@@ -1457,6 +1555,50 @@ class TestDataloaderState:
 
 
 class TestReplayBufferPersistence:
+    def test_run_recovers_unfinished_groups_before_starting_pumps(self, tmp_path):
+        ckpt_dir = tmp_path / "resume_ckpt"
+        ckpt_dir.mkdir()
+        torch.save({"groups": []}, ckpt_dir / REPLAY_BUFFER_METADATA_FILENAME)
+        mc = _actor_master_config(
+            tmp_path,
+            max_num_steps=0,
+            buffer_checkpoint=True,
+            data_plane_checkpoint=True,
+        )
+        mc.token_capture.enabled = True
+        ledger = RolloutRecoveryLedger()
+        ledger.reserve_group(
+            group_id="partial-group",
+            prompt_id="17",
+            prompt_ref=PromptRef(sample_id="17", task_name="nemo_gym"),
+            prompt_payload={"idx": 17, "task_name": "nemo_gym"},
+            expected_generations=2,
+            target_step=None,
+            start_weight_version=0,
+        )
+        manager = _FakeRolloutManager(ledger)
+        metadata = {
+            "replay_manifest_digest": "digest-1",
+            "replay_group_count": 0,
+            "rollout_recovery_payload_sha256": "recovery-digest",
+            "rollout_recovery_group_count": 1,
+        }
+
+        actor, result = _run_actor_run(
+            mc,
+            _make_actor_args(
+                rollout_manager=manager,
+                tq_buffer=_FakeTQBuffer(load_return=0),
+                last_checkpoint_path=str(ckpt_dir),
+                data_plane_checkpoint_metadata=metadata,
+            ),
+        )
+
+        assert manager.recovery_calls == ["partial-group"]
+        assert len(ledger) == 0
+        assert actor._buffer_capacity._value == 4
+        assert result["train_steps"] == 0
+
     def test_checkpoint_capable_sampler_without_native_tq_is_rejected(self, tmp_path):
         mc = _actor_master_config(
             tmp_path,
@@ -1521,7 +1663,7 @@ class TestReplayBufferPersistence:
                 ),
                 "start_weight": 0,
                 "end_weight": 0,
-                "target_step": i,
+                "target_step": None,
                 "group_id": f"g{i}",
             }
             for i in range(2)
@@ -1646,7 +1788,7 @@ class TestReplayBufferPersistence:
                     ),
                     "start_weight": 0,
                     "end_weight": 0,
-                    "target_step": 0,
+                    "target_step": None,
                     "group_id": "g0",
                 }
             ]

--- a/tests/unit/single_controller/test_sc_checkpointing.py
+++ b/tests/unit/single_controller/test_sc_checkpointing.py
@@ -1349,7 +1349,12 @@ def _setup_master_config(checkpoint_dir: str) -> MasterConfig:
     checkpointing block setup now reads.
     """
     return MasterConfig.model_construct(
-        data_plane={"enabled": True, "impl": "transfer_queue"},
+        data_plane={
+            "enabled": True,
+            "impl": "transfer_queue",
+            "backend": "simple",
+            "checkpointing_enabled": True,
+        },
         data={
             "use_multiple_dataloader": False,
             "shuffle": False,

--- a/tests/unit/single_controller/test_sc_checkpointing.py
+++ b/tests/unit/single_controller/test_sc_checkpointing.py
@@ -193,7 +193,11 @@ class _FakeSampler:
         max_prompt_groups: int,
     ) -> tuple[KVBatchMeta, int]:
         n = max_prompt_groups
-        sample_ids = [f"s{self._step}-{i}" for i in range(n)]
+        # Canonical rollout rows are named ``{group_id}_g{generation_index}``.
+        # This fixture models one physical row per prompt group, so give each
+        # synthetic group its generation-0 row rather than using the legacy
+        # suffix-free IDs that the train pump now correctly rejects.
+        sample_ids = [f"s{self._step}-{i}_g0" for i in range(n)]
         self._step += 1
         meta = KVBatchMeta(
             partition_id=_PARTITION_ID,

--- a/tests/unit/single_controller/test_sc_checkpointing.py
+++ b/tests/unit/single_controller/test_sc_checkpointing.py
@@ -95,6 +95,7 @@ from tests.unit.single_controller.test_single_controller_setup import (
 _ACTOR_CLS = SingleControllerActor.__ray_metadata__.modified_class
 
 _PARTITION_ID = "rollout_data"
+_STAGING_PARTITION_ID = "rollout_staging"
 
 
 # ── fakes ────────────────────────────────────────────────────────────────────
@@ -278,22 +279,35 @@ class _FakeDPClient:
         *,
         save_error: Optional[Exception] = None,
         sample_ids: Optional[list[str]] = None,
+        staging_sample_ids: Optional[list[str]] = None,
     ) -> None:
         self.clear_calls: list[tuple[list[str], str]] = []
         self.clear_thread_ids: list[int] = []
+        self.list_calls: list[str] = []
         self.save_calls: list[dict[str, Any]] = []
         self.save_error = save_error
-        self.sample_ids = list(sample_ids or [])
+        self.sample_ids_by_partition = {
+            _PARTITION_ID: list(sample_ids or []),
+            _STAGING_PARTITION_ID: list(staging_sample_ids or []),
+        }
+        # Preserve the existing canonical-row test surface while modelling the
+        # staging partition independently.
+        self.sample_ids = self.sample_ids_by_partition[_PARTITION_ID]
 
     def list_sample_ids(self, partition_id: str) -> list[str]:
-        assert partition_id == _PARTITION_ID
-        return sorted(self.sample_ids)
+        self.list_calls.append(partition_id)
+        assert partition_id in self.sample_ids_by_partition
+        return sorted(self.sample_ids_by_partition[partition_id])
 
     def clear_samples(self, sample_ids: list[str], partition_id: str) -> None:
+        assert partition_id in self.sample_ids_by_partition
         self.clear_thread_ids.append(threading.get_ident())
         self.clear_calls.append((list(sample_ids), partition_id))
         cleared = set(sample_ids)
-        self.sample_ids = [sid for sid in self.sample_ids if sid not in cleared]
+        partition_sample_ids = self.sample_ids_by_partition[partition_id]
+        partition_sample_ids[:] = [
+            sample_id for sample_id in partition_sample_ids if sample_id not in cleared
+        ]
 
     def save_checkpoint(
         self,
@@ -972,6 +986,10 @@ class TestDataPlaneCheckpoint:
         assert state["groups"][0]["group_id"] == "partial-group"
         assert "prompt_payload" not in state["groups"][0]
         assert manager.checkpoint_barrier is not None
+        assert dp_client.list_calls == [
+            _PARTITION_ID,
+            mc.token_capture.staging_partition,
+        ]
 
     def test_saves_authoritative_tq_state_and_metadata_only_replay_index(
         self, tmp_path

--- a/tests/unit/single_controller/test_sc_checkpointing.py
+++ b/tests/unit/single_controller/test_sc_checkpointing.py
@@ -353,6 +353,18 @@ class _FakeWeightSynchronizer:
         self.sync_count += 1
 
 
+class _FakeGeneration:
+    """Generation stand-in for weight-version updates during actor startup."""
+
+    requires_kv_scale_sync = False
+
+    def __init__(self) -> None:
+        self.rollout_weight_versions: list[int] = []
+
+    def set_rollout_weight_version(self, version: int) -> None:
+        self.rollout_weight_versions.append(version)
+
+
 class _FakeRolloutManager:
     def __init__(self, recovery_ledger: Optional[RolloutRecoveryLedger] = None) -> None:
         self.weight_versions: list[int] = []
@@ -576,7 +588,7 @@ def _make_actor_args(
     rollout_manager: Optional[_FakeRolloutManager] = None,
 ) -> SingleControllerActorArgs:
     return SingleControllerActorArgs(
-        gen_handle=object(),
+        gen_handle=_FakeGeneration(),
         trainer_handle=trainer if trainer is not None else _FakeTrainer(),
         env_handles={},
         train_cluster=None,  # type: ignore[arg-type]
@@ -1001,7 +1013,7 @@ class TestDataPlaneCheckpoint:
             buffer_checkpoint=True,
             data_plane_checkpoint=True,
         )
-        sample_ids = ["g0-0", "g0-1"]
+        sample_ids = ["g0_g0", "g0_g1"]
         dp_client = _FakeDPClient(sample_ids=sample_ids)
         replay_metadata = {
             "schema_version": REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
@@ -1067,10 +1079,10 @@ class TestDataPlaneCheckpoint:
     @pytest.mark.parametrize(
         ("actual_sample_ids", "error_fragment"),
         [
-            (["g0-0"], r"missing=\['g0-1'\]"),
+            (["g0_g0"], r"missing=\['g0_g1'\]"),
             (
-                ["g0-0", "g0-1", "orphan-0"],
-                r"unexpected=\['orphan-0'\]",
+                ["g0_g0", "g0_g1", "orphan_g0"],
+                r"unexpected=\['orphan_g0'\]",
             ),
         ],
     )
@@ -1084,7 +1096,7 @@ class TestDataPlaneCheckpoint:
             buffer_checkpoint=True,
             data_plane_checkpoint=True,
         )
-        sample_ids = ["g0-0", "g0-1"]
+        sample_ids = ["g0_g0", "g0_g1"]
         replay_metadata = {
             "schema_version": REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
             "storage": REPLAY_BUFFER_METADATA_STORAGE,
@@ -1917,13 +1929,13 @@ class TestReplayBufferPersistence:
     ):
         ckpt_dir = tmp_path / "resume_ckpt"
         ckpt_dir.mkdir()
-        sample_ids = ["g0-0", "g0-1", "g1-0", "g1-1"]
+        sample_ids = ["g0_g0", "g0_g1", "g1_g0", "g1_g1"]
         groups = [
             {
                 "meta": KVBatchMeta(
                     partition_id=_PARTITION_ID,
                     task_name=None,
-                    sample_ids=[f"g{i}-0", f"g{i}-1"],
+                    sample_ids=[f"g{i}_g0", f"g{i}_g1"],
                     sequence_lengths=[16, 16],
                     tags=[{"weight_version": 0}, {"weight_version": 0}],
                 ),
@@ -1979,13 +1991,13 @@ class TestReplayBufferPersistence:
         # acquisition shape.
         ckpt_dir = tmp_path / "resume_ckpt"
         ckpt_dir.mkdir()
-        sample_ids = [f"g{i}-{j}" for i in range(4) for j in range(2)]
+        sample_ids = [f"g{i}_g{j}" for i in range(4) for j in range(2)]
         groups = [
             {
                 "meta": KVBatchMeta(
                     partition_id=_PARTITION_ID,
                     task_name=None,
-                    sample_ids=[f"g{i}-0", f"g{i}-1"],
+                    sample_ids=[f"g{i}_g0", f"g{i}_g1"],
                     sequence_lengths=[16, 16],
                     tags=[{"weight_version": 0}, {"weight_version": 0}],
                 ),
@@ -2030,10 +2042,10 @@ class TestReplayBufferPersistence:
     @pytest.mark.parametrize(
         ("actual_sample_ids", "error_fragment"),
         [
-            (["g0-0"], r"missing=\['g0-1'\]"),
+            (["g0_g0"], r"missing=\['g0_g1'\]"),
             (
-                ["g0-0", "g0-1", "orphan-0"],
-                r"unexpected=\['orphan-0'\]",
+                ["g0_g0", "g0_g1", "orphan_g0"],
+                r"unexpected=\['orphan_g0'\]",
             ),
         ],
     )
@@ -2048,7 +2060,7 @@ class TestReplayBufferPersistence:
                     "meta": KVBatchMeta(
                         partition_id=_PARTITION_ID,
                         task_name=None,
-                        sample_ids=["g0-0", "g0-1"],
+                        sample_ids=["g0_g0", "g0_g1"],
                         sequence_lengths=[16, 16],
                         tags=[{"weight_version": 0}, {"weight_version": 0}],
                     ),

--- a/tests/unit/single_controller/test_sc_checkpointing.py
+++ b/tests/unit/single_controller/test_sc_checkpointing.py
@@ -363,6 +363,21 @@ class _FakeRolloutManager:
         self.recovery_ledger.discard_group(group_id)
 
 
+def _unfinished_recovery_ledger(group_count: int) -> RolloutRecoveryLedger:
+    ledger = RolloutRecoveryLedger()
+    for index in range(group_count):
+        ledger.reserve_group(
+            group_id=f"recovery-g{index}",
+            prompt_id=str(index),
+            prompt_ref=PromptRef(sample_id=str(index), task_name="nemo_gym"),
+            prompt_payload={"idx": index, "task_name": "nemo_gym"},
+            expected_generations=2,
+            target_step=None,
+            start_weight_version=0,
+        )
+    return ledger
+
+
 class _FakeTQBuffer:
     """TQReplayBuffer stand-in for the SC save/restore integration tests."""
 
@@ -1555,7 +1570,7 @@ class TestDataloaderState:
 
 
 class TestReplayBufferPersistence:
-    def test_run_recovers_unfinished_groups_before_starting_pumps(self, tmp_path):
+    def test_run_completes_unfinished_recovery_with_zero_train_steps(self, tmp_path):
         ckpt_dir = tmp_path / "resume_ckpt"
         ckpt_dir.mkdir()
         torch.save({"groups": []}, ckpt_dir / REPLAY_BUFFER_METADATA_FILENAME)
@@ -1598,6 +1613,230 @@ class TestReplayBufferPersistence:
         assert len(ledger) == 0
         assert actor._buffer_capacity._value == 4
         assert result["train_steps"] == 0
+
+    def test_restore_recovers_groups_in_parallel_with_bounded_concurrency(
+        self, tmp_path
+    ):
+        class _BlockingRecoveryManager(_FakeRolloutManager):
+            def __init__(self, ledger: RolloutRecoveryLedger) -> None:
+                super().__init__(ledger)
+                self.active = 0
+                self.peak_active = 0
+                self.two_started = asyncio.Event()
+                self.release = asyncio.Event()
+
+            async def recover_for_finalization(
+                self, group_id: str, **kwargs: Any
+            ) -> None:
+                del kwargs
+                self.active += 1
+                self.peak_active = max(self.peak_active, self.active)
+                if self.active == 2:
+                    self.two_started.set()
+                try:
+                    await self.release.wait()
+                    await super().recover_for_finalization(group_id)
+                finally:
+                    self.active -= 1
+
+        async def _main() -> None:
+            mc = _actor_master_config(
+                tmp_path,
+                max_num_steps=0,
+                buffer_checkpoint=True,
+                data_plane_checkpoint=True,
+            )
+            mc.token_capture.enabled = True
+            mc.async_rl.max_inflight_prompts = 2
+            ledger = _unfinished_recovery_ledger(3)
+            manager = _BlockingRecoveryManager(ledger)
+            actor = _ACTOR_CLS(
+                mc,
+                _make_actor_args(
+                    rollout_manager=manager,
+                    data_plane_checkpoint_metadata={
+                        "rollout_recovery_payload_sha256": "digest"
+                    },
+                ),
+                SetupTimingMetrics(),
+            )
+
+            recovery_task = asyncio.create_task(
+                actor._maybe_restore_rollout_recovery(restored_replay_groups=0)
+            )
+            await asyncio.wait_for(manager.two_started.wait(), timeout=1.0)
+
+            assert manager.peak_active == 2
+            assert actor._rollout_slots._value == 0
+            # All restored groups own capacity, including the one queued behind
+            # the two-worker recovery limit.
+            assert actor._buffer_capacity._value == 1
+
+            manager.release.set()
+            await asyncio.wait_for(recovery_task, timeout=1.0)
+            actor._checkpointer.shutdown()
+
+            assert manager.peak_active == 2
+            assert sorted(manager.recovery_calls) == [
+                "recovery-g0",
+                "recovery-g1",
+                "recovery-g2",
+            ]
+            assert actor._rollout_slots._value == 2
+            assert actor._buffer_capacity._value == 4
+            assert actor._rollout_recovery_complete.is_set()
+
+        asyncio.run(_main())
+
+    def test_parallel_recovery_failure_releases_uncommitted_capacity(self, tmp_path):
+        class _FailingRecoveryManager(_FakeRolloutManager):
+            async def recover_for_finalization(
+                self, group_id: str, **kwargs: Any
+            ) -> None:
+                del kwargs
+                await asyncio.sleep(0)
+                if group_id == "recovery-g0":
+                    raise RuntimeError("injected recovery failure")
+                await asyncio.Event().wait()
+
+        async def _main() -> None:
+            mc = _actor_master_config(
+                tmp_path,
+                max_num_steps=0,
+                buffer_checkpoint=True,
+                data_plane_checkpoint=True,
+            )
+            mc.token_capture.enabled = True
+            mc.async_rl.max_inflight_prompts = 2
+            ledger = _unfinished_recovery_ledger(3)
+            actor = _ACTOR_CLS(
+                mc,
+                _make_actor_args(
+                    rollout_manager=_FailingRecoveryManager(ledger),
+                    data_plane_checkpoint_metadata={
+                        "rollout_recovery_payload_sha256": "digest"
+                    },
+                ),
+                SetupTimingMetrics(),
+            )
+
+            with pytest.raises(ExceptionGroup) as exc_info:
+                await asyncio.wait_for(
+                    actor._maybe_restore_rollout_recovery(restored_replay_groups=0),
+                    timeout=1.0,
+                )
+            actor._checkpointer.shutdown()
+
+            assert exc_info.value.subgroup(RuntimeError) is not None
+            assert actor._rollout_slots._value == 2
+            assert actor._buffer_capacity._value == 4
+            assert actor._rollout_recovery_complete.is_set()
+
+        asyncio.run(_main())
+
+    def test_run_overlaps_recovery_with_fresh_rollout_and_train_pumps(self, tmp_path):
+        class _BlockingRecoveryManager(_FakeRolloutManager):
+            def __init__(self, ledger: RolloutRecoveryLedger) -> None:
+                super().__init__(ledger)
+                self.started = asyncio.Event()
+                self.release = asyncio.Event()
+
+            async def recover_for_finalization(
+                self, group_id: str, **kwargs: Any
+            ) -> None:
+                del kwargs
+                self.started.set()
+                await self.release.wait()
+                await super().recover_for_finalization(group_id)
+
+        async def _main() -> None:
+            mc = _actor_master_config(
+                tmp_path,
+                max_num_steps=1,
+                buffer_checkpoint=True,
+                data_plane_checkpoint=True,
+            )
+            mc.token_capture.enabled = True
+            mc.async_rl.max_inflight_prompts = 2
+            ledger = _unfinished_recovery_ledger(1)
+            manager = _BlockingRecoveryManager(ledger)
+            actor = _ACTOR_CLS(
+                mc,
+                _make_actor_args(
+                    rollout_manager=manager,
+                    data_plane_checkpoint_metadata={
+                        "rollout_recovery_payload_sha256": "digest"
+                    },
+                ),
+                SetupTimingMetrics(),
+            )
+
+            rollout_started = asyncio.Event()
+            train_started = asyncio.Event()
+            finish_pumps = asyncio.Event()
+
+            async def _no_sync() -> None:
+                return None
+
+            async def _no_replay() -> int:
+                return 0
+
+            async def _rollout_pump() -> None:
+                acquired = 0
+                rollout_slot_owned = False
+                try:
+                    for _ in range(2):
+                        await actor._buffer_capacity.acquire()
+                        acquired += 1
+                    await actor._rollout_slots.acquire()
+                    rollout_slot_owned = True
+                    rollout_started.set()
+                    await finish_pumps.wait()
+                finally:
+                    if rollout_slot_owned:
+                        actor._rollout_slots.release()
+                    for _ in range(acquired):
+                        actor._buffer_capacity.release()
+
+            async def _train_pump() -> None:
+                train_started.set()
+                await finish_pumps.wait()
+
+            async def _watchdog_pump() -> None:
+                await finish_pumps.wait()
+
+            actor._sync_weights = _no_sync
+            actor._maybe_restore_replay_buffer = _no_replay
+            actor._rollout_pump = _rollout_pump
+            actor._train_pump = _train_pump
+            actor._watchdog_pump = _watchdog_pump
+
+            run_task = asyncio.create_task(actor.run())
+            await asyncio.wait_for(
+                asyncio.gather(
+                    manager.started.wait(),
+                    rollout_started.wait(),
+                    train_started.wait(),
+                ),
+                timeout=1.0,
+            )
+
+            # One restored permit and two fresh permits coexist while recovery
+            # is still blocked, and both paths share the two generation slots.
+            assert actor._buffer_capacity._value == 1
+            assert actor._rollout_slots._value == 0
+            assert not actor._rollout_recovery_complete.is_set()
+
+            manager.release.set()
+            finish_pumps.set()
+            result = await asyncio.wait_for(run_task, timeout=1.0)
+
+            assert result["train_steps"] == 0
+            assert manager.recovery_calls == ["recovery-g0"]
+            assert actor._buffer_capacity._value == 4
+            assert actor._rollout_recovery_complete.is_set()
+
+        asyncio.run(_main())
 
     def test_checkpoint_capable_sampler_without_native_tq_is_rejected(self, tmp_path):
         mc = _actor_master_config(

--- a/tests/unit/single_controller/test_sc_checkpointing.py
+++ b/tests/unit/single_controller/test_sc_checkpointing.py
@@ -33,6 +33,7 @@ Covers:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import os
 import threading
@@ -68,6 +69,11 @@ from nemo_rl.algorithms.single_controller_utils import (
 from nemo_rl.algorithms.single_controller_utils.setup import SingleControllerActorArgs
 from nemo_rl.data.utils import load_dataloader_state
 from nemo_rl.data_plane import KVBatchMeta
+from nemo_rl.experience.rollout_recovery import (
+    ROLLOUT_RECOVERY_SCHEMA_VERSION,
+    ROLLOUT_RECOVERY_STATE_FILENAME,
+    RolloutRecoveryLedger,
+)
 from nemo_rl.utils.checkpoint import CheckpointManager
 
 # Reuse the factory patches from the setup tests (same cross-module fixture
@@ -208,16 +214,21 @@ class _FakeDPClient:
         *,
         save_error: Optional[Exception] = None,
         sample_ids: Optional[list[str]] = None,
+        staging_sample_ids: Optional[list[str]] = None,
     ) -> None:
         self.clear_calls: list[tuple[list[str], str]] = []
         self.clear_thread_ids: list[int] = []
         self.save_calls: list[dict[str, Any]] = []
         self.save_error = save_error
         self.sample_ids = list(sample_ids or [])
+        self.staging_sample_ids = list(staging_sample_ids or [])
 
     def list_sample_ids(self, partition_id: str) -> list[str]:
-        assert partition_id == _PARTITION_ID
-        return sorted(self.sample_ids)
+        if partition_id == _PARTITION_ID:
+            return sorted(self.sample_ids)
+        if partition_id == "rollout_staging":
+            return sorted(self.staging_sample_ids)
+        raise AssertionError(f"unexpected partition_id={partition_id!r}")
 
     def clear_samples(self, sample_ids: list[str], partition_id: str) -> None:
         self.clear_thread_ids.append(threading.get_ident())
@@ -268,12 +279,63 @@ class _FakeWeightSynchronizer:
 
 
 class _FakeRolloutManager:
-    def __init__(self) -> None:
+    def __init__(self, recovery_ledger: Optional[RolloutRecoveryLedger] = None) -> None:
         self.weight_versions: list[int] = []
         self._tq_buffer = None
+        self._recovery_ledger = recovery_ledger
+        self.checkpoint_barrier: Optional[DataPlaneCheckpointBarrier] = None
+        self.recovered_group_ids: list[str] = []
+
+    @property
+    def recovery_ledger(self) -> Optional[RolloutRecoveryLedger]:
+        return self._recovery_ledger
+
+    def set_data_plane_checkpoint_barrier(
+        self, barrier: DataPlaneCheckpointBarrier
+    ) -> None:
+        self.checkpoint_barrier = barrier
 
     def set_weight_version(self, version: int) -> None:
         self.weight_versions.append(version)
+
+    async def recover_group(self, group_id: str) -> bool:
+        self.recovered_group_ids.append(group_id)
+        assert self._recovery_ledger is not None
+        self._recovery_ledger.prepare_for_restart()
+        for generation_index in self._recovery_ledger.retryable_generation_indices(
+            group_id
+        ):
+            self._recovery_ledger.retry_sibling(
+                group_id, generation_index=generation_index
+            )
+        group = self._recovery_ledger.get_group(group_id)
+        retry_indices = [
+            sibling.generation_index
+            for sibling in group.siblings
+            if sibling.current_attempt.status.value == "reserved"
+        ]
+        if retry_indices:
+            self._recovery_ledger.mark_siblings_dispatched(
+                group_id, generation_indices=retry_indices
+            )
+            for generation_index in retry_indices:
+                retry_group = self._recovery_ledger.get_group(group_id)
+                attempt = retry_group.siblings[generation_index].current_attempt
+                self._recovery_ledger.mark_sibling_sealed(
+                    group_id,
+                    generation_index=generation_index,
+                    gate_rollout_id=attempt.gate_rollout_id,
+                    receipt={
+                        "rollout_id": attempt.gate_rollout_id,
+                        "manifest": [
+                            {"staging_key": f"retry-stage-{generation_index}"}
+                        ],
+                    },
+                    reward=0.0,
+                )
+        self._recovery_ledger.mark_group_finalized(group_id)
+        self._recovery_ledger.release_finalized_group(group_id)
+        return True
 
 
 class _FakeTQBuffer:
@@ -363,6 +425,7 @@ def _actor_master_config(
     max_num_epochs: int = 1,
     buffer_checkpoint: bool = False,
     data_plane_checkpoint: bool = False,
+    token_capture: bool = False,
 ) -> MasterConfig:
     """MasterConfig for in-process SingleControllerActor tests.
 
@@ -376,7 +439,7 @@ def _actor_master_config(
         if buffer_checkpoint
         else InOrderSamplerConfig(max_lookahead_versions=1)
     )
-    return MasterConfig.model_construct(
+    config = MasterConfig.model_construct(
         policy={
             # One optimizer.step per RL step: prompts * generations == gbs.
             "train_global_batch_size": num_prompts_per_step * 2,
@@ -423,6 +486,8 @@ def _actor_master_config(
             max_buffered_rollouts=4,
         ),
     )
+    config.token_capture.enabled = token_capture
+    return config
 
 
 def _make_actor_args(
@@ -434,6 +499,7 @@ def _make_actor_args(
     dp_client: Optional[_FakeDPClient] = None,
     last_checkpoint_path: Optional[str] = None,
     data_plane_checkpoint_metadata: Optional[dict[str, Any]] = None,
+    rollout_manager: Optional[_FakeRolloutManager] = None,
 ) -> SingleControllerActorArgs:
     return SingleControllerActorArgs(
         gen_handle=object(),
@@ -446,7 +512,9 @@ def _make_actor_args(
         weight_synchronizer=_FakeWeightSynchronizer(),  # type: ignore[arg-type]
         advantage_estimator=None,
         loss_fn=object(),  # type: ignore[arg-type]
-        rollout_manager=_FakeRolloutManager(),  # type: ignore[arg-type]
+        rollout_manager=(
+            rollout_manager if rollout_manager is not None else _FakeRolloutManager()
+        ),  # type: ignore[arg-type]
         tq_buffer=tq_buffer if tq_buffer is not None else _FakeTQBuffer(),  # type: ignore[arg-type]
         partition_id=_PARTITION_ID,
         save_state=(
@@ -455,6 +523,72 @@ def _make_actor_args(
         last_checkpoint_path=last_checkpoint_path,
         data_plane_checkpoint_metadata=data_plane_checkpoint_metadata,
     )
+
+
+def _sealed_recovery_ledger(*, group_id: str = "recovery-g0") -> RolloutRecoveryLedger:
+    ledger = RolloutRecoveryLedger()
+    group = ledger.reserve_group(
+        group_id=group_id,
+        prompt_id="prompt-0",
+        prompt_payload={
+            "idx": 0,
+            "message_log": [{"role": "user", "content": "solve"}],
+            "extra_env_info": {},
+            "task_name": "nemo_gym",
+        },  # type: ignore[arg-type]
+        expected_generations=2,
+        target_step=None,
+        start_weight_version=0,
+    )
+    ledger.mark_group_dispatched(group.group_id)
+    for sibling in group.siblings:
+        rollout_id = sibling.current_attempt.gate_rollout_id
+        ledger.mark_sibling_sealed(
+            group.group_id,
+            generation_index=sibling.generation_index,
+            gate_rollout_id=rollout_id,
+            receipt={
+                "rollout_id": rollout_id,
+                "manifest": [
+                    {
+                        "staging_key": f"{group.group_id}-stage-{sibling.generation_index}"
+                    }
+                ],
+            },
+            reward=float(sibling.generation_index),
+        )
+    return ledger
+
+
+def _partial_recovery_ledger() -> RolloutRecoveryLedger:
+    ledger = RolloutRecoveryLedger()
+    group = ledger.reserve_group(
+        group_id="partial-g0",
+        prompt_id="prompt-0",
+        prompt_payload={
+            "idx": 0,
+            "message_log": [{"role": "user", "content": "solve"}],
+            "extra_env_info": {},
+            "task_name": "nemo_gym",
+        },  # type: ignore[arg-type]
+        expected_generations=2,
+        target_step=None,
+        start_weight_version=0,
+    )
+    ledger.mark_group_dispatched(group.group_id)
+    first_rollout_id = group.siblings[0].current_attempt.gate_rollout_id
+    ledger.mark_sibling_sealed(
+        group.group_id,
+        generation_index=0,
+        gate_rollout_id=first_rollout_id,
+        receipt={
+            "rollout_id": first_rollout_id,
+            "manifest": [{"staging_key": "partial-g0-stage-0"}],
+        },
+        reward=1.0,
+    )
+    ledger.abandon_group(group.group_id)
+    return ledger
 
 
 def _run_train_pump(
@@ -688,6 +822,185 @@ class TestSaveTrigger:
 
 
 class TestDataPlaneCheckpoint:
+    def test_restore_replays_fully_sealed_groups_before_pumps(self, tmp_path):
+        mc = _actor_master_config(
+            tmp_path,
+            buffer_checkpoint=True,
+            data_plane_checkpoint=True,
+            token_capture=True,
+        )
+        ledger = _sealed_recovery_ledger()
+        (group,) = ledger.groups()
+        manager = _FakeRolloutManager(ledger)
+        actor = _ACTOR_CLS(
+            mc,
+            _make_actor_args(
+                dp_client=_FakeDPClient(
+                    staging_sample_ids=sorted(ledger.expected_staging_keys())
+                ),
+                rollout_manager=manager,
+                data_plane_checkpoint_metadata={
+                    "rollout_recovery_payload_sha256": "digest"
+                },
+            ),
+        )
+
+        asyncio.run(actor._maybe_restore_rollout_recovery(restored_replay_groups=0))
+        actor._checkpointer.shutdown()
+
+        assert manager.recovered_group_ids == [group.group_id]
+        assert len(ledger) == 0
+
+    def test_restore_redispatches_partial_groups_before_pumps(self, tmp_path):
+        mc = _actor_master_config(
+            tmp_path,
+            buffer_checkpoint=True,
+            data_plane_checkpoint=True,
+            token_capture=True,
+        )
+        ledger = _partial_recovery_ledger()
+        manager = _FakeRolloutManager(ledger)
+        actor = _ACTOR_CLS(
+            mc,
+            _make_actor_args(
+                dp_client=_FakeDPClient(
+                    staging_sample_ids=sorted(ledger.expected_staging_keys())
+                ),
+                rollout_manager=manager,
+                data_plane_checkpoint_metadata={
+                    "rollout_recovery_payload_sha256": "digest"
+                },
+            ),
+        )
+
+        asyncio.run(actor._maybe_restore_rollout_recovery(restored_replay_groups=0))
+        actor._checkpointer.shutdown()
+
+        assert manager.recovered_group_ids == ["partial-g0"]
+        assert len(ledger) == 0
+
+    def test_restore_rejects_missing_staging_rows(self, tmp_path):
+        mc = _actor_master_config(
+            tmp_path,
+            buffer_checkpoint=True,
+            data_plane_checkpoint=True,
+            token_capture=True,
+        )
+        ledger = _sealed_recovery_ledger()
+        actor = _ACTOR_CLS(
+            mc,
+            _make_actor_args(
+                dp_client=_FakeDPClient(),
+                rollout_manager=_FakeRolloutManager(ledger),
+                data_plane_checkpoint_metadata={
+                    "rollout_recovery_payload_sha256": "digest"
+                },
+            ),
+        )
+
+        with pytest.raises(RuntimeError, match="staging rows missing"):
+            asyncio.run(actor._maybe_restore_rollout_recovery(restored_replay_groups=0))
+        actor._checkpointer.shutdown()
+
+    def test_saves_rollout_recovery_sidecar_bound_to_tq_snapshot(self, tmp_path):
+        mc = _actor_master_config(
+            tmp_path,
+            max_num_steps=1,
+            save_period=1,
+            buffer_checkpoint=True,
+            data_plane_checkpoint=True,
+            token_capture=True,
+        )
+        ledger = _sealed_recovery_ledger()
+        expected_state = ledger.state_dict()
+        staging_keys = sorted(ledger.expected_staging_keys())
+        dp_client = _FakeDPClient(staging_sample_ids=staging_keys)
+        rollout_manager = _FakeRolloutManager(ledger)
+
+        async def _main() -> None:
+            actor = _ACTOR_CLS(
+                mc,
+                _make_actor_args(
+                    dp_client=dp_client,
+                    rollout_manager=rollout_manager,
+                ),
+            )
+            actor._train_steps = 1
+            actor._trainer_version = 1
+            await actor._save_checkpoint({"loss": 1.0})
+            actor._checkpointer.shutdown()
+
+        asyncio.run(_main())
+
+        step_dir = tmp_path / "checkpoints" / "step_1"
+        recovery_path = step_dir / ROLLOUT_RECOVERY_STATE_FILENAME
+        payload = recovery_path.read_bytes()
+        assert torch.load(recovery_path, weights_only=False) == expected_state
+        metadata = dp_client.save_calls[0]["metadata"]
+        assert metadata["rollout_recovery_schema_version"] == (
+            ROLLOUT_RECOVERY_SCHEMA_VERSION
+        )
+        assert (
+            metadata["rollout_recovery_payload_sha256"]
+            == hashlib.sha256(payload).hexdigest()
+        )
+        assert metadata["rollout_recovery_group_count"] == 1
+        assert metadata["mode"] == "authoritative"
+
+    def test_canonical_replay_wins_over_ledger_during_checkpoint_cut(self, tmp_path):
+        mc = _actor_master_config(
+            tmp_path,
+            max_num_steps=1,
+            save_period=1,
+            buffer_checkpoint=True,
+            data_plane_checkpoint=True,
+            token_capture=True,
+        )
+        ledger = _sealed_recovery_ledger(group_id="g0")
+        sample_ids = ["g0_g0", "g0_g1"]
+        replay_metadata = {
+            "schema_version": REPLAY_BUFFER_METADATA_SCHEMA_VERSION,
+            "storage": REPLAY_BUFFER_METADATA_STORAGE,
+            "partition_id": _PARTITION_ID,
+            "saved_capacity": 4,
+            "manifest_digest": "digest-g0",
+            "groups": [
+                {
+                    "meta": KVBatchMeta(
+                        partition_id=_PARTITION_ID,
+                        task_name="train",
+                        sample_ids=sample_ids,
+                        fields=["input_ids"],
+                        sequence_lengths=[16, 16],
+                        tags=[{"weight_version": 0}, {"weight_version": 0}],
+                    ),
+                    "start_weight": 0,
+                    "end_weight": 0,
+                    "target_step": None,
+                    "group_id": "g0",
+                }
+            ],
+        }
+        actor = _ACTOR_CLS(
+            mc,
+            _make_actor_args(
+                dp_client=_FakeDPClient(sample_ids=sample_ids),
+                tq_buffer=_FakeTQBuffer(metadata_state=replay_metadata),
+                rollout_manager=_FakeRolloutManager(ledger),
+            ),
+        )
+        actor._train_steps = 1
+        actor._trainer_version = 1
+
+        asyncio.run(actor._save_checkpoint({"loss": 1.0}))
+        actor._checkpointer.shutdown()
+
+        recovery_state = torch.load(
+            tmp_path / "checkpoints" / "step_1" / ROLLOUT_RECOVERY_STATE_FILENAME,
+            weights_only=False,
+        )
+        assert recovery_state["groups"] == []
+
     def test_saves_authoritative_tq_state_and_metadata_only_replay_index(
         self, tmp_path
     ):
@@ -754,9 +1067,10 @@ class TestDataPlaneCheckpoint:
         }
         step_dir = tmp_path / "checkpoints" / "step_1"
         assert (step_dir / "data_plane" / "metadata.json").is_file()
-        assert torch.load(
-            step_dir / REPLAY_BUFFER_METADATA_FILENAME, weights_only=False
-        ) == replay_metadata
+        assert (
+            torch.load(step_dir / REPLAY_BUFFER_METADATA_FILENAME, weights_only=False)
+            == replay_metadata
+        )
         assert not (step_dir / "replay_buffer.pt").exists()
         assert buffer.metadata_state_dict_calls == [4]
 
@@ -1312,16 +1626,12 @@ class TestReplayBufferPersistence:
         ckpt_dir = tmp_path / "checkpoints"
         assert (ckpt_dir / "step_2" / "training_info.json").exists()
         assert not (ckpt_dir / "step_2" / "replay_buffer.pt").exists()
-        assert not (
-            ckpt_dir / "step_2" / REPLAY_BUFFER_METADATA_FILENAME
-        ).exists()
+        assert not (ckpt_dir / "step_2" / REPLAY_BUFFER_METADATA_FILENAME).exists()
 
     def test_run_rejects_legacy_replay_file(self, tmp_path):
         ckpt_dir = tmp_path / "resume_ckpt"
         ckpt_dir.mkdir()
-        torch.save(
-            {"groups": ["legacy"]}, ckpt_dir / LEGACY_REPLAY_BUFFER_FILENAME
-        )
+        torch.save({"groups": ["legacy"]}, ckpt_dir / LEGACY_REPLAY_BUFFER_FILENAME)
         mc = _actor_master_config(
             tmp_path,
             max_num_steps=0,
@@ -1333,9 +1643,7 @@ class TestReplayBufferPersistence:
         with pytest.raises(RuntimeError, match="legacy replay_buffer.pt"):
             _run_actor_run(
                 mc,
-                _make_actor_args(
-                    tq_buffer=buffer, last_checkpoint_path=str(ckpt_dir)
-                ),
+                _make_actor_args(tq_buffer=buffer, last_checkpoint_path=str(ckpt_dir)),
             )
 
         assert buffer.load_calls == []
@@ -1501,9 +1809,7 @@ class TestReplayBufferPersistence:
         ckpt_dir = tmp_path / "resume_ckpt"
         ckpt_dir.mkdir()
         torch.save({"groups": []}, ckpt_dir / REPLAY_BUFFER_METADATA_FILENAME)
-        mc = _actor_master_config(
-            tmp_path, max_num_steps=0, buffer_checkpoint=False
-        )
+        mc = _actor_master_config(tmp_path, max_num_steps=0, buffer_checkpoint=False)
 
         with pytest.raises(RuntimeError, match="does not support replay-buffer"):
             _run_actor_run(

--- a/tests/unit/single_controller/test_single_controller.py
+++ b/tests/unit/single_controller/test_single_controller.py
@@ -138,6 +138,7 @@ def test_logs_hyperparameters_and_concrete_weight_synchronizer(
         save_state=_initial_grpo_save_state(),
         last_checkpoint_path=None,
         data_plane_checkpoint_metadata=None,
+        finalizer_actors=[],
     )
     controller_cls = SingleControllerActor.__ray_metadata__.modified_class
 
@@ -196,6 +197,7 @@ def test_logs_setup_timing_metrics(monkeypatch, tmp_path) -> None:
         save_state=_initial_grpo_save_state(),
         last_checkpoint_path=None,
         data_plane_checkpoint_metadata=None,
+        finalizer_actors=[],
     )
     controller_cls = SingleControllerActor.__ray_metadata__.modified_class
 
@@ -358,6 +360,7 @@ def _train_pump_controller(*, sampler) -> object:
         # The pump's step epilogue reads the save triggers even when saving
         # is disabled.
         checkpointing={"enabled": False, "save_period": 10},
+        token_capture=SimpleNamespace(enabled=False),
     )
     ctrl._async_cfg = SimpleNamespace(min_groups_for_streaming_train=1)
     ctrl._consumed_samples = 0
@@ -385,6 +388,12 @@ def _train_pump_controller(*, sampler) -> object:
     ctrl._train_steps = 0
     ctrl._data_plane_checkpoint_barrier = DataPlaneCheckpointBarrier()
     ctrl._rollout_recovery_ledger = None
+    ctrl._finalizer_actors = []
+    ctrl._available_finalizers = asyncio.Queue()
+    ctrl._active_finalizers = 0
+    ctrl._finalizer_waiters = 0
+    ctrl._finalizer_unknown_outcomes = 0
+    ctrl._finalizer_metrics_by_group = {}
     ctrl._step_log_dict = {
         "rewards": [],
         "masked_advantages": [],
@@ -420,7 +429,7 @@ def test_train_pump_fails_if_rollout_exhausts_during_partial_step() -> None:
     meta = KVBatchMeta(
         partition_id="rollout_data",
         task_name="train",
-        sample_ids=["sample-0"],
+        sample_ids=["g0_g0"],
         fields=[],
         sequence_lengths=[1],
         tags=[{"weight_version": 0}],
@@ -441,7 +450,7 @@ def test_train_pump_logs_nonzero_stale_group_metrics(monkeypatch) -> None:
     meta = KVBatchMeta(
         partition_id="rollout_data",
         task_name="train",
-        sample_ids=["sample-0", "sample-1"],
+        sample_ids=["g0_g0", "g1_g0"],
         fields=[],
         sequence_lengths=[1, 1],
         tags=[{"weight_version": 0}, {"weight_version": 0}],

--- a/tests/unit/single_controller/test_single_controller.py
+++ b/tests/unit/single_controller/test_single_controller.py
@@ -374,6 +374,8 @@ def _train_pump_controller(*, sampler) -> object:
     ctrl._buffer_capacity = asyncio.Semaphore(2)
     ctrl._rollout_exhausted = asyncio.Event()
     ctrl._rollout_exhausted.set()
+    ctrl._rollout_recovery_complete = asyncio.Event()
+    ctrl._rollout_recovery_complete.set()
     ctrl._trainer = _NoOpTrainer()
     ctrl._gen = SimpleNamespace(requires_kv_scale_sync=False)
     ctrl._loss_fn = None
@@ -397,6 +399,21 @@ def test_train_pump_stops_after_rollout_exhaustion_and_buffer_drain() -> None:
     asyncio.run(asyncio.wait_for(ctrl._train_pump(), timeout=1.0))
 
     assert ctrl._train_steps == 0
+
+
+def test_train_pump_waits_for_recovery_after_dataloader_exhaustion() -> None:
+    async def _main() -> None:
+        ctrl = _train_pump_controller(sampler=_EmptySampler())
+        ctrl._rollout_recovery_complete.clear()
+
+        train_task = asyncio.create_task(ctrl._train_pump())
+        await asyncio.sleep(0.02)
+        assert not train_task.done()
+
+        ctrl._rollout_recovery_complete.set()
+        await asyncio.wait_for(train_task, timeout=1.0)
+
+    asyncio.run(_main())
 
 
 def test_train_pump_fails_if_rollout_exhausts_during_partial_step() -> None:

--- a/tests/unit/single_controller/test_single_controller_setup.py
+++ b/tests/unit/single_controller/test_single_controller_setup.py
@@ -16,6 +16,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import io
 from typing import Any, Optional
 from unittest.mock import MagicMock, patch
 
@@ -47,6 +49,12 @@ from nemo_rl.algorithms.single_controller_utils import (
     setup_single_controller,
 )
 from nemo_rl.data_plane import DATA_PLANE_CHECKPOINT_SCHEMA_VERSION
+from nemo_rl.experience.rollout_recovery import (
+    ROLLOUT_RECOVERY_SCHEMA_VERSION,
+    ROLLOUT_RECOVERY_STATE_FILENAME,
+    PromptRef,
+    RolloutRecoveryLedger,
+)
 
 
 class _CheckpointingCustomSampler(WindowedSampler):
@@ -925,3 +933,92 @@ class TestNativeTQRecoverySetup:
                 partition_id="rollout_data",
                 sampler_name="in_order",
             )
+
+
+class TestRolloutRecoverySetup:
+    @staticmethod
+    def _write_partial_ledger(checkpoint_path) -> tuple[dict[str, Any], str]:
+        ledger = RolloutRecoveryLedger()
+        ledger.reserve_group(
+            group_id="partial-group",
+            prompt_id="2",
+            prompt_ref=PromptRef(sample_id="2", task_name="nemo_gym"),
+            prompt_payload={"idx": 2, "task_name": "nemo_gym"},
+            expected_generations=2,
+            target_step=3,
+            start_weight_version=3,
+        )
+        buffer = io.BytesIO()
+        torch.save(ledger.state_dict(), buffer)
+        payload = buffer.getvalue()
+        (checkpoint_path / ROLLOUT_RECOVERY_STATE_FILENAME).write_bytes(payload)
+        digest = hashlib.sha256(payload).hexdigest()
+        return (
+            {
+                "rollout_recovery_schema_version": (ROLLOUT_RECOVERY_SCHEMA_VERSION),
+                "rollout_recovery_payload_sha256": digest,
+                "rollout_recovery_group_count": 1,
+            },
+            digest,
+        )
+
+    def test_restores_digest_bound_lineage_and_rehydrates_prompt(self, tmp_path):
+        checkpoint_path = tmp_path / "step_3"
+        checkpoint_path.mkdir()
+        metadata, _ = self._write_partial_ledger(checkpoint_path)
+
+        ledger = sc_setup_mod._maybe_restore_rollout_recovery_ledger(
+            last_checkpoint_path=str(checkpoint_path),
+            data_plane_checkpoint_metadata=metadata,
+            token_capture_enabled=True,
+        )
+        assert ledger is not None
+        dataset = [
+            {"idx": index, "task_name": "nemo_gym", "payload": f"prompt-{index}"}
+            for index in range(4)
+        ]
+
+        sc_setup_mod._rehydrate_rollout_recovery_prompts(ledger, dataset)
+
+        restored = ledger.get_group("partial-group")
+        assert restored.runtime_prompt_payload is dataset[2]
+
+    def test_rejects_corrupt_rollout_recovery_sidecar(self, tmp_path):
+        checkpoint_path = tmp_path / "step_3"
+        checkpoint_path.mkdir()
+        metadata, _ = self._write_partial_ledger(checkpoint_path)
+        (checkpoint_path / ROLLOUT_RECOVERY_STATE_FILENAME).write_bytes(b"corrupt")
+
+        with pytest.raises(ValueError, match="digest does not match"):
+            sc_setup_mod._maybe_restore_rollout_recovery_ledger(
+                last_checkpoint_path=str(checkpoint_path),
+                data_plane_checkpoint_metadata=metadata,
+                token_capture_enabled=True,
+            )
+
+    def test_rejects_native_token_capture_checkpoint_without_lineage(self, tmp_path):
+        checkpoint_path = tmp_path / "step_3"
+        checkpoint_path.mkdir()
+
+        with pytest.raises(FileNotFoundError, match="older checkpoints"):
+            sc_setup_mod._maybe_restore_rollout_recovery_ledger(
+                last_checkpoint_path=str(checkpoint_path),
+                data_plane_checkpoint_metadata={"mode": "authoritative"},
+                token_capture_enabled=True,
+            )
+
+    def test_static_prompt_reference_must_match_current_dataset(self, tmp_path):
+        checkpoint_path = tmp_path / "step_3"
+        checkpoint_path.mkdir()
+        metadata, _ = self._write_partial_ledger(checkpoint_path)
+        ledger = sc_setup_mod._maybe_restore_rollout_recovery_ledger(
+            last_checkpoint_path=str(checkpoint_path),
+            data_plane_checkpoint_metadata=metadata,
+            token_capture_enabled=True,
+        )
+        assert ledger is not None
+        dataset = [{"idx": index, "task_name": "nemo_gym"} for index in range(4)]
+        dataset[2] = {"idx": 99, "task_name": "nemo_gym"}
+
+        with pytest.raises(ValueError, match="durable sample reference"):
+            sc_setup_mod._rehydrate_rollout_recovery_prompts(ledger, dataset)

--- a/tests/unit/single_controller/test_single_controller_setup.py
+++ b/tests/unit/single_controller/test_single_controller_setup.py
@@ -351,6 +351,10 @@ class TestSetup:
             ("global_batch_size", "must equal policy.train_global_batch_size"),
             ("buffer_capacity", "required capacity"),
             (
+                "streaming_buffer_capacity",
+                "max_buffered_rollouts.*must be >=.*min_groups_for_streaming_train",
+            ),
+            (
                 "deferred_routes_without_capture",
                 "defer_routed_experts_to_policy requires",
             ),
@@ -369,6 +373,12 @@ class TestSetup:
             mc.policy["train_global_batch_size"] = 7
         elif invalid_case == "buffer_capacity":
             mc.async_rl.max_buffered_rollouts = 7
+        elif invalid_case == "streaming_buffer_capacity":
+            # WindowedSampler has no stronger sampler-specific capacity floor. A
+            # buffer smaller than the streaming threshold would let the producer
+            # consume every permit while the trainer waits for an unreachable count.
+            mc.async_rl.sampler = WindowedSamplerConfig(max_staleness_versions=1)
+            mc.async_rl.max_buffered_rollouts = 3
         elif invalid_case == "deferred_routes_without_capture":
             mc.token_capture.defer_routed_experts_to_policy = True
         else:  # pragma: no cover

--- a/tests/unit/single_controller/test_single_controller_setup.py
+++ b/tests/unit/single_controller/test_single_controller_setup.py
@@ -16,10 +16,12 @@
 
 from __future__ import annotations
 
+import hashlib
 from typing import Any, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
+import torch
 
 import nemo_rl.algorithms.single_controller_utils.setup as sc_setup_mod
 from nemo_rl.algorithms.async_utils.replay_buffer import (
@@ -37,6 +39,11 @@ from nemo_rl.algorithms.single_controller_utils import (
     MasterConfig,
     SingleControllerActorArgs,
     setup_single_controller,
+)
+from nemo_rl.experience.rollout_recovery import (
+    ROLLOUT_RECOVERY_SCHEMA_VERSION,
+    ROLLOUT_RECOVERY_STATE_FILENAME,
+    RolloutRecoveryLedger,
 )
 
 
@@ -111,9 +118,7 @@ def _native_tq_metadata(
     *, step: int = 3, trainer_version: Optional[int] = None, epoch: int = 1
 ) -> dict[str, Any]:
     return {
-        "data_plane_checkpoint_schema_version": (
-            DATA_PLANE_CHECKPOINT_SCHEMA_VERSION
-        ),
+        "data_plane_checkpoint_schema_version": (DATA_PLANE_CHECKPOINT_SCHEMA_VERSION),
         "single_controller_train_steps": step,
         "single_controller_trainer_version": (
             step if trainer_version is None else trainer_version
@@ -126,6 +131,26 @@ def _native_tq_metadata(
         "replay_manifest_digest": "digest-1",
         "replay_group_count": 2,
     }
+
+
+def _write_recovery_sidecar(checkpoint_path) -> tuple[RolloutRecoveryLedger, str]:
+    ledger = RolloutRecoveryLedger()
+    ledger.reserve_group(
+        group_id="recovery-g0",
+        prompt_id="prompt-0",
+        prompt_payload={
+            "idx": 0,
+            "message_log": [{"role": "user", "content": "solve"}],
+            "extra_env_info": {},
+            "task_name": "nemo_gym",
+        },  # type: ignore[arg-type]
+        expected_generations=2,
+        target_step=None,
+        start_weight_version=3,
+    )
+    recovery_path = checkpoint_path / ROLLOUT_RECOVERY_STATE_FILENAME
+    torch.save(ledger.state_dict(), recovery_path)
+    return ledger, hashlib.sha256(recovery_path.read_bytes()).hexdigest()
 
 
 @pytest.fixture
@@ -276,6 +301,36 @@ class TestSetup:
                 "replay-checkpoint-capable sampler requires "
                 "data_plane.checkpointing_enabled=true"
             ),
+        ):
+            setup_single_controller(mc, MagicMock(pad_token_id=0))
+
+    def test_rejects_token_capture_checkpointing_without_native_tq(self):
+        mc = _make_master_config()
+        mc.checkpointing["enabled"] = True
+        mc.token_capture.enabled = True
+        mc.data_plane.update(
+            {
+                "backend": "simple",
+                "checkpointing_enabled": False,
+            }
+        )
+
+        with pytest.raises(ValueError, match="token-capture checkpointing requires"):
+            setup_single_controller(mc, MagicMock(pad_token_id=0))
+
+    def test_rejects_token_capture_recovery_with_gated_sampler(self):
+        mc = _make_master_config()
+        mc.checkpointing["enabled"] = True
+        mc.token_capture.enabled = True
+        mc.data_plane.update(
+            {
+                "backend": "simple",
+                "checkpointing_enabled": True,
+            }
+        )
+
+        with pytest.raises(
+            NotImplementedError, match="replay-checkpoint-capable sampler"
         ):
             setup_single_controller(mc, MagicMock(pad_token_id=0))
 
@@ -517,6 +572,58 @@ class TestSetup:
 
 
 class TestNativeTQRecoverySetup:
+    def test_restores_rollout_ledger_bound_to_native_tq_metadata(self, tmp_path):
+        checkpoint_path = tmp_path / "step_3"
+        (checkpoint_path / DATA_PLANE_CHECKPOINT_DIR).mkdir(parents=True)
+        expected_ledger, digest = _write_recovery_sidecar(checkpoint_path)
+        metadata = {
+            "data_plane_checkpoint_schema_version": (
+                DATA_PLANE_CHECKPOINT_SCHEMA_VERSION
+            ),
+            "single_controller_train_steps": 3,
+            "single_controller_trainer_version": 3,
+            "single_controller_epoch": 1,
+            "partition_id": "rollout_data",
+            "sampler_name": "windowed",
+            "mode": "authoritative",
+            "rollout_recovery_schema_version": ROLLOUT_RECOVERY_SCHEMA_VERSION,
+            "rollout_recovery_payload_sha256": digest,
+            "rollout_recovery_group_count": 1,
+        }
+        policy = MagicMock()
+        policy.load_data_plane_checkpoint.return_value = metadata
+
+        restored_metadata = sc_setup_mod._maybe_restore_native_data_plane_checkpoint(
+            policy,
+            last_checkpoint_path=str(checkpoint_path),
+            save_state={"current_step": 3, "current_epoch": 1},
+            partition_id="rollout_data",
+            sampler_name="windowed",
+        )
+        restored_ledger = sc_setup_mod._maybe_restore_rollout_recovery_ledger(
+            last_checkpoint_path=str(checkpoint_path),
+            data_plane_checkpoint_metadata=restored_metadata,
+            token_capture_enabled=True,
+        )
+
+        assert restored_ledger is not None
+        assert restored_ledger.state_dict() == expected_ledger.state_dict()
+
+    def test_rejects_rollout_ledger_payload_digest_mismatch(self, tmp_path):
+        checkpoint_path = tmp_path / "step_3"
+        checkpoint_path.mkdir(parents=True)
+        _write_recovery_sidecar(checkpoint_path)
+
+        with pytest.raises(ValueError, match="sidecar digest does not match"):
+            sc_setup_mod._maybe_restore_rollout_recovery_ledger(
+                last_checkpoint_path=str(checkpoint_path),
+                data_plane_checkpoint_metadata={
+                    "rollout_recovery_payload_sha256": "wrong-digest",
+                    "rollout_recovery_group_count": 1,
+                },
+                token_capture_enabled=True,
+            )
+
     def test_setup_loads_tq_before_creating_single_controller_client(
         self, tmp_path, patched_factories
     ):
@@ -541,9 +648,7 @@ class TestNativeTQRecoverySetup:
         checkpointer.get_resume_paths.return_value = (None, None)
         mc = _make_master_config()
 
-        with patch.object(
-            sc_setup_mod, "CheckpointManager", return_value=checkpointer
-        ):
+        with patch.object(sc_setup_mod, "CheckpointManager", return_value=checkpointer):
             actor_args = setup_single_controller(mc, MagicMock(pad_token_id=0))
 
         assert events == ["load", "build"]

--- a/tests/unit/single_controller/test_tq_replay_buffer.py
+++ b/tests/unit/single_controller/test_tq_replay_buffer.py
@@ -260,6 +260,40 @@ class TestDataPlaneCheckpointBarrier:
 
         asyncio.run(exercise())
 
+    def test_nested_mutation_does_not_deadlock_with_waiting_checkpoint(self):
+        async def exercise() -> None:
+            barrier = DataPlaneCheckpointBarrier()
+            outer_entered = asyncio.Event()
+            allow_nested = asyncio.Event()
+            nested_entered = asyncio.Event()
+            checkpoint_entered = asyncio.Event()
+
+            async def mutate() -> None:
+                async with barrier.mutation():
+                    outer_entered.set()
+                    await allow_nested.wait()
+                    async with barrier.mutation():
+                        nested_entered.set()
+
+            async def checkpoint() -> None:
+                async with barrier.checkpoint():
+                    checkpoint_entered.set()
+
+            mutation_task = asyncio.create_task(mutate())
+            await outer_entered.wait()
+            checkpoint_task = asyncio.create_task(checkpoint())
+            await asyncio.sleep(0)
+            allow_nested.set()
+
+            await asyncio.wait_for(nested_entered.wait(), timeout=5.0)
+            assert not checkpoint_entered.is_set()
+            await asyncio.wait_for(
+                asyncio.gather(mutation_task, checkpoint_task), timeout=5.0
+            )
+            assert checkpoint_entered.is_set()
+
+        asyncio.run(exercise())
+
     def test_two_checkpoints_serialize_without_deadlock(self):
         async def exercise() -> None:
             barrier = DataPlaneCheckpointBarrier()


### PR DESCRIPTION
# What does this PR do?

Persists partial-rollout lineage with native TQ state and recovers it through the Single Controller restart lifecycle.

- Saves rollout lineage beside native TQ state, replay metadata, the dataloader cursor, and controller checkpoint metadata.
- Restores TQ through the bootstrap data-plane client before runtime consumers are constructed.
- Reconstructs finalized replay ownership from metadata while tensor payloads remain authoritative in TQ.
- Validates canonical rows, live staging ownership, receipt references, and lineage digest before recovery.
- Clears unreferenced staging rows and drops unfinished groups that are stale under the restored sampler policy.
- Reuses sealed siblings and redispatches only missing or abandoned generation indices.
- Applies bounded infrastructure retries during startup recovery.
- Resolves compact prompt references through the restored input stream rather than serializing large prompts.
- Makes the checkpoint barrier re-entrant.
- Runs restored recovery beside fresh dataloader dispatch after ownership and buffer permits are reconstructed; both share the bounded rollout-worker budget.

Frequent rollout-only snapshots are added by #3508.

## Stack

- Layer 2 of 4.
- Previous: #3506.
- Next: #3508.

## Recovery contract

1. Load the selected trainer checkpoint and native TQ snapshot.
2. Restore replay metadata, lineage, sampler state, and dataloader position.
3. Validate TQ inventory against finalized and unfinished ownership.
4. Reserve restored buffer capacity before fresh dispatch.
5. Recover unfinished groups concurrently with fresh work.
6. Reuse sealed siblings and redispatch only incomplete siblings.

The persisted controller sidecar remains metadata-only.

## Validation

- Unit coverage includes persistence, inventory validation, selective redispatch, finalizer replay, stale cleanup, capacity ownership, sampler restore, and recovery/fresh-dispatch overlap.
- The PR remains draft while the refreshed focused suite, recovery functionals, and full CI are rerun.
