### PR TITLE
fix(sc): skip reference logprobs when KL is disabled

### DIFF
--- a/nemo_rl/algorithms/single_controller.py
+++ b/nemo_rl/algorithms/single_controller.py
@@ -131,8 +131,9 @@ class SingleControllerActor:
             master_config.loss_fn.force_on_policy_ratio
             and master_config.grpo.seq_logprob_error_threshold is None
         )
-        self._reference_logprobs_required = not bool(
-            master_config.grpo.skip_reference_policy_logprobs_calculation
+        self._reference_logprobs_required = bool(
+            master_config.loss_fn.reference_policy_kl_penalty > 0
+            and not master_config.grpo.skip_reference_policy_logprobs_calculation
         )
         self._dp_client = actor_args.dp_client
         self._gen: Generation = actor_args.gen_handle

--- a/nemo_rl/algorithms/single_controller_utils/config.py
+++ b/nemo_rl/algorithms/single_controller_utils/config.py
@@ -758,6 +758,16 @@ def validate_single_controller_config(master_config: MasterConfig) -> None:
             "loss_fn.reference_policy_kl_penalty=0."
         )
 
+    if (
+        reference_policy_kl_penalty <= 0
+        and not master_config.grpo.skip_reference_policy_logprobs_calculation
+    ):
+        print(
+            "Reference policy logprob calculation will be skipped since "
+            "`loss_fn.reference_policy_kl_penalty` is 0, so no reference "
+            "model was initialized."
+        )
+
     _validate_failure_settings(async_config, num_prompts_per_step)
 
     # Nesting says which knob applies to which path, but nothing stops an operator

--- a/nemo_rl/algorithms/single_controller_utils/config.py
+++ b/nemo_rl/algorithms/single_controller_utils/config.py
@@ -745,6 +745,14 @@ def validate_single_controller_config(master_config: MasterConfig) -> None:
     reference_policy_kl_penalty = getattr(
         master_config.loss_fn, "reference_policy_kl_penalty", 0
     )
+
+    if reference_policy_kl_penalty < 0:
+        raise ValueError(
+            "loss_fn.reference_policy_kl_penalty="
+            f"{reference_policy_kl_penalty} must not be negative; "
+            "use 0 to disable the KL penalty."
+        )
+
     if (
         reference_policy_kl_penalty
         and master_config.grpo.skip_reference_policy_logprobs_calculation
@@ -759,7 +767,7 @@ def validate_single_controller_config(master_config: MasterConfig) -> None:
         )
 
     if (
-        reference_policy_kl_penalty <= 0
+        reference_policy_kl_penalty == 0
         and not master_config.grpo.skip_reference_policy_logprobs_calculation
     ):
         print(

--- a/tests/unit/single_controller/test_single_controller.py
+++ b/tests/unit/single_controller/test_single_controller.py
@@ -158,6 +158,72 @@ def test_logs_hyperparameters_and_concrete_weight_synchronizer(
     assert "transport=stub" not in output
 
 
+@pytest.mark.parametrize(
+    ("reference_policy_kl_penalty", "skip_reference_logprobs", "expected_required"),
+    [
+        (0.0, False, False),
+        (0.0, True, False),
+        (0.01, False, True),
+    ],
+)
+def test_reference_logprobs_required_only_when_kl_enabled(
+    monkeypatch,
+    tmp_path,
+    reference_policy_kl_penalty: float,
+    skip_reference_logprobs: bool,
+    expected_required: bool,
+) -> None:
+    """KL-disabled SingleController runs do not request reference logprobs."""
+    monkeypatch.setattr(single_controller, "Logger", lambda _: MagicMock())
+    master_config = MasterConfig.model_construct(
+        policy={"train_global_batch_size": 8},
+        grpo=GRPOConfig.model_construct(
+            num_prompts_per_step=2,
+            num_generations_per_prompt=4,
+            skip_reference_policy_logprobs_calculation=skip_reference_logprobs,
+        ),
+        loss_fn=ClippedPGLossConfig(
+            force_on_policy_ratio=False,
+            reference_policy_kl_penalty=reference_policy_kl_penalty,
+        ),
+        async_rl=AsyncRLConfig(
+            min_groups_for_streaming_train=1,
+            max_buffered_rollouts=4,
+        ),
+        logger={},
+        env={},
+        checkpointing=_checkpointing_config(tmp_path),
+    )
+    actor_args = SimpleNamespace(
+        partition_id="rollout_data",
+        dp_client=None,
+        gen_handle=None,
+        trainer_handle=None,
+        dataloader=None,
+        weight_synchronizer=FakeWeightSynchronizer(),
+        advantage_estimator=None,
+        loss_fn=None,
+        tq_buffer=None,
+        rollout_manager=SimpleNamespace(_tq_buffer=None),
+        env_handles={},
+        fleet_monitor=None,
+        generation_router=None,
+        train_cluster=None,
+        inference_cluster=None,
+        save_state=_initial_grpo_save_state(),
+        last_checkpoint_path=None,
+    )
+    controller_cls = SingleControllerActor.__ray_metadata__.modified_class
+
+    controller = controller_cls(
+        master_config=master_config,
+        actor_args=actor_args,
+        setup_timing_metrics=SetupTimingMetrics(),
+    )
+
+    assert controller._reference_logprobs_required is expected_required
+
+
 def test_logs_setup_timing_metrics(monkeypatch, tmp_path) -> None:
     """setup_timing_metrics is forwarded to Logger.log_metrics under timing/setup."""
     logger = MagicMock()


### PR DESCRIPTION
# What does this PR do?

Ports the still-applicable reference-policy logprob behavior from #2672 to the SingleController GRPO path (`examples/run_grpo_single_controller.py`).

When `loss_fn.reference_policy_kl_penalty == 0`, SingleController now skips reference-policy logprob computation even when `grpo.skip_reference_policy_logprobs_calculation` is left at its default value. This aligns the runtime decision with trainer setup, which does not initialize a reference model when the KL penalty is disabled.

## Scope note

This PR intentionally does **not** port the non-colocated refit changes from #2672 (`offload_before_refit()` / `prepare_for_training()`). Those changes were [reverted](https://github.com/NVIDIA-NeMo/RL/pull/2794/changes#r3465670441) by #2794 because they caused a performance regression, so only the reference-logprob portion is migrated to SingleController.

# Testing

- Added coverage for KL disabled with explicit skip both false and true, and KL enabled with skip false.
- Targeted test: 3 passed.
- Ruff checks passed for the changed files.
- Commit-time pre-commit hooks passed, including Ruff, Ruff format, and Pyrefly.

# Related PRs

- #2672
- #2794