### PR TITLE
docs: nest model guides under their family hubs in the nav tree

### DIFF
--- a/docs/guides/models/index.md
+++ b/docs/guides/models/index.md
@@ -20,3 +20,10 @@ For the full list of supported models, see
 Other model-specific guides currently live directly under
 [Guides](../../index.md) (for example, [DeepSeek](../deepseek.md)) and are
 migrated into this hub as their guidance grows.
+
+```{toctree}
+:hidden:
+
+nemotron/index.md
+qwen/index.md
+```

--- a/docs/guides/models/nemotron/index.md
+++ b/docs/guides/models/nemotron/index.md
@@ -25,3 +25,14 @@ For the full list of supported models, see
 - **[Nemotron 3.5 Lightning](nemotron-3.5-lightning.md)** — RLVR with NeMo Gym
   on GB200, plus a compact 4-node DAPO math recipe on the DTensor (AutoModel)
   backend.
+
+```{toctree}
+:hidden:
+
+nemotron-3-nano.md
+nemotron-3-nano-omni.md
+nemotron-3.5-lightning.md
+nemotron-3-super.md
+nemotron-3-super-omni-mopd.md
+nemotron-3-ultra.md
+```

--- a/docs/guides/models/qwen/index.md
+++ b/docs/guides/models/qwen/index.md
@@ -22,3 +22,9 @@ truth for those models.
 > Qwen3 and Qwen3.5 thinking models need a large generation budget. See
 > [Qwen3.5 → Example Recipes](qwen3-5.md#example-recipes) for the
 > `max_new_tokens` guidance.
+
+```{toctree}
+:hidden:
+
+qwen3-5.md
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -315,15 +315,6 @@ guides/environments.md
 guides/eval.md
 guides/deepseek.md
 guides/models/index.md
-guides/models/nemotron/index.md
-guides/models/nemotron/nemotron-3-nano.md
-guides/models/nemotron/nemotron-3-nano-omni.md
-guides/models/nemotron/nemotron-3.5-lightning.md
-guides/models/nemotron/nemotron-3-super.md
-guides/models/nemotron/nemotron-3-super-omni-mopd.md
-guides/models/nemotron/nemotron-3-ultra.md
-guides/models/qwen/index.md
-guides/models/qwen/qwen3-5.md
 model-quirks.md
 guides/async-grpo.md
 guides/single-controller.md


### PR DESCRIPTION
The nine pages under docs/guides/models/ were all declared flat in the root toctree in docs/index.md, and none of the hub pages (models/index.md, models/nemotron/index.md, models/qwen/index.md) declared a toctree of their own. Sphinx derives nav hierarchy only from nested toctrees, so every page rendered as a toctree-l1 sibling: Model Guides, Nemotron, Nemotron 3 Nano, ... Qwen, Qwen3.5 all at one level, with nothing indicating that the model pages belong to their family hub.

Move the eight descendants out of the root toctree and declare them from their parent hubs with hidden toctrees. The hubs already list their children as prose bullets, so :hidden: adds the nav entries without rendering a duplicate list under the body text.

Verified with a local sphinx build: resulting tree is Model Guides ->
{Nemotron -> 5 pages, Qwen -> 1 page}, zero toc.not_included warnings, and no page registered under more than one parent.

# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
