### PR TITLE
feat(generation): add heterogeneous vLLM server groups for NeMo Gym

### DIFF
--- a/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
+++ b/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
@@ -265,6 +265,21 @@ policy:
       resources:
         gpus_per_node: null # Decides num gpus to be dedicated to generation when there is one node in the cluster i.e cluster.num_nodes == 1
         num_nodes: null # Decides number of nodes to be dedicated to generation
+    # Optional heterogeneous replica groups (requires colocated.enabled=false).
+    # Group gpus must sum to the colocated.resources budget; overrides are
+    # deep-merged onto this generation config. Example:
+    # server_groups:
+    #   - name: low_latency
+    #     gpus: 2
+    #     overrides:
+    #       vllm_cfg: { tensor_parallel_size: 1 }
+    #       vllm_kwargs: { max_num_seqs: 16 }
+    #   - name: high_throughput
+    #     gpus: 4
+    #     overrides:
+    #       vllm_cfg: { tensor_parallel_size: 4 }
+    #       vllm_kwargs: { max_num_seqs: 512 }
+    server_groups: null
 
 data:
   # The complete trajectory is managed by gym, which will pass the entire thing to vllm.

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -109,6 +109,10 @@ from nemo_rl.models.generation.vllm.config import (
     VLLM_SPARSE_REFIT_TRANSPORTS,
     normalize_vllm_refit_config,
 )
+from nemo_rl.models.generation.vllm.multi_group import (
+    MultiVllmGeneration,
+    build_group_configs,
+)
 from nemo_rl.models.megatron.router_replay import (
     configure_vllm_for_router_replay,
     router_replay_enabled,
@@ -599,6 +603,24 @@ def setup(
     )
     nemo_gym_actor = None
 
+    use_server_groups = bool(generation_config.get("server_groups"))
+    if use_server_groups:
+        assert generation_config["backend"] == "vllm", (
+            "policy.generation.server_groups requires the vLLM backend"
+        )
+        assert enable_nemo_gym, (
+            "policy.generation.server_groups is only supported with NeMo Gym"
+        )
+        assert not colocated_inference, (
+            "policy.generation.server_groups requires colocated.enabled=false"
+        )
+        assert generation_config.get("refit_transport") is None, (
+            "policy.generation.server_groups requires refit_transport=null"
+        )
+        assert cluster_config.get("segment_size") is None, (
+            "policy.generation.server_groups does not support cluster.segment_size"
+        )
+
     def _spinup_nemo_gym(base_urls, model_name):
         """Spin up the NeMo Gym actor against the given generation server URLs."""
         t0 = time.perf_counter()
@@ -888,32 +910,65 @@ def setup(
             flush=True,
         )
 
-        # Create inference cluster with topology constraints so TP groups
-        # stay within NVLink domains. Eagerly initialize PGs when constraints
-        # are set so inference claims domain-aligned nodes first.
-        inference_cluster = RayVirtualCluster(
-            name="grpo_inference_cluster",
-            bundle_ct_per_node_list=[inference_gpus_per_node] * inference_nodes,
-            use_gpus=True,
-            num_gpus_per_node=inference_gpus_per_node,
-            max_colocated_worker_groups=1,
-            port_range_low=cluster_config.get("master_port_range_low"),
-            port_range_high=cluster_config.get("master_port_range_high"),
-            segment_size=inference_segment_size,
-            node_resource_constraints=inference_node_resource_constraints,
-        )
-        if inference_node_resource_constraints is not None:
-            {
-                "vllm": VllmGeneration,
-                "trtllm": TrtllmGeneration,
-            }[generation_config["backend"]].init_cluster_placement_groups(
-                inference_cluster,
-                generation_config,
+        if use_server_groups:
+            server_groups = generation_config["server_groups"]
+            assert (
+                sum(g["gpus"] for g in server_groups)
+                == inference_nodes * inference_gpus_per_node
+            ), (
+                f"server_groups GPUs {[g['gpus'] for g in server_groups]} must sum to "
+                f"the inference budget {inference_nodes}x{inference_gpus_per_node} "
+                "(policy.generation.colocated.resources)"
             )
-        print(
-            f"  ✓ Ray inference cluster initialized with {inference_nodes} nodes with {inference_gpus_per_node} GPUs per node",
-            flush=True,
-        )
+            inference_clusters: dict[str, RayVirtualCluster] = {}
+            for group in server_groups:
+                group_name, group_gpus = group["name"], group["gpus"]
+                assert group_gpus <= inference_gpus_per_node, (
+                    f"server_group '{group_name}': groups must fit in one node "
+                    f"({group_gpus} > {inference_gpus_per_node})"
+                )
+                inference_clusters[group_name] = RayVirtualCluster(
+                    name=f"grpo_inference_{group_name}",
+                    bundle_ct_per_node_list=[group_gpus],
+                    use_gpus=True,
+                    num_gpus_per_node=group_gpus,
+                    max_colocated_worker_groups=1,
+                    port_range_low=cluster_config.get("master_port_range_low"),
+                    port_range_high=cluster_config.get("master_port_range_high"),
+                )
+                print(
+                    f"  ✓ Ray inference cluster for server group '{group_name}' "
+                    f"initialized with {group_gpus} GPUs",
+                    flush=True,
+                )
+            inference_cluster = None
+        else:
+            # Create inference cluster with topology constraints so TP groups
+            # stay within NVLink domains. Eagerly initialize PGs when constraints
+            # are set so inference claims domain-aligned nodes first.
+            inference_cluster = RayVirtualCluster(
+                name="grpo_inference_cluster",
+                bundle_ct_per_node_list=[inference_gpus_per_node] * inference_nodes,
+                use_gpus=True,
+                num_gpus_per_node=inference_gpus_per_node,
+                max_colocated_worker_groups=1,
+                port_range_low=cluster_config.get("master_port_range_low"),
+                port_range_high=cluster_config.get("master_port_range_high"),
+                segment_size=inference_segment_size,
+                node_resource_constraints=inference_node_resource_constraints,
+            )
+            if inference_node_resource_constraints is not None:
+                {
+                    "vllm": VllmGeneration,
+                    "trtllm": TrtllmGeneration,
+                }[generation_config["backend"]].init_cluster_placement_groups(
+                    inference_cluster,
+                    generation_config,
+                )
+            print(
+                f"  ✓ Ray inference cluster initialized with {inference_nodes} nodes with {inference_gpus_per_node} GPUs per node",
+                flush=True,
+            )
 
     # Reserve topology-aware teacher placement groups before NeMo Gym starts
     # opportunistically placing its GPU-backed services. Worker creation and
@@ -1195,11 +1250,19 @@ def setup(
                 "  ⚡ Deferred model load: reserving vLLM ports for overlapped NeMo Gym init",
                 flush=True,
             )
-            deferred_vllm = VllmGeneration(
-                cluster=inference_cluster,
-                config=generation_config,
-                defer_model_load=True,
-            )
+            group_configs = build_group_configs(generation_config)
+            if group_configs is not None:
+                deferred_vllm = MultiVllmGeneration(
+                    inference_clusters,
+                    group_configs,
+                    defer_model_load=True,
+                )
+            else:
+                deferred_vllm = VllmGeneration(
+                    cluster=inference_cluster,
+                    config=generation_config,
+                    defer_model_load=True,
+                )
             print(
                 f"  ✓ Reserved {len(deferred_vllm.dp_openai_server_base_urls)} vLLM server URLs: "
                 f"{deferred_vllm.dp_openai_server_base_urls}",

--- a/nemo_rl/models/generation/vllm/config.py
+++ b/nemo_rl/models/generation/vllm/config.py
@@ -144,6 +144,8 @@ class VllmRefitConfig(BaseModel, extra="allow"):
 class VllmConfig(GenerationConfig):
     vllm_cfg: VllmSpecificArgs
     vllm_kwargs: NotRequired[dict[str, Any]]
+    # [{name, gpus, overrides: {vllm_cfg, vllm_kwargs}}], see vllm/multi_group.py
+    server_groups: NotRequired[list[dict[str, Any]] | None]
     # Null uses the topology default (IPC colocated, NCCL non-colocated).
     # Built-ins select sparse delta over S3/ZeroMQ or NIXL.
     # A custom checkpoint engine may use a ``module:ClassName`` selector.

--- a/nemo_rl/models/generation/vllm/multi_group.py
+++ b/nemo_rl/models/generation/vllm/multi_group.py
@@ -1,0 +1,172 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""N named VllmGeneration replica groups of one policy behind one interface.
+
+Groups get disjoint GPUs (one RayVirtualCluster each) and heterogeneous
+``vllm_cfg``/``vllm_kwargs`` overrides; refit joins them into the single
+train+inference NCCL broadcast world via per-group ``rank_offset``.
+v1 scope: GRPO + NeMo Gym, non-colocated, default NCCL refit.
+"""
+
+import copy
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Optional, cast
+
+import ray
+
+from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
+from nemo_rl.models.generation.interfaces import GenerationInterface
+from nemo_rl.models.generation.vllm.config import VllmConfig
+from nemo_rl.models.generation.vllm.vllm_generation import VllmGeneration
+
+_OVERRIDABLE_KEYS = {"vllm_cfg", "vllm_kwargs"}
+_FORBIDDEN_VLLM_CFG_KEYS = {"async_engine", "expose_http_server", "max_model_len"}
+
+
+def _merge(base: dict[str, Any], patch: dict[str, Any]) -> dict[str, Any]:
+    out = dict(base)
+    for key, value in patch.items():
+        out[key] = (
+            _merge(base[key], value)
+            if isinstance(base.get(key), dict) and isinstance(value, dict)
+            else value
+        )
+    return out
+
+
+def build_group_configs(
+    generation_config: VllmConfig,
+) -> Optional[dict[str, VllmConfig]]:
+    """Build one merged VllmConfig per server group; None when unconfigured.
+
+    Call after setup() has finished mutating the generation config
+    (model_name, hf_overrides, router replay) so the copies inherit it.
+    """
+    groups = generation_config.get("server_groups")
+    if not groups:
+        return None
+    names = [g["name"] for g in groups]
+    assert len(set(names)) == len(names), f"duplicate server_group names: {names}"
+    base = {k: v for k, v in generation_config.items() if k != "server_groups"}
+    configs: dict[str, VllmConfig] = {}
+    for g in groups:
+        overrides = g.get("overrides") or {}
+        assert set(overrides) <= _OVERRIDABLE_KEYS, (
+            f"server_group '{g['name']}': only {sorted(_OVERRIDABLE_KEYS)} may be "
+            f"overridden, got {sorted(overrides)}"
+        )
+        forbidden = set(overrides.get("vllm_cfg", {})) & _FORBIDDEN_VLLM_CFG_KEYS
+        assert not forbidden, (
+            f"server_group '{g['name']}': may not override {sorted(forbidden)}"
+        )
+        assert "max_model_len" not in overrides.get("vllm_kwargs", {}), (
+            f"server_group '{g['name']}': max_model_len must be uniform across groups"
+        )
+        configs[g["name"]] = cast(VllmConfig, _merge(copy.deepcopy(base), overrides))
+    return configs
+
+
+class MultiVllmGeneration(GenerationInterface):
+    """Pure fan-out over named VllmGeneration groups; generation goes over HTTP."""
+
+    def __init__(
+        self,
+        clusters: dict[str, RayVirtualCluster],
+        configs: dict[str, VllmConfig],
+        defer_model_load: bool = False,
+    ):
+        self.groups = {
+            name: VllmGeneration(
+                clusters[name],
+                cfg,
+                name_prefix=f"vllm_{name}",
+                defer_model_load=defer_model_load,
+            )
+            for name, cfg in configs.items()
+        }
+        self.cfg = next(iter(configs.values()))
+
+    @property
+    def dp_openai_server_base_urls(self) -> list[Optional[str]]:
+        return [
+            url for g in self.groups.values() for url in g.dp_openai_server_base_urls
+        ]
+
+    def init_collective(
+        self, ip: str, port: int, world_size: int, *, train_world_size: int
+    ) -> list[ray.ObjectRef]:
+        futures: list[ray.ObjectRef] = []
+        rank_offset = 0
+        for g in self.groups.values():
+            futures += g.init_collective(
+                ip,
+                port,
+                world_size,
+                train_world_size=train_world_size,
+                rank_offset=rank_offset,
+            )
+            rank_offset += len(g.worker_group.workers)
+        return futures
+
+    def prepare_refit_info(self, state_dict_info: dict[str, Any]) -> None:
+        for g in self.groups.values():
+            g.prepare_refit_info(state_dict_info)
+
+    def update_weights_from_collective(self) -> list[ray.ObjectRef]:
+        return [
+            f for g in self.groups.values() for f in g.update_weights_from_collective()
+        ]
+
+    def load_and_start(self) -> None:
+        with ThreadPoolExecutor(max_workers=len(self.groups)) as executor:
+            list(executor.map(lambda g: g.load_and_start(), self.groups.values()))
+
+    def prepare_for_generation(self, *args: Any, **kwargs: Any) -> bool:
+        return all(
+            [g.prepare_for_generation(*args, **kwargs) for g in self.groups.values()]
+        )
+
+    def finish_generation(self, *args: Any, **kwargs: Any) -> bool:
+        return all([g.finish_generation(*args, **kwargs) for g in self.groups.values()])
+
+    def shutdown(self) -> bool:
+        return all([g.shutdown() for g in self.groups.values()])
+
+    def clear_logger_metrics(self) -> None:
+        for g in self.groups.values():
+            g.clear_logger_metrics()
+
+    def get_logger_metrics(self) -> dict[str, Any]:
+        return {
+            f"{name}/{k}": v
+            for name, g in self.groups.items()
+            for k, v in g.get_logger_metrics().items()
+        }
+
+    def start_gpu_profiling(self) -> None:
+        for g in self.groups.values():
+            g.start_gpu_profiling()
+
+    def stop_gpu_profiling(self) -> None:
+        for g in self.groups.values():
+            g.stop_gpu_profiling()
+
+    @property
+    def requires_kv_scale_sync(self) -> bool:
+        return any(g.requires_kv_scale_sync for g in self.groups.values())
+
+    def generate(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError(
+            "MultiVllmGeneration serves generation over HTTP (NeMo Gym) only"
+        )

--- a/nemo_rl/models/generation/vllm/vllm_generation.py
+++ b/nemo_rl/models/generation/vllm/vllm_generation.py
@@ -584,9 +584,19 @@ class VllmGeneration(GenerationInterface):
         return step_metrics
 
     def init_collective(
-        self, ip: str, port: int, world_size: int, *, train_world_size: int
+        self,
+        ip: str,
+        port: int,
+        world_size: int,
+        *,
+        train_world_size: int,
+        rank_offset: int = 0,
     ) -> list[ray.ObjectRef]:
-        """Initialize the collective communication."""
+        """Initialize the collective communication.
+
+        ``rank_offset`` shifts the rank prefixes so multiple generation groups
+        can join one broadcast world (see multi_group.MultiVllmGeneration).
+        """
         if not self.worker_group or not self.worker_group.workers:
             raise RuntimeError("Worker group is not initialized")
 
@@ -604,7 +614,9 @@ class VllmGeneration(GenerationInterface):
                 "Data parallel size is zero, cannot initialize collective."
             )
         workers_per_group = total_workers // self.dp_size
-        rank_prefix_list = list(range(0, total_workers, workers_per_group))
+        rank_prefix_list = [
+            rank_offset + r for r in range(0, total_workers, workers_per_group)
+        ]
 
         # Send world_size and rank for init collective to all workers
         futures = self.worker_group.run_all_workers_multiple_data(

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -181,6 +181,7 @@ project-includes = [
   "nemo_rl/models/generation/vllm/checkpoint_engine.py",
   "nemo_rl/models/generation/vllm/collective_rpc.py",
   "nemo_rl/models/generation/vllm/config.py",
+  "nemo_rl/models/generation/vllm/multi_group.py",
   "nemo_rl/models/generation/vllm/patches.py",
   "nemo_rl/models/generation/vllm/quantization/fp8_train_utils.py",
   "nemo_rl/models/generation/vllm/quantization/mxfp8_utils.py",


### PR DESCRIPTION
## Summary

Adds optional heterogeneous vLLM server groups for NeMo Gym. Each named group gets a disjoint GPU budget and may override only `vllm_cfg` and `vllm_kwargs`; the existing GRPO/Gym lifecycle and refit path remain unchanged.

Without `policy.generation.server_groups`, the default path is unchanged and no multi-group code runs. With groups enabled, their HTTP endpoints are flattened into the existing NeMo Gym `policy_base_url` list.

## Configuration

Example:

```yaml
policy:
  generation:
    colocated:
      enabled: false
      resources: {gpus_per_node: 6, num_nodes: 1}
    server_groups:
      - name: low_latency
        gpus: 2
        overrides:
          vllm_cfg: {tensor_parallel_size: 1}
          vllm_kwargs: {max_num_seqs: 16}
      - name: high_throughput
        gpus: 4
        overrides:
          vllm_cfg: {tensor_parallel_size: 4}
          vllm_kwargs: {max_num_seqs: 512}
```

All groups inherit the common model, context length, HTTP-server, and refit settings. Groups join one NCCL broadcast world using disjoint rank ranges, so one refit updates every group.

## Reproduction

1. Check out this PR in a NeMo RL v0.7.0 Enroot/container environment and mount the repository into the container:

```bash
git clone https://github.com/NVIDIA-NeMo/RL.git
cd RL
git fetch origin pull/3520/head:pr-3520
git checkout pr-3520
```

2. From inside the container, submit the driver through the cluster's normal Ray/Slurm launcher. The driver command is:

```bash
export VLLM_ALLOW_INSECURE_SERIALIZATION=1
python -u examples/nemo_gym/run_grpo_nemo_gym.py \
  --config examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml \
  policy.model_name=Qwen/Qwen3-0.6B \
  cluster.gpus_per_node=4 \
  cluster.num_nodes=3 \
  policy.generation.colocated.resources.gpus_per_node=4 \
  policy.generation.colocated.resources.num_nodes=2 \
  'policy.generation.server_groups=[{name:low_latency,gpus:4,overrides:{vllm_cfg:{tensor_parallel_size:1},vllm_kwargs:{max_num_seqs:16}}},{name:high_throughput,gpus:4,overrides:{vllm_cfg:{tensor_parallel_size:4},vllm_kwargs:{max_num_seqs:512}}}]'
```

This uses Qwen/Qwen3-0.6B, the official Workplace Assistant dataset, two GRPO steps, four training GPUs, and eight inference GPUs across three GB200 nodes. The effective groups are `low_latency` (TP=1, four replicas) and `high_throughput` (TP=4, one replica), for five HTTP endpoints.

## Validation

Job 12674 completed with exit code 0.

- Both server-group Ray inference clusters initialized.
- Five vLLM HTTP endpoints were reserved; all five `/tokenize` probes passed.
- The TP=1 and TP=4 engines both initialized, and the step 1 → step 2 NCCL refit completed successfully.
- Refit timings were 0.89 s and 0.85 s.
- A non-fatal aiohttp event-loop warning was printed during final teardown after successful completion.

Raw validation artifacts: [GitHub Gist](https://gist.github.com/aoshen02/d0e43ef52715f8d068db699e30dc1565)

## Scope

v1 supports GRPO + NeMo Gym, the vLLM backend, non-colocated inference, the default NCCL refit transport, no `cluster.segment_size`, and groups that each fit within one node. Same-node port contention is handled by the existing bind-retry behavior.

## Checks

- Config merge, override rejection, URL concatenation, and per-group rank offsets were verified with local ad-hoc tests.
- `ruff@0.9.9 check/format`: clean.
- `pyrefly@0.24.2`: 0 errors.
- Duplicate check: no open PR implementing heterogeneous vLLM server groups was found.

AI-assisted (Claude); every changed line was reviewed by the submitter.