### PR TITLE
fix(agent): make the functional-test report say what it actually tested

### DIFF
--- a/.agents/contributor-skills/megatron-pr-failure-triage/SKILL.md
+++ b/.agents/contributor-skills/megatron-pr-failure-triage/SKILL.md
@@ -43,9 +43,22 @@ uv run --script .agents/nemo-rl-testing-agent/scripts/known_issues.py annotate \
 Each failure comes back in one of three states.
 
 **`known`** — already diagnosed, with its fix linked. The entry's diagnosis is
-written into the test's comment for you. Do not investigate; do not open another
-fix branch. If the fix has been sitting in review, chasing the reviewer is the
-useful action, not re-debugging the bug.
+written into the test's comment for you, and the status drops to
+`fail (pre-existing)`, because an entry only ever exists for a break the PR did
+not cause. Do not investigate; do not open another fix branch. If the fix has
+been sitting in review, chasing the reviewer is the useful action, not
+re-debugging the bug.
+
+That downgrade is also why you must not record a break the PR *did* cause. The
+registry is cross-PR memory: an entry excuses this failure on every future run,
+including the one where it is somebody's fault. Report those against the author
+instead.
+
+Do not lean on `apply_baseline.py` to do that downgrade. It only fires when the
+cached baseline failed the same test, and the baseline runs on a stack that
+carries pending fixes — so the moment a fix exists, the baseline goes green and
+stops covering for anybody. That combination once had three innocent PRs
+reported as `fail` with a link to the fix printed directly underneath.
 
 **`STALE`** — the registry claims a fix **and that fix is already applied to the
 branch this run tested**, yet the test failed anyway. This is a genuine finding.
@@ -198,12 +211,25 @@ uv run --script .agents/nemo-rl-testing-agent/scripts/known_issues.py record \
   --id <stable-slug> --test <test name> \
   --signature "<error_signature verbatim from the results JSON>" \
   --diagnosis "One or two sentences a PR author can act on." \
-  --repo NVIDIA-NeMo/RL --fix-pr <n>          # omit --fix-pr if there is no fix
+  --repo NVIDIA-NeMo/RL --fix-pr <n> \        # omit --fix-pr if there is no fix
+  --fix-branch <branch> \                     # required for a Bridge or mcore fix
+  --first-seen-megatron-pr <N>
 ```
 
 Copy the signature verbatim; `normalize()` strips the run-specific parts. Never
 hand-write one containing a measured value — `median(...) < 1.1 (measured 3.37)`
 will not match the same bug measuring 2.01 next week.
+
+`--first-seen-megatron-pr` records which run surfaced the break, for tracing it
+back later. It is not a culprit: the break is usually older than that PR and
+often in another repository, so nothing reads it as blame.
+
+`--fix-branch` is load-bearing. It is what carries a **Megatron-Bridge or
+Megatron-LM** fix into subsequent runs at all: a
+NeMo-RL fix rides the integration branch, but a fix in another repository is
+checked out inside the container, and `run_suite.sh` looks the branch up here to
+decide. Omit it and the fix exists in review while every run keeps reproducing
+the bug it fixes — for as long as review takes.
 
 The registry entry is about the bug. If the investigation also taught you
 something about *how to investigate* — a place this skill sent you that was

--- a/.agents/contributor-skills/megatron-pr-fix-delivery/SKILL.md
+++ b/.agents/contributor-skills/megatron-pr-fix-delivery/SKILL.md
@@ -118,9 +118,11 @@ uv run --script .agents/nemo-rl-testing-agent/scripts/known_issues.py record \
 
 The first makes later runs recognise the failure instead of re-debugging it. The
 second puts the fix on the integration branch, so later runs do not hit the
-failure at all. Only NeMo-RL fixes ride the integration branch; a Megatron-Bridge
-or Megatron-LM fix still needs `--bridge-ref` / `--mcore-ref` on the run that
-depends on it, so make the registry entry say so.
+failure at all. Only NeMo-RL fixes ride the integration branch. A Megatron-Bridge
+or Megatron-LM fix is checked out inside the container instead, and the registry
+entry is the only thing that knows which branch that is — so record it with
+`--fix-branch`, and `run_suite.sh` will carry it until the fix merges. Leave it
+off and the branch you just pushed changes nothing about the next run.
 
 `sync_integration.sh` only picks up branches named `mcore-*-fix` whose PR is
 open, which is why the naming convention matters. If it reports

--- a/.agents/contributor-skills/megatron-pr-reporting/SKILL.md
+++ b/.agents/contributor-skills/megatron-pr-reporting/SKILL.md
@@ -101,12 +101,21 @@ uv run --script .agents/nemo-rl-testing-agent/scripts/post_report.py \
   --results ~/.nemo-rl-testing-agent/pr-5700/l1.results.json \
   --results ~/.nemo-rl-testing-agent/pr-5700/l2.results.json \
   --integration ~/.nemo-rl-testing-agent/integration.json \
-  --meta megatron-lm=<HEAD_SHA> --meta merged-with-main=<BASE_SHA> \
   --meta cluster=oci-hsg --meta image=nvcr.io/nvidian/nemo-rl:nightly
 ```
 
 Results files render in the order given, so pass L1 before L2. Add `--dry-run`
 to review the markdown first — always do this before the first post on a PR.
+
+Do not pass revisions as `--meta`. The report builds an **Exactly what was
+tested** table out of the `prep` block the run recorded, naming the ref *and*
+the commit for megatron-core, Megatron-Bridge and NeMo-RL, each linked to the
+repository it was actually fetched from. Ref and commit have to travel together:
+a bare sha cannot distinguish the Bridge NeMo-RL pins from a fix branch carried
+in its place, and a NeMo-RL sha links nowhere useful unless the reader knows it
+came from a fork. Hand-typed shas were also a silent source of error — nothing
+checked them against the run, so a stale copy-paste read exactly like a result.
+`--meta` is for what the run does not record, such as the cluster and image.
 
 **Always pass `--integration`.** Runs carry NeMo-RL fixes that are raised but not
 merged, so a green table means "green with those applied", and a reader entitled

--- a/.agents/contributor-skills/megatron-pr-test-run/SKILL.md
+++ b/.agents/contributor-skills/megatron-pr-test-run/SKILL.md
@@ -67,6 +67,17 @@ self-consistent: it is the combination NeMo-RL ships and CI expects. Use
 `--bridge-ref <sha|ref>` to test a specific Bridge, or `--bridge-ref image` to
 keep whatever the image carries (only useful for reproducing an old run).
 
+One case overrides that default on its own. When the registry holds an open
+Bridge fix with a `fix_branch`, `run_suite.sh` checks that branch out instead
+and logs `carrying unmerged Megatron-Bridge fix '<branch>'`. The pinned Bridge
+necessarily lags megatron-core `main` by however long it has been since NeMo-RL
+bumped the submodule, so an mcore change to an API Bridge uses breaks every test
+at import until the Bridge-side fix merges *and* NeMo-RL advances the pin — a
+window of weeks, during which the default pin makes each sweep re-report a break
+that is already fixed in review. Read the `BRIDGE_REF=` line rather than
+assuming: if it names a branch, the run is not on the shipped combination, and
+that belongs in the report note.
+
 ## Which NeMo-RL is under test
 
 The third leg is pinned the same way, and by default it is **not** plain `main`.

--- a/.agents/contributor-skills/nemo-rl-mcore-watchdog/SKILL.md
+++ b/.agents/contributor-skills/nemo-rl-mcore-watchdog/SKILL.md
@@ -30,7 +30,9 @@ That does five things, in order:
 2. `known_issues.py refresh` asks GitHub about each registry entry's fix PR and
    retires the merged ones.
 3. `ensure_baseline.sh --force` runs the suite: megatron-core `main` × the
-   integration branch × the Bridge sha NeMo-RL pins.
+   integration branch × the Bridge sha NeMo-RL pins, or an open Bridge fix
+   branch when the registry has one (step 2 is what decides that, by retiring
+   the entries whose fixes merged).
 4. `known_issues.py annotate` labels each failure with what we already know.
 5. `post_tracking_issue.py` renders the tracking issue.
 

--- a/.agents/nemo-rl-testing-agent/scripts/known_issues.py
+++ b/.agents/nemo-rl-testing-agent/scripts/known_issues.py
@@ -35,10 +35,18 @@ Two things keep it from becoming a source of wrong answers:
   ``annotate`` says so loudly instead of quietly labelling it known -- the entry
   is stale, or this is a different bug wearing the same signature.
 
+An entry does two things beyond naming the bug. It downgrades the failure out of
+`fail`, because an entry exists only for a break the revision under test did not
+cause. And, for a fix in a repo the integration branch cannot carry, it tells
+later runs which branch to check out, so a Bridge fix in review stops having to
+be remembered by hand on every submit.
+
 Usage:
     uv run --script known_issues.py annotate --results r.json [--integration m.json]
     uv run --script known_issues.py record --id <slug> --test <name> \
-        --signature "<error line>" --diagnosis "..." --repo owner/name --fix-pr 3363
+        --signature "<error line>" --diagnosis "..." --repo owner/name --fix-pr 3363 \
+        [--fix-branch <branch>] [--first-seen-megatron-pr <n>]
+    uv run --script known_issues.py pending-fix-ref --repo owner/name
     uv run --script known_issues.py refresh
     uv run --script known_issues.py list
 """
@@ -199,6 +207,26 @@ def cmd_annotate(args: argparse.Namespace) -> int:
 
         test["known_issue"] = issue.get("id")
         test["comment"] = build_comment(issue)
+
+        # An entry only ever describes a break that is *not* the fault of the
+        # revision under test -- triage records one after deciding the PR did not
+        # cause it, and a break the PR did cause is reported against the author
+        # rather than filed as cross-PR memory. So a match has to move the status
+        # as well as the comment, since `fail` means "this PR broke it". Leaving
+        # it alone once put three innocent PRs on the hook: the baseline had been
+        # taken on a stack carrying the fix, so `apply_baseline` had nothing to
+        # downgrade, and the report read `fail` with a link to the fix printed
+        # directly underneath.
+        #
+        # Note this deliberately does not consult first_seen_megatron_pr. That
+        # field records which PR's run first surfaced the break, which is not the
+        # same as which PR caused it and is usually not even the same repository
+        # -- the Bridge break below was first seen on Megatron-LM#5382 and caused
+        # by #5865, long merged. Reading it as the culprit would blame whichever
+        # PR had the bad luck to run first.
+        if test.get("status") == "fail":
+            test["status"] = "fail (pre-existing)"
+
         issue["last_seen_utc"] = now_utc()
         matched += 1
         fix = f"{issue.get('repo')}#{fix_pr}" if fix_pr else "no fix raised yet"
@@ -332,6 +360,46 @@ def cmd_list(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_pending_fix_ref(args: argparse.Namespace) -> int:
+    """The branch a run must check out to carry an unmerged fix in one repo.
+
+    A NeMo-RL fix reaches later runs on its own: sync_integration.sh cherry-picks
+    every open `mcore-*-fix` PR onto the integration branch. A fix in
+    Megatron-Bridge or Megatron-LM cannot ride along, because the branch is a
+    NeMo-RL branch and those commits live in another repository -- they are
+    checked out inside the container instead. Without this lookup the operator has
+    to remember to pass `--bridge-ref` on every submit, and the sweep that forgets
+    reports a break that is already fixed in review as though the PR under test
+    caused it.
+
+    Prints one branch name, or nothing when no such fix is pending. Two pending
+    fixes in one repo cannot be combined into a single ref, so that is an error
+    rather than a silent pick.
+    """
+    registry = load(registry_path(args.registry))
+    branches = sorted(
+        {
+            issue["fix_branch"]
+            for issue in registry.get("issues", [])
+            if issue.get("state") in (None, "open")
+            and issue.get("repo") == args.repo
+            and issue.get("fix_branch")
+        }
+    )
+    if not branches:
+        return 0
+    if len(branches) > 1:
+        print(
+            f"known_issues: {len(branches)} unmerged fixes pending in {args.repo} "
+            f"({', '.join(branches)}); they cannot be carried by one ref. Merge one, "
+            "or pass the ref explicitly.",
+            file=sys.stderr,
+        )
+        return 1
+    print(branches[0])
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--registry", type=Path, help="Override $KNOWN_ISSUES_FILE.")
@@ -347,6 +415,15 @@ def main() -> int:
         help="integration.json manifest, so an already-applied fix is not credited twice.",
     )
     annotate.set_defaults(func=cmd_annotate)
+
+    pending = sub.add_parser(
+        "pending-fix-ref",
+        help="Print the branch carrying an unmerged fix for one repo, if any.",
+    )
+    pending.add_argument(
+        "--repo", required=True, help="Repo the fix lands in, owner/name."
+    )
+    pending.set_defaults(func=cmd_pending_fix_ref)
 
     record = sub.add_parser("record", help="Add or update an entry.")
     record.add_argument(

--- a/.agents/nemo-rl-testing-agent/scripts/parse_results.py
+++ b/.agents/nemo-rl-testing-agent/scripts/parse_results.py
@@ -51,7 +51,8 @@ TEST_SKIP_RE = re.compile(
 PREP_FIELD_RE = re.compile(
     r"^(mcore_fetch_ref|mcore_sha|mcore_sha_before|mcore_subject|megatron_core_file"
     r"|bridge_fetch_ref|bridge_sha"
-    r"|nemo_rl_fetch_ref|nemo_rl_sha|nemo_rl_env_sha|nemo_rl_mode)=(.*)$"
+    r"|nemo_rl_fetch_ref|nemo_rl_sha|nemo_rl_env_sha|nemo_rl_mode"
+    r"|nemo_rl_url|mcore_url|bridge_url)=(.*)$"
 )
 
 # Ordered by how specific the signal is; the first pattern that matches when

--- a/.agents/nemo-rl-testing-agent/scripts/post_report.py
+++ b/.agents/nemo-rl-testing-agent/scripts/post_report.py
@@ -128,6 +128,131 @@ def render_pending_fixes(manifest_path: Path | None) -> list[str]:
     ]
 
 
+def slug_of(url: str) -> str:
+    """owner/name out of a clone URL, in either of the forms we clone with."""
+    match = re.search(r"(?:github\.com[:/])([^/]+/[^/]+?)(?:\.git)?/?$", url or "")
+    return match.group(1) if match else ""
+
+
+def commit_link(sha: str, url: str) -> str:
+    short = sha[:8] if re.fullmatch(r"[0-9a-f]{40}", sha or "") else sha
+    slug = slug_of(url)
+    if not short:
+        return "?"
+    if not slug:
+        return f"`{short}`"
+    return f"[`{short}`](https://github.com/{slug}/commit/{sha})"
+
+
+def describe_ref(ref: str, url: str) -> str:
+    """What the ref means, not just what it is called.
+
+    A reader who has to decode `refs/pull/5382/head` or tell a 40-character
+    Bridge sha apart from a branch name is being asked to reconstruct the run,
+    which is the job this table exists to do for them.
+    """
+    if not ref or ref.startswith("<"):
+        return ref or "?"
+    pull = re.fullmatch(r"refs/pull/(\d+)/head", ref)
+    if pull:
+        slug = slug_of(url)
+        number = pull.group(1)
+        link = (
+            f"[#{number}](https://github.com/{slug}/pull/{number})"
+            if slug
+            else f"#{number}"
+        )
+        return f"{link} head"
+    if re.fullmatch(r"[0-9a-f]{40}", ref):
+        return "the sha NeMo-RL pins"
+    return f"`{ref.removeprefix('refs/heads/')}`"
+
+
+def describe_bridge_ref(ref: str) -> str:
+    """Whether the Bridge under test is the one NeMo-RL ships, or a substitute.
+
+    Only a sha is the pin. Anything else is an override -- normally a fix branch
+    the harness carried because the fix is still in review -- and that changes
+    what a green table means: the suite passed against a Bridge that nobody can
+    `pip install` yet. Saying only the branch name leaves the reader to infer it.
+    """
+    if re.fullmatch(r"[0-9a-f]{40}", ref or ""):
+        return "the sha NeMo-RL pins"
+    if not ref or ref.startswith("<"):
+        return "whatever the container image carries"
+    return f"`{ref}` — an override, **not** the Bridge NeMo-RL pins"
+
+
+def render_stack(
+    payloads: list[dict[str, Any]], heading: str = "**Exactly what was tested**"
+) -> list[str]:
+    """Exactly which three revisions produced the table below.
+
+    Every one of them is a choice the harness made rather than an obvious
+    default: megatron-core is the PR's head, Megatron-Bridge is either NeMo-RL's
+    pin or an unmerged fix branch checked out in its place, and NeMo-RL is
+    normally a fork branch of `main` plus fixes still in review. A reader who
+    cannot see that cannot tell what a green table is a statement about, and the
+    shas were previously retyped by hand into `--meta`, where the refs were lost
+    and a typo looked exactly like a result.
+    """
+    prep: dict[str, str] = {}
+    baseline: dict[str, str] = {}
+    for payload in payloads:
+        prep = prep or (payload.get("prep") or {})
+        baseline = baseline or (payload.get("baseline") or {})
+    if not prep:
+        return []
+
+    rows = [
+        (
+            "megatron-core",
+            describe_ref(prep.get("mcore_fetch_ref", ""), prep.get("mcore_url", "")),
+            commit_link(prep.get("mcore_sha", ""), prep.get("mcore_url", "")),
+        ),
+        (
+            "Megatron-Bridge",
+            describe_bridge_ref(prep.get("bridge_fetch_ref", "")),
+            commit_link(prep.get("bridge_sha", ""), prep.get("bridge_url", "")),
+        ),
+        (
+            "NeMo-RL",
+            describe_ref(
+                prep.get("nemo_rl_fetch_ref", ""), prep.get("nemo_rl_url", "")
+            ),
+            commit_link(prep.get("nemo_rl_sha", ""), prep.get("nemo_rl_url", "")),
+        ),
+    ]
+    lines = [
+        heading,
+        "",
+        "| Component | Ref | Commit |",
+        "| --- | --- | --- |",
+    ]
+    lines += [f"| {name} | {ref} | {sha} |" for name, ref, sha in rows]
+    if baseline.get("mcore_sha"):
+        lines += [
+            "",
+            "Compared against a baseline of the same suite on megatron-core `main` at "
+            + commit_link(baseline["mcore_sha"], prep.get("mcore_url", ""))
+            + ".",
+        ]
+    lines += [""]
+    return lines
+
+
+# Superseded by the stack table, which says the same thing with the ref that
+# gives each sha its meaning. Kept out of the header rather than rejected at the
+# CLI so that an older invocation still renders, just without the duplication.
+STACK_META_KEYS = {
+    "mcore_sha",
+    "bridge_sha",
+    "nemo_rl_sha",
+    "base_sha",
+    "baseline_main_sha",
+}
+
+
 def render(
     state: str,
     results_files: list[Path],
@@ -136,8 +261,12 @@ def render(
     integration: Path | None = None,
 ) -> str:
     stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    payloads = [json.loads(path.read_text()) for path in results_files]
+    stack = render_stack(payloads)
     meta_bits = [
-        f"{key.replace('_', ' ')}: `{value}`" for key, value in meta.items() if value
+        f"{key.replace('_', ' ')}: `{value}`"
+        for key, value in meta.items()
+        if value and not (stack and key in STACK_META_KEYS)
     ]
     meta_bits.append(f"updated {stamp}")
 
@@ -147,6 +276,7 @@ def render(
         "",
         " · ".join(meta_bits),
         "",
+        *stack,
         *render_pending_fixes(integration),
     ]
 
@@ -163,8 +293,7 @@ def render(
         lines += ["", note or "See the run log for details."]
     else:
         rows: list[tuple[str, str, str]] = []
-        for path in results_files:
-            payload: dict[str, Any] = json.loads(path.read_text())
+        for payload in payloads:
             for test in payload.get("tests", []):
                 status = test.get("status", "unknown")
                 icon = STATUS_ICONS.get(status, "")

--- a/.agents/nemo-rl-testing-agent/scripts/post_tracking_issue.py
+++ b/.agents/nemo-rl-testing-agent/scripts/post_tracking_issue.py
@@ -45,6 +45,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+# Sibling script, imported for the provenance table so the two renderings cannot
+# drift apart. Safe to import: it declares no dependencies of its own and does
+# nothing at module scope. `uv run --script` sets sys.path[0] to this directory,
+# but a plain `python3 path/to/script.py` from elsewhere does too, so no path
+# fixing is needed.
+import post_report
+
 MARKER = "<!-- nrlta-watchdog -->"
 TITLE = "NeMo-RL vs megatron-core `main`: current functional-test breakage"
 FAILING = {"fail", "fail (pre-existing)", "incomplete", "pass (suspect)"}
@@ -72,6 +79,30 @@ def short(sha: str) -> str:
     return sha[:8] if sha else "unknown"
 
 
+def render_stack_section(results: dict[str, Any], meta: dict[str, str]) -> list[str]:
+    """The same provenance table the PR comments carry.
+
+    Shared rather than reimplemented because the two must not drift: this issue
+    and a PR comment can describe the same run, and the reader comparing them is
+    doing so precisely because something looks inconsistent. The old hand-rolled
+    version asserted a bare Bridge sha with no ref, which stopped being true the
+    moment runs could carry an unmerged Bridge fix branch in place of the pin.
+    """
+    if results.get("prep"):
+        return post_report.render_stack([results], heading="### Stack under test")
+
+    # A results payload with no prep block predates that record, so fall back to
+    # what the meta file carries rather than showing nothing.
+    return [
+        "### Stack under test",
+        "",
+        f"- megatron-core: `main` @ `{short(meta.get('MCORE_SHA', ''))}`",
+        f"- Megatron-Bridge: `{short(meta.get('BRIDGE_SHA', ''))}`",
+        f"- NeMo-RL: `main` plus the pending fixes below @ `{short(meta.get('NEMO_RL_SHA', ''))}`",
+        "",
+    ]
+
+
 def render(
     suite: str,
     results: dict[str, Any],
@@ -93,12 +124,7 @@ def render(
         "that is **not** caused by any particular Megatron-LM pull request, so that "
         "labeled PRs do not each have to rediscover it.",
         "",
-        "### Stack under test",
-        "",
-        f"- megatron-core: `main` @ `{short(meta.get('MCORE_SHA', ''))}`",
-        f"- Megatron-Bridge: `{short(meta.get('BRIDGE_SHA', ''))}`",
-        f"- NeMo-RL: `main` plus the pending fixes below @ `{short(meta.get('NEMO_RL_SHA', ''))}`",
-        "",
+        *render_stack_section(results, meta),
     ]
 
     applied = manifest.get("applied", [])

--- a/.agents/nemo-rl-testing-agent/scripts/prep_container.sh
+++ b/.agents/nemo-rl-testing-agent/scripts/prep_container.sh
@@ -291,6 +291,14 @@ if [ -n "${NRLTA_ARTIFACT_DIR:-}" ]; then
   mkdir -p "${NRLTA_ARTIFACT_DIR}"
 fi
 
+# The clone URLs go in the record too, so a reader of the report can follow a sha
+# to the commit it names. Which repository each one lives in is not guessable
+# from the report: NeMo-RL is fetched from a fork whenever the integration branch
+# is in play, and a bare sha with no repository behind it is a string nobody can
+# check.
+echo "nemo_rl_url=${NEMO_RL_CLONE_URL:-}"
+echo "mcore_url=${MEGATRON_CLONE_URL:-}"
+echo "bridge_url=${MEGATRON_BRIDGE_CLONE_URL:-}"
 echo "nemo_rl_fetch_ref=${NEMO_RL_FETCH_REF:-<worktree overlay>}"
 echo "nemo_rl_sha_before=${nemo_rl_sha_before}"
 echo "nemo_rl_sha=${nemo_rl_sha:-${nemo_rl_sha_before}}"

--- a/.agents/nemo-rl-testing-agent/scripts/run_suite.sh
+++ b/.agents/nemo-rl-testing-agent/scripts/run_suite.sh
@@ -171,6 +171,24 @@ else
   fi
 fi
 
+# One thing outranks the pin below: a Megatron-Bridge fix this agent has already
+# raised and that is still in review. A NeMo-RL fix reaches later runs on its own
+# because sync_integration.sh cherry-picks it onto the integration branch, but a
+# Bridge commit cannot ride a NeMo-RL branch, so it would otherwise have to be
+# remembered as --bridge-ref on every single submit. Forgetting it does not
+# produce a missing result, it produces a confidently wrong one: the break shows
+# up against whichever PR happens to be under test, weeks after it was diagnosed
+# and fixed. The registry knows the branch, so ask it rather than the operator.
+if [[ -z "${bridge_ref}" ]]; then
+  pending_bridge_ref="$(uv run --script "${NRLTA_SCRIPT_DIR}/known_issues.py" \
+    pending-fix-ref --repo "${MEGATRON_BRIDGE_REPO}")" || nrlta_die \
+    "could not decide which Megatron-Bridge fix to carry; pass --bridge-ref explicitly"
+  if [[ -n "${pending_bridge_ref}" ]]; then
+    bridge_ref="${pending_bridge_ref}"
+    nrlta_log "carrying unmerged Megatron-Bridge fix '${bridge_ref}' (known-issues registry)"
+  fi
+fi
+
 # Default the Bridge pin to the one the NeMo-RL *under test* points at, which is
 # the combination NeMo-RL ships. Pairing a current megatron-core with a Bridge
 # from anywhere else breaks every test deep inside Bridge and reads as the

--- a/.agents/nemo-rl-testing-agent/tests/test_known_issues.sh
+++ b/.agents/nemo-rl-testing-agent/tests/test_known_issues.sh
@@ -56,6 +56,16 @@ for test in payload["tests"]:
 PY
 }
 
+raw_status_of() {
+  python3 - "$1" "$2" <<'PY'
+import json, sys
+payload = json.load(open(sys.argv[1]))
+for test in payload["tests"]:
+    if test["name"] == sys.argv[2]:
+        print(test.get("status", "<none>"))
+PY
+}
+
 run record \
   --id mcore-5918-prompt-tokens \
   --test grpo_megatron_generation \
@@ -104,6 +114,47 @@ check "leaves an unrelated failure for investigation" \
 check "ignores a clean pass" \
   "<none>" "$(status_of "${work}/results.json" grpo_megatron_generation_non_colocated)"
 
+# Matching an entry has to move the status too, not just add a comment. `fail`
+# means "this PR broke it", and a break the registry already knows about predates
+# the run that hit it. Leaving the status alone once put three innocent PRs on
+# the hook: the baseline had been taken on a stack carrying the fix, so
+# apply_baseline had nothing to downgrade, and the report said `fail` while the
+# comment directly underneath linked the fix already in review.
+check "downgrades a known failure so no PR is accused of it" \
+  "fail (pre-existing)" "$(raw_status_of "${work}/results.json" grpo_megatron_generation)"
+check "leaves a suspect pass as it found it" \
+  "pass (suspect)" "$(raw_status_of "${work}/results.json" grpo_megatron_generation_async)"
+check "leaves an unmatched failure as a plain fail" \
+  "fail" "$(raw_status_of "${work}/results.json" grpo_megatron_generation_multiturn)"
+
+# first_seen_megatron_pr must not be read as "the PR that caused this". It names
+# the run that first surfaced the break, which is routinely a different repo's
+# problem entirely -- the Bridge break in the live registry was first seen on
+# Megatron-LM#5382 and caused by #5865, merged weeks earlier. Excusing must not
+# depend on it, or the PR unlucky enough to run first gets blamed on every
+# re-run.
+run record \
+  --id mcore-9999-first-seen \
+  --test grpo_megatron_training \
+  --signature "RuntimeError: tensor model parallel group is not initialized" \
+  --diagnosis "Pre-existing on main; surfaced by whichever PR ran first." \
+  --first-seen-megatron-pr 9999 >/dev/null
+
+cat > "${work}/first_seen.json" <<'JSON'
+{
+  "tests": [
+    {
+      "name": "grpo_megatron_training",
+      "status": "fail",
+      "error_signature": "RuntimeError: tensor model parallel group is not initialized"
+    }
+  ]
+}
+JSON
+run annotate --results "${work}/first_seen.json" >/dev/null
+check "excuses the break on the PR that first surfaced it too" \
+  "fail (pre-existing)" "$(raw_status_of "${work}/first_seen.json" grpo_megatron_training)"
+
 # Same signature, a test the entry does not claim: must NOT be excused.
 cat > "${work}/other.json" <<'JSON'
 {
@@ -139,6 +190,8 @@ JSON
 out="$(run annotate --results "${work}/stale.json" --integration "${work}/integration.json")"
 check "flags a recurrence of an already-applied fix instead of excusing it" \
   "mcore-5918-prompt-tokens" "$(status_of "${work}/stale.json" grpo_megatron_generation)"
+check "keeps the fail when the applied fix did not hold" \
+  "fail" "$(raw_status_of "${work}/stale.json" grpo_megatron_generation)"
 if grep -q "STALE" <<<"${out}"; then
   echo "ok: says loudly that the entry is stale"
 else
@@ -177,6 +230,44 @@ run annotate --results "${work}/stale.json" --integration "${work}/integration.j
 run annotate --results "${work}/stale.json" >/dev/null
 check "drops a stale verdict when re-annotated without the manifest" \
   "mcore-5918-prompt-tokens" "$(status_of "${work}/stale.json" grpo_megatron_generation)"
+
+# pending-fix-ref is what stops a raised-but-unmerged Megatron-Bridge fix from
+# having to be remembered as --bridge-ref on every submit for weeks.
+check "says nothing when no fix is pending in a repo" \
+  "" "$(run pending-fix-ref --repo NVIDIA-NeMo/Megatron-Bridge)"
+
+run record \
+  --id bridge-unwrap-model \
+  --test grpo_megatron_generation \
+  --signature "TypeError: isinstance() arg 2 must be a type" \
+  --diagnosis "Bridge passes a factory function to isinstance()." \
+  --repo NVIDIA-NeMo/Megatron-Bridge --fix-pr 5357 --fix-branch mcore-5382-fix >/dev/null
+check "names the branch carrying the one pending fix" \
+  "mcore-5382-fix" "$(run pending-fix-ref --repo NVIDIA-NeMo/Megatron-Bridge)"
+check "does not offer another repo's fix" \
+  "" "$(run pending-fix-ref --repo NVIDIA/Megatron-LM)"
+
+# Two pending fixes cannot both be checked out at one ref. Picking either one
+# silently would test a stack nobody chose, so it has to fail and say so.
+run record \
+  --id bridge-second-break \
+  --test grpo_megatron_training \
+  --signature "ImportError: cannot import name something" \
+  --diagnosis "A second, unrelated Bridge break." \
+  --repo NVIDIA-NeMo/Megatron-Bridge --fix-pr 5400 --fix-branch mcore-6000-fix >/dev/null
+if run pending-fix-ref --repo NVIDIA-NeMo/Megatron-Bridge >/dev/null 2>&1; then
+  echo "FAIL: silently picked one of two pending fixes"
+  failures=$((failures + 1))
+else
+  echo "ok: refuses to choose between two pending fixes"
+fi
+
+python3 - "${REGISTRY}" <<'PY'
+import json, sys
+payload = json.load(open(sys.argv[1]))
+payload["issues"] = [i for i in payload["issues"] if i["id"] != "bridge-second-break"]
+json.dump(payload, open(sys.argv[1], "w"), indent=2)
+PY
 
 # A merged fix must stop excusing anything: the failure is a regression now.
 python3 - "${REGISTRY}" <<'PY'

--- a/.agents/nemo-rl-testing-agent/tests/test_report_stack.sh
+++ b/.agents/nemo-rl-testing-agent/tests/test_report_stack.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Checks the provenance table that tells a reader which three revisions produced
+# a result.
+#
+# The thing being defended is that a reader can tell, without asking, whether a
+# green table is a statement about the stack NeMo-RL ships or about a stack that
+# exists only inside this harness. Those look identical once the refs are
+# dropped, which is what the old hand-typed `--meta` shas did. The Bridge row
+# carries the most weight: a sha there is NeMo-RL's pin, while a branch is a fix
+# nobody has merged.
+
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${here}/../scripts/post_report.py"
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+
+failures=0
+
+check() {
+  local label="$1" want="$2" got="$3"
+  if [[ "${got}" == "${want}" ]]; then
+    echo "ok: ${label}"
+  else
+    echo "FAIL: ${label}"
+    echo "    wanted: ${want}"
+    echo "    got:    ${got}"
+    failures=$((failures + 1))
+  fi
+}
+
+contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if [[ "${haystack}" == *"${needle}"* ]]; then
+    echo "ok: ${label}"
+  else
+    echo "FAIL: ${label}"
+    echo "    expected to find: ${needle}"
+    failures=$((failures + 1))
+  fi
+}
+
+absent() {
+  local label="$1" needle="$2" haystack="$3"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    echo "ok: ${label}"
+  else
+    echo "FAIL: ${label}"
+    echo "    expected NOT to find: ${needle}"
+    failures=$((failures + 1))
+  fi
+}
+
+# A run of a labeled PR, carrying an unmerged Bridge fix on a fork branch of
+# NeMo-RL: the shape every sweep produces while a Bridge fix is in review.
+cat > "${work}/results.json" <<'JSON'
+{
+  "prep": {
+    "mcore_fetch_ref": "refs/pull/5382/head",
+    "mcore_sha": "eb01b689c4ddf1034db987a25736aee12552d2ea",
+    "mcore_url": "https://github.com/NVIDIA/Megatron-LM.git",
+    "bridge_fetch_ref": "mcore-5382-fix",
+    "bridge_sha": "2940a635731da68c5960a020f8ea2f678fa1e073",
+    "bridge_url": "https://github.com/NVIDIA-NeMo/Megatron-Bridge.git",
+    "nemo_rl_fetch_ref": "nrlta/integration",
+    "nemo_rl_sha": "86774472e229b457314418fe3f25e8e844775596",
+    "nemo_rl_url": "https://github.com/shanmugamr1992/RL.git"
+  },
+  "baseline": {"mcore_sha": "3aee84c392e3a265c497991d0d07b27bfffb2490"},
+  "tests": [{"name": "grpo_megatron_generation", "status": "pass"}]
+}
+JSON
+
+body="$(uv run --script "${SCRIPT}" --pr 5382 --state results --dry-run \
+  --results "${work}/results.json" --meta suite=L1 \
+  --meta mcore_sha=eb01b689c4ddf1034db987a25736aee12552d2ea)"
+
+contains "names the PR the mcore revision came from" \
+  "[#5382](https://github.com/NVIDIA/Megatron-LM/pull/5382) head" "${body}"
+contains "links the mcore commit to Megatron-LM" \
+  "[\`eb01b689\`](https://github.com/NVIDIA/Megatron-LM/commit/eb01b689c4ddf1034db987a25736aee12552d2ea)" \
+  "${body}"
+
+# The fork matters: NeMo-RL's sha does not exist in NVIDIA-NeMo/RL while the
+# integration branch lives on a fork, so a link to the upstream repo 404s.
+contains "links the NeMo-RL commit to the fork it was fetched from" \
+  "https://github.com/shanmugamr1992/RL/commit/86774472" "${body}"
+contains "names the NeMo-RL branch, not just its sha" "\`nrlta/integration\`" "${body}"
+
+contains "says a Bridge branch is an override rather than the pin" \
+  "an override, **not** the Bridge NeMo-RL pins" "${body}"
+contains "still records the baseline it was compared against" \
+  "megatron-core \`main\` at [\`3aee84c3\`]" "${body}"
+
+# The header used to carry the same shas, typed by hand. Two places to read one
+# fact is one place to get it wrong.
+absent "drops a sha from the header once the table states it" \
+  "mcore sha: \`eb01b689" "${body}"
+contains "keeps header fields the table does not cover" "suite: \`L1\`" "${body}"
+
+# A Bridge sha is the pin, and must not be described as an override.
+python3 - "${work}" <<'PY'
+import json, sys
+work = sys.argv[1]
+payload = json.load(open(f"{work}/results.json"))
+payload["prep"]["bridge_fetch_ref"] = "573e088c1234567890abcdef1234567890abcdef"
+payload["prep"]["mcore_fetch_ref"] = "refs/heads/main"
+json.dump(payload, open(f"{work}/pinned.json", "w"), indent=2)
+PY
+pinned="$(uv run --script "${SCRIPT}" --pr 5382 --state results --dry-run \
+  --results "${work}/pinned.json" --meta suite=L1)"
+contains "calls a Bridge sha the pin" "the sha NeMo-RL pins" "${pinned}"
+absent "does not call the pin an override" "an override" "${pinned}"
+contains "renders a branch ref without its refs/heads prefix" "| megatron-core | \`main\` |" "${pinned}"
+
+# Results from before the URLs were recorded must still render, minus the links.
+python3 - "${work}" <<'PY'
+import json, sys
+work = sys.argv[1]
+payload = json.load(open(f"{work}/results.json"))
+for key in ("mcore_url", "bridge_url", "nemo_rl_url"):
+    payload["prep"].pop(key)
+json.dump(payload, open(f"{work}/nourls.json", "w"), indent=2)
+PY
+nourls="$(uv run --script "${SCRIPT}" --pr 5382 --state results --dry-run \
+  --results "${work}/nourls.json" --meta suite=L1)"
+contains "still shows the refs when no URL was recorded" "\`nrlta/integration\`" "${nourls}"
+contains "falls back to a bare sha rather than a broken link" "| \`86774472\` |" "${nourls}"
+
+# `--state running` is posted before any suite has run, so there is nothing to
+# describe and the table must not appear half-filled.
+running="$(uv run --script "${SCRIPT}" --pr 5382 --state running --dry-run --meta suite=L1)"
+absent "omits the table entirely before the run has results" "Exactly what was tested" "${running}"
+
+# The watchdog issue must render the same table from the same code.
+issue_out="${work}/issue.md"
+uv run --script "${here}/../scripts/post_tracking_issue.py" --suite l1 \
+  --results "${work}/results.json" --out "${issue_out}" >/dev/null 2>&1
+issue="$(cat "${issue_out}" 2>/dev/null)"
+contains "the watchdog issue carries the same Bridge warning" \
+  "an override, **not** the Bridge NeMo-RL pins" "${issue}"
+check "the watchdog issue heads the table its own way" \
+  "1" "$(grep -c '^### Stack under test$' "${issue_out}" 2>/dev/null || echo 0)"
+absent "does not stack two headings on one table" "**Exactly what was tested**" "${issue}"
+
+echo
+if [[ "${failures}" -eq 0 ]]; then
+  echo "report stack: all checks passed"
+else
+  echo "report stack: ${failures} check(s) failed"
+fi
+exit $(( failures > 0 ))


### PR DESCRIPTION
Follow-up to #3522, from continuing to pull on the same sweep. Two commits, each
fixing a way the functional-test report could mislead the person reading it.

## 1. Known breaks were reported as PR-caused failures

`known_issues.py annotate` labelled a matched failure with its diagnosis and fix
link but left `status: fail`, which the report vocabulary defines as *"genuine
failure caused by the PR"*. Nothing looked wrong while `apply_baseline.py`
happened to cover for it: it downgrades any failure the cached baseline also
hit, and the baseline was red for the same reason.

That cover disappears exactly when a fix is raised. The baseline gets re-taken on
a stack carrying the fix, goes green, stops matching — so the next sweep reports
the *same known break* as `fail` against whichever PRs are under test, with a
link to the fix printed directly underneath.

An entry only ever exists for a break the PR did not cause, so `annotate` now
downgrades to `fail (pre-existing)` on match. It deliberately does **not** read
`first_seen_megatron_pr` as a culprit: that field records which run first
surfaced the break, usually neither the cause nor even the same repository — the
Bridge break in the registry was first seen on Megatron-LM#5382 and caused by
#5865, merged weeks earlier.

**Carrying a fix the integration branch cannot reach.** `sync_integration.sh`
cherry-picks open NeMo-RL fixes onto the branch under test, so those reach later
runs by themselves. A Megatron-Bridge or Megatron-LM fix is checked out inside
the container instead, so it had to be passed as `--bridge-ref` on every single
submit until it merged; forgetting it produces a confident wrong answer rather
than a missing one. `run_suite.sh` now asks the registry through a new
`pending-fix-ref` query, and errors rather than guessing when two fixes are
pending in one repo. This makes `--fix-branch` load-bearing at `record` time,
which the triage and fix-delivery skills now say.

## 2. The report did not say which revisions it ran

The header carried four bare shas, retyped by hand into `--meta` on every post.
Nothing checked them against the run, so a stale copy-paste read exactly like a
result, and the refs that give a sha its meaning were dropped on the way.

That got worse once runs stopped being uniform. Megatron-Bridge is now either the
sha NeMo-RL pins or a fix branch carried in its place, and those are different
claims about what a green table proves. NeMo-RL is normally a fork branch, so its
sha links nowhere a reader can check. megatron-core `main` and a PR head are
indistinguishable once written as hex.

The report now builds this from the `prep` block the run already recorded:

| Component | Ref | Commit |
| --- | --- | --- |
| megatron-core | [#5382](https://github.com/NVIDIA/Megatron-LM/pull/5382) head | [`eb01b689`](https://github.com/NVIDIA/Megatron-LM/commit/eb01b689c4ddf1034db987a25736aee12552d2ea) |
| Megatron-Bridge | `mcore-5382-fix` — an override, **not** the Bridge NeMo-RL pins | [`2940a635`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/commit/2940a635731da68c5960a020f8ea2f678fa1e073) |
| NeMo-RL | `nrlta/integration` | [`86774472`](https://github.com/shanmugamr1992/RL/commit/86774472e229b457314418fe3f25e8e844775596) |

Clone URLs are recorded in `prep` so those links can be built at all. The
watchdog issue imports the same renderer rather than keeping its own, which had
begun asserting a bare Bridge sha that is no longer necessarily the pin.

## Test plan

- [x] `test_known_issues.sh` — 18 checks, extended with the downgrade, the
      suspect-pass and unmatched-failure cases that must *not* move, the
      stale-entry case that keeps its `fail`, and `pending-fix-ref` on none /
      one / two pending fixes
- [x] `test_report_stack.sh` — new; 17 checks covering all three Bridge ref
      shapes, the fork link, PR-head vs `main`, header de-duplication, results
      predating the URL record, `--state running`, and the watchdog heading
- [x] Remaining four agent test scripts pass unchanged
- [x] `run_suite.sh --dry-run` picks up `mcore-5382-fix` from the live registry
- [x] Re-annotating the real PR 5382 L1 results downgrades only `topp_topk`
- [x] Rendered against the real PR 5382 and watchdog baseline results
- [x] `ruff check` / `ruff format`