### PR TITLE
feat(sc): report trajectory age in the SingleController train pump

### DIFF
--- a/nemo_rl/algorithms/async_utils/staleness_sampler.py
+++ b/nemo_rl/algorithms/async_utils/staleness_sampler.py
@@ -179,6 +179,30 @@ class BaseSampler(abc.ABC):
         # Pre-incremented before each admitted batch, so -1 lets the first
         # batch through a zero-staleness gate.
         self._dispatch_index: int = -1
+        # Trajectory age of the groups the most recent ``select`` returned, in
+        # trainer versions. Reset by every ``select``, including one that
+        # selects nothing.
+        self._last_selection_trajectory_ages: list[int] = []
+
+    @property
+    def last_selection_trajectory_ages(self) -> list[int]:
+        """Per-group trajectory age of the last ``select``, in trainer versions.
+
+        ``current_train_weight - start_weight`` for each returned group: how
+        many optimizer steps separate the policy that generated the tokens from
+        the one about to be updated on them. Empty when the last ``select``
+        returned nothing.
+
+        Same quantity the pre-SC async GRPO path reports as
+        ``avg_trajectory_age`` (``ReplayBuffer.sample``), which is why the
+        metric keeps that name -- "staleness" in this module names the
+        admission/selection policy, not the measurement.
+
+        Read by the SC train pump for metrics. Not part of
+        ``PromptGroupSampler`` -- an out-of-repo sampler that doesn't define it
+        simply reports no age rather than failing.
+        """
+        return self._last_selection_trajectory_ages
 
     @property
     def dispatch_index(self) -> int:
@@ -282,6 +306,8 @@ class BaseSampler(abc.ABC):
         valid_idxs: list[int],
         min_prompt_groups: int,
         max_prompt_groups: int,
+        *,
+        current_train_weight: int,
     ) -> tuple[Optional[KVBatchMeta], int]:
         """Cap, drop from the buffer, and concat the chosen groups.
 
@@ -289,6 +315,7 @@ class BaseSampler(abc.ABC):
         ``max_prompt_groups`` (never fewer on purpose, never waits to fill it),
         or ``(None, 0)`` below ``min_prompt_groups``.
         """
+        self._last_selection_trajectory_ages = []
         if len(valid_idxs) < min_prompt_groups:
             return None, 0
         requested_groups = min(len(valid_idxs), max_prompt_groups)
@@ -298,6 +325,13 @@ class BaseSampler(abc.ABC):
             metrics
             for meta in selected_metas
             for metrics in meta.extra_info.get(ROLLOUT_METRICS, [])  # type: ignore[union-attr]
+        ]
+        # Read before claiming: the selected indices leave the ready inventory.
+        # ``start_weight`` is the version that generated the tokens, so this is
+        # the age of the data the next gradient step consumes.
+        self._last_selection_trajectory_ages = [
+            current_train_weight - self._buffer.start_weight_list[i]
+            for i in selected_idxs
         ]
         selected_meta = selected_metas[0].concat(*selected_metas[1:])  # type: ignore[union-attr]
         selected_meta.extra_info[ROLLOUT_METRICS] = selected_rollout_metrics
@@ -392,7 +426,10 @@ class WindowedSampler(BaseSampler):
                 )
             )
         return await self._finalize_selection(
-            valid_idxs, min_prompt_groups, max_prompt_groups
+            valid_idxs,
+            min_prompt_groups,
+            max_prompt_groups,
+            current_train_weight=current_train_weight,
         )
 
 
@@ -494,7 +531,10 @@ class ReadyFirstSampler(_GatedSampler):
             if weight <= current_train_weight and self._buffer.ready_list[i]
         ]
         return await self._finalize_selection(
-            valid_idxs, min_prompt_groups, max_prompt_groups
+            valid_idxs,
+            min_prompt_groups,
+            max_prompt_groups,
+            current_train_weight=current_train_weight,
         )
 
     async def evict(self, *, current_train_weight: int) -> int:
@@ -539,7 +579,10 @@ class WeightFifoSampler(_GatedSampler):
             if weight == target_version and self._buffer.ready_list[i]
         ]
         return await self._finalize_selection(
-            valid_idxs, min_prompt_groups, max_prompt_groups
+            valid_idxs,
+            min_prompt_groups,
+            max_prompt_groups,
+            current_train_weight=current_train_weight,
         )
 
 
@@ -600,7 +643,10 @@ class InOrderSampler(_GatedSampler):
             if target == current_train_weight and self._buffer.ready_list[i]
         ]
         return await self._finalize_selection(
-            valid_idxs, min_prompt_groups, max_prompt_groups
+            valid_idxs,
+            min_prompt_groups,
+            max_prompt_groups,
+            current_train_weight=current_train_weight,
         )
 
     async def evict(self, *, current_train_weight: int) -> int:

--- a/nemo_rl/algorithms/async_utils/staleness_sampler.py
+++ b/nemo_rl/algorithms/async_utils/staleness_sampler.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 import abc
 import asyncio
 import importlib
+from dataclasses import dataclass
 from typing import (
     Annotated,
     Callable,
@@ -63,6 +64,18 @@ from nemo_rl.data_plane.schema import ROLLOUT_METRICS
 
 # Poll interval for the rollout-pump admission gate.
 _GATE_POLL_SECONDS = 0.005
+
+
+@dataclass(frozen=True)
+class SamplerSelection:
+    """One sampler selection and the metadata needed to diagnose it."""
+
+    meta: Optional[KVBatchMeta]
+    num_groups: int
+    trajectory_ages: tuple[int, ...]
+
+
+SamplerSelectionResult = SamplerSelection | tuple[Optional[KVBatchMeta], int]
 
 
 @runtime_checkable
@@ -97,12 +110,13 @@ class PromptGroupSampler(Protocol):
         current_train_weight: int,
         min_prompt_groups: int,
         max_prompt_groups: int,
-    ) -> tuple[Optional[KVBatchMeta], int]:
-        """Pick up to ``max_prompt_groups`` eligible groups for training.
+    ) -> SamplerSelectionResult:
+        """Pick eligible groups and optionally return trajectory-age metadata.
 
-        Claim-aware samplers transfer the groups from ordinary replay-buffer
-        selection into training ownership until the controller releases them.
-        Legacy custom samplers may still remove selected groups immediately.
+        Built-in samplers return ``SamplerSelection`` and transfer selected
+        groups into training ownership until the controller releases them.
+        Legacy custom samplers may still return the two-tuple contract and
+        remove selected groups immediately.
         """
         ...
 
@@ -179,30 +193,6 @@ class BaseSampler(abc.ABC):
         # Pre-incremented before each admitted batch, so -1 lets the first
         # batch through a zero-staleness gate.
         self._dispatch_index: int = -1
-        # Trajectory age of the groups the most recent ``select`` returned, in
-        # trainer versions. Reset by every ``select``, including one that
-        # selects nothing.
-        self._last_selection_trajectory_ages: list[int] = []
-
-    @property
-    def last_selection_trajectory_ages(self) -> list[int]:
-        """Per-group trajectory age of the last ``select``, in trainer versions.
-
-        ``current_train_weight - start_weight`` for each returned group: how
-        many optimizer steps separate the policy that generated the tokens from
-        the one about to be updated on them. Empty when the last ``select``
-        returned nothing.
-
-        Same quantity the pre-SC async GRPO path reports as
-        ``avg_trajectory_age`` (``ReplayBuffer.sample``), which is why the
-        metric keeps that name -- "staleness" in this module names the
-        admission/selection policy, not the measurement.
-
-        Read by the SC train pump for metrics. Not part of
-        ``PromptGroupSampler`` -- an out-of-repo sampler that doesn't define it
-        simply reports no age rather than failing.
-        """
-        return self._last_selection_trajectory_ages
 
     @property
     def dispatch_index(self) -> int:
@@ -250,7 +240,7 @@ class BaseSampler(abc.ABC):
         current_train_weight: int,
         min_prompt_groups: int,
         max_prompt_groups: int,
-    ) -> tuple[Optional[KVBatchMeta], int]: ...
+    ) -> SamplerSelection: ...
 
     async def evict(self, *, current_train_weight: int) -> int:
         """Default: drop *ready* groups below the weight window.
@@ -308,16 +298,15 @@ class BaseSampler(abc.ABC):
         max_prompt_groups: int,
         *,
         current_train_weight: int,
-    ) -> tuple[Optional[KVBatchMeta], int]:
+    ) -> SamplerSelection:
         """Cap, drop from the buffer, and concat the chosen groups.
 
         Greedy without waiting: returns all currently-eligible groups up to
         ``max_prompt_groups`` (never fewer on purpose, never waits to fill it),
-        or ``(None, 0)`` below ``min_prompt_groups``.
+        or an empty selection below ``min_prompt_groups``.
         """
-        self._last_selection_trajectory_ages = []
         if len(valid_idxs) < min_prompt_groups:
-            return None, 0
+            return SamplerSelection(meta=None, num_groups=0, trajectory_ages=())
         requested_groups = min(len(valid_idxs), max_prompt_groups)
         selected_idxs = valid_idxs[:requested_groups]
         selected_metas = [self._buffer.meta_list[i] for i in selected_idxs]
@@ -326,17 +315,22 @@ class BaseSampler(abc.ABC):
             for meta in selected_metas
             for metrics in meta.extra_info.get(ROLLOUT_METRICS, [])  # type: ignore[union-attr]
         ]
-        # Read before claiming: the selected indices leave the ready inventory.
-        # ``start_weight`` is the version that generated the tokens, so this is
-        # the age of the data the next gradient step consumes.
-        self._last_selection_trajectory_ages = [
+        # Read before claiming: the indices leave the ready inventory. start_weight is
+        # the version that generated the tokens, so this is the age of the data
+        # the next gradient step consumes -- the off-policyness the importance
+        # ratio has to correct for.
+        trajectory_ages = tuple(
             current_train_weight - self._buffer.start_weight_list[i]
             for i in selected_idxs
-        ]
+        )
         selected_meta = selected_metas[0].concat(*selected_metas[1:])  # type: ignore[union-attr]
         selected_meta.extra_info[ROLLOUT_METRICS] = selected_rollout_metrics
         await self._buffer.claim_for_training(selected_idxs)
-        return selected_meta, len(selected_idxs)
+        return SamplerSelection(
+            meta=selected_meta,
+            num_groups=len(selected_idxs),
+            trajectory_ages=trajectory_ages,
+        )
 
 
 class WindowedSampler(BaseSampler):
@@ -409,7 +403,7 @@ class WindowedSampler(BaseSampler):
         current_train_weight: int,
         min_prompt_groups: int,
         max_prompt_groups: int,
-    ) -> tuple[Optional[KVBatchMeta], int]:
+    ) -> SamplerSelection:
         self._validate_group_bounds(min_prompt_groups, max_prompt_groups)
         min_valid_version = max(0, current_train_weight - self.max_staleness_versions)
         valid_idxs = [
@@ -523,7 +517,7 @@ class ReadyFirstSampler(_GatedSampler):
         current_train_weight: int,
         min_prompt_groups: int,
         max_prompt_groups: int,
-    ) -> tuple[Optional[KVBatchMeta], int]:
+    ) -> SamplerSelection:
         self._validate_group_bounds(min_prompt_groups, max_prompt_groups)
         valid_idxs = [
             i
@@ -562,7 +556,7 @@ class WeightFifoSampler(_GatedSampler):
         current_train_weight: int,
         min_prompt_groups: int,
         max_prompt_groups: int,
-    ) -> tuple[Optional[KVBatchMeta], int]:
+    ) -> SamplerSelection:
         self._validate_group_bounds(min_prompt_groups, max_prompt_groups)
         min_valid_version = max(0, current_train_weight - self.max_staleness_versions)
         in_window = [
@@ -571,7 +565,7 @@ class WeightFifoSampler(_GatedSampler):
             if min_valid_version <= weight <= current_train_weight
         ]
         if not in_window:
-            return None, 0
+            return SamplerSelection(meta=None, num_groups=0, trajectory_ages=())
         target_version = min(in_window)
         valid_idxs = [
             i
@@ -635,7 +629,7 @@ class InOrderSampler(_GatedSampler):
         current_train_weight: int,
         min_prompt_groups: int,
         max_prompt_groups: int,
-    ) -> tuple[Optional[KVBatchMeta], int]:
+    ) -> SamplerSelection:
         self._validate_group_bounds(min_prompt_groups, max_prompt_groups)
         valid_idxs = [
             i

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -86,6 +86,7 @@ from nemo_rl.algorithms.async_utils.replay_buffer import (
     TQReplayMetadataState,
 )
 from nemo_rl.algorithms.async_utils.staleness_sampler import (
+    SamplerSelection,
     TransactionalAdmissionSampler,
     create_sampler,
 )
@@ -2529,11 +2530,18 @@ class SingleControllerActor:
                         training_claim_ids_before = (
                             self._buffer.training_owned_group_ids()
                         )
-                        train_meta, num_groups = await self._sampler.select(
+                        selection = await self._sampler.select(
                             current_train_weight=self._trainer_version,
                             min_prompt_groups=min_prompt_groups,
                             max_prompt_groups=max_prompt_groups,
                         )
+                        if isinstance(selection, SamplerSelection):
+                            train_meta = selection.meta
+                            num_groups = selection.num_groups
+                            step_trajectory_ages.extend(selection.trajectory_ages)
+                        else:
+                            # Preserve the two-tuple contract for external samplers.
+                            train_meta, num_groups = selection
                         training_claim_ids_after = (
                             self._buffer.training_owned_group_ids()
                         )
@@ -2566,15 +2574,6 @@ class SingleControllerActor:
                                 "returning batch metadata: "
                                 f"{sorted(new_training_claim_ids)!r}"
                             )
-                        # getattr, not a Protocol member: a sampler loaded by FQN
-                        # from outside this repo need not provide it, and then
-                        # simply reports no staleness.
-                        step_trajectory_ages.extend(
-                            getattr(
-                                self._sampler, "last_selection_trajectory_ages", None
-                            )
-                            or ()
-                        )
 
                         # If no batch is selectable, sleep and retry
                         if train_meta is None:

--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -2460,6 +2460,9 @@ class SingleControllerActor:
             version_during_step = self._trainer_version
             groups_dispatched = 0
             evicted_stale_prompt_groups = 0
+            # Trajectory age, in trainer versions, of every group this step trains
+            # on. Accumulated across selects: a step is assembled from several.
+            step_trajectory_ages: list[int] = []
             min_sample_version = None
             step_open = False
             chunks_dispatched = 0
@@ -2563,6 +2566,15 @@ class SingleControllerActor:
                                 "returning batch metadata: "
                                 f"{sorted(new_training_claim_ids)!r}"
                             )
+                        # getattr, not a Protocol member: a sampler loaded by FQN
+                        # from outside this repo need not provide it, and then
+                        # simply reports no staleness.
+                        step_trajectory_ages.extend(
+                            getattr(
+                                self._sampler, "last_selection_trajectory_ages", None
+                            )
+                            or ()
+                        )
 
                         # If no batch is selectable, sleep and retry
                         if train_meta is None:
@@ -2966,6 +2978,18 @@ class SingleControllerActor:
                             )
                 self._retune_lookahead_versions()
                 self._rollout_manager.set_weight_version(self._trainer_version)
+                if step_trajectory_ages:
+                    # Keep the pre-SC async GRPO metric name so both paths can be
+                    # compared on one dashboard. The max exposes the long tail
+                    # that ready_first permits but eviction counters cannot show.
+                    step_metrics.update(
+                        {
+                            "avg_trajectory_age": (
+                                sum(step_trajectory_ages) / len(step_trajectory_ages)
+                            ),
+                            "max_trajectory_age": max(step_trajectory_ages),
+                        }
+                    )
                 step_metrics.update(
                     {
                         "evicted_stale_prompt_groups": evicted_stale_prompt_groups,

--- a/tests/unit/single_controller/_checkpoint_scenarios.py
+++ b/tests/unit/single_controller/_checkpoint_scenarios.py
@@ -477,14 +477,15 @@ async def _round_trip(
             current_train_weight=select_current_train_weight
         )
         evicted_after_restore = groups_before_evict - set(buf_b._group_ids)
-        selected_meta, selected_count = await sampler_b.select(
+        selection = await sampler_b.select(
             current_train_weight=select_current_train_weight,
             min_prompt_groups=select_min_prompt_groups,
             max_prompt_groups=select_max_prompt_groups,
         )
-        if selected_meta is not None:
+        selected_count = selection.num_groups
+        if selection.meta is not None:
             selected = {
-                sample_id.rpartition("_g")[0] for sample_id in selected_meta.sample_ids
+                sample_id.rpartition("_g")[0] for sample_id in selection.meta.sample_ids
             }
     return RoundTrip(
         recovered=recovered,

--- a/tests/unit/single_controller/test_checkpointing.py
+++ b/tests/unit/single_controller/test_checkpointing.py
@@ -62,6 +62,7 @@ from nemo_rl.algorithms.async_utils.replay_buffer import (
 )
 from nemo_rl.algorithms.async_utils.staleness_sampler import (
     InOrderSamplerConfig,
+    SamplerSelection,
     WindowedSamplerConfig,
     sampler_supports_buffer_checkpoint,
 )
@@ -245,7 +246,7 @@ class _FakeSampler:
         current_train_weight: int,
         min_prompt_groups: int,
         max_prompt_groups: int,
-    ) -> tuple[KVBatchMeta, int]:
+    ) -> SamplerSelection:
         n = max_prompt_groups
         sample_ids = [f"s{self._step}-{i}" for i in range(n)]
         self._step += 1
@@ -256,7 +257,7 @@ class _FakeSampler:
             sequence_lengths=[16] * n,
             tags=[{"weight_version": current_train_weight}] * n,
         )
-        return meta, n
+        return SamplerSelection(meta=meta, num_groups=n, trajectory_ages=(0,) * n)
 
     @property
     def is_on_policy(self) -> bool:
@@ -290,9 +291,9 @@ class _ExhaustingSampler(_FakeSampler):
         super().__init__()
         self._remaining = steps
 
-    async def select(self, **kwargs) -> tuple[Optional[KVBatchMeta], int]:
+    async def select(self, **kwargs) -> SamplerSelection:
         if self._remaining == 0:
-            return None, 0
+            return SamplerSelection(meta=None, num_groups=0, trajectory_ages=())
         self._remaining -= 1
         return await super().select(**kwargs)
 
@@ -311,11 +312,10 @@ class _RestoredGroupsSampler(_FakeSampler):
         current_train_weight: int,
         min_prompt_groups: int,
         max_prompt_groups: int,
-    ) -> tuple[Optional[KVBatchMeta], int]:
-        del current_train_weight
+    ) -> SamplerSelection:
         selected = self._groups[:max_prompt_groups]
         if len(selected) < min_prompt_groups:
-            return None, 0
+            return SamplerSelection(meta=None, num_groups=0, trajectory_ages=())
         del self._groups[: len(selected)]
         # Legacy local-removal contract: a sampler without training claims drops
         # the rows from the replay index at selection, so a checkpoint taken
@@ -323,8 +323,8 @@ class _RestoredGroupsSampler(_FakeSampler):
         self._buffer.drop_groups([group["group_id"] for group in selected])
 
         metas = [group["meta"] for group in selected]
-        return (
-            KVBatchMeta(
+        return SamplerSelection(
+            meta=KVBatchMeta(
                 partition_id=_PARTITION_ID,
                 task_name=None,
                 sample_ids=[sid for meta in metas for sid in meta.sample_ids],
@@ -333,7 +333,10 @@ class _RestoredGroupsSampler(_FakeSampler):
                 ],
                 tags=[tag for meta in metas for tag in (meta.tags or [])],
             ),
-            len(selected),
+            num_groups=len(selected),
+            trajectory_ages=tuple(
+                current_train_weight - group["start_weight"] for group in selected
+            ),
         )
 
 

--- a/tests/unit/single_controller/test_sampler_interface.py
+++ b/tests/unit/single_controller/test_sampler_interface.py
@@ -856,7 +856,7 @@ class TestSelectionStaleness:
         ],
         ids=["windowed", "ready_first", "weight_fifo"],
     )
-    def test_every_built_in_sampler_reports_it(self, sampler_factory):
+    def test_every_weight_selecting_sampler_reports_it(self, sampler_factory):
         buf = FakeBuffer()
         buf.add("g0", weight=3)
         s = sampler_factory(buf)
@@ -867,3 +867,43 @@ class TestSelectionStaleness:
 
         assert n == 1
         assert s.last_selection_trajectory_ages == [2]
+
+    def test_in_order_reports_it_too(self):
+        """InOrderSampler selects on target_step, but still reports by weight.
+
+        Its ``select`` keys on ``target_step == current_train_weight`` rather
+        than on ``start_weight``, so it is the one built-in whose selection
+        filter does not itself bound the age. The reported value is still
+        ``current_train_weight - start_weight``, which is what the importance
+        ratio spans regardless of how the group was chosen.
+        """
+        buf = FakeBuffer()
+        buf.add("g0", weight=3, target_step=5)
+        s = InOrderSampler(buf, max_lookahead_versions=4)
+
+        _, n = _run(
+            s.select(current_train_weight=5, min_prompt_groups=1, max_prompt_groups=1)
+        )
+
+        assert n == 1
+        assert s.last_selection_trajectory_ages == [2]
+
+    def test_age_is_reported_unclamped(self):
+        """A group newer than the trainer reports a negative age, not zero.
+
+        Not expected in practice, but worth pinning: the three weight-filtering
+        samplers bound this by construction, while InOrderSampler's filter is
+        on ``target_step``, so nothing local to it rules the case out.
+        Clamping would turn a stamping inversion into a plausible-looking zero;
+        reporting it is what makes it findable.
+        """
+        buf = FakeBuffer()
+        buf.add("g0", weight=7, target_step=5)
+        s = InOrderSampler(buf, max_lookahead_versions=4)
+
+        _, n = _run(
+            s.select(current_train_weight=5, min_prompt_groups=1, max_prompt_groups=1)
+        )
+
+        assert n == 1
+        assert s.last_selection_trajectory_ages == [-2]

--- a/tests/unit/single_controller/test_sampler_interface.py
+++ b/tests/unit/single_controller/test_sampler_interface.py
@@ -784,3 +784,86 @@ class PropertyCapabilitySampler:
 
 
 NOT_A_SAMPLER_CLASS = object()
+
+
+class TestSelectionStaleness:
+    """``last_selection_trajectory_ages`` reports the age of what select returned.
+
+    The two existing staleness metrics count only what was discarded, and both
+    are structurally zero under ready_first: its ``evict`` returns 0 and it
+    inherits ``should_abort_inflight`` -> False. So without this, a ready_first
+    run reports no staleness however old the data it trains on is.
+    """
+
+    def test_reports_age_of_each_selected_group(self):
+        buf = FakeBuffer()
+        for i, weight in enumerate((2, 5, 7)):
+            buf.add(f"g{i}", weight=weight)
+        s = ReadyFirstSampler(buf, max_staleness_versions=1)
+
+        meta, n = _run(
+            s.select(current_train_weight=9, min_prompt_groups=1, max_prompt_groups=3)
+        )
+
+        assert n == 3
+        assert meta is not None
+        assert s.last_selection_trajectory_ages == [7, 4, 2]
+
+    def test_reports_only_the_groups_actually_selected(self):
+        buf = FakeBuffer()
+        for i, weight in enumerate((0, 1, 2, 3)):
+            buf.add(f"g{i}", weight=weight)
+        s = ReadyFirstSampler(buf, max_staleness_versions=1)
+
+        _, n = _run(
+            s.select(current_train_weight=5, min_prompt_groups=1, max_prompt_groups=2)
+        )
+
+        assert n == 2
+        assert s.last_selection_trajectory_ages == [5, 4]
+
+    def test_selecting_nothing_clears_the_previous_reading(self):
+        buf = FakeBuffer()
+        buf.add("g0", weight=1)
+        s = ReadyFirstSampler(buf, max_staleness_versions=1)
+
+        _run(s.select(current_train_weight=4, min_prompt_groups=1, max_prompt_groups=1))
+        assert s.last_selection_trajectory_ages == [3]
+
+        # Buffer now empty: a stale reading must not survive into the next step.
+        _run(s.select(current_train_weight=5, min_prompt_groups=1, max_prompt_groups=1))
+        assert s.last_selection_trajectory_ages == []
+
+    def test_unready_groups_are_not_counted(self):
+        buf = FakeBuffer()
+        buf.add("g0", weight=1, ready=False)
+        buf.add("g1", weight=3, ready=True)
+        s = ReadyFirstSampler(buf, max_staleness_versions=1)
+
+        _, n = _run(
+            s.select(current_train_weight=6, min_prompt_groups=1, max_prompt_groups=4)
+        )
+
+        assert n == 1
+        assert s.last_selection_trajectory_ages == [3]
+
+    @pytest.mark.parametrize(
+        "sampler_factory",
+        [
+            lambda buf: WindowedSampler(buf, max_staleness_versions=4),
+            lambda buf: ReadyFirstSampler(buf, max_staleness_versions=4),
+            lambda buf: WeightFifoSampler(buf, max_staleness_versions=4),
+        ],
+        ids=["windowed", "ready_first", "weight_fifo"],
+    )
+    def test_every_built_in_sampler_reports_it(self, sampler_factory):
+        buf = FakeBuffer()
+        buf.add("g0", weight=3)
+        s = sampler_factory(buf)
+
+        _, n = _run(
+            s.select(current_train_weight=5, min_prompt_groups=1, max_prompt_groups=1)
+        )
+
+        assert n == 1
+        assert s.last_selection_trajectory_ages == [2]

--- a/tests/unit/single_controller/test_sampler_interface.py
+++ b/tests/unit/single_controller/test_sampler_interface.py
@@ -35,6 +35,7 @@ from nemo_rl.algorithms.async_utils.staleness_sampler import (
     PromptGroupSampler,
     ReadyFirstSampler,
     ReadyFirstSamplerConfig,
+    SamplerSelection,
     SamplerConfig,
     TransactionalAdmissionSampler,
     WeightFifoSampler,
@@ -494,10 +495,10 @@ class TestWindowedSelect:
         buf.add("b", weight=5)  # current
         buf.add("c", weight=1)  # below window (5-2=3)
         s = WindowedSampler(buf, max_staleness_versions=2)
-        meta, n = _run(
+        selection = _run(
             s.select(current_train_weight=5, min_prompt_groups=1, max_prompt_groups=8)
         )
-        assert n == 2  # a(3) and b(5); c(1) excluded
+        assert selection.num_groups == 2  # a(3) and b(5); c(1) excluded
         assert len(buf.start_weight_list) == 1  # only c remains
 
     def test_carries_metrics_only_for_selected_groups(self):
@@ -507,7 +508,7 @@ class TestWindowedSelect:
         buf.add("not-selected", weight=5, rollout_metrics={"metric": 100.0})
         sampler = WindowedSampler(buf, max_staleness_versions=1)
 
-        meta, num_groups = _run(
+        selection = _run(
             sampler.select(
                 current_train_weight=5,
                 min_prompt_groups=1,
@@ -515,9 +516,9 @@ class TestWindowedSelect:
             )
         )
 
-        assert num_groups == 2
-        assert meta is not None
-        assert meta.extra_info[ROLLOUT_METRICS] == [
+        assert selection.num_groups == 2
+        assert selection.meta is not None
+        assert selection.meta.extra_info[ROLLOUT_METRICS] == [
             {"metric": 1.0},
             {"metric": 2.0},
         ]
@@ -534,7 +535,7 @@ class TestWindowedSelect:
         restored_meta.extra_info.pop(ROLLOUT_METRICS)
         sampler = WindowedSampler(buf, max_staleness_versions=1)
 
-        meta, num_groups = _run(
+        selection = _run(
             sampler.select(
                 current_train_weight=5,
                 min_prompt_groups=1,
@@ -542,9 +543,9 @@ class TestWindowedSelect:
             )
         )
 
-        assert num_groups == 2
-        assert meta is not None
-        assert meta.extra_info[ROLLOUT_METRICS] == [{"metric": 2.0}]
+        assert selection.num_groups == 2
+        assert selection.meta is not None
+        assert selection.meta.extra_info[ROLLOUT_METRICS] == [{"metric": 2.0}]
 
     def test_below_min_returns_none(self):
         buf = FakeBuffer()
@@ -552,7 +553,7 @@ class TestWindowedSelect:
         s = WindowedSampler(buf, max_staleness_versions=2)
         assert _run(
             s.select(current_train_weight=5, min_prompt_groups=2, max_prompt_groups=8)
-        ) == (None, 0)
+        ) == SamplerSelection(meta=None, num_groups=0, trajectory_ages=())
 
     def test_unready_excluded(self):
         buf = FakeBuffer()
@@ -560,18 +561,18 @@ class TestWindowedSelect:
         s = WindowedSampler(buf, max_staleness_versions=2)
         assert _run(
             s.select(current_train_weight=5, min_prompt_groups=1, max_prompt_groups=8)
-        ) == (None, 0)
+        ) == SamplerSelection(meta=None, num_groups=0, trajectory_ages=())
 
     def test_freshest_first_orders_by_lag(self):
         buf = FakeBuffer()
         buf.add("old", weight=1)
         buf.add("new", weight=5)
         s = WindowedSampler(buf, max_staleness_versions=10, sample_freshest_first=True)
-        meta, n = _run(
+        selection = _run(
             s.select(current_train_weight=5, min_prompt_groups=1, max_prompt_groups=1)
         )
         # freshest (weight 5) picked first -> "old" (weight 1) remains.
-        assert n == 1
+        assert selection.num_groups == 1
         assert buf.start_weight_list == [1]
 
 
@@ -582,10 +583,10 @@ class TestWeightFifoSelect:
         buf.add("new", weight=5)
         buf.add("old2", weight=3)
         s = WeightFifoSampler(buf, max_staleness_versions=5)
-        meta, n = _run(
+        selection = _run(
             s.select(current_train_weight=5, min_prompt_groups=1, max_prompt_groups=8)
         )
-        assert n == 2  # both weight-3 groups; weight-5 waits its turn
+        assert selection.num_groups == 2  # both weight-3 groups; weight-5 waits
         assert buf.start_weight_list == [5]
 
     def test_waits_for_partial_oldest_batch(self):
@@ -596,7 +597,7 @@ class TestWeightFifoSelect:
         # ahead to a newer weight.
         assert _run(
             s.select(current_train_weight=5, min_prompt_groups=2, max_prompt_groups=8)
-        ) == (None, 0)
+        ) == SamplerSelection(meta=None, num_groups=0, trajectory_ages=())
 
     def test_empty_window_returns_none(self):
         buf = FakeBuffer()
@@ -604,7 +605,7 @@ class TestWeightFifoSelect:
         s = WeightFifoSampler(buf, max_staleness_versions=2)
         assert _run(
             s.select(current_train_weight=5, min_prompt_groups=1, max_prompt_groups=8)
-        ) == (None, 0)
+        ) == SamplerSelection(meta=None, num_groups=0, trajectory_ages=())
 
 
 class TestReadyFirstSelect:
@@ -616,13 +617,13 @@ class TestReadyFirstSelect:
         buf.add("future", weight=4)
         s = ReadyFirstSampler(buf, max_staleness_versions=1)
 
-        meta, n = _run(
+        selection = _run(
             s.select(current_train_weight=3, min_prompt_groups=3, max_prompt_groups=3)
         )
 
-        assert n == 3
-        assert meta is not None
-        assert meta.sample_ids == ["old_g0", "current_g0", "middle_g0"]
+        assert selection.num_groups == 3
+        assert selection.meta is not None
+        assert selection.meta.sample_ids == ["old_g0", "current_g0", "middle_g0"]
         assert buf.start_weight_list == [4]
 
     def test_no_eviction_keeps_late_straggler_selectable(self):
@@ -631,13 +632,13 @@ class TestReadyFirstSelect:
         s = ReadyFirstSampler(buf, max_staleness_versions=1)
 
         assert _run(s.evict(current_train_weight=5)) == 0
-        meta, n = _run(
+        selection = _run(
             s.select(current_train_weight=5, min_prompt_groups=1, max_prompt_groups=1)
         )
 
-        assert n == 1
-        assert meta is not None
-        assert meta.sample_ids == ["late_g0"]
+        assert selection.num_groups == 1
+        assert selection.meta is not None
+        assert selection.meta.sample_ids == ["late_g0"]
         assert buf.remove_calls == [([0], False)]
 
 
@@ -647,10 +648,10 @@ class TestInOrderSelect:
         # weight far outside any window, but target_step == trainer version.
         buf.add("g", weight=100, target_step=5)
         s = InOrderSampler(buf, max_lookahead_versions=1)
-        meta, n = _run(
+        selection = _run(
             s.select(current_train_weight=5, min_prompt_groups=1, max_prompt_groups=8)
         )
-        assert n == 1
+        assert selection.num_groups == 1
 
     def test_non_matching_target_not_selected(self):
         buf = FakeBuffer()
@@ -658,7 +659,7 @@ class TestInOrderSelect:
         s = InOrderSampler(buf, max_lookahead_versions=1)
         assert _run(
             s.select(current_train_weight=5, min_prompt_groups=1, max_prompt_groups=8)
-        ) == (None, 0)
+        ) == SamplerSelection(meta=None, num_groups=0, trajectory_ages=())
 
 
 class TestDefaultEvictSkipsUnready:
@@ -787,7 +788,7 @@ NOT_A_SAMPLER_CLASS = object()
 
 
 class TestSelectionStaleness:
-    """``last_selection_trajectory_ages`` reports the age of what select returned.
+    """The selection result reports the age of every returned group.
 
     The two existing staleness metrics count only what was discarded, and both
     are structurally zero under ready_first: its ``evict`` returns 0 and it
@@ -801,13 +802,13 @@ class TestSelectionStaleness:
             buf.add(f"g{i}", weight=weight)
         s = ReadyFirstSampler(buf, max_staleness_versions=1)
 
-        meta, n = _run(
+        selection = _run(
             s.select(current_train_weight=9, min_prompt_groups=1, max_prompt_groups=3)
         )
 
-        assert n == 3
-        assert meta is not None
-        assert s.last_selection_trajectory_ages == [7, 4, 2]
+        assert selection.num_groups == 3
+        assert selection.meta is not None
+        assert selection.trajectory_ages == (7, 4, 2)
 
     def test_reports_only_the_groups_actually_selected(self):
         buf = FakeBuffer()
@@ -815,24 +816,28 @@ class TestSelectionStaleness:
             buf.add(f"g{i}", weight=weight)
         s = ReadyFirstSampler(buf, max_staleness_versions=1)
 
-        _, n = _run(
+        selection = _run(
             s.select(current_train_weight=5, min_prompt_groups=1, max_prompt_groups=2)
         )
 
-        assert n == 2
-        assert s.last_selection_trajectory_ages == [5, 4]
+        assert selection.num_groups == 2
+        assert selection.trajectory_ages == (5, 4)
 
     def test_selecting_nothing_clears_the_previous_reading(self):
         buf = FakeBuffer()
         buf.add("g0", weight=1)
         s = ReadyFirstSampler(buf, max_staleness_versions=1)
 
-        _run(s.select(current_train_weight=4, min_prompt_groups=1, max_prompt_groups=1))
-        assert s.last_selection_trajectory_ages == [3]
+        selection = _run(
+            s.select(current_train_weight=4, min_prompt_groups=1, max_prompt_groups=1)
+        )
+        assert selection.trajectory_ages == (3,)
 
         # Buffer now empty: a stale reading must not survive into the next step.
-        _run(s.select(current_train_weight=5, min_prompt_groups=1, max_prompt_groups=1))
-        assert s.last_selection_trajectory_ages == []
+        selection = _run(
+            s.select(current_train_weight=5, min_prompt_groups=1, max_prompt_groups=1)
+        )
+        assert selection.trajectory_ages == ()
 
     def test_unready_groups_are_not_counted(self):
         buf = FakeBuffer()
@@ -840,12 +845,12 @@ class TestSelectionStaleness:
         buf.add("g1", weight=3, ready=True)
         s = ReadyFirstSampler(buf, max_staleness_versions=1)
 
-        _, n = _run(
+        selection = _run(
             s.select(current_train_weight=6, min_prompt_groups=1, max_prompt_groups=4)
         )
 
-        assert n == 1
-        assert s.last_selection_trajectory_ages == [3]
+        assert selection.num_groups == 1
+        assert selection.trajectory_ages == (3,)
 
     @pytest.mark.parametrize(
         "sampler_factory",
@@ -861,12 +866,12 @@ class TestSelectionStaleness:
         buf.add("g0", weight=3)
         s = sampler_factory(buf)
 
-        _, n = _run(
+        selection = _run(
             s.select(current_train_weight=5, min_prompt_groups=1, max_prompt_groups=1)
         )
 
-        assert n == 1
-        assert s.last_selection_trajectory_ages == [2]
+        assert selection.num_groups == 1
+        assert selection.trajectory_ages == (2,)
 
     def test_in_order_reports_it_too(self):
         """InOrderSampler selects on target_step, but still reports by weight.
@@ -881,12 +886,12 @@ class TestSelectionStaleness:
         buf.add("g0", weight=3, target_step=5)
         s = InOrderSampler(buf, max_lookahead_versions=4)
 
-        _, n = _run(
+        selection = _run(
             s.select(current_train_weight=5, min_prompt_groups=1, max_prompt_groups=1)
         )
 
-        assert n == 1
-        assert s.last_selection_trajectory_ages == [2]
+        assert selection.num_groups == 1
+        assert selection.trajectory_ages == (2,)
 
     def test_age_is_reported_unclamped(self):
         """A group newer than the trainer reports a negative age, not zero.
@@ -901,9 +906,9 @@ class TestSelectionStaleness:
         buf.add("g0", weight=7, target_step=5)
         s = InOrderSampler(buf, max_lookahead_versions=4)
 
-        _, n = _run(
+        selection = _run(
             s.select(current_train_weight=5, min_prompt_groups=1, max_prompt_groups=1)
         )
 
-        assert n == 1
-        assert s.last_selection_trajectory_ages == [-2]
+        assert selection.num_groups == 1
+        assert selection.trajectory_ages == (-2,)

--- a/tests/unit/single_controller/test_single_controller_actor.py
+++ b/tests/unit/single_controller/test_single_controller_actor.py
@@ -26,7 +26,10 @@ from tensordict import TensorDict
 
 import nemo_rl.algorithms.single_controller as single_controller
 from nemo_rl.algorithms.async_utils.replay_buffer import DataPlaneCheckpointBarrier
-from nemo_rl.algorithms.async_utils.staleness_sampler import BaseSampler
+from nemo_rl.algorithms.async_utils.staleness_sampler import (
+    BaseSampler,
+    SamplerSelection,
+)
 from nemo_rl.algorithms.grpo import GRPOConfig, _initial_grpo_save_state
 from nemo_rl.algorithms.loss import ClippedPGLossConfig
 from nemo_rl.algorithms.metric_utils import SetupTimingMetrics
@@ -1097,7 +1100,7 @@ class _EmptySampler:
 
     async def select(self, **kwargs):
         del kwargs
-        return None, 0
+        return SamplerSelection(meta=None, num_groups=0, trajectory_ages=())
 
 
 class _OneThenEmptySampler(_EmptySampler):
@@ -1107,10 +1110,10 @@ class _OneThenEmptySampler(_EmptySampler):
     async def select(self, **kwargs):
         del kwargs
         if self._meta is None:
-            return None, 0
+            return SamplerSelection(meta=None, num_groups=0, trajectory_ages=())
         meta = self._meta
         self._meta = None
-        return meta, 1
+        return SamplerSelection(meta=meta, num_groups=1, trajectory_ages=(0,))
 
 
 class _EvictingSampler(_OneThenEmptySampler):
@@ -1119,14 +1122,21 @@ class _EvictingSampler(_OneThenEmptySampler):
         return 2
 
     async def select(self, **kwargs):
-        meta, num_groups = await super().select(**kwargs)
-        return meta, 2 if num_groups else 0
+        selection = await super().select(**kwargs)
+        num_groups = 2 if selection.num_groups else 0
+        ages = selection.trajectory_ages * num_groups
+        return SamplerSelection(selection.meta, num_groups, ages)
 
 
 class _FullStepSampler(_OneThenEmptySampler):
     async def select(self, **kwargs):
-        meta, num_groups = await super().select(**kwargs)
-        return meta, 2 if num_groups else 0
+        selection = await super().select(**kwargs)
+        num_groups = 2 if selection.num_groups else 0
+        return SamplerSelection(
+            selection.meta,
+            num_groups,
+            selection.trajectory_ages * num_groups,
+        )
 
 
 class _ChunkedSampler(_EmptySampler):
@@ -1152,9 +1162,13 @@ class _ChunkedSampler(_EmptySampler):
             (kwargs["min_prompt_groups"], kwargs["max_prompt_groups"])
         )
         if self._remaining == 0:
-            return None, 0
+            return SamplerSelection(meta=None, num_groups=0, trajectory_ages=())
         self._remaining -= 1
-        return self._meta, self._groups_per_chunk
+        return SamplerSelection(
+            self._meta,
+            self._groups_per_chunk,
+            (0,) * self._groups_per_chunk,
+        )
 
 
 class _SequenceSampler(_EmptySampler):
@@ -1164,8 +1178,8 @@ class _SequenceSampler(_EmptySampler):
     async def select(self, **kwargs):
         del kwargs
         if not self._metas:
-            return None, 0
-        return self._metas.pop(0), 1
+            return SamplerSelection(meta=None, num_groups=0, trajectory_ages=())
+        return SamplerSelection(self._metas.pop(0), 1, (0,))
 
 
 class _EmptyBuffer:
@@ -1487,10 +1501,10 @@ class _DroppingSampler(_OneThenEmptySampler):
         BaseSampler._validate_group_bounds(
             kwargs["min_prompt_groups"], kwargs["max_prompt_groups"]
         )
-        meta, num_groups = await super().select(**kwargs)
-        if meta is None and not self._credit_in_evict:
+        selection = await super().select(**kwargs)
+        if selection.meta is None and not self._credit_in_evict:
             self._credit()
-        return meta, num_groups
+        return selection
 
 
 def _dropping_controller(*, credit_in_evict: bool):
@@ -1590,15 +1604,13 @@ class _AgeReportingSampler(_EmptySampler):
     def __init__(self, meta: KVBatchMeta, age_batches: list[list[int]]) -> None:
         self._meta = meta
         self._age_batches = list(age_batches)
-        self.last_selection_trajectory_ages: list[int] = []
 
     async def select(self, **kwargs):
         del kwargs
         if not self._age_batches:
-            self.last_selection_trajectory_ages = []
-            return None, 0
-        self.last_selection_trajectory_ages = self._age_batches.pop(0)
-        return self._meta, 1
+            return SamplerSelection(meta=None, num_groups=0, trajectory_ages=())
+        ages = tuple(self._age_batches.pop(0))
+        return SamplerSelection(self._meta, 1, ages)
 
 
 def _age_meta() -> KVBatchMeta:
@@ -1639,10 +1651,14 @@ def test_train_pump_accumulates_trajectory_age_across_every_select(monkeypatch):
 
 
 def test_train_pump_omits_trajectory_age_when_no_ages_are_reported(monkeypatch):
-    """A sampler that reports no ages must leave the keys out, not divide by
-    zero. This is the path every sampler without the property takes -- the
-    metric is deliberately not on the Protocol."""
-    ctrl = _train_pump_controller(sampler=_OneThenEmptySampler(_age_meta()))
+    """A legacy two-tuple sampler must leave trajectory-age metrics out."""
+
+    class _LegacyOneThenEmptySampler(_OneThenEmptySampler):
+        async def select(self, **kwargs):
+            selection = await super().select(**kwargs)
+            return selection.meta, selection.num_groups
+
+    ctrl = _train_pump_controller(sampler=_LegacyOneThenEmptySampler(_age_meta()))
     ctrl._master_config.grpo.num_prompts_per_step = 1
     ctrl._sync_weights = AsyncMock(return_value=0)
     ctrl._logger = MagicMock()

--- a/tests/unit/single_controller/test_single_controller_actor.py
+++ b/tests/unit/single_controller/test_single_controller_actor.py
@@ -1579,6 +1579,83 @@ def test_train_pump_prunes_stamps_older_than_the_step_that_just_closed(
     assert ctrl._batch_shortfall == {5: 1}
 
 
+class _AgeReportingSampler(_EmptySampler):
+    """Yields one meta per configured age list, then goes empty.
+
+    A step is assembled from several selects on the streaming path, so the
+    metric has to accumulate ACROSS them -- an assignment instead of an extend
+    reports only the last select's ages and passes any single-select test.
+    """
+
+    def __init__(self, meta: KVBatchMeta, age_batches: list[list[int]]) -> None:
+        self._meta = meta
+        self._age_batches = list(age_batches)
+        self.last_selection_trajectory_ages: list[int] = []
+
+    async def select(self, **kwargs):
+        del kwargs
+        if not self._age_batches:
+            self.last_selection_trajectory_ages = []
+            return None, 0
+        self.last_selection_trajectory_ages = self._age_batches.pop(0)
+        return self._meta, 1
+
+
+def _age_meta() -> KVBatchMeta:
+    return KVBatchMeta(
+        partition_id="rollout_data",
+        task_name="train",
+        sample_ids=["sample-0"],
+        fields=[],
+        sequence_lengths=[1],
+        tags=[{"weight_version": 0}],
+    )
+
+
+def _run_age_pump(age_batches, monkeypatch) -> dict:
+    ctrl = _train_pump_controller(
+        sampler=_AgeReportingSampler(_age_meta(), age_batches)
+    )
+    ctrl._master_config.grpo.num_prompts_per_step = len(age_batches) or 1
+    ctrl._sync_weights = AsyncMock(return_value=0)
+    ctrl._logger = MagicMock()
+    monkeypatch.setattr(single_controller.ray, "cluster_resources", lambda: {})
+
+    asyncio.run(asyncio.wait_for(ctrl._train_pump(), timeout=1.0))
+
+    for call in ctrl._logger.log_metrics.call_args_list:
+        metrics = call.args[0] if call.args else call.kwargs.get("metrics", {})
+        if "avg_trajectory_age" in metrics or "max_trajectory_age" in metrics:
+            return metrics
+    return {}
+
+
+def test_train_pump_accumulates_trajectory_age_across_every_select(monkeypatch):
+    """Two selects in one step. Averaging only the last one would give 5.0."""
+    metrics = _run_age_pump([[1, 3], [5, 5]], monkeypatch)
+
+    assert metrics.get("avg_trajectory_age") == pytest.approx(3.5)
+    assert metrics.get("max_trajectory_age") == 5
+
+
+def test_train_pump_omits_trajectory_age_when_no_ages_are_reported(monkeypatch):
+    """A sampler that reports no ages must leave the keys out, not divide by
+    zero. This is the path every sampler without the property takes -- the
+    metric is deliberately not on the Protocol."""
+    ctrl = _train_pump_controller(sampler=_OneThenEmptySampler(_age_meta()))
+    ctrl._master_config.grpo.num_prompts_per_step = 1
+    ctrl._sync_weights = AsyncMock(return_value=0)
+    ctrl._logger = MagicMock()
+    monkeypatch.setattr(single_controller.ray, "cluster_resources", lambda: {})
+
+    asyncio.run(asyncio.wait_for(ctrl._train_pump(), timeout=1.0))
+
+    for call in ctrl._logger.log_metrics.call_args_list:
+        metrics = call.args[0] if call.args else call.kwargs.get("metrics", {})
+        assert "avg_trajectory_age" not in metrics
+        assert "max_trajectory_age" not in metrics
+
+
 @pytest.mark.parametrize(
     (
         "policy_logprobs_required",


### PR DESCRIPTION
## What does this PR do?

Reports `avg_trajectory_age` and `max_trajectory_age` for trajectories consumed by each Single Controller train step.

Built-in samplers return a typed `SamplerSelection` with selected metadata, group count, and trajectory ages. The train pump accumulates ages across all selections contributing to a step. External samplers returning the existing two-tuple remain compatible.

Age is `current_train_weight - selected_group.start_weight`, intentionally unclamped so invalid negative ages remain visible.

## Validation

Refreshed September 18: head `a8687819be2f51922d78ae619224f80495e95102`, based on upstream `main` at `b7a4d95d9099bae2b7f3713cc402aed3f21aef8d`.

| Check | Scope | Result |
| --- | --- | --- |
| Current-head CPU suite | sampler interface, SC actor, checkpointing and train-pump E2E tests | 237 passed; 1 existing main-equivalent failure |
| Current-head static checks | Ruff, import sorting, formatting, diff check, DCO | passed |

The unchanged `TestPeriodicRolloutCheckpoint::test_logs_raw_and_canonical_rollout_throughput` assertion expects `20.0` and observes `6.666666666666667`. It fails identically on unmodified current main in the same local harness. It was included in the complete run, not deselected.

Environment: macOS arm64, Python 3.12.2, pytest 8.4.2, torch 2.8.0 CPU, Ray 2.51.1. This is not locked Linux worker or maintainer-CI validation. Rebase conflicts were limited to adjacent imports; range-diff preserves the feature/test commits. One test import ordering correction is included.

Coverage includes selected-only accounting, unclamped ages, reset behavior, every built-in sampler, external two-tuple compatibility, multi-selection accumulation, rollout metrics, and checkpoint restore. Main's eviction-before-selection ordering remains intact.

## Earlier GPU evidence

Pre-refresh head `b48548c6dd692d10dab3a831f70d74abac6eb33d` completed a 2×H100 run with Qwen3-0.6B, Megatron policy, real vLLM rollout, native TQ, `ready_first`, importance-sampling correction, and `max_staleness_versions=3`:

| train step | 1 | 2 | 3 | 4 | 5 | 6 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `avg_trajectory_age` | 0 | 1 | 2 | 3 | 3 | 3 |
| `max_trajectory_age` | 0 | 1 | 2 | 3 | 3 | 3 |

It finished at `train_steps=6`, `trainer_version=6`, with no evicted, aborted, dropped, or replaced groups. This was **not rerun at the current head**; current-head GPU confirmation remains pending.
