### PR TITLE
chore: gitignore unit test result artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ actual_test_nemo_gym_sanity.json
 .nrl_remote_state.json
 # Test biproducts
 tests/functional/*/
+tests/unit/unit_results.json
+tests/unit/unit_results/
 
 # Cache
 uv_cache/


### PR DESCRIPTION
# What does this PR do ?

Adds `tests/unit/unit_results.json` and `tests/unit/unit_results/` to `.gitignore` so unit test runs don't leave untracked files behind.

# Issues

None filed — noticed while setting up a local dev environment.

# Usage

`tests/unit/conftest.py` writes both paths on every unit test run:

```python
UNIT_RESULTS_FILE = os.path.join(dir_path, "unit_results.json")
UNIT_RESULTS_FILE_DATED = os.path.join(
    dir_path, f"unit_results/{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
)
```

Neither is ignored, so any local run leaves them in `git status`:

```console
$ uv run pytest tests/unit/tools/test_config_cli.py
14 passed

$ git status --short
?? tests/unit/unit_results.json
?? tests/unit/unit_results/
```

After this change the files are still written as before, and `git status` stays clean.

The third artifact directory written by the same conftest — `tests/unit/test_assets` — is already covered by the `test_assets/` entry, so this just brings the other two in line. They're placed under the existing `# Test biproducts` section next to `tests/functional/*/`.

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? — n/a, `.gitignore`-only change
- [x] Did you run the unit tests and functional tests locally? — ran `tests/unit/tools/test_config_cli.py` before and after to confirm the artifacts are still written and no longer surface as untracked
- [x] Did you add or update any necessary documentation? — n/a

# Additional Information

* No behaviour change; nothing is added to or removed from what the test suite writes.
