### PR TITLE
fix: stop the launcher environment leaking into checkpoint config.yaml

### DIFF
--- a/nemo_rl/distributed/worker_group_utils.py
+++ b/nemo_rl/distributed/worker_group_utils.py
@@ -14,6 +14,8 @@
 
 import fnmatch
 import logging
+import os
+from collections.abc import Mapping
 from copy import deepcopy
 from typing import Any
 
@@ -22,6 +24,19 @@ from nemo_rl.utils.nsys import (
     NRL_NSYS_PROFILE_STEP_RANGE,
     NRL_NSYS_WORKER_PATTERNS,
 )
+
+
+def merge_env_vars_with_process_env(env_vars: Mapping[str, str]) -> dict[str, str]:
+    """Combine caller-declared env vars with the launching process environment.
+
+    Declared values win. Returns a new dict: callers pass a live reference into the
+    run config, and merging in place would persist the whole launcher environment
+    (including any secrets it holds) into every checkpoint's ``config.yaml``.
+    """
+    merged = dict(env_vars)
+    for k, v in os.environ.items():
+        merged.setdefault(k, v)
+    return merged
 
 
 def get_nsight_config_if_pattern_matches(worker_name: str) -> dict[str, Any]:

--- a/nemo_rl/distributed/worker_groups.py
+++ b/nemo_rl/distributed/worker_groups.py
@@ -29,7 +29,10 @@ from nemo_rl.distributed.ray_actor_environment_registry import (
     get_actor_python_env,
 )
 from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
-from nemo_rl.distributed.worker_group_utils import recursive_merge_options
+from nemo_rl.distributed.worker_group_utils import (
+    merge_env_vars_with_process_env,
+    recursive_merge_options,
+)
 from nemo_rl.utils.venvs import (
     create_local_venv_on_each_node,
 )
@@ -448,10 +451,7 @@ class RayWorkerGroup:
             self.cluster.get_master_address_and_port()
         )
 
-        # Update env_vars with the current environment variables
-        for k, v in os.environ.items():
-            if k not in env_vars:
-                env_vars[k] = v
+        env_vars = merge_env_vars_with_process_env(env_vars)
 
         # Get the python environment for the actor
         actor_python_env = get_actor_python_env(

--- a/tests/unit/distributed/test_worker_groups_utils.py
+++ b/tests/unit/distributed/test_worker_groups_utils.py
@@ -15,7 +15,38 @@
 
 from copy import deepcopy
 
-from nemo_rl.distributed.worker_group_utils import recursive_merge_options
+from nemo_rl.distributed.worker_group_utils import (
+    merge_env_vars_with_process_env,
+    recursive_merge_options,
+)
+
+
+class TestMergeEnvVarsWithProcessEnv:
+    """Test cases for the merge_env_vars_with_process_env function."""
+
+    def test_does_not_mutate_the_caller_dict(self, monkeypatch):
+        """The caller's dict is a live reference into the run config, so it must not grow."""
+        monkeypatch.setenv("NRL_TEST_LAUNCHER_ONLY", "launcher-value")
+        declared = {"PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"}
+
+        merge_env_vars_with_process_env(declared)
+
+        assert declared == {"PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"}
+
+    def test_merges_process_environment_into_the_result(self, monkeypatch):
+        monkeypatch.setenv("NRL_TEST_LAUNCHER_ONLY", "launcher-value")
+
+        result = merge_env_vars_with_process_env({"NRL_TEST_DECLARED": "declared"})
+
+        assert result["NRL_TEST_LAUNCHER_ONLY"] == "launcher-value"
+        assert result["NRL_TEST_DECLARED"] == "declared"
+
+    def test_declared_values_win_over_the_process_environment(self, monkeypatch):
+        monkeypatch.setenv("NRL_TEST_OVERRIDDEN", "launcher-value")
+
+        result = merge_env_vars_with_process_env({"NRL_TEST_OVERRIDDEN": "declared"})
+
+        assert result["NRL_TEST_OVERRIDDEN"] == "declared"
 
 
 class TestRecursiveMergeOptions:


### PR DESCRIPTION
# What does this PR do ?

Stops the launching process's environment from being merged into the run config and persisted, in plaintext, into every checkpoint's `config.yaml`.

# Issues

- Fixes #3384

# Usage

No user-facing change. Workers receive exactly the same environment as before; only the caller's dict is left alone.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? (unit tests for the touched module; no GPU available for functional tests)
- [ ] Did you add or update any necessary documentation? — no doc change needed

# Additional Information

* The merge into `env_vars` was in place, and callers hand it a live reference into the master config, so the whole launcher environment reached `CheckpointManager` and was dumped verbatim. Fixing at the mutation site covers every current and future caller, including the shared mutable default argument.
* I also considered a second layer — redacting secret-shaped keys before the config is written. I left it out: a naive key regex clobbers legitimate values in the shipped configs (`tokenizer`, `*_key`, `moe_token_dispatcher_type`, `max_new_tokens`), and `config.yaml` is read back at resume time. Happy to send that separately, scoped to `env_vars` blocks only, if you'd like it.

<sub>Generated with Claude Code</sub>