### PR TITLE
fix(agent): parse Slurm .out and drop awk from L2 prep

### DIFF
--- a/.agents/contributor-skills/megatron-pr-test-run/SKILL.md
+++ b/.agents/contributor-skills/megatron-pr-test-run/SKILL.md
@@ -253,6 +253,11 @@ from a failing command substitution):
 bash .agents/nemo-rl-testing-agent/tests/test_import_guard.sh
 ```
 
+Prep must also stay runnable on L2 Ray workers whose `PATH` may omit `/usr/bin`
+(one failure was `awk: command not found` mid-prep while the head node was
+fine). Keep system dirs first on `PATH` at the top of prep, and prefer bash
+builtins over tools like `awk` when parsing smoke-test output.
+
 Whenever you abandon or park a run for infra reasons — including a prep failure
 that never reached a test — post it to the PR immediately rather than waiting
 for a later run to succeed:

--- a/.agents/contributor-skills/megatron-pr-test-run/SKILL.md
+++ b/.agents/contributor-skills/megatron-pr-test-run/SKILL.md
@@ -197,21 +197,24 @@ serialising keeps the failure attribution clean.
 ### 2. Collect results
 
 The run writes to shared scratch (`ARTIFACT_DIR` in the submit output):
-`results.tsv` plus one `<test>.log` per sub-test. The markers are also in the
-Slurm log, which is what `cog.log` captures.
+`results.tsv` plus one `<test>.log` per sub-test. The `NRLTA_TEST_*` markers
+live in the Slurm job `.out`. Do **not** treat `cog.log` as that log by
+default: on oci-hsg it often only holds the submission JSON plus a short
+stderr (exit code), so `parse_results.py` on `COG_LOG` reports 0 tests and
+looks like a prep death even when the suite finished.
 
-```bash
-COG_LOG=~/.nemo-rl-testing-agent/runs/nrlta-pr5700-l1-a1/cog.log
-uv run --script .agents/nemo-rl-testing-agent/scripts/parse_results.py \
-  "$COG_LOG" --artifact-dir <ARTIFACT_DIR> \
-  --out ~/.nemo-rl-testing-agent/pr-5700/l1.results.json
-```
-
-If the Slurm log is truncated in `cog.log`, read it from the cluster instead:
+Always parse the Slurm `.out` (fetch it if needed):
 
 ```bash
 ssh oci 'cat <SLURM_LOG_DIR>/<JOBID>.out' > /tmp/l1.out
+uv run --script .agents/nemo-rl-testing-agent/scripts/parse_results.py \
+  /tmp/l1.out --artifact-dir <ARTIFACT_DIR> \
+  --out ~/.nemo-rl-testing-agent/pr-5700/l1.results.json
 ```
+
+If you already pointed `parse_results.py` at `COG_LOG` and got 0 tests,
+immediately fetch the cluster `.out` and re-parse before calling it a prep
+failure. Only use `cog.log` when it actually contains the `NRLTA_*` markers.
 
 Each entry gets `status` (`pass` / `fail` / `incomplete` / `not run`), `rc`,
 `secs`, an `error_signature`, and the tail of the output. `comment` is left

--- a/.agents/nemo-rl-testing-agent/scripts/prep_container.sh
+++ b/.agents/nemo-rl-testing-agent/scripts/prep_container.sh
@@ -26,6 +26,11 @@
 
 set -euo pipefail
 
+# Ray worker setup on L2 has been observed with a PATH that cannot resolve
+# common /usr/bin tools (awk). Keep system dirs first so prep never depends on
+# whatever the launcher left in PATH.
+export PATH="/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
 : "${CONTAINER_ROOT:=/opt/nemo-rl}"
 : "${CONTAINER_MCORE_DIR:?CONTAINER_MCORE_DIR must be set}"
 : "${MCORE_FETCH_REF:?MCORE_FETCH_REF must be set (e.g. refs/pull/1234/head)}"
@@ -288,7 +293,15 @@ print("BRIDGE_IMPORT_OK")
     exit 1
   fi
 
-  bridge_file="$(printf '%s\n' "${smoke_out}" | awk '/^BRIDGE_FILE /{print $2}')"
+  # Prefer bash over awk: some L2 Ray worker containers have a PATH that
+  # cannot resolve awk (seen as `awk: command not found` mid-prep while the
+  # head node already printed earlier bridge_venv lines).
+  bridge_file=""
+  while IFS= read -r _nrlta_line || [ -n "${_nrlta_line}" ]; do
+    case "${_nrlta_line}" in
+      BRIDGE_FILE\ *) bridge_file="${_nrlta_line#BRIDGE_FILE }" ;;
+    esac
+  done <<< "${smoke_out}"
   if [ -n "${bridge_file}" ]; then
     echo "bridge_venv=${venv_name} resolves=${bridge_file}"
     if [ -n "${CONTAINER_BRIDGE_DIR:-}" ]; then


### PR DESCRIPTION
## Summary
Promote pending NemoRLTest learnings from the PR #6222 as-is re-run:

- Collect results from the Slurm `.out` (not `cog.log` alone) — on oci-hsg `cog.log` often only has submission JSON, so a 0-test parse looks like a prep death.
- Harden `prep_container.sh` for L2 Ray workers: put `/usr/bin` first on `PATH`, parse `BRIDGE_FILE` with bash instead of `awk`.

## Sweep learnings
- **cog-log-lacks-test-markers** — Always parse from the Slurm `.out`; if `COG_LOG` yields 0 tests, fetch the cluster `.out` and re-parse before treating it as prep failure.
- **prep-l2-ray-worker-path-missing-awk** — Do not use awk (or assume a full PATH) in prep; keep `/usr/bin` first and parse with bash.

## Test plan
- [x] `for t in .agents/nemo-rl-testing-agent/tests/*.sh; do bash "$t"; done`
- [ ] Next L2 submit: prep completes on both Ray nodes without `awk: command not found`
- [ ] Next L1/L2 collect: parse from Slurm `.out` when `cog.log` has no markers