### PR TITLE
fix: gate MTP layers from the nccl-reshard bulk refit path

### DIFF
--- a/docs/design-docs/nccl-reshard-refit.md
+++ b/docs/design-docs/nccl-reshard-refit.md
@@ -58,6 +58,15 @@ nccl-reshard-refit implementation:
   `.weight`, dense MLP and MoE experts alike; see `is_nccl_reshard_param()`). These are
   resharded shard-to-shard with `xferdtensor` over dedicated NCCL communicators. For
   large models this covers the vast majority of the refit bytes. For the current version of implementation, it only detects `(experts).N.{gate_proj|up_proj|down_proj}` as the subject of this performant transportation path. The coverage will be expanded via future updates.
+  Two FFN-named groups are explicitly excluded and ride the misc path instead:
+  shared-expert weights (`*.shared_expert.*`, which fuse differently on the vLLM
+  side) and co-trained MTP drafter weights (which vLLM keeps in a separate
+  drafter module updated through `load_weights`). MTP weights are recognized two
+  ways: bare-`mtp.`-prefix HF names (NemotronH, Qwen3.5) via
+  `is_nccl_reshard_param()`, and DeepSeek-style MTP exported as trailing
+  `model.layers.N` indices via provenance — the Megatron-side name on the
+  Bridge conversion tasks is uniformly `mtp.*`, so the worker excludes those HF
+  layers when building the metadata (`_collect_mtp_hf_layer_names()`).
 * **Misc path** — everything else (embeddings, attention projections, layernorms, the
   MoE router, `lm_head`, FP8 `_scale_inv` siblings, FP8 KV-cache scales, …). These ride
   a packed broadcast (conventional `packed_tensor.py` implementation) over the shared

--- a/docs/design-docs/nccl-reshard-refit.md
+++ b/docs/design-docs/nccl-reshard-refit.md
@@ -39,6 +39,9 @@ single `ValueError` listing every violation. The current requirements are:
 * vLLM expert parallelism is supported with the NeMo RL convention
   `expert_parallel_size == tensor_parallel_size`. 
 * Generation-side, PP > 1 is not supported. 
+* **No ModelOpt real quantization** — `policy.generation.real_quant=false`. Real-quant
+  rollouts refit through vLLM's layerwise-reload weight loaders, which the bulk
+  `xferdtensor` writes bypass.
 
 Operational knobs:
 
@@ -64,9 +67,10 @@ nccl-reshard-refit implementation:
   drafter module updated through `load_weights`). MTP weights are recognized two
   ways: bare-`mtp.`-prefix HF names (NemotronH, Qwen3.5) via
   `is_nccl_reshard_param()`, and DeepSeek-style MTP exported as trailing
-  `model.layers.N` indices via provenance — the Megatron-side name on the
-  Bridge conversion tasks is uniformly `mtp.*`, so the worker excludes those HF
-  layers when building the metadata (`_collect_mtp_hf_layer_names()`).
+  `model.layers.N` indices via provenance — the Megatron-side name carries an
+  `mtp.` module segment (bare for LM bridges, `language_model.mtp.*` for the VL
+  and EXAONE bridges), so the worker excludes those HF layers when building the
+  metadata (`_collect_mtp_hf_layer_names()`).
 * **Misc path** — everything else (embeddings, attention projections, layernorms, the
   MoE router, `lm_head`, FP8 `_scale_inv` siblings, FP8 KV-cache scales, …). These ride
   a packed broadcast (conventional `packed_tensor.py` implementation) over the shared

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -56,7 +56,7 @@ except ImportError:
     )
 
 
-WeightUpdateTransport = Literal["ipc", "collective"]
+WeightUpdateTransport = Literal["ipc", "collective", "nccl_reshard"]
 WeightUpdateFinalizer = Callable[[], None]
 
 
@@ -1064,33 +1064,26 @@ class VllmInternalWorkerExtension:
 
         import time
 
-        misc_t0 = time.perf_counter()
-        self._receive_and_load_misc_params()
-        torch.cuda.synchronize()
-        if torch.distributed.get_rank() == 0:
-            print(
-                f"[nccl_reshard_refit] misc recv+load (gen side): "
-                f"{time.perf_counter() - misc_t0:.2f}s",
-                flush=True,
-            )
-        torch.cuda.empty_cache()
-        from vllm.config import set_current_vllm_config
-        from vllm.model_executor.model_loader.utils import (
-            process_weights_after_loading,
-        )
+        with self._weight_update_lifecycle("nccl_reshard") as finalize:
+            misc_t0 = time.perf_counter()
+            self._receive_and_load_misc_params()
+            torch.cuda.synchronize()
+            if torch.distributed.get_rank() == 0:
+                print(
+                    f"[nccl_reshard_refit] misc recv+load (gen side): "
+                    f"{time.perf_counter() - misc_t0:.2f}s",
+                    flush=True,
+                )
+            torch.cuda.empty_cache()
 
-        # Finalize post-load weight processing: dense Linear + attention/MLA, and
-        # crucially the per-MoE-backend w13 layout (FlashInfer CUTLASS/TRTLLM) that
-        # the canonical [gate; up] bulk write above defers to here.
-        with set_current_vllm_config(self.model_runner.vllm_config):
-            process_weights_after_loading(
-                self.model_runner.model, self.model_config, self.device
-            )
+            # Finalize post-load weight processing: dense Linear + attention/MLA,
+            # the per-MoE-backend w13 layout (FlashInfer CUTLASS/TRTLLM) that the
+            # canonical [gate; up] bulk write above defers to here, and the MTP
+            # drafter's mirror of the same. The FP8 KV-cache per-layer k/v scales
+            # are finalized by the lifecycle on exit.
+            finalize()
 
-        torch.cuda.empty_cache()
-
-        # Finalize FP8 KV-cache per-layer k/v scales after the misc broadcast.
-        self._maybe_process_fp8_kv_cache()
+            torch.cuda.empty_cache()
         return True
 
     def _receive_and_load_misc_params(self) -> None:

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -201,6 +201,39 @@ def _estimate_refit_tensor_size_in_bytes(
     return param.numel() * tp_size * ep_size * element_size
 
 
+def _collect_mtp_hf_layer_names(conversion_tasks: Optional[list]) -> set[str]:
+    """Return HF layer names whose weights originate from Megatron's MTP module.
+
+    The Megatron-side parameter name is uniformly ``mtp.*`` for every model
+    family, but the HF-side name is not: DeepSeek-style bridges export MTP as
+    trailing main-model layer indices (``model.layers.{N + num_layers}.*``),
+    which ``is_nccl_reshard_param`` cannot recognize from the name shape alone.
+    Provenance — the Megatron name carried by the Bridge conversion task — is
+    the reliable signal. Results are keyed by ``_extract_layer_name`` so a
+    whole MTP layer is routed to the misc path together.
+
+    Args:
+        conversion_tasks: Megatron-Bridge ``WeightConversionTask`` list; only
+            ``global_param_name`` (resolved Megatron-side name) and
+            ``mapping.hf_param`` (str, or dict of str for compound mappings)
+            are consulted. ``None`` entries are tolerated.
+
+    Returns:
+        Set of HF layer names, e.g. ``{"model.layers.61", "mtp.layers.0"}``.
+    """
+    from nemo_rl.weight_sync.nccl_reshard_utils import _extract_layer_name
+
+    mtp_layers: set[str] = set()
+    for task in conversion_tasks or []:
+        # FP8 export can leave None placeholders in the task list (BF16 export
+        # pre-filters them; see _build_refit_conversion_tasks).
+        if task is not None and task.global_param_name.startswith("mtp."):
+            hf = task.mapping.hf_param
+            for hf_name in hf.values() if isinstance(hf, dict) else [str(hf)]:
+                mtp_layers.add(_extract_layer_name(hf_name))
+    return mtp_layers
+
+
 @contextmanager
 def _meta_tensor_alloc_context():
     """Skip real GPU work during metadata enumeration.
@@ -2402,7 +2435,18 @@ class MegatronPolicyWorkerImpl(
         # state_dict_metadata[hf_name] -> [shape, dtype]
         # At the same time, filter the params to the misc subset (packed_broadcast path).
         # misc_meta[hf_name] -> [shape, dtype]
-        from nemo_rl.weight_sync.nccl_reshard_utils import _extract_layer_prefix
+        from nemo_rl.weight_sync.nccl_reshard_utils import (
+            _extract_layer_name,
+            _extract_layer_prefix,
+        )
+
+        # HF layers whose weights come from Megatron's MTP module. The prefix
+        # gate inside is_nccl_reshard_param only catches families whose HF
+        # names keep the bare ``mtp.`` prefix (NemotronH, Qwen3.5); DeepSeek
+        # exports MTP as trailing ``model.layers.N`` indices, so provenance is
+        # the only reliable signal. vLLM keeps the MTP drafter separate from
+        # the main model and updates it through load_weights -> misc path.
+        mtp_hf_layers_names = _collect_mtp_hf_layer_names(self.refit_conversion_tasks)
 
         layer_prefix = None
         with _meta_tensor_alloc_context():
@@ -2414,7 +2458,10 @@ class MegatronPolicyWorkerImpl(
                 _nbytes = tensor.numel() * tensor.element_size()
                 # Downsized whitelist: only FFN gate/up/down weights take the bulk
                 # nccl-reshard path; everything else -> misc (packed_broadcast).
-                if is_nccl_reshard_param(name):
+                if (
+                    is_nccl_reshard_param(name)
+                    and _extract_layer_name(name) not in mtp_hf_layers_names
+                ):
                     state_dict_metadata[name] = meta
                     _xfer_bytes += _nbytes
                     if layer_prefix is not None:

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -203,20 +203,11 @@ def _estimate_refit_tensor_size_in_bytes(
 
 def _collect_mtp_hf_layer_names(conversion_tasks: Optional[list]) -> set[str]:
     """Return HF layer names whose weights originate from Megatron's MTP module.
-
-    The Megatron-side parameter name is uniformly ``mtp.*`` for every model
-    family, but the HF-side name is not: DeepSeek-style bridges export MTP as
-    trailing main-model layer indices (``model.layers.{N + num_layers}.*``),
-    which ``is_nccl_reshard_param`` cannot recognize from the name shape alone.
-    Provenance — the Megatron name carried by the Bridge conversion task — is
-    the reliable signal. Results are keyed by ``_extract_layer_name`` so a
-    whole MTP layer is routed to the misc path together.
+    This is required because, in some casees, only the Megatron-side name contains
+    the `mtp` string, while the HF-side name does not.
 
     Args:
-        conversion_tasks: Megatron-Bridge ``WeightConversionTask`` list; only
-            ``global_param_name`` (resolved Megatron-side name) and
-            ``mapping.hf_param`` (str, or dict of str for compound mappings)
-            are consulted. ``None`` entries are tolerated.
+        conversion_tasks: Megatron-Bridge ``WeightConversionTask`` list
 
     Returns:
         Set of HF layer names, e.g. ``{"model.layers.61", "mtp.layers.0"}``.
@@ -225,9 +216,11 @@ def _collect_mtp_hf_layer_names(conversion_tasks: Optional[list]) -> set[str]:
 
     mtp_layers: set[str] = set()
     for task in conversion_tasks or []:
-        # FP8 export can leave None placeholders in the task list (BF16 export
-        # pre-filters them; see _build_refit_conversion_tasks).
-        if task is not None and task.global_param_name.startswith("mtp."):
+        if task is None:
+            continue
+        if ".mtp." in task.global_param_name or task.global_param_name.startswith(
+            "mtp."
+        ):
             hf = task.mapping.hf_param
             for hf_name in hf.values() if isinstance(hf, dict) else [str(hf)]:
                 mtp_layers.add(_extract_layer_name(hf_name))

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -203,7 +203,8 @@ def _estimate_refit_tensor_size_in_bytes(
 
 def _collect_mtp_hf_layer_names(conversion_tasks: Optional[list]) -> set[str]:
     """Return HF layer names whose weights originate from Megatron's MTP module.
-    This is required because, in some casees, only the Megatron-side name contains
+
+    This is required because, in some cases, only the Megatron-side name contains
     the `mtp` string, while the HF-side name does not.
 
     Args:

--- a/nemo_rl/weight_sync/nccl_reshard_utils.py
+++ b/nemo_rl/weight_sync/nccl_reshard_utils.py
@@ -191,8 +191,12 @@ def is_nccl_reshard_param(param_name: str) -> bool:
     ``load_weights`` path.
 
     Shared-expert FFN weights (``*.shared_expert.*``) are routed to misc path.
-    Co-trained MTP weights are also routed to misc because vLLM keeps the MTP
-    drafter separate from the main model and updates it through ``load_weights``.
+    Bare ``mtp.``-prefixed HF names are routed to misc too, because vLLM keeps
+    the MTP drafter separate and updates it through ``load_weights``. That only
+    covers families whose HF names keep the ``mtp.`` prefix. DeepSeek exports
+    MTP under ``model.layers.N`` HF names (the ``mtp.`` appears only on the
+    Megatron side), so those return True here; the caller drops them instead,
+    using the layer set from ``_collect_mtp_hf_layer_names``.
     """
     if "shared_expert" in param_name:
         return False

--- a/nemo_rl/weight_sync/nccl_reshard_utils.py
+++ b/nemo_rl/weight_sync/nccl_reshard_utils.py
@@ -191,8 +191,12 @@ def is_nccl_reshard_param(param_name: str) -> bool:
     ``load_weights`` path.
 
     Shared-expert FFN weights (``*.shared_expert.*``) are routed to misc path.
+    Co-trained MTP weights are also routed to misc because vLLM keeps the MTP
+    drafter separate from the main model and updates it through ``load_weights``.
     """
     if "shared_expert" in param_name:
+        return False
+    if param_name.startswith("mtp."):
         return False
     return param_name.endswith(FFN_PROJ_WEIGHT_SUFFIXES) or param_name.endswith(
         FFN_GROUPED_EXPERT_SUFFIXES

--- a/nemo_rl/weight_sync/nccl_reshard_utils.py
+++ b/nemo_rl/weight_sync/nccl_reshard_utils.py
@@ -565,6 +565,16 @@ def check_nccl_reshard_refit_support(master_config: dict) -> None:
             "dynamic expert load balancing can change ownership afterwards)."
         )
 
+    # ModelOpt real-quant rollout holds NVFP4-packed vLLM params and refits
+    # through vLLM's layerwise-reload weight loaders; the bulk xferdtensor
+    # path writes directly into param storage, bypassing both.
+    if generation.get("real_quant"):
+        violations.append(
+            "policy.generation.real_quant must be False "
+            "(nccl_reshard_refit's bulk xferdtensor writes bypass the "
+            "layerwise-reload weight loaders that ModelOpt real quant requires)."
+        )
+
     # This initial version supports only the Megatron train + vLLM gen
     # combination; the DTensor train backend refit path is intentionally
     # dropped (Megatron is the path validated end-to-end).

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -69,6 +69,56 @@ def test_model_owned_mtp_loss_mask_packing_capability_is_detected():
     assert not _model_self_packs_mtp_loss_mask(object())
 
 
+def _conversion_task(megatron_param: str, hf_param) -> SimpleNamespace:
+    return SimpleNamespace(
+        global_param_name=megatron_param,
+        mapping=SimpleNamespace(hf_param=hf_param),
+    )
+
+
+def test_collect_mtp_hf_layer_names_covers_both_naming_schemes():
+    from nemo_rl.models.policy.workers.megatron_policy_worker import (
+        _collect_mtp_hf_layer_names,
+    )
+
+    tasks = [
+        None,  # dropped tasks are tolerated
+        # DeepSeek-style: megatron mtp.* exports as a trailing main-model
+        # layer index (num_hidden_layers=61 -> HF layer model.layers.61).
+        _conversion_task(
+            "mtp.layers.0.mtp_model_layer.mlp.linear_fc1.weight",
+            {
+                "gate": "model.layers.61.mlp.gate_proj.weight",
+                "up": "model.layers.61.mlp.up_proj.weight",
+            },
+        ),
+        # NemotronH-style: bare mtp. prefix survives into the HF name.
+        _conversion_task(
+            "mtp.layers.0.mtp_model_layer.layers.0.mlp.linear_fc1.weight",
+            "mtp.layers.0.mixer.up_proj.weight",
+        ),
+        # Main-model tasks must not contribute.
+        _conversion_task(
+            "decoder.layers.3.mlp.linear_fc1.weight",
+            {"gate": "model.layers.3.mlp.gate_proj.weight"},
+        ),
+        _conversion_task(
+            "embedding.word_embeddings.weight", "model.embed_tokens.weight"
+        ),
+    ]
+
+    assert _collect_mtp_hf_layer_names(tasks) == {"model.layers.61", "mtp.layers.0"}
+
+
+def test_collect_mtp_hf_layer_names_empty_inputs():
+    from nemo_rl.models.policy.workers.megatron_policy_worker import (
+        _collect_mtp_hf_layer_names,
+    )
+
+    assert _collect_mtp_hf_layer_names([]) == set()
+    assert _collect_mtp_hf_layer_names(None) == set()
+
+
 def test_regular_model_does_not_delegate_packing():
     from nemo_rl.models.policy.workers.megatron_policy_worker import (
         _model_self_packs_for_cp,

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -97,6 +97,12 @@ def test_collect_mtp_hf_layer_names_covers_both_naming_schemes():
             "mtp.layers.0.mtp_model_layer.layers.0.mlp.linear_fc1.weight",
             "mtp.layers.0.mixer.up_proj.weight",
         ),
+        # Qwen3.5-VL / EXAONE-style: megatron name carries a language_model.
+        # prefix before the mtp. segment; the HF name stays bare mtp.*.
+        _conversion_task(
+            "language_model.mtp.layers.1.mtp_model_layer.mlp.linear_fc1.weight",
+            "mtp.layers.1.mlp.up_proj.weight",
+        ),
         # Main-model tasks must not contribute.
         _conversion_task(
             "decoder.layers.3.mlp.linear_fc1.weight",
@@ -107,7 +113,11 @@ def test_collect_mtp_hf_layer_names_covers_both_naming_schemes():
         ),
     ]
 
-    assert _collect_mtp_hf_layer_names(tasks) == {"model.layers.61", "mtp.layers.0"}
+    assert _collect_mtp_hf_layer_names(tasks) == {
+        "model.layers.61",
+        "mtp.layers.0",
+        "mtp.layers.1",
+    }
 
 
 def test_collect_mtp_hf_layer_names_empty_inputs():


### PR DESCRIPTION
I am separating PR https://github.com/NVIDIA-NeMo/RL/pull/3532 into two. Wire-safe part and the MTP gating part.

# What does this PR do ?

Gate the MTP layers from the nccl-reshard path. It will force the use of the conventional refit path for the MTP layer.
The PR also contains the correct MTP gating for the DeepSeek MTP and the refactor in the misc path call to correctly update the MTP drafter in the vLLM engine.


# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
