### PR TITLE
fix: merge hf_config_overrides into vllm hf_overrides rather than overwriting

### DIFF
--- a/nemo_rl/algorithms/distillation.py
+++ b/nemo_rl/algorithms/distillation.py
@@ -71,6 +71,7 @@ from nemo_rl.models.generation.interfaces import (
 from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration
 from nemo_rl.models.generation.vllm.config import (
     VLLM_SPARSE_REFIT_TRANSPORTS,
+    merge_hf_overrides,
     normalize_vllm_refit_config,
 )
 from nemo_rl.models.policy import PolicyConfig
@@ -511,8 +512,9 @@ def setup(
         generation_config = cast(VllmConfig, generation_config)
         if "vllm_cfg" in generation_config:
             ## make vllm hf overrides match the training policy
-            generation_config["vllm_kwargs"]["hf_overrides"] = policy_config.get(
-                "hf_config_overrides", {}
+            merge_hf_overrides(
+                generation_config.setdefault("vllm_kwargs", {}),
+                hf_config_overrides=policy_config.get("hf_config_overrides"),
             )
         if enable_nemo_gym:
             deferred_vllm = VllmGeneration(

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -113,6 +113,7 @@ from nemo_rl.models.generation.trtllm import TrtllmConfig, TrtllmGeneration
 from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration
 from nemo_rl.models.generation.vllm.config import (
     VLLM_SPARSE_REFIT_TRANSPORTS,
+    merge_hf_overrides,
     normalize_vllm_refit_config,
 )
 from nemo_rl.models.megatron.router_replay import (
@@ -493,8 +494,9 @@ def setup(
                 "policy.generation.backend='dynamo'; managed Dynamo drains "
                 "rollouts before layerwise weight refit"
             )
-        generation_config.setdefault("vllm_kwargs", {})["hf_overrides"] = (
-            policy_config.get("hf_config_overrides") or {}
+        merge_hf_overrides(
+            generation_config.setdefault("vllm_kwargs", {}),
+            hf_config_overrides=policy_config.get("hf_config_overrides"),
         )
         generation_config = DynamoConfig.model_validate(generation_config).model_dump()
         policy_config["generation"] = generation_config
@@ -1342,7 +1344,9 @@ def setup(
         vllm_kwargs = generation_config.setdefault("vllm_kwargs", {})
 
         ## make vllm hf overrides match the training policy
-        vllm_kwargs["hf_overrides"] = policy_config.get("hf_config_overrides", {})
+        merge_hf_overrides(
+            vllm_kwargs, hf_config_overrides=policy_config.get("hf_config_overrides")
+        )
 
         if enable_nemo_gym:
             # ---- NeMo Gym: reserve vLLM ports up-front so we can hand the

--- a/nemo_rl/algorithms/ppo.py
+++ b/nemo_rl/algorithms/ppo.py
@@ -79,6 +79,7 @@ from nemo_rl.models.generation.sglang.sglang_generation import SGLangGeneration
 from nemo_rl.models.generation.vllm import VllmConfig, VllmGeneration
 from nemo_rl.models.generation.vllm.config import (
     VLLM_SPARSE_REFIT_TRANSPORTS,
+    merge_hf_overrides,
     normalize_vllm_refit_config,
 )
 from nemo_rl.models.policy import MegatronConfig, PolicyConfig
@@ -814,8 +815,9 @@ def setup(
             )
 
         ## make vllm hf overrides match the training policy
-        generation_config["vllm_kwargs"]["hf_overrides"] = policy_config.get(
-            "hf_config_overrides", {}
+        merge_hf_overrides(
+            generation_config.setdefault("vllm_kwargs", {}),
+            hf_config_overrides=policy_config.get("hf_config_overrides"),
         )
 
         policy_generation, policy, value_model = initialize_generation_with_policy(

--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -84,7 +84,7 @@ from nemo_rl.models.generation.interfaces import (
 from nemo_rl.models.generation.sglang.config import SGLangConfig
 from nemo_rl.models.generation.sglang.sglang_generation import SGLangGeneration
 from nemo_rl.models.generation.vllm import VllmGeneration
-from nemo_rl.models.generation.vllm.config import VllmConfig
+from nemo_rl.models.generation.vllm.config import VllmConfig, merge_hf_overrides
 from nemo_rl.models.megatron.router_replay import (
     configure_vllm_for_router_replay,
     router_replay_enabled,
@@ -224,8 +224,9 @@ def _build_generation(
 
     if backend == "vllm":
         vllm_config = cast(VllmConfig, generation_config)
-        vllm_config.setdefault("vllm_kwargs", {})["hf_overrides"] = (
-            master_config.policy.get("hf_config_overrides", {})
+        merge_hf_overrides(
+            vllm_config.setdefault("vllm_kwargs", {}),
+            hf_config_overrides=master_config.policy.get("hf_config_overrides"),
         )
         configure_vllm_for_router_replay(master_config.policy)
         gen = VllmGeneration(

--- a/nemo_rl/models/generation/vllm/config.py
+++ b/nemo_rl/models/generation/vllm/config.py
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+import warnings
 from typing import Annotated, Any, Literal, NotRequired, TypedDict, cast, get_args
 
 from pydantic import BaseModel, Field, NonNegativeInt, PositiveFloat, PositiveInt
 
 from nemo_rl.models.generation.interfaces import GenerationConfig
+
+logger = logging.getLogger(__name__)
 
 VllmRefitTransportName = Literal["s3", "zmq"]
 VllmRefitSelector = Literal["vllm_s3_sparse", "vllm_zmq_sparse", "nixl", "nccl_reshard"]
@@ -210,3 +214,59 @@ def normalize_vllm_refit_config(config: VllmConfig) -> VllmRefitConfig | None:
         VllmCheckpointEnginePluginConfig.model_validate(plugin_config)
     config["refit_cfg"] = refit_config
     return refit_config
+
+
+def merge_hf_overrides(
+    vllm_kwargs: dict[str, Any], *, hf_config_overrides: dict[str, Any] | None
+) -> None:
+    """Merge the training policy's HF config overrides into ``vllm_kwargs`` in place.
+
+    vLLM has to see the same HF config as the training policy, so
+    ``policy.hf_config_overrides`` is propagated to the generation engine. Assigning it
+    wholesale silently discarded a user-supplied
+    ``policy.generation.vllm_kwargs.hf_overrides`` (and reset it to ``{}`` whenever the
+    policy declared no overrides of its own). This is the same overwrite-vs-merge bug
+    that was fixed in the worker; see #1413/#2904.
+
+    The merge is shallow, like ``_merge_fp8_kwargs``. The training policy wins outright on
+    a conflicting top-level key -- a ``rope_scaling`` declared by the policy replaces a
+    generation-side one instead of being merged into it -- so vLLM and the trainer still
+    cannot disagree on anything the policy declares, which is what these call sites exist
+    to guarantee. Only keys the policy leaves unset survive from the generation side.
+
+    Nothing here resolves silently: the merged overrides are logged, and a generation-side
+    value the policy shadows with a different one warns. A callable ``hf_overrides``, which
+    vLLM accepts but which cannot be merged with a mapping, is dropped like the worker
+    already drops a non-dict value -- but with a warning rather than silently.
+    """
+    generation_hf_overrides = vllm_kwargs.get("hf_overrides")
+    if generation_hf_overrides is not None and not isinstance(
+        generation_hf_overrides, dict
+    ):
+        warnings.warn(
+            "policy.generation.vllm_kwargs.hf_overrides is "
+            f"{type(generation_hf_overrides).__name__}, which cannot be merged with "
+            "policy.hf_config_overrides; dropping it.",
+            stacklevel=2,
+        )
+    if not isinstance(generation_hf_overrides, dict):
+        generation_hf_overrides = {}
+    hf_config_overrides = hf_config_overrides or {}
+
+    shadowed = sorted(
+        key
+        for key, value in generation_hf_overrides.items()
+        if key in hf_config_overrides and hf_config_overrides[key] != value
+    )
+    if shadowed:
+        warnings.warn(
+            "policy.hf_config_overrides takes precedence over "
+            f"policy.generation.vllm_kwargs.hf_overrides for {shadowed}, so the "
+            "generation engine sees the same HF config as the training policy.",
+            stacklevel=2,
+        )
+
+    merged = {**generation_hf_overrides, **hf_config_overrides}
+    if merged:
+        logger.info("Generation engine hf_overrides resolved to %s", merged)
+    vllm_kwargs["hf_overrides"] = merged

--- a/tests/unit/models/generation/test_vllm_hf_overrides_merge.py
+++ b/tests/unit/models/generation/test_vllm_hf_overrides_merge.py
@@ -1,0 +1,225 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for propagating hf_config_overrides to the generation engine.
+
+The algorithm entry points push ``policy.hf_config_overrides`` into
+``policy.generation.vllm_kwargs.hf_overrides`` so the generation engine sees the same
+HF config as the training policy. Assigning it wholesale discarded any user-supplied
+``hf_overrides``, which is the same overwrite-vs-merge bug the worker hit in
+#1413/#2904 -- where it was fixed, silently reverted (#2188), and fixed again. The
+source checks below pin the call sites so this one cannot be reverted the same way.
+"""
+
+import ast
+import logging
+import pathlib
+import warnings
+
+import pytest
+
+from nemo_rl.models.generation.vllm.config import merge_hf_overrides
+
+REPO = pathlib.Path(__file__).resolve().parents[4]
+
+ENTRY_POINTS = (
+    "nemo_rl/algorithms/grpo.py",
+    "nemo_rl/algorithms/ppo.py",
+    "nemo_rl/algorithms/distillation.py",
+    "nemo_rl/algorithms/single_controller_utils/setup.py",
+)
+
+# The merge helper itself, and the worker's own fp8 merge and non-dict guard.
+ALLOWED_TO_SET_HF_OVERRIDES = frozenset(
+    {
+        "nemo_rl/models/generation/vllm/config.py",
+        "nemo_rl/models/generation/vllm/vllm_worker.py",
+    }
+)
+
+
+def _lines_setting_hf_overrides(tree: ast.Module) -> list[int]:
+    """Lines that replace ``hf_overrides`` wholesale, by assignment or ``update()``."""
+    lines = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Subscript)
+        and isinstance(target.slice, ast.Constant)
+        and target.slice.value == "hf_overrides"
+    ]
+    lines += [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "update"
+        for arg in [*node.args, *(kw.value for kw in node.keywords)]
+        if isinstance(arg, ast.Dict)
+        and any(
+            isinstance(key, ast.Constant) and key.value == "hf_overrides"
+            for key in arg.keys
+        )
+    ]
+    lines += [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "update"
+        and any(kw.arg == "hf_overrides" for kw in node.keywords)
+    ]
+    return sorted(lines)
+
+
+def test_generation_only_hf_overrides_survive():
+    """A generation-side override is kept when the policy declares none."""
+    vllm_kwargs = {"hf_overrides": {"rope_scaling": {"rope_type": "yarn"}}}
+
+    merge_hf_overrides(vllm_kwargs, hf_config_overrides={})
+
+    assert vllm_kwargs["hf_overrides"] == {"rope_scaling": {"rope_type": "yarn"}}
+
+
+def test_policy_hf_config_overrides_are_propagated():
+    """The training policy's overrides still reach the generation engine."""
+    vllm_kwargs = {}
+
+    merge_hf_overrides(
+        vllm_kwargs, hf_config_overrides={"max_position_embeddings": 8192}
+    )
+
+    assert vllm_kwargs["hf_overrides"] == {"max_position_embeddings": 8192}
+
+
+def test_both_sides_coexist():
+    """Non-conflicting keys from both sides are merged."""
+    vllm_kwargs = {"hf_overrides": {"rope_scaling": {"rope_type": "yarn"}}}
+
+    merge_hf_overrides(
+        vllm_kwargs, hf_config_overrides={"max_position_embeddings": 8192}
+    )
+
+    assert vllm_kwargs["hf_overrides"] == {
+        "rope_scaling": {"rope_type": "yarn"},
+        "max_position_embeddings": 8192,
+    }
+
+
+def test_policy_wins_on_conflict_and_warns():
+    """The policy wins on key collision, loudly, so the configs cannot disagree."""
+    vllm_kwargs = {"hf_overrides": {"max_position_embeddings": 4096}}
+
+    with pytest.warns(UserWarning, match="max_position_embeddings"):
+        merge_hf_overrides(
+            vllm_kwargs, hf_config_overrides={"max_position_embeddings": 8192}
+        )
+
+    assert vllm_kwargs["hf_overrides"] == {"max_position_embeddings": 8192}
+
+
+def test_shallow_merge_does_not_blend_nested_overrides():
+    """A policy-declared key replaces its generation-side counterpart wholesale."""
+    vllm_kwargs = {"hf_overrides": {"rope_scaling": {"rope_type": "yarn", "factor": 4}}}
+
+    with pytest.warns(UserWarning, match="rope_scaling"):
+        merge_hf_overrides(
+            vllm_kwargs, hf_config_overrides={"rope_scaling": {"rope_type": "linear"}}
+        )
+
+    assert vllm_kwargs["hf_overrides"] == {"rope_scaling": {"rope_type": "linear"}}
+
+
+def test_none_treated_as_empty():
+    """``None`` on either side (e.g. from config defaults) is handled as empty."""
+    vllm_kwargs = {"hf_overrides": None}
+
+    merge_hf_overrides(vllm_kwargs, hf_config_overrides=None)
+
+    assert vllm_kwargs["hf_overrides"] == {}
+
+
+def test_callable_hf_overrides_dropped_with_a_warning():
+    """vLLM's callable form cannot be merged; drop it as the worker already does."""
+    vllm_kwargs = {"hf_overrides": lambda config: config}
+
+    with pytest.warns(UserWarning, match="cannot be merged"):
+        merge_hf_overrides(
+            vllm_kwargs, hf_config_overrides={"max_position_embeddings": 8192}
+        )
+
+    assert vllm_kwargs["hf_overrides"] == {"max_position_embeddings": 8192}
+
+
+def test_identical_values_do_not_warn():
+    """A key both sides set to the same value overrides nothing, so stay quiet."""
+    vllm_kwargs = {"hf_overrides": {"max_position_embeddings": 8192}}
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        merge_hf_overrides(
+            vllm_kwargs, hf_config_overrides={"max_position_embeddings": 8192}
+        )
+
+    assert vllm_kwargs["hf_overrides"] == {"max_position_embeddings": 8192}
+
+
+def test_resolved_overrides_are_logged(caplog):
+    """The value the engine will actually see is reported at launch."""
+    vllm_kwargs = {"hf_overrides": {"rope_scaling": {"rope_type": "yarn"}}}
+
+    with caplog.at_level(logging.INFO, logger=merge_hf_overrides.__module__):
+        merge_hf_overrides(vllm_kwargs, hf_config_overrides=None)
+
+    assert "rope_scaling" in caplog.text
+
+
+def test_only_the_merge_helper_sets_hf_overrides():
+    """Nothing outside the helper may replace hf_overrides, including future call sites.
+
+    The dynamo and single-controller generation paths were added after the original
+    grpo/ppo/distillation ones and inherited this bug, so listing today's call sites
+    would not catch the next one. Scan the package instead and allowlist the two files
+    that legitimately set hf_overrides.
+    """
+    offenders = {}
+    for path in sorted((REPO / "nemo_rl").rglob("*.py")):
+        rel_path = path.relative_to(REPO).as_posix()
+        if rel_path in ALLOWED_TO_SET_HF_OVERRIDES:
+            continue
+        lines = _lines_setting_hf_overrides(ast.parse(path.read_text()))
+        if lines:
+            offenders[rel_path] = lines
+
+    assert not offenders, (
+        f"{offenders} set hf_overrides directly; call merge_hf_overrides() instead so "
+        "generation-side overrides are not discarded."
+    )
+
+
+@pytest.mark.parametrize("rel_path", ENTRY_POINTS)
+def test_entry_point_calls_merge_hf_overrides(rel_path: str):
+    """Every entry point that wires up generation routes through the merge helper."""
+    tree = ast.parse((REPO / rel_path).read_text())
+
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "merge_hf_overrides"
+    ]
+
+    assert calls, f"{rel_path} does not call merge_hf_overrides()"


### PR DESCRIPTION
# What does this PR do ?

**Merge `policy.hf_config_overrides` into the generation engine's `hf_overrides` instead of overwriting it, so a user-supplied `policy.generation.vllm_kwargs.hf_overrides` is no longer silently discarded.**

Five call sites assign it wholesale:

| file | line | backend |
|---|---|---|
| `nemo_rl/algorithms/grpo.py` | 1345 | vllm |
| `nemo_rl/algorithms/grpo.py` | 496 | dynamo |
| `nemo_rl/algorithms/ppo.py` | 817 | vllm |
| `nemo_rl/algorithms/distillation.py` | 514 | vllm |
| `nemo_rl/algorithms/single_controller_utils/setup.py` | 227 | vllm |

```python
## make vllm hf overrides match the training policy
vllm_kwargs["hf_overrides"] = policy_config.get("hf_config_overrides", {})
```

`vllm_kwargs` is a user-facing config field, so this drops anything the user set under
`policy.generation.vllm_kwargs.hf_overrides` — and because the default is `{}`, it drops
it even when the policy declares no overrides at all. No warning is emitted.

This is the same overwrite-vs-merge bug `_merge_fp8_kwargs` fixed one layer down in the
worker (#1413, reverted in #2188, re-fixed in #2904); the algorithm entry points were
never updated. This PR adds `merge_hf_overrides()` next to the other vLLM config helpers
and routes all five call sites through it.

**The trainer/generation invariant is unchanged.** The merge is shallow and the training
policy wins outright on a conflicting top-level key — a `rope_scaling` declared by the
policy replaces a generation-side one rather than being blended into it — so the two can
still not disagree on anything the policy declares, and the yarn `rope_scaling` validation
in `nemo_rl/models/megatron/setup.py` keeps applying unchanged. A generation-side override
only takes effect for keys the policy leaves unset.

**Nothing resolves silently.** The merged overrides are logged, so the value the engine
will actually see is visible at launch rather than only in downstream metrics. A
generation-side value the policy shadows with a *different* value warns; a key both sides
set identically overrides nothing and stays quiet. vLLM's callable form of `hf_overrides`
cannot be merged with a mapping, so it is dropped with a warning rather than raising —
matching what `vllm_worker.py` already does with a non-dict `hf_overrides`.

The `ppo.py` and `distillation.py` call sites indexed `generation_config["vllm_kwargs"]`
directly while the others used `setdefault`; they now all use `setdefault`, since
`vllm_kwargs` is `NotRequired` in `VllmConfig`.

# Issues

Closes #3728

# Usage

```yaml
policy:
  # no hf_config_overrides
  generation:
    backend: vllm
    vllm_kwargs:
      hf_overrides:
        max_position_embeddings: 8192   # before: silently reset to {}; after: reaches vLLM
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information

* New tests live in `tests/unit/models/generation/test_vllm_hf_overrides_merge.py`, next
  to the existing `test_vllm_fp8_hf_overrides.py` regression tests for the same class of
  bug. Since that bug was fixed, reverted and re-fixed, the new tests also pin the call
  sites with an `ast` check (in the style of `test_vllm_patches.py`): every entry point
  must call `merge_hf_overrides()`, and nothing in `nemo_rl/` outside an allowlist of two
  files may replace `hf_overrides` by assignment or `update()`. The scan is deliberately
  package-wide rather than a list of today's call sites: the dynamo and single-controller
  paths were added after the original three and inherited the bug, so a fixed list would
  not catch the next one. The check flags all five pre-fix call sites.
* Ran locally (CPU): the new and existing `hf_overrides` test modules plus the unit tests
  that import the changed modules — `test_grpo_checkpoint_engine.py`, `test_utils.py`,
  `test_ppo.py`, `test_distillation.py`, `test_vllm_quant_backend.py`,
  `test_vllm_worker_helpers.py`, `test_single_controller_setup.py` (142 passed, 12 skipped
  for GPU/modelopt). `ruff` and `pyrefly` are clean.
* No documentation change: this restores the pass-through contract of
  `policy.generation.vllm_kwargs` rather than adding a feature. That contract is
  documented for other keys — `docs/guides/eagle3-speculative-decoding.md` and
  `docs/guides/checkpoint-engine-refit.md` both instruct users to set things under
  `vllm_kwargs` — though `hf_overrides` itself is not mentioned anywhere in `docs/`.
