### PR TITLE
feat(gym): apply effort-level reward shaping in the SingleController

### DIFF
--- a/nemo_rl/algorithms/single_controller_utils/setup.py
+++ b/nemo_rl/algorithms/single_controller_utils/setup.py
@@ -38,6 +38,7 @@ from nemo_rl.algorithms.async_utils.replay_buffer import TQReplayBuffer
 from nemo_rl.algorithms.grpo import (
     GRPOSaveState,
     _create_advantage_estimator,
+    _get_effort_config,
     _get_grpo_save_state,
 )
 from nemo_rl.algorithms.grpo import MasterConfig as GrpoMasterConfig
@@ -810,6 +811,7 @@ def setup_single_controller(
             env_s=master_config.async_rl.rollout_failure.native.env_timeout_s,
         ),
         retry_policy=_build_retry_policy(master_config),
+        effort_config=_get_effort_config(cast(GrpoMasterConfig, master_config)),
     )
 
     # Print setup timing metrics

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -16,6 +16,7 @@ import asyncio
 import copy
 import enum
 import json
+import statistics
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
@@ -41,8 +42,11 @@ from nemo_rl.experience.failures import (
 from nemo_rl.experience.interfaces import Completion, PromptGroupRecord
 from nemo_rl.experience.metric_utils import calculate_single_metric, pct
 from nemo_rl.experience.rollouts import (
+    EffortLevelsConfig,
+    _apply_effort_shaping,
     _attach_routed_experts_to_message_log_prefix,
     _dummy_routed_experts_for_tokens,
+    _EffortShapingMetrics,
     _find_routed_experts_template,
     _tensorize_by_key,
     attach_static_multimodal_payload,
@@ -749,6 +753,8 @@ class AsyncNemoGymRolloutImpl:
         # Shared with the owning RolloutManager so row-level re-dispatches are visible
         # in the same counters as everything else. None when constructed directly.
         stats: Optional[RolloutStats] = None,
+        # Length-based reward shaping for low-effort prompts; None disables it.
+        effort_config: Optional[EffortLevelsConfig] = None,
         **kwargs: Any,
     ) -> None:
         self._tokenizer = tokenizer
@@ -765,6 +771,7 @@ class AsyncNemoGymRolloutImpl:
             else RolloutRetryPolicy.single_attempt()
         ).max_gym_row_attempts
         self._stats = stats
+        self._effort_config = effort_config
 
         self._validate_init_params()
 
@@ -985,6 +992,10 @@ class AsyncNemoGymRolloutImpl:
                 raise failure from last_error
 
             completed_results = [result for result in results if result is not None]
+            # Shape rewards for low-effort prompts before completions are built.
+            shaping = _apply_effort_shaping(
+                completed_results, inputs, self._effort_config
+            )
             # All N rollouts share the same input prompt; tensorize one copy.
             prompt_message_log = completed_results[0]["input_message_log"]
             _tensorize_by_key(prompt_message_log, "token_ids")
@@ -996,7 +1007,7 @@ class AsyncNemoGymRolloutImpl:
         # Compute rollout metrics.
         with timer.time(f"{timer_prefix}/compute_metrics"):
             rollout_metrics = self._compute_rollout_metrics(
-                completions, inputs[0]["agent_ref"]["name"]
+                completions, inputs[0]["agent_ref"]["name"], shaping
             )
 
         rollout_metrics.update(env_timing_metrics)
@@ -1034,6 +1045,7 @@ class AsyncNemoGymRolloutImpl:
         self,
         completions: list[Completion],
         agent_name: str,
+        shaping: _EffortShapingMetrics,
     ) -> dict[str, Any]:
         """Aggregate per-sample and per-agent metrics."""
         # Prepare lists of values for each metric.
@@ -1105,6 +1117,31 @@ class AsyncNemoGymRolloutImpl:
         rollout_metrics["mean_gen_tokens_per_sample"] = rollout_metrics[
             "gen_tokens_per_sample/mean"
         ]
+
+        # Length-based reward shaping metrics for low-effort prompts. Empty lists
+        # (shaping disabled or no matching prompt) leave rollout_metrics untouched.
+        if shaping.length_rewards_low:
+            rollout_metrics["mean_length_reward_low"] = sum(
+                shaping.length_rewards_low
+            ) / len(shaping.length_rewards_low)
+        if shaping.rewards_low:
+            rollout_metrics["mean_reward_low"] = sum(shaping.rewards_low) / len(
+                shaping.rewards_low
+            )
+        if shaping.low_lengths:
+            rollout_metrics["mean_length_low"] = sum(shaping.low_lengths) / len(
+                shaping.low_lengths
+            )
+            rollout_metrics["median_length_low"] = float(
+                statistics.median(shaping.low_lengths)
+            )
+        if shaping.high_lengths:
+            rollout_metrics["mean_length_high"] = sum(shaping.high_lengths) / len(
+                shaping.high_lengths
+            )
+            rollout_metrics["median_length_high"] = float(
+                statistics.median(shaping.high_lengths)
+            )
         return rollout_metrics
 
 
@@ -1125,6 +1162,7 @@ class RolloutManager:
         tq_buffer: Optional[TQReplayBuffer] = None,
         timeouts: Optional[RolloutTimeouts] = None,
         retry_policy: Optional[RolloutRetryPolicy] = None,
+        effort_config: Optional[EffortLevelsConfig] = None,
     ) -> None:
         assert num_generations_per_prompt >= 1, (
             "num_generations_per_prompt must be >= 1"
@@ -1166,6 +1204,7 @@ class RolloutManager:
             # Only the NeMo-Gym impl reads these; the native impl absorbs them via kwargs.
             retry_policy=self._retry_policy,
             stats=self._stats,
+            effort_config=effort_config,
         )
         self._tokenizer = tokenizer
         self._num_generations_per_prompt = num_generations_per_prompt

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -1117,7 +1117,6 @@ class AsyncNemoGymRolloutImpl:
         rollout_metrics["mean_gen_tokens_per_sample"] = rollout_metrics[
             "gen_tokens_per_sample/mean"
         ]
-
         return rollout_metrics
 
 

--- a/nemo_rl/experience/rollout_manager.py
+++ b/nemo_rl/experience/rollout_manager.py
@@ -16,7 +16,6 @@ import asyncio
 import copy
 import enum
 import json
-import statistics
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
@@ -46,7 +45,7 @@ from nemo_rl.experience.rollouts import (
     _apply_effort_shaping,
     _attach_routed_experts_to_message_log_prefix,
     _dummy_routed_experts_for_tokens,
-    _EffortShapingMetrics,
+    _effort_shaping_metrics,
     _find_routed_experts_template,
     _tensorize_by_key,
     attach_static_multimodal_payload,
@@ -1007,8 +1006,10 @@ class AsyncNemoGymRolloutImpl:
         # Compute rollout metrics.
         with timer.time(f"{timer_prefix}/compute_metrics"):
             rollout_metrics = self._compute_rollout_metrics(
-                completions, inputs[0]["agent_ref"]["name"], shaping
+                completions, inputs[0]["agent_ref"]["name"]
             )
+            # Same helper the batched path uses, so the two cannot drift apart.
+            rollout_metrics.update(_effort_shaping_metrics(shaping))
 
         rollout_metrics.update(env_timing_metrics)
 
@@ -1045,7 +1046,6 @@ class AsyncNemoGymRolloutImpl:
         self,
         completions: list[Completion],
         agent_name: str,
-        shaping: _EffortShapingMetrics,
     ) -> dict[str, Any]:
         """Aggregate per-sample and per-agent metrics."""
         # Prepare lists of values for each metric.
@@ -1118,30 +1118,6 @@ class AsyncNemoGymRolloutImpl:
             "gen_tokens_per_sample/mean"
         ]
 
-        # Length-based reward shaping metrics for low-effort prompts. Empty lists
-        # (shaping disabled or no matching prompt) leave rollout_metrics untouched.
-        if shaping.length_rewards_low:
-            rollout_metrics["mean_length_reward_low"] = sum(
-                shaping.length_rewards_low
-            ) / len(shaping.length_rewards_low)
-        if shaping.rewards_low:
-            rollout_metrics["mean_reward_low"] = sum(shaping.rewards_low) / len(
-                shaping.rewards_low
-            )
-        if shaping.low_lengths:
-            rollout_metrics["mean_length_low"] = sum(shaping.low_lengths) / len(
-                shaping.low_lengths
-            )
-            rollout_metrics["median_length_low"] = float(
-                statistics.median(shaping.low_lengths)
-            )
-        if shaping.high_lengths:
-            rollout_metrics["mean_length_high"] = sum(shaping.high_lengths) / len(
-                shaping.high_lengths
-            )
-            rollout_metrics["median_length_high"] = float(
-                statistics.median(shaping.high_lengths)
-            )
         return rollout_metrics
 
 

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -466,6 +466,38 @@ def _apply_effort_shaping(
     )
 
 
+def _effort_shaping_metrics(shaping: _EffortShapingMetrics) -> dict[str, float]:
+    """Build the rollout-metric entries for one group's effort-shaping lists.
+
+    Shared by the batched v1 path and the SingleController rollout manager so the
+    two cannot drift apart.
+
+    Args:
+        shaping: Per-sample tracking lists returned by ``_apply_effort_shaping``.
+
+    Returns:
+        Metric name to value. Empty when shaping was disabled or when no prompt in
+        the group matched ``low_string`` -- callers ``update`` an existing dict, so
+        an absent key leaves the metric unreported rather than reporting a zero.
+    """
+    metrics: dict[str, float] = {}
+    if shaping.length_rewards_low:
+        metrics["mean_length_reward_low"] = sum(shaping.length_rewards_low) / len(
+            shaping.length_rewards_low
+        )
+    if shaping.rewards_low:
+        metrics["mean_reward_low"] = sum(shaping.rewards_low) / len(shaping.rewards_low)
+    if shaping.low_lengths:
+        metrics["mean_length_low"] = sum(shaping.low_lengths) / len(shaping.low_lengths)
+        metrics["median_length_low"] = float(statistics.median(shaping.low_lengths))
+    if shaping.high_lengths:
+        metrics["mean_length_high"] = sum(shaping.high_lengths) / len(
+            shaping.high_lengths
+        )
+        metrics["median_length_high"] = float(statistics.median(shaping.high_lengths))
+    return metrics
+
+
 def generate_responses(
     policy_generation: GenerationInterface,
     generation_input_data: BatchedDataDict[GenerationDatumSpec],
@@ -2610,10 +2642,6 @@ def _postprocess_single_nemo_gym_group(
     """Postprocess one complete prompt group from the NeMo-Gym stream."""
     # Length-based reward shaping for low-effort prompts
     shaping = _apply_effort_shaping(results, nemo_gym_rows, effort_config)
-    length_rewards_low = shaping.length_rewards_low
-    rewards_low = shaping.rewards_low
-    low_lengths = shaping.low_lengths
-    high_lengths = shaping.high_lengths
 
     resolved_reward_penalty_config = resolve_reward_penalty_config(
         reward_penalty_config, tokenizer, thinking_tags=thinking_tags
@@ -2793,18 +2821,7 @@ def _postprocess_single_nemo_gym_group(
     if mask_env_flagged_samples:
         final_batch["mask_sample"] = _extract_mask_sample_flags(results)
 
-    if length_rewards_low:
-        rollout_metrics["mean_length_reward_low"] = sum(length_rewards_low) / len(
-            length_rewards_low
-        )
-    if rewards_low:
-        rollout_metrics["mean_reward_low"] = sum(rewards_low) / len(rewards_low)
-    if low_lengths:
-        rollout_metrics["mean_length_low"] = sum(low_lengths) / len(low_lengths)
-        rollout_metrics["median_length_low"] = float(statistics.median(low_lengths))
-    if high_lengths:
-        rollout_metrics["mean_length_high"] = sum(high_lengths) / len(high_lengths)
-        rollout_metrics["median_length_high"] = float(statistics.median(high_lengths))
+    rollout_metrics.update(_effort_shaping_metrics(shaping))
 
     # Penalty metrics — map count keys to (config flag, metric name)
     _PENALTY_METRICS = {

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -476,9 +476,9 @@ def _effort_shaping_metrics(shaping: _EffortShapingMetrics) -> dict[str, float]:
         shaping: Per-sample tracking lists returned by ``_apply_effort_shaping``.
 
     Returns:
-        Metric name to value. Empty when shaping was disabled or when no prompt in
-        the group matched ``low_string`` -- callers ``update`` an existing dict, so
-        an absent key leaves the metric unreported rather than reporting a zero.
+        Metric name to value. Empty only when shaping was disabled; callers
+        ``update`` an existing dict, so an absent key leaves the metric unreported
+        rather than reporting a zero.
     """
     metrics: dict[str, float] = {}
     if shaping.length_rewards_low:

--- a/tests/unit/experience/test_rollout_generation_failures.py
+++ b/tests/unit/experience/test_rollout_generation_failures.py
@@ -537,6 +537,8 @@ def _make_gym_impl(
     impl._stats = stats if stats is not None else RolloutStats()
     # Upstream default; this fixture is about re-dispatch, not sample masking.
     impl._mask_env_flagged_samples = True
+    # Effort-level reward shaping is off unless env.nemo_gym.effort_levels is set.
+    impl._effort_config = None
     return impl
 
 

--- a/tests/unit/experience/test_rollouts.py
+++ b/tests/unit/experience/test_rollouts.py
@@ -2209,6 +2209,7 @@ def test_rollout_manager_consumes_stream_and_restores_input_order():
         "nemo_gym": type("_Environment", (), {"run_rollouts": _RunRolloutsRemote()})()
     }
     manager._tokenizer = None
+    manager._effort_config = None
     manager._result_to_completion = lambda result: result["value"]
     manager._compute_rollout_metrics = lambda completions, agent: {
         "completion_count": len(completions),

--- a/tests/unit/single_controller/test_single_controller_setup.py
+++ b/tests/unit/single_controller/test_single_controller_setup.py
@@ -33,6 +33,7 @@ from nemo_rl.algorithms.single_controller_utils import (
     SingleControllerActorArgs,
     setup_single_controller,
 )
+from nemo_rl.experience.rollouts import EffortLevelsConfig
 
 
 def _make_master_config(
@@ -339,6 +340,52 @@ class TestSetup:
         assert actor_args.partition_id == "rollout_data"
         assert actor_args.tq_buffer._partition_id == "rollout_data"
         assert actor_args.tq_buffer._require_routed_experts is False
+
+    def test_effort_levels_reach_the_rollout_manager(self, patched_factories):
+        """env.nemo_gym.effort_levels is resolved into RolloutManager's kwarg.
+
+        Asserted on the constructor rather than on ``_impl``: only the NeMo-Gym impl
+        keeps the config, while the native impl absorbs it via ``**kwargs``.
+        """
+        mc = _make_master_config(
+            env={
+                "nemo_gym": {
+                    "effort_levels": {
+                        "low_weight": 1.0,
+                        "low_penalty": 2.0,
+                        "low_ub": 500,
+                        "low_string": "<budget>",
+                    }
+                }
+            }
+        )
+
+        with patch.object(sc_setup_mod, "RolloutManager") as mock_rollout_manager:
+            setup_single_controller(mc, MagicMock(pad_token_id=0))
+
+        _, call_kwargs = mock_rollout_manager.call_args
+        assert call_kwargs["effort_config"] == EffortLevelsConfig(
+            low_weight=1.0, low_penalty=2.0, low_ub=500, low_string="<budget>"
+        )
+
+    @pytest.mark.parametrize(
+        "env",
+        [
+            pytest.param({}, id="no_nemo_gym_section"),
+            pytest.param({"nemo_gym": {}}, id="no_effort_levels_key"),
+        ],
+    )
+    def test_rollout_manager_gets_no_effort_config_when_unset(
+        self, env: dict, patched_factories
+    ):
+        """Shaping stays off unless env.nemo_gym.effort_levels is configured."""
+        mc = _make_master_config(env=env)
+
+        with patch.object(sc_setup_mod, "RolloutManager") as mock_rollout_manager:
+            setup_single_controller(mc, MagicMock(pad_token_id=0))
+
+        _, call_kwargs = mock_rollout_manager.call_args
+        assert call_kwargs["effort_config"] is None
 
     def test_router_replay_requires_routes_in_tq_buffer(self, patched_factories):
         mc = _make_master_config(colocated=True)

--- a/tests/unit/test_effort_shaping.py
+++ b/tests/unit/test_effort_shaping.py
@@ -12,9 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+from typing import Optional
+
 import pytest
 
+from nemo_rl.experience.rollout_manager import (
+    AsyncNemoGymRolloutImpl,
+    RolloutManager,
+)
 from nemo_rl.experience.rollouts import EffortLevelsConfig, _apply_effort_shaping
+from nemo_rl.utils.timer import Timer
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -190,3 +198,185 @@ def test_mixed_batch_routes_correctly():
     assert metrics.high_lengths == [200]
     # high-effort sample reward must be unchanged
     assert results[1]["full_result"]["reward"] == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# Wiring: RolloutManager -> AsyncNemoGymRolloutImpl -> Completion + metrics
+#
+# The cases above exercise `_apply_effort_shaping` in isolation. These drive the
+# real `_run_rollouts` so they also pin down *where* the shaping happens: it must
+# land before `_result_to_completion`, or `Completion.reward` -- the value that
+# becomes `total_reward` in the train batch -- keeps the env's raw reward.
+# ---------------------------------------------------------------------------
+
+_GENERATION_CONFIG = {
+    "stop_strings": None,
+    "stop_token_ids": None,
+    "top_k": None,
+}
+
+_LOW_EFFORT_CONFIG = EffortLevelsConfig(
+    low_weight=1.0, low_penalty=1.0, low_ub=1000, low_string="<budget>"
+)
+
+_SHAPING_METRIC_KEYS = (
+    "mean_length_reward_low",
+    "mean_reward_low",
+    "mean_length_low",
+    "median_length_low",
+    "mean_length_high",
+    "median_length_high",
+)
+
+
+class _ReadyRef:
+    """Stands in for the ObjectRef each streamed NeMo-Gym row resolves to."""
+
+    def __init__(self, value):
+        self.value = value
+
+    def __await__(self):
+        async def _resolve():
+            return self.value
+
+        return _resolve().__await__()
+
+
+class _Stream:
+    def __init__(self, refs):
+        self._refs = iter(refs)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._refs)
+        except StopIteration as error:
+            raise StopAsyncIteration from error
+
+
+class _RunRolloutsRemote:
+    """The Ray actor handle is the only seam that has to be faked."""
+
+    def __init__(self, results):
+        self._results = results
+
+    def options(self, *, num_returns):
+        assert num_returns == "streaming"
+        return self
+
+    def remote(self, inputs, timer_prefix):
+        del inputs, timer_prefix
+        return _Stream([_ReadyRef((i, r, None)) for i, r in enumerate(self._results)])
+
+
+def _gym_result(reward: float, response_tokens: int) -> dict:
+    """Build one NeMo-Gym result row, pre-tensorization."""
+    return {
+        "input_message_log": [{"role": "user", "token_ids": [1, 2]}],
+        "message_log": [
+            {"role": "user", "token_ids": [1, 2]},
+            {
+                "role": "assistant",
+                "token_ids": list(range(response_tokens)),
+                "generation_logprobs": [0.0] * response_tokens,
+            },
+        ],
+        "full_result": {"reward": reward},
+    }
+
+
+def _gym_input(rowidx: int, prompt: str) -> dict:
+    return {
+        "_rowidx": rowidx,
+        "agent_ref": {"name": "agent"},
+        "responses_create_params": {"input": [{"role": "user", "content": prompt}]},
+    }
+
+
+def _run_gym_rollouts(
+    effort_config: Optional[EffortLevelsConfig],
+    prompt: str,
+    results: list[dict],
+):
+    """Drive the real _run_rollouts against a fake NeMo-Gym stream."""
+    impl = AsyncNemoGymRolloutImpl(
+        tokenizer=None,
+        task_to_env={},
+        num_generations_per_prompt=len(results),
+        max_seq_len=100_000,
+        max_rollout_turns=1,
+        generation_config=_GENERATION_CONFIG,
+        effort_config=effort_config,
+    )
+    impl._task_to_env = {
+        "nemo_gym": type(
+            "_Environment", (), {"run_rollouts": _RunRolloutsRemote(results)}
+        )()
+    }
+    inputs = [_gym_input(i, prompt) for i in range(len(results))]
+    return asyncio.run(impl._run_rollouts(inputs, Timer(), "timing/test"))
+
+
+def test_rollout_manager_forwards_effort_config():
+    """effort_config reaches the NeMo-Gym impl through RolloutManager."""
+    common = {
+        "tokenizer": None,
+        "task_to_env": {},
+        "num_generations_per_prompt": 1,
+        "max_seq_len": 1,
+        "generation_config": _GENERATION_CONFIG,
+        "use_nemo_gym": True,
+    }
+
+    assert RolloutManager(**common)._impl._effort_config is None
+    manager = RolloutManager(**common, effort_config=_LOW_EFFORT_CONFIG)
+    assert manager._impl._effort_config is _LOW_EFFORT_CONFIG
+
+
+def test_run_rollouts_shapes_completion_reward_and_emits_low_metrics():
+    """The Completion carries the shaped reward, not the env's raw reward."""
+    completions, _, metrics = _run_gym_rollouts(
+        _LOW_EFFORT_CONFIG,
+        "<budget> be concise",
+        [_gym_result(reward=1.0, response_tokens=100)],
+    )
+
+    # length_reward = min(1, 1.0 * (1 - 100/1000)) = 0.9 -> 1.0 + 1.0 * 0.9 = 1.9
+    assert completions[0].reward == pytest.approx(1.9)
+    # Downstream reward metrics are computed from the shaped Completion.
+    assert metrics["total_reward/mean"] == pytest.approx(1.9)
+    assert metrics["mean_length_reward_low"] == pytest.approx(0.9)
+    assert metrics["mean_reward_low"] == pytest.approx(1.9)
+    assert metrics["mean_length_low"] == pytest.approx(100)
+    assert metrics["median_length_low"] == pytest.approx(100.0)
+    assert "mean_length_high" not in metrics
+    assert "median_length_high" not in metrics
+
+
+def test_run_rollouts_leaves_high_effort_prompt_reward_untouched():
+    """A prompt without low_string is only counted, never re-scored."""
+    completions, _, metrics = _run_gym_rollouts(
+        _LOW_EFFORT_CONFIG,
+        "explain everything in detail",
+        [_gym_result(reward=1.0, response_tokens=200)],
+    )
+
+    assert completions[0].reward == pytest.approx(1.0)
+    assert metrics["mean_length_high"] == pytest.approx(200)
+    assert metrics["median_length_high"] == pytest.approx(200.0)
+    assert "mean_length_low" not in metrics
+    assert "mean_reward_low" not in metrics
+
+
+def test_run_rollouts_without_effort_config_emits_no_shaping_metrics():
+    """The default (effort_levels unset) path is a no-op end to end."""
+    completions, _, metrics = _run_gym_rollouts(
+        None,
+        "<budget> be concise",
+        [_gym_result(reward=1.0, response_tokens=100)],
+    )
+
+    assert completions[0].reward == pytest.approx(1.0)
+    assert not any(key in metrics for key in _SHAPING_METRIC_KEYS)


### PR DESCRIPTION
PR #2770 only wired length-based effort reward shaping into the run_grpo.py (v1) synchronous paths. The SingleController (v2) path runs its own NeMo-Gym rollout via RolloutManager/AsyncNemoGymRolloutImpl, which never applied it.

- Thread EffortLevelsConfig through RolloutManager into AsyncNemoGymRolloutImpl and call the shared _apply_effort_shaping before completions are built, so the shaped reward flows into Completion.reward.
- Fold the effort length/reward metrics into _compute_rollout_metrics.
- setup.py resolves the config via the shared _get_effort_config helper.

No behaviour change when env.nemo_gym.effort_levels is unset (_get_effort_config returns None -> shaping is a no-op).

# result
<img width="711" height="338" alt="image" src="https://github.com/user-attachments/assets/79a2dd74-4164-46f5-9795-4ec5eb4fa90f" />
<img width="713" height="338" alt="image" src="https://github.com/user-attachments/assets/ef70131f-9b9f-4dd2-a02c-a2c75a13ff21" />


# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA-NeMo/RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA-NeMo/RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA-NeMo/RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
