### PR TITLE
fix(sc): mask sequence logprob outliers

### DIFF
--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -47,7 +47,11 @@ import ray
 import torch
 
 from nemo_rl.algorithms.async_utils.staleness_sampler import create_sampler
-from nemo_rl.algorithms.grpo import GRPOSaveState, _write_latest_checkpoint_status
+from nemo_rl.algorithms.grpo import (
+    GRPOSaveState,
+    _write_latest_checkpoint_status,
+    compute_and_apply_seq_logprob_error_masking,
+)
 from nemo_rl.algorithms.metric_utils import SetupTimingMetrics
 from nemo_rl.algorithms.single_controller_utils.config import (
     AdvantageConfig,
@@ -255,6 +259,7 @@ class SingleControllerActor:
             "rewards": [],
             "masked_advantages": [],
             "sequence_lengths": [],
+            "seq_logprob_error_metrics": [],
         }
 
         print(
@@ -963,22 +968,29 @@ class SingleControllerActor:
 
                     # Compute advantages
                     with self._timer.time("advantage_calculation"):
-                        train_meta = await self._advantage_stage(train_meta)
+                        (
+                            train_meta,
+                            has_valid_training_tokens,
+                        ) = await self._advantage_stage(train_meta)
 
-                    # Train
+                    # Filtering can leave a streaming chunk with no training tokens.
+                    # Consume that chunk without F/B, then continue the same optimizer
+                    # step with the next chunk. Always restore training mode because
+                    # log-prob inference may have switched the model to inference mode.
                     with self._timer.time("training_prep"):
                         await asyncio.to_thread(self._trainer.prepare_for_training)
-                    with self._timer.time("policy_training"):
-                        if not step_open:
+                    if has_valid_training_tokens:
+                        with self._timer.time("policy_training"):
+                            if not step_open:
+                                await asyncio.to_thread(
+                                    self._trainer.begin_train_step,
+                                    self._loss_fn,
+                                )
+                                step_open = True
                             await asyncio.to_thread(
-                                self._trainer.begin_train_step,
-                                self._loss_fn,
+                                self._trainer.train_microbatches_from_meta,
+                                train_meta,
                             )
-                            step_open = True
-                        await asyncio.to_thread(
-                            self._trainer.train_microbatches_from_meta,
-                            train_meta,
-                        )
 
                     if train_meta.sequence_lengths:
                         self._step_log_dict["sequence_lengths"].extend(
@@ -1046,6 +1058,13 @@ class SingleControllerActor:
                     chunks_dispatched,
                     groups_dispatched,
                 )
+                if not step_open:
+                    raise RuntimeError(
+                        "SingleController has no valid response tokens after "
+                        "filtering. Check grpo.seq_logprob_error_threshold to "
+                        "avoid an optimizer step with an empty batch."
+                    )
+
                 with self._timer.time("policy_training"):
                     result = await asyncio.to_thread(self._trainer.finish_train_step)
 
@@ -1175,8 +1194,8 @@ class SingleControllerActor:
                 print(f"  • {k}: {v:.2f}s ({percent:.1f}%)")
 
             # TODO: per-step train_data jsonl dump, vllm metrics logger,
-            #   histogram log, rollout_metrics, seq_logprob_error_metrics,
-            #   pretty-print "Training Results" block, print_performance_metrics.
+            #   histogram log, rollout_metrics, pretty-print "Training Results"
+            #   block, print_performance_metrics.
             print(f"step_metrics={step_metrics}", flush=True)
             self._logger.log_metrics(
                 step_metrics, step=self._train_steps, prefix="train"
@@ -1656,7 +1675,7 @@ class SingleControllerActor:
         self._rollout_permitted.set()
         return aborted_stale_inflight_groups
 
-    async def _advantage_stage(self, meta: KVBatchMeta) -> KVBatchMeta:
+    async def _advantage_stage(self, meta: KVBatchMeta) -> tuple[KVBatchMeta, bool]:
         """Fetch advantage inputs, compute advantages, and write them back.
 
         SC owns the prompt-group-scoped advantage stage because the selected
@@ -1664,9 +1683,13 @@ class SingleControllerActor:
         DP sharding. Tensor payloads still move through DataPlane: SC fetches
         only the configured advantage input columns and writes the computed
         ``advantages`` column back under the same ``sample_ids``.
+
+        Returns:
+            The updated batch metadata and whether the batch contains at least
+            one valid training token.
         """
         if self._advantage_estimator is None:
-            return meta
+            return meta, True
         adv_cfg = self._advantage_cfg
 
         data = await self._call_dp(
@@ -1684,6 +1707,51 @@ class SingleControllerActor:
         sample_mask = squeeze_trailing_unit_dim(
             tensor_field(data, adv_cfg.sample_mask_field)
         ).float()
+
+        seq_logprob_error_threshold = (
+            self._master_config.grpo.seq_logprob_error_threshold
+        )
+        # Match the legacy path: whenever real policy logprobs are available,
+        # report sequence-level generation/training mismatch. A threshold adds
+        # masking; leaving it unset keeps this metrics-only.
+        if self._policy_logprobs_required:
+            masking_data = BatchedDataDict(
+                {
+                    "token_mask": token_mask,
+                    "sample_mask": sample_mask,
+                    "prev_logprobs": tensor_field(
+                        data,
+                        adv_cfg.policy_logprobs_field,
+                    ),
+                    "generation_logprobs": tensor_field(
+                        data,
+                        adv_cfg.generation_logprobs_field,
+                    ),
+                }
+            )
+            num_valid_seqs_before = float(
+                ((token_mask[:, 1:] * sample_mask.unsqueeze(-1)).sum(dim=-1) > 0)
+                .sum()
+                .item()
+            )
+            seq_error_metrics = compute_and_apply_seq_logprob_error_masking(
+                train_data=masking_data,
+                rewards=rewards,
+                seq_logprob_error_threshold=seq_logprob_error_threshold,
+            )
+            sample_mask = masking_data["sample_mask"]
+            num_valid_seqs_after = float(
+                ((token_mask[:, 1:] * sample_mask.unsqueeze(-1)).sum(dim=-1) > 0)
+                .sum()
+                .item()
+            )
+            seq_error_metrics["num_masked_seqs_by_logprob_error"] = (
+                seq_error_metrics.pop("num_masked_seqs")
+            )
+            seq_error_metrics["_num_valid_seqs_before"] = num_valid_seqs_before
+            seq_error_metrics["_num_valid_seqs_after"] = num_valid_seqs_after
+            self._step_log_dict["seq_logprob_error_metrics"].append(seq_error_metrics)
+
         mask = token_mask * sample_mask.unsqueeze(-1)
 
         repeated_batch: dict[str, torch.Tensor] = {
@@ -1706,29 +1774,39 @@ class SingleControllerActor:
                 adv_cfg.reference_logprobs_field,
             )
 
-        advantages = self._advantage_estimator.compute_advantage(
-            prompt_ids=prompt_ids,
-            rewards=rewards,
-            mask=mask,
-            repeated_batch=repeated_batch,
-            **kwargs,
-        )
+        # Training predicts token t from position t - 1, so token_mask[:, 1:]
+        # is the exact mask used when global_valid_toks and the loss are built.
+        has_valid_training_tokens = bool(mask[:, 1:].bool().any().item())
+        if has_valid_training_tokens:
+            advantages = self._advantage_estimator.compute_advantage(
+                prompt_ids=prompt_ids,
+                rewards=rewards,
+                mask=mask,
+                repeated_batch=repeated_batch,
+                **kwargs,
+            )
+        else:
+            advantages = torch.zeros_like(mask)
         response_advantages = torch.masked_select(advantages, mask.bool())
         self._step_log_dict["rewards"].append(rewards.detach().cpu())
         self._step_log_dict["masked_advantages"].append(
             response_advantages.detach().cpu()
         )
 
+        fields_to_put = {adv_cfg.output_field: advantages}
+        if seq_logprob_error_threshold is not None:
+            fields_to_put[adv_cfg.sample_mask_field] = sample_mask
+
         await self._call_dp(
             "put_samples",
             sample_ids=meta.sample_ids,
             partition_id=meta.partition_id,
-            fields=fields_for_put(
-                meta,
-                {adv_cfg.output_field: advantages},
-            ),
+            fields=fields_for_put(meta, fields_to_put),
         )
-        return meta.with_fields([adv_cfg.output_field])
+        return (
+            meta.with_fields([adv_cfg.output_field]),
+            has_valid_training_tokens,
+        )
 
     # ── utility helpers ────────────────────────────────────────────────────
 
@@ -1743,6 +1821,8 @@ class SingleControllerActor:
         ]
         if self._policy_logprobs_required:
             fields.append(adv_cfg.policy_logprobs_field)
+        if self._policy_logprobs_required:
+            fields.append(adv_cfg.generation_logprobs_field)
         if self._reference_logprobs_required:
             fields.append(adv_cfg.reference_logprobs_field)
         return list(dict.fromkeys(fields))

--- a/nemo_rl/algorithms/single_controller_utils/config.py
+++ b/nemo_rl/algorithms/single_controller_utils/config.py
@@ -807,4 +807,5 @@ class AdvantageConfig:
     sample_mask_field: str = "sample_mask"
     repeated_batch_fields: list[str] = field(default_factory=list)
     policy_logprobs_field: str = "prev_logprobs"
+    generation_logprobs_field: str = "generation_logprobs"
     reference_logprobs_field: str = "reference_policy_logprobs"

--- a/nemo_rl/algorithms/single_controller_utils/utils.py
+++ b/nemo_rl/algorithms/single_controller_utils/utils.py
@@ -94,6 +94,7 @@ def reduce_advantage_pump_metrics(
     rewards: list[torch.Tensor],
     masked_advantages: list[torch.Tensor],
     sequence_lengths: list[int],
+    seq_logprob_error_metrics: list[dict[str, float]] | None = None,
 ) -> dict[str, float]:
     """Reduce per-step accumulators from _advantage_stage into step scalars.
 
@@ -101,9 +102,12 @@ def reduce_advantage_pump_metrics(
         rewards: One tensor per advantage_stage call; each row a sample reward.
         masked_advantages: Token-masked advantages, one tensor per call.
         sequence_lengths: All input_lengths trained on this step.
+        seq_logprob_error_metrics: Sequence-error metrics and their aggregation
+            counts, one record per streaming chunk.
 
     Returns:
-        Dict with reward, advantages/{mean,max,min}, total_num_tokens.
+        Step-level reward, advantage, token-count, and optional sequence
+        log-probability error metrics.
     """
     out: dict[str, float] = {}
     if rewards:
@@ -120,7 +124,61 @@ def reduce_advantage_pump_metrics(
             out["advantages/min"] = 0.0
     if sequence_lengths:
         out["total_num_tokens"] = float(sum(sequence_lengths))
+    if seq_logprob_error_metrics:
+        out.update(_reduce_seq_logprob_error_metrics(seq_logprob_error_metrics))
     return out
+
+
+def _reduce_seq_logprob_error_metrics(
+    records: list[dict[str, float]],
+) -> dict[str, float]:
+    """Reduce sequence-error metrics across streaming chunks."""
+
+    def reduce_range(
+        *,
+        count_key: str,
+        max_key: str,
+        mean_key: str,
+        min_key: str,
+    ) -> dict[str, float]:
+        populated = [record for record in records if record[count_key] > 0]
+        count = sum(record[count_key] for record in populated)
+        if not count:
+            return {max_key: 0.0, mean_key: 0.0, min_key: 0.0}
+        return {
+            max_key: max(record[max_key] for record in populated),
+            mean_key: sum(record[mean_key] * record[count_key] for record in populated)
+            / count,
+            min_key: min(record[min_key] for record in populated),
+        }
+
+    reduced = reduce_range(
+        count_key="_num_valid_seqs_before",
+        max_key="max_seq_mult_prob_error",
+        mean_key="mean_seq_mult_prob_error",
+        min_key="min_seq_mult_prob_error",
+    )
+    reduced.update(
+        reduce_range(
+            count_key="_num_valid_seqs_after",
+            max_key="max_seq_mult_prob_error_after_mask",
+            mean_key="mean_seq_mult_prob_error_after_mask",
+            min_key="min_seq_mult_prob_error_after_mask",
+        )
+    )
+
+    masked_count = sum(record["num_masked_seqs_by_logprob_error"] for record in records)
+    reduced["num_masked_seqs_by_logprob_error"] = int(masked_count)
+    reduced["masked_correct_pct"] = (
+        sum(
+            record["masked_correct_pct"] * record["num_masked_seqs_by_logprob_error"]
+            for record in records
+        )
+        / masked_count
+        if masked_count
+        else 0.0
+    )
+    return reduced
 
 
 def tensor_field(data: TensorDict, field_name: str) -> torch.Tensor:

--- a/tests/functional/grpo_dp_single_controller.sh
+++ b/tests/functional/grpo_dp_single_controller.sh
@@ -27,6 +27,7 @@ uv run coverage run -a --data-file=$PROJECT_ROOT/tests/.coverage --source=$PROJE
     policy.model_name=Qwen/Qwen3-0.6B \
     grpo.num_prompts_per_step=2 \
     grpo.num_generations_per_prompt=4 \
+    grpo.seq_logprob_error_threshold=1000 \
     policy.train_global_batch_size=8 \
     policy.train_micro_batch_size=1 \
     cluster.gpus_per_node=2 \
@@ -50,6 +51,8 @@ uv run coverage run -a --data-file=$PROJECT_ROOT/tests/.coverage --source=$PROJE
 uv run tests/json_dump_tb_logs.py $LOG_DIR --output_path $JSON_METRICS
 
 uv run tests/check_metrics.py $JSON_METRICS \
+    'max(data["train/num_masked_seqs_by_logprob_error"]) == 0' \
+    'max(data["train/max_seq_mult_prob_error"]) < 1000' \
     'max(data["train/gen_kl_error"]) < 0.002' \
     'min(data["train/probs_ratio_clamped_min"]) > 0.79' \
     'max(data["train/probs_ratio_clamped_min"]) < 1.21' \

--- a/tests/unit/single_controller/test_sc_utils_helpers.py
+++ b/tests/unit/single_controller/test_sc_utils_helpers.py
@@ -160,6 +160,50 @@ class TestReduceAdvantagePumpMetrics:
     def test_all_empty_inputs_returns_empty_dict(self) -> None:
         assert reduce_advantage_pump_metrics([], [], []) == {}
 
+    def test_seq_logprob_error_metrics_are_reduced_across_streaming_chunks(
+        self,
+    ) -> None:
+        out = reduce_advantage_pump_metrics(
+            rewards=[],
+            masked_advantages=[],
+            sequence_lengths=[],
+            seq_logprob_error_metrics=[
+                {
+                    "max_seq_mult_prob_error": 10.0,
+                    "mean_seq_mult_prob_error": 3.0,
+                    "min_seq_mult_prob_error": 1.1,
+                    "max_seq_mult_prob_error_after_mask": 1.5,
+                    "mean_seq_mult_prob_error_after_mask": 1.2,
+                    "min_seq_mult_prob_error_after_mask": 1.0,
+                    "num_masked_seqs_by_logprob_error": 1,
+                    "masked_correct_pct": 1.0,
+                    "_num_valid_seqs_before": 4,
+                    "_num_valid_seqs_after": 3,
+                },
+                {
+                    "max_seq_mult_prob_error": 5.0,
+                    "mean_seq_mult_prob_error": 2.0,
+                    "min_seq_mult_prob_error": 1.05,
+                    "max_seq_mult_prob_error_after_mask": 1.8,
+                    "mean_seq_mult_prob_error_after_mask": 1.4,
+                    "min_seq_mult_prob_error_after_mask": 1.02,
+                    "num_masked_seqs_by_logprob_error": 2,
+                    "masked_correct_pct": 0.0,
+                    "_num_valid_seqs_before": 6,
+                    "_num_valid_seqs_after": 4,
+                },
+            ],
+        )
+
+        assert out["max_seq_mult_prob_error"] == pytest.approx(10.0)
+        assert out["mean_seq_mult_prob_error"] == pytest.approx(2.4)
+        assert out["min_seq_mult_prob_error"] == pytest.approx(1.05)
+        assert out["max_seq_mult_prob_error_after_mask"] == pytest.approx(1.8)
+        assert out["mean_seq_mult_prob_error_after_mask"] == pytest.approx(9.2 / 7)
+        assert out["min_seq_mult_prob_error_after_mask"] == pytest.approx(1.0)
+        assert out["num_masked_seqs_by_logprob_error"] == 3
+        assert out["masked_correct_pct"] == pytest.approx(1.0 / 3)
+
 
 class TestFieldsForPut:
     def test_no_sequence_lengths_packs_contiguous(self) -> None:

--- a/tests/unit/single_controller/test_single_controller.py
+++ b/tests/unit/single_controller/test_single_controller.py
@@ -15,11 +15,13 @@
 """Tests for SingleController initialization and pump lifecycle."""
 
 import asyncio
+import math
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import torch
+from tensordict import TensorDict
 
 import nemo_rl.algorithms.single_controller as single_controller
 from nemo_rl.algorithms.async_utils.staleness_sampler import BaseSampler
@@ -285,6 +287,274 @@ def test_sync_weights_calibrates_and_forwards_fp8_kv_scales() -> None:
     )
 
 
+class _AdvantageDataPlane:
+    def __init__(self, data: TensorDict) -> None:
+        self._data = data
+        self.selected_fields: list[str] | None = None
+        self.written_fields: TensorDict | None = None
+
+    def get_samples(self, *, select_fields, **kwargs):
+        del kwargs
+        self.selected_fields = list(select_fields)
+        return self._data
+
+    def put_samples(self, *, fields, **kwargs) -> None:
+        del kwargs
+        self.written_fields = fields
+
+
+class _MaskRecordingAdvantageEstimator:
+    def __init__(self) -> None:
+        self.mask: torch.Tensor | None = None
+
+    def compute_advantage(self, *, rewards, mask, **kwargs) -> torch.Tensor:
+        del kwargs
+        self.mask = mask.clone()
+        return rewards.unsqueeze(-1).expand_as(mask).clone()
+
+
+def test_advantage_stage_applies_seq_logprob_error_mask_before_streaming_train(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    batch_size, sequence_length = 4, 5
+    generation_logprobs = torch.zeros(batch_size, sequence_length)
+    # exp(abs(1 - 0)) > the configured threshold of 2, so only row 2
+    # should be removed from the loss while the other rows remain trainable.
+    generation_logprobs[2, 1:] = 1.0
+    data = TensorDict(
+        {
+            "prompt_ids_for_adv": torch.zeros(
+                batch_size, sequence_length, dtype=torch.long
+            ),
+            "total_reward": torch.tensor([0.0, 0.0, 1.0, 0.0]),
+            "token_mask": torch.ones(batch_size, sequence_length),
+            "sample_mask": torch.ones(batch_size),
+            "prev_logprobs": torch.zeros(batch_size, sequence_length),
+            "generation_logprobs": generation_logprobs,
+        },
+        batch_size=[batch_size],
+    )
+    data_plane = _AdvantageDataPlane(data)
+    estimator = _MaskRecordingAdvantageEstimator()
+
+    controller_cls = SingleControllerActor.__ray_metadata__.modified_class
+    ctrl = object.__new__(controller_cls)
+    ctrl._dp_client = data_plane
+    ctrl._advantage_cfg = AdvantageConfig()
+    ctrl._advantage_estimator = estimator
+    ctrl._policy_logprobs_required = True
+    ctrl._reference_logprobs_required = False
+    ctrl._master_config = SimpleNamespace(
+        grpo=SimpleNamespace(seq_logprob_error_threshold=2.0)
+    )
+    ctrl._step_log_dict = {
+        "rewards": [],
+        "masked_advantages": [],
+        "sequence_lengths": [],
+        "seq_logprob_error_metrics": [],
+    }
+    meta = KVBatchMeta(
+        partition_id="rollout_data",
+        task_name="train",
+        sample_ids=[f"sample-{i}" for i in range(batch_size)],
+        fields=list(data.keys()),
+    )
+
+    result_meta, has_valid_training_tokens = asyncio.run(ctrl._advantage_stage(meta))
+    capsys.readouterr()
+
+    assert has_valid_training_tokens
+    assert data_plane.selected_fields is not None
+    assert "prev_logprobs" in data_plane.selected_fields
+    assert "generation_logprobs" in data_plane.selected_fields
+    assert data_plane.written_fields is not None
+    assert torch.equal(
+        data_plane.written_fields["sample_mask"],
+        torch.tensor([1.0, 1.0, 0.0, 1.0]),
+    )
+    assert estimator.mask is not None
+    assert estimator.mask[2].count_nonzero() == 0
+    assert estimator.mask[[0, 1, 3]].all()
+    metrics = ctrl._step_log_dict["seq_logprob_error_metrics"]
+    assert len(metrics) == 1
+    assert metrics[0]["num_masked_seqs_by_logprob_error"] == 1
+    assert metrics[0]["max_seq_mult_prob_error"] == pytest.approx(math.e)
+    assert metrics[0]["max_seq_mult_prob_error_after_mask"] == pytest.approx(1.0)
+    assert "advantages" in (result_meta.fields or [])
+
+
+def test_advantage_stage_reports_seq_logprob_metrics_without_masking() -> None:
+    batch_size, sequence_length = 2, 5
+    generation_logprobs = torch.zeros(batch_size, sequence_length)
+    generation_logprobs[1, 1:] = 1.0
+    data = TensorDict(
+        {
+            "prompt_ids_for_adv": torch.zeros(
+                batch_size, sequence_length, dtype=torch.long
+            ),
+            "total_reward": torch.tensor([0.0, 1.0]),
+            "token_mask": torch.ones(batch_size, sequence_length),
+            "sample_mask": torch.ones(batch_size),
+            "prev_logprobs": torch.zeros(batch_size, sequence_length),
+            "generation_logprobs": generation_logprobs,
+        },
+        batch_size=[batch_size],
+    )
+    data_plane = _AdvantageDataPlane(data)
+    estimator = _MaskRecordingAdvantageEstimator()
+
+    controller_cls = SingleControllerActor.__ray_metadata__.modified_class
+    ctrl = object.__new__(controller_cls)
+    ctrl._dp_client = data_plane
+    ctrl._advantage_cfg = AdvantageConfig()
+    ctrl._advantage_estimator = estimator
+    ctrl._policy_logprobs_required = True
+    ctrl._reference_logprobs_required = False
+    ctrl._master_config = SimpleNamespace(
+        grpo=SimpleNamespace(seq_logprob_error_threshold=None)
+    )
+    ctrl._step_log_dict = {
+        "rewards": [],
+        "masked_advantages": [],
+        "sequence_lengths": [],
+        "seq_logprob_error_metrics": [],
+    }
+    meta = KVBatchMeta(
+        partition_id="rollout_data",
+        task_name="train",
+        sample_ids=[f"sample-{i}" for i in range(batch_size)],
+        fields=list(data.keys()),
+    )
+
+    _, has_valid_training_tokens = asyncio.run(ctrl._advantage_stage(meta))
+
+    assert has_valid_training_tokens
+    assert data_plane.selected_fields is not None
+    assert "prev_logprobs" in data_plane.selected_fields
+    assert "generation_logprobs" in data_plane.selected_fields
+    assert data_plane.written_fields is not None
+    assert "sample_mask" not in data_plane.written_fields
+    assert estimator.mask is not None
+    assert estimator.mask.all()
+    metrics = ctrl._step_log_dict["seq_logprob_error_metrics"]
+    assert len(metrics) == 1
+    assert metrics[0]["num_masked_seqs_by_logprob_error"] == 0
+    assert metrics[0]["max_seq_mult_prob_error"] == pytest.approx(math.e)
+    assert metrics[0]["max_seq_mult_prob_error_after_mask"] == pytest.approx(math.e)
+
+
+def test_advantage_stage_skips_estimator_when_seq_mask_removes_whole_chunk(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    batch_size, sequence_length = 2, 5
+    data = TensorDict(
+        {
+            "prompt_ids_for_adv": torch.zeros(
+                batch_size, sequence_length, dtype=torch.long
+            ),
+            "total_reward": torch.tensor([1.0, 0.0]),
+            "token_mask": torch.ones(batch_size, sequence_length),
+            "sample_mask": torch.ones(batch_size),
+            "prev_logprobs": torch.zeros(batch_size, sequence_length),
+            "generation_logprobs": torch.ones(batch_size, sequence_length),
+        },
+        batch_size=[batch_size],
+    )
+    data_plane = _AdvantageDataPlane(data)
+    estimator = MagicMock()
+
+    controller_cls = SingleControllerActor.__ray_metadata__.modified_class
+    ctrl = object.__new__(controller_cls)
+    ctrl._dp_client = data_plane
+    ctrl._advantage_cfg = AdvantageConfig()
+    ctrl._advantage_estimator = estimator
+    ctrl._policy_logprobs_required = True
+    ctrl._reference_logprobs_required = False
+    ctrl._master_config = SimpleNamespace(
+        grpo=SimpleNamespace(seq_logprob_error_threshold=2.0)
+    )
+    ctrl._step_log_dict = {
+        "rewards": [],
+        "masked_advantages": [],
+        "sequence_lengths": [],
+        "seq_logprob_error_metrics": [],
+    }
+    meta = KVBatchMeta(
+        partition_id="rollout_data",
+        task_name="train",
+        sample_ids=[f"sample-{i}" for i in range(batch_size)],
+        fields=list(data.keys()),
+    )
+
+    result_meta, has_valid_training_tokens = asyncio.run(ctrl._advantage_stage(meta))
+    capsys.readouterr()
+
+    assert not has_valid_training_tokens
+    estimator.compute_advantage.assert_not_called()
+    assert data_plane.written_fields is not None
+    assert not data_plane.written_fields["sample_mask"].bool().any()
+    assert torch.equal(
+        data_plane.written_fields["advantages"],
+        torch.zeros(batch_size, sequence_length),
+    )
+    assert "advantages" in (result_meta.fields or [])
+
+
+def test_advantage_stage_skips_preexisting_empty_mask_without_seq_threshold() -> None:
+    batch_size, sequence_length = 2, 5
+    data = TensorDict(
+        {
+            "prompt_ids_for_adv": torch.zeros(
+                batch_size, sequence_length, dtype=torch.long
+            ),
+            "total_reward": torch.tensor([1.0, 0.0]),
+            "token_mask": torch.ones(batch_size, sequence_length),
+            "sample_mask": torch.zeros(batch_size),
+        },
+        batch_size=[batch_size],
+    )
+    data_plane = _AdvantageDataPlane(data)
+    estimator = MagicMock()
+
+    controller_cls = SingleControllerActor.__ray_metadata__.modified_class
+    ctrl = object.__new__(controller_cls)
+    ctrl._dp_client = data_plane
+    ctrl._advantage_cfg = AdvantageConfig()
+    ctrl._advantage_estimator = estimator
+    ctrl._policy_logprobs_required = False
+    ctrl._reference_logprobs_required = False
+    ctrl._master_config = SimpleNamespace(
+        grpo=SimpleNamespace(seq_logprob_error_threshold=None)
+    )
+    ctrl._step_log_dict = {
+        "rewards": [],
+        "masked_advantages": [],
+        "sequence_lengths": [],
+        "seq_logprob_error_metrics": [],
+    }
+    meta = KVBatchMeta(
+        partition_id="rollout_data",
+        task_name="train",
+        sample_ids=[f"sample-{i}" for i in range(batch_size)],
+        fields=list(data.keys()),
+    )
+
+    result_meta, has_valid_training_tokens = asyncio.run(ctrl._advantage_stage(meta))
+
+    assert not has_valid_training_tokens
+    estimator.compute_advantage.assert_not_called()
+    assert data_plane.selected_fields is not None
+    assert "prev_logprobs" not in data_plane.selected_fields
+    assert "generation_logprobs" not in data_plane.selected_fields
+    assert data_plane.written_fields is not None
+    assert "sample_mask" not in data_plane.written_fields
+    assert torch.equal(
+        data_plane.written_fields["advantages"],
+        torch.zeros(batch_size, sequence_length),
+    )
+    assert "advantages" in (result_meta.fields or [])
+
+
 class _EmptySampler:
     async def evict(self, *, current_train_weight: int) -> int:
         del current_train_weight
@@ -336,6 +606,17 @@ class _ChunkedSampler(_EmptySampler):
             return None, 0
         self._remaining -= 1
         return self._meta, 1
+
+
+class _SequenceSampler(_EmptySampler):
+    def __init__(self, metas: list[KVBatchMeta]) -> None:
+        self._metas = list(metas)
+
+    async def select(self, **kwargs):
+        del kwargs
+        if not self._metas:
+            return None, 0
+        return self._metas.pop(0), 1
 
 
 class _EmptyBuffer:
@@ -577,6 +858,75 @@ def test_train_pump_prunes_stamps_older_than_the_step_that_just_closed(
     asyncio.run(asyncio.wait_for(ctrl._train_pump(), timeout=1.0))
 
     assert ctrl._batch_shortfall == {5: 1}
+
+
+def test_train_pump_rejects_step_with_no_valid_training_chunks() -> None:
+    meta = KVBatchMeta(
+        partition_id="rollout_data",
+        task_name="train",
+        sample_ids=["sample-0"],
+        fields=[],
+        sequence_lengths=[1],
+        tags=[{"weight_version": 0}],
+    )
+    ctrl = _train_pump_controller(sampler=_OneThenEmptySampler(meta))
+    ctrl._master_config.grpo.num_prompts_per_step = 1
+    ctrl._advantage_stage = AsyncMock(return_value=(meta, False))
+    trainer = MagicMock(spec=_NoOpTrainer)
+    ctrl._trainer = trainer
+
+    with pytest.raises(
+        RuntimeError,
+        match="no valid response tokens after filtering",
+    ):
+        asyncio.run(asyncio.wait_for(ctrl._train_pump(), timeout=1.0))
+
+    trainer.prepare_for_training.assert_called_once_with()
+    trainer.begin_train_step.assert_not_called()
+    trainer.train_microbatches_from_meta.assert_not_called()
+    trainer.finish_train_step.assert_not_called()
+
+
+def test_train_pump_skips_empty_chunk_and_trains_later_valid_chunk(
+    monkeypatch,
+) -> None:
+    empty_meta = KVBatchMeta(
+        partition_id="rollout_data",
+        task_name="train",
+        sample_ids=["empty-sample"],
+        fields=[],
+        sequence_lengths=[1],
+        tags=[{"weight_version": 0}],
+    )
+    valid_meta = KVBatchMeta(
+        partition_id="rollout_data",
+        task_name="train",
+        sample_ids=["valid-sample"],
+        fields=[],
+        sequence_lengths=[1],
+        tags=[{"weight_version": 0}],
+    )
+    ctrl = _train_pump_controller(sampler=_SequenceSampler([empty_meta, valid_meta]))
+    ctrl._advantage_stage = AsyncMock(
+        side_effect=[
+            (empty_meta, False),
+            (valid_meta, True),
+        ]
+    )
+    trainer = MagicMock(spec=_NoOpTrainer)
+    trainer.finish_train_step.return_value = {}
+    ctrl._trainer = trainer
+    ctrl._sync_weights = AsyncMock(return_value=0)
+    ctrl._logger = MagicMock()
+    monkeypatch.setattr(single_controller.ray, "cluster_resources", lambda: {})
+
+    asyncio.run(asyncio.wait_for(ctrl._train_pump(), timeout=1.0))
+
+    assert trainer.prepare_for_training.call_count == 2
+    trainer.begin_train_step.assert_called_once_with(None)
+    trainer.train_microbatches_from_meta.assert_called_once_with(valid_meta)
+    trainer.finish_train_step.assert_called_once_with()
+    assert ctrl._train_steps == 1
 
 
 def test_train_pump_logs_nonzero_stale_group_metrics(monkeypatch) -> None:


### PR DESCRIPTION
# What does this PR do?

Adds sequence-level generation/training log-probability mismatch filtering to the SingleController GRPO path, matching the protection already available in the legacy GRPO path.

- Fetches generation log-probabilities when `grpo.seq_logprob_error_threshold` is configured.
- Applies the shared sequence-level mismatch calculation before advantage estimation.
- Writes the filtered `sample_mask` back to the data plane so masked sequences do not contribute to training.
- Aggregates mismatch and masking metrics correctly across streaming chunks.
- Skips advantage normalization and F/B for a streaming chunk with no valid loss tokens, while allowing later valid chunks in the same logical step to train.
- Fails before optimizer/scheduler advancement if an entire logical step contains no valid loss tokens.

When `grpo.seq_logprob_error_threshold` is `null`, SC does not fetch generation log-probabilities or apply the sequence mismatch mask. The empty-loss-token guard applies regardless of the threshold: a pre-existing all-zero chunk is consumed without F/B, and an entirely empty logical step fails before optimizer/scheduler advancement.

# Issues

SingleController previously accepted `seq_logprob_error_threshold` in the shared GRPO configuration but did not apply the mask before streaming training. Large generation/training log-probability disagreements could therefore affect V2 training even when the protection was configured.

# Usage

```yaml
grpo:
  seq_logprob_error_threshold: 2.0
```

Sequences whose mean multiplicative probability error exceeds the threshold are removed from the loss, and the following metrics are emitted at the logical-step level:

- `max/mean/min_seq_mult_prob_error`
- `max/mean/min_seq_mult_prob_error_after_mask`
- `num_masked_seqs_by_logprob_error`
- `masked_correct_pct`

# Validation

- 32 focused SingleController and metric-reduction unit tests passed at the current PR head.
- Added regression coverage for partial masking, an entirely masked streaming chunk, a pre-existing all-zero mask with the threshold disabled, an entirely invalid logical step, and an empty chunk followed by a valid chunk.
- Ruff check and format passed.
- Pyrefly, recipe minimization, and all applicable pre-commit hooks passed.
- A 100-step Nano 3.5 SingleController in-order/lookahead-1 run completed and wrote checkpoint 100 with this masking path enabled.

## Matched Nano 3.5 comparison

The table compares independent runs of the same V2 recipe, node geometry, GBS 2048, in-order/lookahead-1 sampler, and steps 26–100. The baseline used the pre-fix SC path, where the configured threshold was accepted but not applied; the masked run used threshold `2.0`. Acceptance was no greater than a 5% regression in mean reward, entropy, step time, or valid-token throughput, together with removal of pathological policy-KL outliers.

| Metric (steps 26–100) | Pre-fix SC | Masked SC | Change |
|---|---:|---:|---:|
| `train/reward` mean | 0.96905 | 0.97078 | +0.18% |
| `train/approx_entropy` mean | 0.68068 | 0.67070 | -1.47% |
| `train/policy_kl_error` median / max | 0.00314 / 35.98457 | 0.00185 / 0.00644 | outlier removed |
| `train/gen_kl_error` mean | 0.001796 | 0.001618 | -9.94% |
| `train/is_oob_ratio` mean | 2.679e-5 | 2.478e-5 | -7.50% |
| `timing/train/total_step_time` mean | 702.77 s | 718.32 s | +2.21% |
| `timing/train/valid_tokens_per_sec_per_gpu` mean | 69.95 | 71.73 | +2.54% |
| sequences masked | not applied | 86 / 153,600 (0.056%) | — |

The matched window shows no reward or throughput regression outside the 5% bound, while the rare policy-KL failure is contained. This PR is marked `CI:L2` because the change affects which sequences contribute to gradients.
