### PR TITLE
feat/sc: Telemetry to report gym postprocess share

### DIFF
--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -768,6 +768,7 @@ class SingleControllerActor:
                 timing_metrics, step=self._train_steps, prefix="timing/train"
             )
             await self._report_generation_saturation()
+            self._log_rollout_postprocess_share()
             self._timer.reset()
 
             # min sample version refers to the version each consumed sample was
@@ -951,15 +952,34 @@ class SingleControllerActor:
 
         await asyncio.to_thread(self._gen.clear_logger_metrics)
 
-    async def _telemetry_report_pump(self) -> None:
-        """Print engine saturation on a fixed cadence, independent of step boundaries.
+    def _log_rollout_postprocess_share(self) -> None:
+        """Log how NeMo-Gym rollout time splits between awaiting and postprocessing.
 
-        The step-close reporter above only runs when a step closes, so a run that stalls
+        ``NemoGym.run_rollouts`` decodes and tensorizes each result inline, on the
+        same event loop it awaits the next one from, so this share is what says
+        whether that inline work is worth moving off the actor -- and it is the
+        number to check before raising the fan-in onto a single actor.
+
+        The totals are cumulative over the run (see NemoGymRolloutTiming), so
+        reading a window means differencing the series rather than trusting one
+        point. Empty on the native rollout path, which has no Gym postprocess.
+        """
+        summary = self._rollout_manager.rollout_timing.summarize()
+        if not summary:
+            return
+        self._logger.log_metrics(
+            summary, step=self._train_steps, prefix="rollout/nemo_gym"
+        )
+
+    async def _telemetry_report_pump(self) -> None:
+        """Print telemetry on a fixed cadence, independent of step boundaries.
+
+        The step-close reporters above only run when a step closes, so a run that stalls
         before completing one emits nothing at all -- precisely the run where the numbers
         decide what to do next. This closes that gap on stdout only: with no step to log
-        against there is no meaningful step index, and writing the same ``generation/``
-        keys from two places at one step index would just have the last writer win.
-        Nothing is cleared here either, so the step-close reporting is unaffected.
+        against there is no meaningful step index, and writing the same keys from two
+        places at one step index would just have the last writer win. Nothing is cleared
+        here either, so the step-close reporting is unaffected.
 
         Never exits, including on error. It is one of the tasks ``run`` waits on, so
         returning would be read as a pump finishing and would stop the training loop over
@@ -968,6 +988,21 @@ class SingleControllerActor:
         collect: Optional[asyncio.Task[dict[str, dict[int, list[Any]]]]] = None
         while True:
             await asyncio.sleep(_TELEMETRY_REPORT_SECONDS)
+
+            # Reported first, and before anything can `continue`: these totals are
+            # local state, so unlike engine saturation they survive a generation
+            # fleet that is unreachable or is collecting no metrics at all.
+            rollout_summary = self._rollout_manager.rollout_timing.summarize()
+            if rollout_summary:
+                print(
+                    f"gym rollout phases (train_step={self._train_steps}): "
+                    f"await_results={rollout_summary['await_results']:.2f}s "
+                    f"postprocess_results={rollout_summary['postprocess_results']:.2f}s "
+                    f"postprocess_results_pct="
+                    f"{rollout_summary['postprocess_results_pct']:.2f} "
+                    f"groups={int(rollout_summary['groups'])}",
+                    flush=True,
+                )
 
             if collect is None:
                 collect = asyncio.create_task(

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -60,6 +60,7 @@ from nemo_rl.algorithms.single_controller_utils.utils import (
     squeeze_trailing_unit_dim,
     tensor_field,
 )
+from nemo_rl.algorithms.utils import log_generation_metrics_to_wandb
 from nemo_rl.data.interfaces import DatumSpec
 from nemo_rl.data_plane import KVBatchMeta
 from nemo_rl.data_plane.schema import DP_CALIB_INPUT_FIELDS
@@ -74,6 +75,53 @@ from nemo_rl.utils.logger import Logger
 from nemo_rl.utils.timer import TimeoutChecker, Timer
 
 Generation = Union[VllmGeneration, SGLangGeneration]
+
+# Cadence for the step-independent telemetry pump. Matched to the watchdog's default
+# tick so the two report at a comparable rate.
+_TELEMETRY_REPORT_SECONDS = 30.0
+
+
+def _summarize_generation_saturation(
+    gen_metrics: dict[str, dict[int, list[Any]]],
+) -> dict[str, float]:
+    """Pool per-worker vLLM engine samples into one saturation summary.
+
+    ``num_pending_samples`` is vLLM's ``num_requests_waiting``, which is what separates
+    an engine fleet that is compute-bound from one that is merely under-subscribed. The
+    two are indistinguishable from the trainer's side -- both surface only as time spent
+    in generation -- but only the second can be improved by admitting more in-flight
+    prompts, so this is the measurement that decides whether a deeper lag setting can
+    buy throughput.
+
+    ``queue_busy_frac`` is reported because the mean alone hides the shape: a queue that
+    is deep for a tenth of the step and empty afterwards averages out to look idle.
+
+    Returns an empty dict when the backend collects none of these, which is the case for
+    every backend except vLLM with ``enable_vllm_metrics_logger`` set.
+    """
+
+    def pooled(name: str) -> list[float]:
+        per_worker: dict[int, list[Any]] = gen_metrics.get(name, {})
+        return [float(v) for samples in per_worker.values() for v in samples]
+
+    running = pooled("inflight_batch_sizes")
+    waiting = pooled("num_pending_samples")
+    kv_usage = pooled("kv_cache_usage_perc")
+
+    saturation: dict[str, float] = {}
+    if running:
+        saturation["requests_running_mean"] = sum(running) / len(running)
+        saturation["requests_running_max"] = max(running)
+    if waiting:
+        saturation["requests_waiting_mean"] = sum(waiting) / len(waiting)
+        saturation["requests_waiting_max"] = max(waiting)
+        saturation["queue_busy_frac"] = sum(1.0 for v in waiting if v > 0) / len(
+            waiting
+        )
+    if kv_usage:
+        saturation["kv_cache_usage_mean"] = sum(kv_usage) / len(kv_usage)
+        saturation["kv_cache_usage_max"] = max(kv_usage)
+    return saturation
 
 
 @ray.remote(num_cpus=1, num_gpus=0)  # pragma: no cover
@@ -232,11 +280,12 @@ class SingleControllerActor:
 
         await self._maybe_restore_replay_buffer()
 
-        # Start the rollout and train pumps, plus the watchdog
+        # Start the rollout and train pumps, plus the watchdog and telemetry
         rollout_task = asyncio.create_task(self._rollout_pump())
         train_task = asyncio.create_task(self._train_pump())
         watchdog_task = asyncio.create_task(self._watchdog_pump())
-        tasks = (rollout_task, train_task, watchdog_task)
+        telemetry_task = asyncio.create_task(self._telemetry_report_pump())
+        tasks = (rollout_task, train_task, watchdog_task, telemetry_task)
         try:
             done, _ = await asyncio.wait(
                 set(tasks), return_when=asyncio.FIRST_COMPLETED
@@ -708,9 +757,9 @@ class SingleControllerActor:
                 percent = (v / total_time * 100) if total_time > 0 else 0.0
                 print(f"  • {k}: {v:.2f}s ({percent:.1f}%)")
 
-            # TODO: per-step train_data jsonl dump, vllm metrics logger,
-            #   histogram log, rollout_metrics, seq_logprob_error_metrics,
-            #   pretty-print "Training Results" block, print_performance_metrics.
+            # TODO: per-step train_data jsonl dump, rollout_metrics,
+            #   seq_logprob_error_metrics, pretty-print "Training Results" block,
+            #   print_performance_metrics.
             print(f"step_metrics={step_metrics}", flush=True)
             self._logger.log_metrics(
                 step_metrics, step=self._train_steps, prefix="train"
@@ -718,6 +767,7 @@ class SingleControllerActor:
             self._logger.log_metrics(
                 timing_metrics, step=self._train_steps, prefix="timing/train"
             )
+            await self._report_generation_saturation()
             self._timer.reset()
 
             # min sample version refers to the version each consumed sample was
@@ -770,9 +820,28 @@ class SingleControllerActor:
 
             metrics = dict(stats.as_metrics())
             metrics["rollout/inflight"] = float(self._inflight_rollouts)
+            metrics["rollout/buffered"] = float(len(self._buffer))
             metrics["rollout/idle_s"] = idle_s
             metrics["rollout/train_steps"] = float(self._train_steps)
             self._logger.log_metrics(metrics, step=self._train_steps)
+
+            # Occupancy against the two capacities that bound it, which is the series
+            # the async knobs are tuned against. Buffer depth was previously readable
+            # only from the train pump's stall warning, so a run that never stalled
+            # reported it nowhere. Printed as well as logged because sizing these
+            # knobs is usually done from a job's stdout, and printed here rather than
+            # from a reporter of its own so the line and the series it summarizes
+            # cannot drift onto different cadences.
+            print(
+                f"occupancy (train_step={self._train_steps}): "
+                f"inflight={self._inflight_rollouts}/"
+                f"{self._async_cfg.max_inflight_prompts} "
+                f"buffered={len(self._buffer)}/"
+                f"{self._async_cfg.max_buffered_rollouts} "
+                f"committed={stats.committed} skipped={stats.skipped} "
+                f"trainer_v={self._trainer_version}",
+                flush=True,
+            )
 
             if watchdog_cfg.gym_subprocess_check:
                 # Bounded by one tick so a wedged environment cannot stop the pump, and
@@ -837,6 +906,99 @@ class SingleControllerActor:
             except Exception as error:
                 problems.append(f"environment {env_name!r} reported unhealthy: {error}")
         return problems
+
+    async def _report_generation_saturation(self) -> None:
+        """Log engine saturation for the step just closed, and clear the samples.
+
+        This is the metrics channel: a closed step gives the samples a step index to be
+        logged against, so the series here is the one to read in W&B or TensorBoard. The
+        stdout line is deliberately one line -- the numbers are in the series.
+
+        No-ops on backends that collect none of this, which is everything except vLLM
+        with ``enable_vllm_metrics_logger`` set.
+        """
+        # Collection does a blocking ray.get, so keep it off the event loop the rollout
+        # pump shares.
+        gen_metrics = await asyncio.to_thread(self._gen.get_logger_metrics)
+        if not gen_metrics:
+            return
+
+        saturation = _summarize_generation_saturation(gen_metrics)
+        if not saturation:
+            return
+
+        summary = " ".join(f"{k}={v:.3f}" for k, v in saturation.items())
+        engines = len(gen_metrics.get("inflight_batch_sizes", {}))
+        print(
+            f"engine saturation (engines={engines}): {summary}",
+            flush=True,
+        )
+        self._logger.log_metrics(
+            saturation, step=self._train_steps, prefix="generation"
+        )
+
+        if self._master_config.logger["wandb_enabled"]:
+            # W&B can block on the network; the rollout pump shares this loop.
+            await asyncio.to_thread(
+                log_generation_metrics_to_wandb,
+                gen_metrics,
+                self._train_steps,
+                self._master_config.policy["generation"]["vllm_cfg"][
+                    "vllm_metrics_logger_interval"
+                ],
+                self._logger,
+            )
+
+        await asyncio.to_thread(self._gen.clear_logger_metrics)
+
+    async def _telemetry_report_pump(self) -> None:
+        """Print engine saturation on a fixed cadence, independent of step boundaries.
+
+        The step-close reporter above only runs when a step closes, so a run that stalls
+        before completing one emits nothing at all -- precisely the run where the numbers
+        decide what to do next. This closes that gap on stdout only: with no step to log
+        against there is no meaningful step index, and writing the same ``generation/``
+        keys from two places at one step index would just have the last writer win.
+        Nothing is cleared here either, so the step-close reporting is unaffected.
+
+        Never exits, including on error. It is one of the tasks ``run`` waits on, so
+        returning would be read as a pump finishing and would stop the training loop over
+        a telemetry failure.
+        """
+        collect: Optional[asyncio.Task[dict[str, dict[int, list[Any]]]]] = None
+        while True:
+            await asyncio.sleep(_TELEMETRY_REPORT_SECONDS)
+
+            if collect is None:
+                collect = asyncio.create_task(
+                    asyncio.to_thread(self._gen.get_logger_metrics)
+                )
+            done, _ = await asyncio.wait({collect}, timeout=_TELEMETRY_REPORT_SECONDS)
+            if not done:
+                # A collection outliving its own cadence is itself the signal that the
+                # fleet is unreachable. Keep the handle and try again next tick rather
+                # than awaiting it -- an unbounded await is how the environment health
+                # probe used to wedge the watchdog -- and rather than issuing a second
+                # one, which would pile a thread up per tick behind the wedged first.
+                continue
+
+            try:
+                gen_metrics = collect.result()
+            except Exception as error:
+                # Telemetry must not end a run; this is whatever Ray raises for an
+                # unreachable worker.
+                print(f"WARNING: engine saturation unavailable -- {error}", flush=True)
+                gen_metrics = {}
+            collect = None
+
+            saturation = _summarize_generation_saturation(gen_metrics)
+            if not saturation:
+                continue
+            summary = " ".join(f"{k}={v:.3f}" for k, v in saturation.items())
+            print(
+                f"engine saturation (train_step={self._train_steps}): {summary}",
+                flush=True,
+            )
 
     async def _abort_stale_inflight(self) -> int:
         """Abort in-flight rollouts that the sampler can no longer select."""

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -47,6 +47,7 @@ from nemo_rl.experience.rollouts import (
     _tensorize_by_key,
     calculate_rewards,
 )
+from nemo_rl.experience.rollout_timing import NemoGymRolloutTiming
 from nemo_rl.models.generation.interfaces import (
     GenerationConfig,
     GenerationDatumSpec,
@@ -1100,6 +1101,7 @@ class RolloutManager:
             else RolloutRetryPolicy.single_attempt()
         )
         self._stats = RolloutStats()
+        self._rollout_timing = NemoGymRolloutTiming()
 
         if not use_nemo_gym:
             rollout_cls = AsyncRolloutImpl
@@ -1141,6 +1143,11 @@ class RolloutManager:
     def stats(self) -> RolloutStats:
         """Counters describing retry/skip activity so far."""
         return self._stats
+
+    @property
+    def rollout_timing(self) -> NemoGymRolloutTiming:
+        """NeMo-Gym rollout phase times pooled over the groups committed so far."""
+        return self._rollout_timing
 
     def set_weight_version(self, version: int) -> None:
         """Set the weight_version used for rollout tags.
@@ -1294,6 +1301,10 @@ class RolloutManager:
                 raise
 
             self._stats.committed += 1
+            # Pooled here rather than returned, because commit keeps only the
+            # tensors: this is the last point at which a group's rollout metrics
+            # exist at all.
+            self._rollout_timing.add(record.rollout_metrics)
             return RolloutOutcome.COMMITTED
 
         # The infrastructure budget ran out. The same failure followed the prompt across

--- a/nemo_rl/experience/rollout_timing.py
+++ b/nemo_rl/experience/rollout_timing.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pool NeMo-Gym rollout phase times across the prompt groups of a run.
+
+``NemoGym.run_rollouts`` already times the two phases of its result loop --
+``await_results``, blocked waiting for the next Gym task, and
+``postprocess_results``, the CPU-bound decode-and-tensorize step it runs inline
+on the Gym actor's event loop -- and the numbers ride
+``PromptGroupRecord.rollout_metrics`` back to the caller. Pooling them here lets
+SingleController report what share of that loop the inline postprocess costs,
+which is what decides whether moving it off the actor's event loop is worth
+doing.
+
+Kept free of heavy imports so the aggregation can be unit tested on its own.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+# Suffixes of the two labels ``NemoGym.run_rollouts`` times. The prefix is the
+# caller's ``timer_prefix``, so match the suffix rather than the whole key.
+_AWAIT_SUFFIX = "/await_results"
+_POSTPROCESS_SUFFIX = "/postprocess_results"
+
+
+def _sum_with_suffix(metrics: Mapping[str, Any], suffix: str) -> Optional[float]:
+    """Total the numeric entries whose key ends with ``suffix``.
+
+    Args:
+        metrics: One prompt group's rollout metrics.
+        suffix: Timer label suffix to match, including its leading separator.
+
+    Returns:
+        Summed seconds, or None when no key matched.
+    """
+    total: Optional[float] = None
+    for key, value in metrics.items():
+        if key.endswith(suffix) and isinstance(value, (int, float)):
+            total = (total or 0.0) + float(value)
+    return total
+
+
+@dataclass
+class NemoGymRolloutTiming:
+    """Running totals of NeMo-Gym rollout phase times over committed groups.
+
+    Totals are cumulative over the run rather than per step, matching
+    RolloutStats, the other counter the manager exposes: nothing then has to
+    agree on who clears them, and a share taken over the whole run is the
+    number this exists to answer. Both updating and summarizing are O(1), so an
+    asyncio caller can report from the event loop it shares with the pumps
+    without stalling them.
+    """
+
+    groups: int = 0
+    await_seconds: float = 0.0
+    postprocess_seconds: float = 0.0
+
+    def add(self, rollout_metrics: Optional[Mapping[str, Any]]) -> None:
+        """Fold one prompt group's rollout metrics into the totals.
+
+        Metrics carrying neither label are ignored: that is what the native
+        async rollout path produces, and it has no Gym postprocess to measure.
+
+        Args:
+            rollout_metrics: A group's ``PromptGroupRecord.rollout_metrics``.
+        """
+        if not rollout_metrics:
+            return
+
+        await_seconds = _sum_with_suffix(rollout_metrics, _AWAIT_SUFFIX)
+        postprocess_seconds = _sum_with_suffix(rollout_metrics, _POSTPROCESS_SUFFIX)
+        if await_seconds is None and postprocess_seconds is None:
+            return
+
+        self.groups += 1
+        self.await_seconds += await_seconds or 0.0
+        self.postprocess_seconds += postprocess_seconds or 0.0
+
+    def summarize(self) -> dict[str, float]:
+        """Reduce the totals to the scalars worth printing and logging.
+
+        The absolute times sum across groups because within a group the
+        generator awaits and postprocesses its results sequentially, so the two
+        phases partition the time spent inside ``run_rollouts``. The share is
+        taken against that sum rather than against wall time, which groups
+        running concurrently would otherwise make meaningless.
+
+        Returns:
+            Scalar statistics, empty until a NeMo-Gym group has landed.
+        """
+        if self.groups == 0:
+            return {}
+
+        loop_seconds = self.await_seconds + self.postprocess_seconds
+        return {
+            "await_results": self.await_seconds,
+            "postprocess_results": self.postprocess_seconds,
+            "postprocess_results_pct": (
+                100.0 * self.postprocess_seconds / loop_seconds
+                if loop_seconds > 0
+                else 0.0
+            ),
+            "groups": float(self.groups),
+        }

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -148,6 +148,7 @@ project-includes = [
   "nemo_rl/experience/metric_utils.py",
   "nemo_rl/experience/payload.py",
   "nemo_rl/experience/rollout_manager.py",
+  "nemo_rl/experience/rollout_timing.py",
   "nemo_rl/experience/rollouts.py",
   "nemo_rl/modelopt/__init__.py",
   "nemo_rl/modelopt/models/__init__.py",

--- a/tests/unit/experience/test_rollout_generation_failures.py
+++ b/tests/unit/experience/test_rollout_generation_failures.py
@@ -54,6 +54,7 @@ from nemo_rl.experience.rollout_manager import (
     _Deadline,
     _gather_cancelling_siblings,
 )
+from nemo_rl.experience.rollout_timing import NemoGymRolloutTiming
 from nemo_rl.utils.timer import Timer
 
 
@@ -176,6 +177,7 @@ def _make_manager(buffer, impl, retry_policy=None) -> RolloutManager:
         else RolloutRetryPolicy.single_attempt()
     )
     manager._stats = RolloutStats()
+    manager._rollout_timing = NemoGymRolloutTiming()
     manager._skipped_prompts = 0
     return manager
 

--- a/tests/unit/experience/test_rollout_manager.py
+++ b/tests/unit/experience/test_rollout_manager.py
@@ -45,6 +45,7 @@ from nemo_rl.experience.rollout_manager import (
     RolloutRetryPolicy,
     RolloutStats,
 )
+from nemo_rl.experience.rollout_timing import NemoGymRolloutTiming
 from nemo_rl.experience.rollouts import (
     run_async_multi_turn_rollout,
     run_async_nemo_gym_rollout,
@@ -114,11 +115,22 @@ class _FakeBuffer:
         return 1
 
 
+class _FakeRecord:
+    """Stand-in for PromptGroupRecord: a name to assert on, plus pooled metrics."""
+
+    def __init__(self, name: str, rollout_metrics: dict | None = None) -> None:
+        self.name = name
+        self.rollout_metrics = rollout_metrics if rollout_metrics is not None else {}
+
+    def __repr__(self) -> str:
+        return f"_FakeRecord({self.name!r})"
+
+
 class _FakeImpl:
     """Stand-in for AsyncRolloutImpl that returns a sentinel record."""
 
-    def __init__(self, record="sentinel-record", on_run=None) -> None:
-        self._record = record
+    def __init__(self, record="sentinel-record", on_run=None, rollout_metrics=None):
+        self._record = _FakeRecord(record, rollout_metrics)
         self._on_run = on_run
 
     async def run_rollout(self, input_sample):
@@ -147,6 +159,7 @@ def _make_manager(
         else RolloutRetryPolicy.single_attempt()
     )
     mgr._stats = RolloutStats()
+    mgr._rollout_timing = NemoGymRolloutTiming()
     mgr._skipped_prompts = 0
     return mgr
 
@@ -240,7 +253,7 @@ class TestGenerateAndPushFlow:
         assert len(buf.commit_calls) == 1
         gid, record, start_v, end_v = buf.commit_calls[0]
         assert gid in buf._slots
-        assert record == "r0"
+        assert record.name == "r0"
         assert start_v == 0
         assert end_v == 0
 
@@ -276,6 +289,38 @@ class TestGenerateAndPushFlow:
         _, _, start_v, end_v = buf.commit_calls[0]
         assert start_v == 7
         assert end_v == 7
+
+    def test_gym_phase_times_are_pooled_at_commit(self):
+        """commit keeps only the tensors, so this is the last look at the metrics."""
+        buf = _FakeBuffer()
+        impl = _FakeImpl(
+            rollout_metrics={
+                "timing/rollout/await_results": 8.0,
+                "timing/rollout/postprocess_results": 2.0,
+            }
+        )
+        mgr = _make_manager(buf, impl)
+
+        _run(mgr.generate_and_push({"prompt": "p"}))
+        _run(mgr.generate_and_push({"prompt": "p"}))
+
+        summary = mgr.rollout_timing.summarize()
+        assert summary["groups"] == 2.0
+        assert summary["postprocess_results_pct"] == 20.0
+
+    def test_a_failed_rollout_contributes_no_phase_times(self):
+        """Only committed groups have phase times worth pooling."""
+
+        async def _fail_rollout(_sample):
+            raise RuntimeError("injected rollout failure")
+
+        buf = _FakeBuffer()
+        mgr = _make_manager(buf, _FakeImpl(on_run=_fail_rollout))
+
+        with pytest.raises(RuntimeError):
+            _run(mgr.generate_and_push({"prompt": "p"}))
+
+        assert mgr.rollout_timing.summarize() == {}
 
     def test_concurrent_dispatch_preserves_reserve_order(self):
         """Two concurrent generate_and_push calls must reserve before either commits.

--- a/tests/unit/experience/test_rollout_redispatch.py
+++ b/tests/unit/experience/test_rollout_redispatch.py
@@ -44,6 +44,7 @@ from nemo_rl.experience.rollout_manager import (
     RolloutRetryPolicy,
     RolloutStats,
 )
+from nemo_rl.experience.rollout_timing import NemoGymRolloutTiming
 
 
 class _Buffer:
@@ -71,6 +72,14 @@ class _Buffer:
         return 1
 
 
+class _Record:
+    """Stand-in for PromptGroupRecord, carrying the metrics the manager pools."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.rollout_metrics: dict[str, float] = {}
+
+
 class _ScriptedImpl:
     """Rollout impl that raises a scripted sequence of failures, then succeeds."""
 
@@ -86,7 +95,7 @@ class _ScriptedImpl:
             failure = self._failures[index]
             if failure is not None:
                 raise failure
-        return f"record-{index}"
+        return _Record(f"record-{index}")
 
 
 def _make_manager(buffer, impl, policy) -> RolloutManager:
@@ -98,6 +107,7 @@ def _make_manager(buffer, impl, policy) -> RolloutManager:
     manager._weight_version = 0
     manager._retry_policy = policy
     manager._stats = RolloutStats()
+    manager._rollout_timing = NemoGymRolloutTiming()
     manager._skipped_prompts = 0
     return manager
 

--- a/tests/unit/experience/test_rollout_timing.py
+++ b/tests/unit/experience/test_rollout_timing.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for pooling NeMo-Gym rollout phase times across prompt groups."""
+
+import pytest
+
+from nemo_rl.experience.rollout_timing import NemoGymRolloutTiming
+
+
+def _gym_metrics(
+    await_seconds: float, postprocess_seconds: float, prefix: str = "timing/rollout"
+) -> dict[str, float]:
+    """Build one group's rollout metrics as run_rollouts would yield them."""
+    return {
+        f"{prefix}/await_results": await_seconds,
+        f"{prefix}/postprocess_results": postprocess_seconds,
+        f"{prefix}/postprocess_results_pct": 100.0
+        * postprocess_seconds
+        / (await_seconds + postprocess_seconds),
+        f"{prefix}/total": await_seconds + postprocess_seconds,
+        "mean_gen_tokens_per_sample": 512.0,
+    }
+
+
+def test_summarize_is_empty_before_any_group_lands() -> None:
+    assert NemoGymRolloutTiming().summarize() == {}
+
+
+def test_absolute_times_sum_and_share_is_taken_against_their_total() -> None:
+    timing = NemoGymRolloutTiming()
+    timing.add(_gym_metrics(await_seconds=90.0, postprocess_seconds=10.0))
+    timing.add(_gym_metrics(await_seconds=70.0, postprocess_seconds=30.0))
+
+    summary = timing.summarize()
+
+    assert summary["await_results"] == pytest.approx(160.0)
+    assert summary["postprocess_results"] == pytest.approx(40.0)
+    assert summary["postprocess_results_pct"] == pytest.approx(20.0)
+    assert summary["groups"] == 2.0
+
+
+def test_share_weights_groups_by_time_not_by_count() -> None:
+    """A long group must dominate a short one, so pooled totals drive the share."""
+    timing = NemoGymRolloutTiming()
+    timing.add(_gym_metrics(await_seconds=1.0, postprocess_seconds=1.0))
+    timing.add(_gym_metrics(await_seconds=980.0, postprocess_seconds=20.0))
+
+    summary = timing.summarize()
+
+    # Averaging the per-group percentages would give 26%; the pooled share is
+    # what reflects where the time actually went.
+    assert summary["postprocess_results_pct"] == pytest.approx(2.1, abs=0.05)
+
+
+def test_label_prefix_is_not_hardcoded() -> None:
+    """run_rollouts takes its timer prefix from the caller, so match suffixes."""
+    timing = NemoGymRolloutTiming()
+    timing.add(_gym_metrics(await_seconds=8.0, postprocess_seconds=2.0, prefix="env"))
+
+    summary = timing.summarize()
+
+    assert summary["groups"] == 1.0
+    assert summary["postprocess_results_pct"] == pytest.approx(20.0)
+
+
+def test_the_percentage_label_is_not_mistaken_for_a_phase_time() -> None:
+    """postprocess_results_pct shares a stem with the label it is derived from."""
+    timing = NemoGymRolloutTiming()
+    timing.add(_gym_metrics(await_seconds=75.0, postprocess_seconds=25.0))
+
+    assert timing.summarize()["postprocess_results"] == pytest.approx(25.0)
+
+
+@pytest.mark.parametrize(
+    "rollout_metrics",
+    [
+        None,
+        {},
+        # The native async rollout path: real metrics, no Gym phase labels.
+        {"timing/rollout/total": 3.0, "mean_gen_tokens_per_sample": 128.0},
+    ],
+)
+def test_metrics_without_gym_phase_labels_are_ignored(rollout_metrics) -> None:
+    timing = NemoGymRolloutTiming()
+    timing.add(rollout_metrics)
+
+    assert timing.summarize() == {}
+
+
+def test_non_numeric_metric_values_do_not_break_the_totals() -> None:
+    """rollout_metrics also carries tables and lists, keyed alongside the timings."""
+    timing = NemoGymRolloutTiming()
+    timing.add(
+        {
+            "timing/rollout/await_results": 4.0,
+            "timing/rollout/postprocess_results": 1.0,
+            "histogram/gen_tokens_length": [1, 2, 3],
+        }
+    )
+
+    assert timing.summarize()["postprocess_results_pct"] == pytest.approx(20.0)
+
+
+def test_share_is_zero_rather_than_undefined_when_both_phases_are_zero() -> None:
+    timing = NemoGymRolloutTiming()
+    timing.add(
+        {
+            "timing/rollout/await_results": 0.0,
+            "timing/rollout/postprocess_results": 0.0,
+        }
+    )
+
+    summary = timing.summarize()
+
+    assert summary["postprocess_results_pct"] == 0.0
+    assert summary["groups"] == 1.0
+
+
+def test_totals_are_cumulative_over_the_run() -> None:
+    """Nothing clears these, so a later read includes every group before it."""
+    timing = NemoGymRolloutTiming()
+    timing.add(_gym_metrics(await_seconds=9.0, postprocess_seconds=1.0))
+    first = timing.summarize()
+
+    timing.add(_gym_metrics(await_seconds=1.0, postprocess_seconds=9.0))
+    second = timing.summarize()
+
+    assert first["groups"] == 1.0
+    assert second["groups"] == 2.0
+    assert second["await_results"] == pytest.approx(10.0)
+    assert second["postprocess_results"] == pytest.approx(10.0)
+    assert second["postprocess_results_pct"] == pytest.approx(50.0)

--- a/tests/unit/single_controller/test_generation_telemetry.py
+++ b/tests/unit/single_controller/test_generation_telemetry.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Engine saturation: telling a busy generation fleet from an under-subscribed one.
+
+Both look the same from the trainer's side -- time spent in generation -- but only the
+second is fixed by admitting more in-flight prompts, so this is the measurement that
+decides whether a deeper lag setting can buy anything. The reporting has to survive the
+case it is most needed in: a run wedged before its first step closes, where the
+step-boundary reporter never runs at all.
+"""
+
+import asyncio
+import threading
+from types import SimpleNamespace
+
+from nemo_rl.algorithms import single_controller as sc
+from nemo_rl.algorithms.single_controller import (
+    SingleControllerActor,
+    _summarize_generation_saturation,
+)
+
+
+class TestSummarizeGenerationSaturation:
+    def test_samples_are_pooled_across_engines(self):
+        summary = _summarize_generation_saturation(
+            {"inflight_batch_sizes": {0: [2, 4], 1: [6, 8]}}
+        )
+
+        assert summary["requests_running_mean"] == 5.0
+        assert summary["requests_running_max"] == 8.0
+
+    def test_queue_busy_frac_counts_ticks_not_depth(self):
+        """The mean hides the shape: a queue deep for one tick averages out to idle."""
+        summary = _summarize_generation_saturation(
+            {"num_pending_samples": {0: [0, 0, 0, 40]}}
+        )
+
+        assert summary["queue_busy_frac"] == 0.25
+        assert summary["requests_waiting_max"] == 40.0
+
+    def test_a_backend_that_collects_nothing_summarizes_to_nothing(self):
+        """Every backend except vLLM with its metrics logger enabled lands here."""
+        assert _summarize_generation_saturation({}) == {}
+        assert _summarize_generation_saturation({"inflight_batch_sizes": {}}) == {}
+
+    def test_a_partially_reporting_backend_still_summarizes(self):
+        summary = _summarize_generation_saturation(
+            {"kv_cache_usage_perc": {0: [0.25, 0.75]}}
+        )
+
+        assert summary == {"kv_cache_usage_mean": 0.5, "kv_cache_usage_max": 0.75}
+
+
+def _make_controller(get_logger_metrics):
+    controller_cls = SingleControllerActor.__ray_metadata__.modified_class
+    ctrl = object.__new__(controller_cls)
+    ctrl._gen = SimpleNamespace(get_logger_metrics=get_logger_metrics)
+    ctrl._train_steps = 0
+    return ctrl
+
+
+async def _run_ticks(ctrl, seconds: float):
+    task = asyncio.ensure_future(ctrl._telemetry_report_pump())
+    await asyncio.sleep(seconds)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    return task
+
+
+class TestTelemetryReportPump:
+    def test_saturation_is_reported_without_a_step_closing(self, capsys, monkeypatch):
+        """train_steps stays at 0 here -- the wedge this exists for."""
+        monkeypatch.setattr(sc, "_TELEMETRY_REPORT_SECONDS", 0.001)
+        ctrl = _make_controller(lambda: {"num_pending_samples": {0: [12, 12]}})
+
+        asyncio.run(_run_ticks(ctrl, 0.05))
+
+        assert "engine saturation" in capsys.readouterr().out
+
+    def test_a_failing_collection_is_reported_and_the_pump_survives(
+        self, capsys, monkeypatch
+    ):
+        """Telemetry is one of the tasks run() waits on, so exiting would end the run."""
+        monkeypatch.setattr(sc, "_TELEMETRY_REPORT_SECONDS", 0.001)
+
+        def _unreachable():
+            raise RuntimeError("worker is gone")
+
+        ctrl = _make_controller(_unreachable)
+
+        task = asyncio.run(_run_ticks(ctrl, 0.05))
+
+        assert task.cancelled(), "the pump must still have been running to cancel"
+        assert "engine saturation unavailable" in capsys.readouterr().out
+
+    def test_a_wedged_collection_does_not_queue_another_behind_it(self, monkeypatch):
+        """The failure mode this reporting exists to observe must not compound it.
+
+        An unbounded await is how the environment health probe used to wedge the
+        watchdog; issuing a fresh collection per tick instead would pile up one blocked
+        thread every cadence for the rest of the run.
+        """
+        monkeypatch.setattr(sc, "_TELEMETRY_REPORT_SECONDS", 0.001)
+        release = threading.Event()
+        calls = []
+
+        def _wedged():
+            calls.append(1)
+            release.wait(timeout=30)
+            return {}
+
+        ctrl = _make_controller(_wedged)
+        try:
+            asyncio.run(_run_ticks(ctrl, 0.05))
+            assert len(calls) == 1, f"issued {len(calls)} collections behind a wedge"
+        finally:
+            # Let the blocked worker thread exit so it does not outlive the test.
+            release.set()

--- a/tests/unit/single_controller/test_generation_telemetry.py
+++ b/tests/unit/single_controller/test_generation_telemetry.py
@@ -30,6 +30,7 @@ from nemo_rl.algorithms.single_controller import (
     SingleControllerActor,
     _summarize_generation_saturation,
 )
+from nemo_rl.experience.rollout_timing import NemoGymRolloutTiming
 
 
 class TestSummarizeGenerationSaturation:
@@ -63,12 +64,26 @@ class TestSummarizeGenerationSaturation:
         assert summary == {"kv_cache_usage_mean": 0.5, "kv_cache_usage_max": 0.75}
 
 
-def _make_controller(get_logger_metrics):
+def _make_controller(get_logger_metrics, rollout_timing=None):
     controller_cls = SingleControllerActor.__ray_metadata__.modified_class
     ctrl = object.__new__(controller_cls)
     ctrl._gen = SimpleNamespace(get_logger_metrics=get_logger_metrics)
+    ctrl._rollout_manager = SimpleNamespace(
+        rollout_timing=rollout_timing or NemoGymRolloutTiming()
+    )
     ctrl._train_steps = 0
     return ctrl
+
+
+def _gym_timing(await_seconds: float, postprocess_seconds: float):
+    timing = NemoGymRolloutTiming()
+    timing.add(
+        {
+            "timing/rollout/await_results": await_seconds,
+            "timing/rollout/postprocess_results": postprocess_seconds,
+        }
+    )
+    return timing
 
 
 async def _run_ticks(ctrl, seconds: float):
@@ -131,3 +146,68 @@ class TestTelemetryReportPump:
         finally:
             # Let the blocked worker thread exit so it does not outlive the test.
             release.set()
+
+    def test_rollout_phases_survive_an_unreachable_generation_fleet(
+        self, capsys, monkeypatch
+    ):
+        """These totals are local state, so they must not ride on the engine fetch."""
+        monkeypatch.setattr(sc, "_TELEMETRY_REPORT_SECONDS", 0.001)
+
+        def _unreachable():
+            raise RuntimeError("worker is gone")
+
+        ctrl = _make_controller(
+            _unreachable,
+            rollout_timing=_gym_timing(await_seconds=75.0, postprocess_seconds=25.0),
+        )
+
+        asyncio.run(_run_ticks(ctrl, 0.05))
+
+        out = capsys.readouterr().out
+        assert "gym rollout phases" in out
+        assert "postprocess_results_pct=25.00" in out
+
+    def test_the_native_rollout_path_reports_no_phases(self, capsys, monkeypatch):
+        """Only NeMo-Gym has an inline postprocess to account for."""
+        monkeypatch.setattr(sc, "_TELEMETRY_REPORT_SECONDS", 0.001)
+        ctrl = _make_controller(lambda: {"num_pending_samples": {0: [12, 12]}})
+
+        asyncio.run(_run_ticks(ctrl, 0.05))
+
+        out = capsys.readouterr().out
+        assert "gym rollout phases" not in out
+        assert "engine saturation" in out
+
+
+class TestLogRolloutPostprocessShare:
+    def _controller(self, rollout_timing):
+        controller_cls = SingleControllerActor.__ray_metadata__.modified_class
+        ctrl = object.__new__(controller_cls)
+        ctrl._rollout_manager = SimpleNamespace(rollout_timing=rollout_timing)
+        ctrl._train_steps = 7
+        ctrl._logger = SimpleNamespace(
+            logged=[],
+            log_metrics=lambda metrics, step, prefix: ctrl._logger.logged.append(
+                (metrics, step, prefix)
+            ),
+        )
+        return ctrl
+
+    def test_the_share_is_logged_as_a_series(self):
+        ctrl = self._controller(
+            _gym_timing(await_seconds=80.0, postprocess_seconds=20.0)
+        )
+
+        ctrl._log_rollout_postprocess_share()
+
+        metrics, step, prefix = ctrl._logger.logged[0]
+        assert metrics["postprocess_results_pct"] == 20.0
+        assert step == 7
+        assert prefix == "rollout/nemo_gym"
+
+    def test_nothing_is_logged_before_a_gym_group_lands(self):
+        ctrl = self._controller(NemoGymRolloutTiming())
+
+        ctrl._log_rollout_postprocess_share()
+
+        assert ctrl._logger.logged == []

--- a/tests/unit/single_controller/test_sc_checkpointing.py
+++ b/tests/unit/single_controller/test_sc_checkpointing.py
@@ -212,6 +212,20 @@ class _ExhaustingSampler(_FakeSampler):
         return await super().select(**kwargs)
 
 
+class _FakeGeneration:
+    """GenerationInterface stand-in for the telemetry hooks the train pump calls.
+
+    Mirrors the interface defaults -- no samples, nothing to clear -- which is what
+    every backend except vLLM with its metrics logger enabled actually does.
+    """
+
+    def get_logger_metrics(self) -> dict[str, Any]:
+        return {}
+
+    def clear_logger_metrics(self) -> None:
+        return None
+
+
 class _FakeDPClient:
     def __init__(self) -> None:
         self.clear_calls: list[tuple[list[str], str]] = []
@@ -378,7 +392,7 @@ def _make_actor_args(
     last_checkpoint_path: Optional[str] = None,
 ) -> SingleControllerActorArgs:
     return SingleControllerActorArgs(
-        gen_handle=object(),
+        gen_handle=_FakeGeneration(),
         trainer_handle=trainer if trainer is not None else _FakeTrainer(),
         env_handles={},
         train_cluster=None,  # type: ignore[arg-type]

--- a/tests/unit/single_controller/test_sc_checkpointing.py
+++ b/tests/unit/single_controller/test_sc_checkpointing.py
@@ -66,6 +66,7 @@ from nemo_rl.algorithms.single_controller_utils import (
 from nemo_rl.algorithms.single_controller_utils.setup import SingleControllerActorArgs
 from nemo_rl.data.utils import load_dataloader_state
 from nemo_rl.data_plane import KVBatchMeta
+from nemo_rl.experience.rollout_timing import NemoGymRolloutTiming
 from nemo_rl.utils.checkpoint import CheckpointManager
 
 # Reuse the factory patches from the setup tests (same cross-module fixture
@@ -250,6 +251,7 @@ class _FakeRolloutManager:
     def __init__(self) -> None:
         self.weight_versions: list[int] = []
         self._tq_buffer = None
+        self.rollout_timing = NemoGymRolloutTiming()
 
     def set_weight_version(self, version: int) -> None:
         self.weight_versions.append(version)

--- a/tests/unit/single_controller/test_single_controller.py
+++ b/tests/unit/single_controller/test_single_controller.py
@@ -368,7 +368,13 @@ def _train_pump_controller(*, sampler) -> object:
     ctrl._rollout_exhausted = asyncio.Event()
     ctrl._rollout_exhausted.set()
     ctrl._trainer = _NoOpTrainer()
-    ctrl._gen = SimpleNamespace(requires_kv_scale_sync=False)
+    ctrl._gen = SimpleNamespace(
+        requires_kv_scale_sync=False,
+        # Interface defaults: no samples collected, so the step-close saturation
+        # report no-ops, which is every backend but vLLM with its metrics logger on.
+        get_logger_metrics=lambda: {},
+        clear_logger_metrics=lambda: None,
+    )
     ctrl._loss_fn = None
     ctrl._dp_client = _NoOpDataPlane()
     ctrl._timer = Timer()

--- a/tests/unit/single_controller/test_single_controller.py
+++ b/tests/unit/single_controller/test_single_controller.py
@@ -32,6 +32,7 @@ from nemo_rl.algorithms.single_controller_utils.config import (
     MasterConfig,
 )
 from nemo_rl.data_plane import KVBatchMeta
+from nemo_rl.experience.rollout_timing import NemoGymRolloutTiming
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.utils.timer import TimeoutChecker, Timer
 
@@ -376,6 +377,8 @@ def _train_pump_controller(*, sampler) -> object:
         clear_logger_metrics=lambda: None,
     )
     ctrl._loss_fn = None
+    # No group has landed, so the step-close postprocess-share report no-ops too.
+    ctrl._rollout_manager = SimpleNamespace(rollout_timing=NemoGymRolloutTiming())
     ctrl._dp_client = _NoOpDataPlane()
     ctrl._timer = Timer()
     ctrl._trainer_version = 0

--- a/tests/unit/single_controller/test_watchdog_pump.py
+++ b/tests/unit/single_controller/test_watchdog_pump.py
@@ -53,6 +53,7 @@ def _make_controller(
     env_handles=None,
     train_steps: int = 0,
     max_num_steps: int = 100,
+    buffered: int = 0,
 ):
     controller_cls = SingleControllerActor.__ray_metadata__.modified_class
     ctrl = object.__new__(controller_cls)
@@ -64,7 +65,10 @@ def _make_controller(
             stall_timeout_s=stall_timeout_s,
             stall_action=stall_action,
             gym_subprocess_check=gym_subprocess_check,
-        )
+        ),
+        # Capacities the occupancy report divides by.
+        max_inflight_prompts=16,
+        max_buffered_rollouts=64,
     )
     ctrl._master_config = SimpleNamespace(
         grpo=GRPOConfig.model_construct(max_num_steps=max_num_steps)
@@ -72,6 +76,8 @@ def _make_controller(
     ctrl._rollout_manager = SimpleNamespace(stats=stats)
     ctrl._inflight_rollouts = inflight
     ctrl._train_steps = train_steps
+    ctrl._trainer_version = train_steps
+    ctrl._buffer = [None] * buffered
     ctrl._logger = _RecordingLogger()
     ctrl._env_handles = env_handles if env_handles is not None else {}
     return ctrl
@@ -199,6 +205,32 @@ class TestMetrics:
         assert published["rollout/inflight"] == 2.0
         # The leading indicator: idle time rises before a wedge becomes a stall.
         assert "rollout/idle_s" in published
+
+    def test_buffer_occupancy_is_published_as_a_series(self):
+        """Buffer depth against its capacity is what the async knobs are tuned on.
+
+        It used to be readable only from the train pump's stall warning, so a run that
+        never stalled -- every healthy run -- reported it nowhere.
+        """
+        ctrl = _make_controller(
+            stats=RolloutStats(), inflight=2, stall_timeout_s=1000.0, buffered=5
+        )
+
+        asyncio.run(_run_ticks(ctrl, 2))
+
+        assert ctrl._logger.metrics[-1]["rollout/buffered"] == 5.0
+
+    def test_occupancy_is_printed_against_its_capacities(self, capsys):
+        """The numbers are useless without the bounds they are approaching."""
+        ctrl = _make_controller(
+            stats=RolloutStats(), inflight=3, stall_timeout_s=1000.0, buffered=9
+        )
+
+        asyncio.run(_run_ticks(ctrl, 2))
+
+        out = capsys.readouterr().out
+        assert "inflight=3/16" in out
+        assert "buffered=9/64" in out
 
 
 class TestEnvHealthCheck:


### PR DESCRIPTION
# What does this PR do ?

Reports what share of NeMo-Gym rollout time is spent in the CPU-bound postprocess
that runs inline on the Gym actor's event loop, so the decision to shard that actor
(or to raise the fan-in onto a single one) can be made from a run's logs rather than
from a guess.

`NemoGym.run_rollouts` already times both phases of its result loop — `await_results`,
blocked waiting for the next Gym task, and `postprocess_results`, the decode-and-tensorize
step — and even computes the ratio between them. SingleController then drops all of it:
the metrics ride `PromptGroupRecord.rollout_metrics` into `TQReplayBuffer.commit`, which
keeps only the tensors, so today they reach neither stdout nor W&B (still listed as a TODO
in `_train_pump`).

This pools the two phases in `RolloutManager` and reports them from the two places the
controller already reports telemetry. Measurement only — no behaviour change to rollouts.

> **Stacked on #<telemetry PR>.** It reports through the telemetry pump that PR
> introduces, so the diff here shows both commits until that one merges. Review
> only the second commit, `feat(sc): report the NeMo-Gym rollout postprocess share`.

# Issues

None.

# Usage

Nothing to configure — any SingleController run on the NeMo-Gym rollout path reports it.
The step-independent pump prints one line every 30s, including before the first optimizer
step closes:
gym rollout phases (train_step=0): await_results=812.44s postprocess_results=203.11s postprocess_results_pct=20.00 groups=128


and the step-close reporter logs the same numbers as a series:

```python
# W&B / TensorBoard keys, logged at each train step
"rollout/nemo_gym/await_results"          # cumulative seconds
"rollout/nemo_gym/postprocess_results"    # cumulative seconds
"rollout/nemo_gym/postprocess_results_pct"
"rollout/nemo_gym/groups"
```

A high postprocess_results_pct says the inline postprocess is competing with the awaits on one event loop, and that spreading run_rollouts across worker actors would buy something. A low one says it would not, and the fan-in can go onto a single actor.

The native rollout path has no Gym postprocess, so it reports nothing at all.

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
