### PR TITLE
docs(nemotron3): add README pointers to the hero-run configs

### DIFF
--- a/examples/configs/recipes/nemotron3-nano/README.md
+++ b/examples/configs/recipes/nemotron3-nano/README.md
@@ -1,0 +1,30 @@
+# Nemotron 3 Nano
+
+The recipes in this directory are the CI-tested ones: short functional and
+convergence runs that `tools/launch` can start from a driver script under
+`tests/test_suites/nemotron3-nano/`.
+
+**The production post-training run is not here.** It lives in the NeMo-Gym
+examples:
+
+- **Config:** `examples/nemo_gym/grpo_nanov3.yaml` (32 nodes)
+- **Entry point:** `examples/nemo_gym/run_grpo_nemo_gym.py`
+- **Guide:** [docs/guides/nemotron-3-nano.md](../../../../docs/guides/nemotron-3-nano.md)
+
+`grpo-nanov3-30BA3B-2n8g-megatron_generation-async-gym.yaml` in this directory
+inherits from that config, so it exercises the production settings at two nodes
+instead of thirty-two.
+
+## Why the production config is not here
+
+It is standalone rather than a delta on an exemplar, it is launched through the
+NeMo-Gym entry point rather than `tools/launch`, and at 32 nodes it is too
+expensive for any CI suite — so it has no driver script and appears in no test
+manifest.
+
+## What this means for changes
+
+`grpo_nanov3.yaml` is validated indirectly today, because the async-gym recipe
+here inherits from it. Other configs under `examples/nemo_gym/` are not covered
+by `test_all_config_files_have_required_keys`, which only globs
+`examples/configs/`.

--- a/examples/configs/recipes/nemotron3-super/README.md
+++ b/examples/configs/recipes/nemotron3-super/README.md
@@ -1,0 +1,34 @@
+# Nemotron 3 Super
+
+The recipes in this directory are the CI-tested ones: short functional and
+convergence runs that `tools/launch` can start from a driver script under
+`tests/test_suites/nemotron3-super/`.
+
+**The full post-training pipeline is not here.** It lives with its launcher:
+
+- **Configs:** `examples/nemo_gym/nemotron-3-super/` (`stage1_rlvr`, `stage2_swe1`,
+  `stage2_swe2`, `stage3_rlhf`, plus lower-DP H100 variants under `small_scale/`)
+- **Launcher:** `examples/nemo_gym/nemotron-3-super/super_launch.sh`
+- **Guide:** [docs/guides/nemotron-3-super.md](../../../../docs/guides/nemotron-3-super.md)
+
+The three `grpo-qwen3-1.7b-*-megatron-super-*` recipes here are the small
+pipeline sanity checks. They inherit directly from the stage configs above, so
+they exercise the real stage settings at a size CI can afford, on a Qwen3-1.7B
+policy rather than the 120B-A12B model.
+
+## Why the pipeline configs are not here
+
+`super_launch.sh` reads `cluster.num_nodes` out of the config and then allows
+`SBATCH_NUM_NODES` to allocate *more* nodes than that, because Gym judge servers
+need their own. `tools/launch` has one node count and no way to express the
+difference. The stage configs are also standalone rather than deltas on an
+exemplar, and are far too expensive to run in any CI suite — so they have no
+driver script and appear in no test manifest.
+
+## What this means for changes
+
+The stage configs are not covered by `test_all_config_files_have_required_keys`,
+which only globs `examples/configs/`. Four of them are validated indirectly,
+because the sanity-check recipes here inherit from them; `stage2_swe2.yaml` and
+everything under `small_scale/` are not validated at all. If you change config
+schema, check those by hand until that coverage gap is closed.

--- a/examples/configs/recipes/nemotron3-ultra/README.md
+++ b/examples/configs/recipes/nemotron3-ultra/README.md
@@ -1,0 +1,34 @@
+# Nemotron 3 Ultra
+
+There are no recipes in this directory. Every Nemotron 3 Ultra run is a hero
+run, and those configs live with their launcher:
+
+- **Configs:** `examples/nemo_gym/nemotron-3-ultra/`
+- **Launcher:** `examples/nemo_gym/nemotron-3-ultra/ultra_launch.sh`
+- **Guide:** [docs/guides/nemotron-3-ultra.md](../../../../docs/guides/nemotron-3-ultra.md)
+
+Start from the guide — the pipeline is multi-stage (student RLVR, a panel of
+specialised teachers, then multi-teacher on-policy distillation), and each stage
+is the same launcher with a different per-stage YAML.
+
+## Why they are not here
+
+Recipes in this tree are small deltas layered on an exemplar config, run by
+`tools/launch`, which allocates one homogeneous pool of nodes described by the
+`NUM_NODES` / `GPUS_PER_NODE` block in the driver script.
+
+The Ultra configs do not fit any part of that. They are standalone rather than
+inheriting from an exemplar, and `ultra_launch.sh` allocates nodes in distinct
+roles — training, generation, Gym environments and teacher serving — which a
+single node count cannot describe. They are also far too expensive to run in
+any CI suite, so they have no driver script and appear in no test manifest.
+
+Adding an Ultra config here would therefore break the invariant that every
+recipe in this tree has a matching driver under `tests/test_suites/`.
+
+## What this means for changes
+
+These configs are not covered by `test_all_config_files_have_required_keys`,
+which only globs `examples/configs/`. A change to `MasterConfig` will not flag
+them. If you change config schema, check them by hand until that coverage gap
+is closed.


### PR DESCRIPTION
# What does this PR do ?

**Adds a README to each Nemotron 3 family directory pointing at where that model's production run actually lives.** Documentation only — three files, no logic.

**Stack position:** PR 2.5 of 5. Below: #3558 (recipe restructure, which creates these directories). Above: PR 3 (`SUITE=`/`GATES=` declarations replace the `.txt` manifests).

**Reviewer:** this is deliberately split out from #3558 so the Nemotron 3 super/ultra/nano owner can approve the wording about their own runs without being pulled into a 518-file move.

## Why

Grouping recipes by model family made a gap visible that the `llm/`/`vlm/` split had hidden: for Nemotron 3, the configs someone is most likely looking for **are not in the family directory at all**.

| Family dir | What's in it | Where the production run is |
|---|---|---|
| `nemotron3-ultra/` | **nothing** — every Ultra run is a hero run | `examples/nemo_gym/nemotron-3-ultra/` + `ultra_launch.sh` |
| `nemotron3-super/` | 9 CI'd recipes | `examples/nemo_gym/nemotron-3-super/` + `super_launch.sh` |
| `nemotron3-nano/` | 17 CI'd recipes | `examples/nemo_gym/grpo_nanov3.yaml` (32 nodes) |

Each README names the configs, the launcher and the guide, and explains why those configs aren't in this tree. `nemotron3-ultra/` is created by this PR and contains only its README — which is real content, not a placeholder.

## The hero configs deliberately stay put

Three independent reasons, not one:

1. **Structurally different.** They're standalone — `student_rlvr1.yaml` has no `defaults:` and declares every section itself (26 KB) — where a recipe is a ~2 KB delta on an exemplar.
2. **Their launchers can't express the `CONFIG` block.** `ultra_launch.sh` allocates nodes in distinct roles (64 train + 172 gen + 20 gym + teachers); `super_launch.sh` deliberately allocates *more* Slurm nodes than `cluster.num_nodes` so Gym judge servers have somewhere to run. `tools/launch` has one homogeneous `NUM_NODES`.
3. **They will never run in CI** at any cadence — so they need no driver script, no `SUITE=`, and no manifest entry.

Moving them would have broken the invariant that every recipe in this tree has a matching driver under `tests/test_suites/`.

## A gap each README records

These configs are **not covered by `test_all_config_files_have_required_keys`**, which globs only `examples/configs/`. Of the 25 YAMLs under `examples/nemo_gym/`:

- **6 are validated indirectly** — they're `defaults:` parents of CI-tested recipes, so the child pulls them in
- **19 are validated by nothing**, including all 7 Ultra configs, all 4 `nemotron-3-super/small_scale/` convergence configs, and `stage2_swe2.yaml`

A `MasterConfig` change will not flag any of them. Closing that gap is left to a later PR — pointing the validation glob at `examples/nemo_gym/` costs no GPU and runs in the existing L0 lane, but is likely to surface real work (these configs carry keys such as a top-level `reward_penalties:` that no recipe has).

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? — none needed; documentation only.
- [x] Did you run the unit tests and functional tests locally? — the recipe/driver/manifest parity invariants were re-checked; `README.md` is invisible to every `*.yaml`/`*.sh` glob, so nothing else is affected.
- [x] Did you add or update any necessary documentation? — this PR is the documentation. The relative links to `docs/guides/nemotron-3-{ultra,super,nano}.md` were verified to resolve, and `docs/index.md` does not include `examples/`, so the Sphinx build is unaffected (`examples/nemo_gym/nemotron-3-super/small_scale/README.md` is existing precedent).
