### PR TITLE
fix: use minimum sequence divisibility factor

### DIFF
--- a/nemo_rl/models/automodel/setup.py
+++ b/nemo_rl/models/automodel/setup.py
@@ -73,6 +73,7 @@ from nemo_rl.models.automodel.config import (
 )
 from nemo_rl.models.policy import PolicyConfig, TokenizerConfig
 from nemo_rl.models.policy.utils import configure_dynamo_cache, resolve_model_class
+from nemo_rl.models.sequence_length import validate_sequence_length_divisibility
 
 STRING_TO_DTYPE = {
     "float32": torch.float32,
@@ -314,14 +315,38 @@ def validate_and_prepare_config(
         "Please use the Megatron backend (policy.megatron_cfg.enabled=True) for YaRN."
     )
 
+    tp_size = config["dtensor_cfg"].get("tensor_parallel_size", 1)
+    cp_size = config["dtensor_cfg"].get("context_parallel_size", 1)
+    sequence_parallel_enabled = config["dtensor_cfg"]["sequence_parallel"]
+
+    if cp_size > 1 and enable_seq_packing:
+        raise ValueError(
+            "Context parallel is not supported for sequence packing. "
+            "Refer to https://github.com/NVIDIA-NeMo/RL/blob/main/docs/model-quirks.md#context-parallel-with-fsdp2 for more details."
+        )
+
+    if cp_size > 1 and tp_size > 1 and sequence_parallel_enabled:
+        raise ValueError(
+            "Context parallel cannot be used together with TP sequence parallel "
+            "in the DTensor backend. Please either set context_parallel_size=1 "
+            "or disable sequence_parallel. See "
+            "https://github.com/NVIDIA-NeMo/RL/issues/659 for more details."
+        )
+
+    validate_sequence_length_divisibility(
+        config["make_sequence_length_divisible_by"],
+        context_parallel_size=cp_size,
+        tensor_parallel_size=tp_size,
+        sequence_parallel=sequence_parallel_enabled,
+    )
+
     # NeMoAutoModelForCausalLM uses flash_attention_2 by default
     # so we need to set it to None if sequence packing is disabled
     # See https://github.com/NVIDIA-NeMo/Automodel/blob/7e748be260651349307862426c0c168cebdeeec3/nemo_automodel/components/_transformers/auto_model.py#L180
-    cp_size_cfg = config["dtensor_cfg"]["context_parallel_size"]
     attn_impl = (
         "flash_attention_2"
-        if (enable_seq_packing and cp_size_cfg == 1)
-        else ("sdpa" if cp_size_cfg > 1 else None)
+        if (enable_seq_packing and cp_size == 1)
+        else ("sdpa" if cp_size > 1 else None)
     )
 
     # Load model config
@@ -374,18 +399,6 @@ def validate_and_prepare_config(
             raise ValueError(f"Unknown reward model type: {rm_type}")
     else:
         model_class = resolve_model_class(model_config.model_type)
-
-    # Get parallelization sizes
-    tp_size = config["dtensor_cfg"].get("tensor_parallel_size", 1)
-    cp_size = config["dtensor_cfg"].get("context_parallel_size", 1)
-    sequence_parallel_enabled = config["dtensor_cfg"]["sequence_parallel"]
-
-    # Validate parallelization configuration
-    if cp_size > 1 and enable_seq_packing:
-        raise ValueError(
-            "Context parallel is not supported for sequence packing. "
-            "Refer to https://github.com/NVIDIA/NeMo-RL/blob/main/docs/model-quirks.md#context-parallel-with-fsdp2 for more details."
-        )
 
     if sequence_parallel_enabled and tp_size == 1:
         print(

--- a/nemo_rl/models/megatron/data.py
+++ b/nemo_rl/models/megatron/data.py
@@ -31,6 +31,7 @@ from nemo_rl.algorithms.loss.interfaces import LossFunction, LossType
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.model_utils import _get_tokens_on_this_cp_rank
 from nemo_rl.models.megatron.common import _round_up_to_multiple
+from nemo_rl.models.sequence_length import validate_sequence_length_divisibility
 from nemo_rl.utils.r3_trace import (
     r3_trace_verify_forward_enabled,
     trace_cp_routed_experts,
@@ -1217,18 +1218,11 @@ def _get_pack_sequence_parameters_for_megatron(
     fp8_cfg = megatron_cfg.get("fp8_cfg", None) or {}
     use_fp8 = fp8_cfg.get("enabled", False)
 
-    # individual sequence needs to be splitted to CP domain, and to TP domain when SP is enabled.
-    minimum_pad_factor = 1
-    if cp_size > 1:
-        minimum_pad_factor *= cp_size * 2
-    if tp_size > 1 and sp:
-        minimum_pad_factor *= tp_size
-    assert pad_individual_seqs_to_multiple_of % minimum_pad_factor == 0, (
-        f"make_sequence_length_divisible_by ({pad_individual_seqs_to_multiple_of}) is not a multiple of minimum_pad_factor ({minimum_pad_factor}).\n"
-        f"Please set policy.make_sequence_length_divisible_by to a multiple of {minimum_pad_factor}.\n"
-        f"    - If CP is enabled, the minimum pad factor is `cp_size * 2`.\n"
-        f"    - If TP+SP is enabled, the minimum pad factor is `tp_size`.\n"
-        f"    - If both are enabled, the minimum pad factor is `cp_size * 2 * tp_size`."
+    validate_sequence_length_divisibility(
+        pad_individual_seqs_to_multiple_of,
+        context_parallel_size=cp_size,
+        tensor_parallel_size=tp_size,
+        sequence_parallel=sp,
     )
 
     # packed sequence length, after sharding to TP and CP domains, needs to be divisible

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -93,6 +93,7 @@ from nemo_rl.models.policy.workers.checkpoint_engine import (
     PolicyCheckpointEngineMixin,
     maybe_preinit_nixl_checkpoint_engine,
 )
+from nemo_rl.models.sequence_length import validate_sequence_length_divisibility
 from nemo_rl.utils.grad_norm import warn_if_inf_grad_norm
 from nemo_rl.utils.native_checkpoint import (
     load_checkpoint,
@@ -258,6 +259,23 @@ class DTensorPolicyWorkerImpl(
         configure_dynamo_cache()
 
         self.cfg = config
+        tp_size = self.cfg["dtensor_cfg"]["tensor_parallel_size"]
+        cp_size = self.cfg["dtensor_cfg"]["context_parallel_size"]
+        sequence_parallel_enabled = self.cfg["dtensor_cfg"]["sequence_parallel"]
+        if cp_size > 1 and tp_size > 1 and sequence_parallel_enabled:
+            raise ValueError(
+                "Context parallel cannot be used together with TP sequence parallel "
+                "in the DTensor backend. Please either set context_parallel_size=1 "
+                "or disable sequence_parallel. See "
+                "https://github.com/NVIDIA-NeMo/RL/issues/659 for more details."
+            )
+        validate_sequence_length_divisibility(
+            self.cfg["make_sequence_length_divisible_by"],
+            context_parallel_size=cp_size,
+            tensor_parallel_size=tp_size,
+            sequence_parallel=sequence_parallel_enabled,
+        )
+
         # torch distributed init. Envars for rank, world_size, and master_addr and master_port are set from the ray remote call
         torch.distributed.init_process_group(backend="nccl")
         self.rank = torch.distributed.get_rank()
@@ -288,6 +306,11 @@ class DTensorPolicyWorkerImpl(
                 f"[Rank {self.rank}] Sequence packing is enabled for model {model_name}"
             )
             print(f"[Rank {self.rank}] Using FlashAttention2 for sequence packing")
+
+        if cp_size > 1 and self.enable_seq_packing:
+            raise ValueError(
+                "Context parallel is not supported for sequence packing. Refer to https://github.com/NVIDIA-NeMo/RL/blob/main/docs/model-quirks.md#context-parallel-with-fsdp2 for more details."
+            )
 
         hf_config_overrides = self.cfg.get("hf_config_overrides", {}) or {}
 
@@ -363,14 +386,7 @@ class DTensorPolicyWorkerImpl(
         if getattr(self.model.config, "pad_token_id", None) is None:
             self.model.config.pad_token_id = tokenizer.pad_token_id
 
-        tp_size = self.cfg["dtensor_cfg"]["tensor_parallel_size"]
-        cp_size = self.cfg["dtensor_cfg"]["context_parallel_size"]
-        if cp_size > 1 and self.enable_seq_packing:
-            raise ValueError(
-                "Context parallel is not supported for sequence packing. Refer to https://github.com/NVIDIA/NeMo-RL/blob/main/docs/model-quirks.md#context-parallel-with-fsdp2 for more details."
-            )
         dp_size = world_size // tp_size // cp_size
-        sequence_parallel_enabled = self.cfg["dtensor_cfg"]["sequence_parallel"]
         assert world_size == dp_size * tp_size * cp_size, (
             f"World size({world_size}) must equal to dp_size({dp_size}) * tp_size({tp_size}) * cp_size({cp_size}) to use DTensor"
         )

--- a/nemo_rl/models/sequence_length.py
+++ b/nemo_rl/models/sequence_length.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+
+def get_sequence_length_divisibility(
+    *,
+    context_parallel_size: int,
+    tensor_parallel_size: int,
+    sequence_parallel: bool,
+) -> int:
+    """Return the minimum global sequence-length multiple for CP and TP+SP.
+
+    Context parallelism splits the global sequence into ``2 * CP`` balanced
+    chunks. Sequence parallelism then splits the CP-local sequence across TP,
+    so its equivalent global constraint is ``CP * TP``. Independent
+    divisibility constraints combine with an LCM.
+    """
+    cp_factor = 2 * context_parallel_size if context_parallel_size > 1 else 1
+    sequence_parallel_factor = (
+        context_parallel_size * tensor_parallel_size
+        if tensor_parallel_size > 1 and sequence_parallel
+        else 1
+    )
+    return math.lcm(cp_factor, sequence_parallel_factor)
+
+
+def validate_sequence_length_divisibility(
+    make_sequence_length_divisible_by: int,
+    *,
+    context_parallel_size: int,
+    tensor_parallel_size: int,
+    sequence_parallel: bool,
+) -> None:
+    """Validate the sequence-padding multiple required by CP and TP+SP."""
+    minimum_pad_factor = get_sequence_length_divisibility(
+        context_parallel_size=context_parallel_size,
+        tensor_parallel_size=tensor_parallel_size,
+        sequence_parallel=sequence_parallel,
+    )
+
+    if (
+        make_sequence_length_divisible_by <= 0
+        or make_sequence_length_divisible_by % minimum_pad_factor != 0
+    ):
+        raise ValueError(
+            "make_sequence_length_divisible_by "
+            f"({make_sequence_length_divisible_by}) must be a positive multiple "
+            f"of the minimum pad factor ({minimum_pad_factor}).\n"
+            f"Please set policy.make_sequence_length_divisible_by to a positive "
+            f"multiple of {minimum_pad_factor}.\n"
+            "    - CP requires `2 * context_parallel_size`.\n"
+            "    - TP+SP operates on the CP-local sequence and therefore requires "
+            "`context_parallel_size * tensor_parallel_size` globally.\n"
+            "    - When both constraints apply, their least common multiple is used."
+        )

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -203,6 +203,7 @@ project-includes = [
   "nemo_rl/models/policy/workers/megatron_remote_sparse_refit.py",
   "nemo_rl/models/policy/workers/checkpoint_engine.py",
   "nemo_rl/models/policy/workers/patches.py",
+  "nemo_rl/models/sequence_length.py",
   "nemo_rl/models/value/__init__.py",
   "nemo_rl/models/value/config.py",
   "nemo_rl/models/value/workers/__init__.py",

--- a/tests/unit/environments/test_reward_model_environment.py
+++ b/tests/unit/environments/test_reward_model_environment.py
@@ -57,6 +57,7 @@ basic_env_config: RewardModelEnvironmentConfig = {
     "dynamic_batching": {"enabled": False},
     "sequence_packing": {"enabled": False},
     "max_grad_norm": None,
+    "make_sequence_length_divisible_by": 1,
 }
 
 

--- a/tests/unit/models/automodel/test_automodel_setup.py
+++ b/tests/unit/models/automodel/test_automodel_setup.py
@@ -54,6 +54,7 @@ def mock_config():
         "max_grad_norm": 1.0,
         "offload_optimizer_for_logprob": False,
         "sequence_packing": {"enabled": False},
+        "make_sequence_length_divisible_by": 1,
         "dtensor_cfg": {
             "cpu_offload": False,
             "tensor_parallel_size": 1,
@@ -225,6 +226,31 @@ class TestValidateAndPrepareConfig:
     @patch("nemo_rl.models.automodel.setup.AutoConfig")
     @patch("nemo_rl.models.automodel.setup.resolve_model_class")
     @patch("nemo_rl.models.automodel.setup.configure_dynamo_cache")
+    def test_context_parallel_with_tp_sequence_parallel_raises_error(
+        self,
+        mock_dynamo,
+        mock_resolve_class,
+        mock_autoconfig_class,
+        mock_config,
+    ):
+        mock_config["dtensor_cfg"]["context_parallel_size"] = 2
+        mock_config["dtensor_cfg"]["tensor_parallel_size"] = 4
+        mock_config["dtensor_cfg"]["sequence_parallel"] = True
+        mock_config["make_sequence_length_divisible_by"] = 8
+
+        with pytest.raises(
+            ValueError,
+            match="cannot be used together with TP sequence parallel",
+        ):
+            validate_and_prepare_config(
+                config=mock_config,
+                processor=None,
+                rank=0,
+            )
+
+    @patch("nemo_rl.models.automodel.setup.AutoConfig")
+    @patch("nemo_rl.models.automodel.setup.resolve_model_class")
+    @patch("nemo_rl.models.automodel.setup.configure_dynamo_cache")
     def test_sequence_parallel_with_tp_size_one_prints_warning(
         self,
         mock_dynamo,
@@ -260,6 +286,26 @@ class TestValidateAndPrepareConfig:
     @patch("nemo_rl.models.automodel.setup.AutoConfig")
     @patch("nemo_rl.models.automodel.setup.resolve_model_class")
     @patch("nemo_rl.models.automodel.setup.configure_dynamo_cache")
+    def test_make_sequence_length_divisible_by_rejects_invalid_cp_multiple(
+        self,
+        mock_dynamo,
+        mock_resolve_class,
+        mock_autoconfig_class,
+        mock_config,
+    ):
+        mock_config["dtensor_cfg"]["context_parallel_size"] = 2
+        mock_config["make_sequence_length_divisible_by"] = 2
+
+        with pytest.raises(ValueError, match=r"minimum pad factor \(4\)"):
+            validate_and_prepare_config(
+                config=mock_config,
+                processor=None,
+                rank=0,
+            )
+
+    @patch("nemo_rl.models.automodel.setup.AutoConfig")
+    @patch("nemo_rl.models.automodel.setup.resolve_model_class")
+    @patch("nemo_rl.models.automodel.setup.configure_dynamo_cache")
     def test_attention_implementation_selection(
         self,
         mock_dynamo,
@@ -281,11 +327,13 @@ class TestValidateAndPrepareConfig:
         # Test SDPA for cp > 1
         mock_config["sequence_packing"]["enabled"] = False
         mock_config["dtensor_cfg"]["context_parallel_size"] = 2
+        mock_config["make_sequence_length_divisible_by"] = 4
         result = validate_and_prepare_config(mock_config, None, 0)
         assert result.attn_impl == "sdpa"
 
         # Test None for cp=1 without sequence packing
         mock_config["dtensor_cfg"]["context_parallel_size"] = 1
+        mock_config["make_sequence_length_divisible_by"] = 1
         result = validate_and_prepare_config(mock_config, None, 0)
         assert result.attn_impl is None
 

--- a/tests/unit/models/megatron/megatron_data_actors.py
+++ b/tests/unit/models/megatron/megatron_data_actors.py
@@ -617,7 +617,8 @@ class GetPackSequenceParametersTestActor:
             [2, True, 1, 1, 2, 1],  # tp
             [2, False, 1, 1, 1, 1],  # tp+sp
             [1, False, 1, 4, 8, 1],  # cp
-            [2, True, 1, 4, 16, 1],  # cp+tp+sp
+            [2, True, 1, 4, 8, 1],  # cp+tp+sp: lcm(8, 8)
+            [4, True, 1, 2, 8, 1],  # cp+tp+sp: lcm(4, 8)
             [1, False, 4, 1, 1, 1],  # pp
         ]:
             megatron_cfg = {

--- a/tests/unit/models/policy/test_dtensor_worker.py
+++ b/tests/unit/models/policy/test_dtensor_worker.py
@@ -149,6 +149,9 @@ def create_test_config(
             },
         },
         "max_grad_norm": 1.0,
+        "make_sequence_length_divisible_by": (
+            (2 * cp if cp > 1 else 1) * (tp if tp > 1 and sp else 1)
+        ),
     }
 
 

--- a/tests/unit/models/policy/test_dtensor_worker_v2.py
+++ b/tests/unit/models/policy/test_dtensor_worker_v2.py
@@ -178,6 +178,9 @@ def create_test_config(
             },
         },
         "max_grad_norm": 1.0,
+        "make_sequence_length_divisible_by": (
+            (2 * cp if cp > 1 else 1) * (tp if tp > 1 and sp else 1)
+        ),
     }
     if automodel_kwargs is not None:
         config["dtensor_cfg"]["automodel_kwargs"] = automodel_kwargs

--- a/tests/unit/models/policy/test_policy_validation.py
+++ b/tests/unit/models/policy/test_policy_validation.py
@@ -108,6 +108,7 @@ def create_dtensor_config(
         "sequence_packing": {
             "enabled": False,
         },
+        "make_sequence_length_divisible_by": 2 * cp if cp > 1 else 1,
         "optimizer": {
             "name": "torch.optim.AdamW",
             "lr": 5e-6,

--- a/tests/unit/models/policy/test_utils.py
+++ b/tests/unit/models/policy/test_utils.py
@@ -33,6 +33,106 @@ from nemo_rl.models.policy.utils import (
     rebuild_cuda_tensor_from_ipc,
     stream_weights_via_ipc_zmq_impl,
 )
+from nemo_rl.models.sequence_length import (
+    get_sequence_length_divisibility,
+    validate_sequence_length_divisibility,
+)
+
+
+@pytest.mark.parametrize(
+    (
+        "context_parallel_size",
+        "tensor_parallel_size",
+        "sequence_parallel",
+        "expected",
+    ),
+    [
+        (1, 1, False, 1),
+        (2, 1, False, 4),
+        (1, 4, True, 4),
+        (2, 4, True, 8),
+        (2, 3, True, 12),
+    ],
+)
+def test_get_sequence_length_divisibility(
+    context_parallel_size,
+    tensor_parallel_size,
+    sequence_parallel,
+    expected,
+):
+    assert (
+        get_sequence_length_divisibility(
+            context_parallel_size=context_parallel_size,
+            tensor_parallel_size=tensor_parallel_size,
+            sequence_parallel=sequence_parallel,
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        "make_sequence_length_divisible_by",
+        "context_parallel_size",
+        "tensor_parallel_size",
+        "sequence_parallel",
+    ),
+    [
+        (1, 1, 1, False),
+        (4, 2, 1, False),
+        (4, 1, 4, True),
+        # CP=2 and TP=4 requires lcm(4, 8) = 8, not their product (16).
+        (8, 2, 4, True),
+        (16, 2, 4, True),
+    ],
+)
+def test_validate_sequence_length_divisibility_accepts_valid_multiples(
+    make_sequence_length_divisible_by,
+    context_parallel_size,
+    tensor_parallel_size,
+    sequence_parallel,
+):
+    validate_sequence_length_divisibility(
+        make_sequence_length_divisible_by,
+        context_parallel_size=context_parallel_size,
+        tensor_parallel_size=tensor_parallel_size,
+        sequence_parallel=sequence_parallel,
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        "make_sequence_length_divisible_by",
+        "context_parallel_size",
+        "tensor_parallel_size",
+        "sequence_parallel",
+        "minimum_pad_factor",
+    ),
+    [
+        (0, 1, 1, False, 1),
+        (2, 2, 1, False, 4),
+        (2, 1, 4, True, 4),
+        # lcm(2*CP, TP) would accept 4, but SP sees the CP-local length.
+        (4, 2, 4, True, 8),
+    ],
+)
+def test_validate_sequence_length_divisibility_rejects_invalid_multiples(
+    make_sequence_length_divisible_by,
+    context_parallel_size,
+    tensor_parallel_size,
+    sequence_parallel,
+    minimum_pad_factor,
+):
+    with pytest.raises(
+        ValueError,
+        match=rf"positive multiple of the minimum pad factor \({minimum_pad_factor}\)",
+    ):
+        validate_sequence_length_divisibility(
+            make_sequence_length_divisible_by,
+            context_parallel_size=context_parallel_size,
+            tensor_parallel_size=tensor_parallel_size,
+            sequence_parallel=sequence_parallel,
+        )
 
 
 class TestGetMegatronCheckpointDir:

--- a/tests/unit/utils/test_native_checkpoint.py
+++ b/tests/unit/utils/test_native_checkpoint.py
@@ -69,6 +69,7 @@ simple_policy_config = {
         "enabled": False,
     },
     "max_grad_norm": 1.0,
+    "make_sequence_length_divisible_by": 1,
     "generation": {
         "temperature": 1.0,
         "top_p": 1.0,


### PR DESCRIPTION
## Summary

Supersedes #3028 with the minimum sequence-length divisibility constraint derived from the actual Megatron sharding order.

- Context parallelism requires the global sequence length `S` to be divisible by `2 * CP`.
- TP sequence parallelism runs on the CP-local sequence, so it requires `(S / CP) % TP == 0`, equivalently `S % (CP * TP) == 0`.
- The minimum joint factor is therefore:

```text
lcm(2 * CP, CP * TP) = CP * lcm(2, TP)
```

This is not `lcm(2 * CP, TP)`, which can be too small, and it is not generally `2 * CP * TP`, which overpads by 2x for even TP.

## Root cause

Megatron first reshapes each sequence into `2 * cp_size` balanced chunks and selects two chunks per CP rank, leaving a CP-local length of `S / CP` ([source](https://github.com/NVIDIA/Megatron-LM/blob/002255075c3728fded9a2e435677840b08560d55/megatron/core/utils.py#L2348-L2364)). When sequence parallelism is enabled, the embedding path passes that local sequence to the TP group ([source](https://github.com/NVIDIA/Megatron-LM/blob/002255075c3728fded9a2e435677840b08560d55/megatron/core/models/common/embeddings/language_model_embedding.py#L138-L143)); its split explicitly requires the first dimension to be divisible by TP size ([source](https://github.com/NVIDIA/Megatron-LM/blob/002255075c3728fded9a2e435677840b08560d55/megatron/core/tensor_parallel/mappings.py#L56-L75)).

The previous product calculation treated the TP constraint as an independent global factor and multiplied it by the full CP factor, double-counting the factor of 2 when TP is even.

## Changes

- Add a backend-neutral helper that computes `lcm(2 * CP, CP * TP)` and validates positive multiples.
- Use the same validator in the Megatron packed-sequence path and both DTensor setup paths.
- Reject DTensor CP together with TP sequence parallelism before model/distributed initialization because that combination remains unsupported.
- Add decisive coverage for `CP=2, TP=4, SP=true`: factor 4 is rejected, while factors 8 and 16 are accepted.
- Update Megatron parameter coverage so factor 8 is accepted for both `CP=4, TP=2` and `CP=2, TP=4`.

## 8-GPU validation

![Megatron sequence-divisibility probe](https://gist.githubusercontent.com/NolenLiang/a40092d44ab51e7de7e5d7d8260b0e34/raw/8633b54802f590c48334da9b8b23ab3dcbe009be/pr3028_sequence_divisibility_results.svg)

The probe called the exact MCore CP partition, TP sequence-parallel scatter, and backward all-gather primitives on 8 H100 GPUs with `CP=2` and `TP=4`.

| Global sequence length | CP partition | TP/SP forward | Backward all-gather |
| ---: | :---: | :---: | :---: |
| 4 | Pass | **Fail** | Not run |
| 8 | Pass | Pass | Pass |
| 16 | Pass | Pass | Pass |

This directly rejects `lcm(2*CP, TP)=4` and shows that the product `2*CP*TP=16` is not necessary; the derived minimum `lcm(2*CP, CP*TP)=8` passes end to end.

Experiment source version: Megatron-LM `002255075c3728fded9a2e435677840b08560d55`. Runtime: PyTorch `2.13.0a0+8145d630e8.nv26.06`. The corresponding PyTorch 2.11 source was separately audited and has the same CP divisibility behavior.
