### PR TITLE
fix: anchor checkpoint TimeoutChecker at SLURM allocation start

### DIFF
--- a/nemo_rl/utils/timer.py
+++ b/nemo_rl/utils/timer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import datetime
 import logging
+import os
 import sys
 import threading
 import time
@@ -416,25 +417,66 @@ def convert_to_seconds(time_string: str) -> int:
     return days * 86400 + hours * 3600 + minutes * 60 + seconds
 
 
+def get_slurm_job_start_time() -> Optional[float]:
+    """Epoch seconds of the SLURM allocation start, or None outside SLURM.
+
+    Reads ``SLURM_JOB_START_TIME`` (exported by Slurm >= 23.02). An unset,
+    empty, or malformed value returns None so callers fall back to construction
+    time; a malformed value additionally warns rather than crashing.
+    """
+    raw = os.environ.get("SLURM_JOB_START_TIME")
+    if not raw:
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(
+            f"Could not parse SLURM_JOB_START_TIME={raw!r}; anchoring the "
+            "checkpoint timeout at construction time instead."
+        )
+        return None
+
+
 class TimeoutChecker:
     def __init__(
-        self, timeout: Optional[str] = "00:03:45:00", fit_last_save_time: bool = False
+        self,
+        timeout: Optional[str] = "00:03:45:00",
+        fit_last_save_time: bool = False,
+        start_time: Optional[float] = None,
     ):
         """Initializes the TimeoutChecker.
 
         Args:
             timeout (str or None): Timeout in format 'DD:HH:MM:SS'. If None, timeout is considered infinite.
             fit_last_save_time (bool): If True, considers average iteration time when checking timeout.
+            start_time (float or None): Epoch seconds to anchor the timeout budget at.
+                Defaults to the SLURM allocation start (``SLURM_JOB_START_TIME``) when
+                available, otherwise the current time. Anchoring at the allocation start
+                makes ``checkpoint_must_save_by`` budget from allocation start, so the
+                setup time before this checker is constructed is not silently excluded.
         """
         super().__init__()
         self.last_save_time = (
             float("inf") if timeout is None else convert_to_seconds(timeout)
         )
-        self.start_time = time.time()
+        if start_time is None:
+            start_time = get_slurm_job_start_time()
+        if start_time is None:
+            self.start_time = time.time()
+            anchor = "construction time"
+        else:
+            self.start_time = start_time
+            anchor = "SLURM_JOB_START_TIME"
         self.last_saved = False
         self.iteration_times = []
         self.previous_iteration_time: Optional[float] = None
         self.fit_last_save_time = fit_last_save_time
+
+        if self.last_save_time != float("inf"):
+            remaining = self.last_save_time - (time.time() - self.start_time)
+            budget = datetime.timedelta(seconds=round(abs(remaining)))
+            status = "remaining budget" if remaining >= 0 else "budget already exceeded by"
+            logger.info(f"TimeoutChecker anchored at {anchor}; effective {status} {budget}.")
 
     def check_save(self):
         # Flush

--- a/tests/unit/utils/test_timer.py
+++ b/tests/unit/utils/test_timer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import os
 import threading
 import time
 from unittest.mock import patch
@@ -651,3 +652,33 @@ class TestTimeoutChecker:
         checker.mark_iteration()
         assert len(checker.iteration_times) == 1
         assert checker.iteration_times[0] > 0
+
+    def test_defaults_to_construction_time_without_slurm(self):
+        # No SLURM env -> anchored at construction time (pre-existing behavior).
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SLURM_JOB_START_TIME", None)
+            checker = TimeoutChecker(timeout="00:00:01:00")
+        assert checker.check_save() is False
+
+    def test_slurm_job_start_time_budgets_from_allocation(self):
+        # A 60s budget with the allocation started 120s ago is already spent, so
+        # the first check must fire a save. Construction-time anchoring would
+        # instead wait the full 60s -- the bug this fix addresses.
+        started = time.time() - 120
+        with patch.dict(os.environ, {"SLURM_JOB_START_TIME": str(started)}):
+            checker = TimeoutChecker(timeout="00:00:01:00")
+        assert checker.check_save() is True
+
+    def test_malformed_slurm_job_start_time_falls_back(self, caplog):
+        with patch.dict(os.environ, {"SLURM_JOB_START_TIME": "not-a-number"}):
+            with caplog.at_level(logging.WARNING):
+                checker = TimeoutChecker(timeout="00:00:01:00")
+        # Falls back to construction time (budget intact) and warns loudly.
+        assert checker.check_save() is False
+        assert "SLURM_JOB_START_TIME" in caplog.text
+
+    def test_explicit_start_time_overrides_slurm(self):
+        # An explicit start_time wins over the environment.
+        with patch.dict(os.environ, {"SLURM_JOB_START_TIME": str(time.time() - 120)}):
+            checker = TimeoutChecker(timeout="00:00:01:00", start_time=time.time())
+        assert checker.check_save() is False


### PR DESCRIPTION
# What does this PR do ?

`checkpoint_must_save_by` is meant to guarantee that a checkpoint is written
**before the allocation is reclaimed**. But `TimeoutChecker` anchors its budget
at construction time:

```python
self.start_time = time.time()
```

Every algorithm constructs the checker *after* `setup()` returns — Ray init,
cluster spinup, and model/vLLM loading have already happened. The budget
therefore silently excludes 20–30 minutes of setup: a user who requests a 4h
allocation and sets `checkpoint_must_save_by: "00:03:30:00"` actually gets a
save at `training_start + 3h30` = `allocation + 3h30 + setup`. With enough
setup, the timeout save fires *after* the allocation is already dead — losing
exactly the work the knob exists to protect.

## The fix

Anchor the budget at the allocation start when SLURM provides it, through the
single `TimeoutChecker` constructor — so all algorithms are corrected with no
call-site changes:

- Reads `SLURM_JOB_START_TIME` (exported by Slurm ≥ 23.02) via a small
  `get_slurm_job_start_time()` helper.
- Unset / empty / malformed (Kubernetes, local runs, older Slurm) → falls back
  to today's construction-time behavior, a clean no-op. A malformed value warns
  rather than crashing.
- An explicit `start_time` argument still wins, for tests and callers that want
  to pin it.
- A construction-time log records the anchor source and the effective remaining
  budget, so the semantic is visible in every run, e.g.
  `TimeoutChecker anchored at SLURM_JOB_START_TIME; effective remaining budget 3:17:00.`

The new default's failure mode (save slightly earlier than a training-start
anchored user expected) is benign; the old default's failure mode (save after
the allocation dies) loses work.

# Issues

Closes #3596.

# Usage

No config change and no new knob. `checkpoint_must_save_by` now budgets from the
SLURM allocation start automatically; non-SLURM environments are unaffected.

# Before your PR is "Ready for review"

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? (four cases in `tests/unit/utils/test_timer.py`)
- [x] Did you run the unit tests locally? (unit only)
- [x] Did you add or update any necessary documentation? (n/a — behavior fix, no user-facing surface change)

# Additional Information

- `SLURM_JOB_START_TIME` was added in Slurm 23.02 and is epoch seconds; older
  Slurm simply doesn't set it and hits the `None` fallback.
- Surfaced during review of #3429 (whose `TimeoutChecker` placement is correct
  legacy parity and needs no change — this is a pre-existing, cross-cutting
  semantic).
