### PR TITLE
feat(sc): log setup milestones

### DIFF
--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from functools import partial
 from pathlib import Path
 from typing import Any, Callable, Optional, cast
@@ -92,6 +93,12 @@ from nemo_rl.models.megatron.router_replay import (
 from nemo_rl.models.policy.tq_policy import TQPolicy
 from nemo_rl.utils.checkpoint import CheckpointManager
 from nemo_rl.weight_sync import WeightSynchronizer, create_weight_synchronizer
+
+
+def _print_setup_milestone(milestone: str) -> None:
+    """Print a timestamped SingleController setup milestone immediately."""
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    print(f"[{timestamp}] SingleController setup: {milestone}", flush=True)
 
 
 @dataclass
@@ -514,6 +521,7 @@ def setup_single_controller(
         A tuple of (pre-built SC actor args, driver-side per-phase timings
         logged by the SC actor).
     """
+    _print_setup_milestone("started")
     validate_single_controller_config(master_config)
 
     # short names for config sections
@@ -599,6 +607,7 @@ def setup_single_controller(
 
     _clamp_max_num_steps(master_config, dataloader)
     _maybe_inject_megatron_train_iters(master_config)
+    _print_setup_milestone("Dataset & Environments setup complete")
 
     # ==========================
     # Setup Clusters & Workers
@@ -750,12 +759,14 @@ def setup_single_controller(
     # Attach fleet health before any rollout runs, so the very first request is
     # already health-aware.
     fleet_monitor = _maybe_attach_fleet_health(generation, master_config)
+    _print_setup_milestone("Clusters & Workers setup complete")
 
     # ==========================
     # Setup Data Plane Client & Weight Sync
     # ==========================
     # Connect-only DP client; TQPolicy already bootstrapped the controller.
     dp_client = build_data_plane_client(dp_config, bootstrap=False)
+    _print_setup_milestone("data plane client built")
 
     t0 = time.perf_counter()
     weight_synchronizer = create_weight_synchronizer(
@@ -768,6 +779,7 @@ def setup_single_controller(
         refit_buffer_size_gb=policy_config.get("refit_buffer_size_gb"),
     )
     weight_synchronizer.init_communicator()
+    _print_setup_milestone("weight synchronizer communicator initialized")
     setup_timing_metrics.collective_init_time_s = time.perf_counter() - t0
 
     # ==========================
@@ -776,6 +788,7 @@ def setup_single_controller(
     advantage_estimator = _create_advantage_estimator(
         cast(GrpoMasterConfig, master_config)
     )
+    _print_setup_milestone("advantage estimator created")
     loss_fn: LossFunction = ClippedPGLossFn(master_config.loss_fn)
 
     pad_id = int(getattr(tokenizer, "pad_token_id", 0) or 0)
@@ -785,6 +798,7 @@ def setup_single_controller(
         pad_value_dict={"token_ids": pad_id, "input_ids": pad_id},
         require_routed_experts=router_replay_enabled(policy_config),
     )
+    _print_setup_milestone("TQReplayBuffer created")
     rollout_manager = RolloutManager(
         tokenizer=tokenizer,
         task_to_env=env_handles,
@@ -803,6 +817,7 @@ def setup_single_controller(
         ),
         retry_policy=_build_retry_policy(master_config),
     )
+    _print_setup_milestone("RolloutManager created")
 
     # Print setup timing metrics
     total_setup_time = time.perf_counter() - setup_start_time

--- a/tests/unit/single_controller/test_single_controller_setup.py
+++ b/tests/unit/single_controller/test_single_controller_setup.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -223,6 +224,24 @@ def test_build_clusters_rejects_non_colocated_megatron_generation():
         sc_setup_mod._build_clusters(master_config)
 
 
+def test_print_setup_milestone_has_utc_timestamp_and_flushes():
+    """Milestone output is timestamped in UTC and flushed immediately."""
+    fixed_time = datetime(2026, 8, 18, 12, 34, 56, tzinfo=timezone.utc)
+
+    with (
+        patch.object(sc_setup_mod, "datetime") as mock_datetime,
+        patch("builtins.print") as mock_print,
+    ):
+        mock_datetime.now.return_value = fixed_time
+        sc_setup_mod._print_setup_milestone("started")
+
+    mock_datetime.now.assert_called_once_with(timezone.utc)
+    mock_print.assert_called_once_with(
+        "[2026-08-18T12:34:56Z] SingleController setup: started",
+        flush=True,
+    )
+
+
 class TestSetup:
     """setup arg validation + actor_args assembly."""
 
@@ -339,6 +358,24 @@ class TestSetup:
         assert actor_args.partition_id == "rollout_data"
         assert actor_args.tq_buffer._partition_id == "rollout_data"
         assert actor_args.tq_buffer._require_routed_experts is False
+
+    def test_prints_setup_milestones_in_order(self, patched_factories):
+        """Setup reports each requested milestone in execution order."""
+        mc = _make_master_config(colocated=True)
+
+        with patch.object(sc_setup_mod, "_print_setup_milestone") as mock_print:
+            setup_single_controller(mc, MagicMock(pad_token_id=0))
+
+        assert [call.args[0] for call in mock_print.call_args_list] == [
+            "started",
+            "Dataset & Environments setup complete",
+            "Clusters & Workers setup complete",
+            "data plane client built",
+            "weight synchronizer communicator initialized",
+            "advantage estimator created",
+            "TQReplayBuffer created",
+            "RolloutManager created",
+        ]
 
     def test_router_replay_requires_routes_in_tq_buffer(self, patched_factories):
         mc = _make_master_config(colocated=True)


### PR DESCRIPTION
## Summary

- add a UTC ISO-8601 timestamped `SingleController` setup milestone printer with `flush=True`
- report progress at setup start and after dataset/environment, cluster/worker, data-plane client, weight-sync communicator, advantage estimator, replay buffer, and rollout manager setup
- add focused unit coverage for timestamp/flush behavior and milestone ordering

## Why

SingleController setup can spend a long time constructing distributed workers and communication resources. When one of those operations hangs, the driver currently provides too little information to identify the last completed setup stage. Immediate timestamped milestones make the blocking stage visible in job logs.

## User impact

SingleController users can identify the last completed setup phase from buffered or remote job logs without attaching a debugger.

## Validation

- `uvx --from ruff==0.9.9 ruff check nemo_rl/algorithms/single_controller_utils/setup.py tests/unit/single_controller/test_single_controller_setup.py`
- `uvx --from ruff==0.9.9 ruff format --check nemo_rl/algorithms/single_controller_utils/setup.py tests/unit/single_controller/test_single_controller_setup.py`
- isolated syntax/runtime smoke verification for milestone placement, UTC timestamp format, and `flush=True`

The focused pytest file could not run locally because this repository's uv lock supports Linux x86_64/aarch64 while the development host is macOS; Linux CI will provide the unit-test result.
