### PR TITLE
docs: fold nemo-rl-testing-agent sweep learnings back into the skills

### DIFF
--- a/.agents/contributor-skills/megatron-pr-fix-delivery/SKILL.md
+++ b/.agents/contributor-skills/megatron-pr-fix-delivery/SKILL.md
@@ -45,6 +45,11 @@ git commit -s -m "fix: follow megatron-core InferenceConfig rename in the mcore 
   routinely carry unrelated work in progress; commit only the fix files, and
   restore the original working state afterwards.
 - `-s` (DCO sign-off) is mandatory in all three repos.
+- Push over ssh — `git push git@github.com:NVIDIA-NeMo/<repo>.git <branch>`. The
+  https remote a plain clone hands you is refused with a 403 and a SAML SSO
+  authorization prompt, and it only surfaces at push time, after the fix is
+  committed. That 403 is the org's SSO enforcement, not missing write access;
+  `gh` API calls (comments, issues, `pr create`) go through either way.
 - The subject must be [Conventional Commits](../contributing/SKILL.md); the
   `semantic-pull-request` check enforces it on the PR title.
 - Commit only the fix. Ledger files, results JSON, and scratch logs live outside

--- a/.agents/contributor-skills/megatron-pr-reporting/SKILL.md
+++ b/.agents/contributor-skills/megatron-pr-reporting/SKILL.md
@@ -77,6 +77,14 @@ seen any of the logs:
   `Megatron InferenceConfig rename; needs NVIDIA-NeMo/RL#2931 (draft) merged.`
 - **`not run`** — why, and what would unblock it.
 
+When one root cause claims several tests — which is the normal shape when a
+dependency breaks at import — write the explanation once and have each cell
+point at it, rather than repeating a paragraph down every row. Put the shared
+part in the report note under the table and keep the cells to what differs.
+`post_tracking_issue.py` already groups rows by known-issue id and renders each
+diagnosis once below; a table where every row carries the same eighty words is
+one nobody reads, including the author it was written for.
+
 Also flag the checkout caveat here when it applies: if the PR changed
 `setup.py`, `pyproject.toml`, or native sources, the run used the image's
 prebuilt dependencies and extensions (see

--- a/.agents/contributor-skills/megatron-pr-test-run/SKILL.md
+++ b/.agents/contributor-skills/megatron-pr-test-run/SKILL.md
@@ -137,6 +137,15 @@ first if you changed anything in the wiring.
 Budget roughly 1.5–3 h per suite, plus queue time. The `batch` partition MaxTime
 is `04:00:00`; use `batch_long` via `--time` only if a suite genuinely needs it.
 
+Jobs go out under the QOS named by `COG_SLURM_QOS`, which `run_suite.sh` echoes
+back as `QOS=` so a run always records the one it used. cog takes it from the
+environment rather than an argument, so it never appears in the submitted command
+line. Do not submit on the cluster default: it is a far lower scheduling priority
+than the interactive one for an identical request, which on a busy day is the
+difference between starting in seconds and waiting many hours. The interactive
+caps — 4 nodes and 8 jobs per user — fit L1's 1 node and L2's 2, but jobs under it
+are preemptible, so a suite that disappears mid-run is infra, not a result.
+
 **Before the job queues, cog re-syncs the workspace**, and that step dominates
 the wall clock when anything in the repo changed: it hashes ~1500 tracked and
 untracked files and ships them one by one, which over a high-latency link can
@@ -183,6 +192,7 @@ Re-submit (do not report, do not attempt a fix) when the log shows:
 | `NRLTA_PREP_FAIL` | Revision checkout or the megatron import guard failed. |
 | `QOSMinGRES` / "violates accounting policy" | Job asked for less than a whole node. |
 | `srun: error`, `slurmstepd: ... CANCELLED / TIME LIMIT` | Preemption, node failure, or a too-short `--time`. |
+| `PENDING` for hours with `Reason=Priority` and `StartTime=Unknown` | Usually the QOS, not a full cluster. Compare `scontrol show job <id>` against a job that scheduled quickly: an identical request on a lower-priority QOS can sit behind hundreds of jobs with no slot even planned. Fix `COG_SLURM_QOS` and re-submit rather than waiting. |
 | `nemo-gym references a workspace ... not a workspace member` | Ran from the synced workspace instead of `/opt/nemo-rl`. |
 | `status: incomplete` on the last test only | Job hit the time limit mid-test. |
 | `[ERROR] HF_TOKEN is not set` | Tokens file not sourced before submit. |
@@ -231,7 +241,13 @@ Fix attempts and baselines only need the failing tests:
 ```
 
 Use a fresh `--run-name` per attempt (`-a1`, `-a2`, …) so artifacts and logs are
-never overwritten and the ledger can point at each one.
+never overwritten and the ledger can point at each one. `run_suite.sh` refuses a
+name it has already submitted under, so on a resumed sweep — where the attempt
+that spent `-a1` happened in a session you no longer remember — read the error
+and bump the suffix rather than reaching for `--reuse-run-name`. The two runs
+would otherwise be different revisions sharing one artifact directory, and
+`ensure_baseline.sh` parses a run with `cat <slurm_log_dir>/*.out`, which
+concatenates both into a single results JSON with no way to tell them apart.
 
 Local edits under `nemo_rl/`, `tests/`, or `examples/` are only picked up in
 worktree mode: add `--nemo-rl-ref worktree --allow-dirty` to a fix-attempt re-run,
@@ -239,6 +255,15 @@ or the job will test the integration branch and your edit will not be there. A f
 inside Megatron-LM or Megatron-Bridge is different again: it must be pushed to a
 branch and tested by pointing `--mcore-ref` at that branch (see
 [megatron-pr-fix-delivery](../megatron-pr-fix-delivery/SKILL.md)).
+
+Edits to the agent's own scripts travel by a different route again, and it is the
+one that silently does nothing. cog ships the checkout named by
+`NEMO_RL_REPO_PATH`, not the directory you are working in, and both
+`prep_container.sh` and `run_suite_remote.sh` execute from that synced copy. If
+the two are different clones, every edit to either script stops reaching the
+cluster with no error to show for it. Diff those scripts between your working
+checkout and `NEMO_RL_REPO_PATH` before the first submit of a sweep, or point the
+config key at the checkout you actually edit.
 
 ## When a run teaches you something this skill does not say
 

--- a/.agents/contributor-skills/run-functional-tests-cog/SKILL.md
+++ b/.agents/contributor-skills/run-functional-tests-cog/SKILL.md
@@ -63,6 +63,12 @@ accounts `coreai_dlalgo_llm`, import partition `cpu`. NGC enroot creds exist at
   `cluster.gpus_per_node=2` (the extra GPUs sit idle; this still matches CI's
   2-GPU behaviour).
 - `batch` partition: default + MaxTime checks; use `--time 02:00:00`.
+- QOS: cog has no flag for it and reads `COG_SLURM_QOS` from the environment, so
+  export it before submitting. Left unset, the job lands on the cluster default,
+  a much lower scheduling priority than `interactive` for the same request — one
+  pair of jobs sat pending 14 hours that way while identical `interactive` ones
+  started in seconds. `interactive` allows 4 nodes and 8 jobs per user and is
+  preemptible.
 
 ## Secrets / tokens
 
@@ -94,11 +100,12 @@ for this internal cluster, but do not log it to shared files.
 
 ```bash
 # 0. Sanity: profile resolves to nemo_rl + image = nightly
-cog profile --repo ~/RL --run-name nemo-rl-l1-mcore4 --cluster-name oci-hsg
+export COG_SLURM_QOS=interactive
+cog profile --repo ~/temp/RL --run-name nemo-rl-l1-mcore4 --cluster-name oci-hsg
 
 # 1. One-time per image: import the nightly sqsh (~50 GB, ~60 min on cpu).
 #    Cached afterwards (cache_hit: true returns instantly).
-cog prepare-image --repo ~/RL --cluster-name oci-hsg
+cog prepare-image --repo ~/temp/RL --cluster-name oci-hsg
 
 # 2. Submit the functional test. Run it from the image's /opt/nemo-rl, NOT the
 #    synced workspace. Why: NeMo-RL's uv workspace includes member `nemo-gym`,
@@ -112,7 +119,7 @@ cog prepare-image --repo ~/RL --cluster-name oci-hsg
 #    /opt/nemo-rl for uv to resolve the full workspace). The container rootfs is
 #    a writable ephemeral overlay, so the copy is fine.
 cog submit \
-  --repo ~/RL \
+  --repo ~/temp/RL \
   --cluster-name oci-hsg \
   --run-name nemo-rl-l1-mcore4 \
   --command 'mkdir -p /opt/nemo-rl/tests/functional && cp -rf tests/functional/. /opt/nemo-rl/tests/functional/ && cp -f tests/*.py /opt/nemo-rl/tests/ 2>/dev/null || true; cd /opt/nemo-rl && bash tests/functional/L1_Functional_Tests_Megatron_4.sh' \
@@ -132,7 +139,7 @@ The illegal-memory-access is the **first** sub-test, so the L1 script aborts
 there anyway. To iterate faster, target just that script:
 
 ```bash
-cog submit --repo ~/RL --cluster-name oci-hsg --run-name nemo-rl-mcore-gen \
+cog submit --repo ~/temp/RL --cluster-name oci-hsg --run-name nemo-rl-mcore-gen \
   --command 'cp -rf tests/functional/. /opt/nemo-rl/tests/functional/; cd /opt/nemo-rl && uv run --no-sync bash ./tests/functional/grpo_megatron_generation.sh' \
   --gpus 4 --nodes 1 --ntasks-per-node 1 --partition batch --time 01:00:00
 ```
@@ -168,8 +175,8 @@ running, e.g. extend the command with
 persistent allocation (avoids re-queuing each time):
 
 ```bash
-cog session start --repo ~/RL --session-handle nrl-dbg --gpus 4 --time 04:00:00 --partition batch
-cog session exec --session-handle nrl-dbg --repo ~/RL \
+cog session start --repo ~/temp/RL --session-handle nrl-dbg --gpus 4 --time 04:00:00 --partition batch
+cog session exec --session-handle nrl-dbg --repo ~/temp/RL \
   --command 'cp -rf tests/functional/. /opt/nemo-rl/tests/functional/ && cp -rf nemo_rl/. /opt/nemo-rl/nemo_rl/; cd /opt/nemo-rl && bash tests/functional/L1_Functional_Tests_Megatron_4.sh' \
   --wait-timeout 3600
 cog session stop --session-handle nrl-dbg

--- a/.agents/contributor-skills/run-nano35-megatron-inference-cog/SKILL.md
+++ b/.agents/contributor-skills/run-nano35-megatron-inference-cog/SKILL.md
@@ -13,11 +13,17 @@ loading the existing Megatron dist-checkpoint instead of converting from HF.
 ## Cog and cluster prerequisites
 
 - Use `cog` from `~/cog` with the NeMo-RL repo profile installed. The profile
-  must resolve `~/RL` to the prebuilt `nvcr.io/nvidian/nemo-rl:nightly` image
+  must resolve `~/temp/RL` to the prebuilt `nvcr.io/nvidian/nemo-rl:nightly` image
   and reuse `/opt/nemo_rl_venv`; do not build a new image or venv.
 - Use the registered `oci-hsg` cluster. Its GB200 nodes are aarch64 and have
   4 GPUs per node. The QOS requires whole-node GPU allocations, so always pass
   `--gpus 4`, including jobs that use fewer GPUs internally.
+- `export COG_SLURM_QOS=interactive` before submitting. cog has no flag for the
+  QOS and reads that variable from the environment; left unset the job lands on
+  the cluster default, a much lower scheduling priority for the same request —
+  one pair of jobs sat pending 14 hours that way while identical `interactive`
+  ones started in seconds. `interactive` allows 4 nodes and 8 jobs per user, so
+  the 2-node Ray layout below fits, and it is preemptible.
 - Run NeMo-RL commands from `/opt/nemo-rl`, which contains the complete
   submodules and consistent environment. The synced workspace has empty
   `3rdparty` submodule directories; copy local `examples/` and `nemo_rl/`
@@ -104,10 +110,10 @@ already MTP-stripped.
 
 ```bash
 # 0. Sanity: profile resolves to nemo_rl + image = nightly
-cog profile --repo ~/RL --run-name nano35-mcore-gen --cluster-name oci-hsg
+cog profile --repo ~/temp/RL --run-name nano35-mcore-gen --cluster-name oci-hsg
 
 # 1. One-time per image: import the nightly sqsh (cached afterwards).
-cog prepare-image --repo ~/RL --cluster-name oci-hsg
+cog prepare-image --repo ~/temp/RL --cluster-name oci-hsg
 
 # 2. Mount the llmservice checkpoint tree (weights + HF config/tokenizer) into
 #    the container. cog only auto-mounts the coreai scratch root, so export this
@@ -133,7 +139,7 @@ MODEL_DIR=/lustre/fsw/portfolios/llmservice/users/ksanthanam/nemotron-3.5-nano-s
 HF_DIR=/lustre/fsw/portfolios/llmservice/users/dmosallanezh/nemo-evaluator-rundirs/nano_v35/conversions/geshen_ultra_rl_v5_kd600_step30_fixedpath_20260520_1130/hf
 
 cog submit \
-  --repo ~/RL \
+  --repo ~/temp/RL \
   --cluster-name oci-hsg \
   --run-name nano35-mcore-gen \
   --gpus 4 --nodes 1 --ntasks-per-node 1 \
@@ -231,7 +237,7 @@ export COG_EXTRA_MOUNTS='/lustre/fsw/portfolios/llmservice/users/ksanthanam:/lus
 MODEL_DIR=/lustre/fsw/portfolios/llmservice/users/ksanthanam/nemotron-3.5-nano-swe-step25/without_mtp
 HF_DIR=/lustre/fsw/portfolios/llmservice/users/dmosallanezh/nemo-evaluator-rundirs/nano_v35/conversions/geshen_ultra_rl_v5_kd600_step30_fixedpath_20260520_1130/hf
 
-cog submit --repo ~/RL --cluster-name oci-hsg --run-name ray-2node-nano35-math \
+cog submit --repo ~/temp/RL --cluster-name oci-hsg --run-name ray-2node-nano35-math \
   --gpus 4 --nodes 2 --ntasks-per-node 1 --partition batch --time 01:30:00 --job-name ray2node-nano35 \
   --launcher ray \
   --setup-command 'cp -rf examples/. /opt/nemo-rl/examples/ 2>/dev/null || true; cp -rf nemo_rl/. /opt/nemo-rl/nemo_rl/ 2>/dev/null || true' \
@@ -314,7 +320,7 @@ export COG_EXTRA_MOUNTS='/lustre/fsw/portfolios/llmservice/users/ksanthanam:/lus
 MODEL_DIR=/lustre/fsw/portfolios/llmservice/users/ksanthanam/nemotron-3.5-nano-swe-step25/without_mtp
 HF_DIR=/lustre/fsw/portfolios/llmservice/users/dmosallanezh/nemo-evaluator-rundirs/nano_v35/conversions/geshen_ultra_rl_v5_kd600_step30_fixedpath_20260520_1130/hf
 
-cog submit --repo ~/RL --cluster-name oci-hsg --run-name nano35-mcore-noncolo \
+cog submit --repo ~/temp/RL --cluster-name oci-hsg --run-name nano35-mcore-noncolo \
   --gpus 4 --nodes 2 --ntasks-per-node 1 --partition batch --time 02:00:00 --job-name nano35-noncolo \
   --launcher ray \
   --setup-command 'cp -rf examples/. /opt/nemo-rl/examples/ 2>/dev/null || true; cp -rf nemo_rl/. /opt/nemo-rl/nemo_rl/ 2>/dev/null || true' \
@@ -388,7 +394,7 @@ export COG_EXTRA_MOUNTS='/lustre/fsw/portfolios/llmservice/users/ksanthanam:/lus
 MODEL_DIR=/lustre/fsw/portfolios/llmservice/users/ksanthanam/nemotron-3.5-nano-swe-step25/without_mtp
 HF_DIR=/lustre/fsw/portfolios/llmservice/users/dmosallanezh/nemo-evaluator-rundirs/nano_v35/conversions/geshen_ultra_rl_v5_kd600_step30_fixedpath_20260520_1130/hf
 
-cog submit --repo ~/RL --cluster-name oci-hsg --run-name nano35-async-mxfp8 \
+cog submit --repo ~/temp/RL --cluster-name oci-hsg --run-name nano35-async-mxfp8 \
   --gpus 4 --nodes 2 --ntasks-per-node 1 --partition batch --time 04:00:00 --job-name nano35-async-mxfp8 \
   --launcher ray \
   --setup-command 'cp -rf examples/. /opt/nemo-rl/examples/ 2>/dev/null || true; cp -rf nemo_rl/. /opt/nemo-rl/nemo_rl/ 2>/dev/null || true' \
@@ -780,8 +786,8 @@ llmservice path with the cluster (or start the session from a scratch-local copy
 of the checkpoint) if you go the session route:
 
 ```bash
-cog session start --repo ~/RL --session-handle nano35 --gpus 4 --time 04:00:00 --partition batch
-cog session exec --session-handle nano35 --repo ~/RL \
+cog session start --repo ~/temp/RL --session-handle nano35 --gpus 4 --time 04:00:00 --partition batch
+cog session exec --session-handle nano35 --repo ~/temp/RL \
   --command 'cp -rf examples/. /opt/nemo-rl/examples/; cd /opt/nemo-rl && uv run --no-sync python examples/nemo_gym/run_grpo_nemo_gym.py --config examples/nemo_gym/grpo_nanov3.yaml ...same overrides...' \
   --wait-timeout 3600
 cog session stop --session-handle nano35

--- a/.agents/nemo-rl-testing-agent/config.env
+++ b/.agents/nemo-rl-testing-agent/config.env
@@ -51,6 +51,15 @@ L2_SUITE=tests/functional/L2_Functional_Tests_Megatron_4.sh
 COG_CLUSTER=oci-hsg
 COG_PARTITION=batch
 CLUSTER_SSH_ALIAS=oci
+# cog has no --qos flag; it reads this name straight out of the environment, and
+# lib.sh exports everything here, so setting it is enough. Worth setting: the
+# default `normal` QOS has priority 100 against `interactive`'s 700, and on a busy
+# day that is the difference between starting in seconds and sitting 14h behind
+# ~850 higher-priority jobs with no slot even planned. Identical resource request
+# either way. Stay inside the interactive caps (4 nodes and 8 jobs per user, which
+# fit L1's 1 node and L2's 2) and expect preemption -- interactive jobs do get
+# killed mid-run, which shows up as an infra failure and needs a re-submit.
+COG_SLURM_QOS=interactive
 # oci-hsg QOS requires whole-node GPU jobs, so this is always 4 on GB200.
 GPUS_PER_NODE=4
 # L1 is single-node; L2 is a 2-node `--launcher ray` job (1 gen + 1 train node).
@@ -88,7 +97,11 @@ NANO35_HF_DIR=/lustre/fsw/portfolios/llmservice/users/dmosallanezh/nemo-evaluato
 L2_EXTRA_MOUNTS=/lustre/fsw/portfolios/llmservice/users/ksanthanam:/lustre/fsw/portfolios/llmservice/users/ksanthanam,/lustre/fsw/portfolios/llmservice/users/dmosallanezh:/lustre/fsw/portfolios/llmservice/users/dmosallanezh
 
 # --- Local ---------------------------------------------------------------------
-NEMO_RL_REPO_PATH=$HOME/RL
+# The checkout cog syncs to the cluster. `prep_container.sh` and
+# `run_suite_remote.sh` execute from that synced copy, so this must be the same
+# checkout the agent tooling is edited in -- when it pointed at a second clone,
+# edits to either script stopped reaching the cluster with nothing to show for it.
+NEMO_RL_REPO_PATH=$HOME/temp/RL
 # One KEY=value per line; provides HF_TOKEN, WANDB_API_KEY, GITHUB_TOKEN, ...
 TOKENS_FILE=/Users/shanmugamr@nvidia.com/tokens
 # Per-PR ledger, cog logs, and results JSON live here (outside the repo).

--- a/.agents/nemo-rl-testing-agent/scripts/ensure_baseline.sh
+++ b/.agents/nemo-rl-testing-agent/scripts/ensure_baseline.sh
@@ -28,6 +28,15 @@
 #
 # Usage:
 #   ensure_baseline.sh --suite l1 [--force] [--max-age-hours N] [--print-only]
+#                      [--bridge-ref <ref>]
+#
+#   --bridge-ref <ref>   Passed through to run_suite.sh. Needed while a raised but
+#                        unmerged Megatron-Bridge fix is what stands between the
+#                        suite and a usable baseline: a Bridge fix does not ride the
+#                        NeMo-RL integration branch, so without this the baseline
+#                        keeps recording a break that every PR run has already
+#                        worked around, and attribution silently reads off a stack
+#                        nobody is testing against.
 
 set -euo pipefail
 # shellcheck source=lib.sh
@@ -37,6 +46,7 @@ suite=""
 force=0
 print_only=0
 max_age_hours=24
+bridge_ref=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -44,6 +54,7 @@ while [[ $# -gt 0 ]]; do
     --force) force=1; shift ;;
     --print-only) print_only=1; shift ;;
     --max-age-hours) max_age_hours="$2"; shift 2 ;;
+    --bridge-ref) bridge_ref="$2"; shift 2 ;;
     *) nrlta_die "unknown argument: $1" ;;
   esac
 done
@@ -88,11 +99,16 @@ run_name="nrlta-baseline-${suite}-$(date -u +%Y%m%d-%H%M)"
 nrlta_log "running ${suite} baseline against ${MEGATRON_BASE_BRANCH} (${main_sha:0:8}) as ${run_name}"
 
 # A baseline is a normal suite run whose revision under test happens to be main.
-"${NRLTA_SCRIPT_DIR}/run_suite.sh" \
-  --suite "${suite}" \
-  --mcore-ref "refs/heads/${MEGATRON_BASE_BRANCH}" \
-  --mcore-sha "${main_sha}" \
-  --run-name "${run_name}" || nrlta_log "baseline run exited non-zero (expected when tests fail)"
+baseline_args=(
+  --suite "${suite}"
+  --mcore-ref "refs/heads/${MEGATRON_BASE_BRANCH}"
+  --mcore-sha "${main_sha}"
+  --run-name "${run_name}"
+)
+[[ -n "${bridge_ref}" ]] && baseline_args+=(--bridge-ref "${bridge_ref}")
+
+"${NRLTA_SCRIPT_DIR}/run_suite.sh" "${baseline_args[@]}" \
+  || nrlta_log "baseline run exited non-zero (expected when tests fail)"
 
 slurm_log_dir="${CLUSTER_RUNS_ROOT}/${run_name}/slurm"
 combined="${STATE_DIR}/runs/${run_name}/combined.log"

--- a/.agents/nemo-rl-testing-agent/scripts/post_tracking_issue.py
+++ b/.agents/nemo-rl-testing-agent/scripts/post_tracking_issue.py
@@ -157,24 +157,45 @@ def render(
         "| Test | Status | Assessment |",
         "| --- | --- | --- |",
     ]
+    # One registry entry routinely claims every test in the suite, so writing its
+    # diagnosis into each row turned the table into the same paragraph repeated
+    # seven times. Reference it from the row and write it out once below.
+    diagnoses: dict[str, str] = {}
     for test in tests:
         status = test.get("status", "unknown")
         icon = ICONS.get(status, "❔")
+        issue_id = test.get("known_issue")
         if status == "pass":
             assessment = "—"
         elif test.get("known_issue_stale"):
             assessment = (
                 "**Regressed after its fix was already applied. Needs investigation.**"
             )
-        elif test.get("known_issue"):
-            assessment = (test.get("comment") or "Known issue.").strip()
-            if "](http" not in assessment:
-                assessment += " **No fix raised yet.**"
+        elif issue_id:
+            diagnosis = (test.get("comment") or "Known issue.").strip()
+            if "](http" not in diagnosis:
+                diagnosis += " **No fix raised yet.**"
+            diagnoses.setdefault(issue_id, diagnosis)
+            assessment = f"Known issue `{issue_id}` (see below)."
         else:
             assessment = "**Not yet diagnosed.**"
         if test.get("metric_failure"):
             assessment = f"{test['metric_failure']}. {assessment}"
         lines.append(f"| `{test.get('name', '?')}` | {icon} {status} | {assessment} |")
+
+    if diagnoses:
+        lines += ["", "### Diagnoses", ""]
+        for issue_id, diagnosis in diagnoses.items():
+            affected = [
+                t.get("name", "?") for t in tests if t.get("known_issue") == issue_id
+            ]
+            lines += [
+                f"**`{issue_id}`** — {len(affected)} test(s): "
+                + ", ".join(f"`{name}`" for name in affected),
+                "",
+                diagnosis,
+                "",
+            ]
 
     if any(test.get("status") == "pass (suspect)" for test in tests):
         lines += [

--- a/.agents/nemo-rl-testing-agent/scripts/run_suite.sh
+++ b/.agents/nemo-rl-testing-agent/scripts/run_suite.sh
@@ -39,7 +39,11 @@
 #                        that requires a clean tree unless --allow-dirty is given.
 #   --allow-dirty        Permit `--nemo-rl-ref worktree` with uncommitted changes,
 #                        recording the diff alongside the run.
-#   --run-name <name>    cog run name (default nrlta-<suite>-<utc-stamp>).
+#   --run-name <name>    cog run name (default nrlta-<suite>-<utc-stamp>). Must be
+#                        unique per submission; re-using one is refused unless
+#                        --reuse-run-name is passed.
+#   --reuse-run-name     Submit under a run name that has already been used,
+#                        knowingly overwriting its artifacts.
 #   --tests "a b"        Run only these sub-tests (used by the fix loop).
 #   --time HH:MM:SS      Override the suite's Slurm time limit.
 #   --dry-run            Print the cog invocation without submitting.
@@ -58,6 +62,7 @@ bridge_ref=""
 nemo_rl_ref=""
 allow_dirty=0
 run_name=""
+reuse_run_name=0
 only_tests=""
 time_limit=""
 dry_run=0
@@ -71,6 +76,7 @@ while [[ $# -gt 0 ]]; do
     --nemo-rl-ref) nemo_rl_ref="$2"; shift 2 ;;
     --allow-dirty) allow_dirty=1; shift ;;
     --run-name) run_name="$2"; shift 2 ;;
+    --reuse-run-name) reuse_run_name=1; shift ;;
     --tests) only_tests="$2"; shift 2 ;;
     --time) time_limit="$2"; shift 2 ;;
     --dry-run) dry_run=1; shift ;;
@@ -82,17 +88,6 @@ done
 [[ -n "${mcore_ref}" ]] || nrlta_die "--mcore-ref is required"
 nrlta_require MEGATRON_CLONE_URL COG_CLUSTER COG_PARTITION GPUS_PER_NODE \
   CONTAINER_ROOT CONTAINER_MCORE_DIR CLUSTER_ARTIFACTS_ROOT NEMO_RL_REPO_PATH STATE_DIR
-
-# Default the Bridge pin to whatever this NeMo-RL checkout points at. Pairing a
-# current megatron-core with the image's older Bridge breaks every test at import.
-if [[ -z "${bridge_ref}" ]]; then
-  bridge_ref="$(git -C "${NEMO_RL_REPO_PATH}" rev-parse "HEAD:${BRIDGE_SUBMODULE_PATH}" 2>/dev/null || true)"
-  [[ -n "${bridge_ref}" ]] || nrlta_die \
-    "could not read the Megatron-Bridge pin at ${BRIDGE_SUBMODULE_PATH} from ${NEMO_RL_REPO_PATH}; pass --bridge-ref explicitly"
-fi
-if [[ "${bridge_ref}" == "image" ]]; then
-  bridge_ref=""
-fi
 
 case "${suite}" in
   l1)
@@ -118,6 +113,21 @@ run_name="${run_name:-nrlta-${suite}-$(date -u +%Y%m%d-%H%M%S)}"
 artifact_dir="${CLUSTER_ARTIFACTS_ROOT}/${run_name}"
 local_run_dir="${STATE_DIR}/runs/${run_name}"
 cog_log="${local_run_dir}/cog.log"
+
+# The run name is the identity of one submission: it names the artifact directory
+# the per-test logs are written to and the run directory the slurm .out files land
+# in. Re-using it puts two revisions' logs in one place, and nothing downstream can
+# separate them -- ensure_baseline.sh parses with `cat <slurm_log_dir>/*.out`, which
+# would concatenate both into a single results JSON. The prose said to use a fresh
+# name per attempt long before this guard existed and a resumed sweep still re-used
+# `-a1`, because the operator picking the name is not the one who knows it was
+# already spent. So it is checked rather than documented.
+if [[ -e "${cog_log}" && "${reuse_run_name}" -eq 0 && "${dry_run}" -eq 0 ]]; then
+  nrlta_die "$(printf '%s\n' \
+    "run name '${run_name}' was already used (${cog_log} exists)." \
+    "Bump the attempt suffix (-a1 -> -a2) so this submission gets its own artifacts," \
+    "or pass --reuse-run-name to overwrite the previous one knowingly.")"
+fi
 mkdir -p "${local_run_dir}"
 
 # Resolve which NeMo-RL is under test. Default to the integration branch: it is
@@ -159,6 +169,28 @@ else
       "If this is the integration branch, create it with sync_integration.sh first," \
       "or pass --nemo-rl-ref worktree to test the local checkout.")"
   fi
+fi
+
+# Default the Bridge pin to the one the NeMo-RL *under test* points at, which is
+# the combination NeMo-RL ships. Pairing a current megatron-core with a Bridge
+# from anywhere else breaks every test deep inside Bridge and reads as the
+# author's bug. This has to run after the NeMo-RL revision is resolved, and has
+# to read the pin out of that revision rather than out of the local checkout's
+# HEAD: those are different commits whenever the operator is on a branch, so
+# reading HEAD silently made the Bridge under test a property of the working tree
+# instead of the run.
+if [[ -z "${bridge_ref}" ]]; then
+  if [[ "${nemo_rl_ref}" == "worktree" ]]; then
+    bridge_ref="$(git -C "${NEMO_RL_REPO_PATH}" rev-parse "HEAD:${BRIDGE_SUBMODULE_PATH}" 2>/dev/null || true)"
+  else
+    git -C "${NEMO_RL_REPO_PATH}" fetch -q "${nemo_rl_url}" "${nemo_rl_ref}" 2>/dev/null || true
+    bridge_ref="$(git -C "${NEMO_RL_REPO_PATH}" ls-tree "${nemo_rl_sha}" "${BRIDGE_SUBMODULE_PATH}" 2>/dev/null | awk '{print $3}')"
+  fi
+  [[ -n "${bridge_ref}" ]] || nrlta_die \
+    "could not read the Megatron-Bridge pin at ${BRIDGE_SUBMODULE_PATH} from ${nemo_rl_sha}; pass --bridge-ref explicitly"
+fi
+if [[ "${bridge_ref}" == "image" ]]; then
+  bridge_ref=""
 fi
 
 nrlta_load_tokens
@@ -234,6 +266,14 @@ echo "NEMO_RL_SHA=${nemo_rl_sha}"
 echo "ARTIFACT_DIR=${artifact_dir}"
 echo "SLURM_LOG_DIR=${CLUSTER_RUNS_ROOT}/${run_name}/slurm"
 echo "COG_LOG=${cog_log}"
+# cog picks the QOS up from the environment rather than an argument, so it is
+# invisible in the submitted command line. Record it, and say so when it is
+# missing: the fallback is the cluster default, which is where a run silently
+# turns into a multi-hour queue wait for no visible reason.
+echo "QOS=${COG_SLURM_QOS:-<cluster default>}"
+if [[ -z "${COG_SLURM_QOS:-}" ]]; then
+  nrlta_log "COG_SLURM_QOS is unset; this job inherits the cluster's default QOS and may queue for hours"
+fi
 
 if [[ "${dry_run}" -eq 1 ]]; then
   printf 'cog'

--- a/.agents/nemo-rl-testing-agent/tests/test_run_suite_guards.sh
+++ b/.agents/nemo-rl-testing-agent/tests/test_run_suite_guards.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Exercises run_suite.sh's refusal to submit twice under one run name.
+#
+# The rule was prose in megatron-pr-test-run for a long time and a resumed sweep
+# still re-used a name, because the run that spent it happened in an earlier
+# session. Two revisions then shared one artifact directory, which nothing
+# downstream can undo: ensure_baseline.sh parses a run with `cat *.out`. So the
+# rule is enforced in the script, and enforcement gets a test. Run after touching
+# the guard:
+#
+#   bash .agents/nemo-rl-testing-agent/tests/test_run_suite_guards.sh
+
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${here}/../scripts/run_suite.sh"
+ROOT=/tmp/nrlta-run-suite-test
+CONFIG="${ROOT}/config.env"
+GUARD_TEXT="was already used"
+
+failures=0
+
+reset_fixture() {
+  rm -rf "${ROOT}"
+  mkdir -p "${ROOT}/state"
+  # Inherit the real config, then redirect the state dir and point the clone URLs
+  # at paths that cannot resolve. The guard runs before any ref lookup, so the
+  # unresolvable URLs make the no-guard cases fail fast and offline instead of
+  # reaching for the network or, worse, for cog.
+  {
+    echo "source '${here}/../config.env'"
+    echo "STATE_DIR='${ROOT}/state'"
+    echo "NEMO_RL_CLONE_URL='${ROOT}/nonexistent.git'"
+    echo "NEMO_RL_FORK_URL='${ROOT}/nonexistent.git'"
+  } > "${CONFIG}"
+}
+
+spend_run_name() { # name
+  mkdir -p "${ROOT}/state/runs/$1"
+  touch "${ROOT}/state/runs/$1/cog.log"
+}
+
+run_suite() { # extra args...
+  NRLTA_CONFIG="${CONFIG}" bash "${SCRIPT}" \
+    --suite l1 --mcore-ref refs/heads/main "$@" 2>&1
+}
+
+check_guard_fires() { # description, args...
+  local desc="$1"; shift
+  local out rc
+  out="$(run_suite "$@")" && rc=0 || rc=$?
+  if [ "${rc}" -eq 0 ]; then
+    echo "FAIL: ${desc}: expected a non-zero exit"
+    printf '%s\n' "${out}" | sed 's/^/    /'
+    failures=$((failures + 1))
+    return
+  fi
+  if ! printf '%s' "${out}" | grep -q "${GUARD_TEXT}"; then
+    echo "FAIL: ${desc}: output missing '${GUARD_TEXT}'"
+    printf '%s\n' "${out}" | sed 's/^/    /'
+    failures=$((failures + 1))
+    return
+  fi
+  echo "ok: ${desc}"
+}
+
+check_guard_silent() { # description, args...
+  local desc="$1"; shift
+  local out
+  out="$(run_suite "$@")"
+  if printf '%s' "${out}" | grep -q "${GUARD_TEXT}"; then
+    echo "FAIL: ${desc}: the guard fired when it should not have"
+    printf '%s\n' "${out}" | sed 's/^/    /'
+    failures=$((failures + 1))
+    return
+  fi
+  echo "ok: ${desc}"
+}
+
+reset_fixture
+check_guard_silent "an unused run name submits" --run-name nrlta-fresh-l1-a1
+
+reset_fixture
+spend_run_name nrlta-spent-l1-a1
+check_guard_fires "a run name that already has a cog.log is refused" \
+  --run-name nrlta-spent-l1-a1
+
+# The override exists for the rare deliberate overwrite, and has to keep working
+# or the guard becomes something to route around by editing the script.
+reset_fixture
+spend_run_name nrlta-spent-l1-a1
+check_guard_silent "--reuse-run-name overrides the refusal" \
+  --run-name nrlta-spent-l1-a1 --reuse-run-name
+
+# A dry run submits nothing, so refusing it would only obstruct inspecting what a
+# previous attempt did.
+reset_fixture
+spend_run_name nrlta-spent-l1-a1
+check_guard_silent "--dry-run is never refused" \
+  --run-name nrlta-spent-l1-a1 --dry-run
+
+# The default name is a UTC stamp, which collides only if two submits land in the
+# same second; it must not be refused on a clean state dir.
+reset_fixture
+check_guard_silent "the default run name is not refused"
+
+rm -rf "${ROOT}"
+
+echo
+if [ "${failures}" -eq 0 ]; then
+  echo "run_suite guards: all checks passed"
+else
+  echo "run_suite guards: ${failures} check(s) failed"
+fi
+exit $(( failures > 0 ))

--- a/.claude/agents/nemo-rl-testing-agent.md
+++ b/.claude/agents/nemo-rl-testing-agent.md
@@ -68,6 +68,10 @@ the next.
 
 ```
 Once per sweep:
+- [ ] Run the agent's own tests once — they fail loudly if `uv` cannot provide
+      the interpreter the repo pins, which breaks every helper script, not just
+      the tests. Fix it with `uv self update` then `uv python install <version>`
+      before anything else; a repo Python bump outruns an older `uv`.
 - [ ] `sync_integration.sh` — rebuild NeMo-RL `main` + fixes already in review
 - [ ] `known_issues.py refresh` — retire entries whose fix has merged
 - [ ] `ensure_baseline.sh` per suite — a fresh megatron-core `main` baseline
@@ -125,6 +129,12 @@ Once the sweep is done:
 - **Never make a test pass by weakening it.** No loosened thresholds, deleted
   assertions, skipped tests, or shrunken workloads. If that is the only path,
   report it as a finding for the author to decide.
+- **Hours pending is a diagnosis, not weather.** Cluster jobs go out under the
+  QOS named in `config.env`, and `run_suite.sh` echoes it back as `QOS=`. A job
+  sitting on `Reason=Priority` with no planned start usually means the wrong QOS
+  rather than a full cluster: an identical request on the default one can queue
+  behind hundreds of jobs. Compare it against a job that scheduled quickly before
+  settling in to wait.
 - **Never report a result you did not verify.** The prep step proves that
   `import megatron.core` resolves to the revision under test; if that guard
   fails, the run is void.


### PR DESCRIPTION
Corrections the nemo-rl-testing-agent owes its own instructions after the
2026-08-05 sweep over the `NemoRLTest`-labeled Megatron-LM PRs (#5382, #6226,
#6222). One PR per sweep rather than per learning, since these are small
correlated edits.

Each entry below is a queue entry from `learnings.py`, and every hunk in the
diff corresponds to one. Skill prose is edited in place rather than appended to.

## Queue

- **bridge-pin-read-from-working-tree** — Resolve the Bridge pin from the NeMo-RL revision under test, not from the local checkout's HEAD; those differ whenever the operator is on a branch, which makes the Bridge a property of the working tree instead of the run and silently breaks comparability between runs. This also fixes an ordering constraint: the Bridge default can only be computed after the NeMo-RL revision has been resolved. Worktree mode is the one case where reading local HEAD is correct.
  - Trigger: Two runs a day apart pinned different Megatron-Bridge shas for the same NeMo-RL revision under test, because the pin was read from the local checkout's HEAD and the operator had switched checkouts.
  - Applied to: `.agents/nemo-rl-testing-agent/scripts/run_suite.sh`
- **run-name-reuse-mixes-two-revisions** — Run names must be unique per submission, not per PR: suffix the attempt (…-a1, -a2) and bump it on every re-submit, including after a branch update. Before re-using a name, check whether CLUSTER_RUNS_ROOT/<name>/slurm already holds .out files. This matters beyond tidiness because ensure_baseline.sh parses with 'cat <slurm_log_dir>/*.out' -- with two jobs in one directory that concatenates two revisions into one results JSON, and parse_results.py has no way to tell them apart. When parsing by hand, always name the specific job's .out.
  - Trigger: A resumed sweep re-submitted PR 6226's L1 under the run name nrlta-pr6226-l1-a1, which an earlier attempt had already used against a different head (ebfaa7eb vs the updated 0b57f670). Both jobs' slurm .out files landed in the same run directory and both wrote the same artifact dir, so the per-test logs of one revision silently overwrote the other's.
  - Applied to: `.agents/contributor-skills/megatron-pr-test-run/SKILL.md`
- **sso-blocks-https-push-for-fix-branches** — Push agent fix branches to the NVIDIA-NeMo repos over ssh (git push git@github.com:NVIDIA-NeMo/<repo>.git <branch>), not the https remote a plain clone gives you. gh api calls (comments, issues, pr create) are unaffected -- only git push over https is. Do not read the 403 as missing write access.
  - Trigger: Pushing the mcore-5382-fix branch to NVIDIA-NeMo/Megatron-Bridge over the https remote failed with 403 and a SAML SSO authorization prompt, even though the token reports push permission on the repo. The clone had worked, so the block only appears at push time, after the fix is already committed.
  - Applied to: `.agents/contributor-skills/megatron-pr-fix-delivery/SKILL.md`
- **cog-syncs-repo-path-not-cwd** — cog syncs NEMO_RL_REPO_PATH, which is not necessarily the checkout you are editing. prep_container.sh and run_suite_remote.sh execute from that synced copy, so an edit to either only reaches the cluster if NEMO_RL_REPO_PATH has it. Diff those two scripts between your working checkout and NEMO_RL_REPO_PATH before the first submit of a sweep.
  - Trigger: The checkout being edited and the one cog ships to the cluster were two different clones; the cog-side one sat on an unrelated feature branch with the agent tooling untracked and several files behind.
  - Applied to: `.agents/contributor-skills/megatron-pr-test-run/SKILL.md`
- **submit-under-interactive-qos** — cog submit defaults to the normal QOS, which is far lower priority than the interactive one and can mean a multi-hour wait on a busy cluster for an identical request. Set COG_SLURM_QOS in config.env; cog reads it from the environment and lib.sh exports it. When a job is PENDING with reason Priority and no planned start, compare its QOS against a job that scheduled quickly before assuming the cluster is simply full. Interactive jobs can be preempted mid-run, so treat a vanished job as an infra failure and re-submit.
  - Trigger: Two suite jobs sat PENDING for 14 hours with no slot planned, behind ~850 higher-priority jobs, while session jobs on the same cluster with an identical resource request started in seconds.
  - Applied to: `.agents/contributor-skills/megatron-pr-test-run/SKILL.md`
- **tracking-table-repeats-shared-diagnosis** — When one diagnosis covers many tests, reference it from each row and write it out once in a section below rather than repeating it per row. post_tracking_issue.py now groups by known-issue id; keep the same shape for any new report renderer, and when hand-filling result comments put the shared explanation in the report note instead of each cell.
  - Trigger: One registry entry claimed all seven tests, so the rendered table carried the same 80-word diagnosis in every row, in both the PR comment and the tracking issue.
  - Applied to: `.agents/contributor-skills/megatron-pr-reporting/SKILL.md`
- **uv-python-pin-newer-than-local-uv** — Before the first submit of a sweep, run the agent's test suite once. If uv reports no interpreter for the version in .python-version, run 'uv self update' then 'uv python install' for that version -- a repo Python bump outruns an older uv and silently breaks every helper script, not just the tests.
  - Trigger: Every local helper script failed with 'No interpreter found for Python 3.13.14'; the repo had bumped .python-version past what the installed uv could download, so parse_results/known_issues/learnings could not run at all.
  - Applied to: `.claude/agents/nemo-rl-testing-agent.md`

## Two of these were promoted to guards rather than prose

`bridge-pin-read-from-working-tree` and `run-name-reuse-mixes-two-revisions`
were both cases where the instruction either already existed or would have been
unenforceable, so they became checks in `run_suite.sh`:

- The Megatron-Bridge pin is now read from the NeMo-RL revision under test
  instead of the local checkout's `HEAD`. Before this, which Bridge a run tested
  depended on which branch the operator happened to be on.
- Re-submitting under a run name that already has a `cog.log` is refused, with
  `--reuse-run-name` as the deliberate override. The skill already said to use a
  fresh suffix per attempt and a resumed sweep re-used `-a1` anyway, because the
  session that spent it was gone. Two revisions then shared one artifact
  directory, which nothing downstream can separate — `ensure_baseline.sh` parses
  a run with `cat *.out`.

The second guard comes with `tests/test_run_suite_guards.sh`. It runs offline in
well under a second by pointing `NRLTA_CONFIG` at a throwaway config.

`ensure_baseline.sh` also gained a `--bridge-ref` passthrough. A Megatron-Bridge
fix does not ride the NeMo-RL integration branch, so without it a baseline keeps
recording a break every PR run has already worked around, and attribution reads
off a stack nobody is testing against.

## Validation

`for t in .agents/nemo-rl-testing-agent/tests/*.sh; do bash "$t"; done` — all
five suites pass, including the new one. The config, script, and skill changes
were all exercised by this sweep's real runs on oci-hsg.

Draft: raised by an agent, needs a human review before merge.
