### PR TITLE
fix: raise an actionable error when a prepare_for_* step is skipped

### DIFF
--- a/nemo_rl/models/policy/interfaces.py
+++ b/nemo_rl/models/policy/interfaces.py
@@ -148,10 +148,17 @@ class PolicyInterface(ABC):
 
     @abstractmethod
     def prepare_for_training(self, *args: Any, **kwargs: Any) -> None:
+        """Onload the model and optimizer state to GPU so training can run.
+
+        Call this before :meth:`train`. Implementations offload parameters to
+        CPU between phases, so skipping it leaves them on CPU while the training
+        step assumes CUDA.
+        """
         pass
 
     @abstractmethod
     def finish_training(self, *args: Any, **kwargs: Any) -> None:
+        """Release training-only state after a :meth:`train` phase completes."""
         pass
 
     @abstractmethod
@@ -252,7 +259,12 @@ class ColocatablePolicyInterface(PolicyInterface):
 
     @abstractmethod
     def prepare_for_lp_inference(self, keep_train_buffers: bool = False) -> None:
-        """Put the policy in eval mode for logprob inference.
+        """Onload the model and put the policy in eval mode for logprob inference.
+
+        Call this before :meth:`get_logprobs`, :meth:`get_reference_policy_logprobs`,
+        :meth:`get_topk_logits`, or :meth:`score`. As with
+        :meth:`prepare_for_training`, parameters are offloaded to CPU between
+        phases and must be onloaded again first.
 
         Args:
             keep_train_buffers: Leave grad buffers and optimizer state on CUDA

--- a/nemo_rl/models/policy/workers/base_policy_worker.py
+++ b/nemo_rl/models/policy/workers/base_policy_worker.py
@@ -22,8 +22,62 @@ from nemo_rl.models.policy.interfaces import ReferenceLogprobOutputSpec
 from nemo_rl.utils.nsys import wrap_with_nvtx_name
 
 
+def first_parameter_device(
+    model: Any,
+) -> Optional[torch.device]:
+    """Return the device of the model's first parameter, or None if it has none.
+
+    ``model`` is a single ``nn.Module`` on the DTensor workers and a list of
+    virtual pipeline chunks on the Megatron worker, so both are accepted.
+    """
+    modules = model if isinstance(model, (list, tuple)) else [model]
+    for module in modules:
+        for param in module.parameters():
+            return param.device
+    return None
+
+
 class AbstractPolicyWorker:
     """Base class for policy workers with shared functionality."""
+
+    def _assert_model_onloaded(
+        self,
+        api_name: str,
+        required_prepare_call: str,
+        *,
+        params_may_be_offloaded: bool = False,
+    ) -> None:
+        """Fail with an actionable message if the model is still offloaded to CPU.
+
+        Workers offload model parameters to CPU between phases (``finish_inference``,
+        ``offload_after_refit``), and the matching ``prepare_for_*`` call onloads them
+        again. Reaching a compute API without that call leaves parameters on CPU while
+        the rest of the step assumes CUDA, which surfaces as an opaque ``illegal memory
+        access`` rather than anything pointing at the missing step. Check up front so
+        the failure names the call to add.
+
+        Args:
+            api_name: Name of the compute API being entered, used in the message.
+            required_prepare_call: Name of the ``prepare_for_*`` call that onloads the
+                model for ``api_name``.
+            params_may_be_offloaded: Set when the worker is configured so that
+                parameters legitimately live on CPU during compute (FSDP
+                ``cpu_offload``), in which case the check does not apply.
+        """
+        if params_may_be_offloaded:
+            return
+
+        device = first_parameter_device(self.model)
+        if device is None or device.type != "cpu":
+            return
+
+        raise RuntimeError(
+            f"{type(self).__name__}.{api_name}() was called while the model parameters "
+            f"are still on CPU. Call {required_prepare_call}() to onload the model "
+            f"before {api_name}(). Parameters are offloaded to CPU between phases (for "
+            f"example by finish_inference() or offload_after_refit()), and without the "
+            f"onload this typically fails later as a CUDA 'illegal memory access'."
+        )
 
     def init_collective(
         self,

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker.py
@@ -609,6 +609,11 @@ class DTensorPolicyWorkerImpl(
         check_dim_skip_keys: Optional[Iterable[str]] = None,
     ) -> dict[str, Any]:
         """Train the policy on a batch of data with a given loss function."""
+        self._assert_model_onloaded(
+            "train",
+            "prepare_for_training",
+            params_may_be_offloaded=self.cpu_offload,
+        )
         self.timer.start("train")
         if gbs is None:
             gbs = self.cfg["train_global_batch_size"]
@@ -1035,6 +1040,11 @@ class DTensorPolicyWorkerImpl(
           We use the convention that the logprob of the first token is 0 so that the sequence length is maintained.
           The logprob of input token i is specified at position i in the output logprobs tensor.
         """
+        self._assert_model_onloaded(
+            "get_logprobs",
+            "prepare_for_lp_inference",
+            params_may_be_offloaded=self.cpu_offload,
+        )
         self.timer.start("get_logprobs")
         logprob_batch_size = (
             micro_batch_size
@@ -1345,6 +1355,11 @@ class DTensorPolicyWorkerImpl(
     # TODO @Rayen Tian: Related Issue: Refactor shared logic between score() and get_logprobs() (https://github.com/NVIDIA-NeMo/RL/issues/1094)
     @wrap_with_nvtx_name("dtensor_policy_worker/score")
     def score(self, data: BatchedDataDict) -> BatchedDataDict[ScoreOutputSpec]:
+        self._assert_model_onloaded(
+            "score",
+            "prepare_for_lp_inference",
+            params_may_be_offloaded=self.cpu_offload,
+        )
         global_batch_size = min(self.cfg["batch_size"], data.size)
 
         sequence_dim = 1
@@ -1487,6 +1502,11 @@ class DTensorPolicyWorkerImpl(
         - Supports context parallelism with proper CP gather.
         - Otherwise, computes local top-k on full-vocab tensor.
         """
+        self._assert_model_onloaded(
+            "get_topk_logits",
+            "prepare_for_lp_inference",
+            params_may_be_offloaded=self.cpu_offload,
+        )
         self.timer.start("get_topk_logits")
         topk_batch_size = (
             micro_batch_size

--- a/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
+++ b/nemo_rl/models/policy/workers/dtensor_policy_worker_v2.py
@@ -409,6 +409,11 @@ class DTensorPolicyWorkerV2Impl(
         check_dim_skip_keys: Optional[Iterable[str]] = None,
     ) -> dict[str, Any]:
         """Train the policy on a batch of data with a given loss function."""
+        self._assert_model_onloaded(
+            "train",
+            "prepare_for_training",
+            params_may_be_offloaded=self.cpu_offload,
+        )
         self.timer.start("train")
         if gbs is None:
             gbs = self.cfg["train_global_batch_size"]
@@ -602,6 +607,11 @@ class DTensorPolicyWorkerV2Impl(
           We use the convention that the logprob of the first token is 0 so that the sequence length is maintained.
           The logprob of input token i is specified at position i in the output logprobs tensor.
         """
+        self._assert_model_onloaded(
+            "get_logprobs",
+            "prepare_for_lp_inference",
+            params_may_be_offloaded=self.cpu_offload,
+        )
         self.timer.start("get_logprobs")
         logprob_batch_size = (
             micro_batch_size
@@ -684,6 +694,11 @@ class DTensorPolicyWorkerV2Impl(
 
     @wrap_with_nvtx_name("dtensor_policy_worker_v2/score")
     def score(self, data: BatchedDataDict) -> BatchedDataDict[ScoreOutputSpec]:
+        self._assert_model_onloaded(
+            "score",
+            "prepare_for_lp_inference",
+            params_may_be_offloaded=self.cpu_offload,
+        )
         global_batch_size = min(self.cfg["batch_size"], data.size)
 
         # Validate sequence dimension
@@ -762,6 +777,11 @@ class DTensorPolicyWorkerV2Impl(
         - Supports context parallelism with proper CP gather.
         - Otherwise, computes local top-k on full-vocab tensor.
         """
+        self._assert_model_onloaded(
+            "get_topk_logits",
+            "prepare_for_lp_inference",
+            params_may_be_offloaded=self.cpu_offload,
+        )
         topk_batch_size = (
             micro_batch_size
             if micro_batch_size is not None

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -766,6 +766,7 @@ class MegatronPolicyWorkerImpl(
             "check_dim_skip_keys is only supported by the v2 DTensor worker; "
             "Megatron does not run cross-tokenizer distillation."
         )
+        self._assert_model_onloaded("train", "prepare_for_training")
         self.timer.start("train")
         # Note: zero_grad_buffer is called at the start of each global batch iteration
         # in the loop below, so we don't need to call it here.
@@ -1829,6 +1830,7 @@ class MegatronPolicyWorkerImpl(
           We use the convention that the logprob of the first token is 0 so that the sequence length is maintained.
           The logprob of input token i is specified at position i in the output logprobs tensor.
         """
+        self._assert_model_onloaded("get_logprobs", "prepare_for_lp_inference")
         self.timer.start("get_logprobs")
         no_grad = torch.no_grad()
         no_grad.__enter__()
@@ -2053,6 +2055,7 @@ class MegatronPolicyWorkerImpl(
                 - topk_logits: Tensor of top-k logits for each position in the sequence
                 - topk_indices: Tensor of top-k indices for each position in the sequence
         """
+        self._assert_model_onloaded("get_topk_logits", "prepare_for_lp_inference")
         no_grad = torch.no_grad()
         no_grad.__enter__()
 

--- a/tests/unit/models/policy/test_prepare_step_guards.py
+++ b/tests/unit/models/policy/test_prepare_step_guards.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+import torch
+from torch import nn
+
+from nemo_rl.models.policy.workers.base_policy_worker import (
+    AbstractPolicyWorker,
+    first_parameter_device,
+)
+
+
+class FakePolicyWorker(AbstractPolicyWorker):
+    """Minimal stand-in exposing only what the onload guard reads.
+
+    The real workers are Ray actors that need a GPU to construct, so the guard
+    is exercised against the one attribute it touches.
+    """
+
+    def __init__(self, model):
+        self.model = model
+
+
+def _cpu_model() -> nn.Module:
+    return nn.Linear(2, 2, device="cpu")
+
+
+def _offloaded_worker() -> FakePolicyWorker:
+    return FakePolicyWorker(_cpu_model())
+
+
+def test_first_parameter_device_single_module():
+    assert first_parameter_device(_cpu_model()) == torch.device("cpu")
+
+
+def test_first_parameter_device_module_list():
+    # The Megatron worker holds a list of virtual pipeline chunks.
+    chunks = [_cpu_model(), _cpu_model()]
+    assert first_parameter_device(chunks) == torch.device("cpu")
+
+
+def test_first_parameter_device_no_parameters():
+    assert first_parameter_device(nn.Identity()) is None
+
+
+def test_raises_when_model_is_offloaded():
+    worker = _offloaded_worker()
+
+    with pytest.raises(RuntimeError) as excinfo:
+        worker._assert_model_onloaded("get_logprobs", "prepare_for_lp_inference")
+
+    message = str(excinfo.value)
+    assert "FakePolicyWorker.get_logprobs()" in message
+    assert "prepare_for_lp_inference()" in message
+    assert "illegal memory access" in message
+
+
+def test_raises_for_module_list():
+    worker = FakePolicyWorker([_cpu_model(), _cpu_model()])
+
+    with pytest.raises(RuntimeError, match="prepare_for_training"):
+        worker._assert_model_onloaded("train", "prepare_for_training")
+
+
+def test_allows_offloaded_params_when_cpu_offload_is_enabled():
+    # FSDP cpu_offload keeps parameters on CPU during compute by design.
+    worker = _offloaded_worker()
+
+    worker._assert_model_onloaded(
+        "train",
+        "prepare_for_training",
+        params_may_be_offloaded=True,
+    )
+
+
+def test_allows_onloaded_model():
+    # 'meta' stands in for a non-CPU device so the check runs without a GPU.
+    worker = FakePolicyWorker(nn.Linear(2, 2, device="meta"))
+
+    worker._assert_model_onloaded("train", "prepare_for_training")
+
+
+def test_allows_model_without_parameters():
+    worker = FakePolicyWorker(nn.Identity())
+
+    worker._assert_model_onloaded("train", "prepare_for_training")


### PR DESCRIPTION
# What does this PR do ?

Turns the opaque CUDA `illegal memory access` you get from skipping a `prepare_for_*()` step into a `RuntimeError` that names both the API you called and the prepare step you missed.

# Issues

Closes #1141

# Usage

Policy workers offload model parameters to CPU between phases (`finish_inference`, `offload_after_refit`), and the matching `prepare_for_*` call onloads them again. Reaching a compute API without that call leaves parameters on CPU while the rest of the step assumes CUDA. As #1141 notes, that's easy to hit when writing a custom training loop, and the resulting failure points nowhere near the missing step.

Before — an `illegal memory access` from somewhere deep in the forward pass. After:

```python
policy.offload_after_refit()
policy.get_logprobs(data)
```
```
RuntimeError: DTensorPolicyWorkerV2.get_logprobs() was called while the model
parameters are still on CPU. Call prepare_for_lp_inference() to onload the model
before get_logprobs(). Parameters are offloaded to CPU between phases (for example
by finish_inference() or offload_after_refit()), and without the onload this
typically fails later as a CUDA 'illegal memory access'.
```

## What changed

`AbstractPolicyWorker._assert_model_onloaded()` checks the device of the model's first parameter and raises naming the API and the required prepare call. It's wired into the compute entry points of all three policy workers:

| Worker | Guarded API | Required call |
|---|---|---|
| DTensor v1 / v2 | `train` | `prepare_for_training` |
| DTensor v1 / v2 | `get_logprobs`, `score`, `get_topk_logits` | `prepare_for_lp_inference` |
| Megatron | `train` | `prepare_for_training` |
| Megatron | `get_logprobs`, `get_topk_logits` | `prepare_for_lp_inference` |

`get_reference_policy_logprobs` delegates to `get_logprobs`, so it's covered without a second check.

The check deliberately does not fire in three cases:
- **FSDP `cpu_offload`** — parameters legitimately stay on CPU during compute, so callers pass `params_may_be_offloaded=self.cpu_offload`. Megatron only has `optimizer_cpu_offload` (params are always onloaded for compute), so it passes nothing.
- **A model with no parameters** — nothing to check.
- **Any non-CPU device** — only a CPU-resident model is treated as offloaded.

Megatron holds a list of virtual pipeline chunks rather than a single module, so `first_parameter_device()` accepts both shapes.

I also added docstrings to the `PolicyInterface` lifecycle methods (`prepare_for_training`, `finish_training`, `prepare_for_lp_inference`), which had none — that covers the "or document" half of the issue for someone reading the interface before writing their own loop.

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? — `tests/unit/models/policy/test_prepare_step_guards.py`, 8 tests covering the raise path, the message contents, the module-list shape, and each of the three skip conditions. The real workers are Ray actors needing a GPU, so the guard is exercised through a minimal `AbstractPolicyWorker` subclass.
- [x] Did you run the unit tests and functional tests locally? — see below
- [x] Did you add or update any necessary documentation? — interface docstrings; no user-facing config or feature change

# Additional Information

* Local verification (macOS, CPU-only, so GPU paths could not be exercised):
  * `pytest tests/unit/models/policy/test_prepare_step_guards.py` → 8 passed
  * `ruff check` / `ruff format --check` → clean
  * `pyrefly check` → no new errors versus `main`
  * `pytest tests/unit/models/policy` → the failures there (`test_split_api_wrappers.py`, `test_utils.py`, `test_policy_validation.py`) reproduce identically on a clean `main` with `Torch not compiled with CUDA enabled`; none of those files import the modules touched here.
* Scope note: value workers (`nemo_rl/models/value/workers/`) have the same `prepare_for_training` / `prepare_for_inference` lifecycle and could take the same guard. I left them out to keep this focused on the policy path from the issue — happy to extend if you'd prefer it in one change.
