### PR TITLE
fix: preserve fp32 router correction bias during refit

### DIFF
--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -87,6 +87,18 @@ from nemo_rl.utils.packed_tensor import packed_broadcast_producer
 from nemo_rl.utils.timer import Timer
 
 
+def _refit_tensor_dtype(
+    fqn: str, tensor: torch.Tensor, default_dtype: torch.dtype
+) -> torch.dtype:
+    """Preserve the FP32 dtype used by inference-critical MoE router state."""
+    is_router_correction_bias = fqn.rsplit(".", maxsplit=1)[-1] == (
+        "e_score_correction_bias"
+    )
+    if is_router_correction_bias and tensor.dtype == torch.float32:
+        return tensor.dtype
+    return default_dtype
+
+
 def dtensor_params_generator(
     model: nn.Module, target_dtype: torch.dtype
 ) -> Generator[tuple[str, torch.Tensor], None, None]:
@@ -109,10 +121,12 @@ def dtensor_params_generator(
 
         adapted_fqn_tensors = _maybe_adapt_tensor_to_hf(model, name, merged_tensor)
         for adapted_fqn, adapted_tensor in adapted_fqn_tensors:
-            # Convert to target dtype
+            refit_dtype = _refit_tensor_dtype(
+                adapted_fqn, adapted_tensor, target_dtype
+            )
             yield (
                 adapted_fqn,
-                adapted_tensor.to(target_dtype, non_blocking=True).contiguous(),
+                adapted_tensor.to(refit_dtype, non_blocking=True).contiguous(),
             )
             del adapted_tensor
         del adapted_fqn_tensors
@@ -1080,12 +1094,14 @@ class DTensorPolicyWorkerV2Impl(
             full_tensor = (
                 tensor.full_tensor() if isinstance(tensor, DTensor) else tensor
             )
-            # all tensor will be casted to self.dtype in stream_weights_via_ipc_zmq/broadcast_weights_for_collective
             adapted_fqn_tensors = _maybe_adapt_tensor_to_hf(
                 self.model, name, full_tensor
             )
             for adapted_fqn, adapted_tensor in adapted_fqn_tensors:
-                state_dict_info[adapted_fqn] = (adapted_tensor.shape, self.dtype)
+                refit_dtype = _refit_tensor_dtype(
+                    adapted_fqn, adapted_tensor, self.dtype
+                )
+                state_dict_info[adapted_fqn] = (adapted_tensor.shape, refit_dtype)
 
         return state_dict_info
 

--- a/tests/unit/models/policy/test_dtensor_worker_v2.py
+++ b/tests/unit/models/policy/test_dtensor_worker_v2.py
@@ -686,6 +686,24 @@ class TestDTensorParamsGenerator:
                 f"Tensor {name} should be converted to {target_dtype}"
             )
 
+    def test_preserves_fp32_router_correction_bias(self):
+        """FP32 MoE router state must not be downcast during refit."""
+
+        class RouterModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer(
+                    "e_score_correction_bias", torch.arange(4, dtype=torch.float32)
+                )
+                self.register_buffer(
+                    "ordinary_buffer", torch.arange(4, dtype=torch.float32)
+                )
+
+        results = dict(dtensor_params_generator(RouterModel(), torch.bfloat16))
+
+        assert results["e_score_correction_bias"].dtype == torch.float32
+        assert results["ordinary_buffer"].dtype == torch.bfloat16
+
     def test_contiguous_output(self):
         """Test that output tensors are contiguous."""
         # Arrange
@@ -776,6 +794,31 @@ class TestDTensorParamsGenerator:
         for name, tensor in results:
             assert tensor.dtype == target_dtype
             assert tensor.is_contiguous()
+
+
+@pytest.mark.automodel
+@pytest.mark.skipif(not NEMO_AUTOMODEL_AVAILABLE, reason="nemo_automodel not available")
+def test_prepare_refit_info_preserves_fp32_router_correction_bias():
+    """Refit metadata must match the FP32 router-bias payload dtype."""
+
+    class RouterModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.register_buffer(
+                "e_score_correction_bias", torch.arange(4, dtype=torch.float32)
+            )
+            self.register_buffer(
+                "ordinary_buffer", torch.arange(4, dtype=torch.float32)
+            )
+
+    worker = object.__new__(DTensorPolicyWorkerV2Impl)
+    worker.model = RouterModel()
+    worker.dtype = torch.bfloat16
+
+    refit_info = DTensorPolicyWorkerV2Impl.prepare_refit_info(worker)
+
+    assert refit_info["e_score_correction_bias"][1] == torch.float32
+    assert refit_info["ordinary_buffer"][1] == torch.bfloat16
 
 
 @pytest.mark.automodel


### PR DESCRIPTION
# What does this PR do?

Preserve the Nemotron-Nano V3 MoE `e_score_correction_bias` buffer in FP32 during DTensor policy refit instead of unconditionally casting it to the policy dtype (typically BF16).

The change keeps the refit payload and its metadata consistent:

- `dtensor_params_generator` sends the router correction bias in its original FP32 dtype.
- `prepare_refit_info` advertises FP32 for the same tensor.
- Other refit tensors continue to use the configured policy dtype.

# Why?

`e_score_correction_bias` is maintained in FP32, but the current refit path casts every tensor to `self.dtype`. For BF16 policies, that downcast can introduce coarse rounding in the router correction values and change expert routing between the trainer and generation model.

This is a focused mitigation for the router-state precision issue. It does not include the native LoRA prototype and does not claim to address the separate finite-precision loss from materializing merged LoRA weights in BF16.

# Issues

No linked issue.

# Usage

No configuration change is required. FP32 preservation is selected only for tensors whose final fully qualified name is `e_score_correction_bias` and whose source dtype is FP32.

# Testing

- Added unit coverage for the transmitted tensor dtype.
- Added unit coverage for matching refit metadata.
- Verified that ordinary FP32 buffers are still converted to BF16.
- `git diff --check` passes.
- Python syntax compilation passes for the implementation and test files.
- Targeted pytest was not run on the HSG login node because that environment does not provide `torch` or `pytest`; full Nano V3 regression remains pending.

# Before this PR is ready for review

- [x] Followed the contribution conventions and signed off the commit.
- [x] Added focused unit tests.
- [ ] Run the targeted unit tests in the NeMo-RL test environment.
- [ ] Run the Nano V3 trainer-generation logprob/KL regression.

# Additional information

This draft intentionally contains only the two-file router FP32 fix. Native LoRA support, LoRA merge-precision investigation code, experiment recipes, and stream-fence changes are out of scope.
