### PR TITLE
fix(agent): harden L2 prep and preserve the L2 suite carry on sync

### DIFF
--- a/.agents/contributor-skills/megatron-pr-test-run/SKILL.md
+++ b/.agents/contributor-skills/megatron-pr-test-run/SKILL.md
@@ -78,6 +78,30 @@ that is already fixed in review. Read the `BRIDGE_REF=` line rather than
 assuming: if it names a branch, the run is not on the shipped combination, and
 that belongs in the report note.
 
+A second lag is easy to miss. When the Bridge fix has already merged (or the
+agent's draft was closed as superseded by a merged PR) but NeMo-RL has not yet
+bumped the submodule, `known_issues.py refresh` correctly retires the entry and
+`pending-fix-ref` returns nothing. Default suite runs then fall back to the
+stale pin and can fail every L1 test at import (e.g. the FSDP
+`isinstance() arg 2 must be a type` break after Bridge#5431). Before trusting a
+baseline or blaming a labeled PR, check whether Bridge `main` (or an open
+NeMo-RL bump PR) contains the fix the pin lacks. If it does, pass
+`--bridge-ref refs/heads/main` to `ensure_baseline.sh` and `run_suite.sh` until
+the NeMo-RL bump merges, and do **not** cache a baseline taken against the
+broken pin.
+
+### L2 suite may be missing from NeMo-RL `main`
+
+`L2_Functional_Tests_Megatron_4.sh` and its subtests were added on the testing
+agent branch and are not always on NeMo-RL `main`. `sync_integration.sh`
+rebuilds the integration branch from bare `main` every sweep, which **drops**
+any prior local cherry-pick — do not assume yesterday's carry is still there.
+The script re-applies `L2_SUITE_CARRY_COMMIT` automatically; if you sync by
+hand or skip that path, confirm the ref still has the suite
+(`git ls-tree <ref> tests/functional/`) before any L2 submit, re-cherry-pick
+if missing, and disclose the carry in the report note. Otherwise prep succeeds
+and the Ray driver fails with `suite not found` after the cluster is already up.
+
 ## Which NeMo-RL is under test
 
 The third leg is pinned the same way, and by default it is **not** plain `main`.
@@ -200,7 +224,7 @@ Re-submit (do not report, do not attempt a fix) when the log shows:
 
 | Signal | Cause |
 |---|---|
-| `NRLTA_PREP_FAIL` | Revision checkout or the megatron import guard failed. |
+| `NRLTA_PREP_FAIL` | Revision checkout or the megatron import guard failed. **The run is void even if tests appear to start afterwards** — on L2 Ray jobs, a failing `--setup-command` historically did not abort the driver. `run_suite.sh` now chains prep into the head command too; still, scancel any allocation whose Slurm log already shows `NRLTA_PREP_FAIL`, fix the pin, and resubmit. Do not parse or report those results. |
 | `QOSMinGRES` / "violates accounting policy" | Job asked for less than a whole node. |
 | `srun: error`, `slurmstepd: ... CANCELLED / TIME LIMIT` | Preemption, node failure, or a too-short `--time`. |
 | `PENDING` for hours with `Reason=Priority` and `StartTime=Unknown` | Usually the QOS, not a full cluster. Compare `scontrol show job <id>` against a job that scheduled quickly: an identical request on a lower-priority QOS can sit behind hundreds of jobs with no slot even planned. Fix `COG_SLURM_QOS` and re-submit rather than waiting. |

--- a/.agents/nemo-rl-testing-agent/config.env
+++ b/.agents/nemo-rl-testing-agent/config.env
@@ -46,6 +46,10 @@ NEMO_RL_INTEGRATION_BRANCH=nrlta/integration
 # --- Test suites (paths relative to the NeMo-RL repo root) --------------------
 L1_SUITE=tests/functional/L1_Functional_Tests_Megatron_4.sh
 L2_SUITE=tests/functional/L2_Functional_Tests_Megatron_4.sh
+# Commit on the agent branch that adds L2_SUITE (not yet on NeMo-RL main).
+# sync_integration.sh re-cherry-picks this after every rebuild so the carry
+# cannot be silently dropped.
+L2_SUITE_CARRY_COMMIT=8145a1d9fb8f51205e3e44045a0943bf55958d35
 
 # --- Cluster / cog ------------------------------------------------------------
 COG_CLUSTER=oci-hsg

--- a/.agents/nemo-rl-testing-agent/scripts/prep_container.sh
+++ b/.agents/nemo-rl-testing-agent/scripts/prep_container.sh
@@ -34,6 +34,25 @@ set -euo pipefail
 workspace="$(pwd)"
 git config --global --add safe.directory '*' || true
 
+# Cluster nodes occasionally cannot reach github.com for a minute or two; a
+# single failed fetch used to abort an otherwise healthy allocation (and on L2
+# the head re-runs prep after setup already succeeded, doubling the exposure).
+nrlta_git_fetch() {
+  local dir="$1" url="$2" ref="$3"
+  local attempt=1 delay
+  while [ "${attempt}" -le 4 ]; do
+    if git -C "${dir}" fetch --depth=1 --force "${url}" "${ref}"; then
+      return 0
+    fi
+    delay=$(( attempt * 15 ))
+    echo "[nrlta-prep] git fetch ${ref} from ${url} failed (attempt ${attempt}/4); retrying in ${delay}s"
+    sleep "${delay}"
+    attempt=$(( attempt + 1 ))
+  done
+  echo "NRLTA_PREP_FAIL: git fetch ${ref} from ${url} failed after 4 attempts"
+  return 1
+}
+
 echo "===NRLTA_PREP_BEGIN node=$(hostname)==="
 
 # 1. Establish which NeMo-RL is under test.
@@ -65,7 +84,7 @@ if [ -n "${NEMO_RL_FETCH_REF:-}" ]; then
     echo "  revision under test cannot be pinned. Re-run with the worktree overlay."
     exit 1
   fi
-  git -C "${CONTAINER_ROOT}" fetch --depth=1 --force "${NEMO_RL_CLONE_URL}" "${NEMO_RL_FETCH_REF}"
+  nrlta_git_fetch "${CONTAINER_ROOT}" "${NEMO_RL_CLONE_URL}" "${NEMO_RL_FETCH_REF}"
   nemo_rl_sha="$(git -C "${CONTAINER_ROOT}" rev-parse FETCH_HEAD)"
 
   if [ -n "${NEMO_RL_EXPECTED_SHA:-}" ] && [ "${nemo_rl_sha}" != "${NEMO_RL_EXPECTED_SHA}" ]; then
@@ -116,7 +135,7 @@ if [ -n "${BRIDGE_FETCH_REF:-}" ]; then
     exit 1
   fi
   bridge_sha_before="$(git -C "${CONTAINER_BRIDGE_DIR}" rev-parse HEAD 2>/dev/null || echo unknown)"
-  git -C "${CONTAINER_BRIDGE_DIR}" fetch --depth=1 --force "${MEGATRON_BRIDGE_CLONE_URL}" "${BRIDGE_FETCH_REF}"
+  nrlta_git_fetch "${CONTAINER_BRIDGE_DIR}" "${MEGATRON_BRIDGE_CLONE_URL}" "${BRIDGE_FETCH_REF}"
   git -C "${CONTAINER_BRIDGE_DIR}" reset --hard FETCH_HEAD
   # -fd, never -ff: -ff deletes nested git repositories, which would wipe the
   # Megatron-LM submodule checkout living under this directory.
@@ -144,15 +163,23 @@ if ! git -C "${CONTAINER_MCORE_DIR}" rev-parse --git-dir >/dev/null 2>&1; then
   git -C "${CONTAINER_MCORE_DIR}" init -q
 fi
 
-git -C "${CONTAINER_MCORE_DIR}" fetch --depth=1 --force "${MEGATRON_CLONE_URL}" "${MCORE_FETCH_REF}"
-git -C "${CONTAINER_MCORE_DIR}" reset --hard FETCH_HEAD
-# -ffd (not -x) removes stale sources from the previous revision while keeping
-# gitignored build outputs such as the compiled datasets helpers.
-git -C "${CONTAINER_MCORE_DIR}" clean -ffd
-find "${CONTAINER_MCORE_DIR}" -name __pycache__ -type d -prune -exec rm -rf {} + 2>/dev/null || true
-
-new_sha="$(git -C "${CONTAINER_MCORE_DIR}" rev-parse HEAD)"
-new_subject="$(git -C "${CONTAINER_MCORE_DIR}" log -1 --pretty=%s)"
+# L2 Ray runs prep twice on the head (setup-command + driver). If setup already
+# landed the expected tip, skip the second github fetch — cluster egress to
+# github.com flakes often enough that the re-fetch alone has aborted healthy jobs.
+if [ -n "${MCORE_EXPECTED_SHA:-}" ] && [ "${orig_sha}" = "${MCORE_EXPECTED_SHA}" ]; then
+  echo "[nrlta-prep] mcore already at expected ${MCORE_EXPECTED_SHA}; skipping fetch"
+  new_sha="${orig_sha}"
+  new_subject="$(git -C "${CONTAINER_MCORE_DIR}" log -1 --pretty=%s)"
+else
+  nrlta_git_fetch "${CONTAINER_MCORE_DIR}" "${MEGATRON_CLONE_URL}" "${MCORE_FETCH_REF}"
+  git -C "${CONTAINER_MCORE_DIR}" reset --hard FETCH_HEAD
+  # -ffd (not -x) removes stale sources from the previous revision while keeping
+  # gitignored build outputs such as the compiled datasets helpers.
+  git -C "${CONTAINER_MCORE_DIR}" clean -ffd
+  find "${CONTAINER_MCORE_DIR}" -name __pycache__ -type d -prune -exec rm -rf {} + 2>/dev/null || true
+  new_sha="$(git -C "${CONTAINER_MCORE_DIR}" rev-parse HEAD)"
+  new_subject="$(git -C "${CONTAINER_MCORE_DIR}" log -1 --pretty=%s)"
+fi
 
 if [ -n "${MCORE_EXPECTED_SHA:-}" ] && [ "${new_sha}" != "${MCORE_EXPECTED_SHA}" ]; then
   echo "NRLTA_PREP_FAIL: checked out ${new_sha} but caller expected ${MCORE_EXPECTED_SHA}"

--- a/.agents/nemo-rl-testing-agent/scripts/run_suite.sh
+++ b/.agents/nemo-rl-testing-agent/scripts/run_suite.sh
@@ -262,13 +262,18 @@ cog_args_masked=("${cog_args[@]}")
 
 if [[ "${launcher}" == "ray" ]]; then
   # Ray fans the suite out across nodes: prep must run everywhere, the suite
-  # only on the head (it is the driver).
+  # only on the head (it is the driver). cog's --setup-command runs on every
+  # node but a failing setup does NOT abort the driver command — we learned
+  # that the hard way when both workers logged NRLTA_PREP_FAIL and the suite
+  # still started against the wrong mcore tip. So the head command also runs
+  # prep (idempotent) and chains with && so a pin mismatch kills the job
+  # before any test executes.
   cog_args+=(--launcher ray)
   cog_args+=(--setup-command "${token_env} ${remote_env} ${prep_cmd}")
-  cog_args+=(--command "${token_env} ${remote_env} ${run_cmd}")
+  cog_args+=(--command "${token_env} ${remote_env} ${prep_cmd} && ${run_cmd}")
   cog_args_masked+=(--launcher ray)
   cog_args_masked+=(--setup-command "${token_env_masked} ${remote_env} ${prep_cmd}")
-  cog_args_masked+=(--command "${token_env_masked} ${remote_env} ${run_cmd}")
+  cog_args_masked+=(--command "${token_env_masked} ${remote_env} ${prep_cmd} && ${run_cmd}")
 else
   cog_args+=(--command "${token_env} ${remote_env} ${prep_cmd} && ${run_cmd}")
   cog_args_masked+=(--command "${token_env_masked} ${remote_env} ${prep_cmd} && ${run_cmd}")

--- a/.agents/nemo-rl-testing-agent/scripts/sync_integration.sh
+++ b/.agents/nemo-rl-testing-agent/scripts/sync_integration.sh
@@ -152,6 +152,41 @@ for number in ${pr_numbers[@]+"${pr_numbers[@]}"}; do
   fi
 done
 
+# Local carries that do not ride an open fix PR. The rebuild above starts from
+# bare main, so anything previously cherry-picked here is gone unless we put it
+# back. L2 is the one that has bitten twice: the suite is not on main yet, and a
+# silent drop only shows up after the cluster is allocated ("suite not found").
+local_carries_json='[]'
+if [[ -n "${L2_SUITE:-}" && -n "${L2_SUITE_CARRY_COMMIT:-}" ]]; then
+  if ! git -C "${worktree}" cat-file -e "HEAD:${L2_SUITE}" 2>/dev/null; then
+    nrlta_log "L2 suite missing from rebuild; cherry-picking ${L2_SUITE_CARRY_COMMIT:0:8}"
+    # The commit may live only on the operator checkout / agent branch, not on
+    # the shallow fetch of main — make it reachable from the worktree.
+    if ! git -C "${worktree}" cat-file -e "${L2_SUITE_CARRY_COMMIT}^{commit}" 2>/dev/null; then
+      git -C "${worktree}" fetch --quiet "${NEMO_RL_REPO_PATH}" "${L2_SUITE_CARRY_COMMIT}"
+    fi
+    author_date="$(git -C "${worktree}" show -s --format=%aI "${L2_SUITE_CARRY_COMMIT}")"
+    if GIT_COMMITTER_DATE="${author_date}" \
+        git -C "${worktree}" cherry-pick --allow-empty "${L2_SUITE_CARRY_COMMIT}" >/dev/null 2>&1; then
+      carry_sha="$(git -C "${worktree}" rev-parse HEAD)"
+      local_carries_json="$(python3 -c '
+import json, sys
+print(json.dumps([{
+  "id": "l2-megatron-functional-suite",
+  "sha": sys.argv[1],
+  "note": "Cherry-pick of L2 Megatron functional suite (%s); not yet on NeMo-RL main" % sys.argv[2][:8],
+}]))
+' "${carry_sha}" "${L2_SUITE_CARRY_COMMIT}")"
+      nrlta_log "re-applied L2 suite carry -> ${carry_sha:0:8}"
+    else
+      git -C "${worktree}" cherry-pick --abort >/dev/null 2>&1 || true
+      nrlta_die "failed to cherry-pick L2 suite carry ${L2_SUITE_CARRY_COMMIT:0:8}; L2 submits would be void"
+    fi
+  else
+    nrlta_log "L2 suite already present on integration rebuild"
+  fi
+fi
+
 git -C "${worktree}" branch --force "${NEMO_RL_INTEGRATION_BRANCH}" HEAD
 integration_sha="$(git -C "${worktree}" rev-parse HEAD)"
 
@@ -162,11 +197,11 @@ git -C "${worktree}" -c "credential.helper=!gh auth git-credential" \
   "${NEMO_RL_INTEGRATION_BRANCH}:refs/heads/${NEMO_RL_INTEGRATION_BRANCH}"
 
 python3 - "${manifest}" "${integration_sha}" "${base_sha}" \
-  "${applied[*]-}" "${skipped[*]-}" "${prs_json}" <<'PY'
+  "${applied[*]-}" "${skipped[*]-}" "${prs_json}" "${local_carries_json}" <<'PY'
 import json, sys
 from datetime import datetime, timezone
 
-manifest, integration_sha, base_sha, applied, skipped, prs_json = sys.argv[1:7]
+manifest, integration_sha, base_sha, applied, skipped, prs_json, local_carries_json = sys.argv[1:8]
 by_number = {str(pr["number"]): pr for pr in json.loads(prs_json)}
 
 payload = {
@@ -185,6 +220,7 @@ payload = {
         {"pr": int(entry.split(":")[0]), "reason": entry.split(":", 1)[1]}
         for entry in skipped.split()
     ],
+    "local_carries": json.loads(local_carries_json),
 }
 with open(manifest, "w") as handle:
     json.dump(payload, handle, indent=2)
@@ -192,6 +228,8 @@ with open(manifest, "w") as handle:
 print(f"integration branch = {base_sha[:8]} + {len(payload['applied'])} fix(es) -> {integration_sha[:8]}")
 for item in payload["skipped"]:
     print(f"  NOT applied: #{item['pr']} ({item['reason']})")
+for carry in payload["local_carries"]:
+    print(f"  local carry: {carry['id']} @ {carry['sha'][:8]}")
 PY
 
 nrlta_log "manifest written to ${manifest}"


### PR DESCRIPTION
## Summary
Fold NemoRLTest sweep learnings back into the agent skills/scripts so the next pass does not re-discover them:

- Treat any `NRLTA_PREP_FAIL` in an L2 Ray log as void even if tests appear to start; chain prep into the head command so a pin mismatch aborts before the suite.
- Auto re-cherry-pick `L2_SUITE_CARRY_COMMIT` in `sync_integration.sh` after every rebuild from main (the L2 suite is not on NeMo-RL main yet).
- Retry transient `git fetch` failures in `prep_container.sh`, and skip the second mcore fetch on L2 Ray when HEAD already matches `MCORE_EXPECTED_SHA`.

## Sweep learnings
- **l2-ray-continues-after-prep-fail** — On L2 Ray jobs, NRLTA_PREP_FAIL on a worker does not always abort the driver. Treat any PREP_FAIL in the Slurm log as void even if tests appear to run: scancel, fix the pin, and resubmit. Do not parse or report results from a run that logged PREP_FAIL.
  - Trigger: L2 Ray job logged NRLTA_PREP_FAIL on both nodes (mcore sha mismatch) yet still entered NRLTA_SUITE_BEGIN and started tests.
  - Applied to: `.agents/contributor-skills/megatron-pr-test-run/SKILL.md`
- **sync-integration-wipes-l2-local-carry** — sync_integration.sh rebuilds from main and drops local carries. After every sync, confirm the integration branch still has L2_Functional_Tests_Megatron_4.sh (git ls-tree); if missing, re-cherry-pick 8145a1d9, force-push the fork branch, and restore local_carries in integration.json before any L2 submit. Prefer automating the carry inside sync_integration.sh so a rebuild cannot silently drop it.
  - Trigger: After sync_integration.sh rebuilt nrlta/integration from main, L2_Functional_Tests_Megatron_4.sh was gone and local_carries emptied; L2 would fail with suite not found after cluster allocation.
  - Applied to: `.agents/contributor-skills/megatron-pr-test-run/SKILL.md`
- **prep-git-fetch-retry-and-skip-if-pinned** — prep_container.sh must retry git fetch on transient network errors, and skip the mcore fetch when HEAD already equals MCORE_EXPECTED_SHA (L2 Ray runs prep twice on the head). Do not treat a single github.com timeout as a PR result.
  - Trigger: L2 Ray head re-ran prep after setup already pinned mcore; second git fetch to github.com timed out (rc 128) and aborted a healthy allocation.
  - Applied to: `.agents/nemo-rl-testing-agent/scripts/prep_container.sh`

## Test plan
- [x] `for t in .agents/nemo-rl-testing-agent/tests/*.sh; do bash "$t"; done`
- [ ] Next NemoRLTest sweep: L2 submit after `sync_integration.sh` finds the suite without a manual carry
- [ ] Next L2 Ray prep flake: fetch retries / skip-if-pinned path used instead of aborting a healthy allocation