### PR TITLE
feat(opd): add student top-k on-policy distillation

### DIFF
--- a/docs/about/algorithms/mopd.md
+++ b/docs/about/algorithms/mopd.md
@@ -35,6 +35,20 @@ tool / environment tokens contribute zero. Because the advantage subtracts a
 real `prev_logprobs`, MOPD requires the student log-probabilities to actually be
 computed — see [Configuration](#configuration).
 
+### Student top-k reverse KL
+
+Setting `on_policy_distillation.student_topk` replaces the sampled-token MOPD
+loss with a lower-variance reverse-KL estimator. For every token, the student
+selects its highest-probability `k` vocabulary entries. NeMo RL evaluates the
+student and teacher exactly on that support and uses the sampled rollout token
+to estimate the contribution from the remaining vocabulary.
+
+The sampled tail uses the score-function coefficient
+`1 + log π_student − log π_teacher`. The `1` is required because the derivative
+also acts on the student probability multiplying the log-probability gap.
+Support indices and teacher probabilities are treated as constants; gradients
+flow only through the current student probabilities.
+
 ## Configuration
 
 Enable MOPD in two places: select the advantage estimator and add the
@@ -63,6 +77,9 @@ loss_fn:
 
 on_policy_distillation:
   enabled: true
+  # Optional: use the student's top-k vocabulary entries for an exact KL head
+  # and the sampled rollout token for the remaining tail.
+  # student_topk: 64
   # Map each NeMo Gym agent name to a teacher checkpoint.
   teacher_model_by_agent_name:
     default_teacher: Qwen/Qwen3-1.7B
@@ -98,6 +115,20 @@ on_policy_distillation:
 > `prev_logprobs` (`loss_fn.force_on_policy_ratio: true` with no
 > `grpo.seq_logprob_error_threshold`), because the advantage would silently
 > degrade to `teacher_logprobs − 0`.
+
+> [!NOTE]
+> Student top-k mode currently requires async GRPO, a Megatron policy backend,
+> token-level loss, `loss_fn.disable_ppo_ratio: true`, sequence packing disabled,
+> context parallel size 1, fused linear log-probabilities disabled, and an
+> unfiltered training distribution (`generation.top_k: null`, `top_p: 1.0`).
+> CISPO, dual PPO clipping, and sequence-level importance ratios are unsupported.
+
+Student top-k training reports four additional metrics:
+
+- `opd_topk_head_loss`: exact reverse-KL contribution on the selected support.
+- `opd_topk_tail_loss`: sampled score-function surrogate for the tail gradient.
+- `opd_topk_student_mass`: student probability mass captured by the support.
+- `opd_topk_target_outside_fraction`: fraction of sampled targets outside it.
 
 ### Teacher routing
 

--- a/docs/about/algorithms/mopd.md
+++ b/docs/about/algorithms/mopd.md
@@ -172,6 +172,22 @@ The reference recipe self-distills `Qwen/Qwen3-1.7B` (student == teacher) across
 student and teacher are identical, the OPD loss stays near zero — it is a
 correctness smoke test, not a demonstration of distillation gains.
 
+To exercise the student-top-k path with that recipe, disable its inherited
+sequence packing and set the support size explicitly:
+
+```sh
+uv run examples/nemo_gym/run_grpo_nemo_gym.py \
+  --config examples/configs/recipes/llm/mopd-qwen3-1.7b-3n8g-megatron-pack.yaml \
+  policy.sequence_packing.enabled=false \
+  on_policy_distillation.student_topk=64 \
+  data.train.data_path=/path/to/train.jsonl \
+  data.validation.data_path=/path/to/val.jsonl
+```
+
+This remains a smoke-test configuration. Measure throughput, peak memory, and
+loss/reward convergence against full-vocabulary MOPD before using it as a
+performance or quality baseline.
+
 ## References
 
 - LLM-Core Xiaomi, *MiMo-V2-Flash Technical Report*, which introduces the

--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -799,7 +799,19 @@ class AsyncTrajectoryCollector:
         agent_refs: list[dict[str, Any]],
         input_lengths: Optional[torch.Tensor] = None,
     ) -> tuple[torch.Tensor, float]:
-        """Route student-selected supports to teachers and stitch their logprobs."""
+        """Route student-selected supports to teachers and stitch their logprobs.
+
+        Args:
+            input_ids: Student token IDs with shape ``[batch, sequence]``.
+            topk_indices: Student-selected vocabulary indices with shape
+                ``[batch, sequence, k]``.
+            agent_refs: Per-sample agent metadata used for teacher routing.
+            input_lengths: Optional unpadded sequence lengths.
+
+        Returns:
+            Teacher support log-probabilities in original batch order and the
+            elapsed teacher-evaluation time.
+        """
         if topk_indices.ndim != 3 or topk_indices.shape[:2] != input_ids.shape:
             raise ValueError(
                 "topk_indices must have shape [B, S, K] aligned with input_ids; "
@@ -885,7 +897,18 @@ class AsyncTrajectoryCollector:
         agent_refs: list[dict[str, Any]],
         input_lengths: Optional[torch.Tensor] = None,
     ) -> tuple[torch.Tensor, float]:
-        """Run blocking teacher support inference without blocking the actor loop."""
+        """Run teacher support inference without blocking the actor event loop.
+
+        Args:
+            input_ids: Student token IDs with shape ``[batch, sequence]``.
+            topk_indices: Student-selected vocabulary indices with shape
+                ``[batch, sequence, k]``.
+            agent_refs: Per-sample agent metadata used for teacher routing.
+            input_lengths: Optional unpadded sequence lengths.
+
+        Returns:
+            Teacher support log-probabilities and evaluation time.
+        """
         return await asyncio.to_thread(
             self._compute_teacher_support_logprobs,
             input_ids,

--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -792,6 +792,108 @@ class AsyncTrajectoryCollector:
 
         return result, total_time
 
+    def _compute_teacher_support_logprobs(
+        self,
+        input_ids: torch.Tensor,
+        topk_indices: torch.Tensor,
+        agent_refs: list[dict[str, Any]],
+        input_lengths: Optional[torch.Tensor] = None,
+    ) -> tuple[torch.Tensor, float]:
+        """Route student-selected supports to teachers and stitch their logprobs."""
+        if topk_indices.ndim != 3 or topk_indices.shape[:2] != input_ids.shape:
+            raise ValueError(
+                "topk_indices must have shape [B, S, K] aligned with input_ids; "
+                f"got {topk_indices.shape} and {input_ids.shape}."
+            )
+        opd_cfg = self.on_policy_distillation_cfg
+        reference_aliases = resolve_reference_aliases(
+            agent_refs,
+            opd_cfg.get("teacher_model_by_agent_name", {}),
+            default_teacher_alias=opd_cfg.get("default_teacher_alias"),
+            strict_agent_name_match=opd_cfg.get("strict_agent_name_match", False),
+        )
+        group_to_indices: dict[str, list[int]] = defaultdict(list)
+        for sample_index, alias in enumerate(reference_aliases):
+            group_key = self.alias_to_group_alias.get(alias, alias)
+            group_to_indices[group_key].append(sample_index)
+
+        batch_size, seq_len, support_size = topk_indices.shape
+        result = torch.zeros(batch_size, seq_len, support_size, dtype=torch.float32)
+        if not group_to_indices:
+            return result, 0.0
+
+        def _evaluate_group(group_key: str, indices: list[int]):
+            teacher = self.teacher_worker_groups[group_key]
+            sub_input_ids = input_ids[indices]
+            sub_topk_indices = topk_indices[indices]
+            sub_lengths = input_lengths[indices] if input_lengths is not None else None
+            actual_batch_size = sub_input_ids.shape[0]
+            dp_size = teacher.sharding_annotations.get_axis_size("data_parallel")
+            remainder = actual_batch_size % dp_size
+            if remainder:
+                pad_count = dp_size - remainder
+                sub_input_ids = torch.cat(
+                    [sub_input_ids, sub_input_ids[-1:].expand(pad_count, -1)], dim=0
+                )
+                sub_topk_indices = torch.cat(
+                    [
+                        sub_topk_indices,
+                        sub_topk_indices[-1:].expand(pad_count, -1, -1),
+                    ],
+                    dim=0,
+                )
+                if sub_lengths is not None:
+                    sub_lengths = torch.cat(
+                        [sub_lengths, sub_lengths[-1:].expand(pad_count)], dim=0
+                    )
+
+            sub_data = BatchedDataDict(
+                {"input_ids": sub_input_ids, "topk_indices": sub_topk_indices}
+            )
+            if sub_lengths is not None:
+                sub_data["input_lengths"] = sub_lengths
+            lock_started = time.time()
+            with self._teacher_locks[group_key]:
+                inference_started = time.time()
+                support_output = teacher.get_logprobs_on_support(sub_data)
+            finished = time.time()
+            print(
+                f"[teacher_support] group={group_key} samples={actual_batch_size} "
+                f"lock_wait={inference_started - lock_started:.2f}s "
+                f"inference={finished - inference_started:.2f}s"
+            )
+            return indices, support_output["support_logprobs"][:actual_batch_size]
+
+        started = time.time()
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=len(group_to_indices)
+        ) as executor:
+            futures = [
+                executor.submit(_evaluate_group, group_key, indices)
+                for group_key, indices in group_to_indices.items()
+            ]
+            for future in concurrent.futures.as_completed(futures):
+                indices, support_logprobs = future.result()
+                result[indices] = support_logprobs
+        total_time = time.time() - started
+        return result, total_time
+
+    async def compute_teacher_support_logprobs(
+        self,
+        input_ids: torch.Tensor,
+        topk_indices: torch.Tensor,
+        agent_refs: list[dict[str, Any]],
+        input_lengths: Optional[torch.Tensor] = None,
+    ) -> tuple[torch.Tensor, float]:
+        """Run blocking teacher support inference without blocking the actor loop."""
+        return await asyncio.to_thread(
+            self._compute_teacher_support_logprobs,
+            input_ids,
+            topk_indices,
+            agent_refs,
+            input_lengths,
+        )
+
     async def _iter_rollout_groups(
         self,
         repeated_batch: BatchedDataDict[DatumSpec],

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -604,6 +604,39 @@ def setup(
     use_fused_linear_logprobs = bool(
         megatron_cfg.get("enabled") and megatron_cfg.get("use_fused_linear_logprobs")
     )
+    student_topk = opd_module.get_student_topk(master_config)
+    if student_topk is not None:
+        if not opd_module.is_opd_enabled(master_config):
+            raise ValueError(
+                "on_policy_distillation.student_topk requires "
+                "on_policy_distillation.enabled=true."
+            )
+        if not grpo_config.async_grpo.enabled:
+            raise NotImplementedError(
+                "Student-top-k OPD currently supports only grpo.async_grpo.enabled=true."
+            )
+        if policy_config["sequence_packing"]["enabled"]:
+            raise NotImplementedError(
+                "Student-top-k OPD does not yet support sequence packing."
+            )
+        if megatron_cfg.get("context_parallel_size", 1) != 1:
+            raise NotImplementedError(
+                "Student-top-k OPD does not yet support context parallelism."
+            )
+        if not megatron_cfg.get("enabled", False):
+            raise NotImplementedError(
+                "Student-top-k OPD currently requires the Megatron policy backend."
+            )
+        if need_top_k_or_top_p_filtering(
+            TrainingSamplingParams(
+                top_k=generation_config["top_k"],
+                top_p=generation_config["top_p"],
+            )
+        ):
+            raise NotImplementedError(
+                "Student-top-k OPD currently requires unfiltered training distributions "
+                "(policy.generation.top_k=null and top_p=1.0)."
+            )
     if use_fused_linear_logprobs:
         # Sequence packing is not yet validated with the fused path: the fused
         # forward rolls labels over the whole (packed) sequence and would mix
@@ -632,7 +665,9 @@ def setup(
         )
 
     loss_fn = ClippedPGLossFn(
-        loss_config, use_fused_linear_logprobs=use_fused_linear_logprobs
+        loss_config,
+        use_fused_linear_logprobs=use_fused_linear_logprobs,
+        opd_student_topk=student_topk,
     )
 
     # Validate force_on_policy_ratio
@@ -4114,6 +4149,7 @@ def async_grpo_train(
         "Importance sampling correction must be enabled for async GRPO for good convergence due to off-policy samples!"
     )
     max_generation_failures = master_config.grpo.async_grpo.max_generation_failures
+    student_topk = opd_module.get_student_topk(master_config)
 
     if router_replay_enabled(master_config.policy) and (
         master_config.data_plane or {}
@@ -4626,11 +4662,13 @@ def async_grpo_train(
                     # Teacher logprobs are stored in batch dict by collection-time
                     # computation and padded by from_batches. Extract here.
                     trajectory_teacher_logprobs = None
+                    teacher_agent_refs = None
                     if opd_module.is_opd_enabled(master_config):
                         if "teacher_reference_logprobs" in repeated_batch:
                             trajectory_teacher_logprobs = repeated_batch[
                                 "teacher_reference_logprobs"
                             ]
+                        teacher_agent_refs = repeated_batch.get("agent_ref")
 
                     # Aggregate rollout metrics across groups with proper aggregation per metric type
                     per_group_metrics = {}
@@ -4769,6 +4807,46 @@ def async_grpo_train(
                             train_data["generation_logprobs"]
                         )
 
+                    if student_topk is not None:
+                        if trajectory_teacher_logprobs is None:
+                            raise ValueError(
+                                "Student-top-k OPD requires collection-time teacher "
+                                "target logprobs in the replay batch."
+                            )
+                        if not isinstance(teacher_agent_refs, list):
+                            raise ValueError(
+                                "Student-top-k OPD requires one agent_ref per training sample."
+                            )
+                        topk_output = policy.get_topk_logits(
+                            train_data,
+                            k=student_topk,
+                            timer=timer,
+                        )
+                        if "topk_logprobs" not in topk_output:
+                            raise RuntimeError(
+                                "The selected policy backend does not return globally "
+                                "normalized topk_logprobs required by student-top-k OPD."
+                            )
+                        train_data["prev_topk_indices"] = topk_output["topk_indices"]
+                        train_data["prev_topk_logprobs"] = topk_output["topk_logprobs"]
+                        (
+                            teacher_support_logprobs,
+                            teacher_support_time,
+                        ) = ray.get(
+                            trajectory_collector.compute_teacher_support_logprobs.remote(
+                                train_data["input_ids"],
+                                train_data["prev_topk_indices"],
+                                teacher_agent_refs,
+                                input_lengths=train_data["input_lengths"],
+                            )
+                        )
+                        train_data["teacher_support_logprobs"] = (
+                            teacher_support_logprobs
+                        )
+                        rollout_metrics["teacher_support_logprob_time"] = (
+                            teacher_support_time
+                        )
+
                     if not skip_reference_logprobs:
                         train_data["reference_policy_logprobs"] = (
                             policy.get_reference_policy_logprobs(
@@ -4806,6 +4884,10 @@ def async_grpo_train(
                     trajectory_teacher_logprobs = _pad_teacher_logprobs(
                         trajectory_teacher_logprobs, train_data["input_ids"].shape[1]
                     )
+                    if student_topk is not None:
+                        train_data["teacher_reference_logprobs"] = (
+                            trajectory_teacher_logprobs
+                        )
 
                 # Compute advantages with adv_estimator using correct mask and logprobs
                 with timer.time("advantage_calculation"):

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -4822,13 +4822,7 @@ def async_grpo_train(
                             k=student_topk,
                             timer=timer,
                         )
-                        if "topk_logprobs" not in topk_output:
-                            raise RuntimeError(
-                                "The selected policy backend does not return globally "
-                                "normalized topk_logprobs required by student-top-k OPD."
-                            )
                         train_data["prev_topk_indices"] = topk_output["topk_indices"]
-                        train_data["prev_topk_logprobs"] = topk_output["topk_logprobs"]
                         (
                             teacher_support_logprobs,
                             teacher_support_time,

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -382,6 +382,55 @@ def _validate_multimodal_dedup_capability(master_config: MasterConfig) -> None:
             "grpo.deduplicate_multimodal_data=true is currently supported "
             "only when data_plane.enabled=false."
         )
+def _validate_student_topk_config(
+    master_config: MasterConfig, student_topk: Optional[int]
+) -> None:
+    """Reject settings that the student-top-k OPD loss cannot honor."""
+    if student_topk is None:
+        return
+
+    grpo_config = master_config.grpo
+    policy_config = master_config.policy
+    generation_config = policy_config["generation"]
+    megatron_cfg = policy_config.get("megatron_cfg", {})
+
+    if not opd_module.is_opd_enabled(master_config):
+        raise ValueError(
+            "on_policy_distillation.student_topk requires "
+            "on_policy_distillation.enabled=true."
+        )
+    if not grpo_config.async_grpo.enabled:
+        raise NotImplementedError(
+            "Student-top-k OPD currently supports only grpo.async_grpo.enabled=true."
+        )
+    if policy_config["sequence_packing"]["enabled"]:
+        raise NotImplementedError(
+            "Student-top-k OPD does not yet support sequence packing."
+        )
+    if megatron_cfg.get("context_parallel_size", 1) != 1:
+        raise NotImplementedError(
+            "Student-top-k OPD does not yet support context parallelism."
+        )
+    if not megatron_cfg.get("enabled", False):
+        raise NotImplementedError(
+            "Student-top-k OPD currently requires the Megatron policy backend."
+        )
+    if need_top_k_or_top_p_filtering(
+        TrainingSamplingParams(
+            top_k=generation_config["top_k"],
+            top_p=generation_config["top_p"],
+        )
+    ):
+        raise NotImplementedError(
+            "Student-top-k OPD currently requires unfiltered training distributions "
+            "(policy.generation.top_k=null and top_p=1.0)."
+        )
+    if master_config.loss_fn.reference_policy_kl_penalty != 0:
+        raise ValueError(
+            "Student-top-k OPD requires loss_fn.reference_policy_kl_penalty=0."
+        )
+    if grpo_config.adv_estimator.name != "opd":
+        raise ValueError("Student-top-k OPD requires grpo.adv_estimator.name='opd'.")
 
 
 def setup(
@@ -605,38 +654,7 @@ def setup(
         megatron_cfg.get("enabled") and megatron_cfg.get("use_fused_linear_logprobs")
     )
     student_topk = opd_module.get_student_topk(master_config)
-    if student_topk is not None:
-        if not opd_module.is_opd_enabled(master_config):
-            raise ValueError(
-                "on_policy_distillation.student_topk requires "
-                "on_policy_distillation.enabled=true."
-            )
-        if not grpo_config.async_grpo.enabled:
-            raise NotImplementedError(
-                "Student-top-k OPD currently supports only grpo.async_grpo.enabled=true."
-            )
-        if policy_config["sequence_packing"]["enabled"]:
-            raise NotImplementedError(
-                "Student-top-k OPD does not yet support sequence packing."
-            )
-        if megatron_cfg.get("context_parallel_size", 1) != 1:
-            raise NotImplementedError(
-                "Student-top-k OPD does not yet support context parallelism."
-            )
-        if not megatron_cfg.get("enabled", False):
-            raise NotImplementedError(
-                "Student-top-k OPD currently requires the Megatron policy backend."
-            )
-        if need_top_k_or_top_p_filtering(
-            TrainingSamplingParams(
-                top_k=generation_config["top_k"],
-                top_p=generation_config["top_p"],
-            )
-        ):
-            raise NotImplementedError(
-                "Student-top-k OPD currently requires unfiltered training distributions "
-                "(policy.generation.top_k=null and top_p=1.0)."
-            )
+    _validate_student_topk_config(master_config, student_topk)
     if use_fused_linear_logprobs:
         # Sequence packing is not yet validated with the fused path: the fused
         # forward rolls labels over the whole (packed) sequence and would mix

--- a/nemo_rl/algorithms/loss/interfaces.py
+++ b/nemo_rl/algorithms/loss/interfaces.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ class MetricNormalizer(enum.Enum):
 class LossInputType(enum.Enum):
     LOGIT = "logit"
     LOGPROB = "logprob"
+    OPD_STUDENT_TOPK = "opd_student_topk"
     DISTILLATION = "distillation"
     DISTILLATION_CROSS_TOKENIZER = "distillation_cross_tokenizer"
     DRAFT = "draft"
@@ -97,6 +98,7 @@ class LossFunction(Protocol):
             **kwargs: Loss function input, which varies by input_type:
                 - For LossInputType.LOGPROB: next_token_logprobs (torch.Tensor)
                 - For LossInputType.LOGIT: logits (torch.Tensor)
+                - For LossInputType.OPD_STUDENT_TOPK: next-token and selected-support logprobs
                 - For LossInputType.DISTILLATION: student_topk_logprobs, teacher_topk_logprobs, H_all (torch.Tensor)
                 - For LossInputType.DISTILLATION_CROSS_TOKENIZER: logits (torch.Tensor), teacher_full_logits_by_idx (dict[int, torch.Tensor])
                 - For LossInputType.DRAFT: teacher_logits, student_logits, mask (torch.Tensor)

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -173,6 +173,10 @@ class ClippedPGLossDataDict(TypedDict):
     reference_policy_logprobs: torch.Tensor
     token_mask: torch.Tensor
     sample_mask: torch.Tensor
+    prev_topk_indices: NotRequired[torch.Tensor]
+    prev_topk_logprobs: NotRequired[torch.Tensor]
+    teacher_support_logprobs: NotRequired[torch.Tensor]
+    teacher_reference_logprobs: NotRequired[torch.Tensor]
     __extra__: Any
 
 
@@ -225,13 +229,45 @@ class ClippedPGLossFn(LossFunction):
     input_type = LossInputType.LOGPROB
 
     def __init__(
-        self, cfg: ClippedPGLossConfig, use_fused_linear_logprobs: bool = False
+        self,
+        cfg: ClippedPGLossConfig,
+        use_fused_linear_logprobs: bool = False,
+        opd_student_topk: Optional[int] = None,
     ):
         # When True, the model forward is patched to return precomputed next-token
         # logprobs (via chunked linear CE fusion) instead of full logits. This is
         # consumed by prepare_loss_input, which short-circuits the logits->logprobs
         # conversion. See nemo_rl/distributed/model_utils.py for the fused forward.
         self.use_fused_linear_logprobs = use_fused_linear_logprobs
+        self.opd_student_topk = opd_student_topk
+        self.input_type = (
+            LossInputType.OPD_STUDENT_TOPK
+            if opd_student_topk is not None
+            else LossInputType.LOGPROB
+        )
+        if opd_student_topk is not None:
+            if opd_student_topk < 1:
+                raise ValueError(
+                    f"opd_student_topk must be at least 1, got {opd_student_topk}."
+                )
+            if use_fused_linear_logprobs:
+                raise ValueError(
+                    "Student-top-k OPD is incompatible with fused linear logprobs."
+                )
+            if not cfg.disable_ppo_ratio:
+                raise ValueError(
+                    "Student-top-k OPD requires loss_fn.disable_ppo_ratio=true."
+                )
+            if cfg.use_cispo:
+                raise ValueError("Student-top-k OPD is incompatible with CISPO.")
+            if cfg.ratio_clip_c is not None:
+                raise ValueError(
+                    "Student-top-k OPD is incompatible with dual PPO clipping."
+                )
+            if cfg.sequence_level_importance_ratios or not cfg.token_level_loss:
+                raise ValueError(
+                    "Student-top-k OPD requires token-level loss and importance ratios."
+                )
         self.disable_ppo_ratio = cfg.disable_ppo_ratio
         self.ratio_clip_min = cfg.ratio_clip_min
         self.ratio_clip_max = cfg.ratio_clip_max
@@ -369,6 +405,15 @@ class ClippedPGLossFn(LossFunction):
                 if self.truncated_importance_sampling_type == "seq-mask-tis"
                 else MetricNormalizer.TOKENS
             )
+        if self.opd_student_topk is not None:
+            self.metric_normalizations.update(
+                {
+                    "opd_topk_head_loss": MetricNormalizer.TOKENS,
+                    "opd_topk_tail_loss": MetricNormalizer.TOKENS,
+                    "opd_topk_student_mass": MetricNormalizer.TOKENS,
+                    "opd_topk_target_outside_fraction": MetricNormalizer.TOKENS,
+                }
+            )
 
     def __call__(
         self,
@@ -376,6 +421,7 @@ class ClippedPGLossFn(LossFunction):
         data: BatchedDataDict[ClippedPGLossDataDict],
         global_valid_seqs: torch.Tensor,
         global_valid_toks: torch.Tensor,
+        current_support_logprobs: Optional[Tensor] = None,
     ) -> tuple[torch.Tensor, dict]:
         """Clipped Policy Gradient RL loss function."""
         curr_logprobs = next_token_logprobs
@@ -549,6 +595,97 @@ class ClippedPGLossFn(LossFunction):
 
             # Determine which value to use for clipping (max for pessimistic estimate)
             clip_loss = torch.max(loss1, loss2)
+
+        opd_topk_metrics: dict[str, float] = {}
+        if self.opd_student_topk is not None:
+            from nemo_rl.algorithms.opd import student_topk_reverse_kl_loss
+
+            if current_support_logprobs is None:
+                raise ValueError("Student-top-k OPD requires current_support_logprobs.")
+            required_fields = (
+                "prev_topk_indices",
+                "prev_topk_logprobs",
+                "teacher_support_logprobs",
+                "teacher_reference_logprobs",
+            )
+            missing = [field for field in required_fields if field not in data]
+            if missing:
+                raise ValueError(
+                    "Student-top-k OPD training data is missing: " + ", ".join(missing)
+                )
+
+            support_indices = data["prev_topk_indices"][:, :-1]
+            previous_support_logprobs = data["prev_topk_logprobs"][:, :-1]
+            teacher_support_logprobs = data["teacher_support_logprobs"][:, :-1]
+            expected_support_shape = support_indices.shape
+            for name, value in (
+                ("current_support_logprobs", current_support_logprobs),
+                ("prev_topk_logprobs", previous_support_logprobs),
+                ("teacher_support_logprobs", teacher_support_logprobs),
+            ):
+                if value.shape != expected_support_shape:
+                    raise ValueError(
+                        f"{name} must have shape {expected_support_shape}, "
+                        f"got {value.shape}."
+                    )
+            teacher_support_logprobs = teacher_support_logprobs.to(
+                device=current_support_logprobs.device,
+                dtype=current_support_logprobs.dtype,
+            )
+            if expected_support_shape[-1] != self.opd_student_topk:
+                raise ValueError(
+                    "Student top-k data does not match configured support size: "
+                    f"expected {self.opd_student_topk}, got "
+                    f"{expected_support_shape[-1]}."
+                )
+
+            target_indices = data["input_ids"][:, 1:].to(
+                device=support_indices.device,
+                dtype=support_indices.dtype,
+            )
+            target_in_support = support_indices.eq(target_indices.unsqueeze(-1)).any(
+                dim=-1
+            )
+            teacher_target_logprobs = data["teacher_reference_logprobs"][:, 1:].to(
+                device=curr_logprobs.device,
+                dtype=curr_logprobs.dtype,
+            )
+            clip_loss = student_topk_reverse_kl_loss(
+                student_support_logprobs=current_support_logprobs,
+                teacher_support_logprobs=teacher_support_logprobs,
+                student_target_logprobs=curr_logprobs,
+                teacher_target_logprobs=teacher_target_logprobs,
+                target_in_support=target_in_support,
+            )
+            with torch.no_grad():
+                current_support_probs = current_support_logprobs.exp()
+                head_loss = (
+                    current_support_probs
+                    * (current_support_logprobs - teacher_support_logprobs)
+                ).sum(dim=-1)
+                tail_loss = clip_loss - head_loss
+                opd_topk_metrics = {
+                    "opd_topk_head_loss": masked_mean(
+                        head_loss,
+                        mask,
+                        global_normalization_factor=global_valid_toks,
+                    ).item(),
+                    "opd_topk_tail_loss": masked_mean(
+                        tail_loss,
+                        mask,
+                        global_normalization_factor=global_valid_toks,
+                    ).item(),
+                    "opd_topk_student_mass": masked_mean(
+                        current_support_probs.sum(dim=-1),
+                        mask,
+                        global_normalization_factor=global_valid_toks,
+                    ).item(),
+                    "opd_topk_target_outside_fraction": masked_mean(
+                        (~target_in_support).to(mask.dtype),
+                        mask,
+                        global_normalization_factor=global_valid_toks,
+                    ).item(),
+                }
         # Dual-clipping see https://arxiv.org/pdf/1912.09729
         if self.ratio_clip_c is not None:
             assert self.ratio_clip_c > 1, (
@@ -783,6 +920,7 @@ class ClippedPGLossFn(LossFunction):
                 "approx_entropy": seq_entropy_approx.item(),
                 **_is_filter_metrics,
                 "positive_nll_loss": nll_loss.item(),
+                **opd_topk_metrics,
             },
         )
 

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -174,7 +174,6 @@ class ClippedPGLossDataDict(TypedDict):
     token_mask: torch.Tensor
     sample_mask: torch.Tensor
     prev_topk_indices: NotRequired[torch.Tensor]
-    prev_topk_logprobs: NotRequired[torch.Tensor]
     teacher_support_logprobs: NotRequired[torch.Tensor]
     teacher_reference_logprobs: NotRequired[torch.Tensor]
     __extra__: Any
@@ -604,7 +603,6 @@ class ClippedPGLossFn(LossFunction):
                 raise ValueError("Student-top-k OPD requires current_support_logprobs.")
             required_fields = (
                 "prev_topk_indices",
-                "prev_topk_logprobs",
                 "teacher_support_logprobs",
                 "teacher_reference_logprobs",
             )
@@ -615,12 +613,10 @@ class ClippedPGLossFn(LossFunction):
                 )
 
             support_indices = data["prev_topk_indices"][:, :-1]
-            previous_support_logprobs = data["prev_topk_logprobs"][:, :-1]
             teacher_support_logprobs = data["teacher_support_logprobs"][:, :-1]
             expected_support_shape = support_indices.shape
             for name, value in (
                 ("current_support_logprobs", current_support_logprobs),
-                ("prev_topk_logprobs", previous_support_logprobs),
                 ("teacher_support_logprobs", teacher_support_logprobs),
             ):
                 if value.shape != expected_support_shape:

--- a/nemo_rl/algorithms/loss/utils.py
+++ b/nemo_rl/algorithms/loss/utils.py
@@ -29,9 +29,9 @@ from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.model_utils import (
     _get_tokens_on_this_cp_rank,
     from_parallel_logits_to_logprobs_packed_sequences,
+    gather_logits_at_global_indices,
     get_distillation_topk_logprobs_from_logits,
     get_next_token_logprobs_from_logits,
-    gather_logits_at_global_indices,
     vocab_parallel_log_softmax,
 )
 

--- a/nemo_rl/algorithms/loss/utils.py
+++ b/nemo_rl/algorithms/loss/utils.py
@@ -31,6 +31,8 @@ from nemo_rl.distributed.model_utils import (
     from_parallel_logits_to_logprobs_packed_sequences,
     get_distillation_topk_logprobs_from_logits,
     get_next_token_logprobs_from_logits,
+    gather_logits_at_global_indices,
+    vocab_parallel_log_softmax,
 )
 
 
@@ -118,6 +120,64 @@ def prepare_loss_input(
                 )
 
         loss_input = {"next_token_logprobs": logprobs}
+
+    elif loss_fn.input_type == LossInputType.OPD_STUDENT_TOPK:
+        if (
+            context_parallel_group is not None
+            and torch.distributed.get_world_size(context_parallel_group) > 1
+        ):
+            raise NotImplementedError(
+                "Student-top-k OPD loss preparation does not yet support context parallelism."
+            )
+        if "prev_topk_indices" not in data:
+            raise ValueError("Student-top-k OPD requires data['prev_topk_indices'].")
+        support_indices = data["prev_topk_indices"].to(
+            device=logits.device, dtype=torch.long
+        )
+        if support_indices.shape[:2] != logits.shape[:2]:
+            raise ValueError(
+                "prev_topk_indices must match logits batch and sequence dimensions, "
+                f"got {support_indices.shape[:2]} and {logits.shape[:2]}."
+            )
+
+        active_tp_group = vocab_parallel_group
+        if active_tp_group is not None:
+            assert vocab_parallel_rank is not None, (
+                "vocab_parallel_rank is required with vocab_parallel_group"
+            )
+            vocab_shard_size = logits.shape[-1]
+            vocab_start_index = vocab_parallel_rank * vocab_shard_size
+            vocab_end_index = vocab_start_index + vocab_shard_size
+        else:
+            vocab_start_index = 0
+            vocab_end_index = logits.shape[-1]
+
+        local_logprobs = vocab_parallel_log_softmax(
+            logits,
+            temperature=1.0,
+            tp_group=active_tp_group,
+        )
+        current_support_logprobs = gather_logits_at_global_indices(
+            local_logprobs,
+            support_indices,
+            tp_group=active_tp_group,
+            vocab_start_index=vocab_start_index,
+            vocab_end_index=vocab_end_index,
+        )
+        current_target_logprobs = get_next_token_logprobs_from_logits(
+            input_ids=data["input_ids"],
+            next_token_logits=logits,
+            seq_index=data.get("seq_index", None),
+            vocab_parallel_rank=vocab_parallel_rank,
+            vocab_parallel_group=vocab_parallel_group,
+            context_parallel_group=None,
+            sampling_params=sampling_params,
+            chunk_size=chunk_size,
+        )
+        loss_input = {
+            "next_token_logprobs": current_target_logprobs,
+            "current_support_logprobs": current_support_logprobs[:, :-1],
+        }
 
     elif loss_fn.input_type == LossInputType.DISTILLATION:
         calculate_entropy = loss_fn.zero_outside_topk and loss_fn.kl_type != "forward"

--- a/nemo_rl/algorithms/opd.py
+++ b/nemo_rl/algorithms/opd.py
@@ -178,7 +178,9 @@ def student_topk_reverse_kl_loss(
         * (student_support_logprobs - teacher_support_logprobs)
     ).sum(dim=-1)
     tail_advantage = (teacher_target_logprobs - student_target_logprobs).detach()
-    tail_loss = -tail_advantage * student_target_logprobs
+    # The score-function coefficient includes +1 from differentiating the
+    # student-probability prefactor in p_s * (log p_s - log p_t).
+    tail_loss = (1.0 - tail_advantage) * student_target_logprobs
     return support_loss + tail_loss * (~target_in_support.bool()).to(tail_loss.dtype)
 
 

--- a/nemo_rl/algorithms/opd.py
+++ b/nemo_rl/algorithms/opd.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 from typing import Any, Optional
 
 import ray
+import torch
 from pydantic import BaseModel, Field
 
 from nemo_rl.distributed.virtual_cluster import (
@@ -68,6 +69,7 @@ class OnPolicyDistillationConfig(BaseModel, extra="allow"):
     """User-facing config for the top-level ``on_policy_distillation`` block."""
 
     enabled: bool = False
+    student_topk: Optional[int] = Field(default=None, ge=1)
     teacher_model_by_agent_name: dict[str, str] = Field(default_factory=dict)
     default_teacher_alias: Optional[str] = None
     strict_agent_name_match: bool = False
@@ -110,6 +112,74 @@ def is_non_colocated_teachers_enabled(master_config: Any) -> bool:
     return bool(
         _opd_cfg(master_config).get("non_colocated_teachers", {}).get("enabled", False)
     )
+
+
+def get_student_topk(master_config: Any) -> Optional[int]:
+    """Return the configured student-selected OPD support size, if any."""
+    topk = _opd_cfg(master_config).get("student_topk")
+    if topk is None:
+        return None
+    topk = int(topk)
+    if topk < 1:
+        raise ValueError(
+            f"on_policy_distillation.student_topk must be at least 1, got {topk}."
+        )
+    return topk
+
+
+def student_topk_reverse_kl_loss(
+    student_support_logprobs: torch.Tensor,
+    teacher_support_logprobs: torch.Tensor,
+    student_target_logprobs: torch.Tensor,
+    teacher_target_logprobs: torch.Tensor,
+    target_in_support: torch.Tensor,
+) -> torch.Tensor:
+    """Compute the per-token student-top-k reverse-KL estimator.
+
+    The exact reverse-KL contribution is used for the student-selected top-k
+    support. When the sampled target is outside that support, its score-function
+    contribution estimates the remaining vocabulary tail without transferring
+    full-vocabulary teacher logits.
+
+    All log-probabilities must be normalized against their model's full
+    vocabulary. Support selection and teacher values are treated as constants;
+    gradients flow only through the current student log-probabilities.
+    """
+    if student_support_logprobs.shape != teacher_support_logprobs.shape:
+        raise ValueError(
+            "student and teacher support logprobs must have the same shape, "
+            f"got {student_support_logprobs.shape} and "
+            f"{teacher_support_logprobs.shape}."
+        )
+    if student_support_logprobs.ndim < 1:
+        raise ValueError("support logprobs must have a top-k dimension.")
+    token_shape = student_support_logprobs.shape[:-1]
+    for name, value in (
+        ("student_target_logprobs", student_target_logprobs),
+        ("teacher_target_logprobs", teacher_target_logprobs),
+        ("target_in_support", target_in_support),
+    ):
+        if value.shape != token_shape:
+            raise ValueError(
+                f"{name} must have shape {token_shape}, got {value.shape}."
+            )
+
+    teacher_support_logprobs = teacher_support_logprobs.to(
+        device=student_support_logprobs.device,
+        dtype=student_support_logprobs.dtype,
+    ).detach()
+    teacher_target_logprobs = teacher_target_logprobs.to(
+        device=student_target_logprobs.device,
+        dtype=student_target_logprobs.dtype,
+    ).detach()
+
+    support_loss = (
+        student_support_logprobs.exp()
+        * (student_support_logprobs - teacher_support_logprobs)
+    ).sum(dim=-1)
+    tail_advantage = (teacher_target_logprobs - student_target_logprobs).detach()
+    tail_loss = -tail_advantage * student_target_logprobs
+    return support_loss + tail_loss * (~target_in_support.bool()).to(tail_loss.dtype)
 
 
 def _skip_prev_logprobs(master_config: Any) -> bool:

--- a/nemo_rl/algorithms/opd.py
+++ b/nemo_rl/algorithms/opd.py
@@ -128,6 +128,7 @@ def get_student_topk(master_config: Any) -> Optional[int]:
 
 
 def student_topk_reverse_kl_loss(
+    *,
     student_support_logprobs: torch.Tensor,
     teacher_support_logprobs: torch.Tensor,
     student_target_logprobs: torch.Tensor,

--- a/nemo_rl/models/megatron/train.py
+++ b/nemo_rl/models/megatron/train.py
@@ -637,7 +637,7 @@ class TopkLogitsPostProcessor:
         data_dict: BatchedDataDict[Any],
         cu_seqlens_padded: torch.Tensor,
     ) -> Callable[[torch.Tensor], Tuple[torch.Tensor, Dict[str, torch.Tensor]]]:
-        """Create a post-processing function for top-k logits, logprobs, and indices.
+        """Create a post-processing function that computes top-k logits and indices.
 
         This function returns a processor that extracts the top-k highest logits
         and their corresponding vocabulary indices from model outputs. It handles
@@ -648,8 +648,8 @@ class TopkLogitsPostProcessor:
             cu_seqlens_padded: Cumulative sequence lengths for packed sequences
 
         Returns:
-            Callable: Function that returns top-k logits, globally normalized
-                top-k logprobs, and global vocabulary indices.
+            Callable: Function that takes output tensor and returns
+                ``(dummy_loss, {"topk_logits": values, "topk_indices": indices})``.
         """
         pack = self.cfg["sequence_packing"]["enabled"]
         cp_size = self.cfg["megatron_cfg"]["context_parallel_size"]
@@ -674,19 +674,6 @@ class TopkLogitsPostProcessor:
                 vocab_end_index=vocab_start_index + vocab_shard_size,
                 chunk_size=chunk_size,
             )
-            local_logprobs = vocab_parallel_log_softmax(
-                output_tensor,
-                temperature=1.0,
-                tp_group=tp_grp if torch.distributed.is_initialized() else None,
-            )
-            topk_logprobs_local = gather_logits_at_global_indices(
-                local_logprobs,
-                topk_idx_local,
-                tp_group=tp_grp if torch.distributed.is_initialized() else None,
-                vocab_start_index=vocab_start_index,
-                vocab_end_index=vocab_start_index + vocab_shard_size,
-            )
-
             if self.cfg["megatron_cfg"]["context_parallel_size"] > 1:
                 cp_grp = get_context_parallel_group()
                 if pack:
@@ -704,12 +691,6 @@ class TopkLogitsPostProcessor:
                         dtype=topk_idx_local.dtype,
                         device=topk_idx_local.device,
                     )
-                    topk_logprobs_full = torch.zeros(
-                        (1, total_packed_len, self.k),
-                        dtype=topk_logprobs_local.dtype,
-                        device=topk_logprobs_local.device,
-                    )
-
                     for i in range(batch_size):
                         start_idx = int(cu_seqlens_padded[i].item())
                         end_idx = int(cu_seqlens_padded[i + 1].item())
@@ -725,13 +706,6 @@ class TopkLogitsPostProcessor:
                             )
                             gathered_idx = allgather_cp_sharded_tensor(
                                 local_idx_slice, cp_grp, seq_dim=1
-                            )
-                            gathered_logprobs = allgather_cp_sharded_tensor(
-                                topk_logprobs_local[
-                                    :, start_idx // cp_size : end_idx // cp_size, :
-                                ],
-                                cp_grp,
-                                seq_dim=1,
                             )
                             # Some kernels may return [X, Y, k] where X*Y = (end_idx - start_idx).
                             # Flatten leading dims and reshape to [1, expected_len, k] to match target.
@@ -752,9 +726,6 @@ class TopkLogitsPostProcessor:
                                 )
                             topk_vals_full[:, start_idx:end_idx, :] = gathered_vals
                             topk_idx_full[:, start_idx:end_idx, :] = gathered_idx
-                            topk_logprobs_full[:, start_idx:end_idx, :] = (
-                                gathered_logprobs.reshape(1, expected_len, self.k)
-                            )
                 else:
                     # Sequence packing must be enabled when CP > 1
                     raise RuntimeError(
@@ -763,7 +734,6 @@ class TopkLogitsPostProcessor:
             else:
                 topk_vals_full = topk_vals_local
                 topk_idx_full = topk_idx_local
-                topk_logprobs_full = topk_logprobs_local
 
             if pack:
                 batch_size = data_dict["input_ids"].shape[0]
@@ -777,11 +747,6 @@ class TopkLogitsPostProcessor:
                     dtype=topk_idx_full.dtype,
                     device=topk_idx_full.device,
                 )
-                out_logprobs = torch.zeros(
-                    (batch_size, unpacked_seqlen, self.k),
-                    dtype=topk_logprobs_full.dtype,
-                    device=topk_logprobs_full.device,
-                )
                 for i in range(batch_size):
                     seq_len = int(seq_lengths[i].item())
                     start_idx = int(cu_seqlens_padded[i].item())
@@ -792,18 +757,13 @@ class TopkLogitsPostProcessor:
                         out_idx[i, :seq_len, :] = topk_idx_full[
                             0, start_idx : start_idx + seq_len, :
                         ]
-                        out_logprobs[i, :seq_len, :] = topk_logprobs_full[
-                            0, start_idx : start_idx + seq_len, :
-                        ]
                 return output_tensor.new_zeros(()), {
                     "topk_logits": out_vals,
-                    "topk_logprobs": out_logprobs,
                     "topk_indices": out_idx,
                 }
             else:
                 return output_tensor.new_zeros(()), {
                     "topk_logits": topk_vals_full,
-                    "topk_logprobs": topk_logprobs_full,
                     "topk_indices": topk_idx_full,
                 }
 
@@ -820,6 +780,15 @@ class SupportLogprobsPostProcessor:
         self,
         data_dict: BatchedDataDict[Any],
     ) -> Callable[[torch.Tensor], Tuple[torch.Tensor, Dict[str, torch.Tensor]]]:
+        """Create a function that gathers normalized log-probabilities.
+
+        Args:
+            data_dict: Model inputs containing ``topk_indices`` with shape
+                ``[batch, sequence, k]``.
+
+        Returns:
+            Function returning ``support_logprobs`` at the requested indices.
+        """
         if self.cfg["sequence_packing"]["enabled"]:
             raise NotImplementedError(
                 "Support logprob gathering does not yet support sequence packing."

--- a/nemo_rl/models/megatron/train.py
+++ b/nemo_rl/models/megatron/train.py
@@ -49,6 +49,8 @@ from nemo_rl.distributed.model_utils import (
     distributed_vocab_topk,
     from_parallel_logits_to_logprobs,
     from_parallel_logits_to_logprobs_packed_sequences,
+    gather_logits_at_global_indices,
+    vocab_parallel_log_softmax,
 )
 from nemo_rl.models.megatron.config import MegatronModule
 from nemo_rl.models.megatron.data import ProcessedMicrobatch
@@ -66,6 +68,7 @@ from nemo_rl.models.policy import PolicyConfig
 PostProcessingFunction = Union[
     "LossPostProcessor",
     "LogprobsPostProcessor",
+    "SupportLogprobsPostProcessor",
     "TopkLogitsPostProcessor",
 ]
 
@@ -262,7 +265,12 @@ def forward_with_post_processing_fn(
     # Loss computation should use unscaled logits.
     if isinstance(
         post_processing_fn,
-        (LossPostProcessor, LogprobsPostProcessor, TopkLogitsPostProcessor),
+        (
+            LossPostProcessor,
+            LogprobsPostProcessor,
+            SupportLogprobsPostProcessor,
+            TopkLogitsPostProcessor,
+        ),
     ):
         # Temperature scaling is element-wise, directly applying it here.
         # Other sampling parameters like top-k and top-p need the logits from whole vocabulary,
@@ -288,6 +296,8 @@ def forward_with_post_processing_fn(
             data_dict=data_dict,
             cu_seqlens_padded=cu_seqlens_padded,
         )
+    elif isinstance(post_processing_fn, SupportLogprobsPostProcessor):
+        post_processing_fn_wrapped = post_processing_fn(data_dict=data_dict)
     else:
         raise TypeError(
             f"Unknown post-processing function type: {type(post_processing_fn)}"
@@ -627,7 +637,7 @@ class TopkLogitsPostProcessor:
         data_dict: BatchedDataDict[Any],
         cu_seqlens_padded: torch.Tensor,
     ) -> Callable[[torch.Tensor], Tuple[torch.Tensor, Dict[str, torch.Tensor]]]:
-        """Create a post-processing function that computes top-k logits and indices.
+        """Create a post-processing function for top-k logits, logprobs, and indices.
 
         This function returns a processor that extracts the top-k highest logits
         and their corresponding vocabulary indices from model outputs. It handles
@@ -638,8 +648,8 @@ class TopkLogitsPostProcessor:
             cu_seqlens_padded: Cumulative sequence lengths for packed sequences
 
         Returns:
-            Callable: Function that takes output tensor and returns
-                      (dummy_loss, {"topk_logits": values, "topk_indices": indices})
+            Callable: Function that returns top-k logits, globally normalized
+                top-k logprobs, and global vocabulary indices.
         """
         pack = self.cfg["sequence_packing"]["enabled"]
         cp_size = self.cfg["megatron_cfg"]["context_parallel_size"]
@@ -664,6 +674,18 @@ class TopkLogitsPostProcessor:
                 vocab_end_index=vocab_start_index + vocab_shard_size,
                 chunk_size=chunk_size,
             )
+            local_logprobs = vocab_parallel_log_softmax(
+                output_tensor,
+                temperature=1.0,
+                tp_group=tp_grp if torch.distributed.is_initialized() else None,
+            )
+            topk_logprobs_local = gather_logits_at_global_indices(
+                local_logprobs,
+                topk_idx_local,
+                tp_group=tp_grp if torch.distributed.is_initialized() else None,
+                vocab_start_index=vocab_start_index,
+                vocab_end_index=vocab_start_index + vocab_shard_size,
+            )
 
             if self.cfg["megatron_cfg"]["context_parallel_size"] > 1:
                 cp_grp = get_context_parallel_group()
@@ -682,6 +704,11 @@ class TopkLogitsPostProcessor:
                         dtype=topk_idx_local.dtype,
                         device=topk_idx_local.device,
                     )
+                    topk_logprobs_full = torch.zeros(
+                        (1, total_packed_len, self.k),
+                        dtype=topk_logprobs_local.dtype,
+                        device=topk_logprobs_local.device,
+                    )
 
                     for i in range(batch_size):
                         start_idx = int(cu_seqlens_padded[i].item())
@@ -698,6 +725,13 @@ class TopkLogitsPostProcessor:
                             )
                             gathered_idx = allgather_cp_sharded_tensor(
                                 local_idx_slice, cp_grp, seq_dim=1
+                            )
+                            gathered_logprobs = allgather_cp_sharded_tensor(
+                                topk_logprobs_local[
+                                    :, start_idx // cp_size : end_idx // cp_size, :
+                                ],
+                                cp_grp,
+                                seq_dim=1,
                             )
                             # Some kernels may return [X, Y, k] where X*Y = (end_idx - start_idx).
                             # Flatten leading dims and reshape to [1, expected_len, k] to match target.
@@ -718,6 +752,9 @@ class TopkLogitsPostProcessor:
                                 )
                             topk_vals_full[:, start_idx:end_idx, :] = gathered_vals
                             topk_idx_full[:, start_idx:end_idx, :] = gathered_idx
+                            topk_logprobs_full[:, start_idx:end_idx, :] = (
+                                gathered_logprobs.reshape(1, expected_len, self.k)
+                            )
                 else:
                     # Sequence packing must be enabled when CP > 1
                     raise RuntimeError(
@@ -726,6 +763,7 @@ class TopkLogitsPostProcessor:
             else:
                 topk_vals_full = topk_vals_local
                 topk_idx_full = topk_idx_local
+                topk_logprobs_full = topk_logprobs_local
 
             if pack:
                 batch_size = data_dict["input_ids"].shape[0]
@@ -739,6 +777,11 @@ class TopkLogitsPostProcessor:
                     dtype=topk_idx_full.dtype,
                     device=topk_idx_full.device,
                 )
+                out_logprobs = torch.zeros(
+                    (batch_size, unpacked_seqlen, self.k),
+                    dtype=topk_logprobs_full.dtype,
+                    device=topk_logprobs_full.device,
+                )
                 for i in range(batch_size):
                     seq_len = int(seq_lengths[i].item())
                     start_idx = int(cu_seqlens_padded[i].item())
@@ -749,15 +792,73 @@ class TopkLogitsPostProcessor:
                         out_idx[i, :seq_len, :] = topk_idx_full[
                             0, start_idx : start_idx + seq_len, :
                         ]
+                        out_logprobs[i, :seq_len, :] = topk_logprobs_full[
+                            0, start_idx : start_idx + seq_len, :
+                        ]
                 return output_tensor.new_zeros(()), {
                     "topk_logits": out_vals,
+                    "topk_logprobs": out_logprobs,
                     "topk_indices": out_idx,
                 }
             else:
                 return output_tensor.new_zeros(()), {
                     "topk_logits": topk_vals_full,
+                    "topk_logprobs": topk_logprobs_full,
                     "topk_indices": topk_idx_full,
                 }
+
+        return processor_fn_inner
+
+
+class SupportLogprobsPostProcessor:
+    """Gather full-vocabulary-normalized logprobs on caller-provided support."""
+
+    def __init__(self, cfg: PolicyConfig):
+        self.cfg = cfg
+
+    def __call__(
+        self,
+        data_dict: BatchedDataDict[Any],
+    ) -> Callable[[torch.Tensor], Tuple[torch.Tensor, Dict[str, torch.Tensor]]]:
+        if self.cfg["sequence_packing"]["enabled"]:
+            raise NotImplementedError(
+                "Support logprob gathering does not yet support sequence packing."
+            )
+        if self.cfg["megatron_cfg"]["context_parallel_size"] != 1:
+            raise NotImplementedError(
+                "Support logprob gathering does not yet support context parallelism."
+            )
+        support_indices = data_dict["topk_indices"]
+        if support_indices.ndim != 3 or support_indices.shape[-1] < 1:
+            raise ValueError(
+                "topk_indices must have shape [batch, sequence, k] with k >= 1, "
+                f"got {support_indices.shape}."
+            )
+
+        def processor_fn_inner(output_tensor):
+            if support_indices.shape[:2] != output_tensor.shape[:2]:
+                raise ValueError(
+                    "topk_indices must match model output batch and sequence dimensions, "
+                    f"got {support_indices.shape[:2]} and {output_tensor.shape[:2]}."
+                )
+            tp_grp = get_tensor_model_parallel_group()
+            tp_rank = get_tensor_model_parallel_rank()
+            vocab_shard_size = output_tensor.shape[-1]
+            vocab_start_index = tp_rank * vocab_shard_size
+            active_tp_grp = tp_grp if torch.distributed.is_initialized() else None
+            local_logprobs = vocab_parallel_log_softmax(
+                output_tensor,
+                temperature=1.0,
+                tp_group=active_tp_grp,
+            )
+            support_logprobs = gather_logits_at_global_indices(
+                local_logprobs,
+                support_indices.to(device=output_tensor.device, dtype=torch.long),
+                tp_group=active_tp_grp,
+                vocab_start_index=vocab_start_index,
+                vocab_end_index=vocab_start_index + vocab_shard_size,
+            )
+            return output_tensor.new_zeros(()), {"support_logprobs": support_logprobs}
 
         return processor_fn_inner
 

--- a/nemo_rl/models/policy/interfaces.py
+++ b/nemo_rl/models/policy/interfaces.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import ABC, abstractmethod
-from typing import Any, Optional, TypedDict
+from typing import Any, NotRequired, Optional, TypedDict
 
 import ray
 import torch
@@ -42,9 +42,14 @@ class ScoreOutputSpec(TypedDict):
 
 
 class TopkLogitsOutputSpec(TypedDict):
-    """Per-position top-k logits and corresponding global token indices."""
+    """Per-position top-k values and corresponding global token indices.
+
+    ``topk_logprobs`` is normalized against the complete vocabulary; it is
+    optional for backend compatibility while implementations migrate.
+    """
 
     topk_logits: torch.Tensor
+    topk_logprobs: NotRequired[torch.Tensor]
     topk_indices: torch.Tensor
 
 

--- a/nemo_rl/models/policy/interfaces.py
+++ b/nemo_rl/models/policy/interfaces.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import ABC, abstractmethod
-from typing import Any, NotRequired, Optional, TypedDict
+from typing import Any, Optional, TypedDict
 
 import ray
 import torch
@@ -42,14 +42,9 @@ class ScoreOutputSpec(TypedDict):
 
 
 class TopkLogitsOutputSpec(TypedDict):
-    """Per-position top-k values and corresponding global token indices.
-
-    ``topk_logprobs`` is normalized against the complete vocabulary; it is
-    optional for backend compatibility while implementations migrate.
-    """
+    """Per-position top-k values and corresponding global token indices."""
 
     topk_logits: torch.Tensor
-    topk_logprobs: NotRequired[torch.Tensor]
     topk_indices: torch.Tensor
 
 

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -652,7 +652,17 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
         micro_batch_size: Optional[int] = None,
         timer: Optional[Timer] = None,
     ) -> BatchedDataDict[TopkLogitsOutputSpec]:
-        """Dispatch get_topk_logits to workers (no CP/packed support initially)."""
+        """Dispatch top-k evaluation to workers.
+
+        Args:
+            data: Tokenized model inputs.
+            k: Number of vocabulary entries to return per position.
+            micro_batch_size: Optional inference microbatch size.
+            timer: Optional timing collector.
+
+        Returns:
+            Top-k logits and global vocabulary indices.
+        """
         with timer.time("get_topk_logits/shard_data") if timer else nullcontext():
             sharded_data, unsorted_data_indices = self._shard_for_logprob(data)
 
@@ -675,7 +685,10 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
                     "tensor_parallel",
                     "pipeline_parallel",
                 ],
-                common_kwargs={"k": k, "micro_batch_size": micro_batch_size},
+                common_kwargs={
+                    "k": k,
+                    "micro_batch_size": micro_batch_size,
+                },
             )
 
         # Avoid BatchedDataDict.from_batches here because it flattens rows for tensors with ndim>2 ([B,S,k] -> [B,S*k]).
@@ -686,11 +699,6 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
         stacked: BatchedDataDict[TopkLogitsOutputSpec] = BatchedDataDict()
         stacked["topk_logits"] = torch.cat(all_topk_logits, dim=0)
         stacked["topk_indices"] = torch.cat(all_topk_indices, dim=0)
-        if all("topk_logprobs" in batch for batch in worker_batches):
-            stacked["topk_logprobs"] = torch.cat(
-                [batch["topk_logprobs"] for batch in worker_batches], dim=0
-            )
-
         if unsorted_data_indices is not None:
             stacked.reorder_data(unsorted_data_indices)
 

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -681,13 +681,15 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
         # Avoid BatchedDataDict.from_batches here because it flattens rows for tensors with ndim>2 ([B,S,k] -> [B,S*k]).
         worker_batches = self.worker_group.get_all_worker_results(futures)
         all_topk_logits = [wb["topk_logits"] for wb in worker_batches]
-        all_topk_logprobs = [wb["topk_logprobs"] for wb in worker_batches]
         all_topk_indices = [wb["topk_indices"] for wb in worker_batches]
 
         stacked: BatchedDataDict[TopkLogitsOutputSpec] = BatchedDataDict()
         stacked["topk_logits"] = torch.cat(all_topk_logits, dim=0)
-        stacked["topk_logprobs"] = torch.cat(all_topk_logprobs, dim=0)
         stacked["topk_indices"] = torch.cat(all_topk_indices, dim=0)
+        if all("topk_logprobs" in batch for batch in worker_batches):
+            stacked["topk_logprobs"] = torch.cat(
+                [batch["topk_logprobs"] for batch in worker_batches], dim=0
+            )
 
         if unsorted_data_indices is not None:
             stacked.reorder_data(unsorted_data_indices)

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -681,10 +681,12 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
         # Avoid BatchedDataDict.from_batches here because it flattens rows for tensors with ndim>2 ([B,S,k] -> [B,S*k]).
         worker_batches = self.worker_group.get_all_worker_results(futures)
         all_topk_logits = [wb["topk_logits"] for wb in worker_batches]
+        all_topk_logprobs = [wb["topk_logprobs"] for wb in worker_batches]
         all_topk_indices = [wb["topk_indices"] for wb in worker_batches]
 
         stacked: BatchedDataDict[TopkLogitsOutputSpec] = BatchedDataDict()
         stacked["topk_logits"] = torch.cat(all_topk_logits, dim=0)
+        stacked["topk_logprobs"] = torch.cat(all_topk_logprobs, dim=0)
         stacked["topk_indices"] = torch.cat(all_topk_indices, dim=0)
 
         if unsorted_data_indices is not None:

--- a/nemo_rl/models/policy/teacher_worker_group.py
+++ b/nemo_rl/models/policy/teacher_worker_group.py
@@ -115,7 +115,7 @@ class TeacherWorkerGroup:
     - Never initializes an optimizer
     - Never initializes a reference model
     - Loads the checkpoint once at startup
-    - Only exposes get_logprobs()
+    - Exposes sampled-token and caller-selected-support logprob inference
     """
 
     def __init__(

--- a/nemo_rl/models/policy/teacher_worker_group.py
+++ b/nemo_rl/models/policy/teacher_worker_group.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass
 from typing import Any, Optional
 
 import numpy as np
+import torch
 from transformers import PreTrainedTokenizerBase
 
 from nemo_rl.algorithms.opd import TeacherResourceConfig
@@ -293,6 +294,57 @@ class TeacherWorkerGroup:
             result.reorder_data(unsorted_data_indices)
 
         return result
+
+    def get_logprobs_on_support(
+        self,
+        data: BatchedDataDict[GenerationDatumSpec],
+        micro_batch_size: Optional[int] = None,
+    ) -> BatchedDataDict[Any]:
+        """Evaluate teacher logprobs on student-selected vocabulary indices.
+
+        ``data['topk_indices']`` must have shape ``[B, S, K]`` and align with
+        ``input_ids``. This first implementation intentionally excludes packing
+        and context parallelism; those layouts require explicit support-index
+        packing/sharding rather than implicit reshaping.
+        """
+        if self.use_sequence_packing:
+            raise NotImplementedError(
+                "Student-top-k teacher evaluation does not yet support sequence packing."
+            )
+        if self.cfg["megatron_cfg"]["context_parallel_size"] != 1:
+            raise NotImplementedError(
+                "Student-top-k teacher evaluation does not yet support context parallelism."
+            )
+        if "topk_indices" not in data:
+            raise ValueError("get_logprobs_on_support requires data['topk_indices'].")
+
+        dp_size = self.sharding_annotations.get_axis_size("data_parallel")
+        mbs = micro_batch_size or self._micro_batch_size
+        sharded_data = data.shard_by_batch_size(dp_size, batch_size=None)
+        futures = self.worker_group.run_all_workers_sharded_data(
+            "get_logprobs_on_support",
+            data=sharded_data,
+            in_sharded_axes=["data_parallel"],
+            replicate_on_axes=[
+                "context_parallel",
+                "tensor_parallel",
+                "pipeline_parallel",
+            ],
+            output_is_replicated=[
+                "context_parallel",
+                "tensor_parallel",
+                "pipeline_parallel",
+            ],
+            common_kwargs={"micro_batch_size": mbs},
+        )
+        worker_batches = self.worker_group.get_all_worker_results(futures)
+        return BatchedDataDict(
+            {
+                "support_logprobs": torch.cat(
+                    [batch["support_logprobs"] for batch in worker_batches], dim=0
+                ).cpu()
+            }
+        )
 
     def shutdown(self) -> bool:
         """Shut down all workers and clean up resources."""

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -1816,9 +1816,12 @@ class MegatronPolicyWorkerImpl(
         k: int,
         micro_batch_size: Optional[int] = None,
     ):
-        """Get the top-k logits and indices for a batch of data.
+        """Get top-k model outputs for a batch of data.
 
-        The major difference from get_logprobs is that we compute top-k logits and indices for each position in the sequence.
+        Args:
+            data: Tokenized model inputs.
+            k: Number of vocabulary entries to return per position.
+            micro_batch_size: Optional inference microbatch size.
 
         Returns:
             BatchedDataDict containing:
@@ -1867,53 +1870,41 @@ class MegatronPolicyWorkerImpl(
 
         if parallel_state.is_pipeline_last_stage(ignore_virtual=True):
             logits_chunks = []
-            logprobs_chunks = []
             indices_chunks = []
             for out in list_of_outputs:
                 tk = out["topk_logits"]
-                tlp = out["topk_logprobs"]
                 ti = out["topk_indices"]
                 pad_len = seq_length - tk.shape[1]
                 if pad_len > 0:
                     tk = torch.nn.functional.pad(tk, (0, 0, 0, pad_len), value=0.0)
-                    tlp = torch.nn.functional.pad(tlp, (0, 0, 0, pad_len), value=0.0)
                     ti = torch.nn.functional.pad(ti, (0, 0, 0, pad_len), value=0)
                 logits_chunks.append(tk)
-                logprobs_chunks.append(tlp)
                 indices_chunks.append(ti)
 
             topk_logits = torch.cat(logits_chunks, dim=0)
-            topk_logprobs = torch.cat(logprobs_chunks, dim=0)
             topk_indices = torch.cat(indices_chunks, dim=0)
 
             tensors_to_broadcast = {
                 "topk_logits": topk_logits,
-                "topk_logprobs": topk_logprobs,
                 "topk_indices": topk_indices,
             }
         else:
             tensors_to_broadcast = {
                 "topk_logits": None,
-                "topk_logprobs": None,
                 "topk_indices": None,
             }
 
         # Broadcast tensors from last stage to all stages
         broadcasted = broadcast_tensors_from_last_stage(tensors_to_broadcast)
         topk_logits = broadcasted["topk_logits"]
-        topk_logprobs = broadcasted["topk_logprobs"]
         topk_indices = broadcasted["topk_indices"]
 
         no_grad.__exit__(None, None, None)
-        return BatchedDataDict.from_batches(
-            [
-                {
-                    "topk_logits": topk_logits.cpu(),
-                    "topk_logprobs": topk_logprobs.cpu(),
-                    "topk_indices": topk_indices.cpu(),
-                }
-            ]
-        )
+        result = {
+            "topk_logits": topk_logits.cpu(),
+            "topk_indices": topk_indices.cpu(),
+        }
+        return BatchedDataDict.from_batches([result])
 
     @wrap_with_nvtx_name("megatron_policy_worker/get_logprobs_on_support")
     def get_logprobs_on_support(
@@ -1922,7 +1913,17 @@ class MegatronPolicyWorkerImpl(
         data: BatchedDataDict[GenerationDatumSpec],
         micro_batch_size: Optional[int] = None,
     ) -> BatchedDataDict[Any]:
-        """Evaluate normalized model logprobs at caller-provided top-k indices."""
+        """Evaluate normalized model log-probabilities on a supplied support.
+
+        Args:
+            data: Model inputs containing ``topk_indices`` with shape
+                ``[batch, sequence, k]``.
+            micro_batch_size: Optional inference microbatch size.
+
+        Returns:
+            Full-vocabulary-normalized ``support_logprobs`` aligned with the
+            supplied support indices.
+        """
         if self.cfg["sequence_packing"]["enabled"]:
             raise NotImplementedError(
                 "get_logprobs_on_support does not yet support sequence packing."

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -82,6 +82,7 @@ from nemo_rl.models.megatron.setup import (
 from nemo_rl.models.megatron.train import (
     LogprobsPostProcessor,
     LossPostProcessor,
+    SupportLogprobsPostProcessor,
     TopkLogitsPostProcessor,
     aggregate_training_statistics,
     megatron_forward_backward,
@@ -1866,39 +1867,129 @@ class MegatronPolicyWorkerImpl(
 
         if parallel_state.is_pipeline_last_stage(ignore_virtual=True):
             logits_chunks = []
+            logprobs_chunks = []
             indices_chunks = []
             for out in list_of_outputs:
                 tk = out["topk_logits"]
+                tlp = out["topk_logprobs"]
                 ti = out["topk_indices"]
                 pad_len = seq_length - tk.shape[1]
                 if pad_len > 0:
                     tk = torch.nn.functional.pad(tk, (0, 0, 0, pad_len), value=0.0)
+                    tlp = torch.nn.functional.pad(tlp, (0, 0, 0, pad_len), value=0.0)
                     ti = torch.nn.functional.pad(ti, (0, 0, 0, pad_len), value=0)
                 logits_chunks.append(tk)
+                logprobs_chunks.append(tlp)
                 indices_chunks.append(ti)
 
             topk_logits = torch.cat(logits_chunks, dim=0)
+            topk_logprobs = torch.cat(logprobs_chunks, dim=0)
             topk_indices = torch.cat(indices_chunks, dim=0)
 
             tensors_to_broadcast = {
                 "topk_logits": topk_logits,
+                "topk_logprobs": topk_logprobs,
                 "topk_indices": topk_indices,
             }
         else:
             tensors_to_broadcast = {
                 "topk_logits": None,
+                "topk_logprobs": None,
                 "topk_indices": None,
             }
 
         # Broadcast tensors from last stage to all stages
         broadcasted = broadcast_tensors_from_last_stage(tensors_to_broadcast)
         topk_logits = broadcasted["topk_logits"]
+        topk_logprobs = broadcasted["topk_logprobs"]
         topk_indices = broadcasted["topk_indices"]
 
         no_grad.__exit__(None, None, None)
         return BatchedDataDict.from_batches(
-            [{"topk_logits": topk_logits.cpu(), "topk_indices": topk_indices.cpu()}]
+            [
+                {
+                    "topk_logits": topk_logits.cpu(),
+                    "topk_logprobs": topk_logprobs.cpu(),
+                    "topk_indices": topk_indices.cpu(),
+                }
+            ]
         )
+
+    @wrap_with_nvtx_name("megatron_policy_worker/get_logprobs_on_support")
+    def get_logprobs_on_support(
+        self,
+        *,
+        data: BatchedDataDict[GenerationDatumSpec],
+        micro_batch_size: Optional[int] = None,
+    ) -> BatchedDataDict[Any]:
+        """Evaluate normalized model logprobs at caller-provided top-k indices."""
+        if self.cfg["sequence_packing"]["enabled"]:
+            raise NotImplementedError(
+                "get_logprobs_on_support does not yet support sequence packing."
+            )
+        if self.cfg["megatron_cfg"]["context_parallel_size"] != 1:
+            raise NotImplementedError(
+                "get_logprobs_on_support does not yet support context parallelism."
+            )
+
+        with torch.no_grad():
+            self.model.eval()
+            logprob_batch_size = (
+                micro_batch_size
+                if micro_batch_size is not None
+                else self.cfg["logprob_batch_size"]
+            )
+            (
+                mb_iterator,
+                num_microbatches,
+                micro_batch_size,
+                seq_length,
+                padded_seq_length,
+            ) = get_microbatch_iterator(
+                data,
+                self.cfg,
+                logprob_batch_size,
+                straggler_timer=self.mcore_state.straggler_timer,
+                delegate_pack_to_model=self.delegate_pack_to_model,
+                delegate_mtp_loss_mask_to_model=self.delegate_mtp_loss_mask_to_model,
+                model_slices_context_parallel_inputs=(
+                    self.model_slices_context_parallel_inputs
+                ),
+            )
+
+            list_of_outputs = megatron_forward_backward(
+                model=self.model,
+                data_iterator=mb_iterator,
+                seq_length=padded_seq_length,
+                mbs=micro_batch_size,
+                num_microbatches=num_microbatches,
+                post_processing_fn=SupportLogprobsPostProcessor(cfg=self.cfg),
+                forward_only=True,
+                defer_fp32_logits=self.defer_fp32_logits,
+                sampling_params=self.sampling_params,
+                straggler_timer=self.mcore_state.straggler_timer,
+            )
+
+            if parallel_state.is_pipeline_last_stage(ignore_virtual=True):
+                chunks = []
+                for out in list_of_outputs:
+                    support_logprobs = out["support_logprobs"]
+                    pad_len = seq_length - support_logprobs.shape[1]
+                    if pad_len > 0:
+                        support_logprobs = torch.nn.functional.pad(
+                            support_logprobs,
+                            (0, 0, 0, pad_len),
+                            value=0.0,
+                        )
+                    chunks.append(support_logprobs)
+                gathered_support_logprobs = torch.cat(chunks, dim=0)
+            else:
+                gathered_support_logprobs = None
+
+            broadcasted = broadcast_tensors_from_last_stage(
+                {"support_logprobs": gathered_support_logprobs}
+            )["support_logprobs"]
+            return BatchedDataDict({"support_logprobs": broadcasted.cpu()})
 
     @torch.no_grad()
     @wrap_with_nvtx_name("megatron_policy_worker/prepare_refit_info")

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -45,6 +45,7 @@ from nemo_rl.algorithms.grpo import (
     _save_async_replay_buffer_checkpoint,
     _should_use_async_rollouts,
     _validate_multimodal_dedup_capability,
+    _validate_student_topk_config,
     _validate_use_kl_in_reward_compat,
     aggregate_rollout_metrics,
     async_grpo_train,
@@ -57,6 +58,7 @@ from nemo_rl.algorithms.grpo import (
 )
 from nemo_rl.algorithms.grpo_sync import _train_fields_for_step, grpo_train_sync
 from nemo_rl.algorithms.loss import ClippedPGLossConfig, ClippedPGLossFn
+from nemo_rl.algorithms.opd import OnPolicyDistillationConfig
 from nemo_rl.algorithms.reward_functions import (
     RewardShapingConfig,
     apply_reward_shaping,
@@ -182,6 +184,71 @@ def test_initial_policy_generation_stale() -> None:
 
     generation.weight_synchronizer.is_stale = True
     assert _initial_policy_generation_stale(generation, completed_steps=0)
+
+
+def _enable_valid_student_topk(master_config: MasterConfig) -> None:
+    master_config.on_policy_distillation = OnPolicyDistillationConfig(
+        enabled=True, student_topk=8
+    )
+    master_config.grpo.async_grpo.enabled = True
+    master_config.grpo.adv_estimator.name = "opd"
+    master_config.loss_fn.reference_policy_kl_penalty = 0
+    master_config.policy["sequence_packing"] = {"enabled": False}
+    master_config.policy["megatron_cfg"] = {
+        "enabled": True,
+        "context_parallel_size": 1,
+    }
+    master_config.policy["generation"]["top_k"] = None
+    master_config.policy["generation"]["top_p"] = 1.0
+
+
+def test_validate_student_topk_config_accepts_supported_settings(
+    mock_grpo_components,
+):
+    master_config = mock_grpo_components["master_config"]
+    _enable_valid_student_topk(master_config)
+
+    _validate_student_topk_config(master_config, student_topk=8)
+
+
+@pytest.mark.parametrize(
+    ("invalid_setting", "error_type", "message"),
+    [
+        ("opd_disabled", ValueError, "requires on_policy_distillation.enabled=true"),
+        ("sync_grpo", NotImplementedError, "only grpo.async_grpo.enabled=true"),
+        ("sequence_packing", NotImplementedError, "sequence packing"),
+        ("context_parallel", NotImplementedError, "context parallelism"),
+        ("non_megatron", NotImplementedError, "Megatron policy backend"),
+        ("filtered_sampling", NotImplementedError, "unfiltered training distributions"),
+        ("reference_kl", ValueError, "reference_policy_kl_penalty=0"),
+        ("adv_estimator", ValueError, "adv_estimator.name='opd'"),
+    ],
+)
+def test_validate_student_topk_config_rejects_unsupported_settings(
+    mock_grpo_components, invalid_setting, error_type, message
+):
+    master_config = mock_grpo_components["master_config"]
+    _enable_valid_student_topk(master_config)
+
+    if invalid_setting == "opd_disabled":
+        master_config.on_policy_distillation.enabled = False
+    elif invalid_setting == "sync_grpo":
+        master_config.grpo.async_grpo.enabled = False
+    elif invalid_setting == "sequence_packing":
+        master_config.policy["sequence_packing"]["enabled"] = True
+    elif invalid_setting == "context_parallel":
+        master_config.policy["megatron_cfg"]["context_parallel_size"] = 2
+    elif invalid_setting == "non_megatron":
+        master_config.policy["megatron_cfg"]["enabled"] = False
+    elif invalid_setting == "filtered_sampling":
+        master_config.policy["generation"]["top_k"] = 16
+    elif invalid_setting == "reference_kl":
+        master_config.loss_fn.reference_policy_kl_penalty = 0.01
+    elif invalid_setting == "adv_estimator":
+        master_config.grpo.adv_estimator.name = "grpo"
+
+    with pytest.raises(error_type, match=message):
+        _validate_student_topk_config(master_config, student_topk=8)
 
 
 @pytest.fixture

--- a/tests/unit/algorithms/test_loss_functions.py
+++ b/tests/unit/algorithms/test_loss_functions.py
@@ -70,9 +70,6 @@ def _student_topk_opd_loss_data():
             "generation_logprobs": torch.tensor([[0.0, -1.1, -1.2]]),
             "reference_policy_logprobs": torch.zeros(1, 3),
             "prev_topk_indices": torch.tensor([[[1, 0], [0, 1], [0, 0]]]),
-            "prev_topk_logprobs": torch.tensor(
-                [[[-0.4, -1.4], [-0.5, -1.5], [0.0, 0.0]]]
-            ),
             "teacher_support_logprobs": torch.tensor(
                 [[[-0.7, -1.2], [-0.8, -1.0], [0.0, 0.0]]]
             ),
@@ -95,6 +92,41 @@ def test_student_topk_opd_loss_configuration_guards():
     assert loss_fn.input_type.value == "opd_student_topk"
 
 
+@pytest.mark.parametrize(
+    "config_overrides,use_fused_linear_logprobs,error_match",
+    [
+        ({}, True, "fused linear logprobs"),
+        ({"use_cispo": True}, False, "CISPO"),
+        ({"ratio_clip_c": 2.0}, False, "dual PPO clipping"),
+        (
+            {"sequence_level_importance_ratios": True},
+            False,
+            "token-level loss and importance ratios",
+        ),
+        (
+            {"token_level_loss": False},
+            False,
+            "token-level loss and importance ratios",
+        ),
+    ],
+)
+def test_student_topk_opd_loss_rejects_incompatible_options(
+    config_overrides, use_fused_linear_logprobs, error_match
+):
+    cfg = ClippedPGLossConfig(
+        disable_ppo_ratio=True,
+        reference_policy_kl_penalty=0.0,
+        **config_overrides,
+    )
+
+    with pytest.raises(ValueError, match=error_match):
+        ClippedPGLossFn(
+            cfg,
+            use_fused_linear_logprobs=use_fused_linear_logprobs,
+            opd_student_topk=2,
+        )
+
+
 def test_student_topk_opd_loss_uses_head_and_sampled_tail():
     from nemo_rl.algorithms.opd import student_topk_reverse_kl_loss
 
@@ -106,6 +138,9 @@ def test_student_topk_opd_loss_uses_head_and_sampled_tail():
         opd_student_topk=2,
     )
     data = _student_topk_opd_loss_data()
+    # Only the second target contributes. This makes the assertion sensitive to
+    # the loss function's internal ``token_mask[:, 1:]`` slicing.
+    data["token_mask"] = torch.tensor([[0.0, 0.0, 1.0]])
     current_target = torch.tensor([[-0.6, -1.3]], requires_grad=True)
     current_support = torch.tensor([[[-0.3, -1.6], [-0.4, -1.7]]], requires_grad=True)
 
@@ -114,7 +149,7 @@ def test_student_topk_opd_loss_uses_head_and_sampled_tail():
         current_support_logprobs=current_support,
         data=data,
         global_valid_seqs=torch.tensor(1.0),
-        global_valid_toks=torch.tensor(2.0),
+        global_valid_toks=torch.tensor(1.0),
     )
 
     expected = student_topk_reverse_kl_loss(
@@ -123,12 +158,12 @@ def test_student_topk_opd_loss_uses_head_and_sampled_tail():
         current_target,
         data["teacher_reference_logprobs"][:, 1:],
         target_in_support=torch.tensor([[True, False]]),
-    ).mean()
+    )[:, 1].mean()
     torch.testing.assert_close(loss, expected)
     loss.backward()
     assert current_target.grad is not None
     assert current_support.grad is not None
-    assert metrics["opd_topk_target_outside_fraction"] == pytest.approx(0.5)
+    assert metrics["opd_topk_target_outside_fraction"] == pytest.approx(1.0)
 
 
 def test_prepare_student_topk_opd_loss_input_uses_full_vocab_normalization():

--- a/tests/unit/algorithms/test_loss_functions.py
+++ b/tests/unit/algorithms/test_loss_functions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -57,6 +57,103 @@ def setup_dpo_loss_test_data(vocab_size=16, batch_size=1):
 
     next_token_logits = torch.zeros((2 * batch_size, seq_len, vocab_size)).to("cuda")
     return data, next_token_logits
+
+
+def _student_topk_opd_loss_data():
+    return BatchedDataDict(
+        {
+            "input_ids": torch.tensor([[0, 1, 2]]),
+            "token_mask": torch.tensor([[0.0, 1.0, 1.0]]),
+            "sample_mask": torch.tensor([1.0]),
+            "advantages": torch.zeros(1, 3),
+            "prev_logprobs": torch.tensor([[0.0, -1.1, -1.2]]),
+            "generation_logprobs": torch.tensor([[0.0, -1.1, -1.2]]),
+            "reference_policy_logprobs": torch.zeros(1, 3),
+            "prev_topk_indices": torch.tensor([[[1, 0], [0, 1], [0, 0]]]),
+            "prev_topk_logprobs": torch.tensor(
+                [[[-0.4, -1.4], [-0.5, -1.5], [0.0, 0.0]]]
+            ),
+            "teacher_support_logprobs": torch.tensor(
+                [[[-0.7, -1.2], [-0.8, -1.0], [0.0, 0.0]]]
+            ),
+            "teacher_reference_logprobs": torch.tensor([[0.0, -0.7, -0.9]]),
+        }
+    )
+
+
+def test_student_topk_opd_loss_configuration_guards():
+    with pytest.raises(ValueError, match="disable_ppo_ratio"):
+        ClippedPGLossFn(ClippedPGLossConfig(), opd_student_topk=2)
+
+    loss_fn = ClippedPGLossFn(
+        ClippedPGLossConfig(
+            disable_ppo_ratio=True,
+            reference_policy_kl_penalty=0.0,
+        ),
+        opd_student_topk=2,
+    )
+    assert loss_fn.input_type.value == "opd_student_topk"
+
+
+def test_student_topk_opd_loss_uses_head_and_sampled_tail():
+    from nemo_rl.algorithms.opd import student_topk_reverse_kl_loss
+
+    loss_fn = ClippedPGLossFn(
+        ClippedPGLossConfig(
+            disable_ppo_ratio=True,
+            reference_policy_kl_penalty=0.0,
+        ),
+        opd_student_topk=2,
+    )
+    data = _student_topk_opd_loss_data()
+    current_target = torch.tensor([[-0.6, -1.3]], requires_grad=True)
+    current_support = torch.tensor([[[-0.3, -1.6], [-0.4, -1.7]]], requires_grad=True)
+
+    loss, metrics = loss_fn(
+        next_token_logprobs=current_target,
+        current_support_logprobs=current_support,
+        data=data,
+        global_valid_seqs=torch.tensor(1.0),
+        global_valid_toks=torch.tensor(2.0),
+    )
+
+    expected = student_topk_reverse_kl_loss(
+        current_support,
+        data["teacher_support_logprobs"][:, :-1],
+        current_target,
+        data["teacher_reference_logprobs"][:, 1:],
+        target_in_support=torch.tensor([[True, False]]),
+    ).mean()
+    torch.testing.assert_close(loss, expected)
+    loss.backward()
+    assert current_target.grad is not None
+    assert current_support.grad is not None
+    assert metrics["opd_topk_target_outside_fraction"] == pytest.approx(0.5)
+
+
+def test_prepare_student_topk_opd_loss_input_uses_full_vocab_normalization():
+    if not torch.cuda.is_available():
+        pytest.skip("Loss-input preparation follows the CUDA training path.")
+
+    loss_fn = ClippedPGLossFn(
+        ClippedPGLossConfig(
+            disable_ppo_ratio=True,
+            reference_policy_kl_penalty=0.0,
+        ),
+        opd_student_topk=2,
+    )
+    data = _student_topk_opd_loss_data().to("cuda")
+    logits = torch.tensor(
+        [[[0.0, 2.0, 1.0], [2.0, 0.0, 1.0], [0.5, 0.0, 1.0]]],
+        device="cuda",
+    )
+
+    loss_input, _ = prepare_loss_input(logits, data, loss_fn)
+
+    full_logprobs = logits.log_softmax(dim=-1)
+    expected_support = full_logprobs.gather(-1, data["prev_topk_indices"])[:, :-1]
+    torch.testing.assert_close(loss_input["current_support_logprobs"], expected_support)
+    assert loss_input["next_token_logprobs"].shape == (1, 2)
 
 
 def test_nll_loss():

--- a/tests/unit/algorithms/test_loss_functions.py
+++ b/tests/unit/algorithms/test_loss_functions.py
@@ -153,10 +153,10 @@ def test_student_topk_opd_loss_uses_head_and_sampled_tail():
     )
 
     expected = student_topk_reverse_kl_loss(
-        current_support,
-        data["teacher_support_logprobs"][:, :-1],
-        current_target,
-        data["teacher_reference_logprobs"][:, 1:],
+        student_support_logprobs=current_support,
+        teacher_support_logprobs=data["teacher_support_logprobs"][:, :-1],
+        student_target_logprobs=current_target,
+        teacher_target_logprobs=data["teacher_reference_logprobs"][:, 1:],
         target_in_support=torch.tensor([[True, False]]),
     )[:, 1].mean()
     torch.testing.assert_close(loss, expected)

--- a/tests/unit/algorithms/test_opd.py
+++ b/tests/unit/algorithms/test_opd.py
@@ -77,8 +77,54 @@ def test_student_topk_adds_sampled_tail_only_outside_support():
         target_in_support=torch.tensor([True]),
     )
 
-    expected_tail = -(teacher_target - student_target).detach() * student_target
+    expected_tail = (1.0 - (teacher_target - student_target).detach()) * student_target
     torch.testing.assert_close(outside_loss - inside_loss, expected_tail)
+
+
+def test_student_topk_tail_gradient_is_unbiased():
+    """Enumerating sampled tail tokens recovers the exact reverse-KL gradient."""
+    student_logits = torch.tensor(
+        [[0.4, -0.3, 0.8, -0.7]], dtype=torch.float64, requires_grad=True
+    )
+    teacher_logits = torch.tensor([[-0.2, 0.6, 0.1, -0.4]], dtype=torch.float64)
+    student_logprobs = student_logits.log_softmax(dim=-1)
+    teacher_logprobs = teacher_logits.log_softmax(dim=-1)
+    support_indices = torch.tensor([2, 0])
+    tail_indices = torch.tensor([1, 3])
+
+    exact_reverse_kl = (
+        student_logprobs.exp() * (student_logprobs - teacher_logprobs)
+    ).sum()
+    exact_grad = torch.autograd.grad(
+        exact_reverse_kl, student_logits, retain_graph=True
+    )[0]
+
+    expected_estimator = student_logits.new_zeros(())
+    sampling_probs = student_logprobs.exp().detach()
+    for target_index in tail_indices:
+        sampled_loss = student_topk_reverse_kl_loss(
+            student_support_logprobs=student_logprobs[:, support_indices],
+            teacher_support_logprobs=teacher_logprobs[:, support_indices],
+            student_target_logprobs=student_logprobs[:, target_index],
+            teacher_target_logprobs=teacher_logprobs[:, target_index],
+            target_in_support=torch.tensor([False]),
+        )
+        expected_estimator = (
+            expected_estimator + sampling_probs[:, target_index] * sampled_loss.sum()
+        )
+
+    # Samples inside the support contribute the exact head term as well. Their
+    # probabilities complete the expectation over the student's vocabulary.
+    support_loss = (
+        student_logprobs[:, support_indices].exp()
+        * (student_logprobs[:, support_indices] - teacher_logprobs[:, support_indices])
+    ).sum()
+    expected_estimator = (
+        expected_estimator + sampling_probs[:, support_indices].sum() * support_loss
+    )
+    estimator_grad = torch.autograd.grad(expected_estimator, student_logits)[0]
+
+    torch.testing.assert_close(estimator_grad, exact_grad)
 
 
 # ---------------------------------------------------------------------------
@@ -99,9 +145,10 @@ class _MockShardingAnnotations:
 class _MockTeacherWorkerGroup:
     """Returns logprobs filled with a constant; validates DP-divisible batch."""
 
-    def __init__(self, fill_value=1.0, dp_size=4):
+    def __init__(self, fill_value=1.0, dp_size=4, include_input_ids=False):
         self._fill_value = fill_value
         self.sharding_annotations = _MockShardingAnnotations(dp_size)
+        self._include_input_ids = include_input_ids
 
     def get_logprobs(self, data):
         input_ids = data["input_ids"]
@@ -120,13 +167,12 @@ class _MockTeacherWorkerGroup:
         topk_indices = data["topk_indices"]
         dp_size = self.sharding_annotations.get_axis_size("data_parallel")
         assert input_ids.shape[0] % dp_size == 0
-        return BatchedDataDict(
-            {
-                "support_logprobs": torch.full(
-                    topk_indices.shape, self._fill_value, dtype=torch.float32
-                )
-            }
+        support_logprobs = torch.full(
+            topk_indices.shape, self._fill_value, dtype=torch.float32
         )
+        if self._include_input_ids:
+            support_logprobs = support_logprobs + input_ids.unsqueeze(-1)
+        return BatchedDataDict({"support_logprobs": support_logprobs})
 
 
 def _make_collector(**overrides):
@@ -225,8 +271,12 @@ def test_compute_teacher_logprobs_routes_to_correct_teacher():
 
 
 def test_compute_teacher_support_logprobs_routes_and_trims_dp_padding():
-    math_twg = _MockTeacherWorkerGroup(fill_value=-1.0, dp_size=4)
-    code_twg = _MockTeacherWorkerGroup(fill_value=-2.0, dp_size=2)
+    math_twg = _MockTeacherWorkerGroup(
+        fill_value=-1.0, dp_size=4, include_input_ids=True
+    )
+    code_twg = _MockTeacherWorkerGroup(
+        fill_value=-2.0, dp_size=2, include_input_ids=True
+    )
     collector = _make_collector(
         teacher_worker_groups={"math": math_twg, "code": code_twg},
         alias_to_group_alias={"math": "math", "code": "code"},
@@ -250,9 +300,15 @@ def test_compute_teacher_support_logprobs_routes_and_trims_dp_padding():
     )
 
     assert result.shape == (3, 5, 2)
-    torch.testing.assert_close(result[0], torch.full((5, 2), -1.0))
-    torch.testing.assert_close(result[1], torch.full((5, 2), -2.0))
-    torch.testing.assert_close(result[2], torch.full((5, 2), -1.0))
+    torch.testing.assert_close(
+        result[0], input_ids[0].unsqueeze(-1).expand(-1, 2) - 1.0
+    )
+    torch.testing.assert_close(
+        result[1], input_ids[1].unsqueeze(-1).expand(-1, 2) - 2.0
+    )
+    torch.testing.assert_close(
+        result[2], input_ids[2].unsqueeze(-1).expand(-1, 2) - 1.0
+    )
 
 
 def test_compute_teacher_logprobs_deduplication():

--- a/tests/unit/algorithms/test_opd.py
+++ b/tests/unit/algorithms/test_opd.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,71 @@
 import pytest
 import torch
 
+from nemo_rl.algorithms.opd import (
+    OnPolicyDistillationConfig,
+    get_student_topk,
+    student_topk_reverse_kl_loss,
+)
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+
+# ---------------------------------------------------------------------------
+# Student-top-k estimator tests
+# ---------------------------------------------------------------------------
+
+
+def test_student_topk_config_validation():
+    cfg = OnPolicyDistillationConfig(enabled=True, student_topk=32)
+    assert get_student_topk({"on_policy_distillation": cfg}) == 32
+
+    with pytest.raises(ValueError, match="greater than or equal to 1"):
+        OnPolicyDistillationConfig(enabled=True, student_topk=0)
+
+
+def test_student_topk_full_support_matches_exact_reverse_kl():
+    student_logits = torch.tensor([[0.1, 0.7, -0.4]], requires_grad=True)
+    teacher_logits = torch.tensor([[0.5, -0.2, 0.3]])
+    student_logprobs = student_logits.log_softmax(dim=-1)
+    teacher_logprobs = teacher_logits.log_softmax(dim=-1)
+
+    estimated = student_topk_reverse_kl_loss(
+        student_support_logprobs=student_logprobs,
+        teacher_support_logprobs=teacher_logprobs,
+        student_target_logprobs=student_logprobs[:, 0],
+        teacher_target_logprobs=teacher_logprobs[:, 0],
+        target_in_support=torch.ones(1, dtype=torch.bool),
+    )
+    exact = (student_logprobs.exp() * (student_logprobs - teacher_logprobs)).sum(dim=-1)
+
+    torch.testing.assert_close(estimated, exact)
+    estimated.sum().backward()
+    assert student_logits.grad is not None
+    assert torch.isfinite(student_logits.grad).all()
+
+
+def test_student_topk_adds_sampled_tail_only_outside_support():
+    student_support = torch.log(torch.tensor([[0.6]]))
+    teacher_support = torch.log(torch.tensor([[0.5]]))
+    student_target = torch.log(torch.tensor([0.1], requires_grad=True))
+    teacher_target = torch.log(torch.tensor([0.2]))
+
+    outside_loss = student_topk_reverse_kl_loss(
+        student_support,
+        teacher_support,
+        student_target,
+        teacher_target,
+        target_in_support=torch.tensor([False]),
+    )
+    inside_loss = student_topk_reverse_kl_loss(
+        student_support,
+        teacher_support,
+        student_target,
+        teacher_target,
+        target_in_support=torch.tensor([True]),
+    )
+
+    expected_tail = -(teacher_target - student_target).detach() * student_target
+    torch.testing.assert_close(outside_loss - inside_loss, expected_tail)
+
 
 # ---------------------------------------------------------------------------
 # Mock teacher worker group for _compute_teacher_logprobs tests

--- a/tests/unit/algorithms/test_opd.py
+++ b/tests/unit/algorithms/test_opd.py
@@ -63,17 +63,17 @@ def test_student_topk_adds_sampled_tail_only_outside_support():
     teacher_target = torch.log(torch.tensor([0.2]))
 
     outside_loss = student_topk_reverse_kl_loss(
-        student_support,
-        teacher_support,
-        student_target,
-        teacher_target,
+        student_support_logprobs=student_support,
+        teacher_support_logprobs=teacher_support,
+        student_target_logprobs=student_target,
+        teacher_target_logprobs=teacher_target,
         target_in_support=torch.tensor([False]),
     )
     inside_loss = student_topk_reverse_kl_loss(
-        student_support,
-        teacher_support,
-        student_target,
-        teacher_target,
+        student_support_logprobs=student_support,
+        teacher_support_logprobs=teacher_support,
+        student_target_logprobs=student_target,
+        teacher_target_logprobs=teacher_target,
         target_in_support=torch.tensor([True]),
     )
 

--- a/tests/unit/algorithms/test_opd.py
+++ b/tests/unit/algorithms/test_opd.py
@@ -115,6 +115,19 @@ class _MockTeacherWorkerGroup:
             {"reference_logprobs": torch.full((B, S), self._fill_value)}
         )
 
+    def get_logprobs_on_support(self, data):
+        input_ids = data["input_ids"]
+        topk_indices = data["topk_indices"]
+        dp_size = self.sharding_annotations.get_axis_size("data_parallel")
+        assert input_ids.shape[0] % dp_size == 0
+        return BatchedDataDict(
+            {
+                "support_logprobs": torch.full(
+                    topk_indices.shape, self._fill_value, dtype=torch.float32
+                )
+            }
+        )
+
 
 def _make_collector(**overrides):
     """Build a bare AsyncTrajectoryCollector (bypass Ray) for unit testing."""
@@ -209,6 +222,37 @@ def test_compute_teacher_logprobs_routes_to_correct_teacher():
     assert torch.allclose(result[1], torch.tensor(2.0))
     assert torch.allclose(result[2], torch.tensor(1.0))
     assert torch.allclose(result[3], torch.tensor(2.0))
+
+
+def test_compute_teacher_support_logprobs_routes_and_trims_dp_padding():
+    math_twg = _MockTeacherWorkerGroup(fill_value=-1.0, dp_size=4)
+    code_twg = _MockTeacherWorkerGroup(fill_value=-2.0, dp_size=2)
+    collector = _make_collector(
+        teacher_worker_groups={"math": math_twg, "code": code_twg},
+        alias_to_group_alias={"math": "math", "code": "code"},
+        on_policy_distillation_cfg={
+            "teacher_model_by_agent_name": {
+                "math": "/ckpt/math",
+                "code": "/ckpt/code",
+            },
+        },
+        _has_distillation_teachers=True,
+    )
+    input_ids = torch.arange(15).reshape(3, 5)
+    topk_indices = torch.zeros(3, 5, 2, dtype=torch.long)
+    agent_refs = [{"name": "math"}, {"name": "code"}, {"name": "math"}]
+
+    result, _ = collector._compute_teacher_support_logprobs(
+        input_ids,
+        topk_indices,
+        agent_refs,
+        input_lengths=torch.tensor([5, 4, 3]),
+    )
+
+    assert result.shape == (3, 5, 2)
+    torch.testing.assert_close(result[0], torch.full((5, 2), -1.0))
+    torch.testing.assert_close(result[1], torch.full((5, 2), -2.0))
+    torch.testing.assert_close(result[2], torch.full((5, 2), -1.0))
 
 
 def test_compute_teacher_logprobs_deduplication():

--- a/tests/unit/models/megatron/test_train.py
+++ b/tests/unit/models/megatron/test_train.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import torch
 
 from nemo_rl.algorithms.logits_sampling_utils import TrainingSamplingParams
 from nemo_rl.algorithms.loss.interfaces import LossInputType
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 
 pytestmark = pytest.mark.mcore
 
@@ -1010,8 +1011,10 @@ class TestTopkLogitsPostProcessor:
         loss, result = wrapped_fn(output_tensor)
 
         assert "topk_logits" in result
+        assert "topk_logprobs" in result
         assert "topk_indices" in result
         assert result["topk_logits"].shape[-1] == k
+        assert result["topk_logprobs"].shape == result["topk_logits"].shape
 
     @patch("nemo_rl.models.megatron.train.get_tensor_model_parallel_group")
     @patch(
@@ -1058,6 +1061,7 @@ class TestTopkLogitsPostProcessor:
         loss, result = wrapped_fn(output_tensor)
 
         assert "topk_logits" in result
+        assert "topk_logprobs" in result
         assert "topk_indices" in result
         # Output should be unpacked to batch shape
         assert result["topk_logits"].shape[0] == 1
@@ -1149,7 +1153,8 @@ class TestTopkLogitsPostProcessor:
         # allgather returns the full gathered tensor
         gathered_vals = torch.randn(1, seq_len, k)
         gathered_idx = torch.randint(0, 100, (1, seq_len, k))
-        mock_allgather.side_effect = [gathered_vals, gathered_idx]
+        gathered_logprobs = torch.randn(1, seq_len, k)
+        mock_allgather.side_effect = [gathered_vals, gathered_idx, gathered_logprobs]
 
         cu_seqlens_padded = torch.tensor([0, seq_len])
 
@@ -1161,9 +1166,10 @@ class TestTopkLogitsPostProcessor:
         output_tensor = torch.randn(1, local_seq_len, 100)
         loss, result = wrapped_fn(output_tensor)
 
-        # Verify allgather was called for both vals and indices
-        assert mock_allgather.call_count == 2
+        # Verify allgather was called for logits, indices, and logprobs.
+        assert mock_allgather.call_count == 3
         assert "topk_logits" in result
+        assert "topk_logprobs" in result
         assert "topk_indices" in result
         # Output should be unpacked: (batch_size=1, unpacked_seqlen=8, k=3)
         assert result["topk_logits"].shape == (1, 8, k)
@@ -1214,7 +1220,7 @@ class TestTopkLogitsPostProcessor:
         mock_topk_idx = torch.randint(0, 100, (1, local_packed_len, k))
         mock_topk.return_value = (mock_topk_vals, mock_topk_idx)
 
-        # allgather is called once per sequence (2 sequences x 2 tensors = 4 calls)
+        # allgather is called once per sequence for logits, indices, and logprobs.
         def fake_allgather(local_tensor, group, seq_dim):
             # Simulate gathering: double the seq_dim since cp_size=2
             return local_tensor.repeat(1, cp_size, 1)
@@ -1231,13 +1237,66 @@ class TestTopkLogitsPostProcessor:
         output_tensor = torch.randn(1, local_packed_len, 100)
         loss, result = wrapped_fn(output_tensor)
 
-        # allgather called 2x per sequence (vals + idx) x 2 sequences = 4 calls
-        assert mock_allgather.call_count == 4
+        assert mock_allgather.call_count == 6
         assert "topk_logits" in result
+        assert "topk_logprobs" in result
         assert "topk_indices" in result
         # Output should be unpacked: (batch_size=2, unpacked_seqlen=6, k=3)
         assert result["topk_logits"].shape == (2, unpacked_seqlen, k)
         assert result["topk_indices"].shape == (2, unpacked_seqlen, k)
+
+
+class TestSupportLogprobsPostProcessor:
+    """Tests for gathering teacher logprobs on a student-selected support."""
+
+    @patch("nemo_rl.models.megatron.train.get_tensor_model_parallel_group")
+    @patch(
+        "nemo_rl.models.megatron.train.get_tensor_model_parallel_rank", return_value=0
+    )
+    def test_gathers_full_vocab_normalized_logprobs(self, mock_tp_rank, mock_tp_group):
+        from nemo_rl.models.megatron.train import SupportLogprobsPostProcessor
+
+        mock_tp_group.return_value = None
+        logits = torch.tensor([[[1.0, 3.0, 2.0], [4.0, 0.0, 1.0]]])
+        support_indices = torch.tensor([[[1, 2], [0, 2]]])
+        cfg = {
+            "sequence_packing": {"enabled": False},
+            "megatron_cfg": {"context_parallel_size": 1},
+        }
+        processor = SupportLogprobsPostProcessor(cfg=cfg)
+
+        _, output = processor(
+            BatchedDataDict(
+                {
+                    "input_ids": torch.zeros(1, 2, dtype=torch.long),
+                    "topk_indices": support_indices,
+                }
+            )
+        )(logits)
+
+        expected = logits.log_softmax(dim=-1).gather(-1, support_indices)
+        torch.testing.assert_close(output["support_logprobs"], expected)
+
+    @pytest.mark.parametrize(
+        "packing,context_parallel_size",
+        [(True, 1), (False, 2)],
+    )
+    def test_rejects_unimplemented_layouts(self, packing, context_parallel_size):
+        from nemo_rl.models.megatron.train import SupportLogprobsPostProcessor
+
+        cfg = {
+            "sequence_packing": {"enabled": packing},
+            "megatron_cfg": {"context_parallel_size": context_parallel_size},
+        }
+        with pytest.raises(NotImplementedError):
+            SupportLogprobsPostProcessor(cfg=cfg)(
+                BatchedDataDict(
+                    {
+                        "input_ids": torch.zeros(1, 2, dtype=torch.long),
+                        "topk_indices": torch.zeros(1, 2, 1, dtype=torch.long),
+                    }
+                )
+            )
 
 
 class TestAggregateTrainingStatistics:

--- a/tests/unit/models/megatron/test_train.py
+++ b/tests/unit/models/megatron/test_train.py
@@ -1011,10 +1011,8 @@ class TestTopkLogitsPostProcessor:
         loss, result = wrapped_fn(output_tensor)
 
         assert "topk_logits" in result
-        assert "topk_logprobs" in result
         assert "topk_indices" in result
         assert result["topk_logits"].shape[-1] == k
-        assert result["topk_logprobs"].shape == result["topk_logits"].shape
 
     @patch("nemo_rl.models.megatron.train.get_tensor_model_parallel_group")
     @patch(
@@ -1061,7 +1059,6 @@ class TestTopkLogitsPostProcessor:
         loss, result = wrapped_fn(output_tensor)
 
         assert "topk_logits" in result
-        assert "topk_logprobs" in result
         assert "topk_indices" in result
         # Output should be unpacked to batch shape
         assert result["topk_logits"].shape[0] == 1
@@ -1153,8 +1150,7 @@ class TestTopkLogitsPostProcessor:
         # allgather returns the full gathered tensor
         gathered_vals = torch.randn(1, seq_len, k)
         gathered_idx = torch.randint(0, 100, (1, seq_len, k))
-        gathered_logprobs = torch.randn(1, seq_len, k)
-        mock_allgather.side_effect = [gathered_vals, gathered_idx, gathered_logprobs]
+        mock_allgather.side_effect = [gathered_vals, gathered_idx]
 
         cu_seqlens_padded = torch.tensor([0, seq_len])
 
@@ -1166,10 +1162,9 @@ class TestTopkLogitsPostProcessor:
         output_tensor = torch.randn(1, local_seq_len, 100)
         loss, result = wrapped_fn(output_tensor)
 
-        # Verify allgather was called for logits, indices, and logprobs.
-        assert mock_allgather.call_count == 3
+        # Verify allgather was called for logits and indices.
+        assert mock_allgather.call_count == 2
         assert "topk_logits" in result
-        assert "topk_logprobs" in result
         assert "topk_indices" in result
         # Output should be unpacked: (batch_size=1, unpacked_seqlen=8, k=3)
         assert result["topk_logits"].shape == (1, 8, k)
@@ -1220,7 +1215,7 @@ class TestTopkLogitsPostProcessor:
         mock_topk_idx = torch.randint(0, 100, (1, local_packed_len, k))
         mock_topk.return_value = (mock_topk_vals, mock_topk_idx)
 
-        # allgather is called once per sequence for logits, indices, and logprobs.
+        # allgather is called once per sequence for logits and indices.
         def fake_allgather(local_tensor, group, seq_dim):
             # Simulate gathering: double the seq_dim since cp_size=2
             return local_tensor.repeat(1, cp_size, 1)
@@ -1237,9 +1232,8 @@ class TestTopkLogitsPostProcessor:
         output_tensor = torch.randn(1, local_packed_len, 100)
         loss, result = wrapped_fn(output_tensor)
 
-        assert mock_allgather.call_count == 6
+        assert mock_allgather.call_count == 4
         assert "topk_logits" in result
-        assert "topk_logprobs" in result
         assert "topk_indices" in result
         # Output should be unpacked: (batch_size=2, unpacked_seqlen=6, k=3)
         assert result["topk_logits"].shape == (2, unpacked_seqlen, k)

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -2096,13 +2096,15 @@ def test_megatron_policy_topk_logits(topk_setup):
     outputs = policy.get_topk_logits(data, k=k)
 
     # Basic validation
-    assert "topk_logits" in outputs and "topk_indices" in outputs, (
-        "Top-k outputs should contain both 'topk_logits' and 'topk_indices'"
-    )
+    assert all(
+        key in outputs for key in ("topk_logits", "topk_logprobs", "topk_indices")
+    ), "Top-k outputs should contain logits, globally normalized logprobs, and indices"
     topk_logits = outputs["topk_logits"]
+    topk_logprobs = outputs["topk_logprobs"]
     topk_indices = outputs["topk_indices"]
 
     assert isinstance(topk_logits, torch.Tensor)
+    assert isinstance(topk_logprobs, torch.Tensor)
     assert isinstance(topk_indices, torch.Tensor)
     assert topk_logits.dtype == torch.float32
     assert topk_indices.dtype in (torch.int32, torch.int64, torch.long)
@@ -2110,6 +2112,7 @@ def test_megatron_policy_topk_logits(topk_setup):
     # Shape checks
     B, S = data.get("input_ids").shape
     assert topk_logits.shape == (B, S, k)
+    assert topk_logprobs.shape == (B, S, k)
     assert topk_indices.shape == (B, S, k)
 
     # Mask invalid positions and check for NaN/Inf

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -18,7 +18,7 @@ import time
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Optional
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -44,6 +44,74 @@ from nemo_rl.utils.checkpoint import CheckpointManager
 from tests.unit.test_utils import SimpleLossFn
 
 pytestmark = pytest.mark.mcore
+
+
+def test_get_logprobs_on_support_runs_forward_and_restores_sequence_shape():
+    from nemo_rl.models.policy.workers.megatron_policy_worker import (
+        MegatronPolicyWorkerImpl,
+    )
+
+    worker = object.__new__(MegatronPolicyWorkerImpl)
+    worker.cfg = {
+        "sequence_packing": {"enabled": False},
+        "megatron_cfg": {"context_parallel_size": 1},
+        "logprob_batch_size": 2,
+    }
+    worker.model = MagicMock()
+    worker.mcore_state = SimpleNamespace(straggler_timer=MagicMock())
+    worker.delegate_pack_to_model = False
+    worker.delegate_mtp_loss_mask_to_model = False
+    worker.model_slices_context_parallel_inputs = False
+    worker.defer_fp32_logits = False
+    worker.sampling_params = MagicMock()
+    data = BatchedDataDict(
+        {
+            "input_ids": torch.zeros(2, 3, dtype=torch.long),
+            "topk_indices": torch.zeros(2, 3, 2, dtype=torch.long),
+        }
+    )
+    first = torch.tensor([[[1.0, 2.0], [3.0, 4.0]]])
+    second = torch.tensor([[[5.0, 6.0], [7.0, 8.0]]])
+    expected = torch.cat(
+        (
+            torch.nn.functional.pad(first, (0, 0, 0, 1)),
+            torch.nn.functional.pad(second, (0, 0, 0, 1)),
+        ),
+        dim=0,
+    )
+
+    with (
+        patch(
+            "nemo_rl.models.policy.workers.megatron_policy_worker.get_microbatch_iterator",
+            return_value=(iter(()), 2, 1, 3, 4),
+        ),
+        patch(
+            "nemo_rl.models.policy.workers.megatron_policy_worker.megatron_forward_backward",
+            return_value=[
+                {"support_logprobs": first},
+                {"support_logprobs": second},
+            ],
+        ) as forward_backward,
+        patch(
+            "nemo_rl.models.policy.workers.megatron_policy_worker.parallel_state.is_pipeline_last_stage",
+            return_value=True,
+        ),
+        patch(
+            "nemo_rl.models.policy.workers.megatron_policy_worker.broadcast_tensors_from_last_stage",
+            side_effect=lambda tensors: tensors,
+        ) as broadcast,
+    ):
+        result = MegatronPolicyWorkerImpl.get_logprobs_on_support(
+            worker, data=data, micro_batch_size=1
+        )
+
+    worker.model.eval.assert_called_once_with()
+    torch.testing.assert_close(result["support_logprobs"], expected)
+    torch.testing.assert_close(
+        broadcast.call_args.args[0]["support_logprobs"], expected
+    )
+    assert forward_backward.call_args.kwargs["forward_only"] is True
+    assert forward_backward.call_args.kwargs["post_processing_fn"].cfg is worker.cfg
 
 
 def test_model_owned_packing_capability_is_detected():

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -2096,15 +2096,13 @@ def test_megatron_policy_topk_logits(topk_setup):
     outputs = policy.get_topk_logits(data, k=k)
 
     # Basic validation
-    assert all(
-        key in outputs for key in ("topk_logits", "topk_logprobs", "topk_indices")
-    ), "Top-k outputs should contain logits, globally normalized logprobs, and indices"
+    assert "topk_logits" in outputs and "topk_indices" in outputs, (
+        "Top-k outputs should contain both 'topk_logits' and 'topk_indices'"
+    )
     topk_logits = outputs["topk_logits"]
-    topk_logprobs = outputs["topk_logprobs"]
     topk_indices = outputs["topk_indices"]
 
     assert isinstance(topk_logits, torch.Tensor)
-    assert isinstance(topk_logprobs, torch.Tensor)
     assert isinstance(topk_indices, torch.Tensor)
     assert topk_logits.dtype == torch.float32
     assert topk_indices.dtype in (torch.int32, torch.int64, torch.long)
@@ -2112,7 +2110,6 @@ def test_megatron_policy_topk_logits(topk_setup):
     # Shape checks
     B, S = data.get("input_ids").shape
     assert topk_logits.shape == (B, S, k)
-    assert topk_logprobs.shape == (B, S, k)
     assert topk_indices.shape == (B, S, k)
 
     # Mask invalid positions and check for NaN/Inf

--- a/tests/unit/models/policy/test_teacher_worker_group.py
+++ b/tests/unit/models/policy/test_teacher_worker_group.py
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import MagicMock
+
+import torch
+
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+
 
 def test_teacher_resource_config_defaults():
     from nemo_rl.algorithms.opd import TeacherResourceConfig
@@ -77,3 +83,39 @@ def test_create_teacher_configs_deduplicates():
         }
     )
     assert len(configs) == 2
+
+
+def test_get_logprobs_on_support_routes_shards_and_preserves_worker_order():
+    from nemo_rl.models.policy.teacher_worker_group import TeacherWorkerGroup
+
+    teacher = object.__new__(TeacherWorkerGroup)
+    teacher.use_sequence_packing = False
+    teacher.cfg = {"megatron_cfg": {"context_parallel_size": 1}}
+    teacher._micro_batch_size = 3
+    teacher.sharding_annotations = MagicMock()
+    teacher.sharding_annotations.get_axis_size.return_value = 2
+    teacher.worker_group = MagicMock()
+    teacher.worker_group.run_all_workers_sharded_data.return_value = ["f0", "f1"]
+    first = torch.tensor([[[1.0, 2.0]], [[3.0, 4.0]]])
+    second = torch.tensor([[[5.0, 6.0]], [[7.0, 8.0]]])
+    teacher.worker_group.get_all_worker_results.return_value = [
+        {"support_logprobs": first},
+        {"support_logprobs": second},
+    ]
+    data = BatchedDataDict(
+        {
+            "input_ids": torch.arange(4).unsqueeze(1),
+            "topk_indices": torch.zeros(4, 1, 2, dtype=torch.long),
+        }
+    )
+
+    result = teacher.get_logprobs_on_support(data)
+
+    torch.testing.assert_close(
+        result["support_logprobs"], torch.cat((first, second), dim=0)
+    )
+    teacher.worker_group.run_all_workers_sharded_data.assert_called_once()
+    call = teacher.worker_group.run_all_workers_sharded_data.call_args
+    assert call.args == ("get_logprobs_on_support",)
+    assert len(call.kwargs["data"]) == 2
+    assert call.kwargs["common_kwargs"] == {"micro_batch_size": 3}


### PR DESCRIPTION
# What does this PR do ?

Adds student-selected top-k on-policy distillation (OPD) support for async GRPO.

Instead of transferring the teacher’s full-vocabulary distribution, the student selects its top-k tokens and the teacher evaluates only those tokens. This reduces the teacher-to-student data transferred per token while preserving:
  - An exact reverse-KL contribution over the student’s top-k support.
  - A sampled gradient estimate for the remaining vocabulary tail.
  - Full-vocabulary normalization of teacher probabilities.

## Current restrictions

Student top-k OPD currently requires:
  - OPD enabled.
  - Async GRPO.
  - `grpo.adv_estimator.name: opd`.
  - Megatron policy and teacher backends.
  - Sequence packing disabled.
  - Context parallel size `1`.
  - Unfiltered training distributions:
    - `policy.generation.top_k: null`
    - `policy.generation.top_p: 1.0`
  - `loss_fn.reference_policy_kl_penalty: 0`.
  - Fused linear log-probabilities disabled.
# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
