### PR TITLE
docs: fix references that point at files which do not exist

### DIFF
--- a/infra/nrl_k8s/src/nrl_k8s/cli.py
+++ b/infra/nrl_k8s/src/nrl_k8s/cli.py
@@ -675,7 +675,8 @@ def run(
     if not loaded.infra.launch.entrypoint:
         _cli_error(
             "infra.launch.entrypoint is empty",
-            hint="`nrl-k8s run` requires infra.launch.entrypoint; see docs/recipes.md",
+            hint="`nrl-k8s run` requires infra.launch.entrypoint; see the "
+            "'Config layout' section of infra/nrl_k8s/README.md",
         )
 
     if as_rayjob:
@@ -1841,7 +1842,10 @@ def _explain_and_exit(exc: BaseException, *, context: str) -> NoReturn:
             "is kubectl authenticated? (try `aws sso login`)"
         )
     elif isinstance(exc, ValueError) and "launch.entrypoint" in str(exc):
-        hint = "set infra.launch.entrypoint in your recipe; see docs/recipes.md."
+        hint = (
+            "set infra.launch.entrypoint in your recipe; see the 'Config layout' "
+            "section of infra/nrl_k8s/README.md."
+        )
     _cli_error(f"{context}: {exc}", hint=hint)
 
 

--- a/nemo_rl/data_plane/README.md
+++ b/nemo_rl/data_plane/README.md
@@ -489,5 +489,6 @@ trainer uses only half of it**. The task-mediated half
 (`claim_meta` / `get_data` / `check_consumption_status`) is reserved
 for the async trainer, which is not yet wired into production.
 
-Design proposal, filtering / staleness strategies, and open questions:
-see [`docs/data-plane-async-proposal.md`](docs/data-plane-async-proposal.md).
+The design proposal covering filtering / staleness strategies and the open
+questions has not been written up yet; the task-mediated methods on
+`DataPlaneClient` are the current source of truth for the intended shape.

--- a/research/README.md
+++ b/research/README.md
@@ -12,22 +12,22 @@ cp -r research/template_project research/my_new_project
 
 The template includes:
 - A minimal train-and-generate loop example:
-    - Main loop: [single_update.py](research/template_project/single_update.py)
-    - Utilities used by the main loop: [template_project/](research/template_project/template_project)
-- Configuration examples: [configs/](research/template_project/configs)
-    - The subdirectory [configs/recipes/](research/template_project/configs/recipes) is used only for test suites
-- Documentation template: [README.md](research/template_project/README.md)
-- Complete test suite structure (unit, functional, and test suites): [tests/](research/template_project/tests)
-- Dependency specification: [.python-version](research/template_project/.python-version) and [pyproject.toml](research/template_project/pyproject.toml)
+    - Main loop: [single_update.py](template_project/single_update.py)
+    - Utilities used by the main loop: [template_project/](template_project/template_project)
+- Configuration examples: [configs/](template_project/configs)
+    - The subdirectory [configs/recipes/](template_project/configs/recipes) is used only for test suites
+- Documentation template: [README.md](template_project/README.md)
+- Complete test suite structure (unit, functional, and test suites): [tests/](template_project/tests)
+- Dependency specification: [.python-version](template_project/.python-version) and [pyproject.toml](template_project/pyproject.toml)
 
 ## What Needs To Be Provided
 
 A new research project needs to include at least:
 - Driver script and main loop
-    - You can refer to [run_grpo.py](examples/run_grpo.py) and [grpo.py](nemo_rl/algorithms/grpo.py) in the core repository, and [single_update.py](research/template_project/single_update.py) in the research template for examples.
+    - You can refer to [run_grpo.py](../examples/run_grpo.py) and [grpo.py](../nemo_rl/algorithms/grpo.py) in the core repository, and [single_update.py](template_project/single_update.py) in the research template for examples.
 - Configuration
     - A runnable `config.yaml` that defines the experiment.
-    - You can refer to [examples/configs/](examples/configs) in the core repository and [configs/](research/template_project/configs) in the research template for examples.
+    - You can refer to [examples/configs/](../examples/configs) in the core repository and [configs/](template_project/configs) in the research template for examples.
 - Documentation
     - A `README.md` that describes the project, how to run it, and how to reproduce results.
 - Functional test

--- a/skills/nemo-rl-session-memory/skill-card.md
+++ b/skills/nemo-rl-session-memory/skill-card.md
@@ -19,8 +19,8 @@ Risk: Review before execution as proposals could introduce incorrect or misleadi
 Mitigation: Review and scan skill before deployment. <br>
 
 ## Reference(s): <br>
-- [Skill Definition (SKILL.md)](skills/nemo-rl-session-memory/SKILL.md) <br>
-- [Evaluation Report (BENCHMARK.md)](skills/nemo-rl-session-memory/BENCHMARK.md) <br>
+- [Skill Definition (SKILL.md)](SKILL.md) <br>
+- [Evaluation Report (BENCHMARK.md)](BENCHMARK.md) <br>
 
 
 ## Skill Output: <br>


### PR DESCRIPTION
# What does this PR do ?

**Fixes four places that send a reader to a file which is not there.** Found while auditing the repo for staleness after the recipe restructure; none of these are caused by that work, which is why they are here and not in that stack.

Standalone, based on `main`, no dependencies.

## `research/README.md` — 13 dead links

Links were written repo-root-relative *without* a leading slash, so GitHub resolved every one of them to `research/research/...`:

```diff
-    - Main loop: [single_update.py](research/template_project/single_update.py)
+    - Main loop: [single_update.py](template_project/single_update.py)
```

This is the first document a new research contributor reads, and every link in "The template includes" was broken. The file's own **Projects** section already used the correct relative form, which is what the rest now matches. Links that genuinely point outside `research/` became `../examples/...` and `../nemo_rl/...`.

`skills/nemo-rl-session-memory/skill-card.md` had the identical bug on its two reference links.

## `nemo_rl/data_plane/README.md` — a proposal that was never written

The async section pointed at `docs/data-plane-async-proposal.md` for "design proposal, filtering / staleness strategies, and open questions". That file has never existed. Rather than invent a target, the sentence now says the write-up does not exist yet and names `DataPlaneClient`'s task-mediated methods (`claim_meta` / `get_data` / `check_consumption_status`) as the current source of truth — which is what the paragraph above it already describes.

## `nrl-k8s` — two error hints citing a nonexistent doc

```python
hint="`nrl-k8s run` requires infra.launch.entrypoint; see docs/recipes.md"
```

`docs/recipes.md` has never existed in this repo. `infra.launch.entrypoint` is documented under **Config layout** in `infra/nrl_k8s/README.md`, which is where both hints point now. These fire exactly when someone is already stuck, so the pointer has to land somewhere real.

## Verified

- Every markdown link in the repo re-checked: the only remaining "misses" are `/NVIDIA-NeMo/RL/blob/main/...` in the PR template, which are site-absolute URLs that resolve correctly on github.com
- `ruff check` and `ruff format --check` clean on `cli.py`

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? — none; documentation references only.
- [x] Did you run the unit tests and functional tests locally? — not applicable. The one code change is a user-facing error-hint string; it was linted and the module parses.
- [x] Did you add or update any necessary documentation? — that is what this PR is.
