### PR TITLE
feat(sc): warn when the train pump selects no group for minutes

### DIFF
--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -75,6 +75,10 @@ from nemo_rl.utils.timer import TimeoutChecker, Timer
 
 Generation = Union[VllmGeneration, SGLangGeneration]
 
+# How long the train pump may go without selecting a group before it says so.
+# Generous: a healthy step can wait several minutes on generation alone.
+_SELECT_STALL_WARN_SECONDS = 600.0
+
 
 @ray.remote(num_cpus=1, num_gpus=0)  # pragma: no cover
 class SingleControllerActor:
@@ -485,6 +489,8 @@ class SingleControllerActor:
             version_during_step = self._trainer_version
             groups_dispatched = 0
             evicted_stale_prompt_groups = 0
+            last_select = time.monotonic()
+            select_stall_warnings = 0
             min_sample_version = None
             step_open = False
             calibration_batches: list[BatchedDataDict[Any]] = []
@@ -540,6 +546,29 @@ class SingleControllerActor:
                                     f"{grpo_cfg.num_prompts_per_step} prompt "
                                     f"groups with {buffered_groups} group(s) "
                                     f"remaining in the buffer"
+                                )
+                            # The watchdog cannot see this one: it resets its idle
+                            # timer on every commit, so a fleet that keeps rolling
+                            # out into a step that never fills reads as healthy
+                            # there while the pump spins here in silence. Escalate
+                            # the threshold on each firing so a long stall reports
+                            # periodically rather than every 5ms.
+                            stalled_for = time.monotonic() - last_select
+                            if stalled_for > _SELECT_STALL_WARN_SECONDS * (
+                                select_stall_warnings + 1
+                            ):
+                                select_stall_warnings += 1
+                                print(
+                                    f"WARNING: train_pump selected no group for "
+                                    f"{stalled_for / 60:.1f} min on step "
+                                    f"{self._train_steps}: "
+                                    f"{groups_dispatched}/"
+                                    f"{grpo_cfg.num_prompts_per_step} groups, "
+                                    f"{len(self._buffer)} buffered, "
+                                    f"{self._inflight_rollouts} rollouts in flight, "
+                                    f"{self._rollout_manager.stats.skipped} prompts "
+                                    f"skipped",
+                                    flush=True,
                                 )
                             await asyncio.sleep(0.005)
                             continue
@@ -626,6 +655,8 @@ class SingleControllerActor:
                     )
 
                     groups_dispatched += num_groups
+                    last_select = time.monotonic()
+                    select_stall_warnings = 0
 
                 with self._timer.time("policy_training"):
                     result = await asyncio.to_thread(self._trainer.finish_train_step)

--- a/tests/unit/single_controller/test_single_controller.py
+++ b/tests/unit/single_controller/test_single_controller.py
@@ -364,6 +364,10 @@ def _train_pump_controller(*, sampler) -> object:
     ctrl._partition_id = "rollout_data"
     ctrl._sampler = sampler
     ctrl._buffer = _EmptyBuffer()
+    # Read only by the select-stall warning, which reports what the pump is
+    # waiting on.
+    ctrl._inflight_rollouts = 0
+    ctrl._rollout_manager = SimpleNamespace(stats=SimpleNamespace(skipped=0))
     ctrl._buffer_capacity = asyncio.Semaphore(2)
     ctrl._rollout_exhausted = asyncio.Event()
     ctrl._rollout_exhausted.set()
@@ -409,6 +413,78 @@ def test_train_pump_fails_if_rollout_exhausts_during_partial_step() -> None:
         ),
     ):
         asyncio.run(asyncio.wait_for(ctrl._train_pump(), timeout=1.0))
+
+
+async def _spin_train_pump(ctrl, seconds: float) -> None:
+    """Run the pump against a sampler that never selects, then stop it.
+
+    The pump only returns once a step closes or rollout is exhausted, and this is
+    the case where neither happens.
+    """
+    task = asyncio.ensure_future(ctrl._train_pump())
+    await asyncio.sleep(seconds)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+class TestSelectStallWarning:
+    """The stall the watchdog cannot see.
+
+    Its idle timer resets on every commit, so a fleet that keeps rolling out into a
+    step that never fills reads as healthy there while this pump spins in silence.
+    """
+
+    def _stalling_controller(self, monkeypatch, *, warn_after: float = 0.01):
+        monkeypatch.setattr(single_controller, "_SELECT_STALL_WARN_SECONDS", warn_after)
+        ctrl = _train_pump_controller(sampler=_EmptySampler())
+        # Not exhausted: the pump waits rather than returning, which is the wedge.
+        ctrl._rollout_exhausted.clear()
+        return ctrl
+
+    def test_a_pump_that_selects_nothing_says_so(self, capsys, monkeypatch) -> None:
+        ctrl = self._stalling_controller(monkeypatch)
+        ctrl._inflight_rollouts = 5
+        ctrl._rollout_manager.stats.skipped = 3
+
+        asyncio.run(_spin_train_pump(ctrl, 0.05))
+
+        out = capsys.readouterr().out
+        assert "train_pump selected no group" in out
+        # The four numbers that separate a short-batch wedge from starvation at
+        # the concurrency gate.
+        assert "0/2 groups" in out
+        assert "0 buffered" in out
+        assert "5 rollouts in flight" in out
+        assert "3 prompts skipped" in out
+
+    def test_the_threshold_escalates_instead_of_printing_every_tick(
+        self, capsys, monkeypatch
+    ) -> None:
+        """The pump retries every 5ms; one line per retry would bury the log.
+
+        The k-th warning waits k thresholds, so over a window of 5 thresholds this
+        prints about 5 lines where the pump retried about 20 times.
+        """
+        ctrl = self._stalling_controller(monkeypatch, warn_after=0.02)
+
+        asyncio.run(_spin_train_pump(ctrl, 0.1))
+
+        warnings = capsys.readouterr().out.count("train_pump selected no group")
+        assert 1 <= warnings <= 6, f"printed {warnings} warnings in 100ms"
+
+    def test_a_pump_still_making_progress_stays_quiet(
+        self, capsys, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(single_controller, "_SELECT_STALL_WARN_SECONDS", 30.0)
+        ctrl = _train_pump_controller(sampler=_EmptySampler())
+        ctrl._rollout_exhausted.clear()
+
+        asyncio.run(_spin_train_pump(ctrl, 0.05))
+
+        assert "train_pump selected no group" not in capsys.readouterr().out
 
 
 def test_train_pump_logs_nonzero_stale_group_metrics(monkeypatch) -> None:


### PR DESCRIPTION
# Overview 

A step that cannot fill its batch and a step starved at the rollout concurrency gate produce identical logs today: the pump sits in exposed_generation printing nothing, and only the wall clock says anything is wrong. Several 68-node probe arms were inconclusive for exactly this reason.

The watchdog does not cover it. Its idle timer resets on every committed rollout, so a fleet that keeps rolling out into a step that never fills -- an in-order sampler waiting on prompts that were dropped, or a staleness window rejecting everything buffered -- reads as healthy there while the pump spins here in silence.

Track the time since the last successful select and print once the gap passes _SELECT_STALL_WARN_SECONDS, escalating the threshold on each firing so a long stall reports periodically rather than every 5ms. The line carries the four numbers that separate the two failure modes: groups dispatched against the count wanted, groups buffered, rollouts in flight, and prompts skipped. A short-batch wedge shows in-flight at zero with skips non-zero; starvation at the gate shows in-flight pinned at the ceiling with skips at zero.

Print-only. No control flow changes and nothing is raised, so a run that would have finished still finishes.

# What does this PR do ?

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
