### PR TITLE
fix(docker): add --package nemo-rl to uv sync calls to fix workspace extra resolution

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -220,17 +220,19 @@ fi
 # Do everything in one layer to prevent large layers.
 
 # The venv is symlinked to avoid bloating the layer size
-UV_LINK_MODE=hardlink uv sync --frozen --no-install-project
+# --package nemo-rl pins the sync target explicitly so uv resolves extras against
+# nemo-rl's pyproject.toml regardless of workspace member ordering in the lockfile.
+UV_LINK_MODE=hardlink uv sync --frozen --package nemo-rl --no-install-project
 if [[ -z "${SKIP_VLLM_BUILD:-}" ]]; then
-    UV_LINK_MODE=hardlink uv sync --frozen --extra vllm --no-install-project
+    UV_LINK_MODE=hardlink uv sync --frozen --package nemo-rl --extra vllm --no-install-project
 fi
 if [[ -z "${SKIP_SGLANG_BUILD:-}" ]]; then
-    UV_LINK_MODE=hardlink uv sync --frozen --extra sglang --no-install-project
+    UV_LINK_MODE=hardlink uv sync --frozen --package nemo-rl --extra sglang --no-install-project
 fi
-uv sync --link-mode symlink --frozen --extra mcore --no-install-project
-uv sync --link-mode symlink --frozen --extra automodel --no-install-project
-uv sync --link-mode symlink --frozen --extra modelopt --no-install-project
-uv sync --link-mode symlink --frozen --all-groups --no-install-project
+uv sync --link-mode symlink --frozen --package nemo-rl --extra mcore --no-install-project
+uv sync --link-mode symlink --frozen --package nemo-rl --extra automodel --no-install-project
+uv sync --link-mode symlink --frozen --package nemo-rl --extra modelopt --no-install-project
+uv sync --link-mode symlink --frozen --package nemo-rl --all-groups --no-install-project
 
 # Remove the aiohttp in this uv cache dir to fully address CVE GHSA-mqqc-3gqh-h2x8
 # The ray install will include the older aiohttp version in its cache


### PR DESCRIPTION
## What does this PR do?

Fixes `uv sync --frozen --extra X` failing with:
```
error: Extra 'vllm' is not defined in the project's optional-dependencies table
```

## Root cause

uv 0.11.x generates **revision 4** lockfiles when packages actually change (e.g. during an automated MBridge bump). In revision 4, `uv sync --frozen --extra X` without an explicit `--package` flag resolves the sync target against the **first workspace member** (`nemo-gym`) rather than the CWD package (`nemo-rl`). Since `nemo-gym` has no extras, any `--extra X` call fails.

The committed `uv.lock` on `main` is **revision 3** (generated when nothing changes) and works fine. But as soon as any dependency changes and `uv lock` runs, the lockfile becomes revision 4 and all `--extra X` syncs break.

## Fix

Add `--package nemo-rl` to all `uv sync` calls in the hermetic build stage. This makes workspace package selection explicit regardless of lockfile revision or member ordering.

## Testing

Verified via the nemo-ci mbridge bump automation (`build-NeMo-RL-mbridge-bump` job) which exercises exactly this code path on a freshly-relocked bump branch.