### PR TITLE
fix(megatron): create CUDA graph managers for colocated generation

### DIFF
--- a/nemo_rl/models/generation/megatron/megatron_worker.py
+++ b/nemo_rl/models/generation/megatron/megatron_worker.py
@@ -30,7 +30,11 @@ from megatron.core.inference.config import (
 from megatron.core.inference.engines.dynamic_engine import EngineState
 from megatron.core.inference.sampling_params import SamplingParams
 from megatron.core.transformer.enums import InferenceCudaGraphScope
-from megatron.core.transformer.utils import toggle_cuda_graphs
+from megatron.core.transformer.utils import (
+    init_cuda_graph_cache,
+    toggle_cuda_graphs,
+    transition_moe_cudagraphs,
+)
 from megatron.core.utils import unwrap_model
 
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
@@ -44,6 +48,74 @@ from nemo_rl.models.generation.megatron.utils import (
     resolve_torch_dtype,
 )
 from nemo_rl.utils.nsys import wrap_with_nvtx_name
+
+
+def _invalidate_cuda_graph_attr_cache(model: torch.nn.Module) -> None:
+    import megatron.core.transformer.utils as cg_utils
+
+    model_id = id(model)
+    if cg_utils.cuda_graph_attr_cache is not None:
+        cg_utils.cuda_graph_attr_cache.pop(model_id, None)
+
+
+def _ensure_inference_cuda_graph_managers(
+    lang_module: torch.nn.Module, mcore_generation_config: dict
+) -> None:
+    """Attach CUDA graph managers when generation enables graphs after train init.
+
+    Colocated NeMo-RL policies are built with ``megatron_cfg.cuda_graph_impl=none``.
+    ``toggle_cuda_graphs('local')`` only restores managers that existed at model
+    init, so generation must create them here.
+    """
+    cuda_graph_impl = mcore_generation_config.get("cuda_graph_impl", "none")
+    if cuda_graph_impl == "none":
+        return
+
+    from megatron.core.transformer.cuda_graphs import CudaGraphManager
+    from megatron.core.transformer.transformer_block import TransformerBlock
+    from megatron.core.transformer.transformer_layer import (
+        MoETransformerLayer,
+        TransformerLayer,
+    )
+
+    config = lang_module.config
+    config.cuda_graph_impl = cuda_graph_impl
+    config.cuda_graph_modules = []
+
+    scope_name = mcore_generation_config.get("inference_cuda_graph_scope", "block")
+    scope = InferenceCudaGraphScope[scope_name]
+    config.inference_cuda_graph_scope = scope
+
+    if scope == InferenceCudaGraphScope.block:
+        for module in lang_module.modules():
+            if isinstance(module, TransformerBlock) and not hasattr(
+                module, "cudagraph_manager"
+            ):
+                module.cudagraph_manager = CudaGraphManager(config)
+        for module in lang_module.modules():
+            if isinstance(module, MoETransformerLayer):
+                module.use_partial_cudagraphs = False
+                module.mlp.fwd_execution_map = [
+                    "route",
+                    "expert_compute",
+                    "postprocess",
+                ]
+    elif scope == InferenceCudaGraphScope.layer:
+        for module in lang_module.modules():
+            if (
+                isinstance(module, TransformerLayer)
+                and hasattr(module, "create_mcore_cudagraph_manager")
+                and not hasattr(module, "cudagraph_manager")
+            ):
+                module.create_mcore_cudagraph_manager(config)
+
+        if any(
+            isinstance(module, MoETransformerLayer) for module in lang_module.modules()
+        ):
+            transition_moe_cudagraphs(lang_module, "full")
+
+    _invalidate_cuda_graph_attr_cache(lang_module)
+    init_cuda_graph_cache(lang_module)
 
 
 class MegatronGenerationMixin:
@@ -357,6 +429,7 @@ class MegatronGenerationMixin:
             ]
             if cuda_graph_impl != "none":
                 toggle_cuda_graphs(lang_module, set_to="none")
+                _invalidate_cuda_graph_attr_cache(lang_module)
 
         rotary_module = getattr(lang_module, "rotary_pos_emb", None)
         if rotary_module is not None and hasattr(
@@ -404,6 +477,7 @@ class MegatronGenerationMixin:
 
         cuda_graph_impl = mcore_generation_config["cuda_graph_impl"]
         if cuda_graph_impl != "none":
+            _ensure_inference_cuda_graph_managers(lang_module, mcore_generation_config)
             toggle_cuda_graphs(lang_module, set_to=cuda_graph_impl)
 
         # tags=["weights"] means we are inside refit_policy_generation between

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -530,6 +530,130 @@ def test_prepare_for_generation_disables_param_gather_hook_before_wake(
     assert model.config.flash_decode is False
 
 
+def test_prepare_for_generation_ensures_cuda_graph_managers_before_toggle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nemo_rl.models.generation.megatron import megatron_worker
+
+    events: list[str | tuple[str, str]] = []
+    model = SimpleNamespace(
+        config=SimpleNamespace(flash_decode=True),
+        eval=lambda: events.append("eval"),
+    )
+    worker = object.__new__(megatron_worker.MegatronGenerationMixin)
+    worker.cfg = {
+        "generation": {
+            "mcore_generation_config": {
+                "cuda_graph_impl": "local",
+                "inference_cuda_graph_scope": "block",
+            }
+        }
+    }
+    worker.model = model
+    worker.is_generation_colocated = False
+    worker.should_disable_forward_pre_hook = False
+    worker._inference_engine_initialized = True
+    worker._wake = lambda: events.append("wake_engine")
+
+    monkeypatch.setattr(megatron_worker, "log_gpu_memory", lambda *_: None)
+    monkeypatch.setattr(megatron_worker, "unwrap_model", lambda model: model)
+    monkeypatch.setattr(
+        megatron_worker,
+        "_ensure_inference_cuda_graph_managers",
+        lambda lang_module, mcore_generation_config: events.append("ensure_managers"),
+    )
+    monkeypatch.setattr(
+        megatron_worker,
+        "toggle_cuda_graphs",
+        lambda lang_module, set_to: events.append(("toggle_cuda_graphs", set_to)),
+    )
+
+    worker.prepare_for_generation()
+
+    assert events.index("ensure_managers") < events.index(("toggle_cuda_graphs", "local"))
+    assert ("toggle_cuda_graphs", "local") in events
+
+
+def test_prepare_for_generation_skips_cuda_graph_managers_when_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nemo_rl.models.generation.megatron import megatron_worker
+
+    ensure_called = False
+    toggle_called = False
+    model = SimpleNamespace(
+        config=SimpleNamespace(flash_decode=True),
+        eval=lambda: None,
+    )
+    worker = object.__new__(megatron_worker.MegatronGenerationMixin)
+    worker.cfg = {
+        "generation": {"mcore_generation_config": {"cuda_graph_impl": "none"}}
+    }
+    worker.model = model
+    worker.is_generation_colocated = False
+    worker.should_disable_forward_pre_hook = False
+    worker._inference_engine_initialized = True
+    worker._wake = lambda: None
+
+    monkeypatch.setattr(megatron_worker, "log_gpu_memory", lambda *_: None)
+    monkeypatch.setattr(megatron_worker, "unwrap_model", lambda model: model)
+
+    def _ensure_managers(lang_module, mcore_generation_config):
+        nonlocal ensure_called
+        ensure_called = True
+
+    def _toggle_cuda_graphs(lang_module, set_to):
+        nonlocal toggle_called
+        toggle_called = True
+
+    monkeypatch.setattr(
+        megatron_worker, "_ensure_inference_cuda_graph_managers", _ensure_managers
+    )
+    monkeypatch.setattr(megatron_worker, "toggle_cuda_graphs", _toggle_cuda_graphs)
+
+    worker.prepare_for_generation()
+
+    assert not ensure_called
+    assert not toggle_called
+
+
+def test_finish_generation_invalidates_cuda_graph_attr_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nemo_rl.models.generation.megatron import megatron_worker
+
+    events: list[str | tuple[str, str]] = []
+    model = SimpleNamespace(config=SimpleNamespace())
+    worker = object.__new__(megatron_worker.MegatronGenerationMixin)
+    worker.cfg = {
+        "generation": {"mcore_generation_config": {"cuda_graph_impl": "local"}}
+    }
+    worker.model = model
+    worker.rank = 0
+    worker.is_generation_colocated = True
+    worker._inference_engine_initialized = False
+    worker._inference_engine_asleep = True
+
+    monkeypatch.setattr(megatron_worker, "log_gpu_memory", lambda *_: None)
+    monkeypatch.setattr(megatron_worker, "unwrap_model", lambda model: model)
+    monkeypatch.setattr(
+        megatron_worker,
+        "toggle_cuda_graphs",
+        lambda lang_module, set_to: events.append(("toggle_cuda_graphs", set_to)),
+    )
+    monkeypatch.setattr(
+        megatron_worker,
+        "_invalidate_cuda_graph_attr_cache",
+        lambda lang_module: events.append("invalidate_cache"),
+    )
+    monkeypatch.setattr(megatron_worker.gc, "collect", lambda: None)
+    monkeypatch.setattr(megatron_worker.torch.cuda, "empty_cache", lambda: None)
+
+    worker.finish_generation()
+
+    assert events == [("toggle_cuda_graphs", "none"), "invalidate_cache"]
+
+
 def create_megatron_test_config(
     model_name: str,
     tp: int = 1,

--- a/tests/unit/models/policy/test_megatron_worker.py
+++ b/tests/unit/models/policy/test_megatron_worker.py
@@ -530,7 +530,7 @@ def test_prepare_for_generation_disables_param_gather_hook_before_wake(
     assert model.config.flash_decode is False
 
 
-def test_prepare_for_generation_ensures_cuda_graph_managers_before_toggle(
+def test_prepare_for_generation_ensure_cuda_graph_managers_before_toggle(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from nemo_rl.models.generation.megatron import megatron_worker


### PR DESCRIPTION

# What does this PR do?

**Fix colocated Megatron inference staying on the eager decode path when generation enables CUDA graphs.**

NeMo-RL colocated policies are built with `megatron_cfg.cuda_graph_impl=none` (train). Generation then sets `mcore_generation_config.cuda_graph_impl: local`. Megatron's `toggle_cuda_graphs('local')` only restores `CudaGraphManager` instances that existed at model init, so warmup/decode never capture graphs even though the dynamic engine reports graph buckets.

This PR creates managers at `prepare_for_generation` time and clears the cached module list when toggling graphs off in `finish_generation`.


# Issues

<!-- Link issues if applicable, e.g. Closes #1234 -->

# Usage

No config change. Existing recipes with colocated Megatron generation and CUDA graphs, e.g.:

```yaml
policy:
  megatron_cfg:
    cuda_graph_impl: none          # train path (default for colocated)

  generation:
    backend: megatron
    mcore_generation_config:
      cuda_graph_impl: local       # generation path
      inference_cuda_graph_scope: block   # or layer
```

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [x] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

**Tests to add** (in `tests/unit/models/policy/test_megatron_worker.py`, mock wiring):

- `prepare_for_generation` calls `_ensure_inference_cuda_graph_managers` before `toggle_cuda_graphs` when `cuda_graph_impl != none`
- `prepare_for_generation` skips manager creation when `cuda_graph_impl: none`
- `finish_generation` calls `_invalidate_cuda_graph_attr_cache` when colocated graphs are toggled off

```bash
uv run --extra mcore --group test pytest \
  tests/unit/models/policy/test_megatron_worker.py \
  -k "ensure_cuda_graph_managers or skips_cuda_graph_managers or invalidates_cuda_graph_attr" \
  --mcore-only --shard-id=0 --num-shards=1 -v
```

# Additional Information

## Files changed

| File | Change |
|------|--------|
| `nemo_rl/models/generation/megatron/megatron_worker.py` | `_ensure_inference_cuda_graph_managers`, `_invalidate_cuda_graph_attr_cache`; wired in `prepare_for_generation` / `finish_generation` |

## Validation (manual)

- [x] Colocated MoE run with `cuda_graph_impl: local` in `mcore_generation_config` — decode uses captured graphs (not eager-only)
- [x] Train step after `finish_generation` still works with graphs toggled off
