### PR TITLE
fix: make nccl_reshard_refit_info wire-safe for the generation-worker.

### DIFF
--- a/docs/design-docs/nccl-reshard-refit.md
+++ b/docs/design-docs/nccl-reshard-refit.md
@@ -87,7 +87,11 @@ training starts:
    builds a backend-agnostic description** of every bulk parameter
    (`build_nccl_reshard_refit_info()` in `nemo_rl/weight_sync/nccl_reshard_utils.py`),
    keyed strictly by **HuggingFace parameter names**, and ships it to the generation
-   side.
+   side. Before shipping, `make_nccl_reshard_refit_info_wire_safe()` converts the
+   `MeshInfo` rank tensors and `Shard`/`Replicate` placements into plain dicts/lists —
+   Megatron patches torch's storage unpickler, so raw tensor pickles would require
+   `import megatron` inside the vLLM worker. The generation side rebuilds the objects
+   with `restore_refit_info_placements()`.
 
 The derived metadata (`nccl_reshard_refit_info`) contains, per parameter:
 

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -236,9 +236,13 @@ class SingleControllerActor:
             rollout_task.cancel()
             train_task.cancel()
             await asyncio.gather(rollout_task, train_task, return_exceptions=True)
-            self._logger.finish()
-            # Flush the last checkpoint's background finalization before exit.
-            await asyncio.to_thread(self._checkpointer.shutdown)
+            try:
+                self._weight_synchronizer.shutdown()
+            except Exception as e:  # teardown must not mask the original failure
+                print(f"Error during weight-synchronizer shutdown: {e}", flush=True)
+            finally:
+                self._logger.finish()
+                await asyncio.to_thread(self._checkpointer.shutdown)
 
         return {
             "train_steps": self._train_steps,

--- a/nemo_rl/weight_sync/nccl_reshard_utils.py
+++ b/nemo_rl/weight_sync/nccl_reshard_utils.py
@@ -19,6 +19,8 @@ This module provides:
   shared torch.distributed process group (needed for cross-world transfers)
 - Placement rules: mapping param names to TP/EP sharding strategies
 - build_nccl_reshard_refit_info: compute per-layer param metadata for refit
+- make_nccl_reshard_refit_info_wire_safe: convert placements and meshes into
+  plain dicts/lists before the refit metadata crosses a process boundary
 - restore_refit_info_placements: undo msgspec dict-flattening of placements
   and meshes on the receiving side
 
@@ -245,6 +247,45 @@ def _restore_placement(p):
             return Shard(p["dim"])
         return Replicate()
     return Replicate()
+
+
+def make_nccl_reshard_refit_info_wire_safe(refit_info: dict) -> dict:
+    """Copy refit metadata into types safe for vLLM's subprocess RPC.
+
+    Importing ``megatron.core`` replaces ``torch.storage._load_from_bytes`` with
+    a Megatron function, so Tensor pickles require Megatron at unpickle time.
+    vLLM subprocesses may not have it importable; convert the metadata to the
+    plain representation accepted by ``restore_refit_info_placements``.
+    """
+
+    def _wire_mesh(mesh):
+        if isinstance(mesh, MeshInfo):
+            return {"mesh": mesh.mesh.tolist()}
+        return mesh
+
+    def _wire_placement(placement):
+        if isinstance(placement, Shard):
+            return {"dim": placement.dim}
+        if isinstance(placement, Replicate):
+            return {}
+        return placement
+
+    wire_info = dict(refit_info)
+    wire_layers = {}
+    for layer_name, params in refit_info.get("per_layer_params", {}).items():
+        wire_params = []
+        for param_info in params:
+            wire_param = dict(param_info)
+            for key in ("src_mesh_info", "dst_mesh_info"):
+                if key in wire_param:
+                    wire_param[key] = _wire_mesh(wire_param[key])
+            for key in ("src_placements", "dst_placements"):
+                if key in wire_param:
+                    wire_param[key] = [_wire_placement(p) for p in wire_param[key]]
+            wire_params.append(wire_param)
+        wire_layers[layer_name] = wire_params
+    wire_info["per_layer_params"] = wire_layers
+    return wire_info
 
 
 def restore_refit_info_placements(refit_info: dict) -> dict:

--- a/nemo_rl/weight_sync/nccl_reshard_weight_synchronizer.py
+++ b/nemo_rl/weight_sync/nccl_reshard_weight_synchronizer.py
@@ -43,6 +43,9 @@ import ray
 
 from nemo_rl.utils.timer import Timer
 from nemo_rl.weight_sync.interfaces import WeightSynchronizer
+from nemo_rl.weight_sync.nccl_reshard_utils import (
+    make_nccl_reshard_refit_info_wire_safe,
+)
 
 
 class NcclReshardWeightSynchronizer(WeightSynchronizer):
@@ -205,9 +208,22 @@ class NcclReshardWeightSynchronizer(WeightSynchronizer):
             train_world_size,
             inference_world_size,
         )
-        self._generation.prepare_nccl_reshard_refit_info(nccl_reshard_refit_info)
+
+        # nccl_reshard_refit_info holds MeshInfo rank tensors created under
+        # Megatron, whose pickles resolve a Megatron-patched storage loader and
+        # therefore need `import megatron` on unpickle. Convert them to plain
+        # lists here; the vLLM worker rebuilds them in
+        # `restore_refit_info_placements()`.
+        wire_refit_info = make_nccl_reshard_refit_info_wire_safe(
+            nccl_reshard_refit_info
+        )
+        self._generation.prepare_nccl_reshard_refit_info(wire_refit_info)
 
     def shutdown(self) -> None:
         # The NCCL process groups' lifecycle is managed by Ray actor teardown;
         # the workers that own the groups are destroyed with the cluster.
-        pass
+        # Break the VllmGeneration <-> synchronizer reference cycle so the
+        # generation wrapper is garbage-collectable after teardown. The
+        # synchronizer is never used again after shutdown(), so losing the
+        # handle is safe.
+        self._generation = None

--- a/tests/unit/single_controller/test_sc_checkpointing.py
+++ b/tests/unit/single_controller/test_sc_checkpointing.py
@@ -223,9 +223,13 @@ class _FakeDPClient:
 class _FakeWeightSynchronizer:
     def __init__(self) -> None:
         self.sync_count = 0
+        self.shutdown_count = 0
 
     def sync_weights(self, *, kv_scales: Any = None) -> None:
         self.sync_count += 1
+
+    def shutdown(self) -> None:
+        self.shutdown_count += 1
 
 
 class _FakeRolloutManager:
@@ -1132,6 +1136,8 @@ class TestReplayBufferPersistence:
         # Each restored group holds one _buffer_capacity permit.
         assert actor._buffer_capacity._value == 4 - 3
         assert result["train_steps"] == 0
+        # run()'s finally must tear the synchronizer down exactly once.
+        assert actor._weight_synchronizer.shutdown_count == 1
 
     def test_restored_permits_are_released_by_a_live_pump(self, tmp_path):
         # The restore takes one capacity permit per group; a running pump must

--- a/tests/unit/weight_sync/test_nccl_reshard_utils.py
+++ b/tests/unit/weight_sync/test_nccl_reshard_utils.py
@@ -21,6 +21,7 @@ mesh construction, placement rules, expert grouping, and the top-level
 torch.distributed, no model object — so this module runs on CPU with no extras.
 """
 
+import pickle
 from types import SimpleNamespace
 
 import pytest
@@ -38,6 +39,8 @@ from nemo_rl.weight_sync.nccl_reshard_utils import (
     group_expert_params_in_metadata,
     is_expert_param,
     is_nccl_reshard_param,
+    make_nccl_reshard_refit_info_wire_safe,
+    restore_refit_info_placements,
 )
 
 
@@ -476,3 +479,81 @@ def test_build_refit_info_groups_experts_and_tags_them():
         for layer in info["layer_names"]
         for p in info["per_layer_params"][layer]
     )
+
+
+# --------------------------------------------------------------------------
+# make_nccl_reshard_refit_info_wire_safe / restore_refit_info_placements
+# --------------------------------------------------------------------------
+def _contains_tensor(obj) -> bool:
+    if isinstance(obj, torch.Tensor):
+        return True
+    if isinstance(obj, dict):
+        return any(_contains_tensor(v) for v in obj.values())
+    if isinstance(obj, (list, tuple)):
+        return any(_contains_tensor(v) for v in obj)
+    if hasattr(obj, "__dict__"):  # e.g. MeshInfo wrapping its rank tensor
+        return any(_contains_tensor(v) for v in vars(obj).values())
+    return False
+
+
+def _refit_info_for_wire() -> dict:
+    return build_nccl_reshard_refit_info(
+        _dense_metadata(),
+        train_parallelism={"tp_size": 2, "ep_size": 1, "pp_size": 1},
+        gen_parallelism={"tp_size": 4, "ep_size": 1, "pp_size": 1},
+        train_world_size=2,
+        gen_world_size=4,
+    )
+
+
+def test_wire_safe_refit_info_carries_no_tensors_and_pickles_plainly():
+    # MeshInfo holds a rank tensor; a tensor pickled in a megatron-importing
+    # process needs `import megatron` at unpickle time, so the wire form must
+    # be tensor-free end to end (the invariant this function exists for).
+    info = _refit_info_for_wire()
+    assert _contains_tensor(info)
+
+    wire = make_nccl_reshard_refit_info_wire_safe(info)
+
+    assert not _contains_tensor(wire)
+    # Placements are encoded exactly as restore expects: Shard -> {"dim": d},
+    # Replicate -> {}.
+    for params in wire["per_layer_params"].values():
+        for p in params:
+            assert isinstance(p["src_mesh_info"], dict)
+            assert isinstance(p["dst_mesh_info"], dict)
+            for placement in p["src_placements"] + p["dst_placements"]:
+                assert isinstance(placement, dict)
+    pickle.loads(pickle.dumps(wire))
+
+
+def test_wire_safe_does_not_mutate_the_train_side_refit_info():
+    info = _refit_info_for_wire()
+
+    make_nccl_reshard_refit_info_wire_safe(info)
+
+    for layer in info["layer_names"]:
+        for p in info["per_layer_params"][layer]:
+            assert isinstance(p["src_mesh_info"], MeshInfo)
+            assert isinstance(p["dst_mesh_info"], MeshInfo)
+            for placement in p["src_placements"] + p["dst_placements"]:
+                assert isinstance(placement, (Shard, Replicate))
+
+
+def test_wire_safe_then_restore_reproduces_placements_and_meshes():
+    info = _refit_info_for_wire()
+
+    wire = pickle.loads(pickle.dumps(make_nccl_reshard_refit_info_wire_safe(info)))
+    restored = restore_refit_info_placements(wire)
+
+    assert restored["layer_names"] == info["layer_names"]
+    for layer in info["layer_names"]:
+        original = {p["name"]: p for p in info["per_layer_params"][layer]}
+        assert len(restored["per_layer_params"][layer]) == len(original)
+        for p in restored["per_layer_params"][layer]:
+            o = original[p["name"]]
+            for key in ("src_mesh_info", "dst_mesh_info"):
+                assert isinstance(p[key], MeshInfo)
+                assert torch.equal(p[key].mesh, o[key].mesh)
+            for key in ("src_placements", "dst_placements"):
+                assert p[key] == o[key]

--- a/tests/unit/weight_sync/test_nccl_reshard_utils.py
+++ b/tests/unit/weight_sync/test_nccl_reshard_utils.py
@@ -557,3 +557,31 @@ def test_wire_safe_then_restore_reproduces_placements_and_meshes():
                 assert torch.equal(p[key].mesh, o[key].mesh)
             for key in ("src_placements", "dst_placements"):
                 assert p[key] == o[key]
+
+
+def test_wire_safe_pickle_is_independent_of_a_patched_storage_loader(monkeypatch):
+    # megatron.core replaces torch.storage._load_from_bytes at import time; a
+    # tensor pickled under the patch records the patcher's module path and
+    # cannot be unpickled without it. Mimic the patch with a dummy module and
+    # assert only the raw form references it — the invariant the wire-safe
+    # conversion exists to guarantee.
+    import io
+    import sys
+    import types
+
+    dummy = types.ModuleType("dummy_unpickler_module")
+
+    def _dummy_load_from_bytes(b):
+        return torch.load(io.BytesIO(b), weights_only=True)
+
+    _dummy_load_from_bytes.__module__ = "dummy_unpickler_module"
+    _dummy_load_from_bytes.__qualname__ = "_dummy_load_from_bytes"
+    dummy._dummy_load_from_bytes = _dummy_load_from_bytes
+    monkeypatch.setitem(sys.modules, "dummy_unpickler_module", dummy)
+    monkeypatch.setattr(torch.storage, "_load_from_bytes", _dummy_load_from_bytes)
+
+    info = _refit_info_for_wire()
+    wire = make_nccl_reshard_refit_info_wire_safe(info)
+
+    assert b"dummy_unpickler_module" in pickle.dumps(info)
+    assert b"dummy_unpickler_module" not in pickle.dumps(wire)

--- a/tests/unit/weight_sync/test_weight_synchronizer.py
+++ b/tests/unit/weight_sync/test_weight_synchronizer.py
@@ -34,6 +34,10 @@ from nemo_rl.weight_sync.interfaces import WeightSynchronizer
 from nemo_rl.weight_sync.ipc_weight_synchronizer import (
     IPCWeightSynchronizer,
 )
+from nemo_rl.weight_sync.nccl_reshard_utils import build_nccl_reshard_refit_info
+from nemo_rl.weight_sync.nccl_reshard_weight_synchronizer import (
+    NcclReshardWeightSynchronizer,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -414,6 +418,77 @@ class TestCollectiveWeightSynchronizer:
         gen.init_collective.assert_called_once_with(
             "10.0.0.1", 29500, 6, train_world_size=4
         )
+
+
+# ---------------------------------------------------------------------------
+# NcclReshardWeightSynchronizer
+# ---------------------------------------------------------------------------
+
+
+class TestNcclReshardWeightSynchronizer:
+    @patch("nemo_rl.weight_sync.nccl_reshard_weight_synchronizer.ray")
+    def test_init_communicator_ships_wire_safe_refit_info(self, mock_ray):
+        # The train-side refit info carries MeshInfo rank tensors; the copy
+        # handed to the generation side must be the wire-safe (plain-dict)
+        # form, or the vLLM worker needs `import megatron` to unpickle it.
+        mock_ray.get.return_value = [True]
+        refit_info = build_nccl_reshard_refit_info(
+            {
+                "model.layers.0.mlp.gate_proj.weight": {
+                    "shape": [64, 32],
+                    "dtype": "torch.bfloat16",
+                }
+            },
+            train_parallelism={"tp_size": 2, "ep_size": 1, "pp_size": 1},
+            gen_parallelism={"tp_size": 4, "ep_size": 1, "pp_size": 1},
+            train_world_size=2,
+            gen_world_size=4,
+        )
+        policy = _mock_policy(
+            cfg={
+                "megatron_cfg": {
+                    "tensor_model_parallel_size": 2,
+                    "expert_model_parallel_size": 1,
+                    "pipeline_model_parallel_size": 1,
+                },
+                "generation": {"vllm_cfg": {"tensor_parallel_size": 4}},
+            },
+        )
+        policy.init_nccl_reshard_comm_group.return_value = [MagicMock()]
+        policy.prepare_nccl_reshard_refit_info.return_value = refit_info
+        gen = _mock_generation()
+        gen.init_nccl_reshard_comm_group.return_value = [MagicMock()]
+        train_cluster = _mock_cluster(world_size=2)
+        train_cluster.num_gpus_per_node = 8
+        train_cluster.get_available_address_and_port.return_value = (
+            "10.0.0.1",
+            12345,
+        )
+        inference_cluster = _mock_cluster(world_size=4)
+
+        sync = NcclReshardWeightSynchronizer(
+            policy, gen, train_cluster, inference_cluster
+        )
+        sync.init_communicator()
+
+        policy.prepare_nccl_reshard_refit_info.assert_called_once()
+        gen.prepare_nccl_reshard_refit_info.assert_called_once()
+        (shipped,), _ = gen.prepare_nccl_reshard_refit_info.call_args
+        for params in shipped["per_layer_params"].values():
+            for p in params:
+                assert isinstance(p["src_mesh_info"], dict)
+                assert isinstance(p["dst_mesh_info"], dict)
+                for placement in p["src_placements"] + p["dst_placements"]:
+                    assert isinstance(placement, dict)
+
+    def test_shutdown_drops_the_generation_handle(self):
+        sync = NcclReshardWeightSynchronizer(
+            _mock_policy(), _mock_generation(), _mock_cluster(), _mock_cluster()
+        )
+
+        sync.shutdown()
+
+        assert sync._generation is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
I am separating PR #3532 into two. Wire-safe part and the MTP gating part.

# What does this PR do ?

Make the nccl_reshard_refit_info object wire-safe before sending it to the generation worker during initialization.
nccl_reshard_refit_info contains torch tensors, created by Megatron. The problem is that Megatron replaces the
torch.storage._load_from_bytes function that is required for unpickling to a Megatron-specific function.
So, during unpickling from the generation worker, it will call import megatron which will cause an import error.
This PR fixes that issue.


**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
