### PR TITLE
fix: propagate policy CLI overrides to the distillation teacher config

### DIFF
--- a/examples/configs/distillation_math.yaml
+++ b/examples/configs/distillation_math.yaml
@@ -252,6 +252,13 @@ policy: &POLICY_BASE
 teacher:
     <<: *POLICY_BASE
     model_name: "Qwen/Qwen3-4B"
+    # The `<<` merge key above is resolved by the YAML parser, so it copies the
+    # policy values as they are written in this file and does not see later CLI
+    # overrides. Track the student sequence length through an interpolation
+    # instead, so `policy.max_total_sequence_length=...` on the command line
+    # applies to both models (and to everything derived from it below, such as
+    # dynamic batching and the vLLM `max_model_len`).
+    max_total_sequence_length: ${policy.max_total_sequence_length}
     dtensor_cfg:
         <<: *DTENSOR_BASE
         context_parallel_size: 2 

--- a/examples/configs/distillation_math_megatron.yaml
+++ b/examples/configs/distillation_math_megatron.yaml
@@ -187,6 +187,13 @@ policy: &POLICY_BASE
 teacher:
     <<: *POLICY_BASE
     model_name: "Qwen/Qwen3-4B"
+    # The `<<` merge key above is resolved by the YAML parser, so it copies the
+    # policy values as they are written in this file and does not see later CLI
+    # overrides. Track the student sequence length through an interpolation
+    # instead, so `policy.max_total_sequence_length=...` on the command line
+    # applies to both models (and to everything derived from it below, such as
+    # dynamic batching and the vLLM `max_model_len`).
+    max_total_sequence_length: ${policy.max_total_sequence_length}
     megatron_cfg:
         <<: *MEGATRON_BASE
         context_parallel_size: 2

--- a/tests/unit/test_config_validation.py
+++ b/tests/unit/test_config_validation.py
@@ -40,6 +40,7 @@ from nemo_rl.algorithms.xtoken_off_policy_distillation import (
 from nemo_rl.evals.eval import MasterConfig as EvalMasterConfig
 from nemo_rl.utils.config import (
     load_config_with_inheritance,
+    parse_hydra_overrides,
     register_omegaconf_resolvers,
 )
 
@@ -272,3 +273,43 @@ def test_all_config_no_tp_size_accuracy_issues(config_file):
             f"Config file {config_file} has TP size >= 4 accuracy issues. "
             "Please set policy.train_micro_batch_size and policy.logprob_batch_size to be the same value."
         )
+
+
+# Configs where a `teacher` section copies `policy` with a YAML merge key (`<<`).
+# The merge key is resolved by the YAML parser, so it captures the policy values
+# as written in the file and never sees a later CLI override. Fields that must
+# match between student and teacher therefore have to be interpolations.
+TEACHER_INHERITING_CONFIGS = [
+    "examples/configs/distillation_math.yaml",
+    "examples/configs/distillation_math_megatron.yaml",
+]
+
+
+@pytest.mark.parametrize("config_file", TEACHER_INHERITING_CONFIGS)
+def test_teacher_sequence_length_follows_policy_override(config_file):
+    """A CLI override of the student sequence length must reach the teacher.
+
+    Guards against regressing to a plain `<<: *POLICY_BASE` copy, where
+    `policy.max_total_sequence_length=N` silently left the teacher (and its
+    generation and batching limits, which are derived from it) at the value
+    written in the file.
+    """
+    override_value = 12345
+
+    config = load_config_with_inheritance(config_file)
+    assert config.policy.max_total_sequence_length != override_value, (
+        "pick an override value that differs from the config default"
+    )
+
+    config = parse_hydra_overrides(
+        config, [f"policy.max_total_sequence_length={override_value}"]
+    )
+    resolved = OmegaConf.to_container(config, resolve=True)
+
+    assert resolved["teacher"]["max_total_sequence_length"] == override_value, (
+        f"{config_file}: overriding policy.max_total_sequence_length did not "
+        f"propagate to the teacher "
+        f"(teacher is {resolved['teacher']['max_total_sequence_length']})"
+    )
+    # Limits derived from the teacher's own sequence length follow it.
+    assert resolved["teacher"]["generation"]["max_new_tokens"] == override_value


### PR DESCRIPTION
# What does this PR do ?

Makes `policy.max_total_sequence_length=N` on the command line actually reach the distillation teacher, instead of silently moving only the student.

# Issues

Closes #1483

# Usage

The distillation configs hand the teacher the policy's settings with a YAML merge key:

```yaml
teacher:
    <<: *POLICY_BASE
    model_name: "Qwen/Qwen3-4B"
```

Merge keys are resolved by the YAML parser when the file is loaded — which happens in `load_config()`, before `parse_hydra_overrides()` runs. So the teacher captures the values *as written in the file* and never sees a CLI override. Reproduced on `main`:

```python
cfg = load_config("examples/configs/distillation_math.yaml")
cfg = parse_hydra_overrides(cfg, ["policy.max_total_sequence_length=9999"])
c = OmegaConf.to_container(cfg, resolve=True)

c["policy"]["max_total_sequence_length"]   # 9999
c["teacher"]["max_total_sequence_length"]  # 8192  <-- still the file value
```

The fix tracks the student length from the teacher with an interpolation, which resolves *after* overrides are applied:

```yaml
teacher:
    <<: *POLICY_BASE
    model_name: "Qwen/Qwen3-4B"
    max_total_sequence_length: ${policy.max_total_sequence_length}
```

One line covers more than the one field: the teacher's dynamic batching, sequence packing, generation `max_new_tokens` and vLLM `max_model_len` are all relative references (`${..max_total_sequence_length}`) into the teacher's own block, so they follow automatically.

Applied to both configs that use this pattern — `distillation_math.yaml` and `distillation_math_megatron.yaml`.

## Effect on existing configs

I resolved every distillation config (both bases, all 13 inheriting recipes, and the two `examples/modelopt` parents) before and after the change and diffed the fully-resolved trees. **16 of 17 are byte-identical.**

The one that changes is worth a look, because it is the bug rather than a regression:

`examples/configs/recipes/llm/distillation-qwen3-1.7b-1n8g-megatron-qa-nvfp4.yaml` sets 4096 in three places — `policy.max_total_sequence_length`, `policy.generation.vllm_cfg.max_model_len`, and `data.max_input_seq_length` — but never sets it on the teacher. So the teacher was inheriting 8192 from the base config while the rest of the recipe ran at 4096:

```
teacher.max_total_sequence_length:            8192 -> 4096
teacher.generation.max_new_tokens:            8192 -> 4096
teacher.generation.vllm_cfg.max_model_len:    8192 -> 4096
teacher.dynamic_batching.{train,logprob}_mb_tokens:  8192 -> 4096
teacher.sequence_packing.{train,logprob}_mb_tokens:  8192 -> 4096
```

That looks like exactly the silent student/teacher mismatch #1483 is about, and it now matches the recipe's evident intent. Flagging it explicitly since this recipe has no `.vN` suffix — if you would rather this PR be strictly behaviour-preserving, say the word and I will pin `teacher.max_total_sequence_length: 8192` in that recipe, though I think the value it picks up now is the intended one.

Note that `recipes/llm/distillation-qwen3-32b-to-4b-base-2n8g-fsdp2tp2-long.v1.yaml` already works around this by writing `max_total_sequence_length: 20480` under both `policy` and `teacher`. It keeps resolving to the same values, and the duplicate line is now redundant rather than load-bearing.

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? — `test_teacher_sequence_length_follows_policy_override` in `tests/unit/test_config_validation.py`, parametrized over both configs. Verified it fails on the unfixed configs (`... did not propagate to the teacher (teacher is 8192)`) and passes with the fix.
- [x] Did you run the unit tests and functional tests locally? — see below
- [x] Did you add or update any necessary documentation? — the reason for the interpolation is commented inline in both configs, so the next person does not "simplify" it back into the merge key

# Additional Information

* Local verification (macOS, CPU-only):
  * `pytest tests/unit/test_config_validation.py tests/unit/test_config_v2.py tests/unit/tools/test_config_cli.py` → new tests pass; the 10 failures in `test_all_config_no_tp_size_accuracy_issues` are all on unrelated `grpo-*` / `mopd-*` recipes and reproduce identically on a clean `main`
  * `./tools/config_cli.py minimize-check examples/configs/recipes/{llm,vlm}/*.yaml` → clean
  * `ruff check` / `ruff format --check` → clean
  * `pyrefly check` → no new errors versus `main`
