### PR TITLE
feat(async-grpo): add length reward shaping

### DIFF
--- a/docs/guides/dapo.md
+++ b/docs/guides/dapo.md
@@ -65,6 +65,7 @@ grpo:
   
   reward_shaping:
     enabled: true
+    mode: response_length
     overlong_buffer_length: 4096     # Threshold before penalties apply (paper uses 4096)
     overlong_buffer_penalty: 1.0     # Penalty per excess token
     max_response_length: 20480       # Hard maximum generation length
@@ -75,7 +76,7 @@ grpo:
 - **`batch_multiplier`**: Factor that scales the initial prompt pool size for sampling.
 - **`dynamic_sampling_max_gen_batches`**: Maximum number of batches to be used for accumulating nonzero standard deviation prompts.
 - **`reward_scaling`**: When enabled, clamps each reward in the batch to [source_min, source_max] and linearly rescales it to [target_min, target_max]. Defaults: source_min=0.0, source_max=1.0, target_min=0.0, target_max=1.0.
-- **`reward_shaping`**: When enabled, applies the overlong penalty mechanism described in the Reward Shaping section above. Responses exceeding `max_response_length - overlong_buffer_length` receive penalties proportional to their excess length, helping to reduce reward noise and stabilize training.
+- **`reward_shaping`**: With `mode: response_length`, applies the overlong penalty mechanism described above in synchronous or asynchronous GRPO. Responses exceeding `max_response_length - overlong_buffer_length` receive penalties proportional to their excess length, helping to reduce reward noise and stabilize training.
 
 > [!NOTE]
 > When dynamic sampling is enabled, monitor the `filtered_reward` metric to track the average reward of the prompts with std > 0.

--- a/docs/guides/models/nemotron/nemotron-3-nano-omni.md
+++ b/docs/guides/models/nemotron/nemotron-3-nano-omni.md
@@ -221,6 +221,15 @@ The synchronous and asynchronous overlays are:
 - [2-node synchronous recipe](../../../../examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-2n8g-megatron-tp4ep4-gym-video.v1.yaml)
 - [16-node asynchronous recipe](../../../../examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-16n8g-megatron-tp4ep4-async-gym-video.v1.yaml)
 
+The opt-in length-reward variants select `reasoning_length` under the existing
+`grpo.reward_shaping` configuration. The correctness-gated reward uses the
+assistant reasoning-chain length before `</think>`. It keeps incorrect responses
+at zero while reducing positive reward after 1,024 reasoning tokens, reaching
+the maximum 5% penalty at 4,096 tokens:
+
+- [2-node synchronous length-reward recipe](../../../../examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-2n8g-megatron-tp4ep4-gym-video-length-reward.v1.yaml)
+- [16-node asynchronous length-reward recipe](../../../../examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-16n8g-megatron-tp2ep16-async-gym-video-length-reward.v1.yaml)
+
 They require the corresponding Nemotron Omni support in Megatron Bridge and
 video request/token propagation in NeMo Gym. Policy preprocessing numerically
 matches unmodified stock vLLM 0.25.1; a custom vLLM fork is not required.

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -29,10 +29,21 @@ grpo:
   batch_multiplier: 1
   reward_shaping:
     enabled: false
+    # response_length preserves DAPO/stop-properly shaping;
+    # reasoning_length applies the nested Gym reasoning-chain reward.
+    mode: response_length
     overlong_buffer_length: 128
     overlong_buffer_penalty: 1
     max_response_length: ${policy.max_total_sequence_length}
     stop_properly_penalty_coef: null
+    # Used only when mode=reasoning_length. The end-token ID is
+    # model/tokenizer specific and is required when shaping is enabled.
+    reasoning_length:
+      tau1: 4096
+      tau2: 13000
+      weight: 0.1
+      composition: additive
+      reasoning_end_token_id: null
 
   # Advantage Estimator Configuration
   # Options: "grpo" (default) or "reinforce_plus_plus"

--- a/examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-16n8g-megatron-tp2ep16-async-gym-video-length-reward.v1.yaml
+++ b/examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-16n8g-megatron-tp2ep16-async-gym-video-length-reward.v1.yaml
@@ -1,0 +1,59 @@
+defaults: vlm_grpo-nemotron-omni-30ba3b-16n8g-megatron-tp4ep4-async-gym-video.v1.yaml
+grpo:
+  num_prompts_per_step: 128
+  max_num_epochs: 1000000
+  val_period: 0
+  reward_shaping:
+    enabled: true
+    mode: reasoning_length
+    reasoning_length:
+      tau1: 1024
+      tau2: 4096
+      weight: 0.05
+      composition: correctness_gated
+      reasoning_end_token_id: 13
+checkpointing:
+  save_period: 2
+  keep_top_k: 5
+policy:
+  train_global_batch_size: 2048
+  max_total_sequence_length: 16384
+  sequence_packing:
+    enabled: true
+  megatron_cfg:
+    activation_checkpointing: false
+    tensor_model_parallel_size: 2
+    expert_model_parallel_size: 16
+    moe_shared_expert_overlap: true
+    optimizer:
+      optimizer_cpu_offload: false
+      optimizer_offload_fraction: 0.0
+    scheduler:
+      lr_warmup_iters: 10
+      lr_warmup_init: 3.0e-08
+  generation:
+    max_new_tokens: 16384
+    vllm_cfg:
+      tensor_parallel_size: 2
+      gpu_memory_utilization: 0.7
+      enforce_eager: false
+      video:
+        num_frames: 64
+    vllm_kwargs:
+      mm_processor_cache_gb: 4
+      max_num_seqs: 8
+      max_num_batched_tokens: 32768
+      limit_mm_per_prompt:
+        image: 64
+        video:
+          num_frames: 64
+      media_io_kwargs:
+        video:
+          num_frames: 64
+    colocated:
+      resources:
+        num_nodes: 8
+data:
+  shuffle: true
+  default:
+    num_frames: 64

--- a/examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-2n8g-megatron-tp4ep4-gym-video-length-reward.v1.yaml
+++ b/examples/configs/recipes/vlm/vlm_grpo-nemotron-omni-30ba3b-2n8g-megatron-tp4ep4-gym-video-length-reward.v1.yaml
@@ -1,0 +1,40 @@
+defaults: vlm_grpo-nemotron-omni-30ba3b-2n8g-megatron-tp4ep4-gym-video.v1.yaml
+grpo:
+  max_num_epochs: 1000000
+  val_period: 0
+  reward_shaping:
+    enabled: true
+    mode: reasoning_length
+    reasoning_length:
+      tau1: 1024
+      tau2: 4096
+      weight: 0.05
+      composition: correctness_gated
+      reasoning_end_token_id: 13
+checkpointing:
+  save_period: 2
+  keep_top_k: 5
+policy:
+  sequence_packing:
+    enabled: true
+  megatron_cfg:
+    scheduler:
+      lr_warmup_iters: 10
+      lr_warmup_init: 3.0e-08
+  generation:
+    vllm_cfg:
+      video:
+        num_frames: 64
+    vllm_kwargs:
+      mm_processor_cache_gb: 4
+      limit_mm_per_prompt:
+        image: 64
+        video:
+          num_frames: 64
+      media_io_kwargs:
+        video:
+          num_frames: 64
+data:
+  shuffle: true
+  default:
+    num_frames: 64

--- a/examples/nemo_gym/grpo_nanov3.yaml
+++ b/examples/nemo_gym/grpo_nanov3.yaml
@@ -32,6 +32,15 @@ grpo:
   use_dynamic_sampling: False
   reward_shaping:
     enabled: False
+    mode: response_length
+    # Used only when mode=reasoning_length. Set the model/tokenizer-specific
+    # reasoning end-token ID when enabling reward shaping.
+    reasoning_length:
+      tau1: 4096
+      tau2: 13000
+      weight: 0.1
+      composition: additive
+      reasoning_end_token_id: null
   reward_scaling:
     enabled: False
 

--- a/examples/nemo_gym/run_grpo_nemo_gym.py
+++ b/examples/nemo_gym/run_grpo_nemo_gym.py
@@ -293,9 +293,9 @@ The validation set you pass in will directly be used for validation with no addi
                 raise NotImplementedError(
                     "reward_scaling is not supported with async GRPO"
                 )
-            if config.grpo.reward_shaping.enabled:
+            if config.grpo.reward_shaping.response_length_enabled:
                 raise NotImplementedError(
-                    "reward_shaping is not supported with async GRPO"
+                    "response-length reward shaping is not supported with async GRPO"
                 )
 
             # Async GRPO does not support multiple dataloaders

--- a/examples/nemo_gym/run_grpo_nemo_gym.py
+++ b/examples/nemo_gym/run_grpo_nemo_gym.py
@@ -284,7 +284,7 @@ The validation set you pass in will directly be used for validation with no addi
             )
         # Check if async mode is enabled
         elif config.grpo.async_grpo.enabled:
-            # Async GRPO does not support dynamic sampling, reward scaling, or reward shaping (DAPO features)
+            # Async GRPO does not support dynamic sampling or reward scaling.
             if config.grpo.use_dynamic_sampling:
                 raise NotImplementedError(
                     "use_dynamic_sampling is not supported with async GRPO"
@@ -293,11 +293,6 @@ The validation set you pass in will directly be used for validation with no addi
                 raise NotImplementedError(
                     "reward_scaling is not supported with async GRPO"
                 )
-            if config.grpo.reward_shaping.response_length_enabled:
-                raise NotImplementedError(
-                    "response-length reward shaping is not supported with async GRPO"
-                )
-
             # Async GRPO does not support multiple dataloaders
             if config.data["use_multiple_dataloader"]:
                 raise NotImplementedError(

--- a/examples/run_grpo.py
+++ b/examples/run_grpo.py
@@ -182,7 +182,7 @@ def main() -> None:
     try:
         # Check if async mode is enabled
         if config.grpo.async_grpo.enabled:
-            # Async GRPO does not support dynamic sampling, reward scaling, or reward shaping (DAPO features)
+            # Async GRPO does not support dynamic sampling or reward scaling.
             if config.grpo.use_dynamic_sampling:
                 raise NotImplementedError(
                     "use_dynamic_sampling is not supported with async GRPO"
@@ -191,11 +191,6 @@ def main() -> None:
                 raise NotImplementedError(
                     "reward_scaling is not supported with async GRPO"
                 )
-            if config.grpo.reward_shaping.enabled:
-                raise NotImplementedError(
-                    "reward_shaping is not supported with async GRPO"
-                )
-
             # Async GRPO does not support multiple dataloaders
             if config.data["use_multiple_dataloader"]:
                 raise NotImplementedError(

--- a/examples/run_vlm_grpo.py
+++ b/examples/run_vlm_grpo.py
@@ -140,8 +140,6 @@ def main() -> None:
             )
         if config.grpo.reward_scaling.enabled:
             raise NotImplementedError("reward_scaling is not supported with async GRPO")
-        if config.grpo.reward_shaping.enabled:
-            raise NotImplementedError("reward_shaping is not supported with async GRPO")
         if config.data["use_multiple_dataloader"]:
             raise NotImplementedError(
                 "use_multiple_dataloader is not supported with async GRPO"

--- a/nemo_rl/algorithms/advantage_estimator.py
+++ b/nemo_rl/algorithms/advantage_estimator.py
@@ -66,7 +66,14 @@ class GRPOAdvantageEstimator:
         self.use_leave_one_out_baseline = estimator_config.use_leave_one_out_baseline
         self.normalize_rewards = estimator_config.normalize_rewards
 
-    def compute_advantage(self, prompt_ids, rewards, mask, **kwargs):
+    def compute_advantage(
+        self,
+        prompt_ids,
+        rewards,
+        mask,
+        std_rewards: torch.Tensor | None = None,
+        **kwargs,
+    ):
         """Compute GRPO advantages.
 
         Args:
@@ -74,6 +81,9 @@ class GRPOAdvantageEstimator:
             rewards: Tensor of shape [batch_size] containing reward for each sample.
             mask: Response token mask of shape [batch_size, seq_len], 1 for valid response tokens, 0 for padding.
                   Used only for expanding advantages to token-level shape.
+            std_rewards: Optional raw reward tensor used only to compute the
+                normalization standard deviation. The baseline and advantage
+                numerator always use ``rewards``.
             **kwargs: Additional arguments (unused).
 
         Returns:
@@ -84,6 +94,7 @@ class GRPOAdvantageEstimator:
             rewards,
             torch.ones_like(rewards),
             leave_one_out_baseline=self.use_leave_one_out_baseline,
+            std_rewards=std_rewards,
         )
         advantages = (rewards - baseline).unsqueeze(-1)
 

--- a/nemo_rl/algorithms/async_utils/trajectory_collector.py
+++ b/nemo_rl/algorithms/async_utils/trajectory_collector.py
@@ -921,6 +921,11 @@ class AsyncTrajectoryCollector:
                 "stop_token_ids": None,
                 "stop_strings": None,
             }
+            reward_shaping_config = (
+                self.master_config.grpo.reward_shaping
+                if isinstance(self.master_config, GRPOMasterConfig)
+                else None
+            )
             async for rollout_result in run_async_nemo_gym_rollout(
                 policy_generation=self.policy_generation,
                 input_batch=repeated_batch,
@@ -935,6 +940,7 @@ class AsyncTrajectoryCollector:
                 ),
                 max_rollout_turns=None,
                 greedy=False,
+                reward_shaping_config=reward_shaping_config,
                 reward_penalty_config=self.master_config.reward_penalties,
                 thinking_tags=get_nemo_gym_thinking_tags(self.master_config.env),
                 mask_env_flagged_samples=should_mask_flagged_samples(

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -4727,6 +4727,16 @@ def async_grpo_train(
                     del initial_prompt_message_logs
                     del prompt_batched_flat
 
+                    # Match the synchronous GRPO path: native response-length
+                    # shaping must run after rollout collection and before the
+                    # shaped rewards are used to compute advantages. Reasoning-
+                    # length shaping is already applied by NeMo Gym before the
+                    # trajectory enters the replay buffer.
+                    if master_config.grpo.reward_shaping.response_length_enabled:
+                        repeated_batch = apply_reward_shaping(
+                            repeated_batch, master_config.grpo.reward_shaping
+                        )
+
                     rewards = repeated_batch["total_reward"]
 
                     print(

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -53,7 +53,7 @@ from nemo_rl.algorithms.metric_utils import (
 )
 from nemo_rl.algorithms.opd import OnPolicyDistillationConfig
 from nemo_rl.algorithms.reward_functions import (
-    RewardShapingConfig,
+    GRPORewardShapingConfig,
     apply_reward_shaping,
 )
 from nemo_rl.algorithms.utils import (
@@ -287,7 +287,9 @@ class GRPOConfig(BaseModel, extra="allow"):
     # When using dynamic sampling, generation prompt batch size will equal
     # num_prompts_per_step * batch_multiplier
     batch_multiplier: float = 1.0
-    reward_shaping: RewardShapingConfig = Field(default_factory=RewardShapingConfig)
+    reward_shaping: GRPORewardShapingConfig = Field(
+        default_factory=GRPORewardShapingConfig
+    )
     reward_scaling: RewardScalingConfig = Field(default_factory=RewardScalingConfig)
     # By default advantages are calculated on CPU. Setting this flag to true leverages GPU for their computation.
     calculate_advantages_on_gpu: bool = False
@@ -732,6 +734,9 @@ def setup(
     # spinup can overlap with vLLM model loading via deferred model load.
     enable_nemo_gym = should_use_nemo_gym(master_config)
     _raise_if_reward_penalties_enabled_without_nemo_gym(
+        master_config, enable_nemo_gym=enable_nemo_gym
+    )
+    _raise_if_reasoning_length_reward_enabled_without_nemo_gym(
         master_config, enable_nemo_gym=enable_nemo_gym
     )
     nemo_gym_actor = None
@@ -1984,6 +1989,25 @@ def _raise_if_reward_penalties_enabled_without_nemo_gym(
     )
 
 
+def _raise_if_reasoning_length_reward_enabled_without_nemo_gym(
+    master_config: MasterConfig,
+    *,
+    enable_nemo_gym: bool,
+) -> None:
+    """Validate reasoning-length reward shaping is only used with NeMo-Gym."""
+    if (
+        enable_nemo_gym
+        or not master_config.grpo.reward_shaping.reasoning_length_enabled
+    ):
+        return
+
+    raise ValueError(
+        "grpo.reward_shaping mode=reasoning_length requires the NeMo-Gym path "
+        "(env.should_use_nemo_gym=true); it is not supported with the native "
+        "generation path."
+    )
+
+
 def _apply_message_level_advantage_penalties(
     train_data: BatchedDataDict[ClippedPGLossDataDict],
     message_logs: list[LLMMessageLogType | VLMMessageLogType],
@@ -2957,6 +2981,7 @@ def grpo_train(
                             max_rollout_turns=None,
                             greedy=False,
                             effort_config=_get_effort_config(master_config),
+                            reward_shaping_config=master_config.grpo.reward_shaping,
                             reward_penalty_config=master_config.reward_penalties,
                             thinking_tags=get_nemo_gym_thinking_tags(master_config.env),
                             mask_env_flagged_samples=should_mask_flagged_samples(
@@ -3025,7 +3050,7 @@ def grpo_train(
                     repeated_batch, master_config.grpo.reward_scaling
                 )
                 # Process rewards with custom reward function
-                if master_config.grpo.reward_shaping.enabled:
+                if master_config.grpo.reward_shaping.response_length_enabled:
                     repeated_batch = apply_reward_shaping(
                         repeated_batch, master_config.grpo.reward_shaping
                     )
@@ -3295,6 +3320,7 @@ def grpo_train(
                         prompt_ids=prompt_ids_for_adv,
                         rewards=rewards,
                         mask=mask,
+                        std_rewards=repeated_batch.get("unshaped_total_reward"),
                         repeated_batch=repeated_batch,
                         logprobs_policy=train_data["prev_logprobs"],
                         logprobs_reference=train_data.get("reference_policy_logprobs"),
@@ -3894,6 +3920,7 @@ def validate(
                     max_rollout_turns=None,
                     greedy=False,
                     effort_config=_get_effort_config(master_config),
+                    reward_shaping_config=master_config.grpo.reward_shaping,
                     reward_penalty_config=master_config.reward_penalties,
                     thinking_tags=get_nemo_gym_thinking_tags(master_config.env),
                     mask_env_flagged_samples=should_mask_flagged_samples(
@@ -4840,6 +4867,7 @@ def async_grpo_train(
                         prompt_ids=prompt_ids_for_adv,
                         rewards=rewards,
                         mask=mask,
+                        std_rewards=repeated_batch.get("unshaped_total_reward"),
                         repeated_batch=repeated_batch,
                         logprobs_policy=train_data["prev_logprobs"],
                         logprobs_reference=train_data.get("reference_policy_logprobs"),

--- a/nemo_rl/algorithms/grpo_sync.py
+++ b/nemo_rl/algorithms/grpo_sync.py
@@ -692,7 +692,7 @@ def grpo_train_sync(
                         driver_carry,
                         master_config.grpo.reward_scaling,
                     )
-                    if master_config.grpo.reward_shaping.enabled:
+                    if master_config.grpo.reward_shaping.response_length_enabled:
                         driver_carry = apply_reward_shaping(
                             driver_carry,
                             master_config.grpo.reward_shaping,
@@ -703,6 +703,7 @@ def grpo_train_sync(
                             driver_carry["total_reward"],
                             torch.ones_like(driver_carry["total_reward"]),
                             leave_one_out_baseline=master_config.grpo.use_leave_one_out_baseline,
+                            std_rewards=driver_carry.get("unshaped_total_reward"),
                         )
                     )
                     # Mirror std onto meta so dynamic_sampling can filter
@@ -894,6 +895,7 @@ def grpo_train_sync(
                         prompt_ids=prompt_ids_for_adv,
                         rewards=rewards,
                         mask=mask,
+                        std_rewards=driver_carry.get("unshaped_total_reward"),
                         repeated_batch=adv_inputs,
                         logprobs_policy=prev_logprobs,
                         logprobs_reference=reference_policy_logprobs,

--- a/nemo_rl/algorithms/reward_functions.py
+++ b/nemo_rl/algorithms/reward_functions.py
@@ -11,21 +11,193 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import TypeVar
+from dataclasses import dataclass
+from typing import Any, Literal, TypeVar
 
 import torch
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, model_validator
 
+from nemo_rl.data.interfaces import LLMMessageLogType, VLMMessageLogType
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 
 Tensor = TypeVar("Tensor", bound=torch.Tensor)
 
 
+class ReasoningLengthRewardConfig(BaseModel, extra="allow"):
+    """Configure reasoning-chain length reward for NeMo-Gym rollouts.
+
+    The component reward is one through ``tau1``, decreases linearly to zero
+    at ``tau2``, and remains zero for longer reasoning chains. The end-token ID
+    is model/tokenizer specific and must be provided whenever the feature is
+    enabled.
+    """
+
+    tau1: int = 4096
+    tau2: int = 13000
+    weight: float = 0.1
+    composition: Literal["additive", "correctness_gated"] = "additive"
+    reasoning_end_token_id: int | None = None
+
+    @model_validator(mode="after")
+    def _validate_reasoning_length_reward(self) -> "ReasoningLengthRewardConfig":
+        if self.tau1 < 0:
+            raise ValueError(f"tau1 must be non-negative, got {self.tau1}")
+        if self.tau2 <= self.tau1:
+            raise ValueError(
+                f"tau2 must be greater than tau1, got tau1={self.tau1}, "
+                f"tau2={self.tau2}"
+            )
+        if self.weight < 0:
+            raise ValueError(f"weight must be non-negative, got {self.weight}")
+        if self.composition == "correctness_gated" and self.weight > 1:
+            raise ValueError(
+                "correctness-gated length-aware reward weight must be at most 1, "
+                f"got {self.weight}"
+            )
+        if self.reasoning_end_token_id is not None and self.reasoning_end_token_id < 0:
+            raise ValueError(
+                "reasoning_end_token_id must be non-negative, got "
+                f"{self.reasoning_end_token_id}"
+            )
+        return self
+
+
+@dataclass(frozen=True)
+class LengthAwareRewardMetrics:
+    component_rewards: list[float]
+    reasoning_chain_lengths: list[int]
+    unshaped_rewards: list[float]
+
+
+def length_aware_regularization_reward(
+    chain_length: int, *, tau1: int, tau2: int
+) -> float:
+    """Return the piecewise-linear reward for a reasoning-chain length."""
+    if chain_length < 0:
+        raise ValueError(f"chain_length must be non-negative, got {chain_length}")
+    if tau1 < 0:
+        raise ValueError(f"tau1 must be non-negative, got {tau1}")
+    if tau2 <= tau1:
+        raise ValueError(
+            f"tau2 must be greater than tau1, got tau1={tau1}, tau2={tau2}"
+        )
+
+    if chain_length <= tau1:
+        return 1.0
+    if chain_length >= tau2:
+        return 0.0
+    return 1.0 - (chain_length - tau1) / (tau2 - tau1)
+
+
+def reasoning_chain_token_length(
+    message_log: LLMMessageLogType | VLMMessageLogType,
+    *,
+    reasoning_end_token_id: int,
+) -> int:
+    """Count assistant reasoning tokens, excluding each reasoning end token.
+
+    An assistant turn without the configured end token is treated as unfinished
+    reasoning, so its complete generated token sequence is counted.
+    """
+    total = 0
+    for message in message_log:
+        if message.get("role") != "assistant":
+            continue
+        token_ids = message.get("token_ids")
+        if not isinstance(token_ids, torch.Tensor):
+            raise TypeError(
+                "Assistant message token_ids must be a torch.Tensor when applying "
+                "length-aware reward"
+            )
+        if token_ids.ndim != 1:
+            raise ValueError(
+                "Assistant message token_ids must be one-dimensional when applying "
+                f"length-aware reward, got shape={tuple(token_ids.shape)}"
+            )
+        token_id_list = token_ids.tolist()
+        try:
+            total += token_id_list.index(reasoning_end_token_id)
+        except ValueError:
+            total += len(token_id_list)
+    return total
+
+
+def apply_length_aware_reward(
+    results: list[dict[str, Any]], config: ReasoningLengthRewardConfig | None
+) -> LengthAwareRewardMetrics:
+    """Compose reasoning-chain length reward into NeMo-Gym scalar rewards.
+
+    ``additive`` uses ``base + weight * component``. ``correctness_gated`` uses
+    ``base * (1 - weight * (1 - component))``, which prevents short incorrect
+    responses from receiving positive reward.
+
+    Multi-component Gym rewards are rejected because a non-additive transform
+    would otherwise violate the ``reward == sum(reward_components)`` contract.
+    """
+    if config is None:
+        return LengthAwareRewardMetrics([], [], [])
+
+    reasoning_end_token_id = config.reasoning_end_token_id
+    if reasoning_end_token_id is None:
+        raise ValueError(
+            "reasoning_end_token_id must be set when length-aware reward is enabled"
+        )
+
+    for result in results:
+        full_result = result["full_result"]
+        if full_result.get("reward_components"):
+            raise ValueError(
+                "Length-aware reward does not support NeMo-Gym results with "
+                "reward_components"
+            )
+    reasoning_chain_lengths = []
+    for result in results:
+        # NeMo Gym returns the complete conversation in ``message_log`` and
+        # the original prompt as its prefix in ``input_message_log``. Exclude
+        # that prefix so assistant turns supplied by a multi-turn dataset are
+        # not mistaken for newly generated reasoning.
+        input_message_count = len(result.get("input_message_log", []))
+        reasoning_chain_lengths.append(
+            reasoning_chain_token_length(
+                result["message_log"][input_message_count:],
+                reasoning_end_token_id=reasoning_end_token_id,
+            )
+        )
+    component_rewards = [
+        length_aware_regularization_reward(
+            chain_length,
+            tau1=config.tau1,
+            tau2=config.tau2,
+        )
+        for chain_length in reasoning_chain_lengths
+    ]
+
+    unshaped_rewards = [float(result["full_result"]["reward"]) for result in results]
+    adjusted_rewards = []
+    for base_reward, component_reward in zip(unshaped_rewards, component_rewards):
+        if config.composition == "correctness_gated":
+            adjusted_reward = base_reward * (
+                1.0 - config.weight * (1.0 - component_reward)
+            )
+        else:
+            adjusted_reward = base_reward + config.weight * component_reward
+        adjusted_rewards.append(adjusted_reward)
+
+    for result, adjusted_reward in zip(results, adjusted_rewards):
+        result["full_result"]["reward"] = adjusted_reward
+
+    return LengthAwareRewardMetrics(
+        component_rewards,
+        reasoning_chain_lengths,
+        unshaped_rewards,
+    )
+
+
 class RewardShapingConfig(BaseModel, extra="allow"):
     """Configuration for reward function processing.
 
-    This configuration enables custom reward shaping, currently supporting DAPO-style
-    penalties for responses that exceed the maximum response length threshold.
+    This configuration enables DAPO overlong or stop-properly shaping for
+    response-length processing.
     """
 
     enabled: bool = False
@@ -46,6 +218,46 @@ class RewardShapingConfig(BaseModel, extra="allow"):
     # When set to 1, no penalty is applied (default behavior).
     stop_properly_penalty_coef: float | None = None
 
+    @property
+    def response_length_enabled(self) -> bool:
+        """Whether batch-level DAPO or stop-properly shaping is active."""
+        return self.enabled
+
+
+class GRPORewardShapingConfig(RewardShapingConfig):
+    """Select response- or reasoning-length reward shaping for GRPO."""
+
+    mode: Literal["response_length", "reasoning_length"] = "response_length"
+
+    # Reasoning-chain parameters used when mode=reasoning_length. The end-token
+    # ID is model/tokenizer specific and must be set when that mode is enabled.
+    reasoning_length: ReasoningLengthRewardConfig = Field(
+        default_factory=ReasoningLengthRewardConfig
+    )
+
+    @model_validator(mode="after")
+    def _validate_reasoning_length_mode(self) -> "GRPORewardShapingConfig":
+        if (
+            self.enabled
+            and self.mode == "reasoning_length"
+            and self.reasoning_length.reasoning_end_token_id is None
+        ):
+            raise ValueError(
+                "reasoning_length.reasoning_end_token_id must be set when "
+                "reasoning-length reward shaping is enabled"
+            )
+        return self
+
+    @property
+    def response_length_enabled(self) -> bool:
+        """Whether batch-level DAPO or stop-properly shaping is active."""
+        return self.enabled and self.mode == "response_length"
+
+    @property
+    def reasoning_length_enabled(self) -> bool:
+        """Whether NeMo-Gym reasoning-chain shaping is active."""
+        return self.enabled and self.mode == "reasoning_length"
+
 
 def apply_reward_shaping(
     batch: BatchedDataDict, cfg: RewardShapingConfig
@@ -57,6 +269,11 @@ def apply_reward_shaping(
     rewards = batch["total_reward"]
     if not cfg.enabled:
         return batch
+    if not cfg.response_length_enabled:
+        raise ValueError(
+            "reasoning-length reward shaping must be applied to NeMo-Gym results "
+            "before batch-level reward processing"
+        )
 
     # Preserve the pre-shaping reward so downstream consumers (e.g. DAPO
     # dynamic sampling) can filter prompt groups on the raw task metric

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -31,6 +31,10 @@ from pydantic import BaseModel
 from transformers import PreTrainedTokenizerBase
 from wandb import Table
 
+from nemo_rl.algorithms.reward_functions import (
+    GRPORewardShapingConfig,
+    apply_length_aware_reward,
+)
 from nemo_rl.algorithms.utils import get_gdpo_reward_component_keys
 from nemo_rl.data.interfaces import (
     DatumSpec,
@@ -2270,6 +2274,7 @@ async def run_async_nemo_gym_rollout(
     max_rollout_turns: Optional[int] = None,
     greedy: bool = False,
     effort_config: Optional[EffortLevelsConfig] = None,
+    reward_shaping_config: GRPORewardShapingConfig | None = None,
     reward_penalty_config: dict[str, Any] | BaseModel | None = None,
     thinking_tags: list[str] | tuple[str, ...] | None = None,
     mask_env_flagged_samples: bool = True,
@@ -2301,6 +2306,8 @@ async def run_async_nemo_gym_rollout(
         max_rollout_turns: Must be ``None`` because NeMo-Gym owns turn limits.
         greedy: Must be ``False`` because this path does not support greedy mode.
         effort_config: Optional configuration for effort-based reward shaping.
+        reward_shaping_config: Optional GRPO reward-shaping configuration. The
+            reasoning-length mode is applied to each completed Gym rollout.
         reward_penalty_config: Optional reward-penalty configuration.
         thinking_tags: Optional opening and closing tags used by thinking penalties.
         mask_env_flagged_samples: Whether to carry env-driven ``mask_sample``
@@ -2476,6 +2483,7 @@ async def run_async_nemo_gym_rollout(
                         tokenizer=tokenizer,
                         log_full_result_tables=log_full_result_tables,
                         effort_config=effort_config,
+                        reward_shaping_config=reward_shaping_config,
                         reward_penalty_config=reward_penalty_config,
                         thinking_tags=thinking_tags,
                         mask_env_flagged_samples=mask_env_flagged_samples,
@@ -2513,6 +2521,7 @@ def run_nemo_gym_rollout_sync(
     max_rollout_turns: Optional[int] = None,
     greedy: bool = False,
     effort_config: Optional[EffortLevelsConfig] = None,
+    reward_shaping_config: GRPORewardShapingConfig | None = None,
     reward_penalty_config: dict[str, Any] | BaseModel | None = None,
     thinking_tags: list[str] | tuple[str, ...] | None = None,
     sampling_params: Optional[GenerationSamplingParams] = None,
@@ -2540,6 +2549,8 @@ def run_nemo_gym_rollout_sync(
         max_rollout_turns: Must be ``None`` because NeMo-Gym owns turn limits.
         greedy: Must be ``False`` because this path does not support greedy mode.
         effort_config: Optional configuration for effort-based reward shaping.
+        reward_shaping_config: Optional GRPO reward-shaping configuration. The
+            reasoning-length mode is applied to each completed Gym rollout.
         reward_penalty_config: Optional reward-penalty configuration.
         thinking_tags: Optional opening and closing tags used by thinking penalties.
         sampling_params: Sampling profile stamped onto every NeMo-Gym row.
@@ -2577,6 +2588,7 @@ def run_nemo_gym_rollout_sync(
             max_rollout_turns=max_rollout_turns,
             greedy=greedy,
             effort_config=effort_config,
+            reward_shaping_config=reward_shaping_config,
             reward_penalty_config=reward_penalty_config,
             thinking_tags=thinking_tags,
             mask_env_flagged_samples=mask_env_flagged_samples,
@@ -2603,6 +2615,7 @@ def _postprocess_single_nemo_gym_group(
     tokenizer: TokenizerType,
     log_full_result_tables: bool,
     effort_config: Optional[EffortLevelsConfig] = None,
+    reward_shaping_config: GRPORewardShapingConfig | None = None,
     reward_penalty_config: dict[str, Any] | BaseModel | None = None,
     thinking_tags: list[str] | tuple[str, ...] | None = None,
     mask_env_flagged_samples: bool = True,
@@ -2615,6 +2628,13 @@ def _postprocess_single_nemo_gym_group(
     low_lengths = shaping.low_lengths
     high_lengths = shaping.high_lengths
 
+    reasoning_length_config = (
+        reward_shaping_config.reasoning_length
+        if reward_shaping_config is not None
+        and reward_shaping_config.reasoning_length_enabled
+        else None
+    )
+    length_aware_metrics = apply_length_aware_reward(results, reasoning_length_config)
     resolved_reward_penalty_config = resolve_reward_penalty_config(
         reward_penalty_config, tokenizer, thinking_tags=thinking_tags
     )
@@ -2753,6 +2773,21 @@ def _postprocess_single_nemo_gym_group(
     rollout_metrics["mean_gen_tokens_per_sample"] = rollout_metrics[
         "gen_tokens_per_sample/mean"
     ]
+    if length_aware_metrics.component_rewards:
+        rollout_metrics.update(
+            calculate_single_metric(
+                length_aware_metrics.component_rewards,
+                len(length_aware_metrics.component_rewards),
+                "length_aware_reward",
+            )
+        )
+        rollout_metrics.update(
+            calculate_single_metric(
+                length_aware_metrics.reasoning_chain_lengths,
+                len(length_aware_metrics.reasoning_chain_lengths),
+                "reasoning_chain_tokens",
+            )
+        )
 
     # Convert LLMMessageLogType to FlatMessagesType for generation
     input_batch_for_input_ids = BatchedDataDict[DatumSpec](
@@ -2788,6 +2823,13 @@ def _postprocess_single_nemo_gym_group(
             ),
         }
     )
+    if length_aware_metrics.unshaped_rewards:
+        # Preserve the verifier reward separately from the shaped optimization
+        # reward. GRPO uses it only for per-prompt normalization so a tiny
+        # variance among shaped peer rewards cannot amplify an outlier.
+        final_batch["unshaped_total_reward"] = torch.tensor(
+            length_aware_metrics.unshaped_rewards
+        )
     # Env/agent mask flag: flagged samples are dropped from the loss but still
     # count for advantages. env.should_mask_flagged_samples=false skips this.
     if mask_env_flagged_samples:

--- a/nemo_rl/experience/sync_rollout_actor.py
+++ b/nemo_rl/experience/sync_rollout_actor.py
@@ -259,6 +259,7 @@ class SyncRolloutActor:
                 if "nemo_gym" in cfg.env
                 and cfg.env["nemo_gym"].get("effort_levels") is not None
                 else None,
+                reward_shaping_config=cfg.grpo.reward_shaping,
                 reward_penalty_config=cfg.reward_penalties,
                 thinking_tags=get_nemo_gym_thinking_tags(cfg.env),
                 deduplicate_multimodal_data=cfg.grpo.deduplicate_multimodal_data,
@@ -365,6 +366,8 @@ class SyncRolloutActor:
             # apply_reward_shaping on the driver without a TQ fetch.
             "response_token_lengths": decomposed["response_token_lengths"],
         }
+        if "unshaped_total_reward" in fb:
+            driver_carry["unshaped_total_reward"] = fb["unshaped_total_reward"]
         # GDPO multi-reward components: scale_rewards iterates these
         # keys driver-side and the GDPO advantage estimator reads them
         # from ``adv_inputs``. Plumb them through ``driver_carry``

--- a/tests/test_suites/disabled.txt
+++ b/tests/test_suites/disabled.txt
@@ -10,11 +10,13 @@ tests/test_suites/vlm/vlm_grpo-qwen3.5-35ba3b-geo3k-2n8g-megatron-ep16.sh
 # is too large for nightly. Run it manually before changes to the async video
 # rollout/training path are merged.
 tests/test_suites/vlm/vlm_grpo-nemotron-omni-30ba3b-16n8g-megatron-tp4ep4-async-gym-video.v1.sh
+tests/test_suites/vlm/vlm_grpo-nemotron-omni-30ba3b-16n8g-megatron-tp2ep16-async-gym-video-length-reward.v1.sh
 
 # The synchronous video GRPO smoke test is self-contained, but its 2x8-GPU,
 # 240-minute allocation adds 64 GPU-hours and exceeds the nightly budget.
 # Run it manually until the nightly suite has room.
 tests/test_suites/vlm/vlm_grpo-nemotron-omni-30ba3b-2n8g-megatron-tp4ep4-gym-video.v1.sh
+tests/test_suites/vlm/vlm_grpo-nemotron-omni-30ba3b-2n8g-megatron-tp4ep4-gym-video-length-reward.v1.sh
 
 # First multimodal NeMo-Gym recipe (circle_click at the pinned Gym). Disabled on
 # landing for two reasons: the recipe has not been run end to end yet, so its

--- a/tests/test_suites/vlm/vlm_grpo-nemotron-omni-30ba3b-16n8g-megatron-tp2ep16-async-gym-video-length-reward.v1.sh
+++ b/tests/test_suites/vlm/vlm_grpo-nemotron-omni-30ba3b-16n8g-megatron-tp2ep16-async-gym-video-length-reward.v1.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ===== BEGIN CONFIG =====
+NUM_NODES=16
+GPUS_PER_NODE=8
+STEPS_PER_RUN=1
+MAX_STEPS=1
+NUM_RUNS=1
+NUM_MINUTES=240
+# ===== END CONFIG =====
+
+# Reuse the video regression setup while resolving this script's production
+# TP2/EP16 length-reward recipe by basename.
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source "$SCRIPT_DIR/vlm_grpo-nemotron-omni-30ba3b-16n8g-megatron-tp4ep4-async-gym-video.v1.sh"

--- a/tests/test_suites/vlm/vlm_grpo-nemotron-omni-30ba3b-2n8g-megatron-tp4ep4-gym-video-length-reward.v1.sh
+++ b/tests/test_suites/vlm/vlm_grpo-nemotron-omni-30ba3b-2n8g-megatron-tp4ep4-gym-video-length-reward.v1.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ===== BEGIN CONFIG =====
+NUM_NODES=2
+GPUS_PER_NODE=8
+STEPS_PER_RUN=1
+MAX_STEPS=1
+NUM_RUNS=1
+NUM_MINUTES=240
+# ===== END CONFIG =====
+
+# Reuse the manually invoked synchronous video regression with this script's
+# basename so common.env resolves the corresponding length-reward recipe.
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source "$SCRIPT_DIR/vlm_grpo-nemotron-omni-30ba3b-2n8g-megatron-tp4ep4-gym-video.v1.sh"

--- a/tests/unit/algorithms/test_async_utils.py
+++ b/tests/unit/algorithms/test_async_utils.py
@@ -2132,6 +2132,10 @@ class TestAsyncTrajectoryCollector:
             assert kwargs["generation_config"]["stop_token_ids"] is None
             assert kwargs["generation_config"]["stop_strings"] is None
             assert kwargs["log_full_result_tables"] is False
+            assert (
+                kwargs["reward_shaping_config"]
+                is collector.master_config.grpo.reward_shaping
+            )
             rollout_calls += 1
             yield _rollout_result(7)
             if rollout_calls == 1:

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -42,6 +42,7 @@ from nemo_rl.algorithms.grpo import (
     _initial_grpo_save_state,
     _initial_policy_generation_stale,
     _needs_hf_refit_handshake,
+    _raise_if_reasoning_length_reward_enabled_without_nemo_gym,
     _raise_if_reward_penalties_enabled_without_nemo_gym,
     _resolve_logprob_skip_flags,
     _resolve_message_level_advantage_penalties,
@@ -61,6 +62,8 @@ from nemo_rl.algorithms.grpo import (
 from nemo_rl.algorithms.grpo_sync import _train_fields_for_step, grpo_train_sync
 from nemo_rl.algorithms.loss import ClippedPGLossConfig, ClippedPGLossFn
 from nemo_rl.algorithms.reward_functions import (
+    GRPORewardShapingConfig,
+    ReasoningLengthRewardConfig,
     RewardShapingConfig,
     apply_reward_shaping,
 )
@@ -317,7 +320,11 @@ def mock_grpo_components():
                 advantage_clip_low=None,
                 advantage_clip_high=None,
                 reward_scaling=RewardScalingConfig.model_construct(enabled=False),
-                reward_shaping=RewardShapingConfig.model_construct(enabled=False),
+                reward_shaping=GRPORewardShapingConfig.model_construct(
+                    enabled=False,
+                    mode="response_length",
+                    reasoning_length=ReasoningLengthRewardConfig(),
+                ),
                 use_dynamic_sampling=False,
                 async_grpo=AsyncGRPOConfig.model_construct(
                     enabled=False,
@@ -439,7 +446,10 @@ def test_grpo_config_nested_defaults_are_populated():
 
     assert isinstance(first.async_grpo, AsyncGRPOConfig)
     assert isinstance(first.adv_estimator, AdvEstimatorConfig)
-    assert isinstance(first.reward_shaping, RewardShapingConfig)
+    assert isinstance(first.reward_shaping, GRPORewardShapingConfig)
+    assert isinstance(
+        first.reward_shaping.reasoning_length, ReasoningLengthRewardConfig
+    )
     assert isinstance(first.reward_scaling, RewardScalingConfig)
     assert first.async_grpo.enabled is False
     assert first.async_grpo.max_generation_failures == 0
@@ -449,6 +459,10 @@ def test_grpo_config_nested_defaults_are_populated():
     assert first.async_grpo is not second.async_grpo
     assert first.adv_estimator is not second.adv_estimator
     assert first.reward_shaping is not second.reward_shaping
+    assert (
+        first.reward_shaping.reasoning_length
+        is not second.reward_shaping.reasoning_length
+    )
     assert first.reward_scaling is not second.reward_scaling
 
 
@@ -724,6 +738,26 @@ def test_raise_if_reward_penalties_enabled_without_nemo_gym_allows_nemo_gym(
     )
 
     _raise_if_reward_penalties_enabled_without_nemo_gym(
+        master_config, enable_nemo_gym=True
+    )
+
+
+def test_raise_if_reasoning_length_reward_enabled_without_nemo_gym(
+    mock_grpo_components,
+):
+    master_config = mock_grpo_components["master_config"]
+    master_config.grpo.reward_shaping = GRPORewardShapingConfig(
+        enabled=True,
+        mode="reasoning_length",
+        reasoning_length={"reasoning_end_token_id": 13},
+    )
+
+    with pytest.raises(ValueError, match="mode=reasoning_length requires"):
+        _raise_if_reasoning_length_reward_enabled_without_nemo_gym(
+            master_config, enable_nemo_gym=False
+        )
+
+    _raise_if_reasoning_length_reward_enabled_without_nemo_gym(
         master_config, enable_nemo_gym=True
     )
 
@@ -4323,6 +4357,40 @@ def test_grpo_advantage_estimator_small_nonzero_std():
 
     # Verify opposite signs
     assert result[0, 0] * result[1, 0] < 0
+
+
+def test_grpo_advantage_estimator_uses_raw_rewards_for_shaped_reward_std():
+    """Length shaping must not amplify an outlier via tiny peer variance."""
+    estimator_config = AdvEstimatorConfig.model_construct(
+        use_leave_one_out_baseline=True,
+        normalize_rewards=True,
+    )
+    estimator = GRPOAdvantageEstimator(estimator_config, ClippedPGLossConfig())
+
+    prompt_ids = torch.zeros((16, 1), dtype=torch.long)
+    # One incorrect result and 15 correct results with tiny length-dependent
+    # differences reproduce the sustained 16-node validation outlier.
+    shaped_rewards = torch.tensor(
+        [0.0] + [0.95 + i * 1.0e-3 for i in range(15)],
+        dtype=torch.float32,
+    )
+    raw_rewards = torch.tensor([0.0] + [1.0] * 15, dtype=torch.float32)
+    mask = torch.ones((16, 3), dtype=torch.float32)
+
+    unstable = estimator.compute_advantage(prompt_ids, shaped_rewards, mask)
+    stable = estimator.compute_advantage(
+        prompt_ids,
+        shaped_rewards,
+        mask,
+        std_rewards=raw_rewards,
+    )
+
+    assert unstable[0, 0].abs() > 100
+    assert stable.abs().max() < 5
+    assert stable[0, 0] == pytest.approx(
+        -shaped_rewards[1:].mean().item(),
+        abs=1.0e-5,
+    )
 
 
 # ============================================================================

--- a/tests/unit/algorithms/test_grpo.py
+++ b/tests/unit/algorithms/test_grpo.py
@@ -1357,6 +1357,83 @@ def test_async_grpo_propagates_main_loop_collector_failure(mock_grpo_components)
     mock_grpo_components["policy"].shutdown.assert_called_once()
 
 
+def test_async_grpo_applies_response_length_shaping_before_advantages(
+    mock_grpo_components,
+):
+    """Native response-length shaping must affect async GRPO advantages."""
+    master_config = mock_grpo_components["master_config"]
+    master_config.grpo.max_num_steps = 1
+    master_config.grpo.val_period = 0
+    master_config.grpo.val_at_start = False
+    master_config.grpo.val_at_end = False
+    master_config.grpo.use_dynamic_sampling = False
+    master_config.grpo.reward_shaping = GRPORewardShapingConfig(
+        enabled=True,
+        mode="response_length",
+        max_response_length=6,
+        overlong_buffer_length=2,
+        overlong_buffer_penalty=1.0,
+    )
+    master_config.policy["generation"]["colocated"]["enabled"] = False
+
+    mock_batch = next(iter(mock_grpo_components["train_dataloader"]))
+    mock_batch["message_log"] = [
+        [
+            {
+                "role": "user",
+                "content": "test",
+                "token_ids": torch.tensor([1, 2, 3]),
+            },
+            {
+                "role": "assistant",
+                "content": "response",
+                "token_ids": torch.tensor([4, 5, 6, 7, 8]),
+                "generation_logprobs": torch.zeros(5),
+            },
+        ]
+    ]
+    mock_batch["total_reward"] = torch.tensor([1.0])
+    mock_rollout_metrics = {"mean_gen_tokens_per_sample": 5.0}
+
+    advantage_estimator = MagicMock()
+    advantage_estimator.compute_advantage.return_value = torch.zeros(1, 2)
+    advantage_estimator.last_metrics = {}
+
+    with (
+        mock_async_grpo_infrastructure(mock_batch, mock_rollout_metrics),
+        _patched_logprob_phase(mock_grpo_components["policy"]),
+        patch(
+            "nemo_rl.algorithms.grpo._create_advantage_estimator",
+            return_value=advantage_estimator,
+        ),
+    ):
+        async_grpo_train(
+            mock_grpo_components["policy"],
+            _mock_policy_generation(),
+            mock_grpo_components["train_dataloader"],
+            mock_grpo_components["val_dataloader"],
+            mock_grpo_components["tokenizer"],
+            mock_grpo_components["loss_fn"],
+            mock_grpo_components["task_to_env"],
+            mock_grpo_components["val_task_to_env"],
+            mock_grpo_components["logger"],
+            mock_grpo_components["checkpointer"],
+            _initial_grpo_save_state(),
+            master_config,
+        )
+
+    advantage_kwargs = advantage_estimator.compute_advantage.call_args.kwargs
+    torch.testing.assert_close(advantage_kwargs["rewards"], torch.tensor([0.5]))
+    torch.testing.assert_close(
+        advantage_kwargs["repeated_batch"]["unshaped_total_reward"],
+        torch.tensor([1.0]),
+    )
+    torch.testing.assert_close(
+        advantage_kwargs["std_rewards"],
+        torch.tensor([1.0]),
+    )
+
+
 @pytest.mark.parametrize(
     ("generation_config", "expected"),
     [

--- a/tests/unit/algorithms/test_reward_functions.py
+++ b/tests/unit/algorithms/test_reward_functions.py
@@ -17,12 +17,174 @@ import torch
 
 from nemo_rl.algorithms.grpo import RewardScalingConfig, scale_rewards
 from nemo_rl.algorithms.reward_functions import (
+    GRPORewardShapingConfig,
+    ReasoningLengthRewardConfig,
     RewardShapingConfig,
+    apply_length_aware_reward,
     apply_reward_shaping,
+    length_aware_regularization_reward,
+    reasoning_chain_token_length,
 )
 from nemo_rl.data.interfaces import DatumSpec
 from nemo_rl.distributed.batched_data_dict import BatchedDataDict
 from tests.unit.algorithms.utils import create_mock_batch_with_responses
+
+
+def test_length_aware_regularization_reward_boundaries():
+    assert length_aware_regularization_reward(0, tau1=10, tau2=20) == 1.0
+    assert length_aware_regularization_reward(10, tau1=10, tau2=20) == 1.0
+    assert length_aware_regularization_reward(15, tau1=10, tau2=20) == 0.5
+    assert length_aware_regularization_reward(20, tau1=10, tau2=20) == 0.0
+    assert length_aware_regularization_reward(21, tau1=10, tau2=20) == 0.0
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"tau1": -1},
+        {"tau1": 20, "tau2": 20},
+        {"tau1": 21, "tau2": 20},
+        {"weight": -0.1},
+        {"composition": "correctness_gated", "weight": 1.1},
+        {"reasoning_end_token_id": -1},
+    ],
+)
+def test_reasoning_length_reward_config_rejects_invalid_values(kwargs):
+    config_values = {"reasoning_end_token_id": 13, **kwargs}
+    with pytest.raises(ValueError):
+        ReasoningLengthRewardConfig(**config_values)
+
+
+def test_grpo_reward_shaping_requires_reasoning_end_token_for_active_mode():
+    with pytest.raises(ValueError, match="reasoning_end_token_id"):
+        GRPORewardShapingConfig(enabled=True, mode="reasoning_length")
+
+
+def test_grpo_reward_shaping_selects_one_processing_stage():
+    response_length = GRPORewardShapingConfig(enabled=True)
+    reasoning_length = GRPORewardShapingConfig(
+        enabled=True,
+        mode="reasoning_length",
+        reasoning_length={"reasoning_end_token_id": 13},
+    )
+
+    assert response_length.response_length_enabled is True
+    assert response_length.reasoning_length_enabled is False
+    assert reasoning_length.response_length_enabled is False
+    assert reasoning_length.reasoning_length_enabled is True
+
+
+def test_reasoning_chain_token_length_uses_end_token_and_counts_unfinished_turn():
+    message_log = [
+        {"role": "user", "token_ids": torch.tensor([8, 9])},
+        {"role": "assistant", "token_ids": torch.tensor([1, 2, 13, 7])},
+        {"role": "assistant", "token_ids": torch.tensor([3, 4, 5])},
+    ]
+
+    assert reasoning_chain_token_length(message_log, reasoning_end_token_id=13) == 5
+
+
+def test_apply_length_aware_reward_correctness_gates_base_reward():
+    results = [
+        {
+            "message_log": [
+                {"role": "assistant", "token_ids": torch.tensor([1, 2, 3, 13])}
+            ],
+            "full_result": {"reward": base_reward},
+        }
+        for base_reward in (1.0, 0.5, 0.0)
+    ]
+    config = ReasoningLengthRewardConfig(
+        tau1=2,
+        tau2=4,
+        weight=0.2,
+        composition="correctness_gated",
+        reasoning_end_token_id=13,
+    )
+
+    metrics = apply_length_aware_reward(results, config)
+
+    assert metrics.component_rewards == [0.5, 0.5, 0.5]
+    assert metrics.reasoning_chain_lengths == [3, 3, 3]
+    assert metrics.unshaped_rewards == [1.0, 0.5, 0.0]
+    assert [result["full_result"]["reward"] for result in results] == pytest.approx(
+        [0.9, 0.45, 0.0]
+    )
+
+
+def test_apply_length_aware_reward_adds_component_when_configured():
+    results = [
+        {
+            "message_log": [
+                {"role": "assistant", "token_ids": torch.tensor([1, 2, 3, 13])}
+            ],
+            "full_result": {"reward": 0.0},
+        }
+    ]
+    config = ReasoningLengthRewardConfig(
+        tau1=2,
+        tau2=4,
+        weight=0.2,
+        composition="additive",
+        reasoning_end_token_id=13,
+    )
+
+    apply_length_aware_reward(results, config)
+
+    assert results[0]["full_result"]["reward"] == pytest.approx(0.1)
+
+
+def test_apply_length_aware_reward_excludes_assistant_prompt_history():
+    input_message_log = [
+        {"role": "user", "token_ids": torch.tensor([7])},
+        {"role": "assistant", "token_ids": torch.tensor([4, 5, 6, 13])},
+        {"role": "user", "token_ids": torch.tensor([8])},
+    ]
+    results = [
+        {
+            "input_message_log": input_message_log,
+            "message_log": [
+                *input_message_log,
+                {"role": "assistant", "token_ids": torch.tensor([1, 13])},
+            ],
+            "full_result": {"reward": 1.0},
+        }
+    ]
+    config = ReasoningLengthRewardConfig(
+        tau1=1,
+        tau2=3,
+        weight=0.5,
+        composition="correctness_gated",
+        reasoning_end_token_id=13,
+    )
+
+    metrics = apply_length_aware_reward(results, config)
+
+    assert metrics.reasoning_chain_lengths == [1]
+    assert metrics.component_rewards == [1.0]
+    assert results[0]["full_result"]["reward"] == pytest.approx(1.0)
+
+
+def test_apply_length_aware_reward_rejects_multi_component_rewards():
+    results = [
+        {
+            "message_log": [{"role": "assistant", "token_ids": torch.tensor([1, 13])}],
+            "full_result": {"reward": 0.5},
+        },
+        {
+            "message_log": [{"role": "assistant", "token_ids": torch.tensor([1, 13])}],
+            "full_result": {
+                "reward": 1.0,
+                "reward_components": {"accuracy": 1.0},
+            },
+        },
+    ]
+    config = ReasoningLengthRewardConfig(reasoning_end_token_id=13)
+
+    with pytest.raises(ValueError, match="reward_components"):
+        apply_length_aware_reward(results, config)
+
+    assert results[0]["full_result"]["reward"] == 0.5
 
 
 def test_reward_scaling_disabled():

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -26,6 +26,7 @@ from PIL import Image
 from transformers import AutoTokenizer
 
 import nemo_rl.experience.rollouts as rollouts_mod
+from nemo_rl.algorithms.reward_functions import GRPORewardShapingConfig
 from nemo_rl.data.collate_fn import rl_collate_fn
 from nemo_rl.data.datasets.response_datasets import NemoGymDataset
 from nemo_rl.data.interfaces import DatumSpec
@@ -1777,6 +1778,11 @@ def test_run_async_nemo_gym_rollout_streams_complete_prompt_groups(monkeypatch):
 
     clock = {"now": 0.0}
     payload_calls = []
+    reward_shaping_config = GRPORewardShapingConfig(
+        enabled=True,
+        mode="reasoning_length",
+        reasoning_length={"reasoning_end_token_id": 13},
+    )
 
     class _FakeTimerContext:
         def __init__(self, timer, label):
@@ -1913,6 +1919,7 @@ def test_run_async_nemo_gym_rollout_streams_complete_prompt_groups(monkeypatch):
 
     def _postprocess_group(**kwargs):
         assert kwargs["log_full_result_tables"] is False
+        assert kwargs["reward_shaping_config"] is reward_shaping_config
         task_index = int(kwargs["nemo_gym_rows"][0]["_ng_task_index"])
         for result, original_log in zip(
             kwargs["results"], kwargs["input_batch"]["message_log"]
@@ -1979,6 +1986,7 @@ def test_run_async_nemo_gym_rollout_streams_complete_prompt_groups(monkeypatch):
             },
             num_generations=2,
             log_full_result_tables=False,
+            reward_shaping_config=reward_shaping_config,
             deduplicate_multimodal_data=True,
             debug_payload_metrics=True,
         ):
@@ -2106,8 +2114,82 @@ def test_postprocess_nemo_gym_group_returns_task_index(log_full_result_tables):
     ) is log_full_result_tables
 
 
+def test_postprocess_nemo_gym_group_applies_length_aware_reward():
+    rows = [
+        {"agent_ref": {"name": "agent"}, "_ng_task_index": 42},
+        {"agent_ref": {"name": "agent"}, "_ng_task_index": 42},
+    ]
+    assistant_token_ids = (torch.tensor([1, 2, 13]), torch.tensor([1, 13]))
+    results = []
+    for reward, token_ids in zip((1.0, 0.0), assistant_token_ids):
+        input_message = {
+            "role": "user",
+            "content": "prompt",
+            "token_ids": torch.tensor([1]),
+        }
+        results.append(
+            {
+                "input_message_log": [input_message],
+                "message_log": [
+                    input_message,
+                    {
+                        "role": "assistant",
+                        "content": "answer",
+                        "token_ids": token_ids,
+                        "generation_logprobs": torch.full(token_ids.shape, -0.1),
+                    },
+                ],
+                "full_result": {"reward": reward},
+            }
+        )
+
+    rollout_result = rollouts_mod._postprocess_single_nemo_gym_group(
+        nemo_gym_rows=rows,
+        results=results,
+        timer=rollouts_mod.Timer(),
+        timer_prefix="timing/rollout",
+        policy_generation=type(
+            "_PolicyGeneration",
+            (),
+            {"cfg": {"vllm_cfg": {"max_model_len": 128}}},
+        )(),
+        input_batch=BatchedDataDict({"loss_multiplier": torch.ones(2)}),
+        tokenizer=type("_Tokenizer", (), {"pad_token_id": 0})(),
+        log_full_result_tables=False,
+        reward_shaping_config=GRPORewardShapingConfig(
+            enabled=True,
+            mode="reasoning_length",
+            reasoning_length={
+                "tau1": 1,
+                "tau2": 3,
+                "weight": 0.5,
+                "composition": "correctness_gated",
+                "reasoning_end_token_id": 13,
+            },
+        ),
+    )
+
+    assert rollout_result.final_batch["total_reward"].tolist() == pytest.approx(
+        [0.75, 0.0]
+    )
+    assert rollout_result.final_batch[
+        "unshaped_total_reward"
+    ].tolist() == pytest.approx([1.0, 0.0])
+    assert rollout_result.rollout_metrics["length_aware_reward/mean"] == pytest.approx(
+        0.75
+    )
+    assert rollout_result.rollout_metrics[
+        "reasoning_chain_tokens/mean"
+    ] == pytest.approx(1.5)
+
+
 def test_run_nemo_gym_rollout_sync_drains_entire_batch(monkeypatch):
     input_batch = BatchedDataDict({"loss_multiplier": torch.ones(3)})
+    reward_shaping_config = GRPORewardShapingConfig(
+        enabled=True,
+        mode="reasoning_length",
+        reasoning_length={"reasoning_end_token_id": 13},
+    )
     expected = rollouts_mod.NemoGymRolloutResult(
         input_ids=torch.empty(0),
         final_batch=input_batch,
@@ -2121,6 +2203,7 @@ def test_run_nemo_gym_rollout_sync_drains_entire_batch(monkeypatch):
         assert kwargs["log_full_result_tables"] is False
         assert kwargs["deduplicate_multimodal_data"] is True
         assert kwargs["debug_payload_metrics"] is True
+        assert kwargs["reward_shaping_config"] is reward_shaping_config
         yield expected
 
     monkeypatch.setattr(rollouts_mod, "run_async_nemo_gym_rollout", fake_stream)
@@ -2132,6 +2215,7 @@ def test_run_nemo_gym_rollout_sync_drains_entire_batch(monkeypatch):
         task_to_env={},
         generation_config={},
         log_full_result_tables=False,
+        reward_shaping_config=reward_shaping_config,
         deduplicate_multimodal_data=True,
         debug_payload_metrics=True,
     )

--- a/tests/unit/reference_configs/grpo_math_1B.yaml
+++ b/tests/unit/reference_configs/grpo_math_1B.yaml
@@ -27,10 +27,17 @@ grpo:
   batch_multiplier: 1
   reward_shaping:
     enabled: false
+    mode: response_length
     overlong_buffer_length: 128
     overlong_buffer_penalty: 1
     max_response_length: ${policy.max_total_sequence_length}
     stop_properly_penalty_coef: null
+    reasoning_length:
+      tau1: 4096
+      tau2: 13000
+      weight: 0.1
+      composition: additive
+      reasoning_end_token_id: null
 
   # Advantage Estimator Configuration
   # Options: "grpo" (default) or "reinforce_plus_plus"

--- a/tests/unit/test_config_validation.py
+++ b/tests/unit/test_config_validation.py
@@ -235,6 +235,58 @@ def test_vlm_launcher_dispatches_on_async_grpo_enabled():
     assert "grpo_train" in sync_calls
 
 
+@pytest.mark.parametrize(
+    "launcher_relpath",
+    [
+        "examples/run_grpo.py",
+        "examples/run_vlm_grpo.py",
+        "examples/nemo_gym/run_grpo_nemo_gym.py",
+    ],
+)
+def test_async_grpo_launchers_allow_reward_shaping(launcher_relpath: str):
+    """Keep launchers from rejecting shaping supported by async_grpo_train."""
+    launcher = Path(__file__).parents[2] / launcher_relpath
+    tree = ast.parse(launcher.read_text())
+
+    async_branches = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.If)
+        and ast.unparse(node.test) == "config.grpo.async_grpo.enabled"
+    ]
+    assert len(async_branches) == 1
+
+    unsupported_checks = [
+        ast.unparse(node.test)
+        for node in ast.walk(async_branches[0])
+        if isinstance(node, ast.If) and "reward_shaping" in ast.unparse(node.test)
+    ]
+    assert unsupported_checks == []
+
+
+def test_sync_rollout_actor_forwards_reward_shaping():
+    """Keep SingleController Gym rollouts on the same shaping path."""
+    actor_source = (
+        Path(__file__).parents[2] / "nemo_rl" / "experience" / "sync_rollout_actor.py"
+    )
+    tree = ast.parse(actor_source.read_text())
+    rollout_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "run_nemo_gym_rollout_sync"
+    ]
+    assert len(rollout_calls) == 1
+
+    reward_shaping_values = [
+        ast.unparse(keyword.value)
+        for keyword in rollout_calls[0].keywords
+        if keyword.arg == "reward_shaping_config"
+    ]
+    assert reward_shaping_values == ["cfg.grpo.reward_shaping"]
+
+
 def test_reward_penalty_config_requires_explicit_unwanted_token_ids():
     """Unwanted-token penalty requires explicit unwanted-token config.
 

--- a/tests/unit/test_video_grpo_recipes.py
+++ b/tests/unit/test_video_grpo_recipes.py
@@ -37,6 +37,8 @@ def test_video_grpo_recipes_preserve_unmasked_sync_and_async_contracts():
         assert grpo["max_num_steps"] == 1_000_000
         assert grpo["seq_logprob_error_threshold"] is None
         assert grpo["async_grpo"]["enabled"] is async_enabled
+        assert grpo["reward_shaping"]["enabled"] is False
+        assert grpo["reward_shaping"]["mode"] == "response_length"
         assert policy["is_vlm"] is True
         assert vllm_cfg["video"] == {
             "sampling_style": "nemotron_vl",
@@ -52,6 +54,67 @@ def test_video_grpo_recipes_preserve_unmasked_sync_and_async_contracts():
             "NRL_VIDEO_SAMPLING_STYLE",
             "NRL_VIDEO_TEMPORAL_PATCH_SIZE",
         } & set(vllm_cfg.get("env_vars", {}))
+
+
+def test_video_length_reward_recipes_preserve_arushi_experiment_contract():
+    async_recipe = _load_recipe(
+        "vlm_grpo-nemotron-omni-30ba3b-16n8g-megatron-tp2ep16-async-gym-video-length-reward.v1.yaml"
+    )
+    sync_recipe = _load_recipe(
+        "vlm_grpo-nemotron-omni-30ba3b-2n8g-megatron-tp4ep4-gym-video-length-reward.v1.yaml"
+    )
+
+    for recipe, async_enabled in ((async_recipe, True), (sync_recipe, False)):
+        assert recipe["grpo"]["async_grpo"]["enabled"] is async_enabled
+        reward_shaping = recipe["grpo"]["reward_shaping"]
+        assert reward_shaping["enabled"] is True
+        assert reward_shaping["mode"] == "reasoning_length"
+        assert reward_shaping["reasoning_length"] == {
+            "tau1": 1024,
+            "tau2": 4096,
+            "weight": 0.05,
+            "composition": "correctness_gated",
+            "reasoning_end_token_id": 13,
+        }
+
+    assert async_recipe["grpo"]["num_prompts_per_step"] == 128
+    assert async_recipe["grpo"]["num_generations_per_prompt"] == 16
+    assert async_recipe["grpo"]["max_num_steps"] == 1_000_000
+    assert async_recipe["grpo"]["max_num_epochs"] == 1_000_000
+    assert async_recipe["grpo"]["seq_logprob_error_threshold"] is None
+    assert async_recipe["loss_fn"]["reference_policy_kl_penalty"] == 0.0
+    assert async_recipe["loss_fn"]["use_importance_sampling_correction"] is True
+
+    policy = async_recipe["policy"]
+    assert policy["train_global_batch_size"] == 2048
+    assert policy["max_total_sequence_length"] == 16384
+    assert policy["sequence_packing"]["enabled"] is True
+    assert policy["megatron_cfg"]["tensor_model_parallel_size"] == 2
+    assert policy["megatron_cfg"]["expert_model_parallel_size"] == 16
+    assert policy["megatron_cfg"]["activation_checkpointing"] is False
+    assert policy["megatron_cfg"]["optimizer"]["lr"] == 3.0e-6
+    assert policy["megatron_cfg"]["scheduler"]["lr_warmup_iters"] == 10
+
+    generation = policy["generation"]
+    assert generation["max_new_tokens"] == 16384
+    assert generation["temperature"] == 1.0
+    assert generation["top_p"] == 1.0
+    assert generation["vllm_cfg"]["tensor_parallel_size"] == 2
+    assert generation["vllm_cfg"]["gpu_memory_utilization"] == 0.7
+    assert generation["vllm_cfg"]["video"]["num_frames"] == 64
+    assert generation["vllm_kwargs"]["max_num_seqs"] == 8
+    assert generation["vllm_kwargs"]["max_num_batched_tokens"] == 32768
+    assert async_recipe["data"]["shuffle"] is True
+    assert async_recipe["data"]["default"]["num_frames"] == 64
+
+    sync_policy = sync_recipe["policy"]
+    assert sync_recipe["grpo"]["max_num_epochs"] == 1_000_000
+    assert sync_recipe["grpo"]["val_period"] == 0
+    assert sync_recipe["data"]["shuffle"] is True
+    assert sync_policy["sequence_packing"]["enabled"] is True
+    assert sync_policy["generation"]["vllm_cfg"]["video"]["num_frames"] == 64
+    assert sync_policy["generation"]["vllm_kwargs"]["mm_processor_cache_gb"] == 4
+    assert sync_policy["megatron_cfg"]["scheduler"]["lr_warmup_iters"] == 10
 
 
 def test_video_recipe_materializes_one_sampling_contract_for_all_consumers():


### PR DESCRIPTION
## Summary

Add opt-in length reward shaping to synchronous and asynchronous GRPO:

- `reasoning_length` shapes Gym rewards from generated assistant reasoning tokens before trajectories enter the replay buffer.
- `response_length` applies the existing DAPO/stop-properly response-length shaping to async batches before advantage computation.
- Preserve the unshaped task reward for logging and reward normalization.
- Add typed configuration, metrics, focused tests, and 2-node sync / 16-node async Nemotron Omni video recipes.

## Reasoning-length reward

For reasoning length `n`:

```text
R_length(n) = 1                              if n <= tau1
            = (tau2 - n) / (tau2 - tau1)    if tau1 < n < tau2
            = 0                              if n >= tau2

R_final = R_base * (1 - weight * (1 - R_length))
```

The video recipes use:

```yaml
grpo:
  reward_shaping:
    enabled: true
    mode: reasoning_length
    reasoning_length:
      tau1: 1024
      tau2: 4096
      weight: 0.05
      composition: correctness_gated
      reasoning_end_token_id: 13
```

Reasoning length counts newly generated assistant tokens before Nemotron Omni's `</think>` token. Assistant turns already present in the prompt are excluded.

## Async response-length shaping

The existing response-length configuration now also affects async GRPO:

```yaml
grpo:
  reward_shaping:
    enabled: true
    mode: response_length
    overlong_buffer_length: 128
    overlong_buffer_penalty: 1
    max_response_length: ${policy.max_total_sequence_length}
    stop_properly_penalty_coef: null
```

Setting `stop_properly_penalty_coef` selects stop-properly shaping; otherwise the DAPO overlong settings are used.

## Validation

- Ruff and formatting checks passed; 26 focused reward, rollout, async-GRPO, configuration, and recipe tests passed.
- Final diff/whitespace, recipe, launcher dry-run, and secret/path audits passed.
- 2-node synchronous validation used Arushi's MPO-125 checkpoint and cached 64-frame dataset for the full four-hour allocation, completing step 68 before the scheduler stopped step 69. Mean TMPE stayed `1.00945-1.02196`, peak max TMPE was `1.04519`, reward stayed `0-0.99497`, and no samples were masked.
- 16-node asynchronous validation uses 8 training + 8 generation nodes, TP2/EP16, vLLM TP2, 128 prompts x 16 generations, GBS 2048, sequence packing, in-flight refits, and importance correction. Array task `6303627` restored step 6 and completed cleanly after 3h55m at step 28 with a finalized policy/replay-buffer checkpoint. Mean TMPE stayed `1.01533-1.01622`, reward stayed `0.235-0.401`, average trajectory age was 1, and no samples were masked. [W&B run](https://wandb.ai/adlr/Nemotron-omni-RL-debug/runs/0823_video_length_reward_arushi_mpo125_async_normfix_ceb477ae1)

The validation launchers and credentials are not included in this PR.
