### PR TITLE
docs: copy nemotron model guides into guides/ with deprecation notice

### DIFF
--- a/docs/guides/nemotron-3-nano-omni.md
+++ b/docs/guides/nemotron-3-nano-omni.md
@@ -1,0 +1,163 @@
+# Nemotron 3 Nano Omni
+
+> **Note:** This document has moved and will be deprecated here. See the new location: https://github.com/NVIDIA-NeMo/RL/blob/main/docs/guides/models/nemotron/nemotron-3-nano-omni.md
+
+This guide explains how to post-train the Nemotron 3 Nano Omni vision-language model with GRPO using NeMo RL. Both the AutoModel and Megatron backends are supported for image-and-text training.
+
+## Multimodal payload deduplication
+
+The maintained Nemotron recipes enable `grpo.deduplicate_multimodal_data` to
+share immutable model-ready media segments across logical GRPO generations and
+re-intern them after batching, replay, and sharding. The representation supports
+image, video, and audio payload keys, although the maintained recipes currently
+qualify image inputs only. Deduplication currently requires the vLLM generation
+backend and `data_plane.enabled=false`.
+
+`grpo.debug_payload_metrics` emits logical, physical, and protocol-5 serialized
+payload sizes for the exact Ray boundaries used by generation, replay, logprobs,
+and training. It is disabled by default because measuring serialized size adds
+work and is intended for qualification and debugging rather than production.
+
+## AutoModel backend
+
+It covers two recipes:
+
+- **CLEVR-CoGenT** — runs on a single 8-GPU node (interactive container).
+- **MMPR-Tiny** — runs on 4 nodes via Slurm.
+
+Both share the same checkpoint, model code, and reward pipeline; they differ only in the dataset, reward functions, and node count.
+
+### Recipe 1 — CLEVR-CoGenT (single-node)
+
+The CLEVR-CoGenT recipe uses [`examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-clevr-1n8g-automodel-ep8.v1.yaml`](../../../../examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-clevr-1n8g-automodel-ep8.v1.yaml). It expects 8 GPUs on a single node, EP=8 across the experts, and TP=8 in vLLM.
+
+Key knobs in the config:
+
+| Field | Value |
+|---|---|
+| `policy.model_name` | path to the Nemotron-Omni HF checkpoint |
+| `policy.dtensor_cfg.expert_parallel_size` | 8 |
+| `policy.generation.vllm_cfg.tensor_parallel_size` | 8 |
+| `policy.max_total_sequence_length` | 8192 |
+| `data.train.dataset_name` | `clevr-cogent` (split `train`) |
+| `data.validation.dataset_name` | `clevr-cogent` (split `valA`) |
+| `env.clevr-cogent.reward_functions` | `format` (0.2) + `exact_alnum` (0.8) |
+
+CLEVR is loaded automatically from HuggingFace by the `clevr-cogent` response dataset on first run; no manual prep is required.
+
+### Launch (interactive container)
+
+From inside the container on an 8-GPU node:
+
+```bash
+export NRL_MAMBA_PREFILL_DECODE_SYNC="${NRL_MAMBA_PREFILL_DECODE_SYNC:-1}"
+
+uv run examples/run_vlm_grpo.py --config examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-clevr-1n8g-automodel-ep8.v1.yaml \
+    cluster.gpus_per_node=8 \
+    cluster.num_nodes=1
+```
+
+To override the model path or any other YAML field, append Hydra-style overrides:
+
+```bash
+uv run examples/run_vlm_grpo.py --config examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-clevr-1n8g-automodel-ep8.v1.yaml \
+    policy.model_name=/path/to/your/checkpoint \
+    cluster.gpus_per_node=8 cluster.num_nodes=1
+```
+
+### Recipe 2 — MMPR-Tiny (4-node Slurm)
+
+The MMPR-Tiny recipe uses [`examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-mmpr-4n8g-automodel-ep8.v1.yaml`](../../../../examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-mmpr-4n8g-automodel-ep8.v1.yaml). Differences vs. the CLEVR recipe:
+
+| Field | Value |
+|---|---|
+| `data.train.dataset_name` | `mmpr-tiny` |
+| `data.train.download_dir` | local cache dir for MMPR-Tiny (loader auto-downloads from HF) |
+| `data.train.split_validation_size` | `0.008` (val split carved out of train) |
+| `policy.max_total_sequence_length` | 8192 |
+| `env.mmpr-tiny.reward_functions` | `geo3k` (1.0, `format_score: 0.1`) |
+
+
+### Launch (4-node Slurm)
+
+Submit with `ray.sub`. From the repo root on a Slurm login node:
+
+```bash
+# --- Cluster config ---
+export SBATCH_ACCOUNT=your_slurm_account
+export SBATCH_PARTITION=batch
+export SBATCH_TIME=4:00:00
+export CONTAINER=/path/to/containers/nemo-rl-nano-v3-vl-<tag>.sqsh
+export MOUNTS=/lustre:/lustre
+export HF_HOME=/path/to/cache/huggingface
+export TMPDIR=/tmp/nrl-${USER}
+export NCCL_DEBUG=WARN
+export NRL_IGNORE_VERSION_MISMATCH=1
+
+# --- Run config ---
+NUM_NODES=4
+GPUS_PER_NODE=8
+JOB_NAME=grpo-nemotron-omni-mmpr
+RESULTS_DIR=$PWD/results/${JOB_NAME}
+CONFIG_PATH=examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-mmpr-4n8g-automodel-ep8.v1.yaml
+
+# --- Build the training command (run inside the container on every node) ---
+export COMMAND="\
+export PYTHONPATH=\${PYTHONPATH:-}:/path/to/automodel-omni && \
+export CUDA_LAUNCH_BLOCKING=0 && \
+export TORCH_USE_CUDA_DSA=0 && \
+export NRL_MAMBA_PREFILL_DECODE_SYNC=1 && \
+mkdir -p ${HF_HOME} ${TMPDIR} ${RESULTS_DIR} && \
+uv run examples/run_vlm_grpo.py --config ${CONFIG_PATH} \
+    cluster.num_nodes=${NUM_NODES} \
+    cluster.gpus_per_node=${GPUS_PER_NODE} \
+    checkpointing.checkpoint_dir='${RESULTS_DIR}' \
+    logger.wandb.name='${JOB_NAME}'"
+
+# --- Submit ---
+sbatch \
+    --nodes=${NUM_NODES} \
+    --account=${SBATCH_ACCOUNT} \
+    --job-name=nemo-rl-${JOB_NAME} \
+    --partition=${SBATCH_PARTITION} \
+    --time=${SBATCH_TIME} \
+    --dependency=singleton \
+    --gres=gpu:${GPUS_PER_NODE} \
+    ray.sub
+```
+
+To run on a different node count, change `NUM_NODES` and the `--nodes` flag.
+
+## Megatron backend
+
+The Megatron backend uses a dedicated `NemotronOmniModel` supplied by Megatron Bridge. The Hugging Face processor expands each image placeholder into the complete media-token sequence before the batch reaches the model. NeMo RL passes that expanded sequence and the image tensors to the model; `NemotronOmniModel` replaces the media-token positions with RADIO encoder outputs and then performs sequence packing and context-parallel sharding.
+
+This is the same model-owned packing boundary used by maintained Megatron VLM integrations. It differs from the historical Nemotron Omni `LLaVAModel` path, which collapsed the expanded media-token sequence before packing and expanded it again inside the model. The dedicated model removes that extra representation change and allows the integration to use Megatron Bridge and Megatron-LM from their maintained main branches.
+
+The current Megatron recipes cover Nano image-and-text GRPO. Super, video, and audio training are follow-up work and are not enabled by these recipes.
+
+### Checkpoint compatibility
+
+Use the `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16` Hugging Face checkpoint or a checkpoint converted with the dedicated `NemotronOmniModel` integration. Legacy Megatron checkpoints whose parameter names use an `llava_model` prefix are not compatible with this model definition. Reconvert those checkpoints from the original Hugging Face checkpoint instead of loading them directly.
+
+### Maintained recipes
+
+| Workload | Recipe | Topology |
+|---|---|---|
+| CLEVR-CoGenT | [`vlm_grpo-nemotron-omni-30ba3b-clevr-1n8g-megatron-tp8ep8.v1.yaml`](../../../../examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-clevr-1n8g-megatron-tp8ep8.v1.yaml) | 1 node, 8 GPUs, TP=8, EP=8 |
+| MMPR-Tiny | [`vlm_grpo-nemotron-omni-30ba3b-mmpr-4n8g-megatron-tp8ep16.v1.yaml`](../../../../examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-mmpr-4n8g-megatron-tp8ep16.v1.yaml) | 4 nodes, 8 GPUs per node, TP=8, EP=16, vLLM TP=2 |
+
+Launch the single-node Megatron recipe from inside the container on an 8-GPU node:
+
+```bash
+uv run examples/run_vlm_grpo.py \
+    --config examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-clevr-1n8g-megatron-tp8ep8.v1.yaml
+```
+
+For a four-node Slurm run, use the `ray.sub` example above with the following configuration path and omit the AutoModel-specific `PYTHONPATH` addition:
+
+```bash
+CONFIG_PATH=examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-mmpr-4n8g-megatron-tp8ep16.v1.yaml
+```
+
+The recipes keep sequence packing enabled because the model owns the packing step after multimodal embedding insertion. They also request raw generation log probabilities so that vLLM and the Megatron policy compare the same pre-processor probability values when generation constraints such as `bad_words` are active. The generation context cap prevents the processor-expanded image prompt plus generated response from exceeding the configured 8192-token context length.

--- a/docs/guides/nemotron-3-nano-omni.md
+++ b/docs/guides/nemotron-3-nano-omni.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # Nemotron 3 Nano Omni
 
 > **Note:** This document has moved and will be deprecated here. See the new location: https://github.com/NVIDIA-NeMo/RL/blob/main/docs/guides/models/nemotron/nemotron-3-nano-omni.md
@@ -29,7 +33,7 @@ Both share the same checkpoint, model code, and reward pipeline; they differ onl
 
 ### Recipe 1 — CLEVR-CoGenT (single-node)
 
-The CLEVR-CoGenT recipe uses [`examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-clevr-1n8g-automodel-ep8.v1.yaml`](../../../../examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-clevr-1n8g-automodel-ep8.v1.yaml). It expects 8 GPUs on a single node, EP=8 across the experts, and TP=8 in vLLM.
+The CLEVR-CoGenT recipe uses [`examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-clevr-1n8g-automodel-ep8.v1.yaml`](../../examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-clevr-1n8g-automodel-ep8.v1.yaml). It expects 8 GPUs on a single node, EP=8 across the experts, and TP=8 in vLLM.
 
 Key knobs in the config:
 
@@ -67,7 +71,7 @@ uv run examples/run_vlm_grpo.py --config examples/configs/recipes/vlm/vlm_grpo-n
 
 ### Recipe 2 — MMPR-Tiny (4-node Slurm)
 
-The MMPR-Tiny recipe uses [`examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-mmpr-4n8g-automodel-ep8.v1.yaml`](../../../../examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-mmpr-4n8g-automodel-ep8.v1.yaml). Differences vs. the CLEVR recipe:
+The MMPR-Tiny recipe uses [`examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-mmpr-4n8g-automodel-ep8.v1.yaml`](../../examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-mmpr-4n8g-automodel-ep8.v1.yaml). Differences vs. the CLEVR recipe:
 
 | Field | Value |
 |---|---|
@@ -144,8 +148,8 @@ Use the `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16` Hugging Face checkp
 
 | Workload | Recipe | Topology |
 |---|---|---|
-| CLEVR-CoGenT | [`vlm_grpo-nemotron-omni-30ba3b-clevr-1n8g-megatron-tp8ep8.v1.yaml`](../../../../examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-clevr-1n8g-megatron-tp8ep8.v1.yaml) | 1 node, 8 GPUs, TP=8, EP=8 |
-| MMPR-Tiny | [`vlm_grpo-nemotron-omni-30ba3b-mmpr-4n8g-megatron-tp8ep16.v1.yaml`](../../../../examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-mmpr-4n8g-megatron-tp8ep16.v1.yaml) | 4 nodes, 8 GPUs per node, TP=8, EP=16, vLLM TP=2 |
+| CLEVR-CoGenT | [`vlm_grpo-nemotron-omni-30ba3b-clevr-1n8g-megatron-tp8ep8.v1.yaml`](../../examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-clevr-1n8g-megatron-tp8ep8.v1.yaml) | 1 node, 8 GPUs, TP=8, EP=8 |
+| MMPR-Tiny | [`vlm_grpo-nemotron-omni-30ba3b-mmpr-4n8g-megatron-tp8ep16.v1.yaml`](../../examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-mmpr-4n8g-megatron-tp8ep16.v1.yaml) | 4 nodes, 8 GPUs per node, TP=8, EP=16, vLLM TP=2 |
 
 Launch the single-node Megatron recipe from inside the container on an 8-GPU node:
 

--- a/docs/guides/nemotron-3-nano.md
+++ b/docs/guides/nemotron-3-nano.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # Nemotron 3 Nano
 
 > **Note:** This document has moved and will be deprecated here. See the new location: https://github.com/NVIDIA-NeMo/RL/blob/main/docs/guides/models/nemotron/nemotron-3-nano.md

--- a/docs/guides/nemotron-3-nano.md
+++ b/docs/guides/nemotron-3-nano.md
@@ -1,0 +1,71 @@
+# Nemotron 3 Nano
+
+> **Note:** This document has moved and will be deprecated here. See the new location: https://github.com/NVIDIA-NeMo/RL/blob/main/docs/guides/models/nemotron/nemotron-3-nano.md
+
+This guide explains how to post-train the [Nemotron 3 Nano model](https://research.nvidia.com/labs/nemotron/files/NVIDIA-Nemotron-3-Nano-Technical-Report.pdf) using NeMo RL.
+
+**Note:** vLLM versions prior to 0.17.0 have a bug that causes logprob values to diverge between vLLM and Megatron for certain sequences, which can lead to training instability. To work around this, the recipe below sets `seq_logprob_error_threshold: 2` to mask out sequences where the logprob mismatch exceeds the threshold. This bug is fixed in vLLM 0.17.0 and will be incorporated in the Nemotron 3 Ultra release.
+
+## Download and prepare the data
+
+```bash
+# Download RL data blend
+uvx --from huggingface-hub hf download nvidia/Nemotron-3-Nano-RL-Training-Blend --repo-type dataset --local-dir=data
+
+# Fill in placeholders in dataset
+chmod +x data/create_nanov3_jsonl.py
+./data/create_nanov3_jsonl.py --input data/train.jsonl --output data/train-full.jsonl
+
+# Use the last 1000 rows for validation
+head -n -1000 data/train-full.jsonl > data/train-split.jsonl
+tail -n 1000 data/train-full.jsonl > data/val-split.jsonl
+```
+
+## Prepare the code
+```bash
+# Checkout NeMo RL
+git clone https://github.com/NVIDIA-NeMo/RL.git
+cd RL
+
+# Initialize the submodules
+git submodule update --init --recursive
+```
+
+## Create a launch script
+
+Create a file named `launch.sh` with the following contents. Be sure to fill in the `DATA_DIR`, `MODEL_CHECKPOINT`, `WANDB_API_KEY`, `SLURM_ACCOUNT`, `SLURM_PARTITION`, `MOUNTS`. Note that the default recipe (`examples/nemo_gym/grpo_nanov3.yaml`) uses 32 nodes.
+
+```bash
+CODE_DIR=$PWD
+SLURM_JOB_NAME=nano-v3-rl-training
+
+# Fill these in
+DATA_DIR=...
+MODEL_CHECKPOINT=...
+WANDB_API_KEY=...
+SLURM_ACCOUNT=...
+SLURM_PARTITION=...
+MOUNTS=... # SRC:DST[,SRC:DST...] e.g., MOUNTS="/lustre:/lustre,/data:/data"
+
+CONTAINER="nvcr.io/nvidia/nemo-rl:v0.4.0.nemotron_3_nano"
+COMMAND="uv run examples/nemo_gym/run_grpo_nemo_gym.py --config examples/nemo_gym/grpo_nanov3.yaml data.train_jsonl_fpath=$DATA_DIR/train-split.jsonl data.validation_jsonl_fpath=$DATA_DIR/val-split.jsonl policy.model_name=$MODEL_CHECKPOINT logger.wandb_enabled=True"
+
+COMMAND="${COMMAND}" \
+CONTAINER="${CONTAINER}" \
+MOUNTS="${MOUNTS}" \
+WANDB_API_KEY=${WANDB_API_KEY} \
+sbatch \
+    --nodes=32 \
+    --account="${SLURM_ACCOUNT}" \
+    --job-name="${SLURM_JOB_NAME}" \
+    --partition="${SLURM_PARTITION}" \
+    --time=4:0:0 \
+    --gres=gpu:8 \
+    ray.sub
+```
+
+
+## Launch training
+```bash
+bash launch.sh
+```

--- a/docs/guides/nemotron-3-super.md
+++ b/docs/guides/nemotron-3-super.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # Nemotron 3 Super
 
 > **Note:** This document has moved and will be deprecated here. See the new location: https://github.com/NVIDIA-NeMo/RL/blob/main/docs/guides/models/nemotron/nemotron-3-super.md

--- a/docs/guides/nemotron-3-super.md
+++ b/docs/guides/nemotron-3-super.md
@@ -1,0 +1,239 @@
+# Nemotron 3 Super
+
+> **Note:** This document has moved and will be deprecated here. See the new location: https://github.com/NVIDIA-NeMo/RL/blob/main/docs/guides/models/nemotron/nemotron-3-super.md
+
+**Technical Report:** [NVIDIA Nemotron-3-Super Technical Report](https://research.nvidia.com/labs/nemotron/files/NVIDIA-Nemotron-3-Super-Technical-Report.pdf)
+
+This guide explains how to post-train the Nemotron 3 Super model using NeMo RL.
+
+## Container
+
+The released NeMo RL base container is:
+
+```
+nvcr.io/nvidia/nemo-rl:v0.7.0
+```
+
+To reduce launch-time setup, prebake the NeMo-Gym virtual environments into a derived image:
+
+```text
+docker buildx build \
+  -t your-registry/nemo-rl:v0.7.0.prefetched_venvs \
+  --push \
+  -f- . <<'EOF'
+FROM nvcr.io/nvidia/nemo-rl:v0.7.0
+
+ARG NEMO_GYM_CUDA=cu130
+ARG NEMO_GYM_VLLM_VERSION=0.20.0
+ARG WHEEL_ARCH=x86_64
+RUN <<'RUNEOF' bash -exu -o pipefail
+cd /opt/nemo-rl
+GYM_VLLM_OVERRIDE=/opt/nemo-rl/.gym-vllm-override.txt
+printf 'vllm @ https://github.com/vllm-project/vllm/releases/download/v%s/vllm-%s+%s-cp38-abi3-manylinux_2_35_%s.whl\n' \
+    "${NEMO_GYM_VLLM_VERSION}" "${NEMO_GYM_VLLM_VERSION}" "${NEMO_GYM_CUDA}" "${WHEEL_ARCH}" > "${GYM_VLLM_OVERRIDE}"
+
+UV_TORCH_BACKEND="${NEMO_GYM_CUDA}" \
+UV_OVERRIDE="${GYM_VLLM_OVERRIDE}" \
+UV_LINK_MODE=symlink uv run python examples/nemo_gym/prefetch_venvs.py \
+    examples/nemo_gym/prefetch_super_all_envs.yaml
+rm -f "${GYM_VLLM_OVERRIDE}"
+RUNEOF
+EOF
+```
+
+Push the derived image to a registry visible to the training cluster and use it as `CONTAINER` in the launch commands below.
+
+## Download and prepare the data
+
+```bash
+# Download RL data blends (rlvr1, rlvr2, rlvr3, swe1, swe2, rlhf)
+uvx --from huggingface-hub hf download nvidia/Nemotron-RL-Super-Training-Blends --repo-type dataset --local-dir=data_with_placeholders
+
+
+# Fill in placeholders in data blends
+chmod +x data_with_placeholders/fill_placeholders.py
+./data_with_placeholders/fill_placeholders.py --input-dir data_with_placeholders --output-dir data_filled
+
+
+# Create train/val splits for each data blend (last 100 rows held out for validation)
+for f in data_filled/*.jsonl; do
+  name=$(basename "$f" .jsonl)
+  mkdir -p "data/$name"
+  head -n -100 "$f" > "data/$name/train-split.jsonl"
+  tail -n 100 "$f" > "data/$name/val-split.jsonl"
+done
+```
+
+## Prepare the code
+```bash
+git clone --recursive https://github.com/NVIDIA-NeMo/RL.git
+cd RL
+```
+
+## Training the model
+
+RL training for Nemotron 3 Super consists of 3 main stages:
+
+1. Reinforcement Learning with Verifiable Rewards (RLVR)
+2. SWE RL
+3. RLHF with length penalty to reduce verbosity
+
+The RLVR stage consists of 3 sub-stages with different data blends and the SWE RL stage consists of 2 sub-stages, for 6 total stages.
+
+### Build sandbox container
+
+Several [Gym](https://github.com/NVIDIA-NeMo/Gym) environments used during training rely on a sandbox container for code execution, including [NeMo-Skills tools](https://github.com/NVIDIA-NeMo/Gym/tree/main/resources_servers/ns_tools) (stateful Python execution with math verification) and [Lean4 formal proof verification](https://github.com/NVIDIA-NeMo/Gym/tree/main/resources_servers/math_formal_lean). To build the sandbox container, use the [NeMo-Skills Dockerfile](https://github.com/NVIDIA-NeMo/Skills/blob/main/dockerfiles/Dockerfile.sandbox):
+
+```bash
+git clone https://github.com/NVIDIA-NeMo/Skills.git
+cd Skills
+git checkout a5da59797890284af4df1c2a9c10990b33623a9d
+docker build -t nemo-skills-sandbox:latest -f dockerfiles/Dockerfile.sandbox .
+```
+
+For SLURM clusters using [enroot](https://github.com/NVIDIA/enroot), convert the image to a `.sqsh` file:
+
+```bash
+enroot import -o nemo-skills-sandbox.sqsh dockerd://nemo-skills-sandbox:latest
+```
+
+### Launch script
+
+Each stage is launched with `super_launch.sh`. Set the following variables before running:
+
+* `$DATA_DIR`: Path to the **final** `data` directory produced in [Download and prepare the data](#download-and-prepare-the-data).
+* `$SANDBOX_CONTAINER`: The sandbox container image from [Build sandbox container](#build-sandbox-container) (`.sqsh` path or registry URI).
+* `$PERSISTENT_CACHE`: Path to a directory used to store caches for vLLM and FlashInfer.
+* `$EXTRA_MOUNTS`: Comma-separated `host:container` mount pairs for shared filesystems that your data, models, and checkpoints reside on (e.g. `EXTRA_MOUNTS=/scratch:/scratch,/lustre:/lustre`). The launch script only mounts the code snapshot directory by default.
+* `$SKIP_CODE_SNAPSHOT`: Optional. Set to `true` to run from the current checkout instead of creating or refreshing a code snapshot.
+* `$SIF_DIR`: *(Stage 2.2 only)* Path to the directory containing Apptainer `.sif` images for the SWE-bench environments. These are converted Docker images from R2E-Gym, SWE-Gym, and SWE-Bench Verified. See [Stage 2.2](#stage-22---swe-2-64-h100-gpu-nodes) for download instructions.
+* `$SLURM_PARTITION`
+* `$SLURM_ACCOUNT`
+
+`MODEL_PATH` is the input checkpoint for each stage. Stage 1.1 starts from the SFT checkpoint; every subsequent stage takes the output of the previous one.
+
+The launch examples below use the H100 prod configs. For stages with GPU judge servers, set `SBATCH_NUM_NODES` to the total node count so SLURM allocates both the NeMo-RL nodes and the extra NeMo-Gym nodes. Lower-DP H100 variants are available under `examples/nemo_gym/nemotron-3-super/small_scale/`.
+
+### Stage 1 - RLVR
+
+#### Stage 1.1 - RLVR 1 (183 H100 GPU nodes)
+```bash
+EXP_NAME=stage1.1-rlvr1 \
+CONFIG_PATH=examples/nemo_gym/nemotron-3-super/stage1_rlvr.yaml \
+MODEL_PATH=/path/to/sft_checkpoint \
+TRAIN_PATH=$DATA_DIR/rlvr1/train-split.jsonl \
+VAL_PATH=$DATA_DIR/rlvr1/val-split.jsonl \
+CONTAINER=your-registry/nemo-rl:v0.7.0.prefetched_venvs \
+SANDBOX_CONTAINER=$SANDBOX_CONTAINER \
+PERSISTENT_CACHE=$PERSISTENT_CACHE \
+EXTRA_MOUNTS=$EXTRA_MOUNTS \
+SLURM_PARTITION=$SLURM_PARTITION \
+SLURM_ACCOUNT=$SLURM_ACCOUNT \
+SBATCH_NUM_NODES=183 \
+bash super_launch.sh
+```
+
+#### Stage 1.2 - RLVR 2 (183 H100 GPU nodes)
+```bash
+EXP_NAME=stage1.2-rlvr2 \
+CONFIG_PATH=examples/nemo_gym/nemotron-3-super/stage1_rlvr.yaml \
+MODEL_PATH=/path/to/rlvr1_checkpoint \
+TRAIN_PATH=$DATA_DIR/rlvr2/train-split.jsonl \
+VAL_PATH=$DATA_DIR/rlvr2/val-split.jsonl \
+CONTAINER=your-registry/nemo-rl:v0.7.0.prefetched_venvs \
+SANDBOX_CONTAINER=$SANDBOX_CONTAINER \
+PERSISTENT_CACHE=$PERSISTENT_CACHE \
+EXTRA_MOUNTS=$EXTRA_MOUNTS \
+SLURM_PARTITION=$SLURM_PARTITION \
+SLURM_ACCOUNT=$SLURM_ACCOUNT \
+SBATCH_NUM_NODES=183 \
+bash super_launch.sh
+```
+
+#### Stage 1.3 - RLVR 3 (183 H100 GPU nodes)
+```bash
+EXP_NAME=stage1.3-rlvr3 \
+CONFIG_PATH=examples/nemo_gym/nemotron-3-super/stage1_rlvr.yaml \
+MODEL_PATH=/path/to/rlvr2_checkpoint \
+TRAIN_PATH=$DATA_DIR/rlvr3/train-split.jsonl \
+VAL_PATH=$DATA_DIR/rlvr3/val-split.jsonl \
+CONTAINER=your-registry/nemo-rl:v0.7.0.prefetched_venvs \
+SANDBOX_CONTAINER=$SANDBOX_CONTAINER \
+PERSISTENT_CACHE=$PERSISTENT_CACHE \
+EXTRA_MOUNTS=$EXTRA_MOUNTS \
+SLURM_PARTITION=$SLURM_PARTITION \
+SLURM_ACCOUNT=$SLURM_ACCOUNT \
+SBATCH_NUM_NODES=183 \
+bash super_launch.sh
+```
+
+### Stage 2 - SWE
+
+#### Stage 2.1 - SWE 1 (64 H100 GPU nodes)
+```bash
+EXP_NAME=stage2.1-swe1 \
+CONFIG_PATH=examples/nemo_gym/nemotron-3-super/stage2_swe1.yaml \
+MODEL_PATH=/path/to/rlvr3_checkpoint \
+TRAIN_PATH=$DATA_DIR/swe1/train-split.jsonl \
+VAL_PATH=$DATA_DIR/swe1/val-split.jsonl \
+CONTAINER=your-registry/nemo-rl:v0.7.0.prefetched_venvs \
+SANDBOX_CONTAINER=$SANDBOX_CONTAINER \
+PERSISTENT_CACHE=$PERSISTENT_CACHE \
+EXTRA_MOUNTS=$EXTRA_MOUNTS \
+SLURM_PARTITION=$SLURM_PARTITION \
+SLURM_ACCOUNT=$SLURM_ACCOUNT \
+bash super_launch.sh
+```
+
+#### Stage 2.2 - SWE 2 (64 H100 GPU nodes)
+
+This stage requires Apptainer images for the SWE Gym environments.
+
+First, install [Apptainer](https://apptainer.org/docs/admin/main/installation.html) if it is not already available:
+
+```bash
+# Ubuntu/Debian
+wget https://github.com/apptainer/apptainer/releases/download/v1.3.1/apptainer_1.3.1_amd64.deb
+sudo apt install -y ./apptainer_1.3.1_amd64.deb
+```
+
+Then run the download script, which pulls Docker images from the R2E-Gym, SWE-Gym, and SWE-Bench Verified datasets on HuggingFace and converts them to `.sif` files:
+
+```bash
+./examples/nemo_gym/download_swe_images.py --sif-dir /path/to/sif --concurrency 16
+```
+
+Then launch the training run with `SIF_DIR` pointing at the directory containing the downloaded `.sif` files:
+
+```bash
+EXP_NAME=stage2.2-swe2 \
+CONFIG_PATH=examples/nemo_gym/nemotron-3-super/stage2_swe2.yaml \
+MODEL_PATH=/path/to/swe1_checkpoint \
+TRAIN_PATH=$DATA_DIR/swe2/train-split.jsonl \
+VAL_PATH=$DATA_DIR/swe2/val-split.jsonl \
+CONTAINER=your-registry/nemo-rl:v0.7.0.prefetched_venvs \
+SANDBOX_CONTAINER=$SANDBOX_CONTAINER \
+PERSISTENT_CACHE=$PERSISTENT_CACHE \
+EXTRA_MOUNTS=$EXTRA_MOUNTS \
+SLURM_PARTITION=$SLURM_PARTITION \
+SLURM_ACCOUNT=$SLURM_ACCOUNT \
+SIF_DIR=/path/to/sif \
+bash super_launch.sh
+```
+
+### Stage 3 - RLHF (100 H100 GPU nodes)
+```bash
+EXP_NAME=stage3-rlhf \
+CONFIG_PATH=examples/nemo_gym/nemotron-3-super/stage3_rlhf.yaml \
+MODEL_PATH=/path/to/swe2_checkpoint \
+TRAIN_PATH=$DATA_DIR/rlhf/train-split.jsonl \
+VAL_PATH=$DATA_DIR/rlhf/val-split.jsonl \
+CONTAINER=your-registry/nemo-rl:v0.7.0.prefetched_venvs \
+SANDBOX_CONTAINER=$SANDBOX_CONTAINER \
+PERSISTENT_CACHE=$PERSISTENT_CACHE \
+EXTRA_MOUNTS=$EXTRA_MOUNTS \
+SLURM_PARTITION=$SLURM_PARTITION \
+SLURM_ACCOUNT=$SLURM_ACCOUNT \
+SBATCH_NUM_NODES=100 \
+bash super_launch.sh
+```

--- a/docs/guides/nemotron-3-ultra.md
+++ b/docs/guides/nemotron-3-ultra.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # Nemotron 3 Ultra
 
 > **Note:** This document has moved and will be deprecated here. See the new location: https://github.com/NVIDIA-NeMo/RL/blob/main/docs/guides/models/nemotron/nemotron-3-ultra.md

--- a/docs/guides/nemotron-3-ultra.md
+++ b/docs/guides/nemotron-3-ultra.md
@@ -1,0 +1,707 @@
+# Nemotron 3 Ultra
+
+> **Note:** This document has moved and will be deprecated here. See the new location: https://github.com/NVIDIA-NeMo/RL/blob/main/docs/guides/models/nemotron/nemotron-3-ultra.md
+
+**Technical Report:** [NVIDIA Nemotron 3 Ultra Technical Report](https://research.nvidia.com/labs/nemotron/files/NVIDIA-Nemotron-3-Ultra-Technical-Report.pdf)
+
+This guide explains how to post-train the Nemotron 3 Ultra model with NeMo RL on
+**GB200 NVL72** (ARM64 / aarch64) hardware.
+
+## Overview
+
+Nemotron 3 Ultra is post-trained with a multi-stage pipeline that mixes
+Reinforcement Learning with Verifiable Rewards (RLVR), RLHF, and Multi-Teacher
+On-Policy Distillation (MOPD) from a panel of specialised teacher models. The
+main stages are:
+
+1. **Student RLVR** — produces the student policy from the supervised
+   fine-tuning (SFT) checkpoint using GRPO with verifiable rewards.
+2. **Teacher training** — trains a panel of teachers (the Student RLVR policy
+   itself serves as the general teacher, alongside specialised teachers such as
+   reasoning, instruction-following/abstention, RLHF chat, and SWE).
+3. **MOPD** — on-policy distillation from the student into the teacher panel.
+
+Every stage shares the same launcher (`ultra_launch.sh`) and a per-stage YAML
+config under `examples/nemo_gym/nemotron-3-ultra/`.
+
+### Checkpoint flow
+
+The pipeline starts from an SFT checkpoint and produces a panel of teacher
+checkpoints that, together with the Student RLVR output, feed MOPD. The Student
+RLVR policy itself serves as the general teacher:
+
+```
+        ┌─────┐
+        │ SFT │
+        └──┬──┘
+           v
+    ┌──────────────┐
+    │ Student RLVR │
+    └──┬───────────┘
+       │
+       │   ┌────────────────────┐
+       ├──>│  General Teacher   │──┐
+       │   └────────────────────┘  │
+       │   ┌────────────────────┐  │
+       ├──>│  Reasoning Teacher │──┤
+       │   └────────────────────┘  │
+       │   ┌────────────────────┐  │
+       ├──>│    RLHF Teacher    │──┤
+       │   └────────────────────┘  │
+       │   ┌────────────────────┐  │
+       ├──>│  IFBench Teacher   │──┤
+       │   └────────────────────┘  │
+       │   ┌────────────────────┐  │
+       ├──>│    SWE Teacher     │──┤
+       │   └────────────────────┘  │
+       │                           │
+       v                           v
+   ┌─────────┐               ┌──────────┐
+   │ Student │──────────────>│   MOPD   │
+   └─────────┘               └──────────┘
+```
+
+## Container
+
+Ultra uses vLLM and requires an **aarch64 (arm64)** image for GB200 NVL72
+nodes. Prebake the NeMo Gym virtual environments used by the recipes to avoid
+building them when each training job starts. From the root of the repository,
+build the image with the Gym virtual environments for the Ultra recipes:
+
+```bash
+docker buildx build \
+  --platform linux/arm64 \
+  --progress=plain \
+  -f docker/Dockerfile \
+  --target release \
+  -t <your-registry>/nemo-rl:main-ultra-prefetched-venvs \
+  --push \
+  --build-context nemo-rl=. \
+  --build-arg MAX_JOBS=8 \
+  --build-arg SKIP_SGLANG_BUILD=1 \
+  --build-arg SKIP_TRTLLM_BUILD=1 \
+  --build-arg NEMO_GYM_PREFETCH_CONFIGS="examples/nemo_gym/prefetch_ultra_all_envs.yaml" \
+  .
+```
+
+Build args:
+- `NEMO_GYM_PREFETCH_CONFIGS` — space-separated union configs whose Gym virtual
+  environments are baked into the image.
+- `SKIP_SGLANG_BUILD=1` — Ultra runs on vLLM; skip the SGLang build.
+- `SKIP_TRTLLM_BUILD=1` — Ultra does not use TensorRT-LLM; skip its build.
+- `MAX_JOBS` — parallel build jobs; tune to your machine.
+- `--build-context nemo-rl=.` — build from your local checkout (otherwise the
+  Dockerfile pulls `NVIDIA-NeMo/RL.git#main`).
+
+To run on the cluster with Slurm, convert the image to a squashfs (`.sqsh`)
+with [enroot](https://github.com/NVIDIA/enroot):
+
+```bash
+enroot import -o nemo-rl-container.sqsh \
+  docker://<your-registry>/nemo-rl:main-ultra-prefetched-venvs
+```
+
+Pass the resulting image as `CONTAINER` in every launch command below (shown as
+`CONTAINER=/path/to/nemo-rl-container` — a `.sqsh` path, or a registry image URI
+if you're not using enroot). All Ultra stages run from this single image.
+
+## Download and prepare the data
+
+The training blends are published as
+[`nvidia/Nemotron-RL-Ultra-Training-Blends`](https://huggingface.co/datasets/nvidia/Nemotron-RL-Ultra-Training-Blends),
+one JSONL per stage: `rlvr1`, `rlvr2`, `ifbench`, `rlhf`, `reasoning`, `swe`, and
+`mopd`. Math rows that originate from `BytedTsinghua-SIA/DAPO-Math-17k` and
+`Skywork/Skywork-OR1-RL-Data` ship as placeholders; the bundled
+`fill_placeholders.py` restores them from the original datasets on Hugging Face.
+
+```bash
+export DATA_DIR=/path/to/ultra/data
+
+# 1. Download the blends + fill_placeholders.py
+huggingface-cli download nvidia/Nemotron-RL-Ultra-Training-Blends \
+  --repo-type dataset --local-dir ultra-blends
+
+# 2. Restore the DAPO / Skywork placeholders into $DATA_DIR
+cd ultra-blends
+./fill_placeholders.py --input-dir . --output-dir "$DATA_DIR"   # requires uv
+```
+
+This produces `$DATA_DIR/{rlvr1,rlvr2,ifbench,rlhf,reasoning,swe,mopd}.jsonl`. Hold
+out the last 100 rows of each blend as a validation split — the launch commands
+below consume `<name>.train.jsonl` as `TRAIN_PATH` and `<name>.val.jsonl` as
+`VAL_PATH`:
+
+```bash
+cd "$DATA_DIR"
+for name in rlvr1 rlvr2 ifbench rlhf reasoning swe mopd; do
+  head -n -100 "$name.jsonl" > "$name.train.jsonl"
+  tail -n 100   "$name.jsonl" > "$name.val.jsonl"
+done
+```
+
+By electing to use the external datasets you are responsible for confirming their
+licenses are fit for your intended use.
+
+The SWE stage additionally requires per-instance `.sif` container images built
+from SWE-Gym and SWE-rebench-V2 — see [SWE Teacher](#swe-teacher) for the build
+steps.
+
+For now, each stage takes a JSONL training file and a JSONL validation file
+(see [Launch script](#launch-script) below).
+
+## Prepare the code
+
+```bash
+git clone --recursive -b main https://github.com/NVIDIA-NeMo/RL.git
+cd RL
+```
+
+## Build the sandbox container
+
+Several [Gym](https://github.com/NVIDIA-NeMo/Gym) environments used during
+training (notably `ns_tools` for stateful Python execution with math
+verification, and `math_formal_lean` for Lean4 proof verification) rely on a
+sandbox container. Build it from the
+[NeMo-Skills Dockerfile](https://github.com/NVIDIA-NeMo/Skills/blob/main/dockerfiles/Dockerfile.sandbox):
+
+```bash
+git clone https://github.com/NVIDIA-NeMo/Skills.git
+cd Skills
+git checkout b620e79   # Skills commit pinned for the Ultra release
+docker build -t nemo-skills-sandbox:latest -f dockerfiles/Dockerfile.sandbox .
+```
+
+For SLURM clusters using [enroot](https://github.com/NVIDIA/enroot), convert
+to a `.sqsh`:
+
+```bash
+enroot import -o nemo-skills-sandbox.sqsh dockerd://nemo-skills-sandbox:latest
+```
+
+## Launch script
+
+Every stage is submitted with `examples/nemo_gym/nemotron-3-ultra/ultra_launch.sh`,
+run from the repo root. The launcher
+handles SLURM submission, code snapshotting, persistent cache management, and
+container mounts — stage-specific hyperparameters (batch size, advantage clip,
+MoE parallelism, learning rate) live in the per-stage YAML.
+
+Set the following before each `bash examples/nemo_gym/nemotron-3-ultra/ultra_launch.sh` invocation:
+
+| Variable | Purpose |
+|---|---|
+| `EXP_NAME` | Job name, W&B run name, and the suffix for output directories. Must be unique per run; same name across resubmissions resumes from the latest checkpoint. |
+| `CONFIG_PATH` | Path to the per-stage YAML config (e.g. `examples/nemo_gym/nemotron-3-ultra/student_rlvr1.yaml`). |
+| `MODEL_PATH` | Initial policy checkpoint (HuggingFace repo id or local path). Student RLVR starts from the Ultra SFT checkpoint; the teacher stages start from the Student RLVR checkpoint; MOPD starts from the student (the Student RLVR checkpoint). |
+| `TRAIN_PATH` | Training data JSONL. |
+| `VAL_PATH` | Validation data JSONL. |
+| `CONTAINER` | NeMo RL container image (`.sqsh` path or registry image URI). |
+| `SANDBOX_CONTAINER` | Sandbox image from [Build the sandbox container](#build-the-sandbox-container). |
+| `PERSISTENT_CACHE` | Directory on a shared filesystem (e.g. Lustre) where vLLM/Triton/Inductor compile caches are persisted across runs. |
+| `EXTRA_MOUNTS` | Comma-separated `host:container` mount pairs for any shared filesystems holding your data, model checkpoints, and `PERSISTENT_CACHE` (e.g. `EXTRA_MOUNTS=/lustre:/lustre,/scratch:/scratch`). |
+| `SLURM_PARTITION`, `SLURM_ACCOUNT` | Your SLURM cluster credentials. |
+| `GENRM_MODEL` | GenRM judge: HF repo id or local path. Default is [`nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-GenRM`](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-GenRM). Served in-cluster from the gym pool at TP=4 (DP varies by stage). Required unless `GENRM_BASE_URL` is set. |
+| `GENRM_BASE_URL` | _Optional._ URL of a separately-deployed GenRM service (e.g. `http://genrm-host:9213/v1`). If set, routes judging to that endpoint and ignores `GENRM_MODEL`. Useful when sharing a single GenRM deployment across many training jobs. |
+| `NL2BASH_JUDGE_MODEL` | NL2Bash / general-purpose judge: HF repo id or local path. Default judge is `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8`. |
+| `NL2BASH_BASE_URL` | _Optional._ URL of a separately-deployed NL2Bash judge service. Same semantics as `GENRM_BASE_URL`. |
+| `SAFETY_JUDGE_MODEL` | Content-safety judge: HF repo id or local path. Default is [`nvidia/Nemotron-Content-Safety-Reasoning-4B`](https://huggingface.co/nvidia/Nemotron-Content-Safety-Reasoning-4B). |
+
+> **Serving GenRM outside Gym.** For a separately deployed OpenAI-compatible
+> endpoint, set `GENRM_BASE_URL=http://<host>:<port>/v1`. Judging is then routed
+> to that endpoint instead of being served from the Gym pool, allowing one
+> deployment to back multiple training runs.
+>
+> To co-schedule dedicated model servers with training in one Slurm
+> heterogeneous allocation, set `EXTERNAL_JUDGES=1` — see
+> [External judge services](#external-judge-services) below.
+
+Optional knobs:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `WALLTIME` | `4:00:00` | SLURM `--time` |
+| `SLURM_QOS`, `SLURM_RESERVATION`, `EXCLUDE_NODES` | _empty_ | Optional SLURM flags |
+| `NUM_TRAIN_NODES`, `NUM_GEN_NODES`, `NUM_GYM_NODES` | `64`, `172`, `20` | GB200 4-GPU node split. Total must be a multiple of 16. |
+| `ENABLE_MTP_INFERENCE` | `0` | Set to `1` to enable MTP speculative decoding for vLLM |
+| `NRL_MAX_STEPS` | _from YAML_ | Override `grpo.max_num_steps` |
+| `WANDB_API_KEY`, `WANDB_PROJ`, `WANDB_ENTITY` | _unset_ / `nemotron-3-ultra` / _unset_ | W&B logging is disabled if `WANDB_API_KEY` is unset |
+| `HF_HOME`, `HF_TOKEN` | _unset_ | Shared HuggingFace cache and gated-model token |
+| `USE_SNAPSHOT` | `1` | Snapshot the source tree at submission time |
+| `DRY_RUN` | `0` | Set to `1` to print the resolved `TRAIN_CMD` without submitting |
+
+### External judge services
+
+By default the GenRM and NL2Bash judges are served by NeMo Gym inside the
+training Ray cluster, consuming part of `NUM_GYM_NODES`. Setting
+`EXTERNAL_JUDGES=1` instead serves them as fixed-model vLLM pools in a second
+Slurm heterogeneous component. This keeps judge serving off the training Ray
+cluster, so a judge restart or OOM cannot destabilise training, and it lets each
+judge be scaled independently of the Gym pool.
+
+The launcher registers both pools through the
+[external Gym vLLM pool helpers](https://github.com/NVIDIA-NeMo/RL/blob/main/tools/external_gym_vllm/README.md)
+and submits `tools/external_gym_vllm/run_in_allocation.sh` instead of `ray.sub`.
+That wrapper starts every replica in its own private Ray cluster, brings up one
+OpenAI-compatible load balancer per pool, waits for all backends to become
+healthy, substitutes the resolved URLs into the driver command, and only then
+starts `ray.sub` on the training component. If a required service exits, the
+training job is stopped.
+
+In this mode `GENRM_MODEL` and `NL2BASH_JUDGE_MODEL` are the checkpoints the
+pools serve, and Gym addresses them by `GENRM_SERVED_MODEL_NAME` /
+`NL2BASH_SERVED_MODEL_NAME` (both `model` by default). Setting
+`GENRM_BASE_URL` or `NL2BASH_BASE_URL` by hand is rejected, since the wrapper
+supplies those.
+
+Each pool is registered only when its model variable is set, so set at least
+one of them. Stages declare only the judges they use — `rlhf_teacher` has no
+NL2Bash block, `reasoning_teacher` has no GenRM block, `swe_teacher` has
+neither — and setting a judge the stage does not declare makes the driver fail
+on an unknown config key.
+
+`BASE_LOG_DIR` and `EXTERNAL_VLLM_TOOLS_DIR_HOST` (the repo's
+`tools/external_gym_vllm`) must resolve under `EXTERNAL_VLLM_SHARED_ROOT`,
+because the wrapper bind-mounts that root into the service containers. Since
+`RESULTS_DIR` defaults to a path relative to the repo, pass an explicit
+`BASE_LOG_DIR` on the shared filesystem when the checkout lives elsewhere.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `EXTERNAL_JUDGES` | `0` | `1` serves GenRM and NL2Bash in a second hetgroup |
+| `GENRM_REPLICAS`, `GENRM_TENSOR_PARALLEL_SIZE` | `4`, `4` | Independent DP=1 GenRM servers and TP per server |
+| `GENRM_REASONING_PARSER_NAME` | `nemotron_v3` | Reasoning parser for the GenRM; `nemotron_v3` is built into vLLM and handles the `<think>`/`</think>` format |
+| `GENRM_REASONING_PARSER` | _unset_ | Path to a reasoning-parser plugin `.py`, only for a checkpoint whose parser vLLM does not ship |
+| `NL2BASH_REPLICAS`, `NL2BASH_TENSOR_PARALLEL_SIZE` | `4`, `4` | Independent DP=1 NL2Bash servers and TP per server |
+| `EXTERNAL_VLLM_SEGMENT_SIZE` | `4` | SLURM `--segment` for the external component |
+
+Node counts are derived from the replica shapes, not set directly:
+`nodes = REPLICAS × TENSOR_PARALLEL_SIZE / GPUS_PER_NODE` per pool. The two
+components are validated separately — `NUM_TRAIN_NODES + NUM_GEN_NODES +
+NUM_GYM_NODES` must be a multiple of `SEGMENT_SIZE`, and the external node total
+must be a multiple of `EXTERNAL_VLLM_SEGMENT_SIZE`. With both judges external,
+`NUM_GYM_NODES` only has to cover the safety judge. Model paths, the parser
+plugin, and `BASE_LOG_DIR` must live under `EXTERNAL_VLLM_SHARED_ROOT`
+(`/lustre` by default), which is mounted into the service containers.
+`INTERACTIVE=1` is not supported in this mode.
+
+Building on the [Phase 1](#phase-1--49k-context-128-steps) invocation, add:
+
+```bash
+EXTERNAL_JUDGES=1 \
+GENRM_MODEL=/path/to/genrm-checkpoint \
+GENRM_REPLICAS=16 \
+NL2BASH_JUDGE_MODEL=/path/to/nl2bash-judge-checkpoint \
+NL2BASH_REPLICAS=4 \
+NUM_TRAIN_NODES=64 \
+NUM_GEN_NODES=172 \
+NUM_GYM_NODES=4 \
+BASE_LOG_DIR=/lustre/path/to/ray_logs \
+EXP_NAME=... CONFIG_PATH=... MODEL_PATH=... TRAIN_PATH=... VAL_PATH=... \
+CONTAINER=... SANDBOX_CONTAINER=... PERSISTENT_CACHE=... \
+SLURM_PARTITION=$SLURM_PARTITION SLURM_ACCOUNT=$SLURM_ACCOUNT \
+SAFETY_JUDGE_MODEL=nvidia/Nemotron-Content-Safety-Reasoning-4B \
+bash examples/nemo_gym/nemotron-3-ultra/ultra_launch.sh
+```
+
+That allocates 64 + 172 + 4 = 240 NeMo RL nodes (a multiple of `SEGMENT_SIZE`,
+with Gym now hosting only the safety judge) plus 16 GenRM + 4 NL2Bash = 20
+external nodes. Set only `GENRM_MODEL` or only `NL2BASH_JUDGE_MODEL` to move
+just that judge out of Gym — useful for the teacher stages, which declare only
+the judges they use.
+
+## Stage 1 — Student RLVR
+
+GRPO with verifiable rewards on the Ultra SFT checkpoint.
+
+Student RLVR is split into two phases that share the same `EXP_NAME` so the
+second phase resumes from the first phase's checkpoint:
+
+| | Phase 1 | Phase 2 |
+|---|---|---|
+| Config | `examples/nemo_gym/nemotron-3-ultra/student_rlvr1.yaml` | `examples/nemo_gym/nemotron-3-ultra/student_rlvr2.yaml` |
+| `max_total_sequence_length` | 49,152 | 65,536 |
+| Steps in this phase | ~128 | ~50 |
+| `NRL_MAX_STEPS` to set | `128` | `178` (= 128 + 50) |
+| `group_answer_length_penalty_coeff` | 0.25 | 0.08 |
+
+Both phases share TP=8, EP=64, CP=8, PP=1, GBS=8192 (512 prompts × 16
+generations), advantage clip ±20, and the 256-node cluster shape.
+
+### Phase 1 — 49k context, 128 steps
+
+```bash
+EXP_NAME=ultra-student-rlvr \
+CONFIG_PATH=examples/nemo_gym/nemotron-3-ultra/student_rlvr1.yaml \
+ENABLE_MTP_INFERENCE=1 \
+NRL_MAX_STEPS=128 \
+MODEL_PATH=/path/to/ultra_sft_checkpoint \
+TRAIN_PATH=$DATA_DIR/rlvr1.train.jsonl \
+VAL_PATH=$DATA_DIR/rlvr1.val.jsonl \
+CONTAINER=/path/to/nemo-rl-container \
+SANDBOX_CONTAINER=/path/to/nemo-skills-sandbox.sqsh \
+PERSISTENT_CACHE=/path/to/persistent/cache \
+EXTRA_MOUNTS=/lustre:/lustre \
+SLURM_PARTITION=$SLURM_PARTITION \
+SLURM_ACCOUNT=$SLURM_ACCOUNT \
+GENRM_MODEL=nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-GenRM \
+NL2BASH_JUDGE_MODEL=Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 \
+SAFETY_JUDGE_MODEL=nvidia/Nemotron-Content-Safety-Reasoning-4B \
+WANDB_API_KEY=$WANDB_API_KEY \
+HF_HOME=/path/to/hf_cache \
+HF_TOKEN=$HF_TOKEN \
+bash examples/nemo_gym/nemotron-3-ultra/ultra_launch.sh
+```
+
+### Phase 2 — 65k context, ~50 more steps
+
+Same env vars as Phase 1 but swap the config, raise `NRL_MAX_STEPS`, and point
+at the Phase 2 training data file. Keep `EXP_NAME` and `RESULTS_DIR` identical
+to Phase 1 so `CheckpointManager` auto-resumes from the latest Phase 1
+checkpoint.
+
+```bash
+EXP_NAME=ultra-student-rlvr \
+CONFIG_PATH=examples/nemo_gym/nemotron-3-ultra/student_rlvr2.yaml \
+ENABLE_MTP_INFERENCE=1 \
+NRL_MAX_STEPS=178 \
+MODEL_PATH=/path/to/ultra_sft_checkpoint \
+TRAIN_PATH=$DATA_DIR/rlvr2.train.jsonl \
+VAL_PATH=$DATA_DIR/rlvr2.val.jsonl \
+CONTAINER=/path/to/nemo-rl-container \
+SANDBOX_CONTAINER=/path/to/nemo-skills-sandbox.sqsh \
+PERSISTENT_CACHE=/path/to/persistent/cache \
+EXTRA_MOUNTS=/lustre:/lustre \
+SLURM_PARTITION=$SLURM_PARTITION \
+SLURM_ACCOUNT=$SLURM_ACCOUNT \
+GENRM_MODEL=nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-GenRM \
+NL2BASH_JUDGE_MODEL=Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 \
+SAFETY_JUDGE_MODEL=nvidia/Nemotron-Content-Safety-Reasoning-4B \
+WANDB_API_KEY=$WANDB_API_KEY \
+HF_HOME=/path/to/hf_cache \
+HF_TOKEN=$HF_TOKEN \
+bash examples/nemo_gym/nemotron-3-ultra/ultra_launch.sh
+```
+
+Note: Phase 1 and Phase 2 use different training blends (`rlvr1.train.jsonl` and
+`rlvr2.train.jsonl`); see the [Download and prepare the data](#download-and-prepare-the-data)
+section above.
+
+The launcher reports the experiment directory layout, sample monitoring
+commands, and (on submission) the SLURM job id.
+
+## Stage 2 — Teacher training
+
+The teacher panel is a set of specialised RL runs that each start from the
+Student RLVR output (Stage 1) (see [Checkpoint flow](#checkpoint-flow) above). Each teacher
+runs independently with its own YAML config under `examples/nemo_gym/nemotron-3-ultra/`.
+
+The teachers don't depend on each other and can run in parallel.
+
+### IFBench Teacher
+
+RLHF teacher specializing in instruction following, abstention, and refusal
+behavior. Trained at 49k context with a smaller batch (`GBS=2048`) and lower
+learning rate (`lr=2.5e-6`) than the student RLVR stage.
+
+**Config:** `examples/nemo_gym/nemotron-3-ultra/ifbench_teacher.yaml`
+- TP=8, EP=64, CP=8, PP=1
+- `max_total_sequence_length=49152`
+- `train_global_batch_size=2048`, `num_prompts_per_step=128`, `num_generations_per_prompt=16`
+- Learning rate `2.5e-6` constant
+- Default cluster shape: 80 nodes (32 training + 28 vLLM + 20 Gym)
+
+```bash
+EXP_NAME=ultra-ifbench-teacher \
+CONFIG_PATH=examples/nemo_gym/nemotron-3-ultra/ifbench_teacher.yaml \
+MODEL_PATH=/path/to/student_rlvr_output \
+TRAIN_PATH=$DATA_DIR/ifbench.train.jsonl \
+VAL_PATH=$DATA_DIR/ifbench.val.jsonl \
+NUM_TRAIN_NODES=32 \
+NUM_GEN_NODES=28 \
+NUM_GYM_NODES=20 \
+ENABLE_MTP_INFERENCE=1 \
+CONTAINER=/path/to/nemo-rl-container \
+SANDBOX_CONTAINER=/path/to/nemo-skills-sandbox.sqsh \
+PERSISTENT_CACHE=/path/to/persistent/cache \
+EXTRA_MOUNTS=/lustre:/lustre \
+SLURM_PARTITION=$SLURM_PARTITION \
+SLURM_ACCOUNT=$SLURM_ACCOUNT \
+GENRM_MODEL=nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-GenRM \
+NL2BASH_JUDGE_MODEL=Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 \
+SAFETY_JUDGE_MODEL=nvidia/Nemotron-Content-Safety-Reasoning-4B \
+WANDB_API_KEY=$WANDB_API_KEY \
+HF_HOME=/path/to/hf_cache \
+HF_TOKEN=$HF_TOKEN \
+bash examples/nemo_gym/nemotron-3-ultra/ultra_launch.sh
+```
+
+### RLHF Teacher
+
+General-purpose RLHF teacher trained against the pairwise GenRM comparison
+signal alone. Same training shape as the IFBench teacher (cluster, batch,
+learning rate, context).
+
+**Config:** `examples/nemo_gym/nemotron-3-ultra/rlhf_teacher.yaml`
+- TP=8, EP=64, CP=8, PP=1
+- `max_total_sequence_length=49152`
+- `train_global_batch_size=2048`, `num_prompts_per_step=128`, `num_generations_per_prompt=16`
+- Learning rate `2.5e-6` constant
+- Default cluster shape: 80 nodes (32 training + 28 vLLM + 20 Gym)
+
+```bash
+EXP_NAME=ultra-rlhf-teacher \
+CONFIG_PATH=examples/nemo_gym/nemotron-3-ultra/rlhf_teacher.yaml \
+MODEL_PATH=/path/to/student_rlvr_output \
+TRAIN_PATH=$DATA_DIR/rlhf.train.jsonl \
+VAL_PATH=$DATA_DIR/rlhf.val.jsonl \
+NUM_TRAIN_NODES=32 \
+NUM_GEN_NODES=28 \
+NUM_GYM_NODES=20 \
+ENABLE_MTP_INFERENCE=1 \
+CONTAINER=/path/to/nemo-rl-container \
+SANDBOX_CONTAINER=/path/to/nemo-skills-sandbox.sqsh \
+PERSISTENT_CACHE=/path/to/persistent/cache \
+EXTRA_MOUNTS=/lustre:/lustre \
+SLURM_PARTITION=$SLURM_PARTITION \
+SLURM_ACCOUNT=$SLURM_ACCOUNT \
+GENRM_MODEL=nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-GenRM \
+WANDB_API_KEY=$WANDB_API_KEY \
+HF_HOME=/path/to/hf_cache \
+HF_TOKEN=$HF_TOKEN \
+bash examples/nemo_gym/nemotron-3-ultra/ultra_launch.sh
+```
+
+This is the teacher referred to as `NRL_CHAT_TEACHER1` / `NRL_RLHF_TEACHER` in
+the MOPD config — it provides the `genrm_simple_agent` and
+`genrm_simple_agent_reasoning_off` teacher signals.
+
+### Reasoning Teacher
+
+General reasoning teacher. The training data subsamples an RLVR
+blend, where every prompt is graded by the `equivalence_llm_judge` agent
+(LLM-judge equivalence over freeform short answers). The output checkpoint
+serves the `code_gen`, `ns_tools`, `math_with_judge`,
+`equivalence_llm_judge`, and `mcqa` agent slots in MOPD — one checkpoint,
+many roles.
+
+**Config:** `examples/nemo_gym/nemotron-3-ultra/reasoning_teacher.yaml`
+- TP=8, EP=32, CP=8, PP=1 (half the expert parallelism of Student RLVR)
+- `max_total_sequence_length=65536`
+- `train_global_batch_size=2048`, `num_prompts_per_step=128`, `num_generations_per_prompt=16`
+- Learning rate `3.0e-6` constant
+- `max_num_epochs=10` — small sub-sampled dataset, multiple passes expected
+- Default cluster shape: 128 nodes (64 training + 54 vLLM + 10 Gym)
+
+```bash
+EXP_NAME=ultra-reasoning-teacher \
+CONFIG_PATH=examples/nemo_gym/nemotron-3-ultra/reasoning_teacher.yaml \
+ENABLE_MTP_INFERENCE=1 \
+MODEL_PATH=/path/to/student_rlvr_output \
+TRAIN_PATH=$DATA_DIR/reasoning.train.jsonl \
+VAL_PATH=$DATA_DIR/reasoning.val.jsonl \
+NUM_TRAIN_NODES=64 \
+NUM_GEN_NODES=54 \
+NUM_GYM_NODES=10 \
+CONTAINER=/path/to/nemo-rl-container \
+SANDBOX_CONTAINER=/path/to/nemo-skills-sandbox.sqsh \
+PERSISTENT_CACHE=/path/to/persistent/cache \
+EXTRA_MOUNTS=/lustre:/lustre \
+SLURM_PARTITION=$SLURM_PARTITION \
+SLURM_ACCOUNT=$SLURM_ACCOUNT \
+NL2BASH_JUDGE_MODEL=Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 \
+WANDB_API_KEY=$WANDB_API_KEY \
+HF_HOME=/path/to/hf_cache \
+HF_TOKEN=$HF_TOKEN \
+bash examples/nemo_gym/nemotron-3-ultra/ultra_launch.sh
+```
+
+### SWE Teacher
+
+Software-engineering RLVR teacher trained against code execution. The
+`swe_agents` agent runs the policy's candidate fixes inside apptainer (`.sif`)
+container images for each SWE-Gym / SWE-rebench-V2 instance and rewards
+the rollout based on test pass/fail.
+
+**Config:** `examples/nemo_gym/nemotron-3-ultra/swe_teacher.yaml`
+- TP=8, EP=32, CP=32, PP=1 (large CP for long context)
+- `max_total_sequence_length=196608` (192k context)
+- `train_global_batch_size=512`, `num_prompts_per_step=32`, `num_generations_per_prompt=16`
+- Learning rate `3.0e-6` constant, advantage clip ±100, `max_num_epochs=4`
+- Default cluster shape: 128 nodes (64 training + 64 vLLM + 0 Gym)
+
+### Building the SIF images
+
+Each rollout runs inside a per-instance apptainer (`.sif`) image resolved from
+`${SIF_DIR}` via the agent's `container_formatter`. Since this recipe targets
+GB200 (aarch64) and the upstream SWE images ship for x86 only, the images must
+be rebuilt for ARM — one per instance — then converted to `.sif`. The resulting
+directory is reused across runs.
+
+The released SWE blend draws from two benchmarks:
+
+| Benchmark | HF dataset | `.sif` path under `${SIF_DIR}` | Instances |
+|---|---|---|---|
+| SWE-Gym | `SWE-Gym/SWE-Gym` | `swegym/sweb.eval.arm64.{instance_id}.sif` | 206 |
+| SWE-rebench-V2 | `nebius/SWE-rebench-V2` | `swerebench/{instance_id}.sif` | 7,610 |
+
+**1. Prerequisites.** Docker, Apptainer, and `uv` on the build host. Build on an
+ARM64 (GB200) node so images are natively aarch64 with no emulation. You also
+need a container **registry** to publish to: set `REGISTRY` to its endpoint and
+`docker login` to it first. The build scripts push every per-instance image
+there, and the conversion step (3) pulls them back to produce the `.sif` files —
+so the registry must be reachable from both the build and the convert hosts.
+
+Install Apptainer on the build host via the official PPA, pinned to the version
+the training container ships (so the `.sif` format matches — see
+`docker/install_apptainer.sh`):
+
+```bash
+sudo add-apt-repository -y ppa:apptainer/ppa
+sudo apt-get update
+sudo apt-get install -y "apptainer=1.5.0-2-1~$(. /etc/os-release && echo "$VERSION_CODENAME")"
+```
+
+> **Storage.** The registry accumulates ~7,800 images, plus the converted `.sif`
+> set on the build host. The pushed images can be deleted once every `.sif` has
+> been built.
+
+**2. Build the per-instance images.**
+```bash
+git clone -b ultra-v3 https://github.com/nujoug/swe-gym-arm-build
+git clone -b ultra-v3 https://github.com/nujoug/swe-rebench-v2-arm-build
+export REGISTRY=registry.example.com/ultra-swe   # your registry endpoint (docker login first)
+
+# --- SWE-Gym (206 images) ---
+# No verify gate: this wrapper builds + pushes only. After it finishes, drop any
+# instance listed under handoff/failed_instances/ before using the images.
+cd swe-gym-arm-build
+uv venv && source .venv/bin/activate && uv pip install -e .
+python scripts/batch_build_push.py \
+  --dataset SWE-Gym/SWE-Gym --split train \
+  --instance_ids_file swe_gym_instance_ids.txt \
+  --registry "${REGISTRY}/swe-gym" --push_env_images \
+  --max_workers 8 --state_file build_push_state.json
+deactivate; cd ..
+
+# --- SWE-rebench-V2 (7,610 images) ---
+# Omitting --skip-eval enables the verify gate: each image is built, the gold
+# patch is applied, the tests are run, and only images whose FAIL_TO_PASS /
+# PASS_TO_PASS transition matches are published (others land in
+# handoff/failed_instances/).
+cd swe-rebench-v2-arm-build
+uv venv && source .venv/bin/activate && uv pip install -r requirements.txt
+# Build the per-language base images first (Go/Java/Rust/Python/… environments
+# that the instance images layer on top of).
+# Note: expect one known failure when building scala_base (its Dockerfile runs `foundryup`, which 403s on the GitHub API).
+python3 scripts/build_all_arm_bases.py --platform linux/arm64 --keep-going --max-workers 4 --skip-existing
+python3 scripts/prepare_ready_tasks.py --hf-dataset nebius/SWE-rebench-V2 --output ready_tasks.json
+python3 scripts/build_eval_cleanup.py \
+  --json ready_tasks.json --platform linux/arm64 --max-workers 8 \
+  --report-json eval_report.json --skip-done \
+  --gitlab-registry "${REGISTRY}/swerebenchv2"
+deactivate; cd ..
+```
+
+**3. Convert to `.sif` and lay out `${SIF_DIR}`.** `build_swe_sif_images.py` pulls
+each published image and runs `apptainer build` under the exact filename the
+recipe expects — SWE-Gym from the `swe-gym:sweb.eval.arm64.<id>` tags, and
+SWE-rebench-V2 from the verified (`passed_match`) instances in `eval_report.json`.
+It skips images already converted and continues past any that are missing (e.g.
+instances that failed to build), recording them in `${SIF_DIR}/missing_instances.txt`.
+Run it from the NeMo RL repo root:
+```bash
+export SIF_DIR=/path/to/sif/images
+python examples/nemo_gym/build_swe_sif_images.py \
+  --registry "${REGISTRY}" --sif-dir "${SIF_DIR}" \
+  --swe-gym-ids /path/to/swe-gym-arm-build/swe_gym_instance_ids.txt \
+  --rebench-report /path/to/swe-rebench-v2-arm-build/eval_report.json
+```
+
+With `${SIF_DIR}` populated, launch the SWE teacher:
+
+```bash
+EXP_NAME=ultra-swe-teacher \
+CONFIG_PATH=examples/nemo_gym/nemotron-3-ultra/swe_teacher.yaml \
+ENABLE_MTP_INFERENCE=1 \
+MODEL_PATH=/path/to/student_rlvr_output \
+TRAIN_PATH=$DATA_DIR/swe.train.jsonl \
+VAL_PATH=$DATA_DIR/swe.val.jsonl \
+NUM_TRAIN_NODES=64 \
+NUM_GEN_NODES=64 \
+NUM_GYM_NODES=0 \
+SIF_DIR=/path/to/sif/images \
+CONTAINER=/path/to/nemo-rl-container \
+SANDBOX_CONTAINER=/path/to/nemo-skills-sandbox.sqsh \
+PERSISTENT_CACHE=/path/to/persistent/cache \
+EXTRA_MOUNTS=/lustre:/lustre \
+SLURM_PARTITION=$SLURM_PARTITION \
+SLURM_ACCOUNT=$SLURM_ACCOUNT \
+WANDB_API_KEY=$WANDB_API_KEY \
+HF_HOME=/path/to/hf_cache \
+HF_TOKEN=$HF_TOKEN \
+bash examples/nemo_gym/nemotron-3-ultra/ultra_launch.sh
+```
+
+## Stage 3 — MOPD
+
+Multi-Teacher On-Policy Distillation. The Student RLVR output is the student; each
+Gym agent is routed to one of the Stage 2 teacher checkpoints. Trains the
+student to match per-agent teacher distributions.
+
+**Config:** `examples/nemo_gym/nemotron-3-ultra/mopd.yaml`
+- TP=8, EP=64, CP=32, PP=1, max context 192k
+- Teacher parallelism: TP=8, CP=2, EP=16, 4 nodes per teacher
+- Routing: agent → teacher checkpoint baked into the YAML via
+  `${_teachers.<role>}` references; only `_teachers.general` is required and
+  every other slot falls back to it.
+- Default cluster shape: 224 nodes (64 training + 128 vLLM + 12 Gym + 20 teachers).
+
+### Teacher mapping
+
+| Logical slot | Path source | MOPD agents it serves |
+|---|---|---|
+| `general` | Student RLVR output | `lc_judge_simple_agent`, fallback for unset slots below |
+| `rlhf` | RLHF Teacher | `genrm_simple_agent`, `genrm_simple_agent_reasoning_off` |
+| `ifbench` | IFBench Teacher | `instruction_following_simple_agent`, `abstention_simple_agent`, `multichallenge_simple_agent` |
+| `reasoning` | Reasoning Teacher | `math_with_judge_simple_agent`, `equivalence_llm_judge_simple_agent`, `mcqa_simple_agent`, `ns_tools_simple_agent`, `code_gen_simple_agent` |
+| `swe` | SWE Teacher | all `swe_pivot_*`, `terminal_multi_harness_{opencode,agent006,codex}`, `droid_pivot_*`, `structured_outputs_v3_simple_agent`, `freeform_formatting_simple_agent`, `citation_format_simple_agent` |
+
+### Launch
+
+Pass `STAGE_TYPE=mopd` to the launcher to enable the teacher-pool node math
+and the `_teachers.X` Hydra overrides. `NRL_GENERAL_TEACHER_PATH` is required;
+the other four teacher paths are optional and fall back to general when
+unset.
+
+```bash
+STAGE_TYPE=mopd \
+EXP_NAME=ultra-mopd-stage1 \
+CONFIG_PATH=examples/nemo_gym/nemotron-3-ultra/mopd.yaml \
+ENABLE_MTP_INFERENCE=1 \
+MODEL_PATH=/path/to/student_rlvr_output \
+TRAIN_PATH=$DATA_DIR/mopd.train.jsonl \
+VAL_PATH=$DATA_DIR/mopd.val.jsonl \
+NUM_TRAIN_NODES=64 \
+NUM_GEN_NODES=128 \
+NUM_GYM_NODES=12 \
+NUM_UNIQUE_TEACHERS=5 \
+NUM_NODES_PER_TEACHER=4 \
+NRL_GENERAL_TEACHER_PATH=/path/to/student_rlvr_output \
+NRL_RLHF_TEACHER_PATH=/path/to/rlhf_teacher_output \
+NRL_IFBENCH_TEACHER_PATH=/path/to/ifbench_teacher_output \
+NRL_REASONING_TEACHER_PATH=/path/to/reasoning_teacher_output \
+NRL_SWE_TEACHER_PATH=/path/to/swe_teacher_output \
+CONTAINER=/path/to/nemo-rl-container \
+SANDBOX_CONTAINER=/path/to/nemo-skills-sandbox.sqsh \
+PERSISTENT_CACHE=/path/to/persistent/cache \
+EXTRA_MOUNTS=/lustre:/lustre \
+SLURM_PARTITION=$SLURM_PARTITION \
+SLURM_ACCOUNT=$SLURM_ACCOUNT \
+GENRM_MODEL=nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-GenRM \
+NL2BASH_JUDGE_MODEL=Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 \
+SAFETY_JUDGE_MODEL=nvidia/Nemotron-Content-Safety-Reasoning-4B \
+WANDB_API_KEY=$WANDB_API_KEY \
+HF_HOME=/path/to/hf_cache \
+HF_TOKEN=$HF_TOKEN \
+bash examples/nemo_gym/nemotron-3-ultra/ultra_launch.sh
+```

--- a/docs/guides/nemotron-3.5-lightning.md
+++ b/docs/guides/nemotron-3.5-lightning.md
@@ -1,1 +1,304 @@
-models/nemotron/nemotron-3.5-lightning.md
+# Nemotron 3.5 Lightning
+
+> **Note:** This document has moved and will be deprecated here. See the new location: https://github.com/NVIDIA-NeMo/RL/blob/main/docs/guides/models/nemotron/nemotron-3.5-lightning.md
+
+This guide covers two ways to post-train Nemotron 3.5 Lightning with NeMo RL:
+
+- [RLVR with NeMo Gym (GB200 reference run)](#rlvr-with-nemo-gym-gb200-reference-run) —
+  the full 86-node asynchronous GRPO + NeMo Gym recipe used for the reference
+  RLVR stage on GB200 NVL72 (ARM64 / aarch64) hardware.
+- [DAPO math RL with the automodel backend](#dapo-math-rl-with-the-automodel-backend) —
+  a compact 4-node DAPO recipe on the DTensor (automodel) training backend,
+  useful as a smaller-footprint starting point on x86 H100 clusters.
+
+## RLVR with NeMo Gym (GB200 reference run)
+
+This section explains how to reproduce the Nemotron 3.5 Lightning RLVR recipe
+with NeMo RL on **GB200 NVL72** (ARM64 / aarch64) hardware.
+
+### Overview
+
+Nemotron 3.5 Lightning is post-trained in a single Reinforcement Learning with
+Verifiable Rewards (RLVR) stage using asynchronous Group Relative Policy
+Optimization (GRPO) and NeMo Gym.
+
+Training and policy generation use separate node pools. The GenRM and
+general-purpose NL2Bash judge run as external vLLM pools in the same Slurm
+heterogeneous allocation, while the smaller content-safety judge runs in the
+Gym pool.
+
+The recipe files are under
+`examples/nemo_gym/nemotron-3.5-lightning/`:
+
+- `rlvr.yaml` contains the training, generation, reward, and Gym configuration.
+- `lightning35_launch.sh` handles Slurm submission, code snapshots, persistent
+  caches, container mounts, and run-specific paths.
+
+The reference run uses the following training configuration:
+
+| Setting | Value |
+|---|---:|
+| Maximum sequence length | 73,728 tokens |
+| Prompts per step | 512 |
+| Generations per prompt | 16 |
+| Global batch size | 8,192 |
+| Training parallelism | TP=4, CP=4, EP=16, PP=1 |
+| Policy-generation parallelism | TP=4, PP=1 |
+| Training precision | BF16 |
+
+#### Topology
+
+The recipe uses four GPUs per GB200 node:
+
+| Component | Deployment | Nodes | GPUs |
+|---|---|---:|---:|
+| Training | Megatron TP=4, CP=4, EP=16 | 32 | 128 |
+| Policy generation | NeMo RL vLLM TP=4 | 32 | 128 |
+| Safety judge | Gym vLLM TP=4, DP=2 | 2 | 8 |
+| GenRM | 8 independent TP=8 vLLM servers | 16 | 64 |
+| NL2Bash judge | 4 independent TP=4 vLLM servers | 4 | 16 |
+| **Total** |  | **86** | **344** |
+
+### Prepare the code
+
+Clone NeMo RL and its submodules on a filesystem visible to every allocated
+node:
+
+```bash
+git clone --recursive https://github.com/NVIDIA-NeMo/RL.git
+cd RL
+```
+
+The launcher mounts the current NeMo RL source, Lightning recipe directory,
+and Gym checkout into the training container. With `USE_SNAPSHOT=1` (the
+default), it first snapshots tracked source files so the submitted job uses a
+stable copy.
+
+### Container
+
+Nemotron 3.5 Lightning uses vLLM and requires an **aarch64 (arm64)** image for
+GB200 NVL72 nodes. Prebake the NeMo Gym virtual environments used by the recipe
+to avoid building them every time a training job starts. From the root of the
+NeMo RL repository, build and push the image:
+
+```bash
+docker buildx build \
+  --platform linux/arm64 \
+  --progress=plain \
+  -f docker/Dockerfile \
+  --target release \
+  -t <your-registry>/nemo-rl:main-lightning35-prefetched-venvs \
+  --push \
+  --build-context nemo-rl=. \
+  --build-arg MAX_JOBS=8 \
+  --build-arg SKIP_SGLANG_BUILD=1 \
+  --build-arg SKIP_TRTLLM_BUILD=1 \
+  --build-arg NEMO_GYM_PREFETCH_CONFIGS="examples/nemo_gym/nemotron-3.5-lightning/rlvr.yaml" \
+  .
+```
+
+Build arguments:
+
+- `NEMO_GYM_PREFETCH_CONFIGS` builds the Gym virtual environments referenced
+  by `rlvr.yaml` into the image.
+- `SKIP_SGLANG_BUILD=1` skips SGLang because this recipe uses vLLM.
+- `SKIP_TRTLLM_BUILD=1` skips TensorRT-LLM because this recipe does not use it.
+- `MAX_JOBS` controls parallel build jobs; tune it for the build machine.
+- `--build-context nemo-rl=.` builds from the current checkout. Without it,
+  the Dockerfile pulls `NVIDIA-NeMo/RL.git#main`.
+
+On a Slurm cluster using [enroot](https://github.com/NVIDIA/enroot), convert
+the image to squashfs:
+
+```bash
+enroot import -o nemo-rl-lightning35.sqsh \
+  docker://<your-registry>/nemo-rl:main-lightning35-prefetched-venvs
+```
+
+Pass the resulting `.sqsh` path as `CONTAINER`. A registry image URI can be
+used instead on clusters that do not require a local squashfs image. The same
+image is used for training, policy generation, and the external judge pools by
+default.
+
+### Download and prepare the data
+
+The RLVR blend is published as
+[`nvidia/Nemotron-RL-Lightning-Training-Blend`](https://huggingface.co/datasets/nvidia/Nemotron-RL-Lightning-Training-Blend).
+It contains `rlvr.jsonl` and `fill_placeholders.py`. Math rows originating from
+`BytedTsinghua-SIA/DAPO-Math-17k` and `Skywork/Skywork-OR1-RL-Data` are
+represented by placeholders; the bundled script restores them from the
+original datasets on Hugging Face. This is the same general preparation flow
+used by the [Nemotron 3 Ultra recipe](nemotron-3-ultra.md#download-and-prepare-the-data).
+
+```bash
+export DATA_DIR=/path/to/lightning/data
+
+# Download rlvr.jsonl and fill_placeholders.py.
+uvx --from huggingface-hub hf download \
+  nvidia/Nemotron-RL-Lightning-Training-Blend \
+  --repo-type dataset \
+  --local-dir lightning-blend
+
+# Restore the source-backed placeholders into $DATA_DIR/rlvr.jsonl.
+chmod +x lightning-blend/fill_placeholders.py
+./lightning-blend/fill_placeholders.py \
+  --input-dir lightning-blend \
+  --output-dir "$DATA_DIR"
+```
+
+The resulting `$DATA_DIR/rlvr.jsonl` is already in the format expected by
+`NemoGymDataset`. The released recipe does not run periodic, start, or end
+validation, but the launcher still requires both paths. To reproduce the
+reference run, pass the restored blend as both:
+
+```bash
+TRAIN_PATH=$DATA_DIR/rlvr.jsonl
+VAL_PATH=$DATA_DIR/rlvr.jsonl
+```
+
+Rows select their Gym agent through `agent_ref`. The corresponding agent and
+resource-server configs are already listed under `env.nemo_gym.config_paths`
+in `rlvr.yaml`.
+
+For each external dataset you elect to use, you are responsible for confirming
+that its license is appropriate for your intended use.
+
+### Build the sandbox container
+
+Several Gym environments used by the Lightning blend, including `ns_tools`
+and `math_formal_lean`, execute verification tools in a sandbox container.
+Build it from the
+[NeMo Skills Dockerfile](https://github.com/NVIDIA-NeMo/Skills/blob/main/dockerfiles/Dockerfile.sandbox):
+
+```bash
+git clone https://github.com/NVIDIA-NeMo/Skills.git
+cd Skills
+git checkout b620e79
+docker build -t nemo-skills-sandbox:latest -f dockerfiles/Dockerfile.sandbox .
+```
+
+For Slurm clusters using enroot, convert it to a `.sqsh`:
+
+```bash
+enroot import -o nemo-skills-sandbox.sqsh \
+  dockerd://nemo-skills-sandbox:latest
+```
+
+Pass this image as `SANDBOX_CONTAINER` when launching training.
+
+### Prepare the policy and judge models
+
+Set `MODEL_PATH` to the Transformers-compatible Nemotron 3.5 Lightning SFT
+checkpoint from which RLVR should start.
+
+```bash
+MODEL_PATH=/path/to/nemotron-3.5-lightning-sft-checkpoint
+```
+
+The recipe uses three judge roles:
+
+| Variable | Reference model | Deployment |
+|---|---|---|
+| `GENRM_MODEL` | [`nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-GenRM`](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-GenRM) | 8 external TP=8 servers |
+| `NL2BASH_JUDGE_MODEL` | [`Qwen/Qwen3-235B-A22B-Instruct-2507-FP8`](https://huggingface.co/Qwen/Qwen3-235B-A22B-Instruct-2507-FP8) | 4 external TP=4 servers |
+| `SAFETY_JUDGE_MODEL` | [`nvidia/Nemotron-Content-Safety-Reasoning-4B`](https://huggingface.co/nvidia/Nemotron-Content-Safety-Reasoning-4B) | Gym TP=4, DP=2 |
+
+### Launch script
+
+Run `examples/nemo_gym/nemotron-3.5-lightning/lightning35_launch.sh` from the
+repository root. The launcher handles Slurm submission, source snapshots,
+persistent compile caches, container mounts, external vLLM services, and
+run-specific paths. Training hyperparameters and parallelism remain in
+`rlvr.yaml` and the launcher defaults.
+
+Optional knobs:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `WALLTIME` | `4:00:00` | Slurm `--time` |
+| `NUM_TRAIN_NODES`, `NUM_GEN_NODES`, `NUM_GYM_NODES` | `32`, `32`, `2` | Training, policy-generation, and in-cluster Gym node counts |
+| `NRL_MAX_STEPS` | _from YAML_ | Override `grpo.max_num_steps` |
+| `WANDB_PROJ` | `nemotron-3.5-lightning` | W&B project name |
+| `DRY_RUN` | `0` | Set to `1` to print the resolved training command without submitting |
+
+### Launch RLVR
+
+The following command launches the complete 86-node reference topology. Run it
+from a NeMo RL checkout located under the shared filesystem root:
+
+```bash
+export SHARED_ROOT=/shared
+export DATA_DIR=$SHARED_ROOT/data/lightning
+
+EXP_NAME=lightning35-rlvr \
+MODEL_PATH=$SHARED_ROOT/models/nemotron-3.5-lightning-sft-checkpoint \
+TRAIN_PATH=$DATA_DIR/rlvr.jsonl \
+VAL_PATH=$DATA_DIR/rlvr.jsonl \
+GENRM_MODEL=nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-GenRM \
+NL2BASH_JUDGE_MODEL=Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 \
+SAFETY_JUDGE_MODEL=nvidia/Nemotron-Content-Safety-Reasoning-4B \
+CONTAINER=$SHARED_ROOT/containers/nemo-rl-lightning35.sqsh \
+SANDBOX_CONTAINER=$SHARED_ROOT/containers/nemo-skills-sandbox.sqsh \
+PERSISTENT_CACHE=$SHARED_ROOT/cache/lightning35-rlvr \
+HF_HOME=$SHARED_ROOT/cache/huggingface \
+HF_TOKEN=$HF_TOKEN \
+RESULTS_DIR=$SHARED_ROOT/results/lightning35-rlvr \
+EXTERNAL_VLLM_SHARED_ROOT=$SHARED_ROOT \
+EXTRA_MOUNTS=$SHARED_ROOT:$SHARED_ROOT \
+SLURM_PARTITION=your-partition \
+SLURM_ACCOUNT=your-account \
+bash examples/nemo_gym/nemotron-3.5-lightning/lightning35_launch.sh
+```
+
+## DAPO math RL with the automodel backend
+
+The recipe `examples/configs/recipes/llm/dapo-nanov3.5-30BA3B-4n8g-automodel.yaml`
+trains [`nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16`](https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16)
+with DAPO on math data using the DTensor (automodel) training backend and
+colocated vLLM generation. It runs on 4 nodes of 8x H100 80GB and is also
+exercised as a nightly test
+(`tests/test_suites/llm/dapo-nanov3.5-30BA3B-4n8g-automodel.sh`).
+
+### Overview
+
+| Setting | Value |
+|---|---:|
+| Algorithm | GRPO with DAPO (dynamic sampling, overlong filtering, reward scaling/shaping, TIS) |
+| Data | `DAPOMath17K` train / `DAPOMathAIME2024` validation |
+| Maximum sequence length | 9,216 tokens (8,192 generated) |
+| Rollouts per step | 32 prompts x 16 generations (global batch size 512) |
+| Training parallelism | DTensor FSDP with EP=8, TP=1, activation checkpointing |
+| Policy generation | Colocated vLLM TP=4 |
+| Optimizer | TransformerEngine `FusedAdam`, lr 1e-6, wd 0.1, 10-step warmup |
+| Training precision | BF16 |
+
+The Lightning checkpoint ships a Multi-Token Prediction (MTP) module
+(`mtp.*` weights, `num_nextn_predict_layers=1`). The recipe ignores MTP
+end-to-end without code changes: the automodel custom NemotronH
+implementation builds only the backbone and LM head, the DCP loader never
+reads the `mtp.*` tensors, and vLLM skips them at load and refit. Keep
+`dtensor_cfg.automodel_kwargs.force_hf` and generation `speculative_config`
+unset, otherwise the MTP module is instantiated.
+
+### Launch training
+
+From the repository root:
+
+```bash
+uv run examples/run_grpo.py \
+    --config examples/configs/recipes/llm/dapo-nanov3.5-30BA3B-4n8g-automodel.yaml \
+    logger.wandb_enabled=True
+```
+
+For launching on a multi-node Slurm or Kubernetes cluster, see the
+[cluster guide](../../../cluster.md). Interrupted runs resume automatically
+from the latest checkpoint in `checkpointing.checkpoint_dir`.
+
+### Results
+
+Over roughly 210 steps, training reward climbs
+from -0.7 to about 0.5 and AIME-2024 validation accuracy improves from 0.33
+to about 0.75. The truncation rate drops from ~0.5 to ~0.1 as responses
+shorten from ~5,500 to ~3,000 generated tokens per sample.
+
+![Nemotron 3.5 Lightning DAPO automodel training curves](../../../assets/nemotron/nemotron-3.5-lightning-automodel.png)

--- a/docs/guides/nemotron-3.5-lightning.md
+++ b/docs/guides/nemotron-3.5-lightning.md
@@ -1,0 +1,1 @@
+models/nemotron/nemotron-3.5-lightning.md

--- a/docs/guides/nemotron-3.5-lightning.md
+++ b/docs/guides/nemotron-3.5-lightning.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # Nemotron 3.5 Lightning
 
 > **Note:** This document has moved and will be deprecated here. See the new location: https://github.com/NVIDIA-NeMo/RL/blob/main/docs/guides/models/nemotron/nemotron-3.5-lightning.md
@@ -291,7 +295,7 @@ uv run examples/run_grpo.py \
 ```
 
 For launching on a multi-node Slurm or Kubernetes cluster, see the
-[cluster guide](../../../cluster.md). Interrupted runs resume automatically
+[cluster guide](../cluster.md). Interrupted runs resume automatically
 from the latest checkpoint in `checkpointing.checkpoint_dir`.
 
 ### Results
@@ -301,4 +305,4 @@ from -0.7 to about 0.5 and AIME-2024 validation accuracy improves from 0.33
 to about 0.75. The truncation rate drops from ~0.5 to ~0.1 as responses
 shorten from ~5,500 to ~3,000 generated tokens per sample.
 
-![Nemotron 3.5 Lightning DAPO automodel training curves](../../../assets/nemotron/nemotron-3.5-lightning-automodel.png)
+![Nemotron 3.5 Lightning DAPO automodel training curves](../assets/nemotron/nemotron-3.5-lightning-automodel.png)


### PR DESCRIPTION
## Summary
- Copy the five Nemotron model guides (`nemotron-3-nano.md`, `nemotron-3-nano-omni.md`, `nemotron-3-super.md`, `nemotron-3-ultra.md`, `nemotron-3.5-lightning.md`) from `docs/guides/models/nemotron/` into `docs/guides/` as plain copies (previously attempted as a symlink, reverted in favor of real files).
- Each copy has a deprecation note added under its title, pointing readers to the canonical source at `docs/guides/models/nemotron/<file>.md`, since these top-level copies will be removed in a future cleanup.

## Test plan
- N/A (docs-only change)