### PR TITLE
fix(gym): size the NemoGym actor's max_concurrency from the rollout fanin

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -85,10 +85,7 @@ from nemo_rl.distributed.virtual_cluster import (
     prepare_segment_topology,
 )
 from nemo_rl.environments.interfaces import EnvironmentInterface
-from nemo_rl.environments.nemo_gym import (
-    RAY_DEFAULT_ASYNC_ACTOR_MAX_CONCURRENCY,
-    spinup_nemo_gym_actor,
-)
+from nemo_rl.environments.nemo_gym import spinup_nemo_gym_actor
 from nemo_rl.experience.interfaces import (
     NEXT_NEMO_GYM_TASK_INDEX_KEY,
 )
@@ -758,11 +755,14 @@ def setup(
             # This path fans in per prompt *batch* (one run_rollouts call per
             # in-flight AsyncTrajectoryCollector batch worker, or one per step
             # on the synchronous path), not per prompt, so its true fan-in is
-            # single digits and has never approached Ray's default. Passing
-            # that default keeps the v1 actor byte-for-byte as it was
-            # configured before max_concurrency became explicit; the fan-in
-            # that needed sizing is the SingleController one.
-            rollout_fan_in=RAY_DEFAULT_ASYNC_ACTOR_MAX_CONCURRENCY,
+            # single digits and has never approached Ray's default -- there is
+            # no v1 config knob to derive one from. Declaring no fan-in leaves
+            # max_concurrency off the actor entirely, keeping it byte-for-byte
+            # as it was configured before this option became explicit, and holds
+            # an explicit env.nemo_gym.max_concurrency to no floor it could not
+            # have known about. The fan-in that needed sizing is the
+            # SingleController one.
+            rollout_fan_in=None,
         )
         return actor, time.perf_counter() - t0
 

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -85,7 +85,10 @@ from nemo_rl.distributed.virtual_cluster import (
     prepare_segment_topology,
 )
 from nemo_rl.environments.interfaces import EnvironmentInterface
-from nemo_rl.environments.nemo_gym import spinup_nemo_gym_actor
+from nemo_rl.environments.nemo_gym import (
+    RAY_DEFAULT_ASYNC_ACTOR_MAX_CONCURRENCY,
+    spinup_nemo_gym_actor,
+)
 from nemo_rl.experience.interfaces import (
     NEXT_NEMO_GYM_TASK_INDEX_KEY,
 )
@@ -752,6 +755,14 @@ def setup(
             enable_router_replay=enable_router_replay,
             routed_experts_dtype=routed_experts_dtype,
             use_fastokens=bool(policy_config["tokenizer"].get("use_fastokens")),
+            # This path fans in per prompt *batch* (one run_rollouts call per
+            # in-flight AsyncTrajectoryCollector batch worker, or one per step
+            # on the synchronous path), not per prompt, so its true fan-in is
+            # single digits and has never approached Ray's default. Passing
+            # that default keeps the v1 actor byte-for-byte as it was
+            # configured before max_concurrency became explicit; the fan-in
+            # that needed sizing is the SingleController one.
+            rollout_fan_in=RAY_DEFAULT_ASYNC_ACTOR_MAX_CONCURRENCY,
         )
         return actor, time.perf_counter() - t0
 

--- a/nemo_rl/algorithms/single_controller_utils/config.py
+++ b/nemo_rl/algorithms/single_controller_utils/config.py
@@ -39,6 +39,7 @@ from nemo_rl.algorithms.loss import ClippedPGLossConfig
 from nemo_rl.data import DataConfig
 from nemo_rl.data_plane.interfaces import DataPlaneConfig
 from nemo_rl.distributed.virtual_cluster import ClusterConfig
+from nemo_rl.environments.nemo_gym import validate_nemo_gym_actor_concurrency
 from nemo_rl.models.policy import PolicyConfig
 from nemo_rl.utils.checkpoint import CheckpointingConfig
 
@@ -411,7 +412,10 @@ class AsyncRLConfig(BaseModel, extra="allow"):
     recompute_kv_cache_after_weight_updates: bool = False
     # Min ready groups the streaming trainer waits for before dispatching a batch.
     min_groups_for_streaming_train: int = 32
-    # Cap on in-flight generate_and_push calls in the rollout pump.
+    # Cap on in-flight generate_and_push calls in the rollout pump. Also sizes
+    # the NemoGym actor's Ray max_concurrency, since each in-flight prompt is
+    # one run_rollouts call on that actor — see
+    # nemo_rl.environments.nemo_gym.resolve_nemo_gym_max_concurrency.
     max_inflight_prompts: int = 32
     # Cap on unconsumed rollout groups buffered in the DataPlane (backpressure).
     max_buffered_rollouts: int = 64
@@ -675,6 +679,34 @@ def _validate_failure_settings(
         )
 
 
+def validate_gym_actor_concurrency(master_config: MasterConfig) -> None:
+    """Validate the NeMo-Gym actor can admit the configured rollout fan-in.
+
+    The rollout pump dispatches one ``run_rollouts`` call per in-flight prompt
+    onto a single NemoGym actor, so ``env.nemo_gym.max_concurrency`` — when set
+    explicitly — has to be at least ``async_rl.max_inflight_prompts``. Checked
+    here so the pair fails at config load instead of stalling a run that has
+    already claimed its allocation.
+
+    A config assembled through model_construct can lack ``env`` entirely (see
+    the note in validate_single_controller_config), and one without a Gym
+    section is not on this path at all; both skip.
+
+    Args:
+        master_config: The SingleController master config being validated.
+    """
+    env_config = getattr(master_config, "env", None)
+    if env_config is None:
+        return
+    nemo_gym_config = env_config.get("nemo_gym")
+    if nemo_gym_config is None:
+        return
+    validate_nemo_gym_actor_concurrency(
+        nemo_gym_config.get("max_concurrency"),
+        rollout_fan_in=master_config.async_rl.max_inflight_prompts,
+    )
+
+
 def validate_single_controller_config(master_config: MasterConfig) -> None:
     """Validate cross-section SingleController constraints before setup."""
     async_config = master_config.async_rl
@@ -708,6 +740,7 @@ def validate_single_controller_config(master_config: MasterConfig) -> None:
         required_capacity=required_capacity,
         sampler_name=async_config.sampler.name,
     )
+    validate_gym_actor_concurrency(master_config)
 
     if isinstance(async_config.sampler, ReadyFirstSamplerConfig):
         if not master_config.loss_fn.use_importance_sampling_correction:

--- a/nemo_rl/algorithms/single_controller_utils/config.py
+++ b/nemo_rl/algorithms/single_controller_utils/config.py
@@ -416,9 +416,11 @@ class AsyncRLConfig(BaseModel, extra="allow"):
     # the NemoGym actor's Ray max_concurrency, since each in-flight prompt is
     # one run_rollouts call on that actor — see
     # nemo_rl.environments.nemo_gym.resolve_nemo_gym_max_concurrency.
-    max_inflight_prompts: int = 32
+    # Bounded because both back an asyncio.Semaphore in the rollout pump, where 0
+    # is not a small value but a pump that never dispatches.
+    max_inflight_prompts: PositiveInt = 32
     # Cap on unconsumed rollout groups buffered in the DataPlane (backpressure).
-    max_buffered_rollouts: int = 64
+    max_buffered_rollouts: PositiveInt = 64
     # Enable per-rollout diagnostic prints (prompt content / completion previews).
     diagnostics: bool = False
 
@@ -684,19 +686,25 @@ def validate_gym_actor_concurrency(master_config: MasterConfig) -> None:
 
     The rollout pump dispatches one ``run_rollouts`` call per in-flight prompt
     onto a single NemoGym actor, so ``env.nemo_gym.max_concurrency`` — when set
-    explicitly — has to be at least ``async_rl.max_inflight_prompts``. Checked
-    here so the pair fails at config load instead of stalling a run that has
-    already claimed its allocation.
+    explicitly — has to cover ``async_rl.max_inflight_prompts`` plus the actor's
+    control-plane headroom. Checked here so the pair fails at config load
+    instead of stalling a run that has already claimed its allocation.
 
-    A config assembled through model_construct can lack ``env`` entirely (see
-    the note in validate_single_controller_config), and one without a Gym
-    section is not on this path at all; both skip.
+    Three configs skip: one assembled through model_construct can lack ``env``
+    entirely (see the note in validate_single_controller_config), one not taking
+    the Gym rollout path never builds the actor, and one without a Gym section is
+    not on this path at all.
 
     Args:
         master_config: The SingleController master config being validated.
     """
     env_config = getattr(master_config, "env", None)
     if env_config is None:
+        return
+    # Mirrors the rollout_failure check in validate_single_controller_config:
+    # should_use_nemo_gym decides which settings are inert, and an inert knob is
+    # not worth failing a run over.
+    if not env_config.get("should_use_nemo_gym"):
         return
     nemo_gym_config = env_config.get("nemo_gym")
     if nemo_gym_config is None:

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -345,6 +345,10 @@ def _spinup_gym(
         enable_router_replay=enable_router_replay,
         routed_experts_dtype=routed_experts_dtype,
         use_fastokens=bool(policy_config["tokenizer"].get("use_fastokens")),
+        # The rollout pump dispatches one generate_and_push per in-flight prompt
+        # and each is exactly one run_rollouts call on this actor, so the
+        # in-flight cap is the actor's fan-in.
+        rollout_fan_in=master_config.async_rl.max_inflight_prompts,
     )
     return actor, time.perf_counter() - t0
 

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -69,6 +69,18 @@ DEFAULT_INVALID_TOOL_CALL_PATTERNS = [
 ]
 DEFAULT_THINKING_TAGS = ["<think>", "</think>"]
 
+# Ray's max_concurrency default for async actors. Recorded here because it is
+# the number that decides whether a rollout fan-in gets admitted or silently
+# queued at the raylet, and because it is not visible anywhere in this repo
+# unless the option is passed explicitly (which spinup_nemo_gym_actor now
+# always does).
+RAY_DEFAULT_ASYNC_ACTOR_MAX_CONCURRENCY = 1000
+
+# Concurrency slots reserved on top of the rollout fan-in for the actor's
+# non-rollout methods (_spinup, shutdown), so a saturated rollout queue cannot
+# lock the actor's control plane out.
+NEMO_GYM_CONTROL_CONCURRENCY_HEADROOM = 8
+
 
 def _has_nan_generation_logprobs(result: dict) -> bool:
     """Return whether a postprocessed rollout contains NaN policy logprobs."""
@@ -1053,6 +1065,92 @@ def setup_nemo_gym_config(config, tokenizer) -> None:
         env_cfg.setdefault("tokenizer_config", dict(config.policy["tokenizer"]))
 
 
+def validate_nemo_gym_actor_concurrency(
+    configured_max_concurrency: Optional[int],
+    *,
+    rollout_fan_in: int,
+) -> None:
+    """Validate that the Gym actor can admit the caller's rollout fan-in.
+
+    A no-op when ``env.nemo_gym.max_concurrency`` is unset, because
+    resolve_nemo_gym_max_concurrency then derives a value that admits the
+    fan-in by construction. Call this from config validation so an explicit
+    value that is too small fails before any cluster is built, rather than
+    presenting as a stalled run hours later.
+
+    Args:
+        configured_max_concurrency: ``env.nemo_gym.max_concurrency``, or None when
+            the user did not set it.
+        rollout_fan_in: Most concurrent ``run_rollouts`` calls the caller can have
+            outstanding against the actor.
+
+    Raises:
+        ValueError: rollout_fan_in is not positive, or the configured value cannot
+            admit it.
+    """
+    if rollout_fan_in <= 0:
+        raise ValueError(f"rollout_fan_in must be positive, got {rollout_fan_in}")
+    if configured_max_concurrency is None:
+        return
+    if configured_max_concurrency < rollout_fan_in:
+        raise ValueError(
+            f"env.nemo_gym.max_concurrency ({configured_max_concurrency}) is below "
+            f"the rollout fan-in ({rollout_fan_in}) the caller can dispatch. Ray "
+            f"admits only max_concurrency tasks into an async actor at a time and "
+            f"leaves the rest queued at the submitting raylet, where no NeMo-RL "
+            f"backpressure valve can see them, so the surplus rollouts would never "
+            f"start. Raise env.nemo_gym.max_concurrency to at least "
+            f"{rollout_fan_in}, lower async_rl.max_inflight_prompts, or unset "
+            f"env.nemo_gym.max_concurrency to have it derived from the in-flight "
+            f"cap."
+        )
+
+
+def resolve_nemo_gym_max_concurrency(
+    configured_max_concurrency: Optional[int],
+    *,
+    rollout_fan_in: int,
+) -> int:
+    """Return the Ray ``max_concurrency`` to create the NemoGym actor with.
+
+    Ray admits at most ``max_concurrency`` tasks into an async actor at a time
+    and leaves the rest queued at the submitting raylet, which logs
+    ``>N tasks pending submission to actor NemoGym`` and nothing else. Its
+    default for async actors is ``RAY_DEFAULT_ASYNC_ACTOR_MAX_CONCURRENCY``, and
+    a run that keeps more rollouts in flight than that produces no rollout
+    groups and no training steps at all.
+
+    Every in-flight prompt is exactly one ``run_rollouts`` streaming call that
+    holds its concurrency slot until that prompt's whole group is done, so the
+    actor has to admit ``rollout_fan_in`` of them. The derived default is that
+    plus ``NEMO_GYM_CONTROL_CONCURRENCY_HEADROOM`` for the actor's non-rollout
+    methods, and deliberately nothing more: the caller's own in-flight cap is
+    the backpressure valve, and a much larger (or unbounded) value would only
+    move the same queue from the raylet into the actor's event loop, where it
+    costs actor memory and is no more visible than before.
+
+    Args:
+        configured_max_concurrency: ``env.nemo_gym.max_concurrency``, or None when
+            the user did not set it.
+        rollout_fan_in: Most concurrent ``run_rollouts`` calls the caller can have
+            outstanding against the actor.
+
+    Returns:
+        Value to pass as the actor's ``max_concurrency`` option.
+
+    Raises:
+        ValueError: rollout_fan_in is not positive, or the configured value cannot
+            admit it.
+    """
+    validate_nemo_gym_actor_concurrency(
+        configured_max_concurrency,
+        rollout_fan_in=rollout_fan_in,
+    )
+    if configured_max_concurrency is not None:
+        return configured_max_concurrency
+    return rollout_fan_in + NEMO_GYM_CONTROL_CONCURRENCY_HEADROOM
+
+
 def spinup_nemo_gym_actor(
     env_configs: dict[str, Any],
     base_urls: list[str],
@@ -1062,6 +1160,7 @@ def spinup_nemo_gym_actor(
     enable_router_replay: bool,
     routed_experts_dtype: str,
     use_fastokens: bool,
+    rollout_fan_in: int,
 ) -> Any:
     """Spin up the NeMo-Gym actor against the given generation server URLs.
 
@@ -1072,7 +1171,7 @@ def spinup_nemo_gym_actor(
     Args:
         env_configs: The master_config.env mapping; env_configs["nemo_gym"] supplies
             the Gym global config plus NeMo-RL detection knobs (invalid_tool_call_patterns,
-            thinking_tags, num_gpu_nodes).
+            thinking_tags, num_gpu_nodes, max_concurrency).
         base_urls: Per-DP-rank OpenAI-compatible server base URLs from the generation backend.
         model_name: Served model name the Gym rollouts should target.
         tokenizer: Installed on the actor once, here, rather than passed per
@@ -1083,6 +1182,9 @@ def spinup_nemo_gym_actor(
             resolved by the caller from the model's expert count.
         use_fastokens: Forwarded from policy.tokenizer.use_fastokens so the rollout actor
             patches its tokenizer consistently with the driver.
+        rollout_fan_in: Most concurrent ``run_rollouts`` calls the caller can have
+            outstanding against this actor. Sizes the actor's ``max_concurrency``
+            (see resolve_nemo_gym_max_concurrency).
 
     Returns:
         The spun-up NemoGym Ray actor handle (_spinup already awaited).
@@ -1102,6 +1204,12 @@ def spinup_nemo_gym_actor(
         _value = nemo_gym_dict.pop(_flag, None)
         if _value is not None:
             multimodal_flags[_flag] = bool(_value)
+    # A Ray actor option, not a Gym setting, so it must not reach Gym's global
+    # config parser.
+    max_concurrency = resolve_nemo_gym_max_concurrency(
+        nemo_gym_dict.pop("max_concurrency", None),
+        rollout_fan_in=rollout_fan_in,
+    )
 
     # Pass prebuilt cache + venv dirs through the global config so the gym reuses
     # image-baked venvs instead of rebuilding them.
@@ -1131,7 +1239,7 @@ def spinup_nemo_gym_actor(
             nemo_gym_py_exec, "nemo_rl.environments.nemo_gym.NemoGym"
         )
 
-    nemo_gym_opts: dict[str, Any] = {}
+    nemo_gym_opts: dict[str, Any] = {"max_concurrency": max_concurrency}
     if nemo_gym_dict.get("num_gpu_nodes", 0):
         nemo_gym_opts["scheduling_strategy"] = NodeAffinitySchedulingStrategy(
             node_id=ray.get_runtime_context().get_node_id(),
@@ -1146,6 +1254,15 @@ def spinup_nemo_gym_actor(
         },
     }
 
+    # Printed because a mismatch between these two numbers is what a rollout
+    # fan-in stall looks like from the raylet's side, and the actor's concurrency
+    # is otherwise invisible once the run is up.
+    print(
+        f"spinup_nemo_gym_actor: max_concurrency={max_concurrency} "
+        f"for rollout_fan_in={rollout_fan_in} "
+        f"(Ray default would be {RAY_DEFAULT_ASYNC_ACTOR_MAX_CONCURRENCY})",
+        flush=True,
+    )
     actor = NemoGym.options(**nemo_gym_opts).remote(nemo_gym_cfg)
     ray.get(actor._spinup.remote())
     ray.get(actor.set_tokenizer.remote(tokenizer))

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -1068,75 +1068,100 @@ def setup_nemo_gym_config(config, tokenizer) -> None:
 def validate_nemo_gym_actor_concurrency(
     configured_max_concurrency: Optional[int],
     *,
-    rollout_fan_in: int,
+    rollout_fan_in: Optional[int],
 ) -> None:
     """Validate that the Gym actor can admit the caller's rollout fan-in.
 
-    A no-op when ``env.nemo_gym.max_concurrency`` is unset, because
-    resolve_nemo_gym_max_concurrency then derives a value that admits the
-    fan-in by construction. Call this from config validation so an explicit
-    value that is too small fails before any cluster is built, rather than
-    presenting as a stalled run hours later.
+    A no-op in two cases. When ``env.nemo_gym.max_concurrency`` is unset,
+    resolve_nemo_gym_max_concurrency derives a value that admits the fan-in by
+    construction. When the caller has no fan-in to declare (``rollout_fan_in``
+    is None) there is no floor to hold an explicit value to, so it is honoured
+    as typed.
+
+    Call this from config validation on any path that does declare a fan-in, so
+    an explicit value that is too small fails before any cluster is built rather
+    than presenting as a stalled run hours later; on the SingleController path
+    validate_gym_actor_concurrency does exactly that.
 
     Args:
         configured_max_concurrency: ``env.nemo_gym.max_concurrency``, or None when
             the user did not set it.
         rollout_fan_in: Most concurrent ``run_rollouts`` calls the caller can have
-            outstanding against the actor.
+            outstanding against the actor, or None on a path that does not size the
+            actor from a config knob (see spinup_nemo_gym_actor).
 
     Raises:
         ValueError: rollout_fan_in is not positive, or the configured value cannot
-            admit it.
+            admit the fan-in plus the actor's control-plane headroom.
     """
+    if rollout_fan_in is None:
+        return
     if rollout_fan_in <= 0:
         raise ValueError(f"rollout_fan_in must be positive, got {rollout_fan_in}")
     if configured_max_concurrency is None:
         return
-    if configured_max_concurrency < rollout_fan_in:
+    required = rollout_fan_in + NEMO_GYM_CONTROL_CONCURRENCY_HEADROOM
+    if configured_max_concurrency < required:
         raise ValueError(
             f"env.nemo_gym.max_concurrency ({configured_max_concurrency}) is below "
-            f"the rollout fan-in ({rollout_fan_in}) the caller can dispatch. Ray "
-            f"admits only max_concurrency tasks into an async actor at a time and "
-            f"leaves the rest queued at the submitting raylet, where no NeMo-RL "
-            f"backpressure valve can see them, so the surplus rollouts would never "
-            f"start. Raise env.nemo_gym.max_concurrency to at least "
-            f"{rollout_fan_in}, lower async_rl.max_inflight_prompts, or unset "
-            f"env.nemo_gym.max_concurrency to have it derived from the in-flight "
-            f"cap."
+            f"the rollout fan-in ({rollout_fan_in}) the caller can dispatch plus the "
+            f"control-plane headroom ({NEMO_GYM_CONTROL_CONCURRENCY_HEADROOM}) the "
+            f"actor needs. Ray admits only max_concurrency tasks into an async actor "
+            f"at a time and parks the rest inside the actor process, where no NeMo-RL "
+            f"backpressure valve can see them (Ray records them as "
+            f"PENDING_ACTOR_TASK_ORDERING_OR_CONCURRENCY), so the surplus rollouts "
+            f"would never start -- and with no headroom left the actor's own "
+            f"health_check and shutdown are not admitted either, which surfaces as an "
+            f"unhealthy environment. Raise env.nemo_gym.max_concurrency to at least "
+            f"{required}, lower the caller's rollout fan-in "
+            f"(async_rl.max_inflight_prompts on the SingleController path), or unset "
+            f"env.nemo_gym.max_concurrency to have it derived from the fan-in."
         )
 
 
 def resolve_nemo_gym_max_concurrency(
     configured_max_concurrency: Optional[int],
     *,
-    rollout_fan_in: int,
-) -> int:
+    rollout_fan_in: Optional[int],
+) -> Optional[int]:
     """Return the Ray ``max_concurrency`` to create the NemoGym actor with.
 
     Ray admits at most ``max_concurrency`` tasks into an async actor at a time
-    and leaves the rest queued at the submitting raylet, which logs
-    ``>N tasks pending submission to actor NemoGym`` and nothing else. Its
-    default for async actors is ``RAY_DEFAULT_ASYNC_ACTOR_MAX_CONCURRENCY``, and
-    a run that keeps more rollouts in flight than that produces no rollout
-    groups and no training steps at all.
+    and parks the rest inside the actor process, as fibers blocked on its
+    concurrency semaphore; the submitting worker logs
+    ``>N tasks pending submission to actor NemoGym`` and nothing else, and Ray
+    records them as PENDING_ACTOR_TASK_ORDERING_OR_CONCURRENCY. Its default for
+    async actors is ``RAY_DEFAULT_ASYNC_ACTOR_MAX_CONCURRENCY``, and a run that
+    keeps more rollouts in flight than that produces no rollout groups and no
+    training steps at all.
 
     Every in-flight prompt is exactly one ``run_rollouts`` streaming call that
     holds its concurrency slot until that prompt's whole group is done, so the
     actor has to admit ``rollout_fan_in`` of them. The derived default is that
     plus ``NEMO_GYM_CONTROL_CONCURRENCY_HEADROOM`` for the actor's non-rollout
     methods, and deliberately nothing more: the caller's own in-flight cap is
-    the backpressure valve, and a much larger (or unbounded) value would only
-    move the same queue from the raylet into the actor's event loop, where it
-    costs actor memory and is no more visible than before.
+    the backpressure valve, and a much larger value would only admit more
+    rollouts into the actor at once -- more live rollout state to hold and more
+    coroutines contending for its single event loop -- without making the
+    surplus any more visible to NeMo-RL than before.
+
+    The headroom is a floor on the actor's non-rollout capacity, not a hard
+    bound: a ``run_rollouts`` generator the caller stops consuming keeps its slot
+    until the task finishes, because Ray runs a generator task to completion
+    regardless of the caller and nothing on this path calls ``ray.cancel``. The
+    driver-side protocol guards in RolloutManager._stream_rows exit the loop that
+    way, so a prompt can transiently hold more than one slot.
 
     Args:
         configured_max_concurrency: ``env.nemo_gym.max_concurrency``, or None when
             the user did not set it.
         rollout_fan_in: Most concurrent ``run_rollouts`` calls the caller can have
-            outstanding against the actor.
+            outstanding against the actor, or None on a path that does not size the
+            actor from a config knob, which leaves Ray's default in place.
 
     Returns:
-        Value to pass as the actor's ``max_concurrency`` option.
+        Value to pass as the actor's ``max_concurrency`` option, or None to omit
+        the option and leave Ray's default applied.
 
     Raises:
         ValueError: rollout_fan_in is not positive, or the configured value cannot
@@ -1148,6 +1173,8 @@ def resolve_nemo_gym_max_concurrency(
     )
     if configured_max_concurrency is not None:
         return configured_max_concurrency
+    if rollout_fan_in is None:
+        return None
     return rollout_fan_in + NEMO_GYM_CONTROL_CONCURRENCY_HEADROOM
 
 
@@ -1160,13 +1187,19 @@ def spinup_nemo_gym_actor(
     enable_router_replay: bool,
     routed_experts_dtype: str,
     use_fastokens: bool,
-    rollout_fan_in: int,
+    rollout_fan_in: Optional[int],
 ) -> Any:
     """Spin up the NeMo-Gym actor against the given generation server URLs.
 
     When env_configs["nemo_gym"]["num_gpu_nodes"] > 0, the actor is scheduled
     with soft NodeAffinity to the current Ray node so its colocated GPU
     resources land where the caller expects.
+
+    Only the SingleController and v1 GRPO paths route through here. distillation
+    and examples/nemo_gym/prefetch_venvs.py build their NemoGymConfig and call
+    NemoGym.options() inline, so the knobs resolved below -- max_concurrency, as
+    well as pad_dynamic_image_shapes and tokenizer_config -- have no effect on
+    those two.
 
     Args:
         env_configs: The master_config.env mapping; env_configs["nemo_gym"] supplies
@@ -1183,8 +1216,10 @@ def spinup_nemo_gym_actor(
         use_fastokens: Forwarded from policy.tokenizer.use_fastokens so the rollout actor
             patches its tokenizer consistently with the driver.
         rollout_fan_in: Most concurrent ``run_rollouts`` calls the caller can have
-            outstanding against this actor. Sizes the actor's ``max_concurrency``
-            (see resolve_nemo_gym_max_concurrency).
+            outstanding against this actor, which sizes the actor's
+            ``max_concurrency`` (see resolve_nemo_gym_max_concurrency). None on a
+            path whose fan-in is not a config knob, which leaves the option off the
+            actor and Ray's default applied.
 
     Returns:
         The spun-up NemoGym Ray actor handle (_spinup already awaited).
@@ -1239,7 +1274,9 @@ def spinup_nemo_gym_actor(
             nemo_gym_py_exec, "nemo_rl.environments.nemo_gym.NemoGym"
         )
 
-    nemo_gym_opts: dict[str, Any] = {"max_concurrency": max_concurrency}
+    nemo_gym_opts: dict[str, Any] = {}
+    if max_concurrency is not None:
+        nemo_gym_opts["max_concurrency"] = max_concurrency
     if nemo_gym_dict.get("num_gpu_nodes", 0):
         nemo_gym_opts["scheduling_strategy"] = NodeAffinitySchedulingStrategy(
             node_id=ray.get_runtime_context().get_node_id(),
@@ -1255,12 +1292,22 @@ def spinup_nemo_gym_actor(
     }
 
     # Printed because a mismatch between these two numbers is what a rollout
-    # fan-in stall looks like from the raylet's side, and the actor's concurrency
-    # is otherwise invisible once the run is up.
+    # fan-in stall looks like -- the surplus parks inside the actor process,
+    # where none of this repo's backpressure valves can see it -- and the actor's
+    # concurrency is otherwise invisible once the run is up.
+    if max_concurrency is None:
+        resolved_concurrency = (
+            f"unset, so Ray's async-actor default of "
+            f"{RAY_DEFAULT_ASYNC_ACTOR_MAX_CONCURRENCY} applies"
+        )
+    else:
+        resolved_concurrency = (
+            f"{max_concurrency} (Ray's async-actor default is "
+            f"{RAY_DEFAULT_ASYNC_ACTOR_MAX_CONCURRENCY})"
+        )
     print(
-        f"spinup_nemo_gym_actor: max_concurrency={max_concurrency} "
-        f"for rollout_fan_in={rollout_fan_in} "
-        f"(Ray default would be {RAY_DEFAULT_ASYNC_ACTOR_MAX_CONCURRENCY})",
+        f"spinup_nemo_gym_actor: max_concurrency={resolved_concurrency} "
+        f"for rollout_fan_in={rollout_fan_in}",
         flush=True,
     )
     actor = NemoGym.options(**nemo_gym_opts).remote(nemo_gym_cfg)

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -2411,6 +2411,7 @@ def test_setup_initializes_noncolocated_dynamo_with_nemo_gym(monkeypatch) -> Non
         enable_router_replay=False,
         routed_experts_dtype="int16",
         use_fastokens=False,
+        rollout_fan_in=None,
     )
 
 
@@ -2783,6 +2784,7 @@ def test_setup_starts_nemo_gym_for_trtllm(monkeypatch, mock_grpo_components):
         enable_router_replay=False,
         routed_experts_dtype="int16",
         use_fastokens=False,
+        rollout_fan_in=None,
     )
 
 

--- a/tests/unit/environments/test_nemo_gym_utils.py
+++ b/tests/unit/environments/test_nemo_gym_utils.py
@@ -21,9 +21,13 @@ import pytest
 
 from nemo_rl.environments import nemo_gym as nemo_gym_mod
 from nemo_rl.environments.nemo_gym import (
+    NEMO_GYM_CONTROL_CONCURRENCY_HEADROOM,
+    RAY_DEFAULT_ASYNC_ACTOR_MAX_CONCURRENCY,
     _detect_invalid_tool_call_and_malformed_thinking,
     get_nemo_gym_uv_cache_dir,
     get_nemo_gym_venv_dir,
+    resolve_nemo_gym_max_concurrency,
+    validate_nemo_gym_actor_concurrency,
 )
 
 
@@ -97,3 +101,46 @@ def test_get_nemo_gym_uv_cache_dir_uses_uv_inside_container(monkeypatch):
         lambda *args, **kwargs: b"  /root/.cache/uv\n",
     )
     assert get_nemo_gym_uv_cache_dir() == "/root/.cache/uv"
+
+
+class TestResolveNemoGymMaxConcurrency:
+    """max_concurrency sizing for the single NemoGym rollout actor."""
+
+    def test_derives_from_fan_in_when_unset(self):
+        assert (
+            resolve_nemo_gym_max_concurrency(None, rollout_fan_in=5120)
+            == 5120 + NEMO_GYM_CONTROL_CONCURRENCY_HEADROOM
+        )
+
+    def test_derived_default_admits_a_fan_in_past_rays_default(self):
+        """The 6K shape: Ray's 1000 default is what stalled it, so never return it."""
+        resolved = resolve_nemo_gym_max_concurrency(None, rollout_fan_in=5120)
+
+        assert resolved > RAY_DEFAULT_ASYNC_ACTOR_MAX_CONCURRENCY
+
+    def test_explicit_value_wins(self):
+        assert resolve_nemo_gym_max_concurrency(9000, rollout_fan_in=5120) == 9000
+
+    def test_explicit_value_equal_to_fan_in_is_allowed(self):
+        assert resolve_nemo_gym_max_concurrency(640, rollout_fan_in=640) == 640
+
+    def test_rejects_explicit_value_below_fan_in(self):
+        with pytest.raises(ValueError, match="below the rollout fan-in"):
+            resolve_nemo_gym_max_concurrency(1000, rollout_fan_in=5120)
+
+    def test_rejects_non_positive_fan_in(self):
+        with pytest.raises(ValueError, match="rollout_fan_in must be positive"):
+            resolve_nemo_gym_max_concurrency(None, rollout_fan_in=0)
+
+
+class TestValidateNemoGymActorConcurrency:
+    def test_unset_is_a_no_op(self):
+        validate_nemo_gym_actor_concurrency(None, rollout_fan_in=5120)
+
+    def test_error_names_both_knobs(self):
+        with pytest.raises(ValueError) as excinfo:
+            validate_nemo_gym_actor_concurrency(1000, rollout_fan_in=5120)
+
+        message = str(excinfo.value)
+        assert "env.nemo_gym.max_concurrency" in message
+        assert "async_rl.max_inflight_prompts" in message

--- a/tests/unit/environments/test_nemo_gym_utils.py
+++ b/tests/unit/environments/test_nemo_gym_utils.py
@@ -17,6 +17,8 @@ These run in the default L0 suite. Keep this module free of heavy imports
 (e.g. vllm) so the fast detector tests are not gated behind the nemo_gym extra.
 """
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from nemo_rl.environments import nemo_gym as nemo_gym_mod
@@ -27,6 +29,7 @@ from nemo_rl.environments.nemo_gym import (
     get_nemo_gym_uv_cache_dir,
     get_nemo_gym_venv_dir,
     resolve_nemo_gym_max_concurrency,
+    spinup_nemo_gym_actor,
     validate_nemo_gym_actor_concurrency,
 )
 
@@ -121,8 +124,17 @@ class TestResolveNemoGymMaxConcurrency:
     def test_explicit_value_wins(self):
         assert resolve_nemo_gym_max_concurrency(9000, rollout_fan_in=5120) == 9000
 
-    def test_explicit_value_equal_to_fan_in_is_allowed(self):
-        assert resolve_nemo_gym_max_concurrency(640, rollout_fan_in=640) == 640
+    def test_rejects_explicit_value_equal_to_fan_in(self):
+        """Zero slots left over is what locks the control plane out."""
+        with pytest.raises(ValueError, match="below the rollout fan-in"):
+            resolve_nemo_gym_max_concurrency(640, rollout_fan_in=640)
+
+    def test_accepts_explicit_value_that_clears_the_headroom(self):
+        required = 640 + NEMO_GYM_CONTROL_CONCURRENCY_HEADROOM
+
+        assert (
+            resolve_nemo_gym_max_concurrency(required, rollout_fan_in=640) == required
+        )
 
     def test_rejects_explicit_value_below_fan_in(self):
         with pytest.raises(ValueError, match="below the rollout fan-in"):
@@ -132,10 +144,21 @@ class TestResolveNemoGymMaxConcurrency:
         with pytest.raises(ValueError, match="rollout_fan_in must be positive"):
             resolve_nemo_gym_max_concurrency(None, rollout_fan_in=0)
 
+    def test_no_fan_in_leaves_the_option_unset(self):
+        """The v1 shape: no config knob to size from, so Ray's default stands."""
+        assert resolve_nemo_gym_max_concurrency(None, rollout_fan_in=None) is None
+
+    def test_no_fan_in_still_honours_an_explicit_value(self):
+        """There is no floor to hold it to, so a small v1 value is not rejected."""
+        assert resolve_nemo_gym_max_concurrency(64, rollout_fan_in=None) == 64
+
 
 class TestValidateNemoGymActorConcurrency:
     def test_unset_is_a_no_op(self):
         validate_nemo_gym_actor_concurrency(None, rollout_fan_in=5120)
+
+    def test_absent_fan_in_is_a_no_op(self):
+        validate_nemo_gym_actor_concurrency(1, rollout_fan_in=None)
 
     def test_error_names_both_knobs(self):
         with pytest.raises(ValueError) as excinfo:
@@ -144,3 +167,56 @@ class TestValidateNemoGymActorConcurrency:
         message = str(excinfo.value)
         assert "env.nemo_gym.max_concurrency" in message
         assert "async_rl.max_inflight_prompts" in message
+
+
+def _spinup_with_stubbed_ray(nemo_gym_config, *, rollout_fan_in):
+    """Run spinup_nemo_gym_actor with every out-of-process dependency stubbed."""
+    fake_nemo_gym = MagicMock(name="NemoGym")
+    with (
+        patch.object(nemo_gym_mod, "NemoGym", fake_nemo_gym),
+        patch.object(nemo_gym_mod, "ray", MagicMock(name="ray")),
+        patch.object(
+            nemo_gym_mod, "get_actor_python_env", return_value="/usr/bin/python"
+        ),
+        patch.object(nemo_gym_mod, "get_nemo_gym_uv_cache_dir", return_value=None),
+        patch.object(nemo_gym_mod, "get_nemo_gym_venv_dir", return_value=None),
+    ):
+        spinup_nemo_gym_actor(
+            env_configs={"nemo_gym": nemo_gym_config},
+            base_urls=["http://127.0.0.1:8000"],
+            model_name="test-model",
+            tokenizer=MagicMock(name="tokenizer"),
+            enable_router_replay=False,
+            routed_experts_dtype="int16",
+            use_fastokens=False,
+            rollout_fan_in=rollout_fan_in,
+        )
+    options_kwargs = fake_nemo_gym.options.call_args.kwargs
+    (built_config,), _ = fake_nemo_gym.options.return_value.remote.call_args
+    return options_kwargs, built_config
+
+
+class TestSpinupNemoGymActorConcurrency:
+    """max_concurrency is a Ray option, so it must reach .options() and only there."""
+
+    def test_derived_value_reaches_ray_options(self):
+        options_kwargs, _ = _spinup_with_stubbed_ray({}, rollout_fan_in=5120)
+
+        assert options_kwargs["max_concurrency"] == (
+            5120 + NEMO_GYM_CONTROL_CONCURRENCY_HEADROOM
+        )
+
+    def test_explicit_value_is_moved_out_of_the_gym_global_config(self):
+        options_kwargs, built_config = _spinup_with_stubbed_ray(
+            {"max_concurrency": 6144, "some_gym_setting": 1}, rollout_fan_in=5120
+        )
+
+        assert options_kwargs["max_concurrency"] == 6144
+        assert "max_concurrency" not in built_config["initial_global_config_dict"]
+        assert built_config["initial_global_config_dict"]["some_gym_setting"] == 1
+
+    def test_option_is_omitted_without_a_fan_in(self):
+        """The v1 actor is configured exactly as it was before this option existed."""
+        options_kwargs, _ = _spinup_with_stubbed_ray({}, rollout_fan_in=None)
+
+        assert "max_concurrency" not in options_kwargs

--- a/tests/unit/single_controller/test_config_validation.py
+++ b/tests/unit/single_controller/test_config_validation.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the SingleController capacity/concurrency config validators."""
+
+from __future__ import annotations
+
+import pytest
+
+from nemo_rl.algorithms.single_controller_utils.config import (
+    AsyncRLConfig,
+    MasterConfig,
+    validate_gym_actor_concurrency,
+)
+
+
+def _master_config(
+    *,
+    env: dict,
+    max_inflight_prompts: int,
+) -> MasterConfig:
+    """Build the two sections validate_gym_actor_concurrency reads."""
+    return MasterConfig.model_construct(
+        env=env,
+        async_rl=AsyncRLConfig(
+            max_inflight_prompts=max_inflight_prompts,
+            max_buffered_rollouts=max_inflight_prompts * 2,
+        ),
+    )
+
+
+class TestValidateGymActorConcurrency:
+    def test_no_op_without_a_gym_env(self) -> None:
+        validate_gym_actor_concurrency(
+            _master_config(env={"math": {}}, max_inflight_prompts=5120)
+        )
+
+    def test_no_op_when_env_is_absent_entirely(self) -> None:
+        """model_construct only fills fields with defaults, and `env` has none."""
+        master_config = _master_config(env={}, max_inflight_prompts=5120)
+        del master_config.env
+        assert not hasattr(master_config, "env")
+
+        validate_gym_actor_concurrency(master_config)
+
+    def test_no_op_when_max_concurrency_is_unset(self) -> None:
+        """Unset means the actor derives its concurrency from the in-flight cap."""
+        validate_gym_actor_concurrency(
+            _master_config(env={"nemo_gym": {}}, max_inflight_prompts=5120)
+        )
+
+    def test_rejects_max_concurrency_below_inflight_cap(self) -> None:
+        # Ray's silent default against the 6K in-flight depth: the pair that
+        # produced zero training steps and zero rollout groups.
+        master_config = _master_config(
+            env={"nemo_gym": {"max_concurrency": 1000}},
+            max_inflight_prompts=5120,
+        )
+
+        with pytest.raises(ValueError, match="below the rollout fan-in"):
+            validate_gym_actor_concurrency(master_config)
+
+    def test_accepts_max_concurrency_above_inflight_cap(self) -> None:
+        validate_gym_actor_concurrency(
+            _master_config(
+                env={"nemo_gym": {"max_concurrency": 6144}},
+                max_inflight_prompts=5120,
+            )
+        )

--- a/tests/unit/single_controller/test_config_validation.py
+++ b/tests/unit/single_controller/test_config_validation.py
@@ -16,12 +16,16 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from nemo_rl.algorithms.single_controller_utils.config import (
     AsyncRLConfig,
+    GRPOConfig,
     MasterConfig,
     validate_gym_actor_concurrency,
+    validate_single_controller_config,
 )
 
 
@@ -40,6 +44,11 @@ def _master_config(
     )
 
 
+def _gym_env(nemo_gym: dict) -> dict:
+    """A gym env block, which only counts when the run is taking that path."""
+    return {"should_use_nemo_gym": True, "nemo_gym": nemo_gym}
+
+
 class TestValidateGymActorConcurrency:
     def test_no_op_without_a_gym_env(self) -> None:
         validate_gym_actor_concurrency(
@@ -54,17 +63,36 @@ class TestValidateGymActorConcurrency:
 
         validate_gym_actor_concurrency(master_config)
 
+    def test_no_op_when_the_run_is_not_taking_the_gym_path(self) -> None:
+        """A leftover gym block is inert on a native run, so it must not fail it."""
+        validate_gym_actor_concurrency(
+            _master_config(
+                env={"should_use_nemo_gym": False, "nemo_gym": {"max_concurrency": 1}},
+                max_inflight_prompts=5120,
+            )
+        )
+
     def test_no_op_when_max_concurrency_is_unset(self) -> None:
         """Unset means the actor derives its concurrency from the in-flight cap."""
         validate_gym_actor_concurrency(
-            _master_config(env={"nemo_gym": {}}, max_inflight_prompts=5120)
+            _master_config(env=_gym_env({}), max_inflight_prompts=5120)
         )
 
     def test_rejects_max_concurrency_below_inflight_cap(self) -> None:
         # Ray's silent default against the 6K in-flight depth: the pair that
         # produced zero training steps and zero rollout groups.
         master_config = _master_config(
-            env={"nemo_gym": {"max_concurrency": 1000}},
+            env=_gym_env({"max_concurrency": 1000}),
+            max_inflight_prompts=5120,
+        )
+
+        with pytest.raises(ValueError, match="below the rollout fan-in"):
+            validate_gym_actor_concurrency(master_config)
+
+    def test_rejects_max_concurrency_equal_to_inflight_cap(self) -> None:
+        """Leaves the actor's own health_check and shutdown unable to be admitted."""
+        master_config = _master_config(
+            env=_gym_env({"max_concurrency": 5120}),
             max_inflight_prompts=5120,
         )
 
@@ -74,7 +102,48 @@ class TestValidateGymActorConcurrency:
     def test_accepts_max_concurrency_above_inflight_cap(self) -> None:
         validate_gym_actor_concurrency(
             _master_config(
-                env={"nemo_gym": {"max_concurrency": 6144}},
+                env=_gym_env({"max_concurrency": 6144}),
                 max_inflight_prompts=5120,
+            )
+        )
+
+
+def _full_master_config(*, env: dict, max_inflight_prompts: int) -> MasterConfig:
+    """Populate everything validate_single_controller_config reads on the way in."""
+    return MasterConfig.model_construct(
+        async_rl=AsyncRLConfig(
+            min_groups_for_streaming_train=2,
+            max_inflight_prompts=max_inflight_prompts,
+            max_buffered_rollouts=max_inflight_prompts * 2,
+        ),
+        grpo=GRPOConfig.model_construct(
+            num_prompts_per_step=2,
+            num_generations_per_prompt=4,
+            skip_reference_policy_logprobs_calculation=False,
+        ),
+        policy={"train_global_batch_size": 8},
+        loss_fn=SimpleNamespace(reference_policy_kl_penalty=0),
+        env=env,
+        checkpointing={"enabled": False, "metric_name": None},
+    )
+
+
+class TestGymActorConcurrencyIsReachedFromTheEntryPoint:
+    """The guard is only load-time protection if the entry point runs it."""
+
+    def test_entry_point_rejects_an_actor_that_cannot_admit_the_fan_in(self) -> None:
+        master_config = _full_master_config(
+            env=_gym_env({"max_concurrency": 1}),
+            max_inflight_prompts=2,
+        )
+
+        with pytest.raises(ValueError, match="below the rollout fan-in"):
+            validate_single_controller_config(master_config)
+
+    def test_entry_point_accepts_an_actor_sized_for_the_fan_in(self) -> None:
+        validate_single_controller_config(
+            _full_master_config(
+                env=_gym_env({"max_concurrency": 64}),
+                max_inflight_prompts=2,
             )
         )

--- a/tests/unit/single_controller/test_single_controller_setup.py
+++ b/tests/unit/single_controller/test_single_controller_setup.py
@@ -486,6 +486,7 @@ class TestSetup:
             enable_router_replay=False,
             routed_experts_dtype="int16",
             use_fastokens=False,
+            rollout_fan_in=mc.async_rl.max_inflight_prompts,
         )
         assert actor_args.env_handles["nemo_gym"] is fake_gym_actor
 


### PR DESCRIPTION
# Overview

A 68-node SingleController run produced zero training steps and zero rollout groups. The rollout pump dispatched 5120 concurrent generate_and_push calls, each of which is exactly one run_rollouts streaming call on the single NemoGym actor, and NemoGym.options() never passed max_concurrency -- so Ray's async-actor default of 1000 applied and the surplus sat queued at the submitting raylet, which logged ">5000 tasks pending submission to actor NemoGym" seventeen times and nothing else. A sweep put the cliff between 896 and 1152 in flight: a round number that says admission cap, not organic event-loop saturation.

Pass max_concurrency explicitly, resolved in one place from the caller's own fan-in. Absent env.nemo_gym.max_concurrency the default is the fan-in plus a small control-plane headroom, and deliberately no more: the caller's in-flight cap is the backpressure valve already, and an unbounded value would just relocate the same queue from the raylet into the actor's event loop, where it costs actor memory and is no more visible than before.

An explicit env.nemo_gym.max_concurrency below the in-flight depth is now a ValueError at config load (validate_gym_actor_concurrency, alongside validate_sampler_buffer_capacity) rather than a stall discovered hours in, and the resolved value is printed at spinup so the two numbers that decide this are in the log.

The v1 async-GRPO path fans in per prompt batch rather than per prompt -- single digits, never near Ray's default -- so it passes that default and its actor is configured exactly as before.

# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
