### PR TITLE
fix(sc): give the SC rollout path a deadline instead of waiting forever

### DIFF
--- a/examples/configs/grpo_math_1B_megatron_single_controller.yaml
+++ b/examples/configs/grpo_math_1B_megatron_single_controller.yaml
@@ -44,14 +44,23 @@ async_rl:
     # INDEPENDENT counters, so one prompt can consume up to their sum minus one.
     max_skipped_prompts: 0
 
-    # Deadlines. null disables, which is the default and reproduces the historical
-    # behaviour of waiting forever. Set them in any run that matters: without one a
-    # wedged generation engine parks a rollout permanently, holding a
-    # max_inflight_prompts slot for the rest of the job.
+    # Deadlines, set rather than left at their null default, because null means wait
+    # forever: nothing below SC bounds a rollout, so a wedged generation engine or
+    # environment server parks one permanently and holds its max_inflight_prompts
+    # slot for the rest of the job. Under a sampler that stamps target steps that is
+    # a hang rather than a slowdown -- the stamped step never fills, and since no
+    # exception is raised, none of the retry budgets above ever see it.
+    #
+    # Sized so only a wedge can trip them, not a slow rollout: this config generates
+    # at most max_total_sequence_length=512 tokens per turn and scores with a local
+    # math verifier, both of which are seconds' work. Size your own from the p99 you
+    # measure, keeping watchdog.stall_timeout_s (below) above every value set here.
     native:                           # AsyncRolloutImpl only
-      generation_timeout_s: null      # one generate_async turn
-      env_timeout_s: null             # one environment step
+      generation_timeout_s: 300.0     # one generate_async turn
+      env_timeout_s: 120.0            # one environment step
     nemo_gym:                         # AsyncNemoGymRolloutImpl only
+      # Left at its default: this is a native run, and setup rejects a populated
+      # nemo_gym block instead of letting it read as effective while being ignored.
       rollout_timeout_s: null         # the whole prompt-group rollout, retries included
       # Re-send just the rows that never arrived before retrying the whole group.
       # Gym's stream dies on its first failing row, so one bad row loses every later

--- a/tests/functional/grpo_async_gym_single_controller.sh
+++ b/tests/functional/grpo_async_gym_single_controller.sh
@@ -55,6 +55,10 @@ VALIDATION_PATH=$DATA_DIR/workplace_assistant_validation.jsonl
 jq -c '.responses_create_params.tools |= (.[0:1])' 3rdparty/Gym-workspace/Gym/data/workplace_assistant/train.jsonl > $TRAIN_PATH
 jq -c '.responses_create_params.tools |= (.[0:1])' 3rdparty/Gym-workspace/Gym/data/workplace_assistant/validation.jsonl > $VALIDATION_PATH
 
+# rollout_timeout_s is set here because this is the only test that takes the NeMo-Gym
+# rollout path, so it is the only place that deadline runs at all. 300s is orders above
+# a 512-token Qwen3-0.6B group on one tool, so it fires only on a wedge, and it stays
+# under the default watchdog.stall_timeout_s of 600s as that guard requires.
 uv run coverage run -a --data-file=$PROJECT_ROOT/tests/.coverage --source=$PROJECT_ROOT/nemo_rl \
     $PROJECT_ROOT/examples/run_grpo_single_controller.py \
     --config $PROJECT_ROOT/examples/nemo_gym/grpo_qwen3_30ba3b_instruct.yaml \
@@ -104,6 +108,7 @@ uv run coverage run -a --data-file=$PROJECT_ROOT/tests/.coverage --source=$PROJE
     ++async_rl.min_groups_for_streaming_train=4 \
     ++async_rl.max_inflight_prompts=4 \
     ++async_rl.max_buffered_rollouts=4 \
+    ++async_rl.rollout_failure.nemo_gym.rollout_timeout_s=300.0 \
     $@ \
     2>&1 | tee $RUN_LOG
 


### PR DESCRIPTION
The deadlines added with the rollout fault-tolerance restructure all default to null, so every SingleController run inherits an unbounded await unless someone opts in, and none of the configs in the repo did. Nothing below SC bounds a rollout: NeMo-Gym retries its server-to-server hops in an uncapped loop and builds its aiohttp session with an unset ClientTimeout, so a wedged environment server never raises and the await never returns.

Under a sampler that stamps target steps that is fatal rather than merely slow. The hung prompt's slot stays reserved at a target_step that never becomes ready, InOrderSampler.select needs every group ready at the current train weight, evict skips unready slots by design, and because no exception fires none of the retry budgets or drop counters ever see it. The train pump cannot close the step, the trainer version never advances, the rollout pump then blocks on the admission gate, and both pumps wedge until the wall clock. That is the shape a 68-node run hit, and it costs the whole job rather than one prompt.

So set them where a run is actually configured:

- The SC exemplar takes the native deadlines. Values are sized so only a wedge trips them -- the config generates at most 512 tokens per turn and scores with a local math verifier -- and stay under the existing stall_timeout_s, which the watchdog guard requires. Its nemo_gym block stays at its defaults, because a native run rejects a populated one rather than let it look effective.
- The gym e2e smoke takes nemo_gym.rollout_timeout_s. It is the only test on that rollout path, so it is the only place that deadline runs at all; the native one already runs in the chaos harness.

Library defaults are deliberately left alone: flipping them would overturn the tested "defaults are inert" invariant and force watchdog.stall_timeout_s up for every run, which is a policy call rather than a fix.

# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
