### PR TITLE
fix(gym): hold the tokenizer in NemoGym instead of passing it per rollout

### DIFF
--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -564,6 +564,7 @@ def setup(
                     )
                 actor = NemoGym.options(**nemo_gym_opts).remote(nemo_gym_cfg)
                 ray.get(actor._spinup.remote())
+                ray.get(actor.set_tokenizer.remote(tokenizer))
                 return actor
 
             init_tasks = {

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -704,6 +704,7 @@ def setup(
             env_configs=env_configs,
             base_urls=base_urls,
             model_name=model_name,
+            tokenizer=tokenizer,
             enable_router_replay=enable_router_replay,
             routed_experts_dtype=routed_experts_dtype,
             use_fastokens=bool(policy_config["tokenizer"].get("use_fastokens")),

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -312,12 +312,18 @@ def _build_trainer(
     return trainer, time.perf_counter() - t0
 
 
-def _spinup_gym(master_config: MasterConfig, base_urls: list[str]) -> tuple[Any, float]:
+def _spinup_gym(
+    master_config: MasterConfig,
+    base_urls: list[str],
+    tokenizer: PreTrainedTokenizerBase,
+) -> tuple[Any, float]:
     """Spin up the NeMo-Gym actor against the reserved vLLM URLs.
 
     Args:
         master_config: SC MasterConfig.
         base_urls: Reserved vLLM OpenAI server URLs.
+        tokenizer: Installed on the actor at spinup rather than passed per rollout
+            call. See NemoGym.set_tokenizer.
 
     Returns:
         A tuple of (NeMo-Gym actor, wall time spent in this call).
@@ -335,6 +341,7 @@ def _spinup_gym(master_config: MasterConfig, base_urls: list[str]) -> tuple[Any,
         env_configs=master_config.env,
         base_urls=base_urls,
         model_name=generation_config["model_name"],
+        tokenizer=tokenizer,
         enable_router_replay=enable_router_replay,
         routed_experts_dtype=routed_experts_dtype,
         use_fastokens=bool(policy_config["tokenizer"].get("use_fastokens")),
@@ -690,6 +697,7 @@ def setup_single_controller(
                 if generation_router is not None
                 else generation.dp_openai_server_base_urls
             ),
+            tokenizer=tokenizer,
         )
 
     if colocated:

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -416,6 +416,10 @@ class NemoGym(EnvironmentInterface):
         self.head_server_config: Any = None
         self.node_ip: Optional[str] = None
         self.head_server_port: Optional[int] = None
+        # Installed by set_tokenizer at spinup, not passed per rollout call. Declared
+        # here rather than in _spinup so a second spinup cannot wipe an installed
+        # tokenizer and then report that set_tokenizer was never called.
+        self._tokenizer: Optional[PreTrainedTokenizerBase] = None
         self._pad_dynamic_image_shapes = bool(cfg.get("pad_dynamic_image_shapes"))
         # Reconstruct the processor inside the actor (rather than serializing it
         # per rollout call) for full-trajectory multimodal postprocessing.
@@ -553,10 +557,33 @@ Depending on your data shape, you may want to change these values."""
         )
         self.rch = RolloutCollectionHelper()
 
+    def set_tokenizer(self, tokenizer: PreTrainedTokenizerBase) -> None:
+        """Install the tokenizer run_rollouts postprocesses with.
+
+        Called once per actor at spinup. It used to be a run_rollouts argument,
+        which meant Ray deserialized a tokenizer per prompt on this actor's
+        task-execution thread. That thread holds the GIL, so it blocked the
+        actor's event loop and no rollout could issue its first HTTP request
+        until its own copy finished loading.
+
+        The cost is not marginal. A tokenizer of this shape measured 7.45 MB on
+        the wire, 286 ms to serialize and 1052 ms to deserialize, so a
+        SingleController recipe admitting ~1000 prompts per step spends roughly
+        18 minutes deserializing a single admission burst, against a step that
+        should take minutes. Runs on that shape stalled without completing a
+        rollout.
+
+        Measured on one CPU node with 1024 concurrent calls against one actor:
+        153 of 1024 prompts finished in 300 s passing the tokenizer per call,
+        versus all 1024 in 16 s holding it here. Passing an ObjectRef instead
+        does not help -- Ray caches the object buffer, not the deserialized
+        value, so it still pays per task.
+        """
+        self._tokenizer = tokenizer
+
     async def run_rollouts(
         self,
         nemo_gym_examples: list[dict],
-        tokenizer: PreTrainedTokenizerBase,
         timer_prefix: str,
         deduplicate_multimodal_data: bool = False,
     ) -> AsyncGenerator[tuple[int, dict, dict | None], None]:
@@ -564,6 +591,11 @@ Depending on your data shape, you may want to change these values."""
         self._require_spinup()
         if not nemo_gym_examples:
             raise ValueError("NeMo-Gym rollout batch must not be empty")
+        if self._tokenizer is None:
+            raise RuntimeError(
+                "NemoGym.set_tokenizer must be called before run_rollouts"
+            )
+        tokenizer = self._tokenizer
 
         from nemo_rl.utils.fastokens import maybe_patch_fastokens
 
@@ -1024,6 +1056,7 @@ def spinup_nemo_gym_actor(
     base_urls: list[str],
     model_name: str,
     *,
+    tokenizer: PreTrainedTokenizerBase,
     enable_router_replay: bool,
     routed_experts_dtype: str,
     use_fastokens: bool,
@@ -1040,6 +1073,9 @@ def spinup_nemo_gym_actor(
             thinking_tags, num_gpu_nodes).
         base_urls: Per-DP-rank OpenAI-compatible server base URLs from the generation backend.
         model_name: Served model name the Gym rollouts should target.
+        tokenizer: Installed on the actor once, here, rather than passed per
+            rollout call. See NemoGym.set_tokenizer for why that distinction is
+            the difference between a working run and a stalled one.
         enable_router_replay: Sets require_routed_experts on the NemoGymConfig.
         routed_experts_dtype: Dtype name for R3 routed_experts tensors ("int8"/"int16"/"int32"),
             resolved by the caller from the model's expert count.
@@ -1110,4 +1146,5 @@ def spinup_nemo_gym_actor(
 
     actor = NemoGym.options(**nemo_gym_opts).remote(nemo_gym_cfg)
     ray.get(actor._spinup.remote())
+    ray.get(actor.set_tokenizer.remote(tokenizer))
     return actor

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -834,7 +834,7 @@ class AsyncNemoGymRolloutImpl:
 
         async for result_ref in nemo_gym_env.run_rollouts.options(
             num_returns="streaming"
-        ).remote(pending, self._tokenizer, timer_prefix):
+        ).remote(pending, timer_prefix):
             rowidx, result, timing_metrics = await result_ref
             # Validated against the original group, not the pending subset: on a
             # re-dispatch the row keeps its original index so results stay ordered.

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -2249,7 +2249,8 @@ async def run_async_nemo_gym_rollout(
         policy_generation: Generation interface whose configuration supplies the
             model's maximum sequence length.
         input_batch: Batch whose ``extra_env_info`` field contains NeMo-Gym rows.
-        tokenizer: Tokenizer used by the NeMo-Gym actor and local postprocessing.
+        tokenizer: Tokenizer for local postprocessing. The actor holds its own,
+            installed once at spinup -- see NemoGym.set_tokenizer.
         task_to_env: Environment mapping containing the ``"nemo_gym"`` actor.
         generation_config: Sampling parameters forwarded to every NeMo-Gym row.
         num_generations: Number of contiguous rows belonging to each prompt group.
@@ -2363,7 +2364,6 @@ async def run_async_nemo_gym_rollout(
         with timer.time(run_rollouts_timer_label):
             ray_arguments = (
                 nemo_gym_rows,
-                tokenizer,
                 timer_prefix,
                 deduplicate_multimodal_data,
             )
@@ -2482,7 +2482,8 @@ def run_nemo_gym_rollout_sync(
         policy_generation: Generation interface whose configuration supplies the
             model's maximum sequence length.
         input_batch: Batch whose ``extra_env_info`` field contains NeMo-Gym rows.
-        tokenizer: Tokenizer used by the NeMo-Gym actor and local postprocessing.
+        tokenizer: Tokenizer for local postprocessing. The actor holds its own,
+            installed once at spinup -- see NemoGym.set_tokenizer.
         task_to_env: Environment mapping containing the ``"nemo_gym"`` actor.
         generation_config: Sampling parameters forwarded to every NeMo-Gym row.
         log_full_result_tables: Whether to include complete per-agent result

--- a/tests/unit/algorithms/test_distillation.py
+++ b/tests/unit/algorithms/test_distillation.py
@@ -14,7 +14,7 @@
 
 import copy
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 import torch
@@ -1281,7 +1281,13 @@ def test_distillation_setup_nemo_gym_uses_deferred_vllm(
     }
     assert master_config.env["nemo_gym"] == nemo_gym_env_before
     nemo_gym_actor._spinup.remote.assert_called_once_with()
-    mock_ray.get.assert_called_once_with("spinup-ref")
+    # Two waits, in order: the spinup, then the tokenizer install. Distillation
+    # builds its actor inline rather than through spinup_nemo_gym_actor, so it
+    # is the one call site that has to set the tokenizer itself -- passing it
+    # per rollout is what made the actor deserialize it once per prompt.
+    assert mock_ray.get.call_args_list[0] == call("spinup-ref")
+    assert mock_ray.get.call_count == 2
+    nemo_gym_actor.set_tokenizer.remote.assert_called_once_with(tokenizer)
 
 
 def test_nemo_gym_distillation_runner_uses_setup_actor():

--- a/tests/unit/environments/test_nemo_gym.py
+++ b/tests/unit/environments/test_nemo_gym.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import json
 import time
 from copy import deepcopy
@@ -166,7 +167,7 @@ def nemo_gym_vllm_generation(cluster, nemo_gym_tokenizer):  # noqa: F811
 
 
 @pytest.fixture(scope="function")
-def nemo_gym(nemo_gym_vllm_generation):
+def nemo_gym(nemo_gym_vllm_generation, nemo_gym_tokenizer):  # noqa: F811
     """Create a NeMo-Gym actor for testing."""
 
     yaml_str = r"""example_multi_step_resources_server:
@@ -210,6 +211,10 @@ openai_model:
 
     # Blocking wait for NeMo-Gym to spin up
     ray.get(env._spinup.remote())
+    # Install the tokenizer here, as spinup_nemo_gym_actor does, so the fixture
+    # yields an actor that can actually run rollouts. Tests reaching the actor
+    # through RolloutManager never see set_tokenizer themselves.
+    ray.get(env.set_tokenizer.remote(nemo_gym_tokenizer))
 
     yield env
     # Clean up the actor and wait for it to be killed
@@ -261,6 +266,26 @@ def _write_actual_test_data(original_input: list, actual_result: list):
         json.dump(data, f)
         f.write("\n")
     print(f"Wrote updated test data to {output_path}")
+
+
+def test_run_rollouts_requires_an_installed_tokenizer():
+    """run_rollouts reads the tokenizer off the actor, so reaching it without one fails.
+
+    Every call site installs it via spinup, so this is unreachable in practice -- but
+    silently postprocessing with no tokenizer is worse than a named error, and a future
+    spinup path that forgets the call should say so here rather than deeper in.
+    """
+    gym_cls = NemoGym.__ray_metadata__.modified_class
+    # Constructed through __init__ rather than object.__new__ so the None comes from
+    # the declaration itself: an attribute set only in _spinup would leave a second
+    # spinup free to wipe an installed tokenizer.
+    gym = gym_cls({})
+    assert gym._tokenizer is None
+    gym.rh = object()  # satisfies _require_spinup
+
+    stream = gym.run_rollouts([{"_rowidx": 0}], "")
+    with pytest.raises(RuntimeError, match="set_tokenizer must be called"):
+        asyncio.run(stream.__anext__())
 
 
 def test_nemo_gym_postprocess_uses_batch_decode():
@@ -669,7 +694,6 @@ def test_nemo_gym_sanity(
     nemo_gym,
     nemo_gym_sanity_test_data,
     nemo_gym_vllm_generation,
-    nemo_gym_tokenizer,  # noqa: F811
 ):
     """Test basic functionality of MathEnvironment step with simple messages."""
 
@@ -688,7 +712,7 @@ def test_nemo_gym_sanity(
 
     actual_result = [None] * len(nemo_gym_sanity_test_data["input"])
     for result_ref in nemo_gym.run_rollouts.options(num_returns="streaming").remote(
-        nemo_gym_sanity_test_data["input"], nemo_gym_tokenizer, ""
+        nemo_gym_sanity_test_data["input"], ""
     ):
         rowidx, result, _ = ray.get(result_ref)
         actual_result[rowidx] = result

--- a/tests/unit/experience/test_rollout_generation_failures.py
+++ b/tests/unit/experience/test_rollout_generation_failures.py
@@ -460,8 +460,8 @@ class _PartialGymMethod:
         del kwargs
         return self
 
-    def remote(self, inputs, tokenizer, timer_prefix):
-        del tokenizer, timer_prefix
+    def remote(self, inputs, timer_prefix):
+        del timer_prefix
         self.dispatched.append([row["_rowidx"] for row in inputs])
         attempt = self.attempts
         self.attempts += 1
@@ -500,8 +500,8 @@ class _FakeGymMethod:
         del kwargs
         return self
 
-    def remote(self, inputs, tokenizer, timer_prefix):
-        del tokenizer, timer_prefix
+    def remote(self, inputs, timer_prefix):
+        del timer_prefix
         return self._stream(len(inputs))
 
     async def _stream(self, num_inputs):

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -1810,11 +1810,10 @@ def test_run_async_nemo_gym_rollout_streams_complete_prompt_groups(monkeypatch):
         def remote(
             self,
             rows,
-            tokenizer,
             timer_prefix,
             deduplicate_multimodal_data,
         ):
-            del rows, tokenizer, timer_prefix
+            del rows, timer_prefix
             assert deduplicate_multimodal_data is True
             # Both groups complete out of order internally and group 1 completes first.
             completion_order = [3, 1, 2, 0]
@@ -1953,7 +1952,9 @@ def test_run_async_nemo_gym_rollout_streams_complete_prompt_groups(monkeypatch):
     assert boundary == "nemo_gym_request"
     assert enabled is True
     assert ray_arguments[0] is rows
-    assert ray_arguments[3:] == (True,)
+    # (rows, timer_prefix, deduplicate_multimodal_data) -- the tokenizer is no longer
+    # among the arguments crossing to the actor, which is the point of set_tokenizer.
+    assert ray_arguments[2:] == (True,)
     for expected_rowidx, (payload, boundary, enabled) in zip(
         (3, 1, 2, 0), payload_calls[1:]
     ):
@@ -2146,8 +2147,8 @@ def test_rollout_manager_consumes_stream_and_restores_input_order():
             assert num_returns == "streaming"
             return self
 
-        def remote(self, inputs, tokenizer, timer_prefix):
-            del inputs, tokenizer, timer_prefix
+        def remote(self, inputs, timer_prefix):
+            del inputs, timer_prefix
             return _Stream()
 
     manager = object.__new__(AsyncNemoGymRolloutImpl)
@@ -2219,8 +2220,8 @@ def test_rollout_manager_rejects_duplicate_stream_rows():
             assert num_returns == "streaming"
             return self
 
-        def remote(self, inputs, tokenizer, timer_prefix):
-            del inputs, tokenizer, timer_prefix
+        def remote(self, inputs, timer_prefix):
+            del inputs, timer_prefix
             return _DuplicateStream()
 
     manager = object.__new__(AsyncNemoGymRolloutImpl)

--- a/tests/unit/single_controller/test_single_controller_setup.py
+++ b/tests/unit/single_controller/test_single_controller_setup.py
@@ -429,12 +429,16 @@ class TestSetup:
             ) as mock_spinup,
             patch.object(sc_setup_mod, "router_replay_enabled", return_value=False),
         ):
-            actor_args, _ = setup_single_controller(mc, MagicMock(pad_token_id=0))
+            tokenizer = MagicMock(pad_token_id=0)
+            actor_args, _ = setup_single_controller(mc, tokenizer)
 
         mock_spinup.assert_called_once_with(
             env_configs=mc.env,
             base_urls=patched_factories["fake_gen"].dp_openai_server_base_urls,
             model_name="test-model",
+            # Reaches the actor once, at spinup, rather than riding along with every
+            # run_rollouts call.
+            tokenizer=tokenizer,
             enable_router_replay=False,
             routed_experts_dtype="int16",
             use_fastokens=False,


### PR DESCRIPTION
# Overview
run_rollouts took the tokenizer as an argument and the rollout pump calls it once per prompt, so Ray deserialized a 7.45 MB tokenizer on the actor's task-execution thread for every prompt. That thread holds the GIL, so it blocked the actor's event loop and no rollout could issue its first HTTP request until its own copy finished loading.

Measured: 286 ms to serialize, 1052 ms to deserialize. A SingleController recipe admitting ~1000 prompts per step spends ~18 minutes deserializing one admission burst.

Reproduced on one CPU node with 1024 concurrent calls against one actor: 153 of 1024 prompts finished in 300 s passing the tokenizer per call, versus all 1024 in 16 s installing it once. Passing an ObjectRef instead does not help; Ray caches the object buffer and not the deserialized value, so the actor still pays per task.

Install it through the spinup paths so no call site can forget: the shared spinup_nemo_gym_actor helper takes it as a keyword argument, and distillation, which builds its actor inline, sets it alongside its own _spinup call. On the SingleController path it threads through _spinup_gym, since the kwargs that used to sit at the partial now live inside that function.

run_rollouts fails loudly rather than silently if it is somehow reached without one -- postprocessing with no tokenizer is worse than a named error, and the attribute is initialized in __init__ so the check reads as state rather than as an absent attribute.

Test fakes that stood in for the actor method lose the argument with it, and the SingleController setup test now asserts the tokenizer reaches spinup, which is the property that keeps it off the per-call path.

# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
