### PR TITLE
feat(trtllm): support Qwen3.5 routed-expert block-FP8 refit

### DIFF
--- a/docs/guides/refit.md
+++ b/docs/guides/refit.md
@@ -35,6 +35,38 @@ the generation backend; both Megatron and DTensor policy workers can send
 weights. Sparse delta is currently limited to GRPO. NIXL is initialized by the
 GRPO and distillation setup paths; PPO currently requires colocated generation.
 
+### TRT-LLM Qwen3.5 Routed-Expert FP8
+
+TRT-LLM supports online block-FP8 refit for Qwen3.5 MoE rollouts. Policy
+training remains in BF16, and this setting does not change optimizer-state
+precision. During each refit, NeMo RL converts only the routed-expert weights
+to E4M3 with 128x128 blocks and FP32 scales; attention, routers, shared experts,
+embeddings, and the output head remain in BF16.
+
+This path starts from a BF16 policy checkpoint. Direct loading of a
+pre-quantized ModelOpt FP8 checkpoint is outside its scope.
+
+Enable the path with:
+
+```yaml
+policy:
+  generation:
+    trtllm_cfg:
+      precision: fp8
+```
+
+This path currently accepts only checkpoints whose Transformers `model_type`
+is `qwen3_5_moe`. NeMo RL initializes the TRT-LLM model with `load_format` set
+to `dummy`, then populates it from the first BF16 policy refit. The TRTLLM MoE
+backend is required to preserve FP32 block scales; MXFP8/E8M0 scales are not
+used.
+
+The installed TRT-LLM must provide the incremental-refit lifecycle APIs
+`begin_update_weights`, `finalize_update_weights`, `abort_update_weights`, and
+`WorkerExtension.finalize_weight_update`. NeMo RL fails during setup if any of
+these APIs are unavailable. Supporting another model architecture requires a
+model-specific quantization filter and weight mapper.
+
 ## Minimal Configuration
 
 Colocated refit needs no transport configuration:

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -4047,6 +4047,10 @@ def async_grpo_train(
     # SGLang async rollouts do not support the async GRPO replay path.
     generation_config = master_config.policy["generation"]
     backend = generation_config.get("backend", "") if generation_config else ""
+    requires_initial_fp8_refit = (
+        backend == "trtllm"
+        and generation_config.get("trtllm_cfg", {}).get("precision") == "fp8"
+    )
     assert backend in ("vllm", "megatron", "trtllm") and _should_use_async_rollouts(
         master_config
     ), (
@@ -4238,13 +4242,12 @@ def async_grpo_train(
         next_nemo_gym_task_index=next_nemo_gym_task_index,
     )
 
-    # Start trajectory collection in background
-    collection_task = trajectory_collector.start_collection.remote(dataloader)
-
-    # Ensure collector knows initial weight version
-    trajectory_collector.set_weight_version.remote(weight_version)
-
-    print("📦 Started continuous background trajectory collection")
+    if not requires_initial_fp8_refit:
+        # Preserve the existing overlap for generation engines that already
+        # contain usable weights when the collector starts.
+        collection_task = trajectory_collector.start_collection.remote(dataloader)
+        trajectory_collector.set_weight_version.remote(weight_version)
+        print("📦 Started continuous background trajectory collection")
 
     print(
         f"🚀 Starting async GRPO training with buffer_size={optimal_buffer_size}, max_age={max_trajectory_age_steps} steps"
@@ -4338,6 +4341,13 @@ def async_grpo_train(
             except Exception as e:
                 print(f"Error stopping replay buffer: {e}")
             return
+
+    if requires_initial_fp8_refit:
+        # The TRT-LLM FP8 engine starts with dummy weights, so no rollout may
+        # begin until the initial refit has completed successfully.
+        ray.get(trajectory_collector.set_weight_version.remote(weight_version))
+        collection_task = trajectory_collector.start_collection.remote(dataloader)
+        print("📦 Started continuous background trajectory collection")
 
     print("✅ All setup complete, starting buffer wait...")
     # Clear logger metrics at start of training

--- a/nemo_rl/models/generation/trtllm/quantization/__init__.py
+++ b/nemo_rl/models/generation/trtllm/quantization/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Quantization helpers for TRT-LLM generation."""

--- a/nemo_rl/models/generation/trtllm/quantization/fp8.py
+++ b/nemo_rl/models/generation/trtllm/quantization/fp8.py
@@ -74,10 +74,10 @@ _SPLIT_LINEAR_ATTN_RE = re.compile(
 )
 
 
-def validate_qwen35_fused_expert_layout(
+def validate_fused_expert_layout(
     state_dict_info: dict[str, Any],
 ) -> None:
-    """Validate the fused trainer layout before the first refit."""
+    """Validate Qwen3.5's fused routed-expert layout before the first refit."""
     layouts: dict[str, dict[str, tuple[int, ...]]] = {}
     for name, metadata in state_dict_info.items():
         match = _FUSED_EXPERT_RE.fullmatch(name)
@@ -319,7 +319,7 @@ def _insert_quantized_projection(
     _insert_unique(output, scale_name, scale_inv)
 
 
-def clone_qwen35_mapper_staging_weights(
+def clone_mapper_staging_weights(
     weights: dict[str, torch.Tensor],
 ) -> dict[str, torch.Tensor]:
     """Detach split linear-attention tensors that the mapper may retain.

--- a/nemo_rl/models/generation/trtllm/quantization/fp8.py
+++ b/nemo_rl/models/generation/trtllm/quantization/fp8.py
@@ -1,0 +1,416 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Qwen3.5 routed-expert block-FP8 refit support for TRT-LLM."""
+
+import math
+import re
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+
+FP8_BLOCK_SIZE = (128, 128)
+FP8_EXPERT_CHUNK_SIZE = 16
+
+# TRT-LLM's HF quantization config only has a negative module filter. Keep
+# every Qwen3.5 linear outside the routed-expert subtree in BF16.
+FP8_BLOCK_QUANT_KWARGS: dict[str, Any] = {
+    "activation_scheme": "dynamic",
+    "fmt": "e4m3",
+    "quant_method": "fp8",
+    "weight_block_size": list(FP8_BLOCK_SIZE),
+    "modules_to_not_convert": [
+        "model.layers.*.self_attn*",
+        "model.layers.*.linear_attn*",
+        "model.layers.*.mlp.gate",
+        "model.layers.*.mlp.shared_expert*",
+        "model.embed_tokens",
+        "model.norm",
+        "lm_head",
+        # Qwen3.5 has one MTP layer. Keep its attention/shared paths in BF16,
+        # but quantize its routed experts under the same contract.
+        "mtp.layers.0.self_attn*",
+        "mtp.layers.0.linear_attn*",
+        "mtp.layers.0.mlp.gate",
+        "mtp.layers.0.mlp.shared_expert*",
+        "mtp.fc*",
+        "mtp.norm*",
+        "mtp.pre_fc_norm_embedding*",
+        "mtp.pre_fc_norm_hidden*",
+    ],
+}
+
+_QWEN35_PREFIX = (
+    r"(?:"
+    r"(?:(?:model\.)?(?:language_model\.)?)layers\.\d+"
+    r"|mtp\.layers\.\d+"
+    r")\.mlp\.experts"
+)
+_FUSED_EXPERT_RE = re.compile(
+    rf"^(?P<prefix>{_QWEN35_PREFIX})\."
+    r"(?P<projection>gate_up_proj|down_proj)$"
+)
+_SPLIT_EXPERT_RE = re.compile(
+    rf"^(?P<prefix>{_QWEN35_PREFIX})\.\d+\."
+    r"(?:gate_proj|up_proj|down_proj)\.weight$"
+)
+_SPLIT_LINEAR_ATTN_RE = re.compile(
+    r"^(?:.*\.)?layers\.\d+\.linear_attn\."
+    r"in_proj_(?:qkv|q|k|v|z|a|b)\..+$"
+)
+
+
+def validate_qwen35_fused_expert_layout(
+    state_dict_info: dict[str, Any],
+) -> None:
+    """Validate the fused trainer layout before the first refit."""
+    layouts: dict[str, dict[str, tuple[int, ...]]] = {}
+    for name, metadata in state_dict_info.items():
+        match = _FUSED_EXPERT_RE.fullmatch(name)
+        if match is None:
+            continue
+        shape, _ = metadata
+        layouts.setdefault(match.group("prefix"), {})[match.group("projection")] = (
+            tuple(shape)
+        )
+
+    if not layouts:
+        raise ValueError(
+            "No Qwen3.5 fused routed-expert weights were found; expected "
+            "gate_up_proj=[E,2I,H] and down_proj=[E,H,I]."
+        )
+
+    for prefix, projections in layouts.items():
+        if set(projections) != {"gate_up_proj", "down_proj"}:
+            raise ValueError(
+                f"Qwen3.5 fused experts require both gate_up_proj and down_proj: "
+                f"{prefix} has {sorted(projections)}"
+            )
+        gate_up_shape = projections["gate_up_proj"]
+        down_shape = projections["down_proj"]
+        valid = (
+            len(gate_up_shape) == 3
+            and len(down_shape) == 3
+            and gate_up_shape[0] == down_shape[0]
+            and gate_up_shape[1] == 2 * down_shape[2]
+            and gate_up_shape[2] == down_shape[1]
+        )
+        if not valid:
+            raise ValueError(
+                "Qwen3.5 fused expert weights must use gate_up_proj=[E,2I,H] "
+                f"and down_proj=[E,H,I]; {prefix} has "
+                f"gate_up_proj={gate_up_shape}, down_proj={down_shape}"
+            )
+
+
+def configure_fp8_llm_kwargs(llm_kwargs: dict[str, Any], *, model_type: str) -> None:
+    """Apply the experts-only block-FP8 contract to TRT-LLM constructor args.
+
+    Existing Qwen3.5 ``model_kwargs`` entries are preserved. Conflicting
+    quantization or load-format overrides fail at setup instead of silently
+    creating a runtime whose refit schema differs from this converter.
+    """
+    if model_type != "qwen3_5_moe":
+        raise ValueError(
+            "precision='fp8' currently supports only Qwen3.5 MoE, got "
+            f"model_type={model_type!r}"
+        )
+
+    model_kwargs = dict(llm_kwargs.get("model_kwargs") or {})
+    existing_quant_config = model_kwargs.get("quantization_config")
+    if (
+        existing_quant_config is not None
+        and dict(existing_quant_config) != FP8_BLOCK_QUANT_KWARGS
+    ):
+        raise ValueError(
+            "precision='fp8' requires NeMo-RL's Qwen3.5 routed-experts-only "
+            "block-FP8 quantization_config"
+        )
+
+    load_format = llm_kwargs.get("load_format")
+    if load_format is not None and load_format != "dummy":
+        raise ValueError(
+            "precision='fp8' requires load_format='dummy'; the initial BF16 "
+            "trainer refit populates the FP8 weights and scales"
+        )
+
+    quantization_config = dict(FP8_BLOCK_QUANT_KWARGS)
+    quantization_config["modules_to_not_convert"] = list(
+        FP8_BLOCK_QUANT_KWARGS["modules_to_not_convert"]
+    )
+    model_kwargs["quantization_config"] = quantization_config
+    llm_kwargs["model_kwargs"] = model_kwargs
+    llm_kwargs["load_format"] = "dummy"
+    llm_kwargs["dtype"] = "bfloat16"
+    # This keeps any block-FP8 Linear fallback on the FP32-scale path. Routed
+    # experts additionally require MoeConfig(backend="TRTLLM"), configured by
+    # the worker.
+    llm_kwargs["use_cute_dsl_blockscaling_mm"] = True
+
+
+def configure_fp8_moe_backend(
+    llm_kwargs: dict[str, Any], moe_config_type: type[Any]
+) -> None:
+    """Force TRTLLMGen MoE while preserving other MoeConfig fields."""
+    moe_config = llm_kwargs.get("moe_config")
+    if moe_config is None:
+        llm_kwargs["moe_config"] = moe_config_type(backend="TRTLLM")
+        return
+
+    if isinstance(moe_config, dict):
+        moe_config_kwargs = dict(moe_config)
+        configured_backend = str(moe_config_kwargs.get("backend", "TRTLLM")).upper()
+        if configured_backend != "TRTLLM":
+            raise ValueError(
+                "precision='fp8' with FP32 routed-expert scales requires "
+                "trtllm_kwargs.moe_config.backend='TRTLLM', got "
+                f"{configured_backend!r}"
+            )
+        moe_config_kwargs["backend"] = "TRTLLM"
+        llm_kwargs["moe_config"] = moe_config_type(**moe_config_kwargs)
+        return
+
+    if isinstance(moe_config, moe_config_type):
+        configured_backend = str(moe_config.backend).upper()
+        if configured_backend != "TRTLLM":
+            raise ValueError(
+                "precision='fp8' with FP32 routed-expert scales requires "
+                "trtllm_kwargs.moe_config.backend='TRTLLM', got "
+                f"{moe_config.backend!r}"
+            )
+        return
+
+    raise TypeError(
+        "trtllm_kwargs.moe_config must be a dict or MoeConfig, got "
+        f"{type(moe_config).__name__}"
+    )
+
+
+def _has_fp8_block_scales(quant_config: Any) -> bool:
+    if quant_config is None:
+        return False
+    layer_mode = getattr(quant_config, "layer_quant_mode", None)
+    if layer_mode is None:
+        return False
+    return layer_mode.has_fp8_block_scales() is True
+
+
+def is_fp8_model(quant_config: Any) -> bool:
+    """Return whether a TRT-LLM model uses 128x128 block FP8."""
+    return _has_fp8_block_scales(quant_config)
+
+
+def cast_tensor_to_fp8_blockwise(
+    data_hp: torch.Tensor,
+    weight_block_size: Sequence[int] = FP8_BLOCK_SIZE,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize the final two dimensions into E4M3 with FP32 block scales.
+
+    Leading dimensions are treated as independent matrices. The returned
+    ``weight_scale_inv`` uses ``[..., out_block, in_block]`` orientation and
+    dequantizes as ``fp8.float() * weight_scale_inv`` per block.
+    """
+    if data_hp.dim() < 2:
+        raise ValueError(
+            "cast_tensor_to_fp8_blockwise expects at least a 2-D tensor, got "
+            f"shape {tuple(data_hp.shape)}"
+        )
+    if len(weight_block_size) != 2:
+        raise ValueError(
+            f"weight_block_size must contain two dimensions, got {weight_block_size}"
+        )
+    block_m, block_n = (int(weight_block_size[0]), int(weight_block_size[1]))
+    if (block_m, block_n) != FP8_BLOCK_SIZE:
+        raise ValueError(
+            "TRT-LLM FP8_BLOCK_SCALES requires weight_block_size=[128, 128], "
+            f"got {[block_m, block_n]}"
+        )
+
+    batch_shape = tuple(data_hp.shape[:-2])
+    rows, columns = data_hp.shape[-2:]
+    pad_rows = (-rows) % block_m
+    pad_columns = (-columns) % block_n
+
+    data_fp32 = data_hp.to(torch.float32)
+    if pad_rows or pad_columns:
+        data_fp32 = F.pad(data_fp32, (0, pad_columns, 0, pad_rows), value=0.0)
+
+    padded_rows, padded_columns = data_fp32.shape[-2:]
+    row_blocks = padded_rows // block_m
+    column_blocks = padded_columns // block_n
+    batch_size = math.prod(batch_shape) if batch_shape else 1
+
+    blocked = (
+        data_fp32.reshape(
+            batch_size,
+            row_blocks,
+            block_m,
+            column_blocks,
+            block_n,
+        )
+        .permute(0, 1, 3, 2, 4)
+        .contiguous()
+        .flatten(start_dim=3)
+    )
+
+    fp8_max = torch.finfo(torch.float8_e4m3fn).max
+    max_abs = torch.amax(torch.abs(blocked), dim=-1, keepdim=True)
+    valid_scale = torch.isfinite(max_abs) & (max_abs > 0)
+    scale_inv = torch.where(
+        valid_scale,
+        max_abs / fp8_max,
+        torch.ones_like(max_abs),
+    )
+    quant_scale = torch.where(
+        valid_scale,
+        torch.reciprocal(scale_inv),
+        torch.ones_like(scale_inv),
+    )
+    fp8_data = torch.clamp(
+        blocked * quant_scale,
+        min=-fp8_max,
+        max=fp8_max,
+    ).to(torch.float8_e4m3fn)
+
+    fp8_data = (
+        fp8_data.reshape(
+            batch_size,
+            row_blocks,
+            column_blocks,
+            block_m,
+            block_n,
+        )
+        .permute(0, 1, 3, 2, 4)
+        .reshape(*batch_shape, padded_rows, padded_columns)
+    )
+    fp8_data = fp8_data[..., :rows, :columns].contiguous()
+    scale_inv = scale_inv.squeeze(-1).reshape(*batch_shape, row_blocks, column_blocks)
+    return fp8_data, scale_inv.contiguous()
+
+
+def _insert_unique(
+    output: dict[str, torch.Tensor], name: str, tensor: torch.Tensor
+) -> None:
+    if name in output:
+        raise ValueError(f"Duplicate refit weight after FP8 conversion: {name}")
+    output[name] = tensor
+
+
+def _insert_quantized_projection(
+    output: dict[str, torch.Tensor], name: str, tensor: torch.Tensor
+) -> None:
+    fp8_data, scale_inv = cast_tensor_to_fp8_blockwise(tensor)
+    _insert_unique(output, name, fp8_data)
+    scale_name = name.removesuffix(".weight") + ".weight_scale_inv"
+    _insert_unique(output, scale_name, scale_inv)
+
+
+def clone_qwen35_mapper_staging_weights(
+    weights: dict[str, torch.Tensor],
+) -> dict[str, torch.Tensor]:
+    """Detach split linear-attention tensors that the mapper may retain.
+
+    Qwen3.5's mapper stages partial QKVZ and BA groups across reload calls. IPC
+    transport buffers are acknowledged and reused after each call, so retained
+    views must own their storage before the sender can overwrite that buffer.
+    """
+    return {
+        name: tensor.clone()
+        if _SPLIT_LINEAR_ATTN_RE.fullmatch(name) is not None
+        else tensor
+        for name, tensor in weights.items()
+    }
+
+
+def _convert_fused_expert_weight(
+    output: dict[str, torch.Tensor],
+    *,
+    name: str,
+    tensor: torch.Tensor,
+    prefix: str,
+    projection: str,
+) -> None:
+    if tensor.dim() != 3:
+        raise ValueError(
+            f"Qwen3.5 fused expert weight {name} must be 3-D, got {tuple(tensor.shape)}"
+        )
+
+    num_experts = tensor.shape[0]
+    if projection == "gate_up_proj" and tensor.shape[1] % 2 != 0:
+        raise ValueError(
+            f"Qwen3.5 gate_up_proj dimension must be even, got {tuple(tensor.shape)}"
+        )
+
+    for start in range(0, num_experts, FP8_EXPERT_CHUNK_SIZE):
+        end = min(start + FP8_EXPERT_CHUNK_SIZE, num_experts)
+        if projection == "gate_up_proj":
+            intermediate_size = tensor.shape[1] // 2
+            projections = (
+                ("gate_proj", tensor[start:end, :intermediate_size, :]),
+                ("up_proj", tensor[start:end, intermediate_size:, :]),
+            )
+        else:
+            projections = (("down_proj", tensor[start:end]),)
+
+        for projection_name, projection_tensor in projections:
+            fp8_data, scale_inv = cast_tensor_to_fp8_blockwise(projection_tensor)
+            for chunk_index, expert_index in enumerate(range(start, end)):
+                weight_name = f"{prefix}.{expert_index}.{projection_name}.weight"
+                scale_name = weight_name.removesuffix(".weight") + ".weight_scale_inv"
+                _insert_unique(output, weight_name, fp8_data[chunk_index])
+                _insert_unique(output, scale_name, scale_inv[chunk_index])
+
+
+def load_weights(
+    weight_list: Iterable[tuple[str, torch.Tensor]],
+) -> dict[str, torch.Tensor]:
+    """Convert only Qwen3.5 routed experts from BF16 to HF block-FP8.
+
+    Fused Transformers/Megatron expert tensors are expanded into the standard
+    per-expert HF names consumed by TRT-LLM's Qwen3.5 mapper. All non-routed
+    weights pass through unchanged.
+    """
+    output: dict[str, torch.Tensor] = {}
+    for name, tensor in weight_list:
+        if not isinstance(name, str):
+            raise TypeError(
+                f"TRT-LLM refit weight names must be strings, got {type(name).__name__}"
+            )
+        weight_name = str(name)
+        fused_match = (
+            _FUSED_EXPERT_RE.fullmatch(  # pyrefly: ignore[no-matching-overload]
+                weight_name
+            )
+        )
+        if fused_match is not None:
+            _convert_fused_expert_weight(
+                output,
+                name=weight_name,
+                tensor=tensor,
+                prefix=fused_match.group("prefix"),
+                projection=fused_match.group("projection"),
+            )
+        elif (
+            _SPLIT_EXPERT_RE.fullmatch(  # pyrefly: ignore[no-matching-overload]
+                weight_name
+            )
+            is not None
+        ):
+            _insert_quantized_projection(output, weight_name, tensor)
+        else:
+            _insert_unique(output, weight_name, tensor)
+    return output

--- a/nemo_rl/models/generation/trtllm/trtllm_backend.py
+++ b/nemo_rl/models/generation/trtllm/trtllm_backend.py
@@ -57,8 +57,8 @@ def _call_model_loader_hook_if_available(model_loader: Any, hook_name: str) -> b
     return True
 
 
-def _require_fp8_refit_lifecycle(model_loader: Any) -> None:
-    """Require the Qwen3.5 incremental-refit APIs from the target TRT-LLM."""
+def _require_fp8_refit_hooks(model_loader: Any) -> None:
+    """Require TRT-LLM hooks for transactional Qwen3.5 FP8 refits."""
     required_hooks = (
         "begin_update_weights",
         "finalize_update_weights",
@@ -73,8 +73,8 @@ def _require_fp8_refit_lifecycle(model_loader: Any) -> None:
         missing_hooks.append("WorkerExtension.finalize_weight_update")
     if missing_hooks:
         raise RuntimeError(
-            "Qwen3.5 FP8 refit requires the target TRT-LLM incremental-refit "
-            f"lifecycle. Missing APIs: {missing_hooks}."
+            "Qwen3.5 FP8 refit requires TRT-LLM weight-update hooks. "
+            f"Missing APIs: {missing_hooks}."
         )
 
 
@@ -135,8 +135,8 @@ class NcclExtension(WorkerExtension):
         self.state_dict_info = state_dict_info
         model = self.engine.model_engine.model
         if fp8_quantization.is_fp8_model(model.model_config.quant_config):
-            fp8_quantization.validate_qwen35_fused_expert_layout(state_dict_info)
-            _require_fp8_refit_lifecycle(self.engine.model_engine.model_loader)
+            fp8_quantization.validate_fused_expert_layout(state_dict_info)
+            _require_fp8_refit_hooks(self.engine.model_engine.model_loader)
 
     def _finalize_weight_update(self) -> None:
         """Finalize refit using TRT-LLM's CUDA-graph-safe path when available."""
@@ -346,9 +346,7 @@ class NcclExtension(WorkerExtension):
                     # Qwen3.5's mapper may retain split QKVZ/BA tensors until a
                     # later IPC chunk completes the fusion group. Detach those
                     # views before ACK lets the trainer reuse its transport buffer.
-                    weights = fp8_quantization.clone_qwen35_mapper_staging_weights(
-                        weights
-                    )
+                    weights = fp8_quantization.clone_mapper_staging_weights(weights)
 
                 model_engine.model_loader.reload(
                     model,

--- a/nemo_rl/models/generation/trtllm/trtllm_backend.py
+++ b/nemo_rl/models/generation/trtllm/trtllm_backend.py
@@ -33,6 +33,7 @@ import zmq
 from tensorrt_llm._ray_utils import control_action_decorator
 from tensorrt_llm.llmapi.rlhf_utils import WorkerExtension
 
+from nemo_rl.models.generation.trtllm.quantization import fp8 as fp8_quantization
 from nemo_rl.models.policy.utils import (
     IPCProtocol,
     calculate_aligned_size,
@@ -54,6 +55,27 @@ def _call_model_loader_hook_if_available(model_loader: Any, hook_name: str) -> b
         return False
     hook()
     return True
+
+
+def _require_fp8_refit_lifecycle(model_loader: Any) -> None:
+    """Require the Qwen3.5 incremental-refit APIs from the target TRT-LLM."""
+    required_hooks = (
+        "begin_update_weights",
+        "finalize_update_weights",
+        "abort_update_weights",
+    )
+    missing_hooks = [
+        hook_name
+        for hook_name in required_hooks
+        if not callable(getattr(model_loader, hook_name, None))
+    ]
+    if not callable(getattr(WorkerExtension, "finalize_weight_update", None)):
+        missing_hooks.append("WorkerExtension.finalize_weight_update")
+    if missing_hooks:
+        raise RuntimeError(
+            "Qwen3.5 FP8 refit requires the target TRT-LLM incremental-refit "
+            f"lifecycle. Missing APIs: {missing_hooks}."
+        )
 
 
 class NcclExtension(WorkerExtension):
@@ -111,6 +133,10 @@ class NcclExtension(WorkerExtension):
 
     def prepare_refit_info(self, state_dict_info: dict[str, Any]) -> None:
         self.state_dict_info = state_dict_info
+        model = self.engine.model_engine.model
+        if fp8_quantization.is_fp8_model(model.model_config.quant_config):
+            fp8_quantization.validate_qwen35_fused_expert_layout(state_dict_info)
+            _require_fp8_refit_lifecycle(self.engine.model_engine.model_loader)
 
     def _finalize_weight_update(self) -> None:
         """Finalize refit using TRT-LLM's CUDA-graph-safe path when available."""
@@ -136,6 +162,34 @@ class NcclExtension(WorkerExtension):
                 module, "_weights_removed", False
             ):
                 module.post_load_weights()
+
+    def _ensure_refit_usable(self) -> None:
+        failure = getattr(self, "_fp8_refit_failure", None)
+        if failure is not None:
+            raise RuntimeError(
+                "This TRT-LLM worker is unusable after a failed partial FP8 "
+                f"refit and must be restarted. Original failure: {failure}"
+            )
+
+    def _abort_weight_update_after_failure(
+        self, model: Any, model_loader: Any, error: Exception
+    ) -> None:
+        fp8_refit_failed = fp8_quantization.is_fp8_model(
+            model.model_config.quant_config
+        )
+        if fp8_refit_failed:
+            # Record poisoning before abort: abort itself may fail, but this
+            # worker must never serve with partially updated FP8 weights.
+            self._fp8_refit_failure = repr(error)
+        try:
+            _call_model_loader_hook_if_available(model_loader, "abort_update_weights")
+        finally:
+            if fp8_refit_failed:
+                raise RuntimeError(
+                    "Partial Qwen3.5 FP8 refit failed after runtime weights may have "
+                    "been modified. The TRT-LLM worker is poisoned and must be "
+                    "restarted."
+                ) from error
 
     # ------------------------------------------------------------------ #
     #  NCCL weight receive + reload
@@ -165,11 +219,16 @@ class NcclExtension(WorkerExtension):
         )
         model_engine = self.engine.model_engine
         model = model_engine.model
+        self._ensure_refit_usable()
 
         def load_model_weight_func(weight_list):
+            if fp8_quantization.is_fp8_model(model.model_config.quant_config):
+                weights = fp8_quantization.load_weights(weight_list)
+            else:
+                weights = dict(weight_list)
             model_engine.model_loader.reload(
                 model,
-                dict(weight_list),
+                weights,
                 allow_partial_loading=True,
             )
 
@@ -199,8 +258,8 @@ class NcclExtension(WorkerExtension):
 
                 self.engine.reset_prefix_cache()
             except Exception as e:
-                _call_model_loader_hook_if_available(
-                    model_engine.model_loader, "abort_update_weights"
+                self._abort_weight_update_after_failure(
+                    model, model_engine.model_loader, e
                 )
                 print(f"Error in NcclExtension.update_weights_from_collective: {e}")
                 return False
@@ -238,6 +297,7 @@ class NcclExtension(WorkerExtension):
         )
         model_engine = self.engine.model_engine
         model = model_engine.model
+        self._ensure_refit_usable()
 
         buffer = None
         weights = None
@@ -281,6 +341,15 @@ class NcclExtension(WorkerExtension):
                     "Likely stale state_dict_info (wrong shape/dtype for some key)."
                 )
 
+                if fp8_quantization.is_fp8_model(model.model_config.quant_config):
+                    weights = fp8_quantization.load_weights(weights.items())
+                    # Qwen3.5's mapper may retain split QKVZ/BA tensors until a
+                    # later IPC chunk completes the fusion group. Detach those
+                    # views before ACK lets the trainer reuse its transport buffer.
+                    weights = fp8_quantization.clone_qwen35_mapper_staging_weights(
+                        weights
+                    )
+
                 model_engine.model_loader.reload(
                     model,
                     weights,
@@ -302,8 +371,8 @@ class NcclExtension(WorkerExtension):
             torch.cuda.empty_cache()
             return True
         except Exception as e:
-            _call_model_loader_hook_if_available(
-                model_engine.model_loader, "abort_update_weights"
+            self._abort_weight_update_after_failure(
+                model, model_engine.model_loader, e
             )
             print(
                 f"Error in NcclExtension.update_weights_via_ipc_zmq: {e}\n"

--- a/nemo_rl/models/generation/trtllm/trtllm_worker_async.py
+++ b/nemo_rl/models/generation/trtllm/trtllm_worker_async.py
@@ -314,6 +314,30 @@ class TrtllmAsyncGenerationWorkerImpl:
         # they can override anything above for advanced tuning.
         llm_kwargs.update(extra_trtllm_kwargs)
 
+        if engine_cfg["precision"] == "fp8":
+            # Import only in TRT-LLM actors so the base NeMo-RL environment
+            # does not need the optional TRT-LLM dependency.
+            from tensorrt_llm.llmapi.llm_args import MoeConfig
+            from transformers import AutoConfig
+
+            from nemo_rl.models.generation.trtllm.quantization.fp8 import (
+                configure_fp8_llm_kwargs,
+                configure_fp8_moe_backend,
+            )
+
+            hf_config = AutoConfig.from_pretrained(
+                self.model_name, trust_remote_code=True
+            )
+            configure_fp8_llm_kwargs(
+                llm_kwargs,
+                model_type=hf_config.model_type,
+            )
+
+            # DeepGEMM resmooths 128x128 FP32 block scales to E8M0 on
+            # Blackwell. The TRTLLM MoE backend retains the requested FP32
+            # scale buffers. Preserve any other user MoeConfig fields.
+            configure_fp8_moe_backend(llm_kwargs, MoeConfig)
+
         # Propagate the nsight runtime_env down to TRT-LLM's internal Ray GPU
         # workers.  The outer actor's @ray.remote nsight config does NOT inherit
         # into TRT-LLM's RayExecutor workers (ray_executor.py sets an explicit
@@ -499,10 +523,18 @@ class TrtllmAsyncGenerationWorkerImpl:
                 "update_weights_from_collective",
                 kwargs={"drain": drain, "recompute_kv": recompute_kv},
             )
-            worker_result = results[0] if results else True
-            if not worker_result:
+            if not results:
+                print("Error: TRT-LLM weight update returned no worker results.")
+                return False
+            failed_workers = [
+                (rank, result)
+                for rank, result in enumerate(results)
+                if not result
+            ]
+            if failed_workers:
                 print(
-                    f"Error: TRT-LLM worker failed to update weights. Result: {worker_result}"
+                    "Error: TRT-LLM workers failed to update weights. "
+                    f"Results: {failed_workers}"
                 )
                 return False
             return True
@@ -517,10 +549,18 @@ class TrtllmAsyncGenerationWorkerImpl:
         assert self.llm is not None
         try:
             results = await self.llm.collective_rpc("update_weights_via_ipc_zmq")
-            worker_result = results[0] if results else True
-            if not worker_result:
+            if not results:
+                print("Error: TRT-LLM IPC weight update returned no worker results.")
+                return False
+            failed_workers = [
+                (rank, result)
+                for rank, result in enumerate(results)
+                if not result
+            ]
+            if failed_workers:
                 print(
-                    f"Error: TRT-LLM worker failed to update weights via IPC. Result: {worker_result}"
+                    "Error: TRT-LLM workers failed to update weights via IPC. "
+                    f"Results: {failed_workers}"
                 )
                 return False
             return True

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -175,6 +175,7 @@ project-includes = [
   "nemo_rl/models/generation/sglang/utils/ray_utils.py",
   "nemo_rl/models/generation/trtllm/__init__.py",
   "nemo_rl/models/generation/trtllm/config.py",
+  "nemo_rl/models/generation/trtllm/quantization/fp8.py",
   "nemo_rl/models/generation/trtllm/trtllm_generation.py",
   "nemo_rl/models/generation/trtllm/trtllm_http_server.py",
   "nemo_rl/models/generation/vllm/__init__.py",

--- a/tests/unit/models/generation/trtllm/test_trtllm_backend.py
+++ b/tests/unit/models/generation/trtllm/test_trtllm_backend.py
@@ -84,24 +84,55 @@ def test_model_loader_lifecycle_hooks_are_optional(hook_name, is_available):
         hook.assert_not_called()
 
 
+def test_fp8_prepare_refit_info_requires_incremental_lifecycle(monkeypatch):
+    from nemo_rl.models.generation.trtllm import trtllm_backend as backend
+
+    extension, _, model, _, _ = _extension(backend)
+    model.model_config = SimpleNamespace(quant_config=object())
+    extension.engine.model_engine.model_loader = SimpleNamespace()
+    monkeypatch.setattr(backend.fp8_quantization, "is_fp8_model", lambda _: True)
+    with pytest.raises(RuntimeError, match="incremental-refit lifecycle"):
+        extension.prepare_refit_info(
+            {
+                "model.layers.0.mlp.experts.gate_up_proj": (
+                    torch.Size([1, 2, 1]),
+                    torch.bfloat16,
+                ),
+                "model.layers.0.mlp.experts.down_proj": (
+                    torch.Size([1, 1, 1]),
+                    torch.bfloat16,
+                ),
+            }
+        )
+
+
 @pytest.mark.parametrize(
-    ("drain", "recompute_kv"),
-    [(True, False), (False, False), (False, True)],
+    ("drain", "recompute_kv", "fp8"),
+    [
+        (True, False, False),
+        (False, False, False),
+        (False, True, False),
+        (True, False, True),
+    ],
 )
 def test_collective_refit_runs_at_async_engine_boundary(
-    monkeypatch, drain, recompute_kv
+    monkeypatch, drain, recompute_kv, fp8
 ):
     from nemo_rl.models.generation.trtllm import trtllm_backend as backend
 
     extension, module, model, model_loader, engine = _extension(backend)
     call_order = []
+    incoming = [("model.weight", torch.tensor([1.0]))]
+    converted = {"converted.weight": torch.tensor([2.0])}
+    convert = MagicMock(return_value=converted)
+    model.model_config = SimpleNamespace(quant_config=object())
 
     def packed_consumer(*, iterator, group, src, post_unpack_func):
         call_order.append("broadcast")
         assert list(iterator) == list(extension.state_dict_info.items())
         assert group is extension.model_update_group
         assert src == 0
-        post_unpack_func([("model.weight", torch.tensor([1.0]))])
+        post_unpack_func(incoming)
 
     module.pre_reload_weights.side_effect = lambda: call_order.append("pre")
     module.process_weights_after_loading.side_effect = lambda: call_order.append(
@@ -114,6 +145,8 @@ def test_collective_refit_runs_at_async_engine_boundary(
         "finalize"
     )
     monkeypatch.setattr(backend, "packed_broadcast_consumer", packed_consumer)
+    monkeypatch.setattr(backend.fp8_quantization, "is_fp8_model", lambda _: fp8)
+    monkeypatch.setattr(backend.fp8_quantization, "load_weights", convert)
     monkeypatch.setattr(
         backend.torch.cuda, "synchronize", lambda: call_order.append("cuda_sync")
     )
@@ -132,9 +165,10 @@ def test_collective_refit_runs_at_async_engine_boundary(
     engine.control_action.assert_called_once_with(drain=drain)
     model_loader.reload.assert_called_once_with(
         model,
-        {"model.weight": torch.tensor([1.0])},
+        converted if fp8 else dict(incoming),
         allow_partial_loading=True,
     )
+    assert convert.call_count == int(fp8)
     assert call_order == [
         "cuda_sync",
         "begin",
@@ -179,16 +213,43 @@ def test_collective_refit_returns_false_when_reload_fails(monkeypatch):
     engine.reset_prefix_cache.assert_not_called()
 
 
-def test_ipc_zmq_streams_chunk_and_reloads_with_aligned_offsets(monkeypatch):
+def test_failed_fp8_refit_poisoning_requires_worker_restart(monkeypatch):
+    from nemo_rl.models.generation.trtllm import trtllm_backend as backend
+
+    extension, _, model, model_loader, _ = _extension(backend)
+    model.model_config = SimpleNamespace(quant_config=object())
+
+    def packed_consumer(*, post_unpack_func, **_):
+        post_unpack_func([("model.weight", torch.tensor([1.0]))])
+
+    model_loader.reload.side_effect = RuntimeError("partial reload failed")
+    model_loader.abort_update_weights.side_effect = RuntimeError("abort failed")
+    monkeypatch.setattr(backend, "packed_broadcast_consumer", packed_consumer)
+    monkeypatch.setattr(backend.torch.cuda, "synchronize", lambda: None)
+    monkeypatch.setattr(backend.fp8_quantization, "is_fp8_model", lambda _: True)
+
+    with pytest.raises(RuntimeError, match="poisoned and must be restarted"):
+        extension.update_weights_from_collective()
+    with pytest.raises(RuntimeError, match="unusable.*must be restarted"):
+        extension.update_weights_from_collective()
+
+
+@pytest.mark.parametrize("fp8", [False, True])
+def test_ipc_zmq_streams_chunk_and_reloads_with_aligned_offsets(monkeypatch, fp8):
     from nemo_rl.models.generation.trtllm import trtllm_backend as backend
     from nemo_rl.models.policy.utils import IPCProtocol
 
     extension, model_loader, engine = _ipc_extension(backend)
+    model = extension.engine.model_engine.model
+    model.model_config = SimpleNamespace(quant_config=object())
+    convert = MagicMock(side_effect=lambda weights: dict(weights))
 
     buffer = torch.zeros(1024, dtype=torch.uint8)
     monkeypatch.setattr(backend, "rebuild_cuda_tensor_from_ipc", lambda h, d: buffer)
     monkeypatch.setattr(backend.torch.cuda, "current_stream", lambda: MagicMock())
     monkeypatch.setattr(backend.torch.cuda, "empty_cache", lambda: None)
+    monkeypatch.setattr(backend.fp8_quantization, "is_fp8_model", lambda _: fp8)
+    monkeypatch.setattr(backend.fp8_quantization, "load_weights", convert)
 
     # One weight chunk carrying keys a,b (used_bytes == computed offset), then COMPLETE.
     extension.zmq_socket.recv_pyobj.side_effect = [
@@ -205,12 +266,56 @@ def test_ipc_zmq_streams_chunk_and_reloads_with_aligned_offsets(monkeypatch):
     assert weights["a"].shape == torch.Size([2])
     assert weights["b"].shape == torch.Size([3])
     assert kwargs["allow_partial_loading"] is True
+    assert convert.call_count == int(fp8)
     model_loader.begin_update_weights.assert_called_once_with()
     model_loader.finalize_update_weights.assert_called_once_with()
     model_loader.abort_update_weights.assert_not_called()
     engine.reset_prefix_cache.assert_called_once_with()
     # COMPLETE is ACKed after the final chunk.
     assert extension.zmq_socket.send.call_count == 2
+
+
+def test_ipc_zmq_detaches_mapper_staging_tensor_before_buffer_ack(monkeypatch):
+    from nemo_rl.models.generation.trtllm import trtllm_backend as backend
+    from nemo_rl.models.policy.utils import IPCProtocol
+
+    extension, model_loader, _ = _ipc_extension(backend)
+    model = extension.engine.model_engine.model
+    model.model_config = SimpleNamespace(quant_config=object())
+    qkv_name = "model.language_model.layers.0.linear_attn.in_proj_qkv.weight"
+    z_name = "model.language_model.layers.0.linear_attn.in_proj_z.weight"
+    extension.state_dict_info = {
+        qkv_name: (torch.Size([2]), torch.float32),
+        z_name: (torch.Size([2]), torch.float32),
+    }
+    buffer = torch.zeros(512, dtype=torch.uint8)
+    staged_weights = []
+
+    def retain_reload_input(_, weights, **__):
+        staged_weights.extend(weights.values())
+
+    def overwrite_after_ack(*_):
+        if extension.zmq_socket.send.call_count == 1:
+            buffer.fill_(0xFF)
+
+    model_loader.reload.side_effect = retain_reload_input
+    extension.zmq_socket.send.side_effect = overwrite_after_ack
+    extension.zmq_socket.recv_pyobj.side_effect = [
+        ("ipc_handle", [qkv_name], 512),
+        ("ipc_handle", [z_name], 512),
+        IPCProtocol.COMPLETE,
+    ]
+    monkeypatch.setattr(backend, "rebuild_cuda_tensor_from_ipc", lambda h, d: buffer)
+    monkeypatch.setattr(backend.torch.cuda, "current_stream", lambda: MagicMock())
+    monkeypatch.setattr(backend.torch.cuda, "empty_cache", lambda: None)
+    monkeypatch.setattr(backend.fp8_quantization, "is_fp8_model", lambda _: True)
+
+    assert extension.update_weights_via_ipc_zmq() is True
+
+    assert len(staged_weights) == 2
+    assert torch.equal(staged_weights[0], torch.zeros(2, dtype=torch.float32))
+    assert torch.isnan(staged_weights[1]).all()
+    assert extension.zmq_socket.send.call_count == 3
 
 
 def test_ipc_zmq_offset_mismatch_returns_false_without_reload(monkeypatch):

--- a/tests/unit/models/generation/trtllm/test_trtllm_backend.py
+++ b/tests/unit/models/generation/trtllm/test_trtllm_backend.py
@@ -84,14 +84,15 @@ def test_model_loader_lifecycle_hooks_are_optional(hook_name, is_available):
         hook.assert_not_called()
 
 
-def test_fp8_prepare_refit_info_requires_incremental_lifecycle(monkeypatch):
+def test_fp8_refit_hooks(monkeypatch):
     from nemo_rl.models.generation.trtllm import trtllm_backend as backend
 
     extension, _, model, _, _ = _extension(backend)
     model.model_config = SimpleNamespace(quant_config=object())
     extension.engine.model_engine.model_loader = SimpleNamespace()
     monkeypatch.setattr(backend.fp8_quantization, "is_fp8_model", lambda _: True)
-    with pytest.raises(RuntimeError, match="incremental-refit lifecycle"):
+    # A missing hook could leave only part of the model updated after a failure.
+    with pytest.raises(RuntimeError, match="weight-update hooks"):
         extension.prepare_refit_info(
             {
                 "model.layers.0.mlp.experts.gate_up_proj": (

--- a/tests/unit/models/generation/trtllm/test_trtllm_fp8.py
+++ b/tests/unit/models/generation/trtllm/test_trtllm_fp8.py
@@ -1,0 +1,223 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from nemo_rl.models.generation.trtllm.quantization.fp8 import (
+    FP8_BLOCK_QUANT_KWARGS,
+    cast_tensor_to_fp8_blockwise,
+    configure_fp8_llm_kwargs,
+    configure_fp8_moe_backend,
+    load_weights,
+    validate_qwen35_fused_expert_layout,
+)
+
+pytestmark = pytest.mark.trtllm
+
+
+def _block_matrix(values: list[list[float]]) -> torch.Tensor:
+    return torch.cat(
+        [
+            torch.cat(
+                [torch.full((128, 128), value) for value in row],
+                dim=1,
+            )
+            for row in values
+        ],
+        dim=0,
+    )
+
+
+def test_validate_qwen35_fused_expert_layout():
+    prefix = "model.layers.0.mlp.experts"
+    valid = {
+        f"{prefix}.gate_up_proj": (torch.Size([256, 1024, 2048]), torch.bfloat16),
+        f"{prefix}.down_proj": (torch.Size([256, 2048, 512]), torch.bfloat16),
+    }
+
+    validate_qwen35_fused_expert_layout(valid)
+
+    valid[f"{prefix}.gate_up_proj"] = (
+        torch.Size([256, 2048, 1024]),
+        torch.bfloat16,
+    )
+    with pytest.raises(ValueError, match=r"gate_up_proj=\[E,2I,H\]"):
+        validate_qwen35_fused_expert_layout(valid)
+
+
+def test_validate_qwen35_fused_expert_layout_requires_experts():
+    with pytest.raises(ValueError, match="No Qwen3.5 fused routed-expert weights"):
+        validate_qwen35_fused_expert_layout({})
+
+
+def test_configure_fp8_llm_kwargs_preserves_qwen35_model_overrides():
+    llm_kwargs = {
+        "dtype": "fp8",
+        "model_kwargs": {"pretrained_config": {"num_hidden_layers": 4}},
+    }
+
+    configure_fp8_llm_kwargs(llm_kwargs, model_type="qwen3_5_moe")
+
+    assert llm_kwargs["dtype"] == "bfloat16"
+    assert llm_kwargs["load_format"] == "dummy"
+    assert llm_kwargs["use_cute_dsl_blockscaling_mm"] is True
+    assert llm_kwargs["model_kwargs"]["pretrained_config"] == {"num_hidden_layers": 4}
+    assert llm_kwargs["model_kwargs"]["quantization_config"] == FP8_BLOCK_QUANT_KWARGS
+
+
+@pytest.mark.parametrize(
+    ("llm_kwargs", "model_type"),
+    [
+        ({"load_format": "auto"}, "qwen3_5_moe"),
+        (
+            {"model_kwargs": {"quantization_config": {"quant_method": "modelopt"}}},
+            "qwen3_5_moe",
+        ),
+        ({}, "qwen3_moe"),
+    ],
+)
+def test_configure_fp8_llm_kwargs_rejects_unsupported_contract(llm_kwargs, model_type):
+    with pytest.raises(ValueError, match="precision='fp8'"):
+        configure_fp8_llm_kwargs(llm_kwargs, model_type=model_type)
+
+
+class _MoeConfig:
+    def __init__(self, backend="AUTO", **kwargs) -> None:
+        self.backend = backend
+        self.kwargs = kwargs
+
+
+def test_configure_fp8_moe_backend_preserves_other_fields():
+    llm_kwargs = {
+        "moe_config": {
+            "backend": "trtllm",
+            "load_balancer_config": {"num_slots": 16},
+        }
+    }
+
+    configure_fp8_moe_backend(llm_kwargs, _MoeConfig)
+
+    assert isinstance(llm_kwargs["moe_config"], _MoeConfig)
+    assert llm_kwargs["moe_config"].backend == "TRTLLM"
+    assert llm_kwargs["moe_config"].kwargs == {
+        "load_balancer_config": {"num_slots": 16}
+    }
+
+
+@pytest.mark.parametrize(
+    "moe_config",
+    [
+        {"backend": "DEEPGEMM"},
+        _MoeConfig(backend="CUTLASS"),
+    ],
+)
+def test_configure_fp8_moe_backend_rejects_non_trtllm(moe_config):
+    with pytest.raises(ValueError, match="backend='TRTLLM'"):
+        configure_fp8_moe_backend({"moe_config": moe_config}, _MoeConfig)
+
+
+def test_block_fp8_scale_orientation_is_out_block_by_in_block():
+    source = _block_matrix([[1.0, 2.0], [3.0, 4.0]])
+
+    fp8_data, scale_inv = cast_tensor_to_fp8_blockwise(source)
+
+    assert fp8_data.dtype == torch.float8_e4m3fn
+    assert scale_inv.dtype == torch.float32
+    assert scale_inv.shape == (2, 2)
+    assert torch.equal(
+        scale_inv,
+        torch.tensor([[1.0, 2.0], [3.0, 4.0]]) / 448.0,
+    )
+    for row_block in range(2):
+        for column_block in range(2):
+            block = fp8_data[
+                row_block * 128 : (row_block + 1) * 128,
+                column_block * 128 : (column_block + 1) * 128,
+            ]
+            dequantized = block.float() * scale_inv[row_block, column_block]
+            assert torch.equal(
+                dequantized,
+                source[
+                    row_block * 128 : (row_block + 1) * 128,
+                    column_block * 128 : (column_block + 1) * 128,
+                ],
+            )
+
+
+def test_block_fp8_handles_batched_non_aligned_zero_weights():
+    source = torch.zeros((2, 130, 259), dtype=torch.bfloat16)
+
+    fp8_data, scale_inv = cast_tensor_to_fp8_blockwise(source)
+
+    assert fp8_data.shape == source.shape
+    assert scale_inv.shape == (2, 2, 3)
+    assert torch.count_nonzero(fp8_data.float()) == 0
+    assert torch.equal(scale_inv, torch.ones_like(scale_inv))
+
+
+def test_qwen35_only_routed_experts_become_hf_fp8_weights_and_scales():
+    prefix = "model.language_model.layers.3.mlp.experts"
+    gate = torch.stack([_block_matrix([[1.0, 2.0]]), _block_matrix([[3.0, 4.0]])])
+    up = torch.stack([_block_matrix([[5.0, 6.0]]), _block_matrix([[7.0, 8.0]])])
+    down = torch.stack(
+        [_block_matrix([[9.0], [10.0]]), _block_matrix([[11.0], [12.0]])]
+    )
+    gate_up = torch.cat((gate, up), dim=1).to(torch.bfloat16)
+    down = down.to(torch.bfloat16)
+    mtp_expert_name = "mtp.layers.0.mlp.experts.7.down_proj.weight"
+    mtp_expert = torch.randn(128, 128, dtype=torch.bfloat16)
+    passthrough = {
+        "model.layers.0.self_attn.q_proj.weight": torch.randn(128, 128),
+        "model.layers.0.linear_attn.in_proj_qkvz.weight": torch.randn(128, 128),
+        "model.layers.0.mlp.shared_expert.gate_proj.weight": torch.randn(128, 128),
+        "model.language_model.layers.3.mlp.gate.weight": torch.randn(2, 256),
+    }
+
+    converted = load_weights(
+        [
+            (f"{prefix}.gate_up_proj", gate_up),
+            (f"{prefix}.down_proj", down),
+            (mtp_expert_name, mtp_expert),
+            *passthrough.items(),
+        ]
+    )
+
+    assert f"{prefix}.gate_up_proj" not in converted
+    assert f"{prefix}.down_proj" not in converted
+
+    source_projections = {
+        "gate_proj": gate,
+        "up_proj": up,
+        "down_proj": down,
+    }
+    for expert_index in range(2):
+        for projection_name, source in source_projections.items():
+            weight_name = f"{prefix}.{expert_index}.{projection_name}.weight"
+            scale_name = weight_name.removesuffix(".weight") + ".weight_scale_inv"
+            expected_weight, expected_scale = cast_tensor_to_fp8_blockwise(
+                source[expert_index]
+            )
+            assert torch.equal(converted[weight_name].float(), expected_weight.float())
+            assert torch.equal(converted[scale_name], expected_scale)
+            assert converted[weight_name].dtype == torch.float8_e4m3fn
+            assert converted[scale_name].dtype == torch.float32
+    assert converted[mtp_expert_name].dtype == torch.float8_e4m3fn
+    assert (
+        converted["mtp.layers.0.mlp.experts.7.down_proj.weight_scale_inv"].dtype
+        == torch.float32
+    )
+    for name, tensor in passthrough.items():
+        assert converted[name] is tensor
+        assert name.removesuffix(".weight") + ".weight_scale_inv" not in converted

--- a/tests/unit/models/generation/trtllm/test_trtllm_fp8.py
+++ b/tests/unit/models/generation/trtllm/test_trtllm_fp8.py
@@ -21,7 +21,7 @@ from nemo_rl.models.generation.trtllm.quantization.fp8 import (
     configure_fp8_llm_kwargs,
     configure_fp8_moe_backend,
     load_weights,
-    validate_qwen35_fused_expert_layout,
+    validate_fused_expert_layout,
 )
 
 pytestmark = pytest.mark.trtllm
@@ -40,29 +40,29 @@ def _block_matrix(values: list[list[float]]) -> torch.Tensor:
     )
 
 
-def test_validate_qwen35_fused_expert_layout():
+def test_fused_expert_layout():
     prefix = "model.layers.0.mlp.experts"
     valid = {
         f"{prefix}.gate_up_proj": (torch.Size([256, 1024, 2048]), torch.bfloat16),
         f"{prefix}.down_proj": (torch.Size([256, 2048, 512]), torch.bfloat16),
     }
 
-    validate_qwen35_fused_expert_layout(valid)
+    validate_fused_expert_layout(valid)
 
     valid[f"{prefix}.gate_up_proj"] = (
         torch.Size([256, 2048, 1024]),
         torch.bfloat16,
     )
     with pytest.raises(ValueError, match=r"gate_up_proj=\[E,2I,H\]"):
-        validate_qwen35_fused_expert_layout(valid)
+        validate_fused_expert_layout(valid)
 
 
-def test_validate_qwen35_fused_expert_layout_requires_experts():
+def test_missing_expert_layout():
     with pytest.raises(ValueError, match="No Qwen3.5 fused routed-expert weights"):
-        validate_qwen35_fused_expert_layout({})
+        validate_fused_expert_layout({})
 
 
-def test_configure_fp8_llm_kwargs_preserves_qwen35_model_overrides():
+def test_fp8_config_preserves_overrides():
     llm_kwargs = {
         "dtype": "fp8",
         "model_kwargs": {"pretrained_config": {"num_hidden_layers": 4}},
@@ -167,7 +167,7 @@ def test_block_fp8_handles_batched_non_aligned_zero_weights():
     assert torch.equal(scale_inv, torch.ones_like(scale_inv))
 
 
-def test_qwen35_only_routed_experts_become_hf_fp8_weights_and_scales():
+def test_routed_expert_conversion():
     prefix = "model.language_model.layers.3.mlp.experts"
     gate = torch.stack([_block_matrix([[1.0, 2.0]]), _block_matrix([[3.0, 4.0]])])
     up = torch.stack([_block_matrix([[5.0, 6.0]]), _block_matrix([[7.0, 8.0]])])

--- a/tests/unit/models/generation/trtllm/test_trtllm_worker_async.py
+++ b/tests/unit/models/generation/trtllm/test_trtllm_worker_async.py
@@ -211,8 +211,11 @@ async def test_async_lifecycle_resets_cache_before_sleep_and_resumes_selected_ta
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("result", [[True], [], [False]])
-async def test_async_collective_refit_propagates_worker_result(result):
+@pytest.mark.parametrize(
+    "result",
+    [[True], [], [False], [True, False], [True, True]],
+)
+async def test_async_collective_refit_propagates_every_worker_result(result):
     worker = _worker()
     worker.llm.collective_rpc.return_value = result
 
@@ -221,7 +224,7 @@ async def test_async_collective_refit_propagates_worker_result(result):
         recompute_kv=True,
     )
 
-    assert succeeded is (result != [False])
+    assert succeeded is (bool(result) and all(result))
     worker.llm.collective_rpc.assert_awaited_once_with(
         "update_weights_from_collective",
         kwargs={"drain": False, "recompute_kv": True},
@@ -232,5 +235,14 @@ async def test_async_collective_refit_propagates_worker_result(result):
 async def test_async_ipc_refit_returns_false_on_worker_exception():
     worker = _worker()
     worker.llm.collective_rpc.side_effect = RuntimeError("refit failed")
+
+    assert await worker.update_weights_via_ipc_zmq_async() is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("result", [[], [True, False]])
+async def test_async_ipc_refit_checks_every_worker_result(result):
+    worker = _worker()
+    worker.llm.collective_rpc.return_value = result
 
     assert await worker.update_weights_via_ipc_zmq_async() is False


### PR DESCRIPTION
# What does this PR do ?

Enable Qwen3.5 MoE rollout workers to use routed-expert block-FP8 weights with TRT-LLM while policy training remains in BF16. This feature does not change optimizer-state precision.

During each BF16 trainer-to-generation refit, NeMo RL:

- Validates the fused Qwen3.5 expert layout: gate_up_proj=[E,2I,H] and down_proj=[E,H,I].

- Splits the fused expert tensors into the per-expert gate_proj, up_proj, and down_proj weights expected by the TRT-LLM Qwen3.5 mapper.

- Quantizes only routed-expert weights to E4M3 using 128x128 blocks and FP32 weight_scale_inv tensors.

- Keeps attention, routers, shared experts, embeddings, and the output head in BF16.

- Applies the conversion to both collective and IPC/ZMQ refit transports.

- Requires TRT-LLM's incremental-refit lifecycle and fails during setup when the required APIs are unavailable.

- Marks a worker unusable after a failed partial FP8 refit, preventing generation with mixed old and new weights.

- Checks the update result from every TRT-LLM worker instead of only the first worker.

- Delays async rollout collection until the initial FP8 refit is complete, without changing startup behavior for non-FP8 backends.

This implementation currently supports only Transformers models with model_type=qwen3_5_moe. It uses TRT-LLM's MoE backend to preserve FP32 block scales; MXFP8/E8M0 scaling is not used.

# Issues
None.


# Usage
* Enable Qwen3.5 routed-expert FP8 rollout refit with:

```python
policy:
  generation:
    backend: trtllm
    trtllm_cfg:
      precision: fp8
```
The source policy checkpoint is BF16. Direct loading of a pre-quantized ModelOpt FP8 checkpoint is outside the scope of this PR.

The installed TRT-LLM build must provide the Qwen3.5 mapper and incremental-refit lifecycle used by this path.

# How to test

Run the focused Qwen3.5 TRT-LLM FP8 refit unit test:

```python
uv run --group test pytest -q \
  tests/unit/models/generation/trtllm/test_trtllm_fp8.py
```

This test covers the fused expert layout, E4M3 block quantization and FP32 scales, routed-expert filtering, non-aligned shapes, and Qwen3.5-only configuration guards.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

**Additional Information**:

*Scope boundaries*:

- Qwen3.5 MoE only.

- Routed experts only; non-expert modules remain BF16.

- E4M3 128x128 block FP8 with FP32 scales, not MXFP8/E8M0.

- Direct ModelOpt FP8 checkpoint loading is not included.

- This PR does not add KV-cache recomputation semantics for in-flight weight updates.