### PR TITLE
fix(megatron): plumb moe_router_enable_expert_bias from megatron_cfg

### DIFF
--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -754,6 +754,10 @@ def _apply_moe_config(model_cfg: Any, config: PolicyConfig) -> None:
     model_cfg.moe_router_bias_update_rate = config["megatron_cfg"][
         "moe_router_bias_update_rate"
     ]
+    if "moe_router_enable_expert_bias" in config["megatron_cfg"]:
+        model_cfg.moe_router_enable_expert_bias = config["megatron_cfg"][
+            "moe_router_enable_expert_bias"
+        ]
 
     model_cfg.moe_enable_deepep = config["megatron_cfg"]["moe_enable_deepep"]
     model_cfg.moe_token_dispatcher_type = config["megatron_cfg"][


### PR DESCRIPTION
## Summary

`_apply_moe_config` (`nemo_rl/models/megatron/setup.py`) wires most `megatron_cfg.moe_*` yaml values onto the mcore `TransformerConfig`, but silently omits `moe_router_enable_expert_bias`. This means the yaml value is validated into `MasterConfig` but never reaches the `TransformerConfig` at runtime — the bridge's hardcoded default wins.

For example, the NemotronH bridge unconditionally sets `provider.moe_router_enable_expert_bias = True` in `provider_bridge()`:

https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/src/megatron/bridge/models/nemotronh/nemotron_h_bridge.py

Even setting `policy.megatron_cfg.moe_router_enable_expert_bias: false` in the yaml has no effect — `finalize_model_grads` still enters `_update_router_expert_bias`, which then fails on models with heterogeneous per-layer expert counts (e.g. Puzzle NAS pruned MoE), because `torch.stack(tokens_per_expert_list)` requires uniform expert counts across all MoE layers.   (separate PR for that fix in mcore). 

## Change

Add the missing plumb-through, guarded by `"moe_router_enable_expert_bias" in config["megatron_cfg"]` so it's a no-op for existing configs. This mirrors the pattern used for other optional MoE fields in the same function (`moe_router_num_groups`, `moe_router_group_topk`, etc.).

