### PR TITLE
feat(spec-decode): multi-pass TTT training for EAGLE-3 drafts (Megatron)

### DIFF
--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -328,6 +328,13 @@ policy:
     loss_weight: 0.1
     num_layers: null
     aux_layer_indices: null
+    ttt_steps: 1 # >1 = multi-pass TTT draft training (requires CP=1, no sequence parallel, no sequence packing)
+    ttt_pass_weights: null # per-pass loss weights alpha_d (len == ttt_steps); null = uniform 1.0
+    loss_seq_chunk_size: 4096 # sequence-dim tile for the multi-pass draft loss internals (memory vs a few extra TP collectives; never affects results)
+    # Draft-only optimizer param group; all null = share the policy optimizer settings.
+    lr: null
+    min_lr: null # null = follow the draft lr (constant draft LR while the policy decays)
+    weight_decay: null
 
   # See docs/design-docs/sequence-packing-and-dynamic-batching.md 
   # for more details on dynamic batching and sequence packing.

--- a/examples/configs/ppo_math_1B_megatron_single_controller.yaml
+++ b/examples/configs/ppo_math_1B_megatron_single_controller.yaml
@@ -167,6 +167,13 @@ policy:
     loss_weight: 0.1
     num_layers: null
     aux_layer_indices: null
+    ttt_steps: 1 # >1 = multi-pass TTT draft training (requires CP=1, no sequence parallel, no sequence packing)
+    ttt_pass_weights: null # per-pass loss weights alpha_d (len == ttt_steps); null = uniform 1.0
+    loss_seq_chunk_size: 4096 # sequence-dim tile for the multi-pass draft loss internals (memory vs a few extra TP collectives; never affects results)
+    # Draft-only optimizer param group; all null = share the policy optimizer settings.
+    lr: null
+    min_lr: null # null = follow the draft lr (constant draft LR while the policy decays)
+    weight_decay: null
 
   generation:
     # HTTP ports use the shared [3000, 4999) virtual-cluster defaults.

--- a/nemo_rl/algorithms/loss/__init__.py
+++ b/nemo_rl/algorithms/loss/__init__.py
@@ -23,6 +23,7 @@ from nemo_rl.algorithms.loss.loss_functions import (
     DPOLossDataDict,
     DPOLossFn,
     DraftCrossEntropyLossFn,
+    DraftTTTCrossEntropyLossFn,
     MseValueLossConfig,
     MseValueLossFn,
     NLLLossFn,

--- a/nemo_rl/algorithms/loss/interfaces.py
+++ b/nemo_rl/algorithms/loss/interfaces.py
@@ -55,6 +55,7 @@ class LossInputType(enum.Enum):
     DISTILLATION = "distillation"
     DISTILLATION_CROSS_TOKENIZER = "distillation_cross_tokenizer"
     DRAFT = "draft"
+    DRAFT_TTT = "draft_ttt"
 
 
 class LossFunction(Protocol):

--- a/nemo_rl/algorithms/loss/loss_functions.py
+++ b/nemo_rl/algorithms/loss/loss_functions.py
@@ -23,6 +23,7 @@ from nemo_rl.algorithms.loss.interfaces import (
     LossType,
     MetricNormalizer,
 )
+from nemo_rl.algorithms.loss.utils import draft_pass_token_mask
 from nemo_rl.algorithms.utils import calculate_kl, masked_mean
 from nemo_rl.algorithms.x_token.loss_utils import (
     LocalizedAlignment,
@@ -39,6 +40,7 @@ from nemo_rl.algorithms.x_token.loss_utils import (
 )
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.distributed.model_utils import (
+    ChunkedDistributedCrossEntropy,
     DistributedCrossEntropy,
     cp_shift_next,
     group_all_reduce_sum,
@@ -59,6 +61,14 @@ class DraftCrossEntropyLossConfig(TypedDict):
 class DraftCrossEntropyLossDataDict(TypedDict):
     teacher_logits: Tensor
     student_logits: Tensor
+    token_mask: Tensor
+    sample_mask: Tensor
+    student_vocab_indices: NotRequired[Tensor]
+
+
+class DraftTTTCrossEntropyLossDataDict(TypedDict):
+    teacher_logits: Tensor
+    student_logits_by_pass: list[Tensor]
     token_mask: Tensor
     sample_mask: Tensor
     student_vocab_indices: NotRequired[Tensor]
@@ -107,6 +117,154 @@ class DraftCrossEntropyLossFn(LossFunction):
             mask,
             global_normalization_factor=global_valid_toks,
         )
+
+
+class DraftTTTCrossEntropyLossFn(LossFunction):
+    """Soft-target cross-entropy over several TTT draft passes.
+
+    The multi-pass sibling of :class:`DraftCrossEntropyLossFn`, selected when
+    ``policy.draft.ttt_steps > 1``. The single-pass class stays the loss for
+    ``ttt_steps == 1`` (including the packed layout), which is why the two live
+    side by side instead of behind a flag.
+
+    Pass ``d`` (1-indexed) student logits at position ``i`` predict token
+    ``x_{i+d+1}``; the matching soft target is the (detached, unshifted)
+    policy logits at position ``i + d``, so both sides are pure slices of
+    their full-length tensors. The per-pass mask is
+    ``token_mask[i + d + 1] * sample_mask`` (see ``draft_pass_token_mask``).
+
+    The scalar loss is ``sum_d alpha_d * masked_sum_d / denominator`` where
+    the denominator is ``sum_d alpha_d * global_draft_pass_counts[d-1]`` (the
+    DP-all-reduced per-pass counts from ``compute_draft_pass_valid_counts``)
+    when provided, else the policy's ``global_valid_toks`` (single-pass
+    fallback for callers that do not thread the draft counts).
+
+    Every returned metric is normalized by a GLOBAL denominator so the
+    driver's sum-over-microbatches aggregation reconstructs a global mean
+    (mirroring how the policy losses report): ``draft_loss_pass_d`` sums to
+    the global per-token soft-CE of pass d.
+    """
+
+    loss_type = LossType.TOKEN_LEVEL
+    input_type = LossInputType.DRAFT_TTT
+
+    def __init__(
+        self,
+        vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
+        pass_weights: Optional[list[float]] = None,
+        seq_chunk_size: int = 4096,
+    ):
+        self.vocab_parallel_group = vocab_parallel_group
+        self.pass_weights = pass_weights
+        # Sequence-dim tile for the loss internals: the fp32 soft-CE buffers
+        # here and the d2t full-vocab TP gather in prepare_loss_input. Trades
+        # a few extra TP collectives for peak memory; never affects results.
+        # Set via policy.draft.loss_seq_chunk_size.
+        self.seq_chunk_size = seq_chunk_size
+
+    def _per_token_soft_ce(
+        self, student_logits: Tensor, teacher_logits: Tensor
+    ) -> Tensor:
+        # Soft cross entropy matches the forward-KL student gradient. The
+        # sequence-chunked variant keeps the fp32 softmax buffers chunk-sized
+        # and saves only the bf16 logits references for backward — essential
+        # when several TTT passes stack up before the shared backward.
+        return ChunkedDistributedCrossEntropy.apply(
+            student_logits,
+            teacher_logits,
+            self.seq_chunk_size,
+            self.vocab_parallel_group,
+            False,
+        )
+
+    def __call__(
+        self,
+        teacher_logits: Tensor,
+        student_logits_by_pass: list[Tensor],
+        data: BatchedDataDict[DraftTTTCrossEntropyLossDataDict],
+        global_valid_seqs: torch.Tensor,
+        global_valid_toks: torch.Tensor,
+        global_draft_pass_counts: Optional[torch.Tensor] = None,
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
+        """Reduce the masked per-pass draft losses to a scalar and metrics."""
+        num_passes = len(student_logits_by_pass)
+        if self.pass_weights is not None and len(self.pass_weights) != num_passes:
+            raise ValueError(
+                f"pass_weights has {len(self.pass_weights)} entries but the "
+                f"draft produced {num_passes} passes."
+            )
+        if (
+            global_draft_pass_counts is not None
+            and global_draft_pass_counts.shape[0] != num_passes
+        ):
+            raise ValueError(
+                f"global_draft_pass_counts has {global_draft_pass_counts.shape[0]} "
+                f"entries but the draft produced {num_passes} passes."
+            )
+
+        token_mask = data["token_mask"]
+        sample_mask = data["sample_mask"]
+        seq_len = teacher_logits.shape[1]
+
+        if global_draft_pass_counts is not None:
+            pass_counts = global_draft_pass_counts.float()
+            weights = (
+                torch.ones_like(pass_counts)
+                if self.pass_weights is None
+                else pass_counts.new_tensor(self.pass_weights)
+            )
+            denominator = (weights * pass_counts).sum()
+        else:
+            pass_counts = None
+            denominator = global_valid_toks
+
+        metrics: dict[str, Any] = {}
+        total = teacher_logits.new_zeros((), dtype=torch.float32)
+        for pass_index, student_logits in enumerate(student_logits_by_pass):
+            # Passes count from 1: the draft consumes emb(x_{i+1}) alongside
+            # h_i, so its first prediction at slot i is x_{i+2} — deliberately
+            # one step deeper than DraftCrossEntropyLossFn, which pairs slot i
+            # with x_{i+1}. Each loss is consistent with its own slices.
+            ttt_pass = pass_index + 1
+            weight = (
+                1.0
+                if self.pass_weights is None
+                else float(self.pass_weights[pass_index])
+            )
+            valid_len = seq_len - ttt_pass - 1
+            if valid_len <= 0:
+                metrics[f"draft_loss_pass_{ttt_pass}"] = 0.0
+                continue
+
+            # Views into the unshifted tensors — the chunked CE makes its own
+            # per-chunk contiguous fp32 copies, so no full-pass copy here.
+            student_slice = student_logits[:, :valid_len]
+            teacher_slice = teacher_logits[:, ttt_pass : ttt_pass + valid_len]
+            per_token_loss = self._per_token_soft_ce(student_slice, teacher_slice)
+
+            pass_mask = draft_pass_token_mask(
+                token_mask, ttt_pass
+            ) * sample_mask.unsqueeze(-1)
+            pass_sum = (per_token_loss.float() * pass_mask).sum()
+            total = total + weight * pass_sum
+
+            with torch.no_grad():
+                # GLOBAL per-pass denominator: the driver aggregates mb-metric
+                # lists with a plain sum, so a per-microbatch mean would be
+                # inflated by the number of microbatches (~512x at gbs 512).
+                metric_denominator = (
+                    pass_counts[pass_index]
+                    if pass_counts is not None
+                    else global_valid_toks.float()
+                )
+                metrics[f"draft_loss_pass_{ttt_pass}"] = float(
+                    (
+                        pass_sum.detach() / torch.clamp(metric_denominator, min=1.0)
+                    ).item()
+                )
+
+        loss = total / torch.clamp(denominator.float(), min=1.0)
+        return loss, metrics
 
 
 class ClippedPGLossConfig(BaseModel, extra="allow"):

--- a/nemo_rl/algorithms/loss/utils.py
+++ b/nemo_rl/algorithms/loss/utils.py
@@ -45,6 +45,7 @@ def map_teacher_logits_to_draft_vocab(
     d2t: Optional[torch.Tensor],
     vocab_parallel_rank: Optional[int] = None,
     vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
+    seq_chunk_size: Optional[int] = None,
 ) -> torch.Tensor:
     """Restrict full-vocab teacher logits to the draft vocabulary via ``d2t``.
 
@@ -53,6 +54,10 @@ def map_teacher_logits_to_draft_vocab(
     are gathered to the full vocab and re-sliced to this rank's shard of the
     draft vocabulary (the draft output layer is sharded the same way). No-op
     when ``d2t`` is None (full-vocab drafts).
+
+    ``seq_chunk_size`` gathers and subsets in sequence chunks instead of all at
+    once: the full ``[B, S, V_full]`` gather peaks at several GiB at long
+    sequence lengths while only the ``[B, S, draft_vocab/tp]`` subset survives.
     """
     if d2t is None:
         return teacher_logits
@@ -64,15 +69,37 @@ def map_teacher_logits_to_draft_vocab(
             gather_from_tensor_model_parallel_region,
         )
 
-        teacher_logits = gather_from_tensor_model_parallel_region(
-            teacher_logits, vocab_parallel_group
-        )
         tp_size = torch.distributed.get_world_size(vocab_parallel_group)
         local_draft_size = len(d2t) // tp_size
         assert vocab_parallel_rank is not None
         start_index = vocab_parallel_rank * local_draft_size
         end_index = (vocab_parallel_rank + 1) * local_draft_size
         reverse_mapping = reverse_mapping[start_index:end_index]
+
+        if seq_chunk_size is None:
+            teacher_logits = gather_from_tensor_model_parallel_region(
+                teacher_logits, vocab_parallel_group
+            )
+        else:
+            batch_size, seq_size = teacher_logits.shape[:2]
+            subset_teacher = torch.empty(
+                batch_size,
+                seq_size,
+                reverse_mapping.shape[0],
+                dtype=teacher_logits.dtype,
+                device=teacher_logits.device,
+            )
+            for chunk_start in range(0, seq_size, seq_chunk_size):
+                chunk_end = min(seq_size, chunk_start + seq_chunk_size)
+                gathered_chunk = gather_from_tensor_model_parallel_region(
+                    teacher_logits[:, chunk_start:chunk_end].contiguous(),
+                    vocab_parallel_group,
+                )
+                subset_teacher[:, chunk_start:chunk_end] = gathered_chunk[
+                    :, :, reverse_mapping
+                ]
+                del gathered_chunk
+            return subset_teacher
     return teacher_logits[:, :, reverse_mapping]
 
 
@@ -337,10 +364,77 @@ def prepare_loss_input(
             "token_mask": token_mask,
         }
 
+    elif loss_fn.input_type == LossInputType.DRAFT_TTT:
+        # Multi-pass convention: pass-d student logits z^d_i predict x_{i+d+1},
+        # so the matching teacher is the policy's logits at position i+d. The
+        # teacher stays UNSHIFTED here — DraftTTTCrossEntropyLossFn slices it
+        # per pass (pure views) and builds the shifted masks with
+        # draft_pass_token_mask. Slicing replaces the CP-aware roll, so this
+        # path requires CP == 1.
+        if (
+            context_parallel_group is not None
+            and torch.distributed.is_initialized()
+            and torch.distributed.get_world_size(context_parallel_group) > 1
+        ):
+            raise NotImplementedError(
+                "Multi-pass draft distillation requires context_parallel_size == 1."
+            )
+        teacher_logits = map_teacher_logits_to_draft_vocab(
+            logits.detach(),
+            d2t,
+            vocab_parallel_rank=vocab_parallel_rank,
+            vocab_parallel_group=vocab_parallel_group,
+            seq_chunk_size=loss_fn.seq_chunk_size,
+        )
+        loss_input = {
+            "teacher_logits": teacher_logits,
+            "student_logits_by_pass": list(data["student_logits_by_pass"]),
+        }
+
     else:
         raise ValueError(f"Unknown loss function input type: {loss_fn.input_type}")
 
     return loss_input, data
+
+
+def draft_pass_token_mask(token_mask: torch.Tensor, ttt_pass: int) -> torch.Tensor:
+    """Per-pass draft loss mask (before the sample_mask factor).
+
+    Pass ``d`` position ``i`` predicts token ``x_{i+d+1}``, so its validity is
+    ``token_mask[i + d + 1]``: a left shift by ``d + 1`` that also drops the
+    out-of-bounds tail. Returned shape is ``[B, S - d - 1]``, aligned with the
+    ``student[:, :S-d-1]`` / ``teacher[:, d:S-1]`` slices used by
+    ``DraftCrossEntropyLossFn``.
+    """
+    return token_mask[:, ttt_pass + 1 :]
+
+
+def compute_draft_pass_valid_counts(
+    token_mask: torch.Tensor,
+    sample_mask: torch.Tensor,
+    *,
+    ttt_steps: int,
+) -> torch.Tensor:
+    """Local per-pass valid-token counts for the draft TTT loss.
+
+    Returns a fp32 tensor of shape ``[ttt_steps]`` where entry ``d-1`` is this
+    rank's ``#valid pass-d targets``. The caller must all-reduce it over the
+    data-parallel group (and only DP: every CP/TP rank computes the loss over
+    the full sequence/vocab, so reducing over those groups would double-count).
+
+    The loss consumes the vector twice: the gradient denominator is
+    ``sum_d alpha_d * counts[d-1]``, and the per-pass diagnostic metrics divide
+    by ``counts[d-1]`` so that the driver's sum-over-microbatches aggregation
+    (grpo.py logs mb-metric lists with ``np.sum``) reconstructs the global
+    per-token mean instead of summing per-microbatch means.
+    """
+    counts = token_mask.new_zeros((ttt_steps,), dtype=torch.float32)
+    for ttt_pass in range(1, ttt_steps + 1):
+        pass_mask = draft_pass_token_mask(token_mask, ttt_pass) * sample_mask.unsqueeze(
+            -1
+        )
+        counts[ttt_pass - 1] = pass_mask.sum().float()
+    return counts
 
 
 def _pack_input_ids(

--- a/nemo_rl/algorithms/loss/wrapper.py
+++ b/nemo_rl/algorithms/loss/wrapper.py
@@ -19,7 +19,10 @@ import torch
 import torch.distributed
 
 from nemo_rl.algorithms.loss.interfaces import LossFunction
-from nemo_rl.algorithms.loss.loss_functions import DraftCrossEntropyLossFn
+from nemo_rl.algorithms.loss.loss_functions import (
+    DraftCrossEntropyLossFn,
+    DraftTTTCrossEntropyLossFn,
+)
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 
 Tensor = TypeVar("Tensor", bound=torch.Tensor)
@@ -243,6 +246,12 @@ class DraftLossWrapper:
       vocabulary, and the token mask is packed with the same per-sequence
       shift; ``student_logits`` must be passed explicitly (it is kept out of
       the data dict so the packing loss wrappers never slice it).
+
+    ``ttt_steps > 1`` selects the multi-pass loss
+    (:class:`DraftTTTCrossEntropyLossFn`), which returns per-pass metrics
+    alongside the loss and needs ``global_draft_pass_counts``.
+    ``draft_loss_kwargs`` are the selected LossFn's remaining ctor kwargs —
+    ``pass_weights`` / ``seq_chunk_size`` for the multi-pass loss.
     """
 
     def __init__(
@@ -251,6 +260,8 @@ class DraftLossWrapper:
         prepare_fn: Optional[Callable[Any, Any]],
         data_dict: BatchedDataDict[Any],
         loss_weight: float = 1.0,
+        draft_loss_kwargs: Optional[dict[str, Any]] = None,
+        global_draft_pass_counts: Optional[torch.Tensor] = None,
         vocab_parallel_rank: Optional[int] = None,
         vocab_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
         context_parallel_group: Optional[torch.distributed.ProcessGroup] = None,
@@ -258,11 +269,13 @@ class DraftLossWrapper:
         cu_seqlens_q_padded: Optional[torch.Tensor] = None,
         d2t: Optional[torch.Tensor] = None,
         student_logits: Optional[torch.Tensor] = None,
+        ttt_steps: int = 1,
     ):
         self.loss_fn = loss_fn
         self.prepare_fn = prepare_fn
         self.data_dict = data_dict
         self.loss_weight = loss_weight
+        self.global_draft_pass_counts = global_draft_pass_counts
         self.vocab_parallel_rank = vocab_parallel_rank
         self.vocab_parallel_group = vocab_parallel_group
         self.context_parallel_group = context_parallel_group
@@ -276,9 +289,24 @@ class DraftLossWrapper:
             raise ValueError("student_logits must be passed explicitly in packed mode.")
         if cu_seqlens_q is None and prepare_fn is None:
             raise ValueError("prepare_fn is required in unpacked mode.")
-        self.draft_loss_fn = DraftCrossEntropyLossFn(
-            vocab_parallel_group=vocab_parallel_group,
-        )
+        self.multi_pass = ttt_steps > 1
+        if cu_seqlens_q is not None and self.multi_pass:
+            raise ValueError(
+                "Multi-pass draft training (policy.draft.ttt_steps > 1) does not "
+                "support sequence packing; the per-pass slicing convention needs "
+                "the unpacked [B, S] layout."
+            )
+        draft_loss_kwargs = draft_loss_kwargs or {}
+        if self.multi_pass:
+            self.draft_loss_fn: Any = DraftTTTCrossEntropyLossFn(
+                vocab_parallel_group=vocab_parallel_group,
+                **draft_loss_kwargs,
+            )
+        else:
+            self.draft_loss_fn = DraftCrossEntropyLossFn(
+                vocab_parallel_group=vocab_parallel_group,
+                **draft_loss_kwargs,
+            )
 
     def _packed_draft_loss(
         self,
@@ -339,6 +367,7 @@ class DraftLossWrapper:
             **kwargs,
         )
 
+        draft_metrics: dict[str, Any] = {}
         if self.cu_seqlens_q is not None:
             draft_loss = self._packed_draft_loss(
                 next_token_logits, data, global_valid_seqs, global_valid_toks
@@ -352,14 +381,24 @@ class DraftLossWrapper:
                 vocab_parallel_group=self.vocab_parallel_group,
                 context_parallel_group=self.context_parallel_group,
             )
-            draft_loss = self.draft_loss_fn(
-                data=data,
-                global_valid_seqs=global_valid_seqs,
-                global_valid_toks=global_valid_toks,
-                **loss_input,
-            )
+            if self.multi_pass:
+                draft_loss, draft_metrics = self.draft_loss_fn(
+                    data=data,
+                    global_valid_seqs=global_valid_seqs,
+                    global_valid_toks=global_valid_toks,
+                    global_draft_pass_counts=self.global_draft_pass_counts,
+                    **loss_input,
+                )
+            else:
+                draft_loss = self.draft_loss_fn(
+                    data=data,
+                    global_valid_seqs=global_valid_seqs,
+                    global_valid_toks=global_valid_toks,
+                    **loss_input,
+                )
         combined_loss = policy_loss + self.loss_weight * draft_loss
         metrics["draft_loss"] = float(draft_loss.detach().item())
+        metrics.update(draft_metrics)
         return combined_loss, metrics
 
 

--- a/nemo_rl/distributed/model_utils.py
+++ b/nemo_rl/distributed/model_utils.py
@@ -267,6 +267,138 @@ class DistributedCrossEntropy(torch.autograd.Function):
         return grad_student, None, None, None
 
 
+class ChunkedDistributedCrossEntropy(torch.autograd.Function):
+    """Soft-target cross entropy across TP-sharded vocab, chunked along sequence.
+
+    Same math as :class:`DistributedCrossEntropy`, but the fp32 softmax /
+    log-softmax buffers only ever exist for one sequence chunk:
+
+    - forward computes the per-token CE chunk-by-chunk and saves only the
+      (typically bf16) logits references — DistributedCrossEntropy instead
+      saves two full-size fp32 probability tensors for backward, which is the
+      dominant memory cost when several draft TTT passes stack up before the
+      shared backward;
+    - backward recomputes the chunk softmaxes and writes the gradient into a
+      single input-dtype buffer (mirrors :class:`ChunkedDistributedLogprob`).
+
+    ``group=None`` runs the same chunked math without collectives (single
+    process / no vocab parallelism).
+    """
+
+    @staticmethod
+    def forward(  # pyrefly: ignore[bad-override]
+        ctx: Any,
+        student_logits: torch.Tensor,
+        target_logits: torch.Tensor,
+        chunk_size: int,
+        group: Optional[torch.distributed.ProcessGroup],
+        inference_only: bool = False,
+    ) -> torch.Tensor:
+        if student_logits.shape != target_logits.shape:
+            raise ValueError(
+                "student_logits and target_logits must have the same shape, "
+                f"got {student_logits.shape} and {target_logits.shape}."
+            )
+
+        seq_size = int(student_logits.shape[1])
+        num_chunks = (seq_size + chunk_size - 1) // chunk_size
+        ce_chunks = []
+
+        for chunk_idx in range(num_chunks):
+            chunk_start = chunk_idx * chunk_size
+            chunk_end = min(seq_size, (chunk_idx + 1) * chunk_size)
+
+            student_fp32 = student_logits[:, chunk_start:chunk_end, :].to(
+                dtype=torch.float32
+            )
+            target_fp32 = target_logits[:, chunk_start:chunk_end, :].to(
+                dtype=torch.float32
+            )
+
+            if group is None:
+                target_probs = torch.softmax(target_fp32, dim=-1)
+                student_log_probs = torch.log_softmax(student_fp32, dim=-1)
+                ce_chunk = (
+                    torch.einsum("...v,...v->...", target_probs, student_log_probs)
+                    .neg_()
+                    .contiguous()
+                )
+            else:
+                target_probs = _compute_distributed_softmax(target_fp32, group=group)
+                student_log_probs = _compute_distributed_log_softmax(
+                    student_fp32, group=group
+                )
+                ce_chunk = torch.einsum(
+                    "...v,...v->...", target_probs, student_log_probs
+                ).neg_()
+                torch.distributed.all_reduce(
+                    ce_chunk,
+                    op=torch.distributed.ReduceOp.SUM,
+                    group=group,
+                )
+
+            ce_chunks.append(ce_chunk)
+            del student_fp32, target_fp32, target_probs, student_log_probs
+
+        cross_entropy = torch.cat(ce_chunks, dim=1)
+
+        if not inference_only:
+            # Only references are saved; no fp32 full-size buffers survive.
+            ctx.save_for_backward(student_logits, target_logits)
+            ctx.chunk_size = chunk_size
+            ctx.group = group
+
+        return cross_entropy
+
+    @staticmethod
+    def backward(
+        ctx: Any,
+        *grad_outputs: torch.Tensor,
+    ) -> tuple[torch.Tensor, None, None, None, None]:
+        grad_output = grad_outputs[0]
+        student_logits, target_logits = ctx.saved_tensors
+        chunk_size = ctx.chunk_size
+        group = ctx.group
+
+        seq_size = int(student_logits.shape[1])
+        num_chunks = (seq_size + chunk_size - 1) // chunk_size
+
+        # Every chunk row is written below, so no zero-init is needed.
+        grad_student = torch.empty_like(student_logits)
+
+        for chunk_idx in range(num_chunks):
+            chunk_start = chunk_idx * chunk_size
+            chunk_end = min(seq_size, (chunk_idx + 1) * chunk_size)
+
+            student_fp32 = student_logits[:, chunk_start:chunk_end, :].to(
+                dtype=torch.float32
+            )
+            target_fp32 = target_logits[:, chunk_start:chunk_end, :].to(
+                dtype=torch.float32
+            )
+
+            if group is None:
+                target_probs = torch.softmax(target_fp32, dim=-1)
+                student_probs = torch.softmax(student_fp32, dim=-1)
+            else:
+                target_probs = _compute_distributed_softmax(target_fp32, group=group)
+                student_probs = _compute_distributed_log_softmax(
+                    student_fp32, group=group
+                ).exp_()
+
+            # d(H(p, q))/d(z_v) = q_v - p_v
+            chunk_grad_fp32 = student_probs.sub_(target_probs)
+            chunk_grad_fp32.mul_(
+                grad_output[:, chunk_start:chunk_end].unsqueeze(dim=-1)
+            )
+            grad_student[:, chunk_start:chunk_end, :].copy_(chunk_grad_fp32)
+
+            del student_fp32, target_fp32, target_probs, student_probs
+            del chunk_grad_fp32
+
+        return grad_student, None, None, None, None
+
+
 class ChunkedDistributedLogprob(torch.autograd.Function):
     """Custom autograd function for computing log probabilities in a distributed setting.
 

--- a/nemo_rl/models/generation/vllm/vllm_backend.py
+++ b/nemo_rl/models/generation/vllm/vllm_backend.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 import gc
 import logging
 import re
@@ -596,8 +597,66 @@ class VllmInternalWorkerExtension:
         because these are dynamic vLLM model classes whose ``load_weights`` /
         ``mtp_start_layer_idx`` members are not visible through ``nn.Module``.
         """
-        draft_owner = getattr(self.model_runner, "drafter", None)
+        # The V1 model runner names the owner `drafter`; the V2 runner
+        # `speculator`. On both, non-last PP ranks carry the attribute as None.
+        draft_owner = getattr(self.model_runner, "drafter", None) or getattr(
+            self.model_runner, "speculator", None
+        )
         return getattr(draft_owner, "model", None) if draft_owner else None
+
+    def _unshare_draft_lm_head(self, draft_model: torch.nn.Module) -> None:
+        """Give the drafter a private lm_head before loading a trained head.
+
+        vLLM's spec-decode proposer aliases the drafter's ``lm_head`` MODULE to
+        the target's when their weights are identical at engine init — and
+        unconditionally for drafters without a ``has_own_lm_head`` flag
+        (``SpecDecodeBaseProposer._maybe_share_lm_head``, vLLM 0.26). For a
+        draft that TRAINS its own head (Eagle), the refit stream would then
+        write the diverged draft head through the alias, silently overwriting
+        the serving target's head (generation no longer matches the trained
+        policy — broken importance ratios / KL). Deep-copy the head into
+        drafter-private storage before such a load; later refits see distinct
+        storage and no-op.
+
+        Only called when the incoming draft weights actually contain an
+        lm_head update: head-less drafts WANT the sharing to persist — their
+        draft logits must track the target's live head. Embedding sharing is
+        likewise left intact.
+        """
+        target_model = getattr(self.model_runner, "model", None)
+        if target_model is not None and hasattr(target_model, "get_language_model"):
+            target_model = target_model.get_language_model()
+        draft_lm_head = getattr(draft_model, "lm_head", None)
+        target_lm_head = getattr(target_model, "lm_head", None)
+        if not isinstance(target_lm_head, torch.nn.Module):
+            return
+        draft_weight = getattr(draft_lm_head, "weight", None)
+        target_weight = getattr(target_lm_head, "weight", None)
+        if not isinstance(draft_weight, torch.Tensor) or not isinstance(
+            target_weight, torch.Tensor
+        ):
+            return
+        if (
+            draft_weight.untyped_storage().data_ptr()
+            != target_weight.untyped_storage().data_ptr()
+        ):
+            return
+        private_lm_head = copy.deepcopy(target_lm_head)
+        # Parameter.__deepcopy__ rebuilds bare Parameters, dropping the attrs
+        # vLLM attaches via set_weight_attrs (weight_loader, output_dim, ...);
+        # without them a later load_weights falls back to
+        # default_weight_loader, which cannot shard under TP. The loaders take
+        # the param explicitly, so rebinding the originals is safe.
+        for private_param, source_param in zip(
+            private_lm_head.parameters(), target_lm_head.parameters()
+        ):
+            private_param.__dict__.update(source_param.__dict__)
+        draft_model.lm_head = private_lm_head
+        print(
+            "[draft] Drafter lm_head was aliased to the target's (vLLM "
+            "share-on-identical-weights); un-shared it into private storage "
+            "before applying draft refit weights."
+        )
 
     def _load_draft_weights(
         self, draft_weights: list[tuple[str, torch.Tensor]]
@@ -607,10 +666,23 @@ class VllmInternalWorkerExtension:
 
         draft_model = self._get_drafter_model()
         if draft_model is None:
-            logger.warning(
-                "[draft] Received draft weights but vLLM drafter is unavailable; skipping draft update."
+            # vLLM places the drafter on the last PP stage only; its absence
+            # on earlier stages is expected (cf. load_mtp_weights_from_disk).
+            if not get_pp_group().is_last_rank:
+                return
+            # The trainer only streams draft.* weights when a draft model is
+            # co-training, so an unreachable drafter here means the weights
+            # would be silently dropped and serving would keep stale draft
+            # weights forever (observed: acceptance rate pinned at exactly 0
+            # while draft_loss fell). Fail loudly instead.
+            raise RuntimeError(
+                "[draft] Received draft weights but no vLLM drafter was found "
+                "on the model runner; the draft refit would be silently "
+                "dropped. Check the speculative_config and the vLLM "
+                "model-runner version compatibility."
             )
-            return
+        if any("lm_head" in name for name, _ in draft_weights):
+            self._unshare_draft_lm_head(draft_model)
         draft_weights = self._trim_vocab_padding(draft_model, draft_weights)
         draft_model.load_weights(weights=draft_weights)
 

--- a/nemo_rl/models/megatron/draft/eagle.py
+++ b/nemo_rl/models/megatron/draft/eagle.py
@@ -12,12 +12,47 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Megatron training implementation of the EAGLE-3 draft model.
+
+This file wraps ModelOpt's ``EagleModule`` and adds two training paths:
+
+- :meth:`EagleModel.forward` runs one causal draft pass when ``ttt_steps == 1``.
+- :meth:`EagleModel.forward_ttt` runs several sequential TTT passes.
+  Each pass feeds its hidden state and shifted token embeddings into the next
+  pass, matching the draft model's self-conditioning during serving.
+
+For a query at anchor ``i`` in TTT pass ``d``, attention can read:
+
+- the pass-1 trunk at positions ``0..i``; and
+- the entry at anchor ``i`` from every pass ``2..d``.
+
+It cannot read a later trunk position or another anchor's branch. This matches
+the serving cache: causal prefill entries followed by one draft-generated entry
+for each speculation depth. :class:`TwoPartTTTAttention` shows the full mask.
+
+The causal trunk uses FlashAttention. The short per-anchor branch uses an
+einsum. Their output and log-sum-exp values are merged to produce the exact
+softmax over both sets of keys; backward uses the same joint values to produce
+the exact gradients.
+
+The implementation uses private FlashAttention functions because the merge
+needs their log-sum-exp values. Their interface is pinned to the compatible
+FlashAttention 2.x versions checked below.
+"""
+
 from __future__ import annotations
 
 from contextlib import contextmanager, nullcontext
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
+import flash_attn
 import torch
+from flash_attn.flash_attn_interface import (
+    _flash_attn_backward,
+    _flash_attn_forward,
+    flash_attn_func,
+)
+from megatron.core import parallel_state
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from megatron.core.models.common.embeddings import RotaryEmbedding
 from megatron.core.packed_seq_params import PackedSeqParams
@@ -30,10 +65,388 @@ from megatron.core.transformer.utils import (
 from torch import Tensor
 
 
+def _check_flash_attn_version() -> None:
+    """Reject flash-attn versions whose private interface may not match.
+
+    ``_flash_attn_forward``/``_flash_attn_backward`` are private FlashAttention
+    functions, so their signatures cannot be inspected reliably; this file uses
+    the interface from version 2.8.1, compatible with FlashAttention 2.7 and
+    later 2.x releases. Checked when the multi-pass attention is built — not at
+    import — so a future flash-attn bump surfaces here as a clear error for TTT
+    users instead of an import failure for every Megatron run (this module is
+    imported on the refit path even with the draft disabled).
+    """
+    major, minor = (int(x) for x in flash_attn.__version__.split(".")[:2])
+    if not (major == 2 and minor >= 7):
+        raise RuntimeError(
+            f"flash-attn {flash_attn.__version__} does not match the private "
+            "interface vendored for flash-attn 2.8.1; update "
+            "nemo_rl/models/megatron/draft/eagle.py."
+        )
+
+
+def _fa_forward_causal(
+    q: Tensor, k: Tensor, v: Tensor, softmax_scale: float
+) -> tuple[Tensor, Tensor]:
+    """Run causal FlashAttention on batch-first tensors.
+
+    Returns the output with shape ``[B, S, Hq, D]`` and fp32 log-sum-exp values
+    with shape ``[B, Hq, S]``.
+    """
+    out, softmax_lse, _, _ = _flash_attn_forward(
+        q,
+        k,
+        v,
+        0.0,  # dropout_p
+        softmax_scale,
+        True,  # causal
+        -1,  # window_size_left
+        -1,  # window_size_right
+        0.0,  # softcap
+        None,  # alibi_slopes
+        False,  # return_softmax
+    )
+    return out, softmax_lse
+
+
+def _fa_backward_causal(
+    *,
+    dout: Tensor,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    out: Tensor,
+    lse: Tensor,
+    dq: Tensor,
+    dk: Tensor,
+    dv: Tensor,
+    softmax_scale: float,
+) -> None:
+    """Run causal FlashAttention backward into existing buffers.
+
+    ``out`` and ``lse`` describe attention over all merged key sets. Passing
+    them to this call produces the exact part of that joint-softmax gradient
+    that belongs to this call's keys.
+    """
+    _flash_attn_backward(
+        dout,
+        q,
+        k,
+        v,
+        out,
+        lse,
+        dq,
+        dk,
+        dv,
+        0.0,  # dropout_p
+        softmax_scale,
+        True,  # causal
+        -1,  # window_size_left
+        -1,  # window_size_right
+        0.0,  # softcap
+        None,  # alibi_slopes
+        False,  # deterministic
+        None,  # rng_state
+    )
+
+
+class TwoPartTTTAttention(torch.autograd.Function):
+    """Combine a causal pass-1 trunk with each anchor's own branch keys.
+
+    In TTT pass ``d``, the query at anchor ``i`` can attend to:
+
+    - pass-1 trunk keys at positions ``0..i``; and
+    - the key at anchor ``i`` from every pass ``2..d``.
+
+    It cannot attend to later trunk positions or branch keys from another
+    anchor. Teacher forcing treats every sequence position as an independent
+    anchor, so all anchors from one pass can be processed together.
+
+    The example below has four anchors and three passes. ``q2@1`` means the
+    query for anchor 1 during pass 2. ``A`` marks trunk attention computed by
+    FlashAttention, ``x`` marks the small same-anchor branch computed by an
+    fp32 einsum, and blank cells are masked. Each group of query rows is one
+    :class:`TwoPartTTTAttention` call; pass 1 has no branch::
+
+                 | pass-1 KV(trunk) |    pass-2 KV    |    pass-3 KV    |
+       anchor j: |  0   1   2   3   |  0   1   2   3  |  0   1   2   3  |
+       ==================================================================
+       q1@0      |  A               |                 |                 |
+       q1@1      |  A   A           |                 |                 |
+       q1@2      |  A   A   A       |                 |                 |
+       q1@3      |  A   A   A   A   |                 |                 |
+       ------------------------------------------------------------------
+       q2@0      |  A               |  x              |                 |
+       q2@1      |  A   A           |      x          |                 |
+       q2@2      |  A   A   A       |          x      |                 |
+       q2@3      |  A   A   A   A   |              x  |                 |
+       ------------------------------------------------------------------
+       q3@0      |  A               |  x              |  x              |
+       q3@1      |  A   A           |      x          |      x          |
+       q3@2      |  A   A   A       |          x      |          x      |
+       q3@3      |  A   A   A   A   |              x  |              x  |
+       ==================================================================
+
+    The RoPE positions follow the serving cache. For ``q_d@i``, the trunk uses
+    positions ``0..i`` and branch keys use ``i+1..i+d-1``. The query and its
+    current-pass key both use ``i+d-1``. Thus the cache contains the causal
+    prefill plus the ``d - 1`` entries generated by this speculation chain.
+
+    For pass ``d`` and anchor ``i``:
+
+    - Input: ``concat(e(x_{i+d}), h^{d-1}_i)``. Here ``h^0`` is the projected
+      target auxiliary state, and later ``h`` values are pre-norm draft states.
+    - RoPE position: ``i + d - 1``.
+    - Training target: ``x_{i+d+1}``.
+    - Saved state: ``(k^d_i, v^d_i)``, which becomes a branch entry for the
+      next pass.
+
+    The trunk and branch are evaluated separately, then merged with their
+    log-sum-exp values. This gives the exact softmax over the union of keys
+    without creating an ``S x S`` score matrix. Backward passes the merged
+    output and log-sum-exp to FlashAttention for the trunk and computes the
+    branch gradient directly.
+
+    Inputs to ``apply`` use the batch-first FlashAttention layout:
+
+    - ``q``: Current-pass queries with shape ``[B, S, Hq, D]``.
+    - ``k1`` and ``v1``: Pass-1 trunk K/V with shape ``[B, S, Hkv, D]``.
+    - ``kb`` and ``vb``: Branch K/V with shape ``[B, S, Hkv, P, D]``. The branch
+      axis stores passes ``2..d`` for the same anchor, so ``P = d - 1``.
+    - ``softmax_scale``: Scale applied to attention scores.
+
+    The returned tensor has shape ``[B, S, Hq, D]``.
+    """
+
+    @staticmethod
+    def forward(  # type: ignore[override]
+        ctx: Any,
+        q: Tensor,
+        k1: Tensor,
+        v1: Tensor,
+        kb: Tensor,
+        vb: Tensor,
+        softmax_scale: float,
+    ) -> Tensor:
+        batch, seqlen, num_q_heads, head_dim = q.shape
+        num_kv_heads = k1.shape[2]
+        group = num_q_heads // num_kv_heads
+
+        out_t, lse_t = _fa_forward_causal(q, k1, v1, softmax_scale)
+
+        # Branch part in fp32: scores/probs over at most P keys per query.
+        q_grouped = q.view(batch, seqlen, num_kv_heads, group, head_dim).float()
+        # [B, S, Hkv, G, P]
+        scores_b = (
+            torch.einsum("bskgd,bskpd->bskgp", q_grouped, kb.float()) * softmax_scale
+        )
+        lse_b = torch.logsumexp(scores_b, dim=-1)  # [B, S, Hkv, G]
+        probs_b = torch.exp(scores_b - lse_b.unsqueeze(-1))
+        out_b = torch.einsum("bskgp,bskpd->bskgd", probs_b, vb.float())
+
+        # Exact LSE merge of the two disjoint key sets.
+        lse_t_grouped = (
+            lse_t.permute(0, 2, 1).view(batch, seqlen, num_kv_heads, group).float()
+        )
+        lse_joint = torch.logaddexp(lse_t_grouped, lse_b)  # [B, S, Hkv, G]
+        w_t = torch.exp(lse_t_grouped - lse_joint).unsqueeze(-1)
+        w_b = torch.exp(lse_b - lse_joint).unsqueeze(-1)
+        out_f32 = (
+            w_t * out_t.view(batch, seqlen, num_kv_heads, group, head_dim).float()
+            + w_b * out_b
+        )
+        out = out_f32.view(batch, seqlen, num_q_heads, head_dim).to(q.dtype)
+
+        # FlashAttention backward expects lse as [B, Hq, S] fp32.
+        lse_joint_hbs = (
+            lse_joint.view(batch, seqlen, num_q_heads).permute(0, 2, 1).contiguous()
+        )
+
+        ctx.save_for_backward(q, k1, v1, kb, vb, out, lse_joint_hbs)
+        ctx.softmax_scale = softmax_scale
+        return out
+
+    @staticmethod
+    def backward(  # type: ignore[override]
+        ctx: Any, dout: Tensor
+    ) -> tuple[Optional[Tensor], ...]:
+        q, k1, v1, kb, vb, out, lse_joint_hbs = ctx.saved_tensors
+        softmax_scale = ctx.softmax_scale
+        batch, seqlen, num_q_heads, head_dim = q.shape
+        num_kv_heads = k1.shape[2]
+        group = num_q_heads // num_kv_heads
+
+        dout = dout.contiguous()
+
+        # Trunk gradient: FA backward with the joint (out, lse) returns the
+        # exact joint-softmax gradient restricted to the trunk key set.
+        dq_t = torch.empty_like(q)
+        dk1 = torch.empty_like(k1)
+        dv1 = torch.empty_like(v1)
+        _fa_backward_causal(
+            dout=dout,
+            q=q,
+            k=k1,
+            v=v1,
+            out=out,
+            lse=lse_joint_hbs,
+            dq=dq_t,
+            dk=dk1,
+            dv=dv1,
+            softmax_scale=softmax_scale,
+        )
+
+        # Branch gradient in closed form (fp32): probs are joint-normalized,
+        # and the D_i = rowsum(dout * out_joint) term carries the cross-part
+        # softmax correction (same identity the FA kernel applies internally).
+        q_grouped = q.view(batch, seqlen, num_kv_heads, group, head_dim).float()
+        scores_b = (
+            torch.einsum("bskgd,bskpd->bskgp", q_grouped, kb.float()) * softmax_scale
+        )
+        lse_joint_grouped = (
+            lse_joint_hbs.permute(0, 2, 1)
+            .reshape(batch, seqlen, num_kv_heads, group)
+            .float()
+        )
+        probs_bj = torch.exp(scores_b - lse_joint_grouped.unsqueeze(-1))
+
+        dout_f32 = dout.float()
+        d_row = (
+            (dout_f32 * out.float())
+            .sum(dim=-1)
+            .view(batch, seqlen, num_kv_heads, group)
+        )
+        dout_grouped = dout_f32.view(batch, seqlen, num_kv_heads, group, head_dim)
+
+        dvb = torch.einsum("bskgp,bskgd->bskpd", probs_bj, dout_grouped)
+        d_probs = torch.einsum("bskgd,bskpd->bskgp", dout_grouped, vb.float())
+        d_scores = probs_bj * (d_probs - d_row.unsqueeze(-1)) * softmax_scale
+        dq_b = torch.einsum("bskgp,bskpd->bskgd", d_scores, kb.float()).view(
+            batch, seqlen, num_q_heads, head_dim
+        )
+        dkb = torch.einsum("bskgp,bskgd->bskpd", d_scores, q_grouped)
+
+        dq = (dq_t.float() + dq_b).to(q.dtype)
+        return dq, dk1, dv1, dkb.to(kb.dtype), dvb.to(vb.dtype), None
+
+
+class TTTDraftCoreAttention(torch.nn.Module):
+    """Drop-in ``core_attention`` for the draft decoder's multi-pass training.
+
+    Replaces the layer's TE core attention (see ``EagleModel``); receives the
+    post-RoPE q/k/v that MCore's ``SelfAttention.forward`` hands to
+    ``core_attention`` in sbhd layout and returns ``[S, B, Hq * D]``.
+
+    Statefulness contract: the TTT driver calls :meth:`begin_pass` before each
+    draft decoder pass and :meth:`reset` when the multi-pass loop finishes (or
+    aborts). Pass 1 runs plain causal FlashAttention and stashes its KV
+    (non-detached — cross-pass reuse must carry gradients back to the pass-1
+    projections); later passes stash their own KV as branch entries and run
+    :class:`TwoPartTTTAttention` against the trunk. Because the stash holds
+    the exact tensors fed to the kernels, a single backward over the combined
+    loss accumulates every pass's contribution automatically.
+    """
+
+    def __init__(self, config: Any):
+        super().__init__()
+        _check_flash_attn_version()
+        attention_dropout = float(getattr(config, "attention_dropout", 0.0) or 0.0)
+        if attention_dropout != 0.0:
+            raise ValueError(
+                "TTTDraftCoreAttention does not support attention dropout "
+                f"(got attention_dropout={attention_dropout})."
+            )
+        if int(getattr(config, "context_parallel_size", 1) or 1) != 1:
+            raise ValueError(
+                "TTTDraftCoreAttention requires context_parallel_size == 1."
+            )
+        # Match MCore's DotProductAttention convention: explicit config
+        # softmax_scale, else 1/sqrt(head_dim).
+        self.softmax_scale: Optional[float] = getattr(config, "softmax_scale", None)
+        self._pass_idx = 0
+        self._kv_by_pass: list[tuple[Tensor, Tensor]] = []
+
+    def begin_pass(self, pass_idx: int) -> None:
+        """Arm the module for TTT pass ``pass_idx`` (1-indexed)."""
+        if pass_idx == 1:
+            self._kv_by_pass = []
+        elif pass_idx != self._pass_idx + 1:
+            raise RuntimeError(
+                f"TTT passes must run in order; got begin_pass({pass_idx}) "
+                f"after pass {self._pass_idx}."
+            )
+        self._pass_idx = pass_idx
+
+    def reset(self) -> None:
+        """Clear saved K/V and release the cross-pass autograd graph."""
+        self._pass_idx = 0
+        self._kv_by_pass = []
+
+    def forward(
+        self,
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        attention_mask: Optional[Tensor],
+        attn_mask_type: Optional[Any] = None,
+        attention_bias: Optional[Tensor] = None,
+        packed_seq_params: Optional[Any] = None,
+    ) -> Tensor:
+        if packed_seq_params is not None:
+            raise NotImplementedError(
+                "TTT draft training does not support sequence packing; "
+                "disable policy.sequence_packing."
+            )
+        if attention_mask is not None:
+            # The layer spec is AttnMaskType.arbitrary, so MCore may hand in a
+            # mask; this module builds its own trunk/branch structure and
+            # silently dropping a padding mask would be wrong.
+            raise ValueError(
+                "TTTDraftCoreAttention builds its own trunk/branch attention_mask "
+                "structure and cannot honour an external attention_mask."
+            )
+        if attention_bias is not None:
+            raise ValueError("TTTDraftCoreAttention does not support attention_bias.")
+        if self._pass_idx < 1:
+            raise RuntimeError(
+                "TTTDraftCoreAttention.forward called without begin_pass(); "
+                "the TTT driver must arm the pass index before each pass."
+            )
+
+        seqlen, batch = query.shape[0], query.shape[1]
+        softmax_scale = self.softmax_scale or query.shape[-1] ** -0.5
+
+        # sbhd -> bshd (FlashAttention layout).
+        q = query.transpose(0, 1).contiguous()
+        k = key.transpose(0, 1).contiguous()
+        v = value.transpose(0, 1).contiguous()
+
+        self._kv_by_pass.append((k, v))
+
+        if self._pass_idx == 1:
+            out = flash_attn_func(q, k, v, softmax_scale=softmax_scale, causal=True)
+        else:
+            k1, v1 = self._kv_by_pass[0]
+            kb = torch.stack([kv[0] for kv in self._kv_by_pass[1:]], dim=3)
+            vb = torch.stack([kv[1] for kv in self._kv_by_pass[1:]], dim=3)
+            out = TwoPartTTTAttention.apply(q, k1, v1, kb, vb, softmax_scale)
+
+        # bshd -> [S, B, Hq * D] (core_attention output contract).
+        return out.transpose(0, 1).reshape(seqlen, batch, -1)
+
+
 class EagleModel(MegatronModule):
-    def __init__(self, config: TransformerConfig):
+    def __init__(
+        self,
+        config: TransformerConfig,
+        *,
+        ttt_steps: int = 1,
+    ):
         super().__init__(config=config)
         self.config = config
+        self.ttt_steps = int(ttt_steps)
+        if self.ttt_steps < 1:
+            raise ValueError(f"ttt_steps must be >= 1, got {self.ttt_steps}.")
 
         rotary_pos_emb = RotaryEmbedding(
             kv_channels=config.kv_channels,
@@ -59,6 +472,32 @@ class EagleModel(MegatronModule):
         self.eagle_module = EagleModule(
             config=config, rotary_pos_emb=rotary_pos_emb, bias=False
         )
+
+        self._ttt_attn_modules: list[TTTDraftCoreAttention] = []
+        self._ttt_prenorm_hidden: Optional[Tensor] = None
+        if self.ttt_steps > 1:
+            if getattr(config, "recompute_granularity", None) is not None:
+                # Activation recomputation would call this stateful attention
+                # again during backward and corrupt its per-pass K/V list.
+                raise ValueError(
+                    "TTT draft training (ttt_steps > 1) is incompatible with "
+                    "activation recomputation on the draft config."
+                )
+            for layer in self.eagle_module.decoder.layers:
+                ttt_attention = TTTDraftCoreAttention(config)
+                layer.self_attention.core_attention = ttt_attention
+                self._ttt_attn_modules.append(ttt_attention)
+            # ModelOpt's hook saves a detached value. TTT instead needs the
+            # pre-final-norm hidden state with gradients for the next pass.
+            self.eagle_module.decoder.layers[-1].register_forward_hook(
+                self._capture_prenorm_hidden_hook
+            )
+
+    def _capture_prenorm_hidden_hook(
+        self, _module: torch.nn.Module, _args: Tuple, output: Tensor | Tuple
+    ) -> None:
+        hidden_states = output[0] if isinstance(output, tuple) else output
+        self._ttt_prenorm_hidden = hidden_states
 
     def sharded_state_dict(
         self,
@@ -163,3 +602,91 @@ class EagleModel(MegatronModule):
         logits, _ = self.eagle_module.eagle_output_layer(hidden_states)
         logits = logits.transpose(0, 1).contiguous()
         return logits
+
+    def _ttt_rotary_pos_emb(self, ttt_pass: int, seq_len: int) -> Optional[Tensor]:
+        """Build RoPE frequencies for one TTT pass.
+
+        Pass ``d`` shifts every position by ``d - 1``. A query at anchor ``i``
+        therefore uses position ``i + d - 1``, matching the extra cache entry
+        created at each speculation depth during serving. Pass 1 returns
+        ``None`` because EagleModule's default table is already correct.
+
+        Args:
+            ttt_pass: One-indexed TTT pass ``d``.
+            seq_len: Length of the input sequence.
+
+        Returns:
+            Shifted RoPE frequencies for this pass, or ``None`` for pass 1.
+        """
+        if ttt_pass == 1:
+            return None
+        rotary = self.eagle_module.rotary_pos_emb(seq_len + ttt_pass - 1)
+        return rotary[ttt_pass - 1 :]
+
+    def forward_ttt(
+        self,
+        hidden_states: Tensor,
+        input_embeds: Tensor,
+    ) -> list[Tensor]:
+        """Run the configured TTT passes in sequence.
+
+        Pass 1 projects the target auxiliary hidden states. Every later pass
+        receives the previous pass's pre-final-norm hidden state without
+        detaching it, so gradients flow through the entire pass chain. Token
+        embeddings shift left by one position before each new pass.
+
+        Args:
+            hidden_states: Target auxiliary hidden states with shape
+                ``[S, B, 3h]``.
+            input_embeds: Pass-1 token embeddings ``e(x_{i+1})`` with shape
+                ``[S, B, h]``. They have already been shifted left once.
+
+        Returns:
+            One ``[B, S, draft_vocab]`` logits tensor per pass. At pass ``d``,
+            position ``i`` predicts token ``x_{i+d+1}``.
+        """
+        if self.ttt_steps < 2:
+            raise RuntimeError(
+                "forward_ttt requires ttt_steps >= 2; use forward() for the "
+                "single-pass draft."
+            )
+        # Needed only by the multi-pass training path.
+        from megatron.core.transformer.multi_token_prediction import roll_tensor
+
+        hidden = self.eagle_module.fc(hidden_states)[0]
+        embeds = input_embeds
+        logits_by_pass: list[Tensor] = []
+        try:
+            for ttt_pass in range(1, self.ttt_steps + 1):
+                for ttt_attention in self._ttt_attn_modules:
+                    ttt_attention.begin_pass(ttt_pass)
+                self._ttt_prenorm_hidden = None
+                decoder_hidden, _ = self.eagle_module(
+                    embeddings=embeds,
+                    hidden_states=hidden,
+                    # The custom attention modules create the trunk/branch mask.
+                    attention_mask=None,
+                    rotary_pos_emb=self._ttt_rotary_pos_emb(ttt_pass, embeds.shape[0]),
+                )
+                logits, _ = self.eagle_module.eagle_output_layer(decoder_hidden)
+                logits_by_pass.append(logits.transpose(0, 1).contiguous())
+
+                if ttt_pass < self.ttt_steps:
+                    if self._ttt_prenorm_hidden is None:
+                        raise RuntimeError(
+                            "TTT pre-norm hidden-state capture hook did not "
+                            "fire; cannot feed the next draft pass."
+                        )
+                    hidden = self._ttt_prenorm_hidden
+                    embeds = roll_tensor(
+                        embeds,
+                        shifts=-1,
+                        dims=0,
+                        cp_group=parallel_state.get_context_parallel_group(),
+                    )[0]
+        finally:
+            # Clear saved K/V and hidden states even if a pass raises an error.
+            for ttt_attention in self._ttt_attn_modules:
+                ttt_attention.reset()
+            self._ttt_prenorm_hidden = None
+        return logits_by_pass

--- a/nemo_rl/models/megatron/draft/utils.py
+++ b/nemo_rl/models/megatron/draft/utils.py
@@ -19,11 +19,17 @@ import re
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Iterator, Mapping
+from typing import Any, Callable, Iterator, Mapping, Optional
 
 import torch
 import torch.distributed as dist
+from megatron.bridge.training.config import (
+    OptimizerConfigOverrideProvider,
+    OptimizerConfigOverrideProviderContext,
+)
 from megatron.core import parallel_state
+from megatron.core.optimizer import ParamKey
+from megatron.core.optimizer_param_scheduler import ParamGroupOverride
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer import MegatronModule, TransformerConfig
 from megatron.core.utils import unwrap_model
@@ -1252,6 +1258,117 @@ def register_draft_grad_norm_group() -> None:
         )
 
 
+@dataclass
+class DraftOptimizerConfigOverrideProvider(OptimizerConfigOverrideProvider):
+    """Give ``draft_model.*`` params their own optimizer param group.
+
+    The draft trains at its own lr / weight decay while the policy keeps the
+    ``megatron_cfg.optimizer`` settings; the schedule shape (warmup, decay
+    style) stays shared. mcore matches checkpointed param groups to runtime
+    groups by ``param_group_identifier_keys`` (which include ``max_lr`` /
+    ``min_lr`` / ``start_wd`` / ``end_wd`` since Megatron-LM#4705), so the
+    override must differ from the policy group in at least one of those
+    fields — indistinguishable groups collapse at load and a resumed run
+    silently swaps hyperparameters. :meth:`build_config_overrides` rejects an
+    indistinguishable override.
+    """
+
+    draft_lr: Optional[float]
+    draft_min_lr: Optional[float]
+    draft_weight_decay: Optional[float]
+
+    def build_config_overrides(
+        self, context: OptimizerConfigOverrideProviderContext
+    ) -> dict[ParamKey, ParamGroupOverride] | None:
+        overrides = super().build_config_overrides(context) or {}
+        draft_override = ParamGroupOverride()
+        if self.draft_lr is not None:
+            draft_override["max_lr"] = float(self.draft_lr)
+            # A draft head generally wants to keep a high LR even when the
+            # policy LR decays, so min_lr follows the draft LR unless set.
+            draft_override["min_lr"] = float(
+                self.draft_min_lr if self.draft_min_lr is not None else self.draft_lr
+            )
+        elif self.draft_min_lr is not None:
+            draft_override["min_lr"] = float(self.draft_min_lr)
+        if self.draft_weight_decay is not None:
+            draft_override["start_wd"] = float(self.draft_weight_decay)
+            draft_override["end_wd"] = float(self.draft_weight_decay)
+
+        base_config = context.optimizer_config
+        effective_max_lr = draft_override.get("max_lr", base_config.lr)
+        effective_min_lr = draft_override.get("min_lr", base_config.min_lr)
+        # Must differ from the policy group in at least one of mcore's
+        # param_group_identifier_keys, or the two collapse at checkpoint load
+        # and swap params. The policy group carries no start_wd/end_wd at all,
+        # so setting them on the draft is itself distinguishing.
+        distinguishes = (
+            "start_wd" in draft_override
+            or "end_wd" in draft_override
+            or (effective_max_lr, effective_min_lr)
+            != (base_config.lr, base_config.min_lr)
+        )
+        if not distinguishes:
+            raise ValueError(
+                "[draft] draft (lr, min_lr, weight_decay) must differ from the "
+                "policy's in at least one field."
+            )
+
+        overrides[ParamKey(name="*draft_model.*")] = draft_override
+        return overrides
+
+
+def build_draft_optimizer_override_provider(
+    draft_config: Mapping[str, Any],
+) -> Optional[DraftOptimizerConfigOverrideProvider]:
+    """Build the draft optimizer override provider from ``policy.draft`` config.
+
+    Returns None when the config requests no draft-specific optimizer settings,
+    so the caller falls back to megatron-bridge's default provider and the
+    optimizer param-group partition is byte-identical to a no-override run.
+    """
+    draft_lr = draft_config.get("lr")
+    draft_min_lr = draft_config.get("min_lr")
+    draft_weight_decay = draft_config.get("weight_decay")
+    if draft_lr is None and draft_min_lr is None and draft_weight_decay is None:
+        return None
+    return DraftOptimizerConfigOverrideProvider(
+        draft_lr=draft_lr,
+        draft_min_lr=draft_min_lr,
+        draft_weight_decay=draft_weight_decay,
+    )
+
+
+def resolve_draft_aux_layer_ids(
+    draft_config: Mapping[str, Any], num_layers: int
+) -> tuple[int, ...]:
+    """Resolve the policy aux-layer ids the draft taps, rank-independently.
+
+    Every PP stage must resolve the same list: the hidden-state capture posts
+    one P2P send/recv per id, so stages disagreeing about it desync the
+    pipeline — and only the last stage owns a draft model to read the resolved
+    value from. Sources, in order: the draft checkpoint's
+    ``eagle_aux_hidden_state_layer_ids`` when ``model_name`` is set (a config
+    read, identical on every rank), else ``policy.draft.aux_layer_indices``,
+    else modelopt's defaults (unless the checkpoint disables aux states).
+    """
+    from transformers import AutoConfig
+
+    from nemo_rl.models.megatron.draft.hidden_capture import (
+        get_eagle3_aux_hidden_state_layers,
+    )
+
+    model_name = draft_config.get("model_name")
+    hf_config = AutoConfig.from_pretrained(model_name).to_dict() if model_name else {}
+    if model_name is not None:
+        ids = hf_config.get("eagle_aux_hidden_state_layer_ids", [])
+    else:
+        ids = draft_config.get("aux_layer_indices") or []
+    if not ids and hf_config.get("use_aux_hidden_state", True):
+        ids = get_eagle3_aux_hidden_state_layers(num_layers)
+    return tuple(int(i) for i in ids)
+
+
 def build_draft_model(
     model_provider,
     draft_config: dict[str, Any],
@@ -1265,9 +1382,6 @@ def build_draft_model(
     from transformers import AutoConfig
 
     from nemo_rl.models.megatron.draft.eagle import EagleModel
-    from nemo_rl.models.megatron.draft.hidden_capture import (
-        get_eagle3_aux_hidden_state_layers,
-    )
 
     model_name = draft_config.get("model_name")
     hf_config = AutoConfig.from_pretrained(model_name).to_dict() if model_name else {}
@@ -1323,11 +1437,14 @@ def build_draft_model(
     )
     config.rotary_percent = model_provider.rotary_percent
     config.rotary_base = hf_config.get("rope_theta", model_provider.rotary_base)
+    # Official z-lab configs carry an explicit "rope_scaling": null — a
+    # present-but-null key must read as "no scaling", not crash on None.get.
+    hf_rope_scaling = (hf_config.get("rope_scaling") or {}) if hf_config else None
     config.rope_scaling = (
-        "rope_scaling" in hf_config if hf_config else model_provider.rope_scaling
+        bool(hf_rope_scaling) if hf_config else model_provider.rope_scaling
     )
     config.rope_scaling_factor = (
-        hf_config.get("rope_scaling", {}).get("factor")
+        hf_rope_scaling.get("factor", model_provider.rope_scaling_factor)
         if hf_config
         else model_provider.rope_scaling_factor
     )
@@ -1337,27 +1454,34 @@ def build_draft_model(
     )
     config.use_last_layernorm = hf_config.get("use_last_layernorm", True)
     config.use_aux_hidden_state = hf_config.get("use_aux_hidden_state", True)
-    if model_name is not None:
-        config.eagle_aux_hidden_state_layer_ids = hf_config.get(
-            "eagle_aux_hidden_state_layer_ids", []
-        )
-    else:
-        config.eagle_aux_hidden_state_layer_ids = (
-            draft_config.get("aux_layer_indices") or []
-        )
-    if (
-        config.use_aux_hidden_state
-        and len(config.eagle_aux_hidden_state_layer_ids) == 0
-    ):
-        config.eagle_aux_hidden_state_layer_ids = get_eagle3_aux_hidden_state_layers(
-            model_provider.num_layers
-        )
+    # Shared with the worker's capture threading so every PP stage resolves
+    # the same list (see resolve_draft_aux_layer_ids).
+    config.eagle_aux_hidden_state_layer_ids = list(
+        resolve_draft_aux_layer_ids(draft_config, model_provider.num_layers)
+    )
 
     config.parallel_draft_step = 1
     config.use_mtp_layernorm = config.parallel_draft_heads_num_layers = None
     config.has_lm_head = True
 
-    draft_model = EagleModel(config=config)
+    raw_ttt_steps = draft_config.get("ttt_steps", 1)
+    ttt_steps = 1 if raw_ttt_steps is None else int(raw_ttt_steps)
+    if ttt_steps > 1:
+        # The TTT attention/loss path slices sequences locally and stashes
+        # per-pass KV; both require every rank to see the full sequence.
+        if int(getattr(model_provider, "context_parallel_size", 1) or 1) != 1:
+            raise ValueError(
+                "policy.draft.ttt_steps > 1 requires context_parallel_size == 1."
+            )
+        if bool(model_provider.sequence_parallel):
+            raise ValueError(
+                "policy.draft.ttt_steps > 1 requires sequence_parallel == false."
+            )
+
+    draft_model = EagleModel(
+        config=config,
+        ttt_steps=ttt_steps,
+    )
     tp_group = getattr(pg_collection, "tp", None)
     if tp_group is not None:
         for module in draft_model.modules():

--- a/nemo_rl/models/megatron/setup.py
+++ b/nemo_rl/models/megatron/setup.py
@@ -242,6 +242,7 @@ from nemo_rl.models.megatron.config import (
 )
 from nemo_rl.models.megatron.draft.utils import (
     build_draft_model,
+    build_draft_optimizer_override_provider,
     find_draft_owner_chunk,
     get_attached_draft_model,
 )
@@ -2019,11 +2020,20 @@ def setup_model_and_optimizer(
     )
 
     if load_optimizer:
+        # Draft co-training may give `draft_model.*` params their own LR/WD
+        # param group (policy.draft.{lr,min_lr,weight_decay}); None keeps the
+        # stock megatron-bridge provider and param-group partition.
+        optimizer_config_override_provider = (
+            build_draft_optimizer_override_provider(policy_cfg["draft"])
+            if draft_enabled
+            else None
+        )
         optimizer, scheduler = setup_optimizer(
             optimizer_config=megatron_cfg.optimizer,
             scheduler_config=megatron_cfg.scheduler,
             model=model,
             use_gloo_process_groups=megatron_cfg.dist.use_gloo_process_groups,
+            optimizer_config_override_provider=optimizer_config_override_provider,
         )
     else:
         optimizer = None

--- a/nemo_rl/models/megatron/train.py
+++ b/nemo_rl/models/megatron/train.py
@@ -225,10 +225,13 @@ def forward_with_post_processing_fn(
     defer_fp32_logits: Optional[bool] = False,
     global_valid_seqs: Optional[torch.Tensor] = None,
     global_valid_toks: Optional[torch.Tensor] = None,
+    global_draft_pass_counts: Optional[torch.Tensor] = None,
     sampling_params: Optional[TrainingSamplingParams] = None,
     straggler_timer: Optional[StragglerDetector] = None,
     draft_model: Optional[MegatronModule] = None,
     enable_hidden_capture: Optional[bool] = False,
+    draft_ttt_steps: int = 1,
+    draft_aux_layer_indices: Optional[Tuple[int, ...]] = None,
     use_fused_linear_logprobs: bool = False,
     use_router_replay: bool = False,
     router_replay_train: bool = False,
@@ -250,6 +253,9 @@ def forward_with_post_processing_fn(
         straggler_timer: Straggler detector for profiling the forward pass
         draft_model: Draft model for online draft model training
         enable_hidden_capture: Whether to enable hidden state capture for draft model training
+        draft_aux_layer_indices: Aux-layer ids to capture, resolved
+            rank-independently by the worker (every PP stage must agree; see
+            resolve_draft_aux_layer_ids)
 
     Returns:
         tuple: (output_tensor, post_processing_fn_wrapped)
@@ -279,8 +285,24 @@ def forward_with_post_processing_fn(
             )
         set_router_replay_forward(model, routed_experts_cp_sharded)
 
-    # Insert hook to capture hidden states and embeddings for draft model training if draft_model is provided
-    capture_context, capture = get_capture_context(model, enable_hidden_capture)
+    # Insert hook to capture hidden states and embeddings for draft model
+    # training. Capture the aux layers the DRAFT was built for (checkpoint
+    # eagle_aux_hidden_state_layer_ids / policy.draft.aux_layer_indices): the
+    # serving-side drafter taps exactly these policy layers, so capturing the
+    # hard-coded defaults instead would silently train on different features
+    # (or break the fc width when the counts differ). The worker resolves the
+    # list rank-independently (resolve_draft_aux_layer_ids) and threads it in:
+    # under PP only the last stage owns a draft model to read it from, and the
+    # capture posts one P2P send/recv per id, so stages disagreeing about the
+    # list would desync the pipeline.
+    aux_layer_indices = draft_aux_layer_indices
+    if aux_layer_indices is None and draft_model is not None:
+        configured_aux_layers = draft_model.config.eagle_aux_hidden_state_layer_ids
+        if configured_aux_layers:
+            aux_layer_indices = tuple(int(i) for i in configured_aux_layers)
+    capture_context, capture = get_capture_context(
+        model, enable_hidden_capture, aux_layer_indices=aux_layer_indices
+    )
     try:
         with capture_context:
             output_tensor = model_forward(
@@ -313,6 +335,15 @@ def forward_with_post_processing_fn(
     if capture is not None:
         from megatron.core.transformer.multi_token_prediction import roll_tensor
 
+        if use_fused_linear_logprobs:
+            # The fused path never materializes the policy's full logits, so
+            # there is no soft-CE teacher for the draft; the DRAFT loss prep
+            # would silently treat fused logprobs as logits.
+            raise RuntimeError(
+                "Draft-model training requires the policy's full logits; "
+                "disable megatron_cfg.use_fused_linear_logprobs."
+            )
+
         captured_states = capture.get_captured_states()
         if packed_seq_params is not None:
             # Packed layout: rolling the captured embeddings would leak the
@@ -338,12 +369,22 @@ def forward_with_post_processing_fn(
                 dims=0,
                 cp_group=get_context_parallel_group(),
             )[0]
-        data_dict["student_logits"] = draft_model(
-            hidden_states=captured_states.hidden_states,
-            input_embeds=shifted_input_embeds,
-            attention_mask=attention_mask,
-            packed_seq_params=packed_seq_params,
-        )
+        if draft_ttt_steps > 1:
+            # Multi-pass TTT self-conditions on its own output, so it drives the
+            # draft decoder itself instead of the single forward below. The
+            # wrapper rejects packing on this path (per-pass slicing needs the
+            # unpacked [B, S] layout).
+            data_dict["student_logits_by_pass"] = draft_model.forward_ttt(
+                hidden_states=captured_states.hidden_states,
+                input_embeds=shifted_input_embeds,
+            )
+        else:
+            data_dict["student_logits"] = draft_model(
+                hidden_states=captured_states.hidden_states,
+                input_embeds=shifted_input_embeds,
+                attention_mask=attention_mask,
+                packed_seq_params=packed_seq_params,
+            )
 
     # Apply temperature scaling only for sampling-oriented post-processors.
     # Loss computation should use unscaled logits.
@@ -363,6 +404,7 @@ def forward_with_post_processing_fn(
             packed_seq_params=packed_seq_params,
             global_valid_seqs=global_valid_seqs,
             global_valid_toks=global_valid_toks,
+            global_draft_pass_counts=global_draft_pass_counts,
         )
     elif isinstance(post_processing_fn, LogprobsPostProcessor):
         assert original_seq_length is not None
@@ -398,10 +440,13 @@ def megatron_forward_backward(
     defer_fp32_logits: Optional[bool] = False,
     global_valid_seqs: Optional[torch.Tensor] = None,
     global_valid_toks: Optional[torch.Tensor] = None,
+    global_draft_pass_counts: Optional[torch.Tensor] = None,
     sampling_params: Optional[TrainingSamplingParams] = None,
     straggler_timer: Optional[StragglerDetector] = None,
     draft_model: Optional[MegatronModule] = None,
     enable_hidden_capture: Optional[bool] = False,
+    draft_ttt_steps: int = 1,
+    draft_aux_layer_indices: Optional[Tuple[int, ...]] = None,
     use_fused_linear_logprobs: bool = False,
     use_router_replay: bool = False,
     router_replay_train: bool = False,
@@ -437,10 +482,13 @@ def megatron_forward_backward(
         defer_fp32_logits=defer_fp32_logits,
         global_valid_seqs=global_valid_seqs,
         global_valid_toks=global_valid_toks,
+        global_draft_pass_counts=global_draft_pass_counts,
         sampling_params=sampling_params,
         straggler_timer=straggler_timer,
         draft_model=draft_model,
         enable_hidden_capture=enable_hidden_capture,
+        draft_ttt_steps=draft_ttt_steps,
+        draft_aux_layer_indices=draft_aux_layer_indices,
         use_fused_linear_logprobs=use_fused_linear_logprobs,
         use_router_replay=use_router_replay,
         router_replay_train=router_replay_train,
@@ -498,8 +546,9 @@ class LossPostProcessor:
         self.cp_normalize = cp_normalize
         self.sampling_params = sampling_params
         self.prepare_fn = prepare_fn
-        if draft_model is not None and draft_model.eagle_module is not None:
-            self.d2t = getattr(draft_model.eagle_module, "d2t", None)
+        eagle_module = getattr(draft_model, "eagle_module", None)
+        if eagle_module is not None:
+            self.d2t = getattr(eagle_module, "d2t", None)
         else:
             self.d2t = None
 
@@ -509,6 +558,7 @@ class LossPostProcessor:
         packed_seq_params: Optional[PackedSeqParams] = None,
         global_valid_seqs: Optional[torch.Tensor] = None,
         global_valid_toks: Optional[torch.Tensor] = None,
+        global_draft_pass_counts: Optional[torch.Tensor] = None,
     ) -> Callable[[torch.Tensor], Tuple[torch.Tensor, Dict[str, Any]]]:
         """Create a loss post-processing function for training.
 
@@ -539,7 +589,17 @@ class LossPostProcessor:
 
         # wrap loss function with loss input preparation
         pack_sequences = self.cfg["sequence_packing"]["enabled"]
+        has_draft_logits = (
+            "student_logits" in data_dict or "student_logits_by_pass" in data_dict
+        )
         if pack_sequences and packed_seq_params is not None:
+            if "student_logits_by_pass" in data_dict:
+                # Only the single-pass head has a packed loss path below; the
+                # multi-pass logits would be dropped and silently never train.
+                raise NotImplementedError(
+                    "Multi-pass TTT draft training does not support sequence "
+                    "packing; disable policy.sequence_packing."
+                )
             fuse_loss = self.cfg.get("sequence_packing", {}).get("fuse_loss", False)
             if fuse_loss:
                 # The fused path prepares loss via prepare_packed_loss_input and
@@ -598,15 +658,51 @@ class LossPostProcessor:
                 vocab_parallel_group=get_tensor_model_parallel_group(),
                 context_parallel_group=get_context_parallel_group(),
             )
-            if "student_logits" in data_dict:
+            if has_draft_logits:
+                draft_cfg = self.cfg["draft"]
+                raw_ttt_steps = draft_cfg.get("ttt_steps", 1)
+                ttt_steps = 1 if raw_ttt_steps is None else int(raw_ttt_steps)
+                if ttt_steps < 1:
+                    raise ValueError(
+                        f"policy.draft.ttt_steps must be >= 1, got {raw_ttt_steps}."
+                    )
+                # ttt_steps reaches the forward independently (the
+                # draft_ttt_steps argument threaded into
+                # megatron_forward_backward); a caller omitting it with a
+                # multi-pass config would otherwise surface as a KeyError far
+                # from the cause.
+                multi_pass = "student_logits_by_pass" in data_dict
+                if multi_pass != (ttt_steps > 1):
+                    raise RuntimeError(
+                        f"draft forward produced "
+                        f"{'multi-pass' if multi_pass else 'single-pass'} logits "
+                        f"but policy.draft.ttt_steps={ttt_steps}; the "
+                        "draft_ttt_steps argument threaded into "
+                        "megatron_forward_backward disagrees with the config."
+                    )
+                # Ctor kwargs for the draft LossFn (uniform shape;
+                # DraftLossWrapper splats them into the selected class). Only
+                # the multi-pass class takes pass weights and the chunk size.
+                draft_loss_kwargs: dict[str, Any] = (
+                    {"pass_weights": draft_cfg.get("ttt_pass_weights")}
+                    if ttt_steps > 1
+                    else {}
+                )
+                if ttt_steps > 1 and draft_cfg.get("loss_seq_chunk_size") is not None:
+                    draft_loss_kwargs["seq_chunk_size"] = int(
+                        draft_cfg["loss_seq_chunk_size"]
+                    )
                 loss_fn_wrapped = DraftLossWrapper(
                     loss_fn=loss_fn_wrapped,
                     prepare_fn=prepare_loss_input_wrapped,
                     data_dict=data_dict,
-                    loss_weight=float(self.cfg["draft"]["loss_weight"]),
+                    loss_weight=float(draft_cfg["loss_weight"]),
+                    draft_loss_kwargs=draft_loss_kwargs,
+                    global_draft_pass_counts=global_draft_pass_counts,
                     vocab_parallel_rank=get_tensor_model_parallel_rank(),
                     vocab_parallel_group=get_tensor_model_parallel_group(),
                     context_parallel_group=get_context_parallel_group(),
+                    ttt_steps=ttt_steps,
                 )
 
         loss_fn_wrapped = partial(

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -502,6 +502,27 @@ class DraftConfig(TypedDict):
     loss_weight: NotRequired[float]
     num_layers: NotRequired[int | None]
     aux_layer_indices: NotRequired[list[int] | None]
+    # Multi-pass TTT draft training. ttt_steps=1 (default) keeps the stock
+    # single-pass path; >1 runs that many sequential draft passes with the
+    # trunk+branch two-part attention (requires CP=1, no sequence parallel,
+    # no sequence packing, no fused linear logprobs). Pass-d RoPE positions
+    # are offset by d-1 (inference-aligned, matching modelopt's reference
+    # TTT) — not configurable.
+    ttt_steps: NotRequired[int]
+    # Per-pass loss weights alpha_d (len == ttt_steps); null = uniform 1.0.
+    ttt_pass_weights: NotRequired[list[float] | None]
+    # Sequence-dim chunk size for the multi-pass draft loss internals (the
+    # fp32 soft-CE buffers and the d2t full-vocab TP gather). Trades a few
+    # extra TP collectives for peak memory; does not affect results. Only
+    # used when ttt_steps > 1 (the single-pass loss keeps the stock unchunked
+    # path). Default in the exemplar YAML: 4096.
+    loss_seq_chunk_size: NotRequired[int | None]
+    # Draft-only optimizer param group (separate from the policy's
+    # megatron_cfg.optimizer settings). All null = share the policy optimizer
+    # settings and keep the stock param-group partition.
+    lr: NotRequired[float | None]
+    min_lr: NotRequired[float | None]
+    weight_decay: NotRequired[float | None]
 
 
 class TokenizerConfig(TypedDict):

--- a/nemo_rl/models/policy/lm_policy.py
+++ b/nemo_rl/models/policy/lm_policy.py
@@ -173,6 +173,52 @@ class Policy(ColocatablePolicyInterface, GenerationInterface):
                 "which the fused path never materializes. Disable one of the "
                 "two."
             )
+        if draft_enabled:
+            raw_ttt_steps = config["draft"].get("ttt_steps", 1)
+            draft_ttt_steps = 1 if raw_ttt_steps is None else int(raw_ttt_steps)
+            if draft_ttt_steps < 1:
+                raise ValueError(
+                    f"policy.draft.ttt_steps must be >= 1, got {raw_ttt_steps}."
+                )
+            draft_pass_weights = config["draft"].get("ttt_pass_weights")
+            if (
+                draft_pass_weights is not None
+                and len(draft_pass_weights) != draft_ttt_steps
+            ):
+                raise ValueError(
+                    "policy.draft.ttt_pass_weights must have ttt_steps="
+                    f"{draft_ttt_steps} entries, got {len(draft_pass_weights)}."
+                )
+            if draft_ttt_steps > 1 and bool(
+                config.get("sequence_packing", {}).get("enabled", False)
+            ):
+                # Multi-pass TTT slices the unshifted teacher per pass to build
+                # its targets, which assumes the [B, S] layout; the packed
+                # draft loss pre-shifts and packs a single mask instead.
+                raise ValueError(
+                    "policy.draft.ttt_steps > 1 does not support sequence packing "
+                    "yet. Set policy.draft.ttt_steps=1 or disable "
+                    "policy.sequence_packing."
+                )
+            # The TTT attention slices sequences locally and stashes per-pass
+            # KV; both need every rank to see the full sequence
+            # (build_draft_model re-checks on the worker).
+            if (
+                draft_ttt_steps > 1
+                and int(config["megatron_cfg"].get("context_parallel_size", 1) or 1)
+                != 1
+            ):
+                raise ValueError(
+                    "policy.draft.ttt_steps > 1 requires "
+                    "policy.megatron_cfg.context_parallel_size=1."
+                )
+            if draft_ttt_steps > 1 and bool(
+                config["megatron_cfg"].get("sequence_parallel")
+            ):
+                raise ValueError(
+                    "policy.draft.ttt_steps > 1 requires "
+                    "policy.megatron_cfg.sequence_parallel=false."
+                )
         if megatron_enable:
             worker_builder_cls_fqn = resolve_policy_worker_cls(
                 "nemo_rl.models.policy.workers.megatron_policy_worker.MegatronPolicyWorker",

--- a/nemo_rl/models/policy/workers/megatron_policy_worker.py
+++ b/nemo_rl/models/policy/workers/megatron_policy_worker.py
@@ -51,6 +51,9 @@ from transformers import PreTrainedTokenizerBase
 
 from nemo_rl.algorithms.logits_sampling_utils import TrainingSamplingParams
 from nemo_rl.algorithms.loss.interfaces import LossFunction
+from nemo_rl.algorithms.loss.utils import (
+    compute_draft_pass_valid_counts,
+)
 from nemo_rl.data.multimodal_utils import (
     attach_media_token_validity_mask,
     chunks_accept_media_token_validity_mask,
@@ -74,6 +77,7 @@ from nemo_rl.models.megatron.data import (
     get_microbatch_iterator,
     process_global_batch,
 )
+from nemo_rl.models.megatron.draft.utils import resolve_draft_aux_layer_ids
 from nemo_rl.models.megatron.pipeline_parallel import (
     broadcast_loss_metrics_from_last_stage,
     broadcast_obj_from_pp_rank,
@@ -857,6 +861,44 @@ class MegatronPolicyWorkerImpl(
                 global_valid_seqs = gb_result["global_valid_seqs"]
                 global_valid_toks = gb_result["global_valid_toks"]
 
+                # Draft (TTT) loss normalization: the draft's valid-token
+                # counts differ from the policy's (per-pass masks shift by
+                # d+1), so it gets its own global per-pass counts, all-reduced
+                # over DP only. The loss derives its gradient denominator
+                # (sum_d alpha_d * count_d) and the per-pass metric
+                # denominators from this vector.
+                draft_enabled = "draft" in self.cfg and self.cfg["draft"]["enabled"]
+                raw_ttt_steps = (
+                    self.cfg["draft"].get("ttt_steps", 1) if draft_enabled else 1
+                )
+                draft_ttt_steps = 1 if raw_ttt_steps is None else int(raw_ttt_steps)
+                # Aux-layer ids are resolved rank-independently: under PP only
+                # the last stage owns the draft model, but every stage's
+                # capture must post the same P2P schedule (one send/recv per
+                # id), so each rank derives the list from the shared config.
+                draft_aux_layer_ids = (
+                    resolve_draft_aux_layer_ids(
+                        self.cfg["draft"], self._get_model_config().num_layers
+                    )
+                    if draft_enabled
+                    else None
+                )
+                global_draft_pass_counts = None
+                if (
+                    draft_ttt_steps > 1
+                    and "token_mask" in batch
+                    and "sample_mask" in batch
+                ):
+                    global_draft_pass_counts = compute_draft_pass_valid_counts(
+                        batch["token_mask"],
+                        batch["sample_mask"],
+                        ttt_steps=draft_ttt_steps,
+                    ).to(device=global_valid_toks.device)
+                    torch.distributed.all_reduce(
+                        global_draft_pass_counts,
+                        group=parallel_state.get_data_parallel_group(),
+                    )
+
                 # Pre-compute the MTP loss mask, only when MTP is enabled, so
                 # process_microbatch can pack it.
                 model_config = self._get_model_config()
@@ -924,7 +966,6 @@ class MegatronPolicyWorkerImpl(
                     self._set_mtp_grad_scale_func(lambda: mtp_scale)
 
                     # Forward pass.
-                    draft_enabled = "draft" in self.cfg and self.cfg["draft"]["enabled"]
                     use_router_replay = _should_use_router_replay(
                         enabled=self._router_replay_enabled,
                         data=batch,
@@ -943,10 +984,13 @@ class MegatronPolicyWorkerImpl(
                             defer_fp32_logits=self.defer_fp32_logits,
                             global_valid_seqs=global_valid_seqs,
                             global_valid_toks=global_valid_toks,
+                            global_draft_pass_counts=global_draft_pass_counts,
                             sampling_params=self.sampling_params,
                             straggler_timer=self.mcore_state.straggler_timer,
                             draft_model=self.draft_model,
                             enable_hidden_capture=draft_enabled,
+                            draft_ttt_steps=draft_ttt_steps,
+                            draft_aux_layer_indices=draft_aux_layer_ids,
                             use_fused_linear_logprobs=self.cfg["megatron_cfg"].get(
                                 "use_fused_linear_logprobs", False
                             ),
@@ -1507,6 +1551,30 @@ class MegatronPolicyWorkerImpl(
         placeholder_n = torch.tensor(1.0, device="cuda")
 
         draft_enabled = "draft" in self.cfg and self.cfg["draft"]["enabled"]
+        # With TTT enabled the draft's core attention is the multi-pass module,
+        # so the forward MUST run through forward_ttt even here (the plain
+        # single-pass forward would trip its begin_pass guard).
+        raw_ttt_steps = self.cfg["draft"].get("ttt_steps", 1) if draft_enabled else 1
+        draft_ttt_steps = 1 if raw_ttt_steps is None else int(raw_ttt_steps)
+        if draft_ttt_steps > 1:
+            # This path never computes global_draft_pass_counts, and its
+            # placeholder-N contract (loss returns un-normalized sums, one
+            # global 1/N rescale at finish) cannot express the multi-pass
+            # denominator sum_d alpha_d * count_d alongside the policy's
+            # global_valid_toks — the draft gradient would silently mis-scale
+            # by roughly sum_d alpha_d.
+            raise NotImplementedError(
+                "policy.draft.ttt_steps > 1 is not supported on the split "
+                "train-step path (single controller); use the batched train() "
+                "path."
+            )
+        draft_aux_layer_ids = (
+            resolve_draft_aux_layer_ids(
+                self.cfg["draft"], self._get_model_config().num_layers
+            )
+            if draft_enabled
+            else None
+        )
         use_router_replay = _should_use_router_replay(
             enabled=self._router_replay_enabled,
             data=data,
@@ -1537,6 +1605,8 @@ class MegatronPolicyWorkerImpl(
                     straggler_timer=self.mcore_state.straggler_timer,
                     draft_model=self.draft_model,
                     enable_hidden_capture=draft_enabled,
+                    draft_ttt_steps=draft_ttt_steps,
+                    draft_aux_layer_indices=draft_aux_layer_ids,
                     use_fused_linear_logprobs=self.cfg["megatron_cfg"].get(
                         "use_fused_linear_logprobs", False
                     ),

--- a/tests/unit/algorithms/test_draft_loss_wrapper.py
+++ b/tests/unit/algorithms/test_draft_loss_wrapper.py
@@ -18,11 +18,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 
-from nemo_rl.algorithms.loss.loss_functions import DraftCrossEntropyLossFn
+from nemo_rl.algorithms.loss.loss_functions import DraftTTTCrossEntropyLossFn
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 
 
-@patch("nemo_rl.algorithms.loss.wrapper.DraftCrossEntropyLossFn")
+@patch("nemo_rl.algorithms.loss.wrapper.DraftTTTCrossEntropyLossFn")
 def test_draft_loss_wrapper_combines_policy_and_draft_loss(mock_draft_loss_cls):
     """DraftLossWrapper should add the weighted draft loss to the policy loss."""
     from nemo_rl.algorithms.loss.wrapper import DraftLossWrapper
@@ -36,7 +36,7 @@ def test_draft_loss_wrapper_combines_policy_and_draft_loss(mock_draft_loss_cls):
 
     policy_loss_fn = MagicMock(return_value=(policy_loss, metrics.copy()))
     prepare_fn = MagicMock(return_value=({"prepared": torch.tensor(1.0)}, data))
-    draft_loss_fn = MagicMock(return_value=draft_loss)
+    draft_loss_fn = MagicMock(return_value=(draft_loss, {"draft_loss_pass_1": 2.0}))
     mock_draft_loss_cls.return_value = draft_loss_fn
 
     wrapper = DraftLossWrapper(
@@ -44,6 +44,7 @@ def test_draft_loss_wrapper_combines_policy_and_draft_loss(mock_draft_loss_cls):
         prepare_fn=prepare_fn,
         data_dict=data,
         loss_weight=0.5,
+        ttt_steps=2,
     )
 
     combined_loss, combined_metrics = wrapper(
@@ -55,10 +56,11 @@ def test_draft_loss_wrapper_combines_policy_and_draft_loss(mock_draft_loss_cls):
 
     assert combined_loss.item() == 4.0
     assert combined_metrics["draft_loss"] == draft_loss.item()
+    assert combined_metrics["draft_loss_pass_1"] == 2.0
     assert combined_metrics["policy_metric"] == metrics["policy_metric"]
 
 
-@patch("nemo_rl.algorithms.loss.wrapper.DraftCrossEntropyLossFn")
+@patch("nemo_rl.algorithms.loss.wrapper.DraftTTTCrossEntropyLossFn")
 def test_draft_loss_wrapper_reports_draft_loss_when_weight_is_zero(
     mock_draft_loss_cls,
 ):
@@ -73,7 +75,7 @@ def test_draft_loss_wrapper_reports_draft_loss_when_weight_is_zero(
 
     policy_loss_fn = MagicMock(return_value=(policy_loss, {}))
     prepare_fn = MagicMock(return_value=({"prepared": torch.tensor(1.0)}, data))
-    draft_loss_fn = MagicMock(return_value=draft_loss)
+    draft_loss_fn = MagicMock(return_value=(draft_loss, {}))
     mock_draft_loss_cls.return_value = draft_loss_fn
 
     wrapper = DraftLossWrapper(
@@ -81,6 +83,7 @@ def test_draft_loss_wrapper_reports_draft_loss_when_weight_is_zero(
         prepare_fn=prepare_fn,
         data_dict=data,
         loss_weight=0.0,
+        ttt_steps=2,
     )
 
     combined_loss, metrics = wrapper(
@@ -94,31 +97,77 @@ def test_draft_loss_wrapper_reports_draft_loss_when_weight_is_zero(
     assert metrics["draft_loss"] == draft_loss.item()
 
 
-@patch("nemo_rl.algorithms.loss.loss_functions.DistributedCrossEntropy.apply")
+@patch("nemo_rl.algorithms.loss.wrapper.DraftTTTCrossEntropyLossFn")
+def test_draft_loss_wrapper_threads_draft_pass_counts(mock_draft_loss_cls):
+    """The wrapper must hand the global per-pass counts to the draft loss fn."""
+    from nemo_rl.algorithms.loss.wrapper import DraftLossWrapper
+
+    data = BatchedDataDict({})
+    global_valid = torch.tensor(1)
+    draft_pass_counts = torch.tensor([42.0, 17.0])
+
+    policy_loss_fn = MagicMock(return_value=(torch.tensor(1.0), {}))
+    prepare_fn = MagicMock(return_value=({}, data))
+    draft_loss_fn = MagicMock(return_value=(torch.tensor(0.5), {}))
+    mock_draft_loss_cls.return_value = draft_loss_fn
+
+    wrapper = DraftLossWrapper(
+        loss_fn=policy_loss_fn,
+        prepare_fn=prepare_fn,
+        data_dict=data,
+        loss_weight=1.0,
+        draft_loss_kwargs={"pass_weights": [1.0, 0.5]},
+        global_draft_pass_counts=draft_pass_counts,
+        ttt_steps=2,
+    )
+    wrapper(
+        next_token_logits=torch.randn(1, 2, 3),
+        data=data,
+        global_valid_seqs=global_valid,
+        global_valid_toks=global_valid,
+    )
+
+    mock_draft_loss_cls.assert_called_once_with(
+        vocab_parallel_group=None,
+        pass_weights=[1.0, 0.5],
+    )
+    call_kwargs = draft_loss_fn.call_args[1]
+    assert call_kwargs["global_draft_pass_counts"] is draft_pass_counts
+
+
+@patch("nemo_rl.algorithms.loss.loss_functions.ChunkedDistributedCrossEntropy.apply")
 def test_draft_cross_entropy_loss_uses_distributed_path_for_tp(
     mock_distributed_ce,
 ):
-    """DraftCrossEntropyLossFn should delegate to DistributedCrossEntropy under TP."""
-    teacher_logits = torch.randn(2, 3, 5)
-    student_logits = torch.randn(2, 3, 5)
-    token_mask = torch.ones(2, 3)
+    """DraftTTTCrossEntropyLossFn should delegate to the chunked distributed CE."""
+    seq_len = 4
+    # Pass 1 slices to valid_len = S - 2 = 2 positions.
+    teacher_logits = torch.randn(2, seq_len, 5)
+    student_logits = torch.randn(2, seq_len, 5)
+    token_mask = torch.ones(2, seq_len)
     sample_mask = torch.ones(2)
-    global_valid = torch.tensor(6.0)
-    per_token_loss = torch.full((2, 3), 2.0)
+    global_valid = torch.tensor(4.0)
+    per_token_loss = torch.full((2, 2), 2.0)
     mock_distributed_ce.return_value = per_token_loss
 
-    loss_fn = DraftCrossEntropyLossFn(vocab_parallel_group=MagicMock())
-    loss = loss_fn(
+    loss_fn = DraftTTTCrossEntropyLossFn(vocab_parallel_group=MagicMock())
+    loss, metrics = loss_fn(
         teacher_logits=teacher_logits,
-        student_logits=student_logits,
-        token_mask=token_mask,
-        data=BatchedDataDict({"sample_mask": sample_mask}),
+        student_logits_by_pass=[student_logits],
+        data=BatchedDataDict({"sample_mask": sample_mask, "token_mask": token_mask}),
         global_valid_seqs=global_valid,
         global_valid_toks=global_valid,
     )
 
     mock_distributed_ce.assert_called_once()
+    student_arg, teacher_arg = mock_distributed_ce.call_args[0][:2]
+    assert student_arg.shape == (2, 2, 5)
+    assert teacher_arg.shape == (2, 2, 5)
+    assert torch.equal(student_arg, student_logits[:, :2])
+    assert torch.equal(teacher_arg, teacher_logits[:, 1:3])
+    # 4 valid positions x loss 2.0 / global_valid_toks 4.0
     assert loss.item() == 2.0
+    assert metrics["draft_loss_pass_1"] == 2.0
 
 
 def test_roll_packed_seq_dim_respects_segment_boundaries():

--- a/tests/unit/algorithms/test_draft_ttt_loss.py
+++ b/tests/unit/algorithms/test_draft_ttt_loss.py
@@ -1,0 +1,295 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Index/mask/normalization tests for the multi-pass (TTT) draft loss.
+
+Convention under test: pass-d student logits at position ``i`` predict token
+``x_{i+d+1}``; the teacher is the policy's logits at position ``i + d``; the
+mask is ``token_mask[i + d + 1] * sample_mask``.
+"""
+
+import torch
+
+from nemo_rl.algorithms.loss.loss_functions import DraftTTTCrossEntropyLossFn
+from nemo_rl.algorithms.loss.utils import (
+    compute_draft_pass_valid_counts,
+    draft_pass_token_mask,
+    prepare_loss_input,
+)
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+
+
+def _soft_ce(student_row: torch.Tensor, teacher_row: torch.Tensor) -> torch.Tensor:
+    teacher_probs = torch.softmax(teacher_row, dim=-1)
+    student_log_probs = torch.log_softmax(student_row, dim=-1)
+    return -(teacher_probs * student_log_probs).sum(dim=-1)
+
+
+def _manual_draft_loss(
+    teacher_logits: torch.Tensor,
+    student_logits_by_pass: list[torch.Tensor],
+    token_mask: torch.Tensor,
+    sample_mask: torch.Tensor,
+    pass_weights: list[float],
+    denominator: float,
+) -> float:
+    """Direct positional transcription of the pass-d index convention."""
+    batch_size, seq_len, _ = teacher_logits.shape
+    total = 0.0
+    for pass_index, student_logits in enumerate(student_logits_by_pass):
+        ttt_pass = pass_index + 1
+        for b in range(batch_size):
+            for i in range(seq_len):
+                target_index = i + ttt_pass + 1
+                if target_index >= seq_len:
+                    continue
+                mask = float(token_mask[b, target_index]) * float(sample_mask[b])
+                if mask == 0.0:
+                    continue
+                ce = _soft_ce(
+                    student_logits[b, i], teacher_logits[b, i + ttt_pass]
+                ).item()
+                total += pass_weights[pass_index] * ce * mask
+    return total / max(denominator, 1.0)
+
+
+def test_draft_pass_token_mask_is_shifted_by_pass_plus_one():
+    token_mask = torch.tensor([[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]])
+    assert torch.equal(draft_pass_token_mask(token_mask, 1), token_mask[:, 2:])
+    assert torch.equal(draft_pass_token_mask(token_mask, 2), token_mask[:, 3:])
+    assert draft_pass_token_mask(token_mask, 5).shape == (1, 0)
+
+
+def test_compute_draft_pass_valid_counts_counts_shifted_masks():
+    token_mask = torch.tensor([[1.0, 1.0, 1.0, 0.0, 1.0], [1.0, 1.0, 1.0, 1.0, 1.0]])
+    sample_mask = torch.tensor([1.0, 0.0])
+    # Pass 1: token_mask[:, 2:] -> row0 [1,0,1]*1 = 2, row1 masked out = 0.
+    # Pass 2: token_mask[:, 3:] -> row0 [0,1]*1 = 1, row1 = 0.
+    counts = compute_draft_pass_valid_counts(token_mask, sample_mask, ttt_steps=2)
+    assert counts.tolist() == [2.0, 1.0]
+
+
+def test_single_pass_loss_matches_manual_soft_ce():
+    torch.manual_seed(0)
+    batch_size, seq_len, vocab = 2, 6, 7
+    teacher = torch.randn(batch_size, seq_len, vocab)
+    student = torch.randn(batch_size, seq_len, vocab)
+    token_mask = torch.tensor(
+        [[0.0, 1.0, 1.0, 1.0, 0.0, 1.0], [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]]
+    )
+    sample_mask = torch.tensor([1.0, 1.0])
+    pass_counts = compute_draft_pass_valid_counts(token_mask, sample_mask, ttt_steps=1)
+
+    loss_fn = DraftTTTCrossEntropyLossFn()
+    loss, _ = loss_fn(
+        teacher_logits=teacher,
+        student_logits_by_pass=[student],
+        data=BatchedDataDict({"token_mask": token_mask, "sample_mask": sample_mask}),
+        global_valid_seqs=torch.tensor(1.0),
+        global_valid_toks=torch.tensor(1.0),
+        global_draft_pass_counts=pass_counts,
+    )
+    expected = _manual_draft_loss(
+        teacher, [student], token_mask, sample_mask, [1.0], pass_counts[0].item()
+    )
+    torch.testing.assert_close(loss.item(), expected, atol=1e-5, rtol=1e-5)
+
+
+def test_multi_pass_loss_applies_weights_and_draft_denominator():
+    torch.manual_seed(1)
+    batch_size, seq_len, vocab = 2, 8, 5
+    teacher = torch.randn(batch_size, seq_len, vocab)
+    students = [torch.randn(batch_size, seq_len, vocab) for _ in range(3)]
+    token_mask = (torch.rand(batch_size, seq_len) > 0.3).float()
+    sample_mask = torch.tensor([1.0, 1.0])
+    pass_weights = [1.0, 0.5, 0.25]
+    pass_counts = compute_draft_pass_valid_counts(token_mask, sample_mask, ttt_steps=3)
+    denominator = sum(
+        w * c for w, c in zip(pass_weights, pass_counts.tolist(), strict=True)
+    )
+
+    loss_fn = DraftTTTCrossEntropyLossFn(pass_weights=pass_weights)
+    loss, metrics = loss_fn(
+        teacher_logits=teacher,
+        student_logits_by_pass=students,
+        data=BatchedDataDict({"token_mask": token_mask, "sample_mask": sample_mask}),
+        global_valid_seqs=torch.tensor(1.0),
+        global_valid_toks=torch.tensor(1.0),
+        global_draft_pass_counts=pass_counts,
+    )
+    expected = _manual_draft_loss(
+        teacher, students, token_mask, sample_mask, pass_weights, denominator
+    )
+    torch.testing.assert_close(loss.item(), expected, atol=1e-5, rtol=1e-5)
+    # Per-pass metrics are pass_sum / global pass count so the driver's
+    # sum-over-microbatches aggregation yields a global per-token mean.
+    for ttt_pass in (1, 2, 3):
+        expected_metric = _manual_draft_loss(
+            teacher,
+            [torch.zeros_like(students[0])] * (ttt_pass - 1) + [students[ttt_pass - 1]],
+            token_mask,
+            sample_mask,
+            [0.0] * (ttt_pass - 1) + [1.0],
+            pass_counts[ttt_pass - 1].item(),
+        )
+        torch.testing.assert_close(
+            metrics[f"draft_loss_pass_{ttt_pass}"],
+            expected_metric,
+            atol=1e-5,
+            rtol=1e-5,
+        )
+
+
+def test_masked_positions_do_not_affect_loss():
+    torch.manual_seed(2)
+    batch_size, seq_len, vocab = 1, 6, 5
+    teacher = torch.randn(batch_size, seq_len, vocab)
+    student = torch.randn(batch_size, seq_len, vocab)
+    token_mask = torch.tensor([[1.0, 1.0, 1.0, 0.0, 1.0, 0.0]])
+    sample_mask = torch.tensor([1.0])
+    data = BatchedDataDict({"token_mask": token_mask, "sample_mask": sample_mask})
+    loss_fn = DraftTTTCrossEntropyLossFn()
+    kwargs = dict(
+        global_valid_seqs=torch.tensor(1.0),
+        global_valid_toks=torch.tensor(1.0),
+        global_draft_pass_counts=torch.tensor([3.0]),
+    )
+
+    loss_a, _ = loss_fn(
+        teacher_logits=teacher, student_logits_by_pass=[student], data=data, **kwargs
+    )
+
+    # Pass 1 position i is masked iff token_mask[i + 2] == 0: perturb the
+    # student at masked positions (i = 1, 3, 4, 5) and the loss must not move.
+    student_perturbed = student.clone()
+    student_perturbed[0, 1] += 100.0
+    student_perturbed[0, 3:] -= 50.0
+    loss_b, _ = loss_fn(
+        teacher_logits=teacher,
+        student_logits_by_pass=[student_perturbed],
+        data=data,
+        **kwargs,
+    )
+    torch.testing.assert_close(loss_a.item(), loss_b.item(), atol=1e-6, rtol=1e-6)
+
+
+def test_out_of_bounds_pass_is_skipped():
+    torch.manual_seed(3)
+    seq_len = 3
+    teacher = torch.randn(1, seq_len, 4)
+    students = [torch.randn(1, seq_len, 4) for _ in range(3)]
+    token_mask = torch.ones(1, seq_len)
+    sample_mask = torch.ones(1)
+
+    loss_fn = DraftTTTCrossEntropyLossFn()
+    loss, metrics = loss_fn(
+        teacher_logits=teacher,
+        student_logits_by_pass=students,
+        data=BatchedDataDict({"token_mask": token_mask, "sample_mask": sample_mask}),
+        global_valid_seqs=torch.tensor(1.0),
+        global_valid_toks=torch.tensor(1.0),
+        global_draft_pass_counts=torch.tensor([1.0, 0.0, 0.0]),
+    )
+    # Passes 2 and 3 have no in-bounds target (S - d - 1 <= 0) and contribute 0.
+    assert torch.isfinite(loss)
+    assert metrics["draft_loss_pass_2"] == 0.0
+    assert metrics["draft_loss_pass_3"] == 0.0
+    expected = _manual_draft_loss(
+        teacher, students, token_mask, sample_mask, [1.0, 1.0, 1.0], 1.0
+    )
+    torch.testing.assert_close(loss.item(), expected, atol=1e-5, rtol=1e-5)
+
+
+def test_chunked_ce_matches_unchunked_loss_and_grads():
+    """Sequence-chunked soft CE must match the single-chunk result exactly.
+
+    Covers both the loss value and the gradient w.r.t. the student logits
+    (the chunked Function recomputes softmaxes in backward instead of saving
+    the fp32 probability tensors).
+    """
+    torch.manual_seed(4)
+    batch_size, seq_len, vocab = 2, 11, 6
+    teacher = torch.randn(batch_size, seq_len, vocab)
+    students = [
+        torch.randn(batch_size, seq_len, vocab, requires_grad=True) for _ in range(2)
+    ]
+    token_mask = (torch.rand(batch_size, seq_len) > 0.2).float()
+    sample_mask = torch.ones(batch_size)
+    data = BatchedDataDict({"token_mask": token_mask, "sample_mask": sample_mask})
+    kwargs = dict(
+        global_valid_seqs=torch.tensor(1.0),
+        global_valid_toks=torch.tensor(1.0),
+        global_draft_pass_counts=torch.tensor([4.0, 3.0]),
+    )
+
+    # Single chunk covers the whole sequence.
+    loss_a, _ = DraftTTTCrossEntropyLossFn(seq_chunk_size=seq_len)(
+        teacher_logits=teacher,
+        student_logits_by_pass=list(students),
+        data=data,
+        **kwargs,
+    )
+    grads_a = torch.autograd.grad(loss_a, students, retain_graph=False)
+
+    # Uneven multi-chunk split (11 = 3 + 3 + 3 + 2).
+    loss_b, _ = DraftTTTCrossEntropyLossFn(seq_chunk_size=3)(
+        teacher_logits=teacher,
+        student_logits_by_pass=list(students),
+        data=data,
+        **kwargs,
+    )
+    grads_b = torch.autograd.grad(loss_b, students)
+
+    torch.testing.assert_close(loss_a, loss_b, atol=1e-6, rtol=1e-6)
+    for grad_a, grad_b in zip(grads_a, grads_b):
+        torch.testing.assert_close(grad_a, grad_b, atol=1e-6, rtol=1e-6)
+
+
+def test_chunked_ce_grad_matches_plain_autograd():
+    """Hand-rolled chunked backward vs plain torch autograd on the same math."""
+    from nemo_rl.distributed.model_utils import ChunkedDistributedCrossEntropy
+
+    torch.manual_seed(5)
+    student = torch.randn(1, 9, 5, requires_grad=True)
+    teacher = torch.randn(1, 9, 5)
+    weights = torch.rand(1, 9)
+
+    per_token = ChunkedDistributedCrossEntropy.apply(student, teacher, 4, None, False)
+    (per_token * weights).sum().backward()
+
+    student_ref = student.detach().clone().requires_grad_()
+    ce_ref = -(
+        torch.softmax(teacher, dim=-1) * torch.log_softmax(student_ref, dim=-1)
+    ).sum(-1)
+    (ce_ref * weights).sum().backward()
+
+    torch.testing.assert_close(student.grad, student_ref.grad, atol=1e-6, rtol=1e-6)
+
+
+def test_prepare_loss_input_keeps_teacher_unshifted_and_detached():
+    logits = torch.randn(1, 5, 6, requires_grad=True)
+    student = torch.randn(1, 5, 6)
+    data = BatchedDataDict(
+        {
+            "student_logits_by_pass": [student, student],
+            "token_mask": torch.ones(1, 5),
+            "sample_mask": torch.ones(1),
+        }
+    )
+    loss_fn = DraftTTTCrossEntropyLossFn()
+    loss_input, _ = prepare_loss_input(logits=logits, data=data, loss_fn=loss_fn)
+
+    assert torch.equal(loss_input["teacher_logits"], logits.detach())
+    assert not loss_input["teacher_logits"].requires_grad
+    assert len(loss_input["student_logits_by_pass"]) == 2

--- a/tests/unit/models/generation/test_vllm_draft_lm_head_unshare.py
+++ b/tests/unit/models/generation/test_vllm_draft_lm_head_unshare.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Un-sharing the vLLM drafter lm_head before draft refit.
+
+vLLM 0.26's spec-decode proposer aliases the drafter's ``lm_head`` module to
+the target's when their weights are identical at engine init
+(``SpecDecodeBaseProposer._maybe_share_lm_head``). With a co-training draft,
+loading the trained (diverged) draft head through that alias would overwrite
+the serving target's head. ``_unshare_draft_lm_head`` must detect the alias
+and give the drafter private storage — and must not touch anything otherwise.
+"""
+
+import types
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.vllm
+
+pytest.importorskip("vllm", reason="vllm_backend requires a vLLM install")
+
+from nemo_rl.models.generation.vllm.vllm_backend import (  # noqa: E402
+    VllmInternalWorkerExtension,
+)
+
+
+def _make_backend(target_lm_head):
+    backend = types.SimpleNamespace(
+        model_runner=types.SimpleNamespace(
+            model=types.SimpleNamespace(lm_head=target_lm_head)
+        )
+    )
+    backend._unshare_draft_lm_head = types.MethodType(
+        VllmInternalWorkerExtension._unshare_draft_lm_head, backend
+    )
+    return backend
+
+
+def _lm_head(weight):
+    head = torch.nn.Module()
+    head.weight = torch.nn.Parameter(weight, requires_grad=False)
+    return head
+
+
+def test_aliased_lm_head_is_unshared_and_target_protected():
+    target_head = _lm_head(torch.randn(16, 8))
+    # vLLM attaches loader metadata to parameters via set_weight_attrs; the
+    # private copy must keep it, or the next load_weights on the drafter fails.
+    target_head.weight.weight_loader = lambda param, loaded: None
+    draft_model = types.SimpleNamespace(lm_head=target_head)  # vLLM-style alias
+    backend = _make_backend(target_head)
+
+    backend._unshare_draft_lm_head(draft_model)
+
+    assert draft_model.lm_head is not target_head
+    assert (
+        draft_model.lm_head.weight.untyped_storage().data_ptr()
+        != target_head.weight.untyped_storage().data_ptr()
+    )
+    torch.testing.assert_close(draft_model.lm_head.weight, target_head.weight)
+    assert draft_model.lm_head.weight.weight_loader is target_head.weight.weight_loader
+
+    # A subsequent draft-head update must leave the target untouched.
+    before = target_head.weight.detach().clone()
+    with torch.no_grad():
+        draft_model.lm_head.weight += 1.0
+    torch.testing.assert_close(target_head.weight.detach(), before)
+
+
+def test_distinct_lm_head_is_left_alone():
+    target_head = _lm_head(torch.randn(16, 8))
+    own_head = _lm_head(torch.randn(16, 8))
+    draft_model = types.SimpleNamespace(lm_head=own_head)
+    backend = _make_backend(target_head)
+
+    backend._unshare_draft_lm_head(draft_model)
+
+    assert draft_model.lm_head is own_head  # no copy when not aliased
+
+
+def test_missing_lm_head_is_a_noop():
+    backend = _make_backend(target_lm_head=None)
+    draft_model = types.SimpleNamespace()
+    backend._unshare_draft_lm_head(draft_model)  # must not raise
+
+
+def _make_refit_backend(model_runner):
+    backend = types.SimpleNamespace(model_runner=model_runner)
+    backend._get_drafter_model = types.MethodType(
+        VllmInternalWorkerExtension._get_drafter_model, backend
+    )
+    backend._load_draft_weights = types.MethodType(
+        VllmInternalWorkerExtension._load_draft_weights, backend
+    )
+    return backend
+
+
+def test_speculator_attribute_is_a_drafter_fallback():
+    # The V2 model runner names the owner `speculator` instead of `drafter`.
+    model = types.SimpleNamespace()
+    runner = types.SimpleNamespace(
+        drafter=None, speculator=types.SimpleNamespace(model=model)
+    )
+    assert _make_refit_backend(runner)._get_drafter_model() is model
+
+
+def test_missing_drafter_raises_on_last_pp_rank(monkeypatch):
+    import nemo_rl.models.generation.vllm.vllm_backend as vllm_backend_module
+
+    monkeypatch.setattr(
+        vllm_backend_module,
+        "get_pp_group",
+        lambda: types.SimpleNamespace(is_last_rank=True),
+    )
+    backend = _make_refit_backend(types.SimpleNamespace(drafter=None))
+    with pytest.raises(RuntimeError, match="no vLLM drafter"):
+        backend._load_draft_weights([("lm_head.weight", torch.zeros(1))])
+
+
+def test_missing_drafter_is_expected_on_earlier_pp_ranks(monkeypatch):
+    import nemo_rl.models.generation.vllm.vllm_backend as vllm_backend_module
+
+    monkeypatch.setattr(
+        vllm_backend_module,
+        "get_pp_group",
+        lambda: types.SimpleNamespace(is_last_rank=False),
+    )
+    backend = _make_refit_backend(types.SimpleNamespace(drafter=None))
+    backend._load_draft_weights([("lm_head.weight", torch.zeros(1))])  # must not raise

--- a/tests/unit/models/megatron/test_draft_optimizer_overrides.py
+++ b/tests/unit/models/megatron/test_draft_optimizer_overrides.py
@@ -1,0 +1,214 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import fnmatch
+
+import pytest
+
+# draft.utils imports megatron at module top, so every test here needs mcore.
+pytestmark = pytest.mark.mcore
+
+
+def test_build_provider_returns_none_when_no_draft_optimizer_settings():
+    from nemo_rl.models.megatron.draft.utils import (
+        build_draft_optimizer_override_provider,
+    )
+
+    assert (
+        build_draft_optimizer_override_provider(
+            {"enabled": True, "model_name": None, "lr": None}
+        )
+        is None
+    )
+    assert build_draft_optimizer_override_provider({"enabled": True}) is None
+
+
+def test_draft_override_group_values_and_standard_overrides_preserved():
+    from megatron.bridge.training.config import (
+        OptimizerConfigOverrideProviderContext,
+    )
+    from megatron.core.optimizer import OptimizerConfig, ParamKey
+
+    from nemo_rl.models.megatron.draft.utils import (
+        build_draft_optimizer_override_provider,
+    )
+
+    provider = build_draft_optimizer_override_provider(
+        {"enabled": True, "lr": 5e-5, "min_lr": None, "weight_decay": 0.0}
+    )
+    assert provider is not None
+
+    optimizer_config = OptimizerConfig(optimizer="adam", lr=1e-6, min_lr=1e-7)
+    context = OptimizerConfigOverrideProviderContext(
+        scheduler_config=None, optimizer_config=optimizer_config, model=None
+    )
+    overrides = provider.build_config_overrides(context)
+
+    draft_key = ParamKey(name="*draft_model.*")
+    assert draft_key in overrides
+    draft_override = overrides[draft_key]
+    assert draft_override["max_lr"] == 5e-5
+    # min_lr defaults to the draft lr when unset.
+    assert draft_override["min_lr"] == 5e-5
+    assert draft_override["start_wd"] == 0.0
+    assert draft_override["end_wd"] == 0.0
+
+    # The standard megatron-bridge overrides must survive the merge.
+    from megatron.core.optimizer import get_standard_config_overrides
+
+    standard = get_standard_config_overrides(config=optimizer_config) or {}
+    for key in standard:
+        assert key in overrides
+
+    # The glob must match DDP-prefixed draft param names but not policy params.
+    assert fnmatch.fnmatch(
+        "module.module.draft_model.eagle_module.fc.weight", "*draft_model.*"
+    )
+    assert not fnmatch.fnmatch(
+        "module.module.decoder.layers.0.mlp.linear_fc1.weight", "*draft_model.*"
+    )
+
+
+def _make_param_group(*, params, **overrides):
+    """A param group shaped like mcore's ``_get_param_groups`` output.
+
+    Keys are derived from the live ``param_group_identifier_keys`` tuple (with
+    shared defaults) so the fakes track upstream instead of hard-coding a
+    snapshot of the tuple; a future key added upstream lands as a shared
+    default and stays collision-free.
+    """
+    from megatron.core.optimizer import optimizer as mcore_optimizer
+
+    defaults = {
+        "wd_mult": 1.0,
+        "lr_mult": 1.0,
+        "is_expert_parallel": False,
+        "is_decoupled_lr": False,
+        "optimizer": "adam",
+        "max_lr": 1e-6,
+        "min_lr": 1e-7,
+        "start_wd": 0.01,
+        "end_wd": 0.01,
+    }
+    group = {
+        key: defaults.get(key) for key in mcore_optimizer.param_group_identifier_keys
+    }
+    group.update(overrides)
+    group["params"] = params
+    return group
+
+
+def test_upstream_identifier_keys_cover_draft_group_identity():
+    """Pin the upstream premise the draft group's resume safety relies on.
+
+    mcore matches checkpointed optimizer param groups to runtime groups by
+    ``param_group_identifier_keys``; the draft group differs from the policy
+    group only in max_lr/min_lr/start_wd/end_wd, so those must be part of the
+    identity or a resumed run silently swaps the two groups' hyperparameters
+    (observed pre-fix: policy at 50x LR). Upstream added them in
+    Megatron-LM#4705; a submodule regression should fail loudly here instead
+    of corrupting a resume. distrib_optimizer holds its own binding via
+    ``from ... import``, so every consuming module is checked.
+    """
+    from megatron.core import optimizer as mcore_optimizer_pkg
+    from megatron.core.optimizer import distrib_optimizer as mcore_distrib_optimizer
+    from megatron.core.optimizer import optimizer as mcore_optimizer
+
+    for module in (mcore_optimizer, mcore_distrib_optimizer, mcore_optimizer_pkg):
+        keys = set(module.param_group_identifier_keys)
+        assert {"max_lr", "min_lr", "start_wd", "end_wd"} <= keys
+
+
+def test_resume_group_matching_keeps_policy_and_draft_hyperparams():
+    """Regression test: resume must not conflate the policy and draft groups.
+
+    The draft param group differs from the policy group only in
+    max_lr/min_lr/wd endpoints. ``param_group_identifier_keys`` includes those
+    fields (see the premise test above), so ``_filter_and_reorder_param_groups``
+    must map each saved group back onto its own runtime group even when the
+    saved order is flipped. ``DistributedOptimizer.load_state_dict`` builds an
+    equivalent dict keyed by the same tuple, so this exercises the shared
+    matching mechanism for both load paths.
+    """
+    from megatron.core.optimizer import optimizer as mcore_optimizer
+    from megatron.core.optimizer.optimizer import MegatronOptimizer
+
+    policy_group = _make_param_group(max_lr=1e-6, min_lr=1e-7, params=[0, 1])
+    draft_group = _make_param_group(max_lr=5e-5, min_lr=5e-5, params=[2])
+    current_groups = [policy_group, draft_group]
+    saved_groups = [dict(draft_group), dict(policy_group)]  # reversed on disk
+
+    reordered = MegatronOptimizer._filter_and_reorder_param_groups(
+        current_groups, saved_groups
+    )
+    assert reordered[0]["max_lr"] == 1e-6
+    assert reordered[0]["min_lr"] == 1e-7
+    assert reordered[1]["max_lr"] == 5e-5
+    assert reordered[1]["min_lr"] == 5e-5
+    # Only the hyperparameters follow the identity matching; ``params`` keep
+    # state-dict positional order (upstream contract — they map the saved
+    # optimizer state onto the current groups).
+    assert reordered[0]["params"] == [2]
+    assert reordered[1]["params"] == [0, 1]
+
+    # The identity must be collision-free over these groups, which is what
+    # DistributedOptimizer.load_state_dict's dict-based mapping needs.
+    identifier_keys = mcore_optimizer.param_group_identifier_keys
+    identity_tuples = {tuple(g[k] for k in identifier_keys) for g in saved_groups}
+    assert len(identity_tuples) == len(saved_groups)
+
+
+def test_draft_override_distinctness_guard():
+    from megatron.bridge.training.config import (
+        OptimizerConfigOverrideProviderContext,
+    )
+    from megatron.core.optimizer import OptimizerConfig, ParamKey
+
+    from nemo_rl.models.megatron.draft.utils import (
+        build_draft_optimizer_override_provider,
+    )
+
+    optimizer_config = OptimizerConfig(optimizer="adam", lr=1e-6, min_lr=1e-7)
+    context = OptimizerConfigOverrideProviderContext(
+        scheduler_config=None, optimizer_config=optimizer_config, model=None
+    )
+
+    # weight_decay-only override: start_wd/end_wd are identifier keys, so the
+    # group is distinguishable at resume and the config must be accepted.
+    wd_only_provider = build_draft_optimizer_override_provider(
+        {"enabled": True, "lr": None, "min_lr": None, "weight_decay": 0.01}
+    )
+    assert wd_only_provider is not None
+    wd_only_overrides = wd_only_provider.build_config_overrides(context)
+    wd_only_override = wd_only_overrides[ParamKey(name="*draft_model.*")]
+    assert wd_only_override["start_wd"] == 0.01
+    assert wd_only_override["end_wd"] == 0.01
+    assert "max_lr" not in wd_only_override
+
+    # Draft lr/min_lr numerically equal to the policy's and no weight decay:
+    # nothing distinguishes the groups at resume, so this must be rejected.
+    same_lr_provider = build_draft_optimizer_override_provider(
+        {"enabled": True, "lr": 1e-6, "min_lr": 1e-7, "weight_decay": None}
+    )
+    assert same_lr_provider is not None
+    with pytest.raises(ValueError, match="must differ from the policy's"):
+        same_lr_provider.build_config_overrides(context)
+
+    # Draft lr equal to the policy lr but min_lr defaulting to the draft lr
+    # (!= policy min_lr) keeps the pair distinct and is allowed.
+    distinct_min_lr_provider = build_draft_optimizer_override_provider(
+        {"enabled": True, "lr": 1e-6, "min_lr": None, "weight_decay": None}
+    )
+    overrides = distinct_min_lr_provider.build_config_overrides(context)
+    assert overrides is not None

--- a/tests/unit/models/megatron/test_hidden_capture_aux_layers.py
+++ b/tests/unit/models/megatron/test_hidden_capture_aux_layers.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Hidden-state capture must tap the aux layers the draft was built for.
+
+The drafter checkpoint's ``target_layer_ids`` (or
+``policy.draft.aux_layer_indices``) decide which policy layers feed the draft
+at serving time; the trainer capture must hook the same layers, not the
+hard-coded defaults (silent feature mismatch when the counts match, fc width
+mismatch when they don't).
+"""
+
+import types
+
+import pytest
+import torch
+import torch.distributed as dist
+
+pytestmark = pytest.mark.mcore
+
+from megatron.core import parallel_state  # noqa: E402
+
+from nemo_rl.models.megatron.draft.hidden_capture import (  # noqa: E402
+    get_capture_context,
+    get_eagle3_aux_hidden_state_layers,
+)
+
+requires_gpu = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires CUDA (parallel_state init)"
+)
+
+
+def _make_policy_stub(num_layers: int) -> torch.nn.Module:
+    model = torch.nn.Module()
+    model.config = types.SimpleNamespace(num_layers=num_layers)
+    model.decoder = torch.nn.Module()
+    layers = []
+    for layer_idx in range(num_layers):
+        layer = torch.nn.Identity()
+        layer.layer_number = layer_idx + 1  # mcore layer_number is 1-based
+        layers.append(layer)
+    model.decoder.layers = torch.nn.ModuleList(layers)
+    return model
+
+
+@requires_gpu
+def test_capture_hooks_follow_configured_aux_layers(tmp_path):
+    created_process_group = False
+    try:
+        torch.cuda.set_device(0)
+        if not dist.is_initialized():
+            dist.init_process_group(
+                backend="nccl",
+                rank=0,
+                world_size=1,
+                init_method=f"file://{tmp_path / 'capture_pg_init'}",
+            )
+            created_process_group = True
+        parallel_state.destroy_model_parallel()
+        parallel_state.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+        )
+
+        model = _make_policy_stub(num_layers=8)
+
+        # Configured ids (e.g. an external checkpoint's target_layer_ids)
+        # must reach the hooks verbatim.
+        context, capture = get_capture_context(
+            model, enabled=True, aux_layer_indices=(2, 5)
+        )
+        assert capture.aux_layer_indices == (2, 5)
+        assert capture._local_aux_indices == [2, 5]
+        with context:
+            # One hook per aux layer (the stub has no embedding module).
+            assert len(capture._hooks) == 2
+
+        # Without configured ids the default formula applies.
+        _, default_capture = get_capture_context(model, enabled=True)
+        assert default_capture.aux_layer_indices == get_eagle3_aux_hidden_state_layers(
+            8
+        )
+    finally:
+        parallel_state.destroy_model_parallel()
+        if created_process_group and dist.is_initialized():
+            dist.destroy_process_group()

--- a/tests/unit/models/megatron/test_train.py
+++ b/tests/unit/models/megatron/test_train.py
@@ -791,6 +791,73 @@ class TestForwardWithPostProcessingFn:
         )
         assert data_dict["student_logits"] is student_logits
 
+    @patch("megatron.core.transformer.multi_token_prediction.roll_tensor")
+    @patch("nemo_rl.models.megatron.train.get_context_parallel_group")
+    @patch("nemo_rl.models.megatron.train.get_capture_context")
+    @patch("nemo_rl.models.megatron.train.model_forward")
+    def test_forward_with_ttt_draft_model_uses_forward_ttt(
+        self,
+        mock_model_forward,
+        mock_get_capture_context,
+        mock_get_cp_group,
+        mock_roll_tensor,
+    ):
+        """draft_ttt_steps > 1 must route through forward_ttt with per-pass logits."""
+        from nemo_rl.models.megatron.data import ProcessedMicrobatch
+        from nemo_rl.models.megatron.train import (
+            LogprobsPostProcessor,
+            forward_with_post_processing_fn,
+        )
+
+        hidden_states = torch.randn(3, 1, 4)
+        inputs_embeds = torch.randn(3, 1, 4)
+        shifted_embeds = torch.randn(3, 1, 4)
+        logits_by_pass = [torch.randn(1, 3, 5), torch.randn(1, 3, 5)]
+
+        mock_model_forward.return_value = torch.randn(1, 3, 5)
+        mock_get_cp_group.return_value = MagicMock()
+        mock_roll_tensor.return_value = (shifted_embeds, None)
+        mock_capture = MagicMock()
+        mock_capture.get_captured_states.return_value = SimpleNamespace(
+            hidden_states=hidden_states,
+            inputs_embeds=inputs_embeds,
+        )
+        mock_get_capture_context.return_value = (nullcontext(), mock_capture)
+
+        data_dict = {"input_ids": torch.tensor([[1, 2, 3]])}
+        processed_mb = ProcessedMicrobatch(
+            data_dict=data_dict,
+            input_ids=torch.tensor([[1, 2, 3]]),
+            input_ids_cp_sharded=torch.tensor([[1, 2, 3]]),
+            attention_mask=None,
+            position_ids=torch.tensor([[0, 1, 2]]),
+            packed_seq_params=None,
+            cu_seqlens_padded=None,
+            original_seq_length=3,
+        )
+        post_processor = LogprobsPostProcessor(
+            cfg={"sequence_packing": {"enabled": False}}
+        )
+        draft_model = MagicMock()
+        draft_model.forward_ttt.return_value = logits_by_pass
+
+        with patch.object(post_processor, "__call__", return_value=MagicMock()):
+            forward_with_post_processing_fn(
+                data_iterator=iter([processed_mb]),
+                model=MagicMock(),
+                post_processing_fn=post_processor,
+                draft_model=draft_model,
+                draft_ttt_steps=2,
+            )
+
+        draft_model.forward_ttt.assert_called_once_with(
+            hidden_states=hidden_states,
+            input_embeds=shifted_embeds,
+        )
+        draft_model.assert_not_called()
+        assert data_dict["student_logits_by_pass"] is logits_by_pass
+        assert "student_logits" not in data_dict
+
 
 class TestMegatronForwardBackward:
     """Tests for megatron_forward_backward function."""

--- a/tests/unit/models/megatron/test_ttt_attention.py
+++ b/tests/unit/models/megatron/test_ttt_attention.py
@@ -1,0 +1,354 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Numerics tests for the two-part TTT draft attention.
+
+The reference is a dense fp32 joint softmax over the concatenated trunk
+(causal pass-1) and branch (same-anchor diagonal) key sets — the staircase
+mask materialized — with native autograd. The kernel path must match it in
+both outputs and all input gradients (including the cross-pass gradient
+accumulation into the stashed pass-1 KV).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from nemo_rl.models.megatron.draft.eagle import (
+    TTTDraftCoreAttention,
+    TwoPartTTTAttention,
+)
+
+# The module under test is torch-only, but importing it goes through the
+# draft package __init__, which pulls in megatron.core.
+pytestmark = pytest.mark.mcore
+
+
+def _flash_attn_available() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    try:
+        import flash_attn  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+requires_flash_attn = pytest.mark.skipif(
+    not _flash_attn_available(), reason="Requires CUDA and flash-attn"
+)
+
+
+def dense_two_part_reference(
+    q: torch.Tensor,
+    k1: torch.Tensor,
+    v1: torch.Tensor,
+    kb: torch.Tensor,
+    vb: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    """Joint softmax over causal trunk + diagonal branch keys, materialized.
+
+    Shapes follow TwoPartTTTAttention: q ``[B,S,Hq,D]``, k1/v1 ``[B,S,Hkv,D]``,
+    kb/vb ``[B,S,Hkv,P,D]`` (P may be 0 for a pure causal pass).
+    """
+    batch, seqlen, num_q_heads, _ = q.shape
+    group = num_q_heads // k1.shape[2]
+    k1e = k1.repeat_interleave(group, dim=2)
+    v1e = v1.repeat_interleave(group, dim=2)
+    kbe = kb.repeat_interleave(group, dim=2)
+    vbe = vb.repeat_interleave(group, dim=2)
+
+    scores_trunk = torch.einsum("bihd,bjhd->bhij", q, k1e) * softmax_scale
+    causal = torch.tril(torch.ones(seqlen, seqlen, dtype=torch.bool, device=q.device))
+    scores_trunk = scores_trunk.masked_fill(~causal, float("-inf"))
+    scores_branch = torch.einsum("bihd,bihpd->bhip", q, kbe) * softmax_scale
+
+    probs = torch.softmax(torch.cat([scores_trunk, scores_branch], dim=-1), dim=-1)
+    out_trunk = torch.einsum("bhij,bjhd->bihd", probs[..., :seqlen], v1e)
+    out_branch = torch.einsum("bhip,bihpd->bihd", probs[..., seqlen:], vbe)
+    return out_trunk + out_branch
+
+
+def _assert_close(actual: torch.Tensor, expected: torch.Tensor, name: str) -> None:
+    actual = actual.float()
+    expected = expected.float()
+    max_diff = (actual - expected).abs().max().item()
+    scale = expected.abs().max().clamp(min=1e-6).item()
+    assert max_diff <= 3e-2 + 3e-2 * scale, (
+        f"{name}: max abs diff {max_diff:.4e} (ref scale {scale:.4e})"
+    )
+
+
+@requires_flash_attn
+@pytest.mark.parametrize("num_kv_heads", [8, 4])  # MHA and GQA (group = 2)
+def test_two_part_function_matches_dense(num_kv_heads):
+    torch.manual_seed(0)
+    batch, seqlen, num_q_heads, head_dim, num_branch = 2, 97, 8, 64, 2
+    softmax_scale = head_dim**-0.5
+
+    def make(*shape):
+        return torch.randn(
+            *shape, device="cuda", dtype=torch.bfloat16, requires_grad=True
+        )
+
+    q = make(batch, seqlen, num_q_heads, head_dim)
+    k1 = make(batch, seqlen, num_kv_heads, head_dim)
+    v1 = make(batch, seqlen, num_kv_heads, head_dim)
+    kb = make(batch, seqlen, num_kv_heads, num_branch, head_dim)
+    vb = make(batch, seqlen, num_kv_heads, num_branch, head_dim)
+
+    out = TwoPartTTTAttention.apply(q, k1, v1, kb, vb, softmax_scale)
+    dout = torch.randn_like(out)
+    grads = torch.autograd.grad(out, (q, k1, v1, kb, vb), dout)
+
+    refs = [t.detach().float().requires_grad_() for t in (q, k1, v1, kb, vb)]
+    out_ref = dense_two_part_reference(*refs, softmax_scale)
+    ref_grads = torch.autograd.grad(out_ref, refs, dout.float())
+
+    _assert_close(out, out_ref, "out")
+    for grad, ref_grad, name in zip(
+        grads, ref_grads, ("dq", "dk1", "dv1", "dkb", "dvb")
+    ):
+        _assert_close(grad, ref_grad, name)
+
+
+@requires_flash_attn
+def test_module_multi_pass_matches_dense_and_accumulates_trunk_grads():
+    """Three TTT passes through the core-attention module vs the dense oracle.
+
+    The pass-1 KV gradient must accumulate contributions from all passes
+    (trunk reuse), which is the property the KV stash exists for.
+    """
+    torch.manual_seed(1)
+    num_passes = 3
+    seqlen, batch, num_q_heads, num_kv_heads, head_dim = 64, 2, 4, 2, 32
+    softmax_scale = head_dim**-0.5
+
+    module = TTTDraftCoreAttention(
+        SimpleNamespace(
+            attention_dropout=0.0, context_parallel_size=1, softmax_scale=None
+        )
+    )
+
+    # sbhd layout, as handed to core_attention by MCore SelfAttention.
+    qs = [
+        torch.randn(
+            seqlen, batch, num_q_heads, head_dim, device="cuda", dtype=torch.bfloat16
+        ).requires_grad_()
+        for _ in range(num_passes)
+    ]
+    ks = [
+        torch.randn(
+            seqlen, batch, num_kv_heads, head_dim, device="cuda", dtype=torch.bfloat16
+        ).requires_grad_()
+        for _ in range(num_passes)
+    ]
+    vs = [
+        torch.randn(
+            seqlen, batch, num_kv_heads, head_dim, device="cuda", dtype=torch.bfloat16
+        ).requires_grad_()
+        for _ in range(num_passes)
+    ]
+
+    outs = []
+    for ttt_pass in range(1, num_passes + 1):
+        module.begin_pass(ttt_pass)
+        outs.append(module(qs[ttt_pass - 1], ks[ttt_pass - 1], vs[ttt_pass - 1], None))
+    module.reset()
+
+    dout = [torch.randn_like(o) for o in outs]
+    grads = torch.autograd.grad(outs, qs + ks + vs, dout, allow_unused=False)
+
+    # Dense reference on fp32 leaf copies (bshd layout).
+    def to_bshd(t):
+        return t.detach().float().transpose(0, 1).contiguous().requires_grad_()
+
+    qs_ref = [to_bshd(t) for t in qs]
+    ks_ref = [to_bshd(t) for t in ks]
+    vs_ref = [to_bshd(t) for t in vs]
+    outs_ref = []
+    for ttt_pass in range(1, num_passes + 1):
+        branch_k = ks_ref[1:ttt_pass]
+        if branch_k:
+            kb = torch.stack(branch_k, dim=3)
+            vb = torch.stack(vs_ref[1:ttt_pass], dim=3)
+        else:
+            kb = ks_ref[0].new_zeros(batch, seqlen, num_kv_heads, 0, head_dim)
+            vb = kb.clone()
+        out_ref = dense_two_part_reference(
+            qs_ref[ttt_pass - 1], ks_ref[0], vs_ref[0], kb, vb, softmax_scale
+        )
+        # bshd -> [S, B, H*D] to match the module output contract.
+        outs_ref.append(
+            out_ref.transpose(0, 1).reshape(seqlen, batch, num_q_heads * head_dim)
+        )
+    grads_ref = torch.autograd.grad(
+        outs_ref, qs_ref + ks_ref + vs_ref, [d.float() for d in dout]
+    )
+
+    for out, out_ref in zip(outs, outs_ref):
+        _assert_close(out, out_ref, "pass output")
+    for grad, grad_ref, name in zip(
+        grads,
+        grads_ref,
+        [f"dq{i}" for i in range(num_passes)]
+        + [f"dk{i}" for i in range(num_passes)]
+        + [f"dv{i}" for i in range(num_passes)],
+    ):
+        # Reference grads are bshd; module grads are sbhd.
+        _assert_close(grad, grad_ref.transpose(0, 1), name)
+
+    # The cross-pass property: pass-1 KV must receive gradient from passes 2/3
+    # too — compare against a single-pass-only reference to prove they differ.
+    single_pass_ref = torch.autograd.grad(
+        dense_two_part_reference(
+            to_bshd(qs[0]),
+            (k_only := to_bshd(ks[0])),
+            to_bshd(vs[0]),
+            k_only.new_zeros(batch, seqlen, num_kv_heads, 0, head_dim),
+            k_only.new_zeros(batch, seqlen, num_kv_heads, 0, head_dim),
+            softmax_scale,
+        )
+        .transpose(0, 1)
+        .reshape(seqlen, batch, num_q_heads * head_dim),
+        k_only,
+        dout[0].float(),
+    )[0]
+    assert not torch.allclose(
+        grads[num_passes].float(), single_pass_ref.transpose(0, 1), atol=1e-3
+    ), "pass-1 K grad shows no cross-pass contribution"
+
+
+@requires_flash_attn
+def test_two_part_matches_modelopt_multistep_mask_oracle():
+    """External oracle: modelopt's own TTT mask must reproduce our attention.
+
+    modelopt's ``set_multi_step_attention_mask`` (megatron_eagle.py) is the
+    NVIDIA reference for EAGLE multi-step training: one dense attention over
+    the K-fold concatenated sequence with a staircase mask. Its layout shifts
+    the hidden stream down one row per pass, so its pass-(p) block row ``r``
+    hosts our (pass p, anchor i = r - (p-1)) entry. Feeding the SAME per-pass
+    q/k/v to both sides and comparing row-by-row pins our trunk/branch
+    correspondence and the LSE merge against an implementation we did not
+    write. RoPE is bypassed (raw q/k/v), so this checks mask semantics only.
+    """
+    from modelopt.torch.speculative.plugins.megatron_eagle import (
+        set_multi_step_attention_mask,
+    )
+
+    torch.manual_seed(7)
+    seqlen, num_heads, head_dim, num_passes = 8, 2, 16, 3
+    softmax_scale = head_dim**-0.5
+    device = "cuda"
+
+    qs = [
+        torch.randn(seqlen, 1, num_heads, head_dim, device=device, dtype=torch.bfloat16)
+        for _ in range(num_passes)
+    ]
+    ks = [torch.randn_like(qs[0]) for _ in range(num_passes)]
+    vs = [torch.randn_like(qs[0]) for _ in range(num_passes)]
+
+    # --- Our side: per-pass two-part attention -> [S, 1, H*D] per pass.
+    module = TTTDraftCoreAttention(
+        SimpleNamespace(
+            attention_dropout=0.0, context_parallel_size=1, softmax_scale=None
+        )
+    )
+    ours = []
+    for ttt_pass in range(1, num_passes + 1):
+        module.begin_pass(ttt_pass)
+        ours.append(
+            module(qs[ttt_pass - 1], ks[ttt_pass - 1], vs[ttt_pass - 1], None).float()
+        )
+    module.reset()
+
+    # --- Oracle side: modelopt runs S query rows per ttt step against the
+    # KV cache of all previous blocks; set_multi_step_attention_mask(base, p)
+    # returns the [S, (p+1)S] mask for block p's queries. Block p row r hosts
+    # our (pass p+1, anchor i = r - p); rows with no valid anchor stay zero
+    # and are never compared.
+    def place_block(stream, block):
+        placed = torch.zeros(
+            seqlen, num_heads, head_dim, device=device, dtype=torch.float32
+        )
+        for row in range(block, seqlen):
+            placed[row] = stream[block][row - block, 0].float()
+        return placed
+
+    # Base causal mask (True = masked) + modelopt's pass-1 edge adjustment
+    # (their pass-1 stream carries rolled input_ids, so the mask is shifted
+    # diagonally and the padding row/col is masked out).
+    causal = torch.triu(
+        torch.ones(seqlen, seqlen, dtype=torch.bool, device=device), diagonal=1
+    )[None, None]
+    base = causal.clone()
+    base[:, :, :-1, :-1] = causal[:, :, 1:, 1:]
+    base[:, :, -1, :] = True
+    base[:, :, :, -1] = True
+
+    for block in range(num_passes):
+        qc = place_block(qs, block)
+        kc = torch.cat([place_block(ks, b) for b in range(block + 1)], dim=0)
+        vc = torch.cat([place_block(vs, b) for b in range(block + 1)], dim=0)
+        mask = set_multi_step_attention_mask(base.clone(), block)[0, 0]
+        assert mask.shape == (seqlen, (block + 1) * seqlen)
+
+        scores = torch.einsum("ihd,jhd->hij", qc, kc) * softmax_scale
+        scores = scores.masked_fill(mask.unsqueeze(0), float("-inf"))
+        oracle = torch.einsum("hij,jhd->ihd", torch.softmax(scores, dim=-1), vc)
+
+        # Compare on rows that are valid on both sides: modelopt unmasks the
+        # block-p self-diagonal only for rows in [p, S-2].
+        for row in range(block, seqlen - 1):
+            anchor = row - block
+            mine = ours[block][anchor, 0].view(num_heads, head_dim)
+            ref = oracle[row]
+            max_diff = (mine - ref).abs().max().item()
+            assert max_diff < 2e-2, (
+                f"pass {block + 1} anchor {anchor} (oracle row {row}): "
+                f"max diff {max_diff:.4e}"
+            )
+
+
+def test_module_guards_do_not_require_gpu():
+    module = TTTDraftCoreAttention(
+        SimpleNamespace(
+            attention_dropout=0.0, context_parallel_size=1, softmax_scale=None
+        )
+    )
+    q = torch.randn(4, 1, 2, 8)
+
+    with pytest.raises(RuntimeError, match="begin_pass"):
+        module(q, q, q, None)
+
+    module.begin_pass(1)
+    with pytest.raises(RuntimeError, match="in order"):
+        module.begin_pass(3)
+
+    with pytest.raises(NotImplementedError, match="sequence packing"):
+        module(q, q, q, None, packed_seq_params=object())
+
+    with pytest.raises(ValueError, match="attention_mask"):
+        module(q, q, q, torch.ones(1))
+
+
+def test_module_rejects_attention_dropout():
+    with pytest.raises(ValueError, match="dropout"):
+        TTTDraftCoreAttention(
+            SimpleNamespace(
+                attention_dropout=0.1, context_parallel_size=1, softmax_scale=None
+            )
+        )

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -313,6 +313,12 @@ policy:
     loss_weight: 0.1
     num_layers: null
     aux_layer_indices: null
+    ttt_steps: 1
+    ttt_pass_weights: null
+    loss_seq_chunk_size: 4096
+    lr: null
+    min_lr: null
+    weight_decay: null
 
   # See docs/design-docs/sequence-packing-and-dynamic-batching.md
   # for more details on dynamic batching and sequence packing.


### PR DESCRIPTION
# What does this PR do ?

Extends the single-pass EAGLE-3 draft co-training path (**Megatron** policy backend; the automodel path is being handled separately) to multi-pass TTT training (`policy.draft.ttt_steps > 1`), co-trained with the policy during GRPO and refit into vLLM alongside the policy weights.

# Issues

Part of #3698 (1/5). Stacked series: this PR → #3712 (DFlash) → #3713 (DSpark) → #4059 (sequence packing + CP) → #4060 (PP).

# Usage

```yaml
policy:
  draft:
    enabled: true
    model_name: <eagle3 draft ckpt or null>
    loss_weight: 0.1
    ttt_steps: 3            # >1 = multi-pass TTT; 1 = stock single pass
    ttt_pass_weights: null  # per-pass alphas, null = uniform
    loss_seq_chunk_size: null # seq-dim tile for the multi-pass loss internals; null = 4096
    lr: 5e-5                # optional draft-only optimizer group
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

Draft for visibility — actively being worked on. Main pieces:

- **Multi-pass TTT** (`EagleModel.forward_ttt`): sequential draft passes with a two-part trunk+branch flash attention (exact joint-LSE merge), inference-aligned per-pass RoPE offsets, non-detached hidden-state chain between passes.
- **Chunked distillation loss**: `ChunkedDistributedCrossEntropy` keeps fp32 softmax buffers chunk-sized (several TTT passes stack before the shared backward; chunk size via `policy.draft.loss_seq_chunk_size`). `DraftTTTCrossEntropyLossFn` — the multi-pass sibling of the single-pass `DraftCrossEntropyLossFn`, which stays the `ttt_steps == 1` loss (including the packed layout) — does per-pass slicing (pass d predicts x_{i+d+1}), per-pass alphas, and per-pass global valid-count normalization (DP-only all-reduce).
- **Draft-only optimizer group**: optional `draft.{lr,min_lr,weight_decay}` param group with resume-safe param-group identity keys.
- **vLLM refit safety**: un-share the drafter lm_head before loading a trained head (vLLM's share-on-identical-weights alias would let the draft refit silently overwrite the serving target's head); fail loudly when draft weights arrive but no drafter is reachable.

EAGLE-3 runs on the currently pinned vLLM. Smoke-tested on a Qwen3-8B GRPO math recipe.

A suspected TP grad all-reduce gap on the (unexercised) split-API train-step path was found during this work; it is tracked separately with its regression test in #3716 rather than bundled here.

# Evaluation verification
 - Model: Qwen3-8B
 - Benchmark: AIME24
 - Purple line: Eagle3 pretrained by AngelSlim/Qwen3-8B_eagle3
 - Pink line: Eagle3 w/ ttt=3, trained from random initialization
 - Blue line: no speculative decoding
<img width="1345" height="633" alt="image" src="https://github.com/user-attachments/assets/37ea3dab-b22d-4976-9d7f-11a98ca906be" />


Perf:
<img width="1350" height="633" alt="image" src="https://github.com/user-attachments/assets/5a607439-669a-437c-a76c-6d2f45487a4d" />


