### PR TITLE
perf(external-vllm): remove startup preflights

### DIFF
--- a/tests/unit/tools/test_external_gym_vllm.py
+++ b/tests/unit/tools/test_external_gym_vllm.py
@@ -564,9 +564,7 @@ def test_launcher_routes_generic_pools_to_explicit_hetgroups():
                 srun_blocks.append("\n".join(current_block))
                 current_block = []
 
-    assert len(srun_blocks) == 4
-    pool_preflight = next(block for block in srun_blocks if "import ray, vllm" in block)
-    lb_preflight = next(block for block in srun_blocks if "import aiohttp" in block)
+    assert len(srun_blocks) == 2
     replica_launch = next(block for block in srun_blocks if "VLLM_SERVER_BODY" in block)
     lb_launch = next(
         block
@@ -574,18 +572,16 @@ def test_launcher_routes_generic_pools_to_explicit_hetgroups():
         if "lb_watchdog.sh" in block and "--output=" in block
     )
 
-    for block in (pool_preflight, replica_launch):
-        assert "--het-group=1" in block
-        assert '-A "${SLURM_JOB_ACCOUNT}"' not in block
-        assert '-p "${SLURM_JOB_PARTITION}"' not in block
-    for block in (lb_preflight, lb_launch):
-        assert "--het-group=0" in block
-        assert '-A "${SLURM_JOB_ACCOUNT}"' in block
-        assert '-p "${SLURM_JOB_PARTITION}"' in block
+    assert "--het-group=1" in replica_launch
+    assert '-A "${SLURM_JOB_ACCOUNT}"' not in replica_launch
+    assert '-p "${SLURM_JOB_PARTITION}"' not in replica_launch
+    assert "--het-group=0" in lb_launch
+    assert '-A "${SLURM_JOB_ACCOUNT}"' in lb_launch
+    assert '-p "${SLURM_JOB_PARTITION}"' in lb_launch
 
-    assert 'preflight_labels+=("${display_names[${pool}]} container")' in source
-    assert 'preflight_labels+=("load balancer container")' in source
-    assert "${preflight_labels[${preflight_index}]}" in source
+    assert "preflight" not in source.lower()
+    assert "import ray, vllm" not in source
+    assert "import aiohttp" not in source
     assert 'export "${pool}_ENV_VARS=$(pool_value "${pool}" ENV_VARS)"' in source
     assert 'export "${pool}_VLLM_ARGS=$(pool_value "${pool}" VLLM_ARGS)"' in source
     assert 'SLURM_JOB_NODELIST="${SLURM_JOB_NODELIST_HET_GROUP_0}"' in source

--- a/tools/external_gym_vllm/run_in_allocation.sh
+++ b/tools/external_gym_vllm/run_in_allocation.sh
@@ -282,8 +282,6 @@ declare -a service_step_pids=()
 declare -a service_step_labels=()
 declare -a lb_step_pids=()
 declare -a lb_step_labels=()
-declare -a preflight_pids=()
-declare -a preflight_labels=()
 ray_sub_pid=""
 
 cleanup() {
@@ -294,7 +292,7 @@ cleanup() {
   if [[ -n "${ray_sub_pid}" ]] && kill -0 "${ray_sub_pid}" 2>/dev/null; then
     kill "${ray_sub_pid}" 2>/dev/null || true
   fi
-  for pid in "${lb_step_pids[@]}" "${service_step_pids[@]}" "${preflight_pids[@]}"; do
+  for pid in "${lb_step_pids[@]}" "${service_step_pids[@]}"; do
     if [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null; then
       kill "${pid}" 2>/dev/null || true
     fi
@@ -515,65 +513,6 @@ external_service_mount="${EXTERNAL_VLLM_SHARED_ROOT}:${EXTERNAL_VLLM_SHARED_ROOT
 for pool in "${pool_names[@]}"; do
   lb_mounts+=",${state_dirs[${pool}]}:${lb_state_dirs[${pool}]}"
 done
-
-for pool in "${pool_names[@]}"; do
-  offset="${node_offsets[${pool}]}"
-  first_pool_node="${external_nodes[${offset}]}"
-  echo "[INFO] Validating the ${display_names[${pool}]} container and Python environment"
-  srun \
-    --het-group=1 \
-    --no-container-mount-home \
-    --container-image="${containers[${pool}]}" \
-    --container-mounts="${external_service_mount}" \
-    --mpi=pmix \
-    --gres="gpu:${GPUS_PER_NODE}" \
-    --overlap \
-    --kill-on-bad-exit=1 \
-    --nodelist="${first_pool_node}" \
-    --nodes=1 \
-    --ntasks=1 \
-    bash -lc \
-    "command -v ray >/dev/null && '${vllm_pythons[${pool}]}' -c 'import ray, vllm; from nemo_rl.models.generation.vllm.patches import _apply_vllm_patches'" \
-    >/dev/null &
-  preflight_pids+=("$!")
-  preflight_labels+=("${display_names[${pool}]} container")
-done
-
-echo "[INFO] Validating the load-balancer container and Python environment"
-srun \
-  --het-group=0 \
-  --no-container-mount-home \
-  --container-image="${CONTAINER}" \
-  --container-mounts="${lb_mounts}" \
-  --container-workdir="${SLURM_SUBMIT_DIR}" \
-  --mpi=pmix \
-  -A "${SLURM_JOB_ACCOUNT}" \
-  -p "${SLURM_JOB_PARTITION}" \
-  --overlap \
-  --kill-on-bad-exit=1 \
-  --nodelist="${ray_head_node}" \
-  --nodes=1 \
-  --ntasks=1 \
-  --cpus-per-task=1 \
-  bash -lc \
-  "test -x /opt/external-vllm-tools/lb_watchdog.sh && '${EXTERNAL_VLLM_LB_PYTHON}' -c 'import aiohttp'" \
-  >/dev/null &
-preflight_pids+=("$!")
-preflight_labels+=("load balancer container")
-
-preflight_failed=0
-for preflight_index in "${!preflight_pids[@]}"; do
-  preflight_pid="${preflight_pids[${preflight_index}]}"
-  if ! wait "${preflight_pid}"; then
-    echo "[FATAL] External-vLLM preflight failed: ${preflight_labels[${preflight_index}]} (pid=${preflight_pid})" >&2
-    preflight_failed=1
-  fi
-done
-preflight_pids=()
-preflight_labels=()
-if (( preflight_failed != 0 )); then
-  exit 1
-fi
 
 for pool in "${pool_names[@]}"; do
   echo "[INFO] Launching ${display_names[${pool}]} replicas"


### PR DESCRIPTION
# What does this PR do ?

Launch external vLLM replicas and load balancers immediately instead of starting separate container and import probes first.

Measured parallel preflights added 295-317 seconds per launch. Backend registration, health checks, load-balancer readiness, and process monitoring continue to gate training startup.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
