### PR TITLE
fix(ppo): let async PPO reach the three settings the collector hard-coded

### DIFF
--- a/examples/configs/ppo_math_1B.yaml
+++ b/examples/configs/ppo_math_1B.yaml
@@ -34,6 +34,10 @@ ppo:
     max_trajectory_age_steps: 1
     # Requires policy_training_start_step > 0. null uses max_trajectory_age_steps.
     warmup_generation_lead_steps: null
+    # Number of generation-worker failures tolerated before aborting.
+    # 0 (default) = fail on the first worker exception. Increase only
+    # when transient generation errors are expected and acceptable to drop.
+    max_generation_failures: 0
     in_flight_weight_updates: false
     recompute_kv_cache_after_weight_updates: false
     # true discards partial restored rows and fills from subsequent prompts.

--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -177,9 +177,11 @@ class AsyncTrajectoryCollector:
         elif isinstance(master_config, PPOMasterConfig):
             algorithm_config = master_config.ppo
             async_config = algorithm_config.async_ppo  # type: ignore
-            self._deduplicate_multimodal_data = False
-            self._debug_payload_metrics = False
-            self._max_generation_failures = 0
+            self._deduplicate_multimodal_data = (
+                algorithm_config.deduplicate_multimodal_data
+            )
+            self._debug_payload_metrics = algorithm_config.debug_payload_metrics
+            self._max_generation_failures = async_config.max_generation_failures
         else:
             raise TypeError(
                 "master_config must be a GRPO or PPO MasterConfig, got "

--- a/nemo_rl/algorithms/ppo.py
+++ b/nemo_rl/algorithms/ppo.py
@@ -138,6 +138,10 @@ class AsyncPPOConfig(BaseModel, extra="allow"):
     # Number of future target steps generation may fill during critic warmup.
     # None uses max_trajectory_age_steps as the generation lead.
     warmup_generation_lead_steps: int | None = Field(default=None, ge=1)
+    # Generation-worker failures tolerated before the AsyncTrajectoryCollector
+    # aborts the run. A successful batch worker resets the count.
+    # 0 makes the very first worker exception fatal.
+    max_generation_failures: int = Field(default=0, ge=0)
     # Allows weight updates while rollout requests are still in flight.
     in_flight_weight_updates: bool = False
     # Recomputes the KV cache after weight updates.
@@ -192,6 +196,11 @@ class PPOConfig(BaseModel, extra="allow"):
     batch_multiplier: float = 1.0
     # Number of actor (policy) passes over each rollout batch.
     ppo_epochs: int = 4
+    # Share and compact immutable image/video/audio payload segments across
+    # logical PPO rows. Prompt identity is never used as proof of equality.
+    deduplicate_multimodal_data: bool = False
+    # Emit exact-boundary and logical-vs-physical payload metrics.
+    debug_payload_metrics: bool = False
     # Number of critic (value) passes over each rollout batch. Defaults to
     # ppo_epochs (see validate_epoch) unless explicitly set.
     critic_ppo_epochs: int = 4

--- a/tests/unit/algorithms/test_async_utils.py
+++ b/tests/unit/algorithms/test_async_utils.py
@@ -2485,6 +2485,42 @@ class TestAsyncTrajectoryCollector:
         assert collector._max_trajectory_age_steps == 5
         assert collector._calculate_target_weights(2) == [3, 4, 5]
 
+    def test_collector_reads_ppo_payload_and_failure_settings(self):
+        """The PPO branch must read these, not hard-code them.
+
+        The GRPO branch ten lines above reads all three from config. The PPO
+        branch used to pin them to False/False/0, so no recipe could reach
+        them -- and ``max_generation_failures=0`` makes the very first
+        generation-worker exception fatal, with no way to opt into tolerating
+        transient failures.
+        """
+        from nemo_rl.algorithms.ppo import AsyncPPOConfig, PPOConfig
+        from nemo_rl.algorithms.ppo import MasterConfig as PPOMasterConfig
+
+        master_config = PPOMasterConfig.model_construct(
+            policy={"make_sequence_length_divisible_by": 1},
+            ppo=PPOConfig.model_construct(
+                num_prompts_per_step=2,
+                num_generations_per_prompt=4,
+                max_rollout_turns=1,
+                deduplicate_multimodal_data=True,
+                debug_payload_metrics=True,
+                async_ppo=AsyncPPOConfig(max_generation_failures=3),
+            ),
+        )
+        collector_cls = AsyncTrajectoryCollector.__ray_metadata__.modified_class
+        collector = collector_cls(
+            policy_generation=MockGenerationInterface(),
+            tokenizer=mock.MagicMock(),
+            task_to_env={},
+            master_config=master_config,
+            replay_buffer=mock.MagicMock(),
+        )
+
+        assert collector._deduplicate_multimodal_data is True
+        assert collector._debug_payload_metrics is True
+        assert collector._max_generation_failures == 3
+
     def test_collector_grpo_window_remains_fixed(self):
         collector = self.create_local_collector()
 


### PR DESCRIPTION
## What does this PR do?

Lets async PPO configure three collector settings that were hard-coded on its branch:

- `deduplicate_multimodal_data`
- `debug_payload_metrics`
- `async_ppo.max_generation_failures`

Defaults stay unchanged (`false`, `false`, and `0`). A zero failure budget still fails on the first generation-worker exception; a positive value now permits the requested number of failures.

This is the first item in #3695. Async PPO already requires a non-colocated asynchronous vLLM backend, so the refresh keeps the configuration path small and does not add a second backend guard.

## Validation

Current head `afa5a3f2f39fce2e3b3c3e16edb6c8f92130e42c`, rebased onto upstream `main` at `90a2a212d503455d8590be5c8de3cb989d3425b0`.

- full `tests/unit/algorithms/test_async_utils.py`: **117 passed**
- covers PPO config selection, payload/debug/failure forwarding, Gym and non-Gym batching, failure thresholds, replay/refit behavior, and collector telemetry
- pytest 9.1.1 with the repository-locked `pytest-asyncio` 1.4.0
- Ruff check, Ruff format check, and `git diff --check`: passed

The suite runs with a local CPU Ray cluster; no GPU workload is required for these configuration and collector regressions.
