### PR TITLE
fix: fix missing tokenizer in unit test

### DIFF
--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -2407,6 +2407,7 @@ def test_setup_initializes_noncolocated_dynamo_with_nemo_gym(monkeypatch) -> Non
         env_configs=master_config.env,
         base_urls=["http://dynamo-wrapper.example/v1"],
         model_name=master_config.policy["model_name"],
+        tokenizer=tokenizer,
         enable_router_replay=False,
         routed_experts_dtype="int16",
         use_fastokens=False,
@@ -2770,13 +2771,15 @@ def test_setup_starts_nemo_gym_for_trtllm(monkeypatch, mock_grpo_components):
 
     dataset = MagicMock()
     dataset.__len__ = MagicMock(return_value=1)
-    result = grpo_mod.setup(master_config, MagicMock(), dataset, None)
+    tokenizer = MagicMock()
+    result = grpo_mod.setup(master_config, tokenizer, dataset, None)
 
     assert result[2] is nemo_gym_actor
     spinup_nemo_gym_actor.assert_called_once_with(
         env_configs=master_config.env,
         base_urls=["http://trtllm.example/v1"],
         model_name="test-model",
+        tokenizer=tokenizer,
         enable_router_replay=False,
         routed_experts_dtype="int16",
         use_fastokens=False,


### PR DESCRIPTION
fix the unit test fail comes from the silent merge conflict of https://github.com/NVIDIA-NeMo/RL/pull/3668 + https://github.com/NVIDIA-NeMo/RL/pull/3391.

validated `test_setup_initializes_noncolocated_dynamo_with_nemo_gym` and `test_setup_starts_nemo_gym_for_trtllm` added in #3391 could pass.