### PR TITLE
perf(vllm): avoid repeated multi-turn tokenization

### DIFF
--- a/nemo_rl/models/generation/dynamo/token_wrapper.py
+++ b/nemo_rl/models/generation/dynamo/token_wrapper.py
@@ -27,7 +27,12 @@ from nemo_rl.distributed.virtual_cluster import (
     _get_free_port_local,
     _get_node_ip_local,
 )
-from nemo_rl.models.generation.openai_server_utils import replace_prefix_tokens
+from nemo_rl.models.generation.openai_server_utils import (
+    CompleteTokenInjectionError,
+    build_complete_prompt_token_ids,
+    find_latest_tokenized_assistant,
+    replace_prefix_tokens,
+)
 
 _GYM_TOKEN_METADATA_FIELDS = (
     "prompt_token_ids",
@@ -189,30 +194,91 @@ def _render_prompt_token_ids_with_optional_prefix(
     return full_prompt_token_ids, template_prefix_token_ids
 
 
-def _latest_tokenized_assistant_index(messages: list[Any]) -> Optional[int]:
-    for index in reversed(range(len(messages))):
-        message = messages[index]
-        if not isinstance(message, dict) or message.get("role") != "assistant":
-            continue
-        if (
-            message.get("prompt_token_ids") is not None
-            and message.get("generation_token_ids") is not None
-        ):
-            return index
-    return None
-
-
-def _derive_required_prefix_token_ids(messages: list[Any]) -> list[int] | None:
-    """Return the exact prompt and generation IDs from the latest model turn."""
-    assistant_index = _latest_tokenized_assistant_index(messages)
-    if assistant_index is None:
+def _derive_tokenized_assistant_context(
+    messages: list[Any],
+) -> tuple[int, int, list[int]] | None:
+    """Return the ordinal, index, and exact IDs of the latest model turn."""
+    tokenized_assistant = find_latest_tokenized_assistant(messages)
+    if tokenized_assistant is None:
         return None
-    message = messages[assistant_index]
-    if not isinstance(message, dict):
-        return None
-    return _coerce_token_id_list(
+    assistant_ordinal, message = tokenized_assistant
+    assistant_indexes = [
+        index
+        for index, candidate in enumerate(messages)
+        if isinstance(candidate, dict) and candidate.get("role") == "assistant"
+    ]
+    assistant_index = assistant_indexes[assistant_ordinal]
+    required_prefix_token_ids = _coerce_token_id_list(
         message["prompt_token_ids"], "prompt_token_ids"
     ) + _coerce_token_id_list(message["generation_token_ids"], "generation_token_ids")
+    return assistant_ordinal, assistant_index, required_prefix_token_ids
+
+
+def _messages_are_text_only(messages: list[Any]) -> bool:
+    """Return whether chat-template input contains only plain-text messages."""
+    return all(
+        isinstance(message, dict)
+        and (message.get("content") is None or isinstance(message.get("content"), str))
+        for message in messages
+    )
+
+
+def _render_complete_prompt_token_ids(
+    *,
+    tokenizer: Any,
+    request_body: dict[str, Any],
+    messages: list[Any],
+    tokenizer_chat_template_kwargs: Optional[dict[str, Any]],
+    exclude_tools_when_tool_choice_none: bool,
+    add_generation_prompt: bool,
+    assistant_ordinal: int,
+    required_prefix_token_ids: list[int],
+) -> list[int]:
+    """Build complete IDs by encoding only the suffix after a model turn."""
+
+    def render_prompt_text(conversation: list[Any]) -> str:
+        return _apply_chat_template(
+            tokenizer=tokenizer,
+            request_body=request_body,
+            messages=conversation,
+            tokenizer_chat_template_kwargs=tokenizer_chat_template_kwargs,
+            exclude_tools_when_tool_choice_none=exclude_tools_when_tool_choice_none,
+            add_generation_prompt=add_generation_prompt,
+            tokenize=False,
+        )
+
+    def render_assistant_close_text(conversation: list[Any]) -> str:
+        return _apply_chat_template(
+            tokenizer=tokenizer,
+            request_body=request_body,
+            messages=conversation,
+            tokenizer_chat_template_kwargs=tokenizer_chat_template_kwargs,
+            exclude_tools_when_tool_choice_none=exclude_tools_when_tool_choice_none,
+            add_generation_prompt=False,
+            tokenize=False,
+        )
+
+    return build_complete_prompt_token_ids(
+        tokenizer=tokenizer,
+        conversation=messages,
+        assistant_ordinal=assistant_ordinal,
+        model_prefix_token_ids=required_prefix_token_ids,
+        render_prompt_text=render_prompt_text,
+        render_assistant_close_text=render_assistant_close_text,
+    )
+
+
+def _is_tool_argument_mapping_error(error: BaseException) -> bool:
+    """Return whether an exception wraps the known tool-template error."""
+    current: BaseException | None = error
+    while current is not None:
+        if (
+            isinstance(current, TypeError)
+            and str(current) == _TOOL_ARGUMENT_MAPPING_ERROR
+        ):
+            return True
+        current = current.__cause__
+    return False
 
 
 def _normalize_tool_arguments_for_template(
@@ -323,57 +389,95 @@ def prepare_dynamo_chat_completion_request(
     prepared_body["messages"] = stripped_messages
     prepared_body.pop("required_prefix_token_ids", None)
 
-    required_prefix_token_ids = _derive_required_prefix_token_ids(messages)
     add_generation_prompt = _request_add_generation_prompt(prepared_body)
     template_messages = deepcopy(stripped_messages)
+    tokenized_assistant_context = _derive_tokenized_assistant_context(messages)
+    required_prefix_token_ids: list[int] | None = None
+    assistant_ordinal: int | None = None
     assistant_index: int | None = None
-    if required_prefix_token_ids is not None:
-        assistant_index = _latest_tokenized_assistant_index(messages)
-        if assistant_index is None:
-            raise ValueError(
-                "Dynamo prefix token metadata must be attached to an assistant message."
+    full_prompt_token_ids: list[int] | None = None
+    if tokenized_assistant_context is not None:
+        (
+            assistant_ordinal,
+            assistant_index,
+            required_prefix_token_ids,
+        ) = tokenized_assistant_context
+
+    if required_prefix_token_ids is not None and _messages_are_text_only(
+        template_messages
+    ):
+        assert assistant_ordinal is not None
+        try:
+            full_prompt_token_ids = _render_complete_prompt_token_ids(
+                tokenizer=tokenizer,
+                request_body=prepared_body,
+                messages=template_messages,
+                tokenizer_chat_template_kwargs=tokenizer_chat_template_kwargs,
+                exclude_tools_when_tool_choice_none=exclude_tools_when_tool_choice_none,
+                add_generation_prompt=add_generation_prompt,
+                assistant_ordinal=assistant_ordinal,
+                required_prefix_token_ids=required_prefix_token_ids,
+            )
+        except CompleteTokenInjectionError as e:
+            if _is_tool_argument_mapping_error(e):
+                _normalize_tool_arguments_for_template(
+                    template_messages, before_index=len(template_messages)
+                )
+                try:
+                    full_prompt_token_ids = _render_complete_prompt_token_ids(
+                        tokenizer=tokenizer,
+                        request_body=prepared_body,
+                        messages=template_messages,
+                        tokenizer_chat_template_kwargs=tokenizer_chat_template_kwargs,
+                        exclude_tools_when_tool_choice_none=exclude_tools_when_tool_choice_none,
+                        add_generation_prompt=add_generation_prompt,
+                        assistant_ordinal=assistant_ordinal,
+                        required_prefix_token_ids=required_prefix_token_ids,
+                    )
+                except CompleteTokenInjectionError:
+                    pass
+
+    if full_prompt_token_ids is None:
+        try:
+            (
+                full_prompt_token_ids,
+                template_prefix_token_ids,
+            ) = _render_prompt_token_ids_with_optional_prefix(
+                tokenizer=tokenizer,
+                request_body=prepared_body,
+                messages=template_messages,
+                tokenizer_chat_template_kwargs=tokenizer_chat_template_kwargs,
+                exclude_tools_when_tool_choice_none=exclude_tools_when_tool_choice_none,
+                add_generation_prompt=add_generation_prompt,
+                assistant_index=assistant_index,
+            )
+        except TypeError as e:
+            if str(e) != _TOOL_ARGUMENT_MAPPING_ERROR:
+                raise
+            _normalize_tool_arguments_for_template(
+                template_messages, before_index=len(template_messages)
+            )
+            (
+                full_prompt_token_ids,
+                template_prefix_token_ids,
+            ) = _render_prompt_token_ids_with_optional_prefix(
+                tokenizer=tokenizer,
+                request_body=prepared_body,
+                messages=template_messages,
+                tokenizer_chat_template_kwargs=tokenizer_chat_template_kwargs,
+                exclude_tools_when_tool_choice_none=exclude_tools_when_tool_choice_none,
+                add_generation_prompt=add_generation_prompt,
+                assistant_index=assistant_index,
             )
 
-    try:
-        (
-            full_prompt_token_ids,
-            template_prefix_token_ids,
-        ) = _render_prompt_token_ids_with_optional_prefix(
-            tokenizer=tokenizer,
-            request_body=prepared_body,
-            messages=template_messages,
-            tokenizer_chat_template_kwargs=tokenizer_chat_template_kwargs,
-            exclude_tools_when_tool_choice_none=exclude_tools_when_tool_choice_none,
-            add_generation_prompt=add_generation_prompt,
-            assistant_index=assistant_index,
-        )
-    except TypeError as e:
-        if str(e) != _TOOL_ARGUMENT_MAPPING_ERROR:
-            raise
-        _normalize_tool_arguments_for_template(
-            template_messages, before_index=len(template_messages)
-        )
-        (
-            full_prompt_token_ids,
-            template_prefix_token_ids,
-        ) = _render_prompt_token_ids_with_optional_prefix(
-            tokenizer=tokenizer,
-            request_body=prepared_body,
-            messages=template_messages,
-            tokenizer_chat_template_kwargs=tokenizer_chat_template_kwargs,
-            exclude_tools_when_tool_choice_none=exclude_tools_when_tool_choice_none,
-            add_generation_prompt=add_generation_prompt,
-            assistant_index=assistant_index,
-        )
-
-    if required_prefix_token_ids is not None:
-        assert template_prefix_token_ids is not None
-        full_prompt_token_ids = replace_prefix_tokens(
-            tokenizer,
-            model_prefix_token_ids=required_prefix_token_ids,
-            template_prefix_token_ids=template_prefix_token_ids,
-            template_token_ids=full_prompt_token_ids,
-        )
+        if required_prefix_token_ids is not None:
+            assert template_prefix_token_ids is not None
+            full_prompt_token_ids = replace_prefix_tokens(
+                tokenizer,
+                model_prefix_token_ids=required_prefix_token_ids,
+                template_prefix_token_ids=template_prefix_token_ids,
+                template_token_ids=full_prompt_token_ids,
+            )
 
     nvext = prepared_body.get("nvext")
     if nvext is None:

--- a/nemo_rl/models/generation/openai_server_utils.py
+++ b/nemo_rl/models/generation/openai_server_utils.py
@@ -38,7 +38,15 @@ class CompleteTokenInjectionError(ValueError):
 def find_latest_tokenized_assistant(
     messages: list[Any],
 ) -> tuple[int, Mapping[str, Any]] | None:
-    """Return the latest fully tokenized assistant and its assistant ordinal."""
+    """Return the ordinal and message for the latest tokenized assistant.
+
+    Args:
+        messages: Validated chat messages in conversation order.
+
+    Returns:
+        The assistant ordinal and message when an assistant contains both prompt
+        and generation token IDs, or ``None`` when no complete metadata exists.
+    """
     assistant_ordinal = -1
     latest_tokenized_assistant = None
     for message in messages:
@@ -98,6 +106,28 @@ def build_complete_prompt_token_ids(
     assistant while making its assistant-close sequence the exact splice
     boundary. The close sequence can differ from the tokenizer EOS token, as it
     does for Gemma chat templates.
+
+    Args:
+        tokenizer: Tokenizer used by the serving renderer.
+        conversation: Parsed text-only chat messages.
+        assistant_ordinal: Ordinal of the assistant covered by the model prefix.
+        model_prefix_token_ids: Non-empty
+            ``prompt_token_ids + generation_token_ids`` from that assistant.
+        render_prompt_text: Callback that renders the complete marked
+            conversation as text.
+        render_assistant_close_text: Optional callback that renders the marked
+            conversation through the selected assistant. It must expose an
+            unconditional assistant-close sequence after the marker. Templates
+            that gate the close on ``add_generation_prompt`` fall back to native
+            preprocessing.
+
+    Returns:
+        Exact model-prefix tokens followed by the tokenized contextual suffix.
+
+    Raises:
+        CompleteTokenInjectionError: The splice contract could not be verified.
+            Callers must use native preprocessing instead of rejecting the
+            request.
     """
     try:
         marked_conversation = deepcopy(conversation)
@@ -139,12 +169,17 @@ def build_complete_prompt_token_ids(
     if not isinstance(marked_text, str):
         raise CompleteTokenInjectionError("The marked prompt must render as text.")
 
-    marker_pos = marked_text.find(_COMPLETE_TOKEN_BOUNDARY_MARKER)
-    if marker_pos < 0:
+    marker_count = marked_text.count(_COMPLETE_TOKEN_BOUNDARY_MARKER)
+    if marker_count == 0:
         raise CompleteTokenInjectionError(
             "The chat template did not preserve the complete-token boundary marker."
         )
+    if marker_count > 1:
+        raise CompleteTokenInjectionError(
+            "The complete-token boundary marker collided with rendered request data."
+        )
 
+    marker_pos = marked_text.find(_COMPLETE_TOKEN_BOUNDARY_MARKER)
     marker_end = marker_pos + len(_COMPLETE_TOKEN_BOUNDARY_MARKER)
 
     if render_assistant_close_text is None:
@@ -187,6 +222,9 @@ def build_complete_prompt_token_ids(
             )
         close_marker_end = close_marker_pos + len(_COMPLETE_TOKEN_BOUNDARY_MARKER)
         raw_assistant_close_text = closed_assistant_text[close_marker_end:]
+        # Drop only leading whitespace before the close sequence. The guard below
+        # uses the raw text so the slice removes exactly that same whitespace;
+        # trailing whitespace remains part of the verified close sequence.
         assistant_close_text = raw_assistant_close_text.lstrip()
         if not assistant_close_text:
             raise CompleteTokenInjectionError(

--- a/nemo_rl/models/generation/openai_server_utils.py
+++ b/nemo_rl/models/generation/openai_server_utils.py
@@ -85,6 +85,7 @@ def build_complete_prompt_token_ids(
     assistant_ordinal: int,
     model_prefix_token_ids: list[int],
     render_prompt_text: Callable[[list[Any]], str],
+    render_assistant_close_text: Callable[[list[Any]], str] | None = None,
 ) -> list[int]:
     """Join exact model-prefix tokens with a verified contextual suffix.
 
@@ -94,7 +95,9 @@ def build_complete_prompt_token_ids(
 
     The complete conversation is rendered with the tokenized assistant replaced
     by a marker. This preserves context-sensitive template behavior after that
-    assistant while making its closing EOS the exact splice boundary.
+    assistant while making its assistant-close sequence the exact splice
+    boundary. The close sequence can differ from the tokenizer EOS token, as it
+    does for Gemma chat templates.
     """
     try:
         marked_conversation = deepcopy(conversation)
@@ -142,32 +145,69 @@ def build_complete_prompt_token_ids(
             "The chat template did not preserve the complete-token boundary marker."
         )
 
-    eos_token = getattr(tokenizer, "eos_token", None)
-    eos_token_id = getattr(tokenizer, "eos_token_id", None)
-    if not isinstance(eos_token, str) or eos_token_id is None:
-        raise CompleteTokenInjectionError(
-            "Complete-token injection requires tokenizer EOS text and ID."
-        )
-
-    suffix_pos = marked_text.find(
-        eos_token, marker_pos + len(_COMPLETE_TOKEN_BOUNDARY_MARKER)
-    )
-    if suffix_pos < 0:
-        raise CompleteTokenInjectionError(
-            "The chat template did not close the tokenized assistant with EOS."
-        )
     marker_end = marker_pos + len(_COMPLETE_TOKEN_BOUNDARY_MARKER)
-    # The legacy prefix replacement also cuts at EOS, so dropping whitespace
-    # between the marker and EOS keeps both paths token-identical.
-    if marked_text[marker_end:suffix_pos].strip():
-        raise CompleteTokenInjectionError(
-            "The chat template did not close the tokenized assistant immediately; "
-            "the EOS boundary would skip intervening messages."
-        )
+
+    if render_assistant_close_text is None:
+        eos_token = getattr(tokenizer, "eos_token", None)
+        if not isinstance(eos_token, str):
+            raise CompleteTokenInjectionError(
+                "Complete-token injection requires tokenizer EOS text."
+            )
+        suffix_pos = marked_text.find(eos_token, marker_end)
+        if suffix_pos < 0:
+            raise CompleteTokenInjectionError(
+                "The chat template did not close the tokenized assistant with EOS."
+            )
+        if marked_text[marker_end:suffix_pos].strip():
+            raise CompleteTokenInjectionError(
+                "The chat template did not close the tokenized assistant immediately; "
+                "the EOS boundary would skip intervening messages."
+            )
+        assistant_close_text = eos_token
+        contextual_suffix_text = marked_text[suffix_pos:]
+    else:
+        try:
+            closed_assistant_text = render_assistant_close_text(
+                marked_conversation[: assistant_index + 1]
+            )
+        except CompleteTokenInjectionError:
+            raise
+        except Exception as e:
+            raise CompleteTokenInjectionError(
+                "The assistant-close probe could not be rendered."
+            ) from e
+        if not isinstance(closed_assistant_text, str):
+            raise CompleteTokenInjectionError(
+                "The assistant-close probe must render as text."
+            )
+        close_marker_pos = closed_assistant_text.find(_COMPLETE_TOKEN_BOUNDARY_MARKER)
+        if close_marker_pos < 0:
+            raise CompleteTokenInjectionError(
+                "The assistant-close probe did not preserve the boundary marker."
+            )
+        close_marker_end = close_marker_pos + len(_COMPLETE_TOKEN_BOUNDARY_MARKER)
+        raw_assistant_close_text = closed_assistant_text[close_marker_end:]
+        assistant_close_text = raw_assistant_close_text.lstrip()
+        if not assistant_close_text:
+            raise CompleteTokenInjectionError(
+                "The chat template did not emit an assistant-close sequence."
+            )
+        contextual_suffix_text = marked_text[marker_end:]
+        if not contextual_suffix_text.startswith(raw_assistant_close_text):
+            raise CompleteTokenInjectionError(
+                "The assistant-close sequence changed in the complete conversation."
+            )
+        contextual_suffix_text = contextual_suffix_text[
+            len(raw_assistant_close_text) - len(assistant_close_text) :
+        ]
 
     try:
+        assistant_close_token_ids = _coerce_token_id_list(
+            tokenizer.encode(assistant_close_text, add_special_tokens=False),
+            "Assistant-close token IDs",
+        )
         suffix_token_ids = _coerce_token_id_list(
-            tokenizer.encode(marked_text[suffix_pos:], add_special_tokens=False),
+            tokenizer.encode(contextual_suffix_text, add_special_tokens=False),
             "Contextual suffix token IDs",
         )
     except CompleteTokenInjectionError:
@@ -177,16 +217,30 @@ def build_complete_prompt_token_ids(
             "The contextual suffix could not be tokenized."
         ) from e
 
-    if not suffix_token_ids or suffix_token_ids[0] != eos_token_id:
+    if (
+        not assistant_close_token_ids
+        or suffix_token_ids[: len(assistant_close_token_ids)]
+        != assistant_close_token_ids
+    ):
         raise CompleteTokenInjectionError(
-            "The contextual suffix did not begin with EOS."
+            "The contextual suffix did not begin with the assistant-close sequence."
         )
+    model_prefix_token_ids = _coerce_token_id_list(
+        model_prefix_token_ids, "Model prefix token IDs"
+    )
     if not model_prefix_token_ids:
         raise CompleteTokenInjectionError("The model prefix token IDs were empty.")
-    model_cut_end = len(model_prefix_token_ids)
-    if model_prefix_token_ids[-1] == eos_token_id:
-        model_cut_end -= 1
-    return model_prefix_token_ids[:model_cut_end] + suffix_token_ids
+
+    max_overlap = min(len(model_prefix_token_ids), len(assistant_close_token_ids))
+    overlap = next(
+        (
+            overlap
+            for overlap in range(max_overlap, 0, -1)
+            if model_prefix_token_ids[-overlap:] == suffix_token_ids[:overlap]
+        ),
+        0,
+    )
+    return model_prefix_token_ids + suffix_token_ids[overlap:]
 
 
 def replace_prefix_tokens(

--- a/nemo_rl/models/generation/openai_server_utils.py
+++ b/nemo_rl/models/generation/openai_server_utils.py
@@ -24,6 +24,7 @@ retokenization drift to correct.
 """
 
 from collections.abc import Callable, Mapping
+from copy import Error as CopyError
 from copy import deepcopy
 from typing import Any
 
@@ -70,12 +71,11 @@ def _assistant_index_from_ordinal(
 def _coerce_token_id_list(value: Any, field_name: str) -> list[int]:
     if not isinstance(value, list):
         raise CompleteTokenInjectionError(f"{field_name} must be a list.")
-    try:
-        return [int(token_id) for token_id in value]
-    except (TypeError, ValueError) as e:
+    if any(type(token_id) is not int for token_id in value):
         raise CompleteTokenInjectionError(
             f"{field_name} must contain only integer token IDs."
-        ) from e
+        )
+    return list(value)
 
 
 def build_complete_prompt_token_ids(
@@ -96,7 +96,12 @@ def build_complete_prompt_token_ids(
     by a marker. This preserves context-sensitive template behavior after that
     assistant while making its closing EOS the exact splice boundary.
     """
-    marked_conversation = deepcopy(conversation)
+    try:
+        marked_conversation = deepcopy(conversation)
+    except (CopyError, TypeError) as e:
+        raise CompleteTokenInjectionError(
+            "The conversation could not be copied for complete-token injection."
+        ) from e
     if any(
         _COMPLETE_TOKEN_BOUNDARY_MARKER in str(message)
         for message in marked_conversation
@@ -152,6 +157,8 @@ def build_complete_prompt_token_ids(
             "The chat template did not close the tokenized assistant with EOS."
         )
     marker_end = marker_pos + len(_COMPLETE_TOKEN_BOUNDARY_MARKER)
+    # The legacy prefix replacement also cuts at EOS, so dropping whitespace
+    # between the marker and EOS keeps both paths token-identical.
     if marked_text[marker_end:suffix_pos].strip():
         raise CompleteTokenInjectionError(
             "The chat template did not close the tokenized assistant immediately; "
@@ -174,8 +181,10 @@ def build_complete_prompt_token_ids(
         raise CompleteTokenInjectionError(
             "The contextual suffix did not begin with EOS."
         )
+    if not model_prefix_token_ids:
+        raise CompleteTokenInjectionError("The model prefix token IDs were empty.")
     model_cut_end = len(model_prefix_token_ids)
-    if model_prefix_token_ids and model_prefix_token_ids[-1] == eos_token_id:
+    if model_prefix_token_ids[-1] == eos_token_id:
         model_cut_end -= 1
     return model_prefix_token_ids[:model_cut_end] + suffix_token_ids
 

--- a/nemo_rl/models/generation/openai_server_utils.py
+++ b/nemo_rl/models/generation/openai_server_utils.py
@@ -13,32 +13,33 @@
 # limitations under the License.
 """Shared helpers for the OpenAI-compatible HTTP generation servers.
 
-These utilities are backend-agnostic: they operate on token-ID lists plus a
-tokenizer, with no engine calls. They are shared by the vLLM async worker
-(``vllm_worker_async.py``) and the TRT-LLM HTTP server (``trtllm_http_server.py``),
-which both put a message-based ``/v1/chat/completions`` layer in front of a token
-engine for the agentic NeMo-Gym path. SGLang does not use these — it is driven
-token-in/token-out via ``generate(input_ids)`` and never re-templates messages,
-so it has no retokenization drift to correct.
+These backend-agnostic utilities operate on token-ID lists, parsed chat messages,
+and caller-supplied tokenizers or render functions. They make no engine calls.
+They are shared by the vLLM async worker (``vllm_worker_async.py``) and the
+TRT-LLM HTTP server (``trtllm_http_server.py``), which both put a message-based
+``/v1/chat/completions`` layer in front of a token engine for the agentic
+NeMo-Gym path. SGLang does not use these — it is driven token-in/token-out via
+``generate(input_ids)`` and never re-templates messages, so it has no
+retokenization drift to correct.
 """
 
-import json
 from collections.abc import Callable, Mapping
 from copy import deepcopy
 from typing import Any
-
 
 _COMPLETE_TOKEN_BOUNDARY_MARKER = "NEMO_RL_PREFIX_BOUNDARY_7F3A9C1E"
 
 
 class CompleteTokenInjectionError(ValueError):
-    """Raised when complete prompt tokens cannot be derived safely."""
+    """Signal that complete-token injection must use native preprocessing."""
 
 
-def find_latest_tokenized_assistant_ordinal(messages: list[Any]) -> int | None:
-    """Return the assistant ordinal carrying the latest Gym token metadata."""
+def find_latest_tokenized_assistant(
+    messages: list[Any],
+) -> tuple[int, Mapping[str, Any]] | None:
+    """Return the latest fully tokenized assistant and its assistant ordinal."""
     assistant_ordinal = -1
-    latest_tokenized_ordinal = None
+    latest_tokenized_assistant = None
     for message in messages:
         if not isinstance(message, Mapping) or message.get("role") != "assistant":
             continue
@@ -47,8 +48,8 @@ def find_latest_tokenized_assistant_ordinal(messages: list[Any]) -> int | None:
             message.get("prompt_token_ids") is not None
             and message.get("generation_token_ids") is not None
         ):
-            latest_tokenized_ordinal = assistant_ordinal
-    return latest_tokenized_ordinal
+            latest_tokenized_assistant = (assistant_ordinal, message)
+    return latest_tokenized_assistant
 
 
 def _assistant_index_from_ordinal(
@@ -64,33 +65,6 @@ def _assistant_index_from_ordinal(
     raise CompleteTokenInjectionError(
         "The tokenized assistant message was not present after chat parsing."
     )
-
-
-def _normalize_tool_arguments_for_template(
-    messages: list[Any], *, before_index: int
-) -> None:
-    for message in messages[:before_index]:
-        if not isinstance(message, dict) or message.get("role") != "assistant":
-            continue
-        tool_calls = message.get("tool_calls")
-        if not isinstance(tool_calls, list):
-            continue
-        for tool_call in tool_calls:
-            if not isinstance(tool_call, dict):
-                continue
-            function = tool_call.get("function", tool_call)
-            if not isinstance(function, dict):
-                continue
-            arguments = function.get("arguments")
-            if not isinstance(arguments, str):
-                continue
-            try:
-                parsed_arguments = json.loads(arguments)
-            except json.JSONDecodeError:
-                parsed_arguments = {}
-            function["arguments"] = (
-                parsed_arguments if isinstance(parsed_arguments, dict) else {}
-            )
 
 
 def _coerce_token_id_list(value: Any, field_name: str) -> list[int]:
@@ -114,6 +88,10 @@ def build_complete_prompt_token_ids(
 ) -> list[int]:
     """Join exact model-prefix tokens with a verified contextual suffix.
 
+    ``assistant_ordinal`` must identify the assistant turn covered by
+    ``model_prefix_token_ids``. A mismatch can produce a valid but incorrect
+    prompt, so callers must derive both values from the same message.
+
     The complete conversation is rendered with the tokenized assistant replaced
     by a marker. This preserves context-sensitive template behavior after that
     assistant while making its closing EOS the exact splice boundary.
@@ -129,9 +107,6 @@ def build_complete_prompt_token_ids(
 
     assistant_index = _assistant_index_from_ordinal(
         marked_conversation, assistant_ordinal
-    )
-    _normalize_tool_arguments_for_template(
-        marked_conversation, before_index=assistant_index
     )
 
     marked_assistant = marked_conversation[assistant_index]
@@ -175,6 +150,12 @@ def build_complete_prompt_token_ids(
     if suffix_pos < 0:
         raise CompleteTokenInjectionError(
             "The chat template did not close the tokenized assistant with EOS."
+        )
+    marker_end = marker_pos + len(_COMPLETE_TOKEN_BOUNDARY_MARKER)
+    if marked_text[marker_end:suffix_pos].strip():
+        raise CompleteTokenInjectionError(
+            "The chat template did not close the tokenized assistant immediately; "
+            "the EOS boundary would skip intervening messages."
         )
 
     try:

--- a/nemo_rl/models/generation/openai_server_utils.py
+++ b/nemo_rl/models/generation/openai_server_utils.py
@@ -22,7 +22,181 @@ token-in/token-out via ``generate(input_ids)`` and never re-templates messages,
 so it has no retokenization drift to correct.
 """
 
+import json
+from collections.abc import Callable, Mapping
+from copy import deepcopy
 from typing import Any
+
+
+_COMPLETE_TOKEN_BOUNDARY_MARKER = "NEMO_RL_PREFIX_BOUNDARY_7F3A9C1E"
+
+
+class CompleteTokenInjectionError(ValueError):
+    """Raised when complete prompt tokens cannot be derived safely."""
+
+
+def find_latest_tokenized_assistant_ordinal(messages: list[Any]) -> int | None:
+    """Return the assistant ordinal carrying the latest Gym token metadata."""
+    assistant_ordinal = -1
+    latest_tokenized_ordinal = None
+    for message in messages:
+        if not isinstance(message, Mapping) or message.get("role") != "assistant":
+            continue
+        assistant_ordinal += 1
+        if (
+            message.get("prompt_token_ids") is not None
+            and message.get("generation_token_ids") is not None
+        ):
+            latest_tokenized_ordinal = assistant_ordinal
+    return latest_tokenized_ordinal
+
+
+def _assistant_index_from_ordinal(
+    conversation: list[Any], assistant_ordinal: int
+) -> int:
+    current_ordinal = -1
+    for index, message in enumerate(conversation):
+        if not isinstance(message, Mapping) or message.get("role") != "assistant":
+            continue
+        current_ordinal += 1
+        if current_ordinal == assistant_ordinal:
+            return index
+    raise CompleteTokenInjectionError(
+        "The tokenized assistant message was not present after chat parsing."
+    )
+
+
+def _normalize_tool_arguments_for_template(
+    messages: list[Any], *, before_index: int
+) -> None:
+    for message in messages[:before_index]:
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        tool_calls = message.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, dict):
+                continue
+            function = tool_call.get("function", tool_call)
+            if not isinstance(function, dict):
+                continue
+            arguments = function.get("arguments")
+            if not isinstance(arguments, str):
+                continue
+            try:
+                parsed_arguments = json.loads(arguments)
+            except json.JSONDecodeError:
+                parsed_arguments = {}
+            function["arguments"] = (
+                parsed_arguments if isinstance(parsed_arguments, dict) else {}
+            )
+
+
+def _coerce_token_id_list(value: Any, field_name: str) -> list[int]:
+    if not isinstance(value, list):
+        raise CompleteTokenInjectionError(f"{field_name} must be a list.")
+    try:
+        return [int(token_id) for token_id in value]
+    except (TypeError, ValueError) as e:
+        raise CompleteTokenInjectionError(
+            f"{field_name} must contain only integer token IDs."
+        ) from e
+
+
+def build_complete_prompt_token_ids(
+    *,
+    tokenizer: Any,
+    conversation: list[Any],
+    assistant_ordinal: int,
+    model_prefix_token_ids: list[int],
+    render_prompt_text: Callable[[list[Any]], str],
+) -> list[int]:
+    """Join exact model-prefix tokens with a verified contextual suffix.
+
+    The complete conversation is rendered with the tokenized assistant replaced
+    by a marker. This preserves context-sensitive template behavior after that
+    assistant while making its closing EOS the exact splice boundary.
+    """
+    marked_conversation = deepcopy(conversation)
+    if any(
+        _COMPLETE_TOKEN_BOUNDARY_MARKER in str(message)
+        for message in marked_conversation
+    ):
+        raise CompleteTokenInjectionError(
+            "The complete-token boundary marker collided with request data."
+        )
+
+    assistant_index = _assistant_index_from_ordinal(
+        marked_conversation, assistant_ordinal
+    )
+    _normalize_tool_arguments_for_template(
+        marked_conversation, before_index=assistant_index
+    )
+
+    marked_assistant = marked_conversation[assistant_index]
+    if not isinstance(marked_assistant, dict):
+        raise CompleteTokenInjectionError(
+            "The tokenized assistant message was not a message object."
+        )
+    marked_assistant["content"] = _COMPLETE_TOKEN_BOUNDARY_MARKER
+    marked_assistant.pop("reasoning_content", None)
+    marked_assistant.pop("reasoning", None)
+    marked_assistant.pop("tool_calls", None)
+
+    try:
+        marked_text = render_prompt_text(marked_conversation)
+    except CompleteTokenInjectionError:
+        raise
+    except Exception as e:
+        raise CompleteTokenInjectionError(
+            "The marked chat template could not be rendered."
+        ) from e
+
+    if not isinstance(marked_text, str):
+        raise CompleteTokenInjectionError("The marked prompt must render as text.")
+
+    marker_pos = marked_text.find(_COMPLETE_TOKEN_BOUNDARY_MARKER)
+    if marker_pos < 0:
+        raise CompleteTokenInjectionError(
+            "The chat template did not preserve the complete-token boundary marker."
+        )
+
+    eos_token = getattr(tokenizer, "eos_token", None)
+    eos_token_id = getattr(tokenizer, "eos_token_id", None)
+    if not isinstance(eos_token, str) or eos_token_id is None:
+        raise CompleteTokenInjectionError(
+            "Complete-token injection requires tokenizer EOS text and ID."
+        )
+
+    suffix_pos = marked_text.find(
+        eos_token, marker_pos + len(_COMPLETE_TOKEN_BOUNDARY_MARKER)
+    )
+    if suffix_pos < 0:
+        raise CompleteTokenInjectionError(
+            "The chat template did not close the tokenized assistant with EOS."
+        )
+
+    try:
+        suffix_token_ids = _coerce_token_id_list(
+            tokenizer.encode(marked_text[suffix_pos:], add_special_tokens=False),
+            "Contextual suffix token IDs",
+        )
+    except CompleteTokenInjectionError:
+        raise
+    except Exception as e:
+        raise CompleteTokenInjectionError(
+            "The contextual suffix could not be tokenized."
+        ) from e
+
+    if not suffix_token_ids or suffix_token_ids[0] != eos_token_id:
+        raise CompleteTokenInjectionError(
+            "The contextual suffix did not begin with EOS."
+        )
+    model_cut_end = len(model_prefix_token_ids)
+    if model_prefix_token_ids and model_prefix_token_ids[-1] == eos_token_id:
+        model_cut_end -= 1
+    return model_prefix_token_ids[:model_cut_end] + suffix_token_ids
 
 
 def replace_prefix_tokens(

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -61,6 +61,7 @@ from nemo_rl.models.generation.vllm.utils import (
 from nemo_rl.models.generation.vllm.vllm_worker import BaseVllmGenerationWorker
 
 LOGGER = logging.getLogger(__name__)
+COMPLETE_TOKEN_INJECTION_VLLM_VERSION = "0.25.1"
 
 
 def _prefix_matches_tokenized_assistant(
@@ -101,7 +102,7 @@ def _complete_token_injection_eligibility(
     has_multimodal_config: bool,
     prompt_embeds_enabled: bool,
     renderer_supported: bool,
-    vllm_version_supported: bool = True,
+    vllm_version_supported: bool,
 ) -> tuple[int | None, str | None]:
     """Return an assistant ordinal or a reason to use native preprocessing."""
     if request.stream:
@@ -450,7 +451,7 @@ class VllmAsyncGenerationWorkerImpl(
         from copy import deepcopy
         from logging import Filter as LoggingFilter
         from logging import LogRecord
-        from typing import List, Optional, Union
+        from typing import Any, List, Optional, Union
 
         from fastapi import Request
         from fastapi.responses import JSONResponse, StreamingResponse
@@ -581,14 +582,21 @@ class VllmAsyncGenerationWorkerImpl(
                         value=error.value,
                     ) from error
 
-            def _record_complete_token_injection_fallback(self, reason: str) -> None:
+            def _record_complete_token_injection_fallback(
+                self, reason: str, detail: str | None = None
+            ) -> None:
                 self._complete_token_injection_fallbacks[reason] += 1
                 if reason in self._logged_complete_token_injection_fallbacks:
                     return
                 self._logged_complete_token_injection_fallbacks.add(reason)
+                rendered_reason = reason if detail is None else f"{reason} ({detail})"
                 LOGGER.warning(
-                    "Complete-token injection fell back to native preprocessing: %s",
-                    reason,
+                    "Complete-token injection fell back to native preprocessing: "
+                    "%s; statistics: %s",
+                    rendered_reason,
+                    json.dumps(
+                        self._get_complete_token_injection_stats(), sort_keys=True
+                    ),
                 )
 
             def _get_complete_token_injection_stats(self) -> dict[str, Any]:
@@ -793,6 +801,9 @@ class VllmAsyncGenerationWorkerImpl(
                     and request.required_prefix_token_ids is not None
                 ):
                     self._complete_token_injection_attempts += 1
+                    vllm_version_supported = (
+                        vllm.__version__ == COMPLETE_TOKEN_INJECTION_VLLM_VERSION
+                    )
                     assistant_ordinal, fallback_reason = (
                         _complete_token_injection_eligibility(
                             request,
@@ -802,11 +813,19 @@ class VllmAsyncGenerationWorkerImpl(
                             ),
                             prompt_embeds_enabled=self.model_config.enable_prompt_embeds,
                             renderer_supported=isinstance(self.renderer, HfRenderer),
-                            vllm_version_supported=(vllm.__version__ == "0.25.1"),
+                            vllm_version_supported=vllm_version_supported,
                         )
                     )
                     if fallback_reason is not None:
-                        self._record_complete_token_injection_fallback(fallback_reason)
+                        fallback_detail = None
+                        if fallback_reason == "unsupported vLLM version":
+                            fallback_detail = (
+                                f"detected {vllm.__version__!r}, expected "
+                                f"{COMPLETE_TOKEN_INJECTION_VLLM_VERSION!r}"
+                            )
+                        self._record_complete_token_injection_fallback(
+                            fallback_reason, fallback_detail
+                        )
                         self._maybe_log_complete_token_injection_stats()
                     else:
                         assert assistant_ordinal is not None

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -40,6 +40,12 @@ from nemo_rl.models.generation.interfaces import (
     GenerationOutputSpec,
     verify_right_padding,
 )
+from nemo_rl.models.generation.openai_server_utils import (
+    CompleteTokenInjectionError,
+    build_complete_prompt_token_ids,
+    find_latest_tokenized_assistant_ordinal,
+    replace_prefix_tokens,
+)
 from nemo_rl.models.generation.vllm.checkpoint_engine import (
     VllmAsyncCheckpointEngineRpcMixin,
 )
@@ -51,9 +57,6 @@ from nemo_rl.models.generation.vllm.utils import (
     pad_and_align_routed_expert_indices,
 )
 from nemo_rl.models.generation.vllm.vllm_worker import BaseVllmGenerationWorker
-from nemo_rl.models.generation.openai_server_utils import (
-    replace_prefix_tokens,
-)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -365,6 +368,7 @@ class VllmAsyncGenerationWorkerImpl(
         from vllm.entrypoints.openai.engine.protocol import ErrorResponse
         from vllm.entrypoints.openai.models.protocol import BaseModelPath
         from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+        from vllm.entrypoints.chat_utils import parse_chat_messages_async
         from vllm.entrypoints.serve.tokenize.protocol import (
             TokenizeChatRequest,
             TokenizeCompletionRequest,
@@ -373,10 +377,17 @@ class VllmAsyncGenerationWorkerImpl(
         from vllm.entrypoints.serve.tokenize.serving import (
             ServingTokenization,
         )
+        from vllm.renderers import merge_kwargs
+        from vllm.renderers.hf import (
+            HfRenderer,
+            resolve_chat_template_content_format,
+            safe_apply_chat_template,
+        )
         from vllm.renderers.online_renderer import OnlineRenderer
         from vllm.exceptions import VLLMValidationError
         from vllm.reasoning.abs_reasoning_parsers import ReasoningParserManager
         from vllm.tool_parsers.abstract_tool_parser import ToolParserManager
+        from vllm.utils.mistral import is_mistral_tokenizer, is_mistral_tool_parser
         from vllm.v1.engine.async_llm import logger as vllm_async_llm_logger
 
         maybe_tool_parser_plugin = self.cfg["vllm_cfg"].get("tool_parser_plugin")
@@ -448,6 +459,167 @@ class VllmAsyncGenerationWorkerImpl(
                 max_tokens = min(request_max_tokens, remaining)
                 self._set_max_tokens(request, max_tokens)
 
+            def _complete_token_injection_assistant_ordinal(
+                self, request, messages
+            ) -> Optional[int]:
+                """Return the assistant ordinal when the guarded path is supported."""
+                if not isinstance(request, NeMoRLChatCompletionRequest):
+                    return None
+                if request.required_prefix_token_ids is None:
+                    return None
+                if getattr(request, "stream", False):
+                    return None
+                if getattr(request, "n", 1) not in (None, 1):
+                    return None
+                if getattr(request, "continue_final_message", False):
+                    return None
+                if getattr(request, "echo", False):
+                    return None
+                if getattr(request, "return_assistant_tokens_mask", False):
+                    return None
+                if self.model_config.multimodal_config is not None:
+                    return None
+                if self.model_config.enable_prompt_embeds:
+                    return None
+                if not isinstance(self.renderer, HfRenderer):
+                    return None
+                for message in messages:
+                    if not isinstance(message, dict):
+                        return None
+                    if message.get("role") not in {
+                        "system",
+                        "user",
+                        "assistant",
+                        "tool",
+                    }:
+                        return None
+                    content = message.get("content")
+                    if content is not None and not isinstance(content, str):
+                        return None
+                return find_latest_tokenized_assistant_ordinal(request.messages)
+
+            async def _preprocess_chat_with_complete_token_ids(
+                self,
+                request,
+                messages,
+                default_template,
+                default_template_content_format,
+                default_template_kwargs,
+                tool_dicts,
+                parser,
+                assistant_ordinal: int,
+                *,
+                skip_mm_cache: bool,
+            ):
+                """Preserve vLLM preprocessing while skipping prompt re-encoding."""
+                renderer = self.renderer
+                arrival_time = time.time()
+                default_template_kwargs = merge_kwargs(
+                    default_template_kwargs,
+                    dict(tools=tool_dicts, tokenize=False),
+                )
+                tok_params = request.build_tok_params(self.model_config)
+                chat_params = request.build_chat_params(
+                    default_template, default_template_content_format
+                ).with_defaults(
+                    default_template_kwargs,
+                    default_media_io_kwargs=None,
+                    default_mm_processor_kwargs=getattr(
+                        request, "mm_processor_kwargs", None
+                    ),
+                )
+                if chat_params.return_assistant_tokens_mask:
+                    raise CompleteTokenInjectionError(
+                        "Assistant token masks require native preprocessing."
+                    )
+
+                tokenizer = renderer.get_tokenizer()
+                conversation, mm_data, mm_uuids = await parse_chat_messages_async(
+                    messages,
+                    self.model_config,
+                    content_format=resolve_chat_template_content_format(
+                        chat_template=chat_params.chat_template,
+                        tools=chat_params.chat_template_kwargs.get("tools"),
+                        given_format=chat_params.chat_template_content_format,
+                        tokenizer=tokenizer,
+                        model_config=self.model_config,
+                    ),
+                    media_io_kwargs=chat_params.media_io_kwargs,
+                    mm_processor_kwargs=chat_params.mm_processor_kwargs,
+                )
+                if mm_data is not None or mm_uuids is not None:
+                    raise CompleteTokenInjectionError(
+                        "Multimodal chat data requires native preprocessing."
+                    )
+                apply_chat_template_kwargs = dict(
+                    chat_params.get_apply_chat_template_kwargs()
+                )
+                apply_chat_template_kwargs.pop("tokenize", None)
+
+                def render_prompt_text(marked_conversation):
+                    rendered = safe_apply_chat_template(
+                        self.model_config,
+                        tokenizer,
+                        marked_conversation,
+                        tokenize=False,
+                        **apply_chat_template_kwargs,
+                    )
+                    if not isinstance(rendered, str):
+                        raise CompleteTokenInjectionError(
+                            "The marked prompt did not render as text."
+                        )
+                    return rendered
+
+                prompt_token_ids = await asyncio.to_thread(
+                    build_complete_prompt_token_ids,
+                    tokenizer=tokenizer,
+                    conversation=conversation,
+                    assistant_ordinal=assistant_ordinal,
+                    model_prefix_token_ids=list(request.required_prefix_token_ids),
+                    render_prompt_text=render_prompt_text,
+                )
+                prompt = {"prompt_token_ids": prompt_token_ids}
+                tokenized_prompt = await renderer.tokenize_prompt_async(
+                    prompt, tok_params
+                )
+                renderer._apply_prompt_extras(
+                    [tokenized_prompt],
+                    {
+                        key: value
+                        for key in ("mm_processor_kwargs", "cache_salt")
+                        if (value := getattr(request, key, None)) is not None
+                    },
+                )
+                engine_prompt = await renderer.process_for_engine_async(
+                    tokenized_prompt,
+                    arrival_time,
+                    skip_mm_cache=skip_mm_cache,
+                )
+
+                if parser is not None:
+                    tool_parser = parser.tool_parser_cls
+                    tool_choice = getattr(request, "tool_choice", "none")
+                    is_mistral_grammar_eligible = (
+                        tool_parser is not None
+                        and is_mistral_tool_parser(tool_parser)
+                        and is_mistral_tokenizer(tokenizer)
+                        and tokenizer.supports_grammar
+                    )
+                    should_adjust_request = (
+                        parser.reasoning_parser_cls is not None
+                        or tool_choice != "none"
+                        or is_mistral_grammar_eligible
+                    )
+                    if should_adjust_request:
+                        request = parser(
+                            tokenizer,
+                            request.tools,
+                            model_config=self.model_config,
+                            chat_template_kwargs=chat_params.chat_template_kwargs,
+                        ).adjust_request(request=request)
+
+                return conversation, [engine_prompt]
+
             # vLLM 0.25 moved chat preprocessing to
             # OnlineRenderer.preprocess_chat (tool_parser/reasoning_parser were
             # folded into a single `parser`), so this override now applies via
@@ -483,6 +655,39 @@ class VllmAsyncGenerationWorkerImpl(
                     # So we don't need to set the request's max output tokens to 1 here.
                     if actual_request_max_tokens is not None:
                         self._set_max_tokens(request, 1)
+
+                assistant_ordinal = self._complete_token_injection_assistant_ordinal(
+                    request, messages
+                )
+                if assistant_ordinal is not None:
+                    try:
+                        res = await self._preprocess_chat_with_complete_token_ids(
+                            request=request,
+                            messages=messages,
+                            default_template=default_template,
+                            default_template_content_format=(
+                                default_template_content_format
+                            ),
+                            default_template_kwargs=default_template_kwargs,
+                            tool_dicts=tool_dicts,
+                            parser=parser,
+                            assistant_ordinal=assistant_ordinal,
+                            skip_mm_cache=skip_mm_cache,
+                        )
+                    except CompleteTokenInjectionError as e:
+                        LOGGER.warning(
+                            "Complete-token injection fell back to native "
+                            "preprocessing: %s",
+                            e,
+                        )
+                    else:
+                        if actual_request_max_tokens is not None:
+                            self._clamp_max_tokens(
+                                request,
+                                actual_request_max_tokens,
+                                res[1][0]["prompt_token_ids"],
+                            )
+                        return res
 
                 try:
                     res = await super().preprocess_chat(

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -99,7 +99,6 @@ def _complete_token_injection_eligibility(
     request: Any,
     messages: list[Any],
     *,
-    has_multimodal_config: bool,
     prompt_embeds_enabled: bool,
     renderer_supported: bool,
     vllm_version_supported: bool,
@@ -119,8 +118,6 @@ def _complete_token_injection_eligibility(
         return None, "add_special_tokens request"
     if request.return_prompt_text:
         return None, "return_prompt_text request"
-    if has_multimodal_config:
-        return None, "multimodal model"
     if prompt_embeds_enabled:
         return None, "prompt embeddings enabled"
     if not renderer_supported:
@@ -808,9 +805,6 @@ class VllmAsyncGenerationWorkerImpl(
                         _complete_token_injection_eligibility(
                             request,
                             messages,
-                            has_multimodal_config=(
-                                self.model_config.multimodal_config is not None
-                            ),
                             prompt_embeds_enabled=self.model_config.enable_prompt_embeds,
                             renderer_supported=isinstance(self.renderer, HfRenderer),
                             vllm_version_supported=vllm_version_supported,

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -20,6 +20,7 @@ import threading
 import time
 import uuid
 import warnings
+from collections import Counter
 from typing import Any, AsyncGenerator, Optional, cast
 
 import ray
@@ -43,7 +44,7 @@ from nemo_rl.models.generation.interfaces import (
 from nemo_rl.models.generation.openai_server_utils import (
     CompleteTokenInjectionError,
     build_complete_prompt_token_ids,
-    find_latest_tokenized_assistant_ordinal,
+    find_latest_tokenized_assistant,
     replace_prefix_tokens,
 )
 from nemo_rl.models.generation.vllm.checkpoint_engine import (
@@ -59,6 +60,51 @@ from nemo_rl.models.generation.vllm.utils import (
 from nemo_rl.models.generation.vllm.vllm_worker import BaseVllmGenerationWorker
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _complete_token_injection_eligibility(
+    request: Any,
+    messages: list[Any],
+    *,
+    has_multimodal_config: bool,
+    prompt_embeds_enabled: bool,
+    renderer_supported: bool,
+) -> tuple[int | None, str | None]:
+    """Return an assistant ordinal or a reason to use native preprocessing."""
+    if getattr(request, "stream", False):
+        return None, "streaming request"
+    if getattr(request, "n", 1) not in (None, 1):
+        return None, "multiple response choices"
+    if getattr(request, "continue_final_message", False):
+        return None, "continue_final_message request"
+    if getattr(request, "echo", False):
+        return None, "echo request"
+    if getattr(request, "return_assistant_tokens_mask", False):
+        return None, "assistant token mask request"
+    if getattr(request, "add_special_tokens", False):
+        return None, "add_special_tokens request"
+    if getattr(request, "return_prompt_text", False):
+        return None, "return_prompt_text request"
+    if has_multimodal_config:
+        return None, "multimodal model"
+    if prompt_embeds_enabled:
+        return None, "prompt embeddings enabled"
+    if not renderer_supported:
+        return None, "unsupported renderer"
+    for message in messages:
+        if not isinstance(message, dict):
+            return None, "non-object message"
+        if message.get("role") not in {"system", "user", "assistant", "tool"}:
+            return None, "unsupported message role"
+        content = message.get("content")
+        if content is not None and not isinstance(content, str):
+            return None, "non-text message content"
+
+    tokenized_assistant = find_latest_tokenized_assistant(messages)
+    if tokenized_assistant is None:
+        return None, "no fully tokenized assistant"
+    assistant_ordinal, _ = tokenized_assistant
+    return assistant_ordinal, None
 
 
 class VllmAsyncGenerationWorkerImpl(
@@ -422,13 +468,13 @@ class VllmAsyncGenerationWorkerImpl(
             def model_post_init(self, context):
                 # NeMo-Gym specific processing. This is just how NeMo-Gym returns the extra token information.
                 if self.required_prefix_token_ids is None:
-                    for message in reversed(self.messages):
-                        if "prompt_token_ids" in message:
-                            self.required_prefix_token_ids = (
-                                message["prompt_token_ids"]
-                                + message["generation_token_ids"]
-                            )
-                            break
+                    tokenized_assistant = find_latest_tokenized_assistant(self.messages)
+                    if tokenized_assistant is not None:
+                        _, message = tokenized_assistant
+                        self.required_prefix_token_ids = (
+                            message["prompt_token_ids"]
+                            + message["generation_token_ids"]
+                        )
 
                 return super().model_post_init(context)
 
@@ -459,44 +505,15 @@ class VllmAsyncGenerationWorkerImpl(
                 max_tokens = min(request_max_tokens, remaining)
                 self._set_max_tokens(request, max_tokens)
 
-            def _complete_token_injection_assistant_ordinal(
-                self, request, messages
-            ) -> Optional[int]:
-                """Return the assistant ordinal when the guarded path is supported."""
-                if not isinstance(request, NeMoRLChatCompletionRequest):
-                    return None
-                if request.required_prefix_token_ids is None:
-                    return None
-                if getattr(request, "stream", False):
-                    return None
-                if getattr(request, "n", 1) not in (None, 1):
-                    return None
-                if getattr(request, "continue_final_message", False):
-                    return None
-                if getattr(request, "echo", False):
-                    return None
-                if getattr(request, "return_assistant_tokens_mask", False):
-                    return None
-                if self.model_config.multimodal_config is not None:
-                    return None
-                if self.model_config.enable_prompt_embeds:
-                    return None
-                if not isinstance(self.renderer, HfRenderer):
-                    return None
-                for message in messages:
-                    if not isinstance(message, dict):
-                        return None
-                    if message.get("role") not in {
-                        "system",
-                        "user",
-                        "assistant",
-                        "tool",
-                    }:
-                        return None
-                    content = message.get("content")
-                    if content is not None and not isinstance(content, str):
-                        return None
-                return find_latest_tokenized_assistant_ordinal(request.messages)
+            def _record_complete_token_injection_fallback(self, reason: str) -> None:
+                self._complete_token_injection_fallbacks[reason] += 1
+                if reason in self._logged_complete_token_injection_fallbacks:
+                    return
+                self._logged_complete_token_injection_fallbacks.add(reason)
+                LOGGER.warning(
+                    "Complete-token injection fell back to native preprocessing: %s",
+                    reason,
+                )
 
             async def _preprocess_chat_with_complete_token_ids(
                 self,
@@ -640,8 +657,6 @@ class VllmAsyncGenerationWorkerImpl(
                     if message.get("tool_calls"):
                         message["tool_calls"] = list(message["tool_calls"])
 
-                messages_for_replace_prefix_tokens = deepcopy(messages)
-
                 # Temporarily set to 1 so vLLM's pre-tokenization length check passes;
                 # the actual value will be set through _clamp_max_tokens later.
                 actual_request_max_tokens = None
@@ -656,38 +671,53 @@ class VllmAsyncGenerationWorkerImpl(
                     if actual_request_max_tokens is not None:
                         self._set_max_tokens(request, 1)
 
-                assistant_ordinal = self._complete_token_injection_assistant_ordinal(
-                    request, messages
-                )
-                if assistant_ordinal is not None:
-                    try:
-                        res = await self._preprocess_chat_with_complete_token_ids(
-                            request=request,
-                            messages=messages,
-                            default_template=default_template,
-                            default_template_content_format=(
-                                default_template_content_format
+                if (
+                    isinstance(request, NeMoRLChatCompletionRequest)
+                    and request.required_prefix_token_ids is not None
+                ):
+                    self._complete_token_injection_attempts += 1
+                    assistant_ordinal, fallback_reason = (
+                        _complete_token_injection_eligibility(
+                            request,
+                            messages,
+                            has_multimodal_config=(
+                                self.model_config.multimodal_config is not None
                             ),
-                            default_template_kwargs=default_template_kwargs,
-                            tool_dicts=tool_dicts,
-                            parser=parser,
-                            assistant_ordinal=assistant_ordinal,
-                            skip_mm_cache=skip_mm_cache,
+                            prompt_embeds_enabled=self.model_config.enable_prompt_embeds,
+                            renderer_supported=isinstance(self.renderer, HfRenderer),
                         )
-                    except CompleteTokenInjectionError as e:
-                        LOGGER.warning(
-                            "Complete-token injection fell back to native "
-                            "preprocessing: %s",
-                            e,
-                        )
+                    )
+                    if fallback_reason is not None:
+                        self._record_complete_token_injection_fallback(fallback_reason)
                     else:
-                        if actual_request_max_tokens is not None:
-                            self._clamp_max_tokens(
-                                request,
-                                actual_request_max_tokens,
-                                res[1][0]["prompt_token_ids"],
+                        assert assistant_ordinal is not None
+                        try:
+                            res = await self._preprocess_chat_with_complete_token_ids(
+                                request=request,
+                                messages=messages,
+                                default_template=default_template,
+                                default_template_content_format=(
+                                    default_template_content_format
+                                ),
+                                default_template_kwargs=default_template_kwargs,
+                                tool_dicts=tool_dicts,
+                                parser=parser,
+                                assistant_ordinal=assistant_ordinal,
+                                skip_mm_cache=skip_mm_cache,
                             )
-                        return res
+                        except CompleteTokenInjectionError as e:
+                            self._record_complete_token_injection_fallback(str(e))
+                        else:
+                            self._complete_token_injection_successes += 1
+                            if actual_request_max_tokens is not None:
+                                self._clamp_max_tokens(
+                                    request,
+                                    actual_request_max_tokens,
+                                    res[1][0]["prompt_token_ids"],
+                                )
+                            return res
+
+                messages_for_replace_prefix_tokens = deepcopy(messages)
 
                 try:
                     res = await super().preprocess_chat(
@@ -858,7 +888,12 @@ class VllmAsyncGenerationWorkerImpl(
             pass
 
         class NeMoRLOnlineRenderer(NeMoRLOpenAIServingMixin, OnlineRenderer):
-            pass
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self._complete_token_injection_attempts = 0
+                self._complete_token_injection_successes = 0
+                self._complete_token_injection_fallbacks: Counter[str] = Counter()
+                self._logged_complete_token_injection_fallbacks: set[str] = set()
 
         serving_chat_default_kwargs = dict(
             response_role="assistant",

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -69,8 +69,20 @@ def _prefix_matches_tokenized_assistant(
     """Return whether a prefix is the exact token metadata from one message."""
     prompt_token_ids = message.get("prompt_token_ids")
     generation_token_ids = message.get("generation_token_ids")
-    if not isinstance(prompt_token_ids, list) or not isinstance(
-        generation_token_ids, list
+    if (
+        not isinstance(required_prefix_token_ids, list)
+        or not required_prefix_token_ids
+        or not isinstance(prompt_token_ids, list)
+        or not isinstance(generation_token_ids, list)
+        or any(
+            type(token_id) is not int
+            for token_ids in (
+                required_prefix_token_ids,
+                prompt_token_ids,
+                generation_token_ids,
+            )
+            for token_id in token_ids
+        )
     ):
         return False
 
@@ -89,6 +101,7 @@ def _complete_token_injection_eligibility(
     has_multimodal_config: bool,
     prompt_embeds_enabled: bool,
     renderer_supported: bool,
+    vllm_version_supported: bool = True,
 ) -> tuple[int | None, str | None]:
     """Return an assistant ordinal or a reason to use native preprocessing."""
     if request.stream:
@@ -111,11 +124,14 @@ def _complete_token_injection_eligibility(
         return None, "prompt embeddings enabled"
     if not renderer_supported:
         return None, "unsupported renderer"
+    if not vllm_version_supported:
+        return None, "unsupported vLLM version"
     for message in messages:
         if not isinstance(message, dict):
             return None, "non-object message"
-        # vLLM can consolidate developer and system messages, which can change
-        # the assistant ordinal and invalidate the splice boundary.
+        # vLLM rewrites messages only when a developer role is present. It
+        # converts that role to system and then merges systems to index 0,
+        # which would shift the assistant ordinal.
         if message.get("role") not in {"system", "user", "assistant", "tool"}:
             return None, "unsupported message role"
         content = message.get("content")
@@ -438,6 +454,7 @@ class VllmAsyncGenerationWorkerImpl(
 
         from fastapi import Request
         from fastapi.responses import JSONResponse, StreamingResponse
+        import vllm
         from vllm.entrypoints.chat_utils import load_chat_template
         from vllm.entrypoints.openai.chat_completion.protocol import (
             ChatCompletionRequest,
@@ -539,6 +556,30 @@ class VllmAsyncGenerationWorkerImpl(
                     )
                 max_tokens = min(request_max_tokens, remaining)
                 self._set_max_tokens(request, max_tokens)
+
+            def _restore_max_tokens_after_error(
+                self, request, request_max_tokens: int, error: Exception
+            ) -> None:
+                """Restore caller state and preserve the real output count in errors."""
+                self._set_max_tokens(request, request_max_tokens)
+                if (
+                    isinstance(error, VLLMValidationError)
+                    and error.parameter == "input_tokens"
+                    and "maximum context length" in str(error)
+                ):
+                    token_count = error.value
+                    qualifier = "at least " if "contains at least" in str(error) else ""
+                    total = token_count + request_max_tokens
+                    raise VLLMValidationError(
+                        f"This model's maximum context length is "
+                        f"{self.model_config.max_model_len} tokens. However, you "
+                        f"requested {request_max_tokens} output tokens and your prompt "
+                        f"contains {qualifier}{token_count} input tokens, for a total "
+                        f"of {qualifier}{total} tokens. Please reduce the length of "
+                        f"the input prompt or the number of requested output tokens.",
+                        parameter=error.parameter,
+                        value=error.value,
+                    ) from error
 
             def _record_complete_token_injection_fallback(self, reason: str) -> None:
                 self._complete_token_injection_fallbacks[reason] += 1
@@ -645,6 +686,23 @@ class VllmAsyncGenerationWorkerImpl(
                         )
                     return rendered
 
+                def render_assistant_close_text(marked_conversation):
+                    close_template_kwargs = apply_chat_template_kwargs | {
+                        "add_generation_prompt": False
+                    }
+                    rendered = safe_apply_chat_template(
+                        self.model_config,
+                        tokenizer,
+                        marked_conversation,
+                        tokenize=False,
+                        **close_template_kwargs,
+                    )
+                    if not isinstance(rendered, str):
+                        raise CompleteTokenInjectionError(
+                            "The assistant-close probe did not render as text."
+                        )
+                    return rendered
+
                 # Do not use vLLM's one-worker renderer executor here. It would
                 # serialize the fast path and can remove the measured speedup.
                 prompt_token_ids = await asyncio.to_thread(
@@ -654,14 +712,18 @@ class VllmAsyncGenerationWorkerImpl(
                     assistant_ordinal=assistant_ordinal,
                     model_prefix_token_ids=list(request.required_prefix_token_ids),
                     render_prompt_text=render_prompt_text,
+                    render_assistant_close_text=render_assistant_close_text,
                 )
                 prompt = {"prompt_token_ids": prompt_token_ids}
                 tokenized_prompt = await renderer.tokenize_prompt_async(
                     prompt, tok_params
                 )
-                for key in ("mm_processor_kwargs", "cache_salt"):
-                    if (value := getattr(request, key, None)) is not None:
-                        tokenized_prompt[key] = value
+                if request.mm_processor_kwargs is not None:
+                    tokenized_prompt["mm_processor_kwargs"] = (
+                        request.mm_processor_kwargs
+                    )
+                if request.cache_salt is not None:
+                    tokenized_prompt["cache_salt"] = request.cache_salt
                 engine_prompt = await renderer.process_for_engine_async(
                     tokenized_prompt,
                     arrival_time,
@@ -670,7 +732,7 @@ class VllmAsyncGenerationWorkerImpl(
 
                 if parser is not None:
                     tool_parser = parser.tool_parser_cls
-                    tool_choice = getattr(request, "tool_choice", "none")
+                    tool_choice = request.tool_choice
                     is_mistral_grammar_eligible = (
                         tool_parser is not None
                         and is_mistral_tool_parser(tool_parser)
@@ -740,6 +802,7 @@ class VllmAsyncGenerationWorkerImpl(
                             ),
                             prompt_embeds_enabled=self.model_config.enable_prompt_embeds,
                             renderer_supported=isinstance(self.renderer, HfRenderer),
+                            vllm_version_supported=(vllm.__version__ == "0.25.1"),
                         )
                     )
                     if fallback_reason is not None:
@@ -764,15 +827,27 @@ class VllmAsyncGenerationWorkerImpl(
                         except CompleteTokenInjectionError as e:
                             self._record_complete_token_injection_fallback(str(e))
                             self._maybe_log_complete_token_injection_stats()
+                        except Exception as e:
+                            if actual_request_max_tokens is not None:
+                                self._restore_max_tokens_after_error(
+                                    request, actual_request_max_tokens, e
+                                )
+                            raise
                         else:
                             self._complete_token_injection_successes += 1
                             self._maybe_log_complete_token_injection_stats()
                             if actual_request_max_tokens is not None:
-                                self._clamp_max_tokens(
-                                    request,
-                                    actual_request_max_tokens,
-                                    res[1][0]["prompt_token_ids"],
-                                )
+                                try:
+                                    self._clamp_max_tokens(
+                                        request,
+                                        actual_request_max_tokens,
+                                        res[1][0]["prompt_token_ids"],
+                                    )
+                                except Exception as e:
+                                    self._restore_max_tokens_after_error(
+                                        request, actual_request_max_tokens, e
+                                    )
+                                    raise
                             return res
 
                 messages_for_replace_prefix_tokens = deepcopy(messages)
@@ -794,6 +869,16 @@ class VllmAsyncGenerationWorkerImpl(
 
                         logging.getLogger(__name__).warning(
                             "Prompt exceeds max_model_len: %s", e
+                        )
+                    if actual_request_max_tokens is not None:
+                        self._restore_max_tokens_after_error(
+                            request, actual_request_max_tokens, e
+                        )
+                    raise
+                except Exception as e:
+                    if actual_request_max_tokens is not None:
+                        self._restore_max_tokens_after_error(
+                            request, actual_request_max_tokens, e
                         )
                     raise
 
@@ -831,38 +916,60 @@ class VllmAsyncGenerationWorkerImpl(
                     update={"add_generation_prompt": False}
                 )
 
-                corresponding_res = await super().preprocess_chat(
-                    request=modified_request,
-                    messages=messages_to_last_assistant_message,
-                    default_template=default_template,
-                    default_template_content_format=default_template_content_format,
-                    default_template_kwargs=default_template_kwargs,
-                    tool_dicts=tool_dicts,
-                    parser=parser,
-                    skip_mm_cache=skip_mm_cache,
-                )
+                try:
+                    corresponding_res = await super().preprocess_chat(
+                        request=modified_request,
+                        messages=messages_to_last_assistant_message,
+                        default_template=default_template,
+                        default_template_content_format=(
+                            default_template_content_format
+                        ),
+                        default_template_kwargs=default_template_kwargs,
+                        tool_dicts=tool_dicts,
+                        parser=parser,
+                        skip_mm_cache=skip_mm_cache,
+                    )
+                except Exception as e:
+                    if actual_request_max_tokens is not None:
+                        self._restore_max_tokens_after_error(
+                            request, actual_request_max_tokens, e
+                        )
+                    raise
                 actual_corresponding_token_ids = corresponding_res[1][0][
                     "prompt_token_ids"
                 ]
 
                 engine_prompt = res[1][0]
 
-                final_prompt_token_ids = replace_prefix_tokens(
-                    tokenizer=self.renderer.tokenizer,
-                    model_prefix_token_ids=request.required_prefix_token_ids,
-                    template_prefix_token_ids=actual_corresponding_token_ids,
-                    template_token_ids=engine_prompt["prompt_token_ids"],
-                )
+                try:
+                    final_prompt_token_ids = replace_prefix_tokens(
+                        tokenizer=self.renderer.tokenizer,
+                        model_prefix_token_ids=request.required_prefix_token_ids,
+                        template_prefix_token_ids=actual_corresponding_token_ids,
+                        template_token_ids=engine_prompt["prompt_token_ids"],
+                    )
+                except Exception as e:
+                    if actual_request_max_tokens is not None:
+                        self._restore_max_tokens_after_error(
+                            request, actual_request_max_tokens, e
+                        )
+                    raise
 
                 engine_prompt["prompt_token_ids"] = final_prompt_token_ids
 
                 # Clamp after prefix replacement since the prompt length may have changed.
                 if actual_request_max_tokens is not None:
-                    self._clamp_max_tokens(
-                        request,
-                        actual_request_max_tokens,
-                        final_prompt_token_ids,
-                    )
+                    try:
+                        self._clamp_max_tokens(
+                            request,
+                            actual_request_max_tokens,
+                            final_prompt_token_ids,
+                        )
+                    except Exception as e:
+                        self._restore_max_tokens_after_error(
+                            request, actual_request_max_tokens, e
+                        )
+                        raise
 
                 return res
 

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -15,6 +15,7 @@
 import asyncio
 import copy
 import gc
+import json
 import logging
 import threading
 import time
@@ -62,6 +63,25 @@ from nemo_rl.models.generation.vllm.vllm_worker import BaseVllmGenerationWorker
 LOGGER = logging.getLogger(__name__)
 
 
+def _prefix_matches_tokenized_assistant(
+    required_prefix_token_ids: list[int], message: Any
+) -> bool:
+    """Return whether a prefix is the exact token metadata from one message."""
+    prompt_token_ids = message.get("prompt_token_ids")
+    generation_token_ids = message.get("generation_token_ids")
+    if not isinstance(prompt_token_ids, list) or not isinstance(
+        generation_token_ids, list
+    ):
+        return False
+
+    prompt_length = len(prompt_token_ids)
+    return (
+        len(required_prefix_token_ids) == prompt_length + len(generation_token_ids)
+        and required_prefix_token_ids[:prompt_length] == prompt_token_ids
+        and required_prefix_token_ids[prompt_length:] == generation_token_ids
+    )
+
+
 def _complete_token_injection_eligibility(
     request: Any,
     messages: list[Any],
@@ -71,19 +91,19 @@ def _complete_token_injection_eligibility(
     renderer_supported: bool,
 ) -> tuple[int | None, str | None]:
     """Return an assistant ordinal or a reason to use native preprocessing."""
-    if getattr(request, "stream", False):
+    if request.stream:
         return None, "streaming request"
-    if getattr(request, "n", 1) not in (None, 1):
+    if request.n not in (None, 1):
         return None, "multiple response choices"
-    if getattr(request, "continue_final_message", False):
+    if request.continue_final_message:
         return None, "continue_final_message request"
-    if getattr(request, "echo", False):
+    if request.echo:
         return None, "echo request"
-    if getattr(request, "return_assistant_tokens_mask", False):
+    if request.return_assistant_tokens_mask:
         return None, "assistant token mask request"
-    if getattr(request, "add_special_tokens", False):
+    if request.add_special_tokens:
         return None, "add_special_tokens request"
-    if getattr(request, "return_prompt_text", False):
+    if request.return_prompt_text:
         return None, "return_prompt_text request"
     if has_multimodal_config:
         return None, "multimodal model"
@@ -94,16 +114,24 @@ def _complete_token_injection_eligibility(
     for message in messages:
         if not isinstance(message, dict):
             return None, "non-object message"
+        # vLLM can consolidate developer and system messages, which can change
+        # the assistant ordinal and invalidate the splice boundary.
         if message.get("role") not in {"system", "user", "assistant", "tool"}:
             return None, "unsupported message role"
         content = message.get("content")
+        # Responses-style content-part lists stay on native preprocessing. Chat
+        # templates can treat these lists differently from flattened text.
         if content is not None and not isinstance(content, str):
             return None, "non-text message content"
 
     tokenized_assistant = find_latest_tokenized_assistant(messages)
     if tokenized_assistant is None:
         return None, "no fully tokenized assistant"
-    assistant_ordinal, _ = tokenized_assistant
+    assistant_ordinal, message = tokenized_assistant
+    if not _prefix_matches_tokenized_assistant(
+        request.required_prefix_token_ids, message
+    ):
+        return None, "client-supplied prefix does not match message token metadata"
     return assistant_ordinal, None
 
 
@@ -148,6 +176,7 @@ class VllmAsyncGenerationWorkerImpl(
         self.server_thread = None
         self.base_url = None
         self.http_server = None
+        self._online_renderer = None
 
         super().__init__(
             config,
@@ -177,6 +206,12 @@ class VllmAsyncGenerationWorkerImpl(
         return bool(
             self.cfg.get("vllm_kwargs", {}).get("enable_return_routed_experts", False)
         )
+
+    def _get_complete_token_injection_stats(self) -> dict[str, Any]:
+        """Return a snapshot of complete-token injection renderer counters."""
+        if self._online_renderer is None:
+            return {"attempts": 0, "successes": 0, "fallbacks": {}}
+        return self._online_renderer._get_complete_token_injection_stats()
 
     def _reserve_port(self) -> None:
         """Bind and listen on a TCP socket to reserve a free port from the OS.
@@ -515,6 +550,25 @@ class VllmAsyncGenerationWorkerImpl(
                     reason,
                 )
 
+            def _get_complete_token_injection_stats(self) -> dict[str, Any]:
+                """Return a copy of the complete-token injection counters."""
+                return {
+                    "attempts": self._complete_token_injection_attempts,
+                    "successes": self._complete_token_injection_successes,
+                    "fallbacks": dict(self._complete_token_injection_fallbacks),
+                }
+
+            def _maybe_log_complete_token_injection_stats(self) -> None:
+                attempts = self._complete_token_injection_attempts
+                if attempts != 1 and attempts % 1000 != 0:
+                    return
+                LOGGER.info(
+                    "Complete-token injection statistics: %s",
+                    json.dumps(
+                        self._get_complete_token_injection_stats(), sort_keys=True
+                    ),
+                )
+
             async def _preprocess_chat_with_complete_token_ids(
                 self,
                 request,
@@ -528,7 +582,11 @@ class VllmAsyncGenerationWorkerImpl(
                 *,
                 skip_mm_cache: bool,
             ):
-                """Preserve vLLM preprocessing while skipping prompt re-encoding."""
+                """Preserve vLLM preprocessing while skipping prompt re-encoding.
+
+                This mirrors vLLM 0.25.1 ``OnlineRenderer.preprocess_chat``.
+                Re-diff that function and its render helpers during vLLM upgrades.
+                """
                 renderer = self.renderer
                 arrival_time = time.time()
                 default_template_kwargs = merge_kwargs(
@@ -587,6 +645,8 @@ class VllmAsyncGenerationWorkerImpl(
                         )
                     return rendered
 
+                # Do not use vLLM's one-worker renderer executor here. It would
+                # serialize the fast path and can remove the measured speedup.
                 prompt_token_ids = await asyncio.to_thread(
                     build_complete_prompt_token_ids,
                     tokenizer=tokenizer,
@@ -599,14 +659,9 @@ class VllmAsyncGenerationWorkerImpl(
                 tokenized_prompt = await renderer.tokenize_prompt_async(
                     prompt, tok_params
                 )
-                renderer._apply_prompt_extras(
-                    [tokenized_prompt],
-                    {
-                        key: value
-                        for key in ("mm_processor_kwargs", "cache_salt")
-                        if (value := getattr(request, key, None)) is not None
-                    },
-                )
+                for key in ("mm_processor_kwargs", "cache_salt"):
+                    if (value := getattr(request, key, None)) is not None:
+                        tokenized_prompt[key] = value
                 engine_prompt = await renderer.process_for_engine_async(
                     tokenized_prompt,
                     arrival_time,
@@ -689,6 +744,7 @@ class VllmAsyncGenerationWorkerImpl(
                     )
                     if fallback_reason is not None:
                         self._record_complete_token_injection_fallback(fallback_reason)
+                        self._maybe_log_complete_token_injection_stats()
                     else:
                         assert assistant_ordinal is not None
                         try:
@@ -707,8 +763,10 @@ class VllmAsyncGenerationWorkerImpl(
                             )
                         except CompleteTokenInjectionError as e:
                             self._record_complete_token_injection_fallback(str(e))
+                            self._maybe_log_complete_token_injection_stats()
                         else:
                             self._complete_token_injection_successes += 1
+                            self._maybe_log_complete_token_injection_stats()
                             if actual_request_max_tokens is not None:
                                 self._clamp_max_tokens(
                                     request,
@@ -955,6 +1013,7 @@ class VllmAsyncGenerationWorkerImpl(
             # here keeps the two endpoints rendering identical prompts.
             default_chat_template_kwargs=default_chat_template_kwargs,
         )
+        self._online_renderer = online_renderer
         serving_chat_kwargs.update(
             dict(
                 engine_client=engine_client,

--- a/tests/unit/models/generation/test_dynamo_token_wrapper.py
+++ b/tests/unit/models/generation/test_dynamo_token_wrapper.py
@@ -32,12 +32,14 @@ class _Tokenizer:
 
     def __init__(self) -> None:
         self.calls = []
+        self.encode_calls = []
 
     def decode(self, token_ids):
         return repr(token_ids)
 
     def encode(self, text, add_special_tokens=False):
         assert add_special_tokens is False
+        self.encode_calls.append(text)
         token_ids = []
         while text:
             if text.startswith(self.eos_token):
@@ -192,6 +194,8 @@ def test_prepare_dynamo_chat_completion_request_first_turn() -> None:
         "enable_thinking": False,
         "force_nonempty_content": True,
     }
+    assert tokenizer.calls[0]["tokenize"] is True
+    assert tokenizer.encode_calls == []
 
 
 def test_public_qwen3_tokenizer_first_turn_matches_chat_template(
@@ -362,8 +366,86 @@ def test_prepare_dynamo_chat_completion_request_preserves_prior_prefix() -> None
     assert "generation_log_probs" not in prepared["messages"][1]
     assert tokenizer.calls[0]["add_generation_prompt"] is True
     assert tokenizer.calls[1]["add_generation_prompt"] is False
-    assert tokenizer.calls[0]["tokenize"] is True
-    assert tokenizer.calls[1]["tokenize"] is True
+    assert tokenizer.calls[0]["tokenize"] is False
+    assert tokenizer.calls[1]["tokenize"] is False
+    assert tokenizer.encode_calls == ["<eos>", "<eos>nextGEN"]
+
+
+def test_prepare_dynamo_chat_completion_request_falls_back_for_unsupported_boundary() -> (
+    None
+):
+    class MissingCloseTokenizer(_Tokenizer):
+        def apply_chat_template(self, *args, **kwargs):
+            rendered = super().apply_chat_template(*args, **kwargs)
+            if (
+                kwargs.get("tokenize", True)
+                or "NEMO_RL_PREFIX_BOUNDARY" not in rendered
+            ):
+                return rendered
+            return rendered.replace("<eos>", "", 1)
+
+    tokenizer = MissingCloseTokenizer()
+    body = {
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": "first",
+                "prompt_token_ids": [10],
+                "generation_token_ids": [31, 32, 2],
+                "generation_log_probs": [-0.1, -0.2, -0.3],
+            },
+            {"role": "user", "content": "next"},
+        ]
+    }
+
+    prepared = prepare_dynamo_chat_completion_request(
+        body,
+        tokenizer=tokenizer,
+        exclude_tools_when_tool_choice_none=True,
+    )
+
+    assert prepared["nvext"]["token_data"] == [10, 31, 32, 2, 40, 99]
+    assert [call["tokenize"] for call in tokenizer.calls] == [
+        False,
+        False,
+        True,
+        True,
+    ]
+
+
+def test_prepare_dynamo_chat_completion_request_falls_back_for_media_content() -> None:
+    tokenizer = _Tokenizer()
+    body = {
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": "first",
+                "prompt_token_ids": [10],
+                "generation_token_ids": [31, 32, 2],
+                "generation_log_probs": [-0.1, -0.2, -0.3],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/image.png"},
+                    }
+                ],
+            },
+        ]
+    }
+
+    prepared = prepare_dynamo_chat_completion_request(
+        body,
+        tokenizer=tokenizer,
+        exclude_tools_when_tool_choice_none=True,
+    )
+
+    assert prepared["nvext"]["token_data"] == [10, 31, 32, 2, 900, 99]
+    assert [call["tokenize"] for call in tokenizer.calls] == [True, True]
 
 
 def test_prepare_dynamo_chat_completion_request_validates_extra_fields() -> None:

--- a/tests/unit/models/generation/test_openai_server_utils.py
+++ b/tests/unit/models/generation/test_openai_server_utils.py
@@ -16,6 +16,132 @@
 import pytest
 
 from nemo_rl.models.generation.openai_server_utils import replace_prefix_tokens
+from nemo_rl.models.generation.openai_server_utils import (
+    CompleteTokenInjectionError,
+    build_complete_prompt_token_ids,
+    find_latest_tokenized_assistant_ordinal,
+)
+
+
+class _CompleteTokenTokenizer:
+    eos_token = "<eos>"
+    eos_token_id = 2
+
+    def encode(self, text, add_special_tokens=False):
+        assert add_special_tokens is False
+        token_ids = []
+        while text:
+            if text.startswith(self.eos_token):
+                token_ids.append(self.eos_token_id)
+                text = text[len(self.eos_token) :]
+            elif text.startswith("next"):
+                token_ids.append(40)
+                text = text[len("next") :]
+            elif text.startswith("GEN"):
+                token_ids.append(99)
+                text = text[len("GEN") :]
+            else:
+                raise AssertionError(f"Unexpected text to encode: {text!r}")
+        return token_ids
+
+
+def _render_marked_conversation(conversation, *, tokenize):
+    token_ids = []
+    rendered = ""
+    for message in conversation:
+        for tool_call in message.get("tool_calls", []):
+            function = tool_call.get("function", tool_call)
+            assert isinstance(function.get("arguments"), dict)
+
+        role = message["role"]
+        content = message.get("content")
+        if role == "user" and content == "hello":
+            token_ids.append(10)
+            rendered += "hello"
+        elif role == "user" and content == "next":
+            token_ids.append(40)
+            rendered += "next"
+        elif role == "assistant":
+            token_ids.extend([777, 2])
+            rendered += f"{content}<eos>"
+        else:
+            token_ids.append(900)
+            rendered += "other"
+    token_ids.append(99)
+    rendered += "GEN"
+    return token_ids if tokenize else rendered
+
+
+def test_build_complete_prompt_token_ids_preserves_prefix_and_suffix() -> None:
+    tokenizer = _CompleteTokenTokenizer()
+    conversation = [
+        {"role": "user", "content": "hello"},
+        {
+            "role": "assistant",
+            "content": "older tool call",
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "shell",
+                        "arguments": '{"command":"pwd"}',
+                    },
+                }
+            ],
+        },
+        {"role": "user", "content": "next"},
+        {"role": "assistant", "content": "first"},
+        {"role": "user", "content": "next"},
+    ]
+
+    result = build_complete_prompt_token_ids(
+        tokenizer=tokenizer,
+        conversation=conversation,
+        assistant_ordinal=1,
+        model_prefix_token_ids=[10, 777, 2, 40, 31, 32, 2],
+        render_prompt_text=lambda messages: _render_marked_conversation(
+            messages, tokenize=False
+        ),
+    )
+
+    assert result == [10, 777, 2, 40, 31, 32, 2, 40, 99]
+    assert conversation[1]["tool_calls"][0]["function"]["arguments"] == (
+        '{"command":"pwd"}'
+    )
+
+
+def test_complete_token_injection_finds_latest_tokenized_assistant() -> None:
+    messages = [
+        {"role": "assistant", "content": "first"},
+        {
+            "role": "assistant",
+            "content": "second",
+            "prompt_token_ids": [1],
+            "generation_token_ids": [2],
+        },
+        {"role": "assistant", "content": "third"},
+    ]
+
+    assert find_latest_tokenized_assistant_ordinal(messages) == 1
+
+
+def test_complete_token_injection_requires_assistant_eos() -> None:
+    tokenizer = _CompleteTokenTokenizer()
+    conversation = [
+        {"role": "assistant", "content": "first"},
+        {"role": "user", "content": "next"},
+    ]
+
+    with pytest.raises(CompleteTokenInjectionError, match="did not close"):
+        build_complete_prompt_token_ids(
+            tokenizer=tokenizer,
+            conversation=conversation,
+            assistant_ordinal=0,
+            model_prefix_token_ids=[31, 32, 2],
+            render_prompt_text=lambda messages: (
+                "NEMO_RL_PREFIX_BOUNDARY_7F3A9C1E missing boundary close"
+            ),
+        )
 
 
 def test_replace_prefix_tokens_empty_model_prefix_returns_template():

--- a/tests/unit/models/generation/test_openai_server_utils.py
+++ b/tests/unit/models/generation/test_openai_server_utils.py
@@ -13,10 +13,15 @@
 # limitations under the License.
 """Tests for the shared on-policy prefix splice used by the vLLM/TRT-LLM OpenAI servers."""
 
+from collections import UserDict
+from copy import deepcopy
+from types import MappingProxyType
+
 import pytest
 
 from nemo_rl.models.generation.openai_server_utils import (
     CompleteTokenInjectionError,
+    _coerce_token_id_list,
     build_complete_prompt_token_ids,
     find_latest_tokenized_assistant,
     replace_prefix_tokens,
@@ -87,6 +92,7 @@ def test_build_complete_prompt_token_ids_preserves_prefix_and_suffix() -> None:
         {"role": "assistant", "content": "first"},
         {"role": "user", "content": "next"},
     ]
+    original_conversation = deepcopy(conversation)
 
     result = build_complete_prompt_token_ids(
         tokenizer=tokenizer,
@@ -97,9 +103,7 @@ def test_build_complete_prompt_token_ids_preserves_prefix_and_suffix() -> None:
     )
 
     assert result == [10, 777, 2, 40, 31, 32, 2, 40, 99]
-    assert conversation[1]["tool_calls"][0]["function"]["arguments"] == {
-        "command": "pwd"
-    }
+    assert conversation == original_conversation
 
 
 @pytest.mark.parametrize(
@@ -177,7 +181,9 @@ def test_complete_token_injection_finds_latest_tokenized_assistant(
 
 
 @pytest.mark.parametrize("gap", ["", " \n\t"])
-def test_complete_token_injection_requires_adjacent_assistant_eos(gap) -> None:
+def test_complete_token_injection_tolerates_whitespace_before_assistant_eos(
+    gap,
+) -> None:
     tokenizer = _CompleteTokenTokenizer()
     marker = "NEMO_RL_PREFIX_BOUNDARY_7F3A9C1E"
 
@@ -220,7 +226,10 @@ def test_complete_token_injection_requires_assistant_eos() -> None:
         {"role": "user", "content": "next"},
     ]
 
-    with pytest.raises(CompleteTokenInjectionError, match="did not close"):
+    with pytest.raises(
+        CompleteTokenInjectionError,
+        match="did not close the tokenized assistant with EOS",
+    ):
         build_complete_prompt_token_ids(
             tokenizer=tokenizer,
             conversation=conversation,
@@ -230,6 +239,243 @@ def test_complete_token_injection_requires_assistant_eos() -> None:
                 "NEMO_RL_PREFIX_BOUNDARY_7F3A9C1E missing boundary close"
             ),
         )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [pytest.param((2, 40), id="non_list"), pytest.param(None, id="none")],
+)
+def test_complete_token_injection_rejects_non_list_token_ids(value) -> None:
+    with pytest.raises(CompleteTokenInjectionError, match="must be a list"):
+        _coerce_token_id_list(value, "Token IDs")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(["2"], id="string"),
+        pytest.param([2.9], id="float"),
+        pytest.param([True], id="bool"),
+    ],
+)
+def test_complete_token_injection_rejects_non_integer_token_ids(value) -> None:
+    with pytest.raises(CompleteTokenInjectionError, match="only integer token IDs"):
+        _coerce_token_id_list(value, "Token IDs")
+
+
+def test_complete_token_injection_copies_valid_token_ids() -> None:
+    token_ids = [2, 40]
+
+    result = _coerce_token_id_list(token_ids, "Token IDs")
+
+    assert result == token_ids
+    assert result is not token_ids
+
+
+def test_complete_token_injection_wraps_copy_failure() -> None:
+    conversation = [MappingProxyType({"role": "assistant", "content": "first"})]
+
+    with pytest.raises(CompleteTokenInjectionError, match="could not be copied"):
+        build_complete_prompt_token_ids(
+            tokenizer=_CompleteTokenTokenizer(),
+            conversation=conversation,
+            assistant_ordinal=0,
+            model_prefix_token_ids=[31, 32, 2],
+            render_prompt_text=_render_marked_conversation,
+        )
+
+
+def test_complete_token_injection_rejects_marker_collision() -> None:
+    with pytest.raises(CompleteTokenInjectionError, match="marker collided"):
+        build_complete_prompt_token_ids(
+            tokenizer=_CompleteTokenTokenizer(),
+            conversation=[
+                {
+                    "role": "assistant",
+                    "content": "NEMO_RL_PREFIX_BOUNDARY_7F3A9C1E",
+                }
+            ],
+            assistant_ordinal=0,
+            model_prefix_token_ids=[31, 32, 2],
+            render_prompt_text=_render_marked_conversation,
+        )
+
+
+def test_complete_token_injection_rejects_missing_assistant_ordinal() -> None:
+    with pytest.raises(
+        CompleteTokenInjectionError, match="not present after chat parsing"
+    ):
+        build_complete_prompt_token_ids(
+            tokenizer=_CompleteTokenTokenizer(),
+            conversation=[{"role": "assistant", "content": "first"}],
+            assistant_ordinal=1,
+            model_prefix_token_ids=[31, 32, 2],
+            render_prompt_text=_render_marked_conversation,
+        )
+
+
+def test_complete_token_injection_rejects_non_dict_assistant() -> None:
+    with pytest.raises(CompleteTokenInjectionError, match="not a message object"):
+        build_complete_prompt_token_ids(
+            tokenizer=_CompleteTokenTokenizer(),
+            conversation=[UserDict({"role": "assistant", "content": "first"})],
+            assistant_ordinal=0,
+            model_prefix_token_ids=[31, 32, 2],
+            render_prompt_text=_render_marked_conversation,
+        )
+
+
+def test_complete_token_injection_preserves_render_fallback() -> None:
+    def render_prompt_text(messages):
+        raise CompleteTokenInjectionError("renderer requested native preprocessing")
+
+    with pytest.raises(
+        CompleteTokenInjectionError,
+        match="renderer requested native preprocessing",
+    ):
+        build_complete_prompt_token_ids(
+            tokenizer=_CompleteTokenTokenizer(),
+            conversation=[{"role": "assistant", "content": "first"}],
+            assistant_ordinal=0,
+            model_prefix_token_ids=[31, 32, 2],
+            render_prompt_text=render_prompt_text,
+        )
+
+
+def test_complete_token_injection_wraps_render_failure() -> None:
+    def render_prompt_text(messages):
+        raise RuntimeError("render failed")
+
+    with pytest.raises(CompleteTokenInjectionError, match="could not be rendered"):
+        build_complete_prompt_token_ids(
+            tokenizer=_CompleteTokenTokenizer(),
+            conversation=[{"role": "assistant", "content": "first"}],
+            assistant_ordinal=0,
+            model_prefix_token_ids=[31, 32, 2],
+            render_prompt_text=render_prompt_text,
+        )
+
+
+@pytest.mark.parametrize(
+    ("rendered", "expected_error"),
+    [
+        pytest.param([], "must render as text", id="non_text"),
+        pytest.param("missing marker<eos>", "did not preserve", id="missing_marker"),
+    ],
+)
+def test_complete_token_injection_rejects_invalid_render_output(
+    rendered, expected_error
+) -> None:
+    with pytest.raises(CompleteTokenInjectionError, match=expected_error):
+        build_complete_prompt_token_ids(
+            tokenizer=_CompleteTokenTokenizer(),
+            conversation=[{"role": "assistant", "content": "first"}],
+            assistant_ordinal=0,
+            model_prefix_token_ids=[31, 32, 2],
+            render_prompt_text=lambda messages: rendered,
+        )
+
+
+def test_complete_token_injection_requires_tokenizer_eos() -> None:
+    tokenizer = _CompleteTokenTokenizer()
+    tokenizer.eos_token = None
+
+    with pytest.raises(CompleteTokenInjectionError, match="requires tokenizer EOS"):
+        build_complete_prompt_token_ids(
+            tokenizer=tokenizer,
+            conversation=[{"role": "assistant", "content": "first"}],
+            assistant_ordinal=0,
+            model_prefix_token_ids=[31, 32, 2],
+            render_prompt_text=lambda messages: (
+                "NEMO_RL_PREFIX_BOUNDARY_7F3A9C1E<eos>nextGEN"
+            ),
+        )
+
+
+def test_complete_token_injection_preserves_encoding_fallback() -> None:
+    tokenizer = _CompleteTokenTokenizer()
+
+    def encode(text, add_special_tokens=False):
+        raise CompleteTokenInjectionError("encoder requested native preprocessing")
+
+    tokenizer.encode = encode
+    with pytest.raises(
+        CompleteTokenInjectionError,
+        match="encoder requested native preprocessing",
+    ):
+        build_complete_prompt_token_ids(
+            tokenizer=tokenizer,
+            conversation=[{"role": "assistant", "content": "first"}],
+            assistant_ordinal=0,
+            model_prefix_token_ids=[31, 32, 2],
+            render_prompt_text=lambda messages: (
+                "NEMO_RL_PREFIX_BOUNDARY_7F3A9C1E<eos>nextGEN"
+            ),
+        )
+
+
+def test_complete_token_injection_wraps_encoding_failure() -> None:
+    tokenizer = _CompleteTokenTokenizer()
+
+    def encode(text, add_special_tokens=False):
+        raise RuntimeError("encode failed")
+
+    tokenizer.encode = encode
+    with pytest.raises(CompleteTokenInjectionError, match="could not be tokenized"):
+        build_complete_prompt_token_ids(
+            tokenizer=tokenizer,
+            conversation=[{"role": "assistant", "content": "first"}],
+            assistant_ordinal=0,
+            model_prefix_token_ids=[31, 32, 2],
+            render_prompt_text=lambda messages: (
+                "NEMO_RL_PREFIX_BOUNDARY_7F3A9C1E<eos>nextGEN"
+            ),
+        )
+
+
+def test_complete_token_injection_requires_encoded_suffix_eos() -> None:
+    tokenizer = _CompleteTokenTokenizer()
+    tokenizer.encode = lambda text, add_special_tokens=False: [40]
+
+    with pytest.raises(CompleteTokenInjectionError, match="did not begin with EOS"):
+        build_complete_prompt_token_ids(
+            tokenizer=tokenizer,
+            conversation=[{"role": "assistant", "content": "first"}],
+            assistant_ordinal=0,
+            model_prefix_token_ids=[31, 32, 2],
+            render_prompt_text=lambda messages: (
+                "NEMO_RL_PREFIX_BOUNDARY_7F3A9C1E<eos>nextGEN"
+            ),
+        )
+
+
+def test_complete_token_injection_rejects_empty_model_prefix() -> None:
+    with pytest.raises(
+        CompleteTokenInjectionError, match="prefix token IDs were empty"
+    ):
+        build_complete_prompt_token_ids(
+            tokenizer=_CompleteTokenTokenizer(),
+            conversation=[{"role": "assistant", "content": "first"}],
+            assistant_ordinal=0,
+            model_prefix_token_ids=[],
+            render_prompt_text=lambda messages: (
+                "NEMO_RL_PREFIX_BOUNDARY_7F3A9C1E<eos>nextGEN"
+            ),
+        )
+
+
+def test_complete_token_injection_appends_eos_when_prefix_has_no_eos() -> None:
+    result = build_complete_prompt_token_ids(
+        tokenizer=_CompleteTokenTokenizer(),
+        conversation=[{"role": "assistant", "content": "first"}],
+        assistant_ordinal=0,
+        model_prefix_token_ids=[31, 32],
+        render_prompt_text=lambda messages: (
+            "NEMO_RL_PREFIX_BOUNDARY_7F3A9C1E<eos>nextGEN"
+        ),
+    )
+
+    assert result == [31, 32, 2, 40, 99]
 
 
 def test_replace_prefix_tokens_empty_model_prefix_returns_template():

--- a/tests/unit/models/generation/test_openai_server_utils.py
+++ b/tests/unit/models/generation/test_openai_server_utils.py
@@ -61,6 +61,9 @@ class _GemmaStyleTokenizer(_CompleteTokenTokenizer):
             if text.startswith("<end_of_turn>"):
                 token_ids.append(106)
                 text = text[len("<end_of_turn>") :]
+            elif text.startswith("\n"):
+                token_ids.append(107)
+                text = text[1:]
             elif text.startswith("next"):
                 token_ids.append(40)
                 text = text[len("next") :]
@@ -131,8 +134,16 @@ def test_build_complete_prompt_token_ids_preserves_prefix_and_suffix() -> None:
 @pytest.mark.parametrize(
     ("model_prefix_token_ids", "expected"),
     [
-        pytest.param([31, 32, 106], [31, 32, 106, 40, 99], id="close_present"),
-        pytest.param([31, 32], [31, 32, 106, 40, 99], id="close_missing"),
+        pytest.param(
+            [31, 32, 106, 107],
+            [31, 32, 106, 107, 40, 99],
+            id="close_present",
+        ),
+        pytest.param(
+            [31, 32],
+            [31, 32, 106, 107, 40, 99],
+            id="close_missing",
+        ),
     ],
 )
 def test_complete_token_injection_uses_template_assistant_close(
@@ -148,8 +159,8 @@ def test_complete_token_injection_uses_template_assistant_close(
         ],
         assistant_ordinal=0,
         model_prefix_token_ids=model_prefix_token_ids,
-        render_prompt_text=lambda messages: (f"{marker} \n<end_of_turn>nextGEN"),
-        render_assistant_close_text=lambda messages: (f"{marker} \n<end_of_turn>"),
+        render_prompt_text=lambda messages: f"{marker}<end_of_turn>\nnextGEN",
+        render_assistant_close_text=lambda messages: f"{marker}<end_of_turn>\n",
     )
 
     assert result == expected
@@ -340,13 +351,32 @@ def test_complete_token_injection_rejects_marker_collision() -> None:
             tokenizer=_CompleteTokenTokenizer(),
             conversation=[
                 {
-                    "role": "assistant",
+                    "role": "user",
                     "content": "NEMO_RL_PREFIX_BOUNDARY_7F3A9C1E",
-                }
+                },
+                {
+                    "role": "assistant",
+                    "content": "first",
+                },
             ],
             assistant_ordinal=0,
             model_prefix_token_ids=[31, 32, 2],
             render_prompt_text=_render_marked_conversation,
+        )
+
+
+def test_complete_token_injection_rejects_rendered_marker_collision() -> None:
+    marker = "NEMO_RL_PREFIX_BOUNDARY_7F3A9C1E"
+
+    with pytest.raises(
+        CompleteTokenInjectionError, match="collided with rendered request data"
+    ):
+        build_complete_prompt_token_ids(
+            tokenizer=_CompleteTokenTokenizer(),
+            conversation=[{"role": "assistant", "content": "first"}],
+            assistant_ordinal=0,
+            model_prefix_token_ids=[31, 32, 2],
+            render_prompt_text=lambda messages: f"{marker}{marker}<eos>nextGEN",
         )
 
 
@@ -423,6 +453,91 @@ def test_complete_token_injection_rejects_invalid_render_output(
             model_prefix_token_ids=[31, 32, 2],
             render_prompt_text=lambda messages: rendered,
         )
+
+
+@pytest.mark.parametrize(
+    ("render_assistant_close_text", "expected_error"),
+    [
+        pytest.param(
+            lambda messages: (_ for _ in ()).throw(
+                CompleteTokenInjectionError("probe requested native preprocessing")
+            ),
+            "probe requested native preprocessing",
+            id="native_fallback",
+        ),
+        pytest.param(
+            lambda messages: (_ for _ in ()).throw(RuntimeError("probe failed")),
+            "probe could not be rendered",
+            id="render_failure",
+        ),
+        pytest.param(lambda messages: [], "must render as text", id="non_text"),
+        pytest.param(
+            lambda messages: "missing marker<eos>",
+            "did not preserve the boundary marker",
+            id="missing_marker",
+        ),
+        pytest.param(
+            lambda messages: "NEMO_RL_PREFIX_BOUNDARY_7F3A9C1E \n\t",
+            "did not emit an assistant-close sequence",
+            id="empty_close",
+        ),
+        pytest.param(
+            lambda messages: "NEMO_RL_PREFIX_BOUNDARY_7F3A9C1E<eos>",
+            "assistant-close sequence changed",
+            id="changed_close",
+        ),
+    ],
+)
+def test_complete_token_injection_rejects_invalid_close_probe(
+    render_assistant_close_text, expected_error
+) -> None:
+    marker = "NEMO_RL_PREFIX_BOUNDARY_7F3A9C1E"
+
+    with pytest.raises(CompleteTokenInjectionError, match=expected_error):
+        build_complete_prompt_token_ids(
+            tokenizer=_GemmaStyleTokenizer(),
+            conversation=[
+                {"role": "assistant", "content": "first"},
+                {"role": "user", "content": "next"},
+            ],
+            assistant_ordinal=0,
+            model_prefix_token_ids=[31, 32, 106, 107],
+            render_prompt_text=lambda messages: f"{marker}<end_of_turn>\nnextGEN",
+            render_assistant_close_text=render_assistant_close_text,
+        )
+
+
+@pytest.mark.hf_gated
+def test_complete_token_injection_matches_real_gemma_template() -> None:
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained("google/gemma-3-1b-it")
+    prior_user = {"role": "user", "content": "hello"}
+    prior_assistant = {"role": "assistant", "content": "answer"}
+    next_user = {"role": "user", "content": "next"}
+    conversation = [prior_user, prior_assistant, next_user]
+    first_prompt_token_ids = tokenizer.apply_chat_template(
+        [prior_user], tokenize=True, add_generation_prompt=True
+    )
+    generation_token_ids = tokenizer.encode("answer", add_special_tokens=False)
+    native_token_ids = tokenizer.apply_chat_template(
+        conversation, tokenize=True, add_generation_prompt=True
+    )
+
+    injected_token_ids = build_complete_prompt_token_ids(
+        tokenizer=tokenizer,
+        conversation=conversation,
+        assistant_ordinal=0,
+        model_prefix_token_ids=first_prompt_token_ids + generation_token_ids,
+        render_prompt_text=lambda messages: tokenizer.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True
+        ),
+        render_assistant_close_text=lambda messages: tokenizer.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=False
+        ),
+    )
+
+    assert injected_token_ids == native_token_ids
 
 
 def test_complete_token_injection_requires_tokenizer_eos() -> None:

--- a/tests/unit/models/generation/test_openai_server_utils.py
+++ b/tests/unit/models/generation/test_openai_server_utils.py
@@ -518,11 +518,11 @@ def test_complete_token_injection_matches_real_gemma_template() -> None:
     conversation = [prior_user, prior_assistant, next_user]
     first_prompt_token_ids = tokenizer.apply_chat_template(
         [prior_user], tokenize=True, add_generation_prompt=True
-    )
+    ).input_ids
     generation_token_ids = tokenizer.encode("answer", add_special_tokens=False)
     native_token_ids = tokenizer.apply_chat_template(
         conversation, tokenize=True, add_generation_prompt=True
-    )
+    ).input_ids
 
     injected_token_ids = build_complete_prompt_token_ids(
         tokenizer=tokenizer,

--- a/tests/unit/models/generation/test_openai_server_utils.py
+++ b/tests/unit/models/generation/test_openai_server_utils.py
@@ -50,6 +50,28 @@ class _CompleteTokenTokenizer:
         return token_ids
 
 
+class _GemmaStyleTokenizer(_CompleteTokenTokenizer):
+    eos_token = "<eos>"
+    eos_token_id = 1
+
+    def encode(self, text, add_special_tokens=False):
+        assert add_special_tokens is False
+        token_ids = []
+        while text:
+            if text.startswith("<end_of_turn>"):
+                token_ids.append(106)
+                text = text[len("<end_of_turn>") :]
+            elif text.startswith("next"):
+                token_ids.append(40)
+                text = text[len("next") :]
+            elif text.startswith("GEN"):
+                token_ids.append(99)
+                text = text[len("GEN") :]
+            else:
+                raise AssertionError(f"Unexpected text to encode: {text!r}")
+        return token_ids
+
+
 def _render_marked_conversation(conversation):
     rendered = ""
     for message in conversation:
@@ -104,6 +126,33 @@ def test_build_complete_prompt_token_ids_preserves_prefix_and_suffix() -> None:
 
     assert result == [10, 777, 2, 40, 31, 32, 2, 40, 99]
     assert conversation == original_conversation
+
+
+@pytest.mark.parametrize(
+    ("model_prefix_token_ids", "expected"),
+    [
+        pytest.param([31, 32, 106], [31, 32, 106, 40, 99], id="close_present"),
+        pytest.param([31, 32], [31, 32, 106, 40, 99], id="close_missing"),
+    ],
+)
+def test_complete_token_injection_uses_template_assistant_close(
+    model_prefix_token_ids, expected
+) -> None:
+    marker = "NEMO_RL_PREFIX_BOUNDARY_7F3A9C1E"
+
+    result = build_complete_prompt_token_ids(
+        tokenizer=_GemmaStyleTokenizer(),
+        conversation=[
+            {"role": "assistant", "content": "first"},
+            {"role": "user", "content": "next"},
+        ],
+        assistant_ordinal=0,
+        model_prefix_token_ids=model_prefix_token_ids,
+        render_prompt_text=lambda messages: (f"{marker} \n<end_of_turn>nextGEN"),
+        render_assistant_close_text=lambda messages: (f"{marker} \n<end_of_turn>"),
+    )
+
+    assert result == expected
 
 
 @pytest.mark.parametrize(
@@ -433,11 +482,15 @@ def test_complete_token_injection_wraps_encoding_failure() -> None:
         )
 
 
-def test_complete_token_injection_requires_encoded_suffix_eos() -> None:
+def test_complete_token_injection_requires_encoded_assistant_close() -> None:
     tokenizer = _CompleteTokenTokenizer()
-    tokenizer.encode = lambda text, add_special_tokens=False: [40]
+    tokenizer.encode = lambda text, add_special_tokens=False: (
+        [2] if text == "<eos>" else [40]
+    )
 
-    with pytest.raises(CompleteTokenInjectionError, match="did not begin with EOS"):
+    with pytest.raises(
+        CompleteTokenInjectionError, match="did not begin with the assistant-close"
+    ):
         build_complete_prompt_token_ids(
             tokenizer=tokenizer,
             conversation=[{"role": "assistant", "content": "first"}],

--- a/tests/unit/models/generation/test_openai_server_utils.py
+++ b/tests/unit/models/generation/test_openai_server_utils.py
@@ -15,11 +15,11 @@
 
 import pytest
 
-from nemo_rl.models.generation.openai_server_utils import replace_prefix_tokens
 from nemo_rl.models.generation.openai_server_utils import (
     CompleteTokenInjectionError,
     build_complete_prompt_token_ids,
-    find_latest_tokenized_assistant_ordinal,
+    find_latest_tokenized_assistant,
+    replace_prefix_tokens,
 )
 
 
@@ -45,8 +45,7 @@ class _CompleteTokenTokenizer:
         return token_ids
 
 
-def _render_marked_conversation(conversation, *, tokenize):
-    token_ids = []
+def _render_marked_conversation(conversation):
     rendered = ""
     for message in conversation:
         for tool_call in message.get("tool_calls", []):
@@ -56,20 +55,15 @@ def _render_marked_conversation(conversation, *, tokenize):
         role = message["role"]
         content = message.get("content")
         if role == "user" and content == "hello":
-            token_ids.append(10)
             rendered += "hello"
         elif role == "user" and content == "next":
-            token_ids.append(40)
             rendered += "next"
         elif role == "assistant":
-            token_ids.extend([777, 2])
             rendered += f"{content}<eos>"
         else:
-            token_ids.append(900)
             rendered += "other"
-    token_ids.append(99)
     rendered += "GEN"
-    return token_ids if tokenize else rendered
+    return rendered
 
 
 def test_build_complete_prompt_token_ids_preserves_prefix_and_suffix() -> None:
@@ -84,7 +78,7 @@ def test_build_complete_prompt_token_ids_preserves_prefix_and_suffix() -> None:
                     "type": "function",
                     "function": {
                         "name": "shell",
-                        "arguments": '{"command":"pwd"}',
+                        "arguments": {"command": "pwd"},
                     },
                 }
             ],
@@ -99,30 +93,124 @@ def test_build_complete_prompt_token_ids_preserves_prefix_and_suffix() -> None:
         conversation=conversation,
         assistant_ordinal=1,
         model_prefix_token_ids=[10, 777, 2, 40, 31, 32, 2],
-        render_prompt_text=lambda messages: _render_marked_conversation(
-            messages, tokenize=False
-        ),
+        render_prompt_text=_render_marked_conversation,
     )
 
     assert result == [10, 777, 2, 40, 31, 32, 2, 40, 99]
-    assert conversation[1]["tool_calls"][0]["function"]["arguments"] == (
-        '{"command":"pwd"}'
+    assert conversation[1]["tool_calls"][0]["function"]["arguments"] == {
+        "command": "pwd"
+    }
+
+
+@pytest.mark.parametrize(
+    ("messages", "expected_ordinal", "expected_index"),
+    [
+        pytest.param([], None, None, id="empty"),
+        pytest.param(
+            [
+                {"role": "user", "content": "question"},
+                {"role": "assistant", "content": "answer"},
+            ],
+            None,
+            None,
+            id="no_token_metadata",
+        ),
+        pytest.param(
+            [
+                {
+                    "role": "user",
+                    "content": "question one",
+                    "prompt_token_ids": [90],
+                    "generation_token_ids": [91],
+                },
+                {
+                    "role": "assistant",
+                    "content": "answer one",
+                    "prompt_token_ids": [1],
+                    "generation_token_ids": [2],
+                },
+                {
+                    "role": "tool",
+                    "content": "result",
+                    "prompt_token_ids": [92],
+                    "generation_token_ids": [93],
+                },
+                {"role": "user", "content": "question two"},
+                {
+                    "role": "assistant",
+                    "content": "answer two",
+                    "prompt_token_ids": [3],
+                    "generation_token_ids": [4],
+                },
+                {"role": "user", "content": "question three"},
+            ],
+            1,
+            4,
+            id="latest_assistant_ignores_other_roles",
+        ),
+        pytest.param(
+            [
+                {
+                    "role": "assistant",
+                    "content": "partial",
+                    "prompt_token_ids": [1],
+                }
+            ],
+            None,
+            None,
+            id="partial_metadata",
+        ),
+    ],
+)
+def test_complete_token_injection_finds_latest_tokenized_assistant(
+    messages, expected_ordinal, expected_index
+) -> None:
+    """The selector counts assistant messages and returns the latest full record."""
+    result = find_latest_tokenized_assistant(messages)
+    if expected_ordinal is None:
+        assert result is None
+    else:
+        assert result is not None
+        assistant_ordinal, message = result
+        assert assistant_ordinal == expected_ordinal
+        assert message is messages[expected_index]
+
+
+@pytest.mark.parametrize("gap", ["", " \n\t"])
+def test_complete_token_injection_requires_adjacent_assistant_eos(gap) -> None:
+    tokenizer = _CompleteTokenTokenizer()
+    marker = "NEMO_RL_PREFIX_BOUNDARY_7F3A9C1E"
+
+    result = build_complete_prompt_token_ids(
+        tokenizer=tokenizer,
+        conversation=[
+            {"role": "assistant", "content": "first"},
+            {"role": "user", "content": "next"},
+        ],
+        assistant_ordinal=0,
+        model_prefix_token_ids=[31, 32, 2],
+        render_prompt_text=lambda messages: f"{marker}{gap}<eos>nextGEN",
     )
 
+    assert result == [31, 32, 2, 40, 99]
 
-def test_complete_token_injection_finds_latest_tokenized_assistant() -> None:
-    messages = [
-        {"role": "assistant", "content": "first"},
-        {
-            "role": "assistant",
-            "content": "second",
-            "prompt_token_ids": [1],
-            "generation_token_ids": [2],
-        },
-        {"role": "assistant", "content": "third"},
-    ]
 
-    assert find_latest_tokenized_assistant_ordinal(messages) == 1
+def test_complete_token_injection_rejects_intervening_content_before_eos() -> None:
+    tokenizer = _CompleteTokenTokenizer()
+
+    with pytest.raises(CompleteTokenInjectionError, match="did not close.*immediately"):
+        build_complete_prompt_token_ids(
+            tokenizer=tokenizer,
+            conversation=[
+                {"role": "assistant", "content": "first"},
+                {"role": "user", "content": "next"},
+            ],
+            assistant_ordinal=0,
+            model_prefix_token_ids=[31, 32, 2],
+            render_prompt_text=lambda messages: (
+                "NEMO_RL_PREFIX_BOUNDARY_7F3A9C1Eintervening<eos>nextGEN"
+            ),
+        )
 
 
 def test_complete_token_injection_requires_assistant_eos() -> None:

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -188,7 +188,6 @@ def test_complete_token_injection_eligibility_returns_latest_assistant() -> None
     ordinal, reason = _complete_token_injection_eligibility(
         _complete_token_request(),
         _tokenized_assistant_messages(),
-        has_multimodal_config=False,
         prompt_embeds_enabled=False,
         renderer_supported=True,
         vllm_version_supported=True,
@@ -205,7 +204,6 @@ def test_complete_token_injection_eligibility_accepts_supported_roles(role) -> N
     _, reason = _complete_token_injection_eligibility(
         _complete_token_request(),
         messages,
-        has_multimodal_config=False,
         prompt_embeds_enabled=False,
         renderer_supported=True,
         vllm_version_supported=True,
@@ -252,7 +250,6 @@ def test_complete_token_injection_eligibility_rejects_request_options(
     ordinal, reason = _complete_token_injection_eligibility(
         _complete_token_request(**{field: value}),
         _tokenized_assistant_messages(),
-        has_multimodal_config=False,
         prompt_embeds_enabled=False,
         renderer_supported=True,
         vllm_version_supported=True,
@@ -265,11 +262,6 @@ def test_complete_token_injection_eligibility_rejects_request_options(
 @pytest.mark.parametrize(
     ("helper_updates", "expected_reason"),
     [
-        pytest.param(
-            {"has_multimodal_config": True},
-            "multimodal model",
-            id="multimodal",
-        ),
         pytest.param(
             {"prompt_embeds_enabled": True},
             "prompt embeddings enabled",
@@ -291,7 +283,6 @@ def test_complete_token_injection_eligibility_rejects_model_options(
     helper_updates, expected_reason
 ) -> None:
     helper_args = {
-        "has_multimodal_config": False,
         "prompt_embeds_enabled": False,
         "renderer_supported": True,
         "vllm_version_supported": True,
@@ -346,7 +337,6 @@ def test_complete_token_injection_eligibility_rejects_messages(
     ordinal, reason = _complete_token_injection_eligibility(
         _complete_token_request(),
         messages,
-        has_multimodal_config=False,
         prompt_embeds_enabled=False,
         renderer_supported=True,
         vllm_version_supported=True,
@@ -379,7 +369,6 @@ def test_complete_token_injection_eligibility_rejects_mismatched_prefix(
     ordinal, reason = _complete_token_injection_eligibility(
         _complete_token_request(required_prefix_token_ids=required_prefix_token_ids),
         messages,
-        has_multimodal_config=False,
         prompt_embeds_enabled=False,
         renderer_supported=True,
         vllm_version_supported=True,
@@ -393,7 +382,6 @@ def test_complete_token_injection_eligibility_rejects_slot_swapped_prefix() -> N
     ordinal, reason = _complete_token_injection_eligibility(
         _complete_token_request(required_prefix_token_ids=[12, 13, 14, 10, 11]),
         _tokenized_assistant_messages(),
-        has_multimodal_config=False,
         prompt_embeds_enabled=False,
         renderer_supported=True,
         vllm_version_supported=True,
@@ -598,9 +586,6 @@ def _install_fake_vllm_openai_modules(monkeypatch):
     make_module(
         "vllm.entrypoints.chat_utils",
         load_chat_template=MagicMock(return_value=None),
-    )
-    make_module(
-        "vllm.entrypoints.chat_utils",
         parse_chat_messages_async=AsyncMock(),
     )
     make_module(
@@ -708,7 +693,8 @@ def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch, caplo
         served_model_name="served-model",
         model="model-path",
         max_model_len=128,
-        multimodal_config=None,
+        # A VLM-capable model can use injection when this request has no media.
+        multimodal_config=object(),
         enable_prompt_embeds=False,
     )
     worker.llm = MagicMock(model_config=model_config, renderer=hf_renderer())
@@ -857,6 +843,44 @@ def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch, caplo
         request.max_tokens = None
         return request
 
+    def make_renderer_request(**updates):
+        request = make_request(**updates)
+        request.build_tok_params = MagicMock(return_value={})
+        request.build_chat_params = MagicMock(return_value=chat_params)
+        request.mm_processor_kwargs = None
+        request.cache_salt = None
+        request.tool_choice = "none"
+        request.tools = []
+        return request
+
+    parse_chat_messages = sys.modules[
+        "vllm.entrypoints.chat_utils"
+    ].parse_chat_messages_async
+    for mm_data, mm_uuids in (
+        ({"image": [object()]}, None),
+        (None, {"image": ["image-uuid"]}),
+    ):
+        parse_chat_messages.return_value = (
+            _tokenized_assistant_messages(),
+            mm_data,
+            mm_uuids,
+        )
+        multimodal_result = asyncio.run(
+            renderer.preprocess_chat(
+                request=make_renderer_request(),
+                messages=_tokenized_assistant_messages(),
+                default_template=None,
+                default_template_content_format="auto",
+                default_template_kwargs={},
+            )
+        )
+        assert multimodal_result[1][0]["prompt_token_ids"] == [7]
+    parse_chat_messages.return_value = (
+        _tokenized_assistant_messages(),
+        None,
+        None,
+    )
+
     request = make_request()
     renderer._preprocess_chat_with_complete_token_ids = AsyncMock(
         return_value=(
@@ -877,6 +901,32 @@ def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch, caplo
 
     assert result[1][0]["prompt_token_ids"] == [3, 4, 5]
     assert request.max_completion_tokens == 10
+    renderer._preprocess_chat_with_complete_token_ids.assert_awaited_once()
+
+    media_messages = [
+        *_tokenized_assistant_messages(),
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/image.png"},
+                }
+            ],
+        },
+    ]
+    media_request = make_request()
+    media_result = asyncio.run(
+        renderer.preprocess_chat(
+            request=media_request,
+            messages=media_messages,
+            default_template=None,
+            default_template_content_format="auto",
+            default_template_kwargs={},
+        )
+    )
+    assert media_result[1][0]["prompt_token_ids"] == [7]
+    assert media_request.max_completion_tokens == 10
     renderer._preprocess_chat_with_complete_token_ids.assert_awaited_once()
 
     error_request = make_request(
@@ -958,9 +1008,11 @@ def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch, caplo
     )
 
     assert worker._get_complete_token_injection_stats() == {
-        "attempts": 5,
+        "attempts": 8,
         "successes": 1,
         "fallbacks": {
+            "Multimodal chat data requires native preprocessing.": 2,
+            "non-text message content": 1,
             "streaming request": 1,
             "test fallback": 2,
             "test injection error": 1,

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -19,6 +19,7 @@ import sys
 import types
 from copy import deepcopy
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -153,6 +154,7 @@ def _complete_token_request(**updates):
         "return_assistant_tokens_mask": False,
         "add_special_tokens": False,
         "return_prompt_text": False,
+        "required_prefix_token_ids": [3, 4],
     }
     values.update(updates)
     return types.SimpleNamespace(**values)
@@ -287,9 +289,14 @@ def test_complete_token_injection_eligibility_rejects_model_options(
             id="unsupported_role",
         ),
         pytest.param(
-            [{"role": "user", "content": ["text"]}],
+            [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "question"}],
+                }
+            ],
             "non-text message content",
-            id="non_text_content",
+            id="responses_text_parts",
         ),
         pytest.param(
             [
@@ -317,6 +324,19 @@ def test_complete_token_injection_eligibility_rejects_messages(
 
     assert ordinal is None
     assert reason == expected_reason
+
+
+def test_complete_token_injection_eligibility_rejects_mismatched_prefix() -> None:
+    ordinal, reason = _complete_token_injection_eligibility(
+        _complete_token_request(required_prefix_token_ids=[1, 2]),
+        _tokenized_assistant_messages(),
+        has_multimodal_config=False,
+        prompt_embeds_enabled=False,
+        renderer_supported=True,
+    )
+
+    assert ordinal is None
+    assert reason == "client-supplied prefix does not match message token metadata"
 
 
 def test_context_capped_max_new_tokens():
@@ -1865,6 +1885,25 @@ def _wait_for_vllm_http_server_spinup(base_url: str):
             pass
 
 
+def _get_complete_token_injection_stats(
+    vllm_generation: VllmGeneration,
+) -> dict[str, Any]:
+    futures = vllm_generation.worker_group.run_all_workers_single_data(
+        "_get_complete_token_injection_stats",
+        run_rank_0_only_axes=["tensor_parallel", "pipeline_parallel"],
+    )
+    worker_stats = ray.get(futures)
+    fallback_counts: dict[str, int] = {}
+    for stats in worker_stats:
+        for reason, count in stats["fallbacks"].items():
+            fallback_counts[reason] = fallback_counts.get(reason, 0) + count
+    return {
+        "attempts": sum(stats["attempts"] for stats in worker_stats),
+        "successes": sum(stats["successes"] for stats in worker_stats),
+        "fallbacks": fallback_counts,
+    }
+
+
 def test_vllm_http_server(cluster, tokenizer):
     """Test that vLLM http server works."""
 
@@ -2331,7 +2370,8 @@ async def test_vllm_http_server_correct_merged_tokens_matches_baseline(
         vllm_http_server_generated_token["token"].removeprefix("token_id:")
     )
 
-    # Compare the injected continuation prompt with the native /tokenize path.
+    # Compare the injected continuation prompt with the legacy /tokenize
+    # prefix-replacement path.
     first_message = vllm_http_server_result["choices"][0]["message"]
     continuation_messages = [
         body["messages"][0],
@@ -2360,6 +2400,7 @@ async def test_vllm_http_server_correct_merged_tokens_matches_baseline(
     }
     native_response = requests.post(url=f"{base_urls[0]}/../tokenize", json=native_body)
     native_response.raise_for_status()
+    stats_before_injection = _get_complete_token_injection_stats(vllm_generation)
     injected_response = requests.post(
         url=f"{base_urls[0]}/chat/completions", json=continuation_body
     )
@@ -2368,6 +2409,10 @@ async def test_vllm_http_server_correct_merged_tokens_matches_baseline(
         injected_response.json()["choices"][0]["message"]["prompt_token_ids"]
         == native_response.json()["tokens"]
     )
+    stats_after_injection = _get_complete_token_injection_stats(vllm_generation)
+    assert stats_after_injection["attempts"] == stats_before_injection["attempts"] + 1
+    assert stats_after_injection["successes"] == stats_before_injection["successes"] + 1
+    assert stats_after_injection["fallbacks"] == stats_before_injection["fallbacks"]
 
     async for _, generate_result in vllm_generation.generate_async(
         BatchedDataDict[GenerationDatumSpec](

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -239,6 +239,7 @@ def _install_fake_vllm_openai_modules(monkeypatch):
     for module_name in (
         "vllm",
         "vllm.entrypoints",
+        "vllm.entrypoints.chat_utils",
         "vllm.entrypoints.openai",
         "vllm.entrypoints.openai.chat_completion",
         "vllm.entrypoints.openai.engine",
@@ -250,6 +251,7 @@ def _install_fake_vllm_openai_modules(monkeypatch):
         "vllm.tool_parsers",
         "vllm.v1",
         "vllm.v1.engine",
+        "vllm.utils",
     ):
         monkeypatch.setitem(sys.modules, module_name, types.ModuleType(module_name))
 
@@ -304,6 +306,10 @@ def _install_fake_vllm_openai_modules(monkeypatch):
         load_chat_template=MagicMock(return_value=None),
     )
     make_module(
+        "vllm.entrypoints.chat_utils",
+        parse_chat_messages_async=MagicMock(),
+    )
+    make_module(
         "vllm.entrypoints.openai.chat_completion.protocol",
         ChatCompletionRequest=type("ChatCompletionRequest", (), {}),
         ChatCompletionResponse=type("ChatCompletionResponse", (), {}),
@@ -334,6 +340,13 @@ def _install_fake_vllm_openai_modules(monkeypatch):
         "vllm.renderers.online_renderer",
         OnlineRenderer=OnlineRenderer,
     )
+    sys.modules["vllm.renderers"].merge_kwargs = MagicMock()
+    make_module(
+        "vllm.renderers.hf",
+        HfRenderer=type("HfRenderer", (), {}),
+        resolve_chat_template_content_format=MagicMock(),
+        safe_apply_chat_template=MagicMock(),
+    )
     make_module(
         "vllm.entrypoints.serve.tokenize.serving",
         ServingTokenization=ServingTokenization,
@@ -346,6 +359,11 @@ def _install_fake_vllm_openai_modules(monkeypatch):
     make_module(
         "vllm.tool_parsers.abstract_tool_parser",
         ToolParserManager=ToolParserManager,
+    )
+    make_module(
+        "vllm.utils.mistral",
+        is_mistral_tokenizer=MagicMock(return_value=False),
+        is_mistral_tool_parser=MagicMock(return_value=False),
     )
     make_module("vllm.v1.engine.async_llm", logger=MagicMock())
     return ToolParserManager, ReasoningParserManager, OpenAIServingChat
@@ -2135,6 +2153,33 @@ async def test_vllm_http_server_correct_merged_tokens_matches_baseline(
     ]["content"][0]
     vllm_http_server_generated_token_id = int(
         vllm_http_server_generated_token["token"].removeprefix("token_id:")
+    )
+
+    # Compare the injected continuation prompt with the native /tokenize path.
+    first_message = vllm_http_server_result["choices"][0]["message"]
+    continuation_messages = [
+        body["messages"][0],
+        {
+            "role": "assistant",
+            "content": first_message["content"],
+            "prompt_token_ids": first_message["prompt_token_ids"],
+            "generation_token_ids": first_message["generation_token_ids"],
+            "generation_log_probs": first_message["generation_log_probs"],
+        },
+        {"role": "user", "content": " next"},
+    ]
+    continuation_body = body | {"messages": continuation_messages}
+    native_response = requests.post(
+        url=f"{base_urls[0]}/../tokenize", json=continuation_body
+    )
+    native_response.raise_for_status()
+    injected_response = requests.post(
+        url=f"{base_urls[0]}/chat/completions", json=continuation_body
+    )
+    injected_response.raise_for_status()
+    assert (
+        injected_response.json()["choices"][0]["message"]["prompt_token_ids"]
+        == native_response.json()["tokens"]
     )
 
     async for _, generate_result in vllm_generation.generate_async(

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -41,13 +41,14 @@ from nemo_rl.models.generation.openai_server_utils import (
     CompleteTokenInjectionError,
     replace_prefix_tokens,
 )
-from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration
+from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration, vllm_worker_async
 from nemo_rl.models.generation.vllm.vllm_worker import (
     VllmGenerationWorkerImpl,
     _context_capped_max_new_tokens,
     _resolve_enable_prefix_caching,
 )
 from nemo_rl.models.generation.vllm.vllm_worker_async import (
+    COMPLETE_TOKEN_INJECTION_VLLM_VERSION,
     VllmAsyncGenerationWorkerImpl,
     _complete_token_injection_eligibility,
 )
@@ -190,6 +191,7 @@ def test_complete_token_injection_eligibility_returns_latest_assistant() -> None
         has_multimodal_config=False,
         prompt_embeds_enabled=False,
         renderer_supported=True,
+        vllm_version_supported=True,
     )
 
     assert ordinal == 1
@@ -206,6 +208,7 @@ def test_complete_token_injection_eligibility_accepts_supported_roles(role) -> N
         has_multimodal_config=False,
         prompt_embeds_enabled=False,
         renderer_supported=True,
+        vllm_version_supported=True,
     )
 
     assert reason is None
@@ -252,6 +255,7 @@ def test_complete_token_injection_eligibility_rejects_request_options(
         has_multimodal_config=False,
         prompt_embeds_enabled=False,
         renderer_supported=True,
+        vllm_version_supported=True,
     )
 
     assert ordinal is None
@@ -345,19 +349,40 @@ def test_complete_token_injection_eligibility_rejects_messages(
         has_multimodal_config=False,
         prompt_embeds_enabled=False,
         renderer_supported=True,
+        vllm_version_supported=True,
     )
 
     assert ordinal is None
     assert reason == expected_reason
 
 
-def test_complete_token_injection_eligibility_rejects_mismatched_prefix() -> None:
+@pytest.mark.parametrize(
+    ("required_prefix_token_ids", "message_updates"),
+    [
+        pytest.param(None, {}, id="none"),
+        pytest.param([], {}, id="empty"),
+        pytest.param((10, 11, 12, 13, 14), {}, id="non_list"),
+        pytest.param([10, 11, 12, 13, True], {}, id="boolean_token"),
+        pytest.param(
+            [10, 11, 12, 13, 14],
+            {"generation_token_ids": [12, 13, "14"]},
+            id="invalid_message_token",
+        ),
+        pytest.param([1, 2], {}, id="different_tokens"),
+    ],
+)
+def test_complete_token_injection_eligibility_rejects_mismatched_prefix(
+    required_prefix_token_ids, message_updates
+) -> None:
+    messages = _tokenized_assistant_messages()
+    messages[-1].update(message_updates)
     ordinal, reason = _complete_token_injection_eligibility(
-        _complete_token_request(required_prefix_token_ids=[1, 2]),
-        _tokenized_assistant_messages(),
+        _complete_token_request(required_prefix_token_ids=required_prefix_token_ids),
+        messages,
         has_multimodal_config=False,
         prompt_embeds_enabled=False,
         renderer_supported=True,
+        vllm_version_supported=True,
     )
 
     assert ordinal is None
@@ -371,10 +396,18 @@ def test_complete_token_injection_eligibility_rejects_slot_swapped_prefix() -> N
         has_multimodal_config=False,
         prompt_embeds_enabled=False,
         renderer_supported=True,
+        vllm_version_supported=True,
     )
 
     assert ordinal is None
     assert reason == "client-supplied prefix does not match message token metadata"
+
+
+@pytest.mark.vllm
+def test_complete_token_injection_vllm_version_matches_installed_package() -> None:
+    import vllm
+
+    assert vllm.__version__ == COMPLETE_TOKEN_INJECTION_VLLM_VERSION
 
 
 def test_context_capped_max_new_tokens():
@@ -488,7 +521,7 @@ def _install_fake_vllm_openai_modules(monkeypatch):
         "vllm.utils",
     ):
         monkeypatch.setitem(sys.modules, module_name, types.ModuleType(module_name))
-    sys.modules["vllm"].__version__ = "0.25.1"
+    sys.modules["vllm"].__version__ = COMPLETE_TOKEN_INJECTION_VLLM_VERSION
 
     def make_module(name: str, **attrs):
         module = types.ModuleType(name)
@@ -505,6 +538,15 @@ def _install_fake_vllm_openai_modules(monkeypatch):
         def __init__(self, **kwargs):
             self.kwargs = kwargs
             self.registry = "registry"
+
+    class ChatCompletionRequest:
+        def model_post_init(self, context):
+            return context
+
+        def model_copy(self, *, update):
+            copied_request = type(self)()
+            vars(copied_request).update(vars(self) | update)
+            return copied_request
 
     class OnlineRenderer:
         def __init__(self, **kwargs):
@@ -563,7 +605,7 @@ def _install_fake_vllm_openai_modules(monkeypatch):
     )
     make_module(
         "vllm.entrypoints.openai.chat_completion.protocol",
-        ChatCompletionRequest=type("ChatCompletionRequest", (), {}),
+        ChatCompletionRequest=ChatCompletionRequest,
         ChatCompletionResponse=type("ChatCompletionResponse", (), {}),
     )
     make_module(
@@ -635,6 +677,7 @@ class _FakeFastAPIApp:
 
 
 def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch, caplog):
+    caplog.set_level("INFO", logger="nemo_rl.models.generation.vllm.vllm_worker_async")
     (
         tool_parser_manager,
         reasoning_parser_manager,
@@ -673,6 +716,8 @@ def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch, caplo
     worker.llm_async_engine_args.create_model_config.return_value = model_config
 
     app = _FakeFastAPIApp()
+    # Ray may omit globals used only in annotations when it serializes the worker.
+    monkeypatch.delattr(vllm_worker_async, "Any")
     assert worker._setup_vllm_openai_api_server(app) is app
 
     tool_parser_manager.import_tool_parser.assert_called_once_with(
@@ -690,10 +735,29 @@ def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch, caplo
     renderer._record_complete_token_injection_fallback("test fallback")
     assert (
         caplog.messages.count(
-            "Complete-token injection fell back to native preprocessing: test fallback"
+            "Complete-token injection fell back to native preprocessing: "
+            "test fallback; statistics: "
+            '{"attempts": 0, "fallbacks": {"test fallback": 1}, "successes": 0}'
         )
         == 1
     )
+    renderer._complete_token_injection_attempts = 1
+    renderer._maybe_log_complete_token_injection_stats()
+    renderer._complete_token_injection_attempts = 2
+    renderer._maybe_log_complete_token_injection_stats()
+    renderer._complete_token_injection_attempts = 1000
+    renderer._maybe_log_complete_token_injection_stats()
+    assert (
+        len(
+            [
+                message
+                for message in caplog.messages
+                if message.startswith("Complete-token injection statistics:")
+            ]
+        )
+        == 2
+    )
+    renderer._complete_token_injection_attempts = 0
 
     tokenizer = object()
     worker.llm.renderer.get_tokenizer = MagicMock(return_value=tokenizer)
@@ -770,9 +834,20 @@ def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch, caplo
 
     assert direct_result[1][0]["prompt_token_ids"] == [3, 4, 5]
     parser.return_value.adjust_request.assert_called_once_with(request=direct_request)
+    close_render_call = sys.modules[
+        "vllm.renderers.hf"
+    ].safe_apply_chat_template.call_args_list[-1]
+    assert close_render_call.kwargs["add_generation_prompt"] is False
+    assert close_render_call.kwargs["tokenize"] is False
 
     chat_route = dict(app.routes)["/v1/chat/completions"]
     request_type = chat_route.__annotations__["request"]
+
+    auto_prefix_request = request_type()
+    auto_prefix_request.required_prefix_token_ids = None
+    auto_prefix_request.messages = _tokenized_assistant_messages()
+    assert auto_prefix_request.model_post_init("context") == "context"
+    assert auto_prefix_request.required_prefix_token_ids == [10, 11, 12, 13, 14]
 
     def make_request(**updates):
         request = request_type()
@@ -801,6 +876,7 @@ def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch, caplo
     )
 
     assert result[1][0]["prompt_token_ids"] == [3, 4, 5]
+    assert request.max_completion_tokens == 10
     renderer._preprocess_chat_with_complete_token_ids.assert_awaited_once()
 
     error_request = make_request(
@@ -821,27 +897,31 @@ def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch, caplo
         )
     assert error_request.max_completion_tokens == 10
 
+    streaming_request = make_request(stream=True)
     asyncio.run(
         renderer.preprocess_chat(
-            request=make_request(stream=True),
+            request=streaming_request,
             messages=_tokenized_assistant_messages(),
             default_template=None,
             default_template_content_format="auto",
             default_template_kwargs={},
         )
     )
+    assert streaming_request.max_completion_tokens == 10
     renderer._preprocess_chat_with_complete_token_ids = AsyncMock(
         side_effect=CompleteTokenInjectionError("test injection error")
     )
+    injection_fallback_request = make_request()
     asyncio.run(
         renderer.preprocess_chat(
-            request=make_request(),
+            request=injection_fallback_request,
             messages=_tokenized_assistant_messages(),
             default_template=None,
             default_template_content_format="auto",
             default_template_kwargs={},
         )
     )
+    assert injection_fallback_request.max_completion_tokens == 10
     renderer._preprocess_chat_with_complete_token_ids = AsyncMock(
         side_effect=RuntimeError("unexpected injection error")
     )
@@ -858,13 +938,33 @@ def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch, caplo
         )
     assert unexpected_error_request.max_completion_tokens == 10
 
+    version_request = make_request()
+    sys.modules["vllm"].__version__ = "0.25.1+local"
+    asyncio.run(
+        renderer.preprocess_chat(
+            request=version_request,
+            messages=_tokenized_assistant_messages(),
+            default_template=None,
+            default_template_content_format="auto",
+            default_template_kwargs={},
+        )
+    )
+    assert version_request.max_completion_tokens == 10
+    sys.modules["vllm"].__version__ = COMPLETE_TOKEN_INJECTION_VLLM_VERSION
+    assert any(
+        "unsupported vLLM version "
+        "(detected '0.25.1+local', expected '0.25.1')" in message
+        for message in caplog.messages
+    )
+
     assert worker._get_complete_token_injection_stats() == {
-        "attempts": 4,
+        "attempts": 5,
         "successes": 1,
         "fallbacks": {
             "streaming request": 1,
             "test fallback": 2,
             "test injection error": 1,
+            "unsupported vLLM version": 1,
         },
     }
 

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -158,7 +158,7 @@ def _complete_token_request(**updates):
         "return_assistant_tokens_mask": False,
         "add_special_tokens": False,
         "return_prompt_text": False,
-        "required_prefix_token_ids": [3, 4],
+        "required_prefix_token_ids": [10, 11, 12, 13, 14],
     }
     values.update(updates)
     return types.SimpleNamespace(**values)
@@ -177,8 +177,8 @@ def _tokenized_assistant_messages():
         {
             "role": "assistant",
             "content": "answer two",
-            "prompt_token_ids": [3],
-            "generation_token_ids": [4],
+            "prompt_token_ids": [10, 11],
+            "generation_token_ids": [12, 13, 14],
         },
     ]
 
@@ -193,6 +193,21 @@ def test_complete_token_injection_eligibility_returns_latest_assistant() -> None
     )
 
     assert ordinal == 1
+    assert reason is None
+
+
+@pytest.mark.parametrize("role", ["system", "user", "assistant", "tool"])
+def test_complete_token_injection_eligibility_accepts_supported_roles(role) -> None:
+    messages = [{"role": role, "content": "text"}, *_tokenized_assistant_messages()]
+
+    _, reason = _complete_token_injection_eligibility(
+        _complete_token_request(),
+        messages,
+        has_multimodal_config=False,
+        prompt_embeds_enabled=False,
+        renderer_supported=True,
+    )
+
     assert reason is None
 
 
@@ -261,6 +276,11 @@ def test_complete_token_injection_eligibility_rejects_request_options(
             "unsupported renderer",
             id="renderer",
         ),
+        pytest.param(
+            {"vllm_version_supported": False},
+            "unsupported vLLM version",
+            id="vllm_version",
+        ),
     ],
 )
 def test_complete_token_injection_eligibility_rejects_model_options(
@@ -270,6 +290,7 @@ def test_complete_token_injection_eligibility_rejects_model_options(
         "has_multimodal_config": False,
         "prompt_embeds_enabled": False,
         "renderer_supported": True,
+        "vllm_version_supported": True,
     }
     helper_args.update(helper_updates)
 
@@ -333,6 +354,19 @@ def test_complete_token_injection_eligibility_rejects_messages(
 def test_complete_token_injection_eligibility_rejects_mismatched_prefix() -> None:
     ordinal, reason = _complete_token_injection_eligibility(
         _complete_token_request(required_prefix_token_ids=[1, 2]),
+        _tokenized_assistant_messages(),
+        has_multimodal_config=False,
+        prompt_embeds_enabled=False,
+        renderer_supported=True,
+    )
+
+    assert ordinal is None
+    assert reason == "client-supplied prefix does not match message token metadata"
+
+
+def test_complete_token_injection_eligibility_rejects_slot_swapped_prefix() -> None:
+    ordinal, reason = _complete_token_injection_eligibility(
+        _complete_token_request(required_prefix_token_ids=[12, 13, 14, 10, 11]),
         _tokenized_assistant_messages(),
         has_multimodal_config=False,
         prompt_embeds_enabled=False,
@@ -454,6 +488,7 @@ def _install_fake_vllm_openai_modules(monkeypatch):
         "vllm.utils",
     ):
         monkeypatch.setitem(sys.modules, module_name, types.ModuleType(module_name))
+    sys.modules["vllm"].__version__ = "0.25.1"
 
     def make_module(name: str, **attrs):
         module = types.ModuleType(name)
@@ -478,6 +513,15 @@ def _install_fake_vllm_openai_modules(monkeypatch):
             self.renderer = kwargs["renderer"]
 
         async def preprocess_chat(self, request, messages, **kwargs):
+            if getattr(request, "raise_context_error", False):
+                raise VLLMValidationError(
+                    "This model's maximum context length is 128 tokens. However, "
+                    f"you requested {request.max_completion_tokens} output tokens "
+                    "and your prompt contains at least 128 input tokens, for a total "
+                    f"of at least {128 + request.max_completion_tokens} tokens.",
+                    parameter="input_tokens",
+                    value=128,
+                )
             request.required_prefix_token_ids = None
             return messages, [{"prompt_token_ids": [7]}]
 
@@ -496,7 +540,10 @@ def _install_fake_vllm_openai_modules(monkeypatch):
             self.instances.append(self)
 
     class VLLMValidationError(Exception):
-        pass
+        def __init__(self, message, *, parameter=None, value=None):
+            super().__init__(message)
+            self.parameter = parameter
+            self.value = value
 
     class ToolParserManager:
         import_tool_parser = MagicMock()
@@ -512,7 +559,7 @@ def _install_fake_vllm_openai_modules(monkeypatch):
     )
     make_module(
         "vllm.entrypoints.chat_utils",
-        parse_chat_messages_async=MagicMock(),
+        parse_chat_messages_async=AsyncMock(),
     )
     make_module(
         "vllm.entrypoints.openai.chat_completion.protocol",
@@ -648,6 +695,82 @@ def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch, caplo
         == 1
     )
 
+    tokenizer = object()
+    worker.llm.renderer.get_tokenizer = MagicMock(return_value=tokenizer)
+    worker.llm.renderer.tokenize_prompt_async = AsyncMock(
+        return_value={"prompt_token_ids": [3, 4, 5]}
+    )
+    worker.llm.renderer.process_for_engine_async = AsyncMock(
+        return_value={"prompt_token_ids": [3, 4, 5]}
+    )
+    sys.modules["vllm.renderers"].merge_kwargs.side_effect = (
+        lambda defaults, extras: defaults | extras
+    )
+    sys.modules[
+        "vllm.entrypoints.chat_utils"
+    ].parse_chat_messages_async.return_value = (
+        _tokenized_assistant_messages(),
+        None,
+        None,
+    )
+    sys.modules[
+        "vllm.renderers.hf"
+    ].resolve_chat_template_content_format.return_value = "string"
+    sys.modules["vllm.renderers.hf"].safe_apply_chat_template.side_effect = [
+        "marked prompt",
+        "assistant close",
+    ]
+
+    def build_prompt_token_ids(**kwargs):
+        assert kwargs["tokenizer"] is tokenizer
+        assert kwargs["render_prompt_text"](kwargs["conversation"]) == "marked prompt"
+        assert (
+            kwargs["render_assistant_close_text"](kwargs["conversation"])
+            == "assistant close"
+        )
+        return [3, 4, 5]
+
+    monkeypatch.setattr(
+        "nemo_rl.models.generation.vllm.vllm_worker_async.build_complete_prompt_token_ids",
+        build_prompt_token_ids,
+    )
+
+    chat_params = MagicMock(
+        return_assistant_tokens_mask=False,
+        chat_template="template",
+        chat_template_content_format="auto",
+        chat_template_kwargs={},
+        media_io_kwargs=None,
+        mm_processor_kwargs=None,
+    )
+    chat_params.with_defaults.return_value = chat_params
+    chat_params.get_apply_chat_template_kwargs.return_value = {"tokenize": True}
+    direct_request = _complete_token_request()
+    direct_request.build_tok_params = MagicMock(return_value={})
+    direct_request.build_chat_params = MagicMock(return_value=chat_params)
+    direct_request.mm_processor_kwargs = {"size": 1}
+    direct_request.cache_salt = "salt"
+    direct_request.tool_choice = "none"
+    direct_request.tools = []
+    parser = MagicMock(tool_parser_cls=None, reasoning_parser_cls=object())
+
+    direct_result = asyncio.run(
+        renderer._preprocess_chat_with_complete_token_ids(
+            request=direct_request,
+            messages=_tokenized_assistant_messages(),
+            default_template=None,
+            default_template_content_format="auto",
+            default_template_kwargs={},
+            tool_dicts=[],
+            parser=parser,
+            assistant_ordinal=1,
+            skip_mm_cache=False,
+        )
+    )
+
+    assert direct_result[1][0]["prompt_token_ids"] == [3, 4, 5]
+    parser.return_value.adjust_request.assert_called_once_with(request=direct_request)
+
     chat_route = dict(app.routes)["/v1/chat/completions"]
     request_type = chat_route.__annotations__["request"]
 
@@ -680,6 +803,24 @@ def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch, caplo
     assert result[1][0]["prompt_token_ids"] == [3, 4, 5]
     renderer._preprocess_chat_with_complete_token_ids.assert_awaited_once()
 
+    error_request = make_request(
+        required_prefix_token_ids=None, raise_context_error=True
+    )
+    with pytest.raises(
+        sys.modules["vllm.exceptions"].VLLMValidationError,
+        match="requested 10 output tokens",
+    ):
+        asyncio.run(
+            renderer.preprocess_chat(
+                request=error_request,
+                messages=_tokenized_assistant_messages(),
+                default_template=None,
+                default_template_content_format="auto",
+                default_template_kwargs={},
+            )
+        )
+    assert error_request.max_completion_tokens == 10
+
     asyncio.run(
         renderer.preprocess_chat(
             request=make_request(stream=True),
@@ -701,9 +842,24 @@ def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch, caplo
             default_template_kwargs={},
         )
     )
+    renderer._preprocess_chat_with_complete_token_ids = AsyncMock(
+        side_effect=RuntimeError("unexpected injection error")
+    )
+    unexpected_error_request = make_request()
+    with pytest.raises(RuntimeError, match="unexpected injection error"):
+        asyncio.run(
+            renderer.preprocess_chat(
+                request=unexpected_error_request,
+                messages=_tokenized_assistant_messages(),
+                default_template=None,
+                default_template_content_format="auto",
+                default_template_kwargs={},
+            )
+        )
+    assert unexpected_error_request.max_completion_tokens == 10
 
     assert worker._get_complete_token_injection_stats() == {
-        "attempts": 3,
+        "attempts": 4,
         "successes": 1,
         "fallbacks": {
             "streaming request": 1,

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -44,6 +44,7 @@ from nemo_rl.models.generation.vllm.vllm_worker import (
 )
 from nemo_rl.models.generation.vllm.vllm_worker_async import (
     VllmAsyncGenerationWorkerImpl,
+    _complete_token_injection_eligibility,
 )
 from nemo_rl.models.policy import LoRAConfig, PolicyConfig
 from nemo_rl.models.policy.lm_policy import Policy
@@ -141,6 +142,181 @@ basic_dtensor_test_config: PolicyConfig = {
     "make_sequence_length_divisible_by": 1,
     "generation": deepcopy(basic_vllm_test_config),
 }
+
+
+def _complete_token_request(**updates):
+    values = {
+        "stream": False,
+        "n": 1,
+        "continue_final_message": False,
+        "echo": False,
+        "return_assistant_tokens_mask": False,
+        "add_special_tokens": False,
+        "return_prompt_text": False,
+    }
+    values.update(updates)
+    return types.SimpleNamespace(**values)
+
+
+def _tokenized_assistant_messages():
+    return [
+        {"role": "user", "content": "question one"},
+        {
+            "role": "assistant",
+            "content": "answer one",
+            "prompt_token_ids": [1],
+            "generation_token_ids": [2],
+        },
+        {"role": "user", "content": "question two"},
+        {
+            "role": "assistant",
+            "content": "answer two",
+            "prompt_token_ids": [3],
+            "generation_token_ids": [4],
+        },
+    ]
+
+
+def test_complete_token_injection_eligibility_returns_latest_assistant() -> None:
+    ordinal, reason = _complete_token_injection_eligibility(
+        _complete_token_request(),
+        _tokenized_assistant_messages(),
+        has_multimodal_config=False,
+        prompt_embeds_enabled=False,
+        renderer_supported=True,
+    )
+
+    assert ordinal == 1
+    assert reason is None
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected_reason"),
+    [
+        pytest.param("stream", True, "streaming request", id="stream"),
+        pytest.param("n", 2, "multiple response choices", id="multiple_choices"),
+        pytest.param(
+            "continue_final_message",
+            True,
+            "continue_final_message request",
+            id="continue_final_message",
+        ),
+        pytest.param("echo", True, "echo request", id="echo"),
+        pytest.param(
+            "return_assistant_tokens_mask",
+            True,
+            "assistant token mask request",
+            id="assistant_token_mask",
+        ),
+        pytest.param(
+            "add_special_tokens",
+            True,
+            "add_special_tokens request",
+            id="add_special_tokens",
+        ),
+        pytest.param(
+            "return_prompt_text",
+            True,
+            "return_prompt_text request",
+            id="return_prompt_text",
+        ),
+    ],
+)
+def test_complete_token_injection_eligibility_rejects_request_options(
+    field, value, expected_reason
+) -> None:
+    ordinal, reason = _complete_token_injection_eligibility(
+        _complete_token_request(**{field: value}),
+        _tokenized_assistant_messages(),
+        has_multimodal_config=False,
+        prompt_embeds_enabled=False,
+        renderer_supported=True,
+    )
+
+    assert ordinal is None
+    assert reason == expected_reason
+
+
+@pytest.mark.parametrize(
+    ("helper_updates", "expected_reason"),
+    [
+        pytest.param(
+            {"has_multimodal_config": True},
+            "multimodal model",
+            id="multimodal",
+        ),
+        pytest.param(
+            {"prompt_embeds_enabled": True},
+            "prompt embeddings enabled",
+            id="prompt_embeds",
+        ),
+        pytest.param(
+            {"renderer_supported": False},
+            "unsupported renderer",
+            id="renderer",
+        ),
+    ],
+)
+def test_complete_token_injection_eligibility_rejects_model_options(
+    helper_updates, expected_reason
+) -> None:
+    helper_args = {
+        "has_multimodal_config": False,
+        "prompt_embeds_enabled": False,
+        "renderer_supported": True,
+    }
+    helper_args.update(helper_updates)
+
+    ordinal, reason = _complete_token_injection_eligibility(
+        _complete_token_request(),
+        _tokenized_assistant_messages(),
+        **helper_args,
+    )
+
+    assert ordinal is None
+    assert reason == expected_reason
+
+
+@pytest.mark.parametrize(
+    ("messages", "expected_reason"),
+    [
+        pytest.param(["invalid"], "non-object message", id="non_object"),
+        pytest.param(
+            [{"role": "developer", "content": "text"}],
+            "unsupported message role",
+            id="unsupported_role",
+        ),
+        pytest.param(
+            [{"role": "user", "content": ["text"]}],
+            "non-text message content",
+            id="non_text_content",
+        ),
+        pytest.param(
+            [
+                {
+                    "role": "assistant",
+                    "content": "partial",
+                    "prompt_token_ids": [1],
+                }
+            ],
+            "no fully tokenized assistant",
+            id="partial_metadata",
+        ),
+    ],
+)
+def test_complete_token_injection_eligibility_rejects_messages(
+    messages, expected_reason
+) -> None:
+    ordinal, reason = _complete_token_injection_eligibility(
+        _complete_token_request(),
+        messages,
+        has_multimodal_config=False,
+        prompt_embeds_enabled=False,
+        renderer_supported=True,
+    )
+
+    assert ordinal is None
+    assert reason == expected_reason
 
 
 def test_context_capped_max_new_tokens():
@@ -2166,12 +2342,23 @@ async def test_vllm_http_server_correct_merged_tokens_matches_baseline(
             "generation_token_ids": first_message["generation_token_ids"],
             "generation_log_probs": first_message["generation_log_probs"],
         },
-        {"role": "user", "content": " next"},
+        {
+            "role": "user",
+            "content": " next",
+            # Non-assistant metadata must not replace the assistant prefix.
+            "prompt_token_ids": [12345],
+            "generation_token_ids": [67890],
+        },
     ]
     continuation_body = body | {"messages": continuation_messages}
-    native_response = requests.post(
-        url=f"{base_urls[0]}/../tokenize", json=continuation_body
-    )
+    expected_required_prefix_token_ids = [
+        *first_message["prompt_token_ids"],
+        *first_message["generation_token_ids"],
+    ]
+    native_body = continuation_body | {
+        "required_prefix_token_ids": expected_required_prefix_token_ids
+    }
+    native_response = requests.post(url=f"{base_urls[0]}/../tokenize", json=native_body)
     native_response.raise_for_status()
     injected_response = requests.post(
         url=f"{base_urls[0]}/chat/completions", json=continuation_body

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import importlib.util
 import json
 import os
@@ -20,7 +21,7 @@ import types
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import ray
@@ -36,7 +37,10 @@ from nemo_rl.models.generation import configure_generation_config
 from nemo_rl.models.generation.interfaces import (
     GenerationDatumSpec,
 )
-from nemo_rl.models.generation.openai_server_utils import replace_prefix_tokens
+from nemo_rl.models.generation.openai_server_utils import (
+    CompleteTokenInjectionError,
+    replace_prefix_tokens,
+)
 from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration
 from nemo_rl.models.generation.vllm.vllm_worker import (
     VllmGenerationWorkerImpl,
@@ -470,7 +474,12 @@ def _install_fake_vllm_openai_modules(monkeypatch):
     class OnlineRenderer:
         def __init__(self, **kwargs):
             self.kwargs = kwargs
+            self.model_config = kwargs["model_config"]
             self.renderer = kwargs["renderer"]
+
+        async def preprocess_chat(self, request, messages, **kwargs):
+            request.required_prefix_token_ids = None
+            return messages, [{"prompt_token_ids": [7]}]
 
     class OpenAIServingChat:
         instances = []
@@ -537,9 +546,10 @@ def _install_fake_vllm_openai_modules(monkeypatch):
         OnlineRenderer=OnlineRenderer,
     )
     sys.modules["vllm.renderers"].merge_kwargs = MagicMock()
+    hf_renderer = type("HfRenderer", (), {})
     make_module(
         "vllm.renderers.hf",
-        HfRenderer=type("HfRenderer", (), {}),
+        HfRenderer=hf_renderer,
         resolve_chat_template_content_format=MagicMock(),
         safe_apply_chat_template=MagicMock(),
     )
@@ -562,7 +572,7 @@ def _install_fake_vllm_openai_modules(monkeypatch):
         is_mistral_tool_parser=MagicMock(return_value=False),
     )
     make_module("vllm.v1.engine.async_llm", logger=MagicMock())
-    return ToolParserManager, ReasoningParserManager, OpenAIServingChat
+    return ToolParserManager, ReasoningParserManager, OpenAIServingChat, hf_renderer
 
 
 class _FakeFastAPIApp:
@@ -577,11 +587,12 @@ class _FakeFastAPIApp:
         return decorator
 
 
-def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch):
+def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch, caplog):
     (
         tool_parser_manager,
         reasoning_parser_manager,
         openai_serving_chat,
+        hf_renderer,
     ) = _install_fake_vllm_openai_modules(monkeypatch)
 
     worker = VllmAsyncGenerationWorkerImpl.__new__(VllmAsyncGenerationWorkerImpl)
@@ -596,8 +607,21 @@ def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch):
             },
         },
     }
-    worker.llm = MagicMock(model_config="model-config", renderer="renderer")
-    model_config = MagicMock(served_model_name="served-model", model="model-path")
+    worker._online_renderer = None
+    assert worker._get_complete_token_injection_stats() == {
+        "attempts": 0,
+        "successes": 0,
+        "fallbacks": {},
+    }
+
+    model_config = MagicMock(
+        served_model_name="served-model",
+        model="model-path",
+        max_model_len=128,
+        multimodal_config=None,
+        enable_prompt_embeds=False,
+    )
+    worker.llm = MagicMock(model_config=model_config, renderer=hf_renderer())
     worker.llm_async_engine_args = MagicMock()
     worker.llm_async_engine_args.create_model_config.return_value = model_config
 
@@ -613,6 +637,80 @@ def test_vllm_async_http_server_loads_reasoning_parser_plugin(monkeypatch):
     assert openai_serving_chat.instances[0].kwargs["reasoning_parser"] == "nano_v3"
     # make sure that the config attribute does not leak into `http_server_serving_chat_kwargs`
     assert "reasoning_parser_plugin" not in openai_serving_chat.instances[0].kwargs
+
+    renderer = worker._online_renderer
+    renderer._record_complete_token_injection_fallback("test fallback")
+    renderer._record_complete_token_injection_fallback("test fallback")
+    assert (
+        caplog.messages.count(
+            "Complete-token injection fell back to native preprocessing: test fallback"
+        )
+        == 1
+    )
+
+    chat_route = dict(app.routes)["/v1/chat/completions"]
+    request_type = chat_route.__annotations__["request"]
+
+    def make_request(**updates):
+        request = request_type()
+        for name, value in vars(_complete_token_request(**updates)).items():
+            setattr(request, name, value)
+        request.max_completion_tokens = 10
+        request.max_tokens = None
+        return request
+
+    request = make_request()
+    renderer._preprocess_chat_with_complete_token_ids = AsyncMock(
+        return_value=(
+            _tokenized_assistant_messages(),
+            [{"prompt_token_ids": [3, 4, 5]}],
+        )
+    )
+
+    result = asyncio.run(
+        renderer.preprocess_chat(
+            request=request,
+            messages=_tokenized_assistant_messages(),
+            default_template=None,
+            default_template_content_format="auto",
+            default_template_kwargs={},
+        )
+    )
+
+    assert result[1][0]["prompt_token_ids"] == [3, 4, 5]
+    renderer._preprocess_chat_with_complete_token_ids.assert_awaited_once()
+
+    asyncio.run(
+        renderer.preprocess_chat(
+            request=make_request(stream=True),
+            messages=_tokenized_assistant_messages(),
+            default_template=None,
+            default_template_content_format="auto",
+            default_template_kwargs={},
+        )
+    )
+    renderer._preprocess_chat_with_complete_token_ids = AsyncMock(
+        side_effect=CompleteTokenInjectionError("test injection error")
+    )
+    asyncio.run(
+        renderer.preprocess_chat(
+            request=make_request(),
+            messages=_tokenized_assistant_messages(),
+            default_template=None,
+            default_template_content_format="auto",
+            default_template_kwargs={},
+        )
+    )
+
+    assert worker._get_complete_token_injection_stats() == {
+        "attempts": 3,
+        "successes": 1,
+        "fallbacks": {
+            "streaming request": 1,
+            "test fallback": 2,
+            "test injection error": 1,
+        },
+    }
 
 
 def test_nano_v3_reasoning_parser_swaps_reasoning_when_thinking_disabled(


### PR DESCRIPTION
# What does this PR do ?

Avoid repeated full-history tokenization for supported multi-turn vLLM chat requests. When an earlier assistant message includes exact token metadata, NeMo-RL reuses that model prefix and tokenizes only the contextual suffix for the next turn.

The guarded path keeps vLLM chat parsing, template rendering, tool and reasoning adjustment, validation, and engine preparation. First turns and unsupported requests continue to use native vLLM preprocessing. This PR does not change the public API or require a Gym change.

Text-only requests on multimodal-capable models are supported when every message has plain string content. Requests with OpenAI content parts or parsed image, audio, or video data continue to use native vLLM preprocessing.

## Performance

A matched end-to-end validation used 320 rollouts per arm and approximately 18,000 model calls:

The baseline used commit `0ded4a9f510f55efb154d8005519d2b7e4ed463e`. The optimized arm used commit `56bb18ece647029ec49ad477e2047ac934578cab`.

| Metric | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Server preprocessing, mean | 0.938 s | 0.038 s | 96.0% |
| Server preprocessing, p50 | 0.700 s | 0.026 s | 96.3% |
| Server preprocessing, p95 | 2.497 s | 0.093 s | 96.3% |
| Observed per-turn response latency, mean | 3.984 s | 3.327 s | 16.5% |
| Observed per-turn response latency, p50 | 2.956 s | 2.047 s | 30.8% |

The response-latency measurements are end-to-end model-call latencies observed by the agent. They include inference and request-processing time.

The validation used a Nemotron Nano v3.5 SWE checkpoint with:

- `NemotronHForCausalLM`
- `PreTrainedTokenizerFast`
- `<|im_end|>` as the EOS token
- `enable_thinking=true`
- vLLM 0.25.1
- chat-template SHA-256 `82753bef5cedc4932c1ed509b5c9a12be680fd86d1adb65bc3f7398d11c8eebc`

# Issues

None.

# Usage

No configuration change is required. NeMo-RL selects the optimization only when complete token metadata is available and all safety guards pass.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added focused unit tests for prompt-token construction, guards, fallbacks, and HTTP behavior.
- [x] Ran the focused unit and end-to-end functional validation.
- [x] No documentation update is required because there is no public API or configuration change.

# Additional Information

Validation included:

- `pytest -q tests/unit/models/generation/test_openai_server_utils.py`
- `pytest -q -s tests/unit/models/generation/test_vllm_generation.py::test_vllm_http_server_correct_merged_tokens_matches_baseline`
- Exact native-versus-injected prompt comparison across 3,709 subsequent-turn requests, with zero mismatches.
- Full end-to-end validation with 320 valid rollouts per arm, zero injection failures, and zero unexpected fallbacks.
- Head-level shadow validation at commit `8790130218435a6d350d3c0b089f67660266e333` completed 64 valid rollouts. It compared 3,639 injected prompts with native vLLM preprocessing and found zero mismatches, zero injection failures, zero unexpected fallbacks, zero `/tokenize` calls, and zero HTTP errors.
