### PR TITLE
docs: consolidate test-suite conventions into the testing skill

### DIFF
--- a/.agents/contributor-skills/review-pr/SKILL.md
+++ b/.agents/contributor-skills/review-pr/SKILL.md
@@ -102,6 +102,7 @@ After all subagents return: merge results and deduplicate (same file+line+issue 
 - Cross-reference existing review comments (PR mode only, from step 4) to avoid duplicating points already raised by other reviewers
 - Compare any new component to its nearest existing analog in the repo (a new worker group ↔ `lm_policy.py`, a new advantage estimator ↔ the existing estimators, a new config block ↔ `MasterConfig`) and flag missing affordances: backend dispatch, override hooks (e.g. `resolve_policy_worker_cls`), guards/validation, type annotations, return-shape consistency. "It works for the shipped recipe" is not enough if it silently diverges from the sibling's contract
 - Also apply any patterns from review memory files
+- If the diff touches `tests/test_suites/` or `examples/configs/recipes/`, work through the checklist at the end of the `testing` skill. The unit tests already cover naming, budgets, and declarations, so do not re-derive those — the reviewer's job is the part they cannot check: whether the test catches something no existing test does, whether it is worth its GPU-hours (nightly costs 7× its per-run price every week), whether feature coverage belongs on the vehicle model instead, and whether a linked W&B run shows it converging
 - Categorize findings:
   - **[BUG]** — Logic errors, null refs, race conditions, syntax errors
   - **[TEST]** — Missing or insufficient test coverage

--- a/.agents/contributor-skills/testing/SKILL.md
+++ b/.agents/contributor-skills/testing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: testing
-description: Testing conventions for NeMo-RL. Covers Ray actor coverage pragmas, nightly test requirements, and recipe naming rules.
-when_to_use: Writing or reviewing tests; adding a nightly test; naming a recipe; 'coverage pragma', 'Ray actor test', 'nightly test requirement', 'how to name recipes', during code review of test files.
+description: Testing conventions for NeMo-RL. Covers Ray actor coverage pragmas, what earns a place in the nightly/release/performance suites, suite membership declarations, and recipe naming.
+when_to_use: Writing or reviewing tests; adding a recipe or a nightly test; deciding whether a test is worth its GPU hours; naming a recipe; 'coverage pragma', 'Ray actor test', 'nightly test', 'SUITE=', 'how to name recipes', during code review of anything under tests/test_suites or examples/configs/recipes.
 ---
 
 # Testing Conventions
@@ -25,62 +25,225 @@ def remote_eval(batch):
     ...
 ```
 
-## Nightly Tests for New Model Support
+---
 
-When adding support for a new model, add a corresponding nightly test consisting of:
+# Suite Tests
 
-### 1. Recipe YAML under `examples/configs/recipes/`
+The rest of this file is about the GPU suites — the recipes under
+`examples/configs/recipes/` and their drivers under `tests/test_suites/`.
 
-Place it in the model family's directory, `examples/configs/recipes/<family>/` (e.g. `qwen3/`, `llama3.1/`). The family is the model generation, taken from the resolved `policy.model_name`. Performance recipes go in `<family>/performance/`. Name it following the recipe naming rules below.
+For the mechanics of adding one — files to create, the CONFIG block, the GB200
+mirror, how to check your work locally — see @adding-a-test.md. This file is
+about whether the test should exist and what it should be called.
 
-### 2. Driver script under `tests/test_suites/`
+## A nightly test is not free
 
-Create a shell script at the mirrored path, `tests/test_suites/<family>/`. Source the shared environment with `source "${SCRIPT_DIR%%/tests/test_suites/*}/tests/test_suites/common.env"` and invoke the training entrypoint with `uv run ... --config $CONFIG_PATH`. Match the driver script filename to the YAML base name with `.sh`.
+Nightly runs **seven times a week, forever.** A 32 GPU-hour test is 224
+GPU-hours/week; a 128 GPU-hour test is nearly 900. Nightly is by far the largest
+consumer of the fleet even though a single release run costs more than a single
+nightly run — cadence, not per-run size, is what decides a lane's bill.
 
-### 3. Add to nightly list
+Each lane has a weekly ceiling in `SUITE_BUDGETS` in
+@tests/unit/test_recipes_and_test_suites.py, set per SKU because H100 and GB200
+capacity are separate pools that cannot be traded against each other. The
+ceilings sit ~15% above current usage, so there is room for a good test and not
+much more. **When a lane is full, the fix is to retire a test, not to raise the
+ceiling.** The test prints the ten most expensive tests in the lane when it
+fails, so you can see what to trade away.
 
-Append the driver script path (relative to `tests/test_suites/`) to @tests/test_suites/nightly.txt.
+For live numbers: `tools/list-suites --gpu-hours nightly`.
 
-## Recipe Naming Rules
+## Cost bands
 
-### LLM Pattern
+Per-run GPU-hours for a new nightly test, from `tools/list-suites --gpu-hours`:
+
+| Cost | What it takes |
+|---|---|
+| **≤ 32 GPU-h** | Fine. Add it. |
+| **33–64** | Justify the size in the PR description — say what a cheaper version would fail to catch. |
+| **> 64** | Needs a reviewer to agree it is worth the slot. |
+| **> 128** | Does not belong in nightly. Put it in `release` (1×/week instead of 7×). |
+
+These are calibrated to how the lane actually looks: about 79% of nightly tests
+are in the ≤32 band and account for only ~40% of the lane's cost, while a
+handful above 64 carry more than a third of it. The tail is where the budget
+goes.
+
+Before assuming you need a big test, try shrinking: fewer steps, a smaller
+model, a shorter sequence. Most regressions this suite catches show up in the
+first few hundred steps.
+
+## At most two nightly tests per model
+
+Two nightly tests per (algorithm, model) pair. A third needs a reviewer to agree
+the coverage is not obtainable from the existing two.
+
+Not counted as separate tests:
+
+- a **GB200 mirror** of an H100 test (same coverage, other SKU)
+- a **TQ wrapper** (`-tq_simple`, `-tq_mooncake`) of an existing test
+- a **`.vN` bump** replacing its predecessor
+
+The tree currently exceeds this in places — `sft`+`llama3.1-8b`,
+`grpo`+`qwen3-30ba3b` and `grpo`+`nanov3-30BA3B` each carry six distinct nightly
+H100 tests, `ppo`+`qwen2.5-1.5b-gsm8k` five. Those are the backlog, not the
+precedent. The rule bites on **additions**.
+
+## Feature coverage rides on one model
+
+New coverage for a *feature* — sequence packing, activation checkpointing, LoRA,
+FP8, non-colocated generation, a new parallelism — goes on
+**Qwen2.5-Math-1.5B-Instruct**, not on whichever model you happen to be working
+on. It is small and fast: a feature test on it costs ~16 GPU-h instead of the
+several hundred a 30B model would, and it is the DTensor control the
+`nightly_mcore` gate already carries. (Its plain-Megatron arm is still to be
+built; today the only Megatron variant is the single-controller one.)
+
+Two consequences:
+
+- The vehicle is **exempt from the ≤2 rule.** Its test count is supposed to grow
+  as features accumulate. That is what it is for.
+- The vehicle is **exempt from product-relevance pruning.** Nobody ships
+  Qwen2.5-Math-1.5B. It stays anyway, because deleting it would push every
+  feature test back onto a large model.
+
+Add a test on a *different* model only when the feature interacts with something
+that model specifically has — an MoE routing path, a VLM encoder, a context
+length that a 1.5B model cannot exercise. Say which in the PR description.
+
+A new **model** still gets its own test (up to two). This rule is about
+features, not models.
+
+## Where tests may not go
+
+- **Never add coverage to a `performance/` recipe.** Those hyperparameters are
+  hand-tuned for peak throughput and their numbers feed a tracked series. Adding
+  a feature flag to one changes what the series measures. Write a separate
+  functional recipe.
+- **Nightly node counts: 8 or fewer, 1–4 preferred.** Larger allocations queue
+  longer, fail more often, and cost proportionally more. Above 8 nodes in
+  nightly, expect to justify it — it probably belongs in `release`, where
+  32- and 64-node tests are normal.
+- **A new algorithm gets one config to start.** Prove it converges before
+  branching into variants.
+
+## GB200 variants
+
+Hardware is not a directory and not a fork. A GB200 recipe `defaults:` onto its
+H100 counterpart and overrides only what the SKU forces — `cluster.gpus_per_node: 4`
+and any parallelism that has to change. Anything else, and the two drift and
+you no longer know whether a GB200 failure is a hardware problem or a
+config difference.
+
+The filename carries the SKU as its cluster tuple (`1n4g` vs `1n8g`), and the
+driver declares `SKU=gb200`. A unit test checks that `SKU` and `GPUS_PER_NODE`
+agree.
+
+## Evidence
+
+A new suite test needs a W&B run showing it converges before it merges. Link it
+in the PR description. "It ran without crashing" is not the bar — these tests
+exist to detect convergence regressions, so a test that has never demonstrated
+convergence cannot detect a change in it.
+
+Every driver must assert something with `tests/check_metrics.py`. A driver that
+runs a job and checks nothing burns GPU-hours to turn a job green. The only
+exception is a TQ wrapper, which delegates to its base driver and inherits that
+driver's assertions.
+
+## Declaring suite membership
+
+Each driver declares its own membership in its CONFIG block:
+
+```bash
+# ===== BEGIN CONFIG =====
+SUITE=nightly            # nightly | release | performance | disabled
+TAGS="mcore"             # optional; labels a slice of the suite
+SKU=h100                 # h100 | gb200
+NUM_NODES=1
+STEPS_PER_RUN=450
+MAX_STEPS=450
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))
+NUM_MINUTES=120
+# ===== END CONFIG =====
+```
+
+- `SUITE=disabled` requires a non-empty `DISABLED_REASON`. A test that stops
+  running without a recorded reason is a test nobody can decide to delete.
+- `TAGS` labels a *slice* of a suite, not a suite of its own. `TAGS="mcore"`
+  puts a test in the `nightly_mcore` gate, which is a subset of `nightly`.
+  Membership is deliberate curation, not "has `megatron_cfg.enabled`". Deriving
+  it from the config would cost roughly 5× as much — 2,177 GPU-hours per run
+  against the curated gate's 465 — and would drop the DTensor control the gate
+  carries on purpose.
+
+Read the suites with `tools/list-suites <suite>`, which is plain bash with no
+dependencies so a broken `uv sync` cannot make a suite look empty:
+
+```sh
+tools/list-suites nightly
+tools/list-suites --gpu-hours release
+tools/list-suites --suites
+```
+
+## Recipe naming
+
+The filename is the **only** place that records what a test covers. Nothing else
+says a test exists to exercise sequence packing, or that two tests are a
+deliberate pair differing by one knob. `tests/unit/test_recipe_naming.py`
+enforces it.
 
 ```
-<algo>-<model>-<nodes>n<gpus>g-<strategy-and-params>[-modifiers][-long][.vN].(yaml|sh)
+<algo>-<model>-<N>n<M>g-<backend[parallelism]>[-<feature>...][.vN].(yaml|sh)
 ```
 
-- **algo**: `sft`, `dpo`, `grpo`, etc.
-- **model**: `llama3.1-8b-instruct`, `qwen2.5-7b-instruct`, etc.
-- **nodes/gpus**: `1n8g`, `4n8g`, `8n8g`
-- **strategy-and-params**: `fsdp2tp1`, `tp4pp2`, `megatron`, `dtensor2tp1`
-- **modifiers** (optional): `sp`, `actckpt`, `fp8`, `noncolocated`, `quick`
-- **-long** (optional): long-running recipe
-- **.vN** (optional): version suffix for convergence-impacting changes
+VLM recipes prefix the algorithm with `vlm_`.
 
-Examples:
-```
-sft-llama3.1-8b-1n8g-fsdp2tp1-long.yaml
-grpo-llama3.1-8b-instruct-1n8g-megatron-fp8.yaml
-grpo-qwen2.5-7b-instruct-4n8g-fsdp2tp4sp.v3.yaml
-```
+| Section | Rule |
+|---|---|
+| **algo** | `sft`, `dpo`, `grpo`, `dapo`, `distillation`, `rm`, … — must be one the repo knows |
+| **model** | `llama3.1-8b-instruct`, `qwen2.5-math-1.5b-instruct` |
+| **cluster** | `1n8g`, `4n8g` — must match the driver's `NUM_NODES`/`GPUS_PER_NODE` *and* the config's `cluster.gpus_per_node` |
+| **backend** | `megatron`, `fsdp2tp1`, `dtensor2tp1`, `automodel`, `hsdp` — fused or separated parallelism both fine; must match which of `megatron_cfg`/`dtensor_cfg` is enabled |
+| **feature** | `seqpack`, `actckpt`, `fp8`, `noncolocated`, `lora`, `long`, `quick`, … |
+| **`.vN`** | Convergence-affecting changes only |
 
-### VLM Pattern
+The mandated sections are checked **both ways** — the name must match the config
+and the config must match the name. Feature tokens are checked **one way only**:
+a name that claims a feature must have it, but a config may use a feature
+without advertising it. That asymmetry is deliberate. Over a hundred recipes
+enable sequence packing and eight say `seqpack`, because the token means *"this
+test exists to cover packing"*, not *"packing is on"*. Enforcing it both ways
+would demand dozens of renames and destroy the signal the name is carrying.
 
-```
-vlm_<algo>-<model>-<nodes>n<gpus>g-<strategy>[-modifiers][.vN].(yaml|sh)
-```
+**`.vN`** is for changes that move convergence — a dataset swap, a loss change,
+a convergence bug fix — because the version is what tells you a metrics history
+is no longer comparable. Pure performance changes do not bump it. The marker
+belongs to the base recipe, so a wrapper appends after it:
+`…-fsdp2tp1.v3-tq_simple`.
 
-### Directory Placement
+`performance/` and `reproduce/` are exempt from the grammar. Performance recipes
+are named for the shape being benchmarked, and `reproduce/` recipes encode what
+the reproduction varies — the DeepScaleR chain puts context length where the
+cluster tuple would go.
 
-```
-examples/configs/recipes/
-  <family>/<name>.yaml
-  <family>/performance/<name>.yaml
-  reproduce/<name>.yaml
+## Reviewing a PR that adds a suite test
 
-tests/test_suites/
-  common.env
-  <family>/<name>.sh
-  <family>/performance/<name>.sh
-  nightly.txt
-```
+The unit tests catch naming, budget overruns, and missing declarations. They
+cannot catch a test that is well-formed and not worth running. Check by hand:
+
+1. **What does this catch that an existing test does not?** If the answer is a
+   feature, it should be on the vehicle model. If it is a model, it should be
+   within the ≤2 budget.
+2. **What does it cost?** `tools/list-suites --gpu-hours` on the branch; apply
+   the bands. For nightly, multiply by 7 before reacting to the number.
+3. **Is there a W&B run?** Convergent, linked in the description.
+4. **Does it assert a metric?** `check_metrics.py`, with thresholds that would
+   actually fail on a regression.
+5. **Right lane?** Expensive and slow-moving belongs in `release`. Throughput
+   belongs in `performance/` — and nothing else does.
+6. **If it touches `performance/`:** the hyperparameters must be unchanged.
+
+These are judgement calls, not lint. It is reasonable to accept a test that
+breaks a rule when the author says why in the PR description — and reasonable to
+ask for that sentence when it is missing.

--- a/.agents/contributor-skills/testing/adding-a-test.md
+++ b/.agents/contributor-skills/testing/adding-a-test.md
@@ -1,0 +1,230 @@
+# Adding a Suite Test — Mechanics
+
+Read @SKILL.md first for whether the test should exist. This file is the how.
+
+A test is a **pair**: a recipe YAML and a driver script at mirrored paths with
+the same basename. `common.env` derives one from the other, so the pairing is
+structural, not a convention you can drift from.
+
+```
+examples/configs/recipes/<family>/<name>.yaml
+tests/test_suites/<family>/<name>.sh
+```
+
+`<family>` is the model *generation*, taken from the resolved
+`policy.model_name` — `qwen3/`, `llama3.1/`, `nemotron3-super/`. Performance
+recipes go one level deeper in `<family>/performance/`. Recipes built on a model
+outside any official family live in `reproduce/`.
+
+Hardware is **not** a directory. A GB200 variant is a filename token and a
+`defaults:` child of its H100 counterpart.
+
+## 1. The recipe YAML
+
+Inherit from the algorithm's base config rather than restating it:
+
+```yaml
+defaults: ../../grpo_math_1B.yaml
+```
+
+The path is **relative to the recipe file**, so it changes if the recipe moves
+between depths. Only override what your test actually varies — every key you
+restate is a key that stops tracking the base config.
+
+## 2. The driver script
+
+```bash
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source "${SCRIPT_DIR%%/tests/test_suites/*}/tests/test_suites/common.env"
+# ===== BEGIN CONFIG =====
+SUITE=nightly
+SKU=h100
+NUM_NODES=1
+STEPS_PER_RUN=450
+MAX_STEPS=450
+NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))  # Round up
+NUM_MINUTES=120
+# ===== END CONFIG =====
+
+exit_if_max_steps_reached
+
+cd $PROJECT_ROOT
+uv run examples/run_grpo.py \
+    --config $CONFIG_PATH \
+    grpo.max_num_steps=$MAX_STEPS \
+    logger.log_dir=$LOG_DIR \
+    logger.wandb_enabled=True \
+    logger.wandb.project=nemo-rl \
+    logger.wandb.name=$EXP_NAME \
+    logger.monitor_gpus=True \
+    logger.tensorboard_enabled=True \
+    checkpointing.enabled=True \
+    checkpointing.checkpoint_dir=$CKPT_DIR \
+    $@ \
+    2>&1 | tee $RUN_LOG
+
+uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
+
+if [[ $(jq 'to_entries | .[] | select(.key == "train/loss") | .value | keys | map(tonumber) | max' $JSON_METRICS) -ge $MAX_STEPS ]]; then
+    uv run tests/check_metrics.py $JSON_METRICS \
+        'median(data["train/token_mult_prob_error"]) < 1.1' \
+        'data["train/token_mult_prob_error"]["450"] < 1.1'
+fi
+```
+
+### The source line
+
+Copy it verbatim. `${SCRIPT_DIR%%/tests/test_suites/*}` strips everything from
+the `tests/test_suites` path component onward, which finds the project root at
+**any** driver depth. A counted `../..` breaks the moment a recipe moves between
+a family directory and a `performance/` subdirectory, and it breaks silently.
+
+### The CONFIG block
+
+`tools/launch`, `tools/list-suites`, and the unit tests all parse this block as
+text between the `BEGIN`/`END` markers. Keep declarations there — a variable set
+after `END CONFIG` is invisible to all three.
+
+| Variable | Meaning |
+|---|---|
+| `SUITE` | `nightly`, `release`, `performance`, or `disabled` |
+| `TAGS` | Optional. Slice within the suite, e.g. `"mcore"` → the `nightly_mcore` gate |
+| `SKU` | `h100` (8 GPUs/node) or `gb200` (4). Must agree with `GPUS_PER_NODE` |
+| `DISABLED_REASON` | Required when `SUITE=disabled` |
+| `NUM_NODES` | Slurm allocation. Must match the `<N>n` in the filename |
+| `GPUS_PER_NODE` | Defaults to 8. Set to 4 for GB200 |
+| `MAX_STEPS` | Total steps across all runs |
+| `STEPS_PER_RUN` | Steps per Slurm job — set below the partition's time limit |
+| `NUM_RUNS` | Jobs needed to reach `MAX_STEPS`; use the ceiling-division idiom |
+| `NUM_MINUTES` | Wall-clock per job. GPU-hours = `NUM_NODES × GPUS_PER_NODE × NUM_MINUTES / 60 × NUM_RUNS` |
+
+`NUM_MINUTES` is what the budget is computed from, so an inflated value costs
+the lane real headroom whether or not the job uses the time.
+
+### What `common.env` gives you
+
+`PROJECT_ROOT`, `EXP_NAME` (basename of the driver), `EXP_DIR`, `LOG_DIR`,
+`CKPT_DIR`, `JSON_METRICS`, `RUN_LOG`, and `CONFIG_PATH` — derived from the
+driver's own path by swapping `tests/test_suites` → `examples/configs/recipes`,
+which is what makes the YAML/driver pairing mandatory. It errors out if the
+config is missing.
+
+It also provides `exit_if_max_steps_reached` (skip the job if a previous run
+already reached `MAX_STEPS`) and `assert_not_grep`, sets `PYTHONPATH`, installs
+audio deps for `omni`/`audio`/`avqa`/`vlm` drivers, and exits early under
+`TEST_DRYRUN`.
+
+## 3. The suite manifest
+
+Add the driver path, relative to the project root, to the matching
+`tests/test_suites/<suite>.txt`. This must agree with the driver's `SUITE`/`SKU`
+declaration — `test_declarations_reproduce_the_manifest` compares the two and
+fails on any disagreement.
+
+The manifests are on their way out: once nemo-ci reads the declarations, they
+and that test are deleted together, and this step disappears.
+
+## GB200 mirrors
+
+The YAML inherits from its H100 sibling and overrides only what the SKU forces:
+
+```yaml
+defaults: ./grpo-qwen3-8b-1n8g-megatron.yaml
+cluster:
+  gpus_per_node: 4
+policy:
+  megatron_cfg:
+    tensor_model_parallel_size: 4   # halved from 8
+```
+
+The driver sets `SKU=gb200` and `GPUS_PER_NODE=4`, and the filename says `1n4g`.
+
+## TQ wrappers
+
+A `-tq_simple` / `-tq_mooncake` variant re-runs an existing recipe with a
+different transfer backend. The wrapper delegates rather than duplicating:
+
+```bash
+source "${SCRIPT_DIR%%/tests/test_suites/*}/tests/test_suites/common-tq.env"
+export EXP_NAME="$TQ_EXP_NAME"
+bash "$SCRIPT_DIR/$BASE_RECIPE.sh" "$@"
+```
+
+`EXP_NAME` is exported so the wrapper gets its own log directory, checkpoint
+directory, and W&B run name while executing the base driver's body — including
+its metric assertions. The wrapper's CONFIG block must mirror the base's
+`NUM_NODES`/`MAX_STEPS`/`NUM_MINUTES` so GPU-hour accounting stays right.
+
+## Verifying locally
+
+You cannot run the training itself without a cluster, but everything else is
+checkable:
+
+```sh
+# The driver resolves its config and sources cleanly (no GPU needed)
+TEST_DRYRUN=1 ./tests/test_suites/<family>/<name>.sh
+
+# GPU-hour cost of your test and of the lane it joins
+DRYRUN=1 CONTAINER= ACCOUNT= PARTITION= ./tools/launch ./tests/test_suites/<family>/<name>.sh
+tools/list-suites --gpu-hours nightly | tail -1
+
+# The declaration lands in the suite you expect
+tools/list-suites nightly | grep <name>
+
+# Naming, declarations, manifests, budgets
+uv run pytest tests/unit/test_recipe_naming.py tests/unit/test_recipes_and_test_suites.py
+```
+
+`tools/launch` needs GNU `sed` and will not run on macOS.
+
+## Running on the head node
+
+A driver is directly executable, and results land beside it in a directory named
+after the script:
+
+```sh
+uv run ./tests/test_suites/llama3.1/sft-llama3.1-8b-1n8g-megatron-seqpack.sh
+
+ls -lh tests/test_suites/llama3.1/sft-llama3.1-8b-1n8g-megatron-seqpack/
+# drwxr-xr-x 2 user dip 4.0K Apr 23 18:07 ckpts
+# drwxr-xr-x 3 user dip 4.0K Apr 23 18:07 logs
+# -rw-r--r-- 1 user dip 142K Apr 23 18:23 metrics.json
+# -rw-r--r-- 1 user dip  94K Apr 23 18:23 run.log
+```
+
+## Launching with code snapshots
+
+`tools/launch` copies the tree to a code snapshot and submits `NUM_RUNS` Slurm
+jobs against **that** copy, so an experiment keeps running against the code as it
+was at launch even as the repo moves on.
+
+```sh
+# Launch
+CONTAINER=... ACCOUNT=... PARTITION=... ./tools/launch ./tests/test_suites/<family>/<name>.sh
+
+# Print estimated GPU hours, then exit
+DRYRUN=1 CONTAINER=... ACCOUNT=... PARTITION=... ./tools/launch ./tests/test_suites/<family>/<name>.sh
+
+# Print estimated GPU hours, create the snapshot, then exit
+DRYRUN=2 CONTAINER=... ACCOUNT=... PARTITION=... ./tools/launch ./tests/test_suites/<family>/<name>.sh
+
+# Launch with extra env vars
+EXTRA_ENV="NRL_FORCE_REBUILD_VENVS=true NRL_DEEPSCALER_8K_CKPT=/8k-ckpt" \
+CONTAINER=... ACCOUNT=... PARTITION=... ./tools/launch ./tests/test_suites/<family>/<name>.sh
+```
+
+`tools/launch` reads `NUM_NODES`, `GPUS_PER_NODE`, `NUM_RUNS` and `NUM_MINUTES`
+straight out of the CONFIG block to size the allocation and estimate the cost.
+Results live under the snapshot:
+
+```sh
+ls -lh code_snapshots/<name>/recipes/<family>/<name>/
+```
+
+Each snapshot also gets a `continue.sh` that launches another run with the same
+arguments — useful if a job was cancelled or you want to run longer:
+
+```sh
+code_snapshots/<name>/continue.sh
+```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -173,6 +173,29 @@ CONTAINER=... bash tests/run_functional_in_docker.sh tests/functional/sft.sh
 
 The required `CONTAINER` can be built by following the instructions in the [Docker documentation](docker.md).
 
+## Suite Tests
+
+The nightly, release and performance suites are multi-node convergence and
+throughput runs on Slurm, not something you run locally. Each is a pair: a
+recipe YAML under `examples/configs/recipes/<family>/` and a driver script at
+the mirrored path under `tests/test_suites/<family>/`.
+
+A driver declares which suite it belongs to in its `CONFIG` block, so listing a
+suite means reading the declarations:
+
+```sh
+tools/list-suites nightly
+tools/list-suites --gpu-hours release    # per-test and total GPU hours
+tools/list-suites --suites               # every suite name it understands
+```
+
+Adding one is governed by conventions that a unit test cannot check on its own —
+what a nightly slot costs, how much coverage a model is entitled to, which model
+new feature tests belong on. Those live in the `testing` skill
+(`.agents/contributor-skills/testing/`); see
+[tests/test_suites/README.md](../tests/test_suites/README.md) for the entry
+point.
+
 ## Bisecting Failing Tests
 
 > [!IMPORTANT]

--- a/research/template_project/README.md
+++ b/research/template_project/README.md
@@ -85,7 +85,7 @@ bash tests/test_suites/llm/single_update_1n8g.sh
 
 # Launch on SLURM with code snapshots
 # For full documentation on tools/launch, see:
-# https://github.com/NVIDIA-NeMo/RL/blob/main/tests/test_suites/README.md#launching-with-code-snapshots
+# https://github.com/NVIDIA-NeMo/RL/blob/main/.agents/contributor-skills/testing/adding-a-test.md#launching-with-code-snapshots
 bash ../../tools/launch tests/test_suites/llm/single_update_1n8g.sh
 
 # Dry run to estimate GPU hours needed

--- a/tests/test_suites/README.md
+++ b/tests/test_suites/README.md
@@ -1,133 +1,27 @@
-# Recipes
+# Test Suites
 
-## Test Suites
+Driver scripts for the GPU suites. Each one pairs with a recipe YAML at the
+mirrored path under `examples/configs/recipes/<family>/`, same basename —
+`common.env` derives the config path from the driver's own path, so the pairing
+is structural rather than a convention.
 
-Test suites are defined in `.txt` files that list the test scripts to run:
-
-- `nightly.txt` - H100 tests for nightly CI (8 GPUs per node)
-- `release.txt` - H100 tests for release CI (8 GPUs per node)
-- `nightly_gb200.txt` - GB200 tests for nightly CI (4 GPUs per node)
-- `release_gb200.txt` - GB200 tests for release CI (4 GPUs per node)
-- `performance.txt` - Performance benchmarks for H100 (8 GPUs per node)
-- `performance_gb200.txt` - Performance benchmarks for GB200 (4 GPUs per node)
-
-## Naming
-
-Base pattern (LLM):
-
-```
-<algo>-<model>-<nodes>n<gpus>g-<strategy-and-params>[-modifiers][-long][.vN].sh
-```
-
-VLM pattern:
-
-```
-vlm_<algo>-<model>-<nodes>n<gpus>g-<strategy>[-modifiers][.vN].sh
-```
-
-- **algo**: task or algorithm, e.g., `sft`, `dpo`, `grpo`.
-- **model**: model identifier, e.g., `llama3.1-8b-instruct`, `qwen2.5-7b-instruct`.
-- **nodes/gpus**: cluster allocation, e.g., `1n8g`, `4n8g`, `8n8g`.
-- **strategy-and-params**: parallelism or framework detail, e.g., `fsdp2tp1`, `tp4pp2`, `megatron`, `dtensor2tp1`.
-- **modifiers** (optional): short flags like `sp` (sequence packing), `actckpt` (activation checkpointing), `fp8`, `noncolocated`, `quick`.
-- **-long** (optional): indicates long-running recipe.
-- **.vN** (optional): version suffix (e.g., `.v2`, `.v3`) reserved for convergence-impacting changes. Use when the recipe's convergence behavior changes (dataset, loss, convergence bug fix). Pure performance changes do not require a version bump.
-
-Examples:
-
-```
-sft-llama3.1-8b-1n8g-fsdp2tp1-long.sh
-dpo-llama3.1-8b-instruct-4n8g-fsdp2tp4.sh
-grpo-llama3.1-8b-instruct-1n8g-megatron-fp8.sh
-grpo-qwen2.5-7b-instruct-4n8g-fsdp2tp4sp.v3.sh
-```
-
-Known exceptions currently present:
-- Deepscaler recipes encode context length in place of the cluster tuple, e.g., `grpo-deepscaler-1.5b-8K.sh`. These are allowed but should document the intended hardware in the script body.
-- Some recipes include additional short flags in the strategy token (e.g., `fsdp2tp8sp`). Treat these as modifiers appended to the strategy.
-
-Directory placement and naming parity:
-- Recipes are grouped by model family: `examples/configs/recipes/<family>/`, e.g. `qwen3/`, `llama3.1/`, `nemotron3-super/`. The family is the model *generation*, taken from the recipe's resolved `policy.model_name`.
-- Performance recipes live in `examples/configs/recipes/<family>/performance/`. They are tuned for peak throughput, so their hyperparameters are not a place to add feature coverage.
-- `examples/configs/recipes/reproduce/` holds recipes built on a model outside any official family, such as the DeepScaleR context-extension chain.
-- Hardware is **not** a directory. A GB200 variant is a filename token (`4n4g`) and a `defaults:` child of its H100 counterpart.
-- Place driver scripts at the mirrored path under `tests/test_suites/<family>/`, with the same filename and a `.sh` suffix. `common.env` resolves the project root from the `tests/test_suites` path component, so drivers work at any depth.
-- Add the relative script path to `tests/test_suites/nightly.txt` for nightly execution.
-
-## Running manually
-
-Each recipe can be run on the head node:
+Each driver declares which suite it belongs to in its CONFIG block
+(`SUITE`, `TAGS`, `SKU`). To list a suite:
 
 ```sh
-uv run ./llm/sft-llama3.1-8b-1n8g-fsdp2tp2.sh
+tools/list-suites nightly
+tools/list-suites --gpu-hours release    # per-test and total GPU hours
+tools/list-suites --suites               # every suite name it understands
 ```
 
-and the result directory can be found at the same level of the script (w/o `.sh` prefix):
+The `<suite>.txt` manifests are what nemo-ci reads today to build its dynamic
+pipeline; a unit test keeps them in agreement with the declarations. They are
+removed once nemo-ci reads the declarations directly.
 
-```sh
-ls -lh llm/sft-llama3.1-8b-1n8g-fsdp2tp2/
-# drwxr-xr-x 2 terryk dip 4.0K Apr 23 18:07 ckpts
-# drwxr-xr-x 3 terryk dip 4.0K Apr 23 18:07 logs
-# -rw-r--r-- 1 terryk dip 142K Apr 23 18:23 metrics.json
-# -rw-r--r-- 1 terryk dip  94K Apr 23 18:23 run.log
-```
+**The conventions live in the `testing` skill**, not here:
 
-## GB200 Variants
-
-For GB200 systems with 4 GPUs per node, test scripts should include `GPUS_PER_NODE=4` in the CONFIG section. This ensures the launch script uses the correct GPU count for slurm allocation and GPU hour calculations:
-
-```sh
-# ===== BEGIN CONFIG =====
-NUM_NODES=1
-GPUS_PER_NODE=4    # 4 for GB200, 8 for H100 (default)
-STEPS_PER_RUN=450
-MAX_STEPS=450
-NUM_RUNS=$(( (MAX_STEPS + STEPS_PER_RUN - 1) / STEPS_PER_RUN ))
-NUM_MINUTES=120
-# ===== END CONFIG =====
-```
-
-GB200 YAML configs should inherit from their 8g counterparts and override:
-- `cluster.gpus_per_node: 4`
-- Any parallelism settings that need to change (e.g., halving `tensor_parallel_size`)
-- Directory/name references updated to reflect the 4g naming
-
-## Launching with code snapshots
-
-We provide a convenience script that will create a code snapshot and launch `NUM_RUNS` number of slurm jobs (`NUM_RUNS` is defined in the script itself). We create a code snapshot to
-ensure that even as the master repo changes its code, you can always run your experiment with
-the snapshot of the code at the time the experiment was initially launched.
-
-```sh
-# Launch
-CONTAINER=... ACCOUNT=... PARTITION=... ../tools/launch ./llm/sft-llama3.1-8b-1n8g-fsdp2tp2.sh
-
-# Prints Estimated GPUhrs and then exits
-DRYRUN=1 CONTAINER=... ACCOUNT=... PARTITION=... ../tools/launch ./llm/sft-llama3.1-8b-1n8g-fsdp2tp2.sh
-
-# Prints Estimated GPUhrs, creates code snapshot, then exits
-DRYRUN=2 CONTAINER=... ACCOUNT=... PARTITION=... ../tools/launch ./llm/sft-llama3.1-8b-1n8g-fsdp2tp2.sh
-
-# Launch but set extra env vars
-EXTRA_ENV="NRL_FORCE_REBUILD_VENVS=true NRL_DEEPSCALER_8K_CKPT=/8k-ckpt NRL_DEEPSCALER_16K_CKPT=/16k-ckpt" \
-CONTAINER=... ACCOUNT=... PARTITION=... ../tools/launch ./llm/sft-llama3.1-8b-1n8g-fsdp2tp2.sh
-```
-
-After this completes, you can find the result under
-
-```sh
-ls -lh ../code_snapshots/sft-llama3.1-8b-1n8g-fsdp2tp2/recipes/llm/sft-llama3.1-8b-1n8g-fsdp2tp2/
-# drwxr-xr-x 2 terryk dip 4.0K Apr 23 18:07 ckpts
-# drwxr-xr-x 3 terryk dip 4.0K Apr 23 18:07 logs
-# -rw-r--r-- 1 terryk dip 142K Apr 23 18:23 metrics.json
-# -rw-r--r-- 1 terryk dip  94K Apr 23 18:23 run.log
-```
-
-As a convenience, there's also a `continue.sh` script under that will launch
-another run using the same arguments. This is helpful if your job was
-unexpectedly cancelled or you want to run it for a little longer.
-
-```sh
-# This launches one more run of the same experiment
-../code_snapshots/sft-llama3.1-8b-1n8g-fsdp2tp2/continue.sh
-```
+- [`.agents/contributor-skills/testing/SKILL.md`](../../.agents/contributor-skills/testing/SKILL.md)
+  — what earns a place in a suite, GPU-hour bands, suite declarations, recipe naming
+- [`.agents/contributor-skills/testing/adding-a-test.md`](../../.agents/contributor-skills/testing/adding-a-test.md)
+  — the mechanics: files to create, the CONFIG block, GB200 mirrors, running and
+  launching with `tools/launch`

--- a/tests/unit/test_recipe_naming.py
+++ b/tests/unit/test_recipe_naming.py
@@ -26,9 +26,9 @@ The mandated sections -- algo, model, cluster tuple, backend -- are checked
 **both ways**: the name must match the config and the config must match the
 name. Feature tokens are checked **one way only**: if the name claims a feature
 the config must have it, but a config may use a feature without advertising it.
-That asymmetry is deliberate. 94 recipes enable sequence packing; only a handful
-say ``seqpack``, because the token means "this test exists to cover packing",
-not "packing happens to be on".
+That asymmetry is deliberate. Of the recipes checked here, 64 enable sequence
+packing and 8 say ``seqpack``, because the token means "this test exists to
+cover packing", not "packing happens to be on".
 """
 
 import glob


### PR DESCRIPTION
# What does this PR do ?

**Writes down the rules that decided the four PRs below it.**

**Stack position:** PR 5 of 5, the last one. Below: #3561 (recipe naming + validator). Nothing above.

PR 1–4 pruned, restructured, declared, and renamed on the basis of rules that existed only in a review conversation. This puts them in the `testing` skill so the next person adding a nightly test can find them, and so a reviewer has something to point at.

## What the skill now says

The unit tests already catch naming, budget overruns, and missing declarations. The skill covers what they cannot:

- **A nightly slot costs 7× its per-run price, every week, forever.** That one sentence is the reason for everything else. Lane ceilings live in `SUITE_BUDGETS`; when a lane is full the fix is to retire a test, not raise the number.
- **Cost bands** — ≤32 GPU-h fine / 33–64 justify / >64 reviewer agreement / >128 belongs in `release`. Calibrated to the lane: ~79% of nightly tests sit in the ≤32 band and account for ~40% of the cost, while the handful above 64 carry more than a third.
- **At most two nightly tests per (algorithm, model).** GB200 mirrors, TQ wrappers, and `.vN` bumps don't count separately. The tree exceeds this today — `sft`+`llama3.1-8b`, `grpo`+`qwen3-30ba3b` and `grpo`+`nanov3-30BA3B` carry six apiece — which is stated as backlog, not precedent.
- **Feature coverage rides on one model.** New coverage for packing, LoRA, FP8, a new parallelism goes on Qwen2.5-Math-1.5B-Instruct (~16 GPU-h) rather than whichever model the author happens to be working on. It is explicitly exempt from both the ≤2 rule and from product-relevance pruning — nobody ships it, and that is fine, because deleting it would push every feature test back onto a large model.
- **Never add coverage to a `performance/` recipe.** Those hyperparameters feed a tracked series.
- **Evidence** — a linked W&B run showing convergence, and a `check_metrics.py` assertion. A test that has never demonstrated convergence cannot detect a change in it.

`adding-a-test.md` holds the mechanics: the YAML/driver pair, the CONFIG block variables and what each one costs you, the depth-independent `common.env` source line, GB200 mirrors, TQ wrapper delegation, and the local checks that work without a cluster.

## Also in this PR

- **`tests/test_suites/README.md` becomes a pointer.** It was a second copy of the naming rules, which now have a validator. The launch/snapshot documentation moved into the skill; `research/template_project/README.md` linked to its anchor and was repointed.
- **The review skill checks suite tests.** `review-pr` now works the testing checklist when a diff touches `tests/test_suites/` or `examples/configs/recipes/` — explicitly *not* re-deriving what the unit tests cover.
- **Fixes a wrong number I introduced in #3561.** The naming validator's docstring said 94 recipes enable sequence packing; the real figure over the 185 recipes it checks is **64**. The argument is unchanged (8 recipes say `seqpack` either way), but the number was wrong and is now verified.

## Verified locally

- All nine suites still reproduce their manifests; all six budgets pass (nightly 22,974/26,500 GPU-h per week)
- 231/231 drivers pass `TEST_DRYRUN`
- Every number quoted in the skill recomputed against the tree at this SHA, not carried over from the earlier PRs

## Follow-ups this does not do

The skill describes the vehicle model as the home for feature coverage, but the re-homing itself is separate work: building the vehicle's plain-Megatron arm, and moving the sampling-parity pair, HSDP, and `megatron_generation` coverage onto it. PR 3b (deleting the manifests) is still waiting on the nemo-ci change scoped in #3560.

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? — none; this is documentation plus a docstring correction.
- [x] Did you run the unit tests and functional tests locally? — the suite/manifest/budget/dry-run checks were run directly (see above). The pytest run itself needs CI: the uv workspace will not build without the `3rdparty/*` submodules.
- [x] Did you add or update any necessary documentation? — that is what this PR is.
