### PR TITLE
fix(sglang): expose cfg on SGLangGeneration

### DIFF
--- a/nemo_rl/models/generation/sglang/sglang_generation.py
+++ b/nemo_rl/models/generation/sglang/sglang_generation.py
@@ -122,6 +122,17 @@ class SGLangGeneration(GenerationInterface):
         if init_handles:
             ray.get(init_handles)
 
+    @property
+    def cfg(self) -> SGLangConfig:
+        """Full generation config, matching the ``GenerationInterface`` contract.
+
+        ``sglang_cfg`` already is that config, so alias it rather than keep a
+        second reference. Backend-agnostic callers such as
+        ``nemo_rl.weight_sync.factory.create_weight_synchronizer`` read
+        ``generation.cfg`` regardless of backend.
+        """
+        return self.sglang_cfg
+
     # ------------------------------------------------------------------
     # Engine topology properties (formerly ``ServerGroup``)
     # ------------------------------------------------------------------

--- a/tests/unit/weight_sync/test_weight_synchronizer.py
+++ b/tests/unit/weight_sync/test_weight_synchronizer.py
@@ -444,6 +444,36 @@ class TestFactory:
         )
         assert isinstance(sync, HTTPWeightSynchronizer)
 
+    def test_colocated_sglang_accepts_real_generation_object(self):
+        """A real SGLangGeneration must expose ``cfg`` like the other backends.
+
+        ``create_weight_synchronizer`` reads ``generation.cfg`` before any
+        backend dispatch. The MagicMock double used above answers ``cfg``
+        automatically, so only the real class can catch a missing attribute.
+        """
+        from nemo_rl.models.generation.sglang.sglang_generation import (
+            SGLangGeneration,
+        )
+
+        # ``__new__`` skips ``__init__``, which would need Ray, a router and
+        # live engines; ``cfg`` only depends on ``sglang_cfg``.
+        gen = SGLangGeneration.__new__(SGLangGeneration)
+        gen.sglang_cfg = {"backend": "sglang", "model_name": "dummy"}
+        # ``__del__`` calls ``shutdown()``, which reads these four attributes.
+        gen.all_engines = []
+        gen._router_actor = None
+        gen._http_client = None
+        gen._async_loop = None
+        assert gen.cfg is gen.sglang_cfg
+
+        sync = create_weight_synchronizer(
+            policy=_mock_policy(),
+            generation=gen,
+            generation_backend=SGLANG_BACKEND,
+            colocated=True,
+        )
+        assert isinstance(sync, HTTPWeightSynchronizer)
+
     def test_colocated_megatron_returns_ipc(self):
         policy = _mock_policy()
         gen = _mock_generation()


### PR DESCRIPTION
## What does this PR do?

Adds a read-only `cfg` property to `SGLangGeneration`, aliasing its existing `sglang_cfg`.

`create_weight_synchronizer` reads `generation.cfg` before backend dispatch. Without this property, colocated SGLang raises `AttributeError` instead of constructing its `HTTPWeightSynchronizer`.

## Testing

- Added a CPU-only factory regression test using the real `SGLangGeneration` class
- Test passes locally
- `ruff check` and `ruff format` pass

## Issues

Found while investigating #3288. Draft PR #3330 contains the same property as part of a larger change.

cc @RayenTian @yuki-97
