### PR TITLE
docs: refresh config-conventions skill after BaseModel migrations

### DIFF
--- a/.agents/contributor-skills/config-conventions/SKILL.md
+++ b/.agents/contributor-skills/config-conventions/SKILL.md
@@ -16,7 +16,7 @@ We are **gradually migrating** the config schema from `typing.TypedDict` (v1) to
 
 Use the right tool for the job. **v2 (the new convention):**
 
-- **`pydantic.BaseModel` — v2, user-facing config (the new default).** Any class the user touches via YAML — currently the top-level `MasterConfig` of each algorithm (`grpo`, `dpo`, `sft`, `rm`, `distillation`, `eval`) and a few shared schemas like `ClippedPGLossConfig` — is a `BaseModel` declared with `extra="allow"` so unknown keys don't break older configs:
+- **`pydantic.BaseModel` — v2, user-facing config (the new default).** Any class the user touches via YAML — the top-level `MasterConfig` of every algorithm (`grpo`, `ppo`, `dpo`, `sft`, `rm`, `distillation`, `opd`, `eval`, single-controller) and most algorithm-level sub-configs (`GRPOConfig`, `AsyncGRPOConfig`, `ClippedPGLossConfig`, ...) — is a `BaseModel`, normally declared with `extra="allow"` so unknown keys don't break older configs (rarely `extra="forbid"` where strict validation is intended, e.g. `MseValueLossConfig`):
 
   ```python
   from pydantic import BaseModel
@@ -33,7 +33,7 @@ Use the right tool for the job. **v2 (the new convention):**
 
 **v1 (legacy, being migrated away):**
 
-- **`typing.TypedDict` — v1, legacy / not-yet-migrated user-facing config.** Some nested sub-configs are still `TypedDict`. Continue to maintain them with the same defaults rules below until they are migrated to `BaseModel`. Use `typing.NotRequired` to mark optional attributes. **Do not add new `TypedDict`-based config classes.**
+- **`typing.TypedDict` — v1, legacy / not-yet-migrated user-facing config.** The remaining `TypedDict` configs live mostly outside the algorithm modules — e.g. `PolicyConfig` and its nested blocks (`DTensorConfig`, `MegatronConfig`, ...) in `nemo_rl/models/policy/__init__.py`, plus `ClusterConfig`, `CheckpointingConfig`, `LoggerConfig`, and the environment configs. Continue to maintain them with the same defaults rules below until they are migrated to `BaseModel`. Use `typing.NotRequired` to mark optional attributes. **Do not add new `TypedDict`-based config classes.**
 
 When in doubt: *is this class populated from a user-edited YAML?* If yes → `BaseModel` (or legacy `TypedDict`). If no → `@dataclass`.
 
@@ -114,10 +114,11 @@ When accessing a `NotRequired` field, use an `in` check or `.get(key)` / `.get(k
 **Do:**
 ```python
 # .get() with None (not a hidden default)
-stop_properly_penalty_coef = cfg.get("stop_properly_penalty_coef", None)
+if checkpointing_cfg.get("model_save_format", None) is not None:
+    ...
 
 # Truthiness check for optional booleans
-if master_config.grpo.get("skip_reference_policy_logprobs_calculation"):
+if megatron_cfg.get("enabled") and megatron_cfg.get("use_fused_linear_logprobs"):
     ...
 
 # Nested NotRequired: check presence at each level explicitly

--- a/docs/design-docs/design-and-philosophy.md
+++ b/docs/design-docs/design-and-philosophy.md
@@ -122,12 +122,12 @@ We are **incrementally migrating** the config schema from `typing.TypedDict` (v1
 
 **v2 — the new conventions (use these for all new code):**
 
-- **`pydantic.BaseModel` — v2, user-facing config (the new default).** Any class a user touches via YAML — currently the top-level `MasterConfig` of each algorithm and a few shared schemas like `ClippedPGLossConfig` — is declared as a `BaseModel` with `extra="allow"`. The `extra="allow"` flag preserves the original motivation behind picking `TypedDict`: users can keep using older configuration files with obsolete or user-defined keys without load-time errors. New user-facing configs should be `BaseModel`, and existing `TypedDict`s should be migrated as the codebase moves.
+- **`pydantic.BaseModel` — v2, user-facing config (the new default).** Any class a user touches via YAML — the top-level `MasterConfig` of every algorithm and most algorithm-level sub-configs (`GRPOConfig`, `AsyncGRPOConfig`, `ClippedPGLossConfig`, ...) — is declared as a `BaseModel`, normally with `extra="allow"`. The `extra="allow"` flag preserves the original motivation behind picking `TypedDict`: users can keep using older configuration files with obsolete or user-defined keys without load-time errors. New user-facing configs should be `BaseModel`, and existing `TypedDict`s should be migrated as the codebase moves.
 - **`@dataclass` — v2, internal classes, *not* loaded from YAML.** Process-local data containers (worker metadata, datum specs, internal state passed between Python components) use `@dataclass`. They are not config and should not pretend to be.
 
 **v1 — legacy, being migrated away:**
 
-- **`typing.TypedDict` — v1, legacy user-facing config still being migrated.** Most nested sub-configs (e.g. `GRPOConfig`, `RewardScalingConfig`) remain `TypedDict` for now and continue to follow the same default-handling rules below until they are migrated to `BaseModel`. Do not add new `TypedDict`-based config classes.
+- **`typing.TypedDict` — v1, legacy user-facing config still being migrated.** The remaining `TypedDict` configs live mostly outside the algorithm modules (e.g. `PolicyConfig` and its nested blocks, `ClusterConfig`, `CheckpointingConfig`, `LoggerConfig`) and continue to follow the same default-handling rules below until they are migrated to `BaseModel`. Do not add new `TypedDict`-based config classes.
 
 We follow a few design principles regarding configuration:
 


### PR DESCRIPTION
# What does this PR do ?

Focused audit + cleanup of `.agents/contributor-skills/config-conventions/SKILL.md` and the matching section of `docs/design-docs/design-and-philosophy.md`, which drifted from the code after recent BaseModel migrations:

- `GRPOConfig`, `RewardScalingConfig`, and `AsyncGRPOConfig` were cited as still-TypedDict examples — all three are `BaseModel` on main. The legacy-TypedDict description now points at the configs that actually remain (`PolicyConfig` and its nested blocks in `nemo_rl/models/policy/__init__.py`, `ClusterConfig`, `CheckpointingConfig`, `LoggerConfig`, environment configs).
- The BaseModel scope now reflects that every algorithm `MasterConfig` (incl. `ppo`, `opd`, single-controller) and most algorithm-level sub-configs are migrated, and notes the rare `extra="forbid"` case (`MseValueLossConfig`).
- The "Accessing NotRequired Fields" **Do** examples used accessors that no longer exist in that form (`master_config.grpo.get(...)` on what is now a BaseModel). Replaced with patterns taken verbatim from current code (`checkpointing_cfg.get("model_save_format", None)` — `lm_policy.py`; `megatron_cfg.get("enabled") and megatron_cfg.get("use_fused_linear_logprobs")` — `grpo.py`).

Doc-only; no code changes.

# Issues

Fixes #3598

# Before your PR is "Ready for review"

- [x] Docs-only change; verified cited classes/patterns against current `main`