### PR TITLE
docs: document token_level_loss in the GRPO guide

### DIFF
--- a/docs/guides/cispo.md
+++ b/docs/guides/cispo.md
@@ -53,7 +53,7 @@ loss_fn:
 - **`use_cispo`**: Enables the CISPO objective in the shared `ClippedPGLossFn`.
 - **`ratio_clip_min` / `ratio_clip_max`**: Follow the paper's additive epsilon convention. The effective clamp range is `[1 - ratio_clip_min, 1 + ratio_clip_max]`. For example, `ratio_clip_min: 1.0` and `ratio_clip_max: 5.0` clamp ratios to `[0, 6]`; since policy ratios are non-negative, this is effectively an upper-only clamp at `6`.
 - **`ratio_clip_c`**: Must be `null` for CISPO — dual clipping is incompatible with the CISPO objective.
-- **`token_level_loss`**: CISPO is defined per token, so keep this `true`.
+- **`token_level_loss`**: CISPO is defined per token, so keep this `true`. Setting it to `false` is rejected at construction time. See [Loss Normalization](grpo.md#loss-normalization-token_level_loss) for what this parameter controls.
 
 > [!NOTE]
 > When `use_importance_sampling_correction: true`, the shared GRPO loss path additionally multiplies the CISPO token loss by the actor-vs-generation correction `exp(prev_logprobs - generation_logprobs)`. This correction is separate from CISPO's clipped `pi_theta / pi_old` weight.

--- a/docs/guides/dapo.md
+++ b/docs/guides/dapo.md
@@ -83,7 +83,7 @@ grpo:
 > [!NOTE]
 > **Clip-Higher** and **Token-Level Policy Gradient Loss** are already supported in NeMo RL and can be configured through the `loss_fn` section of your experiment config:
 > - Set `ratio_clip_max` to enable Clip-Higher (e.g., `ratio_clip_max: 0.28`)
-> - Set `token_level_loss: true` to enable Token-Level Policy Gradient Loss
+> - Set `token_level_loss: true` to enable Token-Level Policy Gradient Loss (see [Loss Normalization](grpo.md#loss-normalization-token_level_loss) for what this changes and the tradeoff against sequence-level normalization)
 > 
 > See the full [DAPO example config](../../examples/configs/recipes/llm/dapo-qwen2.5-7b.v2.yaml) for reference.
 

--- a/docs/guides/grpo.md
+++ b/docs/guides/grpo.md
@@ -504,7 +504,7 @@ The table below covers the metrics reported by `ClippedPGLossFn` (the GRPO/PPO f
 | **Keyed on a different parameter** | `sampling_importance_ratio` follows `sequence_level_importance_ratios`; `is_oob_ratio` is sequence-normalized only for `truncated_importance_sampling_type: seq-mask-tis` |
 | **Not normalized** — raw counts, per-microbatch means, or extrema combined with min/max | `num_valid_samples`, `positive_nll_loss`, `probs_ratio_min`, `probs_ratio_max`, `probs_ratio_clamped_min`, `probs_ratio_clamped_max` |
 
-The authoritative list is the [`metric_normalizations` table in `ClippedPGLossFn`](https://github.com/NVIDIA-NeMo/RL/blob/e98357616c0bb8fb13140841e225583b5cc36b0e/nemo_rl/algorithms/loss/loss_functions.py#L335-L371), which is kept in sync with the metrics the loss returns.
+The authoritative list is the [`metric_normalizations` table in `ClippedPGLossFn`](https://github.com/NVIDIA-NeMo/RL/blob/4a1454bf430624786251d14ba0197169c8e68a5c/nemo_rl/algorithms/loss/loss_functions.py#L335-L371), which is kept in sync with the metrics the loss returns.
 
 #### Choosing a setting
 

--- a/docs/guides/grpo.md
+++ b/docs/guides/grpo.md
@@ -432,19 +432,19 @@ where:
 
 ### Loss Normalization (`token_level_loss`)
 
-The formulas above are written with a bare expectation $E_t[\cdot]$, which leaves one detail unspecified: the loss is computed per token, but the optimizer needs a single number, so those per-token values have to be averaged. The `token_level_loss` parameter chooses how that average is taken. It does not change the per-token quantity itself — only how the per-token values are combined into the scalar that is differentiated.
+The formulas above are written with a bare expectation $E_t[\cdot]$, which leaves one detail unspecified: the loss is computed per token, but the optimizer needs a single number, so those per-token values have to be averaged. The `token_level_loss` parameter chooses how that average is taken. It does not change the per-token objective itself — only how the per-token values are combined into the scalar that is differentiated.
 
 There are two choices:
 
 - **`token_level_loss: true`** — average over every token in the batch. Every token counts the same, so a response contributes to the update in proportion to how many tokens it has.
 - **`token_level_loss: false`** — average within each response first, then average those per-response values. Every *response* counts the same regardless of length.
 
-Writing $\ell_{i,t}$ for the per-token quantity of token $t$ in response $o_i$, $|o_i|$ for the number of unmasked tokens in that response, and $N$ for the number of valid responses:
+Writing $\ell_{i,t}$ for the per-token objective of token $t$ in response $o_i$ — the quantity inside the expectation in the formula above — $|o_i|$ for the number of unmasked tokens in that response, and $N$ for the number of valid responses:
 
 $$
-L_{\text{token}}(\theta) = -\frac{1}{\sum_{i=1}^{N} |o_i|} \sum_{i=1}^{N} \sum_{t=1}^{|o_i|} \ell_{i,t}
+L_{\text{token}}(\theta) = \frac{1}{\sum_{i=1}^{N} |o_i|} \sum_{i=1}^{N} \sum_{t=1}^{|o_i|} \ell_{i,t}
 \qquad\qquad
-L_{\text{seq}}(\theta) = -\frac{1}{N} \sum_{i=1}^{N} \frac{1}{|o_i|} \sum_{t=1}^{|o_i|} \ell_{i,t}
+L_{\text{seq}}(\theta) = \frac{1}{N} \sum_{i=1}^{N} \frac{1}{|o_i|} \sum_{t=1}^{|o_i|} \ell_{i,t}
 $$
 
 Both denominators — $\sum_i |o_i|$ and $N$ — are counts over the whole global batch, not over a single microbatch. Each microbatch divides by the global count and contributes a partial sum, so the microbatch losses can simply be summed to recover the global-batch loss. See [Loss Functions](../design-docs/loss-functions.md) for how that normalization factor is computed and passed in.
@@ -464,14 +464,14 @@ That is arithmetic, not a recommendation — which weighting is preferable depen
 
 `token_level_loss` lives on `ClippedPGLossFn`, the loss shared by the policy-gradient algorithms. The table below writes out the full objective for each one under both settings. To keep the expressions readable they show the base objective only; optional terms — the KL penalty, dual clipping (`ratio_clip_c`), and the importance-sampling correction (`use_importance_sampling_correction`) — are applied on top of it and are documented in the sections that follow.
 
-Throughout, $r_{i,t} = \frac{\pi_\theta(o_{i,t})}{\pi_{\theta_{\text{old}}}(o_{i,t})}$ is the per-token probability ratio, $A_i$ is the advantage for response $i$, $\text{sg}(\cdot)$ is the stop-gradient operator, and $\varepsilon_{\text{low}}$/$\varepsilon_{\text{high}}$ are `ratio_clip_min`/`ratio_clip_max`.
+Throughout, $r_{i,t} = \frac{\pi_\theta(o_{i,t})}{\pi_{\theta_{\text{old}}}(o_{i,t})}$ is the per-token probability ratio, $A_i$ is the advantage for response $i$, $\text{sg}(\cdot)$ is the stop-gradient operator, and $\varepsilon_{\text{low}}$, $\varepsilon_{\text{high}}$ are `ratio_clip_min`/`ratio_clip_max`.
 
 | Algorithm | `token_level_loss: true` | `token_level_loss: false` |
 | --- | --- | --- |
-| **GRPO / PPO / DAPO** | $-\frac{1}{\sum_i \lvert o_i\rvert} \sum_i \sum_t \min\big(r_{i,t} A_i,\ \text{clip}(r_{i,t}, 1-\varepsilon_{\text{low}}, 1+\varepsilon_{\text{high}}) A_i\big)$ | $-\frac{1}{N} \sum_i \frac{1}{\lvert o_i\rvert} \sum_t \min\big(r_{i,t} A_i,\ \text{clip}(r_{i,t}, 1-\varepsilon_{\text{low}}, 1+\varepsilon_{\text{high}}) A_i\big)$ |
-| **CISPO** (`use_cispo: true`) | $-\frac{1}{\sum_i \lvert o_i\rvert} \sum_i \sum_t \text{sg}\big(\text{clip}(r_{i,t}, 1-\varepsilon_{\text{low}}, 1+\varepsilon_{\text{high}})\big) A_i \log \pi_\theta(o_{i,t})$ | Not available — rejected at construction time, because CISPO is defined per token. |
-| **GSPO** (`sequence_level_importance_ratios: true`) | Not available — rejected at construction time, because the sequence-level ratio is mutually exclusive with token-level reduction. | $-\frac{1}{N} \sum_i \frac{1}{\lvert o_i\rvert} \sum_t \min\big(s_i A_i,\ \text{clip}(s_i, 1-\varepsilon_{\text{low}}, 1+\varepsilon_{\text{high}}) A_i\big)$, where $s_i = \Big(\frac{\pi_\theta(o_i)}{\pi_{\theta_{\text{old}}}(o_i)}\Big)^{1/\lvert o_i\rvert}$ |
-| **REINFORCE / RLOO** (`disable_ppo_ratio: true`) | $-\frac{1}{\sum_i \lvert o_i\rvert} \sum_i \sum_t A_i \log \pi_\theta(o_{i,t})$ | $-\frac{1}{N} \sum_i \frac{1}{\lvert o_i\rvert} \sum_t A_i \log \pi_\theta(o_{i,t})$ |
+| **GRPO / PPO / DAPO** | $\frac{1}{\sum_i \lvert o_i\rvert} \sum_i \sum_t \min\big(r_{i,t} A_i,\ \text{clip}(r_{i,t}, 1-\varepsilon_{\text{low}}, 1+\varepsilon_{\text{high}}) A_i\big)$ | $\frac{1}{N} \sum_i \frac{1}{\lvert o_i\rvert} \sum_t \min\big(r_{i,t} A_i,\ \text{clip}(r_{i,t}, 1-\varepsilon_{\text{low}}, 1+\varepsilon_{\text{high}}) A_i\big)$ |
+| **CISPO** (`use_cispo: true`) | $\frac{1}{\sum_i \lvert o_i\rvert} \sum_i \sum_t \text{sg}\big(\text{clip}(r_{i,t}, 1-\varepsilon_{\text{low}}, 1+\varepsilon_{\text{high}})\big) A_i \log \pi_\theta(o_{i,t})$ | Not available — rejected at construction time, because CISPO is defined per token. |
+| **GSPO** (`sequence_level_importance_ratios: true`) | Not available — rejected at construction time, because the sequence-level ratio is mutually exclusive with token-level reduction. | $\frac{1}{N} \sum_i \frac{1}{\lvert o_i\rvert} \sum_t \min\big(s_i A_i,\ \text{clip}(s_i, 1-\varepsilon_{\text{low}}, 1+\varepsilon_{\text{high}}) A_i\big)$, where $s_i = \Big(\frac{\pi_\theta(o_i)}{\pi_{\theta_{\text{old}}}(o_i)}\Big)^{1/\lvert o_i\rvert}$ |
+| **REINFORCE / RLOO** (`disable_ppo_ratio: true`) | $\frac{1}{\sum_i \lvert o_i\rvert} \sum_i \sum_t A_i \log \pi_\theta(o_{i,t})$ | $\frac{1}{N} \sum_i \frac{1}{\lvert o_i\rvert} \sum_t A_i \log \pi_\theta(o_{i,t})$ |
 
 Two notes on the table:
 

--- a/docs/guides/grpo.md
+++ b/docs/guides/grpo.md
@@ -430,6 +430,90 @@ where:
 - c is the dual-clip parameter (ratio_clip_c), which must be greater than 1 and is usually set to 3 empirically.
 - $r_t(\theta)$ is the ratio $\frac{\pi_\theta(x)}{\pi_{\theta_{\text{old}}}(x)}$ that measures how much the policy has changed.
 
+### Loss Normalization (`token_level_loss`)
+
+The formulas above are written with a bare expectation $E_t[\cdot]$, which leaves one detail unspecified: the loss is computed per token, but the optimizer needs a single number, so those per-token values have to be averaged. The `token_level_loss` parameter chooses how that average is taken. It does not change the per-token quantity itself — only how the per-token values are combined into the scalar that is differentiated.
+
+There are two choices:
+
+- **`token_level_loss: true`** — average over every token in the batch. Every token counts the same, so a response contributes to the update in proportion to how many tokens it has.
+- **`token_level_loss: false`** — average within each response first, then average those per-response values. Every *response* counts the same regardless of length.
+
+Writing $\ell_{i,t}$ for the per-token quantity of token $t$ in response $o_i$, $|o_i|$ for the number of unmasked tokens in that response, and $N$ for the number of valid responses:
+
+$$
+L_{\text{token}}(\theta) = -\frac{1}{\sum_{i=1}^{N} |o_i|} \sum_{i=1}^{N} \sum_{t=1}^{|o_i|} \ell_{i,t}
+\qquad\qquad
+L_{\text{seq}}(\theta) = -\frac{1}{N} \sum_{i=1}^{N} \frac{1}{|o_i|} \sum_{t=1}^{|o_i|} \ell_{i,t}
+$$
+
+Both denominators — $\sum_i |o_i|$ and $N$ — are counts over the whole global batch, not over a single microbatch. Each microbatch divides by the global count and contributes a partial sum, so the microbatch losses can simply be summed to recover the global-batch loss. See [Loss Functions](../design-docs/loss-functions.md) for how that normalization factor is computed and passed in.
+
+The same choice also normalizes the KL penalty term, so `reference_policy_kl_penalty` is applied on whichever scale you select.
+
+#### An example of what this changes
+
+Consider a batch of two responses — one 10 tokens long, one 1000 tokens long — where every token happens to have the same per-token value:
+
+- Under `token_level_loss: true`, the denominator is $10 + 1000 = 1010$, so the long response accounts for about 99% of the update and the short one about 1%.
+- Under `token_level_loss: false`, each response is averaged over its own length first, so the two contribute 50% each. Per token, that means each token of the short response carries roughly 100× the weight of each token of the long response.
+
+That is arithmetic, not a recommendation — which weighting is preferable depends on the algorithm and the workload. See [Choosing a setting](#choosing-a-setting) below.
+
+#### Objectives under each setting
+
+`token_level_loss` lives on `ClippedPGLossFn`, the loss shared by the policy-gradient algorithms. The table below writes out the full objective for each one under both settings. To keep the expressions readable they show the base objective only; optional terms — the KL penalty, dual clipping (`ratio_clip_c`), and the importance-sampling correction (`use_importance_sampling_correction`) — are applied on top of it and are documented in the sections that follow.
+
+Throughout, $r_{i,t} = \frac{\pi_\theta(o_{i,t})}{\pi_{\theta_{\text{old}}}(o_{i,t})}$ is the per-token probability ratio, $A_i$ is the advantage for response $i$, $\text{sg}(\cdot)$ is the stop-gradient operator, and $\varepsilon_{\text{low}}$/$\varepsilon_{\text{high}}$ are `ratio_clip_min`/`ratio_clip_max`.
+
+| Algorithm | `token_level_loss: true` | `token_level_loss: false` |
+| --- | --- | --- |
+| **GRPO / PPO / DAPO** | $-\frac{1}{\sum_i \lvert o_i\rvert} \sum_i \sum_t \min\big(r_{i,t} A_i,\ \text{clip}(r_{i,t}, 1-\varepsilon_{\text{low}}, 1+\varepsilon_{\text{high}}) A_i\big)$ | $-\frac{1}{N} \sum_i \frac{1}{\lvert o_i\rvert} \sum_t \min\big(r_{i,t} A_i,\ \text{clip}(r_{i,t}, 1-\varepsilon_{\text{low}}, 1+\varepsilon_{\text{high}}) A_i\big)$ |
+| **CISPO** (`use_cispo: true`) | $-\frac{1}{\sum_i \lvert o_i\rvert} \sum_i \sum_t \text{sg}\big(\text{clip}(r_{i,t}, 1-\varepsilon_{\text{low}}, 1+\varepsilon_{\text{high}})\big) A_i \log \pi_\theta(o_{i,t})$ | Not available — rejected at construction time, because CISPO is defined per token. |
+| **GSPO** (`sequence_level_importance_ratios: true`) | Not available — rejected at construction time, because the sequence-level ratio is mutually exclusive with token-level reduction. | $-\frac{1}{N} \sum_i \frac{1}{\lvert o_i\rvert} \sum_t \min\big(s_i A_i,\ \text{clip}(s_i, 1-\varepsilon_{\text{low}}, 1+\varepsilon_{\text{high}}) A_i\big)$, where $s_i = \Big(\frac{\pi_\theta(o_i)}{\pi_{\theta_{\text{old}}}(o_i)}\Big)^{1/\lvert o_i\rvert}$ |
+| **REINFORCE / RLOO** (`disable_ppo_ratio: true`) | $-\frac{1}{\sum_i \lvert o_i\rvert} \sum_i \sum_t A_i \log \pi_\theta(o_{i,t})$ | $-\frac{1}{N} \sum_i \frac{1}{\lvert o_i\rvert} \sum_t A_i \log \pi_\theta(o_{i,t})$ |
+
+Two notes on the table:
+
+- The "not available" cells are enforced by assertions in `ClippedPGLossFn.__init__`, so an incompatible config fails immediately rather than training with a silently different objective.
+- In the GSPO row, $s_i$ does not depend on $t$, so the inner $\frac{1}{\lvert o_i\rvert} \sum_t$ collapses and the objective reduces to one clipped term per response.
+
+#### Losses that do not expose this parameter
+
+`token_level_loss` is a field of `ClippedPGLossConfig` only. Every other loss fixes its normalization as a class attribute, so setting `token_level_loss` in, say, an SFT config has no effect:
+
+| Loss function | Used by | Normalization |
+| --- | --- | --- |
+| `NLLLossFn` | SFT | Token-level |
+| `PreferenceLossFn` / `DPOLossFn` | DPO, RM | Sequence-level |
+| `DistillationLossFn` | On-policy distillation | Token-level |
+| `MseValueLossFn` | PPO critic | Token-level |
+| `CrossTokenizerDistillationLossFn` | Cross-tokenizer distillation | Token-level |
+| `DraftCrossEntropyLossFn` | Eagle3 draft training | Token-level |
+
+#### How metrics are normalized
+
+Some of the metrics logged during training follow `token_level_loss`, and some do not. This matters when comparing runs: switching `token_level_loss` changes the scale of `loss` and `kl_penalty`, but leaves the token-normalized diagnostics directly comparable.
+
+The table below covers the metrics reported by `ClippedPGLossFn` (the GRPO/PPO family). Other algorithms report a different, generally smaller set.
+
+| Behavior | Metrics |
+| --- | --- |
+| **Follows `token_level_loss`** — token-normalized when `true`, sequence-normalized when `false` | `loss`, `kl_penalty` |
+| **Always token-normalized**, regardless of the setting | `probs_ratio`, `probs_ratio_clamped`, `token_mult_prob_error`, `gen_kl_error`, `policy_kl_error`, `js_divergence_error`, `approx_entropy` |
+| **Keyed on a different parameter** | `sampling_importance_ratio` follows `sequence_level_importance_ratios`; `is_oob_ratio` is sequence-normalized only for `truncated_importance_sampling_type: seq-mask-tis` |
+| **Not normalized** — raw counts, per-microbatch means, or extrema combined with min/max | `num_valid_samples`, `positive_nll_loss`, `probs_ratio_min`, `probs_ratio_max`, `probs_ratio_clamped_min`, `probs_ratio_clamped_max` |
+
+The authoritative list is the [`metric_normalizations` table in `ClippedPGLossFn`](https://github.com/NVIDIA-NeMo/RL/blob/e98357616c0bb8fb13140841e225583b5cc36b0e/nemo_rl/algorithms/loss/loss_functions.py#L335-L371), which is kept in sync with the metrics the loss returns.
+
+#### Choosing a setting
+
+For CISPO and GSPO there is nothing to choose — each admits only one setting, as shown above. For vanilla GRPO (and PPO) both are available, and the tradeoff is the weighting described in the example above.
+
+The argument most often made for token-level normalization comes from the [DAPO paper](https://arxiv.org/abs/2503.14476) (§3.3, "Token-Level Policy Gradient Loss"), in the context of long chain-of-thought training. Their reasoning is that under sequence-level normalization, "since all samples are assigned the same weight in the loss calculation, tokens within longer responses (which contain more tokens) may have a disproportionately lower contribution to the overall loss." They argue this cuts both ways: for high-quality long responses, "this effect can impede the model's ability to learn reasoning-relevant patterns within them." For low-quality ones, "excessively long samples often exhibit low-quality patterns such as gibberish and repetitive words. Thus, sample-level loss calculation, due to its inability to effectively penalize those undesirable patterns in long samples, leads to an unhealthy increase in entropy and response length."
+
+This is one reported result on one class of workloads, not a settled rule. The original [GRPO paper](https://arxiv.org/abs/2402.03300) formulates the loss at the sequence level. If response lengths in your workload are fairly uniform, the two settings differ little; the gap widens as the length distribution spreads out. Treat it as a hyperparameter worth sweeping rather than a setting with a known-correct value, and if you change it mid-project, expect the absolute scale of `loss` and `kl_penalty` to shift even when nothing else has.
+
 ### Improvements to the GRPO Loss Formulation for Stability and Accuracy
 
 #### On-Policy KL Approximation

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -203,7 +203,7 @@ class ClippedPGLossFn(LossFunction):
     - KL(π_θ || π_ref) is the KL divergence between the current policy and reference policy (Schulman Approx.)
 
     For REINFORCE/RLOO (when disable_ppo_ratio=True), the formula simplifies to:
-    L(θ) = E_t [ π_θ(a_t|s_t) * A_t ] - β * KL(π_θ || π_ref)
+    L(θ) = E_t [ log π_θ(a_t|s_t) * A_t ] - β * KL(π_θ || π_ref)
 
     Formula (CISPO):
     L(θ) = E_t [ sg(clip(r_t(θ), 1-ε_low, 1+ε_high)) * A_t * log π_θ(a_t|s_t) ]


### PR DESCRIPTION
## What

Closes #1274.

`token_level_loss` had no explanation anywhere in the docs — it appeared only as a bare line in config blocks (`dapo.md`, `cispo.md`, `ppo.md`, `prorlv2.md`) and in ~30 example YAMLs. This adds a **Loss Normalization** section to `docs/guides/grpo.md`, placed under `## Loss` before the "Improvements to the GRPO Loss Formulation" subsections — it is not an optional stability add-on like those, it is a property of the baseline loss that the existing $E_t[\cdot]$ notation leaves unspecified.

## Contents of the new section

- **What it controls.** The reduction applied to the per-token loss, not the per-token quantity itself. The same switch also normalizes the KL penalty, and both denominators are global-batch counts rather than per-microbatch.
- **The two reductions**, written out once, plus a worked example: a 10-token and a 1000-token response give a 99%/1% split under `true` and 50%/50% under `false`, so short-response tokens carry ~100× the per-token weight under sequence-level.
- **Objectives table.** Full objective for GRPO/PPO/DAPO, CISPO, GSPO and REINFORCE/RLOO under both settings. The guide never wrote these objectives out anywhere, so the table does double duty. CISPO and GSPO each have one cell marked unavailable — those combinations are rejected by assertions in `ClippedPGLossFn.__init__`.
- **Losses without this parameter.** `token_level_loss` is a field of `ClippedPGLossConfig` only; SFT, DPO/RM, distillation, the PPO critic, cross-tokenizer distillation and Eagle3 draft training all fix `loss_type` as a class attribute. Setting it in an SFT config does nothing, which is worth saying out loud.
- **Metric normalization.** Which reported metrics follow the flag (`loss`, `kl_penalty`), which are always token-normalized, which key off a *different* parameter (`sampling_importance_ratio`, `is_oob_ratio`), and which are not normalized at all. Relevant when comparing runs across the setting.
- **Choosing a setting.** DAPO §3.3's argument for token-level in long-CoT, quoted rather than paraphrased, and explicitly framed as one reported result rather than a rule — the original GRPO paper formulates the loss at the sequence level, and this repo has no benchmark comparing the two.

## Also in this PR

- **Docstring fix** (`loss_functions.py:206`): the REINFORCE/RLOO objective was written as $E_t[\pi_\theta(a_t|s_t) \cdot A_t]$, but `:541` sets `ratios = curr_logprobs` — the raw log-probability, not `exp()`. The new table is derived from the code, so leaving the docstring disagreeing with it would have been confusing. Corrected to $\log \pi_\theta$.
- **Cross-links** from `dapo.md:86` and `cispo.md:56` to the new section. Those are the two pages where a reader meets this parameter first and currently gets no explanation — the same gap the issue reports.

No changes to `ppo.md` (it already defers wholesale to the GRPO guide) or `docs/index.md` (no new file; `grpo.md` is already in the toctree).

## Verification

The docs build could not be run locally — `uv.lock` only supports Linux and this is macOS — so the MyST-level checks were done directly:

- Heading anchors confirmed against `mdit_py_plugins.anchors.slugify`: `Loss Normalization (\`token_level_loss\`)` → `loss-normalization-token_level_loss`, matching the links from `dapo.md` and `cispo.md`. `myst_heading_anchors = 5` in `conf.py:68` covers the `###`/`####` levels used.
- Parsed the file with `markdown-it-py` + `dollarmath`: all 3 tables parse with the intended cell counts, and all inline/display math tokenizes. Table cells use `\lvert`/`\rvert` rather than bare `|`, which would otherwise split the rows.
- Every formula in the objectives table was read back off the implementation rather than from the papers — GSPO's $s_i$ against `:528-534`, CISPO against `:545`, the clipped surrogate against `:547-551`, REINFORCE against `:541-542`.
- Every row of the "losses without this parameter" table was checked against its actual consumer (`sft.py:229`, `dpo.py:284`, `rm.py:263`, `distillation.py:641`, `ppo.py:377`, `xtoken_off_policy_distillation.py:479`, `wrapper.py:251`).
- The DAPO quotes were pulled from the paper, not recalled.
- `ruff format --check` and `ruff check` pass on the modified Python file.

The permalink to `metric_normalizations` is SHA-pinned rather than `blob/main`, since a line-anchored link to `main` breaks silently as code shifts.
