### PR TITLE
fix(megatron): free reference model GPU memory before policy buffer reloaded

### DIFF
--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import copy
+import gc
 import hashlib
 import json
 import os
@@ -2130,6 +2131,15 @@ def setup_reference_model_state(
             print("Reference model not loaded")
     finally:
         clear_global_router_replay_instances()
+
+    # Release the GPU copy of the reference model before returning. The caller
+    # immediately reloads the policy's DDP buffers onto the GPU, and the
+    # DDP-wrapped reference model (own param+grad buffers, ~2x the model
+    # bytes) holds reference cycles that refcounting alone does not collect
+    # at function exit.
+    del reference_model
+    gc.collect()
+    torch.cuda.empty_cache()
 
     return reference_state_dict
 


### PR DESCRIPTION
# What does this PR do ?

**Frees the reference model's GPU memory in `setup_reference_model_state` (Megatron path) right after the reference state dict has been captured to CPU, instead of leaving it resident until much later — at large model scale this blocks worker initialization with GPU OOM.**

PR title suggestion (conventional commit): `fix(megatron): free reference model GPU memory before policy buffer reload`

## Problem

`setup_reference_model_state` builds the reference model via `get_model(...)` with the policy's DDP config, so it gets its own param+grad buffers (roughly 2x the model bytes on the GPU). After the frozen reference state dict is copied to CPU, the function returns without releasing the live reference model object. The DDP wrapper holds reference cycles, so plain refcounting does not collect it at function exit — the GPU allocations survive into the caller, which immediately reloads the policy's DDP buffers onto a GPU still occupied by the dead reference model.

At small scale this is wasted-but-survivable memory. At large scale it is fatal: with a ~700B MoE (GLM-5.1) trained with GRPO on 384 training GPUs + 32 vLLM GPUs, non-colocated, on GH200 nodes (4 GPUs/node, ~450 GB usable host RAM), the leaked reference model left ~75 GiB resident per GPU and the subsequent 12.94 GiB expert grad buffer reload OOM'd during worker init.

## Fix

After the reference state dict is captured, explicitly drop the reference model and return its memory to the allocator:

```python
del reference_model
gc.collect()
torch.cuda.empty_cache()
```

The `gc.collect()` is required because of the DDP wrapper's reference cycles; `empty_cache()` returns the freed blocks to CUDA so the policy buffer reload (and later vLLM/NCCL allocations) can use them.

# Issues

N/A (no tracking issue filed; happy to open one if preferred).

# Usage

No user-facing API change. Behavior change only: GPU memory held by the reference model is released before `setup_reference_model_state` returns.

# Changes

- `nemo_rl/models/megatron/setup.py` — add `import gc`; in `setup_reference_model_state`, `del reference_model; gc.collect(); torch.cuda.empty_cache()` after the reference state dict is captured, before returning.

# Testing

- Production-scale evidence: with this fix, full 384-worker initialization of the ~700B MoE (GLM-5.1) GRPO setup described above completed successfully where it previously OOM'd during the policy DDP buffer reload (14/192 Megatron workers hit CUDA OOM without the fix).
- `python3 -m py_compile nemo_rl/models/megatron/setup.py` passes.
- No new unit test: the failure mode only manifests when reference model + policy buffers exceed device memory, which is not reproducible in the unit-test environment. The change is a pure release of an object that is provably dead (only the CPU state dict is returned).

# Backward compatibility

- No signature or config changes; no caller changes.
- The reference model object was already unreachable after this function returned — this only makes its memory actually reusable at the point where it is needed.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? — No new test is *necessary*: the failure mode (reference model + policy buffers exceeding device memory) only manifests at multi-node scale and is not reproducible in the unit-test environment; the change releases an object that is provably unreachable (only the CPU state dict escapes the function). Production-scale validation in the Testing section.
- [ ] Did you run the unit tests and functional tests locally? ← **TODO before opening the PR**: run `uv run --group test pytest tests/unit` inside the container on this branch, then tick this box (existing tests exercise `setup_reference_model_state` indirectly; expect no behavior change).
- [x] Did you add or update any necessary documentation? — Not applicable: no user-facing API or config change.

# Additional Information

- Commit is signed off (`Signed-off-by: Philip Mueller <claude@philipmueller.ch>`).