### PR TITLE
fix: mtp gating for the nccl-reshard-refit and fix the error when doing ray RPC.

### DIFF
--- a/docs/design-docs/nccl-reshard-refit.md
+++ b/docs/design-docs/nccl-reshard-refit.md
@@ -60,11 +60,13 @@ nccl-reshard-refit implementation:
   large models this covers the vast majority of the refit bytes. For the current version of implementation, it only detects `(experts).N.{gate_proj|up_proj|down_proj}` as the subject of this performant transportation path. The coverage will be expanded via future updates.
   Two FFN-named groups are explicitly excluded and ride the misc path instead:
   shared-expert weights (`*.shared_expert.*`, which fuse differently on the vLLM
-  side) and co-trained MTP drafter weights (`mtp.*`, which vLLM keeps in a separate
-  drafter module updated through `load_weights`). The MTP exclusion matches the
-  bare-`mtp.`-prefix HF naming (NemotronH, Qwen3.5); DeepSeek-style MTP exported as
-  trailing `model.layers.N` indices is not yet gated, and nccl-reshard-refit does
-  not support it.
+  side) and co-trained MTP drafter weights (which vLLM keeps in a separate
+  drafter module updated through `load_weights`). MTP weights are recognized two
+  ways: bare-`mtp.`-prefix HF names (NemotronH, Qwen3.5) via
+  `is_nccl_reshard_param()`, and DeepSeek-style MTP exported as trailing
+  `model.layers.N` indices via provenance — the Megatron-side name on the
+  Bridge conversion tasks is uniformly `mtp.*`, so the worker excludes those HF
+  layers when building the metadata (`_collect_mtp_hf_layer_names()`).
 * **Misc path** — everything else (embeddings, attention projections, layernorms, the
   MoE router, `lm_head`, FP8 `_scale_inv` siblings, FP8 KV-cache scales, …). These ride
   a packed broadcast (conventional `packed_tensor.py` implementation) over the shared

--- a/docs/design-docs/nccl-reshard-refit.md
+++ b/docs/design-docs/nccl-reshard-refit.md
@@ -58,6 +58,13 @@ nccl-reshard-refit implementation:
   `.weight`, dense MLP and MoE experts alike; see `is_nccl_reshard_param()`). These are
   resharded shard-to-shard with `xferdtensor` over dedicated NCCL communicators. For
   large models this covers the vast majority of the refit bytes. For the current version of implementation, it only detects `(experts).N.{gate_proj|up_proj|down_proj}` as the subject of this performant transportation path. The coverage will be expanded via future updates.
+  Two FFN-named groups are explicitly excluded and ride the misc path instead:
+  shared-expert weights (`*.shared_expert.*`, which fuse differently on the vLLM
+  side) and co-trained MTP drafter weights (`mtp.*`, which vLLM keeps in a separate
+  drafter module updated through `load_weights`). The MTP exclusion matches the
+  bare-`mtp.`-prefix HF naming (NemotronH, Qwen3.5); DeepSeek-style MTP exported as
+  trailing `model.layers.N` indices is not yet gated, and nccl-reshard-refit does
+  not support it.
 * **Misc path** — everything else (embeddings, attention projections, layernorms, the
   MoE router, `lm_head`, FP8 `_scale_inv` siblings, FP8 KV-cache scales, …). These ride
   a packed broadcast (conventional `packed_tensor.py` implementation) over the shared
@@ -87,7 +94,11 @@ training starts:
    builds a backend-agnostic description** of every bulk parameter
    (`build_nccl_reshard_refit_info()` in `nemo_rl/weight_sync/nccl_reshard_utils.py`),
    keyed strictly by **HuggingFace parameter names**, and ships it to the generation
-   side.
+   side. Before shipping, `make_nccl_reshard_refit_info_wire_safe()` converts the
+   `MeshInfo` rank tensors and `Shard`/`Replicate` placements into plain dicts/lists —
+   Megatron patches torch's storage unpickler, so raw tensor pickles would require
+   `import megatron` inside the vLLM worker. The generation side rebuilds the objects
+   with `restore_refit_info_placements()`.
 
 The derived metadata (`nccl_reshard_refit_info`) contains, per parameter:
 

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -217,6 +217,8 @@ class SingleControllerActor:
             await asyncio.gather(rollout_task, train_task, return_exceptions=True)
             try:
                 self._weight_synchronizer.shutdown()
+            except Exception as e:  # teardown must not mask the original failure
+                print(f"Error during weight-synchronizer shutdown: {e}", flush=True)
             finally:
                 self._logger.finish()
 

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -207,7 +207,10 @@ class SingleControllerActor:
             rollout_task.cancel()
             train_task.cancel()
             await asyncio.gather(rollout_task, train_task, return_exceptions=True)
-            self._logger.finish()
+            try:
+                self._weight_synchronizer.shutdown()
+            finally:
+                self._logger.finish()
 
         return {
             "train_steps": self._train_steps,

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -215,7 +215,10 @@ class SingleControllerActor:
             rollout_task.cancel()
             train_task.cancel()
             await asyncio.gather(rollout_task, train_task, return_exceptions=True)
-            self._logger.finish()
+            try:
+                self._weight_synchronizer.shutdown()
+            finally:
+                self._logger.finish()
 
         return {
             "train_steps": self._train_steps,

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -56,7 +56,7 @@ except ImportError:
     )
 
 
-WeightUpdateTransport = Literal["ipc", "collective"]
+WeightUpdateTransport = Literal["ipc", "collective", "nccl_reshard"]
 WeightUpdateFinalizer = Callable[[], None]
 
 
@@ -1064,33 +1064,26 @@ class VllmInternalWorkerExtension:
 
         import time
 
-        misc_t0 = time.perf_counter()
-        self._receive_and_load_misc_params()
-        torch.cuda.synchronize()
-        if torch.distributed.get_rank() == 0:
-            print(
-                f"[nccl_reshard_refit] misc recv+load (gen side): "
-                f"{time.perf_counter() - misc_t0:.2f}s",
-                flush=True,
-            )
-        torch.cuda.empty_cache()
-        from vllm.config import set_current_vllm_config
-        from vllm.model_executor.model_loader.utils import (
-            process_weights_after_loading,
-        )
+        with self._weight_update_lifecycle("nccl_reshard") as finalize:
+            misc_t0 = time.perf_counter()
+            self._receive_and_load_misc_params()
+            torch.cuda.synchronize()
+            if torch.distributed.get_rank() == 0:
+                print(
+                    f"[nccl_reshard_refit] misc recv+load (gen side): "
+                    f"{time.perf_counter() - misc_t0:.2f}s",
+                    flush=True,
+                )
+            torch.cuda.empty_cache()
 
-        # Finalize post-load weight processing: dense Linear + attention/MLA, and
-        # crucially the per-MoE-backend w13 layout (FlashInfer CUTLASS/TRTLLM) that
-        # the canonical [gate; up] bulk write above defers to here.
-        with set_current_vllm_config(self.model_runner.vllm_config):
-            process_weights_after_loading(
-                self.model_runner.model, self.model_config, self.device
-            )
+            # Finalize post-load weight processing: dense Linear + attention/MLA,
+            # the per-MoE-backend w13 layout (FlashInfer CUTLASS/TRTLLM) that the
+            # canonical [gate; up] bulk write above defers to here, and the MTP
+            # drafter's mirror of the same. The FP8 KV-cache per-layer k/v scales
+            # are finalized by the lifecycle on exit.
+            finalize()
 
-        torch.cuda.empty_cache()
-
-        # Finalize FP8 KV-cache per-layer k/v scales after the misc broadcast.
-        self._maybe_process_fp8_kv_cache()
+            torch.cuda.empty_cache()
         return True
 
     def _receive_and_load_misc_params(self) -> None:

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -201,6 +201,39 @@ def _estimate_refit_tensor_size_in_bytes(
     return param.numel() * tp_size * ep_size * element_size
 
 
+def _collect_mtp_hf_layer_names(conversion_tasks: Optional[list]) -> set[str]:
+    """Return HF layer names whose weights originate from Megatron's MTP module.
+
+    The Megatron-side parameter name is uniformly ``mtp.*`` for every model
+    family, but the HF-side name is not: DeepSeek-style bridges export MTP as
+    trailing main-model layer indices (``model.layers.{N + num_layers}.*``),
+    which ``is_nccl_reshard_param`` cannot recognize from the name shape alone.
+    Provenance — the Megatron name carried by the Bridge conversion task — is
+    the reliable signal. Results are keyed by ``_extract_layer_name`` so a
+    whole MTP layer is routed to the misc path together.
+
+    Args:
+        conversion_tasks: Megatron-Bridge ``WeightConversionTask`` list; only
+            ``global_param_name`` (resolved Megatron-side name) and
+            ``mapping.hf_param`` (str, or dict of str for compound mappings)
+            are consulted. ``None`` entries are tolerated.
+
+    Returns:
+        Set of HF layer names, e.g. ``{"model.layers.61", "mtp.layers.0"}``.
+    """
+    from nemo_rl.weight_sync.nccl_reshard_utils import _extract_layer_name
+
+    mtp_layers: set[str] = set()
+    for task in conversion_tasks or []:
+        # FP8 export can leave None placeholders in the task list (BF16 export
+        # pre-filters them; see _build_refit_conversion_tasks).
+        if task is not None and task.global_param_name.startswith("mtp."):
+            hf = task.mapping.hf_param
+            for hf_name in hf.values() if isinstance(hf, dict) else [str(hf)]:
+                mtp_layers.add(_extract_layer_name(hf_name))
+    return mtp_layers
+
+
 @contextmanager
 def _meta_tensor_alloc_context():
     """Skip real GPU work during metadata enumeration.
@@ -2402,7 +2435,18 @@ class MegatronPolicyWorkerImpl(
         # state_dict_metadata[hf_name] -> [shape, dtype]
         # At the same time, filter the params to the misc subset (packed_broadcast path).
         # misc_meta[hf_name] -> [shape, dtype]
-        from nemo_rl.weight_sync.nccl_reshard_utils import _extract_layer_prefix
+        from nemo_rl.weight_sync.nccl_reshard_utils import (
+            _extract_layer_name,
+            _extract_layer_prefix,
+        )
+
+        # HF layers whose weights come from Megatron's MTP module. The prefix
+        # gate inside is_nccl_reshard_param only catches families whose HF
+        # names keep the bare ``mtp.`` prefix (NemotronH, Qwen3.5); DeepSeek
+        # exports MTP as trailing ``model.layers.N`` indices, so provenance is
+        # the only reliable signal. vLLM keeps the MTP drafter separate from
+        # the main model and updates it through load_weights -> misc path.
+        mtp_hf_layers_names = _collect_mtp_hf_layer_names(self.refit_conversion_tasks)
 
         layer_prefix = None
         with _meta_tensor_alloc_context():
@@ -2414,7 +2458,10 @@ class MegatronPolicyWorkerImpl(
                 _nbytes = tensor.numel() * tensor.element_size()
                 # Downsized whitelist: only FFN gate/up/down weights take the bulk
                 # nccl-reshard path; everything else -> misc (packed_broadcast).
-                if is_nccl_reshard_param(name):
+                if (
+                    is_nccl_reshard_param(name)
+                    and _extract_layer_name(name) not in mtp_hf_layers_names
+                ):
                     state_dict_metadata[name] = meta
                     _xfer_bytes += _nbytes
                     if layer_prefix is not None:

--- a/nemo_rl/weight_sync/nccl_reshard_utils.py
+++ b/nemo_rl/weight_sync/nccl_reshard_utils.py
@@ -191,8 +191,12 @@ def is_nccl_reshard_param(param_name: str) -> bool:
     ``load_weights`` path.
 
     Shared-expert FFN weights (``*.shared_expert.*``) are routed to misc path.
+    Co-trained MTP weights are also routed to misc because vLLM keeps the MTP
+    drafter separate from the main model and updates it through ``load_weights``.
     """
     if "shared_expert" in param_name:
+        return False
+    if param_name.startswith("mtp."):
         return False
     return param_name.endswith(FFN_PROJ_WEIGHT_SUFFIXES) or param_name.endswith(
         FFN_GROUPED_EXPERT_SUFFIXES
@@ -245,6 +249,44 @@ def _restore_placement(p):
             return Shard(p["dim"])
         return Replicate()
     return Replicate()
+
+
+def make_nccl_reshard_refit_info_wire_safe(refit_info: dict) -> dict:
+    """Copy refit metadata into types safe for vLLM's subprocess RPC.
+
+    Megatron patches Torch's tensor pickle reducer to use its safe_globals
+    loader. vLLM worker subprocesses intentionally do not install Megatron, so
+    even the small CPU rank tensors in MeshInfo cannot cross that pickle
+    boundary. Convert meshes and placements to the plain representation that
+    restore_refit_info_placements accepts.
+    """
+
+    def _wire_mesh(mesh):
+        if isinstance(mesh, MeshInfo):
+            return {"mesh": mesh.mesh.tolist()}
+        return mesh
+
+    def _wire_placement(placement):
+        if isinstance(placement, Shard):
+            return {"dim": placement.dim}
+        if isinstance(placement, Replicate):
+            return {}
+        return placement
+
+    wire_info = dict(refit_info)
+    wire_layers = {}
+    for layer_name, params in refit_info.get("per_layer_params", {}).items():
+        wire_params = []
+        for param_info in params:
+            wire_param = dict(param_info)
+            for key in ("src_mesh_info", "dst_mesh_info"):
+                wire_param[key] = _wire_mesh(wire_param.get(key))
+            for key in ("src_placements", "dst_placements"):
+                wire_param[key] = [_wire_placement(p) for p in wire_param.get(key, [])]
+            wire_params.append(wire_param)
+        wire_layers[layer_name] = wire_params
+    wire_info["per_layer_params"] = wire_layers
+    return wire_info
 
 
 def restore_refit_info_placements(refit_info: dict) -> dict:

--- a/nemo_rl/weight_sync/nccl_reshard_utils.py
+++ b/nemo_rl/weight_sync/nccl_reshard_utils.py
@@ -254,11 +254,10 @@ def _restore_placement(p):
 def make_nccl_reshard_refit_info_wire_safe(refit_info: dict) -> dict:
     """Copy refit metadata into types safe for vLLM's subprocess RPC.
 
-    Megatron patches Torch's tensor pickle reducer to use its safe_globals
-    loader. vLLM worker subprocesses intentionally do not install Megatron, so
-    even the small CPU rank tensors in MeshInfo cannot cross that pickle
-    boundary. Convert meshes and placements to the plain representation that
-    restore_refit_info_placements accepts.
+    Importing ``megatron.core`` replaces ``torch.storage._load_from_bytes`` with
+    a Megatron function, so Tensor pickles require Megatron at unpickle time.
+    vLLM subprocesses may not have it importable; convert the metadata to the
+    plain representation accepted by ``restore_refit_info_placements``.
     """
 
     def _wire_mesh(mesh):

--- a/nemo_rl/weight_sync/nccl_reshard_utils.py
+++ b/nemo_rl/weight_sync/nccl_reshard_utils.py
@@ -19,6 +19,8 @@ This module provides:
   shared torch.distributed process group (needed for cross-world transfers)
 - Placement rules: mapping param names to TP/EP sharding strategies
 - build_nccl_reshard_refit_info: compute per-layer param metadata for refit
+- make_nccl_reshard_refit_info_wire_safe: convert placements and meshes into
+  plain dicts/lists before the refit metadata crosses a process boundary
 - restore_refit_info_placements: undo msgspec dict-flattening of placements
   and meshes on the receiving side
 
@@ -279,9 +281,11 @@ def make_nccl_reshard_refit_info_wire_safe(refit_info: dict) -> dict:
         for param_info in params:
             wire_param = dict(param_info)
             for key in ("src_mesh_info", "dst_mesh_info"):
-                wire_param[key] = _wire_mesh(wire_param.get(key))
+                if key in wire_param:
+                    wire_param[key] = _wire_mesh(wire_param[key])
             for key in ("src_placements", "dst_placements"):
-                wire_param[key] = [_wire_placement(p) for p in wire_param.get(key, [])]
+                if key in wire_param:
+                    wire_param[key] = [_wire_placement(p) for p in wire_param[key]]
             wire_params.append(wire_param)
         wire_layers[layer_name] = wire_params
     wire_info["per_layer_params"] = wire_layers

--- a/nemo_rl/weight_sync/nccl_reshard_weight_synchronizer.py
+++ b/nemo_rl/weight_sync/nccl_reshard_weight_synchronizer.py
@@ -210,6 +210,8 @@ class NcclReshardWeightSynchronizer(WeightSynchronizer):
             make_nccl_reshard_refit_info_wire_safe,
         )
 
+        # SingleController sends this across vLLM's subprocess boundary, so avoid
+        # Megatron-dependent Tensor pickles.
         wire_refit_info = make_nccl_reshard_refit_info_wire_safe(
             nccl_reshard_refit_info
         )

--- a/nemo_rl/weight_sync/nccl_reshard_weight_synchronizer.py
+++ b/nemo_rl/weight_sync/nccl_reshard_weight_synchronizer.py
@@ -210,8 +210,10 @@ class NcclReshardWeightSynchronizer(WeightSynchronizer):
             make_nccl_reshard_refit_info_wire_safe,
         )
 
-        # SingleController sends this across vLLM's subprocess boundary, so avoid
-        # Megatron-dependent Tensor pickles.
+        # nccl_reshard_refit_info contains Torch Tensors that are created by
+        # Megatron, which will invoke `import megatron` when unpickled.
+        # To avoid this, we remove the Torch Tensors and restore them later,
+        # via `restore_nccl_reshard_refit_info()`.
         wire_refit_info = make_nccl_reshard_refit_info_wire_safe(
             nccl_reshard_refit_info
         )

--- a/nemo_rl/weight_sync/nccl_reshard_weight_synchronizer.py
+++ b/nemo_rl/weight_sync/nccl_reshard_weight_synchronizer.py
@@ -210,10 +210,11 @@ class NcclReshardWeightSynchronizer(WeightSynchronizer):
             make_nccl_reshard_refit_info_wire_safe,
         )
 
-        # nccl_reshard_refit_info contains Torch Tensors that are created by
-        # Megatron, which will invoke `import megatron` when unpickled.
-        # To avoid this, we remove the Torch Tensors and restore them later,
-        # via `restore_nccl_reshard_refit_info()`.
+        # nccl_reshard_refit_info holds MeshInfo rank tensors created under
+        # Megatron, whose pickles resolve a Megatron-patched storage loader and
+        # therefore need `import megatron` on unpickle. Convert them to plain
+        # lists here; the vLLM worker rebuilds them in
+        # `restore_refit_info_placements()`.
         wire_refit_info = make_nccl_reshard_refit_info_wire_safe(
             nccl_reshard_refit_info
         )

--- a/nemo_rl/weight_sync/nccl_reshard_weight_synchronizer.py
+++ b/nemo_rl/weight_sync/nccl_reshard_weight_synchronizer.py
@@ -43,6 +43,9 @@ import ray
 
 from nemo_rl.utils.timer import Timer
 from nemo_rl.weight_sync.interfaces import WeightSynchronizer
+from nemo_rl.weight_sync.nccl_reshard_utils import (
+    make_nccl_reshard_refit_info_wire_safe,
+)
 
 
 class NcclReshardWeightSynchronizer(WeightSynchronizer):
@@ -206,10 +209,6 @@ class NcclReshardWeightSynchronizer(WeightSynchronizer):
             inference_world_size,
         )
 
-        from nemo_rl.weight_sync.nccl_reshard_utils import (
-            make_nccl_reshard_refit_info_wire_safe,
-        )
-
         # nccl_reshard_refit_info holds MeshInfo rank tensors created under
         # Megatron, whose pickles resolve a Megatron-patched storage loader and
         # therefore need `import megatron` on unpickle. Convert them to plain
@@ -223,6 +222,8 @@ class NcclReshardWeightSynchronizer(WeightSynchronizer):
     def shutdown(self) -> None:
         # The NCCL process groups' lifecycle is managed by Ray actor teardown;
         # the workers that own the groups are destroyed with the cluster.
-        # Drop the local wrapper reference explicitly without changing how the
-        # object graph is serialized into SingleControllerActor.
+        # Break the VllmGeneration <-> synchronizer reference cycle so the
+        # generation wrapper is garbage-collectable after teardown. The
+        # synchronizer is never used again after shutdown(), so losing the
+        # handle is safe.
         self._generation = None

--- a/nemo_rl/weight_sync/nccl_reshard_weight_synchronizer.py
+++ b/nemo_rl/weight_sync/nccl_reshard_weight_synchronizer.py
@@ -205,9 +205,19 @@ class NcclReshardWeightSynchronizer(WeightSynchronizer):
             train_world_size,
             inference_world_size,
         )
-        self._generation.prepare_nccl_reshard_refit_info(nccl_reshard_refit_info)
+
+        from nemo_rl.weight_sync.nccl_reshard_utils import (
+            make_nccl_reshard_refit_info_wire_safe,
+        )
+
+        wire_refit_info = make_nccl_reshard_refit_info_wire_safe(
+            nccl_reshard_refit_info
+        )
+        self._generation.prepare_nccl_reshard_refit_info(wire_refit_info)
 
     def shutdown(self) -> None:
         # The NCCL process groups' lifecycle is managed by Ray actor teardown;
         # the workers that own the groups are destroyed with the cluster.
-        pass
+        # Drop the local wrapper reference explicitly without changing how the
+        # object graph is serialized into SingleControllerActor.
+        self._generation = None

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -69,6 +69,56 @@ def test_model_owned_mtp_loss_mask_packing_capability_is_detected():
     assert not _model_self_packs_mtp_loss_mask(object())
 
 
+def _conversion_task(megatron_param: str, hf_param) -> SimpleNamespace:
+    return SimpleNamespace(
+        global_param_name=megatron_param,
+        mapping=SimpleNamespace(hf_param=hf_param),
+    )
+
+
+def test_collect_mtp_hf_layer_names_covers_both_naming_schemes():
+    from nemo_rl.models.policy.workers.megatron_policy_worker import (
+        _collect_mtp_hf_layer_names,
+    )
+
+    tasks = [
+        None,  # dropped tasks are tolerated
+        # DeepSeek-style: megatron mtp.* exports as a trailing main-model
+        # layer index (num_hidden_layers=61 -> HF layer model.layers.61).
+        _conversion_task(
+            "mtp.layers.0.mtp_model_layer.mlp.linear_fc1.weight",
+            {
+                "gate": "model.layers.61.mlp.gate_proj.weight",
+                "up": "model.layers.61.mlp.up_proj.weight",
+            },
+        ),
+        # NemotronH-style: bare mtp. prefix survives into the HF name.
+        _conversion_task(
+            "mtp.layers.0.mtp_model_layer.layers.0.mlp.linear_fc1.weight",
+            "mtp.layers.0.mixer.up_proj.weight",
+        ),
+        # Main-model tasks must not contribute.
+        _conversion_task(
+            "decoder.layers.3.mlp.linear_fc1.weight",
+            {"gate": "model.layers.3.mlp.gate_proj.weight"},
+        ),
+        _conversion_task(
+            "embedding.word_embeddings.weight", "model.embed_tokens.weight"
+        ),
+    ]
+
+    assert _collect_mtp_hf_layer_names(tasks) == {"model.layers.61", "mtp.layers.0"}
+
+
+def test_collect_mtp_hf_layer_names_empty_inputs():
+    from nemo_rl.models.policy.workers.megatron_policy_worker import (
+        _collect_mtp_hf_layer_names,
+    )
+
+    assert _collect_mtp_hf_layer_names([]) == set()
+    assert _collect_mtp_hf_layer_names(None) == set()
+
+
 def test_regular_model_does_not_delegate_packing():
     from nemo_rl.models.policy.workers.megatron_policy_worker import (
         _model_self_packs_for_cp,

--- a/tests/unit/weight_sync/test_nccl_reshard_utils.py
+++ b/tests/unit/weight_sync/test_nccl_reshard_utils.py
@@ -21,6 +21,7 @@ mesh construction, placement rules, expert grouping, and the top-level
 torch.distributed, no model object — so this module runs on CPU with no extras.
 """
 
+import pickle
 from types import SimpleNamespace
 
 import pytest
@@ -38,6 +39,8 @@ from nemo_rl.weight_sync.nccl_reshard_utils import (
     group_expert_params_in_metadata,
     is_expert_param,
     is_nccl_reshard_param,
+    make_nccl_reshard_refit_info_wire_safe,
+    restore_refit_info_placements,
 )
 
 
@@ -476,3 +479,81 @@ def test_build_refit_info_groups_experts_and_tags_them():
         for layer in info["layer_names"]
         for p in info["per_layer_params"][layer]
     )
+
+
+# --------------------------------------------------------------------------
+# make_nccl_reshard_refit_info_wire_safe / restore_refit_info_placements
+# --------------------------------------------------------------------------
+def _contains_tensor(obj) -> bool:
+    if isinstance(obj, torch.Tensor):
+        return True
+    if isinstance(obj, dict):
+        return any(_contains_tensor(v) for v in obj.values())
+    if isinstance(obj, (list, tuple)):
+        return any(_contains_tensor(v) for v in obj)
+    if hasattr(obj, "__dict__"):  # e.g. MeshInfo wrapping its rank tensor
+        return any(_contains_tensor(v) for v in vars(obj).values())
+    return False
+
+
+def _refit_info_for_wire() -> dict:
+    return build_nccl_reshard_refit_info(
+        _dense_metadata(),
+        train_parallelism={"tp_size": 2, "ep_size": 1, "pp_size": 1},
+        gen_parallelism={"tp_size": 4, "ep_size": 1, "pp_size": 1},
+        train_world_size=2,
+        gen_world_size=4,
+    )
+
+
+def test_wire_safe_refit_info_carries_no_tensors_and_pickles_plainly():
+    # MeshInfo holds a rank tensor; a tensor pickled in a megatron-importing
+    # process needs `import megatron` at unpickle time, so the wire form must
+    # be tensor-free end to end (the invariant this function exists for).
+    info = _refit_info_for_wire()
+    assert _contains_tensor(info)
+
+    wire = make_nccl_reshard_refit_info_wire_safe(info)
+
+    assert not _contains_tensor(wire)
+    # Placements are encoded exactly as restore expects: Shard -> {"dim": d},
+    # Replicate -> {}.
+    for params in wire["per_layer_params"].values():
+        for p in params:
+            assert isinstance(p["src_mesh_info"], dict)
+            assert isinstance(p["dst_mesh_info"], dict)
+            for placement in p["src_placements"] + p["dst_placements"]:
+                assert isinstance(placement, dict)
+    pickle.loads(pickle.dumps(wire))
+
+
+def test_wire_safe_does_not_mutate_the_train_side_refit_info():
+    info = _refit_info_for_wire()
+
+    make_nccl_reshard_refit_info_wire_safe(info)
+
+    for layer in info["layer_names"]:
+        for p in info["per_layer_params"][layer]:
+            assert isinstance(p["src_mesh_info"], MeshInfo)
+            assert isinstance(p["dst_mesh_info"], MeshInfo)
+            for placement in p["src_placements"] + p["dst_placements"]:
+                assert isinstance(placement, (Shard, Replicate))
+
+
+def test_wire_safe_then_restore_reproduces_placements_and_meshes():
+    info = _refit_info_for_wire()
+
+    wire = pickle.loads(pickle.dumps(make_nccl_reshard_refit_info_wire_safe(info)))
+    restored = restore_refit_info_placements(wire)
+
+    assert restored["layer_names"] == info["layer_names"]
+    for layer in info["layer_names"]:
+        original = {p["name"]: p for p in info["per_layer_params"][layer]}
+        assert len(restored["per_layer_params"][layer]) == len(original)
+        for p in restored["per_layer_params"][layer]:
+            o = original[p["name"]]
+            for key in ("src_mesh_info", "dst_mesh_info"):
+                assert isinstance(p[key], MeshInfo)
+                assert torch.equal(p[key].mesh, o[key].mesh)
+            for key in ("src_placements", "dst_placements"):
+                assert p[key] == o[key]


### PR DESCRIPTION
# What does this PR do ?

This PR is doing two independent things. I split this PR into two.

1. Gate the MTP layers from the nccl-reshard path. It will force the use of the conventional refit path for the MTP layer.

Goes to #3619

2. Make the `nccl_reshard_refit_info` object wire-safe before sending it to the generation worker during initialization. 
`nccl_reshard_refit_info` contains torch tensors, created by Megatron. The problem is that Megatron replaces the
`torch.storage._load_from_bytes` function that is required for unpickling to a Megatron-specific function. 
So, during unpickling from the generation worker, it will call `import megatron` which will cause an import error.
This PR fixes that issue.

Goes to #3618


# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
