### PR TITLE
feat(sc): report generation saturation and buffer occupancy

### DIFF
--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -60,6 +60,7 @@ from nemo_rl.algorithms.single_controller_utils.utils import (
     squeeze_trailing_unit_dim,
     tensor_field,
 )
+from nemo_rl.algorithms.utils import log_generation_metrics_to_wandb
 from nemo_rl.data.interfaces import DatumSpec
 from nemo_rl.data_plane import KVBatchMeta
 from nemo_rl.data_plane.schema import DP_CALIB_INPUT_FIELDS
@@ -74,6 +75,53 @@ from nemo_rl.utils.logger import Logger
 from nemo_rl.utils.timer import TimeoutChecker, Timer
 
 Generation = Union[VllmGeneration, SGLangGeneration]
+
+# Cadence for the step-independent telemetry pump. Matched to the watchdog's default
+# tick so the two report at a comparable rate.
+_TELEMETRY_REPORT_SECONDS = 30.0
+
+
+def _summarize_generation_saturation(
+    gen_metrics: dict[str, dict[int, list[Any]]],
+) -> dict[str, float]:
+    """Pool per-worker vLLM engine samples into one saturation summary.
+
+    ``num_pending_samples`` is vLLM's ``num_requests_waiting``, which is what separates
+    an engine fleet that is compute-bound from one that is merely under-subscribed. The
+    two are indistinguishable from the trainer's side -- both surface only as time spent
+    in generation -- but only the second can be improved by admitting more in-flight
+    prompts, so this is the measurement that decides whether a deeper lag setting can
+    buy throughput.
+
+    ``queue_busy_frac`` is reported because the mean alone hides the shape: a queue that
+    is deep for a tenth of the step and empty afterwards averages out to look idle.
+
+    Returns an empty dict when the backend collects none of these, which is the case for
+    every backend except vLLM with ``enable_vllm_metrics_logger`` set.
+    """
+
+    def pooled(name: str) -> list[float]:
+        per_worker: dict[int, list[Any]] = gen_metrics.get(name, {})
+        return [float(v) for samples in per_worker.values() for v in samples]
+
+    running = pooled("inflight_batch_sizes")
+    waiting = pooled("num_pending_samples")
+    kv_usage = pooled("kv_cache_usage_perc")
+
+    saturation: dict[str, float] = {}
+    if running:
+        saturation["requests_running_mean"] = sum(running) / len(running)
+        saturation["requests_running_max"] = max(running)
+    if waiting:
+        saturation["requests_waiting_mean"] = sum(waiting) / len(waiting)
+        saturation["requests_waiting_max"] = max(waiting)
+        saturation["queue_busy_frac"] = sum(1.0 for v in waiting if v > 0) / len(
+            waiting
+        )
+    if kv_usage:
+        saturation["kv_cache_usage_mean"] = sum(kv_usage) / len(kv_usage)
+        saturation["kv_cache_usage_max"] = max(kv_usage)
+    return saturation
 
 
 @ray.remote(num_cpus=1, num_gpus=0)  # pragma: no cover
@@ -232,11 +280,12 @@ class SingleControllerActor:
 
         await self._maybe_restore_replay_buffer()
 
-        # Start the rollout and train pumps, plus the watchdog
+        # Start the rollout and train pumps, plus the watchdog and telemetry
         rollout_task = asyncio.create_task(self._rollout_pump())
         train_task = asyncio.create_task(self._train_pump())
         watchdog_task = asyncio.create_task(self._watchdog_pump())
-        tasks = (rollout_task, train_task, watchdog_task)
+        telemetry_task = asyncio.create_task(self._telemetry_report_pump())
+        tasks = (rollout_task, train_task, watchdog_task, telemetry_task)
         try:
             done, _ = await asyncio.wait(
                 set(tasks), return_when=asyncio.FIRST_COMPLETED
@@ -708,9 +757,9 @@ class SingleControllerActor:
                 percent = (v / total_time * 100) if total_time > 0 else 0.0
                 print(f"  • {k}: {v:.2f}s ({percent:.1f}%)")
 
-            # TODO: per-step train_data jsonl dump, vllm metrics logger,
-            #   histogram log, rollout_metrics, seq_logprob_error_metrics,
-            #   pretty-print "Training Results" block, print_performance_metrics.
+            # TODO: per-step train_data jsonl dump, rollout_metrics,
+            #   seq_logprob_error_metrics, pretty-print "Training Results" block,
+            #   print_performance_metrics.
             print(f"step_metrics={step_metrics}", flush=True)
             self._logger.log_metrics(
                 step_metrics, step=self._train_steps, prefix="train"
@@ -718,6 +767,7 @@ class SingleControllerActor:
             self._logger.log_metrics(
                 timing_metrics, step=self._train_steps, prefix="timing/train"
             )
+            await self._report_generation_saturation()
             self._timer.reset()
 
             # min sample version refers to the version each consumed sample was
@@ -770,9 +820,28 @@ class SingleControllerActor:
 
             metrics = dict(stats.as_metrics())
             metrics["rollout/inflight"] = float(self._inflight_rollouts)
+            metrics["rollout/buffered"] = float(len(self._buffer))
             metrics["rollout/idle_s"] = idle_s
             metrics["rollout/train_steps"] = float(self._train_steps)
             self._logger.log_metrics(metrics, step=self._train_steps)
+
+            # Occupancy against the two capacities that bound it, which is the series
+            # the async knobs are tuned against. Buffer depth was previously readable
+            # only from the train pump's stall warning, so a run that never stalled
+            # reported it nowhere. Printed as well as logged because sizing these
+            # knobs is usually done from a job's stdout, and printed here rather than
+            # from a reporter of its own so the line and the series it summarizes
+            # cannot drift onto different cadences.
+            print(
+                f"occupancy (train_step={self._train_steps}): "
+                f"inflight={self._inflight_rollouts}/"
+                f"{self._async_cfg.max_inflight_prompts} "
+                f"buffered={len(self._buffer)}/"
+                f"{self._async_cfg.max_buffered_rollouts} "
+                f"committed={stats.committed} skipped={stats.skipped} "
+                f"trainer_v={self._trainer_version}",
+                flush=True,
+            )
 
             if watchdog_cfg.gym_subprocess_check:
                 # Bounded by one tick so a wedged environment cannot stop the pump, and
@@ -837,6 +906,99 @@ class SingleControllerActor:
             except Exception as error:
                 problems.append(f"environment {env_name!r} reported unhealthy: {error}")
         return problems
+
+    async def _report_generation_saturation(self) -> None:
+        """Log engine saturation for the step just closed, and clear the samples.
+
+        This is the metrics channel: a closed step gives the samples a step index to be
+        logged against, so the series here is the one to read in W&B or TensorBoard. The
+        stdout line is deliberately one line -- the numbers are in the series.
+
+        No-ops on backends that collect none of this, which is everything except vLLM
+        with ``enable_vllm_metrics_logger`` set.
+        """
+        # Collection does a blocking ray.get, so keep it off the event loop the rollout
+        # pump shares.
+        gen_metrics = await asyncio.to_thread(self._gen.get_logger_metrics)
+        if not gen_metrics:
+            return
+
+        saturation = _summarize_generation_saturation(gen_metrics)
+        if not saturation:
+            return
+
+        summary = " ".join(f"{k}={v:.3f}" for k, v in saturation.items())
+        engines = len(gen_metrics.get("inflight_batch_sizes", {}))
+        print(
+            f"engine saturation (engines={engines}): {summary}",
+            flush=True,
+        )
+        self._logger.log_metrics(
+            saturation, step=self._train_steps, prefix="generation"
+        )
+
+        if self._master_config.logger["wandb_enabled"]:
+            # W&B can block on the network; the rollout pump shares this loop.
+            await asyncio.to_thread(
+                log_generation_metrics_to_wandb,
+                gen_metrics,
+                self._train_steps,
+                self._master_config.policy["generation"]["vllm_cfg"][
+                    "vllm_metrics_logger_interval"
+                ],
+                self._logger,
+            )
+
+        await asyncio.to_thread(self._gen.clear_logger_metrics)
+
+    async def _telemetry_report_pump(self) -> None:
+        """Print engine saturation on a fixed cadence, independent of step boundaries.
+
+        The step-close reporter above only runs when a step closes, so a run that stalls
+        before completing one emits nothing at all -- precisely the run where the numbers
+        decide what to do next. This closes that gap on stdout only: with no step to log
+        against there is no meaningful step index, and writing the same ``generation/``
+        keys from two places at one step index would just have the last writer win.
+        Nothing is cleared here either, so the step-close reporting is unaffected.
+
+        Never exits, including on error. It is one of the tasks ``run`` waits on, so
+        returning would be read as a pump finishing and would stop the training loop over
+        a telemetry failure.
+        """
+        collect: Optional[asyncio.Task[dict[str, dict[int, list[Any]]]]] = None
+        while True:
+            await asyncio.sleep(_TELEMETRY_REPORT_SECONDS)
+
+            if collect is None:
+                collect = asyncio.create_task(
+                    asyncio.to_thread(self._gen.get_logger_metrics)
+                )
+            done, _ = await asyncio.wait({collect}, timeout=_TELEMETRY_REPORT_SECONDS)
+            if not done:
+                # A collection outliving its own cadence is itself the signal that the
+                # fleet is unreachable. Keep the handle and try again next tick rather
+                # than awaiting it -- an unbounded await is how the environment health
+                # probe used to wedge the watchdog -- and rather than issuing a second
+                # one, which would pile a thread up per tick behind the wedged first.
+                continue
+
+            try:
+                gen_metrics = collect.result()
+            except Exception as error:
+                # Telemetry must not end a run; this is whatever Ray raises for an
+                # unreachable worker.
+                print(f"WARNING: engine saturation unavailable -- {error}", flush=True)
+                gen_metrics = {}
+            collect = None
+
+            saturation = _summarize_generation_saturation(gen_metrics)
+            if not saturation:
+                continue
+            summary = " ".join(f"{k}={v:.3f}" for k, v in saturation.items())
+            print(
+                f"engine saturation (train_step={self._train_steps}): {summary}",
+                flush=True,
+            )
 
     async def _abort_stale_inflight(self) -> int:
         """Abort in-flight rollouts that the sampler can no longer select."""

--- a/tests/unit/single_controller/test_generation_telemetry.py
+++ b/tests/unit/single_controller/test_generation_telemetry.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Engine saturation: telling a busy generation fleet from an under-subscribed one.
+
+Both look the same from the trainer's side -- time spent in generation -- but only the
+second is fixed by admitting more in-flight prompts, so this is the measurement that
+decides whether a deeper lag setting can buy anything. The reporting has to survive the
+case it is most needed in: a run wedged before its first step closes, where the
+step-boundary reporter never runs at all.
+"""
+
+import asyncio
+import threading
+from types import SimpleNamespace
+
+from nemo_rl.algorithms import single_controller as sc
+from nemo_rl.algorithms.single_controller import (
+    SingleControllerActor,
+    _summarize_generation_saturation,
+)
+
+
+class TestSummarizeGenerationSaturation:
+    def test_samples_are_pooled_across_engines(self):
+        summary = _summarize_generation_saturation(
+            {"inflight_batch_sizes": {0: [2, 4], 1: [6, 8]}}
+        )
+
+        assert summary["requests_running_mean"] == 5.0
+        assert summary["requests_running_max"] == 8.0
+
+    def test_queue_busy_frac_counts_ticks_not_depth(self):
+        """The mean hides the shape: a queue deep for one tick averages out to idle."""
+        summary = _summarize_generation_saturation(
+            {"num_pending_samples": {0: [0, 0, 0, 40]}}
+        )
+
+        assert summary["queue_busy_frac"] == 0.25
+        assert summary["requests_waiting_max"] == 40.0
+
+    def test_a_backend_that_collects_nothing_summarizes_to_nothing(self):
+        """Every backend except vLLM with its metrics logger enabled lands here."""
+        assert _summarize_generation_saturation({}) == {}
+        assert _summarize_generation_saturation({"inflight_batch_sizes": {}}) == {}
+
+    def test_a_partially_reporting_backend_still_summarizes(self):
+        summary = _summarize_generation_saturation(
+            {"kv_cache_usage_perc": {0: [0.25, 0.75]}}
+        )
+
+        assert summary == {"kv_cache_usage_mean": 0.5, "kv_cache_usage_max": 0.75}
+
+
+def _make_controller(get_logger_metrics):
+    controller_cls = SingleControllerActor.__ray_metadata__.modified_class
+    ctrl = object.__new__(controller_cls)
+    ctrl._gen = SimpleNamespace(get_logger_metrics=get_logger_metrics)
+    ctrl._train_steps = 0
+    return ctrl
+
+
+async def _run_ticks(ctrl, seconds: float):
+    task = asyncio.ensure_future(ctrl._telemetry_report_pump())
+    await asyncio.sleep(seconds)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    return task
+
+
+class TestTelemetryReportPump:
+    def test_saturation_is_reported_without_a_step_closing(self, capsys, monkeypatch):
+        """train_steps stays at 0 here -- the wedge this exists for."""
+        monkeypatch.setattr(sc, "_TELEMETRY_REPORT_SECONDS", 0.001)
+        ctrl = _make_controller(lambda: {"num_pending_samples": {0: [12, 12]}})
+
+        asyncio.run(_run_ticks(ctrl, 0.05))
+
+        assert "engine saturation" in capsys.readouterr().out
+
+    def test_a_failing_collection_is_reported_and_the_pump_survives(
+        self, capsys, monkeypatch
+    ):
+        """Telemetry is one of the tasks run() waits on, so exiting would end the run."""
+        monkeypatch.setattr(sc, "_TELEMETRY_REPORT_SECONDS", 0.001)
+
+        def _unreachable():
+            raise RuntimeError("worker is gone")
+
+        ctrl = _make_controller(_unreachable)
+
+        task = asyncio.run(_run_ticks(ctrl, 0.05))
+
+        assert task.cancelled(), "the pump must still have been running to cancel"
+        assert "engine saturation unavailable" in capsys.readouterr().out
+
+    def test_a_wedged_collection_does_not_queue_another_behind_it(self, monkeypatch):
+        """The failure mode this reporting exists to observe must not compound it.
+
+        An unbounded await is how the environment health probe used to wedge the
+        watchdog; issuing a fresh collection per tick instead would pile up one blocked
+        thread every cadence for the rest of the run.
+        """
+        monkeypatch.setattr(sc, "_TELEMETRY_REPORT_SECONDS", 0.001)
+        release = threading.Event()
+        calls = []
+
+        def _wedged():
+            calls.append(1)
+            release.wait(timeout=30)
+            return {}
+
+        ctrl = _make_controller(_wedged)
+        try:
+            asyncio.run(_run_ticks(ctrl, 0.05))
+            assert len(calls) == 1, f"issued {len(calls)} collections behind a wedge"
+        finally:
+            # Let the blocked worker thread exit so it does not outlive the test.
+            release.set()

--- a/tests/unit/single_controller/test_sc_checkpointing.py
+++ b/tests/unit/single_controller/test_sc_checkpointing.py
@@ -212,6 +212,20 @@ class _ExhaustingSampler(_FakeSampler):
         return await super().select(**kwargs)
 
 
+class _FakeGeneration:
+    """GenerationInterface stand-in for the telemetry hooks the train pump calls.
+
+    Mirrors the interface defaults -- no samples, nothing to clear -- which is what
+    every backend except vLLM with its metrics logger enabled actually does.
+    """
+
+    def get_logger_metrics(self) -> dict[str, Any]:
+        return {}
+
+    def clear_logger_metrics(self) -> None:
+        return None
+
+
 class _FakeDPClient:
     def __init__(self) -> None:
         self.clear_calls: list[tuple[list[str], str]] = []
@@ -378,7 +392,7 @@ def _make_actor_args(
     last_checkpoint_path: Optional[str] = None,
 ) -> SingleControllerActorArgs:
     return SingleControllerActorArgs(
-        gen_handle=object(),
+        gen_handle=_FakeGeneration(),
         trainer_handle=trainer if trainer is not None else _FakeTrainer(),
         env_handles={},
         train_cluster=None,  # type: ignore[arg-type]

--- a/tests/unit/single_controller/test_single_controller.py
+++ b/tests/unit/single_controller/test_single_controller.py
@@ -368,7 +368,13 @@ def _train_pump_controller(*, sampler) -> object:
     ctrl._rollout_exhausted = asyncio.Event()
     ctrl._rollout_exhausted.set()
     ctrl._trainer = _NoOpTrainer()
-    ctrl._gen = SimpleNamespace(requires_kv_scale_sync=False)
+    ctrl._gen = SimpleNamespace(
+        requires_kv_scale_sync=False,
+        # Interface defaults: no samples collected, so the step-close saturation
+        # report no-ops, which is every backend but vLLM with its metrics logger on.
+        get_logger_metrics=lambda: {},
+        clear_logger_metrics=lambda: None,
+    )
     ctrl._loss_fn = None
     ctrl._dp_client = _NoOpDataPlane()
     ctrl._timer = Timer()

--- a/tests/unit/single_controller/test_watchdog_pump.py
+++ b/tests/unit/single_controller/test_watchdog_pump.py
@@ -53,6 +53,7 @@ def _make_controller(
     env_handles=None,
     train_steps: int = 0,
     max_num_steps: int = 100,
+    buffered: int = 0,
 ):
     controller_cls = SingleControllerActor.__ray_metadata__.modified_class
     ctrl = object.__new__(controller_cls)
@@ -64,7 +65,10 @@ def _make_controller(
             stall_timeout_s=stall_timeout_s,
             stall_action=stall_action,
             gym_subprocess_check=gym_subprocess_check,
-        )
+        ),
+        # Capacities the occupancy report divides by.
+        max_inflight_prompts=16,
+        max_buffered_rollouts=64,
     )
     ctrl._master_config = SimpleNamespace(
         grpo=GRPOConfig.model_construct(max_num_steps=max_num_steps)
@@ -72,6 +76,8 @@ def _make_controller(
     ctrl._rollout_manager = SimpleNamespace(stats=stats)
     ctrl._inflight_rollouts = inflight
     ctrl._train_steps = train_steps
+    ctrl._trainer_version = train_steps
+    ctrl._buffer = [None] * buffered
     ctrl._logger = _RecordingLogger()
     ctrl._env_handles = env_handles if env_handles is not None else {}
     return ctrl
@@ -199,6 +205,32 @@ class TestMetrics:
         assert published["rollout/inflight"] == 2.0
         # The leading indicator: idle time rises before a wedge becomes a stall.
         assert "rollout/idle_s" in published
+
+    def test_buffer_occupancy_is_published_as_a_series(self):
+        """Buffer depth against its capacity is what the async knobs are tuned on.
+
+        It used to be readable only from the train pump's stall warning, so a run that
+        never stalled -- every healthy run -- reported it nowhere.
+        """
+        ctrl = _make_controller(
+            stats=RolloutStats(), inflight=2, stall_timeout_s=1000.0, buffered=5
+        )
+
+        asyncio.run(_run_ticks(ctrl, 2))
+
+        assert ctrl._logger.metrics[-1]["rollout/buffered"] == 5.0
+
+    def test_occupancy_is_printed_against_its_capacities(self, capsys):
+        """The numbers are useless without the bounds they are approaching."""
+        ctrl = _make_controller(
+            stats=RolloutStats(), inflight=3, stall_timeout_s=1000.0, buffered=9
+        )
+
+        asyncio.run(_run_ticks(ctrl, 2))
+
+        out = capsys.readouterr().out
+        assert "inflight=3/16" in out
+        assert "buffered=9/64" in out
 
 
 class TestEnvHealthCheck:


### PR DESCRIPTION
# Overview
Tuning the async knobs at scale meant guessing. A generation fleet that is compute-bound and one that is merely under-subscribed both surface to the trainer as nothing but time spent in generation, yet only the second is fixed by admitting more in-flight prompts, so choosing a lag setting had no evidence behind it. vLLM already collects what settles it -- num_requests_waiting, the running batch sizes, KV-cache use -- and the workers already sample it under enable_vllm_metrics_logger; SingleController simply never read it.

Reported on two channels, split by what each can honestly carry:

  - At step close, as metrics under generation/, where a closed step gives the samples a step index worth logging against. This also clears the worker-side samples, so each report covers one step.

  - On a fixed cadence, on stdout only. The step-close reporter runs only when a step closes, so a run wedged before its first one reports nothing at all -- the run where the numbers matter most. With no step to log against there is no meaningful index, and writing the same generation/ keys from two places at one index would only have the last writer win, so this prints and clears nothing.

Buffer occupancy joins rollout/inflight in the watchdog's existing dict rather than arriving as a report of its own. Buffer depth was readable only from the train pump's stall warning, so every run that never stalled reported it nowhere, and the watchdog is already sampling this exact state on a timer.

The cadence collection cannot compound the failure it exists to observe: a collection that outlives its own cadence is left outstanding rather than awaited, and no second one is issued behind it. An unbounded await here is how the environment health probe used to wedge the watchdog, and issuing one per tick would pile up a blocked thread every cadence for the rest of the run.

Backends that collect none of this summarize to nothing and report nothing, which is every backend but vLLM with its metrics logger enabled.

Two test fakes grew the interface's telemetry hooks, which they had stubbed as a bare object() and a SimpleNamespace.

# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
