### PR TITLE
ci: fix Ruff import hook arguments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     - id: ruff
       args: ["--fix"]
     - id: ruff
-      args: ["check", "--select", "I", "--fix"]
+      args: ["--select", "I", "--fix"]
     - id: ruff-format
 
   - repo: https://github.com/ComPWA/mirrors-taplo


### PR DESCRIPTION
## Summary

- remove the redundant `check` positional argument from the import-only Ruff pre-commit hook
- preserve the hook's `--select I --fix` import-sorting behavior

## Root cause

The `ruff` hook already uses `ruff check` as its entry point. Passing `check` again makes Ruff interpret it as a path and emit:

```text
warning: Failed to lint check: No such file or directory (os error 2)
```

This was visible in the lint job for #3494. The warning is repository-wide and independent of that PR's three auto-format edits.

## Validation

- `uvx --from pre-commit==3.8.0 pre-commit validate-config`
- `uvx --from pre-commit==3.8.0 pre-commit run ruff --all-files`
- `uvx --from pre-commit==3.8.0 pre-commit run ruff-format --all-files`
- `git diff --check`

All passed. The host's Git 2.25 cannot run the latest pre-commit wrapper because that release invokes `git ls-files --deduplicate`; the affected hooks were therefore validated with a pre-commit version compatible with the host Git.
