### PR TITLE
fix(vllm): resolve unset sampling params to neutral defaults

### DIFF
--- a/nemo_rl/models/generation/vllm/vllm_worker.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker.py
@@ -589,6 +589,13 @@ class BaseVllmGenerationWorker:
             enable_sleep_mode=True,
             # Set disable_log_stats=False so that self.llm.get_metrics() works.
             disable_log_stats=False,
+            # Resolve sampling params NeMo-RL leaves unset (min_p,
+            # repetition_penalty, ...) to vLLM's neutral defaults instead of the
+            # model's generation_config.json, so policy.generation.* stays the
+            # single source of truth for the sampling distribution that the
+            # train-side logprob rescaling assumes. Overridable via
+            # generation.vllm_kwargs.generation_config. See #3497.
+            generation_config="vllm",
             **vllm_kwargs,
         )
 

--- a/nemo_rl/models/generation/vllm/vllm_worker_async.py
+++ b/nemo_rl/models/generation/vllm/vllm_worker_async.py
@@ -747,12 +747,16 @@ class VllmAsyncGenerationWorkerImpl(
             # caller that constructs a non-train GenerationSamplingParams. Multi-turn
             # agents issue their own requests, so this server-side check is the one
             # chokepoint they all pass.
-            # vLLM resolves an unset top_p from the model's generation_config.json
-            # (ModelConfig.generation_config defaults to "auto"), NOT to 1.0, so a
-            # request omitting it would sample off-policy while passing this check.
+            # The engine is constructed with generation_config="vllm" (see
+            # BaseVllmGenerationWorker._load_model), so an unset top_p resolves to
+            # vLLM's neutral 1.0 rather than the model's generation_config.json.
+            # Still require it explicitly: a silently-resolved 1.0 would only match
+            # the on-policy check by coincidence, and an explicit value keeps this
+            # chokepoint independent of the engine-level setting (which
+            # generation.vllm_kwargs.generation_config can override).
             assert request.top_p is not None, (
-                "top_p must be set explicitly on NeMo-RL requests; an unset top_p is "
-                "resolved by vLLM from the model's generation_config.json and would "
+                "top_p must be set explicitly on NeMo-RL requests; an unset top_p "
+                "would be resolved by vLLM instead of the NeMo-RL config and would "
                 "bypass the on-policy sampling check."
             )
             request_top_p = request.top_p


### PR DESCRIPTION
# What does this PR do ?

Passes `generation_config="vllm"` in the shared engine kwargs built by `BaseVllmGenerationWorker._load_model` (consumed by both the sync `vllm.LLM` engine and the async `AsyncEngineArgs` path), so sampling parameters NeMo-RL leaves unset on a request (`min_p`, `repetition_penalty`, and formerly `top_p`) resolve to vLLM's **neutral** defaults instead of the model's `generation_config.json`.

Without this, a model shipping non-neutral values (e.g. `Qwen2.5-0.5B-Instruct` with `repetition_penalty: 1.1`) silently samples off-policy while the train-side logprob rescaling replicates the distribution recorded in `policy.generation.*` — the mismatch is invisible to the existing async-server guard, which only covers `top_k`/`temperature`/`top_p`. This is the engine-level fix proposed in the issue: it removes the whole class of drift rather than patching one parameter at the guard, and makes `policy.generation.*` the single source of truth.

Details:
- The new kwarg sits **before** `**vllm_kwargs`, so `generation.vllm_kwargs.generation_config` can deliberately restore model-default behavior (e.g. if that is ever wanted for validation rollouts).
- The async server's explicit `top_p is not None` assert is kept as defense-in-depth; its comment is updated since its old rationale (resolution from `generation_config.json`) no longer applies at the engine level.

# Issues

Fixes #3497

# Usage

No user-facing config change. To intentionally restore per-model sampling defaults:

```yaml
policy:
  generation:
    vllm_kwargs:
      generation_config: "auto"
```

# Before your PR is "Ready for review"

- [x] One-line engine-arg change + comment updates; verified `generation_config` is an `EngineArgs`/`ModelConfig` field on the pinned vllm==0.25.1
- [ ] Functional coverage: existing L1 tests exercise the vLLM engine; `token_mult_prob_error`-style checks guard sampling/train distribution agreement