### PR TITLE
fix(grpo): start collection after initial refit

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -4351,9 +4351,7 @@ def async_grpo_train(
     # Start trajectory collection only after generation setup completes.
     # Starting it earlier can overlap rollout work with the initial
     # policy-to-generation refit and stall the refit collectives.
-    collection_task = trajectory_collector.start_collection.remote(  # noqa: F841
-        dataloader
-    )
+    collection_task = trajectory_collector.start_collection.remote(dataloader)
 
     # Ensure collector knows initial weight version
     trajectory_collector.set_weight_version.remote(weight_version)

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -4348,10 +4348,9 @@ def async_grpo_train(
             traceback.print_exc()
             return
 
-    # Start trajectory collection only after generation holds real weights.
-    # The engines come up with load_format=dummy (weights arrive via the refit
-    # above); collecting before the refit can race weight loading and produce
-    # rollouts from randomly initialized weights.
+    # Start trajectory collection only after generation setup completes.
+    # Starting it earlier can overlap rollout work with the initial
+    # policy-to-generation refit and stall the refit collectives.
     collection_task = trajectory_collector.start_collection.remote(  # noqa: F841
         dataloader
     )

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -4313,14 +4313,6 @@ def async_grpo_train(
         processor=processor,
     )
 
-    # Start trajectory collection in background
-    collection_task = trajectory_collector.start_collection.remote(dataloader)
-
-    # Ensure collector knows initial weight version
-    trajectory_collector.set_weight_version.remote(weight_version)
-
-    print("📦 Started continuous background trajectory collection")
-
     print(
         f"🚀 Starting async GRPO training with buffer_size={optimal_buffer_size}, "
         f"max_age={max_trajectory_age_steps} steps, "
@@ -4355,6 +4347,19 @@ def async_grpo_train(
 
             traceback.print_exc()
             return
+
+    # Start trajectory collection only after generation holds real weights.
+    # The engines come up with load_format=dummy (weights arrive via the refit
+    # above); collecting before the refit can race weight loading and produce
+    # rollouts from randomly initialized weights.
+    collection_task = trajectory_collector.start_collection.remote(  # noqa: F841
+        dataloader
+    )
+
+    # Ensure collector knows initial weight version
+    trajectory_collector.set_weight_version.remote(weight_version)
+
+    print("📦 Started continuous background trajectory collection")
 
     print("✅ Policy generation setup complete, proceeding to validation...")
 

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -1239,6 +1239,71 @@ def mock_sync_grpo_infrastructure(policy):
     return stack
 
 
+def test_async_grpo_refits_before_starting_trajectory_collection(
+    mock_grpo_components,
+):
+    """Generation must hold trained weights before any rollout can start."""
+
+    class StartupOrderObserved(Exception):
+        pass
+
+    master_config = mock_grpo_components["master_config"]
+    master_config.policy["generation"]["colocated"]["enabled"] = False
+    master_config.grpo.val_at_start = False
+    master_config.grpo.val_at_end = False
+    mock_grpo_components["checkpointer"].get_latest_checkpoint_path.return_value = None
+
+    events = []
+    policy_generation = _mock_policy_generation()
+    policy_generation.weight_synchronizer = None
+
+    collector = MagicMock()
+
+    def record_collection_start(*_args, **_kwargs):
+        assert events == ["refit"], (
+            "trajectory collection started before generation received trained weights"
+        )
+        events.append("start_collection")
+        raise StartupOrderObserved
+
+    collector.start_collection.remote.side_effect = record_collection_start
+    collector_cls = MagicMock()
+    collector_cls.options.return_value.remote.return_value = collector
+
+    def record_refit(*_args, **_kwargs):
+        events.append("refit")
+
+    mock_batch = next(iter(mock_grpo_components["train_dataloader"]))
+    with (
+        mock_async_grpo_infrastructure(mock_batch, {}),
+        patch(
+            "nemo_rl.algorithms.async_utils.AsyncTrajectoryCollector",
+            collector_cls,
+        ),
+        patch(
+            "nemo_rl.algorithms.grpo.refit_policy_generation",
+            side_effect=record_refit,
+        ),
+        pytest.raises(StartupOrderObserved),
+    ):
+        async_grpo_train(
+            mock_grpo_components["policy"],
+            policy_generation,
+            mock_grpo_components["train_dataloader"],
+            mock_grpo_components["val_dataloader"],
+            mock_grpo_components["tokenizer"],
+            mock_grpo_components["loss_fn"],
+            mock_grpo_components["task_to_env"],
+            mock_grpo_components["val_task_to_env"],
+            mock_grpo_components["logger"],
+            mock_grpo_components["checkpointer"],
+            _initial_grpo_save_state(),
+            master_config,
+        )
+
+    assert events == ["refit", "start_collection"]
+
+
 def test_async_grpo_propagates_main_loop_collector_failure(mock_grpo_components):
     """A fatal collector health result aborts the trainer and still cleans up."""
     master_config = mock_grpo_components["master_config"]


### PR DESCRIPTION
# What does this PR do ?

Start asynchronous trajectory collection only after the initial policy-to-generation refit or generation preparation has completed.

Previously, `AsyncTrajectoryCollector.start_collection()` could run before the initial policy weights had been transferred to the generation backend. This made rollout requests eligible to begin before generation was ready with the trained policy weights.

This PR restores the required startup order:

1. initialize the generation backend;
2. complete its initial refit or preparation;
3. start background trajectory collection;
4. set the collector's initial weight version.

The change affects only startup ordering. It does not alter the existing steady-state coordination or in-flight weight-update behavior after collection has started.

# Issues

None.

# Usage

No user-facing API or configuration changes are required.

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests. (All tests related to this change passed.)
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs. (N/A: no public API or configuration change.)

# Additional Information

## Observed hang

The failure we observed was a hang in the initial policy-to-generation refit. It occurred at GBS256 in configurations with high rollout concurrency relative to global batch size.

However, all four GBS512 and GBS1024 controls completed successfully with the same pre-fix startup ordering. In each control, the initial refit started and both startup rollout workers were launched before refit completed. No complete prompt group was buffered before refit success, although the available logs cannot establish whether individual generation requests were already in flight. One GBS512 configuration also had enough concurrency to admit the complete two-target startup workload. A high concurrency-to-batch-size ratio is therefore not sufficient to trigger the hang; whether it is necessary was not established.

With `max_trajectory_age_steps=1`, the collector can reserve the current training step and one-step lookahead at startup. At GBS256, both step-sized rollout batches fit within the configured admission capacity. Smaller rollout payloads and lower admission backpressure may change batching, serialization, and request-routing timing enough to make a vulnerable interleaving more likely, but that mechanism was not independently isolated. Because collection starts asynchronously, calling `start_collection()` establishes eligibility for rollout work but does not prove that every generation worker was executing a rollout at the exact vulnerable instant.

When the failure occurred, policy ranks stopped making consistent progress through the initial refit's expert-parallel all-gather and pipeline-parallel broadcast operations. The NCCL watchdog eventually reported 600-second collective timeouts.

Sanitized representative excerpts:

```text
Watchdog caught collective operation timeout:
WorkNCCL(SeqNum=2928, OpType=ALLGATHER, ..., Timeout(ms)=600000)

Watchdog caught collective operation timeout:
WorkNCCL(SeqNum=36292, OpType=BROADCAST, ..., Timeout(ms)=600000)
```

These messages identify the collectives in which progress stopped; they do not, by themselves, establish why ranks diverged in collective progress.

The correctness requirement does not depend on how frequently the race reproduces: generation must receive or prepare the initial policy weights before rollout collection can begin. This PR makes that startup barrier explicit while leaving steady-state asynchronous collection and in-flight update behavior unchanged.

## Testing

All tests related to this change passed, including the new ordering regression test.

Testing for the affected asynchronous GRPO path included:

- added `test_async_grpo_refits_before_starting_trajectory_collection`, which fails if collection starts before the initial refit;
- ran the new regression test;
- ran related asynchronous GRPO tests;
- ran the complete `tests/unit/algorithms/test_grpo.py` module;
- exercised broader non-gated unit-test configurations where the available environment allowed it.

## Async behavior

The initial transition must be strict: when generation still needs the policy's initial weights, no rollout should start before refit or preparation completes.

After startup, the existing asynchronous behavior is unchanged. In particular, this PR does not change how steady-state refits coordinate new dispatches, already in-flight requests, weight versions, or KV-cache updates.
