### PR TITLE
fix(nemo-gym): honour pad_dynamic_image_shapes on the dedup prompt path

### DIFF
--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -30,6 +30,7 @@ from transformers import PreTrainedTokenizerBase
 from nemo_rl.algorithms.grpo import (
     AsyncGRPOConfig,
     GRPOConfig,
+    get_pad_dynamic_image_shapes,
 )
 from nemo_rl.algorithms.grpo import (
     MasterConfig as GRPOMasterConfig,
@@ -520,7 +521,11 @@ class AsyncTrajectoryCollector:
                 self._stamp_nemo_gym_task_indices(rollout_batch)
                 if self._deduplicate_multimodal_data:
                     attach_initial_nemo_gym_image_payloads(
-                        rollout_batch, self.processor
+                        rollout_batch,
+                        self.processor,
+                        pad_dynamic_image_shapes=get_pad_dynamic_image_shapes(
+                            self.master_config
+                        ),
                     )
             repeated_batch = rollout_batch.repeat_interleave(
                 num_generations,

--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -30,7 +30,6 @@ from transformers import PreTrainedTokenizerBase
 from nemo_rl.algorithms.grpo import (
     AsyncGRPOConfig,
     GRPOConfig,
-    get_pad_dynamic_image_shapes,
 )
 from nemo_rl.algorithms.grpo import (
     MasterConfig as GRPOMasterConfig,
@@ -48,7 +47,10 @@ from nemo_rl.data.interfaces import DatumSpec
 from nemo_rl.data.multimodal_utils import PackedTensor
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.environments.interfaces import EnvironmentInterface
-from nemo_rl.environments.nemo_gym import should_use_nemo_gym
+from nemo_rl.environments.nemo_gym import (
+    get_pad_dynamic_image_shapes,
+    should_use_nemo_gym,
+)
 from nemo_rl.experience.interfaces import (
     NEMO_GYM_TASK_INDEX_KEY,
     NEXT_NEMO_GYM_TASK_INDEX_KEY,
@@ -524,7 +526,7 @@ class AsyncTrajectoryCollector:
                         rollout_batch,
                         self.processor,
                         pad_dynamic_image_shapes=get_pad_dynamic_image_shapes(
-                            self.master_config
+                            self.master_config.env
                         ),
                     )
             repeated_batch = rollout_batch.repeat_interleave(

--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -47,10 +47,7 @@ from nemo_rl.data.interfaces import DatumSpec
 from nemo_rl.data.multimodal_utils import PackedTensor
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from nemo_rl.environments.interfaces import EnvironmentInterface
-from nemo_rl.environments.nemo_gym import (
-    get_pad_dynamic_image_shapes,
-    should_use_nemo_gym,
-)
+from nemo_rl.environments.nemo_gym import should_use_nemo_gym
 from nemo_rl.experience.interfaces import (
     NEMO_GYM_TASK_INDEX_KEY,
     NEXT_NEMO_GYM_TASK_INDEX_KEY,
@@ -525,9 +522,7 @@ class AsyncTrajectoryCollector:
                     attach_initial_nemo_gym_image_payloads(
                         rollout_batch,
                         self.processor,
-                        pad_dynamic_image_shapes=get_pad_dynamic_image_shapes(
-                            self.master_config.env
-                        ),
+                        env_config=self.master_config.env,
                     )
             repeated_batch = rollout_batch.repeat_interleave(
                 num_generations,

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -85,7 +85,11 @@ from nemo_rl.distributed.virtual_cluster import (
     prepare_segment_topology,
 )
 from nemo_rl.environments.interfaces import EnvironmentInterface
-from nemo_rl.environments.nemo_gym import should_use_nemo_gym, spinup_nemo_gym_actor
+from nemo_rl.environments.nemo_gym import (
+    get_pad_dynamic_image_shapes,
+    should_use_nemo_gym,
+    spinup_nemo_gym_actor,
+)
 from nemo_rl.experience.interfaces import (
     NEXT_NEMO_GYM_TASK_INDEX_KEY,
 )
@@ -2224,19 +2228,6 @@ def _get_effort_config(master_config: MasterConfig) -> Optional[EffortLevelsConf
     return EffortLevelsConfig.model_validate(effort_dict)
 
 
-def get_pad_dynamic_image_shapes(master_config: MasterConfig) -> bool:
-    """Return env.nemo_gym's pad_dynamic_image_shapes, defaulting to off.
-
-    The NeMo-Gym actor reads this from its own config for the per-turn attach.
-    The initial-payload attach runs in the driver instead, so it has to be read
-    here and passed down, or multi-image prompts would be processed under
-    different rules on the two paths.
-    """
-    if "nemo_gym" not in master_config.env:
-        return False
-    return bool(master_config.env["nemo_gym"].get("pad_dynamic_image_shapes"))
-
-
 def _pad_teacher_logprobs(teacher_logprobs: torch.Tensor, train_S: int) -> torch.Tensor:
     """Right-zero-pad teacher logprobs ``[B, teacher_S]`` to ``train_S``.
 
@@ -2858,7 +2849,7 @@ def grpo_train(
                             batch,
                             processor,
                             pad_dynamic_image_shapes=get_pad_dynamic_image_shapes(
-                                master_config
+                                master_config.env
                             ),
                         )
                     # Repeat batch items
@@ -3888,7 +3879,7 @@ def validate(
                         val_batch,
                         processor,
                         pad_dynamic_image_shapes=get_pad_dynamic_image_shapes(
-                            master_config
+                            master_config.env
                         ),
                     )
                 generation_config = master_config.policy["generation"]

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -2224,6 +2224,19 @@ def _get_effort_config(master_config: MasterConfig) -> Optional[EffortLevelsConf
     return EffortLevelsConfig.model_validate(effort_dict)
 
 
+def get_pad_dynamic_image_shapes(master_config: MasterConfig) -> bool:
+    """Return env.nemo_gym's pad_dynamic_image_shapes, defaulting to off.
+
+    The NeMo-Gym actor reads this from its own config for the per-turn attach.
+    The initial-payload attach runs in the driver instead, so it has to be read
+    here and passed down, or multi-image prompts would be processed under
+    different rules on the two paths.
+    """
+    if "nemo_gym" not in master_config.env:
+        return False
+    return bool(master_config.env["nemo_gym"].get("pad_dynamic_image_shapes"))
+
+
 def _pad_teacher_logprobs(teacher_logprobs: torch.Tensor, train_S: int) -> torch.Tensor:
     """Right-zero-pad teacher logprobs ``[B, teacher_S]`` to ``train_S``.
 
@@ -2841,7 +2854,13 @@ def grpo_train(
                         master_config.grpo.deduplicate_multimodal_data
                         and should_use_nemo_gym(master_config)
                     ):
-                        attach_initial_nemo_gym_image_payloads(batch, processor)
+                        attach_initial_nemo_gym_image_payloads(
+                            batch,
+                            processor,
+                            pad_dynamic_image_shapes=get_pad_dynamic_image_shapes(
+                                master_config
+                            ),
+                        )
                     # Repeat batch items
                     repeated_batch: BatchedDataDict[DatumSpec] = (
                         batch.repeat_interleave(
@@ -3865,7 +3884,13 @@ def validate(
             # We cascade NeMo-Gym first since NeMo-Gym also uses async rollouts.
             if should_use_nemo_gym(master_config):
                 if master_config.grpo.deduplicate_multimodal_data:
-                    attach_initial_nemo_gym_image_payloads(val_batch, processor)
+                    attach_initial_nemo_gym_image_payloads(
+                        val_batch,
+                        processor,
+                        pad_dynamic_image_shapes=get_pad_dynamic_image_shapes(
+                            master_config
+                        ),
+                    )
                 generation_config = master_config.policy["generation"]
                 # Validation-only sampling (e.g. near-greedy validation);
                 # defaults to the train profile via the exemplar YAML

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -85,11 +85,7 @@ from nemo_rl.distributed.virtual_cluster import (
     prepare_segment_topology,
 )
 from nemo_rl.environments.interfaces import EnvironmentInterface
-from nemo_rl.environments.nemo_gym import (
-    get_pad_dynamic_image_shapes,
-    should_use_nemo_gym,
-    spinup_nemo_gym_actor,
-)
+from nemo_rl.environments.nemo_gym import should_use_nemo_gym, spinup_nemo_gym_actor
 from nemo_rl.experience.interfaces import (
     NEXT_NEMO_GYM_TASK_INDEX_KEY,
 )
@@ -2848,9 +2844,7 @@ def grpo_train(
                         attach_initial_nemo_gym_image_payloads(
                             batch,
                             processor,
-                            pad_dynamic_image_shapes=get_pad_dynamic_image_shapes(
-                                master_config.env
-                            ),
+                            env_config=master_config.env,
                         )
                     # Repeat batch items
                     repeated_batch: BatchedDataDict[DatumSpec] = (
@@ -3878,9 +3872,7 @@ def validate(
                     attach_initial_nemo_gym_image_payloads(
                         val_batch,
                         processor,
-                        pad_dynamic_image_shapes=get_pad_dynamic_image_shapes(
-                            master_config.env
-                        ),
+                        env_config=master_config.env,
                     )
                 generation_config = master_config.policy["generation"]
                 # Validation-only sampling (e.g. near-greedy validation);

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -16,7 +16,7 @@ import os
 import subprocess
 import sys
 from collections import Counter
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Mapping
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, Dict, List, NotRequired, Optional, Protocol, TypedDict
@@ -297,6 +297,24 @@ def _looks_like_image_src(src: str) -> bool:
     which treats it as a filesystem path and raises ``FileNotFoundError``.
     """
     return src.startswith(_IMAGE_SRC_PREFIXES)
+
+
+def get_pad_dynamic_image_shapes(env_config: Mapping[str, Any]) -> bool:
+    """Return nemo_gym's pad_dynamic_image_shapes from an env config, or False.
+
+    Takes ``master_config.env`` rather than the whole config: interpreting
+    NeMo-Gym settings belongs with the environment, and callers outside it only
+    need the resolved boolean.
+
+    The NemoGym actor reads the same key from its own config for the per-turn
+    attach. The initial-payload attach runs in the driver instead, so it has to
+    be read here and passed down, or multi-image prompts would be processed
+    under different rules on the two paths.
+    """
+    nemo_gym_config = env_config.get("nemo_gym") if env_config else None
+    if not nemo_gym_config:
+        return False
+    return bool(nemo_gym_config.get("pad_dynamic_image_shapes"))
 
 
 def _extract_input_images_from_message(item: dict) -> list[Image.Image]:

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -77,6 +77,8 @@ TokenizerType = PreTrainedTokenizerBase
 def attach_initial_nemo_gym_image_payloads(
     batch: BatchedDataDict[DatumSpec],
     processor: Any,
+    *,
+    pad_dynamic_image_shapes: bool = False,
 ) -> None:
     """Attach initial Gym image tensors once, before prompt repeat.
 
@@ -85,6 +87,11 @@ def attach_initial_nemo_gym_image_payloads(
     prompt batch, allowing ``repeat_interleave(..., share_immutable_media=True)``
     to retain one physical processor output per prompt. Flag-off runs never call
     this helper.
+
+    ``pad_dynamic_image_shapes`` mirrors the per-turn attach inside the NeMo-Gym
+    actor. It only matters for a turn carrying more than one image at differing
+    resolutions, where the processor returns a ragged CHW list; without it the
+    processor is asked to stack those and raises before the shapes are read.
     """
     for message_log, extra_env_info in zip(
         batch["message_log"], batch["extra_env_info"]
@@ -114,6 +121,7 @@ def attach_initial_nemo_gym_image_payloads(
             user_message,
             images=images,
             processor=processor,
+            pad_dynamic_image_shapes=pad_dynamic_image_shapes,
         )
 
 

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -21,7 +21,7 @@ import json
 import statistics
 import warnings
 from collections import defaultdict
-from collections.abc import AsyncGenerator, Sequence
+from collections.abc import AsyncGenerator, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -54,7 +54,10 @@ from nemo_rl.environments.interfaces import (
     EnvironmentInterface,
     EnvironmentReturn,
 )
-from nemo_rl.environments.nemo_gym import DEFAULT_THINKING_TAGS
+from nemo_rl.environments.nemo_gym import (
+    DEFAULT_THINKING_TAGS,
+    get_pad_dynamic_image_shapes,
+)
 from nemo_rl.experience.interfaces import NEMO_GYM_TASK_INDEX_KEY
 from nemo_rl.experience.metric_utils import calculate_single_metric, pct
 from nemo_rl.models.generation.interfaces import (
@@ -78,7 +81,7 @@ def attach_initial_nemo_gym_image_payloads(
     batch: BatchedDataDict[DatumSpec],
     processor: Any,
     *,
-    pad_dynamic_image_shapes: bool = False,
+    env_config: Mapping[str, Any],
 ) -> None:
     """Attach initial Gym image tensors once, before prompt repeat.
 
@@ -88,11 +91,16 @@ def attach_initial_nemo_gym_image_payloads(
     to retain one physical processor output per prompt. Flag-off runs never call
     this helper.
 
-    ``pad_dynamic_image_shapes`` mirrors the per-turn attach inside the NeMo-Gym
-    actor. It only matters for a turn carrying more than one image at differing
-    resolutions, where the processor returns a ragged CHW list; without it the
-    processor is asked to stack those and raises before the shapes are read.
+    Takes ``master_config.env`` and resolves ``pad_dynamic_image_shapes``
+    itself, mirroring the per-turn attach inside the NeMo-Gym actor. Resolving
+    here rather than at each call site means a caller cannot supply the wrong
+    value -- the divergence between the two attach paths that this helper
+    previously had. The flag only matters for a turn carrying more than one
+    image at differing resolutions, where the processor returns a ragged CHW
+    list; without it the processor is asked to stack those and raises before
+    the shapes are read.
     """
+    pad_dynamic_image_shapes = get_pad_dynamic_image_shapes(env_config)
     for message_log, extra_env_info in zip(
         batch["message_log"], batch["extra_env_info"]
     ):

--- a/tests/unit/experience/test_initial_gym_image_payload_shapes.py
+++ b/tests/unit/experience/test_initial_gym_image_payload_shapes.py
@@ -143,3 +143,32 @@ def test_with_the_flag_the_prompt_is_padded_and_keeps_its_true_sizes():
     # The true per-image extents survive the pad: (height, width). Read off the
     # unpadded tiles, so the smaller image still reports 3x2 rather than 5x4.
     assert user_message["imgs_sizes"].as_tensor().tolist() == [[3, 2], [5, 4]]
+
+
+# --------------------------------------------------------------------------
+# reading the flag out of the config
+# --------------------------------------------------------------------------
+
+
+class _Config:
+    def __init__(self, env):
+        self.env = env
+
+
+def test_flag_is_read_from_the_nemo_gym_env_config():
+    from nemo_rl.algorithms.grpo import get_pad_dynamic_image_shapes
+
+    assert (
+        get_pad_dynamic_image_shapes(
+            _Config({"nemo_gym": {"pad_dynamic_image_shapes": True}})
+        )
+        is True
+    )
+
+
+def test_flag_defaults_off_when_unset_or_absent():
+    """A run without NeMo-Gym must not fabricate a value for it."""
+    from nemo_rl.algorithms.grpo import get_pad_dynamic_image_shapes
+
+    assert get_pad_dynamic_image_shapes(_Config({"nemo_gym": {}})) is False
+    assert get_pad_dynamic_image_shapes(_Config({})) is False

--- a/tests/unit/experience/test_initial_gym_image_payload_shapes.py
+++ b/tests/unit/experience/test_initial_gym_image_payload_shapes.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The initial Gym payload must honour pad_dynamic_image_shapes.
+
+This path only runs when ``grpo.deduplicate_multimodal_data`` is true: the
+driver attaches the prompt's image tensors once, before
+``repeat_interleave(..., share_immutable_media=True)`` fans the prompt out. The
+per-turn attach inside the NeMo-Gym actor already reads the flag, so without it
+here the same prompt is processed under different rules on the two paths.
+
+It bites only for a prompt carrying more than one image at differing
+resolutions, which is exactly what a dynamic-resolution processor returns as a
+ragged CHW list.
+"""
+
+import pytest
+import torch
+from PIL import Image
+
+import nemo_rl.experience.rollouts as rollouts_mod
+from nemo_rl.data.multimodal_utils import image_to_data_url
+from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+
+
+class NemotronNanoVLV2Processor:
+    """Stand-in for a processor that emits per-image resolutions.
+
+    The name matters: ``uses_image_placeholder`` dispatches on the class name,
+    so this exercises the same branch the real processor does.
+    """
+
+    image_token = "<image>"
+    # The extractor unions these to decide which keys are model inputs.
+    model_input_names = ["input_ids"]
+
+    class _ImageProcessor:
+        model_input_names = ["pixel_values", "imgs_sizes"]
+
+    class _Tokenizer:
+        # Subtracted from the union, leaving the media keys.
+        model_input_names = ["input_ids"]
+
+    image_processor = _ImageProcessor()
+    tokenizer = _Tokenizer()
+
+    def __call__(self, *, text, images, return_tensors):
+        tiles = [
+            torch.zeros(3, image.height, image.width, dtype=torch.float32)
+            for image in images
+        ]
+        # One placeholder token per image, as the real processors emit.
+        token_ids = [0] * len(images)
+        if return_tensors == "pt":
+            # What a real processor does for "pt": stack into one tensor. Images
+            # of differing resolutions cannot stack, so this raises -- the
+            # failure pad_dynamic_image_shapes exists to avoid.
+            return {
+                "pixel_values": torch.stack(tiles),
+                "input_ids": torch.tensor([token_ids]),
+            }
+        # return_tensors=None hands everything back as plain lists, including
+        # the ragged per-image pixel values this mode is requested for.
+        return {
+            "pixel_values": [tile.tolist() for tile in tiles],
+            "input_ids": [token_ids],
+        }
+
+
+def _batch_with_two_differently_sized_images() -> BatchedDataDict:
+    urls = [
+        image_to_data_url(Image.new("RGB", (2, 3), color="red")),
+        image_to_data_url(Image.new("RGB", (4, 5), color="blue")),
+    ]
+    return BatchedDataDict(
+        {
+            "message_log": [[{"role": "user", "content": ""}]],
+            "extra_env_info": [
+                {
+                    "responses_create_params": {
+                        "input": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "input_image", "image_url": url}
+                                    for url in urls
+                                ],
+                            }
+                        ]
+                    }
+                }
+            ],
+        }
+    )
+
+
+def test_without_the_flag_a_mixed_resolution_prompt_fails_to_stack():
+    """Documents the gap: the default asks the processor to stack the images.
+
+    This is what the dedup path did before the flag was threaded, because the
+    call site passed neither value and the parameter defaults to off.
+    """
+    batch = _batch_with_two_differently_sized_images()
+
+    with pytest.raises(
+        RuntimeError, match="stack expects each tensor to be equal size"
+    ):
+        rollouts_mod.attach_initial_nemo_gym_image_payloads(
+            batch, NemotronNanoVLV2Processor()
+        )
+
+
+def test_with_the_flag_the_prompt_is_padded_and_keeps_its_true_sizes():
+    """The padded tensor is one shape, but imgs_sizes stays per-image.
+
+    Padding is a batching convenience; the model needs the unpadded extents to
+    crop each image back out, so they must be read before the pad.
+    """
+    batch = _batch_with_two_differently_sized_images()
+
+    rollouts_mod.attach_initial_nemo_gym_image_payloads(
+        batch,
+        NemotronNanoVLV2Processor(),
+        pad_dynamic_image_shapes=True,
+    )
+
+    user_message = batch["message_log"][0][0]
+    pixel_values = user_message["pixel_values"].as_tensor()
+    # Padded up to the larger image, one row per image.
+    assert pixel_values.shape[0] == 2
+    assert pixel_values.shape[-2:] == torch.Size([5, 4])
+    # The true per-image extents survive the pad: (height, width). Read off the
+    # unpadded tiles, so the smaller image still reports 3x2 rather than 5x4.
+    assert user_message["imgs_sizes"].as_tensor().tolist() == [[3, 2], [5, 4]]

--- a/tests/unit/experience/test_initial_gym_image_payload_shapes.py
+++ b/tests/unit/experience/test_initial_gym_image_payload_shapes.py
@@ -56,25 +56,44 @@ class NemotronNanoVLV2Processor:
     image_processor = _ImageProcessor()
     tokenizer = _Tokenizer()
 
+    def __init__(self):
+        # Records what the caller asked for, so a test can assert the choice
+        # directly instead of inferring it from an exception type.
+        self.return_tensors_seen = []
+
     def __call__(self, *, text, images, return_tensors):
+        self.return_tensors_seen.append(return_tensors)
         tiles = [
             torch.zeros(3, image.height, image.width, dtype=torch.float32)
             for image in images
         ]
         # One placeholder token per image, as the real processors emit.
         token_ids = [0] * len(images)
-        if return_tensors == "pt":
-            # What a real processor does for "pt": stack into one tensor. Images
-            # of differing resolutions cannot stack, so this raises -- the
-            # failure pad_dynamic_image_shapes exists to avoid.
+        # The real image processor always reports per-image extents, so the
+        # derive-them-here fallback in _stack_ragged_pixel_values is dead in
+        # production. Emit them, so this exercises the branch production takes.
+        imgs_sizes = [[tile.shape[-2], tile.shape[-1]] for tile in tiles]
+        all_same_shape = len({tuple(size) for size in imgs_sizes}) == 1
+        if return_tensors == "pt" and all_same_shape:
+            # BatchFeature converts every key, not just pixel_values.
             return {
                 "pixel_values": torch.stack(tiles),
+                "imgs_sizes": torch.tensor(imgs_sizes, dtype=torch.long),
                 "input_ids": torch.tensor([token_ids]),
             }
-        # return_tensors=None hands everything back as plain lists, including
-        # the ragged per-image pixel values this mode is requested for.
+        if return_tensors == "pt":
+            # What the real processor does: it does NOT stack here. It hands
+            # BatchFeature a ragged list, and transformers re-raises the torch
+            # error as ValueError. Reproducing the real type matters -- a test
+            # expecting RuntimeError would not catch the production failure.
+            raise ValueError(
+                "Unable to convert output 'pixel_values' (type: list) to tensor: "
+                "stack expects each tensor to be equal size, but got "
+                f"{list(tiles[0].shape)} at entry 0 and {list(tiles[1].shape)} at entry 1"
+            )
         return {
             "pixel_values": [tile.tolist() for tile in tiles],
+            "imgs_sizes": imgs_sizes,
             "input_ids": [token_ids],
         }
 
@@ -106,20 +125,87 @@ def _batch_with_two_differently_sized_images() -> BatchedDataDict:
     )
 
 
-def test_without_the_flag_a_mixed_resolution_prompt_fails_to_stack():
-    """Documents the gap: the default asks the processor to stack the images.
+def test_without_the_flag_a_mixed_resolution_prompt_is_asked_to_stack():
+    """Documents the gap: the flag off asks the processor for stacked tensors.
 
     This is what the dedup path did before the flag was threaded, because the
-    call site passed neither value and the parameter defaults to off.
+    call site passed nothing and the parameter defaulted to off.
+
+    The assertion is on the ``return_tensors`` the processor was handed, not on
+    the exception: production raises ``ValueError`` from ``BatchFeature``, with
+    the torch ``RuntimeError`` only as ``__cause__``, so matching on the torch
+    message would pass against a fake while missing the real failure.
     """
     batch = _batch_with_two_differently_sized_images()
+    processor = NemotronNanoVLV2Processor()
 
-    with pytest.raises(
-        RuntimeError, match="stack expects each tensor to be equal size"
-    ):
+    with pytest.raises(ValueError, match="Unable to convert output"):
         rollouts_mod.attach_initial_nemo_gym_image_payloads(
-            batch, NemotronNanoVLV2Processor()
+            batch, processor, env_config={}
         )
+
+    assert processor.return_tensors_seen == ["pt"]
+
+
+def test_with_the_flag_the_processor_is_asked_for_ragged_output():
+    """The flag-on multi-image case must request return_tensors=None."""
+    batch = _batch_with_two_differently_sized_images()
+    processor = NemotronNanoVLV2Processor()
+
+    rollouts_mod.attach_initial_nemo_gym_image_payloads(
+        batch,
+        processor,
+        env_config={"nemo_gym": {"pad_dynamic_image_shapes": True}},
+    )
+
+    assert processor.return_tensors_seen == [None]
+
+
+def test_equal_resolution_multi_image_is_unchanged_by_the_flag():
+    """Turning the flag on must not perturb the homogeneous case.
+
+    Multi-image prompts at one resolution are the common shape; the ragged
+    branch keys on image *count*, not on the resolutions differing, so they
+    change code path when the flag flips. The payload must not change with it.
+    """
+
+    def _payload(env_config):
+        batch = BatchedDataDict(
+            {
+                "message_log": [[{"role": "user", "content": ""}]],
+                "extra_env_info": [
+                    {
+                        "responses_create_params": {
+                            "input": [
+                                {
+                                    "role": "user",
+                                    "content": [
+                                        {
+                                            "type": "input_image",
+                                            "image_url": image_to_data_url(
+                                                Image.new("RGB", (4, 4), color=colour)
+                                            ),
+                                        }
+                                        for colour in ("red", "blue")
+                                    ],
+                                }
+                            ]
+                        }
+                    }
+                ],
+            }
+        )
+        rollouts_mod.attach_initial_nemo_gym_image_payloads(
+            batch, NemotronNanoVLV2Processor(), env_config=env_config
+        )
+        return batch["message_log"][0][0]
+
+    off = _payload({})
+    on = _payload({"nemo_gym": {"pad_dynamic_image_shapes": True}})
+
+    assert off.keys() == on.keys()
+    for key in ("pixel_values", "imgs_sizes"):
+        assert torch.equal(off[key].as_tensor(), on[key].as_tensor()), key
 
 
 def test_with_the_flag_the_prompt_is_padded_and_keeps_its_true_sizes():
@@ -133,7 +219,7 @@ def test_with_the_flag_the_prompt_is_padded_and_keeps_its_true_sizes():
     rollouts_mod.attach_initial_nemo_gym_image_payloads(
         batch,
         NemotronNanoVLV2Processor(),
-        pad_dynamic_image_shapes=True,
+        env_config={"nemo_gym": {"pad_dynamic_image_shapes": True}},
     )
 
     user_message = batch["message_log"][0][0]
@@ -163,3 +249,44 @@ def test_flag_defaults_off_when_unset_or_absent():
     assert get_pad_dynamic_image_shapes({"nemo_gym": {}}) is False
     assert get_pad_dynamic_image_shapes({}) is False
     assert get_pad_dynamic_image_shapes({"nemo_gym": None}) is False
+    # The value a user writes to turn a recipe's `true` back off.
+    assert (
+        get_pad_dynamic_image_shapes({"nemo_gym": {"pad_dynamic_image_shapes": False}})
+        is False
+    )
+
+
+# --------------------------------------------------------------------------
+# the wiring: the flag must survive the trip from the config to the processor
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "env_config, expected_return_tensors",
+    [
+        ({"nemo_gym": {"pad_dynamic_image_shapes": True}}, None),
+        ({"nemo_gym": {"pad_dynamic_image_shapes": False}}, "pt"),
+        ({}, "pt"),
+    ],
+)
+def test_env_config_reaches_the_processor(env_config, expected_return_tensors):
+    """The helper resolves the flag from env config, not from a caller literal.
+
+    This is the regression the fix addresses: the call sites previously passed
+    nothing, so the prompt was processed under the wrong rules. Resolving inside
+    the helper means there is no per-call-site value left to get wrong.
+    """
+    batch = _batch_with_two_differently_sized_images()
+    processor = NemotronNanoVLV2Processor()
+
+    if expected_return_tensors == "pt":
+        with pytest.raises(ValueError, match="Unable to convert output"):
+            rollouts_mod.attach_initial_nemo_gym_image_payloads(
+                batch, processor, env_config=env_config
+            )
+    else:
+        rollouts_mod.attach_initial_nemo_gym_image_payloads(
+            batch, processor, env_config=env_config
+        )
+
+    assert processor.return_tensors_seen == [expected_return_tensors]

--- a/tests/unit/experience/test_initial_gym_image_payload_shapes.py
+++ b/tests/unit/experience/test_initial_gym_image_payload_shapes.py
@@ -32,6 +32,7 @@ from PIL import Image
 import nemo_rl.experience.rollouts as rollouts_mod
 from nemo_rl.data.multimodal_utils import image_to_data_url
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
+from nemo_rl.environments.nemo_gym import get_pad_dynamic_image_shapes
 
 
 class NemotronNanoVLV2Processor:
@@ -150,25 +151,15 @@ def test_with_the_flag_the_prompt_is_padded_and_keeps_its_true_sizes():
 # --------------------------------------------------------------------------
 
 
-class _Config:
-    def __init__(self, env):
-        self.env = env
-
-
 def test_flag_is_read_from_the_nemo_gym_env_config():
-    from nemo_rl.algorithms.grpo import get_pad_dynamic_image_shapes
-
     assert (
-        get_pad_dynamic_image_shapes(
-            _Config({"nemo_gym": {"pad_dynamic_image_shapes": True}})
-        )
+        get_pad_dynamic_image_shapes({"nemo_gym": {"pad_dynamic_image_shapes": True}})
         is True
     )
 
 
 def test_flag_defaults_off_when_unset_or_absent():
     """A run without NeMo-Gym must not fabricate a value for it."""
-    from nemo_rl.algorithms.grpo import get_pad_dynamic_image_shapes
-
-    assert get_pad_dynamic_image_shapes(_Config({"nemo_gym": {}})) is False
-    assert get_pad_dynamic_image_shapes(_Config({})) is False
+    assert get_pad_dynamic_image_shapes({"nemo_gym": {}}) is False
+    assert get_pad_dynamic_image_shapes({}) is False
+    assert get_pad_dynamic_image_shapes({"nemo_gym": None}) is False

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -116,20 +116,21 @@ def test_attach_initial_nemo_gym_image_payloads_attaches_once(monkeypatch):
     calls = []
 
     def fake_attach(message, *, images, processor, pad_dynamic_image_shapes=False):
-        calls.append((message, images, processor))
+        calls.append((message, images, processor, pad_dynamic_image_shapes))
         message["pixel_values"] = attached
 
     monkeypatch.setattr(
         rollouts_mod, "attach_image_model_inputs_to_message", fake_attach
     )
 
-    rollouts_mod.attach_initial_nemo_gym_image_payloads(batch, processor)
-    rollouts_mod.attach_initial_nemo_gym_image_payloads(batch, processor)
+    rollouts_mod.attach_initial_nemo_gym_image_payloads(batch, processor, env_config={})
+    rollouts_mod.attach_initial_nemo_gym_image_payloads(batch, processor, env_config={})
 
     assert len(calls) == 1
     assert calls[0][0] is batch["message_log"][0][0]
     assert calls[0][1][0].size == (2, 3)
     assert calls[0][2] is processor
+    assert calls[0][3] is False
     assert batch["message_log"][0][0]["pixel_values"] is attached
 
 
@@ -140,7 +141,7 @@ def test_attach_initial_nemo_gym_image_payloads_requires_processor():
         ValueError,
         match="requires the multimodal processor",
     ):
-        rollouts_mod.attach_initial_nemo_gym_image_payloads(batch, None)
+        rollouts_mod.attach_initial_nemo_gym_image_payloads(batch, None, env_config={})
 
 
 def test_attach_initial_nemo_gym_image_payloads_requires_a_user_message():
@@ -155,7 +156,9 @@ def test_attach_initial_nemo_gym_image_payloads_requires_a_user_message():
         ValueError,
         match="no user message to attach to",
     ):
-        rollouts_mod.attach_initial_nemo_gym_image_payloads(batch, _Processor())
+        rollouts_mod.attach_initial_nemo_gym_image_payloads(
+            batch, _Processor(), env_config={}
+        )
 
 
 def test_attach_image_model_inputs_keeps_rollout_tokens_and_packs_media():

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -115,7 +115,7 @@ def test_attach_initial_nemo_gym_image_payloads_attaches_once(monkeypatch):
     processor = _Processor()
     calls = []
 
-    def fake_attach(message, *, images, processor):
+    def fake_attach(message, *, images, processor, pad_dynamic_image_shapes=False):
         calls.append((message, images, processor))
         message["pixel_values"] = attached
 


### PR DESCRIPTION
## What

A NeMo-Gym prompt's images are attached in one of two places, and only one of
them read `pad_dynamic_image_shapes`:

| `deduplicate_multimodal_data` | attach site | flag honoured |
|---|---|---|
| off (default) | `nemo_gym.py` — env actor, per turn | yes |
| **on** | `rollouts.py` — driver, once before `repeat_interleave` | **no** |

The dedup call site passed neither value, so the parameter took its default of
`False`. This threads it from `env.nemo_gym` at all three call sites through one
accessor, so both paths process the same prompt under the same rules.

## Why it breaks

The flag decides whether the processor is asked for stacked tensors
(`return_tensors="pt"`) or a ragged CHW list. A prompt carrying **more than one
image at differing resolutions** cannot be stacked — which is exactly what a
dynamic-resolution processor produces, and exactly what the flag exists to
handle.

So the same prompt trained fine with dedup off and raised with it on.

## Evidence

**Cluster A/B** — 16 nodes, Super Omni, `++grpo.deduplicate_multimodal_data=true`,
identical dataset of multi-image prompts at mixed resolutions (multi-image rows
are ~1.3% of the blend, so the dataset was filtered to them; a random sample
would not reach this path).

| arm | job | Slurm | outcome |
|---|---|---|---|
| without fix | 1716862 | **FAILED** (8m17s) | 24 stack errors, never reached step 1 |
| with fix | 1716888 | **COMPLETED** (13m54s) | Step 1/1, rollouts 100%, 0 stack errors |

Failure from the unfixed arm, raised inside `AsyncTrajectoryCollector`:

```
    return torch.stack(value)
RuntimeError: stack expects each tensor to be equal size,
              but got [3, 576, 576] at entry 0 and [3, 512, 576] at entry 1
```

Real dimensions from the blend — two 576-wide images differing in height.

**Local, same config both ways** (`pad_dynamic_image_shapes = True` read from
`env.nemo_gym` in both; only the call site differs):

```
with fix    -> attached OK, imgs_sizes=[[3, 2], [5, 4]]
without fix -> RuntimeError: stack expects each tensor to be equal size
```

## Scope

Opt-in only: `deduplicate_multimodal_data` defaults to `False`, and the helper's
docstring already noted *"Flag-off runs never call this helper."* It needs dedup
on **and** a multi-image prompt **and** differing resolutions, which is why it
has gone unnoticed.

## Tests

`tests/unit/experience/test_initial_gym_image_payload_shapes.py`:

- the default raises on a mixed-resolution prompt — documents the gap
- with the flag, the batch is padded **and** `imgs_sizes` keeps the true
  per-image extents (`[[3,2],[5,4]]`, not the padded `[5,4]` twice), which the
  model needs to crop each image back out

One existing test changed: `fake_attach` in `test_rollouts.py` gains the new
keyword, forced by the signature change.
