### PR TITLE
feat(recipe): NT 3.5 Nano RLVR pipecleaning recipes

### DIFF
--- a/.github/workflows/config/.secrets.baseline
+++ b/.github/workflows/config/.secrets.baseline
@@ -197,6 +197,22 @@
         "line_number": 11
       }
     ],
+    "examples/nemo_gym/nemotron-3.5-nano/rlvr_dolphin.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "examples/nemo_gym/nemotron-3.5-nano/rlvr_dolphin.yaml",
+        "hashed_secret": "58c0a2526aed0c90b1e01d20c2ba40ea9f7add58",
+        "is_verified": false,
+        "line_number": 274
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "examples/nemo_gym/nemotron-3.5-nano/rlvr_dolphin.yaml",
+        "hashed_secret": "a43cf0c7e16b9e9832c73202830a65fda21d23c9",
+        "is_verified": false,
+        "line_number": 303
+      }
+    ],
     "tests/unit/test_version_check.py": [
       {
         "type": "Hex High Entropy String",
@@ -207,5 +223,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-15T20:07:55Z"
+  "generated_at": "2026-08-17T17:48:51Z"
 }

--- a/examples/nemo_gym/nemotron-3-ultra/launch_6k_pipeclean.sh
+++ b/examples/nemo_gym/nemotron-3-ultra/launch_6k_pipeclean.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# =============================================================================
+# launch_6k_pipeclean.sh
+#
+# Thin wrapper around ultra_launch.sh for the 6K-GPU (1536-node) Ultra
+# pipeclean recipe. Sets the validated node split and config path, then
+# forwards to the launcher.
+#
+# Shape (GB200 NVL72, 4 GPUs/node):
+#   NeMo RL: Training 512 / vLLM 960 / Gym 48
+#   External judges: GenRM 16 nodes / NL2Bash 2 nodes
+#
+# Usage — the site block below supplies model, data, container and Slurm
+# defaults for the GB200 cluster this recipe was validated on, so a bare
+# invocation works there:
+#
+#   WANDB_API_KEY=$WANDB_API_KEY \
+#   bash examples/nemo_gym/nemotron-3-ultra/launch_6k_pipeclean.sh
+#
+# On any other cluster, export the site variables yourself (they are all
+# ${VAR:-default} and every one of them wins over the default).
+#
+# Optional:
+#   NRL_MAX_STEPS=4              # short pipeclean
+#   WALLTIME=4:00:00
+#   CONTEXT_PARALLEL_SIZE=16     # default; raise only if CP=16 still OOMs
+#   DRY_RUN=1
+#   NUM_TRAIN_NODES / NUM_GEN_NODES / NUM_GYM_NODES  # override the 6K split
+#
+# Extra positional args are forwarded as Hydra overrides to ultra_launch.sh.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+# Default config — callers may still override CONFIG_PATH explicitly.
+export CONFIG_PATH="${CONFIG_PATH:-${SCRIPT_DIR}/pipeclean_6k.yaml}"
+
+# =============================================================================
+# Site defaults
+# =============================================================================
+# Paths on the GB200 cluster where this recipe was validated: the checkpoint,
+# blend and judges the 6K runs used, so a bare invocation reproduces them.
+# Export any of these to point elsewhere.
+# =============================================================================
+export MODEL_PATH="${MODEL_PATH:-/lustre/fsw/portfolios/llmservice/users/jiaqiz/models/ultra_stage2sft_step300}"
+export TRAIN_PATH="${TRAIN_PATH:-/lustre/fsw/portfolios/llmservice/users/jiaqiz/data/gym/rl-data-tools/blends/curriculum_v35_inescapable-sawfly.train.efforts0p15_qamathcode.jsonl}"
+# The reference runs validate on the training blend; there is no separate split.
+export VAL_PATH="${VAL_PATH:-${TRAIN_PATH}}"
+
+# Must carry vLLM 0.25.1 in the RL venvs to match this branch's code; a
+# pre-bump image fails at import with "cannot import name ServingTokenization".
+#
+# Striped copies — see the identical block in launch_6k_pipeclean_sc.sh for why
+# the upstream 8-OST images cause a pyxis read storm at ~1500 nodes.
+export CONTAINER="${CONTAINER:-/lustre/fsw/portfolios/llmservice/users/sauramishra/images-striped/nemo-rl-nightly-20260806-sandbox.squashfs}"
+export SANDBOX_CONTAINER="${SANDBOX_CONTAINER:-/lustre/fsw/portfolios/llmservice/users/sauramishra/images-striped/nemo-skills-sandbox-dc43f3e.sqsh}"
+export EXTRA_MOUNTS="${EXTRA_MOUNTS:-/lustre:/lustre}"
+export PERSISTENT_CACHE="${PERSISTENT_CACHE:-/lustre/fsw/portfolios/llmservice/users/${USER}/.cache/nemotron_ultra}"
+export HF_HOME="${HF_HOME:-/lustre/fsw/portfolios/llmservice/users/${USER}/hf_home}"
+
+export GENRM_MODEL="${GENRM_MODEL:-/lustre/fsw/portfolios/llmservice/users/ansubramania/models/qwen235b_principle_comparison_genrm_step1230}"
+export NL2BASH_JUDGE_MODEL="${NL2BASH_JUDGE_MODEL:-/lustre/fsw/portfolios/llmservice/users/ansubramania/models/Qwen3-235B-A22B-Instruct-2507-FP8}"
+export SAFETY_JUDGE_MODEL="${SAFETY_JUDGE_MODEL:-/lustre/fsw/portfolios/llmservice/users/ansubramania/super_v3/model_checkpoints/Nemotron-Content-Safety-Reasoning-4B}"
+
+# Serve the two large judge models outside the training Ray cluster. The pool
+# sizes and model-specific flags match their native-DP definitions in
+# pipeclean_6k.yaml; the safety judge remains inside Gym.
+export EXTERNAL_JUDGES="${EXTERNAL_JUDGES:-1}"
+export GENRM_REPLICAS="${GENRM_REPLICAS:-16}"
+export GENRM_TENSOR_PARALLEL_SIZE="${GENRM_TENSOR_PARALLEL_SIZE:-4}"
+export GENRM_REASONING_PARSER_NAME="${GENRM_REASONING_PARSER_NAME:-deepseek_r1}"
+export GENRM_ENABLE_EXPERT_PARALLEL="${GENRM_ENABLE_EXPERT_PARALLEL:-0}"
+export NL2BASH_REPLICAS="${NL2BASH_REPLICAS:-2}"
+export NL2BASH_TENSOR_PARALLEL_SIZE="${NL2BASH_TENSOR_PARALLEL_SIZE:-4}"
+export EXTERNAL_VLLM_SEGMENT_SIZE="${EXTERNAL_VLLM_SEGMENT_SIZE:-2}"
+export EXTERNAL_VLLM_SKIP_PREFLIGHT="${EXTERNAL_VLLM_SKIP_PREFLIGHT:-1}"
+
+export SLURM_ACCOUNT="${SLURM_ACCOUNT:-nemotron_sw_pre}"
+export SLURM_PARTITION="${SLURM_PARTITION:-batch}"
+# A 6K allocation may additionally need SLURM_QOS, SLURM_RESERVATION and
+# EXCLUDE_NODES. They are left unset because a reservation you do not hold
+# makes sbatch fail outright; see ultra_launch.sh for the variable names.
+
+# Gym is sized to its only GPU consumer. With GenRM and NL2Bash served from the
+# external hetgroup, that is the safety judge at TP=4 x DP=2: 8 GPUs, or 2 nodes.
+# Nothing else needs this pool to be larger — the nemo-skills sandbox runs on
+# every node in the allocation (ray.sub expects SLURM_JOB_NUM_NODES - 1 ready
+# instances), and Gym's resource servers are CPU-requesting Ray actors that
+# schedule wherever CPUs are free.
+#
+# Only the total is constrained: ultra_launch.sh requires train + gen + gym to be
+# a multiple of SEGMENT_SIZE=16, so generation takes the remainder. 1006 is even,
+# so it still divides into TP=8 instances (1006 x 4 GPUs / 8 = 503).
+export NUM_TRAIN_NODES="${NUM_TRAIN_NODES:-512}"
+export NUM_GEN_NODES="${NUM_GEN_NODES:-1006}"
+export NUM_GYM_NODES="${NUM_GYM_NODES:-2}"
+
+# CP=16 is baked into pipeclean_6k.yaml; allow an override for memory experiments.
+CONTEXT_PARALLEL_SIZE="${CONTEXT_PARALLEL_SIZE:-16}"
+
+# Sensible defaults for short 6K hero / pipeclean allocations when unset.
+export EXP_NAME="${EXP_NAME:-ultra-6k-pipeclean}"
+export WALLTIME="${WALLTIME:-4:00:00}"
+
+exec bash "${SCRIPT_DIR}/ultra_launch.sh" \
+  "policy.megatron_cfg.context_parallel_size=${CONTEXT_PARALLEL_SIZE}" \
+  "$@"

--- a/examples/nemo_gym/nemotron-3-ultra/launch_6k_pipeclean_sc.sh
+++ b/examples/nemo_gym/nemotron-3-ultra/launch_6k_pipeclean_sc.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# =============================================================================
+# launch_6k_pipeclean_sc.sh
+#
+# SingleController variant of launch_6k_pipeclean.sh: same 6K-GPU Ultra
+# pipeclean, driven by run_grpo_single_controller.py with streaming
+# forward/backward and the TransferQueue data plane.
+#
+# Shape (GB200 NVL72, 4 GPUs/node), unchanged from the legacy pipeclean so the
+# two are comparable:
+#   NeMo RL: Training 512 / vLLM 960 / Gym 48
+#   External judges: GenRM 16 nodes / NL2Bash 2 nodes
+#
+# Smaller-scale SC runs at a 4:1 generation-to-training ratio were still
+# generation-bound, spending 71-73% of the step in exposed_generation. If this
+# split starves, shift nodes with NUM_TRAIN_NODES / NUM_GEN_NODES /
+# NUM_GYM_NODES (the total must stay a multiple of SEGMENT_SIZE=16).
+#
+# NO CHECKPOINTING. The SC path raises if checkpointing.enabled is true, so the
+# run cannot resume across the wall clock and Slurm singleton buys nothing
+# here. Size NRL_MAX_STEPS to fit one allocation.
+#
+# Usage — the site block below supplies model, data, container and Slurm
+# defaults for the GB200 cluster this recipe was validated on, identical to
+# launch_6k_pipeclean.sh, so the two runs differ only in the SC wiring:
+#
+#   WANDB_API_KEY=$WANDB_API_KEY NRL_MAX_STEPS=10 \
+#   bash examples/nemo_gym/nemotron-3-ultra/launch_6k_pipeclean_sc.sh
+#
+# On any other cluster, export the site variables yourself (they are all
+# ${VAR:-default} and every one of them wins over the default).
+#
+# Optional:
+#   NRL_MAX_STEPS=4              # short pipeclean
+#   WALLTIME=4:00:00
+#   CONTEXT_PARALLEL_SIZE=16     # default; raise only if CP=16 still OOMs
+#   STREAM_MIN_GROUPS=256        # async_rl.min_groups_for_streaming_train
+#   NUM_STORAGE_UNITS=64         # data_plane.num_storage_units
+#   REFIT_TRANSPORT=null         # fall back to the full-tensor NCCL broadcast
+#   DRY_RUN=1
+#   NUM_TRAIN_NODES / NUM_GEN_NODES / NUM_GYM_NODES  # override the 6K split
+#
+# Extra positional args are forwarded as Hydra overrides to ultra_launch.sh.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+# Default config — callers may still override CONFIG_PATH explicitly.
+export CONFIG_PATH="${CONFIG_PATH:-${SCRIPT_DIR}/pipeclean_6k_sc.yaml}"
+
+# The SC driver. data_plane.enabled=true (set in the config) is mandatory for it.
+export TRAIN_ENTRYPOINT="${TRAIN_ENTRYPOINT:-./examples/run_grpo_single_controller.py}"
+
+# =============================================================================
+# Site defaults — identical to launch_6k_pipeclean.sh
+# =============================================================================
+# Kept byte-identical to the baseline wrapper on purpose: the SC comparison is
+# only meaningful if both runs read the same checkpoint, blend and judges.
+# =============================================================================
+export MODEL_PATH="${MODEL_PATH:-/lustre/fsw/portfolios/llmservice/users/jiaqiz/models/ultra_stage2sft_step300}"
+export TRAIN_PATH="${TRAIN_PATH:-/lustre/fsw/portfolios/llmservice/users/jiaqiz/data/gym/rl-data-tools/blends/curriculum_v35_inescapable-sawfly.train.efforts0p15_qamathcode.jsonl}"
+export VAL_PATH="${VAL_PATH:-${TRAIN_PATH}}"
+
+# Must carry vLLM 0.25.1 in the RL venvs to match this branch's code; a
+# pre-bump image fails at import with "cannot import name ServingTokenization".
+#
+# Both images are Lustre-striped copies (lfs setstripe -c -1 -S 16M, 350 OSTs)
+# of the upstream squashfs files. The originals sit on 8 OSTs, and ~1500 nodes
+# extracting an 87 GB image from 8 OSTs is a read storm: pyxis fails with
+# "failed to create container filesystem" / "could not wait for child:
+# Interrupted system call" in the thousands, and the job dies before the Ray
+# head comes up. Striping cut that to a handful of failures. Refresh the copies
+# when the upstream image changes:
+#   mkdir -p <dir> && lfs setstripe -c -1 -S 16M <dir> && cp <upstream> <dir>/
+# The sandbox copy pins the dc43f3e build that nemo-skills-sandbox-latest.sqsh
+# resolved to, so the sandbox version no longer drifts between runs.
+export CONTAINER="${CONTAINER:-/lustre/fsw/portfolios/llmservice/users/sauramishra/images-striped/nemo-rl-nightly-20260806-sandbox.squashfs}"
+export SANDBOX_CONTAINER="${SANDBOX_CONTAINER:-/lustre/fsw/portfolios/llmservice/users/sauramishra/images-striped/nemo-skills-sandbox-dc43f3e.sqsh}"
+export EXTRA_MOUNTS="${EXTRA_MOUNTS:-/lustre:/lustre}"
+export PERSISTENT_CACHE="${PERSISTENT_CACHE:-/lustre/fsw/portfolios/llmservice/users/${USER}/.cache/nemotron_ultra}"
+export HF_HOME="${HF_HOME:-/lustre/fsw/portfolios/llmservice/users/${USER}/hf_home}"
+
+export GENRM_MODEL="${GENRM_MODEL:-/lustre/fsw/portfolios/llmservice/users/ansubramania/models/qwen235b_principle_comparison_genrm_step1230}"
+export NL2BASH_JUDGE_MODEL="${NL2BASH_JUDGE_MODEL:-/lustre/fsw/portfolios/llmservice/users/ansubramania/models/Qwen3-235B-A22B-Instruct-2507-FP8}"
+export SAFETY_JUDGE_MODEL="${SAFETY_JUDGE_MODEL:-/lustre/fsw/portfolios/llmservice/users/ansubramania/super_v3/model_checkpoints/Nemotron-Content-Safety-Reasoning-4B}"
+
+# Keep judge deployment identical to launch_6k_pipeclean.sh so the comparison
+# isolates the SingleController path.
+export EXTERNAL_JUDGES="${EXTERNAL_JUDGES:-1}"
+export GENRM_REPLICAS="${GENRM_REPLICAS:-16}"
+export GENRM_TENSOR_PARALLEL_SIZE="${GENRM_TENSOR_PARALLEL_SIZE:-4}"
+export GENRM_REASONING_PARSER_NAME="${GENRM_REASONING_PARSER_NAME:-deepseek_r1}"
+export GENRM_ENABLE_EXPERT_PARALLEL="${GENRM_ENABLE_EXPERT_PARALLEL:-0}"
+export NL2BASH_REPLICAS="${NL2BASH_REPLICAS:-2}"
+export NL2BASH_TENSOR_PARALLEL_SIZE="${NL2BASH_TENSOR_PARALLEL_SIZE:-4}"
+export EXTERNAL_VLLM_SEGMENT_SIZE="${EXTERNAL_VLLM_SEGMENT_SIZE:-2}"
+export EXTERNAL_VLLM_SKIP_PREFLIGHT="${EXTERNAL_VLLM_SKIP_PREFLIGHT:-1}"
+
+export SLURM_ACCOUNT="${SLURM_ACCOUNT:-nemotron_sw_pre}"
+export SLURM_PARTITION="${SLURM_PARTITION:-batch}"
+# A 6K allocation may additionally need SLURM_QOS, SLURM_RESERVATION and
+# EXCLUDE_NODES; see launch_6k_pipeclean.sh.
+
+# 6K node split, identical to the legacy pipeclean. Callers may override.
+export NUM_TRAIN_NODES="${NUM_TRAIN_NODES:-512}"
+export NUM_GEN_NODES="${NUM_GEN_NODES:-960}"
+export NUM_GYM_NODES="${NUM_GYM_NODES:-48}"
+
+# CP=16 is baked into pipeclean_6k.yaml; allow an override for memory experiments.
+CONTEXT_PARALLEL_SIZE="${CONTEXT_PARALLEL_SIZE:-16}"
+
+# The two SC knobs worth sweeping without editing the config. Lowering
+# STREAM_MIN_GROUPS starts the optimizer step earlier on partial cohorts;
+# NUM_STORAGE_UNITS is the untuned one at this data volume.
+STREAM_MIN_GROUPS="${STREAM_MIN_GROUPS:-256}"
+NUM_STORAGE_UNITS="${NUM_STORAGE_UNITS:-64}"
+
+# Shard-to-shard weight refit, on by default in this variant. It is still
+# experimental, so keep the escape hatch one env var away: REFIT_TRANSPORT=null
+# restores the full-tensor broadcast that pipeclean_6k.yaml uses.
+REFIT_TRANSPORT="${REFIT_TRANSPORT:-nccl_reshard}"
+
+# Sensible defaults for short 6K hero / pipeclean allocations when unset.
+export EXP_NAME="${EXP_NAME:-ultra-6k-pipeclean-sc}"
+export WALLTIME="${WALLTIME:-4:00:00}"
+
+exec bash "${SCRIPT_DIR}/ultra_launch.sh" \
+  "policy.megatron_cfg.context_parallel_size=${CONTEXT_PARALLEL_SIZE}" \
+  "async_rl.min_groups_for_streaming_train=${STREAM_MIN_GROUPS}" \
+  "data_plane.num_storage_units=${NUM_STORAGE_UNITS}" \
+  "policy.generation.refit_transport=${REFIT_TRANSPORT}" \
+  "$@"

--- a/examples/nemo_gym/nemotron-3-ultra/launch_6k_pipeclean_sc_smoke.sh
+++ b/examples/nemo_gym/nemotron-3-ultra/launch_6k_pipeclean_sc_smoke.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# SingleController counterpart to launch_6k_pipeclean_smoke.sh. It uses the
+# same 64-node topology and 512-sample cohort so the two execution paths remain
+# directly comparable. SC-specific queue and streaming sizes are reduced to the
+# 32-prompt cohort while retaining the production lookahead of four versions.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+export NUM_TRAIN_NODES="${NUM_TRAIN_NODES:-32}"
+export NUM_GEN_NODES="${NUM_GEN_NODES:-14}"
+export NUM_GYM_NODES="${NUM_GYM_NODES:-2}"
+export SEGMENT_SIZE="${SEGMENT_SIZE:-16}"
+export GPUS_PER_NODE="${GPUS_PER_NODE:-4}"
+
+# Keep production TP sizes while fitting the external pool into 16 nodes.
+export EXTERNAL_JUDGES=1
+export GENRM_REPLICAS=14
+export GENRM_TENSOR_PARALLEL_SIZE=4
+export NL2BASH_REPLICAS=2
+export NL2BASH_TENSOR_PARALLEL_SIZE=4
+export EXTERNAL_VLLM_SEGMENT_SIZE=2
+
+NUM_PROMPTS_PER_STEP="${NUM_PROMPTS_PER_STEP:-32}"
+TRAIN_GLOBAL_BATCH_SIZE="${TRAIN_GLOBAL_BATCH_SIZE:-$((NUM_PROMPTS_PER_STEP * 16))}"
+MAX_TOTAL_SEQUENCE_LENGTH="${MAX_TOTAL_SEQUENCE_LENGTH:-49152}"
+MAX_LOOKAHEAD_VERSIONS=4
+SMOKE_BUFFER_CAPACITY=$((NUM_PROMPTS_PER_STEP * (MAX_LOOKAHEAD_VERSIONS + 1)))
+
+# The smaller validated SC profile began training at one quarter of the cohort.
+export STREAM_MIN_GROUPS="${STREAM_MIN_GROUPS:-$((NUM_PROMPTS_PER_STEP / 4))}"
+export NUM_STORAGE_UNITS="${NUM_STORAGE_UNITS:-2}"
+
+export EXP_NAME="${EXP_NAME:-ultra-6k-pipeclean-sc-external-judges-smoke-py31314}"
+export NRL_MAX_STEPS="${NRL_MAX_STEPS:-2}"
+export WALLTIME="${WALLTIME:-2:00:00}"
+export SLURM_ACCOUNT="${SLURM_ACCOUNT:-nemotron_sw_post}"
+export SLURM_PARTITION="${SLURM_PARTITION:-batch}"
+export SLURM_QOS="${SLURM_QOS:-short}"
+export USE_SNAPSHOT="${USE_SNAPSHOT:-0}"
+
+echo "Ultra 6K SingleController external-judge smoke profile"
+echo "  hetgroup 0: train=${NUM_TRAIN_NODES}, generation=${NUM_GEN_NODES}, Gym=${NUM_GYM_NODES}"
+echo "  hetgroup 1: GenRM=${GENRM_REPLICAS}xTP${GENRM_TENSOR_PARALLEL_SIZE}, NL2Bash=${NL2BASH_REPLICAS}xTP${NL2BASH_TENSOR_PARALLEL_SIZE}"
+echo "  batch: prompts=${NUM_PROMPTS_PER_STEP}, generations=16, global=${TRAIN_GLOBAL_BATCH_SIZE}"
+echo "  max sequence length: ${MAX_TOTAL_SEQUENCE_LENGTH}"
+echo "  SC: stream_min_groups=${STREAM_MIN_GROUPS}, buffer_capacity=${SMOKE_BUFFER_CAPACITY}, storage_units=${NUM_STORAGE_UNITS}"
+
+exec bash "${SCRIPT_DIR}/launch_6k_pipeclean_sc.sh" \
+  "grpo.num_prompts_per_step=${NUM_PROMPTS_PER_STEP}" \
+  "policy.train_global_batch_size=${TRAIN_GLOBAL_BATCH_SIZE}" \
+  "policy.max_total_sequence_length=${MAX_TOTAL_SEQUENCE_LENGTH}" \
+  "policy.generation.max_new_tokens=${MAX_TOTAL_SEQUENCE_LENGTH}" \
+  "policy.generation.vllm_cfg.max_model_len=${MAX_TOTAL_SEQUENCE_LENGTH}" \
+  "async_rl.max_inflight_prompts=${SMOKE_BUFFER_CAPACITY}" \
+  "async_rl.max_buffered_rollouts=${SMOKE_BUFFER_CAPACITY}" \
+  "$@"

--- a/examples/nemo_gym/nemotron-3-ultra/launch_6k_pipeclean_smoke.sh
+++ b/examples/nemo_gym/nemotron-3-ultra/launch_6k_pipeclean_smoke.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Smaller-scale validation wrapper for launch_6k_pipeclean.sh.
+#
+# It preserves the production model and external judge deployment while
+# reducing policy training, generation, Gym, batch size, and sequence length:
+#
+#   Hetgroup 0: 32 training + 14 generation + 2 Gym = 48 nodes (segment 16)
+#   Hetgroup 1: 14 GenRM + 2 NL2Bash = 16 nodes (segment 2)
+#   Batch:      32 prompts x 16 generations = 512 samples
+#   Sequence:   49,152 tokens
+#   Total:      64 nodes / 256 GPUs
+#
+# The safety judge remains in Gym. The 16-node training segments match the
+# HybridEP assumption of 64 ranks per NVLink domain. The external pool keeps
+# the production TP sizes but uses two fewer GenRM replicas to stay at 64 nodes.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+export NUM_TRAIN_NODES="${NUM_TRAIN_NODES:-32}"
+export NUM_GEN_NODES="${NUM_GEN_NODES:-14}"
+export NUM_GYM_NODES="${NUM_GYM_NODES:-2}"
+export SEGMENT_SIZE="${SEGMENT_SIZE:-16}"
+export GPUS_PER_NODE="${GPUS_PER_NODE:-4}"
+
+# Keep production TP sizes while fitting the external pool into 16 nodes.
+export EXTERNAL_JUDGES=1
+export GENRM_REPLICAS=14
+export GENRM_TENSOR_PARALLEL_SIZE=4
+export NL2BASH_REPLICAS=2
+export NL2BASH_TENSOR_PARALLEL_SIZE=4
+export EXTERNAL_VLLM_SEGMENT_SIZE=2
+
+NUM_PROMPTS_PER_STEP="${NUM_PROMPTS_PER_STEP:-32}"
+TRAIN_GLOBAL_BATCH_SIZE="${TRAIN_GLOBAL_BATCH_SIZE:-$((NUM_PROMPTS_PER_STEP * 16))}"
+MAX_TOTAL_SEQUENCE_LENGTH="${MAX_TOTAL_SEQUENCE_LENGTH:-49152}"
+
+export EXP_NAME="${EXP_NAME:-ultra-6k-pipeclean-external-judges-smoke-py31314}"
+export NRL_MAX_STEPS="${NRL_MAX_STEPS:-2}"
+export WALLTIME="${WALLTIME:-2:00:00}"
+export SLURM_ACCOUNT="${SLURM_ACCOUNT:-nemotron_sw_post}"
+export SLURM_PARTITION="${SLURM_PARTITION:-batch}"
+export SLURM_QOS="${SLURM_QOS:-short}"
+export USE_SNAPSHOT="${USE_SNAPSHOT:-0}"
+
+echo "Ultra 6K pipeclean external-judge smoke profile"
+echo "  hetgroup 0: train=${NUM_TRAIN_NODES}, generation=${NUM_GEN_NODES}, Gym=${NUM_GYM_NODES}"
+echo "  hetgroup 1: GenRM=${GENRM_REPLICAS}xTP${GENRM_TENSOR_PARALLEL_SIZE}, NL2Bash=${NL2BASH_REPLICAS}xTP${NL2BASH_TENSOR_PARALLEL_SIZE}"
+echo "  batch: prompts=${NUM_PROMPTS_PER_STEP}, generations=16, global=${TRAIN_GLOBAL_BATCH_SIZE}"
+echo "  max sequence length: ${MAX_TOTAL_SEQUENCE_LENGTH}"
+
+exec bash "${SCRIPT_DIR}/launch_6k_pipeclean.sh" \
+  "grpo.num_prompts_per_step=${NUM_PROMPTS_PER_STEP}" \
+  "policy.train_global_batch_size=${TRAIN_GLOBAL_BATCH_SIZE}" \
+  "policy.max_total_sequence_length=${MAX_TOTAL_SEQUENCE_LENGTH}" \
+  "policy.generation.max_new_tokens=${MAX_TOTAL_SEQUENCE_LENGTH}" \
+  "policy.generation.vllm_cfg.max_model_len=${MAX_TOTAL_SEQUENCE_LENGTH}" \
+  "$@"

--- a/examples/nemo_gym/nemotron-3-ultra/pipeclean_6k.yaml
+++ b/examples/nemo_gym/nemotron-3-ultra/pipeclean_6k.yaml
@@ -1,0 +1,736 @@
+# =============================================================================
+# Nemotron 3 Ultra — 6K-GPU pipeclean (1536 nodes × 4 GPUs, 128K context)
+# =============================================================================
+# Scale validation / pipeclean recipe for GRPO on 1536 GB200 NVL72 nodes
+# (6144 GPUs), on the Ultra YAML schema used by `ultra_launch.sh`.
+#
+# Cluster shape (1536 nodes × 4 GPUs = 6144 GPUs):
+#   Training 512 / vLLM 960 / Gym 64. Override via NUM_TRAIN_NODES, etc.
+#   Ratio (~33% train / ~63% gen / ~4% gym) is carried over from the validated
+#   768-node shape.
+#
+# Training parallelism: TP=8, EP=64, CP=16, PP=1, SP=true.
+#   CP=16 (vs CP=8 on the 256n Student RLVR stages) is required at 128K
+#   context so each CP rank sees 8192 tokens; CP=8 OOM'd the train step at
+#   this scale.
+# Global batch: 16384 (1024 prompts × 16 generations).
+# Sequence length: 131072 (128K).
+#
+# vLLM parallelism: TP=8, EP=8 (EP=TP keeps vllm_dp_size=1; EP>TP is blocked
+# by https://github.com/NVIDIA-NeMo/RL/issues/1101).
+#
+# Launch with examples/nemo_gym/nemotron-3-ultra/launch_6k_pipeclean.sh (sets
+# the 1536n node split) or call ultra_launch.sh with NUM_TRAIN_NODES=512
+# NUM_GEN_NODES=960 NUM_GYM_NODES=64.
+# =============================================================================
+
+# =============================================================================
+# Cluster — read by ultra_launch.sh to size the SLURM allocation
+# =============================================================================
+cluster:
+  gpus_per_node: 4
+  num_nodes: 1536
+  segment_size: 16
+
+# =============================================================================
+# Checkpointing — checkpoint_dir is overridden by the launcher
+# =============================================================================
+checkpointing:
+  enabled: true
+  checkpoint_dir: "results/ultra_6k_pipeclean"
+  metric_name: "val:total_reward/mean"
+  higher_is_better: true
+  keep_top_k: 10
+  save_period: 10
+  ft_keep_latest_k: 1
+  ft_save_period: 1
+  # Short hero / pipeclean walltimes — leave headroom for a final save.
+  checkpoint_must_save_by: "00:03:30:00"
+  model_save_format: "safetensors"
+  save_consolidated: false
+  save_optimizer: true
+
+# =============================================================================
+# GRPO Algorithm
+# =============================================================================
+grpo:
+  num_prompts_per_step: 1024
+  num_generations_per_prompt: 16
+  val_num_generations_per_prompt: 2
+  max_rollout_turns: 1
+  max_num_epochs: 1
+  max_num_steps: 1000000
+  normalize_rewards: true
+  use_leave_one_out_baseline: true
+  advantage_clip_low: -50
+  advantage_clip_high: 50
+  # Pipeclean focuses on train-step stability; skip periodic validation.
+  val_period: -1
+  val_start_at: -1
+  val_at_start: false
+  val_at_end: false
+  overlong_filtering: false
+  max_val_samples: null
+  # Early stop once this metric (e.g. accuracy or pass_k) reaches the threshold; null disables.
+  stop_at_validation_metric: null
+  # Required when stop_at_validation_metric is set.
+  stop_at_validation_threshold: null
+  val_batch_size: 256
+  seed: 42
+
+  use_dynamic_sampling: false
+  dynamic_sampling_max_gen_batches: 10
+  batch_multiplier: 1
+
+  penalize_invalid_tool_call: true
+  invalid_tool_call_advantage: -5.0
+
+  reward_shaping:
+    enabled: false
+    overlong_buffer_length: 128
+    overlong_buffer_penalty: 1
+    max_response_length: ${policy.max_total_sequence_length}
+    stop_properly_penalty_coef: null
+  reward_scaling:
+    enabled: false
+    source_min: 0.0
+    source_max: 1.0
+    target_min: 0.0
+    target_max: 1.0
+
+  async_grpo:
+    enabled: true
+    max_trajectory_age_steps: 1
+    in_flight_weight_updates: true
+    recompute_kv_cache_after_weight_updates: false
+
+  use_best_at_k: false
+  best_at_k_k: 8
+  best_at_k_m: 1000
+
+  use_combined_training: false
+  combined_training_weight_mode: "auto"
+  combined_training_best_at_k_weight: 0.2
+  combined_training_pass_at_1_weight: 1.0
+
+  dynamic_sampling_oversample_ratio: 1.0
+  seq_logprob_error_threshold: 2
+
+# =============================================================================
+# Loss Function
+# =============================================================================
+loss_fn:
+  reference_policy_kl_penalty: 0.0
+  reference_policy_kl_type: "k3"
+  kl_input_clamp_value: null
+  kl_output_clamp_value: null
+
+  ratio_clip_min: 0.2
+  ratio_clip_max: 0.28
+  ratio_clip_c: null
+  use_on_policy_kl_approximation: true
+  use_importance_sampling_correction: true
+  truncated_importance_sampling_ratio: 5
+  truncated_importance_sampling_ratio_min: 0.2
+  truncated_importance_sampling_type: tis
+  sequence_level_importance_ratios: false
+  token_level_loss: true
+  force_on_policy_ratio: true
+  use_kl_in_reward: false
+
+# =============================================================================
+# Policy — model_name is overridden by the launcher (MODEL_PATH env var)
+# =============================================================================
+policy:
+  model_name: null
+  tokenizer:
+    name: ${policy.model_name}
+    chat_template_kwargs: null
+  hf_config_overrides: {}
+
+  train_global_batch_size: 16384
+  train_micro_batch_size: 1
+  generation_batch_size: 64
+  logprob_batch_size: 1
+  max_total_sequence_length: 131072
+  precision: "bfloat16"
+  logprob_chunk_size: 2048
+  offload_optimizer_for_logprob: false
+
+  dtensor_cfg:
+    _v2: true
+    enabled: false
+    cpu_offload: false
+    sequence_parallel: false
+    activation_checkpointing: false
+    tensor_parallel_size: 1
+    context_parallel_size: 1
+    custom_parallel_plan: null
+
+  megatron_cfg:
+    enabled: true
+    empty_unused_memory_level: 2
+    activation_checkpointing: true
+
+    # TP=8 spans 2 GB200 nodes (4 GPUs each) via intra-rack NVLink.
+    tensor_model_parallel_size: 8
+    expert_tensor_parallel_size: 1
+    # EP=64: 512 experts / 64 = 8 experts per EP rank
+    # All-to-all spans 64 GPUs (16 nodes), fits within one NVLink domain
+    expert_model_parallel_size: 64
+    pipeline_model_parallel_size: 1
+    num_layers_in_first_pipeline_stage: null
+    num_layers_in_last_pipeline_stage: null
+    # CP=16 required at 128K / 6K-GPU scale (CP=8 OOM'd the train step).
+    context_parallel_size: 16
+    pipeline_dtype: ${policy.precision}
+    sequence_parallel: true
+
+    # MoE
+    freeze_moe_router: true
+    moe_router_dtype: "fp32"
+    moe_router_load_balancing_type: "none"
+    moe_router_bias_update_rate: 1.0e-3
+    moe_router_enable_expert_bias: true
+    moe_permute_fusion: true
+    moe_enable_deepep: false
+    moe_token_dispatcher_type: "flex"
+    moe_flex_dispatcher_backend: "hybridep"
+    moe_hybridep_num_sms: 32
+    moe_aux_loss_coeff: 0.0
+    moe_shared_expert_overlap: false
+
+    # Compute
+    apply_rope_fusion: true
+    use_fused_weighted_squared_relu: true
+    bias_activation_fusion: false
+    gradient_accumulation_fusion: false
+    defer_fp32_logits: true
+
+    # Logging
+    track_moe_metrics: true
+    moe_per_layer_logging: true
+    do_not_average_loss: true
+    cp_normalize: true
+    calculate_per_token_loss: true
+    scale_loss_by_dp_cp_size: false
+
+    # MTP — disabled by default; enable via ENABLE_MTP_INFERENCE=1 in the launcher
+    mtp_loss_scaling_factor: 0.3
+    mtp_use_repeated_layer: true
+    mtp_num_layers: 5
+    mtp_detach_heads: true
+
+    optimizer:
+      optimizer: "adam"
+      lr: 4.0e-6
+      min_lr: 4.0e-6
+      weight_decay: 0.0
+      bf16: true
+      fp16: false
+      params_dtype: "float32"
+
+      adam_beta1: 0.9
+      adam_beta2: 0.999
+      adam_eps: 1e-8
+
+      sgd_momentum: 0.9
+
+      use_distributed_optimizer: true
+      use_precision_aware_optimizer: true
+
+      clip_grad: ${policy.max_grad_norm}
+
+      optimizer_cpu_offload: false
+      optimizer_offload_fraction: 0.0
+
+    scheduler:
+      start_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
+      end_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
+      weight_decay_incr_style: "constant"
+      lr_decay_style: "constant"
+      lr_decay_iters: null
+      lr_warmup_iters: 10
+      lr_warmup_init: 4e-7
+      override_opt_param_scheduler: true
+
+    distributed_data_parallel_config:
+      grad_reduce_in_fp32: false
+      overlap_grad_reduce: false
+      overlap_param_gather: true
+      average_in_collective: false
+      use_custom_fsdp: false
+      data_parallel_sharding_strategy: "optim_grads_params"
+
+    fp8_cfg:
+      enabled: false
+      fp8: "e4m3"
+      fp8_recipe: "mxfp8"
+      fp8_param: false
+
+    first_last_layers_bf16: true
+    num_layers_at_start_in_bf16: 1
+    num_layers_at_end_in_bf16: 1
+
+    use_gloo_process_groups: false
+
+    checkpoint:
+      async_save: true
+      ckpt_assume_constant_structure: true
+      fully_parallel_save_process_group: "ep_dp"
+      fully_parallel_load_process_group: "ep_dp"
+      fully_parallel_load_exchange_algo: "broadcast"
+
+    env_vars: null
+
+  # ---------------------------------------------------------------------------
+  # Sequence Packing
+  # ---------------------------------------------------------------------------
+  dynamic_batching:
+    enabled: false
+    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
+    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
+    sequence_length_round: 64
+
+  sequence_packing:
+    enabled: true
+    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
+    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
+    algorithm: "modified_first_fit_decreasing"
+    sequence_length_round: 64
+    fuse_loss: true
+
+  make_sequence_length_divisible_by: ${mul:${policy.megatron_cfg.context_parallel_size}, ${mul:2, ${policy.megatron_cfg.tensor_model_parallel_size}}}
+  max_grad_norm: 1.0
+  optimizer: null
+  scheduler: null
+
+  # ---------------------------------------------------------------------------
+  # Generation (vLLM) — Non-colocated, async
+  # ---------------------------------------------------------------------------
+  generation:
+    port_range_low: 3000
+    port_range_high: 4999
+    backend: "vllm"
+    max_new_tokens: 131072
+    temperature: 1.0
+    top_p: 1.0
+    top_k: null
+    stop_token_ids: null
+    stop_strings: null
+    # TP=8 EP=8: EP=TP so vllm_dp_size=1, async_engine=true works with NeMo Gym.
+    # Same memory as EP=1 but uses all-to-all for expert routing.
+    # EP > TP blocked by https://github.com/NVIDIA-NeMo/RL/issues/1101.
+    vllm_cfg:
+      async_engine: true
+      precision: ${policy.precision}
+      kv_cache_dtype: "auto"
+      tensor_parallel_size: 8
+      pipeline_parallel_size: 1
+      expert_parallel_size: 8
+      # Leave enough headroom for the temporary packed buffer used during
+      # Megatron-to-vLLM weight refits.
+      gpu_memory_utilization: 0.85
+      max_model_len: 131072
+      enforce_eager: false
+      use_deep_gemm: false
+      num_last_layers_in_bf16: 0
+      num_first_layers_in_bf16: 0
+      enable_vllm_metrics_logger: true
+      vllm_metrics_logger_interval: 0.5
+      expose_http_server: true
+      skip_tokenizer_init: false
+      # Absolute container path: vLLM resolves this in the generation worker,
+      # a Ray actor whose CWD is the (unmounted) submit dir, not the code root.
+      # ultra_launch.sh overlays nemo_rl onto /opt/nemo-rl/nemo_rl.
+      reasoning_parser_plugin: /opt/nemo-rl/nemo_rl/models/generation/vllm/reasoning_parsers/nano_v3_reasoning_parser.py
+      http_server_serving_chat_kwargs:
+        enable_auto_tools: true
+        tool_parser: qwen3_coder
+        reasoning_parser: nano_v3
+
+    vllm_kwargs:
+      attention_backend: FLASH_ATTN
+      mamba_ssm_cache_dtype: "float32"
+      # Hybrid Mamba: one state slot per running seq; the vLLM default (1024) can
+      # exceed available slots. 256 matches the Ultra GB200 serving reference
+      # (Gym nemotron_3_ultra_dev_nemorl_gb200.yaml).
+      max_num_seqs: 256
+      # Pinned because the refit path cannot address the default backend's
+      # layout against a 0.25 container. Left at the default "auto", 0.25 picks
+      # the FlashInfer TRT-LLM BF16 MoE, whose expert weights are 3D grouped
+      # tensors under the new routed_experts submodule. Refit then hands them to
+      # a loader that rejects the expert dimension, failing with "shard_dim=0 is
+      # not a valid data dimension for a 3D tensor (expected 1 or 2)".
+      # flashinfer_cutlass keeps the layout refit can address.
+      moe_backend: flashinfer_cutlass
+      compilation_config:
+        cudagraph_capture_sizes: [1,2,4,8,16,32,64]
+        cudagraph_mode: PIECEWISE
+        pass_config:
+          fuse_allreduce_rms: false
+
+    colocated:
+      enabled: false
+      resources:
+        gpus_per_node: 4
+        num_nodes: 960   # Overridden by launch script via NUM_GEN_NODES
+
+# =============================================================================
+# Data — data_path is overridden by the launcher (TRAIN_PATH / VAL_PATH)
+# =============================================================================
+data:
+  max_input_seq_length: null
+  shuffle: false
+  num_workers: 1
+  use_multiple_dataloader: false
+  train:
+    data_path: null
+  validation:
+    data_path: null
+  default:
+    dataset_name: NemoGymDataset
+    env_name: "nemo_gym"
+    prompt_file: null
+    system_prompt_file: null
+    processor: "nemo_gym_data_processor"
+
+# =============================================================================
+# Environment — NeMo Gym + Judge Models
+#
+# Judge model paths and external service URLs are set by the launcher:
+#   - genrm_model.model/base_url      ← GENRM_MODEL / GENRM_BASE_URL
+#   - nl2bash_judge_model.model       ← NL2BASH_JUDGE_MODEL
+#   - nl2bash_judge_model.base_url    ← NL2BASH_BASE_URL
+#   - safety_judge_model.model        ← SAFETY_JUDGE_MODEL
+# =============================================================================
+env:
+  should_use_nemo_gym: true
+  should_log_nemo_gym_responses: true
+  nemo_gym:
+    nemo_gym_log_dir: "logs/nemo_gym"
+    skip_venv_if_present: true
+    num_gpu_nodes: 64
+    # NeMo-RL-side effort shaping; stripped before forwarding to Gym.
+    effort_levels:
+      low_string: "{reasoning effort: efficient}"
+      low_weight: 0.1
+      low_penalty: 1
+      low_ub: 15000
+    port_range_low: 5000
+    port_range_high: 5999
+    invalid_tool_call_patterns:
+      - "<tool_call>"
+      - "</tool_call>"
+      - "<function_call>"
+      - "</function_call>"
+    thinking_tags:
+      - "<think>"
+      - "</think>"
+    config_paths:
+      - responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
+      - resources_servers/math_with_judge/configs/math_with_judge.yaml
+      - resources_servers/code_gen/configs/code_gen.yaml
+      - resources_servers/workplace_assistant/configs/workplace_assistant.yaml
+      - resources_servers/mcqa/configs/mcqa.yaml
+      - resources_servers/instruction_following/configs/instruction_following.yaml
+      - resources_servers/equivalence_llm_judge/configs/lc_judge.yaml
+      - resources_servers/calendar/configs/calendar.yaml
+      - resources_servers/genrm_compare/configs/genrm_compare.yaml
+      - resources_servers/equivalence_llm_judge/configs/nl2bash-equivalency.yaml
+      - resources_servers/equivalence_llm_judge/configs/equivalence_llm_judge.yaml
+      - resources_servers/single_step_tool_use_with_argument_comparison/configs/single_step_tool_use_with_argument_comparison.yaml
+      - resources_servers/reasoning_gym/configs/reasoning_gym.yaml
+      - resources_servers/terminus_judge/configs/terminus_judge_string_only.yaml
+      - resources_servers/ns_tools/configs/ns_tools.yaml
+      - resources_servers/math_formal_lean/configs/math_formal_lean_multi_turn.yaml
+      - resources_servers/multichallenge/configs/multichallenge.yaml
+      - resources_servers/inverse_if/configs/inverse_if.yaml
+      - resources_servers/single_step_tool_use_with_argument_comparison/configs/search_pivot_single_step_tool_use_with_argument_comparison.yaml
+      - resources_servers/single_step_tool_use_with_argument_comparison/configs/toolcall_schema_single_step_tool_use_with_argument_comparison.yaml
+      - resources_servers/single_step_tool_use_with_argument_comparison/configs/swe_pivot_single_step_tool_use_with_argument_comparison.yaml
+      - resources_servers/abstention/configs/abstention.yaml
+      - resources_servers/nvarc/configs/inductive.yaml
+      - resources_servers/nvarc/configs/transductive.yaml
+      - resources_servers/single_step_tool_use_with_argument_comparison/configs/droid_pivot_single_step_tool_use_with_argument_comparison.yaml
+      - resources_servers/equivalence_rule/configs/lc.yaml
+      - resources_servers/ether0/configs/ether0.yaml
+      - resources_servers/structured_outputs/configs/structured_outputs_json_yaml_xml_v1.yaml
+      - resources_servers/structured_outputs/configs/structured_outputs_v3.yaml
+      - resources_servers/format_verification/configs/freeform_formatting.yaml
+      - resources_servers/format_verification/configs/citation_format.yaml
+      - resources_servers/litmus_agent/configs/litmus_agent.yaml
+      - resources_servers/jailbreak_detection/configs/jailbreak_detection_nemotron_combined_reward_tp8.yaml
+      - resources_servers/indirect_prompt_injection/configs/indirect_prompt_injection.yaml
+
+    # The RLVR2 blend still uses the superseded rdkit_chemistry agent
+    # name. Keep that data reference while running the replacement Litmus agent.
+    rdkit_chemistry_agent:
+      _inherit_from: litmus_agent_agent
+
+    policy_model:
+      responses_api_models:
+        vllm_model:
+          num_workers: 16
+          num_groups_nemo_rl: ${add:${grpo.async_grpo.max_trajectory_age_steps}, 1}
+          # Model-specific (Nemotron chat template): keep reasoning in multi-turn
+          # history so the trajectory grows monotonically for token-in-token-out RL.
+          chat_template_kwargs:
+            enable_thinking: true
+            truncate_history_thinking: false
+          sequential_reasoning_allowed: false
+    policy_model_reasoning_off:
+      _copy: policy_model
+      responses_api_models:
+        vllm_model:
+          num_workers: 4
+          num_groups_nemo_rl: ${add:${grpo.async_grpo.max_trajectory_age_steps}, 1}
+          chat_template_kwargs:
+            enable_thinking: false
+
+    abstention:
+      resources_servers:
+        abstention:
+          judge_model_server:
+            type: responses_api_models
+            name: nl2bash_judge_model
+          judge_responses_create_params:
+            max_output_tokens: 8192
+
+    # Safety judge: TP=4 ensures each placement group claims a full GB200 node,
+    # avoiding GPU fragmentation that can block larger-TP models.
+    jailbreak_detection:
+      resources_servers:
+        jailbreak_detection:
+          judge_model_server:
+            type: responses_api_models
+            name: safety_judge_model
+
+    safety_judge_model:
+      responses_api_models:
+        local_vllm_model:
+          entrypoint: app.py
+          model: null   # Set by launcher (SAFETY_JUDGE_MODEL)
+          return_token_id_information: false
+          uses_reasoning_parser: false
+          debug: true
+          vllm_serve_env_vars:
+            VLLM_RAY_DP_PACK_STRATEGY: strict
+            VLLM_USE_DEEP_GEMM: "0"
+            VLLM_MOE_USE_DEEP_GEMM: "0"
+
+          vllm_serve_kwargs:
+            attention_backend: TRITON_ATTN
+            language_model_only: true
+            tensor_parallel_size: 4
+            data_parallel_size: 2
+            data_parallel_size_local: 1
+            pipeline_parallel_size: 1
+            gpu_memory_utilization: 0.85
+            max_model_len: 96000
+            model_loader_extra_config:
+              enable_multithread_load: true
+              num_threads: 112
+            compilation_config:
+              cudagraph_capture_sizes: [1,2,4,8,16]
+
+    # NL2Bash / general judge: use NL2BASH_BASE_URL for an external service,
+    # otherwise launch TP=4 locally on GB200 192GB.
+    nl2bash_judge_model:
+      responses_api_models:
+        local_vllm_model:
+          entrypoint: app.py
+          model: null   # Set by launcher (NL2BASH_JUDGE_MODEL)
+          return_token_id_information: false
+          uses_reasoning_parser: false
+          debug: true
+          ray_worker_py_executable: /opt/ray_venvs/nemo_rl.models.generation.vllm.vllm_worker_async.VllmAsyncGenerationWorker/bin/python
+          vllm_serve_env_vars:
+            VLLM_RAY_DP_PACK_STRATEGY: strict
+            VLLM_USE_FLASHINFER_MOE_FP16: "0"
+            VLLM_USE_FLASHINFER_MOE_FP8: "0"
+            VLLM_USE_DEEP_GEMM: "0"
+            VLLM_MOE_USE_DEEP_GEMM: "0"
+            NCCL_MNNVL_ENABLE: "1"
+
+          vllm_serve_kwargs:
+            attention_backend: TRITON_ATTN
+            tensor_parallel_size: 4
+            data_parallel_size: 2
+            data_parallel_size_local: 1
+            pipeline_parallel_size: 1
+            enable_expert_parallel: true
+            enable_auto_tool_choice: true
+            tool_call_parser: hermes
+            gpu_memory_utilization: 0.85
+            max_model_len: 131072
+            max_num_seqs: 256
+            enable_prefix_caching: true
+            enable_chunked_prefill: true
+            model_loader_extra_config:
+              enable_multithread_load: true
+              num_threads: 112
+            compilation_config:
+              cudagraph_capture_sizes: [1,2,4,8,16,32]
+
+    inverse_if:
+      resources_servers:
+        inverse_if:
+          judge_model_server:
+            type: responses_api_models
+            name: nl2bash_judge_model
+
+    multichallenge:
+      resources_servers:
+        multichallenge:
+          judge_model_server:
+            type: responses_api_models
+            name: nl2bash_judge_model
+          judge_responses_create_params:
+            max_output_tokens: 8192
+
+    equivalence_llm_judge:
+      resources_servers:
+        equivalence_llm_judge:
+          judge_model_server:
+            name: nl2bash_judge_model
+          judge_responses_create_params:
+            max_output_tokens: 8192
+
+    # GenRM compare: deployed as a separate service; URL set by launcher
+    genrm_compare_resources_server:
+      resources_servers:
+        genrm_compare:
+          num_rollouts_per_prompt: ${grpo.num_generations_per_prompt}
+          genrm_model_server:
+            type: responses_api_models
+            name: genrm_model
+          genrm_responses_create_params:
+            max_output_tokens: 24576
+            temperature: 1.0
+            top_p: 0.95
+          comparison_strategy: "circular"
+          num_judges_per_comparison: 1
+          use_principle: true
+          default_principle: "You will be given one or more evaluation criteria (rubrics).\nEvaluate both responses on EACH criterion individually first, then synthesize an overall judgment.\nCriteria:\n\n1. Please act as an impartial judge and evaluate the quality of the responses provided by two AI assistants to the user prompt. Begin your evaluation by generating your own answer to the prompt. You must provide your answer before judging any answers. When evaluating the assistants' answers, compare both assistants' answers with your answer. You must identify and correct any mistakes or inaccurate information. Then consider if the assistant's answers are helpful, relevant, and concise. Helpful means the answer correctly responds to the prompt or follows the instructions. Note when user prompt has any ambiguity or more than one interpretation, it is more helpful and appropriate to ask for clarifications or more information from the user than providing an answer based on assumptions. Relevant means all parts of the response closely connect or are appropriate to what is being asked. Concise means the response is clear and not verbose or excessive. Then consider the creativity and novelty of the assistant's answers when needed. Finally, identify any missing important information in the assistants' answers that would be beneficial to include when responding to the user prompt."
+          aggregator_method: "simple_tiebreaker"
+          reasoning_bonus: 0.5
+          answer_bonus: 0.5
+          top_percentile: 0.2
+          genrm_parse_retries: 1
+          group_reasoning_length_penalty_coeff: 0.1
+          group_answer_length_penalty_coeff: 0.2
+          group_style_penalty_coeff: 0.0
+          default_score: 3.0
+          default_ranking: 3.5
+
+    # Launcher sets either `base_url` (route to remote GenRM service) or
+    # `model` (serve locally using vllm_serve_kwargs below). See the guide.
+    genrm_model:
+      responses_api_models:
+        genrm_model:
+          entrypoint: app.py
+          api_key: dummy_key
+          model: null
+          uses_reasoning_parser: true
+          return_token_id_information: false
+          debug: true
+          ray_worker_py_executable: /opt/ray_venvs/nemo_rl.models.generation.vllm.vllm_worker_async.VllmAsyncGenerationWorker/bin/python
+          vllm_serve_env_vars:
+            # Keep each TP=4 replica on one four-GPU GB200 node.
+            VLLM_RAY_DP_PACK_STRATEGY: strict
+            NCCL_MNNVL_ENABLE: "1"
+            VLLM_FLASHINFER_ALLREDUCE_BACKEND: trtllm
+            VLLM_ALLREDUCE_USE_SYMM_MEM: "0"
+
+          vllm_serve_kwargs:
+            tensor_parallel_size: 4
+            data_parallel_size: 16
+            data_parallel_size_local: 1
+            pipeline_parallel_size: 1
+            distributed_executor_backend: ray
+            data_parallel_backend: ray
+            api_server_count: 1
+            enable_expert_parallel: false
+            dtype: bfloat16
+            kv_cache_dtype: fp8
+            gpu_memory_utilization: 0.95
+            max_model_len: 262144
+            max_num_seqs: 256
+            max_num_batched_tokens: 8192
+            enable_prefix_caching: true
+            enable_chunked_prefill: true
+            trust_remote_code: true
+            enable_auto_tool_choice: true
+            tool_call_parser: qwen3_coder
+            model_loader_extra_config:
+              enable_multithread_load: true
+              num_threads: 96
+            load_format: auto
+            compilation_config:
+              pass_config:
+                fuse_allreduce_rms: false
+
+    lc_judge:
+      resources_servers:
+        equivalence_llm_judge:
+          judge_model_server:
+            name: nl2bash_judge_model
+          judge_responses_create_params:
+            max_output_tokens: 8192
+
+    math_with_judge:
+      resources_servers:
+        math_with_judge:
+          judge_model_server:
+            name: nl2bash_judge_model
+          judge_responses_create_params:
+            max_output_tokens: 8192
+          should_use_judge: true
+
+    code_gen:
+      resources_servers:
+        code_gen:
+          num_processes: 2048
+          unit_test_timeout_secs: 10
+          debug: false
+
+    math_formal_lean_refinement_agent:
+      responses_api_agents:
+        proof_refinement_agent:
+          max_correction_turns: 2
+
+# =============================================================================
+# Logger — log_dir, wandb.name, wandb.project are overridden by the launcher
+# =============================================================================
+logger:
+  log_dir: "logs/ultra_student_rlvr"
+  num_val_samples_to_print: 0
+  wandb_enabled: false
+  tensorboard_enabled: false
+  mlflow_enabled: false
+  monitor_gpus: true
+  swanlab_enabled: false
+  wandb:
+    project: "nemotron-3-ultra"
+    name: "ultra-student-rlvr"
+  tensorboard: {}
+  mlflow:
+    experiment_name: "nemotron-3-ultra"
+    run_name: "ultra-student-rlvr"
+  gpu_monitoring:
+    collection_interval: 10
+    flush_interval: 10
+
+# =============================================================================
+# Reward Penalties (set reward to 0 when triggered)
+# =============================================================================
+reward_penalties:
+  penalize_duplicated_reasoning: true
+  penalize_empty_final_answer: true
+  penalize_unwanted_tokens: true
+  penalize_malformed_think_tag: true
+  token_ids:
+    unwanted: [2]
+    think_open: 12
+    think_close: 13

--- a/examples/nemo_gym/nemotron-3-ultra/pipeclean_6k_sc.yaml
+++ b/examples/nemo_gym/nemotron-3-ultra/pipeclean_6k_sc.yaml
@@ -1,0 +1,243 @@
+# =============================================================================
+# Nemotron 3 Ultra — 6K-GPU pipeclean on the SingleController path
+# =============================================================================
+# Overlay on pipeclean_6k.yaml that swaps the legacy async-GRPO driver for the
+# SingleController (SC) architecture: streaming forward/backward, the
+# TransferQueue data plane, and gated in-order rollout sampling.
+#
+# Everything about the model, parallelism, batch shape, sequence length and the
+# Gym blend is inherited unchanged, so a run of this config is comparable
+# against a pipeclean_6k.yaml run on the same node split.
+#
+# Entrypoint: examples/run_grpo_single_controller.py (NOT run_grpo_nemo_gym.py).
+# launch_6k_pipeclean_sc.sh sets that via TRAIN_ENTRYPOINT.
+#
+# Derived from two validated SC runs of a smaller model at GBS=512 (PPS=32),
+# one at the full-cohort streaming threshold and one at a quarter of it. The
+# second demonstrates streaming: each step's forward/backward is dispatched in
+# 2-3 chunks instead of one.
+#
+# Group vs sample units: async_rl counts PROMPT GROUPS, not generations. One
+# optimizer cohort here is 16384 / 16 = 1024 groups, versus 32 in the Nano runs.
+# =============================================================================
+defaults: pipeclean_6k.yaml
+
+# =============================================================================
+# Checkpointing — must be off
+# =============================================================================
+# setup_single_controller raises NotImplementedError when
+# checkpointing.enabled is true (single_controller_utils/setup.py). Saving is
+# still a TODO on the SC path (single_controller.py). The run therefore cannot
+# resume across the wall clock: size max_num_steps to fit one allocation.
+# =============================================================================
+checkpointing:
+  enabled: false
+
+grpo:
+  # Required because loss_fn.reference_policy_kl_penalty is 0.0. No reference
+  # model is built, but SC still computes reference logprobs unless this is
+  # set, and then fails with AttributeError: 'MegatronPolicyWorker' has no
+  # 'reference_state_dict'.
+  skip_reference_policy_logprobs_calculation: true
+
+  # val_period=-1 / val_at_start=false / val_at_end=false are inherited and
+  # already satisfy the SC guard (it rejects val_period > 0). No change needed.
+  #
+  # run_grpo_single_controller.py raises unless this is null; the SC knobs live
+  # under async_rl. pipeclean_6k.yaml interpolates
+  # ${add:${grpo.async_grpo.max_trajectory_age_steps}, 1} for num_groups_nemo_rl
+  # in two places, so both are pinned to the value that interpolation resolved
+  # to (max_trajectory_age_steps: 1) under env.nemo_gym below. Nothing may
+  # reference this block once it is null or config load fails.
+  async_grpo: null
+
+policy:
+  # ---------------------------------------------------------------------------
+  # Speculative-decoding draft head. run_grpo_single_controller.py reads
+  # config.policy["draft"]["enabled"] unconditionally, so omitting this block
+  # is a KeyError before Ray starts. The nemo_gym runner guards it with an `in`
+  # check, which is why pipeclean_6k.yaml does not need it.
+  # ---------------------------------------------------------------------------
+  draft:
+    enabled: false
+    model_name: null
+    loss_weight: 0.1
+    num_layers: null
+    aux_layer_indices: null
+
+  generation:
+    # ---------------------------------------------------------------------------
+    # Weight refit transport. The inherited default (null) broadcasts every full
+    # parameter tensor from training to all 3840 generation ranks. nccl_reshard
+    # instead moves each parameter shard-to-shard between the two parallelism
+    # layouts over NCCL's M2N reshard, so no rank ever materializes a full
+    # tensor. The bulk path covers the MoE FFN projections, which are 97-98% of
+    # the weights at EP=64.
+    #
+    # Declared here rather than passed with `+` because refit_transport is
+    # NotRequired in VllmConfig; with the key present, REFIT_TRANSPORT=null in
+    # launch_6k_pipeclean_sc.sh falls back to the broadcast path.
+    #
+    # Experimental, and it degrades quietly: if the container lacks the nccl4py
+    # M2N integration, xferdtensor.py logs "nccl.m2n.reshard not found" and uses
+    # a Python implementation instead. Check the first run's logs for that line.
+    #
+    # Config already satisfies every constraint in
+    # docs/design-docs/nccl-reshard-refit.md: non-colocated, Megatron train,
+    # vLLM gen, ETP=1, PP=1 with no custom layout, BF16 end to end, and vLLM
+    # expert_parallel_size == tensor_parallel_size (8).
+    # ---------------------------------------------------------------------------
+    refit_transport: nccl_reshard
+
+    vllm_cfg:
+      # 0.85 -> 0.80. The NCCL staging buffer for update_weights_from_collective
+      # grows with generation rank count; a smaller-scale run OOM'd there at
+      # 0.85 with 128 generation ranks after running fine at 32. This recipe has
+      # 3840. Costs KV cache, so watch generation throughput.
+      #
+      # This is the pressure refit_transport: nccl_reshard removes, so 0.85 may
+      # be recoverable once a reshard run is confirmed healthy. Left at 0.80
+      # so the two only differ in the transport.
+      gpu_memory_utilization: 0.80
+
+# =============================================================================
+# SingleController async RL — required by MasterConfig
+# =============================================================================
+# in_order stamps each dispatched cohort with its exact target optimizer step.
+# The lookahead is the ceiling on off-policyness: generation may start a cohort
+# at most this many optimizer steps before the step that trains on it, so the
+# reported `lag` settles there once generation is the bottleneck.
+#
+# 4 buys deep generation/training overlap at the cost of policy freshness. The
+# loss compensates via truncated importance sampling (loss_fn:
+# use_importance_sampling_correction, truncated_importance_sampling_ratio 5),
+# but watch token_mult_prob_error and is_oob_ratio — if they climb, the
+# correction is being asked to cover too large a policy gap. Drop to 1 (the
+# validated value at smaller scale) if training destabilizes.
+# =============================================================================
+
+# =============================================================================
+# Loss — off-policy correction, required by every arm past lag 1
+# =============================================================================
+# pipeclean_6k.yaml pins the importance ratio at 1, which makes
+# use_importance_sampling_correction inert: the sampled tokens come from an
+# older policy but the loss is computed as though they came from the current
+# one. A lag sweep run that way measures the uncorrected loss, not the
+# staleness. Lifting the pin costs the prev_logprobs forward pass it skipped,
+# and is what the truncated_importance_sampling_ratio above assumes.
+# =============================================================================
+loss_fn:
+  force_on_policy_ratio: false
+
+async_rl:
+  sampler:
+    name: in_order
+    max_lookahead_versions: 4
+  recompute_kv_cache_after_weight_updates: false
+
+  # Begin forward/backward once this many groups are ready rather than waiting
+  # for all 1024; the remainder streams in behind it and accumulates into the
+  # single GBS=16384 optimizer step. 256 is 25% of the cohort, the ratio the
+  # smaller-scale streaming run used (8 of 32) to get 2-3 chunks per step.
+  min_groups_for_streaming_train: 256
+
+  # Let the current cohort and all four lookahead cohorts generate concurrently.
+  max_inflight_prompts: 5120
+
+  # Hard floor, not a preference: validate_sampler_buffer_capacity raises if
+  # this is below num_prompts_per_step * (max_lookahead_versions + 1)
+  # = 1024 * 5 = 5120, because the rollout pump would deadlock waiting for
+  # buffer slots. It scales with the lookahead, so raising one raises both.
+  max_buffered_rollouts: 5120
+
+  diagnostics: false
+
+  # Rollout fault tolerance. Infra failures (dead shard, timeout, transport)
+  # re-dispatch onto a different shard; data failures are deterministic and do
+  # not. The two budgets are independent counters, not a total and a sub-total.
+  rollout_failure:
+    max_infra_attempts_per_prompt: 5
+    max_data_attempts_per_prompt: 2
+    backoff_base_s: 1.0
+    max_backoff_s: 30.0
+
+    # A single unlucky prompt must not cost a 1520-node allocation. Any commit
+    # resets the count, so this bounds an outage rather than the run's lifetime.
+    max_consecutive_dropped_prompts: 32
+    max_skipped_prompts: 32
+
+    # Hold the configured batch size across a drop rather than closing the step
+    # short. Under in_order a dropped prompt would otherwise strand its step
+    # entirely; under either sampler a step that quietly trains on fewer than
+    # 1024 groups is not the measurement the lag arms are compared on.
+    on_dropped_prompt: replace
+    max_replacement_attempts: 1
+    replacement_reserve_prompts: 1
+    min_step_batch_fraction: 0.9
+
+    # This is the NeMo-Gym rollout path, so only the nemo_gym block applies;
+    # validate_single_controller_config rejects a populated native block rather
+    # than letting it look effective. Sized above the longest legitimate rollout
+    # at 131072 tokens, so only a wedge trips it -- nothing below SC bounds one.
+    nemo_gym:
+      rollout_timeout_s: 3600.0
+
+  # Must outlast every deadline above, which _check_watchdog_outlasts_rollouts
+  # enforces: below it, a rollout that is merely slow reads as a stall.
+  watchdog:
+    interval_s: 30.0
+    stall_timeout_s: 4200.0
+    stall_action: warn
+    gym_subprocess_check: true
+
+# =============================================================================
+# NeMo-Gym rollout actor
+# =============================================================================
+env:
+  nemo_gym:
+    # Pinned literals for what pipeclean_6k.yaml interpolated off
+    # grpo.async_grpo.max_trajectory_age_steps, which is null on this path.
+    policy_model:
+      responses_api_models:
+        vllm_model:
+          num_groups_nemo_rl: 2
+    policy_model_reasoning_off:
+      responses_api_models:
+        vllm_model:
+          num_groups_nemo_rl: 2
+
+    # Ray's max_concurrency for the single NemoGym actor. This shape offers 5120
+    # in-flight prompts and each one is a single run_rollouts call on that
+    # actor, so at Ray's async default of 1000 the surplus queued at the raylet
+    # and the run produced zero groups.
+    #
+    # null now means "size it from async_rl.max_inflight_prompts plus a small
+    # control-plane headroom" (resolve_nemo_gym_max_concurrency), which covers
+    # the 5120 without a number here that has to be kept in step with it. It is
+    # declared rather than omitted because Hydra runs in struct mode: an
+    # undeclared key cannot be set from the command line.
+    max_concurrency: null
+
+# =============================================================================
+# TransferQueue data plane — mandatory for the SC path
+# =============================================================================
+# run_grpo_single_controller.py refuses to start unless enabled is true, and
+# DataPlaneConfig requires every key below with no Python-side defaults.
+# global_segment_size / local_buffer_size are read only when backend is
+# mooncake_cpu, but must still be present.
+# =============================================================================
+data_plane:
+  enabled: true
+  impl: transfer_queue
+  backend: "simple"
+  storage_capacity: 1000000
+  # UNVALIDATED AT THIS SCALE. The smaller-scale reference uses 2 for 512
+  # rows/step at 73728 tokens; this recipe pushes 16384 rows/step at 131072
+  # tokens, roughly 57x the bytes, and the lookahead of 4 keeps up to 5120
+  # groups (81920 rows) resident at once. 64 is proportional to the per-step
+  # volume, not measured — raise it first if the TQ storage actors bottleneck
+  # or OOM.
+  num_storage_units: 64
+  claim_meta_poll_interval_s: 0.5
+  global_segment_size: 549755813888  # 512 GiB
+  local_buffer_size:   68719476736   # 64 GiB

--- a/examples/nemo_gym/nemotron-3-ultra/record_code_at_start.sh
+++ b/examples/nemo_gym/nemotron-3-ultra/record_code_at_start.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# =============================================================================
+# Record, at job start, the code that is actually about to run.
+#
+# provenance.txt is written on the login node at *submit* time, but with
+# USE_SNAPSHOT=0 the source is bind-mounted live and is read at *job start*.
+# Under a QOS that serialises large jobs those two moments can be hours and
+# several commits apart, and the arms of a sweep then do not all run the same
+# code. That already happened: the previous four-arm staleness sweep ran a
+# mixture, and the low end of the trend was confounded by it.
+#
+# Two independent records, because either alone can mislead:
+#
+#   git    -- the host repo is visible through the /lustre mount, so its HEAD
+#             is readable from inside the container. It is the useful handle
+#             for "which commit", but it describes the checkout as of now, not
+#             necessarily what was imported, and it is silent about uncommitted
+#             edits and about which paths are actually mounted.
+#   digest -- a content hash of the mounted source, which is ground truth for
+#             what this job will import regardless of git state. Two arms with
+#             the same digest provably ran the same code.
+#
+# Best effort by construction: this runs inside the training command, so a
+# failure here must never take the job with it. Every step is guarded and the
+# script always exits 0.
+#
+# Usage: record_code_at_start.sh <code_root> <run_dir> [repo_root]
+# =============================================================================
+
+CODE_ROOT="${1:?code root required}"
+RUN_DIR="${2:?run dir required}"
+REPO_ROOT="${3:-}"
+
+OUT="${RUN_DIR}/code_at_start.txt"
+
+{
+  echo "recorded_at: $(date -Iseconds)"
+  echo "hostname: $(hostname 2>/dev/null || echo unknown)"
+  echo "slurm_job_id: ${SLURM_JOB_ID:-none}"
+  echo "code_root: ${CODE_ROOT}"
+
+  if [[ -n "${REPO_ROOT}" ]]; then
+    echo "repo_root: ${REPO_ROOT}"
+    echo "git_commit: $(git -C "${REPO_ROOT}" rev-parse HEAD 2>/dev/null || echo unavailable)"
+    echo "git_branch: $(git -C "${REPO_ROOT}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unavailable)"
+    # Truncated: a long dirty list would bury the hashes below it.
+    echo "git_dirty: $(git -C "${REPO_ROOT}" status --porcelain 2>/dev/null | head -20 | tr '\n' ';' || echo unavailable)"
+  fi
+
+  # Hash what will be imported. Scoped to the three trees ultra_launch.sh and
+  # nano35_dolphin_launch.sh actually overlay onto the image -- hashing all of
+  # CODE_ROOT would pull in the container's own site-packages and swamp the
+  # signal with bytes no launcher can change.
+  #
+  # The file count is printed with the digest, and the digest of empty input is
+  # rejected outright, because the failure mode here is silent agreement: if
+  # the pipeline below dies (it did, on a login node at its PID ceiling) every
+  # command in it still exits and sha256sum still prints -- the hash of
+  # nothing. That is a well-formed hash that every arm would report
+  # identically, so the one record meant to prove the arms matched would be the
+  # record asserting it most confidently while measuring nothing at all.
+  empty_digest=$(printf '' | sha256sum | cut -d' ' -f1)
+  for tree in "${CODE_ROOT}/nemo_rl" "${CODE_ROOT}/examples/nemo_gym" "${CODE_ROOT}/examples/configs"; do
+    if [[ ! -d "${tree}" ]]; then
+      echo "digest ${tree}: missing"
+      continue
+    fi
+    listing=$(find "${tree}" -type f \( -name '*.py' -o -name '*.yaml' -o -name '*.yml' -o -name '*.sh' \) -print 2>/dev/null | LC_ALL=C sort)
+    count=$(printf '%s\n' "${listing}" | grep -c . || true)
+    digest=$(printf '%s\n' "${listing}" | tr '\n' '\0' | xargs -0 -r sha256sum 2>/dev/null | sha256sum | cut -d' ' -f1)
+    if [[ -z "${digest}" || "${digest}" == "${empty_digest}" || "${count}" -eq 0 ]]; then
+      echo "digest ${tree}: UNAVAILABLE (hashing failed; files=${count}) — do not treat arms as matched on this record"
+    else
+      echo "digest ${tree}: ${digest} (files=${count})"
+    fi
+  done
+} >"${OUT}" 2>&1
+
+echo "code provenance at start recorded to ${OUT}"
+cat "${OUT}" 2>/dev/null
+
+exit 0

--- a/examples/nemo_gym/nemotron-3-ultra/ultra_launch.sh
+++ b/examples/nemo_gym/nemotron-3-ultra/ultra_launch.sh
@@ -89,7 +89,11 @@ set -euo pipefail
 : "${TRAIN_PATH:?TRAIN_PATH is required (training data jsonl path)}"
 : "${VAL_PATH:?VAL_PATH is required (validation data jsonl path)}"
 : "${CONTAINER:?CONTAINER is required (NGC image URI or .sqsh path)}"
-: "${SANDBOX_CONTAINER:?SANDBOX_CONTAINER is required (nemo-skills sandbox image)}"
+# Set it empty to disable the colocated sandbox: ray.sub starts the sandbox only
+# when SANDBOX_CONTAINER and SANDBOX_COMMAND are both non-empty, and a blend that
+# routes to none of the three sandbox-backed Gym servers does not need it. Hence
+# `?` rather than `:?` -- unset is still an error, empty is a deliberate opt-out.
+: "${SANDBOX_CONTAINER?SANDBOX_CONTAINER is required (nemo-skills sandbox image; set it empty to disable the sandbox)}"
 : "${PERSISTENT_CACHE:?PERSISTENT_CACHE is required (Lustre dir for vLLM/Triton/Inductor caches)}"
 : "${SLURM_PARTITION:?SLURM_PARTITION is required}"
 : "${SLURM_ACCOUNT:?SLURM_ACCOUNT is required}"
@@ -855,6 +859,36 @@ export SETUP_COMMAND
 # learning rate, etc.) live in CONFIG_PATH. The launcher only passes the
 # per-run overrides: cluster shape, paths, judge endpoints, logging.
 # =============================================================================
+# SingleController recipes swap this for ./examples/run_grpo_single_controller.py.
+# Both drivers accept the same --config and Hydra override surface.
+TRAIN_ENTRYPOINT="${TRAIN_ENTRYPOINT:-./examples/nemo_gym/run_grpo_nemo_gym.py}"
+if [[ ! -f "${PROJECT_ROOT}/${TRAIN_ENTRYPOINT#./}" ]]; then
+  echo "ERROR: TRAIN_ENTRYPOINT does not exist: ${TRAIN_ENTRYPOINT}" >&2
+  exit 1
+fi
+
+# UV_CACHE_DIR points at the warm cache the container already ships at
+# /root/.cache/uv, rather than /tmp/nemo-gym-uv-cache-${SLURM_JOB_ID:-default},
+# which breaks twice over:
+#
+#   - ray.sub scrubs every SLURM_* variable before entering the head container,
+#     so the job-id suffix always collapses to "default"; and /tmp is node-local
+#     and wiped, so the cache is cold on every node of every job by construction.
+#   - Worse, pointing uv at /tmp discards the image's own cache, which holds git
+#     databases for all 13 git dependencies plus the vllm and flash-attn wheels,
+#     so every job re-clones and re-downloads roughly 700 MB from github.
+#
+# Any run that mounts a Gym differing from the baked one pays this: the mismatch
+# invalidates the lock and forces a re-resolve, and with a cold cache that
+# re-resolve has to reach github from a compute node. It cost ~26 min of startup
+# in jobs 6231494/6232802/6233682, and earlier killed 6071350, 6071353 and
+# 6071948 outright when a clone timed out at ~134s.
+#
+# Set explicitly rather than simply unset: sbatch --export=ALL carries an
+# inherited UV_CACHE_DIR from the submitting shell all the way into the
+# container, so relying on uv's default is not enough. Verified in job 6072555 --
+# with github made unreachable, the /tmp arm failed exactly as in production and
+# this arm resolved and synced clean.
 TRAIN_CMD="cd ${CODE_ROOT} && date ; \
 OMP_NUM_THREADS=16 \
 RAY_DEDUP_LOGS=1 \
@@ -864,7 +898,7 @@ NRL_VLLM_CACHE_SEED_DIR=${NRL_VLLM_CACHE_SEED_DIR} \
 DG_JIT_CACHE_DIR=${NRL_VLLM_LOCAL_CACHE_DIR}/deep_gemm \
 TORCHINDUCTOR_CACHE_DIR=${INDUCTOR_CACHE_DIR} \
 TRITON_CACHE_DIR=${TRITON_CACHE_DIR} \
-UV_CACHE_DIR=/tmp/nemo-gym-uv-cache-\${SLURM_JOB_ID:-default} \
+UV_CACHE_DIR=/root/.cache/uv \
 UV_LOCK_TIMEOUT=1800 \
 RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 \
 UV_HTTP_TIMEOUT=10 \
@@ -875,7 +909,7 @@ NRL_WG_USE_RAY_REF=1 \
 HF_HOME=${HF_HOME:-} \
 HF_TOKEN=${HF_TOKEN:-} \
 NRL_USE_FASTOKENS=${NRL_USE_FASTOKENS:-1} \
-uv run ./examples/nemo_gym/run_grpo_nemo_gym.py \
+uv run ${TRAIN_ENTRYPOINT} \
 --config ${CONFIG_PATH} \
 policy.model_name=${MODEL_PATH} \
 cluster.num_nodes=${NUM_ACTOR_NODES} \
@@ -904,6 +938,21 @@ if (( NUM_EXTERNAL_SERVICE_NODES > 0 )); then
   validate_external_vllm_submission "${COMMAND}" "${NUM_EXTERNAL_SERVICE_NODES}"
 fi
 
+# TRAIN_CMD is assembled in double quotes, so ${HF_TOKEN} and friends are already
+# expanded to their literal values. Anything that writes it to disk must go
+# through this first: RUN_DIR lives on shared Lustre with a default 0644 umask.
+# Substituting the unexpanded name keeps the output runnable when sourced from a
+# shell that has the secret set. The -n guards matter — an empty search pattern
+# would splice the replacement between every character.
+redact_secrets() {
+  local text="$1" name
+  for name in HF_TOKEN WANDB_API_KEY OPENAI_API_KEY NGC_API_KEY; do
+    local value="${!name:-}"
+    [[ -n "${value}" ]] && text="${text//"${value}"/\$${name}}"
+  done
+  printf '%s' "${text}"
+}
+
 # =============================================================================
 # Summary
 # =============================================================================
@@ -913,6 +962,7 @@ echo "  Nemotron 3 Ultra — ${EXP_NAME} (${NUM_TOTAL_NODES}-node)"
 echo "================================================================"
 echo "  Job name:    ${JOB_NAME}  (singleton — only one runs at a time)"
 echo "  Config:      ${CONFIG_PATH}"
+echo "  Entrypoint:  ${TRAIN_ENTRYPOINT}"
 echo "  Nodes:       ${NUM_TOTAL_NODES} total"
 if (( NUM_EXTERNAL_SERVICE_NODES > 0 )); then
 echo "    Hetgroup 0: ${NUM_RAY_NODES} NeMo RL nodes  (segment=${SEGMENT_SIZE})"
@@ -970,7 +1020,7 @@ echo ""
   fi
   echo "container: ${CONTAINER}"
   echo "config: ${CONFIG_PATH}"
-  echo "command: ${TRAIN_CMD}"
+  echo "command: $(redact_secrets "${TRAIN_CMD}")"
 } > "${RUN_DIR}/provenance.txt"
 
 # =============================================================================
@@ -981,7 +1031,7 @@ if [[ "${DRY_RUN}" == "1" ]]; then
   echo "DRY_RUN=1 — printing TRAIN_CMD and exiting without submission."
   echo ""
   echo "--- TRAIN_CMD ---"
-  echo "${TRAIN_CMD}"
+  redact_secrets "${TRAIN_CMD}"; echo
   echo "--- end ---"
   exit 0
 fi
@@ -1032,7 +1082,7 @@ if [[ "${INTERACTIVE}" == "1" ]]; then
   ATTACH_SCRIPT="${LAUNCH_DIR}/${JOB_ID}-attach.sh"
   CMD_FILE="${LAUNCH_DIR}/${JOB_ID}-run-cmd.sh"
   cat > "${CMD_FILE}" <<CMDEOF
-${TRAIN_CMD}
+$(redact_secrets "${TRAIN_CMD}")
 CMDEOF
   chmod +x "${CMD_FILE}"
 

--- a/examples/nemo_gym/nemotron-3.5-nano/nano35_dolphin_launch.sh
+++ b/examples/nemo_gym/nemotron-3.5-nano/nano35_dolphin_launch.sh
@@ -1,0 +1,407 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# =============================================================================
+# nano35_dolphin_launch.sh
+#
+# Nemotron 3.5 Nano — RLVR, legacy async-1, honest-dolphin warm start.
+# Reproduces the internal reference run
+#   geshen-ultra-rl-nano-honest-dolphin-v10-iter6000-mopd-rlvr
+# (launch_nano_honest_dolphin.sh + grpo_ultra_512n4g_bf16.yaml on
+#  nemo-rl-internal @ 97c55ee2) on public NeMo-RL main.
+#
+# This is a thin wrapper over examples/nemo_gym/nemotron-3-ultra/ultra_launch.sh.
+# That launcher is fully parameterised and already handles code snapshotting,
+# persistent-cache seeding, container mounts, Ray/Gym orchestration, and the
+# OccupiedIdleGPUsJobReaper --comment exemption — so we set environment and
+# delegate rather than forking 800+ lines.
+#
+# Usage. Judges run one of two ways; see the GenRM section below for the
+# trade-off between them.
+#
+#   Against a warm out-of-band GenRM pool (default; must already be serving):
+#     GENRM_BASE_URL=http://<lb-host>:9213/v1 \
+#       bash examples/nemo_gym/nemotron-3.5-nano/nano35_dolphin_launch.sh
+#
+#   Hosting GenRM and the NL2Bash judge inside the job, as the 6K recipe does:
+#     EXTERNAL_JUDGES=1 \
+#       bash examples/nemo_gym/nemotron-3.5-nano/nano35_dolphin_launch.sh
+#
+#   DRY_RUN=1 GENRM_BASE_URL=... bash .../nano35_dolphin_launch.sh   # inspect only
+#
+# Extra Hydra overrides are forwarded verbatim:
+#   GENRM_BASE_URL=... bash .../nano35_dolphin_launch.sh grpo.max_num_steps=2
+# =============================================================================
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "${REPO_ROOT}"   # ultra_launch.sh derives PROJECT_ROOT from $PWD
+
+# -----------------------------------------------------------------------------
+# GenRM hosting. Two shapes, and this recipe supports both.
+#
+# EXTERNAL_JUDGES=1 is the 6K shape: GenRM and the NL2Bash judge are
+# co-scheduled in a second Slurm hetgroup inside this job. The allocation
+# wrapper brings up every replica plus one load balancer per pool, waits for
+# health, then substitutes the resolved URLs into the driver command. The job
+# owns its judges, so the reward model lands in provenance and no run can
+# outlive, mismatch, or be starved by a pool it does not control.
+#
+# EXTERNAL_JUDGES=0 (default) keeps GenRM on a separately managed warm pool
+# reached through GENRM_BASE_URL, and leaves the NL2Bash judge in the Gym pool.
+# Partition `batch` caps at 4 h, so a warm pool amortizes the 470 GB bf16
+# Qwen3-235B load across a whole chain of jobs. The in-job path instead pays
+# that load once per job — about ten minutes before training starts, measured
+# on the 6K run — in exchange for being self-contained.
+#
+# To stand up the out-of-band pool (copy the dir first — it holds .lb_pid_*,
+# logs/ and a flock'd registry, so running someone else's in place collides):
+#
+#   cp -r /lustre/fs1/portfolios/llmservice/projects/llmservice_modelalignment_ppo/\
+# users/geshen/mopd_nano_fast/genrm_serving  <your-dir>/genrm_serving
+#   cd <your-dir>/genrm_serving
+#   MODEL=/lustre/fsw/portfolios/llmservice/users/ansubramania/models/qwen235b_principle_comparison_genrm_step1230 \
+#   ACCOUNT=nemotron_sw_post PARTITION=batch_long TIME=1-12:00:00 \
+#   LB_PORT=9213 GENRM_GROUP_ID=nano35_dolphin \
+#     ./genrm_server_manager.sh launch N
+#   ./genrm_server_manager.sh url
+#
+# NOTE: that script's default MODEL is the *ultra* GenRM (step_720) — override it.
+# Each worker is 2 nodes x 4 GPUs at TP=8, separate from this job's 64 nodes.
+#
+# The `model` field must equal the pool's --served-model-name ("model" in
+# genrm_worker.sh). ultra_launch.sh sets base_url XOR model, never both, so the
+# name is pinned in rlvr_dolphin.yaml instead of passed here.
+# -----------------------------------------------------------------------------
+export EXTERNAL_JUDGES="${EXTERNAL_JUDGES:-0}"
+_DEFAULT_GYM_NODES=16
+if [[ "${EXTERNAL_JUDGES}" == "1" ]]; then
+  # Both pools reproduce the control run's serving shape, not just its GPU count,
+  # so only the judges' location changes. GenRM is 2 replicas at TP=8 spanning
+  # two nodes each, exactly as genrm_worker.sh ran them in the warm pool, filling
+  # the same four nodes. NL2Bash is eight TP=4 replicas, equalling the TP4 x DP8
+  # deployment it replaces in Gym.
+  #
+  # GenRM's TP is the one number worth not "simplifying" to a single node. The
+  # checkpoint is 438 GB, so it is resident once per replica: 4 x TP4 would hold
+  # four copies (1752 GB) on the same 16 GPUs where 2 x TP8 holds two (876 GB),
+  # and the difference comes straight out of KV cache -- roughly 1.1 TB against
+  # 2.0 TB pool-wide. Four replicas would buy more schedulers and more concurrent
+  # slots, but GenRM's long prompts are KV-bound, so the control's shape wins.
+  export GENRM_MODEL="${GENRM_MODEL:-/lustre/fsw/portfolios/llmservice/users/ansubramania/models/qwen235b_principle_comparison_genrm_step1230}"
+  export GENRM_REPLICAS="${GENRM_REPLICAS:-2}"
+  export GENRM_TENSOR_PARALLEL_SIZE="${GENRM_TENSOR_PARALLEL_SIZE:-8}"
+  # The warm pool serves this checkpoint through the ultra_v3 parser plugin, so
+  # carry both the plugin and its name over rather than vLLM's built-ins.
+  export GENRM_REASONING_PARSER="${GENRM_REASONING_PARSER:-/lustre/fsw/portfolios/llmservice/users/lvega/evals/ultra_v3_reasoning_parser.py}"
+  export GENRM_REASONING_PARSER_NAME="${GENRM_REASONING_PARSER_NAME:-ultra_v3}"
+  # The control's genrm_worker.sh passes --enable-expert-parallel; the 6K
+  # deployment of this checkpoint does not. Follow the control.
+  export GENRM_ENABLE_EXPERT_PARALLEL="${GENRM_ENABLE_EXPERT_PARALLEL:-1}"
+  export NL2BASH_REPLICAS="${NL2BASH_REPLICAS:-8}"
+  export NL2BASH_TENSOR_PARALLEL_SIZE="${NL2BASH_TENSOR_PARALLEL_SIZE:-4}"
+  export EXTERNAL_VLLM_SEGMENT_SIZE="${EXTERNAL_VLLM_SEGMENT_SIZE:-2}"
+  # Gym drops to 8 nodes because the NL2Bash judge vacates exactly the 8 it was
+  # filling: TP=4 puts one replica on each four-GPU node, and DP=8 means eight
+  # of them. Every Gym node that was not serving NL2Bash stays, so the safety
+  # judge and the CPU-side env servers are untouched.
+  #
+  # That keeps the GPU allocation comparable to the control run. Akash's
+  # baseline was a 64-node job (5931924: 8 train + 40 gen + 16 gym) alongside a
+  # 4-node GenRM pool of its own (5931683 and 5931688, 2 nodes each, spanning
+  # the full training window) -- 68 nodes, 272 GB200 GPUs. This path is
+  # 8 + 40 + 8 in hetgroup 0 plus 12 service nodes, which is the same 68.
+  _DEFAULT_GYM_NODES=8
+  #
+  # CHECK THIS FIRST IF A POOL FAILS TO START. serve_vllm_on_ray.py imports
+  # nemo_rl before vLLM's serve CLI, so pools must run the RL venv; they cannot
+  # use the Gym venv that rlvr_dolphin.yaml deliberately gives the in-Gym
+  # NL2Bash judge. On a vLLM 0.25 container that RL venv pairs vLLM with the
+  # openai release uv.lock pins, and `vllm serve` dies importing NamespaceTool
+  # from openai.types.responses (job 5943331). Judges share nothing with the
+  # trainer, so the fix is to serve them from an image whose RL venv is
+  # self-consistent rather than to match CONTAINER. Both pools default to
+  # CONTAINER in ultra_launch.sh and are overridable independently:
+  #   GENRM_CONTAINER=<image> NL2BASH_CONTAINER=<image>
+else
+  : "${GENRM_BASE_URL:?GENRM_BASE_URL must point to the external GenRM /v1 endpoint (or set EXTERNAL_JUDGES=1 to host GenRM in-job)}"
+  export GENRM_BASE_URL
+  unset GENRM_MODEL
+fi
+
+# -----------------------------------------------------------------------------
+# Experiment identity
+# EXP_NAME drives the W&B run name, the singleton job name, and the checkpoint
+# and log dirs — so changing it starts a *new* run rather than resuming.
+# -----------------------------------------------------------------------------
+export EXP_NAME="${EXP_NAME:-akamehra-nano35-honest-dolphin-v10-iter6000-rlvr-async1-tp4_cp4_ep8_pp1_gpp16_pps128_gbs2048}"
+export CONFIG_PATH="${CONFIG_PATH:-examples/nemo_gym/nemotron-3.5-nano/rlvr_dolphin.yaml}"
+
+# -----------------------------------------------------------------------------
+# Model and data
+# -----------------------------------------------------------------------------
+# honest-dolphin SFT v10 (closethink unmask, from midtrain 100B LC), iter_0006000.
+export MODEL_PATH="${MODEL_PATH:-/lustre/fsw/portfolios/llmservice/users/venkats/training_actual_0603/nano_n3_post/checkpoints/nano-3.5-sft-v10-closethink-unmask-orig6k-from-midtrain-100B-lc-lr2e-5/eval/iter_0006000/hf}"
+
+# trusty_viper: 199,680 prompts / 24 agent families, carrying agent_ref per row.
+# VAL_PATH intentionally equals TRAIN_PATH, as in the reference — validation is
+# effectively disabled (grpo.val_period is very large) because the genrm cohort
+# envs are train-only and would hang under eval.
+_BLEND="${_BLEND:-/lustre/fs1/portfolios/llmservice/projects/llmservice_modelalignment_ppo/users/geshen/rl-data-tools/blends/curriculum_honest_dolphin_v41_trusty_viper.train.jsonl}"
+export TRAIN_PATH="${TRAIN_PATH:-${_BLEND}}"
+export VAL_PATH="${VAL_PATH:-${_BLEND}}"
+
+# -----------------------------------------------------------------------------
+# Judge checkpoints. Where they run depends on EXTERNAL_JUDGES above: the safety
+# judge is always served from the Gym pool, and the NL2Bash judge joins it there
+# unless the in-job hetgroup is enabled, in which case Gym skips its local
+# launch and proxies to the pool's load balancer instead.
+# -----------------------------------------------------------------------------
+export NL2BASH_JUDGE_MODEL="${NL2BASH_JUDGE_MODEL:-/lustre/fsw/portfolios/llmservice/users/ansubramania/models/Qwen3-235B-A22B-Instruct-2507-FP8}"
+export SAFETY_JUDGE_MODEL="${SAFETY_JUDGE_MODEL:-/lustre/fsw/portfolios/llmservice/users/ansubramania/super_v3/model_checkpoints/Nemotron-Content-Safety-Reasoning-4B}"
+
+# -----------------------------------------------------------------------------
+# Containers
+# Built 2026-08-14 with prefetched venvs, on vllm 0.25.1.
+#
+# The image supplies Megatron, and that is why this pin has to track the repo.
+# ultra_launch.sh overlays only nemo_rl/, examples/configs and Gym from the
+# worktree, so megatron.core always comes from the container. `46ab18ce1 ci: bump
+# Megatron-Bridge to 0c565c9a0 (#3568)` landed on main 2026-08-11 and made
+# megatron_policy_worker.py import FullyShardedDataParallelV1, which no image
+# built before that date has -- including the 2026-07-30 one that used to be the
+# default here and the 2026-08-07 main build. Both fail at
+# `from megatron.core.distributed.fsdp.mcore_fsdp_adapter import ...` while the
+# Megatron workers come up, ~20 min in (job 6231494). To check a candidate before
+# spending an allocation on it:
+#
+#   unsquashfs -l <image> | grep mcore_fsdp_adapter
+#   unsquashfs -d /tmp/probe -f <image> \
+#     opt/nemo-rl/3rdparty/Megatron-Bridge-workspace/Megatron-Bridge/3rdparty/\
+# Megatron-LM/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+#
+# Keep vllm >= 0.25.1 when moving this pin: vllm_worker_async.py imports
+# ServingTokenization from vllm.entrypoints.serve.tokenize.serving, added in
+# 0.25.x, and a 0.20.0 image kills every generation worker at engine init ~25 min
+# in, after the judges and the Megatron workers have already loaded (jobs 5942981
+# and 5981739).
+#
+# The image's vllm and its nvidia-cutlass-dsl also have to agree, which is why
+# this is the 08-14 build and not the 08-15 one that first got us past the
+# Megatron import. The 08-15 image carries vllm 0.25.1+precompiled, whose
+# vllm/vllm_flash_attn/cute/utils.py adds
+# `from cutlass._mlir_helpers.arith import recast_type`; the cutlass-dsl 4.5.2
+# it ships exposes that module only as cutlass.base_dsl._mlir_helpers, so the
+# import raises ModuleNotFoundError. utils.py is imported lazily, from the FA4
+# branch of flash_attn_varlen_func, so nothing surfaces until the first real
+# attention forward: engine init and the weight sync both succeed, then every
+# TP worker dies on the first rollout wave, EngineCore goes down, every
+# generation 500s and the infra budget aborts the run ~3 min into serving (jobs
+# 6233682 and 6234556, which is also where the scheduler's req_id_to_index
+# KeyError came from -- collateral from the workers dying mid-batch, not a
+# cause). FA4 is the default on these GB200s, so there is no getting to it.
+# Add to the candidate probe above:
+#
+#   unsquashfs -d /tmp/probe -f <image> \
+#     opt/ray_venvs/nemo_rl.models.generation.vllm.vllm_worker_async.\
+# VllmAsyncGenerationWorker/lib/python3.13/site-packages/vllm/vllm_flash_attn/\
+# cute/utils.py
+#   # follow the symlink into /root/.cache/uv, then:
+#   grep -n 'from cutlass' <extracted utils.py>   # must not name _mlir_helpers
+#
+# The 07-30 image passes that check but fails the Megatron one; 08-14 is the
+# only build in yifuw's directory that passes both.
+# -----------------------------------------------------------------------------
+export CONTAINER="${CONTAINER:-/lustre/fsw/portfolios/coreai/users/yifuw/enroot-images/gitlab-master.nvidia.com/yifuw/images/nemo-rl:omni_mopd_20260814_prefetched_venvs_arm64.squashfs}"
+
+# -----------------------------------------------------------------------------
+# Sandbox process DISABLED — this is what killed jobs 5726250 and 5732681.
+#
+# ray.sub launches the nemo-skills sandbox on every node with
+# `--kill-on-bad-exit=1` (ray.sub:967), unlike the Ray worker step which uses
+# `--kill-on-bad-exit=0` (ray.sub:1016). So a single node failing during sandbox
+# startup makes srun tear down all 64 sandbox tasks; ray.sub then sees its
+# background sandbox srun die and exits. At 64 nodes that happened on 3 of 3
+# attempts, on different nodes each time (nvl72133-T01, nvl72141-T07,
+# nvl72126-T05/T17) — node exclusion cannot fix it.
+#
+# Only three Gym servers use the sandbox: competitive_coding_challenges (not in
+# our blend), math_formal_lean and ns_tools. Both of the latter are in
+# config_paths and are LEFT THERE deliberately: they construct their sandbox
+# client lazily (math_formal_lean/app.py:387 builds it, :444 uses it inside a
+# request handler; ns_tools only holds sandbox_host/port as config), so they
+# boot fine without a sandbox and only contact it if a request routes to them.
+# The dolphin blend routes to neither, so the sandbox is never needed.
+#
+# ray.sub gates everything sandbox-related on SANDBOX_CONTAINER && SANDBOX_COMMAND
+# both being non-empty (ray.sub:559) — the ports dir, the 64-instance ready wait,
+# and the srun itself. The unmodified ultra launcher replaces an empty
+# SANDBOX_COMMAND with its default, so keep SANDBOX_CONTAINER empty instead.
+#
+# Side benefit: no 16 GB sandbox image extracted on 64 nodes, so faster startup.
+# To re-enable (e.g. if a future blend uses Lean4), explicitly set
+# SANDBOX_CONTAINER to the sandbox image path.
+# -----------------------------------------------------------------------------
+export SANDBOX_CONTAINER="${SANDBOX_CONTAINER-}"
+
+# -----------------------------------------------------------------------------
+# Caches
+# PERSISTENT_CACHE must be set explicitly: ultra_launch.sh requires it, and the
+# internal reference's derivation (/lustre/fsw/portfolios/${ACCOUNT%%_*}/users/$USER)
+# would resolve to /lustre/fsw/portfolios/nemotron/... which is read-only for us.
+# HF_HOME is a *sibling* of the cache, not inside it, because the launcher purges
+# vllm_compile_cache* under PERSISTENT_CACHE on every submission.
+# HF_HOME also decides where the HF->Megatron conversion of the 62 GB checkpoint
+# lands (get_megatron_checkpoint_dir falls back to $HF_HOME/nemo_rl), so keeping
+# it on Lustre means the conversion is done once, not once per job.
+# -----------------------------------------------------------------------------
+export PERSISTENT_CACHE="${PERSISTENT_CACHE:-/lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_llm/users/akamehra/.cache/nano35-dolphin}"
+export HF_HOME="${HF_HOME:-/lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_llm/users/akamehra/hf_home}"
+
+# -----------------------------------------------------------------------------
+# Container mounts — REQUIRED.
+# ultra_launch.sh starts MOUNTS empty and only appends three source overlays
+# (nemo_rl, examples/configs, Gym). It never mounts /lustre, so without this the
+# container cannot see the checkpoint, the blend jsonl, the judge models,
+# HF_HOME or PERSISTENT_CACHE. The internal reference hardcoded this mount.
+# -----------------------------------------------------------------------------
+export MOUNTS="${MOUNTS:-/lustre:/lustre}"
+
+# -----------------------------------------------------------------------------
+# Do not write bytecode into the Lustre-mounted source.
+#
+# nemo_rl is bind-mounted from Lustre into every container. Without this, all 64
+# nodes write .pyc back into that shared tree (194 files appeared during earlier
+# runs, including generation/__pycache__/interfaces.cpython-313.pyc). That is
+# metadata churn on the exact directories every node is importing from.
+#
+# Job 5742619 died when Ray unpickled VllmAsyncGenerationWorker on one node:
+# __init__.py executed from the mount, then its sibling interfaces.py was not
+# found — a per-node directory-view inconsistency, not a missing file. Reads
+# alone are far safer than reads plus concurrent writes.
+# -----------------------------------------------------------------------------
+export PYTHONDONTWRITEBYTECODE="${PYTHONDONTWRITEBYTECODE:-1}"
+
+# -----------------------------------------------------------------------------
+# examples/nemo_gym mount — REQUIRED, and the reason job 5730369 died with
+#   FileNotFoundError: /opt/nemo-rl/examples/nemo_gym/nemotron-3.5-nano/rlvr_dolphin.yaml
+#
+# ultra_launch.sh overlays only nemo_rl, examples/configs and Gym. Everything
+# else under /opt/nemo-rl — including examples/nemo_gym, where this recipe and
+# the nemotron-3-ultra base config live — comes from the container image.
+# Two things are therefore invisible without this mount:
+#   1. rlvr_dolphin.yaml itself (written here, never in any image), and
+#   2. nemotron-3-ultra/student_rlvr1.yaml, which it inherits — that landed on
+#      main in 64cb9f985 (Jul 29-30) but this image was built Jul 26, so the
+#      image genuinely does not contain it (verified by inspecting the image).
+# Mounting the directory fixes both, and also removes a version skew: nemo_rl
+# would otherwise come from this checkout while examples/nemo_gym came from a
+# Jul-26 image.
+#
+# Scoped to this one directory rather than mounting the repo root over
+# /opt/nemo-rl, to avoid shadowing anything the image builds in place.
+# -----------------------------------------------------------------------------
+_NEMO_GYM_MOUNT="${REPO_ROOT}/examples/nemo_gym:/opt/nemo-rl/examples/nemo_gym"
+if [[ -n "${EXTRA_MOUNTS:-}" ]]; then
+  export EXTRA_MOUNTS="${EXTRA_MOUNTS},${_NEMO_GYM_MOUNT}"
+else
+  export EXTRA_MOUNTS="${_NEMO_GYM_MOUNT}"
+fi
+
+# -----------------------------------------------------------------------------
+# Snapshotting is OFF because tools/code_snapshot.sh copies only *git-tracked*
+# files, and this recipe is untracked (`?? examples/nemo_gym/nemotron-3.5-nano/`).
+# With snapshotting on, the mount above would point into a snapshot that does
+# not contain the config. To restore frozen provenance, `git add` the recipe and
+# set USE_SNAPSHOT=1.
+# -----------------------------------------------------------------------------
+export USE_SNAPSHOT="${USE_SNAPSHOT:-0}"
+
+# -----------------------------------------------------------------------------
+# Results root — MUST be absolute.
+# ultra_launch.sh defaults RESULTS_DIR to the relative "results/${EXP_NAME}".
+# The host mkdir would land it in the repo, but TRAIN_CMD does `cd /opt/nemo-rl`
+# inside the container, so the same relative string resolves to
+# /opt/nemo-rl/results/... — the container's ephemeral overlay. Checkpoints
+# would vanish at job end and the singleton auto-resume would never find them,
+# so on a 4 h wall the run would restart from the SFT checkpoint forever.
+# An absolute Lustre path fixes checkpoints, logs, ray_logs and slurm output.
+# -----------------------------------------------------------------------------
+export RESULTS_DIR="${RESULTS_DIR:-/lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_llm/users/akamehra/runs/${EXP_NAME}}"
+
+# -----------------------------------------------------------------------------
+# SLURM
+# Job shape: 8 train + 40 gen + 16 gym = 64 GB200 nodes (4 GPUs each), a 5:1
+# generation-to-training split. GenRM runs in its own allocation (2 replicas x
+# 2 nodes), so the campaign footprint is 68 nodes.
+# SEGMENT_SIZE=2 is the nano value; ultra defaults to 16.
+# Partition `batch` caps at 4 h (batch_long is 7 d), so WALLTIME is 4 h and
+# CHECKPOINTING_SAVE_BY keeps the reference's 25-minute teardown margin.
+# -----------------------------------------------------------------------------
+export SLURM_ACCOUNT="${SLURM_ACCOUNT:-nemotron_sw_post}"
+export SLURM_PARTITION="${SLURM_PARTITION:-batch}"
+export WALLTIME="${WALLTIME:-4:00:00}"
+# Async rollout collection can leave the training GPUs idle while judges work,
+# and startup is idle end to end: job 5965796 needed 56 minutes to reach its
+# first optimizer step and the reaper took it at 60. This is the name
+# ultra_launch.sh actually reads -- JOB_REAPER_EXEMPT_IDLE_MINS was never
+# consumed by anything, so the banner reported a number with no effect.
+export JOB_REAPER_EXEMPT_MINS="${JOB_REAPER_EXEMPT_MINS:-120}"
+export CHECKPOINTING_SAVE_BY="${CHECKPOINTING_SAVE_BY:-00:03:35:00}"
+export NUM_TRAIN_NODES="${NUM_TRAIN_NODES:-8}"
+export NUM_GEN_NODES="${NUM_GEN_NODES:-40}"
+export NUM_GYM_NODES="${NUM_GYM_NODES:-${_DEFAULT_GYM_NODES}}"
+export SEGMENT_SIZE="${SEGMENT_SIZE:-2}"
+
+# -----------------------------------------------------------------------------
+# W&B. WANDB_API_KEY must already be in the environment — ultra_launch.sh needs
+# it. If it is exported only from ~/.zshrc, submit from zsh; a bash context
+# will not see it.
+# -----------------------------------------------------------------------------
+export WANDB_PROJ="${WANDB_PROJ:-ultra-streaming}"
+export WANDB_ENTITY="${WANDB_ENTITY:-joc}"
+
+# MTP: head *training* is on via the config (5 repeated layers, loss 0.3,
+# detached heads), matching the reference. MTP *speculative decoding* for vLLM
+# is a separate, independent switch and is off, also matching the reference.
+export ENABLE_MTP_INFERENCE="${ENABLE_MTP_INFERENCE:-0}"
+
+echo "================================================================"
+echo "  Nemotron 3.5 Nano — RLVR async-1 (honest-dolphin)"
+echo "================================================================"
+echo "  Experiment : ${EXP_NAME}"
+echo "  Config     : ${CONFIG_PATH}"
+echo "  Model      : ${MODEL_PATH}"
+echo "  Blend      : ${TRAIN_PATH}"
+echo "  Container  : ${CONTAINER}"
+echo "  Cache      : ${PERSISTENT_CACHE}"
+echo "  HF_HOME    : ${HF_HOME}"
+if [[ "${EXTERNAL_JUDGES}" == "1" ]]; then
+echo "  GenRM      : in-job hetgroup — ${GENRM_REPLICAS} x TP=${GENRM_TENSOR_PARALLEL_SIZE}"
+echo "               ${GENRM_MODEL}"
+echo "  NL2Bash    : in-job hetgroup — ${NL2BASH_REPLICAS} x TP=${NL2BASH_TENSOR_PARALLEL_SIZE}"
+else
+echo "  GenRM      : ${GENRM_BASE_URL} (external pool; served model name: model)"
+echo "  NL2Bash    : served in the Gym pool"
+fi
+echo "  SLURM      : ${SLURM_ACCOUNT} / ${SLURM_PARTITION} / ${WALLTIME}"
+echo "  Reaper     : ${JOB_REAPER_EXEMPT_MINS} min idle exemption"
+echo "  Nodes      : ${NUM_TRAIN_NODES} train + ${NUM_GEN_NODES} gen + ${NUM_GYM_NODES} gym"
+echo "  W&B        : ${WANDB_ENTITY}/${WANDB_PROJ}"
+echo "================================================================"
+echo ""
+
+exec bash examples/nemo_gym/nemotron-3-ultra/ultra_launch.sh "$@"

--- a/examples/nemo_gym/nemotron-3.5-nano/nano35_dolphin_launch_sc.sh
+++ b/examples/nemo_gym/nemotron-3.5-nano/nano35_dolphin_launch_sc.sh
@@ -1,0 +1,226 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# =============================================================================
+# nano35_dolphin_launch_sc.sh
+#
+# SingleController variant of nano35_dolphin_launch.sh: the same 64-node
+# Nemotron 3.5 Nano RLVR pipeclean, driven by run_grpo_single_controller.py
+# with streaming forward/backward, the TransferQueue data plane and
+# shard-to-shard NCCL-reshard weight refit.
+#
+# Shape (GB200, 4 GPUs/node -> 256 GPUs), unchanged from the baseline so the
+# two runs are comparable:
+#   8 train + 40 generation + 16 gym = 64 nodes  (5:1 generation-to-training)
+# GenRM adds 4 nodes from its own allocation, so the campaign footprint is 68.
+#
+# This is a thin wrapper over nano35_dolphin_launch.sh, which already carries
+# every site default (model, blend, judges, container, mounts, caches, Slurm).
+# We only swap the config and the driver, so the two runs differ solely in the
+# SC wiring.
+#
+# NO CHECKPOINTING. The SC path raises if checkpointing.enabled is true, so the
+# run cannot resume across the wall clock and the baseline's singleton
+# auto-resume buys nothing here. Size NRL_MAX_STEPS to fit the 4 h allocation.
+#
+# Usage:
+#   GENRM_BASE_URL=http://<lb-host>:9213/v1 \
+#     bash examples/nemo_gym/nemotron-3.5-nano/nano35_dolphin_launch_sc.sh
+#
+#   DRY_RUN=1 GENRM_BASE_URL=... bash .../nano35_dolphin_launch_sc.sh
+#
+# GenRM must already be serving — see the GenRM section of the baseline script
+# for how to stand up the external pool, or pass EXTERNAL_JUDGES=1 to host
+# GenRM and the NL2Bash judge in a hetgroup inside this job instead, which is
+# the shape the 6K recipe uses.
+#
+# Optional:
+#   NRL_MAX_STEPS=10             # short pipeclean
+#   STREAM_MIN_GROUPS=32         # async_rl.min_groups_for_streaming_train
+#   SAMPLER=ready_first          # ready_first | in_order | windowed
+#   MAX_LOOKAHEAD_VERSIONS=4     # the sampler's slack, whatever it spells it
+#                                # 1 restores parity with the async-1 baseline
+#   BUFFER_RETENTION_MULTIPLIER=2  # max_buffered_rollouts only; gated samplers
+#   NUM_STORAGE_UNITS=16         # data_plane.num_storage_units
+#   GYM_MAX_CONCURRENCY=1280     # env.nemo_gym.max_concurrency; unset = Ray's 1000
+#   REFIT_TRANSPORT=null         # fall back to the full-tensor NCCL broadcast
+#
+# Extra positional args are forwarded as Hydra overrides, after ours, so they win.
+# =============================================================================
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+export CONFIG_PATH="${CONFIG_PATH:-examples/nemo_gym/nemotron-3.5-nano/rlvr_dolphin_sc.yaml}"
+
+# The SC driver. data_plane.enabled=true (set in the config) is mandatory for it.
+export TRAIN_ENTRYPOINT="${TRAIN_ENTRYPOINT:-./examples/run_grpo_single_controller.py}"
+
+# Distinct from the baseline's EXP_NAME so this starts a new W&B run, run dir
+# and singleton job name rather than colliding with the async-1 baseline.
+export EXP_NAME="${EXP_NAME:-akamehra-nano35-honest-dolphin-v10-iter6000-rlvr-sc-tp4_cp4_ep8_pp1_gpp16_pps128_gbs2048}"
+
+# The SC knobs worth sweeping without editing the config.
+#
+# STREAM_MIN_GROUPS starts the optimizer step earlier on partial cohorts.
+# NUM_STORAGE_UNITS is the untuned one at this data volume. It is passed as a
+# Hydra override unconditionally below, so it beats the recipe and the value in
+# rlvr_dolphin_sc.yaml is never what runs — keep the two in step. It shards a
+# global pool rather than reserving per unit, so over-provisioning costs only a
+# CPU actor each; the windowed sweep's 14336 peak rows are 1.4% of capacity.
+# MAX_LOOKAHEAD_VERSIONS is the sampler's slack, in trainer versions, whichever
+# sampler is selected; raising it also raises the two capacity floors below,
+# which validate_sampler_buffer_capacity enforces (max_buffered_rollouts >=
+# num_prompts_per_step * (slack + 1)). Under ready_first it bounds admission
+# only — a group that commits late is still trained on, so it is not a ceiling
+# on realized staleness the way its name suggests.
+STREAM_MIN_GROUPS="${STREAM_MIN_GROUPS:-32}"
+NUM_STORAGE_UNITS="${NUM_STORAGE_UNITS:-16}"
+MAX_LOOKAHEAD_VERSIONS="${MAX_LOOKAHEAD_VERSIONS:-4}"
+
+# Ray's max_concurrency for the single NemoGym actor. Empty means "don't pass
+# it", leaving Ray's asyncio default of 1000, which is above this recipe's 640
+# in-flight prompts and therefore not binding. Set it when the offered load
+# crosses 1000 (the 6K shape offered 5120 and completed no steps), or to cap the
+# actor below the offered load deliberately as an inverse probe.
+#
+# Expanded below as ${_GYM_OVERRIDES[@]+"${_GYM_OVERRIDES[@]}"} because `set -u`
+# treats a plain "${arr[@]}" on an empty array as unbound on bash before 4.4.
+GYM_MAX_CONCURRENCY="${GYM_MAX_CONCURRENCY:-}"
+_GYM_OVERRIDES=()
+if [[ -n "${GYM_MAX_CONCURRENCY}" ]]; then
+  _GYM_OVERRIDES+=("env.nemo_gym.max_concurrency=${GYM_MAX_CONCURRENCY}")
+fi
+
+# Which selection policy the slack above configures. The samplers spell it
+# differently — in_order counts dispatch batches of lookahead, ready_first and
+# windowed count weight versions of staleness — and every sampler config is
+# extra="allow", so passing the wrong key is accepted and silently ignored,
+# leaving that arm sitting at the default of 1. Emitting only the key that
+# matches SAMPLER is what stops a sweep from quietly running four copies of the
+# same configuration; tests/unit/single_controller/test_sampler_interface.py
+# pins the footgun so the launcher and the schema cannot drift apart.
+#
+# rlvr_dolphin_sc.yaml now declares the ready_first block, so ready_first and
+# windowed override their key in place while in_order has to add its own. Hydra
+# runs in struct mode: `+` on a key that already exists is an error, and a plain
+# override of one that does not is also an error, so these forms are not
+# interchangeable. Keys belonging to the samplers not chosen stay in the dict
+# and are inert — every config accepts extras — but they do show up in the
+# resolved config, so read `name` first when checking an arm.
+SAMPLER="${SAMPLER:-ready_first}"
+case "${SAMPLER}" in
+  ready_first)
+    _SAMPLER_OVERRIDES=(
+      "async_rl.sampler.name=ready_first"
+      "async_rl.sampler.max_staleness_versions=${MAX_LOOKAHEAD_VERSIONS}"
+    )
+    ;;
+  in_order)
+    _SAMPLER_OVERRIDES=(
+      "async_rl.sampler.name=in_order"
+      "+async_rl.sampler.max_lookahead_versions=${MAX_LOOKAHEAD_VERSIONS}"
+    )
+    ;;
+  windowed)
+    _SAMPLER_OVERRIDES=(
+      "async_rl.sampler.name=windowed"
+      "async_rl.sampler.max_staleness_versions=${MAX_LOOKAHEAD_VERSIONS}"
+    )
+    ;;
+  *)
+    echo "SAMPLER must be ready_first, in_order or windowed, got '${SAMPLER}'" >&2
+    exit 1
+    ;;
+esac
+
+# Shard-to-shard weight refit, on by default in this variant. It is still
+# experimental, so keep the escape hatch one env var away: REFIT_TRANSPORT=null
+# restores the full-tensor broadcast that rlvr_dolphin.yaml uses.
+REFIT_TRANSPORT="${REFIT_TRANSPORT:-nccl_reshard}"
+
+_NUM_PROMPTS_PER_STEP="${_NUM_PROMPTS_PER_STEP:-128}"
+
+# Generation quota: the current cohort plus every lookahead cohort in flight at
+# once. This is the number that must not move, because it is what the arms are
+# compared on.
+_MAX_INFLIGHT_PROMPTS=$(( _NUM_PROMPTS_PER_STEP * (MAX_LOOKAHEAD_VERSIONS + 1) ))
+
+# Retention headroom, as a multiple of that quota. These were one variable until
+# ready_first made them different quantities.
+#
+# _buffer_capacity is a per-group semaphore taken at dispatch and released on
+# select, evict, or failure. Zero eviction deletes one of those three release
+# paths, so groups that have finished generating but have not yet been trained
+# on stay resident holding permits. At a multiplier of 1 they are holding
+# permits out of the same pool that admission draws from, so the finished work
+# crowds out new generation -- the fix for eviction creates a throughput
+# problem one layer down.
+#
+# A multiplier above 1 gives retention its own headroom, which is what v1 does:
+# late_arrival_slack=2 sizes its retention at P*lag*2 against a generation quota
+# of P*lag. Retention strictly exceeding what admission can produce is the
+# property that stops completed work from starving dispatch.
+#
+# This is NOT job 6014206 (768 buffered against 384 in flight, 1.8x slower).
+# That arm ran WindowedSampler, which derives from BaseSampler and whose admit
+# returns None immediately -- "dispatch is bounded by buffer capacity, not by
+# version" -- so there the buffer was the only thing limiting dispatch and
+# raising it raised dispatch. ready_first is a _GatedSampler: _dispatch_index
+# caps admission at MAX_LOOKAHEAD_VERSIONS+1 batches independently of the
+# buffer, so raising the buffer raises retention only. The guard below is what
+# keeps that reasoning honest rather than a comment nobody rereads.
+BUFFER_RETENTION_MULTIPLIER="${BUFFER_RETENTION_MULTIPLIER:-1}"
+_MAX_BUFFERED_ROLLOUTS=$(( _MAX_INFLIGHT_PROMPTS * BUFFER_RETENTION_MULTIPLIER ))
+
+if (( BUFFER_RETENTION_MULTIPLIER < 1 )); then
+  echo "BUFFER_RETENTION_MULTIPLIER must be >= 1, got ${BUFFER_RETENTION_MULTIPLIER}." >&2
+  echo "Below 1 the buffer sits under the sampler's required floor and the train" >&2
+  echo "pump waits for a batch the buffer is too small to ever hold." >&2
+  exit 1
+fi
+
+if (( BUFFER_RETENTION_MULTIPLIER > 1 )) && [[ "${SAMPLER}" == "windowed" ]]; then
+  echo "BUFFER_RETENTION_MULTIPLIER=${BUFFER_RETENTION_MULTIPLIER} with SAMPLER=windowed is the 6014206 trap." >&2
+  echo "WindowedSampler.admit returns None, so the buffer is its only dispatch" >&2
+  echo "limit and raising it raises dispatch: that arm ran 1.8x slower. Only the" >&2
+  echo "gated samplers (ready_first, in_order, weight_fifo) can take a multiplier." >&2
+  exit 1
+fi
+
+echo "================================================================"
+echo "  Nemotron 3.5 Nano — RLVR SingleController (honest-dolphin)"
+echo "================================================================"
+echo "  Entrypoint : ${TRAIN_ENTRYPOINT}"
+echo "  Config     : ${CONFIG_PATH}"
+echo "  Refit      : ${REFIT_TRANSPORT}"
+echo "  Streaming  : min ${STREAM_MIN_GROUPS} of ${_NUM_PROMPTS_PER_STEP} groups per dispatch"
+echo "  Sampler    : ${SAMPLER} (slack ${MAX_LOOKAHEAD_VERSIONS})"
+echo "  Capacity   : buffer ${_MAX_BUFFERED_ROLLOUTS} groups (x${BUFFER_RETENTION_MULTIPLIER}), ${_MAX_INFLIGHT_PROMPTS} in flight"
+echo "  TQ units   : ${NUM_STORAGE_UNITS}"
+echo "  Gym concur : ${GYM_MAX_CONCURRENCY:-unset (Ray default 1000)}"
+echo "================================================================"
+echo ""
+
+exec bash "${SCRIPT_DIR}/nano35_dolphin_launch.sh" \
+  "async_rl.min_groups_for_streaming_train=${STREAM_MIN_GROUPS}" \
+  "${_SAMPLER_OVERRIDES[@]}" \
+  "async_rl.max_inflight_prompts=${_MAX_INFLIGHT_PROMPTS}" \
+  "async_rl.max_buffered_rollouts=${_MAX_BUFFERED_ROLLOUTS}" \
+  "data_plane.num_storage_units=${NUM_STORAGE_UNITS}" \
+  "policy.generation.refit_transport=${REFIT_TRANSPORT}" \
+  ${_GYM_OVERRIDES[@]+"${_GYM_OVERRIDES[@]}"} \
+  "$@"

--- a/examples/nemo_gym/nemotron-3.5-nano/nano35_dolphin_launch_sc_smoke.sh
+++ b/examples/nemo_gym/nemotron-3.5-nano/nano35_dolphin_launch_sc_smoke.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# =============================================================================
+# Nemotron 3.5 Nano — 8-node SingleController pipeclean
+#
+# Scaled-down nano35_dolphin_launch_sc.sh for validating the stack end to end
+# before spending a 68-node allocation: SingleController, the TransferQueue
+# data plane, nccl_reshard refit with MTP-head gating, and the in-job judge
+# hetgroup this recipe gained from the 6K side.
+#
+# Usage:
+#   bash examples/nemo_gym/nemotron-3.5-nano/nano35_dolphin_launch_sc_smoke.sh
+#   DRY_RUN=1 bash .../nano35_dolphin_launch_sc_smoke.sh        # inspect only
+#
+# Training parallelism is deliberately NOT scaled. Four nodes is the floor that
+# preserves it exactly: TP=4 x CP=4 x PP=1 fills 16 GPUs, and EP=8 still divides
+# 16 at ETP=1, so every rank owns the same 16 of the 128 routed experts as the
+# full-scale run. The only difference is DP, which drops from 2 to 1.
+# Going to 2 training nodes would force CP below 4, and CP=4 is what makes the
+# 73728-token context tractable, so the comparison would stop being meaningful.
+#
+# Sequence length is left at the production 73728 on purpose. Truncating it
+# would risk failures in the blend rather than in the code under test, and
+# generation length is bounded by EOS in practice, not by the cap.
+#
+# What gets scaled instead is the cohort, from 128 prompts to 8, and the step
+# count. NRL_MAX_STEPS must stay >= 2: the first weight sync only happens
+# between steps, and refit is the main thing this run exists to exercise.
+#
+# The default shape is 8 nodes total. Raise NUM_GEN_NODES / NUM_GYM_NODES to 2
+# each (10 nodes) if rollouts are throughput-bound or Gym's env servers are
+# cramped on a single node.
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+# 4 + 1 + 1 in hetgroup 0, plus 2 service nodes below = 8. Both counts have to
+# stay divisible by their segment size, which is 2 on nano.
+export NUM_TRAIN_NODES="${NUM_TRAIN_NODES:-4}"
+export NUM_GEN_NODES="${NUM_GEN_NODES:-1}"
+export NUM_GYM_NODES="${NUM_GYM_NODES:-1}"
+export SEGMENT_SIZE="${SEGMENT_SIZE:-2}"
+
+# Judges in-job, which is the path that has never been run and the main reason
+# this profile exists. One replica each at the production TP, so the servers
+# are sharded exactly as they would be at full scale -- there are just fewer.
+# This also frees Gym down to a single node, since only the safety judge
+# (TP=1, DP=1) still runs there.
+export EXTERNAL_JUDGES="${EXTERNAL_JUDGES:-1}"
+export GENRM_REPLICAS="${GENRM_REPLICAS:-1}"
+export GENRM_TENSOR_PARALLEL_SIZE="${GENRM_TENSOR_PARALLEL_SIZE:-4}"
+export NL2BASH_REPLICAS="${NL2BASH_REPLICAS:-1}"
+export NL2BASH_TENSOR_PARALLEL_SIZE="${NL2BASH_TENSOR_PARALLEL_SIZE:-4}"
+export EXTERNAL_VLLM_SEGMENT_SIZE="${EXTERNAL_VLLM_SEGMENT_SIZE:-2}"
+
+# 8 prompts x 16 generations. Over DP=1 that is 128 sequences per rank against
+# 1024 at full scale, so this is strictly lighter per GPU, not heavier.
+NUM_PROMPTS_PER_STEP="${NUM_PROMPTS_PER_STEP:-8}"
+TRAIN_GLOBAL_BATCH_SIZE="${TRAIN_GLOBAL_BATCH_SIZE:-$((NUM_PROMPTS_PER_STEP * 16))}"
+
+# Production lookahead, so the sampler and its capacity checks behave as they
+# would at scale; the buffer floor scales with the cohort.
+MAX_LOOKAHEAD_VERSIONS="${MAX_LOOKAHEAD_VERSIONS:-4}"
+export MAX_LOOKAHEAD_VERSIONS
+export _NUM_PROMPTS_PER_STEP="${NUM_PROMPTS_PER_STEP}"
+
+# Start the optimizer on a quarter cohort so streaming is actually exercised
+# rather than trivially satisfied by the full cohort arriving at once.
+export STREAM_MIN_GROUPS="${STREAM_MIN_GROUPS:-$((NUM_PROMPTS_PER_STEP / 4))}"
+export NUM_STORAGE_UNITS="${NUM_STORAGE_UNITS:-2}"
+
+# The full-scale recipe inherits akamehra's results and cache directories from
+# the reference run, and they are not group-writable. Point both at the
+# submitter's own scratch so this profile runs as-is for whoever launches it.
+_USER_SCRATCH="/lustre/fsw/portfolios/llmservice/users/${USER}"
+export RESULTS_DIR="${RESULTS_DIR:-${_USER_SCRATCH}/runs/nano35-sc-pipeclean-n8}"
+export PERSISTENT_CACHE="${PERSISTENT_CACHE:-${_USER_SCRATCH}/.cache/nano35-dolphin}"
+
+export EXP_NAME="${EXP_NAME:-${USER}-nano35-sc-pipeclean-n8}"
+export NRL_MAX_STEPS="${NRL_MAX_STEPS:-3}"
+export WALLTIME="${WALLTIME:-2:00:00}"
+export SLURM_QOS="${SLURM_QOS:-short}"
+# Run the live worktree rather than a submission-time copy, so a fix can be
+# retried without re-snapshotting between attempts.
+export USE_SNAPSHOT="${USE_SNAPSHOT:-0}"
+
+if (( NRL_MAX_STEPS < 2 )); then
+  echo "ERROR: NRL_MAX_STEPS=${NRL_MAX_STEPS} never reaches a weight sync, which" >&2
+  echo "       leaves nccl_reshard refit -- the point of this run -- untested." >&2
+  exit 1
+fi
+
+echo "Nemotron 3.5 Nano — SingleController pipeclean profile"
+echo "  hetgroup 0: train=${NUM_TRAIN_NODES}, generation=${NUM_GEN_NODES}, Gym=${NUM_GYM_NODES}"
+echo "  hetgroup 1: GenRM=${GENRM_REPLICAS}xTP${GENRM_TENSOR_PARALLEL_SIZE}, NL2Bash=${NL2BASH_REPLICAS}xTP${NL2BASH_TENSOR_PARALLEL_SIZE}"
+echo "  parallelism: TP4 x CP4 x EP8 x PP1 (ETP1) — unchanged, DP 2 -> 1"
+echo "  batch: prompts=${NUM_PROMPTS_PER_STEP}, generations=16, global=${TRAIN_GLOBAL_BATCH_SIZE}"
+echo "  steps: ${NRL_MAX_STEPS}"
+
+# The per-step floor is a fraction of the cohort, and the cohort is what this
+# profile shrinks, so the recipe's production value does not survive the scaling:
+# the floor is ceil(num_prompts_per_step * fraction), which at 0.9 of 8 is 8 --
+# every prompt required, so the first drop that survives replacement aborts the
+# run. At the full 128 the same fraction tolerates 12. Scale it back to something
+# a cohort of 8 can express: ceil(8 * 0.75) = 6, so two drops are absorbed and an
+# emptier batch is still refused. Only the in_order arm can reach this at all --
+# ready_first does not stamp a target step, so nothing is ever credited short.
+MIN_STEP_BATCH_FRACTION="${MIN_STEP_BATCH_FRACTION:-0.75}"
+
+exec bash "${SCRIPT_DIR}/nano35_dolphin_launch_sc.sh" \
+  "grpo.num_prompts_per_step=${NUM_PROMPTS_PER_STEP}" \
+  "policy.train_global_batch_size=${TRAIN_GLOBAL_BATCH_SIZE}" \
+  "async_rl.rollout_failure.min_step_batch_fraction=${MIN_STEP_BATCH_FRACTION}" \
+  "$@"

--- a/examples/nemo_gym/nemotron-3.5-nano/rlvr_dolphin.yaml
+++ b/examples/nemo_gym/nemotron-3.5-nano/rlvr_dolphin.yaml
@@ -1,0 +1,336 @@
+# =============================================================================
+# Nemotron 3.5 Nano — RLVR, legacy async-1, honest-dolphin warm start
+# =============================================================================
+# Reproduces the internal reference run
+#   geshen-ultra-rl-nano-honest-dolphin-v10-iter6000-mopd-rlvr
+#   (launch_nano_honest_dolphin.sh + examples/configs/grpo_ultra_512n4g_bf16.yaml
+#    on nemo-rl-internal @ 97c55ee2, branch geshen/nano_training)
+# on public NeMo-RL main.
+#
+# Inherits examples/nemo_gym/nemotron-3-ultra/student_rlvr1.yaml. "ultra" there
+# names the RLVR *recipe lineage* — the 34-env Gym blend, GenRM comparison
+# judging, judge topology, reward penalties, async-1 — not the model. The
+# reference does the same thing: it runs the nano checkpoint against the ultra
+# config and overrides parallelism. Everything ultra-shaped is overridden below.
+#
+# Model: NemotronH hybrid-Mamba MoE, 52 layers, hidden 2688, 128 routed experts
+# top-6 + 1 shared, 32 heads / 2 KV, mamba n_groups=8, MTP 1 layer, vocab 131072.
+#
+# Node budget (GB200, 4 GPU/node), sbatch --nodes=64:
+#   8 train + 40 generation   -> cluster.num_nodes = 48
+#   16 gym                    -> env.nemo_gym.num_gpu_nodes = 16
+#
+# A 5:1 generation-to-training split. GenRM is served from a SEPARATE
+# allocation (2 replicas x 2 nodes = 4 nodes), so the campaign footprint is 68
+# nodes even though this job asks for 64.
+# =============================================================================
+defaults: ../nemotron-3-ultra/student_rlvr1.yaml
+
+# -----------------------------------------------------------------------------
+# Cluster — ultra was 256 nodes / segment 16; nano uses 48 actor nodes / segment 2
+# -----------------------------------------------------------------------------
+cluster:
+  gpus_per_node: 4
+  num_nodes: 48
+  segment_size: 2
+
+checkpointing:
+  # 4 h wall on partition `batch` (batch_long's 7 d is not what we're using),
+  # minus the reference's 25 min teardown margin.
+  checkpoint_must_save_by: "00:03:35:00"
+  # Reference used 10 against a 24 h wall. At 4 h a slow step can mean a job
+  # restarts having saved nothing and re-does the same work forever. Raise back
+  # toward 10 once step time is measured.
+  save_period: 5
+  save_optimizer: true
+
+grpo:
+  # Stability setting: cut the prompt groups while retaining 16 generations per
+  # prompt. This yields 2048 samples/step and an async replay-buffer capacity
+  # of 256 groups.
+  num_prompts_per_step: 128
+  # Validation is effectively off in the reference; genrm cohort envs are
+  # train-only and would hang under eval.
+  val_period: 10000000
+  # REQUIRED by GRPOConfig, and absent from the inherited student_rlvr1.yaml —
+  # upstream inconsistency: 83753ed56 (Jul 29-30) added val_start_at as a required
+  # field while 64cb9f985 added the ultra recipes without it, so student_rlvr1.yaml
+  # on main cannot be validated by MasterConfig. Killed job 5733424 with
+  # "ValidationError: grpo.val_start_at Field required".
+  # -1 disables the delay, matching grpo_nanov3.yaml and grpo_math_1B.yaml.
+  val_start_at: -1
+
+# -----------------------------------------------------------------------------
+# Policy — nano parallelism (reference: TP=4 CP=4 EP=16 PP=1 ETP=1)
+# -----------------------------------------------------------------------------
+policy:
+  model_name: /lustre/fsw/portfolios/llmservice/users/venkats/training_actual_0603/nano_n3_post/checkpoints/nano-3.5-sft-v10-closethink-unmask-orig6k-from-midtrain-100B-lc-lr2e-5/eval/iter_0006000/hf
+
+  # Must equal num_prompts_per_step * num_generations_per_prompt: 128 * 16.
+  # Over DP=2 (32 training GPUs / TP4 x CP4 x PP1) this is 1024 sequences per
+  # data-parallel rank — the same per-rank load as the 16-node / GBS 4096 shape
+  # this replaces, so per-GPU memory pressure is unchanged.
+  train_global_batch_size: 2048
+
+  # Ultra base is 49152. Reference nano runs 73728.
+  max_total_sequence_length: 73728
+
+  megatron_cfg:
+    tensor_model_parallel_size: 4
+    expert_tensor_parallel_size: 1
+    # 128 routed experts / EP8 = 16 experts per rank. Matches the control run
+    # (job 5931924) so the judge relocation is the only variable between them.
+    expert_model_parallel_size: 8
+    pipeline_model_parallel_size: 1
+    context_parallel_size: 4
+    moe_token_dispatcher_type: "alltoall"
+    moe_flex_dispatcher_backend: "alltoall"
+    # MTP head training is inherited unchanged from the base and matches the
+    # reference exactly: mtp_num_layers 5, loss_scaling 0.3, use_repeated_layer
+    # true, detach_heads true. detach_heads keeps the MTP loss off the backbone,
+    # so it cannot perturb GRPO. use_repeated_layer reconciles 5 with the
+    # checkpoint's num_nextn_predict_layers=1 (one layer's weights reused 5x).
+
+  generation:
+    # Base hardcodes 49152; re-tie to the policy value.
+    max_new_tokens: ${policy.max_total_sequence_length}
+
+    vllm_cfg:
+      tensor_parallel_size: 4
+      # Reference runs EP=1 for nano. vLLM's EP = DP * TP, and EP > TP is
+      # blocked upstream (NVIDIA-NeMo/RL#1101).
+      expert_parallel_size: 1
+      max_model_len: ${policy.max_total_sequence_length}
+      # 0.85 -> 0.80. Job 5744748 died in weight refit:
+      #   update_weights_from_collective: CUDA out of memory.
+      #   Tried to allocate 3.69 GiB. GPU has 184.31 GiB total, 1.61 GiB free;
+      #   this process holds 163.22 GiB.
+      # The OOM killed that vLLM rank, which was a participant in the NCCL
+      # collective, so MegatronPolicyWorker rank=0/22 aborted with it.
+      # 0.80 frees ~9 GiB per GPU against a 3.69 GiB staging buffer.
+      # The 40-node smoke run refit fine at 0.85 because it had 32 generation
+      # ranks; the buffer grows with that count. This shape has 160, more than
+      # the 128 that OOM'd, so 0.80 is a floor to watch rather than a settled
+      # value. Costs some KV cache, so slightly lower generation throughput.
+      gpu_memory_utilization: 0.80
+      # nano_v3 reasoning parser + qwen3_coder tool parser are inherited and are
+      # correct for this checkpoint: its chat template emits <think> and the
+      # <tool_call><function=...><parameter=...> XML form.
+
+    vllm_kwargs:
+      # Hybrid Mamba allocates one state slot per running sequence. Base uses
+      # 256 (sized for ultra); the reference nano run uses 64 at 73728 tokens.
+      max_num_seqs: 64
+      # Required on vLLM 0.25 and NOT accepted by 0.20 -- this branch only runs
+      # against a 0.25 container. Left at the default "auto", 0.25 picks the
+      # FlashInfer TRT-LLM BF16 MoE, whose expert weights are 3D grouped
+      # tensors under the new routed_experts submodule. Refit then hands them to
+      # a loader that rejects the expert dimension: job 5944595 died in
+      # update_weights_from_collective with "shard_dim=0 is not a valid data
+      # dimension for a 3D tensor (expected 1 or 2)". flashinfer_cutlass keeps
+      # the layout refit can address and is the backend the 64-node Ultra smoke
+      # run (job 5939591) refit through step 4 with on this same container.
+      moe_backend: flashinfer_cutlass
+
+    colocated:
+      enabled: false
+      resources:
+        gpus_per_node: 4
+        # Overridden by the launch script via NUM_GEN_NODES.
+        num_nodes: 40
+
+# -----------------------------------------------------------------------------
+# Data — the launcher overrides these; defaults point at the reference blend.
+# trusty_viper carries agent_ref per row, so NeMo-Gym routes each row to its
+# family directly (no BlendDispatchAgent — that is a nemogym2mrl construct).
+# -----------------------------------------------------------------------------
+data:
+  train:
+    data_path: /lustre/fs1/portfolios/llmservice/projects/llmservice_modelalignment_ppo/users/geshen/rl-data-tools/blends/curriculum_honest_dolphin_v41_trusty_viper.train.jsonl
+  validation:
+    data_path: /lustre/fs1/portfolios/llmservice/projects/llmservice_modelalignment_ppo/users/geshen/rl-data-tools/blends/curriculum_honest_dolphin_v41_trusty_viper.train.jsonl
+
+env:
+  nemo_gym:
+    num_gpu_nodes: 16
+
+    # -------------------------------------------------------------------------
+    # Env blend. Identical to the base except rdkit_chemistry, which the base
+    # lists but the pinned Gym submodule (473f446) does not ship — it would fail
+    # at Gym startup. Unused by this blend, so dropped.
+    # -------------------------------------------------------------------------
+    config_paths:
+      - responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
+      - resources_servers/math_with_judge/configs/math_with_judge.yaml
+      - resources_servers/code_gen/configs/code_gen.yaml
+      - resources_servers/workplace_assistant/configs/workplace_assistant.yaml
+      - resources_servers/mcqa/configs/mcqa.yaml
+      - resources_servers/instruction_following/configs/instruction_following.yaml
+      - resources_servers/equivalence_llm_judge/configs/lc_judge.yaml
+      - resources_servers/calendar/configs/calendar.yaml
+      - resources_servers/genrm_compare/configs/genrm_compare.yaml
+      - resources_servers/equivalence_llm_judge/configs/nl2bash-equivalency.yaml
+      - resources_servers/equivalence_llm_judge/configs/equivalence_llm_judge.yaml
+      - resources_servers/single_step_tool_use_with_argument_comparison/configs/single_step_tool_use_with_argument_comparison.yaml
+      - resources_servers/reasoning_gym/configs/reasoning_gym.yaml
+      - resources_servers/terminus_judge/configs/terminus_judge_string_only.yaml
+      - resources_servers/ns_tools/configs/ns_tools.yaml
+      - resources_servers/math_formal_lean/configs/math_formal_lean_multi_turn.yaml
+      - resources_servers/multichallenge/configs/multichallenge.yaml
+      - resources_servers/inverse_if/configs/inverse_if.yaml
+      - resources_servers/single_step_tool_use_with_argument_comparison/configs/search_pivot_single_step_tool_use_with_argument_comparison.yaml
+      - resources_servers/single_step_tool_use_with_argument_comparison/configs/toolcall_schema_single_step_tool_use_with_argument_comparison.yaml
+      - resources_servers/single_step_tool_use_with_argument_comparison/configs/swe_pivot_single_step_tool_use_with_argument_comparison.yaml
+      - resources_servers/abstention/configs/abstention.yaml
+      - resources_servers/nvarc/configs/inductive.yaml
+      - resources_servers/nvarc/configs/transductive.yaml
+      - resources_servers/single_step_tool_use_with_argument_comparison/configs/droid_pivot_single_step_tool_use_with_argument_comparison.yaml
+      - resources_servers/equivalence_rule/configs/lc.yaml
+      - resources_servers/ether0/configs/ether0.yaml
+      - resources_servers/structured_outputs/configs/structured_outputs_json_yaml_xml_v1.yaml
+      - resources_servers/structured_outputs/configs/structured_outputs_v3.yaml
+      - resources_servers/format_verification/configs/freeform_formatting.yaml
+      - resources_servers/format_verification/configs/citation_format.yaml
+      - resources_servers/jailbreak_detection/configs/jailbreak_detection_nemotron_combined_reward_tp8.yaml
+      - resources_servers/indirect_prompt_injection/configs/indirect_prompt_injection.yaml
+
+    # -------------------------------------------------------------------------
+    # GenRM — EXTERNAL. The launcher sets base_url to the compute-side load
+    # balancer. `model` must match the external vLLM --served-model-name.
+    # Local vLLM settings below are inert whenever base_url is set.
+    # -------------------------------------------------------------------------
+    genrm_model:
+      _override_: true
+      responses_api_models:
+        genrm_model:
+          entrypoint: app.py
+          api_key: dummy_key
+          base_url: null         # set by the launcher via GENRM_BASE_URL
+          model: "model"
+          uses_reasoning_parser: true
+          return_token_id_information: false
+          debug: true
+          ray_worker_py_executable: /opt/ray_venvs/nemo_rl.models.generation.vllm.vllm_worker_async.VllmAsyncGenerationWorker/bin/python
+          # Aligned to nl2bash_judge_model where their roles overlap, except for
+          # GenRM-specific data parallelism, parsing, batching, and load format.
+          # Job 5746440's external GenRM predecessor died with a Triton illegal
+          # memory access; that incident is separate from job 5755734's internal
+          # nl2bash collective stall.
+          vllm_serve_env_vars:
+            VLLM_RAY_DP_PACK_STRATEGY: strict
+            NCCL_MNNVL_ENABLE: "1"
+            # Disable the blocked-GEMM MoE kernels. Job 5743685 died here:
+            #   AssertionError: K must be divisible by blockK
+            #   Error executing method 'load_model'
+            # genrm_model was the only vLLM service with none of these set, and
+            # it inherits VLLM_USE_FLASHINFER_MOE_FP8=1 from the driver's
+            # TRAIN_CMD. nl2bash is the control: same Qwen3-235B-A22B family,
+            # same TP4, loads fine with all four disabled. safety disables
+            # DeepGEMM too. This makes GenRM match them.
+            VLLM_USE_DEEP_GEMM: "0"
+            VLLM_MOE_USE_DEEP_GEMM: "0"
+            VLLM_USE_FLASHINFER_MOE_FP8: "0"
+            VLLM_USE_FLASHINFER_MOE_FP16: "0"
+          vllm_serve_kwargs:
+            attention_backend: FLASH_ATTN      # was TRITON_ATTN; matches nl2bash
+            tensor_parallel_size: 4
+            data_parallel_size: 4
+            data_parallel_size_local: 1
+            pipeline_parallel_size: 1
+            enable_expert_parallel: true       # matches nl2bash on the same MoE family
+            reasoning_parser: deepseek_r1      # GenRM-specific, nl2bash has none
+            gpu_memory_utilization: 0.85
+            max_model_len: 131072
+            max_num_seqs: 256
+            max_num_batched_tokens: 8192
+            enable_prefix_caching: true
+            enable_chunked_prefill: true
+            # Back to 112 (upstream default). The os error 108 in job 5744482
+            # was traced to a single bad node, nvl72138-T01 (10.109.24.155),
+            # which also caused the ModuleNotFoundError in 5742619 and 5745204 —
+            # not loader-thread pressure. That node is now excluded at submit.
+            model_loader_extra_config:
+              enable_multithread_load: true
+              num_threads: 112
+            load_format: auto
+            compilation_config:                # matches nl2bash
+              cudagraph_capture_sizes: [1, 2, 4, 8, 16, 32]
+
+    genrm_compare_resources_server:
+      resources_servers:
+        genrm_compare:
+          # Base ships 0.1 / 0.25 (retuned for ultra). Reference dolphin used
+          # 0.12 / 0.12 — restored, since we are reproducing that run.
+          group_reasoning_length_penalty_coeff: 0.12
+          group_answer_length_penalty_coeff: 0.12
+
+    # Qwen3-235B-A22B-Instruct-2507-FP8. TP4 x DP8 = 32 GPUs = 8 of the 16 gym
+    # nodes. Base ships DP4 (sized for 256n ultra); reference uses DP8.
+    # Backs equivalence_llm_judge, lc_judge, math_with_judge, multichallenge,
+    # inverse_if and abstention — so this sizing gates six families.
+    nl2bash_judge_model:
+      responses_api_models:
+        local_vllm_model:
+          model: /lustre/fsw/portfolios/llmservice/users/ansubramania/models/Qwen3-235B-A22B-Instruct-2507-FP8
+          # Launch this judge from the Gym venv, not the RL one. On a 0.25
+          # container the RL venv pairs vLLM 0.25 with the openai version
+          # uv.lock pins, and `vllm serve` then fails to import NamespaceTool
+          # from openai.types.responses (job 5943331). The Gym venv is
+          # self-consistent. Judges need no weight sync, so they gain nothing
+          # from sharing the RL venv.
+          ray_worker_py_executable: /opt/gym_venvs/responses_api_models/local_vllm_model/.venv/bin/python
+          vllm_serve_env_vars:
+            # Matches the known-working internal dolphin/bear judge recipe.
+            NCCL_MNNVL_ENABLE: "0"
+            # Keep Ray's compiled-DAG wait aligned with vLLM's distributed wait.
+            RAY_CGRAPH_get_timeout: "2400"
+            # Off for every judge that runs from the Gym venv; see the note on
+            # safety_judge_model below.
+            VLLM_USE_FASTOKENS: "0"
+          vllm_serve_kwargs:
+            tensor_parallel_size: 4
+            data_parallel_size: 8
+            distributed_timeout_seconds: 2400
+            # Back to 112 (upstream default); see genrm note above.
+            model_loader_extra_config:
+              enable_multithread_load: true
+              num_threads: 112
+
+    # Nemotron-Content-Safety-Reasoning-4B — 1 GPU, per the reference.
+    safety_judge_model:
+      responses_api_models:
+        local_vllm_model:
+          model: /lustre/fsw/portfolios/llmservice/users/ansubramania/super_v3/model_checkpoints/Nemotron-Content-Safety-Reasoning-4B
+          vllm_serve_env_vars:
+            # Some images bake VLLM_USE_FASTOKENS=1 into /etc/environment, so
+            # every process inherits it, but only the RL venv carries the wheel
+            # (fastokens 0.3.1). This judge has no ray_worker_py_executable, so
+            # it runs from the Gym venv, whose vLLM ships the integration module
+            # (vllm/tokenizers/fastokens.py) without the package behind it, and
+            # exits at import with "The 'fastokens' package (>= 0.2.0) is
+            # required when VLLM_USE_FASTOKENS=1" -- taking Gym spinup down with
+            # it (job 6232802, on the 08-15 build). The Jul-30 image's Gym vLLM
+            # had no fastokens support at all and ignored the flag, which is why
+            # this appeared only once the pin moved forward. Pinned off rather
+            # than left to the image so a future pin cannot reintroduce it.
+            # Merged onto the base's env vars rather than replacing them.
+            VLLM_USE_FASTOKENS: "0"
+          vllm_serve_kwargs:
+            tensor_parallel_size: 1
+            data_parallel_size: 1
+
+# -----------------------------------------------------------------------------
+# Logger — log_dir / wandb.name are set by the launcher.
+# -----------------------------------------------------------------------------
+logger:
+  wandb_enabled: true
+  tensorboard_enabled: true
+  monitor_gpus: true
+  wandb:
+    project: "ultra-streaming"
+
+# reward_penalties inherited unchanged and already match the reference:
+#   penalize_duplicated_reasoning / empty_final_answer / unwanted_tokens /
+#   malformed_think_tag all true, token_ids {unwanted: [2], think_open: 12,
+#   think_close: 13}. This is the upstreamed form of the internal config's
+#   top-level penalize_* + token_ids block.

--- a/examples/nemo_gym/nemotron-3.5-nano/rlvr_dolphin_sc.yaml
+++ b/examples/nemo_gym/nemotron-3.5-nano/rlvr_dolphin_sc.yaml
@@ -1,0 +1,394 @@
+# =============================================================================
+# Nemotron 3.5 Nano — RLVR on the SingleController path
+# =============================================================================
+# Overlay on rlvr_dolphin.yaml that swaps the legacy async-GRPO driver for the
+# SingleController (SC) architecture: streaming forward/backward, the
+# TransferQueue data plane, gated in-order rollout sampling, and shard-to-shard
+# NCCL-reshard weight refit.
+#
+# Everything about the model, parallelism, batch shape, sequence length, node
+# split and the Gym blend is inherited unchanged, so a run of this config is
+# directly comparable against a rlvr_dolphin.yaml run on the same 64 nodes
+# (8 train + 40 generation + 16 gym, plus GenRM's own 4).
+#
+# Entrypoint: examples/run_grpo_single_controller.py (NOT run_grpo_nemo_gym.py).
+# nano35_dolphin_launch_sc.sh sets that via TRAIN_ENTRYPOINT.
+#
+# Group vs sample units: async_rl counts PROMPT GROUPS, not generations. One
+# optimizer cohort here is 2048 / 16 = 128 groups.
+# =============================================================================
+defaults: rlvr_dolphin.yaml
+
+# =============================================================================
+# Checkpointing — on, because a 100-step run outlives the 4 h wall
+# =============================================================================
+# The SC path saves and resumes now: _save_checkpoint writes policy weights, the
+# optimizer, the tokenizer, the dataloader state, the replay buffer and the
+# step/epoch/consumed-sample counters, and setup_single_controller resumes from
+# get_latest_checkpoint_path. Restoring the buffer matters more here than the
+# weights do -- a resumed run comes back with its lag-4 staleness distribution
+# instead of ramping from zero, so the convergence curve has no seam at the job
+# boundary. The buffer restore is skipped if the sampler name changed, so every
+# job in a chain must keep the same async_rl.sampler.name.
+#
+# grpo.max_num_steps is compared against the *restored* step count, so it is a
+# whole-campaign target: NRL_MAX_STEPS=100 once, and each requeued job continues
+# toward it rather than running 100 more steps.
+#
+# Three inherited values are wrong the moment this is enabled:
+#
+#   metric_name    student_rlvr1.yaml sets "val:total_reward/mean", which
+#                  validate_single_controller_config rejects outright -- SC has
+#                  no validation loop, so a "val:" metric is never collected and
+#                  top-k retention would silently degrade to a no-op. null here
+#                  makes retention purely recency-based, which is what we want.
+#   ft_save_period Inherited as 1, and should_save_by_step ORs it with
+#                  save_period, so every single step would write a full MoE
+#                  checkpoint. Pinned to save_period so the two agree.
+#   keep_top_k     Inherited as 1000000, i.e. keep everything. With no metric,
+#                  "best" is recency, so this keeps the newest 3 periodic
+#                  checkpoints and lets the rest go. 100 steps at save_period 5
+#                  would otherwise leave 20 full checkpoints on disk.
+#
+# checkpoint_must_save_by comes from the launcher (CHECKPOINTING_SAVE_BY,
+# 00:03:35:00) and forces a save before the 4 h wall regardless of save_period.
+# save_period 5 is the baseline's value, chosen so a job that dies mid-window
+# loses at most 5 steps; revisit once step time at lag 4 is measured, since a
+# job that never reaches a save redoes the same work on every requeue.
+# =============================================================================
+checkpointing:
+  enabled: true
+  metric_name: null
+  save_period: 5
+  ft_save_period: 5
+  ft_keep_latest_k: 1
+  keep_top_k: 3
+  save_optimizer: true
+
+grpo:
+  # setup_single_controller rejects val_period > 0 outright, so the baseline's
+  # "effectively disabled" 10000000 is not enough — validation has to be off.
+  # val_start_at: -1, val_at_start: false and val_at_end: false are inherited
+  # and already satisfy the rest of the guard.
+  val_period: 0
+
+  # Required because loss_fn.reference_policy_kl_penalty is 0.0 (inherited from
+  # student_rlvr1.yaml). No reference model is built, but the SC train pump
+  # still computes reference logprobs unless this is set, and then fails with
+  # AttributeError: 'MegatronPolicyWorker' has no 'reference_state_dict'.
+  skip_reference_policy_logprobs_calculation: true
+
+  # run_grpo_single_controller.py raises unless this is null; the SC knobs live
+  # under async_rl. student_rlvr1.yaml interpolates
+  # ${add:${grpo.async_grpo.max_trajectory_age_steps}, 1} for num_groups_nemo_rl
+  # in two places, so both are pinned to the value that interpolation resolved
+  # to (max_trajectory_age_steps: 1) under env.nemo_gym below. Nothing may
+  # reference this block once it is null or config load fails.
+  async_grpo: null
+
+policy:
+  # ---------------------------------------------------------------------------
+  # Speculative-decoding draft head. run_grpo_single_controller.py reads
+  # config.policy["draft"]["enabled"] unconditionally, so omitting this block is
+  # a KeyError before Ray starts. The nemo_gym runner guards it with an `in`
+  # check, which is why neither rlvr_dolphin.yaml nor student_rlvr1.yaml needs it.
+  #
+  # Unrelated to the MTP head this recipe trains: MTP head training is on via
+  # megatron_cfg (5 repeated layers, loss 0.3, detached), and MTP speculative
+  # decoding in vLLM is off (ENABLE_MTP_INFERENCE=0), both inherited.
+  # ---------------------------------------------------------------------------
+  draft:
+    enabled: false
+    model_name: null
+    loss_weight: 0.1
+    num_layers: null
+    aux_layer_indices: null
+
+  generation:
+    # -------------------------------------------------------------------------
+    # Pinned, not interpolated. rlvr_dolphin.yaml ties max_new_tokens to
+    # ${policy.max_total_sequence_length}, which also feeds vllm_cfg.max_model_len
+    # — so the generation budget and the context window are the same number and
+    # a prompt at exactly that length can never emit a token. It is rejected
+    # deterministically instead, and because Gym prepends system prompts and tool
+    # schemas at rollout time and rollouts are multi-turn, no first-turn filter
+    # bounds it: that pairing rejected 2108 prompts in one 8-node ultra probe arm
+    # and 1344 in another at a 16384 window.
+    #
+    # 73728 is the value the interpolation already resolves to here, kept
+    # identical on purpose so these arms stay comparable with the v1 and windowed
+    # arms they are measured against. The pin buys decoupling, not headroom: what
+    # actually keeps rejections at zero on this recipe is that the window is 4.5x
+    # the ultra one and no row of the dolphin blend approaches it (job 5995586
+    # logged no context rejections at this window). Anyone lowering
+    # max_total_sequence_length here must now choose a smaller max_new_tokens
+    # deliberately, which is the step the ultra fan-in config skipped.
+    # -------------------------------------------------------------------------
+    max_new_tokens: 73728
+
+    # -------------------------------------------------------------------------
+    # Weight refit transport. The inherited default (null) broadcasts every full
+    # parameter tensor from the 32 training ranks to all 160 generation ranks.
+    # nccl_reshard instead moves each parameter shard-to-shard between the two
+    # parallelism layouts over NCCL's M2N reshard, so no rank ever materializes
+    # a full tensor. The bulk path covers the MoE FFN projections, which are
+    # 97-98% of the weights at EP=16.
+    #
+    # Declared here rather than passed with `+` because refit_transport is
+    # NotRequired in VllmConfig; with the key present, REFIT_TRANSPORT=null in
+    # nano35_dolphin_launch_sc.sh falls back to the broadcast path.
+    #
+    # This config satisfies every config-checkable constraint in
+    # check_nccl_reshard_refit_support: non-colocated, Megatron train, vLLM gen,
+    # ETP=1, PP=1 with no custom layout, BF16 end to end, no EPLB, and vLLM
+    # expert_parallel_size=1 (allowed alongside any TP; the other legal value is
+    # EP == TP).
+    #
+    # STILL WORTH CHECKING ON THE FIRST RUN: if the container lacks the nccl4py
+    # M2N integration, xferdtensor.py logs "nccl.m2n.reshard not found" and
+    # silently falls back to a Python implementation. Grep the logs for it.
+    #
+    # The MTP-head risk flagged here before is now handled: this checkpoint's HF
+    # export does emit MTP expert projections (mtp.layers.N.mixer.experts.*), and
+    # they did take the bulk path and fail (job 5943756, "layer_prefix mismatch:
+    # mtp != backbone"). is_nccl_reshard_param now routes anything under mtp. to
+    # the misc path, matching what the broadcast baseline does with them.
+    # REFIT_TRANSPORT=null remains the escape hatch.
+    # -------------------------------------------------------------------------
+    refit_transport: nccl_reshard
+
+    # vllm_cfg.gpu_memory_utilization stays at the inherited 0.80. That was
+    # lowered from 0.85 for the broadcast path's staging buffer (job 5744748
+    # OOM'd in update_weights_from_collective at 128 generation ranks, and this
+    # shape has 160) — the exact pressure nccl_reshard removes. 0.85 may be
+    # recoverable here once a reshard run is confirmed healthy; left alone so
+    # the two recipes differ only in the transport.
+
+    vllm_cfg:
+      # -----------------------------------------------------------------------
+      # Samples vllm:num_requests_running / num_requests_waiting /
+      # kv_cache_usage_perc off each engine so a step's exposed_generation can
+      # be attributed. Every run so far shows generation as the binding
+      # constraint (0.18 groups/s produced against a 0.26 groups/s trainer
+      # appetite) without showing why: a compute-bound fleet and an
+      # under-subscribed one are indistinguishable from the trainer's side, and
+      # only the second gets faster when max_inflight_prompts rises. A waiting
+      # queue that is busy most of the step means the engines are the ceiling
+      # and deeper lag cannot help.
+      #
+      # Matches the nemotron-3-ultra recipes, which all enable this. Costs one
+      # Prometheus snapshot per engine every 0.5 s on a daemon thread.
+      # -----------------------------------------------------------------------
+      enable_vllm_metrics_logger: true
+      vllm_metrics_logger_interval: 0.5
+
+# =============================================================================
+# Loss — off-policy correction, required by every arm past lag 1
+# =============================================================================
+# student_rlvr1.yaml pins the importance ratio at 1, which makes
+# use_importance_sampling_correction inert: the sampled tokens come from an
+# older policy but the loss is computed as though they came from the current
+# one. A lag sweep run that way measures the uncorrected loss, not the
+# staleness, so the pin is lifted here for every sampler rather than for
+# ready_first alone (which validate_single_controller_config refuses to run
+# with it set). Costs the prev_logprobs forward pass the pin was skipping.
+# =============================================================================
+loss_fn:
+  force_on_policy_ratio: false
+
+# =============================================================================
+# SingleController async RL — required by MasterConfig
+# =============================================================================
+async_rl:
+  # ready_first: gated admission, streaming selection, zero eviction.
+  #
+  # Admission is the same gate in_order uses — generation may run at most
+  # max_staleness_versions dispatch batches ahead of the trainer — but selection
+  # takes any ready group whose start weight does not exceed the trainer
+  # version, oldest first, rather than only the cohort stamped for this step.
+  # A step therefore closes on the first num_prompts_per_step groups that are
+  # ready, and a prompt lost to a rollout fault is backfilled instead of waited
+  # for. That removes the 5982927 wedge structurally rather than by credit.
+  #
+  # This replaces in_order for the staleness sweep because the two v2 samplers
+  # that already ran both discard generated work: windowed evicts 21.4 / 6.6 /
+  # 3.0% of groups at staleness 2 / 4 / 6, and those are the long ones
+  # (2.4-2.8x the retained mean). ready_first keeps them. Do not read its step
+  # time against a windowed baseline — the batches are legitimately longer, and
+  # at staleness 1 that comparison is off by more than 3x in the direction that
+  # makes the correct change look like a regression. Compare against v1, or
+  # compare loss-bearing tokens/sec.
+  #
+  # Zero eviction is structural in the upstream sampler rather than a knob:
+  # ReadyFirstSampler has no evict_stale_samples field, and every ready group
+  # generated by a policy no newer than the trainer stays selectable, late
+  # stragglers included. The snapshot recipes set that key; it is dropped here
+  # because SamplerConfig is extra="allow" and an inert key that reads as a
+  # safety setting is worse than no key.
+  #
+  # NOTE ON THE LOSS. student_rlvr1.yaml sets loss_fn.force_on_policy_ratio,
+  # which pins the importance ratio at 1 — so despite
+  # use_importance_sampling_correction there would be no off-policy correction
+  # at all, and every arm past lag 1 would measure an uncorrected loss rather
+  # than the staleness. This overlay turns it off (see the loss_fn block below),
+  # which is also what validate_single_controller_config now requires of
+  # ready_first.
+  #
+  # The launcher overrides name and the slack per arm. It emits the key that
+  # matches the sampler it selected: ready_first and windowed both spell it
+  # max_staleness_versions, in_order spells it max_lookahead_versions, and every
+  # sampler config is extra="allow", so the wrong key is accepted in silence and
+  # leaves the arm at the default of 1.
+  sampler:
+    name: ready_first
+    max_staleness_versions: 4
+
+  recompute_kv_cache_after_weight_updates: false
+
+  # Begin forward/backward once this many groups are ready rather than waiting
+  # for all 128; the remainder streams in behind it and accumulates into the
+  # single GBS=2048 optimizer step. 32 is 25% of the cohort, the ratio the
+  # validated smaller-scale streaming runs used to get 2-3 chunks per step.
+  min_groups_for_streaming_train: 32
+
+  # Let the current cohort and all four lookahead cohorts generate
+  # concurrently: num_prompts_per_step * (max_staleness_versions + 1) = 128 * 5.
+  max_inflight_prompts: 640
+
+  # Hard floor, not a preference: validate_sampler_buffer_capacity raises if
+  # this is below num_prompts_per_step * (max_staleness_versions + 1) = 640,
+  # because the rollout pump would deadlock waiting for buffer slots. It scales
+  # with the slack, so raising one raises both.
+  #
+  # Keep it EQUAL to max_inflight_prompts, never above. The buffer permit is
+  # acquired before dispatch, so it is a dispatch semaphore rather than passive
+  # capacity: job 6014206 set 768 against 384 in flight and ran 1.8x slower.
+  max_buffered_rollouts: 640
+
+  # Rollout fault tolerance. Gym retries dropped connections itself, but hands
+  # us env-server 500s and truncated response bodies, and one of those used to
+  # abort the whole run: jobs 5966951 and 5967263 died that way after one and
+  # six steps while the legacy stack absorbed 400 of the same faults and kept
+  # training.
+  #
+  # Retrying matters more here than it does in v1. A dropped prompt leaves its
+  # batch a group short, and the in_order sampler only ever offers the trainer
+  # groups stamped for the current step, so that step can never close: job
+  # 5982927 wedged exactly this way after step 7 when two prompts hit 500s from
+  # a single sick env server, then sat idle for 104 minutes. Keeping the batch
+  # whole is worth waiting for; the trainer falls back to a shortened batch only
+  # once every attempt is gone.
+  #
+  # Keys follow the post-#3589 taxonomy: infra failures (dead shard, timeout,
+  # transport) re-dispatch onto a different shard, data failures do not. The two
+  # budgets are independent counters, not a total and a sub-total.
+  rollout_failure:
+    # 5 infra attempts with a 1s base gives 1s/2s/4s/8s, bounded at 30s. v1's
+    # AsyncTrajectoryCollector retries a comparable number of times, so neither
+    # stack absorbs more than the other.
+    max_infra_attempts_per_prompt: 5
+    max_data_attempts_per_prompt: 2
+    backoff_base_s: 1.0
+    max_backoff_s: 30.0
+
+    # Consecutive drops that mean the environment servers or the generation
+    # backend are down rather than one prompt being bad. Any commit resets it,
+    # so this bounds an outage rather than the run. Failing fast past that beats
+    # burning the rest of the allocation.
+    max_consecutive_dropped_prompts: 32
+    # A handful of genuinely bad prompts should not end a 68-node run; a dataset
+    # that is wrong throughout still will.
+    max_skipped_prompts: 32
+
+    # Hold the batch size across a drop rather than closing the step short: the
+    # lag arms are compared on gradient quality, and a step that silently trains
+    # on 120 of 128 groups is not the same measurement as one that trains on
+    # 128. Falls back to shrinking, floored at 90% of num_prompts_per_step.
+    on_dropped_prompt: replace
+    max_replacement_attempts: 1
+    replacement_reserve_prompts: 1
+    min_step_batch_fraction: 0.9
+
+    # Deadlines. This is the NeMo-Gym rollout path, so only the nemo_gym block
+    # applies; validate_single_controller_config rejects a populated native
+    # block here rather than letting it look effective. Nothing below SC bounds
+    # a rollout -- Gym retries its server-to-server hops in an uncapped loop
+    # against an aiohttp session with no ClientTimeout -- so without this a
+    # wedged env server holds its in_order slot until the wall clock.
+    nemo_gym:
+      rollout_timeout_s: 1800.0
+
+  # Must outlast every deadline above, which _check_watchdog_outlasts_rollouts
+  # enforces: below it, a rollout that is merely slow reads as a stall.
+  watchdog:
+    interval_s: 30.0
+    stall_timeout_s: 2400.0
+    stall_action: warn
+    gym_subprocess_check: true
+
+# =============================================================================
+# NeMo-Gym rollout actor
+# =============================================================================
+env:
+  nemo_gym:
+    # Pinned literals for what student_rlvr1.yaml interpolated off
+    # grpo.async_grpo.max_trajectory_age_steps, which is null on this path.
+    policy_model:
+      responses_api_models:
+        vllm_model:
+          num_groups_nemo_rl: 2
+    policy_model_reasoning_off:
+      responses_api_models:
+        vllm_model:
+          num_groups_nemo_rl: 2
+
+    # Ray's max_concurrency for the single NemoGym actor: the ceiling on rollout
+    # tasks it executes at once. NemoGym.run_rollouts is `async def`, so the
+    # actor takes Ray's asyncio branch. Tasks past the cap queue at the
+    # submitting raylet rather than running, and a deep enough backlog makes Ray
+    # log "More than 5000 tasks pending submission to actor NemoGym" and nothing
+    # else, which is how the 6K run produced zero groups.
+    #
+    # null now means "size it from async_rl.max_inflight_prompts plus a small
+    # control-plane headroom" rather than Ray's default of 1000
+    # (resolve_nemo_gym_max_concurrency), so this recipe's 640 is covered
+    # without setting anything. An explicit value below the in-flight depth is
+    # a ValueError at config load rather than a stall discovered hours in.
+    #
+    # Declared explicitly rather than left to the `+` override form because
+    # Hydra runs in struct mode: an undeclared key cannot be set from the
+    # command line.
+    max_concurrency: null
+
+# =============================================================================
+# TransferQueue data plane — mandatory for the SC path
+# =============================================================================
+# run_grpo_single_controller.py refuses to start unless enabled is true, and
+# DataPlaneConfig requires every key below with no Python-side defaults.
+# global_segment_size / local_buffer_size are read only when backend is
+# mooncake_cpu, but must still be present.
+# =============================================================================
+data_plane:
+  enabled: true
+  impl: transfer_queue
+  backend: "simple"
+  storage_capacity: 1000000
+  # Sharding only — storage_capacity above is global and TQ splits it, as
+  # ceil(total_storage_size / num_data_storage_units), so this trades unit count
+  # against per-unit size and reserves nothing extra. Raising it costs one CPU
+  # actor each and buys read/write fan-out.
+  #
+  # 16 is headroom, not a fix for anything measured. The windowed sweep sizes
+  # the buffer as num_prompts_per_step * (staleness + 1), so the arms hold 256 /
+  # 384 / 640 / 896 groups resident — up to 14336 rows at staleness 6, which is
+  # 40% past the 10240 the previous value of 8 was reasoned against. Peak
+  # resident is still only ~1.4% of the 1000000-row global capacity, so the
+  # concern is the actors' aggregate throughput rather than their space. Held
+  # identical across arms deliberately: varying it would confound the staleness
+  # comparison the sweep exists to make.
+  num_storage_units: 16
+  claim_meta_poll_interval_s: 0.5
+  # Mooncake-only: _init_tq reads these solely on the mooncake_cpu branch, and
+  # this recipe is backend "simple". Inert here, kept for backend switches.
+  global_segment_size: 549755813888  # 512 GiB
+  local_buffer_size:   68719476736   # 64 GiB


### PR DESCRIPTION
# Overview
Adds the Nemotron 3.5 Nano RLVR (honest-dolphin) recipes at three scales, each in
both the legacy async-GRPO and SingleController flavors, so a run of either arm is
directly comparable against the other on the same allocation.
- **272-GPU** — `rlvr_dolphin.yaml` (legacy async) and `rlvr_dolphin_sc.yaml` (SC
  overlay: streaming forward/backward, TransferQueue data plane, gated rollout
  sampling, `nccl_reshard` refit), with `nano35_dolphin_launch{,_sc}.sh`.
- **32-GPU** — `nano35_dolphin_launch_sc_smoke.sh`, a pipeclean profile for
  validating the SC stack end to end before spending a 68-node allocation.
  Training parallelism is deliberately not scaled: four nodes is the floor that
  preserves it exactly, since TP=4 x CP=4 x PP=1 fills 16 GPUs and EP=8 still
  divides 16 at ETP=1, so every rank owns the same 16 of the 128 routed experts as
  the full-scale run and only DP drops from 2 to 1. Sequence length stays at the
  production 73728. What scales instead is the cohort (128 prompts to 8) and the
  step count, with the per-step batch floor scaled alongside the cohort.
- **6Kr-GPU** — `pipeclean_6k.yaml` / `pipeclean_6k_sc.yaml` plus launchers and
  smoke profiles, and `record_code_at_start.sh` to snapshot what a run actually
  executed (a job can sit queued long enough for the worktree to move underneath
  it).
Also included: `ultra_launch.sh` now points uv at the container's warm cache
rather than a per-job `/tmp` path. `ray.sub` scrubs `SLURM_*` before entering the
container, so the job-id suffix collapsed to a constant, and `/tmp` is node-local
— the cache was cold on every node of every job by construction, and it shadowed
the image's warm one.


# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
