### PR TITLE
feat(nemo-gym): expose resolved config entries

### DIFF
--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -62,6 +62,15 @@ from nemo_rl.utils.venvs import make_actor_runtime_env
 NEMO_GYM_ACTOR_FQN = "nemo_rl.environments.nemo_gym.NemoGym"
 NEMO_GYM_GRACEFUL_SHUTDOWN_TIMEOUT_S = 120
 
+# The three server-type keys Gym nests under a top-level config entry. Gym's
+# constant is private (nemo_gym.discovery._SERVER_GROUP_KEYS), and the literal
+# list also appears in global_config.py, config_types.py, and cli/env.py.
+GYM_SERVER_TYPE_KEYS = (
+    "responses_api_agents",
+    "responses_api_models",
+    "resources_servers",
+)
+
 # Kept local so the Gym actor does not depend on model-config dtype resolution.
 # Must cover every name resolve_routed_experts_dtype can produce.
 _ROUTED_EXPERTS_DTYPES = {
@@ -589,6 +598,51 @@ Depending on your data shape, you may want to change these values."""
                 f"HTTP {response.status} {await response.text()}"
             )
         return await response.json()
+
+    def list_entries(self) -> Dict[str, List[str]]:
+        """Report which config entries this actor actually spawned.
+
+        Returns ``{entry_name: [server_type_keys]}`` read from Gym's *resolved*
+        config, so entries that arrived via ``config_paths`` are included. The
+        config NeMo RL passed in is not a substitute: it still holds
+        ``config_paths`` as file paths and none of the entries they expand
+        into, so reading it would miss every agent and judge loaded from a
+        path.
+
+        Entries whose server config has no ``entrypoint`` are omitted because
+        Gym does not start a process for them.
+
+        Callers compare these names across actors to build the agent->shard map
+        and to catch an entry duplicated across shards. Names are all that is
+        interpreted; what an entry *means* is Gym's business.
+        """
+        if self.rh is None:
+            raise RuntimeError(
+                "list_entries() needs a running Gym stack; call _spinup() first."
+            )
+
+        from nemo_gym.global_config import get_global_config_dict
+        from omegaconf import DictConfig
+
+        resolved = get_global_config_dict()
+        entries: Dict[str, List[str]] = {}
+        for name, entry in resolved.items():
+            if not isinstance(entry, (dict, DictConfig)):
+                continue
+            # Fixed key order so the map is stable across actors and runs.
+            types = []
+            for key in GYM_SERVER_TYPE_KEYS:
+                server_group = entry.get(key)
+                if not isinstance(server_group, (dict, DictConfig)):
+                    continue
+                if any(
+                    isinstance(server, (dict, DictConfig)) and "entrypoint" in server
+                    for server in server_group.values()
+                ):
+                    types.append(key)
+            if types:
+                entries[str(name)] = types
+        return entries
 
     async def run_rollouts(
         self,

--- a/tests/unit/environments/test_nemo_gym_utils.py
+++ b/tests/unit/environments/test_nemo_gym_utils.py
@@ -18,9 +18,13 @@ These run in the default L0 suite. Keep this module free of heavy imports
 """
 
 import copy
+import sys
+import types
+from contextlib import contextmanager
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+from omegaconf import DictConfig
 
 from nemo_rl.environments import nemo_gym as nemo_gym_mod
 from nemo_rl.environments.nemo_gym import (
@@ -403,3 +407,90 @@ def test_nemo_gym_shutdown_before_spinup_is_a_noop():
     actor.__init__({})
 
     actor.shutdown()  # must not raise
+
+
+@contextmanager
+def _stub_gym_resolved_config(resolved):
+    """Stand in for nemo_gym.global_config, which lives in the actor's venv."""
+    package = types.ModuleType("nemo_gym")
+    module = types.ModuleType("nemo_gym.global_config")
+    module.get_global_config_dict = lambda: resolved
+    with patch.dict(
+        sys.modules, {"nemo_gym": package, "nemo_gym.global_config": module}
+    ):
+        yield
+
+
+def _spun_up_actor():
+    cls = nemo_gym_mod.NemoGym.__ray_metadata__.modified_class
+    actor = cls.__new__(cls)
+    actor.__init__({})
+    actor.rh = MagicMock()
+    return actor
+
+
+def test_list_entries_reports_entry_names_and_server_types():
+    resolved = DictConfig(
+        {
+            "math_agent": {
+                "responses_api_agents": {"simple_agent": {"entrypoint": "app.py"}}
+            },
+            "math_env": {"resources_servers": {"math": {"entrypoint": "app.py"}}},
+            # An entry can carry more than one server type.
+            "judge": {
+                "responses_api_models": {"local_vllm_model": {"entrypoint": "app.py"}},
+                "resources_servers": {"judge_tools": {"entrypoint": "app.py"}},
+            },
+            # Plain Gym settings are not entries.
+            "port_range_low": 5000,
+            "default_host": "10.0.0.1",
+            "config_paths": ["a.yaml"],
+        }
+    )
+
+    with _stub_gym_resolved_config(resolved):
+        entries = _spun_up_actor().list_entries()
+
+    assert entries == {
+        "math_agent": ["responses_api_agents"],
+        "math_env": ["resources_servers"],
+        "judge": ["responses_api_models", "resources_servers"],
+    }
+
+
+def test_list_entries_skips_dicts_that_hold_no_server_type():
+    """A dict-shaped setting is not an entry unless it nests a server type."""
+    resolved = DictConfig(
+        {
+            "real_entry": {"resources_servers": {"env": {"entrypoint": "app.py"}}},
+            "some_setting": {"nested": "value"},
+        }
+    )
+
+    with _stub_gym_resolved_config(resolved):
+        entries = _spun_up_actor().list_entries()
+
+    assert entries == {"real_entry": ["resources_servers"]}
+
+
+def test_list_entries_skips_an_entry_that_starts_no_server():
+    resolved = DictConfig(
+        {
+            "math_env": {"resources_servers": {"math": {"entrypoint": "app.py"}}},
+            "code_gen": {"resources_servers": {"code": {"host": "10.0.0.1"}}},
+        }
+    )
+
+    with _stub_gym_resolved_config(resolved):
+        entries = _spun_up_actor().list_entries()
+
+    assert entries == {"math_env": ["resources_servers"]}
+
+
+def test_list_entries_before_spinup_raises():
+    cls = nemo_gym_mod.NemoGym.__ray_metadata__.modified_class
+    actor = cls.__new__(cls)
+    actor.__init__({})
+
+    with pytest.raises(RuntimeError, match="call _spinup"):
+        actor.list_entries()


### PR DESCRIPTION
## Summary

Adds `NemoGym.list_entries()` so NeMo RL can inspect the runnable entries that Gym resolved during startup.

The input configuration contains `config_paths`, but those paths do not directly describe the agents, models, and resource servers that Gym loaded. Reading the resolved configuration gives shard discovery an accurate inventory without reproducing Gym's configuration merge in NeMo RL.

`list_entries()` returns each resolved entry name and the server-type groups whose nested configuration has an `entrypoint`. Gym does not start a process for a leaf without an `entrypoint`, so those names are excluded from the routing inventory. Calling `list_entries()` before `_spinup()` fails because the actor does not yet have a resolved Gym configuration.

## Stack

This PR depends on #3368. The shard configuration schema follows in #3369.