### PR TITLE
feat(logger): WanDB now shows core metrics in a separate tab for convenience

### DIFF
--- a/nemo_rl/utils/logger.py
+++ b/nemo_rl/utils/logger.py
@@ -46,13 +46,15 @@ from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 # Flag to track if rich logging has been configured
 _rich_logging_configured = False
 
-# Metrics that are re-logged under the "core/" prefix so they appear in a
-# dedicated WandB section alongside their normal train/* location.
+# Metrics that are re-logged under the "core/<prefix>" namespace so they appear in a
+# dedicated WandB section alongside their normal train/* or validation/* location.
 _CORE_METRIC_KEYS: frozenset[str] = frozenset(
     {
         "total_reward/mean",
+        "mean_total_reward",
         "mean_generation_length",
         "gen_tokens_per_sample/mean",
+        "mean_gen_tokens_per_sample",
         "approx_entropy",
         "kl_penalty",
         "gen_kl_error",
@@ -1061,15 +1063,21 @@ class Logger(LoggerInterface):
             prefix: Optional prefix for metric names
             step_metric: Optional name of a field in metrics to use as step instead
                          of the provided step value (currently only needed for wandb)
+
+        Any key in `_CORE_METRIC_KEYS` is additionally re-logged under a
+        "core/<prefix>" namespace (e.g. "core/train", "core/validation") so it
+        appears in a dedicated dashboard section; the original prefixed entry
+        is unaffected.
         """
         for logger in self.loggers:
             logger.log_metrics(metrics, step, prefix, step_metric, step_finished)
 
         core_metrics = {k: v for k, v in metrics.items() if k in _CORE_METRIC_KEYS}
         if core_metrics:
+            core_prefix = f"core/{prefix}" if prefix else "core"
             for logger in self.loggers:
                 logger.log_metrics(
-                    core_metrics, step, "core", step_metric, step_finished
+                    core_metrics, step, core_prefix, step_metric, step_finished
                 )
 
     def log_hyperparams(self, params: Mapping[str, Any]) -> None:

--- a/nemo_rl/utils/logger.py
+++ b/nemo_rl/utils/logger.py
@@ -46,6 +46,19 @@ from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 # Flag to track if rich logging has been configured
 _rich_logging_configured = False
 
+# Metrics that are re-logged under the "core/" prefix so they appear in a
+# dedicated WandB section alongside their normal train/* location.
+_CORE_METRIC_KEYS: frozenset[str] = frozenset(
+    {
+        "total_reward/mean",
+        "mean_generation_length",
+        "gen_tokens_per_sample/mean",
+        "approx_entropy",
+        "kl_penalty",
+        "gen_kl_error",
+    }
+)
+
 
 class WandbConfig(TypedDict):
     project: NotRequired[str]
@@ -1051,6 +1064,13 @@ class Logger(LoggerInterface):
         """
         for logger in self.loggers:
             logger.log_metrics(metrics, step, prefix, step_metric, step_finished)
+
+        core_metrics = {k: v for k, v in metrics.items() if k in _CORE_METRIC_KEYS}
+        if core_metrics:
+            for logger in self.loggers:
+                logger.log_metrics(
+                    core_metrics, step, "core", step_metric, step_finished
+                )
 
     def log_hyperparams(self, params: Mapping[str, Any]) -> None:
         """Log hyperparameters to all enabled backends.

--- a/tests/unit/utils/test_logger.py
+++ b/tests/unit/utils/test_logger.py
@@ -1665,6 +1665,96 @@ class TestLogger:
 
     @patch("nemo_rl.utils.logger.WandbLogger")
     @patch("nemo_rl.utils.logger.TensorboardLogger")
+    def test_log_metrics_relogs_core_metrics(
+        self, mock_tb_logger, mock_wandb_logger, temp_dir
+    ):
+        """Test that core metrics are additionally logged under a core/<prefix> namespace."""
+        cfg = {
+            "wandb_enabled": True,
+            "tensorboard_enabled": True,
+            "mlflow_enabled": False,
+            "swanlab_enabled": False,
+            "monitor_gpus": False,
+            "wandb": {"project": "test-project"},
+            "tensorboard": {"log_dir": "test_logs"},
+            "log_dir": temp_dir,
+        }
+        logger = Logger(cfg)
+
+        mock_wandb_instance = mock_wandb_logger.return_value
+        mock_tb_instance = mock_tb_logger.return_value
+
+        metrics = {"loss": 0.5, "kl_penalty": 0.02, "total_reward/mean": 1.5}
+        step = 10
+        logger.log_metrics(metrics, step, prefix="train")
+
+        expected_core = {"kl_penalty": 0.02, "total_reward/mean": 1.5}
+        for mock_instance in (mock_wandb_instance, mock_tb_instance):
+            assert mock_instance.log_metrics.call_args_list == [
+                call(metrics, step, "train", None, False),
+                call(expected_core, step, "core/train", None, False),
+            ]
+
+    @patch("nemo_rl.utils.logger.WandbLogger")
+    @patch("nemo_rl.utils.logger.TensorboardLogger")
+    def test_log_metrics_core_namespace_separates_train_and_validation(
+        self, mock_tb_logger, mock_wandb_logger, temp_dir
+    ):
+        """Test that train and validation core metrics land under distinct core/ names."""
+        cfg = {
+            "wandb_enabled": True,
+            "tensorboard_enabled": True,
+            "mlflow_enabled": False,
+            "swanlab_enabled": False,
+            "monitor_gpus": False,
+            "wandb": {"project": "test-project"},
+            "tensorboard": {"log_dir": "test_logs"},
+            "log_dir": temp_dir,
+        }
+        logger = Logger(cfg)
+
+        mock_wandb_instance = mock_wandb_logger.return_value
+
+        logger.log_metrics({"total_reward/mean": 1.0}, 10, prefix="train")
+        logger.log_metrics({"total_reward/mean": 2.0}, 10, prefix="validation")
+
+        assert mock_wandb_instance.log_metrics.call_args_list == [
+            call({"total_reward/mean": 1.0}, 10, "train", None, False),
+            call({"total_reward/mean": 1.0}, 10, "core/train", None, False),
+            call({"total_reward/mean": 2.0}, 10, "validation", None, False),
+            call({"total_reward/mean": 2.0}, 10, "core/validation", None, False),
+        ]
+
+    @patch("nemo_rl.utils.logger.WandbLogger")
+    @patch("nemo_rl.utils.logger.TensorboardLogger")
+    def test_log_metrics_without_core_metrics_logs_once(
+        self, mock_tb_logger, mock_wandb_logger, temp_dir
+    ):
+        """Test that no extra core/ dispatch happens when no core metric is present."""
+        cfg = {
+            "wandb_enabled": True,
+            "tensorboard_enabled": True,
+            "mlflow_enabled": False,
+            "swanlab_enabled": False,
+            "monitor_gpus": False,
+            "wandb": {"project": "test-project"},
+            "tensorboard": {"log_dir": "test_logs"},
+            "log_dir": temp_dir,
+        }
+        logger = Logger(cfg)
+
+        metrics = {"loss": 0.5, "accuracy": 0.8}
+        logger.log_metrics(metrics, 10, prefix="train")
+
+        mock_wandb_logger.return_value.log_metrics.assert_called_once_with(
+            metrics, 10, "train", None, False
+        )
+        mock_tb_logger.return_value.log_metrics.assert_called_once_with(
+            metrics, 10, "train", None, False
+        )
+
+    @patch("nemo_rl.utils.logger.WandbLogger")
+    @patch("nemo_rl.utils.logger.TensorboardLogger")
     def test_log_hyperparams(self, mock_tb_logger, mock_wandb_logger, temp_dir):
         """Test logging hyperparameters to all enabled loggers."""
         cfg = {


### PR DESCRIPTION
## Add core metrics tab in WandB for key training signals

# What does this PR do?

Adds a `_CORE_METRIC_KEYS` frozenset in `nemo_rl/utils/logger.py` listing the key training signals: `total_reward/mean`, `mean_total_reward`, `mean_generation_length`, `gen_tokens_per_sample/mean`, `mean_gen_tokens_per_sample`, `approx_entropy`, `kl_penalty`, and `gen_kl_error`.

Extends `Logger.log_metrics` to re-log any of these keys under a `core/<prefix>` namespace (e.g. `core/train`, `core/validation`) after each normal dispatch, so they appear in a dedicated WandB "core" section without being removed from their original `train/*` / `validation/*` location. No changes to any algorithm code — the interception is at the logger level and applies to all callers (`grpo.py`, `grpo_sync.py`, etc.).

### Notes

- `kl_penalty` is always emitted by the loss function (`0` when `reference_policy_kl_penalty` is disabled), so `core/<prefix>/kl_penalty` renders as a flat-zero series on runs without a KL penalty rather than being absent.
- `mean_total_reward` / `mean_gen_tokens_per_sample` cover the classic (non-NeMo-Gym) multi-turn and single-turn rollout paths; `total_reward/mean` / `gen_tokens_per_sample/mean` cover the NeMo-Gym path. Both spellings are tracked so the core tab isn't empty on either path.

### Fixes since the initial version

- The `core/` re-log previously ignored the caller's `prefix` and always wrote to a flat `"core"` key, so train and validation values for the same metric could silently collide into one WandB series. Fixed by namespacing as `core/<prefix>` (e.g. `core/train`, `core/validation`) so they stay distinct.
- `_CORE_METRIC_KEYS` was missing the classic multi-turn/single-turn path's key names (`mean_total_reward`, `mean_gen_tokens_per_sample`) — added, so standard (non-NeMo-Gym) GRPO runs also populate the core tab's reward/length signal.

### Tests

Added to `tests/unit/utils/test_logger.py::TestLogger`:

- `test_log_metrics_relogs_core_metrics` — a metrics dict containing a core key (`kl_penalty`, `total_reward/mean`) triggers a second `log_metrics` dispatch to every backend under `core/<prefix>`, alongside the original prefixed call.
- `test_log_metrics_core_namespace_separates_train_and_validation` — logging `total_reward/mean` once with `prefix="train"` and once with `prefix="validation"` lands under distinct `core/train` and `core/validation` series rather than colliding into one.
- `test_log_metrics_without_core_metrics_logs_once` — a metrics dict with no core keys triggers exactly one dispatch (no accidental extra `core/` call), which is also a regression guard for the pre-existing `assert_called_once_with`-based tests in this file.

All 85 tests in `tests/unit/utils/test_logger.py` pass locally (`uv run pytest unit/utils/test_logger.py`), including the 3 new ones, with no regressions to the existing suite.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
