### PR TITLE
feat(megatron): router replay for colocated Megatron inference

### DIFF
--- a/docs/guides/router-replay.md
+++ b/docs/guides/router-replay.md
@@ -9,9 +9,8 @@ that is unrelated to the policy update.
 
 Router Replay is disabled by default. It is not needed for dense models. In
 the current NeMo RL integration, Router Replay is wired and tested for
-Megatron MoE policy training with vLLM rollout generation. Other
-inference/generation backends are not wired into this path and have not been
-tested with Router Replay.
+Megatron MoE policy training with vLLM or colocated Megatron rollout
+generation.
 
 ## Configuration
 
@@ -39,6 +38,10 @@ The native async TransferQueue path uses the SingleController entrypoint with:
 ```text
 examples/configs/recipes/llm/grpo-qwen3-30ba3b-10n8g-megatron-cp2-r3-async-single-controller.yaml
 ```
+
+With `policy.generation.backend: megatron`, NeMo RL enables
+`moe_enable_routing_replay`, sets `moe_router_fusion=False`, and packs each
+sample's `routing_indices` into `routed_experts` for train/logprob replay.
 
 ## Validation
 
@@ -121,6 +124,9 @@ When fallback is used, the vLLM worker emits a `R3 router replay fallback:` warn
 to the run log naming the affected sample count and missing token-route count.
 Fallback should normally be absent or rare; frequent warnings mean a meaningful
 share of token routes used Megatron's normal router instead of replay.
+
+On the colocated Megatron inference path, missing `routing_indices` fails at
+pack time instead of using this sentinel fallback.
 
 The generation backend also computes
 `r3/routed_experts_fallback_token_route_fraction`, but no training loop currently

--- a/nemo_rl/models/generation/megatron/megatron_worker.py
+++ b/nemo_rl/models/generation/megatron/megatron_worker.py
@@ -94,6 +94,15 @@ class MegatronGenerationMixin:
         )
         from megatron.core.utils import get_attr_wrapped_model
 
+        from nemo_rl.models.megatron.router_replay import (
+            apply_router_replay_inference_patches,
+            assert_megatron_inference_router_replay_ready,
+            rebuild_global_router_replay_registry,
+            reset_moe_routing_metadata_buffer,
+            router_replay_enabled,
+            sync_model_config_for_router_replay,
+        )
+
         pg_collection = get_attr_wrapped_model(self.model, "pg_collection")
 
         buffer_size_gb = mcore_generation_config["buffer_size_gb"]
@@ -139,6 +148,11 @@ class MegatronGenerationMixin:
         if logging_step_interval is None:
             logging_step_interval = 0
 
+        if router_replay_enabled(self.cfg):
+            rebuild_global_router_replay_registry(self.model)
+            apply_router_replay_inference_patches()
+        sync_model_config_for_router_replay(self.model, self.cfg)
+
         # flashinfer's fused-RoPE kernel only dispatches fp16/bf16 q/k.
         use_flashinfer_fused_rope = self.model.config.params_dtype in (
             torch.float16,
@@ -182,6 +196,11 @@ class MegatronGenerationMixin:
 
         self.inference_context = DynamicInferenceContext(
             self.model.config, inference_config
+        )
+        if router_replay_enabled(self.cfg):
+            reset_moe_routing_metadata_buffer(self.inference_context)
+        assert_megatron_inference_router_replay_ready(
+            self.model, self.inference_context, self.cfg
         )
         self.inference_wrapped_model = GPTInferenceWrapper(
             self.model, self.inference_context

--- a/nemo_rl/models/megatron/moe_routing_record.py
+++ b/nemo_rl/models/megatron/moe_routing_record.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Record MoE routing during Megatron-inference generation as R3 ``routed_experts``.
+
+Upstream router replay (R3, ``nemo_rl.models.megatron.router_replay``) provides the
+*replay* side for the Megatron training/logprob forward, but only records routing on
+the vLLM generation path. The colocated Megatron-inference generation path therefore
+has no recorder. This module bridges that gap: it converts the dynamic-inference
+engine's per-sample ``routing_indices`` into the ``[batch, seq, layers, topk]``
+``routed_experts`` tensor that ``router_replay.set_router_replay_forward`` /
+``build_router_replay_assignments`` consume (see ``_normalize_routed_experts_for_mcore``,
+which accepts ``[B, S, L, K]``).
+"""
+
+from typing import Optional
+
+import torch
+
+
+def coerce_routing_to_3d(routing: torch.Tensor) -> torch.Tensor:
+    """Normalize per-sample routing to ``[num_tokens, num_layers, topk]``."""
+    if not isinstance(routing, torch.Tensor):
+        raise TypeError(f"routing_indices must be a torch.Tensor, got {type(routing)}")
+    if routing.ndim == 3:
+        return routing
+    raise ValueError(
+        f"routing_indices must be 3D [tokens, layers, topk], got shape {tuple(routing.shape)}"
+    )
+
+
+def align_routing_rows_to_token_count(
+    routing: torch.Tensor, num_tokens: int
+) -> torch.Tensor:
+    """Pad/trim routing rows to ``num_tokens`` so they replay on a full-sequence forward.
+
+    Dynamic inference accumulates ``[num_tokens, layers, topk]`` (sometimes one fewer
+    row than the padded sequence length). Repeat the last recorded row when an extra
+    step is required; trim when there are more.
+    """
+    if routing.ndim != 3:
+        raise ValueError(f"Expected 3D routing tensor, got {tuple(routing.shape)}")
+    num_rows = routing.shape[0]
+    if num_rows == num_tokens:
+        return routing
+    if num_rows > num_tokens:
+        return routing[:num_tokens].contiguous()
+    if num_rows == 0:
+        raise ValueError("Cannot align empty routing indices to a non-empty sequence")
+    pad_rows = num_tokens - num_rows
+    last = routing[-1:].expand(pad_rows, -1, -1)
+    return torch.cat([routing, last], dim=0)
+
+
+def build_routed_experts_batch(
+    routing_per_sample: list[Optional[torch.Tensor]],
+    seq_lengths: torch.Tensor,
+    seq_dim: int,
+) -> Optional[torch.Tensor]:
+    """Build the R3 ``routed_experts`` tensor ``[batch, seq_dim, layers, topk]``.
+
+    Each sample's routing is aligned to its (unpadded) sequence length and right-padded
+    with zeros to ``seq_dim`` (the generation ``output_ids`` sequence length), so that
+    ``routed_experts[i][:seq_lengths[i]]`` is the per-token routing and the tail is pad.
+    Returns ``None`` when no sample carries routing (e.g. dense models / replay disabled).
+    """
+    if not any(r is not None for r in routing_per_sample):
+        return None
+    if any(r is None for r in routing_per_sample):
+        raise ValueError(
+            "routing_indices must be present for every sample when router replay is enabled"
+        )
+    aligned = [
+        align_routing_rows_to_token_count(
+            coerce_routing_to_3d(r), int(seq_lengths[i].item())
+        )
+        for i, r in enumerate(routing_per_sample)
+    ]
+    num_layers, topk = aligned[0].shape[1], aligned[0].shape[2]
+    out = torch.zeros(
+        len(aligned), seq_dim, num_layers, topk, dtype=aligned[0].dtype
+    )
+    for i, r in enumerate(aligned):
+        n = min(r.shape[0], seq_dim)
+        out[i, :n] = r[:n]
+    return out

--- a/nemo_rl/models/megatron/router_replay.py
+++ b/nemo_rl/models/megatron/router_replay.py
@@ -18,9 +18,15 @@ import inspect
 import os
 from collections.abc import Iterable
 from functools import wraps
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import torch
+
+if TYPE_CHECKING:
+    from megatron.core.inference.engines.dynamic_engine import DynamicInferenceEngine
+    from megatron.core.inference.text_generation_controllers.text_generation_controller import (
+        TextGenerationController,
+    )
 
 from nemo_rl.models.generation.interfaces import (
     ROUTED_EXPERTS_MISSING_ROUTE_SENTINEL,
@@ -50,6 +56,58 @@ def configure_vllm_for_router_replay(config: PolicyConfig) -> None:
     vllm_kwargs["enable_return_routed_experts"] = True
 
 
+def sync_model_config_for_router_replay(model: Any, config: PolicyConfig) -> None:
+    """Ensure the built mcore model config enables inference routing recording."""
+    if not router_replay_enabled(config):
+        return
+    model_config = _unwrap_model_config(model)
+    if model_config is None:
+        return
+    model_config.moe_enable_routing_replay = True
+    # Fused TE top-k bypasses RouterReplay.RECORD; force the replay-capable path.
+    model_config.moe_router_fusion = False
+
+
+def assert_megatron_inference_router_replay_ready(
+    model: Any, inference_context: Any, config: PolicyConfig
+) -> None:
+    """Fail fast when router replay is on but the inference engine cannot record routing."""
+    if not router_replay_enabled(config):
+        return
+
+    from megatron.core.transformer.moe.router_replay import RouterReplay
+
+    model_config = getattr(model, "config", None)
+    if model_config is None or not getattr(
+        model_config, "moe_enable_routing_replay", False
+    ):
+        raise RuntimeError(
+            "policy.router_replay.enabled=true requires model.config."
+            "moe_enable_routing_replay=True before Megatron inference starts."
+        )
+
+    if getattr(model_config, "num_moe_experts", None) in (None, 0):
+        raise RuntimeError(
+            "policy.router_replay.enabled=true requires a MoE model with "
+            "num_moe_experts > 0."
+        )
+
+    if not RouterReplay.global_router_replay_instances:
+        raise RuntimeError(
+            "policy.router_replay.enabled=true but no RouterReplay instances "
+            "were registered on the model. Ensure setup_model_config applied "
+            "moe_enable_routing_replay before the model was built."
+        )
+
+    if getattr(inference_context, "moe_routing_metadata", None) is None:
+        raise RuntimeError(
+            "policy.router_replay.enabled=true but the Megatron dynamic "
+            "inference context has no moe_routing_metadata. The inference "
+            "engine was likely initialized before moe_enable_routing_replay "
+            "was enabled; restart the job after enabling router replay."
+        )
+
+
 def validate_router_replay_config(config: PolicyConfig) -> None:
     if not router_replay_enabled(config):
         return
@@ -57,8 +115,11 @@ def validate_router_replay_config(config: PolicyConfig) -> None:
     generation = config.get("generation") or {}
     megatron_cfg = config.get("megatron_cfg") or {}
 
-    if generation.get("backend") != "vllm":
-        raise ValueError("router_replay.enabled requires vLLM generation.")
+    generation_backend = generation.get("backend")
+    if generation_backend not in ("vllm", "megatron"):
+        raise ValueError(
+            "router_replay.enabled requires vLLM or Megatron generation."
+        )
     if not megatron_cfg.get("enabled", False):
         raise ValueError("router_replay.enabled requires the Megatron policy backend.")
 
@@ -102,8 +163,37 @@ def _unwrap_model_config(model: Any) -> Optional[Any]:
     return None
 
 
+def _hybrid_moe_layer_numbers(hybrid_layer_pattern: str, num_layers: int) -> list[int]:
+    # Deferred import: megatron.core is only available inside the Megatron worker venv.
+    from megatron.core.models.hybrid.hybrid_layer_allocation import (
+        Symbols,
+        parse_hybrid_pattern,
+    )
+
+    main_pattern = parse_hybrid_pattern(hybrid_layer_pattern).main_pattern or ""
+    # '|' marks a pipeline-stage boundary, not a layer; every other symbol occupies one slot.
+    layer_symbols = [symbol for symbol in main_pattern if symbol != Symbols.PIPE]
+    if len(layer_symbols) != num_layers:
+        raise ValueError(
+            f"hybrid_layer_pattern main segment has {len(layer_symbols)} layers "
+            f"but num_layers={num_layers} (pattern={hybrid_layer_pattern!r})"
+        )
+    return [
+        layer_idx + 1
+        for layer_idx, symbol in enumerate(layer_symbols)
+        if symbol == Symbols.MOE
+    ]
+
+
 def _global_moe_layer_numbers(model_config: Any) -> list[int]:
     num_layers = int(getattr(model_config, "num_layers"))
+
+    # Hybrid Mamba/attention models place MoE layers via 'E' symbols of hybrid_layer_pattern
+    # and leave moe_layer_freq at its default of 1, which would wrongly claim every layer is MoE.
+    hybrid_layer_pattern = getattr(model_config, "hybrid_layer_pattern", None)
+    if hybrid_layer_pattern:
+        return _hybrid_moe_layer_numbers(hybrid_layer_pattern, num_layers)
+
     moe_layer_freq = getattr(model_config, "moe_layer_freq", 1)
 
     if isinstance(moe_layer_freq, int):
@@ -530,3 +620,192 @@ def clear_global_router_replay_instances() -> None:
     from megatron.core.transformer.moe.router_replay import RouterReplay
 
     RouterReplay.clear_global_router_replay_instances()
+
+
+def rebuild_global_router_replay_registry(model: Any) -> None:
+    """Re-register policy RouterReplay instances after a temporary model build.
+
+    Reference-model setup builds a throwaway Megatron model whose RouterReplay
+    objects register globally, then clears the global list. Megatron inference
+    recording uses that global list, so we must restore the live policy model's
+    instances before generation starts.
+    """
+    from megatron.core.transformer.moe.router_replay import RouterReplay
+    from megatron.core.utils import unwrap_model
+
+    instances = _router_replay_instances_for_model(unwrap_model(model))
+    if not instances:
+        return
+
+    RouterReplay.clear_global_router_replay_instances()
+    # Preserve module-walk order to match RouterReplay() instantiation order.
+    RouterReplay.global_router_replay_instances.extend(
+        replay_instance for replay_instance, _ in instances
+    )
+
+
+def reset_moe_routing_metadata_buffer(inference_context: Any) -> None:
+    """Drop cached MoE routing CUDA-graph buffers so they resize to the live registry."""
+    metadata = getattr(inference_context, "moe_routing_metadata", None)
+    if metadata is None:
+        return
+    metadata.routing_indices_buffer = None
+    metadata.num_moe_layers = None
+
+
+_DYNAMIC_STEP_BOOKKEEPING_ORIG = None
+_ASYNC_BOOKKEEP_ORIG = None
+_ROUTER_REPLAY_INFERENCE_PATCHED = False
+
+
+def _nrl_dynamic_step_context_bookkeeping(
+    self: TextGenerationController,
+) -> Dict[str, Any]:
+    """Reconstruct MoE routing for finished requests before KV blocks are released."""
+    from torch.cuda.nvtx import range_pop, range_push
+
+    context = self.inference_wrapped_model.inference_context
+    active_request_count = context.total_request_count - context.paused_request_count
+    active_request_slice = slice(context.paused_request_count, context.total_request_count)
+
+    range_push("transfer_samples_to_cpu")
+    sampled_tokens_cpu, sampled_mtp_tokens_cpu = self._transfer_samples_to_cpu(
+        active_request_count
+    )
+    range_pop()
+
+    range_push("active_request_mask")
+    active_request_ids = context.request_ids[active_request_slice].long()
+    active_sequence_lengths = context.get_active_sequence_lengths()
+    active_sequence_lengths += 1
+    max_sequence_lengths = context.get_max_sequence_lengths()
+
+    active_request_mask = (
+        sampled_tokens_cpu
+        != context.active_request_metadata["termination_id"][:active_request_count]
+    ).byte() & torch.less(active_sequence_lengths, max_sequence_lengths).byte()
+
+    if self._get_stop_word_finished_ids_callback is not None:
+        request_ids_list = active_request_ids.tolist()
+        stop_word_finished_ids = self._get_stop_word_finished_ids_callback(
+            request_ids_list
+        )
+        if stop_word_finished_ids:
+            for idx, request_id in enumerate(request_ids_list):
+                if request_id in stop_word_finished_ids:
+                    active_request_mask[idx] = 0
+
+    finished_idxs = (
+        torch.nonzero(active_request_mask == 0, as_tuple=True)[0]
+        + context.paused_request_count
+    )
+    finished_request_ids = context.request_ids[finished_idxs]
+
+    finished_routing_indices: Dict[int, Any] = {}
+    if context.moe_enable_routing_replay and finished_idxs.numel() > 0:
+        for fidx in finished_idxs.tolist():
+            req_id = int(context.request_ids[fidx].item())
+            blocks = context.request_to_kv_block_ids[fidx]
+            valid = blocks[blocks >= 0].tolist()
+            if not valid:
+                continue
+            total_tokens = int(
+                active_sequence_lengths[fidx - context.paused_request_count].item()
+            )
+            routing = context.kv_block_allocator.reconstruct_routing_from_blocks(
+                valid, total_tokens - 1
+            )
+            if routing is not None:
+                finished_routing_indices[req_id] = routing
+
+    new_sample_copy = sampled_tokens_cpu.clone()
+    range_pop()
+
+    range_push("update_requests")
+    update_result = context.update_requests(
+        active_request_mask, new_sample_copy, sampled_mtp_tokens_cpu
+    )
+    range_pop()
+
+    return {
+        "active_request_ids": active_request_ids,
+        "finished_request_ids": finished_request_ids,
+        "sample": sampled_tokens_cpu,
+        "finished_routing_indices": finished_routing_indices,
+        **(update_result or {}),
+    }
+
+
+async def _nrl_async_bookkeep(
+    self: DynamicInferenceEngine,
+    step_result: Optional[Dict[str, Any]],
+    context_state: Dict[str, Any],
+    step_time: float,
+):
+    """Apply pre-reconstructed routing before upstream post_process."""
+    if step_result is not None:
+        finished_routing_indices = step_result.get("finished_routing_indices")
+        if finished_routing_indices:
+            for request_id, routing in finished_routing_indices.items():
+                if request_id in self.requests:
+                    self.get_request(request_id).routing_indices = routing
+        step_result = dict(step_result)
+        step_result.pop("finished_routing_block_ids", None)
+    assert _ASYNC_BOOKKEEP_ORIG is not None
+    return await _ASYNC_BOOKKEEP_ORIG(self, step_result, context_state, step_time)
+
+
+def apply_router_replay_inference_patches() -> None:
+    """Patch dynamic inference for early router-replay reconstruction."""
+    global _DYNAMIC_STEP_BOOKKEEPING_ORIG, _ASYNC_BOOKKEEP_ORIG, _ROUTER_REPLAY_INFERENCE_PATCHED
+    if _ROUTER_REPLAY_INFERENCE_PATCHED:
+        return
+    try:
+        from megatron.core.inference.engines.dynamic_engine import DynamicInferenceEngine
+        from megatron.core.inference.text_generation_controllers.text_generation_controller import (
+            TextGenerationController,
+        )
+    except ImportError:
+        print(
+            "router_replay: Megatron inference modules are not importable; "
+            "skipping router-replay inference patches."
+        )
+        return
+
+    _DYNAMIC_STEP_BOOKKEEPING_ORIG = (
+        TextGenerationController._dynamic_step_context_bookkeeping
+    )
+    TextGenerationController._dynamic_step_context_bookkeeping = (
+        _nrl_dynamic_step_context_bookkeeping
+    )
+
+    _ASYNC_BOOKKEEP_ORIG = DynamicInferenceEngine.async_bookkeep
+    DynamicInferenceEngine.async_bookkeep = _nrl_async_bookkeep
+
+    _ROUTER_REPLAY_INFERENCE_PATCHED = True
+    print(
+        "[router_replay] patched TextGenerationController."
+        "_dynamic_step_context_bookkeeping and DynamicInferenceEngine.async_bookkeep "
+        "for early router-replay routing reconstruction."
+    )
+
+
+def restore_router_replay_inference_patches() -> None:
+    """Restore Megatron inference entry points patched by this module (for tests)."""
+    global _DYNAMIC_STEP_BOOKKEEPING_ORIG, _ASYNC_BOOKKEEP_ORIG, _ROUTER_REPLAY_INFERENCE_PATCHED
+    if not _ROUTER_REPLAY_INFERENCE_PATCHED:
+        return
+    from megatron.core.inference.engines.dynamic_engine import DynamicInferenceEngine
+    from megatron.core.inference.text_generation_controllers.text_generation_controller import (
+        TextGenerationController,
+    )
+
+    if _DYNAMIC_STEP_BOOKKEEPING_ORIG is not None:
+        TextGenerationController._dynamic_step_context_bookkeeping = (
+            _DYNAMIC_STEP_BOOKKEEPING_ORIG
+        )
+    if _ASYNC_BOOKKEEP_ORIG is not None:
+        DynamicInferenceEngine.async_bookkeep = _ASYNC_BOOKKEEP_ORIG
+    _DYNAMIC_STEP_BOOKKEEPING_ORIG = None
+    _ASYNC_BOOKKEEP_ORIG = None
+    _ROUTER_REPLAY_INFERENCE_PATCHED = False

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -229,6 +229,7 @@ from nemo_rl.models.megatron.draft.utils import (
 )
 from nemo_rl.models.megatron.router_replay import (
     clear_global_router_replay_instances,
+    rebuild_global_router_replay_registry,
     router_replay_enabled,
     validate_router_replay_config,
 )
@@ -834,7 +835,12 @@ def _apply_moe_config(model_cfg: Any, config: PolicyConfig) -> None:
 
     if "moe_grouped_gemm" in config["megatron_cfg"]:
         model_cfg.moe_grouped_gemm = config["megatron_cfg"]["moe_grouped_gemm"]
+
+    # Enable the dynamic-inference engine's MoE routing recorder when router replay (R3)
+    # is on, so the Megatron-inference generate path produces routing_indices to replay.
     model_cfg.moe_enable_routing_replay = router_replay_enabled(config)
+    if router_replay_enabled(config):
+        model_cfg.moe_router_fusion = False
 
 
 def _apply_mtp_config(model_cfg: Any, config: PolicyConfig) -> None:
@@ -1657,6 +1663,7 @@ def setup_reference_model_state(
     megatron_cfg: ConfigContainer,
     pretrained_path: str,
     pre_load_checkpoint_hook: Optional[Callable] = None,
+    policy_model: Optional[Any] = None,
 ) -> dict:
     """Setup the reference model for inference and return its state dict."""
     # Create reference checkpoint config
@@ -1786,7 +1793,10 @@ def setup_reference_model_state(
         else:
             print("Reference model not loaded")
     finally:
-        clear_global_router_replay_instances()
+        if policy_model is not None:
+            rebuild_global_router_replay_registry(policy_model)
+        else:
+            clear_global_router_replay_instances()
 
     return reference_state_dict
 

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -850,10 +850,23 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
             output_is_replicated=["tensor_parallel", "pipeline_parallel"],
             common_kwargs={"greedy": greedy},
         )
-        result = BatchedDataDict.from_batches(
-            self.worker_group.get_all_worker_results(futures),
-            pad_value_dict={"output_ids": self.cfg["generation"]["_pad_token_id"]},
-        )
+        assert self.cfg["generation"] is not None, "Generation config is not set"
+        worker_batches = self.worker_group.get_all_worker_results(futures)
+        if self.cfg["generation"]["backend"] == "megatron":
+            # Coordinator-based Megatron inference: only the DP=0 submitter returns
+            # tensors; other ranks return empty shells. Take the submitter's result
+            # directly — from_batches would also flatten any ndim>3 output tensors
+            # (e.g. routed_experts [B, S, L, K] for router replay).
+            result: BatchedDataDict[GenerationOutputSpec] = next(
+                wb
+                for wb in worker_batches
+                if wb.get("output_ids") is not None and wb["output_ids"].numel() > 0
+            )
+        else:
+            result = BatchedDataDict.from_batches(
+                worker_batches,
+                pad_value_dict={"output_ids": self.cfg["generation"]["_pad_token_id"]},
+            )
 
         required_keys = [
             "output_ids",

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -52,7 +52,11 @@ from nemo_rl.algorithms.loss.interfaces import LossFunction
 from nemo_rl.data_plane.worker_mixin import TQWorkerMixin
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.named_sharding import NamedSharding
-from nemo_rl.models.generation.interfaces import GenerationDatumSpec
+from nemo_rl.models.generation.interfaces import (
+    GenerationDatumSpec,
+    GenerationOutputSpec,
+)
+from nemo_rl.models.megatron.moe_routing_record import build_routed_experts_batch
 from nemo_rl.models.generation.megatron.megatron_worker import (
     MegatronGenerationMixin,
     MegatronGenerationRefitMixin,
@@ -527,6 +531,7 @@ class MegatronPolicyWorkerImpl(
                 pre_load_checkpoint_hook=getattr(
                     self, "_pre_load_checkpoint_hook", None
                 ),
+                policy_model=self.model,
             )
             self.model = self.move_model(self.model, "cuda")
             log_gpu_memory_diagnostics(
@@ -1805,6 +1810,48 @@ class MegatronPolicyWorkerImpl(
             ## re-enable overlap param gather after weight swap
             if self.should_disable_forward_pre_hook:
                 self.enable_forward_pre_hook()
+
+    def _parse_result_to_batched_data_dict(
+        self,
+        data: BatchedDataDict[GenerationDatumSpec],
+        result: list,
+    ) -> BatchedDataDict[GenerationOutputSpec]:
+        """Pack inference results, additionally recording MoE routing for R3 replay.
+
+        Extends the mixin's packing with the Megatron-inference router-replay recorder.
+        The dynamic-inference engine exposes per-sample ``routing_indices`` (numpy
+        ``[tokens, layers, topk]``); we convert it into the ``routed_experts``
+        ``[batch, seq, layers, topk]`` tensor that the train/logprob forward replays
+        (same key/shape the vLLM path already produces). No-op for dense models or when
+        router replay is disabled / the engine recorded no routing.
+        """
+        out = super()._parse_result_to_batched_data_dict(data, result)
+        if router_replay_enabled(self.cfg):
+            routing_per_sample = [
+                getattr(result[i], "routing_indices", None)
+                for i in range(len(result))
+            ]
+            routed_experts = build_routed_experts_batch(
+                [
+                    torch.from_numpy(r) if r is not None else None
+                    for r in routing_per_sample
+                ],
+                out["unpadded_sequence_lengths"],
+                out["output_ids"].shape[1],
+            )
+            if routed_experts is None:
+                missing = sum(r is None for r in routing_per_sample)
+                raise RuntimeError(
+                    "policy.router_replay.enabled=true requires Megatron "
+                    "inference to return routing_indices for every generated "
+                    f"sample, but {missing}/{len(routing_per_sample)} samples "
+                    "were missing that field. This usually means "
+                    "moe_enable_routing_replay was not enabled on the model "
+                    "config before the inference engine was initialized."
+                )
+            # Set after super()'s from_batches: it flattens 4D tensors into 1D rows.
+            out["routed_experts"] = routed_experts
+        return out
 
     @wrap_with_nvtx_name("megatron_policy_worker/get_topk_logits")
     def get_topk_logits(

--- a/tests/unit/models/megatron/test_megatron_setup.py
+++ b/tests/unit/models/megatron/test_megatron_setup.py
@@ -2484,6 +2484,50 @@ class TestSetupReferenceModelState:
     @patch("nemo_rl.models.megatron.setup.init_checkpointing_context")
     @patch("nemo_rl.models.megatron.setup.GlobalState")
     @patch("nemo_rl.models.megatron.setup.get_model")
+    @patch("nemo_rl.models.megatron.setup.checkpoint_exists")
+    @patch("nemo_rl.models.megatron.setup.rebuild_global_router_replay_registry")
+    @patch("nemo_rl.models.megatron.setup.load_checkpoint")
+    @patch("nemo_rl.models.megatron.setup.HAVE_FSDP2", False)
+    def test_setup_reference_model_rebuilds_router_replay_when_policy_model_passed(
+        self,
+        mock_load_checkpoint,
+        mock_rebuild_global_router_replay_registry,
+        mock_checkpoint_exists,
+        mock_get_model,
+        mock_global_state,
+        mock_init_ckpt_context,
+        mock_pg_collection,
+    ):
+        """Test setup_reference_model_state restores policy RouterReplay after ref build."""
+        from nemo_rl.models.megatron.setup import setup_reference_model_state
+
+        mock_global_state.return_value = MagicMock()
+        mock_megatron_cfg = MagicMock()
+        mock_megatron_cfg.dist.use_torch_fsdp2 = False
+
+        mock_ref_model = MagicMock()
+        mock_ref_model.state_dict.return_value = {"layer1.weight": torch.tensor([1.0])}
+        mock_get_model.return_value = [mock_ref_model]
+        mock_checkpoint_exists.return_value = True
+
+        policy_model = MagicMock()
+        config = {"megatron_cfg": {"freeze_moe_router": False}}
+
+        setup_reference_model_state(
+            config=config,
+            megatron_cfg=mock_megatron_cfg,
+            pretrained_path="/path/to/pretrained",
+            policy_model=policy_model,
+        )
+
+        mock_rebuild_global_router_replay_registry.assert_called_once_with(
+            policy_model
+        )
+
+    @patch("nemo_rl.models.megatron.setup.ProcessGroupCollection")
+    @patch("nemo_rl.models.megatron.setup.init_checkpointing_context")
+    @patch("nemo_rl.models.megatron.setup.GlobalState")
+    @patch("nemo_rl.models.megatron.setup.get_model")
     @patch("nemo_rl.models.megatron.setup.clear_global_router_replay_instances")
     def test_setup_reference_model_clears_router_replay_on_get_model_error(
         self,

--- a/tests/unit/models/megatron/test_moe_routing_record.py
+++ b/tests/unit/models/megatron/test_moe_routing_record.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from nemo_rl.models.megatron.moe_routing_record import (
+    align_routing_rows_to_token_count,
+    build_routed_experts_batch,
+    coerce_routing_to_3d,
+)
+
+
+def test_coerce_routing_to_3d_accepts_tokens_layers_topk():
+    routing = torch.zeros(5, 2, 4, dtype=torch.int32)
+    assert coerce_routing_to_3d(routing).shape == (5, 2, 4)
+
+
+def test_align_routing_rows_to_token_count_pads_with_last_row():
+    routing = torch.tensor([[[1, 2]], [[3, 4]]], dtype=torch.int32)
+    aligned = align_routing_rows_to_token_count(routing, num_tokens=4)
+    assert aligned.shape == (4, 1, 2)
+    assert aligned[2].tolist() == [[3, 4]]
+    assert aligned[3].tolist() == [[3, 4]]
+
+
+def test_build_routed_experts_batch_right_pads_to_seq_dim():
+    routing_a = torch.ones(3, 2, 1, dtype=torch.int32)
+    routing_b = torch.full((2, 2, 1), 7, dtype=torch.int32)
+    seq_lengths = torch.tensor([3, 2])
+    batch = build_routed_experts_batch(
+        [routing_a, routing_b],
+        seq_lengths,
+        seq_dim=5,
+    )
+    assert batch is not None
+    assert batch.shape == (2, 5, 2, 1)
+    assert batch[0, :3, 0, 0].tolist() == [1, 1, 1]
+    assert batch[0, 3:, 0, 0].tolist() == [0, 0]
+    assert batch[1, :2, 0, 0].tolist() == [7, 7]

--- a/tests/unit/models/megatron/test_router_replay.py
+++ b/tests/unit/models/megatron/test_router_replay.py
@@ -56,6 +56,19 @@ def test_validate_router_replay_config_allows_prefix_cache_default():
 
 
 @pytest.mark.mcore
+def test_validate_router_replay_config_allows_megatron_backend():
+    from nemo_rl.models.megatron.router_replay import validate_router_replay_config
+
+    config = {
+        "router_replay": {"enabled": True},
+        "generation": {"backend": "megatron"},
+        "megatron_cfg": {"enabled": True},
+    }
+
+    validate_router_replay_config(config)
+
+
+@pytest.mark.mcore
 def test_normalize_routed_experts_dense_batch_uses_seq_major_order():
     from nemo_rl.models.megatron.router_replay import (
         _normalize_routed_experts_for_mcore,


### PR DESCRIPTION
# What does this PR do?
**Enable MoE router replay (R3) end-to-end on the colocated Megatron-inference generation path, so train/logprob can replay the same expert routing that generation recorded.**
Previously, router replay worked with **vLLM generation** (via `enable_return_routed_experts`) plus **Megatron train/logprob** replay. Colocated **Megatron inference** did not record or return per-token routing, so R3 could not be used with `generation.backend: megatron`.
This PR adds:
1. **Megatron inference routing recorder** — enables `moe_enable_routing_replay` on the model config and patches the dynamic inference engine to reconstruct `routing_indices` before KV blocks are released.
2. **Batch conversion** — `moe_routing_record.py` converts per-sample `routing_indices [tokens, layers, topk]` into the `routed_experts [batch, seq, layers, topk]` tensor the existing R3 train forward expects.
3. **Policy worker wiring** — packs `routed_experts` from Megatron generation results; preserves 4D tensors through the Megatron coordinator path in `lm_policy.py`.
4. **Registry lifecycle** — after reference-model setup, rebuilds the live policy's `RouterReplay` global registry (ref-model build previously cleared it).
5. **Config validation** — `validate_router_replay_config` now accepts `generation.backend: megatron` in addition to `vllm`.

# Issues
<!-- Link issues if applicable, e.g. Closes #1234 -->
# Usage
Enable router replay with Megatron colocated generation:
```yaml
policy:
  router_replay:
    enabled: true
  megatron_cfg:
    enabled: true
    # MoE model with EP/TP as usual
    expert_model_parallel_size: 8
    tensor_model_parallel_size: 1
    moe_permute_fusion: false   # recommended; also forced when R3 is on
  generation:
    backend: megatron
    mcore_generation_config:
      max_model_len: 4096
      max_tokens: 4096
      cuda_graph_impl: none       # or local; cuda-graph decode fix is a separate PR
      # ... other mcore_generation_config knobs unchanged
```
Requirements when `router_replay.enabled: true`:
- Megatron policy backend (`megatron_cfg.enabled: true`)
- MoE model (`num_moe_experts > 0`)
- `generation.backend` is `megatron` or `vllm`
- Virtual pipeline parallelism size must be 1 (unchanged from existing R3 constraint)
At runtime you should see:
```
[router_replay] patched TextGenerationController._dynamic_step_context_bookkeeping ...
```
and generated batches should carry a non-empty `routed_experts` tensor for replay on the next train/logprob forward.
# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.
**Tests added/updated:**
| Test | What it covers |
|------|----------------|
| `tests/unit/models/megatron/test_moe_routing_record.py` | `routing_indices` → `routed_experts` batch conversion |
| `tests/unit/models/megatron/test_router_replay.py` | `validate_router_replay_config` accepts Megatron backend |
| `tests/unit/models/megatron/test_megatron_setup.py` | Ref-model teardown rebuilds policy `RouterReplay` registry |
**Suggested local test run:**
```bash
uv run --extra mcore --group test pytest \
  tests/unit/models/megatron/test_moe_routing_record.py \
  tests/unit/models/megatron/test_router_replay.py \
  tests/unit/models/megatron/test_megatron_setup.py \
  --mcore-only \
  -p no:shard \
  -v
```
# Additional Information
## Files changed
| File | Change |
|------|--------|
| `nemo_rl/models/megatron/router_replay.py` | Megatron-backend validation; inference setup helpers; early routing reconstruction patches |
| `nemo_rl/models/megatron/moe_routing_record.py` | **New** — generation routing → `routed_experts` tensor |
| `nemo_rl/models/megatron/setup.py` | `moe_enable_routing_replay` + `moe_router_fusion=False`; ref-model registry rebuild |
| `nemo_rl/models/generation/megatron/megatron_worker.py` | Engine init: registry rebuild, config sync, inference patches, readiness checks |
| `nemo_rl/models/policy/workers/megatron_policy_worker.py` | Record `routed_experts` from inference; pass `policy_model` to ref setup |
| `nemo_rl/models/policy/lm_policy.py` | Preserve 4D `routed_experts` on Megatron coordinator path |
## Design notes
- **Why patch inference bookkeeping?** Upstream Megatron reconstructs finished-request routing after KV release; R3 needs `routing_indices` on the request earlier. The patch hooks `_dynamic_step_context_bookkeeping` and `async_bookkeep` to fix that.
- **Why rebuild the global registry?** Reference-model setup builds a throwaway model that registers its own `RouterReplay` instances globally, then clears them. Generation recording uses that global list, so we restore the live policy's instances before inference starts.
- **vLLM path unchanged** — existing vLLM + R3 behavior is untouched; this PR only adds the Megatron generation recorder.
