### PR TITLE
Deterministic true on-policy GRPO wit the inference-optimized megatron generation (EP8/TP1)

### DIFF
--- a/docs/design-docs/deterministic-inference-ep8tp1.md
+++ b/docs/design-docs/deterministic-inference-ep8tp1.md
@@ -1,0 +1,32 @@
+# Bitwise-deterministic true on-policy GRPO on the inference-optimized Megatron engine (EP8/TP1)
+
+Generation logprobs bitwise-identical to the training/scoring forward:
+TensorBoard `train/gen_kl_error == 0.000000e+00` over full-lr GRPO
+(18/18 steps, prod bed seq4096/GBS512, 5,217 gen tok/s/GPU = 1.02x tax vs
+matched non-deterministic; small bed 20/20 at 1,368 tok/s/GPU).
+
+## Megatron-LM dependency
+This work requires the companion Megatron-LM branch (deterministic
+inference-optimized engine, certified stack):
+
+    https://github.com/utkarsh530/Megatron-LM/tree/det-inference-ep8tp1-certified
+
+(base: upstream `2463dbe89`, the version this stack was certified against).
+Upstream Megatron master has since gained `batch_invariant_mode`
+(and PR #5700 fixed the InferenceTopKRouter wiring); migration of this stack
+onto that framework is planned as a follow-up
+(`batch-invariant-inference-ep8tp1` branch).
+
+## What this PR adds (NeMo-RL side)
+- fail-fast validation for colocated-vs-dedicated mcore generation config
+- non-colocated (dedicated-node) megatron generation support
+- deterministic scoring path: fused logprob (`float() -> log_softmax ->
+  gather`), per-EP-rank fp64 combine mirror, refit param-gather sync barrier
+- batch-invariant activation hooks in the megatron model setup
+- certified recipe: `examples/configs/recipes/grpo_math_qwen30ba3b_megatron_det_ep8tp1.yaml`
+- determinism CI gate: `examples/gen_kl_harness.py` (run_grpo minus the
+  training loop; asserts bitwise-exact gen-vs-score, ~8 min on 1 node)
+
+## Scope
+EP=8, TP=1, decode-only CUDA graphs. Router replay and MoE config pinning are
+OFF (proven unnecessary: bitwise logits imply identical routes).

--- a/examples/configs/recipes/grpo_math_qwen30ba3b_megatron_det_ep8tp1.yaml
+++ b/examples/configs/recipes/grpo_math_qwen30ba3b_megatron_det_ep8tp1.yaml
@@ -1,0 +1,114 @@
+# GRPO config — Qwen3-30B-A3B, Megatron INFERENCE-OPTIMIZED generation.
+# Copy of grpo_math_qwen30ba3b_megatron.yaml with the colleague's mcore_generation_config
+# block baked in (so transformer_impl etc. load from YAML, not the corrupting +CLI merge).
+# Mounted over /opt/nemo-rl/examples/configs/grpo_math_qwen30ba3b_megatron.yaml at run time.
+defaults: "grpo_math_1B_megatron.yaml"
+
+grpo:
+  num_prompts_per_step: 64
+  num_generations_per_prompt: 32
+
+policy:
+  model_name: "Qwen/Qwen3-30B-A3B"
+  tokenizer:
+    name: ${policy.model_name}
+  train_global_batch_size: 512
+  train_micro_batch_size: 1
+  generation_batch_size: 32
+  logprob_batch_size: 4
+  max_total_sequence_length: 4096
+  precision: "bfloat16"
+  router_replay:
+    enabled: false
+
+  dtensor_cfg:
+    enabled: false
+
+  sequence_packing:
+    enabled: False
+
+  optimizer: null
+  scheduler: null
+
+  megatron_cfg:
+    enabled: true
+    empty_unused_memory_level: 1
+    tensor_model_parallel_size: 2
+    pipeline_model_parallel_size: 1
+    context_parallel_size: 1
+    expert_tensor_parallel_size: 1
+    expert_model_parallel_size: 8
+    sequence_parallel: True
+    pipeline_dtype: ${policy.precision}
+    # Required when capturing CUDA graphs with expert parallelism (EP>1).
+    moe_pad_experts_for_cuda_graph_inference: true
+
+    optimizer:
+      optimizer: "adam"
+      lr: 3.0e-7
+      min_lr: 3.0e-8
+      weight_decay: 0.01
+      bf16: true
+      fp16: false
+      params_dtype: "float32"
+
+    scheduler:
+      start_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
+      end_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
+      weight_decay_incr_style: "constant"
+      lr_decay_style: "constant"
+      lr_decay_iters: 1000
+      lr_warmup_iters: 13
+      lr_warmup_init: 3.0e-8
+
+    env_vars:
+      PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:False"
+
+  generation:
+    backend: "megatron"
+    max_new_tokens: ${policy.max_total_sequence_length}
+    temperature: 1.0
+    top_p: 1.0
+    top_k: null
+    stop_token_ids: null
+    colocated:
+      enabled: false
+      resources:
+        gpus_per_node: 8
+        num_nodes: 1
+    stop_strings: null
+    # Inference-optimized Megatron generation (colleague's config, baked into YAML).
+    mcore_generation_config:
+      max_model_len: ${policy.max_total_sequence_length}
+      transformer_impl: "inference_optimized"
+      cuda_graph_impl: "local"
+      inference_cuda_graph_scope: "block"
+      inference_moe_token_dispatcher_type: "nvls"
+      inference_grouped_gemm_backend: "vllm"
+      moe_pad_experts_for_cuda_graph_inference: false
+      moe_router_num_groups: null
+      moe_router_group_topk: null
+      pipeline_model_parallel_size: 1
+      expert_tensor_parallel_size: 1
+      expert_model_parallel_size: 8
+      sequence_parallel: False
+      context_parallel_size: 1
+      tensor_model_parallel_size: 1
+      buffer_size_gb: 20
+      num_cuda_graphs: -1
+      block_size_tokens: 256
+      use_cuda_graphs_for_non_decode_steps: true
+      enable_chunked_prefill: true
+      max_tokens: 16384
+      kv_cache_management_mode: "persist"
+      materialize_only_last_token_logits: true
+      num_speculative_tokens: 0
+      refit_backend: "nvshmem"
+      async_engine: true
+      expose_http_server: true
+      enable_prefix_caching: true
+
+cluster:
+  gpus_per_node: 8
+  num_nodes: 8
+  segment_size: null

--- a/examples/gen_kl_harness.py
+++ b/examples/gen_kl_harness.py
@@ -1,0 +1,362 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# gen_kl_harness.py — FAITHFUL cheap replica of the NeMo-RL gen_kl determinism path.
+#
+# It reuses NeMo-RL's OWN code paths (setup() model construction, the real engine
+# generate via run_multi_turn_rollout, the real TE-training-path get_logprobs, and
+# the real calculate_kl/masked_mean) to measure gen_kl_error EXACTLY as grpo_train
+# does — but WITHOUT the training loop: no policy.train(), no optimizer step, no
+# refit/weight-sync, no multi-step, no val, no checkpointing.
+#
+# gen_kl_error is computed in grpo_train BEFORE the policy is ever updated
+# (it compares the engine's generation_logprobs against the TE get_logprobs of the
+# same tokens). So one {rollout -> flatten -> get_logprobs -> calculate_kl} pass is
+# a complete, faithful measurement. This is the "cheap test bed" for probing
+# determinism fixes/optimizations without a full GRPO job.
+#
+# Invoke with the SAME config + overrides as the det bed (run_grpo.py), e.g.:
+#   python gen_kl_harness.py --config <yaml> <hydra overrides...>
+#
+# Faithfulness contract (each line here mirrors grpo_train, file:line noted):
+#   preamble         -> examples/run_grpo.py:66-154
+#   repeat + flatten -> grpo.py:2115-2125
+#   generation       -> grpo.py:2177,2232-2243  (run_multi_turn_rollout)
+#   train_data build -> grpo.py:2378-2401  (add_grpo_token_loss_masks..., flatten)
+#   prev_logprobs    -> grpo.py:2449-2479  (prepare_for_lp_inference, get_logprobs)
+#   gen_kl_error     -> loss/loss_functions.py:308-345 (calculate_kl + masked_mean)
+
+import argparse
+import json
+import os
+import pprint
+import time
+
+import torch
+from omegaconf import OmegaConf
+
+from nemo_rl.algorithms.grpo import (
+    MasterConfig,
+    add_grpo_token_loss_masks_and_generation_logprobs,
+    refit_policy_generation,
+    setup,
+)
+from nemo_rl.models.generation.megatron import MegatronGeneration
+from nemo_rl.algorithms.utils import calculate_kl, get_tokenizer, masked_mean
+from nemo_rl.data.llm_message_utils import batched_message_log_to_flat_message
+from nemo_rl.data.utils import setup_response_data
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.distributed.virtual_cluster import init_ray
+from nemo_rl.experience.rollouts import run_multi_turn_rollout
+from nemo_rl.models.generation import configure_generation_config
+from nemo_rl.models.megatron.router_replay import router_replay_enabled
+from nemo_rl.utils.config import (
+    load_config,
+    parse_hydra_overrides,
+    register_omegaconf_resolvers,
+)
+from nemo_rl.utils.logger import get_next_experiment_dir
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="gen_kl determinism harness")
+    parser.add_argument("--config", type=str, default=None, help="Path to YAML config")
+    parser.add_argument(
+        "--num-batches",
+        type=int,
+        default=1,
+        help="How many dataloader batches to measure (each = one gen+score+kl pass)",
+    )
+    parser.add_argument(
+        "--jsonl",
+        type=str,
+        default=os.environ.get("NRL_GENKL_JSONL", "gen_kl_harness_results.jsonl"),
+        help="Where to append per-batch results",
+    )
+    args, overrides = parser.parse_known_args()
+    return args, overrides
+
+
+def _report(tag, gen_lp, prev_lp, token_mask, sample_mask, kl_type):
+    """Compute gen_kl EXACTLY as ClippedPGLossFn (loss_functions.py:308-345),
+    plus richer diagnostics the bed floors away (max|Δ|, exact-match count)."""
+    gen = gen_lp[:, 1:]
+    prev = prev_lp[:, 1:]
+    mask = token_mask[:, 1:] * sample_mask.unsqueeze(-1)
+    global_valid_toks = mask.sum()
+
+    # k3 (default) gen_kl — the shipped metric
+    gen_kl = calculate_kl(
+        logprobs=gen,
+        logprobs_reference=prev,
+        kl_type=kl_type,
+        input_clamp_value=None,
+        output_clamp_value=None,
+    )
+    gen_kl_mean = masked_mean(
+        gen_kl, mask, global_normalization_factor=global_valid_toks
+    ).item()
+
+    # diagnostics
+    lp_abs = torch.abs(gen - prev)
+    m = mask.bool()
+    n_valid = int(m.sum().item())
+    if n_valid == 0:
+        return {
+            "tag": tag,
+            "gen_kl_error": gen_kl_mean,
+            "n_valid_toks": 0,
+        }
+    masked_abs = lp_abs[m]
+    max_abs = masked_abs.max().item()
+    mean_abs = masked_abs.mean().item()
+    # bitwise-exact tokens (|Δlp| == 0.0)
+    n_exact = int((masked_abs == 0.0).sum().item())
+    mult_prob_error = masked_mean(
+        torch.exp(lp_abs * mask), mask, global_normalization_factor=global_valid_toks
+    ).item()
+
+    return {
+        "tag": tag,
+        "gen_kl_error": gen_kl_mean,
+        "mult_prob_error": mult_prob_error,
+        "max_abs_lp_err": max_abs,
+        "mean_abs_lp_err": mean_abs,
+        "n_valid_toks": n_valid,
+        "n_exact_toks": n_exact,
+        "frac_exact": n_exact / n_valid,
+    }
+
+
+def main():
+    register_omegaconf_resolvers()
+    args, overrides = parse_args()
+    if not args.config:
+        raise SystemExit("--config is required (use the det bed yaml)")
+
+    config = load_config(args.config)
+    print(f"[HARNESS] Loaded configuration from: {args.config}", flush=True)
+    if overrides:
+        print(f"[HARNESS] Overrides: {overrides}", flush=True)
+        config = parse_hydra_overrides(config, overrides)
+    config = OmegaConf.to_container(config, resolve=True)
+    config = MasterConfig(**config)
+    print("[HARNESS] Final config:")
+    pprint.pprint(config)
+
+    config.logger["log_dir"] = get_next_experiment_dir(config.logger["log_dir"])
+    print(f"[HARNESS] log dir: {config.logger['log_dir']}", flush=True)
+
+    init_ray()
+
+    # ---- setup: EXACTLY run_grpo.py:99-154 (tokenizer, gen cfg, data, setup) ----
+    tokenizer = get_tokenizer(config.policy["tokenizer"])
+    assert config.policy["generation"] is not None, "generation config required"
+    has_refit_draft_weights = bool(config.policy["draft"]["enabled"])
+    megatron_cfg = config.policy.get("megatron_cfg") or {}
+    trains_mtp = bool(megatron_cfg.get("mtp_num_layers"))
+    config.policy["generation"] = configure_generation_config(
+        config.policy["generation"],
+        tokenizer,
+        has_refit_draft_weights=has_refit_draft_weights,
+        trains_mtp=trains_mtp,
+    )
+
+    dataset, val_dataset, task_to_env, val_task_to_env = setup_response_data(
+        tokenizer, config.data, config.env
+    )
+
+    (
+        policy,
+        policy_generation,
+        _nemo_gym,
+        cluster,
+        dataloader,
+        val_dataloader,
+        loss_fn,
+        logger,
+        checkpointer,
+        grpo_state,
+        master_config,
+    ) = setup(config, tokenizer, dataset, val_dataset, policy_factory=None)
+
+    kl_type = master_config.loss_fn.reference_policy_kl_type
+    num_gen = master_config.grpo["num_generations_per_prompt"]
+    make_div_by = master_config.policy["make_sequence_length_divisible_by"]
+    max_seq_len = master_config.policy["max_total_sequence_length"]
+    max_rollout_turns = master_config.grpo["max_rollout_turns"]
+
+    print(
+        f"[HARNESS] kl_type={kl_type} num_gen={num_gen} "
+        f"make_div_by={make_div_by} max_seq_len={max_seq_len}",
+        flush=True,
+    )
+
+    # ---- first-generation weight sync: grpo.py:2014-2018, 2133-2177 ----
+    # grpo_train ALWAYS refits before the first generation when gen is a separate
+    # worker group (NEED_REFIT: MegatronGeneration non-colocated => True). Mirror it
+    # so the gen model carries exactly the weights the scoring model has.
+    colocated_inference = master_config.policy["generation"]["colocated"]["enabled"]
+    need_refit = not (
+        isinstance(policy_generation, MegatronGeneration) and colocated_inference
+    )
+    print(f"[HARNESS] colocated={colocated_inference} need_refit={need_refit}", flush=True)
+    refit_done = False
+
+    results = []
+    n_done = 0
+    for batch in dataloader:
+        if n_done >= args.num_batches:
+            break
+        t0 = time.time()
+        # ---- repeat + flatten for generation: grpo.py:2115-2125 ----
+        repeated_batch = batch.repeat_interleave(num_gen)
+
+        # ---- generation via the REAL engine path: grpo.py:2133-2177,2232-2243 ----
+        if need_refit and not refit_done:
+            refit_policy_generation(policy, policy_generation, colocated_inference)
+            refit_done = True
+        else:
+            if colocated_inference:
+                policy.offload_after_refit()
+            policy_generation.prepare_for_generation()
+        repeated_batch, rollout_metrics = run_multi_turn_rollout(
+            policy_generation=policy_generation,
+            input_batch=repeated_batch,
+            tokenizer=tokenizer,
+            task_to_env=task_to_env,
+            max_seq_len=max_seq_len,
+            max_rollout_turns=max_rollout_turns,
+            greedy=False,
+        )
+        policy_generation.finish_generation()
+        t_gen = time.time() - t0
+
+        # ---- build train_data EXACTLY as grpo.py:2378-2401 ----
+        add_grpo_token_loss_masks_and_generation_logprobs(repeated_batch["message_log"])
+        flat_messages, input_lengths = batched_message_log_to_flat_message(
+            repeated_batch["message_log"],
+            pad_value_dict={"token_ids": tokenizer.pad_token_id},
+            make_sequence_length_divisible_by=make_div_by,
+        )
+        train_data = BatchedDataDict(
+            {
+                "input_ids": flat_messages["token_ids"],
+                "input_lengths": input_lengths,
+                "generation_logprobs": flat_messages["generation_logprobs"],
+                "token_mask": flat_messages["token_loss_mask"],
+                "sample_mask": repeated_batch["loss_multiplier"],
+            }
+        )
+        train_data.to("cpu")
+
+        # ---- prev_logprobs via TE training-path get_logprobs: grpo.py:2449-2479 ----
+        policy.prepare_for_lp_inference()
+        logprob_data = BatchedDataDict(
+            {
+                "input_ids": train_data["input_ids"],
+                "input_lengths": train_data["input_lengths"],
+                "token_mask": flat_messages["token_loss_mask"],
+                "sample_mask": repeated_batch["loss_multiplier"],
+            }
+        )
+        if (
+            router_replay_enabled(master_config.policy)
+            and "routed_experts" in flat_messages
+        ):
+            logprob_data["routed_experts"] = flat_messages["routed_experts"]
+        t1 = time.time()
+        prev_logprobs = policy.get_logprobs(logprob_data)["logprobs"]
+        t_score = time.time() - t1
+
+        # ---- gen_kl EXACTLY as loss_functions.py:308-345 ----
+        rec = _report(
+            f"batch{n_done}",
+            train_data["generation_logprobs"],
+            prev_logprobs,
+            train_data["token_mask"],
+            train_data["sample_mask"],
+            kl_type,
+        )
+        rec["t_gen_s"] = round(t_gen, 2)
+        rec["t_score_s"] = round(t_score, 2)
+        rec["batch_size"] = int(train_data["input_ids"].shape[0])
+        rec["seq_len"] = int(train_data["input_ids"].shape[1])
+
+        # ---- per-sequence victim diagnostics (prod-bed tail localization) ----
+        # Which sequences carry the mismatches, where does divergence start within
+        # each victim, and are victims the truncated (cap-hitting) sequences?
+        _gen = train_data["generation_logprobs"][:, 1:]
+        _prev = prev_logprobs[:, 1:]
+        _m = (train_data["token_mask"][:, 1:] * train_data["sample_mask"].unsqueeze(-1)).bool()
+        _diff = (_gen != _prev) & _m
+        _bad_per_seq = _diff.sum(dim=1)
+        _victims = (_bad_per_seq > 0).nonzero(as_tuple=True)[0]
+        _trunc = repeated_batch.get("truncated", None)
+        if _trunc is not None and not torch.is_tensor(_trunc):
+            _trunc = torch.tensor(_trunc, dtype=torch.bool)
+        _n_trunc_total = int(_trunc.sum().item()) if _trunc is not None else -1
+        vdiags = []
+        for _vi in _victims.tolist():
+            _row = _diff[_vi].nonzero(as_tuple=True)[0]
+            _mrow = _m[_vi].nonzero(as_tuple=True)[0]
+            _gen_start = int(_mrow.min().item())
+            _gen_end = int(_mrow.max().item())
+            vdiags.append({
+                "idx": _vi,
+                "n_bad": int(_bad_per_seq[_vi].item()),
+                "n_valid": int(_m[_vi].sum().item()),
+                "gen_span": [_gen_start, _gen_end],
+                "first_bad_off": int(_row.min().item()) - _gen_start,
+                "last_bad_off": int(_row.max().item()) - _gen_start,
+                "input_len": int(train_data["input_lengths"][_vi].item()),
+                "truncated": bool(_trunc[_vi].item()) if _trunc is not None else None,
+            })
+        _n_vt = sum(1 for v in vdiags if v["truncated"]) if _trunc is not None else -1
+        rec["n_victims"] = len(vdiags)
+        rec["n_victims_truncated"] = _n_vt
+        rec["n_truncated_total"] = _n_trunc_total
+        rec["victims"] = vdiags[:40]
+        print(f"[VICTIMS] {rec['tag']}: {len(vdiags)} victim seqs / {rec['batch_size']} "
+              f"(truncated victims: {_n_vt}/{_n_trunc_total} truncated in batch)", flush=True)
+        for v in vdiags[:20]:
+            _glen = v["gen_span"][1] - v["gen_span"][0] + 1
+            print(f"[VICTIMS]   idx={v['idx']:5d} bad={v['n_bad']:5d}/{v['n_valid']:5d} "
+                  f"first_bad@{v['first_bad_off']}/{_glen} last@{v['last_bad_off']} "
+                  f"in_len={v['input_len']} trunc={v['truncated']}", flush=True)
+        results.append(rec)
+
+        print(
+            f"\n[GENKL] {rec['tag']}: gen_kl_error={rec['gen_kl_error']:.3e}  "
+            f"max|Δlp|={rec.get('max_abs_lp_err', float('nan')):.3e}  "
+            f"exact={rec.get('n_exact_toks', 0)}/{rec.get('n_valid_toks', 0)} "
+            f"({rec.get('frac_exact', 0.0) * 100:.2f}%)  "
+            f"mult_prob_err={rec.get('mult_prob_error', float('nan')):.6f}  "
+            f"[gen {t_gen:.1f}s score {t_score:.1f}s]\n",
+            flush=True,
+        )
+        with open(args.jsonl, "a") as f:
+            f.write(json.dumps(rec) + "\n")
+        n_done += 1
+
+    # ---- summary ----
+    if results:
+        kls = [r["gen_kl_error"] for r in results]
+        maxes = [r.get("max_abs_lp_err", 0.0) for r in results]
+        print("\n" + "=" * 60, flush=True)
+        print(f"[GENKL SUMMARY] batches={len(results)}", flush=True)
+        print(
+            f"[GENKL SUMMARY] gen_kl_error: min={min(kls):.3e} "
+            f"max={max(kls):.3e} mean={sum(kls) / len(kls):.3e}",
+            flush=True,
+        )
+        print(f"[GENKL SUMMARY] worst max|Δlp| over batches = {max(maxes):.3e}", flush=True)
+        all_exact = all(m == 0.0 for m in maxes)
+        print(
+            f"[GENKL SUMMARY] VERDICT: {'BITWISE-EXACT ZERO' if all_exact else 'NON-ZERO RESIDUAL'}",
+            flush=True,
+        )
+        print("=" * 60, flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -749,6 +749,37 @@ def setup(
             flush=True,
         )
 
+    elif os.environ.get("NRL_MINF_SHARED_CLUSTER") == "1":
+        # PATCH(PR-3 v0 / single-node dedicated megatron generation):
+        # colocated.enabled=false keeps the PROVEN non-colocated choreography
+        # (dedicated inference Policy + collective weight refit, validated at
+        # 2906-2981 tok/s/gpu on 2 nodes), but instead of splitting nodes we
+        # build ONE shared cluster with max_colocated_worker_groups=2 so the
+        # training and generation worker groups co-schedule on the SAME GPUs
+        # (fractional num_gpus, the same mechanism vLLM colocated uses).
+        # Memory: both models resident (train ~90GB/GPU + gen weights/KV
+        # ~35GB) — sized for 180GB B200s; OOM here means fall back to 2-node.
+        cluster = RayVirtualCluster(
+            name="grpo_shared_cluster",
+            bundle_ct_per_node_list=[cluster_config["gpus_per_node"]] * total_nodes,
+            use_gpus=True,
+            num_gpus_per_node=cluster_config["gpus_per_node"],
+            max_colocated_worker_groups=2,
+            port_range_low=cluster_config.get("master_port_range_low"),
+            port_range_high=cluster_config.get("master_port_range_high"),
+            segment_size=segment_size,
+        )
+        train_cluster = cluster
+        inference_cluster = cluster
+        # Consumed later for the refit collective world size (setup() ~line 1119):
+        # the generation Policy spans the full shared cluster.
+        inference_nodes = total_nodes
+        inference_gpus_per_node = cluster_config["gpus_per_node"]
+        print(
+            f"  ✓ PR-3 v0 SHARED cluster: train + dedicated-gen co-scheduled on "
+            f"{total_nodes} node(s) x {cluster_config['gpus_per_node']} GPUs (fractional workers)",
+            flush=True,
+        )
     else:
         # train resources will be updated through overall and inference resources below
         train_gpus_per_node = cluster_config["gpus_per_node"]

--- a/nemo_rl/algorithms/utils.py
+++ b/nemo_rl/algorithms/utils.py
@@ -791,6 +791,13 @@ def print_performance_metrics(
         )
         training_num_gpus = total_num_gpus - generation_num_gpus
 
+    # PATCH(PR-3 v0): with the shared-cluster mode (train + dedicated generation
+    # co-scheduled on the SAME GPUs), generation_num_gpus == total_num_gpus and the
+    # subtraction above yields 0 -> divide-by-zero -> inf throughputs. The GPU sets
+    # overlap fully, so the correct denominator is the full set.
+    if training_num_gpus <= 0:
+        training_num_gpus = total_num_gpus
+
     total_num_tokens = metrics.get("total_num_tokens", 0)
 
     e2e_samples_per_sec_per_gpu = (

--- a/nemo_rl/models/generation/megatron/megatron_generation.py
+++ b/nemo_rl/models/generation/megatron/megatron_generation.py
@@ -102,6 +102,31 @@ class MegatronGeneration(GenerationInterface):
 
         if policy is not None:
             # Reuse the existing training policy.
+            # Fail fast: colocated generation reuses the TRAINING model, so
+            # model-side keys in mcore_generation_config are silently ignored
+            # (the megatron_cfg merge below only runs in the dedicated-Policy
+            # branch). Raise instead of no-opping.
+            _MODEL_SIDE_KEYS = (
+                "transformer_impl",
+                "inference_grouped_gemm_backend",
+                "inference_moe_token_dispatcher_type",
+                "tensor_model_parallel_size",
+                "pipeline_model_parallel_size",
+                "expert_model_parallel_size",
+                "expert_tensor_parallel_size",
+                "context_parallel_size",
+                "sequence_parallel",
+            )
+            _ignored = [
+                k for k in _MODEL_SIDE_KEYS if k in self.cfg["mcore_generation_config"]
+            ]
+            if _ignored:
+                raise ValueError(
+                    f"generation.colocated.enabled=true reuses the training model; "
+                    f"model-side keys {_ignored} in mcore_generation_config would be "
+                    f"silently ignored. Set generation.colocated.enabled=false to build "
+                    f"a dedicated inference model with these settings, or remove them."
+                )
             self._policy = policy
             self._owns_policy = False
             if self.cfg["mcore_generation_config"]["expose_http_server"]:

--- a/nemo_rl/models/generation/megatron/megatron_worker.py
+++ b/nemo_rl/models/generation/megatron/megatron_worker.py
@@ -554,6 +554,46 @@ class MegatronGenerationMixin:
             "unpadded_sequence_lengths": unpadded_sequence_lengths,
         }
 
+        # PATCH(PR-4 router-replay-mcore): pack per-request routing indices
+        # recorded by the mcore engine (model_config.moe_enable_routing_replay)
+        # into GenerationOutputSpec["routed_experts"], mirroring the alignment
+        # contract of vllm/utils.pad_and_align_routed_expert_indices:
+        # row t = experts used when token t was processed as input; rows
+        # [0, seq_len-1) are real, missing rows in that range use the all--1
+        # sentinel (consumer falls back to fresh top-k), padding rows use
+        # arange(topk) (masked out downstream, must merely be valid ids).
+        # PATCH(det): route replay is proven redundant for the det stack (bitwise
+        # logits => identical routes; certificate 2322656). The harvest also crashes
+        # grpo message-log flattening when shards emit inconsistent shapes (job
+        # 2322767: [seq,48,8] vs [seq]). Pack ONLY when explicitly requested.
+        import os as _os_re
+        routing_arrays = [getattr(r, "routing_indices", None) for r in result]
+        if (_os_re.environ.get("NRL_PACK_ROUTED_EXPERTS", "0") == "1"
+                and any(ra is not None for ra in routing_arrays)):
+            template = next(ra for ra in routing_arrays if ra is not None)
+            num_moe_layers, topk = int(template.shape[1]), int(template.shape[2])
+            default_route = torch.arange(topk, dtype=torch.int32, device=input_ids.device)
+            routed_experts_padded = (
+                default_route.view(1, 1, 1, -1)
+                .expand(batch_size, max_seq_len, num_moe_layers, topk)
+                .clone()
+            )
+            for i in range(batch_size):
+                expected_routes = int(unpadded_sequence_lengths[i].item()) - 1
+                if expected_routes <= 0:
+                    continue
+                if routing_arrays[i] is None:
+                    routed_experts_padded[i, :expected_routes] = -1
+                    continue
+                routed = torch.as_tensor(
+                    routing_arrays[i], dtype=torch.int32, device=input_ids.device
+                )
+                routes_to_copy = min(expected_routes, routed.shape[0])
+                routed_experts_padded[i, :routes_to_copy] = routed[:routes_to_copy]
+                if routes_to_copy < expected_routes:
+                    routed_experts_padded[i, routes_to_copy:expected_routes] = -1
+            out_dict["routed_experts"] = routed_experts_padded
+
         return BatchedDataDict.from_batches([out_dict]).to("cpu")
 
     @wrap_with_nvtx_name("megatron_policy_worker/generate")
@@ -634,6 +674,227 @@ class MegatronGenerationMixin:
         for result in asyncio.as_completed(tasks):
             yield await result
 
+        # PATCH(det quiesced probe, NRL_PROBE_QUIESCED=1): all generation for this call
+        # has drained; the engine is idle. Three-way attribution on stashed sequences:
+        #   P2  = decode-time generated_log_probs vs SOLO prefill score (quiet engine)
+        #   P1  = SOLO score vs GROUP score (same kernels/phase, only co-batch differs)
+        # plus route flips between solo and group scoring passes.
+        if (
+            os.environ.get("NRL_PROBE_QUIESCED", "0") == "1"
+            and getattr(self, "_nrl_probe_stash", None)
+        ):
+            stash = self._nrl_probe_stash
+            self._nrl_probe_stash = []
+            n_probe = int(os.environ.get("NRL_PROBE_QUIESCED_N", "16"))
+            probe_set = stash[:n_probe]
+
+            def _mk_sp():
+                sp = self._build_sampling_params(greedy=False, stop_words=None)
+                sp.num_tokens_to_generate = 1
+                sp.skip_prompt_log_probs = False
+                return sp
+
+            async def _score(tokens):
+                fut = self.inference_client.add_request(tokens, _mk_sp())
+                return await fut
+
+            def _p2_stats(r, s):
+                gen_lp = list(r.generated_log_probs)
+                plp = list(s.prompt_log_probs or [])
+                p_len = len(r.prompt_tokens)
+                d = [
+                    abs(gen_lp[j] - plp[p_len - 1 + j])
+                    for j in range(len(gen_lp))
+                    if p_len - 1 + j < len(plp)
+                ]
+                if not d:
+                    return None
+                return (sum(1 for x in d if x == 0.0), len(d), max(d))
+
+            # PATCH(det route-replay-into-scoring, probe v7, NRL_PROBE_REPLAY=1):
+            # after the solo pass, re-score each sequence with its generation-time
+            # routes REPLAYED into the scoring prefill (partial-replay hook in
+            # InferenceTopKRouter._forward, armed via
+            # router_replay.nrl_partial_target). Arming is engine-LOCAL to this
+            # rank-0 worker process, but the DP coordinator round-robins requests
+            # over all 8 engines — so retry the (idempotent, quiesced-solo) scoring
+            # request until the returned routing_indices verbatim-match the target
+            # (proof the request prefilled on THIS rank with replay engaged).
+            # Strictly one request in flight at a time; the pair phase is skipped.
+            def _routers_in_layer_order():
+                lang = unwrap_model(self.model)
+                return [
+                    m
+                    for _n, m in lang.named_modules()
+                    if getattr(m, "router_replay", None) is not None
+                ]
+
+            async def _replay_score_one(r, so, routers):
+                import numpy as _np
+
+                ri = getattr(r, "routing_indices", None)
+                if ri is None:
+                    print("[NRL_RPROBE] skip: request has no routing_indices", flush=True)
+                    return
+                ri = _np.asarray(ri)
+                n_rows, n_layers, _topk = ri.shape
+                if len(routers) != n_layers:
+                    print(
+                        f"[NRL_RPROBE] skip: {len(routers)} armed routers != "
+                        f"{n_layers} recorded layers",
+                        flush=True,
+                    )
+                    return
+                tgt = torch.from_numpy(_np.ascontiguousarray(ri)).to(
+                    device="cuda", dtype=torch.int64
+                )  # [T-1, L, K]
+                layer_tgts = [tgt[:, li, :].contiguous() for li in range(n_layers)]
+                full = r.prompt_tokens.tolist() + list(r.generated_tokens)
+                max_attempts = int(os.environ.get("NRL_RPROBE_MAX_ATTEMPTS", "10"))
+                res, engaged, attempts = None, False, 0
+                for _attempt in range(max_attempts):
+                    attempts = _attempt + 1
+                    for rt, lt in zip(routers, layer_tgts):
+                        rt.router_replay.nrl_partial_target = lt
+                    try:
+                        res = await _score(full)
+                    finally:
+                        for rt in routers:
+                            rt.router_replay.nrl_partial_target = None
+                    rs = getattr(res, "routing_indices", None)
+                    if (
+                        rs is not None
+                        and rs.shape[0] >= n_rows
+                        and _np.array_equal(
+                            _np.asarray(rs)[:n_rows].astype(_np.int64),
+                            ri.astype(_np.int64),
+                        )
+                    ):
+                        engaged = True
+                        break
+                # Route flips vs generation (top-k SET comparison, as in earlier probes).
+                rs = getattr(res, "routing_indices", None)
+                rflip, m = -1, 0
+                if rs is not None:
+                    rs = _np.asarray(rs)
+                    m = min(n_rows, rs.shape[0])
+                    neq = _np.sort(rs[:m], -1) != _np.sort(ri[:m], -1)
+                    rflip = int(neq.any(-1).any(-1).sum())
+                # Per-token |dlp| distribution: decode-time logprobs vs replay-scored prefill.
+                gen_lp = list(r.generated_log_probs)
+                plp = list(res.prompt_log_probs or [])
+                p_len = len(r.prompt_tokens)
+                d = [
+                    abs(gen_lp[j] - plp[p_len - 1 + j])
+                    for j in range(len(gen_lp))
+                    if p_len - 1 + j < len(plp)
+                ]
+                dist = ""
+                if d:
+                    ds = sorted(d)
+                    dist = (
+                        f" mean={sum(d) / len(d):.3e} p50={ds[len(ds) // 2]:.3e}"
+                        f" p90={ds[min(int(len(ds) * 0.9), len(ds) - 1)]:.3e}"
+                        f" p99={ds[min(int(len(ds) * 0.99), len(ds) - 1)]:.3e}"
+                    )
+                p2r = (
+                    (sum(1 for x in d if x == 0.0), len(d), max(d)) if d else None
+                )
+                # Solo(unarmed) score vs replay score — same phase/kernels, routes pinned.
+                so_lp = list(so.prompt_log_probs or [])
+                nn = min(len(so_lp), len(plp))
+                d1 = [abs(so_lp[j] - plp[j]) for j in range(nn)]
+                print(
+                    "[NRL_RPROBE] P2r(gen-vs-replayscore): "
+                    + (f"exact={p2r[0]}/{p2r[1]} max={p2r[2]:.3e}" if p2r else "n/a")
+                    + f" route_flips={rflip}/{m}{dist}"
+                    + f" engaged={int(engaged)} attempts={attempts}"
+                    + f" | P1r(solo-vs-replay): exact={sum(1 for x in d1 if x == 0.0)}/{nn}"
+                    + (f" max={max(d1):.3e}" if d1 else " max=n/a"),
+                    flush=True,
+                )
+
+            async def _quiesced_probe():
+                # Serialize probes: multiple generate_async calls can schedule
+                # probe coroutines on this loop; replay arming is engine-global
+                # state, and solo scoring must truly be one request at a time.
+                if not hasattr(self, "_nrl_probe_gate"):
+                    self._nrl_probe_gate = asyncio.Lock()
+                async with self._nrl_probe_gate:
+                    await _quiesced_probe_body()
+
+            async def _quiesced_probe_body():
+                solo_results = []
+                for r in probe_set:
+                    full = r.prompt_tokens.tolist() + list(r.generated_tokens)
+                    solo_results.append(await _score(full))  # strictly one at a time
+                if os.environ.get("NRL_PROBE_REPLAY", "0") == "1":
+                    routers = _routers_in_layer_order()
+                    for r, so in zip(probe_set, solo_results):
+                        try:
+                            await _replay_score_one(r, so, routers)
+                        except Exception:
+                            import traceback
+
+                            traceback.print_exc()
+                    return  # replay experiment: never submit pairs
+                # PATCH(probe v6): PAIR-WISE group submission — one pair in flight at a
+                # time, so any merged (~1024-row) dump pass between the pair markers is
+                # attributable to exactly these two sequences.
+                group_results = []
+                for _i in range(0, len(probe_set), 2):
+                    _chunk = probe_set[_i : _i + 2]
+                    print(f"[NRL_QPROBE_PAIR] indices={_i},{_i+1}", flush=True)
+                    _rs = await asyncio.gather(
+                        *[
+                            _score(r.prompt_tokens.tolist() + list(r.generated_tokens))
+                            for r in _chunk
+                        ]
+                    )
+                    group_results.extend(_rs)
+                for r, so, gr in zip(probe_set, solo_results, group_results):
+                    p2 = _p2_stats(r, so)
+                    so_lp = list(so.prompt_log_probs or [])
+                    gr_lp = list(gr.prompt_log_probs or [])
+                    n = min(len(so_lp), len(gr_lp))
+                    d1 = [abs(so_lp[j] - gr_lp[j]) for j in range(n)]
+                    p1_exact = sum(1 for x in d1 if x == 0.0)
+                    p1_max = max(d1) if d1 else -1.0
+                    rflip = -1
+                    layer_info = ""
+                    ri_s, ri_g = getattr(so, "routing_indices", None), getattr(
+                        gr, "routing_indices", None
+                    )
+                    if ri_s is not None and ri_g is not None:
+                        import numpy as _np
+
+                        m = min(ri_s.shape[0], ri_g.shape[0])
+                        neq = _np.sort(ri_s[:m], -1) != _np.sort(ri_g[:m], -1)
+                        per_layer = neq.any(-1).sum(axis=0)  # [L] tokens flipped per layer
+                        rflip = int(neq.any(-1).any(-1).sum())
+                        nz = _np.nonzero(per_layer)[0]
+                        first_l = int(nz[0]) if nz.size else -1
+                        L = per_layer.shape[0]
+                        q = max(L // 4, 1)
+                        buckets = [int(per_layer[i : i + q].sum()) for i in range(0, L, q)]
+                        layer_info = (
+                            f" first_flip_layer={first_l}"
+                            f" l0-3={[int(per_layer[i]) for i in range(min(4, L))]}"
+                            f" layer_buckets={buckets}"
+                        )
+                    print(
+                        f"[NRL_QPROBE] P2(gen-vs-solo): "
+                        + (f"exact={p2[0]}/{p2[1]} max={p2[2]:.3e}" if p2 else "n/a")
+                        + f" | P1(solo-vs-group): exact={p1_exact}/{n} max={p1_max:.3e}"
+                        f" route_flips={rflip}/{m if rflip >= 0 else 0}" + layer_info,
+                        flush=True,
+                    )
+
+            future = asyncio.run_coroutine_threadsafe(
+                _quiesced_probe(), self._inference_loop
+            )
+            await asyncio.wrap_future(future)
+
     async def _generate_with_persistent_engine(
         self,
         prompt_tokens_tensor: torch.Tensor,
@@ -663,6 +924,93 @@ class MegatronGenerationMixin:
 
         results: list[DynamicInferenceRequest] = await asyncio.gather(*futures)
         print(f"[Rank {dist_rank}] Completed {len(results)} requests")
+
+        # PATCH(det self-score probe, NRL_PROBE_SELF_SCORE=1): re-score each finished
+        # sequence through the SAME engine's prefill and diff against the decode-time
+        # generated_log_probs. Measures the engine's decode-vs-prefill self-consistency —
+        # the floor that engine-based logprob scoring (fused-logprob option A) can reach.
+        # Requires mcore_generation_config.materialize_only_last_token_logits=false
+        # (engine asserts otherwise). Alignment: scoring prompt_log_probs[j] = logprob of
+        # token j+1 given prefix; generated token P+j (0-based) -> prompt_log_probs[P-1+j].
+        if os.environ.get("NRL_PROBE_QUIESCED", "0") == "1":
+            # PATCH(det quiesced probe): defer scoring to the post-generation quiet
+            # window (see generate_async) instead of interleaving with live decode.
+            if not hasattr(self, "_nrl_probe_stash"):
+                self._nrl_probe_stash = []
+            self._nrl_probe_stash.extend(results)
+        elif os.environ.get("NRL_PROBE_SELF_SCORE", "0") == "1":
+            score_futures = []
+            for r in results:
+                full_tokens = r.prompt_tokens.tolist() + list(r.generated_tokens)
+                sp = self._build_sampling_params(greedy=False, stop_words=None)
+                sp.num_tokens_to_generate = 1
+                sp.skip_prompt_log_probs = False
+                score_futures.append(self.inference_client.add_request(full_tokens, sp))
+            score_results = await asyncio.gather(*score_futures)
+            for r, s in zip(results, score_results):
+                gen_lp = list(r.generated_log_probs)
+                plp = s.prompt_log_probs
+                if plp is None:
+                    print("[NRL_SELF_SCORE] prompt_log_probs is None — set "
+                          "materialize_only_last_token_logits=false", flush=True)
+                    break
+                plp = list(plp)
+                p_len = len(r.prompt_tokens)
+                diffs = [
+                    abs(gen_lp[j] - plp[p_len - 1 + j])
+                    for j in range(len(gen_lp))
+                    if p_len - 1 + j < len(plp)
+                ]
+                if diffs:
+                    n_exact = sum(1 for d in diffs if d == 0.0)
+                    print(
+                        f"[NRL_SELF_SCORE] G={len(diffs)} max={max(diffs):.3e} "
+                        f"mean={sum(diffs)/len(diffs):.3e} exact={n_exact}/{len(diffs)}",
+                        flush=True,
+                    )
+                # PATCH(det self-score probe v2): route-flip attribution. Both requests
+                # record routing (moe_enable_routing_replay); routing row i = experts
+                # used processing input token i, so generated token j uses row p_len-1+j
+                # (same row the logprob comes from). A token is "flipped" if ANY MoE
+                # layer's top-k SET differs between the decode-time and scoring passes.
+                ri_g = getattr(r, "routing_indices", None)
+                ri_s = getattr(s, "routing_indices", None)
+                if ri_g is not None and ri_s is not None and diffs:
+                    import numpy as _np
+
+                    n_rows = min(len(diffs), ri_g.shape[0] - (p_len - 1), ri_s.shape[0] - (p_len - 1))
+                    flip_d, same_d = [], []
+                    layer_flips = _np.zeros(ri_g.shape[1], dtype=_np.int64)
+                    for j in range(max(n_rows, 0)):
+                        rg = _np.sort(ri_g[p_len - 1 + j], axis=-1)
+                        rs = _np.sort(ri_s[p_len - 1 + j], axis=-1)
+                        per_layer = (rg != rs).any(axis=-1)
+                        if per_layer.any():
+                            flip_d.append(diffs[j])
+                            layer_flips += per_layer
+                        else:
+                            same_d.append(diffs[j])
+                    if flip_d or same_d:
+                        same_exact = sum(1 for d in same_d if d == 0.0)
+                        top_layers = _np.argsort(layer_flips)[::-1][:3]
+                        # v3: prompt-region control — positions 0..P-2 were computed in
+                        # PREFILL mode by BOTH passes; their flip rate is the
+                        # prefill-vs-prefill baseline (and a row-alignment sanity check:
+                        # if ~= generated-region rate, suspect misalignment or pure
+                        # batch-composition variance).
+                        n_prompt_rows = min(p_len - 1, ri_g.shape[0], ri_s.shape[0])
+                        pg = _np.sort(ri_g[:n_prompt_rows], axis=-1)
+                        ps = _np.sort(ri_s[:n_prompt_rows], axis=-1)
+                        prompt_flips = int((pg != ps).any(axis=-1).any(axis=-1).sum())
+                        print(
+                            f"[NRL_ROUTE_DIFF] flip={len(flip_d)}/{len(flip_d)+len(same_d)} "
+                            f"dlp_flip={sum(flip_d)/max(len(flip_d),1):.3e} "
+                            f"dlp_same={sum(same_d)/max(len(same_d),1):.3e} "
+                            f"exact_same={same_exact}/{max(len(same_d),1)} "
+                            f"prompt_flip={prompt_flips}/{n_prompt_rows} "
+                            f"top_flip_layers={[(int(l), int(layer_flips[l])) for l in top_layers if layer_flips[l] > 0]}",
+                            flush=True,
+                        )
         return results
 
 
@@ -816,6 +1164,29 @@ class MegatronGenerationRefitMixin:
         """
         from megatron.core.resharding.refit import swap_model_weights
 
+        # PATCH(golden refit-param-sync, upstream #13, ported from the det-TE golden
+        # worker): with distributed optimizer + overlap_param_gather, the post-step
+        # param all-gather completes lazily via TRAINING forward pre-hooks; refit can
+        # read param.data before they fire, shipping a bucket-wise MIX of theta_k and
+        # theta_{k-1} to the gen model (multi-step gen-KL drift). Force param-sync
+        # completion on the SRC before reading weights.
+        import os as _os_ps
+        if (
+            _os_ps.environ.get("NRL_REFIT_PARAM_SYNC", "0") == "1"
+            and is_source
+            and getattr(self, "should_disable_forward_pre_hook", False)
+        ):
+            _resync = self._forward_pre_hook_enabled()
+            if _resync:
+                self.disable_forward_pre_hook(param_sync=True)
+                self.enable_forward_pre_hook()
+            if not getattr(type(self), "_nrl_ps_banner", False):
+                type(self)._nrl_ps_banner = True
+                print(
+                    f"[NRL_REFIT_PARAM_SYNC] forced param-gather completion before refit (hook_was_enabled={_resync})",
+                    flush=True,
+                )
+
         src_model = self.model if is_source else None
         dst_model = None if is_source else self.model
 
@@ -827,6 +1198,32 @@ class MegatronGenerationRefitMixin:
             src_rank_offset=0,
             dst_rank_offset=self.refit_dst_rank_offset,
         )
+
+        # PATCH(NRL_REFIT_CKSUM): after refit, print per-group checksums of params
+        # AND buffers on both sides — any src/dst mismatch = the refit gap that
+        # explains gen-vs-scoring logprob residuals with all shapes/kernels aligned.
+        import os as _os_ck
+        if _os_ck.environ.get("NRL_REFIT_CKSUM", "0") == "1":
+            _m = self.model
+            _mm = _m[0] if isinstance(_m, list) else _m
+            while hasattr(_mm, "module"):
+                _mm = _mm.module
+            import hashlib as _hl
+            _side = "SRC" if is_source else "DST"
+            _lines = []
+            for _kind, _iter in (("P", _mm.named_parameters()), ("B", _mm.named_buffers())):
+                for _n, _t in _iter:
+                    _h = _hl.md5(_t.detach().float().cpu().numpy().tobytes()).hexdigest()[:12]
+                    _lines.append(f"{_side} {_kind}:{_n} {tuple(_t.shape)} {_h}")
+            _dir = _os_ck.environ.get("NRL_REFIT_CKSUM_DIR", "/tmp")
+            _rank = _os_ck.environ.get("RANK", _os_ck.environ.get("RAY_RANK", "0"))
+            _step = getattr(type(self), "_nrl_ck_step", 0)
+            type(self)._nrl_ck_step = _step + 1
+            import socket as _sk
+            _fn = f"{_dir}/refit_cksum_{_side}_{_sk.gethostname()}_{_os_ck.getpid()}_s{_step}.txt"
+            with open(_fn, "w") as _f:
+                _f.write("\n".join(_lines))
+            print(f"[NRL_REFIT_CKSUM] wrote {len(_lines)} entries -> {_fn}", flush=True)
 
         return True
 

--- a/nemo_rl/models/megatron/router_replay.py
+++ b/nemo_rl/models/megatron/router_replay.py
@@ -57,8 +57,15 @@ def validate_router_replay_config(config: PolicyConfig) -> None:
     generation = config.get("generation") or {}
     megatron_cfg = config.get("megatron_cfg") or {}
 
-    if generation.get("backend") != "vllm":
-        raise ValueError("router_replay.enabled requires vLLM generation.")
+    # PATCH(PR-4 router-replay-mcore): allow the megatron generation backend.
+    # The mcore dynamic engine records per-token routing natively
+    # (model_config.moe_enable_routing_replay -> RoutingMetadata static buffers
+    # -> DynamicInferenceRequest.routing_indices); the megatron worker packs it
+    # into GenerationOutputSpec["routed_experts"] with vLLM-identical alignment.
+    if generation.get("backend") not in ("vllm", "megatron"):
+        raise ValueError(
+            "router_replay.enabled requires vLLM or megatron generation."
+        )
     if not megatron_cfg.get("enabled", False):
         raise ValueError("router_replay.enabled requires the Megatron policy backend.")
 

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -313,6 +313,25 @@ def validate_and_set_config(
     weights_path,
     optimizer_path,
 ):
+    # PATCH(det batch-invariant): env-gated activation of the fork's batch-invariant
+    # kernels (incl. te_gemm_cublas_pinned — cuBLASLt workspace starved to force
+    # SPLITK_NUM=1). Nightly NeMo-RL dropped the batch_invariant_mode config key, so
+    # gate on NRL_BATCH_INVARIANT=1; NRL_BI_KERNELS selects categories. Runs in EVERY
+    # MegatronPolicyWorker (train AND dedicated-gen), so both forwards get the pin.
+    import os as _os
+
+    if _os.environ.get("NRL_BATCH_INVARIANT", "0") == "1":
+        from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
+            enable_batch_invariant_mode,
+        )
+
+        enable_batch_invariant_mode()
+        print(
+            f"[NRL_BATCH_INVARIANT] batch-invariant kernels ENABLED "
+            f"(NRL_BI_KERNELS={_os.environ.get('NRL_BI_KERNELS', 'all')})",
+            flush=True,
+        )
+
     # Handle generation configuration
     is_generation_colocated = None
     sampling_params = None
@@ -836,6 +855,18 @@ def _apply_moe_config(model_cfg: Any, config: PolicyConfig) -> None:
         model_cfg.moe_grouped_gemm = config["megatron_cfg"]["moe_grouped_gemm"]
     model_cfg.moe_enable_routing_replay = router_replay_enabled(config)
 
+    # PATCH(det attention num_splits pin): nightly mcore's TEDotProductAttention pins
+    # flash-attn num_splits=1 ONLY when config.batch_invariant_mode is truthy
+    # (extensions/transformer_engine.py ~:1618). Nightly NeMo-RL dropped the config
+    # knob, so with only the kernel monkeypatches active, inference attention kept the
+    # AUTO split-KV heuristic -> batch-shape-dependent softmax partial ordering
+    # (bf16-visible) -> router flips. Gate on the same env as the kernel patches.
+    import os as _os_bi
+
+    if _os_bi.environ.get("NRL_BATCH_INVARIANT", "0") == "1":
+        model_cfg.batch_invariant_mode = True
+        print("[NRL_BATCH_INVARIANT] model_cfg.batch_invariant_mode=True (num_splits=1 pin)", flush=True)
+
 
 def _apply_mtp_config(model_cfg: Any, config: PolicyConfig) -> None:
     """Apply Multi-Token Prediction settings onto the mcore model config."""
@@ -956,6 +987,33 @@ def _apply_performance_config(model_cfg: Any, config: PolicyConfig) -> None:
     # These overrides need to be applied before the workers spawn.
     if "transformer_impl" in config["megatron_cfg"]:
         model_cfg.transformer_impl = config["megatron_cfg"]["transformer_impl"]
+        # PATCH(PR-2/infopt-spec): Megatron-Bridge providers never map
+        # transformer_impl -> layer spec: GPTModelProvider.default_layer_spec branches
+        # only on use_transformer_engine_full_layer_spec (both branches TE), so
+        # "inference_optimized" silently builds TE modules and the whole fused
+        # inference stack (InferenceGroupedMLP, InferenceTopKRouter, inference
+        # dispatchers) is unreachable. Assign the inference-optimized GPT layer spec
+        # through the provider's documented override field (same hook the modelopt
+        # path uses). Callable form so it resolves against the FINAL provider fields
+        # at provide() time (after parallelism/MoE/precision overrides).
+        if model_cfg.transformer_impl == "inference_optimized":
+
+            def _inference_optimized_layer_spec(provider, vp_stage=None):
+                from megatron.core.models.gpt.gpt_layer_specs import (
+                    get_gpt_layer_with_inference_spec,
+                )
+
+                return get_gpt_layer_with_inference_spec(
+                    qk_layernorm=getattr(provider, "qk_layernorm", False),
+                    multi_latent_attention=getattr(
+                        provider, "multi_latent_attention", False
+                    ),
+                    qk_l2_norm=getattr(provider, "qk_l2_norm", False),
+                    num_experts=getattr(provider, "num_moe_experts", None),
+                    moe_grouped_gemm=getattr(provider, "moe_grouped_gemm", False),
+                )
+
+            model_cfg.transformer_layer_spec = _inference_optimized_layer_spec
     if "cuda_graph_impl" in config["megatron_cfg"]:
         model_cfg.cuda_graph_impl = config["megatron_cfg"]["cuda_graph_impl"]
         if model_cfg.cuda_graph_impl != "none":

--- a/nemo_rl/models/megatron/train.py
+++ b/nemo_rl/models/megatron/train.py
@@ -124,6 +124,191 @@ def model_forward(
         # GPTModel.forward signatures do not accept it.
         additional_kwargs["return_logprobs_for_linear_ce_fusion"] = True
 
+    # PATCH(golden score-checksum): timeline of which theta the train model holds.
+    # Hashes a marker param (layer-0 router weight) on every forward; prints only on
+    # value CHANGE so the log shows exactly when weights transition across
+    # gen/score/train phases. Compare against [NRL_REFIT_CHECKSUM] swap-time hashes.
+    import os as _os_sc
+    if _os_sc.environ.get("NRL_SCORE_CHECKSUM", "0") == "1":
+        import hashlib as _hl
+        _st = getattr(model_forward, "_nrl_sc", None)
+        if _st is None:
+            # router.weight is bitwise-frozen under routing replay (no grads) —
+            # use a param guaranteed to be in the loss path.
+            _mark = None
+            for _n, _p in model.named_parameters():
+                if "layers.0." in _n and "linear_qkv" in _n and _n.endswith("weight"):
+                    _mark = (_n, _p)
+                    break
+            if _mark is None:
+                _mark = next(iter(model.named_parameters()))
+            model_forward._nrl_sc = _st = {"n": 0, "last": None, "mark": _mark}
+        _st["n"] += 1
+        _mn, _mp = _st["mark"]
+        _h = _hl.md5(
+            _mp.data.detach().float().cpu().contiguous().numpy().tobytes()
+        ).hexdigest()[:12]
+        if _h != _st["last"]:
+            import torch.distributed as _dist_sc
+            _r = _dist_sc.get_rank() if _dist_sc.is_initialized() else -1
+            print(
+                f"[NRL_SCORE_CHECKSUM] rank={_r} call={_st['n']} {_mn} md5={_h} (CHANGED)",
+                flush=True,
+            )
+            _st["last"] = _h
+
+    # PATCH(NRL_SCORE_LAYERDUMP): in-situ per-layer residual-stream dump of the
+    # SCORING forward — one-shot hooks on every decoder layer's pre-attn norm input
+    # (the exact residual the engine's gdump records). Faithful localization of the
+    # infopt-vs-TE-scoring logit gap: diff engine gdump vs this per (position,layer).
+    import os as _os_sld
+    if _os_sld.environ.get("NRL_SCORE_LAYERDUMP", "") and not getattr(model_forward, "_nrl_sld", False):
+        model_forward._nrl_sld = True
+        _mm = model
+        while hasattr(_mm, "module"):
+            _mm = _mm.module
+        _dec = getattr(_mm, "decoder", None)
+        if _dec is not None and hasattr(_dec, "layers"):
+            import torch as _t_sld
+            _buf = {}
+            builtins_sld = __import__("builtins")
+            builtins_sld._NRL_SLD_BUF = _buf
+            # capture ALL rows of the first-token dim so offline we can pick any seq;
+            # residual is [S,B,H] (megatron) — keep [S,B,H] transposed to [B,S,H]
+            builtins_sld._NRL_SLD_FIRES = [0, None]
+            def _mk(li):
+                def hook(mod, args, kwargs, out):
+                    x = None
+                    if args and _t_sld.is_tensor(args[0]):
+                        x = args[0]
+                    elif isinstance(kwargs, dict) and _t_sld.is_tensor(kwargs.get("hidden_states")):
+                        x = kwargs["hidden_states"]
+                    builtins_sld._NRL_SLD_FIRES[0] += 1
+                    if x is None:
+                        builtins_sld._NRL_SLD_FIRES[1] = f"no-tensor args={len(args)} kw={list(kwargs)[:4]}"
+                        return
+                    if x.dim() != 3:
+                        builtins_sld._NRL_SLD_FIRES[1] = f"dim={x.dim()} shape={tuple(x.shape)}"
+                        return
+                    # [S,B,H] -> [B,S,H]; store first 16 microbatches (all local seqs)
+                    _mb = getattr(builtins_sld, "_NRL_SLD_MB", 0)
+                    if _mb < 16:
+                        _buf[(_mb, li)] = x.transpose(0, 1).detach().float().cpu().clone()
+                return hook
+            for _li, _lyr in enumerate(_dec.layers):
+                _lyr.register_forward_hook(_mk(_li), with_kwargs=True)
+            # save the batch input_ids so offline we can map batch-row -> jsonl seq
+            builtins_sld._NRL_SLD_IDS = []
+            def _save_sld(*_a):
+                try:
+                    import torch.distributed as _d_sld
+                    _rk = _d_sld.get_rank() if _d_sld.is_initialized() else 0
+                    _t_sld.save({"layers": {k: v for k, v in _buf.items()},
+                                 "ids": getattr(builtins_sld, "_NRL_SLD_IDS", None)},
+                                _os_sld.environ["NRL_SCORE_LAYERDUMP"] + f"/score_layers_rank{_rk}.pt")
+                    print(f"[NRL_SCORE_LAYERDUMP] saved {len(_buf)} layers rank{_rk} "
+                          f"fires={getattr(builtins_sld, '_NRL_SLD_FIRES', None)}", flush=True)
+                except Exception as _e:
+                    print(f"[NRL_SCORE_LAYERDUMP] save failed: {_e}", flush=True)
+            import atexit as _ax_sld
+            _ax_sld.register(_save_sld)
+
+    # PATCH(NRL_MOE_DUMP, K2v3): scoring-side counterpart of the engine's moeA dump —
+    # per-layer MoE INPUT (post-norm hidden, = engine vllm_fused_moe `hs`) and router
+    # output (probs + routing map) for layers 0..3, first 4 scoring fires, all ranks.
+    # Matched-point bracket: MoE-in matches + next-layer-in differs => MoE block
+    # convicted; MoE-in differs => attention path upstream.
+    if _os_sld.environ.get("NRL_MOE_DUMP_DEADPATH", "") and not getattr(model_forward, "_nrl_moedump", False):
+        model_forward._nrl_moedump = True
+        _mm2 = model
+        while hasattr(_mm2, "module"):
+            _mm2 = _mm2.module
+        _dec2 = getattr(_mm2, "decoder", None)
+        if _dec2 is not None and hasattr(_dec2, "layers"):
+            import torch as _t_md
+            _mdst = {"fires": {}}
+            def _mk_moein(li):
+                def hook(mod, args, kwargs):
+                    x = args[0] if args and _t_md.is_tensor(args[0]) else kwargs.get("hidden_states")
+                    if x is None or x.dim() != 3:
+                        return
+                    f = _mdst["fires"].setdefault(li, 0)
+                    if f < 4:
+                        _mdst["fires"][li] = f + 1
+                        _mdst[("in", f, li)] = x.transpose(0, 1).reshape(-1, x.shape[-1])[:512].detach().float().cpu().clone()
+                return hook
+            def _mk_router(li):
+                def hook(mod, args, kwargs, out):
+                    f = _mdst["fires"].get(li, 1) - 1
+                    if f < 0 or f >= 4 or ("rt", f, li) in _mdst:
+                        pass
+                    try:
+                        probs, rmap = out[0], out[1]
+                        if ("rt", f, li) not in _mdst and 0 <= f < 4:
+                            _mdst[("rt", f, li)] = (probs.reshape(-1, probs.shape[-1])[:512].detach().float().cpu().clone(),
+                                                    rmap.reshape(-1, rmap.shape[-1])[:512].detach().cpu().clone())
+                    except Exception:
+                        pass
+                return hook
+            # module hooks do NOT fire here (megatron calls submodule.forward directly,
+            # bypassing __call__) -> wrap the BOUND forward methods instead.
+            _nmlp, _nrtr = 0, 0
+            def _wrap_mlp(li, mod):
+                _orig = mod.forward
+                def fwd(*args, **kwargs):
+                    x = args[0] if args and _t_md.is_tensor(args[0]) else kwargs.get("hidden_states")
+                    _dbg = _mdst.setdefault("dbg", [])
+                    if len(_dbg) < 8:
+                        _dbg.append((li, None if x is None else tuple(x.shape), len(args), sorted(kwargs)[:3]))
+                    if x is not None and x.dim() >= 2:
+                        f = _mdst["fires"].setdefault(li, 0)
+                        if f < 4:
+                            _mdst["fires"][li] = f + 1
+                            _mdst[("in", f, li)] = x.reshape(-1, x.shape[-1])[:512].detach().float().cpu().clone()
+                    return _orig(*args, **kwargs)
+                mod.forward = fwd
+            def _wrap_router(li, mod):
+                _orig = mod.forward
+                def fwd(*args, **kwargs):
+                    out = _orig(*args, **kwargs)
+                    try:
+                        f = max(_mdst["fires"].get(li, 1) - 1, 0)
+                        if f < 4 and ("rt", f, li) not in _mdst:
+                            probs, rmap = out[0], out[1]
+                            _mdst[("rt", f, li)] = (probs.reshape(-1, probs.shape[-1])[:512].detach().float().cpu().clone(),
+                                                    rmap.reshape(-1, rmap.shape[-1])[:512].detach().cpu().clone())
+                    except Exception:
+                        pass
+                    return out
+                mod.forward = fwd
+            for _li2, _lyr2 in enumerate(_dec2.layers):
+                if _li2 >= 4:
+                    break
+                _mlp = getattr(_lyr2, "mlp", None)
+                if _mlp is not None:
+                    _wrap_mlp(_li2, _mlp)
+                    _nmlp += 1
+                    _rtr = getattr(_mlp, "router", None)
+                    if _rtr is not None:
+                        _wrap_router(_li2, _rtr)
+                        _nrtr += 1
+            print(f"[NRL_MOE_DUMP:B] method-wrapped mlp={_nmlp} router={_nrtr} "
+                  f"n_layers={len(_dec2.layers)}", flush=True)
+            def _save_md(*_a):
+                try:
+                    import torch.distributed as _d_md
+                    _rk2 = _d_md.get_rank() if _d_md.is_initialized() else 0
+                    payload = {k: v for k, v in _mdst.items() if k != "fires"}
+                    payload["_dbg"] = _mdst.get("dbg", [])
+                    _t_md.save(payload, _os_sld.environ["NRL_MOE_DUMP"] + f"/moeB_rank{_rk2}.pt")
+                    print(f"[NRL_MOE_DUMP:B] saved {len(payload)} entries rank{_rk2}", flush=True)
+                except Exception as _e:
+                    print(f"[NRL_MOE_DUMP:B] save failed: {_e}", flush=True)
+            import atexit as _ax_md
+            _ax_md.register(_save_md)
+            builtins_sld._NRL_SLD_SAVE = _save_sld
+            print(f"[NRL_SCORE_LAYERDUMP] hooked {len(_dec.layers)} decoder layers", flush=True)
+
     with straggler_timer() if straggler_timer is not None else nullcontext():
         output_tensor = model(
             input_ids=input_ids_cp_sharded,
@@ -132,6 +317,19 @@ def model_forward(
             **additional_kwargs,
             **multimodal_data,
         )
+
+    # dump the scoring residuals after the FIRST scoring forward (one-shot) so the
+    # save happens even without atexit (SIGTERM/ray teardown races)
+    if _os_sld.environ.get("NRL_SCORE_LAYERDUMP", "") and getattr(model_forward, "_nrl_sld", False):
+        _bi2 = __import__("builtins")
+        _mb = getattr(_bi2, "_NRL_SLD_MB", 0)
+        if _mb < 16:
+            _bi2._NRL_SLD_IDS.append(input_ids_cp_sharded.detach().cpu().clone())
+        _bi2._NRL_SLD_MB = _mb + 1
+        _sv = getattr(_bi2, "_NRL_SLD_SAVE", None)
+        if _sv is not None and _bi2._NRL_SLD_MB == 16 and not getattr(model_forward, "_nrl_sld_done", False):
+            model_forward._nrl_sld_done = True
+            _sv()
 
     return output_tensor
 
@@ -582,6 +780,40 @@ class LogprobsPostProcessor:
                     cp_group=get_context_parallel_group(),
                     chunk_size=logprob_chunk_size,
                     sampling_params=self.sampling_params,
+                )
+            elif (
+                __import__("os").environ.get("NRL_FUSED_TRAIN_LOGPROB", "off")
+                in ("1", "fused")
+                and torch.distributed.get_world_size(
+                    group=get_tensor_model_parallel_group()
+                )
+                == 1
+                and torch.distributed.get_world_size(
+                    group=get_context_parallel_group()
+                )
+                == 1
+            ):
+                # PATCH(S7 fused-logprob, ported from v0.5.0 train.py): match mcore
+                # generation's exact logprob op sequence (logits.float() -> fused
+                # F.log_softmax -> gather) instead of the hand-rolled distributed
+                # logsumexp. The two routines round differently (~1 fp32 ulp on
+                # ~30% of tokens) and are the residual train/gen logprob floor at
+                # TP=1. Only valid at TP=1 & CP=1 (full logit row on one rank).
+                if not getattr(LogprobsPostProcessor, "_nrl_s7_banner", False):
+                    LogprobsPostProcessor._nrl_s7_banner = True
+                    print("[NRL_FUSED_TRAIN_LOGPROB] fused log_softmax->gather logprob path ACTIVE", flush=True)
+                _full_lp = torch.nn.functional.log_softmax(
+                    output_tensor.float(), dim=-1
+                )
+                token_logprobs = (
+                    _full_lp[:, :-1]
+                    .gather(
+                        -1,
+                        unpacked_input_ids[:, 1:]
+                        .to(output_tensor.device)
+                        .unsqueeze(-1),
+                    )
+                    .squeeze(-1)
                 )
             else:
                 tp_grp = get_tensor_model_parallel_group()


### PR DESCRIPTION
Generation bitwise-identical to training/scoring (gen_kl == 0.0 x18 full-lr, prod bed, 1.02x throughput tax; cert job 2333154). Requires the companion Megatron-LM branch [utkarsh530/Megatron-LM:det-inference-ep8tp1-certified](https://github.com/utkarsh530/Megatron-LM/tree/det-inference-ep8tp1-certified). Tested model: Qwen30B-A3B

NeMo-RL side:
- megatron_generation: fail fast when colocated generation would silently ignore model-side mcore_generation_config keys
- grpo/utils: non-colocated (dedicated-node) megatron generation
- setup: batch-invariant activation hook + det attention num_splits pin
- train: fused logprob scoring path (float -> log_softmax -> gather) + per-EP-rank fp64 combine mirror env gates
- megatron_worker: det wiring + refit param-gather sync barrier
- router_replay: megatron-backend support (feature OFF in the recipe)
- recipe YAML (certified config) + gen_kl_harness determinism gate + docs

# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
This branch is in active development and will be pushed for further updates. I need to clip out some of the redundant paths and will try to get the relevant paths in the Megatron-LM we're merging to make it completely usable. 