### PR TITLE
feat(sc): tolerate and replace dropped rollouts in the SingleController

### DIFF
--- a/examples/configs/grpo_math_1B_megatron_single_controller.yaml
+++ b/examples/configs/grpo_math_1B_megatron_single_controller.yaml
@@ -35,7 +35,7 @@ async_rl:
   # so the structure says which knob applies where. Filling in the block for the
   # path a run is not taking is rejected at setup rather than silently ignored.
   rollout_failure:
-    max_infra_attempts_per_prompt: 5  # infra budget; exhausting it fails the run
+    max_infra_attempts_per_prompt: 5  # infra budget; exhausting it drops the prompt
     max_data_attempts_per_prompt: 2   # data budget; 1 retry separates transient from deterministic
     backoff_base_s: 1.0
     max_backoff_s: 30.0
@@ -43,6 +43,30 @@ async_rl:
     # on the first one, propagating the original error. The two budgets above are
     # INDEPENDENT counters, so one prompt can consume up to their sum minus one.
     max_skipped_prompts: 0
+    # CONSECUTIVE prompts allowed to exhaust their infra budget and be dropped; any
+    # committed rollout resets the count. 0 fails the run on the first one. Raise it
+    # on a large fleet where losing the odd shard is expected and a whole run is
+    # expensive to restart -- a step short a few groups still trains, and the count
+    # only keeps climbing if nothing at all is coming back.
+    max_consecutive_dropped_prompts: 0
+    # Smallest batch a step may train on, as a fraction of num_prompts_per_step.
+    # The budgets above are run-scoped and cannot bound how short one step gets, so
+    # this is what guarantees the gradient is computed from most of a batch. The floor
+    # is ceil(fraction * num_prompts_per_step), so small batches tolerate no drops.
+    min_step_batch_fraction: 0.9
+    # What happens to the step a dropped prompt was stamped for (in_order sampler only;
+    # an unstamped sampler strands nothing). "shrink" trains the step on fewer groups,
+    # bounded by the floor above. "replace" substitutes a fresh prompt so the step keeps
+    # its configured batch size -- what the v1 stack does -- and still shrinks if the
+    # attempts or spares below run out. When a later step already has a finished group,
+    # replace borrows it to close the dropped step immediately and sends the fresh
+    # prompt to repay that step instead, so the trainer does not idle waiting on a new
+    # rollout; promoted_prompt_groups reports when that happened.
+    on_dropped_prompt: shrink         # shrink | replace
+    max_replacement_attempts: 1       # fresh prompts tried per lost group
+    # Low-water mark for the spare-prompt pool. Refilled by diverting one whole batch
+    # from the dataloader before it is admitted, so a refill yields a batch of spares.
+    replacement_reserve_prompts: 1
 
     # Deadlines. null disables, which is the default and reproduces the historical
     # behaviour of waiting forever. Set them in any run that matters: without one a

--- a/nemo_rl/algorithms/async_utils/replay_buffer.py
+++ b/nemo_rl/algorithms/async_utils/replay_buffer.py
@@ -1085,6 +1085,51 @@ class TQReplayBuffer:
         """Return how many slots are stamped with ``target_step``."""
         return sum(1 for target in self.target_step_list if target == target_step)
 
+    def promote_ready_group(self, *, to_target_step: int) -> Optional[int]:
+        """Re-stamp a finished group from a later step so it lands in this one.
+
+        Fills a hole left by a dropped prompt with generation that is already done,
+        which is the point: the step closes immediately instead of waiting out a fresh
+        rollout. The step it was borrowed from is returned so the caller can repay it,
+        and the caller must -- an unrepaid loan is the same hole one step later, carried
+        forward until it reaches the last step, which has nobody to borrow from.
+
+        The furthest future step is preferred because it is due last and so has the most
+        slack to absorb the repayment. Only ready slots qualify: an unready one is a
+        reservation whose rollout is still running, so moving its stamp would hand this
+        step the same wait it is trying to avoid.
+
+        Promotion can only make a step fresher, never staler. Slots are appended in
+        dispatch order and the trainer version never decreases, so a group stamped for a
+        later step was generated at a weight version at least as new as the ones already
+        in this step.
+
+        Synchronous on purpose. ``remove`` deletes its indices before its own first
+        await, so as long as nothing here yields, the index picked below cannot be
+        shifted out from under the write by a selection running concurrently.
+
+        Args:
+            to_target_step: Training step to re-stamp the borrowed group onto -- the
+                step that lost a prompt. Must be at or ahead of the trainer version:
+                a group re-stamped onto a step already trained is never selectable
+                again and would only be evicted.
+
+        Returns:
+            The target step the group was taken from, or None when no later step has a
+            ready group to lend.
+        """
+        lender_idx: Optional[int] = None
+        lender_target: Optional[int] = None
+        for i, target in enumerate(self.target_step_list):
+            if target is None or target <= to_target_step or not self.ready_list[i]:
+                continue
+            if lender_target is None or target > lender_target:
+                lender_idx, lender_target = i, target
+        if lender_idx is None:
+            return None
+        self.target_step_list[lender_idx] = to_target_step
+        return lender_target
+
     def size(self) -> int:
         """Return the number of prompt-group entries currently held."""
         return len(self.meta_list)

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -36,10 +36,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import os
 import time
+from collections import deque
 from functools import partial
-from typing import Any, Optional, Union, cast
+from typing import Any, Awaitable, Callable, Optional, Union, cast
 
 import ray
 import torch
@@ -211,6 +213,34 @@ class SingleControllerActor:
 
         self._inflight_by_group_id: dict[str, tuple[asyncio.Task[None], int]] = {}
 
+        # Groups that will never arrive, keyed by the training step they were stamped
+        # for. A sampler that matches batches to steps exactly (InOrderSampler) can only
+        # ever select num_prompts_per_step groups carrying that stamp, so a dropped
+        # prompt leaves that step permanently one short and the train pump waits on a
+        # group no one is generating. The pump subtracts these to close the step short.
+        # Only stamped prompts appear here: with an unstamped sampler the batch fills
+        # from whatever is ready, so a drop costs throughput but strands nothing.
+        self._batch_shortfall: dict[int, int] = {}
+
+        # Spare prompts that on_dropped_prompt="replace" substitutes for dropped ones,
+        # and the per-step counts of how each step got made whole (logged so a step's
+        # batch size stays explainable after the fact). The reserve is filled only by the
+        # rollout pump, which owns the dataloader iterator; see the config docstring for
+        # why a dispatch task cannot pull from it directly.
+        #
+        # The two counters read from opposite ends of a borrow: a step that filled a
+        # hole with a later step's finished group counts a promotion, and the step it
+        # borrowed from counts the replacement that repaid it.
+        self._replacement_reserve: deque[DatumSpec] = deque()
+        self._batch_replacements: dict[int, int] = {}
+        self._batch_promotions: dict[int, int] = {}
+        # Whether the sampler has ever handed back a target step. Only stamped prompts
+        # can strand a step, so this gates the pool: filling it for a sampler that never
+        # stamps would divert a batch of prompts that nothing is ever able to draw on.
+        # Learned from admit rather than the sampler's type, because a custom sampler's
+        # stamping is not knowable until it answers.
+        self._sampler_stamps_target_steps: bool = False
+
         # Backpressure valve: max unconsumed rollout groups allowed in DataPlane.
         # Acquired before each rollout dispatch; released when the buffer
         # drops a group (sampler.evict or post-train buffer.remove).
@@ -244,6 +274,7 @@ class SingleControllerActor:
         await self._sync_weights()
 
         await self._maybe_restore_replay_buffer()
+        await self._maybe_restore_replacement_reserve()
 
         # Start the rollout and train pumps, plus the watchdog
         rollout_task = asyncio.create_task(self._rollout_pump())
@@ -352,6 +383,42 @@ class SingleControllerActor:
         for _ in range(restored):
             await self._buffer_capacity.acquire()
 
+    async def _maybe_restore_replacement_reserve(self) -> None:
+        """Restore spare prompts diverted before the previous run's checkpoint.
+
+        These were pulled from the dataloader and never dispatched, so the restored
+        dataloader resumes past them. Nothing else in the checkpoint holds them, and
+        without this they are simply gone: one batch of the dataset per divert, plus
+        the training step ``_clamp_max_num_steps`` had budgeted for it.
+
+        No sampler-name guard, unlike the buffer restore. Spares carry no stamp -- they
+        are prompts that never reached ``admit`` -- so nothing about them depends on
+        which sampler wrote the checkpoint. They are restored even into a run that has
+        since switched to ``on_dropped_prompt="shrink"``, where the pool is never drawn
+        on but is still drained back into training at the end of the dataloader.
+        """
+        if self._last_checkpoint_path is None:
+            return
+        reserve_path = os.path.join(
+            self._last_checkpoint_path, "replacement_reserve.pt"
+        )
+        # Absent for every run that never diverted a batch, which is every run that
+        # does not use "replace" -- so silence here rather than the buffer restore's
+        # warning, since this is the ordinary case rather than a lost artifact.
+        if not os.path.exists(reserve_path):
+            return
+        # weights_only=False: spares are pickled DatumSpecs, and the checkpoint is a
+        # trusted same-job artifact (the replay buffer restore loads on the same terms).
+        reserve_state = await asyncio.to_thread(
+            torch.load, reserve_path, weights_only=False
+        )
+        self._replacement_reserve.extend(reserve_state)
+        print(
+            f"📦 Restored {len(reserve_state)} pooled spare prompt(s) from checkpoint: "
+            f"{reserve_path}",
+            flush=True,
+        )
+
     async def _ray_get(self, obj_ref: Any) -> Any:
         """Await a Ray ObjectRef without blocking the asyncio event loop."""
         return await obj_ref
@@ -373,8 +440,10 @@ class SingleControllerActor:
         """Continuously dispatch rollout tasks until cancellation.
 
         Per batch:
-          0. await sampler.admit(...) to wait until the batch may dispatch and
-             obtain its target_step stamp.
+          0. Under on_dropped_prompt="replace", divert the batch into the spare pool
+             if the pool is below its low-water mark, and skip admission entirely.
+             Otherwise await sampler.admit(...) to wait until the batch may dispatch
+             and obtain its target_step stamp.
 
         Per prompt:
           1. Acquire _buffer_capacity slot (backpressure)
@@ -383,7 +452,14 @@ class SingleControllerActor:
           4. Call rollout_manager.generate_and_push(prompt) — local async
              RolloutManager reserves a slot, runs the rollout, then commits the
              group via TQReplayBuffer (→ dp_client.put_samples + mark ready)
-          5. Decrement _inflight_rollouts
+          5. If the prompt was dropped, substitute a spare and repeat step 4 -- for this
+             step, or for whichever step lends this one a finished group in its place
+             (see _take_replacement, _promote_into_step) -- or credit the step short so
+             the train pump can close it
+          6. Decrement _inflight_rollouts
+
+        Once every epoch is done, whatever is left in the spare pool is dispatched as
+        ordinary steps rather than discarded (see _drain_reserve_into_steps).
         """
         sem = asyncio.Semaphore(self._async_cfg.max_inflight_prompts)
         self._rollout_exhausted.clear()
@@ -396,26 +472,69 @@ class SingleControllerActor:
         ) -> None:
             task_started_event.set()
             self._inflight_rollouts += 1
+            # This task owns one slot of a step, which can outlive both the prompt it
+            # started with and the step it started on: a dropped prompt is substituted in
+            # place and the loop runs again, and the slot is re-aimed at whichever step
+            # lends this one a finished group. Both permits are held across
+            # substitutions because the slot stays occupied either way -- they are
+            # released once something commits, or once a step is credited short.
+            replacements = 0
             try:
-                outcome = await self._rollout_manager.generate_and_push(
-                    prompt,
-                    target_step=target_step,
-                    inflight_registry=self._inflight_by_group_id,
-                )
-            except BaseException:
-                # On success ownership transfers to the train pump, which
-                # releases this permit after consuming the committed group.
-                self._buffer_capacity.release()
-                raise
+                while True:
+                    try:
+                        outcome = await self._rollout_manager.generate_and_push(
+                            prompt,
+                            target_step=target_step,
+                            inflight_registry=self._inflight_by_group_id,
+                        )
+                    except BaseException:
+                        # On success ownership transfers to the train pump, which
+                        # releases this permit after consuming the committed group.
+                        self._buffer_capacity.release()
+                        raise
+
+                    if outcome is not RolloutOutcome.SKIPPED:
+                        break
+
+                    replacement = self._take_replacement(target_step, replacements)
+                    if replacement is None:
+                        # Nothing was committed, so the train pump will never see this
+                        # group and never release its permit on our behalf.
+                        self._buffer_capacity.release()
+                        self._credit_shortfall(target_step)
+                        return
+
+                    replacements += 1
+                    prompt = replacement
+                    print(
+                        f"  target_step={target_step}: substituting a spare prompt for "
+                        f"the dropped group (replacement {replacements}/"
+                        f"{self._async_cfg.rollout_failure.max_replacement_attempts}, "
+                        f"{len(self._replacement_reserve)} spare(s) left)",
+                        flush=True,
+                    )
+                    # Attempted only now that a spare is in hand, because the borrow is a
+                    # debt and the spare is what repays it. Borrowing without one would
+                    # leave the lender short instead: the same hole, one step later.
+                    lender_step = self._promote_into_step(target_step)
+                    if lender_step is not None:
+                        target_step = lender_step
+                    # A substitution is a fresh rollout, not a continuation of the one
+                    # that failed, so it observes the same pause a first dispatch does
+                    # instead of pushing new generation into a weight-sync window.
+                    await self._rollout_permitted.wait()
             finally:
                 self._inflight_rollouts -= 1
                 sem.release()
 
-            if outcome is RolloutOutcome.SKIPPED:
-                # Nothing was committed, so the train pump will never see this group
-                # and never release its permit on our behalf.
-                self._buffer_capacity.release()
-                return
+            if replacements and target_step is not None:
+                # Counted per slot, not per attempt: a step got its group back, which is
+                # the fact that explains why its batch is full despite a drop. Recorded
+                # against the step the spare actually committed to, which after a borrow
+                # is the lender rather than the step that was dropped from.
+                self._batch_replacements[target_step] = (
+                    self._batch_replacements.get(target_step, 0) + 1
+                )
 
             if self._async_cfg.diagnostics:
                 content = ""
@@ -434,13 +553,40 @@ class SingleControllerActor:
                 self._buffer_capacity.release()
                 sem.release()
 
+        async def _launch(prompt: DatumSpec, target_step: Optional[int]) -> None:
+            # check if buffer is full
+            await self._buffer_capacity.acquire()
+            # check if inflight rollouts is full
+            await sem.acquire()
+            # wait for rollout to be permitted
+            await self._rollout_permitted.wait()
+
+            task_started_event = asyncio.Event()
+            # dispatch rollout
+            task = rollout_tasks.create_task(
+                _dispatch_one_prompt(prompt, target_step, task_started_event)
+            )
+            self._dispatched_rollouts.add(task)
+            task.add_done_callback(self._dispatched_rollouts.discard)
+            task.add_done_callback(
+                partial(
+                    _release_permits_if_task_not_started,
+                    task_started_event=task_started_event,
+                )
+            )
+
         max_epochs = self._master_config.grpo.max_num_epochs
         async with asyncio.TaskGroup() as rollout_tasks:
             while max_epochs is None or self._current_epoch < max_epochs:
                 for prompt_batch in self._dataloader:
+                    if self._divert_batch_to_reserve(prompt_batch):
+                        continue
+
                     target_step = await self._sampler.admit(
                         trainer_version_fn=lambda: self._trainer_version
                     )
+                    if target_step is not None:
+                        self._sampler_stamps_target_steps = True
 
                     num_prompts = prompt_batch.size
                     if target_step is not None:
@@ -458,31 +604,17 @@ class SingleControllerActor:
                         prompt: DatumSpec = {  # type: ignore
                             k: v[prompt_idx] for k, v in prompt_batch.items()
                         }
-
-                        # check if buffer is full
-                        await self._buffer_capacity.acquire()
-                        # check if inflight rollouts is full
-                        await sem.acquire()
-                        # wait for rollout to be permitted
-                        await self._rollout_permitted.wait()
-
-                        task_started_event = asyncio.Event()
-                        # dispatch rollout
-                        task = rollout_tasks.create_task(
-                            _dispatch_one_prompt(
-                                prompt, target_step, task_started_event
-                            )
-                        )
-                        self._dispatched_rollouts.add(task)
-                        task.add_done_callback(self._dispatched_rollouts.discard)
-                        task.add_done_callback(
-                            partial(
-                                _release_permits_if_task_not_started,
-                                task_started_event=task_started_event,
-                            )
-                        )
+                        await _launch(prompt, target_step)
 
                 self._current_epoch += 1
+
+        # Only now that every dispatched rollout has settled is the pool genuinely
+        # spare. Draining it inside the group above would race them for it, and a
+        # rollout that was about to be dropped has the better claim: it needs a spare to
+        # keep its step whole, whereas an extra step is only worth having if one is
+        # left over. A second group because the first is closed to new tasks.
+        async with asyncio.TaskGroup() as rollout_tasks:
+            await self._drain_reserve_into_steps(_launch)
 
         # Drain in-flight so return implies "all rollouts in TQ".
         inflight = list(self._dispatched_rollouts)
@@ -491,6 +623,216 @@ class SingleControllerActor:
 
         self._rollout_exhausted.set()
         print(f"rollout_pump: completed {self._current_epoch} epoch(s)", flush=True)
+
+    def _divert_batch_to_reserve(
+        self, prompt_batch: BatchedDataDict[DatumSpec]
+    ) -> bool:
+        """Consume a whole batch as spare prompts instead of admitting it as a step.
+
+        Returns whether the batch was taken, in which case the caller must not admit it.
+        Diverting before ``admit`` is what keeps the stamp sequence honest: admitting a
+        batch and then dispatching nothing for it would leave a target step that no
+        group is ever generated for, which is exactly the hang the shortfall accounting
+        exists to prevent.
+
+        A whole batch at a time because the dataloader only yields batches. The spares
+        that go unused are not wasted work -- nothing has been generated for them -- and
+        they stay in the pool for later steps.
+
+        Nothing is diverted until the sampler has actually stamped a batch, so a run
+        whose sampler never stamps does not lose a batch of prompts to a pool it can
+        never draw on. The cost is that the first batch is always admitted rather than
+        diverted; in practice the pool is filled while that first batch's rollouts are
+        still running, so it is available by the time any of them can be given up on.
+        """
+        failure_cfg = self._async_cfg.rollout_failure
+        if failure_cfg.on_dropped_prompt != "replace":
+            return False
+        if not self._sampler_stamps_target_steps:
+            return False
+        if len(self._replacement_reserve) >= failure_cfg.replacement_reserve_prompts:
+            return False
+
+        for prompt_idx in range(prompt_batch.size):
+            spare: DatumSpec = {  # type: ignore
+                k: v[prompt_idx] for k, v in prompt_batch.items()
+            }
+            self._replacement_reserve.append(spare)
+        print(
+            f"  spare pool refilled with {prompt_batch.size} prompt(s) "
+            f"(low-water mark {failure_cfg.replacement_reserve_prompts}); this batch is "
+            "not admitted as a training step",
+            flush=True,
+        )
+        return True
+
+    async def _drain_reserve_into_steps(
+        self, launch: Callable[[DatumSpec, Optional[int]], Awaitable[None]]
+    ) -> None:
+        """Train on the leftover spares once the dataloader has nothing more to give.
+
+        Spares were consumed from the dataset like any other prompt, so leaving them in
+        the pool at the end of the last epoch throws away data the run already paid for.
+
+        It also restores the step count. ``_clamp_max_num_steps`` derives
+        ``max_num_steps`` from ``len(dataloader)``, and every diverted batch is one
+        fewer batch the loop can admit -- so without this a replace-mode run quietly
+        finishes one step short of the budget it was configured with, per divert.
+
+        Whole steps only. A partial pool dispatched as a step is short by construction,
+        and ``min_step_batch_fraction`` would then reject it and fail a run that had
+        otherwise completed cleanly. In the ordinary case the pool holds exactly one
+        batch (the dataloader uses ``batch_size=num_prompts_per_step``), so the common
+        outcome is that the whole thing is recovered.
+
+        Not gated on ``on_dropped_prompt``: an empty pool makes this a no-op anyway, and
+        only "replace" ever fills one, so the gate would buy nothing while stranding a
+        pool restored from a checkpoint into a run that has since switched to "shrink".
+        """
+        num_prompts_per_step = self._master_config.grpo.num_prompts_per_step
+        while len(self._replacement_reserve) >= num_prompts_per_step:
+            # Take the step's prompts out before the first await. A drop resolving
+            # concurrently draws from this same pool, and could otherwise claim one of
+            # them and leave the step it is filling one group short.
+            step_prompts = [
+                self._replacement_reserve.popleft() for _ in range(num_prompts_per_step)
+            ]
+            target_step = await self._sampler.admit(
+                trainer_version_fn=lambda: self._trainer_version
+            )
+            print(
+                f"  dataloader exhausted; training on {len(step_prompts)} pooled "
+                f"spare(s) as target_step={target_step}",
+                flush=True,
+            )
+            for prompt in step_prompts:
+                await launch(prompt, target_step)
+
+        if self._replacement_reserve:
+            print(
+                f"  {len(self._replacement_reserve)} pooled spare(s) left over, fewer "
+                f"than the {num_prompts_per_step} a step needs; they are not trained on",
+                flush=True,
+            )
+
+    def _take_replacement(
+        self, target_step: Optional[int], replacements_used: int
+    ) -> Optional[DatumSpec]:
+        """A spare prompt to stand in for a dropped group, or None to shrink instead.
+
+        None covers the four ways a replacement can be unavailable: it was not asked
+        for, the sampler did not stamp this prompt so no step is waiting on it, the
+        per-slot budget is spent, or the pool is empty because the dataloader is
+        exhausted. Every one of them falls back to ``on_dropped_prompt="shrink"`` rather
+        than waiting, because a step whose replacements keep failing still has to close.
+        """
+        failure_cfg = self._async_cfg.rollout_failure
+        if failure_cfg.on_dropped_prompt != "replace":
+            return None
+        if target_step is None:
+            return None
+        if replacements_used >= failure_cfg.max_replacement_attempts:
+            return None
+        if not self._replacement_reserve:
+            return None
+        return self._replacement_reserve.popleft()
+
+    def _promote_into_step(self, target_step: Optional[int]) -> Optional[int]:
+        """Fill a dropped step from a later step's finished work, and name the lender.
+
+        Where a replacement goes, rather than whether one happens. The lost step closes
+        on generation that already exists instead of waiting out a rollout with the
+        trainer idle, and the caller redirects its spare prompt to the lender, which is
+        due a training step later and has the slack to absorb the wait. The same prompt
+        is generated either way.
+
+        Only ever reached with a spare already in hand, which is what makes the borrow
+        safe to take: an unrepaid loan is the same hole one step later.
+
+        Returns None -- leaving the caller filling the dropped step directly -- when
+        nothing is stamped so no step is stranded, when the trainer has already moved
+        past this step (a second drop can land after the first one closed it short, and
+        a group stamped for a finished step would only be evicted), or when no later
+        step has a finished group to lend. The last is always the case at
+        ``in_order.max_lookahead_versions=0``, where the next batch is not dispatched
+        until this step trains.
+
+        Returns:
+            The step that lent the group, which the caller now owes a rollout, or None.
+        """
+        if target_step is None:
+            return None
+        if target_step < self._trainer_version:
+            return None
+        lender_step = self._buffer.promote_ready_group(to_target_step=target_step)
+        if lender_step is None:
+            return None
+        self._batch_promotions[target_step] = (
+            self._batch_promotions.get(target_step, 0) + 1
+        )
+        print(
+            f"  target_step={target_step}: filled the dropped group by promoting a "
+            f"finished group from target_step={lender_step}; the spare prompt is "
+            "dispatched to repay that step instead",
+            flush=True,
+        )
+        return lender_step
+
+    def _credit_shortfall(self, target_step: Optional[int]) -> None:
+        """Record that a stamped step will never receive a group it is waiting for."""
+        if target_step is None:
+            return
+        self._batch_shortfall[target_step] = (
+            self._batch_shortfall.get(target_step, 0) + 1
+        )
+        print(
+            f"  target_step={target_step} is one group short "
+            f"({self._batch_shortfall[target_step]} total); the train pump "
+            "will close that step early",
+            flush=True,
+        )
+
+    def _target_groups_for_step(self, step: int) -> int:
+        """How many prompt groups this step should train on, after dropped prompts.
+
+        ``num_prompts_per_step`` is the target; groups stamped for this step that were
+        given up on are subtracted, because they are never arriving and a sampler that
+        matches batches to steps exactly cannot substitute another step's groups for
+        them. Without this the pump waits on a group no one is generating.
+
+        The step trains on fewer samples than configured, which is the point: a smaller
+        step beats a stalled run. The count is logged as ``dropped_prompt_groups`` so
+        the batch size a step actually used is recoverable afterwards.
+
+        How much smaller is bounded by ``min_step_batch_fraction``, and that bound has
+        to live here because neither drop budget provides it. Both budgets are
+        run-scoped -- the consecutive counter is cleared by any commit, including
+        commits for other steps -- so drops landing on one step while other steps
+        succeed can shrink it without ever tripping them.
+
+        Raises:
+            RuntimeError: The step fell below ``min_step_batch_fraction`` of
+                ``num_prompts_per_step``. Training a fraction of a batch is a silent
+                change to the gradient estimate, so it is refused rather than absorbed.
+        """
+        num_prompts_per_step = self._master_config.grpo.num_prompts_per_step
+        dropped = self._batch_shortfall.get(step, 0)
+        target = num_prompts_per_step - dropped
+        fraction = self._async_cfg.rollout_failure.min_step_batch_fraction
+        # ceil, so the floor is never rounded down into allowing one more drop than the
+        # fraction states. With fraction > 0 this is always >= 1, which also rules out
+        # the empty step.
+        floor = math.ceil(num_prompts_per_step * fraction)
+        if target < floor:
+            raise RuntimeError(
+                f"training step {step} lost {dropped} of {num_prompts_per_step} prompt "
+                f"group(s), leaving {target}, below the floor of {floor} set by "
+                f"async_rl.rollout_failure.min_step_batch_fraction={fraction}. "
+                "Either the generation fleet is failing a whole step's worth of "
+                "prompts, or the drop budgets are set too high to catch it: they are "
+                "run-scoped and cannot bound how short a single step gets."
+            )
+        return target
 
     async def _train_pump(self) -> None:
         """Per-prompt-group streaming train loop.
@@ -517,7 +859,12 @@ class SingleControllerActor:
             calibration_batches: list[BatchedDataDict[Any]] = []
 
             with self._timer.time("total_step_time"):
-                while groups_dispatched < grpo_cfg.num_prompts_per_step:
+                # Re-read on every iteration rather than once: a prompt stamped for this
+                # step can be dropped while the pump is already waiting for it, which is
+                # precisely the case that would otherwise wait forever.
+                while groups_dispatched < self._target_groups_for_step(
+                    version_during_step
+                ):
                     # Wait for a selectable batch
                     with self._timer.time("exposed_generation"):
                         await asyncio.sleep(0)
@@ -535,10 +882,19 @@ class SingleControllerActor:
                             for _ in range(evicted):
                                 self._buffer_capacity.release()
 
-                        # Select a batch
-                        max_prompt_groups = (
-                            grpo_cfg.num_prompts_per_step - groups_dispatched
+                        # Select a batch. Read the target again rather than reusing
+                        # the loop condition's value: the awaits above are a window in
+                        # which a prompt stamped for this step can be dropped, and the
+                        # target would then be stale by the time it is subtracted. It
+                        # can also have fallen to what is already dispatched, which is
+                        # not a batch the sampler can be asked for -- select() rejects
+                        # a min below 1 -- so close the step instead.
+                        target_groups = self._target_groups_for_step(
+                            version_during_step
                         )
+                        max_prompt_groups = target_groups - groups_dispatched
+                        if max_prompt_groups <= 0:
+                            break
                         min_prompt_groups = min(
                             self._async_cfg.min_groups_for_streaming_train,
                             max_prompt_groups,
@@ -560,11 +916,14 @@ class SingleControllerActor:
                                         flush=True,
                                     )
                                     return
+                                # Against the step's own target, not the configured
+                                # batch size: a step that legitimately shrank would
+                                # otherwise be reported as missing groups it was
+                                # already excused from.
                                 raise RuntimeError(
                                     "rollout exhausted before a complete training "
                                     f"step was assembled: dispatched "
-                                    f"{groups_dispatched}/"
-                                    f"{grpo_cfg.num_prompts_per_step} prompt "
+                                    f"{groups_dispatched}/{target_groups} prompt "
                                     f"groups with {buffered_groups} group(s) "
                                     f"remaining in the buffer"
                                 )
@@ -698,6 +1057,33 @@ class SingleControllerActor:
 
                 self._trainer_version += 1
                 self._train_steps += 1
+                dropped_prompt_groups = self._batch_shortfall.get(
+                    version_during_step, 0
+                )
+                replaced_prompt_groups = self._batch_replacements.get(
+                    version_during_step, 0
+                )
+                promoted_prompt_groups = self._batch_promotions.get(
+                    version_during_step, 0
+                )
+                # Prune every stamp this step or older. Popping only this step's entry
+                # would leak the ones belonging to a step that was already closed when
+                # a straggler stamped for it was finally given up on.
+                self._batch_shortfall = {
+                    step: dropped
+                    for step, dropped in self._batch_shortfall.items()
+                    if step > version_during_step
+                }
+                self._batch_replacements = {
+                    step: replaced
+                    for step, replaced in self._batch_replacements.items()
+                    if step > version_during_step
+                }
+                self._batch_promotions = {
+                    step: promoted
+                    for step, promoted in self._batch_promotions.items()
+                    if step > version_during_step
+                }
                 with self._timer.time("weight_sync"):
                     calibration_data = (
                         BatchedDataDict.from_batches(calibration_batches)
@@ -711,11 +1097,31 @@ class SingleControllerActor:
                         {
                             "evicted_stale_prompt_groups": evicted_stale_prompt_groups,
                             "aborted_stale_inflight_groups": aborted_stale_inflight_groups,
+                            # Non-zero means this step trained on a smaller batch than
+                            # num_prompts_per_step, which any comparison of step metrics
+                            # across steps has to account for.
+                            "dropped_prompt_groups": dropped_prompt_groups,
+                            # Groups filled by a spare prompt this step waited on --
+                            # either one it lost itself, or one it lent to an earlier
+                            # step and was repaid for. Non-zero here with zero above is
+                            # the healthy shape of on_dropped_prompt="replace": the
+                            # batch stayed whole, and the cost was the wall-clock spent
+                            # waiting on the spare.
+                            "replaced_prompt_groups": replaced_prompt_groups,
+                            # Groups this step lost and filled by borrowing finished work
+                            # from a later step. The better shape of the same thing: the
+                            # batch stayed whole and nothing waited for it, with the
+                            # repayment showing up as a replacement on the lender.
+                            "promoted_prompt_groups": promoted_prompt_groups,
                         }
                     )
 
                 # Checkpointing (mirrors async_grpo_train's save block).
-                self._consumed_samples += grpo_cfg.num_prompts_per_step
+                # What the step actually trained on, which is num_prompts_per_step only
+                # when nothing was dropped. Counted from the dispatch tally rather than
+                # derived from the shortfall so the figure does not depend on the
+                # bookkeeping staying exact; this lands in the checkpoint.
+                self._consumed_samples += groups_dispatched
                 self._total_valid_tokens += step_metrics.get("global_valid_toks", 0)
                 self._timeout.mark_iteration()
 
@@ -1102,6 +1508,15 @@ class SingleControllerActor:
         # Snapshot before any await so it can't interleave with
         # _rollout_pump iterating this same dataloader.
         dataloader_state = self._dataloader.state_dict()
+        # The spare pool has to be saved with that snapshot, not left out of the
+        # checkpoint: diverting a batch already advanced the iterator, so the state
+        # above records those prompts as consumed while they are still only in memory.
+        # Without this a resumed replace-mode run comes back with an empty pool and a
+        # dataloader positioned past the diverted batch, silently losing it -- and
+        # losing it for good, since _drain_reserve_into_steps only ever recovers spares
+        # held by the process that diverted them. Snapshotted here, in the same
+        # await-free window, so the pair cannot disagree.
+        reserve_state = list(self._replacement_reserve)
         # SC has no validation loop yet; drop the default sentinel instead of
         # persisting a bogus val_reward.
         if hasattr(save_state, "val_reward"):
@@ -1143,6 +1558,12 @@ class SingleControllerActor:
             dataloader_state,
             os.path.join(checkpoint_path, "train_dataloader.pt"),
         )
+        if reserve_state:
+            await asyncio.to_thread(
+                torch.save,
+                reserve_state,
+                os.path.join(checkpoint_path, "replacement_reserve.pt"),
+            )
         buffer_state = await self._buffer.state_dict(
             saved_capacity=self._async_cfg.max_buffered_rollouts
         )

--- a/nemo_rl/algorithms/single_controller_utils/config.py
+++ b/nemo_rl/algorithms/single_controller_utils/config.py
@@ -565,21 +565,26 @@ def validate_sampler_buffer_capacity(
         )
 
 
-def _warn_on_inert_failure_settings(
+def _validate_failure_settings(
     async_config: AsyncRLConfig,
     num_prompts_per_step: int,
 ) -> None:
-    """Warn about rollout_failure settings that cannot do what they were set for.
+    """Check rollout_failure settings that cannot do what they were set for.
 
     ``RolloutFailureConfig._check_consistent`` rejects the two combinations that make
     ``on_dropped_prompt="replace"`` unable to ever produce a replacement. These are the
     combinations it cannot see, because each depends on a field outside that block.
 
-    Warnings rather than errors, deliberately: every one of these is a coherent thing
-    to have typed -- a strict "never train a short batch" run, one base YAML whose
-    sampler is overridden per experiment, a deliberately deep spare pool -- so
-    rejecting them would forbid configurations somebody wants. What is not acceptable
-    is finding out hours into a run, or not at all.
+    Warnings rather than errors for most of them, deliberately: a strict "never train a
+    short batch" run, one base YAML whose sampler is overridden per experiment, a
+    deliberately deep spare pool are all coherent things to have typed, so rejecting
+    them would forbid configurations somebody wants. What is not acceptable is finding
+    out hours into a run, or not at all.
+
+    The exception, and the only hard error here, is a drop budget under a sampler that
+    stamps no target step. That one is not a knob cancelling itself out; it converts a
+    recoverable prompt failure into a stalled run, so there is no configuration it
+    could be the intent of.
     """
     failure_config = async_config.rollout_failure
     drop_budget = (
@@ -591,9 +596,39 @@ def _warn_on_inert_failure_settings(
     # stamped step can be credited short, so for the others the floor is unreachable
     # and the spare pool is never filled. A "custom" sampler may or may not stamp,
     # which is why it is in neither set -- a warning nobody can act on is noise.
+    #
+    # Named by exclusion rather than by list so that a sampler added later is guarded
+    # by default instead of silently exempt: every built-in but InOrderSampler leaves
+    # _GatedSampler._stamp returning None, and ready_first (#3582) landed doing exactly
+    # that after this check was first written.
     sampler_name = async_config.sampler.name
     sampler_stamps = sampler_name == "in_order"
-    sampler_never_stamps = sampler_name in ("windowed", "weight_fifo")
+    sampler_never_stamps = sampler_name not in ("in_order", "custom")
+
+    # A budget that permits drops is worse than inert under an unstamped sampler: the
+    # prompt is still given up on, but _credit_shortfall has no step to charge it to,
+    # so the step's target never falls and the train pump waits on a group nobody is
+    # generating. How that ends depends on the sampler. Under weight_fifo the wait never
+    # does: the same gate that stops the rollout pump running ahead also stops it
+    # reaching exhaustion, so the "rollout exhausted" error never fires and the run
+    # holds its GPUs until the wall clock kills it. Under windowed and ready_first the
+    # shortfall instead migrates from batch to batch until the last one, which has none
+    # left to borrow from, and the run dies there hours in. A zero budget is exempt: no
+    # drop is tolerated at all then, so nothing reaches the shortfall path and the
+    # warnings below are the right register.
+    if sampler_never_stamps and drop_budget:
+        raise ValueError(
+            f"async_rl.sampler.name={sampler_name!r} stamps no target step, so the drop "
+            f"budget (max_skipped_prompts={failure_config.max_skipped_prompts}, "
+            f"max_consecutive_dropped_prompts="
+            f"{failure_config.max_consecutive_dropped_prompts}) cannot be honoured: a "
+            "prompt that is given up on is never subtracted from the step waiting for "
+            "it, so that step waits on a group no one is generating -- ending the run "
+            "at its final step, or stalling it outright with no error at all. Set "
+            "async_rl.sampler.name='in_order' to get the tolerance these budgets "
+            "promise, or set both budgets to 0 to end the run on the first dropped "
+            "prompt instead."
+        )
 
     if (
         sampler_stamps
@@ -723,7 +758,7 @@ def validate_single_controller_config(master_config: MasterConfig) -> None:
             "loss_fn.reference_policy_kl_penalty=0."
         )
 
-    _warn_on_inert_failure_settings(async_config, num_prompts_per_step)
+    _validate_failure_settings(async_config, num_prompts_per_step)
 
     # Nesting says which knob applies to which path, but nothing stops an operator
     # filling in the block for the path this run is not taking -- and a populated

--- a/nemo_rl/algorithms/single_controller_utils/config.py
+++ b/nemo_rl/algorithms/single_controller_utils/config.py
@@ -14,8 +14,10 @@
 
 from __future__ import annotations
 
+import math
+import warnings
 from dataclasses import dataclass, field
-from typing import Any, Literal, Optional
+from typing import Annotated, Any, Literal, Optional
 
 from pydantic import (
     BaseModel,
@@ -88,12 +90,24 @@ class RolloutFailureConfig(BaseModel, extra="allow"):
     Infrastructure failures re-dispatch the prompt onto a different generation shard;
     data failures are deterministic, so their budget is small and exhausting it is
     reported rather than absorbed. Nothing here ever discards a prompt silently.
+
+    Each class also has a budget for how many prompts may be given up on entirely, and
+    the two differ because the question they answer differs. Data exhaustion is a
+    property of the dataset, so ``max_skipped_prompts`` counts them for the run's
+    lifetime. Infra exhaustion is a property of the fleet at a moment in time, so
+    ``max_consecutive_dropped_prompts`` resets on every success: an outage that ends is
+    absorbed, one that does not stops the run.
+
+    Once a prompt has been given up on, ``on_dropped_prompt`` decides what happens to
+    the training step it was stamped for: train the step on fewer groups, or substitute
+    a fresh prompt so the step keeps its configured batch size.
     """
 
     # ── shared: consumed by generate_and_push, above the impl split ──
     # Attempts for infrastructure failures (timeout, dead shard, transport). Each retry
     # re-enters shard selection, so it lands elsewhere. Exhausting this means the fleet
-    # is broken rather than the prompt, and the run fails.
+    # is broken rather than the prompt; whether that ends the run is then decided by
+    # max_consecutive_dropped_prompts below.
     #
     # Named for the failure class it bounds, not "per prompt": this budget and the data
     # budget below are INDEPENDENT counters, not a total and a sub-total. Worst case for
@@ -113,6 +127,75 @@ class RolloutFailureConfig(BaseModel, extra="allow"):
     # never actually skip anything", which meant a validator existed purely to reject
     # that one combination. At 0 the name reads as its own documentation.
     max_skipped_prompts: NonNegativeInt = 0
+    # Consecutive prompts that may exhaust their infra budget and be dropped before the
+    # run fails. Any committed rollout resets the count, so this bounds an outage rather
+    # than the run's lifetime: a fleet losing the occasional shard keeps going, a fleet
+    # that has stopped answering stops the run instead of retrying into a stall.
+    #
+    # 0 (the default) fails on the first exhaustion, which is both the behaviour before
+    # this knob existed and the default the v1 stack ships for the same idea
+    # (``async_grpo.max_generation_failures``).
+    #
+    # Counted separately from max_skipped_prompts rather than sharing one budget: a
+    # shared counter would let a bad dataset consume the allowance that exists to ride
+    # out a shard outage, which is the one distinction the failure taxonomy draws.
+    max_consecutive_dropped_prompts: NonNegativeInt = 0
+    # Smallest batch a training step may close on, as a fraction of
+    # num_prompts_per_step. Below it the run fails instead of training the step.
+    #
+    # Neither drop budget bounds this on its own. Both are properties of the run:
+    # max_skipped_prompts is a lifetime total, and the consecutive counter is cleared by
+    # any commit at all, including commits belonging to other steps. So drops
+    # concentrated on one step, interleaved with unrelated successes, keep resetting the
+    # counter while that one step shrinks without limit -- and a step is what the
+    # gradient is actually computed from.
+    #
+    # A fraction rather than a count so it holds across batch sizes, and so small
+    # batches are protected more strictly: losing 1 group of 4 is a 25% batch reduction
+    # and should not be treated like losing 1 of 128. The floor is ceil(fraction * N),
+    # so at the default a batch of 8 or fewer tolerates no drops at all.
+    min_step_batch_fraction: Annotated[float, Field(gt=0.0, le=1.0)] = 0.9
+    # What becomes of the training step a given-up prompt was stamped for. Only stamped
+    # prompts are affected: with a sampler that does not stamp (WeightFifoSampler,
+    # whose admit returns None) a step fills from whatever is ready, so a drop costs
+    # throughput but strands nothing and there is nothing to substitute for.
+    #
+    # "shrink" (the default, and the behaviour before this knob existed) closes the step
+    # on fewer groups, bounded by min_step_batch_fraction above.
+    #
+    # "replace" dispatches a fresh prompt so the step trains on the batch size that was
+    # configured. This is what both the v1 stack and verl do -- v1 discards the whole
+    # batch and regenerates it, verl's async path evicts the failed group and refills.
+    # It is bounded by max_replacement_attempts and by the spare pool below, and falls
+    # back to shrinking when either runs out; without that fallback a step whose
+    # replacements keep failing would never close at all.
+    #
+    # Where the fresh prompt is *sent* is an optimization, not a knob. If a later step
+    # already has a finished group, that group is re-stamped into the step that was
+    # dropped from -- which therefore closes immediately rather than waiting out a
+    # rollout while the trainer idles -- and the fresh prompt repays the lender, which
+    # is not due for another training step and has the slack to receive it. When no such
+    # group exists the fresh prompt fills the dropped step directly. Both paths hold the
+    # batch size; asking for the slower one is not a choice worth exposing, so the
+    # counters (promoted_prompt_groups, replaced_prompt_groups) report which one ran
+    # instead of a mode selecting it.
+    on_dropped_prompt: Literal["shrink", "replace"] = "shrink"
+    # Fresh prompts to substitute for one lost group before giving up and shrinking the
+    # step. Read only when on_dropped_prompt="replace".
+    max_replacement_attempts: NonNegativeInt = 1
+    # Low-water mark for the pool of spare prompts that replacements are drawn from. A
+    # threshold rather than a size because the pool is refilled by diverting one whole
+    # dataloader batch, so a single refill yields a batch worth of spares.
+    #
+    # The pool exists because the refill has to happen on the pump loop: it is the sole
+    # consumer of the StatefulDataLoader, and pulling from that iterator inside a
+    # dispatch task -- which is where a drop is discovered, arbitrarily later -- would
+    # race the iteration order that checkpoint/resume accounting depends on. Diverting
+    # happens before admit(), so a diverted batch never burns a target step.
+    #
+    # Read only when on_dropped_prompt="replace". Borrowing draws on it too: a group is
+    # only ever taken from a later step when a spare is in hand to repay that step.
+    replacement_reserve_prompts: NonNegativeInt = 1
     # ── path-specific ──
     native: NativeRolloutFTConfig = Field(default_factory=NativeRolloutFTConfig)
     nemo_gym: NemoGymRolloutFTConfig = Field(default_factory=NemoGymRolloutFTConfig)
@@ -124,6 +207,25 @@ class RolloutFailureConfig(BaseModel, extra="allow"):
                 f"async_rl.rollout_failure.max_backoff_s ({self.max_backoff_s}) must be "
                 f">= backoff_base_s ({self.backoff_base_s})"
             )
+        # Both of these would leave on_dropped_prompt="replace" configured but unable to
+        # ever produce a replacement, so it would quietly behave as "shrink". Rejected
+        # rather than tolerated: the whole point of asking for "replace" is the batch
+        # size guarantee, and losing it silently is the failure mode worth preventing.
+        if self.on_dropped_prompt == "replace":
+            if self.max_replacement_attempts < 1:
+                raise ValueError(
+                    "async_rl.rollout_failure.on_dropped_prompt='replace' requires "
+                    "max_replacement_attempts >= 1, got "
+                    f"{self.max_replacement_attempts}; at 0 no replacement is ever "
+                    "dispatched, which is on_dropped_prompt='shrink'"
+                )
+            if self.replacement_reserve_prompts < 1:
+                raise ValueError(
+                    "async_rl.rollout_failure.on_dropped_prompt='replace' requires "
+                    "replacement_reserve_prompts >= 1, got "
+                    f"{self.replacement_reserve_prompts}; at 0 the spare pool is never "
+                    "refilled, so every replacement falls back to shrinking"
+                )
         return self
 
     @model_validator(mode="after")
@@ -463,6 +565,81 @@ def validate_sampler_buffer_capacity(
         )
 
 
+def _warn_on_inert_failure_settings(
+    async_config: AsyncRLConfig,
+    num_prompts_per_step: int,
+) -> None:
+    """Warn about rollout_failure settings that cannot do what they were set for.
+
+    ``RolloutFailureConfig._check_consistent`` rejects the two combinations that make
+    ``on_dropped_prompt="replace"`` unable to ever produce a replacement. These are the
+    combinations it cannot see, because each depends on a field outside that block.
+
+    Warnings rather than errors, deliberately: every one of these is a coherent thing
+    to have typed -- a strict "never train a short batch" run, one base YAML whose
+    sampler is overridden per experiment, a deliberately deep spare pool -- so
+    rejecting them would forbid configurations somebody wants. What is not acceptable
+    is finding out hours into a run, or not at all.
+    """
+    failure_config = async_config.rollout_failure
+    drop_budget = (
+        failure_config.max_skipped_prompts
+        + failure_config.max_consecutive_dropped_prompts
+    )
+    floor = math.ceil(num_prompts_per_step * failure_config.min_step_batch_fraction)
+    # InOrderSampler is the only built-in that stamps a target step, and only a
+    # stamped step can be credited short, so for the others the floor is unreachable
+    # and the spare pool is never filled. A "custom" sampler may or may not stamp,
+    # which is why it is in neither set -- a warning nobody can act on is noise.
+    sampler_name = async_config.sampler.name
+    sampler_stamps = sampler_name == "in_order"
+    sampler_never_stamps = sampler_name in ("windowed", "weight_fifo")
+
+    if (
+        sampler_stamps
+        and drop_budget
+        and floor >= num_prompts_per_step
+        and failure_config.on_dropped_prompt == "shrink"
+    ):
+        warnings.warn(
+            f"async_rl.rollout_failure.min_step_batch_fraction="
+            f"{failure_config.min_step_batch_fraction} gives a floor of {floor} of "
+            f"grpo.num_prompts_per_step={num_prompts_per_step}, so no prompt may be "
+            f"dropped -- but max_skipped_prompts="
+            f"{failure_config.max_skipped_prompts} / max_consecutive_dropped_prompts="
+            f"{failure_config.max_consecutive_dropped_prompts} permit drops, and the "
+            "first one will fail the run mid-training rather than shrinking the step. "
+            "Lower min_step_batch_fraction to buy the tolerance the budgets promise, "
+            "or set on_dropped_prompt='replace' to hold the batch size instead.",
+            stacklevel=2,
+        )
+
+    if failure_config.on_dropped_prompt == "replace" and sampler_never_stamps:
+        warnings.warn(
+            f"async_rl.rollout_failure.on_dropped_prompt='replace' does nothing with "
+            f"the {sampler_name} sampler: it does not stamp a target step, so no step "
+            "is ever left short, the spare pool is never filled, and every drop "
+            "behaves as 'shrink'. replaced_prompt_groups will stay at 0 whether or "
+            "not anything failed.",
+            stacklevel=2,
+        )
+
+    if (
+        failure_config.on_dropped_prompt == "replace"
+        and failure_config.replacement_reserve_prompts > num_prompts_per_step
+    ):
+        warnings.warn(
+            f"async_rl.rollout_failure.replacement_reserve_prompts="
+            f"{failure_config.replacement_reserve_prompts} exceeds "
+            f"grpo.num_prompts_per_step={num_prompts_per_step}. The pool is refilled "
+            "by diverting one whole dataloader batch, so a mark above one batch "
+            "diverts several in a row before any is admitted -- and diverting happens "
+            "before admit(), outside the sampler gate and the buffer-capacity valve, "
+            "so nothing is dispatched while the pool fills.",
+            stacklevel=2,
+        )
+
+
 def validate_single_controller_config(master_config: MasterConfig) -> None:
     """Validate cross-section SingleController constraints before setup."""
     async_config = master_config.async_rl
@@ -545,6 +722,8 @@ def validate_single_controller_config(master_config: MasterConfig) -> None:
             "grpo.skip_reference_policy_logprobs_calculation=false, or set "
             "loss_fn.reference_policy_kl_penalty=0."
         )
+
+    _warn_on_inert_failure_settings(async_config, num_prompts_per_step)
 
     # Nesting says which knob applies to which path, but nothing stops an operator
     # filling in the block for the path this run is not taking -- and a populated

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -498,6 +498,7 @@ def _build_retry_policy(master_config: MasterConfig) -> RolloutRetryPolicy:
         backoff_base_s=failure_config.backoff_base_s,
         max_backoff_s=failure_config.max_backoff_s,
         max_skipped_prompts=failure_config.max_skipped_prompts,
+        max_consecutive_dropped_prompts=failure_config.max_consecutive_dropped_prompts,
         max_gym_row_attempts=failure_config.nemo_gym.max_row_attempts,
     )
 

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -62,8 +62,10 @@ class RolloutOutcome(str, enum.Enum):
 
     # The prompt group reached the replay buffer.
     COMMITTED = "committed"
-    # The prompt exhausted its data-failure budget within max_skipped_prompts.
-    # No group was committed, so the caller owns releasing its backpressure permit.
+    # The prompt was given up on within a budget: its data-failure budget within
+    # max_skipped_prompts, or its infrastructure budget within
+    # max_consecutive_dropped_prompts. No group was committed, so the caller owns
+    # releasing its backpressure permit and crediting the step's shortfall.
     SKIPPED = "skipped"
 
 
@@ -92,6 +94,10 @@ class RolloutRetryPolicy:
     # enforced across every generate_and_push call. 0 means none may be: the first
     # exhaustion propagates the original failure.
     max_skipped_prompts: int = 0
+    # Cap on CONSECUTIVE prompts that may exhaust their infra budget and be dropped;
+    # any commit resets the run of failures. 0 means none may be, so the first
+    # exhaustion raises RolloutRedispatchExhausted as it did before this budget existed.
+    max_consecutive_dropped_prompts: int = 0
 
     @classmethod
     def single_attempt(cls, **overrides: Any) -> "RolloutRetryPolicy":
@@ -148,6 +154,15 @@ class RolloutStats:
     data_retries_by_reason: dict[str, int] = field(default_factory=dict)
     # Prompts that ran out of data budget entirely.
     data_failures_by_reason: dict[str, int] = field(default_factory=dict)
+    # Prompts that ran out of INFRA budget and were dropped rather than failing the run.
+    # Distinct from redispatches_by_reason, which counts attempts that were retried: a
+    # fleet that recovers shows redispatches with this flat, and the two diverging is
+    # what says the outage outlasted the per-prompt budget.
+    infra_drops_by_reason: dict[str, int] = field(default_factory=dict)
+    # Longest run of consecutive infra drops seen so far. The live counter resets on
+    # every commit, so without this high-water mark a run that came within one prompt of
+    # aborting is indistinguishable from one that never dropped anything.
+    max_consecutive_infra_drops: int = 0
     # NeMo-Gym row-level re-dispatches. These recover a partial prompt group without
     # redoing the whole thing, so they never reached the counters above and gym could
     # retry rows all run with redispatch_total sitting flat.
@@ -166,6 +181,14 @@ class RolloutStats:
     def record_data_failure(self, reason: str) -> None:
         self.data_failures_by_reason[reason] = (
             self.data_failures_by_reason.get(reason, 0) + 1
+        )
+
+    def record_infra_drop(self, reason: str, consecutive: int) -> None:
+        self.infra_drops_by_reason[reason] = (
+            self.infra_drops_by_reason.get(reason, 0) + 1
+        )
+        self.max_consecutive_infra_drops = max(
+            self.max_consecutive_infra_drops, consecutive
         )
 
     def record_gym_row_redispatch(self, rows: int = 1) -> None:
@@ -188,6 +211,12 @@ class RolloutStats:
                 sum(self.data_failures_by_reason.values())
             ),
             "rollout/gym_row_redispatch_total": float(self.gym_row_redispatches),
+            "rollout/infra_drops_total": float(
+                sum(self.infra_drops_by_reason.values())
+            ),
+            "rollout/max_consecutive_infra_drops": float(
+                self.max_consecutive_infra_drops
+            ),
         }
         for reason, count in self.redispatches_by_reason.items():
             metrics[f"rollout/redispatch_total/{reason}"] = float(count)
@@ -195,6 +224,8 @@ class RolloutStats:
             metrics[f"rollout/data_retry_total/{reason}"] = float(count)
         for reason, count in self.data_failures_by_reason.items():
             metrics[f"rollout/data_failures_total/{reason}"] = float(count)
+        for reason, count in self.infra_drops_by_reason.items():
+            metrics[f"rollout/infra_drops_total/{reason}"] = float(count)
         return metrics
 
 
@@ -1136,6 +1167,10 @@ class RolloutManager:
         # Run-wide, shared across concurrent generate_and_push calls. Safe as a plain
         # int: every caller runs on the SingleController's single event loop.
         self._skipped_prompts: int = 0
+        # Infra drops since the last commit. Shared for the same reason, and shared
+        # deliberately: the question it answers -- "is the fleet still answering
+        # anyone?" -- is about the fleet, not about one prompt's history.
+        self._consecutive_infra_drops: int = 0
 
     @property
     def stats(self) -> RolloutStats:
@@ -1181,12 +1216,17 @@ class RolloutManager:
                 its dispatch task and start weight version.
 
         Returns:
-            ``COMMITTED`` when the group reached the buffer, ``SKIPPED`` when the prompt
-            exhausted its data budget within ``max_skipped_prompts``.
+            ``COMMITTED`` when the group reached the buffer, or ``SKIPPED`` when the
+            prompt was given up on within a budget: its data budget within
+            ``max_skipped_prompts``, or its infra budget within
+            ``max_consecutive_dropped_prompts``. A ``SKIPPED`` prompt committed nothing,
+            so the caller owns both its backpressure permit and the shortfall for the
+            training step it was stamped for.
 
         Raises:
-            RolloutRedispatchExhausted: The infra budget ran out.
-            RolloutDataFailure: The data budget ran out under ``fail_fast``.
+            RolloutRedispatchExhausted: The infra budget ran out and the fleet has not
+                committed anything since ``max_consecutive_dropped_prompts`` drops ago.
+            RolloutDataFailure: The data budget ran out beyond ``max_skipped_prompts``.
         """
         assert self._tq_buffer is not None, (
             "generate_and_push requires tq_buffer to be set at __init__"
@@ -1294,19 +1334,45 @@ class RolloutManager:
                 raise
 
             self._stats.committed += 1
+            # A commit proves the fleet is answering, which is exactly the claim the
+            # consecutive budget is testing, so it clears the run of drops. Placed on
+            # the success path rather than in the infra handler so that a prompt which
+            # succeeded on a retry also counts -- the fleet recovered either way.
+            self._consecutive_infra_drops = 0
             return RolloutOutcome.COMMITTED
 
         # The infrastructure budget ran out. The same failure followed the prompt across
         # repeated shard selections, which says the fleet is broken rather than the
-        # prompt, so this is reported rather than absorbed.
+        # prompt.
         #
         # The budget is >= 1 (enforced in RolloutRetryPolicy), so the loop ran at least
         # once and can only have exited through the infra branch's break.
         assert last_infra_error is not None
-        raise RolloutRedispatchExhausted(
-            f"prompt idx={input_sample['idx']} exhausted its infrastructure retry "
-            f"budget after {infra_attempts} attempt(s) "
-            f"(max_infra_attempts_per_prompt="
-            f"{policy.max_infra_attempts}); last failure was "
-            f"{type(last_infra_error).__name__}: {last_infra_error}"
-        ) from last_infra_error
+        reason = type(last_infra_error).__name__
+        self._consecutive_infra_drops += 1
+        if self._consecutive_infra_drops > policy.max_consecutive_dropped_prompts:
+            raise RolloutRedispatchExhausted(
+                f"prompt idx={input_sample['idx']} exhausted its infrastructure retry "
+                f"budget after {infra_attempts} attempt(s) "
+                f"(max_infra_attempts_per_prompt="
+                f"{policy.max_infra_attempts}), and this was drop "
+                f"{self._consecutive_infra_drops} with no rollout committed in between, "
+                f"exceeding max_consecutive_dropped_prompts="
+                f"{policy.max_consecutive_dropped_prompts}; the generation fleet is not "
+                f"recovering. Last failure was {reason}: {last_infra_error}"
+            ) from last_infra_error
+
+        # Under the budget: give up on this prompt and let the run continue. The caller
+        # owns the backpressure permit for a SKIPPED outcome, and -- because the prompt
+        # may have been stamped for a specific training step that will now never fill --
+        # owns crediting the shortfall so the train pump can close that step short.
+        self._stats.record_infra_drop(reason, self._consecutive_infra_drops)
+        print(
+            f"dropping prompt idx={input_sample['idx']} after {infra_attempts} "
+            f"infrastructure failure(s) ({reason}: {last_infra_error}) "
+            f"[consecutive drop {self._consecutive_infra_drops}/"
+            f"{policy.max_consecutive_dropped_prompts}]",
+            flush=True,
+        )
+        self._stats.skipped += 1
+        return RolloutOutcome.SKIPPED

--- a/tests/unit/experience/test_rollout_generation_failures.py
+++ b/tests/unit/experience/test_rollout_generation_failures.py
@@ -177,6 +177,7 @@ def _make_manager(buffer, impl, retry_policy=None) -> RolloutManager:
     )
     manager._stats = RolloutStats()
     manager._skipped_prompts = 0
+    manager._consecutive_infra_drops = 0
     return manager
 
 

--- a/tests/unit/experience/test_rollout_manager.py
+++ b/tests/unit/experience/test_rollout_manager.py
@@ -148,6 +148,7 @@ def _make_manager(
     )
     mgr._stats = RolloutStats()
     mgr._skipped_prompts = 0
+    mgr._consecutive_infra_drops = 0
     return mgr
 
 

--- a/tests/unit/experience/test_rollout_redispatch.py
+++ b/tests/unit/experience/test_rollout_redispatch.py
@@ -12,12 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Re-dispatch policy: no prompt is discarded for infrastructure reasons.
+"""Re-dispatch policy: a prompt is retried before it is ever given up on.
 
 An infra failure means the fleet is unwell, not the prompt, so the attempt is retried.
 The retry re-enters generation-shard selection, which is what makes it land somewhere
 else -- generate_and_push itself knows nothing about shard health. Deterministic
 failures get a much smaller budget because another shard rejects the prompt identically.
+
+A prompt that exhausts its budget is discarded only within an explicit allowance, and
+the two classes get different allowances because they answer different questions.
+``max_skipped_prompts`` is a lifetime total: a dataset does not get better.
+``max_consecutive_dropped_prompts`` resets on every commit, so it asks whether the fleet
+is answering *anyone* right now. Both default to 0, which is the fail-on-the-first-one
+behaviour these budgets were added on top of.
 
 The invariants every test here upholds:
   - nothing is committed unless the rollout actually succeeded
@@ -99,6 +106,7 @@ def _make_manager(buffer, impl, policy) -> RolloutManager:
     manager._retry_policy = policy
     manager._stats = RolloutStats()
     manager._skipped_prompts = 0
+    manager._consecutive_infra_drops = 0
     return manager
 
 
@@ -272,6 +280,122 @@ class TestDataFailures:
         asyncio.run(_drive())
 
 
+class TestInfraDropTolerance:
+    """Exhausting the infra budget need not end the run.
+
+    A fleet large enough to lose the occasional shard would otherwise fail a job over a
+    single unlucky prompt. The budget is on *consecutive* drops so that tolerance never
+    accumulates into ignoring a fleet that has stopped answering altogether -- the same
+    shape as the v1 stack's ``max_generation_failures``.
+    """
+
+    def test_exhaustion_drops_the_prompt_instead_of_failing_the_run(self, no_sleep):
+        buffer = _Buffer()
+        impl = _ScriptedImpl([GenerationUnavailable("shard down")] * 10)
+        manager = _make_manager(
+            buffer,
+            impl,
+            RolloutRetryPolicy.single_attempt(
+                max_infra_attempts=2, max_consecutive_dropped_prompts=3
+            ),
+        )
+
+        outcome = asyncio.run(manager.generate_and_push(_sample()))
+
+        assert outcome is RolloutOutcome.SKIPPED
+        assert impl.attempts == 2, "the retry budget is still spent in full first"
+        assert buffer.commits == [], "a dropped prompt must never reach training"
+        assert len(buffer.removals) == 2, "every reserved slot released"
+
+    def test_a_commit_clears_the_run_of_drops(self, no_sleep):
+        """Tolerance is per-outage, so a recovered fleet starts from zero again."""
+        buffer = _Buffer()
+        # fail, succeed, fail, succeed, ... with a budget of 1 consecutive drop. Four
+        # drops in total, none of them consecutive, so the run survives all of them.
+        impl = _ScriptedImpl([GenerationUnavailable("x"), None] * 4)
+        manager = _make_manager(
+            buffer,
+            impl,
+            RolloutRetryPolicy.single_attempt(max_consecutive_dropped_prompts=1),
+        )
+
+        async def _drive():
+            for _ in range(4):
+                assert await manager.generate_and_push(_sample()) is (
+                    RolloutOutcome.SKIPPED
+                )
+                assert await manager.generate_and_push(_sample()) is (
+                    RolloutOutcome.COMMITTED
+                )
+
+        asyncio.run(_drive())
+
+        assert manager.stats.committed == 4
+        assert manager.stats.max_consecutive_infra_drops == 1
+
+    def test_an_outage_that_does_not_recover_still_fails_the_run(self, no_sleep):
+        buffer = _Buffer()
+        impl = _ScriptedImpl([ray.exceptions.RayActorError()] * 20)
+        manager = _make_manager(
+            buffer,
+            impl,
+            RolloutRetryPolicy.single_attempt(max_consecutive_dropped_prompts=2),
+        )
+
+        async def _drive():
+            assert await manager.generate_and_push(_sample()) is RolloutOutcome.SKIPPED
+            assert await manager.generate_and_push(_sample()) is RolloutOutcome.SKIPPED
+            with pytest.raises(
+                RolloutRedispatchExhausted, match="max_consecutive_dropped_prompts=2"
+            ):
+                await manager.generate_and_push(_sample())
+
+        asyncio.run(_drive())
+
+    def test_the_default_budget_fails_on_the_first_drop(self, no_sleep):
+        """The knob is opt-in: without it, exhaustion ends the run as it always did."""
+        buffer = _Buffer()
+        impl = _ScriptedImpl([GenerationUnavailable("x")] * 5)
+        manager = _make_manager(
+            buffer, impl, RolloutRetryPolicy.single_attempt(max_infra_attempts=2)
+        )
+
+        assert manager._retry_policy.max_consecutive_dropped_prompts == 0
+        with pytest.raises(RolloutRedispatchExhausted):
+            asyncio.run(manager.generate_and_push(_sample()))
+
+    def test_the_infra_budget_is_not_spent_by_data_skips(self, no_sleep):
+        """Sharing one allowance would let a bad dataset mask a dying fleet."""
+        buffer = _Buffer()
+        # Two data skips, then an infra exhaustion. With a shared counter the infra drop
+        # would be the third and would abort; the budgets are independent, so it is the
+        # first infra drop and is tolerated.
+        impl = _ScriptedImpl(
+            [
+                RolloutDataFailure("bad prompt"),
+                RolloutDataFailure("bad prompt"),
+                GenerationUnavailable("shard down"),
+            ]
+        )
+        manager = _make_manager(
+            buffer,
+            impl,
+            RolloutRetryPolicy.single_attempt(
+                max_skipped_prompts=5, max_consecutive_dropped_prompts=1
+            ),
+        )
+
+        async def _drive():
+            for _ in range(3):
+                assert await manager.generate_and_push(_sample()) is (
+                    RolloutOutcome.SKIPPED
+                )
+
+        asyncio.run(_drive())
+
+        assert manager.stats.max_consecutive_infra_drops == 1
+
+
 class TestCancellationIsNeverRetried:
     def test_cancellation_propagates_and_releases_the_slot(self, no_sleep):
         buffer = _Buffer()
@@ -343,3 +467,45 @@ class TestStats:
         assert metrics["rollout/skipped_total"] == 1.0
         assert metrics["rollout/committed_total"] == 0.0
         assert metrics["rollout/data_failures_total/RolloutDataFailure"] == 1.0
+
+    def test_infra_drops_are_distinguishable_from_redispatches(self, no_sleep):
+        """Redispatches alone cannot say whether the fleet recovered; drops can."""
+        buffer = _Buffer()
+        impl = _ScriptedImpl([GenerationUnavailable("x")] * 5)
+        manager = _make_manager(
+            buffer,
+            impl,
+            RolloutRetryPolicy.single_attempt(
+                max_infra_attempts=2, max_consecutive_dropped_prompts=5
+            ),
+        )
+
+        asyncio.run(manager.generate_and_push(_sample()))
+
+        metrics = manager.stats.as_metrics()
+        assert metrics["rollout/infra_drops_total"] == 1.0
+        assert metrics["rollout/infra_drops_total/GenerationUnavailable"] == 1.0
+        # One retry happened before the budget ran out, so both series move -- but by
+        # different amounts, which is the whole reason they are separate.
+        assert metrics["rollout/redispatch_total"] == 1.0
+
+    def test_the_consecutive_high_water_mark_survives_recovery(self, no_sleep):
+        """The live counter resets on commit, so only this records a near-miss."""
+        buffer = _Buffer()
+        impl = _ScriptedImpl([GenerationUnavailable("x")] * 3 + [None])
+        manager = _make_manager(
+            buffer,
+            impl,
+            RolloutRetryPolicy.single_attempt(max_consecutive_dropped_prompts=5),
+        )
+
+        async def _drive():
+            for _ in range(3):
+                await manager.generate_and_push(_sample())
+            await manager.generate_and_push(_sample())
+
+        asyncio.run(_drive())
+
+        metrics = manager.stats.as_metrics()
+        assert metrics["rollout/max_consecutive_infra_drops"] == 3.0
+        assert manager._consecutive_infra_drops == 0, "the commit cleared the live run"

--- a/tests/unit/single_controller/test_resiliency_config.py
+++ b/tests/unit/single_controller/test_resiliency_config.py
@@ -20,6 +20,7 @@ combinations that would silently do nothing are rejected at load time rather tha
 hour three of a run.
 """
 
+import warnings
 from types import SimpleNamespace
 
 import pytest
@@ -35,6 +36,26 @@ from nemo_rl.algorithms.single_controller_utils.config import (
     WatchdogConfig,
     validate_single_controller_config,
 )
+from nemo_rl.algorithms.single_controller_utils.setup import _build_retry_policy
+
+
+def _master_config(*, num_prompts_per_step: int = 8, **async_kwargs) -> MasterConfig:
+    """A config the SC validator accepts, with the fields under test overridable."""
+    return MasterConfig.model_construct(
+        async_rl=AsyncRLConfig(
+            min_groups_for_streaming_train=num_prompts_per_step,
+            **async_kwargs,
+        ),
+        grpo=GRPOConfig.model_construct(
+            num_prompts_per_step=num_prompts_per_step,
+            num_generations_per_prompt=4,
+            skip_reference_policy_logprobs_calculation=False,
+        ),
+        policy={"train_global_batch_size": num_prompts_per_step * 4},
+        loss_fn=SimpleNamespace(reference_policy_kl_penalty=0),
+        env={"should_use_nemo_gym": True},
+        checkpointing={"enabled": False, "metric_name": None},
+    )
 
 
 class TestDefaultsAreInert:
@@ -51,6 +72,11 @@ class TestDefaultsAreInert:
         assert cfg.backoff_base_s == 1.0
         assert cfg.max_backoff_s == 30.0
         assert cfg.max_skipped_prompts == 0
+        assert cfg.max_consecutive_dropped_prompts == 0
+        assert cfg.min_step_batch_fraction == 0.9
+        assert cfg.on_dropped_prompt == "shrink"
+        assert cfg.max_replacement_attempts == 1
+        assert cfg.replacement_reserve_prompts == 1
         assert cfg.nemo_gym.max_row_attempts == 3
 
     def test_watchdog_has_documented_defaults(self):
@@ -94,6 +120,72 @@ class TestRolloutFailureValidation:
         validator existed purely to reject that one combination.
         """
         assert RolloutFailureConfig().max_skipped_prompts == 0
+
+    def test_a_consecutive_drop_budget_is_accepted(self):
+        cfg = RolloutFailureConfig(max_consecutive_dropped_prompts=4)
+        assert cfg.max_consecutive_dropped_prompts == 4
+
+    def test_the_two_drop_budgets_are_independent_knobs(self):
+        """Tolerating a bad dataset must not imply tolerating a dying fleet."""
+        cfg = RolloutFailureConfig(max_skipped_prompts=100)
+        assert cfg.max_consecutive_dropped_prompts == 0
+
+    @pytest.mark.parametrize("fraction", [0.0, -0.1, 1.1])
+    def test_an_out_of_range_step_floor_is_rejected(self, fraction):
+        """0 would permit an empty step; above 1 could never be satisfied."""
+        with pytest.raises(ValidationError):
+            RolloutFailureConfig(min_step_batch_fraction=fraction)
+
+    def test_a_full_step_floor_is_allowed_and_forbids_shrinking(self):
+        assert RolloutFailureConfig(min_step_batch_fraction=1.0).min_step_batch_fraction
+
+    def test_replace_mode_is_opt_in(self):
+        """Shrinking is what the branch shipped with; replacing must be asked for."""
+        assert RolloutFailureConfig().on_dropped_prompt == "shrink"
+
+    @pytest.mark.parametrize("policy", ["regenerate", "promote"])
+    def test_an_unknown_drop_policy_is_rejected(self, policy):
+        """Borrowing is an optimization inside "replace", not a mode to select.
+
+        Both paths hold the batch size, so "please hold it the slower way" is not a
+        choice worth offering; promoted_prompt_groups reports which one ran.
+        """
+        with pytest.raises(ValidationError):
+            RolloutFailureConfig(on_dropped_prompt=policy)
+
+    @pytest.mark.parametrize(
+        ("field", "message"),
+        [
+            ("max_replacement_attempts", "max_replacement_attempts"),
+            ("replacement_reserve_prompts", "replacement_reserve_prompts"),
+        ],
+    )
+    def test_replace_mode_that_could_never_replace_is_rejected(self, field, message):
+        """Either zero leaves "replace" configured but behaving as "shrink".
+
+        Silently degrading is the failure worth catching: the only reason to ask for
+        replacement is the batch-size guarantee, so losing it without a word defeats
+        the point of setting the knob. The spare pool gates borrowing too, since a
+        group is only taken from a later step when a spare can repay it.
+        """
+        with pytest.raises(ValidationError, match=message):
+            RolloutFailureConfig(on_dropped_prompt="replace", **{field: 0})
+
+    def test_the_same_zeros_are_fine_while_shrinking(self):
+        """They are only read in replace mode, so shrink runs must not trip on them."""
+        cfg = RolloutFailureConfig(
+            max_replacement_attempts=0, replacement_reserve_prompts=0
+        )
+        assert cfg.on_dropped_prompt == "shrink"
+
+    def test_replace_mode_accepts_a_deeper_budget(self):
+        cfg = RolloutFailureConfig(
+            on_dropped_prompt="replace",
+            max_replacement_attempts=3,
+            replacement_reserve_prompts=16,
+        )
+        assert cfg.max_replacement_attempts == 3
+        assert cfg.replacement_reserve_prompts == 16
 
     @pytest.mark.parametrize("attempts", [0, -1])
     def test_non_positive_attempt_budgets_are_rejected(self, attempts):
@@ -419,3 +511,99 @@ class TestRouterDeadlineFitsInsideTheRollout:
             rollout_failure={"nemo_gym": {"rollout_timeout_s": 60.0}},
         )
         assert cfg.generation_router.enabled is False
+
+
+class TestTheDropBudgetsReachTheRolloutLayer:
+    """A validated knob that no one reads is still a knob that does nothing.
+
+    ``max_consecutive_dropped_prompts`` is enforced inside RolloutManager, which only
+    ever sees ``RolloutRetryPolicy``. Nothing else in the suite crosses that seam, so a
+    dropped assignment in `_build_retry_policy` would leave every config test green
+    while the budget silently reverted to the default.
+    """
+
+    def test_the_configured_budgets_are_carried_across(self):
+        policy = _build_retry_policy(
+            _master_config(
+                rollout_failure={
+                    "max_consecutive_dropped_prompts": 8,
+                    "max_skipped_prompts": 3,
+                }
+            )
+        )
+        assert policy.max_consecutive_dropped_prompts == 8
+        assert policy.max_skipped_prompts == 3
+
+    def test_the_default_still_fails_the_run_on_the_first_drop(self):
+        policy = _build_retry_policy(_master_config())
+        assert policy.max_consecutive_dropped_prompts == 0
+        assert policy.max_skipped_prompts == 0
+
+
+class TestCombinationsThatCannotDoWhatTheyWereSetFor:
+    """Coherent configs whose knobs cancel out warn instead of failing.
+
+    Each of these parses, and each is a defensible thing to ask for while debugging, so
+    rejecting them would be wrong. What is not defensible is discovering hours in that
+    the tolerance you configured could never have been exercised.
+    """
+
+    @staticmethod
+    def _messages(cfg) -> list[str]:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            validate_single_controller_config(cfg)
+        return [str(w.message) for w in caught]
+
+    def test_a_floor_that_rounds_up_to_the_full_batch_cancels_the_drop_budget(self):
+        """8 prompts at the 0.9 default floor to 8: no step may ever run short."""
+        cfg = _master_config(rollout_failure={"max_consecutive_dropped_prompts": 4})
+        with pytest.warns(UserWarning, match="min_step_batch_fraction"):
+            validate_single_controller_config(cfg)
+
+    def test_replacing_keeps_the_full_batch_legitimately(self):
+        """A full floor is the point of replace mode, not a contradiction with it."""
+        cfg = _master_config(
+            rollout_failure={
+                "max_consecutive_dropped_prompts": 4,
+                "min_step_batch_fraction": 1.0,
+                "on_dropped_prompt": "replace",
+            }
+        )
+        assert not any("min_step_batch_fraction" in m for m in self._messages(cfg))
+
+    def test_a_floor_that_leaves_room_to_shrink_is_not_warned_about(self):
+        cfg = _master_config(
+            rollout_failure={
+                "max_consecutive_dropped_prompts": 4,
+                "min_step_batch_fraction": 0.5,
+            }
+        )
+        assert not any("min_step_batch_fraction" in m for m in self._messages(cfg))
+
+    def test_replacing_under_a_sampler_that_never_stamps_falls_back_to_shrinking(self):
+        """Replacement needs a step stamp to know which step it owes a group to."""
+        cfg = _master_config(
+            sampler={"name": "windowed"},
+            rollout_failure={"on_dropped_prompt": "replace"},
+        )
+        with pytest.warns(UserWarning, match="on_dropped_prompt"):
+            validate_single_controller_config(cfg)
+
+    def test_a_stamping_sampler_is_not_warned_about(self):
+        cfg = _master_config(rollout_failure={"on_dropped_prompt": "replace"})
+        assert not any("on_dropped_prompt" in m for m in self._messages(cfg))
+
+    def test_a_reserve_larger_than_a_step_can_never_fill(self):
+        """The reserve is skimmed from completed steps, so a step bounds it."""
+        cfg = _master_config(
+            rollout_failure={
+                "on_dropped_prompt": "replace",
+                "replacement_reserve_prompts": 100,
+            }
+        )
+        with pytest.warns(UserWarning, match="replacement_reserve_prompts"):
+            validate_single_controller_config(cfg)
+
+    def test_an_untouched_config_warns_about_nothing(self):
+        assert self._messages(_master_config()) == []

--- a/tests/unit/single_controller/test_resiliency_config.py
+++ b/tests/unit/single_controller/test_resiliency_config.py
@@ -22,10 +22,12 @@ hour three of a run.
 
 import warnings
 from types import SimpleNamespace
+from typing import get_args
 
 import pytest
 from pydantic import ValidationError
 
+from nemo_rl.algorithms.async_utils.staleness_sampler import SamplerConfig
 from nemo_rl.algorithms.grpo import GRPOConfig
 from nemo_rl.algorithms.single_controller_utils.config import (
     AsyncRLConfig,
@@ -37,6 +39,17 @@ from nemo_rl.algorithms.single_controller_utils.config import (
     validate_single_controller_config,
 )
 from nemo_rl.algorithms.single_controller_utils.setup import _build_retry_policy
+
+
+def _all_sampler_names() -> list[str]:
+    """Every name the sampler union accepts, read off the union itself.
+
+    ``SamplerConfig`` is ``Annotated[Union[...], Field(discriminator=...)]``, so the
+    variants are one level in. Deriving the list rather than restating it is the point:
+    a sampler added later shows up here on its own.
+    """
+    variants = get_args(get_args(SamplerConfig)[0])
+    return [variant.model_fields["name"].default for variant in variants]
 
 
 def _master_config(*, num_prompts_per_step: int = 8, **async_kwargs) -> MasterConfig:
@@ -52,7 +65,13 @@ def _master_config(*, num_prompts_per_step: int = 8, **async_kwargs) -> MasterCo
             skip_reference_policy_logprobs_calculation=False,
         ),
         policy={"train_global_batch_size": num_prompts_per_step * 4},
-        loss_fn=SimpleNamespace(reference_policy_kl_penalty=0),
+        # The last two are read only on the ready_first branch, which rejects a run
+        # without them before it reaches anything under test here.
+        loss_fn=SimpleNamespace(
+            reference_policy_kl_penalty=0,
+            use_importance_sampling_correction=True,
+            force_on_policy_ratio=False,
+        ),
         env={"should_use_nemo_gym": True},
         checkpointing={"enabled": False, "metric_name": None},
     )
@@ -607,3 +626,83 @@ class TestCombinationsThatCannotDoWhatTheyWereSetFor:
 
     def test_an_untouched_config_warns_about_nothing(self):
         assert self._messages(_master_config()) == []
+
+
+class TestADropBudgetNeedsASamplerThatStamps:
+    """The one combination in this area that is rejected rather than warned about.
+
+    An unstamped drop is not a pair of knobs cancelling out: the prompt is given up on
+    and no step is credited for it, so that step waits on a group nobody is generating.
+    Under ``weight_fifo`` the gate that stops the rollout pump running ahead also stops
+    it reaching exhaustion, so the "rollout exhausted" error never fires and the run
+    stalls silently -- which is why config load is the last place that can object.
+    """
+
+    @pytest.mark.parametrize("sampler_name", ["windowed", "weight_fifo", "ready_first"])
+    @pytest.mark.parametrize(
+        "budget",
+        [{"max_skipped_prompts": 1}, {"max_consecutive_dropped_prompts": 1}],
+    )
+    def test_either_budget_under_any_unstamped_sampler_is_rejected(
+        self, sampler_name, budget
+    ):
+        cfg = _master_config(sampler={"name": sampler_name}, rollout_failure=budget)
+        with pytest.raises(ValueError, match="stamps no target step"):
+            validate_single_controller_config(cfg)
+
+    def test_every_built_in_but_in_order_and_custom_is_covered(self):
+        """Read off the union, so a sampler added later is caught by default.
+
+        ready_first (#3582) landed between this PR's base and its rebase, inheriting the
+        None stamp like the rest. An allow-list would have let it straight through, and a
+        test that hardcoded the same list would have stayed green while it did.
+        """
+        exempt = {"in_order", "custom"}
+        covered = [n for n in _all_sampler_names() if n not in exempt]
+        assert covered, "the union should carry at least one unstamped sampler"
+        for sampler_name in covered:
+            cfg = _master_config(
+                sampler={"name": sampler_name},
+                rollout_failure={"max_consecutive_dropped_prompts": 1},
+            )
+            with pytest.raises(ValueError, match="stamps no target step"):
+                validate_single_controller_config(cfg)
+
+    def test_shrink_mode_is_rejected_too_not_only_replace(self):
+        """The gap this closes: shrink is the default, so it was the silent one."""
+        cfg = _master_config(
+            sampler={"name": "weight_fifo"},
+            rollout_failure={
+                "max_consecutive_dropped_prompts": 2,
+                "on_dropped_prompt": "shrink",
+            },
+        )
+        with pytest.raises(ValueError, match="stamps no target step"):
+            validate_single_controller_config(cfg)
+
+    def test_a_stamping_sampler_carries_the_same_budget(self):
+        cfg = _master_config(
+            sampler={"name": "in_order"},
+            rollout_failure={
+                "max_consecutive_dropped_prompts": 2,
+                "min_step_batch_fraction": 0.5,
+            },
+        )
+        validate_single_controller_config(cfg)
+
+    def test_a_zero_budget_is_left_to_the_warnings(self):
+        """No drop is tolerated at all, so the shortfall path is unreachable anyway."""
+        cfg = _master_config(
+            sampler={"name": "windowed"},
+            rollout_failure={"on_dropped_prompt": "replace"},
+        )
+        with pytest.warns(UserWarning, match="on_dropped_prompt"):
+            validate_single_controller_config(cfg)
+
+    def test_a_custom_sampler_is_not_second_guessed(self):
+        """Whether it stamps is knowable only to its author, so neither set claims it."""
+        cfg = _master_config(
+            sampler={"name": "custom", "target": "my_pkg.samplers:MySampler"},
+            rollout_failure={"max_consecutive_dropped_prompts": 2},
+        )
+        validate_single_controller_config(cfg)

--- a/tests/unit/single_controller/test_rollout_pump.py
+++ b/tests/unit/single_controller/test_rollout_pump.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections import deque
 from types import SimpleNamespace
 from typing import Any
 
@@ -62,17 +63,65 @@ from tests.unit.single_controller._dp_fakes import (
 )
 
 
-class _RecordingBuffer:
-    """TQReplayBuffer stand-in recording the target_step of each reserve."""
+def _failure_cfg(
+    *,
+    on_dropped_prompt: str = "shrink",
+    max_replacement_attempts: int = 1,
+    replacement_reserve_prompts: int = 1,
+    min_step_batch_fraction: float = 0.9,
+) -> SimpleNamespace:
+    """The rollout_failure block the pump reads, defaulted to today's behaviour."""
+    return SimpleNamespace(
+        on_dropped_prompt=on_dropped_prompt,
+        max_replacement_attempts=max_replacement_attempts,
+        replacement_reserve_prompts=replacement_reserve_prompts,
+        min_step_batch_fraction=min_step_batch_fraction,
+    )
 
-    def __init__(self, target_step_list: list[int | None] | None = None) -> None:
+
+def _init_pump_ledgers(ctrl: Any) -> None:
+    """Set the per-step bookkeeping the pump reads unconditionally.
+
+    Empty is the neutral state, so tests that do not care about these can call this
+    and forget them. They are collected here because every hand-built controller in
+    this file needs all of them, and a field added to only some of the builders is a
+    missing attribute rather than a wrong answer.
+    """
+    ctrl._batch_shortfall = {}
+    ctrl._batch_replacements = {}
+    ctrl._batch_promotions = {}
+    ctrl._replacement_reserve = deque()
+
+
+class _RecordingBuffer:
+    """TQReplayBuffer stand-in recording the target_step of each reserve.
+
+    Seeded entries stand for groups whose rollout has already finished; anything the
+    pump reserves during the test is in flight and so unready, as in the real buffer.
+    """
+
+    def __init__(
+        self,
+        target_step_list: list[int | None] | None = None,
+        ready_list: list[bool] | None = None,
+    ) -> None:
         self.target_step_list: list[int | None] = list(target_step_list or [])
+        self.ready_list: list[bool] = (
+            list(ready_list)
+            if ready_list is not None
+            else [True] * len(self.target_step_list)
+        )
 
     def reserve(self, *, target_step: int | None) -> None:
         self.target_step_list.append(target_step)
+        self.ready_list.append(False)
 
     def count_for_target_step(self, target_step: int) -> int:
         return sum(1 for target in self.target_step_list if target == target_step)
+
+    # The real thing, so the pump tests exercise the promotion the controller ships
+    # rather than a second implementation of it that could drift.
+    promote_ready_group = TQReplayBuffer.promote_ready_group
 
 
 class _RecordingRolloutManager:
@@ -110,6 +159,7 @@ def test_rollout_pump_stamps_target_steps(
     ctrl._async_cfg = SimpleNamespace(
         max_inflight_prompts=2,
         diagnostics=False,
+        rollout_failure=_failure_cfg(),
     )
     ctrl._master_config = SimpleNamespace(
         grpo=GRPOConfig.model_construct(max_num_epochs=1)
@@ -131,6 +181,7 @@ def test_rollout_pump_stamps_target_steps(
     ctrl._dispatched_rollouts = set()
     ctrl._trainer_version = 0
     ctrl._current_epoch = 0
+    _init_pump_ledgers(ctrl)
 
     asyncio.run(ctrl._rollout_pump())
 
@@ -166,7 +217,9 @@ def test_rollout_pump_releases_capacity_only_for_uncommitted_prompts(
 
     controller_cls = SingleControllerActor.__ray_metadata__.modified_class
     ctrl = object.__new__(controller_cls)
-    ctrl._async_cfg = SimpleNamespace(max_inflight_prompts=2, diagnostics=False)
+    ctrl._async_cfg = SimpleNamespace(
+        max_inflight_prompts=2, diagnostics=False, rollout_failure=_failure_cfg()
+    )
     ctrl._master_config = SimpleNamespace(
         grpo=GRPOConfig.model_construct(max_num_epochs=1)
     )
@@ -184,6 +237,7 @@ def test_rollout_pump_releases_capacity_only_for_uncommitted_prompts(
     ctrl._trainer_version = 0
     ctrl._current_epoch = 0
     ctrl._inflight_by_group_id = {}
+    _init_pump_ledgers(ctrl)
 
     asyncio.run(ctrl._rollout_pump())
 
@@ -217,7 +271,9 @@ def test_rollout_pump_tops_up_restored_target_step(
     controller_cls = SingleControllerActor.__ray_metadata__.modified_class
     ctrl = object.__new__(controller_cls)
     ctrl._buffer = buffer
-    ctrl._async_cfg = SimpleNamespace(max_inflight_prompts=2, diagnostics=False)
+    ctrl._async_cfg = SimpleNamespace(
+        max_inflight_prompts=2, diagnostics=False, rollout_failure=_failure_cfg()
+    )
     ctrl._master_config = SimpleNamespace(
         grpo=GRPOConfig.model_construct(max_num_epochs=1)
     )
@@ -243,6 +299,7 @@ def test_rollout_pump_tops_up_restored_target_step(
     ctrl._dispatched_rollouts = set()
     ctrl._trainer_version = 0
     ctrl._current_epoch = 0
+    _init_pump_ledgers(ctrl)
 
     asyncio.run(ctrl._rollout_pump())
 
@@ -254,6 +311,452 @@ def test_rollout_pump_tops_up_restored_target_step(
     assert ctrl._buffer_capacity._value == 4 - expected_new_dispatches
     assert ctrl._inflight_rollouts == 0
     assert ctrl._rollout_exhausted.is_set()
+
+
+class _SkippingRolloutManager:
+    """Every prompt is given up on within budget, so nothing is ever committed."""
+
+    async def generate_and_push(
+        self,
+        prompt: Any,
+        *,
+        target_step: int | None = None,
+        inflight_registry: dict[str, Any] | None = None,
+    ) -> RolloutOutcome:
+        del prompt, target_step, inflight_registry
+        return RolloutOutcome.SKIPPED
+
+
+@pytest.mark.parametrize(
+    ("make_sampler", "expected_shortfall"),
+    [
+        # in_order matches a batch to one step exactly, so a group that is never
+        # generated leaves that step permanently short. Without the credit the train
+        # pump waits on it forever, turning a tolerated drop into a hung run.
+        (lambda buf: InOrderSampler(buf, max_lookahead_versions=1), {0: 1, 1: 1}),
+        # weight_fifo does not stamp a step: the batch fills from whatever is ready, so
+        # a drop costs throughput and strands nothing. Crediting here would shrink an
+        # unrelated step.
+        (lambda buf: WeightFifoSampler(buf, max_staleness_versions=1), {}),
+    ],
+)
+def test_rollout_pump_credits_shortfall_only_for_stamped_prompts(
+    make_sampler,
+    expected_shortfall: dict[int, int],
+) -> None:
+    buffer = _RecordingBuffer()
+    controller_cls = SingleControllerActor.__ray_metadata__.modified_class
+    ctrl = object.__new__(controller_cls)
+    ctrl._buffer = buffer
+    ctrl._async_cfg = SimpleNamespace(
+        max_inflight_prompts=2, diagnostics=False, rollout_failure=_failure_cfg()
+    )
+    ctrl._master_config = SimpleNamespace(
+        grpo=GRPOConfig.model_construct(max_num_epochs=1)
+    )
+    ctrl._rollout_manager = _SkippingRolloutManager()
+    ctrl._sampler = make_sampler(buffer)
+    prompt_batch = BatchedDataDict(
+        {"message_log": [[{"role": "user", "content": "prompt"}]]}
+    )
+    ctrl._dataloader = [prompt_batch, prompt_batch]
+    ctrl._rollout_permitted = asyncio.Event()
+    ctrl._rollout_permitted.set()
+    ctrl._rollout_exhausted = asyncio.Event()
+    ctrl._buffer_capacity = asyncio.Semaphore(2)
+    ctrl._inflight_rollouts = 0
+    ctrl._inflight_by_group_id = {}
+    ctrl._dispatched_rollouts = set()
+    ctrl._trainer_version = 0
+    ctrl._current_epoch = 0
+    _init_pump_ledgers(ctrl)
+
+    asyncio.run(ctrl._rollout_pump())
+
+    assert ctrl._batch_shortfall == expected_shortfall
+    # A dropped prompt commits nothing, so every permit comes back either way.
+    assert ctrl._buffer_capacity._value == 2
+
+
+class _ScriptedRolloutManager:
+    """Returns a scripted outcome per call, recording which prompt each one saw."""
+
+    def __init__(self, outcomes: list[RolloutOutcome]) -> None:
+        self._outcomes = list(outcomes)
+        self.prompts_seen: list[str] = []
+
+    async def generate_and_push(
+        self,
+        prompt: Any,
+        *,
+        target_step: int | None = None,
+        inflight_registry: dict[str, Any] | None = None,
+    ) -> RolloutOutcome:
+        del target_step, inflight_registry
+        self.prompts_seen.append(prompt["message_log"][0]["content"])
+        if self._outcomes:
+            return self._outcomes.pop(0)
+        return RolloutOutcome.COMMITTED
+
+
+def _batch(*contents: str) -> BatchedDataDict:
+    """A dataloader batch holding one prompt per content string."""
+    return BatchedDataDict(
+        {"message_log": [[{"role": "user", "content": c}] for c in contents]}
+    )
+
+
+def _pump_controller(
+    manager: Any,
+    dataloader: list[BatchedDataDict],
+    *,
+    on_dropped_prompt: str = "replace",
+    max_replacement_attempts: int = 1,
+    num_prompts_per_step: int = 1,
+    buffer: _RecordingBuffer | None = None,
+    trainer_version: int = 0,
+):
+    buffer = _RecordingBuffer() if buffer is None else buffer
+    controller_cls = SingleControllerActor.__ray_metadata__.modified_class
+    ctrl = object.__new__(controller_cls)
+    ctrl._buffer = buffer
+    ctrl._async_cfg = SimpleNamespace(
+        max_inflight_prompts=2,
+        diagnostics=False,
+        rollout_failure=_failure_cfg(
+            on_dropped_prompt=on_dropped_prompt,
+            max_replacement_attempts=max_replacement_attempts,
+        ),
+    )
+    ctrl._master_config = SimpleNamespace(
+        grpo=GRPOConfig.model_construct(
+            max_num_epochs=1, num_prompts_per_step=num_prompts_per_step
+        )
+    )
+    ctrl._rollout_manager = manager
+    ctrl._sampler = InOrderSampler(buffer, max_lookahead_versions=1)
+    ctrl._dataloader = dataloader
+    ctrl._rollout_permitted = asyncio.Event()
+    ctrl._rollout_permitted.set()
+    ctrl._rollout_exhausted = asyncio.Event()
+    ctrl._buffer_capacity = asyncio.Semaphore(4)
+    ctrl._inflight_rollouts = 0
+    ctrl._inflight_by_group_id = {}
+    ctrl._dispatched_rollouts = set()
+    ctrl._trainer_version = trainer_version
+    ctrl._current_epoch = 0
+    _init_pump_ledgers(ctrl)
+    ctrl._sampler_stamps_target_steps = False
+    return ctrl
+
+
+class TestReplaceDroppedPrompt:
+    """on_dropped_prompt="replace": hold the batch size by substituting a spare."""
+
+    def test_a_spare_stands_in_so_the_step_keeps_its_batch_size(self):
+        # The first batch is admitted as step 0; the second is diverted into the pool
+        # while step 0's rollout is still in flight, which is what makes it available.
+        manager = _ScriptedRolloutManager([RolloutOutcome.SKIPPED])
+        ctrl = _pump_controller(manager, [_batch("step0"), _batch("spare")])
+
+        asyncio.run(ctrl._rollout_pump())
+
+        assert manager.prompts_seen == ["step0", "spare"]
+        assert ctrl._batch_shortfall == {}, (
+            "a group that was replaced must not also shrink its step -- crediting both "
+            "would drop a group the step is actually going to receive"
+        )
+        assert ctrl._batch_replacements == {0: 1}
+
+    def test_a_replacement_that_also_fails_falls_back_to_shrinking(self):
+        """Bounded rounds are what guarantee the step still closes."""
+        manager = _ScriptedRolloutManager(
+            [RolloutOutcome.SKIPPED, RolloutOutcome.SKIPPED]
+        )
+        ctrl = _pump_controller(
+            manager,
+            [_batch("step0"), _batch("spare")],
+            max_replacement_attempts=1,
+        )
+
+        asyncio.run(ctrl._rollout_pump())
+
+        assert manager.prompts_seen == ["step0", "spare"], (
+            "budget of 1 was not exceeded"
+        )
+        assert ctrl._batch_shortfall == {0: 1}
+        assert ctrl._batch_replacements == {}
+        # Nothing committed, so the slot's permit must come back exactly once.
+        assert ctrl._buffer_capacity._value == 4
+
+    def test_an_unstamped_sampler_never_diverts_a_batch_into_the_pool(self):
+        """No step can be stranded, so a pool would only cost prompts nothing draws on."""
+        buffer = _RecordingBuffer()
+        manager = _ScriptedRolloutManager([RolloutOutcome.SKIPPED])
+        ctrl = _pump_controller(
+            manager,
+            [_batch("p0"), _batch("p1")],
+            buffer=buffer,
+        )
+        ctrl._sampler = WeightFifoSampler(buffer, max_staleness_versions=1)
+
+        asyncio.run(ctrl._rollout_pump())
+
+        assert manager.prompts_seen == ["p0", "p1"], "no substitution attempted"
+        assert len(ctrl._replacement_reserve) == 0, "no batch was spent on the pool"
+        assert ctrl._batch_shortfall == {}
+
+    @pytest.mark.parametrize("on_dropped_prompt", ["shrink", "replace"])
+    def test_a_clean_run_loses_neither_a_prompt_nor_a_step_to_the_pool(
+        self, on_dropped_prompt: str
+    ):
+        """Enabling replace must be free when nothing fails.
+
+        The pool is filled by diverting a batch, so without draining it at the end that
+        batch is never trained on -- and since max_num_steps is derived from
+        len(dataloader), the run would also finish a step short of its budget.
+
+        Stamps contiguous from 0 are what pin the diverting order. Diverting *after*
+        admit would leave step 0 with no group at all, and these stamps would start at
+        1: a step the train pump waits on forever.
+        """
+        buffer = _RecordingBuffer()
+        ctrl = _pump_controller(
+            _RecordingRolloutManager(buffer),
+            [_batch("a"), _batch("b")],
+            on_dropped_prompt=on_dropped_prompt,
+            buffer=buffer,
+        )
+
+        asyncio.run(ctrl._rollout_pump())
+
+        assert buffer.target_step_list == [0, 1], "both batches became training steps"
+        assert len(ctrl._replacement_reserve) == 0, "the pool was handed back"
+
+    def test_a_partial_pool_is_not_dispatched_as_a_short_step(self):
+        """A step short by construction would trip the floor and fail a finished run."""
+        buffer = _RecordingBuffer()
+        manager = _ScriptedRolloutManager([RolloutOutcome.SKIPPED])
+        ctrl = _pump_controller(
+            manager,
+            [_batch("p0", "p1"), _batch("s0", "s1")],
+            num_prompts_per_step=2,
+            buffer=buffer,
+        )
+
+        asyncio.run(ctrl._rollout_pump())
+
+        # s0 stood in for the dropped p0, which leaves the pool one short of a step.
+        assert manager.prompts_seen == ["p0", "s0", "p1"]
+        assert len(ctrl._replacement_reserve) == 1, "s1 is left over, not a short step"
+
+
+class TestBorrowFromALaterStep:
+    """Where a replacement is sent when a later step has finished work to lend.
+
+    Same guarantee as any replacement -- the batch size holds -- but the dropped step
+    closes on a group that already exists instead of one the trainer has to wait for.
+    Each case seeds a finished group stamped for a later step, which is what a run with
+    lookahead has in the buffer by the time a drop is declared.
+    """
+
+    @staticmethod
+    def _with_lender(
+        *,
+        lender_step: int | None = 1,
+        lender_ready: bool = True,
+        trainer_version: int = 0,
+        outcomes: list[RolloutOutcome] | None = None,
+    ):
+        buffer = _RecordingBuffer(
+            target_step_list=[] if lender_step is None else [lender_step],
+            ready_list=[] if lender_step is None else [lender_ready],
+        )
+        manager = _ScriptedRolloutManager(
+            [RolloutOutcome.SKIPPED] if outcomes is None else outcomes
+        )
+        ctrl = _pump_controller(
+            manager,
+            [_batch("step0"), _batch("spare")],
+            on_dropped_prompt="replace",
+            buffer=buffer,
+            trainer_version=trainer_version,
+        )
+        return ctrl, manager, buffer
+
+    def test_the_lost_step_is_filled_now_and_the_lender_is_repaid_later(self):
+        ctrl, manager, buffer = self._with_lender()
+
+        asyncio.run(ctrl._rollout_pump())
+
+        assert buffer.target_step_list == [0], (
+            "the finished group was re-stamped, so step 0 is whole immediately"
+        )
+        assert manager.prompts_seen == ["step0", "spare"]
+        assert ctrl._batch_promotions == {0: 1}, "step 0 borrowed one group"
+        assert ctrl._batch_replacements == {1: 1}, (
+            "the spare repays the lender, not the step that was dropped from"
+        )
+        assert ctrl._batch_shortfall == {}, "neither step ends up short"
+
+    def test_nothing_to_borrow_degrades_to_replacing_in_place(self):
+        # The shape at max_lookahead_versions=0, where the next batch is not dispatched
+        # until this step trains, so no later step can ever have finished work.
+        ctrl, manager, _ = self._with_lender(lender_step=None)
+
+        asyncio.run(ctrl._rollout_pump())
+
+        assert manager.prompts_seen == ["step0", "spare"]
+        assert ctrl._batch_promotions == {}
+        assert ctrl._batch_replacements == {0: 1}, "the spare filled step 0 itself"
+        assert ctrl._batch_shortfall == {}
+
+    def test_an_in_flight_group_is_not_borrowed(self):
+        """Borrowing one would inherit its wait, which is the thing being avoided."""
+        ctrl, manager, buffer = self._with_lender(lender_ready=False)
+
+        asyncio.run(ctrl._rollout_pump())
+
+        assert buffer.target_step_list == [1], "the reservation kept its own step"
+        assert ctrl._batch_promotions == {}
+        assert ctrl._batch_replacements == {0: 1}
+
+    def test_a_step_the_trainer_has_passed_is_not_filled(self):
+        """A second drop can land after the first already closed the step short.
+
+        A group re-stamped for a finished step is selectable by nobody and evicted as
+        stale, so the borrow would destroy the lender's work for nothing.
+        """
+        ctrl, manager, buffer = self._with_lender(lender_step=9, trainer_version=5)
+
+        asyncio.run(ctrl._rollout_pump())
+
+        assert buffer.target_step_list == [9], "the lender kept its group"
+        assert ctrl._batch_promotions == {}
+        assert ctrl._batch_replacements == {0: 1}
+
+    def test_a_borrow_is_never_taken_without_a_spare_to_repay_it(self):
+        """An unrepaid loan is the same hole one step later, carried to the last step."""
+        buffer = _RecordingBuffer(target_step_list=[1], ready_list=[True])
+        manager = _ScriptedRolloutManager([RolloutOutcome.SKIPPED])
+        # One batch, so nothing is ever diverted and the pool stays empty.
+        ctrl = _pump_controller(
+            manager,
+            [_batch("step0")],
+            on_dropped_prompt="replace",
+            buffer=buffer,
+        )
+
+        asyncio.run(ctrl._rollout_pump())
+
+        assert buffer.target_step_list == [1], "no group was moved off the lender"
+        assert ctrl._batch_promotions == {}
+        assert ctrl._batch_shortfall == {0: 1}, "step 0 shrinks instead"
+
+
+class TestTakeReplacement:
+    """Every way a substitution can be unavailable falls back to shrinking."""
+
+    @staticmethod
+    def _controller(
+        *,
+        on_dropped_prompt: str = "replace",
+        max_replacement_attempts: int = 1,
+        spares: int = 0,
+    ):
+        controller_cls = SingleControllerActor.__ray_metadata__.modified_class
+        ctrl = object.__new__(controller_cls)
+        ctrl._async_cfg = SimpleNamespace(
+            rollout_failure=_failure_cfg(
+                on_dropped_prompt=on_dropped_prompt,
+                max_replacement_attempts=max_replacement_attempts,
+            )
+        )
+        ctrl._replacement_reserve = deque(_batch(f"spare{i}") for i in range(spares))
+        return ctrl
+
+    def test_a_spare_is_handed_out_and_leaves_the_pool(self):
+        ctrl = self._controller(spares=2)
+        assert ctrl._take_replacement(0, 0) is not None
+        assert len(ctrl._replacement_reserve) == 1
+
+    def test_shrink_mode_never_substitutes(self):
+        ctrl = self._controller(on_dropped_prompt="shrink", spares=2)
+        assert ctrl._take_replacement(0, 0) is None
+        assert len(ctrl._replacement_reserve) == 2, "pool left untouched"
+
+    def test_an_unstamped_prompt_has_no_short_step_to_repair(self):
+        ctrl = self._controller(spares=2)
+        assert ctrl._take_replacement(None, 0) is None
+
+    def test_the_per_slot_budget_stops_substituting(self):
+        ctrl = self._controller(max_replacement_attempts=2, spares=5)
+        assert ctrl._take_replacement(0, 1) is not None
+        assert ctrl._take_replacement(0, 2) is None
+
+    def test_an_empty_pool_shrinks_instead_of_waiting(self):
+        """At epoch end there is no more data; the step closes short, not never."""
+        ctrl = self._controller(spares=0)
+        assert ctrl._take_replacement(0, 0) is None
+
+
+class TestTargetGroupsForStep:
+    """How many groups a step waits for, once some are known not to be coming."""
+
+    @staticmethod
+    def _controller(
+        num_prompts_per_step: int,
+        shortfall: dict[int, int],
+        fraction: float = 0.9,
+    ):
+        controller_cls = SingleControllerActor.__ray_metadata__.modified_class
+        ctrl = object.__new__(controller_cls)
+        ctrl._master_config = SimpleNamespace(
+            grpo=GRPOConfig.model_construct(
+                num_prompts_per_step=num_prompts_per_step,
+            )
+        )
+        ctrl._async_cfg = SimpleNamespace(
+            rollout_failure=SimpleNamespace(min_step_batch_fraction=fraction)
+        )
+        ctrl._batch_shortfall = dict(shortfall)
+        return ctrl
+
+    def test_an_untouched_step_waits_for_the_configured_batch(self):
+        ctrl = self._controller(128, {})
+        assert ctrl._target_groups_for_step(3) == 128
+
+    def test_a_dropped_group_shrinks_only_the_step_it_was_stamped_for(self):
+        ctrl = self._controller(128, {3: 2})
+        assert ctrl._target_groups_for_step(3) == 126
+        assert ctrl._target_groups_for_step(4) == 128, "neighbouring steps unaffected"
+
+    def test_a_step_below_the_floor_fails_rather_than_training_a_part_batch(self):
+        """The drop budgets are run-scoped and cannot bound one step's shrinkage."""
+        # floor = ceil(0.9 * 128) = 116, so 12 drops are allowed and 13 are not.
+        ctrl = self._controller(128, {0: 12})
+        assert ctrl._target_groups_for_step(0) == 116
+
+        ctrl = self._controller(128, {0: 13})
+        with pytest.raises(RuntimeError, match="below the floor of 116"):
+            ctrl._target_groups_for_step(0)
+
+    def test_a_small_batch_is_protected_more_strictly(self):
+        """Losing 1 of 4 is a 25% batch reduction; the fraction says no."""
+        ctrl = self._controller(4, {0: 1})
+        with pytest.raises(RuntimeError, match="below the floor of 4"):
+            ctrl._target_groups_for_step(0)
+
+    def test_a_step_stripped_of_every_group_never_reaches_an_empty_batch(self):
+        """ceil() with a positive fraction keeps the floor >= 1, so this is caught."""
+        ctrl = self._controller(4, {0: 4}, fraction=0.01)
+        with pytest.raises(RuntimeError, match="leaving 0"):
+            ctrl._target_groups_for_step(0)
+
+    def test_a_fraction_of_one_forbids_shrinking_at_all(self):
+        ctrl = self._controller(128, {0: 1}, fraction=1.0)
+        with pytest.raises(RuntimeError, match="below the floor of 128"):
+            ctrl._target_groups_for_step(0)
 
 
 def test_abort_stale_inflight_cancels_only_out_of_window_rollouts() -> None:
@@ -342,6 +845,7 @@ def test_rollout_pump_failure_cancels_sibling_and_releases_capacity() -> None:
         ctrl._async_cfg = SimpleNamespace(
             max_inflight_prompts=2,
             diagnostics=False,
+            rollout_failure=_failure_cfg(),
         )
         ctrl._master_config = SimpleNamespace(
             grpo=GRPOConfig.model_construct(max_num_epochs=1)
@@ -368,6 +872,7 @@ def test_rollout_pump_failure_cancels_sibling_and_releases_capacity() -> None:
         ctrl._dispatched_rollouts = set()
         ctrl._trainer_version = 0
         ctrl._current_epoch = 0
+        _init_pump_ledgers(ctrl)
 
         with pytest.raises(ExceptionGroup) as exc_info:
             await asyncio.wait_for(ctrl._rollout_pump(), timeout=1.0)
@@ -428,6 +933,7 @@ def test_rollout_pump_releases_permits_when_child_never_starts(monkeypatch) -> N
         ctrl._async_cfg = SimpleNamespace(
             max_inflight_prompts=1,
             diagnostics=False,
+            rollout_failure=_failure_cfg(),
         )
         ctrl._master_config = SimpleNamespace(
             grpo=GRPOConfig.model_construct(max_num_epochs=1)
@@ -447,6 +953,7 @@ def test_rollout_pump_releases_permits_when_child_never_starts(monkeypatch) -> N
         ctrl._dispatched_rollouts = set()
         ctrl._trainer_version = 0
         ctrl._current_epoch = 0
+        _init_pump_ledgers(ctrl)
 
         await ctrl._rollout_pump()
         await asyncio.sleep(0)

--- a/tests/unit/single_controller/test_sc_checkpointing.py
+++ b/tests/unit/single_controller/test_sc_checkpointing.py
@@ -39,6 +39,7 @@ import asyncio
 import json
 import os
 import threading
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Optional, Union
 from unittest.mock import MagicMock, patch
@@ -403,16 +404,22 @@ def _run_train_pump(
     actor_args: SingleControllerActorArgs,
     *,
     flush: bool = True,
+    seed: Optional[Callable[[Any], None]] = None,
 ):
     """Construct the actor in-process and drive _train_pump to completion.
 
     flush=True joins the (possibly async) checkpoint finalization afterwards,
     like run()'s exit path does, so step_N dirs are visible to assertions.
+
+    seed runs against the constructed actor before the pump does, for state the
+    pump is expected to persist but that no actor_args field carries.
     """
 
     async def _main():
         actor = _ACTOR_CLS(mc, actor_args, SetupTimingMetrics())
         actor._sampler = _FakeSampler()
+        if seed is not None:
+            seed(actor)
         # In-process runs have no Ray runtime; the pump only reads the GPU
         # count for a throughput metric.
         with patch("ray.cluster_resources", return_value={"GPU": 0}):
@@ -437,6 +444,22 @@ def _run_actor_run(mc: MasterConfig, actor_args: SingleControllerActorArgs):
         actor = _ACTOR_CLS(mc, actor_args, SetupTimingMetrics())
         result = await asyncio.wait_for(actor.run(), timeout=60.0)
         return actor, result
+
+    return asyncio.run(_main())
+
+
+def _run_reserve_restore(mc: MasterConfig, actor_args: SingleControllerActorArgs):
+    """Construct the actor and await only the spare-pool restore.
+
+    run() cannot stand in here: it starts the rollout pump, which drains any whole
+    step's worth of spares straight into training, so the pool is empty again by the
+    time the assertion runs.
+    """
+
+    async def _main():
+        actor = _ACTOR_CLS(mc, actor_args, SetupTimingMetrics())
+        await actor._maybe_restore_replacement_reserve()
+        return actor
 
     return asyncio.run(_main())
 
@@ -1218,3 +1241,111 @@ class TestReplayBufferPersistence:
         assert buffer.load_calls == []
         assert actor._buffer_capacity._value == 4
         assert any("skipping the buffer restore" in line for line in printed)
+
+
+# ── replacement reserve persistence ──────────────────────────────────────────
+
+
+class TestReplacementReservePersistence:
+    """The spare-prompt pool has to survive a restart, or the batch is lost.
+
+    Diverting a batch into the pool advances the dataloader, so the dataloader state
+    the checkpoint saves already records those prompts as consumed while they exist
+    only in memory. Resuming without them leaves a run whose iterator is positioned
+    past a batch nobody holds, and `_drain_reserve_into_steps` cannot get it back --
+    it only recovers spares held by the process that diverted them.
+    """
+
+    def test_save_writes_the_pooled_spares(self, tmp_path):
+        mc = _actor_master_config(tmp_path, max_num_steps=2, save_period=2)
+
+        actor = _run_train_pump(
+            mc,
+            _make_actor_args(),
+            seed=lambda a: a._replacement_reserve.extend(["spare0", "spare1"]),
+        )
+
+        reserve_path = tmp_path / "checkpoints" / "step_2" / "replacement_reserve.pt"
+        assert reserve_path.exists()
+        assert torch.load(reserve_path, weights_only=False) == ["spare0", "spare1"]
+        # Saved, not consumed: the pool the run continues with is untouched.
+        assert list(actor._replacement_reserve) == ["spare0", "spare1"]
+
+    def test_save_omits_the_file_when_the_pool_is_empty(self, tmp_path):
+        """Which is every run that never diverted, i.e. every non-replace run.
+
+        The restore is silent about a missing file for exactly this reason, so an
+        always-written empty file would make that silence indefensible.
+        """
+        mc = _actor_master_config(tmp_path, max_num_steps=2, save_period=2)
+
+        _run_train_pump(mc, _make_actor_args())
+
+        step_dir = tmp_path / "checkpoints" / "step_2"
+        assert step_dir.exists()
+        assert not (step_dir / "replacement_reserve.pt").exists()
+
+    def test_run_restores_the_pooled_spares(self, tmp_path):
+        ckpt_dir = tmp_path / "resume_ckpt"
+        ckpt_dir.mkdir()
+        torch.save(["spare0", "spare1"], ckpt_dir / "replacement_reserve.pt")
+        mc = _actor_master_config(tmp_path, max_num_steps=0)
+
+        actor = _run_reserve_restore(
+            mc,
+            _make_actor_args(
+                last_checkpoint_path=str(ckpt_dir),
+                save_state=_matching_save_state(),
+            ),
+        )
+
+        assert list(actor._replacement_reserve) == ["spare0", "spare1"]
+
+    def test_run_restores_the_pool_even_when_the_buffer_restore_is_skipped(
+        self, tmp_path
+    ):
+        """The sampler guard that protects the buffer must not cover the pool.
+
+        Spares never reached `admit`, so they carry no target-step stamp and nothing
+        about them depends on which sampler wrote the checkpoint. Skipping them here
+        would strand the batch permanently for the one case -- a sampler change on
+        resume -- where the operator is least likely to look for it.
+        """
+        ckpt_dir = tmp_path / "resume_ckpt"
+        ckpt_dir.mkdir()
+        torch.save({"groups": []}, ckpt_dir / "replay_buffer.pt")
+        # One spare is less than num_prompts_per_step, so the full run() path here
+        # holds it back rather than draining it, and the pool is still observable.
+        torch.save(["spare0"], ckpt_dir / "replacement_reserve.pt")
+        mc = _actor_master_config(tmp_path, max_num_steps=0)
+        save_state = _initial_grpo_save_state()
+        save_state.sampler_name = "in_order"  # current run uses windowed
+        buffer = _FakeTQBuffer(load_return=2)
+
+        actor, _ = _run_actor_run(
+            mc,
+            _make_actor_args(
+                tq_buffer=buffer,
+                last_checkpoint_path=str(ckpt_dir),
+                save_state=save_state,
+            ),
+        )
+
+        assert buffer.load_calls == []
+        assert list(actor._replacement_reserve) == ["spare0"]
+
+    def test_run_without_a_reserve_file_starts_with_an_empty_pool(self, tmp_path):
+        """A checkpoint predating this file, or any run that never diverted."""
+        ckpt_dir = tmp_path / "resume_ckpt"
+        ckpt_dir.mkdir()
+        mc = _actor_master_config(tmp_path, max_num_steps=0)
+
+        actor, _ = _run_actor_run(
+            mc,
+            _make_actor_args(
+                last_checkpoint_path=str(ckpt_dir),
+                save_state=_matching_save_state(),
+            ),
+        )
+
+        assert list(actor._replacement_reserve) == []

--- a/tests/unit/single_controller/test_single_controller.py
+++ b/tests/unit/single_controller/test_single_controller.py
@@ -22,6 +22,7 @@ import pytest
 import torch
 
 import nemo_rl.algorithms.single_controller as single_controller
+from nemo_rl.algorithms.async_utils.staleness_sampler import BaseSampler
 from nemo_rl.algorithms.grpo import GRPOConfig, _initial_grpo_save_state
 from nemo_rl.algorithms.loss import ClippedPGLossConfig
 from nemo_rl.algorithms.metric_utils import SetupTimingMetrics
@@ -389,7 +390,10 @@ def _train_pump_controller(*, sampler) -> object:
         # is disabled.
         checkpointing={"enabled": False, "save_period": 10},
     )
-    ctrl._async_cfg = SimpleNamespace(min_groups_for_streaming_train=1)
+    ctrl._async_cfg = SimpleNamespace(
+        min_groups_for_streaming_train=1,
+        rollout_failure=SimpleNamespace(min_step_batch_fraction=0.9),
+    )
     ctrl._consumed_samples = 0
     ctrl._total_valid_tokens = 0
     ctrl._timeout = TimeoutChecker(timeout=None, fit_last_save_time=True)
@@ -411,6 +415,9 @@ def _train_pump_controller(*, sampler) -> object:
     ctrl._timer = Timer()
     ctrl._trainer_version = 0
     ctrl._train_steps = 0
+    ctrl._batch_shortfall = {}
+    ctrl._batch_replacements = {}
+    ctrl._batch_promotions = {}
     ctrl._step_log_dict = {
         "rewards": [],
         "masked_advantages": [],
@@ -446,6 +453,130 @@ def test_train_pump_fails_if_rollout_exhausts_during_partial_step() -> None:
         ),
     ):
         asyncio.run(asyncio.wait_for(ctrl._train_pump(), timeout=1.0))
+
+
+class _DroppingSampler(_OneThenEmptySampler):
+    """Yields one group, then reports the second as never coming.
+
+    Stands in for a prompt that was stamped for this step and then given up on: the
+    credit lands while the pump is already waiting for the group, which is the only
+    way it happens in a real run and the case that waits forever without the fix.
+
+    ``select`` validates its bounds through the real sampler's own check, so a pump
+    that asks for a non-positive batch fails here exactly as it would in production
+    rather than being quietly tolerated by a permissive fake.
+    """
+
+    def __init__(self, meta: KVBatchMeta, *, credit_in_evict: bool) -> None:
+        super().__init__(meta)
+        self._credit_in_evict = credit_in_evict
+        self.ctrl = None
+
+    def _credit(self) -> None:
+        self.ctrl._batch_shortfall[self.ctrl._trainer_version] = 1
+
+    async def evict(self, *, current_train_weight: int) -> int:
+        del current_train_weight
+        # The window between the pump's two reads of the step target. A credit landing
+        # here shrinks the target after the loop condition has already passed.
+        if self._credit_in_evict and self._meta is None:
+            self._credit()
+        return 0
+
+    async def select(self, **kwargs):
+        BaseSampler._validate_group_bounds(
+            kwargs["min_prompt_groups"], kwargs["max_prompt_groups"]
+        )
+        meta, num_groups = await super().select(**kwargs)
+        if meta is None and not self._credit_in_evict:
+            self._credit()
+        return meta, num_groups
+
+
+def _dropping_controller(*, credit_in_evict: bool):
+    meta = KVBatchMeta(
+        partition_id="rollout_data",
+        task_name="train",
+        sample_ids=["sample-0"],
+        fields=[],
+        sequence_lengths=[1],
+        tags=[{"weight_version": 0}],
+    )
+    sampler = _DroppingSampler(meta, credit_in_evict=credit_in_evict)
+    ctrl = _train_pump_controller(sampler=sampler)
+    sampler.ctrl = ctrl
+    # ceil(0.9 * 2) is 2, so the harness's default floor forbids any short step at
+    # all; at 0.5 the floor is 1 and closing on the one group it got is legal.
+    ctrl._async_cfg.rollout_failure.min_step_batch_fraction = 0.5
+    # Rollouts are still running, so the "rollout exhausted" escape is unavailable:
+    # a pump that does not act on the credit waits on a group nobody is generating.
+    ctrl._rollout_exhausted.clear()
+    ctrl._sync_weights = AsyncMock(return_value=0)
+    ctrl._logger = MagicMock()
+    return ctrl
+
+
+@pytest.mark.parametrize("credit_in_evict", [False, True])
+def test_train_pump_closes_a_step_short_when_a_stamped_prompt_is_dropped(
+    monkeypatch, credit_in_evict
+) -> None:
+    """Both windows a shortfall can be credited in have to close the step.
+
+    Credited before the loop condition is re-read, the target simply falls to what is
+    already dispatched. Credited after it, between the two reads, the batch the pump
+    would ask for is empty -- which the sampler rejects, so the pump has to notice
+    instead of asking. Either way the step trains on what it got.
+    """
+    ctrl = _dropping_controller(credit_in_evict=credit_in_evict)
+    ctrl._batch_replacements = {0: 1}
+    ctrl._batch_promotions = {0: 2, 3: 1}
+    monkeypatch.setattr(single_controller.ray, "cluster_resources", lambda: {})
+
+    asyncio.run(asyncio.wait_for(ctrl._train_pump(), timeout=1.0))
+
+    assert ctrl._train_steps == 1
+    # One group, not the configured two: the step is what shrank, not the run.
+    assert ctrl._consumed_samples == 1
+    train_metrics = ctrl._logger.log_metrics.call_args_list[0].args[0]
+    assert train_metrics["dropped_prompt_groups"] == 1
+    assert train_metrics["replaced_prompt_groups"] == 1
+    assert train_metrics["promoted_prompt_groups"] == 2
+    # Read against version_during_step, not the already-incremented _trainer_version,
+    # which would report 0 for every step forever.
+    assert ctrl._trainer_version == 1
+    # This step's counts are pruned; a later step's survive to be reported by it.
+    assert ctrl._batch_shortfall == {}
+    assert ctrl._batch_replacements == {}
+    assert ctrl._batch_promotions == {3: 1}
+
+
+def test_train_pump_prunes_stamps_older_than_the_step_that_just_closed(
+    monkeypatch,
+) -> None:
+    """A straggler credited for a step that already closed must not outlive it.
+
+    Popping only the current step's entry would leak those, and they are unreachable
+    afterwards: the target is only ever read for the step being assembled.
+    """
+    meta = KVBatchMeta(
+        partition_id="rollout_data",
+        task_name="train",
+        sample_ids=["sample-0"],
+        fields=[],
+        sequence_lengths=[1],
+        tags=[{"weight_version": 3}],
+    )
+    ctrl = _train_pump_controller(sampler=_OneThenEmptySampler(meta))
+    ctrl._async_cfg.rollout_failure.min_step_batch_fraction = 0.5
+    ctrl._trainer_version = 3
+    ctrl._sync_weights = AsyncMock(return_value=0)
+    ctrl._logger = MagicMock()
+    ctrl._batch_shortfall = {2: 1, 3: 1, 5: 1}
+    monkeypatch.setattr(single_controller.ray, "cluster_resources", lambda: {})
+
+    asyncio.run(asyncio.wait_for(ctrl._train_pump(), timeout=1.0))
+
+    assert ctrl._batch_shortfall == {5: 1}
 
 
 def test_train_pump_logs_nonzero_stale_group_metrics(monkeypatch) -> None:

--- a/tests/unit/single_controller/test_tq_replay_buffer.py
+++ b/tests/unit/single_controller/test_tq_replay_buffer.py
@@ -440,6 +440,75 @@ class TestTQReplayBufferSize:
         assert buf.count_for_target_step(7) == 0
 
 
+class TestTQReplayBufferPromote:
+    """Borrowing inside on_dropped_prompt="replace".
+
+    A step fills a hole from a later step's already-finished work. Not a mode of its
+    own: "promote" is not a value on_dropped_prompt accepts.
+    """
+
+    def test_the_furthest_step_lends_because_it_has_the_most_slack(self):
+        # Both could lend, but 7 is due two steps later than 6, so it has the longer
+        # window to receive the repayment rollout before it is needed.
+        dp = FakeDataPlaneClient()
+        buf = _make_buffer(dp)
+        _add_group(buf, weight=0, target_step=6)
+        _add_group(buf, weight=0, target_step=7)
+
+        assert buf.promote_ready_group(to_target_step=5) == 7
+        assert buf.target_step_list == [6, 5]
+
+    def test_an_unready_group_is_not_borrowed(self):
+        # Its rollout is still running, so moving the stamp would hand the dropped step
+        # exactly the wait that borrowing exists to avoid.
+        dp = FakeDataPlaneClient()
+        buf = _make_buffer(dp)
+        buf.reserve(weight_version=0, target_step=6)
+
+        assert buf.promote_ready_group(to_target_step=5) is None
+        assert buf.target_step_list == [6]
+
+    def test_only_later_steps_lend(self):
+        # A group stamped for this step is already counted toward it, and one stamped
+        # earlier belongs to a step the trainer has passed.
+        dp = FakeDataPlaneClient()
+        buf = _make_buffer(dp)
+        _add_group(buf, weight=0, target_step=4)
+        _add_group(buf, weight=0, target_step=5)
+
+        assert buf.promote_ready_group(to_target_step=5) is None
+        assert buf.target_step_list == [4, 5]
+
+    def test_unstamped_groups_are_never_borrowed(self):
+        # A sampler that does not stamp cannot strand a step, so its groups belong to
+        # no step in particular and there is nothing to move them out of.
+        dp = FakeDataPlaneClient()
+        buf = _make_buffer(dp)
+        _add_group(buf, weight=0, target_step=None)
+
+        assert buf.promote_ready_group(to_target_step=5) is None
+        assert buf.target_step_list == [None]
+
+    def test_an_empty_buffer_has_nothing_to_lend(self):
+        dp = FakeDataPlaneClient()
+        buf = _make_buffer(dp)
+
+        assert buf.promote_ready_group(to_target_step=5) is None
+
+    def test_borrowing_twice_takes_from_two_different_groups(self):
+        # Each borrow must move a distinct group: re-stamping the same one twice would
+        # report two groups gained where only one exists.
+        dp = FakeDataPlaneClient()
+        buf = _make_buffer(dp)
+        _add_group(buf, weight=0, target_step=6)
+        _add_group(buf, weight=0, target_step=6)
+
+        assert buf.promote_ready_group(to_target_step=5) == 6
+        assert buf.promote_ready_group(to_target_step=5) == 6
+        assert buf.promote_ready_group(to_target_step=5) is None
+        assert buf.count_for_target_step(5) == 2
+
+
 # ── state_dict / load_state_dict (checkpointing) ─────────────────────────────
 
 


### PR DESCRIPTION
# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

Make the SingleController path survive rollout failures: drop a prompt within budget instead of ending the run, close the affected training step short so an `in_order` sampler cannot hang on a group nobody is generating, and optionally replace the lost prompt so the step keeps its configured batch size.

# Issues

List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

<!-- fill in, e.g. Closes #NNNN -->

Builds directly on #3589, which added the failure taxonomy and per-prompt retry budgets but always ended the run once a budget was exhausted.

# Usage

* **You can potentially add a usage example below**

All knobs live under `async_rl.rollout_failure`. Defaults are inert — a run that does not set these behaves exactly as it does on `main`.

```yaml
async_rl:
  rollout_failure:
    # Ride out a shard outage instead of losing the job: CONSECUTIVE prompts that may
    # exhaust their infra budget and be dropped. Any committed rollout resets the count,
    # so this bounds an outage rather than the run's lifetime. 0 (default) fails on the
    # first one, which is today's behaviour and v1's default.
    max_consecutive_dropped_prompts: 8

    # Smallest batch a step may close on, as a fraction of num_prompts_per_step. Neither
    # drop budget can bound this on its own, since both are run-scoped.
    min_step_batch_fraction: 0.9

    # "shrink" (default) trains the step on fewer groups, bounded by the floor above.
    # "replace" substitutes a fresh prompt so the step keeps its configured batch size.
    on_dropped_prompt: replace
    max_replacement_attempts: 1     # fresh prompts tried per lost group
    replacement_reserve_prompts: 1  # low-water mark for the spare-prompt pool
```

# Additional Information
Three commits, each standalone:

1. feat(sc): tolerate dropped rollouts instead of failing the run: max_consecutive_dropped_prompts, plus the shortfall credit. InOrderSampler stamps each batch with a target step and selects on an exact match, so a group that never arrives leaves that step permanently short and the train pump waits forever, turning a crash into a hang. The pump now credits the shortfall against the stamped step and closes it early. This also fixes the pre-existing max_skipped_prompts path, which could already strand an in-order step.

2. fix(sc): bound how short a dropped-prompt step may close: min_step_batch_fraction. Both drop budgets are run-scoped (the consecutive counter is cleared by any commit, including commits for other steps), so drops concentrated on one step could shrink it without limit. A fraction rather than a count, so it holds across batch sizes and protects small batches more strictly.

3. feat(sc): replace a dropped prompt so its step keeps its batch size — on_dropped_prompt, the spare-prompt pool, and borrowing.

# Design notes worth reviewer attention:

Only stamping samplers are affected. With weight_fifo or windowed, admit returns None and a step fills from whatever is ready, so a drop costs throughput but strands nothing. Nothing is diverted into the spare pool until the sampler has actually stamped a batch, so an unstamped run does not lose prompts to a pool it can never draw on.
The spare pool is refilled from the pump loop, by diverting one whole dataloader batch before admit(). The pump is the sole owner of the StatefulDataLoader, and advancing that iterator from a dispatch task which is where a drop is discovered, arbitrarily later would race the ordering that checkpoint/resume accounting depends on. Diverting before admit() also means a diverted batch never burns a target step.

Leftover spares are trained on. Once the dataloader is exhausted the pool is dispatched as ordinary steps, so the diverted batch is neither discarded nor silently subtracted from max_num_steps (which is derived from len(dataloader)). Partial pools are held back rather than dispatched as a step that is short by construction.
Borrowing is an optimization inside replace, not a mode. A fresh rollout puts the wait on the critical path — the trainer has closed the previous step and idles until the substitute commits. When a later step already holds a finished group, TQReplayBuffer.promote_ready_group re-stamps it into the dropped step (which then closes immediately) and the fresh prompt repays the lender, which is not due for another step. A borrow is only taken with a spare in hand: an unrepaid loan is the same hole one step later, walking forward to the final step, which has nobody to borrow from. Both paths hold the batch size, so selecting between them is not worth exposing; the two counters report which one ran.

promote_ready_group is deliberately synchronous. TQReplayBuffer.remove deletes its indices before its first await, so as long as the re-stamp does not yield, the index it picks cannot be shifted out from under it by a concurrent selection.

The fallback chain always terminates: borrow → fresh replacement → shrink, bounded by max_replacement_attempts and the pool. Without the shrink fallback, a step whose replacements keep failing would never close at all.


# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.
