### PR TITLE
refactor(dynamo): move native token response handling to Gym

### DIFF
--- a/docs/design-docs/dynamo-integration.md
+++ b/docs/design-docs/dynamo-integration.md
@@ -23,9 +23,12 @@ NATS, etcd, and temporary state independently.
 
 Both GRPO trainers use `DynamoGeneration.generate_async()` against the managed
 frontend. NeMo-Gym traffic passes through a process-local token wrapper. It
-uses the policy tokenizer, preserves caller `nvext.extra_fields`, adds Dynamo
-engine metadata, and translates rendered multi-turn prefixes back to the exact
-caller token IDs.
+uses the policy tokenizer, replaces rendered multi-turn prefixes with Gym's
+exact `required_prefix_token_ids`, and sends `nvext.token_data`. For the Dynamo
+backend, NeMo-RL configures Gym to request `nvext.engine_data`; this request
+also tells Gym when to derive the exact prefix. The wrapper returns Dynamo
+responses unchanged. NeMo-Gym validates the native engine data and creates the
+training token bundle.
 
 Serialized rollout copies contain only frontend URLs and immutable worker
 admin endpoints. They cannot own or stop services. Those endpoints are enough

--- a/docs/guides/dynamo-generation.md
+++ b/docs/guides/dynamo-generation.md
@@ -57,8 +57,11 @@ must update and reverify these coupled locations:
   the version-specific #44814 backport
 - `tests/unit/distributed/test_stateless_process_group.py`: vLLM's
   `broadcast_from/0/0` weight-transfer wire key
-- `nemo_rl/models/generation/dynamo/token_wrapper.py`: the real Dynamo response
-  keys `nvext.engine_data.{prompt_token_ids,completion_token_ids,completion_logprobs}`;
+- `nemo_rl/models/generation/dynamo/token_wrapper.py`: the request-side
+  `nvext.extra_fields=["engine_data"]` signal and `nvext.token_data` prompt
+- `3rdparty/Gym-workspace/Gym/responses_api_models/vllm_model/app.py`: the real
+  Dynamo response keys
+  `nvext.engine_data.{prompt_token_ids,completion_token_ids,completion_logprobs}`;
   reverify them against real Dynamo output because unit tests validate only the
   expected local response shape
 - `nemo_rl/models/generation/dynamo/managed_runtime.py`: the managed

--- a/examples/nemo_gym/grpo_dynamo_gym_smoke.yaml
+++ b/examples/nemo_gym/grpo_dynamo_gym_smoke.yaml
@@ -1,0 +1,121 @@
+# Two-step, two-GPU tool-enabled smoke for NeMo-Gym with managed Dynamo vLLM.
+defaults: grpo_qwen3_30ba3b_instruct.yaml
+
+grpo:
+  max_num_epochs: 1
+  num_prompts_per_step: 2
+  num_generations_per_prompt: 2
+  max_num_steps: 2
+  val_period: 0
+  val_at_start: false
+  val_at_end: false
+  async_grpo:
+    enabled: true
+    max_trajectory_age_steps: 1
+    in_flight_weight_updates: false
+    recompute_kv_cache_after_weight_updates: true
+
+loss_fn:
+  use_importance_sampling_correction: true
+  truncated_importance_sampling_type: tis
+  truncated_importance_sampling_ratio: 2.0
+
+checkpointing:
+  enabled: false
+
+policy:
+  model_name: Qwen/Qwen3-0.6B
+  tokenizer:
+    name: Qwen/Qwen3-0.6B
+  train_global_batch_size: 4
+  train_micro_batch_size: 1
+  logprob_batch_size: 1
+  max_total_sequence_length: 768
+  sequence_packing:
+    enabled: false
+  dtensor_cfg:
+    _v2: false
+    enabled: true
+    cpu_offload: false
+    activation_checkpointing: false
+    tensor_parallel_size: 1
+    context_parallel_size: 1
+    sequence_parallel: false
+  make_sequence_length_divisible_by: 1
+  optimizer:
+    name: torch.optim.AdamW
+    kwargs:
+      lr: 5.0e-6
+      weight_decay: 0.01
+      betas: [0.9, 0.999]
+      eps: 1.0e-8
+  scheduler:
+    - name: torch.optim.lr_scheduler.ConstantLR
+      kwargs:
+        factor: 1.0
+        total_iters: 2
+    - milestones: []
+  megatron_cfg:
+    enabled: false
+  generation:
+    backend: dynamo
+    max_new_tokens: 128
+    dynamo_cfg:
+      engine: vllm
+      startup_timeout_s: 600
+      request_timeout_s: 900
+      control_timeout_s: 600
+      metrics_include_prefixes: null
+      metrics_exclude_prefixes: null
+      worker_args:
+        # Dynamo 1.3.0 routes qwen3_coder + tool_choice=auto through its v2
+        # parser. This smoke targets that parser's nvext.engine_data transport.
+        tool_call_parser: qwen3_coder
+        reasoning_parser: null
+        exclude_tools_when_tool_choice_none: true
+        enable_structural_tag: false
+        structural_tag_scope: auto
+        structural_tag_schema: auto
+        custom_jinja_template: null
+        endpoint_types: [chat, completions]
+        extra_cli_args: []
+      frontend_args:
+        tokenizer: default
+        tokenizer_cache: false
+        tokenizer_cache_bytes: 52428800
+        router_mode: kv
+        router_reset_states: true
+        extra_cli_args: []
+    vllm_cfg:
+      async_engine: true
+      expose_http_server: true
+      tensor_parallel_size: 1
+      pipeline_parallel_size: 1
+      expert_parallel_size: 1
+      precision: bfloat16
+      gpu_memory_utilization: 0.6
+      max_model_len: ${policy.max_total_sequence_length}
+      kv_cache_dtype: auto
+      enforce_eager: true
+      enable_vllm_metrics_logger: true
+      vllm_metrics_logger_interval: 1.0
+      http_server_serving_chat_kwargs: null
+      env_vars:
+        NCCL_MNNVL_ENABLE: "0"
+    vllm_kwargs:
+      max_num_seqs: 8
+    colocated:
+      enabled: false
+      resources:
+        gpus_per_node: 1
+        num_nodes: 1
+
+logger:
+  log_dir: results/grpo-dynamo-gym-smoke
+  wandb_enabled: false
+  tensorboard_enabled: true
+  monitor_gpus: false
+
+cluster:
+  gpus_per_node: 2
+  num_nodes: 1

--- a/nemo_rl/environments/nemo_gym.py
+++ b/nemo_rl/environments/nemo_gym.py
@@ -17,7 +17,7 @@ import os
 import subprocess
 import sys
 from collections import Counter
-from collections.abc import AsyncGenerator, Mapping
+from collections.abc import AsyncGenerator, Mapping, MutableMapping
 from pathlib import Path
 from typing import Any, Dict, List, NotRequired, Optional, Protocol, TypedDict
 
@@ -1238,10 +1238,14 @@ def validate_reward_components_match_scalar(nemo_gym_results: List[dict]) -> Non
 
 
 def setup_nemo_gym_config(config, tokenizer) -> None:
+    """Configure NeMo-Gym for the selected generation backend.
+
+    Dynamo idempotently requests engine data so Gym can derive exact prefixes.
+    """
     generation_config = config.policy["generation"]
 
     backend = generation_config.get("backend")
-    if backend == "vllm":
+    if backend in ("vllm", "dynamo"):
         # Enable the http server. Requires both async engine and the expose_http_server flag
         generation_config["vllm_cfg"]["async_engine"] = True
         generation_config["vllm_cfg"]["expose_http_server"] = True
@@ -1254,6 +1258,39 @@ def setup_nemo_gym_config(config, tokenizer) -> None:
     # Stop strings or token ids are not supported
     generation_config["stop_strings"] = None
     generation_config["stop_token_ids"] = None
+
+    if generation_config["backend"] == "dynamo":
+        env_cfg = config.env.setdefault("nemo_gym", {})
+        model_cfg = (
+            env_cfg.setdefault("policy_model", {})
+            .setdefault("responses_api_models", {})
+            .setdefault("vllm_model", {})
+        )
+        extra_body = model_cfg.get("extra_body")
+        if extra_body is None:
+            model_cfg["extra_body"] = {}
+            extra_body = model_cfg["extra_body"]
+        if not isinstance(extra_body, MutableMapping):
+            raise ValueError(
+                "env.nemo_gym policy model extra_body must be a mapping or null."
+            )
+
+        nvext = extra_body.get("nvext")
+        if nvext is None:
+            extra_body["nvext"] = {}
+            nvext = extra_body["nvext"]
+        if not isinstance(nvext, MutableMapping):
+            raise ValueError(
+                "env.nemo_gym policy model extra_body.nvext must be a mapping or null."
+            )
+
+        extra_fields = nvext.setdefault("extra_fields", [])
+        if not isinstance(extra_fields, list):
+            raise ValueError(
+                "env.nemo_gym policy model nvext.extra_fields must be a list."
+            )
+        if "engine_data" not in extra_fields:
+            extra_fields.append("engine_data")
 
     # For VLM runs, plumb the tokenizer config into the gym env config so the
     # NemoGym actor can reconstruct the processor inside itself (needed for

--- a/nemo_rl/models/generation/dynamo/token_wrapper.py
+++ b/nemo_rl/models/generation/dynamo/token_wrapper.py
@@ -46,17 +46,6 @@ def _coerce_token_id_list(value: Any, field_name: str) -> list[int]:
         raise ValueError(f"{field_name} must contain only integer token IDs.") from e
 
 
-def _coerce_logprob_list(value: Any, field_name: str) -> list[float]:
-    if not isinstance(value, list):
-        raise ValueError(f"{field_name} must be a list of numeric log probabilities.")
-    logprobs: list[float] = []
-    for index, logprob in enumerate(value):
-        if not isinstance(logprob, (int, float)) or isinstance(logprob, bool):
-            raise ValueError(f"{field_name}[{index}] must be numeric.")
-        logprobs.append(float(logprob))
-    return logprobs
-
-
 def _strip_gym_token_metadata(messages: list[Any]) -> list[Any]:
     stripped_messages = deepcopy(messages)
     for message in stripped_messages:
@@ -202,19 +191,6 @@ def _latest_tokenized_assistant_index(messages: list[Any]) -> Optional[int]:
     return None
 
 
-def _derive_required_prefix_token_ids(messages: list[Any]) -> list[int] | None:
-    """Return the exact prompt and generation IDs from the latest model turn."""
-    assistant_index = _latest_tokenized_assistant_index(messages)
-    if assistant_index is None:
-        return None
-    message = messages[assistant_index]
-    if not isinstance(message, dict):
-        return None
-    return _coerce_token_id_list(
-        message["prompt_token_ids"], "prompt_token_ids"
-    ) + _coerce_token_id_list(message["generation_token_ids"], "generation_token_ids")
-
-
 def _normalize_tool_arguments_for_template(
     messages: list[Any], *, before_index: int
 ) -> None:
@@ -249,56 +225,6 @@ def _normalize_tool_arguments_for_template(
             )
 
 
-def _validate_engine_data(
-    response_body: dict[str, Any],
-) -> tuple[list[int], list[int], list[float]]:
-    nvext = response_body.get("nvext")
-    engine_data = nvext.get("engine_data") if isinstance(nvext, dict) else None
-    if not isinstance(engine_data, dict):
-        raise ValueError("Dynamo response did not include nvext.engine_data.")
-
-    prompt_token_ids = _coerce_token_id_list(
-        engine_data.get("prompt_token_ids"),
-        "nvext.engine_data.prompt_token_ids",
-    )
-    completion_token_ids = _coerce_token_id_list(
-        engine_data.get("completion_token_ids"),
-        "nvext.engine_data.completion_token_ids",
-    )
-    completion_logprobs = _coerce_logprob_list(
-        engine_data.get("completion_logprobs"),
-        "nvext.engine_data.completion_logprobs",
-    )
-    if len(completion_logprobs) != len(completion_token_ids):
-        raise ValueError(
-            "Dynamo response returned "
-            f"{len(completion_logprobs)} generation log probabilities for "
-            f"{len(completion_token_ids)} generation token IDs."
-        )
-    return prompt_token_ids, completion_token_ids, completion_logprobs
-
-
-def _inject_gym_token_metadata(response_body: dict[str, Any]) -> None:
-    """Expose Dynamo engine metadata on the message fields consumed by Gym."""
-    (
-        prompt_token_ids,
-        generation_token_ids,
-        generation_logprobs,
-    ) = _validate_engine_data(response_body)
-    choices = response_body.get("choices")
-    if not isinstance(choices, list) or not choices:
-        raise ValueError("Dynamo response did not include choices[0].")
-    choice = choices[0]
-    if not isinstance(choice, dict):
-        raise ValueError("Dynamo response choices[0] must be a JSON object.")
-    message = choice.get("message")
-    if not isinstance(message, dict):
-        raise ValueError("Dynamo response choices[0].message must be a JSON object.")
-    message["prompt_token_ids"] = prompt_token_ids
-    message["generation_token_ids"] = generation_token_ids
-    message["generation_log_probs"] = generation_logprobs
-
-
 def prepare_dynamo_chat_completion_request(
     request_body: dict[str, Any],
     *,
@@ -306,7 +232,11 @@ def prepare_dynamo_chat_completion_request(
     tokenizer_chat_template_kwargs: Optional[dict[str, Any]] = None,
     exclude_tools_when_tool_choice_none: bool,
 ) -> dict[str, Any]:
-    """Prepare a NeMo-Gym chat-completion request for Dynamo token input."""
+    """Prepare a NeMo-Gym chat-completion request for Dynamo token input.
+
+    Gym owns prefix derivation. A tokenized assistant message and its Gym prefix
+    must be present together.
+    """
     if request_body.get("stream"):
         raise ValueError("Dynamo native token wrapper does not support stream=True.")
 
@@ -321,18 +251,29 @@ def prepare_dynamo_chat_completion_request(
     prepared_body = deepcopy(request_body)
     stripped_messages = _strip_gym_token_metadata(messages)
     prepared_body["messages"] = stripped_messages
-    prepared_body.pop("required_prefix_token_ids", None)
+    required_prefix_value = prepared_body.pop("required_prefix_token_ids", None)
+    required_prefix_token_ids = (
+        _coerce_token_id_list(
+            required_prefix_value,
+            "required_prefix_token_ids",
+        )
+        if required_prefix_value is not None
+        else None
+    )
 
-    required_prefix_token_ids = _derive_required_prefix_token_ids(messages)
     add_generation_prompt = _request_add_generation_prompt(prepared_body)
     template_messages = deepcopy(stripped_messages)
-    assistant_index: int | None = None
-    if required_prefix_token_ids is not None:
-        assistant_index = _latest_tokenized_assistant_index(messages)
-        if assistant_index is None:
-            raise ValueError(
-                "Dynamo prefix token metadata must be attached to an assistant message."
-            )
+    assistant_index = _latest_tokenized_assistant_index(messages)
+    if assistant_index is not None and not required_prefix_token_ids:
+        raise ValueError(
+            "A tokenized assistant message requires required_prefix_token_ids. "
+            "Set return_token_id_information: true and request "
+            'nvext.extra_fields=["engine_data"].'
+        )
+    if assistant_index is None and required_prefix_token_ids is not None:
+        raise ValueError(
+            "required_prefix_token_ids requires a tokenized assistant message."
+        )
 
     try:
         (
@@ -475,14 +416,6 @@ class DynamoTokenWrapperServer:
                 prepared_body,
                 authorization=request.headers.get("authorization"),
             )
-            if 200 <= status_code < 300:
-                try:
-                    _inject_gym_token_metadata(response_body)
-                except ValueError as e:
-                    return JSONResponse(
-                        content={"error": {"message": str(e)}},
-                        status_code=502,
-                    )
             return JSONResponse(content=response_body, status_code=status_code)
 
         node_ip = _get_node_ip_local()

--- a/tests/functional/L1_Functional_Tests_Dynamo.sh
+++ b/tests/functional/L1_Functional_Tests_Dynamo.sh
@@ -34,6 +34,7 @@ run_test() {
 }
 
 run_test fast uv run --no-sync bash ./tests/functional/grpo_dynamo.sh
+run_test uv run --no-sync bash ./tests/functional/grpo_dynamo_gym.sh
 
 cd "${PROJECT_ROOT}/tests"
 if compgen -G ".coverage*" > /dev/null; then

--- a/tests/functional/grpo_dynamo_gym.sh
+++ b/tests/functional/grpo_dynamo_gym.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+PROJECT_ROOT=$(realpath "${SCRIPT_DIR}/../..")
+EXP_NAME=$(basename "$0" .sh)
+EXP_DIR=${SCRIPT_DIR}/${EXP_NAME}
+LOG_DIR=${EXP_DIR}/logs
+RUN_LOG=${EXP_DIR}/run.log
+DATA_DIR=${EXP_DIR}/data
+GYM_ROOT=${PROJECT_ROOT}/3rdparty/Gym-workspace/Gym
+SOURCE_DATA_DIR=${WORKPLACE_ASSISTANT_DATA_DIR:-${GYM_ROOT}/data/workplace_assistant}
+export PYTHONPATH=${PROJECT_ROOT}:${PYTHONPATH:-}
+
+rm -rf "${EXP_DIR}"
+mkdir -p "${LOG_DIR}" "${DATA_DIR}"
+git config --global --add safe.directory "${PROJECT_ROOT}"
+
+dynamo_python=/opt/dynamo_venv/bin/python
+"${dynamo_python}" -c \
+  'import importlib.metadata as m; assert m.version("ai-dynamo") == "1.3.0.post1"; assert m.version("vllm") == "0.23.0"'
+grep -Fqx \
+  'vllm PR #44814 merge commit c9e5bf813530fb9ce06024e075da0f520b0718c8' \
+  /opt/dynamo_venv/VLLM_BACKPORTS
+
+if [[ ! -f "${SOURCE_DATA_DIR}/train.jsonl" || ! -f "${SOURCE_DATA_DIR}/validation.jsonl" ]]; then
+  if [[ -z "${HF_TOKEN:-}" ]]; then
+    echo "Workplace-assistant data is missing and HF_TOKEN is not set" >&2
+    exit 1
+  fi
+  cd "${GYM_ROOT}"
+  if [[ ! -f env.yaml ]]; then
+    printf 'hf_token: %s\n' "${HF_TOKEN}" > env.yaml
+  fi
+  uv run ng_prepare_data \
+    "+config_paths=[resources_servers/workplace_assistant/configs/workplace_assistant.yaml]" \
+    +output_dirpath=data/workplace_assistant \
+    +mode=train_preparation \
+    +should_download=true \
+    +data_source=huggingface
+  SOURCE_DATA_DIR=${GYM_ROOT}/data/workplace_assistant
+fi
+
+TRAIN_PATH=${DATA_DIR}/workplace_assistant_train.jsonl
+VALIDATION_PATH=${DATA_DIR}/workplace_assistant_validation.jsonl
+jq -c \
+  '.responses_create_params.tools |= (.[0:1]) | .responses_create_params.tool_choice = "auto"' \
+  "${SOURCE_DATA_DIR}/train.jsonl" > "${TRAIN_PATH}"
+jq -c \
+  '.responses_create_params.tools |= (.[0:1]) | .responses_create_params.tool_choice = "auto"' \
+  "${SOURCE_DATA_DIR}/validation.jsonl" > "${VALIDATION_PATH}"
+jq -s -e '
+  all(.[];
+    ((.responses_create_params.tools | type) == "array") and
+    ((.responses_create_params.tools | length) == 1) and
+    (.responses_create_params.tool_choice == "auto")
+  )
+' "${TRAIN_PATH}" "${VALIDATION_PATH}" > /dev/null
+
+cd "${PROJECT_ROOT}"
+uv run --no-sync coverage run -a \
+  --data-file="${PROJECT_ROOT}/tests/.coverage" \
+  --source="${PROJECT_ROOT}/nemo_rl" \
+  "${PROJECT_ROOT}/examples/nemo_gym/run_grpo_nemo_gym.py" \
+  --config "${PROJECT_ROOT}/examples/nemo_gym/grpo_dynamo_gym_smoke.yaml" \
+  logger.log_dir="${LOG_DIR}" \
+  data.train.data_path="${TRAIN_PATH}" \
+  data.validation.data_path="${VALIDATION_PATH}" \
+  "$@" \
+  2>&1 | tee "${RUN_LOG}"
+
+metrics_json=${EXP_DIR}/metrics.json
+uv run --no-sync tests/json_dump_tb_logs.py \
+  "${LOG_DIR}" \
+  --output_path "${metrics_json}" \
+  --require-tag-prefix "train/"
+uv run --no-sync tests/check_metrics.py \
+  "${metrics_json}" \
+  '"2" in data["train/loss"]' \
+  '"2" in data["train/global_valid_seqs"]'
+
+batch_count=$(grep -Fc "Got trajectory batch (size: 4)" "${RUN_LOG}" || true)
+if [[ "${batch_count}" -ne 2 ]]; then
+  echo "Expected two four-rollout training batches; found ${batch_count}" >&2
+  exit 1
+fi
+echo "Completed training rollouts: 8"
+
+refit_count=$(grep -Fc "Performing policy generation refit" "${RUN_LOG}" || true)
+cache_success_count=$(grep -Fc \
+  "Invalidated generation backend KV caches after weight update" \
+  "${RUN_LOG}" || true)
+if [[ "${refit_count}" -eq 0 || "${cache_success_count}" -ne "${refit_count}" ]]; then
+  echo "Expected one successful cache invalidation per refit; refits=${refit_count}, successes=${cache_success_count}" >&2
+  exit 1
+fi
+if grep -Fq "/tokenize" "${RUN_LOG}"; then
+  echo "Dynamo response used the unsupported /tokenize fallback" >&2
+  exit 1
+fi
+if ! grep -Fq "'DYN_ENABLE_EXPERIMENTAL_PARSERS_V2': '1'" "${RUN_LOG}"; then
+  echo "Managed Dynamo did not enable its nvext-preserving v2 tool parser" >&2
+  exit 1
+fi
+if ! grep -Fq "'--dyn-tool-call-parser', 'qwen3_coder'" "${RUN_LOG}"; then
+  echo "Managed Dynamo did not launch the qwen3_coder v2 tool parser" >&2
+  exit 1
+fi
+if pgrep -f '[d]ynamo.frontend|[d]ynamo.vllm|[/]opt/dynamo_venv/bin/etcd|[/]opt/dynamo_venv/bin/nats-server'; then
+  echo "Managed Dynamo processes remain after NeMo-Gym GRPO shutdown" >&2
+  exit 1
+fi

--- a/tests/unit/environments/test_nemo_gym.py
+++ b/tests/unit/environments/test_nemo_gym.py
@@ -1037,6 +1037,128 @@ def test_nemo_gym_stub_module():
     )
 
 
+def test_setup_nemo_gym_config_requests_dynamo_engine_data() -> None:
+    config = SimpleNamespace(
+        policy={"generation": {"backend": "dynamo", "vllm_cfg": {}}},
+        env={
+            "nemo_gym": {
+                "policy_model": {
+                    "responses_api_models": {
+                        "vllm_model": {
+                            "extra_body": {
+                                "chat_template_kwargs": {"enable_thinking": False},
+                                "nvext": {
+                                    "extra_fields": ["timing"],
+                                    "trace": "keep-me",
+                                },
+                            }
+                        }
+                    }
+                }
+            }
+        },
+    )
+
+    # Repeated setup must not duplicate the Dynamo response field.
+    setup_nemo_gym_config(config, tokenizer=None)
+    setup_nemo_gym_config(config, tokenizer=None)
+
+    extra_body = config.env["nemo_gym"]["policy_model"]["responses_api_models"][
+        "vllm_model"
+    ]["extra_body"]
+    assert extra_body == {
+        "chat_template_kwargs": {"enable_thinking": False},
+        "nvext": {
+            "extra_fields": ["timing", "engine_data"],
+            "trace": "keep-me",
+        },
+    }
+
+
+def test_setup_nemo_gym_config_builds_dynamo_engine_data_config() -> None:
+    config = SimpleNamespace(
+        policy={"generation": {"backend": "dynamo", "vllm_cfg": {}}},
+        env={},
+    )
+
+    setup_nemo_gym_config(config, tokenizer=None)
+
+    assert config.env == {
+        "nemo_gym": {
+            "policy_model": {
+                "responses_api_models": {
+                    "vllm_model": {
+                        "extra_body": {"nvext": {"extra_fields": ["engine_data"]}}
+                    }
+                }
+            }
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    "model_config",
+    [
+        {"extra_body": None},
+        {"extra_body": {"nvext": None}},
+    ],
+)
+def test_setup_nemo_gym_config_normalizes_null_mappings(model_config) -> None:
+    config = SimpleNamespace(
+        policy={"generation": {"backend": "dynamo", "vllm_cfg": {}}},
+        env={
+            "nemo_gym": {
+                "policy_model": {"responses_api_models": {"vllm_model": model_config}}
+            }
+        },
+    )
+
+    setup_nemo_gym_config(config, tokenizer=None)
+
+    assert model_config["extra_body"] == {"nvext": {"extra_fields": ["engine_data"]}}
+
+
+@pytest.mark.parametrize(
+    ("model_config", "error"),
+    [
+        ({"extra_body": []}, "extra_body must be a mapping or null"),
+        (
+            {"extra_body": {"nvext": []}},
+            "extra_body.nvext must be a mapping or null",
+        ),
+        (
+            {"extra_body": {"nvext": {"extra_fields": "timing"}}},
+            "nvext.extra_fields must be a list",
+        ),
+    ],
+)
+def test_setup_nemo_gym_config_rejects_invalid_dynamo_containers(
+    model_config, error
+) -> None:
+    config = SimpleNamespace(
+        policy={"generation": {"backend": "dynamo", "vllm_cfg": {}}},
+        env={
+            "nemo_gym": {
+                "policy_model": {"responses_api_models": {"vllm_model": model_config}}
+            }
+        },
+    )
+
+    with pytest.raises(ValueError, match=error):
+        setup_nemo_gym_config(config, tokenizer=None)
+
+
+def test_setup_nemo_gym_config_does_not_add_dynamo_fields_for_vllm() -> None:
+    config = SimpleNamespace(
+        policy={"generation": {"backend": "vllm", "vllm_cfg": {}}},
+        env={"nemo_gym": {"port_range_low": 5000}},
+    )
+
+    setup_nemo_gym_config(config, tokenizer=None)
+
+    assert config.env["nemo_gym"] == {"port_range_low": 5000}
+
+
 @pytest.fixture(scope="function")
 def nemo_gym_vllm_generation(cluster, nemo_gym_tokenizer):  # noqa: F811
     generation_config = deepcopy(basic_vllm_test_config)

--- a/tests/unit/models/generation/test_dynamo_token_wrapper.py
+++ b/tests/unit/models/generation/test_dynamo_token_wrapper.py
@@ -20,8 +20,6 @@ from transformers import AutoTokenizer
 
 from nemo_rl.models.generation.dynamo.token_wrapper import (
     DynamoTokenWrapperServer,
-    _inject_gym_token_metadata,
-    _validate_engine_data,
     prepare_dynamo_chat_completion_request,
 )
 
@@ -299,7 +297,12 @@ def test_public_qwen3_multiturn_prefix_splice_parity(
     expected_splice = assistant_prefix[:-2] + expected[assistant_eos_index:]
 
     prepared = prepare_dynamo_chat_completion_request(
-        {"model": "Qwen/Qwen3-0.6B", "messages": messages, "tools": TOOLS},
+        {
+            "model": "Qwen/Qwen3-0.6B",
+            "messages": messages,
+            "tools": TOOLS,
+            "required_prefix_token_ids": first_prompt + generation_token_ids,
+        },
         tokenizer=tokenizer,
         tokenizer_chat_template_kwargs=template_kwargs,
         exclude_tools_when_tool_choice_none=True,
@@ -331,18 +334,18 @@ def test_prepare_dynamo_chat_completion_request_preserves_logprob_fields() -> No
     }
 
 
-def test_prepare_dynamo_chat_completion_request_preserves_prior_prefix() -> None:
+def test_prepare_dynamo_chat_completion_request_uses_gym_prefix() -> None:
     tokenizer = _Tokenizer()
     body = {
         "model": "dummy-model",
-        "required_prefix_token_ids": [999],
+        "required_prefix_token_ids": [10, 31, 32, 2],
         "messages": [
             {"role": "user", "content": "hello"},
             {
                 "role": "assistant",
                 "content": "first",
                 "prompt_token_ids": [10],
-                "generation_token_ids": [31, 32, 2],
+                "generation_token_ids": [55, 56, 2],
                 "generation_log_probs": [-0.1, -0.2, -0.3],
             },
             {"role": "user", "content": "next"},
@@ -364,6 +367,57 @@ def test_prepare_dynamo_chat_completion_request_preserves_prior_prefix() -> None
     assert tokenizer.calls[1]["add_generation_prompt"] is False
     assert tokenizer.calls[0]["tokenize"] is True
     assert tokenizer.calls[1]["tokenize"] is True
+
+
+@pytest.mark.parametrize("required_prefix_token_ids", [None, []])
+def test_prepare_dynamo_chat_completion_request_requires_gym_prefix(
+    required_prefix_token_ids,
+) -> None:
+    body = {
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": "first",
+                "prompt_token_ids": [10],
+                "generation_token_ids": [31, 32, 2],
+                "generation_log_probs": [-0.1, -0.2, -0.3],
+            },
+            {"role": "user", "content": "next"},
+        ],
+    }
+
+    if required_prefix_token_ids is not None:
+        body["required_prefix_token_ids"] = required_prefix_token_ids
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "requires required_prefix_token_ids.*"
+            "return_token_id_information.*engine_data"
+        ),
+    ):
+        prepare_dynamo_chat_completion_request(
+            body,
+            tokenizer=_Tokenizer(),
+            exclude_tools_when_tool_choice_none=True,
+        )
+
+
+def test_prepare_dynamo_chat_completion_request_rejects_prefix_without_metadata() -> (
+    None
+):
+    body = {
+        "messages": [{"role": "user", "content": "hello"}],
+        "required_prefix_token_ids": [10, 31, 32, 2],
+    }
+
+    with pytest.raises(ValueError, match="requires a tokenized assistant message"):
+        prepare_dynamo_chat_completion_request(
+            body,
+            tokenizer=_Tokenizer(),
+            exclude_tools_when_tool_choice_none=True,
+        )
 
 
 def test_prepare_dynamo_chat_completion_request_validates_extra_fields() -> None:
@@ -419,6 +473,7 @@ def test_prepare_dynamo_chat_completion_request_normalizes_prior_tool_arguments(
     tokenizer = _Tokenizer()
     body = {
         "model": "dummy-model",
+        "required_prefix_token_ids": [10, 777, 2, 40, 31, 32, 2],
         "messages": [
             {"role": "user", "content": "hello"},
             {
@@ -523,89 +578,18 @@ def test_prepare_dynamo_chat_completion_request_rejects_multiple_choices() -> No
         )
 
 
-def test_validate_engine_data_requires_prompt_completion_and_logprobs() -> None:
-    _validate_engine_data(
-        {
-            "nvext": {
-                "engine_data": {
-                    "prompt_token_ids": [1, 2],
-                    "completion_token_ids": [3],
-                    "completion_logprobs": [-0.25],
-                }
-            }
-        }
-    )
-
-    with pytest.raises(ValueError, match="engine_data"):
-        _validate_engine_data({"nvext": {}})
-    with pytest.raises(ValueError, match="prompt_token_ids"):
-        _validate_engine_data(
-            {
-                "nvext": {
-                    "engine_data": {
-                        "completion_token_ids": [],
-                        "completion_logprobs": [],
-                    }
-                }
-            }
-        )
-    with pytest.raises(ValueError, match="completion_token_ids"):
-        _validate_engine_data(
-            {
-                "nvext": {
-                    "engine_data": {
-                        "prompt_token_ids": [],
-                        "completion_logprobs": [],
-                    }
-                }
-            }
-        )
-    with pytest.raises(ValueError, match="completion_logprobs"):
-        _validate_engine_data(
-            {
-                "nvext": {
-                    "engine_data": {
-                        "prompt_token_ids": [],
-                        "completion_token_ids": [],
-                    }
-                }
-            }
-        )
-
-
-def test_inject_gym_token_metadata_validates_and_populates_message() -> None:
-    response = {
-        "choices": [
-            {
-                "message": {"role": "assistant", "content": "answer"},
-                "logprobs": None,
-            }
-        ],
+def test_forward_chat_completion_reuses_loop_bound_session() -> None:
+    raw_response = {
+        "choices": [{"message": {"role": "assistant", "content": "answer"}}],
         "nvext": {
             "engine_data": {
-                "prompt_token_ids": [1, 2, 3],
-                "completion_token_ids": [4, 5],
-                "completion_logprobs": [-0.25, -0.5],
+                "prompt_token_ids": [1, 2],
+                "completion_token_ids": [3],
+                "completion_logprobs": [-0.25],
             }
         },
     }
 
-    _inject_gym_token_metadata(response)
-
-    assert response["choices"][0]["message"] == {
-        "role": "assistant",
-        "content": "answer",
-        "prompt_token_ids": [1, 2, 3],
-        "generation_token_ids": [4, 5],
-        "generation_log_probs": [-0.25, -0.5],
-    }
-
-    response["nvext"]["engine_data"]["completion_logprobs"] = [-0.25]
-    with pytest.raises(ValueError, match="1 generation log probabilities for 2"):
-        _inject_gym_token_metadata(response)
-
-
-def test_forward_chat_completion_reuses_loop_bound_session() -> None:
     class FakeResponse:
         status = 200
 
@@ -616,7 +600,7 @@ def test_forward_chat_completion_reuses_loop_bound_session() -> None:
             return None
 
         async def text(self):
-            return json.dumps({"choices": []})
+            return json.dumps(raw_response)
 
     class FakeSession:
         def __init__(self):
@@ -637,10 +621,13 @@ def test_forward_chat_completion_reuses_loop_bound_session() -> None:
     server._client_session = session
 
     async def forward_twice():
-        await server._forward_chat_completion({}, authorization=None)
-        await server._forward_chat_completion({}, authorization="Bearer token")
+        first = await server._forward_chat_completion({}, authorization=None)
+        second = await server._forward_chat_completion({}, authorization="Bearer token")
+        return first, second
 
-    asyncio.run(forward_twice())
+    first, second = asyncio.run(forward_twice())
 
     assert len(session.calls) == 2
     assert session.calls[1][2]["Authorization"] == "Bearer token"
+    assert first == (200, raw_response)
+    assert second == (200, raw_response)


### PR DESCRIPTION
## Summary

Move native Dynamo response-token interpretation from the NeMo-RL token wrapper into NeMo-Gym.

- Ask Dynamo for `nvext.engine_data` only when the generation backend is Dynamo.
- Preserve existing `extra_body`, `nvext`, and `extra_fields` values while adding the request field once.
- Keep exact prompt rendering, prior-prefix splicing, metadata stripping, and `nvext.token_data` request preparation in NeMo-RL.
- Return successful Dynamo responses unchanged so Gym owns validation and training-token bundle creation.
- Update the Dynamo design document with the request handshake and ownership boundary.

## Dependency

This PR depends on [NeMo-Gym PR 1784](https://github.com/NVIDIA-NeMo/Gym/pull/1784). The Gym submodule is pinned to its current exact head, `fad304de9f915059277d76be5d30dfce43ad2cf6`, so CI tests both sides together.

Before this PR merges, the submodule must be advanced to the exact Gym `main` commit that contains PR 1784.

## Compatibility

- The request wire fields remain `nvext.token_data` and `nvext.extra_fields=["engine_data"]`.
- Dynamo is unchanged.
- The cleaned-up wrapper requires the updated Gym implementation.
- `uv.lock` is unchanged.

## Validation

- `uv run --no-sync pytest tests/unit/models/generation/test_dynamo_token_wrapper.py tests/unit/environments/test_nemo_gym.py::test_setup_nemo_gym_config_requests_dynamo_engine_data tests/unit/environments/test_nemo_gym.py::test_setup_nemo_gym_config_does_not_add_dynamo_fields_for_vllm` (`16 passed`)
- `uv run --no-sync pre-commit run --files docs/design-docs/dynamo-integration.md nemo_rl/environments/nemo_gym.py nemo_rl/models/generation/dynamo/token_wrapper.py tests/unit/environments/test_nemo_gym.py tests/unit/models/generation/test_dynamo_token_wrapper.py`
- NeMo-Gym PR 1784 CI is green at the pinned Gym SHA.

The NeMo-RL CI run on this PR is the end-to-end validation gate.
