### PR TITLE
fix(trtllm): Align HTTP server sampling params, use generate_async

### DIFF
--- a/nemo_rl/models/generation/trtllm/trtllm_http_server.py
+++ b/nemo_rl/models/generation/trtllm/trtllm_http_server.py
@@ -17,7 +17,6 @@ Returns NeMoGym fields (prompt_token_ids, generation_token_ids, generation_log_p
 Supports Qwen3 tool calling, DeepSeekR1Parser reasoning, and prefix token splicing.
 """
 
-import asyncio
 import logging
 import threading
 import time
@@ -214,9 +213,8 @@ def create_app(
         )
 
         try:
-            outputs = await asyncio.to_thread(
-                llm.generate,
-                [{"prompt_token_ids": adj_prompt}],
+            output = await llm.generate_async(
+                {"prompt_token_ids": adj_prompt},
                 sampling_params=sampling,
             )
         except RequestError as e:
@@ -228,7 +226,6 @@ def create_app(
                 )
             raise
 
-        output = outputs[0]
         gen = output.outputs[0]
         gen_token_ids = list(gen.token_ids)
 

--- a/nemo_rl/models/generation/trtllm/trtllm_http_server.py
+++ b/nemo_rl/models/generation/trtllm/trtllm_http_server.py
@@ -47,6 +47,45 @@ def _build_reasoning_parser(name: str, chat_template_kwargs: dict[str, Any]) -> 
     return ReasoningParserFactory.create_reasoning_parser(name, chat_template_kwargs)
 
 
+def _build_sampling_params(
+    sampling_params_cls: Any,
+    *,
+    sampling_config: dict[str, Any],
+    stop_token_ids: list[int] | None,
+    max_tokens: int,
+) -> Any:
+    """Build the TRT-LLM sampling params for one HTTP rollout request.
+
+    Mirrors the direct generate() path
+    (``TrtllmAsyncGenerationWorkerImpl._build_sampling_params``) so both paths
+    sample from the same distribution for a given generation config.
+
+    Args:
+        sampling_params_cls: ``tensorrt_llm.SamplingParams``, injected so this
+            helper stays importable and testable without the TRT-LLM runtime.
+        sampling_config: NeMo-RL generation config (temperature / top_p / top_k).
+        stop_token_ids: Extra stop tokens from the generation config, if any.
+        max_tokens: Output cap for this request, already clamped to the context window.
+
+    Returns:
+        A ``SamplingParams`` instance to hand to ``llm.generate_async``.
+    """
+    # TRT-LLM spells "no top-k restriction" as 0, the generation config as null.
+    top_k_cfg = sampling_config["top_k"]
+    stop_ids = list(stop_token_ids or [])
+    return sampling_params_cls(
+        temperature=float(sampling_config["temperature"]),
+        top_p=float(sampling_config["top_p"]),
+        top_k=int(top_k_cfg) if top_k_cfg is not None else 0,
+        max_tokens=int(max_tokens),
+        stop_token_ids=stop_ids or None,
+        # Include generated stop tokens so the adapter can trim tokens and logprobs together.
+        include_stop_str_in_output=True,
+        logprobs=True,
+        logprobs_simple_format=True,
+    )
+
+
 def create_app(
     llm: Any,
     tokenizer: Any,
@@ -122,9 +161,9 @@ def create_app(
         # for sampling params.
         for key in ("temperature", "top_p", "top_k"):
             if body.get(key) is not None:
-                assert body[key] == sampling_config.get(key), (
+                assert body[key] == sampling_config[key], (
                     f"request {key} {body[key]!r} must match the "
-                    f"NeMo-RL generation config ({sampling_config.get(key)})"
+                    f"NeMo-RL generation config ({sampling_config[key]})"
                 )
 
         # Request kwargs override server defaults.
@@ -198,18 +237,11 @@ def create_app(
         from tensorrt_llm import SamplingParams as TrtSamplingParams
         from tensorrt_llm.executor.utils import RequestError
 
-        # Same convention as the direct path (_build_sampling_params): TRT-LLM
-        # spells "no top-k restriction" as 0, the generation config as null.
-        top_k_cfg = sampling_config.get("top_k")
-        sampling = TrtSamplingParams(
-            temperature=float(sampling_config["temperature"]),
-            top_p=float(sampling_config["top_p"]),
-            top_k=int(top_k_cfg) if top_k_cfg is not None else 0,
-            max_tokens=int(max_tokens),
-            # Include generated stop tokens so the adapter can trim tokens and logprobs together.
-            include_stop_str_in_output=True,
-            logprobs=True,
-            logprobs_simple_format=True,
+        sampling = _build_sampling_params(
+            TrtSamplingParams,
+            sampling_config=sampling_config,
+            stop_token_ids=stop_token_ids,
+            max_tokens=max_tokens,
         )
 
         try:

--- a/nemo_rl/models/generation/trtllm/trtllm_http_server.py
+++ b/nemo_rl/models/generation/trtllm/trtllm_http_server.py
@@ -121,11 +121,11 @@ def create_app(
 
         # The NeMo-RL generation config, not the request, is the source of truth
         # for sampling params.
-        for key in ("temperature", "top_p"):
+        for key in ("temperature", "top_p", "top_k"):
             if body.get(key) is not None:
-                assert body[key] == sampling_config[key], (
+                assert body[key] == sampling_config.get(key), (
                     f"request {key} {body[key]!r} must match the "
-                    f"NeMo-RL generation config ({sampling_config[key]})"
+                    f"NeMo-RL generation config ({sampling_config.get(key)})"
                 )
 
         # Request kwargs override server defaults.
@@ -199,13 +199,18 @@ def create_app(
         from tensorrt_llm import SamplingParams as TrtSamplingParams
         from tensorrt_llm.executor.utils import RequestError
 
+        # Same convention as the direct path (_build_sampling_params): TRT-LLM
+        # spells "no top-k restriction" as 0, the generation config as null.
+        top_k_cfg = sampling_config.get("top_k")
         sampling = TrtSamplingParams(
             temperature=float(sampling_config["temperature"]),
             top_p=float(sampling_config["top_p"]),
+            top_k=int(top_k_cfg) if top_k_cfg is not None else 0,
             max_tokens=int(max_tokens),
             # Include generated stop tokens so the adapter can trim tokens and logprobs together.
             include_stop_str_in_output=True,
             logprobs=True,
+            logprobs_simple_format=True,
         )
 
         try:

--- a/nemo_rl/models/generation/trtllm/trtllm_worker_async.py
+++ b/nemo_rl/models/generation/trtllm/trtllm_worker_async.py
@@ -295,6 +295,7 @@ class TrtllmAsyncGenerationWorkerImpl:
             sampling_config={
                 "temperature": self.cfg["temperature"],
                 "top_p": self.cfg["top_p"],
+                "top_k": self.cfg["top_k"],
             },
             stop_token_ids=list(self.cfg.get("stop_token_ids") or []),
             default_chat_template_kwargs=self.cfg["trtllm_cfg"].get(

--- a/nemo_rl/models/generation/trtllm/trtllm_worker_async.py
+++ b/nemo_rl/models/generation/trtllm/trtllm_worker_async.py
@@ -566,35 +566,11 @@ class TrtllmAsyncGenerationWorkerImpl:
     #  Helpers
     # ------------------------------------------------------------------ #
 
-    def _resolve_end_id(self) -> Optional[int]:
-        """Resolve end_id from model config.json, cached after first call.
-
-        Mirrors vLLM engine which reads eos_token_id from config.json automatically
-        at startup. TRT-LLM requires it to be passed explicitly as end_id.
-        """
-        if hasattr(self, "_end_id_cache"):
-            return self._end_id_cache
-        end_id: Optional[int] = None
-        try:
-            from transformers import AutoConfig
-
-            hf_config = AutoConfig.from_pretrained(
-                self.model_name, trust_remote_code=True
-            )
-            eos_id = getattr(hf_config, "eos_token_id", None)
-            if eos_id is not None:
-                end_id = eos_id[0] if isinstance(eos_id, list) else eos_id
-        except Exception as e:
-            print(f"[TrtllmAsyncWorker] AutoConfig load failed: {e}", flush=True)
-        self._end_id_cache = end_id
-        return end_id
-
     def _build_sampling_params(self, *, greedy: bool):
         top_k_cfg = self.cfg["top_k"]
         top_k_val = 1 if greedy else (top_k_cfg if top_k_cfg is not None else 0)
         temperature = 0.0 if greedy else self.cfg["temperature"]
 
-        end_id = self._resolve_end_id()
         stop_ids = list(self.cfg.get("stop_token_ids") or [])
 
         return self.TrtSamplingParams(
@@ -602,7 +578,6 @@ class TrtllmAsyncGenerationWorkerImpl:
             top_p=self.cfg["top_p"],
             top_k=top_k_val,
             max_tokens=self.cfg["max_new_tokens"],
-            end_id=end_id,
             stop_token_ids=stop_ids or None,
             # Keep the EOS / stop token in the returned token_ids so that the
             # response sequence matches HF / vLLM behavior. Required for

--- a/tests/unit/models/generation/trtllm/test_trtllm_http_server.py
+++ b/tests/unit/models/generation/trtllm/test_trtllm_http_server.py
@@ -14,11 +14,13 @@
 
 import asyncio
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
 from nemo_rl.models.generation.trtllm.trtllm_http_server import (
     _build_prompt_token_ids,
+    _build_sampling_params,
     _compute_splice_inputs,
     _make_parse_tool_calls,
     _resolve_tool_parser_name,
@@ -47,6 +49,52 @@ class _RecordingTokenizer:
     def apply_chat_template(self, messages, **kwargs):
         self.calls.append((messages, kwargs))
         return [1, 2, 3]
+
+
+def test_http_sampling_params_match_the_direct_path():
+    """The HTTP rollout path must sample exactly like the direct generate() path."""
+    sampling_params_cls = MagicMock()
+
+    _build_sampling_params(
+        sampling_params_cls,
+        sampling_config={"temperature": 0.8, "top_p": 0.9, "top_k": 20},
+        stop_token_ids=[9],
+        max_tokens=4,
+    )
+
+    sampling_params_cls.assert_called_once_with(
+        temperature=0.8,
+        top_p=0.9,
+        top_k=20,
+        max_tokens=4,
+        stop_token_ids=[9],
+        include_stop_str_in_output=True,
+        logprobs=True,
+        logprobs_simple_format=True,
+    )
+
+
+def test_http_sampling_params_map_null_top_k_and_empty_stop_tokens():
+    """null top_k reaches TRT-LLM as 0, and unset stop tokens as None, not []."""
+    sampling_params_cls = MagicMock()
+
+    _build_sampling_params(
+        sampling_params_cls,
+        sampling_config={"temperature": 1.0, "top_p": 1.0, "top_k": None},
+        stop_token_ids=None,
+        max_tokens=8,
+    )
+
+    sampling_params_cls.assert_called_once_with(
+        temperature=1.0,
+        top_p=1.0,
+        top_k=0,
+        max_tokens=8,
+        stop_token_ids=None,
+        include_stop_str_in_output=True,
+        logprobs=True,
+        logprobs_simple_format=True,
+    )
 
 
 def test_explicit_tool_parser_overrides_model_auto_resolution():

--- a/tests/unit/models/generation/trtllm/test_trtllm_worker_async.py
+++ b/tests/unit/models/generation/trtllm/test_trtllm_worker_async.py
@@ -162,6 +162,27 @@ async def test_generate_async_empty_batch_does_not_call_engine():
     worker.llm.generate_async.assert_not_awaited()
 
 
+def test_build_sampling_params_null_top_k_maps_to_zero():
+    """null top_k (default) must reach TRT-LLM as 0, its spelling of 'no restriction'."""
+    worker = _worker()
+    worker.cfg["top_k"] = None
+    worker._resolve_end_id = MagicMock(return_value=2)
+
+    worker._build_sampling_params(greedy=False)
+
+    worker.TrtSamplingParams.assert_called_once_with(
+        temperature=0.8,
+        top_p=0.9,
+        top_k=0,
+        max_tokens=4,
+        end_id=2,
+        stop_token_ids=[9],
+        include_stop_str_in_output=True,
+        logprobs=True,
+        logprobs_simple_format=True,
+    )
+
+
 def test_build_sampling_params_supports_async_greedy_and_sampling_modes():
     worker = _worker()
     worker._resolve_end_id = MagicMock(return_value=2)

--- a/tests/unit/models/generation/trtllm/test_trtllm_worker_async.py
+++ b/tests/unit/models/generation/trtllm/test_trtllm_worker_async.py
@@ -166,7 +166,6 @@ def test_build_sampling_params_null_top_k_maps_to_zero():
     """null top_k (default) must reach TRT-LLM as 0, its spelling of 'no restriction'."""
     worker = _worker()
     worker.cfg["top_k"] = None
-    worker._resolve_end_id = MagicMock(return_value=2)
 
     worker._build_sampling_params(greedy=False)
 
@@ -175,7 +174,6 @@ def test_build_sampling_params_null_top_k_maps_to_zero():
         top_p=0.9,
         top_k=0,
         max_tokens=4,
-        end_id=2,
         stop_token_ids=[9],
         include_stop_str_in_output=True,
         logprobs=True,
@@ -185,7 +183,6 @@ def test_build_sampling_params_null_top_k_maps_to_zero():
 
 def test_build_sampling_params_supports_async_greedy_and_sampling_modes():
     worker = _worker()
-    worker._resolve_end_id = MagicMock(return_value=2)
 
     worker._build_sampling_params(greedy=True)
     worker.TrtSamplingParams.assert_called_once_with(
@@ -193,7 +190,6 @@ def test_build_sampling_params_supports_async_greedy_and_sampling_modes():
         top_p=0.9,
         top_k=1,
         max_tokens=4,
-        end_id=2,
         stop_token_ids=[9],
         include_stop_str_in_output=True,
         logprobs=True,
@@ -207,7 +203,6 @@ def test_build_sampling_params_supports_async_greedy_and_sampling_modes():
         top_p=0.9,
         top_k=20,
         max_tokens=4,
-        end_id=2,
         stop_token_ids=[9],
         include_stop_str_in_output=True,
         logprobs=True,


### PR DESCRIPTION
# What does this PR do ?

**Make the TRT-LLM HTTP rollout path sample the same way the direct`generate()` path already does, and serve it without a worker thread.**
`TrtllmAsyncGenerationWorker` reaches the engine two ways: `generate()` / `generate_async()` call `_build_sampling_params()` directly, while NeMo-Gym rollouts go through the HTTP server, which built its own `SamplingParams`. The two had drifted:

| | direct path | HTTP path (before) |
|---|---|---|
| `top_k` | applied | **not passed — silently ignored** |
| logprob format | `logprobs_simple_format=True` | dict per generated token |
| engine call | native async | `asyncio.to_thread(llm.generate, ...)` |


# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
