### PR TITLE
draft: fix(nsys): make profiling work on SingleController and align throughput metrics

### DIFF
--- a/docs/nsys-profiling.md
+++ b/docs/nsys-profiling.md
@@ -45,8 +45,16 @@ Common additions:
 - `cuda-memory-usage`: track host/device memory allocations (`"true"`).
 - `cpuctxsw`: control CPU context-switch sampling (`"none"`, `"process-tree"`).
 
-Empty or unset means no extras — defaults apply unchanged. Invalid JSON or a non-object
-payload raises at startup so misconfiguration surfaces immediately.
+> [!WARNING]
+> `capture-range-end=stop-shutdown` ends the nsys session at the capture range,
+> which signals the profiled workers to exit -- the run stops at the profiled
+> step. Reports are finalized there instead of at process exit, so they survive
+> a later cancellation. The default `stop` keeps workers running but only writes
+> reports at process exit, losing them if the job is killed first.
+>
+> `gpu-metrics-device` is unsupported on some GPUs (e.g. GB200). Ray's nsight
+> plugin then fails validation with `RuntimeEnvSetupError`, dropping the traces
+> of whichever workers landed on a rejecting node.
 
 ### Pattern Format
 
@@ -116,7 +124,7 @@ When profiling is enabled, it generates the following logs and files:
    trtllm_async_generation_worker_<NRL_NSYS_PROFILE_STEP_RANGE>_<PID>.nsys-rep
    worker_process_<PID>.nsys-rep
    ```
-For TensorRT-LLM, the meaningful generation profiles are the per-internal-GPU-worker files (`trtllm_async_generation_worker_<NRL_NSYS_PROFILE_STEP_RANGE>_<PID>.nsys-rep`), one per GPU (replicas × TP). If you are not using model parallelism in Vllm, you should directly refer to `vllm_generation_worker_<NRL_NSYS_PROFILE_STEP_RANGE>_<PID>.nsys-rep` for nsight reports; If you are using model parallelism, nsight is NOT applied to the outer `VllmGenerationWorker` to avoid interfering with Ray's compiled DAG. Instead, `ray_workers_use_nsight` is enabled and vLLM's default nsight config is monkey-patched to use `capture-range=cudaProfilerApi` (deferred capture). This means the internal TP workers run under nsys with near-zero overhead until `start_gpu_profiling()` triggers `cudaProfilerStart()` on each worker via `collective_rpc`. The `vllm_tp_worker_<NRL_NSYS_PROFILE_STEP_RANGE>_<PID>.nsys-rep` files are the nsight profiles from the internal TP workers. (refer to https://github.com/vllm-project/vllm/blob/7e3a8dc90670fd312ce1e0d4eba9bf11c571e3ad/vllm/executor/ray_distributed_executor.py#L136 for more information).
+For TensorRT-LLM, the meaningful generation profiles are the per-internal-GPU-worker files (`trtllm_async_generation_worker_<NRL_NSYS_PROFILE_STEP_RANGE>_<PID>.nsys-rep`), one per GPU (replicas × TP). If you are not using model parallelism in Vllm, you should directly refer to `vllm_generation_worker_<NRL_NSYS_PROFILE_STEP_RANGE>_<PID>.nsys-rep` for nsight reports; If you are using model parallelism, nsight is NOT applied to the outer `VllmGenerationWorker` to avoid interfering with Ray's compiled DAG. The internal TP workers are not profiled either: vLLM hardcodes an always-on nsight config for them (no `capture-range`), which traces from process start and skews ranks until a collective trips the NCCL watchdog. Generation is covered by the outer worker's own `vllm_async_generation_worker_<NRL_NSYS_PROFILE_STEP_RANGE>_<PID>.nsys-rep` profiles instead. (refer to https://github.com/vllm-project/vllm/blob/7e3a8dc90670fd312ce1e0d4eba9bf11c571e3ad/vllm/executor/ray_distributed_executor.py#L136 for more information).
 
 3. **File Location**: Profile files are saved in `/tmp/ray/session*/logs/nsight/` directory on each worker node. Ensure you check both `ls /tmp/ray/session_[0-9]*/logs/nsight` and `ls /tmp/ray/session_latest/logs/nsight` for the profiles, since the "latest" pointer may be stale.
 

--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -1123,14 +1123,6 @@ def distillation_train(
                 master_config.cluster["num_nodes"]
                 * master_config.cluster["gpus_per_node"]
             )
-            metrics.update(
-                {
-                    "tokens_per_sec_per_gpu": metrics["total_num_tokens"]
-                    / total_time
-                    / total_num_gpus
-                }
-            )
-
             print(f"  • Total step time: {total_time:.2f}s", flush=True)
 
             # Display all other timing metrics
@@ -1141,10 +1133,19 @@ def distillation_train(
                     percent = (v / total_time * 100) if total_time > 0 else 0
                     print(f"  • {k}: {v:.2f}s ({percent:.1f}%)", flush=True)
 
-            timing_metrics["valid_tokens_per_sec_per_gpu"] = (
-                metrics["global_valid_toks"] / total_time / total_num_gpus
-            )
+            performance_metrics: dict[str, float] = {
+                "valid_tokens_per_sec_per_gpu": metrics["global_valid_toks"]
+                / total_time
+                / total_num_gpus
+            }
+            if "total_num_tokens" in metrics:
+                performance_metrics["tokens_per_sec_per_gpu"] = (
+                    metrics["total_num_tokens"] / total_time / total_num_gpus
+                )
             logger.log_metrics(metrics, total_steps + 1, prefix="train")
+            logger.log_metrics(
+                performance_metrics, total_steps + 1, prefix="performance"
+            )
             logger.log_metrics(timing_metrics, total_steps + 1, prefix="timing/train")
 
             timer.reset()

--- a/nemo_rl/algorithms/dpo.py
+++ b/nemo_rl/algorithms/dpo.py
@@ -788,10 +788,19 @@ def dpo_train(
                 master_config.cluster["num_nodes"]
                 * master_config.cluster["gpus_per_node"]
             )
-            timing_metrics["valid_tokens_per_sec_per_gpu"] = (
-                metrics["global_valid_toks"] / total_time / total_num_gpus
-            )
+            performance_metrics: dict[str, float] = {
+                "valid_tokens_per_sec_per_gpu": metrics["global_valid_toks"]
+                / total_time
+                / total_num_gpus
+            }
+            if "total_num_tokens" in metrics:
+                performance_metrics["tokens_per_sec_per_gpu"] = (
+                    metrics["total_num_tokens"] / total_time / total_num_gpus
+                )
             logger.log_metrics(metrics, total_steps + 1, prefix="train")
+            logger.log_metrics(
+                performance_metrics, total_steps + 1, prefix="performance"
+            )
             logger.log_metrics(timing_metrics, total_steps + 1, prefix="timing/train")
 
             timer.reset()

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -3593,11 +3593,11 @@ def grpo_train(
                     percent = (v / total_time * 100) if total_time > 0 else 0
                     print(f"  • {k}: {v:.2f}s ({percent:.1f}%)", flush=True)
 
-            timing_metrics["valid_tokens_per_sec_per_gpu"] = (
-                metrics["global_valid_toks"] / total_time / total_num_gpus
-            )
             performance_metrics = print_performance_metrics(
                 train_results, metrics, timing_metrics, master_config
+            )
+            performance_metrics["valid_tokens_per_sec_per_gpu"] = (
+                metrics["global_valid_toks"] / total_time / total_num_gpus
             )
 
             if refit_metrics:
@@ -5024,11 +5024,11 @@ def async_grpo_train(
                 master_config.cluster["num_nodes"]
                 * master_config.cluster["gpus_per_node"]
             )
-            timing_metrics["valid_tokens_per_sec_per_gpu"] = (
-                metrics["global_valid_toks"] / total_time / total_num_gpus
-            )
             performance_metrics = print_performance_metrics(
                 train_results, metrics, timing_metrics, master_config
+            )
+            performance_metrics["valid_tokens_per_sec_per_gpu"] = (
+                metrics["global_valid_toks"] / total_time / total_num_gpus
             )
 
             collector_efficiency = ray.get(

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -1338,11 +1338,11 @@ def grpo_train_sync(
                     percent = (v / total_time * 100) if total_time > 0 else 0
                     print(f"  • {k}: {v:.2f}s ({percent:.1f}%)", flush=True)
 
-            timing_metrics["valid_tokens_per_sec_per_gpu"] = (
-                metrics["global_valid_toks"] / total_time / total_num_gpus
-            )
             performance_metrics = print_performance_metrics(
                 train_results, metrics, timing_metrics, master_config
+            )
+            performance_metrics["valid_tokens_per_sec_per_gpu"] = (
+                metrics["global_valid_toks"] / total_time / total_num_gpus
             )
 
             logger.log_metrics(metrics, total_steps + 1, prefix="train")

--- a/nemo_rl/algorithms/ppo.py
+++ b/nemo_rl/algorithms/ppo.py
@@ -1660,18 +1660,18 @@ def ppo_train(
                     percent = (v / total_time * 100) if total_time > 0 else 0
                     print(f"  • {k}: {v:.2f}s ({percent:.1f}%)", flush=True)
 
-            if "global_valid_toks" in metrics:
-                timing_metrics["valid_tokens_per_sec_per_gpu"] = (
-                    metrics["global_valid_toks"] / total_time / total_num_gpus
-                    if total_time > 0
-                    else 0
-                )
             performance_metrics = print_performance_metrics(
                 train_results if train_results is not None else (value_results or {}),
                 metrics,
                 timing_metrics,
                 master_config,
             )
+            if "global_valid_toks" in metrics:
+                performance_metrics["valid_tokens_per_sec_per_gpu"] = (
+                    metrics["global_valid_toks"] / total_time / total_num_gpus
+                    if total_time > 0
+                    else 0
+                )
 
             logger.log_metrics(metrics, total_steps + 1, prefix="train")
             logger.log_metrics(

--- a/nemo_rl/algorithms/rm.py
+++ b/nemo_rl/algorithms/rm.py
@@ -711,10 +711,19 @@ def rm_train(
                 master_config.cluster["num_nodes"]
                 * master_config.cluster["gpus_per_node"]
             )
-            timing_metrics["valid_tokens_per_sec_per_gpu"] = (
-                metrics["global_valid_toks"] / total_time / total_num_gpus
-            )
+            performance_metrics: dict[str, float] = {
+                "valid_tokens_per_sec_per_gpu": metrics["global_valid_toks"]
+                / total_time
+                / total_num_gpus
+            }
+            if "total_num_tokens" in metrics:
+                performance_metrics["tokens_per_sec_per_gpu"] = (
+                    metrics["total_num_tokens"] / total_time / total_num_gpus
+                )
             logger.log_metrics(metrics, total_steps + 1, prefix="train")
+            logger.log_metrics(
+                performance_metrics, total_steps + 1, prefix="performance"
+            )
             logger.log_metrics(timing_metrics, total_steps + 1, prefix="timing/train")
 
             timer.reset()

--- a/nemo_rl/algorithms/sft.py
+++ b/nemo_rl/algorithms/sft.py
@@ -644,13 +644,21 @@ def sft_train(
                 master_config.cluster["num_nodes"]
                 * master_config.cluster["gpus_per_node"]
             )
+            performance_metrics: dict[str, float] = {}
             if total_time > 0:
-                timing_metrics["valid_tokens_per_sec_per_gpu"] = (
+                performance_metrics["valid_tokens_per_sec_per_gpu"] = (
                     metrics.get("global_valid_toks", 0) / total_time / total_num_gpus
                 )
+                if "total_num_tokens" in metrics:
+                    performance_metrics["tokens_per_sec_per_gpu"] = (
+                        metrics["total_num_tokens"] / total_time / total_num_gpus
+                    )
             else:
-                timing_metrics["valid_tokens_per_sec_per_gpu"] = 0.0
+                performance_metrics["valid_tokens_per_sec_per_gpu"] = 0.0
             logger.log_metrics(metrics, total_steps + 1, prefix="train")
+            logger.log_metrics(
+                performance_metrics, total_steps + 1, prefix="performance"
+            )
             logger.log_metrics(timing_metrics, total_steps + 1, prefix="timing/train")
 
             timer.reset()

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -65,6 +65,7 @@ from nemo_rl.models.generation.sglang.sglang_generation import SGLangGeneration
 from nemo_rl.models.generation.vllm import VllmGeneration
 from nemo_rl.models.policy.tq_policy import TQPolicy
 from nemo_rl.utils.logger import Logger
+from nemo_rl.utils.nsys import maybe_gpu_profile_step
 from nemo_rl.utils.timer import Timer
 
 Generation = Union[VllmGeneration, SGLangGeneration]
@@ -363,6 +364,17 @@ class SingleControllerActor:
         grpo_cfg = self._master_config.grpo
 
         while self._train_steps < grpo_cfg.max_num_steps:
+            # nsys wraps the matched workers with capture-range=cudaProfilerApi,
+            # so without this cudaProfilerStart the .nsys-rep files come out
+            # empty. Mirrors grpo.py's per-step hook; run off the event loop
+            # since start/stop_gpu_profiling is a blocking ray.get fan-out.
+            await asyncio.to_thread(
+                maybe_gpu_profile_step, self._trainer, self._train_steps + 1
+            )
+            await asyncio.to_thread(
+                maybe_gpu_profile_step, self._gen, self._train_steps + 1
+            )
+
             version_during_step = self._trainer_version
             groups_dispatched = 0
             min_sample_version = None
@@ -531,14 +543,16 @@ class SingleControllerActor:
 
             total_time = timing_metrics.get("total_step_time", 0.0)
             total_num_gpus = int(ray.cluster_resources().get("GPU", 0))
-            if (
-                total_time > 0
-                and total_num_gpus > 0
-                and "global_valid_toks" in step_metrics
-            ):
-                timing_metrics["valid_tokens_per_sec_per_gpu"] = (
-                    step_metrics["global_valid_toks"] / total_time / total_num_gpus
-                )
+            performance_metrics: dict[str, float] = {}
+            if total_time > 0 and total_num_gpus > 0:
+                if "global_valid_toks" in step_metrics:
+                    performance_metrics["valid_tokens_per_sec_per_gpu"] = (
+                        step_metrics["global_valid_toks"] / total_time / total_num_gpus
+                    )
+                if "total_num_tokens" in step_metrics:
+                    performance_metrics["tokens_per_sec_per_gpu"] = (
+                        step_metrics["total_num_tokens"] / total_time / total_num_gpus
+                    )
 
             print("\n⏱️  Timing:")
             print(f"  • Total step time: {total_time:.2f}s")
@@ -558,6 +572,9 @@ class SingleControllerActor:
             print(f"step_metrics={step_metrics}", flush=True)
             self._logger.log_metrics(
                 step_metrics, step=self._train_steps, prefix="train"
+            )
+            self._logger.log_metrics(
+                performance_metrics, step=self._train_steps, prefix="performance"
             )
             self._logger.log_metrics(
                 timing_metrics, step=self._train_steps, prefix="timing/train"

--- a/nemo_rl/data_plane/worker_mixin.py
+++ b/nemo_rl/data_plane/worker_mixin.py
@@ -182,6 +182,7 @@ class TQWorkerMixin:
         """Cross-DP forward pad target, minted by :meth:`TQPolicy._stamp_pad_seqlen`."""
         return int((meta.extra_info or {}).get(GLOBAL_FORWARD_PAD_SEQLEN, 0))
 
+    @wrap_with_nvtx_name("policy_worker/tq_fetch")
     def _fetch(
         self,
         meta: "KVBatchMeta",
@@ -409,6 +410,7 @@ class TQWorkerMixin:
 
         write_columns(self._require_dp_client(), meta, fields)
 
+    @wrap_with_nvtx_name("policy_worker/tq_write_back")
     def _write_back_result_field(
         self,
         meta: "KVBatchMeta",

--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -232,8 +232,9 @@ class BaseVllmGenerationWorker:
         else:
             # TP=1: profile the outer worker directly since it runs the engine in-process.
             # When TP>1, nsight is NOT applied here to avoid interfering with Ray's compiled
-            # DAG used by the internal vLLM TP workers. Instead, ray_workers_use_nsight is
-            # set in _create_engine_from_config to profile the internal workers.
+            # DAG used by the internal vLLM TP workers, and those internal workers are not
+            # profiled either (see _create_engine_from_config): vLLM's built-in nsight
+            # config traces from process start and trips the NCCL watchdog.
             runtime_env = get_nsight_config_if_pattern_matches("vllm_generation_worker")
 
         env_vars["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
@@ -460,14 +461,20 @@ class BaseVllmGenerationWorker:
             len(get_nsight_config_if_pattern_matches("vllm_generation_worker")) > 0
             and vllm_kwargs["distributed_executor_backend"] == "ray"
         ):
+            # Deliberately NOT setting ray_workers_use_nsight. vLLM hardcodes an
+            # always-on nsight config for its internal TP workers (no
+            # capture-range, so nsys traces cuda,cudnn,cublas from process start
+            # for the whole run). That overhead skews ranks until a collective
+            # blows the NCCL watchdog and aborts generation. vLLM offers no way
+            # to override it -- the config is built inside a spawned EngineCore
+            # process, out of reach of any in-process hook -- so the only safe
+            # option is to leave it off.
             logger.warning(
-                "Nsight profiling is enabled for vllm internal TP workers via ray_workers_use_nsight. "
-                "The outer VllmGenerationWorker is NOT profiled to avoid interfering with Ray's compiled DAG. "
-                "vLLM's default nsight config is overridden with capture-range=cudaProfilerApi so that "
-                "profiling is deferred until start_gpu_profiling() is called."
+                "Nsight profiling requested for vLLM, but the internal TP workers "
+                "are NOT profiled: vLLM's built-in nsight config traces from "
+                "process start and trips the NCCL watchdog. Generation is still "
+                "covered by the outer worker's own profile."
             )
-            vllm_kwargs["ray_workers_use_nsight"] = True
-            self._patch_vllm_nsight_config()
 
         # Call init_fp8 when precision is fp8
         # (kv_cache_dtype can be fp8/fp8_e4m3 or auto, validated in init_fp8)
@@ -711,43 +718,6 @@ class BaseVllmGenerationWorker:
                 spec_lookahead,
             )
         return max_new_tokens
-
-    @staticmethod
-    def _patch_vllm_nsight_config() -> None:
-        """Override vLLM's nsight config for internal TP workers to use deferred capture.
-
-        vLLM's default _configure_ray_workers_use_nsight applies an always-on nsight
-        config (no capture-range, cuda-graph-trace=node) which causes significant
-        overhead and hangs Ray's compiled DAG. This patch replaces it with NeMo RL's
-        lighter config that uses capture-range=cudaProfilerApi, deferring actual
-        tracing until start_gpu_profiling() triggers cudaProfilerStart() on each
-        internal worker via collective_rpc.
-        """
-        from nemo_rl.utils.nsys import NRL_NSYS_PROFILE_STEP_RANGE
-
-        nsight_config = {
-            "t": "cuda,cudnn,cublas,nvtx",
-            "o": f"'vllm_tp_worker_{NRL_NSYS_PROFILE_STEP_RANGE}_%p'",
-            "stop-on-exit": "true",
-            "s": "none",
-            "capture-range": "cudaProfilerApi",
-            "capture-range-end": "repeat",
-            "cuda-graph-trace": "node",
-        }
-
-        try:
-            from vllm.v1.executor.ray_executor import RayDistributedExecutor
-        except ImportError:
-            from vllm.executor.ray_distributed_executor import (
-                RayDistributedExecutor,
-            )
-
-        def _patched_configure(self, ray_remote_kwargs):
-            runtime_env = ray_remote_kwargs.setdefault("runtime_env", {})
-            runtime_env.update({"nsight": nsight_config})
-            return ray_remote_kwargs
-
-        RayDistributedExecutor._configure_ray_workers_use_nsight = _patched_configure
 
     def _get_raw_spec_counters(self) -> dict[str, float | list[float]]:
         """Get speculative decoding metrics from the vLLM engine.

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -2676,6 +2676,7 @@ class MegatronPolicyWorkerImpl(
             post_iter_func=lambda x: x[1].contiguous(),
         )
 
+    @wrap_with_nvtx_name("megatron_policy_worker/prepare_for_lp_inference")
     def prepare_for_lp_inference(self):
         self.model = self.move_model(self.model, "cuda", move_grads=False)
         self.model.eval()
@@ -2698,6 +2699,7 @@ class MegatronPolicyWorkerImpl(
         gc.collect()
         torch.cuda.empty_cache()
 
+    @wrap_with_nvtx_name("megatron_policy_worker/prepare_for_training")
     def prepare_for_training(self, *args, **kwargs):
         # onload models and optimizer state to cuda
         self.model = self.move_model(

--- a/nemo_rl/utils/nsys.py
+++ b/nemo_rl/utils/nsys.py
@@ -59,6 +59,22 @@ class ProfilablePolicy(Protocol):
     def stop_gpu_profiling(self) -> None: ...
 
 
+def _stop_gpu_profiling_best_effort(policy: ProfilablePolicy) -> None:
+    """Stop profiling without letting a profiling failure kill the run.
+
+    ``stop_gpu_profiling`` fans out via ``ray.get``; if nsys already tore the
+    workers down (``capture-range-end=stop-shutdown``) that raises
+    ``ActorDiedError`` and would abort training.
+    """
+    try:
+        policy.stop_gpu_profiling()
+    except Exception as e:
+        rich.print(
+            f"[bold yellow]Failed to stop GPU profiling for {policy} "
+            f"({type(e).__name__}: {e}); continuing.[/bold yellow]"
+        )
+
+
 def maybe_gpu_profile_step(policy: ProfilablePolicy, step: int):
     assert not (bool(NRL_NSYS_WORKER_PATTERNS) ^ bool(NRL_NSYS_PROFILE_STEP_RANGE)), (
         "Either both NRL_NSYS_WORKER_PATTERNS and NRL_NSYS_PROFILE_STEP_RANGE must be set, or neither. See https://github.com/NVIDIA/NeMo-RL/tree/main/docs/nsys-profiling.md for more details."
@@ -98,7 +114,7 @@ def maybe_gpu_profile_step(policy: ProfilablePolicy, step: int):
                 rich.print(
                     f"[bold red]Stopping GPU profiling on exit for {policy} for step {step}[/bold red]"
                 )
-                policy.stop_gpu_profiling()
+                _stop_gpu_profiling_best_effort(policy)
 
             atexit.register(stop_profiler_on_exit)
     else:
@@ -106,20 +122,15 @@ def maybe_gpu_profile_step(policy: ProfilablePolicy, step: int):
             rich.print(
                 f"[bold red]Stopping GPU profiling for {policy} for step {step}[/bold red]"
             )
-            policy.stop_gpu_profiling()
+            _stop_gpu_profiling_best_effort(policy)
             policy.__NRL_PROFILE_STARTED = False
 
 
 def wrap_with_nvtx_name(name: str):
-    """A decorator to wrap a function with an NVTX range with the given name."""
+    """A decorator to wrap a function with an NVTX range with the given name.
 
-    def decorator(func):
-        def wrapper(*args, **kwargs):
-            torch.cuda.nvtx.range_push(name)
-            ret = func(*args, **kwargs)
-            torch.cuda.nvtx.range_pop()
-            return ret
-
-        return wrapper
-
-    return decorator
+    ``torch.cuda.nvtx.range`` is a ContextDecorator that pops in a ``finally``,
+    so a raising call cannot leak an unbalanced range and mis-nest every later
+    range in the trace.
+    """
+    return torch.cuda.nvtx.range(name)


### PR DESCRIPTION
Profiling an SC + TransferQueue run produced empty traces, and enabling it on vLLM generation reliably killed the job.

nsys fixes
----------
1. `single_controller.py` never called `maybe_gpu_profile_step`. Every other algorithm entrypoint does (grpo, ppo, sft, dpo, rm, distillation). Since the nsight config uses `capture-range=cudaProfilerApi`, nsys attached but `cudaProfilerStart` was never issued, so every `.nsys-rep` came out empty.

2. Stop enabling `ray_workers_use_nsight` for vLLM. vLLM hardcodes an always-on nsight config for its internal TP workers (no `capture-range`), so nsys traced cuda,cudnn,cublas from process start for the whole run. That overhead skews ranks until a collective blows the NCCL watchdog: on a 6xGB200 SC run all 24 TP workers aborted on a 600s `_ALLGATHER_BASE` timeout on a 64K-element collective. vLLM offers no override -- the config is built inside a spawned EngineCore process -- so the only safe option is to leave the flag off. Generation is still covered by the outer worker's own profile.

3. Remove `_patch_vllm_nsight_config`, which tried to override that config by rebinding the class method. It cannot work: the rebind happens in the worker actor, while vLLM configures the executor in a spawned subprocess. Confirmed from the runtime-env agent logs of a run where it was active -- 18 workers received vLLM's default `worker_process_%p`, none the intended `vllm_tp_worker_*`. It was silently letting the harmful config through.

4. `stop_gpu_profiling` was unguarded, so a profiling teardown failure aborted the run at the diagnostic call rather than at real work. Now best-effort.

Adds NVTX ranges to the TransferQueue hops (`tq_fetch`, `tq_write_back`) and to `prepare_for_training` / `prepare_for_lp_inference`, which the SC loop calls every inner-loop iteration and which were invisible in traces. `wrap_with_nvtx_name` now delegates to `torch.cuda.nvtx.range`, a ContextDecorator that pops in a `finally`, so a raising call cannot leak an unbalanced range and mis-nest every later range in the trace.

Docs record two hardware traps: `stop-shutdown` ends the nsys session at the capture range, signalling the profiled workers to exit; and `gpu-metrics-device` is unsupported on some GPUs (GB200), where Ray's nsight plugin fails validation and silently drops the traces of workers that landed on a rejecting node.

metrics alignment
-----------------
Throughput rates were split across three namespaces: `timing/train/` (8 algorithms), `performance/` (3, via `print_performance_metrics`) and `train/` (distillation). `timing/train/` also mixed rates with durations, so its printout formatted tokens/sec as seconds.

All rates now live under `performance/`, leaving `timing/train/` for durations:

  performance/valid_tokens_per_sec_per_gpu   global_valid_toks / step / gpus
  performance/tokens_per_sec_per_gpu         total_num_tokens  / step / gpus

Both keys are present in all 8 algorithms; five gained a `prefix="performance"` log call. Duplicates removed (distillation's `train/` copy, and a redundant metric with the same formula as the helper's existing key). Per-algorithm guard conditions are preserved -- this is a namespace move, not a behaviour change.

BREAKING: `timing/train/valid_tokens_per_sec_per_gpu` is now `performance/valid_tokens_per_sec_per_gpu`. Dashboards keyed on the old path need updating; historical runs keep the old key.

Verified on 6xGB200 (SC + TQ, Nemotron-3-Nano-30B-A3B): 24/24 GPUs produced valid non-empty traces (16 trainer + 8 generation, 0.67 GB), zero NCCL watchdog timeouts, and the teardown guard fired as designed.

# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
