### PR TITLE
fix(sc): reduce and finalize gradients once per step, not per chunk

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,6 +1,18 @@
 # Debug NeMo RL Applications
 
-This guide explains how to debug NeMo RL applications, covering two scenarios. It first outlines the procedure for debugging distributed Ray worker/actor processes using the Ray Distributed Debugger within a SLURM environment, and then details debugging the main driver script.
+This guide explains how to debug NeMo RL applications. It first covers controlling log verbosity, then outlines the procedure for debugging distributed Ray worker/actor processes using the Ray Distributed Debugger within a SLURM environment, and finally details debugging the main driver script.
+
+## Control Log Verbosity
+
+NeMo RL sets the level of the `nemo_rl` logger from `NRL_LOG_LEVEL`, which defaults to `INFO`. The value must be a standard [`logging` level name](https://docs.python.org/3/library/logging.html#logging-levels): `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`.
+
+```sh
+NRL_LOG_LEVEL=DEBUG uv run examples/run_grpo.py --config examples/configs/grpo_math_1B.yaml
+```
+
+`DEBUG` additionally enables the per-chunk training records and the CUDA allocator samples on the Megatron training path. Those are emitted once per chunk per rank, which is what you want when investigating gradient accumulation or memory growth across a streaming step, and too verbose for a normal run.
+
+The level applies to the `nemo_rl` logger rather than the root logger, so raising it does not also turn on debug output for `torch`, `ray`, and other third-party libraries. Setting it in the driver environment is enough to cover workers: `nemo_rl/__init__.py` runs in Ray workers too, and their records reach the driver log with a `(pid=..., ip=...)` prefix.
 
 ## Debug Worker/Actors on SLURM
 

--- a/nemo_rl/__init__.py
+++ b/nemo_rl/__init__.py
@@ -21,6 +21,24 @@ logging.basicConfig(
     format="%(levelname)s:%(name)s:%(filename)s:%(lineno)d: %(message)s",
 )
 
+# The call above installs the root handler but sets no level, so the root logger
+# stays at WARNING -- and because basicConfig returns early once handlers exist,
+# no later call can raise it (virtual_cluster.py's level=INFO is already a
+# no-op). Every nemo_rl logger inherited that, so until this line no log.info or
+# log.debug record anywhere in the package could reach a run's output, and the
+# instrumentation that emits them was unreachable rather than merely quiet.
+#
+# Set the level on the `nemo_rl` logger rather than on root: records still reach
+# the root handler, but raising the level does not also turn on debug output for
+# torch, ray, httpx and every other third-party logger.
+#
+# INFO by default. That is a change -- it surfaces the package's existing info
+# records, which are ~50 call sites concentrated in venv, cluster and vLLM-patch
+# setup, so they land at startup rather than per step. DEBUG additionally
+# enables the per-chunk and CUDA-allocator records on the training path, which
+# are per chunk per rank and are not meant for a normal run.
+logging.getLogger("nemo_rl").setLevel(os.environ.get("NRL_LOG_LEVEL", "INFO").upper())
+
 """
 This is a work around to ensure whenever NeMo RL is imported, that we
 add Megatron-LM to the python path. The editable install of megatron-core

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -35,6 +35,7 @@ Data flow:
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import time
 from functools import partial
@@ -74,6 +75,10 @@ from nemo_rl.utils.logger import Logger
 from nemo_rl.utils.timer import TimeoutChecker, Timer
 
 Generation = Union[VllmGeneration, SGLangGeneration]
+
+# Named `log` rather than `logger` to keep it distinct from the experiment
+# Logger this module also uses as `self._logger`.
+log = logging.getLogger(__name__)
 
 
 @ray.remote(num_cpus=1, num_gpus=0)  # pragma: no cover
@@ -487,6 +492,7 @@ class SingleControllerActor:
             evicted_stale_prompt_groups = 0
             min_sample_version = None
             step_open = False
+            chunks_dispatched = 0
             calibration_batches: list[BatchedDataDict[Any]] = []
 
             with self._timer.time("total_step_time"):
@@ -554,8 +560,15 @@ class SingleControllerActor:
                         or self._reference_logprobs_required
                     ):
                         with self._timer.time("logprob_inference_prep"):
+                            # Once the step is open, gradients are accumulating
+                            # in the trainer's grad buffers across chunks. The
+                            # Megatron buffer offload frees that storage outright
+                            # and its reload zeroes it, so offloading here would
+                            # discard every chunk but the last while the 1/N
+                            # normalizer still counts all of them.
                             await asyncio.to_thread(
-                                self._trainer.prepare_for_lp_inference
+                                self._trainer.prepare_for_lp_inference,
+                                keep_train_buffers=step_open,
                             )
                         with self._timer.time("policy_and_reference_logprobs"):
                             if self._policy_logprobs_required:
@@ -626,7 +639,33 @@ class SingleControllerActor:
                     )
 
                     groups_dispatched += num_groups
+                    chunks_dispatched += 1
+                    # How many chunks a step is split into decides how many times
+                    # gradients accumulate before the single reduce, so record it
+                    # rather than leaving it to be inferred from phase timings.
+                    #
+                    # These reach a run's output only because nemo_rl/__init__.py
+                    # sets the `nemo_rl` logger to NRL_LOG_LEVEL (INFO by
+                    # default); the bare basicConfig() there pins the root logger
+                    # at WARNING and no later basicConfig can raise it. Note that
+                    # the handler writes to stderr while the progress prints
+                    # around this write to stdout, so the two are not guaranteed
+                    # to interleave in order in a Ray driver log.
+                    log.info(
+                        "train_pump: step %d chunk %d: %d group(s), %d/%d dispatched",
+                        version_during_step,
+                        chunks_dispatched,
+                        num_groups,
+                        groups_dispatched,
+                        grpo_cfg.num_prompts_per_step,
+                    )
 
+                log.info(
+                    "train_pump: step %d closing on %d chunk(s), %d group(s)",
+                    version_during_step,
+                    chunks_dispatched,
+                    groups_dispatched,
+                )
                 with self._timer.time("policy_training"):
                     result = await asyncio.to_thread(self._trainer.finish_train_step)
 

--- a/nemo_rl/models/policy/interfaces.py
+++ b/nemo_rl/models/policy/interfaces.py
@@ -241,5 +241,12 @@ class ColocatablePolicyInterface(PolicyInterface):
         raise NotImplementedError
 
     @abstractmethod
-    def prepare_for_lp_inference(self) -> None:
+    def prepare_for_lp_inference(self, keep_train_buffers: bool = False) -> None:
+        """Put the policy in eval mode for logprob inference.
+
+        Args:
+            keep_train_buffers: Leave grad buffers and optimizer state on CUDA
+                because a train step is already open and its accumulated
+                gradients must survive this call.
+        """
         pass

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -951,9 +951,17 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
         futures = self.worker_group.run_all_workers_single_data("prepare_for_training")
         ray.get(futures)
 
-    def prepare_for_lp_inference(self, *args: Any, **kwargs: Any) -> None:
+    def prepare_for_lp_inference(self, keep_train_buffers: bool = False) -> None:
+        """Put every worker in eval mode for logprob inference.
+
+        Args:
+            keep_train_buffers: Leave grad buffers and optimizer state on CUDA.
+                Set this when a train step is already open, so that gradients
+                accumulated by earlier streaming chunks survive; see
+                ``MegatronPolicyWorker.prepare_for_lp_inference``.
+        """
         futures = self.worker_group.run_all_workers_single_data(
-            "prepare_for_lp_inference"
+            "prepare_for_lp_inference", keep_train_buffers=keep_train_buffers
         )
         ray.get(futures)
 

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -1938,7 +1938,16 @@ class DTensorPolicyWorkerImpl(
             self.model = self.move_to_cpu(self.model)
 
     @wrap_with_nvtx_name("dtensor_policy_worker/prepare_for_lp_inference")
-    def prepare_for_lp_inference(self) -> None:
+    def prepare_for_lp_inference(self, keep_train_buffers: bool = False) -> None:
+        """Put the model in eval mode for logprob inference.
+
+        Args:
+            keep_train_buffers: Leave the optimizer state on CUDA because a train
+                step is already open. This backend accumulates gradients in
+                ``param.grad`` and never offloads them, so unlike the Megatron
+                backend there is nothing here that could discard them; the flag
+                only suppresses the per-chunk optimizer round trip.
+        """
         # onload model to cuda
         if not self.cpu_offload:
             self.move_to_cuda(self.model)
@@ -1949,7 +1958,11 @@ class DTensorPolicyWorkerImpl(
 
         # offload optimizer to cpu
         torch.randn(1).cuda()  # wake up torch allocator
-        if self.optimizer is not None and self.offload_optimizer_for_logprob:
+        if (
+            not keep_train_buffers
+            and self.optimizer is not None
+            and self.offload_optimizer_for_logprob
+        ):
             self.move_optimizer_to_device("cpu")
 
         gc.collect()

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -1213,7 +1213,16 @@ class DTensorPolicyWorkerV2Impl(
             self.model = self.move_to_cpu(self.model)
 
     @wrap_with_nvtx_name("dtensor_policy_worker_v2/prepare_for_lp_inference")
-    def prepare_for_lp_inference(self) -> None:
+    def prepare_for_lp_inference(self, keep_train_buffers: bool = False) -> None:
+        """Put the model in eval mode for logprob inference.
+
+        Args:
+            keep_train_buffers: Leave the optimizer state on CUDA because a train
+                step is already open. This backend accumulates gradients in
+                ``param.grad`` and never offloads them, so unlike the Megatron
+                backend there is nothing here that could discard them; the flag
+                only suppresses the per-chunk optimizer round trip.
+        """
         # onload model to cuda
         if not self.cpu_offload:
             self.move_to_cuda(self.model)
@@ -1224,7 +1233,11 @@ class DTensorPolicyWorkerV2Impl(
 
         # offload optimizer to cpu
         torch.randn(1).cuda()  # wake up torch allocator
-        if self.optimizer is not None and self.offload_optimizer_for_logprob:
+        if (
+            not keep_train_buffers
+            and self.optimizer is not None
+            and self.offload_optimizer_for_logprob
+        ):
             self.move_optimizer_to_device("cpu")
 
         gc.collect()

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -1133,12 +1133,17 @@ class MegatronPolicyWorkerImpl(
     #    ``forward_backward_func`` calls between ``optimizer.step()`` would
     #    over-count: each call's terminal reduce sums an already-reduced
     #    bucket again. We wrap every call in ``self.model.no_sync()`` so
-    #    hooks accumulate locally only; one explicit ``start_grad_sync`` +
-    #    ``finish_grad_sync`` at finish does the single true reduce.
-    # 2. PP>1: the pipeline scheduler invokes ``config.grad_sync_func``
-    #    directly on last-microbatch boundaries — this bypasses the
-    #    ``no_sync`` gate. We null it for the duration of the step and
-    #    restore at finish/abort.
+    #    hooks accumulate locally only; the single true reduce happens once at
+    #    finish, inside the relocated ``finalize_model_grads_func`` call
+    #    (preceded by ``start_grad_sync`` when ``overlap_grad_reduce`` is set).
+    # 2. Three ``model.config`` hooks would otherwise fire a reduce mid-step,
+    #    none of them gated by the ``no_sync`` above: ``grad_sync_func`` (the
+    #    PP>1 scheduler calls it directly on last-microbatch boundaries),
+    #    ``no_sync_func`` (the PP=1 schedule runs its last microbatch outside
+    #    it) and ``finalize_model_grads_func`` (end of every
+    #    ``forward_backward_func``, i.e. once per chunk). All three are nulled
+    #    for the duration of the step and restored at finish/abort; see
+    #    ``begin_train_step`` for what each one does.
     # 3. Grad clip is bundled inside ``MegatronOptimizer.step()``; the 1/N
     #    rescale via ``self.model.scale_gradients(1/N)`` must run before
     #    ``optimizer.step()`` so the clip operates on the rescaled grad.
@@ -1286,21 +1291,17 @@ class MegatronPolicyWorkerImpl(
         #                    pair (typically step 2).
         #   finalize_model_grads_func
         #                  — every mcore schedule calls this at the END of each
-        #                    ``forward_backward_func`` invocation (schedules.py,
-        #                    ``if config.finalize_model_grads_func is not None
-        #                    and not forward_only``), so under streaming it fires
-        #                    once per chunk rather than once per step. Nothing we
+        #                    ``forward_backward_func`` invocation, so under
+        #                    streaming it fires once per chunk. Nothing we
         #                    already override gates it: it reaches
-        #                    ``finish_grad_sync()`` directly, and
-        #                    ``model.no_sync()`` only clears
-        #                    ``is_last_microbatch``, which is consulted by
-        #                    ``register_grad_ready`` on the overlap path and
-        #                    ignored by ``finish_grad_sync``. With a distributed
-        #                    optimizer the reduce-scatter also writes into the
-        #                    buffer it reads, leaving this rank's shard DP-summed
-        #                    and the remainder local for the next chunk to
-        #                    accumulate on top of. The real callable runs once,
-        #                    in ``_finish_train_step_body``.
+        #                    ``finish_grad_sync()`` directly, which ignores the
+        #                    ``is_last_microbatch`` flag that ``model.no_sync()``
+        #                    clears. With a distributed optimizer the
+        #                    reduce-scatter also writes into the buffer it reads,
+        #                    leaving this rank's shard DP-summed and the
+        #                    remainder local for the next chunk to accumulate on
+        #                    top of. The real callable runs once, in
+        #                    ``_finish_train_step_body``.
         # Save all three so finish/abort restores them.
         # Read "config" via getattr-by-string so the token stays out of
         # begin_train_step.__code__.co_names; otherwise cloudpickle matches
@@ -1550,55 +1551,44 @@ class MegatronPolicyWorkerImpl(
         # owns more than the cross-DP reduce: the non-tensor-parallel / layernorm
         # all-reduce across TP (sequence parallelism), the tied word-embedding
         # and position-embedding all-reduces across PP, the MoE router
-        # expert-bias update, and reset_model_temporary_tensors. Before this
-        # change those were reached ONLY via the per-chunk call, so dropping the
-        # hook outright would have silently lost all of them.
+        # expert-bias update, and reset_model_temporary_tensors.
         #
-        # ``num_tokens=None`` is deliberate: the 1/N normalization is applied
-        # just above from this path's own accumulated valid-token count, and
-        # mcore rescales only when num_tokens is not None, so passing None is
-        # what avoids double-normalizing.
+        # Both arguments are load-bearing by omission:
+        #   num_tokens=None — mcore rescales only when it is not None, and the
+        #     1/N normalization is already applied just above from this path's
+        #     own accumulated valid-token count.
+        #   no pg_collection — the saved callable is not bare
+        #     ``finalize_model_grads`` but Megatron-Bridge's
+        #     ``partial(finalize_model_grads, pg_collection=...)``
+        #     (bridge/training/setup.py, ``_update_model_config_funcs``), so
+        #     omitting the keyword lets that binding through where supplying one
+        #     would override it. It is group-equivalent to the
+        #     ``_build_default_pg_collection()`` the schedule passed on the
+        #     per-chunk path, down to the ``tp_dp_cp`` field that is the one
+        #     thing finalize_model_grads asserts on, for the expert-bias update.
         #
-        # No ``pg_collection`` keyword, which is not the same as leaving the
-        # parameter at its default: the saved callable is not bare
-        # ``finalize_model_grads`` but Megatron-Bridge's
-        # ``partial(finalize_model_grads, pg_collection=...)``
-        # (bridge/training/setup.py, ``_update_model_config_funcs``), built in
-        # nemo_rl/models/megatron/setup.py from
-        # ``ProcessGroupCollection.use_mpu_process_groups()``. Omitting the
-        # keyword lets that binding through; supplying one would override it,
-        # since an explicit keyword beats a partial's.
-        #
-        # The per-chunk path ran with a different collection object but the same
-        # groups, which is what makes relocating the call safe:
-        # megatron_forward_backward calls forward_backward_func without one, so
-        # the schedule built ``_build_default_pg_collection()`` from
-        # ``parallel_state`` and passed it explicitly, overriding the binding.
-        # Both collections carry the same tp / pp / embd / pos_embd / dp_cp
-        # groups, and both populate ``tp_dp_cp`` — the single field
-        # finalize_model_grads asserts on, for the MoE router expert-bias
-        # update — so recipes that set ``moe_router_enable_expert_bias`` satisfy
-        # it either way.
-        #
-        # ``force_all_reduce`` is genuinely left at its default. The schedule
-        # passes it explicitly, but its default is False on both sides and
-        # nothing in NeMo-RL sets it, so the reduce is dispatched the same way.
-        #
-        # Megatron-core's BucketGroup.finish_grad_sync, when
-        # overlap_grad_reduce=False, internally dispatches the synchronous
-        # collective via start_grad_sync(force_all_reduce=...). On the overlap
-        # path ``model.no_sync()`` stopped register_grad_ready from dispatching,
-        # so there is no outstanding handle for the finalize's finish_grad_sync
-        # to wait on — fire start_grad_sync ourselves in that case only.
+        # Checked before anything is dispatched, and asserted rather than
+        # falling back to a bare ``finish_grad_sync()``: that reduces across DP
+        # and silently skips every other collective listed above, which is wrong
+        # gradients with no error. Bridge binds the hook whenever an optimizer
+        # exists, and an open train step implies one because this method steps it
+        # below, so None here means the model config never went through setup.
+        finalize_model_grads_func = state["saved_finalize_model_grads_func"]
+        assert finalize_model_grads_func is not None, (
+            "finalize_model_grads_func was None at finish_train_step; expected "
+            "Megatron-Bridge's _update_model_config_funcs to have bound it on "
+            "the model config during setup"
+        )
+
+        # With overlap_grad_reduce, ``model.no_sync()`` stopped
+        # register_grad_ready from dispatching, so the finalize's internal
+        # finish_grad_sync has no outstanding handle to wait on — start the
+        # reduce ourselves in that case only.
         if self.cfg["megatron_cfg"]["distributed_data_parallel_config"][
             "overlap_grad_reduce"
         ]:
             self.model.start_grad_sync()
-        finalize_model_grads_func = state.get("saved_finalize_model_grads_func")
-        if finalize_model_grads_func is not None:
-            finalize_model_grads_func([self.model], None)
-        else:
-            self.model.finish_grad_sync()
+        finalize_model_grads_func([self.model], None)
 
         # Wait for the comm-stream reduce dispatched above before opt.step
         # reads main_grad. Without this, grad_norm collapses to ~1/2.
@@ -2891,6 +2881,17 @@ class MegatronPolicyWorkerImpl(
                 only the last chunk's contribution against a 1/N normalizer
                 computed over all of them. Keeping the buffers resident also
                 avoids round-tripping tens of GiB per chunk.
+
+                Suppressing the offload here is sufficient only because of an
+                mcore invariant on the other side of the detour:
+                ``prepare_for_training`` runs before every chunk and reloads with
+                ``move_grads=True``, and ``reload_from_cpu`` resizes and
+                ``zero_()``s the grad buffer only ``if grad_data_size > 0``, a
+                counter set only by a matching ``offload_to_cpu``. With the
+                offload suppressed it stays 0, so the reload is a no-op and
+                the accumulated gradients survive. An mcore change that dropped
+                that guard, or that zeroed unconditionally, would silently
+                reinstate this bug.
         """
         # First worker call after the controller's select() wait returns, so this
         # is also the "idle wait end" marker. Whether the offload was suppressed

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -1174,9 +1174,14 @@ class MegatronPolicyWorkerImpl(
             "all_mb_metrics": [],
             "mb_losses": [],
             "total_num_microbatches": 0,
+            # One increment per train_microbatch call, i.e. the number of
+            # streaming chunks the controller has fed into this optimizer step
+            # so far.
+            "num_chunks": 0,
             # Saved across the step so we can restore at finish/abort.
             "saved_grad_sync_func": None,
             "saved_no_sync_func": None,
+            "saved_finalize_model_grads_func": None,
         }
 
     def _assert_step_open(self) -> dict[str, Any]:
@@ -1187,20 +1192,58 @@ class MegatronPolicyWorkerImpl(
             )
         return state
 
-    def _restore_saved_grad_sync_func(self, state: dict[str, Any]) -> None:
+    def _log_gpu_mem(self, tag: str) -> None:
+        """Emit per-rank CUDA allocator counters for memory forensics.
+
+        The ``max_*`` figures are interval peaks: the peak counters are reset on
+        every call, so each line reports the high-water mark since the previous
+        boundary rather than since process start. ``driver_used`` comes from the
+        driver and therefore includes NCCL's own device allocations, which the
+        torch counters do not see.
+
+        Resetting the peak counters is observable to anything else reading them,
+        so skip the whole body when the level is off rather than sampling and
+        discarding. Run with ``NRL_LOG_LEVEL=DEBUG`` to turn these on.
+
+        Args:
+            tag: Phase-boundary name this sample belongs to.
+        """
+        if not torch.cuda.is_available() or not log.isEnabledFor(logging.DEBUG):
+            return
+        dev = torch.cuda.current_device()
+        gib = float(1024**3)
+        free_b, total_b = torch.cuda.mem_get_info(dev)
+        log.debug(
+            "[gpumem] tag=%s rank=%d alloc=%.2f max_alloc=%.2f reserved=%.2f "
+            "max_reserved=%.2f driver_used=%.2f total=%.2f",
+            tag,
+            self.rank,
+            torch.cuda.memory_allocated(dev) / gib,
+            torch.cuda.max_memory_allocated(dev) / gib,
+            torch.cuda.memory_reserved(dev) / gib,
+            torch.cuda.max_memory_reserved(dev) / gib,
+            (total_b - free_b) / gib,
+            total_b / gib,
+        )
+        torch.cuda.reset_peak_memory_stats(dev)
+
+    def _restore_saved_mcore_hooks(self, state: dict[str, Any]) -> None:
         """Restore the mcore hooks nulled in ``begin_train_step``.
 
-        Restores both ``grad_sync_func`` and ``no_sync_func`` from the
-        saved values on the open-step state. Idempotent on those values;
-        safe to call from the happy-path finish/abort or from a try/except
-        cleanup in train_microbatch / finish_train_step when those raise
-        mid-body. See begin_train_step for why ``.config`` is read via
-        getattr-by-string.
+        Restores ``grad_sync_func``, ``no_sync_func`` and
+        ``finalize_model_grads_func`` from the saved values on the open-step
+        state. Idempotent on those values; safe to call from the happy-path
+        finish/abort or from a try/except cleanup in train_microbatch /
+        finish_train_step when those raise mid-body. See begin_train_step for
+        why ``.config`` is read via getattr-by-string.
         """
         model_config = getattr(self.model, "config", None)
         if model_config is not None:
             model_config.grad_sync_func = state.get("saved_grad_sync_func")
             model_config.no_sync_func = state.get("saved_no_sync_func")
+            model_config.finalize_model_grads_func = state.get(
+                "saved_finalize_model_grads_func"
+            )
 
     @wrap_with_nvtx_name("megatron_policy_worker/begin_train_step")
     def begin_train_step(
@@ -1230,7 +1273,7 @@ class MegatronPolicyWorkerImpl(
 
         state = self._split_step_state_init(loss_fn=loss_fn, gbs=gbs, mbs=mbs)
 
-        # Null both mcore hooks that would fire a mid-step DP reduce:
+        # Null the three mcore hooks that would fire a mid-step DP reduce:
         #   grad_sync_func — PP scheduler's direct call on last-MB boundaries
         #                    (PP>1 path).
         #   no_sync_func   — ``forward_backward_no_pipelining`` (PP=1, the
@@ -1241,7 +1284,24 @@ class MegatronPolicyWorkerImpl(
         #                    ``model.no_sync()`` we apply in train_microbatch,
         #                    triggering an assertion on the next begin/microbatch
         #                    pair (typically step 2).
-        # Save both so finish/abort restores them.
+        #   finalize_model_grads_func
+        #                  — every mcore schedule calls this at the END of each
+        #                    ``forward_backward_func`` invocation (schedules.py,
+        #                    ``if config.finalize_model_grads_func is not None
+        #                    and not forward_only``), so under streaming it fires
+        #                    once per chunk rather than once per step. Nothing we
+        #                    already override gates it: it reaches
+        #                    ``finish_grad_sync()`` directly, and
+        #                    ``model.no_sync()`` only clears
+        #                    ``is_last_microbatch``, which is consulted by
+        #                    ``register_grad_ready`` on the overlap path and
+        #                    ignored by ``finish_grad_sync``. With a distributed
+        #                    optimizer the reduce-scatter also writes into the
+        #                    buffer it reads, leaving this rank's shard DP-summed
+        #                    and the remainder local for the next chunk to
+        #                    accumulate on top of. The real callable runs once,
+        #                    in ``_finish_train_step_body``.
+        # Save all three so finish/abort restores them.
         # Read "config" via getattr-by-string so the token stays out of
         # begin_train_step.__code__.co_names; otherwise cloudpickle matches
         # torch.distributed.config (a non-pickleable ConfigModuleInstance).
@@ -1253,9 +1313,14 @@ class MegatronPolicyWorkerImpl(
             state["saved_no_sync_func"] = getattr(model_config, "no_sync_func", None)
             model_config.grad_sync_func = None
             model_config.no_sync_func = nullcontext
+            state["saved_finalize_model_grads_func"] = getattr(
+                model_config, "finalize_model_grads_func", None
+            )
+            model_config.finalize_model_grads_func = None
         else:
             state["saved_grad_sync_func"] = None
             state["saved_no_sync_func"] = None
+            state["saved_finalize_model_grads_func"] = None
 
         self._train_step_state = state
 
@@ -1277,16 +1342,17 @@ class MegatronPolicyWorkerImpl(
         try:
             self._train_microbatch_body(state, data)
         except Exception:
-            # The body left ``grad_sync_func`` nulled when begin_train_step
-            # opened the step. If we propagate without restoring, future
-            # steps run with the PP scheduler bypass disabled. Restore here;
-            # the caller is still expected to invoke abort_train_step
-            # (idempotent on the saved value) to drop ``_train_step_state``.
+            # The body left all three mcore hooks nulled when begin_train_step
+            # opened the step. If we propagate without restoring, future steps
+            # run with the PP scheduler bypass disabled and with no end-of-step
+            # gradient finalization at all. Restore here; the caller is still
+            # expected to invoke abort_train_step (idempotent on the saved
+            # values) to drop ``_train_step_state``.
             try:
-                self._restore_saved_grad_sync_func(state)
+                self._restore_saved_mcore_hooks(state)
             except Exception:
                 log.exception(
-                    "failed to restore grad_sync_func after train_microbatch error"
+                    "failed to restore mcore hooks after train_microbatch error"
                 )
             raise
 
@@ -1295,6 +1361,8 @@ class MegatronPolicyWorkerImpl(
         state: dict[str, Any],
         data: BatchedDataDict[Any],
     ) -> None:
+        state["num_chunks"] += 1
+        self._log_gpu_mem("chunk_enter")
         loss_fn = state["loss_fn"]
 
         # Accumulate local mask sums for the finish-time all_reduce.
@@ -1314,6 +1382,27 @@ class MegatronPolicyWorkerImpl(
 
         state["local_valid_seqs"] = state["local_valid_seqs"] + call_local_seqs
         state["local_valid_toks"] = state["local_valid_toks"] + call_local_toks
+
+        # The number of chunks per optimizer step is a first-class property of
+        # this path — it decides how many times gradients are accumulated before
+        # a single reduce — but it was previously only recoverable by calibrating
+        # per-phase timer ratios. Log it directly instead. Debug rather than
+        # print because this is per chunk per rank; run with NRL_LOG_LEVEL=DEBUG
+        # to see it. Guarded because the arguments are evaluated at the call site
+        # whether or not the record is emitted, and four of them are ``.item()``
+        # host-device syncs on the critical path. The per-step summary in
+        # ``_finish_train_step_body`` is the always-on one.
+        if log.isEnabledFor(logging.DEBUG):
+            log.debug(
+                "[chunk] chunks=%d rank=%d local_seqs=%.0f local_toks=%.0f "
+                "cum_local_seqs=%.0f cum_local_toks=%.0f",
+                state["num_chunks"],
+                self.rank,
+                call_local_seqs.item(),
+                call_local_toks.item(),
+                state["local_valid_seqs"].item(),
+                state["local_valid_toks"].item(),
+            )
 
         # Build the per-call iterator. Each ``train_microbatches_from_meta``
         # call carries one DP slice; the iterator subdivides into pipeline
@@ -1385,6 +1474,7 @@ class MegatronPolicyWorkerImpl(
 
         if self.cfg["megatron_cfg"]["empty_unused_memory_level"] >= 1:
             torch.cuda.empty_cache()
+        self._log_gpu_mem("chunk_exit")
 
         # Collect per-mb metrics from the last PP stage; broadcast to all
         # PP ranks so non-last-stage ranks have something to all_reduce
@@ -1414,16 +1504,16 @@ class MegatronPolicyWorkerImpl(
         try:
             return self._finish_train_step_body(state)
         except Exception:
-            # Mid-finish failure: state machine is in a partial state and
-            # ``grad_sync_func`` may still be nulled (or restored, depending
-            # on how far the body got). Restore unconditionally so future
-            # steps run with the right config. Leave ``_train_step_state``
-            # for the caller's abort_train_step to clear.
+            # Mid-finish failure: state machine is in a partial state and the
+            # mcore hooks may still be nulled (or restored, depending on how far
+            # the body got). Restore unconditionally so future steps run with
+            # the right config. Leave ``_train_step_state`` for the caller's
+            # abort_train_step to clear.
             try:
-                self._restore_saved_grad_sync_func(state)
+                self._restore_saved_mcore_hooks(state)
             except Exception:
                 log.exception(
-                    "failed to restore grad_sync_func after finish_train_step error"
+                    "failed to restore mcore hooks after finish_train_step error"
                 )
             raise
 
@@ -1453,17 +1543,62 @@ class MegatronPolicyWorkerImpl(
         # Either way, opt.step sees the right-normalized gradient.
         self.model.scale_gradients(inv_n)
 
-        # Cross-DP grad reduce. Megatron-core's BucketGroup.finish_grad_sync,
-        # when overlap_grad_reduce=False, internally dispatches the synchronous
-        # collective via start_grad_sync(force_all_reduce=...). So calling
-        # both unconditionally double-reduces the grads (scales by world_size).
-        # Mirror the contract: only fire start_grad_sync ourselves when the
-        # overlap path needs it; finish_grad_sync handles the rest.
+        # End-of-step gradient finalization, exactly once per optimizer step.
+        # ``begin_train_step`` nulled ``finalize_model_grads_func`` so mcore's
+        # schedule cannot fire it per streaming chunk; the real callable runs
+        # here instead. Relocating it rather than deleting it matters because it
+        # owns more than the cross-DP reduce: the non-tensor-parallel / layernorm
+        # all-reduce across TP (sequence parallelism), the tied word-embedding
+        # and position-embedding all-reduces across PP, the MoE router
+        # expert-bias update, and reset_model_temporary_tensors. Before this
+        # change those were reached ONLY via the per-chunk call, so dropping the
+        # hook outright would have silently lost all of them.
+        #
+        # ``num_tokens=None`` is deliberate: the 1/N normalization is applied
+        # just above from this path's own accumulated valid-token count, and
+        # mcore rescales only when num_tokens is not None, so passing None is
+        # what avoids double-normalizing.
+        #
+        # No ``pg_collection`` keyword, which is not the same as leaving the
+        # parameter at its default: the saved callable is not bare
+        # ``finalize_model_grads`` but Megatron-Bridge's
+        # ``partial(finalize_model_grads, pg_collection=...)``
+        # (bridge/training/setup.py, ``_update_model_config_funcs``), built in
+        # nemo_rl/models/megatron/setup.py from
+        # ``ProcessGroupCollection.use_mpu_process_groups()``. Omitting the
+        # keyword lets that binding through; supplying one would override it,
+        # since an explicit keyword beats a partial's.
+        #
+        # The per-chunk path ran with a different collection object but the same
+        # groups, which is what makes relocating the call safe:
+        # megatron_forward_backward calls forward_backward_func without one, so
+        # the schedule built ``_build_default_pg_collection()`` from
+        # ``parallel_state`` and passed it explicitly, overriding the binding.
+        # Both collections carry the same tp / pp / embd / pos_embd / dp_cp
+        # groups, and both populate ``tp_dp_cp`` — the single field
+        # finalize_model_grads asserts on, for the MoE router expert-bias
+        # update — so recipes that set ``moe_router_enable_expert_bias`` satisfy
+        # it either way.
+        #
+        # ``force_all_reduce`` is genuinely left at its default. The schedule
+        # passes it explicitly, but its default is False on both sides and
+        # nothing in NeMo-RL sets it, so the reduce is dispatched the same way.
+        #
+        # Megatron-core's BucketGroup.finish_grad_sync, when
+        # overlap_grad_reduce=False, internally dispatches the synchronous
+        # collective via start_grad_sync(force_all_reduce=...). On the overlap
+        # path ``model.no_sync()`` stopped register_grad_ready from dispatching,
+        # so there is no outstanding handle for the finalize's finish_grad_sync
+        # to wait on — fire start_grad_sync ourselves in that case only.
         if self.cfg["megatron_cfg"]["distributed_data_parallel_config"][
             "overlap_grad_reduce"
         ]:
             self.model.start_grad_sync()
-        self.model.finish_grad_sync()
+        finalize_model_grads_func = state.get("saved_finalize_model_grads_func")
+        if finalize_model_grads_func is not None:
+            finalize_model_grads_func([self.model], None)
+        else:
+            self.model.finish_grad_sync()
 
         # Wait for the comm-stream reduce dispatched above before opt.step
         # reads main_grad. Without this, grad_norm collapses to ~1/2.
@@ -1487,8 +1622,33 @@ class MegatronPolicyWorkerImpl(
         if self.cfg["megatron_cfg"]["empty_unused_memory_level"] >= 2:
             torch.cuda.empty_cache()
 
-        # Restore grad_sync_func before scheduler.step / further state.
-        self._restore_saved_grad_sync_func(state)
+        # Pair this step's chunk count with the gradient norm it produced on one
+        # line. Any dependence of grad_norm on chunks is a bug in the streaming
+        # accumulation, so making the two directly greppable together is the
+        # cheapest way to keep that testable.
+        #
+        # Info, so it is on in a default run: nemo_rl/__init__.py sets the
+        # `nemo_rl` logger to NRL_LOG_LEVEL, which defaults to INFO. Rank 0 only
+        # -- every field is uniform across ranks by this point (both counters are
+        # DP all_reduced, grad_norm is reduced across the model-parallel group),
+        # so the other ranks would contribute duplicate lines and two
+        # host-device syncs each.
+        if self.rank == 0:
+            log.info(
+                "[step] chunks=%d microbatches=%d global_valid_seqs=%.0f "
+                "global_valid_toks=%.0f grad_norm=%s",
+                state["num_chunks"],
+                state["total_num_microbatches"],
+                global_valid_seqs.item(),
+                global_valid_toks.item(),
+                grad_norm,
+            )
+        # Last worker call before the controller re-enters the select() wait, so
+        # this is also the "idle wait start" marker.
+        self._log_gpu_mem("step_finish")
+
+        # Restore the mcore hooks before scheduler.step / further state.
+        self._restore_saved_mcore_hooks(state)
 
         # Capture lr/wd BEFORE scheduler.step so the per-mb metrics carry
         # the value of THIS step, not the next one. (terrykong, #2683:832).
@@ -1601,9 +1761,9 @@ class MegatronPolicyWorkerImpl(
         state = getattr(self, "_train_step_state", None)
         if state is None:
             return
-        # Restore grad_sync_func first so the model is back to a normal
+        # Restore the mcore hooks first so the model is back to a normal
         # state before zero_grad_buffer touches anything.
-        self._restore_saved_grad_sync_func(state)
+        self._restore_saved_mcore_hooks(state)
         self.model.zero_grad_buffer()
         self.optimizer.zero_grad()
         self._train_step_state = None
@@ -2715,19 +2875,47 @@ class MegatronPolicyWorkerImpl(
             post_iter_func=lambda x: x[1].contiguous(),
         )
 
-    def prepare_for_lp_inference(self):
+    def prepare_for_lp_inference(self, keep_train_buffers: bool = False) -> None:
+        """Put the model in eval mode for logprob inference.
+
+        Args:
+            keep_train_buffers: Leave the grad buffers and the optimizer state on
+                CUDA. Set this when a train step is already open. mcore's
+                ``_ParamAndGradBuffer.offload_to_cpu(move_grads=True)`` does not
+                copy gradients anywhere — it calls
+                ``grad_data.storage().resize_(0)``, freeing them — and the
+                matching ``reload_from_cpu`` resizes the storage back and
+                ``zero_()``s it. ``param.main_grad`` stays a valid view of that
+                storage throughout, so nothing raises: the gradients accumulated
+                by earlier streaming chunks of this step are simply gone, leaving
+                only the last chunk's contribution against a 1/N normalizer
+                computed over all of them. Keeping the buffers resident also
+                avoids round-tripping tens of GiB per chunk.
+        """
+        # First worker call after the controller's select() wait returns, so this
+        # is also the "idle wait end" marker. Whether the offload was suppressed
+        # is the difference between accumulating gradients across chunks and
+        # discarding all but the last, so it is worth a line.
+        log.debug(
+            "[lp_prep] rank=%d keep_train_buffers=%s",
+            self.rank,
+            keep_train_buffers,
+        )
+        self._log_gpu_mem("lp_prep_enter")
         self.model = self.move_model(self.model, "cuda", move_grads=False)
         self.model.eval()
 
-        # offload grads to cpu
-        self.model = self.move_model(
-            self.model, "cpu", move_params=False, move_grads=True
-        )  # get rid of grad buffers
+        if not keep_train_buffers:
+            # offload grads to cpu
+            self.model = self.move_model(
+                self.model, "cpu", move_params=False, move_grads=True
+            )  # get rid of grad buffers
 
         # offload optimizer to cpu
         torch.randn(1).cuda()  # wake up torch allocator
         if (
-            hasattr(self, "optimizer")
+            not keep_train_buffers
+            and hasattr(self, "optimizer")
             and self.optimizer is not None
             and not self.optimizer_cpu_offload
             and self.offload_optimizer_for_logprob
@@ -2736,6 +2924,7 @@ class MegatronPolicyWorkerImpl(
 
         gc.collect()
         torch.cuda.empty_cache()
+        self._log_gpu_mem("lp_prep_exit")
 
     def prepare_for_training(self, *args, **kwargs):
         # onload models and optimizer state to cuda
@@ -2755,6 +2944,10 @@ class MegatronPolicyWorkerImpl(
 
         if self.cfg["megatron_cfg"]["empty_unused_memory_level"] >= 1:
             torch.cuda.empty_cache()
+        # The interval peak reported here covers the logprob phase and the
+        # grad/optimizer onload, which is the figure that decides whether keeping
+        # the train buffers resident fits in HBM.
+        self._log_gpu_mem("train_prep_exit")
 
     def finish_inference(self) -> None:
         """Offload model params to CPU after inference. Only used in PPO."""

--- a/tests/unit/models/policy/test_dtensor_worker.py
+++ b/tests/unit/models/policy/test_dtensor_worker.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import pprint
+from unittest.mock import MagicMock
 
 import pytest
 import ray
@@ -33,9 +34,13 @@ from tests.unit.test_utils import SimpleLossFn
 class _FakeTrainableModel:
     def __init__(self):
         self.train_called = False
+        self.eval_called = False
 
     def train(self):
         self.train_called = True
+
+    def eval(self):
+        self.eval_called = True
 
 
 def test_dtensor_prepare_for_training_restores_optimizer(monkeypatch):
@@ -61,6 +66,47 @@ def test_dtensor_prepare_for_training_restores_optimizer(monkeypatch):
 
     assert model.train_called
     assert restored_devices == ["cuda"]
+
+
+@pytest.mark.parametrize("keep_train_buffers", [False, True])
+def test_dtensor_prepare_for_lp_inference_keep_train_buffers(
+    monkeypatch, keep_train_buffers
+):
+    """``keep_train_buffers`` suppresses the optimizer offload and nothing else.
+
+    ``True`` is not reachable from a dtensor run today -- the split train API
+    that leaves a step open (begin_train_step / train_microbatch /
+    finish_train_step) exists only on the Megatron worker -- but the branch is
+    here, so pin it: inverted, it would strand the optimizer on CPU for the rest
+    of the step.
+    """
+    from nemo_rl.models.policy.workers.dtensor_policy_worker import (
+        DTensorPolicyWorkerImpl,
+    )
+
+    worker = object.__new__(DTensorPolicyWorkerImpl)
+    model = _FakeTrainableModel()
+    offloaded_devices = []
+
+    worker.model = model
+    worker.optimizer = object()
+    worker.cpu_offload = False
+    worker.offload_optimizer_for_logprob = True
+    worker.move_to_cuda = lambda model: model
+    worker.move_optimizer_to_device = lambda device: offloaded_devices.append(device)
+
+    monkeypatch.setattr(torch.cuda.nvtx, "range_push", lambda _name: None)
+    monkeypatch.setattr(torch.cuda.nvtx, "range_pop", lambda: None)
+    monkeypatch.setattr(torch.cuda, "empty_cache", lambda: None)
+    # The allocator wake-up is a real ``.cuda()`` call; keep this test CPU-only.
+    monkeypatch.setattr(torch, "randn", lambda *args, **kwargs: MagicMock())
+
+    DTensorPolicyWorkerImpl.prepare_for_lp_inference(
+        worker, keep_train_buffers=keep_train_buffers
+    )
+
+    assert model.eval_called
+    assert offloaded_devices == ([] if keep_train_buffers else ["cpu"])
 
 
 def create_test_config(

--- a/tests/unit/models/policy/test_dtensor_worker_v2.py
+++ b/tests/unit/models/policy/test_dtensor_worker_v2.py
@@ -46,9 +46,13 @@ except ImportError:
 class _FakeTrainableModel:
     def __init__(self):
         self.train_called = False
+        self.eval_called = False
 
     def train(self):
         self.train_called = True
+
+    def eval(self):
+        self.eval_called = True
 
 
 @pytest.mark.automodel
@@ -72,6 +76,45 @@ def test_dtensor_v2_prepare_for_training_restores_optimizer(monkeypatch):
 
     assert model.train_called
     assert restored_devices == ["cuda"]
+
+
+@pytest.mark.automodel
+@pytest.mark.skipif(not NEMO_AUTOMODEL_AVAILABLE, reason="nemo_automodel not available")
+@pytest.mark.parametrize("keep_train_buffers", [False, True])
+def test_dtensor_v2_prepare_for_lp_inference_keep_train_buffers(
+    monkeypatch, keep_train_buffers
+):
+    """``keep_train_buffers`` suppresses the optimizer offload and nothing else.
+
+    ``True`` is not reachable from a dtensor run today -- the split train API
+    that leaves a step open (begin_train_step / train_microbatch /
+    finish_train_step) exists only on the Megatron worker -- but the branch is
+    here, so pin it: inverted, it would strand the optimizer on CPU for the rest
+    of the step.
+    """
+    worker = object.__new__(DTensorPolicyWorkerV2Impl)
+    model = _FakeTrainableModel()
+    offloaded_devices = []
+
+    worker.model = model
+    worker.optimizer = object()
+    worker.cpu_offload = False
+    worker.offload_optimizer_for_logprob = True
+    worker.move_to_cuda = lambda model: model
+    worker.move_optimizer_to_device = lambda device: offloaded_devices.append(device)
+
+    monkeypatch.setattr(torch.cuda.nvtx, "range_push", lambda _name: None)
+    monkeypatch.setattr(torch.cuda.nvtx, "range_pop", lambda: None)
+    monkeypatch.setattr(torch.cuda, "empty_cache", lambda: None)
+    # The allocator wake-up is a real ``.cuda()`` call; keep this test CPU-only.
+    monkeypatch.setattr(torch, "randn", lambda *args, **kwargs: MagicMock())
+
+    DTensorPolicyWorkerV2Impl.prepare_for_lp_inference(
+        worker, keep_train_buffers=keep_train_buffers
+    )
+
+    assert model.eval_called
+    assert offloaded_devices == ([] if keep_train_buffers else ["cpu"])
 
 
 @pytest.mark.automodel

--- a/tests/unit/models/policy/test_megatron_split_state.py
+++ b/tests/unit/models/policy/test_megatron_split_state.py
@@ -27,10 +27,25 @@ The bugs these catch:
   - ``zero_grad_buffer`` not called at begin (mcore's contiguous grad
     buffer leaks stale grads otherwise).
   - off-by-one in ``total_num_microbatches`` (used to scale MoE aux-loss).
+  - ``finalize_model_grads_func`` firing once per streaming chunk instead of
+    once per optimizer step. mcore's schedule calls it at the end of every
+    ``forward_backward_func``, so under streaming it reduces a partially
+    accumulated buffer N times; with a distributed optimizer the reduce-scatter
+    also writes into the buffer it reads, so later chunks accumulate on top of
+    an already-DP-summed shard.
+  - the same hook being dropped rather than relocated, which would silently
+    lose the TP layernorm all-reduce, the tied embedding all-reduces across PP,
+    the MoE router expert-bias update, and reset_model_temporary_tensors.
+  - the relocated finalize being passed a ``num_tokens``, which would rescale
+    on top of this path's own 1/N normalization.
+  - ``prepare_for_lp_inference`` offloading grad buffers mid-step, which frees
+    (not copies) every earlier chunk's gradients while the 1/N normalizer still
+    counts them.
 """
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -65,6 +80,11 @@ def _make_mock_model():
     model = MagicMock()
     model.config = MagicMock()
     model.config.grad_sync_func = "ORIGINAL_GRAD_SYNC_FUNC"  # sentinel
+    # Set explicitly rather than letting MagicMock auto-create it: the finish
+    # path branches on whether this was saved as None, so an auto-attribute
+    # would silently pick the finalize branch in tests meaning to cover the
+    # fallback.
+    model.config.finalize_model_grads_func = MagicMock(name="ORIGINAL_FINALIZE")
     model.config.num_moe_experts = None  # disable MoE branch
     # no_sync() is a context manager — return a MagicMock that supports
     # __enter__/__exit__ so the `with self.model.no_sync():` block works.
@@ -125,6 +145,13 @@ def _make_worker(loss_type):
     w.dtype = torch.float32
     w._is_reward_model = False
     w._router_replay_enabled = False
+    # Normally set from get_rank_safe() in __init__, which object.__new__ skips.
+    # The step summary in finish_train_step reads it eagerly to decide whether
+    # this rank prints.
+    w.rank = 0
+    # Pure telemetry, and it resets the CUDA peak counters — keep it out of the
+    # way so these tests stay hermetic on GPU shards.
+    w._log_gpu_mem = MagicMock()
 
     # Stash a loss_fn with the requested loss_type for tests that need one.
     w._test_loss_fn = MagicMock(loss_type=loss_type)
@@ -425,7 +452,44 @@ class TestFinish:
         self, mock_module_symbols, overlap_grad_reduce
     ):
         """Call order matters: scale_gradients -> [start_grad_sync when
-        overlap=True] -> finish_grad_sync -> optimizer.step.
+        overlap=True] -> finalize_model_grads_func -> optimizer.step.
+
+        The relocated finalize owns the cross-DP reduce (it reaches
+        finish_grad_sync itself), so this path must NOT also call
+        finish_grad_sync — that would double-reduce. On the overlap path
+        ``model.no_sync()`` suppressed register_grad_ready's dispatch, so there
+        is no outstanding handle for the finalize to wait on and start_grad_sync
+        has to fire first.
+        """
+        from nemo_rl.algorithms.loss.interfaces import LossType
+
+        w = self._setup_open_step(mock_module_symbols, LossType.TOKEN_LEVEL)
+        w.cfg["megatron_cfg"]["distributed_data_parallel_config"][
+            "overlap_grad_reduce"
+        ] = overlap_grad_reduce
+        # Record call order via a shared list
+        order: list[str] = []
+        w.model.scale_gradients.side_effect = lambda s: order.append("scale")
+        w.model.start_grad_sync.side_effect = lambda: order.append("start_sync")
+        w.model.finish_grad_sync.side_effect = lambda: order.append("finish_sync")
+        w._train_step_state["saved_finalize_model_grads_func"] = (
+            lambda models, num_tokens: order.append("finalize")
+        )
+        w.optimizer.step.side_effect = lambda: (
+            order.append("opt_step") or (True, 0.5, 0)
+        )
+        w.finish_train_step()
+        if overlap_grad_reduce:
+            assert order == ["scale", "start_sync", "finalize", "opt_step"]
+        else:
+            assert order == ["scale", "finalize", "opt_step"]
+
+    @pytest.mark.parametrize("overlap_grad_reduce", [False, True])
+    def test_grad_sync_falls_back_to_finish_grad_sync_without_finalize_hook(
+        self, mock_module_symbols, overlap_grad_reduce
+    ):
+        """When mcore never had a finalize hook there is nothing to relocate,
+        so the reduce must still happen via finish_grad_sync directly.
 
         With overlap=False, Megatron's finish_grad_sync internally calls
         start_grad_sync(force_all_reduce=True), so calling start_grad_sync
@@ -437,7 +501,7 @@ class TestFinish:
         w.cfg["megatron_cfg"]["distributed_data_parallel_config"][
             "overlap_grad_reduce"
         ] = overlap_grad_reduce
-        # Record call order via a shared list
+        w._train_step_state["saved_finalize_model_grads_func"] = None
         order: list[str] = []
         w.model.scale_gradients.side_effect = lambda s: order.append("scale")
         w.model.start_grad_sync.side_effect = lambda: order.append("start_sync")
@@ -727,3 +791,372 @@ class TestGradSyncFuncLifecycle:
         w.train_microbatch(_fake_batch())
         w.finish_train_step()
         assert w.model.config.grad_sync_func is None
+
+
+# ── finalize_model_grads_func: once per STEP, not per chunk ──────────────
+
+
+class TestFinalizeModelGradsOncePerStep:
+    """The streaming train path feeds N chunks into one optimizer step.
+
+    mcore calls ``finalize_model_grads_func`` at the end of every
+    ``forward_backward_func``, so left alone it fires N times per step. These
+    tests pin the relocation: nulled for the step's duration, invoked exactly
+    once at finish, restored afterwards.
+    """
+
+    def test_begin_saves_and_nulls_the_hook(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        sentinel = w.model.config.finalize_model_grads_func
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        assert w.model.config.finalize_model_grads_func is None
+        assert w._train_step_state["saved_finalize_model_grads_func"] is sentinel
+
+    def test_hook_stays_nulled_across_every_chunk(self, mock_module_symbols):
+        """The whole point: while chunks are being dispatched, mcore's schedule
+        must find no hook to call."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        sentinel = w.model.config.finalize_model_grads_func
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        for _ in range(4):
+            w.train_microbatch(_fake_batch())
+            assert w.model.config.finalize_model_grads_func is None
+        sentinel.assert_not_called()
+
+    @pytest.mark.parametrize("num_chunks", [1, 2, 5])
+    def test_called_exactly_once_regardless_of_chunk_count(
+        self, mock_module_symbols, num_chunks
+    ):
+        """The regression this branch exists to prevent: one reduce per step,
+        whether the step arrived as 1 chunk or 5."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        sentinel = w.model.config.finalize_model_grads_func
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        for _ in range(num_chunks):
+            w.train_microbatch(_fake_batch())
+        w.finish_train_step()
+        assert sentinel.call_count == 1
+
+    def test_called_with_model_list_and_no_num_tokens(self, mock_module_symbols):
+        """``num_tokens=None`` is load-bearing: this path already applied 1/N
+        from its own accumulated valid-token count, and mcore rescales only when
+        num_tokens is not None. Passing a count would double-normalize."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        sentinel = w.model.config.finalize_model_grads_func
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.train_microbatch(_fake_batch())
+        w.finish_train_step()
+        args, kwargs = sentinel.call_args
+        assert args[0] == [w.model]
+        assert args[1] is None
+        # No keywords at all, which is what keeps Megatron-Bridge's
+        # ``partial(finalize_model_grads, pg_collection=...)`` binding intact —
+        # an explicit keyword here would override it. See the note at the call
+        # site for why that binding is group-equivalent to the collection the
+        # schedule used to pass on the per-chunk path.
+        assert kwargs == {}
+
+    def test_does_not_also_call_finish_grad_sync(self, mock_module_symbols):
+        """finalize reaches finish_grad_sync internally, so calling both
+        double-reduces (scales grads by world_size)."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.train_microbatch(_fake_batch())
+        w.finish_train_step()
+        w.model.finish_grad_sync.assert_not_called()
+
+    def test_runs_after_rescale_and_before_optimizer_step(self, mock_module_symbols):
+        """The 1/N rescale must land on the local buffer before the reduce, and
+        the reduce before opt.step reads main_grad."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        order: list[str] = []
+        w.model.scale_gradients.side_effect = lambda s: order.append("scale")
+        w.model.config.finalize_model_grads_func = MagicMock(
+            side_effect=lambda models, num_tokens: order.append("finalize")
+        )
+        w.optimizer.step.side_effect = lambda: (
+            order.append("opt_step") or (True, 0.5, 0)
+        )
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.train_microbatch(_fake_batch())
+        w.finish_train_step()
+        assert order == ["scale", "finalize", "opt_step"]
+
+    def test_finish_restores_the_hook(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        sentinel = w.model.config.finalize_model_grads_func
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.train_microbatch(_fake_batch())
+        w.finish_train_step()
+        assert w.model.config.finalize_model_grads_func is sentinel
+
+    def test_abort_restores_the_hook(self, mock_module_symbols):
+        """Otherwise a subsequent sync train() would run with no finalize at
+        all — no cross-DP reduce, no embedding all-reduce."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        sentinel = w.model.config.finalize_model_grads_func
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.train_microbatch(_fake_batch())
+        w.abort_train_step()
+        assert w.model.config.finalize_model_grads_func is sentinel
+
+    def test_abort_does_not_call_the_hook(self, mock_module_symbols):
+        """An aborted step throws its gradients away; reducing them would leak
+        a partial step into the next one."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        sentinel = w.model.config.finalize_model_grads_func
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.train_microbatch(_fake_batch())
+        w.abort_train_step()
+        sentinel.assert_not_called()
+
+    def test_handles_originally_none_hook(self, mock_module_symbols):
+        """PP=1 without a custom finalize: begin → finish must leave it None and
+        fall back to finish_grad_sync for the reduce."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.model.config.finalize_model_grads_func = None
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.train_microbatch(_fake_batch())
+        w.finish_train_step()
+        assert w.model.config.finalize_model_grads_func is None
+        w.model.finish_grad_sync.assert_called_once()
+
+    def test_two_consecutive_steps_each_finalize_once(self, mock_module_symbols):
+        """Restore-then-null across step boundaries must not lose the hook or
+        double up on it."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        sentinel = w.model.config.finalize_model_grads_func
+        for _ in range(2):
+            w.begin_train_step(loss_fn=w._test_loss_fn)
+            w.train_microbatch(_fake_batch())
+            w.train_microbatch(_fake_batch())
+            w.finish_train_step()
+        assert sentinel.call_count == 2
+        assert w.model.config.finalize_model_grads_func is sentinel
+
+
+# ── num_chunks ───────────────────────────────────────────────────────────
+
+
+class TestNumChunks:
+    """``num_chunks`` records how many chunks accumulated into the step, which
+    is what makes "did the grads get reduced once or N times" greppable from a
+    run's logs rather than inferable from timer ratios."""
+
+    def test_starts_at_zero(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        assert w._train_step_state["num_chunks"] == 0
+
+    def test_increments_once_per_train_microbatch(self, mock_module_symbols):
+        """Once per chunk, NOT once per pipeline microbatch: the mocked
+        iterator yields 2 pipeline mbs per call, so 3 calls is 3 chunks and 6
+        microbatches."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        for expected in (1, 2, 3):
+            w.train_microbatch(_fake_batch())
+            assert w._train_step_state["num_chunks"] == expected
+        assert w._train_step_state["total_num_microbatches"] == 6
+
+    def test_resets_on_next_step(self, mock_module_symbols):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.train_microbatch(_fake_batch())
+        w.finish_train_step()
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        assert w._train_step_state["num_chunks"] == 0
+
+
+class TestStepSummaryIsEmitted:
+    """The per-step summary has to survive at the level a default run uses.
+
+    ``nemo_rl/__init__.py`` calls ``basicConfig()`` with no level, which pins the
+    root logger at WARNING, and every later ``basicConfig`` returns early because
+    handlers already exist. The first version of this telemetry was therefore
+    dropped outright -- a 68-node run produced zero matches. It emits now because
+    that module also sets the ``nemo_rl`` logger from ``NRL_LOG_LEVEL``,
+    defaulting to INFO, so this pins the record at INFO and not below.
+    """
+
+    LOGGER = "nemo_rl.models.policy.workers.megatron_policy_worker"
+
+    def test_logs_chunk_count_and_grad_norm(self, mock_module_symbols, caplog):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+
+        caplog.set_level(logging.INFO, logger=self.LOGGER)
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.train_microbatch(_fake_batch())
+        w.train_microbatch(_fake_batch())
+        w.finish_train_step()
+
+        assert "[step] chunks=2" in caplog.text
+        # Paired with the chunk count on one line: a grad_norm that moves with
+        # the chunk count is the bug this PR fixes.
+        assert "grad_norm=0.5" in caplog.text
+
+    def test_only_rank_zero_logs(self, mock_module_symbols, caplog):
+        """Every field is DP- or MP-reduced by this point, so off-rank lines
+        would be duplicates -- and each costs two host-device syncs."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+
+        caplog.set_level(logging.INFO, logger=self.LOGGER)
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.rank = 3
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.train_microbatch(_fake_batch())
+        w.finish_train_step()
+
+        assert "[step]" not in caplog.text
+
+
+class TestChunkRecordIsGuarded:
+    """The per-chunk record is debug-only, and must be both free and reachable.
+
+    Free: its arguments are evaluated at the call site whether or not the record
+    is emitted, and four of them are ``.item()`` host-device syncs, so the
+    ``isEnabledFor`` guard is what keeps a disabled record off the critical path.
+    Reachable: that guard is only worth having if the level can actually be
+    raised, which is what ``NRL_LOG_LEVEL`` in ``nemo_rl/__init__.py`` provides.
+    """
+
+    LOGGER = "nemo_rl.models.policy.workers.megatron_policy_worker"
+
+    def test_silent_at_the_default_level(self, mock_module_symbols, caplog):
+        """INFO is what a default run gets, and this record sits below it."""
+        from nemo_rl.algorithms.loss.interfaces import LossType
+
+        caplog.set_level(logging.INFO, logger=self.LOGGER)
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.train_microbatch(_fake_batch())
+
+        assert "[chunk]" not in caplog.text
+
+    def test_emitted_when_debug_is_enabled(self, mock_module_symbols, caplog):
+        from nemo_rl.algorithms.loss.interfaces import LossType
+
+        caplog.set_level(logging.DEBUG, logger=self.LOGGER)
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.train_microbatch(_fake_batch())
+
+        assert "[chunk] chunks=1" in caplog.text
+
+
+# ── prepare_for_lp_inference ─────────────────────────────────────────────
+
+
+class TestPrepareForLpInference:
+    """``keep_train_buffers`` decides whether an open step's accumulated
+    gradients survive the logprob phase.
+
+    mcore's ``offload_to_cpu(move_grads=True)`` does not copy the gradients
+    anywhere — it resizes their storage to 0 — and nothing raises afterwards
+    because ``param.main_grad`` stays a valid view. So the failure mode this
+    guards is silent: every chunk but the last is discarded while the 1/N
+    normalizer still counts all of them.
+    """
+
+    @staticmethod
+    def _worker():
+        from nemo_rl.algorithms.loss.interfaces import LossType
+
+        w = _make_worker(LossType.TOKEN_LEVEL)
+        w.move_model = MagicMock(side_effect=lambda model, *a, **k: model)
+        w.move_optimizer = MagicMock()
+        w.optimizer_cpu_offload = False
+        w.offload_optimizer_for_logprob = True
+        return w
+
+    @staticmethod
+    def _grad_offload_calls(w) -> list:
+        """The move_model calls that free grad buffers, i.e. to cpu with
+        move_grads=True."""
+        return [
+            c
+            for c in w.move_model.call_args_list
+            if c.args[1:2] == ("cpu",) and c.kwargs.get("move_grads")
+        ]
+
+    def test_keeps_buffers_when_step_is_open(self, mock_module_symbols):
+        w = self._worker()
+        with patch("torch.randn"):
+            w.prepare_for_lp_inference(keep_train_buffers=True)
+        assert self._grad_offload_calls(w) == []
+        w.move_optimizer.assert_not_called()
+
+    def test_offloads_buffers_when_no_step_is_open(self, mock_module_symbols):
+        """The non-streaming path still has to reclaim the buffers, otherwise
+        the logprob phase peaks tens of GiB higher than it needs to."""
+        w = self._worker()
+        with patch("torch.randn"):
+            w.prepare_for_lp_inference(keep_train_buffers=False)
+        assert len(self._grad_offload_calls(w)) == 1
+        w.move_optimizer.assert_called_once_with("cpu")
+
+    def test_defaults_to_offloading(self, mock_module_symbols):
+        """Callers that predate the flag keep their old behaviour."""
+        w = self._worker()
+        with patch("torch.randn"):
+            w.prepare_for_lp_inference()
+        assert len(self._grad_offload_calls(w)) == 1
+        w.move_optimizer.assert_called_once_with("cpu")
+
+    @pytest.mark.parametrize("keep_train_buffers", [False, True])
+    def test_always_onloads_params_and_sets_eval(
+        self, mock_module_symbols, keep_train_buffers
+    ):
+        """Params go to CUDA and the model goes to eval either way — only the
+        grad/optimizer offload is conditional."""
+        w = self._worker()
+        with patch("torch.randn"):
+            w.prepare_for_lp_inference(keep_train_buffers=keep_train_buffers)
+        first = w.move_model.call_args_list[0]
+        assert first.args[1] == "cuda"
+        assert first.kwargs == {"move_grads": False}
+        w.model.eval.assert_called_once()
+
+    def test_keeps_buffers_across_an_open_step(self, mock_module_symbols):
+        """The sequence the streaming pump actually produces: open a step, run a
+        chunk, take the logprob detour, run another chunk, finish. The finalize
+        must still fire exactly once and the grads must never be offloaded."""
+        w = self._worker()
+        sentinel = w.model.config.finalize_model_grads_func
+        w.begin_train_step(loss_fn=w._test_loss_fn)
+        w.train_microbatch(_fake_batch())
+        with patch("torch.randn"):
+            w.prepare_for_lp_inference(keep_train_buffers=True)
+        w.train_microbatch(_fake_batch())
+        w.finish_train_step()
+        assert self._grad_offload_calls(w) == []
+        assert sentinel.call_count == 1

--- a/tests/unit/models/policy/test_megatron_split_state.py
+++ b/tests/unit/models/policy/test_megatron_split_state.py
@@ -81,9 +81,8 @@ def _make_mock_model():
     model.config = MagicMock()
     model.config.grad_sync_func = "ORIGINAL_GRAD_SYNC_FUNC"  # sentinel
     # Set explicitly rather than letting MagicMock auto-create it: the finish
-    # path branches on whether this was saved as None, so an auto-attribute
-    # would silently pick the finalize branch in tests meaning to cover the
-    # fallback.
+    # path asserts this was saved non-None, so the tests that cover the missing
+    # hook need to be able to clear it to a real None.
     model.config.finalize_model_grads_func = MagicMock(name="ORIGINAL_FINALIZE")
     model.config.num_moe_experts = None  # disable MoE branch
     # no_sync() is a context manager — return a MagicMock that supports
@@ -485,15 +484,16 @@ class TestFinish:
             assert order == ["scale", "finalize", "opt_step"]
 
     @pytest.mark.parametrize("overlap_grad_reduce", [False, True])
-    def test_grad_sync_falls_back_to_finish_grad_sync_without_finalize_hook(
+    def test_grad_sync_refuses_to_reduce_without_the_finalize_hook(
         self, mock_module_symbols, overlap_grad_reduce
     ):
-        """When mcore never had a finalize hook there is nothing to relocate,
-        so the reduce must still happen via finish_grad_sync directly.
+        """A missing finalize hook fails the step instead of reducing without it.
 
-        With overlap=False, Megatron's finish_grad_sync internally calls
-        start_grad_sync(force_all_reduce=True), so calling start_grad_sync
-        ourselves would double-reduce.
+        A bare finish_grad_sync would cover the cross-DP reduce and silently
+        skip everything else the finalize owns -- the TP layernorm all-reduce,
+        the tied-embedding all-reduces across PP, the MoE expert-bias update --
+        so falling back would train on wrong gradients with no error. Nothing is
+        dispatched before the check, and the optimizer does not step.
         """
         from nemo_rl.algorithms.loss.interfaces import LossType
 
@@ -502,18 +502,11 @@ class TestFinish:
             "overlap_grad_reduce"
         ] = overlap_grad_reduce
         w._train_step_state["saved_finalize_model_grads_func"] = None
-        order: list[str] = []
-        w.model.scale_gradients.side_effect = lambda s: order.append("scale")
-        w.model.start_grad_sync.side_effect = lambda: order.append("start_sync")
-        w.model.finish_grad_sync.side_effect = lambda: order.append("finish_sync")
-        w.optimizer.step.side_effect = lambda: (
-            order.append("opt_step") or (True, 0.5, 0)
-        )
-        w.finish_train_step()
-        if overlap_grad_reduce:
-            assert order == ["scale", "start_sync", "finish_sync", "opt_step"]
-        else:
-            assert order == ["scale", "finish_sync", "opt_step"]
+        with pytest.raises(AssertionError, match="finalize_model_grads_func was None"):
+            w.finish_train_step()
+        w.model.start_grad_sync.assert_not_called()
+        w.model.finish_grad_sync.assert_not_called()
+        w.optimizer.step.assert_not_called()
 
     def test_picks_global_valid_toks_for_token_level_loss(self, mock_module_symbols):
         """N selection: TOKEN_LEVEL → N = global_valid_toks (not seqs)."""
@@ -928,18 +921,22 @@ class TestFinalizeModelGradsOncePerStep:
         w.abort_train_step()
         sentinel.assert_not_called()
 
-    def test_handles_originally_none_hook(self, mock_module_symbols):
-        """PP=1 without a custom finalize: begin → finish must leave it None and
-        fall back to finish_grad_sync for the reduce."""
+    def test_originally_none_hook_fails_the_step(self, mock_module_symbols):
+        """Megatron-Bridge binds the hook whenever an optimizer exists, and an
+        open step implies one, so a None here means the model config never went
+        through setup. The step fails rather than reducing with finish_grad_sync
+        alone, and the restore path still runs on the way out."""
         from nemo_rl.algorithms.loss.interfaces import LossType
 
         w = _make_worker(LossType.TOKEN_LEVEL)
         w.model.config.finalize_model_grads_func = None
         w.begin_train_step(loss_fn=w._test_loss_fn)
         w.train_microbatch(_fake_batch())
-        w.finish_train_step()
+        with pytest.raises(AssertionError, match="finalize_model_grads_func was None"):
+            w.finish_train_step()
+        w.model.finish_grad_sync.assert_not_called()
         assert w.model.config.finalize_model_grads_func is None
-        w.model.finish_grad_sync.assert_called_once()
+        assert w.model.config.grad_sync_func == "ORIGINAL_GRAD_SYNC_FUNC"
 
     def test_two_consecutive_steps_each_finalize_once(self, mock_module_symbols):
         """Restore-then-null across step boundaries must not lose the hook or

--- a/tests/unit/single_controller/test_sc_checkpointing.py
+++ b/tests/unit/single_controller/test_sc_checkpointing.py
@@ -92,8 +92,8 @@ class _FakeTrainer:
         self.save_calls: list[dict[str, Any]] = []
         self.finalize_calls: int = 0
 
-    def prepare_for_lp_inference(self) -> None:
-        pass
+    def prepare_for_lp_inference(self, keep_train_buffers: bool = False) -> None:
+        del keep_train_buffers
 
     def get_logprobs_from_meta(self, meta: KVBatchMeta) -> None:
         pass

--- a/tests/unit/single_controller/test_single_controller.py
+++ b/tests/unit/single_controller/test_single_controller.py
@@ -313,14 +313,34 @@ class _EvictingSampler(_OneThenEmptySampler):
         return meta, 2 if num_groups else 0
 
 
+class _ChunkedSampler(_EmptySampler):
+    """Assembles one step out of several single-group chunks, then goes empty.
+
+    This is the shape the streaming path actually produces and the reason
+    ``keep_train_buffers`` exists: every chunk after the first runs against an
+    already-open train step.
+    """
+
+    def __init__(self, meta: KVBatchMeta, chunks: int) -> None:
+        self._meta = meta
+        self._remaining = chunks
+
+    async def select(self, **kwargs):
+        del kwargs
+        if self._remaining == 0:
+            return None, 0
+        self._remaining -= 1
+        return self._meta, 1
+
+
 class _EmptyBuffer:
     def __len__(self) -> int:
         return 0
 
 
 class _NoOpTrainer:
-    def prepare_for_lp_inference(self) -> None:
-        pass
+    def prepare_for_lp_inference(self, keep_train_buffers: bool = False) -> None:
+        del keep_train_buffers
 
     def prepare_for_training(self) -> None:
         pass
@@ -333,6 +353,19 @@ class _NoOpTrainer:
 
     def finish_train_step(self) -> dict:
         return {}
+
+
+class _LpRecordingTrainer(_NoOpTrainer):
+    """Records the ``keep_train_buffers`` flag the pump passes on each chunk."""
+
+    def __init__(self) -> None:
+        self.keep_train_buffers_calls: list[bool] = []
+
+    def prepare_for_lp_inference(self, keep_train_buffers: bool = False) -> None:
+        self.keep_train_buffers_calls.append(keep_train_buffers)
+
+    def get_logprobs_from_meta(self, meta: KVBatchMeta) -> None:
+        del meta
 
 
 class _NoOpDataPlane:
@@ -431,3 +464,35 @@ def test_train_pump_logs_nonzero_stale_group_metrics(monkeypatch) -> None:
     train_metrics = ctrl._logger.log_metrics.call_args_list[0].args[0]
     assert train_metrics["evicted_stale_prompt_groups"] == 2
     assert train_metrics["aborted_stale_inflight_groups"] == 1
+
+
+def test_train_pump_keeps_train_buffers_once_the_step_is_open(monkeypatch) -> None:
+    """The logprob detour between chunks must not offload the trainer's grad
+    buffers, because mcore's offload frees the gradients the earlier chunks of
+    this step accumulated rather than copying them out.
+
+    First chunk: no step open yet, nothing to preserve, so the offload is still
+    worth taking. Every later chunk: step open, buffers must stay resident.
+    """
+    meta = KVBatchMeta(
+        partition_id="rollout_data",
+        task_name="train",
+        sample_ids=["sample-0"],
+        fields=[],
+        sequence_lengths=[1],
+        tags=[{"weight_version": 0}],
+    )
+    # num_prompts_per_step is 2 in the harness, so two single-group chunks close
+    # the step.
+    ctrl = _train_pump_controller(sampler=_ChunkedSampler(meta, chunks=2))
+    ctrl._policy_logprobs_required = True
+    trainer = _LpRecordingTrainer()
+    ctrl._trainer = trainer
+    ctrl._sync_weights = AsyncMock(return_value=1)
+    ctrl._logger = MagicMock()
+    monkeypatch.setattr(single_controller.ray, "cluster_resources", lambda: {})
+
+    asyncio.run(asyncio.wait_for(ctrl._train_pump(), timeout=1.0))
+
+    assert ctrl._train_steps == 1
+    assert trainer.keep_train_buffers_calls == [False, True]


### PR DESCRIPTION
The SingleController streaming train path feeds N chunks into a single optimizer step, but two paths still behaved as though each chunk were a step of its own.

mcore calls config.finalize_model_grads_func at the end of every forward_backward_func invocation, so under streaming it fired once per chunk. Nothing already overridden gated it: it reaches finish_grad_sync directly, and model.no_sync() only clears is_last_microbatch, which finish_grad_sync ignores. With a distributed optimizer the reduce-scatter also writes into the buffer it reads, leaving this rank's shard DP-summed and the remainder local for the next chunk to accumulate on top of. Null the hook for the step's duration and invoke the saved callable once from _finish_train_step_body with num_tokens=None, since this path applies its own 1/N. Relocating rather than dropping it matters because it also owns the non-tensor-parallel/layernorm all-reduce across TP, the tied word- and position-embedding all-reduces across PP, the MoE router expert-bias update, and reset_model_temporary_tensors.

prepare_for_lp_inference offloaded the grad buffers on every logprob detour. mcore's offload_to_cpu(move_grads=True) does not copy the gradients anywhere, it resizes their storage to 0, and the matching reload zeroes it; param.main_grad stays a valid view throughout, so nothing raises and every chunk but the last is silently discarded against a 1/N normalizer that still counts them all. Add keep_train_buffers, which the controller passes as step_open.

Record the chunk count per step alongside grad_norm and sample the CUDA allocator at the phase boundaries under debug, so the accumulation is greppable from a run rather than inferred from timer ratios.

Cover both bugs in tests: the finalize hook is saved, nulled, invoked exactly once with num_tokens=None whether the step arrived as one chunk or five, and restored on finish and abort; the grad buffers survive a logprob detour mid-step; and the controller passes keep_train_buffers=step_open across a multi-chunk step.

# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
